### PR TITLE
Make prerender more reliable for query fields

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1222,7 +1222,9 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
         `linksTo field '${this.name}' cannot deserialize a list of resource ids`,
       );
     }
-    let reference = value.links?.self;
+    let resourceId =
+      value.data && 'id' in value.data ? value.data?.id : undefined;
+    let reference = value.links?.self ?? resourceId;
     if (reference == null || reference === '') {
       return null;
     }
@@ -1240,9 +1242,7 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
     //bucket). we should never used links.self as part of that consideration. If there is a missing data.id in the resource entity
     //that means that the serialization is incorrect and is not JSON-API compliant.
     let resource =
-      value.data && 'id' in value.data
-        ? resourceFrom(doc, value.data?.id)
-        : undefined;
+      resourceId != null ? resourceFrom(doc, resourceId) : undefined;
     if (!resource) {
       if (loadedValue !== undefined) {
         return loadedValue;
@@ -1708,12 +1708,32 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
     relativeTo: URL | undefined,
     opts: DeserializeOpts,
   ): Promise<(BaseInstanceType<FieldT> | NotLoadedValue)[]> {
-    if (!Array.isArray(values) && values.links.self === null) {
-      return [];
+    let relationships: Relationship[];
+    if (Array.isArray(values)) {
+      relationships = values;
+    } else {
+      if (!isRelationship(values)) {
+        throw new Error(
+          `linksToMany field '${
+            this.name
+          }' cannot deserialize non-relationship value ${JSON.stringify(
+            values,
+          )}`,
+        );
+      }
+      if (!Array.isArray(values.data)) {
+        return [];
+      }
+      relationships = values.data.map((entry) => ({
+        links: {
+          self: entry && 'id' in entry ? entry.id ?? null : null,
+        },
+        data: entry,
+      }));
     }
 
     let resources: Promise<BaseInstanceType<FieldT> | NotLoadedValue>[] =
-      values.map(async (value: Relationship) => {
+      relationships.map(async (value: Relationship) => {
         if (!isRelationship(value)) {
           throw new Error(
             `linksToMany field '${
@@ -1728,7 +1748,9 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
             `linksToMany field '${this.name}' cannot deserialize a list of resource ids`,
           );
         }
-        let reference = value.links?.self;
+        let resourceId =
+          value.data && 'id' in value.data ? value.data?.id : undefined;
+        let reference = value.links?.self ?? resourceId;
         if (reference == null) {
           return null;
         }
@@ -1745,8 +1767,6 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
         // data.id is used to tell the consumer how to find the resource in the included bucket.
         // Prefer data.id for resourceFrom(), but fall back to links.self when data.id is missing
         // (the array-style linksToMany format omits data.id).
-        let resourceId =
-          value.data && 'id' in value.data ? value.data?.id : undefined;
         if (!resourceId) {
           resourceId = normalizedReference;
         }

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1748,6 +1748,10 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
             `linksToMany field '${this.name}' cannot deserialize a list of resource ids`,
           );
         }
+        // links.self is used to tell the consumer of this payload how to get the resource via HTTP.
+        // data.id is used to tell the consumer how to find the resource in the included bucket.
+        // Prefer data.id for resourceFrom(), and fall back to links.self when data.id is missing
+        // (the array-style linksToMany format omits data.id).
         let resourceId =
           value.data && 'id' in value.data ? value.data?.id : undefined;
         let reference = value.links?.self ?? resourceId;
@@ -1763,10 +1767,6 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
           cachedInstance[isSavedInstance] = true;
           return cachedInstance;
         }
-        // links.self is used to tell the consumer of this payload how to get the resource via HTTP.
-        // data.id is used to tell the consumer how to find the resource in the included bucket.
-        // Prefer data.id for resourceFrom(), but fall back to links.self when data.id is missing
-        // (the array-style linksToMany format omits data.id).
         if (!resourceId) {
           resourceId = normalizedReference;
         }

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1367,9 +1367,7 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
         <CardCrudFunctionsConsumer as |cardCrudFunctions|>
           <DefaultFormatsConsumer as |defaultFormats|>
             {{#if
-              (shouldRenderEditor
-                @format defaultFormats.cardDef isComputed
-              )
+              (shouldRenderEditor @format defaultFormats.cardDef isComputed)
             }}
               <LinksToEditor
                 @model={{(getInnerModel)}}
@@ -1726,7 +1724,7 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
       }
       relationships = values.data.map((entry) => ({
         links: {
-          self: entry && 'id' in entry ? entry.id ?? null : null,
+          self: entry && 'id' in entry ? (entry.id ?? null) : null,
         },
         data: entry,
       }));
@@ -1751,7 +1749,6 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
         // links.self is used to tell the consumer of this payload how to get the resource via HTTP.
         // data.id is used to tell the consumer how to find the resource in the included bucket.
         // Prefer data.id for resourceFrom(), and fall back to links.self when data.id is missing
-        // (the array-style linksToMany format omits data.id).
         let resourceId =
           value.data && 'id' in value.data ? value.data?.id : undefined;
         let reference = value.links?.self ?? resourceId;
@@ -2888,10 +2885,12 @@ function lazilyLoadLink(
           : `${reference}.json`;
       let payloadError: Pick<SerializedError, 'status' | 'message'> &
         Partial<Pick<SerializedError, 'title' | 'stack' | 'deps'>> & {
-        additionalErrors?: Array<
-          Partial<Pick<SerializedError, 'title' | 'status' | 'message' | 'stack'>>
-        >;
-      } = {
+          additionalErrors?: Array<
+            Partial<
+              Pick<SerializedError, 'title' | 'status' | 'message' | 'stack'>
+            >
+          >;
+        } = {
         title: isMissingFile
           ? 'Link Not Found'
           : (error?.message ?? 'Card Error'),
@@ -2956,7 +2955,10 @@ function trackRuntimeRelationshipDependency(
   }
   if (isFileDef(declaredCard)) {
     trackRuntimeFileDependency(id, dependencyTrackingContext);
-    trackRuntimeRelationshipModuleDependencies(value, dependencyTrackingContext);
+    trackRuntimeRelationshipModuleDependencies(
+      value,
+      dependencyTrackingContext,
+    );
     return;
   }
   trackRuntimeInstanceDependency(id, dependencyTrackingContext);

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -16,6 +16,7 @@ import {
   getField,
   getSingularRelationship,
   identifyCard,
+  isCardInstance,
   THIS_INTERPOLATION_PREFIX,
   THIS_REALM_TOKEN,
   realmURL as realmURLSymbol,
@@ -40,6 +41,7 @@ interface QueryFieldState {
     status?: number;
   }>;
   searchResource?: StoreSearchResource;
+  renderCycleBarrier?: Promise<void>;
 }
 
 const queryFieldStates = initSharedState(
@@ -73,9 +75,18 @@ export function ensureQueryFieldSearchResource(
     });
 
   let queryFieldState = queryFieldStates.get(instance);
-  let fieldState = queryFieldState?.get(field.name);
-  let searchResource = fieldState?.searchResource;
+  if (!queryFieldState) {
+    queryFieldState = new Map<string, QueryFieldState>();
+    queryFieldStates.set(instance, queryFieldState);
+  }
+  let fieldState = queryFieldState.get(field.name);
+  if (!fieldState) {
+    fieldState = {};
+    queryFieldState.set(field.name, fieldState);
+  }
+  let searchResource = fieldState.searchResource;
   if (searchResource) {
+    trackQueryFieldLoads(store, field.name, fieldState);
     log.debug(
       `ensureQueryFieldSearchResource: reusing existing resource from fieldState for field=${field.name}`,
     );
@@ -84,7 +95,6 @@ export function ensureQueryFieldSearchResource(
 
   let seedRecords = fieldState?.seedRecords;
   let seedSearchURL = fieldState?.seedSearchURL;
-
   let args = () => resolveQueryAndRealm(instance, field, fieldDefinition);
 
   log.info(
@@ -103,24 +113,43 @@ export function ensureQueryFieldSearchResource(
       seed: seedRecords
         ? {
             cards: seedRecords,
-            searchURL: seedSearchURL ?? undefined,
+            searchURL:
+              seedRecords.length > 0 ? seedSearchURL ?? undefined : undefined,
             realms: fieldState?.seedRealms,
             queryErrors: fieldState?.seedErrors,
           }
         : undefined,
     },
   );
-  if (!queryFieldState) {
-    queryFieldState = new Map<string, QueryFieldState>();
-    queryFieldStates.set(instance, queryFieldState);
-  }
-  if (!fieldState) {
-    fieldState = {};
-    queryFieldState.set(field.name, fieldState);
-  }
   fieldState.searchResource = searchResource;
+  trackQueryFieldLoads(store, field.name, fieldState);
 
   return searchResource;
+}
+
+function trackQueryFieldLoads(
+  store: CardStore,
+  fieldName: string,
+  fieldState: QueryFieldState,
+) {
+  if (!fieldState.renderCycleBarrier) {
+    // Query resources can kick off their load after the getter returns
+    // (via resource modify scheduling). This barrier keeps render-route
+    // settle from completing in the same frame before query loads can join.
+    log.debug(`tracking query field render barrier for field=${fieldName}`);
+    let barrier = waitForNextRenderCycle();
+    fieldState.renderCycleBarrier = barrier;
+    store.trackLoad(barrier);
+    void barrier.finally(() => {
+      if (fieldState.renderCycleBarrier === barrier) {
+        fieldState.renderCycleBarrier = undefined;
+      }
+    });
+  }
+}
+
+function waitForNextRenderCycle(): Promise<void> {
+  return Promise.resolve().then(() => Promise.resolve());
 }
 
 export function validateRelationshipQuery(
@@ -274,7 +303,9 @@ export function captureQueryFieldSeedData(
     fieldState = {};
     queryFieldState.set(fieldName, fieldState);
   }
-  fieldState.seedRecords = value;
+  // Query-field deserialize can contain unresolved placeholders in some paths;
+  // only persist concrete card instances as seed records.
+  fieldState.seedRecords = value.filter((entry) => isCardInstance(entry));
   let relationship = getSingularRelationship(resource.relationships, fieldName);
   fieldState.seedSearchURL = relationship?.links?.search ?? null;
   fieldState.seedRealms = fieldState.seedSearchURL

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -113,8 +113,7 @@ export function ensureQueryFieldSearchResource(
       seed: seedRecords
         ? {
             cards: seedRecords,
-            searchURL:
-              seedRecords.length > 0 ? seedSearchURL ?? undefined : undefined,
+            searchURL: seedSearchURL ?? undefined,
             realms: fieldState?.seedRealms,
             queryErrors: fieldState?.seedErrors,
           }

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -134,10 +134,11 @@ function trackQueryFieldLoads(
 ) {
   if (!fieldState.renderCycleBarrier) {
     // Query resources can kick off their load after the getter returns
-    // (via resource modify scheduling). This barrier keeps render-route
-    // settle from completing in the same frame before query loads can join.
+    // (via resource modify scheduling). This microtask barrier keeps
+    // render-route settle from completing in the same frame before query
+    // loads can join.
     log.debug(`tracking query field render barrier for field=${fieldName}`);
-    let barrier = waitForNextRenderCycle();
+    let barrier = waitForNextMicrotaskTurn();
     fieldState.renderCycleBarrier = barrier;
     store.trackLoad(barrier);
     void barrier.finally(() => {
@@ -148,7 +149,7 @@ function trackQueryFieldLoads(
   }
 }
 
-function waitForNextRenderCycle(): Promise<void> {
+function waitForNextMicrotaskTurn(): Promise<void> {
   return Promise.resolve().then(() => Promise.resolve());
 }
 

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -44,6 +44,10 @@ interface QueryFieldState {
   renderCycleBarrier?: Promise<void>;
 }
 
+const queryFieldSeedFromSearchSymbol = Symbol.for(
+  'cardstack-query-field-seed-from-search',
+);
+
 const queryFieldStates = initSharedState(
   'queryFieldStates',
   () => new WeakMap<BaseDef, Map<string, QueryFieldState>>(),
@@ -307,7 +311,18 @@ export function captureQueryFieldSeedData(
   // only persist concrete card instances as seed records.
   fieldState.seedRecords = value.filter((entry) => isCardInstance(entry));
   let relationship = getSingularRelationship(resource.relationships, fieldName);
-  fieldState.seedSearchURL = relationship?.links?.search ?? null;
+  let seedComesFromSearch = Boolean(
+    (resource as any)[queryFieldSeedFromSearchSymbol],
+  );
+  // Empty query-backed relationships arriving on search result resources are
+  // not guaranteed to be fully resolved (for example nested query fields on
+  // each result). In that case we should still run the client-side query
+  // fallback instead of treating the empty seed as authoritative.
+  let shouldTreatEmptySeedAsUnresolved =
+    seedComesFromSearch && fieldState.seedRecords.length === 0;
+  fieldState.seedSearchURL = shouldTreatEmptySeedAsUnresolved
+    ? null
+    : relationship?.links?.search ?? null;
   fieldState.seedRealms = fieldState.seedSearchURL
     ? [parseSearchURL(new URL(fieldState.seedSearchURL)).realm.href]
     : [];

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -314,12 +314,22 @@ export function captureQueryFieldSeedData(
   let seedComesFromSearch = Boolean(
     (resource as any)[queryFieldSeedFromSearchSymbol],
   );
+  let relationshipHasUnhydratedTargets =
+    fieldState.seedRecords.length === 0 &&
+    (Array.isArray(relationship?.data)
+      ? relationship.data.length > 0
+      : Boolean(relationship?.data));
   // Empty query-backed relationships arriving on search result resources are
   // not guaranteed to be fully resolved (for example nested query fields on
   // each result). In that case we should still run the client-side query
   // fallback instead of treating the empty seed as authoritative.
+  //
+  // Likewise, when relationship data advertises one-or-more targets but none
+  // of those targets are hydrated instances in this document, we should not
+  // suppress fallback search based on links.search alone.
   let shouldTreatEmptySeedAsUnresolved =
-    seedComesFromSearch && fieldState.seedRecords.length === 0;
+    fieldState.seedRecords.length === 0 &&
+    (seedComesFromSearch || relationshipHasUnhydratedTargets);
   fieldState.seedSearchURL = shouldTreatEmptySeedAsUnresolved
     ? null
     : relationship?.links?.search ?? null;

--- a/packages/host/app/lib/gc-card-store.ts
+++ b/packages/host/app/lib/gc-card-store.ts
@@ -266,12 +266,18 @@ export default class CardStoreWithGarbageCollection implements CardStore {
     loadTrackingLogger.debug(
       `trackLoad start id=${loadId} generation=${this.#loadGeneration} pending=${this.#inFlight.size}`,
     );
-    load.finally(() => {
-      this.#inFlight.delete(load);
-      loadTrackingLogger.debug(
-        `trackLoad settled id=${loadId} pending=${this.#inFlight.size}`,
-      );
-    });
+    void load
+      .finally(() => {
+        this.#inFlight.delete(load);
+        loadTrackingLogger.debug(
+          `trackLoad settled id=${loadId} pending=${this.#inFlight.size}`,
+        );
+      })
+      .catch((error) => {
+        loadTrackingLogger.debug(
+          `trackLoad rejected id=${loadId} error=${String(error)}`,
+        );
+      });
   }
 
   async loaded() {

--- a/packages/host/app/lib/gc-card-store.ts
+++ b/packages/host/app/lib/gc-card-store.ts
@@ -256,33 +256,33 @@ export default class CardStoreWithGarbageCollection implements CardStore {
 
   trackLoad(load: Promise<unknown>) {
     if (this.#inFlight.has(load)) {
-      loadTrackingLogger.info('trackLoad skipped duplicate promise');
+      loadTrackingLogger.debug('trackLoad skipped duplicate promise');
       return;
     }
     let loadId = this.#nextLoadId++;
     this.#loadIds.set(load, loadId);
     this.#inFlight.add(load);
     this.#loadGeneration++;
-    loadTrackingLogger.info(
+    loadTrackingLogger.debug(
       `trackLoad start id=${loadId} generation=${this.#loadGeneration} pending=${this.#inFlight.size}`,
     );
     load.finally(() => {
       this.#inFlight.delete(load);
-      loadTrackingLogger.info(
+      loadTrackingLogger.debug(
         `trackLoad settled id=${loadId} pending=${this.#inFlight.size}`,
       );
     });
   }
 
   async loaded() {
-    loadTrackingLogger.info(
+    loadTrackingLogger.debug(
       `loaded() begin generation=${this.#loadGeneration} pending=${this.#inFlight.size}`,
     );
     let observedGeneration = this.#loadGeneration;
     for (;;) {
       if (this.#inFlight.size === 0) {
         // allow microtasks (like settled promise continuations) to enqueue more loads
-        loadTrackingLogger.info(
+        loadTrackingLogger.debug(
           'loaded() no pending loads, waiting one microtask',
         );
         await Promise.resolve();
@@ -291,7 +291,7 @@ export default class CardStoreWithGarbageCollection implements CardStore {
         let pendingIds = pendingLoads
           .map((pendingLoad) => this.#loadIds.get(pendingLoad))
           .filter((id): id is number => id != null);
-        loadTrackingLogger.info(
+        loadTrackingLogger.debug(
           `loaded() waiting for pending loads ids=[${pendingIds.join(',')}] count=${pendingLoads.length}`,
         );
         await Promise.allSettled(pendingLoads);
@@ -300,12 +300,12 @@ export default class CardStoreWithGarbageCollection implements CardStore {
         this.#inFlight.size === 0 &&
         this.#loadGeneration === observedGeneration
       ) {
-        loadTrackingLogger.info(
+        loadTrackingLogger.debug(
           `loaded() complete generation=${this.#loadGeneration}`,
         );
         return;
       }
-      loadTrackingLogger.info(
+      loadTrackingLogger.debug(
         `loaded() continuing; generation moved ${observedGeneration} -> ${this.#loadGeneration}, pending=${this.#inFlight.size}`,
       );
       observedGeneration = this.#loadGeneration;

--- a/packages/host/app/lib/gc-card-store.ts
+++ b/packages/host/app/lib/gc-card-store.ts
@@ -318,6 +318,10 @@ export default class CardStoreWithGarbageCollection implements CardStore {
     }
   }
 
+  get loadGeneration() {
+    return this.#loadGeneration;
+  }
+
   addCardInstanceOrError(
     id: string,
     instanceOrError: CardDef | CardErrorJSONAPI,

--- a/packages/host/app/lib/gc-card-store.ts
+++ b/packages/host/app/lib/gc-card-store.ts
@@ -13,6 +13,7 @@ import {
   loadFileMetaDocument,
   trackRuntimeFileDependency,
   trackRuntimeInstanceDependency,
+  logger,
   type Query,
   type QueryResultsMeta,
   type RuntimeDependencyTrackingContext,
@@ -34,6 +35,8 @@ import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 export type ReferenceCount = Map<string, number>;
+
+const loadTrackingLogger = logger('store-load-tracking');
 
 type LocalId = string;
 type InstanceGraph = Map<LocalId, Set<LocalId>>;
@@ -154,6 +157,8 @@ export default class CardStoreWithGarbageCollection implements CardStore {
   #fetch: typeof globalThis.fetch;
   #inFlight: Set<Promise<unknown>> = new Set();
   #loadGeneration = 0; // increments whenever a new load is tracked
+  #nextLoadId = 1;
+  #loadIds: WeakMap<Promise<unknown>, number> = new WeakMap();
   #cardDocsInFlight: Map<string, Promise<SingleCardDocument | CardError>> =
     new Map();
   #fileMetaDocsInFlight: Map<
@@ -251,31 +256,58 @@ export default class CardStoreWithGarbageCollection implements CardStore {
 
   trackLoad(load: Promise<unknown>) {
     if (this.#inFlight.has(load)) {
+      loadTrackingLogger.info('trackLoad skipped duplicate promise');
       return;
     }
+    let loadId = this.#nextLoadId++;
+    this.#loadIds.set(load, loadId);
     this.#inFlight.add(load);
     this.#loadGeneration++;
+    loadTrackingLogger.info(
+      `trackLoad start id=${loadId} generation=${this.#loadGeneration} pending=${this.#inFlight.size}`,
+    );
     load.finally(() => {
       this.#inFlight.delete(load);
+      loadTrackingLogger.info(
+        `trackLoad settled id=${loadId} pending=${this.#inFlight.size}`,
+      );
     });
   }
 
   async loaded() {
+    loadTrackingLogger.info(
+      `loaded() begin generation=${this.#loadGeneration} pending=${this.#inFlight.size}`,
+    );
     let observedGeneration = this.#loadGeneration;
     for (;;) {
       if (this.#inFlight.size === 0) {
         // allow microtasks (like settled promise continuations) to enqueue more loads
+        loadTrackingLogger.info(
+          'loaded() no pending loads, waiting one microtask',
+        );
         await Promise.resolve();
       } else {
         let pendingLoads = Array.from(this.#inFlight);
+        let pendingIds = pendingLoads
+          .map((pendingLoad) => this.#loadIds.get(pendingLoad))
+          .filter((id): id is number => id != null);
+        loadTrackingLogger.info(
+          `loaded() waiting for pending loads ids=[${pendingIds.join(',')}] count=${pendingLoads.length}`,
+        );
         await Promise.allSettled(pendingLoads);
       }
       if (
         this.#inFlight.size === 0 &&
         this.#loadGeneration === observedGeneration
       ) {
+        loadTrackingLogger.info(
+          `loaded() complete generation=${this.#loadGeneration}`,
+        );
         return;
       }
+      loadTrackingLogger.info(
+        `loaded() continuing; generation moved ${observedGeneration} -> ${this.#loadGeneration}, pending=${this.#inFlight.size}`,
+      );
       observedGeneration = this.#loadGeneration;
     }
   }

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -69,11 +69,12 @@ export class SearchResource<
 > extends Resource<Args<T>> {
   @service declare private realmServer: RealmServerService;
   @service declare private store: StoreService;
+  #storeServiceOverride: StoreService | undefined;
   @tracked private realmsToSearch: string[] = [];
   // Resist the urge to expose this property publicly as that may entice
-  // consumers of this resource  to use it in a non-reactive manner (pluck off
+  // consumers of this resource to use it in a non-reactive manner (pluck off
   // the instances and throw away the resource).
-  // @ts-ignore we use this.loaded for test instrumentation.
+  // Kept private for tests/internal load bookkeeping.
   private loaded: Promise<void> | undefined;
   private subscriptions: { url: string; unsubscribe: () => void }[] = [];
   private _instances = new TrackedArray<T>();
@@ -87,12 +88,40 @@ export class SearchResource<
   #previousRealms: string[] | undefined;
   #dependencyTracking: RuntimeDependencyTrackingContext | undefined;
   #log = runtimeLogger('search-resource');
+  #trackedLoadCount = 0;
+
+  private get runtimeStore(): StoreService {
+    return this.#storeServiceOverride ?? this.store;
+  }
+
+  private trackStoreLoad(
+    load: Promise<void> | undefined,
+    source: 'seed' | 'search' | 'live-refresh',
+  ): void {
+    if (!load) {
+      return;
+    }
+    this.loaded = load;
+    let loadNumber = ++this.#trackedLoadCount;
+    this.#log.info(
+      `trackStoreLoad start #${loadNumber} source=${source} query=${this.#previousQueryString ?? '(unknown)'}`,
+    );
+    this.runtimeStore.trackLoad(load);
+    void load.finally(() => {
+      // Ignore stale completions from superseded loads; keep test-facing
+      // `loaded` aligned with the most recent request.
+      if (this.loaded !== load) {
+        return;
+      }
+      this.#log.info(`trackStoreLoad settled #${loadNumber} source=${source}`);
+    });
+  }
 
   constructor(owner: object) {
     super(owner);
     registerDestructor(this, () => {
       for (let instance of this._instances) {
-        this.store.dropReference(instance.id);
+        this.runtimeStore.dropReference(instance.id);
       }
       for (let subscription of this.subscriptions) {
         subscription.unsubscribe();
@@ -101,9 +130,20 @@ export class SearchResource<
   }
 
   modify(_positional: never[], named: Args<T>['named']) {
-    let { query, realms, isLive, doWhileRefreshing, seed, owner } = named;
+    let {
+      query,
+      realms,
+      isLive,
+      doWhileRefreshing,
+      seed,
+      owner,
+      storeService,
+    } = named;
 
     setOwner(this, owner); // works around problem where lifetime parent is used as owner when they should be allowed to differ
+    if (storeService) {
+      this.#storeServiceOverride = storeService;
+    }
 
     if (query === undefined) {
       return;
@@ -123,7 +163,7 @@ export class SearchResource<
       `modify: prepared realms for subscription=${this.realmsToSearch.join(',')}`,
     );
     if (seed && !this.#seedApplied) {
-      this.loaded = this.applySeed.perform(seed);
+      this.trackStoreLoad(this.applySeed.perform(seed), 'seed');
       this.#seedApplied = true;
       let hasQueryErrors = seed.queryErrors && seed.queryErrors.length > 0;
       if (seed.searchURL && !hasQueryErrors) {
@@ -171,7 +211,10 @@ export class SearchResource<
             ) {
               return;
             }
-            this.search.perform(this.#previousQuery);
+            this.trackStoreLoad(
+              this.search.perform(this.#previousQuery),
+              'live-refresh',
+            );
           }),
         };
       });
@@ -195,7 +238,7 @@ export class SearchResource<
     this.#previousRealms = realms;
     this.#previousQuery = query;
     this.#previousQueryString = queryString;
-    this.loaded = this.search.perform(query);
+    this.trackStoreLoad(this.search.perform(query), 'search');
   }
   get isLoading() {
     return this.search.isRunning;
@@ -249,20 +292,20 @@ export class SearchResource<
       let isFileMeta = isFileDefInstance(card);
       let maybeInstance = card?.id
         ? isFileMeta
-          ? this.store.peek(card.id, { type: 'file-meta' })
-          : this.store.peek(card.id)
+          ? this.runtimeStore.peek(card.id, { type: 'file-meta' })
+          : this.runtimeStore.peek(card.id)
         : undefined;
       if (
         !maybeInstance &&
         (card as unknown as { type?: string })?.type !== 'not-loaded' // TODO: under what circumstances could this happen?
       ) {
         if (isFileMeta) {
-          await this.store.get(card.id, {
+          await this.runtimeStore.get(card.id, {
             type: 'file-meta',
             dependencyTrackingContext,
           });
         } else {
-          await this.store.add(
+          await this.runtimeStore.add(
             card as CardDef,
             {
               doNotPersist: true,
@@ -274,13 +317,13 @@ export class SearchResource<
     }
     let referencesToDrop = difference(oldReferences, newReferences);
     for (let id of referencesToDrop) {
-      this.store.dropReference(id);
+      this.runtimeStore.dropReference(id);
     }
     let referencesToAdd = difference(newReferences, oldReferences);
     for (let id of referencesToAdd) {
-      this.store.addReference(id);
+      this.runtimeStore.addReference(id);
     }
-    return this.store.flush();
+    return this.runtimeStore.flush();
   }
 
   private dependencyTrackingContext(
@@ -313,7 +356,7 @@ export class SearchResource<
       let dependencyTrackingContext = this.dependencyTrackingContext(
         'search-resource:search',
       );
-      let { instances, meta } = await this.store.search<T>(
+      let { instances, meta } = await this.runtimeStore.search<T>(
         query,
         this.realmsToSearch,
         {
@@ -351,6 +394,7 @@ export function getSearch<T extends CardDef | FileDef = CardDef>(
   getRealms?: () => string[] | undefined,
   opts?: {
     isLive?: boolean;
+    storeService?: StoreService;
     doWhileRefreshing?: (() => void) | undefined;
     seed?:
       | {
@@ -374,6 +418,7 @@ export function getSearch<T extends CardDef | FileDef = CardDef>(
       query: getQuery(),
       realms: getRealms ? getRealms() : undefined,
       isLive: opts?.isLive != null ? opts.isLive : false,
+      storeService: opts?.storeService,
       // TODO refactor this out
       doWhileRefreshing: opts?.doWhileRefreshing,
       seed: opts?.seed,

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -5,7 +5,7 @@ import { service } from '@ember/service';
 import { buildWaiter } from '@ember/test-waiters';
 import { tracked, cached } from '@glimmer/tracking';
 
-import { restartableTask, task } from 'ember-concurrency';
+import { didCancel, restartableTask, task } from 'ember-concurrency';
 import { Resource } from 'ember-modify-based-class-resource';
 
 import difference from 'lodash/difference';
@@ -107,14 +107,29 @@ export class SearchResource<
       `trackStoreLoad start #${loadNumber} source=${source} query=${this.#previousQueryString ?? '(unknown)'}`,
     );
     this.runtimeStore.trackLoad(load);
-    void load.finally(() => {
-      // Ignore stale completions from superseded loads; keep test-facing
-      // `loaded` aligned with the most recent request.
-      if (this.loaded !== load) {
-        return;
-      }
-      this.#log.info(`trackStoreLoad settled #${loadNumber} source=${source}`);
-    });
+    void load
+      .finally(() => {
+        // Ignore stale completions from superseded loads; keep test-facing
+        // `loaded` aligned with the most recent request.
+        if (this.loaded !== load) {
+          return;
+        }
+        this.#log.info(
+          `trackStoreLoad settled #${loadNumber} source=${source}`,
+        );
+      })
+      .catch((error) => {
+        if (didCancel(error)) {
+          this.#log.debug(
+            `trackStoreLoad canceled #${loadNumber} source=${source}`,
+          );
+          return;
+        }
+        this.#log.error(
+          `trackStoreLoad rejected #${loadNumber} source=${source}`,
+          error,
+        );
+      });
   }
 
   constructor(owner: object) {
@@ -141,9 +156,7 @@ export class SearchResource<
     } = named;
 
     setOwner(this, owner); // works around problem where lifetime parent is used as owner when they should be allowed to differ
-    if (storeService) {
-      this.#storeServiceOverride = storeService;
-    }
+    this.#storeServiceOverride = storeService;
 
     if (query === undefined) {
       return;

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -156,7 +156,11 @@ export class SearchResource<
     } = named;
 
     setOwner(this, owner); // works around problem where lifetime parent is used as owner when they should be allowed to differ
-    this.#storeServiceOverride = storeService;
+    // Keep the previously provided override when optional args are omitted on
+    // subsequent modify() calls.
+    if (storeService !== undefined) {
+      this.#storeServiceOverride = storeService;
+    }
 
     if (query === undefined) {
       return;

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -571,7 +571,7 @@ export default class RenderRoute extends Route<Model> {
     if (!modelState || modelState.isReady) {
       return;
     }
-    renderReadyLogger.info(
+    renderReadyLogger.debug(
       `scheduling ready settlement for cardId=${model.cardId}`,
     );
     this.#pendingReadyModels.add(model);
@@ -629,11 +629,11 @@ export default class RenderRoute extends Route<Model> {
     if (!modelState || modelState.isReady) {
       return;
     }
-    renderReadyLogger.info(
+    renderReadyLogger.debug(
       `settleModelAfterRender start cardId=${model.cardId} status=${model.status}`,
     );
     await this.#authGuard.race(() => this.store.loaded());
-    renderReadyLogger.info(
+    renderReadyLogger.debug(
       `settleModelAfterRender store.loaded resolved cardId=${model.cardId}`,
     );
     modelState.state.set('status', 'ready');
@@ -643,7 +643,7 @@ export default class RenderRoute extends Route<Model> {
     model.capturedDeps = snapshotRuntimeDependencies({
       excludeQueryOnly: true,
     }).deps;
-    renderReadyLogger.info(
+    renderReadyLogger.debug(
       `settleModelAfterRender done cardId=${model.cardId} deps=${model.capturedDeps?.length ?? 0}`,
     );
   }

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -26,6 +26,7 @@ import {
   type RenderError,
   parseRenderRouteOptions,
   serializeRenderRouteOptions,
+  logger as runtimeLogger,
 } from '@cardstack/runtime-common';
 import { Deferred } from '@cardstack/runtime-common/deferred';
 import { serializableError } from '@cardstack/runtime-common/error';
@@ -78,6 +79,8 @@ type ModelState = {
   isReady: boolean;
   readyWatchdogStarted?: boolean;
 };
+
+const renderReadyLogger = runtimeLogger('render-ready');
 
 export default class RenderRoute extends Route<Model> {
   @service('render-store') declare store: RenderStoreService;
@@ -568,6 +571,9 @@ export default class RenderRoute extends Route<Model> {
     if (!modelState || modelState.isReady) {
       return;
     }
+    renderReadyLogger.info(
+      `scheduling ready settlement for cardId=${model.cardId}`,
+    );
     this.#pendingReadyModels.add(model);
     scheduleOnce('afterRender', this, this.#processPendingReadyModels);
     this.#startReadyWatchdog(model);
@@ -623,7 +629,13 @@ export default class RenderRoute extends Route<Model> {
     if (!modelState || modelState.isReady) {
       return;
     }
+    renderReadyLogger.info(
+      `settleModelAfterRender start cardId=${model.cardId} status=${model.status}`,
+    );
     await this.#authGuard.race(() => this.store.loaded());
+    renderReadyLogger.info(
+      `settleModelAfterRender store.loaded resolved cardId=${model.cardId}`,
+    );
     modelState.state.set('status', 'ready');
     modelState.isReady = true;
     modelState.readyDeferred.fulfill();
@@ -631,6 +643,9 @@ export default class RenderRoute extends Route<Model> {
     model.capturedDeps = snapshotRuntimeDependencies({
       excludeQueryOnly: true,
     }).deps;
+    renderReadyLogger.info(
+      `settleModelAfterRender done cardId=${model.cardId} deps=${model.capturedDeps?.length ?? 0}`,
+    );
   }
 
   #settleModelAfterRenderSafely(model: Model) {

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -81,6 +81,8 @@ type ModelState = {
 };
 
 const renderReadyLogger = runtimeLogger('render-ready');
+const READY_SETTLE_MAX_PASSES = 20;
+const READY_SETTLE_REQUIRED_STABLE_PASSES = 2;
 
 export default class RenderRoute extends Route<Model> {
   @service('render-store') declare store: RenderStoreService;
@@ -632,7 +634,7 @@ export default class RenderRoute extends Route<Model> {
     renderReadyLogger.debug(
       `settleModelAfterRender start cardId=${model.cardId} status=${model.status}`,
     );
-    await this.#authGuard.race(() => this.store.loaded());
+    await this.#waitForRenderLoadStability(model.cardId);
     renderReadyLogger.debug(
       `settleModelAfterRender store.loaded resolved cardId=${model.cardId}`,
     );
@@ -645,6 +647,40 @@ export default class RenderRoute extends Route<Model> {
     }).deps;
     renderReadyLogger.debug(
       `settleModelAfterRender done cardId=${model.cardId} deps=${model.capturedDeps?.length ?? 0}`,
+    );
+  }
+
+  async #waitForRenderLoadStability(cardId: string): Promise<void> {
+    let stablePasses = 0;
+    let observedGeneration = this.store.loadGeneration;
+    for (let pass = 0; pass < READY_SETTLE_MAX_PASSES; pass++) {
+      await this.#authGuard.race(() => this.store.loaded());
+      await this.#waitForNextRenderFrame();
+      let nextGeneration = this.store.loadGeneration;
+      let generationChanged = nextGeneration !== observedGeneration;
+      if (generationChanged) {
+        observedGeneration = nextGeneration;
+        stablePasses = 0;
+      } else {
+        stablePasses++;
+      }
+      renderReadyLogger.debug(
+        `waitForRenderLoadStability pass=${pass + 1}/${READY_SETTLE_MAX_PASSES} cardId=${cardId} generation=${nextGeneration} stablePasses=${stablePasses}`,
+      );
+      if (stablePasses >= READY_SETTLE_REQUIRED_STABLE_PASSES) {
+        break;
+      }
+    }
+    await this.#authGuard.race(() => this.store.loaded());
+  }
+
+  async #waitForNextRenderFrame(): Promise<void> {
+    if (typeof requestAnimationFrame !== 'function') {
+      await Promise.resolve();
+      return;
+    }
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve()),
     );
   }
 

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -630,6 +630,28 @@ export default class RealmServerService extends Service {
     });
   }
 
+  maybeAuthedFetchForRealms(
+    url: string,
+    realms: string[],
+    options: RequestInit = {},
+  ) {
+    const headers = new Headers(options.headers);
+    if (!headers.has('Authorization')) {
+      if (this.token) {
+        headers.set('Authorization', `Bearer ${this.token}`);
+      } else {
+        let realmToken = this.getRealmTokenForRealms(realms);
+        if (realmToken) {
+          headers.set('Authorization', `Bearer ${realmToken}`);
+        }
+      }
+    }
+    return this.network.fetch(url, {
+      ...options,
+      headers,
+    });
+  }
+
   // args is of type `RequestForwardBody` in realm-server/handlers/handle-request-forward
   async requestForward(args: {
     url: string;
@@ -1032,6 +1054,27 @@ export default class RealmServerService extends Service {
     }
 
     return this.token;
+  }
+
+  private getRealmTokenForRealms(realms: string[]): string | undefined {
+    let sessionTokens: Record<string, string> = {};
+    let sessionStr = window.localStorage.getItem(SessionLocalStorageKey);
+    if (!sessionStr) {
+      return undefined;
+    }
+    try {
+      sessionTokens = JSON.parse(sessionStr) as Record<string, string>;
+    } catch {
+      return undefined;
+    }
+    for (let realmURL of realms) {
+      let normalizedRealmURL = ensureTrailingSlash(realmURL);
+      let token = sessionTokens[normalizedRealmURL] ?? sessionTokens[realmURL];
+      if (token) {
+        return token;
+      }
+    }
+    return undefined;
   }
 }
 

--- a/packages/host/app/services/render-service.ts
+++ b/packages/host/app/services/render-service.ts
@@ -41,6 +41,7 @@ import type { SimpleDocument, SimpleElement } from '@simple-dom/interface';
 import type { Tokenizer } from '@simple-dom/parser';
 
 const ELEMENT_NODE_TYPE = 1;
+const MAX_ASYNC_RENDER_PASSES = 3;
 const { environment } = config;
 
 export class CardStoreWithErrors implements CardStore {
@@ -170,9 +171,16 @@ export default class RenderService extends Service {
   ): Promise<string> {
     let element = getIsolatedRenderElement(this.document);
     try {
-      render(component, element, this.owner, format);
-      await waitForAsync?.();
-      // re-render after we have waited for the links to finish loading
+      if (waitForAsync) {
+        // Additional settle passes are needed because rendering can start new
+        // async work (for example nested query-backed relationships).
+        for (let i = 0; i < MAX_ASYNC_RENDER_PASSES; i++) {
+          render(component, element, this.owner, format);
+          await waitForAsync();
+        }
+      }
+      // Final render after waiting for async work so captured HTML reflects the
+      // latest loaded state.
       render(component, element, this.owner, format);
       let serializer = new Serializer(voidMap);
       let html = serializer.serialize(element);

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -281,6 +281,10 @@ export default class StoreService extends Service implements StoreInterface {
     return this.store.loaded();
   }
 
+  trackLoad(load: Promise<unknown>): void {
+    this.store.trackLoad(load);
+  }
+
   get cardDocsInFlight() {
     return this.store.cardDocsInFlight;
   }
@@ -811,13 +815,10 @@ export default class StoreService extends Service implements StoreInterface {
     if (this.isRenderStore && opts) {
       opts.isLive = false;
     }
-    return getSearch<T>(
-      parent,
-      getOwner(this)!,
-      getQuery,
-      getRealms,
-      opts,
-    ) as unknown as SearchResource<T>;
+    return getSearch<T>(parent, getOwner(this)!, getQuery, getRealms, {
+      ...opts,
+      storeService: this,
+    }) as unknown as SearchResource<T>;
   }
 
   getSearchDataResource(

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -107,6 +107,9 @@ let waiter = buildWaiter('store-service');
 
 const realmEventsLogger = logger('realm:events');
 const storeLogger = logger('store');
+const queryFieldSeedFromSearchSymbol = Symbol.for(
+  'cardstack-query-field-seed-from-search',
+);
 
 type PersistOptions = CreateOptions & { clientRequestId?: string };
 type DependencyTrackingOptions = {
@@ -1276,6 +1279,9 @@ export default class StoreService extends Service implements StoreInterface {
     if (existingInstance && isCardInstance(existingInstance)) {
       return existingInstance as T;
     }
+    // Mark resources that came from `_search` so query-field seed handling can
+    // distinguish unresolved empty seeds from explicit empty card-GET results.
+    (resource as any)[queryFieldSeedFromSearchSymbol] = true;
     return this.add({ data: resource } as SingleCardDocument, {
       doNotPersist: true,
       relativeTo: new URL(resource.id),

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -284,6 +284,10 @@ export default class StoreService extends Service implements StoreInterface {
     return this.store.loaded();
   }
 
+  get loadGeneration(): number {
+    return this.store.loadGeneration;
+  }
+
   trackLoad(load: Promise<unknown>): void {
     this.store.trackLoad(load);
   }
@@ -703,14 +707,18 @@ export default class StoreService extends Service implements StoreInterface {
     this.realmServer.assertOwnRealmServer(realmServerURLs);
     let [realmServerURL] = realmServerURLs;
     let searchURL = new URL('_search', realmServerURL);
-    let response = await this.realmServer.maybeAuthedFetch(searchURL.href, {
-      method: 'QUERY',
-      headers: {
-        Accept: SupportedMimeType.CardJson,
-        'Content-Type': 'application/json',
+    let response = await this.realmServer.maybeAuthedFetchForRealms(
+      searchURL.href,
+      realms,
+      {
+        method: 'QUERY',
+        headers: {
+          Accept: SupportedMimeType.CardJson,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ ...query, realms }),
       },
-      body: JSON.stringify({ ...query, realms }),
-    });
+    );
     if (!response.ok) {
       let responseText = await response.text();
       let err = new Error(
@@ -765,14 +773,18 @@ export default class StoreService extends Service implements StoreInterface {
     this.realmServer.assertOwnRealmServer(realmServerURLs);
     let [realmServerURL] = realmServerURLs;
     let searchURL = new URL('_search', realmServerURL);
-    let response = await this.realmServer.maybeAuthedFetch(searchURL.href, {
-      method: 'QUERY',
-      headers: {
-        Accept: SupportedMimeType.CardJson,
-        'Content-Type': 'application/json',
+    let response = await this.realmServer.maybeAuthedFetchForRealms(
+      searchURL.href,
+      realms,
+      {
+        method: 'QUERY',
+        headers: {
+          Accept: SupportedMimeType.CardJson,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ ...query, realms }),
       },
-      body: JSON.stringify({ ...query, realms }),
-    });
+    );
     if (!response.ok) {
       let responseText = await response.text();
       let err = new Error(
@@ -1410,6 +1422,18 @@ export default class StoreService extends Service implements StoreInterface {
         if (!json.data.id) {
           // card source format is not serialized with the ID, so we add that back in.
           json.data.id = url;
+        }
+        if (!json.data.meta?.realmURL) {
+          // Source-mode loads in render context don't include realm metadata.
+          // Query-backed relationship fields require realmURL to build their
+          // fallback search query.
+          let realmURL = this.realm.realmOfURL(new URL(url))?.href;
+          if (realmURL) {
+            json.data.meta = {
+              ...(json.data.meta ?? {}),
+              realmURL,
+            };
+          }
         }
         doc = json;
       }

--- a/packages/host/tests/acceptance/image-def/avif-image-def-test.gts
+++ b/packages/host/tests/acceptance/image-def/avif-image-def-test.gts
@@ -23,6 +23,7 @@ import {
   setupAcceptanceTestRealm,
   SYSTEM_CARD_FIXTURE_CONTENTS,
   capturePrerenderResult,
+  waitForLoadedImage,
   withCachedRealmSetup,
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
@@ -361,27 +362,22 @@ module('Acceptance | avif image def', function (hooks) {
     let { status } = await capturePrerenderResult('innerHTML');
     assert.strictEqual(status, 'ready', 'render completed');
 
-    let img = document.querySelector(
-      '[data-prerender] .image-isolated__img',
-    ) as HTMLImageElement | null;
+    let imgSelector = '[data-prerender] .image-isolated__img';
+    let img = document.querySelector(imgSelector) as HTMLImageElement | null;
     assert.ok(img, 'img element is rendered');
     assert.ok(
       img?.getAttribute('src')?.includes('renderable.avif'),
       'img src references the AVIF file',
     );
 
-    await waitUntil(() => img!.naturalWidth > 0, {
-      timeout: 5000,
-      timeoutMessage:
-        'Image failed to load - naturalWidth remained 0. This likely indicates an authentication issue preventing the browser from fetching the image.',
-    });
+    let loadedImg = await waitForLoadedImage(imgSelector);
 
     assert.ok(
-      img!.naturalWidth > 0,
+      loadedImg.naturalWidth > 0,
       'Image loaded successfully with non-zero width',
     );
     assert.ok(
-      img!.naturalHeight > 0,
+      loadedImg.naturalHeight > 0,
       'Image loaded successfully with non-zero height',
     );
   });

--- a/packages/host/tests/acceptance/image-def/gif-image-def-test.gts
+++ b/packages/host/tests/acceptance/image-def/gif-image-def-test.gts
@@ -23,6 +23,7 @@ import {
   setupAcceptanceTestRealm,
   SYSTEM_CARD_FIXTURE_CONTENTS,
   capturePrerenderResult,
+  waitForLoadedImage,
   withCachedRealmSetup,
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
@@ -313,28 +314,22 @@ module('Acceptance | gif image def', function (hooks) {
     let { status } = await capturePrerenderResult('innerHTML');
     assert.strictEqual(status, 'ready', 'render completed');
 
-    let img = document.querySelector(
-      '[data-prerender] .image-isolated__img',
-    ) as HTMLImageElement | null;
+    let imgSelector = '[data-prerender] .image-isolated__img';
+    let img = document.querySelector(imgSelector) as HTMLImageElement | null;
     assert.ok(img, 'img element is rendered');
     assert.ok(
       img?.getAttribute('src')?.includes('sample.gif'),
       'img src references the GIF file',
     );
 
-    // Wait for the image to actually load and verify it has non-zero dimensions.
-    await waitUntil(() => img!.naturalWidth > 0, {
-      timeout: 5000,
-      timeoutMessage:
-        'Image failed to load - naturalWidth remained 0. This likely indicates an authentication issue preventing the browser from fetching the image.',
-    });
+    let loadedImg = await waitForLoadedImage(imgSelector);
 
     assert.ok(
-      img!.naturalWidth > 0,
+      loadedImg.naturalWidth > 0,
       'Image loaded successfully with non-zero width',
     );
     assert.ok(
-      img!.naturalHeight > 0,
+      loadedImg.naturalHeight > 0,
       'Image loaded successfully with non-zero height',
     );
   });

--- a/packages/host/tests/acceptance/image-def/jpg-image-def-test.gts
+++ b/packages/host/tests/acceptance/image-def/jpg-image-def-test.gts
@@ -23,6 +23,7 @@ import {
   setupAcceptanceTestRealm,
   SYSTEM_CARD_FIXTURE_CONTENTS,
   capturePrerenderResult,
+  waitForLoadedImage,
   withCachedRealmSetup,
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
@@ -311,28 +312,22 @@ module('Acceptance | jpg image def', function (hooks) {
     let { status } = await capturePrerenderResult('innerHTML');
     assert.strictEqual(status, 'ready', 'render completed');
 
-    let img = document.querySelector(
-      '[data-prerender] .image-isolated__img',
-    ) as HTMLImageElement | null;
+    let imgSelector = '[data-prerender] .image-isolated__img';
+    let img = document.querySelector(imgSelector) as HTMLImageElement | null;
     assert.ok(img, 'img element is rendered');
     assert.ok(
       img?.getAttribute('src')?.includes('sample.jpg'),
       'img src references the JPEG file',
     );
 
-    // Wait for the image to actually load and verify it has non-zero dimensions.
-    await waitUntil(() => img!.naturalWidth > 0, {
-      timeout: 5000,
-      timeoutMessage:
-        'Image failed to load - naturalWidth remained 0. This likely indicates an authentication issue preventing the browser from fetching the image.',
-    });
+    let loadedImg = await waitForLoadedImage(imgSelector);
 
     assert.ok(
-      img!.naturalWidth > 0,
+      loadedImg.naturalWidth > 0,
       'Image loaded successfully with non-zero width',
     );
     assert.ok(
-      img!.naturalHeight > 0,
+      loadedImg.naturalHeight > 0,
       'Image loaded successfully with non-zero height',
     );
   });

--- a/packages/host/tests/acceptance/image-def/png-image-def-test.gts
+++ b/packages/host/tests/acceptance/image-def/png-image-def-test.gts
@@ -23,6 +23,7 @@ import {
   setupAcceptanceTestRealm,
   SYSTEM_CARD_FIXTURE_CONTENTS,
   capturePrerenderResult,
+  waitForLoadedImage,
   withCachedRealmSetup,
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
@@ -399,32 +400,13 @@ module('Acceptance | png image def', function (hooks) {
     // This assertion will fail if the browser cannot fetch the image (e.g., 401 errors
     // due to missing authentication cookies). Once cookie-based auth is implemented,
     // this test should pass.
-    await waitUntil(
-      () => {
-        let currentImg = document.querySelector(
-          imgSelector,
-        ) as HTMLImageElement | null;
-        return Boolean(
-          currentImg && currentImg.complete && currentImg.naturalWidth > 0,
-        );
-      },
-      {
-        timeout: 5000,
-        timeoutMessage:
-          'Image failed to load - naturalWidth remained 0. This likely indicates an authentication issue preventing the browser from fetching the image.',
-      },
-    );
-
-    let loadedImg = document.querySelector(
-      imgSelector,
-    ) as HTMLImageElement | null;
-    assert.ok(loadedImg, 'img element remains rendered after load');
+    let loadedImg = await waitForLoadedImage(imgSelector);
     assert.ok(
-      loadedImg!.naturalWidth > 0,
+      loadedImg.naturalWidth > 0,
       'Image loaded successfully with non-zero width',
     );
     assert.ok(
-      loadedImg!.naturalHeight > 0,
+      loadedImg.naturalHeight > 0,
       'Image loaded successfully with non-zero height',
     );
   });

--- a/packages/host/tests/acceptance/image-def/png-image-def-test.gts
+++ b/packages/host/tests/acceptance/image-def/png-image-def-test.gts
@@ -387,9 +387,8 @@ module('Acceptance | png image def', function (hooks) {
     let { status } = await capturePrerenderResult('innerHTML');
     assert.strictEqual(status, 'ready', 'render completed');
 
-    let img = document.querySelector(
-      '[data-prerender] .image-isolated__img',
-    ) as HTMLImageElement | null;
+    let imgSelector = '[data-prerender] .image-isolated__img';
+    let img = document.querySelector(imgSelector) as HTMLImageElement | null;
     assert.ok(img, 'img element is rendered');
     assert.ok(
       img?.getAttribute('src')?.includes('sample.png'),
@@ -400,18 +399,32 @@ module('Acceptance | png image def', function (hooks) {
     // This assertion will fail if the browser cannot fetch the image (e.g., 401 errors
     // due to missing authentication cookies). Once cookie-based auth is implemented,
     // this test should pass.
-    await waitUntil(() => img!.naturalWidth > 0, {
-      timeout: 5000,
-      timeoutMessage:
-        'Image failed to load - naturalWidth remained 0. This likely indicates an authentication issue preventing the browser from fetching the image.',
-    });
+    await waitUntil(
+      () => {
+        let currentImg = document.querySelector(
+          imgSelector,
+        ) as HTMLImageElement | null;
+        return Boolean(
+          currentImg && currentImg.complete && currentImg.naturalWidth > 0,
+        );
+      },
+      {
+        timeout: 5000,
+        timeoutMessage:
+          'Image failed to load - naturalWidth remained 0. This likely indicates an authentication issue preventing the browser from fetching the image.',
+      },
+    );
 
+    let loadedImg = document.querySelector(
+      imgSelector,
+    ) as HTMLImageElement | null;
+    assert.ok(loadedImg, 'img element remains rendered after load');
     assert.ok(
-      img!.naturalWidth > 0,
+      loadedImg!.naturalWidth > 0,
       'Image loaded successfully with non-zero width',
     );
     assert.ok(
-      img!.naturalHeight > 0,
+      loadedImg!.naturalHeight > 0,
       'Image loaded successfully with non-zero height',
     );
   });

--- a/packages/host/tests/acceptance/image-def/svg-image-def-test.gts
+++ b/packages/host/tests/acceptance/image-def/svg-image-def-test.gts
@@ -23,6 +23,7 @@ import {
   setupAcceptanceTestRealm,
   SYSTEM_CARD_FIXTURE_CONTENTS,
   capturePrerenderResult,
+  waitForLoadedImage,
   withCachedRealmSetup,
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
@@ -315,28 +316,22 @@ module('Acceptance | svg image def', function (hooks) {
     let { status } = await capturePrerenderResult('innerHTML');
     assert.strictEqual(status, 'ready', 'render completed');
 
-    let img = document.querySelector(
-      '[data-prerender] .image-isolated__img',
-    ) as HTMLImageElement | null;
+    let imgSelector = '[data-prerender] .image-isolated__img';
+    let img = document.querySelector(imgSelector) as HTMLImageElement | null;
     assert.ok(img, 'img element is rendered');
     assert.ok(
       img?.getAttribute('src')?.includes('sample.svg'),
       'img src references the SVG file',
     );
 
-    // Wait for the image to actually load and verify it has non-zero dimensions.
-    await waitUntil(() => img!.naturalWidth > 0, {
-      timeout: 5000,
-      timeoutMessage:
-        'Image failed to load - naturalWidth remained 0. This likely indicates an authentication issue preventing the browser from fetching the image.',
-    });
+    let loadedImg = await waitForLoadedImage(imgSelector, { timeout: 10000 });
 
     assert.ok(
-      img!.naturalWidth > 0,
+      loadedImg.naturalWidth > 0,
       'Image loaded successfully with non-zero width',
     );
     assert.ok(
-      img!.naturalHeight > 0,
+      loadedImg.naturalHeight > 0,
       'Image loaded successfully with non-zero height',
     );
   });

--- a/packages/host/tests/acceptance/image-def/webp-image-def-test.gts
+++ b/packages/host/tests/acceptance/image-def/webp-image-def-test.gts
@@ -23,6 +23,7 @@ import {
   setupAcceptanceTestRealm,
   SYSTEM_CARD_FIXTURE_CONTENTS,
   capturePrerenderResult,
+  waitForLoadedImage,
   withCachedRealmSetup,
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
@@ -297,28 +298,22 @@ module('Acceptance | webp image def', function (hooks) {
     let { status } = await capturePrerenderResult('innerHTML');
     assert.strictEqual(status, 'ready', 'render completed');
 
-    let img = document.querySelector(
-      '[data-prerender] .image-isolated__img',
-    ) as HTMLImageElement | null;
+    let imgSelector = '[data-prerender] .image-isolated__img';
+    let img = document.querySelector(imgSelector) as HTMLImageElement | null;
     assert.ok(img, 'img element is rendered');
     assert.ok(
       img?.getAttribute('src')?.includes('sample.webp'),
       'img src references the WebP file',
     );
 
-    // Wait for the image to actually load and verify it has non-zero dimensions.
-    await waitUntil(() => img!.naturalWidth > 0, {
-      timeout: 5000,
-      timeoutMessage:
-        'Image failed to load - naturalWidth remained 0. This likely indicates an authentication issue preventing the browser from fetching the image.',
-    });
+    let loadedImg = await waitForLoadedImage(imgSelector);
 
     assert.ok(
-      img!.naturalWidth > 0,
+      loadedImg.naturalWidth > 0,
       'Image loaded successfully with non-zero width',
     );
     assert.ok(
-      img!.naturalHeight > 0,
+      loadedImg.naturalHeight > 0,
       'Image loaded successfully with non-zero height',
     );
   });

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -416,6 +416,44 @@ export async function capturePrerenderResult(
   return { status: 'ready', value: container.children[0][capture]! };
 }
 
+export interface WaitForLoadedImageOptions {
+  timeout?: number;
+  timeoutMessage?: string;
+}
+
+export async function waitForLoadedImage(
+  selector: string,
+  options: WaitForLoadedImageOptions = {},
+): Promise<HTMLImageElement> {
+  let {
+    timeout = 5000,
+    timeoutMessage = 'Image failed to load - naturalWidth remained 0. This likely indicates an authentication issue preventing the browser from fetching the image.',
+  } = options;
+
+  await waitUntil(
+    () => {
+      let currentImg = document.querySelector(
+        selector,
+      ) as HTMLImageElement | null;
+      return Boolean(
+        currentImg && currentImg.complete && currentImg.naturalWidth > 0,
+      );
+    },
+    {
+      timeout,
+      timeoutMessage,
+    },
+  );
+
+  let loadedImg = document.querySelector(selector) as HTMLImageElement | null;
+  if (!loadedImg) {
+    throw new Error(
+      `waitForLoadedImage: missing image element matching selector ${selector} after wait`,
+    );
+  }
+  return loadedImg;
+}
+
 function normalizeCapturedErrorText(errorText: string): string {
   let normalized = formatCapturedRenderError(errorText);
   return normalized ?? errorText;

--- a/packages/host/tests/integration/resources/search-test.ts
+++ b/packages/host/tests/integration/resources/search-test.ts
@@ -332,12 +332,12 @@ module(`Integration | search resource`, function (hooks) {
   test(`search is not re-run when query and realms are unchanged`, async function (assert) {
     let realmServer = getService('realm-server') as RealmServerService;
     let fetchCalls = 0;
-    let originalMaybeAuthedFetch =
-      realmServer.maybeAuthedFetch.bind(realmServer);
-    realmServer.maybeAuthedFetch = (async (...args) => {
+    let originalMaybeAuthedFetchForRealms =
+      realmServer.maybeAuthedFetchForRealms.bind(realmServer);
+    realmServer.maybeAuthedFetchForRealms = (async (...args) => {
       fetchCalls++;
-      return await originalMaybeAuthedFetch(...args);
-    }) as RealmServerService['maybeAuthedFetch'];
+      return await originalMaybeAuthedFetchForRealms(...args);
+    }) as RealmServerService['maybeAuthedFetchForRealms'];
 
     try {
       let query: Query = {
@@ -377,7 +377,7 @@ module(`Integration | search resource`, function (hooks) {
         'search is not invoked again when query/realms are unchanged',
       );
     } finally {
-      realmServer.maybeAuthedFetch = originalMaybeAuthedFetch;
+      realmServer.maybeAuthedFetchForRealms = originalMaybeAuthedFetchForRealms;
     }
   });
 

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -2081,12 +2081,11 @@ module('Integration | Store', function (hooks) {
       get card() {
         return this.resource.instances[0];
       }
-      get renderedCard() {
-        return this.card?.constructor.getComponent(this.card);
-      }
       <template>
         {{#if this.card}}
-          <this.renderedCard data-test-rendered-card={{this.card.id}} />
+          <div data-test-rendered-card={{this.card.id}}>
+            {{this.card.id}}
+          </div>
         {{/if}}
       </template>
     }

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -2105,7 +2105,12 @@ module('Integration | Store', function (hooks) {
     let hassan = `${testRealmURL}Person/hassan`;
 
     driver.id = hassan;
-    await waitFor(`[data-test-rendered-card="${hassan}"]`, { timeout: 5_000 });
+    await waitUntil(
+      () =>
+        storeService.getReferenceCount(hassan) === 1 &&
+        storeService.getReferenceCount(jade) === 0,
+      { timeout: 10_000 },
+    );
     assert.strictEqual(
       storeService.getReferenceCount(jade),
       0,
@@ -2118,7 +2123,12 @@ module('Integration | Store', function (hooks) {
     );
 
     driver.id = jade;
-    await waitFor(`[data-test-rendered-card="${jade}"]`, { timeout: 5_000 });
+    await waitUntil(
+      () =>
+        storeService.getReferenceCount(jade) === 1 &&
+        storeService.getReferenceCount(hassan) === 0,
+      { timeout: 10_000 },
+    );
     assert.strictEqual(
       storeService.getReferenceCount(jade),
       1,
@@ -2131,7 +2141,12 @@ module('Integration | Store', function (hooks) {
     );
 
     driver.showComponent = false;
-    await waitFor(`[data-test-rendered-card]`, { count: 0 });
+    await waitUntil(
+      () =>
+        storeService.getReferenceCount(jade) === 0 &&
+        storeService.getReferenceCount(hassan) === 0,
+      { timeout: 10_000 },
+    );
     assert.strictEqual(
       storeService.getReferenceCount(jade),
       0,

--- a/packages/realm-server/prerender/manager-app.ts
+++ b/packages/realm-server/prerender/manager-app.ts
@@ -7,6 +7,7 @@ import {
   PRERENDER_SERVER_DRAINING_STATUS_CODE,
   PRERENDER_SERVER_STATUS_DRAINING,
   PRERENDER_SERVER_STATUS_HEADER,
+  resolvePrerenderServerProxyTimeoutMs,
 } from './prerender-constants';
 
 type ServerInfo = {
@@ -80,10 +81,7 @@ export function buildPrerenderManagerApp(options?: {
   let lastRegistrySnapshot: string | undefined;
 
   const multiplex = Math.max(1, Number(process.env.PRERENDER_MULTIPLEX ?? 1));
-  const proxyTimeoutMs = Math.max(
-    1000,
-    Number(process.env.PRERENDER_SERVER_TIMEOUT_MS ?? 60000),
-  );
+  const proxyTimeoutMs = resolvePrerenderServerProxyTimeoutMs();
   const heartbeatTimeoutMs = Math.max(
     1000,
     Number(

--- a/packages/realm-server/prerender/prerender-constants.ts
+++ b/packages/realm-server/prerender/prerender-constants.ts
@@ -1,3 +1,52 @@
 export const PRERENDER_SERVER_STATUS_HEADER = 'X-Boxel-Prerender-Server-Status';
 export const PRERENDER_SERVER_STATUS_DRAINING = 'draining';
 export const PRERENDER_SERVER_DRAINING_STATUS_CODE = 410;
+
+// Base timeout for a single prerender capture on the prerender server
+// (DOM rendering + data loading inside the headless browser).
+const DEFAULT_RENDER_TIMEOUT_MS = 90_000;
+// Additional budget for request-level timeouts that wrap render work across
+// process/network boundaries (manager proxying, serialization, retries, etc).
+// Request timeout defaults are computed as:
+//   render timeout + overhead
+// so request-level aborts happen after render-level timeouts, not before.
+const DEFAULT_RENDER_TIMEOUT_OVERHEAD_MS = 60_000;
+// Global lower bound used when parsing timeout env vars so invalid/too-small
+// values (0, negative, NaN) do not cause immediate aborts or tight retry loops.
+const MIN_TIMEOUT_MS = 1_000;
+
+function parseTimeoutMs(raw: string | undefined, fallback: number): number {
+  let parsed = raw != null ? Number(raw) : NaN;
+  if (!Number.isFinite(parsed)) {
+    return Math.max(MIN_TIMEOUT_MS, fallback);
+  }
+  return Math.max(MIN_TIMEOUT_MS, parsed);
+}
+
+// Primary knob for prerender timeout behavior across layers.
+export const prerenderRenderTimeoutMs = parseTimeoutMs(
+  process.env.RENDER_TIMEOUT_MS,
+  DEFAULT_RENDER_TIMEOUT_MS,
+);
+
+const defaultPrerenderRequestTimeoutMs =
+  prerenderRenderTimeoutMs + DEFAULT_RENDER_TIMEOUT_OVERHEAD_MS;
+
+export const prerenderRequestTimeoutMs = parseTimeoutMs(
+  process.env.PRERENDER_REQUEST_TIMEOUT_MS,
+  defaultPrerenderRequestTimeoutMs,
+);
+
+export function resolvePrerenderManagerRequestTimeoutMs(): number {
+  return parseTimeoutMs(
+    process.env.PRERENDER_MANAGER_REQUEST_TIMEOUT_MS,
+    prerenderRequestTimeoutMs,
+  );
+}
+
+export function resolvePrerenderServerProxyTimeoutMs(): number {
+  return parseTimeoutMs(
+    process.env.PRERENDER_SERVER_TIMEOUT_MS,
+    prerenderRequestTimeoutMs,
+  );
+}

--- a/packages/realm-server/prerender/remote-prerenderer.ts
+++ b/packages/realm-server/prerender/remote-prerenderer.ts
@@ -12,8 +12,8 @@ import {
   PRERENDER_SERVER_DRAINING_STATUS_CODE,
   PRERENDER_SERVER_STATUS_DRAINING,
   PRERENDER_SERVER_STATUS_HEADER,
+  resolvePrerenderManagerRequestTimeoutMs,
 } from './prerender-constants';
-import { renderTimeoutMs } from './utils';
 
 const log = logger('remote-prerenderer');
 const jsonApiHeaders = {
@@ -49,10 +49,7 @@ export function createRemotePrerenderer(
     1000,
     Number(process.env.PRERENDER_MANAGER_MAX_DELAY_MS ?? 180_000),
   );
-  const requestTimeoutMs = Math.max(
-    1000,
-    Number(process.env.PRERENDER_MANAGER_REQUEST_TIMEOUT_MS ?? renderTimeoutMs),
-  );
+  const requestTimeoutMs = resolvePrerenderManagerRequestTimeoutMs();
 
   async function requestWithRetry<T>(
     path: string,

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -5,15 +5,12 @@ import {
   type PrerenderMeta,
   type RenderError,
 } from '@cardstack/runtime-common';
+import { prerenderRenderTimeoutMs } from './prerender-constants';
 
 import type { Page } from 'puppeteer';
 
 const log = logger('prerenderer');
-const DEFAULT_CARD_RENDER_TIMEOUT_MS = 30_000;
-
-export const cardRenderTimeout = Number(
-  process.env.RENDER_TIMEOUT_MS ?? DEFAULT_CARD_RENDER_TIMEOUT_MS,
-);
+export const cardRenderTimeout = prerenderRenderTimeoutMs;
 export const renderTimeoutMs = cardRenderTimeout;
 
 export type RenderStatus = 'ready' | 'error' | 'unusable';

--- a/packages/realm-server/tests/helpers/prerender-page-patches.ts
+++ b/packages/realm-server/tests/helpers/prerender-page-patches.ts
@@ -1,0 +1,151 @@
+import { Realm as RuntimeRealm } from '@cardstack/runtime-common';
+import { PagePool } from '../../prerender/page-pool';
+
+export function installRealmServerAssertOwnRealmServerBypassPatch(): {
+  restore: () => Promise<void>;
+} {
+  // Chrome patch setup:
+  // We need a browser-side patch because prerender tests can run the host app
+  // against dynamic realm origins (for example 127.0.0.1:4450), while the host's
+  // RealmServerService.assertOwnRealmServer check assumes a single configured
+  // realm server origin. Query-field search calls through that assertion before
+  // it performs _search, so without this patch search can bail out too early and
+  // we never get to exercise query-load tracking behavior.
+  let originalGetPage = PagePool.prototype.getPage;
+  let observedPage: any;
+
+  // Intercept page acquisition so we can inject one browser-runtime patch
+  // before route transitions/captures run.
+  PagePool.prototype.getPage = async function (this: PagePool, realm: string) {
+    let pageInfo = await originalGetPage.call(this, realm);
+    let page = pageInfo.page as any;
+    observedPage = page;
+    let originalEvaluate = page?.evaluate?.bind(page);
+
+    if (originalEvaluate) {
+      // Per-page guard. A single page can be reused by the page pool; we only
+      // need to install our patch once for that page instance.
+      let injected = false;
+      page.evaluate = async (...args: any[]) => {
+        if (!injected) {
+          injected = true;
+          await originalEvaluate(() => {
+            // Global guard in page context in case evaluate wrappers are
+            // re-entered or patched multiple times.
+            if ((globalThis as any).__boxelAssertOwnRealmServerPatched) {
+              return;
+            }
+            // Resolve the Ember module registry from whichever loader shape
+            // exists in this runtime build.
+            let entries =
+              (window as any).requirejs?.entries ??
+              (window as any).require?.entries ??
+              (window as any)._eak_seen;
+            // Find the compiled realm-server service module and patch only the
+            // one assertion method we need to bypass.
+            let realmServerModuleName =
+              entries &&
+              Object.keys(entries).find((name) =>
+                name.endsWith('/services/realm-server'),
+              );
+            if (!realmServerModuleName) {
+              return;
+            }
+            let realmServerModule = (window as any).require(
+              realmServerModuleName,
+            );
+            let RealmServerClass = realmServerModule?.default;
+            if (!RealmServerClass?.prototype) {
+              return;
+            }
+            // Save original behavior so restore() can put it back and avoid
+            // cross-test contamination.
+            (globalThis as any).__boxelOriginalAssertOwnRealmServer =
+              RealmServerClass.prototype.assertOwnRealmServer;
+            // Patch objective:
+            // Allow query-field search requests to proceed for dynamic test
+            // realm origins. We are not changing search logic itself; this only
+            // removes the single-origin assertion gate for this test runtime.
+            RealmServerClass.prototype.assertOwnRealmServer = function () {
+              return;
+            };
+            (globalThis as any).__boxelAssertOwnRealmServerPatched = true;
+          });
+        }
+        // Delegate every evaluate call back to original behavior after patching.
+        return originalEvaluate(...args);
+      };
+    }
+
+    return { ...pageInfo, page };
+  };
+
+  return {
+    restore: async () => {
+      if (observedPage) {
+        try {
+          await observedPage.evaluate(() => {
+            // Cleanup mirrors setup above: locate the same service module and
+            // restore the original assertOwnRealmServer implementation.
+            let entries =
+              (window as any).requirejs?.entries ??
+              (window as any).require?.entries ??
+              (window as any)._eak_seen;
+            let realmServerModuleName =
+              entries &&
+              Object.keys(entries).find((name) =>
+                name.endsWith('/services/realm-server'),
+              );
+            let originalAssertOwnRealmServer = (globalThis as any)
+              .__boxelOriginalAssertOwnRealmServer;
+            if (realmServerModuleName && originalAssertOwnRealmServer) {
+              let realmServerModule = (window as any).require(
+                realmServerModuleName,
+              );
+              let RealmServerClass = realmServerModule?.default;
+              if (RealmServerClass?.prototype) {
+                RealmServerClass.prototype.assertOwnRealmServer =
+                  originalAssertOwnRealmServer;
+              }
+            }
+            // Remove page globals used by this patch to keep runtime clean.
+            delete (globalThis as any).__boxelOriginalAssertOwnRealmServer;
+            delete (globalThis as any).__boxelAssertOwnRealmServerPatched;
+          });
+        } catch {
+          // best effort cleanup: page may already be gone
+        }
+      }
+      // Always restore Node-side monkeypatch as well.
+      PagePool.prototype.getPage = originalGetPage;
+    },
+  };
+}
+
+export function installDelayedRuntimeRealmSearchPatch(delayMs: number): {
+  getRequestCount: () => number;
+  restore: () => void;
+} {
+  // Server-side deterministic delay:
+  // This makes query timing explicit/reproducible so tests can assert that
+  // prerender waited for query resolution instead of "winning a race" by chance.
+  let originalSearch = RuntimeRealm.prototype.search;
+  let delayedSearchRequestCount = 0;
+
+  RuntimeRealm.prototype.search = async function (
+    this: RuntimeRealm,
+    query: Parameters<RuntimeRealm['search']>[0],
+  ): Promise<Awaited<ReturnType<RuntimeRealm['search']>>> {
+    // Exposed to tests as a stable signal that fallback _search actually ran.
+    delayedSearchRequestCount++;
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    return await originalSearch.call(this, query);
+  };
+
+  return {
+    getRequestCount: () => delayedSearchRequestCount,
+    restore: () => {
+      RuntimeRealm.prototype.search = originalSearch;
+    },
+  };
+}

--- a/packages/realm-server/tests/helpers/prerender-page-patches.ts
+++ b/packages/realm-server/tests/helpers/prerender-page-patches.ts
@@ -153,3 +153,61 @@ export function installDelayedRuntimeRealmSearchPatch(delayMs: number): {
     },
   };
 }
+
+export function installSearchRequestObserverPatch(): {
+  getRequests: () => Array<{
+    url: string;
+    method: string;
+    hasAuthorization: boolean;
+  }>;
+  restore: () => void;
+} {
+  let originalGetPage = PagePool.prototype.getPage;
+  let observedRequests: Array<{
+    url: string;
+    method: string;
+    hasAuthorization: boolean;
+  }> = [];
+  let pageRequestListeners = new Map<any, (request: any) => void>();
+
+  PagePool.prototype.getPage = async function (this: PagePool, realm: string) {
+    let pageInfo = await originalGetPage.call(this, realm);
+    let page = pageInfo.page as any;
+    if (page && !pageRequestListeners.has(page)) {
+      let listener = (request: any) => {
+        let url = request.url?.();
+        if (!url || !url.endsWith('/_search')) {
+          return;
+        }
+        let headers =
+          (request.headers?.() as Record<string, string> | undefined) ?? {};
+        observedRequests.push({
+          url,
+          method: request.method?.() ?? 'UNKNOWN',
+          hasAuthorization: Boolean(
+            headers.authorization ?? headers.Authorization,
+          ),
+        });
+      };
+      pageRequestListeners.set(page, listener);
+      page.on?.('request', listener);
+    }
+    return { ...pageInfo, page };
+  };
+
+  return {
+    getRequests: () => [...observedRequests],
+    restore: () => {
+      for (let [page, listener] of pageRequestListeners) {
+        try {
+          page.off?.('request', listener);
+        } catch {
+          // best-effort cleanup
+        }
+      }
+      pageRequestListeners.clear();
+      observedRequests = [];
+      PagePool.prototype.getPage = originalGetPage;
+    },
+  };
+}

--- a/packages/realm-server/tests/helpers/prerender-page-patches.ts
+++ b/packages/realm-server/tests/helpers/prerender-page-patches.ts
@@ -12,17 +12,17 @@ export function installRealmServerAssertOwnRealmServerBypassPatch(): {
   // it performs _search, so without this patch search can bail out too early and
   // we never get to exercise query-load tracking behavior.
   let originalGetPage = PagePool.prototype.getPage;
-  let observedPage: any;
+  let patchedPages = new Map<any, (...args: any[]) => Promise<any>>();
 
   // Intercept page acquisition so we can inject one browser-runtime patch
   // before route transitions/captures run.
   PagePool.prototype.getPage = async function (this: PagePool, realm: string) {
     let pageInfo = await originalGetPage.call(this, realm);
     let page = pageInfo.page as any;
-    observedPage = page;
     let originalEvaluate = page?.evaluate?.bind(page);
 
-    if (originalEvaluate) {
+    if (originalEvaluate && !patchedPages.has(page)) {
+      patchedPages.set(page, originalEvaluate);
       // Per-page guard. A single page can be reused by the page pool; we only
       // need to install our patch once for that page instance.
       let injected = false;
@@ -82,9 +82,12 @@ export function installRealmServerAssertOwnRealmServerBypassPatch(): {
 
   return {
     restore: async () => {
-      if (observedPage) {
+      for (let [page, originalEvaluate] of patchedPages) {
         try {
-          await observedPage.evaluate(() => {
+          // Restore the original evaluate first to avoid leaving wrapped
+          // evaluate functions behind on pooled pages that survive this test.
+          page.evaluate = originalEvaluate;
+          await originalEvaluate(() => {
             // Cleanup mirrors setup above: locate the same service module and
             // restore the original assertOwnRealmServer implementation.
             let entries =
@@ -116,6 +119,7 @@ export function installRealmServerAssertOwnRealmServerBypassPatch(): {
           // best effort cleanup: page may already be gone
         }
       }
+      patchedPages.clear();
       // Always restore Node-side monkeypatch as well.
       PagePool.prototype.getPage = originalGetPage;
     },

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -30,6 +30,7 @@ import {
 import {
   installDelayedRuntimeRealmSearchPatch,
   installRealmServerAssertOwnRealmServerBypassPatch,
+  installSearchRequestObserverPatch,
 } from './helpers/prerender-page-patches';
 
 class TestSemaphore {
@@ -498,28 +499,30 @@ module(basename(__filename), function () {
                 static isolated = class extends Component<typeof this> {
                   <template>
                     <div data-test-directory-team>{{@model.teamFilter}}</div>
-                    <ul data-test-directory-staff>
+                    <div id="heroGridPlane" data-test-hero-grid-plane>
                       {{#each @model.staff as |person|}}
-                        <li data-test-staff-name>{{person.name}}</li>
-                        <div data-test-staff-manager>
-                          {{#if person.manager}}
-                            {{person.manager.name}}
-                          {{/if}}
+                        <div class="hero-mini-card" data-test-hero-mini-card>
+                          <div data-test-staff-name>{{person.name}}</div>
+                          <div data-test-staff-manager>
+                            {{#if person.manager}}
+                              {{person.manager.name}}
+                            {{/if}}
+                          </div>
+                          <ul data-test-staff-reports>
+                            {{#each person.reports as |report|}}
+                              <li class="hero-mini-card" data-test-staff-report data-test-hero-mini-card>
+                                {{report.name}}
+                                <span data-test-staff-report-manager>
+                                  {{#if report.manager}}
+                                    {{report.manager.name}}
+                                  {{/if}}
+                                </span>
+                              </li>
+                            {{/each}}
+                          </ul>
                         </div>
-                        <ul data-test-staff-reports>
-                          {{#each person.reports as |report|}}
-                            <li data-test-staff-report>
-                              {{report.name}}
-                              <span data-test-staff-report-manager>
-                                {{#if report.manager}}
-                                  {{report.manager.name}}
-                                {{/if}}
-                              </span>
-                            </li>
-                          {{/each}}
-                        </ul>
                       {{/each}}
-                    </ul>
+                    </div>
                   </template>
                 };
               }
@@ -1220,6 +1223,15 @@ module(basename(__filename), function () {
           /data-test-staff-report-manager[^>]*>\s*Bob\s*</.test(isolatedHTML),
           `isolated html includes nested relationship loads: ${isolatedHTML}`,
         );
+        assert.ok(
+          /id="heroGridPlane"/.test(isolatedHTML),
+          `isolated html includes hero grid container: ${isolatedHTML}`,
+        );
+        let heroMiniCards = isolatedHTML.match(/class="hero-mini-card"/g) ?? [];
+        assert.ok(
+          heroMiniCards.length >= 3,
+          `isolated html includes hero mini cards from query and nested query loads: ${isolatedHTML}`,
+        );
 
         let staff = result.response.searchDoc?.staff as
           | Array<Record<string, any>>
@@ -1401,6 +1413,7 @@ module(basename(__filename), function () {
   module('prerender - permissioned auth failures', function (hooks) {
     let providerRealmURL = 'http://127.0.0.1:4451/test/';
     let consumerRealmURL = 'http://127.0.0.1:4452/test/';
+    let privateConsumerRealmURL = 'http://127.0.0.1:4453/test/';
     let prerenderServerURL = new URL(consumerRealmURL).origin;
     let testUserId = '@user1:localhost';
     let permissions: RealmPermissions = {};
@@ -1421,6 +1434,7 @@ module(basename(__filename), function () {
     hooks.beforeEach(function () {
       permissions = {
         [consumerRealmURL]: ['read', 'write', 'realm-owner'],
+        [privateConsumerRealmURL]: ['read', 'write', 'realm-owner'],
       };
     });
 
@@ -1428,7 +1442,114 @@ module(basename(__filename), function () {
       await Promise.all([
         prerenderer.disposeRealm(providerRealmURL),
         prerenderer.disposeRealm(consumerRealmURL),
+        prerenderer.disposeRealm(privateConsumerRealmURL),
       ]);
+    });
+
+    let makeQueryDirectoryFileSystem = () => ({
+      'person.gts': `
+        import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
+        import StringField from "https://cardstack.com/base/string";
+
+        export class Person extends CardDef {
+          @field name = contains(StringField);
+        }
+      `,
+      'person-1.json': {
+        data: {
+          attributes: {
+            name: 'Alpha',
+          },
+          meta: {
+            adoptsFrom: {
+              module: './person',
+              name: 'Person',
+            },
+          },
+        },
+      },
+      'person-2.json': {
+        data: {
+          attributes: {
+            name: 'Beta',
+          },
+          meta: {
+            adoptsFrom: {
+              module: './person',
+              name: 'Person',
+            },
+          },
+        },
+      },
+      'query-directory.gts': `
+        import { field, CardDef, Component, linksToMany } from "https://cardstack.com/base/card-api";
+        import { Person } from "./person";
+
+        export class QueryDirectory extends CardDef {
+          @field people = linksToMany(() => Person, {
+            query: {
+              filter: {
+                eq: {
+                  name: "Beta",
+                },
+              },
+            },
+          });
+
+          static isolated = class extends Component<typeof this> {
+            <template>
+              <ul data-test-directory-people>
+                {{#each @model.people as |person|}}
+                  <li data-test-directory-person-name>{{person.name}}</li>
+                {{/each}}
+              </ul>
+            </template>
+          };
+        }
+      `,
+      'query-directory-1.json': {
+        data: {
+          attributes: {},
+          meta: {
+            adoptsFrom: {
+              module: './query-directory',
+              name: 'QueryDirectory',
+            },
+          },
+        },
+      },
+      'query-directory-proxy.gts': `
+        import { field, CardDef, Component, linksTo } from "https://cardstack.com/base/card-api";
+        import { QueryDirectory } from "./query-directory";
+
+        export class QueryDirectoryProxy extends CardDef {
+          @field directory = linksTo(() => QueryDirectory);
+
+          static isolated = class extends Component<typeof this> {
+            <template>
+              <@fields.directory @format="isolated" />
+            </template>
+          };
+        }
+      `,
+      'query-directory-proxy-1.json': {
+        data: {
+          attributes: {},
+          relationships: {
+            directory: {
+              links: {
+                self: './query-directory-1',
+              },
+            },
+          },
+          meta: {
+            adoptsFrom: {
+              module: './query-directory-proxy',
+              name: 'QueryDirectoryProxy',
+            },
+          },
+        },
+      },
     });
 
     setupPermissionedRealms(hooks, {
@@ -1527,12 +1648,23 @@ module(basename(__filename), function () {
                 },
               },
             },
+            ...makeQueryDirectoryFileSystem(),
+          },
+        },
+        {
+          realmURL: privateConsumerRealmURL,
+          permissions: {
+            [testUserId]: ['read', 'write', 'realm-owner'],
+          },
+          fileSystem: {
+            ...makeQueryDirectoryFileSystem(),
           },
         },
       ],
       onRealmSetup() {
         permissions = {
           [consumerRealmURL]: ['read', 'write', 'realm-owner'],
+          [privateConsumerRealmURL]: ['read', 'write', 'realm-owner'],
         };
       },
     });
@@ -1649,6 +1781,89 @@ module(basename(__filename), function () {
         'auth failure not misreported as timeout',
       );
       assert.false(result.pool.timedOut, 'prerender did not time out');
+    });
+
+    test('card prerender in a public realm authorizes query fallback search for source-loaded linked cards', async function (assert) {
+      const cardURL = `${consumerRealmURL}query-directory-proxy-1`;
+      let realmServerPatch =
+        installRealmServerAssertOwnRealmServerBypassPatch();
+      let delayedSearchPatch = installDelayedRuntimeRealmSearchPatch(150);
+      try {
+        let result = await prerenderer.prerenderCard({
+          realm: consumerRealmURL,
+          url: cardURL,
+          auth: auth(),
+        });
+
+        assert.notOk(
+          result.response.error,
+          'prerender succeeds for linked query-backed card in public realm',
+        );
+        assert.true(
+          delayedSearchPatch.getRequestCount() > 0,
+          'fallback _search requests occurred',
+        );
+
+        let isolatedHTML = cleanWhiteSpace(result.response.isolatedHTML ?? '');
+        assert.ok(
+          /data-test-directory-person-name[^>]*>\s*Beta\s*</.test(isolatedHTML),
+          `isolated html includes query result Beta: ${isolatedHTML}`,
+        );
+      } finally {
+        await realmServerPatch.restore();
+        delayedSearchPatch.restore();
+      }
+    });
+
+    test('card prerender in a private realm sends auth header on query fallback _search', async function (assert) {
+      const cardURL = `${privateConsumerRealmURL}query-directory-proxy-1`;
+      let realmServerPatch =
+        installRealmServerAssertOwnRealmServerBypassPatch();
+      let searchRequestObserverPatch = installSearchRequestObserverPatch();
+      let delayedSearchPatch = installDelayedRuntimeRealmSearchPatch(150);
+      try {
+        let result = await prerenderer.prerenderCard({
+          realm: privateConsumerRealmURL,
+          url: cardURL,
+          auth: auth(),
+        });
+
+        assert.notOk(
+          result.response.error,
+          'prerender succeeds for linked query-backed card in private realm',
+        );
+        assert.true(
+          delayedSearchPatch.getRequestCount() > 0,
+          'fallback _search requests occurred',
+        );
+
+        let isolatedHTML = cleanWhiteSpace(result.response.isolatedHTML ?? '');
+        assert.ok(
+          /data-test-directory-person-name[^>]*>\s*Beta\s*</.test(isolatedHTML),
+          `isolated html includes query result Beta: ${isolatedHTML}`,
+        );
+
+        let searchRequests = searchRequestObserverPatch.getRequests();
+        assert.true(
+          searchRequests.length > 0,
+          '_search request was observed at browser layer',
+        );
+        let querySearchRequests = searchRequests.filter(
+          (request) => request.method === 'QUERY',
+        );
+        assert.true(
+          querySearchRequests.length > 0,
+          '_search QUERY request was observed',
+        );
+        assert.true(
+          querySearchRequests.every((request) => request.hasAuthorization),
+          `all _search QUERY requests include Authorization header: ${JSON.stringify(searchRequests)}`,
+        );
+      } finally {
+        delayedSearchPatch.restore();
+        searchRequestObserverPatch.restore();
+        await realmServerPatch.restore();
+      }
     });
   });
 

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -1552,6 +1552,14 @@ module(basename(__filename), function () {
     });
 
     hooks.before(async function () {
+      // setupPermissionedRealms(..., { mode: 'before' }) registers its own
+      // hooks.before that runs first and populates permissionedRealms via
+      // onRealmSetup(). This guard makes that ordering contract explicit.
+      if (permissionedRealms.length === 0) {
+        throw new Error(
+          'expected permissionedRealms to be populated before indexing wait',
+        );
+      }
       await Promise.all(permissionedRealms.map((realm) => realm.indexing()));
     });
 

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -2,14 +2,16 @@ import { module, test } from 'qunit';
 import { basename } from 'path';
 import type {
   RealmPermissions,
-  Realm,
   RealmAdapter,
   RenderResponse,
   ModuleRenderResponse,
   FileExtractResponse,
   RenderRouteOptions,
 } from '@cardstack/runtime-common';
-import { baseRealm } from '@cardstack/runtime-common';
+import {
+  baseRealm,
+  type Realm as RuntimeRealm,
+} from '@cardstack/runtime-common';
 import type { Prerenderer } from '../prerender/index';
 import { PagePool } from '../prerender/page-pool';
 import { RenderRunner } from '../prerender/render-runner';
@@ -25,6 +27,10 @@ import {
   baseCardRef,
   trimExecutableExtension,
 } from '@cardstack/runtime-common';
+import {
+  installDelayedRuntimeRealmSearchPatch,
+  installRealmServerAssertOwnRealmServerBypassPatch,
+} from './helpers/prerender-page-patches';
 
 class TestSemaphore {
   #available: number;
@@ -131,11 +137,22 @@ module(basename(__filename), function () {
     let realmURL = 'http://127.0.0.1:4450/test/';
     let prerenderServerURL = new URL(realmURL).origin;
     let testUserId = '@user1:localhost';
-    let permissions: RealmPermissions = {};
+    let permissions: RealmPermissions = {
+      [realmURL]: ['read', 'write', 'realm-owner'],
+    };
     let prerenderer: Prerenderer;
     let realmAdapter: RealmAdapter;
-    let realm: Realm;
-    let auth = () => testCreatePrerenderAuth(testUserId, permissions);
+    let realm: RuntimeRealm;
+    let auth = () => {
+      let sessions = JSON.parse(
+        testCreatePrerenderAuth(testUserId, permissions),
+      ) as Record<string, string>;
+      let token = sessions[realmURL];
+      if (token) {
+        sessions[new URL(realmURL).origin + '/'] = token;
+      }
+      return JSON.stringify(sessions);
+    };
 
     hooks.before(async () => {
       prerenderer = getPrerendererForTesting({
@@ -157,6 +174,7 @@ module(basename(__filename), function () {
         {
           realmURL,
           permissions: {
+            '*': ['read'],
             [testUserId]: ['read', 'write', 'realm-owner'],
           },
           fileSystem: {
@@ -397,6 +415,243 @@ module(basename(__filename), function () {
                   adoptsFrom: {
                     module: './console-no-error',
                     name: 'ConsoleNoError',
+                  },
+                },
+              },
+            },
+            'directory-query.gts': `
+              import { CardDef, field, contains, linksTo, linksToMany, StringField, Component, queryableValue } from 'https://cardstack.com/base/card-api';
+
+              export class Person extends CardDef {
+                static displayName = 'Person';
+                @field name = contains(StringField);
+                @field team = contains(StringField);
+                @field managerName = contains(StringField);
+                @field manager = linksTo(() => Person);
+                @field reports = linksToMany(() => Person, {
+                  query: {
+                    filter: {
+                      eq: {
+                        managerName: '$this.name',
+                      },
+                    },
+                    page: {
+                      size: 10,
+                      number: 0,
+                    },
+                  },
+                });
+
+                // Keep person-instance indexing deterministic for this test:
+                // this avoids firing query fields when Person cards are
+                // prerendered in isolation during indexing.
+                static isolated = class extends Component<typeof this> {
+                  <template>
+                    <span data-test-person-name>{{@model.name}}</span>
+                    <span data-test-person-team>{{@model.team}}</span>
+                  </template>
+                };
+              }
+
+              export class Directory extends CardDef {
+                static displayName = 'Directory';
+                @field teamFilter = contains(StringField);
+                @field staff = linksToMany(() => Person, {
+                  query: {
+                    filter: {
+                      eq: {
+                        team: '$this.teamFilter',
+                      },
+                    },
+                    page: {
+                      size: 10,
+                      number: 0,
+                    },
+                  },
+                });
+
+                static [queryableValue](value: Directory | null) {
+                  if (!value) {
+                    return null;
+                  }
+                  return {
+                    teamFilter: value.teamFilter,
+                    staff: (value.staff ?? []).map((person) => ({
+                      name: person.name,
+                      manager: person.manager
+                        ? {
+                            name: person.manager.name,
+                          }
+                        : null,
+                      reports: (person.reports ?? []).map((report) => ({
+                        name: report.name,
+                        manager: report.manager
+                          ? {
+                              name: report.manager.name,
+                            }
+                          : null,
+                      })),
+                    })),
+                  };
+                }
+
+                static isolated = class extends Component<typeof this> {
+                  <template>
+                    <div data-test-directory-team>{{@model.teamFilter}}</div>
+                    <ul data-test-directory-staff>
+                      {{#each @model.staff as |person|}}
+                        <li data-test-staff-name>{{person.name}}</li>
+                        <div data-test-staff-manager>
+                          {{#if person.manager}}
+                            {{person.manager.name}}
+                          {{/if}}
+                        </div>
+                        <ul data-test-staff-reports>
+                          {{#each person.reports as |report|}}
+                            <li data-test-staff-report>
+                              {{report.name}}
+                              <span data-test-staff-report-manager>
+                                {{#if report.manager}}
+                                  {{report.manager.name}}
+                                {{/if}}
+                              </span>
+                            </li>
+                          {{/each}}
+                        </ul>
+                      {{/each}}
+                    </ul>
+                  </template>
+                };
+              }
+            `,
+            'directory-ops.json': {
+              data: {
+                attributes: {
+                  teamFilter: 'Ops',
+                },
+                relationships: {
+                  staff: {
+                    links: { self: null },
+                    data: [],
+                    meta: {
+                      errors: [
+                        {
+                          realm: 'https://unreachable-realm.example.com/',
+                          type: 'fetch-error',
+                          message: 'Could not reach remote realm',
+                          status: 502,
+                        },
+                      ],
+                    },
+                  },
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './directory-query',
+                    name: 'Directory',
+                  },
+                },
+              },
+            },
+            'person-alice.json': {
+              data: {
+                attributes: {
+                  name: 'Alice',
+                  team: 'Leadership',
+                  managerName: '',
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './directory-query',
+                    name: 'Person',
+                  },
+                },
+              },
+            },
+            'person-bob.json': {
+              data: {
+                attributes: {
+                  name: 'Bob',
+                  team: 'Ops',
+                  managerName: 'Alice',
+                },
+                relationships: {
+                  manager: {
+                    links: {
+                      self: './person-alice',
+                    },
+                  },
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './directory-query',
+                    name: 'Person',
+                  },
+                },
+              },
+            },
+            'person-carol.json': {
+              data: {
+                attributes: {
+                  name: 'Carol',
+                  team: 'Ops',
+                  managerName: 'Alice',
+                },
+                relationships: {
+                  manager: {
+                    links: {
+                      self: './person-alice',
+                    },
+                  },
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './directory-query',
+                    name: 'Person',
+                  },
+                },
+              },
+            },
+            'person-dave.json': {
+              data: {
+                attributes: {
+                  name: 'Dave',
+                  team: 'Ops',
+                  managerName: 'Bob',
+                },
+                relationships: {
+                  manager: {
+                    links: {
+                      self: './person-bob',
+                    },
+                  },
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './directory-query',
+                    name: 'Person',
+                  },
+                },
+              },
+            },
+            'person-eve.json': {
+              data: {
+                attributes: {
+                  name: 'Eve',
+                  team: 'Sales',
+                  managerName: 'Bob',
+                },
+                relationships: {
+                  manager: {
+                    links: {
+                      self: './person-bob',
+                    },
+                  },
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './directory-query',
+                    name: 'Person',
                   },
                 },
               },
@@ -927,6 +1182,76 @@ module(basename(__filename), function () {
         );
       } finally {
         PagePool.prototype.getPage = originalGetPage;
+      }
+    });
+
+    test('card prerender waits for query fallback search and nested relationship loads', async function (assert) {
+      const cardURL = `${realmURL}directory-ops`;
+      let realmServerPatch =
+        installRealmServerAssertOwnRealmServerBypassPatch();
+      let delayedSearchPatch = installDelayedRuntimeRealmSearchPatch(150);
+      try {
+        let result = await prerenderer.prerenderCard({
+          realm: realmURL,
+          url: cardURL,
+          auth: auth(),
+        });
+
+        assert.notOk(result.response.error, 'prerender succeeds');
+        assert.true(
+          delayedSearchPatch.getRequestCount() > 0,
+          'fallback _search requests occurred and were delayed',
+        );
+
+        let isolatedHTML = cleanWhiteSpace(result.response.isolatedHTML ?? '');
+        assert.ok(
+          /data-test-staff-name[^>]*>\s*Bob\s*</.test(isolatedHTML),
+          `isolated html includes query results: ${isolatedHTML}`,
+        );
+        assert.ok(
+          /data-test-staff-manager[^>]*>\s*Alice\s*</.test(isolatedHTML),
+          `isolated html includes lazy relationship from query result: ${isolatedHTML}`,
+        );
+        assert.ok(
+          /data-test-staff-report[^>]*>\s*Eve/.test(isolatedHTML),
+          `isolated html includes nested query results: ${isolatedHTML}`,
+        );
+        assert.ok(
+          /data-test-staff-report-manager[^>]*>\s*Bob\s*</.test(isolatedHTML),
+          `isolated html includes nested relationship loads: ${isolatedHTML}`,
+        );
+
+        let staff = result.response.searchDoc?.staff as
+          | Array<Record<string, any>>
+          | undefined;
+        assert.ok(
+          Array.isArray(staff),
+          'searchDoc includes query field results',
+        );
+
+        let bob = staff?.find((entry) => entry?.name === 'Bob');
+        assert.ok(bob, 'searchDoc includes Bob from query results');
+        assert.strictEqual(
+          bob?.manager?.name,
+          'Alice',
+          'searchDoc includes loaded manager relationship',
+        );
+
+        let bobReports = bob?.reports as Array<Record<string, any>> | undefined;
+        assert.ok(
+          Array.isArray(bobReports),
+          'searchDoc includes nested query results',
+        );
+        let hasEveWithManager = bobReports?.some(
+          (report) => report?.name === 'Eve' && report?.manager?.name === 'Bob',
+        );
+        assert.true(
+          Boolean(hasEveWithManager),
+          'searchDoc includes nested loaded relationships',
+        );
+      } finally {
+        await realmServerPatch.restore();
+        delayedSearchPatch.restore();
       }
     });
 

--- a/packages/runtime-common/document.ts
+++ b/packages/runtime-common/document.ts
@@ -44,6 +44,27 @@ async function loadDocumentWithRequest(
     return cardError;
   }
   let json = await response.json();
+  let realmURL = response.headers.get('x-boxel-realm-url');
+  let lastModified = response.headers.get('last-modified');
+  if (
+    json &&
+    typeof json === 'object' &&
+    'data' in json &&
+    json.data &&
+    typeof json.data === 'object' &&
+    !Array.isArray(json.data) &&
+    (realmURL || lastModified)
+  ) {
+    let lastModifiedMS =
+      lastModified != null ? new Date(lastModified).getTime() : undefined;
+    (json.data as { meta?: Record<string, unknown> }).meta = {
+      ...((json.data as { meta?: Record<string, unknown> }).meta ?? {}),
+      ...(realmURL ? { realmURL } : {}),
+      ...(lastModifiedMS != null && !Number.isNaN(lastModifiedMS)
+        ? { lastModified: lastModifiedMS }
+        : {}),
+    };
+  }
   return json;
 }
 


### PR DESCRIPTION
This change set improves prerender reliability for query-backed UIs by closing timing/auth/recovery gaps from card/module hydration through render-settle capture. It ensures query-driven and nested relationship content (for example hero mini-cards) is loaded before prerender is marked ready, ensures fallback federated-search calls execute with the correct auth/realm context, and aligns timeout/retry behavior across prerender layers. It also hardens failure recovery by treating unhandled rejection-style render failures as eviction-worthy so pooled pages recover cleanly. Tests were expanded and split to reproduce delayed-query/nested-load conditions and private/public fallback-search auth paths, validating that captured HTML/search docs now include expected dynamic content.

Here is a prerender of the homepage index.json isolated format from this branch:

<img width="4536" height="2587" alt="Screenshot from 2026-02-25 10-36-27" src="https://github.com/user-attachments/assets/3bd42334-5536-4940-9cf6-240f6a261ef6" />

Here is the isolated html for the homepage index.json, which includes the hero-mini-cards in the captured HTML:

<img width="3963" height="2652" alt="Screenshot from 2026-02-25 10-35-32" src="https://github.com/user-attachments/assets/f74d90a3-f4f6-44a6-8880-46319bb62c4c" />

