### PR TITLE
Add context menu with Delete option to file tree entries

### DIFF
--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -1,4 +1,4 @@
-import { fn, concat } from '@ember/helper';
+import { fn, concat, array } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
@@ -7,7 +7,13 @@ import { tracked } from '@glimmer/tracking';
 
 import { TrackedArray } from 'tracked-built-ins';
 
-import { eq } from '@cardstack/boxel-ui/helpers';
+import {
+  BoxelDropdown,
+  ContextButton,
+  Menu,
+  type BoxelDropdownAPI,
+} from '@cardstack/boxel-ui/components';
+import { eq, menuItem } from '@cardstack/boxel-ui/helpers';
 
 import { DropdownArrowDown } from '@cardstack/boxel-ui/icons';
 
@@ -25,6 +31,7 @@ interface Args {
     openDirs?: LocalPath[];
     onFileSelected?: (entryPath: LocalPath) => void;
     onDirectorySelected?: (entryPath: LocalPath) => void;
+    onDeleteFile?: (entryPath: LocalPath) => void;
     scrollPositionKey?: LocalPath;
   };
 }
@@ -35,19 +42,55 @@ export default class Directory extends Component<Args> {
       <div class='level' data-test-directory-level>
         {{#let (concat @relativePath entry.name) as |entryPath|}}
           {{#if (eq entry.kind 'file')}}
-            <button
-              data-test-file={{entryPath}}
-              title={{entry.name}}
-              {{on 'click' (fn this.selectFile entryPath)}}
-              {{scrollIntoViewModifier
-                (this.isSelectedFile entryPath)
-                container='file-tree'
-                key=@scrollPositionKey
-              }}
-              class='file {{if (this.isSelectedFile entryPath) "selected"}}'
+            <div
+              class='file-row {{if (this.isSelectedFile entryPath) "selected"}}'
+              data-test-file-row={{entryPath}}
+              {{on 'contextmenu' (fn this.onFileRowContextMenu entryPath)}}
             >
-              {{entry.name}}
-            </button>
+              <button
+                data-test-file={{entryPath}}
+                title={{entry.name}}
+                {{on 'click' (fn this.selectFile entryPath)}}
+                {{scrollIntoViewModifier
+                  (this.isSelectedFile entryPath)
+                  container='file-tree'
+                  key=@scrollPositionKey
+                }}
+                class='file {{if (this.isSelectedFile entryPath) "selected"}}'
+              >
+                {{entry.name}}
+              </button>
+              {{#if @onDeleteFile}}
+                <BoxelDropdown
+                  @registerAPI={{fn this.registerDropdownApi entryPath}}
+                  @contentClass='file-tree-context-menu'
+                >
+                  <:trigger as |bindings|>
+                    <ContextButton
+                      class='file-menu-trigger'
+                      @icon='context-menu'
+                      @size='extra-small'
+                      @label='File options'
+                      @variant='ghost'
+                      {{bindings}}
+                    />
+                  </:trigger>
+                  <:content as |dd|>
+                    <Menu
+                      class='file-tree-context-menu-list'
+                      @items={{array
+                        (menuItem
+                          'Delete'
+                          (fn this.deleteFileEntry entryPath)
+                          dangerous=true
+                        )
+                      }}
+                      @closeMenu={{dd.close}}
+                    />
+                  </:content>
+                </BoxelDropdown>
+              {{/if}}
+            </div>
           {{else}}
             <button
               data-test-directory={{entryPath}}
@@ -74,6 +117,7 @@ export default class Directory extends Component<Args> {
                 @openDirs={{if @openDirs @openDirs this.openDirs}}
                 @onFileSelected={{this.selectFile}}
                 @onDirectorySelected={{this.selectDirectory}}
+                @onDeleteFile={{@onDeleteFile}}
                 @scrollPositionKey={{@scrollPositionKey}}
               />
             {{/if}}
@@ -93,8 +137,49 @@ export default class Directory extends Component<Args> {
         padding-left: 1em;
       }
 
-      .directory,
-      .file {
+      .file-row {
+        display: flex;
+        align-items: center;
+        border-radius: var(--boxel-border-radius-xs);
+      }
+
+      .file-row:hover,
+      .file-row:focus-within {
+        background-color: var(--boxel-200);
+      }
+
+      .file-row.selected {
+        color: var(--boxel-dark);
+        background-color: var(--boxel-highlight);
+      }
+
+      .file-row .file {
+        flex: 1;
+        min-width: 0;
+        background: transparent;
+        border: 0;
+        padding: var(--boxel-sp-xxxs);
+        padding-left: calc(var(--icon-length) + var(--icon-margin));
+        text-align: start;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: inherit;
+        border-radius: var(--boxel-border-radius-xs);
+      }
+
+      .file-menu-trigger {
+        flex-shrink: 0;
+        visibility: hidden;
+        margin-right: var(--boxel-sp-xxxs);
+      }
+
+      .file-row:hover .file-menu-trigger,
+      .file-row:focus-within .file-menu-trigger {
+        visibility: visible;
+      }
+
+      .directory {
         border-radius: var(--boxel-border-radius-xs);
         background: transparent;
         border: 0;
@@ -104,21 +189,11 @@ export default class Directory extends Component<Args> {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-      }
-
-      .directory:hover,
-      .file:hover {
-        background-color: var(--boxel-200);
-      }
-
-      .file.selected,
-      .file:active {
-        color: var(--boxel-dark);
-        background-color: var(--boxel-highlight);
-      }
-
-      .directory {
         padding-left: 0;
+      }
+
+      .directory:hover {
+        background-color: var(--boxel-200);
       }
 
       .directory :deep(.icon) {
@@ -131,10 +206,6 @@ export default class Directory extends Component<Args> {
       .directory :deep(.icon.closed) {
         transform: rotate(-90deg);
       }
-
-      .file {
-        padding-left: calc(var(--icon-length) + var(--icon-margin));
-      }
     </style>
   </template>
 
@@ -146,6 +217,7 @@ export default class Directory extends Component<Args> {
 
   @tracked private selectedFile?: LocalPath;
   private openDirs: TrackedArray<LocalPath> = new TrackedArray();
+  private dropdownApis = new Map<LocalPath, BoxelDropdownAPI>();
 
   @action
   private selectFile(entryPath: LocalPath) {
@@ -180,5 +252,25 @@ export default class Directory extends Component<Args> {
     let openDirs = this.args.openDirs ?? this.openDirs;
 
     return openDirs.includes(dirPath);
+  }
+
+  @action
+  private registerDropdownApi(entryPath: LocalPath, api: BoxelDropdownAPI) {
+    this.dropdownApis.set(entryPath, api);
+  }
+
+  @action
+  private onFileRowContextMenu(entryPath: LocalPath, e: MouseEvent) {
+    if (!this.args.onDeleteFile) {
+      return;
+    }
+    e.preventDefault();
+    const api = this.dropdownApis.get(entryPath);
+    api?.actions.open(e);
+  }
+
+  @action
+  private deleteFileEntry(entryPath: LocalPath) {
+    this.args.onDeleteFile?.(entryPath);
   }
 }

--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -15,7 +15,7 @@ import {
 } from '@cardstack/boxel-ui/components';
 import { eq, menuItem } from '@cardstack/boxel-ui/helpers';
 
-import { DropdownArrowDown } from '@cardstack/boxel-ui/icons';
+import { DropdownArrowDown, IconTrash } from '@cardstack/boxel-ui/icons';
 
 import type { LocalPath } from '@cardstack/runtime-common/paths';
 
@@ -82,6 +82,7 @@ export default class Directory extends Component<Args> {
                         (menuItem
                           'Delete'
                           (fn this.deleteFileEntry entryPath)
+                          icon=IconTrash
                           dangerous=true
                         )
                       }}

--- a/packages/host/app/components/editor/file-tree.gts
+++ b/packages/host/app/components/editor/file-tree.gts
@@ -16,6 +16,7 @@ interface Signature {
     openDirs?: LocalPath[];
     onFileSelected?: (entryPath: LocalPath) => Promise<void>;
     onDirectorySelected?: (entryPath: LocalPath) => void;
+    onDeleteFile?: (entryPath: LocalPath) => void;
     scrollPositionKey?: LocalPath;
   };
 }
@@ -30,6 +31,7 @@ export default class FileTree extends Component<Signature> {
         @openDirs={{@openDirs}}
         @onFileSelected={{@onFileSelected}}
         @onDirectorySelected={{@onDirectorySelected}}
+        @onDeleteFile={{@onDeleteFile}}
         @scrollPositionKey={{@scrollPositionKey}}
       />
       {{#if this.showMask}}

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -38,6 +38,7 @@ import {
   GetCardContextName,
   type ResolvedCodeRef,
   type getCard,
+  type LocalPath,
   CardContextName,
 } from '@cardstack/runtime-common';
 import { isEquivalentBodyPosition } from '@cardstack/runtime-common/schema-analysis-plugin';
@@ -243,6 +244,10 @@ export default class CodeSubmode extends Component<Signature> {
 
   private get realmURL() {
     return this.operatorModeStateService.realmURL;
+  }
+
+  private get canWriteToRealm() {
+    return this.realm.canWrite(this.realmURL);
   }
 
   private get isCard() {
@@ -455,6 +460,11 @@ export default class CodeSubmode extends Component<Signature> {
 
   @action private setItemToDelete(item: CardDef | URL | null | undefined) {
     this.itemToDelete = item;
+  }
+
+  @action private deleteFileInTree(entryPath: LocalPath) {
+    let url = new URL(entryPath, this.realmURL);
+    this.setItemToDelete(url);
   }
 
   @action private onCancelDelete() {
@@ -749,6 +759,10 @@ export default class CodeSubmode extends Component<Signature> {
                           @openDirs={{this.operatorModeStateService.currentRealmOpenDirs}}
                           @onFileSelected={{this.operatorModeStateService.onFileSelected}}
                           @onDirectorySelected={{this.operatorModeStateService.toggleOpenDir}}
+                          @onDeleteFile={{if
+                            this.canWriteToRealm
+                            this.deleteFileInTree
+                          }}
                           @scrollPositionKey={{this.operatorModeStateService.codePathString}}
                         />
                       </:browser>

--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -30,9 +30,11 @@ import {
   setupUserSubscription,
   withCachedRealmSetup,
 } from '../../helpers';
-import type { TestRealmAdapter } from '../../helpers/adapter';
+
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupApplicationTest } from '../../helpers/setup';
+
+import type { TestRealmAdapter } from '../../helpers/adapter';
 
 const indexCardSource = `
   import { CardDef, Component } from "https://cardstack.com/base/card-api";
@@ -1198,8 +1200,9 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
       .exists('friend.gts is still in the file tree after cancel');
 
     let fileContent = await adapter.openFile('friend.gts');
-    assert.ok(
-      fileContent !== undefined,
+    assert.notStrictEqual(
+      fileContent,
+      undefined,
       'friend.gts still exists in the realm',
     );
   });
@@ -1237,5 +1240,4 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
       .dom(`[data-test-delete-modal="${testRealmURL}friend.gts"]`)
       .exists('Delete confirmation modal appears');
   });
-
 });

--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -30,6 +30,7 @@ import {
   setupUserSubscription,
   withCachedRealmSetup,
 } from '../../helpers';
+import type { TestRealmAdapter } from '../../helpers/adapter';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupApplicationTest } from '../../helpers/setup';
 
@@ -200,6 +201,8 @@ const realmInfo = {
 };
 
 module('Acceptance | code submode | file-tree tests', function (hooks) {
+  let adapter: TestRealmAdapter;
+
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
   setupRealmCacheTeardown(hooks);
@@ -229,8 +232,8 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
 
     // this seeds the loader used during index which obtains url mappings
     // from the global loader
-    await withCachedRealmSetup(async () => {
-      await setupAcceptanceTestRealm({
+    ({ adapter } = await withCachedRealmSetup(async () => {
+      return setupAcceptanceTestRealm({
         mockMatrixUtils,
         contents: {
           ...SYSTEM_CARD_FIXTURE_CONTENTS,
@@ -293,7 +296,7 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
           '.realm.json': realmInfo,
         },
       });
-    });
+    }));
   });
 
   test('can navigate file tree, file view mode is persisted in query parameter', async function (assert) {
@@ -398,6 +401,27 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
 
       await waitFor('[data-test-realm-name]');
       assert.dom('[data-test-realm-read-only]').exists();
+    });
+
+    test('file tree does not show context menu in read-only realm', async function (assert) {
+      await visitOperatorMode({
+        stacks: [
+          [
+            {
+              id: `${testRealmURL}Person/1`,
+              format: 'isolated',
+            },
+          ],
+        ],
+        submode: 'code',
+        fileView: 'browser',
+        codePath: `${testRealmURL}friend.gts`,
+      });
+
+      await waitFor('[data-test-file="friend.gts"]');
+      assert
+        .dom('[data-test-file-row="friend.gts"] .file-menu-trigger')
+        .doesNotExist('no context menu trigger shown in read-only realm');
     });
   });
 
@@ -1074,4 +1098,144 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
       .dom(`[data-test-file="${newDirName}/${newFileName}"]`)
       .hasText(newFileName, 'New file is created with the correct name');
   });
+
+  test('can delete a file from file tree context menu', async function (assert) {
+    let recentFilesService = getService('recent-files-service');
+
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}Person/1`,
+            format: 'isolated',
+          },
+        ],
+      ],
+      submode: 'code',
+      fileView: 'browser',
+      codePath: `${testRealmURL}friend.gts`,
+    });
+
+    await waitFor('[data-test-file="friend.gts"]');
+    assert.dom('[data-test-file="friend.gts"]').exists('friend.gts is in tree');
+    assert.dom('[data-test-delete-modal-container]').doesNotExist();
+
+    // Open the "..." context menu for friend.gts
+    // triggerEvent bypasses visibility check (button is hidden until hover)
+    await triggerEvent(
+      '[data-test-file-row="friend.gts"] .file-menu-trigger',
+      'click',
+    );
+
+    await waitFor('[data-test-boxel-menu-item-text="Delete"]');
+    assert
+      .dom('[data-test-boxel-menu-item-text="Delete"]')
+      .exists('Delete menu item is present');
+
+    await click('[data-test-boxel-menu-item-text="Delete"]');
+
+    await waitFor(`[data-test-delete-modal="${testRealmURL}friend.gts"]`);
+    assert
+      .dom(`[data-test-delete-modal="${testRealmURL}friend.gts"]`)
+      .exists('Delete confirmation modal appears');
+
+    await click('[data-test-confirm-delete-button]');
+
+    await waitUntil(
+      () => !document.querySelector('[data-test-file="friend.gts"]'),
+    );
+    assert
+      .dom('[data-test-file="friend.gts"]')
+      .doesNotExist('friend.gts is removed from file tree');
+    assert
+      .dom('[data-test-delete-modal-container]')
+      .doesNotExist('Delete modal is dismissed');
+
+    let notFound = await adapter.openFile('friend.gts');
+    assert.strictEqual(notFound, undefined, 'friend.gts file is deleted');
+
+    assert.notOk(
+      recentFilesService.recentFiles.some(
+        (f) => `${f.realmURL}${f.filePath}` === `${testRealmURL}friend.gts`,
+      ),
+      'deleted file is removed from recent files',
+    );
+  });
+
+  test('can cancel delete from file tree context menu', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}Person/1`,
+            format: 'isolated',
+          },
+        ],
+      ],
+      submode: 'code',
+      fileView: 'browser',
+      codePath: `${testRealmURL}friend.gts`,
+    });
+
+    await waitFor('[data-test-file="friend.gts"]');
+
+    await triggerEvent(
+      '[data-test-file-row="friend.gts"] .file-menu-trigger',
+      'click',
+    );
+
+    await waitFor('[data-test-boxel-menu-item-text="Delete"]');
+    await click('[data-test-boxel-menu-item-text="Delete"]');
+
+    await waitFor(`[data-test-delete-modal="${testRealmURL}friend.gts"]`);
+    await click('[data-test-confirm-cancel-button]');
+
+    assert
+      .dom('[data-test-delete-modal-container]')
+      .doesNotExist('Delete modal is dismissed');
+    assert
+      .dom('[data-test-file="friend.gts"]')
+      .exists('friend.gts is still in the file tree after cancel');
+
+    let fileContent = await adapter.openFile('friend.gts');
+    assert.ok(
+      fileContent !== undefined,
+      'friend.gts still exists in the realm',
+    );
+  });
+
+  test('can delete a file via right-click in file tree', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}Person/1`,
+            format: 'isolated',
+          },
+        ],
+      ],
+      submode: 'code',
+      fileView: 'browser',
+      codePath: `${testRealmURL}friend.gts`,
+    });
+
+    await waitFor('[data-test-file="friend.gts"]');
+    assert.dom('[data-test-delete-modal-container]').doesNotExist();
+
+    // Right-click on the file row opens the context menu
+    await triggerEvent('[data-test-file-row="friend.gts"]', 'contextmenu');
+
+    await waitFor('[data-test-boxel-menu-item-text="Delete"]');
+    assert
+      .dom('[data-test-boxel-menu-item-text="Delete"]')
+      .exists('Delete menu item appears on right-click');
+
+    await click('[data-test-boxel-menu-item-text="Delete"]');
+
+    await waitFor(`[data-test-delete-modal="${testRealmURL}friend.gts"]`);
+    assert
+      .dom(`[data-test-delete-modal="${testRealmURL}friend.gts"]`)
+      .exists('Delete confirmation modal appears');
+  });
+
 });


### PR DESCRIPTION
## Summary

- Adds a "..." context menu to each file row in the code submode file tree (CS-10078)
- Menu is triggered by hovering/clicking the three-dot `ContextButton` or right-clicking the file row
- First menu item is **Delete**, which opens the existing delete confirmation modal
- Context menu is only shown when the user has write access to the realm (read-only realms are unaffected)

## Changes

- **`directory.gts`**: Wraps each file in a `.file-row` div; adds `BoxelDropdown` with hidden `ContextButton` trigger and "Delete" `Menu` item; right-click (`contextmenu`) programmatically opens the dropdown via a `Map<LocalPath, BoxelDropdownAPI>`
- **`file-tree.gts`**: Threads new `onDeleteFile` prop through to `Directory`
- **`code-submode.gts`**: Adds `canWriteToRealm` getter and `deleteFileInTree` action; conditionally passes `@onDeleteFile` to `FileTree`
- **`file-tree-test.ts`**: 4 new acceptance tests

## Test plan

- [x] `can delete a file from file tree context menu` — full delete flow via "..." button
- [x] `can cancel delete from file tree context menu` — cancel flow preserves file
- [x] `can delete a file via right-click in file tree` — contextmenu event triggers dropdown
- [x] `file tree does not show context menu in read-only realm` — no trigger shown for read-only realms
- [x] All 22 file-tree tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2784" height="1800" alt="image" src="https://github.com/user-attachments/assets/c5484fb4-51e3-4f65-9f70-484c8452479b" />
