### PR TITLE
Update card-picker search result summary display

### DIFF
--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -321,29 +321,9 @@ export default class SearchContent extends Component<Signature> {
       return this.resolvedCard ? '1 result from 1 realm' : '0 results';
     }
 
-    // Recents view (empty search or focused on recents)
-    if (this.focusedSection === 'recents' || this.isSearchKeyEmpty) {
-      const count = this.recentCardsSection?.totalCount ?? 0;
-      return `${count} in ${pluralize('Recent', count)}`;
-    }
-
     // Query search results
     const total = this.searchPrerenderedCards.meta.page?.total ?? 0;
     const realms = this.realms;
-
-    // Focused on a specific realm section
-    if (this.focusedSection?.startsWith('realm:')) {
-      const realmUrl = this.focusedSection.slice('realm:'.length);
-      const realmInfo = this.realm.info(realmUrl);
-      const realmName = realmInfo?.name ?? this.realmNameFromUrl(realmUrl);
-      const realmTotal = this.resultCountByRealm[realmUrl];
-
-      if (typeof realmTotal === 'number') {
-        return `${pluralize('result', total, true)} across ${pluralize('realm', realms.length, true)}, ${pluralize('result', realmTotal, true)} in ${realmName}`;
-      }
-
-      return `${pluralize('result', total, true)} in ${realmName}`;
-    }
 
     // Default: all results across all realms
     return `${pluralize('result', total, true)} across ${pluralize('realm', realms.length, true)}`;
@@ -565,17 +545,6 @@ export default class SearchContent extends Component<Signature> {
     }
 
     return sections;
-  }
-
-  private get resultCountByRealm(): Record<string, number> {
-    const sections = this.cardsByQuerySection ?? [];
-    const counts: Record<string, number> = {};
-    for (const section of sections) {
-      if (section.type === 'realm') {
-        counts[section.realmUrl] = section.totalCount;
-      }
-    }
-    return counts;
   }
 
   private get sections(): SearchSheetSection[] {

--- a/packages/host/app/components/card-search/search-result-section.gts
+++ b/packages/host/app/components/card-search/search-result-section.gts
@@ -76,11 +76,6 @@ export default class SearchResultSection extends Component<Signature> {
     return undefined;
   }
 
-  get recentsTitle(): string {
-    const count = this.recentsSection?.totalCount ?? 0;
-    return pluralize('Recent', count);
-  }
-
   @action
   handleShowOnlyChange(checked: boolean) {
     const sid = this.args.section.sid;
@@ -298,9 +293,9 @@ export default class SearchResultSection extends Component<Signature> {
         {{#unless @isCompact}}
           <SearchSheetSectionHeader
             @icon={{this.recentsIcon}}
-            @title={{this.recentsTitle}}
+            @title='Recents'
             @totalCount={{this.recentsSection.totalCount}}
-            @showOnlyLabel={{this.recentsTitle}}
+            @showOnlyLabel='Recents'
             @showOnlyChecked={{@isFocused}}
             @onShowOnlyChange={{this.handleShowOnlyChange}}
           />

--- a/packages/host/app/components/card-search/search-result-section.gts
+++ b/packages/host/app/components/card-search/search-result-section.gts
@@ -294,7 +294,7 @@ export default class SearchResultSection extends Component<Signature> {
           <SearchSheetSectionHeader
             @icon={{this.recentsIcon}}
             @title='Recents'
-            @totalCount={{this.recentsSection.totalCount}}
+            @hideCount={{true}}
             @showOnlyLabel='Recents'
             @showOnlyChecked={{@isFocused}}
             @onShowOnlyChange={{this.handleShowOnlyChange}}

--- a/packages/host/app/components/card-search/section-header.gts
+++ b/packages/host/app/components/card-search/section-header.gts
@@ -11,10 +11,11 @@ import type { ComponentLike } from '@glint/template';
 interface Signature {
   Element: HTMLElement;
   Args: {
+    hideCount?: boolean;
     icon?: ComponentLike<{ Element: Element }>;
     realmInfo?: RealmSectionInfo;
     title: string;
-    totalCount: number;
+    totalCount?: number;
     showOnlyLabel?: string;
     showOnlyChecked?: boolean;
     onShowOnlyChange?: (checked: boolean) => void;
@@ -44,18 +45,20 @@ export default class SearchSheetSectionHeader extends Component<Signature> {
         {{/if}}
       </div>
       <div class='title'>{{@title}}</div>
-      <div
-        class='count'
-        data-test-search-sheet-section-count
-        data-test-results-count
-      >
-        {{#if (eq @totalCount 0)}}
-          No results
-        {{else}}
-          {{@totalCount}}
-          {{if (eq @totalCount 1) 'result' 'results'}}
-        {{/if}}
-      </div>
+      {{#unless @hideCount}}
+        <div
+          class='count'
+          data-test-search-sheet-section-count
+          data-test-results-count
+        >
+          {{#if (eq @totalCount 0)}}
+            No results
+          {{else}}
+            {{@totalCount}}
+            {{if (eq @totalCount 1) 'result' 'results'}}
+          {{/if}}
+        </div>
+      {{/unless}}
       {{#if @showOnlyLabel}}
         <label class='show-only'>
           <input

--- a/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
@@ -355,6 +355,9 @@ module('Integration | operator-mode | card catalog', function (hooks) {
       await settled();
 
       assert
+        .dom('[data-test-search-label]')
+        .hasText('5 results across 3 realms'); // 5 in test realm
+      assert
         .dom(`[data-test-recent-card-result="${testRealmURL}Pet/mango"]`)
         .exists('Pet recent card appears in the linksTo picker');
       assert
@@ -368,6 +371,9 @@ module('Integration | operator-mode | card catalog', function (hooks) {
       await waitFor('[data-test-card-catalog-modal]');
       await settled();
 
+      assert
+        .dom('[data-test-search-label]')
+        .hasText('5 results across 3 realms'); // 5 in test realm
       assert
         .dom(`[data-test-recent-card-result="${testRealmURL}Pet/mango"]`)
         .exists('Pet recent card appears in the linksTo picker');


### PR DESCRIPTION
This PR gets rid of the customization around the result summary that was specified in the designs because it didn't work well in practice, as we've seen during the demo and created confusion. Results will be always be displayed in the form "[X] results across [Y] realms". The count from the Recents section does not affect the total result count.

<img width="646" height="784" alt="results-1" src="https://github.com/user-attachments/assets/0c41bff2-17fd-478b-b0fc-e105bcd78aa2" />

<img width="639" height="706" alt="results-2" src="https://github.com/user-attachments/assets/70256a79-dc82-455f-b218-6d577f99ff6c" />



