### PR TITLE
replace deprecated multi-select component

### DIFF
--- a/packages/boxel-ui/addon/src/components/multi-select/index.gts
+++ b/packages/boxel-ui/addon/src/components/multi-select/index.gts
@@ -7,7 +7,7 @@ import type {
   Select,
 } from 'ember-power-select/components/power-select';
 import BeforeOptions from 'ember-power-select/components/power-select/before-options';
-import PowerSelectMultiple from 'ember-power-select/components/power-select-multiple';
+import PowerSelect from 'ember-power-select/components/power-select';
 
 import { cn } from '../../helpers.ts';
 import { BoxelAfterOptionsComponent } from './after-options.gts';
@@ -60,8 +60,9 @@ export interface Signature<ItemT> {
 
 export class BoxelMultiSelectBasic<ItemT> extends Component<Signature<ItemT>> {
   <template>
-    <PowerSelectMultiple
+    <PowerSelect
       class='boxel-multi-select'
+      @multiple={{true}}
       {{! required args }}
       @options={{@options}}
       @selected={{@selected}}
@@ -97,7 +98,7 @@ export class BoxelMultiSelectBasic<ItemT> extends Component<Signature<ItemT>> {
       as |option|
     >
       {{yield option}}
-    </PowerSelectMultiple>
+    </PowerSelect>
     {{! template-lint-disable require-scoped-style }}
     <style>
       .boxel-multi-select__dropdown {

--- a/packages/boxel-ui/addon/src/components/multi-select/index.gts
+++ b/packages/boxel-ui/addon/src/components/multi-select/index.gts
@@ -6,8 +6,8 @@ import type {
   PowerSelectArgs,
   Select,
 } from 'ember-power-select/components/power-select';
-import BeforeOptions from 'ember-power-select/components/power-select/before-options';
 import PowerSelect from 'ember-power-select/components/power-select';
+import BeforeOptions from 'ember-power-select/components/power-select/before-options';
 
 import { cn } from '../../helpers.ts';
 import { BoxelAfterOptionsComponent } from './after-options.gts';

--- a/packages/boxel-ui/addon/src/components/multi-select/usage.gts
+++ b/packages/boxel-ui/addon/src/components/multi-select/usage.gts
@@ -226,7 +226,7 @@ export default class BoxelMultiSelectUsage extends Component {
           <p>
             Boxel Multi Select is a component that enables the selection of
             multiple items from a customizable dropdown list. It is a wrapper
-            around the PowerSelectMultiple component from the ember-power-select
+            around the PowerSelect component from the ember-power-select
             library, offering off-the-shelf functionality and design.
           </p>
           <p>Key features include:</p>


### PR DESCRIPTION
Addresses this deprecation warning:

<img width="486" height="372" alt="warning" src="https://github.com/user-attachments/assets/3e54cae9-fb50-4b64-9592-7ba23394cd30" />
