### PR TITLE
ci: Fix icons in host previews

### DIFF
--- a/.github/workflows/preview-host.yml
+++ b/.github/workflows/preview-host.yml
@@ -7,6 +7,7 @@ on:
       - "packages/boxel-ui/**"
       - "packages/boxel-icons/**"
       - ".github/workflows/pr-boxel-host.yml"
+      - ".github/workflows/preview-host.yml"
       - "package.json"
       - "pnpm-lock.yaml"
 

--- a/.github/workflows/preview-host.yml
+++ b/.github/workflows/preview-host.yml
@@ -68,6 +68,7 @@ jobs:
           AWS_CLOUDFRONT_DISTRIBUTION: EU4RGLH4EOCHJ
           PUBLISHED_REALM_BOXEL_SPACE_DOMAIN: staging.boxel.dev
           PUBLISHED_REALM_BOXEL_SITE_DOMAIN: staging.boxel.build
+          ICONS_URL: https://boxel-icons.boxel.ai
         # If you change these, change the equivalent line in preview-comment.yml
         with:
           package: boxel-host
@@ -103,6 +104,7 @@ jobs:
           AWS_CLOUDFRONT_DISTRIBUTION: E2PZR9CIAW093B
           PUBLISHED_REALM_BOXEL_SPACE_DOMAIN: boxel.space
           PUBLISHED_REALM_BOXEL_SITE_DOMAIN: boxel.site
+          ICONS_URL: https://boxel-icons.boxel.ai
         # If you change these, change the equivalent line in preview-comment.yml
         with:
           package: boxel-host

--- a/.github/workflows/preview-host.yml
+++ b/.github/workflows/preview-host.yml
@@ -35,6 +35,7 @@ jobs:
             .github/workflows/build-host.yml
             .github/workflows/deploy-host.yml
             .github/workflows/pr-boxel-host.yml
+            .github/workflows/preview-host.yml
             packages/host/**
             packages/boxel-ui/**
             packages/boxel-icons/**


### PR DESCRIPTION
Preview deployments have been trying to reference a localhost icons server:

<img width="1707" height="942" alt="image" src="https://github.com/user-attachments/assets/4532a0d9-267d-4555-b39a-0e7fafe1518d" />

I also updated the workflow to trigger deployments when the workflow itself changes.

Icons load as expected in the preview:

<img width="3638" height="2104" alt="e8c0a21ef0e0f5101a0d9e590435203ca7bf96af 2026-02-26 16-29-01" src="https://github.com/user-attachments/assets/5fae2122-ec03-4525-b560-f9a175e8e03f" />

