### PR TITLE
Refactor prerender in order to capture links in non-isolated format

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2448,7 +2448,7 @@ export class CardInfoField extends FieldDef {
   @field name = contains(StringField);
   @field summary = contains(StringField);
   @field cardThumbnailURL = contains(MaybeBase64Field);
-  @field theme = linksTo(() => Theme, { isUsed: true });
+  @field theme = linksTo(() => Theme);
   @field notes = contains(MarkdownField);
 }
 

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -150,6 +150,8 @@ export default class RenderRoute extends Route<Model> {
       (globalThis as any).__boxelRenderContext = undefined;
     }
     (globalThis as any).__renderModel = undefined;
+    (globalThis as any).__docsInFlight = undefined;
+    (globalThis as any).__waitForRenderLoadStability = undefined;
     window.removeEventListener('boxel-render-error', this.handleRenderError);
     this.#detachWindowErrorListeners();
     this.lastStoreResetKey = undefined;
@@ -202,6 +204,19 @@ export default class RenderRoute extends Route<Model> {
     (globalThis as any).__docsInFlight = () =>
       this.store.cardDocsInFlight.length +
       this.store.fileMetaDocsInFlight.length;
+    (globalThis as any).__waitForRenderLoadStability = async () => {
+      try {
+        await this.#authGuard.race(() =>
+          this.#waitForRenderLoadStability(this.#normalizeCardId(id)),
+        );
+      } catch (error) {
+        if (this.#authGuard.isAuthError(error)) {
+          this.#processRenderError(error);
+          return;
+        }
+        throw error;
+      }
+    };
     let key = `${id}|${nonce}|${canonicalOptions}`;
     let existing = this.#modelPromises.get(key);
     if (existing) {

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -483,11 +483,6 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
                 self: null,
               },
             },
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           'relationships data is correct',
         );

--- a/packages/host/tests/acceptance/prerender-meta-test.gts
+++ b/packages/host/tests/acceptance/prerender-meta-test.gts
@@ -281,11 +281,6 @@ module('Acceptance | prerender | meta', function (hooks) {
                 self: '../Pet/paper',
               },
             },
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -351,9 +346,7 @@ module('Acceptance | prerender | meta', function (hooks) {
       {
         id: `${testRealmURL}Pet/mango`,
         _cardType: 'Pet',
-        cardInfo: {
-          theme: null,
-        },
+        cardInfo: {},
         name: 'Mango',
         cardTitle: 'Mango',
       },
@@ -371,9 +364,7 @@ module('Acceptance | prerender | meta', function (hooks) {
       {
         id: `${testRealmURL}Pet/paper`,
         _cardType: 'Cat',
-        cardInfo: {
-          theme: null,
-        },
+        cardInfo: {},
         name: 'Paper',
         cardTitle: 'Paper',
         aliases: ['Satan', "Satan's Mistress"],

--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -690,13 +690,6 @@ module('Integration | serialization', function (hooks) {
           firstName: 'Mango',
           cardInfo,
         },
-        relationships: {
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
-        },
         meta: {
           adoptsFrom: {
             module: `../test-cards`,
@@ -1101,11 +1094,6 @@ module('Integration | serialization', function (hooks) {
               type: 'card',
             },
           },
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -1121,13 +1109,6 @@ module('Integration | serialization', function (hooks) {
           attributes: {
             cardDescription: 'Toilet paper ghost: Poooo!',
             cardInfo,
-          },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -1151,11 +1132,6 @@ module('Integration | serialization', function (hooks) {
               data: {
                 id: `${testRealmURL}Toy/spookyToiletPaper`,
                 type: 'card',
-              },
-            },
-            'cardInfo.theme': {
-              links: {
-                self: null,
               },
             },
           },
@@ -1248,11 +1224,6 @@ module('Integration | serialization', function (hooks) {
               type: 'card',
             },
           },
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -1268,13 +1239,6 @@ module('Integration | serialization', function (hooks) {
           attributes: {
             cardDescription: 'Toilet paper ghost: Poooo!',
             cardInfo,
-          },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -1295,11 +1259,6 @@ module('Integration | serialization', function (hooks) {
               data: {
                 lid: spookyToiletPaper[localId],
                 type: 'card',
-              },
-            },
-            'cardInfo.theme': {
-              links: {
-                self: null,
               },
             },
           },
@@ -1349,11 +1308,6 @@ module('Integration | serialization', function (hooks) {
               type: 'card',
             },
           },
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -1369,13 +1323,6 @@ module('Integration | serialization', function (hooks) {
           attributes: {
             cardDescription: 'Toilet paper ghost: Poooo!',
             cardInfo: {},
-          },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -1399,11 +1346,6 @@ module('Integration | serialization', function (hooks) {
               data: {
                 id: `${testRealmURL}Toy/spookyToiletPaper`,
                 type: 'card',
-              },
-            },
-            'cardInfo.theme': {
-              links: {
-                self: null,
               },
             },
           },
@@ -1569,11 +1511,6 @@ module('Integration | serialization', function (hooks) {
               id: `${testRealmURL}Pet/mango`,
             },
           },
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -1634,11 +1571,6 @@ module('Integration | serialization', function (hooks) {
               self: null,
             },
           },
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -1661,11 +1593,6 @@ module('Integration | serialization', function (hooks) {
         },
         relationships: {
           pet: {
-            links: {
-              self: null,
-            },
-          },
-          'cardInfo.theme': {
             links: {
               self: null,
             },
@@ -1888,11 +1815,6 @@ module('Integration | serialization', function (hooks) {
               type: 'card',
             },
           },
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -1911,11 +1833,6 @@ module('Integration | serialization', function (hooks) {
           },
           relationships: {
             friend: {
-              links: {
-                self: null,
-              },
-            },
-            'cardInfo.theme': {
               links: {
                 self: null,
               },
@@ -1961,11 +1878,6 @@ module('Integration | serialization', function (hooks) {
             data: {
               lid: mango[localId],
               type: 'card',
-            },
-          },
-          'cardInfo.theme': {
-            links: {
-              self: null,
             },
           },
         },
@@ -2140,11 +2052,6 @@ module('Integration | serialization', function (hooks) {
               id: `${testRealmURL}Toy/spookyToiletPaper`,
             },
           },
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -2160,13 +2067,6 @@ module('Integration | serialization', function (hooks) {
           attributes: {
             cardDescription: 'Toilet paper ghost: Poooo!',
             cardInfo,
-          },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -2284,11 +2184,6 @@ module('Integration | serialization', function (hooks) {
               id: `${testRealmURL}Toy/spookyToiletPaper`,
             },
           },
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -2304,13 +2199,6 @@ module('Integration | serialization', function (hooks) {
           attributes: {
             cardDescription: 'Toilet paper ghost: Poooo!',
             cardInfo,
-          },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -2438,11 +2326,6 @@ module('Integration | serialization', function (hooks) {
               id: `${testRealmURL}Toy/spookyToiletPaper`,
             },
           },
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -2458,13 +2341,6 @@ module('Integration | serialization', function (hooks) {
           attributes: {
             cardDescription: 'Toilet paper ghost: Poooo!',
             cardInfo,
-          },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -3189,7 +3065,11 @@ module('Integration | serialization', function (hooks) {
             cardInfo,
           },
           relationships: {
-            'cardInfo.theme': { links: { self: null } },
+            'cardInfo.theme': {
+              links: {
+                self: null,
+              },
+            },
           },
           meta: {
             adoptsFrom: {
@@ -3375,11 +3255,6 @@ module('Integration | serialization', function (hooks) {
             links: { self: `${testRealmURL}Pet/mango` },
             data: { id: `${testRealmURL}Pet/mango`, type: 'card' },
           },
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Person' },
@@ -3396,13 +3271,6 @@ module('Integration | serialization', function (hooks) {
             cardDescription: 'Pet',
             cardThumbnailURL: '../pet.svg',
             cardInfo,
-          },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Pet' },
@@ -3425,11 +3293,6 @@ module('Integration | serialization', function (hooks) {
             },
             friend: { links: { self: null } },
             friendPet: { links: { self: null } },
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Person' },
@@ -3584,11 +3447,6 @@ module('Integration | serialization', function (hooks) {
             pet: { links: { self: null } },
             friend: { links: { self: null } },
             friendPet: { links: { self: null } },
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Person' },
@@ -3912,13 +3770,6 @@ module('Integration | serialization', function (hooks) {
             cardThumbnailURL: './intro.png',
             cardInfo,
           },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
-          },
           meta: {
             adoptsFrom: {
               module: `${testRealmURL}test-cards`,
@@ -3992,13 +3843,6 @@ module('Integration | serialization', function (hooks) {
           },
           cardInfo,
         },
-        relationships: {
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
-        },
         meta: {
           adoptsFrom: {
             module: `${testRealmURL}test-cards`,
@@ -4069,13 +3913,6 @@ module('Integration | serialization', function (hooks) {
             department: 'wagging',
           },
           cardInfo,
-        },
-        relationships: {
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -4184,13 +4021,6 @@ module('Integration | serialization', function (hooks) {
             },
           },
           cardInfo,
-        },
-        relationships: {
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -4314,13 +4144,6 @@ module('Integration | serialization', function (hooks) {
             },
           ],
           cardInfo,
-        },
-        relationships: {
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -4607,13 +4430,6 @@ module('Integration | serialization', function (hooks) {
           },
           cardInfo,
         },
-        relationships: {
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
-        },
         meta: {
           adoptsFrom: {
             module: `${testRealmURL}test-cards`,
@@ -4780,13 +4596,6 @@ module('Integration | serialization', function (hooks) {
             },
           ],
           cardInfo,
-        },
-        relationships: {
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -5002,11 +4811,6 @@ module('Integration | serialization', function (hooks) {
               type: 'card',
             },
           },
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -5023,13 +4827,6 @@ module('Integration | serialization', function (hooks) {
             name: '808 Analog Kit',
             cardInfo: {},
           },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
-          },
           meta: {
             adoptsFrom: {
               module: `${testRealmURL}test-cards`,
@@ -5043,13 +4840,6 @@ module('Integration | serialization', function (hooks) {
           attributes: {
             cardTitle: 'Beat Maker Studio',
             cardInfo: {},
-          },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -5131,11 +4921,6 @@ module('Integration | serialization', function (hooks) {
               },
             },
           ],
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -5152,13 +4937,6 @@ module('Integration | serialization', function (hooks) {
             name: '808 Analog Kit',
             cardInfo: {},
           },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
-          },
           meta: {
             adoptsFrom: {
               module: `${testRealmURL}test-cards`,
@@ -5172,13 +4950,6 @@ module('Integration | serialization', function (hooks) {
           attributes: {
             cardTitle: 'Beat Maker Studio',
             cardInfo: {},
-          },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -5259,13 +5030,6 @@ module('Integration | serialization', function (hooks) {
           attributes: {
             firstName: 'Mango',
             cardInfo,
-          },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -5349,13 +5113,6 @@ module('Integration | serialization', function (hooks) {
               firstName: 'Mango',
             },
             cardInfo,
-          },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -5475,13 +5232,6 @@ module('Integration | serialization', function (hooks) {
             ],
             cardInfo,
           },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
-          },
           meta: {
             adoptsFrom: {
               module: `./blog`,
@@ -5594,11 +5344,6 @@ module('Integration | serialization', function (hooks) {
               type: 'card',
             },
           },
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -5617,13 +5362,6 @@ module('Integration | serialization', function (hooks) {
             cardThumbnailURL: null,
             cardInfo: {},
           },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
-          },
           meta: {
             adoptsFrom: {
               module: `${testRealmURL}test-cards`,
@@ -5640,13 +5378,6 @@ module('Integration | serialization', function (hooks) {
             cardThumbnailURL: null,
             cardInfo: {},
           },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
-          },
           meta: {
             adoptsFrom: {
               module: `${testRealmURL}test-cards`,
@@ -5662,13 +5393,6 @@ module('Integration | serialization', function (hooks) {
             earnedOn: '2023-10-01',
             cardThumbnailURL: null,
             cardInfo: {},
-          },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -5752,11 +5476,6 @@ module('Integration | serialization', function (hooks) {
                 self: `${testRealmURL}Certificate/2`,
               },
             },
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -5779,13 +5498,6 @@ module('Integration | serialization', function (hooks) {
                 name: 'Certificate',
               },
             },
-            relationships: {
-              'cardInfo.theme': {
-                links: {
-                  self: null,
-                },
-              },
-            },
             type: 'card',
           },
           {
@@ -5801,13 +5513,6 @@ module('Integration | serialization', function (hooks) {
                 name: 'Certificate',
               },
             },
-            relationships: {
-              'cardInfo.theme': {
-                links: {
-                  self: null,
-                },
-              },
-            },
             type: 'card',
           },
           {
@@ -5821,13 +5526,6 @@ module('Integration | serialization', function (hooks) {
               adoptsFrom: {
                 module: `${testRealmURL}test-cards`,
                 name: 'Certificate',
-              },
-            },
-            relationships: {
-              'cardInfo.theme': {
-                links: {
-                  self: null,
-                },
               },
             },
             type: 'card',
@@ -5879,7 +5577,11 @@ module('Integration | serialization', function (hooks) {
           cardInfo,
         },
         relationships: {
-          'cardInfo.theme': { links: { self: null } },
+          'cardInfo.theme': {
+            links: {
+              self: null,
+            },
+          },
         },
         meta: {
           adoptsFrom: {
@@ -5907,7 +5609,11 @@ module('Integration | serialization', function (hooks) {
           cardInfo,
         },
         relationships: {
-          'cardInfo.theme': { links: { self: null } },
+          'cardInfo.theme': {
+            links: {
+              self: null,
+            },
+          },
         },
         meta: {
           adoptsFrom: {
@@ -5949,13 +5655,6 @@ module('Integration | serialization', function (hooks) {
           firstName: 'Mango',
           unRenderedField: null,
           cardInfo,
-        },
-        relationships: {
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -6001,13 +5700,6 @@ module('Integration | serialization', function (hooks) {
           attributes: {
             name: 'Mango',
             cardInfo,
-          },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -6061,13 +5753,6 @@ module('Integration | serialization', function (hooks) {
           attributes: {
             name: 'Mango',
             cardInfo,
-          },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -6192,11 +5877,6 @@ module('Integration | serialization', function (hooks) {
               },
               data: { id: `${testRealmURL}Pet/vanGogh`, type: 'card' },
             },
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Person' },
@@ -6210,13 +5890,6 @@ module('Integration | serialization', function (hooks) {
               firstName: 'Mango',
               cardInfo,
             },
-            relationships: {
-              'cardInfo.theme': {
-                links: {
-                  self: null,
-                },
-              },
-            },
             meta: {
               adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Pet' },
             },
@@ -6227,13 +5900,6 @@ module('Integration | serialization', function (hooks) {
             attributes: {
               firstName: 'Van Gogh',
               cardInfo,
-            },
-            relationships: {
-              'cardInfo.theme': {
-                links: {
-                  self: null,
-                },
-              },
             },
             meta: {
               adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Pet' },
@@ -6294,11 +5960,6 @@ module('Integration | serialization', function (hooks) {
             'pets.1': {
               data: { lid: vanGogh[localId], type: 'card' },
             },
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Person' },
@@ -6312,13 +5973,6 @@ module('Integration | serialization', function (hooks) {
               firstName: 'Mango',
               cardInfo,
             },
-            relationships: {
-              'cardInfo.theme': {
-                links: {
-                  self: null,
-                },
-              },
-            },
             meta: {
               adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Pet' },
             },
@@ -6329,13 +5983,6 @@ module('Integration | serialization', function (hooks) {
             attributes: {
               firstName: 'Van Gogh',
               cardInfo,
-            },
-            relationships: {
-              'cardInfo.theme': {
-                links: {
-                  self: null,
-                },
-              },
             },
             meta: {
               adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Pet' },
@@ -6387,11 +6034,6 @@ module('Integration | serialization', function (hooks) {
                 type: 'card',
               },
             },
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Person' },
@@ -6407,13 +6049,6 @@ module('Integration | serialization', function (hooks) {
               cardThumbnailURL: null,
               cardInfo: {},
             },
-            relationships: {
-              'cardInfo.theme': {
-                links: {
-                  self: null,
-                },
-              },
-            },
             meta: {
               adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Pet' },
             },
@@ -6426,13 +6061,6 @@ module('Integration | serialization', function (hooks) {
               firstName: 'Van Gogh',
               cardThumbnailURL: null,
               cardInfo: {},
-            },
-            relationships: {
-              'cardInfo.theme': {
-                links: {
-                  self: null,
-                },
-              },
             },
             meta: {
               adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Pet' },
@@ -6530,11 +6158,6 @@ module('Integration | serialization', function (hooks) {
                 },
               },
             ],
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Person' },
@@ -6550,13 +6173,6 @@ module('Integration | serialization', function (hooks) {
               cardThumbnailURL: null,
               cardInfo: {},
             },
-            relationships: {
-              'cardInfo.theme': {
-                links: {
-                  self: null,
-                },
-              },
-            },
             meta: {
               adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Pet' },
             },
@@ -6569,13 +6185,6 @@ module('Integration | serialization', function (hooks) {
               firstName: 'Van Gogh',
               cardThumbnailURL: null,
               cardInfo: {},
-            },
-            relationships: {
-              'cardInfo.theme': {
-                links: {
-                  self: null,
-                },
-              },
             },
             meta: {
               adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Pet' },
@@ -6701,11 +6310,6 @@ module('Integration | serialization', function (hooks) {
               },
               data: { id: `${testRealmURL}Pet/mango`, type: 'card' },
             },
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Person' },
@@ -6718,13 +6322,6 @@ module('Integration | serialization', function (hooks) {
             attributes: {
               cardDescription: 'Toilet paper ghost: Poooo!',
               cardInfo,
-            },
-            relationships: {
-              'cardInfo.theme': {
-                links: {
-                  self: null,
-                },
-              },
             },
             meta: {
               adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Toy' },
@@ -6745,11 +6342,6 @@ module('Integration | serialization', function (hooks) {
                 data: {
                   id: `${testRealmURL}Toy/spookyToiletPaper`,
                   type: 'card',
-                },
-              },
-              'cardInfo.theme': {
-                links: {
-                  self: null,
                 },
               },
             },
@@ -6841,11 +6433,6 @@ module('Integration | serialization', function (hooks) {
                 self: null,
               },
             },
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Person' },
@@ -6865,11 +6452,6 @@ module('Integration | serialization', function (hooks) {
           },
           relationships: {
             pets: {
-              links: {
-                self: null,
-              },
-            },
-            'cardInfo.theme': {
               links: {
                 self: null,
               },
@@ -6908,11 +6490,6 @@ module('Integration | serialization', function (hooks) {
           },
           relationships: {
             pets: {
-              links: {
-                self: null,
-              },
-            },
-            'cardInfo.theme': {
               links: {
                 self: null,
               },
@@ -6995,11 +6572,6 @@ module('Integration | serialization', function (hooks) {
                 type: 'card',
               },
             },
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -7015,13 +6587,6 @@ module('Integration | serialization', function (hooks) {
             attributes: {
               firstName: 'Mango',
               cardInfo,
-            },
-            relationships: {
-              'cardInfo.theme': {
-                links: {
-                  self: null,
-                },
-              },
             },
             meta: {
               adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Pet' },
@@ -7085,11 +6650,6 @@ module('Integration | serialization', function (hooks) {
               },
               data: { type: 'card', id: `${testRealmURL}Pet/vanGogh` },
             },
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: {
@@ -7105,13 +6665,6 @@ module('Integration | serialization', function (hooks) {
             attributes: {
               firstName: 'Mango',
               cardInfo,
-            },
-            relationships: {
-              'cardInfo.theme': {
-                links: {
-                  self: null,
-                },
-              },
             },
             meta: {
               adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Pet' },
@@ -7171,11 +6724,6 @@ module('Integration | serialization', function (hooks) {
               links: { self: `./vanGogh` },
               data: { id: `${testRealmURL}Person/vanGogh`, type: 'card' },
             },
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: { module: `../test-cards`, name: 'Person' },
@@ -7191,11 +6739,6 @@ module('Integration | serialization', function (hooks) {
             },
             relationships: {
               friends: { links: { self: null } },
-              'cardInfo.theme': {
-                links: {
-                  self: null,
-                },
-              },
             },
             meta: {
               adoptsFrom: { module: `../test-cards`, name: 'Person' },
@@ -7210,11 +6753,6 @@ module('Integration | serialization', function (hooks) {
             },
             relationships: {
               friends: { links: { self: null } },
-              'cardInfo.theme': {
-                links: {
-                  self: null,
-                },
-              },
             },
             meta: {
               adoptsFrom: { module: `../test-cards`, name: 'Person' },
@@ -7388,11 +6926,6 @@ module('Integration | serialization', function (hooks) {
             links: { self: `${testRealmURL}Pet/van-gogh` },
             data: { id: `${testRealmURL}Pet/van-gogh`, type: 'card' },
           },
-          'cardInfo.theme': {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Person' },
@@ -7410,13 +6943,6 @@ module('Integration | serialization', function (hooks) {
             cardThumbnailURL: null,
             cardInfo,
           },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
-          },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Pet' },
           },
@@ -7430,13 +6956,6 @@ module('Integration | serialization', function (hooks) {
             cardDescription: null,
             cardThumbnailURL: null,
             cardInfo,
-          },
-          relationships: {
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Pet' },
@@ -7460,11 +6979,6 @@ module('Integration | serialization', function (hooks) {
             'pets.1': {
               links: { self: `${testRealmURL}Pet/van-gogh` },
               data: { id: `${testRealmURL}Pet/van-gogh`, type: 'card' },
-            },
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
             },
           },
           meta: {
@@ -7632,11 +7146,6 @@ module('Integration | serialization', function (hooks) {
           relationships: {
             friend: { links: { self: null } },
             friendPets: { links: { self: null } },
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Person' },
@@ -7795,11 +7304,6 @@ module('Integration | serialization', function (hooks) {
         includeComputeds: true,
       });
       assert.deepEqual(serialized.data.relationships, {
-        'cardInfo.theme': {
-          links: {
-            self: null,
-          },
-        },
         friend: {
           links: { self: `${testRealmURL}Friend/hassan` },
           data: { type: 'card', id: `${testRealmURL}Friend/hassan` },

--- a/packages/realm-server/prerender/browser-manager.ts
+++ b/packages/realm-server/prerender/browser-manager.ts
@@ -3,10 +3,13 @@ import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import puppeteer, { type Browser } from 'puppeteer';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 
 const log = logger('prerenderer');
 const PUPPETEER_PROFILE_PREFIX = 'puppeteer_dev_chrome_profile-';
 const USER_DATA_MAX_AGE_MS = 60 * 60 * 1000;
+const execFileAsync = promisify(execFile);
 
 export class BrowserManager {
   #browser: Browser | null = null;
@@ -141,7 +144,9 @@ export class BrowserManager {
     try {
       procEntries = await fs.readdir('/proc');
     } catch (_e) {
-      return [];
+      // /proc traversal is Linux-only; use `ps` table parsing on macOS and
+      // other platforms that don't expose procfs.
+      return this.#findOrphanedChromeProcessesViaPs(activeDir);
     }
     let orphaned: Array<{ pid: number; userDataDir: string }> = [];
     let tmpRoot = tmpdir();
@@ -151,7 +156,6 @@ export class BrowserManager {
       if (!Number.isInteger(pid) || pid <= 0) continue;
       let cmdline = await this.#readProcessCmdline(pid);
       if (!cmdline) continue;
-      if (!cmdline.includes('chrome')) continue;
       let userDataDir = this.#extractUserDataDirFromCmdline(cmdline);
       if (!userDataDir) continue;
       if (!path.basename(userDataDir).startsWith(PUPPETEER_PROFILE_PREFIX)) {
@@ -170,6 +174,85 @@ export class BrowserManager {
       }
     }
     return orphaned;
+  }
+
+  async #findOrphanedChromeProcessesViaPs(
+    activeDir?: string,
+  ): Promise<Array<{ pid: number; userDataDir: string }>> {
+    let processTable = await this.#readProcessTableViaPs();
+    if (processTable.length === 0) {
+      return [];
+    }
+
+    let processByPid = new Map<number, { ppid: number; cmdline: string }>();
+    for (let processInfo of processTable) {
+      processByPid.set(processInfo.pid, {
+        ppid: processInfo.ppid,
+        cmdline: processInfo.cmdline,
+      });
+    }
+
+    let orphaned: Array<{ pid: number; userDataDir: string }> = [];
+    let tmpRoot = tmpdir();
+    for (let { pid, ppid, cmdline } of processTable) {
+      if (!cmdline) continue;
+      let userDataDir = this.#extractUserDataDirFromCmdline(cmdline);
+      if (!userDataDir) continue;
+      if (!path.basename(userDataDir).startsWith(PUPPETEER_PROFILE_PREFIX)) {
+        continue;
+      }
+      if (!path.resolve(userDataDir).startsWith(path.resolve(tmpRoot))) {
+        continue;
+      }
+      if (activeDir && path.resolve(userDataDir) === path.resolve(activeDir)) {
+        continue;
+      }
+      if (this.#isOrphanedParentFromProcessTable(ppid, processByPid)) {
+        orphaned.push({ pid, userDataDir });
+      }
+    }
+    return orphaned;
+  }
+
+  async #readProcessTableViaPs(): Promise<
+    Array<{ pid: number; ppid: number; cmdline: string }>
+  > {
+    let stdout: string;
+    try {
+      ({ stdout } = await execFileAsync('ps', ['-axo', 'pid=,ppid=,command=']));
+    } catch (_e) {
+      return [];
+    }
+    let rows = stdout.split('\n');
+    let processTable: Array<{ pid: number; ppid: number; cmdline: string }> =
+      [];
+    for (let row of rows) {
+      let trimmed = row.trim();
+      if (!trimmed) continue;
+      let match = trimmed.match(/^(\d+)\s+(\d+)\s+(.+)$/);
+      if (!match) continue;
+      let pid = Number(match[1]);
+      let ppid = Number(match[2]);
+      let cmdline = match[3];
+      if (!Number.isInteger(pid) || pid <= 0) continue;
+      if (!Number.isInteger(ppid) || ppid < 0) continue;
+      processTable.push({ pid, ppid, cmdline });
+    }
+    return processTable;
+  }
+
+  #isOrphanedParentFromProcessTable(
+    ppid: number,
+    processByPid: Map<number, { ppid: number; cmdline: string }>,
+  ): boolean {
+    if (ppid <= 1) {
+      return true;
+    }
+    let parent = processByPid.get(ppid);
+    if (!parent || !parent.cmdline) {
+      return true;
+    }
+    return parent.cmdline.includes('systemd --user');
   }
 
   async #readProcessCmdline(pid: number): Promise<string | undefined> {

--- a/packages/realm-server/prerender/browser-manager.ts
+++ b/packages/realm-server/prerender/browser-manager.ts
@@ -16,6 +16,7 @@ export class BrowserManager {
     if (this.#browser) {
       return this.#browser;
     }
+    await this.cleanupUserDataDirs();
 
     let launchArgs: string[] = [];
     let disableSandbox =
@@ -63,6 +64,8 @@ export class BrowserManager {
       return;
     }
 
+    await this.#terminateOrphanedChromeProcesses(activeDir);
+
     let tmpRoot: string;
     try {
       tmpRoot = tmpdir();
@@ -101,6 +104,132 @@ export class BrowserManager {
         log.debug('Unable to remove user data dir %s:', dirPath, e);
       }
     }
+  }
+
+  async #terminateOrphanedChromeProcesses(activeDir?: string): Promise<void> {
+    let orphaned = await this.#findOrphanedChromeProcesses(activeDir);
+    if (orphaned.length === 0) {
+      return;
+    }
+    log.warn(
+      'Terminating %s orphaned Chrome process(es) tied to stale Puppeteer profiles',
+      orphaned.length,
+    );
+    for (let { pid } of orphaned) {
+      try {
+        process.kill(pid, 'SIGTERM');
+      } catch (_e) {
+        // best-effort; process may have already exited
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    for (let { pid } of orphaned) {
+      if (this.#isProcessAlive(pid)) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch (_e) {
+          // best-effort; process may have already exited
+        }
+      }
+    }
+  }
+
+  async #findOrphanedChromeProcesses(
+    activeDir?: string,
+  ): Promise<Array<{ pid: number; userDataDir: string }>> {
+    let procEntries: string[];
+    try {
+      procEntries = await fs.readdir('/proc');
+    } catch (_e) {
+      return [];
+    }
+    let orphaned: Array<{ pid: number; userDataDir: string }> = [];
+    let tmpRoot = tmpdir();
+    for (let entry of procEntries) {
+      if (!/^\d+$/.test(entry)) continue;
+      let pid = Number(entry);
+      if (!Number.isInteger(pid) || pid <= 0) continue;
+      let cmdline = await this.#readProcessCmdline(pid);
+      if (!cmdline) continue;
+      if (!cmdline.includes('chrome')) continue;
+      let userDataDir = this.#extractUserDataDirFromCmdline(cmdline);
+      if (!userDataDir) continue;
+      if (!path.basename(userDataDir).startsWith(PUPPETEER_PROFILE_PREFIX)) {
+        continue;
+      }
+      if (!path.resolve(userDataDir).startsWith(path.resolve(tmpRoot))) {
+        continue;
+      }
+      if (activeDir && path.resolve(userDataDir) === path.resolve(activeDir)) {
+        continue;
+      }
+      let ppid = await this.#readParentPid(pid);
+      if (ppid === undefined) continue;
+      if (await this.#isOrphanedParent(ppid)) {
+        orphaned.push({ pid, userDataDir });
+      }
+    }
+    return orphaned;
+  }
+
+  async #readProcessCmdline(pid: number): Promise<string | undefined> {
+    try {
+      let raw = await fs.readFile(`/proc/${pid}/cmdline`, 'utf8');
+      if (!raw) {
+        return undefined;
+      }
+      return raw.split('\0').join(' ').trim();
+    } catch (_e) {
+      return undefined;
+    }
+  }
+
+  async #readParentPid(pid: number): Promise<number | undefined> {
+    try {
+      let status = await fs.readFile(`/proc/${pid}/status`, 'utf8');
+      let match = status.match(/^PPid:\s+(\d+)$/m);
+      if (!match) {
+        return undefined;
+      }
+      return Number(match[1]);
+    } catch (_e) {
+      return undefined;
+    }
+  }
+
+  async #isOrphanedParent(ppid: number): Promise<boolean> {
+    if (ppid <= 1) {
+      return true;
+    }
+    let parentCmdline = await this.#readProcessCmdline(ppid);
+    if (!parentCmdline) {
+      return true;
+    }
+    return parentCmdline.includes('systemd --user');
+  }
+
+  #isProcessAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (_e) {
+      return false;
+    }
+  }
+
+  #extractUserDataDirFromCmdline(cmdline: string): string | undefined {
+    let split = cmdline.split(/\s+/);
+    for (let i = 0; i < split.length; i++) {
+      let arg = split[i];
+      let match = arg.match(/^--user-data-dir=(.*)$/);
+      if (match?.[1]) {
+        return match[1];
+      }
+      if (arg === '--user-data-dir' && split[i + 1]) {
+        return split[i + 1];
+      }
+    }
+    return undefined;
   }
 
   #extractUserDataDir(browser: Browser | null): string | undefined {

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -144,6 +144,7 @@ export class RenderRunner {
         expectedId: url.replace(/\.json$/i, ''),
         expectedNonce: String(this.#nonce),
         simulateTimeoutMs: opts?.simulateTimeoutMs,
+        timeoutMs: opts?.timeoutMs,
       };
       let applyStepError = (stepError: RenderError, evicted: boolean) => {
         error = error ?? stepError;
@@ -443,6 +444,7 @@ export class RenderRunner {
         expectedId: url,
         expectedNonce: String(this.#nonce),
         simulateTimeoutMs: opts?.simulateTimeoutMs,
+        timeoutMs: opts?.timeoutMs,
       };
 
       let capture = await withTimeout(
@@ -598,6 +600,7 @@ export class RenderRunner {
         expectedId: url,
         expectedNonce: String(this.#nonce),
         simulateTimeoutMs: opts?.simulateTimeoutMs,
+        timeoutMs: opts?.timeoutMs,
       };
 
       let capture = await withTimeout(
@@ -765,6 +768,7 @@ export class RenderRunner {
         expectedId: url,
         expectedNonce: String(this.#nonce),
         simulateTimeoutMs: opts?.simulateTimeoutMs,
+        timeoutMs: opts?.timeoutMs,
       };
 
       log.debug(

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -145,12 +145,47 @@ export class RenderRunner {
         expectedNonce: String(this.#nonce),
         simulateTimeoutMs: opts?.simulateTimeoutMs,
       };
+      let applyStepError = (stepError: RenderError, evicted: boolean) => {
+        error = error ?? stepError;
+        markTimeout(stepError);
+        if (evicted) {
+          poolInfo.evicted = true;
+          shortCircuit = true;
+        }
+        if (this.#isAuthError(error)) {
+          shortCircuit = true;
+        }
+      };
+      let handleDirectStepError = async (
+        step: string,
+        stepError: RenderError,
+      ) => {
+        let evicted = await this.#maybeEvict(realm, step, stepError);
+        applyStepError(stepError, evicted);
+      };
+      let runTimedStep = async <T>(
+        step: string,
+        fn: () => Promise<T | RenderError>,
+      ): Promise<T | undefined> => {
+        if (shortCircuit) {
+          return;
+        }
+        let stepResult = await this.#step(realm, step, () =>
+          withTimeout(page, fn, opts?.timeoutMs),
+        );
+        if (stepResult.ok) {
+          return stepResult.value as T;
+        }
+        applyStepError(stepResult.error, stepResult.evicted);
+        return;
+      };
 
       log.debug(
         `manually visit prerendered url ${url} at: ${this.#boxelHostURL}/render/${encodeURIComponent(url)}/${this.#nonce}/${optionsSegment}/html/isolated/0 with localStorage boxel-session=${auth}`,
       );
 
       // We need to render the isolated HTML view first, as the template will pull linked fields.
+      log.debug(`isolated render start url=${url} realm=${realm}`);
       let result = await withTimeout(
         page,
         async () => {
@@ -163,49 +198,24 @@ export class RenderRunner {
             'isolated',
             '0',
           );
-          return await captureResult(page, 'innerHTML', captureOptions);
+          return await renderHTML(page, 'isolated', 0, captureOptions);
         },
         opts?.timeoutMs,
       );
+      log.debug(
+        `isolated render completed url=${url} realm=${realm} isError=${isRenderError(
+          result,
+        )}`,
+      );
       let isolatedHTML: string | null = null;
       if (isRenderError(result)) {
-        error = result;
-        markTimeout(error);
-        let evicted = await this.#maybeEvict(
-          realm,
-          'isolated render',
-          result as RenderError,
-        );
-        if (evicted) {
-          poolInfo.evicted = true;
-          shortCircuit = true;
-        }
-        if (this.#isAuthError(error)) {
-          shortCircuit = true;
-        }
+        // If isolated fails we cannot reliably render downstream formats for
+        // this card; continuing causes long timeout cascades (for example while
+        // indexing broken cards), so short-circuit immediately.
+        shortCircuit = true;
+        await handleDirectStepError('isolated render', result as RenderError);
       } else {
-        let capture = result as RenderCapture;
-        if (capture.status === 'ready') {
-          isolatedHTML = capture.value;
-        } else {
-          let capErr = this.#captureToError(capture);
-          if (!error && capErr) {
-            error = capErr;
-          }
-          markTimeout(capErr);
-          let evicted = await this.#maybeEvict(
-            realm,
-            'isolated render',
-            capErr,
-          );
-          if (evicted) {
-            poolInfo.evicted = true;
-            shortCircuit = true;
-          }
-          if (this.#isAuthError(error)) {
-            shortCircuit = true;
-          }
-        }
+        isolatedHTML = result as string;
       }
 
       if (shortCircuit) {
@@ -234,76 +244,71 @@ export class RenderRunner {
         };
       }
 
-      // TODO consider breaking out rendering search doc into its own route so
-      // that we can fully understand all the linked fields that are used in all
-      // the html formats and generate a search doc that is well populated. Right
-      // now we only consider linked fields used in the isolated template.
-      let metaMaybeError = await withTimeout(
-        page,
-        () => renderMeta(page, captureOptions),
-        opts?.timeoutMs,
-      );
-      // TODO also consider introducing a mechanism in the API to track and reset
-      // field usage for an instance recursively so that the depth that an
-      // instance is loaded from a different rendering context in the same realm
-      // doesn't elide fields that this rendering context cares about. in that
-      // manner we can get a complete picture of how to build the search doc's linked
-      // fields for each rendering context.
-      let meta: PrerenderMeta;
-      if (isRenderError(metaMaybeError)) {
-        markTimeout(metaMaybeError as RenderError);
-        if (
-          await this.#maybeEvict(
-            realm,
-            'render.meta',
-            metaMaybeError as RenderError,
-          )
-        ) {
-          poolInfo.evicted = true;
-          shortCircuit = true;
-        }
-        error = error ?? (metaMaybeError as RenderError);
-        markTimeout(error);
-        if (this.#isAuthError(error)) {
-          shortCircuit = true;
-        }
-        meta = {
-          serialized: null,
-          searchDoc: null,
-          displayNames: null,
-          deps: null,
-          types: null,
-        };
-      } else {
-        meta = metaMaybeError as PrerenderMeta;
-      }
+      let emptyMeta: PrerenderMeta = {
+        serialized: null,
+        searchDoc: null,
+        displayNames: null,
+        deps: null,
+        types: null,
+      };
+      let meta = emptyMeta;
+      let metaForTypes = emptyMeta;
       let headHTML: string | null = null,
         atomHTML: string | null = null,
         iconHTML: string | null = null,
         embeddedHTML: Record<string, string> | null = null,
         fittedHTML: Record<string, string> | null = null;
 
-      if (!shortCircuit) {
-        let headHTMLResult = await this.#step(realm, 'head render', () =>
-          withTimeout(
-            page,
-            () => renderHTML(page, 'head', 0, captureOptions),
-            opts?.timeoutMs,
-          ),
-        );
-        if (headHTMLResult.ok) {
-          headHTML = headHTMLResult.value as string;
-        } else {
-          error = error ?? headHTMLResult.error;
-          markTimeout(headHTMLResult.error);
-          if (headHTMLResult.evicted) {
-            poolInfo.evicted = true;
-            shortCircuit = true;
-          }
+      const formatSteps: Array<{
+        name: string;
+        cb: () => Promise<string | RenderError>;
+        assign: (value: string) => void;
+      }> = [
+        {
+          name: 'head render',
+          cb: () => renderHTML(page, 'head', 0, captureOptions),
+          assign: (value: string) => {
+            headHTML = value;
+          },
+        },
+        {
+          name: 'atom render',
+          cb: () => renderHTML(page, 'atom', 0, captureOptions),
+          assign: (value: string) => {
+            atomHTML = value;
+          },
+        },
+        {
+          name: 'icon render',
+          cb: () => renderIcon(page, captureOptions),
+          assign: (value: string) => {
+            iconHTML = value;
+          },
+        },
+      ];
+      for (let step of formatSteps) {
+        if (shortCircuit) {
+          break;
+        }
+        let stepValue = await runTimedStep<string>(step.name, step.cb);
+        if (stepValue !== undefined) {
+          step.assign(stepValue);
         }
       }
 
-      if (!shortCircuit && meta.types) {
+      if (!shortCircuit) {
+        // Obtain type hierarchy for ancestor rendering. We capture final meta
+        // again at the end so searchDoc/deps reflect every format's loads.
+        let metaForTypesResult = await runTimedStep<PrerenderMeta>(
+          'render.meta (types)',
+          () => renderMeta(page, captureOptions),
+        );
+        if (metaForTypesResult !== undefined) {
+          metaForTypes = metaForTypesResult;
+        }
+      }
+
+      if (!shortCircuit && metaForTypes.types) {
         // Render sequentially and short-circuit on unusable page/timeout
         const steps: Array<{
           name: string;
@@ -313,7 +318,12 @@ export class RenderRunner {
           {
             name: 'fitted render',
             cb: () =>
-              renderAncestors(page, 'fitted', meta.types!, captureOptions),
+              renderAncestors(
+                page,
+                'fitted',
+                metaForTypes.types!,
+                captureOptions,
+              ),
             assign: (v: string | Record<string, string>) => {
               fittedHTML = v as Record<string, string>;
             },
@@ -321,47 +331,39 @@ export class RenderRunner {
           {
             name: 'embedded render',
             cb: () =>
-              renderAncestors(page, 'embedded', meta.types!, captureOptions),
+              renderAncestors(
+                page,
+                'embedded',
+                metaForTypes.types!,
+                captureOptions,
+              ),
             assign: (v: string | Record<string, string>) => {
               embeddedHTML = v as Record<string, string>;
-            },
-          },
-          {
-            name: 'atom render',
-            cb: () => renderHTML(page, 'atom', 0, captureOptions),
-            assign: (v: string | Record<string, string>) => {
-              atomHTML = v as string;
-            },
-          },
-          {
-            name: 'icon render',
-            cb: () => renderIcon(page, captureOptions),
-            assign: (v: string | Record<string, string>) => {
-              iconHTML = v as string;
             },
           },
         ];
 
         for (let step of steps) {
-          if (shortCircuit) break;
-          let res = await this.#step(realm, step.name, () =>
-            withTimeout(page, step.cb, opts?.timeoutMs),
-          );
-          if (res.ok) {
-            step.assign(res.value);
-          } else {
-            error = error ?? res.error;
-            markTimeout(res.error);
-            if (res.evicted) {
-              poolInfo.evicted = true;
-              shortCircuit = true;
-              break;
-            }
-            if (this.#isAuthError(error)) {
-              shortCircuit = true;
-              break;
-            }
+          if (shortCircuit) {
+            break;
           }
+          let stepValue = await runTimedStep<string | Record<string, string>>(
+            step.name,
+            step.cb,
+          );
+          if (stepValue !== undefined) {
+            step.assign(stepValue);
+          }
+        }
+      }
+
+      if (!shortCircuit) {
+        let finalMetaResult = await runTimedStep<PrerenderMeta>(
+          'render.meta (final)',
+          () => renderMeta(page, captureOptions),
+        );
+        if (finalMetaResult !== undefined) {
+          meta = finalMetaResult;
         }
       }
 
@@ -889,11 +891,18 @@ export class RenderRunner {
   ): Promise<
     { ok: true; value: T } | { ok: false; error: RenderError; evicted: boolean }
   > {
+    log.debug(`prerender step start realm=${realm} step=${step}`);
     let r = await fn();
     if (isRenderError(r)) {
       let evicted = await this.#maybeEvict(realm, step, r as RenderError);
+      log.debug(
+        `prerender step error realm=${realm} step=${step} status=${
+          (r as RenderError).error?.status
+        } title=${(r as RenderError).error?.title} evicted=${evicted}`,
+      );
       return { ok: false, error: r as RenderError, evicted };
     }
+    log.debug(`prerender step done realm=${realm} step=${step}`);
     return { ok: true, value: r as T };
   }
 

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -28,6 +28,7 @@ export interface CaptureOptions {
   expectedId?: string;
   expectedNonce?: string;
   simulateTimeoutMs?: number;
+  timeoutMs?: number;
 }
 
 export interface ModuleCapture {
@@ -166,6 +167,7 @@ async function waitForRoutePathSuffix(
   suffix: string,
   opts?: CaptureOptions,
 ): Promise<void> {
+  let waitTimeoutMs = effectiveRouteWaitTimeoutMs(opts);
   log.debug(`waitForRoutePathSuffix start suffix=${suffix} url=${page.url()}`);
   await page.waitForFunction(
     (
@@ -225,7 +227,7 @@ async function waitForRoutePathSuffix(
       }
       return false;
     },
-    { timeout: cardRenderTimeout },
+    { timeout: waitTimeoutMs },
     suffix,
     opts?.expectedId ?? null,
     opts?.expectedNonce ?? null,
@@ -239,6 +241,18 @@ async function waitForRoutePathSuffix(
   log.debug(
     `waitForRoutePathSuffix done suffix=${suffix} url=${page.url()} matchedByPath=${matchedByPath}`,
   );
+}
+
+function effectiveRouteWaitTimeoutMs(opts?: CaptureOptions): number {
+  if (typeof opts?.timeoutMs !== 'number') {
+    return cardRenderTimeout;
+  }
+
+  // Keep the inner Puppeteer wait close to the caller timeout so it cannot
+  // linger for the full cardRenderTimeout after withTimeout resolves, while
+  // still allowing withTimeout to win the race and produce our canonical error.
+  let withGrace = Math.ceil(opts.timeoutMs + 250);
+  return Math.max(1, Math.min(cardRenderTimeout, withGrace));
 }
 
 async function waitForPrerenderSettle(page: Page): Promise<void> {

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -64,15 +64,29 @@ export async function renderHTML(
   ancestorLevel: number,
   opts?: CaptureOptions,
 ): Promise<string | RenderError> {
+  log.debug(
+    `renderHTML start format=${format} ancestorLevel=${ancestorLevel} url=${page.url()}`,
+  );
   await transitionTo(page, 'render.html', format, String(ancestorLevel));
+  await waitForRoutePathSuffix(page, `/html/${format}/${ancestorLevel}`, opts);
+  await waitForPrerenderSettle(page);
+  log.debug(
+    `renderHTML capture format=${format} ancestorLevel=${ancestorLevel} url=${page.url()}`,
+  );
   let result = await captureResult(
     page,
     ['isolated', 'atom', 'head'].includes(format) ? 'innerHTML' : 'outerHTML',
     opts,
   );
+  log.debug(
+    `renderHTML captured format=${format} ancestorLevel=${ancestorLevel} status=${result.status} id=${result.id} nonce=${result.nonce}`,
+  );
   if (result.status === 'error' || result.status === 'unusable') {
     return renderCaptureToError(page, result, 'render.html');
   }
+  log.debug(
+    `renderHTML success format=${format} ancestorLevel=${ancestorLevel} length=${result.value.length}`,
+  );
   return cleanCapturedHTML(result.value);
 }
 
@@ -80,11 +94,19 @@ export async function renderIcon(
   page: Page,
   opts?: CaptureOptions,
 ): Promise<string | RenderError> {
+  log.debug(`renderIcon start url=${page.url()}`);
   await transitionTo(page, 'render.icon');
+  await waitForRoutePathSuffix(page, '/icon', opts);
+  await waitForPrerenderSettle(page);
+  log.debug(`renderIcon capture url=${page.url()}`);
   let result = await captureResult(page, 'outerHTML', opts);
+  log.debug(
+    `renderIcon captured status=${result.status} id=${result.id} nonce=${result.nonce}`,
+  );
   if (result.status === 'error' || result.status === 'unusable') {
     return renderCaptureToError(page, result, 'render.icon');
   }
+  log.debug(`renderIcon success length=${result.value.length}`);
   return cleanCapturedHTML(result.value);
 }
 
@@ -92,8 +114,15 @@ export async function renderMeta(
   page: Page,
   opts?: CaptureOptions,
 ): Promise<PrerenderMeta | RenderError> {
+  log.debug(`renderMeta start url=${page.url()}`);
   await transitionTo(page, 'render.meta');
+  await waitForRoutePathSuffix(page, '/meta', opts);
+  await waitForPrerenderSettle(page);
+  log.debug(`renderMeta capture url=${page.url()}`);
   let result = await captureResult(page, 'textContent', opts);
+  log.debug(
+    `renderMeta captured status=${result.status} id=${result.id} nonce=${result.nonce}`,
+  );
   if (result.status === 'error' || result.status === 'unusable') {
     return renderCaptureToError(page, result, 'render.meta');
   }
@@ -130,6 +159,160 @@ export async function renderMeta(
       { title: 'Invalid render meta response' },
     );
   }
+}
+
+async function waitForRoutePathSuffix(
+  page: Page,
+  suffix: string,
+  opts?: CaptureOptions,
+): Promise<void> {
+  log.debug(`waitForRoutePathSuffix start suffix=${suffix} url=${page.url()}`);
+  await page.waitForFunction(
+    (
+      targetSuffix: string,
+      expectedId: string | null,
+      expectedNonce: string | null,
+    ) => {
+      if (window.location.pathname.endsWith(targetSuffix)) {
+        return true;
+      }
+
+      // If the render has already entered a terminal state (error/unusable),
+      // do not wait for a route suffix that may never arrive.
+      let elements = Array.from(
+        document.querySelectorAll('[data-prerender]'),
+      ) as HTMLElement[];
+      if (!elements.length) {
+        let errorElement = document.querySelector(
+          '[data-prerender-error]',
+        ) as HTMLElement | null;
+        if (!errorElement) {
+          return false;
+        }
+        let raw = errorElement.textContent ?? errorElement.innerHTML ?? '';
+        return raw.trim().length > 0;
+      }
+      for (let element of elements) {
+        let status = element.dataset.prerenderStatus ?? '';
+        let errorElement = element.querySelector(
+          '[data-prerender-error]',
+        ) as HTMLElement | null;
+        let errorText = (
+          errorElement?.textContent ??
+          errorElement?.innerHTML ??
+          ''
+        ).trim();
+        let isTerminal =
+          status === 'error' || status === 'unusable' || errorText.length > 0;
+        if (!isTerminal) {
+          continue;
+        }
+        if (
+          expectedId &&
+          element.dataset.prerenderId &&
+          element.dataset.prerenderId !== expectedId
+        ) {
+          continue;
+        }
+        if (
+          expectedNonce &&
+          element.dataset.prerenderNonce &&
+          element.dataset.prerenderNonce !== expectedNonce
+        ) {
+          continue;
+        }
+        return true;
+      }
+      return false;
+    },
+    { timeout: cardRenderTimeout },
+    suffix,
+    opts?.expectedId ?? null,
+    opts?.expectedNonce ?? null,
+  );
+  let matchedByPath = false;
+  try {
+    matchedByPath = new URL(page.url()).pathname.endsWith(suffix);
+  } catch {
+    matchedByPath = false;
+  }
+  log.debug(
+    `waitForRoutePathSuffix done suffix=${suffix} url=${page.url()} matchedByPath=${matchedByPath}`,
+  );
+}
+
+async function waitForPrerenderSettle(page: Page): Promise<void> {
+  log.debug(`waitForPrerenderSettle start url=${page.url()}`);
+  let settleState = await page.evaluate(async () => {
+    let hasTerminalPrerenderState = () => {
+      let elements = Array.from(
+        document.querySelectorAll('[data-prerender]'),
+      ) as HTMLElement[];
+      for (let element of elements) {
+        let status = element.dataset.prerenderStatus ?? '';
+        if (status === 'error' || status === 'unusable') {
+          return true;
+        }
+        let errorElement = element.querySelector(
+          '[data-prerender-error]',
+        ) as HTMLElement | null;
+        let errorText = (
+          errorElement?.textContent ??
+          errorElement?.innerHTML ??
+          ''
+        ).trim();
+        if (errorText.length > 0) {
+          return true;
+        }
+      }
+      let detachedErrorElement = document.querySelector(
+        '[data-prerender-error]',
+      ) as HTMLElement | null;
+      if (!detachedErrorElement) {
+        return false;
+      }
+      let detachedErrorText = (
+        detachedErrorElement.textContent ??
+        detachedErrorElement.innerHTML ??
+        ''
+      ).trim();
+      return detachedErrorText.length > 0;
+    };
+
+    if (hasTerminalPrerenderState()) {
+      return 'terminal-before-settle';
+    }
+
+    let settle = (globalThis as any).__waitForRenderLoadStability;
+    if (typeof settle === 'function') {
+      let waitForTerminal = async () => {
+        for (;;) {
+          if (hasTerminalPrerenderState()) {
+            return 'terminal-during-settle';
+          }
+          await new Promise<void>((resolve) =>
+            requestAnimationFrame(() => resolve()),
+          );
+        }
+      };
+
+      try {
+        return await Promise.race([
+          settle().then(() => 'settled'),
+          waitForTerminal(),
+        ]);
+      } catch (error) {
+        if (hasTerminalPrerenderState()) {
+          return 'settle-rejected-terminal';
+        }
+        throw error;
+      }
+    }
+    return 'missing-settle-hook';
+  });
+  log.debug(
+    `waitForPrerenderSettle done url=${page.url()} state=${settleState}`,
+  );
 }
 
 function renderCaptureToError(
@@ -722,6 +905,24 @@ export async function captureResult(
             undefined,
         } as RenderCapture;
       } else {
+        if (capture === 'innerHTML') {
+          return {
+            status: finalStatus,
+            value: resolvedElement.innerHTML ?? '',
+            alive,
+            id: resolvedElement.dataset.prerenderId ?? undefined,
+            nonce: resolvedElement.dataset.prerenderNonce ?? undefined,
+          } as RenderCapture;
+        }
+        if (capture === 'textContent') {
+          return {
+            status: finalStatus,
+            value: resolvedElement.textContent ?? '',
+            alive,
+            id: resolvedElement.dataset.prerenderId ?? undefined,
+            nonce: resolvedElement.dataset.prerenderNonce ?? undefined,
+          } as RenderCapture;
+        }
         const firstChild = resolvedElement.children[0] as
           | (HTMLElement & {
               textContent: string;

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -285,8 +285,18 @@ async function waitForPrerenderSettle(page: Page): Promise<void> {
 
     let settle = (globalThis as any).__waitForRenderLoadStability;
     if (typeof settle === 'function') {
+      let stopPolling = false;
+      let settleOutcome = settle()
+        .then(() => ({ type: 'settled' as const }))
+        .catch((error: unknown) => ({
+          type: 'settle-rejected' as const,
+          error,
+        }))
+        .finally(() => {
+          stopPolling = true;
+        });
       let waitForTerminal = async () => {
-        for (;;) {
+        while (!stopPolling) {
           if (hasTerminalPrerenderState()) {
             return 'terminal-during-settle';
           }
@@ -294,19 +304,28 @@ async function waitForPrerenderSettle(page: Page): Promise<void> {
             requestAnimationFrame(() => resolve()),
           );
         }
+        return 'polling-stopped';
       };
 
-      try {
-        return await Promise.race([
-          settle().then(() => 'settled'),
-          waitForTerminal(),
-        ]);
-      } catch (error) {
-        if (hasTerminalPrerenderState()) {
-          return 'settle-rejected-terminal';
-        }
-        throw error;
+      let winner = await Promise.race([settleOutcome, waitForTerminal()]);
+
+      if (winner === 'terminal-during-settle') {
+        return 'terminal-during-settle';
       }
+
+      let finalOutcome = winner;
+      if (winner === 'polling-stopped') {
+        finalOutcome = await settleOutcome;
+      }
+
+      if (finalOutcome.type === 'settled') {
+        return 'settled';
+      }
+
+      if (hasTerminalPrerenderState()) {
+        return 'settle-rejected-terminal';
+      }
+      throw finalOutcome.error;
     }
     return 'missing-settle-hook';
   });

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -134,7 +134,7 @@ function makeStubPagePool(
 }
 
 module(basename(__filename), function () {
-  module('prerender - dynamic tests', function (hooks) {
+  module('prerender - mutating tests', function (hooks) {
     let realmURL = 'http://127.0.0.1:4450/test/';
     let prerenderServerURL = new URL(realmURL).origin;
     let testUserId = '@user1:localhost';
@@ -171,6 +171,7 @@ module(basename(__filename), function () {
     });
 
     setupPermissionedRealms(hooks, {
+      mode: 'beforeEach',
       realms: [
         {
           realmURL,
@@ -202,7 +203,288 @@ module(basename(__filename), function () {
                 },
               },
             },
-            'dep-reset-consumer.gts': `
+          },
+        },
+      ],
+      onRealmSetup({ realms: setupRealms }) {
+        ({ realm, realmAdapter } = setupRealms[0]);
+        permissions = {
+          [realmURL]: ['read', 'write', 'realm-owner'],
+        };
+      },
+    });
+
+    test('reuses pooled page and picks up updated instance', async function (assert) {
+      const cardURL = `${realmURL}1`;
+
+      let first = await prerenderer.prerenderCard({
+        realm: realmURL,
+        url: cardURL,
+        auth: auth(),
+      });
+
+      assert.false(first.pool.reused, 'first call not reused');
+      assert.false(first.pool.evicted, 'first call not evicted');
+      assert.strictEqual(
+        first.response.serialized?.data.attributes?.name,
+        'Maple',
+        'first render sees original value',
+      );
+
+      await realmAdapter.write(
+        '1.json',
+        JSON.stringify(
+          {
+            data: {
+              attributes: {
+                name: 'Juniper',
+              },
+              meta: {
+                adoptsFrom: {
+                  module: './person',
+                  name: 'Person',
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      await realm.realmIndexUpdater.fullIndex();
+      realm.__testOnlyClearCaches();
+
+      let second = await prerenderer.prerenderCard({
+        realm: realmURL,
+        url: cardURL,
+        auth: auth(),
+      });
+
+      assert.true(second.pool.reused, 'second call reused pooled page');
+      assert.false(second.pool.evicted, 'second call not evicted');
+      assert.strictEqual(
+        second.pool.pageId,
+        first.pool.pageId,
+        'same page reused',
+      );
+      assert.strictEqual(
+        second.response.serialized?.data.attributes?.name,
+        'Juniper',
+        'second render picks up updated value',
+      );
+    });
+
+    test('module prerender reuses pooled page after updates', async function (assert) {
+      const moduleURL = `${realmURL}person.gts`;
+
+      let first = await prerenderer.prerenderModule({
+        realm: realmURL,
+        url: moduleURL,
+        auth: auth(),
+      });
+
+      assert.false(first.pool.reused, 'first module render not reused');
+
+      await realmAdapter.write(
+        'person.gts',
+        `
+          import { CardDef, field, contains, StringField, Component } from 'https://cardstack.com/base/card-api';
+          export class Person extends CardDef {
+            static displayName = "Updated Person";
+            @field name = contains(StringField);
+            static isolated = class extends Component<typeof this> {
+              <template>{{@model.name}}</template>
+            }
+          }
+        `,
+      );
+      realm.__testOnlyClearCaches(); // out write bypasses the index so we need to manually flush the realm cache
+
+      let second = await prerenderer.prerenderModule({
+        realm: realmURL,
+        url: moduleURL,
+        auth: auth(),
+        renderOptions: { clearCache: true },
+      });
+
+      assert.true(
+        second.pool.reused,
+        'second module render reused pooled page',
+      );
+      assert.strictEqual(
+        first.pool.pageId,
+        second.pool.pageId,
+        'same page reused',
+      );
+      let key = `${trimExecutableExtension(new URL(moduleURL)).href}/Person`;
+      let entry = second.response.definitions[key];
+      assert.ok(entry, 'updated module definition entry present');
+      assert.strictEqual(
+        entry?.type,
+        'definition',
+        'updated module definition entry correct',
+      );
+      if (entry?.type === 'definition') {
+        assert.strictEqual(
+          entry.definition.displayName,
+          'Updated Person',
+          'updated module definition observed',
+        );
+      } else {
+        assert.ok(false, 'updated module definition entry should be present');
+      }
+    });
+
+    test('module prerender surfaces syntax errors', async function (assert) {
+      const modulePath = 'person.gts';
+      const moduleURL = `${realmURL}${modulePath}`;
+
+      await realmAdapter.write(modulePath, 'export const Broken = ;');
+      realm.__testOnlyClearCaches();
+
+      let result = await prerenderer.prerenderModule({
+        realm: realmURL,
+        url: moduleURL,
+        auth: auth(),
+      });
+
+      assert.strictEqual(
+        result.response.status,
+        'error',
+        'module render errored',
+      );
+      assert.strictEqual(
+        result.response.error?.error.status,
+        406,
+        'syntax error surfaces as 406',
+      );
+      assert.false(result.pool.evicted, 'page not evicted for syntax error');
+    });
+
+    test('file extract surfaces broken FileDef module error without remote prerender timeout', async function (assert) {
+      await realmAdapter.write(
+        'filedef-mismatch.gts',
+        `
+          import { FileDef as BaseFileDef } from "https://cardstack.com/base/file-api";
+          import { MissingChild } from "./missing-child";
+
+          export class FileDef extends BaseFileDef {
+            static missingChild = MissingChild;
+          }
+        `,
+      );
+      await realmAdapter.write('broken-file.mismatch', 'broken mismatch file');
+      realm.__testOnlyClearCaches();
+
+      let result = await prerenderer.prerenderFileExtract({
+        realm: realmURL,
+        url: `${realmURL}broken-file.mismatch`,
+        auth: auth(),
+        renderOptions: {
+          fileExtract: true,
+          fileDefCodeRef: {
+            module: `${realmURL}filedef-mismatch`,
+            name: 'FileDef',
+          },
+        },
+      });
+
+      assert.strictEqual(
+        result.response.status,
+        'error',
+        'file extract reports error for broken FileDef module',
+      );
+      assert.ok(result.response.error, 'error payload is present');
+      assert.ok(
+        result.response.error?.error.message?.includes(
+          'Received HTTP 404 from server',
+        ),
+        `error message should mention module 404, got: ${result.response.error?.error.message}`,
+      );
+      let messageIncludesTimeoutMarker = Boolean(
+        result.response.error?.error.message?.includes('Prerender request to'),
+      );
+      assert.false(
+        messageIncludesTimeoutMarker,
+        'error should not be reported as a remote prerender request timeout',
+      );
+      assert.false(
+        result.pool.timedOut,
+        'pool should not mark this as a prerender timeout',
+      );
+    });
+  });
+
+  function defineNonMutatingRunnerTests() {
+    module('runner behavior', function (hooks) {
+      let realmURL = 'http://127.0.0.1:4455/test/';
+      let prerenderServerURL = new URL(realmURL).origin;
+      let testUserId = '@user1:localhost';
+      let permissions: RealmPermissions = {
+        [realmURL]: ['read', 'write', 'realm-owner'],
+      };
+      let prerenderer: Prerenderer;
+      let auth = () => {
+        let sessions = JSON.parse(
+          testCreatePrerenderAuth(testUserId, permissions),
+        ) as Record<string, string>;
+        let token = sessions[realmURL];
+        if (token) {
+          sessions[new URL(realmURL).origin + '/'] = token;
+        }
+        return JSON.stringify(sessions);
+      };
+
+      hooks.before(async () => {
+        prerenderer = getPrerendererForTesting({
+          maxPages: 2,
+          serverURL: prerenderServerURL,
+        });
+      });
+
+      hooks.after(async () => {
+        await prerenderer.stop();
+      });
+
+      hooks.beforeEach(async () => {
+        await prerenderer.disposeRealm(realmURL);
+      });
+
+      setupPermissionedRealms(hooks, {
+        mode: 'before',
+        realms: [
+          {
+            realmURL,
+            permissions: {
+              '*': ['read'],
+              [testUserId]: ['read', 'write', 'realm-owner'],
+            },
+            fileSystem: {
+              'person.gts': `
+              import { CardDef, field, contains, StringField, Component } from 'https://cardstack.com/base/card-api';
+              export class Person extends CardDef {
+                static displayName = "Person";
+                @field name = contains(StringField);
+                static isolated = class extends Component<typeof this> {
+                  <template>{{@model.name}}</template>
+                }
+              }
+            `,
+              '1.json': {
+                data: {
+                  attributes: {
+                    name: 'Maple',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './person',
+                      name: 'Person',
+                    },
+                  },
+                },
+              },
+              'dep-reset-consumer.gts': `
               import { CardDef, field, linksTo, Component } from 'https://cardstack.com/base/card-api';
               import { Person } from './person';
               export class DepResetConsumer extends CardDef {
@@ -213,67 +495,67 @@ module(basename(__filename), function () {
                 }
               }
             `,
-            'dep-reset-consumer-a.json': {
-              data: {
-                relationships: {
-                  friend: {
-                    links: {
-                      self: './dep-reset-friend-a',
+              'dep-reset-consumer-a.json': {
+                data: {
+                  relationships: {
+                    friend: {
+                      links: {
+                        self: './dep-reset-friend-a',
+                      },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './dep-reset-consumer',
+                      name: 'DepResetConsumer',
                     },
                   },
                 },
-                meta: {
-                  adoptsFrom: {
-                    module: './dep-reset-consumer',
-                    name: 'DepResetConsumer',
-                  },
-                },
               },
-            },
-            'dep-reset-consumer-b.json': {
-              data: {
-                relationships: {
-                  friend: {
-                    links: {
-                      self: './dep-reset-friend-b',
+              'dep-reset-consumer-b.json': {
+                data: {
+                  relationships: {
+                    friend: {
+                      links: {
+                        self: './dep-reset-friend-b',
+                      },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './dep-reset-consumer',
+                      name: 'DepResetConsumer',
                     },
                   },
                 },
-                meta: {
-                  adoptsFrom: {
-                    module: './dep-reset-consumer',
-                    name: 'DepResetConsumer',
+              },
+              'dep-reset-friend-a.json': {
+                data: {
+                  attributes: {
+                    name: 'Friend A',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './person',
+                      name: 'Person',
+                    },
                   },
                 },
               },
-            },
-            'dep-reset-friend-a.json': {
-              data: {
-                attributes: {
-                  name: 'Friend A',
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './person',
-                    name: 'Person',
+              'dep-reset-friend-b.json': {
+                data: {
+                  attributes: {
+                    name: 'Friend B',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './person',
+                      name: 'Person',
+                    },
                   },
                 },
               },
-            },
-            'dep-reset-friend-b.json': {
-              data: {
-                attributes: {
-                  name: 'Friend B',
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './person',
-                    name: 'Person',
-                  },
-                },
-              },
-            },
-            'no-icon.gts': `
+              'no-icon.gts': `
               import { CardDef, field, contains, StringField, Component } from 'https://cardstack.com/base/card-api';
               export class NoIcon extends CardDef {
                 static displayName = "No Icon";
@@ -286,31 +568,31 @@ module(basename(__filename), function () {
                 }
               }
             `,
-            'no-icon.json': {
-              data: {
-                attributes: {
-                  name: 'Missing Icon',
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './no-icon',
-                    name: 'NoIcon',
+              'no-icon.json': {
+                data: {
+                  attributes: {
+                    name: 'Missing Icon',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './no-icon',
+                      name: 'NoIcon',
+                    },
                   },
                 },
               },
-            },
-            'broken.gts': 'export const Broken = ;',
-            'broken.json': {
-              data: {
-                meta: {
-                  adoptsFrom: {
-                    module: './broken',
-                    name: 'Broken',
+              'broken.gts': 'export const Broken = ;',
+              'broken.json': {
+                data: {
+                  meta: {
+                    adoptsFrom: {
+                      module: './broken',
+                      name: 'Broken',
+                    },
                   },
                 },
               },
-            },
-            'rejects.gts': `
+              'rejects.gts': `
               import { CardDef, Component } from 'https://cardstack.com/base/card-api';
               export class Rejects extends CardDef {
                 static isolated = class extends Component<typeof this> {
@@ -322,17 +604,17 @@ module(basename(__filename), function () {
                 }
               }
             `,
-            'rejects.json': {
-              data: {
-                meta: {
-                  adoptsFrom: {
-                    module: './rejects',
-                    name: 'Rejects',
+              'rejects.json': {
+                data: {
+                  meta: {
+                    adoptsFrom: {
+                      module: './rejects',
+                      name: 'Rejects',
+                    },
                   },
                 },
               },
-            },
-            'rsvp-rejects.gts': `
+              'rsvp-rejects.gts': `
               import { CardDef, Component } from 'https://cardstack.com/base/card-api';
               import * as RSVP from 'rsvp';
               export class RsvpRejects extends CardDef {
@@ -345,17 +627,17 @@ module(basename(__filename), function () {
                 }
               }
             `,
-            'rsvp-rejects.json': {
-              data: {
-                meta: {
-                  adoptsFrom: {
-                    module: './rsvp-rejects',
-                    name: 'RsvpRejects',
+              'rsvp-rejects.json': {
+                data: {
+                  meta: {
+                    adoptsFrom: {
+                      module: './rsvp-rejects',
+                      name: 'RsvpRejects',
+                    },
                   },
                 },
               },
-            },
-            'throws.gts': `
+              'throws.gts': `
               import { CardDef, Component } from 'https://cardstack.com/base/card-api';
               export class Throws extends CardDef {
                 static isolated = class extends Component<typeof this> {
@@ -366,17 +648,17 @@ module(basename(__filename), function () {
                 }
               }
             `,
-            'throws.json': {
-              data: {
-                meta: {
-                  adoptsFrom: {
-                    module: './throws',
-                    name: 'Throws',
+              'throws.json': {
+                data: {
+                  meta: {
+                    adoptsFrom: {
+                      module: './throws',
+                      name: 'Throws',
+                    },
                   },
                 },
               },
-            },
-            'console-error.gts': `
+              'console-error.gts': `
               import { CardDef, Component } from 'https://cardstack.com/base/card-api';
               export class ConsoleError extends CardDef {
                 static isolated = class extends Component<typeof this> {
@@ -388,17 +670,17 @@ module(basename(__filename), function () {
                 }
               }
             `,
-            'console-error.json': {
-              data: {
-                meta: {
-                  adoptsFrom: {
-                    module: './console-error',
-                    name: 'ConsoleError',
+              'console-error.json': {
+                data: {
+                  meta: {
+                    adoptsFrom: {
+                      module: './console-error',
+                      name: 'ConsoleError',
+                    },
                   },
                 },
               },
-            },
-            'console-no-error.gts': `
+              'console-no-error.gts': `
               import { CardDef, Component } from 'https://cardstack.com/base/card-api';
               export class ConsoleNoError extends CardDef {
                 static isolated = class extends Component<typeof this> {
@@ -410,17 +692,17 @@ module(basename(__filename), function () {
                 }
               }
             `,
-            'console-no-error.json': {
-              data: {
-                meta: {
-                  adoptsFrom: {
-                    module: './console-no-error',
-                    name: 'ConsoleNoError',
+              'console-no-error.json': {
+                data: {
+                  meta: {
+                    adoptsFrom: {
+                      module: './console-no-error',
+                      name: 'ConsoleNoError',
+                    },
                   },
                 },
               },
-            },
-            'directory-query.gts': `
+              'directory-query.gts': `
               import { CardDef, field, contains, linksTo, linksToMany, StringField, Component, queryableValue } from 'https://cardstack.com/base/card-api';
 
               export class Person extends CardDef {
@@ -527,673 +809,350 @@ module(basename(__filename), function () {
                 };
               }
             `,
-            'directory-ops.json': {
-              data: {
-                attributes: {
-                  teamFilter: 'Ops',
-                },
-                relationships: {
-                  staff: {
-                    links: { self: null },
-                    data: [],
-                    meta: {
-                      errors: [
-                        {
-                          realm: 'https://unreachable-realm.example.com/',
-                          type: 'fetch-error',
-                          message: 'Could not reach remote realm',
-                          status: 502,
-                        },
-                      ],
+              'directory-ops.json': {
+                data: {
+                  attributes: {
+                    teamFilter: 'Ops',
+                  },
+                  relationships: {
+                    staff: {
+                      links: { self: null },
+                      data: [],
+                      meta: {
+                        errors: [
+                          {
+                            realm: 'https://unreachable-realm.example.com/',
+                            type: 'fetch-error',
+                            message: 'Could not reach remote realm',
+                            status: 502,
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './directory-query',
+                      name: 'Directory',
                     },
                   },
                 },
-                meta: {
-                  adoptsFrom: {
-                    module: './directory-query',
-                    name: 'Directory',
-                  },
-                },
               },
-            },
-            'person-alice.json': {
-              data: {
-                attributes: {
-                  name: 'Alice',
-                  team: 'Leadership',
-                  managerName: '',
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './directory-query',
-                    name: 'Person',
+              'person-alice.json': {
+                data: {
+                  attributes: {
+                    name: 'Alice',
+                    team: 'Leadership',
+                    managerName: '',
                   },
-                },
-              },
-            },
-            'person-bob.json': {
-              data: {
-                attributes: {
-                  name: 'Bob',
-                  team: 'Ops',
-                  managerName: 'Alice',
-                },
-                relationships: {
-                  manager: {
-                    links: {
-                      self: './person-alice',
+                  meta: {
+                    adoptsFrom: {
+                      module: './directory-query',
+                      name: 'Person',
                     },
                   },
                 },
-                meta: {
-                  adoptsFrom: {
-                    module: './directory-query',
-                    name: 'Person',
-                  },
-                },
               },
-            },
-            'person-carol.json': {
-              data: {
-                attributes: {
-                  name: 'Carol',
-                  team: 'Ops',
-                  managerName: 'Alice',
-                },
-                relationships: {
-                  manager: {
-                    links: {
-                      self: './person-alice',
+              'person-bob.json': {
+                data: {
+                  attributes: {
+                    name: 'Bob',
+                    team: 'Ops',
+                    managerName: 'Alice',
+                  },
+                  relationships: {
+                    manager: {
+                      links: {
+                        self: './person-alice',
+                      },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './directory-query',
+                      name: 'Person',
                     },
                   },
                 },
-                meta: {
-                  adoptsFrom: {
-                    module: './directory-query',
-                    name: 'Person',
-                  },
-                },
               },
-            },
-            'person-dave.json': {
-              data: {
-                attributes: {
-                  name: 'Dave',
-                  team: 'Ops',
-                  managerName: 'Bob',
-                },
-                relationships: {
-                  manager: {
-                    links: {
-                      self: './person-bob',
+              'person-carol.json': {
+                data: {
+                  attributes: {
+                    name: 'Carol',
+                    team: 'Ops',
+                    managerName: 'Alice',
+                  },
+                  relationships: {
+                    manager: {
+                      links: {
+                        self: './person-alice',
+                      },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './directory-query',
+                      name: 'Person',
                     },
                   },
                 },
-                meta: {
-                  adoptsFrom: {
-                    module: './directory-query',
-                    name: 'Person',
-                  },
-                },
               },
-            },
-            'person-eve.json': {
-              data: {
-                attributes: {
-                  name: 'Eve',
-                  team: 'Sales',
-                  managerName: 'Bob',
-                },
-                relationships: {
-                  manager: {
-                    links: {
-                      self: './person-bob',
+              'person-dave.json': {
+                data: {
+                  attributes: {
+                    name: 'Dave',
+                    team: 'Ops',
+                    managerName: 'Bob',
+                  },
+                  relationships: {
+                    manager: {
+                      links: {
+                        self: './person-bob',
+                      },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './directory-query',
+                      name: 'Person',
                     },
                   },
                 },
-                meta: {
-                  adoptsFrom: {
-                    module: './directory-query',
-                    name: 'Person',
+              },
+              'person-eve.json': {
+                data: {
+                  attributes: {
+                    name: 'Eve',
+                    team: 'Sales',
+                    managerName: 'Bob',
+                  },
+                  relationships: {
+                    manager: {
+                      links: {
+                        self: './person-bob',
+                      },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './directory-query',
+                      name: 'Person',
+                    },
                   },
                 },
               },
+              'notes.txt': 'Hello from file extract',
             },
-            'notes.txt': 'Hello from file extract',
           },
+        ],
+        onRealmSetup() {
+          permissions = {
+            [realmURL]: ['read', 'write', 'realm-owner'],
+          };
         },
-      ],
-      onRealmSetup({ realms: setupRealms }) {
-        ({ realm, realmAdapter } = setupRealms[0]);
-        permissions = {
-          [realmURL]: ['read', 'write', 'realm-owner'],
-        };
-      },
-    });
-
-    test('reuses pooled page and picks up updated instance', async function (assert) {
-      const cardURL = `${realmURL}1`;
-
-      let first = await prerenderer.prerenderCard({
-        realm: realmURL,
-        url: cardURL,
-        auth: auth(),
       });
 
-      assert.false(first.pool.reused, 'first call not reused');
-      assert.false(first.pool.evicted, 'first call not evicted');
-      assert.strictEqual(
-        first.response.serialized?.data.attributes?.name,
-        'Maple',
-        'first render sees original value',
-      );
+      test('resets runtime deps between consecutive prerenders', async function (assert) {
+        let first = await prerenderer.prerenderCard({
+          realm: realmURL,
+          url: `${realmURL}dep-reset-consumer-a`,
+          auth: auth(),
+        });
+        let firstDeps = first.response.deps ?? [];
+        assert.true(
+          firstDeps.includes(`${realmURL}dep-reset-friend-a.json`),
+          'first prerender includes first relationship target',
+        );
 
-      await realmAdapter.write(
-        '1.json',
-        JSON.stringify(
-          {
-            data: {
-              attributes: {
-                name: 'Juniper',
-              },
-              meta: {
-                adoptsFrom: {
-                  module: './person',
-                  name: 'Person',
-                },
-              },
-            },
-          },
-          null,
-          2,
-        ),
-      );
-
-      await realm.realmIndexUpdater.fullIndex();
-      realm.__testOnlyClearCaches();
-
-      let second = await prerenderer.prerenderCard({
-        realm: realmURL,
-        url: cardURL,
-        auth: auth(),
+        let second = await prerenderer.prerenderCard({
+          realm: realmURL,
+          url: `${realmURL}dep-reset-consumer-b`,
+          auth: auth(),
+        });
+        let secondDeps = second.response.deps ?? [];
+        assert.true(
+          secondDeps.includes(`${realmURL}dep-reset-friend-b.json`),
+          'second prerender includes second relationship target',
+        );
+        assert.false(
+          secondDeps.includes(`${realmURL}dep-reset-friend-a.json`),
+          'second prerender deps do not leak first prerender relationship target',
+        );
       });
 
-      assert.true(second.pool.reused, 'second call reused pooled page');
-      assert.false(second.pool.evicted, 'second call not evicted');
-      assert.strictEqual(
-        second.pool.pageId,
-        first.pool.pageId,
-        'same page reused',
-      );
-      assert.strictEqual(
-        second.response.serialized?.data.attributes?.name,
-        'Juniper',
-        'second render picks up updated value',
-      );
-    });
+      test('prerenderModule returns module metadata', async function (assert) {
+        const moduleURL = `${realmURL}person.gts`;
 
-    test('resets runtime deps between consecutive prerenders', async function (assert) {
-      let first = await prerenderer.prerenderCard({
-        realm: realmURL,
-        url: `${realmURL}dep-reset-consumer-a`,
-        auth: auth(),
-      });
-      let firstDeps = first.response.deps ?? [];
-      assert.true(
-        firstDeps.includes(`${realmURL}dep-reset-friend-a.json`),
-        'first prerender includes first relationship target',
-      );
+        let result = await prerenderer.prerenderModule({
+          realm: realmURL,
+          url: moduleURL,
+          auth: auth(),
+        });
 
-      let second = await prerenderer.prerenderCard({
-        realm: realmURL,
-        url: `${realmURL}dep-reset-consumer-b`,
-        auth: auth(),
-      });
-      let secondDeps = second.response.deps ?? [];
-      assert.true(
-        secondDeps.includes(`${realmURL}dep-reset-friend-b.json`),
-        'second prerender includes second relationship target',
-      );
-      assert.false(
-        secondDeps.includes(`${realmURL}dep-reset-friend-a.json`),
-        'second prerender deps do not leak first prerender relationship target',
-      );
-    });
-
-    test('prerenderModule returns module metadata', async function (assert) {
-      const moduleURL = `${realmURL}person.gts`;
-
-      let result = await prerenderer.prerenderModule({
-        realm: realmURL,
-        url: moduleURL,
-        auth: auth(),
-      });
-
-      assert.false(result.pool.reused, 'first module render not reused');
-      assert.strictEqual(
-        result.response.status,
-        'ready',
-        'module marked ready',
-      );
-      let key = `${trimExecutableExtension(new URL(moduleURL)).href}/Person`;
-      let entry = result.response.definitions[key];
-      assert.ok(entry, 'definition captured');
-      assert.strictEqual(
-        entry?.type,
-        'definition',
-        'definition entry type correct',
-      );
-      if (entry?.type === 'definition') {
-        assert.ok(entry.definition.displayName, 'display name present');
-      } else {
-        assert.ok(false, 'module definition should be present');
-      }
-    });
-
-    test('module prerender reuses pooled page after updates', async function (assert) {
-      const moduleURL = `${realmURL}person.gts`;
-
-      let first = await prerenderer.prerenderModule({
-        realm: realmURL,
-        url: moduleURL,
-        auth: auth(),
-      });
-
-      assert.false(first.pool.reused, 'first module render not reused');
-
-      await realmAdapter.write(
-        'person.gts',
-        `
-          import { CardDef, field, contains, StringField, Component } from 'https://cardstack.com/base/card-api';
-          export class Person extends CardDef {
-            static displayName = "Updated Person";
-            @field name = contains(StringField);
-            static isolated = class extends Component<typeof this> {
-              <template>{{@model.name}}</template>
-            }
-          }
-        `,
-      );
-      realm.__testOnlyClearCaches(); // out write bypasses the index so we need to manually flush the realm cache
-
-      let second = await prerenderer.prerenderModule({
-        realm: realmURL,
-        url: moduleURL,
-        auth: auth(),
-        renderOptions: { clearCache: true },
-      });
-
-      assert.true(
-        second.pool.reused,
-        'second module render reused pooled page',
-      );
-      assert.strictEqual(
-        first.pool.pageId,
-        second.pool.pageId,
-        'same page reused',
-      );
-      let key = `${trimExecutableExtension(new URL(moduleURL)).href}/Person`;
-      let entry = second.response.definitions[key];
-      assert.ok(entry, 'updated module definition entry present');
-      assert.strictEqual(
-        entry?.type,
-        'definition',
-        'updated module definition entry correct',
-      );
-      if (entry?.type === 'definition') {
+        assert.false(result.pool.reused, 'first module render not reused');
         assert.strictEqual(
-          entry.definition.displayName,
-          'Updated Person',
-          'updated module definition observed',
+          result.response.status,
+          'ready',
+          'module marked ready',
         );
-      } else {
-        assert.ok(false, 'updated module definition entry should be present');
-      }
-    });
-
-    test('module prerender surfaces syntax errors', async function (assert) {
-      const modulePath = 'person.gts';
-      const moduleURL = `${realmURL}${modulePath}`;
-
-      await realmAdapter.write(modulePath, 'export const Broken = ;');
-      realm.__testOnlyClearCaches();
-
-      let result = await prerenderer.prerenderModule({
-        realm: realmURL,
-        url: moduleURL,
-        auth: auth(),
-      });
-
-      assert.strictEqual(
-        result.response.status,
-        'error',
-        'module render errored',
-      );
-      assert.strictEqual(
-        result.response.error?.error.status,
-        406,
-        'syntax error surfaces as 406',
-      );
-      assert.false(result.pool.evicted, 'page not evicted for syntax error');
-    });
-
-    test('card prerender hoists module transpile errors', async function (assert) {
-      let brokenCard = `${realmURL}broken.json`;
-
-      let result = await prerenderer.prerenderCard({
-        realm: realmURL,
-        url: brokenCard,
-        auth: auth(),
-      });
-
-      assert.ok(result.response.error, 'prerender reports error');
-      assert.strictEqual(
-        result.response.error?.error.status,
-        406,
-        'status is 406',
-      );
-      assert.strictEqual(
-        result.response.error?.error.message,
-        `Parse Error at broken.gts:1:23: 1:24 (${realmURL}broken)`,
-        'message includes enough information for AI to fix the problem',
-      );
-      assert.ok(
-        result.response.error?.error.stack?.includes('at transpileJS'),
-        `stack should include "at transpileJS" but was ${result.response.error?.error.stack}`,
-      );
-      let additionalErrors = result.response.error?.error.additionalErrors;
-      if (additionalErrors !== null) {
-        assert.ok(
-          Array.isArray(additionalErrors),
-          'additionalErrors is an array when present',
+        let key = `${trimExecutableExtension(new URL(moduleURL)).href}/Person`;
+        let entry = result.response.definitions[key];
+        assert.ok(entry, 'definition captured');
+        assert.strictEqual(
+          entry?.type,
+          'definition',
+          'definition entry type correct',
         );
-        assert.ok(
-          additionalErrors?.every(
-            (entry) =>
-              entry?.title === 'Console error' ||
-              entry?.title === 'Console assert',
-          ),
-          'additionalErrors only include console entries',
-        );
-      }
-      let deps = result.response.error?.error.deps ?? [];
-      assert.ok(
-        deps.some((dep) => dep.includes(`${realmURL}broken`)),
-        'deps include failing module',
-      );
-    });
-
-    test('card prerender surfaces empty render container', async function (assert) {
-      let cardURL = `${realmURL}no-icon.json`;
-
-      let result = await prerenderer.prerenderCard({
-        realm: realmURL,
-        url: cardURL,
-        auth: auth(),
+        if (entry?.type === 'definition') {
+          assert.ok(entry.definition.displayName, 'display name present');
+        } else {
+          assert.ok(false, 'module definition should be present');
+        }
       });
 
-      assert.ok(result.response.error, 'prerender reports error');
-      assert.strictEqual(
-        result.response.error?.error.title,
-        'Invalid render response',
-        'error title indicates invalid render payload',
-      );
-      assert.ok(
-        result.response.error?.error.message?.includes(
-          '[data-prerender] has no child element to capture',
-        ),
-        `error message mentions empty prerender container, got: ${result.response.error?.error.message}`,
-      );
-      let errorDeps = result.response.error?.error.deps;
-      assert.notStrictEqual(
-        errorDeps,
-        null,
-        'short-circuit invalid render response includes non-null deps',
-      );
-      let deps = errorDeps ?? [];
-      assert.true(
-        Array.isArray(deps),
-        'short-circuit invalid render response deps are an array',
-      );
-      assert.true(
-        [`${realmURL}no-icon`, `${realmURL}no-icon.json`].some((dep) =>
-          deps.includes(dep),
-        ),
-        `synthesized invalid render error includes fallback dep context (deps: ${JSON.stringify(deps)})`,
-      );
-    });
-
-    test('card prerender surfaces runtime render errors without timing out', async function (assert) {
-      let cardURL = `${realmURL}throws.json`;
-
-      let result = await prerenderer.prerenderCard({
-        realm: realmURL,
-        url: cardURL,
-        auth: auth(),
-      });
-
-      assert.ok(result.response.error, 'prerender reports error');
-      assert.strictEqual(
-        result.response.error?.error.status,
-        500,
-        'runtime error surfaces as 500',
-      );
-      assert.ok(
-        result.response.error?.error.message?.includes('boom'),
-        `runtime error message includes thrown message, got: ${result.response.error?.error.message}`,
-      );
-      assert.false(
-        result.pool.timedOut,
-        'runtime error should not be mistaken for timeout',
-      );
-      assert.true(
-        result.pool.evicted,
-        'runtime error evicts prerender page to recover clean state',
-      );
-    });
-
-    test('card prerender includes console errors when render fails', async function (assert) {
-      let cardURL = `${realmURL}console-error.json`;
-
-      let result = await prerenderer.prerenderCard({
-        realm: realmURL,
-        url: cardURL,
-        auth: auth(),
-      });
-
-      assert.ok(result.response.error, 'prerender reports error');
-      let additionalErrors = result.response.error?.error.additionalErrors;
-      assert.ok(
-        Array.isArray(additionalErrors),
-        'additionalErrors includes console errors',
-      );
-      assert.ok(
-        additionalErrors?.some(
-          (error) =>
-            typeof error?.message === 'string' &&
-            error.message.includes('console boom'),
-        ),
-        'console error message is captured',
-      );
-    });
-
-    test('card prerender ignores console errors on success', async function (assert) {
-      let cardURL = `${realmURL}console-no-error.json`;
-
-      let result = await prerenderer.prerenderCard({
-        realm: realmURL,
-        url: cardURL,
-        auth: auth(),
-      });
-
-      assert.notOk(result.response.error, 'prerender succeeds');
-    });
-
-    test('card prerender surfaces unhandled promise rejection without timing out', async function (assert) {
-      let cardURL = `${realmURL}rejects.json`;
-
-      let result = await prerenderer.prerenderCard({
-        realm: realmURL,
-        url: cardURL,
-        auth: auth(),
-      });
-
-      assert.ok(result.response.error, 'prerender reports error');
-      assert.strictEqual(
-        result.response.error?.error.status,
-        500,
-        'unhandled rejection surfaces as 500',
-      );
-      assert.ok(
-        result.response.error?.error.message?.includes('reject boom'),
-        `unhandled rejection message includes thrown message, got: ${result.response.error?.error.message}`,
-      );
-      assert.false(
-        result.pool.timedOut,
-        'unhandled rejection should not be mistaken for timeout',
-      );
-      assert.true(
-        result.pool.evicted,
-        'unhandled rejection evicts prerender page to recover clean state',
-      );
-    });
-
-    test('card prerender surfaces RSVP rejection without timing out', async function (assert) {
-      let cardURL = `${realmURL}rsvp-rejects.json`;
-
-      let result = await prerenderer.prerenderCard({
-        realm: realmURL,
-        url: cardURL,
-        auth: auth(),
-      });
-
-      assert.ok(result.response.error, 'prerender reports RSVP rejection');
-      assert.strictEqual(
-        result.response.error?.error.status,
-        500,
-        'RSVP rejection surfaces as 500',
-      );
-      assert.ok(
-        result.response.error?.error.message?.includes('rsvp boom'),
-        `RSVP rejection message includes thrown message, got: ${result.response.error?.error.message}`,
-      );
-      assert.false(
-        result.pool.timedOut,
-        'RSVP rejection should not be mistaken for timeout',
-      );
-      assert.true(
-        result.pool.evicted,
-        'RSVP rejection evicts prerender page to recover clean state',
-      );
-    });
-
-    test('card prerender surfaces errors thrown before the render model hook', async function (assert) {
-      let originalGetPage = PagePool.prototype.getPage;
-      try {
-        PagePool.prototype.getPage = async function (
-          this: PagePool,
-          realm: string,
-        ) {
-          let pageInfo = await originalGetPage.call(this, realm);
-          let page = pageInfo.page as any;
-          let originalEvaluate = page?.evaluate?.bind(page);
-          if (originalEvaluate) {
-            let injected = false;
-            page.evaluate = async (...args: any[]) => {
-              if (!injected) {
-                injected = true;
-                await originalEvaluate(() => {
-                  let entries =
-                    (window as any).requirejs?.entries ??
-                    (window as any).require?.entries ??
-                    (window as any)._eak_seen;
-                  let renderModuleName =
-                    entries &&
-                    Object.keys(entries).find((name) =>
-                      name.endsWith('/routes/render'),
-                    );
-                  if (!renderModuleName) {
-                    throw new Error(
-                      'render route module not found for injection',
-                    );
-                  }
-                  let renderRouteModule = (window as any).require(
-                    renderModuleName,
-                  );
-                  let RenderRouteClass = renderRouteModule?.default;
-                  if (!RenderRouteClass?.prototype) {
-                    throw new Error(
-                      'render route class not found for injection',
-                    );
-                  }
-                  let originalBeforeModel =
-                    RenderRouteClass.prototype.beforeModel;
-                  RenderRouteClass.prototype.beforeModel = async function (
-                    ...bmArgs: any[]
-                  ) {
-                    if (originalBeforeModel) {
-                      await originalBeforeModel.apply(this, bmArgs as any);
-                    }
-                    RenderRouteClass.prototype.beforeModel =
-                      originalBeforeModel;
-                    throw new Error('boom before model');
-                  };
-                });
-              }
-              return originalEvaluate(...args);
-            };
-          }
-          return { ...pageInfo, page };
-        };
+      test('card prerender hoists module transpile errors', async function (assert) {
+        let brokenCard = `${realmURL}broken.json`;
 
         let result = await prerenderer.prerenderCard({
           realm: realmURL,
-          url: `${realmURL}1.json`,
+          url: brokenCard,
           auth: auth(),
         });
 
         assert.ok(result.response.error, 'prerender reports error');
+        assert.strictEqual(
+          result.response.error?.error.status,
+          406,
+          'status is 406',
+        );
+        assert.strictEqual(
+          result.response.error?.error.message,
+          `Parse Error at broken.gts:1:23: 1:24 (${realmURL}broken)`,
+          'message includes enough information for AI to fix the problem',
+        );
         assert.ok(
-          result.response.error?.error.message?.includes('boom before model'),
-          'captures error thrown before model hook',
+          result.response.error?.error.stack?.includes('at transpileJS'),
+          `stack should include "at transpileJS" but was ${result.response.error?.error.stack}`,
         );
-        assert.true(
-          result.pool.evicted,
-          'pre-model error evicts prerender page for clean state',
+        let additionalErrors = result.response.error?.error.additionalErrors;
+        if (additionalErrors !== null) {
+          assert.ok(
+            Array.isArray(additionalErrors),
+            'additionalErrors is an array when present',
+          );
+          assert.ok(
+            additionalErrors?.every(
+              (entry) =>
+                entry?.title === 'Console error' ||
+                entry?.title === 'Console assert',
+            ),
+            'additionalErrors only include console entries',
+          );
+        }
+        let deps = result.response.error?.error.deps ?? [];
+        assert.ok(
+          deps.some((dep) => dep.includes(`${realmURL}broken`)),
+          'deps include failing module',
         );
-        assert.true(
-          (result.response.error as any)?.evict,
-          'error payload flags eviction',
+      });
+
+      test('card prerender surfaces empty render container', async function (assert) {
+        let cardURL = `${realmURL}no-icon.json`;
+
+        let result = await prerenderer.prerenderCard({
+          realm: realmURL,
+          url: cardURL,
+          auth: auth(),
+        });
+
+        assert.ok(result.response.error, 'prerender reports error');
+        assert.strictEqual(
+          result.response.error?.error.title,
+          'Invalid render response',
+          'error title indicates invalid render payload',
         );
-        assert.false(result.pool.timedOut, 'error is not treated as timeout');
+        assert.ok(
+          result.response.error?.error.message?.includes(
+            '[data-prerender] has no child element to capture',
+          ),
+          `error message mentions empty prerender container, got: ${result.response.error?.error.message}`,
+        );
         let errorDeps = result.response.error?.error.deps;
         assert.notStrictEqual(
           errorDeps,
           null,
-          'pre-model short-circuit error includes non-null deps',
+          'short-circuit invalid render response includes non-null deps',
         );
         let deps = errorDeps ?? [];
         assert.true(
           Array.isArray(deps),
-          'pre-model short-circuit deps are an array',
+          'short-circuit invalid render response deps are an array',
         );
         assert.true(
-          [`${realmURL}1.json`, `${realmURL}1`].some((dep) =>
+          [`${realmURL}no-icon`, `${realmURL}no-icon.json`].some((dep) =>
             deps.includes(dep),
           ),
-          `pre-model fallback error includes dep context from transition params (deps: ${JSON.stringify(deps)})`,
+          `synthesized invalid render error includes fallback dep context (deps: ${JSON.stringify(deps)})`,
         );
-      } finally {
-        PagePool.prototype.getPage = originalGetPage;
-      }
-    });
+      });
 
-    test('card prerender waits for query fallback search and nested relationship loads', async function (assert) {
-      const cardURL = `${realmURL}directory-ops`;
-      let realmServerPatch =
-        installRealmServerAssertOwnRealmServerBypassPatch();
-      let delayedSearchPatch = installDelayedRuntimeRealmSearchPatch(150);
-      try {
+      test('card prerender surfaces runtime render errors without timing out', async function (assert) {
+        let cardURL = `${realmURL}throws.json`;
+
+        let result = await prerenderer.prerenderCard({
+          realm: realmURL,
+          url: cardURL,
+          auth: auth(),
+        });
+
+        assert.ok(result.response.error, 'prerender reports error');
+        assert.strictEqual(
+          result.response.error?.error.status,
+          500,
+          'runtime error surfaces as 500',
+        );
+        assert.ok(
+          result.response.error?.error.message?.includes('boom'),
+          `runtime error message includes thrown message, got: ${result.response.error?.error.message}`,
+        );
+        assert.false(
+          result.pool.timedOut,
+          'runtime error should not be mistaken for timeout',
+        );
+        assert.true(
+          result.pool.evicted,
+          'runtime error evicts prerender page to recover clean state',
+        );
+      });
+
+      test('card prerender includes console errors when render fails', async function (assert) {
+        let cardURL = `${realmURL}console-error.json`;
+
+        let result = await prerenderer.prerenderCard({
+          realm: realmURL,
+          url: cardURL,
+          auth: auth(),
+        });
+
+        assert.ok(result.response.error, 'prerender reports error');
+        let additionalErrors = result.response.error?.error.additionalErrors;
+        assert.ok(
+          Array.isArray(additionalErrors),
+          'additionalErrors includes console errors',
+        );
+        assert.ok(
+          additionalErrors?.some(
+            (error) =>
+              typeof error?.message === 'string' &&
+              error.message.includes('console boom'),
+          ),
+          'console error message is captured',
+        );
+      });
+
+      test('card prerender ignores console errors on success', async function (assert) {
+        let cardURL = `${realmURL}console-no-error.json`;
+
         let result = await prerenderer.prerenderCard({
           realm: realmURL,
           url: cardURL,
@@ -1201,213 +1160,349 @@ module(basename(__filename), function () {
         });
 
         assert.notOk(result.response.error, 'prerender succeeds');
-        assert.true(
-          delayedSearchPatch.getRequestCount() > 0,
-          'fallback _search requests occurred and were delayed',
-        );
+      });
 
-        let isolatedHTML = cleanWhiteSpace(result.response.isolatedHTML ?? '');
-        assert.ok(
-          /data-test-staff-name[^>]*>\s*Bob\s*</.test(isolatedHTML),
-          `isolated html includes query results: ${isolatedHTML}`,
-        );
-        assert.ok(
-          /data-test-staff-manager[^>]*>\s*Alice\s*</.test(isolatedHTML),
-          `isolated html includes lazy relationship from query result: ${isolatedHTML}`,
-        );
-        assert.ok(
-          /data-test-staff-report[^>]*>\s*Eve/.test(isolatedHTML),
-          `isolated html includes nested query results: ${isolatedHTML}`,
-        );
-        assert.ok(
-          /data-test-staff-report-manager[^>]*>\s*Bob\s*</.test(isolatedHTML),
-          `isolated html includes nested relationship loads: ${isolatedHTML}`,
-        );
-        assert.ok(
-          /id="heroGridPlane"/.test(isolatedHTML),
-          `isolated html includes hero grid container: ${isolatedHTML}`,
-        );
-        let heroMiniCards = isolatedHTML.match(/class="hero-mini-card"/g) ?? [];
-        assert.ok(
-          heroMiniCards.length >= 3,
-          `isolated html includes hero mini cards from query and nested query loads: ${isolatedHTML}`,
-        );
+      test('card prerender surfaces unhandled promise rejection without timing out', async function (assert) {
+        let cardURL = `${realmURL}rejects.json`;
 
-        let staff = result.response.searchDoc?.staff as
-          | Array<Record<string, any>>
-          | undefined;
-        assert.ok(
-          Array.isArray(staff),
-          'searchDoc includes query field results',
-        );
+        let result = await prerenderer.prerenderCard({
+          realm: realmURL,
+          url: cardURL,
+          auth: auth(),
+        });
 
-        let bob = staff?.find((entry) => entry?.name === 'Bob');
-        assert.ok(bob, 'searchDoc includes Bob from query results');
+        assert.ok(result.response.error, 'prerender reports error');
         assert.strictEqual(
-          bob?.manager?.name,
-          'Alice',
-          'searchDoc includes loaded manager relationship',
+          result.response.error?.error.status,
+          500,
+          'unhandled rejection surfaces as 500',
         );
-
-        let bobReports = bob?.reports as Array<Record<string, any>> | undefined;
         assert.ok(
-          Array.isArray(bobReports),
-          'searchDoc includes nested query results',
+          result.response.error?.error.message?.includes('reject boom'),
+          `unhandled rejection message includes thrown message, got: ${result.response.error?.error.message}`,
         );
-        let hasEveWithManager = bobReports?.some(
-          (report) => report?.name === 'Eve' && report?.manager?.name === 'Bob',
+        assert.false(
+          result.pool.timedOut,
+          'unhandled rejection should not be mistaken for timeout',
         );
         assert.true(
-          Boolean(hasEveWithManager),
-          'searchDoc includes nested loaded relationships',
+          result.pool.evicted,
+          'unhandled rejection evicts prerender page to recover clean state',
         );
-      } finally {
-        await realmServerPatch.restore();
-        delayedSearchPatch.restore();
-      }
+      });
+
+      test('card prerender surfaces RSVP rejection without timing out', async function (assert) {
+        let cardURL = `${realmURL}rsvp-rejects.json`;
+
+        let result = await prerenderer.prerenderCard({
+          realm: realmURL,
+          url: cardURL,
+          auth: auth(),
+        });
+
+        assert.ok(result.response.error, 'prerender reports RSVP rejection');
+        assert.strictEqual(
+          result.response.error?.error.status,
+          500,
+          'RSVP rejection surfaces as 500',
+        );
+        assert.ok(
+          result.response.error?.error.message?.includes('rsvp boom'),
+          `RSVP rejection message includes thrown message, got: ${result.response.error?.error.message}`,
+        );
+        assert.false(
+          result.pool.timedOut,
+          'RSVP rejection should not be mistaken for timeout',
+        );
+        assert.true(
+          result.pool.evicted,
+          'RSVP rejection evicts prerender page to recover clean state',
+        );
+      });
+
+      test('card prerender surfaces errors thrown before the render model hook', async function (assert) {
+        let originalGetPage = PagePool.prototype.getPage;
+        try {
+          PagePool.prototype.getPage = async function (
+            this: PagePool,
+            realm: string,
+          ) {
+            let pageInfo = await originalGetPage.call(this, realm);
+            let page = pageInfo.page as any;
+            let originalEvaluate = page?.evaluate?.bind(page);
+            if (originalEvaluate) {
+              let injected = false;
+              page.evaluate = async (...args: any[]) => {
+                if (!injected) {
+                  injected = true;
+                  await originalEvaluate(() => {
+                    let entries =
+                      (window as any).requirejs?.entries ??
+                      (window as any).require?.entries ??
+                      (window as any)._eak_seen;
+                    let renderModuleName =
+                      entries &&
+                      Object.keys(entries).find((name) =>
+                        name.endsWith('/routes/render'),
+                      );
+                    if (!renderModuleName) {
+                      throw new Error(
+                        'render route module not found for injection',
+                      );
+                    }
+                    let renderRouteModule = (window as any).require(
+                      renderModuleName,
+                    );
+                    let RenderRouteClass = renderRouteModule?.default;
+                    if (!RenderRouteClass?.prototype) {
+                      throw new Error(
+                        'render route class not found for injection',
+                      );
+                    }
+                    let originalBeforeModel =
+                      RenderRouteClass.prototype.beforeModel;
+                    RenderRouteClass.prototype.beforeModel = async function (
+                      ...bmArgs: any[]
+                    ) {
+                      if (originalBeforeModel) {
+                        await originalBeforeModel.apply(this, bmArgs as any);
+                      }
+                      RenderRouteClass.prototype.beforeModel =
+                        originalBeforeModel;
+                      throw new Error('boom before model');
+                    };
+                  });
+                }
+                return originalEvaluate(...args);
+              };
+            }
+            return { ...pageInfo, page };
+          };
+
+          let result = await prerenderer.prerenderCard({
+            realm: realmURL,
+            url: `${realmURL}1.json`,
+            auth: auth(),
+          });
+
+          assert.ok(result.response.error, 'prerender reports error');
+          assert.ok(
+            result.response.error?.error.message?.includes('boom before model'),
+            'captures error thrown before model hook',
+          );
+          assert.true(
+            result.pool.evicted,
+            'pre-model error evicts prerender page for clean state',
+          );
+          assert.true(
+            (result.response.error as any)?.evict,
+            'error payload flags eviction',
+          );
+          assert.false(result.pool.timedOut, 'error is not treated as timeout');
+          let errorDeps = result.response.error?.error.deps;
+          assert.notStrictEqual(
+            errorDeps,
+            null,
+            'pre-model short-circuit error includes non-null deps',
+          );
+          let deps = errorDeps ?? [];
+          assert.true(
+            Array.isArray(deps),
+            'pre-model short-circuit deps are an array',
+          );
+          assert.true(
+            [`${realmURL}1.json`, `${realmURL}1`].some((dep) =>
+              deps.includes(dep),
+            ),
+            `pre-model fallback error includes dep context from transition params (deps: ${JSON.stringify(deps)})`,
+          );
+        } finally {
+          PagePool.prototype.getPage = originalGetPage;
+        }
+      });
+
+      test('card prerender waits for query fallback search and nested relationship loads', async function (assert) {
+        const cardURL = `${realmURL}directory-ops`;
+        let realmServerPatch =
+          installRealmServerAssertOwnRealmServerBypassPatch();
+        let delayedSearchPatch = installDelayedRuntimeRealmSearchPatch(150);
+        try {
+          let result = await prerenderer.prerenderCard({
+            realm: realmURL,
+            url: cardURL,
+            auth: auth(),
+          });
+
+          assert.notOk(result.response.error, 'prerender succeeds');
+          assert.true(
+            delayedSearchPatch.getRequestCount() > 0,
+            'fallback _search requests occurred and were delayed',
+          );
+
+          let isolatedHTML = cleanWhiteSpace(
+            result.response.isolatedHTML ?? '',
+          );
+          assert.ok(
+            /data-test-staff-name[^>]*>\s*Bob\s*</.test(isolatedHTML),
+            `isolated html includes query results: ${isolatedHTML}`,
+          );
+          assert.ok(
+            /data-test-staff-manager[^>]*>\s*Alice\s*</.test(isolatedHTML),
+            `isolated html includes lazy relationship from query result: ${isolatedHTML}`,
+          );
+          assert.ok(
+            /data-test-staff-report[^>]*>\s*Eve/.test(isolatedHTML),
+            `isolated html includes nested query results: ${isolatedHTML}`,
+          );
+          assert.ok(
+            /data-test-staff-report-manager[^>]*>\s*Bob\s*</.test(isolatedHTML),
+            `isolated html includes nested relationship loads: ${isolatedHTML}`,
+          );
+          assert.ok(
+            /id="heroGridPlane"/.test(isolatedHTML),
+            `isolated html includes hero grid container: ${isolatedHTML}`,
+          );
+          let heroMiniCards =
+            isolatedHTML.match(/class="hero-mini-card"/g) ?? [];
+          assert.ok(
+            heroMiniCards.length >= 3,
+            `isolated html includes hero mini cards from query and nested query loads: ${isolatedHTML}`,
+          );
+
+          let staff = result.response.searchDoc?.staff as
+            | Array<Record<string, any>>
+            | undefined;
+          assert.ok(
+            Array.isArray(staff),
+            'searchDoc includes query field results',
+          );
+
+          let bob = staff?.find((entry) => entry?.name === 'Bob');
+          assert.ok(bob, 'searchDoc includes Bob from query results');
+          assert.strictEqual(
+            bob?.manager?.name,
+            'Alice',
+            'searchDoc includes loaded manager relationship',
+          );
+
+          let bobReports = bob?.reports as
+            | Array<Record<string, any>>
+            | undefined;
+          assert.ok(
+            Array.isArray(bobReports),
+            'searchDoc includes nested query results',
+          );
+          let hasEveWithManager = bobReports?.some(
+            (report) =>
+              report?.name === 'Eve' && report?.manager?.name === 'Bob',
+          );
+          assert.true(
+            Boolean(hasEveWithManager),
+            'searchDoc includes nested loaded relationships',
+          );
+        } finally {
+          await realmServerPatch.restore();
+          delayedSearchPatch.restore();
+        }
+      });
+
+      test('module prerender evicts pooled page on timeout', async function (assert) {
+        const moduleURL = `${realmURL}person.gts`;
+
+        let first = await prerenderer.prerenderModule({
+          realm: realmURL,
+          url: moduleURL,
+          auth: auth(),
+        });
+        assert.false(first.pool.reused, 'initial module render not reused');
+        assert.false(first.pool.evicted, 'initial module render not evicted');
+
+        let timedOut = await prerenderer.prerenderModule({
+          realm: realmURL,
+          url: moduleURL,
+          auth: auth(),
+          opts: { timeoutMs: 1, simulateTimeoutMs: 25 },
+        });
+
+        assert.strictEqual(
+          timedOut.response.status,
+          'error',
+          'timeout returns error response',
+        );
+        assert.strictEqual(
+          timedOut.response.error?.error.title,
+          'Render timeout',
+          'timeout surfaces render timeout title',
+        );
+        assert.strictEqual(
+          timedOut.response.error?.error.status,
+          504,
+          'timeout surfaces 504 status',
+        );
+        assert.true(timedOut.pool.timedOut, 'timeout flagged on pool');
+        assert.true(timedOut.pool.evicted, 'pool evicted after timeout');
+        assert.notStrictEqual(
+          timedOut.pool.pageId,
+          'unknown',
+          'timeout retains page identifier',
+        );
+
+        let afterTimeout = await prerenderer.prerenderModule({
+          realm: realmURL,
+          url: moduleURL,
+          auth: auth(),
+        });
+        assert.false(
+          afterTimeout.pool.reused,
+          'timeout eviction prevents reuse on next render',
+        );
+        assert.false(
+          afterTimeout.pool.evicted,
+          'no eviction on recovery render',
+        );
+        assert.false(afterTimeout.pool.timedOut, 'no timeout after recovery');
+        assert.strictEqual(
+          afterTimeout.response.status,
+          'ready',
+          'subsequent render succeeds',
+        );
+      });
+
+      test('file prerender returns extracted metadata', async function (assert) {
+        const fileURL = `${realmURL}notes.txt`;
+
+        let result = await prerenderer.prerenderFileExtract({
+          realm: realmURL,
+          url: fileURL,
+          auth: auth(),
+          renderOptions: { fileExtract: true },
+        });
+
+        assert.strictEqual(
+          result.response.status,
+          'ready',
+          'file extract reports ready',
+        );
+        assert.strictEqual(
+          result.response.searchDoc?.name,
+          'notes.txt',
+          'search doc includes name',
+        );
+        assert.ok(
+          result.response.deps.includes(`${baseRealm.url}file-api`),
+          'deps include base file-api module',
+        );
+        assert.notOk(
+          result.response.deps.includes(fileURL),
+          'deps exclude the file url itself',
+        );
+      });
     });
+  }
 
-    test('module prerender evicts pooled page on timeout', async function (assert) {
-      const moduleURL = `${realmURL}person.gts`;
-
-      let first = await prerenderer.prerenderModule({
-        realm: realmURL,
-        url: moduleURL,
-        auth: auth(),
-      });
-      assert.false(first.pool.reused, 'initial module render not reused');
-      assert.false(first.pool.evicted, 'initial module render not evicted');
-
-      let timedOut = await prerenderer.prerenderModule({
-        realm: realmURL,
-        url: moduleURL,
-        auth: auth(),
-        opts: { timeoutMs: 1, simulateTimeoutMs: 25 },
-      });
-
-      assert.strictEqual(
-        timedOut.response.status,
-        'error',
-        'timeout returns error response',
-      );
-      assert.strictEqual(
-        timedOut.response.error?.error.title,
-        'Render timeout',
-        'timeout surfaces render timeout title',
-      );
-      assert.strictEqual(
-        timedOut.response.error?.error.status,
-        504,
-        'timeout surfaces 504 status',
-      );
-      assert.true(timedOut.pool.timedOut, 'timeout flagged on pool');
-      assert.true(timedOut.pool.evicted, 'pool evicted after timeout');
-      assert.notStrictEqual(
-        timedOut.pool.pageId,
-        'unknown',
-        'timeout retains page identifier',
-      );
-
-      let afterTimeout = await prerenderer.prerenderModule({
-        realm: realmURL,
-        url: moduleURL,
-        auth: auth(),
-      });
-      assert.false(
-        afterTimeout.pool.reused,
-        'timeout eviction prevents reuse on next render',
-      );
-      assert.false(afterTimeout.pool.evicted, 'no eviction on recovery render');
-      assert.false(afterTimeout.pool.timedOut, 'no timeout after recovery');
-      assert.strictEqual(
-        afterTimeout.response.status,
-        'ready',
-        'subsequent render succeeds',
-      );
-    });
-
-    test('file prerender returns extracted metadata', async function (assert) {
-      const fileURL = `${realmURL}notes.txt`;
-
-      let result = await prerenderer.prerenderFileExtract({
-        realm: realmURL,
-        url: fileURL,
-        auth: auth(),
-        renderOptions: { fileExtract: true },
-      });
-
-      assert.strictEqual(
-        result.response.status,
-        'ready',
-        'file extract reports ready',
-      );
-      assert.strictEqual(
-        result.response.searchDoc?.name,
-        'notes.txt',
-        'search doc includes name',
-      );
-      assert.ok(
-        result.response.deps.includes(`${baseRealm.url}file-api`),
-        'deps include base file-api module',
-      );
-      assert.notOk(
-        result.response.deps.includes(fileURL),
-        'deps exclude the file url itself',
-      );
-    });
-
-    test('file extract surfaces broken FileDef module error without remote prerender timeout', async function (assert) {
-      await realmAdapter.write(
-        'filedef-mismatch.gts',
-        `
-          import { FileDef as BaseFileDef } from "https://cardstack.com/base/file-api";
-          import { MissingChild } from "./missing-child";
-
-          export class FileDef extends BaseFileDef {
-            static missingChild = MissingChild;
-          }
-        `,
-      );
-      await realmAdapter.write('broken-file.mismatch', 'broken mismatch file');
-      realm.__testOnlyClearCaches();
-
-      let result = await prerenderer.prerenderFileExtract({
-        realm: realmURL,
-        url: `${realmURL}broken-file.mismatch`,
-        auth: auth(),
-        renderOptions: {
-          fileExtract: true,
-          fileDefCodeRef: {
-            module: `${realmURL}filedef-mismatch`,
-            name: 'FileDef',
-          },
-        },
-      });
-
-      assert.strictEqual(
-        result.response.status,
-        'error',
-        'file extract reports error for broken FileDef module',
-      );
-      assert.ok(result.response.error, 'error payload is present');
-      assert.ok(
-        result.response.error?.error.message?.includes(
-          'Received HTTP 404 from server',
-        ),
-        `error message should mention module 404, got: ${result.response.error?.error.message}`,
-      );
-      let messageIncludesTimeoutMarker = Boolean(
-        result.response.error?.error.message?.includes('Prerender request to'),
-      );
-      assert.false(
-        messageIncludesTimeoutMarker,
-        'error should not be reported as a remote prerender request timeout',
-      );
-      assert.false(
-        result.pool.timedOut,
-        'pool should not mark this as a prerender timeout',
-      );
-    });
+  module('prerender - non-mutating tests', function () {
+    defineNonMutatingRunnerTests();
+    defineNonMutatingStaticTests();
   });
 
   module('prerender - permissioned auth failures', function (hooks) {
@@ -1416,7 +1511,7 @@ module(basename(__filename), function () {
     let prerenderServerURL = new URL(consumerRealmURL).origin;
     let testUserId = '@user1:localhost';
     let permissions: RealmPermissions = {};
-    let permissionedRealms: RuntimeRealm[] = [];
+    let indexingReady: Promise<void> = Promise.resolve();
     let prerenderer: Prerenderer;
     let auth = () => testCreatePrerenderAuth(testUserId, permissions);
 
@@ -1431,7 +1526,8 @@ module(basename(__filename), function () {
       await prerenderer.stop();
     });
 
-    hooks.beforeEach(function () {
+    hooks.beforeEach(async function () {
+      await indexingReady;
       permissions = {
         [consumerRealmURL]: ['read', 'write', 'realm-owner'],
       };
@@ -1544,23 +1640,13 @@ module(basename(__filename), function () {
         },
       ],
       onRealmSetup({ realms }) {
-        permissionedRealms = realms.map(({ realm }) => realm);
+        indexingReady = Promise.all(
+          realms.map(({ realm }) => realm.indexing()),
+        ).then(() => undefined);
         permissions = {
           [consumerRealmURL]: ['read', 'write', 'realm-owner'],
         };
       },
-    });
-
-    hooks.before(async function () {
-      // setupPermissionedRealms(..., { mode: 'before' }) registers its own
-      // hooks.before that runs first and populates permissionedRealms via
-      // onRealmSetup(). This guard makes that ordering contract explicit.
-      if (permissionedRealms.length === 0) {
-        throw new Error(
-          'expected permissionedRealms to be populated before indexing wait',
-        );
-      }
-      await Promise.all(permissionedRealms.map((realm) => realm.indexing()));
     });
 
     test('module prerender surfaces auth error without timing out', async function (assert) {
@@ -1814,7 +1900,7 @@ module(basename(__filename), function () {
     });
 
     setupPermissionedRealms(hooks, {
-      mode: 'beforeEach',
+      mode: 'before',
       realms: [
         {
           realmURL: publicRealmURL,
@@ -2004,7 +2090,7 @@ module(basename(__filename), function () {
       });
 
       setupPermissionedRealms(hooks, {
-        mode: 'beforeEach',
+        mode: 'before',
         realms: [
           {
             realmURL: privateRealmURL,
@@ -2080,44 +2166,45 @@ module(basename(__filename), function () {
     },
   );
 
-  module('prerender - static tests', function (hooks) {
-    let realmURL1 = 'http://127.0.0.1:4447/test/';
-    let realmURL2 = 'http://127.0.0.1:4448/test/';
-    let realmURL3 = 'http://127.0.0.1:4449/test/';
-    let prerenderServerURL = new URL(realmURL1).origin;
-    let testUserId = '@user1:localhost';
-    let permissions: RealmPermissions = {};
-    let prerenderer: Prerenderer;
-    let auth = () => testCreatePrerenderAuth(testUserId, permissions);
-    const disposeAllRealms = async () => {
-      await Promise.all([
-        prerenderer.disposeRealm(realmURL1),
-        prerenderer.disposeRealm(realmURL2),
-        prerenderer.disposeRealm(realmURL3),
-      ]);
-    };
+  function defineNonMutatingStaticTests() {
+    module('formats and pooling', function (hooks) {
+      let realmURL1 = 'http://127.0.0.1:4447/test/';
+      let realmURL2 = 'http://127.0.0.1:4448/test/';
+      let realmURL3 = 'http://127.0.0.1:4449/test/';
+      let prerenderServerURL = new URL(realmURL1).origin;
+      let testUserId = '@user1:localhost';
+      let permissions: RealmPermissions = {};
+      let prerenderer: Prerenderer;
+      let auth = () => testCreatePrerenderAuth(testUserId, permissions);
+      const disposeAllRealms = async () => {
+        await Promise.all([
+          prerenderer.disposeRealm(realmURL1),
+          prerenderer.disposeRealm(realmURL2),
+          prerenderer.disposeRealm(realmURL3),
+        ]);
+      };
 
-    hooks.before(async function () {
-      prerenderer = getPrerendererForTesting({
-        maxPages: 2,
-        serverURL: prerenderServerURL,
+      hooks.before(async function () {
+        prerenderer = getPrerendererForTesting({
+          maxPages: 2,
+          serverURL: prerenderServerURL,
+        });
       });
-    });
 
-    hooks.after(async function () {
-      await prerenderer.stop();
-    });
+      hooks.after(async function () {
+        await prerenderer.stop();
+      });
 
-    setupPermissionedRealms(hooks, {
-      mode: 'before',
-      realms: [
-        {
-          realmURL: realmURL1,
-          permissions: {
-            [testUserId]: ['read', 'write', 'realm-owner'],
-          },
-          fileSystem: {
-            'person.gts': `
+      setupPermissionedRealms(hooks, {
+        mode: 'before',
+        realms: [
+          {
+            realmURL: realmURL1,
+            permissions: {
+              [testUserId]: ['read', 'write', 'realm-owner'],
+            },
+            fileSystem: {
+              'person.gts': `
               import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
               import { Component } from 'https://cardstack.com/base/card-api';
               export class Person extends CardDef {
@@ -2126,57 +2213,57 @@ module(basename(__filename), function () {
                 static fitted = <template><@fields.name/></template>
               }
             `,
-            '1.json': {
-              data: {
-                attributes: {
-                  name: 'Hassan',
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './person',
-                    name: 'Person',
+              '1.json': {
+                data: {
+                  attributes: {
+                    name: 'Hassan',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './person',
+                      name: 'Person',
+                    },
                   },
                 },
               },
-            },
-            '2.json': {
-              data: {
-                attributes: {
-                  name: 'Mango',
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './person',
-                    name: 'Person',
+              '2.json': {
+                data: {
+                  attributes: {
+                    name: 'Mango',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './person',
+                      name: 'Person',
+                    },
                   },
                 },
               },
             },
           },
-        },
-        {
-          realmURL: realmURL2,
-          permissions: {
-            [testUserId]: ['read', 'write', 'realm-owner'],
-          },
-          fileSystem: {
-            'broken-card.gts': `
+          {
+            realmURL: realmURL2,
+            permissions: {
+              [testUserId]: ['read', 'write', 'realm-owner'],
+            },
+            fileSystem: {
+              'broken-card.gts': `
               import {
             `,
-            'broken.json': {
-              data: {
-                attributes: {
-                  name: 'Broken',
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './broken-card',
+              'broken.json': {
+                data: {
+                  attributes: {
                     name: 'Broken',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './broken-card',
+                      name: 'Broken',
+                    },
                   },
                 },
               },
-            },
-            'cat.gts': `
+              'cat.gts': `
               import { CardDef, field, contains, linksTo, StringField } from 'https://cardstack.com/base/card-api';
               import { Component } from 'https://cardstack.com/base/card-api';
               import { Person } from '${realmURL1}person';
@@ -2187,7 +2274,7 @@ module(basename(__filename), function () {
                 static embedded = <template>{{@fields.name}} says Meow. owned by <@fields.owner /></template>
               }
             `,
-            'dog.gts': `
+              'dog.gts': `
               import { CardDef, field, contains, linksTo, StringField, Component } from 'https://cardstack.com/base/card-api';
               import { Person } from '${realmURL1}person';
               export class Dog extends CardDef {
@@ -2200,7 +2287,7 @@ module(basename(__filename), function () {
                 }
               }
             `,
-            'dog-many.gts': `
+              'dog-many.gts': `
               import { CardDef, field, contains, linksToMany, StringField, Component } from 'https://cardstack.com/base/card-api';
               import { Person } from '${realmURL1}person';
               export class DogMany extends CardDef {
@@ -2213,7 +2300,7 @@ module(basename(__filename), function () {
                 }
               }
             `,
-            'dog-profile.gts': `
+              'dog-profile.gts': `
               import { CardDef, FieldDef, field, contains, linksTo, linksToMany, StringField, Component } from 'https://cardstack.com/base/card-api';
               import { Person } from '${realmURL1}person';
 
@@ -2232,127 +2319,229 @@ module(basename(__filename), function () {
                 }
               }
             `,
-            '1.json': {
-              data: {
-                attributes: {
-                  name: 'Maple',
-                },
-                relationships: {
-                  owner: {
-                    links: { self: `${realmURL1}1` },
+              'non-isolated-links-card.gts': `
+              import { CardDef, FieldDef, field, contains, linksTo, linksToMany, StringField, Component } from 'https://cardstack.com/base/card-api';
+              import { Person } from '${realmURL1}person';
+
+              class RelationshipField extends FieldDef {
+                @field lead = linksTo(Person);
+                @field members = linksToMany(Person);
+              }
+
+              export class NonIsolatedLinks extends CardDef {
+                static displayName = 'Non Isolated Links';
+                @field name = contains(StringField);
+                @field owner = linksTo(Person);
+                @field owners = linksToMany(Person);
+                @field profile = contains(RelationshipField);
+
+                static isolated = class extends Component<typeof this> {
+                  <template><div data-test-isolated-name>{{@model.name}}</div></template>
+                };
+
+                static embedded = class extends Component<typeof this> {
+                  <template>
+                    <div data-test-embedded-owner>
+                      <span data-test-embedded-owner>{{@model.owner.name}}</span>
+                    </div>
+                    <div data-test-embedded-owners>
+                      {{#each @model.owners as |owner|}}
+                        <span data-test-embedded-owner-name>{{owner.name}}</span>
+                      {{/each}}
+                    </div>
+                    <div data-test-embedded-profile-lead>
+                      <span data-test-embedded-profile-lead-name>{{@model.profile.lead.name}}</span>
+                    </div>
+                    <div data-test-embedded-profile-members>
+                      {{#each @model.profile.members as |member|}}
+                        <span data-test-embedded-profile-member-name>{{member.name}}</span>
+                      {{/each}}
+                    </div>
+                  </template>
+                };
+              }
+            `,
+              '1.json': {
+                data: {
+                  attributes: {
+                    name: 'Maple',
                   },
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './cat',
-                    name: 'Cat',
+                  relationships: {
+                    owner: {
+                      links: { self: `${realmURL1}1` },
+                    },
                   },
-                },
-              },
-            },
-            'is-used.json': {
-              data: {
-                attributes: {
-                  name: 'Mango',
-                },
-                relationships: {
-                  owner: {
-                    links: { self: `${realmURL1}1` },
-                  },
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './dog',
-                    name: 'Dog',
-                  },
-                },
-              },
-            },
-            'is-used-many.json': {
-              data: {
-                attributes: {
-                  name: 'Mango Many',
-                },
-                relationships: {
-                  'owners.0': {
-                    links: { self: `${realmURL1}1` },
-                  },
-                  'owners.1': {
-                    links: { self: `${realmURL1}2` },
-                  },
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './dog-many',
-                    name: 'DogMany',
-                  },
-                },
-              },
-            },
-            'is-used-field-def.json': {
-              data: {
-                attributes: {
-                  name: 'Mango Profile',
-                  profile: {},
-                },
-                relationships: {
-                  'profile.primaryOwner': {
-                    links: { self: `${realmURL1}1` },
-                  },
-                  'profile.caretakers.0': {
-                    links: { self: `${realmURL1}1` },
-                  },
-                  'profile.caretakers.1': {
-                    links: { self: `${realmURL1}2` },
-                  },
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './dog-profile',
-                    name: 'DogProfile',
-                  },
-                },
-              },
-            },
-            'missing-link.json': {
-              data: {
-                attributes: {
-                  name: 'Missing Owner',
-                },
-                relationships: {
-                  owner: {
-                    links: { self: `${realmURL1}missing-owner` },
-                  },
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './cat',
-                    name: 'Cat',
-                  },
-                },
-              },
-            },
-            'fetch-failed.json': {
-              data: {
-                attributes: {
-                  name: 'Missing Owner',
-                },
-                relationships: {
-                  owner: {
-                    links: {
-                      self: 'http://localhost:9000/this-is-a-link-to-nowhere',
+                  meta: {
+                    adoptsFrom: {
+                      module: './cat',
+                      name: 'Cat',
                     },
                   },
                 },
-                meta: {
-                  adoptsFrom: {
-                    module: './cat',
-                    name: 'Cat',
+              },
+              'is-used.json': {
+                data: {
+                  attributes: {
+                    name: 'Mango',
+                  },
+                  relationships: {
+                    owner: {
+                      links: { self: `${realmURL1}1` },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './dog',
+                      name: 'Dog',
+                    },
                   },
                 },
               },
-            },
-            'intentional-error.gts': `
+              'is-used-many.json': {
+                data: {
+                  attributes: {
+                    name: 'Mango Many',
+                  },
+                  relationships: {
+                    'owners.0': {
+                      links: { self: `${realmURL1}1` },
+                    },
+                    'owners.1': {
+                      links: { self: `${realmURL1}2` },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './dog-many',
+                      name: 'DogMany',
+                    },
+                  },
+                },
+              },
+              'is-used-field-def.json': {
+                data: {
+                  attributes: {
+                    name: 'Mango Profile',
+                    profile: {},
+                  },
+                  relationships: {
+                    'profile.primaryOwner': {
+                      links: { self: `${realmURL1}1` },
+                    },
+                    'profile.caretakers.0': {
+                      links: { self: `${realmURL1}1` },
+                    },
+                    'profile.caretakers.1': {
+                      links: { self: `${realmURL1}2` },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './dog-profile',
+                      name: 'DogProfile',
+                    },
+                  },
+                },
+              },
+              'non-isolated-links.json': {
+                data: {
+                  attributes: {
+                    name: 'Mango Non Isolated',
+                    profile: {},
+                    cardInfo: {
+                      name: null,
+                      summary: null,
+                      cardThumbnailURL: null,
+                      notes: null,
+                    },
+                  },
+                  relationships: {
+                    'cardInfo.theme': {
+                      links: { self: `${realmURL2}non-isolated-theme` },
+                    },
+                    owner: {
+                      links: { self: `${realmURL1}1` },
+                    },
+                    'owners.0': {
+                      links: { self: `${realmURL1}1` },
+                    },
+                    'owners.1': {
+                      links: { self: `${realmURL1}2` },
+                    },
+                    'profile.lead': {
+                      links: { self: `${realmURL1}1` },
+                    },
+                    'profile.members.0': {
+                      links: { self: `${realmURL1}1` },
+                    },
+                    'profile.members.1': {
+                      links: { self: `${realmURL1}2` },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './non-isolated-links-card',
+                      name: 'NonIsolatedLinks',
+                    },
+                  },
+                },
+              },
+              'non-isolated-theme.json': {
+                data: {
+                  type: 'card',
+                  attributes: {
+                    markUsage: {
+                      socialMediaProfileIcon:
+                        'https://example.com/non-isolated-social-icon.png',
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: 'https://cardstack.com/base/brand-guide',
+                      name: 'default',
+                    },
+                  },
+                },
+              },
+              'missing-link.json': {
+                data: {
+                  attributes: {
+                    name: 'Missing Owner',
+                  },
+                  relationships: {
+                    owner: {
+                      links: { self: `${realmURL1}missing-owner` },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './cat',
+                      name: 'Cat',
+                    },
+                  },
+                },
+              },
+              'fetch-failed.json': {
+                data: {
+                  attributes: {
+                    name: 'Missing Owner',
+                  },
+                  relationships: {
+                    owner: {
+                      links: {
+                        self: 'http://localhost:9000/this-is-a-link-to-nowhere',
+                      },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './cat',
+                      name: 'Cat',
+                    },
+                  },
+                },
+              },
+              'intentional-error.gts': `
               import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
               import { Component } from 'https://cardstack.com/base/card-api';
               export class IntentionalError extends CardDef {
@@ -2369,20 +2558,20 @@ module(basename(__filename), function () {
                 }
               }
             `,
-            '2.json': {
-              data: {
-                attributes: {
-                  name: 'Intentional Error',
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './intentional-error',
-                    name: 'IntentionalError',
+              '2.json': {
+                data: {
+                  attributes: {
+                    name: 'Intentional Error',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './intentional-error',
+                      name: 'IntentionalError',
+                    },
                   },
                 },
               },
-            },
-            'timer-error-card.gts': `
+              'timer-error-card.gts': `
               import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
               import { Component } from 'https://cardstack.com/base/card-api';
               export class TimerError extends CardDef {
@@ -2398,20 +2587,20 @@ module(basename(__filename), function () {
                 }
               }
             `,
-            'timer-error.json': {
-              data: {
-                attributes: {
-                  name: 'Timer Error',
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './timer-error-card',
-                    name: 'TimerError',
+              'timer-error.json': {
+                data: {
+                  attributes: {
+                    name: 'Timer Error',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './timer-error-card',
+                      name: 'TimerError',
+                    },
                   },
                 },
               },
-            },
-            'timer-timeout-card.gts': `
+              'timer-timeout-card.gts': `
               import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
               import { Component } from 'https://cardstack.com/base/card-api';
               setTimeout(() => {}, 0);
@@ -2429,24 +2618,24 @@ module(basename(__filename), function () {
                 }
               }
             `,
-            'timer-timeout.json': {
-              data: {
-                attributes: {
-                  name: 'Timer Timeout',
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './timer-timeout-card',
-                    name: 'TimerTimeout',
+              'timer-timeout.json': {
+                data: {
+                  attributes: {
+                    name: 'Timer Timeout',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './timer-timeout-card',
+                      name: 'TimerTimeout',
+                    },
                   },
                 },
               },
-            },
-            // A card that fires the boxel-render-error event (handled by the prerender route)
-            // and then blocks the event loop long enough that Ember health probe times out,
-            // causing data-prerender-status to be set to 'unusable' by the error handler without
-            // transitioning to the render-error route (so nothing overwrites our dataset).
-            'unusable-error.gts': `
+              // A card that fires the boxel-render-error event (handled by the prerender route)
+              // and then blocks the event loop long enough that Ember health probe times out,
+              // causing data-prerender-status to be set to 'unusable' by the error handler without
+              // transitioning to the render-error route (so nothing overwrites our dataset).
+              'unusable-error.gts': `
               import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
               import { Component } from 'https://cardstack.com/base/card-api';
               export class UnusableError extends CardDef {
@@ -2460,20 +2649,20 @@ module(basename(__filename), function () {
                 }
               }
             `,
-            '3.json': {
-              data: {
-                attributes: {
-                  name: 'Force Unusable',
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './unusable-error',
-                    name: 'UnusableError',
+              '3.json': {
+                data: {
+                  attributes: {
+                    name: 'Force Unusable',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './unusable-error',
+                      name: 'UnusableError',
+                    },
                   },
                 },
               },
-            },
-            'embedded-error.gts': `
+              'embedded-error.gts': `
               import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
               export class EmbeddedError extends CardDef {
                 @field name = contains(StringField);
@@ -2494,28 +2683,28 @@ module(basename(__filename), function () {
 </template>
               }
             `,
-            '4.json': {
-              data: {
-                attributes: {
-                  name: 'Embedded Error',
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './embedded-error',
-                    name: 'EmbeddedError',
+              '4.json': {
+                data: {
+                  attributes: {
+                    name: 'Embedded Error',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './embedded-error',
+                      name: 'EmbeddedError',
+                    },
                   },
                 },
               },
             },
           },
-        },
-        {
-          realmURL: realmURL3,
-          permissions: {
-            [testUserId]: ['read', 'write', 'realm-owner'],
-          },
-          fileSystem: {
-            'dog.gts': `
+          {
+            realmURL: realmURL3,
+            permissions: {
+              [testUserId]: ['read', 'write', 'realm-owner'],
+            },
+            fileSystem: {
+              'dog.gts': `
               import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
               import { Component } from 'https://cardstack.com/base/card-api';
               export class Dog extends CardDef {
@@ -2524,1249 +2713,1359 @@ module(basename(__filename), function () {
                 static embedded = <template>{{@fields.name}} wags tail</template>
               }
             `,
-            '1.json': {
-              data: {
-                attributes: {
-                  name: 'Taro',
-                },
-                meta: {
-                  adoptsFrom: {
-                    module: './dog',
-                    name: 'Dog',
+              '1.json': {
+                data: {
+                  attributes: {
+                    name: 'Taro',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './dog',
+                      name: 'Dog',
+                    },
                   },
                 },
               },
             },
           },
+        ],
+        onRealmSetup: () => {
+          permissions = {
+            [realmURL1]: ['read', 'write', 'realm-owner'],
+            [realmURL2]: ['read', 'write', 'realm-owner'],
+            [realmURL3]: ['read', 'write', 'realm-owner'],
+          };
         },
-      ],
-      onRealmSetup: () => {
-        permissions = {
-          [realmURL1]: ['read', 'write', 'realm-owner'],
-          [realmURL2]: ['read', 'write', 'realm-owner'],
-          [realmURL3]: ['read', 'write', 'realm-owner'],
-        };
-      },
-    });
+      });
 
-    module('basics', function (hooks) {
-      hooks.beforeEach(disposeAllRealms);
-      let result: RenderResponse;
+      module('basics', function (hooks) {
+        hooks.beforeEach(disposeAllRealms);
+        let result: RenderResponse;
 
-      hooks.before(async () => {
-        const testCardURL = `${realmURL2}1`;
-        let { response } = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
+        hooks.before(async () => {
+          const testCardURL = `${realmURL2}1`;
+          let { response } = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+          });
+          result = response;
         });
-        result = response;
-      });
 
-      test('embedded HTML', function (assert) {
-        assert.ok(
-          /Maple\s+says\s+Meow/.test(
-            cleanWhiteSpace(result.embeddedHTML![`${realmURL2}cat/Cat`]),
-          ),
-          `failed to match embedded html:${JSON.stringify(result.embeddedHTML)}`,
-        );
-      });
-
-      test('parent embedded HTML', function (assert) {
-        assert.ok(
-          /data-test-card-thumbnail-placeholder/.test(
-            result.embeddedHTML!['https://cardstack.com/base/card-api/CardDef'],
-          ),
-          `failed to match embedded html:${JSON.stringify(result.embeddedHTML)}`,
-        );
-      });
-
-      test('isolated HTML', function (assert) {
-        assert.ok(
-          /data-test-field="cardInfo-summary"/.test(result.isolatedHTML!),
-          `failed to match isolated html:${result.isolatedHTML}`,
-        );
-      });
-
-      test('atom HTML', function (assert) {
-        assert.ok(
-          /Untitled Cat/.test(result.atomHTML!),
-          `failed to match atom html:${result.atomHTML}`,
-        );
-      });
-
-      test('icon HTML', function (assert) {
-        assert.ok(
-          result.iconHTML?.startsWith('<svg'),
-          `iconHTML: ${result.iconHTML}`,
-        );
-      });
-
-      test('head HTML', function (assert) {
-        assert.ok(result.headHTML, 'headHTML should be present');
-        let cleanedHead = cleanWhiteSpace(result.headHTML!);
-
-        assert.ok(
-          cleanedHead.includes(
-            '<title data-test-card-head-title>Untitled Cat</title>',
-          ),
-          `failed to find title in head html:${cleanedHead}`,
-        );
-        assert.ok(
-          cleanedHead.includes('property="og:title" content="Untitled Cat"'),
-          `failed to find og:title in head html:${cleanedHead}`,
-        );
-        assert.ok(
-          cleanedHead.includes(`property="og:url" content="${realmURL2}1"`),
-          `failed to find og:url in head html:${cleanedHead}`,
-        );
-        assert.ok(
-          cleanedHead.includes('name="twitter:card" content="summary"'),
-          `failed to find twitter:card in head html:${cleanedHead}`,
-        );
-      });
-
-      test('serialized', function (assert) {
-        assert.strictEqual(result.serialized?.data.attributes?.name, 'Maple');
-      });
-
-      test('displayNames', function (assert) {
-        assert.deepEqual(result.displayNames, ['Cat', 'Card']);
-      });
-
-      test('deps', function (assert) {
-        // spot check a few deps, as the whole list is overwhelming...
-        assert.ok(
-          result.deps?.includes(baseCardRef.module),
-          `${baseCardRef.module} is a dep`,
-        );
-        assert.ok(
-          result.deps?.includes(`${realmURL1}person`),
-          `${realmURL1}person is a dep`,
-        );
-        assert.ok(
-          result.deps?.includes(`${realmURL2}cat`),
-          `${realmURL2}cat is a dep`,
-        );
-        assert.ok(
-          result.deps?.find((d) =>
-            d.match(
-              /^https:\/\/cardstack.com\/base\/card-api\.gts\..*glimmer-scoped\.css$/,
+        test('embedded HTML', function (assert) {
+          assert.ok(
+            /Maple\s+says\s+Meow/.test(
+              cleanWhiteSpace(result.embeddedHTML![`${realmURL2}cat/Cat`]),
             ),
-          ),
-          `glimmer scoped css from ${baseCardRef.module} is a dep`,
-        );
-      });
-
-      test('types', function (assert) {
-        assert.deepEqual(result.types, [
-          `${realmURL2}cat/Cat`,
-          'https://cardstack.com/base/card-api/CardDef',
-        ]);
-      });
-
-      test('searchDoc', function (assert) {
-        assert.strictEqual(result.searchDoc?.name, 'Maple');
-        assert.strictEqual(result.searchDoc?._cardType, 'Cat');
-        assert.strictEqual(result.searchDoc?.owner.name, 'Hassan');
-      });
-
-      test('isUsed field includes a field in search doc that is not rendered in template', async function (assert) {
-        const testCardURL = `${realmURL2}is-used`;
-        let { response } = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
-        });
-
-        assert.ok(
-          /Mango/.test(response.isolatedHTML!),
-          `failed to match isolated html:${response.isolatedHTML}`,
-        );
-        assert.false(
-          /data-test-field="owner"/.test(response.isolatedHTML!),
-          `owner field is not rendered in isolated html`,
-        );
-        assert.strictEqual(
-          response.searchDoc?.owner.name,
-          'Hassan',
-          'linked field is included in search doc via isUsed=true',
-        );
-      });
-
-      test('isUsed linksToMany field includes links in search doc that are not rendered in template', async function (assert) {
-        const testCardURL = `${realmURL2}is-used-many`;
-        let { response } = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
-        });
-
-        assert.ok(
-          /Mango Many/.test(response.isolatedHTML!),
-          `failed to match isolated html:${response.isolatedHTML}`,
-        );
-        assert.false(
-          /data-test-field="owners"/.test(response.isolatedHTML!),
-          `owners field is not rendered in isolated html`,
-        );
-        assert.strictEqual(
-          response.searchDoc?.owners?.[0]?.name,
-          'Hassan',
-          'first linked record is included in search doc via isUsed=true',
-        );
-        assert.strictEqual(
-          response.searchDoc?.owners?.[1]?.name,
-          'Mango',
-          'second linked record is included in search doc via isUsed=true',
-        );
-      });
-
-      test('isUsed compound field includes nested linksTo relationship in search doc', async function (assert) {
-        const testCardURL = `${realmURL2}is-used-field-def`;
-        let { response } = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
-        });
-
-        assert.ok(
-          /Mango Profile/.test(response.isolatedHTML!),
-          `failed to match isolated html:${response.isolatedHTML}`,
-        );
-        assert.false(
-          /data-test-field="profile"/.test(response.isolatedHTML!),
-          `profile field is not rendered in isolated html`,
-        );
-        assert.strictEqual(
-          response.searchDoc?.profile?.primaryOwner?.name,
-          'Hassan',
-          'nested linksTo relationship is included in search doc via isUsed=true on the relationship field',
-        );
-      });
-
-      test('isUsed compound field includes nested linksToMany relationships in search doc', async function (assert) {
-        const testCardURL = `${realmURL2}is-used-field-def`;
-        let { response } = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
-        });
-
-        assert.ok(
-          /Mango Profile/.test(response.isolatedHTML!),
-          `failed to match isolated html:${response.isolatedHTML}`,
-        );
-        assert.false(
-          /data-test-field="profile"/.test(response.isolatedHTML!),
-          `profile field is not rendered in isolated html`,
-        );
-        assert.strictEqual(
-          response.searchDoc?.profile?.caretakers?.[0]?.name,
-          'Hassan',
-          'first nested linksToMany relationship is included in search doc via isUsed=true on the relationship field',
-        );
-        assert.strictEqual(
-          response.searchDoc?.profile?.caretakers?.[1]?.name,
-          'Mango',
-          'second nested linksToMany relationship is included in search doc via isUsed=true on the relationship field',
-        );
-      });
-    });
-
-    module('errors', function (hooks) {
-      hooks.beforeEach(disposeAllRealms);
-      test('error during render', async function (assert) {
-        const testCardURL = `${realmURL2}2`;
-        let { response } = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
-        });
-        let { error, ...restOfResult } = response;
-
-        assert.strictEqual(error?.error.id, testCardURL);
-        assert.strictEqual(
-          error?.error.message,
-          'intentional failure during render',
-        );
-        assert.strictEqual(error?.error.status, 500);
-        assert.ok(error?.error.stack, 'stack trace exists in error');
-
-        // TODO Perhaps if we add error handlers for the /render/html subroute
-        // these all wont be empty, as this is triggering in the /render route
-        // error handler and hence stomping over all the subroutes.
-        assert.deepEqual(restOfResult, {
-          displayNames: null,
-          deps: null,
-          searchDoc: null,
-          serialized: null,
-          types: null,
-          atomHTML: null,
-          embeddedHTML: null,
-          fittedHTML: null,
-          headHTML: null,
-          iconHTML: null,
-          isolatedHTML: null,
-        });
-      });
-
-      test('error includes blocked timer summary when timers fire', async function (assert) {
-        const testCardURL = `${realmURL2}timer-error`;
-        let { response } = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
-        });
-
-        assert.ok(response.error, 'error present for timer error');
-        let message = response.error?.error.message ?? '';
-        assert.ok(
-          message.includes('timer error during render'),
-          `error message includes original error text, got: ${message}`,
-        );
-        let stack = response.error?.error.stack ?? '';
-        assert.ok(
-          stack.includes('Timers blocked during prerender'),
-          'timer summary appended to stack',
-        );
-        let timeoutMatch = stack.match(/setTimeout:\s+(\d+)/);
-        assert.ok(timeoutMatch, 'setTimeout count included');
-        assert.ok(
-          Number(timeoutMatch?.[1]) >= 1,
-          `expected at least one setTimeout, got: ${timeoutMatch?.[1]}`,
-        );
-        let intervalMatch = stack.match(/setInterval:\s+(\d+)/);
-        assert.ok(intervalMatch, 'setInterval count included');
-        assert.ok(
-          Number(intervalMatch?.[1]) >= 1,
-          `expected at least one setInterval, got: ${intervalMatch?.[1]}`,
-        );
-        assert.ok(
-          stack.includes('at get message'),
-          'timer summary includes a call stack',
-        );
-      });
-
-      test('timeout includes blocked timer summary in stack', async function (assert) {
-        const testCardURL = `${realmURL2}timer-timeout`;
-        await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
-        });
-        let { response } = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
-          opts: { timeoutMs: 1000, simulateTimeoutMs: 2000 },
-        });
-
-        assert.strictEqual(
-          response.error?.error.title,
-          'Render timeout',
-          'timeout surfaced',
-        );
-        let stack = response.error?.error.stack ?? '';
-        assert.ok(
-          stack.includes('Timers blocked during prerender'),
-          'timer summary appended to timeout stack',
-        );
-        assert.ok(
-          /setTimeout:\s+\d+/.test(stack),
-          'timeout stack includes setTimeout count',
-        );
-        assert.ok(
-          /setInterval:\s+\d+/.test(stack),
-          'timeout stack includes setInterval count',
-        );
-      });
-
-      test('missing link surfaces 404 without eviction', async function (assert) {
-        const testCardURL = `${realmURL2}missing-link`;
-        let result = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
-        });
-        let { response } = result;
-
-        assert.ok(response.error, 'error present for missing link');
-        assert.strictEqual(
-          response.error?.error.message,
-          `missing file ${realmURL1}missing-owner.json`,
-        );
-        assert.strictEqual(response.error?.error.status, 404);
-        assert.false(
-          result.pool.evicted,
-          'missing link does not evict prerender page',
-        );
-        assert.false(
-          result.pool.timedOut,
-          'missing link does not mark prerender timeout',
-        );
-      });
-
-      test('fetch failed surfaces error without eviction', async function (assert) {
-        const testCardURL = `${realmURL2}fetch-failed`;
-        let result = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
-        });
-        let { response } = result;
-
-        assert.ok(response.error, 'error present for fetch failed');
-        assert.strictEqual(
-          response.error?.error.message,
-          `unable to fetch http://localhost:9000/this-is-a-link-to-nowhere: fetch failed`,
-        );
-        assert.strictEqual(response.error?.error.status, 500);
-        assert.false(
-          result.pool.evicted,
-          'fetch failed does not evict prerender page',
-        );
-        assert.false(
-          result.pool.timedOut,
-          'fetch failed does not mark prerender timeout',
-        );
-      });
-
-      test('embedded error markup triggers render error', async function (assert) {
-        const testCardURL = `${realmURL2}4`;
-        let { response } = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
-        });
-        assert.ok(response.error, 'error captured');
-        assert.strictEqual(response.error?.error.id, 'embedded-error');
-        assert.strictEqual(
-          response.error?.error.message,
-          'error flagged from DOM',
-        );
-        assert.strictEqual(response.error?.error.title, 'Embedded error');
-        assert.strictEqual(response.error?.error.status, 500);
-      });
-
-      test('unusable triggers eviction and short-circuit', async function (assert) {
-        // Render the card that forces unusable
-        const unusableURL = `${realmURL2}3`;
-        let unusable = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: unusableURL,
-          auth: auth(),
-        });
-
-        // We should see an error with evict semantics and short-circuited payloads
-        assert.ok(unusable.response.error, 'error present for unusable');
-        assert.strictEqual(unusable.response.error?.error.id, unusableURL);
-        assert.strictEqual(
-          unusable.response.error?.error.message,
-          'forced unusable for test',
-        );
-        assert.strictEqual(unusable.response.error?.error.status, 500);
-        assert.strictEqual(
-          unusable.response.isolatedHTML,
-          null,
-          'isolatedHTML null when short-circuited',
-        );
-        assert.strictEqual(
-          unusable.response.embeddedHTML,
-          null,
-          'embeddedHTML null when short-circuited',
-        );
-        assert.strictEqual(
-          unusable.response.atomHTML,
-          null,
-          'atomHTML null when short-circuited',
-        );
-        assert.strictEqual(
-          unusable.response.iconHTML,
-          null,
-          'iconHTML null when short-circuited',
-        );
-        assert.deepEqual(
-          {
-            serialized: unusable.response.serialized,
-            searchDoc: unusable.response.searchDoc,
-            displayNames: unusable.response.displayNames,
-            types: unusable.response.types,
-            deps: unusable.response.deps,
-          },
-          {
-            serialized: null,
-            searchDoc: null,
-            displayNames: null,
-            types: null,
-            deps: null,
-          },
-          'meta fields are null when short-circuited',
-        );
-        assert.true(unusable.pool.evicted, 'pool notes eviction for unusable');
-        assert.false(
-          unusable.pool.timedOut,
-          'unusable eviction does not mark timeout',
-        );
-        assert.notStrictEqual(
-          unusable.pool.pageId,
-          'unknown',
-          'evicted unusable run retains page identifier',
-        );
-
-        // After unusable, the realm should be evicted; a subsequent render should not reuse
-        const healthyURL = `${realmURL2}1`;
-        let next = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: healthyURL,
-          auth: auth(),
-        });
-        assert.false(next.pool.reused, 'did not reuse after unusable eviction');
-        assert.false(next.pool.evicted, 'subsequent render not evicted');
-      });
-
-      test('prerender surfaces module syntax errors without timing out', async function (assert) {
-        const cardURL = `${realmURL2}broken`;
-        let broken = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: cardURL,
-          auth: auth(),
-        });
-        assert.ok(broken.response.error, 'syntax error captured');
-        assert.strictEqual(
-          broken.response.error?.error.status,
-          406,
-          'syntax error reported as 406',
-        );
-        assert.false(broken.pool.timedOut, 'syntax error does not hit timeout');
-      });
-    });
-
-    module('realm pooling', function (hooks) {
-      hooks.beforeEach(disposeAllRealms);
-      test('evicts on timeout and does not reuse', async function (assert) {
-        const testCardURL = `${realmURL2}1`;
-        // First render to initialize pool
-        let first = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
-        });
-        assert.false(first.pool.reused, 'first call not reused');
-
-        // Now trigger a timeout; this should evict the realm
-        let timeoutRun = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
-          opts: { timeoutMs: 1, simulateTimeoutMs: 5 },
-        });
-        assert.strictEqual(
-          timeoutRun.response.error?.error.title,
-          'Render timeout',
-          'got timeout error',
-        );
-        assert.true(timeoutRun.pool.evicted, 'timeout eviction reflected');
-        assert.true(timeoutRun.pool.timedOut, 'timeout flagged on pool');
-        assert.notStrictEqual(
-          timeoutRun.pool.pageId,
-          'unknown',
-          'timeout eviction retains page identifier',
-        );
-
-        // A subsequent render should not reuse the previously pooled page
-        let afterTimeout = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
-        });
-        assert.false(
-          afterTimeout.pool.reused,
-          'did not reuse after timeout eviction',
-        );
-        assert.false(afterTimeout.pool.evicted, 'no eviction on new render');
-        assert.false(afterTimeout.pool.timedOut, 'no timeout on new render');
-      });
-
-      test('reuses the same page within a realm', async function (assert) {
-        const testCardURL = `${realmURL2}1`;
-        let first = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
-        });
-        let second = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: auth(),
-        });
-        assert.strictEqual(first.pool.realm, realmURL2, 'first realm matches');
-        assert.strictEqual(
-          second.pool.realm,
-          realmURL2,
-          'second realm matches',
-        );
-        assert.strictEqual(
-          first.pool.pageId,
-          second.pool.pageId,
-          'pageId reused',
-        );
-        assert.false(first.pool.reused, 'first call not reused');
-        assert.true(second.pool.reused, 'second call reused');
-        assert.false(first.pool.timedOut, 'first call not timed out');
-        assert.false(second.pool.timedOut, 'second call not timed out');
-      });
-
-      test('refreshes prerender session when auth changes for the same realm', async function (assert) {
-        const testCardURL = `${realmURL2}1`;
-        let authA = testCreatePrerenderAuth(testUserId, {
-          [realmURL2]: ['read', 'write', 'realm-owner'],
-        });
-        let authB = testCreatePrerenderAuth(testUserId, {
-          [realmURL2]: ['read', 'write', 'realm-owner'],
-          [realmURL1]: ['read', 'write', 'realm-owner'], // introduce a different token set
-        });
-
-        let first = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: authA,
-        });
-        let second = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL,
-          auth: authB,
-        });
-
-        assert.false(first.pool.reused, 'first call not reused');
-        assert.false(
-          second.pool.reused,
-          'auth change forces a fresh prerender page',
-        );
-        assert.notStrictEqual(
-          first.pool.pageId,
-          second.pool.pageId,
-          'new page allocated when auth differs',
-        );
-        assert.strictEqual(
-          second.response.serialized?.data.attributes?.name,
-          'Maple',
-          'second render still succeeds with new session',
-        );
-      });
-
-      test('does not reuse across different realms', async function (assert) {
-        const testCardURL1 = `${realmURL1}1`;
-        const testCardURL2 = `${realmURL2}1`;
-        let r1 = await prerenderer.prerenderCard({
-          realm: realmURL1,
-          url: testCardURL1,
-          auth: auth(),
-        });
-        let r2 = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: testCardURL2,
-          auth: auth(),
-        });
-        assert.notStrictEqual(
-          r1.pool.pageId,
-          r2.pool.pageId,
-          'distinct pages per realm',
-        );
-        assert.false(r1.pool.reused, 'first realm first call not reused');
-        assert.false(r2.pool.reused, 'second realm first call not reused');
-      });
-
-      test('evicts LRU when capacity reached', async function (assert) {
-        const cardA = `${realmURL1}1`;
-        const cardB = `${realmURL2}1`;
-        const cardC = `${realmURL3}1`;
-
-        let firstA = await prerenderer.prerenderCard({
-          realm: realmURL1,
-          url: cardA,
-          auth: auth(),
-        });
-        assert.false(firstA.pool.reused, 'first A not reused');
-
-        let firstB = await prerenderer.prerenderCard({
-          realm: realmURL2,
-          url: cardB,
-          auth: auth(),
-        });
-        assert.false(firstB.pool.reused, 'first B not reused');
-
-        // Now adding C should evict the LRU (A), since maxPages=2
-        let firstC = await prerenderer.prerenderCard({
-          realm: realmURL3,
-          url: cardC,
-          auth: auth(),
-        });
-        assert.false(firstC.pool.reused, 'first C not reused');
-
-        // Returning to A should not reuse because it was evicted
-        let secondA = await prerenderer.prerenderCard({
-          realm: realmURL1,
-          url: cardA,
-          auth: auth(),
-        });
-        assert.false(secondA.pool.reused, 'A was evicted, so not reused');
-        assert.notStrictEqual(
-          firstA.pool.pageId,
-          secondA.pool.pageId,
-          'A got a new page after eviction',
-        );
-      });
-
-      test('serializes prerenders when only one tab is available', async function (assert) {
-        let prevTabMax = process.env.PRERENDER_REALM_TAB_MAX;
-        let semaphore = new TestSemaphore(1);
-        let active = 0;
-        let maxActive = 0;
-        let pool: PagePool | undefined;
-
-        try {
-          process.env.PRERENDER_REALM_TAB_MAX = '1';
-          ({ pool } = makeStubPagePool(1, semaphore));
-          await pool.warmStandbys();
-
-          let run = async (realm: string) => {
-            let lease = await pool!.getPage(realm);
-            active++;
-            maxActive = Math.max(maxActive, active);
-            await new Promise((resolve) => setTimeout(resolve, 25));
-            active--;
-            lease.release();
-          };
-
-          await Promise.all([run('realm-a'), run('realm-b')]);
-
-          assert.strictEqual(
-            maxActive,
-            1,
-            'renders serialize when only one tab is allowed',
+            `failed to match embedded html:${JSON.stringify(result.embeddedHTML)}`,
           );
-        } finally {
-          await pool?.closeAll();
-          if (prevTabMax === undefined) {
-            delete process.env.PRERENDER_REALM_TAB_MAX;
-          } else {
-            process.env.PRERENDER_REALM_TAB_MAX = prevTabMax;
-          }
-        }
-      });
-
-      test('runs prerenders in parallel when multiple tabs are available', async function (assert) {
-        let prevTabMax = process.env.PRERENDER_REALM_TAB_MAX;
-        let semaphore = new TestSemaphore(2);
-        let active = 0;
-        let maxActive = 0;
-        let pool: PagePool | undefined;
-
-        try {
-          process.env.PRERENDER_REALM_TAB_MAX = '2';
-          ({ pool } = makeStubPagePool(2, semaphore));
-          await pool.warmStandbys();
-
-          let run = async (realm: string) => {
-            let lease = await pool!.getPage(realm);
-            active++;
-            maxActive = Math.max(maxActive, active);
-            await new Promise((resolve) => setTimeout(resolve, 25));
-            active--;
-            lease.release();
-          };
-
-          await Promise.all([run('realm-a'), run('realm-a')]);
-
-          assert.strictEqual(
-            maxActive,
-            2,
-            'renders run in parallel on separate tabs',
-          );
-        } finally {
-          await pool?.closeAll();
-          if (prevTabMax === undefined) {
-            delete process.env.PRERENDER_REALM_TAB_MAX;
-          } else {
-            process.env.PRERENDER_REALM_TAB_MAX = prevTabMax;
-          }
-        }
-      });
-
-      test('prefers idle tab aligned to realm over standby tabs', async function (assert) {
-        let { pool } = makeStubPagePool(2);
-        await pool.warmStandbys();
-
-        let first = await pool.getPage('realm-a');
-        first.release();
-        await pool.warmStandbys();
-
-        let second = await pool.getPage('realm-a');
-        assert.strictEqual(
-          second.pageId,
-          first.pageId,
-          'idle aligned tab reused when available',
-        );
-        assert.true(second.reused, 'reuse flagged for aligned idle tab');
-
-        second.release();
-        await pool.closeAll();
-      });
-
-      test('prefers standby over idle tabs from other realms', async function (assert) {
-        let originalNow = Date.now;
-        let now = 1000;
-        (Date as any).now = () => now;
-        let { pool } = makeStubPagePool(1);
-
-        try {
-          await pool.warmStandbys(); // standby at t=1000
-          now = 1100;
-          let realmALease = await pool.getPage('realm-a');
-          realmALease.release();
-
-          now = 2000;
-          await pool.warmStandbys(); // standby created after idle realm tab
-          let realmBLease = await pool.getPage('realm-b');
-          assert.notStrictEqual(
-            realmBLease.pageId,
-            realmALease.pageId,
-            'standby chosen instead of commandeering an idle realm tab',
-          );
-          assert.false(
-            realmBLease.reused,
-            'standby assignment marked as not reused',
-          );
-          realmBLease.release();
-        } finally {
-          await pool.closeAll();
-          (Date as any).now = originalNow;
-        }
-      });
-
-      test('enforces per-realm tab cap by queueing on an existing tab', async function (assert) {
-        let prevTabMax = process.env.PRERENDER_REALM_TAB_MAX;
-        let pool: PagePool | undefined;
-        let resolved = false;
-
-        try {
-          process.env.PRERENDER_REALM_TAB_MAX = '1';
-          ({ pool } = makeStubPagePool(2));
-          await pool.warmStandbys();
-
-          let first = await pool.getPage('realm-a');
-          let secondPromise = pool.getPage('realm-a').then((lease) => {
-            resolved = true;
-            return lease;
-          });
-
-          await new Promise((resolve) => setTimeout(resolve, 5));
-          assert.false(resolved, 'second request waits when tab cap reached');
-
-          first.release();
-          let second = await secondPromise;
-          assert.strictEqual(
-            second.pageId,
-            first.pageId,
-            'queued request reuses the existing tab',
-          );
-          assert.true(second.reused, 'reuse flagged for queued request');
-          second.release();
-        } finally {
-          await pool?.closeAll();
-          if (prevTabMax === undefined) {
-            delete process.env.PRERENDER_REALM_TAB_MAX;
-          } else {
-            process.env.PRERENDER_REALM_TAB_MAX = prevTabMax;
-          }
-        }
-      });
-
-      test('queues on the least-pending tab when the realm cap is met', async function (assert) {
-        let prevTabMax = process.env.PRERENDER_REALM_TAB_MAX;
-        let pool: PagePool | undefined;
-        let originalNow = Date.now;
-        let now = 1000;
-        (Date as any).now = () => now;
-        let thirdResolved = false;
-        let fourthResolved = false;
-
-        try {
-          process.env.PRERENDER_REALM_TAB_MAX = '2';
-          ({ pool } = makeStubPagePool(2));
-          await pool.warmStandbys();
-
-          let first = await pool.getPage('realm-a');
-          now = 1100;
-          let second = await pool.getPage('realm-a');
-
-          let thirdPromise = pool.getPage('realm-a').then((lease) => {
-            thirdResolved = true;
-            return lease;
-          });
-          await new Promise((resolve) => setTimeout(resolve, 0));
-          let fourthPromise = pool.getPage('realm-a').then((lease) => {
-            fourthResolved = true;
-            return lease;
-          });
-
-          second.release();
-          await new Promise((resolve) => setTimeout(resolve, 5));
-          assert.true(
-            fourthResolved,
-            'request queued on least-pending tab unblocks first',
-          );
-          assert.false(
-            thirdResolved,
-            'request queued on busier tab still waits',
-          );
-
-          let fourth = await fourthPromise;
-          assert.strictEqual(
-            fourth.pageId,
-            second.pageId,
-            'fourth request queued on least-pending tab',
-          );
-
-          first.release();
-          let third = await thirdPromise;
-          assert.strictEqual(
-            third.pageId,
-            first.pageId,
-            'third request queued on the LRU tab when pending counts tied',
-          );
-          fourth.release();
-          third.release();
-        } finally {
-          (Date as any).now = originalNow;
-          await pool?.closeAll();
-          if (prevTabMax === undefined) {
-            delete process.env.PRERENDER_REALM_TAB_MAX;
-          } else {
-            process.env.PRERENDER_REALM_TAB_MAX = prevTabMax;
-          }
-        }
-      });
-
-      test('queued cross-realm requests realign the tab per request', async function (assert) {
-        let { pool } = makeStubPagePool(1);
-        await pool.warmStandbys();
-
-        let first = await pool.getPage('realm-a');
-        await pool.warmStandbys();
-        let blocker = await pool.getPage('realm-c');
-
-        let order: string[] = [];
-        let secondPromise = pool.getPage('realm-a').then((lease) => {
-          order.push('a');
-          return lease;
-        });
-        let thirdPromise = pool.getPage('realm-b').then((lease) => {
-          order.push('b');
-          return lease;
         });
 
-        first.release();
-
-        let second = await secondPromise;
-        assert.deepEqual(order, ['a'], 'queued realm-a request runs first');
-        assert.true(
-          pool.getWarmRealms().includes('realm-a'),
-          'tab aligned to realm-a while queued work runs',
-        );
-        second.release();
-        blocker.release();
-
-        let third = await thirdPromise;
-        assert.deepEqual(
-          order,
-          ['a', 'b'],
-          'queued realm-b request runs after',
-        );
-        assert.true(
-          pool.getWarmRealms().includes('realm-b'),
-          'tab realigned to realm-b when queued request starts',
-        );
-        third.release();
-
-        await pool.closeAll();
-      });
-
-      test('does not reassign a busy tab with queued work across realms', async function (assert) {
-        let { pool } = makeStubPagePool(1, undefined, undefined, {
-          disableStandbyRefill: true,
+        test('parent embedded HTML', function (assert) {
+          assert.ok(
+            /data-test-card-thumbnail-placeholder/.test(
+              result.embeddedHTML![
+                'https://cardstack.com/base/card-api/CardDef'
+              ],
+            ),
+            `failed to match embedded html:${JSON.stringify(result.embeddedHTML)}`,
+          );
         });
 
-        try {
-          await pool.warmStandbys();
-
-          let first = await pool.getPage('realm-a');
-
-          let secondPromise = pool.getPage('realm-a');
-          let thirdPromise = pool.getPage('realm-b');
-
-          await assert.rejects(
-            thirdPromise,
-            /No standby page available for prerender/,
-            'cross-realm request rejects when only busy tab has queued work',
+        test('isolated HTML', function (assert) {
+          assert.ok(
+            /data-test-field="cardInfo-summary"/.test(result.isolatedHTML!),
+            `failed to match isolated html:${result.isolatedHTML}`,
           );
-
-          first.release();
-          let second = await secondPromise;
-          assert.strictEqual(
-            second.pageId,
-            first.pageId,
-            'queued same-realm request keeps the original tab',
-          );
-          second.release();
-
-          assert.false(
-            pool.getWarmRealms().includes('realm-b'),
-            'cross-realm request does not reassign the tab',
-          );
-        } finally {
-          await pool.closeAll();
-        }
-      });
-
-      test('queues same-realm request when tab is transitioning', async function (assert) {
-        let { pool } = makeStubPagePool(1, undefined, undefined, {
-          disableStandbyRefill: true,
         });
 
-        try {
-          await pool.warmStandbys();
-
-          let first = await pool.getPage('realm-a');
-
-          let crossResolved = false;
-          let sameResolved = false;
-          let crossPromise = pool.getPage('realm-b').then((lease) => {
-            crossResolved = true;
-            return lease;
-          });
-          let samePromise = pool.getPage('realm-a').then((lease) => {
-            sameResolved = true;
-            return lease;
-          });
-
-          await new Promise((resolve) => setTimeout(resolve, 5));
-          assert.false(
-            crossResolved,
-            'cross-realm request waits for the busy tab',
+        test('atom HTML', function (assert) {
+          assert.ok(
+            /Untitled Cat/.test(result.atomHTML!),
+            `failed to match atom html:${result.atomHTML}`,
           );
-          assert.false(
-            sameResolved,
-            'same-realm request queues even while transitioning',
-          );
-
-          first.release();
-
-          let cross = await crossPromise;
-          assert.strictEqual(
-            cross.pageId,
-            first.pageId,
-            'cross-realm request uses the existing tab',
-          );
-          cross.release();
-
-          let same = await samePromise;
-          assert.strictEqual(
-            same.pageId,
-            first.pageId,
-            'same-realm request uses the same tab',
-          );
-          assert.false(
-            pool.getWarmRealms().includes('realm-b'),
-            'tab realigned back to realm-a after same-realm request',
-          );
-          same.release();
-        } finally {
-          await pool.closeAll();
-        }
-      });
-
-      test('does not oversubscribe contexts during async eviction', async function (assert) {
-        let prevTabMax = process.env.PRERENDER_REALM_TAB_MAX;
-        let pool: PagePool | undefined;
-        let active = 0;
-        let peak = 0;
-        let resolveClose!: () => void;
-        let closeGate = new Promise<void>((resolve) => {
-          resolveClose = resolve;
         });
 
-        try {
-          process.env.PRERENDER_REALM_TAB_MAX = '2';
-          ({ pool } = makeStubPagePool(2, undefined, undefined, {
-            closeContextDelay: async () => closeGate,
-            onContextCreated() {
-              active++;
-              peak = Math.max(peak, active);
-            },
-            onContextClosed() {
-              active--;
-            },
-          }));
+        test('icon HTML', function (assert) {
+          assert.ok(
+            result.iconHTML?.startsWith('<svg'),
+            `iconHTML: ${result.iconHTML}`,
+          );
+        });
 
-          await pool.warmStandbys();
-
-          let first = await pool.getPage('realm-a');
-          let second = await pool.getPage('realm-a');
-
-          await pool.disposeRealm('realm-a', { awaitIdle: false });
-          await pool.warmStandbys();
+        test('head HTML', function (assert) {
+          assert.ok(result.headHTML, 'headHTML should be present');
+          let cleanedHead = cleanWhiteSpace(result.headHTML!);
 
           assert.ok(
-            peak <= 3,
-            'context count stays within maxPages+1 during async eviction',
+            cleanedHead.includes(
+              '<title data-test-card-head-title>Untitled Cat</title>',
+            ),
+            `failed to find title in head html:${cleanedHead}`,
+          );
+          assert.ok(
+            cleanedHead.includes('property="og:title" content="Untitled Cat"'),
+            `failed to find og:title in head html:${cleanedHead}`,
+          );
+          assert.ok(
+            cleanedHead.includes(`property="og:url" content="${realmURL2}1"`),
+            `failed to find og:url in head html:${cleanedHead}`,
+          );
+          assert.ok(
+            cleanedHead.includes('name="twitter:card" content="summary"'),
+            `failed to find twitter:card in head html:${cleanedHead}`,
+          );
+        });
+
+        test('serialized', function (assert) {
+          assert.strictEqual(result.serialized?.data.attributes?.name, 'Maple');
+        });
+
+        test('displayNames', function (assert) {
+          assert.deepEqual(result.displayNames, ['Cat', 'Card']);
+        });
+
+        test('deps', function (assert) {
+          // spot check a few deps, as the whole list is overwhelming...
+          assert.ok(
+            result.deps?.includes(baseCardRef.module),
+            `${baseCardRef.module} is a dep`,
+          );
+          assert.ok(
+            result.deps?.includes(`${realmURL1}person`),
+            `${realmURL1}person is a dep`,
+          );
+          assert.ok(
+            result.deps?.includes(`${realmURL2}cat`),
+            `${realmURL2}cat is a dep`,
+          );
+          assert.ok(
+            result.deps?.find((d) =>
+              d.match(
+                /^https:\/\/cardstack.com\/base\/card-api\.gts\..*glimmer-scoped\.css$/,
+              ),
+            ),
+            `glimmer scoped css from ${baseCardRef.module} is a dep`,
+          );
+        });
+
+        test('types', function (assert) {
+          assert.deepEqual(result.types, [
+            `${realmURL2}cat/Cat`,
+            'https://cardstack.com/base/card-api/CardDef',
+          ]);
+        });
+
+        test('searchDoc', function (assert) {
+          assert.strictEqual(result.searchDoc?.name, 'Maple');
+          assert.strictEqual(result.searchDoc?._cardType, 'Cat');
+          assert.strictEqual(result.searchDoc?.owner.name, 'Hassan');
+        });
+
+        test('isUsed field includes a field in search doc that is not rendered in template', async function (assert) {
+          const testCardURL = `${realmURL2}is-used`;
+          let { response } = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+          });
+
+          assert.ok(
+            /Mango/.test(response.isolatedHTML!),
+            `failed to match isolated html:${response.isolatedHTML}`,
+          );
+          assert.false(
+            /data-test-field="owner"/.test(response.isolatedHTML!),
+            `owner field is not rendered in isolated html`,
+          );
+          assert.strictEqual(
+            response.searchDoc?.owner.name,
+            'Hassan',
+            'linked field is included in search doc via isUsed=true',
+          );
+        });
+
+        test('isUsed linksToMany field includes links in search doc that are not rendered in template', async function (assert) {
+          const testCardURL = `${realmURL2}is-used-many`;
+          let { response } = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+          });
+
+          assert.ok(
+            /Mango Many/.test(response.isolatedHTML!),
+            `failed to match isolated html:${response.isolatedHTML}`,
+          );
+          assert.false(
+            /data-test-field="owners"/.test(response.isolatedHTML!),
+            `owners field is not rendered in isolated html`,
+          );
+          assert.strictEqual(
+            response.searchDoc?.owners?.[0]?.name,
+            'Hassan',
+            'first linked record is included in search doc via isUsed=true',
+          );
+          assert.strictEqual(
+            response.searchDoc?.owners?.[1]?.name,
+            'Mango',
+            'second linked record is included in search doc via isUsed=true',
+          );
+        });
+
+        test('isUsed compound field includes nested linksTo relationship in search doc', async function (assert) {
+          const testCardURL = `${realmURL2}is-used-field-def`;
+          let { response } = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+          });
+
+          assert.ok(
+            /Mango Profile/.test(response.isolatedHTML!),
+            `failed to match isolated html:${response.isolatedHTML}`,
+          );
+          assert.false(
+            /data-test-field="profile"/.test(response.isolatedHTML!),
+            `profile field is not rendered in isolated html`,
+          );
+          assert.strictEqual(
+            response.searchDoc?.profile?.primaryOwner?.name,
+            'Hassan',
+            'nested linksTo relationship is included in search doc via isUsed=true on the relationship field',
+          );
+        });
+
+        test('isUsed compound field includes nested linksToMany relationships in search doc', async function (assert) {
+          const testCardURL = `${realmURL2}is-used-field-def`;
+          let { response } = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+          });
+
+          assert.ok(
+            /Mango Profile/.test(response.isolatedHTML!),
+            `failed to match isolated html:${response.isolatedHTML}`,
+          );
+          assert.false(
+            /data-test-field="profile"/.test(response.isolatedHTML!),
+            `profile field is not rendered in isolated html`,
+          );
+          assert.strictEqual(
+            response.searchDoc?.profile?.caretakers?.[0]?.name,
+            'Hassan',
+            'first nested linksToMany relationship is included in search doc via isUsed=true on the relationship field',
+          );
+          assert.strictEqual(
+            response.searchDoc?.profile?.caretakers?.[1]?.name,
+            'Mango',
+            'second nested linksToMany relationship is included in search doc via isUsed=true on the relationship field',
+          );
+        });
+
+        test('non-isolated formats render linked fields and those links appear in search doc', async function (assert) {
+          const testCardURL = `${realmURL2}non-isolated-links`;
+          let { response } = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+          });
+
+          let headHTML = cleanWhiteSpace(response.headHTML ?? '');
+          assert.ok(
+            /<link rel="icon" href="https:\/\/example\.com\/non-isolated-social-icon\.png"/.test(
+              headHTML,
+            ),
+            `head html includes favicon from cardInfo.theme: ${headHTML}`,
+          );
+          assert.ok(
+            /<link rel="apple-touch-icon" href="https:\/\/example\.com\/non-isolated-social-icon\.png"/.test(
+              headHTML,
+            ),
+            `head html includes apple-touch-icon from cardInfo.theme: ${headHTML}`,
           );
 
-          first.release();
-          second.release();
-          resolveClose();
-        } finally {
-          if (resolveClose) {
-            resolveClose();
-          }
-          await pool?.closeAll();
-          if (prevTabMax === undefined) {
-            delete process.env.PRERENDER_REALM_TAB_MAX;
-          } else {
-            process.env.PRERENDER_REALM_TAB_MAX = prevTabMax;
-          }
-        }
-      });
-
-      test('creates spare standby when pool is at capacity', async function (assert) {
-        let { pool, contextsCreated } = makeStubPagePool(1);
-        await pool.warmStandbys();
-        assert.strictEqual(
-          contextsCreated.length,
-          1,
-          'initial standby created up to maxPages',
-        );
-
-        let first = await pool.getPage('realm-standby');
-        assert.false(first.reused, 'first checkout uses standby page');
-
-        await pool.warmStandbys();
-        assert.strictEqual(
-          contextsCreated.length,
-          2,
-          'spare standby created once the only slot is occupied',
-        );
-        first.release();
-        await pool.closeAll();
-      });
-
-      test('standby pages bind to the first realm they serve', async function (assert) {
-        let { pool } = makeStubPagePool(2);
-        await pool.warmStandbys(); // fill initial standbys
-
-        let realmAFirst = await pool.getPage('realm-a');
-        let realmAFirstId = realmAFirst.pageId;
-        realmAFirst.release();
-        await pool.warmStandbys(); // replenish after consuming standby
-        let realmBFirst = await pool.getPage('realm-b');
-        let realmBFirstId = realmBFirst.pageId;
-        realmBFirst.release();
-        await pool.warmStandbys(); // replenish again to keep standbys warm
-
-        let realmASecond = await pool.getPage('realm-a');
-        let realmBSecond = await pool.getPage('realm-b');
-
-        assert.false(realmAFirst.reused, 'first realm A call not reused');
-        assert.false(realmBFirst.reused, 'first realm B call not reused');
-        assert.true(realmASecond.reused, 'realm A reuses its page');
-        assert.true(realmBSecond.reused, 'realm B reuses its page');
-        assert.strictEqual(
-          realmASecond.pageId,
-          realmAFirstId,
-          'realm A keeps the same page',
-        );
-        assert.strictEqual(
-          realmBSecond.pageId,
-          realmBFirstId,
-          'realm B keeps the same page',
-        );
-        assert.notStrictEqual(
-          realmAFirstId,
-          realmBFirstId,
-          'distinct pages per realm from standbys',
-        );
-        realmASecond.release();
-        realmBSecond.release();
-        await pool.closeAll();
-      });
-
-      test('evicts idle realms without touching standbys', async function (assert) {
-        let { pool, contextsCreated, contextsClosed } = makeStubPagePool(2);
-        await pool.warmStandbys();
-
-        assert.strictEqual(
-          contextsCreated.length,
-          2,
-          'initial standbys created up to maxPages',
-        );
-
-        let realmLease = await pool.getPage('realm-a');
-        await pool.warmStandbys(); // ensure standby pool replenishment settles before idle sweep
-        realmLease.release();
-
-        let originalNow = Date.now;
-        try {
-          let now = Date.now();
-          (Date as any).now = () => now + 13 * 60 * 60 * 1000; // 13 hours later
-
-          let evicted = await pool.evictIdleRealms(12 * 60 * 60 * 1000);
-
-          assert.deepEqual(evicted, ['realm-a'], 'idle realm evicted');
-          assert.deepEqual(
-            pool.getWarmRealms(),
-            [],
-            'realm entry removed from warm set',
+          let embedded =
+            response.embeddedHTML?.[
+              `${realmURL2}non-isolated-links-card/NonIsolatedLinks`
+            ] ?? '';
+          let cleanedEmbedded = cleanWhiteSpace(embedded);
+          assert.ok(
+            /data-test-embedded-owner[^>]*>\s*Hassan\s*</.test(cleanedEmbedded),
+            `embedded html includes direct linksTo value Hassan: ${cleanedEmbedded}`,
           );
-          let closedAtEviction = [...contextsClosed];
+          assert.ok(
+            /data-test-embedded-owner-name[^>]*>\s*Hassan\s*</.test(
+              cleanedEmbedded,
+            ),
+            `embedded html includes direct linksToMany value Hassan: ${cleanedEmbedded}`,
+          );
+          assert.ok(
+            /data-test-embedded-owner-name[^>]*>\s*Mango\s*</.test(
+              cleanedEmbedded,
+            ),
+            `embedded html includes direct linksToMany value Mango: ${cleanedEmbedded}`,
+          );
+          assert.ok(
+            /data-test-embedded-profile-lead-name[^>]*>\s*Hassan\s*</.test(
+              cleanedEmbedded,
+            ),
+            `embedded html includes nested FieldDef linksTo value Hassan: ${cleanedEmbedded}`,
+          );
+          assert.ok(
+            /data-test-embedded-profile-member-name[^>]*>\s*Hassan\s*</.test(
+              cleanedEmbedded,
+            ),
+            `embedded html includes nested FieldDef linksToMany value Hassan: ${cleanedEmbedded}`,
+          );
+          assert.ok(
+            /data-test-embedded-profile-member-name[^>]*>\s*Mango\s*</.test(
+              cleanedEmbedded,
+            ),
+            `embedded html includes nested FieldDef linksToMany value Mango: ${cleanedEmbedded}`,
+          );
+
+          assert.strictEqual(
+            response.searchDoc?.owner?.name,
+            'Hassan',
+            'searchDoc includes direct linksTo data from non-isolated render',
+          );
+          assert.strictEqual(
+            response.searchDoc?.owners?.[0]?.name,
+            'Hassan',
+            'searchDoc includes direct linksToMany first value from non-isolated render',
+          );
+          assert.strictEqual(
+            response.searchDoc?.owners?.[1]?.name,
+            'Mango',
+            'searchDoc includes direct linksToMany second value from non-isolated render',
+          );
+          assert.strictEqual(
+            response.searchDoc?.profile?.lead?.name,
+            'Hassan',
+            'searchDoc includes nested FieldDef linksTo data from non-isolated render',
+          );
+          assert.strictEqual(
+            response.searchDoc?.profile?.members?.[0]?.name,
+            'Hassan',
+            'searchDoc includes nested FieldDef linksToMany first value from non-isolated render',
+          );
+          assert.strictEqual(
+            response.searchDoc?.profile?.members?.[1]?.name,
+            'Mango',
+            'searchDoc includes nested FieldDef linksToMany second value from non-isolated render',
+          );
+        });
+      });
+
+      module('errors', function (hooks) {
+        hooks.beforeEach(disposeAllRealms);
+        test('error during render', async function (assert) {
+          const testCardURL = `${realmURL2}2`;
+          let { response } = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+          });
+          let { error, ...restOfResult } = response;
+
+          assert.strictEqual(error?.error.id, testCardURL);
+          assert.strictEqual(
+            error?.error.message,
+            'intentional failure during render',
+          );
+          assert.strictEqual(error?.error.status, 500);
+          assert.ok(error?.error.stack, 'stack trace exists in error');
+
+          // TODO Perhaps if we add error handlers for the /render/html subroute
+          // these all wont be empty, as this is triggering in the /render route
+          // error handler and hence stomping over all the subroutes.
+          assert.deepEqual(restOfResult, {
+            displayNames: null,
+            deps: null,
+            searchDoc: null,
+            serialized: null,
+            types: null,
+            atomHTML: null,
+            embeddedHTML: null,
+            fittedHTML: null,
+            headHTML: null,
+            iconHTML: null,
+            isolatedHTML: null,
+          });
+        });
+
+        test('error includes blocked timer summary when timers fire', async function (assert) {
+          const testCardURL = `${realmURL2}timer-error`;
+          let { response } = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+          });
+
+          assert.ok(response.error, 'error present for timer error');
+          let message = response.error?.error.message ?? '';
+          assert.ok(
+            message.includes('timer error during render'),
+            `error message includes original error text, got: ${message}`,
+          );
+          let stack = response.error?.error.stack ?? '';
+          assert.ok(
+            stack.includes('Timers blocked during prerender'),
+            'timer summary appended to stack',
+          );
+          let timeoutMatch = stack.match(/setTimeout:\s+(\d+)/);
+          assert.ok(timeoutMatch, 'setTimeout count included');
+          assert.ok(
+            Number(timeoutMatch?.[1]) >= 1,
+            `expected at least one setTimeout, got: ${timeoutMatch?.[1]}`,
+          );
+          let intervalMatch = stack.match(/setInterval:\s+(\d+)/);
+          assert.ok(intervalMatch, 'setInterval count included');
+          assert.ok(
+            Number(intervalMatch?.[1]) >= 1,
+            `expected at least one setInterval, got: ${intervalMatch?.[1]}`,
+          );
+          assert.ok(
+            stack.includes('at get message'),
+            'timer summary includes a call stack',
+          );
+        });
+
+        test('timeout includes blocked timer summary in stack', async function (assert) {
+          const testCardURL = `${realmURL2}timer-timeout`;
+          await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+          });
+          let { response } = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+            opts: { timeoutMs: 1000, simulateTimeoutMs: 2000 },
+          });
+
+          assert.strictEqual(
+            response.error?.error.title,
+            'Render timeout',
+            'timeout surfaced',
+          );
+          let stack = response.error?.error.stack ?? '';
+          assert.ok(
+            stack.includes('Timers blocked during prerender'),
+            'timer summary appended to timeout stack',
+          );
+          assert.ok(
+            /setTimeout:\s+\d+/.test(stack),
+            'timeout stack includes setTimeout count',
+          );
+          assert.ok(
+            /setInterval:\s+\d+/.test(stack),
+            'timeout stack includes setInterval count',
+          );
+        });
+
+        test('missing link surfaces 404 without eviction', async function (assert) {
+          const testCardURL = `${realmURL2}missing-link`;
+          let result = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+          });
+          let { response } = result;
+
+          assert.ok(response.error, 'error present for missing link');
+          assert.strictEqual(
+            response.error?.error.message,
+            `missing file ${realmURL1}missing-owner.json`,
+          );
+          assert.strictEqual(response.error?.error.status, 404);
+          assert.false(
+            result.pool.evicted,
+            'missing link does not evict prerender page',
+          );
+          assert.false(
+            result.pool.timedOut,
+            'missing link does not mark prerender timeout',
+          );
+        });
+
+        test('fetch failed surfaces error without eviction', async function (assert) {
+          const testCardURL = `${realmURL2}fetch-failed`;
+          let result = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+          });
+          let { response } = result;
+
+          assert.ok(response.error, 'error present for fetch failed');
+          assert.strictEqual(
+            response.error?.error.message,
+            `unable to fetch http://localhost:9000/this-is-a-link-to-nowhere: fetch failed`,
+          );
+          assert.strictEqual(response.error?.error.status, 500);
+          assert.false(
+            result.pool.evicted,
+            'fetch failed does not evict prerender page',
+          );
+          assert.false(
+            result.pool.timedOut,
+            'fetch failed does not mark prerender timeout',
+          );
+        });
+
+        test('embedded error markup triggers render error', async function (assert) {
+          const testCardURL = `${realmURL2}4`;
+          let { response } = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+          });
+          assert.ok(response.error, 'error captured');
+          assert.strictEqual(response.error?.error.id, 'embedded-error');
+          assert.strictEqual(
+            response.error?.error.message,
+            'error flagged from DOM',
+          );
+          assert.strictEqual(response.error?.error.title, 'Embedded error');
+          assert.strictEqual(response.error?.error.status, 500);
+        });
+
+        test('unusable triggers eviction and short-circuit', async function (assert) {
+          // Render the card that forces unusable
+          const unusableURL = `${realmURL2}3`;
+          let unusable = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: unusableURL,
+            auth: auth(),
+          });
+
+          // We should see an error with evict semantics and short-circuited payloads
+          assert.ok(unusable.response.error, 'error present for unusable');
+          assert.strictEqual(unusable.response.error?.error.id, unusableURL);
+          assert.strictEqual(
+            unusable.response.error?.error.message,
+            'forced unusable for test',
+          );
+          assert.strictEqual(unusable.response.error?.error.status, 500);
+          assert.strictEqual(
+            unusable.response.isolatedHTML,
+            null,
+            'isolatedHTML null when short-circuited',
+          );
+          assert.strictEqual(
+            unusable.response.embeddedHTML,
+            null,
+            'embeddedHTML null when short-circuited',
+          );
+          assert.strictEqual(
+            unusable.response.atomHTML,
+            null,
+            'atomHTML null when short-circuited',
+          );
+          assert.strictEqual(
+            unusable.response.iconHTML,
+            null,
+            'iconHTML null when short-circuited',
+          );
           assert.deepEqual(
-            closedAtEviction,
-            [contextsCreated[0]],
-            'only the realm-bound page closed during idle eviction',
+            {
+              serialized: unusable.response.serialized,
+              searchDoc: unusable.response.searchDoc,
+              displayNames: unusable.response.displayNames,
+              types: unusable.response.types,
+              deps: unusable.response.deps,
+            },
+            {
+              serialized: null,
+              searchDoc: null,
+              displayNames: null,
+              types: null,
+              deps: null,
+            },
+            'meta fields are null when short-circuited',
           );
           assert.true(
-            contextsCreated.length > closedAtEviction.length,
-            'standby pages remain available after idle eviction',
+            unusable.pool.evicted,
+            'pool notes eviction for unusable',
           );
-        } finally {
-          (Date as any).now = originalNow;
-          await pool.closeAll();
-        }
+          assert.false(
+            unusable.pool.timedOut,
+            'unusable eviction does not mark timeout',
+          );
+          assert.notStrictEqual(
+            unusable.pool.pageId,
+            'unknown',
+            'evicted unusable run retains page identifier',
+          );
+
+          // After unusable, the realm should be evicted; a subsequent render should not reuse
+          const healthyURL = `${realmURL2}1`;
+          let next = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: healthyURL,
+            auth: auth(),
+          });
+          assert.false(
+            next.pool.reused,
+            'did not reuse after unusable eviction',
+          );
+          assert.false(next.pool.evicted, 'subsequent render not evicted');
+        });
+
+        test('prerender surfaces module syntax errors without timing out', async function (assert) {
+          const cardURL = `${realmURL2}broken`;
+          let broken = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: cardURL,
+            auth: auth(),
+          });
+          assert.ok(broken.response.error, 'syntax error captured');
+          assert.strictEqual(
+            broken.response.error?.error.status,
+            406,
+            'syntax error reported as 406',
+          );
+          assert.false(
+            broken.pool.timedOut,
+            'syntax error does not hit timeout',
+          );
+        });
       });
 
-      test('idle eviction skips unassigned standbys', async function (assert) {
-        let { pool, contextsCreated, contextsClosed } = makeStubPagePool(1);
-        await pool.warmStandbys();
+      module('realm pooling', function (hooks) {
+        hooks.beforeEach(disposeAllRealms);
+        test('evicts on timeout and does not reuse', async function (assert) {
+          const testCardURL = `${realmURL2}1`;
+          // First render to initialize pool
+          let first = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+          });
+          assert.false(first.pool.reused, 'first call not reused');
 
-        let createdBeforeSweep = contextsCreated.length;
-        let evicted = await pool.evictIdleRealms(1);
-        let closedAfterSweep = contextsClosed.length;
+          // Now trigger a timeout; this should evict the realm
+          let timeoutRun = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+            opts: { timeoutMs: 1, simulateTimeoutMs: 5 },
+          });
+          assert.strictEqual(
+            timeoutRun.response.error?.error.title,
+            'Render timeout',
+            'got timeout error',
+          );
+          assert.true(timeoutRun.pool.evicted, 'timeout eviction reflected');
+          assert.true(timeoutRun.pool.timedOut, 'timeout flagged on pool');
+          assert.notStrictEqual(
+            timeoutRun.pool.pageId,
+            'unknown',
+            'timeout eviction retains page identifier',
+          );
 
-        assert.deepEqual(evicted, [], 'no idle realms to evict');
-        assert.strictEqual(
-          contextsCreated.length,
-          createdBeforeSweep,
-          'standby pool untouched by idle eviction',
-        );
-        assert.strictEqual(
-          closedAfterSweep,
-          0,
-          'no contexts closed when only standbys are present',
-        );
-        await pool.closeAll();
+          // A subsequent render should not reuse the previously pooled page
+          let afterTimeout = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+          });
+          assert.false(
+            afterTimeout.pool.reused,
+            'did not reuse after timeout eviction',
+          );
+          assert.false(afterTimeout.pool.evicted, 'no eviction on new render');
+          assert.false(afterTimeout.pool.timedOut, 'no timeout on new render');
+        });
+
+        test('reuses the same page within a realm', async function (assert) {
+          const testCardURL = `${realmURL2}1`;
+          let first = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+          });
+          let second = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: auth(),
+          });
+          assert.strictEqual(
+            first.pool.realm,
+            realmURL2,
+            'first realm matches',
+          );
+          assert.strictEqual(
+            second.pool.realm,
+            realmURL2,
+            'second realm matches',
+          );
+          assert.strictEqual(
+            first.pool.pageId,
+            second.pool.pageId,
+            'pageId reused',
+          );
+          assert.false(first.pool.reused, 'first call not reused');
+          assert.true(second.pool.reused, 'second call reused');
+          assert.false(first.pool.timedOut, 'first call not timed out');
+          assert.false(second.pool.timedOut, 'second call not timed out');
+        });
+
+        test('refreshes prerender session when auth changes for the same realm', async function (assert) {
+          const testCardURL = `${realmURL2}1`;
+          let authA = testCreatePrerenderAuth(testUserId, {
+            [realmURL2]: ['read', 'write', 'realm-owner'],
+          });
+          let authB = testCreatePrerenderAuth(testUserId, {
+            [realmURL2]: ['read', 'write', 'realm-owner'],
+            [realmURL1]: ['read', 'write', 'realm-owner'], // introduce a different token set
+          });
+
+          let first = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: authA,
+          });
+          let second = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL,
+            auth: authB,
+          });
+
+          assert.false(first.pool.reused, 'first call not reused');
+          assert.false(
+            second.pool.reused,
+            'auth change forces a fresh prerender page',
+          );
+          assert.notStrictEqual(
+            first.pool.pageId,
+            second.pool.pageId,
+            'new page allocated when auth differs',
+          );
+          assert.strictEqual(
+            second.response.serialized?.data.attributes?.name,
+            'Maple',
+            'second render still succeeds with new session',
+          );
+        });
+
+        test('does not reuse across different realms', async function (assert) {
+          const testCardURL1 = `${realmURL1}1`;
+          const testCardURL2 = `${realmURL2}1`;
+          let r1 = await prerenderer.prerenderCard({
+            realm: realmURL1,
+            url: testCardURL1,
+            auth: auth(),
+          });
+          let r2 = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: testCardURL2,
+            auth: auth(),
+          });
+          assert.notStrictEqual(
+            r1.pool.pageId,
+            r2.pool.pageId,
+            'distinct pages per realm',
+          );
+          assert.false(r1.pool.reused, 'first realm first call not reused');
+          assert.false(r2.pool.reused, 'second realm first call not reused');
+        });
+
+        test('evicts LRU when capacity reached', async function (assert) {
+          const cardA = `${realmURL1}1`;
+          const cardB = `${realmURL2}1`;
+          const cardC = `${realmURL3}1`;
+
+          let firstA = await prerenderer.prerenderCard({
+            realm: realmURL1,
+            url: cardA,
+            auth: auth(),
+          });
+          assert.false(firstA.pool.reused, 'first A not reused');
+
+          let firstB = await prerenderer.prerenderCard({
+            realm: realmURL2,
+            url: cardB,
+            auth: auth(),
+          });
+          assert.false(firstB.pool.reused, 'first B not reused');
+
+          // Now adding C should evict the LRU (A), since maxPages=2
+          let firstC = await prerenderer.prerenderCard({
+            realm: realmURL3,
+            url: cardC,
+            auth: auth(),
+          });
+          assert.false(firstC.pool.reused, 'first C not reused');
+
+          // Returning to A should not reuse because it was evicted
+          let secondA = await prerenderer.prerenderCard({
+            realm: realmURL1,
+            url: cardA,
+            auth: auth(),
+          });
+          assert.false(secondA.pool.reused, 'A was evicted, so not reused');
+          assert.notStrictEqual(
+            firstA.pool.pageId,
+            secondA.pool.pageId,
+            'A got a new page after eviction',
+          );
+        });
+
+        test('serializes prerenders when only one tab is available', async function (assert) {
+          let prevTabMax = process.env.PRERENDER_REALM_TAB_MAX;
+          let semaphore = new TestSemaphore(1);
+          let active = 0;
+          let maxActive = 0;
+          let pool: PagePool | undefined;
+
+          try {
+            process.env.PRERENDER_REALM_TAB_MAX = '1';
+            ({ pool } = makeStubPagePool(1, semaphore));
+            await pool.warmStandbys();
+
+            let run = async (realm: string) => {
+              let lease = await pool!.getPage(realm);
+              active++;
+              maxActive = Math.max(maxActive, active);
+              await new Promise((resolve) => setTimeout(resolve, 25));
+              active--;
+              lease.release();
+            };
+
+            await Promise.all([run('realm-a'), run('realm-b')]);
+
+            assert.strictEqual(
+              maxActive,
+              1,
+              'renders serialize when only one tab is allowed',
+            );
+          } finally {
+            await pool?.closeAll();
+            if (prevTabMax === undefined) {
+              delete process.env.PRERENDER_REALM_TAB_MAX;
+            } else {
+              process.env.PRERENDER_REALM_TAB_MAX = prevTabMax;
+            }
+          }
+        });
+
+        test('runs prerenders in parallel when multiple tabs are available', async function (assert) {
+          let prevTabMax = process.env.PRERENDER_REALM_TAB_MAX;
+          let semaphore = new TestSemaphore(2);
+          let active = 0;
+          let maxActive = 0;
+          let pool: PagePool | undefined;
+
+          try {
+            process.env.PRERENDER_REALM_TAB_MAX = '2';
+            ({ pool } = makeStubPagePool(2, semaphore));
+            await pool.warmStandbys();
+
+            let run = async (realm: string) => {
+              let lease = await pool!.getPage(realm);
+              active++;
+              maxActive = Math.max(maxActive, active);
+              await new Promise((resolve) => setTimeout(resolve, 25));
+              active--;
+              lease.release();
+            };
+
+            await Promise.all([run('realm-a'), run('realm-a')]);
+
+            assert.strictEqual(
+              maxActive,
+              2,
+              'renders run in parallel on separate tabs',
+            );
+          } finally {
+            await pool?.closeAll();
+            if (prevTabMax === undefined) {
+              delete process.env.PRERENDER_REALM_TAB_MAX;
+            } else {
+              process.env.PRERENDER_REALM_TAB_MAX = prevTabMax;
+            }
+          }
+        });
+
+        test('prefers idle tab aligned to realm over standby tabs', async function (assert) {
+          let { pool } = makeStubPagePool(2);
+          await pool.warmStandbys();
+
+          let first = await pool.getPage('realm-a');
+          first.release();
+          await pool.warmStandbys();
+
+          let second = await pool.getPage('realm-a');
+          assert.strictEqual(
+            second.pageId,
+            first.pageId,
+            'idle aligned tab reused when available',
+          );
+          assert.true(second.reused, 'reuse flagged for aligned idle tab');
+
+          second.release();
+          await pool.closeAll();
+        });
+
+        test('prefers standby over idle tabs from other realms', async function (assert) {
+          let originalNow = Date.now;
+          let now = 1000;
+          (Date as any).now = () => now;
+          let { pool } = makeStubPagePool(1);
+
+          try {
+            await pool.warmStandbys(); // standby at t=1000
+            now = 1100;
+            let realmALease = await pool.getPage('realm-a');
+            realmALease.release();
+
+            now = 2000;
+            await pool.warmStandbys(); // standby created after idle realm tab
+            let realmBLease = await pool.getPage('realm-b');
+            assert.notStrictEqual(
+              realmBLease.pageId,
+              realmALease.pageId,
+              'standby chosen instead of commandeering an idle realm tab',
+            );
+            assert.false(
+              realmBLease.reused,
+              'standby assignment marked as not reused',
+            );
+            realmBLease.release();
+          } finally {
+            await pool.closeAll();
+            (Date as any).now = originalNow;
+          }
+        });
+
+        test('enforces per-realm tab cap by queueing on an existing tab', async function (assert) {
+          let prevTabMax = process.env.PRERENDER_REALM_TAB_MAX;
+          let pool: PagePool | undefined;
+          let resolved = false;
+
+          try {
+            process.env.PRERENDER_REALM_TAB_MAX = '1';
+            ({ pool } = makeStubPagePool(2));
+            await pool.warmStandbys();
+
+            let first = await pool.getPage('realm-a');
+            let secondPromise = pool.getPage('realm-a').then((lease) => {
+              resolved = true;
+              return lease;
+            });
+
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            assert.false(resolved, 'second request waits when tab cap reached');
+
+            first.release();
+            let second = await secondPromise;
+            assert.strictEqual(
+              second.pageId,
+              first.pageId,
+              'queued request reuses the existing tab',
+            );
+            assert.true(second.reused, 'reuse flagged for queued request');
+            second.release();
+          } finally {
+            await pool?.closeAll();
+            if (prevTabMax === undefined) {
+              delete process.env.PRERENDER_REALM_TAB_MAX;
+            } else {
+              process.env.PRERENDER_REALM_TAB_MAX = prevTabMax;
+            }
+          }
+        });
+
+        test('queues on the least-pending tab when the realm cap is met', async function (assert) {
+          let prevTabMax = process.env.PRERENDER_REALM_TAB_MAX;
+          let pool: PagePool | undefined;
+          let originalNow = Date.now;
+          let now = 1000;
+          (Date as any).now = () => now;
+          let thirdResolved = false;
+          let fourthResolved = false;
+
+          try {
+            process.env.PRERENDER_REALM_TAB_MAX = '2';
+            ({ pool } = makeStubPagePool(2));
+            await pool.warmStandbys();
+
+            let first = await pool.getPage('realm-a');
+            now = 1100;
+            let second = await pool.getPage('realm-a');
+
+            let thirdPromise = pool.getPage('realm-a').then((lease) => {
+              thirdResolved = true;
+              return lease;
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            let fourthPromise = pool.getPage('realm-a').then((lease) => {
+              fourthResolved = true;
+              return lease;
+            });
+
+            second.release();
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            assert.true(
+              fourthResolved,
+              'request queued on least-pending tab unblocks first',
+            );
+            assert.false(
+              thirdResolved,
+              'request queued on busier tab still waits',
+            );
+
+            let fourth = await fourthPromise;
+            assert.strictEqual(
+              fourth.pageId,
+              second.pageId,
+              'fourth request queued on least-pending tab',
+            );
+
+            first.release();
+            let third = await thirdPromise;
+            assert.strictEqual(
+              third.pageId,
+              first.pageId,
+              'third request queued on the LRU tab when pending counts tied',
+            );
+            fourth.release();
+            third.release();
+          } finally {
+            (Date as any).now = originalNow;
+            await pool?.closeAll();
+            if (prevTabMax === undefined) {
+              delete process.env.PRERENDER_REALM_TAB_MAX;
+            } else {
+              process.env.PRERENDER_REALM_TAB_MAX = prevTabMax;
+            }
+          }
+        });
+
+        test('queued cross-realm requests realign the tab per request', async function (assert) {
+          let { pool } = makeStubPagePool(1);
+          await pool.warmStandbys();
+
+          let first = await pool.getPage('realm-a');
+          await pool.warmStandbys();
+          let blocker = await pool.getPage('realm-c');
+
+          let order: string[] = [];
+          let secondPromise = pool.getPage('realm-a').then((lease) => {
+            order.push('a');
+            return lease;
+          });
+          let thirdPromise = pool.getPage('realm-b').then((lease) => {
+            order.push('b');
+            return lease;
+          });
+
+          first.release();
+
+          let second = await secondPromise;
+          assert.deepEqual(order, ['a'], 'queued realm-a request runs first');
+          assert.true(
+            pool.getWarmRealms().includes('realm-a'),
+            'tab aligned to realm-a while queued work runs',
+          );
+          second.release();
+          blocker.release();
+
+          let third = await thirdPromise;
+          assert.deepEqual(
+            order,
+            ['a', 'b'],
+            'queued realm-b request runs after',
+          );
+          assert.true(
+            pool.getWarmRealms().includes('realm-b'),
+            'tab realigned to realm-b when queued request starts',
+          );
+          third.release();
+
+          await pool.closeAll();
+        });
+
+        test('does not reassign a busy tab with queued work across realms', async function (assert) {
+          let { pool } = makeStubPagePool(1, undefined, undefined, {
+            disableStandbyRefill: true,
+          });
+
+          try {
+            await pool.warmStandbys();
+
+            let first = await pool.getPage('realm-a');
+
+            let secondPromise = pool.getPage('realm-a');
+            let thirdPromise = pool.getPage('realm-b');
+
+            await assert.rejects(
+              thirdPromise,
+              /No standby page available for prerender/,
+              'cross-realm request rejects when only busy tab has queued work',
+            );
+
+            first.release();
+            let second = await secondPromise;
+            assert.strictEqual(
+              second.pageId,
+              first.pageId,
+              'queued same-realm request keeps the original tab',
+            );
+            second.release();
+
+            assert.false(
+              pool.getWarmRealms().includes('realm-b'),
+              'cross-realm request does not reassign the tab',
+            );
+          } finally {
+            await pool.closeAll();
+          }
+        });
+
+        test('queues same-realm request when tab is transitioning', async function (assert) {
+          let { pool } = makeStubPagePool(1, undefined, undefined, {
+            disableStandbyRefill: true,
+          });
+
+          try {
+            await pool.warmStandbys();
+
+            let first = await pool.getPage('realm-a');
+
+            let crossResolved = false;
+            let sameResolved = false;
+            let crossPromise = pool.getPage('realm-b').then((lease) => {
+              crossResolved = true;
+              return lease;
+            });
+            let samePromise = pool.getPage('realm-a').then((lease) => {
+              sameResolved = true;
+              return lease;
+            });
+
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            assert.false(
+              crossResolved,
+              'cross-realm request waits for the busy tab',
+            );
+            assert.false(
+              sameResolved,
+              'same-realm request queues even while transitioning',
+            );
+
+            first.release();
+
+            let cross = await crossPromise;
+            assert.strictEqual(
+              cross.pageId,
+              first.pageId,
+              'cross-realm request uses the existing tab',
+            );
+            cross.release();
+
+            let same = await samePromise;
+            assert.strictEqual(
+              same.pageId,
+              first.pageId,
+              'same-realm request uses the same tab',
+            );
+            assert.false(
+              pool.getWarmRealms().includes('realm-b'),
+              'tab realigned back to realm-a after same-realm request',
+            );
+            same.release();
+          } finally {
+            await pool.closeAll();
+          }
+        });
+
+        test('does not oversubscribe contexts during async eviction', async function (assert) {
+          let prevTabMax = process.env.PRERENDER_REALM_TAB_MAX;
+          let pool: PagePool | undefined;
+          let active = 0;
+          let peak = 0;
+          let resolveClose!: () => void;
+          let closeGate = new Promise<void>((resolve) => {
+            resolveClose = resolve;
+          });
+
+          try {
+            process.env.PRERENDER_REALM_TAB_MAX = '2';
+            ({ pool } = makeStubPagePool(2, undefined, undefined, {
+              closeContextDelay: async () => closeGate,
+              onContextCreated() {
+                active++;
+                peak = Math.max(peak, active);
+              },
+              onContextClosed() {
+                active--;
+              },
+            }));
+
+            await pool.warmStandbys();
+
+            let first = await pool.getPage('realm-a');
+            let second = await pool.getPage('realm-a');
+
+            await pool.disposeRealm('realm-a', { awaitIdle: false });
+            await pool.warmStandbys();
+
+            assert.ok(
+              peak <= 3,
+              'context count stays within maxPages+1 during async eviction',
+            );
+
+            first.release();
+            second.release();
+            resolveClose();
+          } finally {
+            if (resolveClose) {
+              resolveClose();
+            }
+            await pool?.closeAll();
+            if (prevTabMax === undefined) {
+              delete process.env.PRERENDER_REALM_TAB_MAX;
+            } else {
+              process.env.PRERENDER_REALM_TAB_MAX = prevTabMax;
+            }
+          }
+        });
+
+        test('creates spare standby when pool is at capacity', async function (assert) {
+          let { pool, contextsCreated } = makeStubPagePool(1);
+          await pool.warmStandbys();
+          assert.strictEqual(
+            contextsCreated.length,
+            1,
+            'initial standby created up to maxPages',
+          );
+
+          let first = await pool.getPage('realm-standby');
+          assert.false(first.reused, 'first checkout uses standby page');
+
+          await pool.warmStandbys();
+          assert.strictEqual(
+            contextsCreated.length,
+            2,
+            'spare standby created once the only slot is occupied',
+          );
+          first.release();
+          await pool.closeAll();
+        });
+
+        test('standby pages bind to the first realm they serve', async function (assert) {
+          let { pool } = makeStubPagePool(2);
+          await pool.warmStandbys(); // fill initial standbys
+
+          let realmAFirst = await pool.getPage('realm-a');
+          let realmAFirstId = realmAFirst.pageId;
+          realmAFirst.release();
+          await pool.warmStandbys(); // replenish after consuming standby
+          let realmBFirst = await pool.getPage('realm-b');
+          let realmBFirstId = realmBFirst.pageId;
+          realmBFirst.release();
+          await pool.warmStandbys(); // replenish again to keep standbys warm
+
+          let realmASecond = await pool.getPage('realm-a');
+          let realmBSecond = await pool.getPage('realm-b');
+
+          assert.false(realmAFirst.reused, 'first realm A call not reused');
+          assert.false(realmBFirst.reused, 'first realm B call not reused');
+          assert.true(realmASecond.reused, 'realm A reuses its page');
+          assert.true(realmBSecond.reused, 'realm B reuses its page');
+          assert.strictEqual(
+            realmASecond.pageId,
+            realmAFirstId,
+            'realm A keeps the same page',
+          );
+          assert.strictEqual(
+            realmBSecond.pageId,
+            realmBFirstId,
+            'realm B keeps the same page',
+          );
+          assert.notStrictEqual(
+            realmAFirstId,
+            realmBFirstId,
+            'distinct pages per realm from standbys',
+          );
+          realmASecond.release();
+          realmBSecond.release();
+          await pool.closeAll();
+        });
+
+        test('evicts idle realms without touching standbys', async function (assert) {
+          let { pool, contextsCreated, contextsClosed } = makeStubPagePool(2);
+          await pool.warmStandbys();
+
+          assert.strictEqual(
+            contextsCreated.length,
+            2,
+            'initial standbys created up to maxPages',
+          );
+
+          let realmLease = await pool.getPage('realm-a');
+          await pool.warmStandbys(); // ensure standby pool replenishment settles before idle sweep
+          realmLease.release();
+
+          let originalNow = Date.now;
+          try {
+            let now = Date.now();
+            (Date as any).now = () => now + 13 * 60 * 60 * 1000; // 13 hours later
+
+            let evicted = await pool.evictIdleRealms(12 * 60 * 60 * 1000);
+
+            assert.deepEqual(evicted, ['realm-a'], 'idle realm evicted');
+            assert.deepEqual(
+              pool.getWarmRealms(),
+              [],
+              'realm entry removed from warm set',
+            );
+            let closedAtEviction = [...contextsClosed];
+            assert.deepEqual(
+              closedAtEviction,
+              [contextsCreated[0]],
+              'only the realm-bound page closed during idle eviction',
+            );
+            assert.true(
+              contextsCreated.length > closedAtEviction.length,
+              'standby pages remain available after idle eviction',
+            );
+          } finally {
+            (Date as any).now = originalNow;
+            await pool.closeAll();
+          }
+        });
+
+        test('idle eviction skips unassigned standbys', async function (assert) {
+          let { pool, contextsCreated, contextsClosed } = makeStubPagePool(1);
+          await pool.warmStandbys();
+
+          let createdBeforeSweep = contextsCreated.length;
+          let evicted = await pool.evictIdleRealms(1);
+          let closedAfterSweep = contextsClosed.length;
+
+          assert.deepEqual(evicted, [], 'no idle realms to evict');
+          assert.strictEqual(
+            contextsCreated.length,
+            createdBeforeSweep,
+            'standby pool untouched by idle eviction',
+          );
+          assert.strictEqual(
+            closedAfterSweep,
+            0,
+            'no contexts closed when only standbys are present',
+          );
+          await pool.closeAll();
+        });
       });
     });
-  });
+  }
 
   module('prerender - module retries', function () {
     test('module prerender retries with clear cache on retry signature', async function (assert) {

--- a/packages/realm-server/tests/sanitize-head-html-test.ts
+++ b/packages/realm-server/tests/sanitize-head-html-test.ts
@@ -209,5 +209,24 @@ module(basename(__filename), function () {
       assert.ok(result.includes('div'), 'detects div');
       assert.ok(result.includes('h1'), 'detects h1');
     });
+
+    test('ignores wrapper elements when they only contain allowlisted descendants', function (assert) {
+      let doc = makeDoc();
+      let html =
+        '<div><title>Test</title><meta name="description" content="desc"></div>';
+      let result = findDisallowedHeadTags(html, doc);
+      assert.deepEqual(result, [], 'wrapper div is not reported');
+    });
+
+    test('detects disallowed nested tags even when wrapped', function (assert) {
+      let doc = makeDoc();
+      let html = '<div><script>alert(1)</script><title>Test</title></div>';
+      let result = findDisallowedHeadTags(html, doc);
+      assert.ok(result.includes('script'), 'detects nested script');
+      assert.notOk(
+        result.includes('div'),
+        'wrapper div is ignored when it contains allowlisted descendants',
+      );
+    });
   });
 });

--- a/packages/runtime-common/helpers/sanitize-head-html.ts
+++ b/packages/runtime-common/helpers/sanitize-head-html.ts
@@ -36,38 +36,53 @@ export function sanitizeHeadHTML(
 
   let fragment = doc.createDocumentFragment();
   for (let node of Array.from(template.content.childNodes)) {
-    let sanitized = sanitizeHeadNode(node, doc);
-    if (sanitized) {
-      fragment.appendChild(sanitized);
-    }
+    appendSanitizedHeadNodes(node, doc, fragment);
   }
 
   return fragment.childNodes.length > 0 ? fragment : null;
 }
 
-// Reject any non-element nodes (text nodes, comments, document fragments, etc.)
-// so that only explicit, allowlisted <head> elements are inserted
-function sanitizeHeadNode(node: Node, doc: Document): Node | null {
+function appendSanitizedHeadNodes(
+  node: Node,
+  doc: Document,
+  destination: DocumentFragment,
+) {
+  // Reject text/comments and recurse only through element containers.
   if (node.nodeType !== ELEMENT_NODE) {
-    return null;
+    return;
   }
 
   let element = node as Element;
   let tagName = element.tagName.toLowerCase();
-  if (!ALLOWED_HEAD_TAGS.has(tagName)) {
-    return null;
+  if (ALLOWED_HEAD_TAGS.has(tagName)) {
+    let sanitized = sanitizeAllowedHeadElement(element, doc);
+    if (sanitized) {
+      destination.appendChild(sanitized);
+    }
+    return;
   }
 
-  switch (tagName) {
+  // Allowlisted tags may be nested inside wrapper elements produced by
+  // rendering infrastructure. We keep only the allowlisted descendants.
+  for (let child of Array.from(element.childNodes)) {
+    appendSanitizedHeadNodes(child, doc, destination);
+  }
+}
+
+function sanitizeAllowedHeadElement(
+  element: Element,
+  doc: Document,
+): Node | null {
+  switch (element.tagName.toLowerCase()) {
     case 'meta':
       return sanitizeMetaElement(element, doc);
     case 'title':
       return sanitizeTitleElement(element, doc);
     case 'link':
       return sanitizeLinkElement(element, doc);
+    default:
+      return null;
   }
-
-  return null;
 }
 
 function sanitizeMetaElement(element: Element, doc: Document): HTMLMetaElement {

--- a/packages/runtime-common/helpers/sanitize-head-html.ts
+++ b/packages/runtime-common/helpers/sanitize-head-html.ts
@@ -173,16 +173,40 @@ export function findDisallowedHeadTags(
   let template = doc.createElement('template');
   template.innerHTML = headHTML;
 
-  let disallowed: string[] = [];
+  let disallowed = new Set<string>();
   for (let node of Array.from(template.content.childNodes)) {
-    if (node.nodeType === ELEMENT_NODE) {
-      let tagName = (node as Element).tagName.toLowerCase();
-      if (!ALLOWED_HEAD_TAGS.has(tagName) && !disallowed.includes(tagName)) {
-        disallowed.push(tagName);
-      }
-    }
+    collectDisallowedHeadTags(node, disallowed);
   }
-  return disallowed;
+  return Array.from(disallowed);
+}
+
+function collectDisallowedHeadTags(
+  node: Node,
+  disallowed: Set<string>,
+): boolean {
+  if (node.nodeType !== ELEMENT_NODE) {
+    return false;
+  }
+
+  let element = node as Element;
+  let tagName = element.tagName.toLowerCase();
+  if (ALLOWED_HEAD_TAGS.has(tagName)) {
+    return true;
+  }
+
+  let hasAllowlistedDescendant = false;
+  for (let child of Array.from(element.childNodes)) {
+    hasAllowlistedDescendant =
+      collectDisallowedHeadTags(child, disallowed) || hasAllowlistedDescendant;
+  }
+
+  // Wrapper-only nodes around allowlisted tags are expected from rendering
+  // infrastructure and are stripped by the sanitizer, so we don't warn for
+  // those wrappers.
+  if (!hasAllowlistedDescendant) {
+    disallowed.add(tagName);
+  }
+  return hasAllowlistedDescendant;
 }
 
 function copyAllowedAttributes(


### PR DESCRIPTION
This PR refactors the order in which we do prerendering as well as uses consistent async barriers across the different format rendering so that we capture all of the links from non-isolated formats. This means that we can back out the `isUsed: true` workaround that we added to the `CardInfo`. 

Additionally, this PR fixes a memory leak around AI stopping and starting tests leaving orphaned prerendering processes still running.

This PR also reorganizes the prerender tests to use realm setup/teardown more efficiently, such that the tests now run in less than 1/2 the amount of time as they used to (sorry for all the test churn--i pointed out in comments the new key assertions).