### PR TITLE
index: Fix extraction of card module

### DIFF
--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -403,6 +403,41 @@ function makeTestRealmFileSystem(): Record<
         },
       },
     },
+    'address.gts': `
+      import { contains, field, FieldDef } from "https://cardstack.com/base/card-api";
+      import StringField from "https://cardstack.com/base/string";
+
+      export class Address extends FieldDef {
+        @field street = contains(StringField);
+        @field city = contains(StringField);
+      }
+    `,
+    'order-page.gts': `
+      import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
+      import { Address } from "./address";
+
+      export class OrderPage extends CardDef {
+        @field shippingAddress = contains(Address);
+      }
+    `,
+    'fieldof-address.json': {
+      data: {
+        attributes: {
+          street: '123 Main St',
+          city: 'Anytown',
+        },
+        meta: {
+          adoptsFrom: {
+            type: 'fieldOf',
+            field: 'shippingAddress',
+            card: {
+              module: './order-page',
+              name: 'OrderPage',
+            },
+          },
+        },
+      },
+    },
     'filedef-mismatch.gts': `
       import {
         FileDef as BaseFileDef,
@@ -787,6 +822,17 @@ module(basename(__filename), function () {
         );
       } else {
         assert.ok(false, `could not find ${hassanId} in the index`);
+      }
+    });
+
+    test('it can index a card whose adoptsFrom is a fieldOf CodeRef', async function (assert) {
+      const cardId = `${testRealm}fieldof-address`;
+      let entry = await getInstance(realm, new URL(cardId));
+      if (entry) {
+        assert.strictEqual(entry.searchDoc?.street, '123 Main St');
+        assert.strictEqual(entry.searchDoc?.city, 'Anytown');
+      } else {
+        assert.ok(false, `could not find ${cardId} in the index`);
       }
     });
 

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -23,8 +23,8 @@ import {
   type LocalPath,
   type Reader,
   type Stats,
+  type ResolvedCodeRef,
 } from './index';
-import { moduleFrom } from './code-ref';
 import type { CacheScope, DefinitionLookup } from './definition-lookup';
 import { resolveCardReference } from './card-reference-resolver';
 import { isCardError } from './error';
@@ -402,7 +402,7 @@ export class IndexRunner {
         realm: this.#realmURL.href,
         deps: [
           resolveCardReference(
-            moduleFrom(resource.meta.adoptsFrom),
+            (resource.meta.adoptsFrom as ResolvedCodeRef).module,
             url,
           ),
         ],

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -23,8 +23,8 @@ import {
   type LocalPath,
   type Reader,
   type Stats,
-  type ResolvedCodeRef,
 } from './index';
+import { moduleFrom } from './code-ref';
 import type { CacheScope, DefinitionLookup } from './definition-lookup';
 import { resolveCardReference } from './card-reference-resolver';
 import { isCardError } from './error';
@@ -402,7 +402,7 @@ export class IndexRunner {
         realm: this.#realmURL.href,
         deps: [
           resolveCardReference(
-            (resource.meta.adoptsFrom as ResolvedCodeRef).module,
+            moduleFrom(resource.meta.adoptsFrom),
             url,
           ),
         ],

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -10,7 +10,6 @@ import {
   Deferred,
   RealmPaths,
   type IndexWriter,
-  type ResolvedCodeRef,
   type Batch,
   type LooseCardResource,
   type InstanceEntry,
@@ -25,6 +24,7 @@ import {
   type Reader,
   type Stats,
 } from './index';
+import { moduleFrom } from './code-ref';
 import type { CacheScope, DefinitionLookup } from './definition-lookup';
 import { resolveCardReference } from './card-reference-resolver';
 import { isCardError } from './error';
@@ -402,7 +402,7 @@ export class IndexRunner {
         realm: this.#realmURL.href,
         deps: [
           resolveCardReference(
-            (resource.meta.adoptsFrom as ResolvedCodeRef).module,
+            moduleFrom(resource.meta.adoptsFrom),
             url,
           ),
         ],

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -400,12 +400,7 @@ export class IndexRunner {
         ...this.#jobInfo,
         url,
         realm: this.#realmURL.href,
-        deps: [
-          resolveCardReference(
-            moduleFrom(resource.meta.adoptsFrom),
-            url,
-          ),
-        ],
+        deps: [resolveCardReference(moduleFrom(resource.meta.adoptsFrom), url)],
       },
       status,
     );


### PR DESCRIPTION
A card with this `meta`:

```
  …
    "meta": {
      "adoptsFrom": {
        "type": "fieldOf",
        "field": "savedAddresses",
        "card": {
          "module": "https://realms-staging.stack.cards/…/checkout-page",
          "name": "CheckoutPage"
        }
      }
    }
  }
}
```

Produced an error in Sentry:

<img width="821" height="646" alt="TypeError: Cannot read properties of undefined (reading &#39;startsWith&#39;) — cardstack — realm-server 2026-02-26 19-20-51" src="https://github.com/user-attachments/assets/0aed9508-18f9-4188-b459-ecb7f164d0cb" />

The calling function has an invalid cast that assumes a structure for `meta.adoptsFrom` that doesn’t apply to all cards. `moduleFrom` exists for this exact purpose.

The test file additions [produced the expected errors](https://github.com/cardstack/boxel/actions/runs/22470185071/job/65085450456) when run without the fix.