### PR TITLE
Skip auto-attaching errored card instances to AI Assistant

### DIFF
--- a/packages/host/app/resources/auto-attached-card.ts
+++ b/packages/host/app/resources/auto-attached-card.ts
@@ -88,11 +88,12 @@ export class AutoAttachment extends Resource<Args> {
             continue;
           }
           let card = await this.store.get(item.id);
-          if (card && isCardInstance(card)) {
-            let realmURL = card[realmURLSymbol];
-            if (realmURL && item.id === `${realmURL.href}index`) {
-              continue;
-            }
+          if (!card || !isCardInstance(card)) {
+            continue;
+          }
+          let realmURL = card[realmURLSymbol];
+          if (realmURL && item.id === `${realmURL.href}index`) {
+            continue;
           }
           this.cardIds.add(item.id);
         }
@@ -108,7 +109,10 @@ export class AutoAttachment extends Resource<Args> {
           !removedCardIds?.includes(cardId) &&
           !attachedCardIds?.includes(cardId)
         ) {
-          this.cardIds.add(cardId);
+          let card = await this.store.get(cardId);
+          if (card && isCardInstance(card)) {
+            this.cardIds.add(cardId);
+          }
         }
         if (
           moduleInspectorPanel === 'preview' &&

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -367,6 +367,29 @@ module('Acceptance | AI Assistant tests', function (hooks) {
         ...SYSTEM_CARD_FIXTURE_CONTENTS,
         'person.gts': { Person },
         'pet.gts': { Pet },
+        'broken-card.gts': `
+          import { CardDef, field, contains } from 'https://cardstack.com/base/card-api';
+          import StringField from 'https://cardstack.com/base/string';
+          import { BrokenField } from './does-not-exist';
+          export class BrokenCard extends CardDef {
+            static displayName = 'Broken Card';
+            @field name = contains(StringField);
+            @field broken = contains(BrokenField);
+          }
+        `,
+        'BrokenCard/errored.json': {
+          data: {
+            attributes: {
+              name: 'Errored Instance',
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../broken-card',
+                name: 'BrokenCard',
+              },
+            },
+          },
+        },
         'country.gts': countryDefinition,
         'Country/indonesia.json': {
           data: {
@@ -882,6 +905,28 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     assert.dom('[data-test-autoattached-card]').exists();
     await click(`[data-test-autoattached-card] [data-test-remove-card-btn]`);
     assert.dom('[data-test-autoattached-card]').doesNotExist();
+  });
+
+  test('errored card instance is not auto-attached in code mode', async function (assert) {
+    // Start directly in code mode with the errored card's JSON file
+    await visitOperatorMode({
+      submode: 'code',
+      codePath: `${testRealmURL}BrokenCard/errored.json`,
+      stacks: [[]],
+    });
+    await click('[data-test-open-ai-assistant]');
+    await waitFor(`[data-room-settled]`);
+
+    // The JSON file itself should still be auto-attached as a file
+    assert
+      .dom('[data-test-autoattached-file]')
+      .exists('errored card JSON file should still be auto-attached as a file');
+    // But the card instance should NOT be auto-attached (it has errors)
+    assert
+      .dom('[data-test-autoattached-card]')
+      .doesNotExist(
+        'errored card instance should not be auto-attached as a card',
+      );
   });
 
   test<TestContextWithSave>('can send a newly created auto-attached card', async function (assert) {


### PR DESCRIPTION
## Summary
- When viewing an errored card instance in code mode, the AI Assistant would auto-attach it, triggering cascading 500 errors, Glimmer VM corruption, and `operatorModeStateService` crashes (CS-10289)
- Now validates cards via `store.get()` + `isCardInstance()` before adding them to the auto-attachment set — errored cards are skipped
- Also fixes a pre-existing issue in Interact mode where errored stack cards were still auto-attached

## Test plan
- [ ] Open a card instance in code mode that has an error (e.g. references a nonexistent type)
- [ ] Verify the AI Assistant does not throw errors or show cascading console errors
- [ ] Verify the "Fix with AI" button in the runtime error banner still works
- [ ] Verify auto-attachment still works for healthy cards in both code and interact modes
- [ ] Verify that `.gts`/`.ts` file auto-attachment in code mode is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)