### PR TITLE
CS-10288: Fix RangeError when opening Past Sessions menu

### DIFF
--- a/packages/host/app/components/ai-assistant/past-session-item.gts
+++ b/packages/host/app/components/ai-assistant/past-session-item.gts
@@ -301,12 +301,14 @@ export default class PastSessionItem extends Component<Signature> {
   }
 
   private get lastActive() {
-    return (
+    let timestamp =
       this.matrixService.getLastActiveTimestamp(
         this.args.session.roomId,
         this.args.session.lastActiveTimestamp,
-      ) ?? this.createDate.getTime()
-    );
+      ) ?? this.createDate.getTime();
+    // Guard against NaN timestamps (e.g. from sessions with corrupt/missing
+    // origin_server_ts) to prevent RangeError in date-fns format()
+    return isNaN(timestamp) ? Date.now() : timestamp;
   }
 
   private get formattedDate() {

--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -327,7 +327,10 @@ export class RoomResource extends Resource<Args> {
   @cached
   get created() {
     if (this._createEvent) {
-      return new Date(this._createEvent.origin_server_ts);
+      let d = new Date(this._createEvent.origin_server_ts);
+      if (!isNaN(d.getTime())) {
+        return d;
+      }
     }
     // there is a race condition in the matrix SDK where newly created
     // rooms don't immediately have a created date

--- a/packages/host/app/services/ai-assistant-panel-service.ts
+++ b/packages/host/app/services/ai-assistant-panel-service.ts
@@ -598,7 +598,7 @@ export default class AiAssistantPanelService extends Service {
         ) -
         this.matrixService.getLastActiveTimestamp(
           a.roomId,
-          b.lastActiveTimestamp,
+          a.lastActiveTimestamp,
         ),
     );
   }

--- a/packages/host/tests/integration/components/ai-assistant-panel/past-sessions-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/past-sessions-test.gts
@@ -358,10 +358,8 @@ module('Integration | ai-assistant-panel | past sessions', function (hooks) {
     );
     assert.ok(lastActiveEl, 'last-active element is present');
     let rawValue = lastActiveEl?.getAttribute('data-test-last-active') ?? '';
-    assert.ok(
-      rawValue !== '' && !isNaN(Number(rawValue)),
-      `data-test-last-active is a valid finite number (got: ${rawValue})`,
-    );
+    assert.ok(rawValue !== '', `data-test-last-active should not be empty (got: ${rawValue})`);
+    assert.ok(!isNaN(Number(rawValue)), `data-test-last-active is a valid finite number (got: ${rawValue})`);
 
     // The formatted date text must be non-empty (date-fns rendered successfully)
     let dateText = document
@@ -398,11 +396,8 @@ module('Integration | ai-assistant-panel | past sessions', function (hooks) {
     let recentIdx = roomIds.indexOf(recentRoomId);
     let oldIdx = roomIds.indexOf(oldRoomId);
 
-    assert.ok(
-      recentIdx !== -1,
-      'recent session is present in the list',
-    );
-    assert.ok(oldIdx !== -1, 'old session is present in the list');
+    assert.notStrictEqual(recentIdx, -1, 'recent session is present in the list');
+    assert.notStrictEqual(oldIdx, -1, 'old session is present in the list');
     assert.ok(
       recentIdx < oldIdx,
       `most recently active session (index ${recentIdx}) appears before the oldest one (index ${oldIdx})`,

--- a/packages/host/tests/integration/components/ai-assistant-panel/past-sessions-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/past-sessions-test.gts
@@ -330,6 +330,85 @@ module('Integration | ai-assistant-panel | past sessions', function (hooks) {
       .doesNotHaveAttribute('data-is-current-room');
   });
 
+  test('does not crash when a session has a missing or corrupt origin_server_ts (CS-10288 regression)', async function (assert) {
+    // Simulate a room whose create event has no valid origin_server_ts.
+    // Passing NaN as the timestamp exercises the full bug path:
+    //   new Date(NaN) → Invalid Date → getTime() → NaN → propagates to
+    //   formatDate(NaN) → RangeError: Invalid time value
+    let corruptRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'Corrupt Session',
+      timestamp: NaN,
+    });
+
+    await renderAiAssistantPanel();
+
+    await click('[data-test-past-sessions-button]');
+    await waitFor('[data-test-past-sessions]');
+
+    // The session must appear in the list without throwing an error
+    assert
+      .dom(`[data-test-joined-room="${corruptRoomId}"]`)
+      .exists('corrupt session is displayed in the past-sessions list');
+
+    // The rendered last-active timestamp must be a finite number — not NaN —
+    // which would have caused date-fns to throw before the fix
+    let lastActiveEl = document.querySelector(
+      `[data-test-joined-room="${corruptRoomId}"] [data-test-last-active]`,
+    );
+    assert.ok(lastActiveEl, 'last-active element is present');
+    let rawValue = lastActiveEl?.getAttribute('data-test-last-active') ?? '';
+    assert.ok(
+      rawValue !== '' && !isNaN(Number(rawValue)),
+      `data-test-last-active is a valid finite number (got: ${rawValue})`,
+    );
+
+    // The formatted date text must be non-empty (date-fns rendered successfully)
+    let dateText = document
+      .querySelector(`[data-test-joined-room="${corruptRoomId}"] .date`)
+      ?.textContent?.trim();
+    assert.ok(dateText, 'formatted date is non-empty for corrupt session');
+  });
+
+  test('sessions are sorted by most recently active first (CS-10288 sort fix regression)', async function (assert) {
+    // Create two sessions with known timestamps so we can assert DOM order.
+    // timestamp: 1 → epoch + 1 ms (ancient), well before any real session.
+    // timestamp: 2_000_000_000_000 → year 2033, well after any real session.
+    let oldRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'Old Session',
+      timestamp: 1,
+    });
+    let recentRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'Recent Session',
+      timestamp: 2_000_000_000_000,
+    });
+
+    await renderAiAssistantPanel();
+
+    await click('[data-test-past-sessions-button]');
+    await waitFor('[data-test-past-sessions]');
+
+    let sessionItems = document.querySelectorAll('[data-test-joined-room]');
+    let roomIds = [...sessionItems].map(
+      (el) => el.getAttribute('data-test-joined-room') ?? '',
+    );
+
+    let recentIdx = roomIds.indexOf(recentRoomId);
+    let oldIdx = roomIds.indexOf(oldRoomId);
+
+    assert.ok(
+      recentIdx !== -1,
+      'recent session is present in the list',
+    );
+    assert.ok(oldIdx !== -1, 'old session is present in the list');
+    assert.ok(
+      recentIdx < oldIdx,
+      `most recently active session (index ${recentIdx}) appears before the oldest one (index ${oldIdx})`,
+    );
+  });
+
   test('can copy room id to clipboard', async function (assert) {
     let roomId = await renderAiAssistantPanel();
 

--- a/packages/host/tests/integration/components/ai-assistant-panel/past-sessions-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/past-sessions-test.gts
@@ -358,8 +358,15 @@ module('Integration | ai-assistant-panel | past sessions', function (hooks) {
     );
     assert.ok(lastActiveEl, 'last-active element is present');
     let rawValue = lastActiveEl?.getAttribute('data-test-last-active') ?? '';
-    assert.ok(rawValue !== '', `data-test-last-active should not be empty (got: ${rawValue})`);
-    assert.ok(!isNaN(Number(rawValue)), `data-test-last-active is a valid finite number (got: ${rawValue})`);
+    assert.notStrictEqual(
+      rawValue,
+      '',
+      `data-test-last-active should not be empty (got: ${rawValue})`,
+    );
+    assert.notOk(
+      isNaN(Number(rawValue)),
+      `data-test-last-active is a valid finite number (got: ${rawValue})`,
+    );
 
     // The formatted date text must be non-empty (date-fns rendered successfully)
     let dateText = document
@@ -396,7 +403,11 @@ module('Integration | ai-assistant-panel | past sessions', function (hooks) {
     let recentIdx = roomIds.indexOf(recentRoomId);
     let oldIdx = roomIds.indexOf(oldRoomId);
 
-    assert.notStrictEqual(recentIdx, -1, 'recent session is present in the list');
+    assert.notStrictEqual(
+      recentIdx,
+      -1,
+      'recent session is present in the list',
+    );
     assert.notStrictEqual(oldIdx, -1, 'old session is present in the list');
     assert.ok(
       recentIdx < oldIdx,


### PR DESCRIPTION
## Summary

Fixes the `RangeError: Invalid time value` crash that occurs when opening the AI Assistant Past Sessions menu.

Fixes: CS-10288

## Root Cause

Sessions with a missing or undefined `origin_server_ts` on their Matrix create event produced an Invalid Date via `new Date(undefined)`. Calling `.getTime()` on an Invalid Date returns `NaN`, which silently propagates through:

```
room.ts created getter
  → room.ts lastActiveTimestamp getter (fallback)
    → ai-assistant-panel-service aiSessionRooms
      → past-session-item.gts lastActive getter
        → formattedDate getter
          → date-fns format(NaN, ...) → RangeError: Invalid time value 💥
```

The `??` (nullish coalescing) operators in the chain don't catch `NaN` since it's not `null`/`undefined`.

## Changes

**`packages/host/app/resources/room.ts`** — Root cause fix  
Validate the date constructed from `_createEvent.origin_server_ts` before returning it. If it's an Invalid Date, fall back to `new Date()` (same as the no-create-event path).

**`packages/host/app/components/ai-assistant/past-session-item.gts`** — Safety net  
Add an `isNaN` guard in `lastActive` to catch any remaining paths that could produce a NaN timestamp, falling back to `Date.now()`.

**`packages/host/app/services/ai-assistant-panel-service.ts`** — Sort bug fix  
Fix a copy-paste bug in the session sort comparator: the fallback timestamp for item `a` was using `b.lastActiveTimestamp` instead of `a.lastActiveTimestamp`, causing incorrect session ordering.