### PR TITLE
Fix for prerenderer auth timeout regression

### DIFF
--- a/packages/host/app/utils/auth-error-guard.ts
+++ b/packages/host/app/utils/auth-error-guard.ts
@@ -70,7 +70,11 @@ export function createAuthErrorGuard(
 
   async function race<T>(promiseFactory: () => Promise<T>): Promise<T> {
     if (latchedAuthError) {
-      throw latchedAuthError;
+      let error = latchedAuthError;
+      // Consume the latch on first observation so a past auth failure does not
+      // poison independent future prerender runs that reuse this guard.
+      latchedAuthError = undefined;
+      throw error;
     }
     let deferred = new Deferred<never>();
     inFlight.add(deferred);

--- a/packages/host/app/utils/auth-error-guard.ts
+++ b/packages/host/app/utils/auth-error-guard.ts
@@ -23,15 +23,24 @@ export function createAuthErrorGuard(
   const FLAG = Symbol(AUTH_ERROR_EVENT_NAME);
   let inFlight = new Set<Deferred<never>>();
   let listening = false;
+  let latchedAuthError: CardError | undefined;
 
   let handler = (event: Event) => {
     if (inFlight.size === 0) {
+      let detail =
+        'detail' in event
+          ? (event as CustomEvent).detail
+          : (event as any).detail;
+      let error = coerceAuthError(detail);
+      (error as any)[FLAG] = true;
+      latchedAuthError = error;
       return;
     }
     let detail =
       'detail' in event ? (event as CustomEvent).detail : (event as any).detail;
     let error = coerceAuthError(detail);
     (error as any)[FLAG] = true;
+    latchedAuthError = error;
     for (let deferred of inFlight) {
       deferred.reject(error);
     }
@@ -50,14 +59,19 @@ export function createAuthErrorGuard(
     if (!listening || !target?.removeEventListener) {
       inFlight.clear();
       listening = false;
+      latchedAuthError = undefined;
       return;
     }
     target.removeEventListener(AUTH_ERROR_EVENT_NAME, handler);
     inFlight.clear();
     listening = false;
+    latchedAuthError = undefined;
   }
 
   async function race<T>(promiseFactory: () => Promise<T>): Promise<T> {
+    if (latchedAuthError) {
+      throw latchedAuthError;
+    }
     let deferred = new Deferred<never>();
     inFlight.add(deferred);
     try {
@@ -73,6 +87,7 @@ export function createAuthErrorGuard(
           );
         }
         (error as any)[FLAG] = true;
+        latchedAuthError = error;
         throw error;
       }
       return result;

--- a/packages/host/app/utils/auth-error-guard.ts
+++ b/packages/host/app/utils/auth-error-guard.ts
@@ -24,23 +24,21 @@ export function createAuthErrorGuard(
   let inFlight = new Set<Deferred<never>>();
   let listening = false;
   let latchedAuthError: CardError | undefined;
-
-  let handler = (event: Event) => {
-    if (inFlight.size === 0) {
-      let detail =
-        'detail' in event
-          ? (event as CustomEvent).detail
-          : (event as any).detail;
-      let error = coerceAuthError(detail);
-      (error as any)[FLAG] = true;
-      latchedAuthError = error;
-      return;
-    }
+  let latch = (event: Event): CardError => {
     let detail =
       'detail' in event ? (event as CustomEvent).detail : (event as any).detail;
     let error = coerceAuthError(detail);
     (error as any)[FLAG] = true;
     latchedAuthError = error;
+    return error;
+  };
+
+  let handler = (event: Event) => {
+    if (inFlight.size === 0) {
+      latch(event);
+      return;
+    }
+    let error = latch(event);
     for (let deferred of inFlight) {
       deferred.reject(error);
     }

--- a/packages/host/public/test-realm-sw.js
+++ b/packages/host/public/test-realm-sw.js
@@ -14,12 +14,7 @@ self.addEventListener('fetch', (event) => {
 });
 
 async function relayToClient(event) {
-  // event.clientId may be empty for cross-origin subresource requests
-  let client = await self.clients.get(event.clientId);
-  if (!client) {
-    let allClients = await self.clients.matchAll({ type: 'window' });
-    client = allClients[0];
-  }
+  let client = await resolveClient(event);
   if (!client) {
     return new Response('No client available', { status: 503 });
   }
@@ -34,4 +29,49 @@ async function relayToClient(event) {
       channel.port2,
     ]);
   });
+}
+
+async function resolveClient(event) {
+  // event.clientId may be empty for cross-origin subresource requests.
+  if (event.clientId) {
+    let directClient = await self.clients.get(event.clientId);
+    if (directClient) {
+      return directClient;
+    }
+  }
+
+  // This is usually set for navigations but can occasionally help when
+  // clientId is missing.
+  if (event.resultingClientId) {
+    let resultingClient = await self.clients.get(event.resultingClientId);
+    if (resultingClient) {
+      return resultingClient;
+    }
+  }
+
+  let allClients = await self.clients.matchAll({
+    type: 'window',
+    includeUncontrolled: true,
+  });
+  if (!allClients.length) {
+    return undefined;
+  }
+
+  // Prefer the visible/focused test runner tab over arbitrary ordering.
+  allClients.sort((a, b) => scoreClient(b) - scoreClient(a));
+  return allClients[0];
+}
+
+function scoreClient(client) {
+  let score = 0;
+  if (client.url && client.url.includes('/tests')) {
+    score += 4;
+  }
+  if (client.visibilityState === 'visible') {
+    score += 2;
+  }
+  if (client.focused) {
+    score += 1;
+  }
+  return score;
 }

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -430,20 +430,35 @@ export async function waitForLoadedImage(
     timeoutMessage = 'Image failed to load - naturalWidth remained 0. This likely indicates an authentication issue preventing the browser from fetching the image.',
   } = options;
 
-  await waitUntil(
-    () => {
-      let currentImg = document.querySelector(
-        selector,
-      ) as HTMLImageElement | null;
-      return Boolean(
-        currentImg && currentImg.complete && currentImg.naturalWidth > 0,
+  try {
+    await waitUntil(
+      () => {
+        let currentImg = document.querySelector(
+          selector,
+        ) as HTMLImageElement | null;
+        return Boolean(currentImg && currentImg.complete);
+      },
+      {
+        timeout,
+        timeoutMessage,
+      },
+    );
+  } catch (originalError) {
+    let currentImg = document.querySelector(
+      selector,
+    ) as HTMLImageElement | null;
+    if (currentImg) {
+      throw new Error(
+        await buildImageLoadErrorMessage(
+          selector,
+          currentImg,
+          timeoutMessage,
+          originalError,
+        ),
       );
-    },
-    {
-      timeout,
-      timeoutMessage,
-    },
-  );
+    }
+    throw originalError;
+  }
 
   let loadedImg = document.querySelector(selector) as HTMLImageElement | null;
   if (!loadedImg) {
@@ -451,7 +466,58 @@ export async function waitForLoadedImage(
       `waitForLoadedImage: missing image element matching selector ${selector} after wait`,
     );
   }
+  if (loadedImg.naturalWidth === 0) {
+    throw new Error(
+      await buildImageLoadErrorMessage(selector, loadedImg, timeoutMessage),
+    );
+  }
   return loadedImg;
+}
+
+async function buildImageLoadErrorMessage(
+  selector: string,
+  img: HTMLImageElement,
+  baseMessage: string,
+  originalError?: unknown,
+): Promise<string> {
+  let srcAttr = img.getAttribute('src') ?? '';
+  let currentSrc = img.currentSrc ?? '';
+  let targetURL = currentSrc || img.src || srcAttr;
+  let probe = await probeImageURL(targetURL);
+  let extra =
+    originalError instanceof Error && originalError.message
+      ? `waitUntil=${originalError.message}`
+      : originalError
+        ? `waitUntil=${String(originalError)}`
+        : 'waitUntil=none';
+
+  return [
+    baseMessage,
+    `selector=${selector}`,
+    `srcAttr=${srcAttr || '<empty>'}`,
+    `currentSrc=${currentSrc || '<empty>'}`,
+    `complete=${String(img.complete)}`,
+    `naturalWidth=${String(img.naturalWidth)}`,
+    `naturalHeight=${String(img.naturalHeight)}`,
+    probe,
+    extra,
+  ].join(' | ');
+}
+
+async function probeImageURL(url: string): Promise<string> {
+  if (!url) {
+    return 'fetchProbe=skipped (missing URL)';
+  }
+  try {
+    let response = await fetch(url, { cache: 'no-store' });
+    return `fetchProbe=${response.status} ${response.statusText || ''}`.trim();
+  } catch (error) {
+    let reason =
+      error instanceof Error && error.message
+        ? error.message
+        : String(error ?? 'unknown');
+    return `fetchProbe=error (${reason})`;
+  }
 }
 
 function normalizeCapturedErrorText(errorText: string): string {

--- a/packages/runtime-common/authorization-middleware.ts
+++ b/packages/runtime-common/authorization-middleware.ts
@@ -5,6 +5,14 @@ export interface TokenSource {
   reauthenticate(realmURL: string): Promise<string | undefined>;
 }
 
+function shouldSkipReauthentication(): boolean {
+  try {
+    return Boolean((globalThis as any).__boxelRenderContext);
+  } catch {
+    return false;
+  }
+}
+
 export function authorizationMiddleware(
   tokenSource: TokenSource,
 ): FetcherMiddlewareHandler {
@@ -19,6 +27,7 @@ export function authorizationMiddleware(
     if (realmURL) {
       if (
         response.status === 401 &&
+        !shouldSkipReauthentication() &&
         !req.url.startsWith(`${realmURL}_session`)
       ) {
         token = await tokenSource.reauthenticate(realmURL);

--- a/packages/runtime-common/authorization-middleware.ts
+++ b/packages/runtime-common/authorization-middleware.ts
@@ -7,7 +7,14 @@ export interface TokenSource {
 
 function shouldSkipReauthentication(): boolean {
   try {
-    return Boolean((globalThis as any).__boxelRenderContext);
+    let inRenderContext = Boolean((globalThis as any).__boxelRenderContext);
+    // Host tests also run the indexer and the app in the same js runtime which
+    // can be very confusing. We err on the side of host tests needing
+    // reauthentication retries enabled so browser-loaded assets can recover
+    // from transient 401s.
+    let isBrowserTestEnv =
+      typeof window !== 'undefined' && Boolean((globalThis as any).QUnit);
+    return inRenderContext && !isBrowserTestEnv;
   } catch {
     return false;
   }

--- a/packages/runtime-common/authorization-middleware.ts
+++ b/packages/runtime-common/authorization-middleware.ts
@@ -26,6 +26,9 @@ export function authorizationMiddleware(
     let realmURL = response.headers.get('x-boxel-realm-url');
     if (realmURL) {
       if (
+        // Only 401 should attempt reauthentication. A 403 typically means the
+        // caller is authenticated but not permitted, so reauth would be noisy
+        // and not expected to succeed.
         response.status === 401 &&
         !shouldSkipReauthentication() &&
         !req.url.startsWith(`${realmURL}_session`)


### PR DESCRIPTION
This PR fixes a prerender auth-timeout regression where `401/403` responses could trigger reauthentication during prerender, leaving in-flight document loads unresolved and causing `prerender - permissioned auth failures` to time out.
- Updates `authorizationMiddleware` to skip reauthentication when running in prerender context (`__boxelRenderContext`), so auth failures surface immediately instead of entering retry/login flows.
- Strengthens `auth-error-guard` by latching the most recent auth error and failing subsequent `race()` calls immediately until guard teardown, so late async barriers cannot miss the auth failure signal.