### PR TITLE
Refactor PrerenderedCardSearch to use live search during render/indexing context

### DIFF
--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -3,6 +3,7 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { isDestroyed, isDestroying } from '@ember/destroyable';
 import { getOwner } from '@ember/owner';
 import { precompileTemplate } from '@ember/template-compilation';
+import { isTesting } from '@embroider/macros';
 import Component from '@glimmer/component';
 
 import TriangleAlert from '@cardstack/boxel-icons/triangle-alert';
@@ -13,16 +14,19 @@ import { CardContainer } from '@cardstack/boxel-ui/components';
 
 import {
   RealmPaths,
+  CardContextName,
   type PrerenderedCardLike,
   type PrerenderedCardData,
   type PrerenderedCardComponentSignature,
-  CardContextName,
 } from '@cardstack/runtime-common';
 
-import type { CardContext } from 'https://cardstack.com/base/card-api';
+import type { CardContext, CardDef } from 'https://cardstack.com/base/card-api';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 import { type HTMLComponent, htmlComponent } from '../lib/html-component';
+import { getLivePrerenderedSearch } from '../resources/live-prerendered-search';
 import { getPrerenderedSearch } from '../resources/prerendered-search';
+import { getSearch } from '../resources/search';
 
 const OWNER_DESTROYED_ERROR =
   "Cannot call `.lookup('renderer:-dom')` after the owner has been destroyed";
@@ -171,14 +175,52 @@ export default class PrerenderedCardSearch extends Component<PrerenderedCardComp
     }
   }
 
-  private searchResource = getPrerenderedSearch(this, getOwner(this)!, () => ({
-    query: this.args.query,
-    format: this.args.format,
-    realms: this.args.realms,
-    cardUrls: this.args.cardUrls,
-    isLive: this.args.isLive ?? false,
-    cardComponentModifier: this.cardComponentModifier,
-  }));
+  private prerenderedSearchResource = getPrerenderedSearch(
+    this,
+    getOwner(this)!,
+    () => ({
+      query: this.shouldUseRenderContextSearch ? undefined : this.args.query,
+      format: this.shouldUseRenderContextSearch ? undefined : this.args.format,
+      realms: this.args.realms,
+      cardUrls: this.args.cardUrls,
+      isLive: this.args.isLive ?? false,
+      cardComponentModifier: this.cardComponentModifier,
+    }),
+  );
+
+  private renderContextSearchResource = getSearch<CardDef | FileDef>(
+    this,
+    getOwner(this)!,
+    () => this.args.query,
+    () => this.args.realms,
+    {
+      isLive: false,
+      storeService: getOwner(this)!.lookup('service:render-store') as any,
+    },
+  );
+
+  private renderContextPrerenderedSearchResource = getLivePrerenderedSearch(
+    this,
+    getOwner(this)!,
+    () => ({
+      instances: this.renderContextSearchResource.instances,
+      isLoading: this.renderContextSearchResource.isLoading,
+      meta: this.renderContextSearchResource.meta,
+      format: this.args.format,
+      realms: this.args.realms,
+      cardComponentModifier: this.cardComponentModifier,
+    }),
+  );
+
+  private get shouldUseRenderContextSearch() {
+    return Boolean((globalThis as any).__boxelRenderContext) && !isTesting();
+  }
+
+  private get searchResource() {
+    return this.shouldUseRenderContextSearch
+      ? this.renderContextPrerenderedSearchResource
+      : this.prerenderedSearchResource;
+  }
 
   private get searchResults() {
     return {

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -206,7 +206,7 @@ export default class PrerenderedCardSearch extends Component<PrerenderedCardComp
       instances: this.renderContextSearchResource.instances,
       isLoading: this.renderContextSearchResource.isLoading,
       meta: this.renderContextSearchResource.meta,
-      format: this.args.format,
+      format: this.shouldUseRenderContextSearch ? this.args.format : undefined,
       realms: this.args.realms,
       cardComponentModifier: this.cardComponentModifier,
     }),

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -191,7 +191,7 @@ export default class PrerenderedCardSearch extends Component<PrerenderedCardComp
   private renderContextSearchResource = getSearch<CardDef | FileDef>(
     this,
     getOwner(this)!,
-    () => this.args.query,
+    () => (this.shouldUseRenderContextSearch ? this.args.query : undefined),
     () => this.args.realms,
     {
       isLive: false,

--- a/packages/host/app/resources/live-prerendered-search.ts
+++ b/packages/host/app/resources/live-prerendered-search.ts
@@ -1,0 +1,235 @@
+import type Owner from '@ember/owner';
+import { setOwner } from '@ember/owner';
+import { service } from '@ember/service';
+import { buildWaiter } from '@ember/test-waiters';
+import { tracked } from '@glimmer/tracking';
+
+import { restartableTask } from 'ember-concurrency';
+import { Resource } from 'ember-modify-based-class-resource';
+
+import { isScopedCSSRequest } from 'glimmer-scoped-css';
+import { TrackedArray } from 'tracked-built-ins';
+
+import type { QueryResultsMeta, Format } from '@cardstack/runtime-common';
+import { Loader } from '@cardstack/runtime-common/loader';
+
+import type { CardDef } from 'https://cardstack.com/base/card-api';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
+
+import { PrerenderedCard } from '../components/prerendered-card-search';
+import { normalizeRealms, resolveCardRealmUrl } from '../lib/realm-utils';
+
+import type LoaderService from '../services/loader-service';
+import type RenderService from '../services/render-service';
+import type RenderStoreService from '../services/render-store';
+
+const waiter = buildWaiter('live-prerendered-search-resource:render-waiter');
+
+type SearchInstance = CardDef | FileDef;
+
+export interface Args {
+  named: {
+    instances: SearchInstance[];
+    isLoading: boolean;
+    meta: QueryResultsMeta;
+    format: Format | undefined;
+    realms: string[] | undefined;
+    cardComponentModifier?: any;
+    owner: Owner;
+  };
+}
+
+function captureModeForFormat(format: Format): 'innerHTML' | 'outerHTML' {
+  switch (format) {
+    case 'isolated':
+    case 'atom':
+    case 'head':
+      return 'innerHTML';
+    default:
+      return 'outerHTML';
+  }
+}
+
+export class LivePrerenderedSearchResource extends Resource<Args> {
+  @service declare private renderService: RenderService;
+  // This resource is only used for card prerendering in render context.
+  @service('render-store') declare private renderStore: RenderStoreService;
+  @service('loader-service') declare private loaderService: LoaderService;
+
+  @tracked private _isLoading = false;
+  private _instances = new TrackedArray<PrerenderedCard>();
+  @tracked private _meta: QueryResultsMeta = { page: { total: 0 } };
+  #loadedScopedCssModules = new Set<string>();
+  #previousSignature: string | undefined;
+
+  modify(_positional: never[], named: Args['named']) {
+    let {
+      owner,
+      instances,
+      isLoading,
+      meta,
+      format,
+      realms,
+      cardComponentModifier,
+    } = named;
+
+    setOwner(this, owner);
+    this._isLoading = isLoading;
+    this._meta = meta;
+
+    if (format === undefined) {
+      this.#previousSignature = undefined;
+      this._instances = new TrackedArray();
+      this.buildPrerenderedCards.cancelAll();
+      return;
+    }
+
+    let signature = JSON.stringify({
+      format,
+      ids: instances.map((instance) => instance.id),
+      realms: realms ?? [],
+    });
+
+    if (signature === this.#previousSignature) {
+      return;
+    }
+    this.#previousSignature = signature;
+
+    let load = this.buildPrerenderedCards.perform(
+      [...instances],
+      format,
+      realms ? normalizeRealms(realms) : [],
+      cardComponentModifier,
+    );
+    this.renderStore.trackLoad(load as unknown as Promise<void>);
+  }
+
+  get instances() {
+    return this._instances;
+  }
+
+  get isLoading() {
+    return this._isLoading || this.buildPrerenderedCards.isRunning;
+  }
+
+  get meta() {
+    return this._meta;
+  }
+
+  private isScopedCssModule(url: string): boolean {
+    try {
+      return isScopedCSSRequest(new URL(url).pathname);
+    } catch {
+      return false;
+    }
+  }
+
+  private async loadScopedCssForInstance(instance: SearchInstance) {
+    let identity = Loader.identify(instance.constructor);
+    if (!identity?.module) {
+      return;
+    }
+    let deps = await this.loaderService.loader.getConsumedModules(
+      identity.module,
+    );
+    let scopedCssModules = deps.filter((dep) => this.isScopedCssModule(dep));
+    let modulesToLoad = scopedCssModules.filter(
+      (moduleURL) => !this.#loadedScopedCssModules.has(moduleURL),
+    );
+    if (modulesToLoad.length === 0) {
+      return;
+    }
+    await Promise.all(
+      modulesToLoad.map(async (moduleURL) => {
+        await this.loaderService.loader.import(moduleURL);
+        this.#loadedScopedCssModules.add(moduleURL);
+      }),
+    );
+  }
+
+  private buildPrerenderedCards = restartableTask(
+    async (
+      instances: SearchInstance[],
+      format: Format,
+      normalizedRealms: string[],
+      cardComponentModifier?: any,
+    ) => {
+      let token = waiter.beginAsync();
+      try {
+        if (instances.length === 0) {
+          this._instances = new TrackedArray();
+          return;
+        }
+        let capture = captureModeForFormat(format);
+        let cards = await Promise.all(
+          instances.map(async (instance) => {
+            let url = instance.id;
+            let realmUrl = resolveCardRealmUrl(url, normalizedRealms);
+            try {
+              await this.loadScopedCssForInstance(instance);
+              let component = (
+                instance.constructor as typeof CardDef
+              ).getComponent(instance as CardDef);
+              let html = await this.renderService.renderCardComponent(
+                component,
+                capture,
+                format,
+              );
+              return new PrerenderedCard(
+                {
+                  url,
+                  realmUrl,
+                  html,
+                  isError: false,
+                },
+                cardComponentModifier,
+              );
+            } catch (error) {
+              console.error(
+                `Failed to render live search result ${url}:`,
+                error,
+              );
+              return new PrerenderedCard(
+                {
+                  url,
+                  realmUrl,
+                  html: '',
+                  isError: true,
+                },
+                cardComponentModifier,
+              );
+            }
+          }),
+        );
+        this._instances = new TrackedArray(cards);
+      } finally {
+        waiter.endAsync(token);
+      }
+    },
+  );
+}
+
+export function getLivePrerenderedSearch(
+  parent: object,
+  owner: Owner,
+  args: () => {
+    instances: SearchInstance[];
+    isLoading: boolean;
+    meta: QueryResultsMeta;
+    format: Format | undefined;
+    realms?: string[];
+    cardComponentModifier?: any;
+  },
+) {
+  return LivePrerenderedSearchResource.from(parent, () => ({
+    named: {
+      instances: args().instances,
+      isLoading: args().isLoading,
+      meta: args().meta,
+      format: args().format,
+      realms: args().realms,
+      cardComponentModifier: args().cardComponentModifier,
+      owner,
+    },
+  }));
+}

--- a/packages/host/app/resources/live-prerendered-search.ts
+++ b/packages/host/app/resources/live-prerendered-search.ts
@@ -116,6 +116,34 @@ export class LivePrerenderedSearchResource extends Resource<Args> {
     return this._meta;
   }
 
+  private async waitForPendingDocumentLoads(): Promise<void> {
+    // Do not call `renderStore.loaded()` here. This task is tracked by
+    // render-store, so waiting on `loaded()` would include ourselves.
+    const maxPasses = 10;
+    const requiredStablePasses = 2;
+    let stablePasses = 0;
+    for (let pass = 0; pass < maxPasses; pass++) {
+      let docsInFlight =
+        this.renderStore.cardDocsInFlight.length +
+        this.renderStore.fileMetaDocsInFlight.length;
+      if (docsInFlight === 0) {
+        stablePasses++;
+      } else {
+        stablePasses = 0;
+      }
+      if (stablePasses >= requiredStablePasses) {
+        return;
+      }
+      if (typeof requestAnimationFrame === 'function') {
+        await new Promise<void>((resolve) =>
+          requestAnimationFrame(() => resolve()),
+        );
+      } else {
+        await Promise.resolve();
+      }
+    }
+  }
+
   private isScopedCssModule(url: string): boolean {
     try {
       return isScopedCSSRequest(new URL(url).pathname);
@@ -174,6 +202,7 @@ export class LivePrerenderedSearchResource extends Resource<Args> {
                 component,
                 capture,
                 format,
+                () => this.waitForPendingDocumentLoads(),
               );
               return new PrerenderedCard(
                 {

--- a/packages/host/app/templates/render/html.gts
+++ b/packages/host/app/templates/render/html.gts
@@ -46,7 +46,8 @@ class RenderHtmlTemplate extends Component<Signature> {
   }
 
   @provide(CardContextName)
-  get context(): CardContext {
+  // @ts-ignore "context" is declared but not used
+  private get context(): CardContext {
     return {
       getCard: this.getCard,
       getCards: this.getCards,

--- a/packages/host/app/templates/render/html.gts
+++ b/packages/host/app/templates/render/html.gts
@@ -1,11 +1,64 @@
-import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
 
+import { provide } from 'ember-provide-consume-context';
 import RouteTemplate from 'ember-route-template';
+
+import {
+  type getCard as GetCardType,
+  GetCardContextName,
+  GetCardsContextName,
+  GetCardCollectionContextName,
+  CardContextName,
+} from '@cardstack/runtime-common';
+
+import PrerenderedCardSearch from '@cardstack/host/components/prerendered-card-search';
+import { getCardCollection } from '@cardstack/host/resources/card-collection';
+import { getCard } from '@cardstack/host/resources/card-resource';
+import type RenderStoreService from '@cardstack/host/services/render-store';
+
+import type { CardContext } from 'https://cardstack.com/base/card-api';
 
 import type { Model } from '../../routes/render/html';
 
-export default RouteTemplate(
-  <template>
-    <@model.Component @format={{@model.format}} />
-  </template> satisfies TemplateOnlyComponent<{ Args: { model: Model } }>,
-);
+interface Signature {
+  Args: {
+    model: Model;
+  };
+}
+
+class RenderHtmlTemplate extends Component<Signature> {
+  @service('render-store') declare private store: RenderStoreService;
+
+  @provide(GetCardContextName)
+  private get getCard(): GetCardType {
+    return getCard as unknown as GetCardType;
+  }
+
+  @provide(GetCardsContextName)
+  private get getCards() {
+    return this.store.getSearchResource.bind(this.store);
+  }
+
+  @provide(GetCardCollectionContextName)
+  private get getCardCollection() {
+    return getCardCollection;
+  }
+
+  @provide(CardContextName)
+  get context(): CardContext {
+    return {
+      getCard: this.getCard,
+      getCards: this.getCards,
+      getCardCollection: this.getCardCollection,
+      store: this.store,
+      prerenderedCardSearchComponent: PrerenderedCardSearch,
+      mode: 'host',
+      submode: 'host',
+    };
+  }
+
+  <template><@model.Component @format={{@model.format}} /></template>
+}
+
+export default RouteTemplate(RenderHtmlTemplate);

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -101,7 +101,7 @@ export class PagePool {
     disableStandbyRefill?: boolean;
   }) {
     this.#maxPages = options.maxPages;
-    let envTabMax = Number(process.env.PRERENDER_REALM_TAB_MAX ?? 1);
+    let envTabMax = Number(process.env.PRERENDER_REALM_TAB_MAX ?? 4);
     if (!Number.isFinite(envTabMax) || envTabMax <= 0) {
       envTabMax = 1;
     }

--- a/packages/realm-server/scripts/start-all.sh
+++ b/packages/realm-server/scripts/start-all.sh
@@ -20,7 +20,7 @@ SYNAPSE_URL="http://localhost:8008"
 SMTP_4_DEV_URL="http://localhost:5001"
 ICONS_URL="http://localhost:4206"
 
-WAIT_ON_TIMEOUT=2000000 NODE_NO_WARNINGS=1 start-server-and-test \
+WAIT_ON_TIMEOUT=2400000 NODE_NO_WARNINGS=1 start-server-and-test \
   'run-p -ln start:pg start:matrix start:smtp start:prerender-dev start:prerender-manager-dev start:worker-development start:development' \
   "$BASE_REALM_READY|$CATALOG_REALM_READY|$SKILLS_REALM_READY|$BOXEL_HOMEPAGE_REALM_READY|$EXPERIMENTS_REALM_READY|$SYNAPSE_URL|$SMTP_4_DEV_URL|$ICONS_URL" \
   'run-p -ln start:worker-test start:test-realms' \

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -1500,8 +1500,421 @@ module(basename(__filename), function () {
     });
   }
 
+  function defineLivePrerenderedSearchFallbackTests() {
+    module('live prerendered search fallback', function (hooks) {
+      let realmURL = 'http://127.0.0.1:4456/test/';
+      let prerenderServerURL = new URL(realmURL).origin;
+      let testUserId = '@user1:localhost';
+      let permissions: RealmPermissions = {
+        [realmURL]: ['read', 'write', 'realm-owner'],
+      };
+      let prerenderer: Prerenderer;
+      let dbAdapter: any;
+      let auth = () => {
+        let sessions = JSON.parse(
+          testCreatePrerenderAuth(testUserId, permissions),
+        ) as Record<string, string>;
+        let token = sessions[realmURL];
+        if (token) {
+          sessions[new URL(realmURL).origin + '/'] = token;
+        }
+        return JSON.stringify(sessions);
+      };
+
+      hooks.before(async () => {
+        prerenderer = getPrerendererForTesting({
+          maxPages: 2,
+          serverURL: prerenderServerURL,
+        });
+      });
+
+      hooks.after(async () => {
+        await prerenderer.stop();
+      });
+
+      hooks.beforeEach(async () => {
+        await prerenderer.disposeRealm(realmURL);
+      });
+
+      async function overrideIndexedIsolatedHTML(url: string, html: string) {
+        let alternate = url.endsWith('.json')
+          ? url.replace(/\.json$/, '')
+          : `${url}.json`;
+        await dbAdapter.execute(
+          `UPDATE boxel_index SET isolated_html = $1 WHERE url = $2 OR url = $3`,
+          { bind: [html, url, alternate] },
+        );
+      }
+
+      setupPermissionedRealms(hooks, {
+        mode: 'before',
+        realms: [
+          {
+            realmURL,
+            permissions: {
+              '*': ['read'],
+              [testUserId]: ['read', 'write', 'realm-owner'],
+            },
+            fileSystem: {
+              'prerendered-search-live.gts': `
+              import { CardDef, Component, field, contains, StringField, realmURL, linksTo } from 'https://cardstack.com/base/card-api';
+
+              export class LiveSearchResult extends CardDef {
+                static displayName = 'Live Search Result';
+                @field cardTitle = contains(StringField);
+
+                static fitted = class extends Component<typeof this> {
+                  <template>
+                    <div class="live-search-css-sentinel" data-test-live-card-value>{{@model.cardTitle}}</div>
+                    <style scoped>
+                      .live-search-css-sentinel {
+                        border-top: 4px solid rgb(1, 2, 3);
+                      }
+                    </style>
+                  </template>
+                };
+
+                static embedded = this.fitted;
+                static isolated = this.fitted;
+              }
+
+              export class LiveSearchInner extends CardDef {
+                static displayName = 'Live Search Inner';
+                static isolated = class extends Component<typeof this> {
+                  get realmHref() {
+                    let id = this.args.model?.id;
+                    if (!id) {
+                      return '';
+                    }
+                    return new URL('.', id).href;
+                  }
+
+                  get query() {
+                    return {
+                      filter: {
+                        type: {
+                          module: new URL('./prerendered-search-live', import.meta.url).href,
+                          name: 'LiveSearchResult',
+                        },
+                      },
+                      page: {
+                        size: 10,
+                        number: 0,
+                      },
+                    };
+                  }
+
+                  get realms() {
+                    return [new URL('./', import.meta.url).href];
+                  }
+
+                  <template>
+                    <div data-test-live-search-host-ran>Host ran</div>
+                    <div data-test-live-search-realm>{{this.realmHref}}</div>
+                    {{#if @context.prerenderedCardSearchComponent}}
+                      <@context.prerenderedCardSearchComponent
+                        @query={{this.query}}
+                        @format='fitted'
+                        @realms={{this.realms}}
+                        @isLive={{true}}
+                      >
+                        <:loading>
+                          <div data-test-live-search-loading>Loading...</div>
+                        </:loading>
+                        <:response as |cards|>
+                          {{#each cards as |card|}}
+                            <div data-test-live-search-card={{card.url}}>
+                              <card.component />
+                            </div>
+                          {{/each}}
+                        </:response>
+                        <:meta as |meta|>
+                          <div data-test-live-search-total>{{meta.page.total}}</div>
+                        </:meta>
+                      </@context.prerenderedCardSearchComponent>
+                    {{else}}
+                      <div data-test-live-search-component-missing>missing</div>
+                    {{/if}}
+                  </template>
+                };
+              }
+
+              export class LiveSearchHost extends CardDef {
+                static displayName = 'Live Search Host';
+                @field child = linksTo(() => LiveSearchInner);
+
+                static isolated = class extends Component<typeof this> {
+                  <template>
+                    <@fields.child @format='isolated' />
+                  </template>
+                };
+
+                static embedded = this.isolated;
+              }
+            `,
+              'live-search-host.json': {
+                data: {
+                  relationships: {
+                    child: {
+                      links: {
+                        self: './live-search-inner',
+                      },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './prerendered-search-live',
+                      name: 'LiveSearchHost',
+                    },
+                  },
+                },
+              },
+              'live-search-inner.json': {
+                data: {
+                  meta: {
+                    adoptsFrom: {
+                      module: './prerendered-search-live',
+                      name: 'LiveSearchInner',
+                    },
+                  },
+                },
+              },
+              'live-search-result-1.json': {
+                data: {
+                  attributes: {
+                    cardTitle: 'LIVE_RESULT_VALUE',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './prerendered-search-live',
+                      name: 'LiveSearchResult',
+                    },
+                  },
+                },
+              },
+              'live-file-search-card.gts': `
+              import { CardDef, Component, field, contains, StringField, realmURL, linksTo } from 'https://cardstack.com/base/card-api';
+
+              export class LiveFileSearchInner extends CardDef {
+                static displayName = 'Live File Search Inner';
+                static isolated = class extends Component<typeof this> {
+                  get realmHref() {
+                    let id = this.args.model?.id;
+                    if (!id) {
+                      return '';
+                    }
+                    return new URL('.', id).href;
+                  }
+
+                  get query() {
+                    return {
+                      filter: {
+                        on: {
+                          module: 'https://cardstack.com/base/file-api',
+                          name: 'FileDef',
+                        },
+                        eq: {
+                          url: \`\${this.realmHref}live-file.live\`,
+                        },
+                      },
+                      page: {
+                        size: 10,
+                        number: 0,
+                      },
+                    };
+                  }
+
+                  get realms() {
+                    return [new URL('./', import.meta.url).href];
+                  }
+
+                  <template>
+                    <div data-test-live-file-search-host-ran>File Host ran</div>
+                    {{#if @context.prerenderedCardSearchComponent}}
+                      <@context.prerenderedCardSearchComponent
+                        @query={{this.query}}
+                        @format='embedded'
+                        @realms={{this.realms}}
+                        @isLive={{true}}
+                      >
+                        <:response as |cards|>
+                          {{#each cards as |card|}}
+                            <div data-test-live-file-search-card={{card.url}}>
+                              <card.component />
+                            </div>
+                          {{/each}}
+                        </:response>
+                      </@context.prerenderedCardSearchComponent>
+                    {{else}}
+                      <div data-test-live-file-search-component-missing>missing</div>
+                    {{/if}}
+                  </template>
+                };
+              }
+
+              export class LiveFileSearchHost extends CardDef {
+                static displayName = 'Live File Search Host';
+                @field cardTitle = contains(StringField);
+                @field child = linksTo(() => LiveFileSearchInner);
+
+                static isolated = class extends Component<typeof this> {
+                  <template>
+                    <@fields.child @format='isolated' />
+                  </template>
+                };
+
+                static embedded = this.isolated;
+              }
+            `,
+              'live-file-search-host.json': {
+                data: {
+                  attributes: {
+                    cardTitle: 'Live File Search Host',
+                  },
+                  relationships: {
+                    child: {
+                      links: {
+                        self: './live-file-search-inner',
+                      },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: './live-file-search-card',
+                      name: 'LiveFileSearchHost',
+                    },
+                  },
+                },
+              },
+              'live-file-search-inner.json': {
+                data: {
+                  meta: {
+                    adoptsFrom: {
+                      module: './live-file-search-card',
+                      name: 'LiveFileSearchInner',
+                    },
+                  },
+                },
+              },
+              'live-file.live': 'LIVE_FILE_VALUE',
+            },
+          },
+        ],
+        onRealmSetup({ dbAdapter: setupDbAdapter }) {
+          dbAdapter = setupDbAdapter;
+          permissions = {
+            [realmURL]: ['read', 'write', 'realm-owner'],
+          };
+        },
+      });
+
+      test('card prerendered search uses live rendered CardDef HTML and keeps unique CSS', async function (assert) {
+        const cardURL = `${realmURL}live-search-host`;
+        const sentinel = 'SENTINEL_STALE_CARD_HTML';
+        let realmServerPatch =
+          installRealmServerAssertOwnRealmServerBypassPatch();
+        let searchRequestObserverPatch = installSearchRequestObserverPatch();
+
+        try {
+          let indexedRows = await dbAdapter.execute(
+            `SELECT url FROM boxel_index WHERE url LIKE $1 ORDER BY url`,
+            { bind: [`${realmURL}%live-search%`] },
+          );
+          assert.ok(
+            indexedRows.length > 0,
+            `expected indexed rows for live-search fixtures, got: ${JSON.stringify(indexedRows)}`,
+          );
+
+          await overrideIndexedIsolatedHTML(
+            `${realmURL}live-search-result-1`,
+            `<div data-test-stale-card-html>${sentinel}</div>`,
+          );
+
+          let result = await prerenderer.prerenderCard({
+            realm: realmURL,
+            url: cardURL,
+            auth: auth(),
+          });
+
+          assert.notOk(result.response.error, 'prerender succeeds');
+          let isolatedHTML = cleanWhiteSpace(
+            result.response.isolatedHTML ?? '',
+          );
+          let searchRequests = searchRequestObserverPatch.getRequests();
+          assert.ok(
+            searchRequests.length > 0,
+            `observed federated search requests: ${JSON.stringify(searchRequests)}`,
+          );
+
+          assert.ok(
+            isolatedHTML.includes('LIVE_RESULT_VALUE'),
+            `isolated html includes live card value: ${isolatedHTML}`,
+          );
+          assert.notOk(
+            isolatedHTML.includes(sentinel),
+            `isolated html does not include stale indexed sentinel: ${isolatedHTML}`,
+          );
+          assert.ok(
+            isolatedHTML.includes('live-search-css-sentinel'),
+            `isolated html includes unique live card css class: ${isolatedHTML}`,
+          );
+          assert.ok(
+            /live-search-css-sentinel[^>]*data-scopedcss-[a-f0-9]{10}-[a-f0-9]{10}/.test(
+              isolatedHTML,
+            ),
+            `isolated html keeps scoped css marker on live result: ${isolatedHTML}`,
+          );
+        } finally {
+          searchRequestObserverPatch.restore();
+          await realmServerPatch.restore();
+        }
+      });
+
+      test('card prerendered search uses live rendered FileDef HTML', async function (assert) {
+        const cardURL = `${realmURL}live-file-search-host`;
+        const sentinel = 'SENTINEL_STALE_FILE_HTML';
+        let realmServerPatch =
+          installRealmServerAssertOwnRealmServerBypassPatch();
+
+        try {
+          await overrideIndexedIsolatedHTML(
+            `${realmURL}live-file.live`,
+            `<article data-test-stale-file-html>${sentinel}</article>`,
+          );
+
+          let result = await prerenderer.prerenderCard({
+            realm: realmURL,
+            url: cardURL,
+            auth: auth(),
+          });
+
+          assert.notOk(result.response.error, 'prerender succeeds');
+          let isolatedHTML = cleanWhiteSpace(
+            result.response.isolatedHTML ?? '',
+          );
+
+          assert.ok(
+            isolatedHTML.includes('live-file.live'),
+            `isolated html includes live FileDef fallback value: ${isolatedHTML}`,
+          );
+          assert.notOk(
+            isolatedHTML.includes(sentinel),
+            `isolated html does not include stale file sentinel: ${isolatedHTML}`,
+          );
+          assert.ok(
+            isolatedHTML.includes('data-test-live-file-search-card'),
+            `isolated html includes live FileDef search result wrapper: ${isolatedHTML}`,
+          );
+        } finally {
+          await realmServerPatch.restore();
+        }
+      });
+    });
+  }
+
   module('prerender - non-mutating tests', function () {
     defineNonMutatingRunnerTests();
+    defineLivePrerenderedSearchFallbackTests();
     defineNonMutatingStaticTests();
   });
 

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -1557,7 +1557,7 @@ module(basename(__filename), function () {
             },
             fileSystem: {
               'prerendered-search-live.gts': `
-              import { CardDef, Component, field, contains, StringField, realmURL, linksTo } from 'https://cardstack.com/base/card-api';
+              import { CardDef, Component, field, contains, StringField, linksTo } from 'https://cardstack.com/base/card-api';
 
               export class LiveSearchResult extends CardDef {
                 static displayName = 'Live Search Result';
@@ -1693,7 +1693,7 @@ module(basename(__filename), function () {
                 },
               },
               'live-file-search-card.gts': `
-              import { CardDef, Component, field, contains, StringField, realmURL, linksTo } from 'https://cardstack.com/base/card-api';
+              import { CardDef, Component, field, contains, StringField, linksTo } from 'https://cardstack.com/base/card-api';
 
               export class LiveFileSearchInner extends CardDef {
                 static displayName = 'Live File Search Inner';


### PR DESCRIPTION
## Summary
- Refactors `PrerenderedCardSearch` to use **live search** during render/indexing context, while preserving existing prerendered-search behavior elsewhere.
- Preserves host test semantics by only enabling this fallback when `globalThis.__boxelRenderContext` is true **and** `isTesting()` is false (since host test use the same js runtime for both indexing and tests--its more straight forward that this behavior is suppressed during host tests).
- Keeps the `PrerenderedCardSearch` yielded API compatible by adapting live `CardDef | FileDef` results into `PrerenderedCard` instances.

## What Changed
- Added a new resource: `packages/host/app/resources/live-prerendered-search.ts`
- Updated `packages/host/app/components/prerendered-card-search.gts`:
  - Chooses `getSearch()` + live adapter in render context.
  - Falls back to `getPrerenderedSearch()` outside that context.
- Updated `packages/host/app/templates/render/html.gts`:
  - Provides full `CardContext` (including `prerenderedCardSearchComponent`) in `/render` route so nested dynamic-card usage works.
- Added realm-server prerender coverage in `packages/realm-server/tests/prerendering-test.ts`:
  - CardDef case proves live-rendered HTML is used instead of stale indexed `isolated_html`.
  - FileDef/file-meta parity case verifies same live fallback behavior.
  - CSS assertion verifies scoped-css marker behavior for live-rendered search results.

