### PR TITLE
Use session storage for prerender session persistence

### DIFF
--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -671,7 +671,7 @@ export default class SearchContent extends Component<Signature> {
         {{/if}}
       {{else}}
         {{! Render all sections }}
-        {{#each this.sections as |section i|}}
+        {{#each this.sections key='sid' as |section i|}}
           <SearchResultSection
             @section={{section}}
             @viewOption={{this.activeViewId}}

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -109,7 +109,7 @@ export default class RealmServerService extends Service {
   setClient(client: ExtendedClient) {
     this.client = client;
     this.token =
-      window.localStorage.getItem(sessionLocalStorageKey) ?? undefined;
+      getStorageValueWithFallback(sessionLocalStorageKey) ?? undefined;
   }
 
   async createStripeSession(email: string) {
@@ -206,6 +206,7 @@ export default class RealmServerService extends Service {
       url: baseRealm.url,
     });
     window.localStorage.removeItem(sessionLocalStorageKey);
+    window.sessionStorage.removeItem(sessionLocalStorageKey);
   }
 
   async fetchTokensForAccessibleRealms() {
@@ -270,15 +271,8 @@ export default class RealmServerService extends Service {
     let testRealmOrigin = isTesting()
       ? new URL(testRealmURL).origin
       : undefined;
-    let sessionTokens: Record<string, string> = {};
-    let sessionStr =
-      window.localStorage.getItem(SessionLocalStorageKey) ?? '{}';
-
-    try {
-      sessionTokens = JSON.parse(sessionStr) as Record<string, string>;
-    } catch {
-      sessionTokens = {};
-    }
+    let sessionTokens =
+      getSessionTokenMapWithFallback(SessionLocalStorageKey) ?? {};
 
     let realmServerURLs = new Set<string>();
 
@@ -545,6 +539,8 @@ export default class RealmServerService extends Service {
     } else {
       this.auth = { type: 'anonymous' };
     }
+    // Keep localStorage as the canonical persistence for host realm-server auth.
+    // Read paths use local->session fallback to interoperate with prerender flows.
     window.localStorage.setItem(sessionLocalStorageKey, value ?? '');
     this.tokenRefresher.perform();
   }
@@ -1057,14 +1053,8 @@ export default class RealmServerService extends Service {
   }
 
   private getRealmTokenForRealms(realms: string[]): string | undefined {
-    let sessionTokens: Record<string, string> = {};
-    let sessionStr = window.localStorage.getItem(SessionLocalStorageKey);
-    if (!sessionStr) {
-      return undefined;
-    }
-    try {
-      sessionTokens = JSON.parse(sessionStr) as Record<string, string>;
-    } catch {
+    let sessionTokens = getSessionTokenMapWithFallback(SessionLocalStorageKey);
+    if (!sessionTokens) {
       return undefined;
     }
     for (let realmURL of realms) {
@@ -1080,6 +1070,35 @@ export default class RealmServerService extends Service {
 
 const tokenRefreshPeriodSec = 5 * 60; // 5 minutes
 const sessionLocalStorageKey = 'boxel-realm-server-session';
+
+function getStorageValueWithFallback(key: string): string | null {
+  // Host writes are localStorage-first, but prerender/isolated contexts may use
+  // sessionStorage, so reads intentionally fall back.
+  return window.localStorage.getItem(key) ?? window.sessionStorage.getItem(key);
+}
+
+function getSessionTokenMapWithFallback(
+  key: string,
+): Record<string, string> | undefined {
+  let localTokens = parseSessionTokenMap(window.localStorage.getItem(key));
+  if (localTokens) {
+    return localTokens;
+  }
+  return parseSessionTokenMap(window.sessionStorage.getItem(key));
+}
+
+function parseSessionTokenMap(
+  value: string | null,
+): Record<string, string> | undefined {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(value) as Record<string, string>;
+  } catch {
+    return undefined;
+  }
+}
 
 function claimsFromRawToken(rawToken: string): RealmServerJWTPayload {
   let [_header, payload] = rawToken.split('.');

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -1073,15 +1073,20 @@ const sessionLocalStorageKey = 'boxel-realm-server-session';
 
 function getStorageValueWithFallback(key: string): string | null {
   // Host writes are localStorage-first, but prerender/isolated contexts may use
-  // sessionStorage, so reads intentionally fall back.
-  return window.localStorage.getItem(key) ?? window.sessionStorage.getItem(key);
+  // sessionStorage, so reads intentionally fall back. We treat empty string as
+  // missing because this file stores `''` when clearing auth.
+  let localValue = window.localStorage.getItem(key);
+  if (localValue) {
+    return localValue;
+  }
+  return window.sessionStorage.getItem(key);
 }
 
 function getSessionTokenMapWithFallback(
   key: string,
 ): Record<string, string> | undefined {
   let localTokens = parseSessionTokenMap(window.localStorage.getItem(key));
-  if (localTokens) {
+  if (localTokens && hasTokenEntries(localTokens)) {
     return localTokens;
   }
   return parseSessionTokenMap(window.sessionStorage.getItem(key));
@@ -1098,6 +1103,10 @@ function parseSessionTokenMap(
   } catch {
     return undefined;
   }
+}
+
+function hasTokenEntries(tokens: Record<string, string>): boolean {
+  return Object.keys(tokens).length > 0;
 }
 
 function claimsFromRawToken(rawToken: string): RealmServerJWTPayload {

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -273,6 +273,7 @@ class RealmResource {
     this.fetchingInfo = undefined;
     this.fetchRealmPermissionsTask.cancelAll();
     window.localStorage.removeItem(SessionLocalStorageKey);
+    window.sessionStorage.removeItem(SessionLocalStorageKey);
     syncTokenToServiceWorker(this.realmURL, undefined);
   }
 
@@ -949,7 +950,7 @@ export default class RealmService extends Service {
   token = (url: string): string | undefined => {
     let resource = this.knownRealm(url, { tracked: false });
     if (!resource && (globalThis as any).__boxelRenderContext && !isTesting()) {
-      // prerender contexts should always reflect localStorage session state
+      // prerender contexts should always reflect persisted session state
       this.restoreSessionsFromStorage();
       resource = this.knownRealm(url, { tracked: false });
     }
@@ -1122,18 +1123,19 @@ export function claimsFromRawToken(rawToken: string): JWTPayload {
 
 let SessionStorage = {
   getAll(): Record<string, string> | undefined {
-    let sessionsString = window.localStorage.getItem(SessionLocalStorageKey);
-    if (sessionsString) {
-      return JSON.parse(sessionsString);
-    }
-    return undefined;
+    return getSessionTokensFromStorage();
   },
   persist(realmURL: string, token: string | undefined) {
-    let sessionStr =
-      window.localStorage.getItem(SessionLocalStorageKey) ?? '{}';
-    let session = JSON.parse(sessionStr);
+    // Intentionally persist to localStorage only for normal host sessions.
+    // Reads use localStorage first with sessionStorage fallback so prerender
+    // contexts (which write sessionStorage-only) are still supported.
+    let session = getSessionTokensFromStorage() ?? {};
     if (session[realmURL] !== token) {
-      session[realmURL] = token;
+      if (token === undefined) {
+        delete session[realmURL];
+      } else {
+        session[realmURL] = token;
+      }
       window.localStorage.setItem(
         SessionLocalStorageKey,
         JSON.stringify(session),
@@ -1142,6 +1144,31 @@ let SessionStorage = {
     syncTokenToServiceWorker(realmURL, token);
   },
 };
+
+function getSessionTokensFromStorage(): Record<string, string> | undefined {
+  let localTokens = parseSessionTokens(
+    window.localStorage.getItem(SessionLocalStorageKey),
+  );
+  if (localTokens) {
+    return localTokens;
+  }
+  return parseSessionTokens(
+    window.sessionStorage.getItem(SessionLocalStorageKey),
+  );
+}
+
+function parseSessionTokens(
+  tokens: string | null,
+): Record<string, string> | undefined {
+  if (!tokens) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(tokens) as Record<string, string>;
+  } catch {
+    return undefined;
+  }
+}
 
 declare module '@ember/service' {
   interface Registry {

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -1126,34 +1126,47 @@ let SessionStorage = {
     return getSessionTokensFromStorage();
   },
   persist(realmURL: string, token: string | undefined) {
-    // Intentionally persist to localStorage only for normal host sessions.
-    // Reads use localStorage first with sessionStorage fallback so prerender
-    // contexts (which write sessionStorage-only) are still supported.
-    let session = getSessionTokensFromStorage() ?? {};
+    let inRenderContext = Boolean((globalThis as any).__boxelRenderContext);
+    // Keep prerender auth tab-scoped: never copy sessionStorage tokens into
+    // origin-wide localStorage from render contexts.
+    let session = inRenderContext
+      ? (getSessionTokensFromStorage() ?? {})
+      : (getLocalSessionTokens() ?? {});
     if (session[realmURL] !== token) {
       if (token === undefined) {
         delete session[realmURL];
       } else {
         session[realmURL] = token;
       }
-      window.localStorage.setItem(
-        SessionLocalStorageKey,
-        JSON.stringify(session),
-      );
+      if (inRenderContext) {
+        window.sessionStorage.setItem(
+          SessionLocalStorageKey,
+          JSON.stringify(session),
+        );
+      } else {
+        window.localStorage.setItem(
+          SessionLocalStorageKey,
+          JSON.stringify(session),
+        );
+      }
     }
     syncTokenToServiceWorker(realmURL, token);
   },
 };
 
 function getSessionTokensFromStorage(): Record<string, string> | undefined {
-  let localTokens = parseSessionTokens(
-    window.localStorage.getItem(SessionLocalStorageKey),
-  );
-  if (localTokens) {
+  let localTokens = getLocalSessionTokens();
+  if (localTokens && hasTokenEntries(localTokens)) {
     return localTokens;
   }
   return parseSessionTokens(
     window.sessionStorage.getItem(SessionLocalStorageKey),
+  );
+}
+
+function getLocalSessionTokens(): Record<string, string> | undefined {
+  return parseSessionTokens(
+    window.localStorage.getItem(SessionLocalStorageKey),
   );
 }
 
@@ -1168,6 +1181,10 @@ function parseSessionTokens(
   } catch {
     return undefined;
   }
+}
+
+function hasTokenEntries(tokens: Record<string, string>): boolean {
+  return Object.keys(tokens).length > 0;
 }
 
 declare module '@ember/service' {

--- a/packages/host/app/utils/auth-service-worker-registration.ts
+++ b/packages/host/app/utils/auth-service-worker-registration.ts
@@ -111,13 +111,25 @@ export function clearServiceWorkerTokens(): void {
 }
 
 function readTokensFromStorage(): Record<string, string> | undefined {
+  let localTokens = parseTokenMap(
+    window.localStorage.getItem(SessionLocalStorageKey),
+  );
+  if (localTokens) {
+    return localTokens;
+  }
+  return parseTokenMap(window.sessionStorage.getItem(SessionLocalStorageKey));
+}
+
+function parseTokenMap(
+  value: string | null,
+): Record<string, string> | undefined {
+  if (!value) {
+    return undefined;
+  }
   try {
-    let sessionsString = window.localStorage.getItem(SessionLocalStorageKey);
-    if (sessionsString) {
-      return JSON.parse(sessionsString);
-    }
+    return JSON.parse(value) as Record<string, string>;
   } catch {
     // ignore parse errors
+    return undefined;
   }
-  return undefined;
 }

--- a/packages/host/app/utils/auth-service-worker-registration.ts
+++ b/packages/host/app/utils/auth-service-worker-registration.ts
@@ -114,7 +114,7 @@ function readTokensFromStorage(): Record<string, string> | undefined {
   let localTokens = parseTokenMap(
     window.localStorage.getItem(SessionLocalStorageKey),
   );
-  if (localTokens) {
+  if (localTokens && hasTokenEntries(localTokens)) {
     return localTokens;
   }
   return parseTokenMap(window.sessionStorage.getItem(SessionLocalStorageKey));
@@ -132,4 +132,8 @@ function parseTokenMap(
     // ignore parse errors
     return undefined;
   }
+}
+
+function hasTokenEntries(tokens: Record<string, string>): boolean {
+  return Object.keys(tokens).length > 0;
 }

--- a/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
@@ -1002,6 +1002,21 @@ module('Integration | operator-mode | card catalog', function (hooks) {
       focusedSection,
       'found the section containing the show-only checkbox',
     );
+    const focusedSectionSid = focusedSection.getAttribute('data-section-sid');
+    assert.ok(focusedSectionSid, 'focused section has a section sid');
+    const getFocusedSection = () =>
+      document.querySelector(
+        `[data-section-sid="${focusedSectionSid}"]`,
+      ) as HTMLElement;
+    const waitForPreservedPosition = async (positionBefore: number) => {
+      await waitUntil(
+        () =>
+          Math.abs(
+            getFocusedSection().getBoundingClientRect().top - positionBefore,
+          ) <= 5,
+        { timeout: 2000 },
+      );
+    };
 
     let scrollContainer = document.querySelector(
       '.search-sheet-content',
@@ -1022,11 +1037,12 @@ module('Integration | operator-mode | card catalog', function (hooks) {
     // Sync the modifier's position map and read positionBefore in the same
     // synchronous tick so they are guaranteed to reflect the same layout state.
     scrollContainer.dispatchEvent(new Event('scroll'));
-    let positionBefore = focusedSection.getBoundingClientRect().top;
+    let positionBefore = getFocusedSection().getBoundingClientRect().top;
 
     await click('[data-test-search-sheet-show-only]');
+    await waitForPreservedPosition(positionBefore);
 
-    let positionAfter = focusedSection.getBoundingClientRect().top;
+    let positionAfter = getFocusedSection().getBoundingClientRect().top;
     // Use a 5px tolerance instead of 2px: the scroll-anchor adjustment is
     // sub-pixel-accurate in local environments but CI Chromium instances can
     // render element positions with slight differences depending on DPI/font
@@ -1044,10 +1060,11 @@ module('Integration | operator-mode | card catalog', function (hooks) {
     // record positionBefore for this second assertion.
     await settled();
     scrollContainer.dispatchEvent(new Event('scroll'));
-    positionBefore = focusedSection.getBoundingClientRect().top;
+    positionBefore = getFocusedSection().getBoundingClientRect().top;
     await click('[data-test-search-sheet-show-only]');
+    await waitForPreservedPosition(positionBefore);
 
-    positionAfter = focusedSection.getBoundingClientRect().top;
+    positionAfter = getFocusedSection().getBoundingClientRect().top;
     assert.ok(
       Math.abs(positionAfter - positionBefore) <= 5,
       `focused section position is preserved after unchecking Show only (before: ${positionBefore}, after: ${positionAfter})`,

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -92,6 +92,20 @@ export class RenderRunner {
     }
   }
 
+  async #setPrerenderSessionAuth(
+    page: {
+      evaluate: (fn: (...args: any[]) => any, ...args: any[]) => Promise<any>;
+    },
+    auth: string,
+  ) {
+    await page.evaluate((sessionAuth) => {
+      // Use sessionStorage (not localStorage) for prerender auth so each tab's
+      // JWT remains isolated and one prerender task cannot poison another tab.
+      localStorage.removeItem('boxel-session');
+      sessionStorage.setItem('boxel-session', sessionAuth);
+    }, auth);
+  }
+
   async prerenderCardAttempt({
     realm,
     url,
@@ -134,9 +148,7 @@ export class RenderRunner {
       }
     };
     try {
-      await page.evaluate((sessionAuth) => {
-        localStorage.setItem('boxel-session', sessionAuth);
-      }, auth);
+      await this.#setPrerenderSessionAuth(page, auth);
 
       let renderStart = Date.now();
       let error: RenderError | undefined;
@@ -441,9 +453,9 @@ export class RenderRunner {
       let requestId = randomUUID();
       let nonce = String(this.#nonce);
       let storageKey = `${commandRequestStorageKeyPrefix}${requestId}`;
+      await this.#setPrerenderSessionAuth(page, auth);
       await page.evaluate(
-        (sessionAuth, key, commandToRun, input, requestNonce, createdAt) => {
-          localStorage.setItem('boxel-session', sessionAuth);
+        (key, commandToRun, input, requestNonce, createdAt) => {
           localStorage.setItem(
             key,
             JSON.stringify({
@@ -454,7 +466,6 @@ export class RenderRunner {
             }),
           );
         },
-        auth,
         storageKey,
         command,
         commandInput ?? null,
@@ -622,9 +633,7 @@ export class RenderRunner {
       }
     };
     try {
-      await page.evaluate((sessionAuth) => {
-        localStorage.setItem('boxel-session', sessionAuth);
-      }, auth);
+      await this.#setPrerenderSessionAuth(page, auth);
 
       let renderStart = Date.now();
       let options = renderOptions ?? {};
@@ -778,9 +787,7 @@ export class RenderRunner {
       }
     };
     try {
-      await page.evaluate((sessionAuth) => {
-        localStorage.setItem('boxel-session', sessionAuth);
-      }, auth);
+      await this.#setPrerenderSessionAuth(page, auth);
 
       let renderStart = Date.now();
       let options = renderOptions ?? {};
@@ -932,9 +939,7 @@ export class RenderRunner {
       }
     };
     try {
-      await page.evaluate((sessionAuth) => {
-        localStorage.setItem('boxel-session', sessionAuth);
-      }, auth);
+      await this.#setPrerenderSessionAuth(page, auth);
 
       // Stash file data on globalThis for the render route to consume
       await page.evaluate((data) => {

--- a/packages/realm-server/tests/auth-client-test.ts
+++ b/packages/realm-server/tests/auth-client-test.ts
@@ -17,6 +17,30 @@ function createJWT(
   return jwt.sign(payload, 'secret', { expiresIn });
 }
 
+function createStorage(initial: Record<string, string> = {}): Storage {
+  let values = { ...initial };
+  return {
+    getItem(key: string) {
+      return values[key] ?? null;
+    },
+    setItem(key: string, value: string) {
+      values[key] = value;
+    },
+    removeItem(key: string) {
+      delete values[key];
+    },
+    clear() {
+      values = {};
+    },
+    key(index: number) {
+      return Object.keys(values)[index] ?? null;
+    },
+    get length() {
+      return Object.keys(values).length;
+    },
+  } as Storage;
+}
+
 module(basename(__filename), function () {
   module('realm-auth-client', function (assert) {
     let client: RealmAuthClient;
@@ -179,6 +203,58 @@ module(basename(__filename), function () {
         /expected 'Authorization' header/,
         'missing Authorization header indicates verification failure',
       );
+    });
+
+    test('it reads render-context JWT from localStorage', async function (assert) {
+      let token = createJWT('1h', {
+        sessionRoom: 'room',
+        realmServerURL: 'http://testrealm.com/',
+      });
+      let originalLocalStorage = (globalThis as any).localStorage;
+      let originalSessionStorage = (globalThis as any).sessionStorage;
+      let originalRenderContext = (globalThis as any).__boxelRenderContext;
+
+      (globalThis as any).localStorage = createStorage({
+        'boxel-session': JSON.stringify({
+          'http://testrealm.com/': token,
+        }),
+      });
+      (globalThis as any).sessionStorage = createStorage();
+      (globalThis as any).__boxelRenderContext = true;
+
+      try {
+        assert.strictEqual(await client.getJWT(), token);
+      } finally {
+        (globalThis as any).localStorage = originalLocalStorage;
+        (globalThis as any).sessionStorage = originalSessionStorage;
+        (globalThis as any).__boxelRenderContext = originalRenderContext;
+      }
+    });
+
+    test('it falls back to sessionStorage in render context when localStorage is empty', async function (assert) {
+      let token = createJWT('1h', {
+        sessionRoom: 'room',
+        realmServerURL: 'http://testrealm.com/',
+      });
+      let originalLocalStorage = (globalThis as any).localStorage;
+      let originalSessionStorage = (globalThis as any).sessionStorage;
+      let originalRenderContext = (globalThis as any).__boxelRenderContext;
+
+      (globalThis as any).localStorage = createStorage();
+      (globalThis as any).sessionStorage = createStorage({
+        'boxel-session': JSON.stringify({
+          'http://testrealm.com/': token,
+        }),
+      });
+      (globalThis as any).__boxelRenderContext = true;
+
+      try {
+        assert.strictEqual(await client.getJWT(), token);
+      } finally {
+        (globalThis as any).localStorage = originalLocalStorage;
+        (globalThis as any).sessionStorage = originalSessionStorage;
+        (globalThis as any).__boxelRenderContext = originalRenderContext;
+      }
     });
   });
 });

--- a/packages/runtime-common/realm-auth-client.ts
+++ b/packages/runtime-common/realm-auth-client.ts
@@ -70,11 +70,11 @@ function realmSessionCacheKey(realmURL: URL, sessionEndpoint: string) {
 }
 
 function getBoxelSessionWithFallback(): string | null {
-  let localSession = globalThis.localStorage?.getItem('boxel-session');
-  if (localSession !== null && localSession !== undefined) {
-    return localSession;
+  let sessionStorageValue = globalThis.sessionStorage?.getItem('boxel-session');
+  if (sessionStorageValue !== null && sessionStorageValue !== undefined) {
+    return sessionStorageValue;
   }
-  return globalThis.sessionStorage?.getItem('boxel-session') ?? null;
+  return globalThis.localStorage?.getItem('boxel-session') ?? null;
 }
 
 export class RealmAuthClient {
@@ -98,7 +98,8 @@ export class RealmAuthClient {
     let tokenRefreshLeadTimeSeconds = 60;
     let jwt: string;
 
-    // the prerenderer reads JWTs from localStorage with sessionStorage fallback
+    // Prerender contexts prefer sessionStorage (tab-isolated), then fall back
+    // to localStorage for compatibility with older contexts.
     if ((globalThis as any).__boxelRenderContext) {
       let sessionStr = getBoxelSessionWithFallback() ?? '{}';
       let session: { [realmURL: string]: string } = JSON.parse(sessionStr);

--- a/packages/runtime-common/realm-auth-client.ts
+++ b/packages/runtime-common/realm-auth-client.ts
@@ -69,6 +69,14 @@ function realmSessionCacheKey(realmURL: URL, sessionEndpoint: string) {
   return `${realmURL.href}|${sessionEndpoint}`;
 }
 
+function getBoxelSessionWithFallback(): string | null {
+  let localSession = globalThis.localStorage?.getItem('boxel-session');
+  if (localSession !== null && localSession !== undefined) {
+    return localSession;
+  }
+  return globalThis.sessionStorage?.getItem('boxel-session') ?? null;
+}
+
 export class RealmAuthClient {
   private _jwt: string | undefined;
   private isRealmServerAuth: boolean;
@@ -90,9 +98,9 @@ export class RealmAuthClient {
     let tokenRefreshLeadTimeSeconds = 60;
     let jwt: string;
 
-    // the prerenderer relies solely on the JWT's in local storage
+    // the prerenderer reads JWTs from localStorage with sessionStorage fallback
     if ((globalThis as any).__boxelRenderContext) {
-      let sessionStr = globalThis.localStorage.getItem('boxel-session') ?? '{}';
+      let sessionStr = getBoxelSessionWithFallback() ?? '{}';
       let session: { [realmURL: string]: string } = JSON.parse(sessionStr);
       let jwt = session[this.realmURL.href];
       if (!jwt) {


### PR DESCRIPTION
This PR introduces a session storage fallback for our `boxel-session` so that we can use session storage in our prerenderer instead of localstorage so that we don't poison other tabs when setting a different user session.