### PR TITLE
Revert session storage support for boxel-session and assert that each tab of puppeteer has its own browser context

### DIFF
--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -109,7 +109,7 @@ export default class RealmServerService extends Service {
   setClient(client: ExtendedClient) {
     this.client = client;
     this.token =
-      getStorageValueWithFallback(sessionLocalStorageKey) ?? undefined;
+      window.localStorage.getItem(sessionLocalStorageKey) ?? undefined;
   }
 
   async createStripeSession(email: string) {
@@ -206,7 +206,6 @@ export default class RealmServerService extends Service {
       url: baseRealm.url,
     });
     window.localStorage.removeItem(sessionLocalStorageKey);
-    window.sessionStorage.removeItem(sessionLocalStorageKey);
   }
 
   async fetchTokensForAccessibleRealms() {
@@ -271,8 +270,15 @@ export default class RealmServerService extends Service {
     let testRealmOrigin = isTesting()
       ? new URL(testRealmURL).origin
       : undefined;
-    let sessionTokens =
-      getSessionTokenMapWithFallback(SessionLocalStorageKey) ?? {};
+    let sessionTokens: Record<string, string> = {};
+    let sessionStr =
+      window.localStorage.getItem(SessionLocalStorageKey) ?? '{}';
+
+    try {
+      sessionTokens = JSON.parse(sessionStr) as Record<string, string>;
+    } catch {
+      sessionTokens = {};
+    }
 
     let realmServerURLs = new Set<string>();
 
@@ -539,8 +545,6 @@ export default class RealmServerService extends Service {
     } else {
       this.auth = { type: 'anonymous' };
     }
-    // Keep localStorage as the canonical persistence for host realm-server auth.
-    // Read paths use local->session fallback to interoperate with prerender flows.
     window.localStorage.setItem(sessionLocalStorageKey, value ?? '');
     this.tokenRefresher.perform();
   }
@@ -1053,8 +1057,14 @@ export default class RealmServerService extends Service {
   }
 
   private getRealmTokenForRealms(realms: string[]): string | undefined {
-    let sessionTokens = getSessionTokenMapWithFallback(SessionLocalStorageKey);
-    if (!sessionTokens) {
+    let sessionTokens: Record<string, string> = {};
+    let sessionStr = window.localStorage.getItem(SessionLocalStorageKey);
+    if (!sessionStr) {
+      return undefined;
+    }
+    try {
+      sessionTokens = JSON.parse(sessionStr) as Record<string, string>;
+    } catch {
       return undefined;
     }
     for (let realmURL of realms) {
@@ -1070,44 +1080,6 @@ export default class RealmServerService extends Service {
 
 const tokenRefreshPeriodSec = 5 * 60; // 5 minutes
 const sessionLocalStorageKey = 'boxel-realm-server-session';
-
-function getStorageValueWithFallback(key: string): string | null {
-  // Host writes are localStorage-first, but prerender/isolated contexts may use
-  // sessionStorage, so reads intentionally fall back. We treat empty string as
-  // missing because this file stores `''` when clearing auth.
-  let localValue = window.localStorage.getItem(key);
-  if (localValue) {
-    return localValue;
-  }
-  return window.sessionStorage.getItem(key);
-}
-
-function getSessionTokenMapWithFallback(
-  key: string,
-): Record<string, string> | undefined {
-  let localTokens = parseSessionTokenMap(window.localStorage.getItem(key));
-  if (localTokens && hasTokenEntries(localTokens)) {
-    return localTokens;
-  }
-  return parseSessionTokenMap(window.sessionStorage.getItem(key));
-}
-
-function parseSessionTokenMap(
-  value: string | null,
-): Record<string, string> | undefined {
-  if (!value) {
-    return undefined;
-  }
-  try {
-    return JSON.parse(value) as Record<string, string>;
-  } catch {
-    return undefined;
-  }
-}
-
-function hasTokenEntries(tokens: Record<string, string>): boolean {
-  return Object.keys(tokens).length > 0;
-}
 
 function claimsFromRawToken(rawToken: string): RealmServerJWTPayload {
   let [_header, payload] = rawToken.split('.');

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -273,7 +273,6 @@ class RealmResource {
     this.fetchingInfo = undefined;
     this.fetchRealmPermissionsTask.cancelAll();
     window.localStorage.removeItem(SessionLocalStorageKey);
-    window.sessionStorage.removeItem(SessionLocalStorageKey);
     syncTokenToServiceWorker(this.realmURL, undefined);
   }
 
@@ -950,7 +949,7 @@ export default class RealmService extends Service {
   token = (url: string): string | undefined => {
     let resource = this.knownRealm(url, { tracked: false });
     if (!resource && (globalThis as any).__boxelRenderContext && !isTesting()) {
-      // prerender contexts should always reflect persisted session state
+      // prerender contexts should always reflect localStorage session state
       this.restoreSessionsFromStorage();
       resource = this.knownRealm(url, { tracked: false });
     }
@@ -1123,69 +1122,26 @@ export function claimsFromRawToken(rawToken: string): JWTPayload {
 
 let SessionStorage = {
   getAll(): Record<string, string> | undefined {
-    return getSessionTokensFromStorage();
+    let sessionsString = window.localStorage.getItem(SessionLocalStorageKey);
+    if (sessionsString) {
+      return JSON.parse(sessionsString);
+    }
+    return undefined;
   },
   persist(realmURL: string, token: string | undefined) {
-    let inRenderContext = Boolean((globalThis as any).__boxelRenderContext);
-    // Keep prerender auth tab-scoped: never copy sessionStorage tokens into
-    // origin-wide localStorage from render contexts.
-    let session = inRenderContext
-      ? (getSessionTokensFromStorage() ?? {})
-      : (getLocalSessionTokens() ?? {});
+    let sessionStr =
+      window.localStorage.getItem(SessionLocalStorageKey) ?? '{}';
+    let session = JSON.parse(sessionStr);
     if (session[realmURL] !== token) {
-      if (token === undefined) {
-        delete session[realmURL];
-      } else {
-        session[realmURL] = token;
-      }
-      if (inRenderContext) {
-        window.sessionStorage.setItem(
-          SessionLocalStorageKey,
-          JSON.stringify(session),
-        );
-      } else {
-        window.localStorage.setItem(
-          SessionLocalStorageKey,
-          JSON.stringify(session),
-        );
-      }
+      session[realmURL] = token;
+      window.localStorage.setItem(
+        SessionLocalStorageKey,
+        JSON.stringify(session),
+      );
     }
     syncTokenToServiceWorker(realmURL, token);
   },
 };
-
-function getSessionTokensFromStorage(): Record<string, string> | undefined {
-  let localTokens = getLocalSessionTokens();
-  if (localTokens && hasTokenEntries(localTokens)) {
-    return localTokens;
-  }
-  return parseSessionTokens(
-    window.sessionStorage.getItem(SessionLocalStorageKey),
-  );
-}
-
-function getLocalSessionTokens(): Record<string, string> | undefined {
-  return parseSessionTokens(
-    window.localStorage.getItem(SessionLocalStorageKey),
-  );
-}
-
-function parseSessionTokens(
-  tokens: string | null,
-): Record<string, string> | undefined {
-  if (!tokens) {
-    return undefined;
-  }
-  try {
-    return JSON.parse(tokens) as Record<string, string>;
-  } catch {
-    return undefined;
-  }
-}
-
-function hasTokenEntries(tokens: Record<string, string>): boolean {
-  return Object.keys(tokens).length > 0;
-}
 
 declare module '@ember/service' {
   interface Registry {

--- a/packages/host/app/utils/auth-service-worker-registration.ts
+++ b/packages/host/app/utils/auth-service-worker-registration.ts
@@ -111,29 +111,13 @@ export function clearServiceWorkerTokens(): void {
 }
 
 function readTokensFromStorage(): Record<string, string> | undefined {
-  let localTokens = parseTokenMap(
-    window.localStorage.getItem(SessionLocalStorageKey),
-  );
-  if (localTokens && hasTokenEntries(localTokens)) {
-    return localTokens;
-  }
-  return parseTokenMap(window.sessionStorage.getItem(SessionLocalStorageKey));
-}
-
-function parseTokenMap(
-  value: string | null,
-): Record<string, string> | undefined {
-  if (!value) {
-    return undefined;
-  }
   try {
-    return JSON.parse(value) as Record<string, string>;
+    let sessionsString = window.localStorage.getItem(SessionLocalStorageKey);
+    if (sessionsString) {
+      return JSON.parse(sessionsString);
+    }
   } catch {
     // ignore parse errors
-    return undefined;
   }
-}
-
-function hasTokenEntries(tokens: Record<string, string>): boolean {
-  return Object.keys(tokens).length > 0;
+  return undefined;
 }

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -349,6 +349,11 @@ export class PagePool {
       let browser = await this.#browserManager.getBrowser();
       context = await browser.createBrowserContext();
       let page = await context.newPage();
+      if (page.browserContext() !== context) {
+        throw new Error(
+          'Expected each prerender page to use its own browser context for localStorage isolation',
+        );
+      }
       let pageId = uuidv4();
       this.#attachPageConsole(page, 'standby', pageId);
       await this.#loadStandbyPage(page, pageId);

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -92,20 +92,6 @@ export class RenderRunner {
     }
   }
 
-  async #setPrerenderSessionAuth(
-    page: {
-      evaluate: (fn: (...args: any[]) => any, ...args: any[]) => Promise<any>;
-    },
-    auth: string,
-  ) {
-    await page.evaluate((sessionAuth) => {
-      // Use sessionStorage (not localStorage) for prerender auth so each tab's
-      // JWT remains isolated and one prerender task cannot poison another tab.
-      localStorage.removeItem('boxel-session');
-      sessionStorage.setItem('boxel-session', sessionAuth);
-    }, auth);
-  }
-
   async prerenderCardAttempt({
     realm,
     url,
@@ -148,7 +134,9 @@ export class RenderRunner {
       }
     };
     try {
-      await this.#setPrerenderSessionAuth(page, auth);
+      await page.evaluate((sessionAuth) => {
+        localStorage.setItem('boxel-session', sessionAuth);
+      }, auth);
 
       let renderStart = Date.now();
       let error: RenderError | undefined;
@@ -453,9 +441,9 @@ export class RenderRunner {
       let requestId = randomUUID();
       let nonce = String(this.#nonce);
       let storageKey = `${commandRequestStorageKeyPrefix}${requestId}`;
-      await this.#setPrerenderSessionAuth(page, auth);
       await page.evaluate(
-        (key, commandToRun, input, requestNonce, createdAt) => {
+        (sessionAuth, key, commandToRun, input, requestNonce, createdAt) => {
+          localStorage.setItem('boxel-session', sessionAuth);
           localStorage.setItem(
             key,
             JSON.stringify({
@@ -466,6 +454,7 @@ export class RenderRunner {
             }),
           );
         },
+        auth,
         storageKey,
         command,
         commandInput ?? null,
@@ -633,7 +622,9 @@ export class RenderRunner {
       }
     };
     try {
-      await this.#setPrerenderSessionAuth(page, auth);
+      await page.evaluate((sessionAuth) => {
+        localStorage.setItem('boxel-session', sessionAuth);
+      }, auth);
 
       let renderStart = Date.now();
       let options = renderOptions ?? {};
@@ -787,7 +778,9 @@ export class RenderRunner {
       }
     };
     try {
-      await this.#setPrerenderSessionAuth(page, auth);
+      await page.evaluate((sessionAuth) => {
+        localStorage.setItem('boxel-session', sessionAuth);
+      }, auth);
 
       let renderStart = Date.now();
       let options = renderOptions ?? {};
@@ -939,7 +932,9 @@ export class RenderRunner {
       }
     };
     try {
-      await this.#setPrerenderSessionAuth(page, auth);
+      await page.evaluate((sessionAuth) => {
+        localStorage.setItem('boxel-session', sessionAuth);
+      }, auth);
 
       // Stash file data on globalThis for the render route to consume
       await page.evaluate((data) => {

--- a/packages/realm-server/tests/auth-client-test.ts
+++ b/packages/realm-server/tests/auth-client-test.ts
@@ -17,30 +17,6 @@ function createJWT(
   return jwt.sign(payload, 'secret', { expiresIn });
 }
 
-function createStorage(initial: Record<string, string> = {}): Storage {
-  let values = { ...initial };
-  return {
-    getItem(key: string) {
-      return values[key] ?? null;
-    },
-    setItem(key: string, value: string) {
-      values[key] = value;
-    },
-    removeItem(key: string) {
-      delete values[key];
-    },
-    clear() {
-      values = {};
-    },
-    key(index: number) {
-      return Object.keys(values)[index] ?? null;
-    },
-    get length() {
-      return Object.keys(values).length;
-    },
-  } as Storage;
-}
-
 module(basename(__filename), function () {
   module('realm-auth-client', function (assert) {
     let client: RealmAuthClient;
@@ -203,58 +179,6 @@ module(basename(__filename), function () {
         /expected 'Authorization' header/,
         'missing Authorization header indicates verification failure',
       );
-    });
-
-    test('it reads render-context JWT from localStorage', async function (assert) {
-      let token = createJWT('1h', {
-        sessionRoom: 'room',
-        realmServerURL: 'http://testrealm.com/',
-      });
-      let originalLocalStorage = (globalThis as any).localStorage;
-      let originalSessionStorage = (globalThis as any).sessionStorage;
-      let originalRenderContext = (globalThis as any).__boxelRenderContext;
-
-      (globalThis as any).localStorage = createStorage({
-        'boxel-session': JSON.stringify({
-          'http://testrealm.com/': token,
-        }),
-      });
-      (globalThis as any).sessionStorage = createStorage();
-      (globalThis as any).__boxelRenderContext = true;
-
-      try {
-        assert.strictEqual(await client.getJWT(), token);
-      } finally {
-        (globalThis as any).localStorage = originalLocalStorage;
-        (globalThis as any).sessionStorage = originalSessionStorage;
-        (globalThis as any).__boxelRenderContext = originalRenderContext;
-      }
-    });
-
-    test('it falls back to sessionStorage in render context when localStorage is empty', async function (assert) {
-      let token = createJWT('1h', {
-        sessionRoom: 'room',
-        realmServerURL: 'http://testrealm.com/',
-      });
-      let originalLocalStorage = (globalThis as any).localStorage;
-      let originalSessionStorage = (globalThis as any).sessionStorage;
-      let originalRenderContext = (globalThis as any).__boxelRenderContext;
-
-      (globalThis as any).localStorage = createStorage();
-      (globalThis as any).sessionStorage = createStorage({
-        'boxel-session': JSON.stringify({
-          'http://testrealm.com/': token,
-        }),
-      });
-      (globalThis as any).__boxelRenderContext = true;
-
-      try {
-        assert.strictEqual(await client.getJWT(), token);
-      } finally {
-        (globalThis as any).localStorage = originalLocalStorage;
-        (globalThis as any).sessionStorage = originalSessionStorage;
-        (globalThis as any).__boxelRenderContext = originalRenderContext;
-      }
     });
   });
 });

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -73,6 +73,30 @@ function makeStubPagePool(
     onContextClosed?: (id: string) => void;
   },
 ) {
+  function makeStorage(): Storage {
+    let values: Record<string, string> = {};
+    return {
+      getItem(key: string) {
+        return values[key] ?? null;
+      },
+      setItem(key: string, value: string) {
+        values[key] = value;
+      },
+      removeItem(key: string) {
+        delete values[key];
+      },
+      clear() {
+        values = {};
+      },
+      key(index: number) {
+        return Object.keys(values)[index] ?? null;
+      },
+      get length() {
+        return Object.keys(values).length;
+      },
+    } as Storage;
+  }
+
   let contextCounter = 0;
   let contextsCreated: string[] = [];
   let contextsClosed: string[] = [];
@@ -85,7 +109,8 @@ function makeStubPagePool(
       let id = `ctx-${counter}`;
       contextsCreated.push(id);
       options?.onContextCreated?.(id);
-      return {
+      let localStorage = makeStorage();
+      let context = {
         async newPage() {
           return {
             async goto(_url: string, _opts?: any) {
@@ -93,6 +118,18 @@ function makeStubPagePool(
             },
             async waitForFunction(_fn: any) {
               return true;
+            },
+            async evaluate(fn: (...args: any[]) => any, ...args: any[]) {
+              let originalLocalStorage = (globalThis as any).localStorage;
+              (globalThis as any).localStorage = localStorage;
+              try {
+                return await fn(...args);
+              } finally {
+                (globalThis as any).localStorage = originalLocalStorage;
+              }
+            },
+            browserContext() {
+              return context;
             },
             removeAllListeners() {
               return;
@@ -111,6 +148,7 @@ function makeStubPagePool(
           return;
         },
       } as any;
+      return context;
     },
   };
   let browserManager = {
@@ -4456,6 +4494,47 @@ module(basename(__filename), function () {
           );
           realmASecond.release();
           realmBSecond.release();
+          await pool.closeAll();
+        });
+
+        test('each tab uses a separate browser context', async function (assert) {
+          let { pool } = makeStubPagePool(2);
+          await pool.warmStandbys();
+
+          let first = await pool.getPage('realm-a');
+          let second = await pool.getPage('realm-b');
+
+          assert.notStrictEqual(
+            first.page.browserContext(),
+            second.page.browserContext(),
+            'pages from different tabs are isolated by browser context',
+          );
+          await first.page.evaluate(
+            (key: string, value: string) => localStorage.setItem(key, value),
+            'boxel-test-local-storage-key',
+            'realm-a-value',
+          );
+          let firstValue = await first.page.evaluate(
+            (key: string) => localStorage.getItem(key),
+            'boxel-test-local-storage-key',
+          );
+          let secondValue = await second.page.evaluate(
+            (key: string) => localStorage.getItem(key),
+            'boxel-test-local-storage-key',
+          );
+          assert.strictEqual(
+            firstValue,
+            'realm-a-value',
+            'localStorage value is readable in the context that set it',
+          );
+          assert.strictEqual(
+            secondValue,
+            null,
+            'localStorage value is not visible across browser contexts',
+          );
+
+          first.release();
+          second.release();
           await pool.closeAll();
         });
 

--- a/packages/runtime-common/realm-auth-client.ts
+++ b/packages/runtime-common/realm-auth-client.ts
@@ -69,14 +69,6 @@ function realmSessionCacheKey(realmURL: URL, sessionEndpoint: string) {
   return `${realmURL.href}|${sessionEndpoint}`;
 }
 
-function getBoxelSessionWithFallback(): string | null {
-  let sessionStorageValue = globalThis.sessionStorage?.getItem('boxel-session');
-  if (sessionStorageValue !== null && sessionStorageValue !== undefined) {
-    return sessionStorageValue;
-  }
-  return globalThis.localStorage?.getItem('boxel-session') ?? null;
-}
-
 export class RealmAuthClient {
   private _jwt: string | undefined;
   private isRealmServerAuth: boolean;
@@ -98,10 +90,9 @@ export class RealmAuthClient {
     let tokenRefreshLeadTimeSeconds = 60;
     let jwt: string;
 
-    // Prerender contexts prefer sessionStorage (tab-isolated), then fall back
-    // to localStorage for compatibility with older contexts.
+    // the prerenderer relies solely on the JWT's in local storage
     if ((globalThis as any).__boxelRenderContext) {
-      let sessionStr = getBoxelSessionWithFallback() ?? '{}';
+      let sessionStr = globalThis.localStorage.getItem('boxel-session') ?? '{}';
       let session: { [realmURL: string]: string } = JSON.parse(sessionStr);
       let jwt = session[this.realmURL.href];
       if (!jwt) {


### PR DESCRIPTION
This PR reverts the work to use session storage support for boxel session and assert that each tab of puppeteer has it's own browser context and that local storage is not visible across browser contexts.