### PR TITLE
fix flaky scroll position test

### DIFF
--- a/packages/host/app/modifiers/scroll-anchor.ts
+++ b/packages/host/app/modifiers/scroll-anchor.ts
@@ -64,9 +64,10 @@ export default class ScrollAnchor extends Modifier<ScrollAnchorModifierSignature
       return;
     }
     this.#positionMap.clear();
+    let containerTop = this.#element.getBoundingClientRect().top;
     let elements = this.#element.querySelectorAll(this.#trackSelector);
     elements.forEach((el) => {
-      this.#positionMap.set(el, el.getBoundingClientRect().top);
+      this.#positionMap.set(el, el.getBoundingClientRect().top - containerTop);
     });
   }
 
@@ -80,7 +81,9 @@ export default class ScrollAnchor extends Modifier<ScrollAnchorModifierSignature
       let storedTop = anchor ? this.#positionMap.get(anchor) : undefined;
 
       if (anchor && storedTop !== undefined) {
-        let currentTop = anchor.getBoundingClientRect().top;
+        let currentTop =
+          anchor.getBoundingClientRect().top -
+          this.#element.getBoundingClientRect().top;
         let delta = currentTop - storedTop;
 
         if (Math.abs(delta) > 1) {

--- a/packages/host/app/modifiers/scroll-anchor.ts
+++ b/packages/host/app/modifiers/scroll-anchor.ts
@@ -59,15 +59,19 @@ export default class ScrollAnchor extends Modifier<ScrollAnchorModifierSignature
     };
   }
 
-  private capturePositions(): void {
+  private capturePositions(containerTop?: number): void {
     if (this.#isAdjusting || !this.#trackSelector) {
       return;
     }
     this.#positionMap.clear();
-    let containerTop = this.#element.getBoundingClientRect().top;
+    let relativeContainerTop =
+      containerTop ?? this.#element.getBoundingClientRect().top;
     let elements = this.#element.querySelectorAll(this.#trackSelector);
     elements.forEach((el) => {
-      this.#positionMap.set(el, el.getBoundingClientRect().top - containerTop);
+      this.#positionMap.set(
+        el,
+        el.getBoundingClientRect().top - relativeContainerTop,
+      );
     });
   }
 
@@ -75,15 +79,14 @@ export default class ScrollAnchor extends Modifier<ScrollAnchorModifierSignature
     if (isDestroying(this) || this.#isAdjusting) {
       return;
     }
+    let containerTop = this.#element.getBoundingClientRect().top;
 
     if (this.#anchorSelector) {
       let anchor = this.#element.querySelector(this.#anchorSelector);
       let storedTop = anchor ? this.#positionMap.get(anchor) : undefined;
 
       if (anchor && storedTop !== undefined) {
-        let currentTop =
-          anchor.getBoundingClientRect().top -
-          this.#element.getBoundingClientRect().top;
+        let currentTop = anchor.getBoundingClientRect().top - containerTop;
         let delta = currentTop - storedTop;
 
         if (Math.abs(delta) > 1) {
@@ -96,6 +99,6 @@ export default class ScrollAnchor extends Modifier<ScrollAnchorModifierSignature
 
     // Always recapture after any mutation so newly added elements
     // are tracked for future adjustments.
-    this.capturePositions();
+    this.capturePositions(containerTop);
   }
 }

--- a/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
@@ -1008,19 +1008,13 @@ module('Integration | operator-mode | card catalog', function (hooks) {
       document.querySelector(
         `[data-section-sid="${focusedSectionSid}"]`,
       ) as HTMLElement;
-    const waitForPreservedPosition = async (positionBefore: number) => {
-      await waitUntil(
-        () =>
-          Math.abs(
-            getFocusedSection().getBoundingClientRect().top - positionBefore,
-          ) <= 5,
-        { timeout: 2000 },
-      );
-    };
 
     let scrollContainer = document.querySelector(
       '.search-sheet-content',
     ) as HTMLElement;
+    const getFocusedSectionTopInContainer = () =>
+      getFocusedSection().getBoundingClientRect().top -
+      scrollContainer.getBoundingClientRect().top;
 
     // Force the scroll container to be short enough to require scrolling
     scrollContainer.style.maxHeight = '200px';
@@ -1037,12 +1031,11 @@ module('Integration | operator-mode | card catalog', function (hooks) {
     // Sync the modifier's position map and read positionBefore in the same
     // synchronous tick so they are guaranteed to reflect the same layout state.
     scrollContainer.dispatchEvent(new Event('scroll'));
-    let positionBefore = getFocusedSection().getBoundingClientRect().top;
+    let positionBefore = getFocusedSectionTopInContainer();
 
     await click('[data-test-search-sheet-show-only]');
-    await waitForPreservedPosition(positionBefore);
 
-    let positionAfter = getFocusedSection().getBoundingClientRect().top;
+    let positionAfter = getFocusedSectionTopInContainer();
     // Use a 5px tolerance instead of 2px: the scroll-anchor adjustment is
     // sub-pixel-accurate in local environments but CI Chromium instances can
     // render element positions with slight differences depending on DPI/font
@@ -1060,11 +1053,10 @@ module('Integration | operator-mode | card catalog', function (hooks) {
     // record positionBefore for this second assertion.
     await settled();
     scrollContainer.dispatchEvent(new Event('scroll'));
-    positionBefore = getFocusedSection().getBoundingClientRect().top;
+    positionBefore = getFocusedSectionTopInContainer();
     await click('[data-test-search-sheet-show-only]');
-    await waitForPreservedPosition(positionBefore);
 
-    positionAfter = getFocusedSection().getBoundingClientRect().top;
+    positionAfter = getFocusedSectionTopInContainer();
     assert.ok(
       Math.abs(positionAfter - positionBefore) <= 5,
       `focused section position is preserved after unchecking Show only (before: ${positionBefore}, after: ${positionAfter})`,


### PR DESCRIPTION
## Summary
- Fix scroll anchoring to use positions relative to the scroll container in `ScrollAnchor` instead of viewport coordinates.
- Remove the flaky `waitUntil` loop in `Show only preserves scroll position of the focused section` that could time out in CI.
- Update the test to measure focused-section position relative to `.search-sheet-content`, matching the modifier’s coordinate system and making the assertion deterministic.

## Why
- CI flakes were caused by mixing coordinate spaces (viewport vs container) and by a timing-dependent `waitUntil` condition that could fail to converge.
