### PR TITLE
Implement AI composer file upload state tracking

### DIFF
--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -113,9 +113,9 @@ export default class AttachedItems extends Component<Signature> {
     this.args.removeFile(file);
   }
 
-  private getUploadStatus(file: FileDef): FileUploadStatus | undefined {
+  private getUploadStatus = (file: FileDef): FileUploadStatus | undefined => {
     return this.args.fileUploadStates?.get(file.sourceUrl ?? '')?.status;
-  }
+  };
 
   <template>
     <div class='attached-items' ...attributes>

--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -114,7 +114,11 @@ export default class AttachedItems extends Component<Signature> {
   }
 
   private getUploadStatus = (file: FileDef): FileUploadStatus | undefined => {
-    return this.args.fileUploadStates?.get(file.sourceUrl ?? '')?.status;
+    let sourceUrl = file.sourceUrl;
+    if (!sourceUrl) {
+      return undefined;
+    }
+    return this.args.fileUploadStates?.get(sourceUrl)?.status;
   };
 
   <template>

--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -40,6 +40,8 @@ interface Signature {
     chooseFile?: (file: FileDef) => void;
     isLoaded: boolean;
     autoAttachedCardTooltipMessage?: string;
+    getFileUploadStatus?: (sourceUrl: string | undefined) => string | undefined;
+    retryFileUpload?: (file: FileDef) => void;
   };
 }
 
@@ -106,6 +108,16 @@ export default class AttachedItems extends Component<Signature> {
   private handleRemoveFile(file: FileDef) {
     this.args.removeFile(file);
   }
+
+  private getUploadStatusFor = (file: FileDef): string | undefined => {
+    return this.args.getFileUploadStatus?.(file.sourceUrl);
+  };
+
+  private getRetryActionFor = (file: FileDef): (() => void) | undefined => {
+    if (!this.args.retryFileUpload) return undefined;
+    let retryFn = this.args.retryFileUpload;
+    return () => retryFn(file);
+  };
 
   <template>
     <div class='attached-items' ...attributes>
@@ -191,6 +203,8 @@ export default class AttachedItems extends Component<Signature> {
                     @borderType='dashed'
                     @onClick={{fn this.handleChooseFile item}}
                     @onRemove={{fn this.handleRemoveFile item}}
+                    @uploadStatus={{this.getUploadStatusFor item}}
+                    @onRetry={{this.getRetryActionFor item}}
                     data-test-autoattached-file={{item.sourceUrl}}
                   />
                 </:trigger>
@@ -203,6 +217,8 @@ export default class AttachedItems extends Component<Signature> {
                 @file={{item}}
                 @borderType='solid'
                 @onRemove={{fn this.handleRemoveFile item}}
+                @uploadStatus={{this.getUploadStatusFor item}}
+                @onRetry={{this.getRetryActionFor item}}
               />
             {{/if}}
           {{/if}}

--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -17,6 +17,10 @@ import {
 
 import CardPill from '@cardstack/host/components/card-pill';
 import FilePill from '@cardstack/host/components/file-pill';
+import type {
+  FileUploadState,
+  FileUploadStatus,
+} from '@cardstack/host/lib/file-upload-state';
 import { urlForRealmLookup } from '@cardstack/host/lib/utils';
 
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
@@ -40,7 +44,7 @@ interface Signature {
     chooseFile?: (file: FileDef) => void;
     isLoaded: boolean;
     autoAttachedCardTooltipMessage?: string;
-    getFileUploadStatus?: (sourceUrl: string | undefined) => string | undefined;
+    fileUploadStates?: ReadonlyMap<string, FileUploadState>;
     retryFileUpload?: (file: FileDef) => void;
   };
 }
@@ -109,15 +113,9 @@ export default class AttachedItems extends Component<Signature> {
     this.args.removeFile(file);
   }
 
-  private getUploadStatusFor = (file: FileDef): string | undefined => {
-    return this.args.getFileUploadStatus?.(file.sourceUrl);
-  };
-
-  private getRetryActionFor = (file: FileDef): (() => void) | undefined => {
-    if (!this.args.retryFileUpload) return undefined;
-    let retryFn = this.args.retryFileUpload;
-    return () => retryFn(file);
-  };
+  private getUploadStatus(file: FileDef): FileUploadStatus | undefined {
+    return this.args.fileUploadStates?.get(file.sourceUrl ?? '')?.status;
+  }
 
   <template>
     <div class='attached-items' ...attributes>
@@ -203,8 +201,8 @@ export default class AttachedItems extends Component<Signature> {
                     @borderType='dashed'
                     @onClick={{fn this.handleChooseFile item}}
                     @onRemove={{fn this.handleRemoveFile item}}
-                    @uploadStatus={{this.getUploadStatusFor item}}
-                    @onRetry={{this.getRetryActionFor item}}
+                    @uploadStatus={{this.getUploadStatus item}}
+                    @onRetry={{if @retryFileUpload (fn @retryFileUpload item)}}
                     data-test-autoattached-file={{item.sourceUrl}}
                   />
                 </:trigger>
@@ -217,8 +215,8 @@ export default class AttachedItems extends Component<Signature> {
                 @file={{item}}
                 @borderType='solid'
                 @onRemove={{fn this.handleRemoveFile item}}
-                @uploadStatus={{this.getUploadStatusFor item}}
-                @onRetry={{this.getRetryActionFor item}}
+                @uploadStatus={{this.getUploadStatus item}}
+                @onRetry={{if @retryFileUpload (fn @retryFileUpload item)}}
               />
             {{/if}}
           {{/if}}

--- a/packages/host/app/components/ai-assistant/attachment-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/index.gts
@@ -9,6 +9,7 @@ import {
 } from '@cardstack/runtime-common';
 
 import consumeContext from '@cardstack/host/helpers/consume-context';
+import type { FileUploadState } from '@cardstack/host/lib/file-upload-state';
 
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 
@@ -30,7 +31,7 @@ interface Signature {
     chooseFile: (file: FileDef) => void;
     removeFile: (file: FileDef) => void;
     autoAttachedCardTooltipMessage?: string;
-    getFileUploadStatus?: (sourceUrl: string | undefined) => string | undefined;
+    fileUploadStates?: ReadonlyMap<string, FileUploadState>;
     retryFileUpload?: (file: FileDef) => void;
   };
   Blocks: {
@@ -46,7 +47,7 @@ interface Signature {
         | 'chooseFile'
         | 'autoAttachedCardTooltipMessage'
         | 'isLoaded'
-        | 'getFileUploadStatus'
+        | 'fileUploadStates'
         | 'retryFileUpload'
       >,
       WithBoundArgs<typeof AttachButton, 'chooseCard' | 'chooseFile'>,
@@ -69,7 +70,7 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
         chooseCard=@chooseCard
         chooseFile=@chooseFile
         autoAttachedCardTooltipMessage=@autoAttachedCardTooltipMessage
-        getFileUploadStatus=@getFileUploadStatus
+        fileUploadStates=@fileUploadStates
         retryFileUpload=@retryFileUpload
       )
       (component AttachButton chooseCard=@chooseCard chooseFile=@chooseFile)

--- a/packages/host/app/components/ai-assistant/attachment-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/index.gts
@@ -30,6 +30,8 @@ interface Signature {
     chooseFile: (file: FileDef) => void;
     removeFile: (file: FileDef) => void;
     autoAttachedCardTooltipMessage?: string;
+    getFileUploadStatus?: (sourceUrl: string | undefined) => string | undefined;
+    retryFileUpload?: (file: FileDef) => void;
   };
   Blocks: {
     default: [
@@ -44,6 +46,8 @@ interface Signature {
         | 'chooseFile'
         | 'autoAttachedCardTooltipMessage'
         | 'isLoaded'
+        | 'getFileUploadStatus'
+        | 'retryFileUpload'
       >,
       WithBoundArgs<typeof AttachButton, 'chooseCard' | 'chooseFile'>,
     ];
@@ -65,6 +69,8 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
         chooseCard=@chooseCard
         chooseFile=@chooseFile
         autoAttachedCardTooltipMessage=@autoAttachedCardTooltipMessage
+        getFileUploadStatus=@getFileUploadStatus
+        retryFileUpload=@retryFileUpload
       )
       (component AttachButton chooseCard=@chooseCard chooseFile=@chooseFile)
     }}

--- a/packages/host/app/components/file-pill.gts
+++ b/packages/host/app/components/file-pill.gts
@@ -5,9 +5,10 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 import FileCode from '@cardstack/boxel-icons/file-code';
+import RefreshCw from '@cardstack/boxel-icons/refresh-cw';
 
 import { IconButton, Pill } from '@cardstack/boxel-ui/components';
-import { cn, cssVar } from '@cardstack/boxel-ui/helpers';
+import { cn, cssVar, eq } from '@cardstack/boxel-ui/helpers';
 import { IconX, Download } from '@cardstack/boxel-ui/icons';
 
 import type { FileDef } from 'https://cardstack.com/base/file-api';
@@ -22,9 +23,11 @@ interface FilePillSignature {
     file: FileDef;
     borderType?: 'dashed' | 'solid';
     fileActionsEnabled?: boolean;
+    uploadStatus?: string;
     onClick?: () => void;
     onRemove?: () => void;
     onDownload?: () => void;
+    onRetry?: () => void;
   };
 }
 
@@ -60,6 +63,12 @@ export default class FilePill extends Component<FilePillSignature> {
     }
   }
 
+  @action
+  private handleRetryClick(event: Event) {
+    event.stopPropagation();
+    this.args.onRetry?.();
+  }
+
   private get pillKind() {
     return this.args.onClick ? 'button' : 'default';
   }
@@ -77,6 +86,7 @@ export default class FilePill extends Component<FilePillSignature> {
       @kind={{this.pillKind}}
       class={{cn 'file-pill' this.borderClass}}
       data-test-attached-file={{@file.sourceUrl}}
+      data-test-file-upload-status={{@uploadStatus}}
       {{on 'click' this.handleFileClick}}
       ...attributes
     >
@@ -93,6 +103,18 @@ export default class FilePill extends Component<FilePillSignature> {
         </div>
       </:default>
       <:iconRight>
+        {{#if (eq @uploadStatus 'error')}}
+          {{#if @onRetry}}
+            <IconButton
+              class='retry-button'
+              @icon={{RefreshCw}}
+              @height='10'
+              @width='10'
+              {{on 'click' this.handleRetryClick}}
+              data-test-file-retry-btn
+            />
+          {{/if}}
+        {{/if}}
         {{#if @onRemove}}
           <IconButton
             class='remove-button'

--- a/packages/host/app/components/file-pill.gts
+++ b/packages/host/app/components/file-pill.gts
@@ -11,6 +11,8 @@ import { IconButton, Pill } from '@cardstack/boxel-ui/components';
 import { cn, cssVar, eq } from '@cardstack/boxel-ui/helpers';
 import { IconX, Download } from '@cardstack/boxel-ui/icons';
 
+import type { FileUploadStatus } from '@cardstack/host/lib/file-upload-state';
+
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 import AttachedFileDropdownMenu from './ai-assistant/attached-file-dropdown-menu';
@@ -23,7 +25,7 @@ interface FilePillSignature {
     file: FileDef;
     borderType?: 'dashed' | 'solid';
     fileActionsEnabled?: boolean;
-    uploadStatus?: string;
+    uploadStatus?: FileUploadStatus;
     onClick?: () => void;
     onRemove?: () => void;
     onDownload?: () => void;

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -44,6 +44,7 @@ import {
 } from '@cardstack/runtime-common/matrix-constants';
 
 import UpdateRoomSkillsCommand from '@cardstack/host/commands/update-room-skills';
+import type { FileUploadState } from '@cardstack/host/lib/file-upload-state';
 import type { Message } from '@cardstack/host/lib/matrix-classes/message';
 import type { StackItem } from '@cardstack/host/lib/stack-item';
 import { getAutoAttachment } from '@cardstack/host/resources/auto-attached-card';
@@ -197,7 +198,7 @@ export default class Room extends Component<Signature> {
             @removeFile={{this.removeFile}}
             @autoAttachedFiles={{this.autoAttachedFiles}}
             @filesToAttach={{this.filesToAttach}}
-            @getFileUploadStatus={{this.getFileUploadStatus}}
+            @fileUploadStates={{this.fileUploadStates}}
             @retryFileUpload={{this.retryFileUpload}}
             @autoAttachedCardTooltipMessage={{if
               (eq this.operatorModeStateService.state.submode Submodes.Code)
@@ -478,10 +479,11 @@ export default class Room extends Component<Signature> {
   > = new WeakMap();
 
   @tracked private unknownMessageSendError: string | undefined = undefined;
-  private fileUploadStates = new TrackedMap<
-    string,
-    { status: 'uploading' | 'complete' | 'error'; error?: string }
-  >();
+  private _fileUploadStates = new TrackedMap<string, FileUploadState>();
+
+  get fileUploadStates(): ReadonlyMap<string, FileUploadState> {
+    return this._fileUploadStates;
+  }
   private get shouldShowUnknownMessageSendError() {
     // Since unknownMessageSendError error is coming from the catch-all block in doSendMessage,
     // we need to check if there already exists an error message in the last message, which is
@@ -1083,19 +1085,19 @@ export default class Room extends Component<Signature> {
 
     this.markAttachedFileRemoved(file.sourceUrl);
     if (file.sourceUrl) {
-      this.fileUploadStates.delete(file.sourceUrl);
+      this._fileUploadStates.delete(file.sourceUrl);
     }
   }
 
   private async startFileUpload(file: FileDef) {
     let sourceUrl = file.sourceUrl;
     if (!sourceUrl) return;
-    this.fileUploadStates.set(sourceUrl, { status: 'uploading' });
+    this._fileUploadStates.set(sourceUrl, { status: 'uploading' });
     try {
       await this.matrixService.uploadFiles([file]);
-      this.fileUploadStates.set(sourceUrl, { status: 'complete' });
+      this._fileUploadStates.set(sourceUrl, { status: 'complete' });
     } catch (e: any) {
-      this.fileUploadStates.set(sourceUrl, {
+      this._fileUploadStates.set(sourceUrl, {
         status: 'error',
         error: e?.message,
       });
@@ -1103,7 +1105,7 @@ export default class Room extends Component<Signature> {
   }
 
   private get hasFileUploadIssues() {
-    for (let [, state] of this.fileUploadStates) {
+    for (let [, state] of this._fileUploadStates) {
       if (state.status === 'uploading' || state.status === 'error') {
         return true;
       }
@@ -1114,14 +1116,6 @@ export default class Room extends Component<Signature> {
   @action
   private retryFileUpload(file: FileDef) {
     this.startFileUpload(file);
-  }
-
-  @action
-  private getFileUploadStatus(
-    sourceUrl: string | undefined,
-  ): string | undefined {
-    if (!sourceUrl) return undefined;
-    return this.fileUploadStates.get(sourceUrl)?.status;
   }
 
   private doSendMessage = enqueueTask(

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -1095,12 +1095,20 @@ export default class Room extends Component<Signature> {
     this._fileUploadStates.set(sourceUrl, { status: 'uploading' });
     try {
       await this.matrixService.uploadFiles([file]);
-      this._fileUploadStates.set(sourceUrl, { status: 'complete' });
+      // Only update state if the file is still attached (guards against
+      // race where file is removed while upload was in-flight).
+      if (this.filesToAttach?.find((f) => f.sourceUrl === sourceUrl)) {
+        this._fileUploadStates.set(sourceUrl, { status: 'complete' });
+      }
     } catch (e: any) {
-      this._fileUploadStates.set(sourceUrl, {
-        status: 'error',
-        error: e?.message,
-      });
+      // Only set error state if the file is still attached, to avoid
+      // blocking canSend for a file the user already removed.
+      if (this.filesToAttach?.find((f) => f.sourceUrl === sourceUrl)) {
+        this._fileUploadStates.set(sourceUrl, {
+          status: 'error',
+          error: e?.message,
+        });
+      }
     }
   }
 
@@ -1144,6 +1152,7 @@ export default class Room extends Component<Signature> {
         this.matrixService.setMessageToSend(this.args.roomId, undefined);
         this.matrixService.setCardsToSend(this.args.roomId, undefined);
         this.matrixService.setFilesToSend(this.args.roomId, undefined);
+        this._fileUploadStates.clear();
       }
 
       let openCardIds = new Set([

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -24,7 +24,7 @@ import max from 'lodash/max';
 
 import pluralize from 'pluralize';
 
-import { TrackedObject, TrackedArray } from 'tracked-built-ins';
+import { TrackedObject, TrackedArray, TrackedMap } from 'tracked-built-ins';
 
 import { v4 as uuidv4 } from 'uuid';
 
@@ -197,6 +197,8 @@ export default class Room extends Component<Signature> {
             @removeFile={{this.removeFile}}
             @autoAttachedFiles={{this.autoAttachedFiles}}
             @filesToAttach={{this.filesToAttach}}
+            @getFileUploadStatus={{this.getFileUploadStatus}}
+            @retryFileUpload={{this.retryFileUpload}}
             @autoAttachedCardTooltipMessage={{if
               (eq this.operatorModeStateService.state.submode Submodes.Code)
               'Current card is shared automatically'
@@ -476,6 +478,10 @@ export default class Room extends Component<Signature> {
   > = new WeakMap();
 
   @tracked private unknownMessageSendError: string | undefined = undefined;
+  private fileUploadStates = new TrackedMap<
+    string,
+    { status: 'uploading' | 'complete' | 'error'; error?: string }
+  >();
   private get shouldShowUnknownMessageSendError() {
     // Since unknownMessageSendError error is coming from the catch-all block in doSendMessage,
     // we need to check if there already exists an error message in the last message, which is
@@ -1042,6 +1048,7 @@ export default class Room extends Component<Signature> {
     let files = this.filesToAttach;
     if (!files?.find((f) => f.sourceUrl === file.sourceUrl)) {
       this.matrixService.setFilesToSend(this.args.roomId, [...files, file]);
+      this.startFileUpload(file);
     }
   }
 
@@ -1075,6 +1082,46 @@ export default class Room extends Component<Signature> {
     );
 
     this.markAttachedFileRemoved(file.sourceUrl);
+    if (file.sourceUrl) {
+      this.fileUploadStates.delete(file.sourceUrl);
+    }
+  }
+
+  private async startFileUpload(file: FileDef) {
+    let sourceUrl = file.sourceUrl;
+    if (!sourceUrl) return;
+    this.fileUploadStates.set(sourceUrl, { status: 'uploading' });
+    try {
+      await this.matrixService.uploadFiles([file]);
+      this.fileUploadStates.set(sourceUrl, { status: 'complete' });
+    } catch (e: any) {
+      this.fileUploadStates.set(sourceUrl, {
+        status: 'error',
+        error: e?.message,
+      });
+    }
+  }
+
+  private get hasFileUploadIssues() {
+    for (let [, state] of this.fileUploadStates) {
+      if (state.status === 'uploading' || state.status === 'error') {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @action
+  private retryFileUpload(file: FileDef) {
+    this.startFileUpload(file);
+  }
+
+  @action
+  private getFileUploadStatus(
+    sourceUrl: string | undefined,
+  ): string | undefined {
+    if (!sourceUrl) return undefined;
+    return this.fileUploadStates.get(sourceUrl)?.status;
   }
 
   private doSendMessage = enqueueTask(
@@ -1209,8 +1256,11 @@ export default class Room extends Component<Signature> {
       Boolean(
         this.messageToSend?.trim() ||
         this.cardIdsToAttach?.length ||
-        this.autoAttachedCardIds.size !== 0,
+        this.autoAttachedCardIds.size !== 0 ||
+        this.filesToAttach?.length ||
+        this.autoAttachedFiles.length > 0,
       ) &&
+      !this.hasFileUploadIssues &&
       !!this.room &&
       !this.messages.some((m) => this.isPendingMessage(m)) &&
       !this.matrixService.isLoadingTimeline &&

--- a/packages/host/app/lib/file-upload-state.ts
+++ b/packages/host/app/lib/file-upload-state.ts
@@ -1,0 +1,6 @@
+export type FileUploadStatus = 'uploading' | 'complete' | 'error';
+
+export interface FileUploadState {
+  status: FileUploadStatus;
+  error?: string;
+}

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1159,7 +1159,14 @@ export default class MatrixService extends Service {
     attachedFiles: ReturnType<FileDef['serialize']>[];
   }> {
     let cardFileDefs = await this.uploadCards(attachedCards);
-    let uploadedFileDefs = await this.uploadFiles(attachedFiles);
+    // Skip uploading files that were already eagerly uploaded (url is already
+    // set by startFileUpload); only upload files that don't yet have a url.
+    let filesToUpload = attachedFiles.filter((f) => !f.url);
+    if (filesToUpload.length > 0) {
+      await this.uploadFiles(filesToUpload);
+    }
+    // Preserve original order; freshly uploaded files now have url set on them.
+    let uploadedFileDefs = attachedFiles;
 
     return {
       context,

--- a/packages/host/tests/helpers/mock-matrix.ts
+++ b/packages/host/tests/helpers/mock-matrix.ts
@@ -26,6 +26,7 @@ export interface Config {
   now?: () => number;
   directRooms?: string[];
   systemCardAccountData?: { id?: string };
+  uploadContentInterceptor?: () => Promise<void>;
 }
 
 export function setupMockMatrix(

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -862,6 +862,9 @@ export class MockClient implements ExtendedClient {
     _content: string,
     _opts?: { type?: string; name?: string },
   ): Promise<any> {
+    if (this.sdkOpts.uploadContentInterceptor) {
+      await this.sdkOpts.uploadContentInterceptor();
+    }
     let contentUri = `mxc://mock-server/${Math.random()}`;
     this.serverState.addContent(
       this.mxcUrlToHttp(contentUri),

--- a/packages/host/tests/helpers/mock-matrix/_utils.ts
+++ b/packages/host/tests/helpers/mock-matrix/_utils.ts
@@ -117,6 +117,10 @@ export class MockUtils {
   getUploadedContents = () => {
     return this.testState.sdk!.serverState.getUploadedContents();
   };
+  setUploadContentInterceptor = (fn: (() => Promise<void>) | undefined) => {
+    this.testState.opts!.uploadContentInterceptor = fn;
+  };
+
   setRoomState = (
     roomId: string,
     eventType: string,

--- a/packages/host/tests/integration/components/ai-assistant-panel/file-attachment-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/file-attachment-test.gts
@@ -1,0 +1,485 @@
+import { waitFor, waitUntil, click, fillIn } from '@ember/test-helpers';
+import { settled } from '@ember/test-helpers';
+import GlimmerComponent from '@glimmer/component';
+
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import { baseRealm } from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import OperatorMode from '@cardstack/host/components/operator-mode/container';
+
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+
+import {
+  testRealmURL,
+  setupCardLogs,
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupOnSave,
+  setupOperatorModeStateCleanup,
+  setupRealmCacheTeardown,
+  withCachedRealmSetup,
+} from '../../../helpers';
+import {
+  CardDef,
+  Component,
+  contains,
+  field,
+  setupBaseRealm,
+  StringField,
+} from '../../../helpers/base-realm';
+import { setupMockMatrix } from '../../../helpers/mock-matrix';
+import { renderComponent } from '../../../helpers/render-component';
+import { setupRenderingTest } from '../../../helpers/setup';
+
+module('Integration | ai-assistant-panel | file-attachment', function (hooks) {
+  const realmName = 'Operator Mode Workspace';
+  let loader: Loader;
+  let operatorModeStateService: OperatorModeStateService;
+
+  setupRenderingTest(hooks);
+  setupOperatorModeStateCleanup(hooks);
+  setupBaseRealm(hooks);
+
+  hooks.beforeEach(function () {
+    loader = getService('loader-service').loader;
+  });
+
+  setupLocalIndexing(hooks);
+  setupOnSave(hooks);
+  setupRealmCacheTeardown(hooks);
+  setupCardLogs(
+    hooks,
+    async () => await loader.import(`${baseRealm.url}card-api`),
+  );
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+    now: (() => {
+      let clock = new Date(2024, 8, 19).getTime();
+      return () => (clock += 10);
+    })(),
+  });
+
+  let noop = () => {};
+
+  hooks.beforeEach(async function () {
+    operatorModeStateService = getService('operator-mode-state-service');
+
+    class Person extends CardDef {
+      static displayName = 'Person';
+      @field firstName = contains(StringField);
+      @field cardTitle = contains(StringField, {
+        computeVia: function (this: Person) {
+          return this.firstName;
+        },
+      });
+      static isolated = class Isolated extends Component<typeof this> {
+        <template>
+          <h2 data-test-person={{@model.firstName}}>
+            <@fields.firstName />
+          </h2>
+        </template>
+      };
+    }
+
+    class Pet extends CardDef {
+      static displayName = 'Pet';
+      @field petName = contains(StringField);
+      @field cardTitle = contains(StringField, {
+        computeVia: function (this: Pet) {
+          return this.petName;
+        },
+      });
+      static isolated = class Isolated extends Component<typeof this> {
+        <template>
+          <h2 data-test-pet={{@model.petName}}>
+            <@fields.petName />
+          </h2>
+        </template>
+      };
+    }
+
+    await withCachedRealmSetup(async () => {
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {
+          'person.gts': { Person },
+          'pet.gts': { Pet },
+          'Person/fadhlan.json': new Person({ firstName: 'Fadhlan' }),
+          '.realm.json': `{ "name": "${realmName}" }`,
+        },
+      });
+    });
+  });
+
+  function setCardInOperatorModeState(
+    cardURL?: string,
+    format: 'isolated' | 'edit' = 'isolated',
+  ) {
+    operatorModeStateService.restore({
+      stacks: cardURL ? [[{ id: cardURL, format }]] : [[]],
+    });
+  }
+
+  async function openAiAssistant(): Promise<string> {
+    await waitFor('[data-test-open-ai-assistant]');
+    await click('[data-test-open-ai-assistant]');
+    await waitFor('[data-test-room-settled]');
+    let roomId = document
+      .querySelector('[data-test-room]')
+      ?.getAttribute('data-test-room');
+    if (!roomId) {
+      throw new Error('Expected a room ID');
+    }
+    return roomId;
+  }
+
+  async function attachFileFromRealm(fileName: string) {
+    await click('[data-test-attach-button]');
+    await click('[data-test-attach-file-btn]');
+    await click(`[data-test-file="${fileName}"]`);
+    await click('[data-test-choose-file-modal-add-button]');
+  }
+
+  test('can send a message with only file attachments and no text', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await openAiAssistant();
+
+    await attachFileFromRealm('person.gts');
+    await waitFor(
+      `[data-test-attached-file="${testRealmURL}person.gts"][data-test-file-upload-status="complete"]`,
+    );
+
+    assert
+      .dom(`[data-test-attached-file="${testRealmURL}person.gts"]`)
+      .exists('file pill is rendered after attaching');
+
+    // canSend should be true with only a file attached (no text needed)
+    assert
+      .dom('[data-test-send-message-btn]')
+      .hasAttribute(
+        'data-test-can-send-msg',
+        '',
+        'canSend should be true when file is attached without text',
+      );
+    assert
+      .dom('[data-test-send-message-btn]')
+      .isEnabled('send button should be enabled with only a file attached');
+  });
+
+  test('file from realm file chooser appears as attached with upload status', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await openAiAssistant();
+
+    await attachFileFromRealm('person.gts');
+
+    assert
+      .dom(`[data-test-attached-file="${testRealmURL}person.gts"]`)
+      .exists('file pill is rendered');
+
+    // File pill should expose an upload status attribute
+    assert
+      .dom(
+        `[data-test-attached-file="${testRealmURL}person.gts"][data-test-file-upload-status]`,
+      )
+      .exists('file pill should have an upload status attribute');
+  });
+
+  test('file pill shows uploading indicator while Matrix upload is in progress', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await openAiAssistant();
+
+    let resolveUpload!: () => void;
+    let uploadPromise = new Promise<void>((resolve) => {
+      resolveUpload = resolve;
+    });
+    mockMatrixUtils.setUploadContentInterceptor(() => uploadPromise);
+
+    // Don't await the last click — it triggers startFileUpload which blocks
+    // settled() via test waiters. Instead, fire-and-forget and waitFor the
+    // transient "uploading" state.
+    await click('[data-test-attach-button]');
+    await click('[data-test-attach-file-btn]');
+    await click(`[data-test-file="person.gts"]`);
+    click('[data-test-choose-file-modal-add-button]'); // intentionally not awaited
+
+    await waitFor(
+      `[data-test-attached-file="${testRealmURL}person.gts"][data-test-file-upload-status="uploading"]`,
+    );
+
+    // During the eager upload, the file pill should show uploading status
+    assert
+      .dom(
+        `[data-test-attached-file="${testRealmURL}person.gts"][data-test-file-upload-status="uploading"]`,
+      )
+      .exists('file pill should show uploading status during upload');
+
+    // Clean up: resolve the blocked upload
+    mockMatrixUtils.setUploadContentInterceptor(undefined);
+    resolveUpload();
+    await settled();
+  });
+
+  test('send button is disabled while any file upload is pending', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await openAiAssistant();
+
+    let resolveUpload!: () => void;
+    let uploadPromise = new Promise<void>((resolve) => {
+      resolveUpload = resolve;
+    });
+    mockMatrixUtils.setUploadContentInterceptor(() => uploadPromise);
+
+    // Don't await the last click — it blocks settled() via test waiters
+    await click('[data-test-attach-button]');
+    await click('[data-test-attach-file-btn]');
+    await click(`[data-test-file="person.gts"]`);
+    click('[data-test-choose-file-modal-add-button]'); // intentionally not awaited
+
+    await waitFor(
+      `[data-test-attached-file="${testRealmURL}person.gts"][data-test-file-upload-status="uploading"]`,
+    );
+
+    // After attaching, the file should show its upload status (eagerly uploading)
+    assert
+      .dom(
+        `[data-test-attached-file="${testRealmURL}person.gts"][data-test-file-upload-status="uploading"]`,
+      )
+      .exists('file should show uploading status after attach');
+
+    // Use waitUntil to fill in the message field without settled() blocking
+    let messageField = document.querySelector(
+      '[data-test-message-field]',
+    ) as HTMLTextAreaElement;
+    messageField.value = 'text present but upload pending';
+    messageField.dispatchEvent(new Event('input', { bubbles: true }));
+
+    // Even with text present, send should be blocked while a file is uploading
+    await waitUntil(() =>
+      document.querySelector('[data-test-send-message-btn]'),
+    );
+    assert
+      .dom('[data-test-send-message-btn]')
+      .isDisabled(
+        'send button should be disabled while file upload is pending',
+      );
+
+    // Clean up: resolve the blocked upload
+    mockMatrixUtils.setUploadContentInterceptor(undefined);
+    resolveUpload();
+    await settled();
+  });
+
+  test('send button is disabled when a file upload has failed', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await openAiAssistant();
+
+    mockMatrixUtils.setUploadContentInterceptor(async () => {
+      throw new Error('Upload failed');
+    });
+
+    await attachFileFromRealm('person.gts');
+    await waitFor(
+      `[data-test-attached-file="${testRealmURL}person.gts"][data-test-file-upload-status="error"]`,
+    );
+
+    // After upload failure, file pill should show error status
+    assert
+      .dom(
+        `[data-test-attached-file="${testRealmURL}person.gts"][data-test-file-upload-status="error"]`,
+      )
+      .exists('file pill should show error upload status');
+
+    await fillIn('[data-test-message-field]', 'text with failed upload');
+
+    assert
+      .dom('[data-test-send-message-btn]')
+      .isDisabled(
+        'send button should be disabled when a file upload has failed',
+      );
+  });
+
+  test('retry button on failed file upload restarts the upload', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await openAiAssistant();
+
+    // First upload fails
+    mockMatrixUtils.setUploadContentInterceptor(async () => {
+      throw new Error('Upload failed');
+    });
+
+    await attachFileFromRealm('person.gts');
+    await waitFor(
+      `[data-test-attached-file="${testRealmURL}person.gts"][data-test-file-upload-status="error"]`,
+    );
+
+    // After failure, retry button should be available on the file pill
+    assert
+      .dom(
+        `[data-test-attached-file="${testRealmURL}person.gts"] [data-test-file-retry-btn]`,
+      )
+      .exists('failed file pill should have a retry button');
+
+    // Set up blocking interceptor for retry so we can observe "uploading" state
+    let resolveRetry!: () => void;
+    let retryPromise = new Promise<void>((resolve) => {
+      resolveRetry = resolve;
+    });
+    mockMatrixUtils.setUploadContentInterceptor(() => retryPromise);
+
+    // Don't await — retry triggers startFileUpload which blocks settled()
+    click(
+      `[data-test-attached-file="${testRealmURL}person.gts"] [data-test-file-retry-btn]`,
+    );
+
+    await waitFor(
+      `[data-test-attached-file="${testRealmURL}person.gts"][data-test-file-upload-status="uploading"]`,
+    );
+
+    assert
+      .dom(
+        `[data-test-attached-file="${testRealmURL}person.gts"][data-test-file-upload-status="uploading"]`,
+      )
+      .exists('file should go back to uploading state after retry');
+
+    // Clean up: resolve the blocked retry upload
+    mockMatrixUtils.setUploadContentInterceptor(undefined);
+    resolveRetry();
+    await settled();
+  });
+
+  test('removing a file with failed upload unblocks send when text is present', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await openAiAssistant();
+
+    mockMatrixUtils.setUploadContentInterceptor(async () => {
+      throw new Error('Upload failed');
+    });
+
+    await attachFileFromRealm('person.gts');
+    await waitFor(
+      `[data-test-attached-file="${testRealmURL}person.gts"][data-test-file-upload-status="error"]`,
+    );
+
+    await fillIn('[data-test-message-field]', 'text with failed file');
+
+    // Send should be disabled because of the failed file upload
+    assert
+      .dom(
+        `[data-test-attached-file="${testRealmURL}person.gts"][data-test-file-upload-status="error"]`,
+      )
+      .exists('file pill shows error status');
+    assert
+      .dom('[data-test-send-message-btn]')
+      .isDisabled('send is disabled due to failed file upload');
+
+    // Remove the failed file
+    mockMatrixUtils.setUploadContentInterceptor(undefined);
+    await click(
+      `[data-test-attached-file="${testRealmURL}person.gts"] [data-test-remove-file-btn]`,
+    );
+
+    // With the failed file removed and text present, send should be enabled
+    assert
+      .dom('[data-test-send-message-btn]')
+      .isEnabled('send is enabled after removing the failed file');
+    assert
+      .dom('[data-test-send-message-btn]')
+      .hasAttribute(
+        'data-test-can-send-msg',
+        '',
+        'canSend is true when only text remains',
+      );
+  });
+
+  test('attachment order is preserved in outgoing message event', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    let roomId = await openAiAssistant();
+
+    // Attach person.gts first, then pet.gts second
+    await attachFileFromRealm('person.gts');
+    await attachFileFromRealm('pet.gts');
+    await waitFor(
+      `[data-test-attached-file="${testRealmURL}person.gts"][data-test-file-upload-status="complete"]`,
+    );
+    await waitFor(
+      `[data-test-attached-file="${testRealmURL}pet.gts"][data-test-file-upload-status="complete"]`,
+    );
+
+    await fillIn('[data-test-message-field]', 'message with ordered files');
+    await click('[data-test-send-message-btn]');
+
+    let events = mockMatrixUtils.getRoomEvents(roomId);
+    let sentEvent = events.find(
+      (e: any) =>
+        e.type === 'm.room.message' &&
+        e.content?.body === 'message with ordered files',
+    );
+
+    assert.ok(sentEvent, 'sent event exists');
+
+    let rawData = (sentEvent as any)?.content?.data;
+    let data = typeof rawData === 'string' ? JSON.parse(rawData) : rawData;
+    let attachedFiles = data?.attachedFiles;
+    assert.ok(attachedFiles, 'event has attachedFiles');
+    assert.strictEqual(
+      attachedFiles?.length,
+      2,
+      'two files are attached in the event',
+    );
+    assert.ok(
+      attachedFiles?.[0]?.sourceUrl?.endsWith('person.gts'),
+      'first attached file is person.gts (preserving attachment order)',
+    );
+    assert.ok(
+      attachedFiles?.[1]?.sourceUrl?.endsWith('pet.gts'),
+      'second attached file is pet.gts (preserving attachment order)',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add eager file upload to Matrix when files are attached to the AI composer, with per-file status tracking (uploading/complete/error) using `TrackedMap`
- Block send button while any file upload is pending or has failed; enable file-only sends (no text required) when uploads are complete
- Add retry button on file pills with failed uploads and cleanup of upload state on file removal
- Add `uploadContentInterceptor` to mock Matrix client for controlling upload timing/failure in tests
- Refactor: extract `FileUploadState`/`FileUploadStatus` types into shared module, replace callback indirection (`getFileUploadStatus`) with direct `TrackedMap` access, remove arrow function wrappers in attached-items

## Test plan
- [x] 8 new integration tests in `file-attachment-test.gts`:
  - Can send with only file attachments (no text)
  - File pill shows upload status attribute
  - Uploading indicator during Matrix upload
  - Send disabled while upload pending
  - Send disabled on upload error
  - Retry button restarts failed upload
  - Removing failed file unblocks send
  - Attachment order preserved in outgoing event
- [ ] Manual verification in dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)