### PR TITLE
Binary-safe file upload with content-hash deduplication

### DIFF
--- a/packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts
@@ -33,7 +33,7 @@ interface Signature {
   Element: HTMLDivElement;
   Args: {
     chooseCard: (cardId: string) => void;
-    chooseFile: (file: FileDef) => void;
+    chooseFile: (file: FileDef) => void | Promise<void>;
   };
 }
 
@@ -144,7 +144,7 @@ export default class AttachButton extends Component<Signature> {
   private doChooseFile = restartableTask(async () => {
     let chosenFile: FileDef | undefined = await chooseFile();
     if (chosenFile) {
-      this.args.chooseFile(chosenFile);
+      await this.args.chooseFile(chosenFile);
     }
     return chosenFile;
   });

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -1041,7 +1041,7 @@ export default class Room extends Component<Signature> {
   }
 
   @action
-  private chooseFile(file: FileDef) {
+  private async chooseFile(file: FileDef) {
     // handle the case where auto-attached file pill is clicked
     if (this.isAutoAttachedFile(file)) {
       this.removeAutoAttachedFile(file.sourceUrl ?? undefined);
@@ -1049,6 +1049,7 @@ export default class Room extends Component<Signature> {
 
     let files = this.filesToAttach;
     if (!files?.find((f) => f.sourceUrl === file.sourceUrl)) {
+      await this.matrixService.prefetchFileContent(file);
       this.matrixService.setFilesToSend(this.args.roomId, [...files, file]);
       this.startFileUpload(file);
     }

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -71,6 +71,13 @@ export interface FileDefManager {
   uploadFiles(files: FileDef[]): Promise<FileDef[]>;
 
   /**
+   * Pre-fetches file content at attach time so the bytes are captured
+   * before the user sends the message (guards against file modifications
+   * between attach and send).
+   */
+  prefetchFileContent(file: FileDef): Promise<void>;
+
+  /**
    * Downloads content from a file definition
    * @param fileDef File definition to download from
    * @returns Promise resolving to the downloaded content
@@ -93,7 +100,7 @@ export interface FileDefManager {
 export interface PrivilegedFileDefManager extends FileDefManager {
   contentHashCache: Map<string, string>;
   invalidUrlCache: Set<string>;
-  getContentHash(content: string): Promise<string>;
+  getContentHash(content: string | Uint8Array): Promise<string>;
 }
 
 export default class FileDefManagerImpl
@@ -105,6 +112,10 @@ export default class FileDefManagerImpl
   private inFlightBlobFetches: Map<string, Promise<Blob>> = new Map();
   contentHashCache: Map<string, string> = new Map(); // Maps content hash to URL
   invalidUrlCache: Set<string> = new Set(); // Cache for URLs where content hash validation failed
+  private prefetchedContent: Map<
+    string,
+    { bytes: Uint8Array; contentType: string }
+  > = new Map();
   private client: ExtendedClient;
   private getCardAPI: () => typeof CardAPI;
   private getFileAPI: () => typeof FileAPI;
@@ -139,19 +150,19 @@ export default class FileDefManagerImpl
     return this.getCardAPI();
   }
 
-  async getContentHash(content: string): Promise<string> {
+  async getContentHash(content: string | Uint8Array): Promise<string> {
     return md5(content);
   }
 
   private async getCachedUrlForContent(
-    content: string,
+    content: string | Uint8Array,
   ): Promise<string | null> {
     const hash = await this.getContentHash(content);
     return this.contentHashCache.get(hash) || null;
   }
 
   async uploadContentWithCaching(
-    content: string,
+    content: string | Uint8Array,
     contentType: string,
   ): Promise<string> {
     // Check if we already have this content cached
@@ -347,6 +358,20 @@ export default class FileDefManagerImpl
     return fileDefs;
   }
 
+  async prefetchFileContent(file: FileDef): Promise<void> {
+    if (!file.sourceUrl) {
+      throw new Error('File needs a realm server source URL to prefetch');
+    }
+    let response = await this.network.authedFetch(file.sourceUrl, {
+      headers: {
+        Accept: 'application/vnd.card+source',
+      },
+    });
+    let bytes = new Uint8Array(await response.arrayBuffer());
+    let contentType = response.headers.get('content-type') ?? '';
+    this.prefetchedContent.set(file.sourceUrl, { bytes, contentType });
+  }
+
   async uploadFiles(files: FileDef[]) {
     let uploadedFiles = await Promise.all(
       files.map(async (file) => {
@@ -354,24 +379,29 @@ export default class FileDefManagerImpl
           throw new Error('File needs a realm server source URL to upload');
         }
 
-        let response = await this.network.authedFetch(file.sourceUrl, {
-          headers: {
-            Accept: 'application/vnd.card+source',
-          },
-        });
-
-        // We only support uploading text files (code) for now.
-        // When we start supporting other file types (pdfs, images, etc)
-        // we will need to update this to support those file types.
-        let text = await response.text();
-        let contentType = response.headers.get('content-type');
+        let bytes: Uint8Array;
+        let contentType: string;
+        let cached = this.prefetchedContent.get(file.sourceUrl);
+        if (cached) {
+          bytes = cached.bytes;
+          contentType = cached.contentType;
+          this.prefetchedContent.delete(file.sourceUrl);
+        } else {
+          let response = await this.network.authedFetch(file.sourceUrl, {
+            headers: {
+              Accept: 'application/vnd.card+source',
+            },
+          });
+          bytes = new Uint8Array(await response.arrayBuffer());
+          contentType = response.headers.get('content-type') ?? '';
+        }
 
         if (!contentType) {
           throw new Error(`File has no content type: ${file.sourceUrl}`);
         }
-        file.url = await this.uploadContentWithCaching(text, contentType);
+        file.url = await this.uploadContentWithCaching(bytes, contentType);
         file.contentType = contentType;
-        file.contentHash = await this.getContentHash(text);
+        file.contentHash = await this.getContentHash(bytes);
 
         return file;
       }),

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -82,6 +82,7 @@ export interface FileDefManager {
    * between attach and send).
    */
   prefetchFileContent(file: FileDef): Promise<void>;
+  clearPrefetchedContent(): void;
 
   /**
    * Downloads content from a file definition
@@ -373,6 +374,10 @@ export default class FileDefManagerImpl
     let bytes = new Uint8Array(await response.arrayBuffer());
     let contentType = response.headers.get('content-type') ?? '';
     this.prefetchedContent.set(file.sourceUrl, { bytes, contentType });
+  }
+
+  clearPrefetchedContent(): void {
+    this.prefetchedContent.clear();
   }
 
   async uploadFiles(files: FileDef[]) {

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -170,9 +170,12 @@ export default class FileDefManagerImpl
     if (cachedUrl) {
       return cachedUrl;
     }
-    let response = await this.client.uploadContent(content, {
-      type: contentType,
-    });
+    let response = await this.client.uploadContent(
+      content as XMLHttpRequestBodyInit,
+      {
+        type: contentType,
+      },
+    );
     let url = this.client.mxcUrlToHttp(
       response.content_uri,
       undefined,

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -68,6 +68,12 @@ export interface FileDefManager {
     commandDefinitions: SkillModule.CommandField[],
   ): Promise<FileDef[]>;
 
+  /**
+   * Uploads files (text or binary) and returns their file definitions with
+   * content-hash-based deduplication.
+   * @param files Array of file definitions to upload
+   * @returns Promise resolving to array of uploaded file definitions
+   */
   uploadFiles(files: FileDef[]): Promise<FileDef[]>;
 
   /**
@@ -150,6 +156,18 @@ export default class FileDefManagerImpl
     return this.getCardAPI();
   }
 
+  private mxcToHttpUrl(mxcUrl: string): string | null {
+    return this.client.mxcUrlToHttp(
+      mxcUrl,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+  }
+
   async getContentHash(content: string | Uint8Array): Promise<string> {
     return md5(content);
   }
@@ -172,19 +190,9 @@ export default class FileDefManagerImpl
     }
     let response = await this.client.uploadContent(
       content as XMLHttpRequestBodyInit,
-      {
-        type: contentType,
-      },
+      { type: contentType },
     );
-    let url = this.client.mxcUrlToHttp(
-      response.content_uri,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      true,
-    );
+    let url = this.mxcToHttpUrl(response.content_uri);
     if (!url) {
       throw new Error('Failed to convert mxcUrl to http');
     }
@@ -204,7 +212,7 @@ export default class FileDefManagerImpl
       return;
     }
 
-    let content = await this.downloadContentAsText(url);
+    let content = await this.downloadContentAsBytes(url);
     const fetchedContentHash = await this.getContentHash(content);
     if (fetchedContentHash !== contentHash) {
       console.warn(
@@ -222,15 +230,7 @@ export default class FileDefManagerImpl
     let storedUrl = url;
     if (canonicalKey.startsWith('mxc://')) {
       try {
-        const maybeHttp = this.client.mxcUrlToHttp(
-          canonicalKey,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          true,
-        );
+        const maybeHttp = this.mxcToHttpUrl(canonicalKey);
         if (maybeHttp) {
           storedUrl = maybeHttp;
         }
@@ -498,6 +498,18 @@ export default class FileDefManagerImpl
     } finally {
       this.inFlightTextFetches.delete(canonicalKey);
     }
+  }
+
+  async downloadContentAsBytes(url: string): Promise<Uint8Array> {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${this.client.getAccessToken()}`,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP error. Status: ${response.status}`);
+    }
+    return new Uint8Array(await response.arrayBuffer());
   }
 
   async downloadAsFileInBrowser(serializedFile: SerializedFile) {

--- a/packages/host/app/services/matrix-sdk-loader.ts
+++ b/packages/host/app/services/matrix-sdk-loader.ts
@@ -300,6 +300,8 @@ function extendedClient({
           return fileDefManager.uploadCommandDefinitions.bind(fileDefManager);
         case 'uploadFiles':
           return fileDefManager.uploadFiles.bind(fileDefManager);
+        case 'prefetchFileContent':
+          return fileDefManager.prefetchFileContent.bind(fileDefManager);
         case 'downloadAsFileInBrowser':
           return fileDefManager.downloadAsFileInBrowser.bind(fileDefManager);
         case 'downloadCardFileDef':

--- a/packages/host/app/services/matrix-sdk-loader.ts
+++ b/packages/host/app/services/matrix-sdk-loader.ts
@@ -302,6 +302,8 @@ function extendedClient({
           return fileDefManager.uploadFiles.bind(fileDefManager);
         case 'prefetchFileContent':
           return fileDefManager.prefetchFileContent.bind(fileDefManager);
+        case 'clearPrefetchedContent':
+          return fileDefManager.clearPrefetchedContent.bind(fileDefManager);
         case 'downloadAsFileInBrowser':
           return fileDefManager.downloadAsFileInBrowser.bind(fileDefManager);
         case 'downloadCardFileDef':

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1090,6 +1090,10 @@ export default class MatrixService extends Service {
     return await this.client.uploadFiles(files);
   }
 
+  async prefetchFileContent(file: FileDef) {
+    return await this.client.prefetchFileContent(file);
+  }
+
   async fetchMatrixHostedFile(matrixFileUrl: string) {
     let response = await fetch(matrixFileUrl, {
       headers: {

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -863,7 +863,7 @@ export class MockClient implements ExtendedClient {
   }
 
   async uploadContent(
-    _content: string | Uint8Array,
+    _content: XMLHttpRequestBodyInit,
     _opts?: { type?: string; name?: string },
   ): Promise<any> {
     if (this.sdkOpts.uploadContentInterceptor) {
@@ -872,12 +872,14 @@ export class MockClient implements ExtendedClient {
     let contentUri = `mxc://mock-server/${Math.random()}`;
     let buffer: ArrayBuffer;
     if (_content instanceof Uint8Array) {
-      buffer = _content.buffer.slice(
+      buffer = (_content.buffer as ArrayBuffer).slice(
         _content.byteOffset,
         _content.byteOffset + _content.byteLength,
       );
+    } else if (typeof _content === 'string') {
+      buffer = new TextEncoder().encode(_content).buffer as ArrayBuffer;
     } else {
-      buffer = new TextEncoder().encode(_content).buffer;
+      throw new Error('Unsupported content type in mock uploadContent');
     }
     this.serverState.addContent(this.mxcUrlToHttp(contentUri), buffer);
     return { content_uri: contentUri };

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -25,10 +25,6 @@ import {
 
 import ENV from '@cardstack/host/config/environment';
 
-import type {
-  FileDefManager,
-  PrivilegedFileDefManager,
-} from '@cardstack/host/lib/file-def-manager';
 import FileDefManagerImpl from '@cardstack/host/lib/file-def-manager';
 import type { ExtendedClient } from '@cardstack/host/services/matrix-sdk-loader';
 
@@ -69,7 +65,7 @@ export class MockClient implements ExtendedClient {
   private listeners: Partial<Plural<MatrixSDK.ClientEventHandlerMap>> = {};
 
   private txnCtr = 0;
-  private fileDefManager: FileDefManager;
+  private fileDefManager: FileDefManagerImpl;
   slidingSyncInstance: any;
 
   constructor(
@@ -827,35 +823,32 @@ export class MockClient implements ExtendedClient {
   }
 
   async cacheContentHashIfNeeded(event: DiscreteMatrixEvent): Promise<void> {
-    this.fileDefManager.cacheContentHashIfNeeded(event);
+    await this.fileDefManager.cacheContentHashIfNeeded(event);
   }
 
   async recacheContentHash(contentHash: string, url: string): Promise<void> {
-    const fileDefManager = this.fileDefManager as PrivilegedFileDefManager;
-    if (fileDefManager.invalidUrlCache.has(url)) {
+    if (this.fileDefManager.invalidUrlCache.has(url)) {
       // Skipping re-caching for this url as it was previously checked and is invalid
       return;
     }
-
-    // Update the cache with the new URL for the content hash
-    fileDefManager.contentHashCache.set(contentHash, url);
 
     let contentArrayBuffer = this.serverState.getContent(url);
     if (!contentArrayBuffer) {
       throw new Error('No content found for URL: ' + url);
     }
     let content = new Uint8Array(contentArrayBuffer);
-    const fetchedContentHash = await fileDefManager.getContentHash(content);
+    const fetchedContentHash =
+      await this.fileDefManager.getContentHash(content);
     if (fetchedContentHash !== contentHash) {
       console.warn(
         `Content hash mismatch for URL: ${url}, skipping re-caching step`,
       );
-      fileDefManager.invalidUrlCache.add(url);
+      this.fileDefManager.invalidUrlCache.add(url);
       return;
     }
 
     // Update the cache with the new URL for the content hash
-    fileDefManager.contentHashCache.set(contentHash, url);
+    this.fileDefManager.contentHashCache.set(contentHash, url);
   }
 
   async prefetchFileContent(file: FileDef): Promise<void> {
@@ -863,23 +856,25 @@ export class MockClient implements ExtendedClient {
   }
 
   async uploadContent(
-    _content: XMLHttpRequestBodyInit,
-    _opts?: { type?: string; name?: string },
-  ): Promise<any> {
+    file: XMLHttpRequestBodyInit,
+    _opts?: MatrixSDK.UploadOpts,
+  ): Promise<MatrixSDK.UploadResponse> {
     if (this.sdkOpts.uploadContentInterceptor) {
       await this.sdkOpts.uploadContentInterceptor();
     }
     let contentUri = `mxc://mock-server/${Math.random()}`;
     let buffer: ArrayBuffer;
-    if (_content instanceof Uint8Array) {
-      buffer = (_content.buffer as ArrayBuffer).slice(
-        _content.byteOffset,
-        _content.byteOffset + _content.byteLength,
+    if (file instanceof Uint8Array) {
+      buffer = (file.buffer as ArrayBuffer).slice(
+        file.byteOffset,
+        file.byteOffset + file.byteLength,
       );
-    } else if (typeof _content === 'string') {
-      buffer = new TextEncoder().encode(_content).buffer as ArrayBuffer;
+    } else if (typeof file === 'string') {
+      buffer = new TextEncoder().encode(file).buffer as ArrayBuffer;
     } else {
-      throw new Error('Unsupported content type in mock uploadContent');
+      throw new Error(
+        `MockClient.uploadContent: unsupported file type ${typeof file}`,
+      );
     }
     this.serverState.addContent(this.mxcUrlToHttp(contentUri), buffer);
     return { content_uri: contentUri };

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -855,6 +855,10 @@ export class MockClient implements ExtendedClient {
     return await this.fileDefManager.prefetchFileContent(file);
   }
 
+  clearPrefetchedContent(): void {
+    this.fileDefManager.clearPrefetchedContent();
+  }
+
   async uploadContent(
     file: XMLHttpRequestBodyInit,
     _opts?: MatrixSDK.UploadOpts,
@@ -869,6 +873,8 @@ export class MockClient implements ExtendedClient {
         file.byteOffset,
         file.byteOffset + file.byteLength,
       );
+    } else if (file instanceof ArrayBuffer) {
+      buffer = file;
     } else if (typeof file === 'string') {
       buffer = new TextEncoder().encode(file).buffer as ArrayBuffer;
     } else {

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -841,10 +841,10 @@ export class MockClient implements ExtendedClient {
     fileDefManager.contentHashCache.set(contentHash, url);
 
     let contentArrayBuffer = this.serverState.getContent(url);
-    let content = contentArrayBuffer?.toString();
-    if (!content) {
+    if (!contentArrayBuffer) {
       throw new Error('No content found for URL: ' + url);
     }
+    let content = new Uint8Array(contentArrayBuffer);
     const fetchedContentHash = await fileDefManager.getContentHash(content);
     if (fetchedContentHash !== contentHash) {
       console.warn(
@@ -858,18 +858,28 @@ export class MockClient implements ExtendedClient {
     fileDefManager.contentHashCache.set(contentHash, url);
   }
 
+  async prefetchFileContent(file: FileDef): Promise<void> {
+    return await this.fileDefManager.prefetchFileContent(file);
+  }
+
   async uploadContent(
-    _content: string,
+    _content: string | Uint8Array,
     _opts?: { type?: string; name?: string },
   ): Promise<any> {
     if (this.sdkOpts.uploadContentInterceptor) {
       await this.sdkOpts.uploadContentInterceptor();
     }
     let contentUri = `mxc://mock-server/${Math.random()}`;
-    this.serverState.addContent(
-      this.mxcUrlToHttp(contentUri),
-      _content as unknown as ArrayBuffer,
-    );
+    let buffer: ArrayBuffer;
+    if (_content instanceof Uint8Array) {
+      buffer = _content.buffer.slice(
+        _content.byteOffset,
+        _content.byteOffset + _content.byteLength,
+      );
+    } else {
+      buffer = new TextEncoder().encode(_content).buffer;
+    }
+    this.serverState.addContent(this.mxcUrlToHttp(contentUri), buffer);
     return { content_uri: contentUri };
   }
 
@@ -880,7 +890,8 @@ export class MockClient implements ExtendedClient {
     if (!content) {
       throw new Error(`content not found for ${serializedFile.url}`);
     }
-    return JSON.parse(content.toString()) as LooseSingleCardDocument;
+    let text = new TextDecoder().decode(content);
+    return JSON.parse(text) as LooseSingleCardDocument;
   }
 
   async downloadAsFileInBrowser(

--- a/packages/host/tests/integration/commands/update-room-skills-test.gts
+++ b/packages/host/tests/integration/commands/update-room-skills-test.gts
@@ -219,7 +219,7 @@ export class DoThing extends Command {
       );
       assert.strictEqual(
         [...uploadedContents.values()]
-          .map((s) => JSON.parse(s as any))
+          .map((s) => JSON.parse(new TextDecoder().decode(s)))
           .filter((json) => json.data?.type === 'card').length,
         1,
         'one skill card uploaded',
@@ -344,7 +344,7 @@ export class DoThing extends Command {
         'skill plus one command definitions were uploaded',
       );
       let commandDefJson = JSON.parse(
-        [...uploadedContents.values()][1] as unknown as string,
+        new TextDecoder().decode([...uploadedContents.values()][1]),
       );
       assert.deepEqual(
         commandDefJson.codeRef.name,

--- a/packages/host/tests/integration/commands/update-room-skills-test.gts
+++ b/packages/host/tests/integration/commands/update-room-skills-test.gts
@@ -42,6 +42,8 @@ class StubRealmService extends RealmService {
   }
 }
 
+const decoder = new TextDecoder();
+
 module('Integration | Command | update-room-skills', function (hooks) {
   setupRenderingTest(hooks);
   setupWindowMock(hooks);
@@ -219,7 +221,7 @@ export class DoThing extends Command {
       );
       assert.strictEqual(
         [...uploadedContents.values()]
-          .map((s) => JSON.parse(new TextDecoder().decode(s)))
+          .map((s) => JSON.parse(decoder.decode(s)))
           .filter((json) => json.data?.type === 'card').length,
         1,
         'one skill card uploaded',
@@ -344,7 +346,7 @@ export class DoThing extends Command {
         'skill plus one command definitions were uploaded',
       );
       let commandDefJson = JSON.parse(
-        new TextDecoder().decode([...uploadedContents.values()][1]),
+        decoder.decode([...uploadedContents.values()][1]),
       );
       assert.deepEqual(
         commandDefJson.codeRef.name,

--- a/packages/host/tests/integration/components/ai-assistant-panel/binary-upload-dedupe-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/binary-upload-dedupe-test.gts
@@ -171,8 +171,15 @@ module(
       await sendMessage('Upload binary file');
 
       let uploadedContents = mockMatrixUtils.getUploadedContents();
-      let uploadedBytes = [...uploadedContents.values()][0];
-      let uploadedArray = new Uint8Array(uploadedBytes);
+      let expectedHash = md5(MINIMAL_PNG);
+      let uploadedArray = [...uploadedContents.values()]
+        .map((content) => new Uint8Array(content))
+        .find((content) => md5(content) === expectedHash);
+
+      assert.ok(uploadedArray, 'Found uploaded content matching test-image.png');
+      if (!uploadedArray) {
+        return;
+      }
 
       assert.strictEqual(
         uploadedArray.length,

--- a/packages/host/tests/integration/components/ai-assistant-panel/binary-upload-dedupe-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/binary-upload-dedupe-test.gts
@@ -1,0 +1,299 @@
+import { click, waitFor } from '@ember/test-helpers';
+import { settled } from '@ember/test-helpers';
+import { fillIn } from '@ember/test-helpers';
+import GlimmerComponent from '@glimmer/component';
+
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import { md5 } from 'super-fast-md5';
+
+import { baseRealm } from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import OperatorMode from '@cardstack/host/components/operator-mode/container';
+
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+
+import {
+  testRealmURL,
+  setupCardLogs,
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupOnSave,
+  setupOperatorModeStateCleanup,
+} from '../../../helpers';
+import {
+  CardDef,
+  Component,
+  contains,
+  field,
+  setupBaseRealm,
+  StringField,
+} from '../../../helpers/base-realm';
+import { setupMockMatrix } from '../../../helpers/mock-matrix';
+import { renderComponent } from '../../../helpers/render-component';
+import { setupRenderingTest } from '../../../helpers/setup';
+import { getTestRealmRegistry } from '../../../helpers/test-realm-registry';
+
+// Minimal 1x1 transparent PNG (67 bytes)
+const MINIMAL_PNG = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49,
+  0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06,
+  0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44,
+  0x41, 0x54, 0x78, 0x9c, 0x62, 0x00, 0x02, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0d,
+  0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42,
+  0x60, 0x82,
+]);
+
+// A different 1x1 PNG (RGB, no alpha) — different bytes produce different hash
+const DIFFERENT_BINARY = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49,
+  0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02,
+  0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44,
+  0x41, 0x54, 0x78, 0x9c, 0x62, 0xf8, 0x0f, 0x00, 0x00, 0x01, 0x01, 0x00, 0x05,
+  0x18, 0xd8, 0x4d, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42,
+  0x60, 0x82,
+]);
+
+module(
+  'Integration | ai-assistant-panel | binary upload dedupe',
+  function (hooks) {
+    const realmName = 'Operator Mode Workspace';
+    let loader: Loader;
+    let operatorModeStateService: OperatorModeStateService;
+
+    setupRenderingTest(hooks);
+    setupOperatorModeStateCleanup(hooks);
+    setupBaseRealm(hooks);
+
+    hooks.beforeEach(function () {
+      loader = getService('loader-service').loader;
+    });
+
+    setupLocalIndexing(hooks);
+    setupOnSave(hooks);
+    setupCardLogs(
+      hooks,
+      async () => await loader.import(`${baseRealm.url}card-api`),
+    );
+
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+      activeRealms: [testRealmURL],
+      autostart: true,
+      now: (() => {
+        let clock = new Date(2024, 8, 19).getTime();
+        return () => (clock += 10);
+      })(),
+    });
+
+    let { getRoomEvents } = mockMatrixUtils;
+
+    let noop = () => {};
+
+    hooks.beforeEach(async function () {
+      operatorModeStateService = getService('operator-mode-state-service');
+
+      class Person extends CardDef {
+        static displayName = 'Person';
+        @field firstName = contains(StringField);
+        static isolated = class Isolated extends Component<typeof this> {
+          <template>
+            <h2 data-test-person={{@model.firstName}}>
+              <@fields.firstName />
+            </h2>
+          </template>
+        };
+      }
+
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {
+          'person.gts': { Person },
+          'Person/fadhlan.json': new Person({ firstName: 'Fadhlan' }),
+          'test-image.png': MINIMAL_PNG,
+          'test-image-copy.png': MINIMAL_PNG,
+          'other-image.png': DIFFERENT_BINARY,
+          '.realm.json': `{ "name": "${realmName}" }`,
+        },
+      });
+    });
+
+    function setCardInOperatorModeState(
+      cardURL?: string,
+      format: 'isolated' | 'edit' = 'isolated',
+    ) {
+      operatorModeStateService.restore({
+        stacks: cardURL ? [[{ id: cardURL, format }]] : [[]],
+      });
+    }
+
+    async function openAiAssistant(): Promise<string> {
+      await waitFor('[data-test-open-ai-assistant]');
+      await click('[data-test-open-ai-assistant]');
+      await waitFor('[data-test-room-settled]');
+      let roomId = document
+        .querySelector('[data-test-room]')
+        ?.getAttribute('data-test-room');
+      if (!roomId) throw new Error('Expected a room ID');
+      return roomId;
+    }
+
+    async function renderAiAssistantPanel(id?: string) {
+      setCardInOperatorModeState(id);
+      await renderComponent(
+        class TestDriver extends GlimmerComponent {
+          <template><OperatorMode @onClose={{noop}} /></template>
+        },
+      );
+      let roomId = await openAiAssistant();
+      return roomId;
+    }
+
+    async function attachFile(filename: string) {
+      await click('[data-test-attach-button]');
+      await click('[data-test-attach-file-btn]');
+      await click(`[data-test-file="${filename}"]`);
+      await click('[data-test-choose-file-modal-add-button]');
+    }
+
+    async function sendMessage(text: string) {
+      await fillIn('[data-test-boxel-input-id="ai-chat-input"]', text);
+      await click('[data-test-send-message-btn]');
+    }
+
+    test('binary file upload preserves content integrity', async function (assert) {
+      await renderAiAssistantPanel();
+
+      await attachFile('test-image.png');
+      await sendMessage('Upload binary file');
+
+      let uploadedContents = mockMatrixUtils.getUploadedContents();
+      let uploadedBytes = [...uploadedContents.values()][0];
+      let uploadedArray = new Uint8Array(uploadedBytes);
+
+      assert.strictEqual(
+        uploadedArray.length,
+        MINIMAL_PNG.length,
+        'Uploaded content has same length as original PNG',
+      );
+      assert.deepEqual(
+        uploadedArray,
+        MINIMAL_PNG,
+        'Uploaded bytes match original PNG exactly',
+      );
+    });
+
+    test('binary content hash is computed from raw bytes', async function (assert) {
+      let roomId = await renderAiAssistantPanel();
+
+      await attachFile('test-image.png');
+      await sendMessage('Upload binary file for hash check');
+
+      let messageEvents = getRoomEvents(roomId).filter(
+        (e) => e.type === 'm.room.message',
+      );
+      let messageData = messageEvents[0].content.data
+        ? JSON.parse(messageEvents[0].content.data)
+        : undefined;
+
+      let expectedHash = md5(MINIMAL_PNG);
+
+      assert.ok(messageData?.attachedFiles, 'Message has attached files');
+      assert.strictEqual(
+        messageData.attachedFiles[0].contentHash,
+        expectedHash,
+        'Content hash matches md5 of raw PNG bytes',
+      );
+    });
+
+    test('same binary content from different paths deduplicates to same mxc URL', async function (assert) {
+      let roomId = await renderAiAssistantPanel();
+
+      // Send first message with test-image.png
+      await attachFile('test-image.png');
+      await sendMessage('First binary file');
+
+      // Send second message with test-image-copy.png (same bytes, different path)
+      await attachFile('test-image-copy.png');
+      await sendMessage('Copy of binary file');
+
+      let messageEvents = getRoomEvents(roomId).filter(
+        (e) => e.type === 'm.room.message',
+      );
+      let firstData = messageEvents[0].content.data
+        ? JSON.parse(messageEvents[0].content.data)
+        : undefined;
+      let secondData = messageEvents[1].content.data
+        ? JSON.parse(messageEvents[1].content.data)
+        : undefined;
+
+      let expectedHash = md5(MINIMAL_PNG);
+
+      assert.ok(firstData?.attachedFiles, 'First message has attached files');
+      assert.ok(secondData?.attachedFiles, 'Second message has attached files');
+
+      assert.strictEqual(
+        firstData.attachedFiles[0].url,
+        secondData.attachedFiles[0].url,
+        'Same binary content deduplicates to same mxc URL',
+      );
+      assert.notEqual(
+        firstData.attachedFiles[0].sourceUrl,
+        secondData.attachedFiles[0].sourceUrl,
+        'Source URLs are different (different file paths)',
+      );
+      assert.strictEqual(
+        firstData.attachedFiles[0].contentHash,
+        expectedHash,
+        'First file content hash matches md5 of raw PNG bytes',
+      );
+      assert.strictEqual(
+        secondData.attachedFiles[0].contentHash,
+        expectedHash,
+        'Second file content hash matches md5 of raw PNG bytes',
+      );
+    });
+
+    test('file content is captured at attach time, not send time', async function (assert) {
+      let roomId = await renderAiAssistantPanel();
+
+      // Attach the file
+      await attachFile('test-image.png');
+
+      // Modify the file in the realm before sending
+      let registry = getTestRealmRegistry();
+      let testRealmRecord = registry.get(testRealmURL);
+      if (!testRealmRecord) throw new Error('Test realm not found');
+      await testRealmRecord.adapter.write('test-image.png', DIFFERENT_BINARY);
+      await settled();
+
+      // Now send — should use original content from attach time
+      await sendMessage('File was modified after attach');
+
+      let messageEvents = getRoomEvents(roomId).filter(
+        (e) => e.type === 'm.room.message',
+      );
+      let messageData = messageEvents[0].content.data
+        ? JSON.parse(messageEvents[0].content.data)
+        : undefined;
+
+      let originalHash = md5(MINIMAL_PNG);
+      let modifiedHash = md5(DIFFERENT_BINARY);
+
+      assert.ok(messageData?.attachedFiles, 'Message has attached files');
+      assert.strictEqual(
+        messageData.attachedFiles[0].contentHash,
+        originalHash,
+        'Content hash matches original PNG (captured at attach time)',
+      );
+      assert.notEqual(
+        messageData.attachedFiles[0].contentHash,
+        modifiedHash,
+        'Content hash does not match modified content',
+      );
+    });
+  },
+);

--- a/packages/host/tests/integration/components/ai-assistant-panel/binary-upload-dedupe-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/binary-upload-dedupe-test.gts
@@ -176,13 +176,13 @@ module(
         .map((content) => new Uint8Array(content))
         .find((content) => md5(content) === expectedHash);
 
-      assert.ok(uploadedArray, 'Found uploaded content matching test-image.png');
-      if (!uploadedArray) {
-        return;
-      }
+      assert.ok(
+        uploadedArray,
+        'Found uploaded content matching test-image.png',
+      );
 
       assert.strictEqual(
-        uploadedArray.length,
+        uploadedArray!.length,
         MINIMAL_PNG.length,
         'Uploaded content has same length as original PNG',
       );

--- a/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
+++ b/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
@@ -58,8 +58,9 @@ module('Unit | file-def-manager canonicalize', function () {
     const content = 'canonical-test-content';
     const contentHash = await manager.getContentHash(content);
 
-    // Stub downloadContentAsText to return the content that matches the hash
-    manager.downloadContentAsText = async (_url: string) => content;
+    // Stub downloadContentAsBytes to return the content that matches the hash
+    manager.downloadContentAsBytes = async (_url: string) =>
+      new TextEncoder().encode(content);
 
     const originalUrl =
       'http://localhost/_matrix/media/v3/download/localhost/abc123/somefile.txt?version=1';


### PR DESCRIPTION
## Summary

Makes `FileDefManager` handle binary files correctly in the AI composer attachment flow.

### Changes

- **Binary-safe fetching**: Switch from `response.text()` to `response.arrayBuffer()` when reading file content for upload. `text()` corrupts binary data (PNG, PDF, etc.) by replacing invalid UTF-8 bytes with U+FFFD.
- **Content-hash deduplication**: Widen `getContentHash()` and `uploadContentWithCaching()` to accept `string | Uint8Array`, enabling byte-accurate hashing across both text and binary files.
- **Prefetch cache at attach time**: Capture file bytes when a file is attached rather than at send time, guarding against content changes between attach and send.
- **Type widening**: `uploadFiles()` and related interfaces updated to propagate `Uint8Array` cleanly through the upload pipeline.

### Tests

4 new integration tests in `binary-upload-dedupe-test.gts`:
- Content integrity (binary data survives round-trip without corruption)
- Byte-based hashing (hash computed from raw bytes, not UTF-8-decoded string)
- Cross-path deduplication (same content uploaded from different paths reuses cached URL)
- Attach-time content capture (content snapshot taken at attach, not at send)

### Test plan

- [ ] Run tests at `http://localhost:4200/tests?hidepassed&filter=binary%20upload%20dedupe`
- [ ] Verify all 4 tests pass
- [ ] Lint passes

CS-10245

🤖 Generated with [Claude Code](https://claude.com/claude-code)