### PR TITLE
Fix theme variables not applied in fitted format gallery

### DIFF
--- a/packages/host/app/components/operator-mode/preview-panel/fitted-format-gallery.gts
+++ b/packages/host/app/components/operator-mode/preview-panel/fitted-format-gallery.gts
@@ -58,21 +58,18 @@ export default class FittedFormatGallery extends Component<Signature> {
                   -
                   {{spec.width}}x{{spec.height}}
                 </div>
-                {{#if @isFieldDef}}
-                  <CardContainer
-                    class='item'
-                    @displayBoundaries={{true}}
-                    style={{setContainerSize spec}}
-                  >
-                    <this.renderedCard class='field' />
-                  </CardContainer>
-                {{else}}
-                  <this.renderedCard
-                    class='item'
-                    @displayContainer={{true}}
-                    style={{setContainerSize spec}}
-                  />
-                {{/if}}
+                <div class='item-sizer' style={{setContainerSize spec}}>
+                  {{#if @isFieldDef}}
+                    <CardContainer class='item' @displayBoundaries={{true}}>
+                      <this.renderedCard class='field' />
+                    </CardContainer>
+                  {{else}}
+                    <this.renderedCard
+                      class='item'
+                      @displayContainer={{true}}
+                    />
+                  {{/if}}
+                </div>
               </li>
             {{/each}}
           </ul>
@@ -110,7 +107,7 @@ export default class FittedFormatGallery extends Component<Signature> {
         letter-spacing: var(--boxel-lsp-sm);
         opacity: 70%;
       }
-      .spec-title + .item {
+      .spec-title + .item-sizer {
         margin-top: var(--boxel-sp-xs);
       }
       .item {


### PR DESCRIPTION
 linear: https://linear.app/cardstack/issue/CS-10331/theme-variable-is-not-working-for-fitted-template

## Problem
Theme CSS variables (e.g. --card, --muted) were not being injected into fitted card previews. The style={{setContainerSize spec}} for width/height was passed directly onto <this.renderedCard>, which flowed through Glimmer's ...attributes chain to the <CardContainer> element, overwriting style={{getThemeStyles card}} that contains the theme variables. Glimmer does not merge duplicate style attributes on the same element — the last one wins.                                  

The fix wraps the rendered card in a div that holds the sizing style, so the sizing and theme styles live on separate DOM elements and no longer conflict.

## Demo
Before fix:



https://github.com/user-attachments/assets/fa906ec9-effe-4b8e-9c1f-bb027dae5690





After fix:



https://github.com/user-attachments/assets/ffc5c9a8-5ec0-4215-b0f9-c63c4aca8028





