### PR TITLE
Add support for cancelling running indexing job from a command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -516,6 +516,7 @@ jobs:
             "prerender-proxy-test.ts",
             "remote-prerenderer-test.ts",
             "queue-test.ts",
+            "realm-endpoints/cancel-indexing-job-test.ts",
             "realm-endpoints/dependencies-test.ts",
             "realm-endpoints/directory-test.ts",
             "realm-endpoints/info-test.ts",

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -109,6 +109,10 @@ export class RealmUrlCard extends CardDef {
   @field realmUrl = contains(StringField);
 }
 
+export class CancelIndexingJobInput extends CardDef {
+  @field realmUrl = contains(StringField);
+}
+
 export class ReadTextFileInput extends CardDef {
   @field realm = contains(StringField);
   @field path = contains(StringField);

--- a/packages/host/app/commands/cancel-indexing-job.ts
+++ b/packages/host/app/commands/cancel-indexing-job.ts
@@ -4,13 +4,13 @@ import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import HostBaseCommand from '../lib/host-base-command';
 
-import type RealmServerService from '../services/realm-server';
+import type RealmService from '../services/realm';
 
 export default class CancelIndexingJobCommand extends HostBaseCommand<
   typeof BaseCommandModule.CancelIndexingJobInput,
   undefined
 > {
-  @service declare private realmServer: RealmServerService;
+  @service declare private realm: RealmService;
 
   static actionVerb = 'Cancel';
   description = 'Cancel any currently running indexing job for a realm';
@@ -24,6 +24,6 @@ export default class CancelIndexingJobCommand extends HostBaseCommand<
   protected async run(
     input: BaseCommandModule.CancelIndexingJobInput,
   ): Promise<undefined> {
-    await this.realmServer.cancelIndexingJob(input.realmUrl);
+    await this.realm.cancelIndexingJob(input.realmUrl);
   }
 }

--- a/packages/host/app/commands/cancel-indexing-job.ts
+++ b/packages/host/app/commands/cancel-indexing-job.ts
@@ -1,0 +1,29 @@
+import { service } from '@ember/service';
+
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
+
+import HostBaseCommand from '../lib/host-base-command';
+
+import type RealmServerService from '../services/realm-server';
+
+export default class CancelIndexingJobCommand extends HostBaseCommand<
+  typeof BaseCommandModule.CancelIndexingJobInput,
+  undefined
+> {
+  @service declare private realmServer: RealmServerService;
+
+  static actionVerb = 'Cancel';
+  description = 'Cancel any currently running indexing job for a realm';
+
+  async getInputType() {
+    let commandModule = await this.loadCommandModule();
+    const { CancelIndexingJobInput } = commandModule;
+    return CancelIndexingJobInput;
+  }
+
+  protected async run(
+    input: BaseCommandModule.CancelIndexingJobInput,
+  ): Promise<undefined> {
+    await this.realmServer.cancelIndexingJob(input.realmUrl);
+  }
+}

--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -7,6 +7,7 @@ import * as ApplySearchReplaceBlockCommandModule from './apply-search-replace-bl
 import * as AskAiCommandModule from './ask-ai';
 import * as CreateListingPRRequestCommandModule from './bot-requests/create-listing-pr-request';
 import * as SendBotTriggerEventCommandModule from './bot-requests/send-bot-trigger-event';
+import * as CancelIndexingJobCommandModule from './cancel-indexing-job';
 import * as CheckCorrectnessCommandModule from './check-correctness';
 import * as CopyAndEditCommandModule from './copy-and-edit';
 import * as CopyCardToRealmModule from './copy-card';
@@ -117,6 +118,10 @@ export function shimHostCommands(virtualNetwork: VirtualNetwork) {
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/check-correctness',
     CheckCorrectnessCommandModule,
+  );
+  virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/cancel-indexing-job',
+    CancelIndexingJobCommandModule,
   );
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/generate-theme-example',
@@ -401,6 +406,7 @@ export const HostCommandClasses: (typeof HostBaseCommand<any, any>)[] = [
   SwitchSubmodeCommandModule.default,
   TransformCardsCommandModule.default,
   UnregisterBotCommandModule.default,
+  CancelIndexingJobCommandModule.default,
   CheckCorrectnessCommandModule.default,
   UpdateCodePathWithSelectionCommandModule.default,
   UpdatePlaygroundSelectionCommandModule.default,

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -685,30 +685,6 @@ export default class RealmServerService extends Service {
     return response;
   }
 
-  async cancelIndexingJob(realmURL: string): Promise<void> {
-    await this.login();
-
-    let normalizedRealmURL = ensureTrailingSlash(realmURL);
-    let response = await this.authedFetch(
-      `${normalizedRealmURL}_cancel-indexing-job`,
-      {
-        method: 'POST',
-        headers: {
-          Accept: SupportedMimeType.JSON,
-        },
-      },
-    );
-
-    if (response.status === 204) {
-      return;
-    }
-
-    let errorText = await response.text();
-    throw new Error(
-      `Cancel indexing job failed: ${response.status} - ${errorText}`,
-    );
-  }
-
   async registerBot(username: string) {
     await this.login();
 

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -685,6 +685,30 @@ export default class RealmServerService extends Service {
     return response;
   }
 
+  async cancelIndexingJob(realmURL: string): Promise<void> {
+    await this.login();
+
+    let normalizedRealmURL = ensureTrailingSlash(realmURL);
+    let response = await this.authedFetch(
+      `${normalizedRealmURL}_cancel-indexing-job`,
+      {
+        method: 'POST',
+        headers: {
+          Accept: SupportedMimeType.JSON,
+        },
+      },
+    );
+
+    if (response.status === 204) {
+      return;
+    }
+
+    let errorText = await response.text();
+    throw new Error(
+      `Cancel indexing job failed: ${response.status} - ${errorText}`,
+    );
+  }
+
   async registerBot(username: string) {
     await this.login();
 
@@ -931,7 +955,7 @@ export default class RealmServerService extends Service {
         type: 'claimed-domain',
         attributes: {
           source_realm_url: sourceRealmURL,
-          hostname: hostname,
+          hostname,
         },
       },
     };

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -981,6 +981,36 @@ export default class RealmService extends Service {
     return await resource.unpublish(publishedRealmURL);
   }
 
+  async cancelIndexingJob(realmURL: string): Promise<void> {
+    let normalizedRealmURL = ensureTrailingSlash(realmURL);
+    let resource = this.getOrCreateRealmResource(normalizedRealmURL);
+    await resource.login();
+
+    let headers = new Headers({
+      Accept: SupportedMimeType.JSON,
+    });
+    if (resource.token) {
+      headers.set('Authorization', `Bearer ${resource.token}`);
+    }
+
+    let response = await this.network.fetch(
+      `${normalizedRealmURL}_cancel-indexing-job`,
+      {
+        method: 'POST',
+        headers,
+      },
+    );
+
+    if (response.status === 204) {
+      return;
+    }
+
+    let errorText = await response.text();
+    throw new Error(
+      `Cancel indexing job failed: ${response.status} - ${errorText}`,
+    );
+  }
+
   isUnpublishingAnyRealms = (realmURL: string): boolean => {
     let resource = this.getOrCreateRealmResource(realmURL);
     return resource.isUnpublishingAnyRealms();

--- a/packages/host/tests/integration/commands/cancel-indexing-job-test.gts
+++ b/packages/host/tests/integration/commands/cancel-indexing-job-test.gts
@@ -1,0 +1,105 @@
+import { getOwner } from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import CancelIndexingJobCommand from '@cardstack/host/commands/cancel-indexing-job';
+import RealmService from '@cardstack/host/services/realm';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupRealmServerEndpoints,
+  testRealmInfo,
+  testRealmURL,
+  setupRealmCacheTeardown,
+  withCachedRealmSetup,
+} from '../../helpers';
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+class StubRealmService extends RealmService {
+  get defaultReadableRealm() {
+    return {
+      path: testRealmURL,
+      info: testRealmInfo,
+    };
+  }
+}
+
+module('Integration | commands | cancel-indexing-job', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  let receivedAuthorizationHeader: string | null = null;
+  let receivedMethod: string | null = null;
+  let receivedPathname: string | null = null;
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  setupRealmServerEndpoints(hooks, [
+    {
+      route: 'test/_cancel-indexing-job',
+      getResponse: async (req: Request) => {
+        receivedAuthorizationHeader = req.headers.get('Authorization');
+        receivedMethod = req.method;
+        receivedPathname = new URL(req.url).pathname;
+        return new Response(null, { status: 204 });
+      },
+    },
+  ]);
+
+  setupRealmCacheTeardown(hooks);
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    getOwner(this)!.register('service:realm', StubRealmService);
+    receivedAuthorizationHeader = null;
+    receivedMethod = null;
+    receivedPathname = null;
+
+    await withCachedRealmSetup(async () =>
+      setupIntegrationTestRealm({
+        mockMatrixUtils,
+        realmURL: testRealmURL,
+        contents: {},
+      }),
+    );
+  });
+
+  test('calls realm endpoint with expected auth header', async function (assert) {
+    let commandService = getService('command-service');
+    let realmServer = getService('realm-server');
+    let command = new CancelIndexingJobCommand(commandService.commandContext);
+    let realmURL = new URL('test/', realmServer.url).href;
+
+    let result = await command.execute({
+      realmUrl: realmURL,
+    });
+
+    assert.strictEqual(result, undefined, 'command has no result card');
+    assert.strictEqual(receivedMethod, 'POST', 'uses POST');
+    assert.strictEqual(
+      receivedPathname,
+      '/test/_cancel-indexing-job',
+      'calls correct endpoint',
+    );
+    assert.ok(receivedAuthorizationHeader, 'authorization header is present');
+    assert.true(
+      receivedAuthorizationHeader?.startsWith('Bearer '),
+      'authorization header uses Bearer scheme',
+    );
+    assert.ok(realmServer.token, 'realm server token exists');
+    assert.strictEqual(
+      receivedAuthorizationHeader,
+      `Bearer ${realmServer.token}`,
+      'authorization header value is correct',
+    );
+  });
+});

--- a/packages/host/tests/integration/commands/cancel-indexing-job-test.gts
+++ b/packages/host/tests/integration/commands/cancel-indexing-job-test.gts
@@ -95,11 +95,26 @@ module('Integration | commands | cancel-indexing-job', function (hooks) {
       receivedAuthorizationHeader?.startsWith('Bearer '),
       'authorization header uses Bearer scheme',
     );
-    assert.ok(realmServer.token, 'realm server token exists');
+    let authToken = receivedAuthorizationHeader!.replace('Bearer ', '');
+    let [_header, payload] = authToken.split('.');
+    let tokenClaims = JSON.parse(atob(payload)) as {
+      realm?: string;
+      permissions?: string[];
+    };
     assert.strictEqual(
+      tokenClaims.realm,
+      realmURL,
+      'authorization token is realm-scoped',
+    );
+    assert.deepEqual(
+      tokenClaims.permissions,
+      ['read', 'write'],
+      'authorization token contains realm permissions',
+    );
+    assert.notStrictEqual(
       receivedAuthorizationHeader,
       `Bearer ${realmServer.token}`,
-      'authorization header value is correct',
+      'authorization header does not use realm-server session token',
     );
   });
 });

--- a/packages/realm-server/handlers/handle-remove-job.ts
+++ b/packages/realm-server/handlers/handle-remove-job.ts
@@ -1,45 +1,14 @@
 import type Koa from 'koa';
 import {
-  type Expression,
-  query as _query,
-  param,
-  separatedByCommas,
+  findJobIdForReservationId,
+  forceCancelJobById,
 } from '@cardstack/runtime-common';
 import { sendResponseForBadRequest, setContextResponse } from '../middleware';
 import type { CreateRoutesArgs } from '../routes';
 
-export default function handleReindex({
+export default function handleRemoveJob({
   dbAdapter,
 }: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
-  async function query(expression: Expression) {
-    return await _query(dbAdapter, expression);
-  }
-
-  async function forceJobCompletion(jobId: string) {
-    await query([
-      `UPDATE jobs SET `,
-      ...separatedByCommas([
-        [
-          `result =`,
-          param({
-            status: 418,
-            message: `User initiated job cancellation`,
-          }),
-        ],
-        [`status = 'rejected'`],
-        [`finished_at = NOW()`],
-      ]),
-      'WHERE id =',
-      param(jobId),
-    ] as Expression);
-    await query([
-      `UPDATE job_reservations SET completed_at = NOW() WHERE job_id =`,
-      param(jobId),
-      `AND completed_at IS NULL`,
-    ]);
-    await query([`NOTIFY jobs_finished`]);
-  }
-
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
     let jobId = ctxt.URL.searchParams.get('job_id');
     let jobReservationId = ctxt.URL.searchParams.get('reservation_id');
@@ -52,10 +21,7 @@ export default function handleReindex({
     }
 
     if (jobReservationId) {
-      let [{ job_id: jobId }] = (await query([
-        `SELECT job_id FROM job_reservations WHERE id =`,
-        param(jobReservationId),
-      ])) as [{ job_id: string }];
+      jobId = await findJobIdForReservationId(dbAdapter, jobReservationId);
       if (!jobId) {
         await sendResponseForBadRequest(
           ctxt,
@@ -63,9 +29,9 @@ export default function handleReindex({
         );
         return;
       }
-      await forceJobCompletion(jobId);
+      await forceCancelJobById(dbAdapter, jobId);
     } else if (jobId) {
-      await forceJobCompletion(jobId);
+      await forceCancelJobById(dbAdapter, jobId);
     }
     return setContextResponse(ctxt, new Response(null, { status: 204 }));
   };

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -1182,7 +1182,7 @@ export async function insertPlan(
   creditsIncluded: number,
   stripePlanId: string,
 ): Promise<Plan> {
-  let { valueExpressions, nameExpressions: nameExpressions } = asExpressions({
+  let { valueExpressions, nameExpressions } = asExpressions({
     name,
     monthly_price: monthlyPrice,
     credits_included: creditsIncluded,
@@ -1267,7 +1267,7 @@ export async function insertJob(
     priority?: number;
   },
 ): Promise<Record<string, any>> {
-  let { valueExpressions, nameExpressions: nameExpressions } = asExpressions({
+  let { valueExpressions, nameExpressions } = asExpressions({
     job_type: params.job_type,
     args: params.args ?? {},
     concurrency_group: params.concurrency_group ?? null,
@@ -1584,6 +1584,8 @@ export function setupPermissionedRealm(
     fileSystem?: Record<string, string | LooseSingleCardDocument>;
     onRealmSetup?: (args: {
       dbAdapter: PgAdapter;
+      publisher: QueuePublisher;
+      runner: QueueRunner;
       testRealm: Realm;
       testRealmPath: string;
       testRealmHttpServer: Server;
@@ -1630,6 +1632,8 @@ export function setupPermissionedRealm(
 
       onRealmSetup?.({
         dbAdapter,
+        publisher,
+        runner,
         testRealm: testRealmServer.testRealm,
         testRealmPath: testRealmServer.testRealmDir,
         testRealmHttpServer: testRealmServer.testRealmHttpServer,

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -139,6 +139,7 @@ import './realm-endpoints/info-test';
 import './realm-endpoints/lint-test';
 import './realm-endpoints/mtimes-test';
 import './realm-endpoints/permissions-test';
+import './realm-endpoints/cancel-indexing-job-test';
 import './realm-endpoints/publishability-test';
 import './realm-endpoints/search-test';
 import './realm-endpoints/user-test';

--- a/packages/realm-server/tests/realm-endpoints/cancel-indexing-job-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/cancel-indexing-job-test.ts
@@ -189,6 +189,46 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
         );
       });
 
+      test('does not treat expired reservations as running jobs', async function (assert) {
+        let concurrencyGroup = `indexing:${testRealm.url}`;
+        let [{ id: jobId }] = (await dbAdapter.execute(`INSERT INTO jobs
+        (args, job_type, concurrency_group, timeout, priority)
+        VALUES
+        (
+          '{"realmURL": "${testRealm.url}", "realmUsername":"node-test_realm"}',
+          'from-scratch-index',
+          '${concurrencyGroup}',
+          180,
+          0
+        ) RETURNING id`)) as { id: string }[];
+        await dbAdapter.execute(`INSERT INTO job_reservations
+        (job_id, locked_until ) VALUES (${jobId}, NOW() - INTERVAL '1 minutes')`);
+
+        let response = await request
+          .post('/_cancel-indexing-job')
+          .set('Accept', 'application/json')
+          .set(
+            'Authorization',
+            `Bearer ${createJWT(testRealm, 'writer', ['read', 'write'])}`,
+          );
+
+        assert.strictEqual(response.status, 204, 'HTTP 204 response');
+        let [job] = await dbAdapter.execute(
+          `SELECT status, result, finished_at FROM jobs WHERE id = ${jobId}`,
+        );
+        assert.strictEqual(
+          job.status,
+          'unfulfilled',
+          'job with expired reservation is not canceled',
+        );
+        assert.strictEqual(job.result, null, 'job result remains unchanged');
+        assert.strictEqual(
+          job.finished_at,
+          null,
+          'job finish time remains unchanged',
+        );
+      });
+
       test('worker can continue to process new jobs after canceling a running indexing job', async function (assert) {
         let jobStarted = new Deferred<void>();
         let releaseJob = new Deferred<void>();

--- a/packages/realm-server/tests/realm-endpoints/cancel-indexing-job-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/cancel-indexing-job-test.ts
@@ -1,0 +1,308 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import type { SuperTest, Test } from 'supertest';
+import type {
+  QueuePublisher,
+  QueueRunner,
+  Realm,
+} from '@cardstack/runtime-common';
+import { Deferred } from '@cardstack/runtime-common';
+import { PgAdapter, PgQueueRunner } from '@cardstack/postgres';
+import { createJWT, setupPermissionedRealmCached, waitUntil } from '../helpers';
+import type { PgAdapter as TestPgAdapter } from '@cardstack/postgres';
+
+module(`realm-endpoints/${basename(__filename)}`, function () {
+  module(
+    'Realm-specific Endpoints | POST _cancel-indexing-job',
+    function (hooks) {
+      let testRealm: Realm;
+      let request: SuperTest<Test>;
+      let dbAdapter: TestPgAdapter;
+      let publisher: QueuePublisher;
+      let runner: QueueRunner;
+
+      function onRealmSetup(args: {
+        testRealm: Realm;
+        request: SuperTest<Test>;
+        dbAdapter: TestPgAdapter;
+        publisher: QueuePublisher;
+        runner: QueueRunner;
+      }) {
+        testRealm = args.testRealm;
+        request = args.request;
+        dbAdapter = args.dbAdapter;
+        publisher = args.publisher;
+        runner = args.runner;
+      }
+
+      setupPermissionedRealmCached(hooks, {
+        permissions: {
+          writer: ['read', 'write'],
+          reader: ['read'],
+          '@node-test_realm:localhost': ['read', 'realm-owner'],
+        },
+        onRealmSetup,
+      });
+
+      test('returns 401 without JWT for private realm', async function (assert) {
+        let response = await request
+          .post('/_cancel-indexing-job')
+          .set('Accept', 'application/json');
+
+        assert.strictEqual(response.status, 401, 'HTTP 401 status');
+      });
+
+      test('returns 403 for user without write access', async function (assert) {
+        let response = await request
+          .post('/_cancel-indexing-job')
+          .set('Accept', 'application/json')
+          .set(
+            'Authorization',
+            `Bearer ${createJWT(testRealm, 'reader', ['read'])}`,
+          );
+
+        assert.strictEqual(response.status, 403, 'HTTP 403 status');
+      });
+
+      test('cancels running indexing jobs but does not cancel pending indexing jobs', async function (assert) {
+        let concurrencyGroup = `indexing:${testRealm.url}`;
+        let [{ id: runningJobId }] = (await dbAdapter.execute(`INSERT INTO jobs
+        (args, job_type, concurrency_group, timeout, priority)
+        VALUES
+        (
+          '{"realmURL": "${testRealm.url}", "realmUsername":"node-test_realm"}',
+          'from-scratch-index',
+          '${concurrencyGroup}',
+          180,
+          0
+        ) RETURNING id`)) as { id: string }[];
+        await dbAdapter.execute(`INSERT INTO job_reservations
+        (job_id, locked_until ) VALUES (${runningJobId}, NOW() + INTERVAL '3 minutes')`);
+        let [{ id: pendingJobId }] = (await dbAdapter.execute(`INSERT INTO jobs
+        (args, job_type, concurrency_group, timeout, priority)
+        VALUES
+        (
+          '{"realmURL": "${testRealm.url}", "realmUsername":"node-test_realm"}',
+          'incremental-index',
+          '${concurrencyGroup}',
+          180,
+          0
+        ) RETURNING id`)) as { id: string }[];
+
+        let response = await request
+          .post('/_cancel-indexing-job')
+          .set('Accept', 'application/json')
+          .set(
+            'Authorization',
+            `Bearer ${createJWT(testRealm, 'writer', ['read', 'write'])}`,
+          );
+
+        assert.strictEqual(response.status, 204, 'HTTP 204 response');
+
+        let [runningJob] = await dbAdapter.execute(
+          `SELECT status, result, finished_at FROM jobs WHERE id = ${runningJobId}`,
+        );
+        assert.strictEqual(
+          runningJob.status,
+          'rejected',
+          'running job was canceled',
+        );
+        assert.deepEqual(
+          runningJob.result,
+          {
+            status: 418,
+            message: 'User initiated job cancellation',
+          },
+          'running job result is cancellation payload',
+        );
+        assert.ok(runningJob.finished_at, 'running job has finish time');
+
+        let runningReservations = await dbAdapter.execute(
+          `SELECT id FROM job_reservations WHERE job_id = ${runningJobId} AND completed_at IS NULL`,
+        );
+        assert.strictEqual(
+          runningReservations.length,
+          0,
+          'running job reservations were completed',
+        );
+
+        let [pendingJob] = await dbAdapter.execute(
+          `SELECT status, result, finished_at FROM jobs WHERE id = ${pendingJobId}`,
+        );
+        assert.strictEqual(
+          pendingJob.status,
+          'unfulfilled',
+          'pending job was not canceled',
+        );
+        assert.strictEqual(
+          pendingJob.result,
+          null,
+          'pending job result unchanged',
+        );
+        assert.strictEqual(
+          pendingJob.finished_at,
+          null,
+          'pending job finish time unchanged',
+        );
+      });
+
+      test('returns 204 and does nothing when there is no running indexing job', async function (assert) {
+        let concurrencyGroup = `indexing:${testRealm.url}`;
+        let [{ id: pendingJobId }] = (await dbAdapter.execute(`INSERT INTO jobs
+        (args, job_type, concurrency_group, timeout, priority)
+        VALUES
+        (
+          '{"realmURL": "${testRealm.url}", "realmUsername":"node-test_realm"}',
+          'from-scratch-index',
+          '${concurrencyGroup}',
+          180,
+          0
+        ) RETURNING id`)) as { id: string }[];
+
+        let response = await request
+          .post('/_cancel-indexing-job')
+          .set('Accept', 'application/json')
+          .set(
+            'Authorization',
+            `Bearer ${createJWT(testRealm, 'writer', ['read', 'write'])}`,
+          );
+
+        assert.strictEqual(response.status, 204, 'HTTP 204 response');
+
+        let [pendingJob] = await dbAdapter.execute(
+          `SELECT status, result, finished_at FROM jobs WHERE id = ${pendingJobId}`,
+        );
+        assert.strictEqual(
+          pendingJob.status,
+          'unfulfilled',
+          'pending job remains unfulfilled',
+        );
+        assert.strictEqual(
+          pendingJob.result,
+          null,
+          'pending job result unchanged',
+        );
+        assert.strictEqual(
+          pendingJob.finished_at,
+          null,
+          'pending job finish time unchanged',
+        );
+      });
+
+      test('worker can continue to process new jobs after canceling a running indexing job', async function (assert) {
+        let jobStarted = new Deferred<void>();
+        let releaseJob = new Deferred<void>();
+        let jobFinished = new Deferred<void>();
+        let events: string[] = [];
+
+        runner.register(
+          'blocking-job',
+          async ({ jobNum }: { jobNum: number }) => {
+            events.push(`job${jobNum} start`);
+            if (jobNum === 1) {
+              jobStarted.fulfill();
+              await releaseJob.promise;
+            }
+            events.push(`job${jobNum} finish`);
+            if (jobNum === 1) {
+              jobFinished.fulfill();
+            }
+            return jobNum;
+          },
+        );
+
+        let concurrencyGroup = `indexing:${testRealm.url}`;
+        let job1 = await publisher.publish({
+          jobType: 'blocking-job',
+          concurrencyGroup,
+          timeout: 30,
+          args: { jobNum: 1 },
+        });
+        let job1Outcome = job1.done.then(
+          (result) => ({ outcome: 'resolved' as const, result }),
+          (error) => ({ outcome: 'rejected' as const, error }),
+        );
+
+        await jobStarted.promise;
+        await waitUntil(async () => {
+          let rows = await dbAdapter.execute(
+            `SELECT id FROM job_reservations WHERE job_id = ${job1.id} AND completed_at IS NULL`,
+          );
+          return rows.length > 0;
+        });
+
+        let response = await request
+          .post('/_cancel-indexing-job')
+          .set('Accept', 'application/json')
+          .set(
+            'Authorization',
+            `Bearer ${createJWT(testRealm, 'writer', ['read', 'write'])}`,
+          );
+        assert.strictEqual(response.status, 204, 'HTTP 204 response');
+
+        let [job1Record] = await dbAdapter.execute(
+          `SELECT status FROM jobs WHERE id = ${job1.id}`,
+        );
+        assert.strictEqual(
+          job1Record.status,
+          'rejected',
+          'running job canceled',
+        );
+
+        let adapter2 = new PgAdapter();
+        let runner2 = new PgQueueRunner({
+          adapter: adapter2,
+          workerId: 'cancel-indexing-job-test-worker-2',
+        });
+        runner2.register(
+          'blocking-job',
+          async ({ jobNum }: { jobNum: number }) => {
+            events.push(`job${jobNum} start`);
+            events.push(`job${jobNum} finish`);
+            return jobNum;
+          },
+        );
+        await runner2.start();
+
+        try {
+          let job2 = await publisher.publish({
+            jobType: 'blocking-job',
+            concurrencyGroup,
+            timeout: 30,
+            args: { jobNum: 2 },
+          });
+          let job2Result = await job2.done;
+          assert.strictEqual(job2Result, 2, 'next job completed');
+        } finally {
+          releaseJob.fulfill();
+          await jobFinished.promise;
+          await runner2.destroy();
+          await adapter2.close();
+        }
+
+        let outcome = await job1Outcome;
+        assert.strictEqual(
+          outcome.outcome,
+          'rejected',
+          'job1 outcome is rejected',
+        );
+        if (outcome.outcome === 'rejected') {
+          assert.deepEqual(
+            outcome.error,
+            {
+              status: 418,
+              message: 'User initiated job cancellation',
+            },
+            'job1 cancellation payload is correct',
+          );
+        }
+        assert.deepEqual(events, [
+          'job1 start',
+          'job2 start',
+          'job2 finish',
+          'job1 finish',
+        ]);
+      });
+    },
+  );
+});

--- a/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
@@ -48,6 +48,89 @@ module(`server-endpoints/${basename(__filename)}`, function () {
         assert.ok(job.finished_at, 'job was marked with finish time');
       });
 
+      test('grafana endpoint can target both pending and running jobs by job_id', async function (assert) {
+        let [{ id: pendingJobId }] = (await context.dbAdapter
+          .execute(`INSERT INTO jobs
+        (args, job_type, concurrency_group, timeout, priority)
+        VALUES
+        (
+          '{"realmURL": "${testRealm2URL.href}", "realmUsername":"node-test_realm"}',
+          'from-scratch-index',
+          'indexing:${testRealm2URL.href}',
+          180,
+          0
+        ) RETURNING id`)) as { id: string }[];
+        let [{ id: runningJobId }] = (await context.dbAdapter
+          .execute(`INSERT INTO jobs
+        (args, job_type, concurrency_group, timeout, priority)
+        VALUES
+        (
+          '{"realmURL": "${testRealm2URL.href}", "realmUsername":"node-test_realm"}',
+          'incremental-index',
+          'indexing:${testRealm2URL.href}',
+          180,
+          0
+        ) RETURNING id`)) as { id: string }[];
+        await context.dbAdapter.execute(`INSERT INTO job_reservations
+        (job_id, locked_until ) VALUES (${runningJobId}, NOW() + INTERVAL '3 minutes')`);
+
+        let pendingResponse = await context.request2
+          .get(
+            `/_grafana-complete-job?authHeader=${grafanaSecret}&job_id=${pendingJobId}`,
+          )
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(
+          pendingResponse.status,
+          204,
+          'pending job cancel returns 204',
+        );
+
+        let runningResponse = await context.request2
+          .get(
+            `/_grafana-complete-job?authHeader=${grafanaSecret}&job_id=${runningJobId}`,
+          )
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(
+          runningResponse.status,
+          204,
+          'running job cancel returns 204',
+        );
+
+        let [pendingJob] = await context.dbAdapter.execute(
+          `SELECT status, result FROM jobs WHERE id = ${pendingJobId}`,
+        );
+        assert.strictEqual(
+          pendingJob.status,
+          'rejected',
+          'pending job canceled',
+        );
+        assert.deepEqual(
+          pendingJob.result,
+          {
+            status: 418,
+            message: 'User initiated job cancellation',
+          },
+          'pending job has cancellation payload',
+        );
+
+        let [runningJob] = await context.dbAdapter.execute(
+          `SELECT status, result FROM jobs WHERE id = ${runningJobId}`,
+        );
+        assert.strictEqual(
+          runningJob.status,
+          'rejected',
+          'running job canceled',
+        );
+        assert.deepEqual(
+          runningJob.result,
+          {
+            status: 418,
+            message: 'User initiated job cancellation',
+          },
+          'running job has cancellation payload',
+        );
+      });
+
       test('can force job completion by reservation_id via grafana endpoint', async function (assert) {
         let [{ id: jobId }] = (await context.dbAdapter.execute(`INSERT INTO jobs
         (args, job_type, concurrency_group, timeout, priority)

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -227,6 +227,7 @@ export * from './document';
 export * from './matrix-constants';
 export * from './matrix-client';
 export * from './queue';
+export * from './job-utils';
 export * from './expression';
 export * from './infer-content-type';
 export * from './index-query-engine';

--- a/packages/runtime-common/job-utils.ts
+++ b/packages/runtime-common/job-utils.ts
@@ -1,0 +1,93 @@
+import type { DBAdapter } from './db';
+import {
+  dbExpression,
+  param,
+  query,
+  separatedByCommas,
+  type Expression,
+  type PgPrimitive,
+} from './expression';
+
+export const userInitiatedJobCancellationResult = Object.freeze({
+  status: 418,
+  message: 'User initiated job cancellation',
+});
+
+export async function forceCancelJobById(
+  dbAdapter: DBAdapter,
+  jobId: string,
+  result: PgPrimitive = userInitiatedJobCancellationResult,
+): Promise<void> {
+  await query(dbAdapter, [
+    `UPDATE jobs SET`,
+    ...separatedByCommas([
+      [`result =`, param(result)],
+      [`status = 'rejected'`],
+      [
+        dbExpression({
+          pg: `finished_at = NOW()`,
+          sqlite: `finished_at = CURRENT_TIMESTAMP`,
+        }),
+      ],
+    ]),
+    `WHERE id =`,
+    param(jobId),
+  ] as Expression);
+
+  await query(dbAdapter, [
+    `UPDATE job_reservations SET`,
+    dbExpression({
+      pg: `completed_at = NOW()`,
+      sqlite: `completed_at = CURRENT_TIMESTAMP`,
+    }),
+    `WHERE job_id =`,
+    param(jobId),
+    `AND completed_at IS NULL`,
+  ] as Expression);
+
+  if (dbAdapter.kind === 'pg') {
+    await query(dbAdapter, [`NOTIFY jobs_finished`] as Expression);
+  }
+}
+
+export async function findJobIdForReservationId(
+  dbAdapter: DBAdapter,
+  reservationId: string,
+): Promise<string | null> {
+  let [row] = (await query(dbAdapter, [
+    `SELECT job_id FROM job_reservations WHERE id =`,
+    param(reservationId),
+  ] as Expression)) as { job_id: string }[];
+
+  return row?.job_id ?? null;
+}
+
+export async function findRunningJobIdsForConcurrencyGroup(
+  dbAdapter: DBAdapter,
+  concurrencyGroup: string,
+): Promise<string[]> {
+  let rows = (await query(dbAdapter, [
+    `SELECT DISTINCT j.id FROM jobs j`,
+    `INNER JOIN job_reservations jr ON jr.job_id = j.id`,
+    `WHERE j.concurrency_group =`,
+    param(concurrencyGroup),
+    `AND j.status = 'unfulfilled'`,
+    `AND jr.completed_at IS NULL`,
+    `ORDER BY j.id ASC`,
+  ] as Expression)) as { id: string }[];
+  return rows.map((row) => row.id);
+}
+
+export async function cancelRunningJobsInConcurrencyGroup(
+  dbAdapter: DBAdapter,
+  concurrencyGroup: string,
+): Promise<string[]> {
+  let runningJobIds = await findRunningJobIdsForConcurrencyGroup(
+    dbAdapter,
+    concurrencyGroup,
+  );
+  for (let jobId of runningJobIds) {
+    await forceCancelJobById(dbAdapter, jobId);
+  }
+  return runningJobIds;
+}

--- a/packages/runtime-common/job-utils.ts
+++ b/packages/runtime-common/job-utils.ts
@@ -73,6 +73,11 @@ export async function findRunningJobIdsForConcurrencyGroup(
     param(concurrencyGroup),
     `AND j.status = 'unfulfilled'`,
     `AND jr.completed_at IS NULL`,
+    `AND`,
+    dbExpression({
+      pg: `jr.locked_until > NOW()`,
+      sqlite: `jr.locked_until > CURRENT_TIMESTAMP`,
+    }),
     `ORDER BY j.id ASC`,
   ] as Expression)) as { id: string }[];
   return rows.map((row) => row.id);

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -167,6 +167,7 @@ import {
   type PublishabilityWarningType,
   type ResourceIndexEntry,
 } from './publishability';
+import { cancelRunningJobsInConcurrencyGroup } from './job-utils';
 
 export const REALM_ROOM_RETENTION_POLICY_MAX_LIFETIME = 60 * 60 * 1000;
 
@@ -665,6 +666,11 @@ export class Realm {
         SupportedMimeType.JSONAPI,
         this.handleAtomicOperations.bind(this),
       )
+      .post(
+        '/_cancel-indexing-job',
+        SupportedMimeType.JSON,
+        this.cancelIndexingJob.bind(this),
+      )
       .post('(/|/.+/)', SupportedMimeType.CardJson, this.createCard.bind(this))
       .get('/.*', SupportedMimeType.CardJson, this.getCard.bind(this))
       .patch(
@@ -758,6 +764,24 @@ export class Realm {
 
   async indexing() {
     return this.#realmIndexUpdater.indexing();
+  }
+
+  private async cancelIndexingJob(
+    _request: Request,
+    requestContext: RequestContext,
+  ) {
+    await cancelRunningJobsInConcurrencyGroup(
+      this.#dbAdapter,
+      `indexing:${this.url}`,
+    );
+
+    return createResponse({
+      body: null,
+      init: {
+        status: 204,
+      },
+      requestContext,
+    });
   }
 
   async start() {


### PR DESCRIPTION
This PR adds a new realm endpoint and command that allows a user to cancel the currently running index job. This makes it easier to recover from a scenario where the indexing job is timing out.