### PR TITLE
Prompt attachment policy: content inclusion, image support, and read-file scoping

### DIFF
--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -5150,6 +5150,417 @@ new
       'cache_control should be set to ephemeral',
     );
   });
+
+  test('only the most recent message attachments include file content in the prompt', async () => {
+    // Policy: files attached to older messages should show metadata only,
+    // even if they are NOT re-attached in later messages.
+    // Only the most recent user message's attachments should include content.
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: '1',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Here is a config file',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/config.json',
+                url: 'http://test.com/config-uploaded.json',
+                name: 'config.json',
+                contentType: 'text/plain',
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '1' },
+        status: EventStatus.SENT,
+      },
+      {
+        type: 'm.room.message',
+        sender: '@aibot:localhost',
+        content: {
+          body: 'Got it.',
+          msgtype: 'm.text',
+          format: 'org.matrix.custom.html',
+          isStreamingFinished: true,
+        },
+        origin_server_ts: 2,
+        unsigned: { age: 1000, transaction_id: '2' },
+        event_id: '2',
+        room_id: 'room1',
+        status: EventStatus.SENT,
+      },
+      {
+        type: 'm.room.message',
+        event_id: '3',
+        origin_server_ts: 3,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Now here is a different file',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/utils.ts',
+                url: 'http://test.com/utils-uploaded.ts',
+                name: 'utils.ts',
+                contentType: 'text/plain',
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '3' },
+        status: EventStatus.SENT,
+      },
+    ];
+
+    mockResponses.set('http://test.com/config-uploaded.json', {
+      ok: true,
+      text: '{ "key": "value" }',
+    });
+    mockResponses.set('http://test.com/utils-uploaded.ts', {
+      ok: true,
+      text: 'export function hello() { return "world"; }',
+    });
+
+    let prompt = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      undefined,
+      undefined,
+      [],
+      fakeMatrixClient,
+    );
+
+    let userMessages = prompt.filter((m) => m.role === 'user');
+
+    // Older message's unique file (config.json) should show metadata only, not content
+    assert.ok(
+      (userMessages[0]?.content as string).includes('[config.json]'),
+      'First message mentions config.json',
+    );
+    assert.notOk(
+      (userMessages[0]?.content as string).includes('"key": "value"'),
+      'First message should NOT include config.json content (not the current message)',
+    );
+
+    // Most recent message's file (utils.ts) should include content
+    assert.ok(
+      (userMessages[1]?.content as string).includes(
+        'export function hello() { return "world"; }',
+      ),
+      'Most recent message should include utils.ts content',
+    );
+  });
+
+  test('unsupported MIME types show metadata without error prefix', async () => {
+    // Policy: binary files with unsupported MIME types should show
+    // useful metadata (name, content type, size) rather than an error.
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: '1',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Here is a PDF and an image',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/report.pdf',
+                url: 'http://test.com/report-uploaded.pdf',
+                name: 'report.pdf',
+                contentType: 'application/pdf',
+                contentSize: 102400,
+              },
+              {
+                sourceUrl: 'http://test.com/my-realm/diagram.png',
+                url: 'http://test.com/diagram-uploaded.png',
+                name: 'diagram.png',
+                contentType: 'image/png',
+                contentSize: 51200,
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '1' },
+        status: EventStatus.SENT,
+      },
+    ];
+
+    let prompt = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      undefined,
+      undefined,
+      [],
+      fakeMatrixClient,
+    );
+
+    let userMessages = prompt.filter((m) => m.role === 'user');
+    let content = userMessages[0]?.content as string;
+
+    // Should show metadata, not error messages
+    assert.ok(
+      content.includes('report.pdf'),
+      'Should mention the PDF file',
+    );
+    assert.ok(
+      content.includes('application/pdf'),
+      'Should show the content type for unsupported files',
+    );
+    assert.notOk(
+      content.includes('Error loading attached file'),
+      'Should NOT show error prefix for unsupported MIME types',
+    );
+    assert.notOk(
+      content.includes('Unsupported file type'),
+      'Should NOT show "Unsupported file type" error',
+    );
+  });
+
+  test('image attachments produce native image_url content parts', async () => {
+    // Policy: when an image file is attached, the prompt should use
+    // native image_url content parts (for vision-capable models)
+    // instead of text-only representation.
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: '1',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'What does this image show?',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/screenshot.png',
+                url: 'http://test.com/screenshot-uploaded.png',
+                name: 'screenshot.png',
+                contentType: 'image/png',
+                contentSize: 1024,
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '1' },
+        status: EventStatus.SENT,
+      },
+    ];
+
+    // Mock binary image download (base64 of a tiny PNG)
+    mockResponses.set('http://test.com/screenshot-uploaded.png', {
+      ok: true,
+      text: 'iVBORw0KGgoAAAANSUhEUg==',
+    });
+
+    let prompt = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      undefined,
+      undefined,
+      [],
+      fakeMatrixClient,
+    );
+
+    let userMessages = prompt.filter((m) => m.role === 'user');
+    let messageContent = userMessages[0]?.content;
+
+    // Content should be an array of content parts, not a plain string
+    assert.ok(
+      Array.isArray(messageContent),
+      'User message with image attachment should have content as ContentPart[]',
+    );
+
+    if (Array.isArray(messageContent)) {
+      let imageParts = messageContent.filter(
+        (part: any) => part.type === 'image_url',
+      );
+      assert.ok(
+        imageParts.length > 0,
+        'Should include at least one image_url content part',
+      );
+
+      let textParts = messageContent.filter(
+        (part: any) => part.type === 'text',
+      );
+      assert.ok(
+        textParts.length > 0,
+        'Should still include text content part with the message body',
+      );
+    }
+  });
+
+  test('read-file tool call is rejected for files not previously attached in the room', async () => {
+    // Policy: the AI should only be able to read files that were
+    // previously attached by the user in the same room.
+    // This prevents the AI from accessing arbitrary files.
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: '1',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Here is a file',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/allowed-file.ts',
+                url: 'http://test.com/allowed-uploaded.ts',
+                name: 'allowed-file.ts',
+                contentType: 'text/plain',
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '1' },
+        status: EventStatus.SENT,
+      },
+      {
+        type: 'm.room.message',
+        sender: '@aibot:localhost',
+        content: {
+          body: '',
+          msgtype: 'm.text',
+          format: 'org.matrix.custom.html',
+          isStreamingFinished: true,
+          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+            {
+              id: 'call_1',
+              name: 'read-file-for-ai-assistant_a831',
+              arguments: JSON.stringify({
+                attributes: {
+                  fileUrl: 'http://test.com/my-realm/not-attached-file.ts',
+                },
+                description: 'Reading a file the user did not attach',
+              }),
+            },
+          ],
+        },
+        origin_server_ts: 2,
+        unsigned: { age: 1000, transaction_id: '2' },
+        event_id: '2',
+        room_id: 'room1',
+        status: EventStatus.SENT,
+      },
+      {
+        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        event_id: '3',
+        origin_server_ts: 3,
+        content: {
+          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+          'm.relates_to': {
+            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            event_id: '2',
+            key: 'call_1',
+          },
+          result: JSON.stringify({
+            data: {
+              type: 'card',
+              attributes: {
+                fileForAttachment: {
+                  sourceUrl:
+                    'http://test.com/my-realm/not-attached-file.ts',
+                  url: 'http://test.com/not-attached-uploaded.ts',
+                  name: 'not-attached-file.ts',
+                  contentType: 'text/plain',
+                },
+              },
+            },
+          }),
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '3' },
+        status: EventStatus.SENT,
+      },
+    ];
+
+    mockResponses.set('http://test.com/allowed-uploaded.ts', {
+      ok: true,
+      text: 'export const allowed = true;',
+    });
+    mockResponses.set('http://test.com/not-attached-uploaded.ts', {
+      ok: true,
+      text: 'export const secret = "should not be readable";',
+    });
+
+    let prompt = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      undefined,
+      undefined,
+      [],
+      fakeMatrixClient,
+    );
+
+    // The command result for the unauthorized file should contain a rejection
+    let toolMessages = prompt.filter((m) => m.role === 'tool');
+    let rejectionMessage = toolMessages.find((m) =>
+      (m.content as string).includes('not-attached-file.ts'),
+    );
+
+    assert.ok(
+      rejectionMessage,
+      'Should have a tool result mentioning the unauthorized file',
+    );
+
+    if (rejectionMessage) {
+      let rejectionContent = rejectionMessage.content as string;
+      assert.ok(
+        rejectionContent.includes('not previously attached') ||
+          rejectionContent.includes('not authorized') ||
+          rejectionContent.includes('rejected'),
+        'Tool result should indicate the file was rejected because it was not previously attached in the room',
+      );
+      assert.notOk(
+        rejectionContent.includes('should not be readable'),
+        'The rejected file content should NOT appear in the prompt',
+      );
+    }
+  });
 });
 
 module('set model in prompt', (hooks) => {

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -1029,8 +1029,8 @@ Attached Files (files with newer versions don't show their content):
 Attached Files (files with newer versions don't show their content):
 [spaghetti-recipe.gts](http://test-realm-server/my-realm/spaghetti-recipe.gts)
 [best-friends.txt](http://test-realm-server/my-realm/best-friends.txt)
-[file-that-does-not-exist.txt](http://test.com/my-realm/file-that-does-not-exist.txt): Error loading attached file: HTTP error. Status: 404
-[example.pdf](http://test.com/my-realm/example.pdf): Error loading attached file: Unsupported file type: application/pdf. For now, only text files are supported.
+[file-that-does-not-exist.txt](http://test.com/my-realm/file-that-does-not-exist.txt)
+[example.pdf](http://test.com/my-realm/example.pdf): [application/pdf]
       `.trim(),
       ),
     );
@@ -5323,7 +5323,17 @@ new
     );
 
     let userMessages = prompt.filter((m) => m.role === 'user');
-    let content = userMessages[0]?.content as string;
+    let messageContent = userMessages[0]?.content;
+    // Content may be ContentPart[] when images are attached
+    let content: string;
+    if (Array.isArray(messageContent)) {
+      content = messageContent
+        .filter((p: any) => p.type === 'text')
+        .map((p: any) => p.text)
+        .join('\n');
+    } else {
+      content = messageContent as string;
+    }
 
     // Should show metadata, not error messages
     assert.ok(
@@ -5491,25 +5501,13 @@ new
         origin_server_ts: 3,
         content: {
           msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+          commandRequestId: 'call_1',
           'm.relates_to': {
             rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
             event_id: '2',
-            key: 'call_1',
+            key: 'applied',
           },
-          result: JSON.stringify({
-            data: {
-              type: 'card',
-              attributes: {
-                fileForAttachment: {
-                  sourceUrl:
-                    'http://test.com/my-realm/not-attached-file.ts',
-                  url: 'http://test.com/not-attached-uploaded.ts',
-                  name: 'not-attached-file.ts',
-                  contentType: 'text/plain',
-                },
-              },
-            },
-          }),
+          data: {},
         },
         sender: '@user:localhost',
         room_id: 'room1',

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -5336,10 +5336,7 @@ new
     }
 
     // Should show metadata, not error messages
-    assert.ok(
-      content.includes('report.pdf'),
-      'Should mention the PDF file',
-    );
+    assert.ok(content.includes('report.pdf'), 'Should mention the PDF file');
     assert.ok(
       content.includes('application/pdf'),
       'Should show the content type for unsupported files',
@@ -5473,9 +5470,10 @@ new
         sender: '@aibot:localhost',
         content: {
           body: '',
-          msgtype: 'm.text',
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
           format: 'org.matrix.custom.html',
           isStreamingFinished: true,
+          data: {},
           [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
             {
               id: 'call_1',

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -1,6 +1,7 @@
 import type { MatrixClient, MatrixEvent } from 'matrix-js-sdk';
 import type {
   ChatCompletionMessageToolCall,
+  ImageContentPart,
   OpenAIPromptMessage,
   PendingCodePatchCorrectnessCheck,
   CodePatchCorrectnessCard,
@@ -65,6 +66,47 @@ const CHECK_CORRECTNESS_COMMAND_NAME = 'checkCorrectness';
 
 function getLog() {
   return logger('ai-bot:prompt');
+}
+
+function isTextBasedContentType(contentType?: string): boolean {
+  return (
+    !!contentType &&
+    (contentType.includes('text/') ||
+      contentType.includes('application/vnd.card+json'))
+  );
+}
+
+function isImageContentType(contentType?: string): boolean {
+  return !!contentType && contentType.startsWith('image/');
+}
+
+function isReadFileCommand(request?: CommandRequest): boolean {
+  return !!request?.name?.startsWith('read-file-for-ai-assistant');
+}
+
+function getReadFileUrl(request?: CommandRequest): string | undefined {
+  try {
+    let args =
+      typeof request?.arguments === 'string'
+        ? JSON.parse(request.arguments)
+        : request?.arguments;
+    return args?.attributes?.fileUrl;
+  } catch {
+    return undefined;
+  }
+}
+
+function isFileAttachedInRoom(
+  fileUrl: string,
+  history: DiscreteMatrixEvent[],
+): boolean {
+  return history.some((event) => {
+    let attachedFiles = (event as MatrixEventWithBoxelContext).content?.data
+      ?.attachedFiles;
+    return attachedFiles?.some(
+      (f: SerializedFileDef) => f.sourceUrl === fileUrl,
+    );
+  });
 }
 
 export async function getPromptParts(
@@ -466,15 +508,16 @@ export async function getAttachedFiles(
   client: MatrixClient,
   matrixEvent: MatrixEventWithBoxelContext,
   history: DiscreteMatrixEvent[],
+  isCurrentMessage: boolean = false,
 ): Promise<SerializedFileDef[]> {
   let attachedFiles = matrixEvent.content?.data?.attachedFiles ?? [];
   return Promise.all(
     attachedFiles.map(async (attachedFile: SerializedFileDef) => {
-      // If the file is attached later in the history, we should not include the content here
-      let shouldIncludeContent = !history
+      // Only download content for the most recent user message's files,
+      // and only if the file isn't superseded by a later attachment
+      let isSuperseded = history
         .slice(history.indexOf(matrixEvent) + 1)
         .some((event) => {
-          // event is not always MatrixEventWithBoxelContext but casting lets us safely check attachedFiles
           return (
             event as MatrixEventWithBoxelContext
           ).content?.data?.attachedFiles?.some(
@@ -482,12 +525,17 @@ export async function getAttachedFiles(
               file.sourceUrl === attachedFile.sourceUrl,
           );
         });
+      let shouldIncludeContent =
+        isCurrentMessage &&
+        !isSuperseded &&
+        isTextBasedContentType(attachedFile.contentType);
 
       let result: SerializedFileDef = {
         url: attachedFile.url,
         sourceUrl: attachedFile.sourceUrl ?? '',
         name: attachedFile.name,
         contentType: attachedFile.contentType,
+        contentSize: attachedFile.contentSize,
       };
       if (shouldIncludeContent) {
         try {
@@ -540,6 +588,15 @@ export async function loadCurrentlySerializedFileDefs(
 
   return Promise.all(
     attachedFiles.map(async (attachedFile: SerializedFileDef) => {
+      if (!isTextBasedContentType(attachedFile.contentType)) {
+        return {
+          url: attachedFile.url,
+          sourceUrl: attachedFile.sourceUrl ?? '',
+          name: attachedFile.name,
+          contentType: attachedFile.contentType,
+          contentSize: attachedFile.contentSize,
+        };
+      }
       try {
         let content = await downloadFile(client, attachedFile);
 
@@ -572,6 +629,7 @@ export function attachedFilesToMessage(
     return 'No attached files';
   }
   return attachedFiles
+    .filter((f) => !isImageContentType(f.contentType))
     .map((f) => {
       let hyperlink = f.sourceUrl ? `[${f.name}](${f.sourceUrl})` : f.name;
       if (f.error) {
@@ -588,6 +646,11 @@ export function attachedFilesToMessage(
           )
           .join('\n');
         return `${hyperlink}:\n${numberedContent}`;
+      } else if (!isTextBasedContentType(f.contentType) && f.contentType) {
+        let meta = [f.contentType, f.contentSize ? `${f.contentSize} bytes` : '']
+          .filter(Boolean)
+          .join(', ');
+        return `${hyperlink}: [${meta}]`;
       } else {
         return `${hyperlink}`;
       }
@@ -797,6 +860,13 @@ async function toResultMessages(
           );
           content = checkCorrectnessContent.toolMessage;
           followUpUserMessage = checkCorrectnessContent.followUpUserMessage;
+        } else if (isReadFileCommand(decodedCommandRequest)) {
+          let fileUrl = getReadFileUrl(decodedCommandRequest);
+          if (fileUrl && !isFileAttachedInRoom(fileUrl, history)) {
+            content = `Tool call rejected: the file "${fileUrl}" was not previously attached in the room. Only files attached by the user can be read.\n`;
+          } else {
+            content = `Tool call ${status == 'applied' ? 'executed' : status}.\n`;
+          }
         } else if (
           commandResult.content.msgtype ===
             APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE &&
@@ -809,12 +879,15 @@ async function toResultMessages(
         } else {
           content = `Tool call ${status == 'applied' ? 'executed' : status}.\n`;
         }
-        let attachments = await buildAttachmentsMessagePart(
+        let attachmentResult = await buildAttachmentsMessagePart(
           client,
           commandResult,
           history,
+          true,
         );
-        content = [content, attachments].filter(Boolean).join('\n\n');
+        content = [content, attachmentResult.text]
+          .filter(Boolean)
+          .join('\n\n');
         let toolMessage: OpenAIPromptMessage = {
           role: 'tool',
           tool_call_id: commandRequest.id,
@@ -1188,6 +1261,13 @@ export async function buildPromptForModel(
     throw new Error("Username must be a full id, e.g. '@aibot:localhost'");
   }
   let historicalMessages: OpenAIPromptMessage[] = [];
+  let lastUserMessageEvent = findLast(
+    history,
+    (event) =>
+      event.sender !== aiBotUserId &&
+      event.type === 'm.room.message' &&
+      !isCommandOrCodePatchResult(event),
+  );
   for (let event of history) {
     if (event.type !== 'm.room.message') {
       continue;
@@ -1231,17 +1311,40 @@ export async function buildPromptForModel(
       ).forEach((message) => historicalMessages.push(message));
     }
     if (event.sender !== aiBotUserId) {
-      let attachments = await buildAttachmentsMessagePart(
+      let isCurrentMessage = event === lastUserMessageEvent;
+      let attachmentResult = await buildAttachmentsMessagePart(
         client,
         event as CardMessageEvent,
         history,
+        isCurrentMessage,
       );
-      let content = [body, attachments].filter(Boolean).join('\n\n');
-      if (content) {
-        historicalMessages.push({
-          role: 'user',
-          content,
-        });
+      if (attachmentResult.imageUrls.length > 0) {
+        let textContent = [body, attachmentResult.text]
+          .filter(Boolean)
+          .join('\n\n');
+        let contentParts: (TextContent | ImageContentPart)[] = [];
+        if (textContent) {
+          contentParts.push({ type: 'text', text: textContent });
+        }
+        for (let imageUrl of attachmentResult.imageUrls) {
+          contentParts.push({
+            type: 'image_url',
+            image_url: { url: imageUrl },
+          });
+        }
+        if (contentParts.length) {
+          historicalMessages.push({ role: 'user', content: contentParts });
+        }
+      } else {
+        let content = [body, attachmentResult.text]
+          .filter(Boolean)
+          .join('\n\n');
+        if (content) {
+          historicalMessages.push({
+            role: 'user',
+            content,
+          });
+        }
       }
     }
   }
@@ -1762,17 +1865,29 @@ export const buildAttachmentsMessagePart = async (
   client: MatrixClient,
   matrixEvent: MatrixEventWithBoxelContext,
   history: DiscreteMatrixEvent[],
-) => {
+  isCurrentMessage: boolean = false,
+): Promise<{ text: string; imageUrls: string[] }> => {
   let attachedCards = await getAttachedCards(client, matrixEvent, history);
-  let result = '';
+  let text = '';
   if (attachedCards.length > 0) {
-    result += `Attached Cards (cards with newer versions don't show their content):\n${JSON.stringify(attachedCards, null, 2)}\n`;
+    text += `Attached Cards (cards with newer versions don't show their content):\n${JSON.stringify(attachedCards, null, 2)}\n`;
   }
-  let attachedFiles = await getAttachedFiles(client, matrixEvent, history);
+  let attachedFiles = await getAttachedFiles(
+    client,
+    matrixEvent,
+    history,
+    isCurrentMessage,
+  );
   if (attachedFiles.length > 0) {
-    result += `Attached Files (files with newer versions don't show their content):\n${attachedFilesToMessage(attachedFiles)}\n`;
+    text += `Attached Files (files with newer versions don't show their content):\n${attachedFilesToMessage(attachedFiles)}\n`;
   }
-  return result;
+  let imageUrls: string[] = [];
+  if (isCurrentMessage) {
+    imageUrls = attachedFiles
+      .filter((f) => isImageContentType(f.contentType) && f.url)
+      .map((f) => f.url!);
+  }
+  return { text, imageUrls };
 };
 
 export const buildContextMessage = async (

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -655,7 +655,10 @@ export function attachedFilesToMessage(
           .join('\n');
         return `${hyperlink}:\n${numberedContent}`;
       } else if (!isTextBasedContentType(f.contentType) && f.contentType) {
-        let meta = [f.contentType, f.contentSize ? `${f.contentSize} bytes` : '']
+        let meta = [
+          f.contentType,
+          f.contentSize ? `${f.contentSize} bytes` : '',
+        ]
           .filter(Boolean)
           .join(', ');
         return `${hyperlink}: [${meta}]`;
@@ -893,9 +896,7 @@ async function toResultMessages(
           history,
           true,
         );
-        content = [content, attachmentResult.text]
-          .filter(Boolean)
-          .join('\n\n');
+        content = [content, attachmentResult.text].filter(Boolean).join('\n\n');
         let toolMessage: OpenAIPromptMessage = {
           role: 'tool',
           tool_call_id: commandRequest.id,

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -68,6 +68,38 @@ function getLog() {
   return logger('ai-bot:prompt');
 }
 
+/*
+ * ── Attachment Context Policy ────────────────────────────────────────
+ *
+ * When building prompts for the model, file attachments are handled
+ * according to the following rules:
+ *
+ * 1. **Content inclusion**: Only the most recent user message's attached
+ *    files have their content downloaded and included in the prompt.
+ *    Older messages show file metadata (name, type) only. This keeps
+ *    the prompt focused on fresh data and avoids redundant downloads.
+ *
+ * 2. **Supersession**: Within the current message, if a file (by
+ *    sourceUrl) is re-attached in a later event, the earlier version
+ *    is shown as metadata only (the later version wins).
+ *
+ * 3. **MIME type handling**:
+ *    - Text-based types (text/*, application/vnd.card+json) → content
+ *      downloaded and displayed with line numbers.
+ *    - Image types (image/*) → presented as native image_url content
+ *      parts for vision-capable models.
+ *    - Other types (PDF, binary, etc.) → metadata shown inline
+ *      ([contentType, contentSize bytes]) without an error prefix.
+ *
+ * 4. **Read-file command scoping**: When the AI requests to read a file
+ *    via a tool call, the file URL must match a sourceUrl previously
+ *    attached by the user in the same room. Unrecognised URLs produce
+ *    a rejection message in the tool result.
+ * ─────────────────────────────────────────────────────────────────────
+ */
+
+// ── MIME / category helpers ──────────────────────────────────────────
+
 function isTextBasedContentType(contentType?: string): boolean {
   return (
     !!contentType &&
@@ -79,6 +111,8 @@ function isTextBasedContentType(contentType?: string): boolean {
 function isImageContentType(contentType?: string): boolean {
   return !!contentType && contentType.startsWith('image/');
 }
+
+// ── Read-file command scope helpers ──────────────────────────────────
 
 function isReadFileCommand(request?: CommandRequest): boolean {
   return !!request?.name?.startsWith('read-file-for-ai-assistant');
@@ -107,6 +141,32 @@ function isFileAttachedInRoom(
       (f: SerializedFileDef) => f.sourceUrl === fileUrl,
     );
   });
+}
+
+// ── Shared attachment helpers ────────────────────────────────────────
+
+function toFileDefMetadata(file: SerializedFileDef): SerializedFileDef {
+  return {
+    url: file.url,
+    sourceUrl: file.sourceUrl ?? '',
+    name: file.name,
+    contentType: file.contentType,
+    contentSize: file.contentSize,
+  };
+}
+
+async function downloadTextContent(
+  client: MatrixClient,
+  file: SerializedFileDef,
+): Promise<SerializedFileDef> {
+  let result = toFileDefMetadata(file);
+  try {
+    result.content = await downloadFile(client, file);
+  } catch (error) {
+    getLog().error(`Failed to fetch file ${file.url}:`, error);
+    result.error = `Error loading attached file: ${(error as Error).message}`;
+  }
+  return result;
 }
 
 export async function getPromptParts(
@@ -512,41 +572,25 @@ export async function getAttachedFiles(
 ): Promise<SerializedFileDef[]> {
   let attachedFiles = matrixEvent.content?.data?.attachedFiles ?? [];
   return Promise.all(
-    attachedFiles.map(async (attachedFile: SerializedFileDef) => {
-      // Only download content for the most recent user message's files,
-      // and only if the file isn't superseded by a later attachment
+    attachedFiles.map(async (file: SerializedFileDef) => {
       let isSuperseded = history
         .slice(history.indexOf(matrixEvent) + 1)
-        .some((event) => {
-          return (
+        .some((event) =>
+          (
             event as MatrixEventWithBoxelContext
           ).content?.data?.attachedFiles?.some(
-            (file: SerializedFileDef) =>
-              file.sourceUrl === attachedFile.sourceUrl,
-          );
-        });
-      let shouldIncludeContent =
+            (f: SerializedFileDef) => f.sourceUrl === file.sourceUrl,
+          ),
+        );
+
+      if (
         isCurrentMessage &&
         !isSuperseded &&
-        isTextBasedContentType(attachedFile.contentType);
-
-      let result: SerializedFileDef = {
-        url: attachedFile.url,
-        sourceUrl: attachedFile.sourceUrl ?? '',
-        name: attachedFile.name,
-        contentType: attachedFile.contentType,
-        contentSize: attachedFile.contentSize,
-      };
-      if (shouldIncludeContent) {
-        try {
-          result.content = await downloadFile(client, attachedFile);
-        } catch (error) {
-          getLog().error(`Failed to fetch file ${attachedFile.url}:`, error);
-          result.error = `Error loading attached file: ${(error as Error).message}`;
-          result.content = undefined;
-        }
+        isTextBasedContentType(file.contentType)
+      ) {
+        return downloadTextContent(client, file);
       }
-      return result;
+      return toFileDefMetadata(file);
     }),
   );
 }
@@ -566,59 +610,23 @@ export async function loadCurrentlySerializedFileDefs(
         event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE),
   );
 
-  let mostRecentUserMessageContent = lastMessageEventByUser?.content as {
-    msgtype?: string;
-    data?: {
-      attachedFiles?: SerializedFileDef[];
-    };
-  };
-
-  if (!mostRecentUserMessageContent) {
+  if (!lastMessageEventByUser) {
     return [];
   }
 
-  // We are only interested in downloading the most recently attached files -
-  // downloading older ones is not needed since the prompt that is being constructed
-  // should operate on fresh data
-  if (!mostRecentUserMessageContent.data?.attachedFiles?.length) {
+  let attachedFiles = (lastMessageEventByUser as MatrixEventWithBoxelContext)
+    .content?.data?.attachedFiles;
+  if (!attachedFiles?.length) {
     return [];
   }
 
-  let attachedFiles = mostRecentUserMessageContent.data.attachedFiles;
-
-  return Promise.all(
-    attachedFiles.map(async (attachedFile: SerializedFileDef) => {
-      if (!isTextBasedContentType(attachedFile.contentType)) {
-        return {
-          url: attachedFile.url,
-          sourceUrl: attachedFile.sourceUrl ?? '',
-          name: attachedFile.name,
-          contentType: attachedFile.contentType,
-          contentSize: attachedFile.contentSize,
-        };
-      }
-      try {
-        let content = await downloadFile(client, attachedFile);
-
-        return {
-          url: attachedFile.url,
-          sourceUrl: attachedFile.sourceUrl ?? '',
-          name: attachedFile.name,
-          contentType: attachedFile.contentType,
-          content,
-        };
-      } catch (error) {
-        getLog().error(`Failed to fetch file ${attachedFile.url}:`, error);
-        return {
-          sourceUrl: attachedFile.sourceUrl ?? '',
-          url: attachedFile.url,
-          name: attachedFile.name,
-          contentType: attachedFile.contentType,
-          content: undefined,
-          error: `Error loading attached file: ${(error as Error).message}`,
-        };
-      }
-    }),
+  // Reuse getAttachedFiles with isCurrentMessage=true — this is always the
+  // most recent user event, so supersession can't apply (no later events).
+  return getAttachedFiles(
+    client,
+    lastMessageEventByUser as MatrixEventWithBoxelContext,
+    history,
+    true,
   );
 }
 

--- a/packages/runtime-common/ai/types.ts
+++ b/packages/runtime-common/ai/types.ts
@@ -35,7 +35,7 @@ export type TextContent = {
     type: 'ephemeral';
   };
 };
-type ImageContentPart = {
+export type ImageContentPart = {
   type: 'image_url';
   image_url: {
     url: string; // URL or base64 encoded image data


### PR DESCRIPTION
## Summary

Implements model-aware attachment prompt shaping and room-scoped file reads (CS-10248 / CS-10249 / CS-10250):

- **Message-level content inclusion**: only the most recent user message's file attachments include downloaded content in the prompt; older messages show metadata only
- **Graceful unsupported MIME types**: binary files (PDF, etc.) show metadata (`[contentType, size]`) without error prefixes
- **Native image payloads**: image attachments produce `image_url` content parts for vision-capable models
- **Read-file command scoping**: tool calls targeting files not previously attached by the user in the room are rejected
- **Refactored helpers**: extracted `toFileDefMetadata()` / `downloadTextContent()`, simplified `loadCurrentlySerializedFileDefs` to reuse `getAttachedFiles`, added policy documentation

## Test plan

- [x] 4 new prompt-construction tests pass (RED → GREEN)
- [x] Full ai-bot test suite passes (121/121)
- [x] Existing attachment download tests updated for new policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)