### PR TITLE
Fix TS2552: rename setupPermissionedRealms → setupPermissionedRealmsCached in prerendering-test.ts

### DIFF
--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -1571,7 +1571,7 @@ module(basename(__filename), function () {
         });
       });
 
-      setupPermissionedRealms(hooks, {
+      setupPermissionedRealmsCached(hooks, {
         mode: 'before',
         realms: [
           {


### PR DESCRIPTION
PR #4110 (Refactor prerenderer) renamed `setupPermissionedRealms` → `setupPermissionedRealmsCached` throughout the codebase, but missed one call at line 1574 of `packages/realm-server/tests/prerendering-test.ts`. This causes a `TS2552: Cannot find name 'setupPermissionedRealms'` lint error on main.

One-line fix: rename the remaining call to match the rest of the file.