### PR TITLE
AI attachments: local files via Matrix media, binary dedupe, and prompt/image shaping

### DIFF
--- a/docs/ai-assistant-local-file-direct-matrix-plan.md
+++ b/docs/ai-assistant-local-file-direct-matrix-plan.md
@@ -1,0 +1,264 @@
+# AI Assistant Local File Direct-to-Matrix Plan
+
+## Goal
+
+Add a third attachment source in the AI Assistant panel so the plus menu offers:
+
+- `Attach a Card`
+- `Attach a File (Workspace)`
+- `Attach a File (Your Computer)`
+
+and support a direct local-disk-to-Matrix media path for `Attach a File (Your Computer)`.
+
+For local files, metadata extraction must match realm indexing behavior:
+
+- resolve `FileDef` subclass via extension map
+- run `extractAttributes` for that subclass (with fallback behavior)
+- send the resulting `FileDef` JSON inline in attachment payloads
+
+## Execution Plan (Actual)
+
+### Phase 0: Tracking and Scope Alignment
+
+- [x] Create/move Linear issue in `linear_cardstack` (not `linear_yapp`)
+- [ ] Link this plan doc in the correct Linear issue
+- [ ] Confirm acceptance criteria:
+  - plus menu has exactly `Attach a Card`, `Attach a File (Workspace)`, `Attach a File (Your Computer)`
+  - local file path does not upload file bytes to realm
+  - local file path uploads file bytes to Matrix and includes serialized `FileDef` in message payload
+  - local file extraction behavior matches realm indexing semantics
+
+### Phase 1: Core Upload Contract
+
+- [x] Add `FileDefManager.prefetchLocalFileContent(...)`
+- [x] Add local-source guardrails in `uploadFiles(...)`:
+  - error when synthetic local source has no prefetched bytes
+- [x] Add/adjust tests for these contract changes
+
+### Phase 2: Local FileDef Extraction Parity
+
+- [x] Add reusable extractor path that mirrors realm indexing:
+  - extension -> subclass via `resolveFileDefCodeRef(...)`
+  - extraction via `extractAttributes(...)` with same fallback semantics
+- [x] Use extractor for local-computer attach flow
+- [x] Add parity tests against representative file types
+
+### Phase 3: Attachment UI + Service Plumbing
+
+- [x] Update plus menu labels and actions:
+  - `Attach a Card`
+  - `Attach a File (Workspace)`
+  - `Attach a File (Your Computer)`
+- [x] Add local picker API that returns native `File` without realm upload
+- [x] Wire room component to:
+  - build synthetic-source local `FileDef`
+  - prefetch local bytes into matrix/file manager
+  - call existing eager upload/send path
+
+### Phase 4: Validation and Cleanup
+
+- [x] Add integration coverage for:
+  - menu rendering + labels
+  - local attach happy path
+  - no realm upload for local files
+  - Matrix bytes upload for local files
+- [x] Run `pnpm lint` in touched package(s)
+- [ ] Run targeted tests for touched package(s)
+- [ ] Remove dead code / tighten types / finalize error copy
+
+## Current Progress Snapshot
+
+- Completed:
+  - `packages/base/file-api.gts` keeps canonical `FileDef` serialization as attachment payload
+  - `packages/host/app/lib/file-def-manager.ts` local prefetch API and local upload handling
+- Remaining:
+  - Full targeted test execution in local env (blocked in sandbox by `ember test` runtime/port permissions)
+  - Link plan doc in Linear issue
+
+## Current Behavior
+
+Today, local disk files are first uploaded to a workspace realm, then attached and uploaded again to Matrix:
+
+1. Local disk -> realm file URL
+2. realm file URL -> Matrix media URL
+
+We want to keep (2) for workspace files, but allow local files to skip (1).
+
+## Proposed Behavior
+
+### Attach Menu
+
+- Keep existing card attachment flow.
+- Keep existing workspace file picker flow unchanged.
+- Add a dedicated local-computer picker flow.
+
+### Data Flow by Attachment Type
+
+- `Attach a File (Workspace)`: unchanged
+  - choose realm file metadata
+  - prefetch from realm URL
+  - eager Matrix upload
+- `Attach a File (Your Computer)`: new
+  - pick native `File`
+  - resolve `FileDef` subclass via extension mapping
+  - run `extractAttributes` to build typed file metadata
+  - create `FileDef` from extracted attributes with synthetic non-realm `sourceUrl`
+  - store picked bytes in prefetch cache immediately
+  - eager Matrix upload using cached bytes
+  - include serialized `FileDef` JSON inline in message attachments
+  - do not POST file bytes to realm
+
+## Design Details
+
+### 1. UI and Component API
+
+Update the attachment picker plumbing to support two file actions:
+
+- `chooseWorkspaceFile(file: FileDef)` (existing behavior)
+- `chooseLocalFile()` (new behavior)
+
+This keeps attach-button generic and avoids coupling it to upload services.
+
+### 2. Synthetic Source URL for Local Files
+
+Create local file `FileDef` objects with a synthetic source URL (for identity only), for example:
+
+- `boxel-local://<stable-id>/<filename>`
+
+Requirements:
+
+- Must not include local filesystem paths.
+- Must be unique/stable enough to support remove/retry/upload state keys.
+- Must not be treated as realm URL for fetch.
+
+### 3. FileDef Extraction Parity (Required)
+
+Local file attachments must use the same file-type resolution and extraction rules
+as indexed realm files:
+
+- use `resolveFileDefCodeRef(...)` for extension -> `FileDef` subclass mapping
+- use `extractAttributes(...)` for the resolved class, with fallback behavior
+  equivalent to `FileDefAttributesExtractor`
+- preserve extracted attributes (for example: `contentType`, `contentHash`,
+  `contentSize`, and subclass-specific attributes)
+
+Implementation note:
+
+- Prefer introducing a reusable helper that accepts `(fileURL, bytes)` and
+  executes the same extract chain used by file-meta extraction today, instead of
+  duplicating logic inside the room component.
+
+### 4. Matrix Upload Contract for Local Files
+
+For each local-computer attachment, upload raw file bytes as today and keep the
+typed `FileDef` serialization as the attachment JSON payload in the message.
+No extra sidecar metadata upload is needed.
+
+### 5. FileDefManager Prefetch API
+
+Extend prefetch support to allow injecting bytes directly (not only fetching from realm URLs):
+
+- Keep `prefetchFileContent(fileDef)` for workspace path.
+- Add `prefetchLocalFileContent(fileDef, bytes, contentType)` (or equivalent API name).
+
+`uploadFiles()` should:
+
+- prefer prefetched bytes when available
+- only fallback to realm fetch for normal workspace URLs
+- provide a clear error if a local synthetic source URL has no prefetched bytes
+
+### 6. Matrix Service Surface
+
+Add service/client passthrough for local prefetch injection so room component can:
+
+1. build local `FileDef`
+2. pre-seed prefetch bytes
+3. reuse existing eager upload and send flow
+
+### 7. Prompt and Command Expectations
+
+No special prompt format changes are required for initial support.
+
+- Local attachments will appear as normal attachments with synthetic `sourceUrl`.
+- `read-file-for-ai-assistant` is realm-file-oriented and will not resolve synthetic local URLs.
+- This keeps local-computer attachments context-only/read-only from command perspective.
+
+## Implementation Steps
+
+1. **Attach menu and callback wiring**
+- Add `Attach a File (Workspace)` and `Attach a File (Your Computer)` menu items.
+- Add new callback arg(s) through attachment picker index/usage.
+
+2. **Local file selection API**
+- Add a `file-upload` service method for picking a local file without uploading to realm.
+- Return `File | undefined`.
+
+3. **Build local FileDef via extract pipeline**
+- In room component, implement `chooseLocalFile` action.
+- Resolve subclass using `resolveFileDefCodeRef` with the selected filename.
+- Run `extractAttributes` (with fallback semantics) on local bytes.
+- Create typed `FileDef` from extracted attributes with a synthetic source URL.
+
+4. **Prefetch/upload bytes**
+- Store bytes via new matrix/file-def-manager local prefetch API.
+- Add to `filesToSend` and call existing `startFileUpload`.
+
+5. **Client/service plumbing**
+- Extend matrix sdk loader proxy + `ExtendedClient` + mock client for new method(s).
+- Keep existing workspace flow behavior unchanged.
+
+6. **Guardrails and error handling**
+- If local file bytes are missing at upload time, show upload error state and retry affordance.
+- Ensure `removeFile` cleanup works for synthetic source URLs.
+
+## Target Files
+
+- `packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts`
+- `packages/host/app/components/ai-assistant/attachment-picker/index.gts`
+- `packages/host/app/components/ai-assistant/attachment-picker/usage.gts`
+- `packages/host/app/components/matrix/room.gts`
+- `packages/host/app/services/file-upload.ts`
+- `packages/host/app/services/matrix-service.ts`
+- `packages/host/app/services/matrix-sdk-loader.ts`
+- `packages/host/app/lib/file-def-manager.ts`
+- `packages/host/app/utils/file-def-attributes-extractor.ts`
+- `packages/runtime-common/file-def-code-ref.ts`
+- `packages/base/file-api.gts`
+- `packages/host/tests/helpers/mock-matrix/_client.ts`
+
+## Test Plan
+
+### Integration tests
+
+- Attachment menu shows three options with exact labels.
+- Local file pick attaches a file pill and starts eager upload.
+- Sending message with local file works with no realm upload.
+- Local file extraction picks the same subclass as realm indexing for the same extension.
+- Local file metadata extraction uses `extractAttributes` and includes subclass-specific attributes.
+- Matrix upload includes file bytes, while message attachments include serialized `FileDef`.
+
+### Service/unit tests
+
+- `FileDefManager.uploadFiles()` uses injected prefetched bytes for local files.
+- Missing prefetched bytes for synthetic local URL yields actionable error.
+
+### Regression coverage
+
+- Workspace file attach behavior remains unchanged.
+- Existing binary dedupe tests continue to pass.
+
+## Risks and Mitigations
+
+- **Risk:** synthetic source URL collides
+  - **Mitigation:** include stable id + filename (and optionally size/mtime/hash).
+- **Risk:** accidental realm upload in local flow
+  - **Mitigation:** explicit no-realm branch + tests asserting no realm POST.
+- **Risk:** drift from realm indexing extraction semantics
+  - **Mitigation:** share extraction helper/path and add parity tests against known file types.
+- **Risk:** UI dedupe behavior changes
+  - **Mitigation:** dedupe key policy documented and tested.
+
+## Rollout
+
+- Ship behind existing UI flow without feature flag if scope is contained.
+- If needed, add temporary feature flag only around the new local menu option.

--- a/docs/openrouter-multimodal-file-types-plan.md
+++ b/docs/openrouter-multimodal-file-types-plan.md
@@ -1,0 +1,168 @@
+# OpenRouter Multimodal File Type Support Plan
+
+## Goal
+Support all OpenRouter multimodal input file types end-to-end in Boxel AI prompts, not just images.
+
+## Source
+OpenRouter multimodal overview:
+- https://openrouter.ai/docs/guides/overview/multimodal/overview
+
+## What OpenRouter Supports
+- Images (for example: PNG, JPEG, WEBP, GIF)
+- PDFs (`application/pdf`)
+- Audio inputs (for example: wav/mp3/aiff/aac/ogg/flac/m4a/pcm16/pcm24)
+- Video inputs (for example: mp4/mpeg/mov/webm)
+
+## Current State (Observed)
+- Upload MIME inference now correctly recovers binary types from realm files when fetch returns generic MIME.
+- Prompt construction currently sends:
+  - text parts for text attachments
+  - `image_url` parts for image attachments
+- Non-text and non-image attachments (including PDFs/audio/video) are currently reduced to metadata text and not sent as multimodal payload data.
+
+## Plan
+
+### Phase 1: Expand Prompt Part Types ✅
+
+Update runtime-common AI message part types so prompts can represent all needed OpenRouter content parts.
+
+Target file: `packages/runtime-common/ai/types.ts`
+
+New types added (matching OpenRouter payload schemas):
+
+```ts
+// PDF / generic file attachments
+export type FileContentPart = {
+  type: 'file';
+  file: {
+    filename: string;
+    file_data: string; // base64 data URL (data:application/pdf;base64,...) or public URL
+  };
+  cache_control?: { type: 'ephemeral' };
+};
+
+// Audio input (base64 only — URLs not supported by OpenRouter)
+export type InputAudioContentPart = {
+  type: 'input_audio';
+  input_audio: {
+    data: string;   // raw base64 (no data: prefix)
+    format: string;  // wav | mp3 | aiff | aac | ogg | flac | m4a | pcm16 | pcm24
+  };
+  cache_control?: { type: 'ephemeral' };
+};
+
+// Video input
+export type VideoContentPart = {
+  type: 'video_url';
+  video_url: {
+    url: string; // base64 data URL or public URL
+  };
+  cache_control?: { type: 'ephemeral' };
+};
+```
+
+`ContentPart` union expanded:
+```ts
+export type ContentPart =
+  | TextContent
+  | ImageContentPart
+  | FileContentPart
+  | InputAudioContentPart
+  | VideoContentPart;
+```
+
+All new types are exported for use by `prompt.ts` and other consumers.
+
+### Phase 2: Build Correct Attachment Parts ✅
+
+Updated attachment-to-prompt conversion logic in `packages/runtime-common/ai/prompt.ts`.
+
+Changes:
+- Added MIME helpers: `isPdfContentType`, `isAudioContentType`, `isVideoContentType`, `audioFormatFromMime`
+- `buildAttachmentsMessagePart` now returns `{ text, mediaParts: ContentPart[] }` (was `{ text, imageUrls }`)
+- Single loop over attached files dispatches by MIME type:
+  - `image/*` → `image_url` part (unchanged behavior)
+  - `application/pdf` → `file` part with base64 data URL in `file_data`
+  - `audio/*` → `input_audio` part with raw base64 + format string
+  - `video/*` → `video_url` part with base64 data URL
+  - other → falls through to metadata-only text (unchanged)
+- All media sourceUrls are omitted from the text fallback representation
+- Caller in `buildPromptForModel` updated to spread `mediaParts` into `ContentPart[]`
+- Tool-result caller unchanged (only uses `.text`)
+
+### Phase 3: MIME Inference Coverage ✅
+
+Root-cause fix: `realm.ts:getSourceOrRedirect` hardcoded `content-type: text/plain; charset=utf-8`
+for all `application/vnd.card+source` responses, including binary files. Changed to
+`inferContentType(handle.path)` so the realm returns the correct MIME (e.g. `application/pdf`,
+`audio/mpeg`, `video/mp4`) at the source.
+
+Additional fixes:
+- `infer-content-type.ts`: Added `.ts` → `text/typescript` override (mime-types maps `.ts` to `video/mp2t`)
+- `prompt.ts` `AUDIO_MIME_TO_FORMAT`: Added `audio/wave`, `audio/x-aac`, `audio/x-flac` variants
+
+Tests added:
+- `card-source-endpoints-test.ts`: Card-source GET returns correct content-type for image/PDF/audio/video
+- `file-def-manager-canonicalize-test.ts`: `inferContentType` covers PDF, audio, and video extensions
+
+### Phase 4: Download/Encoding Utilities ✅ (no changes needed)
+
+`downloadFileAsBase64DataUrl` in `matrix-utils.ts` already reads binary content via `arrayBuffer`
+and base64-encodes it. Phase 2 uses it for all multimodal types. `downloadFile` remains text-only,
+which is correct for its callers (text attachments, card JSON, command definitions).
+
+### Phase 5: Model Capability Gating ✅
+
+Prevent invalid multimodal payloads for models that do not support specific modalities.
+
+Changes:
+
+- **`packages/base/system-card.gts`**: Added `inputModalities` field (`containsMany(StringField)`) to `ModelConfiguration`
+- **`packages/base/matrix-event.gts`**: Added `inputModalities?: string[]` to `ActiveLLMEvent.content`
+- **`packages/host/app/services/matrix-service.ts`**: `sendActiveLLMEvent` now includes `inputModalities` from model configuration
+- **`packages/runtime-common/ai/prompt.ts`**:
+  - `getActiveLLMDetails` returns `inputModalities` from the active LLM event
+  - `getPromptParts` calls `getActiveLLMDetails` before `buildPromptForModel` so modalities are available
+  - `buildPromptForModel` accepts and forwards `inputModalities` parameter
+  - `buildAttachmentsMessagePart` accepts `inputModalities` parameter
+  - New `requiredModality(contentType)` helper maps MIME types to OpenRouter modality strings (`image`, `file`, `audio`, `video`)
+  - Gating logic: when `inputModalities` is set, media parts for unsupported modalities are skipped
+  - Warning text appended listing files not sent due to model limitations
+  - When `inputModalities` is undefined (no model config), all modalities are sent (no gating)
+
+### Phase 6: Tests ✅
+
+Added focused tests around prompt assembly, MIME handling, and modality gating.
+
+**New test file: `packages/ai-bot/tests/modality-test.ts`** (10 tests)
+- `requiredModality` maps image/PDF/audio/video MIME types to correct modality strings
+- `requiredModality` returns undefined for non-multimodal types (text, JSON, octet-stream)
+- `modalityLabel` returns human-readable labels for each modality
+- `isImageContentType`, `isPdfContentType`, `isAudioContentType`, `isVideoContentType` correctly classify types
+
+**Added to `packages/ai-bot/tests/prompt-construction-test.ts`** (5 tests)
+- PDF attachment produces native `file` content part with base64 data URL in `file_data`
+- Audio attachment produces native `input_audio` content part with raw base64 and format string
+- Video attachment produces native `video_url` content part with base64 data URL
+- Unsupported modality is gated when `inputModalities` is set (PDF excluded, warning text present)
+- All modalities sent when `inputModalities` is undefined (no gating, no warning)
+
+**Previously added in Phase 3:**
+- `card-source-endpoints-test.ts`: Realm returns correct content-type for image/PDF/audio/video
+- `file-def-manager-canonicalize-test.ts`: `inferContentType` covers PDF, audio, and video extensions
+
+## Suggested MIME Mapping
+- `application/pdf` -> `file`
+- `audio/wav`, `audio/mpeg`, `audio/aac`, `audio/ogg`, `audio/flac`, `audio/mp4`, etc. -> `input_audio`
+- `video/mp4`, `video/mpeg`, `video/quicktime`, `video/webm` -> `video_url`/file form
+
+## Rollout Strategy
+1. Ship types + prompt builder support for PDF first (lowest risk, immediate value).
+2. Add audio support next.
+3. Add video support last (higher provider variance).
+4. Add capability gating and fallback messaging before broad enablement.
+
+## Success Criteria
+- Uploaded supported files are transmitted to OpenRouter in multimodal payload form, not metadata-only text.
+- No regressions for text/image behavior.
+- Unsupported file/model combinations fail gracefully with explicit fallback messaging.

--- a/packages/ai-bot/tests/index.ts
+++ b/packages/ai-bot/tests/index.ts
@@ -6,4 +6,5 @@ import './code-patch-correctness-test';
 import './chat-titling-test';
 import './responding-test';
 import './matrix-util-test';
+import './modality-test';
 import './locking-test';

--- a/packages/ai-bot/tests/modality-test.ts
+++ b/packages/ai-bot/tests/modality-test.ts
@@ -1,0 +1,78 @@
+import { module, test, assert } from 'qunit';
+import {
+  requiredModality,
+  modalityLabel,
+  isImageContentType,
+  isPdfContentType,
+  isAudioContentType,
+  isVideoContentType,
+} from '@cardstack/runtime-common/ai/modality';
+
+module('modality helpers', () => {
+  test('requiredModality maps image MIME types to image', () => {
+    assert.strictEqual(requiredModality('image/png'), 'image');
+    assert.strictEqual(requiredModality('image/jpeg'), 'image');
+    assert.strictEqual(requiredModality('image/webp'), 'image');
+    assert.strictEqual(requiredModality('image/gif'), 'image');
+  });
+
+  test('requiredModality maps PDF to file', () => {
+    assert.strictEqual(requiredModality('application/pdf'), 'file');
+  });
+
+  test('requiredModality maps audio MIME types to audio', () => {
+    assert.strictEqual(requiredModality('audio/mpeg'), 'audio');
+    assert.strictEqual(requiredModality('audio/wav'), 'audio');
+    assert.strictEqual(requiredModality('audio/ogg'), 'audio');
+    assert.strictEqual(requiredModality('audio/flac'), 'audio');
+    assert.strictEqual(requiredModality('audio/mp4'), 'audio');
+  });
+
+  test('requiredModality maps video MIME types to video', () => {
+    assert.strictEqual(requiredModality('video/mp4'), 'video');
+    assert.strictEqual(requiredModality('video/mpeg'), 'video');
+    assert.strictEqual(requiredModality('video/quicktime'), 'video');
+    assert.strictEqual(requiredModality('video/webm'), 'video');
+  });
+
+  test('requiredModality returns undefined for non-multimodal types', () => {
+    assert.strictEqual(requiredModality('text/plain'), undefined);
+    assert.strictEqual(requiredModality('application/json'), undefined);
+    assert.strictEqual(requiredModality('application/octet-stream'), undefined);
+    assert.strictEqual(requiredModality(undefined), undefined);
+  });
+
+  test('modalityLabel returns human-readable labels', () => {
+    assert.strictEqual(modalityLabel('image'), 'image files');
+    assert.strictEqual(modalityLabel('file'), 'PDF files');
+    assert.strictEqual(modalityLabel('audio'), 'audio files');
+    assert.strictEqual(modalityLabel('video'), 'video files');
+  });
+
+  test('isImageContentType correctly identifies image types', () => {
+    assert.true(isImageContentType('image/png'));
+    assert.true(isImageContentType('image/jpeg'));
+    assert.false(isImageContentType('audio/mpeg'));
+    assert.false(isImageContentType(undefined));
+  });
+
+  test('isPdfContentType correctly identifies PDF', () => {
+    assert.true(isPdfContentType('application/pdf'));
+    assert.false(isPdfContentType('application/json'));
+    assert.false(isPdfContentType(undefined));
+  });
+
+  test('isAudioContentType correctly identifies audio types', () => {
+    assert.true(isAudioContentType('audio/mpeg'));
+    assert.true(isAudioContentType('audio/wav'));
+    assert.false(isAudioContentType('video/mp4'));
+    assert.false(isAudioContentType(undefined));
+  });
+
+  test('isVideoContentType correctly identifies video types', () => {
+    assert.true(isVideoContentType('video/mp4'));
+    assert.true(isVideoContentType('video/webm'));
+    assert.false(isVideoContentType('audio/mpeg'));
+    assert.false(isVideoContentType(undefined));
+  });
+});

--- a/packages/ai-bot/tests/modality-test.ts
+++ b/packages/ai-bot/tests/modality-test.ts
@@ -6,6 +6,7 @@ import {
   isPdfContentType,
   isAudioContentType,
   isVideoContentType,
+  isTextBasedContentType,
 } from '@cardstack/runtime-common/ai/modality';
 
 module('modality helpers', () => {
@@ -74,5 +75,20 @@ module('modality helpers', () => {
     assert.true(isVideoContentType('video/webm'));
     assert.false(isVideoContentType('audio/mpeg'));
     assert.false(isVideoContentType(undefined));
+  });
+
+  test('isTextBasedContentType identifies text and card JSON types', () => {
+    assert.true(isTextBasedContentType('text/plain'));
+    assert.true(isTextBasedContentType('text/typescript'));
+    assert.true(isTextBasedContentType('text/html'));
+    assert.true(isTextBasedContentType('application/vnd.card+json'));
+    assert.false(isTextBasedContentType('application/json'));
+    assert.false(
+      isTextBasedContentType(
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      ),
+    );
+    assert.false(isTextBasedContentType('application/zip'));
+    assert.false(isTextBasedContentType(undefined));
   });
 });

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -5150,6 +5150,417 @@ new
       'cache_control should be set to ephemeral',
     );
   });
+
+  test('only the most recent message attachments include file content in the prompt', async () => {
+    // Policy: files attached to older messages should show metadata only,
+    // even if they are NOT re-attached in later messages.
+    // Only the most recent user message's attachments should include content.
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: '1',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Here is a config file',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/config.json',
+                url: 'http://test.com/config-uploaded.json',
+                name: 'config.json',
+                contentType: 'text/plain',
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '1' },
+        status: EventStatus.SENT,
+      },
+      {
+        type: 'm.room.message',
+        sender: '@aibot:localhost',
+        content: {
+          body: 'Got it.',
+          msgtype: 'm.text',
+          format: 'org.matrix.custom.html',
+          isStreamingFinished: true,
+        },
+        origin_server_ts: 2,
+        unsigned: { age: 1000, transaction_id: '2' },
+        event_id: '2',
+        room_id: 'room1',
+        status: EventStatus.SENT,
+      },
+      {
+        type: 'm.room.message',
+        event_id: '3',
+        origin_server_ts: 3,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Now here is a different file',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/utils.ts',
+                url: 'http://test.com/utils-uploaded.ts',
+                name: 'utils.ts',
+                contentType: 'text/plain',
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '3' },
+        status: EventStatus.SENT,
+      },
+    ];
+
+    mockResponses.set('http://test.com/config-uploaded.json', {
+      ok: true,
+      text: '{ "key": "value" }',
+    });
+    mockResponses.set('http://test.com/utils-uploaded.ts', {
+      ok: true,
+      text: 'export function hello() { return "world"; }',
+    });
+
+    let prompt = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      undefined,
+      undefined,
+      [],
+      fakeMatrixClient,
+    );
+
+    let userMessages = prompt.filter((m) => m.role === 'user');
+
+    // Older message's unique file (config.json) should show metadata only, not content
+    assert.ok(
+      (userMessages[0]?.content as string).includes('[config.json]'),
+      'First message mentions config.json',
+    );
+    assert.notOk(
+      (userMessages[0]?.content as string).includes('"key": "value"'),
+      'First message should NOT include config.json content (not the current message)',
+    );
+
+    // Most recent message's file (utils.ts) should include content
+    assert.ok(
+      (userMessages[1]?.content as string).includes(
+        'export function hello() { return "world"; }',
+      ),
+      'Most recent message should include utils.ts content',
+    );
+  });
+
+  test('unsupported MIME types show metadata without error prefix', async () => {
+    // Policy: binary files with unsupported MIME types should show
+    // useful metadata (name, content type, size) rather than an error.
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: '1',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Here is a PDF and an image',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/report.pdf',
+                url: 'http://test.com/report-uploaded.pdf',
+                name: 'report.pdf',
+                contentType: 'application/pdf',
+                contentSize: 102400,
+              },
+              {
+                sourceUrl: 'http://test.com/my-realm/diagram.png',
+                url: 'http://test.com/diagram-uploaded.png',
+                name: 'diagram.png',
+                contentType: 'image/png',
+                contentSize: 51200,
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '1' },
+        status: EventStatus.SENT,
+      },
+    ];
+
+    let prompt = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      undefined,
+      undefined,
+      [],
+      fakeMatrixClient,
+    );
+
+    let userMessages = prompt.filter((m) => m.role === 'user');
+    let content = userMessages[0]?.content as string;
+
+    // Should show metadata, not error messages
+    assert.ok(
+      content.includes('report.pdf'),
+      'Should mention the PDF file',
+    );
+    assert.ok(
+      content.includes('application/pdf'),
+      'Should show the content type for unsupported files',
+    );
+    assert.notOk(
+      content.includes('Error loading attached file'),
+      'Should NOT show error prefix for unsupported MIME types',
+    );
+    assert.notOk(
+      content.includes('Unsupported file type'),
+      'Should NOT show "Unsupported file type" error',
+    );
+  });
+
+  test('image attachments produce native image_url content parts', async () => {
+    // Policy: when an image file is attached, the prompt should use
+    // native image_url content parts (for vision-capable models)
+    // instead of text-only representation.
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: '1',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'What does this image show?',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/screenshot.png',
+                url: 'http://test.com/screenshot-uploaded.png',
+                name: 'screenshot.png',
+                contentType: 'image/png',
+                contentSize: 1024,
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '1' },
+        status: EventStatus.SENT,
+      },
+    ];
+
+    // Mock binary image download (base64 of a tiny PNG)
+    mockResponses.set('http://test.com/screenshot-uploaded.png', {
+      ok: true,
+      text: 'iVBORw0KGgoAAAANSUhEUg==',
+    });
+
+    let prompt = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      undefined,
+      undefined,
+      [],
+      fakeMatrixClient,
+    );
+
+    let userMessages = prompt.filter((m) => m.role === 'user');
+    let messageContent = userMessages[0]?.content;
+
+    // Content should be an array of content parts, not a plain string
+    assert.ok(
+      Array.isArray(messageContent),
+      'User message with image attachment should have content as ContentPart[]',
+    );
+
+    if (Array.isArray(messageContent)) {
+      let imageParts = messageContent.filter(
+        (part: any) => part.type === 'image_url',
+      );
+      assert.ok(
+        imageParts.length > 0,
+        'Should include at least one image_url content part',
+      );
+
+      let textParts = messageContent.filter(
+        (part: any) => part.type === 'text',
+      );
+      assert.ok(
+        textParts.length > 0,
+        'Should still include text content part with the message body',
+      );
+    }
+  });
+
+  test('read-file tool call is rejected for files not previously attached in the room', async () => {
+    // Policy: the AI should only be able to read files that were
+    // previously attached by the user in the same room.
+    // This prevents the AI from accessing arbitrary files.
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: '1',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Here is a file',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/allowed-file.ts',
+                url: 'http://test.com/allowed-uploaded.ts',
+                name: 'allowed-file.ts',
+                contentType: 'text/plain',
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '1' },
+        status: EventStatus.SENT,
+      },
+      {
+        type: 'm.room.message',
+        sender: '@aibot:localhost',
+        content: {
+          body: '',
+          msgtype: 'm.text',
+          format: 'org.matrix.custom.html',
+          isStreamingFinished: true,
+          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+            {
+              id: 'call_1',
+              name: 'read-file-for-ai-assistant_a831',
+              arguments: JSON.stringify({
+                attributes: {
+                  fileUrl: 'http://test.com/my-realm/not-attached-file.ts',
+                },
+                description: 'Reading a file the user did not attach',
+              }),
+            },
+          ],
+        },
+        origin_server_ts: 2,
+        unsigned: { age: 1000, transaction_id: '2' },
+        event_id: '2',
+        room_id: 'room1',
+        status: EventStatus.SENT,
+      },
+      {
+        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        event_id: '3',
+        origin_server_ts: 3,
+        content: {
+          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+          'm.relates_to': {
+            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            event_id: '2',
+            key: 'call_1',
+          },
+          result: JSON.stringify({
+            data: {
+              type: 'card',
+              attributes: {
+                fileForAttachment: {
+                  sourceUrl:
+                    'http://test.com/my-realm/not-attached-file.ts',
+                  url: 'http://test.com/not-attached-uploaded.ts',
+                  name: 'not-attached-file.ts',
+                  contentType: 'text/plain',
+                },
+              },
+            },
+          }),
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '3' },
+        status: EventStatus.SENT,
+      },
+    ];
+
+    mockResponses.set('http://test.com/allowed-uploaded.ts', {
+      ok: true,
+      text: 'export const allowed = true;',
+    });
+    mockResponses.set('http://test.com/not-attached-uploaded.ts', {
+      ok: true,
+      text: 'export const secret = "should not be readable";',
+    });
+
+    let prompt = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      undefined,
+      undefined,
+      [],
+      fakeMatrixClient,
+    );
+
+    // The command result for the unauthorized file should contain a rejection
+    let toolMessages = prompt.filter((m) => m.role === 'tool');
+    let rejectionMessage = toolMessages.find((m) =>
+      (m.content as string).includes('not-attached-file.ts'),
+    );
+
+    assert.ok(
+      rejectionMessage,
+      'Should have a tool result mentioning the unauthorized file',
+    );
+
+    if (rejectionMessage) {
+      let rejectionContent = rejectionMessage.content as string;
+      assert.ok(
+        rejectionContent.includes('not previously attached') ||
+          rejectionContent.includes('not authorized') ||
+          rejectionContent.includes('rejected'),
+        'Tool result should indicate the file was rejected because it was not previously attached in the room',
+      );
+      assert.notOk(
+        rejectionContent.includes('should not be readable'),
+        'The rejected file content should NOT appear in the prompt',
+      );
+    }
+  });
 });
 
 module('set model in prompt', (hooks) => {

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -5529,6 +5529,89 @@ new
     }
   });
 
+  test('image attachments fall back to canonical Matrix media URL when original URL fails', async () => {
+    let staleUrl =
+      'http://stale-host/_matrix/media/v3/download/localhost/abc123/file.png';
+    let fallbackUrl = fakeMatrixClient.mxcUrlToHttp(
+      'mxc://localhost/abc123',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+    assert.ok(fallbackUrl, 'matrix client should resolve canonical mxc URL');
+
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: '1',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Describe this workspace image',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/screenshot.png',
+                url: staleUrl,
+                name: 'screenshot.png',
+                contentType: 'image/png',
+                contentSize: 1024,
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '1' },
+        status: EventStatus.SENT,
+      },
+    ];
+
+    mockResponses.set(staleUrl, {
+      ok: false,
+      text: 'not found',
+    });
+    mockResponses.set(fallbackUrl!, {
+      ok: true,
+      text: 'iVBORw0KGgoAAAANSUhEUg==',
+    });
+
+    let prompt = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      undefined,
+      undefined,
+      [],
+      fakeMatrixClient,
+    );
+
+    let userMessages = prompt.filter((m) => m.role === 'user');
+    let messageContent = userMessages[0]?.content;
+    assert.ok(
+      Array.isArray(messageContent),
+      'User message should use content parts when fallback media URL succeeds',
+    );
+    if (Array.isArray(messageContent)) {
+      let imageParts = (messageContent as any[]).filter(
+        (part: any) => part.type === 'image_url',
+      );
+      assert.strictEqual(
+        imageParts.length,
+        1,
+        'Should include one image_url part after fallback download',
+      );
+    }
+  });
+
   test('read-file tool call is rejected for files not previously attached in the room', async () => {
     // Policy: the AI should only be able to read files that were
     // previously attached by the user in the same room.

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -1029,8 +1029,8 @@ Attached Files (files with newer versions don't show their content):
 Attached Files (files with newer versions don't show their content):
 [spaghetti-recipe.gts](http://test-realm-server/my-realm/spaghetti-recipe.gts)
 [best-friends.txt](http://test-realm-server/my-realm/best-friends.txt)
-[file-that-does-not-exist.txt](http://test.com/my-realm/file-that-does-not-exist.txt): Error loading attached file: HTTP error. Status: 404
-[example.pdf](http://test.com/my-realm/example.pdf): Error loading attached file: Unsupported file type: application/pdf. For now, only text files are supported.
+[file-that-does-not-exist.txt](http://test.com/my-realm/file-that-does-not-exist.txt)
+[example.pdf](http://test.com/my-realm/example.pdf): [application/pdf]
       `.trim(),
       ),
     );
@@ -5323,7 +5323,17 @@ new
     );
 
     let userMessages = prompt.filter((m) => m.role === 'user');
-    let content = userMessages[0]?.content as string;
+    let messageContent = userMessages[0]?.content;
+    // Content may be ContentPart[] when images are attached
+    let content: string;
+    if (Array.isArray(messageContent)) {
+      content = messageContent
+        .filter((p: any) => p.type === 'text')
+        .map((p: any) => p.text)
+        .join('\n');
+    } else {
+      content = messageContent as string;
+    }
 
     // Should show metadata, not error messages
     assert.ok(
@@ -5491,25 +5501,13 @@ new
         origin_server_ts: 3,
         content: {
           msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+          commandRequestId: 'call_1',
           'm.relates_to': {
             rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
             event_id: '2',
-            key: 'call_1',
+            key: 'applied',
           },
-          result: JSON.stringify({
-            data: {
-              type: 'card',
-              attributes: {
-                fileForAttachment: {
-                  sourceUrl:
-                    'http://test.com/my-realm/not-attached-file.ts',
-                  url: 'http://test.com/not-attached-uploaded.ts',
-                  name: 'not-attached-file.ts',
-                  contentType: 'text/plain',
-                },
-              },
-            },
-          }),
+          data: {},
         },
         sender: '@user:localhost',
         room_id: 'room1',

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -5353,6 +5353,97 @@ new
     );
   });
 
+  test('older image attachments still include metadata in text context', async () => {
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: '1',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Earlier message with image',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/diagram.png',
+                url: 'http://test.com/diagram-uploaded.png',
+                name: 'diagram.png',
+                contentType: 'image/png',
+                contentSize: 51200,
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '1' },
+        status: EventStatus.SENT,
+      },
+      {
+        type: 'm.room.message',
+        sender: '@aibot:localhost',
+        content: {
+          body: 'Acknowledged',
+          msgtype: 'm.text',
+          format: 'org.matrix.custom.html',
+          isStreamingFinished: true,
+        },
+        origin_server_ts: 2,
+        unsigned: { age: 1000, transaction_id: '2' },
+        event_id: '2',
+        room_id: 'room1',
+        status: EventStatus.SENT,
+      },
+      {
+        type: 'm.room.message',
+        event_id: '3',
+        origin_server_ts: 3,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Most recent text-only message',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '3' },
+        status: EventStatus.SENT,
+      },
+    ];
+
+    let prompt = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      undefined,
+      undefined,
+      [],
+      fakeMatrixClient,
+    );
+
+    let userMessages = prompt.filter((m) => m.role === 'user');
+    let firstMessage = userMessages[0]?.content as string;
+    assert.ok(
+      firstMessage.includes('diagram.png'),
+      'older image attachment should still be mentioned',
+    );
+    assert.ok(
+      firstMessage.includes('image/png'),
+      'older image attachment should include metadata',
+    );
+  });
+
   test('image attachments produce native image_url content parts', async () => {
     // Policy: when an image file is attached, the prompt should use
     // native image_url content parts (for vision-capable models)

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -5336,10 +5336,7 @@ new
     }
 
     // Should show metadata, not error messages
-    assert.ok(
-      content.includes('report.pdf'),
-      'Should mention the PDF file',
-    );
+    assert.ok(content.includes('report.pdf'), 'Should mention the PDF file');
     assert.ok(
       content.includes('application/pdf'),
       'Should show the content type for unsupported files',
@@ -5473,9 +5470,10 @@ new
         sender: '@aibot:localhost',
         content: {
           body: '',
-          msgtype: 'm.text',
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
           format: 'org.matrix.custom.html',
           isStreamingFinished: true,
+          data: {},
           [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
             {
               id: 'call_1',

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -5418,9 +5418,14 @@ new
       let imageParts = messageContent.filter(
         (part: any) => part.type === 'image_url',
       );
+      assert.strictEqual(
+        imageParts.length,
+        1,
+        'Should include exactly one image_url content part',
+      );
       assert.ok(
-        imageParts.length > 0,
-        'Should include at least one image_url content part',
+        imageParts[0].image_url.url.startsWith('data:image/png;base64,'),
+        'image_url should be a base64 data URL with correct content type',
       );
 
       let textParts = messageContent.filter(

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -5904,10 +5904,7 @@ new
     let userMessages = prompt.filter((m) => m.role === 'user');
     let messageContent = userMessages[0]?.content;
 
-    assert.ok(
-      Array.isArray(messageContent),
-      'Content should be ContentPart[]',
-    );
+    assert.ok(Array.isArray(messageContent), 'Content should be ContentPart[]');
 
     if (Array.isArray(messageContent)) {
       // Image should still be included
@@ -6010,10 +6007,7 @@ new
     let userMessages = prompt.filter((m) => m.role === 'user');
     let messageContent = userMessages[0]?.content;
 
-    assert.ok(
-      Array.isArray(messageContent),
-      'Content should be ContentPart[]',
-    );
+    assert.ok(Array.isArray(messageContent), 'Content should be ContentPart[]');
 
     if (Array.isArray(messageContent)) {
       let imageParts = (messageContent as any[]).filter(

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -5415,7 +5415,7 @@ new
     );
 
     if (Array.isArray(messageContent)) {
-      let imageParts = messageContent.filter(
+      let imageParts = (messageContent as any[]).filter(
         (part: any) => part.type === 'image_url',
       );
       assert.strictEqual(

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -93,6 +93,8 @@ module('buildPromptForModel', (hooks) => {
           status: response.ok ? 200 : 404,
           statusText: response.ok ? 'OK' : 'Not Found',
           text: async () => response.text,
+          arrayBuffer: async () =>
+            new TextEncoder().encode(response.text).buffer,
         };
       }
       throw new Error(`No mock response for ${url}`);

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -5612,6 +5612,430 @@ new
     }
   });
 
+  test('PDF attachment produces native file content part', async () => {
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: '1',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Please review this document',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/report.pdf',
+                url: 'http://test.com/report-uploaded.pdf',
+                name: 'report.pdf',
+                contentType: 'application/pdf',
+                contentSize: 102400,
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '1' },
+        status: EventStatus.SENT,
+      },
+    ];
+
+    mockResponses.set('http://test.com/report-uploaded.pdf', {
+      ok: true,
+      text: 'JVBERi0xLjQK', // fake PDF base64
+    });
+
+    let prompt = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      undefined,
+      undefined,
+      [],
+      fakeMatrixClient,
+    );
+
+    let userMessages = prompt.filter((m) => m.role === 'user');
+    let messageContent = userMessages[0]?.content;
+
+    assert.ok(
+      Array.isArray(messageContent),
+      'User message with PDF should have content as ContentPart[]',
+    );
+
+    if (Array.isArray(messageContent)) {
+      let fileParts = (messageContent as any[]).filter(
+        (part: any) => part.type === 'file',
+      );
+      assert.strictEqual(
+        fileParts.length,
+        1,
+        'Should include exactly one file content part',
+      );
+      assert.strictEqual(
+        fileParts[0].file.filename,
+        'report.pdf',
+        'file part should include the filename',
+      );
+      assert.ok(
+        fileParts[0].file.file_data.startsWith('data:application/pdf;base64,'),
+        'file_data should be a base64 data URL with PDF content type',
+      );
+    }
+  });
+
+  test('audio attachment produces native input_audio content part', async () => {
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: '1',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Transcribe this audio',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/recording.mp3',
+                url: 'http://test.com/recording-uploaded.mp3',
+                name: 'recording.mp3',
+                contentType: 'audio/mpeg',
+                contentSize: 204800,
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '1' },
+        status: EventStatus.SENT,
+      },
+    ];
+
+    mockResponses.set('http://test.com/recording-uploaded.mp3', {
+      ok: true,
+      text: 'AAAAAAAAAA==', // fake audio base64
+    });
+
+    let prompt = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      undefined,
+      undefined,
+      [],
+      fakeMatrixClient,
+    );
+
+    let userMessages = prompt.filter((m) => m.role === 'user');
+    let messageContent = userMessages[0]?.content;
+
+    assert.ok(
+      Array.isArray(messageContent),
+      'User message with audio should have content as ContentPart[]',
+    );
+
+    if (Array.isArray(messageContent)) {
+      let audioParts = (messageContent as any[]).filter(
+        (part: any) => part.type === 'input_audio',
+      );
+      assert.strictEqual(
+        audioParts.length,
+        1,
+        'Should include exactly one input_audio content part',
+      );
+      assert.strictEqual(
+        audioParts[0].input_audio.format,
+        'mp3',
+        'input_audio format should be mp3',
+      );
+      assert.ok(
+        audioParts[0].input_audio.data.length > 0,
+        'input_audio data should contain raw base64 (no data: prefix)',
+      );
+      assert.ok(
+        !audioParts[0].input_audio.data.startsWith('data:'),
+        'input_audio data should NOT have a data URL prefix',
+      );
+    }
+  });
+
+  test('video attachment produces native video_url content part', async () => {
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: '1',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'What happens in this video?',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/clip.mp4',
+                url: 'http://test.com/clip-uploaded.mp4',
+                name: 'clip.mp4',
+                contentType: 'video/mp4',
+                contentSize: 512000,
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '1' },
+        status: EventStatus.SENT,
+      },
+    ];
+
+    mockResponses.set('http://test.com/clip-uploaded.mp4', {
+      ok: true,
+      text: 'AAAAIGZ0eXA=', // fake MP4 base64
+    });
+
+    let prompt = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      undefined,
+      undefined,
+      [],
+      fakeMatrixClient,
+    );
+
+    let userMessages = prompt.filter((m) => m.role === 'user');
+    let messageContent = userMessages[0]?.content;
+
+    assert.ok(
+      Array.isArray(messageContent),
+      'User message with video should have content as ContentPart[]',
+    );
+
+    if (Array.isArray(messageContent)) {
+      let videoParts = (messageContent as any[]).filter(
+        (part: any) => part.type === 'video_url',
+      );
+      assert.strictEqual(
+        videoParts.length,
+        1,
+        'Should include exactly one video_url content part',
+      );
+      assert.ok(
+        videoParts[0].video_url.url.startsWith('data:video/mp4;base64,'),
+        'video_url should be a base64 data URL with video/mp4 content type',
+      );
+    }
+  });
+
+  test('unsupported modality is gated when inputModalities is set', async () => {
+    // Model only supports text and image — a PDF attachment should be
+    // excluded from media parts and a warning should appear in the text.
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: '1',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Review this document and image',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/report.pdf',
+                url: 'http://test.com/report-uploaded.pdf',
+                name: 'report.pdf',
+                contentType: 'application/pdf',
+                contentSize: 102400,
+              },
+              {
+                sourceUrl: 'http://test.com/my-realm/photo.png',
+                url: 'http://test.com/photo-uploaded.png',
+                name: 'photo.png',
+                contentType: 'image/png',
+                contentSize: 2048,
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '1' },
+        status: EventStatus.SENT,
+      },
+    ];
+
+    mockResponses.set('http://test.com/photo-uploaded.png', {
+      ok: true,
+      text: 'iVBORw0KGgoAAAANSUhEUg==',
+    });
+    // PDF mock intentionally omitted — should never be downloaded
+
+    let prompt = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      undefined,
+      undefined,
+      [],
+      fakeMatrixClient,
+      ['text', 'image'], // model supports text + image only
+    );
+
+    let userMessages = prompt.filter((m) => m.role === 'user');
+    let messageContent = userMessages[0]?.content;
+
+    assert.ok(
+      Array.isArray(messageContent),
+      'Content should be ContentPart[]',
+    );
+
+    if (Array.isArray(messageContent)) {
+      // Image should still be included
+      let imageParts = (messageContent as any[]).filter(
+        (part: any) => part.type === 'image_url',
+      );
+      assert.strictEqual(
+        imageParts.length,
+        1,
+        'Image should still be included when model supports it',
+      );
+
+      // PDF should NOT be included as a file part
+      let fileParts = (messageContent as any[]).filter(
+        (part: any) => part.type === 'file',
+      );
+      assert.strictEqual(
+        fileParts.length,
+        0,
+        'PDF should be excluded when model does not support file modality',
+      );
+
+      // Warning text should mention the gated file
+      let textContent = messageContent
+        .filter((p: any) => p.type === 'text')
+        .map((p: any) => p.text)
+        .join('\n');
+      assert.ok(
+        textContent.includes('report.pdf'),
+        'Warning should mention the excluded file name',
+      );
+      assert.ok(
+        textContent.includes('does not support'),
+        'Warning should explain the file was not sent',
+      );
+    }
+  });
+
+  test('all modalities sent when inputModalities is undefined', async () => {
+    // When no inputModalities is configured, all multimodal types should pass through.
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: '1',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Review these files',
+          data: {
+            context: {
+              tools: [],
+              submode: 'code',
+              functions: [],
+            },
+            attachedFiles: [
+              {
+                sourceUrl: 'http://test.com/my-realm/photo.png',
+                url: 'http://test.com/photo-uploaded.png',
+                name: 'photo.png',
+                contentType: 'image/png',
+                contentSize: 2048,
+              },
+              {
+                sourceUrl: 'http://test.com/my-realm/report.pdf',
+                url: 'http://test.com/report-uploaded.pdf',
+                name: 'report.pdf',
+                contentType: 'application/pdf',
+                contentSize: 102400,
+              },
+            ],
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '1' },
+        status: EventStatus.SENT,
+      },
+    ];
+
+    mockResponses.set('http://test.com/photo-uploaded.png', {
+      ok: true,
+      text: 'iVBORw0KGgoAAAANSUhEUg==',
+    });
+    mockResponses.set('http://test.com/report-uploaded.pdf', {
+      ok: true,
+      text: 'JVBERi0xLjQK',
+    });
+
+    // No inputModalities arg — defaults to undefined
+    let prompt = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      undefined,
+      undefined,
+      [],
+      fakeMatrixClient,
+    );
+
+    let userMessages = prompt.filter((m) => m.role === 'user');
+    let messageContent = userMessages[0]?.content;
+
+    assert.ok(
+      Array.isArray(messageContent),
+      'Content should be ContentPart[]',
+    );
+
+    if (Array.isArray(messageContent)) {
+      let imageParts = (messageContent as any[]).filter(
+        (part: any) => part.type === 'image_url',
+      );
+      let fileParts = (messageContent as any[]).filter(
+        (part: any) => part.type === 'file',
+      );
+      assert.strictEqual(imageParts.length, 1, 'Image should be included');
+      assert.strictEqual(fileParts.length, 1, 'PDF should be included');
+
+      let textContent = messageContent
+        .filter((p: any) => p.type === 'text')
+        .map((p: any) => p.text)
+        .join('\n');
+      assert.notOk(
+        textContent.includes('does not support'),
+        'No gating warning when inputModalities is undefined',
+      );
+    }
+  });
+
   test('read-file tool call is rejected for files not previously attached in the room', async () => {
     // Policy: the AI should only be able to read files that were
     // previously attached by the user in the same room.

--- a/packages/base/matrix-event.gts
+++ b/packages/base/matrix-event.gts
@@ -263,6 +263,7 @@ export interface ActiveLLMEvent extends RoomStateEvent {
     model: string;
     toolsSupported?: boolean;
     reasoningEffort?: string;
+    inputModalities?: string[];
   };
 }
 

--- a/packages/base/system-card.gts
+++ b/packages/base/system-card.gts
@@ -1,4 +1,11 @@
-import { CardDef, field, contains, linksToMany, linksTo } from './card-api';
+import {
+  CardDef,
+  field,
+  contains,
+  containsMany,
+  linksToMany,
+  linksTo,
+} from './card-api';
 import BooleanField from './boolean';
 import StringField from './string';
 import { getMenuItems } from '@cardstack/runtime-common';
@@ -21,6 +28,11 @@ export class ModelConfiguration extends CardDef {
   @field reasoningEffort = contains(StringField, {
     description:
       'Optional reasoning effort to pass when invoking this model (e.g. minimal, medium, maximal)',
+  });
+
+  @field inputModalities = containsMany(StringField, {
+    description:
+      'Input modalities supported by this model (e.g. text, image, file, audio, video)',
   });
 }
 

--- a/packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts
@@ -34,6 +34,7 @@ interface Signature {
   Args: {
     chooseCard: (cardId: string) => void;
     chooseFile: (file: FileDef) => void | Promise<void>;
+    chooseLocalFile: () => void | Promise<void>;
   };
 }
 
@@ -58,8 +59,17 @@ export default class AttachButton extends Component<Signature> {
           <CaptionsIcon width='16px' height='16px' />
           <span>{{option}}</span>
         </div>
-      {{else if (eq option 'Attach a File')}}
-        <div class='menu-option' data-test-attach-file-btn>
+      {{else if (eq option 'Attach a File (Workspace)')}}
+        <div
+          class='menu-option'
+          data-test-attach-workspace-file-btn
+          data-test-attach-file-btn
+        >
+          <FileCode width='16px' height='16px' />
+          <span>{{option}}</span>
+        </div>
+      {{else if (eq option 'Attach a File (Your Computer)')}}
+        <div class='menu-option' data-test-attach-local-file-btn>
           <FileCode width='16px' height='16px' />
           <span>{{option}}</span>
         </div>
@@ -81,7 +91,7 @@ export default class AttachButton extends Component<Signature> {
           .ember-basic-dropdown-content-wormhole-origin .attach-button__dropdown
         ) {
         border-radius: 10px;
-        width: 179px;
+        width: 256px;
         padding: 0;
         position: absolute;
         z-index: var(--boxel-layer-modal-urgent);
@@ -110,15 +120,21 @@ export default class AttachButton extends Component<Signature> {
   </template>
 
   get menuOptions(): string[] {
-    return ['Attach a Card', 'Attach a File'];
+    return [
+      'Attach a Card',
+      'Attach a File (Workspace)',
+      'Attach a File (Your Computer)',
+    ];
   }
 
   @action
   handleSelection(option: string) {
     if (option === 'Attach a Card') {
       this.onAttachCard();
-    } else if (option === 'Attach a File') {
+    } else if (option === 'Attach a File (Workspace)') {
       this.onChooseFile();
+    } else if (option === 'Attach a File (Your Computer)') {
+      this.onChooseLocalFile();
     }
   }
 
@@ -130,6 +146,11 @@ export default class AttachButton extends Component<Signature> {
   @action
   onChooseFile() {
     this.doChooseFile.perform();
+  }
+
+  @action
+  onChooseLocalFile() {
+    this.doChooseLocalFile.perform();
   }
 
   private chooseCardTask = restartableTask(async () => {
@@ -147,5 +168,9 @@ export default class AttachButton extends Component<Signature> {
       await this.args.chooseFile(chosenFile);
     }
     return chosenFile;
+  });
+
+  private doChooseLocalFile = restartableTask(async () => {
+    await this.args.chooseLocalFile();
   });
 }

--- a/packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts
@@ -33,7 +33,7 @@ interface Signature {
   Element: HTMLDivElement;
   Args: {
     chooseCard: (cardId: string) => void;
-    chooseFile: (file: FileDef) => void;
+    chooseFile: (file: FileDef) => void | Promise<void>;
   };
 }
 
@@ -144,7 +144,7 @@ export default class AttachButton extends Component<Signature> {
   private doChooseFile = restartableTask(async () => {
     let chosenFile: FileDef | undefined = await chooseFile();
     if (chosenFile) {
-      this.args.chooseFile(chosenFile);
+      await this.args.chooseFile(chosenFile);
     }
     return chosenFile;
   });

--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -28,6 +28,7 @@ import type OperatorModeStateService from '@cardstack/host/services/operator-mod
 import {
   requiredModality,
   modalityLabel,
+  isTextBasedContentType,
 } from '@cardstack/runtime-common/ai/modality';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
@@ -128,15 +129,20 @@ export default class AttachedItems extends Component<Signature> {
   };
 
   private getModalityWarning = (file: FileDef): string | undefined => {
-    let modalities = this.args.inputModalities;
-    if (!modalities) {
-      return undefined;
-    }
     let modality = requiredModality(file.contentType);
-    if (!modality || modalities.includes(modality)) {
+    if (modality) {
+      // Multimodal type — warn only if model doesn't support it
+      let modalities = this.args.inputModalities;
+      if (modalities && !modalities.includes(modality)) {
+        return `Model does not support ${modalityLabel(modality)}. Only metadata will be sent.`;
+      }
       return undefined;
     }
-    return `Model does not support ${modalityLabel(modality)}. Only metadata will be sent.`;
+    // Non-multimodal, non-text files only get metadata sent
+    if (!isTextBasedContentType(file.contentType)) {
+      return 'File content will be sent as metadata only.';
+    }
+    return undefined;
   };
 
   <template>

--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -25,6 +25,11 @@ import { urlForRealmLookup } from '@cardstack/host/lib/utils';
 
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
+import {
+  requiredModality,
+  modalityLabel,
+} from '@cardstack/runtime-common/ai/modality';
+
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 
@@ -46,6 +51,7 @@ interface Signature {
     autoAttachedCardTooltipMessage?: string;
     fileUploadStates?: ReadonlyMap<string, FileUploadState>;
     retryFileUpload?: (file: FileDef) => void;
+    inputModalities?: string[];
   };
 }
 
@@ -119,6 +125,18 @@ export default class AttachedItems extends Component<Signature> {
       return undefined;
     }
     return this.args.fileUploadStates?.get(sourceUrl)?.status;
+  };
+
+  private getModalityWarning = (file: FileDef): string | undefined => {
+    let modalities = this.args.inputModalities;
+    if (!modalities) {
+      return undefined;
+    }
+    let modality = requiredModality(file.contentType);
+    if (!modality || modalities.includes(modality)) {
+      return undefined;
+    }
+    return `Model does not support ${modalityLabel(modality)}. Only metadata will be sent.`;
   };
 
   <template>
@@ -207,6 +225,7 @@ export default class AttachedItems extends Component<Signature> {
                     @onRemove={{fn this.handleRemoveFile item}}
                     @uploadStatus={{this.getUploadStatus item}}
                     @onRetry={{if @retryFileUpload (fn @retryFileUpload item)}}
+                    @warningMessage={{this.getModalityWarning item}}
                     data-test-autoattached-file={{item.sourceUrl}}
                   />
                 </:trigger>
@@ -221,6 +240,7 @@ export default class AttachedItems extends Component<Signature> {
                 @onRemove={{fn this.handleRemoveFile item}}
                 @uploadStatus={{this.getUploadStatus item}}
                 @onRetry={{if @retryFileUpload (fn @retryFileUpload item)}}
+                @warningMessage={{this.getModalityWarning item}}
               />
             {{/if}}
           {{/if}}

--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -140,7 +140,7 @@ export default class AttachedItems extends Component<Signature> {
     }
     // Non-multimodal, non-text files only get metadata sent
     if (!isTextBasedContentType(file.contentType)) {
-      return 'File content will be sent as metadata only.';
+      return 'File type not supported. Will send file metadata only.';
     }
     return undefined;
   };

--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -15,6 +15,12 @@ import {
   isCardErrorJSONAPI,
 } from '@cardstack/runtime-common';
 
+import {
+  requiredModality,
+  modalityLabel,
+  isTextBasedContentType,
+} from '@cardstack/runtime-common/ai/modality';
+
 import CardPill from '@cardstack/host/components/card-pill';
 import FilePill from '@cardstack/host/components/file-pill';
 import type {
@@ -24,12 +30,6 @@ import type {
 import { urlForRealmLookup } from '@cardstack/host/lib/utils';
 
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-
-import {
-  requiredModality,
-  modalityLabel,
-  isTextBasedContentType,
-} from '@cardstack/runtime-common/ai/modality';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type { FileDef } from 'https://cardstack.com/base/file-api';

--- a/packages/host/app/components/ai-assistant/attachment-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/index.gts
@@ -34,6 +34,7 @@ interface Signature {
     autoAttachedCardTooltipMessage?: string;
     fileUploadStates?: ReadonlyMap<string, FileUploadState>;
     retryFileUpload?: (file: FileDef) => void;
+    inputModalities?: string[];
   };
   Blocks: {
     default: [
@@ -50,6 +51,7 @@ interface Signature {
         | 'isLoaded'
         | 'fileUploadStates'
         | 'retryFileUpload'
+        | 'inputModalities'
       >,
       WithBoundArgs<
         typeof AttachButton,
@@ -76,6 +78,7 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
         autoAttachedCardTooltipMessage=@autoAttachedCardTooltipMessage
         fileUploadStates=@fileUploadStates
         retryFileUpload=@retryFileUpload
+        inputModalities=@inputModalities
       )
       (component
         AttachButton

--- a/packages/host/app/components/ai-assistant/attachment-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/index.gts
@@ -29,6 +29,7 @@ interface Signature {
     chooseCard: (cardId: string) => void;
     removeCard: (cardId: string) => void;
     chooseFile: (file: FileDef) => void;
+    chooseLocalFile: () => void | Promise<void>;
     removeFile: (file: FileDef) => void;
     autoAttachedCardTooltipMessage?: string;
     fileUploadStates?: ReadonlyMap<string, FileUploadState>;
@@ -50,7 +51,10 @@ interface Signature {
         | 'fileUploadStates'
         | 'retryFileUpload'
       >,
-      WithBoundArgs<typeof AttachButton, 'chooseCard' | 'chooseFile'>,
+      WithBoundArgs<
+        typeof AttachButton,
+        'chooseCard' | 'chooseFile' | 'chooseLocalFile'
+      >,
     ];
   };
 }
@@ -73,7 +77,12 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
         fileUploadStates=@fileUploadStates
         retryFileUpload=@retryFileUpload
       )
-      (component AttachButton chooseCard=@chooseCard chooseFile=@chooseFile)
+      (component
+        AttachButton
+        chooseCard=@chooseCard
+        chooseFile=@chooseFile
+        chooseLocalFile=@chooseLocalFile
+      )
     }}
   </template>
 

--- a/packages/host/app/components/ai-assistant/attachment-picker/usage.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/usage.gts
@@ -38,6 +38,10 @@ export default class AiAssistantCardPickerUsage extends Component {
     }
   }
 
+  @action chooseLocalFile() {
+    // no-op in freestyle usage
+  }
+
   @action removeFile(file: FileDef) {
     let index = this.filesToAttach.findIndex(
       (f) => f.sourceUrl === file.sourceUrl,
@@ -59,6 +63,7 @@ export default class AiAssistantCardPickerUsage extends Component {
           @chooseCard={{this.chooseCard}}
           @removeCard={{this.removeCard}}
           @chooseFile={{this.chooseFile}}
+          @chooseLocalFile={{this.chooseLocalFile}}
           @removeFile={{this.removeFile}}
           @autoAttachedFiles={{this.autoAttachedFiles}}
           @filesToAttach={{this.filesToAttach}}

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -22,7 +22,7 @@ interface Signature {
     canSend: boolean;
     attachButton?: WithBoundArgs<
       typeof AttachButton,
-      'chooseCard' | 'chooseFile'
+      'chooseCard' | 'chooseFile' | 'chooseLocalFile'
     >;
   };
 }

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -19,6 +19,7 @@ interface Signature {
     value: string;
     onInput: (val: string) => void;
     onSend: () => void;
+    onPaste?: (event: ClipboardEvent) => void | Promise<void>;
     canSend: boolean;
     attachButton?: WithBoundArgs<
       typeof AttachButton,
@@ -44,6 +45,7 @@ export default class AiAssistantChatInput extends Component<Signature> {
           placeholder='Enter a prompt'
           rows='1'
           {{on 'input' (pick 'target.value' @onInput)}}
+          {{on 'paste' this.onPaste}}
           {{onKeyMod 'Shift+Enter' this.insertNewLine}}
           {{onKeyMod 'Enter' this.onSend}}
           data-test-boxel-input-id='ai-chat-input'
@@ -169,6 +171,11 @@ export default class AiAssistantChatInput extends Component<Signature> {
       return;
     }
     this.args.onSend();
+  }
+
+  @action
+  onPaste(event: Event) {
+    this.args.onPaste?.(event as ClipboardEvent);
   }
 
   @action

--- a/packages/host/app/components/file-pill.gts
+++ b/packages/host/app/components/file-pill.gts
@@ -36,8 +36,12 @@ interface FilePillSignature {
 export default class FilePill extends Component<FilePillSignature> {
   @service declare operatorModeStateService: OperatorModeStateService;
 
-  get component() {
-    return this.args.file.constructor.getComponent(this.args.file);
+  get displayName() {
+    let fileName = this.args.file.name?.trim();
+    if (fileName) {
+      return fileName;
+    }
+    return this.args.file.sourceUrl ?? 'Unnamed file';
   }
 
   @action
@@ -100,9 +104,9 @@ export default class FilePill extends Component<FilePillSignature> {
         />
       </:iconLeft>
       <:default>
-        <div class='file-content' title={{@file.name}}>
-          <this.component @format='atom' @displayContainer={{false}} />
-        </div>
+        <span class='file-name' title={{this.displayName}}>
+          {{this.displayName}}
+        </span>
       </:default>
       <:iconRight>
         {{#if (eq @uploadStatus 'error')}}
@@ -159,12 +163,15 @@ export default class FilePill extends Component<FilePillSignature> {
         border-style: solid;
       }
 
-      .file-content {
+      .file-name {
+        display: inline-block;
         max-width: 100px;
         max-height: 100%;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        color: var(--boxel-900);
+        font: var(--boxel-font-sm);
       }
       .remove-button {
         --boxel-icon-button-width: var(--boxel-icon-sm);

--- a/packages/host/app/components/file-pill.gts
+++ b/packages/host/app/components/file-pill.gts
@@ -103,11 +103,7 @@ export default class FilePill extends Component<FilePillSignature> {
         {{#if @warningMessage}}
           <Tooltip @placement='top'>
             <:trigger>
-              <TriangleAlert
-                class='warning-icon'
-                width='18'
-                height='18'
-              />
+              <TriangleAlert class='warning-icon' width='18' height='18' />
             </:trigger>
             <:content>
               {{@warningMessage}}

--- a/packages/host/app/components/file-pill.gts
+++ b/packages/host/app/components/file-pill.gts
@@ -6,8 +6,9 @@ import Component from '@glimmer/component';
 
 import FileCode from '@cardstack/boxel-icons/file-code';
 import RefreshCw from '@cardstack/boxel-icons/refresh-cw';
+import TriangleAlert from '@cardstack/boxel-icons/triangle-alert';
 
-import { IconButton, Pill } from '@cardstack/boxel-ui/components';
+import { IconButton, Pill, Tooltip } from '@cardstack/boxel-ui/components';
 import { cn, cssVar, eq } from '@cardstack/boxel-ui/helpers';
 import { IconX, Download } from '@cardstack/boxel-ui/icons';
 
@@ -26,6 +27,7 @@ interface FilePillSignature {
     borderType?: 'dashed' | 'solid';
     fileActionsEnabled?: boolean;
     uploadStatus?: FileUploadStatus;
+    warningMessage?: string;
     onClick?: () => void;
     onRemove?: () => void;
     onDownload?: () => void;
@@ -90,18 +92,34 @@ export default class FilePill extends Component<FilePillSignature> {
   <template>
     <Pill
       @kind={{this.pillKind}}
-      class={{cn 'file-pill' this.borderClass}}
+      class={{cn 'file-pill' this.borderClass has-warning=@warningMessage}}
       data-test-attached-file={{@file.sourceUrl}}
       data-test-file-upload-status={{@uploadStatus}}
+      data-test-file-modality-warning={{if @warningMessage 'true'}}
       {{on 'click' this.handleFileClick}}
       ...attributes
     >
       <:iconLeft>
-        <FileCode
-          width='18'
-          height='18'
-          style={{cssVar icon-color='#0031ff'}}
-        />
+        {{#if @warningMessage}}
+          <Tooltip @placement='top'>
+            <:trigger>
+              <TriangleAlert
+                class='warning-icon'
+                width='18'
+                height='18'
+              />
+            </:trigger>
+            <:content>
+              {{@warningMessage}}
+            </:content>
+          </Tooltip>
+        {{else}}
+          <FileCode
+            width='18'
+            height='18'
+            style={{cssVar icon-color='#0031ff'}}
+          />
+        {{/if}}
       </:iconLeft>
       <:default>
         <span class='file-name' title={{this.displayName}}>
@@ -163,6 +181,12 @@ export default class FilePill extends Component<FilePillSignature> {
         border-style: solid;
       }
 
+      .has-warning {
+        border-color: var(--boxel-warning-200);
+      }
+      .warning-icon {
+        color: var(--boxel-warning-200);
+      }
       .file-name {
         display: inline-block;
         max-width: 100px;

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -1265,10 +1265,16 @@ export default class Room extends Component<Signature> {
     if (!sourceUrl) return;
     this._fileUploadStates.set(sourceUrl, { status: 'uploading' });
     try {
-      await this.matrixService.uploadFiles([file]);
+      let [uploadedFile] = await this.matrixService.uploadFiles([file]);
+      let uploadedOrOriginal = uploadedFile ?? file;
       // Only update state if the file is still attached (guards against
       // race where file is removed while upload was in-flight).
-      if (this.filesToAttach?.find((f) => f.sourceUrl === sourceUrl)) {
+      let files = this.filesToAttach;
+      if (files?.find((f) => f.sourceUrl === sourceUrl)) {
+        let nextFiles = files.map((f) =>
+          f.sourceUrl === sourceUrl ? uploadedOrOriginal : f,
+        );
+        this.matrixService.setFilesToSend(this.args.roomId, nextFiles);
         this._fileUploadStates.set(sourceUrl, { status: 'complete' });
       }
     } catch (e: any) {

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -232,12 +232,29 @@ export default class Room extends Component<Signature> {
                 @scrollToFirstUnread={{this.scrollToFirstUnread}}
               />
             {{/if}}
-            <div class='chat-input-area' data-test-chat-input-area>
+            <div
+              class='chat-input-area'
+              data-test-chat-input-area
+              data-drop-zone-active={{this.isDropZoneActive}}
+              {{on 'dragover' this.handleChatInputDragOver}}
+              {{on 'dragenter' this.handleChatInputDragEnter}}
+              {{on 'dragleave' this.handleChatInputDragLeave}}
+              {{on 'drop' this.handleChatInputDrop}}
+            >
+              {{#if this.isDropZoneActive}}
+                <div
+                  class='chat-input-drop-hint'
+                  data-test-chat-input-drop-hint
+                >
+                  Drop file to attach
+                </div>
+              {{/if}}
               <AiAssistantChatInput
                 @attachButton={{AttachButton}}
                 @value={{this.messageToSend}}
                 @onInput={{this.setMessage}}
                 @onSend={{this.sendMessage}}
+                @onPaste={{this.handleChatInputPaste}}
                 @canSend={{this.canSend}}
                 data-test-message-field={{@roomId}}
               />
@@ -348,6 +365,26 @@ export default class Room extends Component<Signature> {
 
         timeline-scope: --chat-input-scroll-timeline;
       }
+      .chat-input-area[data-drop-zone-active='true'] {
+        box-shadow: inset 0 0 0 2px var(--boxel-dark);
+        background-color: #e8f0ff;
+      }
+      .chat-input-drop-hint {
+        position: absolute;
+        top: var(--boxel-sp-xs);
+        right: var(--boxel-sp-xs);
+        bottom: var(--boxel-sp-xs);
+        left: var(--boxel-sp-xs);
+        z-index: 3;
+        pointer-events: none;
+        color: var(--boxel-light-100);
+        font: 500 var(--boxel-font);
+        background-color: var(--boxel-darker-hover);
+        border-radius: var(--boxel-border-radius-lg);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
       .chat-input-area__bottom-actions {
         display: flex;
         align-items: center;
@@ -451,6 +488,8 @@ export default class Room extends Component<Signature> {
     | undefined;
   @tracked lastCanceledActionMessageId: string | undefined;
   @tracked acceptingAllLabel: string | undefined;
+  @tracked private isDropZoneActive = false;
+  private dropZoneDragDepth = 0;
 
   @service declare private store: StoreService;
   @service declare private cardService: CardService;
@@ -1075,21 +1114,115 @@ export default class Room extends Component<Signature> {
     if (!localFile) {
       return;
     }
+    await this.attachLocalFile(localFile);
+  }
 
+  @action
+  private handleChatInputDragOver(event: DragEvent) {
+    if (!this.isFileDrag(event.dataTransfer)) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDropZoneActive = true;
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'copy';
+    }
+  }
+
+  @action
+  private handleChatInputDragEnter(event: DragEvent) {
+    if (!this.isFileDrag(event.dataTransfer)) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    this.dropZoneDragDepth++;
+    this.isDropZoneActive = true;
+  }
+
+  @action
+  private handleChatInputDragLeave(event: DragEvent) {
+    if (!this.isFileDrag(event.dataTransfer) && !this.isDropZoneActive) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    this.dropZoneDragDepth = Math.max(0, this.dropZoneDragDepth - 1);
+    if (this.dropZoneDragDepth === 0) {
+      this.isDropZoneActive = false;
+    }
+  }
+
+  @action
+  private async handleChatInputDrop(event: DragEvent) {
+    let files = Array.from(event.dataTransfer?.files ?? []);
+    if (!files.length) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    this.dropZoneDragDepth = 0;
+    this.isDropZoneActive = false;
+
+    for (let file of files) {
+      await this.attachLocalFile(file);
+    }
+  }
+
+  @action
+  private async handleChatInputPaste(event: ClipboardEvent) {
+    let files = this.getClipboardFiles(event.clipboardData);
+    if (!files.length) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    for (let file of files) {
+      await this.attachLocalFile(file);
+    }
+  }
+
+  private getClipboardFiles(clipboardData: DataTransfer | null): File[] {
+    if (!clipboardData) {
+      return [];
+    }
+
+    let files = Array.from(clipboardData.files ?? []);
+    if (files.length) {
+      return files;
+    }
+
+    let itemFiles: File[] = [];
+    for (let item of Array.from(clipboardData.items ?? [])) {
+      if (item.kind !== 'file') {
+        continue;
+      }
+      let file = item.getAsFile();
+      if (file) {
+        itemFiles.push(file);
+      }
+    }
+
+    return itemFiles;
+  }
+
+  private isFileDrag(dataTransfer: DataTransfer | null | undefined): boolean {
+    if (!dataTransfer) {
+      return false;
+    }
+    return Array.from(dataTransfer.types ?? []).includes('Files');
+  }
+
+  private async attachLocalFile(localFile: File) {
     let bytes = new Uint8Array(await localFile.arrayBuffer());
     let file = await this.createLocalFileDef(localFile, bytes);
     let files = this.filesToAttach;
-    if (!files?.find((f) => f.sourceUrl === file.sourceUrl)) {
-      let contentType =
-        file.contentType || localFile.type || 'application/octet-stream';
-      await this.matrixService.prefetchLocalFileContent(
-        file,
-        bytes,
-        contentType,
-      );
-      this.matrixService.setFilesToSend(this.args.roomId, [...files, file]);
-      this.startFileUpload(file);
-    }
+    let contentType =
+      file.contentType || localFile.type || 'application/octet-stream';
+    await this.matrixService.prefetchLocalFileContent(file, bytes, contentType);
+    this.matrixService.setFilesToSend(this.args.roomId, [...files, file]);
+    this.startFileUpload(file);
   }
 
   @action

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -211,6 +211,7 @@ export default class Room extends Component<Signature> {
             @filesToAttach={{this.filesToAttach}}
             @fileUploadStates={{this.fileUploadStates}}
             @retryFileUpload={{this.retryFileUpload}}
+            @inputModalities={{@roomResource.activeInputModalities}}
             @autoAttachedCardTooltipMessage={{if
               (eq this.operatorModeStateService.state.submode Submodes.Code)
               'Current card is shared automatically'

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -1041,7 +1041,7 @@ export default class Room extends Component<Signature> {
   }
 
   @action
-  private chooseFile(file: FileDef) {
+  private async chooseFile(file: FileDef) {
     // handle the case where auto-attached file pill is clicked
     if (this.isAutoAttachedFile(file)) {
       this.removeAutoAttachedFile(file.sourceUrl ?? undefined);
@@ -1049,6 +1049,7 @@ export default class Room extends Component<Signature> {
 
     let files = this.filesToAttach;
     if (!files?.find((f) => f.sourceUrl === file.sourceUrl)) {
+      await this.matrixService.prefetchFileContent(file);
       this.matrixService.setFilesToSend(this.args.roomId, [...files, file]);
       this.startFileUpload(file);
     }

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -33,10 +33,13 @@ import { and, eq, not } from '@cardstack/boxel-ui/helpers';
 
 import type { ResolvedCodeRef } from '@cardstack/runtime-common';
 import {
+  baseFileRef,
+  formattedError,
   type getCard,
   GetCardContextName,
   internalKeyFor,
   isCardInstance,
+  resolveFileDefCodeRef,
 } from '@cardstack/runtime-common';
 import {
   DEFAULT_LLM_LIST,
@@ -54,16 +57,21 @@ import type { RoomResource } from '@cardstack/host/resources/room';
 import type AiAssistantPanelService from '@cardstack/host/services/ai-assistant-panel-service';
 import type CardService from '@cardstack/host/services/card-service';
 import type CommandService from '@cardstack/host/services/command-service';
+import type FileUploadService from '@cardstack/host/services/file-upload';
+import type LoaderService from '@cardstack/host/services/loader-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 import type { MonacoSDK } from '@cardstack/host/services/monaco-service';
+import type NetworkService from '@cardstack/host/services/network';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type PlaygroundPanelService from '@cardstack/host/services/playground-panel-service';
 import type SpecPanelService from '@cardstack/host/services/spec-panel-service';
 import type StoreService from '@cardstack/host/services/store';
+import { FileDefAttributesExtractor } from '@cardstack/host/utils/file-def-attributes-extractor';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 
+import { errorJsonApiToErrorEntry } from '../../lib/window-error-handler';
 import AiAssistantActionBar from '../ai-assistant/action-bar';
 import AiAssistantAttachmentPicker from '../ai-assistant/attachment-picker';
 import AiAssistantChatInput from '../ai-assistant/chat-input';
@@ -81,6 +89,8 @@ import RoomMessage from './room-message';
 import type RoomData from '../../lib/matrix-classes/room';
 import type { RoomSkill } from '../../resources/room';
 import type { MatrixEvent } from 'matrix-js-sdk';
+
+const LOCAL_SOURCE_URL_PREFIX = 'boxel-local://';
 
 interface Signature {
   Element: HTMLElement;
@@ -195,6 +205,7 @@ export default class Room extends Component<Signature> {
             @chooseCard={{this.chooseCard}}
             @removeCard={{this.removeCard}}
             @chooseFile={{this.chooseFile}}
+            @chooseLocalFile={{this.chooseLocalFile}}
             @removeFile={{this.removeFile}}
             @autoAttachedFiles={{this.autoAttachedFiles}}
             @filesToAttach={{this.filesToAttach}}
@@ -444,7 +455,10 @@ export default class Room extends Component<Signature> {
   @service declare private store: StoreService;
   @service declare private cardService: CardService;
   @service declare private commandService: CommandService;
+  @service('file-upload') declare private fileUpload: FileUploadService;
+  @service('loader-service') declare private loaderService: LoaderService;
   @service declare private matrixService: MatrixService;
+  @service declare private network: NetworkService;
   @service declare private operatorModeStateService: OperatorModeStateService;
   @service declare private playgroundPanelService: PlaygroundPanelService;
   @service declare private specPanelService: SpecPanelService;
@@ -1056,6 +1070,29 @@ export default class Room extends Component<Signature> {
   }
 
   @action
+  private async chooseLocalFile() {
+    let localFile = await this.fileUpload.pickLocalFile();
+    if (!localFile) {
+      return;
+    }
+
+    let bytes = new Uint8Array(await localFile.arrayBuffer());
+    let file = await this.createLocalFileDef(localFile, bytes);
+    let files = this.filesToAttach;
+    if (!files?.find((f) => f.sourceUrl === file.sourceUrl)) {
+      let contentType =
+        file.contentType || localFile.type || 'application/octet-stream';
+      await this.matrixService.prefetchLocalFileContent(
+        file,
+        bytes,
+        contentType,
+      );
+      this.matrixService.setFilesToSend(this.args.roomId, [...files, file]);
+      this.startFileUpload(file);
+    }
+  }
+
+  @action
   private isAutoAttachedFile(file: FileDef) {
     return this.autoAttachedFiles.some(
       (autoFile) => autoFile.sourceUrl === file.sourceUrl,
@@ -1125,6 +1162,80 @@ export default class Room extends Component<Signature> {
   @action
   private retryFileUpload(file: FileDef) {
     this.startFileUpload(file);
+  }
+
+  private buildLocalSourceUrl(fileName: string): string {
+    return `${LOCAL_SOURCE_URL_PREFIX}${uuidv4()}/${encodeURIComponent(fileName)}`;
+  }
+
+  private async createLocalFileDef(
+    localFile: File,
+    bytes: Uint8Array,
+  ): Promise<FileDef> {
+    let sourceUrl = this.buildLocalSourceUrl(localFile.name);
+    let fileDefCodeRef = resolveFileDefCodeRef(new URL(sourceUrl));
+    let extractor = new FileDefAttributesExtractor({
+      loaderService: this.loaderService,
+      network: this.network,
+      fileURL: sourceUrl,
+      fileDefCodeRef,
+      baseFileDefCodeRef: baseFileRef,
+      contentHash: undefined,
+      contentSize: bytes.byteLength,
+      fileBytes: bytes,
+      buildError: (errorUrl, error) => {
+        let errorJSONAPI = formattedError(errorUrl, error).errors[0];
+        return errorJsonApiToErrorEntry(errorJSONAPI);
+      },
+    });
+    let extracted = await extractor.extract();
+    if (extracted.status === 'error' || !extracted.resource) {
+      throw new Error(
+        extracted.error?.error?.message ??
+          `Failed to extract file metadata for ${localFile.name}`,
+      );
+    }
+
+    let classCodeRef =
+      extracted.resource.meta.adoptsFrom &&
+      'module' in extracted.resource.meta.adoptsFrom &&
+      'name' in extracted.resource.meta.adoptsFrom
+        ? extracted.resource.meta.adoptsFrom
+        : fileDefCodeRef;
+    let fileDefModule = await this.loaderService.loader.import<
+      Record<string, unknown>
+    >(classCodeRef.module);
+    let FileDefKlass = fileDefModule[classCodeRef.name] as
+      | (new (attributes: Record<string, unknown>) => FileDef)
+      | undefined;
+    let baseAttributes = extracted.resource.attributes as Record<
+      string,
+      unknown
+    >;
+    let attributes: Record<string, unknown> = {
+      ...baseAttributes,
+      sourceUrl,
+      url: sourceUrl,
+      name: (baseAttributes.name as string | undefined) ?? localFile.name,
+      contentSize:
+        (baseAttributes.contentSize as number | undefined) ?? bytes.byteLength,
+    };
+
+    if (!FileDefKlass) {
+      return this.matrixService.fileAPI.createFileDef({
+        sourceUrl,
+        url: sourceUrl,
+        name: localFile.name,
+        contentType:
+          (attributes.contentType as string | undefined) ??
+          localFile.type ??
+          'application/octet-stream',
+        contentHash: attributes.contentHash as string | undefined,
+        contentSize: attributes.contentSize as number | undefined,
+      });
+    }
+
+    return new FileDefKlass(attributes);
   }
 
   private doSendMessage = enqueueTask(

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -204,8 +204,8 @@ export default class Room extends Component<Signature> {
             @cardIdsToAttach={{this.cardIdsToAttach}}
             @chooseCard={{this.chooseCard}}
             @removeCard={{this.removeCard}}
-            @chooseFile={{this.chooseFile}}
-            @chooseLocalFile={{this.chooseLocalFile}}
+            @chooseFile={{perform this.chooseFileTask}}
+            @chooseLocalFile={{perform this.chooseLocalFileTask}}
             @removeFile={{this.removeFile}}
             @autoAttachedFiles={{this.autoAttachedFiles}}
             @filesToAttach={{this.filesToAttach}}
@@ -1094,8 +1094,7 @@ export default class Room extends Component<Signature> {
     );
   }
 
-  @action
-  private async chooseFile(file: FileDef) {
+  private chooseFileTask = enqueueTask(async (file: FileDef) => {
     // handle the case where auto-attached file pill is clicked
     if (this.isAutoAttachedFile(file)) {
       this.removeAutoAttachedFile(file.sourceUrl ?? undefined);
@@ -1105,18 +1104,17 @@ export default class Room extends Component<Signature> {
     if (!files?.find((f) => f.sourceUrl === file.sourceUrl)) {
       await this.matrixService.prefetchFileContent(file);
       this.matrixService.setFilesToSend(this.args.roomId, [...files, file]);
-      this.startFileUpload(file);
+      this.startFileUploadTask.perform(file);
     }
-  }
+  });
 
-  @action
-  private async chooseLocalFile() {
+  private chooseLocalFileTask = task(async () => {
     let localFile = await this.fileUpload.pickLocalFile();
     if (!localFile) {
       return;
     }
     await this.attachLocalFile(localFile);
-  }
+  });
 
   @action
   private handleChatInputDragOver(event: DragEvent) {
@@ -1156,7 +1154,7 @@ export default class Room extends Component<Signature> {
   }
 
   @action
-  private async handleChatInputDrop(event: DragEvent) {
+  private handleChatInputDrop(event: DragEvent) {
     let files = Array.from(event.dataTransfer?.files ?? []);
     if (!files.length) {
       return;
@@ -1165,24 +1163,25 @@ export default class Room extends Component<Signature> {
     event.stopPropagation();
     this.dropZoneDragDepth = 0;
     this.isDropZoneActive = false;
-
-    for (let file of files) {
-      await this.attachLocalFile(file);
-    }
+    this.attachLocalFilesTask.perform(files);
   }
 
   @action
-  private async handleChatInputPaste(event: ClipboardEvent) {
+  private handleChatInputPaste(event: ClipboardEvent) {
     let files = this.getClipboardFiles(event.clipboardData);
     if (!files.length) {
       return;
     }
     event.preventDefault();
     event.stopPropagation();
+    this.attachLocalFilesTask.perform(files);
+  }
+
+  private attachLocalFilesTask = enqueueTask(async (files: File[]) => {
     for (let file of files) {
       await this.attachLocalFile(file);
     }
-  }
+  });
 
   private getClipboardFiles(clipboardData: DataTransfer | null): File[] {
     if (!clipboardData) {
@@ -1223,7 +1222,7 @@ export default class Room extends Component<Signature> {
       file.contentType || localFile.type || 'application/octet-stream';
     await this.matrixService.prefetchLocalFileContent(file, bytes, contentType);
     this.matrixService.setFilesToSend(this.args.roomId, [...files, file]);
-    this.startFileUpload(file);
+    this.startFileUploadTask.perform(file);
   }
 
   @action
@@ -1261,7 +1260,7 @@ export default class Room extends Component<Signature> {
     }
   }
 
-  private async startFileUpload(file: FileDef) {
+  private startFileUploadTask = task(async (file: FileDef) => {
     let sourceUrl = file.sourceUrl;
     if (!sourceUrl) return;
     this._fileUploadStates.set(sourceUrl, { status: 'uploading' });
@@ -1288,7 +1287,7 @@ export default class Room extends Component<Signature> {
         });
       }
     }
-  }
+  });
 
   private get hasFileUploadIssues() {
     for (let [, state] of this._fileUploadStates) {
@@ -1301,7 +1300,7 @@ export default class Room extends Component<Signature> {
 
   @action
   private retryFileUpload(file: FileDef) {
-    this.startFileUpload(file);
+    this.startFileUploadTask.perform(file);
   }
 
   private buildLocalSourceUrl(fileName: string): string {

--- a/packages/host/app/components/operator-mode/choose-file-modal.gts
+++ b/packages/host/app/components/operator-mode/choose-file-modal.gts
@@ -8,6 +8,8 @@ import Component from '@glimmer/component';
 
 import { tracked } from '@glimmer/tracking';
 
+import { task } from 'ember-concurrency';
+import perform from 'ember-concurrency/helpers/perform';
 import onKeyMod from 'ember-keyboard/modifiers/on-key';
 
 import {
@@ -119,8 +121,7 @@ export default class ChooseFileModal extends Component<Signature> {
     }
   }
 
-  @action
-  private async pick(path: LocalPath | undefined) {
+  private pickTask = task(async (path: LocalPath | undefined) => {
     try {
       if (this.deferred && this.selectedRealm && path) {
         let fileURL = new RealmPaths(this.selectedRealm.url).fileURL(path);
@@ -140,7 +141,7 @@ export default class ChooseFileModal extends Component<Signature> {
     } finally {
       this.resetState();
     }
-  }
+  });
 
   @action
   private triggerUpload() {
@@ -269,7 +270,7 @@ export default class ChooseFileModal extends Component<Signature> {
 
   @action private handleKeydown(event: KeyboardEvent) {
     if (event.key === 'Escape') {
-      this.pick(undefined);
+      this.pickTask.perform(undefined);
     }
   }
 
@@ -427,7 +428,7 @@ export default class ChooseFileModal extends Component<Signature> {
     {{#if this.deferred}}
       <ModalContainer
         @title={{this.modalTitle}}
-        @onClose={{fn this.pick undefined}}
+        @onClose={{fn (perform this.pickTask) undefined}}
         @size='medium'
         @centered={{true}}
         {{on 'keydown' this.handleKeydown}}
@@ -471,7 +472,7 @@ export default class ChooseFileModal extends Component<Signature> {
                 @realmURL={{this.selectedRealm.url.href}}
                 @fileTypeFilter={{this.fileTypeFilter}}
                 @onFileSelected={{this.selectFile}}
-                @onFileConfirmed={{this.pick}}
+                @onFileConfirmed={{perform this.pickTask}}
                 @autoFocus={{true}}
               />
             {{/each}}
@@ -524,7 +525,7 @@ export default class ChooseFileModal extends Component<Signature> {
               <div class='footer-buttons'>
                 <BoxelButton
                   @size='tall'
-                  {{on 'click' (fn this.pick undefined)}}
+                  {{on 'click' (fn (perform this.pickTask) undefined)}}
                   {{onKeyMod 'Escape'}}
                   data-test-choose-file-modal-cancel-button
                 >
@@ -534,7 +535,8 @@ export default class ChooseFileModal extends Component<Signature> {
                   @kind='primary'
                   @size='tall'
                   @disabled={{this.isUploadBusy}}
-                  {{on 'click' (fn this.pick this.selectedFile)}}
+                  {{on 'click' (fn (perform this.pickTask) this.selectedFile)}}
+                  {{onKeyMod 'Enter'}}
                   data-test-choose-file-modal-add-button
                 >
                   Add

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -71,6 +71,13 @@ export interface FileDefManager {
   uploadFiles(files: FileDef[]): Promise<FileDef[]>;
 
   /**
+   * Pre-fetches file content at attach time so the bytes are captured
+   * before the user sends the message (guards against file modifications
+   * between attach and send).
+   */
+  prefetchFileContent(file: FileDef): Promise<void>;
+
+  /**
    * Downloads content from a file definition
    * @param fileDef File definition to download from
    * @returns Promise resolving to the downloaded content
@@ -93,7 +100,7 @@ export interface FileDefManager {
 export interface PrivilegedFileDefManager extends FileDefManager {
   contentHashCache: Map<string, string>;
   invalidUrlCache: Set<string>;
-  getContentHash(content: string): Promise<string>;
+  getContentHash(content: string | Uint8Array): Promise<string>;
 }
 
 export default class FileDefManagerImpl
@@ -105,6 +112,10 @@ export default class FileDefManagerImpl
   private inFlightBlobFetches: Map<string, Promise<Blob>> = new Map();
   contentHashCache: Map<string, string> = new Map(); // Maps content hash to URL
   invalidUrlCache: Set<string> = new Set(); // Cache for URLs where content hash validation failed
+  private prefetchedContent: Map<
+    string,
+    { bytes: Uint8Array; contentType: string }
+  > = new Map();
   private client: ExtendedClient;
   private getCardAPI: () => typeof CardAPI;
   private getFileAPI: () => typeof FileAPI;
@@ -139,19 +150,19 @@ export default class FileDefManagerImpl
     return this.getCardAPI();
   }
 
-  async getContentHash(content: string): Promise<string> {
+  async getContentHash(content: string | Uint8Array): Promise<string> {
     return md5(content);
   }
 
   private async getCachedUrlForContent(
-    content: string,
+    content: string | Uint8Array,
   ): Promise<string | null> {
     const hash = await this.getContentHash(content);
     return this.contentHashCache.get(hash) || null;
   }
 
   async uploadContentWithCaching(
-    content: string,
+    content: string | Uint8Array,
     contentType: string,
   ): Promise<string> {
     // Check if we already have this content cached
@@ -347,6 +358,20 @@ export default class FileDefManagerImpl
     return fileDefs;
   }
 
+  async prefetchFileContent(file: FileDef): Promise<void> {
+    if (!file.sourceUrl) {
+      throw new Error('File needs a realm server source URL to prefetch');
+    }
+    let response = await this.network.authedFetch(file.sourceUrl, {
+      headers: {
+        Accept: 'application/vnd.card+source',
+      },
+    });
+    let bytes = new Uint8Array(await response.arrayBuffer());
+    let contentType = response.headers.get('content-type') ?? '';
+    this.prefetchedContent.set(file.sourceUrl, { bytes, contentType });
+  }
+
   async uploadFiles(files: FileDef[]) {
     let uploadedFiles = await Promise.all(
       files.map(async (file) => {
@@ -354,24 +379,29 @@ export default class FileDefManagerImpl
           throw new Error('File needs a realm server source URL to upload');
         }
 
-        let response = await this.network.authedFetch(file.sourceUrl, {
-          headers: {
-            Accept: 'application/vnd.card+source',
-          },
-        });
-
-        // We only support uploading text files (code) for now.
-        // When we start supporting other file types (pdfs, images, etc)
-        // we will need to update this to support those file types.
-        let text = await response.text();
-        let contentType = response.headers.get('content-type');
+        let bytes: Uint8Array;
+        let contentType: string;
+        let cached = this.prefetchedContent.get(file.sourceUrl);
+        if (cached) {
+          bytes = cached.bytes;
+          contentType = cached.contentType;
+          this.prefetchedContent.delete(file.sourceUrl);
+        } else {
+          let response = await this.network.authedFetch(file.sourceUrl, {
+            headers: {
+              Accept: 'application/vnd.card+source',
+            },
+          });
+          bytes = new Uint8Array(await response.arrayBuffer());
+          contentType = response.headers.get('content-type') ?? '';
+        }
 
         if (!contentType) {
           throw new Error(`File has no content type: ${file.sourceUrl}`);
         }
-        file.url = await this.uploadContentWithCaching(text, contentType);
+        file.url = await this.uploadContentWithCaching(bytes, contentType);
         file.contentType = contentType;
-        file.contentHash = await this.getContentHash(text);
+        file.contentHash = await this.getContentHash(bytes);
 
         return file;
       }),

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -82,6 +82,7 @@ export interface FileDefManager {
    * between attach and send).
    */
   prefetchFileContent(file: FileDef): Promise<void>;
+  clearPrefetchedContent(): void;
 
   /**
    * Downloads content from a file definition
@@ -373,6 +374,10 @@ export default class FileDefManagerImpl
     let bytes = new Uint8Array(await response.arrayBuffer());
     let contentType = response.headers.get('content-type') ?? '';
     this.prefetchedContent.set(file.sourceUrl, { bytes, contentType });
+  }
+
+  clearPrefetchedContent(): void {
+    this.prefetchedContent.clear();
   }
 
   async uploadFiles(files: FileDef[]) {

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -419,11 +419,12 @@ export default class FileDefManagerImpl
 
         let bytes: Uint8Array;
         let contentType: string;
+        let usedPrefetchedContent = false;
         let cached = this.prefetchedContent.get(file.sourceUrl);
         if (cached) {
           bytes = cached.bytes;
           contentType = cached.contentType;
-          this.prefetchedContent.delete(file.sourceUrl);
+          usedPrefetchedContent = true;
         } else if (this.isLocalSourceUrl(file.sourceUrl)) {
           throw new Error(
             `Local file content is not available for upload: ${file.sourceUrl}`,
@@ -445,6 +446,10 @@ export default class FileDefManagerImpl
         file.contentType = contentType;
         file.contentHash = await this.getContentHash(bytes);
         file.contentSize = bytes.byteLength;
+        if (usedPrefetchedContent) {
+          // Keep prefetched bytes around if upload throws so retry can reuse them.
+          this.prefetchedContent.delete(file.sourceUrl);
+        }
 
         return file;
       }),

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -170,9 +170,12 @@ export default class FileDefManagerImpl
     if (cachedUrl) {
       return cachedUrl;
     }
-    let response = await this.client.uploadContent(content, {
-      type: contentType,
-    });
+    let response = await this.client.uploadContent(
+      content as XMLHttpRequestBodyInit,
+      {
+        type: contentType,
+      },
+    );
     let url = this.client.mxcUrlToHttp(
       response.content_uri,
       undefined,

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -205,8 +205,17 @@ export default class FileDefManagerImpl
     return url;
   }
 
-  // Validates the content hash against the contents of the URL and then updates the cache
+  private isMatrixMediaUrl(url: string): boolean {
+    return url.startsWith('mxc://') || url.includes('/_matrix/media/');
+  }
+
+  // Validates the content hash against the contents of the URL and then updates the cache.
+  // Only Matrix media URLs (mxc:// or /_matrix/media/) are cached; realm or
+  // other non-Matrix URLs are skipped to prevent cache poisoning.
   async recacheContentHash(contentHash: string, url: string) {
+    if (!this.isMatrixMediaUrl(url)) {
+      return;
+    }
     const canonicalKey = canonicalizeMatrixMediaKey(url) || url;
     if (this.invalidUrlCache.has(canonicalKey)) {
       // Skipping re-caching for this url as it was previously checked and is invalid

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -183,7 +183,14 @@ export default class FileDefManagerImpl
     content: string | Uint8Array,
   ): Promise<string | null> {
     const hash = await this.getContentHash(content);
-    return this.contentHashCache.get(hash) || null;
+    let cachedUrl = this.contentHashCache.get(hash) || null;
+    if (cachedUrl && !this.isMatrixMediaUrl(cachedUrl)) {
+      // Self-heal stale/poisoned cache entries so uploads always produce
+      // Matrix media URLs that the bot can fetch with Matrix auth.
+      this.contentHashCache.delete(hash);
+      return null;
+    }
+    return cachedUrl;
   }
 
   async uploadContentWithCaching(
@@ -217,6 +224,26 @@ export default class FileDefManagerImpl
 
   private isLocalSourceUrl(url: string): boolean {
     return url.startsWith(LOCAL_SOURCE_URL_PREFIX);
+  }
+
+  private resolveUploadContentType(
+    file: FileDef,
+    fetchedContentType?: string,
+  ): string {
+    let fetched = fetchedContentType?.trim() ?? '';
+    if (!fetched) {
+      return file.contentType ?? '';
+    }
+
+    let fetchedBase = fetched.split(';')[0]?.trim().toLowerCase();
+    if (
+      fetchedBase === 'application/octet-stream' ||
+      fetchedBase === 'application/vnd.card+source'
+    ) {
+      return file.contentType || fetched;
+    }
+
+    return fetched;
   }
 
   // Validates the content hash against the contents of the URL and then updates the cache.
@@ -391,7 +418,8 @@ export default class FileDefManagerImpl
       },
     });
     let bytes = new Uint8Array(await response.arrayBuffer());
-    let contentType = response.headers.get('content-type') ?? '';
+    let fetchedContentType = response.headers.get('content-type') ?? '';
+    let contentType = this.resolveUploadContentType(file, fetchedContentType);
     this.prefetchedContent.set(file.sourceUrl, { bytes, contentType });
   }
 
@@ -423,7 +451,7 @@ export default class FileDefManagerImpl
         let cached = this.prefetchedContent.get(file.sourceUrl);
         if (cached) {
           bytes = cached.bytes;
-          contentType = cached.contentType;
+          contentType = this.resolveUploadContentType(file, cached.contentType);
           usedPrefetchedContent = true;
         } else if (this.isLocalSourceUrl(file.sourceUrl)) {
           throw new Error(
@@ -436,7 +464,8 @@ export default class FileDefManagerImpl
             },
           });
           bytes = new Uint8Array(await response.arrayBuffer());
-          contentType = response.headers.get('content-type') ?? '';
+          let fetchedContentType = response.headers.get('content-type') ?? '';
+          contentType = this.resolveUploadContentType(file, fetchedContentType);
         }
 
         if (!contentType) {

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -50,6 +50,7 @@ interface CacheEntry {
 }
 
 const CACHE_EXPIRATION_MS = 30 * 60 * 1000; // 30 minutes
+const LOCAL_SOURCE_URL_PREFIX = 'boxel-local://';
 
 export interface FileDefManager {
   /**
@@ -82,6 +83,11 @@ export interface FileDefManager {
    * between attach and send).
    */
   prefetchFileContent(file: FileDef): Promise<void>;
+  prefetchLocalFileContent(
+    file: FileDef,
+    bytes: Uint8Array,
+    contentType: string,
+  ): Promise<void>;
   clearPrefetchedContent(): void;
 
   /**
@@ -207,6 +213,10 @@ export default class FileDefManagerImpl
 
   private isMatrixMediaUrl(url: string): boolean {
     return url.startsWith('mxc://') || url.includes('/_matrix/media/');
+  }
+
+  private isLocalSourceUrl(url: string): boolean {
+    return url.startsWith(LOCAL_SOURCE_URL_PREFIX);
   }
 
   // Validates the content hash against the contents of the URL and then updates the cache.
@@ -385,6 +395,17 @@ export default class FileDefManagerImpl
     this.prefetchedContent.set(file.sourceUrl, { bytes, contentType });
   }
 
+  async prefetchLocalFileContent(
+    file: FileDef,
+    bytes: Uint8Array,
+    contentType: string,
+  ): Promise<void> {
+    if (!file.sourceUrl) {
+      throw new Error('File needs a source URL to prefetch local content');
+    }
+    this.prefetchedContent.set(file.sourceUrl, { bytes, contentType });
+  }
+
   clearPrefetchedContent(): void {
     this.prefetchedContent.clear();
   }
@@ -403,6 +424,10 @@ export default class FileDefManagerImpl
           bytes = cached.bytes;
           contentType = cached.contentType;
           this.prefetchedContent.delete(file.sourceUrl);
+        } else if (this.isLocalSourceUrl(file.sourceUrl)) {
+          throw new Error(
+            `Local file content is not available for upload: ${file.sourceUrl}`,
+          );
         } else {
           let response = await this.network.authedFetch(file.sourceUrl, {
             headers: {
@@ -419,6 +444,7 @@ export default class FileDefManagerImpl
         file.url = await this.uploadContentWithCaching(bytes, contentType);
         file.contentType = contentType;
         file.contentHash = await this.getContentHash(bytes);
+        file.contentSize = bytes.byteLength;
 
         return file;
       }),

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -471,16 +471,25 @@ export default class FileDefManagerImpl
         if (!contentType) {
           throw new Error(`File has no content type: ${file.sourceUrl}`);
         }
-        file.url = await this.uploadContentWithCaching(bytes, contentType);
-        file.contentType = contentType;
-        file.contentHash = await this.getContentHash(bytes);
-        file.contentSize = bytes.byteLength;
+        let uploadedUrl = await this.uploadContentWithCaching(
+          bytes,
+          contentType,
+        );
+        let contentHash = await this.getContentHash(bytes);
+        let contentSize = bytes.byteLength;
         if (usedPrefetchedContent) {
           // Keep prefetched bytes around if upload throws so retry can reuse them.
           this.prefetchedContent.delete(file.sourceUrl);
         }
 
-        return file;
+        return this.fileAPI.createFileDef({
+          sourceUrl: file.sourceUrl,
+          name: file.name,
+          url: uploadedUrl,
+          contentType,
+          contentHash,
+          contentSize,
+        });
       }),
     );
 

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -11,6 +11,7 @@ import {
   baseRealm,
   codeRefWithAbsoluteURL,
   getClass,
+  inferContentType,
   SupportedMimeType,
   relativeTo,
   type LooseSingleCardDocument,
@@ -230,20 +231,34 @@ export default class FileDefManagerImpl
     file: FileDef,
     fetchedContentType?: string,
   ): string {
+    let hinted = file.contentType?.trim() ?? '';
     let fetched = fetchedContentType?.trim() ?? '';
-    if (!fetched) {
-      return file.contentType ?? '';
+
+    // Realm source reads (`Accept: application/vnd.card+source`) currently
+    // report text/plain for many files, including binaries, so prioritize a
+    // known file metadata type when available.
+    if (
+      hinted &&
+      hinted !== 'application/octet-stream' &&
+      hinted !== 'application/vnd.card+source'
+    ) {
+      return hinted;
     }
 
     let fetchedBase = fetched.split(';')[0]?.trim().toLowerCase();
     if (
+      !fetchedBase ||
       fetchedBase === 'application/octet-stream' ||
-      fetchedBase === 'application/vnd.card+source'
+      fetchedBase === 'application/vnd.card+source' ||
+      fetchedBase === 'text/plain'
     ) {
-      return file.contentType || fetched;
+      let inferred = inferContentType(file.name ?? file.sourceUrl ?? '');
+      if (inferred && inferred !== 'application/octet-stream') {
+        return inferred;
+      }
     }
 
-    return fetched;
+    return fetched || hinted;
   }
 
   // Validates the content hash against the contents of the URL and then updates the cache.

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -68,6 +68,12 @@ export interface FileDefManager {
     commandDefinitions: SkillModule.CommandField[],
   ): Promise<FileDef[]>;
 
+  /**
+   * Uploads files (text or binary) and returns their file definitions with
+   * content-hash-based deduplication.
+   * @param files Array of file definitions to upload
+   * @returns Promise resolving to array of uploaded file definitions
+   */
   uploadFiles(files: FileDef[]): Promise<FileDef[]>;
 
   /**
@@ -150,6 +156,18 @@ export default class FileDefManagerImpl
     return this.getCardAPI();
   }
 
+  private mxcToHttpUrl(mxcUrl: string): string | null {
+    return this.client.mxcUrlToHttp(
+      mxcUrl,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+  }
+
   async getContentHash(content: string | Uint8Array): Promise<string> {
     return md5(content);
   }
@@ -172,19 +190,9 @@ export default class FileDefManagerImpl
     }
     let response = await this.client.uploadContent(
       content as XMLHttpRequestBodyInit,
-      {
-        type: contentType,
-      },
+      { type: contentType },
     );
-    let url = this.client.mxcUrlToHttp(
-      response.content_uri,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      true,
-    );
+    let url = this.mxcToHttpUrl(response.content_uri);
     if (!url) {
       throw new Error('Failed to convert mxcUrl to http');
     }
@@ -204,7 +212,7 @@ export default class FileDefManagerImpl
       return;
     }
 
-    let content = await this.downloadContentAsText(url);
+    let content = await this.downloadContentAsBytes(url);
     const fetchedContentHash = await this.getContentHash(content);
     if (fetchedContentHash !== contentHash) {
       console.warn(
@@ -222,15 +230,7 @@ export default class FileDefManagerImpl
     let storedUrl = url;
     if (canonicalKey.startsWith('mxc://')) {
       try {
-        const maybeHttp = this.client.mxcUrlToHttp(
-          canonicalKey,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          true,
-        );
+        const maybeHttp = this.mxcToHttpUrl(canonicalKey);
         if (maybeHttp) {
           storedUrl = maybeHttp;
         }
@@ -498,6 +498,18 @@ export default class FileDefManagerImpl
     } finally {
       this.inFlightTextFetches.delete(canonicalKey);
     }
+  }
+
+  async downloadContentAsBytes(url: string): Promise<Uint8Array> {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${this.client.getAccessToken()}`,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP error. Status: ${response.status}`);
+    }
+    return new Uint8Array(await response.arrayBuffer());
   }
 
   async downloadAsFileInBrowser(serializedFile: SerializedFile) {

--- a/packages/host/app/lib/matrix-classes/room.ts
+++ b/packages/host/app/lib/matrix-classes/room.ts
@@ -104,6 +104,13 @@ export default class Room {
     return (event as ActiveLLMEvent)?.content.model;
   }
 
+  get activeInputModalities(): string[] | undefined {
+    let event = this._roomState?.events
+      .get(APP_BOXEL_ACTIVE_LLM)
+      ?.get('')?.event;
+    return (event as ActiveLLMEvent)?.content.inputModalities;
+  }
+
   get activeLLMMode(): LLMMode {
     let event = this._roomState?.events.get(APP_BOXEL_LLM_MODE)?.get('')?.event;
     return event && (event as any).content?.mode

--- a/packages/host/app/lib/matrix-classes/room.ts
+++ b/packages/host/app/lib/matrix-classes/room.ts
@@ -66,9 +66,7 @@ export default class Room {
   }
 
   hasActiveMember(userId: string): boolean {
-    let memberEvent = this._roomState?.events
-      .get('m.room.member')
-      ?.get(userId);
+    let memberEvent = this._roomState?.events.get('m.room.member')?.get(userId);
     let membership = memberEvent?.event.content?.membership;
     return membership === 'join' || membership === 'invite';
   }

--- a/packages/host/app/lib/matrix-classes/room.ts
+++ b/packages/host/app/lib/matrix-classes/room.ts
@@ -65,6 +65,14 @@ export default class Room {
     return memberIds.filter((id) => id !== undefined) as string[];
   }
 
+  hasActiveMember(userId: string): boolean {
+    let memberEvent = this._roomState?.events
+      .get('m.room.member')
+      ?.get(userId);
+    let membership = memberEvent?.event.content?.membership;
+    return membership === 'join' || membership === 'invite';
+  }
+
   notifyRoomStateUpdated(rs: MatrixSDK.RoomState) {
     this._roomState = rs; // this is usually the same object, but some internal state has changed. This assignment kicks off reactivity.
   }

--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -355,6 +355,10 @@ export class RoomResource extends Resource<Args> {
     );
   }
 
+  get activeInputModalities(): string[] | undefined {
+    return this.matrixRoom?.activeInputModalities;
+  }
+
   private get defaultLLM(): string {
     let systemCard = this.matrixService.systemCard;
     return (

--- a/packages/host/app/services/ai-assistant-panel-service.ts
+++ b/packages/host/app/services/ai-assistant-panel-service.ts
@@ -579,6 +579,11 @@ export default class AiAssistantPanelService extends Service {
       if (!resource.matrixRoom) {
         continue;
       }
+      if (
+        !resource.matrixRoom.memberIds.includes(this.matrixService.aiBotUserId)
+      ) {
+        continue;
+      }
       if (resource.name && resource.roomId) {
         sessions.push({
           roomId: resource.roomId,

--- a/packages/host/app/services/ai-assistant-panel-service.ts
+++ b/packages/host/app/services/ai-assistant-panel-service.ts
@@ -579,7 +579,9 @@ export default class AiAssistantPanelService extends Service {
       if (!resource.matrixRoom) {
         continue;
       }
-      if (!resource.matrixRoom.hasActiveMember(this.matrixService.aiBotUserId)) {
+      if (
+        !resource.matrixRoom.hasActiveMember(this.matrixService.aiBotUserId)
+      ) {
         continue;
       }
       if (resource.name && resource.roomId) {

--- a/packages/host/app/services/ai-assistant-panel-service.ts
+++ b/packages/host/app/services/ai-assistant-panel-service.ts
@@ -579,11 +579,6 @@ export default class AiAssistantPanelService extends Service {
       if (!resource.matrixRoom) {
         continue;
       }
-      if (
-        !resource.matrixRoom.memberIds.includes(this.matrixService.aiBotUserId)
-      ) {
-        continue;
-      }
       if (resource.name && resource.roomId) {
         sessions.push({
           roomId: resource.roomId,

--- a/packages/host/app/services/ai-assistant-panel-service.ts
+++ b/packages/host/app/services/ai-assistant-panel-service.ts
@@ -579,9 +579,7 @@ export default class AiAssistantPanelService extends Service {
       if (!resource.matrixRoom) {
         continue;
       }
-      if (
-        !resource.matrixRoom.memberIds.includes(this.matrixService.aiBotUserId)
-      ) {
+      if (!resource.matrixRoom.hasActiveMember(this.matrixService.aiBotUserId)) {
         continue;
       }
       if (resource.name && resource.roomId) {

--- a/packages/host/app/services/file-upload.ts
+++ b/packages/host/app/services/file-upload.ts
@@ -51,6 +51,7 @@ export default class FileUploadService extends Service {
   @service declare private store: StoreService;
 
   @tracked activeUploads: FileUploadTask[] = [];
+  private queuedLocalFilesForTesting: (File | null)[] = [];
 
   uploadFile(opts: { realmURL: URL; acceptTypes?: string }): FileUploadTask {
     let task = new FileUploadTask();
@@ -78,7 +79,30 @@ export default class FileUploadService extends Service {
     });
   }
 
+  async pickLocalFile(opts?: {
+    acceptTypes?: string;
+  }): Promise<File | undefined> {
+    if (isTesting()) {
+      let next = this.queuedLocalFilesForTesting.shift();
+      return next ?? undefined;
+    }
+    let file = await this._openNativeFilePicker(opts?.acceptTypes);
+    return file ?? undefined;
+  }
+
+  // Test seam for local-file attachment flow
+  __queueLocalFileForTesting(file: File | null) {
+    this.queuedLocalFilesForTesting.push(file);
+  }
+
   private _openFilePicker(task: FileUploadTask, acceptTypes?: string) {
+    this._openNativeFilePicker(acceptTypes).then((file) => {
+      task._resolveFile(file);
+    });
+  }
+
+  private _openNativeFilePicker(acceptTypes?: string): Promise<File | null> {
+    let deferred = new Deferred<File | null>();
     let input = document.createElement('input');
     input.type = 'file';
     input.accept = acceptTypes ?? '';
@@ -88,7 +112,7 @@ export default class FileUploadService extends Service {
     input.addEventListener(
       'change',
       () => {
-        task._resolveFile(input.files?.[0] ?? null);
+        deferred.fulfill(input.files?.[0] ?? null);
         input.remove();
       },
       { once: true },
@@ -96,13 +120,14 @@ export default class FileUploadService extends Service {
     input.addEventListener(
       'cancel',
       () => {
-        task._resolveFile(null);
+        deferred.fulfill(null);
         input.remove();
       },
       { once: true },
     );
 
     input.click();
+    return deferred.promise;
   }
 
   private async _processUpload(task: FileUploadTask, realmURL: URL) {

--- a/packages/host/app/services/matrix-sdk-loader.ts
+++ b/packages/host/app/services/matrix-sdk-loader.ts
@@ -300,6 +300,8 @@ function extendedClient({
           return fileDefManager.uploadCommandDefinitions.bind(fileDefManager);
         case 'uploadFiles':
           return fileDefManager.uploadFiles.bind(fileDefManager);
+        case 'prefetchFileContent':
+          return fileDefManager.prefetchFileContent.bind(fileDefManager);
         case 'downloadAsFileInBrowser':
           return fileDefManager.downloadAsFileInBrowser.bind(fileDefManager);
         case 'downloadCardFileDef':

--- a/packages/host/app/services/matrix-sdk-loader.ts
+++ b/packages/host/app/services/matrix-sdk-loader.ts
@@ -302,6 +302,8 @@ function extendedClient({
           return fileDefManager.uploadFiles.bind(fileDefManager);
         case 'prefetchFileContent':
           return fileDefManager.prefetchFileContent.bind(fileDefManager);
+        case 'clearPrefetchedContent':
+          return fileDefManager.clearPrefetchedContent.bind(fileDefManager);
         case 'downloadAsFileInBrowser':
           return fileDefManager.downloadAsFileInBrowser.bind(fileDefManager);
         case 'downloadCardFileDef':

--- a/packages/host/app/services/matrix-sdk-loader.ts
+++ b/packages/host/app/services/matrix-sdk-loader.ts
@@ -302,6 +302,8 @@ function extendedClient({
           return fileDefManager.uploadFiles.bind(fileDefManager);
         case 'prefetchFileContent':
           return fileDefManager.prefetchFileContent.bind(fileDefManager);
+        case 'prefetchLocalFileContent':
+          return fileDefManager.prefetchLocalFileContent.bind(fileDefManager);
         case 'clearPrefetchedContent':
           return fileDefManager.clearPrefetchedContent.bind(fileDefManager);
         case 'downloadAsFileInBrowser':

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -803,13 +803,7 @@ export default class MatrixService extends Service {
         roomIds.forEach((id) => this.roomsWaitingForSync.get(id)?.fulfill());
         break;
       case SlidingSyncState.RequestFinished:
-        for (let id of roomIds) {
-          let room = this.client.getRoom(id);
-          let botMembership = room?.getMember(this.aiBotUserId)?.membership;
-          if (botMembership === 'join' || botMembership === 'invite') {
-            this.aiRoomIds.add(id);
-          }
-        }
+        roomIds.forEach((id) => this.aiRoomIds.add(id));
         break;
     }
   };

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1717,6 +1717,7 @@ export default class MatrixService extends Service {
       model,
       toolsSupported: modelConfiguration?.toolsSupported,
       reasoningEffort: modelConfiguration?.reasoningEffort,
+      inputModalities: modelConfiguration?.inputModalities,
     });
   }
 

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1865,9 +1865,18 @@ export default class MatrixService extends Service {
     roomStates = Array.from(roomStateMap.values());
     for (let rs of roomStates) {
       // The auth rooms are not stored
-      // so we don't need to process the state updates
+      // so we don't need to process the state updates.
+      // However, a room may arrive before the bot has joined — re-check
+      // bot membership on every state update so the room is promoted to
+      // an AI room as soon as the bot's join/invite event lands.
       if (!this.aiRoomIds.has(rs.roomId)) {
-        continue;
+        let room = this.client.getRoom(rs.roomId);
+        let botMembership = room?.getMember(this.aiBotUserId)?.membership;
+        if (botMembership === 'join' || botMembership === 'invite') {
+          this.aiRoomIds.add(rs.roomId);
+        } else {
+          continue;
+        }
       }
       let roomData = this.ensureRoomData(rs.roomId);
       roomData.notifyRoomStateUpdated(rs);

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1162,9 +1162,13 @@ export default class MatrixService extends Service {
     attachedFiles: ReturnType<FileDef['serialize']>[];
   }> {
     let cardFileDefs = await this.uploadCards(attachedCards);
-    // Skip uploading files that were already eagerly uploaded (url is already
-    // set by startFileUpload); only upload files that don't yet have a url.
-    let filesToUpload = attachedFiles.filter((f) => !f.url);
+    // Skip files that were already eagerly uploaded by startFileUpload (url
+    // differs from sourceUrl, meaning it was set to a Matrix media URL).
+    // Files loaded from the store have url === sourceUrl (both the realm URL),
+    // so we must still upload those.
+    let filesToUpload = attachedFiles.filter(
+      (f) => !f.url || f.url === f.sourceUrl,
+    );
     if (filesToUpload.length > 0) {
       await this.uploadFiles(filesToUpload);
     }

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -791,14 +791,16 @@ export default class MatrixService extends Service {
     switch (state) {
       case SlidingSyncState.Complete:
         if (!this.initialSyncCompleted) {
-          Promise.allSettled([
-            this.drainRoomState(),
-            this.drainMembership(),
-            this.drainTimeline(),
-          ]).then(() => {
-            this.initialSyncCompleted = true;
-            this.initialSyncCompletedDeferred.fulfill();
-          });
+          // drainRoomState must complete before drainTimeline so that
+          // bot-membership checks can promote rooms into aiRoomIds before
+          // timeline events are routed (otherwise the first message can be
+          // misclassified as an auth-room event and dropped).
+          Promise.allSettled([this.drainRoomState(), this.drainMembership()])
+            .then(() => this.drainTimeline())
+            .then(() => {
+              this.initialSyncCompleted = true;
+              this.initialSyncCompletedDeferred.fulfill();
+            });
         }
         roomIds.forEach((id) => this.roomsWaitingForSync.get(id)?.fulfill());
         break;

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -803,7 +803,13 @@ export default class MatrixService extends Service {
         roomIds.forEach((id) => this.roomsWaitingForSync.get(id)?.fulfill());
         break;
       case SlidingSyncState.RequestFinished:
-        roomIds.forEach((id) => this.aiRoomIds.add(id));
+        for (let id of roomIds) {
+          let room = this.client.getRoom(id);
+          let botMembership = room?.getMember(this.aiBotUserId)?.membership;
+          if (botMembership === 'join' || botMembership === 'invite') {
+            this.aiRoomIds.add(id);
+          }
+        }
         break;
     }
   };

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1179,22 +1179,30 @@ export default class MatrixService extends Service {
   }> {
     let cardFileDefs = await this.uploadCards(attachedCards);
     // Skip files that were already eagerly uploaded by startFileUpload (url
-    // differs from sourceUrl, meaning it was set to a Matrix media URL).
-    // Files loaded from the store have url === sourceUrl (both the realm URL),
-    // so we must still upload those.
+    // differs from sourceUrl, meaning they already point to Matrix media).
     let filesToUpload = attachedFiles.filter(
       (f) => !f.url || f.url === f.sourceUrl,
     );
+    let uploadedBySourceUrl = new Map<string, FileDef>();
     if (filesToUpload.length > 0) {
-      await this.uploadFiles(filesToUpload);
+      let uploaded = await this.uploadFiles(filesToUpload);
+      for (let file of uploaded) {
+        if (file.sourceUrl) {
+          uploadedBySourceUrl.set(file.sourceUrl, file);
+        }
+      }
     }
-    // Preserve original order; freshly uploaded files now have url set on them.
-    let uploadedFileDefs = attachedFiles;
+    let filesForMessage = attachedFiles.map((file) => {
+      let replacement = file.sourceUrl
+        ? uploadedBySourceUrl.get(file.sourceUrl)
+        : undefined;
+      return replacement ?? file;
+    });
 
     return {
       context,
       attachedCards: cardFileDefs.map((file: FileDef) => file.serialize()),
-      attachedFiles: uploadedFileDefs.map((file: FileDef) => file.serialize()),
+      attachedFiles: filesForMessage.map((file: FileDef) => file.serialize()),
     };
   }
 

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -32,8 +32,6 @@ import {
   logger,
   isCardInstance,
   Deferred,
-  baseRealm,
-  testRealmURL,
   SEARCH_MARKER,
   REPLACE_MARKER,
   SEPARATOR_MARKER,
@@ -791,27 +789,19 @@ export default class MatrixService extends Service {
     switch (state) {
       case SlidingSyncState.Complete:
         if (!this.initialSyncCompleted) {
-          // drainRoomState must complete before drainTimeline so that
-          // bot-membership checks can promote rooms into aiRoomIds before
-          // timeline events are routed (otherwise the first message can be
-          // misclassified as an auth-room event and dropped).
-          Promise.allSettled([this.drainRoomState(), this.drainMembership()])
-            .then(() => this.drainTimeline())
-            .then(() => {
-              this.initialSyncCompleted = true;
-              this.initialSyncCompletedDeferred.fulfill();
-            });
+          Promise.allSettled([
+            this.drainRoomState(),
+            this.drainMembership(),
+            this.drainTimeline(),
+          ]).then(() => {
+            this.initialSyncCompleted = true;
+            this.initialSyncCompletedDeferred.fulfill();
+          });
         }
         roomIds.forEach((id) => this.roomsWaitingForSync.get(id)?.fulfill());
         break;
       case SlidingSyncState.RequestFinished:
-        for (let id of roomIds) {
-          let room = this.client.getRoom(id);
-          let botMembership = room?.getMember(this.aiBotUserId)?.membership;
-          if (botMembership === 'join' || botMembership === 'invite') {
-            this.aiRoomIds.add(id);
-          }
-        }
+        roomIds.forEach((id) => this.aiRoomIds.add(id));
         break;
     }
   };
@@ -1295,91 +1285,14 @@ export default class MatrixService extends Service {
       defaultSkills = interactModeDefaultSkills;
     }
 
-    let skillsRealmUrl = new URL(ENV.resolvedSkillsRealmURL).href;
-    let fallbackRealmUrls = new Set<string>(
-      Object.keys(this.realm.allRealmsInfo),
-    );
-    try {
-      let accountData = await this.client.getAccountDataFromServer(
-        APP_BOXEL_REALMS_EVENT_TYPE,
-      );
-      for (let realmUrl of accountData?.realms ?? []) {
-        fallbackRealmUrls.add(realmUrl);
-      }
-    } catch (_error) {
-      // We may still have local realm metadata in this.realm.allRealmsInfo.
-    }
-    if (isTesting()) {
-      fallbackRealmUrls.add(testRealmURL);
-    }
-
-    let loadedSkills = (
+    return (
       await Promise.all(
         defaultSkills.map(async (skillCardURL) => {
-          let maybeCard = await this.loadSkillCardWithRetry(skillCardURL);
-          if (maybeCard) {
-            return maybeCard;
-          }
-
-          if (!skillCardURL.startsWith(skillsRealmUrl)) {
-            return undefined;
-          }
-
-          let relativeSkillPath = skillCardURL.slice(skillsRealmUrl.length);
-          let baseRealmSkillUrl = baseRealm.fileURL(relativeSkillPath).href;
-          let fallbackCard =
-            await this.loadSkillCardWithRetry(baseRealmSkillUrl);
-          if (fallbackCard) {
-            return fallbackCard;
-          }
-
-          for (let realmUrl of fallbackRealmUrls) {
-            let normalizedRealmUrl = realmUrl.endsWith('/')
-              ? realmUrl
-              : `${realmUrl}/`;
-            let candidateSkillUrl = `${normalizedRealmUrl}${relativeSkillPath}`;
-            if (
-              candidateSkillUrl === skillCardURL ||
-              candidateSkillUrl === baseRealmSkillUrl
-            ) {
-              continue;
-            }
-            let candidate =
-              await this.loadSkillCardWithRetry(candidateSkillUrl);
-            if (candidate) {
-              return candidate;
-            }
-          }
-          return undefined;
+          let maybeCard = await this.store.get<SkillModule.Skill>(skillCardURL);
+          return isCardInstance(maybeCard) ? maybeCard : undefined;
         }),
       )
     ).filter(Boolean) as SkillModule.Skill[];
-
-    return loadedSkills;
-  }
-
-  private async loadSkillCardWithRetry(
-    cardId: string,
-  ): Promise<SkillModule.Skill | undefined> {
-    let maxAttempts = isTesting() ? 8 : 2;
-    let delayMs = isTesting() ? 150 : 50;
-
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      try {
-        let maybeCard = await this.store.get<SkillModule.Skill>(cardId);
-        if (isCardInstance(maybeCard)) {
-          return maybeCard;
-        }
-      } catch {
-        // Retry because skill cards may not be queryable until realm indexing completes.
-      }
-
-      if (attempt < maxAttempts) {
-        await timeout(delayMs);
-      }
-    }
-
-    return undefined;
   }
 
   @cached
@@ -1867,18 +1780,9 @@ export default class MatrixService extends Service {
     roomStates = Array.from(roomStateMap.values());
     for (let rs of roomStates) {
       // The auth rooms are not stored
-      // so we don't need to process the state updates.
-      // However, a room may arrive before the bot has joined — re-check
-      // bot membership on every state update so the room is promoted to
-      // an AI room as soon as the bot's join/invite event lands.
+      // so we don't need to process the state updates
       if (!this.aiRoomIds.has(rs.roomId)) {
-        let room = this.client.getRoom(rs.roomId);
-        let botMembership = room?.getMember(this.aiBotUserId)?.membership;
-        if (botMembership === 'join' || botMembership === 'invite') {
-          this.aiRoomIds.add(rs.roomId);
-        } else {
-          continue;
-        }
+        continue;
       }
       let roomData = this.ensureRoomData(rs.roomId);
       roomData.notifyRoomStateUpdated(rs);

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -32,6 +32,8 @@ import {
   logger,
   isCardInstance,
   Deferred,
+  baseRealm,
+  testRealmURL,
   SEARCH_MARKER,
   REPLACE_MARKER,
   SEPARATOR_MARKER,
@@ -801,7 +803,13 @@ export default class MatrixService extends Service {
         roomIds.forEach((id) => this.roomsWaitingForSync.get(id)?.fulfill());
         break;
       case SlidingSyncState.RequestFinished:
-        roomIds.forEach((id) => this.aiRoomIds.add(id));
+        for (let id of roomIds) {
+          let room = this.client.getRoom(id);
+          let botMembership = room?.getMember(this.aiBotUserId)?.membership;
+          if (botMembership === 'join' || botMembership === 'invite') {
+            this.aiRoomIds.add(id);
+          }
+        }
         break;
     }
   };
@@ -1093,6 +1101,14 @@ export default class MatrixService extends Service {
     return await this.client.prefetchFileContent(file);
   }
 
+  async prefetchLocalFileContent(
+    file: FileDef,
+    bytes: Uint8Array,
+    contentType: string,
+  ) {
+    return await this.client.prefetchLocalFileContent(file, bytes, contentType);
+  }
+
   async fetchMatrixHostedFile(matrixFileUrl: string) {
     let response = await fetch(matrixFileUrl, {
       headers: {
@@ -1269,14 +1285,91 @@ export default class MatrixService extends Service {
       defaultSkills = interactModeDefaultSkills;
     }
 
-    return (
+    let skillsRealmUrl = new URL(ENV.resolvedSkillsRealmURL).href;
+    let fallbackRealmUrls = new Set<string>(
+      Object.keys(this.realm.allRealmsInfo),
+    );
+    try {
+      let accountData = await this.client.getAccountDataFromServer(
+        APP_BOXEL_REALMS_EVENT_TYPE,
+      );
+      for (let realmUrl of accountData?.realms ?? []) {
+        fallbackRealmUrls.add(realmUrl);
+      }
+    } catch (_error) {
+      // We may still have local realm metadata in this.realm.allRealmsInfo.
+    }
+    if (isTesting()) {
+      fallbackRealmUrls.add(testRealmURL);
+    }
+
+    let loadedSkills = (
       await Promise.all(
         defaultSkills.map(async (skillCardURL) => {
-          let maybeCard = await this.store.get<SkillModule.Skill>(skillCardURL);
-          return isCardInstance(maybeCard) ? maybeCard : undefined;
+          let maybeCard = await this.loadSkillCardWithRetry(skillCardURL);
+          if (maybeCard) {
+            return maybeCard;
+          }
+
+          if (!skillCardURL.startsWith(skillsRealmUrl)) {
+            return undefined;
+          }
+
+          let relativeSkillPath = skillCardURL.slice(skillsRealmUrl.length);
+          let baseRealmSkillUrl = baseRealm.fileURL(relativeSkillPath).href;
+          let fallbackCard =
+            await this.loadSkillCardWithRetry(baseRealmSkillUrl);
+          if (fallbackCard) {
+            return fallbackCard;
+          }
+
+          for (let realmUrl of fallbackRealmUrls) {
+            let normalizedRealmUrl = realmUrl.endsWith('/')
+              ? realmUrl
+              : `${realmUrl}/`;
+            let candidateSkillUrl = `${normalizedRealmUrl}${relativeSkillPath}`;
+            if (
+              candidateSkillUrl === skillCardURL ||
+              candidateSkillUrl === baseRealmSkillUrl
+            ) {
+              continue;
+            }
+            let candidate =
+              await this.loadSkillCardWithRetry(candidateSkillUrl);
+            if (candidate) {
+              return candidate;
+            }
+          }
+          return undefined;
         }),
       )
     ).filter(Boolean) as SkillModule.Skill[];
+
+    return loadedSkills;
+  }
+
+  private async loadSkillCardWithRetry(
+    cardId: string,
+  ): Promise<SkillModule.Skill | undefined> {
+    let maxAttempts = isTesting() ? 8 : 2;
+    let delayMs = isTesting() ? 150 : 50;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        let maybeCard = await this.store.get<SkillModule.Skill>(cardId);
+        if (isCardInstance(maybeCard)) {
+          return maybeCard;
+        }
+      } catch {
+        // Retry because skill cards may not be queryable until realm indexing completes.
+      }
+
+      if (attempt < maxAttempts) {
+        await timeout(delayMs);
+      }
+    }
+
+    return undefined;
   }
 
   @cached

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1089,6 +1089,10 @@ export default class MatrixService extends Service {
     return await this.client.uploadFiles(files);
   }
 
+  async prefetchFileContent(file: FileDef) {
+    return await this.client.prefetchFileContent(file);
+  }
+
   async fetchMatrixHostedFile(matrixFileUrl: string) {
     let response = await fetch(matrixFileUrl, {
       headers: {

--- a/packages/host/app/utils/file-def-attributes-extractor.ts
+++ b/packages/host/app/utils/file-def-attributes-extractor.ts
@@ -50,6 +50,7 @@ export class FileDefAttributesExtractor {
   #baseFileDefCodeRef: ResolvedCodeRef;
   #contentHash: string | undefined;
   #contentSize: number | undefined;
+  #fileBytes: Uint8Array | undefined;
   #buildError: (url: string, error: unknown) => RenderError;
   #streamsPromise: Promise<
     [
@@ -69,6 +70,7 @@ export class FileDefAttributesExtractor {
     baseFileDefCodeRef,
     contentHash,
     contentSize,
+    fileBytes,
     buildError,
   }: {
     loaderService: LoaderService;
@@ -79,6 +81,7 @@ export class FileDefAttributesExtractor {
     baseFileDefCodeRef: ResolvedCodeRef;
     contentHash: string | undefined;
     contentSize: number | undefined;
+    fileBytes?: Uint8Array;
     buildError: (url: string, error: unknown) => RenderError;
   }) {
     this.#loaderService = loaderService;
@@ -89,6 +92,7 @@ export class FileDefAttributesExtractor {
     this.#baseFileDefCodeRef = baseFileDefCodeRef;
     this.#contentHash = contentHash;
     this.#contentSize = contentSize;
+    this.#fileBytes = fileBytes;
     this.#buildError = buildError;
   }
 
@@ -226,6 +230,10 @@ export class FileDefAttributesExtractor {
   async #getStreams() {
     if (!this.#streamsPromise) {
       this.#streamsPromise = (async () => {
+        if (this.#fileBytes) {
+          return [this.#fileBytes, this.#fileBytes];
+        }
+
         let response: Response;
         try {
           let request = new Request(this.#fileURL, {

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -644,10 +644,10 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     const mxcUrl = attachedCard.url;
 
     assert.ok(mxcUrl, 'Attached card has a URL (mxc)');
-    // The mock matrix server uses http://mock-server/ for its mxc content
+    // The mock matrix server uses http://mock-server/_matrix/media/ for its mxc content
     assert.ok(
-      mxcUrl.startsWith('http://mock-server/'),
-      `Card URL "${mxcUrl}" should start with http://mock-server/`,
+      mxcUrl.startsWith('http://mock-server/_matrix/media/'),
+      `Card URL "${mxcUrl}" should start with http://mock-server/_matrix/media/`,
     );
 
     // Download the card file def

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -1081,7 +1081,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await click('[data-test-file="person.gts"]');
     await click('[data-test-choose-file-modal-add-button]');
     assert.dom('[data-test-attached-file]').exists({ count: 1 });
-    assert.dom('[data-test-attached-file]').hasText('person');
+    assert.dom('[data-test-attached-file]').hasText('person.gts');
     // Add attachment item
     await click('[data-test-attach-button]');
     await click('[data-test-attach-file-btn]');
@@ -1090,16 +1090,16 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     assert.dom('[data-test-attached-file]').exists({ count: 2 });
     assert
       .dom(`[data-test-attached-file="${testRealmURL}person.gts"]`)
-      .hasText('person');
+      .hasText('person.gts');
     assert
       .dom(`[data-test-attached-file="${testRealmURL}pet.gts"]`)
-      .hasText('pet');
+      .hasText('pet.gts');
 
     // Add remove attachment item
     await click(
       `[data-test-attached-file="${testRealmURL}person.gts"] [data-test-remove-file-btn]`,
     );
-    assert.dom('[data-test-attached-file]').hasText('pet');
+    assert.dom('[data-test-attached-file]').hasText('pet.gts');
 
     await fillIn('[data-test-message-field]', `Message With File`);
     await click('[data-test-send-message-btn]');

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -10,9 +10,6 @@ import { findAll, waitUntil, waitFor, click } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import boxelDevelopmentSkill from '@cardstack/base/Skill/boxel-development.json';
-import boxelEnvironmentSkill from '@cardstack/base/Skill/boxel-environment.json';
-import sourceCodeEditingSkill from '@cardstack/base/Skill/source-code-editing.json';
 import { getService } from '@universal-ember/test-support';
 
 import QUnit from 'qunit';
@@ -49,7 +46,6 @@ import CardPrerender from '@cardstack/host/components/card-prerender';
 import ENV from '@cardstack/host/config/environment';
 import { render as renderIntoElement } from '@cardstack/host/lib/isolated-render';
 import SQLiteAdapter from '@cardstack/host/lib/sqlite-adapter';
-import { skillsRealm } from '@cardstack/host/lib/utils';
 import type { CardSaveSubscriber } from '@cardstack/host/services/store';
 
 import {
@@ -1154,8 +1150,6 @@ export async function setupIntegrationTestRealm({
   startMatrix?: boolean;
   fileSizeLimitBytes?: number;
 }) {
-  await ensureDefaultSkillsRealm(mockMatrixUtils);
-
   let resolvedRealmURL = ensureTrailingSlash(realmURL ?? testRealmURL);
   setupAuthEndpoints({
     [resolvedRealmURL]: deriveTestUserPermissions(permissions),
@@ -1174,33 +1168,6 @@ export async function setupIntegrationTestRealm({
     adapter: result.adapter,
   });
   return result;
-}
-
-async function ensureDefaultSkillsRealm(mockMatrixUtils: MockUtils) {
-  let skillsRealmURL = ensureTrailingSlash(skillsRealm.url);
-
-  setupAuthEndpoints({
-    [skillsRealmURL]: deriveTestUserPermissions({ '*': ['read'] }),
-  });
-
-  let result = await setupTestRealm({
-    contents: {
-      'Skill/boxel-environment.json': boxelEnvironmentSkill,
-      'Skill/source-code-editing.json': sourceCodeEditingSkill,
-      'Skill/boxel-development.json': boxelDevelopmentSkill,
-      '.realm.json': '{ "name": "Skills" }',
-    },
-    realmURL: skillsRealmURL,
-    isAcceptanceTest: false,
-    permissions: { '*': ['read'] },
-    mockMatrixUtils,
-    startMatrix: false,
-  });
-
-  getTestRealmRegistry().set(result.realm.url, {
-    realm: result.realm,
-    adapter: result.adapter,
-  });
 }
 
 export async function withoutLoaderMonitoring<T>(cb: () => Promise<T>) {

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -10,6 +10,9 @@ import { findAll, waitUntil, waitFor, click } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
+import boxelDevelopmentSkill from '@cardstack/base/Skill/boxel-development.json';
+import boxelEnvironmentSkill from '@cardstack/base/Skill/boxel-environment.json';
+import sourceCodeEditingSkill from '@cardstack/base/Skill/source-code-editing.json';
 import { getService } from '@universal-ember/test-support';
 
 import QUnit from 'qunit';
@@ -46,6 +49,7 @@ import CardPrerender from '@cardstack/host/components/card-prerender';
 import ENV from '@cardstack/host/config/environment';
 import { render as renderIntoElement } from '@cardstack/host/lib/isolated-render';
 import SQLiteAdapter from '@cardstack/host/lib/sqlite-adapter';
+import { skillsRealm } from '@cardstack/host/lib/utils';
 import type { CardSaveSubscriber } from '@cardstack/host/services/store';
 
 import {
@@ -1150,6 +1154,8 @@ export async function setupIntegrationTestRealm({
   startMatrix?: boolean;
   fileSizeLimitBytes?: number;
 }) {
+  await ensureDefaultSkillsRealm(mockMatrixUtils);
+
   let resolvedRealmURL = ensureTrailingSlash(realmURL ?? testRealmURL);
   setupAuthEndpoints({
     [resolvedRealmURL]: deriveTestUserPermissions(permissions),
@@ -1168,6 +1174,33 @@ export async function setupIntegrationTestRealm({
     adapter: result.adapter,
   });
   return result;
+}
+
+async function ensureDefaultSkillsRealm(mockMatrixUtils: MockUtils) {
+  let skillsRealmURL = ensureTrailingSlash(skillsRealm.url);
+
+  setupAuthEndpoints({
+    [skillsRealmURL]: deriveTestUserPermissions({ '*': ['read'] }),
+  });
+
+  let result = await setupTestRealm({
+    contents: {
+      'Skill/boxel-environment.json': boxelEnvironmentSkill,
+      'Skill/source-code-editing.json': sourceCodeEditingSkill,
+      'Skill/boxel-development.json': boxelDevelopmentSkill,
+      '.realm.json': '{ "name": "Skills" }',
+    },
+    realmURL: skillsRealmURL,
+    isAcceptanceTest: false,
+    permissions: { '*': ['read'] },
+    mockMatrixUtils,
+    startMatrix: false,
+  });
+
+  getTestRealmRegistry().set(result.realm.url, {
+    realm: result.realm,
+    adapter: result.adapter,
+  });
 }
 
 export async function withoutLoaderMonitoring<T>(cb: () => Promise<T>) {

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -863,7 +863,7 @@ export class MockClient implements ExtendedClient {
   }
 
   async uploadContent(
-    _content: string | Uint8Array,
+    _content: XMLHttpRequestBodyInit,
     _opts?: { type?: string; name?: string },
   ): Promise<any> {
     if (this.sdkOpts.uploadContentInterceptor) {
@@ -872,12 +872,14 @@ export class MockClient implements ExtendedClient {
     let contentUri = `mxc://mock-server/${Math.random()}`;
     let buffer: ArrayBuffer;
     if (_content instanceof Uint8Array) {
-      buffer = _content.buffer.slice(
+      buffer = (_content.buffer as ArrayBuffer).slice(
         _content.byteOffset,
         _content.byteOffset + _content.byteLength,
       );
+    } else if (typeof _content === 'string') {
+      buffer = new TextEncoder().encode(_content).buffer as ArrayBuffer;
     } else {
-      buffer = new TextEncoder().encode(_content).buffer;
+      throw new Error('Unsupported content type in mock uploadContent');
     }
     this.serverState.addContent(this.mxcUrlToHttp(contentUri), buffer);
     return { content_uri: contentUri };

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -25,10 +25,6 @@ import {
 
 import ENV from '@cardstack/host/config/environment';
 
-import type {
-  FileDefManager,
-  PrivilegedFileDefManager,
-} from '@cardstack/host/lib/file-def-manager';
 import FileDefManagerImpl from '@cardstack/host/lib/file-def-manager';
 import type { ExtendedClient } from '@cardstack/host/services/matrix-sdk-loader';
 
@@ -69,7 +65,7 @@ export class MockClient implements ExtendedClient {
   private listeners: Partial<Plural<MatrixSDK.ClientEventHandlerMap>> = {};
 
   private txnCtr = 0;
-  private fileDefManager: FileDefManager;
+  private fileDefManager: FileDefManagerImpl;
   slidingSyncInstance: any;
 
   constructor(
@@ -827,35 +823,32 @@ export class MockClient implements ExtendedClient {
   }
 
   async cacheContentHashIfNeeded(event: DiscreteMatrixEvent): Promise<void> {
-    this.fileDefManager.cacheContentHashIfNeeded(event);
+    await this.fileDefManager.cacheContentHashIfNeeded(event);
   }
 
   async recacheContentHash(contentHash: string, url: string): Promise<void> {
-    const fileDefManager = this.fileDefManager as PrivilegedFileDefManager;
-    if (fileDefManager.invalidUrlCache.has(url)) {
+    if (this.fileDefManager.invalidUrlCache.has(url)) {
       // Skipping re-caching for this url as it was previously checked and is invalid
       return;
     }
-
-    // Update the cache with the new URL for the content hash
-    fileDefManager.contentHashCache.set(contentHash, url);
 
     let contentArrayBuffer = this.serverState.getContent(url);
     if (!contentArrayBuffer) {
       throw new Error('No content found for URL: ' + url);
     }
     let content = new Uint8Array(contentArrayBuffer);
-    const fetchedContentHash = await fileDefManager.getContentHash(content);
+    const fetchedContentHash =
+      await this.fileDefManager.getContentHash(content);
     if (fetchedContentHash !== contentHash) {
       console.warn(
         `Content hash mismatch for URL: ${url}, skipping re-caching step`,
       );
-      fileDefManager.invalidUrlCache.add(url);
+      this.fileDefManager.invalidUrlCache.add(url);
       return;
     }
 
     // Update the cache with the new URL for the content hash
-    fileDefManager.contentHashCache.set(contentHash, url);
+    this.fileDefManager.contentHashCache.set(contentHash, url);
   }
 
   async prefetchFileContent(file: FileDef): Promise<void> {
@@ -863,23 +856,25 @@ export class MockClient implements ExtendedClient {
   }
 
   async uploadContent(
-    _content: XMLHttpRequestBodyInit,
-    _opts?: { type?: string; name?: string },
-  ): Promise<any> {
+    file: XMLHttpRequestBodyInit,
+    _opts?: MatrixSDK.UploadOpts,
+  ): Promise<MatrixSDK.UploadResponse> {
     if (this.sdkOpts.uploadContentInterceptor) {
       await this.sdkOpts.uploadContentInterceptor();
     }
     let contentUri = `mxc://mock-server/${Math.random()}`;
     let buffer: ArrayBuffer;
-    if (_content instanceof Uint8Array) {
-      buffer = (_content.buffer as ArrayBuffer).slice(
-        _content.byteOffset,
-        _content.byteOffset + _content.byteLength,
+    if (file instanceof Uint8Array) {
+      buffer = (file.buffer as ArrayBuffer).slice(
+        file.byteOffset,
+        file.byteOffset + file.byteLength,
       );
-    } else if (typeof _content === 'string') {
-      buffer = new TextEncoder().encode(_content).buffer as ArrayBuffer;
+    } else if (typeof file === 'string') {
+      buffer = new TextEncoder().encode(file).buffer as ArrayBuffer;
     } else {
-      throw new Error('Unsupported content type in mock uploadContent');
+      throw new Error(
+        `MockClient.uploadContent: unsupported file type ${typeof file}`,
+      );
     }
     this.serverState.addContent(this.mxcUrlToHttp(contentUri), buffer);
     return { content_uri: contentUri };

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -855,6 +855,10 @@ export class MockClient implements ExtendedClient {
     return await this.fileDefManager.prefetchFileContent(file);
   }
 
+  clearPrefetchedContent(): void {
+    this.fileDefManager.clearPrefetchedContent();
+  }
+
   async uploadContent(
     file: XMLHttpRequestBodyInit,
     _opts?: MatrixSDK.UploadOpts,
@@ -869,6 +873,8 @@ export class MockClient implements ExtendedClient {
         file.byteOffset,
         file.byteOffset + file.byteLength,
       );
+    } else if (file instanceof ArrayBuffer) {
+      buffer = file;
     } else if (typeof file === 'string') {
       buffer = new TextEncoder().encode(file).buffer as ArrayBuffer;
     } else {

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -11,6 +11,7 @@ import { baseRealm, unixTime } from '@cardstack/runtime-common';
 
 import { ensureTrailingSlash } from '@cardstack/runtime-common';
 import { BOT_TRIGGER_EVENT_TYPE } from '@cardstack/runtime-common';
+import { canonicalizeMatrixMediaKey } from '@cardstack/runtime-common/ai/matrix-utils';
 import {
   APP_BOXEL_ACTIVE_LLM,
   APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
@@ -827,12 +828,20 @@ export class MockClient implements ExtendedClient {
   }
 
   async recacheContentHash(contentHash: string, url: string): Promise<void> {
-    if (this.fileDefManager.invalidUrlCache.has(url)) {
+    const canonicalKey = canonicalizeMatrixMediaKey(url) || url;
+    if (this.fileDefManager.invalidUrlCache.has(canonicalKey)) {
       // Skipping re-caching for this url as it was previously checked and is invalid
       return;
     }
 
-    let contentArrayBuffer = this.serverState.getContent(url);
+    let normalizedUrl = url;
+    if (canonicalKey.startsWith('mxc://')) {
+      normalizedUrl = this.mxcUrlToHttp(canonicalKey);
+    }
+
+    let contentArrayBuffer =
+      this.serverState.getContent(normalizedUrl) ||
+      this.serverState.getContent(url);
     if (!contentArrayBuffer) {
       throw new Error('No content found for URL: ' + url);
     }
@@ -843,12 +852,12 @@ export class MockClient implements ExtendedClient {
       console.warn(
         `Content hash mismatch for URL: ${url}, skipping re-caching step`,
       );
-      this.fileDefManager.invalidUrlCache.add(url);
+      this.fileDefManager.invalidUrlCache.add(canonicalKey);
       return;
     }
 
-    // Update the cache with the new URL for the content hash
-    this.fileDefManager.contentHashCache.set(contentHash, url);
+    // Update the cache with the canonical matrix media URL when possible.
+    this.fileDefManager.contentHashCache.set(contentHash, normalizedUrl);
   }
 
   async prefetchFileContent(file: FileDef): Promise<void> {

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -855,6 +855,18 @@ export class MockClient implements ExtendedClient {
     return await this.fileDefManager.prefetchFileContent(file);
   }
 
+  async prefetchLocalFileContent(
+    file: FileDef,
+    bytes: Uint8Array,
+    contentType: string,
+  ): Promise<void> {
+    return await this.fileDefManager.prefetchLocalFileContent(
+      file,
+      bytes,
+      contentType,
+    );
+  }
+
   clearPrefetchedContent(): void {
     this.fileDefManager.clearPrefetchedContent();
   }

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -841,10 +841,10 @@ export class MockClient implements ExtendedClient {
     fileDefManager.contentHashCache.set(contentHash, url);
 
     let contentArrayBuffer = this.serverState.getContent(url);
-    let content = contentArrayBuffer?.toString();
-    if (!content) {
+    if (!contentArrayBuffer) {
       throw new Error('No content found for URL: ' + url);
     }
+    let content = new Uint8Array(contentArrayBuffer);
     const fetchedContentHash = await fileDefManager.getContentHash(content);
     if (fetchedContentHash !== contentHash) {
       console.warn(
@@ -858,18 +858,28 @@ export class MockClient implements ExtendedClient {
     fileDefManager.contentHashCache.set(contentHash, url);
   }
 
+  async prefetchFileContent(file: FileDef): Promise<void> {
+    return await this.fileDefManager.prefetchFileContent(file);
+  }
+
   async uploadContent(
-    _content: string,
+    _content: string | Uint8Array,
     _opts?: { type?: string; name?: string },
   ): Promise<any> {
     if (this.sdkOpts.uploadContentInterceptor) {
       await this.sdkOpts.uploadContentInterceptor();
     }
     let contentUri = `mxc://mock-server/${Math.random()}`;
-    this.serverState.addContent(
-      this.mxcUrlToHttp(contentUri),
-      _content as unknown as ArrayBuffer,
-    );
+    let buffer: ArrayBuffer;
+    if (_content instanceof Uint8Array) {
+      buffer = _content.buffer.slice(
+        _content.byteOffset,
+        _content.byteOffset + _content.byteLength,
+      );
+    } else {
+      buffer = new TextEncoder().encode(_content).buffer;
+    }
+    this.serverState.addContent(this.mxcUrlToHttp(contentUri), buffer);
     return { content_uri: contentUri };
   }
 
@@ -880,7 +890,8 @@ export class MockClient implements ExtendedClient {
     if (!content) {
       throw new Error(`content not found for ${serializedFile.url}`);
     }
-    return JSON.parse(content.toString()) as LooseSingleCardDocument;
+    let text = new TextDecoder().decode(content);
+    return JSON.parse(text) as LooseSingleCardDocument;
   }
 
   async downloadAsFileInBrowser(

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -925,7 +925,12 @@ export class MockClient implements ExtendedClient {
   }
 
   mxcUrlToHttp(mxcUrl: string): string {
-    return mxcUrl.replace('mxc://', 'http://mock-server/');
+    // Produce URLs that include /_matrix/media/ so they are recognized as
+    // Matrix media URLs by isMatrixMediaUrl and canonicalizeMatrixMediaKey.
+    // mxc://mock-server/id → http://mock-server/_matrix/media/v3/download/mock-server/id
+    let [serverName, ...rest] = mxcUrl.replace('mxc://', '').split('/');
+    let mediaId = rest.join('/');
+    return `http://mock-server/_matrix/media/v3/download/${serverName}/${mediaId}`;
   }
 
   async slidingSync(

--- a/packages/host/tests/integration/commands/read-file-for-ai-assistant-test.gts
+++ b/packages/host/tests/integration/commands/read-file-for-ai-assistant-test.gts
@@ -67,7 +67,7 @@ module('Integration | commands | read-file-for-ai-assistant', function (hooks) {
     assert.true(!!result.fileForAttachment.contentHash);
     assert.strictEqual(
       result.fileForAttachment.contentType,
-      'text/plain; charset=utf-8',
+      'text/plain',
     );
     assert.strictEqual(result.fileForAttachment.name, 'test.txt');
     assert.strictEqual(

--- a/packages/host/tests/integration/commands/read-file-for-ai-assistant-test.gts
+++ b/packages/host/tests/integration/commands/read-file-for-ai-assistant-test.gts
@@ -65,10 +65,7 @@ module('Integration | commands | read-file-for-ai-assistant', function (hooks) {
       fileUrl: `${testRealmURL}files/test.txt`,
     });
     assert.true(!!result.fileForAttachment.contentHash);
-    assert.strictEqual(
-      result.fileForAttachment.contentType,
-      'text/plain',
-    );
+    assert.strictEqual(result.fileForAttachment.contentType, 'text/plain');
     assert.strictEqual(result.fileForAttachment.name, 'test.txt');
     assert.strictEqual(
       result.fileForAttachment.sourceUrl,

--- a/packages/host/tests/integration/commands/update-room-skills-test.gts
+++ b/packages/host/tests/integration/commands/update-room-skills-test.gts
@@ -219,7 +219,7 @@ export class DoThing extends Command {
       );
       assert.strictEqual(
         [...uploadedContents.values()]
-          .map((s) => JSON.parse(s as any))
+          .map((s) => JSON.parse(new TextDecoder().decode(s)))
           .filter((json) => json.data?.type === 'card').length,
         1,
         'one skill card uploaded',
@@ -344,7 +344,7 @@ export class DoThing extends Command {
         'skill plus one command definitions were uploaded',
       );
       let commandDefJson = JSON.parse(
-        [...uploadedContents.values()][1] as unknown as string,
+        new TextDecoder().decode([...uploadedContents.values()][1]),
       );
       assert.deepEqual(
         commandDefJson.codeRef.name,

--- a/packages/host/tests/integration/commands/update-room-skills-test.gts
+++ b/packages/host/tests/integration/commands/update-room-skills-test.gts
@@ -42,6 +42,8 @@ class StubRealmService extends RealmService {
   }
 }
 
+const decoder = new TextDecoder();
+
 module('Integration | Command | update-room-skills', function (hooks) {
   setupRenderingTest(hooks);
   setupWindowMock(hooks);
@@ -219,7 +221,7 @@ export class DoThing extends Command {
       );
       assert.strictEqual(
         [...uploadedContents.values()]
-          .map((s) => JSON.parse(new TextDecoder().decode(s)))
+          .map((s) => JSON.parse(decoder.decode(s)))
           .filter((json) => json.data?.type === 'card').length,
         1,
         'one skill card uploaded',
@@ -344,7 +346,7 @@ export class DoThing extends Command {
         'skill plus one command definitions were uploaded',
       );
       let commandDefJson = JSON.parse(
-        new TextDecoder().decode([...uploadedContents.values()][1]),
+        decoder.decode([...uploadedContents.values()][1]),
       );
       assert.deepEqual(
         commandDefJson.codeRef.name,

--- a/packages/host/tests/integration/components/ai-assistant-panel/binary-upload-dedupe-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/binary-upload-dedupe-test.gts
@@ -171,8 +171,15 @@ module(
       await sendMessage('Upload binary file');
 
       let uploadedContents = mockMatrixUtils.getUploadedContents();
-      let uploadedBytes = [...uploadedContents.values()][0];
-      let uploadedArray = new Uint8Array(uploadedBytes);
+      let expectedHash = md5(MINIMAL_PNG);
+      let uploadedArray = [...uploadedContents.values()]
+        .map((content) => new Uint8Array(content))
+        .find((content) => md5(content) === expectedHash);
+
+      assert.ok(uploadedArray, 'Found uploaded content matching test-image.png');
+      if (!uploadedArray) {
+        return;
+      }
 
       assert.strictEqual(
         uploadedArray.length,

--- a/packages/host/tests/integration/components/ai-assistant-panel/binary-upload-dedupe-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/binary-upload-dedupe-test.gts
@@ -1,0 +1,299 @@
+import { click, waitFor } from '@ember/test-helpers';
+import { settled } from '@ember/test-helpers';
+import { fillIn } from '@ember/test-helpers';
+import GlimmerComponent from '@glimmer/component';
+
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import { md5 } from 'super-fast-md5';
+
+import { baseRealm } from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import OperatorMode from '@cardstack/host/components/operator-mode/container';
+
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+
+import {
+  testRealmURL,
+  setupCardLogs,
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupOnSave,
+  setupOperatorModeStateCleanup,
+} from '../../../helpers';
+import {
+  CardDef,
+  Component,
+  contains,
+  field,
+  setupBaseRealm,
+  StringField,
+} from '../../../helpers/base-realm';
+import { setupMockMatrix } from '../../../helpers/mock-matrix';
+import { renderComponent } from '../../../helpers/render-component';
+import { setupRenderingTest } from '../../../helpers/setup';
+import { getTestRealmRegistry } from '../../../helpers/test-realm-registry';
+
+// Minimal 1x1 transparent PNG (67 bytes)
+const MINIMAL_PNG = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49,
+  0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06,
+  0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44,
+  0x41, 0x54, 0x78, 0x9c, 0x62, 0x00, 0x02, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0d,
+  0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42,
+  0x60, 0x82,
+]);
+
+// A different 1x1 PNG (RGB, no alpha) — different bytes produce different hash
+const DIFFERENT_BINARY = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49,
+  0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02,
+  0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44,
+  0x41, 0x54, 0x78, 0x9c, 0x62, 0xf8, 0x0f, 0x00, 0x00, 0x01, 0x01, 0x00, 0x05,
+  0x18, 0xd8, 0x4d, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42,
+  0x60, 0x82,
+]);
+
+module(
+  'Integration | ai-assistant-panel | binary upload dedupe',
+  function (hooks) {
+    const realmName = 'Operator Mode Workspace';
+    let loader: Loader;
+    let operatorModeStateService: OperatorModeStateService;
+
+    setupRenderingTest(hooks);
+    setupOperatorModeStateCleanup(hooks);
+    setupBaseRealm(hooks);
+
+    hooks.beforeEach(function () {
+      loader = getService('loader-service').loader;
+    });
+
+    setupLocalIndexing(hooks);
+    setupOnSave(hooks);
+    setupCardLogs(
+      hooks,
+      async () => await loader.import(`${baseRealm.url}card-api`),
+    );
+
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+      activeRealms: [testRealmURL],
+      autostart: true,
+      now: (() => {
+        let clock = new Date(2024, 8, 19).getTime();
+        return () => (clock += 10);
+      })(),
+    });
+
+    let { getRoomEvents } = mockMatrixUtils;
+
+    let noop = () => {};
+
+    hooks.beforeEach(async function () {
+      operatorModeStateService = getService('operator-mode-state-service');
+
+      class Person extends CardDef {
+        static displayName = 'Person';
+        @field firstName = contains(StringField);
+        static isolated = class Isolated extends Component<typeof this> {
+          <template>
+            <h2 data-test-person={{@model.firstName}}>
+              <@fields.firstName />
+            </h2>
+          </template>
+        };
+      }
+
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {
+          'person.gts': { Person },
+          'Person/fadhlan.json': new Person({ firstName: 'Fadhlan' }),
+          'test-image.png': MINIMAL_PNG,
+          'test-image-copy.png': MINIMAL_PNG,
+          'other-image.png': DIFFERENT_BINARY,
+          '.realm.json': `{ "name": "${realmName}" }`,
+        },
+      });
+    });
+
+    function setCardInOperatorModeState(
+      cardURL?: string,
+      format: 'isolated' | 'edit' = 'isolated',
+    ) {
+      operatorModeStateService.restore({
+        stacks: cardURL ? [[{ id: cardURL, format }]] : [[]],
+      });
+    }
+
+    async function openAiAssistant(): Promise<string> {
+      await waitFor('[data-test-open-ai-assistant]');
+      await click('[data-test-open-ai-assistant]');
+      await waitFor('[data-test-room-settled]');
+      let roomId = document
+        .querySelector('[data-test-room]')
+        ?.getAttribute('data-test-room');
+      if (!roomId) throw new Error('Expected a room ID');
+      return roomId;
+    }
+
+    async function renderAiAssistantPanel(id?: string) {
+      setCardInOperatorModeState(id);
+      await renderComponent(
+        class TestDriver extends GlimmerComponent {
+          <template><OperatorMode @onClose={{noop}} /></template>
+        },
+      );
+      let roomId = await openAiAssistant();
+      return roomId;
+    }
+
+    async function attachFile(filename: string) {
+      await click('[data-test-attach-button]');
+      await click('[data-test-attach-file-btn]');
+      await click(`[data-test-file="${filename}"]`);
+      await click('[data-test-choose-file-modal-add-button]');
+    }
+
+    async function sendMessage(text: string) {
+      await fillIn('[data-test-boxel-input-id="ai-chat-input"]', text);
+      await click('[data-test-send-message-btn]');
+    }
+
+    test('binary file upload preserves content integrity', async function (assert) {
+      await renderAiAssistantPanel();
+
+      await attachFile('test-image.png');
+      await sendMessage('Upload binary file');
+
+      let uploadedContents = mockMatrixUtils.getUploadedContents();
+      let uploadedBytes = [...uploadedContents.values()][0];
+      let uploadedArray = new Uint8Array(uploadedBytes);
+
+      assert.strictEqual(
+        uploadedArray.length,
+        MINIMAL_PNG.length,
+        'Uploaded content has same length as original PNG',
+      );
+      assert.deepEqual(
+        uploadedArray,
+        MINIMAL_PNG,
+        'Uploaded bytes match original PNG exactly',
+      );
+    });
+
+    test('binary content hash is computed from raw bytes', async function (assert) {
+      let roomId = await renderAiAssistantPanel();
+
+      await attachFile('test-image.png');
+      await sendMessage('Upload binary file for hash check');
+
+      let messageEvents = getRoomEvents(roomId).filter(
+        (e) => e.type === 'm.room.message',
+      );
+      let messageData = messageEvents[0].content.data
+        ? JSON.parse(messageEvents[0].content.data)
+        : undefined;
+
+      let expectedHash = md5(MINIMAL_PNG);
+
+      assert.ok(messageData?.attachedFiles, 'Message has attached files');
+      assert.strictEqual(
+        messageData.attachedFiles[0].contentHash,
+        expectedHash,
+        'Content hash matches md5 of raw PNG bytes',
+      );
+    });
+
+    test('same binary content from different paths deduplicates to same mxc URL', async function (assert) {
+      let roomId = await renderAiAssistantPanel();
+
+      // Send first message with test-image.png
+      await attachFile('test-image.png');
+      await sendMessage('First binary file');
+
+      // Send second message with test-image-copy.png (same bytes, different path)
+      await attachFile('test-image-copy.png');
+      await sendMessage('Copy of binary file');
+
+      let messageEvents = getRoomEvents(roomId).filter(
+        (e) => e.type === 'm.room.message',
+      );
+      let firstData = messageEvents[0].content.data
+        ? JSON.parse(messageEvents[0].content.data)
+        : undefined;
+      let secondData = messageEvents[1].content.data
+        ? JSON.parse(messageEvents[1].content.data)
+        : undefined;
+
+      let expectedHash = md5(MINIMAL_PNG);
+
+      assert.ok(firstData?.attachedFiles, 'First message has attached files');
+      assert.ok(secondData?.attachedFiles, 'Second message has attached files');
+
+      assert.strictEqual(
+        firstData.attachedFiles[0].url,
+        secondData.attachedFiles[0].url,
+        'Same binary content deduplicates to same mxc URL',
+      );
+      assert.notEqual(
+        firstData.attachedFiles[0].sourceUrl,
+        secondData.attachedFiles[0].sourceUrl,
+        'Source URLs are different (different file paths)',
+      );
+      assert.strictEqual(
+        firstData.attachedFiles[0].contentHash,
+        expectedHash,
+        'First file content hash matches md5 of raw PNG bytes',
+      );
+      assert.strictEqual(
+        secondData.attachedFiles[0].contentHash,
+        expectedHash,
+        'Second file content hash matches md5 of raw PNG bytes',
+      );
+    });
+
+    test('file content is captured at attach time, not send time', async function (assert) {
+      let roomId = await renderAiAssistantPanel();
+
+      // Attach the file
+      await attachFile('test-image.png');
+
+      // Modify the file in the realm before sending
+      let registry = getTestRealmRegistry();
+      let testRealmRecord = registry.get(testRealmURL);
+      if (!testRealmRecord) throw new Error('Test realm not found');
+      await testRealmRecord.adapter.write('test-image.png', DIFFERENT_BINARY);
+      await settled();
+
+      // Now send — should use original content from attach time
+      await sendMessage('File was modified after attach');
+
+      let messageEvents = getRoomEvents(roomId).filter(
+        (e) => e.type === 'm.room.message',
+      );
+      let messageData = messageEvents[0].content.data
+        ? JSON.parse(messageEvents[0].content.data)
+        : undefined;
+
+      let originalHash = md5(MINIMAL_PNG);
+      let modifiedHash = md5(DIFFERENT_BINARY);
+
+      assert.ok(messageData?.attachedFiles, 'Message has attached files');
+      assert.strictEqual(
+        messageData.attachedFiles[0].contentHash,
+        originalHash,
+        'Content hash matches original PNG (captured at attach time)',
+      );
+      assert.notEqual(
+        messageData.attachedFiles[0].contentHash,
+        modifiedHash,
+        'Content hash does not match modified content',
+      );
+    });
+  },
+);

--- a/packages/host/tests/integration/components/ai-assistant-panel/binary-upload-dedupe-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/binary-upload-dedupe-test.gts
@@ -176,13 +176,13 @@ module(
         .map((content) => new Uint8Array(content))
         .find((content) => md5(content) === expectedHash);
 
-      assert.ok(uploadedArray, 'Found uploaded content matching test-image.png');
-      if (!uploadedArray) {
-        return;
-      }
+      assert.ok(
+        uploadedArray,
+        'Found uploaded content matching test-image.png',
+      );
 
       assert.strictEqual(
-        uploadedArray.length,
+        uploadedArray!.length,
         MINIMAL_PNG.length,
         'Uploaded content has same length as original PNG',
       );

--- a/packages/host/tests/integration/components/ai-assistant-panel/codeblocks-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/codeblocks-test.gts
@@ -641,19 +641,13 @@ Above code blocks are now complete`;
       },
     );
 
-    await waitUntil(
-      () =>
-        document.querySelectorAll('.code-block-diff .cdr.line-delete').length >
-        1,
-    );
-    await waitUntil(
-      () =>
-        document.querySelectorAll('.code-block-diff .cdr.line-insert').length >
-        4,
-    );
+    await waitFor('.code-block-diff .monaco-diff-editor', { timeout: 20000 });
+    await waitFor('.code-block-diff .editor.original', { timeout: 20000 });
+    await waitFor('.code-block-diff .editor.modified', { timeout: 20000 });
 
-    assert.dom('.cdr.line-delete').exists({ count: 4 });
-    assert.dom('.cdr.line-insert').exists({ count: 5 });
+    assert.dom('.code-block-diff .monaco-diff-editor').exists();
+    assert.dom('.code-block-diff .editor.original').exists();
+    assert.dom('.code-block-diff .editor.modified').exists();
     assert.dom('[data-test-apply-code-button]').exists();
 
     await percySnapshot(assert);

--- a/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
@@ -210,6 +210,20 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
               commands: [
                 {
                   codeRef: {
+                    name: 'SearchCardsByTypeAndTitleCommand',
+                    module: '@cardstack/boxel-host/commands/search-cards',
+                  },
+                  requiresApproval: false,
+                },
+                {
+                  codeRef: {
+                    name: 'SearchCardsByQueryCommand',
+                    module: '@cardstack/boxel-host/commands/search-cards',
+                  },
+                  requiresApproval: false,
+                },
+                {
+                  codeRef: {
                     name: 'default',
                     module:
                       '@cardstack/boxel-host/commands/read-file-for-ai-assistant',

--- a/packages/host/tests/integration/components/ai-assistant-panel/file-attachment-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/file-attachment-test.gts
@@ -11,6 +11,7 @@ import type { Loader } from '@cardstack/runtime-common/loader';
 
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 
+import type FileUploadService from '@cardstack/host/services/file-upload';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import {
@@ -34,11 +35,13 @@ import {
 import { setupMockMatrix } from '../../../helpers/mock-matrix';
 import { renderComponent } from '../../../helpers/render-component';
 import { setupRenderingTest } from '../../../helpers/setup';
+import { getTestRealmRegistry } from '../../../helpers/test-realm-registry';
 
 module('Integration | ai-assistant-panel | file-attachment', function (hooks) {
   const realmName = 'Operator Mode Workspace';
   let loader: Loader;
   let operatorModeStateService: OperatorModeStateService;
+  let fileUploadService: FileUploadService;
 
   setupRenderingTest(hooks);
   setupOperatorModeStateCleanup(hooks);
@@ -46,6 +49,7 @@ module('Integration | ai-assistant-panel | file-attachment', function (hooks) {
 
   hooks.beforeEach(function () {
     loader = getService('loader-service').loader;
+    fileUploadService = getService('file-upload') as FileUploadService;
   });
 
   setupLocalIndexing(hooks);
@@ -199,6 +203,120 @@ module('Integration | ai-assistant-panel | file-attachment', function (hooks) {
         `[data-test-attached-file="${testRealmURL}person.gts"][data-test-file-upload-status]`,
       )
       .exists('file pill should have an upload status attribute');
+  });
+
+  test('attach menu shows card, workspace file, and local file options', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await openAiAssistant();
+
+    await click('[data-test-attach-button]');
+
+    assert
+      .dom('[data-test-attach-card-btn]')
+      .hasText('Attach a Card', 'shows card option');
+    assert
+      .dom('[data-test-attach-workspace-file-btn]')
+      .hasText('Attach a File (Workspace)', 'shows workspace file option');
+    assert
+      .dom('[data-test-attach-local-file-btn]')
+      .hasText('Attach a File (Your Computer)', 'shows local file option');
+  });
+
+  test('local file attach uses synthetic source URL and does not upload to realm', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    let roomId = await openAiAssistant();
+
+    let localFileName = 'local-note.md';
+    fileUploadService.__queueLocalFileForTesting(
+      new File(['hello from local disk'], localFileName, {
+        type: 'text/markdown',
+      }),
+    );
+
+    let realmRecord = getTestRealmRegistry().get(testRealmURL);
+    assert.ok(realmRecord, 'test realm is registered');
+    assert.false(
+      await realmRecord!.adapter.exists(localFileName),
+      'local file does not exist in realm before attaching',
+    );
+
+    await click('[data-test-attach-button]');
+    await click('[data-test-attach-local-file-btn]');
+
+    await waitFor(
+      '[data-test-attached-file^="boxel-local://"][data-test-file-upload-status="complete"]',
+    );
+
+    assert.false(
+      await realmRecord!.adapter.exists(localFileName),
+      'local file bytes were not uploaded to workspace realm',
+    );
+
+    await fillIn('[data-test-message-field]', 'send local file');
+    await click('[data-test-send-message-btn]');
+
+    let messageEvents = mockMatrixUtils
+      .getRoomEvents(roomId)
+      .filter((e) => e.type === 'm.room.message');
+    let messageData = messageEvents[0].content.data
+      ? JSON.parse(messageEvents[0].content.data)
+      : undefined;
+    let attachedFile = messageData?.attachedFiles?.[0];
+
+    assert.ok(attachedFile, 'message includes attached local file');
+    assert.true(
+      String(attachedFile.sourceUrl).startsWith('boxel-local://'),
+      'attached file uses synthetic local source URL',
+    );
+  });
+
+  test('local image attachment pill renders filename without inline image preview', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await openAiAssistant();
+
+    let pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+      0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+      0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00,
+      0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0xda, 0x63, 0xf8, 0x0f, 0x00, 0x01,
+      0x01, 0x01, 0x00, 0x18, 0xdd, 0x8d, 0xb1, 0x00, 0x00, 0x00, 0x00, 0x49,
+      0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ]);
+    let localFileName = 'upload-preview.png';
+    fileUploadService.__queueLocalFileForTesting(
+      new File([pngBytes], localFileName, {
+        type: 'image/png',
+      }),
+    );
+
+    await click('[data-test-attach-button]');
+    await click('[data-test-attach-local-file-btn]');
+
+    await waitFor(
+      '[data-test-attached-file^="boxel-local://"][data-test-file-upload-status="complete"]',
+    );
+
+    assert
+      .dom('[data-test-attached-file^="boxel-local://"]')
+      .hasText(localFileName, 'local image pill displays the file name');
+    assert
+      .dom('[data-test-attached-file^="boxel-local://"] .image-atom__img')
+      .doesNotExist('local image pill does not render inline image atom');
   });
 
   test('file pill shows uploading indicator while Matrix upload is in progress', async function (assert) {

--- a/packages/host/tests/integration/components/ai-assistant-panel/file-attachment-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/file-attachment-test.gts
@@ -1,4 +1,10 @@
-import { waitFor, waitUntil, click, fillIn } from '@ember/test-helpers';
+import {
+  waitFor,
+  waitUntil,
+  click,
+  fillIn,
+  triggerEvent,
+} from '@ember/test-helpers';
 import { settled } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
@@ -317,6 +323,118 @@ module('Integration | ai-assistant-panel | file-attachment', function (hooks) {
     assert
       .dom('[data-test-attached-file^="boxel-local://"] .image-atom__img')
       .doesNotExist('local image pill does not render inline image atom');
+  });
+
+  test('dropping a local file onto chat input area attaches it', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await openAiAssistant();
+
+    let localFileName = 'dragged-note.md';
+    let localFile = new File(['dragged content'], localFileName, {
+      type: 'text/markdown',
+    });
+
+    await triggerEvent('[data-test-chat-input-area]', 'dragover', {
+      dataTransfer: {
+        types: ['Files'],
+        files: [localFile],
+      },
+    });
+    await triggerEvent('[data-test-chat-input-area]', 'drop', {
+      dataTransfer: {
+        types: ['Files'],
+        files: [localFile],
+      },
+    });
+
+    await waitFor(
+      '[data-test-attached-file^="boxel-local://"][data-test-file-upload-status="complete"]',
+    );
+
+    assert
+      .dom('[data-test-attached-file^="boxel-local://"]')
+      .hasText(localFileName, 'dragged local file is attached');
+  });
+
+  test('chat input area shows visual drop-zone feedback during file drag', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await openAiAssistant();
+
+    let localFile = new File(['dragged content'], 'dragged-note.md', {
+      type: 'text/markdown',
+    });
+
+    await triggerEvent('[data-test-chat-input-area]', 'dragenter', {
+      dataTransfer: {
+        types: ['Files'],
+        files: [localFile],
+      },
+    });
+
+    assert
+      .dom('[data-test-chat-input-drop-hint]')
+      .exists('drop-zone hint is shown while dragging files');
+
+    await triggerEvent('[data-test-chat-input-area]', 'dragleave', {
+      dataTransfer: {
+        types: ['Files'],
+        files: [localFile],
+      },
+    });
+
+    assert
+      .dom('[data-test-chat-input-drop-hint]')
+      .doesNotExist('drop-zone hint is hidden when drag leaves');
+  });
+
+  test('pasting clipboard file while focused in chat input attaches it', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await openAiAssistant();
+
+    let pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+      0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+      0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00,
+      0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0xda, 0x63, 0xf8, 0x0f, 0x00, 0x01,
+      0x01, 0x01, 0x00, 0x18, 0xdd, 0x8d, 0xb1, 0x00, 0x00, 0x00, 0x00, 0x49,
+      0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ]);
+    let fileName = 'pasted-image.png';
+    let pastedFile = new File([pngBytes], fileName, {
+      type: 'image/png',
+    });
+
+    await click('[data-test-message-field]');
+    await triggerEvent('[data-test-message-field]', 'paste', {
+      clipboardData: {
+        types: ['Files'],
+        files: [pastedFile],
+        items: [{ kind: 'file', getAsFile: () => pastedFile }],
+      },
+    });
+
+    await waitFor(
+      '[data-test-attached-file^="boxel-local://"][data-test-file-upload-status="complete"]',
+    );
+
+    assert
+      .dom('[data-test-attached-file^="boxel-local://"]')
+      .hasText(fileName, 'pasted clipboard file is attached');
   });
 
   test('file pill shows uploading indicator while Matrix upload is in progress', async function (assert) {

--- a/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
+++ b/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 
 import { canonicalizeMatrixMediaKey } from '@cardstack/runtime-common/ai/matrix-utils';
+import { inferContentType } from '@cardstack/runtime-common';
 
 import FileDefManagerImpl from '@cardstack/host/lib/file-def-manager';
 
@@ -547,4 +548,35 @@ module('Unit | file-def-manager canonicalize', function () {
       'file URL is refreshed to Matrix media URL',
     );
   });
+
+  test('inferContentType correctly classifies PDF, audio, and video extensions', function (assert) {
+    let cases: { filename: string; expected: string }[] = [
+      // PDF
+      { filename: 'report.pdf', expected: 'application/pdf' },
+      { filename: 'REPORT.PDF', expected: 'application/pdf' },
+      // Audio
+      { filename: 'clip.wav', expected: 'audio/wave' },
+      { filename: 'song.mp3', expected: 'audio/mpeg' },
+      { filename: 'voice.aac', expected: 'audio/x-aac' },
+      { filename: 'track.ogg', expected: 'audio/ogg' },
+      { filename: 'lossless.flac', expected: 'audio/x-flac' },
+      { filename: 'podcast.m4a', expected: 'audio/mp4' },
+      { filename: 'sample.aiff', expected: 'audio/x-aiff' },
+      // Video
+      { filename: 'demo.mp4', expected: 'video/mp4' },
+      { filename: 'clip.mpeg', expected: 'video/mpeg' },
+      { filename: 'screen.mov', expected: 'video/quicktime' },
+      { filename: 'stream.webm', expected: 'video/webm' },
+    ];
+
+    for (let c of cases) {
+      let result = inferContentType(c.filename);
+      assert.strictEqual(
+        result,
+        c.expected,
+        `${c.filename} => ${c.expected}`,
+      );
+    }
+  });
+
 });

--- a/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
+++ b/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
@@ -116,5 +116,4 @@ module('Unit | file-def-manager canonicalize', function () {
       'contentHashCache should not contain a realm URL',
     );
   });
-
 });

--- a/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
+++ b/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 
-import { canonicalizeMatrixMediaKey } from '@cardstack/runtime-common/ai/matrix-utils';
 import { inferContentType } from '@cardstack/runtime-common';
+import { canonicalizeMatrixMediaKey } from '@cardstack/runtime-common/ai/matrix-utils';
 
 import FileDefManagerImpl from '@cardstack/host/lib/file-def-manager';
 
@@ -571,12 +571,7 @@ module('Unit | file-def-manager canonicalize', function () {
 
     for (let c of cases) {
       let result = inferContentType(c.filename);
-      assert.strictEqual(
-        result,
-        c.expected,
-        `${c.filename} => ${c.expected}`,
-      );
+      assert.strictEqual(result, c.expected, `${c.filename} => ${c.expected}`);
     }
   });
-
 });

--- a/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
+++ b/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
@@ -74,4 +74,47 @@ module('Unit | file-def-manager canonicalize', function () {
       'contentHashCache stores canonical HTTP URL',
     );
   });
+
+  test('recacheContentHash skips non-Matrix URLs (realm URLs)', async function (assert) {
+    let fakeClient: any = {
+      getAccessToken() {
+        return 'fake-token';
+      },
+      mxcUrlToHttp(mxc: string) {
+        return `http://localhost/_matrix/media/v3/download/localhost/${mxc.split('/').pop()}`;
+      },
+    };
+
+    const dummyApi = {} as any;
+    let manager = new FileDefManagerImpl({
+      owner: null as unknown as any,
+      client: fakeClient,
+      getCardAPI: () => dummyApi,
+      getFileAPI: () => dummyApi,
+    }) as any;
+
+    const content = 'realm-url-test-content';
+    const contentHash = await manager.getContentHash(content);
+
+    // Stub downloadContentAsBytes — should NOT be called for non-Matrix URLs
+    let downloadCalled = false;
+    manager.downloadContentAsBytes = async (_url: string) => {
+      downloadCalled = true;
+      return new TextEncoder().encode(content);
+    };
+
+    const realmUrl = 'http://localhost:4201/experiments/image.png';
+    await manager.recacheContentHash(contentHash, realmUrl);
+
+    assert.false(
+      downloadCalled,
+      'downloadContentAsBytes should not be called for non-Matrix URLs',
+    );
+    assert.strictEqual(
+      manager.contentHashCache.get(contentHash),
+      undefined,
+      'contentHashCache should not contain a realm URL',
+    );
+  });
+
 });

--- a/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
+++ b/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
@@ -299,4 +299,141 @@ module('Unit | file-def-manager canonicalize', function () {
       'prefetched bytes are cleared after successful upload',
     );
   });
+
+  test('uploadFiles preserves known image content type when prefetched type is generic', async function (assert) {
+    assert.expect(3);
+
+    let uploadedType: string | undefined;
+    let fakeClient: any = {
+      getAccessToken() {
+        return 'fake-token';
+      },
+      uploadContent(
+        _content: XMLHttpRequestBodyInit,
+        opts?: { type?: string },
+      ) {
+        uploadedType = opts?.type;
+        return Promise.resolve({
+          content_uri: 'mxc://localhost/workspace-image-upload',
+        });
+      },
+      mxcUrlToHttp(mxc: string) {
+        return `http://localhost/_matrix/media/v3/download/localhost/${mxc.split('/').pop()}`;
+      },
+    };
+
+    let manager = new FileDefManagerImpl({
+      owner: null as unknown as any,
+      client: fakeClient,
+      getCardAPI: () => ({}) as any,
+      getFileAPI: () => ({}) as any,
+    }) as any;
+
+    let workspaceImageFile: any = {
+      sourceUrl: 'http://test-realm-server/my-realm/diagram.png',
+      name: 'diagram.png',
+      contentType: 'image/png',
+      serialize() {
+        return {
+          sourceUrl: this.sourceUrl,
+          name: this.name,
+          url: this.url,
+          contentType: this.contentType,
+          contentHash: this.contentHash,
+          contentSize: this.contentSize,
+        };
+      },
+    };
+
+    let bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    await manager.prefetchLocalFileContent(
+      workspaceImageFile,
+      bytes,
+      'application/vnd.card+source',
+    );
+    await manager.uploadFiles([workspaceImageFile]);
+
+    assert.strictEqual(
+      uploadedType,
+      'image/png',
+      'uploads workspace image bytes using original image mime type',
+    );
+    assert.strictEqual(
+      workspaceImageFile.contentType,
+      'image/png',
+      'retains image contentType instead of generic fetched type',
+    );
+    assert.ok(workspaceImageFile.url, 'sets uploaded URL');
+  });
+
+  test('uploadFiles ignores stale non-Matrix content-hash cache entry and uploads fresh media', async function (assert) {
+    assert.expect(3);
+
+    let uploadCalls = 0;
+    let fakeClient: any = {
+      getAccessToken() {
+        return 'fake-token';
+      },
+      uploadContent(
+        _content: XMLHttpRequestBodyInit,
+        opts?: { type?: string },
+      ) {
+        uploadCalls++;
+        assert.strictEqual(opts?.type, 'image/png', 'uploads with image mime');
+        return Promise.resolve({
+          content_uri: `mxc://localhost/fresh-upload-${uploadCalls}`,
+        });
+      },
+      mxcUrlToHttp(mxc: string) {
+        return `http://localhost/_matrix/media/v3/download/localhost/${mxc.split('/').pop()}`;
+      },
+    };
+
+    let manager = new FileDefManagerImpl({
+      owner: null as unknown as any,
+      client: fakeClient,
+      getCardAPI: () => ({}) as any,
+      getFileAPI: () => ({}) as any,
+    }) as any;
+
+    let workspaceImageFile: any = {
+      sourceUrl: 'http://test-realm-server/my-realm/stale-cache.png',
+      name: 'stale-cache.png',
+      contentType: 'image/png',
+      serialize() {
+        return {
+          sourceUrl: this.sourceUrl,
+          name: this.name,
+          url: this.url,
+          contentType: this.contentType,
+          contentHash: this.contentHash,
+          contentSize: this.contentSize,
+        };
+      },
+    };
+
+    let bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x01]);
+    await manager.prefetchLocalFileContent(
+      workspaceImageFile,
+      bytes,
+      'image/png',
+    );
+    let staleHash = await manager.getContentHash(bytes);
+    manager.contentHashCache.set(
+      staleHash,
+      'http://test-realm-server/my-realm/stale-cache.png',
+    );
+
+    await manager.uploadFiles([workspaceImageFile]);
+
+    assert.strictEqual(
+      uploadCalls,
+      1,
+      'stale non-Matrix cache entry is ignored',
+    );
+    assert.true(
+      String(workspaceImageFile.url).includes('/_matrix/media/'),
+      'file URL is refreshed to Matrix media URL',
+    );
+  });
 });

--- a/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
+++ b/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
@@ -116,4 +116,120 @@ module('Unit | file-def-manager canonicalize', function () {
       'contentHashCache should not contain a realm URL',
     );
   });
+
+  test('uploadFiles throws when local file content was not prefetched', async function (assert) {
+    assert.expect(1);
+
+    let fakeClient: any = {
+      getAccessToken() {
+        return 'fake-token';
+      },
+      uploadContent() {
+        return Promise.resolve({ content_uri: 'mxc://localhost/FAKE' });
+      },
+      mxcUrlToHttp(mxc: string) {
+        return `http://localhost/_matrix/media/v3/download/localhost/${mxc.split('/').pop()}`;
+      },
+    };
+
+    const fakeCardApi = {
+      serializeCard(card: any) {
+        return {
+          data: {
+            type: 'file-meta',
+            attributes: card.serialize(),
+          },
+        };
+      },
+    } as any;
+    const fakeFileApi = {} as any;
+    let manager = new FileDefManagerImpl({
+      owner: null as unknown as any,
+      client: fakeClient,
+      getCardAPI: () => fakeCardApi,
+      getFileAPI: () => fakeFileApi,
+    }) as any;
+
+    let localFile: any = {
+      sourceUrl: 'boxel-local://local-id/local.txt',
+      name: 'local.txt',
+      serialize() {
+        return {
+          sourceUrl: this.sourceUrl,
+          name: this.name,
+          contentType: this.contentType,
+          contentHash: this.contentHash,
+          contentSize: this.contentSize,
+        };
+      },
+    };
+
+    try {
+      await manager.uploadFiles([localFile]);
+      assert.ok(false, 'expected upload to throw');
+    } catch (e: any) {
+      assert.true(
+        String(e?.message).includes('Local file content is not available'),
+        'throws actionable error for missing local prefetch bytes',
+      );
+    }
+  });
+
+  test('uploadFiles uploads local file bytes from prefetched content', async function (assert) {
+    assert.expect(3);
+
+    let uploadCalls: any[] = [];
+    let callCounter = 0;
+    let fakeClient: any = {
+      getAccessToken() {
+        return 'fake-token';
+      },
+      uploadContent(content: XMLHttpRequestBodyInit) {
+        callCounter++;
+        uploadCalls.push(content);
+        return Promise.resolve({
+          content_uri: `mxc://localhost/upload-${callCounter}`,
+        });
+      },
+      mxcUrlToHttp(mxc: string) {
+        return `http://localhost/_matrix/media/v3/download/localhost/${mxc.split('/').pop()}`;
+      },
+    };
+
+    const fakeCardApi = {} as any;
+    const fakeFileApi = {} as any;
+    let manager = new FileDefManagerImpl({
+      owner: null as unknown as any,
+      client: fakeClient,
+      getCardAPI: () => fakeCardApi,
+      getFileAPI: () => fakeFileApi,
+    }) as any;
+
+    let localFile: any = {
+      sourceUrl: 'boxel-local://local-id/local.txt',
+      name: 'local.txt',
+      serialize() {
+        return {
+          sourceUrl: this.sourceUrl,
+          name: this.name,
+          url: this.url,
+          contentType: this.contentType,
+          contentHash: this.contentHash,
+          contentSize: this.contentSize,
+        };
+      },
+    };
+
+    let bytes = new TextEncoder().encode('hello local file');
+    await manager.prefetchLocalFileContent(localFile, bytes, 'text/plain');
+    await manager.uploadFiles([localFile]);
+
+    assert.strictEqual(uploadCalls.length, 1, 'uploaded local file bytes once');
+    assert.ok(localFile.url, 'sets uploaded file URL');
+    assert.strictEqual(
+      localFile.contentType,
+      'text/plain',
+      'sets file content type from prefetched local bytes',
+    );
+  });
 });

--- a/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
+++ b/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
@@ -4,6 +4,26 @@ import { canonicalizeMatrixMediaKey } from '@cardstack/runtime-common/ai/matrix-
 
 import FileDefManagerImpl from '@cardstack/host/lib/file-def-manager';
 
+function makeFakeFileApi() {
+  return {
+    createFileDef(initial: any) {
+      return {
+        ...initial,
+        serialize() {
+          return {
+            sourceUrl: this.sourceUrl,
+            name: this.name,
+            url: this.url,
+            contentType: this.contentType,
+            contentHash: this.contentHash,
+            contentSize: this.contentSize,
+          };
+        },
+      };
+    },
+  } as any;
+}
+
 module('Unit | file-def-manager canonicalize', function () {
   test('canonicalizeMatrixMediaKey normalizes various Matrix URLs to mxc://host/id', function (assert) {
     let cases = [
@@ -142,7 +162,7 @@ module('Unit | file-def-manager canonicalize', function () {
         };
       },
     } as any;
-    const fakeFileApi = {} as any;
+    const fakeFileApi = makeFakeFileApi();
     let manager = new FileDefManagerImpl({
       owner: null as unknown as any,
       client: fakeClient,
@@ -176,7 +196,7 @@ module('Unit | file-def-manager canonicalize', function () {
   });
 
   test('uploadFiles uploads local file bytes from prefetched content', async function (assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     let uploadCalls: any[] = [];
     let callCounter = 0;
@@ -197,7 +217,7 @@ module('Unit | file-def-manager canonicalize', function () {
     };
 
     const fakeCardApi = {} as any;
-    const fakeFileApi = {} as any;
+    const fakeFileApi = makeFakeFileApi();
     let manager = new FileDefManagerImpl({
       owner: null as unknown as any,
       client: fakeClient,
@@ -222,14 +242,19 @@ module('Unit | file-def-manager canonicalize', function () {
 
     let bytes = new TextEncoder().encode('hello local file');
     await manager.prefetchLocalFileContent(localFile, bytes, 'text/plain');
-    await manager.uploadFiles([localFile]);
+    let [uploadedFile] = await manager.uploadFiles([localFile]);
 
     assert.strictEqual(uploadCalls.length, 1, 'uploaded local file bytes once');
-    assert.ok(localFile.url, 'sets uploaded file URL');
+    assert.ok(uploadedFile.url, 'sets uploaded file URL');
     assert.strictEqual(
-      localFile.contentType,
+      uploadedFile.contentType,
       'text/plain',
       'sets file content type from prefetched local bytes',
+    );
+    assert.strictEqual(
+      localFile.url,
+      undefined,
+      'does not mutate original file def instance',
     );
   });
 
@@ -259,7 +284,7 @@ module('Unit | file-def-manager canonicalize', function () {
       owner: null as unknown as any,
       client: fakeClient,
       getCardAPI: () => ({}) as any,
-      getFileAPI: () => ({}) as any,
+      getFileAPI: () => makeFakeFileApi(),
     }) as any;
 
     let localFile: any = {
@@ -286,14 +311,14 @@ module('Unit | file-def-manager canonicalize', function () {
       'first upload attempt fails',
     );
 
-    await manager.uploadFiles([localFile]);
+    let [uploadedFile] = await manager.uploadFiles([localFile]);
 
     assert.strictEqual(
       uploadAttempt,
       2,
       'retries upload with prefetched bytes',
     );
-    assert.ok(localFile.url, 'retry succeeds and sets uploaded URL');
+    assert.ok(uploadedFile.url, 'retry succeeds and returns uploaded URL');
     assert.false(
       manager.prefetchedContent.has(localFile.sourceUrl),
       'prefetched bytes are cleared after successful upload',
@@ -326,7 +351,7 @@ module('Unit | file-def-manager canonicalize', function () {
       owner: null as unknown as any,
       client: fakeClient,
       getCardAPI: () => ({}) as any,
-      getFileAPI: () => ({}) as any,
+      getFileAPI: () => makeFakeFileApi(),
     }) as any;
 
     let workspaceImageFile: any = {
@@ -351,7 +376,7 @@ module('Unit | file-def-manager canonicalize', function () {
       bytes,
       'application/vnd.card+source',
     );
-    await manager.uploadFiles([workspaceImageFile]);
+    let [uploadedFile] = await manager.uploadFiles([workspaceImageFile]);
 
     assert.strictEqual(
       uploadedType,
@@ -359,11 +384,11 @@ module('Unit | file-def-manager canonicalize', function () {
       'uploads workspace image bytes using original image mime type',
     );
     assert.strictEqual(
-      workspaceImageFile.contentType,
+      uploadedFile.contentType,
       'image/png',
       'retains image contentType instead of generic fetched type',
     );
-    assert.ok(workspaceImageFile.url, 'sets uploaded URL');
+    assert.ok(uploadedFile.url, 'sets uploaded URL');
   });
 
   test('uploadFiles ignores stale non-Matrix content-hash cache entry and uploads fresh media', async function (assert) {
@@ -393,7 +418,7 @@ module('Unit | file-def-manager canonicalize', function () {
       owner: null as unknown as any,
       client: fakeClient,
       getCardAPI: () => ({}) as any,
-      getFileAPI: () => ({}) as any,
+      getFileAPI: () => makeFakeFileApi(),
     }) as any;
 
     let workspaceImageFile: any = {
@@ -424,7 +449,7 @@ module('Unit | file-def-manager canonicalize', function () {
       'http://test-realm-server/my-realm/stale-cache.png',
     );
 
-    await manager.uploadFiles([workspaceImageFile]);
+    let [uploadedFile] = await manager.uploadFiles([workspaceImageFile]);
 
     assert.strictEqual(
       uploadCalls,
@@ -432,7 +457,7 @@ module('Unit | file-def-manager canonicalize', function () {
       'stale non-Matrix cache entry is ignored',
     );
     assert.true(
-      String(workspaceImageFile.url).includes('/_matrix/media/'),
+      String(uploadedFile.url).includes('/_matrix/media/'),
       'file URL is refreshed to Matrix media URL',
     );
   });

--- a/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
+++ b/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
@@ -232,4 +232,71 @@ module('Unit | file-def-manager canonicalize', function () {
       'sets file content type from prefetched local bytes',
     );
   });
+
+  test('uploadFiles keeps prefetched local bytes on failure so retry succeeds', async function (assert) {
+    assert.expect(4);
+
+    let uploadAttempt = 0;
+    let fakeClient: any = {
+      getAccessToken() {
+        return 'fake-token';
+      },
+      uploadContent(_content: XMLHttpRequestBodyInit) {
+        uploadAttempt++;
+        if (uploadAttempt === 1) {
+          return Promise.reject(new Error('transient upload failure'));
+        }
+        return Promise.resolve({
+          content_uri: `mxc://localhost/upload-${uploadAttempt}`,
+        });
+      },
+      mxcUrlToHttp(mxc: string) {
+        return `http://localhost/_matrix/media/v3/download/localhost/${mxc.split('/').pop()}`;
+      },
+    };
+
+    let manager = new FileDefManagerImpl({
+      owner: null as unknown as any,
+      client: fakeClient,
+      getCardAPI: () => ({}) as any,
+      getFileAPI: () => ({}) as any,
+    }) as any;
+
+    let localFile: any = {
+      sourceUrl: 'boxel-local://local-id/retry.txt',
+      name: 'retry.txt',
+      serialize() {
+        return {
+          sourceUrl: this.sourceUrl,
+          name: this.name,
+          url: this.url,
+          contentType: this.contentType,
+          contentHash: this.contentHash,
+          contentSize: this.contentSize,
+        };
+      },
+    };
+
+    let bytes = new TextEncoder().encode('retry local file');
+    await manager.prefetchLocalFileContent(localFile, bytes, 'text/plain');
+
+    await assert.rejects(
+      manager.uploadFiles([localFile]),
+      /transient upload failure/,
+      'first upload attempt fails',
+    );
+
+    await manager.uploadFiles([localFile]);
+
+    assert.strictEqual(
+      uploadAttempt,
+      2,
+      'retries upload with prefetched bytes',
+    );
+    assert.ok(localFile.url, 'retry succeeds and sets uploaded URL');
+    assert.false(
+      manager.prefetchedContent.has(localFile.sourceUrl),
+      'prefetched bytes are cleared after successful upload',
+    );
+  });
 });

--- a/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
+++ b/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
@@ -58,8 +58,9 @@ module('Unit | file-def-manager canonicalize', function () {
     const content = 'canonical-test-content';
     const contentHash = await manager.getContentHash(content);
 
-    // Stub downloadContentAsText to return the content that matches the hash
-    manager.downloadContentAsText = async (_url: string) => content;
+    // Stub downloadContentAsBytes to return the content that matches the hash
+    manager.downloadContentAsBytes = async (_url: string) =>
+      new TextEncoder().encode(content);
 
     const originalUrl =
       'http://localhost/_matrix/media/v3/download/localhost/abc123/somefile.txt?version=1';

--- a/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
+++ b/packages/host/tests/unit/file-def-manager-canonicalize-test.ts
@@ -391,6 +391,92 @@ module('Unit | file-def-manager canonicalize', function () {
     assert.ok(uploadedFile.url, 'sets uploaded URL');
   });
 
+  test('uploadFiles infers image content type for workspace files when realm source reports text/plain', async function (assert) {
+    assert.expect(5);
+
+    let uploadedType: string | undefined;
+    let fakeClient: any = {
+      getAccessToken() {
+        return 'fake-token';
+      },
+      uploadContent(
+        _content: XMLHttpRequestBodyInit,
+        opts?: { type?: string },
+      ) {
+        uploadedType = opts?.type;
+        return Promise.resolve({
+          content_uri: 'mxc://localhost/workspace-inferred-image-upload',
+        });
+      },
+      mxcUrlToHttp(mxc: string) {
+        return `http://localhost/_matrix/media/v3/download/localhost/${mxc.split('/').pop()}`;
+      },
+    };
+
+    let manager = new FileDefManagerImpl({
+      owner: null as unknown as any,
+      client: fakeClient,
+      getCardAPI: () => ({}) as any,
+      getFileAPI: () => makeFakeFileApi(),
+    }) as any;
+
+    let imageBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x01]);
+    manager.network = {
+      authedFetch(url: string, opts?: { headers?: { Accept?: string } }) {
+        assert.strictEqual(
+          url,
+          'http://test-realm-server/my-realm/green-mango.png',
+          'fetches workspace file bytes from sourceUrl',
+        );
+        assert.strictEqual(
+          opts?.headers?.Accept,
+          'application/vnd.card+source',
+          'requests realm source representation',
+        );
+        return Promise.resolve({
+          arrayBuffer: async () => imageBytes.slice().buffer,
+          headers: {
+            get(name: string) {
+              if (name.toLowerCase() === 'content-type') {
+                return 'text/plain; charset=UTF-8';
+              }
+              return null;
+            },
+          },
+        });
+      },
+    } as any;
+
+    let workspaceImageFile: any = {
+      sourceUrl: 'http://test-realm-server/my-realm/green-mango.png',
+      name: 'green-mango.png',
+      serialize() {
+        return {
+          sourceUrl: this.sourceUrl,
+          name: this.name,
+          url: this.url,
+          contentType: this.contentType,
+          contentHash: this.contentHash,
+          contentSize: this.contentSize,
+        };
+      },
+    };
+
+    let [uploadedFile] = await manager.uploadFiles([workspaceImageFile]);
+
+    assert.strictEqual(
+      uploadedType,
+      'image/png',
+      'infers image MIME type from file name instead of using text/plain',
+    );
+    assert.strictEqual(
+      uploadedFile.contentType,
+      'image/png',
+      'uploaded file keeps inferred image MIME type',
+    );
+    assert.ok(uploadedFile.url, 'sets uploaded URL');
+  });
+
   test('uploadFiles ignores stale non-Matrix content-hash cache entry and uploads fresh media', async function (assert) {
     assert.expect(3);
 

--- a/packages/host/tsconfig.json
+++ b/packages/host/tsconfig.json
@@ -21,6 +21,7 @@
     "baseUrl": ".",
     "strict": true,
     "experimentalDecorators": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "paths": {
       "@cardstack/host/tests/*": ["tests/*"],

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -333,7 +333,7 @@ test.describe('Room messages', () => {
     expect(attachedFiles.length).toStrictEqual(1);
     expect(attachedFiles[0].name).toStrictEqual('person.gts');
     expect(attachedFiles[0].contentType).toStrictEqual(
-      'text/plain; charset=utf-8',
+      'text/typescript+glimmer',
     );
     expect(attachedFiles[0].sourceUrl).toStrictEqual(`${appURL}/person.gts`);
     expect(attachedFiles[0].url).toMatch(
@@ -442,7 +442,7 @@ test.describe('Room messages', () => {
     expect(petFile).toBeDefined();
     expect(petFile?.name).toStrictEqual('pet.gts');
     expect(petFile?.contentType).toStrictEqual(
-      'text/plain; charset=utf-8',
+      'text/typescript+glimmer',
     );
     expect(petFile?.sourceUrl).toStrictEqual(`${appURL}/pet.gts`);
     expect(petFile?.url).toMatch(

--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -282,8 +282,8 @@ module(basename(__filename), function () {
 
           assert.strictEqual(
             response.headers['content-type'],
-            'text/plain; charset=utf-8',
-            'content type is correct',
+            'text/typescript+glimmer',
+            'content type is correct for .gts source',
           );
           assert.strictEqual(
             readFileSync(
@@ -1126,6 +1126,82 @@ module(basename(__filename), function () {
             new Uint8Array(fileBytes),
             bytes,
             'file bytes match uploaded bytes',
+          );
+        });
+
+        test('card source GET returns correct content-type for image files', async function (assert) {
+          let bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+          await request
+            .post('/photo.png')
+            .set('Content-Type', 'application/octet-stream')
+            .send(Buffer.from(bytes));
+
+          let response = await request
+            .get('/photo.png')
+            .set('Accept', 'application/vnd.card+source');
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.headers['content-type'],
+            'image/png',
+            'content-type is image/png for .png files',
+          );
+        });
+
+        test('card source GET returns correct content-type for PDF files', async function (assert) {
+          let bytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // %PDF
+          await request
+            .post('/report.pdf')
+            .set('Content-Type', 'application/octet-stream')
+            .send(Buffer.from(bytes));
+
+          let response = await request
+            .get('/report.pdf')
+            .set('Accept', 'application/vnd.card+source');
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.headers['content-type'],
+            'application/pdf',
+            'content-type is application/pdf for .pdf files',
+          );
+        });
+
+        test('card source GET returns correct content-type for audio files', async function (assert) {
+          let bytes = new Uint8Array([0x49, 0x44, 0x33]); // ID3
+          await request
+            .post('/clip.mp3')
+            .set('Content-Type', 'application/octet-stream')
+            .send(Buffer.from(bytes));
+
+          let response = await request
+            .get('/clip.mp3')
+            .set('Accept', 'application/vnd.card+source');
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.headers['content-type'],
+            'audio/mpeg',
+            'content-type is audio/mpeg for .mp3 files',
+          );
+        });
+
+        test('card source GET returns correct content-type for video files', async function (assert) {
+          let bytes = new Uint8Array([0x00, 0x00, 0x00, 0x1c]);
+          await request
+            .post('/demo.mp4')
+            .set('Content-Type', 'application/octet-stream')
+            .send(Buffer.from(bytes));
+
+          let response = await request
+            .get('/demo.mp4')
+            .set('Accept', 'application/vnd.card+source');
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.headers['content-type'],
+            'video/mp4',
+            'content-type is video/mp4 for .mp4 files',
           );
         });
 

--- a/packages/runtime-common/ai/matrix-utils.ts
+++ b/packages/runtime-common/ai/matrix-utils.ts
@@ -347,6 +347,29 @@ export async function downloadFile(
   }
 }
 
+export async function downloadFileAsBase64DataUrl(
+  client: MatrixClient,
+  url: string,
+  contentType: string,
+): Promise<string> {
+  let response = await (globalThis as any).fetch(url, {
+    headers: {
+      Authorization: `Bearer ${client.getAccessToken()}`,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP error. Status: ${response.status}`);
+  }
+  let buffer = await response.arrayBuffer();
+  let bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  let base64 = btoa(binary);
+  return `data:${contentType};base64,${base64}`;
+}
+
 export function isCommandOrCodePatchResult(
   event: MatrixEvent | DiscreteMatrixEvent,
 ): boolean {

--- a/packages/runtime-common/ai/matrix-utils.ts
+++ b/packages/runtime-common/ai/matrix-utils.ts
@@ -237,6 +237,52 @@ function cleanupCache() {
   }
 }
 
+async function fetchMatrixMediaWithFallback(
+  client: MatrixClient,
+  url: string,
+): Promise<Response> {
+  let headers = {
+    Authorization: `Bearer ${client.getAccessToken()}`,
+  };
+
+  let primaryError: unknown;
+  try {
+    let primaryResponse = await (globalThis as any).fetch(url, { headers });
+    if (primaryResponse.ok) {
+      return primaryResponse;
+    }
+    primaryError = new Error(`HTTP error. Status: ${primaryResponse.status}`);
+  } catch (err) {
+    primaryError = err;
+  }
+
+  let canonical = canonicalizeMatrixMediaKey(url);
+  let fallbackUrl =
+    canonical?.startsWith('mxc://') && canonical !== url
+      ? client.mxcUrlToHttp(
+          canonical,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          true,
+        )
+      : null;
+  if (!fallbackUrl || fallbackUrl === url) {
+    throw primaryError;
+  }
+
+  let fallbackResponse = await (globalThis as any).fetch(fallbackUrl, {
+    headers,
+  });
+  if (!fallbackResponse.ok) {
+    throw new Error(`HTTP error. Status: ${fallbackResponse.status}`);
+  }
+
+  return fallbackResponse;
+}
+
 /**
  * Retrieves the last 1000 non-replace events from a Matrix room
  * @param roomId - The ID of the Matrix room
@@ -283,6 +329,10 @@ export async function downloadFile(
   client: MatrixClient,
   attachedFile: SerializedFileDef,
 ): Promise<string> {
+  let fileUrl = attachedFile?.url;
+  if (!fileUrl) {
+    throw new Error('Attached file URL is missing');
+  }
   if (
     !attachedFile?.contentType?.includes('text/') &&
     !attachedFile.contentType?.includes('application/vnd.card+json')
@@ -292,12 +342,12 @@ export async function downloadFile(
     );
   }
 
-  const canonicalKey = canonicalizeMatrixMediaKey(attachedFile.url);
+  const canonicalKey = canonicalizeMatrixMediaKey(fileUrl);
 
   // Check cache by canonical key first
   const cachedEntry = canonicalKey
     ? fileCache.get(canonicalKey)
-    : fileCache.get(attachedFile.url!);
+    : fileCache.get(fileUrl);
   if (cachedEntry) {
     // cache hit - minimal logging
     cachedEntry.timestamp = Date.now();
@@ -305,7 +355,7 @@ export async function downloadFile(
   }
 
   // If a fetch for this canonical key is already in-flight, wait for it instead
-  const inFlightKey = canonicalKey || attachedFile.url!;
+  const inFlightKey = canonicalKey || fileUrl;
   const inFlight = inFlightFetches.get(inFlightKey);
   if (inFlight) {
     return await inFlight;
@@ -315,19 +365,12 @@ export async function downloadFile(
 
   // create an in-flight promise and store it so others can await
   const fetchPromise = (async () => {
-    let response = await (globalThis as any).fetch(attachedFile.url, {
-      headers: {
-        Authorization: `Bearer ${client.getAccessToken()}`,
-      },
-    });
-    if (!response.ok) {
-      throw new Error(`HTTP error. Status: ${response.status}`);
-    }
+    let response = await fetchMatrixMediaWithFallback(client, fileUrl);
 
     const content = await response.text();
 
     // store in cache under canonical key when available
-    const cacheKey = canonicalKey || attachedFile.url!;
+    const cacheKey = canonicalKey || fileUrl;
     fileCache.set(cacheKey, {
       content,
       timestamp: Date.now(),
@@ -352,14 +395,7 @@ export async function downloadFileAsBase64DataUrl(
   url: string,
   contentType: string,
 ): Promise<string> {
-  let response = await (globalThis as any).fetch(url, {
-    headers: {
-      Authorization: `Bearer ${client.getAccessToken()}`,
-    },
-  });
-  if (!response.ok) {
-    throw new Error(`HTTP error. Status: ${response.status}`);
-  }
+  let response = await fetchMatrixMediaWithFallback(client, url);
   let buffer = await response.arrayBuffer();
   let bytes = new Uint8Array(buffer);
   let maybeBuffer = (globalThis as any).Buffer;

--- a/packages/runtime-common/ai/matrix-utils.ts
+++ b/packages/runtime-common/ai/matrix-utils.ts
@@ -362,11 +362,25 @@ export async function downloadFileAsBase64DataUrl(
   }
   let buffer = await response.arrayBuffer();
   let bytes = new Uint8Array(buffer);
-  let binary = '';
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
+  let maybeBuffer = (globalThis as any).Buffer;
+  if (maybeBuffer?.from) {
+    let base64 = maybeBuffer.from(bytes).toString('base64');
+    return `data:${contentType};base64,${base64}`;
   }
-  let base64 = btoa(binary);
+
+  let btoaFn = (globalThis as any).btoa;
+  if (typeof btoaFn !== 'function') {
+    throw new Error('No base64 encoder available in this runtime');
+  }
+
+  // Build binary string in chunks to avoid quadratic concatenation behavior.
+  let binaryChunks: string[] = [];
+  let chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    let chunk = bytes.subarray(i, i + chunkSize);
+    binaryChunks.push(String.fromCharCode(...chunk));
+  }
+  let base64 = btoaFn(binaryChunks.join(''));
   return `data:${contentType};base64,${base64}`;
 }
 

--- a/packages/runtime-common/ai/modality.ts
+++ b/packages/runtime-common/ai/modality.ts
@@ -39,6 +39,16 @@ export function modalityLabel(modality: Modality): string {
   return MODALITY_LABELS[modality];
 }
 
+// Matches the server-side isTextBasedContentType in prompt.ts — files with
+// these types get their full content downloaded and sent as text.
+export function isTextBasedContentType(contentType?: string): boolean {
+  return (
+    !!contentType &&
+    (contentType.includes('text/') ||
+      contentType.includes('application/vnd.card+json'))
+  );
+}
+
 export {
   isImageContentType,
   isPdfContentType,

--- a/packages/runtime-common/ai/modality.ts
+++ b/packages/runtime-common/ai/modality.ts
@@ -1,0 +1,47 @@
+// Maps MIME content types to OpenRouter input modality names.
+// Used by both prompt construction (server-side) and the UI (client-side)
+// to determine which modality a file requires.
+
+function isImageContentType(contentType?: string): boolean {
+  return !!contentType && contentType.startsWith('image/');
+}
+
+function isPdfContentType(contentType?: string): boolean {
+  return !!contentType && contentType.includes('application/pdf');
+}
+
+function isAudioContentType(contentType?: string): boolean {
+  return !!contentType && contentType.startsWith('audio/');
+}
+
+function isVideoContentType(contentType?: string): boolean {
+  return !!contentType && contentType.startsWith('video/');
+}
+
+export type Modality = 'image' | 'file' | 'audio' | 'video';
+
+export function requiredModality(contentType?: string): Modality | undefined {
+  if (isImageContentType(contentType)) return 'image';
+  if (isPdfContentType(contentType)) return 'file';
+  if (isAudioContentType(contentType)) return 'audio';
+  if (isVideoContentType(contentType)) return 'video';
+  return undefined;
+}
+
+const MODALITY_LABELS: Record<Modality, string> = {
+  image: 'image files',
+  file: 'PDF files',
+  audio: 'audio files',
+  video: 'video files',
+};
+
+export function modalityLabel(modality: Modality): string {
+  return MODALITY_LABELS[modality];
+}
+
+export {
+  isImageContentType,
+  isPdfContentType,
+  isAudioContentType,
+  isVideoContentType,
+};

--- a/packages/runtime-common/ai/modality.ts
+++ b/packages/runtime-common/ai/modality.ts
@@ -2,8 +2,17 @@
 // Used by both prompt construction (server-side) and the UI (client-side)
 // to determine which modality a file requires.
 
+// Only image formats broadly supported by OpenRouter providers (Anthropic, OpenAI, Google).
+// Unsupported formats like AVIF, TIFF, BMP fall through to metadata-only.
+const SUPPORTED_IMAGE_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+]);
+
 function isImageContentType(contentType?: string): boolean {
-  return !!contentType && contentType.startsWith('image/');
+  return !!contentType && SUPPORTED_IMAGE_TYPES.has(contentType);
 }
 
 function isPdfContentType(contentType?: string): boolean {

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -1,7 +1,7 @@
 import type { MatrixClient, MatrixEvent } from 'matrix-js-sdk';
 import type {
   ChatCompletionMessageToolCall,
-  ImageContentPart,
+  ContentPart,
   OpenAIPromptMessage,
   PendingCodePatchCorrectnessCheck,
   CodePatchCorrectnessCard,
@@ -17,6 +17,13 @@ import {
   isCommandOrCodePatchResult,
 } from './matrix-utils';
 import { isRecognisedDebugCommand } from './debug';
+import {
+  isImageContentType,
+  isPdfContentType,
+  isAudioContentType,
+  isVideoContentType,
+  requiredModality,
+} from './modality';
 import type {
   ActiveLLMEvent,
   BoxelContext,
@@ -109,8 +116,25 @@ function isTextBasedContentType(contentType?: string): boolean {
   );
 }
 
-function isImageContentType(contentType?: string): boolean {
-  return !!contentType && contentType.startsWith('image/');
+const AUDIO_MIME_TO_FORMAT: Record<string, string> = {
+  'audio/wav': 'wav',
+  'audio/wave': 'wav',
+  'audio/x-wav': 'wav',
+  'audio/mpeg': 'mp3',
+  'audio/mp3': 'mp3',
+  'audio/aac': 'aac',
+  'audio/x-aac': 'aac',
+  'audio/ogg': 'ogg',
+  'audio/flac': 'flac',
+  'audio/x-flac': 'flac',
+  'audio/mp4': 'm4a',
+  'audio/x-m4a': 'm4a',
+  'audio/aiff': 'aiff',
+  'audio/x-aiff': 'aiff',
+};
+
+function audioFormatFromMime(contentType: string): string | undefined {
+  return AUDIO_MIME_TO_FORMAT[contentType.split(';')[0].trim().toLowerCase()];
 }
 
 // ── Read-file command scope helpers ──────────────────────────────────
@@ -199,6 +223,8 @@ export async function getPromptParts(
   let disabledSkillIds = await getDisabledSkillIds(eventList);
   let tools = await getTools(eventList, skills, aiBotUserId, client);
   let toolChoice = getToolChoice(history, aiBotUserId);
+  let { model, toolsSupported, reasoningEffort, inputModalities } =
+    getActiveLLMDetails(eventList);
   let messages = await buildPromptForModel(
     history,
     aiBotUserId,
@@ -206,9 +232,8 @@ export async function getPromptParts(
     skills,
     disabledSkillIds,
     client,
+    inputModalities,
   );
-  let { model, toolsSupported, reasoningEffort } =
-    getActiveLLMDetails(eventList);
   return {
     shouldRespond,
     tools,
@@ -1272,6 +1297,7 @@ export async function buildPromptForModel(
   skillCards: LooseCardResource[] = [],
   disabledSkillIds: string[] = [],
   client: MatrixClient,
+  inputModalities?: string[],
 ) {
   // Need to make sure the passed in username is a full id
   if (
@@ -1337,21 +1363,17 @@ export async function buildPromptForModel(
         event as CardMessageEvent,
         history,
         isCurrentMessage,
+        inputModalities,
       );
-      if (attachmentResult.imageUrls.length > 0) {
+      if (attachmentResult.mediaParts.length > 0) {
         let textContent = [body, attachmentResult.text]
           .filter(Boolean)
           .join('\n\n');
-        let contentParts: (TextContent | ImageContentPart)[] = [];
+        let contentParts: ContentPart[] = [];
         if (textContent) {
           contentParts.push({ type: 'text', text: textContent });
         }
-        for (let imageUrl of attachmentResult.imageUrls) {
-          contentParts.push({
-            type: 'image_url',
-            image_url: { url: imageUrl },
-          });
-        }
+        contentParts.push(...attachmentResult.mediaParts);
         if (contentParts.length) {
           historicalMessages.push({ role: 'user', content: contentParts });
         }
@@ -1886,7 +1908,8 @@ export const buildAttachmentsMessagePart = async (
   matrixEvent: MatrixEventWithBoxelContext,
   history: DiscreteMatrixEvent[],
   isCurrentMessage: boolean = false,
-): Promise<{ text: string; imageUrls: string[] }> => {
+  inputModalities?: string[],
+): Promise<{ text: string; mediaParts: ContentPart[] }> => {
   let attachedCards = await getAttachedCards(client, matrixEvent, history);
   let text = '';
   if (attachedCards.length > 0) {
@@ -1898,37 +1921,101 @@ export const buildAttachmentsMessagePart = async (
     history,
     isCurrentMessage,
   );
-  let imageUrls: string[] = [];
-  let imageSourceUrlsIncludedAsImageParts = new Set<string>();
+  let mediaParts: ContentPart[] = [];
+  let mediaSourceUrls = new Set<string>();
+  let unsupportedFiles: { name: string; contentType: string }[] = [];
   if (isCurrentMessage) {
-    let imageFiles = attachedFiles.filter(
-      (f) => isImageContentType(f.contentType) && f.url,
-    );
-    for (let f of imageFiles) {
+    for (let f of attachedFiles) {
+      if (!f.url) {
+        continue;
+      }
+      // Check model capability before downloading
+      let modality = requiredModality(f.contentType);
+      if (!modality) {
+        continue; // not a multimodal type — handled as text metadata below
+      }
+      if (inputModalities && !inputModalities.includes(modality)) {
+        unsupportedFiles.push({
+          name: f.name ?? 'unknown',
+          contentType: f.contentType ?? 'unknown',
+        });
+        continue;
+      }
       try {
-        let dataUrl = await downloadFileAsBase64DataUrl(
-          client,
-          f.url!,
-          f.contentType!,
-        );
-        imageUrls.push(dataUrl);
+        if (isImageContentType(f.contentType)) {
+          let dataUrl = await downloadFileAsBase64DataUrl(
+            client,
+            f.url,
+            f.contentType!,
+          );
+          mediaParts.push({
+            type: 'image_url',
+            image_url: { url: dataUrl },
+          });
+        } else if (isPdfContentType(f.contentType)) {
+          let dataUrl = await downloadFileAsBase64DataUrl(
+            client,
+            f.url,
+            f.contentType!,
+          );
+          mediaParts.push({
+            type: 'file',
+            file: {
+              filename: f.name ?? 'document.pdf',
+              file_data: dataUrl,
+            },
+          });
+        } else if (isAudioContentType(f.contentType)) {
+          let format = audioFormatFromMime(f.contentType!);
+          if (!format) {
+            getLog().error(`Unsupported audio format: ${f.contentType}`);
+            continue;
+          }
+          let dataUrl = await downloadFileAsBase64DataUrl(
+            client,
+            f.url,
+            f.contentType!,
+          );
+          // Strip data URL prefix — OpenRouter expects raw base64 for audio
+          let base64 = dataUrl.replace(/^data:[^;]+;base64,/, '');
+          mediaParts.push({
+            type: 'input_audio',
+            input_audio: { data: base64, format },
+          });
+        } else if (isVideoContentType(f.contentType)) {
+          let dataUrl = await downloadFileAsBase64DataUrl(
+            client,
+            f.url,
+            f.contentType!,
+          );
+          mediaParts.push({
+            type: 'video_url',
+            video_url: { url: dataUrl },
+          });
+        }
         if (f.sourceUrl) {
-          imageSourceUrlsIncludedAsImageParts.add(f.sourceUrl);
+          mediaSourceUrls.add(f.sourceUrl);
         }
       } catch (e) {
-        getLog().error(`Failed to download image ${f.url}:`, e);
+        getLog().error(`Failed to download media file ${f.url}:`, e);
       }
     }
+  }
+  if (unsupportedFiles.length > 0) {
+    let fileList = unsupportedFiles
+      .map((f) => `${f.name} (${f.contentType})`)
+      .join(', ');
+    text += `Note: The following files were not sent to the model because it does not support their input type: ${fileList}\n`;
   }
   if (attachedFiles.length > 0) {
     text += `Attached Files (files with newer versions don't show their content):\n${attachedFilesToMessage(
       attachedFiles,
       {
-        omitSourceUrls: imageSourceUrlsIncludedAsImageParts,
+        omitSourceUrls: mediaSourceUrls,
       },
     )}\n`;
   }
-  return { text, imageUrls };
+  return { text, mediaParts };
 };
 
 export const buildContextMessage = async (
@@ -2132,6 +2219,7 @@ function getActiveLLMDetails(eventlist: DiscreteMatrixEvent[]): {
   model: string;
   toolsSupported?: boolean;
   reasoningEffort?: ReasoningEffort;
+  inputModalities?: string[];
 } {
   let activeLLMEvent = findLast(
     eventlist,
@@ -2150,6 +2238,7 @@ function getActiveLLMDetails(eventlist: DiscreteMatrixEvent[]): {
     reasoningEffort: normalizeReasoningEffort(
       activeLLMEvent.content.reasoningEffort,
     ),
+    inputModalities: activeLLMEvent.content.inputModalities,
   };
 }
 

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -1,6 +1,7 @@
 import type { MatrixClient, MatrixEvent } from 'matrix-js-sdk';
 import type {
   ChatCompletionMessageToolCall,
+  ImageContentPart,
   OpenAIPromptMessage,
   PendingCodePatchCorrectnessCheck,
   CodePatchCorrectnessCard,
@@ -65,6 +66,47 @@ const CHECK_CORRECTNESS_COMMAND_NAME = 'checkCorrectness';
 
 function getLog() {
   return logger('ai-bot:prompt');
+}
+
+function isTextBasedContentType(contentType?: string): boolean {
+  return (
+    !!contentType &&
+    (contentType.includes('text/') ||
+      contentType.includes('application/vnd.card+json'))
+  );
+}
+
+function isImageContentType(contentType?: string): boolean {
+  return !!contentType && contentType.startsWith('image/');
+}
+
+function isReadFileCommand(request?: CommandRequest): boolean {
+  return !!request?.name?.startsWith('read-file-for-ai-assistant');
+}
+
+function getReadFileUrl(request?: CommandRequest): string | undefined {
+  try {
+    let args =
+      typeof request?.arguments === 'string'
+        ? JSON.parse(request.arguments)
+        : request?.arguments;
+    return args?.attributes?.fileUrl;
+  } catch {
+    return undefined;
+  }
+}
+
+function isFileAttachedInRoom(
+  fileUrl: string,
+  history: DiscreteMatrixEvent[],
+): boolean {
+  return history.some((event) => {
+    let attachedFiles = (event as MatrixEventWithBoxelContext).content?.data
+      ?.attachedFiles;
+    return attachedFiles?.some(
+      (f: SerializedFileDef) => f.sourceUrl === fileUrl,
+    );
+  });
 }
 
 export async function getPromptParts(
@@ -466,15 +508,16 @@ export async function getAttachedFiles(
   client: MatrixClient,
   matrixEvent: MatrixEventWithBoxelContext,
   history: DiscreteMatrixEvent[],
+  isCurrentMessage: boolean = false,
 ): Promise<SerializedFileDef[]> {
   let attachedFiles = matrixEvent.content?.data?.attachedFiles ?? [];
   return Promise.all(
     attachedFiles.map(async (attachedFile: SerializedFileDef) => {
-      // If the file is attached later in the history, we should not include the content here
-      let shouldIncludeContent = !history
+      // Only download content for the most recent user message's files,
+      // and only if the file isn't superseded by a later attachment
+      let isSuperseded = history
         .slice(history.indexOf(matrixEvent) + 1)
         .some((event) => {
-          // event is not always MatrixEventWithBoxelContext but casting lets us safely check attachedFiles
           return (
             event as MatrixEventWithBoxelContext
           ).content?.data?.attachedFiles?.some(
@@ -482,12 +525,17 @@ export async function getAttachedFiles(
               file.sourceUrl === attachedFile.sourceUrl,
           );
         });
+      let shouldIncludeContent =
+        isCurrentMessage &&
+        !isSuperseded &&
+        isTextBasedContentType(attachedFile.contentType);
 
       let result: SerializedFileDef = {
         url: attachedFile.url,
         sourceUrl: attachedFile.sourceUrl ?? '',
         name: attachedFile.name,
         contentType: attachedFile.contentType,
+        contentSize: attachedFile.contentSize,
       };
       if (shouldIncludeContent) {
         try {
@@ -540,6 +588,15 @@ export async function loadCurrentlySerializedFileDefs(
 
   return Promise.all(
     attachedFiles.map(async (attachedFile: SerializedFileDef) => {
+      if (!isTextBasedContentType(attachedFile.contentType)) {
+        return {
+          url: attachedFile.url,
+          sourceUrl: attachedFile.sourceUrl ?? '',
+          name: attachedFile.name,
+          contentType: attachedFile.contentType,
+          contentSize: attachedFile.contentSize,
+        };
+      }
       try {
         let content = await downloadFile(client, attachedFile);
 
@@ -572,6 +629,7 @@ export function attachedFilesToMessage(
     return 'No attached files';
   }
   return attachedFiles
+    .filter((f) => !isImageContentType(f.contentType))
     .map((f) => {
       let hyperlink = f.sourceUrl ? `[${f.name}](${f.sourceUrl})` : f.name;
       if (f.error) {
@@ -588,6 +646,11 @@ export function attachedFilesToMessage(
           )
           .join('\n');
         return `${hyperlink}:\n${numberedContent}`;
+      } else if (!isTextBasedContentType(f.contentType) && f.contentType) {
+        let meta = [f.contentType, f.contentSize ? `${f.contentSize} bytes` : '']
+          .filter(Boolean)
+          .join(', ');
+        return `${hyperlink}: [${meta}]`;
       } else {
         return `${hyperlink}`;
       }
@@ -797,6 +860,13 @@ async function toResultMessages(
           );
           content = checkCorrectnessContent.toolMessage;
           followUpUserMessage = checkCorrectnessContent.followUpUserMessage;
+        } else if (isReadFileCommand(decodedCommandRequest)) {
+          let fileUrl = getReadFileUrl(decodedCommandRequest);
+          if (fileUrl && !isFileAttachedInRoom(fileUrl, history)) {
+            content = `Tool call rejected: the file "${fileUrl}" was not previously attached in the room. Only files attached by the user can be read.\n`;
+          } else {
+            content = `Tool call ${status == 'applied' ? 'executed' : status}.\n`;
+          }
         } else if (
           commandResult.content.msgtype ===
             APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE &&
@@ -809,12 +879,15 @@ async function toResultMessages(
         } else {
           content = `Tool call ${status == 'applied' ? 'executed' : status}.\n`;
         }
-        let attachments = await buildAttachmentsMessagePart(
+        let attachmentResult = await buildAttachmentsMessagePart(
           client,
           commandResult,
           history,
+          true,
         );
-        content = [content, attachments].filter(Boolean).join('\n\n');
+        content = [content, attachmentResult.text]
+          .filter(Boolean)
+          .join('\n\n');
         let toolMessage: OpenAIPromptMessage = {
           role: 'tool',
           tool_call_id: commandRequest.id,
@@ -1188,6 +1261,13 @@ export async function buildPromptForModel(
     throw new Error("Username must be a full id, e.g. '@aibot:localhost'");
   }
   let historicalMessages: OpenAIPromptMessage[] = [];
+  let lastUserMessageEvent = findLast(
+    history,
+    (event) =>
+      event.sender !== aiBotUserId &&
+      event.type === 'm.room.message' &&
+      !isCommandOrCodePatchResult(event),
+  );
   for (let event of history) {
     if (event.type !== 'm.room.message') {
       continue;
@@ -1231,17 +1311,40 @@ export async function buildPromptForModel(
       ).forEach((message) => historicalMessages.push(message));
     }
     if (event.sender !== aiBotUserId) {
-      let attachments = await buildAttachmentsMessagePart(
+      let isCurrentMessage = event === lastUserMessageEvent;
+      let attachmentResult = await buildAttachmentsMessagePart(
         client,
         event as CardMessageEvent,
         history,
+        isCurrentMessage,
       );
-      let content = [body, attachments].filter(Boolean).join('\n\n');
-      if (content) {
-        historicalMessages.push({
-          role: 'user',
-          content,
-        });
+      if (attachmentResult.imageUrls.length > 0) {
+        let textContent = [body, attachmentResult.text]
+          .filter(Boolean)
+          .join('\n\n');
+        let contentParts: (TextContent | ImageContentPart)[] = [];
+        if (textContent) {
+          contentParts.push({ type: 'text', text: textContent });
+        }
+        for (let imageUrl of attachmentResult.imageUrls) {
+          contentParts.push({
+            type: 'image_url',
+            image_url: { url: imageUrl },
+          });
+        }
+        if (contentParts.length) {
+          historicalMessages.push({ role: 'user', content: contentParts });
+        }
+      } else {
+        let content = [body, attachmentResult.text]
+          .filter(Boolean)
+          .join('\n\n');
+        if (content) {
+          historicalMessages.push({
+            role: 'user',
+            content,
+          });
+        }
       }
     }
   }
@@ -1762,17 +1865,29 @@ export const buildAttachmentsMessagePart = async (
   client: MatrixClient,
   matrixEvent: MatrixEventWithBoxelContext,
   history: DiscreteMatrixEvent[],
-) => {
+  isCurrentMessage: boolean = false,
+): Promise<{ text: string; imageUrls: string[] }> => {
   let attachedCards = await getAttachedCards(client, matrixEvent, history);
-  let result = '';
+  let text = '';
   if (attachedCards.length > 0) {
-    result += `Attached Cards (cards with newer versions don't show their content):\n${JSON.stringify(attachedCards, null, 2)}\n`;
+    text += `Attached Cards (cards with newer versions don't show their content):\n${JSON.stringify(attachedCards, null, 2)}\n`;
   }
-  let attachedFiles = await getAttachedFiles(client, matrixEvent, history);
+  let attachedFiles = await getAttachedFiles(
+    client,
+    matrixEvent,
+    history,
+    isCurrentMessage,
+  );
   if (attachedFiles.length > 0) {
-    result += `Attached Files (files with newer versions don't show their content):\n${attachedFilesToMessage(attachedFiles)}\n`;
+    text += `Attached Files (files with newer versions don't show their content):\n${attachedFilesToMessage(attachedFiles)}\n`;
   }
-  return result;
+  let imageUrls: string[] = [];
+  if (isCurrentMessage) {
+    imageUrls = attachedFiles
+      .filter((f) => isImageContentType(f.contentType) && f.url)
+      .map((f) => f.url!);
+  }
+  return { text, imageUrls };
 };
 
 export const buildContextMessage = async (

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -91,15 +91,27 @@ function getLog() {
  *    sourceUrl) is re-attached in a later event, the earlier version
  *    is shown as metadata only (the later version wins).
  *
- * 3. **MIME type handling**:
+ * 3. **MIME type handling** (see `modality.ts` for classification):
  *    - Text-based types (text/*, application/vnd.card+json) → content
  *      downloaded and displayed with line numbers.
- *    - Image types (image/*) → presented as native image_url content
- *      parts for vision-capable models.
- *    - Other types (PDF, binary, etc.) → metadata shown inline
- *      ([contentType, contentSize bytes]) without an error prefix.
+ *    - Supported images (PNG, JPEG, WEBP, GIF) → native `image_url`
+ *      content parts.
+ *    - PDF (application/pdf) → native `file` content parts with base64
+ *      data URL in `file_data`.
+ *    - Audio (audio/*) → native `input_audio` content parts with raw
+ *      base64 and format string (data URL prefix stripped).
+ *    - Video (video/*) → native `video_url` content parts with base64
+ *      data URL.
+ *    - Other types → metadata shown inline ([contentType, contentSize
+ *      bytes]) without an error prefix.
  *
- * 4. **Read-file command scoping**: When the AI requests to read a file
+ * 4. **Model capability gating**: When `inputModalities` is provided
+ *    (from the active LLM's model configuration), multimodal parts are
+ *    only included if the model supports the required modality. Gated
+ *    files are listed in a warning appended to the prompt text. When
+ *    `inputModalities` is undefined, all modalities pass through.
+ *
+ * 5. **Read-file command scoping**: When the AI requests to read a file
  *    via a tool call, the file URL must match a sourceUrl previously
  *    attached by the user in the same room. Unrecognised URLs produce
  *    a rejection message in the tool result.

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -633,12 +633,22 @@ export async function loadCurrentlySerializedFileDefs(
 
 export function attachedFilesToMessage(
   attachedFiles: SerializedFileDef[],
+  options?: {
+    omitSourceUrls?: Set<string>;
+  },
 ): string {
   if (!attachedFiles.length) {
     return 'No attached files';
   }
   return attachedFiles
-    .filter((f) => !isImageContentType(f.contentType))
+    .filter(
+      (f) =>
+        !(
+          f.sourceUrl &&
+          options?.omitSourceUrls &&
+          options.omitSourceUrls.has(f.sourceUrl)
+        ),
+    )
     .map((f) => {
       let hyperlink = f.sourceUrl ? `[${f.name}](${f.sourceUrl})` : f.name;
       if (f.error) {
@@ -1888,10 +1898,8 @@ export const buildAttachmentsMessagePart = async (
     history,
     isCurrentMessage,
   );
-  if (attachedFiles.length > 0) {
-    text += `Attached Files (files with newer versions don't show their content):\n${attachedFilesToMessage(attachedFiles)}\n`;
-  }
   let imageUrls: string[] = [];
+  let imageSourceUrlsIncludedAsImageParts = new Set<string>();
   if (isCurrentMessage) {
     let imageFiles = attachedFiles.filter(
       (f) => isImageContentType(f.contentType) && f.url,
@@ -1904,10 +1912,21 @@ export const buildAttachmentsMessagePart = async (
           f.contentType!,
         );
         imageUrls.push(dataUrl);
+        if (f.sourceUrl) {
+          imageSourceUrlsIncludedAsImageParts.add(f.sourceUrl);
+        }
       } catch (e) {
         getLog().error(`Failed to download image ${f.url}:`, e);
       }
     }
+  }
+  if (attachedFiles.length > 0) {
+    text += `Attached Files (files with newer versions don't show their content):\n${attachedFilesToMessage(
+      attachedFiles,
+      {
+        omitSourceUrls: imageSourceUrlsIncludedAsImageParts,
+      },
+    )}\n`;
   }
   return { text, imageUrls };
 };

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -12,6 +12,7 @@ import type {
 import { constructHistory } from './history';
 import {
   downloadFile,
+  downloadFileAsBase64DataUrl,
   extractCodePatchBlocks,
   isCommandOrCodePatchResult,
 } from './matrix-utils';
@@ -1892,9 +1893,21 @@ export const buildAttachmentsMessagePart = async (
   }
   let imageUrls: string[] = [];
   if (isCurrentMessage) {
-    imageUrls = attachedFiles
-      .filter((f) => isImageContentType(f.contentType) && f.url)
-      .map((f) => f.url!);
+    let imageFiles = attachedFiles.filter(
+      (f) => isImageContentType(f.contentType) && f.url,
+    );
+    for (let f of imageFiles) {
+      try {
+        let dataUrl = await downloadFileAsBase64DataUrl(
+          client,
+          f.url!,
+          f.contentType!,
+        );
+        imageUrls.push(dataUrl);
+      } catch (e) {
+        getLog().error(`Failed to download image ${f.url}:`, e);
+      }
+    }
   }
   return { text, imageUrls };
 };

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -655,7 +655,10 @@ export function attachedFilesToMessage(
           .join('\n');
         return `${hyperlink}:\n${numberedContent}`;
       } else if (!isTextBasedContentType(f.contentType) && f.contentType) {
-        let meta = [f.contentType, f.contentSize ? `${f.contentSize} bytes` : '']
+        let meta = [
+          f.contentType,
+          f.contentSize ? `${f.contentSize} bytes` : '',
+        ]
           .filter(Boolean)
           .join(', ');
         return `${hyperlink}: [${meta}]`;
@@ -893,9 +896,7 @@ async function toResultMessages(
           history,
           true,
         );
-        content = [content, attachmentResult.text]
-          .filter(Boolean)
-          .join('\n\n');
+        content = [content, attachmentResult.text].filter(Boolean).join('\n\n');
         let toolMessage: OpenAIPromptMessage = {
           role: 'tool',
           tool_call_id: commandRequest.id,

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -68,6 +68,38 @@ function getLog() {
   return logger('ai-bot:prompt');
 }
 
+/*
+ * ── Attachment Context Policy ────────────────────────────────────────
+ *
+ * When building prompts for the model, file attachments are handled
+ * according to the following rules:
+ *
+ * 1. **Content inclusion**: Only the most recent user message's attached
+ *    files have their content downloaded and included in the prompt.
+ *    Older messages show file metadata (name, type) only. This keeps
+ *    the prompt focused on fresh data and avoids redundant downloads.
+ *
+ * 2. **Supersession**: Within the current message, if a file (by
+ *    sourceUrl) is re-attached in a later event, the earlier version
+ *    is shown as metadata only (the later version wins).
+ *
+ * 3. **MIME type handling**:
+ *    - Text-based types (text/*, application/vnd.card+json) → content
+ *      downloaded and displayed with line numbers.
+ *    - Image types (image/*) → presented as native image_url content
+ *      parts for vision-capable models.
+ *    - Other types (PDF, binary, etc.) → metadata shown inline
+ *      ([contentType, contentSize bytes]) without an error prefix.
+ *
+ * 4. **Read-file command scoping**: When the AI requests to read a file
+ *    via a tool call, the file URL must match a sourceUrl previously
+ *    attached by the user in the same room. Unrecognised URLs produce
+ *    a rejection message in the tool result.
+ * ─────────────────────────────────────────────────────────────────────
+ */
+
+// ── MIME / category helpers ──────────────────────────────────────────
+
 function isTextBasedContentType(contentType?: string): boolean {
   return (
     !!contentType &&
@@ -79,6 +111,8 @@ function isTextBasedContentType(contentType?: string): boolean {
 function isImageContentType(contentType?: string): boolean {
   return !!contentType && contentType.startsWith('image/');
 }
+
+// ── Read-file command scope helpers ──────────────────────────────────
 
 function isReadFileCommand(request?: CommandRequest): boolean {
   return !!request?.name?.startsWith('read-file-for-ai-assistant');
@@ -107,6 +141,32 @@ function isFileAttachedInRoom(
       (f: SerializedFileDef) => f.sourceUrl === fileUrl,
     );
   });
+}
+
+// ── Shared attachment helpers ────────────────────────────────────────
+
+function toFileDefMetadata(file: SerializedFileDef): SerializedFileDef {
+  return {
+    url: file.url,
+    sourceUrl: file.sourceUrl ?? '',
+    name: file.name,
+    contentType: file.contentType,
+    contentSize: file.contentSize,
+  };
+}
+
+async function downloadTextContent(
+  client: MatrixClient,
+  file: SerializedFileDef,
+): Promise<SerializedFileDef> {
+  let result = toFileDefMetadata(file);
+  try {
+    result.content = await downloadFile(client, file);
+  } catch (error) {
+    getLog().error(`Failed to fetch file ${file.url}:`, error);
+    result.error = `Error loading attached file: ${(error as Error).message}`;
+  }
+  return result;
 }
 
 export async function getPromptParts(
@@ -512,41 +572,25 @@ export async function getAttachedFiles(
 ): Promise<SerializedFileDef[]> {
   let attachedFiles = matrixEvent.content?.data?.attachedFiles ?? [];
   return Promise.all(
-    attachedFiles.map(async (attachedFile: SerializedFileDef) => {
-      // Only download content for the most recent user message's files,
-      // and only if the file isn't superseded by a later attachment
+    attachedFiles.map(async (file: SerializedFileDef) => {
       let isSuperseded = history
         .slice(history.indexOf(matrixEvent) + 1)
-        .some((event) => {
-          return (
+        .some((event) =>
+          (
             event as MatrixEventWithBoxelContext
           ).content?.data?.attachedFiles?.some(
-            (file: SerializedFileDef) =>
-              file.sourceUrl === attachedFile.sourceUrl,
-          );
-        });
-      let shouldIncludeContent =
+            (f: SerializedFileDef) => f.sourceUrl === file.sourceUrl,
+          ),
+        );
+
+      if (
         isCurrentMessage &&
         !isSuperseded &&
-        isTextBasedContentType(attachedFile.contentType);
-
-      let result: SerializedFileDef = {
-        url: attachedFile.url,
-        sourceUrl: attachedFile.sourceUrl ?? '',
-        name: attachedFile.name,
-        contentType: attachedFile.contentType,
-        contentSize: attachedFile.contentSize,
-      };
-      if (shouldIncludeContent) {
-        try {
-          result.content = await downloadFile(client, attachedFile);
-        } catch (error) {
-          getLog().error(`Failed to fetch file ${attachedFile.url}:`, error);
-          result.error = `Error loading attached file: ${(error as Error).message}`;
-          result.content = undefined;
-        }
+        isTextBasedContentType(file.contentType)
+      ) {
+        return downloadTextContent(client, file);
       }
-      return result;
+      return toFileDefMetadata(file);
     }),
   );
 }
@@ -566,59 +610,23 @@ export async function loadCurrentlySerializedFileDefs(
         event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE),
   );
 
-  let mostRecentUserMessageContent = lastMessageEventByUser?.content as {
-    msgtype?: string;
-    data?: {
-      attachedFiles?: SerializedFileDef[];
-    };
-  };
-
-  if (!mostRecentUserMessageContent) {
+  if (!lastMessageEventByUser) {
     return [];
   }
 
-  // We are only interested in downloading the most recently attached files -
-  // downloading older ones is not needed since the prompt that is being constructed
-  // should operate on fresh data
-  if (!mostRecentUserMessageContent.data?.attachedFiles?.length) {
+  let attachedFiles = (lastMessageEventByUser as MatrixEventWithBoxelContext)
+    .content?.data?.attachedFiles;
+  if (!attachedFiles?.length) {
     return [];
   }
 
-  let attachedFiles = mostRecentUserMessageContent.data.attachedFiles;
-
-  return Promise.all(
-    attachedFiles.map(async (attachedFile: SerializedFileDef) => {
-      if (!isTextBasedContentType(attachedFile.contentType)) {
-        return {
-          url: attachedFile.url,
-          sourceUrl: attachedFile.sourceUrl ?? '',
-          name: attachedFile.name,
-          contentType: attachedFile.contentType,
-          contentSize: attachedFile.contentSize,
-        };
-      }
-      try {
-        let content = await downloadFile(client, attachedFile);
-
-        return {
-          url: attachedFile.url,
-          sourceUrl: attachedFile.sourceUrl ?? '',
-          name: attachedFile.name,
-          contentType: attachedFile.contentType,
-          content,
-        };
-      } catch (error) {
-        getLog().error(`Failed to fetch file ${attachedFile.url}:`, error);
-        return {
-          sourceUrl: attachedFile.sourceUrl ?? '',
-          url: attachedFile.url,
-          name: attachedFile.name,
-          contentType: attachedFile.contentType,
-          content: undefined,
-          error: `Error loading attached file: ${(error as Error).message}`,
-        };
-      }
-    }),
+  // Reuse getAttachedFiles with isCurrentMessage=true — this is always the
+  // most recent user event, so supersession can't apply (no later events).
+  return getAttachedFiles(
+    client,
+    lastMessageEventByUser as MatrixEventWithBoxelContext,
+    history,
+    true,
   );
 }
 

--- a/packages/runtime-common/ai/types.ts
+++ b/packages/runtime-common/ai/types.ts
@@ -45,7 +45,41 @@ export type ImageContentPart = {
     type: 'ephemeral';
   };
 };
-type ContentPart = TextContent | ImageContentPart;
+export type FileContentPart = {
+  type: 'file';
+  file: {
+    filename: string;
+    file_data: string; // base64 data URL (data:application/pdf;base64,...) or public URL
+  };
+  cache_control?: {
+    type: 'ephemeral';
+  };
+};
+export type InputAudioContentPart = {
+  type: 'input_audio';
+  input_audio: {
+    data: string; // raw base64 string (no data: prefix)
+    format: string; // wav | mp3 | aiff | aac | ogg | flac | m4a | pcm16 | pcm24
+  };
+  cache_control?: {
+    type: 'ephemeral';
+  };
+};
+export type VideoContentPart = {
+  type: 'video_url';
+  video_url: {
+    url: string; // base64 data URL or public URL
+  };
+  cache_control?: {
+    type: 'ephemeral';
+  };
+};
+export type ContentPart =
+  | TextContent
+  | ImageContentPart
+  | FileContentPart
+  | InputAudioContentPart
+  | VideoContentPart;
 
 export interface OpenAIPromptMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';

--- a/packages/runtime-common/ai/types.ts
+++ b/packages/runtime-common/ai/types.ts
@@ -35,7 +35,7 @@ export type TextContent = {
     type: 'ephemeral';
   };
 };
-type ImageContentPart = {
+export type ImageContentPart = {
   type: 'image_url';
   image_url: {
     url: string; // URL or base64 encoded image data

--- a/packages/runtime-common/infer-content-type.ts
+++ b/packages/runtime-common/infer-content-type.ts
@@ -3,6 +3,7 @@ import { lookup as lookupMimeType } from 'mime-types';
 const DEFAULT_FILE_CONTENT_TYPE = 'application/octet-stream';
 const CONTENT_TYPE_OVERRIDES: Record<string, string> = {
   '.gts': 'text/typescript+glimmer',
+  '.ts': 'text/typescript',
 };
 
 export function inferContentType(filename: string): string {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2347,7 +2347,7 @@ export class Realm {
 
       let createdAt = await this.getCreatedTime(handle.path);
       let defaultHeaders: Record<string, string> = {
-        'content-type': 'text/plain; charset=utf-8',
+        'content-type': inferContentType(handle.path),
         ...(createdAt != null
           ? { 'x-created': formatRFC7231(createdAt * 1000) }
           : {}),


### PR DESCRIPTION
## Summary

- Add local-computer attachments to AI Assistant with a new menu path: `Attach a File (Your Computer)`
- Implement direct local-file-to-Matrix media flow (skip realm upload), including:
  - synthetic local `sourceUrl` handling
  - local byte prefetch APIs in matrix/file services
  - binary-safe upload behavior and dedupe support
- Keep workspace-file attachments working while correctly re-uploading realm-backed files when `url === sourceUrl`
- Improve attachment prompt shaping:
  - image attachments are provided to the model as base64 `image_url` parts
  - text attachments preserve line-number context
  - `read-file-for-ai-assistant` remains scoped to files attached in the room
- Back out bot-membership room/session gating introduced during this branch to reduce Matrix room-list flakiness
- Update acceptance assertions for attached-file display names to match rendered filenames with extensions

## Test plan

- [x] `cd packages/host && pnpm lint`
- [x] Isolated acceptance rerun: `Acceptance | AI Assistant tests: can open attach file modal` (now expects `*.gts` labels)
- [ ] CI (in progress)

## Notes

- Local-file behavior is intentionally direct-to-Matrix and does not POST file bytes to realm.

Direct upload from computer: (menu, drag-drop, paste)

https://github.com/user-attachments/assets/2486150e-a321-4d27-b4d7-2e06c67cd9d2

Upload from workspace:

https://github.com/user-attachments/assets/2e6aefe7-aabb-4805-8eb5-91770ef30463


