### PR TITLE
server: Add Traefik support for host mode subdomains

### DIFF
--- a/packages/realm-server/lib/dev-service-registry.ts
+++ b/packages/realm-server/lib/dev-service-registry.ts
@@ -80,9 +80,9 @@ export function isEnvironmentMode(): boolean {
 export function registerService(
   server: Server,
   serviceName: string,
-  env?: string,
+  opts?: { env?: string; wildcardSubdomains?: boolean },
 ): void {
-  let slug = env ?? getEnvironmentSlug();
+  let slug = opts?.env ?? getEnvironmentSlug();
   let addr = server.address() as AddressInfo;
   if (!addr || typeof addr === 'string') {
     log.error(
@@ -99,11 +99,19 @@ export function registerService(
   let routerKey = `${serviceName}-${slug}`;
   let hostname = serviceHostname(serviceName, slug);
 
+  // Build the Traefik Host rule. When wildcardSubdomains is true, also match
+  // any subdomain of the service hostname (e.g. *.realm-server.<slug>.localhost)
+  // so that published realm subdomains are routed to the same server.
+  let escapedHostname = hostname.replace(/\./g, '\\.');
+  let rule = opts?.wildcardSubdomains
+    ? `Host(\`${hostname}\`) || HostRegexp(\`^.+\\.${escapedHostname}$\`)`
+    : `Host(\`${hostname}\`)`;
+
   let config: any = {
     http: {
       routers: {
         [routerKey]: {
-          rule: `Host(\`${hostname}\`)`,
+          rule,
           service: routerKey,
           entryPoints: ['web'],
         },

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -385,7 +385,7 @@ const getIndexHTML = async () => {
   let httpServer = server.listen(port);
   httpServer.on('listening', () => {
     if (isEnvironmentMode()) {
-      registerService(httpServer, serviceName);
+      registerService(httpServer, serviceName, { wildcardSubdomains: true });
     }
   });
   process.on('message', (message) => {


### PR DESCRIPTION
This is a quick follow-on to #4086, which didn’t allow the publishing to or visiting of host mode “Boxel Space” domains. With this Traefik will pass `*.realm-server.environment-name.localhost` requests to the environment realm server.

Currently publish requests fail like this:

```
[start:development          ] Error publishing realm: {
[start:development          ]   stack: 'SyntaxError: Unexpected non-whitespace character after JSON at position 4 (line 1 column 5)\n' +
[start:development          ]     '    at JSON.parse (<anonymous>)\n' +
[start:development          ]     '    at parseJSONFromBytes (node:internal/deps/undici/undici:4259:19)\n' +
[start:development          ]     '    at successSteps (node:internal/deps/undici/undici:6882:27)\n' +
[start:development          ]     '    at readAllBytes (node:internal/deps/undici/undici:5807:13)\n' +
[start:development          ]     '    at processTicksAndRejections (node:internal/process/task_queues:103:5)',
[start:development          ]   message: 'Unexpected non-whitespace character after JSON at position 4 (line 1 column 5)'
[start:development          ] }
```

Here it is working locally:

<img width="726" height="543" alt="Boxel 2026-03-06 12-16-44" src="https://github.com/user-attachments/assets/842c0796-516c-44e4-8c0a-90cc1bb9c910" />

<img width="2292" height="2018" alt="e8c0a21ef0e0f5101a0d9e590435203ca7bf96af 2026-03-06 12-17-06" src="https://github.com/user-attachments/assets/561e96d8-8c14-41f4-9dea-8a20e7e5e5e6" />
