### PR TITLE
server: Add fix for environment mode tests

### DIFF
--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -72,10 +72,7 @@ import { createRemotePrerenderer } from '../../prerender/remote-prerenderer';
 import { createPrerenderHttpServer } from '../../prerender/prerender-app';
 import { buildCreatePrerenderAuth } from '../../prerender/auth';
 import { Client as PgClient } from 'pg';
-import {
-  isEnvironmentMode,
-  serviceURL,
-} from '../../lib/dev-service-registry';
+import { isEnvironmentMode, serviceURL } from '../../lib/dev-service-registry';
 
 const testRealmURL = new URL('http://127.0.0.1:4444/');
 const testRealmHref = testRealmURL.href;
@@ -671,9 +668,7 @@ export function setupDB(
 export async function getIndexHTML() {
   let url =
     process.env.HOST_URL ??
-    (isEnvironmentMode()
-      ? serviceURL('host')
-      : 'http://localhost:4200/');
+    (isEnvironmentMode() ? serviceURL('host') : 'http://localhost:4200/');
   let request = await fetch(url);
   return await request.text();
 }

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -72,6 +72,10 @@ import { createRemotePrerenderer } from '../../prerender/remote-prerenderer';
 import { createPrerenderHttpServer } from '../../prerender/prerender-app';
 import { buildCreatePrerenderAuth } from '../../prerender/auth';
 import { Client as PgClient } from 'pg';
+import {
+  isEnvironmentMode,
+  serviceURL,
+} from '../../lib/dev-service-registry';
 
 const testRealmURL = new URL('http://127.0.0.1:4444/');
 const testRealmHref = testRealmURL.href;
@@ -665,7 +669,11 @@ export function setupDB(
 }
 
 export async function getIndexHTML() {
-  let url = process.env.HOST_URL ?? 'http://localhost:4200/';
+  let url =
+    process.env.HOST_URL ??
+    (isEnvironmentMode()
+      ? serviceURL('host')
+      : 'http://localhost:4200/');
   let request = await fetch(url);
   return await request.text();
 }


### PR DESCRIPTION
Another follow-on to #4086, this fixes locating the proper instance of the host application for realm server tests in environment mode.