### PR TITLE
Add drag-and-drop upload overlay to Choose File modal

### DIFF
--- a/packages/host/app/components/operator-mode/choose-file-modal.gts
+++ b/packages/host/app/components/operator-mode/choose-file-modal.gts
@@ -279,7 +279,7 @@ export default class ChooseFileModal extends Component<Signature> {
         content: '';
         position: absolute;
         inset: 0;
-        background-color: var(--boxel-hover-darker, var(--boxel-darker-hover));
+        background-color: var(--boxel-darker-hover);
         pointer-events: none;
         z-index: 2;
       }

--- a/packages/host/app/components/operator-mode/choose-file-modal.gts
+++ b/packages/host/app/components/operator-mode/choose-file-modal.gts
@@ -279,7 +279,7 @@ export default class ChooseFileModal extends Component<Signature> {
         content: '';
         position: absolute;
         inset: 0;
-        background-color: var(--boxel-darker-hover);
+        background-color: var(--boxel-hover-darker, var(--boxel-darker-hover));
         pointer-events: none;
         z-index: 2;
       }

--- a/packages/host/app/components/operator-mode/choose-file-modal.gts
+++ b/packages/host/app/components/operator-mode/choose-file-modal.gts
@@ -53,6 +53,8 @@ export default class ChooseFileModal extends Component<Signature> {
   @tracked fileTypeName?: string;
   @tracked acceptTypes?: string;
   @tracked currentUpload?: FileUploadTask;
+  @tracked isDropZoneActive = false;
+  private dropZoneDragDepth = 0;
 
   @service declare private operatorModeStateService: OperatorModeStateService;
   @service declare private realm: RealmService;
@@ -144,6 +146,70 @@ export default class ChooseFileModal extends Component<Signature> {
       realmURL: this.selectedRealm.url,
       acceptTypes: this.acceptTypes,
     });
+    this.beginUpload(task);
+  }
+
+  @action
+  private handleDragEnter(event: DragEvent) {
+    if (!this.isFileDrag(event.dataTransfer)) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    this.dropZoneDragDepth++;
+    this.isDropZoneActive = true;
+  }
+
+  @action
+  private handleDragOver(event: DragEvent) {
+    if (!this.isFileDrag(event.dataTransfer)) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDropZoneActive = true;
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'copy';
+    }
+  }
+
+  @action
+  private handleDragLeave(event: DragEvent) {
+    if (!this.isFileDrag(event.dataTransfer) && !this.isDropZoneActive) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    this.dropZoneDragDepth = Math.max(0, this.dropZoneDragDepth - 1);
+    if (this.dropZoneDragDepth === 0) {
+      this.isDropZoneActive = false;
+    }
+  }
+
+  @action
+  private handleDrop(event: DragEvent) {
+    if (!this.isFileDrag(event.dataTransfer)) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    this.dropZoneDragDepth = 0;
+    this.isDropZoneActive = false;
+    if (this.isUploadBusy) {
+      return;
+    }
+    let file = event.dataTransfer?.files?.[0];
+    if (!file) {
+      return;
+    }
+    let task = this.fileUpload.uploadProvidedFile({
+      realmURL: this.selectedRealm.url,
+      file,
+    });
+    this.beginUpload(task);
+  }
+
+  private beginUpload(task: FileUploadTask) {
     this.currentUpload = task;
     task.result.then((fileDef) => {
       if (fileDef && this.deferred) {
@@ -155,6 +221,17 @@ export default class ChooseFileModal extends Component<Signature> {
     });
   }
 
+  private isFileDrag(dataTransfer: DataTransfer | null | undefined): boolean {
+    if (!dataTransfer) {
+      return false;
+    }
+    return Array.from(dataTransfer.types ?? []).includes('Files');
+  }
+
+  private get dropZoneLabel() {
+    return `Drop file to upload to ${this.selectedRealm.info.name}`;
+  }
+
   private resetState() {
     this.selectedRealm = this.knownRealms[0];
     this.selectedFile = undefined;
@@ -162,6 +239,8 @@ export default class ChooseFileModal extends Component<Signature> {
     this.fileTypeName = undefined;
     this.acceptTypes = undefined;
     this.currentUpload = undefined;
+    this.isDropZoneActive = false;
+    this.dropZoneDragDepth = 0;
     this.deferred = undefined;
   }
 
@@ -196,8 +275,32 @@ export default class ChooseFileModal extends Component<Signature> {
       .choose-file-modal {
         --horizontal-gap: var(--boxel-sp-xs);
       }
+      .choose-file-modal[data-drop-zone-active]::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-color: var(--boxel-darker-hover);
+        pointer-events: none;
+        z-index: 2;
+      }
+      .choose-file-modal[data-drop-zone-active]::after {
+        content: attr(data-drop-zone-label);
+        position: absolute;
+        inset: 0;
+        padding: var(--boxel-sp-xl);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--boxel-light);
+        font: 600 var(--boxel-font-lg);
+        text-align: center;
+        pointer-events: none;
+        z-index: 3;
+      }
       .choose-file-modal > :deep(.boxel-modal__inner) {
         display: flex;
+        position: relative;
+        z-index: 1;
       }
       :deep(.choose-file-modal__container) {
         height: 32rem;
@@ -309,8 +412,14 @@ export default class ChooseFileModal extends Component<Signature> {
         @size='medium'
         @centered={{true}}
         {{on 'keydown' this.handleKeydown}}
+        {{on 'dragenter' this.handleDragEnter}}
+        {{on 'dragover' this.handleDragOver}}
+        {{on 'dragleave' this.handleDragLeave}}
+        {{on 'drop' this.handleDrop}}
         @cardContainerClass='choose-file-modal__container'
         class='choose-file-modal'
+        data-drop-zone-active={{this.isDropZoneActive}}
+        data-drop-zone-label={{this.dropZoneLabel}}
         data-test-choose-file-modal
       >
         <:content>

--- a/packages/host/app/services/file-upload.ts
+++ b/packages/host/app/services/file-upload.ts
@@ -54,17 +54,28 @@ export default class FileUploadService extends Service {
 
   uploadFile(opts: { realmURL: URL; acceptTypes?: string }): FileUploadTask {
     let task = new FileUploadTask();
-    this.activeUploads = [...this.activeUploads, task];
+    this._startTask(task, opts.realmURL);
 
     if (!isTesting()) {
       this._openFilePicker(task, opts.acceptTypes);
     }
 
-    this._processUpload(task, opts.realmURL).finally(() => {
-      this.activeUploads = this.activeUploads.filter((t) => t !== task);
-    });
+    return task;
+  }
+
+  uploadProvidedFile(opts: { realmURL: URL; file: File }): FileUploadTask {
+    let task = new FileUploadTask();
+    this._startTask(task, opts.realmURL);
+    task._resolveFile(opts.file);
 
     return task;
+  }
+
+  private _startTask(task: FileUploadTask, realmURL: URL) {
+    this.activeUploads = [...this.activeUploads, task];
+    this._processUpload(task, realmURL).finally(() => {
+      this.activeUploads = this.activeUploads.filter((t) => t !== task);
+    });
   }
 
   private _openFilePicker(task: FileUploadTask, acceptTypes?: string) {

--- a/packages/host/tests/acceptance/file-chooser-test.gts
+++ b/packages/host/tests/acceptance/file-chooser-test.gts
@@ -1,4 +1,10 @@
-import { currentURL, click, settled, waitUntil } from '@ember/test-helpers';
+import {
+  currentURL,
+  click,
+  settled,
+  waitUntil,
+  triggerEvent,
+} from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
@@ -252,6 +258,72 @@ module('Acceptance | file chooser tests', function (hooks) {
         '[data-test-links-to-editor="attachment"] [data-test-card="http://test-realm/test/uploaded.txt"]',
       )
       .exists('attachment field now shows the uploaded file');
+  });
+
+  test('can drag and drop a file into chooser modal and see workspace feedback', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}FileLinkCard/empty`,
+            format: 'isolated',
+          },
+        ],
+      ],
+    });
+
+    await click(`[data-test-operator-mode-stack="0"] [data-test-edit-button]`);
+    await click(
+      '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+    );
+
+    assert
+      .dom('[data-test-choose-file-modal]')
+      .exists('file chooser modal is open');
+
+    let droppedFile = new File(['hello drag upload'], 'dropped.txt', {
+      type: 'text/plain',
+    });
+
+    await triggerEvent('[data-test-choose-file-modal]', 'dragenter', {
+      dataTransfer: {
+        types: ['Files'],
+        files: [droppedFile],
+      },
+    });
+
+    assert
+      .dom('[data-test-choose-file-modal]')
+      .hasAttribute('data-drop-zone-active');
+    let dropZoneLabel = document
+      .querySelector('[data-test-choose-file-modal]')
+      ?.getAttribute('data-drop-zone-label');
+    assert.ok(dropZoneLabel, 'drop zone label is exposed on modal');
+    assert.true(
+      dropZoneLabel!.startsWith('Drop file to upload to '),
+      'drop zone label announces upload target',
+    );
+
+    await triggerEvent('[data-test-choose-file-modal]', 'drop', {
+      dataTransfer: {
+        types: ['Files'],
+        files: [droppedFile],
+      },
+    });
+
+    await waitUntil(
+      () => !document.querySelector('[data-test-choose-file-modal]'),
+      {
+        timeout: 10000,
+        timeoutMessage: 'file chooser modal did not close after drop upload',
+      },
+    );
+
+    assert
+      .dom(
+        '[data-test-links-to-editor="attachment"] [data-test-card="http://test-realm/test/dropped.txt"]',
+      )
+      .exists('attachment field now shows the dropped file');
   });
 
   test('uploading a file without an extension shows an error', async function (assert) {


### PR DESCRIPTION
## Summary
- add drag/drop handlers to the Choose File modal so the entire modal acts as a drop target
- add direct file upload support in the file upload service for drag/drop flows
- replace inline drop hint with a pointer-events-none overlay that uses a dark hover background and shows the target workspace name
- add acceptance coverage for drag/drop upload and workspace-aware overlay labeling

## Testing
- cd packages/host && pnpm lint
- cd packages/host && pnpm exec ember test --filter "Acceptance | file chooser tests"

https://github.com/user-attachments/assets/c779a97a-79b5-4d14-a50c-a0e6e37209b3


