### PR TITLE
Eliminate Puppeteer race condition causing false status:'error' in command runner

### DIFF
--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -486,12 +486,60 @@ export class RenderRunner {
       let waitResult = await withTimeout(
         page,
         async () => {
-          if (opts?.simulateTimeoutMs) {
-            await new Promise((resolve) =>
-              setTimeout(resolve, opts.simulateTimeoutMs),
-            );
+          const jsHandle = await page.waitForFunction(
+            (expectedNonce: string) => {
+              let containers = Array.from(
+                document.querySelectorAll(
+                  '[data-prerender][data-prerender-id="command-runner"]',
+                ),
+              ) as HTMLElement[];
+              let container =
+                containers.find(
+                  (candidate) =>
+                    candidate.dataset.prerenderNonce === expectedNonce,
+                ) ?? null;
+              if (!container) {
+                return false;
+              }
+              let status = container.dataset.prerenderStatus ?? '';
+              if (!['ready', 'error', 'unusable'].includes(status)) {
+                return false;
+              }
+              let errorElement = container.querySelector(
+                '[data-prerender-error]',
+              ) as HTMLElement | null;
+              let cardResultStringElement = container.querySelector(
+                '[data-command-result]',
+              ) as HTMLElement | null;
+              let domError = (errorElement?.textContent ?? '').trim() || null;
+              let cardResultString = (
+                cardResultStringElement?.textContent ?? ''
+              ).trim();
+              return {
+                status: status as 'ready' | 'error' | 'unusable',
+                domError,
+                cardResultString:
+                  cardResultString.length > 0 ? cardResultString : null,
+              };
+            },
+            {},
+            nonce,
+          );
+          try {
+            const payload = (await jsHandle.jsonValue()) as {
+              status: 'ready' | 'error' | 'unusable';
+              domError: string | null;
+              cardResultString: string | null;
+            };
+            if (opts?.simulateTimeoutMs) {
+              await new Promise((resolve) =>
+                setTimeout(resolve, opts.simulateTimeoutMs),
+              );
+            }
+            return payload;
+          } finally {
+            await jsHandle.dispose();
           }
-          return true;
         },
         opts?.timeoutMs,
       );
@@ -509,82 +557,31 @@ export class RenderRunner {
         };
       }
 
-      const jsHandle = await page.waitForFunction(
-        (expectedNonce: string) => {
-          let containers = Array.from(
-            document.querySelectorAll(
-              '[data-prerender][data-prerender-id="command-runner"]',
-            ),
-          ) as HTMLElement[];
-          let container =
-            containers.find(
-              (candidate) => candidate.dataset.prerenderNonce === expectedNonce,
-            ) ?? null;
-          if (!container) {
-            return false;
-          }
-          let status = container.dataset.prerenderStatus ?? '';
-          if (!['ready', 'error', 'unusable'].includes(status)) {
-            return false;
-          }
-          let errorElement = container.querySelector(
-            '[data-prerender-error]',
-          ) as HTMLElement | null;
-          let cardResultStringElement = container.querySelector(
-            '[data-command-result]',
-          ) as HTMLElement | null;
-          let errorFromChild = (errorElement?.textContent ?? '').trim();
-          let errorFromAttr = (
-            container.dataset.prerenderErrorMsg ?? ''
-          ).trim();
-          let error =
-            errorFromChild.length > 0
-              ? errorFromChild
-              : errorFromAttr.length > 0
-                ? errorFromAttr
-                : null;
-          let cardResultString = (
-            cardResultStringElement?.textContent ?? ''
-          ).trim();
-          return {
-            status: status as 'ready' | 'error' | 'unusable',
-            error,
-            cardResultString:
-              cardResultString.length > 0 ? cardResultString : null,
-          };
-        },
-        {},
-        String(this.#nonce),
-      );
-
-      const payload = (await jsHandle.jsonValue()) as {
-        status: 'ready' | 'error' | 'unusable';
-        error: string | null;
-        cardResultString: string | null;
-      };
+      const payload = waitResult;
 
       let consoleErrors = this.#pagePool.takeConsoleErrors(pageId);
-      let consoleErrorSummary =
-        consoleErrors.length > 0
-          ? consoleErrors.map((e) => this.#formatConsoleError(e)).join('\n')
-          : undefined;
-
-      let errorDetail = [payload.error, consoleErrorSummary]
-        .filter(Boolean)
-        .join('\n---\n');
 
       let response: RunCommandResponse = {
         status: payload.status,
         cardResultString: payload.cardResultString ?? undefined,
-        error: errorDetail.length > 0 ? errorDetail : undefined,
       };
-      markTimeout(response.status);
 
-      if (response.status === 'error') {
+      if (payload.status !== 'ready') {
+        let consoleErrorSummary =
+          consoleErrors.length > 0
+            ? consoleErrors.map((e) => this.#formatConsoleError(e)).join('\n')
+            : undefined;
+        let errorDetail = [payload.domError, consoleErrorSummary]
+          .filter(Boolean)
+          .join('\n---\n');
+        response.error = errorDetail.length > 0 ? errorDetail : undefined;
+
         log.error(
-          `command runner returned error status command=${command} domError=${payload.error ?? 'null'} consoleErrors=${consoleErrors.length}`,
+          `command runner returned error status command=${command} domError=${payload.domError ?? 'null'} consoleErrors=${consoleErrors.length}`,
         );
       }
+
+      markTimeout(response.status);
 
       return {
         response,

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -486,34 +486,11 @@ export class RenderRunner {
       let waitResult = await withTimeout(
         page,
         async () => {
-          await page.waitForFunction(
-            (expectedNonce: string) => {
-              let containers = Array.from(
-                document.querySelectorAll(
-                  '[data-prerender][data-prerender-id="command-runner"]',
-                ),
-              ) as HTMLElement[];
-              let container =
-                containers.find(
-                  (candidate) =>
-                    candidate.dataset.prerenderNonce === expectedNonce,
-                ) ?? null;
-              if (!container) {
-                return false;
-              }
-              let status = container.dataset.prerenderStatus ?? '';
-              return ['ready', 'error', 'unusable'].includes(status);
-            },
-            {},
-            String(this.#nonce),
-          );
-
           if (opts?.simulateTimeoutMs) {
             await new Promise((resolve) =>
               setTimeout(resolve, opts.simulateTimeoutMs),
             );
           }
-
           return true;
         },
         opts?.timeoutMs,
@@ -532,46 +509,82 @@ export class RenderRunner {
         };
       }
 
-      let payload = await page.evaluate((expectedNonce: string) => {
-        let containers = Array.from(
-          document.querySelectorAll(
-            '[data-prerender][data-prerender-id="command-runner"]',
-          ),
-        ) as HTMLElement[];
-        let container =
-          containers.find(
-            (candidate) => candidate.dataset.prerenderNonce === expectedNonce,
-          ) ?? null;
-        let status =
-          (container?.dataset.prerenderStatus as
-            | 'ready'
-            | 'error'
-            | 'unusable'
-            | undefined) ?? 'error';
-        let errorElement = container?.querySelector(
-          '[data-prerender-error]',
-        ) as HTMLElement | null;
-        let cardResultStringElement = container?.querySelector(
-          '[data-command-result]',
-        ) as HTMLElement | null;
-        let error = (errorElement?.textContent ?? '').trim();
-        let cardResultString = (
-          cardResultStringElement?.textContent ?? ''
-        ).trim();
-        return {
-          status,
-          error: error.length > 0 ? error : null,
-          cardResultString:
-            cardResultString.length > 0 ? cardResultString : null,
-        };
-      }, String(this.#nonce));
+      const jsHandle = await page.waitForFunction(
+        (expectedNonce: string) => {
+          let containers = Array.from(
+            document.querySelectorAll(
+              '[data-prerender][data-prerender-id="command-runner"]',
+            ),
+          ) as HTMLElement[];
+          let container =
+            containers.find(
+              (candidate) => candidate.dataset.prerenderNonce === expectedNonce,
+            ) ?? null;
+          if (!container) {
+            return false;
+          }
+          let status = container.dataset.prerenderStatus ?? '';
+          if (!['ready', 'error', 'unusable'].includes(status)) {
+            return false;
+          }
+          let errorElement = container.querySelector(
+            '[data-prerender-error]',
+          ) as HTMLElement | null;
+          let cardResultStringElement = container.querySelector(
+            '[data-command-result]',
+          ) as HTMLElement | null;
+          let errorFromChild = (errorElement?.textContent ?? '').trim();
+          let errorFromAttr = (
+            container.dataset.prerenderErrorMsg ?? ''
+          ).trim();
+          let error =
+            errorFromChild.length > 0
+              ? errorFromChild
+              : errorFromAttr.length > 0
+                ? errorFromAttr
+                : null;
+          let cardResultString = (
+            cardResultStringElement?.textContent ?? ''
+          ).trim();
+          return {
+            status: status as 'ready' | 'error' | 'unusable',
+            error,
+            cardResultString:
+              cardResultString.length > 0 ? cardResultString : null,
+          };
+        },
+        {},
+        String(this.#nonce),
+      );
+
+      const payload = (await jsHandle.jsonValue()) as {
+        status: 'ready' | 'error' | 'unusable';
+        error: string | null;
+        cardResultString: string | null;
+      };
+
+      let consoleErrors = this.#pagePool.takeConsoleErrors(pageId);
+      let consoleErrorSummary =
+        consoleErrors.length > 0
+          ? consoleErrors.map((e) => this.#formatConsoleError(e)).join('\n')
+          : undefined;
+
+      let errorDetail = [payload.error, consoleErrorSummary]
+        .filter(Boolean)
+        .join('\n---\n');
 
       let response: RunCommandResponse = {
         status: payload.status,
         cardResultString: payload.cardResultString ?? undefined,
-        error: payload.error ?? undefined,
+        error: errorDetail.length > 0 ? errorDetail : undefined,
       };
       markTimeout(response.status);
+
+      if (response.status === 'error') {
+        log.error(
+          `command runner returned error status command=${command} domError=${payload.error ?? 'null'} consoleErrors=${consoleErrors.length}`,
+        );
+      }
 
       return {
         response,

--- a/packages/realm-server/tests/prerender-server-test.ts
+++ b/packages/realm-server/tests/prerender-server-test.ts
@@ -354,6 +354,35 @@ module(basename(__filename), function () {
         assert.ok(res.body.meta?.timing?.totalMs >= 0, 'has timing');
         assert.ok(res.body.meta?.pool?.pageId, 'has pool.pageId');
       });
+
+      test('it returns unusable status when command times out', async function (assert) {
+        let permissions = {
+          [realmURL.href]: ['read', 'write', 'realm-owner'] as (
+            | 'read'
+            | 'write'
+            | 'realm-owner'
+          )[],
+        };
+        let auth = testCreatePrerenderAuth(testUserId, permissions);
+        let command = `${realmURL.href}command-runner-test/SayHelloCommand`;
+        let result = await prerenderer.runCommand({
+          userId: testUserId,
+          auth,
+          command,
+          opts: { timeoutMs: 1, simulateTimeoutMs: 25 },
+        });
+
+        assert.strictEqual(
+          result.response.status,
+          'unusable',
+          'timed-out command returns unusable status',
+        );
+        assert.ok(
+          result.response.error?.includes('Render timed-out'),
+          `error message mentions timeout (got: ${result.response.error})`,
+        );
+        assert.true(result.pool.timedOut, 'pool.timedOut is set');
+      });
     });
 
     test('reports draining status when shutting down', async function (assert) {


### PR DESCRIPTION
### Summary
**Root cause:** render-runner.ts used two separate Puppeteer CDP calls — waitForFunction (to detect status) then page.evaluate (to read the payload). Glimmer's async re-rendering could replace the DOM container between the two calls, so page.evaluate found no container and fell back to status: 'error' even when the command succeeded.

**Fix:** Merged both calls into one atomic waitForFunction that returns the full payload {status, error, cardResultString} at the moment the condition becomes true. No race condition involved.

**Testing:** Console errors captured from the page pool are now attached to the error detail string, and a structured log is emitted when status === 'error' to make future diagnosis easier. 


Before
<img width="337" height="72" alt="Screenshot 2026-03-09 at 8 25 08 PM" src="https://github.com/user-attachments/assets/1a9415fd-e954-499f-a58f-5b0ad99510bb" />

After - more structed error
<img width="794" height="93" alt="Screenshot 2026-03-09 at 8 25 21 PM" src="https://github.com/user-attachments/assets/b9494e4d-d821-42fb-b791-e7109d7d0411" />
