### PR TITLE
Add realm reindex API and commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -500,6 +500,7 @@ jobs:
             "realm-endpoints/mtimes-test.ts",
             "realm-endpoints/permissions-test.ts",
             "realm-endpoints/publishability-test.ts",
+            "realm-endpoints/reindex-test.ts",
             "realm-endpoints/search-test.ts",
             "realm-endpoints/user-test.ts",
             "realm-endpoints-test.ts",

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -109,20 +109,7 @@ export class RealmUrlCard extends CardDef {
   @field realmUrl = contains(StringField);
 }
 
-export class CancelIndexingJobInput extends CardDef {
-  @field realmUrl = contains(StringField);
-}
-
-export class ReindexRealmInput extends CardDef {
-  @field realmUrl = contains(StringField);
-}
-
-export class FullReindexRealmInput extends CardDef {
-  @field realmUrl = contains(StringField);
-}
-
-export class InvalidateRealmUrlsInput extends CardDef {
-  @field realmUrl = contains(StringField);
+export class InvalidateRealmUrlsInput extends RealmUrlCard {
   @field urls = containsMany(StringField);
 }
 

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -113,6 +113,14 @@ export class CancelIndexingJobInput extends CardDef {
   @field realmUrl = contains(StringField);
 }
 
+export class ReindexRealmInput extends CardDef {
+  @field realmUrl = contains(StringField);
+}
+
+export class FullReindexRealmInput extends CardDef {
+  @field realmUrl = contains(StringField);
+}
+
 export class InvalidateRealmUrlsInput extends CardDef {
   @field realmUrl = contains(StringField);
   @field urls = containsMany(StringField);

--- a/packages/host/app/commands/cancel-indexing-job.ts
+++ b/packages/host/app/commands/cancel-indexing-job.ts
@@ -7,7 +7,7 @@ import HostBaseCommand from '../lib/host-base-command';
 import type RealmService from '../services/realm';
 
 export default class CancelIndexingJobCommand extends HostBaseCommand<
-  typeof BaseCommandModule.CancelIndexingJobInput,
+  typeof BaseCommandModule.RealmUrlCard,
   undefined
 > {
   @service declare private realm: RealmService;
@@ -17,12 +17,12 @@ export default class CancelIndexingJobCommand extends HostBaseCommand<
 
   async getInputType() {
     let commandModule = await this.loadCommandModule();
-    const { CancelIndexingJobInput } = commandModule;
-    return CancelIndexingJobInput;
+    const { RealmUrlCard } = commandModule;
+    return RealmUrlCard;
   }
 
   protected async run(
-    input: BaseCommandModule.CancelIndexingJobInput,
+    input: BaseCommandModule.RealmUrlCard,
   ): Promise<undefined> {
     await this.realm.cancelIndexingJob(input.realmUrl);
   }

--- a/packages/host/app/commands/full-reindex-realm.ts
+++ b/packages/host/app/commands/full-reindex-realm.ts
@@ -1,0 +1,30 @@
+import { service } from '@ember/service';
+
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
+
+import HostBaseCommand from '../lib/host-base-command';
+
+import type RealmService from '../services/realm';
+
+export default class FullReindexRealmCommand extends HostBaseCommand<
+  typeof BaseCommandModule.FullReindexRealmInput,
+  undefined
+> {
+  @service declare private realm: RealmService;
+
+  static actionVerb = 'Full Reindex';
+  description =
+    'Force a full realm reindex. This republishes a from-scratch indexing job after clearing indexed mtimes, so every file in the realm is revisited even if mtimes have not changed. Use this when the user suspects indexing drift, stale cached results, or wants a full rebuild instead of the lighter default reindex.';
+
+  async getInputType() {
+    let commandModule = await this.loadCommandModule();
+    const { FullReindexRealmInput } = commandModule;
+    return FullReindexRealmInput;
+  }
+
+  protected async run(
+    input: BaseCommandModule.FullReindexRealmInput,
+  ): Promise<undefined> {
+    await this.realm.fullReindex(input.realmUrl);
+  }
+}

--- a/packages/host/app/commands/full-reindex-realm.ts
+++ b/packages/host/app/commands/full-reindex-realm.ts
@@ -7,7 +7,7 @@ import HostBaseCommand from '../lib/host-base-command';
 import type RealmService from '../services/realm';
 
 export default class FullReindexRealmCommand extends HostBaseCommand<
-  typeof BaseCommandModule.FullReindexRealmInput,
+  typeof BaseCommandModule.RealmUrlCard,
   undefined
 > {
   @service declare private realm: RealmService;
@@ -18,12 +18,12 @@ export default class FullReindexRealmCommand extends HostBaseCommand<
 
   async getInputType() {
     let commandModule = await this.loadCommandModule();
-    const { FullReindexRealmInput } = commandModule;
-    return FullReindexRealmInput;
+    const { RealmUrlCard } = commandModule;
+    return RealmUrlCard;
   }
 
   protected async run(
-    input: BaseCommandModule.FullReindexRealmInput,
+    input: BaseCommandModule.RealmUrlCard,
   ): Promise<undefined> {
     await this.realm.fullReindex(input.realmUrl);
   }

--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -16,6 +16,7 @@ import * as CopyFileToRealmCommandModule from './copy-file-to-realm';
 import * as CopySourceCommandModule from './copy-source';
 import * as CreateAIAssistantRoomCommandModule from './create-ai-assistant-room';
 import * as CreateSpecCommandModule from './create-specs';
+import * as FullReindexRealmCommandModule from './full-reindex-realm';
 import * as GenerateExampleCardsCommandModule from './generate-example-cards';
 import * as GenerateReadmeSpecCommandModule from './generate-readme-spec';
 import * as GenerateThemeExampleCommandModule from './generate-theme-example';
@@ -48,6 +49,7 @@ import * as ReadFileForAiAssistantCommandModule from './read-file-for-ai-assista
 import * as ReadSourceCommandModule from './read-source';
 import * as ReadTextFileCommandModule from './read-text-file';
 import * as RegisterBotCommandModule from './register-bot';
+import * as ReindexRealmCommandModule from './reindex-realm';
 import * as SaveCardCommandModule from './save-card';
 import * as SearchAndChooseCommandModule from './search-and-choose';
 import * as SearchCardsCommandModule from './search-cards';
@@ -127,6 +129,10 @@ export function shimHostCommands(virtualNetwork: VirtualNetwork) {
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/generate-theme-example',
     GenerateThemeExampleCommandModule,
+  );
+  virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/full-reindex-realm',
+    FullReindexRealmCommandModule,
   );
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/get-events-from-room',
@@ -219,6 +225,10 @@ export function shimHostCommands(virtualNetwork: VirtualNetwork) {
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/read-text-file',
     ReadTextFileCommandModule,
+  );
+  virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/reindex-realm',
+    ReindexRealmCommandModule,
   );
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/register-bot',
@@ -363,6 +373,7 @@ export const HostCommandClasses: (typeof HostBaseCommand<any, any>)[] = [
   CreateAIAssistantRoomCommandModule.default,
   CopyAndEditCommandModule.default,
   CreateSpecCommandModule.default,
+  FullReindexRealmCommandModule.default,
   GenerateExampleCardsCommandModule.default,
   GenerateReadmeSpecCommandModule.default,
   GetAllRealmMetasCommandModule.default,
@@ -395,6 +406,7 @@ export const HostCommandClasses: (typeof HostBaseCommand<any, any>)[] = [
   ReadSourceCommandModule.default,
   ReadTextFileCommandModule.default,
   RegisterBotCommandModule.default,
+  ReindexRealmCommandModule.default,
   SaveCardCommandModule.default,
   SerializeCardCommandModule.default,
   SearchAndChooseCommandModule.default,

--- a/packages/host/app/commands/reindex-realm.ts
+++ b/packages/host/app/commands/reindex-realm.ts
@@ -1,0 +1,30 @@
+import { service } from '@ember/service';
+
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
+
+import HostBaseCommand from '../lib/host-base-command';
+
+import type RealmService from '../services/realm';
+
+export default class ReindexRealmCommand extends HostBaseCommand<
+  typeof BaseCommandModule.ReindexRealmInput,
+  undefined
+> {
+  @service declare private realm: RealmService;
+
+  static actionVerb = 'Reindex';
+  description =
+    'Reindex a realm using the lighter/default mode. This republishes a from-scratch indexing job but only revisits files whose indexed state appears stale based on current mtime, deletion, or error semantics. Use this when the user wants to pick up normal recent changes.';
+
+  async getInputType() {
+    let commandModule = await this.loadCommandModule();
+    const { ReindexRealmInput } = commandModule;
+    return ReindexRealmInput;
+  }
+
+  protected async run(
+    input: BaseCommandModule.ReindexRealmInput,
+  ): Promise<undefined> {
+    await this.realm.reindex(input.realmUrl);
+  }
+}

--- a/packages/host/app/commands/reindex-realm.ts
+++ b/packages/host/app/commands/reindex-realm.ts
@@ -7,7 +7,7 @@ import HostBaseCommand from '../lib/host-base-command';
 import type RealmService from '../services/realm';
 
 export default class ReindexRealmCommand extends HostBaseCommand<
-  typeof BaseCommandModule.ReindexRealmInput,
+  typeof BaseCommandModule.RealmUrlCard,
   undefined
 > {
   @service declare private realm: RealmService;
@@ -18,12 +18,12 @@ export default class ReindexRealmCommand extends HostBaseCommand<
 
   async getInputType() {
     let commandModule = await this.loadCommandModule();
-    const { ReindexRealmInput } = commandModule;
-    return ReindexRealmInput;
+    const { RealmUrlCard } = commandModule;
+    return RealmUrlCard;
   }
 
   protected async run(
-    input: BaseCommandModule.ReindexRealmInput,
+    input: BaseCommandModule.RealmUrlCard,
   ): Promise<undefined> {
     await this.realm.reindex(input.realmUrl);
   }

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -1011,6 +1011,61 @@ export default class RealmService extends Service {
     );
   }
 
+  async reindex(realmURL: string): Promise<void> {
+    let normalizedRealmURL = ensureTrailingSlash(realmURL);
+    let resource = this.getOrCreateRealmResource(normalizedRealmURL);
+    await resource.login();
+
+    let headers = new Headers({
+      Accept: SupportedMimeType.JSON,
+    });
+    if (resource.token) {
+      headers.set('Authorization', `Bearer ${resource.token}`);
+    }
+
+    let response = await this.network.fetch(`${normalizedRealmURL}_reindex`, {
+      method: 'POST',
+      headers,
+    });
+
+    if (response.status === 204) {
+      return;
+    }
+
+    let errorText = await response.text();
+    throw new Error(`Reindex realm failed: ${response.status} - ${errorText}`);
+  }
+
+  async fullReindex(realmURL: string): Promise<void> {
+    let normalizedRealmURL = ensureTrailingSlash(realmURL);
+    let resource = this.getOrCreateRealmResource(normalizedRealmURL);
+    await resource.login();
+
+    let headers = new Headers({
+      Accept: SupportedMimeType.JSON,
+    });
+    if (resource.token) {
+      headers.set('Authorization', `Bearer ${resource.token}`);
+    }
+
+    let response = await this.network.fetch(
+      `${normalizedRealmURL}_full-reindex`,
+      {
+        method: 'POST',
+        headers,
+      },
+    );
+
+    if (response.status === 204) {
+      return;
+    }
+
+    let errorText = await response.text();
+    throw new Error(
+      `Full reindex realm failed: ${response.status} - ${errorText}`,
+    );
+  }
+
   async invalidateUrls(realmURL: string, urls: string[]): Promise<void> {
     let normalizedRealmURL = ensureTrailingSlash(realmURL);
     let resource = this.getOrCreateRealmResource(normalizedRealmURL);

--- a/packages/host/tests/integration/commands/full-reindex-realm-test.gts
+++ b/packages/host/tests/integration/commands/full-reindex-realm-test.gts
@@ -1,0 +1,157 @@
+import { getOwner } from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import FullReindexRealmCommand from '@cardstack/host/commands/full-reindex-realm';
+import RealmService from '@cardstack/host/services/realm';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupRealmServerEndpoints,
+  testRealmInfo,
+  testRealmURL,
+  setupRealmCacheTeardown,
+  withCachedRealmSetup,
+} from '../../helpers';
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+class StubRealmService extends RealmService {
+  get defaultReadableRealm() {
+    return {
+      path: testRealmURL,
+      info: testRealmInfo,
+    };
+  }
+}
+
+module('Integration | commands | full-reindex-realm', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  let receivedAuthorizationHeader: string | null = null;
+  let receivedMethod: string | null = null;
+  let receivedPathname: string | null = null;
+  let responseStatus = 204;
+  let responseBody: string | null = null;
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  setupRealmServerEndpoints(hooks, [
+    {
+      route: 'test/_full-reindex',
+      getResponse: async (req: Request) => {
+        receivedAuthorizationHeader = req.headers.get('Authorization');
+        receivedMethod = req.method;
+        receivedPathname = new URL(req.url).pathname;
+        return new Response(responseBody, { status: responseStatus });
+      },
+    },
+  ]);
+
+  setupRealmCacheTeardown(hooks);
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    getOwner(this)!.register('service:realm', StubRealmService);
+    receivedAuthorizationHeader = null;
+    receivedMethod = null;
+    receivedPathname = null;
+    responseStatus = 204;
+    responseBody = null;
+
+    await withCachedRealmSetup(async () =>
+      setupIntegrationTestRealm({
+        mockMatrixUtils,
+        realmURL: testRealmURL,
+        contents: {},
+      }),
+    );
+  });
+
+  test('calls realm endpoint with expected auth header', async function (assert) {
+    let commandService = getService('command-service');
+    let realmServer = getService('realm-server');
+    let command = new FullReindexRealmCommand(commandService.commandContext);
+    let realmURL = new URL('test/', realmServer.url).href;
+
+    let result = await command.execute({
+      realmUrl: realmURL,
+    });
+
+    assert.strictEqual(result, undefined, 'command has no result card');
+    assert.strictEqual(receivedMethod, 'POST', 'uses POST');
+    assert.strictEqual(
+      receivedPathname,
+      '/test/_full-reindex',
+      'calls endpoint',
+    );
+    assert.ok(receivedAuthorizationHeader, 'authorization header is present');
+    assert.true(
+      receivedAuthorizationHeader?.startsWith('Bearer '),
+      'authorization header uses Bearer scheme',
+    );
+
+    let authToken = receivedAuthorizationHeader!.replace('Bearer ', '');
+    let [_header, payload] = authToken.split('.');
+    let tokenClaims = JSON.parse(atob(payload)) as {
+      realm?: string;
+      permissions?: string[];
+    };
+
+    assert.strictEqual(
+      tokenClaims.realm,
+      realmURL,
+      'authorization token is realm-scoped',
+    );
+    assert.deepEqual(
+      tokenClaims.permissions,
+      ['read', 'write'],
+      'authorization token contains realm permissions',
+    );
+    assert.notStrictEqual(
+      receivedAuthorizationHeader,
+      `Bearer ${realmServer.token}`,
+      'authorization header does not use realm-server session token',
+    );
+  });
+
+  test('throws when full reindex endpoint returns non-204', async function (assert) {
+    let commandService = getService('command-service');
+    let realmServer = getService('realm-server');
+    let command = new FullReindexRealmCommand(commandService.commandContext);
+    let realmURL = new URL('test/', realmServer.url).href;
+    responseStatus = 500;
+    responseBody = 'boom';
+
+    await assert.rejects(
+      command.execute({
+        realmUrl: realmURL,
+      }),
+      /Full reindex realm failed: 500 - boom/,
+      'propagates non-204 failure as an error',
+    );
+  });
+
+  test('description explains forced full reindex semantics', async function (assert) {
+    let commandService = getService('command-service');
+    let command = new FullReindexRealmCommand(commandService.commandContext);
+
+    assert.true(
+      command.description.includes('every file in the realm is revisited'),
+      'description identifies this as the forced full option',
+    );
+    assert.true(
+      command.description.includes('stale cached results'),
+      'description explains when to choose it',
+    );
+  });
+});

--- a/packages/host/tests/integration/commands/reindex-realm-test.gts
+++ b/packages/host/tests/integration/commands/reindex-realm-test.gts
@@ -1,0 +1,153 @@
+import { getOwner } from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import ReindexRealmCommand from '@cardstack/host/commands/reindex-realm';
+import RealmService from '@cardstack/host/services/realm';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupRealmServerEndpoints,
+  testRealmInfo,
+  testRealmURL,
+  setupRealmCacheTeardown,
+  withCachedRealmSetup,
+} from '../../helpers';
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+class StubRealmService extends RealmService {
+  get defaultReadableRealm() {
+    return {
+      path: testRealmURL,
+      info: testRealmInfo,
+    };
+  }
+}
+
+module('Integration | commands | reindex-realm', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  let receivedAuthorizationHeader: string | null = null;
+  let receivedMethod: string | null = null;
+  let receivedPathname: string | null = null;
+  let responseStatus = 204;
+  let responseBody: string | null = null;
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  setupRealmServerEndpoints(hooks, [
+    {
+      route: 'test/_reindex',
+      getResponse: async (req: Request) => {
+        receivedAuthorizationHeader = req.headers.get('Authorization');
+        receivedMethod = req.method;
+        receivedPathname = new URL(req.url).pathname;
+        return new Response(responseBody, { status: responseStatus });
+      },
+    },
+  ]);
+
+  setupRealmCacheTeardown(hooks);
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    getOwner(this)!.register('service:realm', StubRealmService);
+    receivedAuthorizationHeader = null;
+    receivedMethod = null;
+    receivedPathname = null;
+    responseStatus = 204;
+    responseBody = null;
+
+    await withCachedRealmSetup(async () =>
+      setupIntegrationTestRealm({
+        mockMatrixUtils,
+        realmURL: testRealmURL,
+        contents: {},
+      }),
+    );
+  });
+
+  test('calls realm endpoint with expected auth header', async function (assert) {
+    let commandService = getService('command-service');
+    let realmServer = getService('realm-server');
+    let command = new ReindexRealmCommand(commandService.commandContext);
+    let realmURL = new URL('test/', realmServer.url).href;
+
+    let result = await command.execute({
+      realmUrl: realmURL,
+    });
+
+    assert.strictEqual(result, undefined, 'command has no result card');
+    assert.strictEqual(receivedMethod, 'POST', 'uses POST');
+    assert.strictEqual(receivedPathname, '/test/_reindex', 'calls endpoint');
+    assert.ok(receivedAuthorizationHeader, 'authorization header is present');
+    assert.true(
+      receivedAuthorizationHeader?.startsWith('Bearer '),
+      'authorization header uses Bearer scheme',
+    );
+
+    let authToken = receivedAuthorizationHeader!.replace('Bearer ', '');
+    let [_header, payload] = authToken.split('.');
+    let tokenClaims = JSON.parse(atob(payload)) as {
+      realm?: string;
+      permissions?: string[];
+    };
+
+    assert.strictEqual(
+      tokenClaims.realm,
+      realmURL,
+      'authorization token is realm-scoped',
+    );
+    assert.deepEqual(
+      tokenClaims.permissions,
+      ['read', 'write'],
+      'authorization token contains realm permissions',
+    );
+    assert.notStrictEqual(
+      receivedAuthorizationHeader,
+      `Bearer ${realmServer.token}`,
+      'authorization header does not use realm-server session token',
+    );
+  });
+
+  test('throws when reindex endpoint returns non-204', async function (assert) {
+    let commandService = getService('command-service');
+    let realmServer = getService('realm-server');
+    let command = new ReindexRealmCommand(commandService.commandContext);
+    let realmURL = new URL('test/', realmServer.url).href;
+    responseStatus = 500;
+    responseBody = 'boom';
+
+    await assert.rejects(
+      command.execute({
+        realmUrl: realmURL,
+      }),
+      /Reindex realm failed: 500 - boom/,
+      'propagates non-204 failure as an error',
+    );
+  });
+
+  test('description explains lighter reindex semantics', async function (assert) {
+    let commandService = getService('command-service');
+    let command = new ReindexRealmCommand(commandService.commandContext);
+
+    assert.true(
+      command.description.includes('lighter/default mode'),
+      'description identifies this as the lighter option',
+    );
+    assert.true(
+      command.description.includes('mtime'),
+      'description explains mtime-based behavior',
+    );
+  });
+});

--- a/packages/realm-server/handlers/handle-reindex.ts
+++ b/packages/realm-server/handlers/handle-reindex.ts
@@ -87,5 +87,8 @@ export async function reindex({
     queue,
     dbAdapter,
     priority,
+    {
+      clearLastModified: true,
+    },
   );
 }

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -142,6 +142,7 @@ import './realm-endpoints/mtimes-test';
 import './realm-endpoints/permissions-test';
 import './realm-endpoints/cancel-indexing-job-test';
 import './realm-endpoints/publishability-test';
+import './realm-endpoints/reindex-test';
 import './realm-endpoints/search-test';
 import './realm-endpoints/user-test';
 import './search-prerendered-test';

--- a/packages/realm-server/tests/realm-endpoints/reindex-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/reindex-test.ts
@@ -1,0 +1,432 @@
+import { module, test } from 'qunit';
+import { basename, join } from 'path';
+import { readFileSync, utimesSync, writeFileSync } from 'fs';
+import type { SuperTest, Test } from 'supertest';
+import type { Realm } from '@cardstack/runtime-common';
+import type { MatrixEvent } from 'https://cardstack.com/base/matrix-event';
+import type { Server } from 'http';
+import type { DirResult } from 'tmp';
+import {
+  createJWT,
+  setupMatrixRoom,
+  setupPermissionedRealmCached,
+  testRealmHref,
+  waitUntil,
+} from '../helpers';
+import type { PgAdapter as TestPgAdapter } from '@cardstack/postgres';
+
+const PERSON_CARD_SOURCE = `
+import {
+  contains,
+  field,
+  Component,
+  CardDef,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+
+export class Person extends CardDef {
+  static displayName = 'Person';
+  @field firstName = contains(StringField);
+  @field cardTitle = contains(StringField, {
+    computeVia: function (this: Person) {
+      return this.firstName;
+    },
+  });
+  static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      <h1 data-test-card><@fields.firstName /></h1>
+    </template>
+  };
+}
+`;
+
+const ARTICLE_CARD_SOURCE = `
+import {
+  contains,
+  field,
+  Component,
+  CardDef,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+
+export class Article extends CardDef {
+  static displayName = 'Article';
+  @field title = contains(StringField);
+  @field cardTitle = contains(StringField, {
+    computeVia: function (this: Article) {
+      return this.title;
+    },
+  });
+  static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      <h1 data-test-card><@fields.title /></h1>
+    </template>
+  };
+}
+`;
+
+const PERSON_INSTANCE = JSON.stringify({
+  data: {
+    type: 'card',
+    attributes: {
+      firstName: 'Mango',
+    },
+    meta: {
+      adoptsFrom: {
+        module: './person.gts',
+        name: 'Person',
+      },
+    },
+  },
+});
+
+const ARTICLE_INSTANCE = JSON.stringify({
+  data: {
+    type: 'card',
+    attributes: {
+      title: 'Unchanged Article',
+    },
+    meta: {
+      adoptsFrom: {
+        module: './article.gts',
+        name: 'Article',
+      },
+    },
+  },
+});
+
+module(`realm-endpoints/${basename(__filename)}`, function () {
+  module(
+    'Realm-specific Endpoints | POST _reindex and _full-reindex',
+    function (hooks) {
+      let testRealm: Realm;
+      let request: SuperTest<Test>;
+      let dbAdapter: TestPgAdapter;
+      let testRealmPath: string;
+      let testRealmHttpServer: Server;
+      let dir: DirResult;
+
+      function onRealmSetup(args: {
+        testRealm: Realm;
+        request: SuperTest<Test>;
+        dbAdapter: TestPgAdapter;
+        testRealmPath: string;
+        testRealmHttpServer: Server;
+        dir: DirResult;
+      }) {
+        testRealm = args.testRealm;
+        request = args.request;
+        dbAdapter = args.dbAdapter;
+        testRealmPath = args.testRealmPath;
+        testRealmHttpServer = args.testRealmHttpServer;
+        dir = args.dir;
+      }
+
+      setupPermissionedRealmCached(hooks, {
+        subscribeToRealmEvents: true,
+        fileSystem: {
+          'person.gts': PERSON_CARD_SOURCE,
+          'person-1.json': PERSON_INSTANCE,
+          'article.gts': ARTICLE_CARD_SOURCE,
+          'article-1.json': ARTICLE_INSTANCE,
+        },
+        permissions: {
+          writer: ['read', 'write'],
+          reader: ['read'],
+          '@node-test_realm:localhost': ['read', 'realm-owner'],
+        },
+        onRealmSetup,
+      });
+
+      let { getMessagesSince } = setupMatrixRoom(hooks, () => ({
+        testRealm,
+        testRealmHttpServer,
+        request,
+        dir,
+        dbAdapter,
+      }));
+
+      async function latestFromScratchJobCount() {
+        let rows = (await dbAdapter.execute(
+          `SELECT id FROM jobs WHERE job_type = 'from-scratch-index'`,
+        )) as { id: number }[];
+        return rows.length;
+      }
+
+      async function latestFromScratchJob() {
+        let [row] = (await dbAdapter.execute(
+          `SELECT id, status, result
+         FROM jobs
+         WHERE job_type = 'from-scratch-index'
+         ORDER BY id DESC
+         LIMIT 1`,
+        )) as {
+          id: number;
+          status: string;
+          result: { invalidations: string[] };
+        }[];
+        return row;
+      }
+
+      function bumpFileMtime(path: string) {
+        let contents = readFileSync(path, 'utf8');
+        writeFileSync(path, `${contents}\n// reindex test`);
+        let now = Date.now() / 1000;
+        utimesSync(path, now + 5, now + 5);
+      }
+
+      function hasMatchingInvalidations(
+        actual: string[],
+        expected: string[],
+      ): boolean {
+        return (
+          JSON.stringify([...actual].sort()) ===
+          JSON.stringify([...expected].sort())
+        );
+      }
+
+      async function waitForIncrementalRealmEvent(
+        since: number,
+        expectedInvalidations: string[],
+      ): Promise<MatrixEvent & { content: { invalidations: string[] } }> {
+        return (await waitUntil(
+          async () => {
+            let messages = await getMessagesSince(since);
+            return messages.find(
+              (
+                event,
+              ): event is MatrixEvent & {
+                content: { invalidations: string[] };
+              } =>
+                event.type === 'app.boxel.realm-event' &&
+                event.content.eventName === 'index' &&
+                event.content.indexType === 'incremental' &&
+                hasMatchingInvalidations(
+                  event.content.invalidations,
+                  expectedInvalidations,
+                ),
+            );
+          },
+          { timeout: 20000 },
+        )) as MatrixEvent & {
+          content: { invalidations: string[] };
+        };
+      }
+
+      async function waitForFullRealmEvent(
+        since: number,
+      ): Promise<MatrixEvent & { content: { indexType: string } }> {
+        return (await waitUntil(
+          async () => {
+            let messages = await getMessagesSince(since);
+            return messages.find(
+              (
+                event,
+              ): event is MatrixEvent & {
+                content: { indexType: string };
+              } =>
+                event.type === 'app.boxel.realm-event' &&
+                event.content.eventName === 'index' &&
+                event.content.indexType === 'full',
+            );
+          },
+          { timeout: 20000 },
+        )) as MatrixEvent & {
+          content: { indexType: string };
+        };
+      }
+
+      async function establishBaselineIndex() {
+        await testRealm.reindex();
+      }
+
+      test('returns 401 without JWT for private realm', async function (assert) {
+        let response = await request
+          .post('/_reindex')
+          .set('Accept', 'application/json');
+
+        assert.strictEqual(response.status, 401, 'HTTP 401 status');
+      });
+
+      test('returns 403 for user without write access', async function (assert) {
+        let response = await request
+          .post('/_reindex')
+          .set('Accept', 'application/json')
+          .set(
+            'Authorization',
+            `Bearer ${createJWT(testRealm, 'reader', ['read'])}`,
+          );
+
+        assert.strictEqual(response.status, 403, 'HTTP 403 status');
+      });
+
+      test('returns 401 without JWT for private realm on full reindex', async function (assert) {
+        let response = await request
+          .post('/_full-reindex')
+          .set('Accept', 'application/json');
+
+        assert.strictEqual(response.status, 401, 'HTTP 401 status');
+      });
+
+      test('returns 403 for user without write access on full reindex', async function (assert) {
+        let response = await request
+          .post('/_full-reindex')
+          .set('Accept', 'application/json')
+          .set(
+            'Authorization',
+            `Bearer ${createJWT(testRealm, 'reader', ['read'])}`,
+          );
+
+        assert.strictEqual(response.status, 403, 'HTTP 403 status');
+      });
+
+      test('reindex publishes a normal from-scratch job and broadcasts changed invalidations', async function (assert) {
+        await establishBaselineIndex();
+        bumpFileMtime(join(testRealmPath, 'person.gts'));
+
+        let initialJobCount = await latestFromScratchJobCount();
+        let realmEventTimestampStart = Date.now();
+
+        let response = await request
+          .post('/_reindex')
+          .set('Accept', 'application/json')
+          .set(
+            'Authorization',
+            `Bearer ${createJWT(testRealm, 'writer', ['read', 'write'])}`,
+          );
+
+        assert.strictEqual(response.status, 204, 'HTTP 204 response');
+
+        await waitUntil(async () => {
+          let currentCount = await latestFromScratchJobCount();
+          return currentCount === initialJobCount + 1 ? true : undefined;
+        });
+
+        let job = await waitUntil(
+          async () => {
+            let row = await latestFromScratchJob();
+            return row?.status === 'resolved' ? row : undefined;
+          },
+          { timeout: 20000 },
+        );
+        assert.ok(job, 'latest from-scratch job resolved');
+        if (!job) {
+          throw new Error('expected latest from-scratch job to resolve');
+        }
+        let event = await waitForIncrementalRealmEvent(
+          realmEventTimestampStart,
+          job.result.invalidations,
+        );
+        let fullEvent = await waitForFullRealmEvent(realmEventTimestampStart);
+
+        assert.deepEqual(
+          event.content.invalidations,
+          job.result.invalidations,
+          'normal reindex broadcasts the worker invalidation payload',
+        );
+        assert.deepEqual(
+          [...event.content.invalidations].sort(),
+          [
+            `${testRealmHref}person-1.json`,
+            `${testRealmHref}person.gts`,
+          ].sort(),
+          'normal reindex invalidates the changed module and its dependent instance, but not unrelated files',
+        );
+        assert.strictEqual(
+          fullEvent.content.indexType,
+          'full',
+          'normal reindex also broadcasts the full index event',
+        );
+      });
+
+      test('Realm.reindex broadcasts incremental invalidations and full index events', async function (assert) {
+        await establishBaselineIndex();
+        bumpFileMtime(join(testRealmPath, 'person.gts'));
+
+        let realmEventTimestampStart = Date.now();
+        await testRealm.reindex();
+
+        let expectedInvalidations = [
+          `${testRealmHref}person-1.json`,
+          `${testRealmHref}person.gts`,
+        ];
+        let incrementalEvent = await waitForIncrementalRealmEvent(
+          realmEventTimestampStart,
+          expectedInvalidations,
+        );
+        let fullEvent = await waitForFullRealmEvent(realmEventTimestampStart);
+
+        assert.deepEqual(
+          [...incrementalEvent.content.invalidations].sort(),
+          expectedInvalidations.sort(),
+          'Realm.reindex broadcasts incremental invalidations from the reindex job result',
+        );
+        assert.strictEqual(
+          fullEvent.content.indexType,
+          'full',
+          'Realm.reindex still broadcasts the full index event',
+        );
+      });
+
+      test('full reindex forces all files to invalidate and broadcasts the full invalidation set', async function (assert) {
+        await establishBaselineIndex();
+
+        let initialJobCount = await latestFromScratchJobCount();
+        let realmEventTimestampStart = Date.now();
+
+        let response = await request
+          .post('/_full-reindex')
+          .set('Accept', 'application/json')
+          .set(
+            'Authorization',
+            `Bearer ${createJWT(testRealm, 'writer', ['read', 'write'])}`,
+          );
+
+        assert.strictEqual(response.status, 204, 'HTTP 204 response');
+
+        await waitUntil(async () => {
+          let currentCount = await latestFromScratchJobCount();
+          return currentCount === initialJobCount + 1 ? true : undefined;
+        });
+
+        let job = await waitUntil(
+          async () => {
+            let row = await latestFromScratchJob();
+            return row?.status === 'resolved' ? row : undefined;
+          },
+          { timeout: 20000 },
+        );
+        assert.ok(job, 'latest full from-scratch job resolved');
+        if (!job) {
+          throw new Error('expected latest full from-scratch job to resolve');
+        }
+        let event = await waitForIncrementalRealmEvent(
+          realmEventTimestampStart,
+          job.result.invalidations,
+        );
+        let fullEvent = await waitForFullRealmEvent(realmEventTimestampStart);
+
+        assert.deepEqual(
+          event.content.invalidations,
+          job.result.invalidations,
+          'full reindex broadcasts the worker invalidation payload',
+        );
+        assert.deepEqual(
+          [...event.content.invalidations].sort(),
+          [
+            `${testRealmHref}article-1.json`,
+            `${testRealmHref}article.gts`,
+            `${testRealmHref}person-1.json`,
+            `${testRealmHref}person.gts`,
+          ].sort(),
+          'full reindex broadcasts all files in the realm',
+        );
+        assert.strictEqual(
+          fullEvent.content.indexType,
+          'full',
+          'full reindex also broadcasts the full index event',
+        );
+      });
+    },
+  );
+});

--- a/packages/runtime-common/jobs/reindex-realm.ts
+++ b/packages/runtime-common/jobs/reindex-realm.ts
@@ -5,21 +5,28 @@ import {
   type FromScratchResult,
 } from '../tasks/indexer';
 
+interface EnqueueReindexRealmJobOptions {
+  clearLastModified?: boolean;
+}
+
 export async function enqueueReindexRealmJob(
   realmUrl: string,
   realmUsername: string,
   queue: QueuePublisher,
   dbAdapter: DBAdapter,
   priority: number,
+  opts?: EnqueueReindexRealmJobOptions,
 ) {
   let args = {
     realmURL: realmUrl,
     realmUsername,
   };
-  await query(dbAdapter, [
-    `UPDATE boxel_index SET last_modified = NULL WHERE realm_url =`,
-    param(realmUrl),
-  ]);
+  if (opts?.clearLastModified) {
+    await query(dbAdapter, [
+      `UPDATE boxel_index SET last_modified = NULL WHERE realm_url =`,
+      param(realmUrl),
+    ]);
+  }
   let job = await queue.publish<FromScratchResult>({
     jobType: 'from-scratch-index',
     concurrencyGroup: `indexing:${realmUrl}`,

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -2,6 +2,7 @@ import { Memoize } from 'typescript-memoize';
 import {
   IndexWriter,
   Deferred,
+  type Job,
   logger,
   systemInitiatedPriority,
   userInitiatedPriority,
@@ -17,11 +18,8 @@ import {
   mapIncrementalDoneResult,
   type IncrementalIndexEnqueueArgs,
 } from './jobs/indexing';
-import {
-  FROM_SCRATCH_JOB_TIMEOUT_SEC,
-  type FromScratchResult,
-  type IncrementalDoneResult,
-} from './tasks/indexer';
+import { enqueueReindexRealmJob } from './jobs/reindex-realm';
+import type { FromScratchResult, IncrementalDoneResult } from './tasks/indexer';
 import type { Realm } from './realm';
 import { RealmPaths } from './paths';
 import ignore, { type Ignore } from 'ignore';
@@ -38,6 +36,7 @@ export class RealmIndexUpdater {
     totalIndexEntries: 0,
   };
   #indexWriter: IndexWriter;
+  #dbAdapter: DBAdapter;
   #queue: QueuePublisher;
   #indexingDeferreds = new Set<Deferred<void>>();
 
@@ -55,6 +54,7 @@ export class RealmIndexUpdater {
         `DB Adapter was not provided to SearchIndex constructor--this is required when using a db based index`,
       );
     }
+    this.#dbAdapter = dbAdapter;
     this.#indexWriter = new IndexWriter(dbAdapter);
     this.#queue = queue;
     this.#realm = realm;
@@ -90,48 +90,69 @@ export class RealmIndexUpdater {
     ).then(() => undefined);
   }
 
-  // TODO consider triggering realm events for invalidations now that we can
-  // calculate fine grained invalidations for from-scratch indexing by passing
-  // in an onInvalidation callback
-  async fullIndex(priority = systemInitiatedPriority) {
+  publishFullIndex(
+    priority = systemInitiatedPriority,
+    opts?: { clearLastModified?: boolean },
+  ): {
+    published: Promise<Job<FromScratchResult>>;
+    completed: Promise<FromScratchResult>;
+  } {
     let indexingDeferred = new Deferred<void>();
+    let published = new Deferred<Job<FromScratchResult>>();
     this.#indexingDeferreds.add(indexingDeferred);
     let startedAt = performance.now();
-    try {
-      let args = {
-        realmURL: this.#realm.url,
-        realmUsername: await this.#realm.getRealmOwnerUsername(),
-      };
 
-      this.#log.info(`Realm ${this.realmURL.href} is starting indexing`);
+    let completed = (async () => {
+      try {
+        this.#log.info(`Realm ${this.realmURL.href} is starting indexing`);
 
-      let job = await this.#queue.publish<FromScratchResult>({
-        jobType: 'from-scratch-index',
-        concurrencyGroup: `indexing:${this.#realm.url}`,
-        timeout: FROM_SCRATCH_JOB_TIMEOUT_SEC,
-        priority,
-        args,
-      });
-      let { ignoreData, stats } = await job.done;
-      this.#stats = stats;
-      this.#ignoreData = ignoreData;
-      let indexingDurationSeconds = (
-        (performance.now() - startedAt) /
-        1000
-      ).toFixed(2);
-      this.#log.info(
-        `Realm ${this.realmURL.href} has completed indexing in ${indexingDurationSeconds}s: ${JSON.stringify(
-          stats,
-          null,
-          2,
-        )}`,
-      );
-    } catch (e: any) {
-      this.#log.error(`Error running from-scratch-index: ${e.message}`);
-    } finally {
-      indexingDeferred.fulfill();
-      this.#indexingDeferreds.delete(indexingDeferred);
-    }
+        let job = await enqueueReindexRealmJob(
+          this.#realm.url,
+          await this.#realm.getRealmOwnerUsername(),
+          this.#queue,
+          this.#dbAdapter,
+          priority,
+          {
+            clearLastModified: opts?.clearLastModified,
+          },
+        );
+        published.fulfill(job);
+
+        let result = await job.done;
+        let { ignoreData, stats } = result;
+        this.#stats = stats;
+        this.#ignoreData = ignoreData;
+        let indexingDurationSeconds = (
+          (performance.now() - startedAt) /
+          1000
+        ).toFixed(2);
+        this.#log.info(
+          `Realm ${this.realmURL.href} has completed indexing in ${indexingDurationSeconds}s: ${JSON.stringify(
+            stats,
+            null,
+            2,
+          )}`,
+        );
+        return result;
+      } catch (e: any) {
+        published.reject(e);
+        this.#log.error(`Error running from-scratch-index: ${e.message}`);
+        throw e;
+      } finally {
+        indexingDeferred.fulfill();
+        this.#indexingDeferreds.delete(indexingDeferred);
+      }
+    })();
+
+    return {
+      published: published.promise,
+      completed,
+    };
+  }
+
+  async fullIndex(priority = systemInitiatedPriority) {
+    let { completed } = this.publishFullIndex(priority);
+    await completed;
   }
 
   async update(

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -133,10 +133,6 @@ export class RealmIndexUpdater {
         );
         return result;
       })
-      .catch((e: any) => {
-        this.#log.error(`Error running from-scratch-index: ${e.message}`);
-        throw e;
-      })
       .finally(() => {
         indexingDeferred.fulfill();
         this.#indexingDeferreds.delete(indexingDeferred);
@@ -150,7 +146,13 @@ export class RealmIndexUpdater {
 
   async fullIndex(priority = systemInitiatedPriority) {
     let { completed } = this.publishFullIndex(priority);
-    await completed;
+    try {
+      await completed;
+    } catch (e: any) {
+      this.#log.error(`Error running from-scratch-index: ${e.message}`);
+      // Preserve the historical fullIndex() behavior for fire-and-forget
+      // callers such as startup.
+    }
   }
 
   async update(

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -98,26 +98,24 @@ export class RealmIndexUpdater {
     completed: Promise<FromScratchResult>;
   } {
     let indexingDeferred = new Deferred<void>();
-    let published = new Deferred<Job<FromScratchResult>>();
     this.#indexingDeferreds.add(indexingDeferred);
     let startedAt = performance.now();
 
-    let completed = (async () => {
-      try {
-        this.#log.info(`Realm ${this.realmURL.href} is starting indexing`);
+    this.#log.info(`Realm ${this.realmURL.href} is starting indexing`);
+    let published = (async () =>
+      await enqueueReindexRealmJob(
+        this.#realm.url,
+        await this.#realm.getRealmOwnerUsername(),
+        this.#queue,
+        this.#dbAdapter,
+        priority,
+        {
+          clearLastModified: opts?.clearLastModified,
+        },
+      ))();
 
-        let job = await enqueueReindexRealmJob(
-          this.#realm.url,
-          await this.#realm.getRealmOwnerUsername(),
-          this.#queue,
-          this.#dbAdapter,
-          priority,
-          {
-            clearLastModified: opts?.clearLastModified,
-          },
-        );
-        published.fulfill(job);
-
+    let completed = published
+      .then(async (job) => {
         let result = await job.done;
         let { ignoreData, stats } = result;
         this.#stats = stats;
@@ -134,18 +132,18 @@ export class RealmIndexUpdater {
           )}`,
         );
         return result;
-      } catch (e: any) {
-        published.reject(e);
+      })
+      .catch((e: any) => {
         this.#log.error(`Error running from-scratch-index: ${e.message}`);
         throw e;
-      } finally {
+      })
+      .finally(() => {
         indexingDeferred.fulfill();
         this.#indexingDeferreds.delete(indexingDeferred);
-      }
-    })();
+      });
 
     return {
-      published: published.promise,
+      published,
       completed,
     };
   }

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -64,6 +64,7 @@ import {
   type ResourceObjectWithId,
   type DirectoryEntryRelationship,
   type DBAdapter,
+  type Job,
   type QueuePublisher,
   type FileMeta,
   type DirectoryMeta,
@@ -87,6 +88,7 @@ import {
   PRERENDERED_HTML_FORMATS,
   hasExtension,
 } from './index';
+import type { FromScratchResult } from './tasks/indexer';
 import { isCodeRef, visitModuleDeps } from './code-ref';
 import merge from 'lodash/merge';
 import mergeWith from 'lodash/mergeWith';
@@ -671,6 +673,12 @@ export class Realm {
         SupportedMimeType.JSON,
         this.cancelIndexingJob.bind(this),
       )
+      .post('/_reindex', SupportedMimeType.JSON, this.queueReindex.bind(this))
+      .post(
+        '/_full-reindex',
+        SupportedMimeType.JSON,
+        this.queueFullReindex.bind(this),
+      )
       .post(
         '/_invalidate',
         SupportedMimeType.JSONAPI,
@@ -771,6 +779,43 @@ export class Realm {
     return this.#realmIndexUpdater.indexing();
   }
 
+  private startReindex(opts?: {
+    clearLastModified?: boolean;
+    priority?: number;
+  }): { published: Promise<Job<FromScratchResult>>; completed: Promise<void> } {
+    let { published, completed: indexingCompleted } =
+      this.#realmIndexUpdater.publishFullIndex(
+        opts?.priority ?? systemInitiatedPriority,
+        {
+          clearLastModified: opts?.clearLastModified,
+        },
+      );
+
+    let completed = indexingCompleted.then(async ({ invalidations }) => {
+      await this.#definitionLookup.clearRealmCache(this.url);
+      this.#moduleCache.clear();
+      if (invalidations.length > 0) {
+        this.broadcastIncrementalInvalidationEvent(invalidations);
+      }
+      this.broadcastRealmEvent({
+        eventName: 'index',
+        indexType: 'full',
+        realmURL: this.url,
+      });
+    });
+
+    void completed.catch((error: unknown) => {
+      let message =
+        error instanceof Error ? error.message : JSON.stringify(error);
+      this.#log.error(`Error completing reindex for ${this.url}: ${message}`);
+    });
+
+    return {
+      published,
+      completed,
+    };
+  }
+
   private async cancelIndexingJob(
     _request: Request,
     requestContext: RequestContext,
@@ -779,6 +824,43 @@ export class Realm {
       this.#dbAdapter,
       `indexing:${this.url}`,
     );
+
+    return createResponse({
+      body: null,
+      init: {
+        status: 204,
+      },
+      requestContext,
+    });
+  }
+
+  private async queueReindex(
+    _request: Request,
+    requestContext: RequestContext,
+  ) {
+    let { published } = this.startReindex({
+      priority: userInitiatedPriority,
+    });
+    await published;
+
+    return createResponse({
+      body: null,
+      init: {
+        status: 204,
+      },
+      requestContext,
+    });
+  }
+
+  private async queueFullReindex(
+    _request: Request,
+    requestContext: RequestContext,
+  ) {
+    let { published } = this.startReindex({
+      clearLastModified: true,
+      priority: userInitiatedPriority,
+    });
+    await published;
 
     return createResponse({
       body: null,
@@ -1460,14 +1542,8 @@ export class Realm {
   }
 
   async reindex() {
-    await this.#realmIndexUpdater.fullIndex();
-    await this.#definitionLookup.clearRealmCache(this.url);
-    this.#moduleCache.clear();
-    this.broadcastRealmEvent({
-      eventName: 'index',
-      indexType: 'full',
-      realmURL: this.url,
-    });
+    let { completed } = this.startReindex();
+    await completed;
   }
 
   async #startup() {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -805,8 +805,16 @@ export class Realm {
     });
 
     void completed.catch((error: unknown) => {
-      let message =
-        error instanceof Error ? error.message : JSON.stringify(error);
+      let message: string;
+      if (error instanceof Error) {
+        message = error.message;
+      } else {
+        try {
+          message = JSON.stringify(error);
+        } catch (_err) {
+          message = String(error);
+        }
+      }
       this.#log.error(`Error completing reindex for ${this.url}: ${message}`);
     });
 

--- a/packages/runtime-common/tasks/full-reindex.ts
+++ b/packages/runtime-common/tasks/full-reindex.ts
@@ -74,6 +74,9 @@ const fullReindex: Task<FullReindexArgs, void> = ({
           queuePublisher,
           dbAdapter,
           systemInitiatedPriority,
+          {
+            clearLastModified: true,
+          },
         );
       } catch (error: any) {
         log.error(


### PR DESCRIPTION
## Summary
- add realm-scoped `POST /_reindex` and `POST /_full-reindex` endpoints for writers, both returning `204` as soon as the reindex job is published
- `/_reindex` runs a normal from-scratch reindex using existing mtime/error/deletion semantics, so unchanged files are skipped and only stale files are revisited
- `/_full-reindex` forces a full realm rebuild by clearing indexed `last_modified` state before publishing the same from-scratch job, causing all files in the realm to be revisited
- refactor reindex orchestration so `Realm.reindex()` and both endpoints share the same completion behavior, including cache clearing plus incremental and full index realm events
- add host-side `reindex-realm` and `full-reindex-realm` commands with realm-scoped JWT auth, no result cards, and descriptions that help callers choose between lighter and forced reindexing
