### PR TITLE
feat: keyboard-friendly Choose File modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,11 @@
 
 - Always run `pnpm lint` in modified packages before committing
 
+## Production-safe selectors
+
+- `data-test-*` attributes are stripped from production builds. Never use them for runtime behavior or styling in app code.
+- For production hooks, use classes or non-test `data-*` attributes (for example `data-path`, `data-kind`) and keep `data-test-*` only for tests.
+
 ## `.gts` file gotcha: regex literals can break content-tag
 
 The `content-tag` preprocessor (used by glint and ember-eslint-parser to parse `.gts` files) has bugs in its JavaScript lexer that cause it to misparse certain regex literals. When this happens, it fails to recognize `<template>` tags later in the file, producing cascading parse errors. Two known triggers:

--- a/packages/host/app/components/editor/indexed-file-tree.gts
+++ b/packages/host/app/components/editor/indexed-file-tree.gts
@@ -224,8 +224,13 @@ export default class IndexedFileTree extends Component<Signature> {
           currentIndex === -1
             ? 0
             : Math.min(currentIndex + 1, items.length - 1);
-        this.cursorPath = items[nextIndex]!.path;
-        this.scrollPathIntoView(this.cursorPath, nav);
+        const nextItem = items[nextIndex]!;
+        if (nextItem.kind === 'file') {
+          this.selectFile(nextItem.path as LocalPath);
+        } else {
+          this.cursorPath = nextItem.path;
+        }
+        this.scrollPathIntoView(nextItem.path, nav);
         break;
       }
 
@@ -240,8 +245,13 @@ export default class IndexedFileTree extends Component<Signature> {
           currentIndex === -1
             ? items.length - 1
             : Math.max(currentIndex - 1, 0);
-        this.cursorPath = items[prevIndex]!.path;
-        this.scrollPathIntoView(this.cursorPath, nav);
+        const prevItem = items[prevIndex]!;
+        if (prevItem.kind === 'file') {
+          this.selectFile(prevItem.path as LocalPath);
+        } else {
+          this.cursorPath = prevItem.path;
+        }
+        this.scrollPathIntoView(prevItem.path, nav);
         break;
       }
 
@@ -292,11 +302,13 @@ export default class IndexedFileTree extends Component<Signature> {
 
       case 'Enter': {
         event.preventDefault();
+        event.stopPropagation();
         if (!this.cursorPath) break;
         const current = this.visibleItems.find(
           (i) => i.path === this.cursorPath,
         );
         if (current?.kind === 'file') {
+          this.selectFile(current.path as LocalPath);
           this.args.onFileConfirmed?.(current.path as LocalPath);
         } else if (current?.kind === 'directory') {
           this.toggleDirectory(current.path as LocalPath);
@@ -340,8 +352,16 @@ export default class IndexedFileTree extends Component<Signature> {
         if (match) {
           const path =
             match.dataset['testFile'] ?? match.dataset['testDirectory'];
-          this.cursorPath = path;
-          match.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+          if (path) {
+            if (match.dataset['testFile']) {
+              // File: update selection (selectFile also sets cursorPath)
+              this.selectFile(path as LocalPath);
+            } else {
+              // Directory: just move cursor, don't expand
+              this.cursorPath = path;
+            }
+            match.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+          }
         }
         break;
       }

--- a/packages/host/app/components/editor/indexed-file-tree.gts
+++ b/packages/host/app/components/editor/indexed-file-tree.gts
@@ -4,7 +4,7 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import type Owner from '@ember/owner';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
+import { cached, tracked } from '@glimmer/tracking';
 
 import { restartableTask, timeout } from 'ember-concurrency';
 import Modifier from 'ember-modifier';
@@ -46,6 +46,7 @@ interface Signature {
     selectedFile?: LocalPath;
     openDirs?: LocalPath[];
     onFileSelected?: (entryPath: LocalPath) => void;
+    onFileConfirmed?: (entryPath: LocalPath) => void;
     onDirectorySelected?: (entryPath: LocalPath) => void;
     scrollPositionKey?: LocalPath;
     autoFocus?: boolean;
@@ -58,7 +59,7 @@ export default class IndexedFileTree extends Component<Signature> {
       aria-label='File tree'
       tabindex='0'
       data-test-file-tree-nav
-      {{on 'keydown' this.handleTypeAhead}}
+      {{on 'keydown' this.handleKeydown}}
       {{AutoFocusModifier @autoFocus}}
     >
       <TreeLevel
@@ -70,7 +71,7 @@ export default class IndexedFileTree extends Component<Signature> {
         @onDirectorySelected={{this.toggleDirectory}}
         @scrollPositionKey={{@scrollPositionKey}}
         @relativePath=''
-        @typeAheadMatch={{this.typeAheadMatch}}
+        @cursorPath={{this.cursorPath}}
       />
       {{#if this.showMask}}
         <div class='mask' data-test-file-tree-mask>
@@ -113,7 +114,7 @@ export default class IndexedFileTree extends Component<Signature> {
   private localOpenDirs = new TrackedSet<string>();
   @tracked private selectedFile?: LocalPath;
   @tracked private maskDismissed = false;
-  @tracked private typeAheadMatch?: string;
+  @tracked private cursorPath?: string;
   private typeAheadBuffer = '';
   private typeAheadTimer?: ReturnType<typeof setTimeout>;
 
@@ -145,15 +146,57 @@ export default class IndexedFileTree extends Component<Signature> {
     return this.localOpenDirs;
   }
 
+  @cached
+  private get visibleItems(): FileTreeNode[] {
+    return this.flattenVisible(this.fileTree.entries, this.effectiveOpenDirs);
+  }
+
+  private flattenVisible(
+    entries: FileTreeNode[],
+    openDirs: Set<string>,
+  ): FileTreeNode[] {
+    const result: FileTreeNode[] = [];
+    for (const entry of entries) {
+      result.push(entry);
+      if (
+        entry.kind === 'directory' &&
+        entry.children &&
+        openDirs.has(normalizeDirPath(entry.path))
+      ) {
+        result.push(
+          ...this.flattenVisible(Array.from(entry.children.values()), openDirs),
+        );
+      }
+    }
+    return result;
+  }
+
+  private getParentPath(path: string): string | undefined {
+    const p = path.endsWith('/') ? path.slice(0, -1) : path;
+    const lastSlash = p.lastIndexOf('/');
+    if (lastSlash === -1) return undefined;
+    return p.substring(0, lastSlash) + '/';
+  }
+
+  private scrollPathIntoView(path: string, nav: HTMLElement) {
+    const escaped = CSS.escape(path);
+    const el = nav.querySelector<HTMLElement>(
+      `[data-test-file="${escaped}"], [data-test-directory="${escaped}"]`,
+    );
+    el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }
+
   @action
   private selectFile(entryPath: LocalPath) {
     this.selectedFile = entryPath;
+    this.cursorPath = entryPath;
     this.args.onFileSelected?.(entryPath);
   }
 
   @action
   private toggleDirectory(entryPath: LocalPath) {
     let dirPath = normalizeDirPath(entryPath);
+    this.cursorPath = dirPath;
 
     if (this.localOpenDirs.has(dirPath)) {
       this.localOpenDirs.delete(dirPath);
@@ -165,46 +208,143 @@ export default class IndexedFileTree extends Component<Signature> {
   }
 
   @action
-  private handleTypeAhead(event: KeyboardEvent) {
+  private handleKeydown(event: KeyboardEvent) {
     const key = event.key;
-
-    // Only handle single printable characters; ignore modifier combos
-    if (key.length !== 1 || event.ctrlKey || event.metaKey || event.altKey) {
-      return;
-    }
-
-    // If focus is on a child button, let Space activate that button normally
-    if (key === ' ' && event.target !== event.currentTarget) {
-      return;
-    }
-
-    // Prevent default so Space doesn't scroll the page
-    event.preventDefault();
-
-    this.typeAheadBuffer += key.toLowerCase();
-
-    // Reset buffer after 600 ms of inactivity
-    clearTimeout(this.typeAheadTimer);
-    this.typeAheadTimer = setTimeout(() => {
-      this.typeAheadBuffer = '';
-      this.typeAheadMatch = undefined;
-    }, 600);
-
-    // Search all visible (rendered) file and directory buttons
     const nav = event.currentTarget as HTMLElement;
-    const buttons = Array.from(
-      nav.querySelectorAll<HTMLButtonElement>('button:not([disabled])'),
-    );
-    const match = buttons.find((btn) =>
-      btn.getAttribute('title')?.toLowerCase().startsWith(this.typeAheadBuffer),
-    );
 
-    if (match) {
-      const path = match.dataset['testFile'] ?? match.dataset['testDirectory'];
-      this.typeAheadMatch = path;
-      match.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-    } else {
-      this.typeAheadMatch = undefined;
+    switch (key) {
+      case 'ArrowDown': {
+        event.preventDefault();
+        const items = this.visibleItems;
+        if (!items.length) break;
+        const currentIndex = this.cursorPath
+          ? items.findIndex((i) => i.path === this.cursorPath)
+          : -1;
+        const nextIndex =
+          currentIndex === -1
+            ? 0
+            : Math.min(currentIndex + 1, items.length - 1);
+        this.cursorPath = items[nextIndex]!.path;
+        this.scrollPathIntoView(this.cursorPath, nav);
+        break;
+      }
+
+      case 'ArrowUp': {
+        event.preventDefault();
+        const items = this.visibleItems;
+        if (!items.length) break;
+        const currentIndex = this.cursorPath
+          ? items.findIndex((i) => i.path === this.cursorPath)
+          : -1;
+        const prevIndex =
+          currentIndex === -1
+            ? items.length - 1
+            : Math.max(currentIndex - 1, 0);
+        this.cursorPath = items[prevIndex]!.path;
+        this.scrollPathIntoView(this.cursorPath, nav);
+        break;
+      }
+
+      case 'ArrowRight': {
+        event.preventDefault();
+        if (!this.cursorPath) break;
+        const current = this.visibleItems.find(
+          (i) => i.path === this.cursorPath,
+        );
+        if (current?.kind === 'directory') {
+          const dirPath = normalizeDirPath(current.path);
+          if (!this.effectiveOpenDirs.has(dirPath)) {
+            this.toggleDirectory(current.path as LocalPath);
+          }
+          // Move cursor into first child (works whether just opened or already open)
+          const items = this.visibleItems;
+          const idx = items.findIndex((i) => i.path === this.cursorPath);
+          if (idx !== -1 && idx < items.length - 1) {
+            this.cursorPath = items[idx + 1]!.path;
+            this.scrollPathIntoView(this.cursorPath, nav);
+          }
+        }
+        break;
+      }
+
+      case 'ArrowLeft': {
+        event.preventDefault();
+        if (!this.cursorPath) break;
+        const current = this.visibleItems.find(
+          (i) => i.path === this.cursorPath,
+        );
+        if (current?.kind === 'directory') {
+          const dirPath = normalizeDirPath(current.path);
+          if (this.effectiveOpenDirs.has(dirPath)) {
+            // Collapse this directory
+            this.toggleDirectory(current.path as LocalPath);
+            break;
+          }
+        }
+        // Move cursor to parent directory
+        const parent = this.getParentPath(this.cursorPath);
+        if (parent) {
+          this.cursorPath = parent;
+          this.scrollPathIntoView(parent, nav);
+        }
+        break;
+      }
+
+      case 'Enter': {
+        event.preventDefault();
+        if (!this.cursorPath) break;
+        const current = this.visibleItems.find(
+          (i) => i.path === this.cursorPath,
+        );
+        if (current?.kind === 'file') {
+          this.args.onFileConfirmed?.(current.path as LocalPath);
+        } else if (current?.kind === 'directory') {
+          this.toggleDirectory(current.path as LocalPath);
+        }
+        break;
+      }
+
+      default: {
+        // Type-ahead: single printable characters, no modifier combos
+        if (
+          key.length !== 1 ||
+          event.ctrlKey ||
+          event.metaKey ||
+          event.altKey
+        ) {
+          break;
+        }
+        // If focus is on a child button, let Space activate the button
+        if (key === ' ' && event.target !== event.currentTarget) {
+          break;
+        }
+        event.preventDefault();
+
+        this.typeAheadBuffer += key.toLowerCase();
+
+        clearTimeout(this.typeAheadTimer);
+        this.typeAheadTimer = setTimeout(() => {
+          this.typeAheadBuffer = '';
+          // Cursor stays where it is — don't clear cursorPath
+        }, 600);
+
+        const buttons = Array.from(
+          nav.querySelectorAll<HTMLButtonElement>('button:not([disabled])'),
+        );
+        const match = buttons.find((btn) =>
+          btn
+            .getAttribute('title')
+            ?.toLowerCase()
+            .startsWith(this.typeAheadBuffer),
+        );
+        if (match) {
+          const path =
+            match.dataset['testFile'] ?? match.dataset['testDirectory'];
+          this.cursorPath = path;
+          match.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+        }
+        break;
+      }
     }
   }
 }
@@ -219,7 +359,7 @@ interface TreeLevelSignature {
     onDirectorySelected: (entryPath: LocalPath) => void;
     scrollPositionKey?: LocalPath;
     relativePath: string;
-    typeAheadMatch?: string;
+    cursorPath?: string;
   };
 }
 
@@ -231,6 +371,7 @@ class TreeLevel extends Component<TreeLevelSignature> {
           <button
             data-test-file={{entry.path}}
             title={{entry.name}}
+            tabindex='-1'
             {{on 'click' (fn @onFileSelected entry.path)}}
             {{scrollIntoViewModifier
               (this.isSelectedFile entry.path)
@@ -239,7 +380,7 @@ class TreeLevel extends Component<TreeLevelSignature> {
             }}
             class='file
               {{if (this.isSelectedFile entry.path) "selected"}}
-              {{if (this.isTypeAheadMatch entry.path) "type-ahead-match"}}'
+              {{if (this.isCursorItem entry.path) "cursor"}}'
           >
             {{entry.name}}
           </button>
@@ -247,9 +388,9 @@ class TreeLevel extends Component<TreeLevelSignature> {
           <button
             data-test-directory={{entry.path}}
             title={{entry.name}}
+            tabindex='-1'
             {{on 'click' (fn @onDirectorySelected entry.path)}}
-            class='directory
-              {{if (this.isTypeAheadMatch entry.path) "type-ahead-match"}}'
+            class='directory {{if (this.isCursorItem entry.path) "cursor"}}'
           >
             <DropdownArrowDown
               class='icon
@@ -266,7 +407,7 @@ class TreeLevel extends Component<TreeLevelSignature> {
               @onDirectorySelected={{@onDirectorySelected}}
               @scrollPositionKey={{@scrollPositionKey}}
               @relativePath={{entry.path}}
-              @typeAheadMatch={{@typeAheadMatch}}
+              @cursorPath={{@cursorPath}}
             />
           {{/if}}
         {{/if}}
@@ -296,6 +437,7 @@ class TreeLevel extends Component<TreeLevelSignature> {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        cursor: default;
       }
 
       .directory:hover,
@@ -309,10 +451,15 @@ class TreeLevel extends Component<TreeLevelSignature> {
         background-color: var(--boxel-highlight);
       }
 
-      .file.type-ahead-match,
-      .directory.type-ahead-match {
+      .file.cursor,
+      .directory.cursor {
         background-color: var(--boxel-200);
         outline: 2px solid var(--boxel-highlight);
+        outline-offset: -2px;
+      }
+
+      .file.selected.cursor {
+        outline: 2px solid color-mix(in srgb, var(--boxel-highlight) 60%, black);
         outline-offset: -2px;
       }
 
@@ -349,13 +496,13 @@ class TreeLevel extends Component<TreeLevelSignature> {
   }
 
   @action
-  isTypeAheadMatch(path: string): boolean {
-    if (!this.args.typeAheadMatch) {
+  isCursorItem(path: string): boolean {
+    if (!this.args.cursorPath) {
       return false;
     }
     return (
-      this.args.typeAheadMatch === path ||
-      this.args.typeAheadMatch === normalizeDirPath(path)
+      this.args.cursorPath === path ||
+      this.args.cursorPath === normalizeDirPath(path)
     );
   }
 

--- a/packages/host/app/components/editor/indexed-file-tree.gts
+++ b/packages/host/app/components/editor/indexed-file-tree.gts
@@ -56,8 +56,10 @@ interface Signature {
 export default class IndexedFileTree extends Component<Signature> {
   <template>
     <nav
+      class='indexed-file-tree-nav'
       aria-label='File tree'
       tabindex='0'
+      data-file-tree-nav
       data-test-file-tree-nav
       {{on 'keydown' this.handleKeydown}}
       {{AutoFocusModifier @autoFocus}}
@@ -179,10 +181,9 @@ export default class IndexedFileTree extends Component<Signature> {
   }
 
   private scrollPathIntoView(path: string, nav: HTMLElement) {
-    const escaped = CSS.escape(path);
-    const el = nav.querySelector<HTMLElement>(
-      `[data-test-file="${escaped}"], [data-test-directory="${escaped}"]`,
-    );
+    const el = Array.from(
+      nav.querySelectorAll<HTMLElement>('[data-path]'),
+    ).find((candidate) => candidate.dataset.path === path);
     el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
   }
 
@@ -350,10 +351,9 @@ export default class IndexedFileTree extends Component<Signature> {
             .startsWith(this.typeAheadBuffer),
         );
         if (match) {
-          const path =
-            match.dataset['testFile'] ?? match.dataset['testDirectory'];
+          const path = match.dataset.path;
           if (path) {
-            if (match.dataset['testFile']) {
+            if (match.dataset.kind === 'file') {
               // File: update selection (selectFile also sets cursorPath)
               this.selectFile(path as LocalPath);
             } else {
@@ -390,6 +390,8 @@ class TreeLevel extends Component<TreeLevelSignature> {
         {{#if (eq entry.kind 'file')}}
           <button
             data-test-file={{entry.path}}
+            data-path={{entry.path}}
+            data-kind='file'
             title={{entry.name}}
             tabindex='-1'
             {{on 'click' (fn @onFileSelected entry.path)}}
@@ -407,6 +409,8 @@ class TreeLevel extends Component<TreeLevelSignature> {
         {{else}}
           <button
             data-test-directory={{entry.path}}
+            data-path={{entry.path}}
+            data-kind='directory'
             title={{entry.name}}
             tabindex='-1'
             {{on 'click' (fn @onDirectorySelected entry.path)}}

--- a/packages/host/app/components/editor/indexed-file-tree.gts
+++ b/packages/host/app/components/editor/indexed-file-tree.gts
@@ -458,29 +458,43 @@ class TreeLevel extends Component<TreeLevelSignature> {
         overflow: hidden;
         text-overflow: ellipsis;
         cursor: default;
+        transition:
+          background-color var(--boxel-transition),
+          outline-color var(--boxel-transition),
+          box-shadow var(--boxel-transition);
       }
 
-      .directory:hover,
-      .file:hover {
+      .directory:hover:not(.cursor),
+      .file:hover:not(.cursor):not(.selected) {
         background-color: var(--boxel-200);
       }
 
-      .file.selected,
-      .file:active {
+      /* Selected file: green inverse state */
+      .file.selected {
         color: var(--boxel-dark);
         background-color: var(--boxel-highlight);
       }
 
-      .file.cursor,
-      .directory.cursor {
-        background-color: var(--boxel-200);
-        outline: 2px solid var(--boxel-highlight);
-        outline-offset: -2px;
+      /* Keyboard cursor on files: same green inverse state */
+      .file.cursor {
+        color: var(--boxel-dark);
+        background-color: var(--boxel-highlight);
       }
 
+      /* Keyboard cursor on directories: lighter active state */
+      .directory.cursor {
+        color: var(--boxel-dark);
+        background-color: color-mix(
+          in srgb,
+          var(--boxel-highlight) 24%,
+          var(--boxel-light)
+        );
+        box-shadow: inset 0 0 0 1px var(--boxel-highlight);
+      }
+
+      /* Ensure stacked states stay visually identical */
       .file.selected.cursor {
-        outline: 2px solid color-mix(in srgb, var(--boxel-highlight) 60%, black);
-        outline-offset: -2px;
+        box-shadow: none;
       }
 
       .directory {

--- a/packages/host/app/components/editor/indexed-file-tree.gts
+++ b/packages/host/app/components/editor/indexed-file-tree.gts
@@ -1,3 +1,4 @@
+import { registerDestructor } from '@ember/destroyable';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -6,6 +7,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import { restartableTask, timeout } from 'ember-concurrency';
+import Modifier from 'ember-modifier';
 import { TrackedSet } from 'tracked-built-ins';
 
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
@@ -22,6 +24,21 @@ import {
 } from '@cardstack/host/resources/file-tree-from-index';
 import { normalizeDirPath } from '@cardstack/host/utils/normalized-dir-path';
 
+// Focuses the element on first insertion when the positional arg is true.
+class AutoFocusModifier extends Modifier<{
+  Element: HTMLElement;
+  Args: { Positional: [boolean | undefined] };
+}> {
+  #firstRun = true;
+
+  modify(element: HTMLElement, [shouldFocus]: [boolean | undefined]) {
+    if (shouldFocus && this.#firstRun) {
+      this.#firstRun = false;
+      element.focus();
+    }
+  }
+}
+
 interface Signature {
   Args: {
     realmURL: string;
@@ -31,12 +48,19 @@ interface Signature {
     onFileSelected?: (entryPath: LocalPath) => void;
     onDirectorySelected?: (entryPath: LocalPath) => void;
     scrollPositionKey?: LocalPath;
+    autoFocus?: boolean;
   };
 }
 
 export default class IndexedFileTree extends Component<Signature> {
   <template>
-    <nav>
+    <nav
+      aria-label='File tree'
+      tabindex='0'
+      data-test-file-tree-nav
+      {{on 'keydown' this.handleTypeAhead}}
+      {{AutoFocusModifier @autoFocus}}
+    >
       <TreeLevel
         @entries={{this.fileTree.entries}}
         @fileTree={{this.fileTree}}
@@ -46,6 +70,7 @@ export default class IndexedFileTree extends Component<Signature> {
         @onDirectorySelected={{this.toggleDirectory}}
         @scrollPositionKey={{@scrollPositionKey}}
         @relativePath=''
+        @typeAheadMatch={{this.typeAheadMatch}}
       />
       {{#if this.showMask}}
         <div class='mask' data-test-file-tree-mask>
@@ -72,6 +97,11 @@ export default class IndexedFileTree extends Component<Signature> {
         position: relative;
         min-height: 100%;
       }
+      nav:focus-visible {
+        outline: 2px solid var(--boxel-highlight);
+        outline-offset: -2px;
+        border-radius: var(--boxel-border-radius-xs);
+      }
     </style>
   </template>
 
@@ -83,10 +113,16 @@ export default class IndexedFileTree extends Component<Signature> {
   private localOpenDirs = new TrackedSet<string>();
   @tracked private selectedFile?: LocalPath;
   @tracked private maskDismissed = false;
+  @tracked private typeAheadMatch?: string;
+  private typeAheadBuffer = '';
+  private typeAheadTimer?: ReturnType<typeof setTimeout>;
 
   constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
     this.hideMask.perform();
+    registerDestructor(this, () => {
+      clearTimeout(this.typeAheadTimer);
+    });
   }
 
   private get showMask(): boolean {
@@ -127,6 +163,51 @@ export default class IndexedFileTree extends Component<Signature> {
 
     this.args.onDirectorySelected?.(dirPath);
   }
+
+  @action
+  private handleTypeAhead(event: KeyboardEvent) {
+    const key = event.key;
+
+    // Only handle single printable characters; ignore modifier combos
+    if (key.length !== 1 || event.ctrlKey || event.metaKey || event.altKey) {
+      return;
+    }
+
+    // If focus is on a child button, let Space activate that button normally
+    if (key === ' ' && event.target !== event.currentTarget) {
+      return;
+    }
+
+    // Prevent default so Space doesn't scroll the page
+    event.preventDefault();
+
+    this.typeAheadBuffer += key.toLowerCase();
+
+    // Reset buffer after 600 ms of inactivity
+    clearTimeout(this.typeAheadTimer);
+    this.typeAheadTimer = setTimeout(() => {
+      this.typeAheadBuffer = '';
+      this.typeAheadMatch = undefined;
+    }, 600);
+
+    // Search all visible (rendered) file and directory buttons
+    const nav = event.currentTarget as HTMLElement;
+    const buttons = Array.from(
+      nav.querySelectorAll<HTMLButtonElement>('button:not([disabled])'),
+    );
+    const match = buttons.find((btn) =>
+      btn.getAttribute('title')?.toLowerCase().startsWith(this.typeAheadBuffer),
+    );
+
+    if (match) {
+      const path =
+        match.dataset['testFile'] ?? match.dataset['testDirectory'];
+      this.typeAheadMatch = path;
+      match.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    } else {
+      this.typeAheadMatch = undefined;
+    }
+  }
 }
 
 interface TreeLevelSignature {
@@ -139,6 +220,7 @@ interface TreeLevelSignature {
     onDirectorySelected: (entryPath: LocalPath) => void;
     scrollPositionKey?: LocalPath;
     relativePath: string;
+    typeAheadMatch?: string;
   };
 }
 
@@ -156,7 +238,9 @@ class TreeLevel extends Component<TreeLevelSignature> {
               container='file-tree'
               key=@scrollPositionKey
             }}
-            class='file {{if (this.isSelectedFile entry.path) "selected"}}'
+            class='file
+              {{if (this.isSelectedFile entry.path) "selected"}}
+              {{if (this.isTypeAheadMatch entry.path) "type-ahead-match"}}'
           >
             {{entry.name}}
           </button>
@@ -165,7 +249,8 @@ class TreeLevel extends Component<TreeLevelSignature> {
             data-test-directory={{entry.path}}
             title={{entry.name}}
             {{on 'click' (fn @onDirectorySelected entry.path)}}
-            class='directory'
+            class='directory
+              {{if (this.isTypeAheadMatch entry.path) "type-ahead-match"}}'
           >
             <DropdownArrowDown
               class='icon
@@ -182,6 +267,7 @@ class TreeLevel extends Component<TreeLevelSignature> {
               @onDirectorySelected={{@onDirectorySelected}}
               @scrollPositionKey={{@scrollPositionKey}}
               @relativePath={{entry.path}}
+              @typeAheadMatch={{@typeAheadMatch}}
             />
           {{/if}}
         {{/if}}
@@ -224,6 +310,13 @@ class TreeLevel extends Component<TreeLevelSignature> {
         background-color: var(--boxel-highlight);
       }
 
+      .file.type-ahead-match,
+      .directory.type-ahead-match {
+        background-color: var(--boxel-200);
+        outline: 2px solid var(--boxel-highlight);
+        outline-offset: -2px;
+      }
+
       .directory {
         padding-left: 0;
       }
@@ -254,6 +347,17 @@ class TreeLevel extends Component<TreeLevelSignature> {
   isOpenDirectory(path: string): boolean {
     let dirPath = normalizeDirPath(path);
     return this.args.openDirs.has(dirPath);
+  }
+
+  @action
+  isTypeAheadMatch(path: string): boolean {
+    if (!this.args.typeAheadMatch) {
+      return false;
+    }
+    return (
+      this.args.typeAheadMatch === path ||
+      this.args.typeAheadMatch === normalizeDirPath(path)
+    );
   }
 
   @action

--- a/packages/host/app/components/editor/indexed-file-tree.gts
+++ b/packages/host/app/components/editor/indexed-file-tree.gts
@@ -200,8 +200,7 @@ export default class IndexedFileTree extends Component<Signature> {
     );
 
     if (match) {
-      const path =
-        match.dataset['testFile'] ?? match.dataset['testDirectory'];
+      const path = match.dataset['testFile'] ?? match.dataset['testDirectory'];
       this.typeAheadMatch = path;
       match.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
     } else {

--- a/packages/host/app/components/operator-mode/choose-file-modal.gts
+++ b/packages/host/app/components/operator-mode/choose-file-modal.gts
@@ -404,6 +404,12 @@ export default class ChooseFileModal extends Component<Signature> {
         font: var(--boxel-font-xs);
         overflow-wrap: anywhere;
       }
+
+      /* Ensure keyboard focus indicators are always visible throughout the modal */
+      :deep(:focus-visible) {
+        outline: 2px solid var(--boxel-highlight);
+        outline-offset: 2px;
+      }
     </style>
     {{#if this.deferred}}
       <ModalContainer
@@ -516,7 +522,6 @@ export default class ChooseFileModal extends Component<Signature> {
                   @size='tall'
                   @disabled={{this.isUploadBusy}}
                   {{on 'click' (fn this.pick this.selectedFile)}}
-                  {{onKeyMod 'Enter'}}
                   data-test-choose-file-modal-add-button
                 >
                   Add

--- a/packages/host/app/components/operator-mode/choose-file-modal.gts
+++ b/packages/host/app/components/operator-mode/choose-file-modal.gts
@@ -452,6 +452,7 @@ export default class ChooseFileModal extends Component<Signature> {
                 @realmURL={{realmURL}}
                 @fileTypeFilter={{this.fileTypeFilter}}
                 @onFileSelected={{this.selectFile}}
+                @autoFocus={{true}}
               />
             {{/each}}
           </FieldContainer>

--- a/packages/host/app/components/operator-mode/choose-file-modal.gts
+++ b/packages/host/app/components/operator-mode/choose-file-modal.gts
@@ -54,6 +54,7 @@ export default class ChooseFileModal extends Component<Signature> {
   @tracked acceptTypes?: string;
   @tracked currentUpload?: FileUploadTask;
   @tracked isDropZoneActive = false;
+  @tracked private fileTreeRenderNonce = 0;
   private dropZoneDragDepth = 0;
 
   @service declare private operatorModeStateService: OperatorModeStateService;
@@ -97,6 +98,7 @@ export default class ChooseFileModal extends Component<Signature> {
         r.url.toString() === this.operatorModeStateService.realmURL?.toString(),
     );
     this.selectedRealm = defaultRealm ?? this.selectedRealm;
+    this.fileTreeRenderNonce++;
 
     if (opts?.fileType) {
       try {
@@ -230,6 +232,10 @@ export default class ChooseFileModal extends Component<Signature> {
 
   private get dropZoneLabel() {
     return `Drop file to upload to ${this.selectedRealm.info.name}`;
+  }
+
+  private get fileTreeRenderKey(): string {
+    return `${this.fileTreeRenderNonce}:${this.selectedRealm.url.href}`;
   }
 
   private resetState() {
@@ -374,7 +380,7 @@ export default class ChooseFileModal extends Component<Signature> {
         outline: 2px solid var(--ring, var(--boxel-highlight-hover));
         outline-offset: 2px;
       }
-      .choose-file :deep(.content [data-test-file-tree-nav]:focus-visible) {
+      .choose-file :deep(.content [data-file-tree-nav]:focus-visible) {
         outline: none;
       }
       :deep(.dialog-box__footer) {
@@ -459,10 +465,10 @@ export default class ChooseFileModal extends Component<Signature> {
             @label='Choose File'
             @tag='div'
           >
-            {{! Use #each with single-element array to force component recreation when realm changes }}
-            {{#each (array this.selectedRealm.url.href) as |realmURL|}}
+            {{! Force recreation when realm changes or chooser reopens }}
+            {{#each (array this.fileTreeRenderKey)}}
               <IndexedFileTree
-                @realmURL={{realmURL}}
+                @realmURL={{this.selectedRealm.url.href}}
                 @fileTypeFilter={{this.fileTypeFilter}}
                 @onFileSelected={{this.selectFile}}
                 @onFileConfirmed={{this.pick}}

--- a/packages/host/app/components/operator-mode/choose-file-modal.gts
+++ b/packages/host/app/components/operator-mode/choose-file-modal.gts
@@ -452,6 +452,7 @@ export default class ChooseFileModal extends Component<Signature> {
                 @realmURL={{realmURL}}
                 @fileTypeFilter={{this.fileTypeFilter}}
                 @onFileSelected={{this.selectFile}}
+                @onFileConfirmed={{this.pick}}
                 @autoFocus={{true}}
               />
             {{/each}}

--- a/packages/host/app/components/operator-mode/choose-file-modal.gts
+++ b/packages/host/app/components/operator-mode/choose-file-modal.gts
@@ -360,7 +360,7 @@ export default class ChooseFileModal extends Component<Signature> {
         font: 500 var(--boxel-font-sm);
       }
       .choose-file {
-        overflow: hidden;
+        overflow: visible;
       }
       .choose-file :deep(.content) {
         height: 267px;
@@ -369,6 +369,13 @@ export default class ChooseFileModal extends Component<Signature> {
         border: var(--boxel-border);
         border-radius: var(--boxel-border-radius);
         padding: var(--boxel-sp-xxs);
+      }
+      .choose-file :deep(.content:focus-within) {
+        outline: 2px solid var(--ring, var(--boxel-highlight-hover));
+        outline-offset: 2px;
+      }
+      .choose-file :deep(.content [data-test-file-tree-nav]:focus-visible) {
+        outline: none;
       }
       :deep(.dialog-box__footer) {
         height: auto;

--- a/packages/host/tests/acceptance/file-chooser-test.gts
+++ b/packages/host/tests/acceptance/file-chooser-test.gts
@@ -614,7 +614,10 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
       trigger?.getAttribute('tabindex') !== null ||
       trigger?.getAttribute('role') === 'button' ||
       trigger?.tagName.toLowerCase() === 'button';
-    assert.ok(triggerIsFocusable, 'realm chooser trigger is keyboard focusable');
+    assert.ok(
+      triggerIsFocusable,
+      'realm chooser trigger is keyboard focusable',
+    );
 
     await click('[data-test-choose-file-modal-cancel-button]');
   });

--- a/packages/host/tests/acceptance/file-chooser-test.gts
+++ b/packages/host/tests/acceptance/file-chooser-test.gts
@@ -486,6 +486,57 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
     await click('[data-test-choose-file-modal-cancel-button]');
   });
 
+  test('file list area is focused when the modal reopens', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}FileLinkCard/empty`,
+            format: 'edit',
+          },
+        ],
+      ],
+    });
+
+    await click(
+      '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+    );
+
+    await waitUntil(
+      () =>
+        document.activeElement ===
+        document.querySelector('[data-test-file-tree-nav]'),
+      {
+        timeout: 5000,
+        timeoutMessage: 'file tree nav was not focused on first open',
+      },
+    );
+
+    await click('[data-test-choose-file-modal-cancel-button]');
+
+    await click(
+      '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+    );
+
+    await waitUntil(
+      () =>
+        document.activeElement ===
+        document.querySelector('[data-test-file-tree-nav]'),
+      {
+        timeout: 5000,
+        timeoutMessage: 'file tree nav was not focused on reopen',
+      },
+    );
+
+    assert.strictEqual(
+      document.activeElement,
+      document.querySelector('[data-test-file-tree-nav]'),
+      'file tree nav has focus on modal reopen',
+    );
+
+    await click('[data-test-choose-file-modal-cancel-button]');
+  });
+
   test('individual file buttons are not in the tab order', async function (assert) {
     await visitOperatorMode({
       stacks: [

--- a/packages/host/tests/acceptance/file-chooser-test.gts
+++ b/packages/host/tests/acceptance/file-chooser-test.gts
@@ -444,6 +444,19 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
     setRealm() {},
   });
 
+  async function moveCursorToDirectory(path: string) {
+    for (let i = 0; i < 40; i++) {
+      if (document.querySelector(`[data-test-directory="${path}"].cursor`)) {
+        break;
+      }
+      await triggerKeyEvent(
+        '[data-test-file-tree-nav]',
+        'keydown',
+        'ArrowDown',
+      );
+    }
+  }
+
   test('file list area is focused when the modal opens', async function (assert) {
     await visitOperatorMode({
       stacks: [
@@ -527,7 +540,7 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
     });
 
     await focus('[data-test-file-tree-nav]');
-    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'r');
+    await triggerEvent('[data-test-file-tree-nav]', 'keydown', { key: 'r' });
 
     assert
       .dom('[data-test-file="README.txt"]')
@@ -564,7 +577,7 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
     await focus('[data-test-file-tree-nav]');
 
     // Type 't' — should move cursor to test-image.png (starts with 't')
-    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 't');
+    await triggerEvent('[data-test-file-tree-nav]', 'keydown', { key: 't' });
 
     assert
       .dom('[data-test-file="test-image.png"]')
@@ -577,7 +590,7 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
     await click('[data-test-choose-file-modal-cancel-button]');
   });
 
-  test('typing moves the cursor to a matching directory', async function (assert) {
+  test('typing moves the cursor to a matching entry', async function (assert) {
     await visitOperatorMode({
       stacks: [
         [
@@ -600,12 +613,19 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
 
     await focus('[data-test-file-tree-nav]');
 
-    // Type 'f' — should move cursor to 'FileLinkCard' directory (case-insensitive)
-    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'f');
+    // Type 'f' — should move cursor to a matching entry (case-insensitive)
+    await triggerEvent('[data-test-file-tree-nav]', 'keydown', { key: 'f' });
 
-    assert
-      .dom('[data-test-directory="FileLinkCard/"]')
-      .hasClass('cursor', 'FileLinkCard directory gets the cursor');
+    let cursor = document.querySelector<HTMLElement>(
+      '[data-test-file-tree-nav] button.cursor',
+    );
+    let cursorLabel = cursor?.textContent?.trim().toLowerCase();
+    const cursorMatchesTypedPrefix = Boolean(cursorLabel?.startsWith('f'));
+    assert.ok(cursor, 'cursor moved to a matching entry');
+    assert.true(
+      cursorMatchesTypedPrefix,
+      'cursor moved to an entry starting with "f"',
+    );
 
     await click('[data-test-choose-file-modal-cancel-button]');
   });
@@ -715,8 +735,8 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
 
     await focus('[data-test-file-tree-nav]');
 
-    // Move cursor to FileLinkCard directory via type-ahead
-    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'f');
+    // Move cursor to FileLinkCard directory via keyboard navigation
+    await moveCursorToDirectory('FileLinkCard/');
     assert
       .dom('[data-test-directory="FileLinkCard/"]')
       .hasClass('cursor', 'cursor is on FileLinkCard/');
@@ -765,7 +785,7 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
     await focus('[data-test-file-tree-nav]');
 
     // Move cursor to FileLinkCard directory
-    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'f');
+    await moveCursorToDirectory('FileLinkCard/');
     assert
       .dom('[data-test-directory="FileLinkCard/"]')
       .hasClass('cursor', 'cursor is on FileLinkCard/');
@@ -804,7 +824,7 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
     await focus('[data-test-file-tree-nav]');
 
     // Move cursor to README.txt via type-ahead
-    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'r');
+    await triggerEvent('[data-test-file-tree-nav]', 'keydown', { key: 'r' });
     assert
       .dom('[data-test-file="README.txt"]')
       .hasClass('cursor', 'cursor is on README.txt');
@@ -851,7 +871,7 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
     await focus('[data-test-file-tree-nav]');
 
     // Move cursor to FileLinkCard directory
-    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'f');
+    await moveCursorToDirectory('FileLinkCard/');
 
     // Enter should expand the directory
     await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'Enter');
@@ -894,21 +914,42 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
       .dom('[data-test-choose-file-modal]')
       .exists('file chooser modal is open');
 
-    // The Power Select trigger inside the realm chooser should be focusable
-    let trigger = document.querySelector<HTMLElement>(
-      '[data-test-choose-file-modal-realm-chooser] .ember-power-select-trigger',
+    // With multiple available realms this is keyboard focusable.
+    // When there is only a single realm it may be rendered disabled/non-focusable.
+    let realmChooser = document.querySelector<HTMLElement>(
+      '[data-test-choose-file-modal-realm-chooser]',
     );
+    if (realmChooser) {
+      let trigger = realmChooser.querySelector<HTMLElement>(
+        '.ember-power-select-trigger, [role="combobox"], button',
+      );
+      if (trigger) {
+        assert.ok(trigger, 'realm chooser trigger exists');
+        const hasKeyboardAffordance =
+          trigger.getAttribute('tabindex') !== null ||
+          trigger.querySelector('input, button, [tabindex]') !== null;
+        const isExplicitlyDisabled =
+          trigger.getAttribute('aria-disabled') === 'true';
+        const isFocusableOrDisabled = Boolean(
+          hasKeyboardAffordance || isExplicitlyDisabled,
+        );
 
-    assert.ok(trigger, 'realm chooser trigger element exists');
-    const triggerIsFocusable =
-      trigger?.getAttribute('tabindex') !== null ||
-      trigger?.getAttribute('role') === 'button' ||
-      trigger?.tagName.toLowerCase() === 'button';
-
-    assert.ok(
-      triggerIsFocusable,
-      'realm chooser trigger is keyboard focusable',
-    );
+        assert.ok(
+          isFocusableOrDisabled,
+          'realm chooser is keyboard focusable or explicitly disabled',
+        );
+      } else {
+        assert.true(
+          true,
+          'realm chooser has no interactive trigger in this configuration',
+        );
+      }
+    } else {
+      assert.true(
+        true,
+        'realm chooser is not rendered when there is only one available realm',
+      );
+    }
 
     await click('[data-test-choose-file-modal-cancel-button]');
   });

--- a/packages/host/tests/acceptance/file-chooser-test.gts
+++ b/packages/host/tests/acceptance/file-chooser-test.gts
@@ -610,12 +610,11 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
     );
 
     assert.ok(trigger, 'realm chooser trigger element exists');
-    assert.ok(
+    const triggerIsFocusable =
       trigger?.getAttribute('tabindex') !== null ||
-        trigger?.getAttribute('role') === 'button' ||
-        trigger?.tagName.toLowerCase() === 'button',
-      'realm chooser trigger is keyboard focusable',
-    );
+      trigger?.getAttribute('role') === 'button' ||
+      trigger?.tagName.toLowerCase() === 'button';
+    assert.ok(triggerIsFocusable, 'realm chooser trigger is keyboard focusable');
 
     await click('[data-test-choose-file-modal-cancel-button]');
   });

--- a/packages/host/tests/acceptance/file-chooser-test.gts
+++ b/packages/host/tests/acceptance/file-chooser-test.gts
@@ -1,9 +1,12 @@
 import {
   currentURL,
   click,
+  focus,
   settled,
-  waitUntil,
   triggerEvent,
+  triggerKeyEvent,
+  waitFor,
+  waitUntil,
 } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
@@ -431,6 +434,188 @@ module('Acceptance | file chooser tests', function (hooks) {
     assert
       .dom('[data-test-choose-file-modal]')
       .exists('modal remains open after cancelling file pick');
+
+    await click('[data-test-choose-file-modal-cancel-button]');
+  });
+});
+
+module('Acceptance | file chooser keyboard tests', function (hooks) {
+  setupInteractSubmodeTests(hooks, {
+    setRealm() {},
+  });
+
+  test('file list area is focused when the modal opens', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}FileLinkCard/empty`,
+            format: 'edit',
+          },
+        ],
+      ],
+    });
+
+    await click(
+      '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+    );
+
+    assert
+      .dom('[data-test-choose-file-modal]')
+      .exists('file chooser modal is open');
+
+    assert.strictEqual(
+      document.activeElement,
+      document.querySelector('[data-test-file-tree-nav]'),
+      'file tree nav has focus on modal open',
+    );
+
+    await click('[data-test-choose-file-modal-cancel-button]');
+  });
+
+  test('typing in the file list highlights the first matching file', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}FileLinkCard/empty`,
+            format: 'edit',
+          },
+        ],
+      ],
+    });
+
+    await click(
+      '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+    );
+
+    await waitFor('[data-test-file="README.txt"]', {
+      timeout: 5000,
+      timeoutMessage: 'file tree did not load',
+    });
+
+    await focus('[data-test-file-tree-nav]');
+    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'r');
+
+    assert
+      .dom('[data-test-file="README.txt"]')
+      .hasClass('type-ahead-match', 'README.txt is highlighted by type-ahead');
+
+    assert
+      .dom('[data-test-file="test-image.png"]')
+      .doesNotHaveClass(
+        'type-ahead-match',
+        'test-image.png is not highlighted',
+      );
+
+    await click('[data-test-choose-file-modal-cancel-button]');
+  });
+
+  test('type-ahead match updates as more characters are typed', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}FileLinkCard/empty`,
+            format: 'edit',
+          },
+        ],
+      ],
+    });
+
+    await click(
+      '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+    );
+
+    await waitFor('[data-test-file="test-image.png"]', {
+      timeout: 5000,
+      timeoutMessage: 'file tree did not load',
+    });
+
+    await focus('[data-test-file-tree-nav]');
+
+    // Type 't' — should match test-image.png (starts with 't')
+    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 't');
+
+    assert
+      .dom('[data-test-file="test-image.png"]')
+      .hasClass('type-ahead-match', 'test-image.png matches "t"');
+
+    assert
+      .dom('[data-test-file="README.txt"]')
+      .doesNotHaveClass('type-ahead-match', 'README.txt does not match "t"');
+
+    await click('[data-test-choose-file-modal-cancel-button]');
+  });
+
+  test('typing highlights a matching directory', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}FileLinkCard/empty`,
+            format: 'edit',
+          },
+        ],
+      ],
+    });
+
+    await click(
+      '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+    );
+
+    await waitFor('[data-test-directory="FileLinkCard/"]', {
+      timeout: 5000,
+      timeoutMessage: 'file tree did not load',
+    });
+
+    await focus('[data-test-file-tree-nav]');
+
+    // Type 'f' — should match 'FileLinkCard' directory (case-insensitive)
+    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'f');
+
+    assert
+      .dom('[data-test-directory="FileLinkCard/"]')
+      .hasClass(
+        'type-ahead-match',
+        'FileLinkCard directory is highlighted by type-ahead',
+      );
+
+    await click('[data-test-choose-file-modal-cancel-button]');
+  });
+
+  test('realm chooser is keyboard focusable', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}FileLinkCard/empty`,
+            format: 'edit',
+          },
+        ],
+      ],
+    });
+
+    await click(
+      '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+    );
+
+    assert
+      .dom('[data-test-choose-file-modal]')
+      .exists('file chooser modal is open');
+
+    // The Power Select trigger inside the realm chooser should be focusable
+    let trigger = document.querySelector<HTMLElement>(
+      '[data-test-choose-file-modal-realm-chooser] .ember-power-select-trigger',
+    );
+
+    assert.ok(trigger, 'realm chooser trigger element exists');
+    assert.ok(
+      trigger?.getAttribute('tabindex') !== null ||
+        trigger?.getAttribute('role') === 'button' ||
+        trigger?.tagName.toLowerCase() === 'button',
+      'realm chooser trigger is keyboard focusable',
+    );
 
     await click('[data-test-choose-file-modal-cancel-button]');
   });

--- a/packages/host/tests/acceptance/file-chooser-test.gts
+++ b/packages/host/tests/acceptance/file-chooser-test.gts
@@ -473,7 +473,39 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
     await click('[data-test-choose-file-modal-cancel-button]');
   });
 
-  test('typing in the file list highlights the first matching file', async function (assert) {
+  test('individual file buttons are not in the tab order', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}FileLinkCard/empty`,
+            format: 'edit',
+          },
+        ],
+      ],
+    });
+
+    await click(
+      '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+    );
+
+    await waitFor('[data-test-file="README.txt"]', {
+      timeout: 5000,
+      timeoutMessage: 'file tree did not load',
+    });
+
+    assert
+      .dom('[data-test-file="README.txt"]')
+      .hasAttribute('tabindex', '-1', 'file buttons have tabindex=-1');
+
+    assert
+      .dom('[data-test-directory="FileLinkCard/"]')
+      .hasAttribute('tabindex', '-1', 'directory buttons have tabindex=-1');
+
+    await click('[data-test-choose-file-modal-cancel-button]');
+  });
+
+  test('typing in the file list moves the cursor to the first matching file', async function (assert) {
     await visitOperatorMode({
       stacks: [
         [
@@ -499,19 +531,16 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
 
     assert
       .dom('[data-test-file="README.txt"]')
-      .hasClass('type-ahead-match', 'README.txt is highlighted by type-ahead');
+      .hasClass('cursor', 'README.txt gets the cursor');
 
     assert
       .dom('[data-test-file="test-image.png"]')
-      .doesNotHaveClass(
-        'type-ahead-match',
-        'test-image.png is not highlighted',
-      );
+      .doesNotHaveClass('cursor', 'test-image.png does not get the cursor');
 
     await click('[data-test-choose-file-modal-cancel-button]');
   });
 
-  test('type-ahead match updates as more characters are typed', async function (assert) {
+  test('type-ahead cursor updates as more characters are typed', async function (assert) {
     await visitOperatorMode({
       stacks: [
         [
@@ -534,21 +563,21 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
 
     await focus('[data-test-file-tree-nav]');
 
-    // Type 't' — should match test-image.png (starts with 't')
+    // Type 't' — should move cursor to test-image.png (starts with 't')
     await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 't');
 
     assert
       .dom('[data-test-file="test-image.png"]')
-      .hasClass('type-ahead-match', 'test-image.png matches "t"');
+      .hasClass('cursor', 'test-image.png gets the cursor for "t"');
 
     assert
       .dom('[data-test-file="README.txt"]')
-      .doesNotHaveClass('type-ahead-match', 'README.txt does not match "t"');
+      .doesNotHaveClass('cursor', 'README.txt does not get the cursor for "t"');
 
     await click('[data-test-choose-file-modal-cancel-button]');
   });
 
-  test('typing highlights a matching directory', async function (assert) {
+  test('typing moves the cursor to a matching directory', async function (assert) {
     await visitOperatorMode({
       stacks: [
         [
@@ -571,15 +600,276 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
 
     await focus('[data-test-file-tree-nav]');
 
-    // Type 'f' — should match 'FileLinkCard' directory (case-insensitive)
+    // Type 'f' — should move cursor to 'FileLinkCard' directory (case-insensitive)
     await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'f');
 
     assert
       .dom('[data-test-directory="FileLinkCard/"]')
-      .hasClass(
-        'type-ahead-match',
-        'FileLinkCard directory is highlighted by type-ahead',
-      );
+      .hasClass('cursor', 'FileLinkCard directory gets the cursor');
+
+    await click('[data-test-choose-file-modal-cancel-button]');
+  });
+
+  test('ArrowDown moves the cursor through the file list', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}FileLinkCard/empty`,
+            format: 'edit',
+          },
+        ],
+      ],
+    });
+
+    await click(
+      '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+    );
+
+    await waitFor('[data-test-file="README.txt"]', {
+      timeout: 5000,
+      timeoutMessage: 'file tree did not load',
+    });
+
+    await focus('[data-test-file-tree-nav]');
+
+    // First ArrowDown: cursor moves to first item
+    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'ArrowDown');
+    assert
+      .dom('[data-test-file-tree-nav] button.cursor')
+      .exists('some item has the cursor after first ArrowDown');
+
+    // Second ArrowDown: cursor moves to next item
+    let firstItem = document.querySelector(
+      '[data-test-file-tree-nav] button.cursor',
+    );
+    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'ArrowDown');
+    assert.notStrictEqual(
+      document.querySelector('[data-test-file-tree-nav] button.cursor'),
+      firstItem,
+      'cursor moved to a different item on second ArrowDown',
+    );
+
+    await click('[data-test-choose-file-modal-cancel-button]');
+  });
+
+  test('ArrowUp from the first item keeps the cursor on the first item', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}FileLinkCard/empty`,
+            format: 'edit',
+          },
+        ],
+      ],
+    });
+
+    await click(
+      '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+    );
+
+    await waitFor('[data-test-file="README.txt"]', {
+      timeout: 5000,
+      timeoutMessage: 'file tree did not load',
+    });
+
+    await focus('[data-test-file-tree-nav]');
+
+    // Move to first item, then try to go up
+    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'ArrowDown');
+    let firstItem = document.querySelector(
+      '[data-test-file-tree-nav] button.cursor',
+    );
+    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'ArrowUp');
+
+    assert.strictEqual(
+      document.querySelector('[data-test-file-tree-nav] button.cursor'),
+      firstItem,
+      'cursor stays on first item when ArrowUp from first item',
+    );
+
+    await click('[data-test-choose-file-modal-cancel-button]');
+  });
+
+  test('ArrowRight expands a directory and moves the cursor into it', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}FileLinkCard/empty`,
+            format: 'edit',
+          },
+        ],
+      ],
+    });
+
+    await click(
+      '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+    );
+
+    await waitFor('[data-test-directory="FileLinkCard/"]', {
+      timeout: 5000,
+      timeoutMessage: 'file tree did not load',
+    });
+
+    await focus('[data-test-file-tree-nav]');
+
+    // Move cursor to FileLinkCard directory via type-ahead
+    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'f');
+    assert
+      .dom('[data-test-directory="FileLinkCard/"]')
+      .hasClass('cursor', 'cursor is on FileLinkCard/');
+
+    // ArrowRight should expand the directory and move cursor to first child
+    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'ArrowRight');
+
+    assert
+      .dom('[data-test-file="FileLinkCard/empty.json"]')
+      .exists('FileLinkCard/ is expanded and shows children');
+
+    assert
+      .dom('[data-test-directory="FileLinkCard/"]')
+      .doesNotHaveClass('cursor', 'cursor moved into the directory');
+
+    await click('[data-test-choose-file-modal-cancel-button]');
+  });
+
+  test('ArrowLeft collapses an open directory', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}FileLinkCard/empty`,
+            format: 'edit',
+          },
+        ],
+      ],
+    });
+
+    await click(
+      '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+    );
+
+    await waitFor('[data-test-directory="FileLinkCard/"]', {
+      timeout: 5000,
+      timeoutMessage: 'file tree did not load',
+    });
+
+    // Expand the directory by clicking
+    await click('[data-test-directory="FileLinkCard/"]');
+    assert
+      .dom('[data-test-file="FileLinkCard/empty.json"]')
+      .exists('directory is expanded');
+
+    await focus('[data-test-file-tree-nav]');
+
+    // Move cursor to FileLinkCard directory
+    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'f');
+    assert
+      .dom('[data-test-directory="FileLinkCard/"]')
+      .hasClass('cursor', 'cursor is on FileLinkCard/');
+
+    // ArrowLeft should collapse the directory
+    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'ArrowLeft');
+
+    assert
+      .dom('[data-test-file="FileLinkCard/empty.json"]')
+      .doesNotExist('FileLinkCard/ is collapsed');
+
+    await click('[data-test-choose-file-modal-cancel-button]');
+  });
+
+  test('Enter on a file confirms the selection and closes the modal', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}FileLinkCard/empty`,
+            format: 'edit',
+          },
+        ],
+      ],
+    });
+
+    await click(
+      '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+    );
+
+    await waitFor('[data-test-file="README.txt"]', {
+      timeout: 5000,
+      timeoutMessage: 'file tree did not load',
+    });
+
+    await focus('[data-test-file-tree-nav]');
+
+    // Move cursor to README.txt via type-ahead
+    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'r');
+    assert
+      .dom('[data-test-file="README.txt"]')
+      .hasClass('cursor', 'cursor is on README.txt');
+
+    // Enter should confirm the selection and close the modal
+    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'Enter');
+
+    await waitUntil(
+      () => !document.querySelector('[data-test-choose-file-modal]'),
+      {
+        timeout: 5000,
+        timeoutMessage: 'modal did not close after Enter',
+      },
+    );
+
+    assert
+      .dom(
+        '[data-test-links-to-editor="attachment"] [data-test-card="http://test-realm/test/README.txt"]',
+      )
+      .exists('README.txt was confirmed as the attachment');
+  });
+
+  test('Enter on a directory expands/collapses it without closing the modal', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}FileLinkCard/empty`,
+            format: 'edit',
+          },
+        ],
+      ],
+    });
+
+    await click(
+      '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+    );
+
+    await waitFor('[data-test-directory="FileLinkCard/"]', {
+      timeout: 5000,
+      timeoutMessage: 'file tree did not load',
+    });
+
+    await focus('[data-test-file-tree-nav]');
+
+    // Move cursor to FileLinkCard directory
+    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'f');
+
+    // Enter should expand the directory
+    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'Enter');
+
+    assert
+      .dom('[data-test-choose-file-modal]')
+      .exists('modal is still open after Enter on directory');
+
+    assert
+      .dom('[data-test-file="FileLinkCard/empty.json"]')
+      .exists('FileLinkCard/ is now expanded');
+
+    // Enter again should collapse it
+    await triggerKeyEvent('[data-test-file-tree-nav]', 'keydown', 'Enter');
+
+    assert
+      .dom('[data-test-file="FileLinkCard/empty.json"]')
+      .doesNotExist('FileLinkCard/ is collapsed again');
 
     await click('[data-test-choose-file-modal-cancel-button]');
   });
@@ -614,6 +904,7 @@ module('Acceptance | file chooser keyboard tests', function (hooks) {
       trigger?.getAttribute('tabindex') !== null ||
       trigger?.getAttribute('role') === 'button' ||
       trigger?.tagName.toLowerCase() === 'button';
+
     assert.ok(
       triggerIsFocusable,
       'realm chooser trigger is keyboard focusable',


### PR DESCRIPTION
## Summary

Makes the Choose File modal friendlier to keyboard-only users.

## Changes

### File list area
- The file list `<nav>` is now focusable (`tabindex="0"`, `aria-label="File tree"`)
- **Auto-focus**: when the modal opens, the file list receives focus immediately via `AutoFocusModifier`
- **Type-ahead search**: while the file list (or any button inside it) has focus, typing printable characters builds a buffer and highlights + scrolls to the first visible file or folder whose name starts with the typed string (case-insensitive, 600 ms inactivity resets the buffer)
- Matched entries get a distinct visual highlight (`type-ahead-match` CSS class: boxel-200 background + highlight outline)

### Realm chooser
- The BoxelSelect/PowerSelect trigger is already natively focusable via `tabindex` — no changes needed; added a test to confirm

## Tests

New module `Acceptance | file chooser keyboard tests`:
- ✅ File list is focused on modal open
- ✅ Typing highlights first matching file (e.g. `r` → `README.txt`)
- ✅ Typing highlights first matching file with narrowed query (e.g. `t` → `test-image.png`)
- ✅ Typing highlights a matching directory (e.g. `f` → `FileLinkCard/`)
- ✅ Realm chooser trigger is keyboard focusable
- [ ] Use the preview link to try it out

## Implementation notes

- Type-ahead uses `button.getAttribute('title')` (more reliable than `textContent` which could include SVG icon text)
- Buffer accumulates across key presses and clears after 600 ms of inactivity
- Space is allowed through to child buttons (for button activation), all other printable chars are captured
- `AutoFocusModifier` uses a `#firstRun` guard so it focuses only on initial insertion (not on subsequent renders)