### PR TITLE
Change realm server test ports in environment mode

### DIFF
--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -72,23 +72,36 @@ import { createRemotePrerenderer } from '../../prerender/remote-prerenderer';
 import { createPrerenderHttpServer } from '../../prerender/prerender-app';
 import { buildCreatePrerenderAuth } from '../../prerender/auth';
 import { Client as PgClient } from 'pg';
-import { isEnvironmentMode, serviceURL } from '../../lib/dev-service-registry';
-
-const testRealmURL = new URL('http://127.0.0.1:4444/');
-const testRealmHref = testRealmURL.href;
+import {
+  isEnvironmentMode,
+  getEnvironmentSlug,
+  serviceURL,
+} from '../../lib/dev-service-registry';
 
 /**
- * In environment mode we listen on port 0 (OS-assigned) so that multiple
- * environments can run realm-server tests simultaneously without port
- * conflicts.  supertest connects to the server object directly, so the
- * actual listen port doesn't need to match the realm identity URL.
+ * In environment mode we shift test ports by a deterministic offset derived
+ * from the environment slug so that parallel environments never collide.
  */
-function resolveListenPort(realmURL: URL): number {
-  if (isEnvironmentMode()) {
+function environmentPortOffset(): number {
+  if (!isEnvironmentMode()) {
     return 0;
   }
-  return parseInt(realmURL.port);
+  let slug = getEnvironmentSlug();
+  let hash = 0;
+  for (let i = 0; i < slug.length; i++) {
+    hash = ((hash << 5) - hash + slug.charCodeAt(i)) | 0;
+  }
+  // offset in range [1000, 9000) — keeps ports well within valid range
+  return 1000 + (Math.abs(hash) % 8000);
 }
+
+/** Return a test port, shifted by a per-environment offset when needed. */
+export function testPort(basePort: number): number {
+  return basePort + environmentPortOffset();
+}
+
+const testRealmURL = new URL(`http://127.0.0.1:${testPort(4444)}/`);
+const testRealmHref = testRealmURL.href;
 
 /** Build the default test-realm URL with an optional sub-path. */
 export function testRealmURLFor(path: string): URL {
@@ -166,11 +179,16 @@ export async function waitUntil<T>(
 }
 
 export const testRealm = 'http://test-realm/';
-export const localBaseRealm = 'http://localhost:4201/base';
-export const matrixURL = new URL('http://localhost:8008');
+export const localBaseRealm = isEnvironmentMode()
+  ? `${serviceURL('realm-server')}/base`
+  : 'http://localhost:4201/base';
+export const matrixURL = new URL(
+  isEnvironmentMode()
+    ? serviceURL('matrix')
+    : 'http://localhost:8008',
+);
 const testPrerenderHost = '127.0.0.1';
-const testPrerenderPort = 4460;
-const testPrerenderURL = `http://${testPrerenderHost}:${testPrerenderPort}`;
+const testPrerenderPort = testPort(4460);
 
 export const testRealmInfo = {
   name: 'Test Realm',
@@ -527,6 +545,8 @@ function prerendererCacheKeyPart(prerenderer?: Prerenderer): string | null {
   }
   return `injected:${id}`;
 }
+
+const testPrerenderURL = `http://${testPrerenderHost}:${testPrerenderPort}`;
 
 async function startTestPrerenderServer(): Promise<string> {
   if (prerenderServer?.listening) {
@@ -900,7 +920,7 @@ export async function runTestRealmServer({
     definitionLookup,
     prerenderer,
   });
-  let testRealmHttpServer = testRealmServer.listen(resolveListenPort(realmURL));
+  let testRealmHttpServer = testRealmServer.listen(parseInt(realmURL.port));
   trackServer(testRealmHttpServer);
   await testRealmServer.start();
   return {
@@ -1025,7 +1045,7 @@ export async function runTestRealmServerWithRealms({
     definitionLookup,
     prerenderer,
   });
-  let testRealmHttpServer = testRealmServer.listen(resolveListenPort(serverURL));
+  let testRealmHttpServer = testRealmServer.listen(parseInt(serverURL.port));
   trackServer(testRealmHttpServer);
   await testRealmServer.start();
 

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -76,6 +76,25 @@ import { isEnvironmentMode, serviceURL } from '../../lib/dev-service-registry';
 
 const testRealmURL = new URL('http://127.0.0.1:4444/');
 const testRealmHref = testRealmURL.href;
+
+/**
+ * In environment mode we listen on port 0 (OS-assigned) so that multiple
+ * environments can run realm-server tests simultaneously without port
+ * conflicts.  supertest connects to the server object directly, so the
+ * actual listen port doesn't need to match the realm identity URL.
+ */
+function resolveListenPort(realmURL: URL): number {
+  if (isEnvironmentMode()) {
+    return 0;
+  }
+  return parseInt(realmURL.port);
+}
+
+/** Build the default test-realm URL with an optional sub-path. */
+export function testRealmURLFor(path: string): URL {
+  return new URL(path, testRealmURL);
+}
+
 const migratedTestDatabaseTemplate = 'boxel_migrated_template';
 
 export const testRealmServerMatrixUsername = 'node-test_realm-server';
@@ -881,7 +900,7 @@ export async function runTestRealmServer({
     definitionLookup,
     prerenderer,
   });
-  let testRealmHttpServer = testRealmServer.listen(parseInt(realmURL.port));
+  let testRealmHttpServer = testRealmServer.listen(resolveListenPort(realmURL));
   trackServer(testRealmHttpServer);
   await testRealmServer.start();
   return {
@@ -1006,7 +1025,7 @@ export async function runTestRealmServerWithRealms({
     definitionLookup,
     prerenderer,
   });
-  let testRealmHttpServer = testRealmServer.listen(parseInt(serverURL.port));
+  let testRealmHttpServer = testRealmServer.listen(resolveListenPort(serverURL));
   trackServer(testRealmHttpServer);
   await testRealmServer.start();
 

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -183,9 +183,7 @@ export const localBaseRealm = isEnvironmentMode()
   ? `${serviceURL('realm-server')}/base`
   : 'http://localhost:4201/base';
 export const matrixURL = new URL(
-  isEnvironmentMode()
-    ? serviceURL('matrix')
-    : 'http://localhost:8008',
+  isEnvironmentMode() ? serviceURL('matrix') : 'http://localhost:8008',
 );
 const testPrerenderHost = '127.0.0.1';
 const testPrerenderPort = testPort(4460);

--- a/packages/realm-server/tests/realm-endpoints/info-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/info-test.ts
@@ -10,13 +10,14 @@ import {
   closeServer,
   testRealmInfo,
   createJWT,
+  testRealmURLFor,
 } from '../helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import { resetCatalogRealms } from '../../handlers/handle-fetch-catalog-realms';
 
 module(`realm-endpoints/${basename(__filename)}`, function () {
   module('Realm-specific Endpoints | QUERY _info', function (hooks) {
-    let realmURL = new URL('http://127.0.0.1:4444/test/');
+    let realmURL = testRealmURLFor('test/');
     let testRealm: Realm;
     let testRealmHttpServer: Server;
     let request: SuperTest<Test>;

--- a/packages/realm-server/tests/realm-endpoints/publishability-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/publishability-test.ts
@@ -12,6 +12,7 @@ import {
   createJWT,
   setupPermissionedRealmCached,
   setupPermissionedRealmsCached,
+  testRealmURLFor,
   type RealmRequest,
   withRealmPath,
 } from '../helpers';
@@ -20,7 +21,7 @@ const ownerUserId = '@mango:localhost';
 
 module(`realm-endpoints/${basename(__filename)}`, function () {
   module('with a publishable realm', function (hooks) {
-    let realmURL = new URL('http://127.0.0.1:4444/test/');
+    let realmURL = testRealmURLFor('test/');
     let request: RealmRequest;
     let testRealm: Realm;
 

--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -3,7 +3,11 @@ import type { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
 import { baseRealm, type Realm } from '@cardstack/runtime-common';
 import type { Query } from '@cardstack/runtime-common/query';
-import { setupPermissionedRealmCached, createJWT } from '../helpers';
+import {
+  setupPermissionedRealmCached,
+  createJWT,
+  testRealmURLFor,
+} from '../helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 
 module(`realm-endpoints/${basename(__filename)}`, function () {
@@ -58,7 +62,7 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
           permissions: {
             '*': ['read'],
           },
-          realmURL: new URL('http://127.0.0.1:4444/test/'),
+          realmURL: testRealmURLFor('test/'),
           onRealmSetup,
         });
 
@@ -521,7 +525,7 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
           permissions: {
             '*': ['read'],
           },
-          realmURL: new URL('http://127.0.0.1:4444/test/'),
+          realmURL: testRealmURLFor('test/'),
           fileSystem: {
             'friend.gts': `
               import {
@@ -749,7 +753,7 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
           permissions: {
             '*': ['read'],
           },
-          realmURL: new URL('http://127.0.0.1:4444/test/'),
+          realmURL: testRealmURLFor('test/'),
           onRealmSetup,
         });
 
@@ -826,7 +830,7 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
             john: ['read'],
             '@node-test_realm:localhost': ['read', 'realm-owner'],
           },
-          realmURL: new URL('http://127.0.0.1:4444/test/'),
+          realmURL: testRealmURLFor('test/'),
           onRealmSetup,
         });
 
@@ -883,7 +887,7 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
             '*': ['read'],
             '@node-test_realm:localhost': ['read', 'realm-owner'],
           },
-          realmURL: new URL('http://127.0.0.1:4444/test/'),
+          realmURL: testRealmURLFor('test/'),
           onRealmSetup,
         });
 

--- a/packages/realm-server/tests/server-endpoints/helpers.ts
+++ b/packages/realm-server/tests/server-endpoints/helpers.ts
@@ -20,10 +20,11 @@ import {
   runTestRealmServer,
   setupDB,
   setupPermissionedRealmCached,
+  testPort,
 } from '../helpers';
 import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 
-export const testRealm2URL = new URL('http://127.0.0.1:4445/test/');
+export const testRealm2URL = new URL(`http://127.0.0.1:${testPort(4445)}/test/`);
 
 export type ServerEndpointsTestContext = {
   testRealm: Realm;

--- a/packages/realm-server/tests/server-endpoints/helpers.ts
+++ b/packages/realm-server/tests/server-endpoints/helpers.ts
@@ -24,7 +24,9 @@ import {
 } from '../helpers';
 import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 
-export const testRealm2URL = new URL(`http://127.0.0.1:${testPort(4445)}/test/`);
+export const testRealm2URL = new URL(
+  `http://127.0.0.1:${testPort(4445)}/test/`,
+);
 
 export type ServerEndpointsTestContext = {
   testRealm: Realm;


### PR DESCRIPTION
This lets realm server tests be run in parallel on different branches.