### PR TITLE
matrix: Remove flaky default skills test

### DIFF
--- a/packages/matrix/tests/skills.spec.ts
+++ b/packages/matrix/tests/skills.spec.ts
@@ -137,7 +137,8 @@ test.describe('Skills', () => {
     );
   });
 
-  test('it will attach code editing skills in code mode by default', async ({
+  // TODO: restore in CS-10374
+  test.skip('it will attach code editing skills in code mode by default', async ({
     page,
   }) => {
     await login(page, firstUser.username, firstUser.password, { url: appURL });


### PR DESCRIPTION
I’ve seen this test fail on unrelated PRs many times ([here](https://github.com/cardstack/boxel/pull/4146) and [here](https://github.com/cardstack/boxel/pull/4145) just today, for instance), I’m pretty sure it’s the reason for this high job failure rate:

<img width="399" height="233" alt="Actions performance metrics 2026-03-09 14-56-53" src="https://github.com/user-attachments/assets/d791bbcc-5f39-400e-b0ed-2f497adf723e" />
