### PR TITLE
LLM is confused and wants to use ApplyMarkdownEditCommand for code patches

### DIFF
--- a/packages/host/app/commands/apply-markdown-edit.ts
+++ b/packages/host/app/commands/apply-markdown-edit.ts
@@ -16,6 +16,8 @@ export default class ApplyMarkdownEditCommand extends HostBaseCommand<
   undefined
 > {
   static actionVerb = 'Apply Markdown Edit';
+  description =
+    'Apply a targeted edit to markdown content only (for example .md/.markdown text). This command is not for source code edits such as .gts/.ts/.js/.json files.';
 
   async getInputType() {
     let commandModule = await this.loadCommandModule();


### PR DESCRIPTION
## Problem
- Regression observed recently: when a user asks to fix a `.gts` error (including via "Fix with AI"), the assistant can choose markdown-edit tooling instead of code-edit flow.
- This misroute is especially visible with mixed attachments (`.gts` + `.md`), even when the request explicitly targets the `.gts` file.
- Resulting behavior includes failed markdown-field operations (for example field-path/content errors) instead of generating code edits.

<img width="1259" height="785" alt="image" src="https://github.com/user-attachments/assets/e6af2701-363d-41e1-9aab-bb1fdf07f1e1" />

## What This PR Changes
- Adds an explicit description to `ApplyMarkdownEditCommand` clarifying it is for markdown content edits only.
- Explicitly states it is not for source-code edits (`.gts/.ts/.js/.json`).

## Why
- Tightens tool semantics so model/tool selection is less ambiguous.
- Supports the broader fix where code-intent requests should route to code editing output (SEARCH/REPLACE) rather than markdown mutation tools.


# 🔔 Accompanying boxel-skills PR 👀 
https://github.com/cardstack/boxel-skills/pull/55
