### PR TITLE
Start icons server in matrix test services startup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -305,9 +305,6 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm exec playwright install
         working-directory: packages/matrix
-      - name: Serve boxel-icons
-        run: pnpm serve &
-        working-directory: packages/boxel-icons
       - name: Serve host dist (test assets) for realm server
         uses: JarvusInnovations/background-action@2428e7b970a846423095c79d43f759abf979a635 # 1.0.7
         with:

--- a/packages/realm-server/scripts/start-services-for-matrix-tests.sh
+++ b/packages/realm-server/scripts/start-services-for-matrix-tests.sh
@@ -8,6 +8,6 @@ pnpm --dir=../skills-realm skills:setup
 # we probably need to add that via the isolated realm server--not here...
 WAIT_ON_TIMEOUT=600000 NODE_NO_WARNINGS=1 SKIP_SUBMISSION=true \
   start-server-and-test \
-    'run-p -ln start:pg start:prerender-dev start:prerender-manager-dev start:worker-base start:base' \
+    'run-p -ln start:pg start:icons start:prerender-dev start:prerender-manager-dev start:worker-base start:base' \
     'http-get://localhost:4201/base/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http://localhost:4206' \
     'wait'


### PR DESCRIPTION
## Summary
- include `start:icons` in `start:services-for-matrix-tests` startup sequence
- keep readiness check on `http://localhost:4206` aligned with services that are actually started