### PR TITLE
More memory improvements

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,7 +7,7 @@
     "chrome-devtools": {
       "type": "stdio",
       "command": "npx",
-      "args": ["chrome-devtools-mcp@latest", "--browserUrl=http://127.0.0.1:9222"],
+      "args": ["chrome-devtools-mcp@latest"],
       "env": {}
     }
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,7 +7,7 @@
     "chrome-devtools": {
       "type": "stdio",
       "command": "npx",
-      "args": ["chrome-devtools-mcp@latest"],
+      "args": ["chrome-devtools-mcp@latest", "--browserUrl=http://127.0.0.1:9222"],
       "env": {}
     }
   }

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -76,6 +76,7 @@ import {
   CodeModePanelWidths,
   CodeModePanelHeights,
 } from '../../utils/local-storage-keys';
+import { runWhileActive } from '../../utils/run-while-active';
 import FileTree from '../editor/file-tree';
 
 import CardURLBar from './card-url-bar';
@@ -659,17 +660,13 @@ export default class CodeSubmode extends Component<Signature> {
     if (!this.isNonModuleFile) {
       return state;
     }
-    let isActive = true;
     let store = this.store;
     let fileUrl = this.readyFile.url;
-    on.cleanup(() => {
-      isActive = false;
-    });
     state.isLoading = true;
-    (async () => {
+    runWhileActive(on, async (isActive) => {
       try {
         let result = await store.get(fileUrl, { type: 'file-meta' });
-        if (!isActive) {
+        if (!isActive()) {
           return;
         }
         if (isCardErrorJSONAPI(result)) {
@@ -680,17 +677,17 @@ export default class CodeSubmode extends Component<Signature> {
           state.error = undefined;
         }
       } catch (e) {
-        if (!isActive) {
+        if (!isActive()) {
           return;
         }
         state.error = e;
         state.value = undefined;
       } finally {
-        if (isActive) {
+        if (isActive()) {
           state.isLoading = false;
         }
       }
-    })();
+    });
     return state;
   });
 

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -646,7 +646,7 @@ export default class CodeSubmode extends Component<Signature> {
     return !this.isModule && !isCardDocumentString(this.readyFile.content);
   }
 
-  @use private fileDefResource = resource(() => {
+  @use private fileDefResource = resource(({ on }) => {
     let state = new TrackedObject<{
       value: BaseDef | undefined;
       isLoading: boolean;
@@ -659,11 +659,19 @@ export default class CodeSubmode extends Component<Signature> {
     if (!this.isNonModuleFile) {
       return state;
     }
+    let isActive = true;
+    let store = this.store;
     let fileUrl = this.readyFile.url;
+    on.cleanup(() => {
+      isActive = false;
+    });
     state.isLoading = true;
     (async () => {
       try {
-        let result = await this.store.get(fileUrl, { type: 'file-meta' });
+        let result = await store.get(fileUrl, { type: 'file-meta' });
+        if (!isActive) {
+          return;
+        }
         if (isCardErrorJSONAPI(result)) {
           state.error = result;
           state.value = undefined;
@@ -672,10 +680,15 @@ export default class CodeSubmode extends Component<Signature> {
           state.error = undefined;
         }
       } catch (e) {
+        if (!isActive) {
+          return;
+        }
         state.error = e;
         state.value = undefined;
       } finally {
-        state.isLoading = false;
+        if (isActive) {
+          state.isLoading = false;
+        }
       }
     })();
     return state;

--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -143,27 +143,38 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
   @tracked private specSearch: ReturnType<getCards<Spec>> | undefined;
   @tracked private cardResource: ReturnType<getCard> | undefined;
 
-  @use private isSpecResource = resource(() => {
+  @use private isSpecResource = resource(({ on }) => {
     let state = new TrackedObject<{ value: boolean }>({ value: false });
     let codeRef = this.selectedDeclarationAsCodeRef;
     if (!codeRef.module || !codeRef.name) {
       return state;
     }
+    let isActive = true;
+    let loader = this.loaderService.loader;
+    let relativeTo = new URL(this.operatorModeStateService.realmURL);
+    on.cleanup(() => {
+      isActive = false;
+    });
     (async () => {
       try {
         let cardDef = await loadCardDef(codeRef, {
-          loader: this.loaderService.loader,
-          relativeTo: new URL(this.operatorModeStateService.realmURL),
+          loader,
+          relativeTo,
         });
+        if (!isActive) {
+          return;
+        }
         state.value = isSpecCard(cardDef);
       } catch {
-        state.value = false;
+        if (isActive) {
+          state.value = false;
+        }
       }
     })();
     return state;
   });
 
-  @use private fileDefResource = resource(() => {
+  @use private fileDefResource = resource(({ on }) => {
     let state = new TrackedObject<{
       value: FileDef | undefined;
       isLoading: boolean;
@@ -176,14 +187,22 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
     if (!this.args.isIncompatibleFile || !this.args.readyFile?.url) {
       return state;
     }
+    let isActive = true;
     let fileUrl = this.args.readyFile.url;
+    let store = this.store;
+    on.cleanup(() => {
+      isActive = false;
+    });
     void this.args.readyFile?.lastModified; // track lastModified to re-run on save
     state.isLoading = true;
     (async () => {
       try {
-        let result = await this.store.getWithoutCache(fileUrl, {
+        let result = await store.getWithoutCache(fileUrl, {
           type: 'file-meta',
         });
+        if (!isActive) {
+          return;
+        }
         if (isCardErrorJSONAPI(result)) {
           state.error = result;
           state.value = undefined;
@@ -192,10 +211,15 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
           state.error = undefined;
         }
       } catch (e) {
+        if (!isActive) {
+          return;
+        }
         state.error = e;
         state.value = undefined;
       } finally {
-        state.isLoading = false;
+        if (isActive) {
+          state.isLoading = false;
+        }
       }
     })();
     return state;

--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -82,6 +82,7 @@ import type SpecPanelService from '@cardstack/host/services/spec-panel-service';
 import type StoreService from '@cardstack/host/services/store';
 
 import { PlaygroundSelections } from '@cardstack/host/utils/local-storage-keys';
+import { runWhileActive } from '@cardstack/host/utils/run-while-active';
 
 import type {
   CardDef,
@@ -149,28 +150,24 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
     if (!codeRef.module || !codeRef.name) {
       return state;
     }
-    let isActive = true;
     let loader = this.loaderService.loader;
     let relativeTo = new URL(this.operatorModeStateService.realmURL);
-    on.cleanup(() => {
-      isActive = false;
-    });
-    (async () => {
+    runWhileActive(on, async (isActive) => {
       try {
         let cardDef = await loadCardDef(codeRef, {
           loader,
           relativeTo,
         });
-        if (!isActive) {
+        if (!isActive()) {
           return;
         }
         state.value = isSpecCard(cardDef);
       } catch {
-        if (isActive) {
+        if (isActive()) {
           state.value = false;
         }
       }
-    })();
+    });
     return state;
   });
 
@@ -187,20 +184,16 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
     if (!this.args.isIncompatibleFile || !this.args.readyFile?.url) {
       return state;
     }
-    let isActive = true;
     let fileUrl = this.args.readyFile.url;
     let store = this.store;
-    on.cleanup(() => {
-      isActive = false;
-    });
     void this.args.readyFile?.lastModified; // track lastModified to re-run on save
     state.isLoading = true;
-    (async () => {
+    runWhileActive(on, async (isActive) => {
       try {
         let result = await store.getWithoutCache(fileUrl, {
           type: 'file-meta',
         });
-        if (!isActive) {
+        if (!isActive()) {
           return;
         }
         if (isCardErrorJSONAPI(result)) {
@@ -211,17 +204,17 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
           state.error = undefined;
         }
       } catch (e) {
-        if (!isActive) {
+        if (!isActive()) {
           return;
         }
         state.error = e;
         state.value = undefined;
       } finally {
-        if (isActive) {
+        if (isActive()) {
           state.isLoading = false;
         }
       }
-    })();
+    });
     return state;
   });
 

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -46,6 +46,7 @@ import type RealmService from '@cardstack/host/services/realm';
 import type RecentFilesService from '@cardstack/host/services/recent-files-service';
 import type SpecPanelService from '@cardstack/host/services/spec-panel-service';
 import type StoreService from '@cardstack/host/services/store';
+import { runWhileActive } from '@cardstack/host/utils/run-while-active';
 
 import type { CardContext } from 'https://cardstack.com/base/card-api';
 import type { Spec } from 'https://cardstack.com/base/spec';
@@ -343,28 +344,24 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
     if (!codeRef.module || !codeRef.name) {
       return state;
     }
-    let isActive = true;
     let loader = this.loaderService.loader;
     let relativeTo = new URL(this.operatorModeStateService.realmURL);
-    on.cleanup(() => {
-      isActive = false;
-    });
-    (async () => {
+    runWhileActive(on, async (isActive) => {
       try {
         let cardDef = await loadCardDef(codeRef, {
           loader,
           relativeTo,
         });
-        if (!isActive) {
+        if (!isActive()) {
           return;
         }
         state.value = isSpecCard(cardDef);
       } catch {
-        if (isActive) {
+        if (isActive()) {
           state.value = false;
         }
       }
-    })();
+    });
     return state;
   });
 

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -337,21 +337,32 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
   @service declare private specPanelService: SpecPanelService;
   @service declare private store: StoreService;
 
-  @use private selectedDeclarationSpecState = resource(() => {
+  @use private selectedDeclarationSpecState = resource(({ on }) => {
     let state = new TrackedObject<{ value: boolean }>({ value: false });
     let codeRef = this.args.selectedDeclarationAsCodeRef;
     if (!codeRef.module || !codeRef.name) {
       return state;
     }
+    let isActive = true;
+    let loader = this.loaderService.loader;
+    let relativeTo = new URL(this.operatorModeStateService.realmURL);
+    on.cleanup(() => {
+      isActive = false;
+    });
     (async () => {
       try {
         let cardDef = await loadCardDef(codeRef, {
-          loader: this.loaderService.loader,
-          relativeTo: new URL(this.operatorModeStateService.realmURL),
+          loader,
+          relativeTo,
         });
+        if (!isActive) {
+          return;
+        }
         state.value = isSpecCard(cardDef);
       } catch {
-        state.value = false;
+        if (isActive) {
+          state.value = false;
+        }
       }
     })();
     return state;

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1335,7 +1335,7 @@ export default class MatrixService extends Service {
     this.flushTimeline = undefined;
     this.flushRoomState = undefined;
     this.timelineLoadingState.clear();
-    this._client = this.matrixSDK.createClient({ baseUrl: matrixURL });
+    this._client = this.#matrixSDK?.createClient({ baseUrl: matrixURL });
     this._currentRoomId = undefined;
     this._isInitializingNewUser = false;
     this.postLoginCompleted = false;

--- a/packages/host/app/utils/run-while-active.ts
+++ b/packages/host/app/utils/run-while-active.ts
@@ -1,0 +1,14 @@
+interface CleanupRegistrar {
+  cleanup(callback: () => void): void;
+}
+
+export function runWhileActive(
+  on: CleanupRegistrar,
+  task: (isActive: () => boolean) => Promise<void>,
+): void {
+  let active = true;
+  on.cleanup(() => {
+    active = false;
+  });
+  void task(() => active);
+}

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -1,4 +1,11 @@
-import { click, waitFor, find, findAll, waitUntil } from '@ember/test-helpers';
+import {
+  click,
+  waitFor,
+  find,
+  findAll,
+  waitUntil,
+  settled,
+} from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, skip, test } from 'qunit';
@@ -418,6 +425,14 @@ ${REPLACE_MARKER}
         timeout: 4000,
       },
     );
+    await waitUntil(
+      () => findAll('[data-test-code-diff-editor]').length === 3,
+      {
+        timeout: 5000,
+        timeoutMessage: 'timed out waiting for all code diff editors to render',
+      },
+    );
+    await settled();
     // Intentionally not using await here to test the loading state of the button
     click('[data-test-ai-assistant-action-bar] [data-test-accept-all]');
     await waitFor(

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -83,6 +83,9 @@ export function setupApplicationTest(hooks: NestedHooks) {
   setupWindowMock(hooks);
   setupFetchDebugging(hooks);
   hooks.afterEach(async function () {
+    resetServiceIfPresent(this.owner, 'service:ai-assistant-panel-service');
+    resetServiceIfPresent(this.owner, 'service:matrix-service');
+    resetServiceIfPresent(this.owner, 'service:operator-mode-state-service');
     await settled();
     (
       this.owner.lookup('service:reset') as ResetService | undefined
@@ -102,4 +105,13 @@ export function setupRenderingTest(hooks: NestedHooks) {
     )?.resetAll();
     cleanupMonacoEditorModels();
   });
+}
+
+function resetServiceIfPresent(
+  owner: { lookup(name: string): unknown },
+  name: string,
+) {
+  (
+    owner.lookup(name) as { resetState?: () => void } | undefined
+  )?.resetState?.();
 }

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -108,10 +108,15 @@ export function setupRenderingTest(hooks: NestedHooks) {
 }
 
 function resetServiceIfPresent(
-  owner: { lookup(name: string): unknown },
+  owner: {
+    __container__?: { cache?: Record<string, unknown> };
+    lookup(name: string): unknown;
+  },
   name: string,
 ) {
   (
-    owner.lookup(name) as { resetState?: () => void } | undefined
+    owner.__container__?.cache?.[name] as
+      | { resetState?: () => void }
+      | undefined
   )?.resetState?.();
 }


### PR DESCRIPTION

## Summary
- reset AI-assistant-related services earlier during test teardown in `setupApplicationTest`, so `ai-assistant-panel-service`, `matrix-service`, and `operator-mode-state-service` release state before the final `settled()` / `resetAll()` pass
- add stale-result guards to async resource flows in code mode so destroyed or superseded component instances do not retain old async work/results
- reduce retained heap in the profiled `Acceptance | AI Assistant tests` run from about `597.46 MB` to about `574.18 MB` at the final forced-GC checkpoint

## Details
The code-mode changes make async resources ignore stale completions after rerender/destroy, which cut retained JS/object state during the AI Assistant acceptance suite. The teardown change resets a few high-retention services earlier in test cleanup, which produced a smaller retained heap and slightly lower DOM-node count in the same profile.

