### PR TITLE
CS-10378: Add federated /_types endpoint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -524,6 +524,7 @@ jobs:
             "server-endpoints/incoming-webhook-test.ts",
             "server-endpoints/webhook-commands-test.ts",
             "server-endpoints/webhook-receiver-test.ts",
+            "server-endpoints/federated-types-test.ts",
             "virtual-network-test.ts",
             "atomic-endpoints-test.ts",
             "request-forward-test.ts",

--- a/packages/realm-server/handlers/handle-federated-types.ts
+++ b/packages/realm-server/handlers/handle-federated-types.ts
@@ -1,9 +1,15 @@
 import type Koa from 'koa';
 import type { DBAdapter } from '@cardstack/runtime-common';
 import { logger, SupportedMimeType } from '@cardstack/runtime-common';
-import { makeCardTypeSummaryDoc } from '@cardstack/runtime-common/document-types';
+import {
+  makeFederatedCardTypeSummaryDoc,
+  type FederatedCardTypeSummaryEntry,
+} from '@cardstack/runtime-common/document-types';
 import { setContextResponse } from '../middleware';
-import { getMultiRealmAuthorization } from '../middleware/multi-realm-authorization';
+import {
+  getMultiRealmAuthorization,
+  getSearchRequestPayload,
+} from '../middleware/multi-realm-authorization';
 import { getPublicReadableRealms } from '../utils/realm-readability';
 
 const log = logger('realm-server');
@@ -20,7 +26,17 @@ export default function handleFederatedTypes({
       realmList,
     );
 
-    let data: Record<string, ReturnType<typeof makeCardTypeSummaryDoc>> = {};
+    let payload = getSearchRequestPayload(ctxt) as
+      | {
+          realms?: string[];
+          searchKey?: string;
+          page?: { number: number; size: number };
+        }
+      | undefined;
+    let searchKey = payload?.searchKey;
+    let page = payload?.page;
+
+    let allEntries: FederatedCardTypeSummaryEntry[] = [];
 
     for (let realmURL of realmList) {
       let realm = realmByURL.get(realmURL);
@@ -30,11 +46,42 @@ export default function handleFederatedTypes({
       try {
         let summaries =
           await realm.realmIndexQueryEngine.fetchCardTypeSummary();
-        data[realmURL] = makeCardTypeSummaryDoc(summaries);
+        for (let summary of summaries) {
+          allEntries.push({
+            type: 'card-type-summary',
+            id: summary.code_ref,
+            attributes: {
+              displayName: summary.display_name,
+              total: summary.total,
+              iconHTML: summary.icon_html,
+            },
+            meta: {
+              realmURL,
+            },
+          });
+        }
       } catch (error) {
         log.warn(`Failed to fetch card type summary for ${realmURL}: ${error}`);
       }
     }
+
+    if (searchKey) {
+      let lowerSearch = searchKey.toLowerCase();
+      allEntries = allEntries.filter(
+        (entry) =>
+          entry.attributes.displayName.toLowerCase().includes(lowerSearch) ||
+          entry.id.toLowerCase().includes(lowerSearch),
+      );
+    }
+
+    let total = allEntries.length;
+
+    if (page) {
+      let start = page.number * page.size;
+      allEntries = allEntries.slice(start, start + page.size);
+    }
+
+    let doc = makeFederatedCardTypeSummaryDoc(allEntries, total);
 
     let headers: Record<string, string> = {
       'content-type': SupportedMimeType.CardTypeSummary,
@@ -46,7 +93,7 @@ export default function handleFederatedTypes({
 
     await setContextResponse(
       ctxt,
-      new Response(JSON.stringify({ data }, null, 2), { headers }),
+      new Response(JSON.stringify(doc, null, 2), { headers }),
     );
   };
 }

--- a/packages/realm-server/handlers/handle-federated-types.ts
+++ b/packages/realm-server/handlers/handle-federated-types.ts
@@ -42,9 +42,11 @@ export default function handleFederatedTypes({
       }),
     );
 
-    for (let result of results) {
+    for (let [index, result] of results.entries()) {
       if (result.status === 'rejected') {
-        log.warn(`Failed to fetch card type summary: ${result.reason}`);
+        log.warn(
+          `Failed to fetch card type summary for realm ${realmList[index]}: ${result.reason}`,
+        );
       }
     }
 

--- a/packages/realm-server/handlers/handle-federated-types.ts
+++ b/packages/realm-server/handlers/handle-federated-types.ts
@@ -1,18 +1,10 @@
 import type Koa from 'koa';
 import type { DBAdapter } from '@cardstack/runtime-common';
-import {
-  ensureTrailingSlash,
-  fetchUserPermissions,
-  logger,
-  SupportedMimeType,
-} from '@cardstack/runtime-common';
+import { logger, SupportedMimeType } from '@cardstack/runtime-common';
 import { makeCardTypeSummaryDoc } from '@cardstack/runtime-common/document-types';
 import { setContextResponse } from '../middleware';
 import { getMultiRealmAuthorization } from '../middleware/multi-realm-authorization';
-import {
-  buildReadableRealms,
-  getPublishedRealmURLs,
-} from '../utils/realm-readability';
+import { getPublicReadableRealms } from '../utils/realm-readability';
 
 const log = logger('realm-server');
 
@@ -30,23 +22,17 @@ export default function handleFederatedTypes({
 
     let data: Record<string, ReturnType<typeof makeCardTypeSummaryDoc>> = {};
 
-    let results = await Promise.allSettled(
-      realmList.map(async (realmURL) => {
-        let realm = realmByURL.get(realmURL);
-        if (!realm) {
-          return;
-        }
+    for (let realmURL of realmList) {
+      let realm = realmByURL.get(realmURL);
+      if (!realm) {
+        continue;
+      }
+      try {
         let summaries =
           await realm.realmIndexQueryEngine.fetchCardTypeSummary();
         data[realmURL] = makeCardTypeSummaryDoc(summaries);
-      }),
-    );
-
-    for (let [index, result] of results.entries()) {
-      if (result.status === 'rejected') {
-        log.warn(
-          `Failed to fetch card type summary for realm ${realmList[index]}: ${result.reason}`,
-        );
+      } catch (error) {
+        log.warn(`Failed to fetch card type summary for ${realmURL}: ${error}`);
       }
     }
 
@@ -63,27 +49,4 @@ export default function handleFederatedTypes({
       new Response(JSON.stringify({ data }, null, 2), { headers }),
     );
   };
-}
-
-async function getPublicReadableRealms(
-  dbAdapter: DBAdapter,
-  realmList: string[],
-): Promise<Set<string>> {
-  let publicPermissions = await fetchUserPermissions(dbAdapter, {
-    userId: '*',
-    onlyOwnRealms: false,
-  });
-
-  let publishedRealmURLs = await getPublishedRealmURLs(dbAdapter, realmList);
-  let publicReadable = buildReadableRealms(
-    publicPermissions,
-    publishedRealmURLs,
-  );
-
-  let normalizedRealmList = realmList.map((realmURL) =>
-    ensureTrailingSlash(realmURL),
-  );
-  return new Set(
-    normalizedRealmList.filter((realmURL) => publicReadable.has(realmURL)),
-  );
 }

--- a/packages/realm-server/handlers/handle-federated-types.ts
+++ b/packages/realm-server/handlers/handle-federated-types.ts
@@ -1,0 +1,87 @@
+import type Koa from 'koa';
+import type { DBAdapter } from '@cardstack/runtime-common';
+import {
+  ensureTrailingSlash,
+  fetchUserPermissions,
+  logger,
+  SupportedMimeType,
+} from '@cardstack/runtime-common';
+import { makeCardTypeSummaryDoc } from '@cardstack/runtime-common/document-types';
+import { setContextResponse } from '../middleware';
+import { getMultiRealmAuthorization } from '../middleware/multi-realm-authorization';
+import {
+  buildReadableRealms,
+  getPublishedRealmURLs,
+} from '../utils/realm-readability';
+
+const log = logger('realm-server');
+
+export default function handleFederatedTypes({
+  dbAdapter,
+}: {
+  dbAdapter: DBAdapter;
+}): (ctxt: Koa.Context) => Promise<void> {
+  return async function (ctxt: Koa.Context) {
+    let { realmList, realmByURL } = getMultiRealmAuthorization(ctxt);
+    let publicReadableRealms = await getPublicReadableRealms(
+      dbAdapter,
+      realmList,
+    );
+
+    let data: Record<string, ReturnType<typeof makeCardTypeSummaryDoc>> = {};
+
+    let results = await Promise.allSettled(
+      realmList.map(async (realmURL) => {
+        let realm = realmByURL.get(realmURL);
+        if (!realm) {
+          return;
+        }
+        let summaries =
+          await realm.realmIndexQueryEngine.fetchCardTypeSummary();
+        data[realmURL] = makeCardTypeSummaryDoc(summaries);
+      }),
+    );
+
+    for (let result of results) {
+      if (result.status === 'rejected') {
+        log.warn(`Failed to fetch card type summary: ${result.reason}`);
+      }
+    }
+
+    let headers: Record<string, string> = {
+      'content-type': SupportedMimeType.CardTypeSummary,
+    };
+    if (publicReadableRealms.size > 0) {
+      headers['x-boxel-realms-public-readable'] =
+        Array.from(publicReadableRealms).join(',');
+    }
+
+    await setContextResponse(
+      ctxt,
+      new Response(JSON.stringify({ data }, null, 2), { headers }),
+    );
+  };
+}
+
+async function getPublicReadableRealms(
+  dbAdapter: DBAdapter,
+  realmList: string[],
+): Promise<Set<string>> {
+  let publicPermissions = await fetchUserPermissions(dbAdapter, {
+    userId: '*',
+    onlyOwnRealms: false,
+  });
+
+  let publishedRealmURLs = await getPublishedRealmURLs(dbAdapter, realmList);
+  let publicReadable = buildReadableRealms(
+    publicPermissions,
+    publishedRealmURLs,
+  );
+
+  let normalizedRealmList = realmList.map((realmURL) =>
+    ensureTrailingSlash(realmURL),
+  );
+  return new Set(
+    normalizedRealmList.filter((realmURL) => publicReadable.has(realmURL)),
+  );
+}

--- a/packages/realm-server/handlers/handle-realm-info.ts
+++ b/packages/realm-server/handlers/handle-realm-info.ts
@@ -1,18 +1,10 @@
 import type Koa from 'koa';
 import type { DBAdapter, RealmInfo } from '@cardstack/runtime-common';
-import {
-  ensureTrailingSlash,
-  fetchUserPermissions,
-  logger,
-  SupportedMimeType,
-} from '@cardstack/runtime-common';
+import { logger, SupportedMimeType } from '@cardstack/runtime-common';
 
 import { setContextResponse } from '../middleware';
 import { getMultiRealmAuthorization } from '../middleware/multi-realm-authorization';
-import {
-  buildReadableRealms,
-  getPublishedRealmURLs,
-} from '../utils/realm-readability';
+import { getPublicReadableRealms } from '../utils/realm-readability';
 
 const log = logger('realm-server');
 
@@ -56,27 +48,4 @@ export default function handleRealmInfo({
       new Response(JSON.stringify({ data }, null, 2), { headers }),
     );
   };
-}
-
-async function getPublicReadableRealms(
-  dbAdapter: DBAdapter,
-  realmList: string[],
-): Promise<Set<string>> {
-  let publicPermissions = await fetchUserPermissions(dbAdapter, {
-    userId: '*',
-    onlyOwnRealms: false,
-  });
-
-  let publishedRealmURLs = await getPublishedRealmURLs(dbAdapter, realmList);
-  let publicReadable = buildReadableRealms(
-    publicPermissions,
-    publishedRealmURLs,
-  );
-
-  let normalizedRealmList = realmList.map((realmURL) =>
-    ensureTrailingSlash(realmURL),
-  );
-  return new Set(
-    normalizedRealmList.filter((realmURL) => publicReadable.has(realmURL)),
-  );
 }

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -41,6 +41,7 @@ import handlePrerenderProxy from './handlers/handle-prerender-proxy';
 import handleSearch from './handlers/handle-search';
 import handleSearchPrerendered from './handlers/handle-search-prerendered';
 import handleRealmInfo from './handlers/handle-realm-info';
+import handleFederatedTypes from './handlers/handle-federated-types';
 import { multiRealmAuthorization } from './middleware/multi-realm-authorization';
 import handleGitHubPRRequest from './handlers/handle-github-pr';
 import handleDownloadRealm from './handlers/handle-download-realm';
@@ -164,6 +165,11 @@ export function createRoutes(args: CreateRoutesArgs) {
     '/_federated-info',
     multiRealmAuthorization(args),
     handleRealmInfo({ dbAdapter: args.dbAdapter }),
+  );
+  router.all(
+    '/_federated-types',
+    multiRealmAuthorization(args),
+    handleFederatedTypes({ dbAdapter: args.dbAdapter }),
   );
   router.all(
     '/_federated-search-prerendered',

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -150,6 +150,7 @@ import './server-endpoints/authentication-test';
 import './server-endpoints/bot-commands-test';
 import './server-endpoints/bot-registration-test';
 import './server-endpoints/download-realm-test';
+import './server-endpoints/federated-types-test';
 import './server-endpoints/index-responses-test';
 import './server-endpoints/maintenance-endpoints-test';
 import './server-endpoints/queue-status-test';

--- a/packages/realm-server/tests/server-endpoints/federated-types-test.ts
+++ b/packages/realm-server/tests/server-endpoints/federated-types-test.ts
@@ -9,6 +9,7 @@ import type {
   QueueRunner,
   Realm,
 } from '@cardstack/runtime-common';
+import type { FederatedCardTypeSummaryEntry } from '@cardstack/runtime-common/document-types';
 import type { PgAdapter } from '@cardstack/postgres';
 import { resetCatalogRealms } from '../../handlers/handle-fetch-catalog-realms';
 import {
@@ -21,6 +22,13 @@ import {
 } from '../helpers';
 import { createJWT as createRealmServerJWT } from '../../utils/jwt';
 import type { Server } from 'http';
+
+interface FederatedTypesResponse {
+  data: FederatedCardTypeSummaryEntry[];
+  meta: {
+    page: { total: number };
+  };
+}
 
 module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
   module('Realm Server Endpoints | /_federated-types', function (hooks) {
@@ -123,51 +131,61 @@ module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
       },
     });
 
-    test('QUERY /_federated-types returns type summaries from multiple realms grouped by realm URL', async function (assert) {
+    function makeAuthenticatedRequest(
+      realms: string[],
+      extra?: Record<string, unknown>,
+    ) {
       let realmServerToken = createRealmServerJWT(
         { user: ownerUserId, sessionRoom: 'session-room-test' },
         realmSecretSeed,
       );
-
-      let response = await request
+      return request
         .post('/_federated-types')
         .set('X-HTTP-Method-Override', 'QUERY')
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${realmServerToken}`)
-        .send({ realms: [testRealm.url, secondaryRealm.url] });
+        .send({ realms, ...extra });
+    }
+
+    test('QUERY /_federated-types returns flat type summaries from multiple realms', async function (assert) {
+      let response = await makeAuthenticatedRequest([
+        testRealm.url,
+        secondaryRealm.url,
+      ]);
 
       assert.strictEqual(response.status, 200, 'HTTP 200 status');
-      let { data } = response.body as {
-        data: Record<
-          string,
-          {
-            data: {
-              type: string;
-              id: string;
-              attributes: { displayName: string; total: number };
-            }[];
-          }
-        >;
-      };
+      let body = response.body as FederatedTypesResponse;
 
-      assert.ok(data[testRealm.url], 'includes primary realm data');
-      assert.ok(data[secondaryRealm.url], 'includes secondary realm data');
+      assert.ok(Array.isArray(body.data), 'data is a flat array');
+      assert.ok(body.data.length > 0, 'has type summaries');
 
-      let primarySummaries = data[testRealm.url].data;
-      assert.ok(
-        primarySummaries.length > 0,
-        'primary realm has type summaries',
+      let primaryEntries = body.data.filter(
+        (entry) => entry.meta.realmURL === testRealm.url,
       );
+      let secondaryEntries = body.data.filter(
+        (entry) => entry.meta.realmURL === secondaryRealm.url,
+      );
+
+      assert.ok(primaryEntries.length > 0, 'has primary realm entries');
+      assert.ok(secondaryEntries.length > 0, 'has secondary realm entries');
+
       assert.strictEqual(
-        primarySummaries[0].type,
+        body.data[0].type,
         'card-type-summary',
-        'summary has correct type',
+        'entry has correct type',
+      );
+      assert.ok(body.data[0].meta.realmURL, 'entry has realmURL in meta');
+      assert.ok(body.data[0].attributes.displayName, 'entry has displayName');
+      assert.strictEqual(
+        typeof body.data[0].attributes.total,
+        'number',
+        'entry has total',
       );
 
-      let secondarySummaries = data[secondaryRealm.url].data;
-      assert.ok(
-        secondarySummaries.length > 0,
-        'secondary realm has type summaries',
+      assert.strictEqual(
+        body.meta.page.total,
+        body.data.length,
+        'meta.page.total matches data length when no pagination',
       );
 
       let publicHeader =
@@ -216,6 +234,7 @@ module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
         'response lists realms lacking read permission',
       );
     });
+
     test('QUERY /_federated-types returns 400 when realms are missing', async function (assert) {
       let response = await request
         .post('/_federated-types')
@@ -240,15 +259,211 @@ module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
         .send({ realms: [testRealm.url] });
 
       assert.strictEqual(response.status, 200, 'HTTP 200 status');
-      let { data } = response.body as {
-        data: Record<string, { data: { type: string; id: string }[] }>;
-      };
+      let body = response.body as FederatedTypesResponse;
 
-      assert.ok(data[testRealm.url], 'includes public realm data');
-      assert.ok(
-        data[testRealm.url].data.length > 0,
-        'public realm has type summaries',
+      assert.ok(Array.isArray(body.data), 'data is a flat array');
+      assert.ok(body.data.length > 0, 'public realm has type summaries');
+      assert.strictEqual(
+        body.data[0].meta.realmURL,
+        testRealm.url,
+        'entries are annotated with realmURL',
       );
+    });
+
+    test('QUERY /_federated-types with pagination returns limited results', async function (assert) {
+      let response = await makeAuthenticatedRequest(
+        [testRealm.url, secondaryRealm.url],
+        { page: { number: 0, size: 1 } },
+      );
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let body = response.body as FederatedTypesResponse;
+
+      assert.strictEqual(body.data.length, 1, 'returns only 1 item');
+      assert.ok(body.meta.page.total > 1, 'total is greater than page size');
+    });
+
+    test('QUERY /_federated-types pagination page 2 returns different items', async function (assert) {
+      let page0Response = await makeAuthenticatedRequest(
+        [testRealm.url, secondaryRealm.url],
+        { page: { number: 0, size: 1 } },
+      );
+      let page1Response = await makeAuthenticatedRequest(
+        [testRealm.url, secondaryRealm.url],
+        { page: { number: 1, size: 1 } },
+      );
+
+      let page0Body = page0Response.body as FederatedTypesResponse;
+      let page1Body = page1Response.body as FederatedTypesResponse;
+
+      assert.strictEqual(page0Body.data.length, 1, 'page 0 has 1 item');
+      assert.strictEqual(page1Body.data.length, 1, 'page 1 has 1 item');
+
+      let page0Id = `${page0Body.data[0].id}-${page0Body.data[0].meta.realmURL}`;
+      let page1Id = `${page1Body.data[0].id}-${page1Body.data[0].meta.realmURL}`;
+      assert.notStrictEqual(
+        page0Id,
+        page1Id,
+        'page 0 and page 1 return different items',
+      );
+      assert.strictEqual(
+        page0Body.meta.page.total,
+        page1Body.meta.page.total,
+        'total is same across pages',
+      );
+    });
+
+    test('QUERY /_federated-types without pagination returns all items', async function (assert) {
+      let allResponse = await makeAuthenticatedRequest([
+        testRealm.url,
+        secondaryRealm.url,
+      ]);
+      let paginatedResponse = await makeAuthenticatedRequest(
+        [testRealm.url, secondaryRealm.url],
+        { page: { number: 0, size: 1 } },
+      );
+
+      let allBody = allResponse.body as FederatedTypesResponse;
+      let paginatedBody = paginatedResponse.body as FederatedTypesResponse;
+
+      assert.strictEqual(
+        allBody.data.length,
+        allBody.meta.page.total,
+        'without pagination, all items are returned',
+      );
+      assert.strictEqual(
+        allBody.meta.page.total,
+        paginatedBody.meta.page.total,
+        'total matches between paginated and non-paginated',
+      );
+    });
+
+    test('QUERY /_federated-types with searchKey filters results', async function (assert) {
+      let allResponse = await makeAuthenticatedRequest([testRealm.url]);
+      let allBody = allResponse.body as FederatedTypesResponse;
+
+      // Use a displayName or code_ref substring from the actual results
+      let firstEntry = allBody.data[0];
+      let searchTerm = firstEntry.attributes.displayName.substring(0, 4);
+
+      let searchResponse = await makeAuthenticatedRequest([testRealm.url], {
+        searchKey: searchTerm,
+      });
+      let searchBody = searchResponse.body as FederatedTypesResponse;
+
+      assert.ok(searchBody.data.length > 0, 'search returns results');
+      assert.ok(
+        searchBody.data.every(
+          (entry) =>
+            entry.attributes.displayName
+              .toLowerCase()
+              .includes(searchTerm.toLowerCase()) ||
+            entry.id.toLowerCase().includes(searchTerm.toLowerCase()),
+        ),
+        'all results match search term',
+      );
+      assert.strictEqual(
+        searchBody.meta.page.total,
+        searchBody.data.length,
+        'total matches filtered results when not paginated',
+      );
+    });
+
+    test('QUERY /_federated-types with searchKey and pagination combined', async function (assert) {
+      let allResponse = await makeAuthenticatedRequest([testRealm.url]);
+      let allBody = allResponse.body as FederatedTypesResponse;
+
+      let firstEntry = allBody.data[0];
+      let searchTerm = firstEntry.attributes.displayName.substring(0, 3);
+
+      let response = await makeAuthenticatedRequest([testRealm.url], {
+        searchKey: searchTerm,
+        page: { number: 0, size: 1 },
+      });
+      let body = response.body as FederatedTypesResponse;
+
+      assert.strictEqual(body.data.length, 1, 'returns 1 item');
+      let matchesDisplayName = body.data[0].attributes.displayName
+        .toLowerCase()
+        .includes(searchTerm.toLowerCase());
+      let matchesCodeRef = body.data[0].id
+        .toLowerCase()
+        .includes(searchTerm.toLowerCase());
+      let matchesSearch = matchesDisplayName || matchesCodeRef;
+      assert.ok(matchesSearch, 'result matches search term');
+      assert.ok(body.meta.page.total >= 1, 'total reflects filtered count');
+    });
+
+    test('QUERY /_federated-types with searchKey that matches nothing returns empty data', async function (assert) {
+      let response = await makeAuthenticatedRequest([testRealm.url], {
+        searchKey: 'zzzzNonExistentTypezzzzz',
+      });
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let body = response.body as FederatedTypesResponse;
+
+      assert.strictEqual(body.data.length, 0, 'no results');
+      assert.strictEqual(body.meta.page.total, 0, 'total is 0');
+    });
+
+    test('QUERY /_federated-types searchKey is case-insensitive', async function (assert) {
+      let allResponse = await makeAuthenticatedRequest([testRealm.url]);
+      let allBody = allResponse.body as FederatedTypesResponse;
+      let firstEntry = allBody.data[0];
+      let searchTerm = firstEntry.attributes.displayName
+        .toUpperCase()
+        .substring(0, 4);
+
+      let response = await makeAuthenticatedRequest([testRealm.url], {
+        searchKey: searchTerm,
+      });
+      let body = response.body as FederatedTypesResponse;
+
+      assert.ok(
+        body.data.length > 0,
+        'case-insensitive search returns results',
+      );
+    });
+
+    test('QUERY /_federated-types each item has meta.realmURL', async function (assert) {
+      let response = await makeAuthenticatedRequest([
+        testRealm.url,
+        secondaryRealm.url,
+      ]);
+
+      let body = response.body as FederatedTypesResponse;
+
+      assert.ok(
+        body.data.every(
+          (entry) =>
+            typeof entry.meta.realmURL === 'string' &&
+            entry.meta.realmURL.length > 0,
+        ),
+        'every entry has a non-empty realmURL',
+      );
+
+      let realmURLs = new Set(body.data.map((entry) => entry.meta.realmURL));
+      assert.ok(realmURLs.has(testRealm.url), 'has entries from primary realm');
+      assert.ok(
+        realmURLs.has(secondaryRealm.url),
+        'has entries from secondary realm',
+      );
+    });
+
+    test('QUERY /_federated-types pagination beyond range returns empty data', async function (assert) {
+      let response = await makeAuthenticatedRequest([testRealm.url], {
+        page: { number: 9999, size: 50 },
+      });
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let body = response.body as FederatedTypesResponse;
+
+      assert.strictEqual(
+        body.data.length,
+        0,
+        'no results for out-of-range page',
+      );
+      assert.ok(body.meta.page.total > 0, 'total still reflects actual count');
     });
   });
 });

--- a/packages/realm-server/tests/server-endpoints/federated-types-test.ts
+++ b/packages/realm-server/tests/server-endpoints/federated-types-test.ts
@@ -197,6 +197,25 @@ module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
       );
     });
 
+    test('QUERY /_federated-types returns 403 for authenticated request to non-public realm without read permission', async function (assert) {
+      let unauthorizedToken = createRealmServerJWT(
+        { user: 'unauthorized-user', sessionRoom: 'session-room-test' },
+        realmSecretSeed,
+      );
+
+      let response = await request
+        .post('/_federated-types')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${unauthorizedToken}`)
+        .send({ realms: [secondaryRealm.url] });
+
+      assert.strictEqual(response.status, 403, 'HTTP 403 status');
+      assert.ok(
+        response.body.errors?.[0]?.includes(secondaryRealm.url),
+        'response lists realms lacking read permission',
+      );
+    });
     test('QUERY /_federated-types returns 400 when realms are missing', async function (assert) {
       let response = await request
         .post('/_federated-types')

--- a/packages/realm-server/tests/server-endpoints/federated-types-test.ts
+++ b/packages/realm-server/tests/server-endpoints/federated-types-test.ts
@@ -1,0 +1,223 @@
+import { module, test } from 'qunit';
+import supertest from 'supertest';
+import type { Test, SuperTest } from 'supertest';
+import { basename, join } from 'path';
+import { dirSync } from 'tmp';
+import type {
+  LooseSingleCardDocument,
+  QueuePublisher,
+  QueueRunner,
+  Realm,
+} from '@cardstack/runtime-common';
+import type { PgAdapter } from '@cardstack/postgres';
+import { resetCatalogRealms } from '../../handlers/handle-fetch-catalog-realms';
+import {
+  closeServer,
+  createVirtualNetwork,
+  setupDB,
+  matrixURL,
+  realmSecretSeed,
+  runTestRealmServerWithRealms,
+} from '../helpers';
+import { createJWT as createRealmServerJWT } from '../../utils/jwt';
+import type { Server } from 'http';
+
+module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
+  module('Realm Server Endpoints | /_federated-types', function (hooks) {
+    let testRealm: Realm;
+    let secondaryRealm: Realm;
+    let request: SuperTest<Test>;
+    let dbAdapter: PgAdapter;
+    let testRealmHttpServer: Server;
+
+    let ownerUserId = '@mango:localhost';
+
+    let realmFileSystem: Record<string, string | LooseSingleCardDocument> = {
+      'test-card.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            cardInfo: {
+              name: 'Test Card',
+            },
+          },
+          meta: {
+            adoptsFrom: {
+              module: 'https://cardstack.com/base/card-api',
+              name: 'CardDef',
+            },
+          },
+        },
+      },
+    };
+
+    async function startTypesRealmServer({
+      dbAdapter,
+      publisher,
+      runner,
+    }: {
+      dbAdapter: PgAdapter;
+      publisher: QueuePublisher;
+      runner: QueueRunner;
+    }) {
+      let virtualNetwork = createVirtualNetwork();
+      let dir = dirSync();
+      let testRealmURL = new URL('http://127.0.0.1:4444/test/');
+      let secondaryRealmURL = new URL('http://127.0.0.1:4444/secondary/');
+      let result = await runTestRealmServerWithRealms({
+        virtualNetwork,
+        realmsRootPath: join(dir.name, 'realm_server_1'),
+        realms: [
+          {
+            realmURL: testRealmURL,
+            fileSystem: {
+              '.realm.json': JSON.stringify({ name: 'Primary Realm' }),
+              ...realmFileSystem,
+            },
+            permissions: {
+              '*': ['read'],
+              [ownerUserId]: ['read', 'write', 'realm-owner'],
+            },
+          },
+          {
+            realmURL: secondaryRealmURL,
+            fileSystem: {
+              '.realm.json': JSON.stringify({ name: 'Secondary Realm' }),
+              ...realmFileSystem,
+            },
+            permissions: {
+              [ownerUserId]: ['read', 'write', 'realm-owner'],
+            },
+          },
+        ],
+        dbAdapter,
+        publisher,
+        runner,
+        matrixURL,
+      });
+
+      testRealmHttpServer = result.testRealmHttpServer;
+      request = supertest(result.testRealmHttpServer);
+      testRealm = result.realms.find(
+        (realm) => realm.url === testRealmURL.href,
+      )!;
+      secondaryRealm = result.realms.find(
+        (realm) => realm.url === secondaryRealmURL.href,
+      )!;
+    }
+
+    async function stopTypesRealmServer() {
+      testRealm.unsubscribe();
+      secondaryRealm.unsubscribe();
+      await closeServer(testRealmHttpServer);
+      resetCatalogRealms();
+    }
+
+    setupDB(hooks, {
+      beforeEach: async (_dbAdapter, publisher, runner) => {
+        dbAdapter = _dbAdapter;
+        await startTypesRealmServer({ dbAdapter, publisher, runner });
+      },
+      afterEach: async () => {
+        await stopTypesRealmServer();
+      },
+    });
+
+    test('QUERY /_federated-types returns type summaries from multiple realms grouped by realm URL', async function (assert) {
+      let realmServerToken = createRealmServerJWT(
+        { user: ownerUserId, sessionRoom: 'session-room-test' },
+        realmSecretSeed,
+      );
+
+      let response = await request
+        .post('/_federated-types')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${realmServerToken}`)
+        .send({ realms: [testRealm.url, secondaryRealm.url] });
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let { data } = response.body as {
+        data: Record<string, { data: { type: string; id: string; attributes: { displayName: string; total: number } }[] }>;
+      };
+
+      assert.ok(data[testRealm.url], 'includes primary realm data');
+      assert.ok(data[secondaryRealm.url], 'includes secondary realm data');
+
+      let primarySummaries = data[testRealm.url].data;
+      assert.ok(primarySummaries.length > 0, 'primary realm has type summaries');
+      assert.strictEqual(
+        primarySummaries[0].type,
+        'card-type-summary',
+        'summary has correct type',
+      );
+
+      let secondarySummaries = data[secondaryRealm.url].data;
+      assert.ok(
+        secondarySummaries.length > 0,
+        'secondary realm has type summaries',
+      );
+
+      let publicHeader =
+        response.headers['x-boxel-realms-public-readable'] ?? '';
+      assert.ok(publicHeader, 'includes public readable realms header');
+      let publicRealms = publicHeader
+        .split(',')
+        .map((value: string) => value.trim());
+      assert.ok(publicRealms.includes(testRealm.url), 'public realm is listed');
+      assert.notOk(
+        publicRealms.includes(secondaryRealm.url),
+        'private realm is not listed',
+      );
+    });
+
+    test('QUERY /_federated-types returns 401 for unauthenticated request to non-public realm', async function (assert) {
+      let response = await request
+        .post('/_federated-types')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .send({ realms: [secondaryRealm.url] });
+
+      assert.strictEqual(response.status, 401, 'HTTP 401 status');
+      assert.ok(
+        response.body.errors?.[0]?.includes(secondaryRealm.url),
+        'response lists realms requiring auth',
+      );
+    });
+
+    test('QUERY /_federated-types returns 400 when realms are missing', async function (assert) {
+      let response = await request
+        .post('/_federated-types')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .send({});
+
+      assert.strictEqual(response.status, 400, 'HTTP 400 status');
+      assert.ok(
+        response.body.errors?.[0]?.includes(
+          'realms must be supplied in request body',
+        ),
+        'response explains missing realms list',
+      );
+    });
+
+    test('QUERY /_federated-types returns type summaries for public realm without auth', async function (assert) {
+      let response = await request
+        .post('/_federated-types')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .send({ realms: [testRealm.url] });
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let { data } = response.body as {
+        data: Record<string, { data: { type: string; id: string }[] }>;
+      };
+
+      assert.ok(data[testRealm.url], 'includes public realm data');
+      assert.ok(
+        data[testRealm.url].data.length > 0,
+        'public realm has type summaries',
+      );
+    });
+  });
+});

--- a/packages/realm-server/tests/server-endpoints/federated-types-test.ts
+++ b/packages/realm-server/tests/server-endpoints/federated-types-test.ts
@@ -138,14 +138,26 @@ module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
 
       assert.strictEqual(response.status, 200, 'HTTP 200 status');
       let { data } = response.body as {
-        data: Record<string, { data: { type: string; id: string; attributes: { displayName: string; total: number } }[] }>;
+        data: Record<
+          string,
+          {
+            data: {
+              type: string;
+              id: string;
+              attributes: { displayName: string; total: number };
+            }[];
+          }
+        >;
       };
 
       assert.ok(data[testRealm.url], 'includes primary realm data');
       assert.ok(data[secondaryRealm.url], 'includes secondary realm data');
 
       let primarySummaries = data[testRealm.url].data;
-      assert.ok(primarySummaries.length > 0, 'primary realm has type summaries');
+      assert.ok(
+        primarySummaries.length > 0,
+        'primary realm has type summaries',
+      );
       assert.strictEqual(
         primarySummaries[0].type,
         'card-type-summary',

--- a/packages/realm-server/utils/realm-readability.ts
+++ b/packages/realm-server/utils/realm-readability.ts
@@ -1,6 +1,7 @@
 import type { DBAdapter } from '@cardstack/runtime-common';
 import {
   ensureTrailingSlash,
+  fetchUserPermissions,
   param,
   query,
   separatedByCommas,
@@ -39,4 +40,27 @@ export function buildReadableRealms(
     readableRealms.add(realmURL);
   }
   return readableRealms;
+}
+
+export async function getPublicReadableRealms(
+  dbAdapter: DBAdapter,
+  realmList: string[],
+): Promise<Set<string>> {
+  let publicPermissions = await fetchUserPermissions(dbAdapter, {
+    userId: '*',
+    onlyOwnRealms: false,
+  });
+
+  let publishedRealmURLs = await getPublishedRealmURLs(dbAdapter, realmList);
+  let publicReadable = buildReadableRealms(
+    publicPermissions,
+    publishedRealmURLs,
+  );
+
+  let normalizedRealmList = realmList.map((realmURL) =>
+    ensureTrailingSlash(realmURL),
+  );
+  return new Set(
+    normalizedRealmList.filter((realmURL) => publicReadable.has(realmURL)),
+  );
 }

--- a/packages/runtime-common/document-types.ts
+++ b/packages/runtime-common/document-types.ts
@@ -208,6 +208,31 @@ export function makeCardTypeSummaryDoc(summaries: CardTypeSummary[]) {
   return { data };
 }
 
+export interface FederatedCardTypeSummaryEntry {
+  type: 'card-type-summary';
+  id: string;
+  attributes: {
+    displayName: string;
+    total: number;
+    iconHTML: string;
+  };
+  meta: {
+    realmURL: string;
+  };
+}
+
+export function makeFederatedCardTypeSummaryDoc(
+  entries: FederatedCardTypeSummaryEntry[],
+  total: number,
+) {
+  return {
+    data: entries,
+    meta: {
+      page: { total },
+    },
+  };
+}
+
 function isIncluded(
   included: any,
 ): included is (CardResource<Saved> | FileMetaResource)[] {


### PR DESCRIPTION
## Summary
- Adds a new `/_federated-types` endpoint that fetches card type summaries from multiple realms in a single request
- Returns a flat paginated array (instead of realm-grouped map), with each entry annotated with `meta.realmURL` for client-side grouping
- Supports optional `page` parameter (`{ number, size }`) for pagination, following existing `/_search` pattern (0-based page numbers)
- Supports optional `searchKey` parameter for server-side case-insensitive substring filtering on `display_name` and `code_ref`
- Includes `meta.page.total` in response for total count after filtering (before pagination)
- Uses `multiRealmAuthorization` middleware and `x-boxel-realms-public-readable` header consistent with `/_federated-info`

## Test plan
- [ ] Verify authenticated user gets flat type summaries from multiple realms with `meta.realmURL` on each entry
- [ ] Verify pagination: `page: { number: 0, size: 1 }` returns 1 item with correct total
- [ ] Verify pagination page 2 returns different items
- [ ] Verify no pagination returns all items
- [ ] Verify search: `searchKey` filters results case-insensitively
- [ ] Verify search + pagination combined
- [ ] Verify search with no matches returns empty data with total 0
- [ ] Verify pagination beyond range returns empty data
- [ ] Verify 401 for unauthenticated request to non-public realm
- [ ] Verify 403 for unauthorized user
- [ ] Verify 400 for missing `realms` in request body
- [ ] Verify public realm accessible without auth
- [ ] Run full `pnpm test` in `packages/realm-server` for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)