### PR TITLE
Fix: Allow duplicate model IDs in AI Assistant model list

### DIFF
--- a/packages/host/app/components/ai-assistant/llm-select.gts
+++ b/packages/host/app/components/ai-assistant/llm-select.gts
@@ -51,7 +51,7 @@ export default class LLMSelect extends Component<Signature> {
       </:headerDetail>
       <:content>
         <ul class='llm-list'>
-          {{#each @options key="id" as |option|}}
+          {{#each @options key='id' as |option|}}
             <li
               class='llm-option {{if (eq @selected option.id) "selected"}}'
               data-test-llm-select-item={{option.id}}

--- a/packages/host/app/components/ai-assistant/llm-select.gts
+++ b/packages/host/app/components/ai-assistant/llm-select.gts
@@ -10,10 +10,16 @@ import { eq } from '@cardstack/boxel-ui/helpers';
 import PillMenu from '@cardstack/host/components/pill-menu';
 import scrollIntoViewModifier from '@cardstack/host/modifiers/scroll-into-view';
 
+export interface LLMOption {
+  id: string;
+  modelId: string;
+  name: string;
+}
+
 interface Signature {
   Args: {
     selected: string;
-    options: Record<string, string>;
+    options: LLMOption[];
     onChange: (selectedLLM: string) => void;
     disabled?: boolean;
     onExpand?: () => void;
@@ -45,28 +51,28 @@ export default class LLMSelect extends Component<Signature> {
       </:headerDetail>
       <:content>
         <ul class='llm-list'>
-          {{#each-in @options as |id name|}}
+          {{#each @options as |option|}}
             <li
-              class='llm-option {{if (eq @selected id) "selected"}}'
-              data-test-llm-select-item={{id}}
+              class='llm-option {{if (eq @selected option.id) "selected"}}'
+              data-test-llm-select-item={{option.id}}
               {{scrollIntoViewModifier
-                (eq @selected id)
+                (eq @selected option.id)
                 container='llm-select'
-                key=id
+                key=option.id
               }}
             >
               <button
                 type='button'
                 class='llm-button'
-                {{on 'click' (fn this.handleOptionClick id)}}
+                {{on 'click' (fn this.handleOptionClick option.id)}}
               >
-                {{name}}
-                {{#if (eq @selected id)}}
+                {{option.name}}
+                {{#if (eq @selected option.id)}}
                   <Check class='selected-icon' />
                 {{/if}}
               </button>
             </li>
-          {{/each-in}}
+          {{/each}}
           {{yield to='footer'}}
         </ul>
       </:content>
@@ -142,7 +148,7 @@ export default class LLMSelect extends Component<Signature> {
   </template>
 
   private get displayName() {
-    return this.args.options[this.args.selected];
+    return this.args.options.find((o) => o.id === this.args.selected)?.name;
   }
 
   @action

--- a/packages/host/app/components/ai-assistant/llm-select.gts
+++ b/packages/host/app/components/ai-assistant/llm-select.gts
@@ -51,7 +51,7 @@ export default class LLMSelect extends Component<Signature> {
       </:headerDetail>
       <:content>
         <ul class='llm-list'>
-          {{#each @options as |option|}}
+          {{#each @options key="id" as |option|}}
             <li
               class='llm-option {{if (eq @selected option.id) "selected"}}'
               data-test-llm-select-item={{option.id}}

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -82,7 +82,7 @@ import AiAssistantAttachmentPicker from '../ai-assistant/attachment-picker';
 import AiAssistantChatInput from '../ai-assistant/chat-input';
 import FocusPill from '../ai-assistant/focus-pill';
 import LLMModeToggle from '../ai-assistant/llm-mode-toggle';
-import LLMSelect from '../ai-assistant/llm-select';
+import LLMSelect, { type LLMOption } from '../ai-assistant/llm-select';
 import { AiAssistantConversation } from '../ai-assistant/message';
 import NewSession from '../ai-assistant/new-session';
 import AiAssistantSkillMenu from '../ai-assistant/skill-menu';
@@ -1055,21 +1055,30 @@ export default class Room extends Component<Signature> {
     return this.args.roomResource.skills;
   }
 
-  private get llmsForSelectMenu() {
-    // Read from the LLM environment card if available
+  private get llmsForSelectMenu(): LLMOption[] {
+    // Read from the system card if available
     let systemCard = this.matrixService.systemCard;
     if (systemCard?.modelConfigurations) {
-      let options: Record<string, string> = {};
+      let options: LLMOption[] = [];
+      let configModelIds = new Set<string>();
       for (let modelConfig of systemCard.modelConfigurations) {
-        if (modelConfig.modelId) {
-          options[modelConfig.modelId] =
-            modelConfig.cardTitle || modelConfig.modelId;
+        if (modelConfig.modelId && modelConfig.id) {
+          options.push({
+            id: modelConfig.id,
+            modelId: modelConfig.modelId,
+            name: modelConfig.cardTitle || modelConfig.modelId,
+          });
+          configModelIds.add(modelConfig.modelId);
         }
       }
-      // Add any used LLMs that aren't already in the options
+      // Add any used LLMs that aren't already covered by a config
       for (let usedLLM of this.args.roomResource.usedLLMs) {
-        if (usedLLM && !options[usedLLM]) {
-          options[usedLLM] = usedLLM; // Use model ID as display name
+        if (usedLLM && !configModelIds.has(usedLLM)) {
+          options.push({
+            id: usedLLM,
+            modelId: usedLLM,
+            name: usedLLM,
+          });
         }
       }
       return options;
@@ -1082,10 +1091,11 @@ export default class Room extends Component<Signature> {
       .filter(Boolean)
       .sort();
 
-    return ids.reduce((acc: Record<string, string>, id) => {
-      acc[id] = DEFAULT_LLM_ID_TO_NAME[id] ?? id;
-      return acc;
-    }, {});
+    return ids.map((id) => ({
+      id,
+      modelId: id,
+      name: DEFAULT_LLM_ID_TO_NAME[id] ?? id,
+    }));
   }
 
   private get systemCardId(): string | undefined {

--- a/packages/host/app/lib/matrix-classes/room.ts
+++ b/packages/host/app/lib/matrix-classes/room.ts
@@ -103,18 +103,19 @@ export default class Room {
     };
   }
 
-  get activeLLM() {
+  get activeLLMEventContent(): ActiveLLMEvent['content'] | undefined {
     let event = this._roomState?.events
       .get(APP_BOXEL_ACTIVE_LLM)
       ?.get('')?.event;
-    return (event as ActiveLLMEvent)?.content.model;
+    return (event as ActiveLLMEvent)?.content;
+  }
+
+  get activeLLM() {
+    return this.activeLLMEventContent?.model;
   }
 
   get activeInputModalities(): string[] | undefined {
-    let event = this._roomState?.events
-      .get(APP_BOXEL_ACTIVE_LLM)
-      ?.get('')?.event;
-    return (event as ActiveLLMEvent)?.content.inputModalities;
+    return this.activeLLMEventContent?.inputModalities;
   }
 
   get activeLLMMode(): LLMMode {

--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -367,7 +367,7 @@ export class RoomResource extends Resource<Args> {
 
   get activeLLM(): string {
     return (
-      this.llmBeingActivated ?? this.matrixRoom?.activeLLM ?? this.defaultLLM
+      this.llmBeingActivated ?? this.resolveActiveLLMKey() ?? this.defaultLLM
     );
   }
 
@@ -375,11 +375,38 @@ export class RoomResource extends Resource<Args> {
     return this.matrixRoom?.activeInputModalities;
   }
 
+  private resolveActiveLLMKey(): string | undefined {
+    let eventContent = this.matrixRoom?.activeLLMEventContent;
+    if (!eventContent?.model) {
+      return undefined;
+    }
+    let systemCard = this.matrixService.systemCard;
+    if (systemCard?.modelConfigurations) {
+      let match = systemCard.modelConfigurations.find(
+        (config) =>
+          config.modelId === eventContent.model &&
+          (config.reasoningEffort ?? undefined) ===
+            (eventContent.reasoningEffort ?? undefined),
+      );
+      if (match?.id) {
+        return match.id;
+      }
+      // Fall back to first config with matching modelId
+      let fallbackMatch = systemCard.modelConfigurations.find(
+        (config) => config.modelId === eventContent.model,
+      );
+      if (fallbackMatch?.id) {
+        return fallbackMatch.id;
+      }
+    }
+    return eventContent.model;
+  }
+
   private get defaultLLM(): string {
     let systemCard = this.matrixService.systemCard;
     return (
-      systemCard?.defaultModelConfiguration?.modelId ??
-      systemCard?.modelConfigurations?.[0]?.modelId ??
+      systemCard?.defaultModelConfiguration?.id ??
+      systemCard?.modelConfigurations?.[0]?.id ??
       DEFAULT_LLM
     );
   }
@@ -402,22 +429,49 @@ export class RoomResource extends Resource<Args> {
     return this.activateLLMTask.isRunning;
   }
 
-  activateLLMTask = restartableTask(async (model: string) => {
+  activateLLMTask = restartableTask(async (key: string) => {
     await this.processing;
-    if (this.activeLLM === model) {
+    if (this.activeLLM === key) {
       return;
     }
-    this.llmBeingActivated = model;
+    this.llmBeingActivated = key;
     try {
       if (!this.matrixRoom) {
         throw new Error('matrixRoom is required to activate LLM');
       }
+
+      // Resolve the key to a modelId and config properties
+      let modelId = key;
+      let config:
+        | {
+            toolsSupported?: boolean;
+            reasoningEffort?: string;
+            inputModalities?: string[];
+          }
+        | undefined;
+
+      let systemCard = this.matrixService.systemCard;
+      if (systemCard?.modelConfigurations) {
+        let modelConfig = systemCard.modelConfigurations.find(
+          (c) => c.id === key,
+        );
+        if (modelConfig?.modelId) {
+          modelId = modelConfig.modelId;
+          config = {
+            toolsSupported: modelConfig.toolsSupported,
+            reasoningEffort: modelConfig.reasoningEffort,
+            inputModalities: modelConfig.inputModalities,
+          };
+        }
+      }
+
       await this.matrixService.sendActiveLLMEvent(
         this.matrixRoom.roomId,
-        model,
+        modelId,
+        config,
       );
       let remainingRetries = 20;
-      while (this.matrixRoom.activeLLM !== model && remainingRetries > 0) {
+      while (this.matrixRoom.activeLLM !== modelId && remainingRetries > 0) {
         await timeout(50);
         remainingRetries--;
       }

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1658,16 +1658,34 @@ export default class MatrixService extends Service {
     return this.timelineLoadingState.get(this.currentRoomId) ?? false;
   }
 
-  async sendActiveLLMEvent(roomId: string, model: string) {
-    let modelConfiguration = this.systemCard?.modelConfigurations?.find(
-      (configuration) => configuration.modelId === model,
-    );
+  async sendActiveLLMEvent(
+    roomId: string,
+    model: string,
+    config?: {
+      toolsSupported?: boolean;
+      reasoningEffort?: string;
+      inputModalities?: string[];
+    },
+  ) {
+    let resolvedConfig = config;
+    if (!resolvedConfig) {
+      let modelConfiguration = this.systemCard?.modelConfigurations?.find(
+        (configuration) => configuration.modelId === model,
+      );
+      if (modelConfiguration) {
+        resolvedConfig = {
+          toolsSupported: modelConfiguration.toolsSupported,
+          reasoningEffort: modelConfiguration.reasoningEffort,
+          inputModalities: modelConfiguration.inputModalities,
+        };
+      }
+    }
 
     await this.client.sendStateEvent(roomId, APP_BOXEL_ACTIVE_LLM, {
       model,
-      toolsSupported: modelConfiguration?.toolsSupported,
-      reasoningEffort: modelConfiguration?.reasoningEffort,
-      inputModalities: modelConfiguration?.inputModalities,
+      toolsSupported: resolvedConfig?.toolsSupported,
+      reasoningEffort: resolvedConfig?.reasoningEffort,
+      inputModalities: resolvedConfig?.inputModalities,
     });
   }
 

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -102,6 +102,7 @@ let matrixRoomId: string;
 let mockedFileContent = 'Hello, world!';
 const TEST_MODEL_NAMES: Record<string, string> = {
   'openai/gpt-5': 'OpenAI: GPT-5',
+  'openai/gpt-5-extended': 'OpenAI: GPT-5 Extended Thinking',
   'openai/gpt-4o-mini': 'OpenAI: GPT-4o-mini',
   'anthropic/claude-sonnet-4.6': 'Anthropic: Claude Sonnet 4.6',
   'anthropic/claude-sonnet-4.5': 'Anthropic: Claude Sonnet 4.5',
@@ -115,6 +116,7 @@ const TEST_MODEL_NAMES: Record<string, string> = {
 // 'ModelConfiguration/gpt-5.json' → `${testRealmURL}ModelConfiguration/gpt-5`).
 const TEST_MODEL_CONFIG_IDS: Record<string, string> = {
   'openai/gpt-5': `${testRealmURL}ModelConfiguration/gpt-5`,
+  'openai/gpt-5-extended': `${testRealmURL}ModelConfiguration/gpt-5-extended`,
   'openai/gpt-4o-mini': `${testRealmURL}ModelConfiguration/gpt-4o-mini`,
   'anthropic/claude-sonnet-4.6': `${testRealmURL}ModelConfiguration/claude-sonnet-4.6`,
   'anthropic/claude-sonnet-4.5': `${testRealmURL}ModelConfiguration/claude-sonnet-4.5`,
@@ -323,6 +325,15 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       reasoningEffort: 'minimal',
     });
 
+    let openAiGpt5ExtendedModel = new ModelConfiguration({
+      cardInfo: new CardInfoField({
+        name: modelNameFor('openai/gpt-5-extended'),
+      }),
+      modelId: 'openai/gpt-5',
+      toolsSupported: true,
+      reasoningEffort: 'high',
+    });
+
     let openAiGpt4oMiniModel = new ModelConfiguration({
       cardInfo: new CardInfoField({
         name: modelNameFor('openai/gpt-4o-mini'),
@@ -360,6 +371,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       defaultModelConfiguration: anthropicClaudeSonnet46Model,
       modelConfigurations: [
         openAiGpt5Model,
+        openAiGpt5ExtendedModel,
         openAiGpt4oMiniModel,
         anthropicClaudeSonnet46Model,
         anthropicClaudeSonnet45Model,
@@ -512,6 +524,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
         },
         'ModelConfiguration/gpt-4o-mini.json': openAiGpt4oMiniModel,
         'ModelConfiguration/gpt-5.json': openAiGpt5Model,
+        'ModelConfiguration/gpt-5-extended.json': openAiGpt5ExtendedModel,
         'ModelConfiguration/claude-sonnet-4.6.json':
           anthropicClaudeSonnet46Model,
         'ModelConfiguration/claude-sonnet-4.5.json':
@@ -701,9 +714,9 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     assert.dom('[data-test-llm-select-selected]').hasText(defaultModelName);
     await click('[data-test-llm-select-selected]');
 
-    // Should have 5 models from our system card
+    // Should have 6 models from our system card (including duplicate modelId with different config)
     assert.dom('[data-test-llm-select-item]').exists({
-      count: 5,
+      count: 6,
     });
 
     let llmIdToChangeTo = 'anthropic/claude-3.7-sonnet';
@@ -787,6 +800,83 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       secondState.reasoningEffort,
       'minimal',
       'Active LLM event records configured reasoning effort for GPT-5',
+    );
+  });
+
+  test('duplicate model IDs render as distinct menu items with correct state', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}index`,
+            format: 'isolated',
+          },
+        ],
+      ],
+    });
+    await click('[data-test-open-ai-assistant]');
+    await waitFor(`[data-room-settled]`);
+    await click('[data-test-llm-select-selected]');
+
+    let gpt5ConfigId = configIdFor('openai/gpt-5');
+    let gpt5ExtendedConfigId = configIdFor('openai/gpt-5-extended');
+
+    // Both configs with the same modelId should appear as distinct menu items
+    assert
+      .dom(`[data-test-llm-select-item="${gpt5ConfigId}"]`)
+      .exists('GPT-5 (minimal) config appears in the menu');
+    assert
+      .dom(`[data-test-llm-select-item="${gpt5ExtendedConfigId}"]`)
+      .exists('GPT-5 Extended Thinking config appears in the menu');
+    assert
+      .dom(`[data-test-llm-select-item="${gpt5ConfigId}"]`)
+      .hasText(modelNameFor('openai/gpt-5'));
+    assert
+      .dom(`[data-test-llm-select-item="${gpt5ExtendedConfigId}"]`)
+      .hasText(modelNameFor('openai/gpt-5-extended'));
+
+    // Select the extended thinking variant
+    await click(`[data-test-llm-select-item="${gpt5ExtendedConfigId}"] button`);
+    await click('[data-test-llm-select-selected]');
+
+    await waitUntil(() => {
+      let state = getRoomState(matrixRoomId, APP_BOXEL_ACTIVE_LLM, '');
+      return state.model === 'openai/gpt-5' && state.reasoningEffort === 'high';
+    });
+
+    let extendedState = getRoomState(matrixRoomId, APP_BOXEL_ACTIVE_LLM, '');
+    assert.strictEqual(
+      extendedState.model,
+      'openai/gpt-5',
+      'Extended thinking variant sends the same modelId',
+    );
+    assert.strictEqual(
+      extendedState.reasoningEffort,
+      'high',
+      'Extended thinking variant sends its own reasoningEffort',
+    );
+
+    // Now select the minimal variant
+    await click(`[data-test-llm-select-item="${gpt5ConfigId}"] button`);
+    await click('[data-test-llm-select-selected]');
+
+    await waitUntil(() => {
+      let state = getRoomState(matrixRoomId, APP_BOXEL_ACTIVE_LLM, '');
+      return (
+        state.model === 'openai/gpt-5' && state.reasoningEffort === 'minimal'
+      );
+    });
+
+    let minimalState = getRoomState(matrixRoomId, APP_BOXEL_ACTIVE_LLM, '');
+    assert.strictEqual(
+      minimalState.model,
+      'openai/gpt-5',
+      'Minimal variant sends the same modelId',
+    );
+    assert.strictEqual(
+      minimalState.reasoningEffort,
+      'minimal',
+      'Minimal variant sends its own reasoningEffort',
     );
   });
 

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -110,6 +110,23 @@ const TEST_MODEL_NAMES: Record<string, string> = {
   'google/gemini-2.5-flash': 'Google: Gemini 2.5 Flash',
 };
 
+// Maps model IDs to their ModelConfiguration card IDs in the test realm.
+// These correspond to the file paths used in the test setup (e.g.,
+// 'ModelConfiguration/gpt-5.json' → `${testRealmURL}ModelConfiguration/gpt-5`).
+const TEST_MODEL_CONFIG_IDS: Record<string, string> = {
+  'openai/gpt-5': `${testRealmURL}ModelConfiguration/gpt-5`,
+  'openai/gpt-4o-mini': `${testRealmURL}ModelConfiguration/gpt-4o-mini`,
+  'anthropic/claude-sonnet-4.6': `${testRealmURL}ModelConfiguration/claude-sonnet-4.6`,
+  'anthropic/claude-sonnet-4.5': `${testRealmURL}ModelConfiguration/claude-sonnet-4.5`,
+  'anthropic/claude-3.7-sonnet': `${testRealmURL}ModelConfiguration/claude-sonnet-3.7`,
+  'deepseek/deepseek-chat-v3-0324': `${testRealmURL}ModelConfiguration/deepseek-chat-v3-0324`,
+  'google/gemini-2.5-flash': `${testRealmURL}ModelConfiguration/gemini-2.5-flash`,
+};
+
+function configIdFor(modelId: string): string {
+  return TEST_MODEL_CONFIG_IDS[modelId] ?? modelId;
+}
+
 function modelNameFor(llmId: string): string {
   return TEST_MODEL_NAMES[llmId] ?? llmId;
 }
@@ -690,12 +707,13 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     });
 
     let llmIdToChangeTo = 'anthropic/claude-3.7-sonnet';
+    let llmConfigId = configIdFor(llmIdToChangeTo);
     let llmNameToChangeTo = modelNameFor('anthropic/claude-3.7-sonnet');
 
     assert
-      .dom(`[data-test-llm-select-item="${llmIdToChangeTo}"]`)
+      .dom(`[data-test-llm-select-item="${llmConfigId}"]`)
       .hasText(llmNameToChangeTo);
-    await click(`[data-test-llm-select-item="${llmIdToChangeTo}"] button`);
+    await click(`[data-test-llm-select-item="${llmConfigId}"] button`);
     await click('[data-test-llm-select-selected]');
     assert.dom('[data-test-llm-select-selected]').hasText(llmNameToChangeTo);
 
@@ -718,7 +736,9 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await waitFor('[data-room-settled]');
 
     await click('[data-test-llm-select-selected]');
-    await click(`[data-test-llm-select-item="openai/gpt-4o-mini"] button`);
+    await click(
+      `[data-test-llm-select-item="${configIdFor('openai/gpt-4o-mini')}"] button`,
+    );
     await click('[data-test-llm-select-selected]');
 
     await waitUntil(() => {
@@ -743,7 +763,9 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     );
 
     await click('[data-test-llm-select-selected]');
-    await click(`[data-test-llm-select-item="openai/gpt-5"] button`);
+    await click(
+      `[data-test-llm-select-item="${configIdFor('openai/gpt-5')}"] button`,
+    );
     await click('[data-test-llm-select-selected]');
 
     await waitUntil(() => {
@@ -816,7 +838,9 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await waitFor(`[data-room-settled]`);
     await click('[data-test-llm-select-selected]');
     assert
-      .dom('[data-test-llm-select-item="deepseek/deepseek-chat-v3-0324"]')
+      .dom(
+        `[data-test-llm-select-item="${configIdFor('deepseek/deepseek-chat-v3-0324')}"]`,
+      )
       .doesNotExist();
     await click('[data-test-llm-select-selected]');
     await click('[data-test-close-ai-assistant]');
@@ -838,13 +862,19 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       .hasText(modelNameFor('deepseek/deepseek-chat-v3-0324'));
     await click('[data-test-llm-select-selected]');
     assert
-      .dom('[data-test-llm-select-item="deepseek/deepseek-chat-v3-0324"]')
+      .dom(
+        `[data-test-llm-select-item="${configIdFor('deepseek/deepseek-chat-v3-0324')}"]`,
+      )
       .exists();
     assert
-      .dom('[data-test-llm-select-item="deepseek/deepseek-chat-v3-0324"]')
+      .dom(
+        `[data-test-llm-select-item="${configIdFor('deepseek/deepseek-chat-v3-0324')}"]`,
+      )
       .hasText(modelNameFor('deepseek/deepseek-chat-v3-0324'));
     assert
-      .dom('[data-test-llm-select-item="google/gemini-2.5-flash"]')
+      .dom(
+        `[data-test-llm-select-item="${configIdFor('google/gemini-2.5-flash')}"]`,
+      )
       .exists();
     await click('[data-test-pill-menu-button]');
     await click('[data-test-close-ai-assistant]');

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -857,6 +857,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     );
 
     // Now select the minimal variant
+    await click('[data-test-llm-select-selected]');
     await click(`[data-test-llm-select-item="${gpt5ConfigId}"] button`);
     await click('[data-test-llm-select-selected]');
 


### PR DESCRIPTION
The LLM select menu previously used Record<string, string> keyed by modelId, which prevented showing multiple configurations for the same model (e.g. "high" and "low" thinking variants). Switch to an array of LLMOption objects keyed by ModelConfiguration card ID, and match the active selection by modelId + reasoningEffort.