### PR TITLE
matrix: Add logging before registering user

### DIFF
--- a/packages/matrix/scripts/register-realm-user.ts
+++ b/packages/matrix/scripts/register-realm-user.ts
@@ -22,6 +22,8 @@ if (!realmUser) {
 (async () => {
   let password = await realmPassword(realmUser, realmSecretSeed);
   return new Promise<string>((resolve, reject) => {
+    console.log(`Registering realm user ${realmUser}`);
+
     const command = `docker exec ${getSynapseContainerName()} register_new_matrix_user http://localhost:8008 -c /data/homeserver.yaml -u ${realmUser} -p ${password} --no-admin`;
     childProcess.exec(command, async (err, stdout) => {
       if (err) {


### PR DESCRIPTION
The `register_new_matrix_user` script only shows this:
```
Sending registration request...
Success!
```

This adds logging before sending the request so we know what user it’s registering.