### PR TITLE
ci: Move Percy finalisation to another job

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -188,8 +188,8 @@ jobs:
           path: /tmp/icon-server.log
           retention-days: 30
 
-  host-merge-reports-and-publish:
-    name: Merge Host reports and publish
+  host-percy-finalize:
+    name: Finalise Percy
     if: always()
     needs: host-test
     runs-on: ubuntu-latest
@@ -204,6 +204,16 @@ jobs:
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_HOST }}
           PERCY_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
+
+  host-merge-reports-and-publish:
+    name: Merge Host reports and publish
+    if: always()
+    needs: host-test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - uses: ./.github/actions/init
 
       - name: Download JUnit reports from GitHub Actions Artifacts
         uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # 4.2.0


### PR DESCRIPTION
Currently Percy is refusing our call to finalise the build, which is making the other steps in that job not run. This separates the Percy step into its own job so it doesn’t interfere with the others. That restores this comment:

<img width="901" height="329" alt="boxel 2026-03-12 19-43-14" src="https://github.com/user-attachments/assets/a3863d39-8ddd-4412-b1f7-cd2a547ccf9f" />
