### PR TITLE
fix: keyboard Choose File modal follow-up — focus trap and container scroll

### DIFF
--- a/packages/host/app/components/editor/indexed-file-tree.gts
+++ b/packages/host/app/components/editor/indexed-file-tree.gts
@@ -184,7 +184,24 @@ export default class IndexedFileTree extends Component<Signature> {
     const el = Array.from(
       nav.querySelectorAll<HTMLElement>('[data-path]'),
     ).find((candidate) => candidate.dataset.path === path);
-    el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    if (!el) return;
+
+    // Scroll within the nearest overflow:auto ancestor (the file list container),
+    // rather than calling scrollIntoView which can scroll the whole viewport.
+    const scrollContainer = nav.parentElement;
+    if (!scrollContainer) {
+      el.scrollIntoView({ block: 'nearest' });
+      return;
+    }
+
+    const containerRect = scrollContainer.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+
+    if (elRect.top < containerRect.top) {
+      scrollContainer.scrollTop -= containerRect.top - elRect.top;
+    } else if (elRect.bottom > containerRect.bottom) {
+      scrollContainer.scrollTop += elRect.bottom - containerRect.bottom;
+    }
   }
 
   @action
@@ -360,7 +377,7 @@ export default class IndexedFileTree extends Component<Signature> {
               // Directory: just move cursor, don't expand
               this.cursorPath = path;
             }
-            match.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+            this.scrollPathIntoView(path, nav);
           }
         }
         break;

--- a/packages/host/app/components/operator-mode/choose-file-modal.gts
+++ b/packages/host/app/components/operator-mode/choose-file-modal.gts
@@ -271,6 +271,39 @@ export default class ChooseFileModal extends Component<Signature> {
   @action private handleKeydown(event: KeyboardEvent) {
     if (event.key === 'Escape') {
       this.pickTask.perform(undefined);
+      return;
+    }
+    if (event.key === 'Tab') {
+      this.trapFocus(event);
+    }
+  }
+
+  private trapFocus(event: KeyboardEvent) {
+    const container = event.currentTarget as HTMLElement;
+    const focusableSelector = [
+      'button:not([disabled]):not([tabindex="-1"])',
+      '[tabindex="0"]',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'a[href]',
+    ].join(', ');
+    const focusable = Array.from(
+      container.querySelectorAll<HTMLElement>(focusableSelector),
+    );
+    if (focusable.length < 2) return;
+    const first = focusable[0]!;
+    const last = focusable[focusable.length - 1]!;
+
+    if (event.shiftKey) {
+      if (document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Follow-up fixes to the keyboard-friendly Choose File modal after initial implementation landed in #4143.

### Focus trap (Tab key wrapping)

Tab now wraps within the modal — pressing Tab on the Add button cycles back to the realm chooser, and Shift+Tab from the realm chooser cycles back to Add. This prevents keyboard focus from escaping the dialog.

### Container-aware scrolling

Arrow key navigation and type-ahead both previously called `scrollIntoView` which can scroll the outer viewport rather than the 267px overflow container. Replaced with `getBoundingClientRect`-based scroll that adjusts the container's `scrollTop` directly — so navigating down a long file list actually keeps the selected item visible within the modal.

### What was already fixed in the merge

The visual feedback for type-ahead and arrow navigation was already corrected in the main merge — `.file.cursor` now uses the same green highlight as `.file.selected`, so typed matches are clearly visible.