### PR TITLE
Reduce OpenRouter sync batch size from 50 to 20

### DIFF
--- a/packages/host/app/commands/sync-openrouter-models.ts
+++ b/packages/host/app/commands/sync-openrouter-models.ts
@@ -11,7 +11,7 @@ import type CardService from '../services/card-service';
 import type NetworkService from '../services/network';
 
 const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models';
-const BATCH_SIZE = 50;
+const BATCH_SIZE = 20;
 
 interface OpenRouterApiModel {
   id: string;


### PR DESCRIPTION
## Summary
- Reduces `BATCH_SIZE` in `SyncOpenRouterModelsCommand` from 50 to 20 to lower the risk of timeouts and partial failures during atomic batch operations against a realm server.

## Test plan
- [ ] Run the sync command against a realm and verify batches complete without timeout errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)