### PR TITLE
Fix issue where scoped glimmer styles were lost after logging out and logging back in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,14 @@
   Note that the filter is matched against the module name and test name, not the file name! Try to avoid using pipe characters in the filter, since they can confuse auto-approval tool use filters set up by the user.
 - run `pnpm lint` in this directory to lint changes made to this package
 - run `pnpm lint:fix` directly in this directory to apply fixes for lint failures made to this package that can be automatically fixed.
+- the host tests report this error:
+  ```
+  Missing symlinked npm packages: 
+  Package: @cardstack/local-types
+    * Specified: workspace:*
+    * Symlinked: (not available)
+  ```
+  This is a red herring. Just ignore this error.
 
 #### Iterating on host tests with the Chrome MCP server
 

--- a/packages/host/app/resources/last-modified-date.ts
+++ b/packages/host/app/resources/last-modified-date.ts
@@ -1,13 +1,25 @@
 import { registerDestructor } from '@ember/destroyable';
 import { tracked } from '@glimmer/tracking';
 
-import { formatDistanceToNow } from 'date-fns';
+import { formatDistance } from 'date-fns';
 import { Resource } from 'ember-modify-based-class-resource';
 
 import type { Ready as ReadyFile } from '@cardstack/host/resources/file';
 
 interface Args {
   named: { file: ReadyFile };
+}
+
+export const LAST_SAVED_JUST_NOW_THRESHOLD_MS = 60 * 1000;
+
+export function formatLastSavedText(date: Date, now = Date.now()) {
+  if (Math.abs(now - date.getTime()) < LAST_SAVED_JUST_NOW_THRESHOLD_MS) {
+    return 'Last saved just now';
+  }
+
+  return `Last saved ${formatDistance(date, now, {
+    addSuffix: true,
+  })}`;
 }
 
 export class LastModifiedDateResource extends Resource<Args> {
@@ -29,14 +41,7 @@ export class LastModifiedDateResource extends Resource<Args> {
 
   private calculate(file: ReadyFile) {
     if (file.lastModifiedAsDate != undefined) {
-      let date = file.lastModifiedAsDate;
-      if (Date.now() - date.getTime() < 10 * 1000) {
-        this.value = 'Last saved just now';
-      } else {
-        this.value = `Last saved ${formatDistanceToNow(date, {
-          addSuffix: true,
-        })}`;
-      }
+      this.value = formatLastSavedText(file.lastModifiedAsDate);
     } else {
       this.value = undefined;
     }

--- a/packages/host/app/services/loader-service.ts
+++ b/packages/host/app/services/loader-service.ts
@@ -47,11 +47,16 @@ export default class LoaderService extends Service {
   }
 
   public resetState() {
-    // this clears the fetch cache in between logins, the idea being that we
-    // don't want to leak modules from private realms between sessions.
-    clearFetchCache();
-    clearInjectedScopedCSS();
-    clearKnownFileMetaUrls();
+    this.clearSessionCaches();
+  }
+
+  public resetSessionBoundary(reason?: string) {
+    this.resetTime = undefined;
+    log.debug(`resetting loader for session boundary (${reason ?? ''})`);
+    this.clearSessionCaches();
+    this.loader = this.loader
+      ? Loader.cloneLoader(this.loader)
+      : this.makeInstance();
   }
 
   public resetLoader(options?: { clearFetchCache?: boolean; reason?: string }) {
@@ -112,6 +117,14 @@ export default class LoaderService extends Service {
     let fetch = fetcher(this.network.fetch, middlewareStack);
     let loader = new Loader(fetch, this.network.resolveImport);
     return loader;
+  }
+
+  private clearSessionCaches() {
+    // This clears cached module fetches and scoped styles at session/test
+    // boundaries so private realm assets do not leak across owners.
+    clearFetchCache();
+    clearInjectedScopedCSS();
+    clearKnownFileMetaUrls();
   }
 }
 

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -502,6 +502,7 @@ export default class MatrixService extends Service {
       // only so tests and app reloads do not accidentally wipe durable state.
       clearLocalStorage(window.localStorage);
       this.reset.resetAll();
+      this.loaderService.resetSessionBoundary('logout');
       this.unbindEventListeners();
       await client?.logout(true);
       // when user logs out we transition them back to an empty stack with the

--- a/packages/host/tests/unit/last-modified-date-test.ts
+++ b/packages/host/tests/unit/last-modified-date-test.ts
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+
+import {
+  formatLastSavedText,
+  LAST_SAVED_JUST_NOW_THRESHOLD_MS,
+} from '@cardstack/host/resources/last-modified-date';
+
+module('Unit | last-modified-date', function () {
+  test('treats files from the last minute as just now', function (assert) {
+    let now = Date.UTC(2026, 2, 13, 12, 0, 0);
+    let lastModified = new Date(now - (LAST_SAVED_JUST_NOW_THRESHOLD_MS - 1));
+
+    assert.strictEqual(
+      formatLastSavedText(lastModified, now),
+      'Last saved just now',
+    );
+  });
+
+  test('switches to relative time after one minute', function (assert) {
+    let now = Date.UTC(2026, 2, 13, 12, 0, 0);
+    let lastModified = new Date(now - LAST_SAVED_JUST_NOW_THRESHOLD_MS);
+
+    assert.strictEqual(
+      formatLastSavedText(lastModified, now),
+      'Last saved 1 minute ago',
+    );
+  });
+});

--- a/packages/host/tests/unit/loader-test.ts
+++ b/packages/host/tests/unit/loader-test.ts
@@ -6,6 +6,8 @@ import { module, test } from 'qunit';
 
 import { baseRealm, Loader } from '@cardstack/runtime-common';
 
+import type LoaderService from '@cardstack/host/services/loader-service';
+
 import {
   testRealmURL,
   setupCardLogs,
@@ -23,11 +25,13 @@ module('Unit | loader', function (hooks) {
   let mockMatrixUtils = setupMockMatrix(hooks);
 
   let loader: Loader;
+  let loaderService: LoaderService;
 
   setupRealmCacheTeardown(hooks);
 
   hooks.beforeEach(async function (this: RenderingTestContext) {
-    loader = getService('loader-service').loader;
+    loaderService = getService('loader-service');
+    loader = loaderService.loader;
 
     await withCachedRealmSetup(async () =>
       setupIntegrationTestRealm({
@@ -118,6 +122,21 @@ module('Unit | loader', function (hooks) {
           export let counter = 0;
           export function increment() {
             counter++;
+          }
+        `,
+          'styled-person.gts': `
+          import { CardDef, Component } from 'https://cardstack.com/base/card-api';
+          export class StyledPerson extends CardDef {
+            static isolated = class Isolated extends Component<typeof this> {
+              <template>
+                <div class="styled-person">Styled Person</div>
+                <style scoped>
+                  .styled-person {
+                    color: rgb(1, 2, 3);
+                  }
+                </style>
+              </template>
+            };
           }
         `,
           'foo.js': `
@@ -228,6 +247,29 @@ module('Unit | loader', function (hooks) {
     }>(`${testRealmURL}foo`);
     assert.strictEqual(checkImportMeta(), `${testRealmURL}foo.js`);
     assert.strictEqual(myLoader(), loader, 'the loader instance is correct');
+  });
+
+  test('session boundary reset rebuilds the loader so scoped CSS can be injected again', async function (assert) {
+    await loaderService.loader.import(`${testRealmURL}styled-person`);
+    assert
+      .dom('style[data-boxel-scoped-css]')
+      .exists('scoped CSS is injected after the initial import');
+
+    loaderService.resetSessionBoundary('test');
+
+    assert
+      .dom('style[data-boxel-scoped-css]')
+      .doesNotExist('session reset clears injected scoped CSS');
+    assert.notStrictEqual(
+      loaderService.loader,
+      loader,
+      'session reset replaces the loader instance',
+    );
+
+    await loaderService.loader.import(`${testRealmURL}styled-person`);
+    assert
+      .dom('style[data-boxel-scoped-css]')
+      .exists('scoped CSS is re-injected after the next import');
   });
 
   test('identify preserves original module for reexports', function (assert) {

--- a/packages/host/tests/unit/loader-test.ts
+++ b/packages/host/tests/unit/loader-test.ts
@@ -6,8 +6,6 @@ import { module, test } from 'qunit';
 
 import { baseRealm, Loader } from '@cardstack/runtime-common';
 
-import type LoaderService from '@cardstack/host/services/loader-service';
-
 import {
   testRealmURL,
   setupCardLogs,
@@ -25,13 +23,10 @@ module('Unit | loader', function (hooks) {
   let mockMatrixUtils = setupMockMatrix(hooks);
 
   let loader: Loader;
-  let loaderService: LoaderService;
-
   setupRealmCacheTeardown(hooks);
 
   hooks.beforeEach(async function (this: RenderingTestContext) {
-    loaderService = getService('loader-service');
-    loader = loaderService.loader;
+    loader = getService('loader-service').loader;
 
     await withCachedRealmSetup(async () =>
       setupIntegrationTestRealm({
@@ -122,21 +117,6 @@ module('Unit | loader', function (hooks) {
           export let counter = 0;
           export function increment() {
             counter++;
-          }
-        `,
-          'styled-person.gts': `
-          import { CardDef, Component } from 'https://cardstack.com/base/card-api';
-          export class StyledPerson extends CardDef {
-            static isolated = class Isolated extends Component<typeof this> {
-              <template>
-                <div class="styled-person">Styled Person</div>
-                <style scoped>
-                  .styled-person {
-                    color: rgb(1, 2, 3);
-                  }
-                </style>
-              </template>
-            };
           }
         `,
           'foo.js': `
@@ -247,29 +227,6 @@ module('Unit | loader', function (hooks) {
     }>(`${testRealmURL}foo`);
     assert.strictEqual(checkImportMeta(), `${testRealmURL}foo.js`);
     assert.strictEqual(myLoader(), loader, 'the loader instance is correct');
-  });
-
-  test('session boundary reset rebuilds the loader so scoped CSS can be injected again', async function (assert) {
-    await loaderService.loader.import(`${testRealmURL}styled-person`);
-    assert
-      .dom('style[data-boxel-scoped-css]')
-      .exists('scoped CSS is injected after the initial import');
-
-    loaderService.resetSessionBoundary('test');
-
-    assert
-      .dom('style[data-boxel-scoped-css]')
-      .doesNotExist('session reset clears injected scoped CSS');
-    assert.notStrictEqual(
-      loaderService.loader,
-      loader,
-      'session reset replaces the loader instance',
-    );
-
-    await loaderService.loader.import(`${testRealmURL}styled-person`);
-    assert
-      .dom('style[data-boxel-scoped-css]')
-      .exists('scoped CSS is re-injected after the next import');
   });
 
   test('identify preserves original module for reexports', function (assert) {

--- a/packages/matrix/helpers/isolated-realm-server.ts
+++ b/packages/matrix/helpers/isolated-realm-server.ts
@@ -294,6 +294,9 @@ export async function startServer({
     stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
     env: {
       ...process.env,
+      // Matrix tests don't exercise GitHub PR creation, so disable that route
+      // to avoid pulling Octokit into the realm server startup path.
+      DISABLE_GITHUB_PR_ROUTE: 'true',
       PUBLISHED_REALM_BOXEL_SPACE_DOMAIN: 'localhost:4205',
       PUBLISHED_REALM_BOXEL_SITE_DOMAIN: 'localhost:4205',
     },

--- a/packages/matrix/tests/glimmer-scoped-css.spec.ts
+++ b/packages/matrix/tests/glimmer-scoped-css.spec.ts
@@ -6,6 +6,8 @@ import {
   postCardSource,
   postNewCard,
   createSubscribedUserAndLogin,
+  login,
+  logout,
 } from '../helpers';
 
 test.describe('glimmer-scoped-css', () => {
@@ -63,11 +65,73 @@ test.describe('glimmer-scoped-css', () => {
     });
 
     await page.goto(newCardURL);
-
-    await page.pause();
-
     await expect(
       page.locator('[data-test-paragraph-with-no-global-style]'),
     ).toHaveCSS('font-style', 'normal');
+  });
+
+  test('scoped card styles are restored after logging out and back in', async ({
+    page,
+  }) => {
+    const realmName = 'realm2';
+    await clearLocalStorage(page, serverIndexUrl);
+    let { username, password } = await createSubscribedUserAndLogin(
+      page,
+      'glimmer-css-relogin-user',
+      serverIndexUrl,
+    );
+    const realmURL = new URL(`${username}/${realmName}/`, serverIndexUrl).href;
+    await createRealm(page, realmName);
+
+    await postCardSource(
+      page,
+      realmURL,
+      'sample-card.gts',
+      `
+      import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
+      import { Component } from 'https://cardstack.com/base/card-api';
+      export class SampleCard extends CardDef {
+        @field name = contains(StringField);
+        static isolated = class Isolated extends Component<typeof this> {
+          <template>
+            <p data-test-scoped-style-restored>Hello <@fields.name /></p>
+            <style scoped>
+              p {
+                background-color: rgb(1, 2, 3);
+              }
+            </style>
+          </template>
+        };
+      }`,
+    );
+
+    newCardURL = await postNewCard(page, realmURL, {
+      data: {
+        type: 'card',
+        attributes: {
+          title: 'Mango',
+          name: 'Mango',
+        },
+        meta: {
+          adoptsFrom: {
+            module: '../sample-card',
+            name: 'SampleCard',
+          },
+        },
+      },
+    });
+
+    await page.goto(newCardURL);
+
+    await expect(
+      page.locator('[data-test-scoped-style-restored]'),
+    ).toHaveCSS('background-color', 'rgb(1, 2, 3)');
+
+    await logout(page);
+    await login(page, username, password, { url: newCardURL });
+
+    await expect(
+      page.locator('[data-test-scoped-style-restored]'),
+    ).toHaveCSS('background-color', 'rgb(1, 2, 3)');
   });
 });

--- a/packages/matrix/tests/glimmer-scoped-css.spec.ts
+++ b/packages/matrix/tests/glimmer-scoped-css.spec.ts
@@ -13,8 +13,6 @@ import {
 test.describe('glimmer-scoped-css', () => {
   const serverIndexUrl = new URL(appURL).origin;
 
-  let newCardURL: string;
-
   test(':global is ignored and does not affect styles', async ({ page }) => {
     const realmName = 'realm1';
     await clearLocalStorage(page, serverIndexUrl);
@@ -48,7 +46,7 @@ test.describe('glimmer-scoped-css', () => {
       }`,
     );
 
-    newCardURL = await postNewCard(page, realmURL, {
+    let newCardURL = await postNewCard(page, realmURL, {
       data: {
         type: 'card',
         attributes: {
@@ -105,7 +103,7 @@ test.describe('glimmer-scoped-css', () => {
       }`,
     );
 
-    newCardURL = await postNewCard(page, realmURL, {
+    let newCardURL = await postNewCard(page, realmURL, {
       data: {
         type: 'card',
         attributes: {
@@ -123,15 +121,17 @@ test.describe('glimmer-scoped-css', () => {
 
     await page.goto(newCardURL);
 
-    await expect(
-      page.locator('[data-test-scoped-style-restored]'),
-    ).toHaveCSS('background-color', 'rgb(1, 2, 3)');
+    await expect(page.locator('[data-test-scoped-style-restored]')).toHaveCSS(
+      'background-color',
+      'rgb(1, 2, 3)',
+    );
 
     await logout(page);
     await login(page, username, password, { url: newCardURL });
 
-    await expect(
-      page.locator('[data-test-scoped-style-restored]'),
-    ).toHaveCSS('background-color', 'rgb(1, 2, 3)');
+    await expect(page.locator('[data-test-scoped-style-restored]')).toHaveCSS(
+      'background-color',
+      'rgb(1, 2, 3)',
+    );
   });
 });

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -68,8 +68,6 @@ import {
 import handleWebhookReceiverRequest from './handlers/handle-webhook-receiver';
 import { buildCreatePrerenderAuth } from './prerender/auth';
 
-const nodeRequire = createRequire(__filename);
-
 export type CreateRoutesArgs = {
   serverURL: string;
   dbAdapter: DBAdapter;

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -68,7 +68,7 @@ import {
 import handleWebhookReceiverRequest from './handlers/handle-webhook-receiver';
 import { buildCreatePrerenderAuth } from './prerender/auth';
 
-const require = createRequire(__filename);
+const nodeRequire = createRequire(__filename);
 
 export type CreateRoutesArgs = {
   serverURL: string;
@@ -349,7 +349,9 @@ function handleGitHubPRRequestLazy(args: CreateRoutesArgs) {
   return async function (ctxt: Koa.Context, next: Koa.Next) {
     if (!handler) {
       handler = (
-        require('./handlers/handle-github-pr') as typeof import('./handlers/handle-github-pr')
+        createRequire(__filename)(
+          './handlers/handle-github-pr',
+        ) as typeof import('./handlers/handle-github-pr')
       ).default(args);
     }
     return await handler(ctxt, next);

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -9,6 +9,7 @@ import type {
 } from '@cardstack/runtime-common';
 import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import Router from '@koa/router';
+import { createRequire } from 'module';
 import handleCreateSessionRequest from './handlers/handle-create-session';
 import handleCreateRealmRequest from './handlers/handle-create-realm';
 import handleFetchCatalogRealmsRequest from './handlers/handle-fetch-catalog-realms';
@@ -43,7 +44,6 @@ import handleSearchPrerendered from './handlers/handle-search-prerendered';
 import handleRealmInfo from './handlers/handle-realm-info';
 import handleFederatedTypes from './handlers/handle-federated-types';
 import { multiRealmAuthorization } from './middleware/multi-realm-authorization';
-import handleGitHubPRRequest from './handlers/handle-github-pr';
 import handleDownloadRealm from './handlers/handle-download-realm';
 import {
   handleBotRegistrationRequest,
@@ -67,6 +67,8 @@ import {
 } from './handlers/handle-webhook-commands';
 import handleWebhookReceiverRequest from './handlers/handle-webhook-receiver';
 import { buildCreatePrerenderAuth } from './prerender/auth';
+
+const require = createRequire(__filename);
 
 export type CreateRoutesArgs = {
   serverURL: string;
@@ -264,11 +266,15 @@ export function createRoutes(args: CreateRoutesArgs) {
     jwtMiddleware(args.realmSecretSeed),
     handleDeleteBoxelClaimedDomainRequest(args),
   );
-  router.post(
-    '/_github-pr',
-    jwtMiddleware(args.realmSecretSeed),
-    handleGitHubPRRequest(args),
-  );
+  // Matrix tests don't need the GitHub PR integration, and skipping this route
+  // keeps the realm server from loading Octokit's ESM entrypoint during boot.
+  if (process.env.DISABLE_GITHUB_PR_ROUTE !== 'true') {
+    router.post(
+      '/_github-pr',
+      jwtMiddleware(args.realmSecretSeed),
+      handleGitHubPRRequestLazy(args),
+    );
+  }
   router.get('/_download-realm', handleDownloadRealm(args));
   router.post(
     '/_bot-registration',
@@ -333,4 +339,19 @@ export function createRoutes(args: CreateRoutesArgs) {
   router.post('/_webhooks/:webhookPath', handleWebhookReceiverRequest(args));
 
   return router.routes();
+}
+
+function handleGitHubPRRequestLazy(args: CreateRoutesArgs) {
+  let handler:
+    | ((ctxt: Koa.Context, next: Koa.Next) => Promise<void>)
+    | undefined;
+
+  return async function (ctxt: Koa.Context, next: Koa.Next) {
+    if (!handler) {
+      handler = (
+        require('./handlers/handle-github-pr') as typeof import('./handlers/handle-github-pr')
+      ).default(args);
+    }
+    return await handler(ctxt, next);
+  };
 }


### PR DESCRIPTION
This fixes an issue that was introduced as part of memory optimization where scoped glimmer styles were after logging out and logging back in again. the issue was that we manually dropped the DOM, but the import that introduced the style was still cached between user sessions. 