### PR TITLE
Add clearSessionRoom function and tests for stale session room handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -481,6 +481,7 @@ jobs:
             "runtime-dependency-tracker-test.ts",
             "transpile-test.ts",
             "module-syntax-test.ts",
+            "node-realm-test.ts",
             "permissions/permission-checker-test.ts",
             "prerendering-test.ts",
             "prerender-server-test.ts",

--- a/packages/realm-server/node-realm.ts
+++ b/packages/realm-server/node-realm.ts
@@ -318,11 +318,23 @@ export class NodeAdapter implements RealmAdapter {
         );
       } catch (e) {
         if (isRealmServerNotInRoomError(e, roomId)) {
-          let cleared = await clearSessionRoom(dbAdapter, userId, roomId);
-          realmEventsLog.warn(
-            `Skipping stale session room ${roomId} for user ${userId}; realm server is no longer in the room`,
-            { cleared, realmUrl },
-          );
+          try {
+            let cleared = await clearSessionRoom(dbAdapter, userId, roomId);
+            realmEventsLog.warn(
+              `Skipping stale session room ${roomId} for user ${userId}; realm server is no longer in the room`,
+              { cleared, realmUrl },
+            );
+          } catch (cleanupError) {
+            realmEventsLog.error(
+              `Failed to clear stale session room ${roomId} for user ${userId}`,
+              cleanupError,
+            );
+            realmEventsLog.error(
+              `Unable to send event in room ${roomId} for user ${userId}`,
+              event,
+              e,
+            );
+          }
           continue;
         }
         realmEventsLog.error(

--- a/packages/realm-server/node-realm.ts
+++ b/packages/realm-server/node-realm.ts
@@ -10,6 +10,7 @@ import {
   unixTime,
   type ResponseWithNodeStream,
   type TokenClaims,
+  clearSessionRoom,
   fetchRealmSessionRooms,
 } from '@cardstack/runtime-common';
 import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
@@ -42,6 +43,40 @@ import { APP_BOXEL_REALM_EVENT_TYPE } from '@cardstack/runtime-common/matrix-con
 import { createJWT, verifyJWT } from './jwt';
 
 const realmEventsLog = logger('realm:events');
+
+function parseMatrixSendEventError(error: unknown): {
+  status?: number;
+  errcode?: string;
+  error?: string;
+} | null {
+  if (!(error instanceof Error)) {
+    return null;
+  }
+
+  let match = error.message.match(/status (\d+) - (\{.*\})$/);
+  if (!match) {
+    return null;
+  }
+
+  let [, status, body] = match;
+  try {
+    return {
+      status: Number(status),
+      ...(JSON.parse(body) as { errcode?: string; error?: string }),
+    };
+  } catch (_err) {
+    return { status: Number(status) };
+  }
+}
+
+function isRealmServerNotInRoomError(error: unknown, roomId: string): boolean {
+  let details = parseMatrixSendEventError(error);
+  return Boolean(
+    details?.status === 403 &&
+    details?.errcode === 'M_FORBIDDEN' &&
+    details?.error?.includes(`not in room ${roomId}`),
+  );
+}
 
 export class NodeAdapter implements RealmAdapter {
   constructor(
@@ -282,6 +317,14 @@ export class NodeAdapter implements RealmAdapter {
           eventWithRealmURL,
         );
       } catch (e) {
+        if (isRealmServerNotInRoomError(e, roomId)) {
+          let cleared = await clearSessionRoom(dbAdapter, userId, roomId);
+          realmEventsLog.warn(
+            `Skipping stale session room ${roomId} for user ${userId}; realm server is no longer in the room`,
+            { cleared, realmUrl },
+          );
+          continue;
+        }
         realmEventsLog.error(
           `Unable to send event in room ${roomId} for user ${userId}`,
           event,

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -179,4 +179,5 @@ import './queries-test';
 import './remote-prerenderer-test';
 import './runtime-dependency-tracker-test';
 import './sanitize-head-html-test';
+import './node-realm-test';
 import './session-room-queries-test';

--- a/packages/realm-server/tests/node-realm-test.ts
+++ b/packages/realm-server/tests/node-realm-test.ts
@@ -107,4 +107,40 @@ module(basename(__filename), function (hooks) {
       'leaves the stored session room alone for other send errors',
     );
   });
+
+  test('does not reject when clearing a stale session room fails', async function (assert) {
+    await insertSessionForAlice();
+    let originalExecute = dbAdapter.execute.bind(dbAdapter);
+    let failCleanup = false;
+    dbAdapter.execute = (async (
+      ...args: Parameters<typeof dbAdapter.execute>
+    ) => {
+      if (failCleanup) {
+        throw new Error('boom');
+      }
+      return await originalExecute(...args);
+    }) as typeof dbAdapter.execute;
+
+    let matrixClient = {
+      login: async () => undefined,
+      getUserId: () => '@realm_server:localhost',
+      sendEvent: async () => {
+        failCleanup = true;
+        throw new Error(
+          `Unable to send room event 'app.boxel.realm-event' to room ${staleRoomId}: status 403 - {"errcode":"M_FORBIDDEN","error":"User @realm_server:localhost not in room ${staleRoomId}"}`,
+        );
+      },
+    } as unknown as MatrixClient;
+
+    let adapter = new NodeAdapter('/tmp');
+
+    await adapter.broadcastRealmEvent(
+      makeEvent(),
+      realmURL.href,
+      matrixClient,
+      dbAdapter,
+    );
+
+    assert.true(true, 'broadcast resolves even if stale room cleanup fails');
+  });
 });

--- a/packages/realm-server/tests/node-realm-test.ts
+++ b/packages/realm-server/tests/node-realm-test.ts
@@ -1,0 +1,110 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import type { PgAdapter } from '@cardstack/postgres';
+import {
+  fetchSessionRoom,
+  insertPermissions,
+  upsertSessionRoom,
+} from '@cardstack/runtime-common';
+import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
+import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
+import { NodeAdapter } from '../node-realm';
+import { insertUser, setupDB } from './helpers';
+
+module(basename(__filename), function (hooks) {
+  let dbAdapter: PgAdapter;
+  const realmURL = new URL('http://127.0.0.1:4444/test/');
+  const staleRoomId = '!room-alice:localhost';
+
+  setupDB(hooks, {
+    beforeEach: async (_dbAdapter) => {
+      dbAdapter = _dbAdapter;
+    },
+  });
+
+  async function insertSessionForAlice() {
+    await insertUser(
+      dbAdapter,
+      '@alice:localhost',
+      'cus_alice',
+      'alice@example.com',
+    );
+    await upsertSessionRoom(dbAdapter, '@alice:localhost', staleRoomId);
+    await insertPermissions(dbAdapter, realmURL, {
+      '@alice:localhost': ['read'],
+    });
+  }
+
+  function makeEvent(): RealmEventContent {
+    return {
+      eventName: 'index',
+      indexType: 'incremental',
+      invalidations: [`${realmURL.href}card`],
+      clientRequestId: null,
+      realmURL: realmURL.href,
+    };
+  }
+
+  test('clears a stale session room when the realm server is no longer in it', async function (assert) {
+    await insertSessionForAlice();
+
+    let sendEventCalls = 0;
+    let matrixClient = {
+      login: async () => undefined,
+      getUserId: () => '@realm_server:localhost',
+      sendEvent: async () => {
+        sendEventCalls++;
+        throw new Error(
+          `Unable to send room event 'app.boxel.realm-event' to room ${staleRoomId}: status 403 - {"errcode":"M_FORBIDDEN","error":"User @realm_server:localhost not in room ${staleRoomId}"}`,
+        );
+      },
+    } as unknown as MatrixClient;
+
+    let adapter = new NodeAdapter('/tmp');
+    await adapter.broadcastRealmEvent(
+      makeEvent(),
+      realmURL.href,
+      matrixClient,
+      dbAdapter,
+    );
+
+    assert.strictEqual(
+      sendEventCalls,
+      1,
+      'attempted to send to the stale room',
+    );
+    assert.strictEqual(
+      await fetchSessionRoom(dbAdapter, '@alice:localhost'),
+      null,
+      'clears the stale session room from the user record',
+    );
+  });
+
+  test('keeps the session room when the send failure is unrelated', async function (assert) {
+    await insertSessionForAlice();
+
+    let matrixClient = {
+      login: async () => undefined,
+      getUserId: () => '@realm_server:localhost',
+      sendEvent: async () => {
+        throw new Error(
+          `Unable to send room event 'app.boxel.realm-event' to room ${staleRoomId}: status 500 - {"errcode":"M_UNKNOWN","error":"boom"}`,
+        );
+      },
+    } as unknown as MatrixClient;
+
+    let adapter = new NodeAdapter('/tmp');
+    await adapter.broadcastRealmEvent(
+      makeEvent(),
+      realmURL.href,
+      matrixClient,
+      dbAdapter,
+    );
+
+    assert.strictEqual(
+      await fetchSessionRoom(dbAdapter, '@alice:localhost'),
+      staleRoomId,
+      'leaves the stored session room alone for other send errors',
+    );
+  });
+});

--- a/packages/realm-server/tests/session-room-queries-test.ts
+++ b/packages/realm-server/tests/session-room-queries-test.ts
@@ -3,6 +3,8 @@ import { basename } from 'path';
 import type { PgAdapter } from '@cardstack/postgres';
 import { insertPermissions } from '@cardstack/runtime-common';
 import {
+  clearSessionRoom,
+  fetchSessionRoom,
   fetchRealmSessionRooms,
   upsertSessionRoom,
 } from '@cardstack/runtime-common/db-queries/session-room-queries';
@@ -381,6 +383,72 @@ module(basename(__filename), function () {
         result['@bob:localhost'],
         '!room-bob:localhost',
         'bob is included via world-readable access',
+      );
+    });
+  });
+
+  module('clearSessionRoom', function (hooks) {
+    let dbAdapter: PgAdapter;
+
+    setupDB(hooks, {
+      beforeEach: async (_dbAdapter) => {
+        dbAdapter = _dbAdapter;
+      },
+    });
+
+    test('clears the stored session room when it matches', async function (assert) {
+      await insertUser(
+        dbAdapter,
+        '@alice:localhost',
+        'cus_alice',
+        'alice@example.com',
+      );
+      await upsertSessionRoom(
+        dbAdapter,
+        '@alice:localhost',
+        '!room-alice:localhost',
+      );
+
+      let cleared = await clearSessionRoom(
+        dbAdapter,
+        '@alice:localhost',
+        '!room-alice:localhost',
+      );
+
+      assert.true(cleared, 'reports that the room was cleared');
+      let remainingRoom = await fetchSessionRoom(dbAdapter, '@alice:localhost');
+      assert.strictEqual(
+        remainingRoom,
+        null,
+        'stored session room is removed from the user record',
+      );
+    });
+
+    test('does not clear the stored session room when the room id does not match', async function (assert) {
+      await insertUser(
+        dbAdapter,
+        '@alice:localhost',
+        'cus_alice',
+        'alice@example.com',
+      );
+      await upsertSessionRoom(
+        dbAdapter,
+        '@alice:localhost',
+        '!room-alice:localhost',
+      );
+
+      let cleared = await clearSessionRoom(
+        dbAdapter,
+        '@alice:localhost',
+        '!different-room:localhost',
+      );
+
+      assert.false(cleared, 'reports that nothing was cleared');
+      let remainingRoom = await fetchSessionRoom(dbAdapter, '@alice:localhost');
+      assert.strictEqual(
+        remainingRoom,
+        '!room-alice:localhost',
+        'stored session room is left untouched',
       );
     });
   });

--- a/packages/runtime-common/db-queries/session-room-queries.ts
+++ b/packages/runtime-common/db-queries/session-room-queries.ts
@@ -46,6 +46,27 @@ export async function upsertSessionRoom(
 }
 
 /**
+ * Clears the stored session room id for the given matrix user if it still
+ * matches the provided room id. Returns true when a row was updated.
+ */
+export async function clearSessionRoom(
+  dbAdapter: DBAdapter,
+  matrixUserId: string,
+  roomId: string,
+) {
+  let rows = await query(dbAdapter, [
+    'UPDATE users SET session_room_id = NULL',
+    'WHERE matrix_user_id =',
+    param(matrixUserId),
+    'AND session_room_id =',
+    param(roomId),
+    'RETURNING id',
+  ]);
+
+  return rows.length > 0;
+}
+
+/**
  * Returns a mapping of matrix user id to session room id for all known sessions
  * that should be notified about changes to the given realm.
  *


### PR DESCRIPTION
## Summary
- Stop repeated realm event broadcast failures caused by stale Matrix session room ids.
- Detect the specific `M_FORBIDDEN` "realm server not in room" send error during `broadcastRealmEvent`.
- Clear the stored `users.session_room_id` for that user/room pair so future index broadcasts stop targeting an invalid room.
- Add regression tests for both the DB helper and the realm-server broadcast cleanup path.
- Register the new realm-server test in the CI shard list.

## Problem
After from-scratch indexing, realm-server could try to broadcast incremental index events into per-user session DM rooms that no longer included `@realm_server:localhost`. Those stale `session_room_id` values remained in the database, so every later broadcast retried the same dead room and logged repeated `403 M_FORBIDDEN` errors.

## Fix
When Matrix rejects a send with the specific "user not in room" error, realm-server now treats that room mapping as stale and removes it from the user record. This keeps the existing design intact, where realm events are delivered through per-user session DMs, while preventing endless retries against rooms the service account has already left or lost access to.
