### PR TITLE
worker: Add indexing dashboard in development

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -477,6 +477,7 @@ jobs:
             "card-source-endpoints-test.ts",
             "definition-lookup-test.ts",
             "file-watcher-events-test.ts",
+            "indexing-event-sink-test.ts",
             "indexing-test.ts",
             "runtime-dependency-tracker-test.ts",
             "transpile-test.ts",

--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Instead of running `pnpm start:base`, you can alternatively use `pnpm start:all`
 
 You can also use `start:development` if you want the functionality of `start:all`, but without running the test realms. `start:development` will enable you to open http://localhost:4201 and allow to select between the cards in the /base and /experiments realm. In order to use `start:development` you must also make sure to run `start:worker-development` in order to start the workers which are normally started in `start:all`.
 
+#### Indexing dashboard
+
+In development, you can visit an indexing dashboard at [`http://localhost:4210/_indexing-dashboard`](http://localhost:4210/_indexing-dashboard) to view the status of all active indexing jobs across all workers.
+
+In environment mode, this is at `http://worker.environment-name.localhost/_indexing-dashboard`.
+
 ### Card Pre-rendering
 
 Boxel supports server-side rendering of cards via a lightweight prerender service and an optional manager that coordinates multiple services.

--- a/packages/realm-server/handlers/handle-indexing-dashboard.ts
+++ b/packages/realm-server/handlers/handle-indexing-dashboard.ts
@@ -1,5 +1,13 @@
 import type { RealmIndexingState } from '../indexing-event-sink';
 
+export interface PendingJob {
+  jobId: number;
+  jobType: string;
+  realmURL: string;
+  createdAt: string;
+  priority: number;
+}
+
 function escapeHtml(str: string): string {
   return str
     .replace(/&/g, '&amp;')
@@ -102,16 +110,29 @@ function renderHistoryRow(state: RealmIndexingState): string {
     </tr>`;
 }
 
+function renderPendingRow(job: PendingJob): string {
+  let createdAt = new Date(job.createdAt);
+  return `
+    <tr>
+      <td>${job.jobId}</td>
+      <td>${escapeHtml(job.jobType)}</td>
+      <td class="realm-url-cell" title="${escapeHtml(job.realmURL)}">${escapeHtml(job.realmURL)}</td>
+      <td>${job.priority}</td>
+      <td>${timeSince(createdAt.getTime())}</td>
+    </tr>`;
+}
+
 export interface DashboardSnapshot {
   active: RealmIndexingState[];
+  pending: PendingJob[];
   history: RealmIndexingState[];
 }
 
 export function renderIndexingDashboard(snapshot: DashboardSnapshot): string {
-  let { active, history } = snapshot;
+  let { active, pending, history } = snapshot;
 
   let activeCards = active.map(renderActiveCard).join('');
-
+  let pendingRows = pending.map(renderPendingRow).join('');
   let historyRows = history.map(renderHistoryRow).join('');
 
   return `<!DOCTYPE html>
@@ -336,6 +357,10 @@ export function renderIndexingDashboard(snapshot: DashboardSnapshot): string {
       <div class="value">${active.length}</div>
       <div class="label">Active Jobs</div>
     </div>
+    <div class="summary-item${pending.length > 0 ? ' alert' : ''}">
+      <div class="value">${pending.length}</div>
+      <div class="label">Pending Jobs</div>
+    </div>
     <div class="summary-item">
       <div class="value">${active.reduce((s, a) => s + (a.totalFiles - a.filesCompleted), 0)}</div>
       <div class="label">Files Remaining</div>
@@ -348,6 +373,26 @@ export function renderIndexingDashboard(snapshot: DashboardSnapshot): string {
 
   <h2>Active Indexing</h2>
   ${activeCards.length > 0 ? `<div class="realm-grid">${activeCards}</div>` : '<div class="empty-state">No active indexing jobs</div>'}
+
+  <h2>Pending Jobs</h2>
+  ${
+    pending.length > 0
+      ? `<div class="table-wrapper">
+    <table>
+      <thead>
+        <tr>
+          <th>Job</th>
+          <th>Type</th>
+          <th>Realm</th>
+          <th>Priority</th>
+          <th>Queued</th>
+        </tr>
+      </thead>
+      <tbody>${pendingRows}</tbody>
+    </table>
+  </div>`
+      : '<div class="empty-state">No pending jobs</div>'
+  }
 
   <h2>Recent Completed</h2>
   ${

--- a/packages/realm-server/handlers/handle-indexing-dashboard.ts
+++ b/packages/realm-server/handlers/handle-indexing-dashboard.ts
@@ -41,9 +41,8 @@ function renderActiveCard(state: RealmIndexingState): string {
       ? Math.round((state.filesCompleted / state.totalFiles) * 100)
       : 0;
 
-  let remainingFiles = state.files.filter(
-    (f) => !state.completedFiles.includes(f),
-  );
+  const completedSet = new Set(state.completedFiles);
+  let remainingFiles = state.files.filter((f) => !completedSet.has(f));
   let remainingList = remainingFiles
     .map((f) => `<li>${escapeHtml(f)}</li>`)
     .join('');

--- a/packages/realm-server/handlers/handle-indexing-dashboard.ts
+++ b/packages/realm-server/handlers/handle-indexing-dashboard.ts
@@ -1,6 +1,3 @@
-import type Koa from 'koa';
-import { setContextResponse } from '../middleware';
-import type { CreateRoutesArgs } from '../routes';
 import type { RealmIndexingState } from '../indexing-event-sink';
 
 function escapeHtml(str: string): string {
@@ -396,25 +393,4 @@ export function renderIndexingDashboard(snapshot: DashboardSnapshot): string {
   </script>
 </body>
 </html>`;
-}
-
-// This handler is for the realm server route (dev-only, proxies to worker-manager or renders empty)
-export default function handleIndexingDashboard(
-  _args: CreateRoutesArgs,
-): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
-  return async function (ctxt: Koa.Context, _next: Koa.Next) {
-    let html = renderIndexingDashboard({ active: [], history: [] });
-    return setContextResponse(
-      ctxt,
-      new Response(
-        html.replace(
-          '<h1>Indexing Dashboard</h1>',
-          '<h1>Indexing Dashboard</h1><p style="color:#f0883e;margin-bottom:16px">This endpoint is on the realm server. The live dashboard is served by the worker manager on its HTTP port.</p>',
-        ),
-        {
-          headers: { 'content-type': 'text/html; charset=utf-8' },
-        },
-      ),
-    );
-  };
 }

--- a/packages/realm-server/handlers/handle-indexing-dashboard.ts
+++ b/packages/realm-server/handlers/handle-indexing-dashboard.ts
@@ -1,128 +1,7 @@
 import type Koa from 'koa';
-import { query } from '@cardstack/runtime-common';
 import { setContextResponse } from '../middleware';
 import type { CreateRoutesArgs } from '../routes';
-
-interface IndexingJob {
-  id: number;
-  job_type: string;
-  concurrency_group: string | null;
-  status: string;
-  priority: number;
-  args: Record<string, unknown> | null;
-  created_at: string;
-  finished_at: string | null;
-  result: Record<string, unknown> | null;
-  worker_id: string | null;
-  reservation_started: string | null;
-  locked_until: string | null;
-}
-
-interface RealmIndexInfo {
-  realm_url: string;
-  total_entries: number;
-  instances: number;
-  files: number;
-  errors: number;
-}
-
-interface WorkingEntry {
-  realm_url: string;
-  working_count: number;
-}
-
-async function getIndexingData(dbAdapter: CreateRoutesArgs['dbAdapter']) {
-  let [activeJobs, recentJobs, realmIndex, workingEntries] = await Promise.all([
-    // Active/pending indexing jobs with reservation info
-    query(dbAdapter, [
-      `SELECT
-        j.id, j.job_type, j.concurrency_group, j.status, j.priority,
-        j.args, j.created_at, j.finished_at, j.result,
-        jr.worker_id, jr.created_at as reservation_started, jr.locked_until
-      FROM jobs j
-      LEFT JOIN job_reservations jr ON jr.job_id = j.id AND jr.completed_at IS NULL
-      WHERE j.job_type IN ('from-scratch-index', 'incremental-index', 'copy-index')
-        AND j.status = 'unfulfilled'
-      ORDER BY j.priority DESC, j.created_at`,
-    ]) as unknown as IndexingJob[],
-
-    // Recent completed jobs
-    query(dbAdapter, [
-      `SELECT
-        j.id, j.job_type, j.concurrency_group, j.status, j.priority,
-        j.args, j.created_at, j.finished_at, j.result,
-        NULL as worker_id, NULL as reservation_started, NULL as locked_until
-      FROM jobs j
-      WHERE j.job_type IN ('from-scratch-index', 'incremental-index', 'copy-index')
-        AND j.status IN ('resolved', 'rejected')
-      ORDER BY j.finished_at DESC
-      LIMIT 50`,
-    ]) as unknown as IndexingJob[],
-
-    // Index entry counts per realm
-    query(dbAdapter, [
-      `SELECT
-        realm_url,
-        CAST(COUNT(*) AS INTEGER) as total_entries,
-        CAST(COUNT(*) FILTER (WHERE type = 'instance') AS INTEGER) as instances,
-        CAST(COUNT(*) FILTER (WHERE type = 'file') AS INTEGER) as files,
-        CAST(COUNT(*) FILTER (WHERE has_error = true) AS INTEGER) as errors
-      FROM boxel_index
-      WHERE is_deleted IS NOT TRUE
-      GROUP BY realm_url
-      ORDER BY realm_url`,
-    ]) as unknown as RealmIndexInfo[],
-
-    // Working entries per realm (shows in-progress batch work)
-    query(dbAdapter, [
-      `SELECT
-        realm_url,
-        CAST(COUNT(*) AS INTEGER) as working_count
-      FROM boxel_index_working
-      GROUP BY realm_url`,
-    ]) as unknown as WorkingEntry[],
-  ]);
-
-  return { activeJobs, recentJobs, realmIndex, workingEntries };
-}
-
-function extractRealmURL(job: IndexingJob): string {
-  if (job.args && typeof job.args === 'object' && 'realmURL' in job.args) {
-    return job.args.realmURL as string;
-  }
-  if (job.concurrency_group) {
-    return job.concurrency_group.replace('indexing:', '');
-  }
-  return 'unknown';
-}
-
-function extractChanges(job: IndexingJob): string[] {
-  if (
-    job.args &&
-    typeof job.args === 'object' &&
-    'changes' in job.args &&
-    Array.isArray(job.args.changes)
-  ) {
-    return job.args.changes.map(
-      (c: { url: string; operation: string }) =>
-        `${c.operation}: ${c.url}`,
-    );
-  }
-  return [];
-}
-
-function extractStats(
-  job: IndexingJob,
-): Record<string, unknown> | null {
-  if (
-    job.result &&
-    typeof job.result === 'object' &&
-    'stats' in job.result
-  ) {
-    return job.result.stats as Record<string, unknown>;
-  }
-  return null;
-}
+import type { RealmIndexingState } from '../indexing-event-sink';
 
 function escapeHtml(str: string): string {
   return str
@@ -132,29 +11,21 @@ function escapeHtml(str: string): string {
     .replace(/"/g, '&quot;');
 }
 
-function timeSince(dateStr: string): string {
-  let date = new Date(dateStr);
-  let seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+function timeSince(ms: number): string {
+  let seconds = Math.floor((Date.now() - ms) / 1000);
   if (seconds < 60) {
     return `${seconds}s ago`;
   }
   let minutes = Math.floor(seconds / 60);
   if (minutes < 60) {
-    return `${minutes}m ago`;
+    return `${minutes}m ${seconds % 60}s ago`;
   }
   let hours = Math.floor(minutes / 60);
-  if (hours < 24) {
-    return `${hours}h ${minutes % 60}m ago`;
-  }
-  let days = Math.floor(hours / 24);
-  return `${days}d ago`;
+  return `${hours}h ${minutes % 60}m ago`;
 }
 
-function duration(startStr: string, endStr: string | null): string {
-  if (!endStr) {
-    return 'in progress';
-  }
-  let ms = new Date(endStr).getTime() - new Date(startStr).getTime();
+function durationMs(startMs: number, endMs?: number): string {
+  let ms = (endMs ?? Date.now()) - startMs;
   if (ms < 1000) {
     return `${ms}ms`;
   }
@@ -166,156 +37,86 @@ function duration(startStr: string, endStr: string | null): string {
   return `${minutes}m ${seconds % 60}s`;
 }
 
-function renderDashboard(data: Awaited<ReturnType<typeof getIndexingData>>): string {
-  let { activeJobs, recentJobs, realmIndex, workingEntries } = data;
+function renderActiveCard(state: RealmIndexingState): string {
+  let remaining = state.totalFiles - state.filesCompleted;
+  let pct =
+    state.totalFiles > 0
+      ? Math.round((state.filesCompleted / state.totalFiles) * 100)
+      : 0;
 
-  let workingMap = new Map(
-    workingEntries.map((w) => [w.realm_url, w.working_count]),
+  let remainingFiles = state.files.filter(
+    (f) => !state.completedFiles.includes(f),
   );
+  let remainingList = remainingFiles
+    .map((f) => `<li>${escapeHtml(f)}</li>`)
+    .join('');
+  let completedList = state.completedFiles
+    .map((f) => `<li class="completed">${escapeHtml(f)}</li>`)
+    .join('');
 
-  // Group active jobs by realm
-  let activeByRealm = new Map<string, IndexingJob[]>();
-  for (let job of activeJobs) {
-    let realmURL = extractRealmURL(job);
-    let jobs = activeByRealm.get(realmURL) || [];
-    jobs.push(job);
-    activeByRealm.set(realmURL, jobs);
-  }
-
-  // Build realm status cards
-  let realmCards = realmIndex
-    .map((realm) => {
-      let active = activeByRealm.get(realm.realm_url) || [];
-      let working = workingMap.get(realm.realm_url) || 0;
-      let isIndexing = active.length > 0;
-      let statusClass = isIndexing ? 'indexing' : 'idle';
-
-      let activeJobsHtml = '';
-      if (active.length > 0) {
-        activeJobsHtml = active
-          .map((job) => {
-            let changes = extractChanges(job);
-            let jobTypeLabel = job.job_type.replace('-', ' ');
-            let startedInfo = job.reservation_started
-              ? `started ${timeSince(job.reservation_started)}`
-              : `queued ${timeSince(job.created_at)}`;
-            let workerInfo = job.worker_id
-              ? ` (worker: ${escapeHtml(job.worker_id.substring(0, 8))})`
-              : '';
-
-            let changesHtml = '';
-            if (changes.length > 0) {
-              let changesList = changes
-                .map((c) => `<li>${escapeHtml(c)}</li>`)
-                .join('');
-              changesHtml = `
-                <details>
-                  <summary>${changes.length} file${changes.length !== 1 ? 's' : ''} to process</summary>
-                  <ul class="file-list">${changesList}</ul>
-                </details>`;
-            }
-
-            return `
-              <div class="job-card">
-                <div class="job-header">
-                  <span class="job-type">${escapeHtml(jobTypeLabel)}</span>
-                  <span class="job-meta">${escapeHtml(startedInfo)}${escapeHtml(workerInfo)}</span>
-                </div>
-                ${changesHtml}
-                ${working > 0 ? `<div class="progress-info">${working} entries written to working index</div>` : ''}
-              </div>`;
-          })
-          .join('');
+  return `
+    <div class="realm-card indexing">
+      <div class="realm-header">
+        <span class="status-indicator"></span>
+        <h3>${escapeHtml(state.realmURL)}</h3>
+      </div>
+      <div class="job-info">
+        <span class="job-type">${escapeHtml(state.jobType)} index</span>
+        <span class="job-meta">job #${state.jobId} &middot; started ${timeSince(state.startedAt)} &middot; ${durationMs(state.startedAt)} elapsed</span>
+      </div>
+      <div class="progress-bar-container">
+        <div class="progress-bar" style="width: ${pct}%"></div>
+        <span class="progress-text">${state.filesCompleted} / ${state.totalFiles} files (${pct}%)</span>
+      </div>
+      <div class="remaining-count">${remaining} file${remaining !== 1 ? 's' : ''} remaining</div>
+      ${
+        remainingFiles.length > 0
+          ? `<details>
+        <summary>${remaining} file${remaining !== 1 ? 's' : ''} left to index</summary>
+        <ul class="file-list">${remainingList}</ul>
+      </details>`
+          : ''
       }
+      ${
+        state.completedFiles.length > 0
+          ? `<details>
+        <summary>${state.filesCompleted} file${state.filesCompleted !== 1 ? 's' : ''} completed</summary>
+        <ul class="file-list">${completedList}</ul>
+      </details>`
+          : ''
+      }
+    </div>`;
+}
 
-      return `
-        <div class="realm-card ${statusClass}">
-          <div class="realm-header">
-            <span class="status-indicator"></span>
-            <h3>${escapeHtml(realm.realm_url)}</h3>
-          </div>
-          <div class="realm-stats">
-            <span class="stat"><strong>${realm.total_entries}</strong> entries</span>
-            <span class="stat"><strong>${realm.instances}</strong> instances</span>
-            <span class="stat"><strong>${realm.files}</strong> files</span>
-            ${realm.errors > 0 ? `<span class="stat error"><strong>${realm.errors}</strong> errors</span>` : ''}
-          </div>
-          ${activeJobsHtml}
-        </div>`;
-    })
-    .join('');
+function renderHistoryRow(state: RealmIndexingState): string {
+  let statsHtml = state.stats
+    ? Object.entries(state.stats)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join(', ')
+    : '';
+  return `
+    <tr>
+      <td>${state.jobId}</td>
+      <td>${escapeHtml(state.jobType)}</td>
+      <td class="realm-url-cell" title="${escapeHtml(state.realmURL)}">${escapeHtml(state.realmURL)}</td>
+      <td>${state.totalFiles}</td>
+      <td>${durationMs(state.startedAt, state.lastUpdatedAt)}</td>
+      <td>${timeSince(state.lastUpdatedAt)}</td>
+      <td class="stats-cell">${escapeHtml(statsHtml)}</td>
+    </tr>`;
+}
 
-  // Also show realms that have active jobs but no index entries yet
-  for (let [realmURL, jobs] of activeByRealm) {
-    if (!realmIndex.find((r) => r.realm_url === realmURL)) {
-      let working = workingMap.get(realmURL) || 0;
-      let jobsHtml = jobs
-        .map((job) => {
-          let jobTypeLabel = job.job_type.replace('-', ' ');
-          let startedInfo = job.reservation_started
-            ? `started ${timeSince(job.reservation_started)}`
-            : `queued ${timeSince(job.created_at)}`;
-          let changes = extractChanges(job);
-          let changesHtml = '';
-          if (changes.length > 0) {
-            let changesList = changes
-              .map((c) => `<li>${escapeHtml(c)}</li>`)
-              .join('');
-            changesHtml = `
-              <details>
-                <summary>${changes.length} file${changes.length !== 1 ? 's' : ''} to process</summary>
-                <ul class="file-list">${changesList}</ul>
-              </details>`;
-          }
-          return `
-            <div class="job-card">
-              <div class="job-header">
-                <span class="job-type">${escapeHtml(jobTypeLabel)}</span>
-                <span class="job-meta">${escapeHtml(startedInfo)}</span>
-              </div>
-              ${changesHtml}
-              ${working > 0 ? `<div class="progress-info">${working} entries written to working index</div>` : ''}
-            </div>`;
-        })
-        .join('');
+export interface DashboardSnapshot {
+  active: RealmIndexingState[];
+  history: RealmIndexingState[];
+}
 
-      realmCards += `
-        <div class="realm-card indexing">
-          <div class="realm-header">
-            <span class="status-indicator"></span>
-            <h3>${escapeHtml(realmURL)}</h3>
-          </div>
-          <div class="realm-stats">
-            <span class="stat"><strong>0</strong> entries (new index)</span>
-          </div>
-          ${jobsHtml}
-        </div>`;
-    }
-  }
+export function renderIndexingDashboard(snapshot: DashboardSnapshot): string {
+  let { active, history } = snapshot;
 
-  // Recent completed jobs table
-  let recentJobsRows = recentJobs
-    .map((job) => {
-      let realmURL = extractRealmURL(job);
-      let stats = extractStats(job);
-      let statsHtml = stats
-        ? Object.entries(stats)
-            .map(([k, v]) => `${k}: ${v}`)
-            .join(', ')
-        : '';
-      let statusClass = job.status === 'resolved' ? 'success' : 'failure';
-      return `
-        <tr class="${statusClass}">
-          <td>${job.id}</td>
-          <td>${escapeHtml(job.job_type.replace('-', ' '))}</td>
-          <td class="realm-url-cell" title="${escapeHtml(realmURL)}">${escapeHtml(realmURL)}</td>
-          <td><span class="status-badge ${statusClass}">${escapeHtml(job.status)}</span></td>
-          <td>${duration(job.created_at, job.finished_at)}</td>
-          <td>${job.finished_at ? timeSince(job.finished_at) : ''}</td>
-          <td class="stats-cell">${escapeHtml(statsHtml)}</td>
-        </tr>`;
-    })
-    .join('');
+  let activeCards = active.map(renderActiveCard).join('');
+
+  let historyRows = history.map(renderHistoryRow).join('');
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -377,7 +178,7 @@ function renderDashboard(data: Awaited<ReturnType<typeof getIndexingData>>): str
     .summary-item.alert .value { color: #f0883e; }
     .realm-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(450px, 1fr));
       gap: 16px;
       margin-bottom: 32px;
     }
@@ -409,29 +210,12 @@ function renderDashboard(data: Awaited<ReturnType<typeof getIndexingData>>): str
       0%, 100% { opacity: 1; }
       50% { opacity: 0.4; }
     }
-    .realm-stats {
+    .job-info {
       display: flex;
-      gap: 12px;
       flex-wrap: wrap;
-      margin-bottom: 8px;
-      font-size: 13px;
-      color: #8b949e;
-    }
-    .realm-stats .stat strong { color: #e1e4e8; }
-    .realm-stats .stat.error strong { color: #f85149; }
-    .job-card {
-      background: #0d1117;
-      border: 1px solid #30363d;
-      border-radius: 6px;
-      padding: 10px 12px;
-      margin-top: 8px;
-      font-size: 13px;
-    }
-    .job-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
       gap: 8px;
+      align-items: center;
+      margin-bottom: 10px;
     }
     .job-type {
       font-weight: 600;
@@ -439,12 +223,40 @@ function renderDashboard(data: Awaited<ReturnType<typeof getIndexingData>>): str
       text-transform: capitalize;
     }
     .job-meta { color: #8b949e; font-size: 12px; }
-    .progress-info {
-      margin-top: 6px;
-      font-size: 12px;
-      color: #58a6ff;
+    .progress-bar-container {
+      position: relative;
+      background: #21262d;
+      border-radius: 4px;
+      height: 24px;
+      margin-bottom: 6px;
+      overflow: hidden;
     }
-    details { margin-top: 8px; }
+    .progress-bar {
+      background: linear-gradient(90deg, #238636, #3fb950);
+      height: 100%;
+      border-radius: 4px;
+      transition: width 0.3s ease;
+    }
+    .progress-text {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+      font-weight: 600;
+      color: #fff;
+      text-shadow: 0 1px 2px rgba(0,0,0,0.5);
+    }
+    .remaining-count {
+      font-size: 13px;
+      color: #f0883e;
+      margin-bottom: 8px;
+    }
+    details { margin-top: 6px; }
     summary {
       cursor: pointer;
       color: #58a6ff;
@@ -454,7 +266,7 @@ function renderDashboard(data: Awaited<ReturnType<typeof getIndexingData>>): str
     .file-list {
       list-style: none;
       padding: 6px 0;
-      max-height: 200px;
+      max-height: 300px;
       overflow-y: auto;
       font-size: 12px;
       font-family: "SF Mono", Monaco, "Cascadia Code", monospace;
@@ -463,6 +275,12 @@ function renderDashboard(data: Awaited<ReturnType<typeof getIndexingData>>): str
       padding: 2px 0;
       color: #c9d1d9;
       word-break: break-all;
+    }
+    .file-list li.completed {
+      color: #3fb950;
+    }
+    .file-list li.completed::before {
+      content: "\\2713 ";
     }
     table {
       width: 100%;
@@ -481,16 +299,6 @@ function renderDashboard(data: Awaited<ReturnType<typeof getIndexingData>>): str
       padding: 6px 12px;
       border-bottom: 1px solid #21262d;
     }
-    tr.failure td { color: #f85149; }
-    .status-badge {
-      display: inline-block;
-      padding: 2px 8px;
-      border-radius: 12px;
-      font-size: 11px;
-      font-weight: 600;
-    }
-    .status-badge.success { background: #238636; color: #fff; }
-    .status-badge.failure { background: #da3633; color: #fff; }
     .realm-url-cell {
       max-width: 300px;
       overflow: hidden;
@@ -522,53 +330,49 @@ function renderDashboard(data: Awaited<ReturnType<typeof getIndexingData>>): str
       <span id="last-updated"></span>
       <label class="auto-refresh">
         <input type="checkbox" id="auto-refresh" checked>
-        Auto-refresh (5s)
+        Auto-refresh (2s)
       </label>
     </div>
   </div>
 
   <div class="summary-bar">
-    <div class="summary-item${activeJobs.length > 0 ? ' alert' : ''}">
-      <div class="value">${activeJobs.length}</div>
+    <div class="summary-item${active.length > 0 ? ' alert' : ''}">
+      <div class="value">${active.length}</div>
       <div class="label">Active Jobs</div>
     </div>
     <div class="summary-item">
-      <div class="value">${realmIndex.length}</div>
-      <div class="label">Realms</div>
+      <div class="value">${active.reduce((s, a) => s + (a.totalFiles - a.filesCompleted), 0)}</div>
+      <div class="label">Files Remaining</div>
     </div>
     <div class="summary-item">
-      <div class="value">${realmIndex.reduce((s, r) => s + r.total_entries, 0)}</div>
-      <div class="label">Total Entries</div>
-    </div>
-    <div class="summary-item">
-      <div class="value">${realmIndex.reduce((s, r) => s + r.errors, 0)}</div>
-      <div class="label">Total Errors</div>
+      <div class="value">${history.length}</div>
+      <div class="label">Completed</div>
     </div>
   </div>
 
-  <h2>Realms</h2>
-  ${realmCards.length > 0 ? `<div class="realm-grid">${realmCards}</div>` : '<div class="empty-state">No realms found</div>'}
+  <h2>Active Indexing</h2>
+  ${activeCards.length > 0 ? `<div class="realm-grid">${activeCards}</div>` : '<div class="empty-state">No active indexing jobs</div>'}
 
-  <h2>Recent Jobs</h2>
+  <h2>Recent Completed</h2>
   ${
-    recentJobs.length > 0
+    history.length > 0
       ? `<div class="table-wrapper">
     <table>
       <thead>
         <tr>
-          <th>ID</th>
+          <th>Job</th>
           <th>Type</th>
           <th>Realm</th>
-          <th>Status</th>
+          <th>Files</th>
           <th>Duration</th>
           <th>Finished</th>
           <th>Stats</th>
         </tr>
       </thead>
-      <tbody>${recentJobsRows}</tbody>
+      <tbody>${historyRows}</tbody>
     </table>
   </div>`
-      : '<div class="empty-state">No recent jobs</div>'
+      : '<div class="empty-state">No completed jobs yet (history is populated from events received since the worker manager started)</div>'
   }
 
   <script>
@@ -577,7 +381,7 @@ function renderDashboard(data: Awaited<ReturnType<typeof getIndexingData>>): str
 
     let refreshInterval;
     function startRefresh() {
-      refreshInterval = setInterval(() => location.reload(), 5000);
+      refreshInterval = setInterval(() => location.reload(), 2000);
     }
     function stopRefresh() {
       clearInterval(refreshInterval);
@@ -594,18 +398,23 @@ function renderDashboard(data: Awaited<ReturnType<typeof getIndexingData>>): str
 </html>`;
 }
 
-export default function handleIndexingDashboard({
-  dbAdapter,
-}: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
+// This handler is for the realm server route (dev-only, proxies to worker-manager or renders empty)
+export default function handleIndexingDashboard(
+  _args: CreateRoutesArgs,
+): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
-    let data = await getIndexingData(dbAdapter);
-    let html = renderDashboard(data);
-
+    let html = renderIndexingDashboard({ active: [], history: [] });
     return setContextResponse(
       ctxt,
-      new Response(html, {
-        headers: { 'content-type': 'text/html; charset=utf-8' },
-      }),
+      new Response(
+        html.replace(
+          '<h1>Indexing Dashboard</h1>',
+          '<h1>Indexing Dashboard</h1><p style="color:#f0883e;margin-bottom:16px">This endpoint is on the realm server. The live dashboard is served by the worker manager on its HTTP port.</p>',
+        ),
+        {
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        },
+      ),
     );
   };
 }

--- a/packages/realm-server/handlers/handle-indexing-dashboard.ts
+++ b/packages/realm-server/handlers/handle-indexing-dashboard.ts
@@ -1,0 +1,625 @@
+import type Koa from 'koa';
+import { query } from '@cardstack/runtime-common';
+import { setContextResponse } from '../middleware';
+import type { CreateRoutesArgs } from '../routes';
+
+interface IndexingJob {
+  id: number;
+  job_type: string;
+  concurrency_group: string | null;
+  status: string;
+  priority: number;
+  args: Record<string, unknown> | null;
+  created_at: string;
+  finished_at: string | null;
+  result: Record<string, unknown> | null;
+  worker_id: string | null;
+  reservation_started: string | null;
+  locked_until: string | null;
+}
+
+interface RealmIndexInfo {
+  realm_url: string;
+  total_entries: number;
+  instances: number;
+  files: number;
+  errors: number;
+}
+
+interface WorkingEntry {
+  realm_url: string;
+  working_count: number;
+}
+
+async function getIndexingData(dbAdapter: CreateRoutesArgs['dbAdapter']) {
+  let [activeJobs, recentJobs, realmIndex, workingEntries] = await Promise.all([
+    // Active/pending indexing jobs with reservation info
+    query(dbAdapter, [
+      `SELECT
+        j.id, j.job_type, j.concurrency_group, j.status, j.priority,
+        j.args, j.created_at, j.finished_at, j.result,
+        jr.worker_id, jr.created_at as reservation_started, jr.locked_until
+      FROM jobs j
+      LEFT JOIN job_reservations jr ON jr.job_id = j.id AND jr.completed_at IS NULL
+      WHERE j.job_type IN ('from-scratch-index', 'incremental-index', 'copy-index')
+        AND j.status = 'unfulfilled'
+      ORDER BY j.priority DESC, j.created_at`,
+    ]) as unknown as IndexingJob[],
+
+    // Recent completed jobs
+    query(dbAdapter, [
+      `SELECT
+        j.id, j.job_type, j.concurrency_group, j.status, j.priority,
+        j.args, j.created_at, j.finished_at, j.result,
+        NULL as worker_id, NULL as reservation_started, NULL as locked_until
+      FROM jobs j
+      WHERE j.job_type IN ('from-scratch-index', 'incremental-index', 'copy-index')
+        AND j.status IN ('resolved', 'rejected')
+      ORDER BY j.finished_at DESC
+      LIMIT 50`,
+    ]) as unknown as IndexingJob[],
+
+    // Index entry counts per realm
+    query(dbAdapter, [
+      `SELECT
+        realm_url,
+        CAST(COUNT(*) AS INTEGER) as total_entries,
+        CAST(COUNT(*) FILTER (WHERE type = 'instance') AS INTEGER) as instances,
+        CAST(COUNT(*) FILTER (WHERE type = 'file') AS INTEGER) as files,
+        CAST(COUNT(*) FILTER (WHERE has_error = true) AS INTEGER) as errors
+      FROM boxel_index
+      WHERE is_deleted IS NOT TRUE
+      GROUP BY realm_url
+      ORDER BY realm_url`,
+    ]) as unknown as RealmIndexInfo[],
+
+    // Working entries per realm (shows in-progress batch work)
+    query(dbAdapter, [
+      `SELECT
+        realm_url,
+        CAST(COUNT(*) AS INTEGER) as working_count
+      FROM boxel_index_working
+      GROUP BY realm_url`,
+    ]) as unknown as WorkingEntry[],
+  ]);
+
+  return { activeJobs, recentJobs, realmIndex, workingEntries };
+}
+
+function extractRealmURL(job: IndexingJob): string {
+  if (job.args && typeof job.args === 'object' && 'realmURL' in job.args) {
+    return job.args.realmURL as string;
+  }
+  if (job.concurrency_group) {
+    return job.concurrency_group.replace('indexing:', '');
+  }
+  return 'unknown';
+}
+
+function extractChanges(job: IndexingJob): string[] {
+  if (
+    job.args &&
+    typeof job.args === 'object' &&
+    'changes' in job.args &&
+    Array.isArray(job.args.changes)
+  ) {
+    return job.args.changes.map(
+      (c: { url: string; operation: string }) =>
+        `${c.operation}: ${c.url}`,
+    );
+  }
+  return [];
+}
+
+function extractStats(
+  job: IndexingJob,
+): Record<string, unknown> | null {
+  if (
+    job.result &&
+    typeof job.result === 'object' &&
+    'stats' in job.result
+  ) {
+    return job.result.stats as Record<string, unknown>;
+  }
+  return null;
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function timeSince(dateStr: string): string {
+  let date = new Date(dateStr);
+  let seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  }
+  let minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  let hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h ${minutes % 60}m ago`;
+  }
+  let days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function duration(startStr: string, endStr: string | null): string {
+  if (!endStr) {
+    return 'in progress';
+  }
+  let ms = new Date(endStr).getTime() - new Date(startStr).getTime();
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  let seconds = Math.floor(ms / 1000);
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  let minutes = Math.floor(seconds / 60);
+  return `${minutes}m ${seconds % 60}s`;
+}
+
+function renderDashboard(data: Awaited<ReturnType<typeof getIndexingData>>): string {
+  let { activeJobs, recentJobs, realmIndex, workingEntries } = data;
+
+  let workingMap = new Map(
+    workingEntries.map((w) => [w.realm_url, w.working_count]),
+  );
+
+  // Group active jobs by realm
+  let activeByRealm = new Map<string, IndexingJob[]>();
+  for (let job of activeJobs) {
+    let realmURL = extractRealmURL(job);
+    let jobs = activeByRealm.get(realmURL) || [];
+    jobs.push(job);
+    activeByRealm.set(realmURL, jobs);
+  }
+
+  // Build realm status cards
+  let realmCards = realmIndex
+    .map((realm) => {
+      let active = activeByRealm.get(realm.realm_url) || [];
+      let working = workingMap.get(realm.realm_url) || 0;
+      let isIndexing = active.length > 0;
+      let statusClass = isIndexing ? 'indexing' : 'idle';
+
+      let activeJobsHtml = '';
+      if (active.length > 0) {
+        activeJobsHtml = active
+          .map((job) => {
+            let changes = extractChanges(job);
+            let jobTypeLabel = job.job_type.replace('-', ' ');
+            let startedInfo = job.reservation_started
+              ? `started ${timeSince(job.reservation_started)}`
+              : `queued ${timeSince(job.created_at)}`;
+            let workerInfo = job.worker_id
+              ? ` (worker: ${escapeHtml(job.worker_id.substring(0, 8))})`
+              : '';
+
+            let changesHtml = '';
+            if (changes.length > 0) {
+              let changesList = changes
+                .map((c) => `<li>${escapeHtml(c)}</li>`)
+                .join('');
+              changesHtml = `
+                <details>
+                  <summary>${changes.length} file${changes.length !== 1 ? 's' : ''} to process</summary>
+                  <ul class="file-list">${changesList}</ul>
+                </details>`;
+            }
+
+            return `
+              <div class="job-card">
+                <div class="job-header">
+                  <span class="job-type">${escapeHtml(jobTypeLabel)}</span>
+                  <span class="job-meta">${escapeHtml(startedInfo)}${escapeHtml(workerInfo)}</span>
+                </div>
+                ${changesHtml}
+                ${working > 0 ? `<div class="progress-info">${working} entries written to working index</div>` : ''}
+              </div>`;
+          })
+          .join('');
+      }
+
+      return `
+        <div class="realm-card ${statusClass}">
+          <div class="realm-header">
+            <span class="status-indicator"></span>
+            <h3>${escapeHtml(realm.realm_url)}</h3>
+          </div>
+          <div class="realm-stats">
+            <span class="stat"><strong>${realm.total_entries}</strong> entries</span>
+            <span class="stat"><strong>${realm.instances}</strong> instances</span>
+            <span class="stat"><strong>${realm.files}</strong> files</span>
+            ${realm.errors > 0 ? `<span class="stat error"><strong>${realm.errors}</strong> errors</span>` : ''}
+          </div>
+          ${activeJobsHtml}
+        </div>`;
+    })
+    .join('');
+
+  // Also show realms that have active jobs but no index entries yet
+  for (let [realmURL, jobs] of activeByRealm) {
+    if (!realmIndex.find((r) => r.realm_url === realmURL)) {
+      let working = workingMap.get(realmURL) || 0;
+      let jobsHtml = jobs
+        .map((job) => {
+          let jobTypeLabel = job.job_type.replace('-', ' ');
+          let startedInfo = job.reservation_started
+            ? `started ${timeSince(job.reservation_started)}`
+            : `queued ${timeSince(job.created_at)}`;
+          let changes = extractChanges(job);
+          let changesHtml = '';
+          if (changes.length > 0) {
+            let changesList = changes
+              .map((c) => `<li>${escapeHtml(c)}</li>`)
+              .join('');
+            changesHtml = `
+              <details>
+                <summary>${changes.length} file${changes.length !== 1 ? 's' : ''} to process</summary>
+                <ul class="file-list">${changesList}</ul>
+              </details>`;
+          }
+          return `
+            <div class="job-card">
+              <div class="job-header">
+                <span class="job-type">${escapeHtml(jobTypeLabel)}</span>
+                <span class="job-meta">${escapeHtml(startedInfo)}</span>
+              </div>
+              ${changesHtml}
+              ${working > 0 ? `<div class="progress-info">${working} entries written to working index</div>` : ''}
+            </div>`;
+        })
+        .join('');
+
+      realmCards += `
+        <div class="realm-card indexing">
+          <div class="realm-header">
+            <span class="status-indicator"></span>
+            <h3>${escapeHtml(realmURL)}</h3>
+          </div>
+          <div class="realm-stats">
+            <span class="stat"><strong>0</strong> entries (new index)</span>
+          </div>
+          ${jobsHtml}
+        </div>`;
+    }
+  }
+
+  // Recent completed jobs table
+  let recentJobsRows = recentJobs
+    .map((job) => {
+      let realmURL = extractRealmURL(job);
+      let stats = extractStats(job);
+      let statsHtml = stats
+        ? Object.entries(stats)
+            .map(([k, v]) => `${k}: ${v}`)
+            .join(', ')
+        : '';
+      let statusClass = job.status === 'resolved' ? 'success' : 'failure';
+      return `
+        <tr class="${statusClass}">
+          <td>${job.id}</td>
+          <td>${escapeHtml(job.job_type.replace('-', ' '))}</td>
+          <td class="realm-url-cell" title="${escapeHtml(realmURL)}">${escapeHtml(realmURL)}</td>
+          <td><span class="status-badge ${statusClass}">${escapeHtml(job.status)}</span></td>
+          <td>${duration(job.created_at, job.finished_at)}</td>
+          <td>${job.finished_at ? timeSince(job.finished_at) : ''}</td>
+          <td class="stats-cell">${escapeHtml(statsHtml)}</td>
+        </tr>`;
+    })
+    .join('');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Indexing Dashboard</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #0f1117;
+      color: #e1e4e8;
+      padding: 24px;
+      line-height: 1.5;
+    }
+    h1 { font-size: 24px; margin-bottom: 8px; }
+    h2 { font-size: 18px; margin: 24px 0 12px; color: #8b949e; }
+    h3 { font-size: 14px; font-weight: 600; word-break: break-all; }
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 24px;
+    }
+    .header-right {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-size: 13px;
+      color: #8b949e;
+    }
+    .auto-refresh { display: flex; align-items: center; gap: 6px; }
+    .auto-refresh input { cursor: pointer; }
+    .summary-bar {
+      display: flex;
+      gap: 16px;
+      margin-bottom: 24px;
+      flex-wrap: wrap;
+    }
+    .summary-item {
+      background: #161b22;
+      border: 1px solid #30363d;
+      border-radius: 8px;
+      padding: 12px 20px;
+      min-width: 120px;
+    }
+    .summary-item .value {
+      font-size: 28px;
+      font-weight: 700;
+      color: #58a6ff;
+    }
+    .summary-item .label {
+      font-size: 12px;
+      color: #8b949e;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .summary-item.alert .value { color: #f0883e; }
+    .realm-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+      gap: 16px;
+      margin-bottom: 32px;
+    }
+    .realm-card {
+      background: #161b22;
+      border: 1px solid #30363d;
+      border-radius: 8px;
+      padding: 16px;
+    }
+    .realm-card.indexing { border-color: #f0883e; }
+    .realm-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 8px;
+    }
+    .status-indicator {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: #3fb950;
+      flex-shrink: 0;
+    }
+    .indexing .status-indicator {
+      background: #f0883e;
+      animation: pulse 1.5s infinite;
+    }
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.4; }
+    }
+    .realm-stats {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 8px;
+      font-size: 13px;
+      color: #8b949e;
+    }
+    .realm-stats .stat strong { color: #e1e4e8; }
+    .realm-stats .stat.error strong { color: #f85149; }
+    .job-card {
+      background: #0d1117;
+      border: 1px solid #30363d;
+      border-radius: 6px;
+      padding: 10px 12px;
+      margin-top: 8px;
+      font-size: 13px;
+    }
+    .job-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 8px;
+    }
+    .job-type {
+      font-weight: 600;
+      color: #f0883e;
+      text-transform: capitalize;
+    }
+    .job-meta { color: #8b949e; font-size: 12px; }
+    .progress-info {
+      margin-top: 6px;
+      font-size: 12px;
+      color: #58a6ff;
+    }
+    details { margin-top: 8px; }
+    summary {
+      cursor: pointer;
+      color: #58a6ff;
+      font-size: 12px;
+    }
+    summary:hover { text-decoration: underline; }
+    .file-list {
+      list-style: none;
+      padding: 6px 0;
+      max-height: 200px;
+      overflow-y: auto;
+      font-size: 12px;
+      font-family: "SF Mono", Monaco, "Cascadia Code", monospace;
+    }
+    .file-list li {
+      padding: 2px 0;
+      color: #c9d1d9;
+      word-break: break-all;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+    th {
+      text-align: left;
+      padding: 8px 12px;
+      border-bottom: 2px solid #30363d;
+      color: #8b949e;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+    td {
+      padding: 6px 12px;
+      border-bottom: 1px solid #21262d;
+    }
+    tr.failure td { color: #f85149; }
+    .status-badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 12px;
+      font-size: 11px;
+      font-weight: 600;
+    }
+    .status-badge.success { background: #238636; color: #fff; }
+    .status-badge.failure { background: #da3633; color: #fff; }
+    .realm-url-cell {
+      max-width: 300px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .stats-cell {
+      font-family: "SF Mono", Monaco, "Cascadia Code", monospace;
+      font-size: 11px;
+      color: #8b949e;
+    }
+    .table-wrapper {
+      overflow-x: auto;
+      background: #161b22;
+      border: 1px solid #30363d;
+      border-radius: 8px;
+    }
+    .empty-state {
+      text-align: center;
+      padding: 40px;
+      color: #8b949e;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1>Indexing Dashboard</h1>
+    <div class="header-right">
+      <span id="last-updated"></span>
+      <label class="auto-refresh">
+        <input type="checkbox" id="auto-refresh" checked>
+        Auto-refresh (5s)
+      </label>
+    </div>
+  </div>
+
+  <div class="summary-bar">
+    <div class="summary-item${activeJobs.length > 0 ? ' alert' : ''}">
+      <div class="value">${activeJobs.length}</div>
+      <div class="label">Active Jobs</div>
+    </div>
+    <div class="summary-item">
+      <div class="value">${realmIndex.length}</div>
+      <div class="label">Realms</div>
+    </div>
+    <div class="summary-item">
+      <div class="value">${realmIndex.reduce((s, r) => s + r.total_entries, 0)}</div>
+      <div class="label">Total Entries</div>
+    </div>
+    <div class="summary-item">
+      <div class="value">${realmIndex.reduce((s, r) => s + r.errors, 0)}</div>
+      <div class="label">Total Errors</div>
+    </div>
+  </div>
+
+  <h2>Realms</h2>
+  ${realmCards.length > 0 ? `<div class="realm-grid">${realmCards}</div>` : '<div class="empty-state">No realms found</div>'}
+
+  <h2>Recent Jobs</h2>
+  ${
+    recentJobs.length > 0
+      ? `<div class="table-wrapper">
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Type</th>
+          <th>Realm</th>
+          <th>Status</th>
+          <th>Duration</th>
+          <th>Finished</th>
+          <th>Stats</th>
+        </tr>
+      </thead>
+      <tbody>${recentJobsRows}</tbody>
+    </table>
+  </div>`
+      : '<div class="empty-state">No recent jobs</div>'
+  }
+
+  <script>
+    document.getElementById('last-updated').textContent =
+      'Updated: ' + new Date().toLocaleTimeString();
+
+    let refreshInterval;
+    function startRefresh() {
+      refreshInterval = setInterval(() => location.reload(), 5000);
+    }
+    function stopRefresh() {
+      clearInterval(refreshInterval);
+    }
+
+    let checkbox = document.getElementById('auto-refresh');
+    if (checkbox.checked) startRefresh();
+    checkbox.addEventListener('change', () => {
+      if (checkbox.checked) startRefresh();
+      else stopRefresh();
+    });
+  </script>
+</body>
+</html>`;
+}
+
+export default function handleIndexingDashboard({
+  dbAdapter,
+  grafanaSecret,
+}: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
+  return async function (ctxt: Koa.Context, _next: Koa.Next) {
+    let authorization = ctxt.req.headers['authorization'];
+    let queryToken = ctxt.query['token'];
+
+    // Allow auth via header or query param (for easy browser access)
+    if (authorization !== grafanaSecret && queryToken !== grafanaSecret) {
+      return setContextResponse(
+        ctxt,
+        new Response('Unauthorized - provide grafana secret as Authorization header or ?token= query param', {
+          status: 401,
+        }),
+      );
+    }
+
+    let data = await getIndexingData(dbAdapter);
+    let html = renderDashboard(data);
+
+    return setContextResponse(
+      ctxt,
+      new Response(html, {
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      }),
+    );
+  };
+}

--- a/packages/realm-server/handlers/handle-indexing-dashboard.ts
+++ b/packages/realm-server/handlers/handle-indexing-dashboard.ts
@@ -596,22 +596,8 @@ function renderDashboard(data: Awaited<ReturnType<typeof getIndexingData>>): str
 
 export default function handleIndexingDashboard({
   dbAdapter,
-  grafanaSecret,
 }: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
-    let authorization = ctxt.req.headers['authorization'];
-    let queryToken = ctxt.query['token'];
-
-    // Allow auth via header or query param (for easy browser access)
-    if (authorization !== grafanaSecret && queryToken !== grafanaSecret) {
-      return setContextResponse(
-        ctxt,
-        new Response('Unauthorized - provide grafana secret as Authorization header or ?token= query param', {
-          status: 401,
-        }),
-      );
-    }
-
     let data = await getIndexingData(dbAdapter);
     let html = renderDashboard(data);
 

--- a/packages/realm-server/indexing-event-sink.ts
+++ b/packages/realm-server/indexing-event-sink.ts
@@ -65,9 +65,7 @@ export class IndexingEventSink {
             if (!completedSet.has(event.url)) {
               completedSet.add(event.url);
               state.completedFiles.push(event.url);
-              if (
-                state.completedFiles.length > this.#maxCompletedFilesPerJob
-              ) {
+              if (state.completedFiles.length > this.#maxCompletedFilesPerJob) {
                 const excess =
                   state.completedFiles.length - this.#maxCompletedFilesPerJob;
                 const removed = state.completedFiles.splice(0, excess);

--- a/packages/realm-server/indexing-event-sink.ts
+++ b/packages/realm-server/indexing-event-sink.ts
@@ -26,6 +26,12 @@ export class IndexingEventSink {
   /** Max history entries to keep */
   #maxHistory = 50;
 
+  /** Tracks unique completed files per realm to avoid duplicates */
+  #completedFilesSets = new Map<string, Set<string>>();
+
+  /** Max completed files to keep per realm for UI/display purposes */
+  #maxCompletedFilesPerRealm = 1000;
+
   handleEvent(event: IndexingProgressEvent): void {
     switch (event.type) {
       case 'indexing-started': {
@@ -41,6 +47,8 @@ export class IndexingEventSink {
           startedAt: Date.now(),
           lastUpdatedAt: Date.now(),
         });
+        // Initialize tracking of unique completed files for this realm
+        this.#completedFilesSets.set(event.realmURL, new Set());
         break;
       }
       case 'file-visited': {
@@ -50,7 +58,25 @@ export class IndexingEventSink {
             event.filesCompleted ?? state.filesCompleted + 1;
           state.totalFiles = event.totalFiles ?? state.totalFiles;
           if (event.url) {
-            state.completedFiles.push(event.url);
+            // Ensure we track unique completed files and bound memory usage
+            let completedSet = this.#completedFilesSets.get(event.realmURL);
+            if (!completedSet) {
+              // Seed the set from any existing completedFiles array
+              completedSet = new Set(state.completedFiles);
+              this.#completedFilesSets.set(event.realmURL, completedSet);
+            }
+            if (!completedSet.has(event.url)) {
+              completedSet.add(event.url);
+              state.completedFiles.push(event.url);
+              // Keep only the most recent N completed files for this realm
+              if (state.completedFiles.length > this.#maxCompletedFilesPerRealm) {
+                const excess = state.completedFiles.length - this.#maxCompletedFilesPerRealm;
+                const removed = state.completedFiles.splice(0, excess);
+                for (let url of removed) {
+                  completedSet.delete(url);
+                }
+              }
+            }
           }
           state.lastUpdatedAt = Date.now();
         }
@@ -67,7 +93,9 @@ export class IndexingEventSink {
             this.#history.length = this.#maxHistory;
           }
         }
+        // Clean up per-realm tracking structures
         this.#active.delete(event.realmURL);
+        this.#completedFilesSets.delete(event.realmURL);
         break;
       }
     }

--- a/packages/realm-server/indexing-event-sink.ts
+++ b/packages/realm-server/indexing-event-sink.ts
@@ -46,7 +46,8 @@ export class IndexingEventSink {
       case 'file-visited': {
         let state = this.#active.get(event.realmURL);
         if (state) {
-          state.filesCompleted = event.filesCompleted ?? state.filesCompleted + 1;
+          state.filesCompleted =
+            event.filesCompleted ?? state.filesCompleted + 1;
           state.totalFiles = event.totalFiles ?? state.totalFiles;
           if (event.url) {
             state.completedFiles.push(event.url);

--- a/packages/realm-server/indexing-event-sink.ts
+++ b/packages/realm-server/indexing-event-sink.ts
@@ -1,0 +1,92 @@
+import type { IndexingProgressEvent, Stats } from '@cardstack/runtime-common';
+
+export interface RealmIndexingState {
+  realmURL: string;
+  jobId: number;
+  jobType: string;
+  status: 'indexing' | 'finished';
+  totalFiles: number;
+  filesCompleted: number;
+  /** All files that need to be indexed */
+  files: string[];
+  /** Files that have been indexed so far */
+  completedFiles: string[];
+  stats?: Stats;
+  startedAt: number;
+  lastUpdatedAt: number;
+}
+
+export class IndexingEventSink {
+  /** Active indexing state per realm */
+  #active = new Map<string, RealmIndexingState>();
+
+  /** Recently completed indexing runs (most recent first) */
+  #history: RealmIndexingState[] = [];
+
+  /** Max history entries to keep */
+  #maxHistory = 50;
+
+  handleEvent(event: IndexingProgressEvent): void {
+    switch (event.type) {
+      case 'indexing-started': {
+        this.#active.set(event.realmURL, {
+          realmURL: event.realmURL,
+          jobId: event.jobId,
+          jobType: event.jobType ?? 'unknown',
+          status: 'indexing',
+          totalFiles: event.totalFiles ?? 0,
+          filesCompleted: 0,
+          files: event.files ?? [],
+          completedFiles: [],
+          startedAt: Date.now(),
+          lastUpdatedAt: Date.now(),
+        });
+        break;
+      }
+      case 'file-visited': {
+        let state = this.#active.get(event.realmURL);
+        if (state) {
+          state.filesCompleted = event.filesCompleted ?? state.filesCompleted + 1;
+          state.totalFiles = event.totalFiles ?? state.totalFiles;
+          if (event.url) {
+            state.completedFiles.push(event.url);
+          }
+          state.lastUpdatedAt = Date.now();
+        }
+        break;
+      }
+      case 'indexing-finished': {
+        let state = this.#active.get(event.realmURL);
+        if (state) {
+          state.status = 'finished';
+          state.stats = event.stats;
+          state.lastUpdatedAt = Date.now();
+          this.#history.unshift({ ...state });
+          if (this.#history.length > this.#maxHistory) {
+            this.#history.length = this.#maxHistory;
+          }
+        }
+        this.#active.delete(event.realmURL);
+        break;
+      }
+    }
+  }
+
+  getActiveIndexing(): RealmIndexingState[] {
+    return [...this.#active.values()];
+  }
+
+  getHistory(): RealmIndexingState[] {
+    return [...this.#history];
+  }
+
+  getSnapshot(): {
+    active: RealmIndexingState[];
+    history: RealmIndexingState[];
+  } {
+    return {
+      active: this.getActiveIndexing(),
+      history: this.getHistory(),
+    };
+  }
+}

--- a/packages/realm-server/indexing-event-sink.ts
+++ b/packages/realm-server/indexing-event-sink.ts
@@ -17,8 +17,8 @@ export interface RealmIndexingState {
 }
 
 export class IndexingEventSink {
-  /** Active indexing state per realm */
-  #active = new Map<string, RealmIndexingState>();
+  /** Active indexing state keyed by jobId */
+  #active = new Map<number, RealmIndexingState>();
 
   /** Recently completed indexing runs (most recent first) */
   #history: RealmIndexingState[] = [];
@@ -26,16 +26,16 @@ export class IndexingEventSink {
   /** Max history entries to keep */
   #maxHistory = 50;
 
-  /** Tracks unique completed files per realm to avoid duplicates */
-  #completedFilesSets = new Map<string, Set<string>>();
+  /** Tracks unique completed files per job to avoid duplicates */
+  #completedFilesSets = new Map<number, Set<string>>();
 
-  /** Max completed files to keep per realm for UI/display purposes */
-  #maxCompletedFilesPerRealm = 1000;
+  /** Max completed files to keep per job for UI/display purposes */
+  #maxCompletedFilesPerJob = 1000;
 
   handleEvent(event: IndexingProgressEvent): void {
     switch (event.type) {
       case 'indexing-started': {
-        this.#active.set(event.realmURL, {
+        this.#active.set(event.jobId, {
           realmURL: event.realmURL,
           jobId: event.jobId,
           jobType: event.jobType ?? 'unknown',
@@ -47,30 +47,29 @@ export class IndexingEventSink {
           startedAt: Date.now(),
           lastUpdatedAt: Date.now(),
         });
-        // Initialize tracking of unique completed files for this realm
-        this.#completedFilesSets.set(event.realmURL, new Set());
+        this.#completedFilesSets.set(event.jobId, new Set());
         break;
       }
       case 'file-visited': {
-        let state = this.#active.get(event.realmURL);
+        let state = this.#active.get(event.jobId);
         if (state) {
           state.filesCompleted =
             event.filesCompleted ?? state.filesCompleted + 1;
           state.totalFiles = event.totalFiles ?? state.totalFiles;
           if (event.url) {
-            // Ensure we track unique completed files and bound memory usage
-            let completedSet = this.#completedFilesSets.get(event.realmURL);
+            let completedSet = this.#completedFilesSets.get(event.jobId);
             if (!completedSet) {
-              // Seed the set from any existing completedFiles array
               completedSet = new Set(state.completedFiles);
-              this.#completedFilesSets.set(event.realmURL, completedSet);
+              this.#completedFilesSets.set(event.jobId, completedSet);
             }
             if (!completedSet.has(event.url)) {
               completedSet.add(event.url);
               state.completedFiles.push(event.url);
-              // Keep only the most recent N completed files for this realm
-              if (state.completedFiles.length > this.#maxCompletedFilesPerRealm) {
-                const excess = state.completedFiles.length - this.#maxCompletedFilesPerRealm;
+              if (
+                state.completedFiles.length > this.#maxCompletedFilesPerJob
+              ) {
+                const excess =
+                  state.completedFiles.length - this.#maxCompletedFilesPerJob;
                 const removed = state.completedFiles.splice(0, excess);
                 for (let url of removed) {
                   completedSet.delete(url);
@@ -83,7 +82,7 @@ export class IndexingEventSink {
         break;
       }
       case 'indexing-finished': {
-        let state = this.#active.get(event.realmURL);
+        let state = this.#active.get(event.jobId);
         if (state) {
           state.status = 'finished';
           state.stats = event.stats;
@@ -93,9 +92,8 @@ export class IndexingEventSink {
             this.#history.length = this.#maxHistory;
           }
         }
-        // Clean up per-realm tracking structures
-        this.#active.delete(event.realmURL);
-        this.#completedFilesSets.delete(event.realmURL);
+        this.#active.delete(event.jobId);
+        this.#completedFilesSets.delete(event.jobId);
         break;
       }
     }

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -66,7 +66,6 @@ import {
   handleDeleteWebhookCommandRequest,
 } from './handlers/handle-webhook-commands';
 import handleWebhookReceiverRequest from './handlers/handle-webhook-receiver';
-import handleIndexingDashboard from './handlers/handle-indexing-dashboard';
 import { buildCreatePrerenderAuth } from './prerender/auth';
 
 export type CreateRoutesArgs = {
@@ -239,9 +238,6 @@ export function createRoutes(args: CreateRoutesArgs) {
     grafanaAuthorization(args.grafanaSecret),
     handleFullReindex(args),
   );
-  if (args.assetsURL.hostname.includes('localhost')) {
-    router.get('/_indexing-dashboard', handleIndexingDashboard(args));
-  }
   router.post('/_post-deployment', handlePostDeployment(args));
   router.post(
     '/_realm-auth',

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -239,10 +239,9 @@ export function createRoutes(args: CreateRoutesArgs) {
     grafanaAuthorization(args.grafanaSecret),
     handleFullReindex(args),
   );
-  router.get(
-    '/_indexing-dashboard',
-    handleIndexingDashboard(args),
-  );
+  if (args.assetsURL.hostname.includes('localhost')) {
+    router.get('/_indexing-dashboard', handleIndexingDashboard(args));
+  }
   router.post('/_post-deployment', handlePostDeployment(args));
   router.post(
     '/_realm-auth',

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -66,6 +66,7 @@ import {
   handleDeleteWebhookCommandRequest,
 } from './handlers/handle-webhook-commands';
 import handleWebhookReceiverRequest from './handlers/handle-webhook-receiver';
+import handleIndexingDashboard from './handlers/handle-indexing-dashboard';
 import { buildCreatePrerenderAuth } from './prerender/auth';
 
 export type CreateRoutesArgs = {
@@ -237,6 +238,10 @@ export function createRoutes(args: CreateRoutesArgs) {
     '/_grafana-full-reindex',
     grafanaAuthorization(args.grafanaSecret),
     handleFullReindex(args),
+  );
+  router.get(
+    '/_indexing-dashboard',
+    handleIndexingDashboard(args),
   );
   router.post('/_post-deployment', handlePostDeployment(args));
   router.post(

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -180,3 +180,4 @@ import './remote-prerenderer-test';
 import './runtime-dependency-tracker-test';
 import './sanitize-head-html-test';
 import './session-room-queries-test';
+import './indexing-event-sink-test';

--- a/packages/realm-server/tests/indexing-event-sink-test.ts
+++ b/packages/realm-server/tests/indexing-event-sink-test.ts
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
+import { basename } from 'path';
 import { IndexingEventSink } from '../indexing-event-sink';
 
-module('IndexingEventSink', function () {
+module(basename(__filename), function () {
   test('tracks active indexing from start through file visits to finish', function (assert) {
     let sink = new IndexingEventSink();
 

--- a/packages/realm-server/tests/indexing-event-sink-test.ts
+++ b/packages/realm-server/tests/indexing-event-sink-test.ts
@@ -1,0 +1,145 @@
+import { module, test } from 'qunit';
+import { IndexingEventSink } from '../indexing-event-sink';
+
+module('IndexingEventSink', function () {
+  test('tracks active indexing from start through file visits to finish', function (assert) {
+    let sink = new IndexingEventSink();
+
+    assert.deepEqual(sink.getSnapshot(), { active: [], history: [] });
+
+    sink.handleEvent({
+      type: 'indexing-started',
+      realmURL: 'http://example.com/realm/',
+      jobId: 1,
+      jobType: 'from-scratch',
+      totalFiles: 3,
+      files: [
+        'http://example.com/realm/a.gts',
+        'http://example.com/realm/b.json',
+        'http://example.com/realm/c.gts',
+      ],
+    });
+
+    let { active, history } = sink.getSnapshot();
+    assert.strictEqual(active.length, 1);
+    assert.strictEqual(history.length, 0);
+    assert.strictEqual(active[0].realmURL, 'http://example.com/realm/');
+    assert.strictEqual(active[0].totalFiles, 3);
+    assert.strictEqual(active[0].filesCompleted, 0);
+    assert.strictEqual(active[0].status, 'indexing');
+
+    sink.handleEvent({
+      type: 'file-visited',
+      realmURL: 'http://example.com/realm/',
+      jobId: 1,
+      url: 'http://example.com/realm/a.gts',
+      filesCompleted: 1,
+      totalFiles: 3,
+    });
+
+    ({ active } = sink.getSnapshot());
+    assert.strictEqual(active[0].filesCompleted, 1);
+    assert.deepEqual(active[0].completedFiles, [
+      'http://example.com/realm/a.gts',
+    ]);
+
+    sink.handleEvent({
+      type: 'file-visited',
+      realmURL: 'http://example.com/realm/',
+      jobId: 1,
+      url: 'http://example.com/realm/b.json',
+      filesCompleted: 2,
+      totalFiles: 3,
+    });
+
+    sink.handleEvent({
+      type: 'file-visited',
+      realmURL: 'http://example.com/realm/',
+      jobId: 1,
+      url: 'http://example.com/realm/c.gts',
+      filesCompleted: 3,
+      totalFiles: 3,
+    });
+
+    ({ active } = sink.getSnapshot());
+    assert.strictEqual(active[0].filesCompleted, 3);
+
+    sink.handleEvent({
+      type: 'indexing-finished',
+      realmURL: 'http://example.com/realm/',
+      jobId: 1,
+      stats: {
+        instancesIndexed: 1,
+        filesIndexed: 2,
+        instanceErrors: 0,
+        fileErrors: 0,
+        totalIndexEntries: 3,
+      },
+    });
+
+    ({ active, history } = sink.getSnapshot());
+    assert.strictEqual(active.length, 0, 'no longer active after finish');
+    assert.strictEqual(history.length, 1);
+    assert.strictEqual(history[0].realmURL, 'http://example.com/realm/');
+    assert.strictEqual(history[0].status, 'finished');
+    assert.deepEqual(history[0].stats, {
+      instancesIndexed: 1,
+      filesIndexed: 2,
+      instanceErrors: 0,
+      fileErrors: 0,
+      totalIndexEntries: 3,
+    });
+  });
+
+  test('tracks multiple realms concurrently', function (assert) {
+    let sink = new IndexingEventSink();
+
+    sink.handleEvent({
+      type: 'indexing-started',
+      realmURL: 'http://example.com/realm-a/',
+      jobId: 1,
+      jobType: 'from-scratch',
+      totalFiles: 10,
+      files: [],
+    });
+
+    sink.handleEvent({
+      type: 'indexing-started',
+      realmURL: 'http://example.com/realm-b/',
+      jobId: 2,
+      jobType: 'incremental',
+      totalFiles: 2,
+      files: [],
+    });
+
+    assert.strictEqual(sink.getActiveIndexing().length, 2);
+
+    sink.handleEvent({
+      type: 'indexing-finished',
+      realmURL: 'http://example.com/realm-b/',
+      jobId: 2,
+    });
+
+    assert.strictEqual(sink.getActiveIndexing().length, 1);
+    assert.strictEqual(
+      sink.getActiveIndexing()[0].realmURL,
+      'http://example.com/realm-a/',
+    );
+    assert.strictEqual(sink.getHistory().length, 1);
+  });
+
+  test('ignores file-visited for unknown realm', function (assert) {
+    let sink = new IndexingEventSink();
+
+    sink.handleEvent({
+      type: 'file-visited',
+      realmURL: 'http://example.com/unknown/',
+      jobId: 99,
+      url: 'http://example.com/unknown/x.json',
+      filesCompleted: 1,
+      totalFiles: 1,
+    });
+
+    assert.strictEqual(sink.getActiveIndexing().length, 0);
+  });
+});

--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -181,7 +181,7 @@ if (port != null) {
         priority: r.priority,
         createdAt: r.created_at,
       }));
-    }
+    };
 
     router.get('/_indexing-dashboard', async (ctxt: Koa.Context) => {
       ctxt.set('Content-Type', 'text/html; charset=utf-8');

--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -146,16 +146,18 @@ if (port != null) {
     ctxt.body = JSON.stringify(result);
     ctxt.status = isReady ? 200 : 503;
   });
-  router.get('/_indexing-dashboard', async (ctxt: Koa.Context) => {
-    ctxt.set('Content-Type', 'text/html; charset=utf-8');
-    ctxt.body = renderIndexingDashboard(eventSink.getSnapshot());
-    ctxt.status = 200;
-  });
-  router.get('/_indexing-status', async (ctxt: Koa.Context) => {
-    ctxt.set('Content-Type', 'application/json');
-    ctxt.body = JSON.stringify(eventSink.getSnapshot());
-    ctxt.status = 200;
-  });
+  if (!ECS_CONTAINER_METADATA_URI) {
+    router.get('/_indexing-dashboard', async (ctxt: Koa.Context) => {
+      ctxt.set('Content-Type', 'text/html; charset=utf-8');
+      ctxt.body = renderIndexingDashboard(eventSink.getSnapshot());
+      ctxt.status = 200;
+    });
+    router.get('/_indexing-status', async (ctxt: Koa.Context) => {
+      ctxt.set('Content-Type', 'application/json');
+      ctxt.body = JSON.stringify(eventSink.getSnapshot());
+      ctxt.status = 200;
+    });
+  }
 
   webServer
     .use(router.routes())

--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -156,7 +156,7 @@ if (port != null) {
     ctxt.status = isReady ? 200 : 503;
   });
   if (eventSink) {
-    async function getPendingJobs(): Promise<PendingJob[]> {
+    let getPendingJobs = async (): Promise<PendingJob[]> => {
       let rows = (await query([
         `SELECT j.id, j.job_type, j.args, j.priority, j.created_at`,
         `FROM jobs j`,

--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -548,9 +548,7 @@ async function startWorker(
           message.startsWith('progress|')
         ) {
           let payload = message.substring('progress|'.length);
-          let progressEvent = JSON.parse(
-            payload,
-          ) as IndexingProgressEvent;
+          let progressEvent = JSON.parse(payload) as IndexingProgressEvent;
           eventSink.handleEvent(progressEvent);
         }
       });

--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -11,6 +11,7 @@ import {
   isUrlLike,
   type Expression,
   type StatusArgs,
+  type IndexingProgressEvent,
 } from '@cardstack/runtime-common';
 import yargs from 'yargs';
 import * as Sentry from '@sentry/node';
@@ -28,6 +29,8 @@ import {
   registerService,
   deregisterService,
 } from './lib/dev-service-registry';
+import { IndexingEventSink } from './indexing-event-sink';
+import { renderIndexingDashboard } from './handlers/handle-indexing-dashboard';
 
 /* About the Worker Manager
  *
@@ -116,6 +119,7 @@ let {
 let isReady = false;
 let isExiting = false;
 let workers: ChildProcess[] = [];
+let eventSink = new IndexingEventSink();
 
 process.on('SIGINT', () => (isExiting = true));
 process.on('SIGTERM', () => (isExiting = true));
@@ -141,6 +145,16 @@ if (port != null) {
     ctxt.set('Content-Type', 'application/json');
     ctxt.body = JSON.stringify(result);
     ctxt.status = isReady ? 200 : 503;
+  });
+  router.get('/_indexing-dashboard', async (ctxt: Koa.Context) => {
+    ctxt.set('Content-Type', 'text/html; charset=utf-8');
+    ctxt.body = renderIndexingDashboard(eventSink.getSnapshot());
+    ctxt.status = 200;
+  });
+  router.get('/_indexing-status', async (ctxt: Koa.Context) => {
+    ctxt.set('Content-Type', 'application/json');
+    ctxt.body = JSON.stringify(eventSink.getSnapshot());
+    ctxt.status = 200;
   });
 
   webServer
@@ -529,6 +543,15 @@ async function startWorker(
             currentState = undefined;
             (worker as any).__boxelIndexState = undefined;
           }
+        } else if (
+          typeof message === 'string' &&
+          message.startsWith('progress|')
+        ) {
+          let payload = message.substring('progress|'.length);
+          let progressEvent = JSON.parse(
+            payload,
+          ) as IndexingProgressEvent;
+          eventSink.handleEvent(progressEvent);
         }
       });
     }),

--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -30,7 +30,10 @@ import {
   deregisterService,
 } from './lib/dev-service-registry';
 import { IndexingEventSink } from './indexing-event-sink';
-import { renderIndexingDashboard } from './handlers/handle-indexing-dashboard';
+import {
+  renderIndexingDashboard,
+  type PendingJob,
+} from './handlers/handle-indexing-dashboard';
 
 /* About the Worker Manager
  *
@@ -153,14 +156,49 @@ if (port != null) {
     ctxt.status = isReady ? 200 : 503;
   });
   if (eventSink) {
+    async function getPendingJobs(): Promise<PendingJob[]> {
+      let rows = (await query([
+        `SELECT j.id, j.job_type, j.args, j.priority, j.created_at`,
+        `FROM jobs j`,
+        `WHERE j.status = 'unfulfilled'`,
+        `AND j.job_type IN ('from-scratch-index', 'incremental-index')`,
+        `AND NOT EXISTS (`,
+        `  SELECT 1 FROM job_reservations jr`,
+        `  WHERE jr.job_id = j.id AND jr.completed_at IS NULL`,
+        `)`,
+        `ORDER BY j.created_at ASC`,
+      ])) as {
+        id: string;
+        job_type: string;
+        args: { realmURL?: string };
+        priority: number;
+        created_at: string;
+      }[];
+      return rows.map((r) => ({
+        jobId: Number(r.id),
+        jobType: r.job_type,
+        realmURL: r.args?.realmURL ?? 'unknown',
+        priority: r.priority,
+        createdAt: r.created_at,
+      }));
+    }
+
     router.get('/_indexing-dashboard', async (ctxt: Koa.Context) => {
       ctxt.set('Content-Type', 'text/html; charset=utf-8');
-      ctxt.body = renderIndexingDashboard(eventSink.getSnapshot());
+      let pending = await getPendingJobs();
+      ctxt.body = renderIndexingDashboard({
+        ...eventSink.getSnapshot(),
+        pending,
+      });
       ctxt.status = 200;
     });
     router.get('/_indexing-status', async (ctxt: Koa.Context) => {
       ctxt.set('Content-Type', 'application/json');
-      ctxt.body = JSON.stringify(eventSink.getSnapshot());
+      let pending = await getPendingJobs();
+      ctxt.body = JSON.stringify({
+        ...eventSink.getSnapshot(),
+        pending,
+      });
       ctxt.status = 200;
     });
   }
@@ -558,9 +596,7 @@ async function startWorker(
         ) {
           try {
             let payload = message.substring('progress|'.length);
-            let progressEvent = JSON.parse(
-              payload,
-            ) as IndexingProgressEvent;
+            let progressEvent = JSON.parse(payload) as IndexingProgressEvent;
             eventSink.handleEvent(progressEvent);
           } catch (e) {
             log.error(`Failed to parse progress event: ${e}`);

--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -119,7 +119,13 @@ let {
 let isReady = false;
 let isExiting = false;
 let workers: ChildProcess[] = [];
-let eventSink = new IndexingEventSink();
+function isIndexingDashboardEnabled(): boolean {
+  return !ECS_CONTAINER_METADATA_URI;
+}
+
+let eventSink: IndexingEventSink | undefined = isIndexingDashboardEnabled()
+  ? new IndexingEventSink()
+  : undefined;
 
 process.on('SIGINT', () => (isExiting = true));
 process.on('SIGTERM', () => (isExiting = true));
@@ -146,7 +152,7 @@ if (port != null) {
     ctxt.body = JSON.stringify(result);
     ctxt.status = isReady ? 200 : 503;
   });
-  if (!ECS_CONTAINER_METADATA_URI) {
+  if (eventSink) {
     router.get('/_indexing-dashboard', async (ctxt: Koa.Context) => {
       ctxt.set('Content-Type', 'text/html; charset=utf-8');
       ctxt.body = renderIndexingDashboard(eventSink.getSnapshot());
@@ -546,12 +552,19 @@ async function startWorker(
             (worker as any).__boxelIndexState = undefined;
           }
         } else if (
+          eventSink &&
           typeof message === 'string' &&
           message.startsWith('progress|')
         ) {
-          let payload = message.substring('progress|'.length);
-          let progressEvent = JSON.parse(payload) as IndexingProgressEvent;
-          eventSink.handleEvent(progressEvent);
+          try {
+            let payload = message.substring('progress|'.length);
+            let progressEvent = JSON.parse(
+              payload,
+            ) as IndexingProgressEvent;
+            eventSink.handleEvent(progressEvent);
+          } catch (e) {
+            log.error(`Failed to parse progress event: ${e}`);
+          }
         }
       });
     }),

--- a/packages/realm-server/worker.ts
+++ b/packages/realm-server/worker.ts
@@ -123,7 +123,7 @@ let autoMigrate = migrateDB || undefined;
   }
 
   function reportProgress(event: IndexingProgressEvent) {
-    if (process.send) {
+    if (!ECS_CONTAINER_METADATA_URI && process.send) {
       process.send(`progress|${JSON.stringify(event)}`);
     }
   }

--- a/packages/realm-server/worker.ts
+++ b/packages/realm-server/worker.ts
@@ -8,6 +8,7 @@ import {
   IndexWriter,
   registerCardReferencePrefix,
   type StatusArgs,
+  type IndexingProgressEvent,
 } from '@cardstack/runtime-common';
 import yargs from 'yargs';
 import * as Sentry from '@sentry/node';
@@ -121,6 +122,12 @@ let autoMigrate = migrateDB || undefined;
     }
   }
 
+  function reportProgress(event: IndexingProgressEvent) {
+    if (process.send) {
+      process.send(`progress|${JSON.stringify(event)}`);
+    }
+  }
+
   let dbAdapter = new PgAdapter({ autoMigrate });
   let queue = new PgQueueRunner({ adapter: dbAdapter, workerId, priority });
   let worker = new Worker({
@@ -130,6 +137,7 @@ let autoMigrate = migrateDB || undefined;
     matrixURL: new URL(matrixURL),
     secretSeed: REALM_SECRET_SEED,
     reportStatus,
+    reportProgress,
     realmServerMatrixUsername: REALM_SERVER_MATRIX_USERNAME,
     dbAdapter,
     queuePublisher: new PgQueuePublisher(dbAdapter),

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -28,6 +28,7 @@ import { moduleFrom } from './code-ref';
 import type { CacheScope, DefinitionLookup } from './definition-lookup';
 import { resolveCardReference } from './card-reference-resolver';
 import { isCardError } from './error';
+import type { IndexingProgressEvent } from './worker';
 import { IndexRunnerDependencyManager } from './index-runner/dependency-resolver';
 import { discoverInvalidations } from './index-runner/discover-invalidations';
 import { visitFileForIndexing } from './index-runner/visit-file';
@@ -61,6 +62,7 @@ export class IndexRunner {
     jobInfo: JobInfo | undefined,
     status: 'start' | 'finish',
   ) => void;
+  #onProgress?: (event: IndexingProgressEvent) => void;
   readonly stats: Stats = {
     instancesIndexed: 0,
     filesIndexed: 0,
@@ -78,6 +80,7 @@ export class IndexRunner {
     ignoreData = {},
     jobInfo,
     reportStatus,
+    onProgress,
     prerenderer,
     auth,
     fetch,
@@ -97,6 +100,7 @@ export class IndexRunner {
       jobInfo: JobInfo | undefined,
       status: 'start' | 'finish',
     ): void;
+    onProgress?(event: IndexingProgressEvent): void;
   }) {
     this.#indexWriter = indexWriter;
     this.#realmPaths = new RealmPaths(realmURL);
@@ -105,6 +109,7 @@ export class IndexRunner {
     this.#ignoreData = ignoreData;
     this.#jobInfo = jobInfo ?? { jobId: -1, reservationId: -1 };
     this.#reportStatus = reportStatus;
+    this.#onProgress = onProgress;
     this.#prerenderer = prerenderer;
     this.#auth = auth;
     this.#fetch = fetch;
@@ -164,8 +169,26 @@ export class IndexRunner {
       await current.#dependencyResolver.orderInvalidationsByDependencies(
         invalidations,
       );
+    current.#onProgress?.({
+      type: 'indexing-started',
+      realmURL: current.realmURL.href,
+      jobId: current.#jobInfo.jobId,
+      jobType: 'from-scratch',
+      totalFiles: invalidations.length,
+      files: invalidations.map((u) => u.href),
+    });
+    let filesCompleted = 0;
     for (let invalidation of invalidations) {
       await current.tryToVisit(invalidation);
+      filesCompleted++;
+      current.#onProgress?.({
+        type: 'file-visited',
+        realmURL: current.realmURL.href,
+        jobId: current.#jobInfo.jobId,
+        url: invalidation.href,
+        filesCompleted,
+        totalFiles: invalidations.length,
+      });
     }
     current.#perfLog.debug(
       `${jobIdentity(current.#jobInfo)} completed index visit in ${Date.now() - visitStart} ms`,
@@ -176,6 +199,12 @@ export class IndexRunner {
       `${jobIdentity(current.#jobInfo)} completed index finalization in ${Date.now() - finalizeStart} ms`,
     );
     current.stats.totalIndexEntries = totalIndexEntries;
+    current.#onProgress?.({
+      type: 'indexing-finished',
+      realmURL: current.realmURL.href,
+      jobId: current.#jobInfo.jobId,
+      stats: current.stats,
+    });
     current.#log.debug(
       `${jobIdentity(current.#jobInfo)} completed from scratch indexing in ${Date.now() - start}ms`,
     );
@@ -242,6 +271,15 @@ export class IndexRunner {
     }
 
     let hrefs = urls.map((u) => u.href);
+    current.#onProgress?.({
+      type: 'indexing-started',
+      realmURL: current.realmURL.href,
+      jobId: current.#jobInfo.jobId,
+      jobType: 'incremental',
+      totalFiles: invalidations.length,
+      files: invalidations.map((u) => u.href),
+    });
+    let filesCompleted = 0;
     for (let invalidation of invalidations) {
       if (
         operations.get(invalidation.href) === 'delete' &&
@@ -251,10 +289,25 @@ export class IndexRunner {
       } else {
         await current.tryToVisit(invalidation);
       }
+      filesCompleted++;
+      current.#onProgress?.({
+        type: 'file-visited',
+        realmURL: current.realmURL.href,
+        jobId: current.#jobInfo.jobId,
+        url: invalidation.href,
+        filesCompleted,
+        totalFiles: invalidations.length,
+      });
     }
 
     let { totalIndexEntries } = await current.batch.done();
     current.stats.totalIndexEntries = totalIndexEntries;
+    current.#onProgress?.({
+      type: 'indexing-finished',
+      realmURL: current.realmURL.href,
+      jobId: current.#jobInfo.jobId,
+      stats: current.stats,
+    });
 
     current.#log.debug(
       `${jobIdentity(current.#jobInfo)} completed incremental indexing for ${urls.map((u) => u.href).join()} in ${

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -177,34 +177,37 @@ export class IndexRunner {
       totalFiles: invalidations.length,
       files: invalidations.map((u) => u.href),
     });
-    let filesCompleted = 0;
-    for (let invalidation of invalidations) {
-      await current.tryToVisit(invalidation);
-      filesCompleted++;
+    try {
+      let filesCompleted = 0;
+      for (let invalidation of invalidations) {
+        await current.tryToVisit(invalidation);
+        filesCompleted++;
+        current.#onProgress?.({
+          type: 'file-visited',
+          realmURL: current.realmURL.href,
+          jobId: current.#jobInfo.jobId,
+          url: invalidation.href,
+          filesCompleted,
+          totalFiles: invalidations.length,
+        });
+      }
+      current.#perfLog.debug(
+        `${jobIdentity(current.#jobInfo)} completed index visit in ${Date.now() - visitStart} ms`,
+      );
+      let finalizeStart = Date.now();
+      let { totalIndexEntries } = await current.batch.done();
+      current.#perfLog.debug(
+        `${jobIdentity(current.#jobInfo)} completed index finalization in ${Date.now() - finalizeStart} ms`,
+      );
+      current.stats.totalIndexEntries = totalIndexEntries;
+    } finally {
       current.#onProgress?.({
-        type: 'file-visited',
+        type: 'indexing-finished',
         realmURL: current.realmURL.href,
         jobId: current.#jobInfo.jobId,
-        url: invalidation.href,
-        filesCompleted,
-        totalFiles: invalidations.length,
+        stats: current.stats,
       });
     }
-    current.#perfLog.debug(
-      `${jobIdentity(current.#jobInfo)} completed index visit in ${Date.now() - visitStart} ms`,
-    );
-    let finalizeStart = Date.now();
-    let { totalIndexEntries } = await current.batch.done();
-    current.#perfLog.debug(
-      `${jobIdentity(current.#jobInfo)} completed index finalization in ${Date.now() - finalizeStart} ms`,
-    );
-    current.stats.totalIndexEntries = totalIndexEntries;
-    current.#onProgress?.({
-      type: 'indexing-finished',
-      realmURL: current.realmURL.href,
-      jobId: current.#jobInfo.jobId,
-      stats: current.stats,
-    });
     current.#log.debug(
       `${jobIdentity(current.#jobInfo)} completed from scratch indexing in ${Date.now() - start}ms`,
     );
@@ -279,35 +282,38 @@ export class IndexRunner {
       totalFiles: invalidations.length,
       files: invalidations.map((u) => u.href),
     });
-    let filesCompleted = 0;
-    for (let invalidation of invalidations) {
-      if (
-        operations.get(invalidation.href) === 'delete' &&
-        hrefs.includes(invalidation.href)
-      ) {
-        // file is deleted, there is nothing to visit
-      } else {
-        await current.tryToVisit(invalidation);
+    try {
+      let filesCompleted = 0;
+      for (let invalidation of invalidations) {
+        if (
+          operations.get(invalidation.href) === 'delete' &&
+          hrefs.includes(invalidation.href)
+        ) {
+          // file is deleted, there is nothing to visit
+        } else {
+          await current.tryToVisit(invalidation);
+        }
+        filesCompleted++;
+        current.#onProgress?.({
+          type: 'file-visited',
+          realmURL: current.realmURL.href,
+          jobId: current.#jobInfo.jobId,
+          url: invalidation.href,
+          filesCompleted,
+          totalFiles: invalidations.length,
+        });
       }
-      filesCompleted++;
+
+      let { totalIndexEntries } = await current.batch.done();
+      current.stats.totalIndexEntries = totalIndexEntries;
+    } finally {
       current.#onProgress?.({
-        type: 'file-visited',
+        type: 'indexing-finished',
         realmURL: current.realmURL.href,
         jobId: current.#jobInfo.jobId,
-        url: invalidation.href,
-        filesCompleted,
-        totalFiles: invalidations.length,
+        stats: current.stats,
       });
     }
-
-    let { totalIndexEntries } = await current.batch.done();
-    current.stats.totalIndexEntries = totalIndexEntries;
-    current.#onProgress?.({
-      type: 'indexing-finished',
-      realmURL: current.realmURL.href,
-      jobId: current.#jobInfo.jobId,
-      stats: current.stats,
-    });
 
     current.#log.debug(
       `${jobIdentity(current.#jobInfo)} completed incremental indexing for ${urls.map((u) => u.href).join()} in ${

--- a/packages/runtime-common/tasks/index.ts
+++ b/packages/runtime-common/tasks/index.ts
@@ -8,7 +8,7 @@ import type {
   RealmPermissions,
   DefinitionLookup,
 } from '../index';
-import type { JobInfo } from '../worker';
+import type { JobInfo, IndexingProgressEvent } from '../worker';
 export * from './lint';
 export * from './full-reindex';
 export * from './daily-credit-grant';
@@ -30,6 +30,7 @@ export interface TaskArgs {
   getAuthedFetch(args: WorkerArgs): Promise<typeof globalThis.fetch>;
   createPrerenderAuth(userId: string, permissions: RealmPermissions): string;
   reportStatus(jobInfo: JobInfo | undefined, status: 'start' | 'finish'): void;
+  reportProgress?(event: IndexingProgressEvent): void;
 }
 
 export type Task<T, K> = (

--- a/packages/runtime-common/tasks/indexer.ts
+++ b/packages/runtime-common/tasks/indexer.ts
@@ -236,6 +236,7 @@ registerQueueJobDefinition({
 const fromScratchIndex: Task<FromScratchArgs, FromScratchResult> = ({
   log,
   reportStatus,
+  reportProgress,
   dbAdapter,
   matrixURL,
   indexWriter,
@@ -268,6 +269,7 @@ const fromScratchIndex: Task<FromScratchArgs, FromScratchResult> = ({
       definitionLookup,
       jobInfo,
       reportStatus,
+      onProgress: reportProgress,
       auth,
       fetch: _fetch,
       prerenderer,
@@ -292,6 +294,7 @@ const fromScratchIndex: Task<FromScratchArgs, FromScratchResult> = ({
 const incrementalIndex: Task<IncrementalArgs, IncrementalResult> = ({
   log,
   reportStatus,
+  reportProgress,
   dbAdapter,
   matrixURL,
   indexWriter,
@@ -325,6 +328,7 @@ const incrementalIndex: Task<IncrementalArgs, IncrementalResult> = ({
       definitionLookup,
       jobInfo,
       reportStatus,
+      onProgress: reportProgress,
       auth,
       fetch: _fetch,
       prerenderer,

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -64,6 +64,18 @@ export interface StatusArgs {
   deps?: string[];
 }
 
+export interface IndexingProgressEvent {
+  type: 'indexing-started' | 'file-visited' | 'indexing-finished';
+  realmURL: string;
+  jobId: number;
+  jobType?: string;
+  totalFiles?: number;
+  filesCompleted?: number;
+  files?: string[];
+  url?: string;
+  stats?: Stats;
+}
+
 export class Worker {
   #log = logger('worker');
   #indexWriter: IndexWriter;
@@ -77,6 +89,7 @@ export class Worker {
   #realmAuthCache: Map<string, RealmAuthDataSource> = new Map();
   #secretSeed: string;
   #reportStatus: ((args: StatusArgs) => void) | undefined;
+  #reportProgress: ((event: IndexingProgressEvent) => void) | undefined;
   #realmServerMatrixUsername;
   #createPrerenderAuth: (
     userId: string,
@@ -93,6 +106,7 @@ export class Worker {
     realmServerMatrixUsername,
     secretSeed,
     reportStatus,
+    reportProgress,
     prerenderer,
     createPrerenderAuth,
   }: {
@@ -106,6 +120,7 @@ export class Worker {
     secretSeed: string;
     prerenderer: Prerenderer;
     reportStatus?: (args: StatusArgs) => void;
+    reportProgress?: (event: IndexingProgressEvent) => void;
     createPrerenderAuth: (
       userId: string,
       permissions: RealmPermissions,
@@ -117,6 +132,7 @@ export class Worker {
     this.#matrixURL = matrixURL;
     this.#secretSeed = secretSeed;
     this.#reportStatus = reportStatus;
+    this.#reportProgress = reportProgress;
     this.#realmServerMatrixUsername = realmServerMatrixUsername;
     this.#dbAdapter = dbAdapter;
     this.#queuePublisher = queuePublisher;
@@ -142,6 +158,7 @@ export class Worker {
       queuePublisher: this.#queuePublisher,
       getAuthedFetch: this.makeAuthedFetch.bind(this),
       reportStatus: this.reportStatus.bind(this),
+      reportProgress: this.reportProgress.bind(this),
       createPrerenderAuth: this.#createPrerenderAuth,
     };
 
@@ -219,6 +236,10 @@ export class Worker {
     if (args?.jobId) {
       this.#reportStatus?.({ ...args, jobId: String(args.jobId), status });
     }
+  }
+
+  private reportProgress(event: IndexingProgressEvent) {
+    this.#reportProgress?.(event);
   }
 }
 


### PR DESCRIPTION
I’m often wondering when developing how much is left to index:

<img width="2884" height="2140" alt="image" src="https://github.com/user-attachments/assets/7130ea6f-48c9-4a43-9602-94128870b99e" />

This adds an event sink for index runners to report on their progress and a worker manager dashboard to report that.