### PR TITLE
open pr reviewer should point to ecosystem and boxel-developers

### DIFF
--- a/packages/bot-runner/lib/github.ts
+++ b/packages/bot-runner/lib/github.ts
@@ -1,5 +1,5 @@
 const GITHUB_API_BASE = 'https://api.github.com';
-const HARDCODED_REVIEWER = 'tintinthong';
+const GITHUB_TEAM_REVIEWERS = ['ecosystem-team', 'boxel-developers'];
 
 export interface OpenPullRequestParams {
   owner: string;
@@ -86,7 +86,7 @@ export class OctokitGitHubClient implements GitHubClient {
       method: 'POST',
       path: `/repos/${params.owner}/${params.repo}/pulls/${createdPR.number}/requested_reviewers`,
       body: {
-        reviewers: [HARDCODED_REVIEWER],
+        team_reviewers: GITHUB_TEAM_REVIEWERS,
       },
     });
 


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-10432/reviewer-should-point-to-cardstack-developerecosystem

<img width="2584" height="984" alt="image" src="https://github.com/user-attachments/assets/989c9e8b-e715-4a2a-a72d-50a9fb191e9d" />
