### PR TITLE
Pass listing summary to PR body

### DIFF
--- a/packages/bot-runner/lib/create-listing-pr-handler.ts
+++ b/packages/bot-runner/lib/create-listing-pr-handler.ts
@@ -202,20 +202,18 @@ export class CreateListingPRHandler {
       eventContent.input && typeof eventContent.input === 'object'
         ? (eventContent.input as Record<string, unknown>)
         : {};
-    let listingDescription =
-      typeof input.listingDescription === 'string'
-        ? input.listingDescription.trim()
-        : typeof input.description === 'string'
-          ? input.description.trim()
-          : '';
+    let listingSummary =
+      typeof input.listingSummary === 'string'
+        ? input.listingSummary.trim()
+        : '';
     let files = await getContentsFromRealm(runCommandResult?.cardResultString);
-    let descriptionValue = listingDescription || '_No description provided_';
 
     return [
       '## Summary',
-      '',
+       ...(listingSummary
+        ? [listingSummary, '', '---']
+        : []),
       `- Listing Name: ${context.listingDisplayName}`,
-      `- Listing Description: ${descriptionValue}`,
       `- Room ID: \`${context.roomId}\``,
       `- User ID: \`${runAs}\``,
       `- Number of Files: ${files.files.length}`,

--- a/packages/bot-runner/tests/command-runner-test.ts
+++ b/packages/bot-runner/tests/command-runner-test.ts
@@ -189,9 +189,9 @@ module('command runner', () => {
         userId: '@alice:localhost',
         input: {
           roomId: '!abc123:localhost',
-          listingName: 'My Listing',
-          listingDescription: 'Example listing',
-        },
+          listingName: 'My Listing Name',
+          listingSummary: 'My listing Summary'
+        },  
       },
       'bot-registration-2',
     );

--- a/packages/bot-runner/tests/create-listing-pr-handler-test.ts
+++ b/packages/bot-runner/tests/create-listing-pr-handler-test.ts
@@ -25,7 +25,7 @@ module('create-listing-pr handler', () => {
       input: {
         roomId: '!abc123:localhost',
         listingName: 'My Listing',
-        listingDescription: 'Example listing',
+        listingSummary: 'My listing Summary',
       },
     };
 
@@ -75,6 +75,10 @@ module('create-listing-pr handler', () => {
       openedCall.params.body?.toString().includes('Submission Card'),
       'summary body omits submission card URL when not provided',
     );
+    assert.true(
+      openedCall.params.body?.toString().includes('My listing Summary\n\n---'),
+      'summary body includes listing summary followed by divider',
+    );
   });
 
   test('includes submission card URL as a markdown link when provided', async (assert) => {
@@ -96,7 +100,7 @@ module('create-listing-pr handler', () => {
       input: {
         roomId: '!abc123:localhost',
         listingName: 'My Listing',
-        listingDescription: 'Example listing',
+        listingSummary: 'My listing Summary',
       },
     };
 

--- a/packages/host/app/commands/bot-requests/create-listing-pr-request.ts
+++ b/packages/host/app/commands/bot-requests/create-listing-pr-request.ts
@@ -38,9 +38,11 @@ export default class CreateListingPRRequestCommand extends HostBaseCommand<
 
     let { realm, listingId } = input;
     let listingName: string | undefined;
+    let listingSummary: string | undefined;
     let listing = await this.store.get<Listing>(listingId);
     if (listing && isCardInstance(listing)) {
       listingName = listing.name ?? listing.id;
+      listingSummary = listing.summary ?? undefined;
     }
 
     let useAiAssistantCommand = new UseAiAssistantCommand(this.commandContext);
@@ -65,6 +67,7 @@ export default class CreateListingPRRequestCommand extends HostBaseCommand<
         realm,
         listingId,
         ...(listingName ? { listingName } : {}),
+        ...(listingSummary ? { listingSummary } : {}),
       },
     });
   }


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-10433/listing-description-return-null-after-a-pr-open

The PR description showed "No description provided" because the listingSummary field was never included in the bot trigger event input. Now we extract listing.summary from the card and pass it as listingSummary so the bot-runner can display it in the PR body as a standalone block separated by dividers, rather than inline in a bullet.



## Demo:

Before:
<img width="1676" height="634" alt="image" src="https://github.com/user-attachments/assets/c9a67e87-d3df-43a1-babc-781ee3bfd62f" />


After:
<img width="1802" height="1022" alt="image" src="https://github.com/user-attachments/assets/4e2bde1f-e6ac-46fd-9e4c-4735f9d33cdd" />
