### PR TITLE
Add skills realm reset to full-reset script

### DIFF
--- a/packages/realm-server/scripts/full-reset.sh
+++ b/packages/realm-server/scripts/full-reset.sh
@@ -13,6 +13,9 @@ pnpm migrate up
 # well.
 rm -rf "${SCRIPTS_DIR}/../realms"
 
+# reset the skills realm contents so they are in sync with the skills repository
+pnpm --dir="${SCRIPTS_DIR}/../../skills-realm" skills:reset
+
 # also now you will have users that have realm associations to realms that don't
 # exist anymore, so we should clear the matrix state so it can be in sync with
 # the DB state


### PR DESCRIPTION
## Summary
- Add `skills:reset` step to `full-reset.sh` so the skills realm contents are re-cloned from the repository, keeping them in sync with the freshly reset database and matrix state.

## Test plan
- [x] Run `full-reset.sh` and verify the skills realm contents directory is removed and re-cloned

🤖 Generated with [Claude Code](https://claude.com/claude-code)