### PR TITLE
ci: Add more concurrency cancellation

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -30,6 +30,9 @@ jobs:
     uses: ./.github/workflows/test-web-assets.yaml
     with:
       skip_catalog: true
+    concurrency:
+      group: test-web-assets-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
 
   host-test:
     name: Host Tests
@@ -191,6 +194,9 @@ jobs:
   host-percy-finalize:
     name: Finalise Percy
     if: always()
+    concurrency:
+      group: host-percy-finalize-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     needs: host-test
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -31,7 +31,7 @@ jobs:
     with:
       skip_catalog: true
     concurrency:
-      group: test-web-assets-${{ github.head_ref || github.run_id }}
+      group: ci-host-test-web-assets-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
   host-test:

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -118,16 +118,16 @@ jobs:
 
       - name: Upload junit report to GitHub Actions Artifacts
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: host-test-report-${{ matrix.shardIndex }}
           path: junit/host-${{ matrix.shardIndex }}.xml
           retention-days: 30
       - name: Print realm server logs
-        if: always()
+        if: ${{ !cancelled() }}
         run: cat /tmp/server.log
       - name: Extract worker and prerender logs
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           grep -E '^\[start:worker-development' /tmp/server.log > /tmp/worker-manager.log || true
           grep -E '^\[start:prerender-dev' /tmp/server.log > /tmp/prerender-server.log || true
@@ -136,56 +136,56 @@ jobs:
           grep -E '^\[start:test-realms|^\[start:worker-test' /tmp/server.log > /tmp/test-realms.log || true
       - name: Upload realm server log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: realm-server-log-${{ matrix.shardIndex }}
           path: /tmp/server.log
           retention-days: 30
       - name: Upload worker manager log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: worker-manager-log-${{ matrix.shardIndex }}
           path: /tmp/worker-manager.log
           retention-days: 30
       - name: Upload prerender server log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: prerender-server-log-${{ matrix.shardIndex }}
           path: /tmp/prerender-server.log
           retention-days: 30
       - name: Upload prerender manager log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: prerender-manager-log-${{ matrix.shardIndex }}
           path: /tmp/prerender-manager.log
           retention-days: 30
       - name: Upload start:development log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: start-development-log-${{ matrix.shardIndex }}
           path: /tmp/start-development.log
           retention-days: 30
       - name: Upload test-realms log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: test-realms-log-${{ matrix.shardIndex }}
           path: /tmp/test-realms.log
           retention-days: 30
       - name: Upload testem log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: testem-log-${{ matrix.shardIndex }}
           path: junit/host-testem.log
           retention-days: 30
       - name: Upload icon server log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: icon-server-log-${{ matrix.shardIndex }}
           path: /tmp/icon-server.log
@@ -193,7 +193,7 @@ jobs:
 
   host-percy-finalize:
     name: Finalise Percy
-    if: always()
+    if: ${{ !cancelled() }}
     concurrency:
       group: host-percy-finalize-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
@@ -213,7 +213,7 @@ jobs:
 
   host-merge-reports-and-publish:
     name: Merge Host reports and publish
-    if: always()
+    if: ${{ !cancelled() }}
     concurrency:
       group: host-merge-reports-and-publish-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
@@ -243,7 +243,7 @@ jobs:
 
       - name: Upload merged report
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: host-test-report-merged
           path: host.xml
@@ -251,7 +251,7 @@ jobs:
 
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # 2.18.0
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           junit_files: host.xml
           check_name: Host Test Results

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -214,6 +214,9 @@ jobs:
   host-merge-reports-and-publish:
     name: Merge Host reports and publish
     if: always()
+    concurrency:
+      group: host-merge-reports-and-publish-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     needs: host-test
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -23,84 +23,84 @@ jobs:
       - uses: ./.github/actions/init
 
       - name: Lint Boxel Icons
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/boxel-icons
       - name: Build Boxel Icons
         # To faciliate linting of projects that depend on Boxel Icons
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run build
         working-directory: packages/boxel-icons
       - name: Lint Boxel UI
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/boxel-ui/addon
       - name: Build Boxel UI
         # To faciliate linting of projects that depend on Boxel UI
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run build
         working-directory: packages/boxel-ui/addon
       - name: Lint Boxel UI Test App
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/boxel-ui/test-app
       - name: Lint Host
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/host
       - name: Lint Matrix
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/matrix
       - name: Lint Realm Server
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/realm-server
       - name: Lint Runtime Common
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/runtime-common
       - name: Lint Billing
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/billing
       - name: Lint Postgres
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/postgres
       - name: Lint Base Realm
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/base
       - name: Lint Catalog Realm
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/catalog-realm
       - name: Lint Experiments Realm
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/experiments-realm
       - name: Lint Software Factory
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/software-factory
       - name: Lint Boxel Tools VS Code extension
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/vscode-boxel-tools
       - name: Lint ESLint Plugin
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/eslint-plugin-boxel
       - name: Lint AI Bot
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/ai-bot
       - name: Lint Bot Runner
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/bot-runner
       - name: Lint Workspace Sync CLI
-        if: always()
+        if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/workspace-sync-cli

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -391,9 +391,12 @@ jobs:
     needs:
       - change-check
       - matrix-client-test
-    # always() makes it run even if a matrix-client-test shard fails
-    if: always() && (needs.change-check.outputs.matrix == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true')
+    # !cancelled() makes it run even if a matrix-client-test shard fails, but still respects cancellation
+    if: ${{ !cancelled() && (needs.change-check.outputs.matrix == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true') }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: matrix-client-merge-reports-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
 
     permissions:
       id-token: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -332,38 +332,38 @@ jobs:
         run: pnpm test:group ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         working-directory: packages/matrix
       - name: Print realm server logs
-        if: always()
+        if: ${{ !cancelled() }}
         run: cat /tmp/server.log
       - name: Extract worker and prerender logs
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           grep -E '^\[start:worker-base|^\[start:worker-development|^\[start:worker-test' /tmp/server.log > /tmp/worker-manager.log || true
           grep -E '^\[start:prerender-dev' /tmp/server.log > /tmp/prerender-server.log || true
           grep -E '^\[start:prerender-manager-dev' /tmp/server.log > /tmp/prerender-manager.log || true
       - name: Upload realm server log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: matrix-test-realm-server-log-${{ matrix.shardIndex }}
           path: /tmp/server.log
           retention-days: 30
       - name: Upload worker manager log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: matrix-test-worker-manager-log-${{ matrix.shardIndex }}
           path: /tmp/worker-manager.log
           retention-days: 30
       - name: Upload prerender server log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: matrix-test-prerender-server-log-${{ matrix.shardIndex }}
           path: /tmp/prerender-server.log
           retention-days: 30
       - name: Upload prerender manager log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: matrix-test-prerender-manager-log-${{ matrix.shardIndex }}
           path: /tmp/prerender-manager.log
@@ -590,16 +590,16 @@ jobs:
         env:
           TEST_MODULE: ${{matrix.testModule}}
       - name: Print realm server logs
-        if: always()
+        if: ${{ !cancelled() }}
         run: cat /tmp/server.log
       - name: Prepare artifact name
         id: artifact_name
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           export SAFE_ARTIFACT_NAME=$(echo ${{ matrix.testModule }} |  sed 's/[/]/_/g')
           echo "artifact_name=$SAFE_ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
       - name: Extract worker and prerender logs
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           grep -E '^\[start:worker-development|^\[start:worker-test' /tmp/server.log > /tmp/worker-manager.log || true
           grep -E '^\[start:prerender-dev' /tmp/server.log > /tmp/prerender-server.log || true
@@ -608,42 +608,42 @@ jobs:
           grep -E '^\[start:test-realms|^\[start:worker-test' /tmp/server.log > /tmp/test-realms.log || true
       - name: Upload realm server log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: realm-server-test-realm-server-log-${{steps.artifact_name.outputs.artifact_name}}
           path: /tmp/server.log
           retention-days: 30
       - name: Upload worker manager log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: realm-server-test-worker-manager-log-${{steps.artifact_name.outputs.artifact_name}}
           path: /tmp/worker-manager.log
           retention-days: 30
       - name: Upload prerender server log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: realm-server-test-prerender-server-log-${{steps.artifact_name.outputs.artifact_name}}
           path: /tmp/prerender-server.log
           retention-days: 30
       - name: Upload prerender manager log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: realm-server-test-prerender-manager-log-${{steps.artifact_name.outputs.artifact_name}}
           path: /tmp/prerender-manager.log
           retention-days: 30
       - name: Upload start:development log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: realm-server-test-start-development-log-${{steps.artifact_name.outputs.artifact_name}}
           path: /tmp/start-development.log
           retention-days: 30
       - name: Upload test-realms log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: realm-server-test-test-realms-log-${{steps.artifact_name.outputs.artifact_name}}
           path: /tmp/test-realms.log
@@ -792,7 +792,7 @@ jobs:
         working-directory: packages/workspace-sync-cli
       - name: Upload test services log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: workspace-sync-cli-test-services-log
           path: /tmp/test-services.log

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,7 +124,7 @@ jobs:
     if: needs.change-check.outputs.boxel == 'true' || needs.change-check.outputs.boxel-ui == 'true' || needs.change-check.outputs.matrix == 'true' || needs.change-check.outputs.realm-server == 'true' || needs.change-check.outputs.software-factory == 'true' || needs.change-check.outputs.vscode-boxel-tools == 'true' || needs.change-check.outputs.workspace-sync-cli == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
     uses: ./.github/workflows/test-web-assets.yaml
     concurrency:
-      group: test-web-assets-${{ github.head_ref || github.run_id }}
+      group: ci-test-web-assets-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
   ai-bot-test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,6 +123,9 @@ jobs:
     needs: change-check
     if: needs.change-check.outputs.boxel == 'true' || needs.change-check.outputs.boxel-ui == 'true' || needs.change-check.outputs.matrix == 'true' || needs.change-check.outputs.realm-server == 'true' || needs.change-check.outputs.software-factory == 'true' || needs.change-check.outputs.vscode-boxel-tools == 'true' || needs.change-check.outputs.workspace-sync-cli == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
     uses: ./.github/workflows/test-web-assets.yaml
+    concurrency:
+      group: test-web-assets-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
 
   ai-bot-test:
     name: AI bot Tests

--- a/.github/workflows/diff-skills.yaml
+++ b/.github/workflows/diff-skills.yaml
@@ -11,3 +11,6 @@ jobs:
   diff-skills:
     uses: cardstack/gh-actions/.github/workflows/diff-skills.yml@main
     secrets: inherit
+    concurrency:
+      group: diff-skills-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -339,7 +339,7 @@ jobs:
         deploy-realm-server,
         post-deploy-realm-server,
       ]
-    if: ${{ github.event_name == 'workflow_dispatch' && !cancelled() }}
+    if: github.event_name == 'workflow_dispatch' && always()
     runs-on: ubuntu-latest
     steps:
       - name: Set deployment status

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -339,7 +339,7 @@ jobs:
         deploy-realm-server,
         post-deploy-realm-server,
       ]
-    if: github.event_name == 'workflow_dispatch' && always()
+    if: ${{ github.event_name == 'workflow_dispatch' && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Set deployment status

--- a/.github/workflows/pr-boxel-ui.yml
+++ b/.github/workflows/pr-boxel-ui.yml
@@ -69,7 +69,7 @@ jobs:
     name: Update preview comment
     needs:
       - deploy-ui-preview-staging
-    if: ${{ always() && needs.deploy-ui-preview-staging.result == 'success' }}
+    if: ${{ !cancelled() && needs.deploy-ui-preview-staging.result == 'success' }}
     uses: ./.github/workflows/preview-comment.yml
     with:
       pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-boxel-ui.yml
+++ b/.github/workflows/pr-boxel-ui.yml
@@ -21,6 +21,9 @@ jobs:
   check-if-requires-preview:
     name: Check if a preview deploy is required
     runs-on: ubuntu-latest
+    concurrency:
+      group: check-if-requires-ui-preview-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     outputs:
       boxel-ui-files-changed: ${{ steps.boxel-ui-files-that-changed.outputs.any_changed }}
     steps:
@@ -40,7 +43,9 @@ jobs:
     # github.head_ref: the branch that the pull request is from. only appears on pull_request events
     if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref && needs.check-if-requires-preview.outputs.boxel-ui-files-changed == 'true'
     needs: check-if-requires-preview
-    concurrency: deploy-ui-preview-staging-${{ github.head_ref || github.run_id }}
+    concurrency:
+      group: deploy-ui-preview-staging-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Configure AWS credentials

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -20,6 +20,9 @@ permissions:
 jobs:
   publish-preview-comment:
     runs-on: ubuntu-latest
+    concurrency:
+      group: publish-preview-comment-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
       - name: Gather preview links
         id: gather

--- a/.github/workflows/preview-host.yml
+++ b/.github/workflows/preview-host.yml
@@ -50,7 +50,9 @@ jobs:
     # github.head_ref: the branch that the pull request is from. only appears on pull_request events
     if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref && needs.check-if-requires-preview.outputs.boxel-host-files-changed == 'true'
     needs: check-if-requires-preview
-    concurrency: deploy-host-preview-staging-${{ github.head_ref || github.run_id }}
+    concurrency:
+      group: deploy-host-preview-staging-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Configure AWS credentials
@@ -79,7 +81,9 @@ jobs:
     # github.head_ref: the branch that the pull request is from. only appears on pull_request events
     if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref && needs.check-if-requires-preview.outputs.boxel-host-files-changed == 'true'
     needs: check-if-requires-preview
-    concurrency: deploy-host-preview-production-${{ github.head_ref || github.run_id }}
+    concurrency:
+      group: deploy-host-preview-production-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Configure AWS credentials

--- a/.github/workflows/preview-host.yml
+++ b/.github/workflows/preview-host.yml
@@ -110,7 +110,7 @@ jobs:
     needs:
       - deploy-host-preview-staging
       - deploy-host-preview-production
-    if: ${{ always() && (needs.deploy-host-preview-staging.result == 'success' || needs.deploy-host-preview-production.result == 'success') }}
+    if: ${{ !cancelled() && (needs.deploy-host-preview-staging.result == 'success' || needs.deploy-host-preview-production.result == 'success') }}
     uses: ./.github/workflows/preview-comment.yml
     with:
       pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-host.yml
+++ b/.github/workflows/preview-host.yml
@@ -23,6 +23,9 @@ jobs:
   check-if-requires-preview:
     name: Check if a preview deploy is required
     runs-on: ubuntu-latest
+    concurrency:
+      group: check-if-requires-preview-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     outputs:
       boxel-host-files-changed: ${{ steps.boxel-host-files-that-changed.outputs.any_changed }}
     steps:

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -8,8 +8,11 @@ on:
 
 jobs:
   lint:
-    name: Lint
+    name: Lint YAML
     runs-on: ubuntu-latest
+    concurrency:
+      group: lint-yaml-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # 3.1.1


### PR DESCRIPTION
This causes more CI jobs to cancel when a newer commit is made, which is common when
accepting automated review suggestions. There’s no reason jobs should still be running
from the older commit when I’ve made so many more since I pushed it:

<img width="1298" height="326" alt="boxel 2026-03-17 16-17-22" src="https://github.com/user-attachments/assets/fbb1393a-442e-4969-a91f-04d9dca3c519" />

Many uses of `always()` are now using `!cancelled()`. We were using the former to ensure
some jobs or steps ran even when previous ones failed; this continues that but makes them
cancel for concurrency reasons.