### PR TITLE
server: Fix lint errors in deletion test

### DIFF
--- a/packages/realm-server/tests/server-endpoints/delete-realm-test.ts
+++ b/packages/realm-server/tests/server-endpoints/delete-realm-test.ts
@@ -20,7 +20,7 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
 
   async function createRealmFor(ownerUserId: string) {
     let endpoint = `delete-me-${uuidv4()}`;
-    let response = await context.request2
+    let response = await context.request
       .post('/_create-realm')
       .set('Accept', 'application/vnd.api+json')
       .set('Content-Type', 'application/json')
@@ -110,7 +110,7 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
       'mango@example.com',
     );
 
-    let publishResponse = await context.request2
+    let publishResponse = await context.request
       .post('/_publish-realm')
       .set('Accept', 'application/vnd.api+json')
       .set('Content-Type', 'application/json')
@@ -277,7 +277,7 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
       insert('claimed_domains_for_sites', nameExpressions, valueExpressions),
     );
 
-    let deleteResponse = await context.request2
+    let deleteResponse = await context.request
       .delete('/_delete-realm')
       .set('Accept', 'application/vnd.api+json')
       .set('Content-Type', 'application/json')
@@ -300,7 +300,7 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
     assert.strictEqual(deleteResponse.status, 204, 'realm deleted');
     assert.false(
       existsSync(
-        join(context.dir.name, 'realm_server_2', realmPath[0]!, realmPath[1]!),
+        join(context.dir.name, 'realm_server_1', realmPath[0]!, realmPath[1]!),
       ),
       'source realm directory was removed after realm deletion',
     );
@@ -308,7 +308,7 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
       existsSync(
         join(
           context.dir.name,
-          'realm_server_2',
+          'realm_server_1',
           '_published',
           publishedRealmId,
         ),
@@ -607,13 +607,13 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
     );
 
     assert.notOk(
-      context.testRealmServer2.testingOnlyRealms.find(
+      context.testRealmServer.testingOnlyRealms.find(
         (realm) => realm.url === realmURL,
       ),
       'source realm is unmounted',
     );
     assert.notOk(
-      context.testRealmServer2.testingOnlyRealms.find(
+      context.testRealmServer.testingOnlyRealms.find(
         (realm) => realm.url === publishedRealmURL,
       ),
       'published realm is unmounted',
@@ -633,7 +633,7 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
       'mango@example.com',
     );
 
-    let publishResponse = await context.request2
+    let publishResponse = await context.request
       .post('/_publish-realm')
       .set('Accept', 'application/vnd.api+json')
       .set('Content-Type', 'application/json')
@@ -655,7 +655,7 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
     let publishedRealmId = publishResponse.body.data.id as string;
     let publishedRealmPath = join(
       context.dir.name,
-      'realm_server_2',
+      'realm_server_1',
       PUBLISHED_DIRECTORY_NAME,
       publishedRealmId,
     );
@@ -664,7 +664,7 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
       'published realm directory exists',
     );
 
-    let mountedPublishedRealm = context.testRealmServer2.testingOnlyRealms.find(
+    let mountedPublishedRealm = context.testRealmServer.testingOnlyRealms.find(
       (realm) => realm.url === publishedRealmURL,
     );
     if (!mountedPublishedRealm) {
@@ -673,7 +673,7 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
     context.virtualNetwork.unmount(mountedPublishedRealm.handle);
 
     let mountedRealms = (
-      context.testRealmServer2 as unknown as { realms: { url: string }[] }
+      context.testRealmServer as unknown as { realms: { url: string }[] }
     ).realms;
     let publishedRealmIndex = mountedRealms.findIndex(
       (realm) => realm.url === publishedRealmURL,
@@ -685,7 +685,7 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
     );
     mountedRealms.splice(publishedRealmIndex, 1);
 
-    let deleteResponse = await context.request2
+    let deleteResponse = await context.request
       .delete('/_delete-realm')
       .set('Accept', 'application/vnd.api+json')
       .set('Content-Type', 'application/json')
@@ -720,7 +720,7 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
       'published realm records are removed',
     );
     assert.notOk(
-      context.testRealmServer2.testingOnlyRealms.find(
+      context.testRealmServer.testingOnlyRealms.find(
         (realm) => realm.url === realmURL,
       ),
       'source realm is unmounted',
@@ -736,7 +736,7 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
       [ownerUserId]: ['read', 'write', 'realm-owner'],
     });
 
-    let response = await context.request2
+    let response = await context.request
       .delete('/_delete-realm')
       .set('Accept', 'application/vnd.api+json')
       .set('Content-Type', 'application/json')
@@ -768,7 +768,7 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
   test('DELETE /_delete-realm rejects an invalid realm URL', async function (assert) {
     let ownerUserId = `@mango-${uuidv4()}:localhost`;
 
-    let response = await context.request2
+    let response = await context.request
       .delete('/_delete-realm')
       .set('Accept', 'application/vnd.api+json')
       .set('Content-Type', 'application/json')


### PR DESCRIPTION
There are lint errors [on `main`](https://github.com/cardstack/boxel/actions/runs/23247307163/job/67579117520#step:11:34). They didn’t show [on the PR](https://github.com/cardstack/boxel/pull/4173) because [these changes](https://github.com/cardstack/boxel/pull/4151) were merged separately.

There are other failures on `main` but this doesn’t address them.