### PR TITLE
Avoid syncing over the top of the OpenRouterModel folder

### DIFF
--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -105,7 +105,7 @@
     "setup:software-factory-in-deployment": "mkdir -p /persistent/software-factory && rsync --dry-run --itemize-changes --checksum --recursive --delete ../software-factory/realm/. /persistent/software-factory/ && rsync --checksum --recursive --delete ../software-factory/realm/. /persistent/software-factory/",
     "setup:boxel-homepage-in-deployment": "mkdir -p /persistent/boxel-homepage",
     "setup:external-catalog-in-deployment": "mkdir -p /persistent/external-catalog && pnpm --dir=../catalog catalog:setup && rsync --dry-run --itemize-changes --checksum --recursive --delete ../catalog/contents/. /persistent/external-catalog/ && rsync --checksum --recursive --delete ../catalog/contents/. /persistent/external-catalog/",
-    "setup:openrouter-in-deployment": "mkdir -p /persistent/openrouter && rsync --dry-run --itemize-changes --checksum --recursive --delete ../openrouter-realm/. /persistent/openrouter/ && rsync --checksum --recursive --delete ../openrouter-realm/. /persistent/openrouter/",
+    "setup:openrouter-in-deployment": "mkdir -p /persistent/openrouter /persistent/openrouter/OpenRouterModel && rsync --dry-run --itemize-changes --checksum --recursive --delete --exclude 'OpenRouterModel/' ../openrouter-realm/. /persistent/openrouter/ && rsync --checksum --recursive --delete --exclude 'OpenRouterModel/' ../openrouter-realm/. /persistent/openrouter/",
     "start": "PGPORT=5435 NODE_NO_WARNINGS=1 ts-node --transpileOnly main",
     "start:base": "./scripts/start-base.sh --workerManagerPort=4213",
     "start:test-realms": "./scripts/start-test-realms.sh --workerManagerPort=4211",


### PR DESCRIPTION
I think this is the reason the OR models are disappearing on deploy