### PR TITLE
Remove runtime realm owner escalation in webhook handler

### DIFF
--- a/packages/matrix/scripts/register-github-webhook-for-submission-realm.ts
+++ b/packages/matrix/scripts/register-github-webhook-for-submission-realm.ts
@@ -2,15 +2,13 @@
 import { registerRealmUser } from './register-realm-user-using-api';
 import { realmPassword } from '../helpers/realm-credentials';
 
-// Usage: register-github-webhook.ts [publicURL] [roomId] [prNumber]
+// Registers a GitHub webhook as the submission_realm user.
 //
-// Environment variables (override or replace positional args):
+// Environment variables:
 //   REALM_SERVER_URL        - realm server base URL (default: http://localhost:4201)
 //   COMMAND_URL             - override the command URL registered with the webhook
 //   SUBMISSION_REALM_URL    - realm URL where GithubEventCards are saved
-//   REALM_SECRET_SEED       - seed used to derive submission_realm password (required if MATRIX_PASSWORD not set)
-//   MATRIX_USERNAME         - override Matrix username (default: submission_realm)
-//   MATRIX_PASSWORD         - override Matrix password (default: derived from REALM_SECRET_SEED)
+//   REALM_SECRET_SEED       - seed used to derive submission_realm password (required)
 
 const realmServerURL = process.env.REALM_SERVER_URL || 'http://localhost:4201';
 
@@ -200,22 +198,14 @@ async function main() {
   console.log(`Command URL:   ${commandURL}`);
   console.log('');
 
-  // Step 1: Authenticate as submission_realm user by default
-  if (!process.env.MATRIX_USERNAME) {
-    process.env.MATRIX_USERNAME = 'submission_realm';
+  // Step 1: Authenticate as submission_realm user
+  const username = 'submission_realm';
+  const seed = process.env.REALM_SECRET_SEED;
+  if (!seed) {
+    throw new Error('REALM_SECRET_SEED must be set to derive submission_realm password');
   }
-  if (!process.env.MATRIX_PASSWORD) {
-    const seed = process.env.REALM_SECRET_SEED;
-    if (!seed) {
-      throw new Error(
-        'REALM_SECRET_SEED must be set to derive submission_realm password (or set MATRIX_PASSWORD explicitly)',
-      );
-    }
-    process.env.MATRIX_PASSWORD = await realmPassword(
-      process.env.MATRIX_USERNAME,
-      seed,
-    );
-  }
+  process.env.MATRIX_USERNAME = username;
+  process.env.MATRIX_PASSWORD = await realmPassword(username, seed);
 
   console.log('Authenticating...');
   const { jwt, userId } = await registerRealmUser();

--- a/packages/matrix/scripts/register-github-webhook.ts
+++ b/packages/matrix/scripts/register-github-webhook.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env ts-node
 import { registerRealmUser } from './register-realm-user-using-api';
+import { realmPassword } from '../helpers/realm-credentials';
 
 // Usage: register-github-webhook.ts [publicURL] [roomId] [prNumber]
 //
@@ -7,6 +8,9 @@ import { registerRealmUser } from './register-realm-user-using-api';
 //   REALM_SERVER_URL        - realm server base URL (default: http://localhost:4201)
 //   COMMAND_URL             - override the command URL registered with the webhook
 //   SUBMISSION_REALM_URL    - realm URL where GithubEventCards are saved
+//   REALM_SECRET_SEED       - seed used to derive submission_realm password (required if MATRIX_PASSWORD not set)
+//   MATRIX_USERNAME         - override Matrix username (default: submission_realm)
+//   MATRIX_PASSWORD         - override Matrix password (default: derived from REALM_SECRET_SEED)
 
 const realmServerURL = process.env.REALM_SERVER_URL || 'http://localhost:4201';
 
@@ -196,7 +200,23 @@ async function main() {
   console.log(`Command URL:   ${commandURL}`);
   console.log('');
 
-  // Step 1: Authenticate
+  // Step 1: Authenticate as submission_realm user by default
+  if (!process.env.MATRIX_USERNAME) {
+    process.env.MATRIX_USERNAME = 'submission_realm';
+  }
+  if (!process.env.MATRIX_PASSWORD) {
+    const seed = process.env.REALM_SECRET_SEED;
+    if (!seed) {
+      throw new Error(
+        'REALM_SECRET_SEED must be set to derive submission_realm password (or set MATRIX_PASSWORD explicitly)',
+      );
+    }
+    process.env.MATRIX_PASSWORD = await realmPassword(
+      process.env.MATRIX_USERNAME,
+      seed,
+    );
+  }
+
   console.log('Authenticating...');
   const { jwt, userId } = await registerRealmUser();
   console.log(`Authenticated as: ${userId}`);

--- a/packages/matrix/scripts/register-realm-user-using-api.ts
+++ b/packages/matrix/scripts/register-realm-user-using-api.ts
@@ -2,9 +2,6 @@ import { loginUser } from '../docker/synapse';
 
 const matrixURL = process.env.MATRIX_URL || 'http://localhost:8008';
 const realmServerURL = process.env.REALM_SERVER_URL || 'http://localhost:4201';
-const username = process.env.MATRIX_USERNAME;
-const password = process.env.MATRIX_PASSWORD;
-const registrationToken = process.env.REALM_REGISTRATION_TOKEN ?? 'dev-token';
 
 function toLocalpart(value: string): string {
   let trimmed = value.startsWith('@') ? value.slice(1) : value;
@@ -78,7 +75,8 @@ async function createRealmUser(jwt: string) {
       data: {
         type: 'user',
         attributes: {
-          registrationToken,
+          registrationToken:
+            process.env.REALM_REGISTRATION_TOKEN ?? 'dev-token',
         },
       },
     }),
@@ -101,6 +99,8 @@ export async function registerRealmUser(): Promise<{
   jwt: string;
   userId: string;
 }> {
+  const username = process.env.MATRIX_USERNAME;
+  const password = process.env.MATRIX_PASSWORD;
   if (!username || !password) {
     throw new Error(
       'MATRIX_USERNAME and MATRIX_PASSWORD must be set to register a realm user',

--- a/packages/realm-server/handlers/handle-webhook-receiver.ts
+++ b/packages/realm-server/handlers/handle-webhook-receiver.ts
@@ -165,7 +165,7 @@ export default function handleWebhookReceiverRequest({
         new Response(
           JSON.stringify({
             status: 'error',
-            message: `All ${matchedCommands} matched commands failed to enqueue`,
+            message: `All ${matchedCommands} matched commands failed to process`,
           }),
           {
             status: 500,

--- a/packages/realm-server/handlers/handle-webhook-receiver.ts
+++ b/packages/realm-server/handlers/handle-webhook-receiver.ts
@@ -99,6 +99,7 @@ export default function handleWebhookReceiverRequest({
     }
 
     let executedCommands = 0;
+    let matchedCommands = 0;
     for (let commandRow of commandRows) {
       let commandFilter = commandRow.command_filter as Record<
         string,
@@ -115,6 +116,7 @@ export default function handleWebhookReceiverRequest({
         continue;
       }
 
+      matchedCommands++;
       let commandURL = commandRow.command as string;
       let realmURL: string;
       let commandInput: Record<string, any>;
@@ -133,23 +135,7 @@ export default function handleWebhookReceiverRequest({
         continue;
       }
 
-      // Run as the realm owner so they have write permissions in the target realm
       let runAs = webhook.username as string;
-      try {
-        let realmOwnerRows = await query(dbAdapter, [
-          `SELECT username FROM realm_user_permissions WHERE realm_url = `,
-          param(realmURL),
-          ` AND realm_owner = true LIMIT 1`,
-        ]);
-        if (realmOwnerRows[0]?.username) {
-          runAs = realmOwnerRows[0].username as string;
-        }
-      } catch (error) {
-        console.error(
-          `Failed to fetch realm owner for ${realmURL}, falling back to webhook user:`,
-          error,
-        );
-      }
 
       try {
         await enqueueRunCommandJob(
@@ -171,6 +157,23 @@ export default function handleWebhookReceiverRequest({
           error,
         );
       }
+    }
+
+    if (matchedCommands > 0 && executedCommands === 0) {
+      await setContextResponse(
+        ctxt,
+        new Response(
+          JSON.stringify({
+            status: 'error',
+            message: `All ${matchedCommands} matched commands failed to enqueue`,
+          }),
+          {
+            status: 500,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
+      );
+      return;
     }
 
     await setContextResponse(


### PR DESCRIPTION
### What is changing 

1. We had a privilege issue where webhook commands might run as the wrong user if they don't have write access to the submission realm. Instead of looking up the realm owner on every webhook event, we now register the webhook upfront as a user who already has the right permissions.
2. Register webhook as submission_realm user instead