### PR TITLE
fix failing realm-endpoints-test

### DIFF
--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -1611,11 +1611,17 @@ module(basename(__filename), function () {
 
     let virtualNetwork = createVirtualNetwork();
     const basePath = resolve(join(__dirname, '..', '..', 'base'));
+    const demoFileSystem: Record<string, string | LooseSingleCardDocument> = {
+      '.realm.json': readJSONSync(join(__dirname, 'cards', '.realm.json')),
+      'person.gts': readFileSync(
+        join(__dirname, 'cards', 'person.gts'),
+        'utf8',
+      ),
+      'person-1.json': readJSONSync(join(__dirname, 'cards', 'person-1.json')),
+    };
 
     hooks.beforeEach(async function () {
       dir = dirSync();
-      ensureDirSync(join(dir.name, 'demo'));
-      copySync(join(__dirname, 'cards'), join(dir.name, 'demo'));
     });
 
     setupDB(hooks, {
@@ -1649,6 +1655,7 @@ module(basename(__filename), function () {
           withWorker: true,
           prerenderer,
           dir: join(dir.name, 'demo'),
+          fileSystem: demoFileSystem,
           virtualNetwork,
           realmURL: 'http://127.0.0.1:4446/demo/',
           publisher,


### PR DESCRIPTION
This fixes a failing realm-endpoints-test by reducing the fixture realm to only the files it needs to run the test.

fixes this failure:
```not ok 28 realm-endpoints-test.ts > Realm server serving multiple realms > Can perform full indexing multiple times on a server that runs multiple realms
  ---
  message: Test took longer than 60000ms; test timed out.
  severity: failed
  ...
  ---
  message: "Promise rejected during \"Can perform full indexing multiple times on a server that runs multiple realms\": Cannot read properties of undefined (reading 'get')"
  severity: failed
  stack: |
    TypeError: Cannot read properties of undefined (reading 'get')
        at Object.<anonymous> (/home/runner/work/boxel/boxel/packages/realm-server/tests/realm-endpoints-test.ts:1696:12)
```