### PR TITLE
worker: Fix queueing time in indexing dashboard

### DIFF
--- a/packages/realm-server/handlers/handle-indexing-dashboard.ts
+++ b/packages/realm-server/handlers/handle-indexing-dashboard.ts
@@ -4,7 +4,7 @@ export interface PendingJob {
   jobId: number;
   jobType: string;
   realmURL: string;
-  createdAt: string;
+  createdAt: number; // UTC epoch millis
   priority: number;
 }
 
@@ -111,19 +111,13 @@ function renderHistoryRow(state: RealmIndexingState): string {
 }
 
 function renderPendingRow(job: PendingJob): string {
-  // The DB column is `timestamp` (without tz) but stores UTC values.
-  // Append 'Z' so Date parses it as UTC rather than local time.
-  let isoString = job.createdAt.endsWith('Z')
-    ? job.createdAt
-    : job.createdAt + 'Z';
-  let createdAt = new Date(isoString);
   return `
     <tr>
       <td>${job.jobId}</td>
       <td>${escapeHtml(job.jobType)}</td>
       <td class="realm-url-cell" title="${escapeHtml(job.realmURL)}">${escapeHtml(job.realmURL)}</td>
       <td>${job.priority}</td>
-      <td>${timeSince(createdAt.getTime())}</td>
+      <td>${timeSince(job.createdAt)}</td>
     </tr>`;
 }
 

--- a/packages/realm-server/handlers/handle-indexing-dashboard.ts
+++ b/packages/realm-server/handlers/handle-indexing-dashboard.ts
@@ -111,7 +111,12 @@ function renderHistoryRow(state: RealmIndexingState): string {
 }
 
 function renderPendingRow(job: PendingJob): string {
-  let createdAt = new Date(job.createdAt);
+  // The DB column is `timestamp` (without tz) but stores UTC values.
+  // Append 'Z' so Date parses it as UTC rather than local time.
+  let isoString = job.createdAt.endsWith('Z')
+    ? job.createdAt
+    : job.createdAt + 'Z';
+  let createdAt = new Date(isoString);
   return `
     <tr>
       <td>${job.jobId}</td>

--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -158,7 +158,7 @@ if (port != null) {
   if (eventSink) {
     let getPendingJobs = async (): Promise<PendingJob[]> => {
       let rows = (await query([
-        `SELECT j.id, j.job_type, j.args, j.priority, j.created_at`,
+        `SELECT j.id, j.job_type, j.args, j.priority, EXTRACT(EPOCH FROM j.created_at) * 1000 AS created_at_ms`,
         `FROM jobs j`,
         `WHERE j.status = 'unfulfilled'`,
         `AND j.job_type IN ('from-scratch-index', 'incremental-index')`,
@@ -172,14 +172,14 @@ if (port != null) {
         job_type: string;
         args: { realmURL?: string };
         priority: number;
-        created_at: string;
+        created_at_ms: string;
       }[];
       return rows.map((r) => ({
         jobId: Number(r.id),
         jobType: r.job_type,
         realmURL: r.args?.realmURL ?? 'unknown',
         priority: r.priority,
-        createdAt: r.created_at,
+        createdAt: Number(r.created_at_ms),
       }));
     };
 


### PR DESCRIPTION
Queueing times have been rendering incorrectly for me:

<img width="1356" height="136" alt="image" src="https://github.com/user-attachments/assets/9e3002aa-f8cb-4758-9910-b790e8d8d006" />

This PR compensates for the column not being timezone-aware so the queueing time is correct:

<img width="1373" height="244" alt="Indexing Dashboard 2026-03-19 11-10-46" src="https://github.com/user-attachments/assets/8d36fd52-a4ac-4d75-b028-4c2fe06cd4a3" />

Another approach could be to change the column type from `timestamp` to `timestamptz` but this approach involves no changes to the database.