### PR TITLE
Fix prerender timeout caused by RAF throttling in render-ready stability loop

### DIFF
--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -51,6 +51,7 @@ import {
   beginTimerBlock,
   appendRenderTimerSummaryToStack,
   resetRenderTimerStats,
+  scheduleNativeTimeout,
 } from '../utils/render-timer-stub';
 
 import type LoaderService from '../services/loader-service';
@@ -728,6 +729,15 @@ export default class RenderRoute extends Route<Model> {
   async #waitForNextRenderFrame(): Promise<void> {
     if (typeof requestAnimationFrame !== 'function') {
       await Promise.resolve();
+      return;
+    }
+    // In the prerender context, requestAnimationFrame is throttled in
+    // background tabs (~1 frame/10s) and may be slow in headless browsers.
+    // Use a native setTimeout(0) instead — this yields to the event loop so
+    // Ember's runloop can flush, without being subject to RAF throttling.
+    // The timer bypasses the prerender timer stub via scheduleNativeTimeout.
+    if ((globalThis as any).__boxelRenderContext) {
+      await new Promise<void>((resolve) => scheduleNativeTimeout(resolve, 0));
       return;
     }
     await new Promise<void>((resolve) =>

--- a/packages/host/app/utils/render-timer-stub.ts
+++ b/packages/host/app/utils/render-timer-stub.ts
@@ -232,3 +232,18 @@ export async function withTimersBlocked<T>(
     release();
   }
 }
+
+/**
+ * Schedule a callback via the native (unblocked) setTimeout, bypassing the
+ * prerender timer stub. This is intended for the render-ready stability loop
+ * which needs a real timer to avoid being blocked by the prerender stub while
+ * still not relying on requestAnimationFrame (which is throttled in background
+ * tabs and headless browsers).
+ */
+export function scheduleNativeTimeout(
+  callback: () => void,
+  delay?: number,
+): ReturnType<typeof window.setTimeout> {
+  let fn = invokeSetTimeout ?? globalThis.setTimeout;
+  return fn(callback, delay);
+}

--- a/packages/realm-server/tests/helpers/prerender-page-patches.ts
+++ b/packages/realm-server/tests/helpers/prerender-page-patches.ts
@@ -214,3 +214,60 @@ export function installSearchRequestObserverPatch(): {
     },
   };
 }
+
+/**
+ * Simulate the background-tab RAF throttling that causes the render-ready
+ * stability loop to stall. This replaces `requestAnimationFrame` inside
+ * prerender pages with a version that delays each callback by `delayMs`.
+ * With the default 20-pass stability loop this makes a card that would
+ * normally settle in <1 s take 20 × delayMs.
+ */
+export function installThrottledRAFPatch(delayMs: number): {
+  restore: () => void;
+} {
+  let originalGetPage = PagePool.prototype.getPage;
+  let patchedPages = new WeakSet<object>();
+
+  PagePool.prototype.getPage = async function (this: PagePool, realm: string) {
+    let pageInfo = await originalGetPage.call(this, realm);
+    let page = pageInfo.page as any;
+    let originalEvaluate = page?.evaluate?.bind(page);
+
+    if (originalEvaluate && !patchedPages.has(page)) {
+      patchedPages.add(page);
+      let injected = false;
+      page.evaluate = async (...args: any[]) => {
+        if (!injected) {
+          injected = true;
+          await originalEvaluate((delay: number) => {
+            if ((globalThis as any).__boxelRAFThrottled) {
+              return;
+            }
+            (globalThis as any).__boxelRAFThrottled = true;
+            let nativeRAF = window.requestAnimationFrame.bind(window);
+            window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+              return nativeRAF(() => {
+                // Use the native setTimeout (before the render-timer-stub
+                // replaces it) to add the delay.
+                let nativeSetTimeout =
+                  (globalThis as any).__boxelNativeSetTimeout ??
+                  window.setTimeout;
+                nativeSetTimeout(() => callback(performance.now()), delay);
+              });
+            };
+            // Stash native setTimeout before the render-timer-stub replaces it.
+            (globalThis as any).__boxelNativeSetTimeout = window.setTimeout;
+          }, delayMs);
+        }
+        return originalEvaluate(...args);
+      };
+    }
+    return { ...pageInfo, page };
+  };
+
+  return {
+    restore: () => {
+      PagePool.prototype.getPage = originalGetPage;
+    },
+  };
+}

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -31,6 +31,7 @@ import {
   installDelayedRuntimeRealmSearchPatch,
   installRealmServerAssertOwnRealmServerBypassPatch,
   installSearchRequestObserverPatch,
+  installThrottledRAFPatch,
 } from './helpers/prerender-page-patches';
 
 class TestSemaphore {
@@ -5213,4 +5214,222 @@ module(basename(__filename), function () {
       }
     });
   });
+
+  module(
+    'prerender - card with many nested linksTo renders promptly',
+    function (hooks) {
+      let parentRealmURL = 'http://127.0.0.1:4470/test/';
+      let childRealmURL = 'http://127.0.0.1:4471/test/';
+      let prerenderServerURL = new URL(parentRealmURL).origin;
+      let testUserId = '@user1:localhost';
+      let permissions: RealmPermissions = {};
+      let prerenderer: Prerenderer;
+      let auth = () => testCreatePrerenderAuth(testUserId, permissions);
+
+      hooks.before(async () => {
+        prerenderer = getPrerendererForTesting({
+          maxPages: 2,
+          serverURL: prerenderServerURL,
+        });
+      });
+
+      hooks.after(async () => {
+        await prerenderer.stop();
+      });
+
+      hooks.afterEach(async () => {
+        await Promise.all([
+          prerenderer.disposeAffinity({
+            affinityType: 'realm',
+            affinityValue: parentRealmURL,
+          }),
+          prerenderer.disposeAffinity({
+            affinityType: 'realm',
+            affinityValue: childRealmURL,
+          }),
+        ]);
+      });
+
+      // Build a file system that mirrors the SystemCard scenario:
+      // ParentCard --linksToMany--> ChildConfig --linksTo--> GrandchildDetail
+      // where there are many ChildConfig instances each linking to a different
+      // GrandchildDetail in a separate realm.
+      let childCount = 10;
+
+      let childRealmFileSystem: Record<string, any> = {
+        'detail.gts': `
+          import { CardDef, field, contains, Component } from 'https://cardstack.com/base/card-api';
+          import StringField from 'https://cardstack.com/base/string';
+          export class Detail extends CardDef {
+            static displayName = 'Detail';
+            @field info = contains(StringField);
+            static isolated = class extends Component<typeof this> {
+              <template><span data-test-detail>{{@model.info}}</span></template>
+            };
+            static fitted = class extends Component<typeof this> {
+              <template><span data-test-detail-fitted>{{@model.info}}</span></template>
+            };
+          }
+        `,
+      };
+
+      for (let i = 0; i < childCount; i++) {
+        childRealmFileSystem[`Detail/detail-${i}.json`] = {
+          data: {
+            attributes: { info: `Detail ${i}` },
+            meta: {
+              adoptsFrom: { module: '../detail', name: 'Detail' },
+            },
+          },
+        };
+      }
+
+      let parentRealmFileSystem: Record<string, any> = {
+        'child-config.gts': `
+          import { CardDef, field, contains, linksTo, Component } from 'https://cardstack.com/base/card-api';
+          import StringField from 'https://cardstack.com/base/string';
+          import { Detail } from '${childRealmURL}detail';
+          export class ChildConfig extends CardDef {
+            static displayName = 'Child Config';
+            @field detail = linksTo(Detail);
+            @field derivedInfo = contains(StringField, {
+              computeVia: function () {
+                try { return this.detail?.info ?? null; } catch(e) { return null; }
+              },
+            });
+            static isolated = class extends Component<typeof this> {
+              <template><div data-test-child><@fields.detail /><span>{{@model.derivedInfo}}</span></div></template>
+            };
+            static fitted = class extends Component<typeof this> {
+              <template><span data-test-child-fitted>{{@model.derivedInfo}}</span></template>
+            };
+          }
+        `,
+        'parent-card.gts': `
+          import { CardDef, field, linksToMany, Component } from 'https://cardstack.com/base/card-api';
+          import { ChildConfig } from './child-config';
+          export class ParentCard extends CardDef {
+            static displayName = 'Parent Card';
+            @field children = linksToMany(ChildConfig);
+            static isolated = class extends Component<typeof this> {
+              <template>
+                <div data-test-parent>
+                  <@fields.children />
+                </div>
+              </template>
+            };
+          }
+        `,
+      };
+
+      // Create ChildConfig instances that each link to a Detail in the child realm
+      for (let i = 0; i < childCount; i++) {
+        parentRealmFileSystem[`ChildConfig/child-${i}.json`] = {
+          data: {
+            relationships: {
+              detail: {
+                links: { self: `${childRealmURL}Detail/detail-${i}` },
+              },
+            },
+            meta: {
+              adoptsFrom: { module: '../child-config', name: 'ChildConfig' },
+            },
+          },
+        };
+      }
+
+      // Create the parent card that links to all children
+      let childRelationships: Record<string, any> = {};
+      for (let i = 0; i < childCount; i++) {
+        childRelationships[`children.${i}`] = {
+          links: { self: `./ChildConfig/child-${i}` },
+        };
+      }
+      parentRealmFileSystem['parent.json'] = {
+        data: {
+          relationships: childRelationships,
+          meta: {
+            adoptsFrom: { module: './parent-card', name: 'ParentCard' },
+          },
+        },
+      };
+
+      setupPermissionedRealmsCached(hooks, {
+        mode: 'before',
+        realms: [
+          {
+            realmURL: childRealmURL,
+            permissions: {
+              '*': ['read'],
+              [testUserId]: ['read', 'write', 'realm-owner'],
+            },
+            fileSystem: childRealmFileSystem,
+          },
+          {
+            realmURL: parentRealmURL,
+            permissions: {
+              '*': ['read'],
+              [testUserId]: ['read', 'write', 'realm-owner'],
+            },
+            fileSystem: parentRealmFileSystem,
+          },
+        ],
+        onRealmSetup() {
+          permissions = {
+            [parentRealmURL]: ['read', 'write', 'realm-owner'],
+            [childRealmURL]: ['read', 'write', 'realm-owner'],
+          };
+        },
+      });
+
+      test(`card with ${childCount} linksToMany each with linksTo in another realm prerenders without timeout`, async function (assert) {
+        // Simulate background-tab RAF throttling: each requestAnimationFrame
+        // callback is delayed by 2 seconds. Without the fix (which uses
+        // setTimeout(0) instead of RAF in prerender context), the 20-pass
+        // stability loop would take 20 × 2s = 40s and hit our 15s timeout.
+        // With the fix, RAF is bypassed entirely and the render completes fast.
+        // Throttle RAF by 1.5s per frame. Without the fix the 20-pass
+        // stability loop would need 20 × 1.5 = 30s just for the loop,
+        // pushing the total well past the 45s timeout below. With the
+        // fix the loop bypasses RAF entirely so total time stays low.
+        let rafPatch = installThrottledRAFPatch(1_500);
+        try {
+          let cardURL = `${parentRealmURL}parent`;
+
+          let startMs = Date.now();
+          let result = await prerenderer.prerenderCard({
+            affinityType: 'realm',
+            affinityValue: parentRealmURL,
+            realm: parentRealmURL,
+            url: cardURL,
+            auth: auth(),
+            opts: { timeoutMs: 45_000 },
+          });
+          let elapsedMs = Date.now() - startMs;
+
+          assert.false(result.pool.timedOut, 'prerender did not time out');
+          assert.notOk(
+            result.response.error,
+            `prerender did not produce an error${result.response.error ? ': ' + JSON.stringify(result.response.error.error?.message ?? result.response.error) : ''}`,
+          );
+
+          // With 1.5s RAF throttle the unpatched stability loop alone
+          // would need ≥30s. Completing under 30s proves RAF was bypassed.
+          assert.true(
+            elapsedMs < 30_000,
+            `prerender completed in ${elapsedMs}ms (expected < 30s with RAF bypassed)`,
+          );
+
+          // Verify the rendered HTML includes content from the nested linked cards
+          let html = result.response.isolatedHTML ?? '';
+          assert.ok(
+            html.includes('data-test-parent'),
+            'rendered HTML contains the parent card',
+          );
+        } finally {
+          rafPatch.restore();
+        }
+      });
+    },
+  );
 });

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -5383,15 +5383,11 @@ module(basename(__filename), function () {
       });
 
       test(`card with ${childCount} linksToMany each with linksTo in another realm prerenders without timeout`, async function (assert) {
-        // Simulate background-tab RAF throttling: each requestAnimationFrame
-        // callback is delayed by 2 seconds. Without the fix (which uses
-        // setTimeout(0) instead of RAF in prerender context), the 20-pass
-        // stability loop would take 20 × 2s = 40s and hit our 15s timeout.
-        // With the fix, RAF is bypassed entirely and the render completes fast.
-        // Throttle RAF by 1.5s per frame. Without the fix the 20-pass
-        // stability loop would need 20 × 1.5 = 30s just for the loop,
-        // pushing the total well past the 45s timeout below. With the
-        // fix the loop bypasses RAF entirely so total time stays low.
+        // Throttle RAF by 1.5s per frame to simulate background-tab behavior.
+        // Without the fix the 20-pass stability loop would need 20 × 1.5 = 30s
+        // just for the loop, pushing the total well past the 30s assertion
+        // threshold below. With the fix the loop bypasses RAF entirely so
+        // total time stays low.
         let rafPatch = installThrottledRAFPatch(1_500);
         try {
           let cardURL = `${parentRealmURL}parent`;


### PR DESCRIPTION
## Summary

- **Fix**: Replace `requestAnimationFrame` with `setTimeout(0)` in the prerender context's render-ready stability loop to avoid Chrome's background-tab RAF throttling
- **Root cause**: Chrome throttles RAF to ~1 frame per 10 seconds in background tabs, causing the 20-pass stability loop to take ~200 seconds instead of <1 second
- **Test**: Added a prerendering test with simulated RAF throttling that fails without the fix (51s) and passes with it (<30s)

## Problem

The `catalog/SystemCard/default.json` card was timing out during prerendering (~95s on staging, ~200s in local Chrome). This card has 23 `linksToMany` ModelConfiguration cards, each with a `linksTo` OpenRouterModel in a separate realm — nothing unusually complex, but the render was taking far too long.

## Investigation

Using Chrome DevTools MCP, we measured RAF frame deltas throughout the entire render lifecycle by injecting a `requestAnimationFrame` loop tracker via `initScript`. The data revealed:

| Phase | Frames | Delta per frame | Duration |
|-------|--------|----------------|----------|
| Module loading + card fetch | 63 frames | <100ms | ~5.7s |
| **RAF-throttled stability loop** | **22 frames** | **~9,000ms** | **~190s** |
| Final settlement | 3 frames | <40ms | instant |

All 137 network requests completed by t=28s. Only 3.5 seconds of CPU work (7 long tasks). The remaining ~190s was pure idle waiting inside `#waitForRenderLoadStability()` — 20 passes × ~9.7s per RAF frame.

## What is RAF throttling?

Chrome aggressively throttles `requestAnimationFrame` in background tabs to save battery and CPU:
- **Foreground tab**: ~60 callbacks/second (16ms apart)
- **Background tab**: ~1 callback every 10 seconds

This is fine for animations but catastrophic for async loops that use RAF as a yield mechanism. When navigating to the render URL via DevTools or when the prerender server opens a headless browser page, the tab may be considered "background," triggering this throttling.

## Fix

In `#waitForNextRenderFrame()` (`render.ts:728`), when in prerender context (`__boxelRenderContext`), use a native `setTimeout(0)` instead of `requestAnimationFrame`. This yields to the event loop so Ember's runloop can flush pending re-renders, without being subject to RAF throttling.

A new `scheduleNativeTimeout()` helper in `render-timer-stub.ts` bypasses the prerender timer stub (which blocks `setTimeout` to prevent runaway timers) by using the saved reference to the real `setTimeout`.

## Test plan

- [x] New test: card with 10 `linksToMany` each with `linksTo` across realms, with simulated RAF throttling (1.5s/frame) — **fails without fix (51s), passes with fix (<30s)**
- [x] All existing prerendering tests pass (76 tests)
- [x] Lint clean in both `host` and `realm-server` packages

Closes CS-10463

🤖 Generated with [Claude Code](https://claude.com/claude-code)