### PR TITLE
ci: Add file filter for Diff Skills workflow

### DIFF
--- a/.github/workflows/diff-skills.yaml
+++ b/.github/workflows/diff-skills.yaml
@@ -2,6 +2,13 @@ name: Diff Skills
 
 on:
   pull_request:
+    paths:
+      - 'packages/base/cards/skill*.json'
+      - 'packages/base/Skill/**/*.json'
+      - 'packages/catalog-realm/**/Skill/**/*.json'
+      - 'packages/experiments-realm/**/Skill*/**/*.json'
+      - 'packages/skills-realm/**/*.json'
+      - 'packages/software-factory/realm/**/*skill*.json'
 
 permissions:
   contents: read

--- a/.github/workflows/diff-skills.yaml
+++ b/.github/workflows/diff-skills.yaml
@@ -7,6 +7,7 @@ on:
       - "packages/base/Skill/**/*.json"
       - "packages/catalog-realm/**/Skill/**/*.json"
       - "packages/experiments-realm/**/Skill*/**/*.json"
+      - "packages/host/tests/cards/skill-*.json"
       - "packages/skills-realm/**/*.json"
       - "packages/software-factory/realm/**/*skill*.json"
 

--- a/.github/workflows/diff-skills.yaml
+++ b/.github/workflows/diff-skills.yaml
@@ -3,12 +3,12 @@ name: Diff Skills
 on:
   pull_request:
     paths:
-      - 'packages/base/cards/skill*.json'
-      - 'packages/base/Skill/**/*.json'
-      - 'packages/catalog-realm/**/Skill/**/*.json'
-      - 'packages/experiments-realm/**/Skill*/**/*.json'
-      - 'packages/skills-realm/**/*.json'
-      - 'packages/software-factory/realm/**/*skill*.json'
+      - "packages/base/cards/skill*.json"
+      - "packages/base/Skill/**/*.json"
+      - "packages/catalog-realm/**/Skill/**/*.json"
+      - "packages/experiments-realm/**/Skill*/**/*.json"
+      - "packages/skills-realm/**/*.json"
+      - "packages/software-factory/realm/**/*skill*.json"
 
 permissions:
   contents: read


### PR DESCRIPTION
I noticed two queued Diff Skills jobs that I knew would end up being no-ops:

<img width="1292" height="796" alt="image" src="https://github.com/user-attachments/assets/501d26c4-b023-460c-b1ca-5b370fd48640" />

From Claude’s analysis, 94 of the last 100 PRs have run this workflow unnecessarily:

```
  ┌─────────────────────────────┬───────┐
  │           Metric            │ Count │
  ├─────────────────────────────┼───────┤
  │ Total PRs                   │ 100   │
  ├─────────────────────────────┼───────┤
  │ PRs with any JSON changes   │ 22    │
  ├─────────────────────────────┼───────┤
  │ PRs with skill-related JSON │ 6     │
  └─────────────────────────────┴───────┘
```

It derived these filters to catch true skill file changes. While it’s a danger that skills in a new place will be missed by this, I think with our CI backlog problems, the savings of not running unnecessary workflow is worth it.