### PR TITLE
Fix deleted files persisting in published realm on republish

### DIFF
--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -348,6 +348,13 @@ export default function handlePublishRealm({
       removeSync(tempCopyPath);
       removeSync(backupPath);
       copySync(sourceRealmPath, tempCopyPath);
+      // Unmount the existing published realm before swapping the
+      // directory so it can't serve requests from a partially
+      // replaced filesystem.
+      if (existingPublishedRealm) {
+        realms.splice(realms.indexOf(existingPublishedRealm), 1);
+        virtualNetwork.unmount(existingPublishedRealm.handle);
+      }
       try {
         if (existsSync(publishedRealmPath)) {
           moveSync(publishedRealmPath, backupPath);
@@ -382,11 +389,6 @@ export default function handlePublishRealm({
         join(publishedRealmPath, '.realm.json'),
         newlyPublishedRealmConfig,
       );
-
-      if (existingPublishedRealm) {
-        realms.splice(realms.indexOf(existingPublishedRealm), 1);
-        virtualNetwork.unmount(existingPublishedRealm.handle);
-      }
 
       // Clear stale modules cache for the published realm so that
       // error entries from a previous publish don't persist

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -363,10 +363,7 @@ export default function handlePublishRealm({
         removeSync(backupPath);
       } catch (swapError) {
         // Restore the old published realm if the swap failed
-        if (
-          !existsSync(publishedRealmPath) &&
-          existsSync(backupPath)
-        ) {
+        if (!existsSync(publishedRealmPath) && existsSync(backupPath)) {
           moveSync(backupPath, publishedRealmPath);
         }
         removeSync(tempCopyPath);

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -20,13 +20,7 @@ import {
 import { getPublishedRealmDomainOverrides } from '@cardstack/runtime-common/constants';
 
 import { join } from 'path';
-import {
-  ensureDirSync,
-  copySync,
-  readJsonSync,
-  writeJsonSync,
-  removeSync,
-} from 'fs-extra';
+import { copySync, readJsonSync, writeJsonSync, removeSync } from 'fs-extra';
 
 import {
   fetchRequestFromContext,
@@ -339,8 +333,10 @@ export default function handlePublishRealm({
       let sourceRealmPath = sourceRealm.dir;
       let publishedDir = join(realmsRootPath, PUBLISHED_DIRECTORY_NAME);
       let publishedRealmPath = join(publishedDir, publishedRealmId);
+      // Remove existing published files so that files deleted from the source
+      // realm don't persist in the published realm on republish
+      removeSync(publishedRealmPath);
       copySync(sourceRealmPath, publishedRealmPath);
-      ensureDirSync(publishedRealmPath);
 
       let newlyPublishedRealmConfig = readJsonSync(
         join(publishedRealmPath, '.realm.json'),

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -20,7 +20,14 @@ import {
 import { getPublishedRealmDomainOverrides } from '@cardstack/runtime-common/constants';
 
 import { join } from 'path';
-import { copySync, readJsonSync, writeJsonSync, removeSync } from 'fs-extra';
+import {
+  copySync,
+  readJsonSync,
+  writeJsonSync,
+  removeSync,
+  existsSync,
+  moveSync,
+} from 'fs-extra';
 
 import {
   fetchRequestFromContext,
@@ -333,10 +340,31 @@ export default function handlePublishRealm({
       let sourceRealmPath = sourceRealm.dir;
       let publishedDir = join(realmsRootPath, PUBLISHED_DIRECTORY_NAME);
       let publishedRealmPath = join(publishedDir, publishedRealmId);
-      // Remove existing published files so that files deleted from the source
-      // realm don't persist in the published realm on republish
-      removeSync(publishedRealmPath);
-      copySync(sourceRealmPath, publishedRealmPath);
+      // Copy source to a temporary directory first, then swap it into
+      // place so that a failed copy doesn't destroy the existing
+      // published realm (e.g. due to disk-full or permission errors).
+      let tempCopyPath = `${publishedRealmPath}.tmp`;
+      let backupPath = `${publishedRealmPath}.backup`;
+      removeSync(tempCopyPath);
+      removeSync(backupPath);
+      copySync(sourceRealmPath, tempCopyPath);
+      try {
+        if (existsSync(publishedRealmPath)) {
+          moveSync(publishedRealmPath, backupPath);
+        }
+        moveSync(tempCopyPath, publishedRealmPath);
+        removeSync(backupPath);
+      } catch (swapError) {
+        // Restore the old published realm if the swap failed
+        if (
+          !existsSync(publishedRealmPath) &&
+          existsSync(backupPath)
+        ) {
+          moveSync(backupPath, publishedRealmPath);
+        }
+        removeSync(tempCopyPath);
+        throw swapError;
+      }
 
       let newlyPublishedRealmConfig = readJsonSync(
         join(publishedRealmPath, '.realm.json'),

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -9,6 +9,7 @@ import {
   pathExistsSync,
   readJsonSync,
   writeJsonSync,
+  removeSync,
 } from 'fs-extra';
 import { basename, join } from 'path';
 import type { Server } from 'http';
@@ -639,6 +640,101 @@ module(basename(__filename), function () {
         assert.notOk(
           publishedRealmConfig.publishable,
           'published realm config should have publishable: false',
+        );
+      });
+
+      test('republishing removes files that were deleted from the source realm', async function (assert) {
+        let sourceRealmURL = new URL(sourceRealmUrlString);
+        let sourceRealmFsPath = join(
+          dir.name,
+          'realm_server_3',
+          ...sourceRealmURL.pathname.split('/').filter(Boolean),
+        );
+
+        // Write a file directly to the source realm filesystem
+        writeJsonSync(join(sourceRealmFsPath, 'ephemeral-card.json'), {
+          data: {
+            type: 'card',
+            id: `${sourceRealmUrlString}ephemeral-card`,
+            attributes: {
+              title: 'Ephemeral Card',
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/card-api',
+                name: 'CardDef',
+              },
+            },
+          },
+        });
+
+        // First publish
+        let firstPublishResponse = await request
+          .post('/_publish-realm')
+          .set('Accept', 'application/vnd.api+json')
+          .set('Content-Type', 'application/json')
+          .set(
+            'Authorization',
+            `Bearer ${createRealmServerJWT(
+              { user: ownerUserId, sessionRoom: 'session-room-test' },
+              realmSecretSeed,
+            )}`,
+          )
+          .send(
+            JSON.stringify({
+              sourceRealmURL: sourceRealmUrlString,
+              publishedRealmURL: 'http://testuser.localhost:4445/test-realm/',
+            }),
+          );
+
+        assert.strictEqual(
+          firstPublishResponse.status,
+          201,
+          'First publish succeeds',
+        );
+
+        let publishedRealmId = firstPublishResponse.body.data.id;
+        let publishedDir = join(dir.name, 'realm_server_3', '_published');
+        let publishedRealmPath = join(publishedDir, publishedRealmId);
+
+        // Verify the file exists in the published realm on disk
+        assert.ok(
+          existsSync(join(publishedRealmPath, 'ephemeral-card.json')),
+          'ephemeral-card.json exists in published realm after first publish',
+        );
+
+        // Delete the file from the source realm filesystem
+        removeSync(join(sourceRealmFsPath, 'ephemeral-card.json'));
+        assert.notOk(
+          existsSync(join(sourceRealmFsPath, 'ephemeral-card.json')),
+          'ephemeral-card.json is removed from source realm',
+        );
+
+        // Republish
+        let republishResponse = await request
+          .post('/_publish-realm')
+          .set('Accept', 'application/vnd.api+json')
+          .set('Content-Type', 'application/json')
+          .set(
+            'Authorization',
+            `Bearer ${createRealmServerJWT(
+              { user: ownerUserId, sessionRoom: 'session-room-test' },
+              realmSecretSeed,
+            )}`,
+          )
+          .send(
+            JSON.stringify({
+              sourceRealmURL: sourceRealmUrlString,
+              publishedRealmURL: 'http://testuser.localhost:4445/test-realm/',
+            }),
+          );
+
+        assert.strictEqual(republishResponse.status, 201, 'Republish succeeds');
+
+        // Verify the file no longer exists on disk in the published realm
+        assert.notOk(
+          existsSync(join(publishedRealmPath, 'ephemeral-card.json')),
+          'ephemeral-card.json should not exist in published realm after republish',
         );
       });
 


### PR DESCRIPTION
## Summary
- Clear the published realm directory before copying from source on republish, so files deleted from the source realm don't persist in the published realm
- Previously, `copySync` would only add/overwrite files but never remove files that existed in the destination but not in the source
- The existing `fullIndex()` call already handles DB-level cleanup by tombstoning index entries for files no longer on disk

Closes CS-10189

## Test plan
- [x] Added test: "republishing removes files that were deleted from the source realm"
- [x] All 14 existing publish/unpublish tests pass
- [ ] Manual verification: delete a card from source realm, republish, confirm it's gone from published realm

🤖 Generated with [Claude Code](https://claude.com/claude-code)