### PR TITLE
Move prerender reproduction URL to its own log category

### DIFF
--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -37,6 +37,7 @@ import {
 import { randomUUID } from 'crypto';
 
 const log = logger('prerenderer');
+const reproduceLog = logger('prerenderer-reproduce');
 const commandRequestStorageKeyPrefix = 'boxel-command-request:';
 
 const CLEAR_CACHE_RETRY_SIGNATURES: readonly (readonly string[])[] = [
@@ -197,7 +198,7 @@ export class RenderRunner {
       };
 
       // please leave the auth token in the debug log so that we can debug timed out prerenders
-      log.debug(
+      reproduceLog.debug(
         `manually visit prerendered url ${url} at: ${this.#boxelHostURL}/render/${encodeURIComponent(url)}/${this.#nonce}/${optionsSegment}/html/isolated/0 with boxel-session = ${auth}`,
       );
 


### PR DESCRIPTION
## Summary

- The `prerenderer` debug logs are too noisy right now — in practice, the only things we need to see are errors and the reproduction URL (so we can manually visit a bad render). This moves the "manually visit prerendered url" message into a dedicated `prerenderer-reproduce` log category so we can turn down the noise by running with `DEBUG=prerenderer-reproduce` instead of `DEBUG=prerenderer`, while still getting the one message that matters for debugging bad renders.

