### PR TITLE
Fix flaky code patch acceptance test caused by Monaco diff race

### DIFF
--- a/patches/monaco-editor@0.52.2.patch
+++ b/patches/monaco-editor@0.52.2.patch
@@ -20,24 +20,24 @@ index 5a5588e64135d87ac643aa75dd339f96ec3613a8..350ab291a325a21b69de9ab6e0be267f
          }
      }
 diff --git a/esm/vs/editor/browser/widget/diffEditor/diffProviderFactoryService.js b/esm/vs/editor/browser/widget/diffEditor/diffProviderFactoryService.js
-index fd5ba8c5c05fe0c69a91a6f08e94ebd41e56fce9..c2e2b4e0a6e8c56a92f63e79d4f7e9d1a3b5c7e2 100644
+index ed54a358226406a60a407324d501f9d8c327d9ca..22c70310ab9b3d15ef2f82aef7acc9565222db53 100644
 --- a/esm/vs/editor/browser/widget/diffEditor/diffProviderFactoryService.js
 +++ b/esm/vs/editor/browser/widget/diffEditor/diffProviderFactoryService.js
-@@ -106,7 +106,16 @@ let WorkerBasedDocumentDiffProvider = WorkerBasedDocumentDiffProvider_1 = class W
+@@ -107,6 +107,17 @@ let WorkerBasedDocumentDiffProvider = class WorkerBasedDocumentDiffProvider {
              };
          }
          if (!result) {
--            throw new Error('no diff result available');
-+            // During test teardown (or when models are disposed mid-computation),
-+            // the editor worker can return null. Rather than throwing an unhandled
-+            // error that surfaces as a flaky "global failure" in QUnit, return an
-+            // empty diff result — the same pattern used above for disposed models.
-+            return {
-+                changes: [],
-+                identical: true,
-+                quitEarly: false,
-+                moves: [],
-+            };
++            // When models are disposed mid-computation the worker returns null.
++            // Only suppress the error in that case — a genuine worker failure with
++            // live models should still surface.
++            if (original.isDisposed() || modified.isDisposed()) {
++                return {
++                    changes: [],
++                    identical: true,
++                    quitEarly: false,
++                    moves: [],
++                };
++            }
+             throw new Error('no diff result available');
          }
          // max 10 items in cache
-         if (WorkerBasedDocumentDiffProvider_1.diffCache.size > 10) {

--- a/patches/monaco-editor@0.52.2.patch
+++ b/patches/monaco-editor@0.52.2.patch
@@ -19,3 +19,25 @@ index 5a5588e64135d87ac643aa75dd339f96ec3613a8..350ab291a325a21b69de9ab6e0be267f
              this.completionPromise = null;
          }
      }
+diff --git a/esm/vs/editor/browser/widget/diffEditor/diffProviderFactoryService.js b/esm/vs/editor/browser/widget/diffEditor/diffProviderFactoryService.js
+index fd5ba8c5c05fe0c69a91a6f08e94ebd41e56fce9..c2e2b4e0a6e8c56a92f63e79d4f7e9d1a3b5c7e2 100644
+--- a/esm/vs/editor/browser/widget/diffEditor/diffProviderFactoryService.js
++++ b/esm/vs/editor/browser/widget/diffEditor/diffProviderFactoryService.js
+@@ -106,7 +106,16 @@ let WorkerBasedDocumentDiffProvider = WorkerBasedDocumentDiffProvider_1 = class W
+             };
+         }
+         if (!result) {
+-            throw new Error('no diff result available');
++            // During test teardown (or when models are disposed mid-computation),
++            // the editor worker can return null. Rather than throwing an unhandled
++            // error that surfaces as a flaky "global failure" in QUnit, return an
++            // empty diff result — the same pattern used above for disposed models.
++            return {
++                changes: [],
++                identical: true,
++                quitEarly: false,
++                moves: [],
++            };
+         }
+         // max 10 items in cache
+         if (WorkerBasedDocumentDiffProvider_1.diffCache.size > 10) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -688,7 +688,7 @@ patchedDependencies:
     hash: 0472d34281d936a5dcdacff67d2851d88c1df9593cd06b7725ee8414c12aa1d5
     path: patches/matrix-js-sdk@38.3.0.patch
   monaco-editor@0.52.2:
-    hash: d387bc68b647d7ffc88bcf608bccfdfa9adbe4c4dae602b7fc9ea0564cc942d0
+    hash: bdefe071221b87c7c15e1add6739d24d486f543dbad0d714ae586085204626cd
     path: patches/monaco-editor@0.52.2.patch
   openai:
     hash: 6833f1bcf56cde16edb25881777c31d2745994c6ea992d1e2051d1248d213449
@@ -2158,10 +2158,10 @@ importers:
         version: 1.2.0(moment@2.30.1)(webpack@5.104.1)
       monaco-editor:
         specifier: 'catalog:'
-        version: 0.52.2(patch_hash=d387bc68b647d7ffc88bcf608bccfdfa9adbe4c4dae602b7fc9ea0564cc942d0)
+        version: 0.52.2(patch_hash=bdefe071221b87c7c15e1add6739d24d486f543dbad0d714ae586085204626cd)
       monaco-editor-webpack-plugin:
         specifier: 'catalog:'
-        version: 7.1.1(monaco-editor@0.52.2(patch_hash=d387bc68b647d7ffc88bcf608bccfdfa9adbe4c4dae602b7fc9ea0564cc942d0))(webpack@5.104.1)
+        version: 7.1.1(monaco-editor@0.52.2(patch_hash=bdefe071221b87c7c15e1add6739d24d486f543dbad0d714ae586085204626cd))(webpack@5.104.1)
       ms:
         specifier: 'catalog:'
         version: 2.1.3
@@ -2851,7 +2851,7 @@ importers:
         version: 6.3.0
       monaco-editor:
         specifier: 'catalog:'
-        version: 0.52.2(patch_hash=d387bc68b647d7ffc88bcf608bccfdfa9adbe4c4dae602b7fc9ea0564cc942d0)
+        version: 0.52.2(patch_hash=bdefe071221b87c7c15e1add6739d24d486f543dbad0d714ae586085204626cd)
       statuses:
         specifier: 'catalog:'
         version: 2.0.2
@@ -24413,13 +24413,13 @@ snapshots:
 
   moment@2.30.1: {}
 
-  monaco-editor-webpack-plugin@7.1.1(monaco-editor@0.52.2(patch_hash=d387bc68b647d7ffc88bcf608bccfdfa9adbe4c4dae602b7fc9ea0564cc942d0))(webpack@5.104.1):
+  monaco-editor-webpack-plugin@7.1.1(monaco-editor@0.52.2(patch_hash=bdefe071221b87c7c15e1add6739d24d486f543dbad0d714ae586085204626cd))(webpack@5.104.1):
     dependencies:
       loader-utils: 2.0.4
-      monaco-editor: 0.52.2(patch_hash=d387bc68b647d7ffc88bcf608bccfdfa9adbe4c4dae602b7fc9ea0564cc942d0)
+      monaco-editor: 0.52.2(patch_hash=bdefe071221b87c7c15e1add6739d24d486f543dbad0d714ae586085204626cd)
       webpack: 5.104.1
 
-  monaco-editor@0.52.2(patch_hash=d387bc68b647d7ffc88bcf608bccfdfa9adbe4c4dae602b7fc9ea0564cc942d0): {}
+  monaco-editor@0.52.2(patch_hash=bdefe071221b87c7c15e1add6739d24d486f543dbad0d714ae586085204626cd): {}
 
   morgan@1.10.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -688,7 +688,7 @@ patchedDependencies:
     hash: 0472d34281d936a5dcdacff67d2851d88c1df9593cd06b7725ee8414c12aa1d5
     path: patches/matrix-js-sdk@38.3.0.patch
   monaco-editor@0.52.2:
-    hash: a09898c89392828a4df910a8b4b952fd774a69b779906e9fa5742cb9c05c2ecf
+    hash: d387bc68b647d7ffc88bcf608bccfdfa9adbe4c4dae602b7fc9ea0564cc942d0
     path: patches/monaco-editor@0.52.2.patch
   openai:
     hash: 6833f1bcf56cde16edb25881777c31d2745994c6ea992d1e2051d1248d213449
@@ -2158,10 +2158,10 @@ importers:
         version: 1.2.0(moment@2.30.1)(webpack@5.104.1)
       monaco-editor:
         specifier: 'catalog:'
-        version: 0.52.2(patch_hash=a09898c89392828a4df910a8b4b952fd774a69b779906e9fa5742cb9c05c2ecf)
+        version: 0.52.2(patch_hash=d387bc68b647d7ffc88bcf608bccfdfa9adbe4c4dae602b7fc9ea0564cc942d0)
       monaco-editor-webpack-plugin:
         specifier: 'catalog:'
-        version: 7.1.1(monaco-editor@0.52.2(patch_hash=a09898c89392828a4df910a8b4b952fd774a69b779906e9fa5742cb9c05c2ecf))(webpack@5.104.1)
+        version: 7.1.1(monaco-editor@0.52.2(patch_hash=d387bc68b647d7ffc88bcf608bccfdfa9adbe4c4dae602b7fc9ea0564cc942d0))(webpack@5.104.1)
       ms:
         specifier: 'catalog:'
         version: 2.1.3
@@ -2851,7 +2851,7 @@ importers:
         version: 6.3.0
       monaco-editor:
         specifier: 'catalog:'
-        version: 0.52.2(patch_hash=a09898c89392828a4df910a8b4b952fd774a69b779906e9fa5742cb9c05c2ecf)
+        version: 0.52.2(patch_hash=d387bc68b647d7ffc88bcf608bccfdfa9adbe4c4dae602b7fc9ea0564cc942d0)
       statuses:
         specifier: 'catalog:'
         version: 2.0.2
@@ -24413,13 +24413,13 @@ snapshots:
 
   moment@2.30.1: {}
 
-  monaco-editor-webpack-plugin@7.1.1(monaco-editor@0.52.2(patch_hash=a09898c89392828a4df910a8b4b952fd774a69b779906e9fa5742cb9c05c2ecf))(webpack@5.104.1):
+  monaco-editor-webpack-plugin@7.1.1(monaco-editor@0.52.2(patch_hash=d387bc68b647d7ffc88bcf608bccfdfa9adbe4c4dae602b7fc9ea0564cc942d0))(webpack@5.104.1):
     dependencies:
       loader-utils: 2.0.4
-      monaco-editor: 0.52.2(patch_hash=a09898c89392828a4df910a8b4b952fd774a69b779906e9fa5742cb9c05c2ecf)
+      monaco-editor: 0.52.2(patch_hash=d387bc68b647d7ffc88bcf608bccfdfa9adbe4c4dae602b7fc9ea0564cc942d0)
       webpack: 5.104.1
 
-  monaco-editor@0.52.2(patch_hash=a09898c89392828a4df910a8b4b952fd774a69b779906e9fa5742cb9c05c2ecf): {}
+  monaco-editor@0.52.2(patch_hash=d387bc68b647d7ffc88bcf608bccfdfa9adbe4c4dae602b7fc9ea0564cc942d0): {}
 
   morgan@1.10.1:
     dependencies:


### PR DESCRIPTION
## Summary
- During test teardown, Monaco's `WorkerBasedDocumentDiffProvider.computeDiff` can receive a `null` result from the editor worker when models are disposed mid-computation. This threw `Error: no diff result available` which surfaced as a flaky QUnit "global failure" in CI on the "Accept All" code patch acceptance test.
- Extended the existing Monaco patch (`patches/monaco-editor@0.52.2.patch`) to return an empty diff result instead of throwing — matching the pattern Monaco already uses for the disposed-models case a few lines above in the same method.

## Test plan
- [x] Ran the specific flaky test (`failure patching code when using "Accept All" button`) — passes
- [x] Ran the full `Code patches tests` acceptance suite (17 tests) — all pass (15 pass, 2 skipped, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)