### PR TITLE
ci: Add workflow for weekday PR review summaries

### DIFF
--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -26,10 +26,13 @@ jobs:
           set -euo pipefail
 
           # Only run at 9 AM ET — skip the trigger that doesn't match current DST
-          current_et_hour="$(TZ=America/New_York date +%H)"
-          if [ "$current_et_hour" != "09" ]; then
-            echo "Current ET hour is $current_et_hour, not 9 AM. Skipping."
-            exit 0
+          # Skip the check for push events (testing)
+          if [ "${{ github.event_name }}" != "push" ]; then
+            current_et_hour="$(TZ=America/New_York date +%H)"
+            if [ "$current_et_hour" != "09" ]; then
+              echo "Current ET hour is $current_et_hour, not 9 AM. Skipping."
+              exit 0
+            fi
           fi
 
           prs="$(gh api graphql -f query='

--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -2,7 +2,8 @@ name: PR Review Reminder
 
 on:
   schedule:
-    - cron: "0 14 * * 1-5" # Weekdays at 2 PM UTC / 10 AM ET
+    - cron: "0 13 * * 1-5" # 9 AM EDT (summer)
+    - cron: "0 14 * * 1-5" # 9 AM EST (winter)
   workflow_dispatch:
 
 permissions:
@@ -20,6 +21,13 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+
+          # Only run at 9 AM ET — skip the trigger that doesn't match current DST
+          current_et_hour="$(TZ=America/New_York date +%H)"
+          if [ "$current_et_hour" != "09" ]; then
+            echo "Current ET hour is $current_et_hour, not 9 AM. Skipping."
+            exit 0
+          fi
 
           prs="$(gh api graphql -f query='
             query($owner: String!, $repo: String!) {

--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 13 * * 1-5" # 9 AM EDT (summer)
     - cron: "0 14 * * 1-5" # 9 AM EST (winter)
   workflow_dispatch:
+  push:
+    branches:
+      - ci/discord-pr-review-summary-cs-10475
 
 permissions:
   pull-requests: read

--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -70,7 +70,7 @@ jobs:
                  url,
                  author: .author.login,
                  waitingSince: (.timelineItems.nodes[0].createdAt // "unknown"),
-                 reviewers: [.reviewRequests.nodes[].requestedReviewer | .login // .name]
+                 reviewers: [.reviewRequests.nodes[].requestedReviewer | (.login // .name // empty)] | map(select(. != ""))
                }
             ] | sort_by(.waitingSince)')"
 
@@ -83,7 +83,7 @@ jobs:
 
           fields="$(echo "$filtered" | jq -c '[.[] | {
             name: ("#\(.number) by \(.author) — waiting since \(.waitingSince | split("T")[0])"),
-            value: "[\(.title)](\(.url))\nReviewers: \(.reviewers | join(", "))",
+            value: (["[\(.title)](\(.url))"] + (if (.reviewers | length) > 0 then ["Reviewers: \(.reviewers | join(", "))"] else [] end) | join("\n")),
             inline: false
           }]')"
 

--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 13 * * 1-5" # 9 AM EDT (summer)
     - cron: "0 14 * * 1-5" # 9 AM EST (winter)
   workflow_dispatch:
+  push:
+    branches:
+      - ci/discord-pr-review-summary-cs-10475
 
 permissions:
   pull-requests: read
@@ -23,10 +26,13 @@ jobs:
           set -euo pipefail
 
           # Only run at 9 AM ET — skip the trigger that doesn't match current DST
-          current_et_hour="$(TZ=America/New_York date +%H)"
-          if [ "$current_et_hour" != "09" ]; then
-            echo "Current ET hour is $current_et_hour, not 9 AM. Skipping."
-            exit 0
+          # Skip the check for push events (testing)
+          if [ "${{ github.event_name }}" != "push" ]; then
+            current_et_hour="$(TZ=America/New_York date +%H)"
+            if [ "$current_et_hour" != "09" ]; then
+              echo "Current ET hour is $current_et_hour, not 9 AM. Skipping."
+              exit 0
+            fi
           fi
 
           prs="$(gh api graphql -f query='

--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Gather PRs and notify Discord
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.PR_REVIEW_DISCORD_WEBHOOK }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -22,6 +22,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "::error::PR_REVIEW_DISCORD_WEBHOOK secret is not set"
+            exit 1
+          fi
+
           # Only run at 9 AM ET — skip the trigger that doesn't match current DST
           current_et_hour="$(TZ=America/New_York date +%H)"
           if [ "$current_et_hour" != "09" ]; then
@@ -39,7 +44,7 @@ jobs:
                     url
                     isDraft
                     author { login }
-                    reviewRequests(first: 10) {
+                    reviewRequests(first: 100) {
                       nodes {
                         requestedReviewer {
                           ... on User { login }
@@ -47,7 +52,7 @@ jobs:
                         }
                       }
                     }
-                    timelineItems(itemTypes: [REVIEW_REQUESTED_EVENT], first: 1) {
+                    timelineItems(itemTypes: [REVIEW_REQUESTED_EVENT], last: 1) {
                       nodes {
                         ... on ReviewRequestedEvent {
                           createdAt
@@ -102,7 +107,7 @@ jobs:
             }]
           }')"
 
-          curl -sf -X POST \
+          curl -sSf -X POST \
             -H "Content-Type: application/json" \
             -d "$payload" \
             "$DISCORD_WEBHOOK"

--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -1,0 +1,102 @@
+name: PR Review Reminder
+
+on:
+  schedule:
+    - cron: "0 14 * * 1-5" # Weekdays at 2 PM UTC / 10 AM ET
+  workflow_dispatch:
+
+permissions:
+  pull-requests: read
+
+jobs:
+  notify:
+    name: Post awaiting-review PRs to Discord
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gather PRs and notify Discord
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          prs="$(gh api graphql -f query='
+            query($owner: String!, $repo: String!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequests(states: OPEN, first: 100, orderBy: {field: CREATED_AT, direction: ASC}) {
+                  nodes {
+                    number
+                    title
+                    url
+                    isDraft
+                    author { login }
+                    reviewRequests(first: 10) {
+                      nodes {
+                        requestedReviewer {
+                          ... on User { login }
+                          ... on Team { name }
+                        }
+                      }
+                    }
+                    timelineItems(itemTypes: [REVIEW_REQUESTED_EVENT], first: 1) {
+                      nodes {
+                        ... on ReviewRequestedEvent {
+                          createdAt
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ' -f owner="${REPO%/*}" -f repo="${REPO#*/}")"
+
+          filtered="$(echo "$prs" | jq -c '
+            [.data.repository.pullRequests.nodes[]
+             | select(.isDraft == false)
+             | select((.reviewRequests.nodes | length) > 0)
+             | {
+                 number,
+                 title,
+                 url,
+                 author: .author.login,
+                 waitingSince: (.timelineItems.nodes[0].createdAt // "unknown"),
+                 reviewers: [.reviewRequests.nodes[].requestedReviewer | .login // .name]
+               }
+            ] | sort_by(.waitingSince)')"
+
+          count="$(echo "$filtered" | jq 'length')"
+
+          if [ "$count" -eq 0 ]; then
+            echo "No PRs awaiting review. Skipping Discord notification."
+            exit 0
+          fi
+
+          fields="$(echo "$filtered" | jq -c '[.[] | {
+            name: ("#\(.number) by \(.author) — waiting since \(.waitingSince | split("T")[0])"),
+            value: "[\(.title)](\(.url))\nReviewers: \(.reviewers | join(", "))",
+            inline: false
+          }]')"
+
+          # Discord embeds support max 25 fields
+          if [ "$count" -gt 25 ]; then
+            extra=$((count - 24))
+            fields="$(echo "$fields" | jq -c ".[:24] + [{\"name\": \"... and ${extra} more\", \"value\": \"Additional PRs not shown\", \"inline\": false}]")"
+          fi
+
+          payload="$(jq -n --argjson fields "$fields" --arg count "$count" '{
+            embeds: [{
+              title: ("📋 " + $count + " PR(s) awaiting review"),
+              color: 16750848,
+              fields: $fields,
+              footer: { text: "Sorted by oldest review request first" }
+            }]
+          }')"
+
+          curl -sf -X POST \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "$DISCORD_WEBHOOK"
+
+          echo "Posted $count PR(s) to Discord."

--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -5,9 +5,6 @@ on:
     - cron: "0 13 * * 1-5" # 9 AM EDT (summer)
     - cron: "0 14 * * 1-5" # 9 AM EST (winter)
   workflow_dispatch:
-  push:
-    branches:
-      - ci/discord-pr-review-summary-cs-10475
 
 permissions:
   pull-requests: read
@@ -26,13 +23,10 @@ jobs:
           set -euo pipefail
 
           # Only run at 9 AM ET — skip the trigger that doesn't match current DST
-          # Skip the check for push events (testing)
-          if [ "${{ github.event_name }}" != "push" ]; then
-            current_et_hour="$(TZ=America/New_York date +%H)"
-            if [ "$current_et_hour" != "09" ]; then
-              echo "Current ET hour is $current_et_hour, not 9 AM. Skipping."
-              exit 0
-            fi
+          current_et_hour="$(TZ=America/New_York date +%H)"
+          if [ "$current_et_hour" != "09" ]; then
+            echo "Current ET hour is $current_et_hour, not 9 AM. Skipping."
+            exit 0
           fi
 
           prs="$(gh api graphql -f query='


### PR DESCRIPTION
It’s scheduled to run at 9am ET, regardless of DST, which in effect means running at both possible hours and ignoring the “wrong” run, because Actions cron is UTC-only.

Here it is working when I had it posting for pushes to this PR, since removed:

<img width="515" height="503" alt="#🚨-alarms-draft-internal | Cardstack - Discord 2026-03-20 12-53-03" src="https://github.com/user-attachments/assets/d20994f7-74ec-4730-8502-c6e671d913dd" />

For that I had it post to the draft alarms channel but have since changed the webhook to post to `#general-internal`.

It only looks at this repository at the moment, I’m not sure how complex it would be to consider others, but we can refine as needed.