### PR TITLE
Fix assistant "out of credit" messaging due to stale credits data in the host app

### DIFF
--- a/packages/ai-bot/lib/matrix/response-publisher.ts
+++ b/packages/ai-bot/lib/matrix/response-publisher.ts
@@ -176,12 +176,13 @@ export default class MatrixResponsePublisher {
     return sendOperation;
   }
 
-  async sendError(error: any) {
+  async sendError(error: any, opts?: { reloadBillingData?: boolean }) {
     sendErrorEvent(
       this.client,
       this.roomId,
       error,
       this.originalResponseEventId,
+      opts,
     );
   }
 

--- a/packages/ai-bot/lib/responder.ts
+++ b/packages/ai-bot/lib/responder.ts
@@ -181,7 +181,10 @@ export class Responder {
     };
   }
 
-  async onError(error: OpenAIError | string) {
+  async onError(
+    error: OpenAIError | string,
+    opts?: { reloadBillingData?: boolean },
+  ) {
     Sentry.captureException(error, {
       extra: {
         roomId: this.matrixResponsePublisher.roomId,
@@ -191,7 +194,7 @@ export class Responder {
     if (this.responseState.isStreamingFinished) {
       return;
     }
-    return await this.matrixResponsePublisher.sendError(error);
+    return await this.matrixResponsePublisher.sendError(error, opts);
   }
 
   async flush() {

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -442,6 +442,7 @@ Common issues are:
             // Careful when changing this message, it's used in the UI as a detection of whether to show the "Buy credits" button.
             return responder.onError(
               `You need a minimum of ${MINIMUM_AI_CREDITS_TO_CONTINUE} credits to continue using the AI bot. Please upgrade to a larger plan, or top up your account.`,
+              { reloadBillingData: true },
             );
           }
 

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -248,6 +248,9 @@ interface ReloadBillingOnInsertSignature {
   };
 }
 
+// In the future if we implement subscription to credit consumption, we can remove this modifier
+// It's currently used to reload the billing data when an out of credits error message is shown so that we can
+// conditionolly display the "buy more credits" button, or "credits added" message + retry button
 class ReloadBillingOnInsert extends Modifier<ReloadBillingOnInsertSignature> {
   private hasReloaded = false;
 

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -2,10 +2,13 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { registerDestructor } from '@ember/destroyable';
 import { hash } from '@ember/helper';
 import { action } from '@ember/object';
+import { scheduleOnce } from '@ember/runloop';
 import { service } from '@ember/service';
 import type { SafeString } from '@ember/template';
 import Component from '@glimmer/component';
 
+import { task } from 'ember-concurrency';
+import perform from 'ember-concurrency/helpers/perform';
 import Modifier from 'ember-modifier';
 import throttle from 'lodash/throttle';
 
@@ -45,6 +48,7 @@ interface Signature {
     isFromAssistant: boolean;
     isStreaming: boolean;
     isLastAssistantMessage: boolean;
+    isMostRecentMessage?: boolean;
     userMessageThisMessageIsRespondingTo?: Message;
     profileAvatar?: ComponentLike;
     collectionResource?: ReturnType<getCardCollection>;
@@ -64,6 +68,7 @@ interface Signature {
       element: HTMLElement;
     }) => void;
     errorMessage?: string;
+    reloadBillingData?: boolean;
     isDebugMessage?: boolean;
     isPending?: boolean;
     retryAction?: () => void;
@@ -234,6 +239,37 @@ class ScrollPosition extends Modifier<ScrollPositionSignature> {
   }
 }
 
+interface ReloadBillingOnInsertSignature {
+  Args: {
+    Named: {
+      shouldReloadBillingData: boolean;
+      reload: () => void;
+    };
+  };
+}
+
+class ReloadBillingOnInsert extends Modifier<ReloadBillingOnInsertSignature> {
+  private hasReloaded = false;
+
+  private runReload(reload: () => void) {
+    reload();
+  }
+
+  modify(
+    _element: HTMLElement,
+    _positional: [],
+    {
+      shouldReloadBillingData,
+      reload,
+    }: ReloadBillingOnInsertSignature['Args']['Named'],
+  ) {
+    if (shouldReloadBillingData && !this.hasReloaded) {
+      this.hasReloaded = true;
+      scheduleOnce('afterRender', this, this.runReload, reload);
+    }
+  }
+}
+
 function isThinkingMessage(s: string | null | undefined) {
   if (!s) {
     return false;
@@ -328,6 +364,12 @@ export default class AiAssistantMessage extends Component<Signature> {
     }
   }
 
+  private reloadBillingDataTask = task(async () => {
+    if (!this.billingService.loadingSubscriptionData) {
+      await this.billingService.loadSubscriptionData();
+    }
+  });
+
   <template>
     <section
       class={{cn
@@ -339,6 +381,10 @@ export default class AiAssistantMessage extends Component<Signature> {
         index=@index
         registerScroller=@registerScroller
         unregisterScroller=@unregisterScroller
+      }}
+      {{ReloadBillingOnInsert
+        shouldReloadBillingData=this.shouldReloadBillingData
+        reload=(perform this.reloadBillingDataTask)
       }}
       data-test-ai-assistant-message
       data-test-ai-assistant-message-pending={{@isPending}}
@@ -540,6 +586,12 @@ export default class AiAssistantMessage extends Component<Signature> {
 
   private get hasAlertActions() {
     return Boolean(this.args.waitAction || this.args.retryAction);
+  }
+
+  private get shouldReloadBillingData() {
+    return Boolean(
+      this.args.reloadBillingData && this.args.isMostRecentMessage,
+    );
   }
 
   private get isOutOfCreditsErrorMessage(): boolean {

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -250,7 +250,7 @@ interface ReloadBillingOnInsertSignature {
 
 // In the future if we implement subscription to credit consumption, we can remove this modifier
 // It's currently used to reload the billing data when an out of credits error message is shown so that we can
-// conditionolly display the "buy more credits" button, or "credits added" message + retry button
+// conditionally display the "buy more credits" button, or "credits added" message + retry button
 class ReloadBillingOnInsert extends Modifier<ReloadBillingOnInsertSignature> {
   private hasReloaded = false;
 

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -41,6 +41,7 @@ interface Signature {
     index: number;
     monacoSDK: MonacoSDK;
     isStreaming: boolean;
+    isMostRecentMessage?: boolean;
     retryAction?: () => void;
     isPending?: boolean;
     registerScroller: (args: {
@@ -185,6 +186,7 @@ export default class RoomMessage extends Component<Signature> {
         @eventId={{this.message.eventId}}
         @index={{@index}}
         @isLastAssistantMessage={{this.isLastAssistantMessage}}
+        @isMostRecentMessage={{@isMostRecentMessage}}
         @userMessageThisMessageIsRespondingTo={{this.userMessageThisMessageIsRespondingTo}}
         @registerScroller={{@registerScroller}}
         @unregisterScroller={{@unregisterScroller}}
@@ -200,6 +202,7 @@ export default class RoomMessage extends Component<Signature> {
         @files={{this.message.attachedFiles}}
         @attachedCardsAsFiles={{this.message.attachedCardsAsFiles}}
         @errorMessage={{this.errorMessage}}
+        @reloadBillingData={{this.message.reloadBillingData}}
         @isDebugMessage={{this.message.isDebugMessage}}
         @isStreaming={{@isStreaming}}
         @retryAction={{@retryAction}}

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -191,6 +191,7 @@ export default class Room extends Component<Signature> {
                 @roomId={{@roomId}}
                 @roomResource={{@roomResource}}
                 @index={{i}}
+                @isMostRecentMessage={{this.isLastMessage i}}
                 @registerScroller={{this.registerMessageScroller}}
                 @unregisterScroller={{this.unregisterMessageScroller}}
                 @isPending={{this.isPendingMessage message}}

--- a/packages/host/app/lib/matrix-classes/message-builder.ts
+++ b/packages/host/app/lib/matrix-classes/message-builder.ts
@@ -23,6 +23,7 @@ import {
   APP_BOXEL_CONTINUATION_OF_CONTENT_KEY,
   APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY,
   APP_BOXEL_MESSAGE_MSGTYPE,
+  APP_BOXEL_RELOAD_BILLING_DATA_KEY,
   APP_BOXEL_REASONING_CONTENT_KEY,
   APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE,
   APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE,
@@ -59,6 +60,14 @@ import type { RoomMember } from './member';
 const ErrorMessage: Record<string, string> = {
   ['M_TOO_LARGE']: 'Message is too large',
 };
+
+function shouldReloadBillingData(content: object) {
+  return Boolean(
+    (content as { [APP_BOXEL_RELOAD_BILLING_DATA_KEY]?: boolean })[
+      APP_BOXEL_RELOAD_BILLING_DATA_KEY
+    ],
+  );
+}
 
 export default class MessageBuilder {
   constructor(
@@ -169,6 +178,7 @@ export default class MessageBuilder {
       message.clientGeneratedId = this.clientGeneratedId;
       message.setIsStreamingFinished(!!event.content.isStreamingFinished);
       message.setIsCanceled(!!event.content.isCanceled);
+      message.reloadBillingData = shouldReloadBillingData(event.content);
       message.attachedCardIds = this.attachedCardIds;
       message.attachedCardsAsFiles = this.attachedCardsAsFiles;
       if (event.content[APP_BOXEL_COMMAND_REQUESTS_KEY]) {
@@ -178,6 +188,7 @@ export default class MessageBuilder {
     } else if (event.content.msgtype === 'm.text') {
       message.setIsStreamingFinished(!!event.content.isStreamingFinished);
       message.setIsCanceled(!!event.content.isCanceled);
+      message.reloadBillingData = shouldReloadBillingData(event.content);
     }
     if (event.type === APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE) {
       message.isDebugMessage = true;
@@ -214,6 +225,7 @@ export default class MessageBuilder {
       : null;
     message.setUpdated(new Date());
     message.errorMessage = this.errorMessage;
+    message.reloadBillingData = shouldReloadBillingData(this.event.content);
 
     let encodedCommandRequests =
       (this.event.content as CardMessageContent)[

--- a/packages/host/app/lib/matrix-classes/message.ts
+++ b/packages/host/app/lib/matrix-classes/message.ts
@@ -46,6 +46,7 @@ interface RoomMessageOptional {
   clientGeneratedId?: string | null;
   reasoningContent?: string | null;
   isDebugMessage?: boolean;
+  reloadBillingData?: boolean;
   hasContinuation?: boolean;
   continuationOf?: string | null;
   agentId?: string;
@@ -73,6 +74,7 @@ export class Message implements RoomMessageInterface {
   errorMessage?: string;
   clientGeneratedId?: string;
   isDebugMessage?: boolean;
+  reloadBillingData?: boolean;
   isCodePatchCorrectness?: boolean;
 
   author: RoomMember;

--- a/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
@@ -23,6 +23,7 @@ import {
   APP_BOXEL_CONTINUATION_OF_CONTENT_KEY,
   APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY,
   APP_BOXEL_MESSAGE_MSGTYPE,
+  APP_BOXEL_RELOAD_BILLING_DATA_KEY,
   APP_BOXEL_REASONING_CONTENT_KEY,
 } from '@cardstack/runtime-common/matrix-constants';
 
@@ -861,6 +862,58 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
         "After adding credits, 'buy more credits' button is replaced with 'retry'",
       );
     assert.dom('[data-test-credits-added]').exists();
+  });
+
+  test('it reloads billing data for the latest flagged out-of-credits message', async function (assert) {
+    let roomId = await renderAiAssistantPanel();
+    let billingService = getService('billing-service');
+    let requestCount = 0;
+
+    billingService.fetchSubscriptionData = async () => {
+      requestCount++;
+
+      let attributes =
+        requestCount === 1
+          ? {
+              creditsAvailableInPlanAllowance: 1,
+              extraCreditsAvailableInBalance: 2,
+            }
+          : {
+              creditsAvailableInPlanAllowance: 1,
+              extraCreditsAvailableInBalance: 1000,
+            };
+
+      return new Response(JSON.stringify({ data: { attributes } }));
+    };
+
+    await billingService.loadSubscriptionData();
+    assert.strictEqual(billingService.availableCredits, 3);
+
+    simulateRemoteMessage(roomId, '@aibot:localhost', {
+      body: 'You need a minimum of 10 credits to continue using the AI bot. Please upgrade to a larger plan, or top up your account.',
+      msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+      format: 'org.matrix.custom.html',
+      isStreamingFinished: true,
+      errorMessage:
+        'You need a minimum of 10 credits to continue using the AI bot. Please upgrade to a larger plan, or top up your account.',
+      [APP_BOXEL_RELOAD_BILLING_DATA_KEY]: true,
+    });
+
+    await waitUntil(() => requestCount === 2);
+    await waitUntil(() => billingService.availableCredits >= 10, {
+      timeout: 2000,
+    });
+
+    assert.strictEqual(requestCount, 2, 'billing data reloads exactly once');
+    assert
+      .dom('[data-test-alert-action-button="Retry"]')
+      .exists('retry is shown after the reload confirms credits are available');
+    assert
+      .dom('[data-test-credits-added]')
+      .exists('credits added notice is shown after the reload');
+    assert
+      .dom('[data-test-alert-action-button="Buy More Credits"]')
+      .doesNotExist();
   });
 
   test('it can retry a message when receiving an error from the AI bot', async function (assert) {

--- a/packages/runtime-common/ai/matrix-utils.ts
+++ b/packages/runtime-common/ai/matrix-utils.ts
@@ -7,6 +7,7 @@ import type { CommandRequest } from '../commands';
 import { encodeCommandRequests } from '../commands';
 import {
   APP_BOXEL_COMMAND_REQUESTS_KEY,
+  APP_BOXEL_RELOAD_BILLING_DATA_KEY,
   APP_BOXEL_REASONING_CONTENT_KEY,
   APP_BOXEL_MESSAGE_MSGTYPE,
   APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE,
@@ -77,6 +78,7 @@ export async function sendErrorEvent(
   roomId: string,
   error: any,
   eventIdToReplace: string | undefined,
+  opts?: { reloadBillingData?: boolean },
 ) {
   try {
     let errorMessage = getErrorMessage(error);
@@ -89,6 +91,7 @@ export async function sendErrorEvent(
       {
         isStreamingFinished: true,
         errorMessage,
+        [APP_BOXEL_RELOAD_BILLING_DATA_KEY]: opts?.reloadBillingData ?? false,
       },
     );
   } catch (e) {

--- a/packages/runtime-common/matrix-constants.ts
+++ b/packages/runtime-common/matrix-constants.ts
@@ -32,6 +32,7 @@ export const APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY =
 export const APP_BOXEL_CONTINUATION_OF_CONTENT_KEY =
   'app.boxel.continuation-of';
 export const APP_BOXEL_LLM_MODE = 'app.boxel.llm-mode';
+export const APP_BOXEL_RELOAD_BILLING_DATA_KEY = 'app.boxel.reloadBillingData';
 export type LLMMode = 'ask' | 'act';
 export const DEFAULT_LLM = 'anthropic/claude-sonnet-4.6';
 export const DEFAULT_CODING_LLM = 'anthropic/claude-sonnet-4.6';


### PR DESCRIPTION
This PR is fixing the bug where if you run out of credits while talking to the assistant, this message will show up and it 
will immediately say "Credits added!", even if no credits were actually added. This is confusing and wrong:

<img width="568" height="162" alt="image" src="https://github.com/user-attachments/assets/991764cb-f94a-4b05-ac32-95ef45e0f179" />

This happens because we show "Credits added!" when the user has enough credits to continue, but in this case, the credits data in the billing service is stale - the host app thinks the user has enough credits to continue, even after the ai bot sends the "out of credit" error message. 

The solution presented here is to reload the credit usage data when "out of credits" error happens, and this way the messaging will be correct, like this:

<img width="537" height="187" alt="image" src="https://github.com/user-attachments/assets/41e9df98-d9ba-48bc-a965-005ca0cb712e" />
 

I don't particularly love this solution, I think we should keep our host app in sync with the credits data at all times without refreshing on demand, possibly via subscription. This already works when user makes actions in Stripe (e.g. buying credits), but we don't  have the plumbing ready to make this work when the ai-bot is involved. This subscription works with the session room and the communication channel for this is host app <-> realm server. But in this case, the producer of this error is the ai bot, so probably we'd have to figure out a way where on user credit consumption event (which is handled in the ai bot), the ai bot can message the realm server so that the realm server can send a notification to the host app to reload credits data. Perhaps, this is a bit too much for now to fix this small bug, but later on if we need display up-to-date credit amounts in places other than the user profile popover (which triggers a request to get the latest credit data) then I think subscription for credit consumption subscription events would be the right way to go...

