### PR TITLE
Don't refresh loader when a new gts file is added if the module has never been loaded

### DIFF
--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -343,7 +343,10 @@ class _FileResource extends Resource<Args> {
           clientRequestId: opts?.clientRequestId,
         },
       );
-      if (opts?.flushLoader) {
+      if (
+        opts?.flushLoader &&
+        this.loaderService.loader.isModuleLoaded(this._url)
+      ) {
         this.store.refreshReferencesForCodeChange('file write');
       }
       if (this.innerState.state === 'not-found') {

--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -334,6 +334,11 @@ class _FileResource extends Resource<Args> {
         clientRequestId?: string;
       },
     ) => {
+      // Capture before saveSource which may call resetLoader(), replacing
+      // the loader with a fresh clone that has no loaded modules.
+      let moduleWasLoaded =
+        opts?.flushLoader &&
+        this.loaderService.loader.isModuleLoaded(this._url);
       let response = await this.cardService.saveSource(
         new URL(this._url),
         content,
@@ -343,10 +348,7 @@ class _FileResource extends Resource<Args> {
           clientRequestId: opts?.clientRequestId,
         },
       );
-      if (
-        opts?.flushLoader &&
-        this.loaderService.loader.isModuleLoaded(this._url)
-      ) {
+      if (moduleWasLoaded) {
         this.store.refreshReferencesForCodeChange('file write');
       }
       if (this.innerState.state === 'not-found') {

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -239,7 +239,10 @@ export default class CardService extends Service {
       }
       this.subscriber?.(url, content);
 
-      if (options?.resetLoader) {
+      if (
+        options?.resetLoader &&
+        this.loaderService.loader.isModuleLoaded(url.href)
+      ) {
         this.loaderService.resetLoader();
       }
 

--- a/packages/host/app/services/loader-service.ts
+++ b/packages/host/app/services/loader-service.ts
@@ -36,7 +36,6 @@ export default class LoaderService extends Service {
   @service declare private reset: ResetService;
 
   @tracked public loader = this.makeInstance();
-  private previousLoader: Loader | null = null;
   private resetTime: number | undefined;
 
   constructor(owner: Owner) {
@@ -48,13 +47,11 @@ export default class LoaderService extends Service {
   }
 
   public resetState() {
-    this.previousLoader = null;
     this.clearSessionCaches();
   }
 
   public resetSessionBoundary(reason?: string) {
     this.resetTime = undefined;
-    this.previousLoader = null;
     log.debug(`resetting loader for session boundary (${reason ?? ''})`);
     this.clearSessionCaches();
     this.loader = this.loader
@@ -70,7 +67,6 @@ export default class LoaderService extends Service {
     if (options?.clearFetchCache) {
       this.resetTime = Date.now();
       log.debug(`resetting loader (clearFetchCache, ${options.reason ?? ''})`);
-      this.previousLoader = this.loader;
       clearFetchCache();
       this.loader = this.makeInstance();
       return;
@@ -84,7 +80,6 @@ export default class LoaderService extends Service {
     if (this.resetTime == null || Date.now() - this.resetTime > 250) {
       this.resetTime = Date.now();
       log.debug(`resetting loader (${options?.reason ?? ''})`);
-      this.previousLoader = this.loader;
       // by default we keep the fetch cache so we can take advantage of HTTP
       // caching when rebuilding the loader state
       if (this.loader) {
@@ -93,18 +88,6 @@ export default class LoaderService extends Service {
         this.loader = this.makeInstance();
       }
     }
-  }
-
-  // Check if a module was loaded in the current loader or in the loader that
-  // was active before the most recent reset. This handles the timing window
-  // where a save path resets the loader before the realm invalidation event
-  // arrives: the module is no longer in the new (cloned) loader, but it was
-  // in the previous one.
-  public wasModuleLoaded(moduleIdentifier: string): boolean {
-    return (
-      this.loader.isModuleLoaded(moduleIdentifier) ||
-      (this.previousLoader?.isModuleLoaded(moduleIdentifier) ?? false)
-    );
   }
 
   private makeInstance() {

--- a/packages/host/app/services/loader-service.ts
+++ b/packages/host/app/services/loader-service.ts
@@ -36,6 +36,7 @@ export default class LoaderService extends Service {
   @service declare private reset: ResetService;
 
   @tracked public loader = this.makeInstance();
+  private previousLoader: Loader | null = null;
   private resetTime: number | undefined;
 
   constructor(owner: Owner) {
@@ -47,11 +48,13 @@ export default class LoaderService extends Service {
   }
 
   public resetState() {
+    this.previousLoader = null;
     this.clearSessionCaches();
   }
 
   public resetSessionBoundary(reason?: string) {
     this.resetTime = undefined;
+    this.previousLoader = null;
     log.debug(`resetting loader for session boundary (${reason ?? ''})`);
     this.clearSessionCaches();
     this.loader = this.loader
@@ -67,6 +70,7 @@ export default class LoaderService extends Service {
     if (options?.clearFetchCache) {
       this.resetTime = Date.now();
       log.debug(`resetting loader (clearFetchCache, ${options.reason ?? ''})`);
+      this.previousLoader = this.loader;
       clearFetchCache();
       this.loader = this.makeInstance();
       return;
@@ -80,6 +84,7 @@ export default class LoaderService extends Service {
     if (this.resetTime == null || Date.now() - this.resetTime > 250) {
       this.resetTime = Date.now();
       log.debug(`resetting loader (${options?.reason ?? ''})`);
+      this.previousLoader = this.loader;
       // by default we keep the fetch cache so we can take advantage of HTTP
       // caching when rebuilding the loader state
       if (this.loader) {
@@ -88,6 +93,18 @@ export default class LoaderService extends Service {
         this.loader = this.makeInstance();
       }
     }
+  }
+
+  // Check if a module was loaded in the current loader or in the loader that
+  // was active before the most recent reset. This handles the timing window
+  // where a save path resets the loader before the realm invalidation event
+  // arrives: the module is no longer in the new (cloned) loader, but it was
+  // in the previous one.
+  public wasModuleLoaded(moduleIdentifier: string): boolean {
+    return (
+      this.loader.isModuleLoaded(moduleIdentifier) ||
+      (this.previousLoader?.isModuleLoaded(moduleIdentifier) ?? false)
+    );
   }
 
   private makeInstance() {

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1064,7 +1064,7 @@ export default class StoreService extends Service implements StoreInterface {
       invalidations.find(
         (i) =>
           hasExecutableExtension(i) &&
-          this.loaderService.wasModuleLoaded(i),
+          this.loaderService.loader.isModuleLoaded(i),
       )
     ) {
       // the invalidation included code changes to modules that are already

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1060,10 +1060,17 @@ export default class StoreService extends Service implements StoreInterface {
     }
     let invalidations = event.invalidations as string[];
 
-    if (invalidations.find((i) => hasExecutableExtension(i))) {
-      // the invalidation included code changes too. in this case we
-      // need to flush the loader so that we can pick up any updated
-      // code before re-running the card
+    if (
+      invalidations.find(
+        (i) =>
+          hasExecutableExtension(i) &&
+          this.loaderService.loader.isModuleLoaded(i),
+      )
+    ) {
+      // the invalidation included code changes to modules that are already
+      // loaded. in this case we need to flush the loader so that we can pick
+      // up the updated code before re-running the card. net-new modules that
+      // have never been loaded don't require a loader reset.
       this.loaderService.resetLoader();
       this.store.reset();
       this.reestablishReferences.perform();

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1064,7 +1064,7 @@ export default class StoreService extends Service implements StoreInterface {
       invalidations.find(
         (i) =>
           hasExecutableExtension(i) &&
-          this.loaderService.loader.isModuleLoaded(i),
+          this.loaderService.wasModuleLoaded(i),
       )
     ) {
       // the invalidation included code changes to modules that are already

--- a/packages/host/tests/unit/loader-test.ts
+++ b/packages/host/tests/unit/loader-test.ts
@@ -127,6 +127,9 @@ module('Unit | loader', function (hooks) {
           export function checkImportMeta() { return import.meta.url; }
           export function myLoader() { return import.meta.loader; }
         `,
+          'reexporter.js': `
+          export { g } from './g';
+        `,
         },
       }),
     );
@@ -251,6 +254,81 @@ module('Unit | loader', function (hooks) {
       consumed,
       [`${testRealmURL}b`, `${testRealmURL}c`, `${testRealmURL}g`],
       'consumed modules resolved correctly from prefix-form identifier',
+    );
+  });
+
+  test('isModuleLoaded returns false for a module that has not been imported', function (assert) {
+    assert.false(
+      loader.isModuleLoaded(`${testRealmURL}a`),
+      'module a is not loaded before import',
+    );
+    assert.false(
+      loader.isModuleLoaded(`${testRealmURL}nonexistent`),
+      'nonexistent module is not loaded',
+    );
+  });
+
+  test('isModuleLoaded returns true for a module that has been imported', async function (assert) {
+    assert.false(
+      loader.isModuleLoaded(`${testRealmURL}a`),
+      'module a is not loaded before import',
+    );
+    await loader.import(`${testRealmURL}a`);
+    assert.true(
+      loader.isModuleLoaded(`${testRealmURL}a`),
+      'module a is loaded after import',
+    );
+  });
+
+  test('isModuleLoaded returns true for dependencies of an imported module', async function (assert) {
+    assert.false(
+      loader.isModuleLoaded(`${testRealmURL}b`),
+      'module b is not loaded before import',
+    );
+    assert.false(
+      loader.isModuleLoaded(`${testRealmURL}c`),
+      'module c is not loaded before import',
+    );
+    await loader.import(`${testRealmURL}a`);
+    assert.true(
+      loader.isModuleLoaded(`${testRealmURL}b`),
+      'module b is loaded as a dependency of a',
+    );
+    assert.true(
+      loader.isModuleLoaded(`${testRealmURL}c`),
+      'module c is loaded as a transitive dependency of a',
+    );
+  });
+
+  test('isModuleLoaded works with executable extensions in the URL', async function (assert) {
+    await loader.import(`${testRealmURL}person`);
+    assert.true(
+      loader.isModuleLoaded(`${testRealmURL}person`),
+      'loaded without extension',
+    );
+    assert.true(
+      loader.isModuleLoaded(`${testRealmURL}person.gts`),
+      'loaded with .gts extension',
+    );
+  });
+
+  test('isModuleLoaded returns true for a re-exported module', async function (assert) {
+    assert.false(
+      loader.isModuleLoaded(`${testRealmURL}reexporter`),
+      'reexporter is not loaded before import',
+    );
+    assert.false(
+      loader.isModuleLoaded(`${testRealmURL}g`),
+      're-exported module g is not loaded before import',
+    );
+    await loader.import(`${testRealmURL}reexporter`);
+    assert.true(
+      loader.isModuleLoaded(`${testRealmURL}reexporter`),
+      'reexporter is loaded after import',
+    );
+    assert.true(
+      loader.isModuleLoaded(`${testRealmURL}g`),
+      're-exported module g is loaded as a dependency of reexporter',
     );
   });
 

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -267,9 +267,16 @@ export class Loader {
   }
 
   isModuleLoaded(moduleIdentifier: string): boolean {
-    moduleIdentifier = this.resolveImport(moduleIdentifier);
-    let resolvedModuleIdentifier = new URL(moduleIdentifier).href;
-    return this.getModule(resolvedModuleIdentifier) !== undefined;
+    try {
+      moduleIdentifier = this.resolveImport(moduleIdentifier);
+      let resolvedModuleIdentifier = new URL(moduleIdentifier).href;
+      return this.getModule(resolvedModuleIdentifier) !== undefined;
+    } catch (e) {
+      if (e instanceof TypeError) {
+        return false;
+      }
+      throw e;
+    }
   }
 
   getKnownConsumedModules(moduleIdentifier: string): string[] {

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -266,6 +266,12 @@ export class Loader {
     }
   }
 
+  isModuleLoaded(moduleIdentifier: string): boolean {
+    moduleIdentifier = this.resolveImport(moduleIdentifier);
+    let resolvedModuleIdentifier = new URL(moduleIdentifier).href;
+    return this.getModule(resolvedModuleIdentifier) !== undefined;
+  }
+
   getKnownConsumedModules(moduleIdentifier: string): string[] {
     let resolvedModuleIdentifier = this.resolveImport(moduleIdentifier);
     let knownDependencies = this.collectKnownModuleDependencies(


### PR DESCRIPTION
## Summary

- Added `isModuleLoaded()` method to the `Loader` class that checks whether a module identifier exists in the internal modules map
- Modified `store.ts`, `card-service.ts`, and `file.ts` to only trigger a loader reset when the changed executable file's module was already loaded
- Net-new GTS/TS/JS files that have never been imported no longer cause a full loader reset and UI refresh

Fixes CS-10474

## Test plan

- [x] Added 5 unit tests for `isModuleLoaded`:
  - Returns false for unimported modules
  - Returns true after import
  - Returns true for transitive dependencies
  - Works with executable extensions (`.gts`, `.js`, etc.)
  - Returns true for re-exported module dependencies
- [x] Verified red-green: tests fail without the implementation, pass with it
- [x] All 23 existing + new loader tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)