### PR TITLE
Fix stale isolated markup for public realm in operator mode

### DIFF
--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -144,7 +144,7 @@ export default class OperatorModeContainer extends Component<Signature> {
   }
 
   <template>
-    <div class='operator-mode'>
+    <div class='operator-mode' ...attributes>
       <ChooseFileModal />
       <CreateListingModal />
       <CreatePRModal />

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -56,6 +56,7 @@ interface Signature {
   Args: {
     onClose: () => void;
   };
+  Element: HTMLElement;
 }
 
 export default class OperatorModeContainer extends Component<Signature> {

--- a/packages/host/app/templates/index.gts
+++ b/packages/host/app/templates/index.gts
@@ -236,7 +236,10 @@ export class IndexComponent extends Component<IndexComponentComponentSignature> 
       />
     {{else}}
       {{pageTitle this.operatorModeStateService.title}}
-      <OperatorModeContainer @onClose={{this.closeOperatorMode}} />
+      <OperatorModeContainer
+        @onClose={{this.closeOperatorMode}}
+        {{this.removeIsolatedMarkup}}
+      />
     {{/if}}
   </template>
 }


### PR DESCRIPTION
`removeIsolatedMarkup` — the modifier that cleans up SSR-prerendered HTML — only fires in Host Mode. This is why on operator mode, on staging and prod we see duplicate markup for the homepage-realm when `https://realms-staging.stack.cards/boxel-homepage` route is visited (prerendered one remains behind the operator mode rendering).

We accidentally realized this issue in homepage-realm because of the z-index on the navbar and because homepage-realm hidden from workspace chooser. In fact, we can see this in other public realms too when directly visited. For example, here's `https://realms-staging.stack.cards/skills` :
<img width="615" height="713" alt="skills-staging" src="https://github.com/user-attachments/assets/f891aed1-1276-4311-bb88-0c0c73aaa87c" />
