### PR TITLE
Fix software factory cache prepare in worktrees

### DIFF
--- a/packages/software-factory/src/cli/cache-realm.ts
+++ b/packages/software-factory/src/cli/cache-realm.ts
@@ -1,10 +1,8 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
-import {
-  ensureFactoryRealmTemplate,
-  type FactoryRealmOptions,
-} from '../harness';
+import { ensureFactoryRealmTemplate } from '../harness';
+import { isFactorySupportContext } from '../harness/shared';
 import { readSupportContext } from '../runtime-metadata';
 
 async function main(): Promise<void> {
@@ -18,9 +16,15 @@ async function main(): Promise<void> {
   ];
   let serializedSupportContext = process.env.SOFTWARE_FACTORY_CONTEXT;
 
-  let supportContext: FactoryRealmOptions['context'] = serializedSupportContext
-    ? (JSON.parse(serializedSupportContext) as FactoryRealmOptions['context'])
-    : (readSupportContext() as FactoryRealmOptions['context']);
+  let parsedEnvContext = serializedSupportContext
+    ? (JSON.parse(serializedSupportContext) as unknown)
+    : undefined;
+  let parsedMetadataContext = readSupportContext();
+  let supportContext = isFactorySupportContext(parsedEnvContext)
+    ? parsedEnvContext
+    : isFactorySupportContext(parsedMetadataContext)
+      ? parsedMetadataContext
+      : undefined;
 
   let preparedTemplates = [];
   for (let realmDir of realmDirs) {

--- a/packages/software-factory/src/harness/isolated-realm-stack.ts
+++ b/packages/software-factory/src/harness/isolated-realm-stack.ts
@@ -339,6 +339,7 @@ export async function startIsolatedRealmStack({
     REALM_SERVER_SECRET_SEED,
     REALM_SECRET_SEED,
     GRAFANA_SECRET,
+    HOST_URL: context.hostURL,
     MATRIX_URL: context.matrixURL,
     MATRIX_REGISTRATION_SHARED_SECRET: context.matrixRegistrationSecret,
     REALM_SERVER_MATRIX_USERNAME: DEFAULT_MATRIX_SERVER_USERNAME,

--- a/packages/software-factory/src/harness/shared.ts
+++ b/packages/software-factory/src/harness/shared.ts
@@ -6,7 +6,7 @@ import {
 import { createHash } from 'node:crypto';
 import { createServer as createNetServer } from 'node:net';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, relative, resolve } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 
 import jwt from 'jsonwebtoken';
 import '../setup-logger';
@@ -19,6 +19,7 @@ export type RealmPermissions = Record<string, RealmAction[]>;
 export type FactorySupportContext = {
   matrixURL: string;
   matrixRegistrationSecret: string;
+  hostURL: string;
 };
 
 export type SynapseInstance = {
@@ -153,10 +154,11 @@ export const DEFAULT_REALM_DIR = resolve(
   packageRoot,
   process.env.SOFTWARE_FACTORY_REALM_DIR ?? 'test-fixtures/darkfactory-adopter',
 );
-export const DEFAULT_HOST_URL =
-  process.env.HOST_URL ?? 'http://localhost:4200/';
 export const DEFAULT_ICONS_URL =
   process.env.ICONS_URL ?? 'http://localhost:4206/';
+export const CONFIGURED_HOST_URL = process.env.SOFTWARE_FACTORY_HOST_URL
+  ? new URL(process.env.SOFTWARE_FACTORY_HOST_URL)
+  : undefined;
 export const DEFAULT_ICONS_PROBE_URL = new URL(
   '@cardstack/boxel-icons/v1/icons/code.js',
   DEFAULT_ICONS_URL,
@@ -586,15 +588,40 @@ export function fileExists(path: string): boolean {
   }
 }
 
+export function findRootRepoCheckoutDir(): string | undefined {
+  let result = spawnSync(
+    'git',
+    ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+    {
+      cwd: workspaceRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    },
+  );
+
+  if (result.status !== 0) {
+    return undefined;
+  }
+
+  let commonDir = result.stdout.trim();
+  if (!commonDir.endsWith(`${join('.git')}`)) {
+    return undefined;
+  }
+
+  return dirname(commonDir);
+}
+
 export function findHostDistPackageDir(): string | undefined {
-  let siblingRoot = resolve(workspaceRoot, '..');
+  let rootRepoCheckoutDir = findRootRepoCheckoutDir();
+  let rootRepoHostDir =
+    rootRepoCheckoutDir && rootRepoCheckoutDir !== workspaceRoot
+      ? resolve(rootRepoCheckoutDir, 'packages', 'host')
+      : undefined;
+
   let candidates = [
     process.env.SOFTWARE_FACTORY_HOST_DIST_PACKAGE_DIR,
-    resolve(siblingRoot, 'boxel', 'packages', 'host'),
-    ...readdirSync(siblingRoot, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => resolve(siblingRoot, entry.name, 'packages', 'host')),
     hostDir,
+    rootRepoHostDir,
   ]
     .filter((value): value is string => Boolean(value))
     .map((value) => resolve(value));
@@ -628,6 +655,21 @@ export function parseFactoryContext(): FactoryTestContext | undefined {
     return undefined;
   }
   return JSON.parse(raw) as FactoryTestContext;
+}
+
+export function isFactorySupportContext(
+  context: unknown,
+): context is FactorySupportContext {
+  return Boolean(
+    context &&
+    typeof context === 'object' &&
+    'matrixURL' in context &&
+    typeof context.matrixURL === 'string' &&
+    'matrixRegistrationSecret' in context &&
+    typeof context.matrixRegistrationSecret === 'string' &&
+    'hostURL' in context &&
+    typeof context.hostURL === 'string',
+  );
 }
 
 export function hasTemplateDatabaseName(

--- a/packages/software-factory/src/harness/support-services.ts
+++ b/packages/software-factory/src/harness/support-services.ts
@@ -1,19 +1,21 @@
 import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import {
   boxelIconsDir,
   browserPassword,
   cleanupStaleSynapseContainers,
-  DEFAULT_HOST_URL,
   DEFAULT_ICONS_PROBE_URL,
   DEFAULT_MATRIX_BROWSER_USERNAME,
   DEFAULT_MATRIX_SERVER_USERNAME,
   DEFAULT_PG_HOST,
   DEFAULT_PG_PORT,
   DEFAULT_PRERENDER_PORT,
+  CONFIGURED_HOST_URL,
   findAvailablePort,
   findHostDistPackageDir,
-  hostDir,
+  findRootRepoCheckoutDir,
   logTimed,
   maybeRequire,
   prepareTestPgScript,
@@ -31,6 +33,91 @@ let preparePgPromise: Promise<void> | undefined;
 
 function hostStartupLooksLikePortContention(logs: string): boolean {
   return /EADDRINUSE|address already in use/i.test(logs);
+}
+
+function assertUsableBoxelUIDist(hostPackageDir: string): void {
+  let boxelUIAddonDir = join(hostPackageDir, '..', 'boxel-ui', 'addon');
+  let boxelUIDistDir = join(boxelUIAddonDir, 'dist');
+  let requiredPaths = [
+    join(boxelUIDistDir, 'components.js'),
+    join(boxelUIDistDir, 'helpers.js'),
+    join(boxelUIDistDir, 'icons.js'),
+    join(boxelUIDistDir, 'styles', 'global.css'),
+  ];
+
+  if (requiredPaths.every((path) => existsSync(path))) {
+    return;
+  }
+
+  let rootRepoCheckoutDir = findRootRepoCheckoutDir();
+  let rootRepoBoxelUIAddonDir =
+    rootRepoCheckoutDir && rootRepoCheckoutDir !== workspaceRoot
+      ? join(rootRepoCheckoutDir, 'packages', 'boxel-ui', 'addon')
+      : undefined;
+  let rootRepoBoxelUIDistDir = rootRepoBoxelUIAddonDir
+    ? join(rootRepoBoxelUIAddonDir, 'dist')
+    : undefined;
+  let hasRootRepoBoxelUIDist =
+    rootRepoBoxelUIDistDir != null &&
+    requiredPaths
+      .map((path) =>
+        join(rootRepoBoxelUIDistDir, path.slice(boxelUIDistDir.length + 1)),
+      )
+      .every((path) => existsSync(path));
+
+  let fixInstructions = [
+    `Run \`cd ${boxelUIAddonDir} && mise exec -- pnpm build\` to build boxel-ui in this checkout.`,
+  ];
+
+  if (hasRootRepoBoxelUIDist && rootRepoBoxelUIDistDir) {
+    fixInstructions.push(
+      `If you are in a worktree and want to reuse the main checkout build, run \`ln -sfn ${rootRepoBoxelUIDistDir} ${boxelUIDistDir}\`.`,
+    );
+  }
+
+  throw new Error(
+    `Boxel UI dist is missing or incomplete at ${boxelUIDistDir}. The software-factory harness needs built @cardstack/boxel-ui artifacts before the host app can boot. ${fixInstructions.join(
+      ' ',
+    )}`,
+  );
+}
+
+function assertUsableHostDist(hostPackageDir: string): void {
+  let indexHTMLPath = join(hostPackageDir, 'dist', 'index.html');
+  if (!existsSync(indexHTMLPath)) {
+    throw new Error(
+      `No built host dist was found at ${indexHTMLPath}. The software-factory harness requires a built host app from the current worktree or root repo checkout. Run \`cd ${hostPackageDir} && mise exec -- pnpm build\` and retry.`,
+    );
+  }
+
+  let html = readFileSync(indexHTMLPath, 'utf8');
+  let match = html.match(
+    /<meta name="@cardstack\/host\/config\/environment" content="([^"]+)">/,
+  );
+  if (!match) {
+    return;
+  }
+
+  try {
+    let config = JSON.parse(decodeURIComponent(match[1]));
+    if (
+      config?.environment === 'test' ||
+      config?.APP?.autoboot === false ||
+      config?.APP?.rootElement === '#ember-testing'
+    ) {
+      throw new Error(
+        `Host dist at ${hostPackageDir}/dist is a test build and cannot power the software-factory harness (environment=${String(
+          config?.environment,
+        )}, autoboot=${String(config?.APP?.autoboot)}, rootElement=${String(
+          config?.APP?.rootElement,
+        )}). The harness needs a normal host app build so /_standby can boot. Run \`cd ${hostPackageDir} && mise exec -- pnpm build\` and retry.`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+  }
 }
 
 async function loadSynapseModule() {
@@ -61,49 +148,68 @@ async function loadMatrixEnvironmentConfigModule() {
   };
 }
 
-async function ensureHostReady(matrixURL: string): Promise<{
+async function ensureHostReady(): Promise<{
+  hostURL: string;
   stop?: () => Promise<void>;
 }> {
+  let configuredHostURL = CONFIGURED_HOST_URL?.href;
   return await logTimed(
     supportLog,
-    `ensureHostReady ${DEFAULT_HOST_URL}`,
+    `ensureHostReady ${configuredHostURL ?? 'dynamic host dist'}`,
     async () => {
-      let response: Response;
-      try {
-        response = await fetch(DEFAULT_HOST_URL);
-        if (response.ok) {
-          return {};
+      if (configuredHostURL) {
+        try {
+          let response = await fetch(configuredHostURL);
+          if (response.ok) {
+            return { hostURL: configuredHostURL };
+          }
+          throw new Error(
+            `configured software-factory host URL ${configuredHostURL} returned HTTP ${response.status}`,
+          );
+        } catch (error) {
+          throw new Error(
+            `configured software-factory host URL ${configuredHostURL} is not reachable: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
         }
-      } catch (error) {
-        supportLog.debug(
-          `host app not reachable at ${DEFAULT_HOST_URL}, starting fallback host service: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
       }
 
       let hostPackageDir = findHostDistPackageDir();
-      let command = ['start'];
-      let cwd = hostDir;
-      if (hostPackageDir) {
-        supportLog.debug(`serving built host dist from ${hostPackageDir}`);
-        command = ['serve:dist'];
-        cwd = hostPackageDir;
-      } else {
-        supportLog.warn(
-          'no built host dist found; falling back to pnpm start in packages/host',
+      if (!hostPackageDir) {
+        throw new Error(
+          'No built host dist is available in the current worktree or root repo checkout',
         );
       }
+      assertUsableBoxelUIDist(hostPackageDir);
+      assertUsableHostDist(hostPackageDir);
+      let port = await findAvailablePort();
+      let hostURL = `http://localhost:${port}/`;
+      supportLog.debug(
+        `serving built host dist from ${hostPackageDir} at ${hostURL}`,
+      );
 
-      let child = spawn('pnpm', command, {
-        cwd,
-        detached: true,
-        stdio: ['ignore', 'pipe', 'pipe'],
-        env: {
-          ...process.env,
-          MATRIX_URL: matrixURL,
+      let child = spawn(
+        'npx',
+        [
+          'serve',
+          '--config',
+          '../tests/serve.json',
+          '--single',
+          '--cors',
+          '--no-request-logging',
+          '--no-etag',
+          '--listen',
+          String(port),
+          'dist',
+        ],
+        {
+          cwd: hostPackageDir,
+          detached: true,
+          stdio: ['ignore', 'pipe', 'pipe'],
+          env: process.env,
         },
-      });
+      );
 
       let logs = '';
       child.stdout?.on('data', (chunk) => {
@@ -116,7 +222,7 @@ async function ensureHostReady(matrixURL: string): Promise<{
       await waitUntil(
         async () => {
           try {
-            let readyResponse = await fetch(DEFAULT_HOST_URL);
+            let readyResponse = await fetch(hostURL);
             if (readyResponse.ok) {
               return true;
             }
@@ -136,11 +242,12 @@ async function ensureHostReady(matrixURL: string): Promise<{
         {
           timeout: 180_000,
           interval: 500,
-          timeoutMessage: `Timed out waiting for host app at ${DEFAULT_HOST_URL}\n${logs}`,
+          timeoutMessage: `Timed out waiting for host app at ${hostURL}\n${logs}`,
         },
       );
 
       return {
+        hostURL,
         async stop() {
           if (child.exitCode === null) {
             try {
@@ -401,7 +508,7 @@ export async function startFactorySupportServices(): Promise<{
     );
     let matrixURL =
       process.env.SOFTWARE_FACTORY_MATRIX_URL ?? getSynapseURL(synapse);
-    let host = await ensureHostReady(matrixURL);
+    let host = await ensureHostReady();
     let icons = await ensureIconsReady();
     await ensureSupportUsers(synapse);
 
@@ -409,6 +516,7 @@ export async function startFactorySupportServices(): Promise<{
       context: {
         matrixURL,
         matrixRegistrationSecret: synapse.registrationSecret,
+        hostURL: host.hostURL,
       },
       async stop() {
         await logTimed(supportLog, 'stopFactorySupportServices', async () => {

--- a/packages/software-factory/src/harness/support-services.ts
+++ b/packages/software-factory/src/harness/support-services.ts
@@ -185,6 +185,8 @@ async function ensureHostReady(): Promise<{
       assertUsableHostDist(hostPackageDir);
       let port = await findAvailablePort();
       let hostURL = `http://localhost:${port}/`;
+      let hostDistDir = join(hostPackageDir, 'dist');
+      let serveConfigPath = join(hostPackageDir, 'tests', 'serve.json');
       supportLog.debug(
         `serving built host dist from ${hostPackageDir} at ${hostURL}`,
       );
@@ -194,14 +196,14 @@ async function ensureHostReady(): Promise<{
         [
           'serve',
           '--config',
-          'tests/serve.json',
+          serveConfigPath,
           '--single',
           '--cors',
           '--no-request-logging',
           '--no-etag',
           '--listen',
           String(port),
-          'dist',
+          hostDistDir,
         ],
         {
           cwd: hostPackageDir,

--- a/packages/software-factory/src/harness/support-services.ts
+++ b/packages/software-factory/src/harness/support-services.ts
@@ -194,7 +194,7 @@ async function ensureHostReady(): Promise<{
         [
           'serve',
           '--config',
-          '../tests/serve.json',
+          'tests/serve.json',
           '--single',
           '--cors',
           '--no-request-logging',


### PR DESCRIPTION
## Summary
- make software-factory harness host-dist lookup work for any git worktree layout by deriving the root checkout from `git rev-parse --git-common-dir` instead of assuming `.claude/worktrees`
- fail fast during `cache:prepare` when the only available host dist is missing, incomplete, or a test build, and include explicit next steps for rebuilding `packages/host` or `packages/boxel-ui/addon`
- ignore stale `support.json` metadata that lacks `hostURL` so cache preparation can bootstrap fresh support services instead of silently inheriting broken harness state
- pass the harness-owned `HOST_URL` into isolated realm-server startup so prerender stays pinned to the harness host instead of drifting to incorrect defaults

## Validation
- `cd packages/software-factory && mise exec -- pnpm exec eslint src/cli/cache-realm.ts src/harness/shared.ts src/harness/support-services.ts src/harness/isolated-realm-stack.ts`
- `cd packages/software-factory && mise exec -- pnpm exec prettier --check src/cli/cache-realm.ts src/harness/shared.ts src/harness/support-services.ts src/harness/isolated-realm-stack.ts`
- `cd packages/boxel-ui/addon && mise exec -- pnpm build`
- `cd packages/host && mise exec -- pnpm build`
- `cd .claude/worktrees/cs-10419/packages/software-factory && mise exec -- pnpm cache:prepare test-fixtures/test-realm-runner`

## Notes
- the `cache:prepare` repro in `cs-10419` now gets past the old standby timeout and uses host assets from the harness-served dynamic host instead of `4200`
