### PR TITLE
Add isLoading checking for the Example field in Create Listing Modal

### DIFF
--- a/packages/host/app/components/operator-mode/create-listing-modal.gts
+++ b/packages/host/app/components/operator-mode/create-listing-modal.gts
@@ -47,8 +47,12 @@ export default class CreateListingModal extends Component<Signature> {
 
   @tracked private selectedExamples: PickerOption[] = [];
 
-  private instancesSearch = getSearch<CardDef>(this, getOwner(this)!, () =>
-    this.codeRef ? { filter: { type: this.codeRef } } : undefined,
+  private instancesSearch = getSearch<CardDef>(
+    this,
+    getOwner(this)!,
+    () => (this.codeRef ? { filter: { type: this.codeRef } } : undefined),
+    () => (this.payload?.targetRealm ? [this.payload.targetRealm] : undefined),
+    { isLive: true },
   );
 
   private get instances(): CardDef[] {
@@ -117,6 +121,10 @@ export default class CreateListingModal extends Component<Signature> {
     return this.selectedExamples.length > 0
       ? this.selectedExamples
       : this.initialSelected;
+  }
+
+  private get isCreateDisabled(): boolean {
+    return this.createListing.isRunning || this.instancesSearch.isLoading;
   }
 
   @action private onExampleChange(selected: PickerOption[]) {
@@ -208,20 +216,22 @@ export default class CreateListingModal extends Component<Signature> {
             </div>
           </FieldContainer>
 
-          {{#if this.instanceOptions.length}}
-            <FieldContainer @label='Examples' class='field'>
-              <div class='field-contents' data-test-examples-container>
-                <CardInstancePicker
-                  @placeholder='Select examples to include in the listing'
-                  @options={{this.instanceOptions}}
-                  @selected={{this.effectiveSelected}}
-                  @onChange={{this.onExampleChange}}
-                  @maxSelectedDisplay={{3}}
-                  data-test-create-listing-examples
-                />
-              </div>
-            </FieldContainer>
-          {{/if}}
+          {{#unless this.instancesSearch.isLoading}}
+            {{#if this.instanceOptions.length}}
+              <FieldContainer @label='Examples' class='field'>
+                <div class='field-contents' data-test-examples-container>
+                  <CardInstancePicker
+                    @placeholder='Select examples to include in the listing'
+                    @options={{this.instanceOptions}}
+                    @selected={{this.effectiveSelected}}
+                    @onChange={{this.onExampleChange}}
+                    @maxSelectedDisplay={{3}}
+                    data-test-create-listing-examples
+                  />
+                </div>
+              </FieldContainer>
+            {{/if}}
+          {{/unless}}
 
         </:content>
         <:footer>
@@ -249,7 +259,7 @@ export default class CreateListingModal extends Component<Signature> {
               @kind='primary'
               @size='tall'
               @loading={{this.createListing.isRunning}}
-              @disabled={{this.createListing.isRunning}}
+              @disabled={{this.isCreateDisabled}}
               {{on 'click' (perform this.createListing)}}
               {{onKeyMod 'Enter'}}
               data-test-create-listing-confirm-button

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -163,6 +163,12 @@ export class SearchResource<
     }
 
     if (query === undefined) {
+      this.#previousQueryString = undefined;
+      this.#previousQuery = undefined;
+      for (let subscription of this.subscriptions) {
+        subscription.unsubscribe();
+      }
+      this.subscriptions = [];
       return;
     }
 

--- a/packages/host/tests/integration/resources/search-test.ts
+++ b/packages/host/tests/integration/resources/search-test.ts
@@ -616,7 +616,11 @@ module(`Integration | search resource`, function (hooks) {
       named: args,
     }));
     await search.loaded;
-    assert.strictEqual(search.instances.length, 2, 'initial search returns 2 books');
+    assert.strictEqual(
+      search.instances.length,
+      2,
+      'initial search returns 2 books',
+    );
 
     // Simulate modal close: set query to undefined
     args = { ...args, query: undefined as any };
@@ -660,7 +664,11 @@ module(`Integration | search resource`, function (hooks) {
       named: args,
     }));
     await search.loaded;
-    assert.strictEqual(search.instances.length, 2, 'initial live search returns 2 books');
+    assert.strictEqual(
+      search.instances.length,
+      2,
+      'initial live search returns 2 books',
+    );
 
     // Simulate modal close: set query to undefined
     args = { ...args, query: undefined as any };

--- a/packages/host/tests/integration/resources/search-test.ts
+++ b/packages/host/tests/integration/resources/search-test.ts
@@ -623,7 +623,7 @@ module(`Integration | search resource`, function (hooks) {
     );
 
     // Simulate modal close: set query to undefined
-    args = { ...args, query: undefined as any };
+    args = { ...args, query: undefined };
     search.modify([], args);
     await settled();
 
@@ -671,7 +671,7 @@ module(`Integration | search resource`, function (hooks) {
     );
 
     // Simulate modal close: set query to undefined
-    args = { ...args, query: undefined as any };
+    args = { ...args, query: undefined };
     search.modify([], args);
     await settled();
 

--- a/packages/host/tests/integration/resources/search-test.ts
+++ b/packages/host/tests/integration/resources/search-test.ts
@@ -591,6 +591,127 @@ module(`Integration | search resource`, function (hooks) {
     );
   });
 
+  test(`setting query to undefined clears cached state and re-runs search on next query`, async function (assert) {
+    let query: Query | undefined = {
+      filter: {
+        on: {
+          module: `${testRealmURL}book`,
+          name: 'Book',
+        },
+        eq: {
+          'author.lastName': 'Abdel-Rahman',
+        },
+      },
+    };
+    let args = {
+      query,
+      realms: [testRealmURL],
+      isLive: false,
+      isAutoSaved: false,
+      storeService,
+      owner: this.owner,
+    } satisfies SearchResourceArgs['named'];
+
+    let search = getSearchResourceForTest(loaderService, () => ({
+      named: args,
+    }));
+    await search.loaded;
+    assert.strictEqual(search.instances.length, 2, 'initial search returns 2 books');
+
+    // Simulate modal close: set query to undefined
+    args = { ...args, query: undefined as any };
+    search.modify([], args);
+    await settled();
+
+    // Simulate modal reopen with same query
+    args = { ...args, query };
+    search.modify([], args);
+    await search.loaded;
+
+    assert.strictEqual(
+      search.instances.length,
+      2,
+      'search re-runs after query was set to undefined and back',
+    );
+  });
+
+  test(`setting query to undefined tears down live subscriptions`, async function (assert) {
+    let query: Query | undefined = {
+      filter: {
+        on: {
+          module: `${testRealmURL}book`,
+          name: 'Book',
+        },
+        eq: {
+          'author.lastName': 'Abdel-Rahman',
+        },
+      },
+    };
+    let args = {
+      query,
+      realms: [testRealmURL],
+      isLive: true,
+      isAutoSaved: false,
+      storeService,
+      owner: this.owner,
+    } satisfies SearchResourceArgs['named'];
+
+    let search = getSearchResourceForTest(loaderService, () => ({
+      named: args,
+    }));
+    await search.loaded;
+    assert.strictEqual(search.instances.length, 2, 'initial live search returns 2 books');
+
+    // Simulate modal close: set query to undefined
+    args = { ...args, query: undefined as any };
+    search.modify([], args);
+    await settled();
+
+    // Write a new matching card while "modal is closed"
+    await realm.write(
+      'books/4.json',
+      JSON.stringify({
+        data: {
+          type: 'card',
+          attributes: {
+            author: {
+              firstName: 'New',
+              lastName: 'Abdel-Rahman',
+            },
+            editions: 0,
+            pubDate: '2024-01-01',
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${testRealmURL}book`,
+              name: 'Book',
+            },
+          },
+        },
+      } as LooseSingleCardDocument),
+    );
+
+    await settled();
+
+    // Instances should NOT have updated since subscriptions were torn down
+    assert.strictEqual(
+      search.instances.length,
+      2,
+      'live subscription was torn down — no update while query is undefined',
+    );
+
+    // Simulate modal reopen: restore query
+    args = { ...args, query };
+    search.modify([], args);
+    await search.loaded;
+
+    assert.strictEqual(
+      search.instances.length,
+      3,
+      'fresh search on reopen picks up the new card',
+    );
+  });
+
   test(`can search for file-meta instances using SearchResource`, async function (assert) {
     let query: Query = {
       filter: {


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-10532/fix-example-missing-in-the-create-listing-modal

  - Add targetRealm and isLive options to the create listing modal's search  resource so instances are scoped to the correct realm with live updates                                                     
  - Hide examples picker while search is loading to prevent showing stale/empty state                                           
  - Fix search resource to properly clean up subscriptions and cached state when query becomes undefined (e.g. modal close), preventing subscription leaks                                                   
  - Add integration tests verifying that setting query to undefined clears cached state and tears down live subscriptions  

<img width="1108" height="360" alt="image" src="https://github.com/user-attachments/assets/39b1121a-5033-4ad5-b938-122548bb24e2" />
