### PR TITLE
Use listing-scoped concurrency group for PrCard creation on shared submission realm

### DIFF
--- a/packages/bot-runner/lib/command-runner.ts
+++ b/packages/bot-runner/lib/command-runner.ts
@@ -134,11 +134,13 @@ export class CommandRunner {
     realmURL,
     command,
     commandInput,
+    concurrencyGroup,
   }: {
     runAs: string;
     realmURL: string;
     command: string;
     commandInput: Record<string, any> | null;
+    concurrencyGroup?: string;
   }): Promise<RunCommandResponse> {
     let job = await enqueueRunCommandJob(
       {
@@ -151,6 +153,7 @@ export class CommandRunner {
       this.queuePublisher,
       this.dbAdapter,
       userInitiatedPriority,
+      concurrencyGroup ? { concurrencyGroup } : undefined,
     );
     return await job.done;
   }
@@ -191,10 +194,12 @@ export class CommandRunner {
     prResult: CreatedListingPRResult;
   }): Promise<void> {
     let submissionRealm = new URL('/submissions/', realmURL).href;
+    let listingConcurrencyGroup = `command:${submissionRealm}:listing:${prResult.branchName}`;
     let prCardResult = await this.enqueueRunCommand({
       runAs: this.submissionBotUserId,
       realmURL: submissionRealm,
       command: CREATE_PR_CARD_COMMAND,
+      concurrencyGroup: listingConcurrencyGroup,
       commandInput: {
         realm: submissionRealm,
         prNumber: prResult.prNumber,

--- a/packages/bot-runner/tests/command-runner-test.ts
+++ b/packages/bot-runner/tests/command-runner-test.ts
@@ -27,7 +27,10 @@ module('command runner', () => {
       destroy: async () => {},
     };
     let githubClient: GitHubClient = {
-      openPullRequest: async () => ({ number: 1, html_url: 'https://example/pr/1' }),
+      openPullRequest: async () => ({
+        number: 1,
+        html_url: 'https://example/pr/1',
+      }),
       createBranch: async () => ({ ref: 'refs/heads/test', sha: 'abc123' }),
       writeFileToBranch: async () => ({ commitSha: 'def456' }),
       writeFilesToBranch: async () => ({ commitSha: 'def456' }),
@@ -84,7 +87,11 @@ module('command runner', () => {
       'bot-registration-1',
     );
 
-    assert.strictEqual(publishedJobs.length, 1, 'published one run-command job');
+    assert.strictEqual(
+      publishedJobs.length,
+      1,
+      'published one run-command job',
+    );
     assert.deepEqual(
       publishedJobs[0],
       {
@@ -220,8 +227,8 @@ module('command runner', () => {
         input: {
           roomId: '!abc123:localhost',
           listingName: 'My Listing Name',
-          listingSummary: 'My listing Summary'
-        },  
+          listingSummary: 'My listing Summary',
+        },
       },
       'bot-registration-2',
     );
@@ -234,6 +241,27 @@ module('command runner', () => {
     assert.strictEqual(createdBranches.length, 1, 'creates branch');
     assert.strictEqual(branchWrites.length, 1, 'writes files to branch');
     assert.strictEqual(openedPRs.length, 1, 'opens pull request');
+
+    // Job 1 (create-submission) targets the user's realm — default concurrency group
+    assert.strictEqual(
+      (publishedJobs[0] as { concurrencyGroup: string }).concurrencyGroup,
+      'command:http://localhost:4201/test/',
+      'Job 1 (create-submission) uses default realm concurrency group',
+    );
+    // Job 2 (create-pr-card) targets the shared submission realm — listing-scoped
+    // concurrency group so different listings can run in parallel
+    assert.strictEqual(
+      (publishedJobs[1] as { concurrencyGroup: string }).concurrencyGroup,
+      `command:${SUBMISSION_REALM_URL}:listing:room-IWFiYzEyMzpsb2NhbGhvc3Q/my-listing-name`,
+      'Job 2 (create-pr-card) uses listing-scoped concurrency group',
+    );
+    // Job 3 (patch-card-instance) targets the user's realm — default concurrency group
+    assert.strictEqual(
+      (publishedJobs[2] as { concurrencyGroup: string }).concurrencyGroup,
+      'command:http://localhost:4201/test/',
+      'Job 3 (patch-card-instance) uses default realm concurrency group',
+    );
+
     assert.deepEqual(
       (publishedJobs[1] as { args: Record<string, unknown> }).args,
       {
@@ -275,7 +303,10 @@ module('command runner', () => {
       },
       'enqueues submission card patch in the user realm',
     );
-    let prBody = (openedPRs[0] as { params: Record<string, unknown> }).params.body?.toString() ?? '';
+    let prBody =
+      (
+        openedPRs[0] as { params: Record<string, unknown> }
+      ).params.body?.toString() ?? '';
     assert.true(
       prBody.includes(`[${submissionCardUrl}](${submissionCardUrl})`),
       'PR body includes submission card URL as markdown link',
@@ -477,7 +508,11 @@ module('command runner', () => {
 
     assert.strictEqual(publishedJobs.length, 1, 'enqueues run-command job');
     assert.strictEqual(createdBranches.length, 0, 'does not create branch');
-    assert.strictEqual(branchWrites.length, 0, 'does not write files to branch');
+    assert.strictEqual(
+      branchWrites.length,
+      0,
+      'does not write files to branch',
+    );
     assert.strictEqual(openedPRs.length, 0, 'does not open pull request');
   });
 });

--- a/packages/runtime-common/jobs/run-command.ts
+++ b/packages/runtime-common/jobs/run-command.ts
@@ -9,10 +9,11 @@ export async function enqueueRunCommandJob(
   queue: QueuePublisher,
   _dbAdapter: DBAdapter,
   priority: number,
+  opts?: { concurrencyGroup?: string },
 ) {
   let job = await queue.publish<RunCommandResponse>({
     jobType: 'run-command',
-    concurrencyGroup: `command:${args.realmURL}`,
+    concurrencyGroup: opts?.concurrencyGroup ?? `command:${args.realmURL}`,
     timeout: RUN_COMMAND_JOB_TIMEOUT_SEC,
     priority,
     args,


### PR DESCRIPTION
## Summary

- Fix submission queue bottleneck where all PrCard creation jobs serialized under a single concurrency group because they all target the shared submission realm
- Scope the PrCard creation job's concurrency group by listing branch name, so different listings process in parallel while same-listing operations remain serialized
- Add optional `concurrencyGroup` override to `enqueueRunCommandJob` for callers that need finer-grained control

## Problem

The job queue enforces that only one job per concurrency group runs at a time. All `run-command` jobs default to `command:${realmURL}` as their group. The submission flow has 3 sequential jobs:

1. **CreateSubmission** — targets the user's realm (already unique per user)
2. **CreatePrCard** — targets the shared `/submissions/` realm (bottleneck)
3. **PatchCardInstance** — targets the user's realm (already unique per user)

Job 2 is the problem: every user's PrCard creation shares `command:${submissionRealmURL}`, so they all serialize. With a 60s timeout per job and N concurrent submissions, the Nth user waits up to N×60s.

## Solution

Override the concurrency group **only for Job 2** using the listing's branch name:

command:${submissionRealm}:listing:${branchName}


Jobs 1 and 3 keep the default `command:${realmURL}` — they already target per-user realms so there's no cross-user contention.

The override is applied in `createAndLinkPrCard` because that's the earliest point where we have `branchName` (returned by the GitHub PR creation step). At the `enqueueRunCommandJob` level, we only have generic `RunCommandArgs` with no domain-specific context — so the caller decides when and how to override.

| Job | Realm | Concurrency group | Cross-user behavior |
|-----|-------|------------------|-------------------|
| 1 - CreateSubmission | User's realm | `command:{userRealm}` (default) | Already parallel |
| 2 - CreatePrCard | Shared submission realm | `command:{submissionRealm}:listing:{branch}` | **Was blocked, now parallel** |
| 3 - PatchCard | User's realm | `command:{userRealm}` (default) | Already parallel |

## Test plan

- [x] All 13 bot-runner tests pass
- [x] New assertions verify Job 2 uses listing-scoped group while Jobs 1 and 3 use default
- [ ] Deploy to staging and test concurrent listing submissions from different users
- [ ] Verify same-listing resubmission still serializes correctly