### PR TITLE
Cs 10504/pr card should add approved or request changed by which reviewer

### DIFF
--- a/packages/catalog-realm/pr-card/components/isolated/review-section.gts
+++ b/packages/catalog-realm/pr-card/components/isolated/review-section.gts
@@ -5,7 +5,10 @@ import type { ReviewState } from '../../utils';
 // ── Sub-components ──────────────────────────────────────────────────────
 
 interface ReviewStateBadgeSignature {
-  Args: { state: ReviewState };
+  Args: {
+    state: ReviewState;
+    reviewerName: string | null;
+  };
 }
 
 class ReviewStateBadge extends GlimmerComponent<ReviewStateBadgeSignature> {
@@ -34,7 +37,9 @@ class ReviewStateBadge extends GlimmerComponent<ReviewStateBadgeSignature> {
 
   <template>
     {{#if this.hasState}}
-      <span class='review-state-badge {{this.stateClass}}'>{{this.label}}</span>
+      <span class='review-state-badge {{this.stateClass}}'>{{this.label}}{{#if
+          @reviewerName
+        }} by {{@reviewerName}}{{/if}}</span>
     {{/if}}
 
     <style scoped>
@@ -88,7 +93,7 @@ class ReviewStateBadge extends GlimmerComponent<ReviewStateBadgeSignature> {
 interface ReviewSectionSignature {
   Args: {
     reviewState: ReviewState;
-    reviewerName: string;
+    reviewerName: string | null;
     comment: string;
     reviewUrl: string | undefined;
     hasReview: boolean;
@@ -113,7 +118,10 @@ export class ReviewSection extends GlimmerComponent<ReviewSectionSignature> {
     <div class='review-section'>
       <div class='review-heading-row'>
         <h2 class='section-heading'>Reviews</h2>
-        <ReviewStateBadge @state={{@reviewState}} />
+        <ReviewStateBadge
+          @state={{@reviewState}}
+          @reviewerName={{@reviewerName}}
+        />
       </div>
 
       {{#if @hasReview}}
@@ -167,7 +175,6 @@ export class ReviewSection extends GlimmerComponent<ReviewSectionSignature> {
       .review-heading-row {
         display: flex;
         align-items: center;
-        justify-content: space-between;
         gap: var(--boxel-sp-xs);
       }
       .review-list {

--- a/packages/catalog-realm/pr-card/components/isolated/review-section.gts
+++ b/packages/catalog-realm/pr-card/components/isolated/review-section.gts
@@ -175,6 +175,7 @@ export class ReviewSection extends GlimmerComponent<ReviewSectionSignature> {
       .review-heading-row {
         display: flex;
         align-items: center;
+        justify-content: space-between;
         gap: var(--boxel-sp-xs);
       }
       .review-list {

--- a/packages/catalog-realm/pr-card/pr-card.gts
+++ b/packages/catalog-realm/pr-card/pr-card.gts
@@ -168,7 +168,7 @@ class IsolatedTemplate extends Component<typeof PrCard> {
     return computeLatestReviewState(this.latestReviewByReviewer);
   }
 
-  get latestPrReviewCommentEventInstance() {
+  get latestPrReviewEventInstance() {
     let state = this.latestReviewState;
     if (state === 'changes_requested') {
       return findLatestChangesRequestedEvent(this.latestReviewByReviewer);
@@ -181,21 +181,21 @@ class IsolatedTemplate extends Component<typeof PrCard> {
 
   get latestReviewComment() {
     let comment =
-      this.latestPrReviewCommentEventInstance?.payload?.review?.body?.trim();
+      this.latestPrReviewEventInstance?.payload?.review?.body?.trim();
     return comment || '-';
   }
 
   get latestReviewCommentUrl() {
-    return this.latestPrReviewCommentEventInstance?.payload?.review?.html_url;
+    return this.latestPrReviewEventInstance?.payload?.review?.html_url;
   }
 
   get hasReview() {
-    return !!this.latestPrReviewCommentEventInstance;
+    return !!this.latestPrReviewEventInstance;
   }
 
   get latestReviewerName() {
     return (
-      this.latestPrReviewCommentEventInstance?.payload?.review?.user?.login ??
+      this.latestPrReviewEventInstance?.payload?.review?.user?.login ??
       null
     );
   }

--- a/packages/catalog-realm/pr-card/pr-card.gts
+++ b/packages/catalog-realm/pr-card/pr-card.gts
@@ -169,23 +169,23 @@ class IsolatedTemplate extends Component<typeof PrCard> {
   }
 
   get latestPrReviewCommentEventInstance() {
-    return findLatestChangesRequestedEvent(this.latestReviewByReviewer);
+    let state = this.latestReviewState;
+    if (state === 'changes_requested') {
+      return findLatestChangesRequestedEvent(this.latestReviewByReviewer);
+    }
+    if (state === 'approved') {
+      return findLatestApprovedEvent(this.latestReviewByReviewer);
+    }
+    return null;
   }
 
-  get latestChangesRequestedReviewerName() {
-    return (
-      this.latestPrReviewCommentEventInstance?.payload?.review?.user?.login ??
-      'Unknown reviewer'
-    );
-  }
-
-  get latestChangesRequestedComment() {
+  get latestReviewComment() {
     let comment =
       this.latestPrReviewCommentEventInstance?.payload?.review?.body?.trim();
     return comment || '-';
   }
 
-  get latestChangesRequestedReviewUrl() {
+  get latestReviewCommentUrl() {
     return this.latestPrReviewCommentEventInstance?.payload?.review?.html_url;
   }
 
@@ -194,14 +194,10 @@ class IsolatedTemplate extends Component<typeof PrCard> {
   }
 
   get latestReviewerName() {
-    let state = this.latestReviewState;
-    let event: any = null;
-    if (state === 'changes_requested') {
-      event = findLatestChangesRequestedEvent(this.latestReviewByReviewer);
-    } else if (state === 'approved') {
-      event = findLatestApprovedEvent(this.latestReviewByReviewer);
-    }
-    return event?.payload?.review?.user?.login ?? null;
+    return (
+      this.latestPrReviewCommentEventInstance?.payload?.review?.user?.login ??
+      null
+    );
   }
 
   // ── Mergeability ──
@@ -269,8 +265,8 @@ class IsolatedTemplate extends Component<typeof PrCard> {
           <ReviewSection
             @reviewState={{this.latestReviewState}}
             @reviewerName={{this.latestReviewerName}}
-            @comment={{this.latestChangesRequestedComment}}
-            @reviewUrl={{this.latestChangesRequestedReviewUrl}}
+            @comment={{this.latestReviewComment}}
+            @reviewUrl={{this.latestReviewCommentUrl}}
             @hasReview={{this.hasReview}}
           />
         </section>

--- a/packages/catalog-realm/pr-card/pr-card.gts
+++ b/packages/catalog-realm/pr-card/pr-card.gts
@@ -30,6 +30,7 @@ import {
   buildLatestReviewByReviewer,
   computeLatestReviewState,
   findLatestChangesRequestedEvent,
+  findLatestApprovedEvent,
   buildGithubEventCardRef,
   searchEventQuery,
   buildRealmHrefs,
@@ -192,6 +193,17 @@ class IsolatedTemplate extends Component<typeof PrCard> {
     return !!this.latestPrReviewCommentEventInstance;
   }
 
+  get latestReviewerName() {
+    let state = this.latestReviewState;
+    let event: any = null;
+    if (state === 'changes_requested') {
+      event = findLatestChangesRequestedEvent(this.latestReviewByReviewer);
+    } else if (state === 'approved') {
+      event = findLatestApprovedEvent(this.latestReviewByReviewer);
+    }
+    return event?.payload?.review?.user?.login ?? null;
+  }
+
   // ── Mergeability ──
   get isClosed() {
     let label = this.latestPrActionLabel;
@@ -256,7 +268,7 @@ class IsolatedTemplate extends Component<typeof PrCard> {
           <hr class='status-divider' />
           <ReviewSection
             @reviewState={{this.latestReviewState}}
-            @reviewerName={{this.latestChangesRequestedReviewerName}}
+            @reviewerName={{this.latestReviewerName}}
             @comment={{this.latestChangesRequestedComment}}
             @reviewUrl={{this.latestChangesRequestedReviewUrl}}
             @hasReview={{this.hasReview}}

--- a/packages/catalog-realm/pr-card/utils.ts
+++ b/packages/catalog-realm/pr-card/utils.ts
@@ -21,10 +21,7 @@ export type CiGroup = {
   items: CiItem[];
 };
 
-export type ReviewState =
-  | 'changes_requested'
-  | 'approved'
-  | 'unknown';
+export type ReviewState = 'changes_requested' | 'approved' | 'unknown';
 
 // ── PR State Helpers ─────────────────────────────────────────────────────
 
@@ -299,13 +296,25 @@ export function computeLatestReviewState(
 export function findLatestChangesRequestedEvent(
   latestReviewByReviewer: Map<string, any>,
 ): any | null {
-  let activeChangesRequestedEvents = [...latestReviewByReviewer.values()].filter(
+  let activeChangesRequestedEvents = [
+    ...latestReviewByReviewer.values(),
+  ].filter(
     (event: any) =>
       normalizeReviewState(event?.payload?.review?.state) ===
         'changes_requested' &&
       (event?.payload?.review?.body ?? '').trim().length > 0,
   );
   return activeChangesRequestedEvents[0] ?? null;
+}
+
+export function findLatestApprovedEvent(
+  latestReviewByReviewer: Map<string, any>,
+): any | null {
+  let approvedEvents = [...latestReviewByReviewer.values()].filter(
+    (event: any) =>
+      normalizeReviewState(event?.payload?.review?.state) === 'approved',
+  );
+  return approvedEvents[0] ?? null;
 }
 
 // ── Query Builders ───────────────────────────────────────────────────────

--- a/packages/catalog-realm/pr-card/utils.ts
+++ b/packages/catalog-realm/pr-card/utils.ts
@@ -301,8 +301,7 @@ export function findLatestChangesRequestedEvent(
   ].filter(
     (event: any) =>
       normalizeReviewState(event?.payload?.review?.state) ===
-        'changes_requested' &&
-      (event?.payload?.review?.body ?? '').trim().length > 0,
+        'changes_requested',
   );
   return activeChangesRequestedEvents[0] ?? null;
 }

--- a/packages/catalog-realm/pr-card/utils.ts
+++ b/packages/catalog-realm/pr-card/utils.ts
@@ -296,24 +296,24 @@ export function computeLatestReviewState(
 export function findLatestChangesRequestedEvent(
   latestReviewByReviewer: Map<string, any>,
 ): any | null {
-  let activeChangesRequestedEvents = [
-    ...latestReviewByReviewer.values(),
-  ].filter(
-    (event: any) =>
-      normalizeReviewState(event?.payload?.review?.state) ===
-        'changes_requested',
+  return (
+    [...latestReviewByReviewer.values()].find(
+      (event: any) =>
+        normalizeReviewState(event?.payload?.review?.state) ===
+          'changes_requested',
+    ) ?? null
   );
-  return activeChangesRequestedEvents[0] ?? null;
 }
 
 export function findLatestApprovedEvent(
   latestReviewByReviewer: Map<string, any>,
 ): any | null {
-  let approvedEvents = [...latestReviewByReviewer.values()].filter(
-    (event: any) =>
-      normalizeReviewState(event?.payload?.review?.state) === 'approved',
+  return (
+    [...latestReviewByReviewer.values()].find(
+      (event: any) =>
+        normalizeReviewState(event?.payload?.review?.state) === 'approved',
+    ) ?? null
   );
-  return approvedEvents[0] ?? null;
 }
 
 // ── Query Builders ───────────────────────────────────────────────────────


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-10504/pr-card-should-add-approved-or-request-changed-by-which-reviewer

1.  Show reviewer name and comment for both approved and changes_requested reviews                                                                                                                                                                                                                                                
2.  Display "by {reviewer}" on the review state badge for PR cards.

<img width="832" height="392" alt="image" src="https://github.com/user-attachments/assets/403dda64-73a6-4729-8fe8-a6c15e0f739e" />
