### PR TITLE
Do not show loading screen on hosted site

### DIFF
--- a/packages/host/app/components/host-mode/card.gts
+++ b/packages/host/app/components/host-mode/card.gts
@@ -3,6 +3,7 @@ import Component from '@glimmer/component';
 import { cached } from '@glimmer/tracking';
 
 import { BoxelButton, CardContainer } from '@cardstack/boxel-ui/components';
+import { bool } from '@cardstack/boxel-ui/helpers';
 
 import CardRenderer from '@cardstack/host/components/card-renderer';
 import CardError from '@cardstack/host/components/operator-mode/card-error';
@@ -57,6 +58,7 @@ export default class HostModeCard extends Component<Signature> {
     <CardContainer
       class='host-mode-card {{if @isPrimary "is-primary"}}'
       displayBoundaries={{@displayBoundaries}}
+      data-test-host-mode-card-loaded={{bool this.card}}
       ...attributes
     >
       {{#if this.cardError}}

--- a/packages/host/app/index.html
+++ b/packages/host/app/index.html
@@ -1,46 +1,54 @@
 <!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-<head>
-  <meta charset="utf-8" />
-  <meta name="description" content="" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+    {{content-for "head"}}
 
-  {{content-for "head"}}
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
+    <link
+      integrity=""
+      rel="stylesheet"
+      href="{{rootURL}}assets/@cardstack/host.css"
+    />
+    <style>
+      /* Allow prerendered cards to scroll while card-specific CSS loads */
+      #boxel-isolated-start + .boxel-card-container {
+        overflow-y: auto;
+      }
+    </style>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=IBM+Plex+Serif:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap"
+      rel="stylesheet"
+    />
 
-  <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
-  <link integrity="" rel="stylesheet" href="{{rootURL}}assets/@cardstack/host.css" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=IBM+Plex+Serif:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap"
-    rel="stylesheet" />
+    {{content-for "head-footer"}}
 
-  {{content-for "head-footer"}}
+    <meta data-boxel-head-start />
+    <title>Boxel</title>
+    <meta data-boxel-head-end />
+  </head>
 
-  <meta data-boxel-head-start />
-  <title>Boxel</title>
-  <meta data-boxel-head-end />
+  <body>
+    <script type="x/boundary" id="boxel-isolated-start"></script>
+    <script type="x/boundary" id="boxel-isolated-end"></script>
 
-</head>
-
-<body>
-  <script type="x/boundary" id="boxel-isolated-start"></script>
-  <script type="x/boundary" id="boxel-isolated-end"></script>
-
-  <!-- in case embercli's hooks insn't run,
+    <!-- in case embercli's hooks insn't run,
          we embed the following div manually -->
-  <div id="ember-basic-dropdown-wormhole"></div>
-  {{content-for "body"}}
+    <div id="ember-basic-dropdown-wormhole"></div>
+    {{content-for "body"}}
 
-  <script type="module">
-    import * as ContentTag from '{{rootURL}}assets/content-tag/standalone.js';
-    globalThis.ContentTagGlobal = ContentTag;
-  </script>
-  <script src="{{rootURL}}assets/vendor.js"></script>
-  <script src="{{rootURL}}assets/@cardstack/host.js"></script>
+    <script type="module">
+      import * as ContentTag from '{{rootURL}}assets/content-tag/standalone.js';
+      globalThis.ContentTagGlobal = ContentTag;
+    </script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/@cardstack/host.js"></script>
 
-  {{content-for "body-footer"}}
-</body>
-
+    {{content-for "body-footer"}}
+  </body>
 </html>

--- a/packages/host/app/routes/index.gts
+++ b/packages/host/app/routes/index.gts
@@ -65,7 +65,7 @@ export default class Card extends Route {
       this.initialLoading = false;
     });
 
-    return this.initialLoading;
+    return this.initialLoading && !this.hostModeService.isActive;
   }
 
   // WARNING! Make sure we are _very_ careful with our async in this model. This

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -282,16 +282,19 @@ module('Acceptance | host mode tests', function (hooks) {
     let store = getService('store') as StoreService;
     let originalGet = store.get.bind(store);
     let gate = new Deferred<void>();
+    let pending = new Deferred<void>();
     let targetId = `${testHostModeRealmURL}Pet/non-existent.json`;
     store.get = (async (...args: Parameters<StoreService['get']>) => {
       let [id] = args;
       if (id === targetId) {
+        pending.fulfill();
         await gate.promise;
       }
       return (originalGet as StoreService['get'])(...args);
     }) as StoreService['get'];
 
     let visitPromise = visit('/test/Pet/non-existent.json');
+    await pending.promise; // store.get is now blocked — loading state is active
     assert
       .dom('[data-test-host-loading]')
       .doesNotExist('Loading screen is never shown on host mode');

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -292,8 +292,9 @@ module('Acceptance | host mode tests', function (hooks) {
     }) as StoreService['get'];
 
     let visitPromise = visit('/test/Pet/non-existent.json');
-    await waitFor('[data-test-host-loading]');
-    assert.dom('[data-test-host-loading]').exists();
+    assert
+      .dom('[data-test-host-loading]')
+      .doesNotExist('Loading screen is never shown on host mode');
     gate.fulfill();
 
     await visitPromise;

--- a/packages/matrix/tests/host-mode.spec.ts
+++ b/packages/matrix/tests/host-mode.spec.ts
@@ -257,7 +257,7 @@ test.describe('Host mode', () => {
   }) => {
     await page.goto(publishedWhitePaperCardURL);
     await page.locator('[data-test-white-paper]').waitFor();
-    await page.locator('[data-test-host-mode-card-loaded').waitFor();
+    await page.locator('[data-test-host-mode-card-loaded]').waitFor();
     await page.emulateMedia({ media: 'print' });
     let pdf = await page.pdf({ format: 'Letter', printBackground: true });
     let pageCount =

--- a/packages/matrix/tests/host-mode.spec.ts
+++ b/packages/matrix/tests/host-mode.spec.ts
@@ -257,11 +257,6 @@ test.describe('Host mode', () => {
   }) => {
     await page.goto(publishedWhitePaperCardURL);
     await page.locator('[data-test-white-paper]').waitFor();
-    await waitUntil(
-      async () =>
-        (await page.locator('[data-test-host-loading]').count()) === 0,
-    );
-
     await page.emulateMedia({ media: 'print' });
     let pdf = await page.pdf({ format: 'Letter', printBackground: true });
     let pageCount =

--- a/packages/matrix/tests/host-mode.spec.ts
+++ b/packages/matrix/tests/host-mode.spec.ts
@@ -257,6 +257,7 @@ test.describe('Host mode', () => {
   }) => {
     await page.goto(publishedWhitePaperCardURL);
     await page.locator('[data-test-white-paper]').waitFor();
+    await page.locator('[data-test-host-mode-card-loaded').waitFor();
     await page.emulateMedia({ media: 'print' });
     let pdf = await page.pdf({ format: 'Letter', printBackground: true });
     let pageCount =


### PR DESCRIPTION
- Do not show `Loading...` screen on hosted card
- It will remain in operator-mode as usual
- Fix for prerendered card scroll before css loads