### PR TITLE
Avoid loading full card modules during AI panel auto-attachment

### DIFF
--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -5,9 +5,8 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import { Tooltip, Pill, RealmIcon } from '@cardstack/boxel-ui/components';
+import { Tooltip, Pill } from '@cardstack/boxel-ui/components';
 import { and, gt, not } from '@cardstack/boxel-ui/helpers';
-import { IconX } from '@cardstack/boxel-ui/icons';
 
 import type { CardErrorJSONAPI } from '@cardstack/runtime-common';
 import {
@@ -32,7 +31,6 @@ import type {
 import { urlForRealmLookup } from '@cardstack/host/lib/utils';
 
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-import type RealmService from '@cardstack/host/services/realm';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type { FileDef } from 'https://cardstack.com/base/file-api';
@@ -64,7 +62,6 @@ export default class AttachedItems extends Component<Signature> {
   @tracked areAllItemsDisplayed = false;
 
   @service declare private operatorModeStateService: OperatorModeStateService;
-  @service declare private realm: RealmService;
 
   private get allItemsCount() {
     let autoCount = this.args.autoAttachedPrerenderedCards?.length ?? 0;
@@ -101,7 +98,6 @@ export default class AttachedItems extends Component<Signature> {
   };
 
   private getPrerenderedCardTitle = (card: PrerenderedCard): string => {
-    // Extract text content from atom HTML. The atom template renders the card title.
     if (!card.data.html) {
       return card.url.split('/').pop() ?? 'Card';
     }
@@ -154,14 +150,12 @@ export default class AttachedItems extends Component<Signature> {
   private getModalityWarning = (file: FileDef): string | undefined => {
     let modality = requiredModality(file.contentType);
     if (modality) {
-      // Multimodal type — warn only if model doesn't support it
       let modalities = this.args.inputModalities;
       if (modalities && !modalities.includes(modality)) {
         return `Model does not support ${modalityLabel(modality)}. Only metadata will be sent.`;
       }
       return undefined;
     }
-    // Non-multimodal, non-text files only get metadata sent
     if (!isTextBasedContentType(file.contentType)) {
       return 'File type not supported. Will send file metadata only.';
     }
@@ -171,41 +165,21 @@ export default class AttachedItems extends Component<Signature> {
   <template>
     <div class='attached-items' ...attributes>
       {{#if @isLoaded}}
-        {{! Auto-attached cards rendered from prerendered HTML (no full card module loading) }}
+        {{! Auto-attached cards use @suppressCardLoad to avoid loading full card
+            modules. The title comes from prerendered atom HTML. }}
         {{#each this.allItemsToDisplay.autoCards as |card|}}
           <Tooltip @placement='top'>
             <:trigger>
-              <Pill
-                @kind='button'
-                class='card-pill border-dashed'
-                data-test-attached-card={{card.url}}
+              <CardPill
+                @cardId={{card.url}}
+                @displayTitle={{this.getPrerenderedCardTitle card}}
+                @suppressCardLoad={{true}}
+                @borderType='dashed'
+                @urlForRealmLookup={{card.data.realmUrl}}
+                @onClick={{fn this.handleChooseCard card.url}}
+                @onRemove={{fn this.handleRemoveCard card.url}}
                 data-test-autoattached-card={{card.url}}
-                {{on 'click' (fn this.handleChooseCard card.url)}}
-              >
-                <:iconLeft>
-                  <RealmIcon
-                    @realmInfo={{this.realm.info card.data.realmUrl}}
-                  />
-                </:iconLeft>
-                <:default>
-                  <div
-                    class='card-content'
-                    title={{this.getPrerenderedCardTitle card}}
-                  >
-                    {{this.getPrerenderedCardTitle card}}
-                  </div>
-                </:default>
-                <:iconRight>
-                  <button
-                    class='remove-button'
-                    type='button'
-                    {{on 'click' (fn this.handleRemoveCard card.url)}}
-                    data-test-remove-card-btn
-                  >
-                    <IconX width='10' height='10' />
-                  </button>
-                </:iconRight>
-              </Pill>
+              />
             </:trigger>
 
             <:content>
@@ -289,36 +263,6 @@ export default class AttachedItems extends Component<Signature> {
         display: flex;
         flex-wrap: wrap;
         gap: var(--boxel-sp-xxxs);
-      }
-      .card-pill {
-        --pill-gap: var(--boxel-sp-xxxs);
-        --pill-icon-size: 18px;
-        --boxel-realm-icon-size: var(--pill-icon-size);
-        border: 1px solid var(--boxel-400);
-        height: var(--pill-height, 1.875rem);
-        overflow: hidden;
-      }
-      .border-dashed {
-        border-style: dashed;
-      }
-      .card-content {
-        max-width: 100px;
-        max-height: 100%;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-      .remove-button {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        background: none;
-        border: none;
-        padding: 0;
-        cursor: pointer;
-        width: var(--boxel-icon-sm);
-        height: var(--boxel-icon-sm);
-        border-radius: var(--boxel-border-radius-xs);
       }
     </style>
   </template>

--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -38,6 +38,7 @@ import type { FileDef } from 'https://cardstack.com/base/file-api';
 import type { TrackedSet } from 'tracked-built-ins';
 
 const MAX_ITEMS_TO_DISPLAY = 4;
+const domParser = new DOMParser();
 
 interface Signature {
   Element: HTMLDivElement;
@@ -101,8 +102,7 @@ export default class AttachedItems extends Component<Signature> {
     if (!card.data.html) {
       return card.url.split('/').pop() ?? 'Card';
     }
-    let parser = new DOMParser();
-    let doc = parser.parseFromString(card.data.html, 'text/html');
+    let doc = domParser.parseFromString(card.data.html, 'text/html');
     return doc.body.textContent?.trim() || card.url.split('/').pop() || 'Card';
   };
 

--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -5,8 +5,9 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import { Tooltip, Pill } from '@cardstack/boxel-ui/components';
+import { Tooltip, Pill, RealmIcon } from '@cardstack/boxel-ui/components';
 import { and, gt, not } from '@cardstack/boxel-ui/helpers';
+import { IconX } from '@cardstack/boxel-ui/icons';
 
 import type { CardErrorJSONAPI } from '@cardstack/runtime-common';
 import {
@@ -23,6 +24,7 @@ import {
 
 import CardPill from '@cardstack/host/components/card-pill';
 import FilePill from '@cardstack/host/components/file-pill';
+import type { PrerenderedCard } from '@cardstack/host/components/prerendered-card-search';
 import type {
   FileUploadState,
   FileUploadStatus,
@@ -30,6 +32,7 @@ import type {
 import { urlForRealmLookup } from '@cardstack/host/lib/utils';
 
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+import type RealmService from '@cardstack/host/services/realm';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type { FileDef } from 'https://cardstack.com/base/file-api';
@@ -43,6 +46,7 @@ interface Signature {
   Args: {
     items: (CardDef | FileDef | CardErrorJSONAPI)[];
     autoAttachedCardIds?: TrackedSet<string>;
+    autoAttachedPrerenderedCards?: PrerenderedCard[];
     autoAttachedFiles?: FileDef[];
     removeCard: (cardId: string) => void;
     removeFile: (file: FileDef) => void;
@@ -60,19 +64,32 @@ export default class AttachedItems extends Component<Signature> {
   @tracked areAllItemsDisplayed = false;
 
   @service declare private operatorModeStateService: OperatorModeStateService;
+  @service declare private realm: RealmService;
 
-  get itemsToDisplay() {
-    return this.areAllItemsDisplayed
-      ? this.args.items
-      : this.args.items.slice(0, MAX_ITEMS_TO_DISPLAY);
+  private get allItemsCount() {
+    let autoCount = this.args.autoAttachedPrerenderedCards?.length ?? 0;
+    return this.args.items.length + autoCount;
+  }
+
+  private get allItemsToDisplay() {
+    let autoCards = this.args.autoAttachedPrerenderedCards ?? [];
+    let items = this.args.items;
+    let total = autoCards.length + items.length;
+
+    if (this.areAllItemsDisplayed || total <= MAX_ITEMS_TO_DISPLAY) {
+      return { autoCards, items };
+    }
+
+    // Show auto-attached cards first, then fill remaining with items
+    let remaining = MAX_ITEMS_TO_DISPLAY;
+    let displayedAutoCards = autoCards.slice(0, remaining);
+    remaining -= displayedAutoCards.length;
+    let displayedItems = remaining > 0 ? items.slice(0, remaining) : [];
+    return { autoCards: displayedAutoCards, items: displayedItems };
   }
 
   private isCard = (item: CardDef | FileDef): item is CardDef => {
     return isCardInstance(item);
-  };
-
-  private isAutoAttachedCard = (cardId: string): boolean => {
-    return this.args.autoAttachedCardIds?.has(cardId) ?? false;
   };
 
   private isAutoAttachedFile = (file: FileDef): boolean => {
@@ -81,6 +98,16 @@ export default class AttachedItems extends Component<Signature> {
         (autoFile) => autoFile.sourceUrl === file.sourceUrl,
       ) ?? false
     );
+  };
+
+  private getPrerenderedCardTitle = (card: PrerenderedCard): string => {
+    // Extract text content from atom HTML. The atom template renders the card title.
+    if (!card.data.html) {
+      return card.url.split('/').pop() ?? 'Card';
+    }
+    let parser = new DOMParser();
+    let doc = parser.parseFromString(card.data.html, 'text/html');
+    return doc.body.textContent?.trim() || card.url.split('/').pop() || 'Card';
   };
 
   @action
@@ -144,69 +171,70 @@ export default class AttachedItems extends Component<Signature> {
   <template>
     <div class='attached-items' ...attributes>
       {{#if @isLoaded}}
-        {{#each this.itemsToDisplay as |item|}}
+        {{! Auto-attached cards rendered from prerendered HTML (no full card module loading) }}
+        {{#each this.allItemsToDisplay.autoCards as |card|}}
+          <Tooltip @placement='top'>
+            <:trigger>
+              <Pill
+                @kind='button'
+                class='card-pill border-dashed'
+                data-test-attached-card={{card.url}}
+                data-test-autoattached-card={{card.url}}
+                {{on 'click' (fn this.handleChooseCard card.url)}}
+              >
+                <:iconLeft>
+                  <RealmIcon
+                    @realmInfo={{this.realm.info card.data.realmUrl}}
+                  />
+                </:iconLeft>
+                <:default>
+                  <div
+                    class='card-content'
+                    title={{this.getPrerenderedCardTitle card}}
+                  >
+                    {{this.getPrerenderedCardTitle card}}
+                  </div>
+                </:default>
+                <:iconRight>
+                  <button
+                    class='remove-button'
+                    type='button'
+                    {{on 'click' (fn this.handleRemoveCard card.url)}}
+                    data-test-remove-card-btn
+                  >
+                    <IconX width='10' height='10' />
+                  </button>
+                </:iconRight>
+              </Pill>
+            </:trigger>
+
+            <:content>
+              {{#if @autoAttachedCardTooltipMessage}}
+                {{@autoAttachedCardTooltipMessage}}
+              {{else}}
+                Topmost card is shared automatically
+              {{/if}}
+            </:content>
+          </Tooltip>
+        {{/each}}
+        {{! Manually attached cards and files (loaded via getCardCollection) }}
+        {{#each this.allItemsToDisplay.items as |item|}}
           {{#if (isCardErrorJSONAPI item)}}
             {{#if item.id}}
-              {{#if (this.isAutoAttachedCard item.id)}}
-                <Tooltip @placement='top'>
-                  <:trigger>
-                    <CardPill
-                      @cardId={{item.id}}
-                      @borderType='dashed'
-                      @onClick={{fn this.handleChooseCard item.id}}
-                      @onRemove={{fn this.handleRemoveCard item.id}}
-                      @urlForRealmLookup={{this.getCardErrorRealm item}}
-                      data-test-autoattached-card={{item.id}}
-                    />
-                  </:trigger>
-
-                  <:content>
-                    {{#if @autoAttachedCardTooltipMessage}}
-                      {{@autoAttachedCardTooltipMessage}}
-                    {{else if (this.isAutoAttachedCard item.id)}}
-                      Topmost card is shared automatically
-                    {{/if}}
-                  </:content>
-                </Tooltip>
-              {{else}}
-                <CardPill
-                  @cardId={{item.id}}
-                  @borderType='solid'
-                  @onRemove={{fn this.handleRemoveCard item.id}}
-                  @urlForRealmLookup={{this.getCardErrorRealm item}}
-                />
-              {{/if}}
-            {{/if}}
-          {{else if (this.isCard item)}}
-            {{#if (this.isAutoAttachedCard item.id)}}
-              <Tooltip @placement='top'>
-                <:trigger>
-                  <CardPill
-                    @cardId={{idFor item}}
-                    @borderType='dashed'
-                    @onClick={{fn this.handleChooseCard (idFor item)}}
-                    @onRemove={{fn this.handleRemoveCard (idFor item)}}
-                    @urlForRealmLookup={{urlForRealmLookup item}}
-                    data-test-autoattached-card={{idFor item}}
-                  />
-                </:trigger>
-
-                <:content>
-                  {{#if @autoAttachedCardTooltipMessage}}
-                    {{@autoAttachedCardTooltipMessage}}
-                  {{else if (this.isAutoAttachedCard item.id)}}
-                    Topmost card is shared automatically
-                  {{/if}}
-                </:content>
-              </Tooltip>
-            {{else}}
               <CardPill
-                @cardId={{idFor item}}
+                @cardId={{item.id}}
                 @borderType='solid'
-                @onRemove={{fn this.handleRemoveCard (idFor item)}}
-                @urlForRealmLookup={{urlForRealmLookup item}}
+                @onRemove={{fn this.handleRemoveCard item.id}}
+                @urlForRealmLookup={{this.getCardErrorRealm item}}
               />
             {{/if}}
+          {{else if (this.isCard item)}}
+            <CardPill
+              @cardId={{idFor item}}
+              @borderType='solid'
+              @onRemove={{fn this.handleRemoveCard (idFor item)}}
+              @urlForRealmLookup={{urlForRealmLookup item}}
+            />
           {{else}}
             {{#if (this.isAutoAttachedFile item)}}
               <Tooltip @placement='top'>
@@ -240,7 +268,7 @@ export default class AttachedItems extends Component<Signature> {
         {{/each}}
         {{#if
           (and
-            (gt @items.length MAX_ITEMS_TO_DISPLAY)
+            (gt this.allItemsCount MAX_ITEMS_TO_DISPLAY)
             (not this.areAllItemsDisplayed)
           )
         }}
@@ -249,7 +277,7 @@ export default class AttachedItems extends Component<Signature> {
             {{on 'click' this.toggleViewAllAttachedCards}}
             data-test-view-all
           >
-            View All ({{@items.length}})
+            View All ({{this.allItemsCount}})
           </Pill>
         {{/if}}
       {{/if}}
@@ -261,6 +289,36 @@ export default class AttachedItems extends Component<Signature> {
         display: flex;
         flex-wrap: wrap;
         gap: var(--boxel-sp-xxxs);
+      }
+      .card-pill {
+        --pill-gap: var(--boxel-sp-xxxs);
+        --pill-icon-size: 18px;
+        --boxel-realm-icon-size: var(--pill-icon-size);
+        border: 1px solid var(--boxel-400);
+        height: var(--pill-height, 1.875rem);
+        overflow: hidden;
+      }
+      .border-dashed {
+        border-style: dashed;
+      }
+      .card-content {
+        max-width: 100px;
+        max-height: 100%;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .remove-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        width: var(--boxel-icon-sm);
+        height: var(--boxel-icon-sm);
+        border-radius: var(--boxel-border-radius-xs);
       }
     </style>
   </template>

--- a/packages/host/app/components/ai-assistant/attachment-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/index.gts
@@ -127,7 +127,7 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
         query: cardUrls.length > 0 ? {} : undefined,
         format: cardUrls.length > 0 ? ('atom' as Format) : undefined,
         realms,
-        cardUrls,
+        cardUrls: resolvedUrls,
         isLive: false,
       };
     },

--- a/packages/host/app/components/ai-assistant/attachment-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/index.gts
@@ -112,10 +112,18 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
     getOwner(this)!,
     () => {
       let cardUrls = this.autoAttachedCardIdsArray;
+      // Only search realms that contain the requested cards to avoid
+      // unnecessary cross-realm federation queries.
+      let realms =
+        cardUrls.length > 0
+          ? this.realmServer.availableRealmURLs.filter((realmUrl) =>
+              cardUrls.some((cardUrl) => cardUrl.startsWith(realmUrl)),
+            )
+          : undefined;
       return {
         query: cardUrls.length > 0 ? {} : undefined,
         format: cardUrls.length > 0 ? ('atom' as Format) : undefined,
-        realms: this.realmServer.availableRealmURLs,
+        realms,
         cardUrls,
         isLive: false,
       };

--- a/packages/host/app/components/ai-assistant/attachment-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/index.gts
@@ -7,6 +7,7 @@ import { consume } from 'ember-provide-consume-context';
 
 import {
   GetCardCollectionContextName,
+  cardIdToURL,
   type getCardCollection,
   type Format,
 } from '@cardstack/runtime-common';
@@ -113,11 +114,13 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
     () => {
       let cardUrls = this.autoAttachedCardIdsArray;
       // Only search realms that contain the requested cards to avoid
-      // unnecessary cross-realm federation queries.
+      // unnecessary cross-realm federation queries. Resolve card IDs
+      // first since they may use prefix form (e.g. @cardstack/catalog/foo).
+      let resolvedUrls = cardUrls.map((id) => cardIdToURL(id).href);
       let realms =
         cardUrls.length > 0
           ? this.realmServer.availableRealmURLs.filter((realmUrl) =>
-              cardUrls.some((cardUrl) => cardUrl.startsWith(realmUrl)),
+              resolvedUrls.some((url) => url.startsWith(realmUrl)),
             )
           : undefined;
       return {

--- a/packages/host/app/components/ai-assistant/attachment-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/index.gts
@@ -1,3 +1,5 @@
+import { getOwner } from '@ember/owner';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { cached } from '@glimmer/tracking';
 
@@ -6,9 +8,13 @@ import { consume } from 'ember-provide-consume-context';
 import {
   GetCardCollectionContextName,
   type getCardCollection,
+  type Format,
 } from '@cardstack/runtime-common';
 
 import type { FileUploadState } from '@cardstack/host/lib/file-upload-state';
+import { getPrerenderedSearch } from '@cardstack/host/resources/prerendered-search';
+
+import type RealmServerService from '@cardstack/host/services/realm-server';
 
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 
@@ -41,6 +47,7 @@ interface Signature {
         typeof AttachedItems,
         | 'items'
         | 'autoAttachedCardIds'
+        | 'autoAttachedPrerenderedCards'
         | 'autoAttachedFiles'
         | 'removeCard'
         | 'removeFile'
@@ -68,6 +75,7 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
         isLoaded=this.isLoaded
         items=this.items
         autoAttachedCardIds=@autoAttachedCardIds
+        autoAttachedPrerenderedCards=this.autoAttachedPrerenderedCards
         autoAttachedFiles=@autoAttachedFiles
         removeCard=@removeCard
         removeFile=@removeFile
@@ -90,9 +98,38 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
   @consume(GetCardCollectionContextName)
   declare private getCardCollection: getCardCollection;
 
+  @service declare private realmServer: RealmServerService;
+
+  // Only load manually attached cards through the store (getCardCollection)
   @cached
   private get cardCollection(): ReturnType<getCardCollection> {
-    return this.getCardCollection(this, () => this.cardIds);
+    return this.getCardCollection(this, () => this.manuallyAttachedCardIds);
+  }
+
+  // Use prerendered search for auto-attached cards to avoid loading full card modules
+  private autoAttachedSearchResource = getPrerenderedSearch(
+    this,
+    getOwner(this)!,
+    () => {
+      let cardUrls = this.autoAttachedCardIdsArray;
+      return {
+        query: cardUrls.length > 0 ? {} : undefined,
+        format: cardUrls.length > 0 ? ('atom' as Format) : undefined,
+        realms: this.realmServer.availableRealmURLs,
+        cardUrls,
+        isLive: false,
+      };
+    },
+  );
+
+  private get autoAttachedCardIdsArray() {
+    return this.args.autoAttachedCardIds
+      ? [...this.args.autoAttachedCardIds]
+      : [];
+  }
+
+  private get autoAttachedPrerenderedCards() {
+    return this.autoAttachedSearchResource.instances;
   }
 
   private get items() {
@@ -100,7 +137,13 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
   }
 
   private get isLoaded() {
-    return this.cardCollection?.isLoaded;
+    let manualLoaded =
+      this.manuallyAttachedCardIds.length === 0 ||
+      this.cardCollection?.isLoaded;
+    let autoLoaded =
+      this.autoAttachedCardIdsArray.length === 0 ||
+      this.autoAttachedSearchResource.hasSearchRun;
+    return manualLoaded && autoLoaded;
   }
 
   private get cards() {
@@ -111,14 +154,10 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
     return this.cardCollection?.cardErrors ?? [];
   }
 
-  private get cardIds() {
+  // Only manually attached cards go through getCardCollection (which loads full card instances)
+  private get manuallyAttachedCardIds() {
     let cardIds = this.args.cardIdsToAttach ?? [];
-
-    if (this.args.autoAttachedCardIds) {
-      cardIds = [...new Set([...this.args.autoAttachedCardIds, ...cardIds])];
-    }
-
-    cardIds = cardIds.filter(Boolean); // Dont show new unsaved cards
+    cardIds = cardIds.filter(Boolean);
     return cardIds;
   }
 

--- a/packages/host/app/components/card-pill.gts
+++ b/packages/host/app/components/card-pill.gts
@@ -32,6 +32,7 @@ interface CardPillSignature {
     borderType?: 'dashed' | 'solid';
     displayTitle?: string;
     showErrorIcon?: boolean;
+    suppressCardLoad?: true;
     onClick?: () => void;
     onRemove?: () => void;
     isEnabled?: boolean;
@@ -45,7 +46,10 @@ export default class CardPill extends Component<CardPillSignature> {
   @service declare private realm: RealmService;
 
   @cached
-  private get cardResource(): ReturnType<getCard> {
+  private get cardResource(): ReturnType<getCard> | undefined {
+    if (this.args.suppressCardLoad) {
+      return undefined;
+    }
     return this.getCard(this, () => this.args.cardId);
   }
 

--- a/packages/host/app/resources/auto-attached-card.ts
+++ b/packages/host/app/resources/auto-attached-card.ts
@@ -1,15 +1,8 @@
-import { registerDestructor } from '@ember/destroyable';
 import { service } from '@ember/service';
 
-import { restartableTask } from 'ember-concurrency';
 import { Resource } from 'ember-modify-based-class-resource';
 
 import { TrackedSet } from 'tracked-built-ins';
-
-import {
-  isCardInstance,
-  realmURL as realmURLSymbol,
-} from '@cardstack/runtime-common';
 
 import type { StackItem } from '@cardstack/host/lib/stack-item';
 
@@ -17,7 +10,7 @@ import { Submodes } from '../components/submode-switcher';
 
 import type { Submode } from '../components/submode-switcher';
 
-import type CardService from '../services/card-service';
+import type RealmServerService from '../services/realm-server';
 import type StoreService from '../services/store';
 
 interface Args {
@@ -35,13 +28,15 @@ interface Args {
 
 /**
  * Manages the auto-attachment of cards within our stack in consideration of user-actions of manually
- * removing and attaching new cards in the ai panel
+ * removing and attaching new cards in the ai panel.
+ *
+ * This resource works purely with card IDs and does NOT load full card instances.
+ * This is critical for performance - loading card instances triggers Babel compilation
+ * of the card's entire module graph on the main thread.
  */
 export class AutoAttachment extends Resource<Args> {
   cardIds: TrackedSet<string> = new TrackedSet(); // auto-attached cards
-  #hasRegisteredDestructor = false;
-  #referenceCounts = new Map<string, number>();
-  @service declare private cardService: CardService;
+  @service declare private realmServer: RealmServerService;
   @service declare private store: StoreService;
 
   modify(_positional: never[], named: Args['named']) {
@@ -55,19 +50,7 @@ export class AutoAttachment extends Resource<Args> {
       attachedCardIds,
       removedCardIds,
     } = named;
-    this.reconcileReferences(
-      this.getCandidateCardIds(
-        submode,
-        moduleInspectorPanel,
-        autoAttachedFileUrls,
-        playgroundPanelCardId,
-        activeSpecId,
-        topMostStackItems,
-        attachedCardIds,
-        removedCardIds,
-      ),
-    );
-    this.calculateAutoAttachments.perform(
+    this.calculateAutoAttachments(
       submode,
       moduleInspectorPanel,
       autoAttachedFileUrls,
@@ -77,98 +60,9 @@ export class AutoAttachment extends Resource<Args> {
       attachedCardIds,
       removedCardIds,
     );
-    if (!this.#hasRegisteredDestructor) {
-      this.#hasRegisteredDestructor = true;
-      registerDestructor(this, () => {
-        for (let [id, count] of this.#referenceCounts) {
-          for (let i = 0; i < count; i++) {
-            this.store.dropReference(id);
-          }
-        }
-        this.#referenceCounts.clear();
-      });
-    }
   }
 
-  private calculateAutoAttachments = restartableTask(
-    async (
-      submode: Submode,
-      moduleInspectorPanel: string | undefined,
-      autoAttachedFileUrls: string[] | undefined,
-      playgroundPanelCardId: string | undefined,
-      activeSpecId: string | null | undefined,
-      topMostStackItems: StackItem[],
-      attachedCardIds: string[] | undefined,
-      removedCardIds: ReadonlySet<string> | undefined,
-    ) => {
-      this.cardIds.clear();
-      if (submode === Submodes.Interact) {
-        for (let item of topMostStackItems) {
-          if (!item.id) {
-            continue;
-          }
-          if (removedCardIds?.has(item.id)) {
-            continue;
-          }
-          if (attachedCardIds?.includes(item.id)) {
-            continue;
-          }
-          let card = await this.loadCard(item.id);
-          if (!card || !isCardInstance(card)) {
-            continue;
-          }
-          let realmURL = card[realmURLSymbol];
-          if (realmURL && item.id === `${realmURL.href}index`) {
-            continue;
-          }
-          this.cardIds.add(item.id);
-        }
-      } else if (submode === Submodes.Code) {
-        let cardFileUrl = autoAttachedFileUrls?.find((url) =>
-          url.endsWith('.json'),
-        );
-        let cardId = cardFileUrl
-          ? cardFileUrl.replace(/\.json$/, '')
-          : undefined;
-        if (
-          cardId &&
-          !removedCardIds?.has(cardId) &&
-          !attachedCardIds?.includes(cardId)
-        ) {
-          let card = await this.loadCard(cardId);
-          if (card && isCardInstance(card)) {
-            this.cardIds.add(cardId);
-          }
-        }
-        if (
-          moduleInspectorPanel === 'preview' &&
-          playgroundPanelCardId &&
-          !removedCardIds?.has(playgroundPanelCardId) &&
-          !attachedCardIds?.includes(playgroundPanelCardId)
-        ) {
-          this.cardIds.add(playgroundPanelCardId);
-        }
-        if (
-          moduleInspectorPanel === 'spec' &&
-          activeSpecId &&
-          !removedCardIds?.has(activeSpecId) &&
-          !attachedCardIds?.includes(activeSpecId)
-        ) {
-          this.cardIds.add(activeSpecId);
-        }
-      }
-    },
-  );
-
-  private async loadCard(id: string) {
-    let existing = this.store.peek(id);
-    if (existing) {
-      return existing;
-    }
-    return await this.store.get(id);
-  }
-
-  private getCandidateCardIds(
+  private calculateAutoAttachments(
     submode: Submode,
     moduleInspectorPanel: string | undefined,
     autoAttachedFileUrls: string[] | undefined,
@@ -178,111 +72,59 @@ export class AutoAttachment extends Resource<Args> {
     attachedCardIds: string[] | undefined,
     removedCardIds: ReadonlySet<string> | undefined,
   ) {
-    let candidateIds: string[] = [];
-
+    this.cardIds.clear();
+    let realmIndexCardIds = this.realmServer.availableRealmIndexCardIds;
     if (submode === Submodes.Interact) {
       for (let item of topMostStackItems) {
-        if (
-          item.id &&
-          !removedCardIds?.has(item.id) &&
-          !attachedCardIds?.includes(item.id)
-        ) {
-          candidateIds.push(item.id);
+        if (!item.id) {
+          continue;
+        }
+        if (removedCardIds?.has(item.id)) {
+          continue;
+        }
+        if (attachedCardIds?.includes(item.id)) {
+          continue;
+        }
+        // Filter out realm index cards by URL check (no card loading needed)
+        if (realmIndexCardIds.includes(item.id)) {
+          continue;
+        }
+        this.cardIds.add(item.id);
+      }
+    } else if (submode === Submodes.Code) {
+      let cardFileUrl = autoAttachedFileUrls?.find((url) =>
+        url.endsWith('.json'),
+      );
+      let cardId = cardFileUrl ? cardFileUrl.replace(/\.json$/, '') : undefined;
+      if (
+        cardId &&
+        !removedCardIds?.has(cardId) &&
+        !attachedCardIds?.includes(cardId)
+      ) {
+        // In code mode, use store.peek() (synchronous, no compilation) to check
+        // if the card is already known to be errored. If it's not in the store
+        // at all, include it optimistically.
+        let existing = this.store.peek(cardId);
+        if (!existing || existing.constructor?.name !== 'CardError') {
+          this.cardIds.add(cardId);
         }
       }
-      return candidateIds;
-    }
-
-    if (submode !== Submodes.Code) {
-      return candidateIds;
-    }
-
-    let cardFileUrl = autoAttachedFileUrls?.find((url) =>
-      url.endsWith('.json'),
-    );
-    let cardId = cardFileUrl ? cardFileUrl.replace(/\.json$/, '') : undefined;
-    if (
-      cardId &&
-      !removedCardIds?.has(cardId) &&
-      !attachedCardIds?.includes(cardId)
-    ) {
-      candidateIds.push(cardId);
-    }
-
-    if (
-      moduleInspectorPanel === 'preview' &&
-      playgroundPanelCardId &&
-      !removedCardIds?.has(playgroundPanelCardId) &&
-      !attachedCardIds?.includes(playgroundPanelCardId)
-    ) {
-      candidateIds.push(playgroundPanelCardId);
-    }
-
-    if (
-      moduleInspectorPanel === 'spec' &&
-      activeSpecId &&
-      !removedCardIds?.has(activeSpecId) &&
-      !attachedCardIds?.includes(activeSpecId)
-    ) {
-      candidateIds.push(activeSpecId);
-    }
-
-    return candidateIds;
-  }
-
-  private reconcileReferences(targetIds: string[]) {
-    let targetCounts = this.countReferences(targetIds);
-
-    for (let [id, currentCount] of this.#referenceCounts) {
-      let targetCount = targetCounts.get(id) ?? 0;
-      if (currentCount > targetCount) {
-        this.dropReference(id, currentCount - targetCount);
+      if (
+        moduleInspectorPanel === 'preview' &&
+        playgroundPanelCardId &&
+        !removedCardIds?.has(playgroundPanelCardId) &&
+        !attachedCardIds?.includes(playgroundPanelCardId)
+      ) {
+        this.cardIds.add(playgroundPanelCardId);
       }
-    }
-
-    for (let [id, targetCount] of targetCounts) {
-      let currentCount = this.#referenceCounts.get(id) ?? 0;
-      if (targetCount > currentCount) {
-        this.addReference(id, targetCount - currentCount);
+      if (
+        moduleInspectorPanel === 'spec' &&
+        activeSpecId &&
+        !removedCardIds?.has(activeSpecId) &&
+        !attachedCardIds?.includes(activeSpecId)
+      ) {
+        this.cardIds.add(activeSpecId);
       }
-    }
-  }
-
-  private countReferences(ids: string[]) {
-    let counts = new Map<string, number>();
-    for (let id of ids) {
-      counts.set(id, (counts.get(id) ?? 0) + 1);
-    }
-    return counts;
-  }
-
-  private addReference(id: string, count = 1) {
-    if (!id || count <= 0) {
-      return;
-    }
-    for (let i = 0; i < count; i++) {
-      this.store.addReference(id);
-    }
-    this.#referenceCounts.set(id, (this.#referenceCounts.get(id) ?? 0) + count);
-  }
-
-  private dropReference(id: string, count = 1) {
-    if (!id || count <= 0) {
-      return;
-    }
-    let currentCount = this.#referenceCounts.get(id);
-    if (!currentCount) {
-      return;
-    }
-    let drops = Math.min(count, currentCount);
-    for (let i = 0; i < drops; i++) {
-      this.store.dropReference(id);
-    }
-    let remaining = currentCount - drops;
-    if (remaining <= 0) {
-      this.#referenceCounts.delete(id);
-    } else {
-      this.#referenceCounts.set(id, remaining);
     }
   }
 }

--- a/packages/host/app/resources/auto-attached-card.ts
+++ b/packages/host/app/resources/auto-attached-card.ts
@@ -101,11 +101,10 @@ export class AutoAttachment extends Resource<Args> {
         !removedCardIds?.has(cardId) &&
         !attachedCardIds?.includes(cardId)
       ) {
-        // In code mode, use store.peek() (synchronous, no compilation) to check
-        // if the card is already known to be errored. If it's not in the store
-        // at all, include it optimistically.
-        let existing = this.store.peek(cardId);
-        if (!existing || existing.constructor?.name !== 'CardError') {
+        // In code mode, use store.peekError() (synchronous, no compilation)
+        // to check if the card is already known to be errored. If there's no
+        // known error, include it optimistically.
+        if (!this.store.peekError(cardId)) {
           this.cardIds.add(cardId);
         }
       }

--- a/packages/host/app/resources/stack-backgrounds.ts
+++ b/packages/host/app/resources/stack-backgrounds.ts
@@ -51,7 +51,13 @@ export class StackBackgroundsResource extends Resource<Args> {
         // Derive the realm URL from the card URL directly.
         // This avoids calling store.get() which would trigger loading the
         // card's full module graph via Babel compilation on the main thread.
-        let realmURL = this.realm.realmOfURL(new URL(bottomMostStackItem.id));
+        let realmURL;
+        try {
+          realmURL = this.realm.realmOfURL(new URL(bottomMostStackItem.id));
+        } catch {
+          // Non-URL ids (e.g. local-...) cannot be parsed; no background URL.
+          return undefined;
+        }
         if (realmURL) {
           await this.realm.ensureRealmMeta(realmURL.href);
           return this.realm.info(realmURL.href)?.backgroundURL;

--- a/packages/host/app/resources/stack-backgrounds.ts
+++ b/packages/host/app/resources/stack-backgrounds.ts
@@ -3,6 +3,8 @@ import { tracked } from '@glimmer/tracking';
 
 import { Resource } from 'ember-modify-based-class-resource';
 
+import { cardIdToURL } from '@cardstack/runtime-common';
+
 import type { Stack } from '../components/operator-mode/interact-submode';
 import type RealmService from '../services/realm';
 
@@ -53,7 +55,7 @@ export class StackBackgroundsResource extends Resource<Args> {
         // card's full module graph via Babel compilation on the main thread.
         let realmURL;
         try {
-          realmURL = this.realm.realmOfURL(new URL(bottomMostStackItem.id));
+          realmURL = this.realm.realmOfURL(cardIdToURL(bottomMostStackItem.id));
         } catch {
           // Non-URL ids (e.g. local-...) cannot be parsed; no background URL.
           return undefined;

--- a/packages/host/app/resources/stack-backgrounds.ts
+++ b/packages/host/app/resources/stack-backgrounds.ts
@@ -3,12 +3,8 @@ import { tracked } from '@glimmer/tracking';
 
 import { Resource } from 'ember-modify-based-class-resource';
 
-import { isCardInstance } from '@cardstack/runtime-common';
-
 import type { Stack } from '../components/operator-mode/interact-submode';
-import type CardService from '../services/card-service';
 import type RealmService from '../services/realm';
-import type StoreService from '../services/store';
 
 interface Args {
   positional: [stacks: Stack[]];
@@ -16,9 +12,7 @@ interface Args {
 
 export class StackBackgroundsResource extends Resource<Args> {
   @tracked value: (string | undefined | null)[] = [];
-  @service declare cardService: CardService;
   @service declare realm: RealmService;
-  @service declare store: StoreService;
 
   get backgroundImageURLs() {
     return this.value?.map((u) => (u ? u : undefined)) ?? [];
@@ -54,17 +48,15 @@ export class StackBackgroundsResource extends Resource<Args> {
         if (!bottomMostStackItem.id) {
           return;
         }
-        let bottomMostCard = await this.store.get(bottomMostStackItem.id);
-        if (!isCardInstance(bottomMostCard)) {
-          let realm = bottomMostCard.realm;
-          if (!realm) {
-            return undefined;
-          }
-          await this.realm.ensureRealmMeta(realm);
-          return this.realm.info(realm)?.backgroundURL;
+        // Derive the realm URL from the card URL directly.
+        // This avoids calling store.get() which would trigger loading the
+        // card's full module graph via Babel compilation on the main thread.
+        let realmURL = this.realm.realmOfURL(new URL(bottomMostStackItem.id));
+        if (realmURL) {
+          await this.realm.ensureRealmMeta(realmURL.href);
+          return this.realm.info(realmURL.href)?.backgroundURL;
         }
-        return (await this.cardService.getRealmInfo(bottomMostCard))
-          ?.backgroundURL;
+        return undefined;
       }),
     );
     this.value = result;

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -596,7 +596,26 @@ export default class OperatorModeStateService extends Service {
     if (!cardIds) {
       return;
     }
-    let cards = (await Promise.all(cardIds.map((id) => this.store.get(id))))
+    // Filter out realm index cards - loading them triggers Babel compilation
+    // of their entire module graph on the main thread (e.g. catalog realm's
+    // 83+ modules causing a ~5s freeze).
+    let realmIndexCardIds = this.realmServer.availableRealmIndexCardIds;
+    cardIds = cardIds.filter((id) => !realmIndexCardIds.includes(id));
+
+    // Use store.peek() first (synchronous, no compilation) since cards
+    // should already be loaded by stack rendering. Only fall back to
+    // store.get() if the card isn't in the store yet.
+    let cards = (
+      await Promise.all(
+        cardIds.map((id) => {
+          let existing = this.store.peek(id);
+          if (existing && isCardInstance(existing)) {
+            return existing;
+          }
+          return this.store.get(id);
+        }),
+      )
+    )
       .filter(Boolean)
       .filter(isCardInstance);
     return cards;

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -1059,6 +1059,94 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await click('[data-test-close-ai-assistant]');
   });
 
+  test('auto-attachment does not trigger full card module loading for cards in the stack', async function (assert) {
+    // Regression test: Previously, the auto-attachment system called store.get()
+    // for every card in the stack, which triggers loading the card's entire module
+    // graph via Babel compilation on the main thread. For deep module graphs like
+    // the catalog realm index card, this caused 83+ modules to be compiled (~5s
+    // freeze and crash). Auto-attachment should not load full card instances.
+    let store = getService('store');
+
+    // Open with the index card and a Person card in the stack.
+    await visitOperatorMode({
+      submode: 'interact',
+      codePath: `${testRealmURL}index.json`,
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}index`,
+            format: 'isolated',
+          },
+          {
+            id: `${testRealmURL}Person/fadhlan`,
+            format: 'isolated',
+          },
+        ],
+      ],
+    });
+
+    // Spy on store.get() BEFORE opening AI panel to capture ALL calls
+    // triggered by auto-attachment, getOpenCards, and stack backgrounds.
+    let storeGetCalls: string[] = [];
+    let originalGet = store.get.bind(store);
+    store.get = async function (id: string, ...args: any[]) {
+      storeGetCalls.push(id);
+      return originalGet(id, ...args);
+    } as typeof store.get;
+
+    try {
+      // Positive control: verify the spy works by calling store.get() directly.
+      await store.get(`${testRealmURL}Pet/mango`);
+      assert.true(
+        storeGetCalls.includes(`${testRealmURL}Pet/mango`),
+        'positive control: store.get() spy is working',
+      );
+
+      // Reset spy before the real test
+      storeGetCalls = [];
+
+      await click('[data-test-open-ai-assistant]');
+      await waitFor(`[data-room-settled]`);
+
+      // Realm index cards should NOT be auto-attached.
+      assert
+        .dom(`[data-test-autoattached-card="${testRealmURL}index"]`)
+        .doesNotExist('realm index card should not be auto-attached');
+
+      // The critical assertion for index cards: store.get() should NOT have
+      // been called for the realm index card by any code path during AI panel
+      // open. On the old code, auto-attachment, getOpenCards, and
+      // StackBackgroundsResource all called store.get() for stack items
+      // including index cards, triggering createFromSerialized → loader.import()
+      // for the card's adoptsFrom module and all transitive dependencies (Babel
+      // compilation on main thread). On staging with the catalog realm, this
+      // caused 83 modules to be compiled (~5s freeze and crash).
+      let indexCardGetCalls = storeGetCalls.filter(
+        (id) => id === `${testRealmURL}index`,
+      );
+      assert.strictEqual(
+        indexCardGetCalls.length,
+        0,
+        `store.get() should not be called for the realm index card, but was called ${indexCardGetCalls.length} time(s)`,
+      );
+
+      // The critical assertion for arbitrary cards: store.get() should NOT
+      // have been called for the Person card during AI panel open. The Person
+      // card is already in the store from stack rendering, so systems should
+      // use store.peek() instead.
+      let personCardGetCalls = storeGetCalls.filter(
+        (id) => id === `${testRealmURL}Person/fadhlan`,
+      );
+      assert.strictEqual(
+        personCardGetCalls.length,
+        0,
+        `store.get() should not be called for Person/fadhlan during AI panel open - store.peek() or prerendered HTML should be used instead`,
+      );
+    } finally {
+      store.get = originalGet;
+    }
+  });
+
   test('auto-attached file is not displayed in interact mode', async function (assert) {
     await visitOperatorMode({
       submode: 'interact',


### PR DESCRIPTION
## Summary

- Eliminates unnecessary `store.get()` calls for stack item cards when the AI assistant panel opens, preventing expensive Babel compilation of card module graphs on the main thread
- On staging, opening the AI panel with the catalog realm index card in the stack triggered loading 83+ catalog modules via Babel (~5 second freeze, tab crash)
- Auto-attached card pills now render from prerendered atom HTML instead of loading full card instances
- Stack background resource derives realm URL from card URL instead of loading the card

## Root Cause

Three code paths called `store.get()` for every stack item card during AI panel open:
1. `auto-attached-card.ts` - loaded each card to check `isCardInstance` and filter index cards
2. `stack-backgrounds.ts` - loaded the bottom stack card to get its realm background URL
3. `attachment-picker/index.gts` - included auto-attached cards in `getCardCollection` which loads full instances

Each `store.get()` triggers `createFromSerialized` → `loader.import()` → Babel `transformAsync()` for the card's `adoptsFrom` module and all transitive dependencies. For the catalog realm index card, this meant compiling 83 modules on the main thread.

## Changes

| File | Before | After |
|---|---|---|
| `auto-attached-card.ts` | `store.get()` + `isCardInstance` + reference counting | URL-based index card filtering, no card loading |
| `stack-backgrounds.ts` | `store.get()` for bottom card | `realm.realmOfURL()` to derive realm from URL |
| `attachment-picker/index.gts` | All cards through `getCardCollection` | Only manually attached cards through `getCardCollection`; auto-attached use prerendered search |
| `attached-items.gts` | `CardPill` with `getCard` for all | Auto-attached pills render from prerendered atom HTML |
| `operator-mode-state-service.ts` | `getOpenCards` calls `store.get()` for all | Filters index cards, uses `store.peek()` first |

## Test plan

- [x] Regression test: spies on `store.get()` and asserts no stack item cards are loaded during AI panel open
- [x] Test fails without fix, passes with fix
- [ ] Verify auto-attached card pills still display correctly with prerendered HTML
- [ ] Verify stack backgrounds still work (derived from realm URL)
- [ ] Verify existing auto-attachment tests still pass
- [ ] Test on staging with catalog realm index card in stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)