### PR TITLE
Fix PR card summary section being cropped in fitted template

### DIFF
--- a/packages/catalog-realm/pr-card/pr-card.gts
+++ b/packages/catalog-realm/pr-card/pr-card.gts
@@ -280,7 +280,7 @@ class IsolatedTemplate extends Component<typeof PrCard> {
         display: flex;
         flex-direction: column;
         height: 100%;
-        overflow: hidden;
+        overflow-y: auto;
       }
 
       /* ── Body ── */
@@ -290,7 +290,6 @@ class IsolatedTemplate extends Component<typeof PrCard> {
         flex-direction: column;
         background: var(--card, #ffffff);
         color: var(--card-foreground, #1f2328);
-        overflow-y: auto;
       }
 
       /* ── Status columns ── */
@@ -849,6 +848,7 @@ class FittedTemplate extends Component<typeof PrCard> {
         font-size: 10px;
         font-weight: 600;
         color: #fff;
+        text-align: center;
       }
       /* ── Summary ── */
       .pr-card :deep(.markdown-content) {


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-10503/pr-card-summary-section-is-cropped

Small fix:
The PR card's summary section content was being clipped/cropped when rendered in the isolated template on stack-item. Updated overflow and layout styles to ensure the summary section displays correctly without being cut off.


https://github.com/user-attachments/assets/eec1b2a5-a5db-47ad-be20-65f9608bfc95

