### PR TITLE
Fix Ask/Act toggle missing default selection on new session

### DIFF
--- a/packages/host/app/components/ai-assistant/llm-mode-toggle.gts
+++ b/packages/host/app/components/ai-assistant/llm-mode-toggle.gts
@@ -20,13 +20,17 @@ interface Signature {
 }
 
 export default class LLMModeToggle extends Component<Signature> {
+  private get selected(): LLMMode {
+    return this.args.selected === 'act' ? 'act' : 'ask';
+  }
+
   <template>
     <div class='llm-mode-toggle' ...attributes>
       <Tooltip @placement='top'>
         <:trigger>
           <button
             type='button'
-            class='llm-mode-option {{if (eq @selected "ask") "selected"}}'
+            class='llm-mode-option {{if (eq this.selected "ask") "selected"}}'
             data-test-llm-mode-option='ask'
             disabled={{@disabled}}
             {{on 'click' (fn this.handleOptionClick 'ask')}}
@@ -45,7 +49,7 @@ export default class LLMModeToggle extends Component<Signature> {
         <:trigger>
           <button
             type='button'
-            class='llm-mode-option {{if (eq @selected "act") "selected"}}'
+            class='llm-mode-option {{if (eq this.selected "act") "selected"}}'
             data-test-llm-mode-option='act'
             disabled={{@disabled}}
             {{on 'click' (fn this.handleOptionClick 'act')}}
@@ -102,7 +106,7 @@ export default class LLMModeToggle extends Component<Signature> {
 
   @action
   private handleOptionClick(mode: LLMMode) {
-    if (mode !== this.args.selected) {
+    if (mode !== this.selected) {
       this.args.onChange(mode);
     }
   }

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -3008,6 +3008,29 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       .exists();
   });
 
+  test('ask/act toggle defaults to ask on new session', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}index`,
+            format: 'isolated',
+          },
+        ],
+      ],
+    });
+
+    await click('[data-test-open-ai-assistant]');
+    await waitFor('[data-room-settled]');
+
+    assert
+      .dom('[data-test-llm-mode-option="ask"]')
+      .hasClass('selected', 'Ask is selected by default on new session');
+    assert
+      .dom('[data-test-llm-mode-option="act"]')
+      .doesNotHaveClass('selected', 'Act is not selected by default');
+  });
+
   test('new session inherits llm mode from current room', async function (assert) {
     await visitOperatorMode({
       stacks: [


### PR DESCRIPTION
When opening starting a new session in the AI assistant, the toggle is sometimes untoggled: 

<img width="1222" height="308" alt="image" src="https://github.com/user-attachments/assets/bba5cc8a-61f3-4130-811e-cff3f9361643" />


## Summary
- Normalize `@selected` in `LLMModeToggle` so the toggle always defaults to "Ask" when the value is not explicitly `"act"`
- Prevents a blank toggle during transient room-resource states introduced by the memory leak cleanup teardown path (`f3fb792`)

## Test plan
- [ ] Open AI assistant and create a new session — toggle should show "Ask" selected
- [ ] Switch between sessions — toggle should always have a selection
- [ ] Existing Ask/Act toggle tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)