### PR TITLE
Normalize registered-prefix card IDs in store lookups

### DIFF
--- a/packages/host/app/services/render-service.ts
+++ b/packages/host/app/services/render-service.ts
@@ -13,8 +13,10 @@ import { tokenize } from 'simple-html-tokenizer';
 
 import type { RealmPaths } from '@cardstack/runtime-common';
 import {
+  isLocalId,
   loadCardDocument,
   loadFileMetaDocument,
+  resolveCardReference,
   type CardError,
   type CodeRef,
   type RuntimeDependencyTrackingContext,
@@ -61,27 +63,27 @@ export class CardStoreWithErrors implements CardStore {
   }
 
   getCard(id: string): CardDef | undefined {
-    id = id.replace(/\.json$/, '');
+    id = normalizeCardStoreKey(id);
     return this.#cards.get(id);
   }
   getFileMeta(id: string): FileDef | undefined {
-    id = id.replace(/\.json$/, '');
+    id = normalizeCardStoreKey(id);
     return this.#fileMetaInstances.get(id);
   }
   setCard(id: string, instance: CardDef): void {
-    id = id.replace(/\.json$/, '');
+    id = normalizeCardStoreKey(id);
     this.#cards.set(id, instance);
   }
   setFileMeta(id: string, instance: FileDef): void {
-    id = id.replace(/\.json$/, '');
+    id = normalizeCardStoreKey(id);
     this.#fileMetaInstances.set(id, instance);
   }
   setCardNonTracked(id: string, instance: CardDef) {
-    id = id.replace(/\.json$/, '');
+    id = normalizeCardStoreKey(id);
     return this.#cards.set(id, instance);
   }
   setFileMetaNonTracked(id: string, instance: FileDef) {
-    id = id.replace(/\.json$/, '');
+    id = normalizeCardStoreKey(id);
     return this.#fileMetaInstances.set(id, instance);
   }
   makeTracked(_id: string) {}
@@ -92,6 +94,7 @@ export class CardStoreWithErrors implements CardStore {
     url: string,
     _opts?: { dependencyTrackingContext?: RuntimeDependencyTrackingContext },
   ) {
+    url = normalizeCardStoreURL(url);
     let promise = this.#cardDocsInFlight.get(url);
     if (promise) {
       return await promise;
@@ -109,6 +112,7 @@ export class CardStoreWithErrors implements CardStore {
     url: string,
     _opts?: { dependencyTrackingContext?: RuntimeDependencyTrackingContext },
   ) {
+    url = normalizeCardStoreURL(url);
     let promise = this.#fileMetaDocsInFlight.get(url);
     if (promise) {
       return await promise;
@@ -142,6 +146,15 @@ export class CardStoreWithErrors implements CardStore {
       errors: undefined,
     } as any;
   }
+}
+
+function normalizeCardStoreKey(id: string): string {
+  return normalizeCardStoreURL(id).replace(/\.json$/, '');
+}
+
+function normalizeCardStoreURL(id: string): string {
+  let key = id.replace(/\.json$/, '');
+  return isLocalId(key) ? id : resolveCardReference(id, undefined);
 }
 
 export interface RenderCardParams {

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -524,6 +524,7 @@ export default class StoreService extends Service implements StoreInterface {
   }
 
   async delete(id: string): Promise<void> {
+    id = asURL(id);
     if (!id) {
       // the card isn't actually saved yet, so do nothing
       return;
@@ -1651,10 +1652,11 @@ export default class StoreService extends Service implements StoreInterface {
   ) {
     let instance: CardDef | undefined;
     if (typeof idOrInstance === 'string') {
-      instance = this.store.getCard(idOrInstance);
-      if (!instance) {
+      let maybeInstance = this.peek(idOrInstance);
+      if (!isCardInstance(maybeInstance)) {
         return;
       }
+      instance = maybeInstance;
     } else {
       instance = idOrInstance;
     }

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -231,6 +231,7 @@ export default class StoreService extends Service implements StoreInterface {
     if (!id) {
       return;
     }
+    id = asURL(id);
     let currentReferenceCount = this.referenceCount.get(id) ?? 0;
     currentReferenceCount -= 1;
     this.referenceCount.set(id, currentReferenceCount);
@@ -254,6 +255,7 @@ export default class StoreService extends Service implements StoreInterface {
     if (!id) {
       return;
     }
+    id = asURL(id);
     let readType: StoreReadType = opts?.type ?? 'card';
     // synchronously update the reference count so we don't run into race
     // conditions requiring a mutex
@@ -428,6 +430,7 @@ export default class StoreService extends Service implements StoreInterface {
     id: string,
     opts?: { type?: StoreReadType },
   ): T | CardErrorJSONAPI | undefined {
+    id = asURL(id);
     let readType = opts?.type ?? 'card';
     if (readType === 'file-meta') {
       return this.store.getFileMetaInstanceOrError<T & FileDef>(id);
@@ -445,6 +448,7 @@ export default class StoreService extends Service implements StoreInterface {
     id: string,
     opts?: { type?: StoreReadType },
   ): CardErrorJSONAPI | undefined {
+    id = asURL(id);
     let readType = opts?.type ?? 'card';
     if (readType === 'file-meta') {
       return this.store.getFileMetaError(id);
@@ -864,6 +868,7 @@ export default class StoreService extends Service implements StoreInterface {
   }
 
   getSaveState(id: string): AutoSaveState | undefined {
+    id = asURL(id);
     return this.autoSaveStates.get(id);
   }
 
@@ -877,6 +882,7 @@ export default class StoreService extends Service implements StoreInterface {
   }
 
   getReferenceCount(id: string) {
+    id = asURL(id);
     return this.referenceCount.get(id) ?? 0;
   }
 
@@ -2072,10 +2078,17 @@ function needsServerStateMerge(
   );
 }
 
+export function asURL(urlOrDoc: string): string;
+export function asURL(urlOrDoc: LooseSingleCardDocument): string | undefined;
+export function asURL(
+  urlOrDoc: string | LooseSingleCardDocument,
+): string | undefined;
 export function asURL(urlOrDoc: string | LooseSingleCardDocument) {
-  return typeof urlOrDoc === 'string'
-    ? urlOrDoc.replace(/\.json$/, '')
-    : urlOrDoc.data.id;
+  if (typeof urlOrDoc !== 'string') {
+    return urlOrDoc.data.id;
+  }
+  let id = urlOrDoc.replace(/\.json$/, '');
+  return isLocalId(id) ? id : resolveCardReference(id, undefined);
 }
 
 function isSystemCardDefaultId(

--- a/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
@@ -701,6 +701,7 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
   test('it can handle an error in a card attached to a matrix message', async function (assert) {
     let roomId = await renderAiAssistantPanel();
     let unreachableCardId = 'http://this-is-not-a-real-card.com';
+    let canonicalUnreachableCardId = new URL(unreachableCardId).href;
     simulateRemoteMessage(roomId, '@aibot:localhost', {
       body: 'card with error',
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
@@ -723,7 +724,7 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
         `This card could not be displayed because it hit a runtime error.`,
       );
     assert
-      .dom(`[data-test-attached-card-error="${unreachableCardId}"]`)
+      .dom(`[data-test-attached-card-error="${canonicalUnreachableCardId}"]`)
       .exists('errored attached cards still render as pills');
     await percySnapshot(assert);
   });

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -24,6 +24,8 @@ import {
   type Realm,
   type SingleCardDocument,
   type LooseSingleCardDocument,
+  registerCardReferencePrefix,
+  unregisterCardReferencePrefix,
 } from '@cardstack/runtime-common';
 
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
@@ -170,6 +172,10 @@ module('Integration | Store', function (hooks) {
     await realmService.login(testRealmURL);
   });
 
+  hooks.afterEach(function () {
+    unregisterCardReferencePrefix('@test-prefix/');
+  });
+
   test('can peek a card instance', async function (assert) {
     storeService.addReference(`${testRealmURL}Person/hassan`);
     await storeService.flush();
@@ -254,6 +260,23 @@ module('Integration | Store', function (hooks) {
   test('peek for an uncached returns undefined', async function (assert) {
     let instance = storeService.peek(`${testRealmURL}Person/does-not-exist`);
     assert.strictEqual(instance, undefined, 'instance is undefined');
+  });
+
+  test('can add and peek a card by registered prefix id', async function (assert) {
+    registerCardReferencePrefix('@test-prefix/', testRealmURL);
+
+    storeService.addReference('@test-prefix/Person/hassan');
+    await storeService.flush();
+
+    let byPrefix = storeService.peek('@test-prefix/Person/hassan');
+    let byUrl = storeService.peek(`${testRealmURL}Person/hassan`);
+
+    assert.true(isCardInstance(byPrefix), 'prefix id resolves to a card');
+    assert.strictEqual(
+      byPrefix,
+      byUrl,
+      'prefix id and resolved URL return the same instance',
+    );
   });
 
   test('peekError returns the server state error when a stale instance exists', async function (assert) {

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -262,7 +262,7 @@ module('Integration | Store', function (hooks) {
     assert.strictEqual(instance, undefined, 'instance is undefined');
   });
 
-  test('can add and peek a card by registered prefix id', async function (assert) {
+  test<TestContextWithSave>('can use registered prefix ids across store APIs', async function (assert) {
     registerCardReferencePrefix('@test-prefix/', testRealmURL);
 
     storeService.addReference('@test-prefix/Person/hassan');
@@ -295,6 +295,46 @@ module('Integration | Store', function (hooks) {
       0,
       'dropping a prefix reference clears the resolved URL reference count',
     );
+
+    let saveFinished = new Deferred<void>();
+    this.onSave((url) => {
+      if (url.href === `${testRealmURL}Person/hassan`) {
+        assert.strictEqual(url.href, `${testRealmURL}Person/hassan`);
+        assert.strictEqual(
+          storeService.getReferenceCount(`${testRealmURL}Person/hassan`),
+          0,
+          'save() does not create a separate resolved-url reference count',
+        );
+        assert.strictEqual(
+          storeService.getReferenceCount('@test-prefix/Person/hassan'),
+          0,
+          'save() does not create a separate prefix reference count',
+        );
+        saveFinished.fulfill();
+      }
+    });
+
+    storeService.save('@test-prefix/Person/hassan');
+    await saveFinished;
+
+    storeService.addReference('@test-prefix/Person/boris');
+    await storeService.flush();
+
+    await storeService.delete('@test-prefix/Person/boris');
+
+    assert.strictEqual(
+      storeService.peek('@test-prefix/Person/boris'),
+      undefined,
+      'delete() clears the prefix-form card identity from the store',
+    );
+    assert.strictEqual(
+      storeService.peek(`${testRealmURL}Person/boris`),
+      undefined,
+      'delete() clears the resolved card identity from the store',
+    );
+
+    let file = await testRealmAdapter.openFile(`Person/boris.json`);
+    assert.strictEqual(file, undefined, 'delete() removes the remote card');
   });
 
   test('peekError returns the server state error when a stale instance exists', async function (assert) {

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -277,6 +277,24 @@ module('Integration | Store', function (hooks) {
       byUrl,
       'prefix id and resolved URL return the same instance',
     );
+    assert.strictEqual(
+      storeService.getReferenceCount('@test-prefix/Person/hassan'),
+      1,
+      'prefix id and resolved URL share a single reference count',
+    );
+    assert.strictEqual(
+      storeService.getReferenceCount(`${testRealmURL}Person/hassan`),
+      1,
+      'resolved URL sees the same reference count',
+    );
+
+    storeService.dropReference('@test-prefix/Person/hassan');
+
+    assert.strictEqual(
+      storeService.getReferenceCount(`${testRealmURL}Person/hassan`),
+      0,
+      'dropping a prefix reference clears the resolved URL reference count',
+    );
   });
 
   test('peekError returns the server state error when a stale instance exists', async function (assert) {

--- a/packages/host/tests/unit/services/render-service-test.ts
+++ b/packages/host/tests/unit/services/render-service-test.ts
@@ -1,0 +1,169 @@
+import { module, test } from 'qunit';
+
+import {
+  Deferred,
+  registerCardReferencePrefix,
+  unregisterCardReferencePrefix,
+  type SingleCardDocument,
+  type SingleFileMetaDocument,
+} from '@cardstack/runtime-common';
+
+import { CardStoreWithErrors } from '@cardstack/host/services/render-service';
+
+import type { CardDef } from 'https://cardstack.com/base/card-api';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
+
+const prefix = '@test-prefix/';
+const targetRealm = 'http://test-realm/test/';
+
+function fetchInputURL(input: string | URL | Request): string {
+  if (typeof input === 'string') {
+    return input;
+  }
+  if (input instanceof Request) {
+    return input.url;
+  }
+  return input.href;
+}
+
+module('Unit | Service | render-service', function (hooks) {
+  hooks.beforeEach(function () {
+    registerCardReferencePrefix(prefix, targetRealm);
+  });
+
+  hooks.afterEach(function () {
+    unregisterCardReferencePrefix(prefix);
+  });
+
+  test('CardStoreWithErrors resolves registered prefix ids for card and file lookups', function (assert) {
+    let store = new CardStoreWithErrors(globalThis.fetch);
+    let card = {} as CardDef;
+    let file = {} as FileDef;
+
+    store.setCard(`${prefix}Person/hassan`, card);
+    store.setFileMeta(`${prefix}hero.png`, file);
+
+    assert.strictEqual(
+      store.getCard(`${targetRealm}Person/hassan`),
+      card,
+      'card lookup shares storage between prefix and resolved ids',
+    );
+    assert.strictEqual(
+      store.getFileMeta(`${targetRealm}hero.png`),
+      file,
+      'file-meta lookup shares storage between prefix and resolved ids',
+    );
+  });
+
+  test('CardStoreWithErrors resolves prefix ids before loading card documents', async function (assert) {
+    let fetchDeferred = new Deferred<Response>();
+    let fetchCalls: string[] = [];
+    let fetch = ((input: string | URL | Request) => {
+      fetchCalls.push(fetchInputURL(input));
+      return fetchDeferred.promise;
+    }) as typeof globalThis.fetch;
+    let store = new CardStoreWithErrors(fetch);
+
+    let firstLoad = store.loadCardDocument(`${prefix}Person/hassan`);
+    let secondLoad = store.loadCardDocument(`${targetRealm}Person/hassan`);
+
+    assert.deepEqual(
+      fetchCalls,
+      [`${targetRealm}Person/hassan.json?noCache=true`],
+      'prefix and resolved ids share one fetch request',
+    );
+
+    let doc: SingleCardDocument = {
+      data: {
+        type: 'card',
+        meta: {
+          adoptsFrom: {
+            module: 'https://cardstack.com/base/card-api',
+            name: 'CardDef',
+          },
+        },
+      },
+    };
+    fetchDeferred.fulfill(
+      new Response(JSON.stringify(doc), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    let [prefixDoc, resolvedDoc] = await Promise.all([firstLoad, secondLoad]);
+    if (!('data' in prefixDoc)) {
+      throw new Error('expected prefix load to return a card document');
+    }
+    if (!('data' in resolvedDoc)) {
+      throw new Error('expected resolved load to return a card document');
+    }
+
+    assert.strictEqual(
+      prefixDoc.data.id,
+      `${targetRealm}Person/hassan`,
+      'loaded card document is normalized to the resolved URL',
+    );
+    assert.strictEqual(
+      resolvedDoc.data.id,
+      `${targetRealm}Person/hassan`,
+      'resolved load returns the same normalized card document',
+    );
+  });
+
+  test('CardStoreWithErrors resolves prefix ids before loading file-meta documents', async function (assert) {
+    let fetchDeferred = new Deferred<Response>();
+    let fetchCalls: string[] = [];
+    let fetch = ((input: string | URL | Request) => {
+      fetchCalls.push(fetchInputURL(input));
+      return fetchDeferred.promise;
+    }) as typeof globalThis.fetch;
+    let store = new CardStoreWithErrors(fetch);
+
+    let firstLoad = store.loadFileMetaDocument(`${prefix}hero.png`);
+    let secondLoad = store.loadFileMetaDocument(`${targetRealm}hero.png`);
+
+    assert.deepEqual(
+      fetchCalls,
+      [`${targetRealm}hero.png?noCache=true`],
+      'prefix and resolved file-meta ids share one fetch request',
+    );
+
+    let doc: SingleFileMetaDocument = {
+      data: {
+        type: 'file-meta',
+        meta: {
+          adoptsFrom: {
+            module: 'https://cardstack.com/base/file-api',
+            name: 'FileDef',
+          },
+        },
+      },
+    };
+    fetchDeferred.fulfill(
+      new Response(JSON.stringify(doc), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    let [prefixDoc, resolvedDoc] = await Promise.all([firstLoad, secondLoad]);
+    if (!('data' in prefixDoc)) {
+      throw new Error('expected prefix load to return a file-meta document');
+    }
+    if (!('data' in resolvedDoc)) {
+      throw new Error('expected resolved load to return a file-meta document');
+    }
+
+    assert.strictEqual(
+      prefixDoc.data.id,
+      `${targetRealm}hero.png`,
+      'loaded file-meta document is normalized to the resolved URL',
+    );
+    assert.strictEqual(
+      resolvedDoc.data.id,
+      `${targetRealm}hero.png`,
+      'resolved load returns the same normalized file-meta document',
+    );
+  });
+});

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -10,6 +10,11 @@ import type { CodeRef, ResolvedCodeRef } from './code-ref';
 import type { RenderRouteOptions } from './render-route-options';
 import type { Definition } from './definitions';
 import type { SerializedError } from './error';
+import {
+  resolveCardReference,
+  unresolveCardReference,
+  isRegisteredPrefix,
+} from './card-reference-resolver';
 
 import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
 import type { FileDef } from 'https://cardstack.com/base/file-api';
@@ -230,10 +235,6 @@ export { v4 as uuidv4 } from '@lukeed/uuid'; // isomorphic UUID's using Math.ran
 import type { LocalPath } from './paths';
 import type { CardTypeFilter, Query, DataQuery, EveryFilter } from './query';
 import { Loader } from './loader';
-import {
-  resolveCardReference,
-  unresolveCardReference,
-} from './card-reference-resolver';
 export * from './paths';
 export * from './cached-fetch';
 export * from './definition-lookup';
@@ -782,7 +783,7 @@ export function unixTime(epochTimeMs: number) {
 }
 
 export function isLocalId(id: string) {
-  return !id.startsWith('http');
+  return !id.startsWith('http') && !isRegisteredPrefix(id);
 }
 
 export function isBrowserTestEnv() {


### PR DESCRIPTION
## Summary
- treat registered-prefix card IDs as remote IDs instead of local IDs
- normalize prefix-form IDs at store ingress so references, peeks, and fetches use the resolved URL form
- add store integration coverage for prefix-form IDs, including shared ref-count behavior
