### PR TITLE
Clear modules cache on realm server boot and during full reindex

### DIFF
--- a/mise-tasks/infra/clear-modules-cache
+++ b/mise-tasks/infra/clear-modules-cache
@@ -4,6 +4,6 @@
 #MISE dir="packages/realm-server"
 
 echo "Clearing modules cache..."
-PGPORT="${PGPORT}" PGDATABASE="${PGDATABASE}" \
+PGPORT="${PGPORT:-5435}" PGDATABASE="${PGDATABASE:-boxel}" \
   NODE_NO_WARNINGS=1 \
   ts-node --transpileOnly scripts/clear-modules-cache.ts

--- a/mise-tasks/infra/clear-modules-cache
+++ b/mise-tasks/infra/clear-modules-cache
@@ -1,0 +1,9 @@
+#!/bin/sh
+#MISE description="Clear the modules cache in the database"
+#MISE depends=["infra:ensure-pg"]
+#MISE dir="packages/realm-server"
+
+echo "Clearing modules cache..."
+PGPORT="${PGPORT}" PGDATABASE="${PGDATABASE}" \
+  NODE_NO_WARNINGS=1 \
+  ts-node --transpileOnly scripts/clear-modules-cache.ts

--- a/mise-tasks/infra/full-reindex
+++ b/mise-tasks/infra/full-reindex
@@ -1,0 +1,6 @@
+#!/bin/sh
+#MISE description="Trigger a full reindex of all realms on running realm servers"
+#MISE depends=["infra:ensure-pg"]
+#MISE dir="packages/realm-server"
+
+exec ./scripts/full-reindex.sh

--- a/mise-tasks/infra/full-reset
+++ b/mise-tasks/infra/full-reset
@@ -1,0 +1,6 @@
+#!/bin/sh
+#MISE description="Full database reset, clear dynamic realms, and restart matrix"
+#MISE depends=["infra:ensure-pg"]
+#MISE dir="packages/realm-server"
+
+exec ./scripts/full-reset.sh

--- a/packages/realm-server/handlers/handle-full-reindex.ts
+++ b/packages/realm-server/handlers/handle-full-reindex.ts
@@ -1,6 +1,5 @@
 import type Koa from 'koa';
 import {
-  fetchAllRealmsWithOwners,
   SupportedMimeType,
   systemInitiatedPriority,
 } from '@cardstack/runtime-common';
@@ -9,27 +8,13 @@ import type { CreateRoutesArgs } from '../routes';
 
 export default function handleFullReindex({
   queue,
-  dbAdapter,
   definitionLookup,
   realms,
 }: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
     let realmUrls = realms.map((r) => r.url);
-    let realmOwners = await fetchAllRealmsWithOwners(dbAdapter);
-    let ownerMap = new Map(
-      realmOwners.map((realmOwner) => [
-        realmOwner.realm_url,
-        realmOwner.owner_username,
-      ]),
-    );
 
-    for (let realmUrl of realmUrls) {
-      let ownerUsername = ownerMap.get(realmUrl);
-      if (!ownerUsername || ownerUsername.startsWith('realm/')) {
-        continue;
-      }
-      await definitionLookup.clearRealmCache(realmUrl);
-    }
+    await definitionLookup.clearAllModules();
 
     await queue.publish<void>({
       jobType: `full-reindex`,

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -300,10 +300,8 @@ const getIndexHTML = async () => {
     createPrerenderAuth,
   );
 
-  if (FULL_INDEX_ON_STARTUP) {
-    log.info('Clearing modules cache before full index...');
-    await definitionLookup.clearAllModules();
-  }
+  log.info('Clearing modules cache...');
+  await definitionLookup.clearAllModules();
 
   for (let [i, path] of paths.entries()) {
     let url = hrefs[i][0];

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -300,6 +300,11 @@ const getIndexHTML = async () => {
     createPrerenderAuth,
   );
 
+  if (FULL_INDEX_ON_STARTUP) {
+    log.info('Clearing modules cache before full index...');
+    await definitionLookup.clearAllModules();
+  }
+
   for (let [i, path] of paths.entries()) {
     let url = hrefs[i][0];
 

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -134,7 +134,7 @@
     "lint:test-shards": "ts-node --transpileOnly scripts/lint-test-shards.ts",
     "full-reset": "./scripts/full-reset.sh",
     "full-reindex": "./scripts/full-reindex.sh",
-    "clear-modules-cache": "NODE_NO_WARNINGS=1 PGPORT=${PGPORT:-5435} ts-node --transpileOnly scripts/clear-modules-cache.ts",
+    "clear-modules-cache": "NODE_NO_WARNINGS=1 PGDATABASE=${PGDATABASE:-boxel} PGPORT=${PGPORT:-5435} ts-node --transpileOnly scripts/clear-modules-cache.ts",
     "check-user-pg-connections": "./scripts/check-user-pg-connections.sh",
     "sync-stripe-products": "NODE_NO_WARNINGS=1 PGDATABASE=boxel PGPORT=5435 ts-node --transpileOnly scripts/sync-stripe-products.ts",
     "sync-openrouter-models": "NODE_NO_WARNINGS=1 PGDATABASE=boxel PGPORT=5435 ts-node --transpileOnly scripts/sync-openrouter-models.ts",

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -134,6 +134,7 @@
     "lint:test-shards": "ts-node --transpileOnly scripts/lint-test-shards.ts",
     "full-reset": "./scripts/full-reset.sh",
     "full-reindex": "./scripts/full-reindex.sh",
+    "clear-modules-cache": "NODE_NO_WARNINGS=1 PGPORT=${PGPORT:-5435} ts-node --transpileOnly scripts/clear-modules-cache.ts",
     "check-user-pg-connections": "./scripts/check-user-pg-connections.sh",
     "sync-stripe-products": "NODE_NO_WARNINGS=1 PGDATABASE=boxel PGPORT=5435 ts-node --transpileOnly scripts/sync-stripe-products.ts",
     "sync-openrouter-models": "NODE_NO_WARNINGS=1 PGDATABASE=boxel PGPORT=5435 ts-node --transpileOnly scripts/sync-openrouter-models.ts",

--- a/packages/realm-server/scripts/clear-modules-cache.ts
+++ b/packages/realm-server/scripts/clear-modules-cache.ts
@@ -1,0 +1,21 @@
+// Clear the modules cache by deleting all rows from the modules table.
+// This is useful when switching branches in local dev, since the cached
+// modules can become stale when the underlying source files change.
+
+import '../setup-logger';
+import { PgAdapter } from '@cardstack/postgres';
+
+async function main() {
+  let adapter = new PgAdapter({ autoMigrate: false });
+  try {
+    await adapter.execute('DELETE FROM modules');
+    console.log('Cleared modules cache.');
+  } finally {
+    await adapter.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('Failed to clear modules cache:', err);
+  process.exit(1);
+});

--- a/packages/realm-server/tests/atomic-endpoints-test.ts
+++ b/packages/realm-server/tests/atomic-endpoints-test.ts
@@ -810,9 +810,10 @@ module(basename(__filename), function () {
           assert.strictEqual(response.status, 500);
           assert.strictEqual(response.body.errors.length, 1);
           assert.strictEqual(response.body.errors[0].title, 'Write Error');
-          assert.strictEqual(
-            response.body.errors[0].detail,
-            `Your filter refers to a nonexistent type: import { Place } from "${testRealmHref}missing-place/does-not-exist"`,
+          assert.ok(
+            response.body.errors[0].detail.includes(
+              'Your filter refers to a nonexistent type: import { Place }',
+            ),
             'error message is correct',
           );
         });

--- a/packages/realm-server/tests/atomic-endpoints-test.ts
+++ b/packages/realm-server/tests/atomic-endpoints-test.ts
@@ -812,7 +812,7 @@ module(basename(__filename), function () {
           assert.strictEqual(response.body.errors[0].title, 'Write Error');
           assert.ok(
             response.body.errors[0].detail.includes(
-              'Your filter refers to a nonexistent type: import { Place }',
+              `Your filter refers to a nonexistent type: import { Place } from "${testRealmHref}missing-place/does-not-exist"`,
             ),
             'error message is correct',
           );

--- a/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
@@ -904,7 +904,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
         );
       });
 
-      test('full reindex does not clear modules cache for bot-owned realms', async function (assert) {
+      test('full reindex clears all modules cache entries', async function (assert) {
         let endpoint = `test-realm-${uuidv4()}`;
         let owner = 'realm/bot';
         let ownerUserId = `@${owner}:localhost`;
@@ -965,8 +965,8 @@ module(`server-endpoints/${basename(__filename)}`, function () {
         );
         assert.strictEqual(
           staleRowsForBotRealm.length,
-          1,
-          'full reindex preserves module rows for bot realms that are skipped',
+          0,
+          'full reindex clears stale module rows for bot realms too',
         );
       });
 

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -124,7 +124,7 @@ export class FilterRefersToNonexistentTypeError extends Error {
 
   constructor(codeRef: ResolvedCodeRef, opts?: { cause?: unknown }) {
     super(
-      `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}". This is almost always caused by a stale modules cache (e.g. after switching branches). Clearing the "modules" table in the database will fix this.`,
+      `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}". This is almost always caused by a stale modules cache. Clearing the "modules" table in the database will fix this.`,
     );
     this.name = 'FilterRefersToNonexistentTypeError';
     this.codeRef = codeRef;

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -124,7 +124,7 @@ export class FilterRefersToNonexistentTypeError extends Error {
 
   constructor(codeRef: ResolvedCodeRef, opts?: { cause?: unknown }) {
     super(
-      `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}". Clearing the "modules" table in the database can fix this if the type really exists.`,
+      `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}". If this type exists it may be caused by a stale modules cache. Clearing the "modules" table in the database can fix this.`,
     );
     this.name = 'FilterRefersToNonexistentTypeError';
     this.codeRef = codeRef;

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -124,7 +124,7 @@ export class FilterRefersToNonexistentTypeError extends Error {
 
   constructor(codeRef: ResolvedCodeRef, opts?: { cause?: unknown }) {
     super(
-      `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}". This is almost always caused by a stale modules cache. Clearing the "modules" table in the database will fix this.`,
+      `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}". Clearing the "modules" table in the database can fix this if the type really exists.`,
     );
     this.name = 'FilterRefersToNonexistentTypeError';
     this.codeRef = codeRef;

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -124,7 +124,7 @@ export class FilterRefersToNonexistentTypeError extends Error {
 
   constructor(codeRef: ResolvedCodeRef, opts?: { cause?: unknown }) {
     super(
-      `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}". If this type exists it may be caused by a stale modules cache. Clearing the "modules" table in the database can fix this.`,
+      `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}". If this type exists, it may be caused by a stale modules cache. Clearing the "modules" table in the database can fix this.`,
     );
     this.name = 'FilterRefersToNonexistentTypeError';
     this.codeRef = codeRef;

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -124,7 +124,7 @@ export class FilterRefersToNonexistentTypeError extends Error {
 
   constructor(codeRef: ResolvedCodeRef, opts?: { cause?: unknown }) {
     super(
-      `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}"`,
+      `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}". This is almost always caused by a stale modules cache (e.g. after switching branches). Clearing the "modules" table in the database will fix this.`,
     );
     this.name = 'FilterRefersToNonexistentTypeError';
     this.codeRef = codeRef;


### PR DESCRIPTION
## Summary
- Clear the modules cache (`DELETE FROM modules`) on realm server boot when `FULL_INDEX_ON_STARTUP` is true (default in dev), fixing corrupt module cache after branch switches
- Fix the full-reindex handler to call `clearAllModules()` instead of per-realm `clearRealmCache()` which was skipping system realms
- Add standalone `clear-modules-cache` script and pnpm command (`pnpm clear-modules-cache`)
- Add mise tasks: `infra:clear-modules-cache`, `infra:full-reindex`, `infra:full-reset`


🤖 Generated with [Claude Code](https://claude.com/claude-code)