### PR TITLE
Increase dev startup timeouts

### DIFF
--- a/mise-tasks/dev
+++ b/mise-tasks/dev
@@ -4,7 +4,7 @@
 
 . "$(cd "$(dirname "$0")" && pwd)/lib/dev-common.sh"
 
-WAIT_ON_TIMEOUT=2400000 NODE_NO_WARNINGS=1 start-server-and-test \
+WAIT_ON_TIMEOUT=7200000 NODE_NO_WARNINGS=1 start-server-and-test \
   'run-p -ln start:pg start:matrix start:smtp start:prerender-dev start:prerender-manager-dev start:worker-development start:development' \
   "$PHASE1_URLS" \
   'run-p -ln start:worker-test start:test-realms' \

--- a/mise-tasks/dev-all
+++ b/mise-tasks/dev-all
@@ -38,7 +38,7 @@ while true; do
 done
 echo "Host app is ready."
 
-WAIT_ON_TIMEOUT=2400000 NODE_NO_WARNINGS=1 start-server-and-test \
+WAIT_ON_TIMEOUT=7200000 NODE_NO_WARNINGS=1 start-server-and-test \
   'run-p -ln start:pg start:matrix start:smtp start:prerender-dev start:prerender-manager-dev start:worker-development start:development' \
   "$PHASE1_URLS" \
   'run-p -ln start:worker-test start:test-realms' \

--- a/mise-tasks/dev-minimal
+++ b/mise-tasks/dev-minimal
@@ -6,7 +6,7 @@ READY_PATH="_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson"
 BASE_REALM_READY="http-get://${REALM_BASE_URL#http://}/base/${READY_PATH}"
 NODE_TEST_REALM_READY="http-get://${REALM_TEST_URL#http://}/node-test/${READY_PATH}"
 
-WAIT_ON_TIMEOUT=900000 \
+WAIT_ON_TIMEOUT=7200000 \
   SKIP_EXPERIMENTS=true \
   SKIP_CATALOG=true \
   SKIP_BOXEL_HOMEPAGE=true \

--- a/mise-tasks/dev-without-matrix
+++ b/mise-tasks/dev-without-matrix
@@ -7,7 +7,7 @@ BASE_REALM_READY="http-get://${REALM_BASE_URL#http://}/base/${READY_PATH}"
 EXPERIMENTS_READY="http-get://${REALM_BASE_URL#http://}/experiments/${READY_PATH}"
 NODE_TEST_REALM_READY="http-get://${REALM_TEST_URL#http://}/node-test/${READY_PATH}"
 
-WAIT_ON_TIMEOUT=900000 SKIP_BOXEL_HOMEPAGE=true NODE_NO_WARNINGS=1 start-server-and-test \
+WAIT_ON_TIMEOUT=7200000 SKIP_BOXEL_HOMEPAGE=true NODE_NO_WARNINGS=1 start-server-and-test \
   'run-p start:pg start:prerender-dev start:prerender-manager-dev start:worker-development start:development' \
   "${BASE_REALM_READY}|${EXPERIMENTS_READY}|${MATRIX_URL_VAL}|http://localhost:5001|${ICONS_URL}" \
   'run-p start:worker-test start:test-realms' \


### PR DESCRIPTION
## Summary
- increase the `WAIT_ON_TIMEOUT` used by the local `mise` dev tasks
- allow full reindex startup flows more time to finish before `start-server-and-test` gives up
- apply the longer timeout consistently across `dev`, `dev-all`, `dev-minimal`, and `dev-without-matrix`
