### PR TITLE
 Hide "Make a PR" menu item when user lacks write permission

### DIFF
--- a/packages/catalog-realm/catalog-app/listing/listing.gts
+++ b/packages/catalog-realm/catalog-app/listing/listing.gts
@@ -666,6 +666,9 @@ export class Listing extends CardDef {
     if (params.menuContext !== 'interact') {
       return;
     }
+    if (!params.canEdit) {
+      return;
+    }
     if (!this[realmURL]?.href) {
       return;
     }


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-10358/do-not-show-make-a-pr-when-user-dont-have-the-permission


Small changes:
The change is straightforward — it adds an early return in the listing menu logic when canEdit is false, preventing the "Make a PR" option from  appearing for users without write permission.
