### PR TITLE
Make "Generate Example", "Update Specs", and "Make a PR" menu items available in all menu contexts

### DIFF
--- a/packages/catalog-realm/catalog-app/listing/listing.gts
+++ b/packages/catalog-realm/catalog-app/listing/listing.gts
@@ -642,9 +642,9 @@ export class Listing extends CardDef {
     let menuItems = super
       [getMenuItems](params)
       .filter((item) => item.label?.toLowerCase() !== 'create listing');
-    const extra = this.getGenerateExampleMenuItem(params);
-    if (extra) {
-      menuItems = [...menuItems, extra];
+    const generateExample = this.getGenerateExampleMenuItem(params);
+    if (generateExample) {
+      menuItems = [...menuItems, generateExample];
     }
     const updateSpecs = this.getUpdateSpecsMenuItem(params);
     if (updateSpecs) {

--- a/packages/catalog-realm/catalog-app/listing/listing.gts
+++ b/packages/catalog-realm/catalog-app/listing/listing.gts
@@ -586,8 +586,8 @@ export class Listing extends CardDef {
   protected getGenerateExampleMenuItem(
     params: GetMenuItemParams,
   ): MenuItemOptions | undefined {
-    if (!params.commandContext) {
-      return undefined;
+    if (!params.commandContext || !params.canEdit) {
+      return;
     }
     const firstExample =
       Array.isArray(this.examples) && this.examples.length
@@ -619,12 +619,11 @@ export class Listing extends CardDef {
   private getUpdateSpecsMenuItem(
     params: GetMenuItemParams,
   ): MenuItemOptions | undefined {
-    if (params.menuContext !== 'interact') {
+    if (!params.commandContext || !params.canEdit) {
       return;
     }
-    const commandContext = params.commandContext;
     const targetRealm = this[realmURL]?.href;
-    if (!commandContext || !targetRealm) {
+    if (!targetRealm) {
       return;
     }
 
@@ -633,7 +632,7 @@ export class Listing extends CardDef {
       id: 'update-listing-specs',
       icon: Refresh,
       action: () =>
-        new ListingUpdateSpecsCommand(commandContext).execute({
+        new ListingUpdateSpecsCommand(params.commandContext).execute({
           listing: this,
         }),
     };
@@ -643,19 +642,17 @@ export class Listing extends CardDef {
     let menuItems = super
       [getMenuItems](params)
       .filter((item) => item.label?.toLowerCase() !== 'create listing');
-    if (params.menuContext === 'interact') {
-      const extra = this.getGenerateExampleMenuItem(params);
-      if (extra) {
-        menuItems = [...menuItems, extra];
-      }
-      const updateSpecs = this.getUpdateSpecsMenuItem(params);
-      if (updateSpecs) {
-        menuItems = [...menuItems, updateSpecs];
-      }
-      const createPRMenuItem = this.getCreatePRMenuItem(params);
-      if (createPRMenuItem) {
-        menuItems = [...menuItems, createPRMenuItem];
-      }
+    const extra = this.getGenerateExampleMenuItem(params);
+    if (extra) {
+      menuItems = [...menuItems, extra];
+    }
+    const updateSpecs = this.getUpdateSpecsMenuItem(params);
+    if (updateSpecs) {
+      menuItems = [...menuItems, updateSpecs];
+    }
+    const createPRMenuItem = this.getCreatePRMenuItem(params);
+    if (createPRMenuItem) {
+      menuItems = [...menuItems, createPRMenuItem];
     }
     return menuItems;
   }
@@ -663,21 +660,17 @@ export class Listing extends CardDef {
   private getCreatePRMenuItem(
     params: GetMenuItemParams,
   ): MenuItemOptions | undefined {
-    if (params.menuContext !== 'interact') {
+    if (!params.commandContext || !params.canEdit) {
       return;
     }
     if (!this[realmURL]?.href) {
-      return;
-    }
-    const commandContext = params.commandContext;
-    if (!commandContext) {
       return;
     }
 
     return {
       label: 'Make a PR',
       action: async () => {
-        await new OpenCreatePRModalCommand(commandContext).execute({
+        await new OpenCreatePRModalCommand(params.commandContext).execute({
           listingId: this.id,
           realm: this[realmURL]!.href,
           listingName: this.name,

--- a/packages/catalog-realm/catalog-app/listing/listing.gts
+++ b/packages/catalog-realm/catalog-app/listing/listing.gts
@@ -644,15 +644,15 @@ export class Listing extends CardDef {
       .filter((item) => item.label?.toLowerCase() !== 'create listing');
     const generateExample = this.getGenerateExampleMenuItem(params);
     if (generateExample) {
-      menuItems = [...menuItems, generateExample];
+      menuItems.push(generateExample);
     }
     const updateSpecs = this.getUpdateSpecsMenuItem(params);
     if (updateSpecs) {
-      menuItems = [...menuItems, updateSpecs];
+      menuItems.push(updateSpecs);
     }
     const createPRMenuItem = this.getCreatePRMenuItem(params);
     if (createPRMenuItem) {
-      menuItems = [...menuItems, createPRMenuItem];
+      menuItems.push(createPRMenuItem);
     }
     return menuItems;
   }


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-10510/make-a-pr-update-specs-generateexample-should-able-to-show-in-code

1.   Make "Generate Example", "Update Specs", and "Make a PR" menu items available in all menu contexts (interact, code-mode-preview,
2.   code-mode-playground) instead of restricting them to interact mode only. Each menu item now checks canEdit permission to hide when the user lacks  write access. Also unified the guard pattern across all three methods for consistency.

Demo:


https://github.com/user-attachments/assets/2bf15697-8d66-457b-9fbc-e9ddf65ce8d1

