### PR TITLE
Fix type picker search placeholder

### DIFF
--- a/packages/boxel-ui/addon/src/components/picker/before-options-with-search.gts
+++ b/packages/boxel-ui/addon/src/components/picker/before-options-with-search.gts
@@ -27,7 +27,7 @@ export default class PickerBeforeOptionsWithSearch extends Component<BeforeOptio
   }
 
   get searchPlaceholder() {
-    return this.args.extra?.searchPlaceholder || 'search for a realm';
+    return this.args.extra?.searchPlaceholder || 'Search...';
   }
 
   @action

--- a/packages/host/app/components/realm-picker/index.gts
+++ b/packages/host/app/components/realm-picker/index.gts
@@ -68,6 +68,7 @@ export default class RealmPicker extends Component<Signature> {
           @selected={{@selected}}
           @onChange={{@onChange}}
           @placeholder={{@placeholder}}
+          @searchPlaceholder='Search for a realm'
           @maxSelectedDisplay={{3}}
           @renderInPlace={{false}}
           @matchTriggerWidth={{false}}

--- a/packages/host/app/components/type-picker/index.gts
+++ b/packages/host/app/components/type-picker/index.gts
@@ -40,6 +40,7 @@ export default class TypePicker extends Component<Signature> {
       @options={{this.allOptions}}
       @selected={{this.selected}}
       @onChange={{@onChange}}
+      @searchPlaceholder='Search for a type'
       @maxSelectedDisplay={{3}}
       @renderInPlace={{false}}
       @matchTriggerWidth={{false}}

--- a/packages/host/tests/integration/components/card-catalog-test.gts
+++ b/packages/host/tests/integration/components/card-catalog-test.gts
@@ -241,6 +241,15 @@ module('Integration | card-catalog', function (hooks) {
     test('can filter cards by selecting a realm', async function (assert) {
       // Open the realm picker and select only Base Workspace
       await click('[data-test-realm-picker] [data-test-boxel-picker-trigger]');
+
+      assert
+        .dom('[data-test-boxel-picker-search] input')
+        .hasAttribute(
+          'placeholder',
+          'Search for a realm',
+          'realm picker has correct search placeholder',
+        );
+
       await click(`[data-test-boxel-picker-option-row="${baseRealm.url}"]`);
 
       // Only Base Workspace results should be shown

--- a/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
@@ -413,6 +413,14 @@ module('Integration | operator-mode | card catalog', function (hooks) {
       await click('[data-test-type-picker] [data-test-boxel-picker-trigger]');
       await waitFor('[data-test-boxel-picker-option-row]');
 
+      assert
+        .dom('[data-test-boxel-picker-search] input')
+        .hasAttribute(
+          'placeholder',
+          'Search for a type',
+          'type picker has correct search placeholder',
+        );
+
       // "Any Type" should be present with count
       assert
         .dom('[data-test-boxel-picker-option-row="select-all"]')


### PR DESCRIPTION
## Summary
- Changed the default search placeholder in Picker's `BeforeOptionsWithSearch` from hardcoded `"search for a realm"` to generic `"Search..."`
- RealmPicker now explicitly passes `@searchPlaceholder='Search for a realm'`
- TypePicker now explicitly passes `@searchPlaceholder='Search for a type'`
- Added placeholder assertions to existing host integration tests

## Test plan
- [ ] Verify realm picker search shows "Search for a realm"
- [ ] Verify type picker search shows "Search for a type"
- [ ] Run existing picker tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)