### PR TITLE
Fix listing-create not linking specs for the module itself

### DIFF
--- a/packages/host/app/commands/listing-create.ts
+++ b/packages/host/app/commands/listing-create.ts
@@ -161,6 +161,7 @@ export default class ListingCreateCommand extends HostBaseCommand<
         listingCard,
         targetRealm,
         firstOpenCardId ?? codeRef?.module,
+        codeRef.module,
       ),
     ]).catch((error) => {
       console.warn('Background autopatch failed:', error);
@@ -247,6 +248,7 @@ export default class ListingCreateCommand extends HostBaseCommand<
     listing: CardAPI.CardDef,
     targetRealm: string,
     resourceUrl: string, // can be module or card instance id
+    moduleUrl: string, // the module URL of the card type being listed
   ): Promise<Spec[]> {
     const resourceRealm =
       this.realm.realmOfURL(new URL(resourceUrl))?.href ?? targetRealm;
@@ -272,7 +274,9 @@ export default class ListingCreateCommand extends HostBaseCommand<
     };
 
     // Collect all modules (main + dependencies). Deduplication happens in sanitizeModuleList().
-    const modulesToCreate: string[] = [];
+    // The _dependencies endpoint excludes the queried resource itself, so we
+    // explicitly include the module URL to ensure a spec is created for it.
+    const modulesToCreate: string[] = [moduleUrl];
 
     jsonApiResponse.data?.forEach((entry) => {
       if (entry.attributes?.dependencies) {


### PR DESCRIPTION
### Summary
The _dependencies endpoint (since PR #4042) excludes the queried resource's own URL from the response
linkSpecs was relying on the old behavior where the self URL appeared in the dependency list, so it never created a spec for the main module — only for its transitive imports
For cards that only import base packages (card-api, string, etc.), all dependencies get filtered out by sanitizeModuleList, resulting in completely empty specs
For cards with realm-local dependencies, specs were created for those deps but the main module's own spec was always missing

### Fix
Explicitly include codeRef.module in the modulesToCreate list so the main module always gets a spec regardless of what _dependencies returns.


### Test plan
- [ ] Create a listing for a simple card (only base imports) → verify spec is created for the card's module
- [ ] Create a listing for a card with local dependencies → verify spec is created for both the card itself and its deps
- [ ] Verify existing listing creation flow still works end-to-end
- [ ] Test case in https://github.com/cardstack/boxel-catalog/pull/294
