### PR TITLE
Skill card ToC scroll issues fix

### DIFF
--- a/packages/base/skill-plus.gts
+++ b/packages/base/skill-plus.gts
@@ -56,7 +56,7 @@ export function parseMarkdownHeaders(markdown?: string): Array<TocItem> {
   const headers: Array<TocItem> = [];
   const usedIds = new Set<string>();
 
-  const headerRegex = /^(#{2,3})\s+(.+)$/gm;
+  const headerRegex = /^ {0,3}(#{2,3})\s+(.+)$/gm;
   let match;
 
   while ((match = headerRegex.exec(markdown)) !== null) {
@@ -96,11 +96,15 @@ export function injectHeadingAnchors(markdown?: string): string {
   const headers = parseMarkdownHeaders(markdown);
   let idx = 0;
 
-  return markdown.replace(/^(#{2,3})\s+(.+)$/gm, (match, hashes, text) => {
-    const item = headers[idx++];
-    if (!item) return match;
-    return `<a id="${item.id}" aria-hidden="true"></a>\n${hashes} ${text}`;
-  });
+  return markdown.replace(
+    /^ {0,3}(#{2,3})\s+(.+)$/gm,
+    (match, hashes, text) => {
+      const item = headers[idx++];
+      if (!item) return match;
+      const cleanText = text.replace(/\s*\{#[a-z0-9-]+\}\s*$/, '').trim();
+      return `<a id="${item.id}" aria-hidden="true"></a>\n${hashes} ${cleanText}`;
+    },
+  );
 }
 
 export class TocSection extends GlimmerComponent<{
@@ -118,12 +122,12 @@ export class TocSection extends GlimmerComponent<{
         <ul>
           {{#each @navItems as |item|}}
             <li
-              class={{if (gt item.level 2) 'toc-subsection' 'toc-section-item'}}
+              class={{if (gt item.level 3) 'toc-sub-subsection' (if (gt item.level 2) 'toc-subsection' 'toc-section-item')}}
             >
               <a
                 href='#{{item.id}}'
                 {{on 'click' (fn this.scrollToItem item.id)}}
-              >{{item.text}}</a>
+              >{{{item.text}}}</a>
             </li>
           {{/each}}
         </ul>
@@ -169,6 +173,10 @@ export class TocSection extends GlimmerComponent<{
       }
       .toc-subsection {
         padding-left: var(--boxel-sp);
+        font-size: var(--boxel-font-size-xs);
+      }
+      .toc-sub-subsection {
+        padding-left: calc(var(--boxel-sp) * 2);
         font-size: var(--boxel-font-size-xs);
       }
     </style>

--- a/packages/base/skill-plus.gts
+++ b/packages/base/skill-plus.gts
@@ -1,6 +1,5 @@
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
-import { modifier } from 'ember-modifier';
 import GlimmerComponent from '@glimmer/component';
 
 import { Button } from '@cardstack/boxel-ui/components';
@@ -611,7 +610,9 @@ export class SkillPlus extends Skill {
   });
   @field toc = containsMany(TocItemField, {
     computeVia: function (this: SkillPlus) {
-      return parseMarkdownHeaders(this.instructions);
+      return parseMarkdownHeaders(this.instructions).map((item) =>
+        Object.assign(new TocItemField(), item),
+      );
     },
   });
   @field commands = containsMany(CommandField);

--- a/packages/base/skill-plus.gts
+++ b/packages/base/skill-plus.gts
@@ -55,20 +55,28 @@ export function parseMarkdownHeaders(markdown?: string): Array<TocItem> {
   }
   const headers: Array<TocItem> = [];
   const usedIds = new Set<string>();
+  const headingRe = /^ {0,3}(#{2,3})\s+(.+)$/;
+  let insideFence = false;
 
-  const headerRegex = /^ {0,3}(#{2,3})\s+(.+)$/gm;
-  let match;
+  for (const line of markdown.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
+      insideFence = !insideFence;
+      continue;
+    }
+    if (insideFence) continue;
 
-  while ((match = headerRegex.exec(markdown)) !== null) {
-    const level = match[1].length;
-    let text = match[2].trim();
+    const m = headingRe.exec(line);
+    if (!m) continue;
+
+    const level = m[1].length;
 
     // Check for explicit ID: {#custom-id}
-    const idMatch = text.match(/\{#([a-z0-9-]+)\}/);
+    const idMatch = m[2].match(/\{#([a-z0-9-]+)\}/);
     const explicitId = idMatch ? idMatch[1] : null;
 
     // Remove {#id} from display text
-    text = text.replace(/\s*\{#[a-z0-9-]+\}\s*/, '').trim();
+    const text = m[2].replace(/\s*\{#[a-z0-9-]+\}\s*/, '').trim();
 
     // Generate base ID
     let baseId = explicitId || slugifyHeading(text);
@@ -90,21 +98,34 @@ export function parseMarkdownHeaders(markdown?: string): Array<TocItem> {
 
 // Pre-process markdown to inject anchor elements before each heading.
 // Uses parseMarkdownHeaders for ID generation so IDs are identical to the toc field.
+// Processes line-by-line to skip fenced code blocks.
 export function injectHeadingAnchors(markdown?: string): string {
   if (!markdown) return '';
 
   const headers = parseMarkdownHeaders(markdown);
   let idx = 0;
+  let insideFence = false;
+  const headingRe = /^ {0,3}(#{2,3})\s+(.+)$/;
 
-  return markdown.replace(
-    /^ {0,3}(#{2,3})\s+(.+)$/gm,
-    (match, hashes, text) => {
+  return markdown
+    .split('\n')
+    .map((line) => {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
+        insideFence = !insideFence;
+        return line;
+      }
+      if (insideFence) return line;
+
+      const m = headingRe.exec(line);
+      if (!m) return line;
+
       const item = headers[idx++];
-      if (!item) return match;
-      const cleanText = text.replace(/\s*\{#[a-z0-9-]+\}\s*$/, '').trim();
-      return `<a id="${item.id}" aria-hidden="true"></a>\n${hashes} ${cleanText}`;
-    },
-  );
+      if (!item) return line;
+      const cleanText = m[2].replace(/\s*\{#[a-z0-9-]+\}\s*$/, '').trim();
+      return `<a id="${item.id}" aria-hidden="true"></a>\n${m[1]} ${cleanText}`;
+    })
+    .join('\n');
 }
 
 export class TocSection extends GlimmerComponent<{
@@ -122,7 +143,11 @@ export class TocSection extends GlimmerComponent<{
         <ul>
           {{#each @navItems as |item|}}
             <li
-              class={{if (gt item.level 3) 'toc-sub-subsection' (if (gt item.level 2) 'toc-subsection' 'toc-section-item')}}
+              class={{if
+                (gt item.level 3)
+                'toc-sub-subsection'
+                (if (gt item.level 2) 'toc-subsection' 'toc-section-item')
+              }}
             >
               <a
                 href='#{{item.id}}'
@@ -703,7 +728,7 @@ export class SkillPlusMarkdown extends SkillPlus {
       return (
         this.cardInfo?.name ??
         this.instructionsSource?.title ??
-        `Untitled ${SkillPlus.displayName}`
+        `Untitled Skill`
       );
     },
   });

--- a/packages/base/skill-plus.gts
+++ b/packages/base/skill-plus.gts
@@ -214,8 +214,9 @@ export class TocSection extends GlimmerComponent<{
 
   private scrollToItem = (id: string, event: Event) => {
     event.preventDefault();
-    document
-      .querySelector(`#${id}`)
+    (event.currentTarget as HTMLElement)
+      .closest('.doc-layout')
+      ?.querySelector(`#${id}`)
       ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 }
@@ -614,8 +615,9 @@ export class DocLayout extends GlimmerComponent<{
 
   private scrollToTop = (event: Event) => {
     event.preventDefault();
-    document
-      .querySelector('#top')
+    (event.currentTarget as HTMLElement)
+      .closest('.doc-layout')
+      ?.querySelector('#top')
       ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 }

--- a/packages/base/skill-plus.gts
+++ b/packages/base/skill-plus.gts
@@ -14,9 +14,11 @@ import {
   contains,
   containsMany,
   linksTo,
+  FieldDef,
   StringField,
   type BaseDefComponent,
 } from './card-api';
+import NumberField from './number';
 import MarkdownField from './markdown';
 import { Skill, CommandField } from './skill';
 import { MarkdownDef } from './markdown-file-def';
@@ -39,6 +41,13 @@ export function slugifyHeading(text: string): string {
 }
 
 type TocItem = { level: number; text: string; id: string };
+
+export class TocItemField extends FieldDef {
+  static displayName = 'TOC Item';
+  @field level = contains(NumberField);
+  @field text = contains(StringField);
+  @field id = contains(StringField);
+}
 
 // Parse headers from markdown text with deterministic ID generation
 export function parseMarkdownHeaders(markdown?: string): Array<TocItem> {
@@ -116,6 +125,21 @@ export const addHeaderIds = modifier((element: HTMLElement) => {
     }
   });
 });
+
+// Pre-process markdown to inject anchor elements before each heading.
+// Uses parseMarkdownHeaders for ID generation so IDs are identical to the toc field.
+export function injectHeadingAnchors(markdown?: string): string {
+  if (!markdown) return '';
+
+  const headers = parseMarkdownHeaders(markdown);
+  let idx = 0;
+
+  return markdown.replace(/^(#{2,3})\s+(.+)$/gm, (match, hashes, text) => {
+    const item = headers[idx++];
+    if (!item) return match;
+    return `<a id="${item.id}" aria-hidden="true"></a>\n${hashes} ${text}`;
+  });
+}
 
 export class TocSection extends GlimmerComponent<{
   Args: {
@@ -615,6 +639,16 @@ export class SkillPlus extends Skill {
   });
 
   @field instructions = contains(MarkdownField);
+  @field instructionsWithIds = contains(MarkdownField, {
+    computeVia: function (this: SkillPlus) {
+      return injectHeadingAnchors(this.instructions);
+    },
+  });
+  @field toc = containsMany(TocItemField, {
+    computeVia: function (this: SkillPlus) {
+      return parseMarkdownHeaders(this.instructions);
+    },
+  });
   @field commands = containsMany(CommandField);
 
   static isolated: BaseDefComponent = class Isolated extends Component<
@@ -635,10 +669,7 @@ export class SkillPlus extends Skill {
       >
         <:navbar>
           {{#if @model.instructions}}
-            <TocSection
-              @sectionTitle='Content'
-              @navItems={{parseMarkdownHeaders @model.instructions}}
-            />
+            <TocSection @sectionTitle='Content' @navItems={{@model.toc}} />
           {{/if}}
           {{#if @model.commands.length}}
             <TocSection @sectionTitle='Appendix'>
@@ -650,12 +681,8 @@ export class SkillPlus extends Skill {
         </:navbar>
         <:default>
           {{#if @model.instructions}}
-            <article
-              class='instructions-article'
-              id='instructions'
-              {{addHeaderIds}}
-            >
-              <@fields.instructions />
+            <article class='instructions-article' id='instructions'>
+              <@fields.instructionsWithIds />
             </article>
           {{else}}
             <EmptyStateContainer>

--- a/packages/base/skill-plus.gts
+++ b/packages/base/skill-plus.gts
@@ -39,7 +39,7 @@ export function slugifyHeading(text: string): string {
   );
 }
 
-type TocItem = { level: number; text: string; id: string };
+type TocItem = { level: number; text: string; id: string; badge?: string };
 
 export class TocItemField extends FieldDef {
   static displayName = 'TOC Item';

--- a/packages/base/skill-plus.gts
+++ b/packages/base/skill-plus.gts
@@ -46,6 +46,7 @@ export class TocItemField extends FieldDef {
   @field level = contains(NumberField);
   @field text = contains(StringField);
   @field id = contains(StringField);
+  @field badge = contains(StringField);
 }
 
 // Parse headers from markdown text with deterministic ID generation
@@ -152,7 +153,7 @@ export class TocSection extends GlimmerComponent<{
               <a
                 href='#{{item.id}}'
                 {{on 'click' (fn this.scrollToItem item.id)}}
-              >{{{item.text}}}</a>
+              >{{#if item.badge}}<b>{{item.badge}}</b> {{/if}}{{item.text}}</a>
             </li>
           {{/each}}
         </ul>

--- a/packages/base/skill-plus.gts
+++ b/packages/base/skill-plus.gts
@@ -89,43 +89,6 @@ export function parseMarkdownHeaders(markdown?: string): Array<TocItem> {
   return headers;
 }
 
-// Modifier to add IDs to rendered markdown headers for TOC markdown anchor links
-export const addHeaderIds = modifier((element: HTMLElement) => {
-  const headers = element.querySelectorAll('h2, h3, h4, h5, h6');
-  const usedIds = new Set<string>();
-
-  headers.forEach((header) => {
-    if (header.getAttribute('id')) return; // Skip if already has ID
-
-    const text = header.textContent || '';
-
-    // Check for explicit ID in text
-    const idMatch = text.match(/\{#([a-z0-9-]+)\}/);
-    let baseId: string;
-
-    if (idMatch) {
-      baseId = idMatch[1];
-      // Remove {#id} from display
-      header.textContent = text.replace(/\s*\{#[a-z0-9-]+\}\s*/, '').trim();
-    } else {
-      baseId = slugifyHeading(text);
-    }
-
-    // Deduplicate IDs
-    let finalId = baseId;
-    let suffix = 2;
-    while (usedIds.has(finalId)) {
-      finalId = `${baseId}-${suffix}`;
-      suffix++;
-    }
-
-    if (finalId) {
-      header.setAttribute('id', finalId);
-      usedIds.add(finalId);
-    }
-  });
-});
-
 // Pre-process markdown to inject anchor elements before each heading.
 // Uses parseMarkdownHeaders for ID generation so IDs are identical to the toc field.
 export function injectHeadingAnchors(markdown?: string): string {
@@ -216,7 +179,7 @@ export class TocSection extends GlimmerComponent<{
     event.preventDefault();
     (event.currentTarget as HTMLElement)
       .closest('.doc-layout')
-      ?.querySelector(`#${id}`)
+      ?.querySelector(`[id="${id}"]`)
       ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 }
@@ -617,7 +580,7 @@ export class DocLayout extends GlimmerComponent<{
     event.preventDefault();
     (event.currentTarget as HTMLElement)
       .closest('.doc-layout')
-      ?.querySelector('#top')
+      ?.querySelector('[id="top"]')
       ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 }
@@ -629,7 +592,7 @@ export class SkillPlus extends Skill {
   // override skill card's title field to be computed of cardInfo.name
   @field cardTitle = contains(StringField, {
     computeVia: function (this: SkillPlus) {
-      return this.cardInfo?.name ?? `Untitled ${SkillPlus.displayName}`;
+      return this.cardInfo?.name ?? `Untitled Skill`;
     },
   });
 

--- a/packages/base/skill-set.gts
+++ b/packages/base/skill-set.gts
@@ -9,8 +9,8 @@ import { gt } from '@cardstack/boxel-ui/helpers';
 
 import {
   SkillPlus,
+  TocItemField,
   slugifyHeading,
-  addHeaderIds,
   DocLayout,
   TocSection,
   EmptyStateContainer,
@@ -22,6 +22,63 @@ import { Component, field, contains, containsMany } from './card-api';
 import StringField from './string';
 import MarkdownField from './markdown';
 
+function isFence(line: string): boolean {
+  if (!line) return false;
+  const c = line[0];
+  return (c === '`' || c === '~') && line.startsWith(c.repeat(3));
+}
+
+function getModeLabel(mode: string): string {
+  return mode === 'full' ? 'Full' : mode === 'essential' ? 'Essential' : 'Link Only';
+}
+
+// Normalize markdown header levels so the top-level header in any skill becomes H2.
+// Skips fenced code blocks. Used both for building instructions and for counting
+// how many headings a skill contributes to the combined document.
+function normalizeHeaders(markdown: string): string {
+  if (!markdown) return markdown;
+
+  const lines = markdown.split('\n');
+  let insideFence = false;
+
+  // Pass 1: find minimum header level outside fenced code
+  let minLevel: number | undefined;
+  for (const raw of lines) {
+    const trimmed = raw.trim();
+    if (isFence(trimmed)) { insideFence = !insideFence; continue; }
+    if (insideFence) continue;
+    const m = trimmed.match(/^(#{1,6})\s+/);
+    if (m) {
+      const lvl = m[1].length;
+      minLevel = minLevel === undefined ? lvl : Math.min(minLevel, lvl);
+    }
+  }
+
+  if (minLevel === undefined) return markdown;
+
+  const levelShift = 2 - minLevel; // make top level ## (H2)
+  if (levelShift === 0) return markdown;
+
+  // Pass 2: shift headers outside fences
+  insideFence = false;
+  const out: string[] = [];
+  for (const raw of lines) {
+    const trimmed = raw.trim();
+    if (isFence(trimmed)) { insideFence = !insideFence; out.push(raw); continue; }
+    if (insideFence) { out.push(raw); continue; }
+    const m = raw.match(/^(\s*)(#{1,6})\s+(.*)$/);
+    if (m) {
+      const leading = m[1] ?? '';
+      const rest = m[3] ?? '';
+      const newLevel = Math.max(2, Math.min(6, m[2].length + levelShift));
+      out.push(`${leading}${'#'.repeat(newLevel)} ${rest}`);
+    } else {
+      out.push(raw);
+    }
+  }
+  return out.join('\n');
+}
+
 // Compute table of contents markdown for a Skill Set's related skills
 // Updated to handle frontMatter, backMatter, and different indentation styles
 function computeTableOfContents(
@@ -31,12 +88,6 @@ function computeTableOfContents(
 ): string | undefined {
   const tocLines: string[] = [];
   let sectionNumber = 0;
-
-  const isFence = (line: string) => {
-    if (!line) return false;
-    const c = line[0];
-    return (c === '`' || c === '~') && line.startsWith(c.repeat(3));
-  };
 
   // ²⁵⁵ Parse markdown heading (## or ###) into structured data
   // Handles headers with or without leading whitespace
@@ -75,16 +126,13 @@ function computeTableOfContents(
     let inFence = false;
 
     for (const rawLine of content.split('\n')) {
-      const line = rawLine;
-
-      // Check for fence markers (trimmed for detection)
-      if (isFence(line.trim())) {
+      if (isFence(rawLine.trim())) {
         inFence = !inFence;
         continue;
       }
       if (inFence) continue;
 
-      const heading = parseHeading(line);
+      const heading = parseHeading(rawLine);
       if (!heading) continue;
 
       // Calculate indent based on header level relative to base
@@ -126,15 +174,13 @@ function computeTableOfContents(
     let inFence = false;
 
     for (const rawLine of skillContent.split('\n')) {
-      const line = rawLine;
-
-      if (isFence(line.trim())) {
+      if (isFence(rawLine.trim())) {
         inFence = !inFence;
         continue;
       }
       if (inFence) continue;
 
-      const heading = parseHeading(line);
+      const heading = parseHeading(rawLine);
       if (!heading) continue;
 
       // ²⁶⁴ Indent nested headers: 2 spaces for H2, 4 spaces for H3
@@ -223,6 +269,66 @@ export class SkillSet extends SkillPlus {
     },
   });
 
+  @field frontMatterToc = containsMany(TocItemField, {
+    // Slice from this.toc so IDs match the anchors in instructionsWithIds exactly.
+    computeVia: function (this: SkillSet) {
+      const count = parseMarkdownHeaders(this.frontMatter).length;
+      return (this.toc as unknown as Array<{ level: number; text: string; id: string }>).slice(0, count);
+    },
+  });
+
+  @field backMatterToc = containsMany(TocItemField, {
+    // Slice from this.toc so IDs match the anchors in instructionsWithIds exactly.
+    computeVia: function (this: SkillSet) {
+      const count = parseMarkdownHeaders(this.backMatter).length;
+      return count > 0
+        ? (this.toc as unknown as Array<{ level: number; text: string; id: string }>).slice(-count)
+        : [];
+    },
+  });
+
+  @field contentToc = containsMany(TocItemField, {
+    // Heading IDs come from this.toc (same dedup context as instructionsWithIds).
+    // normalizeHeaders gives accurate per-skill heading counts in the combined doc.
+    computeVia: function (this: SkillSet) {
+      const allToc = this.toc as unknown as Array<{ level: number; text: string; id: string }>;
+      const frontCount = parseMarkdownHeaders(this.frontMatter).length;
+      const backCount = parseMarkdownHeaders(this.backMatter).length;
+      const contentHeadings = allToc.slice(
+        frontCount,
+        backCount > 0 ? allToc.length - backCount : undefined,
+      );
+
+      const items: Array<{ level: number; text: string; id: string }> = [];
+      let headingIdx = 0;
+
+      for (let i = 0; i < (this.relatedSkills?.length ?? 0); i++) {
+        const skillRef = this.relatedSkills[i];
+        if (!skillRef) continue;
+        const topicName =
+          skillRef.topicName || skillRef.skill?.cardTitle || 'Untitled';
+        items.push({ level: 2, text: topicName, id: `skill-divider-${i}` });
+        const mode = skillRef.inclusionMode || 'link-only';
+        const rawContent =
+          mode === 'full' && skillRef.skill?.instructions
+            ? skillRef.skill.instructions
+            : mode === 'essential' && skillRef.essentials
+              ? skillRef.essentials
+              : '';
+        // Normalize before counting so the count matches the combined instructions
+        const skillHeadingCount = parseMarkdownHeaders(
+          normalizeHeaders(rawContent),
+        ).length;
+        for (let j = 0; j < skillHeadingCount; j++) {
+          const heading = contentHeadings[headingIdx++];
+          if (heading) items.push({ level: 3, text: heading.text, id: heading.id });
+        }
+      }
+
+      return items;
+    },
+  });
+
   @field instructions = contains(MarkdownField, {
     // Computed instructions with table-based skill dividers (NO TOC embedded)
     computeVia: function (this: SkillSet) {
@@ -233,82 +339,8 @@ export class SkillSet extends SkillPlus {
         result += this.frontMatter + '\n\n';
       }
 
-      const isFence = (line: string) => {
-        if (!line) return false;
-        const c = line[0];
-        return c === '`' && line.startsWith(c.repeat(3));
-      };
-
       // REMOVED: Do NOT add tableOfContents here - breaks circular dependency
       // TOC is extracted FROM instructions and displayed separately in template
-
-      // Helper function to normalize markdown header levels
-      // - Top-level becomes ## for each external skill
-      // - Preserves relative depth
-      // - Skips fenced code blocks (``` ... ```)
-      const normalizeHeaders = (markdown: string): string => {
-        if (!markdown) return markdown;
-
-        const lines = markdown.split('\n');
-        let insideFence = false;
-
-        // Pass 1: find minimum header level outside fenced code
-        let minLevel: number | undefined;
-        for (let raw of lines) {
-          const line = raw;
-          const trimmed = line.trim();
-          if (isFence(trimmed)) {
-            insideFence = !insideFence;
-            continue;
-          }
-          if (insideFence) continue;
-
-          const m = trimmed.match(/^(#{1,6})\s+/);
-          if (m) {
-            const lvl = m[1].length;
-            minLevel = minLevel === undefined ? lvl : Math.min(minLevel, lvl);
-          }
-        }
-
-        if (minLevel === undefined) return markdown; // no headers to normalize
-
-        const levelShift = 2 - minLevel; // make top level ## (H2) for external skills
-
-        if (levelShift === 0) return markdown;
-
-        // Pass 2: shift headers outside fences
-        insideFence = false;
-        const out: string[] = [];
-        for (let raw of lines) {
-          const trimmed = raw.trim();
-          if (isFence(trimmed)) {
-            insideFence = !insideFence;
-            out.push(raw);
-            continue;
-          }
-          if (insideFence) {
-            out.push(raw);
-            continue;
-          }
-
-          const m = raw.match(/^(\s*)(#{1,6})\s+(.*)$/);
-          if (m) {
-            const leading = m[1] ?? '';
-            const hashes = m[2];
-            const rest = m[3] ?? '';
-            const currentLevel = hashes.length;
-            const newLevel = Math.max(
-              2,
-              Math.min(6, currentLevel + levelShift),
-            );
-            out.push(`${leading}${'#'.repeat(newLevel)} ${rest}`);
-          } else {
-            out.push(raw);
-          }
-        }
-
-        return out.join('\n');
-      };
 
       // Add related skills with numbered dividers
       if (this.relatedSkills && this.relatedSkills.length > 0) {
@@ -352,13 +384,7 @@ export class SkillSet extends SkillPlus {
           // Add inclusion mode badge to divider (pill-style)
           const indent = '    ';
           dividerLines.push(
-            `${indent}<div class="divider-mode divider-mode-${mode}">${
-              mode === 'full'
-                ? 'Full'
-                : mode === 'essential'
-                  ? 'Essential'
-                  : 'Link Only'
-            }</div>`,
+            `${indent}<div class="divider-mode divider-mode-${mode}">${getModeLabel(mode)}</div>`,
           );
 
           // Close divider tags (no closing </a>)
@@ -397,9 +423,9 @@ export class SkillSet extends SkillPlus {
 
     private get isTocEmpty() {
       return (
-        !this.args.model?.tableOfContents &&
-        !this.args.model?.frontMatter &&
-        !this.args.model?.backMatter &&
+        !this.args.model?.contentToc?.length &&
+        !this.args.model?.frontMatterToc?.length &&
+        !this.args.model?.backMatterToc?.length &&
         !this.hasAppendix
       );
     }
@@ -420,21 +446,22 @@ export class SkillSet extends SkillPlus {
         @hideToc={{this.isTocEmpty}}
       >
         <:navbar>
-          {{#if @model.frontMatter}}
+          {{#if @model.frontMatterToc.length}}
             <TocSection
               @sectionTitle='Intro'
-              @navItems={{parseMarkdownHeaders @model.frontMatter}}
+              @navItems={{@model.frontMatterToc}}
             />
           {{/if}}
-          {{#if @model.tableOfContents}}
-            <TocSection @sectionTitle='Content'>
-              <@fields.tableOfContents />
-            </TocSection>
+          {{#if @model.contentToc.length}}
+            <TocSection
+              @sectionTitle='Content'
+              @navItems={{@model.contentToc}}
+            />
           {{/if}}
-          {{#if @model.backMatter}}
+          {{#if @model.backMatterToc.length}}
             <TocSection
               @sectionTitle='Summary'
-              @navItems={{parseMarkdownHeaders @model.backMatter}}
+              @navItems={{@model.backMatterToc}}
             />
           {{/if}}
           {{#if this.hasAppendix}}
@@ -476,10 +503,9 @@ export class SkillSet extends SkillPlus {
             <article
               class='instructions-article'
               id='instructions'
-              {{addHeaderIds}}
               {{dividerActivation this.activateDivider}}
             >
-              <@fields.instructions />
+              <@fields.instructionsWithIds />
             </article>
           {{else}}
             <EmptyStateContainer>
@@ -709,29 +735,14 @@ export class SkillSet extends SkillPlus {
   };
 
   static embedded = class Embedded extends Component<typeof this> {
-    addHeaderIds = addHeaderIds;
-
     <template>
       <div class='skill-set-embedded'>
         <div class='embedded-header'>
           <div class='skill-type-badge'>
-            <svg
-              class='badge-icon'
-              viewBox='0 0 24 24'
-              fill='none'
-              stroke='currentColor'
-              stroke-width='2'
-            >
-              <path d='M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z' />
-              <path d='M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z' />
-            </svg>
+            <SkillIcon class='badge-icon' />
             SKILL SET
           </div>
-          <h3 class='embedded-title'>{{if
-              @model.cardTitle
-              @model.cardTitle
-              'Untitled Skill Set'
-            }}</h3>
+          <h3 class='embedded-title'>{{@model.cardTitle}}</h3>
         </div>
 
         {{#if @model.cardDescription}}
@@ -897,31 +908,14 @@ export class SkillSet extends SkillPlus {
       <div class='fitted-container'>
         {{! Badge format (≤150px width, <170px height) - Compact title display }}
         <div class='badge-format'>
-          <div class='badge-title'>{{if
-              @model.cardTitle
-              @model.cardTitle
-              'Skill Set'
-            }}</div>
+          <div class='badge-title'>{{@model.cardTitle}}</div>
         </div>
 
         {{! Strip format (>150px width, <170px height) - Horizontal info bar }}
         <div class='strip-format'>
           <div class='strip-left'>
-            <svg
-              class='strip-icon'
-              viewBox='0 0 24 24'
-              fill='none'
-              stroke='currentColor'
-              stroke-width='2'
-            >
-              <path d='M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z' />
-              <path d='M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z' />
-            </svg>
-            <div class='strip-title'>{{if
-                @model.cardTitle
-                @model.cardTitle
-                'Skill Set'
-              }}</div>
+            <SkillIcon class='strip-icon' />
+            <div class='strip-title'>{{@model.cardTitle}}</div>
           </div>
           <div class='strip-count'>{{@model.relatedSkills.length}} skills</div>
         </div>
@@ -929,23 +923,10 @@ export class SkillSet extends SkillPlus {
         {{! Tile format (<400px width, ≥170px height) - Vertical card }}
         <div class='tile-format'>
           <div class='tile-header'>
-            <svg
-              class='tile-icon'
-              viewBox='0 0 24 24'
-              fill='none'
-              stroke='currentColor'
-              stroke-width='2'
-            >
-              <path d='M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z' />
-              <path d='M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z' />
-            </svg>
+            <SkillIcon class='tile-icon' />
             <div class='tile-badge'>SKILL SET</div>
           </div>
-          <h4 class='tile-title'>{{if
-              @model.cardTitle
-              @model.cardTitle
-              'Untitled'
-            }}</h4>
+          <h4 class='tile-title'>{{@model.cardTitle}}</h4>
           <div class='tile-stats'>
             <span class='stat'>{{@model.relatedSkills.length}} skills</span>
           </div>
@@ -958,39 +939,17 @@ export class SkillSet extends SkillPlus {
         <div class='card-format'>
           <div class='card-header'>
             <div class='card-meta'>
-              <svg
-                class='card-icon'
-                viewBox='0 0 24 24'
-                fill='none'
-                stroke='currentColor'
-                stroke-width='2'
-              >
-                <path d='M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z' />
-                <path d='M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z' />
-              </svg>
+              <SkillIcon class='card-icon' />
               <span class='card-type'>SKILL SET</span>
             </div>
-            <h4 class='card-title'>{{if
-                @model.cardTitle
-                @model.cardTitle
-                'Untitled Skill Set'
-              }}</h4>
+            <h4 class='card-title'>{{@model.cardTitle}}</h4>
           </div>
           {{#if @model.cardDescription}}
             <p class='card-description'>{{@model.cardDescription}}</p>
           {{/if}}
           <div class='card-footer'>
             <span class='footer-stat'>
-              <svg
-                class='footer-icon'
-                viewBox='0 0 24 24'
-                fill='none'
-                stroke='currentColor'
-                stroke-width='2'
-              >
-                <path d='M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z' />
-                <path d='M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z' />
-              </svg>
+              <SkillIcon class='footer-icon' />
               {{@model.relatedSkills.length}}
               skills
             </span>

--- a/packages/base/skill-set.gts
+++ b/packages/base/skill-set.gts
@@ -323,7 +323,8 @@ export class SkillSet extends SkillPlus {
         items.push(
           Object.assign(new TocItemField(), {
             level: 2,
-            text: `<b>${sectionNumber}</b> ${topicName}`,
+            text: topicName,
+            badge: String(sectionNumber),
             id: `skill-divider-${i}`,
           }),
         );

--- a/packages/base/skill-set.gts
+++ b/packages/base/skill-set.gts
@@ -273,7 +273,7 @@ export class SkillSet extends SkillPlus {
     // Slice from this.toc so IDs match the anchors in instructionsWithIds exactly.
     computeVia: function (this: SkillSet) {
       const count = parseMarkdownHeaders(this.frontMatter).length;
-      return (this.toc as unknown as Array<{ level: number; text: string; id: string }>).slice(0, count);
+      return (this.toc as TocItemField[]).slice(0, count);
     },
   });
 
@@ -281,9 +281,7 @@ export class SkillSet extends SkillPlus {
     // Slice from this.toc so IDs match the anchors in instructionsWithIds exactly.
     computeVia: function (this: SkillSet) {
       const count = parseMarkdownHeaders(this.backMatter).length;
-      return count > 0
-        ? (this.toc as unknown as Array<{ level: number; text: string; id: string }>).slice(-count)
-        : [];
+      return count > 0 ? (this.toc as TocItemField[]).slice(-count) : [];
     },
   });
 
@@ -291,7 +289,7 @@ export class SkillSet extends SkillPlus {
     // Heading IDs come from this.toc (same dedup context as instructionsWithIds).
     // normalizeHeaders gives accurate per-skill heading counts in the combined doc.
     computeVia: function (this: SkillSet) {
-      const allToc = this.toc as unknown as Array<{ level: number; text: string; id: string }>;
+      const allToc = this.toc as TocItemField[];
       const frontCount = parseMarkdownHeaders(this.frontMatter).length;
       const backCount = parseMarkdownHeaders(this.backMatter).length;
       const contentHeadings = allToc.slice(
@@ -299,7 +297,7 @@ export class SkillSet extends SkillPlus {
         backCount > 0 ? allToc.length - backCount : undefined,
       );
 
-      const items: Array<{ level: number; text: string; id: string }> = [];
+      const items: TocItemField[] = [];
       let headingIdx = 0;
 
       for (let i = 0; i < (this.relatedSkills?.length ?? 0); i++) {
@@ -307,7 +305,7 @@ export class SkillSet extends SkillPlus {
         if (!skillRef) continue;
         const topicName =
           skillRef.topicName || skillRef.skill?.cardTitle || 'Untitled';
-        items.push({ level: 2, text: topicName, id: `skill-divider-${i}` });
+        items.push(Object.assign(new TocItemField(), { level: 2, text: topicName, id: `skill-divider-${i}` }));
         const mode = skillRef.inclusionMode || 'link-only';
         const rawContent =
           mode === 'full' && skillRef.skill?.instructions
@@ -321,7 +319,7 @@ export class SkillSet extends SkillPlus {
         ).length;
         for (let j = 0; j < skillHeadingCount; j++) {
           const heading = contentHeadings[headingIdx++];
-          if (heading) items.push({ level: 3, text: heading.text, id: heading.id });
+          if (heading) items.push(heading);
         }
       }
 

--- a/packages/base/skill-set.gts
+++ b/packages/base/skill-set.gts
@@ -29,7 +29,11 @@ function isFence(line: string): boolean {
 }
 
 function getModeLabel(mode: string): string {
-  return mode === 'full' ? 'Full' : mode === 'essential' ? 'Essential' : 'Link Only';
+  return mode === 'full'
+    ? 'Full'
+    : mode === 'essential'
+      ? 'Essential'
+      : 'Link Only';
 }
 
 // Normalize markdown header levels so the top-level header in any skill becomes H2.
@@ -45,7 +49,10 @@ function normalizeHeaders(markdown: string): string {
   let minLevel: number | undefined;
   for (const raw of lines) {
     const trimmed = raw.trim();
-    if (isFence(trimmed)) { insideFence = !insideFence; continue; }
+    if (isFence(trimmed)) {
+      insideFence = !insideFence;
+      continue;
+    }
     if (insideFence) continue;
     const m = trimmed.match(/^(#{1,6})\s+/);
     if (m) {
@@ -64,8 +71,15 @@ function normalizeHeaders(markdown: string): string {
   const out: string[] = [];
   for (const raw of lines) {
     const trimmed = raw.trim();
-    if (isFence(trimmed)) { insideFence = !insideFence; out.push(raw); continue; }
-    if (insideFence) { out.push(raw); continue; }
+    if (isFence(trimmed)) {
+      insideFence = !insideFence;
+      out.push(raw);
+      continue;
+    }
+    if (insideFence) {
+      out.push(raw);
+      continue;
+    }
     const m = raw.match(/^(\s*)(#{1,6})\s+(.*)$/);
     if (m) {
       const leading = m[1] ?? '';
@@ -245,7 +259,7 @@ export class SkillSet extends SkillPlus {
 
   @field cardTitle = contains(StringField, {
     computeVia: function (this: SkillSet) {
-      return this.cardInfo?.name || `Untitled ${SkillSet.displayName}`;
+      return this.cardInfo?.name || `Untitled Skill Set`;
     },
   });
 
@@ -306,7 +320,13 @@ export class SkillSet extends SkillPlus {
         const topicName =
           skillRef.topicName || skillRef.skill?.cardTitle || 'Untitled';
         const sectionNumber = i + 1;
-        items.push(Object.assign(new TocItemField(), { level: 2, text: `<b>${sectionNumber}</b> ${topicName}`, id: `skill-divider-${i}` }));
+        items.push(
+          Object.assign(new TocItemField(), {
+            level: 2,
+            text: `<b>${sectionNumber}</b> ${topicName}`,
+            id: `skill-divider-${i}`,
+          }),
+        );
         const mode = skillRef.inclusionMode || 'link-only';
         const rawContent =
           mode === 'full' && skillRef.skill?.instructions

--- a/packages/base/skill-set.gts
+++ b/packages/base/skill-set.gts
@@ -305,7 +305,8 @@ export class SkillSet extends SkillPlus {
         if (!skillRef) continue;
         const topicName =
           skillRef.topicName || skillRef.skill?.cardTitle || 'Untitled';
-        items.push(Object.assign(new TocItemField(), { level: 2, text: topicName, id: `skill-divider-${i}` }));
+        const sectionNumber = i + 1;
+        items.push(Object.assign(new TocItemField(), { level: 2, text: `<b>${sectionNumber}</b> ${topicName}`, id: `skill-divider-${i}` }));
         const mode = skillRef.inclusionMode || 'link-only';
         const rawContent =
           mode === 'full' && skillRef.skill?.instructions
@@ -319,7 +320,14 @@ export class SkillSet extends SkillPlus {
         ).length;
         for (let j = 0; j < skillHeadingCount; j++) {
           const heading = contentHeadings[headingIdx++];
-          if (heading) items.push(heading);
+          if (heading)
+            items.push(
+              Object.assign(new TocItemField(), {
+                level: heading.level + 1,
+                text: heading.text,
+                id: heading.id,
+              }),
+            );
         }
       }
 


### PR DESCRIPTION
- Improvement 1: Previously we were using a modifier to parse markdown headers to generate table-of-contents and another modifier to inject ids to headers for scroll to work. These modifiers were being overridden by markdown field's own modifier. Converted the modifiers to computed fields.

- Improvement 2: Scroll function now uses the context of the card to find the nearest id to scroll to. This was an issue when multiple cards of the same type were open in the stack, only one of them scrolled. Now each operate separately.