### PR TITLE
Fix flaky workspace index card test

### DIFF
--- a/packages/host/tests/acceptance/interact-submode-creation-and-permissions-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-creation-and-permissions-test.gts
@@ -935,8 +935,9 @@ module(
             'Build a personal portfolio page with your background, skills, and contact information',
           );
         await click('[data-test-create-this-for-me]');
-        await waitFor('[data-test-message-idx="0"]');
-        await waitFor('[data-test-room-settled="true"]');
+        await waitFor(
+          '[data-test-message-idx="0"] [data-test-attached-card]',
+        );
         assertMessages(assert, [
           {
             from: 'testuser',
@@ -1034,8 +1035,9 @@ module(
           .hasValue(typedPrompt);
 
         await click('[data-test-create-this-for-me]');
-        await waitFor('[data-test-message-idx="0"]');
-        await waitFor('[data-test-room-settled="true"]');
+        await waitFor(
+          '[data-test-message-idx="0"] [data-test-attached-card]',
+        );
         assertMessages(assert, [
           {
             from: 'testuser',

--- a/packages/host/tests/acceptance/interact-submode-creation-and-permissions-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-creation-and-permissions-test.gts
@@ -935,9 +935,7 @@ module(
             'Build a personal portfolio page with your background, skills, and contact information',
           );
         await click('[data-test-create-this-for-me]');
-        await waitFor(
-          '[data-test-message-idx="0"] [data-test-attached-card]',
-        );
+        await waitFor('[data-test-message-idx="0"] [data-test-attached-card]');
         assertMessages(assert, [
           {
             from: 'testuser',
@@ -1035,9 +1033,7 @@ module(
           .hasValue(typedPrompt);
 
         await click('[data-test-create-this-for-me]');
-        await waitFor(
-          '[data-test-message-idx="0"] [data-test-attached-card]',
-        );
+        await waitFor('[data-test-message-idx="0"] [data-test-attached-card]');
         assertMessages(assert, [
           {
             from: 'testuser',

--- a/packages/host/tests/acceptance/interact-submode-creation-and-permissions-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-creation-and-permissions-test.gts
@@ -935,7 +935,8 @@ module(
             'Build a personal portfolio page with your background, skills, and contact information',
           );
         await click('[data-test-create-this-for-me]');
-        await waitFor('[data-test-room-settled]');
+        await waitFor('[data-test-message-idx="0"]');
+        await waitFor('[data-test-room-settled="true"]');
         assertMessages(assert, [
           {
             from: 'testuser',
@@ -1033,7 +1034,8 @@ module(
           .hasValue(typedPrompt);
 
         await click('[data-test-create-this-for-me]');
-        await waitFor('[data-test-room-settled]');
+        await waitFor('[data-test-message-idx="0"]');
+        await waitFor('[data-test-room-settled="true"]');
         assertMessages(assert, [
           {
             from: 'testuser',


### PR DESCRIPTION
## Summary
- Fix race condition in "displays highlights filter with special layout and community cards" test
- `sendMessageCommand.execute()` in `AskAiCommand` is fire-and-forget (not awaited), so the room panel can appear before the message is delivered
- Changed `waitFor('[data-test-room-settled]')` to first wait for `[data-test-message-idx="0"]` (message rendered), then `[data-test-room-settled="true"]` (room fully settled)

## Test plan
- [ ] CI passes — the previously flaky test should now be stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)