### PR TITLE
fix: expand card overlays 2px outside card boundary

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -283,7 +283,7 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
       }
       .spec-preview-overlay {
         pointer-events: none;
-        border-radius: var(--boxel-border-radius);
+        border-radius: var(--boxel-border-radius-lg);
         box-shadow: 0 0 0 1px var(--boxel-dark);
       }
       .spec-selector-container {

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -186,7 +186,7 @@ export default class OperatorModeOverlays extends Overlays {
         --overlay-fitted-card-header-height: 2.5rem;
       }
       .actions-overlay {
-        border-radius: var(--boxel-border-radius);
+        border-radius: var(--boxel-border-radius-lg);
         pointer-events: none;
 
         container-name: actions-overlay;

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -107,19 +107,24 @@ export default class Overlays extends Component<OverlaySignature> {
   @tracked
   protected currentlyHoveredCard: RenderedCardForOverlayActions | null = null;
 
+  // Expand the overlay slightly beyond the card boundary so the selection ring
+  // and hover border sit outside the card, avoiding border-radius style clashes.
+  protected overlayExpansionPx = 2;
+
   protected offset = {
     name: 'offset',
     fn: (state: MiddlewareState) => {
       let { elements, rects } = state;
       let { floating, reference } = elements;
       let { width, height } = reference.getBoundingClientRect();
+      let expansion = this.overlayExpansionPx;
 
-      floating.style.width = width + 'px';
-      floating.style.height = height + 'px';
+      floating.style.width = width + expansion * 2 + 'px';
+      floating.style.height = height + expansion * 2 + 'px';
       floating.style.position = 'absolute';
       return {
-        x: rects.reference.x,
-        y: rects.reference.y,
+        x: rects.reference.x - expansion,
+        y: rects.reference.y - expansion,
       };
     },
   };


### PR DESCRIPTION
## Summary

Fixes CS-9707 — card overlay selection ring was sitting exactly on the card boundary, causing border-radius style clashes with the selected theme.

## Changes

- Added `overlayExpansionPx = 2` property to the `Overlays` base class
- Updated the velcro `offset` middleware to position the overlay 2px outside the card boundary on each side (subtracts expansion from x/y, adds 2× expansion to width/height)
- Updated `border-radius` in overlay CSS from `--boxel-border-radius` (10px) to `--boxel-border-radius-lg` (12px) so the rounded corners follow the expanded boundary cleanly — applies to both the actions overlay and the spec-preview overlay

## Before / After

Before: overlay sits exactly on card boundary → selection ring border-radius clips against card border-radius  
After: overlay extends 2px outside card → selection ring floats cleanly outside the card with matching corner radius

## Testing

Visual change — please verify by selecting a card in interact mode with different themes applied.