### PR TITLE
update GPT-5 model config card to point to GPT-5.4

### DIFF
--- a/packages/catalog-realm/ModelConfiguration/openai-gpt-5.json
+++ b/packages/catalog-realm/ModelConfiguration/openai-gpt-5.json
@@ -3,8 +3,8 @@
     "type": "card",
     "attributes": {
       "cardInfo": {
-        "name": "OpenAI: GPT-5",
-        "summary": "GPT-5 is OpenAI’s most advanced model, offering major improvements in reasoning, code quality, and user experience. It is optimized for complex tasks that require step-by-step reasoning, instruction following, and accuracy in high-stakes use cases. It supports test-time routing features and advanced prompt understanding, including user-specified intent like \"think hard about this.\" Improvements include reductions in hallucination, sycophancy, and better performance in coding, writing, and health-related tasks.",
+        "name": "OpenAI: GPT-5.4",
+        "summary": "GPT-5.4 is OpenAI's latest update to the GPT-5 series, offering major improvements in reasoning, code quality, and user experience. It is optimized for complex tasks that require step-by-step reasoning, instruction following, and accuracy in high-stakes use cases. It supports test-time routing features and advanced prompt understanding, including user-specified intent like \"think hard about this.\" Improvements include reductions in hallucination, sycophancy, and better performance in coding, writing, and health-related tasks.",
         "cardThumbnailURL": null,
         "notes": null
       },
@@ -18,7 +18,7 @@
       },
       "openRouterModel": {
         "links": {
-          "self": "@cardstack/openrouter/OpenRouterModel/openai-gpt-5"
+          "self": "@cardstack/openrouter/OpenRouterModel/openai-gpt-5.4"
         }
       }
     },


### PR DESCRIPTION
## Summary

Updates the OpenAI GPT-5 ModelConfiguration card to reference GPT-5.4 instead of GPT-5.

## Changes

- `packages/catalog-realm/ModelConfiguration/openai-gpt-5.json`
  - Name: `OpenAI: GPT-5` → `OpenAI: GPT-5.4`
  - OpenRouter model ref: `openai-gpt-5` → `openai-gpt-5.4`
  - Summary updated to reflect GPT-5.4 as the latest in the series

> ⚠️ Note: the OpenRouter slug used is `openai-gpt-5.4`. If the correct model ID is `openai/gpt-5.4-pro`, the ref should be updated to `openai-gpt-5.4-pro`.