### PR TITLE
fix: unsubscribe file watcher before removing realm files during deletion

### DIFF
--- a/packages/realm-server/handlers/realm-destruction-utils.ts
+++ b/packages/realm-server/handlers/realm-destruction-utils.ts
@@ -54,6 +54,8 @@ export async function removeMountedRealm(args: {
   let { realm, realmPath, realms, virtualNetwork } = args;
   let cleanupError: Error | undefined;
 
+  realm.unsubscribe();
+
   try {
     let allFilePaths = collectAllFilePaths(realmPath);
     if (allFilePaths.length > 0) {
@@ -100,6 +102,8 @@ export function destroyMountedRealm(args: {
 }) {
   let { realm, realmPath, realms, virtualNetwork } = args;
   let cleanupError: Error | undefined;
+
+  realm.unsubscribe();
 
   try {
     if (pathExistsSync(realmPath)) {

--- a/packages/realm-server/tests/server-endpoints/delete-realm-test.ts
+++ b/packages/realm-server/tests/server-endpoints/delete-realm-test.ts
@@ -277,6 +277,16 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
       insert('claimed_domains_for_sites', nameExpressions, valueExpressions),
     );
 
+    let sourceRealm = context.testRealmServer.testingOnlyRealms.find(
+      (realm) => realm.url === realmURL,
+    )!;
+    let unsubscribeCalled = false;
+    let originalUnsubscribe = sourceRealm.unsubscribe.bind(sourceRealm);
+    sourceRealm.unsubscribe = function () {
+      unsubscribeCalled = true;
+      originalUnsubscribe();
+    };
+
     let deleteResponse = await context.request
       .delete('/_delete-realm')
       .set('Accept', 'application/vnd.api+json')
@@ -298,6 +308,10 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
       );
 
     assert.strictEqual(deleteResponse.status, 204, 'realm deleted');
+    assert.true(
+      unsubscribeCalled,
+      'file watcher was unsubscribed during realm destruction',
+    );
     assert.false(
       existsSync(
         join(context.dir.name, 'realm_server_1', realmPath[0]!, realmPath[1]!),


### PR DESCRIPTION
## Summary
- Fixes a race condition where deleting a realm crashes the server (CS-10555)
- When a realm is deleted, `destroyMountedRealm` removes files from disk, which triggers the file watcher to fire removal events. These events try to re-index the deleted files, which calls `getRealmOwnerUsername()` → `fetchRealmPermissions()`, but the permissions have already been removed from the database. This causes an unhandled `Cannot determine realm owner` error that crashes the entire server process.
- The fix calls `realm.unsubscribe()` in both `destroyMountedRealm` and `removeMountedRealm` before any files are removed, preventing the file watcher from reacting to the deletions.

## Test plan
- [x] Added test verifying `unsubscribe` is called on the realm during deletion
- [x] All existing delete-realm tests pass (5/5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)