### PR TITLE
Fix 3dot menu delete regression

### DIFF
--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 
 import { tracked } from '@glimmer/tracking';
 
+import onClickOutside from 'ember-click-outside/modifiers/on-click-outside';
 import { velcro } from 'ember-velcro';
 import { TrackedArray } from 'tracked-built-ins';
 
@@ -107,6 +108,7 @@ export default class Directory extends Component<Args> {
       <div
         class='file-tree-context-menu'
         {{velcro this.menuTriggerEl placement='bottom-start' strategy='fixed'}}
+        {{onClickOutside this.closeMenu exceptSelector='.file-menu-trigger'}}
       >
         <Menu
           class='file-tree-context-menu-list'
@@ -218,7 +220,6 @@ export default class Directory extends Component<Args> {
     registerDestructor(this, () => {
       this.menuEntryPath = undefined;
       this.menuTriggerEl = undefined;
-      document.removeEventListener('pointerdown', this.handleOutsideClick);
     });
   }
 
@@ -275,7 +276,6 @@ export default class Directory extends Component<Args> {
   private closeMenu() {
     this.menuEntryPath = undefined;
     this.menuTriggerEl = undefined;
-    document.removeEventListener('pointerdown', this.handleOutsideClick);
   }
 
   @action
@@ -291,19 +291,6 @@ export default class Directory extends Component<Args> {
     }
     this.menuEntryPath = entryPath;
     this.menuTriggerEl = e.currentTarget as HTMLElement;
-    document.addEventListener('pointerdown', this.handleOutsideClick);
-  }
-
-  @action
-  private handleOutsideClick(e: PointerEvent) {
-    const menu = document.querySelector('.file-tree-context-menu');
-    if (
-      menu &&
-      !menu.contains(e.target as Node) &&
-      !this.menuTriggerEl?.contains(e.target as Node)
-    ) {
-      this.closeMenu();
-    }
   }
 
   @action

--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -9,12 +9,9 @@ import { tracked } from '@glimmer/tracking';
 
 import { TrackedArray } from 'tracked-built-ins';
 
-import {
-  BoxelDropdown,
-  ContextButton,
-  Menu,
-  type BoxelDropdownAPI,
-} from '@cardstack/boxel-ui/components';
+import { velcro } from 'ember-velcro';
+
+import { ContextButton, Menu } from '@cardstack/boxel-ui/components';
 import { eq, MenuItem } from '@cardstack/boxel-ui/helpers';
 
 import { DropdownArrowDown, IconTrash } from '@cardstack/boxel-ui/icons';
@@ -107,34 +104,17 @@ export default class Directory extends Component<Args> {
         {{/let}}
       </div>
     {{/each}}
-    {{#if @onDeleteFile}}
-      <BoxelDropdown
-        @registerAPI={{this.registerDropdownApi}}
-        @onClose={{this.clearFileMenu}}
-        @contentClass='file-tree-context-menu'
+    {{#if this.menuTriggerEl}}
+      <div
+        class='file-tree-context-menu'
+        {{velcro this.menuTriggerEl placement='bottom-start' strategy='fixed'}}
       >
-        <:trigger as |bindings|>
-          <button
-            type='button'
-            class='file-tree-menu-anchor'
-            aria-hidden='true'
-            tabindex='-1'
-            style={{this.anchorStyle}}
-            {{bindings}}
-          ></button>
-        </:trigger>
-        <:content as |dd|>
-          <Menu
-            class='file-tree-context-menu-list'
-            @items={{this.menuItems}}
-            @closeMenu={{dd.close}}
-            {{on 'pointerenter' this.cancelCloseMenuTimer}}
-            {{on 'pointerleave' this.startCloseMenuTimer}}
-            {{on 'focusin' this.cancelCloseMenuTimer}}
-            {{on 'focusout' this.startCloseMenuTimer}}
-          />
-        </:content>
-      </BoxelDropdown>
+        <Menu
+          class='file-tree-context-menu-list'
+          @items={{this.menuItems}}
+          @closeMenu={{this.closeMenu}}
+        />
+      </div>
     {{/if}}
     <style scoped>
       .level {
@@ -189,14 +169,9 @@ export default class Directory extends Component<Args> {
       .file-row:focus-within .file-menu-trigger {
         visibility: visible;
       }
-      .file-tree-menu-anchor {
-        position: fixed;
-        width: 0;
-        height: 0;
-        padding: 0;
-        border: 0;
-        opacity: 0;
-        pointer-events: none;
+
+      .file-tree-context-menu {
+        z-index: 1000;
       }
 
       .directory {
@@ -236,18 +211,18 @@ export default class Directory extends Component<Args> {
   );
 
   @tracked private selectedFile?: LocalPath;
-  @tracked private anchorStyle = '';
+  @tracked private menuTriggerEl?: HTMLElement;
   private openDirs: TrackedArray<LocalPath> = new TrackedArray();
-  private dropdownApi?: BoxelDropdownAPI;
   private menuEntryPath?: LocalPath;
   private closeMenuTimer?: ReturnType<typeof setTimeout>;
 
   constructor(owner: Owner, args: Args['Args']) {
     super(owner, args);
     registerDestructor(this, () => {
-      this.dropdownApi = undefined;
       this.menuEntryPath = undefined;
+      this.menuTriggerEl = undefined;
       clearTimeout(this.closeMenuTimer);
+      document.removeEventListener('pointerdown', this.handleOutsideClick);
     });
   }
 
@@ -286,11 +261,6 @@ export default class Directory extends Component<Args> {
     return openDirs.includes(dirPath);
   }
 
-  @action
-  private registerDropdownApi(api: BoxelDropdownAPI) {
-    this.dropdownApi = api;
-  }
-
   private get menuItems() {
     if (!this.menuEntryPath) {
       return [];
@@ -306,10 +276,11 @@ export default class Directory extends Component<Args> {
   }
 
   @action
-  private clearFileMenu() {
+  private closeMenu() {
     this.menuEntryPath = undefined;
-    this.anchorStyle = '';
+    this.menuTriggerEl = undefined;
     clearTimeout(this.closeMenuTimer);
+    document.removeEventListener('pointerdown', this.handleOutsideClick);
   }
 
   @action
@@ -320,28 +291,25 @@ export default class Directory extends Component<Args> {
     e.preventDefault();
     e.stopPropagation();
     this.menuEntryPath = entryPath;
-    // Position the hidden anchor to match the clicked trigger so that
-    // ember-basic-dropdown calculates the correct dropdown position.
-    // We use a tracked anchorStyle so Glimmer preserves it through re-renders.
-    const triggerRect = (
-      e.currentTarget as HTMLElement
-    ).getBoundingClientRect();
-    this.anchorStyle = `top: ${triggerRect.top}px; left: ${triggerRect.left}px; width: ${triggerRect.width}px; height: ${triggerRect.height}px;`;
+    this.menuTriggerEl = e.currentTarget as HTMLElement;
     this.startCloseMenuTimer();
-    this.dropdownApi?.actions.open(e);
+    document.addEventListener('pointerdown', this.handleOutsideClick);
+  }
+
+  @action
+  private handleOutsideClick(e: PointerEvent) {
+    const menu = document.querySelector('.file-tree-context-menu');
+    if (menu && !menu.contains(e.target as Node)) {
+      this.closeMenu();
+    }
   }
 
   @action
   private startCloseMenuTimer() {
     clearTimeout(this.closeMenuTimer);
     this.closeMenuTimer = setTimeout(() => {
-      this.dropdownApi?.actions.close();
+      this.closeMenu();
     }, 800);
-  }
-
-  @action
-  private cancelCloseMenuTimer() {
-    clearTimeout(this.closeMenuTimer);
   }
 
   @action

--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -213,14 +213,11 @@ export default class Directory extends Component<Args> {
   @tracked private menuTriggerEl?: HTMLElement;
   private openDirs: TrackedArray<LocalPath> = new TrackedArray();
   private menuEntryPath?: LocalPath;
-  private closeMenuTimer?: ReturnType<typeof setTimeout>;
-
   constructor(owner: Owner, args: Args['Args']) {
     super(owner, args);
     registerDestructor(this, () => {
       this.menuEntryPath = undefined;
       this.menuTriggerEl = undefined;
-      clearTimeout(this.closeMenuTimer);
       document.removeEventListener('pointerdown', this.handleOutsideClick);
     });
   }
@@ -278,7 +275,6 @@ export default class Directory extends Component<Args> {
   private closeMenu() {
     this.menuEntryPath = undefined;
     this.menuTriggerEl = undefined;
-    clearTimeout(this.closeMenuTimer);
     document.removeEventListener('pointerdown', this.handleOutsideClick);
   }
 
@@ -289,26 +285,25 @@ export default class Directory extends Component<Args> {
     }
     e.preventDefault();
     e.stopPropagation();
+    if (this.menuTriggerEl === e.currentTarget) {
+      this.closeMenu();
+      return;
+    }
     this.menuEntryPath = entryPath;
     this.menuTriggerEl = e.currentTarget as HTMLElement;
-    this.startCloseMenuTimer();
     document.addEventListener('pointerdown', this.handleOutsideClick);
   }
 
   @action
   private handleOutsideClick(e: PointerEvent) {
     const menu = document.querySelector('.file-tree-context-menu');
-    if (menu && !menu.contains(e.target as Node)) {
+    if (
+      menu &&
+      !menu.contains(e.target as Node) &&
+      !this.menuTriggerEl?.contains(e.target as Node)
+    ) {
       this.closeMenu();
     }
-  }
-
-  @action
-  private startCloseMenuTimer() {
-    clearTimeout(this.closeMenuTimer);
-    this.closeMenuTimer = setTimeout(() => {
-      this.closeMenu();
-    }, 800);
   }
 
   @action

--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -119,6 +119,7 @@ export default class Directory extends Component<Args> {
             class='file-tree-menu-anchor'
             aria-hidden='true'
             tabindex='-1'
+            style={{this.anchorStyle}}
             {{bindings}}
           ></button>
         </:trigger>
@@ -127,6 +128,8 @@ export default class Directory extends Component<Args> {
             class='file-tree-context-menu-list'
             @items={{this.menuItems}}
             @closeMenu={{dd.close}}
+            {{on 'mouseenter' this.cancelCloseMenuTimer}}
+            {{on 'mouseleave' this.startCloseMenuTimer}}
           />
         </:content>
       </BoxelDropdown>
@@ -231,15 +234,18 @@ export default class Directory extends Component<Args> {
   );
 
   @tracked private selectedFile?: LocalPath;
+  @tracked private anchorStyle = '';
   private openDirs: TrackedArray<LocalPath> = new TrackedArray();
   private dropdownApi?: BoxelDropdownAPI;
   private menuEntryPath?: LocalPath;
+  private closeMenuTimer?: ReturnType<typeof setTimeout>;
 
   constructor(owner: Owner, args: Args['Args']) {
     super(owner, args);
     registerDestructor(this, () => {
       this.dropdownApi = undefined;
       this.menuEntryPath = undefined;
+      clearTimeout(this.closeMenuTimer);
     });
   }
 
@@ -300,6 +306,8 @@ export default class Directory extends Component<Args> {
   @action
   private clearFileMenu() {
     this.menuEntryPath = undefined;
+    this.anchorStyle = '';
+    clearTimeout(this.closeMenuTimer);
   }
 
   @action
@@ -310,7 +318,28 @@ export default class Directory extends Component<Args> {
     e.preventDefault();
     e.stopPropagation();
     this.menuEntryPath = entryPath;
+    // Position the hidden anchor to match the clicked trigger so that
+    // ember-basic-dropdown calculates the correct dropdown position.
+    // We use a tracked anchorStyle so Glimmer preserves it through re-renders.
+    const triggerRect = (
+      e.currentTarget as HTMLElement
+    ).getBoundingClientRect();
+    this.anchorStyle = `top: ${triggerRect.top}px; left: ${triggerRect.left}px; width: ${triggerRect.width}px; height: ${triggerRect.height}px;`;
+    this.startCloseMenuTimer();
     this.dropdownApi?.actions.open(e);
+  }
+
+  @action
+  private startCloseMenuTimer() {
+    clearTimeout(this.closeMenuTimer);
+    this.closeMenuTimer = setTimeout(() => {
+      this.dropdownApi?.actions.close();
+    }, 800);
+  }
+
+  @action
+  private cancelCloseMenuTimer() {
+    clearTimeout(this.closeMenuTimer);
   }
 
   @action

--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -7,9 +7,8 @@ import Component from '@glimmer/component';
 
 import { tracked } from '@glimmer/tracking';
 
-import { TrackedArray } from 'tracked-built-ins';
-
 import { velcro } from 'ember-velcro';
+import { TrackedArray } from 'tracked-built-ins';
 
 import { ContextButton, Menu } from '@cardstack/boxel-ui/components';
 import { eq, MenuItem } from '@cardstack/boxel-ui/helpers';

--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -170,7 +170,7 @@ export default class Directory extends Component<Args> {
       }
 
       .file-tree-context-menu {
-        z-index: 1000;
+        z-index: var(--boxel-layer-floating-button);
       }
 
       .directory {

--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -128,8 +128,10 @@ export default class Directory extends Component<Args> {
             class='file-tree-context-menu-list'
             @items={{this.menuItems}}
             @closeMenu={{dd.close}}
-            {{on 'mouseenter' this.cancelCloseMenuTimer}}
-            {{on 'mouseleave' this.startCloseMenuTimer}}
+            {{on 'pointerenter' this.cancelCloseMenuTimer}}
+            {{on 'pointerleave' this.startCloseMenuTimer}}
+            {{on 'focusin' this.cancelCloseMenuTimer}}
+            {{on 'focusout' this.startCloseMenuTimer}}
           />
         </:content>
       </BoxelDropdown>


### PR DESCRIPTION
# File Tree Delete Dropdown Regression

## The Issue

Commit `6bea2ee2e3` refactored the file tree context menu to use a **single shared `BoxelDropdown`** across all file rows (to avoid memory leaks from per-file dropdown instances).

The new design separates the **visible trigger** (the 3-dot `ContextButton`) from the **dropdown anchor** (a hidden button):

```
[file-row]  [ContextButton .file-menu-trigger]  ← user clicks this
...
[button .file-tree-menu-anchor]                 ← ember-basic-dropdown anchors to THIS
```

The anchor is styled to be invisible:

```css
.file-tree-menu-anchor {
  position: fixed;
  width: 0;
  height: 0;
  opacity: 0;
  pointer-events: none;
  /* ⚠️ no top / left set */
}
```

`ember-basic-dropdown` positions its content by calling `getBoundingClientRect()` on the trigger element. Since the anchor has no `top`/`left`, it sits at its natural DOM position. The dropdown **renders in the DOM but appears offscreen**, hidden behind other UI.

### Why direct DOM manipulation doesn't work

An obvious fix is to set the anchor's inline styles via `anchorEl.style.top = ...` before calling `open()`. However, calling `this.dropdownApi?.actions.open(e)` sets tracked state on the BasicDropdown component, which triggers a Glimmer re-render. During that re-render, Glimmer reconciles the anchor button's DOM attributes against the template — and since the template declares no `style` attribute on the anchor, Glimmer **strips the inline styles we just set**. By the time `ember-basic-dropdown` calls `reposition()` after render, the anchor is back at its default position.

## The Fix

Use a **`@tracked` property** for the anchor's style string so that Glimmer includes it in the re-render instead of removing it:

```typescript
@tracked private anchorStyle = '';
```

In the template, bind it to the anchor button:

```hbs
<button
  class='file-tree-menu-anchor'
  style={{this.anchorStyle}}
  {{bindings}}
></button>
```

In `openFileMenu`, set the tracked property before opening the dropdown:

```typescript
@action
private openFileMenu(entryPath: LocalPath, e: MouseEvent) {
  // ...
  this.menuEntryPath = entryPath;

  // ✅ Set via tracked property — survives Glimmer re-render
  const triggerRect = (e.currentTarget as HTMLElement).getBoundingClientRect();
  this.anchorStyle = `top: ${triggerRect.top}px; left: ${triggerRect.left}px; width: ${triggerRect.width}px; height: ${triggerRect.height}px;`;

  this.dropdownApi?.actions.open(e);
}
```

Now the re-render triggered by `open()` applies `anchorStyle` to the anchor, and when `ember-basic-dropdown` calls `getBoundingClientRect()` on the anchor after render, it gets the correct coordinates of the 3-dot button.

Reset `anchorStyle` when the menu closes:

```typescript
@action
private clearFileMenu() {
  this.menuEntryPath = undefined;
  this.anchorStyle = '';
}
```

## Auto-close Timer

The menu also auto-closes after **800 ms** if the user does not hover over it. Hovering pauses the timer; moving the mouse away restarts it.

```typescript
private startCloseMenuTimer() {
  clearTimeout(this.closeMenuTimer);
  this.closeMenuTimer = setTimeout(() => {
    this.dropdownApi?.actions.close();
  }, 800);
}

private cancelCloseMenuTimer() {
  clearTimeout(this.closeMenuTimer);
}
```

The timer starts when the menu opens and is wired to the menu content via `mouseenter`/`mouseleave`:

```hbs
<Menu
  {{on 'mouseenter' this.cancelCloseMenuTimer}}
  {{on 'mouseleave' this.startCloseMenuTimer}}
  ...
/>
```
