### PR TITLE
Introduce SpecResult to group test results by spec

### DIFF
--- a/packages/software-factory/docs/one-shot-factory-go-plan.md
+++ b/packages/software-factory/docs/one-shot-factory-go-plan.md
@@ -469,7 +469,10 @@ Helper module for managing test execution and results in the test realm.
 - `TestRunStatusField` — enum: running, passed, failed, error
 - `TestResultStatusField` — enum: pending, passed, failed, error
 - `TestResultEntry` (FieldDef) — testName, status, message, stackTrace, durationMs
-- `TestRun` (CardDef) — sequenceNumber, runAt, completedAt, ticket (linksTo), specRef (CodeRefField), status, passedCount, failedCount, durationMs, results (containsMany), errorMessage, title (computed)
+- `SpecResult` (FieldDef) — specRef (CodeRefField), results (containsMany TestResultEntry), passedCount (computed), failedCount (computed)
+- `TestRun` (CardDef) — sequenceNumber, runAt, completedAt, ticket (linksTo), status, passedCount (computed, rolled up from specResults), failedCount (computed, rolled up from specResults), durationMs, specResults (containsMany SpecResult), errorMessage, title (computed)
+
+A TestRun contains multiple SpecResults, each grouping test results under a spec reference. The specRef's `module` field identifies the spec file (e.g., the Playwright suite title). Counts on TestRun are aggregated across all SpecResults.
 
 #### Return Type
 

--- a/packages/software-factory/docs/software-factory-testing-strategy.md
+++ b/packages/software-factory/docs/software-factory-testing-strategy.md
@@ -57,10 +57,10 @@ Flow per ticket:
 
 1. agent implements the card or feature in the target realm
 2. agent generates test specs in the target realm (`Tests/<ticket-slug>.spec.ts`)
-3. `executeTestRunFromRealm` creates a TestRun card in the target realm (`Test Runs/<slug>-<seq>.json`) with `status: running`
+3. `executeTestRunFromRealm` creates a TestRun card in the target realm (`Test Runs/<slug>-<seq>.json`) with `status: running` and pre-populated `specResults` containing pending entries
 4. spec files are pulled from the target realm locally; Playwright runs them against the live target realm
 5. card instances created by specs during execution are written to the test artifacts realm (`Run <seq>/` folder) via `BOXEL_TEST_ARTIFACTS_FOLDER_URL`
-6. test results (all passing + failing) are parsed from the Playwright JSON report and written back to the TestRun card
+6. test results are parsed from the Playwright JSON report, grouped by spec (top-level Playwright suite) into `SpecResult` entries, and written back to the TestRun card's `specResults` field. Each SpecResult has a `specRef` (CodeRefField with `module` = suite title, `name` = "default") and its own `passedCount`/`failedCount` computeds. TestRun's `passedCount`/`failedCount` are rolled up across all SpecResults.
 7. if tests fail, the full test output (errors, stack traces) is available on the TestRun card and fed back to the agent
 8. agent iterates on implementation and/or tests until all tests pass
 9. passing TestRun cards serve as durable verification evidence for the ticket, linked to the Project card

--- a/packages/software-factory/playwright.config.ts
+++ b/packages/software-factory/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   testMatch: ['**/*.spec.ts'],
   fullyParallel: false,
   reporter: process.env.CI ? [['list']] : undefined,
-  workers: process.env.CI ? 2 : 3,
+  workers: 2,
   timeout: 300_000,
   expect: {
     timeout: 15_000,

--- a/packages/software-factory/realm/test-results.gts
+++ b/packages/software-factory/realm/test-results.gts
@@ -295,11 +295,10 @@ export class TestRun extends CardDef {
     }
 
     get failedResults() {
-      return (this.args.model.specResults ?? []).flatMap(
-        (sr) =>
-          (sr.results ?? []).filter(
-            (r) => r.status === 'failed' || r.status === 'error',
-          ),
+      return (this.args.model.specResults ?? []).flatMap((sr) =>
+        (sr.results ?? []).filter(
+          (r) => r.status === 'failed' || r.status === 'error',
+        ),
       );
     }
 

--- a/packages/software-factory/realm/test-results.gts
+++ b/packages/software-factory/realm/test-results.gts
@@ -333,7 +333,7 @@ export class TestRun extends CardDef {
           <section>
             <h2>Project</h2>
             <div class='linked-card'>
-              <@fields.project @format="fitted" />
+              <@fields.project @format="embedded" />
             </div>
           </section>
         {{/if}}
@@ -342,7 +342,7 @@ export class TestRun extends CardDef {
           <section>
             <h2>Ticket</h2>
             <div class='linked-card'>
-              <@fields.ticket @format="fitted" />
+              <@fields.ticket @format="embedded" />
             </div>
           </section>
         {{/if}}

--- a/packages/software-factory/realm/test-results.gts
+++ b/packages/software-factory/realm/test-results.gts
@@ -332,14 +332,18 @@ export class TestRun extends CardDef {
         {{#if @model.project}}
           <section>
             <h2>Project</h2>
-            <@fields.project @format="fitted" />
+            <div class='linked-card'>
+              <@fields.project @format="fitted" />
+            </div>
           </section>
         {{/if}}
 
         {{#if @model.ticket}}
           <section>
             <h2>Ticket</h2>
-            <@fields.ticket @format="fitted" />
+            <div class='linked-card'>
+              <@fields.ticket @format="fitted" />
+            </div>
           </section>
         {{/if}}
 
@@ -379,6 +383,12 @@ export class TestRun extends CardDef {
           padding: 1.5rem;
           display: grid;
           gap: 1rem;
+        }
+        .linked-card {
+          max-height: 5rem;
+          overflow: hidden;
+          border: 1px solid var(--boxel-200, #e5e7eb);
+          border-radius: 0.5rem;
         }
         .header-row {
           display: flex;

--- a/packages/software-factory/realm/test-results.gts
+++ b/packages/software-factory/realm/test-results.gts
@@ -102,6 +102,78 @@ export class TestResultEntry extends FieldDef {
   };
 }
 
+export class SpecResult extends FieldDef {
+  static displayName = 'Spec Result';
+
+  @field specRef = contains(CodeRefField);
+  @field results = containsMany(TestResultEntry);
+
+  @field passedCount = contains(NumberField, {
+    computeVia: function (this: SpecResult) {
+      return (this.results ?? []).filter((r) => r.status === 'passed').length;
+    },
+  });
+
+  @field failedCount = contains(NumberField, {
+    computeVia: function (this: SpecResult) {
+      return (this.results ?? []).filter(
+        (r) => r.status === 'failed' || r.status === 'error',
+      ).length;
+    },
+  });
+
+  get specName() {
+    return this.specRef?.module ?? 'default';
+  }
+
+  static embedded = class Embedded extends Component<typeof SpecResult> {
+    get total() {
+      return (
+        (this.args.model.passedCount ?? 0) + (this.args.model.failedCount ?? 0)
+      );
+    }
+
+    <template>
+      <div class='spec-result'>
+        <div class='spec-header'>
+          <span class='spec-name'>{{this.args.model.specName}}</span>
+          <span class='spec-counts'>
+            {{this.args.model.passedCount}}/{{this.total}}
+            passed
+          </span>
+        </div>
+        <div class='spec-entries'>
+          <@fields.results />
+        </div>
+      </div>
+      <style scoped>
+        .spec-result {
+          margin-bottom: 0.75rem;
+        }
+        .spec-header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          padding: 0.25rem 0;
+          border-bottom: 1px solid var(--boxel-200, #e5e7eb);
+          margin-bottom: 0.25rem;
+        }
+        .spec-name {
+          font-weight: 600;
+          font-size: 0.85rem;
+        }
+        .spec-counts {
+          font-size: 0.8rem;
+          color: var(--muted-foreground);
+        }
+        .spec-entries {
+          padding-left: 0.5rem;
+        }
+      </style>
+    </template>
+  };
+}
+
 export class TestRun extends CardDef {
   static displayName = 'Test Run';
 
@@ -110,23 +182,26 @@ export class TestRun extends CardDef {
   @field completedAt = contains(DateTimeField);
   @field project = linksTo(() => Project);
   @field ticket = linksTo(() => Ticket);
-  @field specRef = contains(CodeRefField);
   @field status = contains(TestRunStatusField);
   @field durationMs = contains(NumberField);
-  @field results = containsMany(TestResultEntry);
+  @field specResults = containsMany(SpecResult);
   @field errorMessage = contains(StringField);
 
   @field passedCount = contains(NumberField, {
     computeVia: function (this: TestRun) {
-      return (this.results ?? []).filter((r) => r.status === 'passed').length;
+      return (this.specResults ?? []).reduce(
+        (sum, sr) => sum + (sr.passedCount ?? 0),
+        0,
+      );
     },
   });
 
   @field failedCount = contains(NumberField, {
     computeVia: function (this: TestRun) {
-      return (this.results ?? []).filter(
-        (r) => r.status === 'failed' || r.status === 'error',
-      ).length;
+      return (this.specResults ?? []).reduce(
+        (sum, sr) => sum + (sr.failedCount ?? 0),
+        0,
+      );
     },
   });
 
@@ -220,8 +295,11 @@ export class TestRun extends CardDef {
     }
 
     get failedResults() {
-      return (this.args.model.results ?? []).filter(
-        (r) => r.status === 'failed' || r.status === 'error',
+      return (this.args.model.specResults ?? []).flatMap(
+        (sr) =>
+          (sr.results ?? []).filter(
+            (r) => r.status === 'failed' || r.status === 'error',
+          ),
       );
     }
 
@@ -258,13 +336,6 @@ export class TestRun extends CardDef {
           </section>
         {{/if}}
 
-        {{#if @model.specRef}}
-          <section>
-            <h2>Spec</h2>
-            <@fields.specRef />
-          </section>
-        {{/if}}
-
         {{#if @model.errorMessage}}
           <section>
             <h2>Error</h2>
@@ -289,10 +360,10 @@ export class TestRun extends CardDef {
           </section>
         {{/if}}
 
-        {{#if @model.results.length}}
+        {{#if @model.specResults.length}}
           <section>
-            <h2>All Results</h2>
-            <@fields.results />
+            <h2>Results by Spec</h2>
+            <@fields.specResults />
           </section>
         {{/if}}
       </article>

--- a/packages/software-factory/realm/test-results.gts
+++ b/packages/software-factory/realm/test-results.gts
@@ -385,10 +385,7 @@ export class TestRun extends CardDef {
           gap: 1rem;
         }
         .linked-card {
-          max-height: 5rem;
-          overflow: hidden;
-          border: 1px solid var(--boxel-200, #e5e7eb);
-          border-radius: 0.5rem;
+          margin-bottom: 0.5rem;
         }
         .header-row {
           display: flex;

--- a/packages/software-factory/realm/test-results.gts
+++ b/packages/software-factory/realm/test-results.gts
@@ -332,14 +332,14 @@ export class TestRun extends CardDef {
         {{#if @model.project}}
           <section>
             <h2>Project</h2>
-            <@fields.project />
+            <@fields.project @format="fitted" />
           </section>
         {{/if}}
 
         {{#if @model.ticket}}
           <section>
             <h2>Ticket</h2>
-            <@fields.ticket />
+            <@fields.ticket @format="fitted" />
           </section>
         {{/if}}
 
@@ -379,10 +379,6 @@ export class TestRun extends CardDef {
           padding: 1.5rem;
           display: grid;
           gap: 1rem;
-          overflow: hidden;
-        }
-        .surface > section {
-          overflow: hidden;
         }
         .header-row {
           display: flex;

--- a/packages/software-factory/realm/test-results.gts
+++ b/packages/software-factory/realm/test-results.gts
@@ -379,6 +379,10 @@ export class TestRun extends CardDef {
           padding: 1.5rem;
           display: grid;
           gap: 1rem;
+          overflow: hidden;
+        }
+        .surface > section {
+          overflow: hidden;
         }
         .header-row {
           display: flex;
@@ -433,6 +437,7 @@ export class TestRun extends CardDef {
           font-family: monospace;
           white-space: pre-wrap;
           overflow-x: auto;
+          max-width: 100%;
           margin: 0.25rem 0;
           color: var(--muted-foreground);
         }

--- a/packages/software-factory/realm/test-results.gts
+++ b/packages/software-factory/realm/test-results.gts
@@ -128,9 +128,7 @@ export class SpecResult extends FieldDef {
 
   static embedded = class Embedded extends Component<typeof SpecResult> {
     get total() {
-      return (
-        (this.args.model.passedCount ?? 0) + (this.args.model.failedCount ?? 0)
-      );
+      return this.args.model.results?.length ?? 0;
     }
 
     <template>

--- a/packages/software-factory/realm/test-results.gts
+++ b/packages/software-factory/realm/test-results.gts
@@ -131,14 +131,24 @@ export class SpecResult extends FieldDef {
       return this.args.model.results?.length ?? 0;
     }
 
+    get isComplete() {
+      return !(this.args.model.results ?? []).some(
+        (r) => r.status === 'pending',
+      );
+    }
+
     <template>
       <div class='spec-result'>
         <div class='spec-header'>
           <span class='spec-name'>{{this.args.model.specName}}</span>
-          <span class='spec-counts'>
-            {{this.args.model.passedCount}}/{{this.total}}
-            passed
-          </span>
+          {{#if this.isComplete}}
+            <span class='spec-counts'>
+              {{this.args.model.passedCount}}/{{this.total}}
+              passed
+            </span>
+          {{else}}
+            <span class='spec-counts'>running...</span>
+          {{/if}}
         </div>
         <div class='spec-entries'>
           <@fields.results />

--- a/packages/software-factory/realm/test-results.gts
+++ b/packages/software-factory/realm/test-results.gts
@@ -333,7 +333,7 @@ export class TestRun extends CardDef {
           <section>
             <h2>Project</h2>
             <div class='linked-card'>
-              <@fields.project @format="embedded" />
+              <@fields.project @format='embedded' />
             </div>
           </section>
         {{/if}}
@@ -342,7 +342,7 @@ export class TestRun extends CardDef {
           <section>
             <h2>Ticket</h2>
             <div class='linked-card'>
-              <@fields.ticket @format="embedded" />
+              <@fields.ticket @format='embedded' />
             </div>
           </section>
         {{/if}}

--- a/packages/software-factory/scripts/lib/factory-test-realm.ts
+++ b/packages/software-factory/scripts/lib/factory-test-realm.ts
@@ -14,6 +14,7 @@ export type {
   ExecuteTestRunOptions,
   RunRealmTestsFailure,
   RunRealmTestsOutput,
+  SpecResultData,
   TestResultEntryData,
   TestRunAttributes,
   TestRunHandle,

--- a/packages/software-factory/scripts/lib/realm-operations.ts
+++ b/packages/software-factory/scripts/lib/realm-operations.ts
@@ -352,6 +352,20 @@ export async function createRealm(
     if (body.includes('[object Object]')) {
       body = 'server returned a non-serialized object body';
     }
+
+    // When the realm already exists, ensure it's still registered in the
+    // user's Matrix account data so it appears in the Boxel dashboard.
+    if (body.includes('already exists')) {
+      let urlMatch = body.match(/'(https?:\/\/[^']+)'/);
+      if (urlMatch) {
+        await addRealmToMatrixAccountData(
+          options.matrixAuth,
+          ensureTrailingSlash(urlMatch[1]),
+          fetchImpl,
+        );
+      }
+    }
+
     return {
       realmUrl: '',
       created: false,

--- a/packages/software-factory/scripts/lib/test-run-cards.ts
+++ b/packages/software-factory/scripts/lib/test-run-cards.ts
@@ -59,16 +59,27 @@ export async function completeTestRun(
     fetch: options.fetch,
   };
 
-  let readResult = await readCardSource(
-    options.testRealmUrl,
-    testRunId,
-    fetchOptions,
-  );
+  // Retry the read — after a long spawnSync (Playwright), TCP connections
+  // may be stale causing the first fetch to fail with "fetch failed".
+  let readResult: Awaited<ReturnType<typeof readCardSource>> | undefined;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    readResult = await readCardSource(
+      options.testRealmUrl,
+      testRunId,
+      fetchOptions,
+    );
+    if (readResult.ok && readResult.document) {
+      break;
+    }
+    if (attempt < 2) {
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+  }
 
-  if (!readResult.ok || !readResult.document) {
+  if (!readResult?.ok || !readResult?.document) {
     return {
       updated: false,
-      error: `Failed to read TestRun: ${readResult.error}`,
+      error: `Failed to read TestRun: ${readResult?.error}`,
     };
   }
 

--- a/packages/software-factory/scripts/lib/test-run-cards.ts
+++ b/packages/software-factory/scripts/lib/test-run-cards.ts
@@ -3,6 +3,7 @@ import type { LooseSingleCardDocument } from '@cardstack/runtime-common';
 import { readCardSource, writeCardSource } from './realm-operations';
 import type {
   CreateTestRunOptions,
+  SpecResultData,
   TestResultEntryData,
   TestRunAttributes,
   TestRunRealmOptions,
@@ -75,7 +76,7 @@ export async function completeTestRun(
     status: attrs.status,
     completedAt: new Date().toISOString(),
     durationMs: attrs.durationMs,
-    results: attrs.results,
+    specResults: attrs.specResults,
   };
   if (attrs.errorMessage) {
     completionAttrs.errorMessage = attrs.errorMessage;
@@ -128,16 +129,19 @@ export function buildTestRunCardDocument(
     status: 'pending' as const,
   }));
 
+  let specResults: SpecResultData[] = [
+    {
+      ...(options?.specRef ? { specRef: options.specRef } : {}),
+      results,
+    },
+  ];
+
   let attributes: Record<string, unknown> = {
     sequenceNumber: options?.sequenceNumber ?? 1,
     runAt: new Date().toISOString(),
     status: 'running',
-    results,
+    specResults,
   };
-
-  if (options?.specRef) {
-    attributes.specRef = options.specRef;
-  }
 
   let relationships:
     | Record<string, { links: { self: string | null } }>

--- a/packages/software-factory/scripts/lib/test-run-execution.ts
+++ b/packages/software-factory/scripts/lib/test-run-execution.ts
@@ -248,7 +248,9 @@ async function findResumableTestRun(
         attributes?: {
           status?: string;
           sequenceNumber?: number;
-          results?: { testName?: string; status?: string }[];
+          specResults?: {
+            results?: { testName?: string; status?: string }[];
+          }[];
         };
       }
     | undefined;
@@ -257,7 +259,8 @@ async function findResumableTestRun(
     return undefined;
   }
 
-  let pendingTests = (latest.attributes.results ?? [])
+  let pendingTests = (latest.attributes.specResults ?? [])
+    .flatMap((sr) => sr.results ?? [])
     .filter((r) => r.status === 'pending')
     .map((r) => r.testName ?? '');
 
@@ -404,7 +407,7 @@ export async function executeTestRunFromRealm(
           passedCount: 0,
           failedCount: 0,
           errorMessage,
-          results: [],
+          specResults: [],
         },
         completeOptions,
       );
@@ -422,7 +425,7 @@ export async function executeTestRunFromRealm(
           passedCount: 0,
           failedCount: 0,
           errorMessage,
-          results: [],
+          specResults: [],
         },
         completeOptions,
       );
@@ -516,7 +519,7 @@ export async function executeTestRunFromRealm(
         durationMs,
         errorMessage:
           `Playwright exited with code ${testRunProcess.status ?? 'unknown'}. ${stderr}`.trim(),
-        results: [],
+        specResults: [],
       };
     }
 
@@ -542,7 +545,7 @@ export async function executeTestRunFromRealm(
           passedCount: 0,
           failedCount: 0,
           errorMessage,
-          results: [],
+          specResults: [],
         },
         completeOptions,
       );

--- a/packages/software-factory/scripts/lib/test-run-parsing.ts
+++ b/packages/software-factory/scripts/lib/test-run-parsing.ts
@@ -1,6 +1,7 @@
 import type { TestResult } from './factory-agent';
 import type {
   RunRealmTestsOutput,
+  SpecResultData,
   TestResultEntryData,
   TestRunAttributes,
 } from './test-run-types';
@@ -26,11 +27,11 @@ export function parseRunRealmTestsOutput(
   }
 
   // Build results from ALL tests (passing + failing), not just failures.
-  let results: TestResultEntryData[];
+  let specResults: SpecResultData[];
   if (playwrightReport.suites) {
-    results = extractAllPlaywrightResults(playwrightReport.suites);
+    specResults = extractGroupedPlaywrightResults(playwrightReport.suites);
   } else {
-    results = rawFailures.map((f) => {
+    let results: TestResultEntryData[] = rawFailures.map((f) => {
       let { message, stackTrace } = splitErrorAndStack(f.error);
       return {
         testName: f.title,
@@ -39,11 +40,13 @@ export function parseRunRealmTestsOutput(
         ...(stackTrace ? { stackTrace: stackTrace.slice(0, 500) } : {}),
       };
     });
+    specResults = results.length > 0 ? [{ results }] : [];
   }
 
+  let allResults = specResults.flatMap((sr) => sr.results);
   let hasFailures =
     unexpected > 0 ||
-    results.some((r) => r.status === 'failed' || r.status === 'error');
+    allResults.some((r) => r.status === 'failed' || r.status === 'error');
   let status: TestRunAttributes['status'] = hasFailures ? 'failed' : 'passed';
 
   // If no tests ran at all, check for Playwright-level errors (e.g. module not found).
@@ -61,7 +64,7 @@ export function parseRunRealmTestsOutput(
         failedCount: 0,
         durationMs,
         errorMessage: errorMessage || 'No tests found',
-        results: [],
+        specResults: [],
       };
     }
     status = 'error';
@@ -70,12 +73,12 @@ export function parseRunRealmTestsOutput(
   // When results include both passing and failing entries (Playwright format),
   // derive counts from results to match the card's computed fields.
   // For legacy format (failures only), use the stats counts.
-  let hasPassingResults = results.some((r) => r.status === 'passed');
+  let hasPassingResults = allResults.some((r) => r.status === 'passed');
   let passedCount = hasPassingResults
-    ? results.filter((r) => r.status === 'passed').length
+    ? allResults.filter((r) => r.status === 'passed').length
     : expected;
   let failedCount = hasPassingResults
-    ? results.filter((r) => r.status === 'failed' || r.status === 'error')
+    ? allResults.filter((r) => r.status === 'failed' || r.status === 'error')
         .length
     : unexpected;
 
@@ -84,7 +87,7 @@ export function parseRunRealmTestsOutput(
     passedCount,
     failedCount,
     durationMs,
-    results,
+    specResults,
   };
 }
 
@@ -96,6 +99,7 @@ interface PlaywrightJsonReport {
 }
 
 interface PlaywrightSuite {
+  title?: string;
   specs?: PlaywrightSpec[];
   suites?: PlaywrightSuite[];
 }
@@ -136,35 +140,44 @@ function extractPlaywrightFailures(
   return failures;
 }
 
-function extractAllPlaywrightResults(
-  suites: PlaywrightSuite[],
+function extractResultsFromSuite(
+  suite: PlaywrightSuite,
 ): TestResultEntryData[] {
   let results: TestResultEntryData[] = [];
-  for (let suite of suites) {
-    if (suite.suites) {
-      results.push(...extractAllPlaywrightResults(suite.suites));
-    }
-    for (let spec of suite.specs ?? []) {
-      let testResult = spec.tests?.[0]?.results?.[0];
-      let status: TestResultEntryData['status'] = spec.ok ? 'passed' : 'failed';
-      let entry: TestResultEntryData = {
-        testName: spec.title ?? 'unknown',
-        status,
-        durationMs: testResult?.duration,
-      };
-      if (!spec.ok && testResult?.errors?.[0]?.message) {
-        let { message, stackTrace } = splitErrorAndStack(
-          testResult.errors[0].message,
-        );
-        entry.message = message;
-        if (stackTrace) {
-          entry.stackTrace = stackTrace.slice(0, 500);
-        }
-      }
-      results.push(entry);
+  if (suite.suites) {
+    for (let nested of suite.suites) {
+      results.push(...extractResultsFromSuite(nested));
     }
   }
+  for (let spec of suite.specs ?? []) {
+    let testResult = spec.tests?.[0]?.results?.[0];
+    let status: TestResultEntryData['status'] = spec.ok ? 'passed' : 'failed';
+    let entry: TestResultEntryData = {
+      testName: spec.title ?? 'unknown',
+      status,
+      durationMs: testResult?.duration,
+    };
+    if (!spec.ok && testResult?.errors?.[0]?.message) {
+      let { message, stackTrace } = splitErrorAndStack(
+        testResult.errors[0].message,
+      );
+      entry.message = message;
+      if (stackTrace) {
+        entry.stackTrace = stackTrace.slice(0, 500);
+      }
+    }
+    results.push(entry);
+  }
   return results;
+}
+
+function extractGroupedPlaywrightResults(
+  suites: PlaywrightSuite[],
+): SpecResultData[] {
+  return suites.map((suite) => ({
+    specRef: { module: suite.title ?? 'default', name: 'default' },
+    results: extractResultsFromSuite(suite),
+  }));
 }
 
 /**
@@ -191,8 +204,16 @@ export function parseToolResultOutput(
         failedCount: 0,
         durationMs,
         errorMessage: errorMsg,
-        results: [
-          { testName: '(test harness)', status: 'error', message: errorMsg },
+        specResults: [
+          {
+            results: [
+              {
+                testName: '(test harness)',
+                status: 'error',
+                message: errorMsg,
+              },
+            ],
+          },
         ],
       };
     }
@@ -206,8 +227,12 @@ export function parseToolResultOutput(
         failedCount: 0,
         durationMs,
         errorMessage: msg,
-        results: [
-          { testName: '(test harness)', status: 'error', message: msg },
+        specResults: [
+          {
+            results: [
+              { testName: '(test harness)', status: 'error', message: msg },
+            ],
+          },
         ],
       };
     }
@@ -225,7 +250,13 @@ export function parseToolResultOutput(
     failedCount: 0,
     durationMs,
     errorMessage: msg,
-    results: [{ testName: '(test harness)', status: 'error', message: msg }],
+    specResults: [
+      {
+        results: [
+          { testName: '(test harness)', status: 'error', message: msg },
+        ],
+      },
+    ],
   };
 }
 

--- a/packages/software-factory/scripts/lib/test-run-parsing.ts
+++ b/packages/software-factory/scripts/lib/test-run-parsing.ts
@@ -171,6 +171,10 @@ function extractResultsFromSuite(
   return results;
 }
 
+// Maps each top-level Playwright suite to a SpecResult. With a single unnamed
+// project (our playwright.realm.config.ts), top-level suites correspond to
+// spec files. Multi-project configs add a project wrapper layer — revisit
+// if named projects are introduced.
 function extractGroupedPlaywrightResults(
   suites: PlaywrightSuite[],
 ): SpecResultData[] {

--- a/packages/software-factory/scripts/lib/test-run-parsing.ts
+++ b/packages/software-factory/scripts/lib/test-run-parsing.ts
@@ -290,18 +290,27 @@ export function formatTestResultSummary(result: TestResult): string {
 }
 
 /**
+ * Strip ANSI escape codes (terminal color sequences) from a string.
+ */
+function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+/**
  * Split a combined error string into message and optional stack trace.
  */
 function splitErrorAndStack(error: string): {
   message: string;
   stackTrace?: string;
 } {
-  let atIndex = error.search(/\n\s+at /);
+  let clean = stripAnsi(error);
+  let atIndex = clean.search(/\n\s+at /);
   if (atIndex === -1) {
-    return { message: error.trim() };
+    return { message: clean.trim() };
   }
   return {
-    message: error.slice(0, atIndex).trim(),
-    stackTrace: error.slice(atIndex + 1).trim(),
+    message: clean.slice(0, atIndex).trim(),
+    stackTrace: clean.slice(atIndex + 1).trim(),
   };
 }

--- a/packages/software-factory/scripts/lib/test-run-types.ts
+++ b/packages/software-factory/scripts/lib/test-run-types.ts
@@ -71,7 +71,7 @@ export interface TestRunAttributes {
   failedCount: number;
   durationMs?: number;
   errorMessage?: string;
-  results: TestResultEntryData[];
+  specResults: SpecResultData[];
 }
 
 /** Shape of a single test result entry within a TestRun card. */
@@ -81,6 +81,12 @@ export interface TestResultEntryData {
   message?: string;
   stackTrace?: string;
   durationMs?: number;
+}
+
+/** Shape of a spec result group within a TestRun card. */
+export interface SpecResultData {
+  specRef?: ResolvedCodeRef;
+  results: TestResultEntryData[];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/software-factory/scripts/lib/test-run-types.ts
+++ b/packages/software-factory/scripts/lib/test-run-types.ts
@@ -59,8 +59,8 @@ export interface TestRunHandle {
  * TestRun card definition in test-results.gts.
  *
  * Note: `passedCount` and `failedCount` are computed fields on the card
- * (derived from `results`), but are included here for convenience when
- * building card documents and in test assertions.
+ * (derived from `specResults[].results`), but are included here for
+ * convenience when building card documents and in test assertions.
  */
 export interface TestRunAttributes {
   sequenceNumber?: number;

--- a/packages/software-factory/src/cli/smoke-test-realm.ts
+++ b/packages/software-factory/src/cli/smoke-test-realm.ts
@@ -263,9 +263,10 @@ async function main() {
 
   console.log('--- Phase 0: Ensuring target realm exists ---\n');
 
+  let realmDisplayName = realmEndpoint.replace(/-/g, ' ');
   console.log(`  Creating realm: ${realmEndpoint}...`);
   let createResult = await createRealm(realmServerUrl, {
-    name: 'Smoke Test Realm',
+    name: realmDisplayName,
     endpoint: realmEndpoint,
     authorization: authorization ?? '',
     matrixAuth: {
@@ -392,9 +393,7 @@ async function main() {
   // Phase 2: Run both specs in a single TestRun
   // -------------------------------------------------------------------------
 
-  console.log(
-    '\n--- Phase 2: Running both specs in a single TestRun ---\n',
-  );
+  console.log('\n--- Phase 2: Running both specs in a single TestRun ---\n');
 
   let matrixAuthForRealm = {
     userId: matrixAuth.userId,
@@ -406,10 +405,7 @@ async function main() {
     targetRealmUrl,
     testResultsModuleUrl,
     slug: 'hello-smoke',
-    specPaths: [
-      'Tests/hello-smoke.spec.ts',
-      'Tests/hello-failing.spec.ts',
-    ],
+    specPaths: ['Tests/hello-smoke.spec.ts', 'Tests/hello-failing.spec.ts'],
     testNames: [
       'hello card renders greeting',
       'hello card has wrong greeting (deliberately fails)',
@@ -427,9 +423,9 @@ async function main() {
   if (handle.errorMessage) {
     console.log(`  Error:       ${handle.errorMessage}`);
   }
-  if ((handle as Record<string, unknown>).error) {
+  if ((handle as unknown as Record<string, unknown>).error) {
     console.log(
-      `  Complete error: ${(handle as Record<string, unknown>).error}`,
+      `  Complete error: ${(handle as unknown as Record<string, unknown>).error}`,
     );
   }
 

--- a/packages/software-factory/src/cli/smoke-test-realm.ts
+++ b/packages/software-factory/src/cli/smoke-test-realm.ts
@@ -10,13 +10,16 @@
  *   2. A Spec card instance pointing to the HelloCard definition
  *   3. A Playwright test spec in the Tests/ folder
  *
- * Phase 2 — Run the testing phase:
- *   Calls executeTestRunFromRealm which:
+ * Phase 2 — Run the testing phase (both specs in a single TestRun):
+ *   Calls executeTestRunFromRealm with both spec paths, which:
  *   - Creates a TestRun card (status: running) in the target realm's Test Runs/ folder
  *   - Pulls spec files from the target realm locally (Playwright needs local .spec.ts files)
- *   - Runs the Playwright spec against the live target realm (no local harness)
+ *   - Runs both Playwright specs against the live target realm (no local harness)
  *   - Any card instances created during spec execution land in the test artifacts realm
- *   - Completes the TestRun card with pass/fail results
+ *   - Completes the TestRun card with SpecResults grouped by spec file
+ *   - The passing spec produces a SpecResult with passedCount=1
+ *   - The failing spec produces a SpecResult with failedCount=1
+ *   - The overall TestRun status is 'failed' (mixed results)
  *
  * Prerequisites:
  *
@@ -386,10 +389,12 @@ async function main() {
   );
 
   // -------------------------------------------------------------------------
-  // Phase 2a: Run a passing test
+  // Phase 2: Run both specs in a single TestRun
   // -------------------------------------------------------------------------
 
-  console.log('\n--- Phase 2a: Running passing spec ---\n');
+  console.log(
+    '\n--- Phase 2: Running both specs in a single TestRun ---\n',
+  );
 
   let matrixAuthForRealm = {
     userId: matrixAuth.userId,
@@ -397,48 +402,35 @@ async function main() {
     matrixUrl: matrixAuth.credentials.matrixUrl,
   };
 
-  let passHandle = await executeTestRunFromRealm({
+  let handle = await executeTestRunFromRealm({
     targetRealmUrl,
     testResultsModuleUrl,
     slug: 'hello-smoke',
-    specPaths: ['Tests/hello-smoke.spec.ts'],
-    testNames: ['hello card renders greeting'],
+    specPaths: [
+      'Tests/hello-smoke.spec.ts',
+      'Tests/hello-failing.spec.ts',
+    ],
+    testNames: [
+      'hello card renders greeting',
+      'hello card has wrong greeting (deliberately fails)',
+    ],
     authorization,
     fetch: fetchImpl,
+    forceNew: true,
     projectCardUrl,
     matrixAuth: matrixAuthForRealm,
     serverToken,
   });
 
-  console.log(`  TestRun ID:  ${passHandle.testRunId}`);
-  console.log(`  Status:      ${passHandle.status}`);
-  if (passHandle.errorMessage) {
-    console.log(`  Error:       ${passHandle.errorMessage}`);
+  console.log(`  TestRun ID:  ${handle.testRunId}`);
+  console.log(`  Status:      ${handle.status}`);
+  if (handle.errorMessage) {
+    console.log(`  Error:       ${handle.errorMessage}`);
   }
-
-  // -------------------------------------------------------------------------
-  // Phase 2b: Run a deliberately failing test
-  // -------------------------------------------------------------------------
-
-  console.log('\n--- Phase 2b: Running failing spec (expected to fail) ---\n');
-
-  let failHandle = await executeTestRunFromRealm({
-    targetRealmUrl,
-    testResultsModuleUrl,
-    slug: 'hello-fail',
-    specPaths: ['Tests/hello-failing.spec.ts'],
-    testNames: ['hello card shows wrong greeting (deliberately fails)'],
-    authorization,
-    fetch: fetchImpl,
-    projectCardUrl,
-    matrixAuth: matrixAuthForRealm,
-    serverToken,
-  });
-
-  console.log(`  TestRun ID:  ${failHandle.testRunId}`);
-  console.log(`  Status:      ${failHandle.status}`);
-  if (failHandle.errorMessage) {
-    console.log(`  Error:       ${failHandle.errorMessage}`);
+  if ((handle as Record<string, unknown>).error) {
+    console.log(
+      `  Complete error: ${(handle as Record<string, unknown>).error}`,
+    );
   }
 
   // -------------------------------------------------------------------------
@@ -447,34 +439,25 @@ async function main() {
 
   console.log('\n--- Results ---\n');
 
-  let passOk = passHandle.status === 'passed';
-  let failOk = failHandle.status === 'failed';
+  // The TestRun should have status 'failed' because it contains both a
+  // passing and a deliberately failing spec. The SpecResults inside should
+  // show one spec passed and one spec failed.
+  let expectedStatus = handle.status === 'failed';
 
   console.log(
-    `  Passing spec: ${passOk ? '✓ passed' : `✗ ${passHandle.status}`}`,
+    `  TestRun status: ${expectedStatus ? '✓ failed (as expected — one spec passes, one fails)' : `✗ expected failed, got ${handle.status}`}`,
   );
-  console.log(
-    `  Failing spec: ${failOk ? '✓ correctly reported as failed' : `✗ expected failed, got ${failHandle.status}`}`,
-  );
-  console.log(`\n  View in Boxel: ${targetRealmUrl}${passHandle.testRunId}`);
-  console.log(`  View in Boxel: ${targetRealmUrl}${failHandle.testRunId}`);
+  console.log(`\n  View in Boxel: ${targetRealmUrl}${handle.testRunId}`);
 
-  if (passOk && failOk) {
+  if (expectedStatus) {
     console.log(
-      '\n✓ Smoke test passed! Both pass and fail paths work correctly.',
+      '\n✓ Smoke test passed! Single TestRun contains both pass and fail spec results.',
     );
   } else {
     console.log('\n✗ Smoke test had unexpected results.');
-    if (!passOk) {
-      console.log(
-        `  Passing spec should be "passed" but was "${passHandle.status}"`,
-      );
-    }
-    if (!failOk) {
-      console.log(
-        `  Failing spec should be "failed" but was "${failHandle.status}"`,
-      );
-    }
+    console.log(
+      `  Expected "failed" (mixed pass/fail specs) but got "${handle.status}"`,
+    );
     process.exit(1);
   }
 }

--- a/packages/software-factory/src/harness/shared.ts
+++ b/packages/software-factory/src/harness/shared.ts
@@ -18,9 +18,10 @@ import { logger } from '../logger';
 // that sets HOST_URL=http://localhost:4200) would be inherited by child
 // processes that don't explicitly override it, causing them to talk to
 // a different Matrix/realm server than the hermetic test infrastructure.
-if (process.env.NODE_ENV === 'test') {
-  delete process.env.HOST_URL;
-}
+// This module is only imported by harness code (test infrastructure),
+// so it's safe to strip unconditionally — NODE_ENV may be 'test' or
+// 'development' depending on how the harness is invoked.
+delete process.env.HOST_URL;
 
 export type RealmAction = 'read' | 'write' | 'realm-owner' | 'assume-user';
 

--- a/packages/software-factory/src/harness/shared.ts
+++ b/packages/software-factory/src/harness/shared.ts
@@ -18,7 +18,9 @@ import { logger } from '../logger';
 // that sets HOST_URL=http://localhost:4200) would be inherited by child
 // processes that don't explicitly override it, causing them to talk to
 // a different Matrix/realm server than the hermetic test infrastructure.
-delete process.env.HOST_URL;
+if (process.env.NODE_ENV === 'test') {
+  delete process.env.HOST_URL;
+}
 
 export type RealmAction = 'read' | 'write' | 'realm-owner' | 'assume-user';
 

--- a/packages/software-factory/src/harness/shared.ts
+++ b/packages/software-factory/src/harness/shared.ts
@@ -12,6 +12,14 @@ import jwt from 'jsonwebtoken';
 import '../setup-logger';
 import { logger } from '../logger';
 
+// Strip ambient env vars that could break the hermetic test seal.
+// The harness always sets HOST_URL explicitly via context.hostURL when
+// spawning child processes — an ambient HOST_URL (e.g. from a dev shell
+// that sets HOST_URL=http://localhost:4200) would be inherited by child
+// processes that don't explicitly override it, causing them to talk to
+// a different Matrix/realm server than the hermetic test infrastructure.
+delete process.env.HOST_URL;
+
 export type RealmAction = 'read' | 'write' | 'realm-owner' | 'assume-user';
 
 export type RealmPermissions = Record<string, RealmAction[]>;

--- a/packages/software-factory/tests/factory-test-realm.test.ts
+++ b/packages/software-factory/tests/factory-test-realm.test.ts
@@ -42,7 +42,7 @@ module('factory-test-realm > parseRunRealmTestsOutput', function () {
     assert.strictEqual(attrs.status, 'passed');
     assert.strictEqual(attrs.passedCount, 3);
     assert.strictEqual(attrs.failedCount, 0);
-    assert.strictEqual(attrs.results.length, 0);
+    assert.strictEqual(attrs.specResults.length, 0);
     assert.strictEqual(attrs.durationMs, 1500);
   });
 
@@ -64,17 +64,18 @@ module('factory-test-realm > parseRunRealmTestsOutput', function () {
     assert.strictEqual(attrs.status, 'failed');
     assert.strictEqual(attrs.passedCount, 2);
     assert.strictEqual(attrs.failedCount, 1);
-    assert.strictEqual(attrs.results.length, 1);
+    assert.strictEqual(attrs.specResults.length, 1);
+    assert.strictEqual(attrs.specResults[0].results.length, 1);
     assert.strictEqual(
-      attrs.results[0].testName,
+      attrs.specResults[0].results[0].testName,
       'sticky-note > renders fitted view',
     );
-    assert.strictEqual(attrs.results[0].status, 'failed');
+    assert.strictEqual(attrs.specResults[0].results[0].status, 'failed');
     assert.strictEqual(
-      attrs.results[0].message,
+      attrs.specResults[0].results[0].message,
       'Expected element to be visible',
     );
-    assert.strictEqual(attrs.results[0].stackTrace, undefined);
+    assert.strictEqual(attrs.specResults[0].results[0].stackTrace, undefined);
   });
 
   test('splits error message from stack trace', function (assert) {
@@ -93,8 +94,15 @@ module('factory-test-realm > parseRunRealmTestsOutput', function () {
 
     let attrs = parseRunRealmTestsOutput(output, 800);
 
-    assert.strictEqual(attrs.results[0].message, 'Expect received to be true');
-    assert.true(attrs.results[0].stackTrace?.includes('Object.<anonymous>'));
+    assert.strictEqual(
+      attrs.specResults[0].results[0].message,
+      'Expect received to be true',
+    );
+    assert.true(
+      attrs.specResults[0].results[0].stackTrace?.includes(
+        'Object.<anonymous>',
+      ),
+    );
   });
 
   test('returns error status for empty output', function (assert) {
@@ -128,9 +136,10 @@ module('factory-test-realm > parseRunRealmTestsOutput', function () {
 
     let attrs = parseRunRealmTestsOutput(output, 2000);
 
-    assert.strictEqual(attrs.results.length, 3);
-    assert.strictEqual(attrs.results[0].testName, 'test A');
-    assert.strictEqual(attrs.results[2].testName, 'test C');
+    assert.strictEqual(attrs.specResults.length, 1);
+    assert.strictEqual(attrs.specResults[0].results.length, 3);
+    assert.strictEqual(attrs.specResults[0].results[0].testName, 'test A');
+    assert.strictEqual(attrs.specResults[0].results[2].testName, 'test C');
   });
 
   test('truncates stack traces to 500 chars', function (assert) {
@@ -142,7 +151,9 @@ module('factory-test-realm > parseRunRealmTestsOutput', function () {
     };
 
     let attrs = parseRunRealmTestsOutput(output, 100);
-    assert.true((attrs.results[0].stackTrace?.length ?? 0) <= 500);
+    assert.true(
+      (attrs.specResults[0].results[0].stackTrace?.length ?? 0) <= 500,
+    );
   });
 
   test('parses Playwright JSON report with passing tests into results', function (assert) {
@@ -169,15 +180,14 @@ module('factory-test-realm > parseRunRealmTestsOutput', function () {
     let attrs = parseRunRealmTestsOutput(report, 2500);
 
     assert.strictEqual(attrs.status, 'passed');
-    assert.strictEqual(attrs.results.length, 2);
-    assert.strictEqual(
-      attrs.results[0].testName,
-      'hello card renders greeting',
-    );
-    assert.strictEqual(attrs.results[0].status, 'passed');
-    assert.strictEqual(attrs.results[0].durationMs, 1200);
-    assert.strictEqual(attrs.results[1].testName, 'hello card shows title');
-    assert.strictEqual(attrs.results[1].status, 'passed');
+    assert.strictEqual(attrs.specResults.length, 1);
+    let results = attrs.specResults[0].results;
+    assert.strictEqual(results.length, 2);
+    assert.strictEqual(results[0].testName, 'hello card renders greeting');
+    assert.strictEqual(results[0].status, 'passed');
+    assert.strictEqual(results[0].durationMs, 1200);
+    assert.strictEqual(results[1].testName, 'hello card shows title');
+    assert.strictEqual(results[1].status, 'passed');
     assert.strictEqual(attrs.passedCount, 2);
     assert.strictEqual(attrs.failedCount, 0);
   });
@@ -216,10 +226,12 @@ module('factory-test-realm > parseRunRealmTestsOutput', function () {
     let attrs = parseRunRealmTestsOutput(report, 1000);
 
     assert.strictEqual(attrs.status, 'failed');
-    assert.strictEqual(attrs.results.length, 2);
-    assert.strictEqual(attrs.results[0].status, 'passed');
-    assert.strictEqual(attrs.results[1].status, 'failed');
-    assert.strictEqual(attrs.results[1].message, 'Expected true to be false');
+    assert.strictEqual(attrs.specResults.length, 1);
+    let results = attrs.specResults[0].results;
+    assert.strictEqual(results.length, 2);
+    assert.strictEqual(results[0].status, 'passed');
+    assert.strictEqual(results[1].status, 'failed');
+    assert.strictEqual(results[1].message, 'Expected true to be false');
     assert.strictEqual(attrs.passedCount, 1);
     assert.strictEqual(attrs.failedCount, 1);
   });
@@ -246,9 +258,11 @@ module('factory-test-realm > parseRunRealmTestsOutput', function () {
 
     let attrs = parseRunRealmTestsOutput(report, 200);
 
-    assert.strictEqual(attrs.results.length, 1);
-    assert.strictEqual(attrs.results[0].testName, 'nested test');
-    assert.strictEqual(attrs.results[0].status, 'passed');
+    assert.strictEqual(attrs.specResults.length, 1);
+    let results = attrs.specResults[0].results;
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual(results[0].testName, 'nested test');
+    assert.strictEqual(results[0].status, 'passed');
   });
 });
 
@@ -271,7 +285,7 @@ module('factory-test-realm > parseToolResultOutput', function () {
 
     assert.strictEqual(attrs.status, 'error');
     assert.true(attrs.errorMessage?.includes('HTTP 500'));
-    assert.strictEqual(attrs.results[0].status, 'error');
+    assert.strictEqual(attrs.specResults[0].results[0].status, 'error');
   });
 
   test('handles unparseable raw output', function (assert) {
@@ -317,16 +331,17 @@ module('factory-test-realm > buildTestRunCardDocument', function () {
     assert.strictEqual(adoptsFrom.name, 'TestRun');
   });
 
-  test('pre-populates results as pending', function (assert) {
+  test('pre-populates specResults with pending entries', function (assert) {
     let doc = buildTestRunCardDocument(
       ['test A', 'test B', 'test C'],
       testRealmOptions.testResultsModuleUrl,
     );
 
-    let results = doc.data.attributes!.results as {
-      testName: string;
-      status: string;
+    let specResults = doc.data.attributes!.specResults as {
+      results: { testName: string; status: string }[];
     }[];
+    assert.strictEqual(specResults.length, 1);
+    let results = specResults[0].results;
     assert.strictEqual(results.length, 3);
     assert.strictEqual(results[0].testName, 'test A');
     assert.strictEqual(results[0].status, 'pending');
@@ -420,19 +435,20 @@ module('factory-test-realm > buildTestRunCardDocument', function () {
     assert.strictEqual(doc.data.relationships, undefined);
   });
 
-  test('includes specRef when provided', function (assert) {
+  test('includes specRef in specResults when provided', function (assert) {
     let doc = buildTestRunCardDocument(
       ['test A'],
       testRealmOptions.testResultsModuleUrl,
       { specRef: { module: './test-spec', name: 'default' } },
     );
 
-    let specRef = doc.data.attributes!.specRef as {
-      module: string;
-      name: string;
-    };
-    assert.strictEqual(specRef.module, './test-spec');
-    assert.strictEqual(specRef.name, 'default');
+    let specResults = doc.data.attributes!.specResults as {
+      specRef?: { module: string; name: string };
+      results: unknown[];
+    }[];
+    assert.strictEqual(specResults.length, 1);
+    assert.strictEqual(specResults[0].specRef?.module, './test-spec');
+    assert.strictEqual(specResults[0].specRef?.name, 'default');
   });
 });
 
@@ -527,7 +543,7 @@ module('factory-test-realm > completeTestRun', function () {
           sequenceNumber: 1,
           passedCount: 0,
           failedCount: 0,
-          results: [],
+          specResults: [],
         },
         meta: {
           adoptsFrom: {
@@ -560,7 +576,7 @@ module('factory-test-realm > completeTestRun', function () {
       passedCount: 3,
       failedCount: 0,
       durationMs: 1500,
-      results: [],
+      specResults: [],
     };
 
     let result = await completeTestRun(
@@ -586,7 +602,7 @@ module('factory-test-realm > completeTestRun', function () {
       passedCount: 1,
       failedCount: 0,
       durationMs: 100,
-      results: [],
+      specResults: [],
     };
 
     let result = await completeTestRun('Test Runs/missing-1', attrs, {
@@ -609,7 +625,9 @@ module('factory-test-realm > resolveTestRun', function () {
       id: string;
       status: string;
       sequenceNumber: number;
-      results?: { testName: string; status: string }[];
+      specResults?: {
+        results?: { testName: string; status: string }[];
+      }[];
     }[],
   ) {
     return (async (url: string | URL | Request, init?: RequestInit) => {
@@ -626,7 +644,7 @@ module('factory-test-realm > resolveTestRun', function () {
               attributes: {
                 status: tr.status,
                 sequenceNumber: tr.sequenceNumber,
-                results: tr.results ?? [],
+                specResults: tr.specResults ?? [],
               },
             })),
           }),
@@ -688,9 +706,13 @@ module('factory-test-realm > resolveTestRun', function () {
           id: 'Test Runs/my-ticket-2',
           status: 'running',
           sequenceNumber: 2,
-          results: [
-            { testName: 'test A', status: 'passed' },
-            { testName: 'test B', status: 'pending' },
+          specResults: [
+            {
+              results: [
+                { testName: 'test A', status: 'passed' },
+                { testName: 'test B', status: 'pending' },
+              ],
+            },
           ],
         },
       ]),

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -106,7 +106,7 @@ function killProcessGroup(pid: number, signal: NodeJS.Signals) {
 
 async function waitForPortFree(
   port: number,
-  timeoutMs = 10_000,
+  timeoutMs = 30_000,
 ): Promise<void> {
   let startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {


### PR DESCRIPTION
## Summary

- Introduce `SpecResult` FieldDef as an intermediate layer between `TestRun` and `TestResultEntry`, grouping test results by spec file
- `TestRun.specResults` replaces `TestRun.results` + `TestRun.specRef` — each `SpecResult` has its own `specRef` (CodeRefField) and `results` (containsMany TestResultEntry)
- `TestRun.passedCount` / `failedCount` are now computed roll-ups across all SpecResults
- Playwright top-level suites are mapped to individual SpecResult entries during parsing
- Strip ambient `HOST_URL` from `process.env` in the test harness to prevent shell env vars from breaking the hermetic test seal

<img width="1458" height="1374" alt="image" src="https://github.com/user-attachments/assets/ab84e15c-93f3-4ef7-aa33-f3f01364281a" />


## Try it out

### Prerequisites

- `mise run dev-all` running
- PR [#4265](https://github.com/cardstack/boxel/pull/4265) merged or its branch checked out

### Run the smoke test

```bash
cd packages/software-factory

MATRIX_URL=http://localhost:8008 \
MATRIX_USERNAME=your-username \
MATRIX_PASSWORD=your-password \
pnpm smoke:test-realm -- \
  --target-realm-url http://localhost:4201/your-username/smoke-test-realm/
```

### What to expect for TestRun artifacts

After the smoke test completes, navigate to your `smoke-test-realm` workspace in the Boxel app:

1. **`Test Runs/` folder** — contains TestRun cards like `hello-smoke-1` and `hello-fail-1`
2. **Fitted view** of a TestRun shows: `#1` sequence number, status badge (passed/failed), aggregated pass/fail counts across all specs, and duration
3. **Isolated view** of a TestRun now shows results **organized by spec**:
   - Each spec appears as a section header with its name (from `specRef.module` — the Playwright suite title / spec file path) and its own pass/total count
   - Individual test results are listed under their spec with status icons, test names, and durations
   - Failures section still shows a flat list of all failures across specs with error messages and stack traces
4. **Test artifacts realm** — card instances created during spec execution (test data) land in a separate auto-created realm (`{ProjectName} Test Artifacts`), keeping test data separate from implementation artifacts

### Card structure

```
TestRun
├── sequenceNumber, status, runAt, completedAt, durationMs
├── passedCount (computed: sum of specResults[].passedCount)
├── failedCount (computed: sum of specResults[].failedCount)
└── specResults: SpecResult[]
    ├── specRef: CodeRefField { module: "Tests/hello-smoke.spec.ts", name: "default" }
    ├── passedCount (computed from results)
    ├── failedCount (computed from results)
    └── results: TestResultEntry[]
        ├── testName, status, message, stackTrace, durationMs
        └── ...
```

## Test plan

- [x] `pnpm test:node` — 321/321 unit tests pass
- [x] `pnpm test:playwright` — 14/14 Playwright tests pass (including `HOST_URL` sanitization fix)
- [x] `npx tsc --noEmit` — no type errors in software-factory files

🤖 Generated with [Claude Code](https://claude.com/claude-code)