### PR TITLE
Add 'in' filter operator to card query language

### DIFF
--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -740,6 +740,174 @@ module('Unit | query', function (hooks) {
     );
   });
 
+  test(`can filter using 'in'`, async function (assert) {
+    let { mango, vangogh, ringo } = testCards;
+    await setupIndex(dbAdapter, [
+      { card: mango, data: { search_doc: { name: 'Mango' } } },
+      { card: vangogh, data: { search_doc: { name: 'Van Gogh' } } },
+      { card: ringo, data: { search_doc: { name: 'Ringo' } } },
+    ]);
+
+    let type = await personCardType(testCards);
+    let { cards: results, meta } = await indexQueryEngine.searchCards(
+      new URL(testRealmURL),
+      {
+        filter: {
+          in: { name: ['Mango', 'Ringo'] },
+          on: type,
+        },
+      },
+    );
+
+    assert.strictEqual(meta.page.total, 2, 'the total results meta is correct');
+    assert.deepEqual(
+      getIds(results),
+      [mango.id, ringo.id],
+      'results are correct',
+    );
+  });
+
+  test(`can filter using 'in' with a single value`, async function (assert) {
+    let { mango, vangogh } = testCards;
+    await setupIndex(dbAdapter, [
+      { card: mango, data: { search_doc: { name: 'Mango' } } },
+      { card: vangogh, data: { search_doc: { name: 'Van Gogh' } } },
+    ]);
+
+    let type = await personCardType(testCards);
+    let { cards: results, meta } = await indexQueryEngine.searchCards(
+      new URL(testRealmURL),
+      {
+        filter: {
+          in: { name: ['Mango'] },
+          on: type,
+        },
+      },
+    );
+
+    assert.strictEqual(meta.page.total, 1, 'the total results meta is correct');
+    assert.deepEqual(getIds(results), [mango.id], 'results are correct');
+  });
+
+  test(`can filter using 'in' with an empty array`, async function (assert) {
+    let { mango, vangogh } = testCards;
+    await setupIndex(dbAdapter, [
+      { card: mango, data: { search_doc: { name: 'Mango' } } },
+      { card: vangogh, data: { search_doc: { name: 'Van Gogh' } } },
+    ]);
+
+    let type = await personCardType(testCards);
+    let { cards: results, meta } = await indexQueryEngine.searchCards(
+      new URL(testRealmURL),
+      {
+        filter: {
+          in: { name: [] },
+          on: type,
+        },
+      },
+    );
+
+    assert.strictEqual(meta.page.total, 0, 'the total results meta is correct');
+    assert.deepEqual(getIds(results), [], 'results are correct');
+  });
+
+  test(`can filter using 'in' with null values`, async function (assert) {
+    let { mango, vangogh, ringo } = testCards;
+    await setupIndex(dbAdapter, [
+      { card: mango, data: { search_doc: { name: 'Mango' } } },
+      { card: vangogh, data: { search_doc: { name: null } } },
+      { card: ringo, data: { search_doc: { name: 'Ringo' } } },
+    ]);
+
+    let type = await personCardType(testCards);
+    let { cards: results, meta } = await indexQueryEngine.searchCards(
+      new URL(testRealmURL),
+      {
+        filter: {
+          in: { name: ['Mango', null] },
+          on: type,
+        },
+      },
+    );
+
+    assert.strictEqual(meta.page.total, 2, 'the total results meta is correct');
+    assert.deepEqual(
+      getIds(results),
+      [mango.id, vangogh.id],
+      'results are correct',
+    );
+  });
+
+  test(`can filter using 'in' thru nested fields`, async function (assert) {
+    let { mango, vangogh, ringo } = testCards;
+    await setupIndex(dbAdapter, [
+      {
+        card: mango,
+        data: {
+          search_doc: {
+            name: 'Mango',
+            address: { city: 'Barksville' },
+          },
+        },
+      },
+      {
+        card: vangogh,
+        data: {
+          search_doc: {
+            name: 'Van Gogh',
+            address: { city: 'Barksville' },
+          },
+        },
+      },
+      {
+        card: ringo,
+        data: {
+          search_doc: {
+            name: 'Ringo',
+            address: { city: 'Waggington' },
+          },
+        },
+      },
+    ]);
+
+    let type = await personCardType(testCards);
+    let { cards: results, meta } = await indexQueryEngine.searchCards(
+      new URL(testRealmURL),
+      {
+        filter: {
+          on: type,
+          in: { 'address.city': ['Waggington'] },
+        },
+      },
+    );
+
+    assert.strictEqual(meta.page.total, 1, 'the total results meta is correct');
+    assert.deepEqual(getIds(results), [ringo.id], 'results are correct');
+  });
+
+  test(`can negate an 'in' filter with 'not'`, async function (assert) {
+    let { mango, vangogh, ringo } = testCards;
+    await setupIndex(dbAdapter, [
+      { card: mango, data: { search_doc: { name: 'Mango' } } },
+      { card: vangogh, data: { search_doc: { name: 'Van Gogh' } } },
+      { card: ringo, data: { search_doc: { name: 'Ringo' } } },
+    ]);
+
+    let type = await personCardType(testCards);
+    let { cards: results, meta } = await indexQueryEngine.searchCards(
+      new URL(testRealmURL),
+      {
+        filter: {
+          on: type,
+          not: { in: { name: ['Mango', 'Ringo'] } },
+        },
+      },
+    );
+
+    assert.strictEqual(meta.page.total, 1, 'the total results meta is correct');
+    assert.deepEqual(getIds(results), [vangogh.id], 'results are correct');
+  });
+
   test(`can search with a 'not' filter`, async function (assert) {
     let { mango, vangogh, ringo } = testCards;
     await setupIndex(dbAdapter, [

--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -908,6 +908,33 @@ module('Unit | query', function (hooks) {
     assert.deepEqual(getIds(results), [vangogh.id], 'results are correct');
   });
 
+  test(`can filter using 'in' with the id field`, async function (assert) {
+    let { mango, vangogh, ringo } = testCards;
+    await setupIndex(dbAdapter, [
+      { card: mango, data: { search_doc: { name: 'Mango' } } },
+      { card: vangogh, data: { search_doc: { name: 'Van Gogh' } } },
+      { card: ringo, data: { search_doc: { name: 'Ringo' } } },
+    ]);
+
+    let type = await personCardType(testCards);
+    let { cards: results, meta } = await indexQueryEngine.searchCards(
+      new URL(testRealmURL),
+      {
+        filter: {
+          on: type,
+          in: { id: [mango.id, ringo.id] },
+        },
+      },
+    );
+
+    assert.strictEqual(meta.page.total, 2, 'the total results meta is correct');
+    assert.deepEqual(
+      getIds(results),
+      [mango.id, ringo.id],
+      'results are correct',
+    );
+  });
+
   test(`can search with a 'not' filter`, async function (assert) {
     let { mango, vangogh, ringo } = testCards;
     await setupIndex(dbAdapter, [

--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -911,9 +911,18 @@ module('Unit | query', function (hooks) {
   test(`can filter using 'in' with the id field`, async function (assert) {
     let { mango, vangogh, ringo } = testCards;
     await setupIndex(dbAdapter, [
-      { card: mango, data: { search_doc: { name: 'Mango' } } },
-      { card: vangogh, data: { search_doc: { name: 'Van Gogh' } } },
-      { card: ringo, data: { search_doc: { name: 'Ringo' } } },
+      {
+        card: mango,
+        data: { search_doc: { id: mango.id, name: 'Mango' } },
+      },
+      {
+        card: vangogh,
+        data: { search_doc: { id: vangogh.id, name: 'Van Gogh' } },
+      },
+      {
+        card: ringo,
+        data: { search_doc: { id: ringo.id, name: 'Ringo' } },
+      },
     ]);
 
     let type = await personCardType(testCards);

--- a/packages/host/tests/unit/query-field-normalization-test.ts
+++ b/packages/host/tests/unit/query-field-normalization-test.ts
@@ -239,6 +239,55 @@ module('normalizeQueryDefinition', function () {
     });
   });
 
+  test('resolves in filter with array interpolation from containsMany field', function (assert) {
+    let realmURL = new URL('https://realm.example/');
+    let instance = { tags: ['red', 'blue', 'green'] };
+    let relativeTo = new URL('https://realm.example/cards/instance');
+
+    let normalized = normalizeQueryDefinition({
+      fieldDefinition,
+      queryDefinition: {
+        filter: { in: { color: '$this.tags' } },
+      },
+      realmURL,
+      fieldName: 'matchingItems',
+      resolvePathValue: (path) => resolvePath(instance, path),
+      relativeTo,
+    });
+
+    let targetRef = codeRefWithAbsoluteURL(
+      fieldDefinition.fieldOrCard,
+      relativeTo,
+    );
+    assert.deepEqual(normalized?.query.filter, {
+      in: { color: ['red', 'blue', 'green'] },
+      on: targetRef,
+    });
+  });
+
+  test('aborts in filter when interpolated array is undefined', function (assert) {
+    let realmURL = new URL('https://realm.example/');
+    let instance = {};
+    let relativeTo = new URL('https://realm.example/cards/instance');
+
+    let normalized = normalizeQueryDefinition({
+      fieldDefinition,
+      queryDefinition: {
+        filter: { in: { color: '$this.tags' } },
+      },
+      realmURL,
+      fieldName: 'matchingItems',
+      resolvePathValue: (path) => resolvePath(instance, path),
+      relativeTo,
+    });
+
+    assert.strictEqual(
+      normalized,
+      null,
+      'query is aborted when in value is undefined',
+    );
+  });
+
   test('resolves live instances via custom path resolver', function (assert) {
     let realmURL = new URL('https://realm.example/');
     let instance = { address: { city: 'Paris' } };

--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -1121,6 +1121,34 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
           );
         });
 
+        test(`can filter using 'in' with the id field`, async function (assert) {
+          let response = await request
+            .post(searchPath)
+            .set('Accept', 'application/vnd.card+json')
+            .set('X-HTTP-Method-Override', 'QUERY')
+            .send({
+              filter: {
+                on: personType(),
+                in: {
+                  id: [`${realmHref}mango`, `${realmHref}ringo`],
+                },
+              },
+            });
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.body.meta.page.total,
+            2,
+            'total count is correct',
+          );
+          let ids = response.body.data.map((d: any) => d.id).sort();
+          assert.deepEqual(
+            ids,
+            [`${realmHref}mango`, `${realmHref}ringo`],
+            'correct cards returned by id',
+          );
+        });
+
         test(`can negate an 'in' filter with 'not'`, async function (assert) {
           let response = await request
             .post(searchPath)

--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -920,5 +920,232 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
         });
       });
     });
+
+    module("'in' filter (postgres)", function () {
+      let testRealm: Realm;
+      let request: SuperTest<Test>;
+      let realmHref: string;
+      let searchPath: string;
+
+      function onRealmSetup(args: {
+        testRealm: Realm;
+        request: SuperTest<Test>;
+      }) {
+        testRealm = args.testRealm;
+        request = args.request;
+        let realmURL = new URL(testRealm.url);
+        realmHref = realmURL.href;
+        searchPath = `${realmURL.pathname.replace(/\/$/, '')}/_search`;
+      }
+
+      function personType() {
+        return {
+          module: `${realmHref}person`,
+          name: 'Person',
+        };
+      }
+
+      module('public readable realm', function (hooks) {
+        setupPermissionedRealmCached(hooks, {
+          permissions: {
+            '*': ['read'],
+          },
+          realmURL: testRealmURLFor('in-test/'),
+          fileSystem: {
+            'person.gts': `
+              import { contains, field, CardDef, Component } from 'https://cardstack.com/base/card-api';
+              import StringField from 'https://cardstack.com/base/string';
+              export class Person extends CardDef {
+                static displayName = 'Person';
+                @field firstName = contains(StringField);
+                @field city = contains(StringField);
+                @field cardTitle = contains(StringField, {
+                  computeVia: function (this: Person) {
+                    return this.firstName;
+                  },
+                });
+                static isolated = class Isolated extends Component<typeof this> {
+                  <template><h1><@fields.firstName /></h1></template>
+                };
+              }
+            `,
+            'mango.json': {
+              data: {
+                type: 'card',
+                attributes: { firstName: 'Mango', city: 'Barksville' },
+                meta: {
+                  adoptsFrom: { module: './person', name: 'Person' },
+                },
+              },
+            },
+            'vangogh.json': {
+              data: {
+                type: 'card',
+                attributes: { firstName: 'Van Gogh', city: 'Barksville' },
+                meta: {
+                  adoptsFrom: { module: './person', name: 'Person' },
+                },
+              },
+            },
+            'ringo.json': {
+              data: {
+                type: 'card',
+                attributes: { firstName: 'Ringo', city: 'Waggington' },
+                meta: {
+                  adoptsFrom: { module: './person', name: 'Person' },
+                },
+              },
+            },
+          },
+          onRealmSetup,
+        });
+
+        test(`can filter using 'in' with multiple values`, async function (assert) {
+          let response = await request
+            .post(searchPath)
+            .set('Accept', 'application/vnd.card+json')
+            .set('X-HTTP-Method-Override', 'QUERY')
+            .send({
+              filter: {
+                on: personType(),
+                in: { firstName: ['Mango', 'Ringo'] },
+              },
+            });
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.body.meta.page.total,
+            2,
+            'total count is correct',
+          );
+          let ids = response.body.data.map((d: any) => d.id).sort();
+          assert.deepEqual(
+            ids,
+            [`${realmHref}mango`, `${realmHref}ringo`],
+            'correct cards returned',
+          );
+        });
+
+        test(`can filter using 'in' with a single value`, async function (assert) {
+          let response = await request
+            .post(searchPath)
+            .set('Accept', 'application/vnd.card+json')
+            .set('X-HTTP-Method-Override', 'QUERY')
+            .send({
+              filter: {
+                on: personType(),
+                in: { firstName: ['Mango'] },
+              },
+            });
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.body.meta.page.total,
+            1,
+            'total count is correct',
+          );
+          assert.strictEqual(
+            response.body.data[0].id,
+            `${realmHref}mango`,
+            'correct card returned',
+          );
+        });
+
+        test(`can filter using 'in' with an empty array`, async function (assert) {
+          let response = await request
+            .post(searchPath)
+            .set('Accept', 'application/vnd.card+json')
+            .set('X-HTTP-Method-Override', 'QUERY')
+            .send({
+              filter: {
+                on: personType(),
+                in: { firstName: [] },
+              },
+            });
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.body.meta.page.total,
+            0,
+            'returns no results for empty array',
+          );
+        });
+
+        test(`can filter using 'in' with null values`, async function (assert) {
+          let response = await request
+            .post(searchPath)
+            .set('Accept', 'application/vnd.card+json')
+            .set('X-HTTP-Method-Override', 'QUERY')
+            .send({
+              filter: {
+                on: personType(),
+                in: { firstName: ['Mango', null] },
+              },
+            });
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          // Mango matches 'Mango', no cards have null firstName
+          assert.ok(
+            response.body.meta.page.total >= 1,
+            'returns at least the matching card',
+          );
+          let ids = response.body.data.map((d: any) => d.id);
+          assert.ok(
+            ids.includes(`${realmHref}mango`),
+            'Mango is in the results',
+          );
+        });
+
+        test(`can filter using 'in' on a different field`, async function (assert) {
+          let response = await request
+            .post(searchPath)
+            .set('Accept', 'application/vnd.card+json')
+            .set('X-HTTP-Method-Override', 'QUERY')
+            .send({
+              filter: {
+                on: personType(),
+                in: { city: ['Waggington'] },
+              },
+            });
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.body.meta.page.total,
+            1,
+            'total count is correct',
+          );
+          assert.strictEqual(
+            response.body.data[0].id,
+            `${realmHref}ringo`,
+            'correct card returned',
+          );
+        });
+
+        test(`can negate an 'in' filter with 'not'`, async function (assert) {
+          let response = await request
+            .post(searchPath)
+            .set('Accept', 'application/vnd.card+json')
+            .set('X-HTTP-Method-Override', 'QUERY')
+            .send({
+              filter: {
+                on: personType(),
+                not: { in: { firstName: ['Mango', 'Ringo'] } },
+              },
+            });
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.body.meta.page.total,
+            1,
+            'total count is correct',
+          );
+          assert.strictEqual(
+            response.body.data[0].id,
+            `${realmHref}vangogh`,
+            'correct card returned',
+          );
+        });
+      });
+    });
   });
 });

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -43,6 +43,7 @@ import {
   type Query,
   type Filter,
   type EqFilter,
+  type InFilter,
   type NotFilter,
   type ContainsFilter,
   type Sort,
@@ -812,6 +813,8 @@ export class IndexQueryEngine {
 
     if ('eq' in filter) {
       return this.eqCondition(filter, on, typeConditionRef);
+    } else if ('in' in filter) {
+      return this.inCondition(filter, on, typeConditionRef);
     } else if ('contains' in filter) {
       return this.containsCondition(filter, on, typeConditionRef);
     } else if ('not' in filter) {
@@ -856,6 +859,20 @@ export class IndexQueryEngine {
       ...(typeRef ? [this.typeCondition(typeRef)] : []),
       ...Object.entries(filter.eq).map(([key, value]) => {
         return this.fieldEqFilter(key, value, on);
+      }),
+    ]);
+  }
+
+  private inCondition(
+    filter: InFilter,
+    on: CodeRef,
+    typeConditionRef?: CodeRef,
+  ): CardExpression {
+    let typeRef = typeConditionRef;
+    return every([
+      ...(typeRef ? [this.typeCondition(typeRef)] : []),
+      ...Object.entries(filter.in).map(([key, values]) => {
+        return this.fieldInFilter(key, values as JSONTypes.Value[], on);
       }),
     ]);
   }
@@ -928,6 +945,59 @@ export class IndexQueryEngine {
         errorHint: 'filter',
       }),
     ];
+  }
+
+  private fieldInFilter(
+    key: string,
+    values: JSONTypes.Value[],
+    onRef: CodeRef,
+  ): CardExpression {
+    if (values.length === 0) {
+      // Empty set matches nothing
+      return ['false'];
+    }
+    let nonNullValues = values.filter((v) => v !== null);
+    let hasNull = values.some((v) => v === null);
+
+    let conditions: CardExpression[] = [];
+
+    if (nonNullValues.length > 0) {
+      let query = fieldQuery(key, onRef, false, 'filter');
+      let inList: CardExpression = [];
+      nonNullValues.forEach((v, i) => {
+        if (i > 0) {
+          inList.push(',');
+        }
+        inList.push(fieldValue(key, [param(v)], onRef, 'filter'));
+      });
+      conditions.push([
+        fieldArity({
+          type: onRef,
+          path: key,
+          value: [query, 'IN', '(', ...inList, ')'],
+          errorHint: 'filter',
+        }),
+      ]);
+    }
+
+    if (hasNull) {
+      let query = fieldQuery(key, onRef, true, 'filter');
+      conditions.push([
+        fieldArity({
+          type: onRef,
+          path: key,
+          value: [query, 'IS NULL'],
+          pluralValue: [query, "= 'null'::jsonb"],
+          usePluralContainer: true,
+          errorHint: 'filter',
+        }),
+      ]);
+    }
+
+    if (conditions.length === 1) {
+      return conditions[0];
+    }
+    return any(conditions);
   }
 
   private fieldLikeFilter(

--- a/packages/runtime-common/query-field-utils.ts
+++ b/packages/runtime-common/query-field-utils.ts
@@ -21,6 +21,7 @@ import {
 
 const EMPTY_PREDICATE_KEYS = new Set([
   'eq',
+  'in',
   'contains',
   'range',
   'any',

--- a/packages/runtime-common/query.ts
+++ b/packages/runtime-common/query.ts
@@ -63,6 +63,7 @@ export type Filter =
   | EveryFilter
   | NotFilter
   | EqFilter
+  | InFilter
   | ContainsFilter
   | RangeFilter
   | CardTypeFilter;
@@ -142,6 +143,10 @@ export interface RangeFilter extends TypedFilter {
   };
 }
 
+export interface InFilter extends TypedFilter {
+  in: { [fieldName: string]: JSONValue[] | string };
+}
+
 export interface ContainsFilter extends TypedFilter {
   contains: { [fieldName: string]: JSONValue };
 }
@@ -163,6 +168,9 @@ export function isEveryFilter(filter: Filter): filter is EveryFilter {
 }
 export function isAnyFilter(filter: Filter): filter is AnyFilter {
   return (filter as AnyFilter).any !== undefined;
+}
+export function isInFilter(filter: Filter): filter is InFilter {
+  return (filter as InFilter).in !== undefined;
 }
 
 export function buildQueryParamValue(query: Query): string {
@@ -389,6 +397,8 @@ function assertFilter(
     assertNotFilter(filter, pointer);
   } else if ('eq' in filter) {
     assertEqFilter(filter, pointer);
+  } else if ('in' in filter) {
+    assertInFilter(filter, pointer);
   } else if ('contains' in filter) {
     assertContainsFilter(filter, pointer);
   } else if ('range' in filter) {
@@ -506,6 +516,39 @@ function assertEqFilter(
   Object.entries(filter.eq).forEach(([key, value]) => {
     assertKey(key, pointer);
     assertJSONValue(value, pointer.concat(key));
+  });
+}
+
+function assertInFilter(
+  filter: any,
+  pointer: string[],
+): asserts filter is InFilter {
+  if (typeof filter !== 'object' || filter == null) {
+    throw new InvalidQueryError(
+      `${pointer.join('/') || '/'}: filter must be an object`,
+    );
+  }
+  let inPointer = pointer.concat('in');
+  if (!('in' in filter)) {
+    throw new InvalidQueryError(
+      `${inPointer.join('/') || '/'}: InFilter must have in property`,
+    );
+  }
+  if (typeof filter.in !== 'object' || filter.in == null) {
+    throw new InvalidQueryError(
+      `${inPointer.join('/') || '/'}: in must be an object`,
+    );
+  }
+  Object.entries(filter.in).forEach(([key, value]) => {
+    assertKey(key, inPointer);
+    if (!Array.isArray(value)) {
+      throw new InvalidQueryError(
+        `${inPointer.concat(key).join('/') || '/'}: in values must be arrays`,
+      );
+    }
+    value.forEach((item, index) => {
+      assertJSONValue(item, inPointer.concat(key, `[${index}]`));
+    });
   });
 }
 

--- a/packages/software-factory/.agents/skills/boxel-development/references/dev-query-systems.md
+++ b/packages/software-factory/.agents/skills/boxel-development/references/dev-query-systems.md
@@ -21,7 +21,7 @@
 
 **Filter types needing 'on':**
 
-- `eq`, `contains`, `range` (except after type filter)
+- `eq`, `in`, `contains`, `range` (except after type filter)
 - Sort on type-specific fields
 
 **Filter composition types:**


### PR DESCRIPTION
## Summary

- Adds a new `in` filter operator to the card query language for concise set membership queries
- Replaces verbose `any` + `eq` workaround: `{ in: { id: ['id1', 'id2'] } }` instead of `{ any: [{ eq: { id: 'id1' } }, { eq: { id: 'id2' } }] }`
- Handles empty arrays (matches nothing), null values (OR'd with IS NULL), and nested field paths
- Supports interpolation from `containsMany` fields in query-backed fields (e.g. `{ in: { tag: '$this.tags' } }`)

Closes CS-10561

## Changes

- **`packages/runtime-common/query.ts`** — `InFilter` type, `isInFilter()` guard, `assertInFilter()` validation
- **`packages/runtime-common/index-query-engine.ts`** — `inCondition()` and `fieldInFilter()` SQL generation
- **`packages/runtime-common/query-field-utils.ts`** — Added `in` to `EMPTY_PREDICATE_KEYS` for query abort on undefined
- **`packages/host/tests/unit/index-query-engine-test.ts`** — 6 query engine test cases
- **`packages/host/tests/unit/query-field-normalization-test.ts`** — 2 interpolation test cases
- **`packages/software-factory/.agents/skills/boxel-development/references/dev-query-systems.md`** — Added `in` to documented filter types

## Test plan

- [x] Basic `in` with multiple values
- [x] Single value in array
- [x] Empty array matches nothing
- [x] Null value handling
- [x] Nested field paths (`address.city`)
- [x] Negation with `not: { in: ... }`
- [x] Array interpolation from `containsMany` field resolves correctly
- [x] Undefined `containsMany` field aborts query gracefully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)