### PR TITLE
Fix OpenRouter model link for GPT-5 configuration

### DIFF
--- a/packages/catalog-realm/ModelConfiguration/openai-gpt-5.json
+++ b/packages/catalog-realm/ModelConfiguration/openai-gpt-5.json
@@ -18,7 +18,7 @@
       },
       "openRouterModel": {
         "links": {
-          "self": "@cardstack/openrouter/OpenRouterModel/openai-gpt-5.4"
+          "self": "@cardstack/openrouter/OpenRouterModel/openai-gpt-5-4"
         }
       }
     },


### PR DESCRIPTION
## Summary

- Fixes broken openRouterModel reference in GPT-5 model configuration
- Link used dot separator (`gpt-5.4`) instead of hyphen (`gpt-5-4`)

## Test plan

- [ ] Verify GPT-5 model configuration resolves correctly in catalog realm

🤖 Generated with [Claude Code](https://claude.com/claude-code)