### PR TITLE
Make cache:prepare self-contained in fresh worktrees

### DIFF
--- a/packages/software-factory/src/cli/cache-realm.ts
+++ b/packages/software-factory/src/cli/cache-realm.ts
@@ -29,24 +29,48 @@ async function main(): Promise<void> {
       ? parsedMetadataContext
       : undefined;
 
-  // Validate that the context's hostURL is still reachable. A stale
-  // support.json from a previous run can have a dead hostURL which
-  // causes the realm server to crash during template builds.
-  if (supportContext && 'hostURL' in supportContext && supportContext.hostURL) {
-    let hostURL = supportContext.hostURL;
-    try {
-      let response = await fetch(hostURL);
-      if (!response.ok) {
+  // Validate that the context's URLs are still reachable. A stale
+  // support.json from a previous run can have dead URLs which cause
+  // the realm server to crash during template builds.
+  if (supportContext) {
+    if ('hostURL' in supportContext && supportContext.hostURL) {
+      let hostURL = supportContext.hostURL;
+      try {
+        let response = await fetch(hostURL);
+        if (!response.ok) {
+          console.warn(
+            `Stale support context: hostURL ${hostURL} returned ${response.status}, ignoring cached context`,
+          );
+          supportContext = undefined;
+        }
+      } catch {
         console.warn(
-          `Stale support context: hostURL ${hostURL} returned ${response.status}, ignoring cached context`,
+          `Stale support context: hostURL ${hostURL} is not reachable, ignoring cached context`,
         );
         supportContext = undefined;
       }
-    } catch {
-      console.warn(
-        `Stale support context: hostURL ${hostURL} is not reachable, ignoring cached context`,
-      );
-      supportContext = undefined;
+    }
+
+    if (
+      supportContext &&
+      'matrixURL' in supportContext &&
+      supportContext.matrixURL
+    ) {
+      let matrixURL = supportContext.matrixURL;
+      try {
+        let response = await fetch(`${matrixURL}/_matrix/client/versions`);
+        if (!response.ok) {
+          console.warn(
+            `Stale support context: matrixURL ${matrixURL} returned ${response.status}, ignoring cached context`,
+          );
+          supportContext = undefined;
+        }
+      } catch {
+        console.warn(
+          `Stale support context: matrixURL ${matrixURL} is not reachable, ignoring cached context`,
+        );
+        supportContext = undefined;
+      }
     }
   }
 

--- a/packages/software-factory/src/harness/database.ts
+++ b/packages/software-factory/src/harness/database.ts
@@ -646,6 +646,9 @@ function startIndexingProgressReporter(
           `\r  indexing: waiting for realm server ${elapsed}s`,
         );
       }
+    } catch {
+      // Progress reporting is best-effort; swallow errors so we don't
+      // crash the process with an unhandled rejection from setInterval.
     } finally {
       polling = false;
     }

--- a/packages/software-factory/src/harness/database.ts
+++ b/packages/software-factory/src/harness/database.ts
@@ -609,37 +609,43 @@ function startIndexingProgressReporter(
   estimatedTotal: number,
 ): { stop: () => void } {
   let stopped = false;
+  let polling = false;
   let lastReported = -1;
   let startedAt = Date.now();
 
   let report = async () => {
-    if (stopped) {
+    if (stopped || polling) {
       return;
     }
-    let { indexed, errors } = await queryIndexedCount(databaseName);
-    if (stopped) {
-      return;
-    }
-    // Only report when the count changes or on the first poll.
-    if (indexed === lastReported) {
-      return;
-    }
-    lastReported = indexed;
+    polling = true;
+    try {
+      let { indexed, errors } = await queryIndexedCount(databaseName);
+      if (stopped) {
+        return;
+      }
+      // Only report when the count changes or on the first poll.
+      if (indexed === lastReported) {
+        return;
+      }
+      lastReported = indexed;
 
-    let elapsed = ((Date.now() - startedAt) / 1000).toFixed(0);
-    let errorSuffix = errors > 0 ? ` (${errors} errors)` : '';
-    if (estimatedTotal > 0) {
-      let pct = Math.min(100, Math.round((indexed / estimatedTotal) * 100));
-      let barWidth = 30;
-      let filled = Math.round((pct / 100) * barWidth);
-      let bar = '='.repeat(filled) + ' '.repeat(barWidth - filled);
-      process.stderr.write(
-        `\r  indexing [${bar}] ${indexed}/${estimatedTotal} files (${pct}%) ${elapsed}s${errorSuffix}`,
-      );
-    } else {
-      process.stderr.write(
-        `\r  indexing ${indexed} files indexed ${elapsed}s${errorSuffix}`,
-      );
+      let elapsed = ((Date.now() - startedAt) / 1000).toFixed(0);
+      let errorSuffix = errors > 0 ? ` (${errors} errors)` : '';
+      if (estimatedTotal > 0) {
+        let pct = Math.min(100, Math.round((indexed / estimatedTotal) * 100));
+        let barWidth = 30;
+        let filled = Math.round((pct / 100) * barWidth);
+        let bar = '='.repeat(filled) + ' '.repeat(barWidth - filled);
+        process.stderr.write(
+          `\r  indexing [${bar}] ${indexed}/${estimatedTotal} files (${pct}%) ${elapsed}s${errorSuffix}`,
+        );
+      } else {
+        process.stderr.write(
+          `\r  indexing ${indexed} files indexed ${elapsed}s${errorSuffix}`,
+        );
+      }
+    } finally {
+      polling = false;
     }
   };
 

--- a/packages/software-factory/src/harness/database.ts
+++ b/packages/software-factory/src/harness/database.ts
@@ -1,19 +1,15 @@
-import { readdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Client as PgClient } from 'pg';
 
 import {
-  baseRealmDir,
   baseRealmURLFor,
   builderDatabaseNameForCacheKey,
   DEFAULT_BASE_REALM_PERMISSIONS,
   DEFAULT_MIGRATED_TEMPLATE_DB,
   DEFAULT_SOURCE_REALM_PERMISSIONS,
+  findAvailablePort,
   logTimed,
   pgAdminConnectionConfig,
   quotePgIdentifier,
-  shouldIgnoreFixturePath,
-  sourceRealmDir,
   sourceRealmURLFor,
   templateLog,
   waitUntil,
@@ -549,69 +545,49 @@ export async function warnIfSnapshotLooksCold(
   );
 }
 
-function countFixtureFiles(dir: string): number {
-  let count = 0;
-  function visit(currentDir: string, relativePath: string) {
-    for (let entry of readdirSync(currentDir, { withFileTypes: true })) {
-      let entryRelativePath = relativePath
-        ? `${relativePath}/${entry.name}`
-        : entry.name;
-      if (shouldIgnoreFixturePath(entryRelativePath)) {
-        continue;
-      }
-      let fullPath = join(currentDir, entry.name);
-      if (entry.isDirectory()) {
-        visit(fullPath, entryRelativePath);
-      } else if (entry.isFile()) {
-        count++;
-      }
-    }
-  }
-  try {
-    visit(dir, '');
-  } catch {
-    // If we can't count files, just return 0 and skip progress reporting
-  }
-  return count;
+interface IndexingStatus {
+  active: {
+    realmURL: string;
+    totalFiles: number;
+    filesCompleted: number;
+  }[];
+  pending: { realmURL: string }[];
 }
 
-async function queryIndexedCount(databaseName: string): Promise<{
-  indexed: number;
-  errors: number;
-}> {
-  let client = new PgClient({
-    ...pgAdminConnectionConfig(databaseName),
-    connectionTimeoutMillis: 2000,
-  });
+async function queryIndexingStatus(
+  workerManagerPort: number,
+): Promise<IndexingStatus | undefined> {
   try {
-    await client.connect();
-    let { rows } = await client.query<{ total: number; errors: number }>(
-      `SELECT COUNT(*)::int AS total, COUNT(*) FILTER (WHERE has_error)::int AS errors FROM boxel_index`,
+    let response = await fetch(
+      `http://localhost:${workerManagerPort}/_indexing-status`,
     );
-    return { indexed: rows[0]?.total ?? 0, errors: rows[0]?.errors ?? 0 };
-  } catch {
-    return { indexed: 0, errors: 0 };
-  } finally {
-    try {
-      await client.end();
-    } catch {
-      // best effort cleanup
+    if (!response.ok) {
+      return undefined;
     }
+    return (await response.json()) as IndexingStatus;
+  } catch {
+    return undefined;
   }
 }
 
 /**
- * Start a progress reporter that polls the database for indexing status and
- * writes updates to stderr. Returns a stop function.
+ * Start a progress reporter that polls the worker-manager's
+ * /_indexing-status JSON endpoint for precise indexing progress.
+ * The port must be pre-allocated by the caller via findAvailablePort()
+ * and passed to startIsolatedRealmStack as workerManagerPort.
  */
 function startIndexingProgressReporter(
-  databaseName: string,
-  estimatedTotal: number,
-): { stop: () => void } {
+  workerManagerPort: number,
+  totalRealms: number,
+): {
+  stop: () => void;
+} {
   let stopped = false;
   let polling = false;
-  let lastReported = -1;
+  let lastCompleted = -1;
+  let lastTotal = -1;
   let startedAt = Date.now();
+  let seenRealms = new Set<string>();
 
   let report = async () => {
     if (stopped || polling) {
@@ -619,29 +595,55 @@ function startIndexingProgressReporter(
     }
     polling = true;
     try {
-      let { indexed, errors } = await queryIndexedCount(databaseName);
+      let elapsed = ((Date.now() - startedAt) / 1000).toFixed(0);
+      let status = await queryIndexingStatus(workerManagerPort);
       if (stopped) {
         return;
       }
-      // Only report when the count changes or on the first poll.
-      if (indexed === lastReported) {
+      if (!status) {
+        process.stderr.write(`\r  indexing: waiting for status ${elapsed}s`);
         return;
       }
-      lastReported = indexed;
 
-      let elapsed = ((Date.now() - startedAt) / 1000).toFixed(0);
-      let errorSuffix = errors > 0 ? ` (${errors} errors)` : '';
-      if (estimatedTotal > 0) {
-        let pct = Math.min(100, Math.round((indexed / estimatedTotal) * 100));
+      let current = status.active[0];
+      let filesCompleted = current?.filesCompleted ?? 0;
+      let totalFiles = current?.totalFiles ?? 0;
+      lastCompleted = filesCompleted;
+      lastTotal = totalFiles;
+
+      // Track which realms we've seen to compute remaining count.
+      if (current) {
+        seenRealms.add(current.realmURL);
+      }
+      let remaining = Math.max(0, totalRealms - seenRealms.size);
+
+      let realmName = current
+        ? new URL(current.realmURL).pathname.replace(/\/$/, '').split('/').pop()
+        : undefined;
+      let realmLabel = realmName ? ` ${realmName}` : '';
+      let remainingLabel =
+        remaining > 0
+          ? ` (${remaining} realm${remaining > 1 ? 's' : ''} remaining)`
+          : '';
+
+      if (totalFiles > 0) {
+        let pct = Math.min(
+          100,
+          Math.round((filesCompleted / totalFiles) * 100),
+        );
         let barWidth = 30;
         let filled = Math.round((pct / 100) * barWidth);
         let bar = '='.repeat(filled) + ' '.repeat(barWidth - filled);
         process.stderr.write(
-          `\r  indexing [${bar}] ${indexed}/${estimatedTotal} files (${pct}%) ${elapsed}s${errorSuffix}`,
+          `\r  indexing${realmLabel} [${bar}] ${filesCompleted}/${totalFiles} files (${pct}%) ${elapsed}s${remainingLabel}`,
+        );
+      } else if (status.active.length > 0) {
+        process.stderr.write(
+          `\r  indexing${realmLabel}: discovering files... ${elapsed}s${remainingLabel}`,
         );
       } else {
         process.stderr.write(
-          `\r  indexing ${indexed} files indexed ${elapsed}s${errorSuffix}`,
+          `\r  indexing: waiting for realm server ${elapsed}s`,
         );
       }
     } finally {
@@ -650,7 +652,6 @@ function startIndexingProgressReporter(
   };
 
   let interval = setInterval(() => void report(), 2000);
-  // Do an immediate first check after a brief delay to let the DB initialize.
   let initialTimeout = setTimeout(() => void report(), 3000);
 
   return {
@@ -658,11 +659,10 @@ function startIndexingProgressReporter(
       stopped = true;
       clearInterval(interval);
       clearTimeout(initialTimeout);
-      // Clear the progress line and print final status.
-      if (lastReported >= 0) {
+      if (lastCompleted >= 0) {
         let elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
         process.stderr.write(
-          `\r  indexing complete: ${lastReported} files indexed in ${elapsed}s\n`,
+          `\r  indexing complete: ${lastCompleted}/${lastTotal} files in ${elapsed}s\n`,
         );
       }
     },
@@ -782,17 +782,11 @@ export async function buildCombinedTemplateDatabase({
         username: `additional_realm_${i}`,
       }));
 
-      // Estimate total files for progress reporting.
-      let estimatedTotal =
-        realmFixtures.reduce(
-          (sum, f) => sum + countFixtureFiles(f.realmDir),
-          0,
-        ) +
-        countFixtureFiles(sourceRealmDir) +
-        countFixtureFiles(baseRealmDir);
+      let wmPort = await findAvailablePort();
+      // base + source + each fixture realm
       let progress = startIndexingProgressReporter(
-        builderDatabaseName,
-        estimatedTotal,
+        wmPort,
+        2 + realmFixtures.length,
       );
 
       let stack;
@@ -806,6 +800,7 @@ export async function buildCombinedTemplateDatabase({
           migrateDB: !hasMigratedTemplate,
           fullIndexOnStartup: true,
           additionalRealms,
+          workerManagerPort: wmPort,
         });
       } catch (error) {
         progress.stop();
@@ -884,15 +879,9 @@ export async function buildTemplateDatabase({
         DEFAULT_SOURCE_REALM_PERMISSIONS,
       );
 
-      // Estimate total files for progress reporting: fixture + source realm + base realm.
-      let estimatedTotal =
-        countFixtureFiles(realmDir) +
-        countFixtureFiles(sourceRealmDir) +
-        countFixtureFiles(baseRealmDir);
-      let progress = startIndexingProgressReporter(
-        builderDatabaseName,
-        estimatedTotal,
-      );
+      let wmPort = await findAvailablePort();
+      // base + source + test realm
+      let progress = startIndexingProgressReporter(wmPort, 3);
 
       let stack;
       try {
@@ -904,6 +893,7 @@ export async function buildTemplateDatabase({
           context,
           migrateDB: !hasMigratedTemplate,
           fullIndexOnStartup: true,
+          workerManagerPort: wmPort,
         });
       } catch (error) {
         progress.stop();

--- a/packages/software-factory/src/harness/database.ts
+++ b/packages/software-factory/src/harness/database.ts
@@ -1,6 +1,9 @@
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
 import { Client as PgClient } from 'pg';
 
 import {
+  baseRealmDir,
   baseRealmURLFor,
   builderDatabaseNameForCacheKey,
   DEFAULT_BASE_REALM_PERMISSIONS,
@@ -9,6 +12,8 @@ import {
   logTimed,
   pgAdminConnectionConfig,
   quotePgIdentifier,
+  shouldIgnoreFixturePath,
+  sourceRealmDir,
   sourceRealmURLFor,
   templateLog,
   waitUntil,
@@ -41,7 +46,10 @@ export async function canConnectToPg(): Promise<boolean> {
 }
 
 export async function databaseExists(databaseName: string): Promise<boolean> {
-  let client = new PgClient(pgAdminConnectionConfig());
+  let client = new PgClient({
+    ...pgAdminConnectionConfig(),
+    connectionTimeoutMillis: 3000,
+  });
   try {
     await client.connect();
     let result = await client.query<{ exists: boolean }>(
@@ -49,8 +57,16 @@ export async function databaseExists(databaseName: string): Promise<boolean> {
       [databaseName],
     );
     return Boolean(result.rows[0]?.exists);
+  } catch {
+    // Postgres may not be running yet (e.g. fresh worktree with no services).
+    // Treat as "database does not exist" so the caller proceeds to start services.
+    return false;
   } finally {
-    await client.end();
+    try {
+      await client.end();
+    } catch {
+      // best effort cleanup
+    }
   }
 }
 
@@ -533,6 +549,120 @@ export async function warnIfSnapshotLooksCold(
   );
 }
 
+function countFixtureFiles(dir: string): number {
+  let count = 0;
+  function visit(currentDir: string, relativePath: string) {
+    for (let entry of readdirSync(currentDir, { withFileTypes: true })) {
+      let entryRelativePath = relativePath
+        ? `${relativePath}/${entry.name}`
+        : entry.name;
+      if (shouldIgnoreFixturePath(entryRelativePath)) {
+        continue;
+      }
+      let fullPath = join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        visit(fullPath, entryRelativePath);
+      } else if (entry.isFile()) {
+        count++;
+      }
+    }
+  }
+  try {
+    visit(dir, '');
+  } catch {
+    // If we can't count files, just return 0 and skip progress reporting
+  }
+  return count;
+}
+
+async function queryIndexedCount(databaseName: string): Promise<{
+  indexed: number;
+  errors: number;
+}> {
+  let client = new PgClient({
+    ...pgAdminConnectionConfig(databaseName),
+    connectionTimeoutMillis: 2000,
+  });
+  try {
+    await client.connect();
+    let { rows } = await client.query<{ total: number; errors: number }>(
+      `SELECT COUNT(*)::int AS total, COUNT(*) FILTER (WHERE has_error)::int AS errors FROM boxel_index`,
+    );
+    return { indexed: rows[0]?.total ?? 0, errors: rows[0]?.errors ?? 0 };
+  } catch {
+    return { indexed: 0, errors: 0 };
+  } finally {
+    try {
+      await client.end();
+    } catch {
+      // best effort cleanup
+    }
+  }
+}
+
+/**
+ * Start a progress reporter that polls the database for indexing status and
+ * writes updates to stderr. Returns a stop function.
+ */
+function startIndexingProgressReporter(
+  databaseName: string,
+  estimatedTotal: number,
+): { stop: () => void } {
+  let stopped = false;
+  let lastReported = -1;
+  let startedAt = Date.now();
+
+  let report = async () => {
+    if (stopped) {
+      return;
+    }
+    let { indexed, errors } = await queryIndexedCount(databaseName);
+    if (stopped) {
+      return;
+    }
+    // Only report when the count changes or on the first poll.
+    if (indexed === lastReported) {
+      return;
+    }
+    lastReported = indexed;
+
+    let elapsed = ((Date.now() - startedAt) / 1000).toFixed(0);
+    let errorSuffix = errors > 0 ? ` (${errors} errors)` : '';
+    if (estimatedTotal > 0) {
+      let pct = Math.min(100, Math.round((indexed / estimatedTotal) * 100));
+      let barWidth = 30;
+      let filled = Math.round((pct / 100) * barWidth);
+      let bar = '='.repeat(filled) + ' '.repeat(barWidth - filled);
+      process.stderr.write(
+        `\r  indexing [${bar}] ${indexed}/${estimatedTotal} files (${pct}%) ${elapsed}s${errorSuffix}`,
+      );
+    } else {
+      process.stderr.write(
+        `\r  indexing ${indexed} files indexed ${elapsed}s${errorSuffix}`,
+      );
+    }
+  };
+
+  let interval = setInterval(() => void report(), 2000);
+  // Do an immediate first check after a brief delay to let the DB initialize.
+  let initialTimeout = setTimeout(() => void report(), 3000);
+
+  return {
+    stop() {
+      stopped = true;
+      clearInterval(interval);
+      clearTimeout(initialTimeout);
+      // Clear the progress line and print final status.
+      if (lastReported >= 0) {
+        let elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+        process.stderr.write(
+          `\r  indexing complete: ${lastReported} files indexed in ${elapsed}s\n`,
+        );
+      }
+    },
+  };
+}
+
 export async function waitForQueueIdle(databaseName: string): Promise<void> {
   await logTimed(templateLog, `waitForQueueIdle ${databaseName}`, async () => {
     await waitUntil(
@@ -646,20 +776,40 @@ export async function buildCombinedTemplateDatabase({
         username: `additional_realm_${i}`,
       }));
 
-      let stack = await startIsolatedRealmStack({
-        realmDir: primary.realmDir,
-        realmURL: primary.realmURL,
-        realmServerURL,
-        databaseName: builderDatabaseName,
-        context,
-        migrateDB: !hasMigratedTemplate,
-        fullIndexOnStartup: true,
-        additionalRealms,
-      });
+      // Estimate total files for progress reporting.
+      let estimatedTotal =
+        realmFixtures.reduce(
+          (sum, f) => sum + countFixtureFiles(f.realmDir),
+          0,
+        ) +
+        countFixtureFiles(sourceRealmDir) +
+        countFixtureFiles(baseRealmDir);
+      let progress = startIndexingProgressReporter(
+        builderDatabaseName,
+        estimatedTotal,
+      );
+
+      let stack;
+      try {
+        stack = await startIsolatedRealmStack({
+          realmDir: primary.realmDir,
+          realmURL: primary.realmURL,
+          realmServerURL,
+          databaseName: builderDatabaseName,
+          context,
+          migrateDB: !hasMigratedTemplate,
+          fullIndexOnStartup: true,
+          additionalRealms,
+        });
+      } catch (error) {
+        progress.stop();
+        throw error;
+      }
 
       try {
         await waitForQueueIdle(builderDatabaseName);
       } finally {
+        progress.stop();
         await stopIsolatedRealmStack(stack);
       }
 
@@ -728,19 +878,36 @@ export async function buildTemplateDatabase({
         DEFAULT_SOURCE_REALM_PERMISSIONS,
       );
 
-      let stack = await startIsolatedRealmStack({
-        realmDir,
-        realmURL,
-        realmServerURL,
-        databaseName: builderDatabaseName,
-        context,
-        migrateDB: !hasMigratedTemplate,
-        fullIndexOnStartup: true,
-      });
+      // Estimate total files for progress reporting: fixture + source realm + base realm.
+      let estimatedTotal =
+        countFixtureFiles(realmDir) +
+        countFixtureFiles(sourceRealmDir) +
+        countFixtureFiles(baseRealmDir);
+      let progress = startIndexingProgressReporter(
+        builderDatabaseName,
+        estimatedTotal,
+      );
+
+      let stack;
+      try {
+        stack = await startIsolatedRealmStack({
+          realmDir,
+          realmURL,
+          realmServerURL,
+          databaseName: builderDatabaseName,
+          context,
+          migrateDB: !hasMigratedTemplate,
+          fullIndexOnStartup: true,
+        });
+      } catch (error) {
+        progress.stop();
+        throw error;
+      }
 
       try {
         await waitForQueueIdle(builderDatabaseName);
       } finally {
+        progress.stop();
         await stopIsolatedRealmStack(stack);
       }
 

--- a/packages/software-factory/src/harness/isolated-realm-stack.ts
+++ b/packages/software-factory/src/harness/isolated-realm-stack.ts
@@ -28,7 +28,6 @@ import {
   DEFAULT_PG_USER,
   DEFAULT_REALM_LOG_LEVELS,
   DEFAULT_REALM_SERVER_PORT,
-  DEFAULT_WORKER_MANAGER_PORT,
   findAvailablePort,
   FIXTURE_SOURCE_REALM_URL_PLACEHOLDER,
   FULL_INDEX_REALM_STARTUP_TIMEOUT_MS,
@@ -296,6 +295,8 @@ export async function startIsolatedRealmStack({
   let testRealmDir = join(rootDir, 'test');
   let workerManagerMetadataFile = join(rootDir, 'worker-manager.runtime.json');
   let realmServerMetadataFile = join(rootDir, 'realm-server.runtime.json');
+  let actualWorkerManagerPort =
+    explicitWorkerManagerPort ?? (await findAvailablePort());
   let actualRealmServerPort =
     DEFAULT_REALM_SERVER_PORT === 0
       ? await findAvailablePort()
@@ -401,7 +402,7 @@ export async function startIsolatedRealmStack({
   let workerArgs = [
     '--transpileOnly',
     'worker-manager',
-    `--port=${explicitWorkerManagerPort ?? DEFAULT_WORKER_MANAGER_PORT}`,
+    `--port=${actualWorkerManagerPort}`,
     `--matrixURL=${context.matrixURL}`,
     `--prerendererUrl=${prerenderURL}`,
     `--fromUrl=${realmURL.href}`,

--- a/packages/software-factory/src/harness/isolated-realm-stack.ts
+++ b/packages/software-factory/src/harness/isolated-realm-stack.ts
@@ -277,6 +277,7 @@ export async function startIsolatedRealmStack({
   migrateDB,
   fullIndexOnStartup,
   additionalRealms,
+  workerManagerPort: explicitWorkerManagerPort,
 }: {
   realmDir: string;
   realmURL: URL;
@@ -286,6 +287,10 @@ export async function startIsolatedRealmStack({
   migrateDB: boolean;
   fullIndexOnStartup: boolean;
   additionalRealms?: AdditionalRealm[];
+  /** When provided, the worker-manager will listen on this port instead of
+   *  picking one dynamically. This lets callers know the port upfront (e.g.
+   *  for progress monitoring via /_indexing-status). */
+  workerManagerPort?: number;
 }): Promise<RunningFactoryStack> {
   let rootDir = mkdtempSync(join(tmpdir(), 'software-factory-realms-'));
   let testRealmDir = join(rootDir, 'test');
@@ -396,7 +401,7 @@ export async function startIsolatedRealmStack({
   let workerArgs = [
     '--transpileOnly',
     'worker-manager',
-    `--port=${DEFAULT_WORKER_MANAGER_PORT}`,
+    `--port=${explicitWorkerManagerPort ?? DEFAULT_WORKER_MANAGER_PORT}`,
     `--matrixURL=${context.matrixURL}`,
     `--prerendererUrl=${prerenderURL}`,
     `--fromUrl=${realmURL.href}`,

--- a/packages/software-factory/src/harness/shared.ts
+++ b/packages/software-factory/src/harness/shared.ts
@@ -140,9 +140,6 @@ export const DEFAULT_REALM_SERVER_PORT = Number(
 export const DEFAULT_COMPAT_REALM_SERVER_PORT = Number(
   process.env.SOFTWARE_FACTORY_COMPAT_REALM_PORT ?? 0,
 );
-export const DEFAULT_WORKER_MANAGER_PORT = Number(
-  process.env.SOFTWARE_FACTORY_WORKER_MANAGER_PORT ?? 0,
-);
 export const CONFIGURED_REALM_URL = process.env.SOFTWARE_FACTORY_REALM_URL
   ? new URL(process.env.SOFTWARE_FACTORY_REALM_URL)
   : undefined;

--- a/packages/software-factory/src/harness/support-services.ts
+++ b/packages/software-factory/src/harness/support-services.ts
@@ -71,8 +71,12 @@ function ensureBoxelUIDist(hostPackageDir: string): void {
       'dist',
     );
     if (
-      existsSync(join(rootRepoBoxelUIDistDir, 'components.js')) &&
-      existsSync(join(rootRepoBoxelUIDistDir, 'helpers.js'))
+      [
+        join(rootRepoBoxelUIDistDir, 'components.js'),
+        join(rootRepoBoxelUIDistDir, 'helpers.js'),
+        join(rootRepoBoxelUIDistDir, 'icons.js'),
+        join(rootRepoBoxelUIDistDir, 'styles', 'global.css'),
+      ].every((p) => existsSync(p))
     ) {
       supportLog.info(
         `symlinking boxel-ui dist from root repo: ${rootRepoBoxelUIDistDir} -> ${boxelUIDistDir}`,

--- a/packages/software-factory/src/harness/support-services.ts
+++ b/packages/software-factory/src/harness/support-services.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from 'node:child_process';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -16,6 +16,7 @@ import {
   findAvailablePort,
   findHostDistPackageDir,
   findRootRepoCheckoutDir,
+  hostDir,
   logTimed,
   maybeRequire,
   prepareTestPgScript,
@@ -35,51 +36,108 @@ function hostStartupLooksLikePortContention(logs: string): boolean {
   return /EADDRINUSE|address already in use/i.test(logs);
 }
 
-function assertUsableBoxelUIDist(hostPackageDir: string): void {
-  let boxelUIAddonDir = join(hostPackageDir, '..', 'boxel-ui', 'addon');
-  let boxelUIDistDir = join(boxelUIAddonDir, 'dist');
-  let requiredPaths = [
+function boxelUIDistIsUsable(hostPackageDir: string): boolean {
+  let boxelUIDistDir = join(hostPackageDir, '..', 'boxel-ui', 'addon', 'dist');
+  return [
     join(boxelUIDistDir, 'components.js'),
     join(boxelUIDistDir, 'helpers.js'),
     join(boxelUIDistDir, 'icons.js'),
     join(boxelUIDistDir, 'styles', 'global.css'),
-  ];
+  ].every((path) => existsSync(path));
+}
 
-  if (requiredPaths.every((path) => existsSync(path))) {
+/**
+ * Ensure boxel-ui dist artifacts exist for the host package. Tries in order:
+ *   1. The current worktree's boxel-ui/addon/dist
+ *   2. Symlink from the root repo's built boxel-ui dist (fast, avoids rebuild)
+ *   3. Build boxel-ui in the current worktree (slow but always works)
+ */
+function ensureBoxelUIDist(hostPackageDir: string): void {
+  if (boxelUIDistIsUsable(hostPackageDir)) {
     return;
   }
 
+  let boxelUIAddonDir = join(hostPackageDir, '..', 'boxel-ui', 'addon');
+  let boxelUIDistDir = join(boxelUIAddonDir, 'dist');
+
+  // Try to symlink from root repo first (fast path for worktrees).
   let rootRepoCheckoutDir = findRootRepoCheckoutDir();
-  let rootRepoBoxelUIAddonDir =
-    rootRepoCheckoutDir && rootRepoCheckoutDir !== workspaceRoot
-      ? join(rootRepoCheckoutDir, 'packages', 'boxel-ui', 'addon')
-      : undefined;
-  let rootRepoBoxelUIDistDir = rootRepoBoxelUIAddonDir
-    ? join(rootRepoBoxelUIAddonDir, 'dist')
-    : undefined;
-  let hasRootRepoBoxelUIDist =
-    rootRepoBoxelUIDistDir != null &&
-    requiredPaths
-      .map((path) =>
-        join(rootRepoBoxelUIDistDir, path.slice(boxelUIDistDir.length + 1)),
-      )
-      .every((path) => existsSync(path));
-
-  let fixInstructions = [
-    `Run \`cd ${boxelUIAddonDir} && mise exec -- pnpm build\` to build boxel-ui in this checkout.`,
-  ];
-
-  if (hasRootRepoBoxelUIDist && rootRepoBoxelUIDistDir) {
-    fixInstructions.push(
-      `If you are in a worktree and want to reuse the main checkout build, run \`ln -sfn ${rootRepoBoxelUIDistDir} ${boxelUIDistDir}\`.`,
+  if (rootRepoCheckoutDir && rootRepoCheckoutDir !== workspaceRoot) {
+    let rootRepoBoxelUIDistDir = join(
+      rootRepoCheckoutDir,
+      'packages',
+      'boxel-ui',
+      'addon',
+      'dist',
     );
+    if (
+      existsSync(join(rootRepoBoxelUIDistDir, 'components.js')) &&
+      existsSync(join(rootRepoBoxelUIDistDir, 'helpers.js'))
+    ) {
+      supportLog.info(
+        `symlinking boxel-ui dist from root repo: ${rootRepoBoxelUIDistDir} -> ${boxelUIDistDir}`,
+      );
+      let result = spawnSync(
+        'ln',
+        ['-sfn', rootRepoBoxelUIDistDir, boxelUIDistDir],
+        {
+          stdio: 'inherit',
+        },
+      );
+      if (result.status === 0 && boxelUIDistIsUsable(hostPackageDir)) {
+        return;
+      }
+    }
   }
 
-  throw new Error(
-    `Boxel UI dist is missing or incomplete at ${boxelUIDistDir}. The software-factory harness needs built @cardstack/boxel-ui artifacts before the host app can boot. ${fixInstructions.join(
-      ' ',
-    )}`,
+  // Fall back to building boxel-ui.
+  supportLog.info(`building boxel-ui dist at ${boxelUIAddonDir}...`);
+  let result = spawnSync('pnpm', ['build'], {
+    cwd: boxelUIAddonDir,
+    stdio: 'inherit',
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to build boxel-ui at ${boxelUIAddonDir} (exit code ${result.status}). ` +
+        `Run \`cd ${boxelUIAddonDir} && pnpm build\` manually to diagnose.`,
+    );
+  }
+  if (!boxelUIDistIsUsable(hostPackageDir)) {
+    throw new Error(
+      `boxel-ui build succeeded but dist is still incomplete at ${boxelUIDistDir}`,
+    );
+  }
+}
+
+/**
+ * Build the host app dist when no pre-built dist is available anywhere.
+ * Returns the host package directory where the dist was built.
+ */
+function buildHostDist(): string {
+  // Prefer building in the current worktree so the output is local.
+  let buildDir = hostDir;
+  supportLog.info(
+    `no pre-built host dist found — building host app at ${buildDir}...`,
   );
+  let result = spawnSync('pnpm', ['build'], {
+    cwd: buildDir,
+    stdio: 'inherit',
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to build host app at ${buildDir} (exit code ${result.status}). ` +
+        `Run \`cd ${buildDir} && pnpm build\` manually to diagnose.`,
+    );
+  }
+  let indexPath = join(buildDir, 'dist', 'index.html');
+  if (!existsSync(indexPath)) {
+    throw new Error(
+      `Host build succeeded but dist/index.html is missing at ${buildDir}`,
+    );
+  }
+  return buildDir;
 }
 
 function assertUsableHostDist(hostPackageDir: string): void {
@@ -178,11 +236,11 @@ async function ensureHostReady(): Promise<{
 
       let hostPackageDir = findHostDistPackageDir();
       if (!hostPackageDir) {
-        throw new Error(
-          'No built host dist is available in the current worktree or root repo checkout',
-        );
+        // No pre-built host dist found anywhere. Build it automatically so
+        // cache:prepare works in a fresh worktree without manual setup.
+        hostPackageDir = buildHostDist();
       }
-      assertUsableBoxelUIDist(hostPackageDir);
+      ensureBoxelUIDist(hostPackageDir);
       assertUsableHostDist(hostPackageDir);
       let port = await findAvailablePort();
       let hostURL = `http://localhost:${port}/`;
@@ -383,6 +441,91 @@ export async function startHarnessPrerenderServer(options: {
   };
 }
 
+/**
+ * Ensure boxel-icons dist exists. In a worktree, symlink from the root repo
+ * if available, otherwise build.
+ */
+function ensureBoxelIconsDist(): void {
+  let distDir = join(boxelIconsDir, 'dist');
+  if (
+    existsSync(join(distDir, '@cardstack')) ||
+    existsSync(join(distDir, 'index.html'))
+  ) {
+    return;
+  }
+
+  // Try to symlink from root repo (fast path for worktrees).
+  let rootRepoCheckoutDir = findRootRepoCheckoutDir();
+  if (rootRepoCheckoutDir && rootRepoCheckoutDir !== workspaceRoot) {
+    let rootRepoIconsDistDir = join(
+      rootRepoCheckoutDir,
+      'packages',
+      'boxel-icons',
+      'dist',
+    );
+    if (existsSync(join(rootRepoIconsDistDir, '@cardstack'))) {
+      supportLog.info(
+        `symlinking boxel-icons dist from root repo: ${rootRepoIconsDistDir} -> ${distDir}`,
+      );
+      let result = spawnSync('ln', ['-sfn', rootRepoIconsDistDir, distDir], {
+        stdio: 'inherit',
+      });
+      if (result.status === 0 && existsSync(join(distDir, '@cardstack'))) {
+        return;
+      }
+    }
+  }
+
+  // Fall back to building boxel-icons.
+  supportLog.info(`building boxel-icons dist at ${boxelIconsDir}...`);
+  let result = spawnSync('pnpm', ['build'], {
+    cwd: boxelIconsDir,
+    stdio: 'inherit',
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to build boxel-icons at ${boxelIconsDir} (exit code ${result.status}). ` +
+        `Run \`cd ${boxelIconsDir} && pnpm build\` manually to diagnose.`,
+    );
+  }
+}
+
+function startIconServerProcess(): {
+  child: ReturnType<typeof spawn>;
+  logs: () => string;
+  stop: () => Promise<void>;
+} {
+  let child = spawn('pnpm', ['serve'], {
+    cwd: boxelIconsDir,
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: process.env,
+  });
+
+  let captured = '';
+  child.stdout?.on('data', (chunk) => {
+    captured = `${captured}${String(chunk)}`.slice(-20_000);
+  });
+  child.stderr?.on('data', (chunk) => {
+    captured = `${captured}${String(chunk)}`.slice(-20_000);
+  });
+
+  return {
+    child,
+    logs: () => captured,
+    async stop() {
+      if (child.exitCode === null) {
+        try {
+          process.kill(-child.pid!, 'SIGTERM');
+        } catch {
+          // best effort cleanup
+        }
+      }
+    },
+  };
+}
+
 async function ensureIconsReady(): Promise<{
   stop?: () => Promise<void>;
 }> {
@@ -390,64 +533,63 @@ async function ensureIconsReady(): Promise<{
     supportLog,
     `ensureIconsReady ${DEFAULT_ICONS_PROBE_URL}`,
     async () => {
+      // Ensure boxel-icons dist exists before trying to serve it.
+      ensureBoxelIconsDist();
+
+      // Always start our own managed icon server so we control its lifecycle.
+      // An externally-running server could die mid-indexing causing silent
+      // render timeouts. If port 4206 is already taken by a healthy dev
+      // server, our spawn will fail and we fall back to the existing one.
+      let server = startIconServerProcess();
+
       try {
-        let response = await fetch(DEFAULT_ICONS_PROBE_URL);
-        if (response.ok) {
-          supportLog.debug('icons server already available');
-          return {};
-        }
-      } catch {
-        // fall through and start the local icon server
+        await waitUntil(
+          async () => {
+            // If our process exited, either the port is already in use (dev
+            // server running) or the start genuinely failed. Check if the
+            // external server is healthy.
+            if (server.child.exitCode !== null) {
+              try {
+                let response = await fetch(DEFAULT_ICONS_PROBE_URL);
+                if (response.ok) {
+                  supportLog.debug(
+                    'icons server already available (external process)',
+                  );
+                  return true;
+                }
+              } catch {
+                // fall through
+              }
+              throw new Error(
+                `icons server exited early with code ${server.child.exitCode}\n${server.logs()}`,
+              );
+            }
+            try {
+              let response = await fetch(DEFAULT_ICONS_PROBE_URL);
+              return response.ok;
+            } catch {
+              return false;
+            }
+          },
+          {
+            timeout: 30_000,
+            interval: 250,
+            timeoutMessage: `Timed out waiting for icons server at ${DEFAULT_ICONS_PROBE_URL}\n${server.logs()}`,
+          },
+        );
+      } catch (error) {
+        await server.stop();
+        throw error;
       }
 
-      let child = spawn('pnpm', ['serve'], {
-        cwd: boxelIconsDir,
-        detached: true,
-        stdio: ['ignore', 'pipe', 'pipe'],
-        env: process.env,
-      });
+      if (server.child.exitCode !== null) {
+        // Our process couldn't start (port already taken by dev server).
+        // Return without a stop function since we don't own the server.
+        return {};
+      }
 
-      let logs = '';
-      child.stdout?.on('data', (chunk) => {
-        logs = `${logs}${String(chunk)}`.slice(-20_000);
-      });
-      child.stderr?.on('data', (chunk) => {
-        logs = `${logs}${String(chunk)}`.slice(-20_000);
-      });
-
-      await waitUntil(
-        async () => {
-          if (child.exitCode !== null) {
-            throw new Error(
-              `icons server exited early with code ${child.exitCode}\n${logs}`,
-            );
-          }
-          try {
-            let response = await fetch(DEFAULT_ICONS_PROBE_URL);
-            return response.ok;
-          } catch {
-            return false;
-          }
-        },
-        {
-          timeout: 30_000,
-          interval: 250,
-          timeoutMessage: `Timed out waiting for icons server at ${DEFAULT_ICONS_PROBE_URL}\n${logs}`,
-        },
-      );
-
-      supportLog.debug('started local icons server');
-      return {
-        async stop() {
-          if (child.exitCode === null) {
-            try {
-              process.kill(-child.pid!, 'SIGTERM');
-            } catch {
-              // best effort cleanup
-            }
-          }
-        },
-      };
+      supportLog.debug('started managed icons server');
+      return { stop: server.stop };
     },
   );
 }

--- a/packages/software-factory/src/harness/support-services.ts
+++ b/packages/software-factory/src/harness/support-services.ts
@@ -93,6 +93,12 @@ function ensureBoxelUIDist(hostPackageDir: string): void {
     }
   }
 
+  // Remove any leftover symlink so the build writes into the worktree,
+  // not through a symlink into the root repo.
+  if (existsSync(boxelUIDistDir)) {
+    rmSync(boxelUIDistDir, { recursive: true, force: true });
+  }
+
   // Fall back to building boxel-ui.
   supportLog.info(`building boxel-ui dist at ${boxelUIAddonDir}...`);
   let result = spawnSync('pnpm', ['build'], {
@@ -486,6 +492,12 @@ function ensureBoxelIconsDist(): void {
     }
   }
 
+  // Remove any leftover symlink so the build writes into the worktree,
+  // not through a symlink into the root repo.
+  if (existsSync(distDir)) {
+    rmSync(distDir, { recursive: true, force: true });
+  }
+
   // Fall back to building boxel-icons.
   supportLog.info(`building boxel-icons dist at ${boxelIconsDir}...`);
   let result = spawnSync('pnpm', ['build'], {
@@ -512,6 +524,7 @@ function ensureBoxelIconsDist(): void {
 function startIconServerProcess(): {
   child: ReturnType<typeof spawn>;
   logs: () => string;
+  spawnFailed: () => boolean;
   stop: () => Promise<void>;
 } {
   let child = spawn('pnpm', ['serve'], {
@@ -522,6 +535,7 @@ function startIconServerProcess(): {
   });
 
   let captured = '';
+  let spawnError = false;
   child.stdout?.on('data', (chunk) => {
     captured = `${captured}${String(chunk)}`.slice(-20_000);
   });
@@ -529,6 +543,7 @@ function startIconServerProcess(): {
     captured = `${captured}${String(chunk)}`.slice(-20_000);
   });
   child.on('error', (err) => {
+    spawnError = true;
     captured = `${captured}\n[icon server spawn error] ${err.message}\n`.slice(
       -20_000,
     );
@@ -537,6 +552,7 @@ function startIconServerProcess(): {
   return {
     child,
     logs: () => captured,
+    spawnFailed: () => spawnError,
     async stop() {
       if (child.exitCode === null) {
         try {
@@ -577,6 +593,9 @@ async function ensureIconsReady(): Promise<{
             // If our process exited, either the port is already in use (dev
             // server running) or the start genuinely failed. Check if the
             // external server is healthy.
+            if (server.spawnFailed()) {
+              throw new Error(`icons server failed to spawn\n${server.logs()}`);
+            }
             if (server.child.exitCode !== null) {
               try {
                 let response = await fetch(DEFAULT_ICONS_PROBE_URL);

--- a/packages/software-factory/src/harness/support-services.ts
+++ b/packages/software-factory/src/harness/support-services.ts
@@ -1,5 +1,5 @@
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 
 import {
@@ -77,15 +77,18 @@ function ensureBoxelUIDist(hostPackageDir: string): void {
       supportLog.info(
         `symlinking boxel-ui dist from root repo: ${rootRepoBoxelUIDistDir} -> ${boxelUIDistDir}`,
       );
-      let result = spawnSync(
-        'ln',
-        ['-sfn', rootRepoBoxelUIDistDir, boxelUIDistDir],
-        {
-          stdio: 'inherit',
-        },
-      );
-      if (result.status === 0 && boxelUIDistIsUsable(hostPackageDir)) {
-        return;
+      try {
+        if (existsSync(boxelUIDistDir)) {
+          rmSync(boxelUIDistDir, { recursive: true, force: true });
+        }
+        symlinkSync(rootRepoBoxelUIDistDir, boxelUIDistDir);
+        if (boxelUIDistIsUsable(hostPackageDir)) {
+          return;
+        }
+      } catch (error) {
+        supportLog.debug(
+          `symlink failed, will try building instead: ${error instanceof Error ? error.message : String(error)}`,
+        );
       }
     }
   }
@@ -467,11 +470,18 @@ function ensureBoxelIconsDist(): void {
       supportLog.info(
         `symlinking boxel-icons dist from root repo: ${rootRepoIconsDistDir} -> ${distDir}`,
       );
-      let result = spawnSync('ln', ['-sfn', rootRepoIconsDistDir, distDir], {
-        stdio: 'inherit',
-      });
-      if (result.status === 0 && existsSync(join(distDir, '@cardstack'))) {
-        return;
+      try {
+        if (existsSync(distDir)) {
+          rmSync(distDir, { recursive: true, force: true });
+        }
+        symlinkSync(rootRepoIconsDistDir, distDir);
+        if (existsSync(join(distDir, '@cardstack'))) {
+          return;
+        }
+      } catch (error) {
+        supportLog.debug(
+          `symlink failed, will try building instead: ${error instanceof Error ? error.message : String(error)}`,
+        );
       }
     }
   }
@@ -487,6 +497,14 @@ function ensureBoxelIconsDist(): void {
     throw new Error(
       `Failed to build boxel-icons at ${boxelIconsDir} (exit code ${result.status}). ` +
         `Run \`cd ${boxelIconsDir} && pnpm build\` manually to diagnose.`,
+    );
+  }
+  if (
+    !existsSync(join(distDir, '@cardstack')) &&
+    !existsSync(join(distDir, 'index.html'))
+  ) {
+    throw new Error(
+      `Built boxel-icons at ${boxelIconsDir} but dist output is missing at ${distDir}`,
     );
   }
 }
@@ -510,6 +528,11 @@ function startIconServerProcess(): {
   child.stderr?.on('data', (chunk) => {
     captured = `${captured}${String(chunk)}`.slice(-20_000);
   });
+  child.on('error', (err) => {
+    captured = `${captured}\n[icon server spawn error] ${err.message}\n`.slice(
+      -20_000,
+    );
+  });
 
   return {
     child,
@@ -519,7 +542,13 @@ function startIconServerProcess(): {
         try {
           process.kill(-child.pid!, 'SIGTERM');
         } catch {
-          // best effort cleanup
+          // best effort — process may have already exited or negative
+          // PID may not be supported on this platform.
+          try {
+            child.kill('SIGTERM');
+          } catch {
+            // truly best effort
+          }
         }
       }
     },
@@ -560,8 +589,15 @@ async function ensureIconsReady(): Promise<{
               } catch {
                 // fall through
               }
+              // If our process exited due to port contention, the external
+              // server may still be starting up. Keep polling instead of
+              // failing immediately.
+              let logs = server.logs();
+              if (/EADDRINUSE|address already in use/i.test(logs)) {
+                return false;
+              }
               throw new Error(
-                `icons server exited early with code ${server.child.exitCode}\n${server.logs()}`,
+                `icons server exited early with code ${server.child.exitCode}\n${logs}`,
               );
             }
             try {

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -165,14 +165,14 @@ async function isPortFree(port: number): Promise<boolean> {
 async function allocateTestWorkerPortSet(
   testWorkerIndex: number,
 ): Promise<TestWorkerPortSet> {
-  // Reserve one stable port block per Playwright testWorker. The isolated
-  // harness still restarts realm-server, worker-manager, compat proxy, and
-  // prerender between tests, but those services should come back on the same
-  // URLs for the lifetime of the testWorker. That keeps BOXEL_HOST_URL and the
-  // prerender standby target stable within a worker even when the realm stack
-  // itself is recreated per test. Include a per-process offset so concurrent
-  // Playwright runs with the same worker index do not all probe the same block
-  // first.
+  // Reserve one stable port block per Playwright testWorker for services whose
+  // URLs must remain constant across test restarts within the same worker:
+  // compat proxy and realm-server (for BOXEL_HOST_URL stability) and prerender
+  // (standby target). The worker-manager port is NOT pre-allocated here — it is
+  // dynamically assigned via findAvailablePort() each time a realm stack starts,
+  // since its URL does not need to be stable. Include a per-process offset so
+  // concurrent Playwright runs with the same worker index do not all probe the
+  // same block first.
   for (let attempt = 0; attempt < 100; attempt++) {
     let blockStart =
       testWorkerPortBase +

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -63,7 +63,6 @@ type SharedRealmHandle = {
 type TestWorkerPortSet = {
   compatRealmServerPort: number;
   realmServerPort: number;
-  workerManagerPort: number;
   prerenderPort: number;
 };
 
@@ -183,8 +182,7 @@ async function allocateTestWorkerPortSet(
     let candidate: TestWorkerPortSet = {
       compatRealmServerPort: blockStart,
       realmServerPort: blockStart + 1,
-      workerManagerPort: blockStart + 2,
-      prerenderPort: blockStart + 3,
+      prerenderPort: blockStart + 2,
     };
     let ports = Object.values(candidate);
     if (
@@ -282,9 +280,6 @@ async function startRealmProcess(
           testWorkerPortSet.compatRealmServerPort,
         ),
         SOFTWARE_FACTORY_REALM_PORT: String(testWorkerPortSet.realmServerPort),
-        SOFTWARE_FACTORY_WORKER_MANAGER_PORT: String(
-          testWorkerPortSet.workerManagerPort,
-        ),
         SOFTWARE_FACTORY_PRERENDER_PORT: String(
           testWorkerPortSet.prerenderPort,
         ),


### PR DESCRIPTION
## Summary

Resolves [CS-10560](https://linear.app/cardstack/issue/CS-10560): `cache:prepare` now works in a completely fresh worktree with zero running services.

- **Auto-provision build artifacts**: Host dist, boxel-ui dist, and boxel-icons dist are automatically symlinked from the root repo (fast) or built from source (fallback) when missing in a worktree. Uses `fs.symlinkSync` for cross-platform compatibility.

- **Managed icon server lifecycle**: Always starts our own icon server process instead of hoping an externally-detected server stays alive. Falls back to the existing dev server if port 4206 is already taken (with EADDRINUSE retry for slow-starting external servers).

- **Indexing progress bar**: Pre-allocates the worker-manager port and polls its `/_indexing-status` JSON endpoint every 2s. Shows an in-place single-line progress bar that updates as each realm is indexed. File counts come from the invalidation graph so they're precise. The reporter tracks seen realms to show how many remain:
  ```
    indexing: waiting for status 3s
    indexing base: discovering files... 8s (2 realms remaining)
    indexing base [===============>              ] 105/153 files (69%) 50s (2 realms remaining)
       ↓ (line switches in-place when realm finishes)
    indexing software-factory [============>         ] 113/204 files (55%) 155s (1 realm remaining)
       ↓
    indexing test [=======================>      ] 10/12 files (83%) 230s
    indexing complete: 12/12 files in 235.0s
  ```

- **Graceful pg unavailability**: `databaseExists()` returns false instead of throwing when postgres isn't running yet.

- **Stale context validation**: Validates both hostURL and matrixURL in cached support.json, discarding stale contexts.

## Test plan

- [x] `cache:prepare` succeeds in a fresh worktree with no services running (pg, synapse, host, icons all auto-started)
- [x] `cache:prepare` succeeds alongside a running `mise run dev-all` without disrupting dev services
- [x] Host app at `localhost:4200` remains fully functional during and after `cache:prepare`
- [x] Progress bar updates live during indexing (verified by polling `/_indexing-status` endpoint directly: base 0→150/153, software-factory 4→198/204, test 0→10/12)
- [x] `totalFiles` from the invalidation graph is precise
- [x] Remaining realm count decrements as realms complete (2 → 1 → 0)
- [ ] Playwright tests pass with the updated harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)