### PR TITLE
fix: reposition file tree context menu anchor (CS-10558)

### DIFF
--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -310,6 +310,25 @@ export default class Directory extends Component<Args> {
     e.preventDefault();
     e.stopPropagation();
     this.menuEntryPath = entryPath;
+
+    // Reposition hidden anchor to the clicked element so the dropdown appears nearby
+    const anchor = document.querySelector(
+      `[data-ebd-id="${this.dropdownApi?.uniqueId}-trigger"]`,
+    ) as HTMLElement | null;
+
+    if (anchor) {
+      if (e.type === 'contextmenu') {
+        anchor.style.top = `${e.clientY}px`;
+        anchor.style.left = `${e.clientX}px`;
+      } else {
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+        anchor.style.top = `${rect.top}px`;
+        anchor.style.left = `${rect.left}px`;
+        anchor.style.width = `${rect.width}px`;
+        anchor.style.height = `${rect.height}px`;
+      }
+    }
+
     this.dropdownApi?.actions.open(e);
   }
 


### PR DESCRIPTION
## Summary
- The delete/context menu in the code mode file tree appeared detached from the selected file item because the hidden dropdown anchor was `position: fixed` at (0, 0) and never repositioned
- Now the anchor is moved to the clicked "..." button's location (or cursor position for right-click) before opening the dropdown, so `ember-basic-dropdown` calculates the correct position
- Likely also fixes CS-10552 (menu added to DOM but not visible — same root cause)

## Test plan
- [x] Verified manually that menu appears adjacent to the clicked file item
- [ ] Existing acceptance tests pass: "can delete a file from file tree context menu", "can cancel delete from file tree context menu", "can delete a file via right-click in file tree"

🤖 Generated with [Claude Code](https://claude.com/claude-code)