### PR TITLE
Resolve module identifier with @cardstack/catalog/ prefix

### DIFF
--- a/packages/host/app/services/card-type-service.ts
+++ b/packages/host/app/services/card-type-service.ts
@@ -120,9 +120,10 @@ export default class CardTypeService extends Service {
       return cached;
     }
     let moduleIdentifier = moduleFrom(ref);
+    let moduleURL = cardIdToURL(moduleIdentifier);
     let moduleInfo =
-      this.moduleInfoCache.get(moduleIdentifier) ??
-      (await this.fetchModuleInfo(cardIdToURL(moduleIdentifier)));
+      this.moduleInfoCache.get(moduleURL.href) ??
+      (await this.fetchModuleInfo(moduleURL));
 
     let api = await loader.import<typeof CardAPI>(`${baseRealm.url}card-api`);
     let { id: _remove, ...fields } = api.getFields(card, {

--- a/packages/host/app/services/card-type-service.ts
+++ b/packages/host/app/services/card-type-service.ts
@@ -11,6 +11,7 @@ import {
   getAncestor,
   SupportedMimeType,
   isResolvedCodeRef,
+  cardIdToURL,
   type ResolvedCodeRef,
 } from '@cardstack/runtime-common';
 import { isCodeRef, type CodeRef } from '@cardstack/runtime-common/code-ref';
@@ -121,7 +122,7 @@ export default class CardTypeService extends Service {
     let moduleIdentifier = moduleFrom(ref);
     let moduleInfo =
       this.moduleInfoCache.get(moduleIdentifier) ??
-      (await this.fetchModuleInfo(new URL(moduleIdentifier)));
+      (await this.fetchModuleInfo(cardIdToURL(moduleIdentifier)));
 
     let api = await loader.import<typeof CardAPI>(`${baseRealm.url}card-api`);
     let { id: _remove, ...fields } = api.getFields(card, {


### PR DESCRIPTION
This affects LHS when we open a module 

<img width="869" height="412" alt="Screenshot 2026-04-01 at 2 45 01 PM" src="https://github.com/user-attachments/assets/e2465801-ed38-468d-8d2e-21383db08664" />


It seems this is activated when opening a card that imports @cardstack/catalog/prefix from the type-chain somehow. Either LHS or RHS