### PR TITLE
Prevent create-file modal from closing during creation

### DIFF
--- a/packages/host/app/components/modal-container.gts
+++ b/packages/host/app/components/modal-container.gts
@@ -19,6 +19,7 @@ interface Signature {
     centered?: boolean;
     cardContainerClass?: string;
     isOpen?: boolean;
+    isCloseDisabled?: boolean;
     layer?: 'urgent';
   };
   Blocks: {
@@ -43,6 +44,7 @@ export default class ModalContainer extends Component<Signature> {
       @isOpen={{this.isOpen}}
       @onClose={{@onClose}}
       @centered={{@centered}}
+      @isOverlayDismissalDisabled={{@isCloseDisabled}}
       @layer={{@layer}}
       ...attributes
     >
@@ -66,6 +68,7 @@ export default class ModalContainer extends Component<Signature> {
             {{on 'click' @onClose}}
             class='dialog-box__close'
             aria-label='close modal'
+            disabled={{@isCloseDisabled}}
             data-test-close-modal
           />
           {{yield to='header'}}

--- a/packages/host/app/components/modal-container.gts
+++ b/packages/host/app/components/modal-container.gts
@@ -146,8 +146,13 @@ export default class ModalContainer extends Component<Signature> {
         border-top-right-radius: calc(var(--boxel-border-radius) - 1px);
       }
 
-      .dialog-box__close:hover {
+      .dialog-box__close:hover:not(:disabled) {
         --icon-color: var(--boxel-highlight);
+      }
+
+      .dialog-box__close:disabled {
+        --icon-color: var(--boxel-300);
+        cursor: default;
       }
 
       .dialog-box__footer {

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -158,6 +158,7 @@ export default class CreateFileModal extends Component<Signature> {
           @size='medium'
           @isOpen={{this.isModalOpen}}
           @onClose={{this.onCancel}}
+          @isCloseDisabled={{this.isCreateRunning}}
           {{focusTrap
             isActive=this.isReady
             focusTrapOptions=(hash
@@ -313,6 +314,7 @@ export default class CreateFileModal extends Component<Signature> {
                     {{on 'click' this.onCancel}}
                     {{onKeyMod 'Escape'}}
                     @size='tall'
+                    @disabled={{this.isCreateRunning}}
                     data-test-cancel-create-file
                   >
                     Cancel
@@ -598,6 +600,9 @@ export default class CreateFileModal extends Component<Signature> {
   }
 
   @action private onCancel() {
+    if (this.isCreateRunning) {
+      return;
+    }
     this.currentRequest?.newFileDeferred.fulfill(undefined);
     this.clearState();
   }
@@ -722,7 +727,8 @@ export default class CreateFileModal extends Component<Signature> {
     return (
       this.createCardInstance.isRunning ||
       this.createDefinition.isRunning ||
-      this.createTextFile.isRunning
+      this.createTextFile.isRunning ||
+      this.duplicateCardInstance.isRunning
     );
   }
 

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -906,15 +906,21 @@ export class TestCard extends Person {
       let createClickPromise = click('[data-test-create-definition]');
 
       // Wait for the POST to be intercepted (task is now mid-creation)
-      await waitUntil(() => postIntercepted);
+      await waitUntil(() => postIntercepted, {
+        timeout: 10000,
+        timeoutMessage: 'Timed out waiting for save POST to be intercepted',
+      });
 
       // Attempt to dismiss the modal while creation is in-flight using raw
       // DOM click (we can't use ember's click helper here because it awaits
       // settled, which won't resolve while the creation task is blocked)
-      let cancelBtn = document.querySelector(
-        '[data-test-cancel-create-file]',
-      ) as HTMLElement;
-      cancelBtn.click();
+      let cancelBtn = document.querySelector('[data-test-cancel-create-file]');
+      if (!cancelBtn) {
+        throw new Error(
+          'Could not find [data-test-cancel-create-file] button while creation is in progress',
+        );
+      }
+      (cancelBtn as HTMLElement).click();
 
       // Modal should still be open because creation is in progress
       assert

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -878,6 +878,60 @@ export class TestCard extends Person {
         .doesNotExist('changing a field should clear the error');
     });
 
+    test<TestContextWithSave>('modal cannot be dismissed while creation is in progress (CS-10557)', async function (assert) {
+      await visitOperatorMode();
+      await openNewFileModal('Card Definition');
+      await fillIn('[data-test-display-name-field]', 'Dismiss Test Card');
+      await fillIn('[data-test-file-name-field]', 'dismiss-test-card');
+
+      // Mount a network handler that blocks the save POST request
+      // so we can attempt to dismiss the modal while creation is in-flight
+      let saveDeferred = new Deferred<void>();
+      let postIntercepted = false;
+      getService('network').mount(
+        async (req: Request) => {
+          if (
+            req.method === 'POST' &&
+            req.url.includes('dismiss-test-card.gts')
+          ) {
+            postIntercepted = true;
+            await saveDeferred.promise;
+          }
+          return null;
+        },
+        { prepend: true },
+      );
+
+      // Click Create without awaiting - the task will be blocked by our handler
+      let createClickPromise = click('[data-test-create-definition]');
+
+      // Wait for the POST to be intercepted (task is now mid-creation)
+      await waitUntil(() => postIntercepted);
+
+      // Attempt to dismiss the modal while creation is in-flight using raw
+      // DOM click (we can't use ember's click helper here because it awaits
+      // settled, which won't resolve while the creation task is blocked)
+      let cancelBtn = document.querySelector(
+        '[data-test-cancel-create-file]',
+      ) as HTMLElement;
+      cancelBtn.click();
+
+      // Modal should still be open because creation is in progress
+      assert
+        .dom('[data-test-create-file-modal]')
+        .exists('modal stays open during creation');
+
+      // Let the save complete
+      this.onSave(() => {});
+      saveDeferred.fulfill();
+      await createClickPromise;
+
+      // After creation completes, the modal closes normally
+      assert
+        .dom('[data-test-create-file-modal]')
+        .doesNotExist('modal closes after creation completes');
+    });
+
     test<TestContextWithSave>('can create a new field definition that extends field definition that uses default export', async function (assert) {
       assert.expect(3);
       await visitOperatorMode();


### PR DESCRIPTION
There is a scenario where if you choose to create a card  or file using the modal in code mode, and click "Create" and then immediately close the modal, this error would show up next time you open the modal:

<img width="770" height="575" alt="image" src="https://github.com/user-attachments/assets/f2eab0e2-a6e5-469a-ba78-b8313219918d" />

I think we should not allow the user to close the modal if file creation is still in progress. This fixes the problem.