### PR TITLE
eslint: Add missing documentation and CI check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -189,6 +189,11 @@ jobs:
       - name: ESLint Plugin Boxel test suite
         run: pnpm test
         working-directory: packages/eslint-plugin-boxel
+      - name: Check generated files are up to date
+        working-directory: packages/eslint-plugin-boxel
+        run: |
+          pnpm run update
+          git diff --exit-code || (echo "::error::Generated files are out of date. Run 'pnpm run update' in packages/eslint-plugin-boxel and commit the result." && exit 1)
 
   postgres-migration-test:
     name: Postgres Migration Test

--- a/packages/eslint-plugin-boxel/README.md
+++ b/packages/eslint-plugin-boxel/README.md
@@ -36,7 +36,7 @@ Then configure the rules you want to use under the rules section:
 | Name                                                                   | Description                                                                                                        | 💼 | 🔧 |
 | :--------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- | :- | :- |
 | [missing-card-api-import](docs/rules/missing-card-api-import.md)       | disallow usage of card-api with missing imports with auto-fix                                                      | ✅  | 🔧 |
-| [no-css-position-fixed](docs/rules/no-css-position-fixed.md)           | disallow `position: fixed` in card CSS because cards should not break out of their bounding box                    | ✅  |    |
+| [no-css-position-fixed](docs/rules/no-css-position-fixed.md)           | disallow `position: fixed` in card CSS because cards should not break out of their bounding box                    |    |    |
 | [no-duplicate-imports](docs/rules/no-duplicate-imports.md)             | Prevent duplicate imports from the same module                                                                     | ✅  | 🔧 |
 | [no-forbidden-head-tags](docs/rules/no-forbidden-head-tags.md)         | disallow forbidden HTML elements in `static head` templates — only `<title>`, `<meta>`, and `<link>` are permitted | ✅  |    |
 | [no-literal-realm-urls](docs/rules/no-literal-realm-urls.md)           | Disallow environment-specific realm URLs in code; use portable prefixes like @cardstack/catalog/ instead           |    | 🔧 |

--- a/packages/eslint-plugin-boxel/README.md
+++ b/packages/eslint-plugin-boxel/README.md
@@ -33,10 +33,15 @@ Then configure the rules you want to use under the rules section:
 ✅ Set in the `recommended` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                                                                   | Description                                                                                     | 💼 | 🔧 |
-| :--------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------- | :- | :- |
-| [missing-card-api-import](docs/rules/missing-card-api-import.md)       | disallow usage of card-api with missing imports with auto-fix                                   | ✅  | 🔧 |
-| [template-missing-invokable](docs/rules/template-missing-invokable.md) | disallow missing helpers, modifiers, or components in \<template\> with auto-fix to import them | ✅  | 🔧 |
+| Name                                                                   | Description                                                                                                        | 💼 | 🔧 |
+| :--------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- | :- | :- |
+| [missing-card-api-import](docs/rules/missing-card-api-import.md)       | disallow usage of card-api with missing imports with auto-fix                                                      | ✅  | 🔧 |
+| [no-css-position-fixed](docs/rules/no-css-position-fixed.md)           | disallow `position: fixed` in card CSS because cards should not break out of their bounding box                    | ✅  |    |
+| [no-duplicate-imports](docs/rules/no-duplicate-imports.md)             | Prevent duplicate imports from the same module                                                                     | ✅  | 🔧 |
+| [no-forbidden-head-tags](docs/rules/no-forbidden-head-tags.md)         | disallow forbidden HTML elements in `static head` templates — only `<title>`, `<meta>`, and `<link>` are permitted | ✅  |    |
+| [no-literal-realm-urls](docs/rules/no-literal-realm-urls.md)           | Disallow environment-specific realm URLs in code; use portable prefixes like @cardstack/catalog/ instead           |    | 🔧 |
+| [no-percy-direct-import](docs/rules/no-percy-direct-import.md)         | Forbid importing percySnapshot directly from @percy/ember; use @cardstack/host/tests/helpers instead               | ✅  | 🔧 |
+| [template-missing-invokable](docs/rules/template-missing-invokable.md) | disallow missing helpers, modifiers, or components in \<template\> with auto-fix to import them                    | ✅  | 🔧 |
 
 <!-- end auto-generated rules list -->
 

--- a/packages/eslint-plugin-boxel/docs/rules/no-css-position-fixed.md
+++ b/packages/eslint-plugin-boxel/docs/rules/no-css-position-fixed.md
@@ -1,0 +1,7 @@
+# Disallow `position: fixed` in card CSS because cards should not break out of their bounding box (`@cardstack/boxel/no-css-position-fixed`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->
+
+Disallow `position: fixed` in CSS within card templates. Cards are rendered inside containers where fixed positioning doesn't behave as expected.

--- a/packages/eslint-plugin-boxel/docs/rules/no-css-position-fixed.md
+++ b/packages/eslint-plugin-boxel/docs/rules/no-css-position-fixed.md
@@ -1,7 +1,5 @@
 # Disallow `position: fixed` in card CSS because cards should not break out of their bounding box (`@cardstack/boxel/no-css-position-fixed`)
 
-💼 This rule is enabled in the ✅ `recommended` config.
-
 <!-- end auto-generated rule header -->
 
 Disallow `position: fixed` in CSS within card templates. Cards are rendered inside containers where fixed positioning doesn't behave as expected.

--- a/packages/eslint-plugin-boxel/docs/rules/no-duplicate-imports.md
+++ b/packages/eslint-plugin-boxel/docs/rules/no-duplicate-imports.md
@@ -1,4 +1,10 @@
-# no-duplicate-imports
+# Prevent duplicate imports from the same module (`@cardstack/boxel/no-duplicate-imports`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 > Enforce all imports from a module to be in a single declaration
 

--- a/packages/eslint-plugin-boxel/docs/rules/no-forbidden-head-tags.md
+++ b/packages/eslint-plugin-boxel/docs/rules/no-forbidden-head-tags.md
@@ -1,0 +1,7 @@
+# Disallow forbidden HTML elements in `static head` templates — only `<title>`, `<meta>`, and `<link>` are permitted (`@cardstack/boxel/no-forbidden-head-tags`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->
+
+Disallow forbidden HTML tags in card head sections.

--- a/packages/eslint-plugin-boxel/docs/rules/no-literal-realm-urls.md
+++ b/packages/eslint-plugin-boxel/docs/rules/no-literal-realm-urls.md
@@ -1,0 +1,17 @@
+# Disallow environment-specific realm URLs in code; use portable prefixes like @cardstack/catalog/ instead (`@cardstack/boxel/no-literal-realm-urls`)
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+Disallow environment-specific realm URLs in code; use portable prefixes like @cardstack/catalog/ instead.
+
+## Options
+
+### `realmMappings`
+
+Array of realm mapping objects, each with:
+
+- `prefix` (string) — the portable prefix (e.g. `@cardstack/catalog/`)
+- `urls` (string[]) — environment-specific URLs to replace
+- `patterns` (string[], optional) — regex patterns for dynamic URLs

--- a/packages/eslint-plugin-boxel/docs/rules/no-percy-direct-import.md
+++ b/packages/eslint-plugin-boxel/docs/rules/no-percy-direct-import.md
@@ -1,0 +1,9 @@
+# Forbid importing percySnapshot directly from @percy/ember; use @cardstack/host/tests/helpers instead (`@cardstack/boxel/no-percy-direct-import`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+Disallow direct imports from Percy packages.

--- a/packages/eslint-plugin-boxel/lib/recommended-rules.js
+++ b/packages/eslint-plugin-boxel/lib/recommended-rules.js
@@ -6,7 +6,6 @@
  */
 module.exports = {
   "@cardstack/boxel/missing-card-api-import": "error",
-  "@cardstack/boxel/no-css-position-fixed": "error",
   "@cardstack/boxel/no-duplicate-imports": "error",
   "@cardstack/boxel/no-forbidden-head-tags": "error",
   "@cardstack/boxel/no-percy-direct-import": "error",

--- a/packages/eslint-plugin-boxel/lib/recommended-rules.js
+++ b/packages/eslint-plugin-boxel/lib/recommended-rules.js
@@ -10,6 +10,5 @@ module.exports = {
   "@cardstack/boxel/no-duplicate-imports": "error",
   "@cardstack/boxel/no-forbidden-head-tags": "error",
   "@cardstack/boxel/no-percy-direct-import": "error",
-  "@cardstack/boxel/template-missing-invokable": "error",
-  "@cardstack/boxel/deliberately-stale": "error"
+  "@cardstack/boxel/template-missing-invokable": "error"
 }

--- a/packages/eslint-plugin-boxel/lib/recommended-rules.js
+++ b/packages/eslint-plugin-boxel/lib/recommended-rules.js
@@ -10,5 +10,6 @@ module.exports = {
   "@cardstack/boxel/no-duplicate-imports": "error",
   "@cardstack/boxel/no-forbidden-head-tags": "error",
   "@cardstack/boxel/no-percy-direct-import": "error",
-  "@cardstack/boxel/template-missing-invokable": "error"
+  "@cardstack/boxel/template-missing-invokable": "error",
+  "@cardstack/boxel/deliberately-stale": "error"
 }

--- a/packages/eslint-plugin-boxel/lib/recommended-rules.js
+++ b/packages/eslint-plugin-boxel/lib/recommended-rules.js
@@ -6,7 +6,9 @@
  */
 module.exports = {
   "@cardstack/boxel/missing-card-api-import": "error",
+  "@cardstack/boxel/no-css-position-fixed": "error",
   "@cardstack/boxel/no-duplicate-imports": "error",
+  "@cardstack/boxel/no-forbidden-head-tags": "error",
   "@cardstack/boxel/no-percy-direct-import": "error",
   "@cardstack/boxel/template-missing-invokable": "error"
 }

--- a/packages/eslint-plugin-boxel/lib/rules/no-css-position-fixed.js
+++ b/packages/eslint-plugin-boxel/lib/rules/no-css-position-fixed.js
@@ -6,7 +6,7 @@ module.exports = {
       description:
         'disallow `position: fixed` in card CSS because cards should not break out of their bounding box',
       category: 'Ember Octane',
-      recommended: true,
+      recommended: false,
     },
     schema: [],
     messages: {


### PR DESCRIPTION
`pnpm run update` in the Boxel ESLint plugin fails when rule documentation is missing:

```
❯ pnpm run update

> @cardstack/eslint-plugin-boxel@0.1.0 update /Users/b/Documents/Cardstack/Code/boxel-motion/.claude/worktrees/eslint-docs/packages/eslint-plugin-boxel
> node ./scripts/update-rules.js && pnpm run update:eslint-docs


> @cardstack/eslint-plugin-boxel@0.1.0 update:eslint-docs /Users/b/Documents/Cardstack/Code/boxel-motion/.claude/worktrees/eslint-docs/packages/eslint-plugin-boxel
> eslint-doc-generator

Could not find rule doc (run with --init-rule-docs to create): docs/rules/template-missing-invokable.md
```

This adds the missing documentation and a CI rule to enforce these rules being added. The CI rule failed [here](https://github.com/cardstack/boxel/actions/runs/23858335788/job/69557765508?pr=4300#step:5:57):

```
diff --git a/packages/eslint-plugin-boxel/lib/recommended-rules.js b/packages/eslint-plugin-boxel/lib/recommended-rules.js
index 2da9dee..dfd235b 100644
--- a/packages/eslint-plugin-boxel/lib/recommended-rules.js
+++ b/packages/eslint-plugin-boxel/lib/recommended-rules.js
@@ -10,6 +10,5 @@ module.exports = {
   "@cardstack/boxel/no-duplicate-imports": "error",
   "@cardstack/boxel/no-forbidden-head-tags": "error",
   "@cardstack/boxel/no-percy-direct-import": "error",
-  "@cardstack/boxel/template-missing-invokable": "error",
-  "@cardstack/boxel/deliberately-stale": "error"
+  "@cardstack/boxel/template-missing-invokable": "error"
 }
\ No newline at end of file
Error: Generated files are out of date. Run 'pnpm run update' in packages/eslint-plugin-boxel and commit the result.
Error: Process completed with exit code 1.
```