### PR TITLE
Add ContextBuilder for AgentContext assembly (CS-10567)

### DIFF
--- a/packages/software-factory/package.json
+++ b/packages/software-factory/package.json
@@ -10,6 +10,7 @@
     "boxel:session": "NODE_NO_WARNINGS=1 ts-node --transpileOnly scripts/boxel-session.ts",
     "cache:prepare": "NODE_NO_WARNINGS=1 ts-node --transpileOnly src/cli/cache-realm.ts",
     "factory:agent-smoke": "NODE_NO_WARNINGS=1 ts-node --transpileOnly scripts/factory-agent-smoke.ts",
+    "factory:context-smoke": "NODE_NO_WARNINGS=1 ts-node --transpileOnly scripts/factory-context-smoke.ts",
     "factory:go": "NODE_NO_WARNINGS=1 ts-node --transpileOnly src/cli/factory-entrypoint.ts",
     "factory:prompt-smoke": "NODE_NO_WARNINGS=1 ts-node --transpileOnly scripts/factory-prompt-smoke.ts",
     "factory:skill-smoke": "NODE_NO_WARNINGS=1 ts-node --transpileOnly scripts/factory-skill-smoke.ts",

--- a/packages/software-factory/scripts/factory-context-smoke.ts
+++ b/packages/software-factory/scripts/factory-context-smoke.ts
@@ -1,0 +1,285 @@
+/**
+ * Smoke test for the ContextBuilder.
+ *
+ * No servers, no API keys — exercises the full context assembly pipeline
+ * using real skill files from disk and the real SkillResolver/SkillLoader.
+ *
+ * Usage:
+ *   pnpm factory:context-smoke
+ *   pnpm factory:context-smoke --max-tokens 8000
+ */
+
+import { parseArgs } from 'node:util';
+
+import type {
+  KnowledgeArticle,
+  ProjectCard,
+  TicketCard,
+} from './lib/factory-agent';
+import { ContextBuilder } from './lib/factory-context-builder';
+import {
+  DefaultSkillResolver,
+  estimateTokens,
+  SkillLoader,
+} from './lib/factory-skill-loader';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function check(label: string, ok: boolean, detail?: string): void {
+  if (ok) {
+    passed++;
+    console.log(`  \u2713 ${label}`);
+  } else {
+    failed++;
+    console.log(`  \u2717 ${label}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SAMPLE_PROJECT: ProjectCard = {
+  id: 'Projects/sticky-notes',
+  name: 'Sticky Notes MVP',
+};
+
+const SAMPLE_KNOWLEDGE: KnowledgeArticle[] = [
+  {
+    id: 'Knowledge/card-basics',
+    title: 'Boxel Card Development Basics',
+    body: 'Cards are defined as .gts files with CardDef base class...',
+  },
+  {
+    id: 'Knowledge/testing-guide',
+    title: 'Playwright Testing Guide',
+    body: 'Tests live in Tests/ folder as .spec.ts files...',
+  },
+];
+
+const SAMPLE_TICKETS: { label: string; ticket: TicketCard }[] = [
+  {
+    label: 'Card definition (.gts work)',
+    ticket: {
+      id: 'Tickets/define-sticky-note',
+      title: 'Define StickyNote card',
+      description:
+        'Create a .gts card definition for StickyNote with title, body, and color fields. Include fitted and isolated views.',
+    },
+  },
+  {
+    label: 'Factory workflow ticket',
+    ticket: {
+      id: 'Tickets/improve-orchestrator',
+      title: 'Improve factory delivery pipeline',
+      description:
+        'Update the factory orchestrator to handle multi-ticket workflows with better error recovery.',
+    },
+  },
+  {
+    label: 'Minimal ticket (base case)',
+    ticket: {
+      id: 'Tickets/add-timestamps',
+      title: 'Add timestamp fields',
+      description: 'Add createdAt and updatedAt fields to the card.',
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  let { values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      'max-tokens': { type: 'string' },
+    },
+    strict: true,
+    allowPositionals: true,
+  });
+
+  let maxSkillTokens = values['max-tokens']
+    ? Number(values['max-tokens'])
+    : undefined;
+
+  if (
+    values['max-tokens'] !== undefined &&
+    (maxSkillTokens === undefined ||
+      !Number.isFinite(maxSkillTokens) ||
+      maxSkillTokens <= 0)
+  ) {
+    console.error(
+      `Invalid value for --max-tokens: "${values['max-tokens']}". ` +
+        'Please provide a positive numeric value.',
+    );
+    process.exit(1);
+  }
+
+  let builder = new ContextBuilder({
+    skillResolver: new DefaultSkillResolver(),
+    skillLoader: new SkillLoader(),
+    maxSkillTokens,
+  });
+
+  console.log('');
+  console.log('=== Context Builder Smoke Test ===');
+  console.log('');
+
+  for (let { label, ticket } of SAMPLE_TICKETS) {
+    console.log(`--- ${label} ---`);
+    console.log(`  Ticket: ${ticket.title}`);
+    console.log('');
+
+    // -------------------------------------------------------------------
+    // First pass (no test results)
+    // -------------------------------------------------------------------
+
+    let ctx = await builder.build({
+      project: SAMPLE_PROJECT,
+      ticket,
+      knowledge: SAMPLE_KNOWLEDGE,
+      targetRealmUrl: 'https://example.test/user/target/',
+      testRealmUrl: 'https://example.test/user/target-test-artifacts/',
+    });
+
+    console.log('  First pass (no test results):');
+    check('project.id set', ctx.project.id === SAMPLE_PROJECT.id);
+    check('ticket.id set', ctx.ticket.id === ticket.id);
+    check(
+      `knowledge: ${ctx.knowledge.length} article(s)`,
+      ctx.knowledge.length === SAMPLE_KNOWLEDGE.length,
+    );
+    check(`skills: ${ctx.skills.length} loaded`, ctx.skills.length > 0);
+    check(
+      'tools not set (provided separately as FactoryTool[])',
+      ctx.tools === undefined,
+    );
+    check('testResults not set', ctx.testResults === undefined);
+    check(
+      'targetRealmUrl set',
+      ctx.targetRealmUrl === 'https://example.test/user/target/',
+    );
+    check(
+      'testRealmUrl set',
+      ctx.testRealmUrl === 'https://example.test/user/target-test-artifacts/',
+    );
+
+    let totalTokens = ctx.skills.reduce((s, sk) => s + estimateTokens(sk), 0);
+    console.log(`  Skill breakdown (~${totalTokens} total tokens):`);
+    for (let skill of ctx.skills) {
+      let tokens = estimateTokens(skill);
+      let refCount = skill.references?.length ?? 0;
+      let refNote = refCount > 0 ? ` + ${refCount} ref(s)` : '';
+      console.log(`    - ${skill.name}: ~${tokens} tokens${refNote}`);
+    }
+
+    // -------------------------------------------------------------------
+    // Iteration pass (with failed test results)
+    // -------------------------------------------------------------------
+
+    let ctxWithResults = await builder.build({
+      project: SAMPLE_PROJECT,
+      ticket,
+      knowledge: SAMPLE_KNOWLEDGE,
+      targetRealmUrl: 'https://example.test/user/target/',
+      testRealmUrl: 'https://example.test/user/target-test-artifacts/',
+      testResults: {
+        status: 'failed',
+        passedCount: 2,
+        failedCount: 1,
+        failures: [
+          {
+            testName: 'renders fitted view',
+            error: 'Expected element [data-test-card] to exist',
+            stackTrace: 'at tests/sticky-note.spec.ts:15:5',
+          },
+        ],
+        durationMs: 8500,
+      },
+    });
+
+    console.log('');
+    console.log('  Iteration pass (with failed test results):');
+    check(
+      'testResults.status = failed',
+      ctxWithResults.testResults?.status === 'failed',
+    );
+    check(
+      'testResults.failedCount = 1',
+      ctxWithResults.testResults?.failedCount === 1,
+    );
+    check(
+      'testResults.failures[0] has error',
+      ctxWithResults.testResults?.failures[0]?.error?.includes(
+        'Expected element',
+      ) ?? false,
+    );
+    check(
+      'skills still loaded on iteration',
+      ctxWithResults.skills.length === ctx.skills.length,
+    );
+    check(
+      'deprecated fields not set',
+      ctxWithResults.toolResults === undefined &&
+        ctxWithResults.previousActions === undefined &&
+        ctxWithResults.iteration === undefined,
+    );
+
+    console.log('');
+  }
+
+  // -----------------------------------------------------------------------
+  // Budget enforcement
+  // -----------------------------------------------------------------------
+
+  if (maxSkillTokens) {
+    console.log(`--- Budget enforcement (${maxSkillTokens} tokens) ---`);
+    console.log('');
+
+    let ctx = await builder.build({
+      project: SAMPLE_PROJECT,
+      ticket: SAMPLE_TICKETS[0].ticket,
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/user/target/',
+      testRealmUrl: 'https://example.test/user/target-test-artifacts/',
+    });
+
+    let totalTokens = ctx.skills.reduce((s, sk) => s + estimateTokens(sk), 0);
+    check(
+      `${ctx.skills.length} skills within budget (~${totalTokens} tokens <= ${maxSkillTokens})`,
+      totalTokens <= maxSkillTokens,
+    );
+    for (let skill of ctx.skills) {
+      console.log(`    - ${skill.name}: ~${estimateTokens(skill)} tokens`);
+    }
+    console.log('');
+  }
+
+  // -----------------------------------------------------------------------
+  // Summary
+  // -----------------------------------------------------------------------
+
+  console.log('===========================');
+  console.log(`  ${passed} passed, ${failed} failed`);
+  console.log('===========================');
+  console.log('');
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(
+    'Smoke test failed:',
+    err instanceof Error ? err.message : String(err),
+  );
+  process.exit(1);
+});

--- a/packages/software-factory/scripts/lib/factory-agent.ts
+++ b/packages/software-factory/scripts/lib/factory-agent.ts
@@ -126,12 +126,14 @@ export interface AgentContext {
   ticket: TicketCard;
   knowledge: KnowledgeArticle[];
   skills: ResolvedSkill[];
-  tools: ToolManifest[];
+  /** @deprecated Tools are now provided separately as FactoryTool[] to agent.run(). */
+  tools?: ToolManifest[];
   testResults?: TestResult;
+  /** @deprecated Tool results are now returned inline during the agent's turn. */
   toolResults?: ToolResult[];
-  /** Actions from the previous plan() call, fed back for iteration prompts. */
+  /** @deprecated Replaced by tool call summary in the iteration prompt. */
   previousActions?: AgentAction[];
-  /** Current iteration number (1-based), set by the orchestrator. */
+  /** @deprecated Iteration tracking is now owned by the orchestrator. */
   iteration?: number;
   targetRealmUrl: string;
   testRealmUrl: string;

--- a/packages/software-factory/scripts/lib/factory-context-builder.ts
+++ b/packages/software-factory/scripts/lib/factory-context-builder.ts
@@ -1,0 +1,125 @@
+import type {
+  AgentAction,
+  AgentContext,
+  KnowledgeArticle,
+  ProjectCard,
+  TestResult,
+  TicketCard,
+  ToolManifest,
+  ToolResult,
+} from './factory-agent';
+
+import type { ResolvedSkill } from './factory-agent';
+
+import {
+  enforceSkillBudget,
+  type SkillLoaderInterface,
+  type SkillResolver,
+} from './factory-skill-loader';
+
+import type { ToolRegistry } from './factory-tool-registry';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface ContextBuilderConfig {
+  skillResolver: SkillResolver;
+  skillLoader: SkillLoaderInterface;
+  toolRegistry: ToolRegistry;
+  /** Maximum token budget for skills. When set, enforceSkillBudget() trims. */
+  maxSkillTokens?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Iteration state (fed back between loop iterations)
+// ---------------------------------------------------------------------------
+
+export interface IterationState {
+  testResults?: TestResult;
+  toolResults?: ToolResult[];
+  previousActions?: AgentAction[];
+  iteration?: number;
+}
+
+// ---------------------------------------------------------------------------
+// ContextBuilder
+// ---------------------------------------------------------------------------
+
+export class ContextBuilder {
+  private skillResolver: SkillResolver;
+  private skillLoader: SkillLoaderInterface;
+  private toolRegistry: ToolRegistry;
+  private maxSkillTokens: number | undefined;
+
+  constructor(config: ContextBuilderConfig) {
+    this.skillResolver = config.skillResolver;
+    this.skillLoader = config.skillLoader;
+    this.toolRegistry = config.toolRegistry;
+    this.maxSkillTokens = config.maxSkillTokens;
+  }
+
+  /**
+   * Assemble a complete AgentContext for one iteration of the execution loop.
+   *
+   * Steps:
+   * 1. Resolve skill names from ticket + project context
+   * 2. Load all resolved skills from disk
+   * 3. Apply skill budget if configured
+   * 4. Get tool manifests from the registry
+   * 5. Merge with iteration state and return AgentContext
+   */
+  async build(params: {
+    project: ProjectCard;
+    ticket: TicketCard;
+    knowledge: KnowledgeArticle[];
+    targetRealmUrl: string;
+    testRealmUrl: string;
+    iterationState?: IterationState;
+  }): Promise<AgentContext> {
+    let { project, ticket, knowledge, targetRealmUrl, testRealmUrl } = params;
+    let iterationState = params.iterationState ?? {};
+
+    // Step 1: Resolve which skills are needed for this ticket
+    let skillNames = this.skillResolver.resolve(ticket, project);
+
+    // Step 2: Load skill content from disk
+    let skills: ResolvedSkill[] = await this.skillLoader.loadAll(
+      skillNames,
+      ticket,
+    );
+
+    // Step 3: Enforce token budget if configured
+    skills = enforceSkillBudget(skills, this.maxSkillTokens);
+
+    // Step 4: Get tool manifests
+    let tools: ToolManifest[] = this.toolRegistry.getManifests();
+
+    // Step 5: Assemble the context
+    let context: AgentContext = {
+      project,
+      ticket,
+      knowledge,
+      skills,
+      tools,
+      targetRealmUrl,
+      testRealmUrl,
+    };
+
+    // Merge iteration state when present
+    if (iterationState.testResults) {
+      context.testResults = iterationState.testResults;
+    }
+    if (iterationState.toolResults) {
+      context.toolResults = iterationState.toolResults;
+    }
+    if (iterationState.previousActions) {
+      context.previousActions = iterationState.previousActions;
+    }
+    if (iterationState.iteration !== undefined) {
+      context.iteration = iterationState.iteration;
+    }
+
+    return context;
+  }
+}

--- a/packages/software-factory/scripts/lib/factory-context-builder.ts
+++ b/packages/software-factory/scripts/lib/factory-context-builder.ts
@@ -1,12 +1,9 @@
 import type {
-  AgentAction,
   AgentContext,
   KnowledgeArticle,
   ProjectCard,
   TestResult,
   TicketCard,
-  ToolManifest,
-  ToolResult,
 } from './factory-agent';
 
 import type { ResolvedSkill } from './factory-agent';
@@ -17,8 +14,6 @@ import {
   type SkillResolver,
 } from './factory-skill-loader';
 
-import type { ToolRegistry } from './factory-tool-registry';
-
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
@@ -26,20 +21,8 @@ import type { ToolRegistry } from './factory-tool-registry';
 export interface ContextBuilderConfig {
   skillResolver: SkillResolver;
   skillLoader: SkillLoaderInterface;
-  toolRegistry: ToolRegistry;
   /** Maximum token budget for skills. When set, enforceSkillBudget() trims. */
   maxSkillTokens?: number;
-}
-
-// ---------------------------------------------------------------------------
-// Iteration state (fed back between loop iterations)
-// ---------------------------------------------------------------------------
-
-export interface IterationState {
-  testResults?: TestResult;
-  toolResults?: ToolResult[];
-  previousActions?: AgentAction[];
-  iteration?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -49,13 +32,11 @@ export interface IterationState {
 export class ContextBuilder {
   private skillResolver: SkillResolver;
   private skillLoader: SkillLoaderInterface;
-  private toolRegistry: ToolRegistry;
   private maxSkillTokens: number | undefined;
 
   constructor(config: ContextBuilderConfig) {
     this.skillResolver = config.skillResolver;
     this.skillLoader = config.skillLoader;
-    this.toolRegistry = config.toolRegistry;
     this.maxSkillTokens = config.maxSkillTokens;
   }
 
@@ -66,8 +47,7 @@ export class ContextBuilder {
    * 1. Resolve skill names from ticket + project context
    * 2. Load all resolved skills from disk
    * 3. Apply skill budget if configured
-   * 4. Get tool manifests from the registry
-   * 5. Merge with iteration state and return AgentContext
+   * 4. Return AgentContext (tools are provided separately as FactoryTool[])
    */
   async build(params: {
     project: ProjectCard;
@@ -75,10 +55,10 @@ export class ContextBuilder {
     knowledge: KnowledgeArticle[];
     targetRealmUrl: string;
     testRealmUrl: string;
-    iterationState?: IterationState;
+    /** Test results from the previous iteration, if any. */
+    testResults?: TestResult;
   }): Promise<AgentContext> {
     let { project, ticket, knowledge, targetRealmUrl, testRealmUrl } = params;
-    let iterationState = params.iterationState ?? {};
 
     // Step 1: Resolve which skills are needed for this ticket
     let skillNames = this.skillResolver.resolve(ticket, project);
@@ -92,32 +72,19 @@ export class ContextBuilder {
     // Step 3: Enforce token budget if configured
     skills = enforceSkillBudget(skills, this.maxSkillTokens);
 
-    // Step 4: Get tool manifests
-    let tools: ToolManifest[] = this.toolRegistry.getManifests();
-
-    // Step 5: Assemble the context
+    // Step 4: Assemble the context
     let context: AgentContext = {
       project,
       ticket,
       knowledge,
       skills,
-      tools,
       targetRealmUrl,
       testRealmUrl,
     };
 
-    // Merge iteration state when present
-    if (iterationState.testResults) {
-      context.testResults = iterationState.testResults;
-    }
-    if (iterationState.toolResults) {
-      context.toolResults = iterationState.toolResults;
-    }
-    if (iterationState.previousActions) {
-      context.previousActions = iterationState.previousActions;
-    }
-    if (iterationState.iteration !== undefined) {
-      context.iteration = iterationState.iteration;
+    // Include test results when iterating after a failed test run
+    if (params.testResults) {
+      context.testResults = params.testResults;
     }
 
     return context;

--- a/packages/software-factory/scripts/lib/factory-prompt-loader.ts
+++ b/packages/software-factory/scripts/lib/factory-prompt-loader.ts
@@ -339,7 +339,7 @@ function buildToolResultsData(
   }
 
   let toolManifestsByName = new Map<string, ToolManifest>();
-  for (let tool of context.tools) {
+  for (let tool of context.tools ?? []) {
     toolManifestsByName.set(tool.name, tool);
   }
 
@@ -381,7 +381,7 @@ export function assembleSystemPrompt(
     references: s.references ?? [],
   }));
 
-  let tools = context.tools.map((t: ToolManifest) => ({
+  let tools = (context.tools ?? []).map((t: ToolManifest) => ({
     name: t.name,
     description: t.description,
     category: t.category,

--- a/packages/software-factory/src/cli/cache-realm.ts
+++ b/packages/software-factory/src/cli/cache-realm.ts
@@ -29,24 +29,48 @@ async function main(): Promise<void> {
       ? parsedMetadataContext
       : undefined;
 
-  // Validate that the context's hostURL is still reachable. A stale
-  // support.json from a previous run can have a dead hostURL which
-  // causes the realm server to crash during template builds.
-  if (supportContext && 'hostURL' in supportContext && supportContext.hostURL) {
-    let hostURL = supportContext.hostURL;
-    try {
-      let response = await fetch(hostURL);
-      if (!response.ok) {
+  // Validate that the context's URLs are still reachable. A stale
+  // support.json from a previous run can have dead URLs which cause
+  // the realm server to crash during template builds.
+  if (supportContext) {
+    if ('hostURL' in supportContext && supportContext.hostURL) {
+      let hostURL = supportContext.hostURL;
+      try {
+        let response = await fetch(hostURL);
+        if (!response.ok) {
+          console.warn(
+            `Stale support context: hostURL ${hostURL} returned ${response.status}, ignoring cached context`,
+          );
+          supportContext = undefined;
+        }
+      } catch {
         console.warn(
-          `Stale support context: hostURL ${hostURL} returned ${response.status}, ignoring cached context`,
+          `Stale support context: hostURL ${hostURL} is not reachable, ignoring cached context`,
         );
         supportContext = undefined;
       }
-    } catch {
-      console.warn(
-        `Stale support context: hostURL ${hostURL} is not reachable, ignoring cached context`,
-      );
-      supportContext = undefined;
+    }
+
+    if (
+      supportContext &&
+      'matrixURL' in supportContext &&
+      supportContext.matrixURL
+    ) {
+      let matrixURL = supportContext.matrixURL;
+      try {
+        let response = await fetch(`${matrixURL}/_matrix/client/versions`);
+        if (!response.ok) {
+          console.warn(
+            `Stale support context: matrixURL ${matrixURL} returned ${response.status}, ignoring cached context`,
+          );
+          supportContext = undefined;
+        }
+      } catch {
+        console.warn(
+          `Stale support context: matrixURL ${matrixURL} is not reachable, ignoring cached context`,
+        );
+        supportContext = undefined;
+      }
     }
   }
 

--- a/packages/software-factory/src/harness/database.ts
+++ b/packages/software-factory/src/harness/database.ts
@@ -609,37 +609,43 @@ function startIndexingProgressReporter(
   estimatedTotal: number,
 ): { stop: () => void } {
   let stopped = false;
+  let polling = false;
   let lastReported = -1;
   let startedAt = Date.now();
 
   let report = async () => {
-    if (stopped) {
+    if (stopped || polling) {
       return;
     }
-    let { indexed, errors } = await queryIndexedCount(databaseName);
-    if (stopped) {
-      return;
-    }
-    // Only report when the count changes or on the first poll.
-    if (indexed === lastReported) {
-      return;
-    }
-    lastReported = indexed;
+    polling = true;
+    try {
+      let { indexed, errors } = await queryIndexedCount(databaseName);
+      if (stopped) {
+        return;
+      }
+      // Only report when the count changes or on the first poll.
+      if (indexed === lastReported) {
+        return;
+      }
+      lastReported = indexed;
 
-    let elapsed = ((Date.now() - startedAt) / 1000).toFixed(0);
-    let errorSuffix = errors > 0 ? ` (${errors} errors)` : '';
-    if (estimatedTotal > 0) {
-      let pct = Math.min(100, Math.round((indexed / estimatedTotal) * 100));
-      let barWidth = 30;
-      let filled = Math.round((pct / 100) * barWidth);
-      let bar = '='.repeat(filled) + ' '.repeat(barWidth - filled);
-      process.stderr.write(
-        `\r  indexing [${bar}] ${indexed}/${estimatedTotal} files (${pct}%) ${elapsed}s${errorSuffix}`,
-      );
-    } else {
-      process.stderr.write(
-        `\r  indexing ${indexed} files indexed ${elapsed}s${errorSuffix}`,
-      );
+      let elapsed = ((Date.now() - startedAt) / 1000).toFixed(0);
+      let errorSuffix = errors > 0 ? ` (${errors} errors)` : '';
+      if (estimatedTotal > 0) {
+        let pct = Math.min(100, Math.round((indexed / estimatedTotal) * 100));
+        let barWidth = 30;
+        let filled = Math.round((pct / 100) * barWidth);
+        let bar = '='.repeat(filled) + ' '.repeat(barWidth - filled);
+        process.stderr.write(
+          `\r  indexing [${bar}] ${indexed}/${estimatedTotal} files (${pct}%) ${elapsed}s${errorSuffix}`,
+        );
+      } else {
+        process.stderr.write(
+          `\r  indexing ${indexed} files indexed ${elapsed}s${errorSuffix}`,
+        );
+      }
+    } finally {
+      polling = false;
     }
   };
 

--- a/packages/software-factory/src/harness/database.ts
+++ b/packages/software-factory/src/harness/database.ts
@@ -1,19 +1,15 @@
-import { readdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Client as PgClient } from 'pg';
 
 import {
-  baseRealmDir,
   baseRealmURLFor,
   builderDatabaseNameForCacheKey,
   DEFAULT_BASE_REALM_PERMISSIONS,
   DEFAULT_MIGRATED_TEMPLATE_DB,
   DEFAULT_SOURCE_REALM_PERMISSIONS,
+  findAvailablePort,
   logTimed,
   pgAdminConnectionConfig,
   quotePgIdentifier,
-  shouldIgnoreFixturePath,
-  sourceRealmDir,
   sourceRealmURLFor,
   templateLog,
   waitUntil,
@@ -549,69 +545,49 @@ export async function warnIfSnapshotLooksCold(
   );
 }
 
-function countFixtureFiles(dir: string): number {
-  let count = 0;
-  function visit(currentDir: string, relativePath: string) {
-    for (let entry of readdirSync(currentDir, { withFileTypes: true })) {
-      let entryRelativePath = relativePath
-        ? `${relativePath}/${entry.name}`
-        : entry.name;
-      if (shouldIgnoreFixturePath(entryRelativePath)) {
-        continue;
-      }
-      let fullPath = join(currentDir, entry.name);
-      if (entry.isDirectory()) {
-        visit(fullPath, entryRelativePath);
-      } else if (entry.isFile()) {
-        count++;
-      }
-    }
-  }
-  try {
-    visit(dir, '');
-  } catch {
-    // If we can't count files, just return 0 and skip progress reporting
-  }
-  return count;
+interface IndexingStatus {
+  active: {
+    realmURL: string;
+    totalFiles: number;
+    filesCompleted: number;
+  }[];
+  pending: { realmURL: string }[];
 }
 
-async function queryIndexedCount(databaseName: string): Promise<{
-  indexed: number;
-  errors: number;
-}> {
-  let client = new PgClient({
-    ...pgAdminConnectionConfig(databaseName),
-    connectionTimeoutMillis: 2000,
-  });
+async function queryIndexingStatus(
+  workerManagerPort: number,
+): Promise<IndexingStatus | undefined> {
   try {
-    await client.connect();
-    let { rows } = await client.query<{ total: number; errors: number }>(
-      `SELECT COUNT(*)::int AS total, COUNT(*) FILTER (WHERE has_error)::int AS errors FROM boxel_index`,
+    let response = await fetch(
+      `http://localhost:${workerManagerPort}/_indexing-status`,
     );
-    return { indexed: rows[0]?.total ?? 0, errors: rows[0]?.errors ?? 0 };
-  } catch {
-    return { indexed: 0, errors: 0 };
-  } finally {
-    try {
-      await client.end();
-    } catch {
-      // best effort cleanup
+    if (!response.ok) {
+      return undefined;
     }
+    return (await response.json()) as IndexingStatus;
+  } catch {
+    return undefined;
   }
 }
 
 /**
- * Start a progress reporter that polls the database for indexing status and
- * writes updates to stderr. Returns a stop function.
+ * Start a progress reporter that polls the worker-manager's
+ * /_indexing-status JSON endpoint for precise indexing progress.
+ * The port must be pre-allocated by the caller via findAvailablePort()
+ * and passed to startIsolatedRealmStack as workerManagerPort.
  */
 function startIndexingProgressReporter(
-  databaseName: string,
-  estimatedTotal: number,
-): { stop: () => void } {
+  workerManagerPort: number,
+  totalRealms: number,
+): {
+  stop: () => void;
+} {
   let stopped = false;
   let polling = false;
-  let lastReported = -1;
+  let lastCompleted = -1;
+  let lastTotal = -1;
   let startedAt = Date.now();
+  let seenRealms = new Set<string>();
 
   let report = async () => {
     if (stopped || polling) {
@@ -619,29 +595,55 @@ function startIndexingProgressReporter(
     }
     polling = true;
     try {
-      let { indexed, errors } = await queryIndexedCount(databaseName);
+      let elapsed = ((Date.now() - startedAt) / 1000).toFixed(0);
+      let status = await queryIndexingStatus(workerManagerPort);
       if (stopped) {
         return;
       }
-      // Only report when the count changes or on the first poll.
-      if (indexed === lastReported) {
+      if (!status) {
+        process.stderr.write(`\r  indexing: waiting for status ${elapsed}s`);
         return;
       }
-      lastReported = indexed;
 
-      let elapsed = ((Date.now() - startedAt) / 1000).toFixed(0);
-      let errorSuffix = errors > 0 ? ` (${errors} errors)` : '';
-      if (estimatedTotal > 0) {
-        let pct = Math.min(100, Math.round((indexed / estimatedTotal) * 100));
+      let current = status.active[0];
+      let filesCompleted = current?.filesCompleted ?? 0;
+      let totalFiles = current?.totalFiles ?? 0;
+      lastCompleted = filesCompleted;
+      lastTotal = totalFiles;
+
+      // Track which realms we've seen to compute remaining count.
+      if (current) {
+        seenRealms.add(current.realmURL);
+      }
+      let remaining = Math.max(0, totalRealms - seenRealms.size);
+
+      let realmName = current
+        ? new URL(current.realmURL).pathname.replace(/\/$/, '').split('/').pop()
+        : undefined;
+      let realmLabel = realmName ? ` ${realmName}` : '';
+      let remainingLabel =
+        remaining > 0
+          ? ` (${remaining} realm${remaining > 1 ? 's' : ''} remaining)`
+          : '';
+
+      if (totalFiles > 0) {
+        let pct = Math.min(
+          100,
+          Math.round((filesCompleted / totalFiles) * 100),
+        );
         let barWidth = 30;
         let filled = Math.round((pct / 100) * barWidth);
         let bar = '='.repeat(filled) + ' '.repeat(barWidth - filled);
         process.stderr.write(
-          `\r  indexing [${bar}] ${indexed}/${estimatedTotal} files (${pct}%) ${elapsed}s${errorSuffix}`,
+          `\r  indexing${realmLabel} [${bar}] ${filesCompleted}/${totalFiles} files (${pct}%) ${elapsed}s${remainingLabel}`,
+        );
+      } else if (status.active.length > 0) {
+        process.stderr.write(
+          `\r  indexing${realmLabel}: discovering files... ${elapsed}s${remainingLabel}`,
         );
       } else {
         process.stderr.write(
-          `\r  indexing ${indexed} files indexed ${elapsed}s${errorSuffix}`,
+          `\r  indexing: waiting for realm server ${elapsed}s`,
         );
       }
     } finally {
@@ -650,7 +652,6 @@ function startIndexingProgressReporter(
   };
 
   let interval = setInterval(() => void report(), 2000);
-  // Do an immediate first check after a brief delay to let the DB initialize.
   let initialTimeout = setTimeout(() => void report(), 3000);
 
   return {
@@ -658,11 +659,10 @@ function startIndexingProgressReporter(
       stopped = true;
       clearInterval(interval);
       clearTimeout(initialTimeout);
-      // Clear the progress line and print final status.
-      if (lastReported >= 0) {
+      if (lastCompleted >= 0) {
         let elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
         process.stderr.write(
-          `\r  indexing complete: ${lastReported} files indexed in ${elapsed}s\n`,
+          `\r  indexing complete: ${lastCompleted}/${lastTotal} files in ${elapsed}s\n`,
         );
       }
     },
@@ -782,17 +782,11 @@ export async function buildCombinedTemplateDatabase({
         username: `additional_realm_${i}`,
       }));
 
-      // Estimate total files for progress reporting.
-      let estimatedTotal =
-        realmFixtures.reduce(
-          (sum, f) => sum + countFixtureFiles(f.realmDir),
-          0,
-        ) +
-        countFixtureFiles(sourceRealmDir) +
-        countFixtureFiles(baseRealmDir);
+      let wmPort = await findAvailablePort();
+      // base + source + each fixture realm
       let progress = startIndexingProgressReporter(
-        builderDatabaseName,
-        estimatedTotal,
+        wmPort,
+        2 + realmFixtures.length,
       );
 
       let stack;
@@ -806,6 +800,7 @@ export async function buildCombinedTemplateDatabase({
           migrateDB: !hasMigratedTemplate,
           fullIndexOnStartup: true,
           additionalRealms,
+          workerManagerPort: wmPort,
         });
       } catch (error) {
         progress.stop();
@@ -884,15 +879,9 @@ export async function buildTemplateDatabase({
         DEFAULT_SOURCE_REALM_PERMISSIONS,
       );
 
-      // Estimate total files for progress reporting: fixture + source realm + base realm.
-      let estimatedTotal =
-        countFixtureFiles(realmDir) +
-        countFixtureFiles(sourceRealmDir) +
-        countFixtureFiles(baseRealmDir);
-      let progress = startIndexingProgressReporter(
-        builderDatabaseName,
-        estimatedTotal,
-      );
+      let wmPort = await findAvailablePort();
+      // base + source + test realm
+      let progress = startIndexingProgressReporter(wmPort, 3);
 
       let stack;
       try {
@@ -904,6 +893,7 @@ export async function buildTemplateDatabase({
           context,
           migrateDB: !hasMigratedTemplate,
           fullIndexOnStartup: true,
+          workerManagerPort: wmPort,
         });
       } catch (error) {
         progress.stop();

--- a/packages/software-factory/src/harness/database.ts
+++ b/packages/software-factory/src/harness/database.ts
@@ -1,6 +1,9 @@
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
 import { Client as PgClient } from 'pg';
 
 import {
+  baseRealmDir,
   baseRealmURLFor,
   builderDatabaseNameForCacheKey,
   DEFAULT_BASE_REALM_PERMISSIONS,
@@ -9,6 +12,8 @@ import {
   logTimed,
   pgAdminConnectionConfig,
   quotePgIdentifier,
+  shouldIgnoreFixturePath,
+  sourceRealmDir,
   sourceRealmURLFor,
   templateLog,
   waitUntil,
@@ -41,7 +46,10 @@ export async function canConnectToPg(): Promise<boolean> {
 }
 
 export async function databaseExists(databaseName: string): Promise<boolean> {
-  let client = new PgClient(pgAdminConnectionConfig());
+  let client = new PgClient({
+    ...pgAdminConnectionConfig(),
+    connectionTimeoutMillis: 3000,
+  });
   try {
     await client.connect();
     let result = await client.query<{ exists: boolean }>(
@@ -49,8 +57,16 @@ export async function databaseExists(databaseName: string): Promise<boolean> {
       [databaseName],
     );
     return Boolean(result.rows[0]?.exists);
+  } catch {
+    // Postgres may not be running yet (e.g. fresh worktree with no services).
+    // Treat as "database does not exist" so the caller proceeds to start services.
+    return false;
   } finally {
-    await client.end();
+    try {
+      await client.end();
+    } catch {
+      // best effort cleanup
+    }
   }
 }
 
@@ -533,6 +549,120 @@ export async function warnIfSnapshotLooksCold(
   );
 }
 
+function countFixtureFiles(dir: string): number {
+  let count = 0;
+  function visit(currentDir: string, relativePath: string) {
+    for (let entry of readdirSync(currentDir, { withFileTypes: true })) {
+      let entryRelativePath = relativePath
+        ? `${relativePath}/${entry.name}`
+        : entry.name;
+      if (shouldIgnoreFixturePath(entryRelativePath)) {
+        continue;
+      }
+      let fullPath = join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        visit(fullPath, entryRelativePath);
+      } else if (entry.isFile()) {
+        count++;
+      }
+    }
+  }
+  try {
+    visit(dir, '');
+  } catch {
+    // If we can't count files, just return 0 and skip progress reporting
+  }
+  return count;
+}
+
+async function queryIndexedCount(databaseName: string): Promise<{
+  indexed: number;
+  errors: number;
+}> {
+  let client = new PgClient({
+    ...pgAdminConnectionConfig(databaseName),
+    connectionTimeoutMillis: 2000,
+  });
+  try {
+    await client.connect();
+    let { rows } = await client.query<{ total: number; errors: number }>(
+      `SELECT COUNT(*)::int AS total, COUNT(*) FILTER (WHERE has_error)::int AS errors FROM boxel_index`,
+    );
+    return { indexed: rows[0]?.total ?? 0, errors: rows[0]?.errors ?? 0 };
+  } catch {
+    return { indexed: 0, errors: 0 };
+  } finally {
+    try {
+      await client.end();
+    } catch {
+      // best effort cleanup
+    }
+  }
+}
+
+/**
+ * Start a progress reporter that polls the database for indexing status and
+ * writes updates to stderr. Returns a stop function.
+ */
+function startIndexingProgressReporter(
+  databaseName: string,
+  estimatedTotal: number,
+): { stop: () => void } {
+  let stopped = false;
+  let lastReported = -1;
+  let startedAt = Date.now();
+
+  let report = async () => {
+    if (stopped) {
+      return;
+    }
+    let { indexed, errors } = await queryIndexedCount(databaseName);
+    if (stopped) {
+      return;
+    }
+    // Only report when the count changes or on the first poll.
+    if (indexed === lastReported) {
+      return;
+    }
+    lastReported = indexed;
+
+    let elapsed = ((Date.now() - startedAt) / 1000).toFixed(0);
+    let errorSuffix = errors > 0 ? ` (${errors} errors)` : '';
+    if (estimatedTotal > 0) {
+      let pct = Math.min(100, Math.round((indexed / estimatedTotal) * 100));
+      let barWidth = 30;
+      let filled = Math.round((pct / 100) * barWidth);
+      let bar = '='.repeat(filled) + ' '.repeat(barWidth - filled);
+      process.stderr.write(
+        `\r  indexing [${bar}] ${indexed}/${estimatedTotal} files (${pct}%) ${elapsed}s${errorSuffix}`,
+      );
+    } else {
+      process.stderr.write(
+        `\r  indexing ${indexed} files indexed ${elapsed}s${errorSuffix}`,
+      );
+    }
+  };
+
+  let interval = setInterval(() => void report(), 2000);
+  // Do an immediate first check after a brief delay to let the DB initialize.
+  let initialTimeout = setTimeout(() => void report(), 3000);
+
+  return {
+    stop() {
+      stopped = true;
+      clearInterval(interval);
+      clearTimeout(initialTimeout);
+      // Clear the progress line and print final status.
+      if (lastReported >= 0) {
+        let elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+        process.stderr.write(
+          `\r  indexing complete: ${lastReported} files indexed in ${elapsed}s\n`,
+        );
+      }
+    },
+  };
+}
+
 export async function waitForQueueIdle(databaseName: string): Promise<void> {
   await logTimed(templateLog, `waitForQueueIdle ${databaseName}`, async () => {
     await waitUntil(
@@ -646,20 +776,40 @@ export async function buildCombinedTemplateDatabase({
         username: `additional_realm_${i}`,
       }));
 
-      let stack = await startIsolatedRealmStack({
-        realmDir: primary.realmDir,
-        realmURL: primary.realmURL,
-        realmServerURL,
-        databaseName: builderDatabaseName,
-        context,
-        migrateDB: !hasMigratedTemplate,
-        fullIndexOnStartup: true,
-        additionalRealms,
-      });
+      // Estimate total files for progress reporting.
+      let estimatedTotal =
+        realmFixtures.reduce(
+          (sum, f) => sum + countFixtureFiles(f.realmDir),
+          0,
+        ) +
+        countFixtureFiles(sourceRealmDir) +
+        countFixtureFiles(baseRealmDir);
+      let progress = startIndexingProgressReporter(
+        builderDatabaseName,
+        estimatedTotal,
+      );
+
+      let stack;
+      try {
+        stack = await startIsolatedRealmStack({
+          realmDir: primary.realmDir,
+          realmURL: primary.realmURL,
+          realmServerURL,
+          databaseName: builderDatabaseName,
+          context,
+          migrateDB: !hasMigratedTemplate,
+          fullIndexOnStartup: true,
+          additionalRealms,
+        });
+      } catch (error) {
+        progress.stop();
+        throw error;
+      }
 
       try {
         await waitForQueueIdle(builderDatabaseName);
       } finally {
+        progress.stop();
         await stopIsolatedRealmStack(stack);
       }
 
@@ -728,19 +878,36 @@ export async function buildTemplateDatabase({
         DEFAULT_SOURCE_REALM_PERMISSIONS,
       );
 
-      let stack = await startIsolatedRealmStack({
-        realmDir,
-        realmURL,
-        realmServerURL,
-        databaseName: builderDatabaseName,
-        context,
-        migrateDB: !hasMigratedTemplate,
-        fullIndexOnStartup: true,
-      });
+      // Estimate total files for progress reporting: fixture + source realm + base realm.
+      let estimatedTotal =
+        countFixtureFiles(realmDir) +
+        countFixtureFiles(sourceRealmDir) +
+        countFixtureFiles(baseRealmDir);
+      let progress = startIndexingProgressReporter(
+        builderDatabaseName,
+        estimatedTotal,
+      );
+
+      let stack;
+      try {
+        stack = await startIsolatedRealmStack({
+          realmDir,
+          realmURL,
+          realmServerURL,
+          databaseName: builderDatabaseName,
+          context,
+          migrateDB: !hasMigratedTemplate,
+          fullIndexOnStartup: true,
+        });
+      } catch (error) {
+        progress.stop();
+        throw error;
+      }
 
       try {
         await waitForQueueIdle(builderDatabaseName);
       } finally {
+        progress.stop();
         await stopIsolatedRealmStack(stack);
       }
 

--- a/packages/software-factory/src/harness/isolated-realm-stack.ts
+++ b/packages/software-factory/src/harness/isolated-realm-stack.ts
@@ -28,7 +28,6 @@ import {
   DEFAULT_PG_USER,
   DEFAULT_REALM_LOG_LEVELS,
   DEFAULT_REALM_SERVER_PORT,
-  DEFAULT_WORKER_MANAGER_PORT,
   findAvailablePort,
   FIXTURE_SOURCE_REALM_URL_PLACEHOLDER,
   FULL_INDEX_REALM_STARTUP_TIMEOUT_MS,
@@ -296,6 +295,8 @@ export async function startIsolatedRealmStack({
   let testRealmDir = join(rootDir, 'test');
   let workerManagerMetadataFile = join(rootDir, 'worker-manager.runtime.json');
   let realmServerMetadataFile = join(rootDir, 'realm-server.runtime.json');
+  let actualWorkerManagerPort =
+    explicitWorkerManagerPort ?? (await findAvailablePort());
   let actualRealmServerPort =
     DEFAULT_REALM_SERVER_PORT === 0
       ? await findAvailablePort()
@@ -401,7 +402,7 @@ export async function startIsolatedRealmStack({
   let workerArgs = [
     '--transpileOnly',
     'worker-manager',
-    `--port=${explicitWorkerManagerPort ?? DEFAULT_WORKER_MANAGER_PORT}`,
+    `--port=${actualWorkerManagerPort}`,
     `--matrixURL=${context.matrixURL}`,
     `--prerendererUrl=${prerenderURL}`,
     `--fromUrl=${realmURL.href}`,

--- a/packages/software-factory/src/harness/isolated-realm-stack.ts
+++ b/packages/software-factory/src/harness/isolated-realm-stack.ts
@@ -277,6 +277,7 @@ export async function startIsolatedRealmStack({
   migrateDB,
   fullIndexOnStartup,
   additionalRealms,
+  workerManagerPort: explicitWorkerManagerPort,
 }: {
   realmDir: string;
   realmURL: URL;
@@ -286,6 +287,10 @@ export async function startIsolatedRealmStack({
   migrateDB: boolean;
   fullIndexOnStartup: boolean;
   additionalRealms?: AdditionalRealm[];
+  /** When provided, the worker-manager will listen on this port instead of
+   *  picking one dynamically. This lets callers know the port upfront (e.g.
+   *  for progress monitoring via /_indexing-status). */
+  workerManagerPort?: number;
 }): Promise<RunningFactoryStack> {
   let rootDir = mkdtempSync(join(tmpdir(), 'software-factory-realms-'));
   let testRealmDir = join(rootDir, 'test');
@@ -396,7 +401,7 @@ export async function startIsolatedRealmStack({
   let workerArgs = [
     '--transpileOnly',
     'worker-manager',
-    `--port=${DEFAULT_WORKER_MANAGER_PORT}`,
+    `--port=${explicitWorkerManagerPort ?? DEFAULT_WORKER_MANAGER_PORT}`,
     `--matrixURL=${context.matrixURL}`,
     `--prerendererUrl=${prerenderURL}`,
     `--fromUrl=${realmURL.href}`,

--- a/packages/software-factory/src/harness/shared.ts
+++ b/packages/software-factory/src/harness/shared.ts
@@ -140,9 +140,6 @@ export const DEFAULT_REALM_SERVER_PORT = Number(
 export const DEFAULT_COMPAT_REALM_SERVER_PORT = Number(
   process.env.SOFTWARE_FACTORY_COMPAT_REALM_PORT ?? 0,
 );
-export const DEFAULT_WORKER_MANAGER_PORT = Number(
-  process.env.SOFTWARE_FACTORY_WORKER_MANAGER_PORT ?? 0,
-);
 export const CONFIGURED_REALM_URL = process.env.SOFTWARE_FACTORY_REALM_URL
   ? new URL(process.env.SOFTWARE_FACTORY_REALM_URL)
   : undefined;

--- a/packages/software-factory/src/harness/support-services.ts
+++ b/packages/software-factory/src/harness/support-services.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from 'node:child_process';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -16,6 +16,7 @@ import {
   findAvailablePort,
   findHostDistPackageDir,
   findRootRepoCheckoutDir,
+  hostDir,
   logTimed,
   maybeRequire,
   prepareTestPgScript,
@@ -35,51 +36,108 @@ function hostStartupLooksLikePortContention(logs: string): boolean {
   return /EADDRINUSE|address already in use/i.test(logs);
 }
 
-function assertUsableBoxelUIDist(hostPackageDir: string): void {
-  let boxelUIAddonDir = join(hostPackageDir, '..', 'boxel-ui', 'addon');
-  let boxelUIDistDir = join(boxelUIAddonDir, 'dist');
-  let requiredPaths = [
+function boxelUIDistIsUsable(hostPackageDir: string): boolean {
+  let boxelUIDistDir = join(hostPackageDir, '..', 'boxel-ui', 'addon', 'dist');
+  return [
     join(boxelUIDistDir, 'components.js'),
     join(boxelUIDistDir, 'helpers.js'),
     join(boxelUIDistDir, 'icons.js'),
     join(boxelUIDistDir, 'styles', 'global.css'),
-  ];
+  ].every((path) => existsSync(path));
+}
 
-  if (requiredPaths.every((path) => existsSync(path))) {
+/**
+ * Ensure boxel-ui dist artifacts exist for the host package. Tries in order:
+ *   1. The current worktree's boxel-ui/addon/dist
+ *   2. Symlink from the root repo's built boxel-ui dist (fast, avoids rebuild)
+ *   3. Build boxel-ui in the current worktree (slow but always works)
+ */
+function ensureBoxelUIDist(hostPackageDir: string): void {
+  if (boxelUIDistIsUsable(hostPackageDir)) {
     return;
   }
 
+  let boxelUIAddonDir = join(hostPackageDir, '..', 'boxel-ui', 'addon');
+  let boxelUIDistDir = join(boxelUIAddonDir, 'dist');
+
+  // Try to symlink from root repo first (fast path for worktrees).
   let rootRepoCheckoutDir = findRootRepoCheckoutDir();
-  let rootRepoBoxelUIAddonDir =
-    rootRepoCheckoutDir && rootRepoCheckoutDir !== workspaceRoot
-      ? join(rootRepoCheckoutDir, 'packages', 'boxel-ui', 'addon')
-      : undefined;
-  let rootRepoBoxelUIDistDir = rootRepoBoxelUIAddonDir
-    ? join(rootRepoBoxelUIAddonDir, 'dist')
-    : undefined;
-  let hasRootRepoBoxelUIDist =
-    rootRepoBoxelUIDistDir != null &&
-    requiredPaths
-      .map((path) =>
-        join(rootRepoBoxelUIDistDir, path.slice(boxelUIDistDir.length + 1)),
-      )
-      .every((path) => existsSync(path));
-
-  let fixInstructions = [
-    `Run \`cd ${boxelUIAddonDir} && mise exec -- pnpm build\` to build boxel-ui in this checkout.`,
-  ];
-
-  if (hasRootRepoBoxelUIDist && rootRepoBoxelUIDistDir) {
-    fixInstructions.push(
-      `If you are in a worktree and want to reuse the main checkout build, run \`ln -sfn ${rootRepoBoxelUIDistDir} ${boxelUIDistDir}\`.`,
+  if (rootRepoCheckoutDir && rootRepoCheckoutDir !== workspaceRoot) {
+    let rootRepoBoxelUIDistDir = join(
+      rootRepoCheckoutDir,
+      'packages',
+      'boxel-ui',
+      'addon',
+      'dist',
     );
+    if (
+      existsSync(join(rootRepoBoxelUIDistDir, 'components.js')) &&
+      existsSync(join(rootRepoBoxelUIDistDir, 'helpers.js'))
+    ) {
+      supportLog.info(
+        `symlinking boxel-ui dist from root repo: ${rootRepoBoxelUIDistDir} -> ${boxelUIDistDir}`,
+      );
+      let result = spawnSync(
+        'ln',
+        ['-sfn', rootRepoBoxelUIDistDir, boxelUIDistDir],
+        {
+          stdio: 'inherit',
+        },
+      );
+      if (result.status === 0 && boxelUIDistIsUsable(hostPackageDir)) {
+        return;
+      }
+    }
   }
 
-  throw new Error(
-    `Boxel UI dist is missing or incomplete at ${boxelUIDistDir}. The software-factory harness needs built @cardstack/boxel-ui artifacts before the host app can boot. ${fixInstructions.join(
-      ' ',
-    )}`,
+  // Fall back to building boxel-ui.
+  supportLog.info(`building boxel-ui dist at ${boxelUIAddonDir}...`);
+  let result = spawnSync('pnpm', ['build'], {
+    cwd: boxelUIAddonDir,
+    stdio: 'inherit',
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to build boxel-ui at ${boxelUIAddonDir} (exit code ${result.status}). ` +
+        `Run \`cd ${boxelUIAddonDir} && pnpm build\` manually to diagnose.`,
+    );
+  }
+  if (!boxelUIDistIsUsable(hostPackageDir)) {
+    throw new Error(
+      `boxel-ui build succeeded but dist is still incomplete at ${boxelUIDistDir}`,
+    );
+  }
+}
+
+/**
+ * Build the host app dist when no pre-built dist is available anywhere.
+ * Returns the host package directory where the dist was built.
+ */
+function buildHostDist(): string {
+  // Prefer building in the current worktree so the output is local.
+  let buildDir = hostDir;
+  supportLog.info(
+    `no pre-built host dist found — building host app at ${buildDir}...`,
   );
+  let result = spawnSync('pnpm', ['build'], {
+    cwd: buildDir,
+    stdio: 'inherit',
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to build host app at ${buildDir} (exit code ${result.status}). ` +
+        `Run \`cd ${buildDir} && pnpm build\` manually to diagnose.`,
+    );
+  }
+  let indexPath = join(buildDir, 'dist', 'index.html');
+  if (!existsSync(indexPath)) {
+    throw new Error(
+      `Host build succeeded but dist/index.html is missing at ${buildDir}`,
+    );
+  }
+  return buildDir;
 }
 
 function assertUsableHostDist(hostPackageDir: string): void {
@@ -178,11 +236,11 @@ async function ensureHostReady(): Promise<{
 
       let hostPackageDir = findHostDistPackageDir();
       if (!hostPackageDir) {
-        throw new Error(
-          'No built host dist is available in the current worktree or root repo checkout',
-        );
+        // No pre-built host dist found anywhere. Build it automatically so
+        // cache:prepare works in a fresh worktree without manual setup.
+        hostPackageDir = buildHostDist();
       }
-      assertUsableBoxelUIDist(hostPackageDir);
+      ensureBoxelUIDist(hostPackageDir);
       assertUsableHostDist(hostPackageDir);
       let port = await findAvailablePort();
       let hostURL = `http://localhost:${port}/`;
@@ -383,6 +441,91 @@ export async function startHarnessPrerenderServer(options: {
   };
 }
 
+/**
+ * Ensure boxel-icons dist exists. In a worktree, symlink from the root repo
+ * if available, otherwise build.
+ */
+function ensureBoxelIconsDist(): void {
+  let distDir = join(boxelIconsDir, 'dist');
+  if (
+    existsSync(join(distDir, '@cardstack')) ||
+    existsSync(join(distDir, 'index.html'))
+  ) {
+    return;
+  }
+
+  // Try to symlink from root repo (fast path for worktrees).
+  let rootRepoCheckoutDir = findRootRepoCheckoutDir();
+  if (rootRepoCheckoutDir && rootRepoCheckoutDir !== workspaceRoot) {
+    let rootRepoIconsDistDir = join(
+      rootRepoCheckoutDir,
+      'packages',
+      'boxel-icons',
+      'dist',
+    );
+    if (existsSync(join(rootRepoIconsDistDir, '@cardstack'))) {
+      supportLog.info(
+        `symlinking boxel-icons dist from root repo: ${rootRepoIconsDistDir} -> ${distDir}`,
+      );
+      let result = spawnSync('ln', ['-sfn', rootRepoIconsDistDir, distDir], {
+        stdio: 'inherit',
+      });
+      if (result.status === 0 && existsSync(join(distDir, '@cardstack'))) {
+        return;
+      }
+    }
+  }
+
+  // Fall back to building boxel-icons.
+  supportLog.info(`building boxel-icons dist at ${boxelIconsDir}...`);
+  let result = spawnSync('pnpm', ['build'], {
+    cwd: boxelIconsDir,
+    stdio: 'inherit',
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to build boxel-icons at ${boxelIconsDir} (exit code ${result.status}). ` +
+        `Run \`cd ${boxelIconsDir} && pnpm build\` manually to diagnose.`,
+    );
+  }
+}
+
+function startIconServerProcess(): {
+  child: ReturnType<typeof spawn>;
+  logs: () => string;
+  stop: () => Promise<void>;
+} {
+  let child = spawn('pnpm', ['serve'], {
+    cwd: boxelIconsDir,
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: process.env,
+  });
+
+  let captured = '';
+  child.stdout?.on('data', (chunk) => {
+    captured = `${captured}${String(chunk)}`.slice(-20_000);
+  });
+  child.stderr?.on('data', (chunk) => {
+    captured = `${captured}${String(chunk)}`.slice(-20_000);
+  });
+
+  return {
+    child,
+    logs: () => captured,
+    async stop() {
+      if (child.exitCode === null) {
+        try {
+          process.kill(-child.pid!, 'SIGTERM');
+        } catch {
+          // best effort cleanup
+        }
+      }
+    },
+  };
+}
+
 async function ensureIconsReady(): Promise<{
   stop?: () => Promise<void>;
 }> {
@@ -390,64 +533,63 @@ async function ensureIconsReady(): Promise<{
     supportLog,
     `ensureIconsReady ${DEFAULT_ICONS_PROBE_URL}`,
     async () => {
+      // Ensure boxel-icons dist exists before trying to serve it.
+      ensureBoxelIconsDist();
+
+      // Always start our own managed icon server so we control its lifecycle.
+      // An externally-running server could die mid-indexing causing silent
+      // render timeouts. If port 4206 is already taken by a healthy dev
+      // server, our spawn will fail and we fall back to the existing one.
+      let server = startIconServerProcess();
+
       try {
-        let response = await fetch(DEFAULT_ICONS_PROBE_URL);
-        if (response.ok) {
-          supportLog.debug('icons server already available');
-          return {};
-        }
-      } catch {
-        // fall through and start the local icon server
+        await waitUntil(
+          async () => {
+            // If our process exited, either the port is already in use (dev
+            // server running) or the start genuinely failed. Check if the
+            // external server is healthy.
+            if (server.child.exitCode !== null) {
+              try {
+                let response = await fetch(DEFAULT_ICONS_PROBE_URL);
+                if (response.ok) {
+                  supportLog.debug(
+                    'icons server already available (external process)',
+                  );
+                  return true;
+                }
+              } catch {
+                // fall through
+              }
+              throw new Error(
+                `icons server exited early with code ${server.child.exitCode}\n${server.logs()}`,
+              );
+            }
+            try {
+              let response = await fetch(DEFAULT_ICONS_PROBE_URL);
+              return response.ok;
+            } catch {
+              return false;
+            }
+          },
+          {
+            timeout: 30_000,
+            interval: 250,
+            timeoutMessage: `Timed out waiting for icons server at ${DEFAULT_ICONS_PROBE_URL}\n${server.logs()}`,
+          },
+        );
+      } catch (error) {
+        await server.stop();
+        throw error;
       }
 
-      let child = spawn('pnpm', ['serve'], {
-        cwd: boxelIconsDir,
-        detached: true,
-        stdio: ['ignore', 'pipe', 'pipe'],
-        env: process.env,
-      });
+      if (server.child.exitCode !== null) {
+        // Our process couldn't start (port already taken by dev server).
+        // Return without a stop function since we don't own the server.
+        return {};
+      }
 
-      let logs = '';
-      child.stdout?.on('data', (chunk) => {
-        logs = `${logs}${String(chunk)}`.slice(-20_000);
-      });
-      child.stderr?.on('data', (chunk) => {
-        logs = `${logs}${String(chunk)}`.slice(-20_000);
-      });
-
-      await waitUntil(
-        async () => {
-          if (child.exitCode !== null) {
-            throw new Error(
-              `icons server exited early with code ${child.exitCode}\n${logs}`,
-            );
-          }
-          try {
-            let response = await fetch(DEFAULT_ICONS_PROBE_URL);
-            return response.ok;
-          } catch {
-            return false;
-          }
-        },
-        {
-          timeout: 30_000,
-          interval: 250,
-          timeoutMessage: `Timed out waiting for icons server at ${DEFAULT_ICONS_PROBE_URL}\n${logs}`,
-        },
-      );
-
-      supportLog.debug('started local icons server');
-      return {
-        async stop() {
-          if (child.exitCode === null) {
-            try {
-              process.kill(-child.pid!, 'SIGTERM');
-            } catch {
-              // best effort cleanup
-            }
-          }
-        },
-      };
+      supportLog.debug('started managed icons server');
+      return { stop: server.stop };
     },
   );
 }

--- a/packages/software-factory/src/harness/support-services.ts
+++ b/packages/software-factory/src/harness/support-services.ts
@@ -1,5 +1,5 @@
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 
 import {
@@ -77,15 +77,18 @@ function ensureBoxelUIDist(hostPackageDir: string): void {
       supportLog.info(
         `symlinking boxel-ui dist from root repo: ${rootRepoBoxelUIDistDir} -> ${boxelUIDistDir}`,
       );
-      let result = spawnSync(
-        'ln',
-        ['-sfn', rootRepoBoxelUIDistDir, boxelUIDistDir],
-        {
-          stdio: 'inherit',
-        },
-      );
-      if (result.status === 0 && boxelUIDistIsUsable(hostPackageDir)) {
-        return;
+      try {
+        if (existsSync(boxelUIDistDir)) {
+          rmSync(boxelUIDistDir, { recursive: true, force: true });
+        }
+        symlinkSync(rootRepoBoxelUIDistDir, boxelUIDistDir);
+        if (boxelUIDistIsUsable(hostPackageDir)) {
+          return;
+        }
+      } catch (error) {
+        supportLog.debug(
+          `symlink failed, will try building instead: ${error instanceof Error ? error.message : String(error)}`,
+        );
       }
     }
   }
@@ -467,11 +470,18 @@ function ensureBoxelIconsDist(): void {
       supportLog.info(
         `symlinking boxel-icons dist from root repo: ${rootRepoIconsDistDir} -> ${distDir}`,
       );
-      let result = spawnSync('ln', ['-sfn', rootRepoIconsDistDir, distDir], {
-        stdio: 'inherit',
-      });
-      if (result.status === 0 && existsSync(join(distDir, '@cardstack'))) {
-        return;
+      try {
+        if (existsSync(distDir)) {
+          rmSync(distDir, { recursive: true, force: true });
+        }
+        symlinkSync(rootRepoIconsDistDir, distDir);
+        if (existsSync(join(distDir, '@cardstack'))) {
+          return;
+        }
+      } catch (error) {
+        supportLog.debug(
+          `symlink failed, will try building instead: ${error instanceof Error ? error.message : String(error)}`,
+        );
       }
     }
   }
@@ -487,6 +497,14 @@ function ensureBoxelIconsDist(): void {
     throw new Error(
       `Failed to build boxel-icons at ${boxelIconsDir} (exit code ${result.status}). ` +
         `Run \`cd ${boxelIconsDir} && pnpm build\` manually to diagnose.`,
+    );
+  }
+  if (
+    !existsSync(join(distDir, '@cardstack')) &&
+    !existsSync(join(distDir, 'index.html'))
+  ) {
+    throw new Error(
+      `Built boxel-icons at ${boxelIconsDir} but dist output is missing at ${distDir}`,
     );
   }
 }
@@ -510,6 +528,11 @@ function startIconServerProcess(): {
   child.stderr?.on('data', (chunk) => {
     captured = `${captured}${String(chunk)}`.slice(-20_000);
   });
+  child.on('error', (err) => {
+    captured = `${captured}\n[icon server spawn error] ${err.message}\n`.slice(
+      -20_000,
+    );
+  });
 
   return {
     child,
@@ -519,7 +542,13 @@ function startIconServerProcess(): {
         try {
           process.kill(-child.pid!, 'SIGTERM');
         } catch {
-          // best effort cleanup
+          // best effort — process may have already exited or negative
+          // PID may not be supported on this platform.
+          try {
+            child.kill('SIGTERM');
+          } catch {
+            // truly best effort
+          }
         }
       }
     },
@@ -560,8 +589,15 @@ async function ensureIconsReady(): Promise<{
               } catch {
                 // fall through
               }
+              // If our process exited due to port contention, the external
+              // server may still be starting up. Keep polling instead of
+              // failing immediately.
+              let logs = server.logs();
+              if (/EADDRINUSE|address already in use/i.test(logs)) {
+                return false;
+              }
               throw new Error(
-                `icons server exited early with code ${server.child.exitCode}\n${server.logs()}`,
+                `icons server exited early with code ${server.child.exitCode}\n${logs}`,
               );
             }
             try {

--- a/packages/software-factory/tests/factory-context-builder.test.ts
+++ b/packages/software-factory/tests/factory-context-builder.test.ts
@@ -1,0 +1,631 @@
+import { module, test } from 'qunit';
+
+import type {
+  AgentAction,
+  KnowledgeArticle,
+  ProjectCard,
+  ResolvedSkill,
+  TestResult,
+  TicketCard,
+  ToolResult,
+} from '../scripts/lib/factory-agent';
+
+import {
+  ContextBuilder,
+  type ContextBuilderConfig,
+} from '../scripts/lib/factory-context-builder';
+
+import type {
+  SkillLoaderInterface,
+  SkillResolver,
+} from '../scripts/lib/factory-skill-loader';
+
+import {
+  REALM_API_TOOLS,
+  SCRIPT_TOOLS,
+  ToolRegistry,
+} from '../scripts/lib/factory-tool-registry';
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+class StubSkillResolver implements SkillResolver {
+  /** Pre-configured skill names returned by resolve(). */
+  skillNames: string[];
+  /** Records all (ticket, project) pairs passed to resolve(). */
+  calls: { ticket: TicketCard; project: ProjectCard }[] = [];
+
+  constructor(skillNames: string[] = ['boxel-development']) {
+    this.skillNames = skillNames;
+  }
+
+  resolve(ticket: TicketCard, project: ProjectCard): string[] {
+    this.calls.push({ ticket, project });
+    return this.skillNames;
+  }
+}
+
+class StubSkillLoader implements SkillLoaderInterface {
+  /** Map from skill name to the ResolvedSkill that load() returns. */
+  private skillMap: Map<string, ResolvedSkill>;
+  /** Records all loadAll() calls: [skillNames, ticket]. */
+  loadAllCalls: { skillNames: string[]; ticket?: TicketCard }[] = [];
+
+  constructor(skills: ResolvedSkill[] = []) {
+    this.skillMap = new Map(skills.map((s) => [s.name, s]));
+  }
+
+  async load(skillName: string, _ticket?: TicketCard): Promise<ResolvedSkill> {
+    let skill = this.skillMap.get(skillName);
+    if (!skill) {
+      throw new Error(`StubSkillLoader: unknown skill "${skillName}"`);
+    }
+    return skill;
+  }
+
+  async loadAll(
+    skillNames: string[],
+    ticket?: TicketCard,
+  ): Promise<ResolvedSkill[]> {
+    this.loadAllCalls.push({ skillNames, ticket });
+    let results: ResolvedSkill[] = [];
+    for (let name of skillNames) {
+      let skill = this.skillMap.get(name);
+      if (skill) {
+        results.push(skill);
+      }
+    }
+    return results;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeProject(overrides?: Partial<ProjectCard>): ProjectCard {
+  return { id: 'project-1', name: 'Sticky Notes', ...overrides };
+}
+
+function makeTicket(overrides?: Partial<TicketCard>): TicketCard {
+  return {
+    id: 'ticket-1',
+    title: 'Implement StickyNote card',
+    description: 'Create a .gts card definition for StickyNote',
+    ...overrides,
+  };
+}
+
+function makeKnowledge(
+  overrides?: Partial<KnowledgeArticle>,
+): KnowledgeArticle {
+  return { id: 'ka-1', title: 'Boxel Card Basics', ...overrides };
+}
+
+function makeSkill(name: string, content?: string): ResolvedSkill {
+  return {
+    name,
+    content: content ?? `Skill content for ${name}`,
+  };
+}
+
+function makeConfig(overrides?: Partial<ContextBuilderConfig>) {
+  let resolver = new StubSkillResolver();
+  let loader = new StubSkillLoader([
+    makeSkill('boxel-development'),
+    makeSkill('boxel-file-structure'),
+    makeSkill('ember-best-practices'),
+  ]);
+  let toolRegistry = new ToolRegistry([...SCRIPT_TOOLS, ...REALM_API_TOOLS]);
+
+  return {
+    config: {
+      skillResolver: resolver,
+      skillLoader: loader,
+      toolRegistry,
+      ...overrides,
+    } as ContextBuilderConfig,
+    resolver,
+    loader,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Skill resolution
+// ---------------------------------------------------------------------------
+
+module('factory-context-builder > skill resolution', function () {
+  test('resolves skills from ticket and project', async function (assert) {
+    let { config, resolver } = makeConfig();
+    let builder = new ContextBuilder(config);
+    let ticket = makeTicket();
+    let project = makeProject();
+
+    await builder.build({
+      project,
+      ticket,
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+    });
+
+    assert.strictEqual(resolver.calls.length, 1, 'resolve() called once');
+    assert.strictEqual(
+      resolver.calls[0].ticket,
+      ticket,
+      'resolve() received the ticket',
+    );
+    assert.strictEqual(
+      resolver.calls[0].project,
+      project,
+      'resolve() received the project',
+    );
+  });
+
+  test('passes resolved skill names to loader', async function (assert) {
+    let resolver = new StubSkillResolver([
+      'boxel-development',
+      'ember-best-practices',
+    ]);
+    let loader = new StubSkillLoader([
+      makeSkill('boxel-development'),
+      makeSkill('ember-best-practices'),
+    ]);
+    let { config } = makeConfig({
+      skillResolver: resolver,
+      skillLoader: loader,
+    });
+    let builder = new ContextBuilder(config);
+
+    await builder.build({
+      project: makeProject(),
+      ticket: makeTicket(),
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+    });
+
+    assert.strictEqual(loader.loadAllCalls.length, 1, 'loadAll() called once');
+    assert.deepEqual(
+      loader.loadAllCalls[0].skillNames,
+      ['boxel-development', 'ember-best-practices'],
+      'loadAll() received the resolved skill names',
+    );
+  });
+
+  test('passes ticket to loadAll for reference filtering', async function (assert) {
+    let resolver = new StubSkillResolver(['boxel-development']);
+    let loader = new StubSkillLoader([makeSkill('boxel-development')]);
+    let { config } = makeConfig({
+      skillResolver: resolver,
+      skillLoader: loader,
+    });
+    let builder = new ContextBuilder(config);
+    let ticket = makeTicket();
+
+    await builder.build({
+      project: makeProject(),
+      ticket,
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+    });
+
+    assert.strictEqual(
+      loader.loadAllCalls[0].ticket,
+      ticket,
+      'loadAll() received the ticket for reference filtering',
+    );
+  });
+
+  test('includes resolved skills in the context', async function (assert) {
+    let resolver = new StubSkillResolver([
+      'boxel-development',
+      'ember-best-practices',
+    ]);
+    let loader = new StubSkillLoader([
+      makeSkill('boxel-development', 'BD content'),
+      makeSkill('ember-best-practices', 'EBP content'),
+    ]);
+    let { config } = makeConfig({
+      skillResolver: resolver,
+      skillLoader: loader,
+    });
+    let builder = new ContextBuilder(config);
+
+    let ctx = await builder.build({
+      project: makeProject(),
+      ticket: makeTicket(),
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+    });
+
+    assert.strictEqual(ctx.skills.length, 2, 'two skills in context');
+    assert.strictEqual(ctx.skills[0].name, 'boxel-development');
+    assert.strictEqual(ctx.skills[1].name, 'ember-best-practices');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Skill budget enforcement
+// ---------------------------------------------------------------------------
+
+module('factory-context-builder > skill budget', function () {
+  test('enforces skill budget when maxSkillTokens is set', async function (assert) {
+    // Each skill content is short (~30 chars ÷ 4 ≈ 8 tokens).
+    // A budget of 10 tokens should allow only one skill.
+    let resolver = new StubSkillResolver([
+      'boxel-development',
+      'ember-best-practices',
+    ]);
+    let loader = new StubSkillLoader([
+      makeSkill('boxel-development', 'A'.repeat(36)), // 9 tokens
+      makeSkill('ember-best-practices', 'B'.repeat(36)), // 9 tokens
+    ]);
+    let { config } = makeConfig({
+      skillResolver: resolver,
+      skillLoader: loader,
+      maxSkillTokens: 10,
+    });
+    let builder = new ContextBuilder(config);
+
+    let ctx = await builder.build({
+      project: makeProject(),
+      ticket: makeTicket(),
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+    });
+
+    assert.strictEqual(ctx.skills.length, 1, 'budget trimmed to one skill');
+    assert.strictEqual(
+      ctx.skills[0].name,
+      'boxel-development',
+      'higher-priority skill kept',
+    );
+  });
+
+  test('does not enforce budget when maxSkillTokens is undefined', async function (assert) {
+    let resolver = new StubSkillResolver([
+      'boxel-development',
+      'ember-best-practices',
+    ]);
+    let loader = new StubSkillLoader([
+      makeSkill('boxel-development', 'A'.repeat(1000)),
+      makeSkill('ember-best-practices', 'B'.repeat(1000)),
+    ]);
+    let { config } = makeConfig({
+      skillResolver: resolver,
+      skillLoader: loader,
+    });
+    let builder = new ContextBuilder(config);
+
+    let ctx = await builder.build({
+      project: makeProject(),
+      ticket: makeTicket(),
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+    });
+
+    assert.strictEqual(ctx.skills.length, 2, 'all skills included');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Tool manifest inclusion
+// ---------------------------------------------------------------------------
+
+module('factory-context-builder > tool manifests', function () {
+  test('includes script and realm-api tools', async function (assert) {
+    let { config } = makeConfig();
+    let builder = new ContextBuilder(config);
+
+    let ctx = await builder.build({
+      project: makeProject(),
+      ticket: makeTicket(),
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+    });
+
+    let expectedCount = SCRIPT_TOOLS.length + REALM_API_TOOLS.length;
+    assert.strictEqual(
+      ctx.tools.length,
+      expectedCount,
+      `context has ${expectedCount} tools (script + realm-api)`,
+    );
+  });
+
+  test('does not include boxel-cli tools', async function (assert) {
+    let { config } = makeConfig();
+    let builder = new ContextBuilder(config);
+
+    let ctx = await builder.build({
+      project: makeProject(),
+      ticket: makeTicket(),
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+    });
+
+    let boxelCliTools = ctx.tools.filter((t) => t.category === 'boxel-cli');
+    assert.strictEqual(
+      boxelCliTools.length,
+      0,
+      'no boxel-cli tools in context',
+    );
+  });
+
+  test('all tools have script or realm-api category', async function (assert) {
+    let { config } = makeConfig();
+    let builder = new ContextBuilder(config);
+
+    let ctx = await builder.build({
+      project: makeProject(),
+      ticket: makeTicket(),
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+    });
+
+    for (let tool of ctx.tools) {
+      let isAllowed =
+        tool.category === 'script' || tool.category === 'realm-api';
+      assert.true(
+        isAllowed,
+        `tool "${tool.name}" has allowed category "${tool.category}"`,
+      );
+    }
+  });
+
+  test('includes expected script tools by name', async function (assert) {
+    let { config } = makeConfig();
+    let builder = new ContextBuilder(config);
+
+    let ctx = await builder.build({
+      project: makeProject(),
+      ticket: makeTicket(),
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+    });
+
+    let toolNames = ctx.tools.map((t) => t.name);
+    assert.true(toolNames.includes('search-realm'), 'has search-realm');
+    assert.true(toolNames.includes('pick-ticket'), 'has pick-ticket');
+    assert.true(toolNames.includes('realm-read'), 'has realm-read');
+    assert.true(toolNames.includes('realm-write'), 'has realm-write');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Iteration state threading
+// ---------------------------------------------------------------------------
+
+module('factory-context-builder > iteration state', function () {
+  test('context has no iteration fields on first pass', async function (assert) {
+    let { config } = makeConfig();
+    let builder = new ContextBuilder(config);
+
+    let ctx = await builder.build({
+      project: makeProject(),
+      ticket: makeTicket(),
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+    });
+
+    assert.strictEqual(ctx.testResults, undefined, 'no testResults');
+    assert.strictEqual(ctx.toolResults, undefined, 'no toolResults');
+    assert.strictEqual(ctx.previousActions, undefined, 'no previousActions');
+    assert.strictEqual(ctx.iteration, undefined, 'no iteration');
+  });
+
+  test('threads testResults from iteration state', async function (assert) {
+    let { config } = makeConfig();
+    let builder = new ContextBuilder(config);
+    let testResults: TestResult = {
+      status: 'failed',
+      passedCount: 2,
+      failedCount: 1,
+      failures: [
+        {
+          testName: 'renders card',
+          error: 'Expected element to exist',
+        },
+      ],
+      durationMs: 5000,
+    };
+
+    let ctx = await builder.build({
+      project: makeProject(),
+      ticket: makeTicket(),
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+      iterationState: { testResults },
+    });
+
+    assert.deepEqual(ctx.testResults, testResults, 'testResults threaded');
+  });
+
+  test('threads toolResults from iteration state', async function (assert) {
+    let { config } = makeConfig();
+    let builder = new ContextBuilder(config);
+    let toolResults: ToolResult[] = [
+      {
+        tool: 'search-realm',
+        exitCode: 0,
+        output: { cards: [] },
+        durationMs: 200,
+      },
+    ];
+
+    let ctx = await builder.build({
+      project: makeProject(),
+      ticket: makeTicket(),
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+      iterationState: { toolResults },
+    });
+
+    assert.deepEqual(ctx.toolResults, toolResults, 'toolResults threaded');
+  });
+
+  test('threads previousActions from iteration state', async function (assert) {
+    let { config } = makeConfig();
+    let builder = new ContextBuilder(config);
+    let previousActions: AgentAction[] = [
+      {
+        type: 'create_file',
+        path: 'sticky-note.gts',
+        content: 'export class...',
+        realm: 'target',
+      },
+    ];
+
+    let ctx = await builder.build({
+      project: makeProject(),
+      ticket: makeTicket(),
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+      iterationState: { previousActions },
+    });
+
+    assert.deepEqual(
+      ctx.previousActions,
+      previousActions,
+      'previousActions threaded',
+    );
+  });
+
+  test('threads iteration number from iteration state', async function (assert) {
+    let { config } = makeConfig();
+    let builder = new ContextBuilder(config);
+
+    let ctx = await builder.build({
+      project: makeProject(),
+      ticket: makeTicket(),
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+      iterationState: { iteration: 3 },
+    });
+
+    assert.strictEqual(ctx.iteration, 3, 'iteration number threaded');
+  });
+
+  test('threads all iteration fields together', async function (assert) {
+    let { config } = makeConfig();
+    let builder = new ContextBuilder(config);
+
+    let testResults: TestResult = {
+      status: 'failed',
+      passedCount: 1,
+      failedCount: 1,
+      failures: [{ testName: 'test-1', error: 'fail' }],
+      durationMs: 3000,
+    };
+    let toolResults: ToolResult[] = [
+      { tool: 'realm-read', exitCode: 0, output: {}, durationMs: 100 },
+    ];
+    let previousActions: AgentAction[] = [
+      {
+        type: 'create_file',
+        path: 'card.gts',
+        content: '...',
+        realm: 'target',
+      },
+      {
+        type: 'create_test',
+        path: 'Tests/card.spec.ts',
+        content: '...',
+        realm: 'target',
+      },
+    ];
+
+    let ctx = await builder.build({
+      project: makeProject(),
+      ticket: makeTicket(),
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+      iterationState: {
+        testResults,
+        toolResults,
+        previousActions,
+        iteration: 2,
+      },
+    });
+
+    assert.deepEqual(ctx.testResults, testResults);
+    assert.deepEqual(ctx.toolResults, toolResults);
+    assert.deepEqual(ctx.previousActions, previousActions);
+    assert.strictEqual(ctx.iteration, 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Core context fields
+// ---------------------------------------------------------------------------
+
+module('factory-context-builder > core fields', function () {
+  test('includes project, ticket, and knowledge in context', async function (assert) {
+    let { config } = makeConfig();
+    let builder = new ContextBuilder(config);
+    let project = makeProject();
+    let ticket = makeTicket();
+    let knowledge = [makeKnowledge(), makeKnowledge({ id: 'ka-2' })];
+
+    let ctx = await builder.build({
+      project,
+      ticket,
+      knowledge,
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+    });
+
+    assert.strictEqual(ctx.project, project, 'project passed through');
+    assert.strictEqual(ctx.ticket, ticket, 'ticket passed through');
+    assert.strictEqual(ctx.knowledge, knowledge, 'knowledge passed through');
+  });
+
+  test('includes realm URLs in context', async function (assert) {
+    let { config } = makeConfig();
+    let builder = new ContextBuilder(config);
+
+    let ctx = await builder.build({
+      project: makeProject(),
+      ticket: makeTicket(),
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/my-realm/',
+      testRealmUrl: 'https://example.test/my-realm-test-artifacts/',
+    });
+
+    assert.strictEqual(ctx.targetRealmUrl, 'https://example.test/my-realm/');
+    assert.strictEqual(
+      ctx.testRealmUrl,
+      'https://example.test/my-realm-test-artifacts/',
+    );
+  });
+
+  test('handles empty knowledge array', async function (assert) {
+    let { config } = makeConfig();
+    let builder = new ContextBuilder(config);
+
+    let ctx = await builder.build({
+      project: makeProject(),
+      ticket: makeTicket(),
+      knowledge: [],
+      targetRealmUrl: 'https://example.test/target/',
+      testRealmUrl: 'https://example.test/target-test-artifacts/',
+    });
+
+    assert.deepEqual(ctx.knowledge, [], 'empty knowledge is fine');
+  });
+});

--- a/packages/software-factory/tests/factory-context-builder.test.ts
+++ b/packages/software-factory/tests/factory-context-builder.test.ts
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 
 import type {
-  AgentAction,
   KnowledgeArticle,
   ProjectCard,
   ResolvedSkill,
   TestResult,
   TicketCard,
-  ToolResult,
 } from '../scripts/lib/factory-agent';
 
 import {
@@ -19,12 +17,6 @@ import type {
   SkillLoaderInterface,
   SkillResolver,
 } from '../scripts/lib/factory-skill-loader';
-
-import {
-  REALM_API_TOOLS,
-  SCRIPT_TOOLS,
-  ToolRegistry,
-} from '../scripts/lib/factory-tool-registry';
 
 // ---------------------------------------------------------------------------
 // Test doubles
@@ -117,13 +109,11 @@ function makeConfig(overrides?: Partial<ContextBuilderConfig>) {
     makeSkill('boxel-file-structure'),
     makeSkill('ember-best-practices'),
   ]);
-  let toolRegistry = new ToolRegistry([...SCRIPT_TOOLS, ...REALM_API_TOOLS]);
 
   return {
     config: {
       skillResolver: resolver,
       skillLoader: loader,
-      toolRegistry,
       ...overrides,
     } as ContextBuilderConfig,
     resolver,
@@ -254,7 +244,7 @@ module('factory-context-builder > skill resolution', function () {
 
 module('factory-context-builder > skill budget', function () {
   test('enforces skill budget when maxSkillTokens is set', async function (assert) {
-    // Each skill content is short (~30 chars ÷ 4 ≈ 8 tokens).
+    // Each skill content is short (~36 chars ÷ 4 ≈ 9 tokens).
     // A budget of 10 tokens should allow only one skill.
     let resolver = new StubSkillResolver([
       'boxel-development',
@@ -315,11 +305,11 @@ module('factory-context-builder > skill budget', function () {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: Tool manifest inclusion
+// Tests: Tools are not included in context
 // ---------------------------------------------------------------------------
 
-module('factory-context-builder > tool manifests', function () {
-  test('includes script and realm-api tools', async function (assert) {
+module('factory-context-builder > tools excluded', function () {
+  test('context does not include tools (provided separately as FactoryTool[])', async function (assert) {
     let { config } = makeConfig();
     let builder = new ContextBuilder(config);
 
@@ -331,82 +321,20 @@ module('factory-context-builder > tool manifests', function () {
       testRealmUrl: 'https://example.test/target-test-artifacts/',
     });
 
-    let expectedCount = SCRIPT_TOOLS.length + REALM_API_TOOLS.length;
     assert.strictEqual(
-      ctx.tools.length,
-      expectedCount,
-      `context has ${expectedCount} tools (script + realm-api)`,
+      ctx.tools,
+      undefined,
+      'tools not set — provided separately as FactoryTool[] to agent.run()',
     );
-  });
-
-  test('does not include boxel-cli tools', async function (assert) {
-    let { config } = makeConfig();
-    let builder = new ContextBuilder(config);
-
-    let ctx = await builder.build({
-      project: makeProject(),
-      ticket: makeTicket(),
-      knowledge: [],
-      targetRealmUrl: 'https://example.test/target/',
-      testRealmUrl: 'https://example.test/target-test-artifacts/',
-    });
-
-    let boxelCliTools = ctx.tools.filter((t) => t.category === 'boxel-cli');
-    assert.strictEqual(
-      boxelCliTools.length,
-      0,
-      'no boxel-cli tools in context',
-    );
-  });
-
-  test('all tools have script or realm-api category', async function (assert) {
-    let { config } = makeConfig();
-    let builder = new ContextBuilder(config);
-
-    let ctx = await builder.build({
-      project: makeProject(),
-      ticket: makeTicket(),
-      knowledge: [],
-      targetRealmUrl: 'https://example.test/target/',
-      testRealmUrl: 'https://example.test/target-test-artifacts/',
-    });
-
-    for (let tool of ctx.tools) {
-      let isAllowed =
-        tool.category === 'script' || tool.category === 'realm-api';
-      assert.true(
-        isAllowed,
-        `tool "${tool.name}" has allowed category "${tool.category}"`,
-      );
-    }
-  });
-
-  test('includes expected script tools by name', async function (assert) {
-    let { config } = makeConfig();
-    let builder = new ContextBuilder(config);
-
-    let ctx = await builder.build({
-      project: makeProject(),
-      ticket: makeTicket(),
-      knowledge: [],
-      targetRealmUrl: 'https://example.test/target/',
-      testRealmUrl: 'https://example.test/target-test-artifacts/',
-    });
-
-    let toolNames = ctx.tools.map((t) => t.name);
-    assert.true(toolNames.includes('search-realm'), 'has search-realm');
-    assert.true(toolNames.includes('pick-ticket'), 'has pick-ticket');
-    assert.true(toolNames.includes('realm-read'), 'has realm-read');
-    assert.true(toolNames.includes('realm-write'), 'has realm-write');
   });
 });
 
 // ---------------------------------------------------------------------------
-// Tests: Iteration state threading
+// Tests: Test results threading
 // ---------------------------------------------------------------------------
 
-module('factory-context-builder > iteration state', function () {
-  test('context has no iteration fields on first pass', async function (assert) {
+module('factory-context-builder > test results', function () {
+  test('context has no testResults on first pass', async function (assert) {
     let { config } = makeConfig();
     let builder = new ContextBuilder(config);
 
@@ -419,12 +347,9 @@ module('factory-context-builder > iteration state', function () {
     });
 
     assert.strictEqual(ctx.testResults, undefined, 'no testResults');
-    assert.strictEqual(ctx.toolResults, undefined, 'no toolResults');
-    assert.strictEqual(ctx.previousActions, undefined, 'no previousActions');
-    assert.strictEqual(ctx.iteration, undefined, 'no iteration');
   });
 
-  test('threads testResults from iteration state', async function (assert) {
+  test('includes testResults when provided', async function (assert) {
     let { config } = makeConfig();
     let builder = new ContextBuilder(config);
     let testResults: TestResult = {
@@ -446,108 +371,22 @@ module('factory-context-builder > iteration state', function () {
       knowledge: [],
       targetRealmUrl: 'https://example.test/target/',
       testRealmUrl: 'https://example.test/target-test-artifacts/',
-      iterationState: { testResults },
+      testResults,
     });
 
-    assert.deepEqual(ctx.testResults, testResults, 'testResults threaded');
+    assert.deepEqual(ctx.testResults, testResults, 'testResults included');
   });
 
-  test('threads toolResults from iteration state', async function (assert) {
+  test('passing testResults does not include deprecated fields', async function (assert) {
     let { config } = makeConfig();
     let builder = new ContextBuilder(config);
-    let toolResults: ToolResult[] = [
-      {
-        tool: 'search-realm',
-        exitCode: 0,
-        output: { cards: [] },
-        durationMs: 200,
-      },
-    ];
-
-    let ctx = await builder.build({
-      project: makeProject(),
-      ticket: makeTicket(),
-      knowledge: [],
-      targetRealmUrl: 'https://example.test/target/',
-      testRealmUrl: 'https://example.test/target-test-artifacts/',
-      iterationState: { toolResults },
-    });
-
-    assert.deepEqual(ctx.toolResults, toolResults, 'toolResults threaded');
-  });
-
-  test('threads previousActions from iteration state', async function (assert) {
-    let { config } = makeConfig();
-    let builder = new ContextBuilder(config);
-    let previousActions: AgentAction[] = [
-      {
-        type: 'create_file',
-        path: 'sticky-note.gts',
-        content: 'export class...',
-        realm: 'target',
-      },
-    ];
-
-    let ctx = await builder.build({
-      project: makeProject(),
-      ticket: makeTicket(),
-      knowledge: [],
-      targetRealmUrl: 'https://example.test/target/',
-      testRealmUrl: 'https://example.test/target-test-artifacts/',
-      iterationState: { previousActions },
-    });
-
-    assert.deepEqual(
-      ctx.previousActions,
-      previousActions,
-      'previousActions threaded',
-    );
-  });
-
-  test('threads iteration number from iteration state', async function (assert) {
-    let { config } = makeConfig();
-    let builder = new ContextBuilder(config);
-
-    let ctx = await builder.build({
-      project: makeProject(),
-      ticket: makeTicket(),
-      knowledge: [],
-      targetRealmUrl: 'https://example.test/target/',
-      testRealmUrl: 'https://example.test/target-test-artifacts/',
-      iterationState: { iteration: 3 },
-    });
-
-    assert.strictEqual(ctx.iteration, 3, 'iteration number threaded');
-  });
-
-  test('threads all iteration fields together', async function (assert) {
-    let { config } = makeConfig();
-    let builder = new ContextBuilder(config);
-
     let testResults: TestResult = {
-      status: 'failed',
-      passedCount: 1,
-      failedCount: 1,
-      failures: [{ testName: 'test-1', error: 'fail' }],
-      durationMs: 3000,
+      status: 'passed',
+      passedCount: 3,
+      failedCount: 0,
+      failures: [],
+      durationMs: 2000,
     };
-    let toolResults: ToolResult[] = [
-      { tool: 'realm-read', exitCode: 0, output: {}, durationMs: 100 },
-    ];
-    let previousActions: AgentAction[] = [
-      {
-        type: 'create_file',
-        path: 'card.gts',
-        content: '...',
-        realm: 'target',
-      },
-      {
-        type: 'create_test',
-        path: 'Tests/card.spec.ts',
-        content: '...',
-        realm: 'target',
-      },
-    ];
 
     let ctx = await builder.build({
       project: makeProject(),
@@ -555,18 +394,14 @@ module('factory-context-builder > iteration state', function () {
       knowledge: [],
       targetRealmUrl: 'https://example.test/target/',
       testRealmUrl: 'https://example.test/target-test-artifacts/',
-      iterationState: {
-        testResults,
-        toolResults,
-        previousActions,
-        iteration: 2,
-      },
+      testResults,
     });
 
-    assert.deepEqual(ctx.testResults, testResults);
-    assert.deepEqual(ctx.toolResults, toolResults);
-    assert.deepEqual(ctx.previousActions, previousActions);
-    assert.strictEqual(ctx.iteration, 2);
+    assert.deepEqual(ctx.testResults, testResults, 'testResults included');
+    assert.strictEqual(ctx.tools, undefined, 'no tools');
+    assert.strictEqual(ctx.toolResults, undefined, 'no toolResults');
+    assert.strictEqual(ctx.previousActions, undefined, 'no previousActions');
+    assert.strictEqual(ctx.iteration, undefined, 'no iteration');
   });
 });
 

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -63,7 +63,6 @@ type SharedRealmHandle = {
 type TestWorkerPortSet = {
   compatRealmServerPort: number;
   realmServerPort: number;
-  workerManagerPort: number;
   prerenderPort: number;
 };
 
@@ -183,8 +182,7 @@ async function allocateTestWorkerPortSet(
     let candidate: TestWorkerPortSet = {
       compatRealmServerPort: blockStart,
       realmServerPort: blockStart + 1,
-      workerManagerPort: blockStart + 2,
-      prerenderPort: blockStart + 3,
+      prerenderPort: blockStart + 2,
     };
     let ports = Object.values(candidate);
     if (
@@ -282,9 +280,6 @@ async function startRealmProcess(
           testWorkerPortSet.compatRealmServerPort,
         ),
         SOFTWARE_FACTORY_REALM_PORT: String(testWorkerPortSet.realmServerPort),
-        SOFTWARE_FACTORY_WORKER_MANAGER_PORT: String(
-          testWorkerPortSet.workerManagerPort,
-        ),
         SOFTWARE_FACTORY_PRERENDER_PORT: String(
           testWorkerPortSet.prerenderPort,
         ),


### PR DESCRIPTION
> **Note:** This PR is based on #4292 (`worktree-cs-10560-cache-prepare`), which needs to be reviewed and merged first.

## Summary

- Add `scripts/lib/factory-context-builder.ts` — assembles a complete `AgentContext` from ticket, project, knowledge articles, and resolved skills
- Aligned with CS-10566's executable tool functions model: tools are no longer in `AgentContext` (provided separately as `FactoryTool[]` to `agent.run()`)
- `AgentContext.tools` marked optional/deprecated; `toolResults`, `previousActions`, `iteration` no longer set by the builder
- Supports `testResults` threading for iteration passes after failed test runs
- Skill budget enforcement via `enforceSkillBudget()` when `maxSkillTokens` is configured
- Guard `context.tools` access in `factory-prompt-loader.ts` with `?? []` for backward compat
- Add `tests/factory-context-builder.test.ts` with 14 tests covering skill resolution, budget enforcement, tool exclusion, test results threading, and core fields
- Add `scripts/factory-context-smoke.ts` — exercises the full pipeline with real skill files from disk

## Try it out

From `packages/software-factory/`:

```bash
# Basic run — exercises skill resolution, loading, context assembly
pnpm factory:context-smoke
```

Expected output:
```
=== Context Builder Smoke Test ===

--- Card definition (.gts work) ---
  Ticket: Define StickyNote card

  First pass (no test results):
  ✓ project.id set
  ✓ ticket.id set
  ✓ knowledge: 2 article(s)
  ✓ skills: 3 loaded
  ✓ tools not set (provided separately as FactoryTool[])
  ✓ testResults not set
  ✓ targetRealmUrl set
  ✓ testRealmUrl set
  Skill breakdown (~69269 total tokens):
    - boxel-development: ~6969 tokens + 5 ref(s)
    - boxel-file-structure: ~1964 tokens
    - ember-best-practices: ~60336 tokens + 1 ref(s)

  Iteration pass (with failed test results):
  ✓ testResults.status = failed
  ✓ testResults.failedCount = 1
  ✓ testResults.failures[0] has error
  ✓ skills still loaded on iteration
  ✓ deprecated fields not set

--- Factory workflow ticket ---
  Ticket: Improve factory delivery pipeline

  ... (same checks, different skills resolved) ...

--- Minimal ticket (base case) ---
  Ticket: Add timestamp fields

  ... (same checks, fewer skills for a generic ticket) ...

===========================
  39 passed, 0 failed
===========================
```

With skill token budget enforcement:
```bash
pnpm factory:context-smoke --max-tokens 8000
```

This trims skills to fit within the budget. You'll see `[SkillBudget] Dropping skill ...` warnings as skills are trimmed, and a budget verification section at the end:
```
[SkillBudget] Dropping skill "boxel-file-structure" (1964 tokens) — would exceed budget of 8000 (used: 6969)
[SkillBudget] Dropping skill "ember-best-practices" (60336 tokens) — would exceed budget of 8000 (used: 6969)
  First pass (no test results):
  ✓ project.id set
  ...
  ✓ skills: 1 loaded
  ...
  Skill breakdown (~6969 total tokens):
    - boxel-development: ~6969 tokens + 5 ref(s)

  ... (more tickets, some fit within budget without trimming) ...

--- Budget enforcement (8000 tokens) ---

[SkillBudget] Dropping skill "boxel-file-structure" (1964 tokens) — would exceed budget of 8000 (used: 6969)
[SkillBudget] Dropping skill "ember-best-practices" (60336 tokens) — would exceed budget of 8000 (used: 6969)
  ✓ 1 skills within budget (~6969 tokens <= 8000)
    - boxel-development: ~6969 tokens

===========================
  40 passed, 0 failed
===========================
```

## Test plan

- [x] `pnpm test:node` — all 321 tests pass (14 new)
- [x] `pnpm lint` — clean (only pre-existing `../base/` glint errors)
- [x] `pnpm factory:context-smoke` — 39 passed, 0 failed
- [x] `pnpm factory:context-smoke --max-tokens 8000` — 40 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)