### PR TITLE
CS-10580, CS-10582: Fix card catalog scrollbar spacing and overflow

### DIFF
--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -644,7 +644,6 @@ export default class SearchContent extends Component<Signature> {
         display: flex;
         flex-direction: column;
         flex: 1;
-        overflow-x: hidden;
         overflow-y: auto;
         overscroll-behavior: none;
         height: 100%;

--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -648,6 +648,7 @@ export default class SearchContent extends Component<Signature> {
         overscroll-behavior: none;
         height: 100%;
         background-color: var(--boxel-light);
+        padding-right: var(--boxel-sp);
         transition: opacity calc(var(--boxel-transition) / 4);
       }
       .search-sheet-content.compact {

--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -644,6 +644,7 @@ export default class SearchContent extends Component<Signature> {
         display: flex;
         flex-direction: column;
         flex: 1;
+        overflow-x: hidden;
         overflow-y: auto;
         overscroll-behavior: none;
         height: 100%;


### PR DESCRIPTION
## Summary
- Adds `padding-right: var(--boxel-sp)` to `.search-sheet-content` so that search results are not flush against the scrollbar in the card catalog (CS-10580)
- Adds `overflow-x: hidden` to `.search-sheet-content` to prevent a horizontal scrollbar from appearing on strip card size (CS-10582)

Both are fixes for PR feedback from Luke on CS-10380 (#4171).

### Before


https://github.com/user-attachments/assets/87bb7978-c7ed-4cf9-8a21-a18058691970


### After


https://github.com/user-attachments/assets/cd3d2b73-d91d-496b-9f33-ad94f866b734



🤖 Generated with [Claude Code](https://claude.com/claude-code)