### PR TITLE
Pass sourceContextCodeRef to guide tag/category selection

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -609,7 +609,8 @@ export class OneShotLLMRequestResult extends CardDef {
 
 // Select up to N cards of a given type using an LLM heuristic
 export class SearchAndChooseInput extends CardDef {
-  @field codeRef = contains(CodeRefField); // module + name of card type to search instances of
+  @field candidateTypeCodeRef = contains(CodeRefField); // module + name of card type whose instances should be searched as candidates
+  @field sourceContextCodeRef = contains(AbsoluteCodeRefField); // optional module + name whose source should guide selection
   @field max = contains(NumberField); // optional, default 2
   @field additionalSystemPrompt = contains(StringField); // optional extra hard rules
   @field llmModel = contains(StringField); // optional model override

--- a/packages/host/app/commands/listing-create.ts
+++ b/packages/host/app/commands/listing-create.ts
@@ -146,8 +146,8 @@ export default class ListingCreateCommand extends HostBaseCommand<
     const backgroundWork = Promise.all([
       this.autoPatchName(listingCard, codeRef),
       this.autoPatchSummary(listingCard, codeRef),
-      this.autoLinkTag(listingCard),
-      this.autoLinkCategory(listingCard),
+      this.autoLinkTag(listingCard, codeRef),
+      this.autoLinkCategory(listingCard, codeRef),
       this.autoLinkLicense(listingCard),
       this.autoLinkExample(listingCard, codeRef, openCardIds),
       this.linkSpecs(
@@ -285,12 +285,19 @@ export default class ListingCreateCommand extends HostBaseCommand<
 
   // --- Linking helpers now use SearchAndChooseCommand ---
   private async chooseCards(
-    codeRef: ResolvedCodeRef,
-    opts?: { max?: number; additionalSystemPrompt?: string },
+    params: {
+      candidateTypeCodeRef: ResolvedCodeRef;
+      sourceContextCodeRef?: ResolvedCodeRef;
+    },
+    opts?: {
+      max?: number;
+      additionalSystemPrompt?: string;
+    },
   ) {
     const command = new SearchAndChooseCommand(this.commandContext);
     const result = await command.execute({
-      codeRef,
+      candidateTypeCodeRef: params.candidateTypeCodeRef,
+      sourceContextCodeRef: params.sourceContextCodeRef,
       max: opts?.max ?? 2,
       additionalSystemPrompt: opts?.additionalSystemPrompt,
     });
@@ -418,22 +425,25 @@ export default class ListingCreateCommand extends HostBaseCommand<
       uniqueById.size < MAX_EXAMPLES
     ) {
       try {
-        const searchAndChoose = new SearchAndChooseCommand(this.commandContext);
         const existingIds = Array.from(uniqueById.keys());
-        const result = await searchAndChoose.execute({
-          codeRef,
-          max: Math.max(1, MAX_EXAMPLES - existingIds.length),
-          additionalSystemPrompt: [
-            'Prefer examples that showcase common or high-impact use cases.',
-            existingIds.length
-              ? `Do not include any id already linked: ${existingIds.join(', ')}.`
-              : '',
-            'Return [] if nothing relevant is found.',
-          ]
-            .filter(Boolean)
-            .join(' '),
-        });
-        for (const card of result.selectedCards ?? []) {
+        const additionalExamples = await this.chooseCards(
+          {
+            candidateTypeCodeRef: codeRef,
+          },
+          {
+            max: Math.max(1, MAX_EXAMPLES - existingIds.length),
+            additionalSystemPrompt: [
+              'Prefer examples that showcase common or high-impact use cases.',
+              existingIds.length
+                ? `Do not include any id already linked: ${existingIds.join(', ')}.`
+                : '',
+              'Return [] if nothing relevant is found.',
+            ]
+              .filter(Boolean)
+              .join(' '),
+          },
+        );
+        for (const card of additionalExamples) {
           addCard(card as CardAPI.CardDef);
         }
       } catch (error) {
@@ -449,41 +459,58 @@ export default class ListingCreateCommand extends HostBaseCommand<
   private async autoLinkLicense(listing: CardAPI.CardDef) {
     const selected = await this.chooseCards(
       {
-        module: `${this.catalogRealm}catalog-app/listing/license`,
-        name: 'License',
-      } as ResolvedCodeRef,
+        candidateTypeCodeRef: {
+          module: `${this.catalogRealm}catalog-app/listing/license`,
+          name: 'License',
+        } as ResolvedCodeRef,
+      },
       { max: 1 },
     );
     (listing as any).license = selected[0];
   }
 
-  private async autoLinkTag(listing: CardAPI.CardDef) {
+  private async autoLinkTag(
+    listing: CardAPI.CardDef,
+    codeRef: ResolvedCodeRef,
+  ) {
     const selected = await this.chooseCards(
       {
-        module: `${this.catalogRealm}catalog-app/listing/tag`,
-        name: 'Tag',
-      } as ResolvedCodeRef,
+        candidateTypeCodeRef: {
+          module: `${this.catalogRealm}catalog-app/listing/tag`,
+          name: 'Tag',
+        } as ResolvedCodeRef,
+        sourceContextCodeRef: codeRef,
+      },
       {
         max: 2,
         additionalSystemPrompt:
-          'RULE: Never select or return any id that contains the substring "stub" (case-insensitive). If all contain stub return [].',
+          "Choose tags that best describe the card's nature or usage pattern." +
+          ' RULE: Never select or return any id that contains the substring "stub" (case-insensitive). If all contain stub return [].',
       },
     );
     (listing as any).tags = selected;
   }
 
-  private async autoLinkCategory(listing: CardAPI.CardDef) {
+  private async autoLinkCategory(
+    listing: CardAPI.CardDef,
+    codeRef: ResolvedCodeRef,
+  ) {
     const selected = await this.chooseCards(
       {
-        module: `${this.catalogRealm}catalog-app/listing/category`,
-        name: 'Category',
-      } as ResolvedCodeRef,
-      { max: 2 },
+        candidateTypeCodeRef: {
+          module: `${this.catalogRealm}catalog-app/listing/category`,
+          name: 'Category',
+        } as ResolvedCodeRef,
+        sourceContextCodeRef: codeRef,
+      },
+      {
+        max: 2,
+        additionalSystemPrompt:
+          "Choose categories that best match the card's domain or purpose.",
+      },
     );
     (listing as any).categories = selected;
   }
-
-  // Removed bespoke AI selection/parsing helpers in favor of SearchAndChooseCommand
 
   private async getStringPatch(opts: {
     systemPrompt: string;

--- a/packages/host/app/commands/search-and-choose.ts
+++ b/packages/host/app/commands/search-and-choose.ts
@@ -1,6 +1,5 @@
-import { service } from '@ember/service';
-
 import { logger } from '@cardstack/runtime-common';
+import type { ResolvedCodeRef } from '@cardstack/runtime-common';
 import { isResolvedCodeRef } from '@cardstack/runtime-common/code-ref';
 
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
@@ -15,18 +14,14 @@ import { SearchCardsByTypeAndTitleCommand } from './search-cards';
 // Command-level logger (general lifecycle + decisions)
 const log = logger('commands:search-and-choose');
 
-import type StoreService from '../services/store';
-
 export default class SearchAndChooseCommand extends HostBaseCommand<
   typeof BaseCommandModule.SearchAndChooseInput,
   typeof BaseCommandModule.SearchAndChooseResult
 > {
-  @service declare private store: StoreService;
-
   static actionVerb = 'Select';
   description =
     'Search for instances of a card type and choose the most relevant subset via LLM';
-  requireInputFields = ['codeRef'];
+  requireInputFields = ['candidateTypeCodeRef'];
 
   async getInputType() {
     let commandModule = await this.loadCommandModule();
@@ -37,32 +32,42 @@ export default class SearchAndChooseCommand extends HostBaseCommand<
   protected async run(
     input: BaseCommandModule.SearchAndChooseInput,
   ): Promise<BaseCommandModule.SearchAndChooseResult> {
-    let { codeRef, max = 2, additionalSystemPrompt, llmModel } = input;
-
-    if (!codeRef) {
-      throw new Error('codeRef is required');
-    }
-    if (!isResolvedCodeRef(codeRef)) {
-      throw new Error('codeRef must have an absolute module URL');
-    }
+    let {
+      sourceContextCodeRef,
+      max = 2,
+      additionalSystemPrompt,
+      llmModel,
+    } = input;
+    let candidateTypeCodeRef = this.assertResolvedCodeRef(
+      input.candidateTypeCodeRef,
+      'candidateTypeCodeRef',
+    );
+    let selectionContextCodeRef = sourceContextCodeRef
+      ? this.assertResolvedCodeRef(sourceContextCodeRef, 'sourceContextCodeRef')
+      : undefined;
     if (max < 1) {
       throw new Error('max must be at least 1');
     }
 
     // 1. Gather candidates via existing search command
     const search = new SearchCardsByTypeAndTitleCommand(this.commandContext);
-    const searchResult = await search.execute({ type: codeRef });
+    const searchResult = await search.execute({ type: candidateTypeCodeRef });
     const instances = searchResult.instances ?? [];
 
     if (instances.length === 0) {
-      log.debug('No instances found for type', { type: codeRef.name });
+      log.debug('No instances found for type', {
+        type: candidateTypeCodeRef.name,
+      });
       const { SearchAndChooseResult } = await this.loadCommandModule();
       return new SearchAndChooseResult({ selectedIds: [], selectedCards: [] });
     }
 
     // 2. Prepare prompt content
-    const summaries = this.instancesToPromptString(instances);
-    let systemPrompt = `You are an expert catalog curator. Select the most relevant 1 to ${max} ids representing ${codeRef.name}. Output ONLY a JSON array of unique id strings. No commentary.`;
+    const summaries = this.formatCandidatesForPrompt(instances);
+    let systemPrompt = `You are an expert catalog curator. Select the most relevant 1 to ${max} ids representing ${candidateTypeCodeRef.name}. Output ONLY a JSON array of unique id strings. No commentary.`;
+    if (selectionContextCodeRef) {
+      systemPrompt += ` Use the attached module source for "${selectionContextCodeRef.name}" (${selectionContextCodeRef.module}) as selection context.`;
+    }
     if (additionalSystemPrompt && additionalSystemPrompt.trim()) {
       systemPrompt += ` ${additionalSystemPrompt.trim()}`;
     }
@@ -74,7 +79,7 @@ export default class SearchAndChooseCommand extends HostBaseCommand<
     // Unified prompt logging via reusable utility
     log.debug(
       prettifyPrompts({
-        scope: `SearchAndChoose:${codeRef.name}`,
+        scope: `SearchAndChoose:${candidateTypeCodeRef.name}`,
         systemPrompt,
         userPrompt,
       }),
@@ -82,11 +87,14 @@ export default class SearchAndChooseCommand extends HostBaseCommand<
     const r = await oneShot.execute({
       systemPrompt,
       userPrompt,
-      llmModel: llmModel || 'openai/gpt-5-nano',
-      codeRef: codeRef,
+      llmModel: llmModel || 'anthropic/claude-3-haiku',
+      ...(selectionContextCodeRef ? { codeRef: selectionContextCodeRef } : {}),
     });
 
-    const selectedIds = this.parseIdsFromOutput(r.output || '[]').slice(0, max);
+    const selectedIds = this.parseIdsFromLlmOutput(r.output || '[]').slice(
+      0,
+      max,
+    );
     const selectedCards = instances.filter((inst: any) =>
       selectedIds.some(
         (id) => typeof inst.id === 'string' && inst.id.includes(id),
@@ -99,7 +107,20 @@ export default class SearchAndChooseCommand extends HostBaseCommand<
     });
   }
 
-  private parseIdsFromOutput(output: string): string[] {
+  private assertResolvedCodeRef(
+    codeRef: BaseCommandModule.SearchAndChooseInput['candidateTypeCodeRef'],
+    fieldName: 'candidateTypeCodeRef' | 'sourceContextCodeRef',
+  ): ResolvedCodeRef {
+    if (!codeRef) {
+      throw new Error(`${fieldName} is required`);
+    }
+    if (!isResolvedCodeRef(codeRef)) {
+      throw new Error(`${fieldName} must have an absolute module URL`);
+    }
+    return codeRef;
+  }
+
+  private parseIdsFromLlmOutput(output: string): string[] {
     let text = output.trim();
     if (!text) return [];
     if (text.startsWith('```')) {
@@ -117,7 +138,7 @@ export default class SearchAndChooseCommand extends HostBaseCommand<
     }
   }
 
-  private instancesToPromptString(instances: any[]): string {
+  private formatCandidatesForPrompt(instances: any[]): string {
     return instances
       .filter((c) => c && c.id)
       .map((c) => `${c.id} :: ${c.title || ''}`.trim())

--- a/packages/host/app/commands/search-and-choose.ts
+++ b/packages/host/app/commands/search-and-choose.ts
@@ -88,7 +88,7 @@ export default class SearchAndChooseCommand extends HostBaseCommand<
       systemPrompt,
       userPrompt,
       llmModel: llmModel || 'anthropic/claude-3-haiku',
-      ...(selectionContextCodeRef ? { codeRef: selectionContextCodeRef } : {}),
+      codeRef: selectionContextCodeRef ?? candidateTypeCodeRef,
     });
 
     const selectedIds = this.parseIdsFromLlmOutput(r.output || '[]').slice(
@@ -115,7 +115,7 @@ export default class SearchAndChooseCommand extends HostBaseCommand<
       throw new Error(`${fieldName} is required`);
     }
     if (!isResolvedCodeRef(codeRef)) {
-      throw new Error(`${fieldName} must have an absolute module URL`);
+      throw new Error(`${fieldName} must be a resolved code ref`);
     }
     return codeRef;
   }

--- a/packages/host/tests/integration/commands/search-and-choose-test.gts
+++ b/packages/host/tests/integration/commands/search-and-choose-test.gts
@@ -1,0 +1,181 @@
+import { getOwner } from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import SearchAndChooseCommand from '@cardstack/host/commands/search-and-choose';
+import RealmService from '@cardstack/host/services/realm';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupRealmCacheTeardown,
+  setupRealmServerEndpoints,
+  testRealmInfo,
+  testRealmURL,
+  withCachedRealmSetup,
+} from '../../helpers';
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+class StubRealmService extends RealmService {
+  get defaultReadableRealm() {
+    return {
+      path: testRealmURL,
+      info: testRealmInfo,
+    };
+  }
+}
+
+module('Integration | commands | search-and-choose', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  let capturedMessages: Array<{ role: string; content: string }> | undefined =
+    undefined;
+
+  setupRealmServerEndpoints(hooks, [
+    {
+      route: '_request-forward',
+      getResponse: async (req: Request) => {
+        const body = await req.json();
+
+        if (body.url === 'https://openrouter.ai/api/v1/chat/completions') {
+          capturedMessages = JSON.parse(body.requestBody).messages;
+          return new Response(
+            JSON.stringify({
+              choices: [
+                {
+                  message: {
+                    content: JSON.stringify([`${testRealmURL}Choice/alpha`]),
+                  },
+                },
+              ],
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          );
+        }
+
+        return new Response(JSON.stringify({ error: 'Unknown endpoint' }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    },
+  ]);
+
+  hooks.beforeEach(function (this: RenderingTestContext) {
+    getOwner(this)!.register('service:realm', StubRealmService);
+    capturedMessages = undefined;
+  });
+
+  let searchAndChooseCommand: SearchAndChooseCommand;
+  setupRealmCacheTeardown(hooks);
+
+  hooks.beforeEach(async function () {
+    const choiceSource = `import { CardDef, field, contains } from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+
+// choice-source-marker
+export class Choice extends CardDef {
+  static displayName = 'Choice';
+  @field cardTitle = contains(StringField);
+}`;
+    const contextSource = `import { CardDef, field, contains } from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+
+// context-source-marker
+export class ContextCard extends CardDef {
+  static displayName = 'ContextCard';
+  @field cardTitle = contains(StringField);
+}`;
+
+    await withCachedRealmSetup(async () =>
+      setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {
+          'choice.gts': choiceSource,
+          'context-card.gts': contextSource,
+          'Choice/alpha.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                cardTitle: 'Alpha choice',
+              },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}choice.gts`,
+                  name: 'Choice',
+                },
+              },
+            },
+          },
+          'Choice/beta.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                cardTitle: 'Beta choice',
+              },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}choice.gts`,
+                  name: 'Choice',
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    const commandService = getService('command-service');
+    searchAndChooseCommand = new SearchAndChooseCommand(
+      commandService.commandContext,
+    );
+  });
+
+  test('uses sourceContextCodeRef source instead of the searched type source', async function (assert) {
+    let result = await searchAndChooseCommand.execute({
+      candidateTypeCodeRef: {
+        module: `${testRealmURL}choice.gts`,
+        name: 'Choice',
+      },
+      sourceContextCodeRef: {
+        module: `${testRealmURL}context-card.gts`,
+        name: 'ContextCard',
+      },
+      max: 1,
+      additionalSystemPrompt: 'Pick the best matching option.',
+    });
+
+    assert.deepEqual(result.selectedIds, [`${testRealmURL}Choice/alpha`]);
+    assert.strictEqual(
+      result.selectedCards[0]?.id,
+      `${testRealmURL}Choice/alpha`,
+    );
+
+    let userMessage =
+      capturedMessages?.find((message) => message.role === 'user')?.content ??
+      '';
+    assert.true(
+      userMessage.includes('context-source-marker'),
+      'LLM request includes the context module source',
+    );
+    assert.false(
+      userMessage.includes('choice-source-marker'),
+      'LLM request does not include the searched type source',
+    );
+  });
+});


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-10434/category-and-tags-were-generated-incorrectly

## Problem:
SearchAndChooseCommand was selecting tags/categories without any schema context — e.g. an Airbnb listing card could get tagged as "Software Development" or other completely unrelated results.


## Fix:
Renames SearchAndChooseInput.codeRef to **candidateTypeCodeRef**, and adds **sourceContextCodeRef** to inject the listed card's module source as LLM context — improving tag/category accuracy.

Switches default model from gpt-5-nano to claude-3-haiku: slightly more expensive on input but cheaper on output, and significantly more accurate at returning correct results.

Adds an integration test verifying the context module source is sent in the LLM request.

## Follow Up:
The current tag pool is very limited, which constrains how well the AI can match — we should expand the available tags to give better selection coverage.

## Demo:

https://github.com/user-attachments/assets/66662998-6e2e-449c-8062-786412d3bd3a

