### PR TITLE
Add live realm server Playwright testsl

### DIFF
--- a/packages/software-factory/docs/phase-1-plan.md
+++ b/packages/software-factory/docs/phase-1-plan.md
@@ -381,7 +381,7 @@ The target realm currently needs explicit bootstrap through the realm-server API
 
 The system needs to resume from existing state instead of recreating everything on rerun.
 
-### 5. Default Verification Policy *(deferred — see CS-10451 cancellation note)*
+### 5. Default Verification Policy _(deferred — see CS-10451 cancellation note)_
 
 ~~The first verification move should be encoded so the runner knows what to do when there are no tests yet.~~
 
@@ -545,7 +545,7 @@ Responsibilities:
 
 For version one, this helper can stay deterministic and data-oriented. Later AI stages should combine the structured brief fields with a stable prompt template rather than embedding a fully rendered prompt into `factory:go` output.
 
-### E. `scripts/lib/factory-loop.ts` *(implemented — CS-10568)*
+### E. `scripts/lib/factory-loop.ts` _(implemented — CS-10568)_
 
 Central execution loop orchestrator. Exports `runFactoryLoop()` which drives the implement→test→iterate cycle for a single ticket.
 

--- a/packages/software-factory/docs/testing-strategy.md
+++ b/packages/software-factory/docs/testing-strategy.md
@@ -428,11 +428,11 @@ The current mapping is:
   - target-realm bootstrap integration tests
 - `CS-10449`
   - artifact-bootstrap and idempotency integration tests
-- ~~`CS-10451`~~ *(cancelled — hard-coded verification policy conflicts with phase-2 issue-driven approach where test execution is an issue type, not an orchestrator-enforced gate)*
+- ~~`CS-10451`~~ _(cancelled — hard-coded verification policy conflicts with phase-2 issue-driven approach where test execution is an issue type, not an orchestrator-enforced gate)_
   - ~~verification-policy unit tests~~
 - `CS-10450`
   - execution loop implementation, broken into child tickets:
-    - ~~action dispatcher~~ *(replaced by agent-driven tool calls in CS-10568)*
+    - ~~action dispatcher~~ _(replaced by agent-driven tool calls in CS-10568)_
     - context builder (assemble `AgentContext` from skills, realm state) — CS-10567
     - core loop orchestrator (run → test → iterate cycle) — CS-10568
     - wire loop into `factory:go --mode implement`

--- a/packages/software-factory/scripts/lib/factory-tool-builder.ts
+++ b/packages/software-factory/scripts/lib/factory-tool-builder.ts
@@ -15,9 +15,8 @@ import type { ToolRegistry } from './factory-tool-registry';
 import { executeTestRunFromRealm } from './test-run-execution';
 import type { ExecuteTestRunOptions, TestRunHandle } from './test-run-types';
 import {
-  writeModuleSource,
-  writeCardSource,
-  readCardSource,
+  writeFile,
+  readFile,
   searchRealm,
   ensureTrailingSlash,
   type RealmFetchOptions,
@@ -148,7 +147,7 @@ function buildWriteFileTool(config: ToolBuilderConfig): FactoryTool {
       let content = args.content as string;
       let realmUrl = resolveRealmUrl(config, args.realm as string | undefined);
       let fetchOptions = buildFetchOptions(config, realmUrl);
-      return writeModuleSource(realmUrl, path, content, fetchOptions);
+      return writeFile(realmUrl, path, content, fetchOptions);
     },
   };
 }
@@ -176,7 +175,7 @@ function buildReadFileTool(config: ToolBuilderConfig): FactoryTool {
       let path = args.path as string;
       let realmUrl = resolveRealmUrl(config, args.realm as string | undefined);
       let fetchOptions = buildFetchOptions(config, realmUrl);
-      return readCardSource(realmUrl, path, fetchOptions);
+      return readFile(realmUrl, path, fetchOptions);
     },
   };
 }
@@ -244,7 +243,12 @@ function buildUpdateTicketTool(config: ToolBuilderConfig): FactoryTool {
           error: `Failed to parse update_ticket content as JSON: ${path}`,
         };
       }
-      return writeCardSource(realmUrl, path, document, fetchOptions);
+      return writeFile(
+        realmUrl,
+        path,
+        JSON.stringify(document, null, 2),
+        fetchOptions,
+      );
     },
   };
 }
@@ -284,7 +288,12 @@ function buildCreateKnowledgeTool(config: ToolBuilderConfig): FactoryTool {
           error: `Failed to parse create_knowledge content as JSON: ${path}`,
         };
       }
-      return writeCardSource(realmUrl, path, document, fetchOptions);
+      return writeFile(
+        realmUrl,
+        path,
+        JSON.stringify(document, null, 2),
+        fetchOptions,
+      );
     },
   };
 }

--- a/packages/software-factory/scripts/lib/factory-tool-builder.ts
+++ b/packages/software-factory/scripts/lib/factory-tool-builder.ts
@@ -204,7 +204,8 @@ function buildSearchRealmTool(config: ToolBuilderConfig): FactoryTool {
       let query = args.query as Record<string, unknown>;
       let realmUrl = resolveRealmUrl(config, args.realm as string | undefined);
       let fetchOptions = buildFetchOptions(config, realmUrl);
-      return searchRealm(realmUrl, query, fetchOptions);
+      let result = await searchRealm(realmUrl, query, fetchOptions);
+      return result.ok ? { data: result.data } : { error: result.error };
     },
   };
 }

--- a/packages/software-factory/scripts/lib/factory-tool-executor.ts
+++ b/packages/software-factory/scripts/lib/factory-tool-executor.ts
@@ -487,8 +487,10 @@ export class ToolExecutor {
             query,
             fetchOptions,
           );
-          ok = result !== undefined;
-          output = result ?? { error: 'Search failed' };
+          ok = result.ok;
+          output = result.ok
+            ? { data: result.data }
+            : { error: result.error, status: result.status };
           break;
         }
 

--- a/packages/software-factory/scripts/lib/factory-tool-executor.ts
+++ b/packages/software-factory/scripts/lib/factory-tool-executor.ts
@@ -8,7 +8,6 @@ import {
   readCardSource,
   writeModuleSource,
   deleteCard,
-  atomicOperation,
   searchRealm,
   createRealm,
   getServerSession,
@@ -347,15 +346,8 @@ export class ToolExecutor {
     toolName: string,
     toolArgs: Record<string, unknown>,
   ): void {
-    // realm-delete and realm-atomic with remove ops need extra care
+    // Extra validation for destructive realm operations
     if (toolName === 'realm-delete') {
-      let realmUrl = toolArgs['realm-url'];
-      if (typeof realmUrl === 'string') {
-        this.validateRealmTarget(toolName, realmUrl);
-      }
-    }
-
-    if (toolName === 'realm-atomic') {
       let realmUrl = toolArgs['realm-url'];
       if (typeof realmUrl === 'string') {
         this.validateRealmTarget(toolName, realmUrl);
@@ -466,17 +458,6 @@ export class ToolExecutor {
           );
           ok = result.ok;
           output = ok ? result : { error: result.error };
-          break;
-        }
-
-        case 'realm-atomic': {
-          let result = await atomicOperation(
-            String(toolArgs['realm-url']),
-            String(toolArgs['operations']),
-            fetchOptions,
-          );
-          ok = result.ok;
-          output = ok ? result.response : { error: result.error };
           break;
         }
 

--- a/packages/software-factory/scripts/lib/factory-tool-executor.ts
+++ b/packages/software-factory/scripts/lib/factory-tool-executor.ts
@@ -5,9 +5,9 @@ import type { ToolResult } from './factory-agent';
 import type { ToolRegistry } from './factory-tool-registry';
 import {
   ensureTrailingSlash,
-  readCardSource,
-  writeModuleSource,
-  deleteCard,
+  readFile,
+  writeFile,
+  deleteFile,
   searchRealm,
   createRealm,
   getServerSession,
@@ -428,7 +428,7 @@ export class ToolExecutor {
 
       switch (toolName) {
         case 'realm-read': {
-          let result = await readCardSource(
+          let result = await readFile(
             String(toolArgs['realm-url']),
             String(toolArgs['path']),
             fetchOptions,
@@ -439,7 +439,7 @@ export class ToolExecutor {
         }
 
         case 'realm-write': {
-          let result = await writeModuleSource(
+          let result = await writeFile(
             String(toolArgs['realm-url']),
             String(toolArgs['path']),
             String(toolArgs['content']),
@@ -451,7 +451,7 @@ export class ToolExecutor {
         }
 
         case 'realm-delete': {
-          let result = await deleteCard(
+          let result = await deleteFile(
             String(toolArgs['realm-url']),
             String(toolArgs['path']),
             fetchOptions,

--- a/packages/software-factory/scripts/lib/factory-tool-registry.ts
+++ b/packages/software-factory/scripts/lib/factory-tool-registry.ts
@@ -390,27 +390,6 @@ const REALM_API_TOOLS: ToolManifest[] = [
     ],
   },
   {
-    name: 'realm-atomic',
-    description: 'Batch operations that succeed or fail atomically.',
-    category: 'realm-api',
-    outputFormat: 'json',
-    args: [
-      {
-        name: 'realm-url',
-        type: 'string',
-        required: true,
-        description: 'Realm base URL',
-      },
-      {
-        name: 'operations',
-        type: 'string',
-        required: true,
-        description:
-          'JSON array of operations: [{"op":"add|update|remove","href":"...","data":{...}}]',
-      },
-    ],
-  },
-  {
     name: 'realm-search',
     description: 'Search for cards using structured queries.',
     category: 'realm-api',

--- a/packages/software-factory/scripts/lib/realm-operations.ts
+++ b/packages/software-factory/scripts/lib/realm-operations.ts
@@ -122,15 +122,16 @@ export async function searchRealm(
 }
 
 // ---------------------------------------------------------------------------
-// Card Read / Write
+// File Read / Write / Delete
 // ---------------------------------------------------------------------------
 
 /**
- * Read a card from a realm as card source JSON.
+ * Read a file from a realm using the card+source MIME type.
+ * Path should include the file extension (e.g. `Card/foo.json`, `my-card.gts`).
  */
-export async function readCardSource(
+export async function readFile(
   realmUrl: string,
-  cardPath: string,
+  path: string,
   options?: RealmFetchOptions,
 ): Promise<{
   ok: boolean;
@@ -138,7 +139,7 @@ export async function readCardSource(
   error?: string;
 }> {
   let fetchImpl = options?.fetch ?? globalThis.fetch;
-  let url = new URL(cardPath, ensureTrailingSlash(realmUrl)).href;
+  let url = new URL(path, ensureTrailingSlash(realmUrl)).href;
 
   try {
     let response = await fetchImpl(url, {
@@ -168,54 +169,17 @@ export async function readCardSource(
 }
 
 /**
- * Write a card to a realm using card source MIME type.
- * The path should include the `.json` extension.
+ * Write a file to a realm using the card+source MIME type.
+ * Path should include the file extension. Content is sent as-is.
  */
-export async function writeCardSource(
+export async function writeFile(
   realmUrl: string,
-  cardPathWithExtension: string,
-  document: LooseSingleCardDocument,
-  options?: RealmFetchOptions,
-): Promise<{ ok: boolean; error?: string }> {
-  let fetchImpl = options?.fetch ?? globalThis.fetch;
-  let url = new URL(cardPathWithExtension, ensureTrailingSlash(realmUrl)).href;
-
-  try {
-    let response = await fetchImpl(url, {
-      method: 'POST',
-      headers: buildCardSourceHeaders(options?.authorization),
-      body: JSON.stringify(document, null, 2),
-    });
-
-    if (!response.ok) {
-      let body = await response.text();
-      return {
-        ok: false,
-        error: `HTTP ${response.status}: ${body.slice(0, 300)}`,
-      };
-    }
-
-    return { ok: true };
-  } catch (err) {
-    return {
-      ok: false,
-      error: err instanceof Error ? err.message : String(err),
-    };
-  }
-}
-
-/**
- * Write a module (.gts, .ts) to a realm as raw source content.
- * Unlike writeCardSource, this sends the raw text — no JSON wrapping.
- */
-export async function writeModuleSource(
-  realmUrl: string,
-  modulePath: string,
+  path: string,
   content: string,
   options?: RealmFetchOptions,
 ): Promise<{ ok: boolean; error?: string }> {
   let fetchImpl = options?.fetch ?? globalThis.fetch;
-  let url = new URL(modulePath, ensureTrailingSlash(realmUrl)).href;
+  let url = new URL(path, ensureTrailingSlash(realmUrl)).href;
 
   try {
     let response = await fetchImpl(url, {
@@ -248,7 +212,7 @@ export async function writeModuleSource(
 /**
  * Delete a card or file from a realm.
  */
-export async function deleteCard(
+export async function deleteFile(
   realmUrl: string,
   cardPath: string,
   options?: RealmFetchOptions,
@@ -259,7 +223,10 @@ export async function deleteCard(
   try {
     let response = await fetchImpl(url, {
       method: 'DELETE',
-      headers: buildAuthHeaders(options?.authorization),
+      headers: buildAuthHeaders(
+        options?.authorization,
+        SupportedMimeType.CardSource,
+      ),
     });
 
     if (!response.ok) {

--- a/packages/software-factory/scripts/lib/realm-operations.ts
+++ b/packages/software-factory/scripts/lib/realm-operations.ts
@@ -76,7 +76,10 @@ export async function searchRealm(
   realmUrl: string,
   query: Record<string, unknown>,
   options?: RealmFetchOptions,
-): Promise<{ data?: Record<string, unknown>[] } | undefined> {
+): Promise<
+  | { ok: true; data?: Record<string, unknown>[] }
+  | { ok: false; status: number; error: string }
+> {
   let fetchImpl = options?.fetch ?? globalThis.fetch;
   let normalizedUrl = ensureTrailingSlash(realmUrl);
   let searchUrl = `${normalizedUrl}_search`;
@@ -97,12 +100,24 @@ export async function searchRealm(
     });
 
     if (!response.ok) {
-      return undefined;
+      let body = await response.text();
+      return {
+        ok: false,
+        status: response.status,
+        error: `HTTP ${response.status}: ${body.slice(0, 300)}`,
+      };
     }
 
-    return (await response.json()) as { data?: Record<string, unknown>[] };
-  } catch {
-    return undefined;
+    let result = (await response.json()) as {
+      data?: Record<string, unknown>[];
+    };
+    return { ok: true, data: result.data };
+  } catch (err) {
+    return {
+      ok: false,
+      status: 0,
+      error: err instanceof Error ? err.message : String(err),
+    };
   }
 }
 

--- a/packages/software-factory/scripts/lib/test-run-cards.ts
+++ b/packages/software-factory/scripts/lib/test-run-cards.ts
@@ -1,6 +1,6 @@
 import type { LooseSingleCardDocument } from '@cardstack/runtime-common';
 
-import { readCardSource, writeCardSource } from './realm-operations';
+import { readFile, writeFile } from './realm-operations';
 import type {
   CreateTestRunOptions,
   SpecResultData,
@@ -32,10 +32,10 @@ export async function createTestRun(
     },
   );
 
-  let result = await writeCardSource(
+  let result = await writeFile(
     options.testRealmUrl,
     `${testRunId}.json`,
-    document,
+    JSON.stringify(document, null, 2),
     { authorization: options.authorization, fetch: options.fetch },
   );
 
@@ -61,13 +61,9 @@ export async function completeTestRun(
 
   // Retry the read — after a long spawnSync (Playwright), TCP connections
   // may be stale causing the first fetch to fail with "fetch failed".
-  let readResult: Awaited<ReturnType<typeof readCardSource>> | undefined;
+  let readResult: Awaited<ReturnType<typeof readFile>> | undefined;
   for (let attempt = 0; attempt < 3; attempt++) {
-    readResult = await readCardSource(
-      options.testRealmUrl,
-      testRunId,
-      fetchOptions,
-    );
+    readResult = await readFile(options.testRealmUrl, testRunId, fetchOptions);
     if (readResult.ok && readResult.document) {
       break;
     }
@@ -109,10 +105,10 @@ export async function completeTestRun(
     };
   }
 
-  let writeResult = await writeCardSource(
+  let writeResult = await writeFile(
     options.testRealmUrl,
     `${testRunId}.json`,
-    readResult.document,
+    JSON.stringify(readResult.document, null, 2),
     fetchOptions,
   );
 

--- a/packages/software-factory/scripts/lib/test-run-execution.ts
+++ b/packages/software-factory/scripts/lib/test-run-execution.ts
@@ -242,7 +242,11 @@ async function findResumableTestRun(
     { authorization: options.authorization, fetch: options.fetch },
   );
 
-  let latest = result?.data?.[0] as
+  if (!result?.ok) {
+    return undefined;
+  }
+
+  let latest = result.data?.[0] as
     | {
         id?: string;
         attributes?: {
@@ -291,9 +295,11 @@ async function getNextSequenceNumber(
     { authorization: options.authorization, fetch: options.fetch },
   );
 
-  let latest = result?.data?.[0] as
-    | { attributes?: { sequenceNumber?: number } }
-    | undefined;
+  let latest = result?.ok
+    ? (result.data?.[0] as
+        | { attributes?: { sequenceNumber?: number } }
+        | undefined)
+    : undefined;
   return (latest?.attributes?.sequenceNumber ?? 0) + 1;
 }
 

--- a/packages/software-factory/scripts/lib/test-run-execution.ts
+++ b/packages/software-factory/scripts/lib/test-run-execution.ts
@@ -15,9 +15,9 @@ import {
   ensureTrailingSlash,
   getRealmScopedAuth,
   pullRealmFiles,
-  readCardSource,
+  readFile,
   searchRealm,
-  writeCardSource,
+  writeFile,
 } from './realm-operations';
 import { createTestRun, completeTestRun } from './test-run-cards';
 import { parseRunRealmTestsOutput } from './test-run-parsing';
@@ -62,7 +62,7 @@ export async function ensureTestArtifactsRealm(
     fetch: options.fetch,
   };
 
-  let readResult = await readCardSource(
+  let readResult = await readFile(
     new URL(projectCardUrl).origin + '/',
     new URL(projectCardUrl).pathname.slice(1),
     fetchOptions,
@@ -145,10 +145,10 @@ export async function ensureTestArtifactsRealm(
 
   let realmUrl = new URL(projectCardUrl).origin + '/';
   let cardPath = new URL(projectCardUrl).pathname.slice(1);
-  let writeResult = await writeCardSource(
+  let writeResult = await writeFile(
     realmUrl,
     `${cardPath}.json`,
-    readResult.document,
+    JSON.stringify(readResult.document, null, 2),
     fetchOptions,
   );
   if (!writeResult.ok) {

--- a/packages/software-factory/src/cli/serve-realm.ts
+++ b/packages/software-factory/src/cli/serve-realm.ts
@@ -17,8 +17,13 @@ async function main(): Promise<void> {
     }
   }
 
+  let permissions = process.env.SOFTWARE_FACTORY_PERMISSIONS
+    ? JSON.parse(process.env.SOFTWARE_FACTORY_PERMISSIONS)
+    : undefined;
+
   let runtime = await startFactoryRealmServer({
     realmDir,
+    permissions,
     templateDatabaseName: process.env.SOFTWARE_FACTORY_TEMPLATE_DATABASE_NAME,
     templateRealmServerURL: process.env
       .SOFTWARE_FACTORY_TEMPLATE_REALM_SERVER_URL

--- a/packages/software-factory/src/cli/serve-realm.ts
+++ b/packages/software-factory/src/cli/serve-realm.ts
@@ -2,6 +2,8 @@ import { readSupportContext } from '../runtime-metadata';
 import { writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
+import type { RealmPermissions } from '@cardstack/runtime-common';
+
 import { startFactoryRealmServer } from '../harness';
 
 async function main(): Promise<void> {
@@ -17,9 +19,16 @@ async function main(): Promise<void> {
     }
   }
 
-  let permissions = process.env.SOFTWARE_FACTORY_PERMISSIONS
-    ? JSON.parse(process.env.SOFTWARE_FACTORY_PERMISSIONS)
-    : undefined;
+  let permissions: RealmPermissions | undefined;
+  if (process.env.SOFTWARE_FACTORY_PERMISSIONS) {
+    try {
+      permissions = JSON.parse(process.env.SOFTWARE_FACTORY_PERMISSIONS);
+    } catch (e) {
+      throw new Error(
+        `SOFTWARE_FACTORY_PERMISSIONS is not valid JSON: ${e instanceof Error ? e.message : e}`,
+      );
+    }
+  }
 
   let runtime = await startFactoryRealmServer({
     realmDir,

--- a/packages/software-factory/src/cli/smoke-test-realm.ts
+++ b/packages/software-factory/src/cli/smoke-test-realm.ts
@@ -42,8 +42,7 @@ import { executeTestRunFromRealm } from '../../scripts/lib/factory-test-realm';
 import {
   createRealm,
   getRealmScopedAuth,
-  writeCardSource,
-  writeModuleSource,
+  writeFile,
 } from '../../scripts/lib/realm-operations';
 
 // ---------------------------------------------------------------------------
@@ -320,10 +319,10 @@ async function main() {
 
   // 1. Project card — represents this project in the testing phase.
   console.log('  Writing Projects/hello-world.json (Project card)...');
-  let projectResult = await writeCardSource(
+  let projectResult = await writeFile(
     targetRealmUrl,
     'Projects/hello-world.json',
-    buildProjectCard(realmServerUrl) as any,
+    JSON.stringify(buildProjectCard(realmServerUrl), null, 2),
     fetchOptions,
   );
   console.log(
@@ -335,7 +334,7 @@ async function main() {
 
   // 2. Card definition
   console.log('  Writing hello.gts (HelloCard definition)...');
-  let defResult = await writeModuleSource(
+  let defResult = await writeFile(
     targetRealmUrl,
     'hello.gts',
     HELLO_CARD_GTS,
@@ -347,10 +346,10 @@ async function main() {
 
   // 3. Spec card instance pointing to the card definition
   console.log('  Writing Spec/hello-card.json (Spec card for HelloCard)...');
-  let specCardResult = await writeCardSource(
+  let specCardResult = await writeFile(
     targetRealmUrl,
     'Spec/hello-card.json',
-    HELLO_SPEC_CARD as any,
+    JSON.stringify(HELLO_SPEC_CARD, null, 2),
     fetchOptions,
   );
   console.log(
@@ -361,7 +360,7 @@ async function main() {
 
   // 5. Playwright test spec
   console.log('  Writing Tests/hello-smoke.spec.ts (Playwright spec)...');
-  let specResult = await writeModuleSource(
+  let specResult = await writeFile(
     targetRealmUrl,
     'Tests/hello-smoke.spec.ts',
     PLAYWRIGHT_SPEC,
@@ -377,7 +376,7 @@ async function main() {
   console.log(
     '  Writing Tests/hello-failing.spec.ts (deliberately failing spec)...',
   );
-  let failSpecResult = await writeModuleSource(
+  let failSpecResult = await writeFile(
     targetRealmUrl,
     'Tests/hello-failing.spec.ts',
     PLAYWRIGHT_FAILING_SPEC,

--- a/packages/software-factory/src/harness/api.ts
+++ b/packages/software-factory/src/harness/api.ts
@@ -43,6 +43,7 @@ import {
   buildCombinedTemplateDatabase,
   buildTemplateDatabase,
   clearModuleCache,
+  clearRealmPermissions,
   cloneDatabaseFromTemplate,
   databaseExists,
   dropDatabase,
@@ -429,6 +430,15 @@ export async function startFactoryRealmServer(
         sourceRealmURL,
         DEFAULT_SOURCE_REALM_PERMISSIONS,
       );
+
+      // Apply custom test-realm permissions if provided. We clear the
+      // template's permissions first so leftover rows (e.g. the default
+      // '*' public-read grant) don't leak into the private realm.
+      let permissions = options.permissions;
+      if (permissions) {
+        await clearRealmPermissions(databaseName, realmURL);
+        await seedRealmPermissions(databaseName, realmURL, permissions);
+      }
 
       stack = await startIsolatedRealmStack({
         realmDir,

--- a/packages/software-factory/src/harness/database.ts
+++ b/packages/software-factory/src/harness/database.ts
@@ -224,6 +224,28 @@ export async function seedRealmPermissions(
   );
 }
 
+export async function clearRealmPermissions(
+  databaseName: string,
+  realmURL: URL,
+): Promise<void> {
+  await logTimed(
+    templateLog,
+    `clearRealmPermissions ${databaseName} ${realmURL.href}`,
+    async () => {
+      let client = new PgClient(pgAdminConnectionConfig(databaseName));
+      try {
+        await client.connect();
+        await client.query(
+          `DELETE FROM realm_user_permissions WHERE realm_url = $1`,
+          [realmURL.href],
+        );
+      } finally {
+        await client.end();
+      }
+    },
+  );
+}
+
 export async function resetRealmState(
   databaseName: string,
   realmURL: URL,

--- a/packages/software-factory/tests/factory-test-realm.spec.ts
+++ b/packages/software-factory/tests/factory-test-realm.spec.ts
@@ -10,10 +10,7 @@ import {
   executeTestRunFromRealm,
   type TestRunRealmOptions,
 } from '../scripts/lib/factory-test-realm';
-import {
-  pullRealmFiles,
-  writeModuleSource,
-} from '../scripts/lib/realm-operations';
+import { pullRealmFiles, writeFile } from '../scripts/lib/realm-operations';
 
 const fixtureRealmDir = resolve(
   process.cwd(),
@@ -60,7 +57,7 @@ test.describe('factory-test-realm e2e', () => {
     let authorization = authHeaders['Authorization'];
 
     // Write the spec to the realm via API — same path as the live system.
-    let writeResult = await writeModuleSource(
+    let writeResult = await writeFile(
       realmUrl,
       'Tests/hello-passing.spec.ts',
       PASSING_SPEC,
@@ -95,7 +92,7 @@ test.describe('factory-test-realm e2e', () => {
     let authorization = authHeaders['Authorization'];
 
     // Write the deliberately failing spec via API.
-    let writeResult = await writeModuleSource(
+    let writeResult = await writeFile(
       realmUrl,
       'Tests/hello-failing.spec.ts',
       FAILING_SPEC,
@@ -129,7 +126,7 @@ test.describe('factory-test-realm e2e', () => {
     let authorization = authHeaders['Authorization'];
 
     // Write a spec file to the realm via the API.
-    let writeResult = await writeModuleSource(
+    let writeResult = await writeFile(
       realmUrl,
       'Tests/hello-passing.spec.ts',
       PASSING_SPEC,

--- a/packages/software-factory/tests/factory-tool-builder.test.ts
+++ b/packages/software-factory/tests/factory-tool-builder.test.ts
@@ -189,7 +189,7 @@ module('factory-tool-builder > write_file', function () {
     assert.strictEqual(requests[0].body, 'export default class MyCard {}');
   });
 
-  test('routes .ts file to writeModuleSource', async function (assert) {
+  test('routes .ts file to writeFile', async function (assert) {
     let { fetch: mockFetch, requests } = createMockFetch(200, {});
     let registry = new ToolRegistry();
     let { executor } = createMockToolExecutor(new Map());
@@ -227,7 +227,7 @@ module('factory-tool-builder > write_file', function () {
     assert.true(result.ok);
     assert.strictEqual(requests[0].url, `${TARGET_REALM}Card/1.json`);
     assert.strictEqual(requests[0].method, 'POST');
-    // writeModuleSource sends raw content as-is
+    // writeFile sends raw content as-is
     assert.strictEqual(requests[0].body, cardJson);
   });
 });

--- a/packages/software-factory/tests/factory-tool-executor.integration.test.ts
+++ b/packages/software-factory/tests/factory-tool-executor.integration.test.ts
@@ -241,53 +241,6 @@ module('factory-tool-executor integration > realm-api requests', function () {
     }
   });
 
-  test('realm-atomic sends correct POST to _atomic with JSON:API operations', async function (assert) {
-    let captured: CapturedRequest | undefined;
-
-    let { server, origin } = await startTestServer((req, respond) => {
-      captured = req;
-      respond(200, { ok: true });
-    });
-
-    try {
-      let registry = new ToolRegistry();
-      let realmUrl = `${origin}/user/target/`;
-      let executor = new ToolExecutor(registry, {
-        packageRoot: '/fake',
-        targetRealmUrl: realmUrl,
-        testRealmUrl: `${origin}/user/target-tests/`,
-        authorization: 'Bearer realm-jwt-for-user',
-      });
-
-      let ops = [
-        { op: 'add', href: './CardDef/new.gts', data: { type: 'module' } },
-        { op: 'remove', href: './Card/old.json' },
-      ];
-
-      let result = await executor.execute('realm-atomic', {
-        'realm-url': realmUrl,
-        operations: JSON.stringify(ops),
-      });
-
-      assert.strictEqual(result.exitCode, 0);
-      assert.strictEqual(captured!.method, 'POST');
-      assert.strictEqual(captured!.url, '/user/target/_atomic');
-      assert.strictEqual(
-        captured!.headers['content-type'],
-        SupportedMimeType.JSONAPI,
-      );
-      assert.strictEqual(
-        captured!.headers.authorization,
-        'Bearer realm-jwt-for-user',
-      );
-
-      let body = JSON.parse(captured!.body);
-      assert.deepEqual(body['atomic:operations'], ops);
-    } finally {
-      await stopServer(server);
-    }
-  });
-
   test('realm-auth sends correct POST to _realm-auth with Authorization header', async function (assert) {
     let captured: CapturedRequest | undefined;
 

--- a/packages/software-factory/tests/factory-tool-executor.spec.ts
+++ b/packages/software-factory/tests/factory-tool-executor.spec.ts
@@ -168,7 +168,7 @@ test('realm-delete removes a card from the test realm', async ({ realm }) => {
           name: 'CardDef',
         },
         eq: {
-          'id': `${realm.realmURL.href}ToolExecutorTest/delete-test`,
+          id: `${realm.realmURL.href}ToolExecutorTest/delete-test`,
         },
       },
     }),
@@ -367,10 +367,13 @@ test.describe('realm-search on a private realm', () => {
       authorization: `Bearer ${unauthorizedToken}`,
     });
 
-    let unauthorizedResult = await unauthorizedExecutor.execute('realm-search', {
-      'realm-url': realm.realmURL.href,
-      query: searchQuery,
-    });
+    let unauthorizedResult = await unauthorizedExecutor.execute(
+      'realm-search',
+      {
+        'realm-url': realm.realmURL.href,
+        query: searchQuery,
+      },
+    );
 
     expect(
       unauthorizedResult.exitCode,

--- a/packages/software-factory/tests/factory-tool-executor.spec.ts
+++ b/packages/software-factory/tests/factory-tool-executor.spec.ts
@@ -16,6 +16,11 @@ import {
   ToolNotFoundError,
 } from '../scripts/lib/factory-tool-executor';
 import { ToolRegistry } from '../scripts/lib/factory-tool-registry';
+import {
+  readSupportMetadata,
+  registerMatrixUser,
+  getRealmToken,
+} from './helpers/matrix-auth';
 
 test('realm-read fetches .realm.json from the test realm', async ({
   realm,
@@ -66,6 +71,112 @@ test('realm-search returns results from the test realm', async ({ realm }) => {
   expect(Array.isArray(output.data)).toBe(true);
 });
 
+test('realm-write creates a card and realm-read retrieves it', async ({
+  realm,
+}) => {
+  let registry = new ToolRegistry();
+  let executor = new ToolExecutor(registry, {
+    packageRoot: process.cwd(),
+    targetRealmUrl: realm.realmURL.href,
+    testRealmUrl: realm.realmURL.href,
+    allowedRealmPrefixes: [realm.realmURL.origin + '/'],
+    authorization: `Bearer ${realm.ownerBearerToken}`,
+  });
+
+  let cardJson = JSON.stringify({
+    data: {
+      type: 'card',
+      attributes: {
+        title: 'Tool Executor Write Test',
+      },
+      meta: {
+        adoptsFrom: {
+          module: 'https://cardstack.com/base/card-api',
+          name: 'CardDef',
+        },
+      },
+    },
+  });
+
+  let writeResult = await executor.execute('realm-write', {
+    'realm-url': realm.realmURL.href,
+    path: 'ToolExecutorTest/write-test.json',
+    content: cardJson,
+  });
+
+  expect(writeResult.exitCode).toBe(0);
+
+  // Verify the written card can be read back
+  let readResult = await executor.execute('realm-read', {
+    'realm-url': realm.realmURL.href,
+    path: 'ToolExecutorTest/write-test.json',
+  });
+
+  expect(readResult.exitCode).toBe(0);
+  let output = readResult.output as {
+    data?: { attributes?: { title?: string } };
+  };
+  expect(output.data?.attributes?.title).toBe('Tool Executor Write Test');
+});
+
+test('realm-delete removes a card from the test realm', async ({ realm }) => {
+  let registry = new ToolRegistry();
+  let executor = new ToolExecutor(registry, {
+    packageRoot: process.cwd(),
+    targetRealmUrl: realm.realmURL.href,
+    testRealmUrl: realm.realmURL.href,
+    allowedRealmPrefixes: [realm.realmURL.origin + '/'],
+    authorization: `Bearer ${realm.ownerBearerToken}`,
+  });
+
+  // First, write a card to delete
+  let cardJson = JSON.stringify({
+    data: {
+      type: 'card',
+      attributes: {},
+      meta: {
+        adoptsFrom: {
+          module: 'https://cardstack.com/base/card-api',
+          name: 'CardDef',
+        },
+      },
+    },
+  });
+
+  let writeResult = await executor.execute('realm-write', {
+    'realm-url': realm.realmURL.href,
+    path: 'ToolExecutorTest/delete-test.json',
+    content: cardJson,
+  });
+  expect(writeResult.exitCode).toBe(0);
+
+  // Delete it
+  let deleteResult = await executor.execute('realm-delete', {
+    'realm-url': realm.realmURL.href,
+    path: 'ToolExecutorTest/delete-test.json',
+  });
+  expect(deleteResult.exitCode).toBe(0);
+
+  // Verify the deletion took effect — search should no longer find the card
+  let searchResult = await executor.execute('realm-search', {
+    'realm-url': realm.realmURL.href,
+    query: JSON.stringify({
+      filter: {
+        type: {
+          module: 'https://cardstack.com/base/card-api',
+          name: 'CardDef',
+        },
+        eq: {
+          'id': `${realm.realmURL.href}ToolExecutorTest/delete-test`,
+        },
+      },
+    }),
+  });
+  expect(searchResult.exitCode).toBe(0);
+  let searchOutput = searchResult.output as { data?: unknown[] };
+  expect(searchOutput.data?.length ?? 0).toBe(0);
+});
+
 test('unregistered tool is rejected without reaching the server', async ({
   realm,
 }) => {
@@ -80,4 +191,133 @@ test('unregistered tool is rejected without reaching the server', async ({
   await expect(
     executor.execute('shell-exec-arbitrary', { command: 'rm -rf /' }),
   ).rejects.toThrow(ToolNotFoundError);
+});
+
+// ---------------------------------------------------------------------------
+// realm-create: requires an isolated realm server (creates a new realm)
+// ---------------------------------------------------------------------------
+
+test.describe('realm-create against a live realm server', () => {
+  test.use({ realmServerMode: 'isolated' });
+  test.setTimeout(180_000);
+
+  test('realm-create creates a new realm on the server via tool executor', async ({
+    realm,
+  }) => {
+    let { matrixURL, matrixRegistrationSecret } = readSupportMetadata();
+
+    // Register a fresh Matrix user for this test
+    let username = `tool-create-${Date.now()}`;
+    let password = 'test-password';
+    await registerMatrixUser(
+      matrixURL,
+      matrixRegistrationSecret,
+      username,
+      password,
+    );
+
+    // Login to Matrix and obtain an OpenID token
+    let baseUrl = matrixURL.endsWith('/') ? matrixURL : `${matrixURL}/`;
+    let loginResponse = await fetch(`${baseUrl}_matrix/client/v3/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'm.login.password',
+        identifier: { type: 'm.id.user', user: username },
+        password,
+      }),
+    });
+    expect(loginResponse.ok).toBe(true);
+    let { access_token, user_id } = (await loginResponse.json()) as {
+      access_token: string;
+      user_id: string;
+    };
+
+    let openIdResponse = await fetch(
+      `${baseUrl}_matrix/client/v3/user/${encodeURIComponent(user_id)}/openid/request_token`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${access_token}`,
+        },
+        body: '{}',
+      },
+    );
+    expect(openIdResponse.ok).toBe(true);
+    let { access_token: openidToken } = (await openIdResponse.json()) as {
+      access_token: string;
+    };
+
+    let realmServerUrl = realm.realmServerURL.href;
+    let registry = new ToolRegistry();
+
+    // Step 1: Obtain a realm-server JWT via the tool executor
+    let sessionExecutor = new ToolExecutor(registry, {
+      packageRoot: process.cwd(),
+      targetRealmUrl: realm.realmURL.href,
+      testRealmUrl: realm.realmURL.href,
+      allowedRealmPrefixes: [realm.realmURL.origin + '/'],
+    });
+
+    let sessionResult = await sessionExecutor.execute('realm-server-session', {
+      'realm-server-url': realmServerUrl,
+      'openid-token': openidToken,
+    });
+
+    expect(
+      sessionResult.exitCode,
+      `realm-server-session failed: ${JSON.stringify(sessionResult.output)}`,
+    ).toBe(0);
+    let serverJwt = (sessionResult.output as { token: string }).token;
+    expect(serverJwt).toBeTruthy();
+
+    // Step 2: Create a new realm via the tool executor
+    let newEndpoint = `e2e-tool-test-${Date.now()}`;
+    let createExecutor = new ToolExecutor(registry, {
+      packageRoot: process.cwd(),
+      targetRealmUrl: realm.realmURL.href,
+      testRealmUrl: realm.realmURL.href,
+      allowedRealmPrefixes: [realm.realmURL.origin + '/'],
+      authorization: serverJwt,
+    });
+
+    let createResult = await createExecutor.execute('realm-create', {
+      'realm-server-url': realmServerUrl,
+      name: 'E2E Tool Executor Test',
+      endpoint: newEndpoint,
+    });
+
+    expect(
+      createResult.exitCode,
+      `realm-create failed: ${JSON.stringify(createResult.output)}`,
+    ).toBe(0);
+    let createOutput = createResult.output as { data?: { id?: string } };
+    expect(createOutput.data?.id).toBeTruthy();
+
+    // Step 3: Verify the realm was actually created by reading .realm.json
+    let newRealmUrl = createOutput.data!.id!;
+    let newRealmToken = await getRealmToken(
+      matrixURL,
+      username,
+      password,
+      newRealmUrl,
+    );
+
+    let verifyExecutor = new ToolExecutor(registry, {
+      packageRoot: process.cwd(),
+      targetRealmUrl: newRealmUrl,
+      testRealmUrl: realm.realmURL.href,
+      allowedRealmPrefixes: [realm.realmURL.origin + '/'],
+      authorization: newRealmToken,
+    });
+
+    let readResult = await verifyExecutor.execute('realm-read', {
+      'realm-url': newRealmUrl,
+      path: '.realm.json',
+    });
+
+    expect(readResult.exitCode).toBe(0);
+    expect(typeof readResult.output).toBe('object');
+  });
 });

--- a/packages/software-factory/tests/factory-tool-executor.spec.ts
+++ b/packages/software-factory/tests/factory-tool-executor.spec.ts
@@ -283,7 +283,7 @@ test.describe('realm-search with seeded fixture data', () => {
 test.describe('realm-search on a private realm', () => {
   test.use({ realmServerMode: 'isolated' });
   test.use({
-    permissions: {
+    realmPermissions: {
       [DEFAULT_REALM_OWNER]: ['read', 'write', 'realm-owner'],
       // No '*' key — unauthenticated reads are denied
     },

--- a/packages/software-factory/tests/factory-tool-executor.spec.ts
+++ b/packages/software-factory/tests/factory-tool-executor.spec.ts
@@ -151,31 +151,22 @@ test('realm-delete removes a card from the test realm', async ({ realm }) => {
   });
   expect(writeResult.exitCode).toBe(0);
 
-  // Delete it
+  // Delete via the tool executor
   let deleteResult = await executor.execute('realm-delete', {
     'realm-url': realm.realmURL.href,
     path: 'ToolExecutorTest/delete-test.json',
   });
   expect(deleteResult.exitCode).toBe(0);
 
-  // Verify the deletion took effect — search should no longer find the card
-  let searchResult = await executor.execute('realm-search', {
+  // Verify the deletion took effect — reading the deleted card should fail
+  let readResult = await executor.execute('realm-read', {
     'realm-url': realm.realmURL.href,
-    query: JSON.stringify({
-      filter: {
-        type: {
-          module: 'https://cardstack.com/base/card-api',
-          name: 'CardDef',
-        },
-        eq: {
-          id: `${realm.realmURL.href}ToolExecutorTest/delete-test`,
-        },
-      },
-    }),
+    path: 'ToolExecutorTest/delete-test.json',
   });
-  expect(searchResult.exitCode).toBe(0);
-  let searchOutput = searchResult.output as { data?: unknown[] };
-  expect(searchOutput.data?.length ?? 0).toBe(0);
+  expect(
+    readResult.exitCode,
+    `Expected realm-read to fail after delete, but got: ${JSON.stringify(readResult.output)}`,
+  ).toBe(1);
 });
 
 test('unregistered tool is rejected without reaching the server', async ({

--- a/packages/software-factory/tests/factory-tool-executor.spec.ts
+++ b/packages/software-factory/tests/factory-tool-executor.spec.ts
@@ -16,6 +16,7 @@ import {
   ToolNotFoundError,
 } from '../scripts/lib/factory-tool-executor';
 import { ToolRegistry } from '../scripts/lib/factory-tool-registry';
+import { DEFAULT_REALM_OWNER } from '../src/harness/shared';
 import {
   readSupportMetadata,
   registerMatrixUser,
@@ -191,6 +192,191 @@ test('unregistered tool is rejected without reaching the server', async ({
   await expect(
     executor.execute('shell-exec-arbitrary', { command: 'rm -rf /' }),
   ).rejects.toThrow(ToolNotFoundError);
+});
+
+// ---------------------------------------------------------------------------
+// realm-search with pre-seeded fixture data
+// The darkfactory-adopter fixture has Project and Ticket cards with
+// distinct types — we search for each and verify the filter works.
+// ---------------------------------------------------------------------------
+
+test.describe('realm-search with seeded fixture data', () => {
+  // Uses default darkfactory-adopter fixture (shared mode for speed)
+
+  test('search by type returns matching cards and excludes non-matching types', async ({
+    realm,
+  }) => {
+    // The darkfactory-adopter fixture type module uses a placeholder URL
+    // that gets remapped at runtime. Discover the live module URL by
+    // reading a known card and extracting its adoptsFrom module.
+    let registry = new ToolRegistry();
+    let executor = new ToolExecutor(registry, {
+      packageRoot: process.cwd(),
+      targetRealmUrl: realm.realmURL.href,
+      testRealmUrl: realm.realmURL.href,
+      allowedRealmPrefixes: [realm.realmURL.origin + '/'],
+      authorization: `Bearer ${realm.ownerBearerToken}`,
+    });
+
+    let projectRead = await executor.execute('realm-read', {
+      'realm-url': realm.realmURL.href,
+      path: 'project-demo.json',
+    });
+    expect(projectRead.exitCode).toBe(0);
+    let projectDoc = projectRead.output as {
+      data: { meta: { adoptsFrom: { module: string; name: string } } };
+    };
+    let darkfactoryModule = projectDoc.data.meta.adoptsFrom.module;
+
+    // Search for Project cards — should find at least project-demo
+    let projectResult = await executor.execute('realm-search', {
+      'realm-url': realm.realmURL.href,
+      query: JSON.stringify({
+        filter: {
+          type: { module: darkfactoryModule, name: 'Project' },
+        },
+      }),
+    });
+
+    expect(
+      projectResult.exitCode,
+      `project search failed: ${JSON.stringify(projectResult.output)}`,
+    ).toBe(0);
+    let projectOutput = projectResult.output as {
+      data?: { id: string }[];
+    };
+    expect(
+      (projectOutput.data?.length ?? 0) > 0,
+      'should find at least one Project card',
+    ).toBe(true);
+    let projectIds = (projectOutput.data ?? []).map((d) => d.id);
+
+    // Verify no Ticket cards leak into the Project results
+    let ticketResult = await executor.execute('realm-search', {
+      'realm-url': realm.realmURL.href,
+      query: JSON.stringify({
+        filter: {
+          type: { module: darkfactoryModule, name: 'Ticket' },
+        },
+      }),
+    });
+    expect(ticketResult.exitCode).toBe(0);
+    let ticketOutput = ticketResult.output as {
+      data?: { id: string }[];
+    };
+    let ticketIds = (ticketOutput.data ?? []).map((d) => d.id);
+
+    // Project and Ticket result sets must be disjoint
+    for (let ticketId of ticketIds) {
+      expect(
+        projectIds.includes(ticketId),
+        `Ticket ${ticketId} should not appear in Project results`,
+      ).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// realm-search on a private realm: verifies auth is enforced
+// ---------------------------------------------------------------------------
+
+test.describe('realm-search on a private realm', () => {
+  test.use({ realmServerMode: 'isolated' });
+  test.use({
+    permissions: {
+      [DEFAULT_REALM_OWNER]: ['read', 'write', 'realm-owner'],
+      // No '*' key — unauthenticated reads are denied
+    },
+  });
+
+  test('search with owner token succeeds, search without token fails', async ({
+    realm,
+  }) => {
+    let registry = new ToolRegistry();
+
+    // Discover the live module URL from the fixture data
+    let ownerExecutor = new ToolExecutor(registry, {
+      packageRoot: process.cwd(),
+      targetRealmUrl: realm.realmURL.href,
+      testRealmUrl: realm.realmURL.href,
+      allowedRealmPrefixes: [realm.realmURL.origin + '/'],
+      authorization: `Bearer ${realm.ownerBearerToken}`,
+    });
+
+    let projectRead = await ownerExecutor.execute('realm-read', {
+      'realm-url': realm.realmURL.href,
+      path: 'project-demo.json',
+    });
+    expect(
+      projectRead.exitCode,
+      `Failed to read project-demo: ${JSON.stringify(projectRead.output)}`,
+    ).toBe(0);
+    let projectDoc = projectRead.output as {
+      data: { meta: { adoptsFrom: { module: string; name: string } } };
+    };
+    let darkfactoryModule = projectDoc.data.meta.adoptsFrom.module;
+
+    let searchQuery = JSON.stringify({
+      filter: {
+        type: { module: darkfactoryModule, name: 'Project' },
+      },
+    });
+
+    // Authenticated search with owner token — should succeed
+    let authedResult = await ownerExecutor.execute('realm-search', {
+      'realm-url': realm.realmURL.href,
+      query: searchQuery,
+    });
+
+    expect(
+      authedResult.exitCode,
+      `authenticated search failed: ${JSON.stringify(authedResult.output)}`,
+    ).toBe(0);
+    let authedOutput = authedResult.output as { data?: unknown[] };
+    expect(
+      (authedOutput.data?.length ?? 0) > 0,
+      'authenticated search should return results',
+    ).toBe(true);
+
+    // Unauthenticated search — should fail (401 → exitCode 1)
+    let noAuthExecutor = new ToolExecutor(registry, {
+      packageRoot: process.cwd(),
+      targetRealmUrl: realm.realmURL.href,
+      testRealmUrl: realm.realmURL.href,
+      allowedRealmPrefixes: [realm.realmURL.origin + '/'],
+      // No authorization — simulates unauthenticated access
+    });
+
+    let noAuthResult = await noAuthExecutor.execute('realm-search', {
+      'realm-url': realm.realmURL.href,
+      query: searchQuery,
+    });
+
+    expect(
+      noAuthResult.exitCode,
+      'unauthenticated search on private realm should fail',
+    ).toBe(1);
+
+    // Search with a token for a different user who has no permissions — should fail
+    let unauthorizedToken = realm.createBearerToken('@stranger:localhost', []);
+    let unauthorizedExecutor = new ToolExecutor(registry, {
+      packageRoot: process.cwd(),
+      targetRealmUrl: realm.realmURL.href,
+      testRealmUrl: realm.realmURL.href,
+      allowedRealmPrefixes: [realm.realmURL.origin + '/'],
+      authorization: `Bearer ${unauthorizedToken}`,
+    });
+
+    let unauthorizedResult = await unauthorizedExecutor.execute('realm-search', {
+      'realm-url': realm.realmURL.href,
+      query: searchQuery,
+    });
+
+    expect(
+      unauthorizedResult.exitCode,
+      'unauthorized user search on private realm should fail',
+    ).toBe(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/software-factory/tests/factory-tool-executor.spec.ts
+++ b/packages/software-factory/tests/factory-tool-executor.spec.ts
@@ -338,7 +338,7 @@ test.describe('realm-search on a private realm', () => {
       'authenticated search should return results',
     ).toBe(true);
 
-    // Unauthenticated search — should fail (401 → exitCode 1)
+    // Unauthenticated search — should fail with 401
     let noAuthExecutor = new ToolExecutor(registry, {
       packageRoot: process.cwd(),
       targetRealmUrl: realm.realmURL.href,
@@ -352,12 +352,11 @@ test.describe('realm-search on a private realm', () => {
       query: searchQuery,
     });
 
-    expect(
-      noAuthResult.exitCode,
-      'unauthenticated search on private realm should fail',
-    ).toBe(1);
+    expect(noAuthResult.exitCode).toBe(1);
+    let noAuthOutput = noAuthResult.output as { status?: number };
+    expect(noAuthOutput.status).toBe(401);
 
-    // Search with a token for a different user who has no permissions — should fail
+    // Search with a token for a different user who has no permissions — should fail with 403
     let unauthorizedToken = realm.createBearerToken('@stranger:localhost', []);
     let unauthorizedExecutor = new ToolExecutor(registry, {
       packageRoot: process.cwd(),
@@ -375,10 +374,9 @@ test.describe('realm-search on a private realm', () => {
       },
     );
 
-    expect(
-      unauthorizedResult.exitCode,
-      'unauthorized user search on private realm should fail',
-    ).toBe(1);
+    expect(unauthorizedResult.exitCode).toBe(1);
+    let unauthorizedOutput = unauthorizedResult.output as { status?: number };
+    expect(unauthorizedOutput.status).toBe(403);
   });
 });
 

--- a/packages/software-factory/tests/factory-tool-executor.test.ts
+++ b/packages/software-factory/tests/factory-tool-executor.test.ts
@@ -371,35 +371,6 @@ module('factory-tool-executor > realm-api execution', function () {
     assert.strictEqual(result.exitCode, 0);
   });
 
-  test('realm-atomic makes POST to _atomic endpoint', async function (assert) {
-    let capturedUrl: string | undefined;
-    let capturedBody: string | undefined;
-
-    let registry = new ToolRegistry();
-    let config = makeConfig({
-      fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
-        capturedUrl = String(input);
-        capturedBody = typeof init?.body === 'string' ? init.body : undefined;
-        return new Response(JSON.stringify({ ok: true }), {
-          status: 200,
-          headers: { 'Content-Type': SupportedMimeType.JSON },
-        });
-      }) as typeof globalThis.fetch,
-    });
-    let executor = new ToolExecutor(registry, config);
-
-    let ops = [{ op: 'add', href: './Foo/bar.json', data: {} }];
-    let result = await executor.execute('realm-atomic', {
-      'realm-url': 'https://realms.example.test/user/target/',
-      operations: JSON.stringify(ops),
-    });
-
-    assert.true(capturedUrl!.endsWith('_atomic'));
-    let body = JSON.parse(capturedBody!);
-    assert.deepEqual(body['atomic:operations'], ops);
-    assert.strictEqual(result.exitCode, 0);
-  });
-
   test('non-ok response produces exitCode 1', async function (assert) {
     let registry = new ToolRegistry();
     let config = makeConfig({
@@ -875,25 +846,6 @@ module('factory-tool-executor > auth header propagation', function () {
     await executor.execute('realm-search', {
       'realm-url': 'https://realms.example.test/user/target/',
       query: '{}',
-    });
-
-    assert.strictEqual(
-      getCapturedHeaders()!.get('Authorization'),
-      'Bearer realm-jwt-abc',
-    );
-  });
-
-  test('realm-atomic sends realm JWT in Authorization header', async function (assert) {
-    let { fetch, getCapturedHeaders } = createHeaderCapturingFetch();
-    let registry = new ToolRegistry();
-    let executor = new ToolExecutor(
-      registry,
-      makeConfig({ authorization: 'Bearer realm-jwt-abc', fetch }),
-    );
-
-    await executor.execute('realm-atomic', {
-      'realm-url': 'https://realms.example.test/user/target/',
-      operations: '[]',
     });
 
     assert.strictEqual(

--- a/packages/software-factory/tests/factory-tool-registry.test.ts
+++ b/packages/software-factory/tests/factory-tool-registry.test.ts
@@ -284,7 +284,6 @@ module('factory-tool-registry > built-in manifests', function () {
     assert.true(registry.has('realm-read'));
     assert.true(registry.has('realm-write'));
     assert.true(registry.has('realm-delete'));
-    assert.true(registry.has('realm-atomic'));
     assert.true(registry.has('realm-search'));
     assert.true(registry.has('realm-create'));
     assert.true(registry.has('realm-server-session'));

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -7,11 +7,14 @@ import { join, resolve } from 'node:path';
 import type { Page } from '@playwright/test';
 import { test as base, expect } from '@playwright/test';
 
+import type { RealmPermissions } from '@cardstack/runtime-common/realm';
+
 import {
   defaultSupportMetadataFile,
   type PreparedTemplateMetadata,
   readSupportMetadata,
 } from '../src/runtime-metadata';
+import { buildRealmToken } from '../src/harness/shared';
 import { startHarnessPrerenderServer } from '../src/harness/support-services';
 import { buildBrowserState, installBrowserState } from './helpers/browser-auth';
 
@@ -26,7 +29,11 @@ type StartedFactoryRealm = {
     workerManagerPort: number;
   };
   cardURL(path: string): string;
-  authorizationHeaders(): Record<string, string>;
+  createBearerToken(user?: string, permissions?: string[]): string;
+  authorizationHeaders(
+    user?: string,
+    permissions?: string[],
+  ): Record<string, string>;
   stop(): Promise<void>;
 };
 
@@ -41,6 +48,7 @@ export type RealmServerMode = 'shared' | 'isolated';
 type FactoryRealmOptions = {
   realmDir: string;
   realmServerMode: RealmServerMode;
+  permissions: RealmPermissions | undefined;
 };
 
 type FactoryRealmWorkerFixtures = {
@@ -228,6 +236,7 @@ async function startRealmProcess(
   realmDir = defaultRealmDir,
   testWorkerPortSet: TestWorkerPortSet,
   testWorkerPrerenderURL: string,
+  permissions?: RealmPermissions,
 ) {
   let tempDir = mkdtempSync(join(tmpdir(), 'software-factory-realm-'));
   let metadataFile = join(tempDir, 'runtime.json');
@@ -289,16 +298,24 @@ async function startRealmProcess(
               SOFTWARE_FACTORY_CONTEXT: JSON.stringify(supportMetadata.context),
             }
           : {}),
-        ...(preparedTemplate
+        // When custom permissions are specified, skip the pre-cached template
+        // so startFactoryRealmServer calls ensureFactoryRealmTemplate with the
+        // custom permissions (the cache key includes permissions).
+        ...(preparedTemplate && !permissions
           ? {
               SOFTWARE_FACTORY_TEMPLATE_DATABASE_NAME:
                 preparedTemplate.templateDatabaseName,
             }
           : {}),
-        ...(preparedTemplate
+        ...(preparedTemplate && !permissions
           ? {
               SOFTWARE_FACTORY_TEMPLATE_REALM_SERVER_URL:
                 preparedTemplate.templateRealmServerURL,
+            }
+          : {}),
+        ...(permissions
+          ? {
+              SOFTWARE_FACTORY_PERMISSIONS: JSON.stringify(permissions),
             }
           : {}),
       },
@@ -382,9 +399,29 @@ async function startRealmProcess(
     cardURL(path: string) {
       return new URL(path, metadata.realmURL).href;
     },
-    authorizationHeaders() {
+    createBearerToken(user?: string, perms?: string[]) {
+      if (!user && !perms) {
+        return metadata.ownerBearerToken;
+      }
+      return buildRealmToken(
+        new URL(metadata.realmURL),
+        new URL(metadata.realmServerURL),
+        user,
+        perms,
+      );
+    },
+    authorizationHeaders(user?: string, perms?: string[]) {
+      let token =
+        !user && !perms
+          ? metadata.ownerBearerToken
+          : buildRealmToken(
+              new URL(metadata.realmURL),
+              new URL(metadata.realmServerURL),
+              user,
+              perms,
+            );
       return {
-        Authorization: `Bearer ${metadata.ownerBearerToken}`,
+        Authorization: `Bearer ${token}`,
       };
     },
     stop,
@@ -444,6 +481,7 @@ export const test = base.extend<
 >({
   realmDir: [defaultRealmDir, { option: true }],
   realmServerMode: ['shared', { option: true }],
+  permissions: [undefined as RealmPermissions | undefined, { option: true }],
   testWorkerPortSet: [
     async ({ browserName: _browserName }, use, workerInfo) => {
       // These services are ephemeral per test, but we intentionally keep their
@@ -480,13 +518,14 @@ export const test = base.extend<
       browserName: _browserName,
       realmDir,
       realmServerMode,
+      permissions,
       testWorkerPortSet,
       testWorkerPrerender,
     },
     use,
     testInfo,
   ) => {
-    if (realmServerMode === 'shared') {
+    if (realmServerMode === 'shared' && !permissions) {
       let key = sharedRealmKey(testInfo.workerIndex, testInfo.file, realmDir);
       let realm = await acquireSharedRealm(
         key,
@@ -506,6 +545,7 @@ export const test = base.extend<
       realmDir,
       testWorkerPortSet,
       testWorkerPrerender.url,
+      permissions,
     );
     try {
       await use(realm);

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -7,7 +7,7 @@ import { join, resolve } from 'node:path';
 import type { Page } from '@playwright/test';
 import { test as base, expect } from '@playwright/test';
 
-import type { RealmPermissions } from '@cardstack/runtime-common/realm';
+import type { RealmAction, RealmPermissions } from '@cardstack/runtime-common';
 
 import {
   defaultSupportMetadataFile,
@@ -29,10 +29,10 @@ type StartedFactoryRealm = {
     workerManagerPort: number;
   };
   cardURL(path: string): string;
-  createBearerToken(user?: string, permissions?: string[]): string;
+  createBearerToken(user?: string, permissions?: RealmAction[]): string;
   authorizationHeaders(
     user?: string,
-    permissions?: string[],
+    permissions?: RealmAction[],
   ): Record<string, string>;
   stop(): Promise<void>;
 };
@@ -48,7 +48,7 @@ export type RealmServerMode = 'shared' | 'isolated';
 type FactoryRealmOptions = {
   realmDir: string;
   realmServerMode: RealmServerMode;
-  permissions: RealmPermissions | undefined;
+  realmPermissions: RealmPermissions | undefined;
 };
 
 type FactoryRealmWorkerFixtures = {
@@ -399,7 +399,7 @@ async function startRealmProcess(
     cardURL(path: string) {
       return new URL(path, metadata.realmURL).href;
     },
-    createBearerToken(user?: string, perms?: string[]) {
+    createBearerToken(user?: string, perms?: RealmAction[]) {
       if (!user && !perms) {
         return metadata.ownerBearerToken;
       }
@@ -410,7 +410,7 @@ async function startRealmProcess(
         perms,
       );
     },
-    authorizationHeaders(user?: string, perms?: string[]) {
+    authorizationHeaders(user?: string, perms?: RealmAction[]) {
       let token =
         !user && !perms
           ? metadata.ownerBearerToken
@@ -481,7 +481,10 @@ export const test = base.extend<
 >({
   realmDir: [defaultRealmDir, { option: true }],
   realmServerMode: ['shared', { option: true }],
-  permissions: [undefined as RealmPermissions | undefined, { option: true }],
+  realmPermissions: [
+    undefined as RealmPermissions | undefined,
+    { option: true },
+  ],
   testWorkerPortSet: [
     async ({ browserName: _browserName }, use, workerInfo) => {
       // These services are ephemeral per test, but we intentionally keep their
@@ -518,7 +521,7 @@ export const test = base.extend<
       browserName: _browserName,
       realmDir,
       realmServerMode,
-      permissions,
+      realmPermissions: permissions,
       testWorkerPortSet,
       testWorkerPrerender,
     },

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -298,16 +298,13 @@ async function startRealmProcess(
               SOFTWARE_FACTORY_CONTEXT: JSON.stringify(supportMetadata.context),
             }
           : {}),
-        // When custom permissions are specified, skip the pre-cached template
-        // so startFactoryRealmServer calls ensureFactoryRealmTemplate with the
-        // custom permissions (the cache key includes permissions).
-        ...(preparedTemplate && !permissions
+        ...(preparedTemplate
           ? {
               SOFTWARE_FACTORY_TEMPLATE_DATABASE_NAME:
                 preparedTemplate.templateDatabaseName,
             }
           : {}),
-        ...(preparedTemplate && !permissions
+        ...(preparedTemplate
           ? {
               SOFTWARE_FACTORY_TEMPLATE_REALM_SERVER_URL:
                 preparedTemplate.templateRealmServerURL,

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -29,7 +29,7 @@ type StartedFactoryRealm = {
     workerManagerPort: number;
   };
   cardURL(path: string): string;
-  createBearerToken(user?: string, permissions?: RealmAction[]): string;
+  createBearerToken(user: string, permissions: RealmAction[]): string;
   authorizationHeaders(
     user?: string,
     permissions?: RealmAction[],
@@ -396,10 +396,7 @@ async function startRealmProcess(
     cardURL(path: string) {
       return new URL(path, metadata.realmURL).href;
     },
-    createBearerToken(user?: string, perms?: RealmAction[]) {
-      if (!user && !perms) {
-        return metadata.ownerBearerToken;
-      }
+    createBearerToken(user: string, perms: RealmAction[]) {
       return buildRealmToken(
         new URL(metadata.realmURL),
         new URL(metadata.realmServerURL),
@@ -408,17 +405,21 @@ async function startRealmProcess(
       );
     },
     authorizationHeaders(user?: string, perms?: RealmAction[]) {
-      let token =
-        !user && !perms
-          ? metadata.ownerBearerToken
-          : buildRealmToken(
-              new URL(metadata.realmURL),
-              new URL(metadata.realmServerURL),
-              user,
-              perms,
-            );
+      if (!user && !perms) {
+        return { Authorization: `Bearer ${metadata.ownerBearerToken}` };
+      }
+      if (!perms) {
+        throw new Error(
+          'authorizationHeaders: permissions must be provided when a user is specified',
+        );
+      }
       return {
-        Authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${buildRealmToken(
+          new URL(metadata.realmURL),
+          new URL(metadata.realmServerURL),
+          user,
+          perms,
+        )}`,
       };
     },
     stop,


### PR DESCRIPTION
## Summary

- **Add Playwright spec tests** that execute realm tool calls against a real realm server (not mocks):
  - `realm-write` — writes a card, reads it back to verify persistence
  - `realm-delete` — writes a card, deletes it, verifies via read it's gone
  - `realm-search` (seeded) — searches by Project type, verifies Ticket type results are disjoint
  - `realm-search` (private realm) — owner token succeeds, no token returns 401, unauthorized user returns 403
  - `realm-create` — registers Matrix user, obtains server JWT, creates realm, verifies `.realm.json`
- **Remove `realm-atomic` tool** from registry, executor, and all tests — the LLM should not make batch atomic updates via this API. this will eventually be facilitated via boxel-cli sync.
- **Add `permissions` fixture option** for configuring private/restricted test realms with custom `realm_user_permissions`
- **Expose `createBearerToken(user, perms)`** on `StartedFactoryRealm` for minting tokens with custom users/permissions in tests
- **Add `SOFTWARE_FACTORY_PERMISSIONS` env var** support in `serve-realm.ts`

## Test plan

- [x] All 8 Playwright spec tests pass (realm-read, realm-search, realm-write, realm-delete, unregistered tool, seeded search, private realm search, realm-create)
- [x] All 379 QUnit node-only unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)