### PR TITLE
Align skills with phase-1 tool-use model (CS-10569)

### DIFF
--- a/packages/software-factory/.agents/skills/boxel-repair/SKILL.md
+++ b/packages/software-factory/.agents/skills/boxel-repair/SKILL.md
@@ -3,6 +3,8 @@ name: boxel-repair
 description: Use when a Boxel workspace has broken realm metadata, missing icons or backgrounds, bad `index.json` or `cards-grid.json` links, or stale Matrix realm metadata that needs `boxel repair-realm` or `boxel repair-realms`.
 ---
 
+> **Factory agent note:** This skill is for human Claude Code sessions only. The factory agent's tool registry does not include boxel-cli tools — all realm I/O uses `write_file`, `read_file`, and `search_realm` tools via the realm HTTP API.
+
 # Boxel Repair
 
 Use this workflow when a workspace has any of these symptoms:

--- a/packages/software-factory/.agents/skills/boxel-restore/SKILL.md
+++ b/packages/software-factory/.agents/skills/boxel-restore/SKILL.md
@@ -3,6 +3,8 @@ name: boxel-restore
 description: Use when restoring a Boxel workspace to a previous checkpoint and syncing deletions back to the server safely, including stopping watch first and running `boxel sync . --prefer-local` after restore.
 ---
 
+> **Factory agent note:** This skill is for human Claude Code sessions only. The factory agent's tool registry does not include boxel-cli tools — all realm I/O uses `write_file`, `read_file`, and `search_realm` tools via the realm HTTP API.
+
 # Boxel Restore
 
 Restore workspace to a previous checkpoint and sync deletions to server.

--- a/packages/software-factory/.agents/skills/boxel-setup/SKILL.md
+++ b/packages/software-factory/.agents/skills/boxel-setup/SKILL.md
@@ -3,6 +3,8 @@ name: boxel-setup
 description: Use for Boxel CLI onboarding, profile setup, verifying login, listing workspaces, switching profiles, or helping a new user perform their first sync.
 ---
 
+> **Factory agent note:** This skill is for human Claude Code sessions only. The factory agent's tool registry does not include boxel-cli tools — all realm I/O uses `write_file`, `read_file`, and `search_realm` tools via the realm HTTP API.
+
 # Boxel Setup
 
 Guide new users through Boxel CLI setup.

--- a/packages/software-factory/.agents/skills/boxel-sync/SKILL.md
+++ b/packages/software-factory/.agents/skills/boxel-sync/SKILL.md
@@ -3,6 +3,8 @@ name: boxel-sync
 description: Use when deciding how to sync a Boxel workspace after local edits, server changes, or a restore, including choosing between interactive sync, `--prefer-local`, `--prefer-remote`, or `--prefer-newest`.
 ---
 
+> **Factory agent note:** This skill is for human Claude Code sessions only. The factory agent's tool registry does not include boxel-cli tools — all realm I/O uses `write_file`, `read_file`, and `search_realm` tools via the realm HTTP API.
+
 # Boxel Sync
 
 Smart bidirectional sync with context-aware conflict resolution.

--- a/packages/software-factory/.agents/skills/boxel-track/SKILL.md
+++ b/packages/software-factory/.agents/skills/boxel-track/SKILL.md
@@ -3,6 +3,8 @@ name: boxel-track
 description: Use when starting or explaining `boxel track` for local file watching, automatic checkpoints, or optional real-time push with `--push` during Boxel development.
 ---
 
+> **Factory agent note:** This skill is for human Claude Code sessions only. The factory agent's tool registry does not include boxel-cli tools — all realm I/O uses `write_file`, `read_file`, and `search_realm` tools via the realm HTTP API.
+
 # Boxel Track
 
 Start `boxel track` to monitor local file changes and create checkpoints automatically.

--- a/packages/software-factory/.agents/skills/boxel-watch/SKILL.md
+++ b/packages/software-factory/.agents/skills/boxel-watch/SKILL.md
@@ -3,6 +3,8 @@ name: boxel-watch
 description: Use when starting or choosing settings for `boxel watch` to monitor remote Boxel changes, including active-development, quick-feedback, and background-monitoring intervals.
 ---
 
+> **Factory agent note:** This skill is for human Claude Code sessions only. The factory agent's tool registry does not include boxel-cli tools — all realm I/O uses `write_file`, `read_file`, and `search_realm` tools via the realm HTTP API.
+
 # Boxel Watch
 
 Start `boxel watch` with intelligent interval settings based on context.

--- a/packages/software-factory/.agents/skills/software-factory-operations/SKILL.md
+++ b/packages/software-factory/.agents/skills/software-factory-operations/SKILL.md
@@ -1,62 +1,87 @@
 ---
 name: software-factory-operations
-description: Use when building or extending an application through the Boxel software-factory workflow in this repo, especially when the task should be broken into tickets, stored in Boxel, implemented in a target realm, verified with Playwright, and synced/checkpointed incrementally.
+description: Use when implementing cards in a target realm through the factory execution loop — covers the tool-use workflow for searching, writing, testing, and updating tickets via factory tools.
 ---
 
 # Software Factory Operations
 
-Use this skill when the objective is not just to write code, but to run the full Boxel software-factory loop successfully.
+Use this skill when operating inside the factory execution loop. The factory agent communicates with realms exclusively through **executable tool functions** — not local filesystem writes or boxel CLI commands.
 
-## Read First
+## Realm Roles
 
-- `AGENTS.md`
-- `.boxel-workspaces.json`
+- **Source realm** (`packages/software-factory/realm`)
+  Publishes shared modules, briefs, templates, and tracker schema. Never write to this realm.
+- **Target realm** (user-specified, passed to `factory:go`)
+  Receives all generated artifacts: Project, Ticket, KnowledgeArticle, card definitions, card instances, Catalog Spec cards, and Playwright test files.
+- **Test artifacts realm** (auto-created, e.g., `<target>-test-artifacts`)
+  Receives only card instances created during test execution. Each test run gets its own folder (`Run 1/`, `Run 2/`).
 
-## Realm Map
+## Available Tools
 
-- `./realms/guidance-tasks`
-  Shared tracker schema and demo cards. Import tracker modules from here.
-- `./realms/software-factory-demo`
-  Default implementation realm for the current demo and the place to build new artifacts.
+The agent has these tools during the execution loop. Use them by name — they are provided via the LLM's native tool-use protocol.
 
-Use `boxel realms --llm` whenever file placement is unclear.
+### Reading and Searching
 
-## Working Commands
+- `read_file(path, realm?)` — Read a file from target or test realm. Use before modifying anything.
+- `search_realm(query, realm?)` — Search for cards using a structured query object (filter, sort, page). Use to check for existing cards, find duplicates, inspect project state.
 
-- Search a realm:
-  `npm run boxel:search -- --realm <realm-url> --size 20`
-- Pick backlog tickets:
-  `npm run boxel:pick-ticket -- --realm <realm-url> --module http://localhost:4201/factory/guidance-tasks/darkfactory-schema`
-- Get browser auth payloads:
-  `npm run boxel:session -- --realm <realm-url>`
-- Run browser verification:
-  `npm run test:ticket-flow`
-- Run Boxel-hosted project tests:
-  `npm run test:realm -- --realm-path ./realms/<project-realm>`
-- Sync implementation realm:
-  `boxel sync ./realms/software-factory-demo --prefer-local`
-- Create manual checkpoints:
-  `boxel history ./realms/software-factory-demo -m "<message>"`
+### Writing Files
+
+- `write_file(path, content, realm?)` — Write a file to the target or test realm. Path must include extension (`.gts`, `.json`, `.spec.ts`). The `realm` arg defaults to `"target"`; use `"test"` for the test realm.
+
+### Updating Project State
+
+- `update_project(path, content)` — Update a Project card in the target realm (e.g., status, success criteria). Content must be valid card source JSON.
+- `update_ticket(path, content)` — Update a Ticket card in the target realm (e.g., status, notes, acceptance criteria). Content must be valid card source JSON.
+- `create_knowledge(path, content)` — Create or update a KnowledgeArticle card in the target realm. Content must be valid card source JSON.
+
+### Testing
+
+- `run_tests(slug, specPaths, testNames?, projectCardUrl?)` — Execute Playwright tests against the target realm. Pulls test spec files from the realm, runs them via the Playwright harness, returns structured results (pass/fail counts, failure details with error messages and stack traces).
+
+### Control Flow
+
+- `signal_done()` — Signal that the current ticket is complete. Call this only after all implementation and test files have been written.
+- `request_clarification(message)` — Signal that you cannot proceed and need human input. Describe what is blocking.
 
 ## Required Flow
 
-1. Search for backlog tickets in the target implementation realm.
-2. Move the chosen ticket to `in_progress` before implementation.
-3. Build the requested Boxel files in the implementation realm.
-4. Keep product-specific Playwright specs and fixture files in the implementation realm when they should persist with the project.
-5. Prefer fixture-driven verification through a fresh scratch realm created by `npm run test:realm`.
-6. Verify the resulting card URL with Playwright.
-7. Update ticket notes, acceptance criteria, and related knowledge.
-8. Sync to Boxel and create meaningful checkpoints.
-9. Commit repo-side tooling or instruction changes in git.
+1. **Inspect before writing.** Use `search_realm` and `read_file` to understand what already exists in the target realm before creating or modifying files.
+2. **Move ticket to `in_progress`.** Use `update_ticket` to set the ticket status before starting implementation.
+3. **Write card definitions** (`.gts`) via `write_file` to the target realm.
+4. **Write card instances** (`.json`) via `write_file` to the target realm.
+5. **Write a Catalog Spec card** (`Spec/<card-name>.json`) for each top-level card defined in the brief. Link sample instances via `linkedExamples`.
+6. **Write Playwright test files** (`Tests/<ticket-slug>.spec.ts`) via `write_file` to the target realm. Every ticket must have at least one test file.
+7. **Call `signal_done()`** when all implementation and test files are written. The orchestrator triggers test execution after this.
+8. **If tests fail**, the orchestrator feeds failure details back. Use `read_file` to inspect current state, then `write_file` to fix implementation or test files. Call `signal_done()` again.
+9. **Update ticket state** via `update_ticket` — update notes, acceptance criteria, and related knowledge as work progresses.
 
-## Important Gotchas
+## Target Realm Artifact Structure
 
-- For tracker searches, use the schema module URL:
-  `http://localhost:4201/factory/guidance-tasks/darkfactory-schema`
-- If a card in one private realm imports definitions from another private realm, seed browser auth for both realms.
-- Realm-hosted test fixtures should usually be stored as final realm-relative paths under `tests/fixtures/`.
-- Scratch realms should be checked out under the canonical Boxel workspace path layout, not ad hoc folders, so `boxel` commands do not keep reporting legacy workspace locations.
-- If a fixture card instance is meant to run in a scratch realm, use an absolute `adoptsFrom.module` URL whenever the backing definition lives in the source realm.
-- Boxel host pages keep long-lived network activity. In Playwright, do not wait for `networkidle`; use `domcontentloaded` plus visible assertions.
-- `guidance-tasks` is a shared schema realm, not the place to build product-specific implementation files.
+```
+target-realm/
+├── card-name.gts                    # Card definition
+├── CardName/
+│   └── sample-instance.json         # Card instance (also a test fixture)
+├── Spec/
+│   └── card-name.json               # Catalog Spec card
+├── Tests/
+│   └── ticket-slug.spec.ts          # Playwright test file
+├── Test Runs/
+│   └── ticket-slug-1.json           # TestRun card (written by orchestrator)
+├── Projects/
+│   └── project-name.json            # Project card
+├── Tickets/
+│   └── ticket-slug.json             # Ticket card
+└── Knowledge Articles/
+    └── article-name.json            # KnowledgeArticle card
+```
+
+## Important Rules
+
+- **Never write to the source realm.** All generated artifacts go to the target realm.
+- **Use realm HTTP APIs only.** The factory agent does not have access to the local filesystem or boxel CLI commands (`boxel sync`, `boxel push`, etc.). All reads and writes go through the realm API via tool functions.
+- **Write source code, not compiled output.** When writing `.gts` files, write clean idiomatic source — never compiled JSON blocks or base64-encoded content.
+- **Use absolute `adoptsFrom.module` URLs** when referencing definitions that live in a different realm (e.g., the source realm's tracker schema).
+- **Playwright tests must not use `networkidle`.** Boxel host pages have long-lived network activity. Use `domcontentloaded` plus visible element assertions instead.
+- **Start small and iterate.** Write the smallest working implementation first, then add the test. If tests fail, read the failure output carefully before making targeted fixes.

--- a/packages/software-factory/.agents/skills/software-factory-operations/SKILL.md
+++ b/packages/software-factory/.agents/skills/software-factory-operations/SKILL.md
@@ -22,27 +22,27 @@ The agent has these tools during the execution loop. Use them by name — they a
 
 ### Reading and Searching
 
-- `read_file(path, realm?)` — Read a file from target or test realm. Use before modifying anything.
-- `search_realm(query, realm?)` — Search for cards using a structured query object (filter, sort, page). Use to check for existing cards, find duplicates, inspect project state.
+- `read_file({ path, realm? })` — Read a file from target or test realm. Use before modifying anything.
+- `search_realm({ query, realm? })` — Search for cards using a structured query object (filter, sort, page). Use to check for existing cards, find duplicates, inspect project state.
 
 ### Writing Files
 
-- `write_file(path, content, realm?)` — Write a file to the target or test realm. Path must include extension (`.gts`, `.json`, `.spec.ts`). The `realm` arg defaults to `"target"`; use `"test"` for the test realm.
+- `write_file({ path, content, realm? })` — Write a file to the target or test realm. Path must include extension (`.gts`, `.json`, `.spec.ts`). The `realm` arg defaults to `"target"`; use `"test"` for the test realm.
 
 ### Updating Project State
 
-- `update_project(path, content)` — Update a Project card in the target realm (e.g., status, success criteria). Content must be valid card source JSON.
-- `update_ticket(path, content)` — Update a Ticket card in the target realm (e.g., status, notes, acceptance criteria). Content must be valid card source JSON.
-- `create_knowledge(path, content)` — Create or update a KnowledgeArticle card in the target realm. Content must be valid card source JSON.
+- `update_project({ path, content })` — Update a Project card in the target realm (e.g., status, success criteria). Content must be valid card source JSON.
+- `update_ticket({ path, content })` — Update a Ticket card in the target realm (e.g., status, notes, acceptance criteria). Content must be valid card source JSON.
+- `create_knowledge({ path, content })` — Create or update a KnowledgeArticle card in the target realm. Content must be valid card source JSON.
 
 ### Testing
 
-- `run_tests(slug, specPaths, testNames?, projectCardUrl?)` — Execute Playwright tests against the target realm. Pulls test spec files from the realm, runs them via the Playwright harness, returns structured results (pass/fail counts, failure details with error messages and stack traces).
+- `run_tests({ slug, specPaths, testNames?, projectCardUrl? })` — Execute Playwright tests against the target realm. Pulls test spec files from the realm, runs them via the Playwright harness, returns structured results (pass/fail counts, failure details with error messages and stack traces).
 
 ### Control Flow
 
 - `signal_done()` — Signal that the current ticket is complete. Call this only after all implementation and test files have been written.
-- `request_clarification(message)` — Signal that you cannot proceed and need human input. Describe what is blocking.
+- `request_clarification({ message })` — Signal that you cannot proceed and need human input. Describe what is blocking.
 
 ## Required Flow
 

--- a/packages/software-factory/docs/phase-2-plan.md
+++ b/packages/software-factory/docs/phase-2-plan.md
@@ -123,7 +123,9 @@ The `FactoryTool[]` type from phase 1 carries forward unchanged. `AgentRunResult
 
 ## Boxel-CLI Integration
 
-Phase 1 communicates with realms exclusively through HTTP API calls (`realm-operations.ts`) because boxel-cli lacked JWT auth support. Phase 2 integrates boxel-cli as a first-class monorepo package and uses it as the primary realm I/O layer, replacing the HTTP stopgap.
+Phase 1 uses HTTP API calls (`realm-operations.ts`) as the primary realm I/O path. Boxel-cli exists and has profile-based auth, but its auth model isn't flexible enough for the factory's needs — specifically, obtaining auth tokens for newly created realms on the fly. Boxel-cli also lives in a separate repository (`cardstack/boxel-cli`), making it difficult to evolve in lockstep with factory requirements.
+
+Phase 2 solves both problems: integrate boxel-cli into the monorepo as a first-class package, extend its auth model to handle dynamically created realms, and use it as the primary realm I/O layer.
 
 ### Why Boxel-CLI Changes Everything
 
@@ -139,38 +141,37 @@ When boxel-cli is available as a local tool, the agent gains a **synced local wo
 Boxel-cli currently lives in a separate repository (`cardstack/boxel-cli`). Phase 2 moves it into the Boxel monorepo as `packages/boxel-cli`:
 
 1. **Import the package** into `packages/boxel-cli` with its existing source, tests, and build configuration
-2. **Wire it into the monorepo** — add it to the pnpm workspace, ensure it builds alongside other packages
+2. **Wire it into the monorepo** — add it to the pnpm workspace, ensure it builds alongside other packages, integrate with CI (linting, type-checking, test suite)
 3. **Make it a dependency** of `packages/software-factory` so factory scripts can import CLI utilities directly (e.g., sync logic, auth helpers) rather than shelling out to `npx boxel`
 4. **Preserve the standalone CLI** — `npx boxel` and `npm install -g boxel-cli` must continue to work for human users
 
 Being in the monorepo means:
 
 - Changes to boxel-cli and the factory can land in the same PR
-- The factory's CI runs against the exact boxel-cli version it depends on
+- The factory's CI runs against the exact boxel-cli version it depends on — no version drift
+- Boxel-cli gets the same CI rigor as other packages: linting, type-checking, thorough test coverage
 - Shared types and utilities can be extracted to `runtime-common` instead of being duplicated
 
 ### Flexible Auth Support (CS-10529)
 
-Phase 1's boxel-cli lacks the auth flexibility the factory needs. The factory creates new realms on the fly and immediately needs to read/write to them — but boxel-cli's profile-based auth only knows about realms the user has manually configured.
+Boxel-cli already has profile-based auth — users log in via `boxel profile add`, and the CLI uses stored credentials to authenticate with realm servers. But the factory creates new realms on the fly and immediately needs to read/write to them. Profile-based auth only knows about realms the user has manually configured; it has no way to obtain tokens for a realm that was just created seconds ago.
 
-CS-10529 extends boxel-cli auth to support:
+CS-10529 extends boxel-cli's auth model to handle this:
 
-1. **`--jwt <token>` flag** on `boxel pull`, `boxel push`, `boxel sync`, and `boxel status` — allows passing a per-realm JWT directly instead of relying on profile-based auth. This is essential for factory-created realms that don't exist in any profile.
-2. **`--realm-server-jwt <token>` flag** on `boxel create` — allows creating realms with a server-level JWT obtained via `matrixLogin()` + `getRealmServerToken()`.
-3. **Programmatic auth API** — export auth helpers from boxel-cli so the factory can call `createAuthenticatedSync(realmUrl, jwt)` directly, without spawning a subprocess.
-4. **Token refresh callback** — allow callers to provide a function that refreshes expired JWTs, so long-running sync operations don't fail mid-stream.
+1. **Dynamic realm token acquisition** — When boxel-cli authenticates with a realm server (via the existing profile-based flow), it already has a realm server token. After creating a new realm, boxel-cli should automatically obtain and store the per-realm JWT for that realm in its auth state. This means `boxel create` followed by `boxel sync` on the new realm should Just Work — no manual token passing needed.
+2. **Realm server token awareness** — Since boxel-cli authenticates with a realm server as part of its profile flow, the realm server URL and token are already known. Commands like `boxel create` should use this existing auth context rather than requiring the realm server URL or token as explicit CLI arguments.
+3. **Programmatic auth API** — Export auth helpers from boxel-cli so the factory can call sync/push/pull programmatically with the CLI's auth context, without spawning a subprocess.
+4. **Token refresh callback** — Allow callers to provide a function that refreshes expired JWTs, so long-running sync operations don't fail mid-stream.
+
+The key insight is that realm creation and subsequent realm I/O should be a seamless flow within boxel-cli's existing auth model. The factory shouldn't need to manually juggle JWTs — boxel-cli's auth state should absorb newly created realms automatically.
 
 ### Realm Creation via Boxel-CLI
 
-Phase 1 creates realms by calling `POST /_create-realm` directly. Phase 2 moves this to boxel-cli:
+Phase 1 creates realms by calling `POST /_create-realm` directly. Phase 2 moves this into boxel-cli as a first-class command. The exact CLI arguments are still being worked through, but the principle is:
 
-```bash
-boxel create realm --name "Sticky Notes" --endpoint "user/sticky-notes" \
-  --realm-server-url http://localhost:4201/ \
-  --realm-server-jwt "$SERVER_JWT"
-```
-
-This means the agent can create realms using the same tool interface as all other CLI operations. The factory's `factory-target-realm.ts` becomes a thin wrapper that calls boxel-cli rather than making raw HTTP requests.
+- Boxel-cli already knows which realm server it's authenticated with (from the active profile). It should not require the realm server URL as a CLI argument.
+- After creating a realm, boxel-cli incorporates the new realm's auth token into its auth state so subsequent commands (`boxel sync`, `boxel pull`, etc.) work immediately.
+- The factory's `factory-target-realm.ts` becomes a thin wrapper that calls boxel-cli rather than making raw HTTP requests.
 
 ### Refactoring: Sync-First I/O Model
 
@@ -204,8 +205,7 @@ This means:
 Some operations are inherently server-side and cannot be replaced by local file I/O:
 
 - **`realm-search`** — structured queries against the realm index (type filters, field queries, sorting)
-- **`realm-create`** — creating new realms (until boxel-cli absorbs this)
-- **`realm-server-session`** / **`realm-auth`** — JWT management
+- **`realm-server-session`** / **`realm-auth`** — JWT management (may be absorbed into boxel-cli's auth layer)
 - **`pick-ticket`** — ticket queries that filter by status, priority, agent
 
 #### Tool Registry Changes
@@ -228,11 +228,11 @@ The 6 CLI skills excluded in phase 1 (`boxel-sync`, `boxel-track`, `boxel-watch`
 
 The refactor happens in stages to avoid a big-bang rewrite:
 
-1. **Stage 1: Monorepo import** — Move boxel-cli into `packages/boxel-cli`. All existing factory code continues to use HTTP-based realm operations unchanged.
-2. **Stage 2: Auth extension (CS-10529)** — Add `--jwt` flag support and programmatic auth API to boxel-cli. Factory tests verify that `boxel pull --jwt` and `boxel sync --jwt` work with factory-created realm tokens.
+1. **Stage 1: Monorepo import** — Move boxel-cli into `packages/boxel-cli`. Set up CI (linting, type-checking, tests). All existing factory code continues to use HTTP-based realm operations unchanged.
+2. **Stage 2: Auth extension (CS-10529)** — Extend boxel-cli auth to automatically acquire and store tokens for newly created realms. Add programmatic auth API. Factory tests verify that `boxel create` followed by `boxel sync` works seamlessly for factory-created realms.
 3. **Stage 3: Sync-based workspace** — Factory entrypoint syncs the target realm to a local workspace before starting the agent loop. Agent writes files locally. A post-iteration sync pushes changes to the realm.
 4. **Stage 4: Retire HTTP wrappers** — Remove `realm-operations.ts` stopgap functions (`writeModuleSource`, `readCardSource`, `writeCardSource`, `pullRealmFiles`). Replace with boxel-cli calls. Keep `searchRealm` for structured queries.
-5. **Stage 5: Re-enable CLI skills** — Remove the `CLI_ONLY_SKILLS` filter from the skill resolver. Update CLI skill content to reference the `--jwt` flag for factory-context auth.
+5. **Stage 5: Re-enable CLI skills** — Remove the `CLI_ONLY_SKILLS` filter from the skill resolver. Update CLI skill content for the factory agent context.
 
 ### Impact on `factory-tool-builder.ts`
 

--- a/packages/software-factory/docs/phase-2-plan.md
+++ b/packages/software-factory/docs/phase-2-plan.md
@@ -121,6 +121,137 @@ Phase 1 and phase 2 can coexist:
 
 The `FactoryTool[]` type from phase 1 carries forward unchanged. `AgentRunResult` may be simplified — in phase 2 the agent signals completion by updating the issue (tagging as blocked, marking done), so the orchestrator reads issue state rather than inspecting a return status. The agent just needs to exit; the orchestrator figures out what happened from the issue.
 
+## Boxel-CLI Integration
+
+Phase 1 communicates with realms exclusively through HTTP API calls (`realm-operations.ts`) because boxel-cli lacked JWT auth support. Phase 2 integrates boxel-cli as a first-class monorepo package and uses it as the primary realm I/O layer, replacing the HTTP stopgap.
+
+### Why Boxel-CLI Changes Everything
+
+When boxel-cli is available as a local tool, the agent gains a **synced local workspace** — a directory on the filesystem that mirrors a realm. This is a fundamental shift:
+
+- **The LLM already knows filesystem tools.** Every coding LLM is fluent with `cat`, `grep`, `ls`, `rm`, file writes, etc. By syncing a realm to a local directory, the agent can inspect and manipulate realm contents using the filesystem tools it's most proficient with — no custom `read_file` / `write_file` / `search_realm` wrapper tools needed for basic operations.
+- **Batch writes become trivial.** Write 10 files locally, then `boxel sync . --prefer-local` to push them all at once. No need for `realm-atomic` batching or per-file HTTP POST calls.
+- **Existing CLI skills become usable.** The 6 CLI skills (`boxel-sync`, `boxel-track`, `boxel-watch`, `boxel-restore`, `boxel-repair`, `boxel-setup`) that were excluded in phase 1 become available to the factory agent.
+- **Test file authoring is natural.** The agent writes `.spec.ts` files to a local directory, and Playwright runs them directly — no need to pull test files from a remote realm to a temp directory first.
+
+### Monorepo Integration (CS-10520)
+
+Boxel-cli currently lives in a separate repository (`cardstack/boxel-cli`). Phase 2 moves it into the Boxel monorepo as `packages/boxel-cli`:
+
+1. **Import the package** into `packages/boxel-cli` with its existing source, tests, and build configuration
+2. **Wire it into the monorepo** — add it to the pnpm workspace, ensure it builds alongside other packages
+3. **Make it a dependency** of `packages/software-factory` so factory scripts can import CLI utilities directly (e.g., sync logic, auth helpers) rather than shelling out to `npx boxel`
+4. **Preserve the standalone CLI** — `npx boxel` and `npm install -g boxel-cli` must continue to work for human users
+
+Being in the monorepo means:
+
+- Changes to boxel-cli and the factory can land in the same PR
+- The factory's CI runs against the exact boxel-cli version it depends on
+- Shared types and utilities can be extracted to `runtime-common` instead of being duplicated
+
+### Flexible Auth Support (CS-10529)
+
+Phase 1's boxel-cli lacks the auth flexibility the factory needs. The factory creates new realms on the fly and immediately needs to read/write to them — but boxel-cli's profile-based auth only knows about realms the user has manually configured.
+
+CS-10529 extends boxel-cli auth to support:
+
+1. **`--jwt <token>` flag** on `boxel pull`, `boxel push`, `boxel sync`, and `boxel status` — allows passing a per-realm JWT directly instead of relying on profile-based auth. This is essential for factory-created realms that don't exist in any profile.
+2. **`--realm-server-jwt <token>` flag** on `boxel create` — allows creating realms with a server-level JWT obtained via `matrixLogin()` + `getRealmServerToken()`.
+3. **Programmatic auth API** — export auth helpers from boxel-cli so the factory can call `createAuthenticatedSync(realmUrl, jwt)` directly, without spawning a subprocess.
+4. **Token refresh callback** — allow callers to provide a function that refreshes expired JWTs, so long-running sync operations don't fail mid-stream.
+
+### Realm Creation via Boxel-CLI
+
+Phase 1 creates realms by calling `POST /_create-realm` directly. Phase 2 moves this to boxel-cli:
+
+```bash
+boxel create realm --name "Sticky Notes" --endpoint "user/sticky-notes" \
+  --realm-server-url http://localhost:4201/ \
+  --realm-server-jwt "$SERVER_JWT"
+```
+
+This means the agent can create realms using the same tool interface as all other CLI operations. The factory's `factory-target-realm.ts` becomes a thin wrapper that calls boxel-cli rather than making raw HTTP requests.
+
+### Refactoring: Sync-First I/O Model
+
+With boxel-cli integration, the factory's I/O model shifts from **per-file HTTP calls** to **sync-based batch operations**:
+
+#### Phase 1 (HTTP-first)
+
+```
+Agent calls write_file({ path: "sticky-note.gts", content: "...", realm: "target" })
+  → orchestrator POSTs to realm HTTP API with card+source MIME type
+  → repeat for each file
+```
+
+#### Phase 2 (sync-first)
+
+```
+Agent writes files to local workspace directory using standard filesystem tools
+  → boxel sync . --prefer-local (pushes all changes to realm in one batch)
+  → or boxel track . --push (auto-pushes as files change)
+```
+
+This means:
+
+- **`write_file` and `read_file` wrapper tools are replaced** by the LLM's native filesystem tools. The agent writes to `./sticky-note.gts` directly.
+- **`search_realm` is replaced** by a combination of local `grep`/`find` for file-level searches and `boxel-search` (or the `search-realm` script tool) for structured card queries that require the realm index.
+- **`realm-read`, `realm-write`, `realm-delete`** remain available for operations that must happen immediately on the live realm (e.g., updating a ticket status that another process is watching), but they are no longer the primary I/O path.
+- **`realm-atomic`** remains for transactional multi-file operations where partial failure is unacceptable.
+
+#### What Stays as Realm API Tools
+
+Some operations are inherently server-side and cannot be replaced by local file I/O:
+
+- **`realm-search`** — structured queries against the realm index (type filters, field queries, sorting)
+- **`realm-create`** — creating new realms (until boxel-cli absorbs this)
+- **`realm-server-session`** / **`realm-auth`** — JWT management
+- **`pick-ticket`** — ticket queries that filter by status, priority, agent
+
+#### Tool Registry Changes
+
+The `ToolRegistry` in phase 2 includes all three categories:
+
+```typescript
+// Phase 1: only SCRIPT_TOOLS + REALM_API_TOOLS
+// Phase 2: all tools available
+let allManifests = [...SCRIPT_TOOLS, ...BOXEL_CLI_TOOLS, ...REALM_API_TOOLS];
+```
+
+`BOXEL_CLI_TOOLS` (`boxel-sync`, `boxel-push`, `boxel-pull`, `boxel-status`, `boxel-create`, `boxel-history`) become available to the agent. The factory-level wrapper tools (`write_file`, `read_file`, `search_realm`) can be retired or kept as convenience aliases that delegate to the filesystem + sync.
+
+#### Skill Re-enablement
+
+The 6 CLI skills excluded in phase 1 (`boxel-sync`, `boxel-track`, `boxel-watch`, `boxel-restore`, `boxel-repair`, `boxel-setup`) are re-enabled in the skill resolver. The `CLI_ONLY_SKILLS` exclusion list in `factory-skill-loader.ts` is removed, and the keyword-based CLI skill resolution logic is restored.
+
+### Migration Strategy
+
+The refactor happens in stages to avoid a big-bang rewrite:
+
+1. **Stage 1: Monorepo import** — Move boxel-cli into `packages/boxel-cli`. All existing factory code continues to use HTTP-based realm operations unchanged.
+2. **Stage 2: Auth extension (CS-10529)** — Add `--jwt` flag support and programmatic auth API to boxel-cli. Factory tests verify that `boxel pull --jwt` and `boxel sync --jwt` work with factory-created realm tokens.
+3. **Stage 3: Sync-based workspace** — Factory entrypoint syncs the target realm to a local workspace before starting the agent loop. Agent writes files locally. A post-iteration sync pushes changes to the realm.
+4. **Stage 4: Retire HTTP wrappers** — Remove `realm-operations.ts` stopgap functions (`writeModuleSource`, `readCardSource`, `writeCardSource`, `pullRealmFiles`). Replace with boxel-cli calls. Keep `searchRealm` for structured queries.
+5. **Stage 5: Re-enable CLI skills** — Remove the `CLI_ONLY_SKILLS` filter from the skill resolver. Update CLI skill content to reference the `--jwt` flag for factory-context auth.
+
+### Impact on `factory-tool-builder.ts`
+
+The factory-level tools evolve:
+
+| Phase 1 Tool            | Phase 2 Replacement                      | Notes                                                    |
+| ----------------------- | ---------------------------------------- | -------------------------------------------------------- |
+| `write_file`            | Filesystem write + `boxel sync`          | Agent writes to local workspace                          |
+| `read_file`             | Filesystem read (`cat`)                  | Agent reads from local workspace                         |
+| `search_realm`          | `grep`/`find` + `realm-search`           | Local search for files, realm API for structured queries |
+| `update_ticket`         | Filesystem write + `boxel sync`          | Or keep as realm-api tool for immediate server update    |
+| `update_project`        | Filesystem write + `boxel sync`          | Or keep as realm-api tool for immediate server update    |
+| `create_knowledge`      | Filesystem write + `boxel sync`          | Agent writes JSON to local workspace                     |
+| `run_tests`             | Playwright runs against local spec files | No need to pull from realm first                         |
+| `signal_done`           | Agent updates issue status directly      | Signals via issue state, not return type                 |
+| `request_clarification` | Agent tags issue as blocked              | Signals via issue state                                  |
+
+Tools like `update_ticket` and `update_project` may be kept as convenience tools that write directly to the realm API for status updates that need to be immediately visible — but the bulk of file I/O moves to the filesystem.
+
 ## Open Questions
 
 - **Issue creation during execution**: Can the agent create new issues mid-loop (e.g., "I found a bug, creating a fix issue")? This is powerful but needs guardrails to prevent issue explosion.
@@ -128,6 +259,8 @@ The `FactoryTool[]` type from phase 1 carries forward unchanged. `AgentRunResult
 - **Max iterations per issue**: Should this be a property on the issue, or a global default? Some issues (test execution) may need more retries than others.
 - **Issue type taxonomy**: What's the minimal set of issue types? Candidates: `implement`, `test-write`, `test-execute`, `bootstrap`, `knowledge`, `review`.
 - **Failure escalation**: When an issue fails after max retries, should it block dependents automatically, or should the agent decide?
+- **Workspace lifecycle**: When the factory creates a new target realm and syncs it locally, where does the local workspace live? Options: a temp directory (cleaned up on exit), a stable path under `.claude/worktrees/`, or a user-specified path.
+- **Concurrent realm writes**: If the agent writes files locally while `boxel track --push` is running, how do we prevent partial pushes? Options: write-then-sync (no track), edit locks, or batched sync after agent exits.
 
 ## Relationship to architecture.md
 
@@ -139,4 +272,6 @@ loop Until no unblocked issues left (or max iterations reached)
     ClaudeCodeCLI->>HostedBoxel: Work issue and update issue status when done
 ```
 
-Phase 2 implements exactly this. The "Factory" is the thin orchestrator/scheduler. "ClaudeCodeCLI" is the `LoopAgent`. "HostedBoxel" is the realm accessed via `FactoryTool[]`. The issue selection, dependency resolution, and status updates are the orchestrator's only responsibilities.
+Phase 2 implements exactly this. The "Factory" is the thin orchestrator/scheduler. "ClaudeCodeCLI" is the `LoopAgent`. "HostedBoxel" is the realm accessed via `FactoryTool[]` and local workspace sync. The issue selection, dependency resolution, and status updates are the orchestrator's only responsibilities.
+
+With boxel-cli integration, "HostedBoxel" is accessed through a synced local workspace rather than direct HTTP calls — the agent works on local files and boxel-cli handles the synchronization. This matches how human developers use Boxel: edit locally, sync to server.

--- a/packages/software-factory/docs/phase-2-plan.md
+++ b/packages/software-factory/docs/phase-2-plan.md
@@ -127,14 +127,14 @@ Phase 1 uses HTTP API calls (`realm-operations.ts`) as the primary realm I/O pat
 
 Phase 2 solves both problems: integrate boxel-cli into the monorepo as a first-class package, extend its auth model to handle dynamically created realms, and use it as the primary realm I/O layer.
 
-### Why Boxel-CLI Changes Everything
+### Benefits of a Synced Local Workspace
 
-When boxel-cli is available as a local tool, the agent gains a **synced local workspace** — a directory on the filesystem that mirrors a realm. This is a fundamental shift:
+With boxel-cli, the agent gets a local directory that mirrors a realm:
 
-- **The LLM already knows filesystem tools.** Every coding LLM is fluent with `cat`, `grep`, `ls`, `rm`, file writes, etc. By syncing a realm to a local directory, the agent can inspect and manipulate realm contents using the filesystem tools it's most proficient with — no custom `read_file` / `write_file` / `search_realm` wrapper tools needed for basic operations.
-- **Batch writes become trivial.** Write 10 files locally, then `boxel sync . --prefer-local` to push them all at once. No need for `realm-atomic` batching or per-file HTTP POST calls.
-- **Existing CLI skills become usable.** The 6 CLI skills (`boxel-sync`, `boxel-track`, `boxel-watch`, `boxel-restore`, `boxel-repair`, `boxel-setup`) that were excluded in phase 1 become available to the factory agent.
-- **Test file authoring is natural.** The agent writes `.spec.ts` files to a local directory, and Playwright runs them directly — no need to pull test files from a remote realm to a temp directory first.
+- **LLMs are already fluent with filesystem tools** — `cat`, `grep`, `ls`, `rm`, file writes. No custom `read_file` / `write_file` / `search_realm` wrappers needed for basic operations.
+- **Batch writes are trivial** — write files locally, then `boxel sync . --prefer-local` to push them all at once.
+- **CLI skills become usable** — the 6 CLI skills excluded in phase 1 become available to the factory agent.
+- **Test files run directly** — the agent writes `.spec.ts` files to a local directory and Playwright runs them without pulling from a remote realm first.
 
 ### Monorepo Integration (CS-10520)
 

--- a/packages/software-factory/scripts/lib/factory-skill-loader.ts
+++ b/packages/software-factory/scripts/lib/factory-skill-loader.ts
@@ -62,15 +62,20 @@ const FACTORY_WORKFLOW_KEYWORDS = [
   'orchestrat',
 ];
 
-/** Map from CLI keyword to the specific skill it triggers. */
-const CLI_KEYWORD_TO_SKILL: Record<string, string> = {
-  sync: 'boxel-sync',
-  track: 'boxel-track',
-  watch: 'boxel-watch',
-  restore: 'boxel-restore',
-  repair: 'boxel-repair',
-  setup: 'boxel-setup',
-};
+/**
+ * CLI skills that depend on boxel CLI commands. These are excluded from the
+ * factory agent's tool registry (boxel-cli tools are not available until
+ * CS-10520 lands). They remain valid for human Claude Code sessions but
+ * should not be resolved for the factory execution loop.
+ */
+const CLI_ONLY_SKILLS: readonly string[] = [
+  'boxel-sync',
+  'boxel-track',
+  'boxel-watch',
+  'boxel-restore',
+  'boxel-repair',
+  'boxel-setup',
+];
 
 /**
  * Reference files in `boxel-development/references/` and the keywords that
@@ -129,12 +134,16 @@ export class DefaultSkillResolver implements SkillResolver {
   /**
    * Determine which skills to load based on ticket and project context.
    *
-   * Resolution rules (from the plan):
+   * Resolution rules (from the phase-1 plan):
    * 1. boxel-development + boxel-file-structure — always loaded (common case)
    * 2. ember-best-practices — when ticket involves .gts component code
    * 3. software-factory-operations — for factory delivery workflow tickets
-   * 4. CLI skills — when ticket involves realm sync/workspace management
-   * 5. KnowledgeArticle tags can specify additional skills
+   * 4. KnowledgeArticle tags can specify additional skills
+   *
+   * CLI skills (boxel-sync, boxel-track, boxel-watch, boxel-restore,
+   * boxel-repair, boxel-setup) are excluded because the factory agent's
+   * tool registry does not include boxel-cli tools (deferred to CS-10520).
+   * These skills reference commands the agent cannot invoke.
    */
   resolve(ticket: TicketCard, project: ProjectCard): string[] {
     let ticketText = extractTicketText(ticket);
@@ -148,16 +157,6 @@ export class DefaultSkillResolver implements SkillResolver {
       skills.push('software-factory-operations');
     }
 
-    // Add specific CLI skills based on matched keywords
-    for (let [keyword, skillName] of Object.entries(CLI_KEYWORD_TO_SKILL)) {
-      if (
-        matchesAnyKeyword(ticketText, [keyword]) &&
-        !skills.includes(skillName)
-      ) {
-        skills.push(skillName);
-      }
-    }
-
     // Check for additional skills from knowledge articles on the project
     // and from related knowledge on the ticket itself.
     let additionalSkills = extractKnowledgeSkillTags(project, ticket);
@@ -167,7 +166,9 @@ export class DefaultSkillResolver implements SkillResolver {
       }
     }
 
-    return skills;
+    // Filter out CLI-only skills that reference boxel CLI commands the
+    // factory agent cannot invoke (tool registry excludes boxel-cli tools).
+    return skills.filter((s) => !CLI_ONLY_SKILLS.includes(s));
   }
 }
 

--- a/packages/software-factory/scripts/smoke-tests/factory-skill-smoke.ts
+++ b/packages/software-factory/scripts/smoke-tests/factory-skill-smoke.ts
@@ -47,7 +47,8 @@ const SAMPLE_TICKETS: { label: string; ticket: TicketCard }[] = [
     },
   },
   {
-    label: 'Realm sync work (triggers CLI skills)',
+    label:
+      'Realm sync work (CLI skills excluded — no boxel-cli tools in registry)',
     ticket: {
       id: 'Tickets/sync-work',
       title: 'Sync and restore workspace',

--- a/packages/software-factory/tests/factory-skill-loader.test.ts
+++ b/packages/software-factory/tests/factory-skill-loader.test.ts
@@ -168,7 +168,7 @@ module('factory-skill-loader > DefaultSkillResolver', function () {
     );
   });
 
-  test('includes boxel-sync when ticket involves sync', function (assert) {
+  test('excludes CLI-only skills even when ticket mentions sync', function (assert) {
     let resolver = new DefaultSkillResolver();
     let ticket = makeTicket({
       description: 'Sync the workspace after local edits',
@@ -177,43 +177,13 @@ module('factory-skill-loader > DefaultSkillResolver', function () {
 
     let skills = resolver.resolve(ticket, project);
 
-    assert.true(
-      skills.includes('boxel-sync'),
-      'includes boxel-sync for sync work',
-    );
-  });
-
-  test('does not trigger boxel-sync for "async" (word boundary)', function (assert) {
-    let resolver = new DefaultSkillResolver();
-    let ticket = makeTicket({
-      description: 'Fix async rendering in the card component',
-    });
-    let project = makeProject();
-
-    let skills = resolver.resolve(ticket, project);
-
     assert.false(
       skills.includes('boxel-sync'),
-      'does not include boxel-sync for "async"',
+      'boxel-sync excluded (CLI-only skill)',
     );
   });
 
-  test('does not trigger boxel-track for "stacktrace" (word boundary)', function (assert) {
-    let resolver = new DefaultSkillResolver();
-    let ticket = makeTicket({
-      description: 'Improve error stacktrace formatting',
-    });
-    let project = makeProject();
-
-    let skills = resolver.resolve(ticket, project);
-
-    assert.false(
-      skills.includes('boxel-track'),
-      'does not include boxel-track for "stacktrace"',
-    );
-  });
-
-  test('includes boxel-restore when ticket involves restore', function (assert) {
+  test('excludes CLI-only skills even when ticket mentions restore', function (assert) {
     let resolver = new DefaultSkillResolver();
     let ticket = makeTicket({
       description: 'Restore workspace to a previous checkpoint',
@@ -222,13 +192,13 @@ module('factory-skill-loader > DefaultSkillResolver', function () {
 
     let skills = resolver.resolve(ticket, project);
 
-    assert.true(
+    assert.false(
       skills.includes('boxel-restore'),
-      'includes boxel-restore for restore work',
+      'boxel-restore excluded (CLI-only skill)',
     );
   });
 
-  test('includes multiple CLI skills when ticket mentions several operations', function (assert) {
+  test('excludes all CLI-only skills even when ticket mentions multiple CLI operations', function (assert) {
     let resolver = new DefaultSkillResolver();
     let ticket = makeTicket({
       description: 'Sync the workspace, track changes, and watch for updates',
@@ -237,9 +207,33 @@ module('factory-skill-loader > DefaultSkillResolver', function () {
 
     let skills = resolver.resolve(ticket, project);
 
-    assert.true(skills.includes('boxel-sync'), 'includes boxel-sync');
-    assert.true(skills.includes('boxel-track'), 'includes boxel-track');
-    assert.true(skills.includes('boxel-watch'), 'includes boxel-watch');
+    assert.false(skills.includes('boxel-sync'), 'boxel-sync excluded');
+    assert.false(skills.includes('boxel-track'), 'boxel-track excluded');
+    assert.false(skills.includes('boxel-watch'), 'boxel-watch excluded');
+  });
+
+  test('excludes CLI-only skills even when added via knowledge article tags', function (assert) {
+    let resolver = new DefaultSkillResolver();
+    let ticket = makeTicket();
+    let project = makeProject({
+      knowledge: [
+        {
+          id: 'Knowledge Articles/cli-ref',
+          tags: ['skill:boxel-sync', 'skill:boxel-repair'],
+        },
+      ],
+    });
+
+    let skills = resolver.resolve(ticket, project);
+
+    assert.false(
+      skills.includes('boxel-sync'),
+      'boxel-sync excluded even from knowledge tags',
+    );
+    assert.false(
+      skills.includes('boxel-repair'),
+      'boxel-repair excluded even from knowledge tags',
+    );
   });
 
   test('extracts additional skills from knowledge article tags', function (assert) {
@@ -955,7 +949,7 @@ module('factory-skill-loader > re-resolution on new ticket', function () {
       description: 'Create a .gts component for the landing page',
     });
     let ticket2 = makeTicket({
-      description: 'Sync the workspace to staging',
+      description: 'Improve the factory delivery pipeline',
     });
 
     let skills1 = resolver.resolve(ticket1, project);
@@ -966,11 +960,14 @@ module('factory-skill-loader > re-resolution on new ticket', function () {
       'ticket1 gets ember-best-practices',
     );
     assert.false(
-      skills1.includes('boxel-sync'),
-      'ticket1 does not get boxel-sync',
+      skills1.includes('software-factory-operations'),
+      'ticket1 does not get software-factory-operations',
     );
 
-    assert.true(skills2.includes('boxel-sync'), 'ticket2 gets boxel-sync');
+    assert.true(
+      skills2.includes('software-factory-operations'),
+      'ticket2 gets software-factory-operations',
+    );
     assert.false(
       skills2.includes('ember-best-practices'),
       'ticket2 does not get ember-best-practices',


### PR DESCRIPTION
## Summary

- **Rewrote `software-factory-operations` skill** to reference actual factory tools (`write_file`, `read_file`, `search_realm`, `update_ticket`, `update_project`, `create_knowledge`, `run_tests`, `signal_done`, `request_clarification`) instead of old `npm run boxel:*` scripts and `boxel sync/history` CLI commands the agent can't invoke
- **Updated skill resolver** to filter out CLI-only skills (`boxel-sync`, `boxel-track`, `boxel-watch`, `boxel-restore`, `boxel-repair`, `boxel-setup`) from factory agent context — these depend on boxel-cli tools excluded from the agent's tool registry pending [CS-10520](https://linear.app/cardstack/issue/CS-10520) (boxel-cli auth integration)
- **Added guard notes** to all 6 CLI skills marking them as human Claude Code session only

## Context

The phase-1 plan specifies that boxel-cli tools are excluded from the agent's tool registry until CS-10520 lands. But 6 of 9 skills were instructing the agent to use `boxel sync`, `boxel track`, `boxel history`, etc. — commands it has no way to invoke. The `software-factory-operations` skill also referenced legacy `npm run boxel:search` scripts instead of the `search_realm` tool.

## Test plan

- [x] All 381 node tests pass (`pnpm test:node`)
- [x] Updated tests: CLI skills are now asserted as excluded (not included)
- [x] New test: CLI skills excluded even when added via knowledge article tags
- [x] ESLint clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)