### PR TITLE
Replace deprecated `inject as service` with `service` from @ember/service

### DIFF
--- a/packages/host/app/commands/ai-assistant.ts
+++ b/packages/host/app/commands/ai-assistant.ts
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import { isCardInstance } from '@cardstack/runtime-common';
 

--- a/packages/host/app/commands/lint-and-fix.ts
+++ b/packages/host/app/commands/lint-and-fix.ts
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import { SupportedMimeType } from '@cardstack/runtime-common';
 

--- a/packages/host/app/commands/open-workspace.ts
+++ b/packages/host/app/commands/open-workspace.ts
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 

--- a/packages/host/app/commands/patch-code.ts
+++ b/packages/host/app/commands/patch-code.ts
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import { hasExecutableExtension } from '@cardstack/runtime-common';
 

--- a/packages/host/app/components/matrix/room-message-command.gts
+++ b/packages/host/app/components/matrix/room-message-command.gts
@@ -1,5 +1,5 @@
 import { array, hash } from '@ember/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 import { cached } from '@glimmer/tracking';

--- a/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
+++ b/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
@@ -1,6 +1,6 @@
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 import FileCheck from '@cardstack/boxel-icons/file-check';

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -1,7 +1,7 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { concat, fn } from '@ember/helper';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import { buildWaiter } from '@ember/test-waiters';
 import { isTesting } from '@embroider/macros';

--- a/packages/host/app/components/operator-mode/profile-info-popover.gts
+++ b/packages/host/app/components/operator-mode/profile-info-popover.gts
@@ -1,7 +1,7 @@
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 import { Avatar, BoxelButton } from '@cardstack/boxel-ui/components';

--- a/packages/host/app/components/operator-mode/profile/profile-email.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-email.gts
@@ -2,7 +2,7 @@ import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import type Owner from '@ember/owner';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/packages/host/app/components/operator-mode/profile/profile-settings-modal.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-settings-modal.gts
@@ -1,7 +1,7 @@
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import type Owner from '@ember/owner';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -2,7 +2,7 @@ import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/packages/host/app/components/operator-mode/workspace-chooser/index.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/index.gts
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/packages/host/app/deprecation-workflow.js
+++ b/packages/host/app/deprecation-workflow.js
@@ -4,10 +4,6 @@ setupDeprecationWorkflow({
   workflow: [
     {
       handler: 'silence',
-      matchId: 'importing-inject-from-ember-service',
-    },
-    {
-      handler: 'silence',
       matchId: 'deprecate-import--set-classic-decorator-from-ember',
     },
     {

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -1,6 +1,6 @@
 import type Owner from '@ember/owner';
 import { setOwner } from '@ember/owner';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import { md5 } from 'super-fast-md5';
 

--- a/packages/host/app/lib/matrix-classes/message-builder.ts
+++ b/packages/host/app/lib/matrix-classes/message-builder.ts
@@ -2,7 +2,7 @@ import type Owner from '@ember/owner';
 
 import { getOwner, setOwner } from '@ember/owner';
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import { TrackedArray } from 'tracked-built-ins';
 

--- a/packages/host/app/lib/matrix-classes/message-code-patch-result.ts
+++ b/packages/host/app/lib/matrix-classes/message-code-patch-result.ts
@@ -1,6 +1,6 @@
 import { setOwner } from '@ember/owner';
 import type Owner from '@ember/owner';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import { tracked } from '@glimmer/tracking';
 

--- a/packages/host/app/lib/matrix-classes/message-command.ts
+++ b/packages/host/app/lib/matrix-classes/message-command.ts
@@ -1,6 +1,6 @@
 import { setOwner } from '@ember/owner';
 import type Owner from '@ember/owner';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import { tracked } from '@glimmer/tracking';
 

--- a/packages/host/app/modifiers/restore-scroll-position.ts
+++ b/packages/host/app/modifiers/restore-scroll-position.ts
@@ -2,7 +2,7 @@ import { registerDestructor, isDestroying } from '@ember/destroyable';
 import type Owner from '@ember/owner';
 import { cancel, debounce } from '@ember/runloop';
 import type { Timer } from '@ember/runloop';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import Modifier from 'ember-modifier';
 

--- a/packages/host/app/modifiers/scroll-into-view.ts
+++ b/packages/host/app/modifiers/scroll-into-view.ts
@@ -1,6 +1,6 @@
 import { registerDestructor } from '@ember/destroyable';
 import type Owner from '@ember/owner';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import Modifier from 'ember-modifier';
 

--- a/packages/host/app/services/code-semantics-service.ts
+++ b/packages/host/app/services/code-semantics-service.ts
@@ -1,6 +1,6 @@
 import type Owner from '@ember/owner';
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import type { ResolvedCodeRef, CodeRef } from '@cardstack/runtime-common';
 import {

--- a/packages/host/app/templates/index.gts
+++ b/packages/host/app/templates/index.gts
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import { getOwner } from '@ember/owner';
 import type RouterService from '@ember/routing/router-service';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { isDevelopingApp } from '@embroider/macros';
 import Component from '@glimmer/component';
 

--- a/packages/host/app/templates/render/html.gts
+++ b/packages/host/app/templates/render/html.gts
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 import { provide } from 'ember-provide-consume-context';


### PR DESCRIPTION
## Summary
- Replaces `import { inject as service } from '@ember/service'` with `import { service } from '@ember/service'` across 21 files in `packages/host/app/`
- Removes the `importing-inject-from-ember-service` silence entry from the deprecation workflow

The `inject` export was deprecated in ember-source 6.2 ([deprecation id: importing-inject-from-ember-service](https://deprecations.emberjs.com/id/importing-inject-from-ember-service)) and will be removed in 7.0.

## Test plan
- [ ] Host app builds without errors
- [ ] Host app tests pass
- [ ] No `importing-inject-from-ember-service` deprecation warnings in test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)