### PR TITLE
Limit tag and category auto-link to single selection, enrich candidates with summaries

### DIFF
--- a/packages/catalog-realm/Tag/140feda8-625b-4a24-9ddb-6f4da891aef2.json
+++ b/packages/catalog-realm/Tag/140feda8-625b-4a24-9ddb-6f4da891aef2.json
@@ -3,13 +3,25 @@
     "type": "card",
     "attributes": {
       "name": "Bundled",
-      "cardDescription": null,
-      "cardThumbnailURL": null
+      "color": "#0069f9",
+      "cardInfo": {
+        "notes": null,
+        "name": null,
+        "summary": "Cards or apps that are packaged together as a curated set, combining multiple related components into a single installable bundle.",
+        "cardThumbnailURL": null
+      }
     },
     "meta": {
       "adoptsFrom": {
         "module": "../catalog-app/listing/tag",
         "name": "Tag"
+      }
+    },
+    "relationships": {
+      "cardInfo.theme": {
+        "links": {
+          "self": null
+        }
       }
     }
   }

--- a/packages/catalog-realm/Tag/4d0f9ae2-048e-4ce0-b263-7006602ce6a4.json
+++ b/packages/catalog-realm/Tag/4d0f9ae2-048e-4ce0-b263-7006602ce6a4.json
@@ -3,14 +3,25 @@
     "type": "card",
     "attributes": {
       "name": "User Contributed",
-      "color": null,
-      "cardDescription": null,
-      "cardThumbnailURL": null
+      "color": "#c3fc33",
+      "cardInfo": {
+        "notes": null,
+        "name": null,
+        "summary": "Content created and submitted by community members rather than the official Cardstack team. Quality and support may vary.",
+        "cardThumbnailURL": null
+      }
     },
     "meta": {
       "adoptsFrom": {
         "module": "../catalog-app/listing/tag",
         "name": "Tag"
+      }
+    },
+    "relationships": {
+      "cardInfo.theme": {
+        "links": {
+          "self": null
+        }
       }
     }
   }

--- a/packages/catalog-realm/Tag/51de249c-516a-4c4d-bd88-76e88274c483.json
+++ b/packages/catalog-realm/Tag/51de249c-516a-4c4d-bd88-76e88274c483.json
@@ -3,14 +3,25 @@
     "type": "card",
     "attributes": {
       "name": "Game",
-      "color": "#1EDF67",
-      "cardDescription": null,
-      "cardThumbnailURL": null
+      "color": "#37eb77",
+      "cardInfo": {
+        "notes": null,
+        "name": null,
+        "summary": "Cards and apps for gaming, game tracking, scoreboards, turn management, or any interactive game-related experience.",
+        "cardThumbnailURL": null
+      }
     },
     "meta": {
       "adoptsFrom": {
         "module": "../catalog-app/listing/tag",
         "name": "Tag"
+      }
+    },
+    "relationships": {
+      "cardInfo.theme": {
+        "links": {
+          "self": null
+        }
       }
     }
   }

--- a/packages/catalog-realm/Tag/631d1b5d-fcd0-465c-964e-e535fc6bb893.json
+++ b/packages/catalog-realm/Tag/631d1b5d-fcd0-465c-964e-e535fc6bb893.json
@@ -3,13 +3,25 @@
     "type": "card",
     "attributes": {
       "name": "Ai",
-      "cardDescription": null,
-      "cardThumbnailURL": null
+      "color": "#6638ff",
+      "cardInfo": {
+        "notes": null,
+        "name": null,
+        "summary": "Cards and apps that use artificial intelligence or machine learning, including LLM-powered features, smart automation, and AI-assisted workflows.",
+        "cardThumbnailURL": null
+      }
     },
     "meta": {
       "adoptsFrom": {
         "module": "../catalog-app/listing/tag",
         "name": "Tag"
+      }
+    },
+    "relationships": {
+      "cardInfo.theme": {
+        "links": {
+          "self": null
+        }
       }
     }
   }

--- a/packages/catalog-realm/Tag/b793225c-32f9-404c-b2a9-b4041b93090c.json
+++ b/packages/catalog-realm/Tag/b793225c-32f9-404c-b2a9-b4041b93090c.json
@@ -9,11 +9,11 @@
     "type": "card",
     "attributes": {
       "name": "Theme",
-      "color": null,
+      "color": "#ff009d",
       "cardInfo": {
         "notes": null,
         "name": null,
-        "summary": null,
+        "summary": "Visual themes and styling cards that customize the appearance and color scheme of the Boxel workspace or other cards.",
         "cardThumbnailURL": null
       }
     },

--- a/packages/catalog-realm/Tag/c1fe433a-b3df-41f4-bdcf-d98686ee42d7.json
+++ b/packages/catalog-realm/Tag/c1fe433a-b3df-41f4-bdcf-d98686ee42d7.json
@@ -3,14 +3,25 @@
     "type": "card",
     "attributes": {
       "name": "Calculator",
-      "color": null,
-      "cardDescription": null,
-      "cardThumbnailURL": null
+      "color": "#00ebe5",
+      "cardInfo": {
+        "notes": null,
+        "name": null,
+        "summary": "Cards that perform numerical computations, financial calculations, unit conversions, or any form of formula-driven data processing.",
+        "cardThumbnailURL": null
+      }
     },
     "meta": {
       "adoptsFrom": {
         "module": "../catalog-app/listing/tag",
         "name": "Tag"
+      }
+    },
+    "relationships": {
+      "cardInfo.theme": {
+        "links": {
+          "self": null
+        }
       }
     }
   }

--- a/packages/catalog-realm/Tag/ed5a1a3f-0dbf-47b5-b2a6-d88b0d2a7642.json
+++ b/packages/catalog-realm/Tag/ed5a1a3f-0dbf-47b5-b2a6-d88b0d2a7642.json
@@ -3,13 +3,25 @@
     "type": "card",
     "attributes": {
       "name": "Official",
-      "cardDescription": null,
-      "cardThumbnailURL": null
+      "color": "#00ebac",
+      "cardInfo": {
+        "notes": null,
+        "name": null,
+        "summary": "Cards and apps officially created and maintained by the Cardstack team. Guaranteed quality, ongoing support, and compatibility with the latest platform updates.",
+        "cardThumbnailURL": null
+      }
     },
     "meta": {
       "adoptsFrom": {
         "module": "../catalog-app/listing/tag",
         "name": "Tag"
+      }
+    },
+    "relationships": {
+      "cardInfo.theme": {
+        "links": {
+          "self": null
+        }
       }
     }
   }

--- a/packages/catalog-realm/Tag/f21d95da-0728-46a8-8622-6c157716c26c.json
+++ b/packages/catalog-realm/Tag/f21d95da-0728-46a8-8622-6c157716c26c.json
@@ -9,11 +9,11 @@
     "type": "card",
     "attributes": {
       "name": "Poster",
-      "color": null,
+      "color": "#ff7f00",
       "cardInfo": {
         "notes": null,
         "name": "",
-        "summary": null,
+        "summary": "Cards designed for creating posters, flyers, promotional visuals, or any print-ready or display-ready graphical layouts.",
         "cardThumbnailURL": null
       }
     },

--- a/packages/host/app/commands/listing-create.ts
+++ b/packages/host/app/commands/listing-create.ts
@@ -508,7 +508,6 @@ export default class ListingCreateCommand extends HostBaseCommand<
         sourceContextCodeRef: codeRef,
       },
       {
-        max: 2,
         additionalSystemPrompt:
           "Choose tags that best describe the card's nature or usage pattern." +
           ' RULE: Never select or return any id that contains the substring "stub" (case-insensitive). If all contain stub return [].',
@@ -530,7 +529,6 @@ export default class ListingCreateCommand extends HostBaseCommand<
         sourceContextCodeRef: codeRef,
       },
       {
-        max: 2,
         additionalSystemPrompt:
           "Choose categories that best match the card's domain or purpose.",
       },

--- a/packages/host/app/commands/listing-create.ts
+++ b/packages/host/app/commands/listing-create.ts
@@ -337,7 +337,7 @@ export default class ListingCreateCommand extends HostBaseCommand<
     const name = await this.getStringPatch({
       codeRef,
       systemPrompt:
-        'You are an expert catalog curator. You read a Cardstack card/field definition source file and create a concise catalog listing title. Respond ONLY with the title text—no quotes, no JSON, no markdown, and no extra commentary.',
+        'You are a concise and accurate summarization system. You read a Cardstack card/field definition source file and create a concise catalog listing title. Respond ONLY with the title text—no quotes, no JSON, no markdown, and no extra commentary.',
       userPrompt: [
         `Generate a catalog listing title for the definition referenced by:`,
         `- module: ${codeRef.module}`,
@@ -358,7 +358,7 @@ export default class ListingCreateCommand extends HostBaseCommand<
     const summary = await this.getStringPatch({
       codeRef,
       systemPrompt:
-        'You are an expert catalog curator. You read a Cardstack card/field definition source file and write a concise spec-style summary. Output ONLY the summary text—no quotes, no JSON, no markdown, and no extra commentary.',
+        'You are a concise and accurate summarization system. You read a Cardstack card/field definition source file and write a concise spec-style summary. Output ONLY the summary text—no quotes, no JSON, no markdown, and no extra commentary.',
       userPrompt: [
         `Generate a README-style catalog listing summary for the definition referenced by:`,
         `- module: ${codeRef.module}`,
@@ -483,14 +483,12 @@ export default class ListingCreateCommand extends HostBaseCommand<
   }
 
   private async autoLinkLicense(listing: CardAPI.CardDef) {
-    const selected = await this.chooseCards(
-      {
-        candidateTypeCodeRef: {
-          module: `${this.catalogRealm}catalog-app/listing/license`,
-          name: 'License',
-        } as ResolvedCodeRef,
-      }
-    );
+    const selected = await this.chooseCards({
+      candidateTypeCodeRef: {
+        module: `${this.catalogRealm}catalog-app/listing/license`,
+        name: 'License',
+      } as ResolvedCodeRef,
+    });
     (listing as any).license = selected[0];
   }
 
@@ -507,9 +505,13 @@ export default class ListingCreateCommand extends HostBaseCommand<
         sourceContextCodeRef: codeRef,
       },
       {
+        max: 1,
         additionalSystemPrompt:
-          "Choose tags that best describe the card's nature or usage pattern." +
-          ' RULE: Never select or return any id that contains the substring "stub" (case-insensitive). If all contain stub return [].',
+          'You are selecting from an existing list of catalog tags. ' +
+          "Choose the single best tag that describes the card's subject matter, use case, or domain. " +
+          'Prefer a specific descriptive tag over a broad organizational bucket. ' +
+          'Only select ids from the provided options. ' +
+          'Return [] if no tag clearly fits.',
       },
     );
     (listing as any).tags = selected;
@@ -528,8 +530,13 @@ export default class ListingCreateCommand extends HostBaseCommand<
         sourceContextCodeRef: codeRef,
       },
       {
+        max: 1,
         additionalSystemPrompt:
-          "Choose categories that best match the card's domain or purpose.",
+          'You are selecting from an existing list of catalog categories. ' +
+          "Choose the single best high-level category that matches the card's main purpose. " +
+          'Prefer broad organizing categories over keyword-style tags. ' +
+          'Only select ids from the provided options. ' +
+          'Return [] if no category clearly fits.',
       },
     );
     (listing as any).categories = selected;

--- a/packages/host/app/commands/listing-create.ts
+++ b/packages/host/app/commands/listing-create.ts
@@ -324,7 +324,7 @@ export default class ListingCreateCommand extends HostBaseCommand<
     const result = await command.execute({
       candidateTypeCodeRef: params.candidateTypeCodeRef,
       sourceContextCodeRef: params.sourceContextCodeRef,
-      max: opts?.max ?? 2,
+      max: opts?.max,
       additionalSystemPrompt: opts?.additionalSystemPrompt,
     });
     return result.selectedCards ?? [];
@@ -489,8 +489,7 @@ export default class ListingCreateCommand extends HostBaseCommand<
           module: `${this.catalogRealm}catalog-app/listing/license`,
           name: 'License',
         } as ResolvedCodeRef,
-      },
-      { max: 1 },
+      }
     );
     (listing as any).license = selected[0];
   }

--- a/packages/host/app/commands/search-and-choose.ts
+++ b/packages/host/app/commands/search-and-choose.ts
@@ -34,7 +34,7 @@ export default class SearchAndChooseCommand extends HostBaseCommand<
   ): Promise<BaseCommandModule.SearchAndChooseResult> {
     let {
       sourceContextCodeRef,
-      max = 2,
+      max = 1,
       additionalSystemPrompt,
       llmModel,
     } = input;

--- a/packages/host/app/commands/search-and-choose.ts
+++ b/packages/host/app/commands/search-and-choose.ts
@@ -64,14 +64,21 @@ export default class SearchAndChooseCommand extends HostBaseCommand<
 
     // 2. Prepare prompt content
     const summaries = this.formatCandidatesForPrompt(instances);
-    let systemPrompt = `You are an expert catalog curator. Select the most relevant 1 to ${max} ids representing ${candidateTypeCodeRef.name}. Output ONLY a JSON array of unique id strings. No commentary.`;
+    console.log('Summaries for SearchAndChooseCommand:\n', summaries);
+    let systemPrompt =
+      max === 1
+        ? `Select the single most relevant id representing ${candidateTypeCodeRef.name}. Output ONLY a JSON array with exactly 1 id string. No commentary.`
+        : `Select the most relevant 1 to ${max} ids representing ${candidateTypeCodeRef.name}. Output ONLY a JSON array of unique id strings. No commentary.`;
     if (selectionContextCodeRef) {
       systemPrompt += ` Use the attached module source for "${selectionContextCodeRef.name}" (${selectionContextCodeRef.module}) as selection context.`;
     }
     if (additionalSystemPrompt && additionalSystemPrompt.trim()) {
       systemPrompt += ` ${additionalSystemPrompt.trim()}`;
     }
-    const userPrompt = `Options (id :: title):\n${summaries}\n\nRules:\n- Return a JSON array with 1 to ${max} ids.\n- No duplicates.\n- Only use ids from the list.\n- If nothing is relevant return [].`;
+    const userPrompt =
+      max === 1
+        ? `Options (id :: title):\n${summaries}\n\nRules:\n- Return a JSON array with exactly 1 id.\n- Only use ids from the list.\n- If nothing is relevant return [].`
+        : `Options (id :: title):\n${summaries}\n\nRules:\n- Return a JSON array with 1 to ${max} ids.\n- No duplicates.\n- Only use ids from the list.\n- If nothing is relevant return [].`;
 
     // 3. LLM selection
     const oneShot = new OneShotLlmRequestCommand(this.commandContext);
@@ -141,7 +148,13 @@ export default class SearchAndChooseCommand extends HostBaseCommand<
   private formatCandidatesForPrompt(instances: any[]): string {
     return instances
       .filter((c) => c && c.id)
-      .map((c) => `${c.id} :: ${c.title || ''}`.trim())
+      .map((c) => {
+        const title = c.title || '';
+        const summary = c.cardInfo?.summary || '';
+        return summary
+          ? `${c.id} :: ${title} — ${summary}`.trim()
+          : `${c.id} :: ${title}`.trim();
+      })
       .join('\n');
   }
 }

--- a/packages/host/app/commands/search-and-choose.ts
+++ b/packages/host/app/commands/search-and-choose.ts
@@ -64,7 +64,6 @@ export default class SearchAndChooseCommand extends HostBaseCommand<
 
     // 2. Prepare prompt content
     const summaries = this.formatCandidatesForPrompt(instances);
-    console.log('Summaries for SearchAndChooseCommand:\n', summaries);
     let systemPrompt =
       max === 1
         ? `Select the single most relevant id representing ${candidateTypeCodeRef.name}. Output ONLY a JSON array with exactly 1 id string. No commentary.`


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-10611/limit-tag-and-category-auto-link-to-single-selection-enrich-candidates

Tag instance JSON files were using an outdated flat structure (cardDescription, cardThumbnailURL) instead of the current cardInfo nested structure, so cardInfo.summary was never populated — leaving the LLM with only a name to
match against when selecting tags, which degraded selection accuracy.

## Fix

- Limit tag and category auto-link to single selection
- Migrate all 8 Tag JSONs to the cardInfo structure and add descriptive summaries and Boxel palette colors to each tag
- Update formatCandidatesForPrompt in SearchAndChooseCommand to include cardInfo.summary alongside the title in the LLM candidate list
- Sharpen additionalSystemPrompt guidance in ListingCreateCommand for tag and category selection to enforce max=1 and prefer specific picks



<img width="1256" height="440" alt="image" src="https://github.com/user-attachments/assets/bec9a367-4f38-4061-aad4-d084277ec183" />
