### PR TITLE
Fix memory leak: clear html-component template cache between tests

### DIFF
--- a/packages/host/app/lib/html-component.ts
+++ b/packages/host/app/lib/html-component.ts
@@ -27,6 +27,10 @@ export type HTMLComponent = ComponentLike<{ Args: {}; Element: Element }>;
 
 const cache = new Map<string, TopElement>();
 
+export function clearHtmlComponentCache() {
+  cache.clear();
+}
+
 type TopElement = ComponentLike<{
   Args: { attrs: Record<string, string> };
   Element: Element;

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -9,6 +9,7 @@ import {
 } from 'ember-qunit';
 import { setupWindowMock } from 'ember-window-mock/test-support';
 
+import { clearHtmlComponentCache } from '@cardstack/host/lib/html-component';
 import type ResetService from '@cardstack/host/services/reset';
 
 import { cleanupMonacoEditorModels } from './index';
@@ -91,6 +92,7 @@ export function setupApplicationTest(hooks: NestedHooks) {
       this.owner.lookup('service:reset') as ResetService | undefined
     )?.resetAll();
     cleanupMonacoEditorModels();
+    clearHtmlComponentCache();
   });
 }
 
@@ -104,6 +106,7 @@ export function setupRenderingTest(hooks: NestedHooks) {
       this.owner.lookup('service:reset') as ResetService | undefined
     )?.resetAll();
     cleanupMonacoEditorModels();
+    clearHtmlComponentCache();
   });
 }
 


### PR DESCRIPTION
## Summary
- The module-level `Map` in `html-component.ts` caches compiled Glimmer templates keyed by HTML source strings
- This cache was never cleared between tests, causing unbounded growth across the test suite
- Adds `clearHtmlComponentCache()` export and calls it in `afterEach` for both application and rendering tests

## Test plan
- [ ] Verify host test suite passes with no regressions
- [ ] Monitor CI shard memory usage for improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)