### PR TITLE
Fix memory leak: clear remoteRealmCache between tests

### DIFF
--- a/packages/host/tests/helpers/realm-server-mock/routes.ts
+++ b/packages/host/tests/helpers/realm-server-mock/routes.ts
@@ -46,6 +46,10 @@ type SearchableRealm = {
 
 const remoteRealmCache = new Map<string, SearchableRealm>();
 
+export function clearRemoteRealmCache() {
+  remoteRealmCache.clear();
+}
+
 const realmServerRoutes = new Map<string, RealmServerMockRoute>();
 
 function normalizeRoutePath(path: string): string {

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -13,6 +13,7 @@ import { clearHtmlComponentCache } from '@cardstack/host/lib/html-component';
 import type ResetService from '@cardstack/host/services/reset';
 
 import { cleanupMonacoEditorModels } from './index';
+import { clearRemoteRealmCache } from './realm-server-mock/routes';
 
 function setupFetchDebugging(hooks: NestedHooks) {
   let originalFetch: typeof globalThis.fetch | undefined;
@@ -93,6 +94,7 @@ export function setupApplicationTest(hooks: NestedHooks) {
     )?.resetAll();
     cleanupMonacoEditorModels();
     clearHtmlComponentCache();
+    clearRemoteRealmCache();
   });
 }
 
@@ -107,6 +109,7 @@ export function setupRenderingTest(hooks: NestedHooks) {
     )?.resetAll();
     cleanupMonacoEditorModels();
     clearHtmlComponentCache();
+    clearRemoteRealmCache();
   });
 }
 

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -12,8 +12,9 @@ import { setupWindowMock } from 'ember-window-mock/test-support';
 import { clearHtmlComponentCache } from '@cardstack/host/lib/html-component';
 import type ResetService from '@cardstack/host/services/reset';
 
-import { cleanupMonacoEditorModels } from './index';
 import { clearRemoteRealmCache } from './realm-server-mock/routes';
+
+import { cleanupMonacoEditorModels } from './index';
 
 function setupFetchDebugging(hooks: NestedHooks) {
   let originalFetch: typeof globalThis.fetch | undefined;


### PR DESCRIPTION
## Summary
- The module-level `remoteRealmCache` Map in `realm-server-mock/routes.ts` caches `SearchableRealm` objects and was never cleared between tests
- These objects hold closures over fetch functions, retaining references across the test suite
- Adds `clearRemoteRealmCache()` export and calls it in `afterEach` for both application and rendering tests

## Test plan
- [ ] Verify host test suite passes with no regressions
- [ ] Monitor CI shard memory usage for improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)