### PR TITLE
Fix flaky test: handle network errors in matrix token validation

### DIFF
--- a/packages/runtime-common/matrix-client.ts
+++ b/packages/runtime-common/matrix-client.ts
@@ -368,11 +368,15 @@ export class MatrixClient {
     if (!this.access) {
       return false;
     }
-    let userId = await this.whoami();
-    if (userId === this.access.userId) {
-      return true;
+    try {
+      let userId = await this.whoami();
+      if (userId === this.access.userId) {
+        return true;
+      }
+      return false;
+    } catch {
+      return false;
     }
-    return false;
   }
 
   async whoami() {

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -190,8 +190,15 @@ export class Worker {
         this.#realmServerMatrixUsername,
       )!;
 
-      if (!(await matrixClient.isTokenValid())) {
-        await matrixClient.login();
+      try {
+        if (!(await matrixClient.isTokenValid())) {
+          await matrixClient.login();
+        }
+      } catch (e) {
+        this.#log.warn(
+          `Failed to validate/refresh matrix token, proceeding without pre-authenticated token`,
+          e,
+        );
       }
     } else {
       matrixClient = new MatrixClient({


### PR DESCRIPTION
## Summary

- **`MatrixClient.isTokenValid()`** now wraps the `whoami()` call in a try-catch and returns `false` on network errors instead of throwing. This is correct behavior: if we cannot reach the matrix server, treating the token as invalid triggers a re-login attempt.
- **`Worker.makeAuthedFetch()`** wraps the token-validation + login flow in a try-catch so transient matrix server failures (common during test teardown in CI) are logged as warnings rather than propagating as unhandled errors through BrowserQueue's `drainJobs`.

These changes fix a flaky CI failure in `commands-test.gts` ("a scripted command can create a card, update it and show it") where a `TypeError: Failed to fetch` from `isTokenValid()` during incremental indexing caused a global QUnit failure.

## Test plan

- [ ] Verify existing tests in `packages/host/tests/acceptance/commands-test.gts` continue to pass
- [ ] Confirm no regressions in matrix authentication flows (login still happens when token is invalid)
- [ ] Monitor CI for absence of the previously flaky `TypeError: Failed to fetch` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)