### PR TITLE
Sideload linked cards in file-meta JSON-API responses

### DIFF
--- a/packages/base/card-serialization.ts
+++ b/packages/base/card-serialization.ts
@@ -12,6 +12,7 @@ import type {
   LooseSingleFileMetaDocument,
   Meta,
   RuntimeDependencyTrackingContext,
+  SingleFileMetaDocument,
 } from '@cardstack/runtime-common';
 import type { BaseDef, BaseDefConstructor, CardDef } from './card-api';
 import type { FileDef } from './file-api';
@@ -181,7 +182,7 @@ export function makeRelativeURL(
 }
 
 export function resourceFrom(
-  doc: CardDocument | undefined,
+  doc: CardDocument | SingleFileMetaDocument | undefined,
   resourceId: string | undefined,
 ): CardResource | FileMetaResource | undefined {
   if (doc == null) {

--- a/packages/base/card-serialization.ts
+++ b/packages/base/card-serialization.ts
@@ -187,8 +187,8 @@ export function resourceFrom(
   if (doc == null) {
     return;
   }
-  let data: CardResource[];
-  if (isSingleCardDocument(doc)) {
+  let data: (CardResource | FileMetaResource)[];
+  if (isSingleCardDocument(doc) || isSingleFileMetaDocument(doc)) {
     if (resourceId === undefined) {
       return undefined;
     }

--- a/packages/host/app/utils/file-def-attributes-extractor.ts
+++ b/packages/host/app/utils/file-def-attributes-extractor.ts
@@ -326,10 +326,9 @@ export class FileDefAttributesExtractor {
     klass: FileDefConstructor,
   ): Promise<Record<string, QueryFieldMeta> | undefined> {
     try {
-      let cardApiModule =
-        await this.#loaderService.loader.import<typeof CardAPI>(
-          'https://cardstack.com/base/card-api',
-        );
+      let cardApiModule = await this.#loaderService.loader.import<
+        typeof CardAPI
+      >('https://cardstack.com/base/card-api');
       let fields = getFieldDefinitions(
         cardApiModule,
         klass as unknown as typeof BaseDef,

--- a/packages/host/app/utils/file-def-attributes-extractor.ts
+++ b/packages/host/app/utils/file-def-attributes-extractor.ts
@@ -9,10 +9,13 @@ import {
   SupportedMimeType,
   type CodeRef,
   type FileMetaResource,
+  type QueryFieldMeta,
   type RenderError,
   type ResolvedCodeRef,
 } from '@cardstack/runtime-common';
+import { getFieldDefinitions } from '@cardstack/runtime-common/definitions';
 
+import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import type { BaseDef } from 'https://cardstack.com/base/card-api';
 
 import type { createAuthErrorGuard } from './auth-error-guard';
@@ -197,10 +200,16 @@ export class FileDefAttributesExtractor {
         let typeCodeRefs = getTypes(klass);
         let types = typeCodeRefs.map((type) => internalKeyFor(type, undefined));
         let adoptsFrom = typeCodeRefs[0] ?? this.#fileDefCodeRef;
+        let queryFieldDefs = await this.extractQueryFieldDefs(klass);
         return {
           status: 'ready',
           searchDoc,
-          resource: buildFileResource(this.#fileURL, searchDoc, adoptsFrom),
+          resource: buildFileResource(
+            this.#fileURL,
+            searchDoc,
+            adoptsFrom,
+            queryFieldDefs,
+          ),
           types,
           deps,
           ...(error ? { error } : {}),
@@ -309,6 +318,44 @@ export class FileDefAttributesExtractor {
     }
     return new Uint8Array(await new Response(stream).arrayBuffer());
   }
+
+  // Extract query field definitions (linksTo/linksToMany with a query) from
+  // the FileDef class so they can be stored in the index and used at serve
+  // time without a runtime definition lookup.
+  private async extractQueryFieldDefs(
+    klass: FileDefConstructor,
+  ): Promise<Record<string, QueryFieldMeta> | undefined> {
+    try {
+      let cardApiModule =
+        await this.#loaderService.loader.import<typeof CardAPI>(
+          'https://cardstack.com/base/card-api',
+        );
+      let fields = getFieldDefinitions(
+        cardApiModule,
+        klass as unknown as typeof BaseDef,
+      );
+      let result: Record<string, QueryFieldMeta> = {};
+      for (let [name, def] of Object.entries(fields)) {
+        if (
+          def.query &&
+          (def.type === 'linksTo' || def.type === 'linksToMany')
+        ) {
+          result[name] = {
+            type: def.type,
+            query: def.query,
+            fieldOrCard: def.fieldOrCard,
+          };
+        }
+      }
+      return Object.keys(result).length > 0 ? result : undefined;
+    } catch (err) {
+      console.warn(
+        `[file-extract] Failed to extract query field defs for ${this.#fileURL}:`,
+        err,
+      );
+      return undefined;
+    }
+  }
 }
 
 export function getTypes(klass: FileDefConstructor): CodeRef[] {
@@ -330,6 +377,7 @@ export function buildFileResource(
   fileURL: string,
   attributes: Record<string, any>,
   adoptsFrom: CodeRef,
+  queryFieldDefs?: Record<string, QueryFieldMeta>,
 ): FileMetaResource {
   let name = new URL(fileURL).pathname.split('/').pop() ?? fileURL;
   let baseAttributes = {
@@ -350,6 +398,7 @@ export function buildFileResource(
     attributes: mergedAttributes,
     meta: {
       adoptsFrom,
+      ...(queryFieldDefs ? { queryFieldDefs } : {}),
     },
     links: { self: fileURL },
   };

--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -227,6 +227,9 @@ module('Unit | query', function (hooks) {
             });
         }
       },
+      async lookupCachedDefinition(): Promise<undefined> {
+        return undefined;
+      },
       async invalidate(_realmURL: string): Promise<string[]> {
         // no-op for tests
         return [];

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -295,6 +295,69 @@ module(basename(__filename), function () {
       );
     });
 
+    test('file meta for markdown with card references includes sideloaded linked cards', async function (assert) {
+      let response = await request
+        .get(`/card-refs.md`)
+        .set('Accept', SupportedMimeType.FileMeta)
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'user', ['read', 'write'])}`,
+        );
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+
+      let json = response.body;
+
+      // The linkedCards relationship should be populated via query
+      let linkedCards = json.data.relationships?.linkedCards;
+      assert.ok(linkedCards, 'linkedCards relationship is present');
+      assert.ok(
+        linkedCards?.links?.search,
+        'linkedCards has a search link',
+      );
+
+      // Sideloaded included resources should contain the referenced cards
+      assert.ok(json.included, 'response has included resources');
+      let includedIds = (json.included ?? []).map(
+        (r: { id: string }) => r.id,
+      );
+      assert.true(
+        includedIds.some((id: string) => id.includes('hassan')),
+        'included resources contain hassan card',
+      );
+      assert.true(
+        includedIds.some((id: string) => id.includes('jade')),
+        'included resources contain jade card',
+      );
+
+      // Each included resource should be a card with proper structure
+      for (let included of json.included ?? []) {
+        assert.strictEqual(included.type, 'card', 'included resource is a card');
+        assert.ok(included.id, 'included resource has an id');
+        assert.ok(included.meta?.adoptsFrom, 'included resource has adoptsFrom');
+      }
+    });
+
+    test('file meta for non-markdown file does not include sideloaded resources', async function (assert) {
+      let response = await request
+        .get(`/person.gts`)
+        .set('Accept', SupportedMimeType.FileMeta)
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'user', ['read', 'write'])}`,
+        );
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+
+      let json = response.body;
+      assert.strictEqual(json.data.type, 'file-meta');
+      assert.notOk(json.included, 'non-markdown file has no included resources');
+      assert.notOk(
+        json.data.relationships?.linkedCards,
+        'non-markdown file has no linkedCards relationship',
+      );
+    });
+
     test('sets canonical path header for nested module requests', async function (assert) {
       let response = await request
         .get(`/nested/example`)

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -311,16 +311,11 @@ module(basename(__filename), function () {
       // The linkedCards relationship should be populated via query
       let linkedCards = json.data.relationships?.linkedCards;
       assert.ok(linkedCards, 'linkedCards relationship is present');
-      assert.ok(
-        linkedCards?.links?.search,
-        'linkedCards has a search link',
-      );
+      assert.ok(linkedCards?.links?.search, 'linkedCards has a search link');
 
       // Sideloaded included resources should contain the referenced cards
       assert.ok(json.included, 'response has included resources');
-      let includedIds = (json.included ?? []).map(
-        (r: { id: string }) => r.id,
-      );
+      let includedIds = (json.included ?? []).map((r: { id: string }) => r.id);
       assert.true(
         includedIds.some((id: string) => id.includes('hassan')),
         'included resources contain hassan card',
@@ -332,9 +327,16 @@ module(basename(__filename), function () {
 
       // Each included resource should be a card with proper structure
       for (let included of json.included ?? []) {
-        assert.strictEqual(included.type, 'card', 'included resource is a card');
+        assert.strictEqual(
+          included.type,
+          'card',
+          'included resource is a card',
+        );
         assert.ok(included.id, 'included resource has an id');
-        assert.ok(included.meta?.adoptsFrom, 'included resource has adoptsFrom');
+        assert.ok(
+          included.meta?.adoptsFrom,
+          'included resource has adoptsFrom',
+        );
       }
     });
 
@@ -351,7 +353,10 @@ module(basename(__filename), function () {
 
       let json = response.body;
       assert.strictEqual(json.data.type, 'file-meta');
-      assert.notOk(json.included, 'non-markdown file has no included resources');
+      assert.notOk(
+        json.included,
+        'non-markdown file has no included resources',
+      );
       assert.notOk(
         json.data.relationships?.linkedCards,
         'non-markdown file has no linkedCards relationship',

--- a/packages/realm-server/tests/scripts/run-qunit-with-test-pg.sh
+++ b/packages/realm-server/tests/scripts/run-qunit-with-test-pg.sh
@@ -24,4 +24,4 @@ NODE_NO_WARNINGS=1 \
 PGPORT=55436 \
 STRIPE_WEBHOOK_SECRET=stripe-webhook-secret \
 STRIPE_API_KEY=stripe-api-key \
-qunit --require ts-node/register/transpile-only "${JUNIT_REPORTER_ARGS[@]}" "$@" tests/index.ts
+qunit --require ts-node/register/transpile-only ${JUNIT_REPORTER_ARGS[@]+"${JUNIT_REPORTER_ARGS[@]}"} "$@" tests/index.ts

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -198,7 +198,10 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     contextOpts?: LookupContext,
   ): Promise<Definition | undefined> {
     let canonicalModuleURL = canonicalURL(codeRef.module);
-    let context = await this.buildLookupContext(canonicalModuleURL, contextOpts);
+    let context = await this.buildLookupContext(
+      canonicalModuleURL,
+      contextOpts,
+    );
     if (!context) {
       return undefined;
     }

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -143,9 +143,10 @@ export function isFilterRefersToNonexistentTypeError(
 
 export interface DefinitionLookup {
   lookupDefinition(codeRef: ResolvedCodeRef): Promise<Definition>;
-  // Like lookupDefinition but only reads from the database cache—never
-  // triggers a prerenderer call.  Returns undefined when the definition is
-  // not yet cached.
+  // Like lookupDefinition but does not trigger a prerenderer call or
+  // populate missing definitions. It may still perform lookup-context
+  // resolution (including remote visibility probing) before reading from the
+  // database cache. Returns undefined when the definition is not yet cached.
   lookupCachedDefinition(
     codeRef: ResolvedCodeRef,
   ): Promise<Definition | undefined>;

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -143,6 +143,12 @@ export function isFilterRefersToNonexistentTypeError(
 
 export interface DefinitionLookup {
   lookupDefinition(codeRef: ResolvedCodeRef): Promise<Definition>;
+  // Like lookupDefinition but only reads from the database cache—never
+  // triggers a prerenderer call.  Returns undefined when the definition is
+  // not yet cached.
+  lookupCachedDefinition(
+    codeRef: ResolvedCodeRef,
+  ): Promise<Definition | undefined>;
   invalidate(moduleURL: string): Promise<string[]>;
   clearRealmCache(realmURL: string): Promise<void>;
   clearAllModules(): Promise<void>;
@@ -185,6 +191,40 @@ export class CachingDefinitionLookup implements DefinitionLookup {
 
   async lookupDefinition(codeRef: ResolvedCodeRef): Promise<Definition> {
     return await this.lookupDefinitionWithContext(codeRef);
+  }
+
+  async lookupCachedDefinition(
+    codeRef: ResolvedCodeRef,
+    contextOpts?: LookupContext,
+  ): Promise<Definition | undefined> {
+    let canonicalModuleURL = canonicalURL(codeRef.module);
+    let context = await this.buildLookupContext(canonicalModuleURL, contextOpts);
+    if (!context) {
+      return undefined;
+    }
+    let { cacheUserId, cacheScope, resolvedRealmURL } = context;
+
+    for (let candidateURL of this.populationCandidates(canonicalModuleURL)) {
+      let cached = await this.readFromDatabaseCache(
+        candidateURL,
+        cacheScope,
+        cacheUserId,
+        resolvedRealmURL,
+      );
+      if (cached) {
+        let canonicalCodeRef =
+          canonicalModuleURL === codeRef.module
+            ? codeRef
+            : { ...codeRef, module: canonicalModuleURL };
+        let moduleId = internalKeyFor(canonicalCodeRef, undefined);
+        let entry = cached.definitions[moduleId];
+        if (entry && 'definition' in entry) {
+          return entry.definition;
+        }
+        return undefined;
+      }
+    }
+    return undefined;
   }
 
   async getModuleCacheEntry(
@@ -1127,6 +1167,14 @@ class RealmScopedDefinitionLookup implements DefinitionLookup {
 
   async lookupDefinition(codeRef: ResolvedCodeRef): Promise<Definition> {
     return await this.#inner.lookupDefinitionForRealm(codeRef, this.#realm);
+  }
+
+  async lookupCachedDefinition(
+    codeRef: ResolvedCodeRef,
+  ): Promise<Definition | undefined> {
+    return await this.#inner.lookupCachedDefinition(codeRef, {
+      requestingRealm: this.#realm,
+    });
   }
 
   async invalidate(moduleURL: string): Promise<string[]> {

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -47,7 +47,12 @@ import {
   isLinkableCollectionDocument,
 } from './document-types';
 import { relationshipEntries } from './relationship-utils';
-import type { CardResource, FileMetaResource, Saved } from './resource-types';
+import type {
+  CardResource,
+  FileMetaResource,
+  QueryFieldMeta,
+  Saved,
+} from './resource-types';
 import type { FieldDefinition } from './definitions';
 import {
   normalizeQueryDefinition,
@@ -58,6 +63,11 @@ import {
 type Options = {
   loadLinks?: true;
   linkFields?: string[];
+  // When true, populateQueryFields will only use cached definitions from the
+  // database and will never trigger a prerenderer call.  This prevents deadlocks
+  // when file-meta responses are served during card prerendering (the single
+  // prerender semaphore permit is already held).
+  cacheOnlyDefinitions?: boolean;
 } & QueryOptions;
 
 type SearchResult = SearchResultDoc | SearchResultError;
@@ -254,7 +264,16 @@ export class RealmIndexQueryEngine {
       return false;
     }
     try {
-      let definition = await this.#definitionLookup.lookupDefinition(codeRef);
+      let definition: import('./definitions').Definition | undefined;
+      if (opts?.cacheOnlyDefinitions) {
+        definition =
+          await this.#definitionLookup.lookupCachedDefinition(codeRef);
+        if (!definition) {
+          return false;
+        }
+      } else {
+        definition = await this.#definitionLookup.lookupDefinition(codeRef);
+      }
       // Strip the linksToMany index suffix (e.g., "friends.0" -> "friends")
       let fieldName = fieldKey.includes('.')
         ? fieldKey.slice(0, fieldKey.indexOf('.'))
@@ -458,7 +477,16 @@ export class RealmIndexQueryEngine {
     if (!isResolvedCodeRef(codeRef)) {
       return;
     }
-    let definition = await this.#definitionLookup.lookupDefinition(codeRef);
+    let definition: import('./definitions').Definition | undefined;
+    if (opts?.cacheOnlyDefinitions) {
+      definition =
+        await this.#definitionLookup.lookupCachedDefinition(codeRef);
+      if (!definition) {
+        return;
+      }
+    } else {
+      definition = await this.#definitionLookup.lookupDefinition(codeRef);
+    }
     for (let [fieldName, fieldDefinition] of Object.entries(
       definition.fields,
     )) {
@@ -480,6 +508,45 @@ export class RealmIndexQueryEngine {
         fieldDefinition,
         fieldName,
         queryDefinition,
+        resource,
+        realmURL,
+        opts,
+      });
+      this.applyQueryResults({
+        fieldDefinition,
+        fieldName,
+        resource,
+        results,
+        errors,
+        searchURL,
+      });
+    }
+  }
+
+  // Populate query-based relationship fields using pre-extracted metadata
+  // stored in the resource's meta during file indexing. This avoids a
+  // runtime definition lookup (which could deadlock during prerendering).
+  private async populateQueryFieldsFromMeta(
+    resource: LooseCardResource | FileMetaResource,
+    realmURL: URL,
+    queryFieldDefs: Record<string, QueryFieldMeta>,
+    opts?: Options,
+  ): Promise<void> {
+    for (let [fieldName, meta] of Object.entries(queryFieldDefs)) {
+      if (opts?.linkFields && !opts.linkFields.includes(fieldName)) {
+        continue;
+      }
+      let fieldDefinition: FieldDefinition = {
+        type: meta.type,
+        isPrimitive: false,
+        isComputed: true,
+        fieldOrCard: meta.fieldOrCard,
+        query: meta.query,
+      };
+      let { results, errors, searchURL } = await this.executeQueryForField({
+        fieldDefinition,
+        fieldName,
+        queryDefinition: meta.query,
         resource,
         realmURL,
         opts,
@@ -1006,7 +1073,22 @@ export class RealmIndexQueryEngine {
     };
 
     await processRelationships();
-    await this.populateQueryFields(resource, realmURL, opts);
+    // When cacheOnlyDefinitions is set (file-meta during prerendering), use
+    // pre-extracted query field metadata from the resource's meta instead of
+    // calling lookupDefinition (which could deadlock).
+    let storedDefs = (
+      resource.meta as { queryFieldDefs?: Record<string, QueryFieldMeta> }
+    )?.queryFieldDefs;
+    if (opts?.cacheOnlyDefinitions && storedDefs) {
+      await this.populateQueryFieldsFromMeta(
+        resource,
+        realmURL,
+        storedDefs,
+        opts,
+      );
+    } else {
+      await this.populateQueryFields(resource, realmURL, opts);
+    }
     await processRelationships();
     return included;
   }

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -266,7 +266,8 @@ export class RealmIndexQueryEngine {
     try {
       let definition: import('./definitions').Definition | undefined;
       if (opts?.cacheOnlyDefinitions) {
-        definition = await this.#definitionLookup.lookupCachedDefinition(codeRef);
+        definition =
+          await this.#definitionLookup.lookupCachedDefinition(codeRef);
         if (!definition) {
           return false;
         }

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -266,8 +266,7 @@ export class RealmIndexQueryEngine {
     try {
       let definition: import('./definitions').Definition | undefined;
       if (opts?.cacheOnlyDefinitions) {
-        definition =
-          await this.#definitionLookup.lookupCachedDefinition(codeRef);
+        definition = await this.#definitionLookup.lookupCachedDefinition(codeRef);
         if (!definition) {
           return false;
         }
@@ -479,8 +478,7 @@ export class RealmIndexQueryEngine {
     }
     let definition: import('./definitions').Definition | undefined;
     if (opts?.cacheOnlyDefinitions) {
-      definition =
-        await this.#definitionLookup.lookupCachedDefinition(codeRef);
+      definition = await this.#definitionLookup.lookupCachedDefinition(codeRef);
       if (!definition) {
         return;
       }

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -463,6 +463,20 @@ export class RealmIndexQueryEngine {
     return await this.#indexQueryEngine.getFile(url, opts);
   }
 
+  async loadLinksForResource(
+    resource: LooseCardResource | FileMetaResource,
+    opts?: Options,
+  ): Promise<(CardResource<Saved> | FileMetaResource)[]> {
+    return await this.loadLinks(
+      {
+        realmURL: this.realmURL,
+        resource,
+        omit: [...(resource.id ? [resource.id] : [])],
+      },
+      opts,
+    );
+  }
+
   private async populateQueryFields(
     resource: LooseCardResource | FileMetaResource,
     realmURL: URL,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2700,15 +2700,25 @@ export class Realm {
           adoptsFrom,
           realmInfo,
           realmURL: this.url,
+          ...(fileEntry.resource?.meta?.queryFieldDefs
+            ? { queryFieldDefs: fileEntry.resource.meta.queryFieldDefs }
+            : {}),
         },
         links: { self: fileURL },
       },
     };
-    // Sideload linked resources for file types with relationships or
-    // query-based link fields (e.g. MarkdownDef's linkedCards).
+    // Sideload linked resources. Use cacheOnlyDefinitions to avoid triggering
+    // prerenderer calls for definition lookups—this prevents deadlocks when the
+    // file-meta response is served during card prerendering (which holds the
+    // prerender semaphore permit). When cacheOnlyDefinitions is set, loadLinks
+    // uses pre-extracted queryFieldDefs from the resource's meta (populated
+    // during file indexing) to discover query-based relationship fields.
     let included = await this.#realmIndexQueryEngine.loadLinksForResource(
       doc.data,
-      { loadLinks: true },
+      {
+        loadLinks: true,
+        cacheOnlyDefinitions: true,
+      },
     );
     if (included.length > 0) {
       doc.included = included;

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2685,6 +2685,7 @@ export class Realm {
         attributes[key] = value;
       }
     }
+    let relationships = fileEntry.resource?.relationships;
     let doc: SingleFileMetaDocument = {
       data: {
         type: 'file-meta',
@@ -2692,6 +2693,9 @@ export class Realm {
         attributes: {
           ...attributes,
         },
+        ...(relationships && Object.keys(relationships).length > 0
+          ? { relationships }
+          : {}),
         meta: {
           adoptsFrom,
           realmInfo,
@@ -2700,6 +2704,15 @@ export class Realm {
         links: { self: fileURL },
       },
     };
+    // Sideload linked resources for file types with relationships or
+    // query-based link fields (e.g. MarkdownDef's linkedCards).
+    let included = await this.#realmIndexQueryEngine.loadLinksForResource(
+      doc.data,
+      { loadLinks: true },
+    );
+    if (included.length > 0) {
+      doc.included = included;
+    }
     return createResponse({
       body: JSON.stringify(doc, null, 2),
       init: {

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -1,6 +1,17 @@
 import type { RealmInfo } from './realm';
 import { type CodeRef, isCodeRef, moduleFrom } from './code-ref';
 import { resolveCardReference } from './card-reference-resolver';
+import type { Query } from './query';
+
+// Metadata for a query-based linksTo/linksToMany field on a FileDef subclass,
+// extracted during file prerendering so that file-meta responses can populate
+// query relationships without a runtime definition lookup (which would
+// deadlock when the request is served during card prerendering).
+export interface QueryFieldMeta {
+  type: 'linksTo' | 'linksToMany';
+  query: Query;
+  fieldOrCard: CodeRef;
+}
 
 export const CardResourceType = 'card';
 export const FileMetaResourceType = 'file-meta';
@@ -64,6 +75,7 @@ export type CardResourceMeta = Meta & {
 export type FileMetaResourceResourceMeta = Meta & {
   realmInfo?: RealmInfo;
   realmURL?: string;
+  queryFieldDefs?: Record<string, QueryFieldMeta>;
 };
 
 export interface CardResource<Identity extends Unsaved = Saved> {


### PR DESCRIPTION
## Summary
- Sideload query-based relationships (e.g. MarkdownDef's linkedCards) in file-meta JSON-API responses
- Extract query field definitions during file prerendering and store in `FileMetaResource.meta.queryFieldDefs`, enabling generic sideloading for any FileDef subclass
- Prevent prerender semaphore deadlock by using stored defs + `cacheOnlyDefinitions` option instead of calling `lookupDefinition` at serve time
- Add `lookupCachedDefinition` to `DefinitionLookup` interface (DB-only, never calls prerenderer)
- Fix bash `set -u` unbound variable error in test runner script

## Test plan
- [ ] Realm server sideloading tests pass
- [ ] Realm server indexing tests pass (FileDef relationship deps tracking)
- [ ] Host unit tests pass (index-query-engine-test with lookupCachedDefinition mock)
- [ ] CI Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)