### PR TITLE
Fix flaky prerender timeout test race condition

### DIFF
--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -1045,7 +1045,14 @@ export async function withTimeout<T>(
   timeoutMs = cardRenderTimeout,
 ): Promise<T | RenderError> {
   let result = await Promise.race([
-    fn(),
+    fn().catch((err) => {
+      // Puppeteer's own TimeoutError (from waitForFunction/waitForSelector)
+      // should be treated the same as our outer timeout
+      if (err instanceof Error && err.name === 'TimeoutError') {
+        return { timeout: true } as { timeout: true };
+      }
+      throw err;
+    }),
     new Promise<{ timeout: true }>((r) =>
       setTimeout(() => {
         r({ timeout: true });


### PR DESCRIPTION
## Summary
- Fixes a race condition in `withTimeout` (`packages/realm-server/prerender/utils.ts`) where Puppeteer's own `TimeoutError` from `waitForFunction`/`waitForSelector` could fire before our outer `setTimeout`, bypassing the clean "Render timed-out" path
- When Puppeteer's timeout fires first, it now gets caught and converted to the same `{ timeout: true }` sentinel, ensuring consistent `unusable` status instead of flaky `error` status
- Fixes the flaky test: "it returns unusable status when command times out"

## Test plan
- [ ] CI passes on `prerender-server-test.ts` timeout test
- [ ] No regressions in other prerender tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)