### PR TITLE
Fix flaky file-tree scroll test

### DIFF
--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -637,10 +637,11 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
     if (!fileElement) {
       assert.ok(fileElement, 'file element should exist');
     } else {
-      assert.ok(
-        await elementIsVisible(fileElement),
-        'expected open file to be scrolled into view',
-      );
+      await waitUntil(async () => await elementIsVisible(fileElement), {
+        timeout: 2000,
+        timeoutMessage: 'expected open file to be scrolled into view',
+      });
+      assert.ok(true, 'expected open file to be scrolled into view');
     }
 
     await click('[data-test-directory="zzz/"]');

--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -637,11 +637,14 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
     if (!fileElement) {
       assert.ok(fileElement, 'file element should exist');
     } else {
-      await waitUntil(async () => await elementIsVisible(fileElement), {
-        timeout: 2000,
-        timeoutMessage: 'expected open file to be scrolled into view',
-      });
-      assert.ok(true, 'expected open file to be scrolled into view');
+      let isVisible = false;
+      for (let i = 0; i < 20 && !isVisible; i++) {
+        isVisible = (await elementIsVisible(fileElement)) as boolean;
+        if (!isVisible) {
+          await new Promise((r) => setTimeout(r, 100));
+        }
+      }
+      assert.ok(isVisible, 'expected open file to be scrolled into view');
     }
 
     await click('[data-test-directory="zzz/"]');


### PR DESCRIPTION
## Summary
- Fix flaky test "open file is within view even when its parent directory is not stored as open" in file-tree acceptance tests
- The `scrollIntoView` modifier uses an async `IntersectionObserver`, creating a race condition where the test checked visibility before the scroll completed
- Replace single-shot `elementIsVisible` check with `waitUntil` polling to handle the async scroll timing

## Test plan
- [x] `pnpm lint:js` passes clean
- [ ] CI passes the previously flaky test reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)