### PR TITLE
Fix flaky CI timeout in host command skill test

### DIFF
--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -683,8 +683,12 @@ module('Acceptance | Commands tests', function (hooks) {
         },
       ],
     });
-    // Click on the apply button
+    // Wait for message to render and for command processing drain to complete
+    // before clicking apply. The drain acquires a test waiter that blocks settled(),
+    // and running it concurrently with the heavy switch-to-code-mode command
+    // can exceed CI's browser_disconnect_timeout.
     await waitFor('[data-test-message-idx="0"]');
+    await settled();
     assert
       .dom('[data-test-message-idx="0"] .command-description')
       .containsText('Switching to code submode');
@@ -692,7 +696,7 @@ module('Acceptance | Commands tests', function (hooks) {
     await click('[data-test-message-idx="0"] [data-test-command-apply]');
 
     // check we're in code mode
-    await waitFor('[data-test-submode-switcher=code]');
+    await waitFor('[data-test-submode-switcher=code]', { timeout: 5000 });
     assert.dom('[data-test-submode-switcher=code]').exists();
 
     // verify that command result event was created correctly
@@ -704,6 +708,10 @@ module('Acceptance | Commands tests', function (hooks) {
             m.content.msgtype ===
             APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
         ),
+      {
+        timeout: 5000,
+        timeoutMessage: 'timed out waiting for command result event',
+      },
     );
     let message = getRoomEvents(roomId).find(
       (m) =>


### PR DESCRIPTION
## Summary
- Fix flaky test "a host command added from a skill can be executed when clicked on" that intermittently hit the 60s `browser_disconnect_timeout`
- Root cause: `simulateRemoteMessage` with `isStreamingFinished` + command requests triggered the auto-processing drain which acquired a test waiter blocking `settled()`. Running it concurrently with the heavy switch-to-code-mode command execution inside `click()` exceeded CI's timeout on slow runners.
- Add `await settled()` after `waitFor` to drain the command processing queue before clicking apply, and increase `waitFor`/`waitUntil` timeouts to 5s for CI headroom

## Test plan
- [ ] CI passes (specifically host test partition containing the commands-test module)
- [ ] The fixed test no longer hits browser timeout on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)