### PR TITLE
Remove min-height from host-mode stack-item container

### DIFF
--- a/packages/boxel-ui/addon/src/components/card-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-container/index.gts
@@ -49,7 +49,7 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
     :global(.boxel-card-container) {
       position: relative;
       background-color: var(--background, var(--boxel-light));
-      border-radius: var(--radius, var(--boxel-border-radius));
+      border-radius: var(--_boxel-radius);
       color: var(--foreground, var(--boxel-dark));
       transition:
         max-width var(--boxel-transition),
@@ -57,6 +57,7 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
       height: 100%;
       width: 100%;
       overflow: hidden;
+      z-index: 0;
     }
     :global(.boxel-card-container--boundaries:not(.hide-boundaries)) {
       box-shadow: 0 0 0 1px var(--border, var(--boxel-border-color));

--- a/packages/boxel-ui/addon/src/components/context-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/context-button/index.gts
@@ -14,7 +14,8 @@ export type ContextButtonVariant =
   | 'ghost'
   | 'destructive'
   | 'highlight-icon'
-  | 'destructive-icon'; // 'highlight' is default
+  | 'destructive-icon'
+  | 'primary-dark'; // 'highlight' is default
 
 export const contextButtonVariants: ContextButtonVariant[] = [
   'highlight',
@@ -22,6 +23,7 @@ export const contextButtonVariants: ContextButtonVariant[] = [
   'ghost',
   'destructive',
   'destructive-icon',
+  'primary-dark',
 ];
 
 export type ContextButtonIcon =
@@ -138,6 +140,12 @@ const DropdownButton: TemplateOnlyComponent<Signature> = <template>
       .boxel-context-button--destructive-icon:hover {
         color: var(--destructive-foreground, var(--boxel-light-100));
         background-color: var(--destructive, var(--boxel-danger));
+      }
+
+      .boxel-context-button--primary-dark {
+        color: var(--primary, var(--boxel-highlight));
+        background-color: var(--primary-foreground, var(--boxel-700));
+        border: 1px solid var(--boxel-light-hover-35);
       }
 
       .boxel-context-button:disabled,

--- a/packages/boxel-ui/addon/src/styles/variables.css
+++ b/packages/boxel-ui/addon/src/styles/variables.css
@@ -192,6 +192,7 @@
   --boxel-dark: #000;
   --boxel-dark-hover: rgba(0, 0, 0, 0.1);
   --boxel-darker-hover: rgba(0, 0, 0, 0.5);
+  --boxel-light-hover-35: rgba(255, 255, 255, 0.35);
 
   --boxel-highlight: var(--boxel-teal);
   --boxel-highlight-hover: var(--boxel-dark-teal);

--- a/packages/host/app/components/host-mode/stack-item.gts
+++ b/packages/host/app/components/host-mode/stack-item.gts
@@ -164,6 +164,7 @@ export default class HostModeStackItem extends Component<Signature> {
             <ContextButton
               @icon='close'
               @label='close'
+              @variant='primary-dark'
               {{on 'click' this.handleClose}}
               data-test-host-stack-item-close-button
             />
@@ -211,15 +212,9 @@ export default class HostModeStackItem extends Component<Signature> {
         position: absolute;
         width: 89%;
         height: inherit;
-        padding-top: var(--boxel-sp-xxl);
+        padding-top: var(--boxel-sp-2xl);
         z-index: 0;
         pointer-events: none;
-      }
-
-      @media screen {
-        .host-mode-stack-item {
-          min-height: 80cqh;
-        }
       }
 
       .host-mode-stack-item:not(.buried) {
@@ -261,7 +256,7 @@ export default class HostModeStackItem extends Component<Signature> {
 
       .stack-item-card {
         height: 100%;
-        border-radius: var(--boxel-border-radius-xl);
+        border-radius: var(--boxel-border-radius-2xl);
         box-shadow: var(--boxel-deep-box-shadow);
         pointer-events: auto;
         overflow: hidden;
@@ -282,17 +277,20 @@ export default class HostModeStackItem extends Component<Signature> {
         right: var(--boxel-sp-xs);
         z-index: 1;
       }
-      .close-button-container :deep(.boxel-context-button:not(:hover)) {
-        background-color: var(--boxel-100);
-      }
       .close-button-container :deep(.boxel-context-button) {
         box-shadow: var(--boxel-box-shadow);
       }
+      .close-button-container :deep(.boxel-context-button:hover) {
+        box-shadow: var(--boxel-box-shadow-hover);
+      }
 
       .host-mode-stack-item-card {
-        border-radius: 0;
+        border-radius: inherit;
         box-shadow: none;
         z-index: 0;
+      }
+      .host-mode-stack-item-card > :deep(.boxel-card-container) {
+        border-radius: inherit;
       }
 
       @media print {

--- a/packages/host/app/components/host-mode/stack.gts
+++ b/packages/host/app/components/host-mode/stack.gts
@@ -80,7 +80,6 @@ export default class HostModeStack extends Component<Signature> {
         /* .inner will handle overflow in host mode stack */
         .host-mode-stack :deep(.host-mode-card, .card) {
           overflow: hidden;
-          min-height: 80cqh;
         }
       }
 


### PR DESCRIPTION
Changes:
- Remove min-height on host-mode stack-item, and improve look of the `X` button to be more consistent with the navbar.
<img width="1811" height="1270" alt="stack-item" src="https://github.com/user-attachments/assets/38ec79b2-6679-4630-ba65-3c70d89df482" />

Note: I tested how this would look if multiple items were stacked on top of one other. Below are some screenshots for these hypotheticals:

2 items in stack:
<img width="1814" height="1286" alt="2-items" src="https://github.com/user-attachments/assets/c54989bb-b98c-440e-a24f-4d4560146804" />

3 items in stack:
<img width="1811" height="1287" alt="3-items" src="https://github.com/user-attachments/assets/60b14d85-637f-47a2-a4b7-883f2bcb69c2" />

- CardContainer improvement for keeping the border-radius consistent and resetting z-index for cases where inner card contents appeared over the system overlays.

