### PR TITLE
host: Remove font links that are also self-hosted

### DIFF
--- a/packages/host/app/index.html
+++ b/packages/host/app/index.html
@@ -13,6 +13,9 @@
       rel="stylesheet"
       href="{{rootURL}}assets/@cardstack/host.css"
     />
+    <link rel="preload" href="{{rootURL}}assets/fonts/IBMPlexSansVar-Roman.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="{{rootURL}}assets/fonts/IBMPlexMono-Regular.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="{{rootURL}}assets/fonts/IBMPlexMono-Bold.woff2" as="font" type="font/woff2" crossorigin />
     <style>
       /* Allow prerendered cards to scroll while card-specific CSS loads */
       #boxel-isolated-start + .boxel-card-container {

--- a/packages/host/app/index.html
+++ b/packages/host/app/index.html
@@ -13,6 +13,8 @@
       rel="stylesheet"
       href="{{rootURL}}assets/@cardstack/host.css"
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preload" href="{{rootURL}}assets/fonts/IBMPlexSansVar-Roman.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="{{rootURL}}assets/fonts/IBMPlexMono-Regular.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="{{rootURL}}assets/fonts/IBMPlexMono-Bold.woff2" as="font" type="font/woff2" crossorigin />

--- a/packages/host/app/index.html
+++ b/packages/host/app/index.html
@@ -19,12 +19,6 @@
         overflow-y: auto;
       }
     </style>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=IBM+Plex+Serif:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap"
-      rel="stylesheet"
-    />
 
     {{content-for "head-footer"}}
 

--- a/packages/host/ember-cli-build.js
+++ b/packages/host/ember-cli-build.js
@@ -57,7 +57,10 @@ module.exports = function (defaults) {
               },
               {
                 test: /\.woff2?$/,
-                type: 'asset',
+                type: 'asset/resource',
+                generator: {
+                  filename: 'assets/fonts/[name][ext]',
+                },
               },
               {
                 test: /\.png$/,


### PR DESCRIPTION
[`fonts.css`](https://github.com/cardstack/boxel/blob/861c03bbbc975c9579c5d1567bbfa0325c32b044/packages/boxel-ui/addon/src/styles/fonts.css) in `boxel-ui` already includes these.