### PR TITLE
Add index caching for use in development

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -822,7 +822,7 @@ jobs:
   cache-index:
     name: Cache realm index
     needs: [change-check, test-web-assets]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/cache-index-development-cs-10664'
     runs-on: ubuntu-latest
     concurrency:
       group: cache-index-${{ github.run_id }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -841,8 +841,15 @@ jobs:
           shopt -s dotglob
           cp -a .test-web-assets-artifact/. ./
       - name: Index all realms and dump tables
-        run: mise run ci:cache-index
+        run: mise run ci:cache-index 2>&1 | tee /tmp/cache-index.log
         timeout-minutes: 45
+      - name: Upload service logs
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
+        if: ${{ !cancelled() }}
+        with:
+          name: cache-index-log
+          path: /tmp/cache-index.log
+          retention-days: 7
       - name: Upload index cache
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -822,7 +822,7 @@ jobs:
   cache-index:
     name: Cache realm index
     needs: [change-check, test-web-assets]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.head_ref == 'cache-index-development-cs-10664'
     runs-on: ubuntu-latest
     concurrency:
       group: cache-index-${{ github.run_id }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -822,7 +822,7 @@ jobs:
   cache-index:
     name: Cache realm index
     needs: [change-check, test-web-assets]
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/cache-index-development-cs-10664'
+    if: github.ref == 'refs/heads/main' || github.head_ref == 'cache-index-development-cs-10664'
     runs-on: ubuntu-latest
     concurrency:
       group: cache-index-${{ github.run_id }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -818,3 +818,34 @@ jobs:
     secrets: inherit
     with:
       environment: "staging"
+
+  cache-index:
+    name: Cache realm index
+    needs: [change-check, test-web-assets]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: cache-index-${{ github.run_id }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/init
+      - name: Download test web assets
+        uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # 4.2.0
+        with:
+          name: ${{ needs.test-web-assets.outputs.artifact_name }}
+          path: .test-web-assets-artifact
+      - name: Restore test web assets into workspace
+        shell: bash
+        run: |
+          shopt -s dotglob
+          cp -a .test-web-assets-artifact/. ./
+      - name: Index all realms and dump tables
+        run: mise run ci:cache-index
+        timeout-minutes: 45
+      - name: Upload index cache
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
+        with:
+          name: boxel-index-cache
+          path: /tmp/boxel-index-cache.sql.gz
+          retention-days: 30

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -822,7 +822,7 @@ jobs:
   cache-index:
     name: Cache realm index
     needs: [change-check, test-web-assets]
-    if: github.ref == 'refs/heads/main' || github.head_ref == 'cache-index-development-cs-10664'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     concurrency:
       group: cache-index-${{ github.run_id }}

--- a/README.md
+++ b/README.md
@@ -170,6 +170,24 @@ To use turbo mode but override a specific value:
 BOXEL_TURBO=true PRERENDER_COUNT=5 mise run dev
 ```
 
+##### Index cache
+
+When using `BOXEL_ENVIRONMENT` to work in an isolated worktree, the first startup normally indexes all realms from scratch, which is slow. Set `INDEX_CACHE=true` to download a pre-built index from CI instead:
+
+```bash
+INDEX_CACHE=true BOXEL_ENVIRONMENT=my-branch mise run dev-all
+```
+
+This downloads the latest `boxel_index` dump produced by CI on `main`, remaps URLs for your environment, and imports it into your local database. It also sets `REALM_SERVER_FULL_INDEX_ON_STARTUP=false` so the realm server skips the background reindex and relies on the file watcher for incremental updates. You can override this:
+
+```bash
+INDEX_CACHE=true REALM_SERVER_FULL_INDEX_ON_STARTUP=true BOXEL_ENVIRONMENT=my-branch mise run dev-all
+```
+
+Requires the `gh` CLI to be installed and authenticated.
+
+##### Services
+
 Here's what is spun up with `mise run dev`:
 
 | Port  | Description                                                                                   | `mise run dev` | `mise run services:realm-server-base` |

--- a/mise-tasks/ci/cache-index
+++ b/mise-tasks/ci/cache-index
@@ -38,7 +38,29 @@ echo "Registering realm users..."
 pnpm --dir=../matrix register-realm-users
 
 echo "Waiting for realm readiness..."
-wait-on -t 1800000 $(echo "$READINESS_URLS" | tr '|' ' ')
+TIMEOUT=1800
+ELAPSED=0
+IFS='|'
+while [ $ELAPSED -lt $TIMEOUT ]; do
+  ALL_READY=true
+  for raw_url in $READINESS_URLS; do
+    url=$(echo "$raw_url" | sed 's|^http-get://|http://|')
+    if ! curl --output /dev/null --silent --fail "$url" 2>/dev/null; then
+      ALL_READY=false
+      break
+    fi
+  done
+  unset IFS
+  if $ALL_READY; then break; fi
+  sleep 5
+  ELAPSED=$((ELAPSED + 5))
+  IFS='|'
+done
+unset IFS
+if [ $ELAPSED -ge $TIMEOUT ]; then
+  echo "Timed out waiting for realm readiness after ${TIMEOUT}s"
+  exit 1
+fi
 
 echo "All realms ready. Dumping index tables..."
 docker exec boxel-pg pg_dump -U postgres --data-only \

--- a/mise-tasks/ci/cache-index
+++ b/mise-tasks/ci/cache-index
@@ -42,7 +42,7 @@ npx wait-on -t 1800000 $(echo "$READINESS_URLS" | tr '|' ' ')
 
 echo "All realms ready. Dumping index tables..."
 docker exec boxel-pg pg_dump -U postgres --data-only \
-  -t boxel_index -t boxel_index_working -t realm_versions -t realm_meta \
+  -t boxel_index -t realm_versions -t realm_meta \
   boxel | gzip > /tmp/boxel-index-cache.sql.gz
 
 echo "Index cache created at /tmp/boxel-index-cache.sql.gz"

--- a/mise-tasks/ci/cache-index
+++ b/mise-tasks/ci/cache-index
@@ -38,7 +38,7 @@ echo "Registering realm users..."
 pnpm --dir=../matrix register-realm-users
 
 echo "Waiting for realm readiness..."
-npx wait-on -t 1800000 $(echo "$READINESS_URLS" | tr '|' ' ')
+wait-on -t 1800000 $(echo "$READINESS_URLS" | tr '|' ' ')
 
 echo "All realms ready. Dumping index tables..."
 docker exec boxel-pg pg_dump -U postgres --data-only \

--- a/mise-tasks/ci/cache-index
+++ b/mise-tasks/ci/cache-index
@@ -1,0 +1,24 @@
+#!/bin/sh
+#MISE description="Index all realms and dump boxel_index tables for caching"
+#MISE dir="packages/realm-server"
+
+# start-server-and-test and run-p live in node_modules/.bin; ensure they're on
+# PATH when this task is invoked directly via `mise run` (not through pnpm).
+export PATH="./node_modules/.bin:$PATH"
+
+READY_PATH="_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson"
+REALM_HOST="${REALM_BASE_URL#http://}"
+
+# Wait for ALL 9 development realms to be indexed and ready.
+READINESS_URLS=""
+for realm in base catalog external-catalog skills submissions boxel-homepage experiments openrouter software-factory; do
+  READINESS_URLS="${READINESS_URLS:+${READINESS_URLS}|}http-get://${REALM_HOST}/${realm}/${READY_PATH}"
+done
+READINESS_URLS="${READINESS_URLS}|${MATRIX_URL_VAL}|http://localhost:5001|${ICONS_URL}|${HOST_URL}"
+
+WAIT_ON_TIMEOUT=1800000 \
+  NODE_NO_WARNINGS=1 \
+  start-server-and-test \
+    'run-p -ln start:icons start:host-dist start:pg start:prerender-dev start:prerender-manager-dev start:matrix start:smtp start:worker-development start:development' \
+    "${READINESS_URLS}" \
+    'docker exec boxel-pg pg_dump -U postgres --data-only -t boxel_index -t boxel_index_working -t realm_versions -t realm_meta boxel | gzip > /tmp/boxel-index-cache.sql.gz && echo "Index cache created at /tmp/boxel-index-cache.sql.gz"'

--- a/mise-tasks/ci/cache-index
+++ b/mise-tasks/ci/cache-index
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 #MISE description="Index all realms and dump boxel_index tables for caching"
 #MISE dir="packages/realm-server"
 
-set -e
+set -euo pipefail
 
 export PATH="./node_modules/.bin:$PATH"
 
@@ -24,26 +24,45 @@ SKIP_BOXEL_HOMEPAGE=true \
   run-p -ln start:icons start:host-dist start:pg start:prerender-dev start:prerender-manager-dev start:matrix start:smtp start:worker-development start:development &
 SERVICES_PID=$!
 
+ensure_services_running() {
+  if ! kill -0 "$SERVICES_PID" 2>/dev/null; then
+    wait "$SERVICES_PID"
+    echo "Services exited unexpectedly."
+    exit 1
+  fi
+}
+
 cleanup() {
   echo "Stopping services..."
-  kill $SERVICES_PID 2>/dev/null || true
-  wait $SERVICES_PID 2>/dev/null || true
+  kill "$SERVICES_PID" 2>/dev/null || true
+  wait "$SERVICES_PID" 2>/dev/null || true
 }
 trap cleanup EXIT INT TERM
 
 # Register realm users with Matrix (waits for Synapse to be healthy).
 # Must happen while services are starting since the realm server needs
 # authenticated Matrix users.
+ensure_services_running
 echo "Registering realm users..."
 pnpm --dir=../matrix register-realm-users
+ensure_services_running
 
 echo "Waiting for realm readiness..."
-wait-on -t 1800000 $(echo "$READINESS_URLS" | tr '|' ' ')
+wait-on -t 1800000 $(echo "$READINESS_URLS" | tr '|' ' ') &
+WAIT_ON_PID=$!
+
+while kill -0 "$WAIT_ON_PID" 2>/dev/null; do
+  ensure_services_running
+  sleep 1
+done
+wait "$WAIT_ON_PID"
 
 echo "All realms ready. Dumping index tables..."
 docker exec boxel-pg pg_dump -U postgres --data-only \
   -t boxel_index -t realm_versions -t realm_meta \
-  boxel | gzip > /tmp/boxel-index-cache.sql.gz
+  boxel > /tmp/boxel-index-cache.sql
+
+gzip /tmp/boxel-index-cache.sql
 
 echo "Index cache created at /tmp/boxel-index-cache.sql.gz"
 ls -lh /tmp/boxel-index-cache.sql.gz

--- a/mise-tasks/ci/cache-index
+++ b/mise-tasks/ci/cache-index
@@ -2,23 +2,48 @@
 #MISE description="Index all realms and dump boxel_index tables for caching"
 #MISE dir="packages/realm-server"
 
-# start-server-and-test and run-p live in node_modules/.bin; ensure they're on
-# PATH when this task is invoked directly via `mise run` (not through pnpm).
+set -e
+
 export PATH="./node_modules/.bin:$PATH"
 
 READY_PATH="_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson"
 REALM_HOST="${REALM_BASE_URL#http://}"
 
-# Wait for ALL 9 development realms to be indexed and ready.
+# Build readiness URLs for all enabled realms.
+# boxel-homepage is excluded: its source repo (cardstack/boxel-home) is private
+# and inaccessible to CI without extra credentials.
 READINESS_URLS=""
-for realm in base catalog external-catalog skills submissions boxel-homepage experiments openrouter software-factory; do
+for realm in base catalog external-catalog skills submissions experiments openrouter software-factory; do
   READINESS_URLS="${READINESS_URLS:+${READINESS_URLS}|}http-get://${REALM_HOST}/${realm}/${READY_PATH}"
 done
 READINESS_URLS="${READINESS_URLS}|${MATRIX_URL_VAL}|http://localhost:5001|${ICONS_URL}|${HOST_URL}"
 
-WAIT_ON_TIMEOUT=1800000 \
+echo "Starting services..."
+SKIP_BOXEL_HOMEPAGE=true \
   NODE_NO_WARNINGS=1 \
-  start-server-and-test \
-    'run-p -ln start:icons start:host-dist start:pg start:prerender-dev start:prerender-manager-dev start:matrix start:smtp start:worker-development start:development' \
-    "${READINESS_URLS}" \
-    'docker exec boxel-pg pg_dump -U postgres --data-only -t boxel_index -t boxel_index_working -t realm_versions -t realm_meta boxel | gzip > /tmp/boxel-index-cache.sql.gz && echo "Index cache created at /tmp/boxel-index-cache.sql.gz"'
+  run-p -ln start:icons start:host-dist start:pg start:prerender-dev start:prerender-manager-dev start:matrix start:smtp start:worker-development start:development &
+SERVICES_PID=$!
+
+cleanup() {
+  echo "Stopping services..."
+  kill $SERVICES_PID 2>/dev/null || true
+  wait $SERVICES_PID 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Register realm users with Matrix (waits for Synapse to be healthy).
+# Must happen while services are starting since the realm server needs
+# authenticated Matrix users.
+echo "Registering realm users..."
+pnpm --dir=../matrix register-realm-users
+
+echo "Waiting for realm readiness..."
+wait-on -t 1800000 $(echo "$READINESS_URLS" | tr '|' ' ')
+
+echo "All realms ready. Dumping index tables..."
+docker exec boxel-pg pg_dump -U postgres --data-only \
+  -t boxel_index -t boxel_index_working -t realm_versions -t realm_meta \
+  boxel | gzip > /tmp/boxel-index-cache.sql.gz
+
+echo "Index cache created at /tmp/boxel-index-cache.sql.gz"
+ls -lh /tmp/boxel-index-cache.sql.gz

--- a/mise-tasks/ci/cache-index
+++ b/mise-tasks/ci/cache-index
@@ -38,29 +38,7 @@ echo "Registering realm users..."
 pnpm --dir=../matrix register-realm-users
 
 echo "Waiting for realm readiness..."
-TIMEOUT=1800
-ELAPSED=0
-IFS='|'
-while [ $ELAPSED -lt $TIMEOUT ]; do
-  ALL_READY=true
-  for raw_url in $READINESS_URLS; do
-    url=$(echo "$raw_url" | sed 's|^http-get://|http://|')
-    if ! curl --output /dev/null --silent --fail "$url" 2>/dev/null; then
-      ALL_READY=false
-      break
-    fi
-  done
-  unset IFS
-  if $ALL_READY; then break; fi
-  sleep 5
-  ELAPSED=$((ELAPSED + 5))
-  IFS='|'
-done
-unset IFS
-if [ $ELAPSED -ge $TIMEOUT ]; then
-  echo "Timed out waiting for realm readiness after ${TIMEOUT}s"
-  exit 1
-fi
+npx wait-on -t 1800000 $(echo "$READINESS_URLS" | tr '|' ' ')
 
 echo "All realms ready. Dumping index tables..."
 docker exec boxel-pg pg_dump -U postgres --data-only \

--- a/mise-tasks/lib/dev-common.sh
+++ b/mise-tasks/lib/dev-common.sh
@@ -35,6 +35,10 @@ if [ -n "$BOXEL_ENVIRONMENT" ]; then
   "$REPO_ROOT/scripts/ensure-branch-db.sh"
   echo "Running database migrations…"
   pnpm migrate
-  "$REPO_ROOT/scripts/import-cached-index.sh" || true
+  if [ "${INDEX_CACHE:-}" = "true" ]; then
+    if "$REPO_ROOT/scripts/import-cached-index.sh"; then
+      export REALM_SERVER_FULL_INDEX_ON_STARTUP="${REALM_SERVER_FULL_INDEX_ON_STARTUP:-false}"
+    fi
+  fi
   ./scripts/start-matrix.sh
 fi

--- a/mise-tasks/lib/dev-common.sh
+++ b/mise-tasks/lib/dev-common.sh
@@ -3,6 +3,8 @@
 # Sourced (not executed) — sets variables and bootstraps infra.
 # Expects to run with MISE dir=packages/realm-server.
 
+export PATH="./node_modules/.bin:$PATH"
+
 READY_PATH="_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson"
 
 # Phase 1 readiness URLs

--- a/mise-tasks/lib/dev-common.sh
+++ b/mise-tasks/lib/dev-common.sh
@@ -35,5 +35,6 @@ if [ -n "$BOXEL_ENVIRONMENT" ]; then
   "$REPO_ROOT/scripts/ensure-branch-db.sh"
   echo "Running database migrations…"
   pnpm migrate
+  "$REPO_ROOT/scripts/import-cached-index.sh" || true
   ./scripts/start-matrix.sh
 fi

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -86,6 +86,7 @@
     "undici": "catalog:",
     "uuid": "catalog:",
     "wait-for-localhost-cli": "catalog:",
+    "wait-on": "^9.0.4",
     "yaml": "catalog:",
     "yargs": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2720,6 +2720,9 @@ importers:
       wait-for-localhost-cli:
         specifier: 'catalog:'
         version: 3.2.0
+      wait-on:
+        specifier: ^9.0.4
+        version: 9.0.4
       yaml:
         specifier: 'catalog:'
         version: 2.8.2
@@ -5035,11 +5038,31 @@ packages:
     resolution: {integrity: sha512-n/SZW+12rwikx/f8YcSv9JCi5p9vn1Bnts9ZtVvfErG4h0gbjHI1H1ZMhVUnaOC7yzFc6PtsCKIK8XeTnL90Gw==}
     engines: {node: ^18 || ^20 || ^22 || >=24}
 
+  '@hapi/address@5.1.1':
+    resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
+    engines: {node: '>=14.0.0'}
+
+  '@hapi/formula@3.0.2':
+    resolution: {integrity: sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==}
+
+  '@hapi/hoek@11.0.7':
+    resolution: {integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==}
+
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
 
+  '@hapi/pinpoint@2.0.1':
+    resolution: {integrity: sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==}
+
+  '@hapi/tlds@1.1.6':
+    resolution: {integrity: sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==}
+    engines: {node: '>=14.0.0'}
+
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
+
+  '@hapi/topo@6.0.2':
+    resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -6057,6 +6080,9 @@ packages:
   '@sqlite.org/sqlite-wasm@3.45.1-build1':
     resolution: {integrity: sha512-1EgshFNhVeBtZ9KtQPm3PzzJ2CtpmXAq2DAPywy7WZ3gOK6p5n8TY+M+mBMpQCF5cLqrdNFb3Kp9uNie9rUAHw==}
     hasBin: true
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@szmarczak/http-timer@1.1.2':
     resolution: {integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==}
@@ -7181,6 +7207,9 @@ packages:
 
   axios@0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
+
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   azure-devops-node-api@12.5.0:
     resolution: {integrity: sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==}
@@ -11201,6 +11230,10 @@ packages:
   joi@17.13.3:
     resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
 
+  joi@18.1.2:
+    resolution: {integrity: sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==}
+    engines: {node: '>= 20'}
+
   js-string-escape@1.0.1:
     resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
     engines: {node: '>= 0.8'}
@@ -11540,6 +11573,9 @@ packages:
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@2.2.0:
     resolution: {integrity: sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==}
@@ -12843,6 +12879,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   ps-tree@1.2.0:
     resolution: {integrity: sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==}
@@ -14675,6 +14715,11 @@ packages:
   wait-on@7.0.1:
     resolution: {integrity: sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==}
     engines: {node: '>=12.0.0'}
+    hasBin: true
+
+  wait-on@9.0.4:
+    resolution: {integrity: sha512-k8qrgfwrPVJXTeFY8tl6BxVHiclK11u72DVKhpybHfUL/K6KM4bdyK9EhIVYGytB5MJe/3lq4Tf0hrjM+pvJZQ==}
+    engines: {node: '>=20.0.0'}
     hasBin: true
 
   walk-sync@0.2.7:
@@ -17073,11 +17118,27 @@ snapshots:
 
   '@handlebars/parser@2.2.2': {}
 
+  '@hapi/address@5.1.1':
+    dependencies:
+      '@hapi/hoek': 11.0.7
+
+  '@hapi/formula@3.0.2': {}
+
+  '@hapi/hoek@11.0.7': {}
+
   '@hapi/hoek@9.3.0': {}
+
+  '@hapi/pinpoint@2.0.1': {}
+
+  '@hapi/tlds@1.1.6': {}
 
   '@hapi/topo@5.1.0':
     dependencies:
       '@hapi/hoek': 9.3.0
+
+  '@hapi/topo@6.0.2':
+    dependencies:
+      '@hapi/hoek': 11.0.7
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -18303,6 +18364,8 @@ snapshots:
   '@socket.io/component-emitter@3.1.2': {}
 
   '@sqlite.org/sqlite-wasm@3.45.1-build1': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@szmarczak/http-timer@1.1.2':
     dependencies:
@@ -19659,6 +19722,14 @@ snapshots:
     dependencies:
       follow-redirects: 1.15.11(debug@4.3.4)
       form-data: 4.0.5
+    transitivePeerDependencies:
+      - debug
+
+  axios@1.15.0:
+    dependencies:
+      follow-redirects: 1.15.11(debug@4.3.4)
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -25336,6 +25407,16 @@ snapshots:
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
 
+  joi@18.1.2:
+    dependencies:
+      '@hapi/address': 5.1.1
+      '@hapi/formula': 3.0.2
+      '@hapi/hoek': 11.0.7
+      '@hapi/pinpoint': 2.0.1
+      '@hapi/tlds': 1.1.6
+      '@hapi/topo': 6.0.2
+      '@standard-schema/spec': 1.1.0
+
   js-string-escape@1.0.1: {}
 
   js-tokens@4.0.0: {}
@@ -25731,6 +25812,8 @@ snapshots:
   lodash.upperfirst@4.3.1: {}
 
   lodash@4.17.21: {}
+
+  lodash@4.18.1: {}
 
   log-symbols@2.2.0:
     dependencies:
@@ -27080,6 +27163,8 @@ snapshots:
       - supports-color
 
   proxy-from-env@1.1.0: {}
+
+  proxy-from-env@2.1.0: {}
 
   ps-tree@1.2.0:
     dependencies:
@@ -29374,6 +29459,16 @@ snapshots:
       axios: 0.27.2(debug@4.3.4)
       joi: 17.13.3
       lodash: 4.17.21
+      minimist: 1.2.8
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - debug
+
+  wait-on@9.0.4:
+    dependencies:
+      axios: 1.15.0
+      joi: 18.1.2
+      lodash: 4.18.1
       minimist: 1.2.8
       rxjs: 7.8.2
     transitivePeerDependencies:

--- a/scripts/import-cached-index.sh
+++ b/scripts/import-cached-index.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Downloads and imports the cached boxel_index tables from a recent CI build.
-# Best-effort: exits 0 on any failure so the normal startup flow continues.
-# Called from mise-tasks/lib/dev-common.sh after migrations have run.
+# Exits 0 on success, 1 on failure. The caller uses the exit code to decide
+# whether to set REALM_SERVER_FULL_INDEX_ON_STARTUP=false.
 
 set -u
 
@@ -24,35 +24,37 @@ ROW_COUNT=$(docker exec boxel-pg psql -U postgres -d "$DB_NAME" -tAc \
   "SELECT COUNT(*) FROM realm_versions" 2>/dev/null) || ROW_COUNT=""
 if [ -n "$ROW_COUNT" ] && [ "$ROW_COUNT" -gt 0 ] 2>/dev/null; then
   echo "Database already has index data ($ROW_COUNT realm versions), skipping cache import."
-  exit 0
+  exit 1
 fi
 
 # Require gh CLI
 if ! command -v gh >/dev/null 2>&1; then
   echo "gh CLI not found, skipping index cache import."
-  exit 0
+  exit 1
 fi
 
-# Find the latest successful CI run on main
+# Find the latest CI run that produced the cache artifact.
+# Uses gh to search for the artifact directly — this works regardless of which
+# branch produced it.
 echo "Looking for cached index from CI..."
-RUN_ID=$(gh run list -w ci.yaml -b main -s success -L 1 \
-  --json databaseId -q '.[0].databaseId' -R "$REPO" 2>/dev/null) || RUN_ID=""
+RUN_ID=$(gh api "repos/$REPO/actions/artifacts?name=$ARTIFACT_NAME&per_page=1" \
+  --jq '.artifacts[0].workflow_run.id // empty' 2>/dev/null) || RUN_ID=""
 if [ -z "$RUN_ID" ]; then
-  echo "No successful CI run found on main, skipping index cache import."
-  exit 0
+  echo "No CI run with index cache found, skipping."
+  exit 1
 fi
 
 # Download the artifact
 echo "Downloading index cache from CI run $RUN_ID..."
 if ! gh run download "$RUN_ID" -n "$ARTIFACT_NAME" -D "$DOWNLOAD_DIR" -R "$REPO" 2>/dev/null; then
   echo "Failed to download index cache artifact, skipping."
-  exit 0
+  exit 1
 fi
 
 CACHE_FILE="$DOWNLOAD_DIR/boxel-index-cache.sql.gz"
 if [ ! -f "$CACHE_FILE" ]; then
   echo "Cache file not found in artifact, skipping."
-  exit 0
+  exit 1
 fi
 
 # Build the import pipeline.
@@ -60,9 +62,11 @@ fi
 # to the environment's Traefik hostname.
 if [ -n "${BOXEL_ENVIRONMENT:-}" ]; then
   SLUG=$(compute_env_slug "$BOXEL_ENVIRONMENT")
-  echo "Remapping URLs: localhost:4201 -> realm-server.${SLUG}.localhost"
+  echo "Remapping URLs for environment '${SLUG}'..."
   gunzip -c "$CACHE_FILE" \
-    | sed "s|http://localhost:4201|http://realm-server.${SLUG}.localhost|g" \
+    | sed \
+      -e "s|http://localhost:4201|http://realm-server.${SLUG}.localhost|g" \
+      -e "s|http://localhost:4206|http://icons.${SLUG}.localhost|g" \
     | docker exec -i boxel-pg psql -U postgres -d "$DB_NAME" --quiet --no-psqlrc
 else
   gunzip -c "$CACHE_FILE" \
@@ -72,8 +76,8 @@ fi
 IMPORT_STATUS=$?
 if [ $IMPORT_STATUS -eq 0 ]; then
   echo "Index cache imported successfully."
+  exit 0
 else
   echo "Index cache import had errors (status $IMPORT_STATUS), server will reindex as needed."
+  exit 1
 fi
-
-exit 0

--- a/scripts/import-cached-index.sh
+++ b/scripts/import-cached-index.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# Downloads and imports the cached boxel_index tables from a recent CI build.
+# Best-effort: exits 0 on any failure so the normal startup flow continues.
+# Called from mise-tasks/lib/dev-common.sh after migrations have run.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/env-slug.sh"
+
+DB_NAME="${PGDATABASE:-boxel}"
+PG_PORT="${PGPORT:-5435}"
+REPO="cardstack/boxel"
+ARTIFACT_NAME="boxel-index-cache"
+DOWNLOAD_DIR="/tmp/boxel-index-cache-$$"
+
+cleanup() {
+  rm -rf "$DOWNLOAD_DIR"
+}
+trap cleanup EXIT
+
+# Check if the database already has index data — if so, skip.
+ROW_COUNT=$(docker exec boxel-pg psql -U postgres -d "$DB_NAME" -tAc \
+  "SELECT COUNT(*) FROM realm_versions" 2>/dev/null) || ROW_COUNT=""
+if [ -n "$ROW_COUNT" ] && [ "$ROW_COUNT" -gt 0 ] 2>/dev/null; then
+  echo "Database already has index data ($ROW_COUNT realm versions), skipping cache import."
+  exit 0
+fi
+
+# Require gh CLI
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI not found, skipping index cache import."
+  exit 0
+fi
+
+# Find the latest successful CI run on main
+echo "Looking for cached index from CI..."
+RUN_ID=$(gh run list -w ci.yaml -b main -s success -L 1 \
+  --json databaseId -q '.[0].databaseId' -R "$REPO" 2>/dev/null) || RUN_ID=""
+if [ -z "$RUN_ID" ]; then
+  echo "No successful CI run found on main, skipping index cache import."
+  exit 0
+fi
+
+# Download the artifact
+echo "Downloading index cache from CI run $RUN_ID..."
+if ! gh run download "$RUN_ID" -n "$ARTIFACT_NAME" -D "$DOWNLOAD_DIR" -R "$REPO" 2>/dev/null; then
+  echo "Failed to download index cache artifact, skipping."
+  exit 0
+fi
+
+CACHE_FILE="$DOWNLOAD_DIR/boxel-index-cache.sql.gz"
+if [ ! -f "$CACHE_FILE" ]; then
+  echo "Cache file not found in artifact, skipping."
+  exit 0
+fi
+
+# Build the import pipeline.
+# In BOXEL_ENVIRONMENT mode, remap URLs from CI standard mode (localhost:4201)
+# to the environment's Traefik hostname.
+if [ -n "${BOXEL_ENVIRONMENT:-}" ]; then
+  SLUG=$(compute_env_slug "$BOXEL_ENVIRONMENT")
+  echo "Remapping URLs: localhost:4201 -> realm-server.${SLUG}.localhost"
+  gunzip -c "$CACHE_FILE" \
+    | sed "s|http://localhost:4201|http://realm-server.${SLUG}.localhost|g" \
+    | docker exec -i boxel-pg psql -U postgres -d "$DB_NAME" --quiet --no-psqlrc
+else
+  gunzip -c "$CACHE_FILE" \
+    | docker exec -i boxel-pg psql -U postgres -d "$DB_NAME" --quiet --no-psqlrc
+fi
+
+IMPORT_STATUS=$?
+if [ $IMPORT_STATUS -eq 0 ]; then
+  echo "Index cache imported successfully."
+else
+  echo "Index cache import had errors (status $IMPORT_STATUS), server will reindex as needed."
+fi
+
+exit 0

--- a/scripts/import-cached-index.sh
+++ b/scripts/import-cached-index.sh
@@ -33,12 +33,10 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 1
 fi
 
-# Find the latest CI run that produced the cache artifact.
-# Uses gh to search for the artifact directly — this works regardless of which
-# branch produced it.
+# Find the latest successful CI run on main that produced the cache artifact.
 echo "Looking for cached index from CI..."
-RUN_ID=$(gh api "repos/$REPO/actions/artifacts?name=$ARTIFACT_NAME&per_page=1" \
-  --jq '.artifacts[0].workflow_run.id // empty' 2>/dev/null) || RUN_ID=""
+RUN_ID=$(gh run list -w ci.yaml -b main -s success -L 1 \
+  --json databaseId -q '.[0].databaseId' -R "$REPO" 2>/dev/null) || RUN_ID=""
 if [ -z "$RUN_ID" ]; then
   echo "No CI run with index cache found, skipping."
   exit 1

--- a/scripts/import-cached-index.sh
+++ b/scripts/import-cached-index.sh
@@ -33,10 +33,12 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 1
 fi
 
-# Find the latest successful CI run on main that produced the cache artifact.
+# Find the latest CI run that produced the cache artifact.
+# Uses gh to search for the artifact directly — this works regardless of which
+# branch produced it.
 echo "Looking for cached index from CI..."
-RUN_ID=$(gh run list -w ci.yaml -b main -s success -L 1 \
-  --json databaseId -q '.[0].databaseId' -R "$REPO" 2>/dev/null) || RUN_ID=""
+RUN_ID=$(gh api "repos/$REPO/actions/artifacts?name=$ARTIFACT_NAME&per_page=1" \
+  --jq '.artifacts[0].workflow_run.id // empty' 2>/dev/null) || RUN_ID=""
 if [ -z "$RUN_ID" ]; then
   echo "No CI run with index cache found, skipping."
   exit 1

--- a/scripts/import-cached-index.sh
+++ b/scripts/import-cached-index.sh
@@ -1,15 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 # Downloads and imports the cached boxel_index tables from a recent CI build.
-# Exits 0 on success, 1 on failure. The caller uses the exit code to decide
-# whether to set REALM_SERVER_FULL_INDEX_ON_STARTUP=false.
+# Exits 0 on success or when import is unnecessary (DB already has data).
+# Exits 1 on failure. The caller uses the exit code to decide whether to
+# set REALM_SERVER_FULL_INDEX_ON_STARTUP=false.
 
-set -u
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPT_DIR/env-slug.sh"
 
 DB_NAME="${PGDATABASE:-boxel}"
-PG_PORT="${PGPORT:-5435}"
 REPO="cardstack/boxel"
 ARTIFACT_NAME="boxel-index-cache"
 DOWNLOAD_DIR="/tmp/boxel-index-cache-$$"
@@ -24,7 +24,7 @@ ROW_COUNT=$(docker exec boxel-pg psql -U postgres -d "$DB_NAME" -tAc \
   "SELECT COUNT(*) FROM realm_versions" 2>/dev/null) || ROW_COUNT=""
 if [ -n "$ROW_COUNT" ] && [ "$ROW_COUNT" -gt 0 ] 2>/dev/null; then
   echo "Database already has index data ($ROW_COUNT realm versions), skipping cache import."
-  exit 1
+  exit 0
 fi
 
 # Require gh CLI
@@ -55,9 +55,10 @@ if [ ! -f "$CACHE_FILE" ]; then
   exit 1
 fi
 
-# Build the import pipeline.
+# Import the cache into the local database.
 # In BOXEL_ENVIRONMENT mode, remap URLs from CI standard mode (localhost:4201)
 # to the environment's Traefik hostname.
+PSQL_OPTS="-U postgres -d $DB_NAME --quiet --no-psqlrc -v ON_ERROR_STOP=1"
 if [ -n "${BOXEL_ENVIRONMENT:-}" ]; then
   SLUG=$(compute_env_slug "$BOXEL_ENVIRONMENT")
   echo "Remapping URLs for environment '${SLUG}'..."
@@ -65,17 +66,10 @@ if [ -n "${BOXEL_ENVIRONMENT:-}" ]; then
     | sed \
       -e "s|http://localhost:4201|http://realm-server.${SLUG}.localhost|g" \
       -e "s|http://localhost:4206|http://icons.${SLUG}.localhost|g" \
-    | docker exec -i boxel-pg psql -U postgres -d "$DB_NAME" --quiet --no-psqlrc
+    | docker exec -i boxel-pg psql $PSQL_OPTS
 else
   gunzip -c "$CACHE_FILE" \
-    | docker exec -i boxel-pg psql -U postgres -d "$DB_NAME" --quiet --no-psqlrc
+    | docker exec -i boxel-pg psql $PSQL_OPTS
 fi
 
-IMPORT_STATUS=$?
-if [ $IMPORT_STATUS -eq 0 ]; then
-  echo "Index cache imported successfully."
-  exit 0
-else
-  echo "Index cache import had errors (status $IMPORT_STATUS), server will reindex as needed."
-  exit 1
-fi
+echo "Index cache imported successfully."


### PR DESCRIPTION
This adds a CI job on `main` that indexes built-in realms and stores an SQL dump of them for use in development. Adding `INDEX_CACHE` with `mise run dev` or `…dev-all` opts into this feature. This facilitates reviewing PRs locally that need the catalog or other large realms, which otherwise take 20+ minutes to index for me.

Here you see me running off an earlier commit (`5ab4d6a20`, if you want to try it yourself) where the script to download the cache would fetch the artifact from this branch instead of `main`, where it doesn’t yet exist:

https://github.com/user-attachments/assets/ea0e112a-1160-4072-90f6-6e89f5584599

I had the `host` application running in another tab to remove the build time from the video.
