### PR TITLE
Add string-to-content serializer for composite field migration

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -509,7 +509,7 @@ function cardTypeFor(
 function assertNoDeserializeOverride(cardClass: typeof BaseDef) {
   if (
     !(primitive in cardClass) &&
-    cardClass.hasOwnProperty(deserialize)
+    Object.prototype.hasOwnProperty.call(cardClass, deserialize)
   ) {
     throw new Error(
       `${cardClass.name} overrides [deserialize] directly. Composite fields must use a registered fieldSerializer instead.`,

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -506,6 +506,17 @@ function cardTypeFor(
     .constructor as typeof BaseDef;
 }
 
+function assertNoDeserializeOverride(cardClass: typeof BaseDef) {
+  if (
+    !(primitive in cardClass) &&
+    cardClass.hasOwnProperty(deserialize)
+  ) {
+    throw new Error(
+      `${cardClass.name} overrides [deserialize] directly. Composite fields must use a registered fieldSerializer instead.`,
+    );
+  }
+}
+
 class ContainsMany<FieldT extends FieldDefConstructor> implements Field<
   FieldT,
   any[] | null
@@ -756,9 +767,19 @@ class ContainsMany<FieldT extends FieldDefConstructor> implements Field<
                   }),
               );
             }
-            return (
-              await cardClassFromResource(resource, this.card, relativeTo)
-            )[deserialize](resource, relativeTo, doc, store, opts);
+            let cardClass = await cardClassFromResource(
+              resource,
+              this.card,
+              relativeTo,
+            );
+            assertNoDeserializeOverride(cardClass);
+            return cardClass[deserialize](
+              resource,
+              relativeTo,
+              doc,
+              store,
+              opts,
+            );
           }
         }),
       ),
@@ -999,9 +1020,13 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
           ]),
       );
     }
-    return (await cardClassFromResource(resource, this.card, relativeTo))[
-      deserialize
-    ](resource, relativeTo, doc, store, opts);
+    let cardClass = await cardClassFromResource(
+      resource,
+      this.card,
+      relativeTo,
+    );
+    assertNoDeserializeOverride(cardClass);
+    return cardClass[deserialize](resource, relativeTo, doc, store, opts);
   }
 
   emptyValue(_instance: BaseDef) {
@@ -2202,14 +2227,6 @@ export class BaseDef {
   ): Promise<BaseInstanceType<T>> {
     if (primitive in this) {
       return data;
-    }
-    if (
-      this.hasOwnProperty(deserialize) &&
-      this !== (BaseDef as unknown as T)
-    ) {
-      throw new Error(
-        `${this.name} overrides [deserialize] directly. Composite fields must use a registered fieldSerializer instead.`,
-      );
     }
     return _createFromSerialized(this, data, doc, relativeTo, store, opts);
   }

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -723,6 +723,17 @@ class ContainsMany<FieldT extends FieldDefConstructor> implements Field<
             }
             return entry;
           } else {
+            if (fieldSerializer in this.card) {
+              assertIsSerializerName(this.card[fieldSerializer]);
+              let serializer = getSerializer(this.card[fieldSerializer]);
+              entry = await serializer.deserialize(
+                entry,
+                relativeTo,
+                doc,
+                store,
+                opts,
+              );
+            }
             let meta = metas[index];
             let resource: LooseCardResource = {
               attributes: entry,
@@ -958,6 +969,11 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
         return serializer.deserialize(value, relativeTo, doc, store, opts);
       }
       return value;
+    }
+    if (fieldSerializer in this.card) {
+      assertIsSerializerName(this.card[fieldSerializer]);
+      let serializer = getSerializer(this.card[fieldSerializer]);
+      value = await serializer.deserialize(value, relativeTo, doc, store, opts);
     }
     if (fieldMeta && Array.isArray(fieldMeta)) {
       throw new Error(
@@ -2186,6 +2202,14 @@ export class BaseDef {
   ): Promise<BaseInstanceType<T>> {
     if (primitive in this) {
       return data;
+    }
+    if (
+      this.hasOwnProperty(deserialize) &&
+      this !== (BaseDef as unknown as T)
+    ) {
+      throw new Error(
+        `${this.name} overrides [deserialize] directly. Composite fields must use a registered fieldSerializer instead.`,
+      );
     }
     return _createFromSerialized(this, data, doc, relativeTo, store, opts);
   }

--- a/packages/base/rich-markdown.gts
+++ b/packages/base/rich-markdown.gts
@@ -1,5 +1,6 @@
 import {
   extractCardReferenceUrls,
+  fieldSerializer,
   relativeTo,
 } from '@cardstack/runtime-common';
 
@@ -35,6 +36,7 @@ import MarkdownTemplate from './default-templates/markdown';
  */
 export class RichMarkdownField extends FieldDef {
   static displayName = 'Rich Markdown';
+  static [fieldSerializer] = 'string-to-content' as const;
 
   /** The raw markdown text. Uses MarkdownField for textarea edit UI. */
   @field content = contains(MarkdownField);

--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -17,6 +17,7 @@ import type {
 } from '@cardstack/runtime-common';
 import {
   baseRealm,
+  fieldSerializer,
   fields,
   isSingleCardDocument,
   localId,
@@ -66,6 +67,8 @@ import {
   BigIntegerField,
   getQueryableValue,
   EthereumAddressField,
+  RichMarkdownField,
+  MarkdownField,
   getFields,
 } from '../../helpers/base-realm';
 
@@ -7698,6 +7701,171 @@ module('Integration | serialization', function (hooks) {
           getQueryableValue(EthereumAddressField, undefined),
           undefined,
         );
+      });
+    });
+
+    module('string-to-content serializer', function () {
+      test('can deserialize a composite field from a plain string (migration path)', async function (assert) {
+        class Post extends CardDef {
+          @field cardTitle = contains(StringField);
+          @field body = contains(RichMarkdownField);
+        }
+        await setupIntegrationTestRealm({
+          mockMatrixUtils,
+          contents: {
+            'test-cards.gts': { Post },
+          },
+        });
+
+        // Old MarkdownField format: body is a plain string
+        let resource = {
+          attributes: {
+            cardTitle: 'Migration Test',
+            body: '# Hello World\n\nSome **bold** text.',
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${testRealmURL}test-cards`,
+              name: 'Post',
+            },
+          },
+        };
+        let post = await createFromSerialized<typeof Post>(
+          resource,
+          { data: resource },
+          undefined,
+        );
+
+        assert.strictEqual(
+          post.body.content,
+          '# Hello World\n\nSome **bold** text.',
+          'content is correctly deserialized from plain string',
+        );
+      });
+
+      test('can deserialize a composite field from an object with content property (normal path)', async function (assert) {
+        class Post extends CardDef {
+          @field cardTitle = contains(StringField);
+          @field body = contains(RichMarkdownField);
+        }
+        await setupIntegrationTestRealm({
+          mockMatrixUtils,
+          contents: {
+            'test-cards.gts': { Post },
+          },
+        });
+
+        // New RichMarkdownField format: body is an object with content
+        let resource = {
+          attributes: {
+            cardTitle: 'Normal Test',
+            body: {
+              content: '# Hello World\n\nSome **bold** text.',
+            },
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${testRealmURL}test-cards`,
+              name: 'Post',
+            },
+          },
+        };
+        let post = await createFromSerialized<typeof Post>(
+          resource,
+          { data: resource },
+          undefined,
+        );
+
+        assert.strictEqual(
+          post.body.content,
+          '# Hello World\n\nSome **bold** text.',
+          'content is correctly deserialized from object',
+        );
+      });
+
+      test('can deserialize null value for a field with string-to-content serializer', async function (assert) {
+        class Post extends CardDef {
+          @field cardTitle = contains(StringField);
+          @field body = contains(RichMarkdownField);
+        }
+        await setupIntegrationTestRealm({
+          mockMatrixUtils,
+          contents: {
+            'test-cards.gts': { Post },
+          },
+        });
+
+        let resource = {
+          attributes: {
+            cardTitle: 'Null Test',
+            body: null,
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${testRealmURL}test-cards`,
+              name: 'Post',
+            },
+          },
+        };
+        let post = await createFromSerialized<typeof Post>(
+          resource,
+          { data: resource },
+          undefined,
+        );
+
+        assert.strictEqual(
+          post.body.content,
+          null,
+          'content is null when body is null',
+        );
+      });
+
+      test('composite field with [deserialize] override throws an error', async function (assert) {
+        let deserializeSymbol = Symbol.for('cardstack-deserialize');
+
+        class BadField extends FieldDef {
+          @field content = contains(StringField);
+          static async [deserializeSymbol]() {
+            return {};
+          }
+        }
+        class Post extends CardDef {
+          @field cardTitle = contains(StringField);
+          @field body = contains(BadField);
+        }
+        await setupIntegrationTestRealm({
+          mockMatrixUtils,
+          contents: {
+            'test-cards.gts': { BadField, Post },
+          },
+        });
+
+        let resource = {
+          attributes: {
+            cardTitle: 'Lockdown Test',
+            body: { content: 'hello' },
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${testRealmURL}test-cards`,
+              name: 'Post',
+            },
+          },
+        };
+
+        try {
+          await createFromSerialized<typeof Post>(
+            resource,
+            { data: resource },
+            undefined,
+          );
+          assert.ok(false, 'should have thrown an error');
+        } catch (e: any) {
+          assert.ok(
+            e.message.includes('overrides [deserialize] directly'),
+            `error message is correct: ${e.message}`,
+          );
+        }
       });
     });
   });

--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -17,7 +17,6 @@ import type {
 } from '@cardstack/runtime-common';
 import {
   baseRealm,
-  fieldSerializer,
   fields,
   isSingleCardDocument,
   localId,
@@ -68,7 +67,6 @@ import {
   getQueryableValue,
   EthereumAddressField,
   RichMarkdownField,
-  MarkdownField,
   getFields,
 } from '../../helpers/base-realm';
 
@@ -7815,8 +7813,8 @@ module('Integration | serialization', function (hooks) {
 
         assert.strictEqual(
           post.body.content,
-          null,
-          'content is null when body is null',
+          undefined,
+          'content is undefined when body is null',
         );
       });
 

--- a/packages/runtime-common/serializers/index.ts
+++ b/packages/runtime-common/serializers/index.ts
@@ -9,6 +9,7 @@ import * as NumberSerializer from './number';
 import * as EmailSerializer from './email';
 import * as ImageSizeSerializer from './image-size';
 import * as PhoneSerializer from './phone';
+import * as StringToContentSerializer from './string-to-content';
 
 import type { CardDocument } from '../index';
 import type {
@@ -33,6 +34,7 @@ export {
   ImageSizeSerializer,
   EmailSerializer,
   PhoneSerializer,
+  StringToContentSerializer,
 };
 
 interface Serializer {
@@ -65,6 +67,7 @@ const serializerMapping: { [name: string]: Serializer } = {
   'image-size': ImageSizeSerializer,
   email: EmailSerializer,
   phone: PhoneSerializer,
+  'string-to-content': StringToContentSerializer,
 };
 
 export type SerializerName =
@@ -78,7 +81,8 @@ export type SerializerName =
   | 'number'
   | 'image-size'
   | 'email'
-  | 'phone';
+  | 'phone'
+  | 'string-to-content';
 
 export function getSerializer(name: SerializerName): Serializer {
   assertIsSerializerName(name);

--- a/packages/runtime-common/serializers/string-to-content.ts
+++ b/packages/runtime-common/serializers/string-to-content.ts
@@ -1,0 +1,34 @@
+import type {
+  BaseDefConstructor,
+  BaseInstanceType,
+} from 'https://cardstack.com/base/card-api';
+
+/**
+ * A migration serializer for composite fields that replace a primitive
+ * StringField where the string value maps to a `content` sub-field.
+ *
+ * Deserialization accepts either:
+ *   - a plain string (old format) → normalizes to `{ content: <string> }`
+ *   - an object (new format) → passes through as-is
+ *
+ * Serialization and queryableValue delegate to the default composite behavior
+ * (this serializer is only needed for the deserialization migration path).
+ */
+
+export function serialize(val: any): any {
+  return val;
+}
+
+export async function deserialize<T extends BaseDefConstructor>(
+  this: T,
+  val: any,
+): Promise<BaseInstanceType<T>> {
+  if (typeof val === 'string') {
+    return { content: val } as BaseInstanceType<T>;
+  }
+  return val;
+}
+
+export function queryableValue(val: any): any {
+  return val;
+}

--- a/packages/runtime-common/serializers/string-to-content.ts
+++ b/packages/runtime-common/serializers/string-to-content.ts
@@ -26,6 +26,9 @@ export async function deserialize<T extends BaseDefConstructor>(
   if (typeof val === 'string') {
     return { content: val } as BaseInstanceType<T>;
   }
+  if (val == null) {
+    return {} as BaseInstanceType<T>;
+  }
   return val;
 }
 


### PR DESCRIPTION
## Summary

- Adds a generic `string-to-content` built-in serializer that normalizes plain string values to `{ content: <string> }` during deserialization, enabling migration from primitive `StringField`-based fields to composite `FieldDef`-based fields
- Extends `fieldSerializer` support to composite fields in both `Contains` and `ContainsMany` deserialization paths (previously gated behind `primitive in this.card`)
- Locks down `[deserialize]` override on composite fields with a runtime check — composite fields must use registered serializers instead of overriding deserialization directly
- Wires up `RichMarkdownField` with `static [fieldSerializer] = 'string-to-content'` so it can accept data in both old `MarkdownField` format (plain string) and new format (object with `content` property)

## Test plan

- [ ] Deserialize `RichMarkdownField` from a plain string (migration path)
- [ ] Deserialize `RichMarkdownField` from an object with `content` property (normal path)
- [ ] Deserialize `null` value for field with `string-to-content` serializer
- [ ] Verify composite field with `[deserialize]` override throws runtime error
- [ ] Verify existing serialization tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)