### PR TITLE
Add prepare-worktree-types script for worktree lint

### DIFF
--- a/mise-tasks/build/worktree-types
+++ b/mise-tasks/build/worktree-types
@@ -1,0 +1,12 @@
+#!/bin/sh
+#MISE description="Build type declarations needed for lint in fresh git worktrees"
+
+set -eu
+
+echo "Building @cardstack/boxel-icons..."
+pnpm --dir packages/boxel-icons build
+
+echo "Building @cardstack/boxel-ui type declarations..."
+pnpm --dir packages/boxel-ui/addon build:types
+
+echo "Done — worktree type declarations are ready for pnpm lint"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "deploy:boxel-ui:preview-staging": "pnpm run build-common-deps && cd packages/boxel-ui/test-app && pnpm exec ember deploy s3-preview-staging --verbose",
     "lint": "pnpm run --filter './packages/**' --if-present -r lint",
     "lint:fix": "pnpm run --filter './packages/**' --if-present -r lint:fix",
-    "openrouter:sync": "OPENROUTER_REALM_URL=${OPENROUTER_REALM_URL:-http://localhost:4201/openrouter/} pnpm --filter @cardstack/realm-server sync-openrouter-models"
+    "openrouter:sync": "OPENROUTER_REALM_URL=${OPENROUTER_REALM_URL:-http://localhost:4201/openrouter/} pnpm --filter @cardstack/realm-server sync-openrouter-models",
+    "prepare-worktree-types": "pnpm --filter @cardstack/boxel-icons build && pnpm --filter @cardstack/boxel-ui build:types"
   },
   "pnpm": {
     "allowedDeprecatedVersions": {

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -886,7 +886,7 @@ export function createPrerenderHttpServer(options?: {
     } catch (e: any) {
       log.warn('Error closing server during fatal shutdown:', e);
     }
-    setTimeout(() => process.exit(1), 100).unref();
+    setTimeout(() => process.exit(1), 100);
   }
 
   const uncaughtExceptionHandler = (err: unknown) =>


### PR DESCRIPTION
## Problem

When running `pnpm lint` in a git worktree (e.g. `.claude/worktrees/`), TypeScript type checks fail with hundreds of `TS2307: Cannot find module '@cardstack/boxel-icons/*'` errors and similar failures for `@cardstack/boxel-ui` imports.

This happens because `boxel-icons` and `boxel-ui/addon` have their `declarations/` and `dist/` directories in `.gitignore` — they're **build artifacts** that exist in the main repo from prior builds but are missing in fresh worktrees. Other packages depend on these for type resolution via the `exports` and `typesVersions` fields in `package.json`.

**Affected packages:**
| Package | Missing artifacts |
|---------|------------------|
| `packages/boxel-icons` | `declarations/`, `dist/` |
| `packages/boxel-ui/addon` | `declarations/` |

## Solution

Added two ways to build just the type declarations needed before running lint in a worktree:

- **pnpm script:** `pnpm prepare-worktree-types`
- **mise task:** `mise run build:worktree-types`

Both run:
1. Full build of `@cardstack/boxel-icons` (types + JS, since the `exports` field references both `dist/` and `declarations/`)
2. Type-only build of `@cardstack/boxel-ui` (`build:types`)

### Usage

After `pnpm install` in a fresh worktree:
```bash
pnpm prepare-worktree-types
# or
mise run build:worktree-types
```

Then `pnpm lint` passes.

## Also fixed: prerender `handleFatal` exit code

While investigating a flaky CI failure in `factory-bootstrap.spec.ts` (`prerender server exited before it became ready (code: 0, signal: null)`), we found that `handleFatal` in `prerender-app.ts` used `setTimeout(() => process.exit(1), 100).unref()`. The `.unref()` allowed the event loop to drain before the timer fired, so when the prerender server hit a fatal error like `EADDRINUSE` (port conflict), it exited with code 0 instead of 1 — masking the real error. Removed `.unref()` so `process.exit(1)` actually fires.

## Test plan

- [x] Created a fresh worktree, confirmed `pnpm lint` fails without build artifacts
- [x] Ran `pnpm prepare-worktree-types`, confirmed it completes successfully
- [x] Ran `pnpm lint` after, confirmed all type checks pass (only pre-existing `openrouter-realm` failure remains, which is broken on main too)
- [x] Verified `handleFatal` fix by tracing the CI log showing EADDRINUSE → code 0 exit path

🤖 Generated with [Claude Code](https://claude.com/claude-code)