### PR TITLE
Fix openrouter-realm lint by adding missing concurrently dep

### DIFF
--- a/packages/openrouter-realm/package.json
+++ b/packages/openrouter-realm/package.json
@@ -8,6 +8,7 @@
     "@cardstack/boxel-ui": "workspace:*",
     "@cardstack/local-types": "workspace:*",
     "@cardstack/runtime-common": "workspace:*",
+    "concurrently": "catalog:",
     "ember-template-lint": "catalog:"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2424,6 +2424,9 @@ importers:
       '@cardstack/runtime-common':
         specifier: workspace:*
         version: link:../runtime-common
+      concurrently:
+        specifier: 'catalog:'
+        version: 8.2.2
       ember-template-lint:
         specifier: 'catalog:'
         version: 7.9.3


### PR DESCRIPTION
## Summary
- `openrouter-realm`'s lint script uses `concurrently` but it wasn't listed as a devDependency, causing `pnpm lint` to always fail for that package with `sh: 1: concurrently: not found` (exit code 1).
- Every other package in the monorepo that uses `concurrently` has it listed as `"concurrently": "catalog:"` in devDependencies.
- This adds the missing dep so `pnpm --filter @cardstack/openrouter-realm lint` succeeds.

## Test plan
- [x] `pnpm --filter @cardstack/openrouter-realm lint` passes (was failing before)
- [x] `pnpm install` updates lockfile cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)