### PR TITLE
ci: Fix incorrect cancellation and host reporting

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -318,7 +318,7 @@ jobs:
 
   host-merge-reports-and-publish:
     name: Merge Host reports and publish
-    if: ${{ !cancelled() && needs.host-test.result != 'skipped' }}
+    if: ${{ !cancelled() && (needs.host-test.result == 'success' || needs.host-test.result == 'failure') }}
     concurrency:
       group: host-merge-reports-and-publish-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -73,6 +73,7 @@ jobs:
     name: Build test web assets
     uses: ./.github/workflows/test-web-assets.yaml
     with:
+      caller: ci-host
       skip_catalog: true
     concurrency:
       group: ci-host-test-web-assets-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -317,7 +317,7 @@ jobs:
 
   host-merge-reports-and-publish:
     name: Merge Host reports and publish
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.host-test.result != 'skipped' }}
     concurrency:
       group: host-merge-reports-and-publish-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true

--- a/.github/workflows/ci-software-factory.yaml
+++ b/.github/workflows/ci-software-factory.yaml
@@ -35,6 +35,8 @@ jobs:
   test-web-assets:
     name: Build test web assets
     uses: ./.github/workflows/test-web-assets.yaml
+    with:
+      caller: ci-software-factory
 
   software-factory-test:
     name: Software Factory Tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,6 +121,8 @@ jobs:
     needs: change-check
     if: needs.change-check.outputs.boxel == 'true' || needs.change-check.outputs.boxel-ui == 'true' || needs.change-check.outputs.matrix == 'true' || needs.change-check.outputs.realm-server == 'true' || needs.change-check.outputs.vscode-boxel-tools == 'true' || needs.change-check.outputs.workspace-sync-cli == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
     uses: ./.github/workflows/test-web-assets.yaml
+    with:
+      caller: ci
     concurrency:
       group: ci-test-web-assets-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true

--- a/.github/workflows/test-web-assets.yaml
+++ b/.github/workflows/test-web-assets.yaml
@@ -3,6 +3,10 @@ name: Build Test Web Assets
 on:
   workflow_call:
     inputs:
+      caller:
+        description: Unique identifier for the calling workflow (used in concurrency group to prevent cross-workflow cancellation)
+        required: true
+        type: string
       skip_catalog:
         description: Build host test assets with catalog skipped
         required: false
@@ -24,7 +28,7 @@ jobs:
     name: Build and cache test web assets
     runs-on: ubuntu-latest
     concurrency:
-      group: test-web-assets-${{ github.ref }}-${{ github.sha }}
+      group: test-web-assets-${{ inputs.caller }}-${{ github.ref }}-${{ github.sha }}
       cancel-in-progress: false
 
     outputs:


### PR DESCRIPTION
I’ve been noticing this a lot lately:

<img width="689" height="86" alt="boxel 2026-04-10 13-27-33" src="https://github.com/user-attachments/assets/8410b7f2-03a0-40dc-8bdc-cf576a45863b" />

There should be no merging of host reports when the ancestor job is cancelled.

But why was it cancelled? Multiple workflows call `test-web-assets` to share an early job that builds the application for future jobs to use, so the `concurrency-group` needs to include an identifier for the calling workflow so they don’t trample each other.