### PR TITLE
Prevent duplicate stack opens when clicking submission workflow listing

### DIFF
--- a/packages/catalog-realm/catalog-app/components/listing-fitted.gts
+++ b/packages/catalog-realm/catalog-app/components/listing-fitted.gts
@@ -98,7 +98,8 @@ export class ListingFittedTemplate extends Component<typeof Listing> {
       : undefined;
   }
 
-  viewDetails = () => {
+  viewDetails = (event: MouseEvent) => {
+    event.stopPropagation();
     this.listingActions?.view();
   };
 

--- a/packages/catalog-realm/catalog-app/components/listing-fitted.gts
+++ b/packages/catalog-realm/catalog-app/components/listing-fitted.gts
@@ -98,7 +98,7 @@ export class ListingFittedTemplate extends Component<typeof Listing> {
       : undefined;
   }
 
-  viewDetails = (event: MouseEvent) => {
+  viewDetails = (event: Event) => {
     event.stopPropagation();
     this.listingActions?.view();
   };


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-10685/prevent-duplicate-stack-opens-when-clicking-submission-workflow

Root cause: the listing click was handled twice.

1. ListingFittedTemplate has {{on 'click' this.viewDetails}}, and viewDetails() calls listingActions.view() (which runs show-card).
2. Operator mode overlays also attach a click handler to linked cards and open the card.
3. One click on the listing in SubmissionWorkflowCard triggered both paths, so two stack opens occurred.

## Fix
viewDetails now accepts the click event and calls event.stopPropagation() before listingActions.view().


https://github.com/user-attachments/assets/687f7399-083d-4317-a241-ef7f3cc69f2c

