### PR TITLE
Drag-and-drop search result cards to neighbor stack triggers

### DIFF
--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -3,7 +3,6 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
-import { Button } from '@cardstack/boxel-ui/components';
 import { and, cn, not } from '@cardstack/boxel-ui/helpers';
 import { IconPlus } from '@cardstack/boxel-ui/icons';
 
@@ -96,6 +95,10 @@ export default class ItemButton extends Component<Signature> {
     return this.args.itemId ?? this.cardItem?.id;
   }
 
+  private get isDraggable(): string {
+    return this.isNewCard ? 'false' : 'true';
+  }
+
   @action handleClick() {
     if (this.isNewCard) {
       // "Create New" always submits immediately, even in multi-select mode
@@ -128,18 +131,55 @@ export default class ItemButton extends Component<Signature> {
     }
   }
 
+  @action handleDragStart(event: DragEvent) {
+    if (!event.dataTransfer || this.isNewCard) {
+      return;
+    }
+    let cardUrl = this.resolvedItemId;
+    if (!cardUrl) {
+      return;
+    }
+    event.dataTransfer.setData('application/boxel-card-id', cardUrl);
+    event.dataTransfer.effectAllowed = 'copy';
+
+    // Create an unclipped drag ghost. The default ghost is clipped by
+    // ancestor overflow, so cards partially off-screen look cut off.
+    let source = event.currentTarget as HTMLElement;
+    let clone = source.cloneNode(true) as HTMLElement;
+    clone.style.position = 'fixed';
+    clone.style.top = '-9999px';
+    clone.style.width = `${source.offsetWidth}px`;
+    clone.style.height = `${source.offsetHeight}px`;
+    document.body.appendChild(clone);
+    let rect = source.getBoundingClientRect();
+    event.dataTransfer.setDragImage(
+      clone,
+      event.clientX - rect.left,
+      event.clientY - rect.top,
+    );
+    setTimeout(() => clone.remove(), 0);
+  }
+
   <template>
-    <Button
-      @rectangular={{true}}
+    {{!
+      Outer div handles ALL pointer interactions (click, dblclick, drag).
+      Inner content is pointer-events:none so mousedown always targets
+      this div — critical for reliable HTML5 drag initiation.
+    }}
+    <div
       class={{cn
         'catalog-item'
         selected=@isSelected
         create-new-button=this.isNewCard
         multi-select=@multiSelect
       }}
+      role='button'
+      tabindex='0'
+      draggable={{this.isDraggable}}
       {{on 'click' this.handleClick}}
       {{on 'dblclick' this.handleDblClick}}
       {{on 'keydown' this.handleKeydown}}
+      {{on 'dragstart' this.handleDragStart}}
       data-test-card-catalog-create-new-button={{this.newCardItem.realmURL}}
       data-test-card-catalog-item={{removeFileExtension this.resolvedItemId}}
       data-test-card-catalog-item-selected={{if @isSelected 'true'}}
@@ -173,25 +213,38 @@ export default class ItemButton extends Component<Signature> {
           data-test-search-result={{removeFileExtension this.resolvedItemId}}
         />
       {{/if}}
-    </Button>
+    </div>
     <style scoped>
       .catalog-item {
         height: 100%;
         width: 100%;
         max-width: 100%;
         position: relative;
+        border: 1px solid var(--boxel-border-color);
+        border-radius: var(--boxel-border-radius);
+        background-color: var(--boxel-light);
+        cursor: pointer;
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
       }
       .catalog-item:not(.create-new-button) {
-        --boxel-button-padding: 0;
-
+        padding: 0;
         box-sizing: content-box;
         text-align: start;
       }
       .catalog-item :deep(*) {
         box-sizing: border-box;
       }
+      /* Prevent child elements from capturing drag or pointer events */
+      .catalog-item:not(.create-new-button) > :deep(*) {
+        pointer-events: none;
+        -webkit-user-drag: none;
+      }
       .catalog-item:focus {
-        --host-outline-offset: -1px;
+        outline: 2px solid var(--boxel-highlight);
+        outline-offset: -1px;
       }
       .catalog-item.selected {
         border-color: var(--boxel-highlight);
@@ -211,6 +264,7 @@ export default class ItemButton extends Component<Signature> {
         flex-wrap: nowrap;
         justify-content: flex-start;
         letter-spacing: var(--boxel-lsp-xs);
+        padding: var(--boxel-sp-xs);
       }
       .plus-icon > :deep(path) {
         stroke: none;

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -10,6 +10,7 @@ import { tracked } from '@glimmer/tracking';
 
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import perform from 'ember-concurrency/helpers/perform';
+import { modifier } from 'ember-modifier';
 import { consume } from 'ember-provide-consume-context';
 
 import get from 'lodash/get';
@@ -96,6 +97,27 @@ import type StoreService from '../../services/store';
 
 const waiter = buildWaiter('operator-mode:interact-submode-waiter');
 
+const BOXEL_CARD_MIME = 'application/boxel-card-id';
+
+const cardDragMonitor = modifier(
+  (_element: Element, [onDragStart, onDragEnd]: [() => void, () => void]) => {
+    let handleDragStart = (e: Event) => {
+      if ((e as DragEvent).dataTransfer?.types.includes(BOXEL_CARD_MIME)) {
+        onDragStart();
+      }
+    };
+    let handleDragEnd = () => {
+      onDragEnd();
+    };
+    document.addEventListener('dragstart', handleDragStart);
+    document.addEventListener('dragend', handleDragEnd);
+    return () => {
+      document.removeEventListener('dragstart', handleDragStart);
+      document.removeEventListener('dragend', handleDragEnd);
+    };
+  },
+);
+
 export type Stack = StackItem[];
 
 const cardSelections = new TrackedWeakMap<StackItem, TrackedSet<CardDef>>();
@@ -138,6 +160,7 @@ export default class InteractSubmode extends Component {
   @service declare private loaderService: LoaderService;
 
   @tracked private searchSheetTrigger: SearchSheetTrigger | null = null;
+  @tracked private isDraggingCard = false;
   @tracked private cardToDelete: CardToDelete | undefined = undefined;
   @tracked private recentCardCollection:
     | ReturnType<getCardCollection>
@@ -634,6 +657,29 @@ export default class InteractSubmode extends Component {
     this.searchSheetTrigger = null;
   }
 
+  handleCardDragStart = () => {
+    // Defer hiding so the browser can capture the drag ghost image
+    // before the search sheet becomes invisible. Chrome cancels the drag
+    // if the source element becomes hidden during dragstart processing.
+    setTimeout(() => {
+      this.isDraggingCard = true;
+    }, 0);
+  };
+
+  handleCardDragEnd = () => {
+    this.isDraggingCard = false;
+  };
+
+  @action private handleDropOnNeighborTrigger(
+    selectCard: (cardId: string) => void,
+    triggerSide: SearchSheetTrigger,
+    cardId: string,
+  ) {
+    this.searchSheetTrigger = triggerSide;
+    this.isDraggingCard = false;
+    selectCard(cardId);
+  }
+
   @action private showSearchWithTrigger(
     openSearchCallback: () => void,
     searchSheetTrigger: SearchSheetTrigger,
@@ -776,23 +822,32 @@ export default class InteractSubmode extends Component {
   <template>
     {{consumeContext this.getRecentCardCollection}}
     <SubmodeLayout
-      class='interact-submode-layout'
+      class={{cn
+        'interact-submode-layout'
+        is-dragging-card=this.isDraggingCard
+      }}
       @onSearchSheetClosed={{this.clearSearchSheetTrigger}}
       @onCardSelectFromSearch={{perform this.openSelectedSearchResultInStack}}
       @newFileOptions={{this.newFileOptions}}
       data-test-interact-submode
       as |search|
     >
-      <div class='interact-submode' style={{this.backgroundImageStyle}}>
+      <div
+        class='interact-submode'
+        style={{this.backgroundImageStyle}}
+        {{cardDragMonitor this.handleCardDragStart this.handleCardDragEnd}}
+      >
         {{#if this.canCreateNeighborStack}}
           <NeighborStackTriggerButton
             class='neighbor-stack-trigger stack-trigger-left'
             @triggerSide={{SearchSheetTriggers.DropCardToLeftNeighborStackButton}}
             @activeTrigger={{this.searchSheetTrigger}}
+            @isDragActive={{this.isDraggingCard}}
             @onTrigger={{fn
               this.showSearchWithTrigger
               search.openSearchToPrompt
             }}
+            @onDrop={{fn this.handleDropOnNeighborTrigger search.selectCard}}
           />
         {{/if}}
         <div class='stacks'>
@@ -848,10 +903,12 @@ export default class InteractSubmode extends Component {
             class='neighbor-stack-trigger stack-trigger-right'
             @triggerSide={{SearchSheetTriggers.DropCardToRightNeighborStackButton}}
             @activeTrigger={{this.searchSheetTrigger}}
+            @isDragActive={{this.isDraggingCard}}
             @onTrigger={{fn
               this.showSearchWithTrigger
               search.openSearchToPrompt
             }}
+            @onDrop={{fn this.handleDropOnNeighborTrigger search.selectCard}}
           />
         {{/if}}
         {{#if this.cardToDelete}}
@@ -878,6 +935,10 @@ export default class InteractSubmode extends Component {
 
       .interact-submode-layout :deep(.submode-layout-top-bar) {
         position: absolute;
+      }
+      .interact-submode-layout.is-dragging-card :deep(#search-sheet) {
+        visibility: hidden;
+        pointer-events: none;
       }
 
       .interact-submode {

--- a/packages/host/app/components/operator-mode/interact-submode/neighbor-stack-trigger.gts
+++ b/packages/host/app/components/operator-mode/interact-submode/neighbor-stack-trigger.gts
@@ -1,6 +1,8 @@
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 import { Button, Tooltip } from '@cardstack/boxel-ui/components';
 import { cn, eq } from '@cardstack/boxel-ui/helpers';
@@ -19,16 +21,46 @@ interface Signature {
     triggerSide: SearchSheetTrigger;
     activeTrigger: SearchSheetTrigger | null;
     onTrigger: (triggerSide: SearchSheetTrigger) => void;
+    isDragActive?: boolean;
+    onDrop?: (triggerSide: SearchSheetTrigger, cardId: string) => void;
   };
 }
 
 export default class NeighborStackTriggerButton extends Component<Signature> {
+  @tracked isDragOver = false;
+
   private get tooltipPlacement() {
     return this.args.triggerSide ===
       SearchSheetTriggers.DropCardToRightNeighborStackButton
       ? SearchSheetTriggers.DropCardToLeftNeighborStackButton
       : SearchSheetTriggers.DropCardToRightNeighborStackButton;
   }
+
+  @action handleDragOver(event: DragEvent) {
+    if (event.dataTransfer?.types.includes('application/boxel-card-id')) {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'copy';
+      this.isDragOver = true;
+    }
+  }
+
+  @action handleDragLeave(event: DragEvent) {
+    let button = event.currentTarget as HTMLElement;
+    let relatedTarget = event.relatedTarget as Node | null;
+    if (!relatedTarget || !button.contains(relatedTarget)) {
+      this.isDragOver = false;
+    }
+  }
+
+  @action handleDrop(event: DragEvent) {
+    event.preventDefault();
+    this.isDragOver = false;
+    let cardId = event.dataTransfer?.getData('application/boxel-card-id');
+    if (cardId) {
+      this.args.onDrop?.(this.args.triggerSide, cardId);
+    }
+  }
+
   <template>
     <Tooltip @placement={{this.tooltipPlacement}} ...attributes>
       <:trigger>
@@ -36,8 +68,13 @@ export default class NeighborStackTriggerButton extends Component<Signature> {
           class={{cn
             'add-card-to-neighbor-stack'
             add-card-to-neighbor-stack--active=(eq @activeTrigger @triggerSide)
+            add-card-to-neighbor-stack--drag-active=@isDragActive
+            add-card-to-neighbor-stack--drag-over=this.isDragOver
           }}
           {{on 'click' (fn @onTrigger @triggerSide)}}
+          {{on 'dragover' this.handleDragOver}}
+          {{on 'dragleave' this.handleDragLeave}}
+          {{on 'drop' this.handleDrop}}
           aria-label='Add card to {{@triggerSide}} stack'
           data-test-add-card-right-stack={{eq
             @triggerSide
@@ -66,6 +103,8 @@ export default class NeighborStackTriggerButton extends Component<Signature> {
         --minimized-height: 20px;
         --expanded-width: 16px;
         --expanded-height: 66px;
+        --drag-target-width: 48px;
+        --drag-target-height: 200px;
         --boxel-transition: 100ms ease;
         --boxel-button-min-width: var(--expanded-width);
         --boxel-button-min-height: var(--minimized-height);
@@ -110,6 +149,34 @@ export default class NeighborStackTriggerButton extends Component<Signature> {
       .add-card-to-neighbor-stack:focus:focus-visible .add-icon,
       .add-card-to-neighbor-stack--active .add-icon {
         visibility: visible;
+      }
+
+      /* Drag target: bigger hit area for easy dropping */
+      .add-card-to-neighbor-stack--drag-active {
+        padding: 0;
+        height: var(--drag-target-height);
+        width: var(--drag-target-width);
+        --boxel-button-min-width: var(--drag-target-width);
+      }
+      .add-card-to-neighbor-stack--drag-active .icon-container {
+        width: var(--expanded-width);
+        height: var(--expanded-height);
+        pointer-events: none;
+      }
+      .add-card-to-neighbor-stack--drag-active .add-icon {
+        visibility: visible;
+        pointer-events: none;
+      }
+
+      /* Drag over: visual feedback when hovering over drop target */
+      .add-card-to-neighbor-stack--drag-over .icon-container {
+        background-color: var(--boxel-highlight);
+        box-shadow: 0 0 20px 8px var(--boxel-highlight);
+        border-color: var(--boxel-light);
+        transform: scale(1.3);
+        transition:
+          transform var(--boxel-transition),
+          box-shadow var(--boxel-transition);
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -74,6 +74,7 @@ interface Signature {
         openSearchToPrompt: () => void;
         openSearchToResults: (term: string, typeRef?: ResolvedCodeRef) => void;
         updateSubmode: (submode: Submode) => void;
+        selectCard: (cardId: string) => void;
       },
     ];
     topBar: [];
@@ -479,6 +480,7 @@ export default class SubmodeLayout extends Component<Signature> {
               openSearchToPrompt=this.openSearchSheetToPrompt
               openSearchToResults=this.openSearchAndShowResults
               updateSubmode=this.updateSubmode
+              selectCard=this.handleCardSelectFromSearch
             )
           }}
           {{#if @onCardSelectFromSearch}}

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -393,6 +393,62 @@ module('Acceptance | interact submode tests', function (hooks) {
       assert.dom('[data-test-neighbor-stack-trigger]').doesNotExist();
     });
 
+    test('dragging a card from search results to the right neighbor trigger opens it in a new stack', async function (assert) {
+      await visitOperatorMode({
+        stacks: [
+          [
+            {
+              id: `${testRealmURL}Person/fadhlan`,
+              format: 'isolated',
+            },
+          ],
+        ],
+      });
+
+      assert.dom('[data-test-operator-mode-stack]').exists({ count: 1 });
+      assert.dom('[data-test-add-card-right-stack]').exists();
+
+      // Open search and find a card
+      await click('[data-test-open-search-field]');
+      await fillIn('[data-test-search-field]', 'Mango');
+      assert.dom('[data-test-search-sheet]').hasClass('results');
+
+      let cardId = `${testRealmURL}Pet/mango`;
+      let dataTransfer = {
+        types: ['application/boxel-card-id'],
+        getData: (type: string) =>
+          type === 'application/boxel-card-id' ? cardId : '',
+        setData: () => {},
+        setDragImage: () => {},
+        effectAllowed: 'copy',
+        dropEffect: 'copy',
+      };
+
+      // Drag the card from search results
+      await triggerEvent(
+        `[data-test-card-catalog-item="${cardId}"]`,
+        'dragstart',
+        { dataTransfer },
+      );
+
+      // Allow the deferred isDraggingCard state to apply
+      await new Promise((r) => setTimeout(r, 10));
+      await settled();
+
+      // Drop on the right neighbor trigger
+      await triggerEvent('[data-test-add-card-right-stack]', 'dragover', {
+        dataTransfer,
+      });
+      await triggerEvent('[data-test-add-card-right-stack]', 'drop', {
+        dataTransfer,
+      });
+
+      // Card opens in a new stack to the right
+      assert.dom('[data-test-operator-mode-stack]').exists({ count: 2 });
+      assert.dom('[data-test-operator-mode-stack="0"]').includesText('Fadhlan');
+      assert.dom('[data-test-operator-mode-stack="1"]').includesText('Mango');
+    });
+
     test('Clicking search panel (without left and right buttons activated) replaces open card on existing stack', async function (assert) {
       await visitOperatorMode({
         stacks: [


### PR DESCRIPTION
## Summary
- Cards in the search results pane can be dragged onto the left/right "add card to neighbor stack" triggers to open them in a new stack.
- Convert `ItemButton` from `<Button>` to a draggable `<div>`; use `setDragImage` with an off-screen clone so the ghost isn't clipped by ancestor overflow.
- Defer `isDraggingCard = true` with `setTimeout(0)` — applying `visibility: hidden` to the search sheet synchronously during `dragstart` causes Chrome to cancel the drag.
- Expand neighbor stack triggers into a larger drop target while a card drag is active, with hover feedback on `dragover`.
- Expose `selectCard` from `SubmodeLayout` so the drop handler can route the dropped card through the existing search-selection flow.

## Test plan
- [ ] New acceptance test passes: `dragging a card from search results to the right neighbor trigger opens it in a new stack`
- [ ] Manual: open search, drag a card onto the right neighbor trigger — verify the search sheet hides during drag, ghost image is unclipped, hover feedback appears on the trigger, and the card opens in a new stack on drop
- [ ] Manual: same flow on the left trigger
- [ ] Manual: drag a card that is partially scrolled off-screen — ghost image is not clipped
- [ ] Manual: "Create New" tile in search results is not draggable

🤖 Generated with [Claude Code](https://claude.com/claude-code)