### PR TITLE
Fix IssueLoopConfig type errors from bad merge

### DIFF
--- a/packages/software-factory/scripts/smoke-tests/issue-loop-smoke.ts
+++ b/packages/software-factory/scripts/smoke-tests/issue-loop-smoke.ts
@@ -719,7 +719,7 @@ async function scenarioBootstrapSeedIssue(): Promise<void> {
     contextBuilder: new StubContextBuilder(),
     tools: TOOLS,
     issueStore: store,
-    validator: new NoOpValidator(),
+    createValidator: () => new NoOpValidator(),
     targetRealmUrl: 'https://example.test/target/',
     briefUrl: 'https://example.test/brief/',
   });

--- a/packages/software-factory/src/factory-issue-loop-wiring.ts
+++ b/packages/software-factory/src/factory-issue-loop-wiring.ts
@@ -181,17 +181,18 @@ export async function runFactoryIssueLoop(
       debug: config.debug,
     } satisfies FactoryAgentConfig);
 
-  // 6. Validator
-  let validator = createDefaultPipeline({
-    realmServerUrl,
-    authorization: config.authorization,
-    fetch: fetchImpl,
-    hostAppUrl,
-    testResultsModuleUrl,
-    issueId: 'validation',
-    fetchFilenames: (realmUrl: string) =>
-      fetchRealmFilenames(realmUrl, fetchOptions),
-  });
+  // 6. Validator factory
+  let createValidator = (issueId: string) =>
+    createDefaultPipeline({
+      realmServerUrl,
+      authorization: config.authorization,
+      fetch: fetchImpl,
+      hostAppUrl,
+      testResultsModuleUrl,
+      issueId,
+      fetchFilenames: (realmUrl: string) =>
+        fetchRealmFilenames(realmUrl, fetchOptions),
+    });
 
   // 7. Run issue loop
   log.info(
@@ -203,7 +204,7 @@ export async function runFactoryIssueLoop(
     contextBuilder,
     tools,
     issueStore,
-    validator,
+    createValidator,
     targetRealmUrl,
     briefUrl: config.briefUrl,
     maxIterationsPerIssue: config.maxIterationsPerIssue,


### PR DESCRIPTION
## Summary
- The `IssueLoopConfig` interface was updated to use `createValidator` (a factory function) in #4381, but two call sites still referenced the old `validator` property after a bad merge, breaking `lint:types` on main.
- Updated `factory-issue-loop-wiring.ts` to pass a `createValidator` factory function instead of a single validator instance.
- Updated `issue-loop-smoke.ts` to use `createValidator: () => new NoOpValidator()`.

## Test plan
- [x] Verified `validator` type errors no longer appear in `pnpm lint` output
- [x] Format and JS lint pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)