### PR TITLE
Agentic loop stability fixes from repeated e2e testing

### DIFF
--- a/packages/software-factory/.agents/skills/software-factory-bootstrap/SKILL.md
+++ b/packages/software-factory/.agents/skills/software-factory-bootstrap/SKILL.md
@@ -24,13 +24,13 @@ Derive names from the brief title:
 
 ### Project Card
 
-**Path:** `Projects/<slug>-mvp.json`
+**Path:** `Projects/<slug>.json`
 **adoptsFrom:** `{ module: "<darkfactoryModuleUrl>", name: "Project" }`
 
 | Field              | Type     | Example                                         |
 | ------------------ | -------- | ----------------------------------------------- |
 | `projectCode`      | String   | `"SN"`                                          |
-| `projectName`      | String   | `"Sticky Note MVP"`                             |
+| `projectName`      | String   | `"Sticky Note"`                                 |
 | `projectStatus`    | Enum     | `"active"`                                      |
 | `objective`        | String   | Brief content summary                           |
 | `scope`            | Markdown | Full brief content by sections                  |
@@ -63,10 +63,10 @@ Add more as the brief warrants (e.g., detailed visual design, deep domain knowle
 
 ### Issue Card — Organized by Entry-Point Card
 
-**Paths:** `Issues/<slug>-<card-slug>.json` (one per entry-point card)
+**Paths:** `Issues/<slug>-<card-name-slug>.json` (one per entry-point card, named after the card)
 **adoptsFrom:** `{ module: "<darkfactoryModuleUrl>", name: "Issue" }`
 
-Organize implementation issues around **entry-point cards** — the top-level cards users interact with directly and that should be discoverable in the catalog. Create **one issue per entry-point card**.
+Organize implementation issues around **entry-point cards** — the top-level cards users interact with directly and that should be discoverable in the catalog. Create **one issue per entry-point card**, named after that card.
 
 Each issue covers the full scope of its entry-point card:
 
@@ -76,22 +76,22 @@ Each issue covers the full scope of its entry-point card:
 
 Interior cards (field cards, helper cards, linked supporting types) are implemented as part of their entry-point card's issue. They need tests but do **not** need their own catalog specs or separate issues.
 
-| Field                | Type     | Description                                                  |
-| -------------------- | -------- | ------------------------------------------------------------ |
-| `issueId`            | String   | `"<projectCode>-<N>"` (sequential)                           |
-| `summary`            | String   | `"Implement <card name> card with tests and catalog spec"`   |
-| `description`        | Markdown | Card to create, fields, support cards, tests, spec, examples |
-| `issueType`          | Enum     | `"feature"`                                                  |
-| `status`             | Enum     | `"backlog"`                                                  |
-| `priority`           | Enum     | `"high"` for first, `"medium"` for subsequent                |
-| `order`              | Number   | Sequential (1, 2, 3, ...)                                    |
-| `acceptanceCriteria` | Markdown | Checklist: card def, support cards, tests, spec, examples    |
-| `createdAt`          | DateTime | ISO timestamp                                                |
-| `updatedAt`          | DateTime | ISO timestamp                                                |
+| Field                | Type     | Description                                                       |
+| -------------------- | -------- | ----------------------------------------------------------------- |
+| `issueId`            | String   | `"<projectCode>-<N>"` (sequential)                                |
+| `summary`            | String   | `"Implement <card name> card"` (named after the entry-point card) |
+| `description`        | Markdown | Card to create, fields, support cards, tests, spec, examples      |
+| `issueType`          | Enum     | `"feature"`                                                       |
+| `status`             | Enum     | `"backlog"`                                                       |
+| `priority`           | Enum     | `"high"` for first, `"medium"` for subsequent                     |
+| `order`              | Number   | Sequential (1, 2, 3, ...)                                         |
+| `acceptanceCriteria` | Markdown | Checklist: card def, support cards, tests, spec, examples         |
+| `createdAt`          | DateTime | ISO timestamp                                                     |
+| `updatedAt`          | DateTime | ISO timestamp                                                     |
 
 **Relationships for each issue:**
 
-- `project` → `{ links: { self: "../Projects/<slug>-mvp" } }`
+- `project` → `{ links: { self: "../Projects/<slug>" } }`
 - `relatedKnowledge.0` → `{ links: { self: "../Knowledge Articles/<slug>-brief-context" } }`
 - `relatedKnowledge.1` → `{ links: { self: "../Knowledge Articles/<slug>-agent-onboarding" } }`
 - `blockedBy` → issues for any entry-point cards this card depends on
@@ -118,7 +118,7 @@ Every card written via `write_file` must be a JSON:API document:
     "type": "card",
     "attributes": { ... },
     "relationships": {
-      "project": { "links": { "self": "../Projects/sticky-note-mvp" } },
+      "project": { "links": { "self": "../Projects/sticky-note" } },
       "relatedKnowledge.0": { "links": { "self": "../Knowledge Articles/sticky-note-brief-context" } }
     },
     "meta": {
@@ -135,13 +135,6 @@ Use relative paths (`../`) for relationship links since cards are in sibling dir
 
 ## Completion
 
-After creating all artifacts, mark the bootstrap issue as done. **Important:**
-`update_issue` writes the full card, not a partial patch. First `read_file` the
-issue to get its current attributes, then call `update_issue` with all existing
-attributes plus `status: "done"`:
-
-```
-// 1. read_file({ path: "Issues/bootstrap-seed" }) to get current attributes
-// 2. update_issue with all attributes:
-update_issue({ path: "Issues/bootstrap-seed", attributes: { ...existing, status: "done" } })
-```
+After creating all artifacts, call `signal_done()`. The orchestrator manages
+issue status transitions — do NOT set the issue status to "done" yourself.
+The orchestrator will mark the issue as done after validation passes.

--- a/packages/software-factory/.agents/skills/software-factory-operations/SKILL.md
+++ b/packages/software-factory/.agents/skills/software-factory-operations/SKILL.md
@@ -34,10 +34,6 @@ The agent has these tools during the execution loop. Use them by name — they a
 - `create_knowledge({ path, attributes, relationships? })` — Create or update a KnowledgeArticle card. Same structured interface with dynamic field schema in the tool parameters.
 - `create_catalog_spec({ path, attributes, relationships? })` — Create a Catalog Spec card in the target realm's `Spec/` folder. Makes a card definition discoverable in the Boxel catalog. Same structured interface with dynamic field schema. The tool auto-constructs the document with `adoptsFrom` pointing to `https://cardstack.com/base/spec#Spec`.
 
-### Testing
-
-- `run_tests({ slug, testNames? })` — Execute QUnit card tests against the target realm. Runs `.test.gts` files co-located with card definitions, returns structured results (pass/fail counts, failure details with error messages and stack traces).
-
 ### Running Host Commands
 
 - `run_command({ command, commandInput? })` — Execute a host command on the realm server via the prerenderer. Commands run in browser context with full card runtime access (Loader, CardAPI, services). Use the specifier format `@cardstack/boxel-host/commands/<name>/default`.
@@ -66,14 +62,13 @@ Returns `{ status: "ready", result: "<serialized JsonCard with schema>" }`. Pars
 ## Required Flow
 
 1. **Inspect before writing.** Use `search_realm` and `read_file` to understand what already exists in the target realm before creating or modifying files.
-2. **Move issue to `in_progress`.** Use `update_issue` to set the issue status before starting implementation.
-3. **Write card definitions** (`.gts`) via `write_file` to the target realm.
+2. **Write card definitions** (`.gts`) via `write_file` to the target realm.
+3. **Write `.test.gts` test files** co-located with card definitions via `write_file` to the target realm. Every issue must have at least one test file. **Write tests immediately after the card definition, before any instances or catalog specs.**
 4. **Write card instances** (`.json`) via `write_file` to the target realm.
 5. **Write a Catalog Spec card** (`Spec/<card-name>.json`) for each top-level card defined in the brief. Link sample instances via `linkedExamples`.
-6. **Write `.test.gts` test files** co-located with card definitions via `write_file` to the target realm. Every issue must have at least one test file.
-7. **Call `signal_done()`** when all implementation and test files are written. The orchestrator triggers test execution after this.
-8. **If tests fail**, the orchestrator feeds failure details back. Use `read_file` to inspect current state, then `write_file` to fix implementation or test files. Call `signal_done()` again.
-9. **Update issue state** via `update_issue` — update notes, acceptance criteria, and related knowledge as work progresses.
+6. **Call `signal_done()`** when all implementation and test files are written. The orchestrator runs the validation pipeline (including test execution) automatically after this.
+7. **If tests fail**, the orchestrator feeds failure details back. Use `read_file` to inspect current state, then `write_file` to fix implementation or test files. Call `signal_done()` again.
+8. **Update issue state** via `update_issue` — update notes, acceptance criteria, and related knowledge as work progresses.
 
 ## Target Realm Artifact Structure
 

--- a/packages/software-factory/docs/phase-2-plan.md
+++ b/packages/software-factory/docs/phase-2-plan.md
@@ -146,7 +146,7 @@ The flow becomes:
    - The Project card
    - KnowledgeArticle cards (brief context + agent onboarding)
    - One implementation issue per entry-point card, with `project` and `relatedKnowledge` relationships wired
-4. The agent marks the seed issue as done via `update_issue`
+4. The agent calls `signal_done()` — the orchestrator marks the seed issue as done after validation passes
 5. The orchestrator now has a populated issue backlog and continues the normal loop
 
 Seed issue creation is **idempotent** — `createSeedIssue()` checks if `Issues/bootstrap-seed` already exists before writing. This supports crash recovery: if the factory restarts, the seed issue is already in the realm and the loop picks it up.
@@ -178,6 +178,9 @@ while (
 ) {
   let issue = scheduler.pickNextIssue(exhaustedIssues);
 
+  // Orchestrator sets in_progress on pickup
+  await issueStore.updateIssue(issue.id, { status: 'in_progress' });
+
   // Inner loop: multiple iterations per issue
   let validationResults = undefined;
   let exitReason = 'max_iterations';
@@ -193,18 +196,24 @@ while (
     // Validation phase — runs after EVERY agent turn
     validationResults = await validator.validate(targetRealmUrl);
 
-    // Read issue state from realm (not from AgentRunResult.status)
+    // Orchestrator promotes to done: signal_done + validation passed
+    let agentSignaledDone = result.toolCalls.some(
+      (tc) => tc.tool === 'signal_done',
+    );
+    if (agentSignaledDone && validationResults?.passed) {
+      await issueStore.updateIssue(issue.id, { status: 'done' });
+    }
+
     issue = await scheduler.refreshIssueState(issue);
 
     if (issue.status === 'done' || issue.status === 'blocked') {
       exitReason = issue.status;
       break;
     }
+    // If agent signaled done but validation failed, continue iterating
   }
 
   if (exitReason === 'max_iterations') {
-    // If validation still failing at max iterations, block the issue
-    // with the reason and failure context written to the realm
     if (validationResults && !validationResults.passed) {
       exitReason = 'blocked';
       await issueStore.updateIssue(issue.id, {
@@ -215,16 +224,18 @@ while (
     exhaustedIssues.add(issue.id);
   }
 
-  // Reload to pick up new issues the agent may have created
   await scheduler.loadIssues();
+}
+
+// Mark project completed when all issues done
+if (outcome === 'all_issues_done') {
+  await issueStore.updateProjectStatus('completed');
 }
 ```
 
-The agent signals progress by updating the issue — tagging it as blocked, marking it done, or leaving it in progress for another iteration. The orchestrator reads issue state from the realm after each agent turn, then runs validation. Validation failures are fed back as context in the next inner-loop iteration so the agent can self-correct. The agent can also create new issues via tool calls if it determines a failure requires separate work.
+The orchestrator owns all status transitions. The agent signals intent via `signal_done()` (for completion) or `update_issue({ status: 'blocked' })` (for blocking). The orchestrator decides whether to actually promote based on validation results. Validation failures are fed back as context in the next inner-loop iteration so the agent can self-correct.
 
-The orchestrator also **writes** to the realm in one case: when max iterations are reached with failing validation, it updates the issue's status to `blocked` and writes the formatted validation failure context into the issue description. This uses `IssueStore.updateIssue()`, which performs a read-modify-write against the realm card.
-
-All domain logic (what to implement, when to create sub-issues, when to tag as blocked) lives in the agent's prompt and skills. The orchestrator owns only: issue selection, agent invocation, validation, and max-iteration blocking.
+All domain logic (what to implement, when to create sub-issues, when to tag as blocked) lives in the agent's prompt and skills. The orchestrator owns: issue selection, status transitions, agent invocation, validation, project completion, and max-iteration blocking.
 
 ### Issue Loading via searchRealm()
 
@@ -345,12 +356,54 @@ CS-10671 trims and renames the current schema as a first step. The adoption from
 ```
 backlog → in_progress → done
                       → blocked (needs human input or max iterations with failing validation)
-                      → review (optional)
 ```
 
-The agent manages its own transitions by updating the issue directly (e.g., tagging as blocked, marking done). The orchestrator reads the issue state after the agent exits to decide what to do next — it does not inspect the agent's return value for status.
+### Orchestrator Owns Status Transitions
 
-The orchestrator also transitions issues to `blocked` in one case: when max iterations are reached with validation still failing. It writes the reason ("max iteration limit reached") and the formatted validation failure context into the issue description via `IssueStore.updateIssue()`, making the blocking reason visible in the realm. Issues blocked this way are also added to an `exhaustedIssues` set to prevent re-selection within the same run.
+**The orchestrator — not the agent — manages issue status transitions.** This is a key design decision validated through end-to-end testing. Allowing the agent to set status directly caused multiple problems:
+
+- The agent would mark issues as `done` before validation passed, causing the loop to exit prematurely with failing tests
+- The `update_issue` tool's full-document write would clobber existing attributes when the agent only intended to update status
+- The agent's status updates conflicted with the orchestrator's view of issue state
+
+The status transition rules are:
+
+| Transition                | Owner                 | Trigger                                                                                    |
+| ------------------------- | --------------------- | ------------------------------------------------------------------------------------------ |
+| `backlog` → `in_progress` | Orchestrator          | Issue picked up by the loop                                                                |
+| `in_progress` → `done`    | Orchestrator          | Agent calls `signal_done` AND validation passes                                            |
+| `in_progress` → `blocked` | Agent or Orchestrator | Agent sets `blocked` via `update_issue`, or max iterations reached with failing validation |
+| `blocked` → `backlog`     | Agent                 | Agent unblocks via `update_issue`                                                          |
+
+The `update_issue` tool strips disallowed status values — only `blocked` and `backlog` pass through. The agent signals completion via `signal_done()`, and the loop promotes to `done` only when validation also passes. If the agent signals done but validation fails, the loop continues iterating with the failure details.
+
+### Project Completion
+
+When the loop outcome is `all_issues_done`, the orchestrator automatically sets the project's `projectStatus` to `completed` via `IssueStore.updateProjectStatus()`.
+
+### Card Update Tools Use Read-Patch-Write
+
+The `update_issue`, `update_project`, and `create_knowledge` tools perform a **read-patch-write** cycle: they read the existing card source, merge the agent-provided attributes on top, and write back the merged document. This preserves attributes the agent didn't include in its update call. Earlier versions used a full-document write via `buildCardDocument()` which would clobber existing attributes — this was identified as a critical bug during e2e testing (bootstrap-seed issue was reduced to just `status` and `updatedAt` after an update).
+
+### run_tests Tool Removed from Agent
+
+The `run_tests` tool is **not exposed** to the agent. The validation pipeline runs tests automatically after every agent turn (after `signal_done`). Giving the agent the tool caused it to waste iterations running tests manually, sometimes before writing test files, and creating duplicate TestRun instances. The system prompt and skills inform the agent that the orchestrator handles test execution.
+
+The `run_command` tool description explicitly states it is for Boxel host commands only (format: `@cardstack/boxel-host/commands/<name>/default`), not shell commands or scripts.
+
+### Playwright waitForFunction Timeout
+
+The validation pipeline's test step uses Playwright's `page.waitForFunction()` to wait for QUnit completion. The timeout must be passed as the **third** argument (`page.waitForFunction(fn, null, { timeout })`) — passing it as the second argument treats it as `arg`, causing Playwright to use its 30s default. The timeout is set to 300s (5 minutes) to accommodate large test suites that can take 30-50s for 10-13 tests.
+
+### darkfactory Module URL
+
+The `buildCardDocument()` function takes the darkfactory module URL as a parameter — it must point to the `software-factory` realm (e.g., `http://localhost:4201/software-factory/darkfactory`), NOT the target realm. Earlier versions constructed the URL from the target realm URL, causing cards written via `update_issue` to have the wrong `adoptsFrom` module. This broke `refreshIssue()` searches which filter by type module URL.
+
+The correct URL is computed once via `inferDarkfactoryModuleUrl(targetRealmUrl)` and threaded through `ToolBuilderConfig.darkfactoryModuleUrl`.
+
+### File Path Extensions
+
+All card tool paths (in `update_issue`, `update_project`, `create_knowledge`, `create_catalog_spec`) are normalized with `ensureJsonExtension()` before being passed to realm operations. The realm API uses `card+source` content negotiation which requires the full file path including `.json` extension. Card IDs (used inside JSON documents) do NOT include extensions — this is a different concept.
 
 ## Migration Path from Phase 1
 

--- a/packages/software-factory/prompts/bootstrap-implement.md
+++ b/packages/software-factory/prompts/bootstrap-implement.md
@@ -23,12 +23,12 @@ Create the following artifacts in the target realm using the available tools
 
 ### 1. Project Card
 
-Write a Project card to `Projects/<slug>-mvp.json` where `<slug>` is derived
+Write a Project card to `Projects/<slug>.json` where `<slug>` is derived
 from the brief title (lowercase, hyphens for spaces/punctuation).
 
 Required attributes:
 - `projectCode` — 2-4 uppercase letters derived from title initials (e.g., "Sticky Note" → "SN")
-- `projectName` — `"<brief title> MVP"`
+- `projectName` — `"<brief title>"`
 - `projectStatus` — `"active"`
 - `objective` — brief content summary
 - `scope` — full brief content organized by sections
@@ -87,9 +87,9 @@ issue must come first. Set `order` so that dependency cards are processed
 before their consumers, and wire `blockedBy` so the consuming card's issue
 cannot start until the dependency card's issue is done.
 
-**Issue format** — for each entry-point card, create an issue at `Issues/<slug>-<card-slug>.json`:
+**Issue format** — for each entry-point card, create an issue named after the card at `Issues/<slug>-<card-name-slug>.json` (e.g., `Issues/sticky-note.json` for a "Sticky Note" card):
 - `issueId` — `"<projectCode>-<N>"` (sequential, dependency-first ordering)
-- `summary` — `"Implement <card name> card with tests and catalog spec"`
+- `summary` — `"Implement <card name> card"` (named after the entry-point card, e.g., "Implement Sticky Note card")
 - `description` — describe the card to create, its fields, any interior/support cards, what tests to write, and what the catalog spec should contain
 - `issueType` — `"feature"`
 - `status` — `"backlog"`
@@ -97,7 +97,7 @@ cannot start until the dependency card's issue is done.
 - `order` — sequential, respecting dependency order (cards with no dependencies first)
 - `acceptanceCriteria` — checklist covering card definition, tests, spec, and examples
 - Relationships:
-  - `project` → `../Projects/<slug>-mvp`
+  - `project` → `../Projects/<slug>`
   - `relatedKnowledge.0` → `../Knowledge Articles/<slug>-brief-context`
   - `relatedKnowledge.1` → `../Knowledge Articles/<slug>-agent-onboarding`
   - `blockedBy` → issues for any entry-point cards this card depends on
@@ -116,7 +116,7 @@ dependency cards are implemented before cards that consume them.
 4. Create Knowledge Article cards (at least brief context + agent onboarding)
 5. Identify entry-point cards from the brief — these are the top-level cards users interact with
 6. Create one implementation Issue per entry-point card, with all relationships wired
-7. Mark this bootstrap issue as done: first `read_file` the issue to get its current attributes, then call `update_issue` with **all existing attributes** plus `status: "done"` (update_issue writes the full card, not a partial patch)
+7. Call `signal_done()` — the orchestrator manages issue status transitions. Do NOT set the issue status yourself.
 
 Create artifacts in the order listed — Project first, then Knowledge Articles,
 then Issues — so that relationship targets exist when referenced.

--- a/packages/software-factory/prompts/system.md
+++ b/packages/software-factory/prompts/system.md
@@ -4,8 +4,8 @@ You are a software factory agent. You implement Boxel cards and tests in
 target realms based on ticket descriptions and project context.
 
 You have access to tools for reading and writing files to realms, searching
-realm state, running tests, and signaling completion. Use these tools to
-inspect existing state before making changes — do not guess.
+realm state, and signaling completion. Use these tools to inspect existing
+state before making changes — do not guess.
 
 # Rules
 
@@ -19,6 +19,10 @@ inspect existing state before making changes — do not guess.
 - When all implementation and test files have been written, call signal_done.
 - All file operations use the realm HTTP API. Write card definitions as .gts
   files and card instances as .json files.
+- After you call signal_done, the orchestrator automatically runs a validation
+  pipeline that executes your .test.gts files and reports results. If tests
+  fail, you will receive the failure details in your next iteration so you
+  can fix them.
 
 # Realms
 

--- a/packages/software-factory/prompts/ticket-implement.md
+++ b/packages/software-factory/prompts/ticket-implement.md
@@ -54,13 +54,13 @@ You previously invoked the following tools. Use these results to inform your imp
 
 # Instructions
 
-Implement this issue:
+Implement this issue in this order:
 
 1. Use search_realm and read_file to inspect existing realm state
-2. Use write_file to create or update card definitions (.gts) and/or card instances (.json) in the target realm
-3. Create a Catalog Spec card in the Spec/ folder for the top-level card (adoptsFrom https://cardstack.com/base/spec#Spec)
-4. Create at least one sample card instance and link it from the Catalog Spec via linkedExamples
-5. Use write_file to create QUnit test files (.test.gts) co-located with card definitions
+2. Use write_file to create or update card definitions (.gts) in the target realm
+3. Use write_file to create QUnit test files (.test.gts) co-located with card definitions — write tests BEFORE any sample instances or catalog specs
+4. Create at least one sample card instance (.json) in the target realm
+5. Create a Catalog Spec card in the Spec/ folder for the top-level card (adoptsFrom https://cardstack.com/base/spec#Spec), linking sample instances via linkedExamples
 6. Call signal_done when all implementation and test files have been written
 
-Start with the smallest working implementation, then add the test.
+The validation pipeline runs tests automatically after `signal_done` — write tests, then signal done, and the orchestrator handles the rest. Do NOT set the issue status to "done" yourself — the orchestrator manages issue status transitions based on validation results.

--- a/packages/software-factory/realm/darkfactory.gts
+++ b/packages/software-factory/realm/darkfactory.gts
@@ -271,7 +271,9 @@ export class Issue extends CardDef {
       <div class='issue-card compact'>
         <div class='row'>
           <strong>{{if @model.issueId @model.issueId 'ISSUE'}}</strong>
-          <span>{{if @model.status @model.status 'backlog'}}</span>
+          <span
+            class='status status-{{if @model.status @model.status "backlog"}}'
+          >{{if @model.status @model.status 'backlog'}}</span>
         </div>
         <div>{{if @model.summary @model.summary 'Untitled Issue'}}</div>
       </div>
@@ -289,8 +291,32 @@ export class Issue extends CardDef {
         .row {
           display: flex;
           justify-content: space-between;
+          align-items: center;
           gap: 0.75rem;
           font-size: 0.8rem;
+        }
+        .status {
+          font-size: 0.75rem;
+          text-transform: uppercase;
+          font-weight: 600;
+          padding: 0.125rem 0.5rem;
+          border-radius: 0.25rem;
+        }
+        .status-done {
+          color: var(--boxel-green, #16a34a);
+          background: #f0fdf4;
+        }
+        .status-in_progress {
+          color: var(--boxel-blue, #2563eb);
+          background: #eff6ff;
+        }
+        .status-backlog {
+          color: var(--boxel-400, #9ca3af);
+          background: #f9fafb;
+        }
+        .status-blocked {
+          color: var(--boxel-red, #dc2626);
+          background: #fef2f2;
         }
       </style>
     </template>
@@ -304,14 +330,18 @@ export class Issue extends CardDef {
         <header>
           <div class='row'>
             <strong>{{if @model.issueId @model.issueId 'ISSUE'}}</strong>
-            <span>{{if @model.status @model.status 'backlog'}}</span>
+            <span
+              class='status status-{{if @model.status @model.status "backlog"}}'
+            >{{if @model.status @model.status 'backlog'}}</span>
           </div>
           <h1>{{if @model.summary @model.summary 'Untitled Issue'}}</h1>
         </header>
         {{#if @model.project}}
           <section>
             <h2>Project</h2>
-            <@fields.project />
+            <div class='linked-card'>
+              <@fields.project @format='embedded' />
+            </div>
           </section>
         {{/if}}
         {{#if @model.description}}
@@ -345,10 +375,37 @@ export class Issue extends CardDef {
           display: grid;
           gap: 1rem;
         }
+        .linked-card {
+          margin-bottom: 0.5rem;
+        }
         .row {
           display: flex;
           justify-content: space-between;
+          align-items: center;
           gap: 0.75rem;
+        }
+        .status {
+          font-size: 0.75rem;
+          text-transform: uppercase;
+          font-weight: 600;
+          padding: 0.125rem 0.5rem;
+          border-radius: 0.25rem;
+        }
+        .status-done {
+          color: var(--boxel-green, #16a34a);
+          background: #f0fdf4;
+        }
+        .status-in_progress {
+          color: var(--boxel-blue, #2563eb);
+          background: #eff6ff;
+        }
+        .status-backlog {
+          color: var(--boxel-400, #9ca3af);
+          background: #f9fafb;
+        }
+        .status-blocked {
+          color: var(--boxel-red, #dc2626);
+          background: #fef2f2;
         }
       </style>
     </template>
@@ -398,11 +455,13 @@ export class Project extends CardDef {
               @model.projectCode
               'PROJECT'
             }}</strong>
-          <span>{{if
-              @model.projectStatus
-              @model.projectStatus
-              'planning'
-            }}</span>
+          <span
+            class='status status-{{if
+                @model.projectStatus
+                @model.projectStatus
+                "planning"
+              }}'
+          >{{if @model.projectStatus @model.projectStatus 'planning'}}</span>
         </div>
         <div>{{if
             @model.projectName
@@ -424,8 +483,36 @@ export class Project extends CardDef {
         .row {
           display: flex;
           justify-content: space-between;
+          align-items: center;
           gap: 0.75rem;
           font-size: 0.8rem;
+        }
+        .status {
+          font-size: 0.75rem;
+          text-transform: uppercase;
+          font-weight: 600;
+          padding: 0.125rem 0.5rem;
+          border-radius: 0.25rem;
+        }
+        .status-active {
+          color: var(--boxel-blue, #2563eb);
+          background: #eff6ff;
+        }
+        .status-planning {
+          color: var(--boxel-400, #9ca3af);
+          background: #f9fafb;
+        }
+        .status-completed {
+          color: var(--boxel-green, #16a34a);
+          background: #f0fdf4;
+        }
+        .status-on_hold {
+          color: var(--boxel-orange, #ea580c);
+          background: #fff7ed;
+        }
+        .status-archived {
+          color: var(--boxel-400, #9ca3af);
+          background: #f3f4f6;
         }
       </style>
     </template>
@@ -443,11 +530,13 @@ export class Project extends CardDef {
                 @model.projectCode
                 'PROJECT'
               }}</strong>
-            <span>{{if
-                @model.projectStatus
-                @model.projectStatus
-                'planning'
-              }}</span>
+            <span
+              class='status status-{{if
+                  @model.projectStatus
+                  @model.projectStatus
+                  "planning"
+                }}'
+            >{{if @model.projectStatus @model.projectStatus 'planning'}}</span>
           </div>
           <h1>{{if
               @model.projectName
@@ -501,7 +590,35 @@ export class Project extends CardDef {
         .row {
           display: flex;
           justify-content: space-between;
+          align-items: center;
           gap: 0.75rem;
+        }
+        .status {
+          font-size: 0.75rem;
+          text-transform: uppercase;
+          font-weight: 600;
+          padding: 0.125rem 0.5rem;
+          border-radius: 0.25rem;
+        }
+        .status-active {
+          color: var(--boxel-blue, #2563eb);
+          background: #eff6ff;
+        }
+        .status-planning {
+          color: var(--boxel-400, #9ca3af);
+          background: #f9fafb;
+        }
+        .status-completed {
+          color: var(--boxel-green, #16a34a);
+          background: #f0fdf4;
+        }
+        .status-on_hold {
+          color: var(--boxel-orange, #ea580c);
+          background: #fff7ed;
+        }
+        .status-archived {
+          color: var(--boxel-400, #9ca3af);
+          background: #f3f4f6;
         }
       </style>
     </template>

--- a/packages/software-factory/realm/test-results.gts
+++ b/packages/software-factory/realm/test-results.gts
@@ -262,11 +262,20 @@ export class TestRun extends CardDef {
       );
     }
 
+    get displayStatus() {
+      if (this.total === 0 && this.args.model.status === 'passed') {
+        return 'empty';
+      }
+      return this.args.model.status;
+    }
+
     <template>
       <div class='test-run compact'>
         <div class='header'>
           <strong>#{{@model.sequenceNumber}}</strong>
-          <span class='status status-{{@model.status}}'>{{@model.status}}</span>
+          <span
+            class='status status-{{this.displayStatus}}'
+          >{{this.displayStatus}}</span>
         </div>
         {{#if @model.issue}}
           <div class='issue-name'>{{@model.issue.summary}}</div>
@@ -324,6 +333,10 @@ export class TestRun extends CardDef {
           color: var(--boxel-blue, #2563eb);
           background: #eff6ff;
         }
+        .status-empty {
+          color: var(--boxel-400, #9ca3af);
+          background: #f9fafb;
+        }
         .issue-name {
           font-size: 0.8rem;
           color: var(--muted-foreground);
@@ -358,14 +371,21 @@ export class TestRun extends CardDef {
       );
     }
 
+    get displayStatus() {
+      if (this.total === 0 && this.args.model.status === 'passed') {
+        return 'empty';
+      }
+      return this.args.model.status;
+    }
+
     <template>
       <article class='surface'>
         <header>
           <div class='header-row'>
             <strong>TestRun #{{@model.sequenceNumber}}</strong>
             <span
-              class='status status-{{@model.status}}'
-            >{{@model.status}}</span>
+              class='status status-{{this.displayStatus}}'
+            >{{this.displayStatus}}</span>
           </div>
           <div class='summary'>
             {{@model.passedCount}}/{{this.total}}
@@ -423,7 +443,11 @@ export class TestRun extends CardDef {
                   {{#if moduleResult.isComplete}}
                     <span
                       class='module-group-counts
-                        {{if moduleResult.failedCount "has-failures"}}'
+                        {{if
+                          moduleResult.failedCount
+                          "has-failures"
+                          (if moduleResult.passedCount "has-passes" "empty")
+                        }}'
                     >
                       {{#if moduleResult.failedCount}}
                         {{moduleResult.passedCount}}
@@ -512,6 +536,10 @@ export class TestRun extends CardDef {
           color: var(--boxel-blue, #2563eb);
           background: #eff6ff;
         }
+        .status-empty {
+          color: var(--boxel-400, #9ca3af);
+          background: #f9fafb;
+        }
         .summary {
           font-size: 0.9rem;
           color: var(--muted-foreground);
@@ -534,7 +562,6 @@ export class TestRun extends CardDef {
         }
         .module-has-failures {
           border-color: var(--boxel-red, #dc2626);
-          border-left-width: 3px;
         }
         .module-group-header {
           display: flex;
@@ -550,6 +577,9 @@ export class TestRun extends CardDef {
         }
         .module-group-counts {
           font-size: 0.8rem;
+          color: var(--boxel-400, #9ca3af);
+        }
+        .module-group-counts.has-passes {
           color: var(--boxel-green, #16a34a);
         }
         .module-group-counts.has-failures {

--- a/packages/software-factory/scripts/smoke-tests/factory-tools-smoke.ts
+++ b/packages/software-factory/scripts/smoke-tests/factory-tools-smoke.ts
@@ -255,6 +255,8 @@ async function main(): Promise<void> {
   let factoryTools = buildFactoryTools(
     {
       targetRealmUrl: 'https://realms.example.test/user/target/',
+      darkfactoryModuleUrl:
+        'https://realms.example.test/software-factory/darkfactory',
       realmServerUrl: 'https://realms.example.test/',
       realmTokens: {
         'https://realms.example.test/user/target/': 'Bearer target-jwt',

--- a/packages/software-factory/src/darkfactory-schemas.ts
+++ b/packages/software-factory/src/darkfactory-schemas.ts
@@ -14,11 +14,7 @@ import type {
   Relationship,
 } from '@cardstack/runtime-common';
 
-import {
-  runRealmCommand,
-  ensureTrailingSlash,
-  type RunCommandOptions,
-} from './realm-operations';
+import { runRealmCommand, type RunCommandOptions } from './realm-operations';
 
 // ---------------------------------------------------------------------------
 // Runtime schema fetching
@@ -99,16 +95,17 @@ export async function fetchCardTypeSchema(
 
 /**
  * Assemble a JSON:API card document from structured attributes and
- * relationships, with the correct `adoptsFrom` pointing to darkfactory
- * in the given realm.
+ * relationships, with the correct `adoptsFrom` pointing to the
+ * darkfactory module (which lives in the software-factory realm,
+ * NOT the target realm).
  */
 export function buildCardDocument(
   cardName: string,
-  realmUrl: string,
+  darkfactoryModuleUrl: string,
   attributes: Record<string, unknown>,
   relationships?: Record<string, unknown>,
 ): LooseSingleCardDocument {
-  let moduleUrl = `${ensureTrailingSlash(realmUrl)}darkfactory`;
+  let moduleUrl = darkfactoryModuleUrl;
   let doc: LooseSingleCardDocument = {
     data: {
       type: 'card',

--- a/packages/software-factory/src/factory-issue-loop-wiring.ts
+++ b/packages/software-factory/src/factory-issue-loop-wiring.ts
@@ -155,6 +155,7 @@ export async function runFactoryIssueLoop(
   let hostAppUrl = config.hostAppUrl ?? realmServerUrl;
   let toolBuilderConfig: ToolBuilderConfig = {
     targetRealmUrl,
+    darkfactoryModuleUrl,
     realmServerUrl,
     realmTokens,
     serverToken,

--- a/packages/software-factory/src/factory-tool-builder.ts
+++ b/packages/software-factory/src/factory-tool-builder.ts
@@ -17,14 +17,12 @@ import type { ToolResult } from './factory-agent';
 import { buildCardDocument } from './darkfactory-schemas';
 import type { ToolExecutor } from './factory-tool-executor';
 import type { ToolRegistry } from './factory-tool-registry';
-import { executeTestRunFromRealm } from './test-run-execution';
-import type { ExecuteTestRunOptions, TestRunHandle } from './test-run-types';
 import {
   writeFile,
   readFile,
   searchRealm,
   runRealmCommand,
-  ensureTrailingSlash,
+  ensureJsonExtension,
   type RealmFetchOptions,
 } from './realm-operations';
 
@@ -47,6 +45,8 @@ export interface FactoryTool {
 
 export interface ToolBuilderConfig {
   targetRealmUrl: string;
+  /** The darkfactory module URL (lives in the software-factory realm, NOT the target realm). */
+  darkfactoryModuleUrl: string;
   /** Per-realm JWTs obtained via getRealmScopedAuth(). */
   realmTokens: Record<string, string>;
   /** Realm server JWT for server-level operations (_create-realm, _realm-auth, _server-session). */
@@ -55,8 +55,6 @@ export interface ToolBuilderConfig {
   testResultsModuleUrl?: string;
   /** Fetch implementation (injectable for testing). */
   fetch?: typeof globalThis.fetch;
-  /** Override for executeTestRunFromRealm (injectable for testing). */
-  executeTestRun?: (options: ExecuteTestRunOptions) => Promise<TestRunHandle>;
   /** Realm server URL. Required — never inferred from realm URLs. */
   realmServerUrl: string;
   /** Host app URL for QUnit test runner. Defaults to realmServerUrl (compat proxy). */
@@ -111,7 +109,6 @@ export function buildFactoryTools(
     buildWriteFileTool(config),
     buildReadFileTool(config),
     buildSearchRealmTool(config),
-    buildRunTestsTool(config),
     buildRunCommandTool(config),
     buildSignalDoneTool(),
     buildRequestClarificationTool(),
@@ -286,23 +283,42 @@ function buildUpdateProjectTool(config: ToolBuilderConfig): FactoryTool {
       schema,
     ),
     execute: async (args) => {
-      let path = args.path as string;
+      let path = ensureJsonExtension(args.path as string);
       let attributes = args.attributes as Record<string, unknown>;
       let relationships = args.relationships as
         | Record<string, unknown>
         | undefined;
       let realmUrl = config.targetRealmUrl;
       let fetchOptions = buildFetchOptions(config, realmUrl);
-      let document = buildCardDocument(
-        'Project',
-        realmUrl,
-        attributes,
-        relationships,
-      );
+
+      // Read-patch-write: preserve attributes the agent didn't include.
+      let existing = await readFile(realmUrl, path, fetchOptions);
+      let doc;
+      if (existing.ok && existing.document) {
+        doc = existing.document;
+        let existingAttrs = (doc.data.attributes ?? {}) as Record<
+          string,
+          unknown
+        >;
+        doc.data.attributes = { ...existingAttrs, ...attributes };
+        if (relationships && Object.keys(relationships).length > 0) {
+          doc.data.relationships = {
+            ...(doc.data.relationships ?? {}),
+            ...relationships,
+          } as typeof doc.data.relationships;
+        }
+      } else {
+        doc = buildCardDocument(
+          'Project',
+          config.darkfactoryModuleUrl,
+          attributes,
+          relationships,
+        );
+      }
       return writeFile(
         realmUrl,
         path,
-        JSON.stringify(document, null, 2),
+        JSON.stringify(doc, null, 2),
         fetchOptions,
       );
     },
@@ -320,23 +336,56 @@ function buildUpdateIssueTool(config: ToolBuilderConfig): FactoryTool {
       schema,
     ),
     execute: async (args) => {
-      let path = args.path as string;
+      let path = ensureJsonExtension(args.path as string);
       let attributes = args.attributes as Record<string, unknown>;
+      // The loop owns issue status transitions (backlog → in_progress → done).
+      // The agent may set status to "blocked" (cannot proceed) or "backlog"
+      // (unblock). The "done" and "in_progress" transitions are managed by
+      // the loop based on signal_done + validation results.
+      let allowedAgentStatuses = ['blocked', 'backlog'];
+      if (
+        attributes.status &&
+        !allowedAgentStatuses.includes(attributes.status as string)
+      ) {
+        delete attributes.status;
+      }
       let relationships = args.relationships as
         | Record<string, unknown>
         | undefined;
       let realmUrl = config.targetRealmUrl;
       let fetchOptions = buildFetchOptions(config, realmUrl);
-      let document = buildCardDocument(
-        'Issue',
-        realmUrl,
-        attributes,
-        relationships,
-      );
+
+      // Read-patch-write: read the existing card source, merge in the
+      // provided attributes/relationships, and write back. This preserves
+      // attributes the agent didn't include in the update call.
+      let existing = await readFile(realmUrl, path, fetchOptions);
+      let doc;
+      if (existing.ok && existing.document) {
+        doc = existing.document;
+        let existingAttrs = (doc.data.attributes ?? {}) as Record<
+          string,
+          unknown
+        >;
+        doc.data.attributes = { ...existingAttrs, ...attributes };
+        if (relationships && Object.keys(relationships).length > 0) {
+          doc.data.relationships = {
+            ...(doc.data.relationships ?? {}),
+            ...relationships,
+          } as typeof doc.data.relationships;
+        }
+      } else {
+        // Card doesn't exist yet — create fresh
+        doc = buildCardDocument(
+          'Issue',
+          config.darkfactoryModuleUrl,
+          attributes,
+          relationships,
+        );
+      }
       return writeFile(
         realmUrl,
         path,
-        JSON.stringify(document, null, 2),
+        JSON.stringify(doc, null, 2),
         fetchOptions,
       );
     },
@@ -354,23 +403,42 @@ function buildCreateKnowledgeTool(config: ToolBuilderConfig): FactoryTool {
       schema,
     ),
     execute: async (args) => {
-      let path = args.path as string;
+      let path = ensureJsonExtension(args.path as string);
       let attributes = args.attributes as Record<string, unknown>;
       let relationships = args.relationships as
         | Record<string, unknown>
         | undefined;
       let realmUrl = config.targetRealmUrl;
       let fetchOptions = buildFetchOptions(config, realmUrl);
-      let document = buildCardDocument(
-        'KnowledgeArticle',
-        realmUrl,
-        attributes,
-        relationships,
-      );
+
+      // Read-patch-write: preserve attributes the agent didn't include.
+      let existing = await readFile(realmUrl, path, fetchOptions);
+      let doc;
+      if (existing.ok && existing.document) {
+        doc = existing.document;
+        let existingAttrs = (doc.data.attributes ?? {}) as Record<
+          string,
+          unknown
+        >;
+        doc.data.attributes = { ...existingAttrs, ...attributes };
+        if (relationships && Object.keys(relationships).length > 0) {
+          doc.data.relationships = {
+            ...(doc.data.relationships ?? {}),
+            ...relationships,
+          } as typeof doc.data.relationships;
+        }
+      } else {
+        doc = buildCardDocument(
+          'KnowledgeArticle',
+          config.darkfactoryModuleUrl,
+          attributes,
+          relationships,
+        );
+      }
       return writeFile(
         realmUrl,
         path,
-        JSON.stringify(document, null, 2),
+        JSON.stringify(doc, null, 2),
         fetchOptions,
       );
     },
@@ -390,7 +458,7 @@ function buildCreateCatalogSpecTool(config: ToolBuilderConfig): FactoryTool {
       schema,
     ),
     execute: async (args) => {
-      let path = args.path as string;
+      let path = ensureJsonExtension(args.path as string);
       let attributes = args.attributes as Record<string, unknown>;
       let relationships = args.relationships as
         | Record<string, unknown>
@@ -425,66 +493,8 @@ function buildCreateCatalogSpecTool(config: ToolBuilderConfig): FactoryTool {
   };
 }
 
-function buildRunTestsTool(config: ToolBuilderConfig): FactoryTool {
-  let lastSequenceBySlug = new Map<string, number>();
-  return {
-    name: 'run_tests',
-    description: 'Execute QUnit card tests against the target realm',
-    parameters: {
-      type: 'object',
-      properties: {
-        slug: {
-          type: 'string',
-          description:
-            'Issue slug used to name the test run (e.g., "define-sticky-note-core")',
-        },
-        testNames: {
-          type: 'array',
-          items: { type: 'string' },
-          description:
-            'Specific test names to run (empty array runs all discovered tests)',
-        },
-        projectCardUrl: {
-          type: 'string',
-          description:
-            'URL to the Project card (used to read/write testArtifactsRealmUrl)',
-        },
-      },
-      required: ['slug'],
-    },
-    execute: async (args) => {
-      let slug = args.slug as string;
-      let targetRealmUrl = config.targetRealmUrl;
-      let authorization = resolveAuthForUrl(config, targetRealmUrl);
-      let testResultsModuleUrl =
-        config.testResultsModuleUrl ??
-        `${ensureTrailingSlash(targetRealmUrl)}test-results`;
-
-      let executeFn = config.executeTestRun ?? executeTestRunFromRealm;
-      let result = await executeFn({
-        targetRealmUrl,
-        testResultsModuleUrl,
-        slug,
-        hostAppUrl: config.hostAppUrl ?? config.realmServerUrl,
-        testNames: (args.testNames as string[]) ?? [],
-        authorization,
-        fetch: config.fetch,
-        projectCardUrl: args.projectCardUrl as string | undefined,
-        realmServerUrl: config.realmServerUrl,
-        forceNew: true,
-        lastSequenceNumber: lastSequenceBySlug.get(slug) ?? 0,
-      });
-
-      // Track the sequence number per slug so subsequent calls don't
-      // reuse it even if the realm search index hasn't caught up yet.
-      if (result.sequenceNumber != null) {
-        lastSequenceBySlug.set(slug, result.sequenceNumber);
-      }
-
-      return result;
-    },
-  };
-}
+// Note: buildRunTestsTool was removed — the validation pipeline runs tests
+// automatically via executeTestRunFromRealm after each agent turn.
 
 function buildSignalDoneTool(): FactoryTool {
   return {
@@ -526,9 +536,10 @@ function buildRunCommandTool(config: ToolBuilderConfig): FactoryTool {
   return {
     name: 'run_command',
     description:
-      'Execute a host command on the realm server via the prerenderer. ' +
-      'Commands run in browser context with full card runtime access. ' +
-      'Use "@cardstack/boxel-host/commands/<name>/default" as the command specifier. ' +
+      'Execute a Boxel host command on the realm server via the prerenderer. ' +
+      'This runs Boxel host commands ONLY — not shell commands, scripts, or Node.js. ' +
+      'Commands must be Boxel host command specifiers in the format ' +
+      '"@cardstack/boxel-host/commands/<name>/default". ' +
       'Auth: realm server token.',
     parameters: {
       type: 'object',
@@ -536,7 +547,7 @@ function buildRunCommandTool(config: ToolBuilderConfig): FactoryTool {
         command: {
           type: 'string',
           description:
-            'Command specifier (e.g., "@cardstack/boxel-host/commands/get-card-type-schema/default")',
+            'Boxel host command specifier — must be in the format "@cardstack/boxel-host/commands/<name>/default"',
         },
         commandInput: {
           type: 'object',

--- a/packages/software-factory/src/factory-tool-builder.ts
+++ b/packages/software-factory/src/factory-tool-builder.ts
@@ -243,6 +243,56 @@ function buildSearchRealmTool(config: ToolBuilderConfig): FactoryTool {
 }
 
 /**
+ * Read-patch-write helper for card update tools.
+ *
+ * Reads the existing card source, merges the provided attributes and
+ * relationships on top, and returns the merged document ready to write.
+ * Only falls back to creating a fresh document on confirmed 404 (card
+ * doesn't exist yet). Other read failures are surfaced as errors to
+ * avoid clobbering existing cards on transient failures.
+ */
+async function readPatchDocument(
+  realmUrl: string,
+  path: string,
+  cardName: string,
+  darkfactoryModuleUrl: string,
+  attributes: Record<string, unknown>,
+  relationships: Record<string, unknown> | undefined,
+  fetchOptions: RealmFetchOptions,
+): Promise<LooseSingleCardDocument> {
+  let existing = await readFile(realmUrl, path, fetchOptions);
+
+  if (existing.ok && existing.document) {
+    let doc = existing.document;
+    let existingAttrs = (doc.data.attributes ?? {}) as Record<string, unknown>;
+    doc.data.attributes = { ...existingAttrs, ...attributes };
+    if (relationships && Object.keys(relationships).length > 0) {
+      doc.data.relationships = {
+        ...(doc.data.relationships ?? {}),
+        ...relationships,
+      } as typeof doc.data.relationships;
+    }
+    return doc;
+  }
+
+  // Only create fresh on 404 (card doesn't exist yet).
+  // Other failures (auth, network, server error) are surfaced.
+  let is404 = existing.error?.startsWith('HTTP 404');
+  if (!existing.ok && is404) {
+    return buildCardDocument(
+      cardName,
+      darkfactoryModuleUrl,
+      attributes,
+      relationships,
+    );
+  }
+
+  throw new Error(
+    `Failed to read existing ${cardName} at "${path}" before update: ${existing.error ?? 'unknown error'}`,
+  );
+}
+
+/**
  * Resolve the schema for a card type from the runtime cache.
  * Only called when the card type is known to exist in cardTypeSchemas
  * (callers check before building the tool).
@@ -292,29 +342,15 @@ function buildUpdateProjectTool(config: ToolBuilderConfig): FactoryTool {
       let fetchOptions = buildFetchOptions(config, realmUrl);
 
       // Read-patch-write: preserve attributes the agent didn't include.
-      let existing = await readFile(realmUrl, path, fetchOptions);
-      let doc;
-      if (existing.ok && existing.document) {
-        doc = existing.document;
-        let existingAttrs = (doc.data.attributes ?? {}) as Record<
-          string,
-          unknown
-        >;
-        doc.data.attributes = { ...existingAttrs, ...attributes };
-        if (relationships && Object.keys(relationships).length > 0) {
-          doc.data.relationships = {
-            ...(doc.data.relationships ?? {}),
-            ...relationships,
-          } as typeof doc.data.relationships;
-        }
-      } else {
-        doc = buildCardDocument(
-          'Project',
-          config.darkfactoryModuleUrl,
-          attributes,
-          relationships,
-        );
-      }
+      let doc = await readPatchDocument(
+        realmUrl,
+        path,
+        'Project',
+        config.darkfactoryModuleUrl,
+        attributes,
+        relationships,
+        fetchOptions,
+      );
       return writeFile(
         realmUrl,
         path,
@@ -337,7 +373,8 @@ function buildUpdateIssueTool(config: ToolBuilderConfig): FactoryTool {
     ),
     execute: async (args) => {
       let path = ensureJsonExtension(args.path as string);
-      let attributes = args.attributes as Record<string, unknown>;
+      // Copy to avoid mutating the caller's args object
+      let attributes = { ...(args.attributes as Record<string, unknown>) };
       // The loop owns issue status transitions (backlog → in_progress → done).
       // The agent may set status to "blocked" (cannot proceed) or "backlog"
       // (unblock). The "done" and "in_progress" transitions are managed by
@@ -355,33 +392,15 @@ function buildUpdateIssueTool(config: ToolBuilderConfig): FactoryTool {
       let realmUrl = config.targetRealmUrl;
       let fetchOptions = buildFetchOptions(config, realmUrl);
 
-      // Read-patch-write: read the existing card source, merge in the
-      // provided attributes/relationships, and write back. This preserves
-      // attributes the agent didn't include in the update call.
-      let existing = await readFile(realmUrl, path, fetchOptions);
-      let doc;
-      if (existing.ok && existing.document) {
-        doc = existing.document;
-        let existingAttrs = (doc.data.attributes ?? {}) as Record<
-          string,
-          unknown
-        >;
-        doc.data.attributes = { ...existingAttrs, ...attributes };
-        if (relationships && Object.keys(relationships).length > 0) {
-          doc.data.relationships = {
-            ...(doc.data.relationships ?? {}),
-            ...relationships,
-          } as typeof doc.data.relationships;
-        }
-      } else {
-        // Card doesn't exist yet — create fresh
-        doc = buildCardDocument(
-          'Issue',
-          config.darkfactoryModuleUrl,
-          attributes,
-          relationships,
-        );
-      }
+      let doc = await readPatchDocument(
+        realmUrl,
+        path,
+        'Issue',
+        config.darkfactoryModuleUrl,
+        attributes,
+        relationships,
+        fetchOptions,
+      );
       return writeFile(
         realmUrl,
         path,
@@ -411,30 +430,15 @@ function buildCreateKnowledgeTool(config: ToolBuilderConfig): FactoryTool {
       let realmUrl = config.targetRealmUrl;
       let fetchOptions = buildFetchOptions(config, realmUrl);
 
-      // Read-patch-write: preserve attributes the agent didn't include.
-      let existing = await readFile(realmUrl, path, fetchOptions);
-      let doc;
-      if (existing.ok && existing.document) {
-        doc = existing.document;
-        let existingAttrs = (doc.data.attributes ?? {}) as Record<
-          string,
-          unknown
-        >;
-        doc.data.attributes = { ...existingAttrs, ...attributes };
-        if (relationships && Object.keys(relationships).length > 0) {
-          doc.data.relationships = {
-            ...(doc.data.relationships ?? {}),
-            ...relationships,
-          } as typeof doc.data.relationships;
-        }
-      } else {
-        doc = buildCardDocument(
-          'KnowledgeArticle',
-          config.darkfactoryModuleUrl,
-          attributes,
-          relationships,
-        );
-      }
+      let doc = await readPatchDocument(
+        realmUrl,
+        path,
+        'KnowledgeArticle',
+        config.darkfactoryModuleUrl,
+        attributes,
+        relationships,
+        fetchOptions,
+      );
       return writeFile(
         realmUrl,
         path,

--- a/packages/software-factory/src/factory-tool-builder.ts
+++ b/packages/software-factory/src/factory-tool-builder.ts
@@ -329,7 +329,7 @@ function buildUpdateProjectTool(config: ToolBuilderConfig): FactoryTool {
     description:
       'Update a project card in the target realm (e.g., update status or success criteria). Auth: per-realm JWT.',
     parameters: buildCardToolParams(
-      'Realm-relative path to the project card (e.g., "Projects/sticky-note-mvp.json")',
+      'Realm-relative path to the project card (e.g., "Projects/sticky-note.json")',
       schema,
     ),
     execute: async (args) => {

--- a/packages/software-factory/src/issue-loop.ts
+++ b/packages/software-factory/src/issue-loop.ts
@@ -427,14 +427,22 @@ export async function runIssueLoop(
 
   log.info(`Outer loop finished: outcome=${outcome}, cycles=${outerCycles}`);
 
-  // Mark the project as completed when all issues are done
+  // Mark the project as completed only when ALL issues in the realm are done
+  // (not just the ones we processed). This prevents marking complete when
+  // pre-existing blocked issues still exist.
   if (outcome === 'all_issues_done' && issueStore.updateProjectStatus) {
-    try {
-      await issueStore.updateProjectStatus('completed');
-    } catch (err) {
-      log.warn(
-        `Failed to update project status to completed: ${err instanceof Error ? err.message : String(err)}`,
-      );
+    let allIssues = await issueStore.listIssues();
+    let allRealmIssuesDone = allIssues.every((i) => i.status === 'done');
+    if (allRealmIssuesDone) {
+      try {
+        await issueStore.updateProjectStatus('completed');
+      } catch (err) {
+        log.warn(
+          `Failed to update project status to completed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    } else {
+      log.info(`Not marking project completed — some issues are not done`);
     }
   }
 

--- a/packages/software-factory/src/issue-loop.ts
+++ b/packages/software-factory/src/issue-loop.ts
@@ -432,7 +432,8 @@ export async function runIssueLoop(
   // pre-existing blocked issues still exist.
   if (outcome === 'all_issues_done' && issueStore.updateProjectStatus) {
     let allIssues = await issueStore.listIssues();
-    let allRealmIssuesDone = allIssues.every((i) => i.status === 'done');
+    let allRealmIssuesDone =
+      allIssues.length > 0 && allIssues.every((i) => i.status === 'done');
     if (allRealmIssuesDone) {
       try {
         await issueStore.updateProjectStatus('completed');

--- a/packages/software-factory/src/issue-loop.ts
+++ b/packages/software-factory/src/issue-loop.ts
@@ -259,6 +259,18 @@ export async function runIssueLoop(
       `Outer cycle ${outerCycles}: picked issue ${issueSummaryLabel(issue)} (status=${issue.status}, priority=${issue.priority})`,
     );
 
+    // Mark the issue as in_progress when the loop picks it up
+    if (issue.status !== 'in_progress') {
+      try {
+        await issueStore.updateIssue(issue.id, { status: 'in_progress' });
+        issue = await scheduler.refreshIssueState(issue);
+      } catch (err) {
+        log.warn(
+          `  Failed to set issue to in_progress: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
     // Create a fresh validator scoped to this issue so that artifacts
     // (e.g. TestRun cards) are named per-issue rather than shared.
     let validator = createValidator(issue.id);
@@ -296,6 +308,30 @@ export async function runIssueLoop(
       // Validation — runs after every agent turn
       validationResults = await validator.validate(targetRealmUrl);
       log.info(`  Validation: ${formatValidation(validationResults)}`);
+
+      // The loop owns issue status transitions. The agent signals
+      // completion via signal_done; the loop promotes to "done" only
+      // when signal_done is called AND validation passes.
+      let agentSignaledDone = result.toolCalls.some(
+        (tc) => tc.tool === 'signal_done',
+      );
+
+      if (agentSignaledDone && validationResults?.passed) {
+        try {
+          await issueStore.updateIssue(issue.id, { status: 'done' });
+          log.info(
+            `  Issue marked done (agent called signal_done, validation passed)`,
+          );
+        } catch (err) {
+          log.warn(
+            `  Failed to mark issue as done: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      } else if (agentSignaledDone && !validationResults?.passed) {
+        log.info(
+          `  Agent signaled done but validation failed — continuing iteration`,
+        );
+      }
 
       // Refresh issue state from realm
       issue = await scheduler.refreshIssueState(issue);
@@ -390,6 +426,17 @@ export async function runIssueLoop(
   }
 
   log.info(`Outer loop finished: outcome=${outcome}, cycles=${outerCycles}`);
+
+  // Mark the project as completed when all issues are done
+  if (outcome === 'all_issues_done' && issueStore.updateProjectStatus) {
+    try {
+      await issueStore.updateProjectStatus('completed');
+    } catch (err) {
+      log.warn(
+        `Failed to update project status to completed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
 
   return { outcome, outerCycles, issueResults };
 }

--- a/packages/software-factory/src/issue-scheduler.ts
+++ b/packages/software-factory/src/issue-scheduler.ts
@@ -285,13 +285,14 @@ export class RealmIssueStore implements IssueStore {
   }
 
   async updateProjectStatus(projectStatus: string): Promise<void> {
-    // Find the project card in the realm
+    // We expect exactly one Project card per target realm.
     let result = await searchRealm(
       this.realmUrl,
       {
         filter: {
           type: { module: this.darkfactoryModuleUrl, name: 'Project' },
         },
+        sort: [{ by: 'lastModified', direction: 'desc' as const }],
       },
       this.options,
     );

--- a/packages/software-factory/src/issue-scheduler.ts
+++ b/packages/software-factory/src/issue-scheduler.ts
@@ -16,6 +16,7 @@ import {
   searchRealm,
   readFile,
   writeFile,
+  ensureJsonExtension,
   type RealmFetchOptions,
 } from './realm-operations';
 import { logger } from './logger';
@@ -40,6 +41,8 @@ export interface IssueStore {
     issueId: string,
     updates: { status?: string; description?: string },
   ): Promise<void>;
+  /** Update a project's status in the realm. */
+  updateProjectStatus?(projectStatus: string): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -243,7 +246,7 @@ export class RealmIssueStore implements IssueStore {
     // stripped relationships during indexing).
     let readResult = await readFile(
       this.realmUrl,
-      `${issueId}.json`,
+      ensureJsonExtension(issueId),
       this.options,
     );
     if (!readResult.ok || !readResult.document) {
@@ -267,7 +270,7 @@ export class RealmIssueStore implements IssueStore {
 
     let writeResult = await writeFile(
       this.realmUrl,
-      `${issueId}.json`,
+      ensureJsonExtension(issueId),
       JSON.stringify(doc, null, 2),
       this.options,
     );
@@ -279,6 +282,62 @@ export class RealmIssueStore implements IssueStore {
     }
 
     log.info(`Updated issue "${issueId}": ${JSON.stringify(updates)}`);
+  }
+
+  async updateProjectStatus(projectStatus: string): Promise<void> {
+    // Find the project card in the realm
+    let result = await searchRealm(
+      this.realmUrl,
+      {
+        filter: {
+          type: { module: this.darkfactoryModuleUrl, name: 'Project' },
+        },
+      },
+      this.options,
+    );
+
+    if (!result.ok || !result.data?.length) {
+      log.warn(
+        `No project found to update status: ${!result.ok ? result.error : 'no results'}`,
+      );
+      return;
+    }
+
+    let projectId = result.data[0].id as string;
+    // Strip the realm URL prefix to get the relative path
+    let relativePath = projectId.replace(this.realmUrl, '');
+
+    let readResult = await readFile(
+      this.realmUrl,
+      ensureJsonExtension(relativePath),
+      this.options,
+    );
+    if (!readResult.ok || !readResult.document) {
+      log.warn(
+        `Failed to read project "${relativePath}" for status update: ${readResult.error ?? 'no document'}`,
+      );
+      return;
+    }
+
+    let doc = readResult.document;
+    let attrs = (doc.data.attributes ?? {}) as Record<string, unknown>;
+    attrs.projectStatus = projectStatus;
+    attrs.updatedAt = new Date().toISOString();
+    doc.data.attributes = attrs;
+
+    let writeResult = await writeFile(
+      this.realmUrl,
+      ensureJsonExtension(relativePath),
+      JSON.stringify(doc, null, 2),
+      this.options,
+    );
+
+    if (!writeResult.ok) {
+      log.warn(`Failed to update project status: ${writeResult.error}`);
+      return;
+    }
+
+    log.info(`Updated project "${relativePath}" status to "${projectStatus}"`);
   }
 }
 

--- a/packages/software-factory/src/realm-operations.ts
+++ b/packages/software-factory/src/realm-operations.ts
@@ -26,6 +26,18 @@ export function ensureTrailingSlash(url: string): string {
   return url.endsWith('/') ? url : `${url}/`;
 }
 
+/**
+ * Ensure a card instance path ends with `.json`. The realm API uses
+ * `card+source` content negotiation which requires the full file path
+ * including extension.
+ */
+export function ensureJsonExtension(path: string): string {
+  if (!path.endsWith('.json')) {
+    return `${path}.json`;
+  }
+  return path;
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------

--- a/packages/software-factory/src/test-run-execution.ts
+++ b/packages/software-factory/src/test-run-execution.ts
@@ -532,10 +532,13 @@ export async function executeTestRunFromRealm(
 
     await page.goto(pageUrl, { waitUntil: 'domcontentloaded' });
 
-    // Wait for QUnit to finish (results collected via inline script hooks)
+    // Wait for QUnit to finish (results collected via inline script hooks).
+    // Note: waitForFunction(fn, arg, options) — pass null as arg so the
+    // timeout option is correctly in the third position.
     await page.waitForFunction(
       () => (window as any).__qunitResults?.runEnd !== null,
-      { timeout: 120_000 },
+      null,
+      { timeout: 300_000 },
     );
 
     let qunitResults: QunitResults = await page.evaluate(

--- a/packages/software-factory/tests/factory-tool-builder.test.ts
+++ b/packages/software-factory/tests/factory-tool-builder.test.ts
@@ -12,10 +12,6 @@ import {
 } from '../src/factory-tool-builder';
 import type { ToolExecutor } from '../src/factory-tool-executor';
 import { ToolRegistry } from '../src/factory-tool-registry';
-import type {
-  ExecuteTestRunOptions,
-  TestRunHandle,
-} from '../src/test-run-types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -65,6 +61,8 @@ const DEFAULT_CARD_TYPE_SCHEMAS = new Map<
 function makeConfig(overrides?: Partial<ToolBuilderConfig>): ToolBuilderConfig {
   return {
     targetRealmUrl: TARGET_REALM,
+    darkfactoryModuleUrl:
+      'https://realms.example.test/software-factory/darkfactory',
     realmServerUrl: 'https://realms.example.test/',
     realmTokens: {
       [TARGET_REALM]: TARGET_TOKEN,
@@ -85,6 +83,8 @@ interface CapturedRequest {
 function createMockFetch(
   status: number,
   responseBody: unknown,
+  /** Optional: return this document for GET requests (read-patch-write support). */
+  getResponseBody?: unknown,
 ): {
   fetch: typeof globalThis.fetch;
   requests: CapturedRequest[];
@@ -103,12 +103,27 @@ function createMockFetch(
         headers[k] = v;
       }
     }
+    let method = init?.method ?? 'GET';
     requests.push({
       url,
-      method: init?.method ?? 'GET',
+      method,
       headers,
       body: typeof init?.body === 'string' ? init.body : '',
     });
+    // For GET requests (reads), return the getResponseBody if provided,
+    // otherwise return 404 (card doesn't exist yet → fresh create).
+    if (method === 'GET' && getResponseBody !== undefined) {
+      return new Response(JSON.stringify(getResponseBody), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (method === 'GET' && getResponseBody === undefined) {
+      return new Response('Not Found', {
+        status: 404,
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    }
     return new Response(JSON.stringify(responseBody), {
       status,
       headers: { 'Content-Type': 'application/json' },
@@ -304,7 +319,19 @@ module('factory-tool-builder > realm targeting and auth', function () {
   });
 
   test('update_issue uses target realm JWT', async function (assert) {
-    let { fetch: mockFetch, requests } = createMockFetch(200, {});
+    let existingDoc = {
+      data: {
+        type: 'card',
+        attributes: { issueId: 'SN-1', summary: 'Existing issue' },
+        meta: {
+          adoptsFrom: {
+            module: 'https://realms.example.test/software-factory/darkfactory',
+            name: 'Issue',
+          },
+        },
+      },
+    };
+    let { fetch: mockFetch, requests } = createMockFetch(200, {}, existingDoc);
     let registry = new ToolRegistry();
     let { executor } = createMockToolExecutor(new Map());
     let config = makeConfig({ fetch: mockFetch });
@@ -313,11 +340,13 @@ module('factory-tool-builder > realm targeting and auth', function () {
 
     await updateTool.execute({
       path: 'Issues/1.json',
-      attributes: { status: 'done' },
+      attributes: { status: 'blocked' },
     });
 
-    assert.strictEqual(requests[0].headers['Authorization'], TARGET_TOKEN);
-    assert.strictEqual(requests[0].url, `${TARGET_REALM}Issues/1.json`);
+    // First request is GET (read), second is POST (write)
+    let writeRequest = requests.find((r) => r.method === 'POST')!;
+    assert.strictEqual(writeRequest.headers['Authorization'], TARGET_TOKEN);
+    assert.strictEqual(writeRequest.url, `${TARGET_REALM}Issues/1.json`);
   });
 
   test('create_knowledge uses target realm JWT', async function (assert) {
@@ -713,8 +742,95 @@ module(
       assert.true(toolNames.includes('run_command'));
     });
 
-    test('update_issue assembles JSON:API document from attributes', async function (assert) {
-      let { fetch: mockFetch, requests } = createMockFetch(200, {});
+    test('update_issue merges attributes with existing card (read-patch-write)', async function (assert) {
+      let existingIssue = {
+        data: {
+          type: 'card',
+          attributes: {
+            issueId: 'SN-1',
+            summary: 'Original summary',
+            description: 'Original description',
+            status: 'backlog',
+            priority: 'high',
+          },
+          meta: {
+            adoptsFrom: {
+              module:
+                'https://realms.example.test/software-factory/darkfactory',
+              name: 'Issue',
+            },
+          },
+        },
+      };
+      let { fetch: mockFetch, requests } = createMockFetch(
+        200,
+        {},
+        existingIssue,
+      );
+      let registry = new ToolRegistry();
+      let { executor } = createMockToolExecutor(new Map());
+      let config = makeConfig({ fetch: mockFetch });
+      let tools = buildFactoryTools(config, executor, registry);
+      let tool = findTool(tools, 'update_issue');
+
+      await tool.execute({
+        path: 'Issues/1.json',
+        attributes: { status: 'blocked', summary: 'Updated summary' },
+      });
+
+      let writeRequest = requests.find((r) => r.method === 'POST')!;
+      let body = JSON.parse(writeRequest.body);
+      assert.strictEqual(body.data.type, 'card');
+      assert.strictEqual(
+        body.data.attributes.status,
+        'blocked',
+        'agent can set status to blocked',
+      );
+      assert.strictEqual(
+        body.data.attributes.summary,
+        'Updated summary',
+        'provided attributes are updated',
+      );
+      assert.strictEqual(
+        body.data.attributes.description,
+        'Original description',
+        'existing attributes are preserved',
+      );
+      assert.strictEqual(
+        body.data.attributes.issueId,
+        'SN-1',
+        'existing issueId preserved',
+      );
+      assert.strictEqual(
+        body.data.attributes.priority,
+        'high',
+        'existing priority preserved',
+      );
+    });
+
+    test('update_issue strips disallowed status values', async function (assert) {
+      let existingIssue = {
+        data: {
+          type: 'card',
+          attributes: {
+            issueId: 'SN-1',
+            summary: 'Existing',
+            status: 'in_progress',
+          },
+          meta: {
+            adoptsFrom: {
+              module:
+                'https://realms.example.test/software-factory/darkfactory',
+              name: 'Issue',
+            },
+          },
+        },
+      };
+      let { fetch: mockFetch, requests } = createMockFetch(
+        200,
+        {},
+        existingIssue,
+      );
       let registry = new ToolRegistry();
       let { executor } = createMockToolExecutor(new Map());
       let config = makeConfig({ fetch: mockFetch });
@@ -726,19 +842,89 @@ module(
         attributes: { status: 'done', summary: 'Build sticky note' },
       });
 
-      assert.strictEqual(requests.length, 1);
-      let body = JSON.parse(requests[0].body);
-      assert.strictEqual(body.data.type, 'card');
-      assert.strictEqual(body.data.attributes.status, 'done');
-      assert.strictEqual(body.data.meta.adoptsFrom.name, 'Issue');
+      let writeRequest = requests.find((r) => r.method === 'POST')!;
+      let body = JSON.parse(writeRequest.body);
       assert.strictEqual(
-        body.data.meta.adoptsFrom.module,
-        `${TARGET_REALM}darkfactory`,
+        body.data.attributes.status,
+        'in_progress',
+        'done status is stripped — existing status preserved',
+      );
+      assert.strictEqual(
+        body.data.attributes.summary,
+        'Build sticky note',
+        'other attributes are updated',
+      );
+    });
+
+    test('update_issue allows blocked and backlog status', async function (assert) {
+      let existingIssue = {
+        data: {
+          type: 'card',
+          attributes: { issueId: 'SN-1', status: 'in_progress' },
+          meta: {
+            adoptsFrom: {
+              module:
+                'https://realms.example.test/software-factory/darkfactory',
+              name: 'Issue',
+            },
+          },
+        },
+      };
+      let { fetch: mockFetch, requests } = createMockFetch(
+        200,
+        {},
+        existingIssue,
+      );
+      let registry = new ToolRegistry();
+      let { executor } = createMockToolExecutor(new Map());
+      let config = makeConfig({ fetch: mockFetch });
+      let tools = buildFactoryTools(config, executor, registry);
+      let tool = findTool(tools, 'update_issue');
+
+      await tool.execute({
+        path: 'Issues/1.json',
+        attributes: { status: 'blocked', summary: 'Stuck' },
+      });
+      let writeRequests = requests.filter((r) => r.method === 'POST');
+      let body1 = JSON.parse(writeRequests[0].body);
+      assert.strictEqual(
+        body1.data.attributes.status,
+        'blocked',
+        'blocked is allowed',
+      );
+
+      await tool.execute({
+        path: 'Issues/1.json',
+        attributes: { status: 'backlog', summary: 'Unblocked' },
+      });
+      writeRequests = requests.filter((r) => r.method === 'POST');
+      let body2 = JSON.parse(writeRequests[1].body);
+      assert.strictEqual(
+        body2.data.attributes.status,
+        'backlog',
+        'backlog is allowed',
       );
     });
 
     test('card tools omit empty relationships from document', async function (assert) {
-      let { fetch: mockFetch, requests } = createMockFetch(200, {});
+      let existingProject = {
+        data: {
+          type: 'card',
+          attributes: { projectCode: 'SN', projectName: 'Sticky Note' },
+          meta: {
+            adoptsFrom: {
+              module:
+                'https://realms.example.test/software-factory/darkfactory',
+              name: 'Project',
+            },
+          },
+        },
+      };
+      let { fetch: mockFetch, requests } = createMockFetch(
+        200,
+        {},
+        existingProject,
+      );
       let registry = new ToolRegistry();
       let { executor } = createMockToolExecutor(new Map());
       let config = makeConfig({ fetch: mockFetch });
@@ -750,131 +936,18 @@ module(
         attributes: { projectStatus: 'completed' },
       });
 
-      let body = JSON.parse(requests[0].body);
+      let writeRequest = requests.find((r) => r.method === 'POST')!;
+      let body = JSON.parse(writeRequest.body);
       assert.strictEqual(
         body.data.relationships,
         undefined,
-        'no relationships key when none provided',
+        'no relationships key when none provided and none existed',
       );
     });
   },
 );
 
-// ---------------------------------------------------------------------------
-// run_tests tool
-// ---------------------------------------------------------------------------
-
-module('factory-tool-builder > run_tests', function () {
-  test('run_tests tool is built and has correct parameters', function (assert) {
-    let registry = new ToolRegistry();
-    let { executor } = createMockToolExecutor(new Map());
-    let config = makeConfig();
-    let tools = buildFactoryTools(config, executor, registry);
-    let runTestsTool = findTool(tools, 'run_tests');
-
-    assert.strictEqual(runTestsTool.name, 'run_tests');
-    let params = runTestsTool.parameters as {
-      required?: string[];
-      properties?: Record<string, unknown>;
-    };
-    assert.true(params.required!.includes('slug'));
-    assert.true('testNames' in params.properties!);
-    assert.true('projectCardUrl' in params.properties!);
-  });
-
-  test('run_tests passes correct options to executeTestRun', async function (assert) {
-    let capturedOptions: ExecuteTestRunOptions | undefined;
-    let mockHandle: TestRunHandle = {
-      testRunId: 'TestRun/run-1',
-      status: 'passed',
-    };
-
-    let registry = new ToolRegistry();
-    let { executor } = createMockToolExecutor(new Map());
-    let config = makeConfig({
-      serverToken: 'Bearer server-jwt',
-      testResultsModuleUrl:
-        'https://realms.example.test/user/target/test-results',
-      executeTestRun: async (options: ExecuteTestRunOptions) => {
-        capturedOptions = options;
-        return mockHandle;
-      },
-    });
-    let tools = buildFactoryTools(config, executor, registry);
-    let runTestsTool = findTool(tools, 'run_tests');
-
-    let result = await runTestsTool.execute({
-      slug: 'define-sticky-note',
-      testNames: ['renders fitted view'],
-      projectCardUrl: 'https://realms.example.test/user/target/Project/mvp',
-    });
-
-    assert.ok(capturedOptions, 'executeTestRun was called');
-    assert.strictEqual(capturedOptions!.targetRealmUrl, TARGET_REALM);
-    assert.strictEqual(
-      capturedOptions!.testResultsModuleUrl,
-      'https://realms.example.test/user/target/test-results',
-    );
-    assert.strictEqual(capturedOptions!.slug, 'define-sticky-note');
-    assert.deepEqual(capturedOptions!.testNames, ['renders fitted view']);
-    assert.strictEqual(capturedOptions!.authorization, TARGET_TOKEN);
-    assert.strictEqual(
-      capturedOptions!.projectCardUrl,
-      'https://realms.example.test/user/target/Project/mvp',
-    );
-
-    // Verify the result is passed through
-    let handle = result as TestRunHandle;
-    assert.strictEqual(handle.testRunId, 'TestRun/run-1');
-    assert.strictEqual(handle.status, 'passed');
-  });
-
-  test('run_tests uses default testResultsModuleUrl when not configured', async function (assert) {
-    let capturedOptions: ExecuteTestRunOptions | undefined;
-
-    let registry = new ToolRegistry();
-    let { executor } = createMockToolExecutor(new Map());
-    let config = makeConfig({
-      executeTestRun: async (options: ExecuteTestRunOptions) => {
-        capturedOptions = options;
-        return { testRunId: 'TestRun/run-1', status: 'passed' as const };
-      },
-    });
-    let tools = buildFactoryTools(config, executor, registry);
-    let runTestsTool = findTool(tools, 'run_tests');
-
-    await runTestsTool.execute({
-      slug: 'test-slug',
-    });
-
-    assert.strictEqual(
-      capturedOptions!.testResultsModuleUrl,
-      `${TARGET_REALM}test-results`,
-    );
-  });
-
-  test('run_tests uses target realm JWT for authorization', async function (assert) {
-    let capturedOptions: ExecuteTestRunOptions | undefined;
-
-    let registry = new ToolRegistry();
-    let { executor } = createMockToolExecutor(new Map());
-    let config = makeConfig({
-      executeTestRun: async (options: ExecuteTestRunOptions) => {
-        capturedOptions = options;
-        return { testRunId: 'TestRun/run-1', status: 'passed' as const };
-      },
-    });
-    let tools = buildFactoryTools(config, executor, registry);
-    let runTestsTool = findTool(tools, 'run_tests');
-
-    await runTestsTool.execute({
-      slug: 'auth-test',
-    });
-
-    assert.strictEqual(
-      capturedOptions!.authorization,
-      TARGET_TOKEN,
-      'should use target realm JWT',
-    );
-  });
-});
+// Note: run_tests is no longer exposed as an agent tool — the validation
+// pipeline runs tests automatically via executeTestRunFromRealm after
+// each agent turn. The buildRunTestsTool function still exists but is
+// not included in buildFactoryTools output.

--- a/packages/software-factory/tests/factory-tool-builder.test.ts
+++ b/packages/software-factory/tests/factory-tool-builder.test.ts
@@ -949,5 +949,5 @@ module(
 
 // Note: run_tests is no longer exposed as an agent tool — the validation
 // pipeline runs tests automatically via executeTestRunFromRealm after
-// each agent turn. The buildRunTestsTool function still exists but is
-// not included in buildFactoryTools output.
+// each agent turn. The former buildRunTestsTool implementation has been
+// removed and is no longer part of buildFactoryTools.

--- a/packages/software-factory/tests/factory-tool-executor.spec.ts
+++ b/packages/software-factory/tests/factory-tool-executor.spec.ts
@@ -248,6 +248,7 @@ async function buildToolsForRealm(realm: {
   return buildFactoryTools(
     {
       targetRealmUrl: realm.realmURL.href,
+      darkfactoryModuleUrl: `${realm.realmServerURL.href}software-factory/darkfactory`,
       realmServerUrl: realm.realmServerURL.href,
       realmTokens: {
         [realm.realmURL.href]: `Bearer ${realm.ownerBearerToken}`,

--- a/packages/software-factory/tests/factory-tool-executor.spec.ts
+++ b/packages/software-factory/tests/factory-tool-executor.spec.ts
@@ -300,7 +300,7 @@ test('update_issue writes and reads back an issue card', async ({ realm }) => {
     path: 'Issues/tool-test-issue.json',
     attributes: {
       summary: 'Test issue for update_issue tool',
-      status: 'in_progress',
+      status: 'blocked',
       priority: 'high',
     },
   })) as CardWriteResult;
@@ -315,7 +315,7 @@ test('update_issue writes and reads back an issue card', async ({ realm }) => {
   expect(readResult.document!.data.attributes!.summary).toBe(
     'Test issue for update_issue tool',
   );
-  expect(readResult.document!.data.attributes!.status).toBe('in_progress');
+  expect(readResult.document!.data.attributes!.status).toBe('blocked');
 });
 
 test('create_knowledge writes and reads back a knowledge article', async ({

--- a/packages/software-factory/tests/issue-loop.test.ts
+++ b/packages/software-factory/tests/issue-loop.test.ts
@@ -26,6 +26,7 @@ import {
 class MockIssueStore implements IssueStore {
   issues: SchedulableIssue[];
   updateCalls: { issueId: string; updates: Record<string, unknown> }[] = [];
+  projectStatusCalls: string[] = [];
 
   constructor(issues: SchedulableIssue[]) {
     this.issues = issues.map((i) => ({ ...i }));
@@ -48,6 +49,15 @@ class MockIssueStore implements IssueStore {
     updates: { status?: string; description?: string },
   ): Promise<void> {
     this.updateCalls.push({ issueId, updates });
+    // Apply status change so refreshIssue reflects it
+    let issue = this.issues.find((i) => i.id === issueId);
+    if (issue && updates.status) {
+      issue.status = updates.status as SchedulableIssue['status'];
+    }
+  }
+
+  async updateProjectStatus(projectStatus: string): Promise<void> {
+    this.projectStatusCalls.push(projectStatus);
   }
 }
 
@@ -554,11 +564,14 @@ module('issue-loop > max inner iterations', function () {
       }),
     );
 
-    assert.strictEqual(store.updateCalls.length, 1, 'updateIssue called once');
-    assert.strictEqual(store.updateCalls[0].issueId, 'iss-1');
-    assert.strictEqual(store.updateCalls[0].updates.status, 'blocked');
+    // First call sets in_progress, second call blocks
+    let blockCall = store.updateCalls.find(
+      (c) => c.updates.status === 'blocked',
+    );
+    assert.ok(blockCall, 'updateIssue called with status: blocked');
+    assert.strictEqual(blockCall!.issueId, 'iss-1');
     assert.ok(
-      (store.updateCalls[0].updates.description as string).includes(
+      (blockCall!.updates.description as string).includes(
         'max iteration limit',
       ),
       'description includes reason',
@@ -889,6 +902,221 @@ module('issue-loop > createValidator receives issue ID', function () {
       receivedIssueIds,
       ['Issues/sticky-note-define-core', 'Issues/sticky-note-catalog-spec'],
       'createValidator received the correct issue IDs in order',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 13. Auto-mark done when agent calls signal_done + validation passes
+// ---------------------------------------------------------------------------
+
+module('issue-loop > auto-mark done on signal_done', function () {
+  test('auto-marks issue done when agent calls signal_done and validation passes', async function (assert) {
+    let store = new MockIssueStore([
+      makeIssue({ id: 'iss-1', status: 'backlog', priority: 'high', order: 1 }),
+    ]);
+
+    // Agent calls signal_done but does NOT update issue status
+    let agent = new MockLoopAgent(
+      [
+        {
+          toolCalls: [
+            { tool: 'write_file', args: { path: 'card.gts', content: 'v1' } },
+            { tool: 'signal_done', args: {} },
+          ],
+        },
+      ],
+      store,
+    );
+
+    let result = await runIssueLoop(
+      makeLoopConfig({
+        agent,
+        issueStore: store,
+        createValidator: () => new MockValidator([makePassingValidation()]),
+      }),
+    );
+
+    assert.strictEqual(result.outcome, 'all_issues_done');
+    assert.strictEqual(result.issueResults[0].exitReason, 'done');
+    assert.strictEqual(result.issueResults[0].innerIterations, 1);
+
+    // Verify the loop auto-marked the issue as done
+    let doneUpdate = store.updateCalls.find(
+      (c) => c.issueId === 'iss-1' && c.updates.status === 'done',
+    );
+    assert.ok(doneUpdate, 'loop called updateIssue with status: done');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 14. signal_done + validation fails → continues iterating (no done status)
+// ---------------------------------------------------------------------------
+
+module('issue-loop > signal_done with failing validation', function () {
+  test('does not mark done when agent signals done but validation fails', async function (assert) {
+    let store = new MockIssueStore([
+      makeIssue({ id: 'iss-1', status: 'backlog', priority: 'high', order: 1 }),
+    ]);
+
+    let agent = new MockLoopAgent(
+      [
+        // Iteration 1: agent signals done but validation fails
+        {
+          toolCalls: [
+            { tool: 'write_file', args: { path: 'card.gts', content: 'v1' } },
+            { tool: 'signal_done', args: {} },
+          ],
+        },
+        // Iteration 2: agent fixes code and signals done, validation passes
+        {
+          toolCalls: [
+            {
+              tool: 'write_file',
+              args: { path: 'card.gts', content: 'v2 fixed' },
+            },
+            { tool: 'signal_done', args: {} },
+          ],
+        },
+      ],
+      store,
+    );
+
+    let result = await runIssueLoop(
+      makeLoopConfig({
+        agent,
+        issueStore: store,
+        createValidator: () =>
+          new MockValidator([makeFailingValidation(), makePassingValidation()]),
+      }),
+    );
+
+    assert.strictEqual(result.outcome, 'all_issues_done');
+    assert.strictEqual(result.issueResults[0].exitReason, 'done');
+    assert.strictEqual(
+      result.issueResults[0].innerIterations,
+      2,
+      'took 2 iterations because validation failed on first',
+    );
+
+    // Only one done call — from the second iteration when validation passed
+    let doneCalls = store.updateCalls.filter(
+      (c) => c.updates.status === 'done',
+    );
+    assert.strictEqual(
+      doneCalls.length,
+      1,
+      'only marked done once (after validation passed)',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 15. Issue set to in_progress on pickup
+// ---------------------------------------------------------------------------
+
+module('issue-loop > in_progress on pickup', function () {
+  test('sets issue to in_progress when picked up from backlog', async function (assert) {
+    let store = new MockIssueStore([
+      makeIssue({ id: 'iss-1', status: 'backlog', priority: 'high', order: 1 }),
+    ]);
+
+    let agent = new MockLoopAgent(
+      [
+        {
+          toolCalls: [
+            { tool: 'write_file', args: { path: 'card.gts', content: 'v1' } },
+          ],
+          updateIssue: { id: 'iss-1', status: 'done' },
+        },
+      ],
+      store,
+    );
+
+    await runIssueLoop(
+      makeLoopConfig({
+        agent,
+        issueStore: store,
+        createValidator: () => new MockValidator([makePassingValidation()]),
+      }),
+    );
+
+    let firstUpdate = store.updateCalls[0];
+    assert.strictEqual(
+      firstUpdate.updates.status,
+      'in_progress',
+      'first updateIssue call sets in_progress',
+    );
+    assert.strictEqual(firstUpdate.issueId, 'iss-1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 16. Project marked completed when all issues done
+// ---------------------------------------------------------------------------
+
+module('issue-loop > project completion', function () {
+  test('project status set to completed when all issues done', async function (assert) {
+    let store = new MockIssueStore([
+      makeIssue({ id: 'iss-1', status: 'backlog', priority: 'high', order: 1 }),
+    ]);
+
+    let agent = new MockLoopAgent(
+      [
+        {
+          toolCalls: [
+            { tool: 'write_file', args: { path: 'card.gts', content: 'v1' } },
+            { tool: 'signal_done', args: {} },
+          ],
+        },
+      ],
+      store,
+    );
+
+    let result = await runIssueLoop(
+      makeLoopConfig({
+        agent,
+        issueStore: store,
+        createValidator: () => new MockValidator([makePassingValidation()]),
+      }),
+    );
+
+    assert.strictEqual(result.outcome, 'all_issues_done');
+    assert.deepEqual(
+      store.projectStatusCalls,
+      ['completed'],
+      'project status set to completed',
+    );
+  });
+
+  test('project status NOT set when some issues blocked', async function (assert) {
+    let store = new MockIssueStore([
+      makeIssue({ id: 'iss-1', status: 'backlog', priority: 'high', order: 1 }),
+    ]);
+
+    let agent = new MockLoopAgent(
+      [
+        {
+          toolCalls: [{ tool: 'read_file', args: { path: 'brief.md' } }],
+          updateIssue: { id: 'iss-1', status: 'blocked' },
+        },
+      ],
+      store,
+    );
+
+    let result = await runIssueLoop(
+      makeLoopConfig({
+        agent,
+        issueStore: store,
+        createValidator: () => new MockValidator([makePassingValidation()]),
+      }),
+    );
+
+    assert.strictEqual(result.outcome, 'no_unblocked_issues');
+    assert.deepEqual(
+      store.projectStatusCalls,
+      [],
+      'project status NOT updated when issues blocked',
     );
   });
 });


### PR DESCRIPTION
## Summary

Addresses state transition issues, testing infrastructure bugs, and consistency problems discovered through repeated end-to-end cycling of the software factory flow (`factory:go` → bootstrap → implement → validate). Each fix was validated by running the full e2e loop (10 runs).

### Orchestrator owns issue status transitions

The agent can no longer set issue status to `done` or `in_progress` — the loop manages these transitions:
- `backlog` → `in_progress`: when the loop picks up an issue
- `in_progress` → `done`: when the agent calls `signal_done` AND validation passes
- Agent can only set `blocked` (can't proceed) or `backlog` (unblock)

Previously the agent could mark issues `done` before validation passed, causing the loop to exit with failing tests.

### Card update tools use read-patch-write

`update_issue`, `update_project`, and `create_knowledge` now read the existing card, merge provided attributes, and write back — instead of creating a fresh document that clobbers existing attributes. This was a critical bug: the bootstrap-seed issue was reduced to just `status` and `updatedAt` after an update.

### Fix darkfactory module URL in buildCardDocument

`buildCardDocument()` was constructing `adoptsFrom.module` from the target realm URL instead of the software-factory realm. This caused `refreshIssue()` searches (which filter by type module) to not find updated cards, making the loop think issues were still in `backlog` after being marked `done`.

### Fix Playwright waitForFunction timeout

The timeout was passed as the second argument (treated as `arg`) instead of the third (options). Playwright fell back to its 30s default, causing test runs that took 30-50s to silently time out instead of completing.

### Remove run_tests from agent tools

The validation pipeline runs tests automatically after every agent turn. Giving the agent the `run_tests` tool caused it to waste iterations running tests manually (sometimes before writing test files), creating duplicate TestRun instances, and even attempting to run Node.js scripts via `run_command`.

### Other fixes

- **ensureJsonExtension**: Card tool paths normalized with `.json` (realm API `card+source` requires full path with extension)
- **Project auto-completion**: Project status set to `completed` when all issues done
- **Status badges**: Issue and Project cards show colored status badges in fitted + isolated templates (matching TestRun pattern)
- **TestRun 0/0 empty state**: Shows gray "empty" badge instead of green "passed" when no tests ran
- **Fix uneven red border**: Failing test module group border is now uniform
- **Issue linked-card**: Project in Issue isolated view uses `@format='embedded'` to prevent layout occlusion
- **Drop "MVP" suffix**: Project naming convention simplified
- **run_command description**: Explicitly states "Boxel host commands ONLY"
- **Updated phase-2-plan.md**: Documents all validated design decisions

## Test plan

- [x] `pnpm lint` passes (lint:js, lint:types, lint:format)
- [x] `pnpm test` — 352 unit tests pass (17 new tests covering status transitions, auto-mark, revert, project completion, read-patch-write, status stripping)
- [x] 10 end-to-end runs (`smoke-test-1` through `smoke-test-10`) validating the full `factory:go` flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)