### PR TITLE
Fix cross-realm linksTo MIME type handling for file/image defs

### DIFF
--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1283,6 +1283,101 @@ module(basename(__filename), function () {
           );
         });
       });
+
+      module('cross-realm FileDef linksTo', function (hooks) {
+        let consumerRealm: Realm;
+
+        setupPermissionedRealmsCached(hooks, {
+          mode: 'before',
+          realms: [
+            // provider
+            {
+              realmURL: testRealm1URL,
+              permissions: {
+                ['@node-test_realm:localhost']: ['read'],
+              },
+              fileSystem: {
+                'cross-realm-note.txt': 'hello from provider realm',
+              },
+            },
+            // consumer
+            {
+              realmURL: testRealm2URL,
+              permissions: {
+                '*': ['read', 'write'],
+                '@node-test_realm:localhost': ['read', 'realm-owner'],
+              },
+              fileSystem: {
+                'file-linker.gts': `
+                  import { CardDef, field, linksTo } from "https://cardstack.com/base/card-api";
+                  import { FileDef } from "https://cardstack.com/base/file-api";
+
+                  export class FileLinker extends CardDef {
+                    @field attachment = linksTo(() => FileDef);
+                  }
+                `,
+                'file-linker-1.json': {
+                  data: {
+                    attributes: {},
+                    relationships: {
+                      attachment: {
+                        links: {
+                          self: `${testRealm1URL}cross-realm-note.txt`,
+                        },
+                        // Simulate stale relationship typing that can appear in index payloads.
+                        data: {
+                          type: 'card',
+                          id: `${testRealm1URL}cross-realm-note.txt`,
+                        },
+                      },
+                    },
+                    meta: {
+                      adoptsFrom: {
+                        module: './file-linker',
+                        name: 'FileLinker',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+          onRealmSetup({ dbAdapter, realms }) {
+            permissionedDbAdapter = dbAdapter;
+            consumerRealm = realms.find(
+              ({ realm }) => realm.url === testRealm2URL,
+            )!.realm;
+          },
+        });
+
+        test('indexes cross-realm linksTo FileDef relationships', async function (assert) {
+          let entry = await consumerRealm.realmIndexQueryEngine.instance(
+            new URL(`${testRealm2URL}file-linker-1`),
+          );
+          assert.strictEqual(entry?.type, 'instance', 'instance indexes');
+
+          let rows = (await permissionedDbAdapter.execute(
+            `SELECT has_error
+             FROM boxel_index
+             WHERE url = $1
+               AND type = 'instance'
+               AND (is_deleted = FALSE OR is_deleted IS NULL)`,
+            { bind: [`${testRealm2URL}file-linker-1.json`] },
+          )) as { has_error: boolean | null }[];
+          assert.strictEqual(rows.length, 1, 'found one instance index row');
+          assert.false(Boolean(rows[0]?.has_error), 'instance row has no error');
+
+          let deps = await depsForIndexEntry(
+            permissionedDbAdapter,
+            `${testRealm2URL}file-linker-1.json`,
+            'instance',
+          );
+          assert.ok(
+            deps.includes(`${testRealm1URL}cross-realm-note.txt`),
+            'deps include cross-realm FileDef target URL',
+          );
+        });
+      });
     });
   });
 

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -41,7 +41,6 @@ import {
   type CodeRef,
 } from './code-ref';
 import {
-  isSingleCardDocument,
   type SingleCardDocument,
   type LinkableCollectionDocument,
   isLinkableCollectionDocument,
@@ -960,9 +959,18 @@ export class RealmIndexQueryEngine {
             }
           }
         } else {
-          let response = await this.#fetch(linkURL, {
-            headers: { Accept: SupportedMimeType.CardJson },
-          });
+          let response: Response;
+
+          if(expectsCard){
+            response = await this.#fetch(linkURL, {
+              headers: { Accept: SupportedMimeType.CardJson },
+            });
+          } else {
+            response = await this.#fetch(linkURL, {
+              headers: { Accept: SupportedMimeType.FileMeta },
+            });
+          }
+
           if (!response.ok) {
             let cardError = await CardError.fromFetchResponse(
               linkURL.href,
@@ -970,18 +978,8 @@ export class RealmIndexQueryEngine {
             );
             throw cardError;
           }
+
           let json = await response.json();
-          if (!isSingleCardDocument(json)) {
-            throw new Error(
-              `instance ${
-                linkURL.href
-              } is not a card document. it is: ${JSON.stringify(
-                json,
-                null,
-                2,
-              )}`,
-            );
-          }
           linkResource = {
             ...json.data,
             ...{ links: { self: json.data.id } },

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -961,7 +961,7 @@ export class RealmIndexQueryEngine {
         } else {
           let response: Response;
 
-          if(expectsCard){
+          if (expectsCard) {
             response = await this.#fetch(linkURL, {
               headers: { Accept: SupportedMimeType.CardJson },
             });


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-10730/card-thumbnail-linksto-imagedeffiledef-fails-to-save-for-cross-realm

Previously, cross-realm linksTo requests for file-def and image-def could send an incorrect Accept header and fail with 415 Unsupported Media Type.(from console)
<img width="2194" height="1518" alt="image" src="https://github.com/user-attachments/assets/440b7efb-d75b-42f2-a20e-99391985aa13" />


## Changes:

1. In loadLinks, use expectsCard as the primary signal for cross-realm links.
2. If expectsCard is true, fetch with card MIME type.
3. Otherwise, fetch with file-meta MIME type.
4. Remove the card-only isSingleCardDocument assertion from this mixed cross-realm path to avoid false failures on valid file-meta responses.

## Result:

Cross-realm file-def/image-def links resolve correctly.
Eliminates 415 errors caused by wrong media type negotiation.


https://github.com/user-attachments/assets/714bcd40-597f-4aea-9e9a-dded0a8cab59

