### PR TITLE
Add linting for data-test attributes used outside of tests, and relevant fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,4 +37,27 @@ module.exports = {
       { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
     ],
   },
+  overrides: [
+    {
+      // Disallow data-test-* CSS selectors in app code across all packages.
+      // ember-test-selectors strips these attributes in production, so selectors
+      // like querySelector('[data-test-foo]') silently break outside of tests.
+      files: ['**/app/**/*.{js,ts,gts,gjs}', '**/src/**/*.{js,ts,gts,gjs}'],
+      rules: {
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector: 'Literal[value=/\\[data-test-/]',
+            message:
+              '`data-test-*` attributes are stripped in production builds. Use a plain `data-*` attribute (e.g. `[data-foo]`) for functional selectors.',
+          },
+          {
+            selector: 'TemplateElement[value.raw=/\\[data-test-/]',
+            message:
+              '`data-test-*` attributes are stripped in production builds. Use a plain `data-*` attribute (e.g. `[data-foo]`) for functional selectors.',
+          },
+        ],
+      },
+    },
+  ],
 };

--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -220,7 +220,7 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
     // the wrong input when multiple editors exist on the page
     let container = this.editorView?.dom?.parentElement;
     let input = (container ?? document).querySelector(
-      '[data-test-card-search-input]',
+      '[data-codemirror-card-search-input]',
     ) as HTMLInputElement;
     input?.focus();
   };
@@ -362,13 +362,31 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
         let fromCoords = view.coordsAtPos(from);
         let toCoords = view.coordsAtPos(to);
         if (!fromCoords || !toCoords) {
-          return { x: 0, y: 0, width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 } as DOMRect;
+          return {
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 0,
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+          } as DOMRect;
         }
         let left = Math.min(fromCoords.left, toCoords.left);
         let top = fromCoords.top;
         let right = Math.max(fromCoords.right, toCoords.right);
         let bottom = toCoords.bottom;
-        return { x: left, y: top, width: right - left, height: bottom - top, top, left, right, bottom } as DOMRect;
+        return {
+          x: left,
+          y: top,
+          width: right - left,
+          height: bottom - top,
+          top,
+          left,
+          right,
+          bottom,
+        } as DOMRect;
       },
     };
 
@@ -377,7 +395,10 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
       let scrollParent = view.dom.closest('.boxel-card-container');
       let parentRect = scrollParent?.getBoundingClientRect();
       let selRect = virtualEl.getBoundingClientRect();
-      if (parentRect && (selRect.bottom < parentRect.top || selRect.top > parentRect.bottom)) {
+      if (
+        parentRect &&
+        (selRect.bottom < parentRect.top || selRect.top > parentRect.bottom)
+      ) {
         element.style.display = 'none';
         return;
       }
@@ -510,7 +531,11 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
       let line = view.state.doc.line(i);
       if (allHavePrefix) {
         // Remove prefix from all lines
-        changes.push({ from: line.from, to: line.from + prefix.length, insert: '' });
+        changes.push({
+          from: line.from,
+          to: line.from + prefix.length,
+          insert: '',
+        });
       } else if (!line.text.startsWith(prefix)) {
         // Add prefix to lines that don't have it
         changes.push({ from: line.from, to: line.from, insert: prefix });
@@ -816,7 +841,8 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
           data-test-floating-toolbar
         >
           <button
-            class='toolbar-btn {{if this.toolbarFormats.bold "toolbar-btn--active"}}'
+            class='toolbar-btn
+              {{if this.toolbarFormats.bold "toolbar-btn--active"}}'
             data-test-toolbar-bold
             title='Bold'
             aria-label='Bold'
@@ -825,7 +851,8 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
             {{on 'click' this._wrapBold}}
           ><BoldIcon width='16' height='16' /></button>
           <button
-            class='toolbar-btn {{if this.toolbarFormats.italic "toolbar-btn--active"}}'
+            class='toolbar-btn
+              {{if this.toolbarFormats.italic "toolbar-btn--active"}}'
             data-test-toolbar-italic
             title='Italic'
             aria-label='Italic'
@@ -834,7 +861,8 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
             {{on 'click' this._wrapItalic}}
           ><ItalicIcon width='16' height='16' /></button>
           <button
-            class='toolbar-btn {{if this.toolbarFormats.strikethrough "toolbar-btn--active"}}'
+            class='toolbar-btn
+              {{if this.toolbarFormats.strikethrough "toolbar-btn--active"}}'
             data-test-toolbar-strikethrough
             title='Strikethrough'
             aria-label='Strikethrough'
@@ -843,7 +871,8 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
             {{on 'click' this._wrapStrikethrough}}
           ><StrikethroughIcon width='16' height='16' /></button>
           <button
-            class='toolbar-btn {{if this.toolbarFormats.code "toolbar-btn--active"}}'
+            class='toolbar-btn
+              {{if this.toolbarFormats.code "toolbar-btn--active"}}'
             data-test-toolbar-code
             title='Code'
             aria-label='Code'
@@ -852,7 +881,8 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
             {{on 'click' this._wrapCode}}
           ><CodeIcon width='16' height='16' /></button>
           <button
-            class='toolbar-btn {{if this.toolbarFormats.link "toolbar-btn--active"}}'
+            class='toolbar-btn
+              {{if this.toolbarFormats.link "toolbar-btn--active"}}'
             data-test-toolbar-link
             title='Link'
             aria-label='Link'
@@ -930,6 +960,7 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
             placeholder='Search cards or paste URL…'
             aria-label='Search cards or paste URL'
             value={{this._cardSearchText}}
+            data-codemirror-card-search-input
             data-test-card-search-input
             {{on 'input' this._handleCardSearchInput}}
             {{on 'keydown' this._handleCardSearchKeydown}}
@@ -1263,239 +1294,239 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
           min-height: 40px;
         }
 
-        /* Card slot wrappers rendered via{{in-element}}*/
-             .codemirror-editor :deep(.codemirror-card-slot) {
-               contain: layout style paint;
-             }
+        /* Card slot wrappers rendered via in-element helper */
+        .codemirror-editor :deep(.codemirror-card-slot) {
+          contain: layout style paint;
+        }
 
-             .codemirror-editor :deep(.codemirror-card-slot--inline) {
-               display: inline-flex;
-               align-items: center;
-               gap: 4px;
-               background-color: var(--boxel-100, #f0f0f0);
-               border: 1px solid var(--boxel-border-color, #c4c4c4);
-               border-radius: var(--boxel-border-radius, 4px);
-               padding: 1px 6px;
-               font-size: 0.85em;
-               cursor: pointer;
-             }
+        .codemirror-editor :deep(.codemirror-card-slot--inline) {
+          display: inline-flex;
+          align-items: center;
+          gap: 4px;
+          background-color: var(--boxel-100, #f0f0f0);
+          border: 1px solid var(--boxel-border-color, #c4c4c4);
+          border-radius: var(--boxel-border-radius, 4px);
+          padding: 1px 6px;
+          font-size: 0.85em;
+          cursor: pointer;
+        }
 
-             .codemirror-editor :deep(.codemirror-card-slot--block) {
-               display: block;
-               border: 1px solid var(--boxel-border-color, #c4c4c4);
-               border-radius: var(--boxel-border-radius, 4px);
-               overflow: hidden;
-             }
+        .codemirror-editor :deep(.codemirror-card-slot--block) {
+          display: block;
+          border: 1px solid var(--boxel-border-color, #c4c4c4);
+          border-radius: var(--boxel-border-radius, 4px);
+          overflow: hidden;
+        }
 
-             /* Fallback for unresolved card references */
-             .codemirror-editor :deep(.codemirror-card-fallback) {
-               display: inline-block;
-               padding: 1px 6px;
-               background-color: var(--boxel-100, #f0f0f0);
-               border: 1px dashed var(--boxel-border-color, #c4c4c4);
-               border-radius: var(--boxel-border-radius, 4px);
-               font-size: 0.85em;
-               color: var(--boxel-400, #666);
-               word-break: break-all;
-             }
+        /* Fallback for unresolved card references */
+        .codemirror-editor :deep(.codemirror-card-fallback) {
+          display: inline-block;
+          padding: 1px 6px;
+          background-color: var(--boxel-100, #f0f0f0);
+          border: 1px dashed var(--boxel-border-color, #c4c4c4);
+          border-radius: var(--boxel-border-radius, 4px);
+          font-size: 0.85em;
+          color: var(--boxel-400, #666);
+          word-break: break-all;
+        }
 
-             /* ── Floating toolbar ── */
-             .codemirror-floating-toolbar {
-               position: fixed;
-               z-index: 110;
-               display: flex;
-               align-items: center;
-               gap: 2px;
-               padding: 4px 6px;
-               background: var(--boxel-dark, #27272a);
-               border-radius: 8px;
-               box-shadow: 0 4px 14px rgb(0 0 0 / 0.25);
-               pointer-events: auto;
-               width: max-content;
-               top: 0;
-               left: 0;
-             }
+        /* ── Floating toolbar ── */
+        .codemirror-floating-toolbar {
+          position: fixed;
+          z-index: 110;
+          display: flex;
+          align-items: center;
+          gap: 2px;
+          padding: 4px 6px;
+          background: var(--boxel-dark, #27272a);
+          border-radius: 8px;
+          box-shadow: 0 4px 14px rgb(0 0 0 / 0.25);
+          pointer-events: auto;
+          width: max-content;
+          top: 0;
+          left: 0;
+        }
 
-             .toolbar-btn {
-               display: flex;
-               align-items: center;
-               justify-content: center;
-               width: 28px;
-               height: 28px;
-               border: none;
-               border-radius: 4px;
-               background: transparent;
-               color: var(--boxel-light, #fafafa);
-               cursor: pointer;
-               padding: 0;
-               transition: background-color 0.1s;
-             }
+        .toolbar-btn {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 28px;
+          height: 28px;
+          border: none;
+          border-radius: 4px;
+          background: transparent;
+          color: var(--boxel-light, #fafafa);
+          cursor: pointer;
+          padding: 0;
+          transition: background-color 0.1s;
+        }
 
-             .toolbar-btn:hover {
-               background: rgb(255 255 255 / 0.15);
-             }
+        .toolbar-btn:hover {
+          background: rgb(255 255 255 / 0.15);
+        }
 
-             .toolbar-btn--active {
-               background: rgb(255 255 255 / 0.2);
-               color: var(--boxel-highlight, #6366f1);
-             }
+        .toolbar-btn--active {
+          background: rgb(255 255 255 / 0.2);
+          color: var(--boxel-highlight, #6366f1);
+        }
 
-             .toolbar-divider {
-               width: 1px;
-               height: 18px;
-               background: rgb(255 255 255 / 0.2);
-               margin: 0 4px;
-             }
+        .toolbar-divider {
+          width: 1px;
+          height: 18px;
+          background: rgb(255 255 255 / 0.2);
+          margin: 0 4px;
+        }
 
-             .codemirror-editor-loading {
-               min-height: 120px;
-               display: flex;
-               align-items: center;
-               justify-content: center;
-               color: var(--boxel-400, #999);
-               font-style: italic;
-             }
+        .codemirror-editor-loading {
+          min-height: 120px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          color: var(--boxel-400, #999);
+          font-style: italic;
+        }
 
-             /* ── Card search popup ── */
-             .codemirror-card-search {
-               position: absolute;
-               z-index: 100;
-               background: var(--boxel-light, #fff);
-               border: 1px solid var(--boxel-border-color, #c4c4c4);
-               border-radius: var(--boxel-border-radius, 4px);
-               box-shadow: 0 4px 12px rgb(0 0 0 / 0.15);
-               min-width: 280px;
-               max-width: 400px;
-               padding: 8px;
-             }
+        /* ── Card search popup ── */
+        .codemirror-card-search {
+          position: absolute;
+          z-index: 100;
+          background: var(--boxel-light, #fff);
+          border: 1px solid var(--boxel-border-color, #c4c4c4);
+          border-radius: var(--boxel-border-radius, 4px);
+          box-shadow: 0 4px 12px rgb(0 0 0 / 0.15);
+          min-width: 280px;
+          max-width: 400px;
+          padding: 8px;
+        }
 
-             .codemirror-card-search-input {
-               width: 100%;
-               padding: 6px 10px;
-               border: 1px solid var(--boxel-border-color, #c4c4c4);
-               border-radius: var(--boxel-border-radius, 4px);
-               font: inherit;
-               font-size: 0.9em;
-               outline: none;
-               box-sizing: border-box;
-             }
+        .codemirror-card-search-input {
+          width: 100%;
+          padding: 6px 10px;
+          border: 1px solid var(--boxel-border-color, #c4c4c4);
+          border-radius: var(--boxel-border-radius, 4px);
+          font: inherit;
+          font-size: 0.9em;
+          outline: none;
+          box-sizing: border-box;
+        }
 
-             .codemirror-card-search-input:focus {
-               border-color: var(--boxel-highlight, #0078d4);
-               box-shadow: 0 0 0 1px var(--boxel-highlight, #0078d4);
-             }
+        .codemirror-card-search-input:focus {
+          border-color: var(--boxel-highlight, #0078d4);
+          box-shadow: 0 0 0 1px var(--boxel-highlight, #0078d4);
+        }
 
-             .codemirror-card-search-loading {
-               padding: 8px 4px;
-               color: var(--boxel-400, #666);
-               font-size: 0.85em;
-               font-style: italic;
-             }
+        .codemirror-card-search-loading {
+          padding: 8px 4px;
+          color: var(--boxel-400, #666);
+          font-size: 0.85em;
+          font-style: italic;
+        }
 
-             .codemirror-card-search-results {
-               margin-top: 4px;
-               max-height: 240px;
-               overflow-y: auto;
-             }
+        .codemirror-card-search-results {
+          margin-top: 4px;
+          max-height: 240px;
+          overflow-y: auto;
+        }
 
-             .codemirror-card-search-result {
-               display: flex;
-               flex-direction: column;
-               align-items: flex-start;
-               width: 100%;
-               padding: 6px 10px;
-               border: none;
-               background: transparent;
-               cursor: pointer;
-               border-radius: var(--boxel-border-radius, 4px);
-               text-align: left;
-               font: inherit;
-             }
+        .codemirror-card-search-result {
+          display: flex;
+          flex-direction: column;
+          align-items: flex-start;
+          width: 100%;
+          padding: 6px 10px;
+          border: none;
+          background: transparent;
+          cursor: pointer;
+          border-radius: var(--boxel-border-radius, 4px);
+          text-align: left;
+          font: inherit;
+        }
 
-             .codemirror-card-search-result:hover,
-             .codemirror-card-search-result.selected {
-               background: var(--boxel-highlight-hover, #e8f0fe);
-             }
+        .codemirror-card-search-result:hover,
+        .codemirror-card-search-result.selected {
+          background: var(--boxel-highlight-hover, #e8f0fe);
+        }
 
-             .search-result-title {
-               font-weight: 500;
-               font-size: 0.9em;
-             }
+        .search-result-title {
+          font-weight: 500;
+          font-size: 0.9em;
+        }
 
-             .search-result-url {
-               font-size: 0.75em;
-               color: var(--boxel-400, #666);
-               word-break: break-all;
-             }
+        .search-result-url {
+          font-size: 0.75em;
+          color: var(--boxel-400, #666);
+          word-break: break-all;
+        }
 
-             /* ── Format picker popup ── */
-             .codemirror-format-picker {
-               position: absolute;
-               z-index: 100;
-               background: var(--boxel-light, #fff);
-               border: 1px solid var(--boxel-border-color, #c4c4c4);
-               border-radius: var(--boxel-border-radius, 4px);
-               box-shadow: 0 4px 12px rgb(0 0 0 / 0.15);
-               padding: 12px;
-               min-width: 220px;
-             }
+        /* ── Format picker popup ── */
+        .codemirror-format-picker {
+          position: absolute;
+          z-index: 100;
+          background: var(--boxel-light, #fff);
+          border: 1px solid var(--boxel-border-color, #c4c4c4);
+          border-radius: var(--boxel-border-radius, 4px);
+          box-shadow: 0 4px 12px rgb(0 0 0 / 0.15);
+          padding: 12px;
+          min-width: 220px;
+        }
 
-             .format-picker-label {
-               display: block;
-               font-size: 0.85em;
-               color: var(--boxel-400, #666);
-               margin-bottom: 8px;
-               word-break: break-word;
-             }
+        .format-picker-label {
+          display: block;
+          font-size: 0.85em;
+          color: var(--boxel-400, #666);
+          margin-bottom: 8px;
+          word-break: break-word;
+        }
 
-             .format-picker-buttons {
-               display: flex;
-               gap: 8px;
-               margin-bottom: 8px;
-             }
+        .format-picker-buttons {
+          display: flex;
+          gap: 8px;
+          margin-bottom: 8px;
+        }
 
-             .format-picker-btn {
-               flex: 1;
-               padding: 6px 12px;
-               border: 1px solid var(--boxel-border-color, #c4c4c4);
-               border-radius: var(--boxel-border-radius, 4px);
-               background: var(--boxel-light, #fff);
-               cursor: pointer;
-               font: inherit;
-               font-size: 0.9em;
-             }
+        .format-picker-btn {
+          flex: 1;
+          padding: 6px 12px;
+          border: 1px solid var(--boxel-border-color, #c4c4c4);
+          border-radius: var(--boxel-border-radius, 4px);
+          background: var(--boxel-light, #fff);
+          cursor: pointer;
+          font: inherit;
+          font-size: 0.9em;
+        }
 
-             .format-picker-btn:hover {
-               background: var(--boxel-highlight-hover, #e8f0fe);
-             }
+        .format-picker-btn:hover {
+          background: var(--boxel-highlight-hover, #e8f0fe);
+        }
 
-             .format-picker-btn--primary {
-               background: var(--boxel-highlight, #0078d4);
-               color: white;
-               border-color: var(--boxel-highlight, #0078d4);
-             }
+        .format-picker-btn--primary {
+          background: var(--boxel-highlight, #0078d4);
+          color: white;
+          border-color: var(--boxel-highlight, #0078d4);
+        }
 
-             .format-picker-btn--primary:hover {
-               opacity: 0.9;
-             }
+        .format-picker-btn--primary:hover {
+          opacity: 0.9;
+        }
 
-             .format-picker-dismiss {
-               display: block;
-               width: 100%;
-               padding: 4px;
-               border: none;
-               background: transparent;
-               color: var(--boxel-400, #666);
-               cursor: pointer;
-               font: inherit;
-               font-size: 0.8em;
-               text-align: center;
-             }
+        .format-picker-dismiss {
+          display: block;
+          width: 100%;
+          padding: 4px;
+          border: none;
+          background: transparent;
+          color: var(--boxel-400, #666);
+          cursor: pointer;
+          font: inherit;
+          font-size: 0.8em;
+          text-align: center;
+        }
 
-             .format-picker-dismiss:hover {
-               color: var(--boxel-dark, #333);
-             }
-           }
+        .format-picker-dismiss:hover {
+          color: var(--boxel-dark, #333);
+        }
+      }
     </style>
   </template>
 }

--- a/packages/boxel-ui/addon/.eslintrc.cjs
+++ b/packages/boxel-ui/addon/.eslintrc.cjs
@@ -118,27 +118,6 @@ module.exports = {
       },
     },
     {
-      // Disallow data-test-* CSS selectors in addon source code.
-      // ember-test-selectors strips these attributes in production, so selectors
-      // like querySelector('[data-test-foo]') silently break outside of tests.
-      files: ['src/**/*.{js,ts,gts,gjs}'],
-      rules: {
-        'no-restricted-syntax': [
-          'error',
-          {
-            selector: 'Literal[value=/\\[data-test-/]',
-            message:
-              '`data-test-*` attributes are stripped in production builds. Use a plain `data-*` attribute (e.g. `[data-foo]`) for functional selectors.',
-          },
-          {
-            selector: 'TemplateElement[value.raw=/\\[data-test-/]',
-            message:
-              '`data-test-*` attributes are stripped in production builds. Use a plain `data-*` attribute (e.g. `[data-foo]`) for functional selectors.',
-          },
-        ],
-      },
-    },
-    {
       // typescript-eslint recommends turning off no-undef for Typescript files since
       // Typescript will better analyse that:
       // https://github.com/typescript-eslint/typescript-eslint/blob/5b0e577f2552e8b2c53a3fb22edc9d219589b937/docs/linting/Troubleshooting.mdx#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors

--- a/packages/boxel-ui/addon/.eslintrc.cjs
+++ b/packages/boxel-ui/addon/.eslintrc.cjs
@@ -118,6 +118,27 @@ module.exports = {
       },
     },
     {
+      // Disallow data-test-* CSS selectors in addon source code.
+      // ember-test-selectors strips these attributes in production, so selectors
+      // like querySelector('[data-test-foo]') silently break outside of tests.
+      files: ['src/**/*.{js,ts,gts,gjs}'],
+      rules: {
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector: 'Literal[value=/\\[data-test-/]',
+            message:
+              '`data-test-*` attributes are stripped in production builds. Use a plain `data-*` attribute (e.g. `[data-foo]`) for functional selectors.',
+          },
+          {
+            selector: 'TemplateElement[value.raw=/\\[data-test-/]',
+            message:
+              '`data-test-*` attributes are stripped in production builds. Use a plain `data-*` attribute (e.g. `[data-foo]`) for functional selectors.',
+          },
+        ],
+      },
+    },
+    {
       // typescript-eslint recommends turning off no-undef for Typescript files since
       // Typescript will better analyse that:
       // https://github.com/typescript-eslint/typescript-eslint/blob/5b0e577f2552e8b2c53a3fb22edc9d219589b937/docs/linting/Troubleshooting.mdx#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors

--- a/packages/boxel-ui/addon/src/components/card-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-container/index.gts
@@ -25,6 +25,7 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
         boxel-card-container--boundaries=@displayBoundaries
         boxel-card-container--themed=@isThemed
       }}
+      data-boxel-card-container
       data-test-boxel-card-container
       ...attributes
     >

--- a/packages/boxel-ui/addon/src/components/picker/before-options-with-search.gts
+++ b/packages/boxel-ui/addon/src/components/picker/before-options-with-search.gts
@@ -112,7 +112,7 @@ export default class PickerBeforeOptionsWithSearch extends Component<BeforeOptio
 
   private scrollSummaryItemIntoView(id: string) {
     const el = document.querySelector(
-      `.picker-before-options__option[data-test-boxel-picker-summary-item="${id}"]`,
+      `[data-boxel-picker-summary-item="${id}"]`,
     );
     if (el instanceof HTMLElement) {
       el.scrollIntoView({ block: 'nearest' });
@@ -257,6 +257,7 @@ export default class PickerBeforeOptionsWithSearch extends Component<BeforeOptio
             @isHighlighted={{eq this.summaryHighlightId item.id}}
             @select={{@select}}
             class='picker-before-options__option'
+            data-boxel-picker-summary-item={{item.id}}
             data-test-boxel-picker-summary-item={{item.id}}
           />
         {{/each}}

--- a/packages/experiments-realm/components/search-input.gts
+++ b/packages/experiments-realm/components/search-input.gts
@@ -51,6 +51,7 @@ export class SearchInput extends Component<Signature> {
         @onInput={{this.onInput}}
         {{on 'keydown' this.onSearchInputKeyDown}}
         autocomplete='off'
+        data-search-field
         data-test-search-field
       />
     </div>

--- a/packages/host/.eslintrc.js
+++ b/packages/host/.eslintrc.js
@@ -137,27 +137,6 @@ module.exports = {
       },
     },
     {
-      // Disallow data-test-* CSS selectors in app code.
-      // ember-test-selectors strips these attributes in production, so selectors
-      // like querySelector('[data-test-foo]') silently break outside of tests.
-      files: ['app/**/*.{js,ts,gts,gjs}'],
-      rules: {
-        'no-restricted-syntax': [
-          'error',
-          {
-            selector: 'Literal[value=/\\[data-test-/]',
-            message:
-              '`data-test-*` attributes are stripped in production builds. Use a plain `data-*` attribute (e.g. `[data-foo]`) for functional selectors.',
-          },
-          {
-            selector: 'TemplateElement[value.raw=/\\[data-test-/]',
-            message:
-              '`data-test-*` attributes are stripped in production builds. Use a plain `data-*` attribute (e.g. `[data-foo]`) for functional selectors.',
-          },
-        ],
-      },
-    },
-    {
       // don't enforce import order on blueprint files
       files: ['app/**', 'tests/**'],
       excludedFiles: ['app/app.ts', 'app/router.ts', 'tests/test-helper.js'],

--- a/packages/host/.eslintrc.js
+++ b/packages/host/.eslintrc.js
@@ -137,7 +137,28 @@ module.exports = {
       },
     },
     {
-      // don’t enforce import order on blueprint files
+      // Disallow data-test-* CSS selectors in app code.
+      // ember-test-selectors strips these attributes in production, so selectors
+      // like querySelector('[data-test-foo]') silently break outside of tests.
+      files: ['app/**/*.{js,ts,gts,gjs}'],
+      rules: {
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector: 'Literal[value=/\\[data-test-/]',
+            message:
+              '`data-test-*` attributes are stripped in production builds. Use a plain `data-*` attribute (e.g. `[data-foo]`) for functional selectors.',
+          },
+          {
+            selector: 'TemplateElement[value.raw=/\\[data-test-/]',
+            message:
+              '`data-test-*` attributes are stripped in production builds. Use a plain `data-*` attribute (e.g. `[data-foo]`) for functional selectors.',
+          },
+        ],
+      },
+    },
+    {
+      // don't enforce import order on blueprint files
       files: ['app/**', 'tests/**'],
       excludedFiles: ['app/app.ts', 'app/router.ts', 'tests/test-helper.js'],
       extends: ['plugin:import/recommended', 'plugin:import/typescript'],

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -125,7 +125,7 @@ export default class CardCatalogModal extends Component<Signature> {
                 isActive=(not state.dismissModal)
                 additionalElements=this.focusTrapAdditionalElements
                 focusTrapOptions=(hash
-                  initialFocus='[data-test-search-field]' allowOutsideClick=true
+                  initialFocus='[data-search-field]' allowOutsideClick=true
                 )
               }}
               {{on 'keydown' this.handleKeydown}}

--- a/packages/host/app/components/card-search/search-bar.gts
+++ b/packages/host/app/components/card-search/search-bar.gts
@@ -115,6 +115,7 @@ export default class SearchBar extends Component<Signature> {
           id={{@id}}
           {{elementCallback @onInputInsertion}}
           {{autoFocus}}
+          data-search-field
           data-test-search-field
         />
       </div>

--- a/packages/host/app/components/head-format-preview.gts
+++ b/packages/host/app/components/head-format-preview.gts
@@ -36,9 +36,7 @@ export default class HeadFormatPreview extends Component<Signature> {
     let getMarkupSource = () => {
       // Remove the noise of the card container in the raw head preview
       return (
-        element.querySelector<HTMLElement>(
-          '[data-test-boxel-card-container]',
-        ) ??
+        element.querySelector<HTMLElement>('[data-boxel-card-container]') ??
         element.firstElementChild ??
         element
       );

--- a/packages/host/app/components/host-mode/breadcrumbs.gts
+++ b/packages/host/app/components/host-mode/breadcrumbs.gts
@@ -67,6 +67,7 @@ export default class HostModeBreadcrumbs extends Component<Signature> {
       class='host-mode-breadcrumbs {{unless this.hasCards "empty"}}'
       aria-label='Card stack navigation'
       hidden={{not this.hasCards}}
+      data-host-mode-breadcrumbs
       data-test-host-mode-breadcrumbs
       ...attributes
     >

--- a/packages/host/app/components/host-mode/stack.gts
+++ b/packages/host/app/components/host-mode/stack.gts
@@ -30,7 +30,7 @@ export default class HostModeStack extends Component<Signature> {
           class='stack-items'
           {{onClickOutside
             this.closeTopCard
-            exceptSelector='[data-test-host-mode-breadcrumbs]'
+            exceptSelector='[data-host-mode-breadcrumbs]'
           }}
           data-test-host-mode-stack-items
         >

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -167,6 +167,7 @@ export default class CreateFileModal extends Component<Signature> {
             )
           }}
           data-test-ready={{this.isReady}}
+          data-create-file-modal
           data-test-create-file-modal
         >
           <:content>
@@ -221,6 +222,7 @@ export default class CreateFileModal extends Component<Signature> {
                 {{#if (eq this.fileType.id 'text-file')}}
                   <FieldContainer @label='File Name' @tag='label' class='field'>
                     <BoxelInput
+                      data-text-file-name-field
                       data-test-text-file-name-field
                       placeholder='notes'
                       @value={{this.fileName}}
@@ -655,9 +657,9 @@ export default class CreateFileModal extends Component<Signature> {
       case 'field-definition':
       case 'file-definition':
       case 'duplicate-instance':
-        return '.create-file-modal .realm-dropdown-trigger';
+        return '[data-create-file-modal] [data-realm-dropdown-trigger]';
       case 'text-file':
-        return '.create-file-modal [data-test-text-file-name-field]';
+        return '[data-create-file-modal] [data-text-file-name-field]';
       default:
         return false;
     }

--- a/packages/host/app/components/realm-dropdown.gts
+++ b/packages/host/app/components/realm-dropdown.gts
@@ -49,6 +49,7 @@ export default class RealmDropdown extends Component<Signature> {
           @size='small'
           @disabled={{@disabled}}
           {{bindings}}
+          data-realm-dropdown-trigger
           data-test-realm-dropdown-trigger
           data-test-realm-name={{this.selectedRealm.name}}
           title={{this.selectedItemText}}

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -1809,6 +1809,7 @@ module(`Integration | realm indexing`, function (hooks) {
       cleanWhiteSpace(
         `<div
           class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card embedded-format display-container-true"
+          data-boxel-card-container
           data-test-boxel-card-container
           style
           data-test-card="http://test-realm/test/germaine"
@@ -1835,6 +1836,7 @@ module(`Integration | realm indexing`, function (hooks) {
       ),
       cleanWhiteSpace(`<div
         class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card embedded-format display-container-true"
+        data-boxel-card-container
         data-test-boxel-card-container
         style
         data-test-card="http://test-realm/test/germaine"
@@ -1851,6 +1853,7 @@ module(`Integration | realm indexing`, function (hooks) {
       cleanWhiteSpace(stripScopedCSSAttributes(embeddedHtml![cardDefRefURL])),
       cleanWhiteSpace(`<div
         class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card embedded-format display-container-true"
+        data-boxel-card-container
         data-test-boxel-card-container
         style
         data-test-card="http://test-realm/test/germaine"
@@ -1945,6 +1948,7 @@ module(`Integration | realm indexing`, function (hooks) {
       cleanWhiteSpace(
         `<div
           class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card fitted-format display-container-true"
+          data-boxel-card-container
           data-test-boxel-card-container
           style
           data-test-card="http://test-realm/test/germaine"
@@ -1971,6 +1975,7 @@ module(`Integration | realm indexing`, function (hooks) {
       ),
       cleanWhiteSpace(`<div
       class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card fitted-format display-container-true"
+      data-boxel-card-container
       data-test-boxel-card-container
       style
       data-test-card="http://test-realm/test/germaine"
@@ -1987,6 +1992,7 @@ module(`Integration | realm indexing`, function (hooks) {
       cleanWhiteSpace(stripScopedCSSAttributes(embeddedHtml![cardDefRefURL])),
       cleanWhiteSpace(`<div
       class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card embedded-format display-container-true"
+      data-boxel-card-container
       data-test-boxel-card-container
       style
       data-test-card="http://test-realm/test/germaine"

--- a/packages/template-lint/lib/no-data-test-selector.mjs
+++ b/packages/template-lint/lib/no-data-test-selector.mjs
@@ -1,0 +1,38 @@
+import { Rule } from 'ember-template-lint';
+
+// data-test-* attributes are stripped from production builds by ember-test-selectors.
+// Using them as CSS selectors (e.g. exceptSelector='[data-test-foo]', querySelector('[data-test-foo]'))
+// works in tests but silently breaks in production.
+export default class NoDataTestSelector extends Rule {
+  visitor() {
+    return {
+      // Catches string literals in modifier/helper hash args:
+      //   {{onClickOutside this.fn exceptSelector='[data-test-foo]'}}
+      //   {{find-all '[data-test-foo]'}}
+      StringLiteral(node) {
+        if (/\[data-test-/.test(node.value)) {
+          this.log({
+            message:
+              '`data-test-*` attributes are stripped in production builds. Use a plain `data-*` attribute (e.g. `[data-foo]`) for functional selectors.',
+            node,
+          });
+        }
+      },
+
+      // Catches string values in HTML attributes:
+      //   <div data-selector='[data-test-foo]'>
+      AttrNode(node) {
+        if (
+          node.value?.type === 'TextNode' &&
+          /\[data-test-/.test(node.value.chars)
+        ) {
+          this.log({
+            message:
+              '`data-test-*` attributes are stripped in production builds. Use a plain `data-*` attribute (e.g. `[data-foo]`) for functional selectors.',
+            node: node.value,
+          });
+        }
+      },
+    };
+  }
+}

--- a/packages/template-lint/plugin.mjs
+++ b/packages/template-lint/plugin.mjs
@@ -1,10 +1,12 @@
 import requireScopedStyle from './lib/require-scoped-style.mjs';
+import noDataTestSelector from './lib/no-data-test-selector.mjs';
 
 export default {
   name: '@cardstack/template-lint',
 
   rules: {
     'require-scoped-style': requireScopedStyle,
+    'no-data-test-selector': noDataTestSelector,
   },
 
   configurations: {
@@ -12,6 +14,7 @@ export default {
       extends: 'recommended',
       rules: {
         'require-scoped-style': true,
+        'no-data-test-selector': true,
 
         'require-button-type': false,
         'no-negated-condition': false,


### PR DESCRIPTION
we strip out the `data-test` attributes in prod, so do not use them for functionality outside of tests

- added linter in `template-lint` package
- updated `.eslintrc.js` for `host`, `boxel-ui/addon`
- remaining changes are the places where incorrect usage was caught by the linter

note: will handle `base` package separately because it turns out `pnpm lint` only lints the template there and not the js