### PR TITLE
Fix memory leak: StoreService setInterval race in host tests

### DIFF
--- a/.claude/skills/host-test-memory-leak-hunting/SKILL.md
+++ b/.claude/skills/host-test-memory-leak-hunting/SKILL.md
@@ -42,10 +42,13 @@ The dev stack must already be up via `mise run dev-all`, with Chrome launched wi
 The test filter you choose dominates iteration time. Use a module that exercises the suspect code path AND completes ~1 second per test. Good defaults:
 
 - `card-basics` — 99 tests, ~1s/test, exercises card-api + Box trees (hits the most common leak shape)
+- `Integration | Store` — good for store/card-api-related leaks; reproduces ~20 MB/test for store service leaks that `card-basics` misses (~1.1 MB/test)
 - `Integration` — slower, broader, use only when narrower filters miss the signal
 - A specific module name from a failing CI shard
 
 Avoid filters that include realm-indexing-heavy tests (e.g. those that intentionally trigger errors) — those run at ~60s/test and crush iteration.
+
+**Important:** if `card-basics` doesn't reproduce the expected slope, try a heavier filter. Some leaks only trigger when specific service code paths are exercised (e.g. StoreService.setup() only fires when the store is actually used).
 
 ### 2. Start the snapshot runner
 
@@ -56,6 +59,8 @@ SNAPSHOT_AT="10,50,90" \
 ```
 
 Snapshots at `t=10` (warm) and `t=50` give a clean delta over 40 tests. Add `t=90` to confirm the t=10→t=50 slope continues (rules out one-time allocations).
+
+**`SNAPSHOT_AT` values must be multiples of 10** — the runner triggers on `MEMPROBE` log lines, which only fire every 10 tests. Values like `3` or `15` will be silently missed.
 
 ### 3. Open a fresh test tab
 
@@ -86,6 +91,7 @@ The top of the output sorted by retained-size delta tells you what's accumulatin
 - `+N copies` of `string::define("https://cardstack.com/base/...")` — a Registry/factory chain is pinning fresh-per-test card-api module sources. Almost always points back to `App._applicationInstances` retention.
 - `+N copies` of `JSArrayBufferData` (native) — usually downstream of the above (each pinned ApplicationInstance brings ArrayBuffers).
 - `+N` Box / FieldComponent / Glimmer-internal counts — Box tree retention.
+- `+N` of `native::DOMTimer` — orphaned `setInterval`/`setTimeout` from async service code that ran after the service was destroyed (see known-leaks.md #5).
 
 ### 6. Trace the retainer chain
 
@@ -109,7 +115,7 @@ If the slope flattens and the offending constructor count stops growing, you're 
 
 - **`getContext()` returns undefined at `QUnit.testDone`** because `unsetContext()` runs in `teardownContext` before the owner is destroyed. Don't snapshot `ctx.owner` in testDone — capture in `hooks.afterEach` of the test module, or read `getApplication()._applicationInstances` directly.
 - **WeakMap edges**. Heap snapshots show WeakMap key→value as a normal-looking edge. `snapshot-retainers.js` skips them when `--strong` is passed; otherwise you'll chase ghosts.
-- **V8 max string length on big snapshots**. `JSON.parse(fs.readFileSync(snap, 'utf8'))` works up to ~500MB, but `chunks.join('')` blows up around 300MB. The runner streams chunks straight to disk for this reason.
+- **V8 max string length on big snapshots**. `JSON.parse(fs.readFileSync(snap, 'utf8'))` works up to ~500MB, but `chunks.join('')` blows up around 300MB. The runner streams chunks straight to disk for this reason. The analysis scripts (`snapshot-diff.js`, `snapshot-retainers.js`) also hit this limit — if snapshots exceed ~500MB, take them earlier in the run (lower `SNAPSHOT_AT` values) to keep file sizes manageable.
 - **GC timing**. The `globalThis.gc(); globalThis.gc()` double-call in setup-qunit is intentional — V8 sometimes needs a second pass to actually collect. If a snapshot still shows the suspect, re-snap after a short wait.
 - **Stale tabs**. Each `/json/new?<URL>` call creates a NEW tab. The runner picks the first one. Close stale tabs before starting the runner.
 

--- a/.claude/skills/host-test-memory-leak-hunting/known-leaks.md
+++ b/.claude/skills/host-test-memory-leak-hunting/known-leaks.md
@@ -58,6 +58,37 @@ The `did-insert`/`will-destroy` modifier added a `mousemove`/`mouseup` listener 
 
 ---
 
+## 5. `StoreService.setup()` setInterval race — async setup, sync destroy
+
+**Commit:** "Fix memory leak: guard setInterval after async setup() in StoreService"
+**Severity:** ~20 MB / test (dominant leak when App._applicationInstances is already swept)
+
+`StoreService.setup()` awaits `this.cardService.getAPI()`, then creates a `setInterval` timer that calls `this.store.sweep(api)`. The problem: Ember destroys services synchronously during test teardown. If `setup()` is still awaiting when `willDestroy` fires, the `await` resolves *after* the service is destroyed, creating an orphaned `setInterval` on a dead service. The timer closure captures `api` (the compiled card-api module proxy), which retains the entire base-realm module graph (~20 MB per test of `define("https://cardstack.com/base/...")` strings).
+
+Additionally, `StoreService.cardApiCache` held a reference to the compiled card-api module, but `resetCache()` (called between tests) didn't clear it — so even without the timer, the prior test's module graph was retained until the *next* test's card-api compiled.
+
+**Retainer chain:**
+```
+DOMTimer → closure → Context:api → JSProxy(card-api) → getComponent → _linksToEditor → module source strings
+DOMTimer → closure → RenderStoreService.cardApiCache → get deserialize → _linksToEditor → module source strings
+```
+
+**Fix pattern:** After every `await` in a service's `setup()` or `init()`, check `isDestroyed(this) || isDestroying(this)` before creating timers, listeners, or any long-lived resources. Also clear cached references in `resetCache()` / `willDestroy()`.
+
+```typescript
+private async setup() {
+  let api = await this.cardService.getAPI();
+  if (isDestroyed(this) || isDestroying(this)) {
+    return;                          // service died while we were awaiting
+  }
+  this.gcInterval = setInterval(...);
+}
+```
+
+**Diagnostic:** `MEMPROBE` shows `used=` climbing ~20 MB/test even with `app_instances=0`. Retainer paths lead through `DOMTimer` to a compiled card-api module proxy. Use `snapshot-retainers.js --strong` to see the `DOMTimer` root.
+
+---
+
 ## Patterns to look for when adding new code
 
 These are not bugs — they're shapes of code that have repeatedly turned out to be leaks. Audit your PR for them:
@@ -67,5 +98,7 @@ These are not bugs — they're shapes of code that have repeatedly turned out to
 - **A `Set` or `Map` keyed by Ember objects.** If it's not a `WeakSet`/`WeakMap`, removal must be explicit and complete. If you need a Set keyed by an object, register a destructor that removes the entry on destruction.
 - **A closure registered on a long-lived service or singleton that captures `this.owner`** (or anything reachable from owner). The closure pins the owner until the registration is undone.
 - **A service that registers itself with another service in `init()`** but doesn't unregister in `willDestroy()`. The other service's registry holds a strong reference.
+- **An `async setup()` or `init()` that creates timers/listeners after an `await`.** Ember destroys services synchronously during test teardown. If the `await` is still pending when `willDestroy` fires, the continuation runs on a dead service. Guard with `isDestroyed(this) || isDestroying(this)` after every `await` before creating any long-lived resource.
+- **A service cache (`this.fooCache`) not cleared in `resetCache()` or `willDestroy()`.** Even if the cache is repopulated next test, the old value is retained until then — and if the old value is a large compiled module graph, that's tens of MB pinned.
 
 When you ship one of these patterns, add a probe of `MEMPROBE` over the relevant test module before declaring done.

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1,4 +1,4 @@
-import { registerDestructor } from '@ember/destroyable';
+import { isDestroyed, isDestroying, registerDestructor } from '@ember/destroyable';
 import type Owner from '@ember/owner';
 import { getOwner } from '@ember/owner';
 import Service, { service } from '@ember/service';
@@ -210,6 +210,7 @@ export default class StoreService extends Service implements StoreInterface {
     if (!opts?.preserveReferences) {
       this.referenceCount = new Map();
     }
+    this.cardApiCache = undefined;
     this.autoSaveStates = new TrackedMap();
     this.newReferencePromises = [];
     this.inflightGetCards = new Map();
@@ -1011,6 +1012,9 @@ export default class StoreService extends Service implements StoreInterface {
 
   private async setup() {
     let api = await this.cardService.getAPI();
+    if (isDestroyed(this) || isDestroying(this)) {
+      return;
+    }
     this.gcInterval = setInterval(
       () => this.store.sweep(api),
       2 * 60_000,

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1,4 +1,8 @@
-import { isDestroyed, isDestroying, registerDestructor } from '@ember/destroyable';
+import {
+  isDestroyed,
+  isDestroying,
+  registerDestructor,
+} from '@ember/destroyable';
 import type Owner from '@ember/owner';
 import { getOwner } from '@ember/owner';
 import Service, { service } from '@ember/service';


### PR DESCRIPTION
## Summary
- Fix ~20 MB/test memory leak in host integration tests caused by `StoreService.setup()` creating orphaned `setInterval` timers after the service is destroyed during test teardown
- Add `isDestroyed`/`isDestroying` guard after `await` in `setup()` to prevent timer creation on dead services
- Clear `cardApiCache` in `resetCache()` to release stale compiled card-api module references between tests
- Document the leak pattern in the memory-leak-hunting skill (known-leaks.md item 5) and update SKILL.md with practical learnings from this hunt

## Root cause

`StoreService.setup()` awaits `this.cardService.getAPI()`, then creates a `setInterval` that calls `this.store.sweep(api)`. Ember destroys services synchronously during test teardown — if the `await` is still pending, the continuation runs *after* the service is destroyed, creating a `DOMTimer` that pins the entire compiled card-api module graph (~20 MB of `define("https://cardstack.com/base/...")` strings per test).

This pre-existing leak was exposed by PR #4370 (codemirror integration), which shifted ember-exam's test distribution so shard 3 received only heavy integration tests with no lightweight unit tests for relief, causing OOM.

## Validation

Local heap-probe validation: 187 tests dropped from 1374 MB → 550 MB (60% reduction). Per-test slope flattened from ~20 MB to near zero in steady state.

## Test plan
- [x] CI host-test shards pass (especially shard 3, the historical canary for memory pressure)
- [x] No regressions in store-related integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)