### PR TITLE
Fix numeric sort in search queries (CS-10733)

### DIFF
--- a/packages/host/tests/integration/realm-querying-test.gts
+++ b/packages/host/tests/integration/realm-querying-test.gts
@@ -67,7 +67,7 @@ module(`Integration | realm querying`, function (hooks) {
         type: 'card',
         attributes: {
           author: { firstName: 'Cardy', lastName: 'Jones' },
-          editions: 1,
+          editions: 10,
           pubDate: '2023-09-01',
         },
         meta: {
@@ -130,7 +130,7 @@ module(`Integration | realm querying`, function (hooks) {
             firstName: 'Mango',
             lastName: 'Abdel-Rahman',
           },
-          editions: 1,
+          editions: 10,
           pubDate: '2022-07-01',
         },
         meta: {
@@ -149,7 +149,7 @@ module(`Integration | realm querying`, function (hooks) {
             firstName: 'Van Gogh',
             lastName: 'Abdel-Rahman',
           },
-          editions: 0,
+          editions: 3,
           pubDate: '2023-08-01',
         },
         meta: {
@@ -168,7 +168,7 @@ module(`Integration | realm querying`, function (hooks) {
             firstName: 'Jackie',
             lastName: 'Aguilar',
           },
-          editions: 2,
+          editions: 200,
           pubDate: '2022-08-01',
         },
         meta: {
@@ -1223,10 +1223,10 @@ module(`Integration | realm querying`, function (hooks) {
     assert.deepEqual(
       matching.map((m) => m.id),
       [
-        `${paths.url}books/2`, // 0
-        `${paths.url}books/1`, // 1
-        `${paths.url}card-2`, // 1
-        `${paths.url}books/3`, // 2
+        `${paths.url}books/2`, // 3
+        `${paths.url}books/1`, // 10 Abdel-Rahman
+        `${paths.url}card-2`, // 10 Jones
+        `${paths.url}books/3`, // 200
       ],
     );
   });
@@ -1279,10 +1279,10 @@ module(`Integration | realm querying`, function (hooks) {
     assert.deepEqual(
       matching.map((m) => m.id),
       [
-        `${paths.url}books/3`, // 2
-        `${paths.url}books/1`, // 1 // Ab
-        `${paths.url}card-2`, // 1 // Jo
-        `${paths.url}books/2`, // 0
+        `${paths.url}books/3`, // 200
+        `${paths.url}books/1`, // 10 Abdel-Rahman
+        `${paths.url}card-2`, // 10 Jones
+        `${paths.url}books/2`, // 3
       ],
     );
   });
@@ -1347,7 +1347,7 @@ module(`Integration | realm querying`, function (hooks) {
           },
           {
             on: { module: `${testModuleRealm}book`, name: 'Book' },
-            eq: { editions: 1 },
+            eq: { editions: 10 },
           },
         ],
       },

--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -1272,11 +1272,7 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
           assert.strictEqual(response.status, 200, 'HTTP 200 status');
           assert.deepEqual(
             response.body.data.map((d: any) => d.id),
-            [
-              `${realmHref}book-a`,
-              `${realmHref}book-c`,
-              `${realmHref}book-b`,
-            ],
+            [`${realmHref}book-a`, `${realmHref}book-c`, `${realmHref}book-b`],
             'books sorted numerically: 3, 10, 200 (not lexicographic "10", "200", "3")',
           );
         });

--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -1175,5 +1175,112 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
         });
       });
     });
+
+    module('numeric sort (postgres)', function () {
+      let testRealm: Realm;
+      let request: SuperTest<Test>;
+      let realmHref: string;
+      let searchPath: string;
+
+      function onRealmSetup(args: {
+        testRealm: Realm;
+        request: SuperTest<Test>;
+      }) {
+        testRealm = args.testRealm;
+        request = args.request;
+        let realmURL = new URL(testRealm.url);
+        realmHref = realmURL.href;
+        searchPath = `${realmURL.pathname.replace(/\/$/, '')}/_search`;
+      }
+
+      function bookType() {
+        return {
+          module: `${realmHref}book`,
+          name: 'Book',
+        };
+      }
+
+      module('public readable realm', function (hooks) {
+        setupPermissionedRealmCached(hooks, {
+          permissions: {
+            '*': ['read'],
+          },
+          realmURL: testRealmURLFor('numeric-sort-test/'),
+          fileSystem: {
+            'book.gts': `
+              import { contains, field, CardDef, Component } from 'https://cardstack.com/base/card-api';
+              import StringField from 'https://cardstack.com/base/string';
+              import NumberField from 'https://cardstack.com/base/number';
+              export class Book extends CardDef {
+                static displayName = 'Book';
+                @field title = contains(StringField);
+                @field editions = contains(NumberField);
+                static isolated = class Isolated extends Component<typeof this> {
+                  <template><h1><@fields.title /></h1></template>
+                };
+              }
+            `,
+            'book-a.json': {
+              data: {
+                type: 'card',
+                attributes: { title: 'Book A', editions: 3 },
+                meta: {
+                  adoptsFrom: { module: './book', name: 'Book' },
+                },
+              },
+            },
+            'book-b.json': {
+              data: {
+                type: 'card',
+                attributes: { title: 'Book B', editions: 200 },
+                meta: {
+                  adoptsFrom: { module: './book', name: 'Book' },
+                },
+              },
+            },
+            'book-c.json': {
+              data: {
+                type: 'card',
+                attributes: { title: 'Book C', editions: 10 },
+                meta: {
+                  adoptsFrom: { module: './book', name: 'Book' },
+                },
+              },
+            },
+          },
+          onRealmSetup,
+        });
+
+        test('sorts by numeric field in correct numeric order (not lexicographic)', async function (assert) {
+          let response = await request
+            .post(searchPath)
+            .set('Accept', 'application/vnd.card+json')
+            .set('X-HTTP-Method-Override', 'QUERY')
+            .send({
+              filter: {
+                type: bookType(),
+              },
+              sort: [
+                {
+                  by: 'editions',
+                  on: bookType(),
+                  direction: 'asc',
+                },
+              ],
+            });
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.deepEqual(
+            response.body.data.map((d: any) => d.id),
+            [
+              `${realmHref}book-a`,
+              `${realmHref}book-c`,
+              `${realmHref}book-b`,
+            ],
+            'books sorted numerically: 3, 10, 200 (not lexicographic "10", "200", "3")',
+          );
+        });
+      });
+    });
   });
 });

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -1155,6 +1155,7 @@ export class IndexQueryEngine {
     // used in the handleFieldArity (the multiple tableValuedTree expressions will
     // collapse into a single function)
     let rootPluralPath: string | undefined;
+    let isNumericField = false;
 
     let exp = await this.walkFilterFieldPath(
       definition,
@@ -1175,6 +1176,9 @@ export class IndexQueryEngine {
           ];
         } else if (!rootPluralPath) {
           let fieldName = currentField(pathTraveled);
+          isNumericField =
+            field.serializerName === 'number' ||
+            field.serializerName === 'big-integer';
           return [...expression, '->>', param(fieldName)];
         }
         return expression;
@@ -1207,7 +1211,22 @@ export class IndexQueryEngine {
       },
     );
     if (!rootPluralPath) {
-      exp = ['search_doc', ...exp];
+      // Numeric fields (NumberField, BigIntegerField) are stored as JSON
+      // numbers/strings but PostgreSQL's ->> extracts them as text. Cast to
+      // numeric so that ORDER BY and range comparisons use numeric ordering
+      // instead of lexicographic ordering (e.g. 100 > 20 > 3, not
+      // "100" < "20" < "3"). SQLite's ->> preserves the original JSON type so
+      // no cast is needed there.
+      if (isNumericField) {
+        exp = [
+          dbExpression({ pg: '(', sqlite: '' }),
+          'search_doc',
+          ...exp,
+          dbExpression({ pg: ')::numeric', sqlite: '' }),
+        ];
+      } else {
+        exp = ['search_doc', ...exp];
+      }
     }
     return exp;
   }


### PR DESCRIPTION
## Summary
- PostgreSQL's `->>` operator extracts JSON values as text, causing `NumberField` and `BigIntegerField` to sort lexicographically instead of numerically (e.g. `"3" > "200"`)
- Cast numeric field extractions to `::numeric` on PostgreSQL so `ORDER BY` and range comparisons use correct numeric ordering
- SQLite's `->>` preserves the original JSON type, so no cast is needed there — uses `dbExpression()` to apply the fix only for PostgreSQL
- Updated test data to use multi-digit numbers (3, 10, 200) that would expose the lexicographic bug

## Test plan
- [x] Existing `realm querying` tests pass (36/36), including updated numeric sort assertions
- [x] Existing `prerendered-card-search` tests pass (10/10)
- [ ] Verify on PostgreSQL that sorting a `NumberField` DESC produces correct numeric order


🤖 Generated with [Claude Code](https://claude.com/claude-code)