### PR TITLE
Fix dirty pg pool connections causing transaction and TypeError crashes

### DIFF
--- a/packages/postgres/pg-adapter.ts
+++ b/packages/postgres/pg-adapter.ts
@@ -161,9 +161,13 @@ export class PgAdapter implements DBAdapter {
       // before any query" errors for the next caller that picks it up.
       try {
         await client.query('ROLLBACK');
-      } catch {
+      } catch (rollbackError) {
         // ROLLBACK failed — the connection is in an unrecoverable state.
         // Destroy it instead of returning it to the pool.
+        log.error(
+          'ROLLBACK failed during connection cleanup, destroying client: %s',
+          rollbackError,
+        );
         client.release(true);
         released = true;
         throw e;

--- a/packages/postgres/pg-adapter.ts
+++ b/packages/postgres/pg-adapter.ts
@@ -151,10 +151,30 @@ export class PgAdapter implements DBAdapter {
       let { rows } = await client.query(sql);
       return rows;
     };
+    let released = false;
     try {
       return await fn(query);
-    } finally {
+    } catch (e) {
+      // Clean up any in-progress transaction before returning the client to
+      // the pool. Without this, a connection left in a dirty transaction
+      // state will cause "SET TRANSACTION ISOLATION LEVEL must be called
+      // before any query" errors for the next caller that picks it up.
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // ROLLBACK failed — the connection is in an unrecoverable state.
+        // Destroy it instead of returning it to the pool.
+        client.release(true);
+        released = true;
+        throw e;
+      }
       client.release();
+      released = true;
+      throw e;
+    } finally {
+      if (!released) {
+        client.release();
+      }
     }
   }
 

--- a/packages/postgres/pg-queue.ts
+++ b/packages/postgres/pg-queue.ts
@@ -630,11 +630,11 @@ export class PgQueueRunner implements QueueRunner {
           );
           await query(['BEGIN']);
           await query(['SET TRANSACTION ISOLATION LEVEL SERIALIZABLE']);
-          let [{ status: jobStatus }] = (await query([
+          let jobRows = (await query([
             'SELECT status FROM jobs WHERE id = ',
             param(jobToRun.id),
           ])) as Pick<JobsTable, 'status'>[];
-          if (jobStatus !== 'unfulfilled') {
+          if (jobRows.length === 0 || jobRows[0].status !== 'unfulfilled') {
             log.debug(
               '%s: rolling back because our job is already marked done',
               this.#workerId,
@@ -642,11 +642,11 @@ export class PgQueueRunner implements QueueRunner {
             await query(['ROLLBACK']);
             return;
           }
-          let [jobReservation] = (await query([
+          let reservationRows = (await query([
             'SELECT *, locked_until < NOW() as expired FROM job_reservations WHERE id = ',
             param(jobReservationId),
           ])) as unknown as (JobReservationsTable & { expired: boolean })[];
-          if (jobReservation.completed_at) {
+          if (reservationRows.length === 0 || reservationRows[0].completed_at) {
             log.debug(
               '%s: rolling back because someone else processed our job',
               this.#workerId,
@@ -654,6 +654,7 @@ export class PgQueueRunner implements QueueRunner {
             await query(['ROLLBACK']);
             return;
           }
+          let jobReservation = reservationRows[0];
           if (jobReservation.expired) {
             // check to see if there are any other reservations for this job
             let [{ total }] = (await query([


### PR DESCRIPTION
## Summary

Fixes three related Sentry issues caused by PostgreSQL connection pool contamination:

- **`withConnection` now cleans up transaction state on error** — When the callback threw, the connection was returned to the pool with a dirty transaction still active. The next caller to reuse that connection would hit `SET TRANSACTION ISOLATION LEVEL must be called before any query` because `BEGIN` silently continued the old transaction instead of starting a fresh one. Now we issue `ROLLBACK` before releasing, and destroy the connection entirely if `ROLLBACK` fails.

- **`processJobs` guards against empty query results** — The job status and reservation lookups destructured the first row without checking for an empty array, causing `TypeError: Cannot read properties of undefined (reading 'status')` and `TypeError: Cannot read properties of undefined (reading 'completed_at')`. Now we check `rows.length === 0` first and roll back gracefully.

Sentry issues:
- https://cardstack.sentry.io/share/issue/92085bcca1834a90993446ac6ed442ac/
- https://cardstack.sentry.io/share/issue/182e8bd68ceb42be856728061b2687f2/
- https://cardstack.sentry.io/share/issue/6932a8b281aa4d9ab6f4c9b4f496630d/

## Test plan
- [ ] Verify `pnpm lint` passes for `@cardstack/postgres`
- [ ] Deploy and monitor Sentry for recurrence of these three error types
- [ ] Confirm job queue processing continues to work correctly under normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)