### PR TITLE
CS-10452: Idempotent factory entrypoint with retry-blocked and smoke tests

### DIFF
--- a/packages/software-factory/README.md
+++ b/packages/software-factory/README.md
@@ -68,10 +68,23 @@ pnpm factory:go -- \
 
 The `--debug` flag shows LLM prompts, tool calls and their results, and `console.log` output from QUnit tests as they run.
 
+### Retrying blocked issues
+
+By default, the factory resets blocked issues to `backlog` with `critical` priority so the scheduler picks them up first. Only issues blocked by validation failures (not by dependency on another issue) are reset. Prior validation failure details are preserved in issue comments so the agent has context for the retry.
+
+To skip retrying blocked issues, use `--no-retry-blocked`:
+
+```bash
+pnpm factory:go -- \
+  --brief-url http://localhost:4201/software-factory/Wiki/sticky-note \
+  --target-realm-url http://localhost:4201/your-username/my-test-realm/ \
+  --no-retry-blocked
+```
+
 ### What to expect on the command line
 
 ```
-[factory:go] mode=implement brief=http://localhost:4201/software-factory/Wiki/sticky-note
+[factory:go] brief=http://localhost:4201/software-factory/Wiki/sticky-note
 [factory:go] Starting seed issue + issue-driven loop...
 [factory-seed] Creating seed issue at Issues/bootstrap-seed.json
 [issue-loop] Starting issue loop: targetRealm=..., maxIterationsPerIssue=5

--- a/packages/software-factory/README.md
+++ b/packages/software-factory/README.md
@@ -60,7 +60,7 @@ Then run the factory:
 ```bash
 cd packages/software-factory
 
-pnpm factory:go -- \
+pnpm factory:go \
   --brief-url http://localhost:4201/software-factory/Wiki/sticky-note \
   --target-realm-url http://localhost:4201/your-username/my-test-realm/ \
   --debug
@@ -75,7 +75,7 @@ By default, the factory resets blocked issues to `backlog` with `critical` prior
 To skip retrying blocked issues, use `--no-retry-blocked`:
 
 ```bash
-pnpm factory:go -- \
+pnpm factory:go \
   --brief-url http://localhost:4201/software-factory/Wiki/sticky-note \
   --target-realm-url http://localhost:4201/your-username/my-test-realm/ \
   --no-retry-blocked

--- a/packages/software-factory/docs/phase-2-plan.md
+++ b/packages/software-factory/docs/phase-2-plan.md
@@ -98,6 +98,16 @@ The inner loop continues until:
 
 The agent always has the option to create new issues via tool calls if it determines that a failure requires separate work (e.g., "this card definition depends on another card that doesn't exist yet — creating a new issue for it"). But the orchestrator does not force this — the agent decides.
 
+### Retrying Blocked Issues (default on, opt out with `--no-retry-blocked`)
+
+By default, the factory resets eligible blocked issues to `backlog` with `critical` priority before running the loop:
+
+- **Only issues blocked without `blockedBy` dependencies are reset** — issues blocked by another issue (dependency) are left alone. This distinguishes "blocked by validation failures" from "blocked by unfinished prerequisite work."
+- **Priority elevation to `critical`** ensures retried issues are picked up before other backlog items by `IssueScheduler.pickNextIssue()`.
+- **A comment is added** documenting the reset for traceability.
+- **Prior validation failure context in issue comments is preserved** — the agent sees what went wrong and has context for the retry.
+- **Opt out with `--no-retry-blocked`** — if you want blocked issues to stay blocked, pass this flag.
+
 ### What This Means for Task Breakdown
 
 During task breakdown, the agent organizes implementation issues around **entry-point cards** — the top-level cards users interact with directly and that should be discoverable in the Boxel catalog. The agent creates **one issue per entry-point card**, where each issue covers:
@@ -149,7 +159,7 @@ The flow becomes:
 4. The agent calls `signal_done()` — the orchestrator marks the seed issue as done after validation passes
 5. The orchestrator now has a populated issue backlog and continues the normal loop
 
-Seed issue creation is **idempotent** — `createSeedIssue()` checks if `Issues/bootstrap-seed` already exists before writing. This supports crash recovery: if the factory restarts, the seed issue is already in the realm and the loop picks it up.
+Seed issue creation is **idempotent** — `createSeedIssue()` checks if `Issues/bootstrap-seed` already exists before writing. This supports crash recovery: if the factory restarts, the seed issue is already in the realm and the loop picks it up. Because of this idempotency, the `--mode` flag (bootstrap / implement / resume) was removed from the CLI — there is no need to distinguish between a fresh run and a resume. The factory always creates the seed (no-op if it already exists) and runs the issue loop.
 
 The `ContextBuilder.buildForIssue()` handles the bootstrap case where no Project exists yet by supplying a minimal stub (`{ id: 'bootstrap-pending' }`) when `loadProject()` returns `undefined` and the issue has `issueType === 'bootstrap'`. This keeps `AgentContext.project` required (no type ripple) while the bootstrap prompt template doesn't reference project fields.
 

--- a/packages/software-factory/package.json
+++ b/packages/software-factory/package.json
@@ -23,6 +23,7 @@
     "lint:types": "ember-tsc --noEmit",
     "serve:realm": "NODE_NO_WARNINGS=1 ts-node --transpileOnly src/cli/serve-realm.ts",
     "serve:support": "NODE_NO_WARNINGS=1 ts-node --transpileOnly src/cli/serve-support.ts",
+    "smoke:factory-scenarios": "NODE_NO_WARNINGS=1 ts-node --transpileOnly scripts/smoke-tests/smoke-test-factory-scenarios.ts",
     "smoke:test-realm": "NODE_NO_WARNINGS=1 ts-node --transpileOnly scripts/smoke-tests/smoke-test-realm.ts",
     "test": "NODE_NO_WARNINGS=1 ts-node --transpileOnly scripts/test.ts",
     "test:all": "NODE_NO_WARNINGS=1 ts-node --transpileOnly scripts/test.ts",

--- a/packages/software-factory/scripts/smoke-tests/smoke-test-factory-scenarios.ts
+++ b/packages/software-factory/scripts/smoke-tests/smoke-test-factory-scenarios.ts
@@ -1,0 +1,796 @@
+/**
+ * Integration smoke tests for the software factory.
+ *
+ * Sets up three real-world scenarios in a live Boxel realm and invokes
+ * `pnpm factory:go` against them. These tests hit a real LLM and write
+ * to a real realm — they are NOT part of CI.
+ *
+ * Scenarios:
+ *   1. Bootstrap complete, no code yet — agent implements from scratch
+ *   2. Blocked issue with validation failures — agent retries via --retry-blocked
+ *   3. Completed project, new enhancement — agent picks up new backlog issue
+ *
+ * Prerequisites:
+ *   - Docker running, `mise run dev-all` (realm server, host app, Synapse, etc.)
+ *   - MATRIX_URL, MATRIX_USERNAME, MATRIX_PASSWORD environment variables
+ *   - OPENROUTER_API_KEY for the LLM agent
+ *
+ * Usage:
+ *   pnpm smoke:factory-scenarios -- --scenario 1 [--debug]
+ *   pnpm smoke:factory-scenarios -- --scenario 2 [--debug]
+ *   pnpm smoke:factory-scenarios -- --scenario 3 [--debug]
+ *   pnpm smoke:factory-scenarios -- --scenario all [--debug]
+ */
+
+// This should be first
+import '../../src/setup-logger';
+
+import { spawn } from 'node:child_process';
+import { resolve } from 'node:path';
+
+import { getRealmServerToken, matrixLogin } from '../../src/boxel';
+import { inferDarkfactoryModuleUrl } from '../../src/factory-seed';
+import { logger } from '../../src/logger';
+import {
+  createRealm,
+  getRealmScopedAuth,
+  writeFile,
+  waitForRealmFile,
+} from '../../src/realm-operations';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+let log = logger('smoke-factory-scenarios');
+let packageRoot = resolve(__dirname, '../..');
+
+const DEFAULT_BRIEF_URL =
+  'http://localhost:4201/software-factory/Wiki/sticky-note';
+
+// ---------------------------------------------------------------------------
+// Card fixture content
+// ---------------------------------------------------------------------------
+
+function buildSeedIssueDocument(darkfactoryModuleUrl: string) {
+  return {
+    data: {
+      type: 'card',
+      attributes: {
+        issueId: 'BOOT-1',
+        summary: 'Process brief and create project artifacts',
+        description: 'Bootstrap issue — already completed.',
+        issueType: 'bootstrap',
+        status: 'done',
+        priority: 'critical',
+        order: 0,
+        createdAt: '2026-04-14T00:00:00.000Z',
+        updatedAt: '2026-04-14T00:00:00.000Z',
+      },
+      meta: {
+        adoptsFrom: { module: darkfactoryModuleUrl, name: 'Issue' },
+      },
+    },
+  };
+}
+
+function buildProjectDocument(
+  darkfactoryModuleUrl: string,
+  overrides?: { projectStatus?: string },
+) {
+  return {
+    data: {
+      type: 'card',
+      attributes: {
+        projectCode: 'HELLO',
+        projectName: 'Hello Card Project',
+        projectStatus: overrides?.projectStatus ?? 'active',
+        objective:
+          'Create a HelloCard with a greeting field that renders in isolated view.',
+        scope:
+          '## Scope\n\nSingle card definition with one string field, co-located QUnit tests, and a catalog spec.',
+        technicalContext:
+          '## Technical Context\n\nUses Boxel CardDef with @field decorator. Greeting field renders in isolated template.',
+        successCriteria:
+          '- HelloCard definition with greeting field\n- Isolated view renders greeting\n- QUnit tests pass\n- Catalog spec with example instance',
+      },
+      meta: {
+        adoptsFrom: { module: darkfactoryModuleUrl, name: 'Project' },
+      },
+    },
+  };
+}
+
+function buildKnowledgeArticleDocument(darkfactoryModuleUrl: string) {
+  return {
+    data: {
+      type: 'card',
+      attributes: {
+        articleTitle: 'Hello Card Brief Context',
+        articleType: 'context',
+        content:
+          '## Brief Context\n\nBuild a HelloCard — a simple greeting card with a `greeting` string field. ' +
+          'The card should render the greeting text in its isolated view using a `<h1>` tag with a `data-test-greeting` attribute. ' +
+          'If no greeting is set, display "Hello World" as the default.',
+        tags: ['hello-card', 'brief'],
+        updatedAt: '2026-04-14T00:00:00.000Z',
+      },
+      meta: {
+        adoptsFrom: { module: darkfactoryModuleUrl, name: 'KnowledgeArticle' },
+      },
+    },
+  };
+}
+
+function buildIssueDocument(
+  darkfactoryModuleUrl: string,
+  opts: {
+    issueId: string;
+    summary: string;
+    description: string;
+    status: string;
+    priority: string;
+    order: number;
+    acceptanceCriteria?: string;
+    comments?: { body: string; author: string; datetime: string }[];
+  },
+) {
+  return {
+    data: {
+      type: 'card',
+      attributes: {
+        issueId: opts.issueId,
+        summary: opts.summary,
+        description: opts.description,
+        issueType: 'feature',
+        status: opts.status,
+        priority: opts.priority,
+        order: opts.order,
+        acceptanceCriteria:
+          opts.acceptanceCriteria ??
+          '- [ ] Card definition exists\n- [ ] Tests pass',
+        comments: opts.comments ?? [],
+        createdAt: '2026-04-14T00:00:00.000Z',
+        updatedAt: '2026-04-14T00:00:00.000Z',
+      },
+      relationships: {
+        project: {
+          links: { self: '../Projects/hello-card' },
+        },
+        'relatedKnowledge.0': {
+          links: {
+            self: '../Knowledge Articles/hello-card-brief-context',
+          },
+        },
+      },
+      meta: {
+        adoptsFrom: { module: darkfactoryModuleUrl, name: 'Issue' },
+      },
+    },
+  };
+}
+
+function buildSpecDocument() {
+  return {
+    data: {
+      type: 'card',
+      attributes: {
+        ref: { module: './hello', name: 'HelloCard' },
+        specType: 'card',
+        readMe:
+          '# HelloCard\n\nA simple greeting card with a greeting field that renders in isolated view.',
+      },
+      meta: {
+        adoptsFrom: {
+          module: 'https://cardstack.com/base/spec',
+          name: 'Spec',
+        },
+      },
+    },
+  };
+}
+
+// Working HelloCard .gts content (passes tests)
+const WORKING_HELLO_GTS = `import {
+  CardDef,
+  Component,
+  field,
+  contains,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+
+export class HelloCard extends CardDef {
+  static displayName = 'Hello Card';
+  @field greeting = contains(StringField);
+  @field title = contains(StringField, {
+    computeVia: function (this: HelloCard) {
+      return this.greeting ?? 'Hello World';
+    },
+  });
+  static isolated = class Isolated extends Component<typeof HelloCard> {
+    <template>
+      <h1 data-test-greeting>{{if @model.greeting @model.greeting 'Hello World'}}</h1>
+    </template>
+  };
+}
+`;
+
+// Buggy HelloCard .gts content (doesn't render greeting — test fails)
+const BUGGY_HELLO_GTS = `import {
+  CardDef,
+  Component,
+  field,
+  contains,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+
+export class HelloCard extends CardDef {
+  static displayName = 'Hello Card';
+  @field greeting = contains(StringField);
+  @field title = contains(StringField, {
+    computeVia: function (this: HelloCard) {
+      return this.greeting ?? 'Hello World';
+    },
+  });
+  static isolated = class Isolated extends Component<typeof HelloCard> {
+    <template>
+      <h1 data-test-greeting>Placeholder</h1>
+    </template>
+  };
+}
+`;
+
+// QUnit test for HelloCard
+const HELLO_TEST_GTS = `import { module, test } from 'qunit';
+import { setupCardTest } from '@cardstack/host/tests/helpers';
+import { renderCard } from '@cardstack/host/tests/helpers/render-component';
+import { getService } from '@universal-ember/test-support';
+
+let cardModuleUrl = new URL('./hello', import.meta.url).href;
+
+export function runTests() {
+  module('HelloCard', function (hooks) {
+    setupCardTest(hooks);
+
+    test('greeting renders in isolated view', async function (assert) {
+      let loader = getService('loader-service').loader;
+      let { HelloCard } = await loader.import(cardModuleUrl);
+      let card = new HelloCard({ greeting: 'Hello from smoke test' });
+      await renderCard(loader, card, 'isolated');
+      assert.dom('[data-test-greeting]').hasText('Hello from smoke test');
+    });
+  });
+}
+`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseArgs(): {
+  scenario: string;
+  debug: boolean;
+  briefUrl: string;
+} {
+  let args = process.argv.slice(2);
+  let scenario = 'all';
+  let debug = false;
+  let briefUrl = DEFAULT_BRIEF_URL;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--' && i === 0) continue;
+    if (args[i] === '--scenario' && args[i + 1]) {
+      scenario = args[++i];
+    } else if (args[i] === '--debug') {
+      debug = true;
+    } else if (args[i] === '--brief-url' && args[i + 1]) {
+      briefUrl = args[++i];
+    }
+  }
+
+  return { scenario, debug, briefUrl };
+}
+
+async function writeFixture(
+  realmUrl: string,
+  path: string,
+  content: string,
+  options: { authorization?: string; fetch?: typeof globalThis.fetch },
+): Promise<void> {
+  let result = await writeFile(realmUrl, path, content, options);
+  if (!result.ok) {
+    throw new Error(`Failed to write ${path}: ${result.error}`);
+  }
+  log.info(`  Wrote ${path}`);
+}
+
+async function writeJsonFixture(
+  realmUrl: string,
+  path: string,
+  document: unknown,
+  options: { authorization?: string; fetch?: typeof globalThis.fetch },
+): Promise<void> {
+  await writeFixture(
+    realmUrl,
+    path,
+    JSON.stringify(document, null, 2),
+    options,
+  );
+  // Wait for the card to be indexed
+  let cardPath = path.replace(/\.json$/, '');
+  let readable = await waitForRealmFile(realmUrl, cardPath, {
+    ...options,
+    timeoutMs: 15_000,
+    pollMs: 500,
+  });
+  if (!readable) {
+    log.warn(`  Warning: ${path} written but not readable after 15s`);
+  }
+}
+
+function runFactory(
+  realmUrl: string,
+  briefUrl: string,
+  extraArgs: string[],
+  debug: boolean,
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolvePromise, reject) => {
+    let args = [
+      '--silent',
+      'factory:go',
+      '--',
+      '--brief-url',
+      briefUrl,
+      '--target-realm-url',
+      realmUrl,
+    ];
+    if (debug) {
+      args.push('--debug');
+    }
+    args.push(...extraArgs);
+
+    log.info(`\n  Running: pnpm ${args.join(' ')}\n`);
+
+    let child = spawn('pnpm', args, {
+      cwd: packageRoot,
+      env: process.env,
+      // stderr streams live to terminal, stdout captured for JSON summary
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+
+    let stdout = '';
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    child.once('error', reject);
+    child.once('close', (status) => {
+      resolvePromise({ status, stdout, stderr: '' });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+async function scenario1(
+  realmUrl: string,
+  darkfactoryModuleUrl: string,
+  briefUrl: string,
+  debug: boolean,
+  fetchOptions: { authorization?: string; fetch?: typeof globalThis.fetch },
+): Promise<boolean> {
+  log.info('');
+  log.info('=== Scenario 1: Bootstrap Complete, No Code Yet ===');
+  log.info('');
+  log.info(
+    'Setup: Project + Issues exist in realm but no card definitions or tests.',
+  );
+  log.info('Expected: Agent picks up backlog issue and implements the card.');
+  log.info('');
+
+  // Write fixture cards
+  log.info('Writing fixture cards...');
+  await writeJsonFixture(
+    realmUrl,
+    'Issues/bootstrap-seed.json',
+    buildSeedIssueDocument(darkfactoryModuleUrl),
+    fetchOptions,
+  );
+  await writeJsonFixture(
+    realmUrl,
+    'Projects/hello-card.json',
+    buildProjectDocument(darkfactoryModuleUrl),
+    fetchOptions,
+  );
+  await writeJsonFixture(
+    realmUrl,
+    'Knowledge Articles/hello-card-brief-context.json',
+    buildKnowledgeArticleDocument(darkfactoryModuleUrl),
+    fetchOptions,
+  );
+  await writeJsonFixture(
+    realmUrl,
+    'Issues/hello-card-define.json',
+    buildIssueDocument(darkfactoryModuleUrl, {
+      issueId: 'HELLO-1',
+      summary: 'Create HelloCard definition with greeting field and tests',
+      description:
+        'Create a HelloCard with a `greeting` string field. ' +
+        'The card should render the greeting in isolated view using `<h1 data-test-greeting>`. ' +
+        'Default to "Hello World" when no greeting is set.\n\n' +
+        'Write co-located QUnit tests in `hello.test.gts` and a catalog spec in `Spec/hello-card.json`.',
+      status: 'backlog',
+      priority: 'high',
+      order: 1,
+      acceptanceCriteria:
+        '- [ ] hello.gts exists with HelloCard definition\n' +
+        '- [ ] greeting field renders in isolated view\n' +
+        '- [ ] hello.test.gts with passing QUnit tests\n' +
+        '- [ ] Spec/hello-card.json catalog spec',
+    }),
+    fetchOptions,
+  );
+
+  log.info('');
+  log.info('Running factory...');
+  let result = await runFactory(realmUrl, briefUrl, [], debug);
+
+  log.info('');
+  log.info(`Factory exited with status: ${result.status}`);
+  let ok = result.status === 0;
+  if (!ok) {
+    log.info('Factory failed. Check the output above for details.');
+  }
+
+  log.info('');
+  log.info('What to look for in the Boxel app:');
+  log.info(`  Target realm: ${realmUrl}`);
+  log.info('  - Issues/hello-card-define should be "done" or "in_progress"');
+  log.info('  - hello.gts should exist with a HelloCard definition');
+  log.info('  - hello.test.gts should exist with QUnit tests');
+  log.info('  - Test Runs/ should have validation results');
+  log.info('');
+
+  return ok;
+}
+
+async function scenario2(
+  realmUrl: string,
+  darkfactoryModuleUrl: string,
+  briefUrl: string,
+  debug: boolean,
+  fetchOptions: { authorization?: string; fetch?: typeof globalThis.fetch },
+): Promise<boolean> {
+  log.info('');
+  log.info('=== Scenario 2: Blocked Issue with Validation Failures ===');
+  log.info('');
+  log.info(
+    'Setup: Issue is blocked after max iterations. Buggy code + failing test exist.',
+  );
+  log.info(
+    'Expected: Factory auto-resets the blocked issue. Agent reads failure context and fixes the bug.',
+  );
+  log.info('');
+
+  // Write fixture cards
+  log.info('Writing fixture cards...');
+  await writeJsonFixture(
+    realmUrl,
+    'Issues/bootstrap-seed.json',
+    buildSeedIssueDocument(darkfactoryModuleUrl),
+    fetchOptions,
+  );
+  await writeJsonFixture(
+    realmUrl,
+    'Projects/hello-card.json',
+    buildProjectDocument(darkfactoryModuleUrl),
+    fetchOptions,
+  );
+  await writeJsonFixture(
+    realmUrl,
+    'Knowledge Articles/hello-card-brief-context.json',
+    buildKnowledgeArticleDocument(darkfactoryModuleUrl),
+    fetchOptions,
+  );
+  await writeJsonFixture(
+    realmUrl,
+    'Issues/hello-card-define.json',
+    buildIssueDocument(darkfactoryModuleUrl, {
+      issueId: 'HELLO-1',
+      summary: 'Create HelloCard definition with greeting field and tests',
+      description:
+        'Create a HelloCard with a `greeting` string field. ' +
+        'The card should render the greeting in isolated view using `<h1 data-test-greeting>`. ' +
+        'Default to "Hello World" when no greeting is set.\n\n' +
+        'Write co-located QUnit tests in `hello.test.gts` and a catalog spec in `Spec/hello-card.json`.',
+      status: 'blocked',
+      priority: 'high',
+      order: 1,
+      comments: [
+        {
+          body:
+            '**Blocked: max iteration limit reached (5 turns) with failing validation.**\n\n' +
+            'The agent was unable to resolve validation failures within the allowed number of iterations.\n\n' +
+            '### Last Validation Results\n\n' +
+            '**test**: FAILED\n' +
+            '- HelloCard > greeting renders in isolated view: ' +
+            "Expected 'Hello from smoke test' but got 'Placeholder'",
+          author: 'orchestrator',
+          datetime: '2026-04-14T01:00:00.000Z',
+        },
+      ],
+    }),
+    fetchOptions,
+  );
+
+  // Write buggy code + test
+  log.info('Writing buggy card definition and test...');
+  await writeFixture(realmUrl, 'hello.gts', BUGGY_HELLO_GTS, fetchOptions);
+  await writeFixture(realmUrl, 'hello.test.gts', HELLO_TEST_GTS, fetchOptions);
+
+  log.info('');
+  log.info('Running factory (blocked issues are auto-retried by default)...');
+  let result = await runFactory(realmUrl, briefUrl, [], debug);
+
+  log.info('');
+  log.info(`Factory exited with status: ${result.status}`);
+  let ok = result.status === 0;
+  if (!ok) {
+    log.info('Factory failed. Check the output above for details.');
+  }
+
+  log.info('');
+  log.info('What to look for in the Boxel app:');
+  log.info(`  Target realm: ${realmUrl}`);
+  log.info('  - Issues/hello-card-define should show the retry comment');
+  log.info(
+    '  - hello.gts should be updated (greeting renders instead of "Placeholder")',
+  );
+  log.info('  - Test Runs/ should have new validation results');
+  log.info('');
+
+  return ok;
+}
+
+async function scenario3(
+  realmUrl: string,
+  darkfactoryModuleUrl: string,
+  briefUrl: string,
+  debug: boolean,
+  fetchOptions: { authorization?: string; fetch?: typeof globalThis.fetch },
+): Promise<boolean> {
+  log.info('');
+  log.info('=== Scenario 3: Completed Project, New Enhancement ===');
+  log.info('');
+  log.info(
+    'Setup: All original work done. Working code + tests. New enhancement issue in backlog.',
+  );
+  log.info(
+    'Expected: Agent picks up the new enhancement issue and implements it.',
+  );
+  log.info('');
+
+  // Write fixture cards
+  log.info('Writing fixture cards...');
+  await writeJsonFixture(
+    realmUrl,
+    'Issues/bootstrap-seed.json',
+    buildSeedIssueDocument(darkfactoryModuleUrl),
+    fetchOptions,
+  );
+  await writeJsonFixture(
+    realmUrl,
+    'Projects/hello-card.json',
+    buildProjectDocument(darkfactoryModuleUrl),
+    fetchOptions,
+  );
+  await writeJsonFixture(
+    realmUrl,
+    'Knowledge Articles/hello-card-brief-context.json',
+    buildKnowledgeArticleDocument(darkfactoryModuleUrl),
+    fetchOptions,
+  );
+  await writeJsonFixture(
+    realmUrl,
+    'Issues/hello-card-define.json',
+    buildIssueDocument(darkfactoryModuleUrl, {
+      issueId: 'HELLO-1',
+      summary: 'Create HelloCard definition with greeting field and tests',
+      description: 'Original implementation issue — completed.',
+      status: 'done',
+      priority: 'high',
+      order: 1,
+    }),
+    fetchOptions,
+  );
+
+  // Write working code + test + spec
+  log.info('Writing working card definition, test, and spec...');
+  await writeFixture(realmUrl, 'hello.gts', WORKING_HELLO_GTS, fetchOptions);
+  await writeFixture(realmUrl, 'hello.test.gts', HELLO_TEST_GTS, fetchOptions);
+  await writeJsonFixture(
+    realmUrl,
+    'Spec/hello-card.json',
+    buildSpecDocument(),
+    fetchOptions,
+  );
+
+  // Write new enhancement issue
+  await writeJsonFixture(
+    realmUrl,
+    'Issues/hello-card-enhance.json',
+    buildIssueDocument(darkfactoryModuleUrl, {
+      issueId: 'HELLO-2',
+      summary: 'Add a color field to HelloCard',
+      description:
+        'Enhance the existing HelloCard by adding a `color` string field. ' +
+        'The color should be applied as the text color of the greeting in isolated view. ' +
+        'Use inline style: `style="color: {{@model.color}}"` on the `<h1>` element.\n\n' +
+        'Update the existing QUnit tests to verify the color renders. ' +
+        'Add new test assertions for the color field.',
+      status: 'backlog',
+      priority: 'high',
+      order: 2,
+      acceptanceCriteria:
+        '- [ ] HelloCard has a color string field\n' +
+        '- [ ] Color applies to greeting text in isolated view\n' +
+        '- [ ] QUnit tests verify color rendering\n' +
+        '- [ ] Existing greeting tests still pass',
+    }),
+    fetchOptions,
+  );
+
+  log.info('');
+  log.info('Running factory...');
+  let result = await runFactory(realmUrl, briefUrl, [], debug);
+
+  log.info('');
+  log.info(`Factory exited with status: ${result.status}`);
+  let ok = result.status === 0;
+  if (!ok) {
+    log.info('Factory failed. Check the output above for details.');
+  }
+
+  log.info('');
+  log.info('What to look for in the Boxel app:');
+  log.info(`  Target realm: ${realmUrl}`);
+  log.info('  - Issues/hello-card-define should still be "done"');
+  log.info('  - Issues/hello-card-enhance should be "done" or "in_progress"');
+  log.info('  - hello.gts should have a color field added');
+  log.info('  - hello.test.gts should have new color test assertions');
+  log.info('');
+
+  return ok;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  let { scenario, debug, briefUrl } = parseArgs();
+  let username = process.env.MATRIX_USERNAME;
+
+  if (!username) {
+    log.error(
+      'MATRIX_USERNAME is required. Set MATRIX_URL, MATRIX_USERNAME, and MATRIX_PASSWORD.',
+    );
+    process.exit(1);
+  }
+
+  if (!process.env.OPENROUTER_API_KEY) {
+    log.error('OPENROUTER_API_KEY is required for the LLM agent.');
+    process.exit(1);
+  }
+
+  if (!process.env.MATRIX_URL) {
+    process.env.MATRIX_URL = 'http://localhost:8008';
+  }
+
+  let realmServerUrl = process.env.REALM_SERVER_URL ?? 'http://localhost:4201/';
+  if (!realmServerUrl.endsWith('/')) {
+    realmServerUrl += '/';
+  }
+
+  log.info('=== Software Factory Smoke Test Scenarios ===');
+  log.info('');
+  log.info(`Realm server: ${realmServerUrl}`);
+  log.info(`Brief URL: ${briefUrl}`);
+  log.info(`Scenario: ${scenario}`);
+  log.info(`Debug: ${debug}`);
+
+  // Authenticate
+  let matrixAuth = await matrixLogin();
+  let serverToken = await getRealmServerToken(matrixAuth);
+  log.info('Auth: server token obtained');
+
+  let scenarios = scenario === 'all' ? ['1', '2', '3'] : [scenario];
+  let results: { name: string; ok: boolean }[] = [];
+
+  for (let s of scenarios) {
+    let realmEndpoint = `smoke-s${s}`;
+    let realmDisplayName = `Smoke Test S${s}`;
+    let targetRealmUrl = `${realmServerUrl}${username}/${realmEndpoint}/`;
+
+    log.info('');
+    log.info(`--- Creating realm: ${realmEndpoint} ---`);
+    let createResult = await createRealm(realmServerUrl, {
+      name: realmDisplayName,
+      endpoint: realmEndpoint,
+      authorization: serverToken,
+      matrixAuth: {
+        userId: matrixAuth.userId,
+        accessToken: matrixAuth.accessToken,
+        matrixUrl: matrixAuth.credentials.matrixUrl,
+      },
+    });
+
+    if (createResult.created) {
+      log.info(`Created realm: ${createResult.realmUrl}`);
+    } else if (createResult.error?.includes('already exists')) {
+      log.info('Realm already exists — reusing.');
+      targetRealmUrl = createResult.realmUrl ?? targetRealmUrl;
+    } else {
+      log.error(`Failed to create realm: ${createResult.error}`);
+      results.push({ name: `Scenario ${s}`, ok: false });
+      continue;
+    }
+
+    // Get realm-scoped auth
+    let realmAuth = await getRealmScopedAuth(realmServerUrl, serverToken);
+    let authorization = realmAuth.tokens[targetRealmUrl] ?? serverToken;
+    let fetchOptions = { authorization, fetch: globalThis.fetch };
+    let darkfactoryModuleUrl = inferDarkfactoryModuleUrl(targetRealmUrl);
+
+    let ok: boolean;
+    if (s === '1') {
+      ok = await scenario1(
+        targetRealmUrl,
+        darkfactoryModuleUrl,
+        briefUrl,
+        debug,
+        fetchOptions,
+      );
+    } else if (s === '2') {
+      ok = await scenario2(
+        targetRealmUrl,
+        darkfactoryModuleUrl,
+        briefUrl,
+        debug,
+        fetchOptions,
+      );
+    } else if (s === '3') {
+      ok = await scenario3(
+        targetRealmUrl,
+        darkfactoryModuleUrl,
+        briefUrl,
+        debug,
+        fetchOptions,
+      );
+    } else {
+      log.error(`Unknown scenario: ${s}. Use 1, 2, 3, or all.`);
+      process.exit(1);
+    }
+
+    results.push({ name: `Scenario ${s}`, ok });
+  }
+
+  // Summary
+  log.info('');
+  log.info('=== Results ===');
+  for (let r of results) {
+    log.info(`  ${r.ok ? '\u2713' : '\u2717'} ${r.name}`);
+  }
+  log.info('');
+
+  if (results.some((r) => !r.ok)) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  log.error(String(err));
+  process.exit(1);
+});

--- a/packages/software-factory/scripts/smoke-tests/smoke-test-factory-scenarios.ts
+++ b/packages/software-factory/scripts/smoke-tests/smoke-test-factory-scenarios.ts
@@ -7,7 +7,7 @@
  *
  * Scenarios:
  *   1. Bootstrap complete, no code yet — agent implements from scratch
- *   2. Blocked issue with validation failures — agent retries via --retry-blocked
+ *   2. Blocked issue with validation failures — agent retries blocked work by default
  *   3. Completed project, new enhancement — agent picks up new backlog issue
  *
  * Prerequisites:

--- a/packages/software-factory/scripts/smoke-tests/smoke-test-factory-scenarios.ts
+++ b/packages/software-factory/scripts/smoke-tests/smoke-test-factory-scenarios.ts
@@ -16,10 +16,10 @@
  *   - OPENROUTER_API_KEY for the LLM agent
  *
  * Usage:
- *   pnpm smoke:factory-scenarios -- --scenario 1 [--debug]
- *   pnpm smoke:factory-scenarios -- --scenario 2 [--debug]
- *   pnpm smoke:factory-scenarios -- --scenario 3 [--debug]
- *   pnpm smoke:factory-scenarios -- --scenario all [--debug]
+ *   pnpm smoke:factory-scenarios --scenario 1 [--debug]
+ *   pnpm smoke:factory-scenarios --scenario 2 [--debug]
+ *   pnpm smoke:factory-scenarios --scenario 3 [--debug]
+ *   pnpm smoke:factory-scenarios --scenario all [--debug]
  */
 
 // This should be first

--- a/packages/software-factory/src/cli/factory-entrypoint.ts
+++ b/packages/software-factory/src/cli/factory-entrypoint.ts
@@ -21,11 +21,8 @@ async function main(): Promise<void> {
     }
 
     let options = parseFactoryEntrypointArgs(process.argv.slice(2));
-    log.info(`mode=${options.mode} brief=${options.briefUrl}`);
-
-    if (options.mode === 'implement') {
-      log.info('Starting seed issue + issue-driven loop...');
-    }
+    log.info(`brief=${options.briefUrl}`);
+    log.info('Starting seed issue + issue-driven loop...');
 
     let summary = await runFactoryEntrypoint(options);
 

--- a/packages/software-factory/src/factory-entrypoint.ts
+++ b/packages/software-factory/src/factory-entrypoint.ts
@@ -89,7 +89,7 @@ export { FactoryEntrypointUsageError } from './factory-entrypoint-errors';
 export function getFactoryEntrypointUsage(): string {
   return [
     'Usage:',
-    '  pnpm factory:go -- --brief-url <url> --target-realm-url <url> [options]',
+    '  pnpm factory:go --brief-url <url> --target-realm-url <url> [options]',
     '',
     'Required:',
     '  --brief-url <url>           Absolute URL for the source brief card',

--- a/packages/software-factory/src/factory-entrypoint.ts
+++ b/packages/software-factory/src/factory-entrypoint.ts
@@ -18,17 +18,13 @@ import {
 import type { IssueLoopResult } from './issue-loop';
 import { createBoxelRealmFetch } from './realm-auth';
 
-const allowedModes = ['bootstrap', 'implement', 'resume'] as const;
-
-export type FactoryEntrypointMode = (typeof allowedModes)[number];
-
 export interface FactoryEntrypointOptions {
   briefUrl: string;
   targetRealmUrl: string | null;
   realmServerUrl: string | null;
-  mode: FactoryEntrypointMode;
   model?: string;
   debug?: boolean;
+  retryBlocked?: boolean;
 }
 
 export interface FactoryEntrypointAction {
@@ -59,7 +55,6 @@ export interface FactoryEntrypointIssueLoopSummary {
 
 export interface FactoryEntrypointSummary {
   command: 'factory:go';
-  mode: FactoryEntrypointMode;
   brief: FactoryEntrypointBriefSummary;
   targetRealm: {
     url: string;
@@ -102,7 +97,7 @@ export function getFactoryEntrypointUsage(): string {
     '',
     'Options:',
     '  --realm-server-url <url>   Realm server URL (default: http://localhost:4201/)',
-    '  --mode <mode>               One of: bootstrap, implement, resume',
+    '  --no-retry-blocked          Skip retrying blocked issues (by default, blocked issues are reset to backlog)',
     '  --model <model>             OpenRouter model ID (e.g., anthropic/claude-sonnet-4)',
     '  --debug                     Log LLM prompts and responses to stderr',
     '  --help                      Show this usage information',
@@ -142,8 +137,8 @@ export function parseFactoryEntrypointArgs(
         help: {
           type: 'boolean',
         },
-        mode: {
-          type: 'string',
+        'no-retry-blocked': {
+          type: 'boolean',
         },
         model: {
           type: 'string',
@@ -173,7 +168,6 @@ export function parseFactoryEntrypointArgs(
     typeof parsed.values['realm-server-url'] === 'string'
       ? normalizeUrl(parsed.values['realm-server-url'], '--realm-server-url')
       : null;
-  let mode = parseMode(parsed.values.mode);
   let model =
     typeof parsed.values.model === 'string'
       ? parsed.values.model.trim() || undefined
@@ -183,9 +177,9 @@ export function parseFactoryEntrypointArgs(
     briefUrl: normalizeUrl(briefUrl, '--brief-url'),
     targetRealmUrl: normalizeUrl(targetRealmUrl, '--target-realm-url'),
     realmServerUrl,
-    mode,
     model,
     debug: parsed.values.debug === true ? true : undefined,
+    retryBlocked: parsed.values['no-retry-blocked'] === true ? false : true,
   };
 }
 
@@ -239,44 +233,41 @@ export async function runFactoryEntrypoint(
   );
 
   // Run the issue-driven loop
-  if (options.mode === 'implement') {
-    let loopFn = dependencies?.runIssueLoop ?? runFactoryIssueLoop;
-    let loopResult = await loopFn({
-      briefUrl: options.briefUrl,
-      targetRealmUrl: targetRealm.url,
-      realmServerUrl: targetRealm.serverUrl,
-      ownerUsername: targetRealm.ownerUsername,
-      authorization: targetRealm.authorization,
-      model: options.model,
-      debug: options.debug,
-      fetch: dependencies?.fetch,
-    });
+  let loopFn = dependencies?.runIssueLoop ?? runFactoryIssueLoop;
+  let loopResult = await loopFn({
+    briefUrl: options.briefUrl,
+    targetRealmUrl: targetRealm.url,
+    realmServerUrl: targetRealm.serverUrl,
+    ownerUsername: targetRealm.ownerUsername,
+    authorization: targetRealm.authorization,
+    model: options.model,
+    debug: options.debug,
+    retryBlocked: options.retryBlocked,
+    fetch: dependencies?.fetch,
+  });
 
-    summary.issueLoop = {
-      outcome: loopResult.outcome,
-      outerCycles: loopResult.outerCycles,
-      issueResults: loopResult.issueResults.map((ir) => ({
-        issueId: ir.issueId,
-        exitReason: ir.exitReason,
-        innerIterations: ir.innerIterations,
-        toolCallCount: ir.toolCallLog.length,
-      })),
-    };
+  summary.issueLoop = {
+    outcome: loopResult.outcome,
+    outerCycles: loopResult.outerCycles,
+    issueResults: loopResult.issueResults.map((ir) => ({
+      issueId: ir.issueId,
+      exitReason: ir.exitReason,
+      innerIterations: ir.innerIterations,
+      toolCallCount: ir.toolCallLog.length,
+    })),
+  };
 
-    let succeeded = loopResult.outcome === 'all_issues_done';
-    summary.result = {
-      status: succeeded ? 'completed' : 'failed',
-      nextStep: succeeded
-        ? 'all-issues-completed'
-        : `loop-${loopResult.outcome}`,
-    };
-  }
+  let succeeded = loopResult.outcome === 'all_issues_done';
+  summary.result = {
+    status: succeeded ? 'completed' : 'failed',
+    nextStep: succeeded ? 'all-issues-completed' : `loop-${loopResult.outcome}`,
+  };
 
   return summary;
 }
 
 export function buildFactoryEntrypointSummary(
-  options: FactoryEntrypointOptions,
+  _options: FactoryEntrypointOptions,
   brief: FactoryBrief,
   targetRealm: FactoryTargetRealmBootstrapResult,
   seedResult: SeedIssueResult,
@@ -323,7 +314,6 @@ export function buildFactoryEntrypointSummary(
 
   return {
     command: 'factory:go',
-    mode: options.mode,
     brief: {
       ...brief,
       url: brief.sourceUrl,
@@ -339,8 +329,7 @@ export function buildFactoryEntrypointSummary(
     actions,
     result: {
       status: 'ready',
-      nextStep:
-        options.mode === 'bootstrap' ? 'seed-issue-created' : 'run-issue-loop',
+      nextStep: 'run-issue-loop',
     },
   };
 }
@@ -354,32 +343,6 @@ function requireStringValue(
   }
 
   throw new FactoryEntrypointUsageError(`Missing required ${flagName}`);
-}
-
-function parseMode(value: string | boolean | undefined): FactoryEntrypointMode {
-  if (value === undefined) {
-    return 'implement';
-  }
-
-  if (typeof value !== 'string') {
-    throw new FactoryEntrypointUsageError(
-      'Expected --mode to be a string value',
-    );
-  }
-
-  if (isFactoryEntrypointMode(value)) {
-    return value;
-  }
-
-  throw new FactoryEntrypointUsageError(
-    `Invalid --mode "${value}". Expected one of: ${allowedModes.join(', ')}`,
-  );
-}
-
-function isFactoryEntrypointMode(
-  value: string,
-): value is FactoryEntrypointMode {
-  return (allowedModes as readonly string[]).includes(value);
 }
 
 function normalizeUrl(rawUrl: string, flagName: string): string {

--- a/packages/software-factory/src/factory-issue-loop-wiring.ts
+++ b/packages/software-factory/src/factory-issue-loop-wiring.ts
@@ -51,7 +51,7 @@ import {
   type IssueLoopConfig,
   type IssueLoopResult,
 } from './issue-loop';
-import { RealmIssueStore } from './issue-scheduler';
+import { RealmIssueStore, type IssueStore } from './issue-scheduler';
 import { RealmIssueRelationshipLoader } from './realm-issue-relationship-loader';
 import {
   ensureTrailingSlash,
@@ -125,7 +125,7 @@ export async function runFactoryIssueLoop(
     options: fetchOptions,
   });
 
-  // 2b. Retry blocked issues (opt-in via --retry-blocked)
+  // 2b. Retry blocked issues (default on, opt out with --no-retry-blocked)
   if (config.retryBlocked) {
     await retryBlockedIssues(issueStore);
   }
@@ -229,18 +229,29 @@ export async function runFactoryIssueLoop(
 // Retry blocked issues
 // ---------------------------------------------------------------------------
 
-async function retryBlockedIssues(issueStore: RealmIssueStore): Promise<void> {
+async function retryBlockedIssues(issueStore: IssueStore): Promise<void> {
   let issues = await issueStore.listIssues();
   let resetCount = 0;
+
+  // Build a status map so we can check if blockers are actually unresolved
+  let statusMap = new Map<string, string>();
+  for (let issue of issues) {
+    statusMap.set(issue.id, issue.status);
+  }
 
   for (let issue of issues) {
     if (issue.status !== 'blocked') continue;
 
     // Only retry issues blocked by validation/max-iterations,
-    // NOT issues blocked by a dependency on another issue.
-    if (issue.blockedBy.length > 0) {
+    // NOT issues with unresolved dependency blockers.
+    // blockedBy relationships persist even after blockers complete,
+    // so we check whether any blocker is actually non-done.
+    let hasUnresolvedBlocker = issue.blockedBy.some(
+      (blockerId) => statusMap.get(blockerId) !== 'done',
+    );
+    if (hasUnresolvedBlocker) {
       log.info(
-        `Retry: skipping "${issue.id}" — blocked by dependency, not retrying`,
+        `Retry: skipping "${issue.id}" — has unresolved dependency blockers`,
       );
       continue;
     }

--- a/packages/software-factory/src/factory-issue-loop-wiring.ts
+++ b/packages/software-factory/src/factory-issue-loop-wiring.ts
@@ -91,6 +91,11 @@ export interface IssueLoopWiringConfig {
   maxIterationsPerIssue?: number;
   /** Max outer-loop cycles. Default: 50. */
   maxOuterCycles?: number;
+  /**
+   * Reset blocked issues (without blockedBy dependencies) to backlog before
+   * running the loop. Sets priority to critical for immediate pickup.
+   */
+  retryBlocked?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -119,6 +124,11 @@ export async function runFactoryIssueLoop(
     darkfactoryModuleUrl,
     options: fetchOptions,
   });
+
+  // 2b. Retry blocked issues (opt-in via --retry-blocked)
+  if (config.retryBlocked) {
+    await retryBlockedIssues(issueStore);
+  }
 
   // 3. Context builder with issue relationship loader
   let issueLoader = new RealmIssueRelationshipLoader({
@@ -213,6 +223,48 @@ export async function runFactoryIssueLoop(
   };
 
   return runIssueLoop(issueLoopConfig);
+}
+
+// ---------------------------------------------------------------------------
+// Retry blocked issues
+// ---------------------------------------------------------------------------
+
+async function retryBlockedIssues(issueStore: RealmIssueStore): Promise<void> {
+  let issues = await issueStore.listIssues();
+  let resetCount = 0;
+
+  for (let issue of issues) {
+    if (issue.status !== 'blocked') continue;
+
+    // Only retry issues blocked by validation/max-iterations,
+    // NOT issues blocked by a dependency on another issue.
+    if (issue.blockedBy.length > 0) {
+      log.info(
+        `Retry: skipping "${issue.id}" — blocked by dependency, not retrying`,
+      );
+      continue;
+    }
+
+    await issueStore.addComment(issue.id, {
+      body: '**Retry:** resetting blocked status to backlog for another attempt.',
+      author: 'orchestrator',
+    });
+    // Set priority to critical so the scheduler picks retried issues first
+    await issueStore.updateIssue(issue.id, {
+      status: 'backlog',
+      priority: 'critical',
+    });
+    log.info(
+      `Retry: reset blocked issue "${issue.id}" to backlog (priority: critical)`,
+    );
+    resetCount++;
+  }
+
+  if (resetCount > 0) {
+    log.info(`Retry: reset ${resetCount} blocked issue(s) to backlog`);
+  } else {
+    log.info('Retry: no eligible blocked issues found to reset');
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/software-factory/src/factory-issue-loop-wiring.ts
+++ b/packages/software-factory/src/factory-issue-loop-wiring.ts
@@ -229,7 +229,9 @@ export async function runFactoryIssueLoop(
 // Retry blocked issues
 // ---------------------------------------------------------------------------
 
-async function retryBlockedIssues(issueStore: IssueStore): Promise<void> {
+export async function retryBlockedIssues(
+  issueStore: IssueStore,
+): Promise<void> {
   let issues = await issueStore.listIssues();
   let resetCount = 0;
 

--- a/packages/software-factory/src/issue-scheduler.ts
+++ b/packages/software-factory/src/issue-scheduler.ts
@@ -37,8 +37,11 @@ export interface IssueStore {
   listIssues(): Promise<SchedulableIssue[]>;
   /** Re-read a single issue's current state from the realm. */
   refreshIssue(issueId: string): Promise<SchedulableIssue>;
-  /** Update issue fields in the realm (e.g., status). Descriptions are immutable — use addComment instead. */
-  updateIssue(issueId: string, updates: { status?: string }): Promise<void>;
+  /** Update issue fields in the realm (e.g., status, priority). Descriptions are immutable — use addComment instead. */
+  updateIssue(
+    issueId: string,
+    updates: { status?: string; priority?: string },
+  ): Promise<void>;
   /** Append a comment to an issue. All post-creation context goes through comments. */
   addComment(
     issueId: string,
@@ -243,7 +246,7 @@ export class RealmIssueStore implements IssueStore {
 
   async updateIssue(
     issueId: string,
-    updates: { status?: string },
+    updates: { status?: string; priority?: string },
   ): Promise<void> {
     // Read the source JSON file (not the indexed card, which can have
     // stripped relationships during indexing).
@@ -267,6 +270,9 @@ export class RealmIssueStore implements IssueStore {
 
     if (updates.status != null) {
       attrs.status = updates.status;
+    }
+    if (updates.priority != null) {
+      attrs.priority = updates.priority;
     }
     attrs.updatedAt = new Date().toISOString();
 

--- a/packages/software-factory/tests/factory-entrypoint.integration.test.ts
+++ b/packages/software-factory/tests/factory-entrypoint.integration.test.ts
@@ -14,7 +14,6 @@ const stickyNoteFixture = readFileSync(
 
 interface FactoryEntrypointIntegrationSummary {
   command: string;
-  mode: string;
   brief: {
     url: string;
     title: string;
@@ -126,6 +125,27 @@ module('factory-entrypoint integration', function () {
             [canonicalTargetRealmUrl]: 'Bearer target-realm-token',
           }),
         );
+      } else if (request.url === '/_run-command' && request.method === 'POST') {
+        // Schema loading — return error so wiring layer skips (non-fatal)
+        response.writeHead(200, { 'content-type': SupportedMimeType.JSON });
+        response.end(
+          JSON.stringify({
+            data: {
+              type: 'card',
+              attributes: {
+                status: 'error',
+                error: 'Schema not available in test',
+              },
+            },
+          }),
+        );
+      } else if (
+        request.url === '/hassan/personal/_search' &&
+        request.method === 'QUERY'
+      ) {
+        // Issue store search — return empty results so the loop exits immediately
+        response.writeHead(200, { 'content-type': SupportedMimeType.CardJson });
+        response.end(JSON.stringify({ data: [] }));
       } else if (
         request.url === '/hassan/personal/_readiness-check' &&
         request.method === 'GET'
@@ -215,8 +235,6 @@ module('factory-entrypoint integration', function () {
           targetRealmUrl,
           '--realm-server-url',
           `${origin}/`,
-          '--mode',
-          'resume',
         ],
         {
           cwd: packageRoot,
@@ -236,7 +254,6 @@ module('factory-entrypoint integration', function () {
         result.stdout,
       ) as FactoryEntrypointIntegrationSummary;
       assert.strictEqual(summary.command, 'factory:go');
-      assert.strictEqual(summary.mode, 'resume');
       assert.strictEqual(summary.brief.url, briefUrl);
       assert.strictEqual(summary.brief.title, 'Sticky Note');
       assert.strictEqual(
@@ -255,9 +272,10 @@ module('factory-entrypoint integration', function () {
         'Issues/bootstrap-seed',
       );
       assert.strictEqual(summary.seedIssue.seedIssueStatus, 'created');
+      // Loop runs and completes immediately (no issues in realm)
       assert.deepEqual(summary.result, {
-        status: 'ready',
-        nextStep: 'run-issue-loop',
+        status: 'completed',
+        nextStep: 'all-issues-completed',
       });
     } finally {
       await new Promise<void>((resolvePromise, reject) =>
@@ -297,7 +315,7 @@ module('factory-entrypoint integration', function () {
     assert.strictEqual(result.status, 0, result.stderr);
     assert.true(/Usage:/.test(result.stdout));
     assert.true(/--brief-url <url>/.test(result.stdout));
-    assert.true(/--mode <mode>/.test(result.stdout));
+    assert.true(/--no-retry-blocked/.test(result.stdout));
   });
 
   test('factory:go fails clearly when MATRIX_USERNAME is missing', async function (assert) {

--- a/packages/software-factory/tests/factory-entrypoint.test.ts
+++ b/packages/software-factory/tests/factory-entrypoint.test.ts
@@ -45,7 +45,7 @@ module('factory-entrypoint', function (hooks) {
     process.env.MATRIX_USERNAME = originalMatrixUsername;
   });
 
-  test('parseFactoryEntrypointArgs accepts required inputs and defaults mode', function (assert) {
+  test('parseFactoryEntrypointArgs accepts required inputs', function (assert) {
     let options = parseFactoryEntrypointArgs([
       '--brief-url',
       briefUrl,
@@ -59,29 +59,24 @@ module('factory-entrypoint', function (hooks) {
       briefUrl,
       targetRealmUrl,
       realmServerUrl: 'https://realms.example.test/',
-      mode: 'implement',
       model: undefined,
       debug: undefined,
+      retryBlocked: true,
     });
   });
 
-  test('parseFactoryEntrypointArgs rejects invalid mode', function (assert) {
-    assert.throws(
-      () =>
-        parseFactoryEntrypointArgs([
-          '--brief-url',
-          briefUrl,
-          '--target-realm-url',
-          targetRealmUrl,
-          '--mode',
-          'ship-it',
-        ]),
-      (error: unknown) =>
-        error instanceof FactoryEntrypointUsageError &&
-        error.message ===
-          'Invalid --mode "ship-it". Expected one of: bootstrap, implement, resume',
-    );
+  test('parseFactoryEntrypointArgs accepts --no-retry-blocked', function (assert) {
+    let options = parseFactoryEntrypointArgs([
+      '--brief-url',
+      briefUrl,
+      '--target-realm-url',
+      targetRealmUrl,
+      '--no-retry-blocked',
+    ]);
+
+    assert.false(options.retryBlocked);
   });
+
   test('parseFactoryEntrypointArgs rejects missing required inputs', function (assert) {
     assert.throws(
       () => parseFactoryEntrypointArgs(['--target-realm-url', targetRealmUrl]),
@@ -96,7 +91,6 @@ module('factory-entrypoint', function (hooks) {
       {
         briefUrl,
         targetRealmUrl,
-        mode: 'bootstrap',
         realmServerUrl: null,
       },
       normalizedBrief,
@@ -105,7 +99,6 @@ module('factory-entrypoint', function (hooks) {
     );
 
     assert.strictEqual(summary.command, 'factory:go');
-    assert.strictEqual(summary.mode, 'bootstrap');
     assert.strictEqual(summary.brief.url, briefUrl);
     assert.strictEqual(summary.brief.title, 'Sticky Note');
     assert.deepEqual(summary.brief.tags, [
@@ -131,7 +124,7 @@ module('factory-entrypoint', function (hooks) {
     assert.strictEqual(summary.seedIssue.seedIssueStatus, 'created');
     assert.deepEqual(summary.result, {
       status: 'ready',
-      nextStep: 'seed-issue-created',
+      nextStep: 'run-issue-loop',
     });
   });
 
@@ -147,7 +140,7 @@ module('factory-entrypoint', function (hooks) {
     assert.true(/--brief-url <url>/.test(usage));
     assert.true(/--target-realm-url <url>/.test(usage));
     assert.true(/--realm-server-url <url>/.test(usage));
-    assert.true(/--mode <mode>/.test(usage));
+    assert.true(/--no-retry-blocked/.test(usage));
     assert.true(/--help/.test(usage));
     assert.true(/MATRIX_USERNAME is required/.test(usage));
     assert.true(/For public briefs, no auth setup is needed./.test(usage));
@@ -163,7 +156,6 @@ module('factory-entrypoint', function (hooks) {
         briefUrl,
         targetRealmUrl,
         realmServerUrl: null,
-        mode: 'implement',
       },
       {
         bootstrapTargetRealm: async (resolution) => ({
@@ -236,7 +228,6 @@ module('factory-entrypoint', function (hooks) {
         briefUrl,
         targetRealmUrl,
         realmServerUrl: 'https://realms.example.test/app/',
-        mode: 'bootstrap',
       },
       {
         bootstrapTargetRealm: async (resolution) => ({
@@ -250,6 +241,11 @@ module('factory-entrypoint', function (hooks) {
           capturedDarkfactoryModuleUrl = options.darkfactoryModuleUrl;
           return mockSeedResult;
         },
+        runIssueLoop: async () => ({
+          outcome: 'all_issues_done' as const,
+          outerCycles: 0,
+          issueResults: [],
+        }),
         fetch: async () =>
           new Response(
             JSON.stringify({

--- a/packages/software-factory/tests/factory-target-realm.spec.ts
+++ b/packages/software-factory/tests/factory-target-realm.spec.ts
@@ -133,7 +133,9 @@ test('factory:go creates a target realm and bootstraps project artifacts end-to-
       };
     };
     expect(issueJson.data.attributes.issueType).toBe('bootstrap');
-    expect(issueJson.data.attributes.status).toBe('backlog');
+    // The loop picks up the seed issue and sets it to in_progress before
+    // the agent fails (no OPENROUTER_API_KEY), so the status is in_progress.
+    expect(issueJson.data.attributes.status).toBe('in_progress');
     expect(issueJson.data.attributes.summary).toContain(
       'Process brief and create project artifacts',
     );

--- a/packages/software-factory/tests/factory-target-realm.spec.ts
+++ b/packages/software-factory/tests/factory-target-realm.spec.ts
@@ -67,6 +67,10 @@ test('factory:go creates a target realm and bootstraps project artifacts end-to-
   ).href;
 
   try {
+    // The factory always runs the issue loop after seed creation. Without
+    // OPENROUTER_API_KEY the loop will fail when it tries to invoke the LLM
+    // agent, so we expect a non-zero exit. The seed issue is still created
+    // before the loop starts — we verify that below by reading it from the realm.
     let result = await runCommand(
       'node',
       [
@@ -80,8 +84,7 @@ test('factory:go creates a target realm and bootstraps project artifacts end-to-
         targetRealmUrl,
         '--realm-server-url',
         realmServerURL,
-        '--mode',
-        'bootstrap',
+        '--no-retry-blocked',
       ],
       {
         cwd: packageRoot,
@@ -95,36 +98,23 @@ test('factory:go creates a target realm and bootstraps project artifacts end-to-
       },
     );
 
+    // The factory exits non-zero because the loop fails without an API key,
+    // but the seed issue and target realm were created before the loop ran.
     expect(
       result.status,
-      `factory:go failed (status=${result.status}).\nstderr:\n${result.stderr}\nstdout:\n${result.stdout}`,
-    ).toBe(0);
+      `factory:go unexpected status.\nstderr:\n${result.stderr}\nstdout:\n${result.stdout}`,
+    ).toBe(1);
 
-    let summary = JSON.parse(result.stdout) as {
-      command: string;
-      targetRealm: { url: string; ownerUsername: string };
-      seedIssue: {
-        seedIssueId: string;
-        seedIssueStatus: string;
-      };
-    };
-
-    expect(summary.command).toBe('factory:go');
-    expect(summary.targetRealm.ownerUsername).toBe(targetUsername);
-    expect(summary.seedIssue.seedIssueId).toBe('Issues/bootstrap-seed');
-    expect(summary.seedIssue.seedIssueStatus).toBe('created');
-
-    // Verify the seed issue actually exists in the newly created target realm
+    // Verify the seed issue exists in the newly created target realm
     // by authenticating as the target user who owns the realm
     let targetRealmToken = await getRealmToken(
       matrixURL,
       targetUsername,
       targetPassword,
-      summary.targetRealm.url,
+      targetRealmUrl,
     );
 
-    let seedIssueUrl = new URL('Issues/bootstrap-seed', summary.targetRealm.url)
-      .href;
+    let seedIssueUrl = new URL('Issues/bootstrap-seed', targetRealmUrl).href;
     let seedIssueResponse = await fetch(seedIssueUrl, {
       headers: {
         Accept: SupportedMimeType.CardSource,

--- a/packages/software-factory/tests/index.ts
+++ b/packages/software-factory/tests/index.ts
@@ -13,5 +13,6 @@ import './factory-tool-builder.test';
 import './realm-auth.test';
 import './issue-loop.test';
 import './issue-scheduler.test';
+import './retry-blocked-issues.test';
 import './validation-pipeline.test';
 import './test-step.test';

--- a/packages/software-factory/tests/retry-blocked-issues.test.ts
+++ b/packages/software-factory/tests/retry-blocked-issues.test.ts
@@ -1,0 +1,160 @@
+import { module, test } from 'qunit';
+
+import type { SchedulableIssue } from '../src/factory-agent';
+import type { IssueStore } from '../src/issue-scheduler';
+import { retryBlockedIssues } from '../src/factory-issue-loop-wiring';
+
+// ---------------------------------------------------------------------------
+// MockIssueStore
+// ---------------------------------------------------------------------------
+
+class MockIssueStore implements IssueStore {
+  issues: SchedulableIssue[];
+  updateCalls: { issueId: string; updates: Record<string, unknown> }[] = [];
+  commentCalls: {
+    issueId: string;
+    comment: { body: string; author: string };
+  }[] = [];
+
+  constructor(issues: SchedulableIssue[]) {
+    this.issues = issues.map((i) => ({ ...i }));
+  }
+
+  async listIssues(): Promise<SchedulableIssue[]> {
+    return this.issues.map((i) => ({ ...i }));
+  }
+
+  async refreshIssue(issueId: string): Promise<SchedulableIssue> {
+    let issue = this.issues.find((i) => i.id === issueId);
+    if (!issue) {
+      throw new Error(`Issue "${issueId}" not found`);
+    }
+    return { ...issue };
+  }
+
+  async updateIssue(
+    issueId: string,
+    updates: { status?: string; priority?: string },
+  ): Promise<void> {
+    this.updateCalls.push({ issueId, updates });
+    let issue = this.issues.find((i) => i.id === issueId);
+    if (issue && updates.status) {
+      issue.status = updates.status as SchedulableIssue['status'];
+    }
+  }
+
+  async addComment(
+    issueId: string,
+    comment: { body: string; author: string },
+  ): Promise<void> {
+    this.commentCalls.push({ issueId, comment });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeIssue(
+  overrides: Partial<SchedulableIssue> & { id: string },
+): SchedulableIssue {
+  return {
+    status: 'backlog',
+    priority: 'medium',
+    blockedBy: [],
+    order: 0,
+    summary: `Issue ${overrides.id}`,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+module('retryBlockedIssues', function () {
+  test('resets a blocked issue with no blockedBy dependencies', async function (assert) {
+    let store = new MockIssueStore([
+      makeIssue({ id: 'ISS-1', status: 'blocked', blockedBy: [] }),
+    ]);
+
+    await retryBlockedIssues(store);
+
+    assert.strictEqual(store.updateCalls.length, 1);
+    assert.strictEqual(store.updateCalls[0].issueId, 'ISS-1');
+    assert.strictEqual(store.updateCalls[0].updates.status, 'backlog');
+    assert.strictEqual(store.updateCalls[0].updates.priority, 'critical');
+    assert.strictEqual(store.commentCalls.length, 1);
+    assert.strictEqual(store.commentCalls[0].issueId, 'ISS-1');
+    assert.true(store.commentCalls[0].comment.body.includes('Retry'));
+  });
+
+  test('skips blocked issue with unresolved blocker', async function (assert) {
+    let store = new MockIssueStore([
+      makeIssue({ id: 'A', status: 'in_progress' }),
+      makeIssue({ id: 'B', status: 'blocked', blockedBy: ['A'] }),
+    ]);
+
+    await retryBlockedIssues(store);
+
+    assert.strictEqual(store.updateCalls.length, 0, 'no updates made');
+    assert.strictEqual(store.commentCalls.length, 0, 'no comments added');
+  });
+
+  test('resets blocked issue whose blockers are all done', async function (assert) {
+    let store = new MockIssueStore([
+      makeIssue({ id: 'A', status: 'done' }),
+      makeIssue({ id: 'B', status: 'blocked', blockedBy: ['A'] }),
+    ]);
+
+    await retryBlockedIssues(store);
+
+    assert.strictEqual(store.updateCalls.length, 1);
+    assert.strictEqual(store.updateCalls[0].issueId, 'B');
+    assert.strictEqual(store.updateCalls[0].updates.status, 'backlog');
+    assert.strictEqual(store.updateCalls[0].updates.priority, 'critical');
+  });
+
+  test('skips non-blocked issues', async function (assert) {
+    let store = new MockIssueStore([
+      makeIssue({ id: 'A', status: 'backlog' }),
+      makeIssue({ id: 'B', status: 'done' }),
+      makeIssue({ id: 'C', status: 'in_progress' }),
+    ]);
+
+    await retryBlockedIssues(store);
+
+    assert.strictEqual(store.updateCalls.length, 0);
+    assert.strictEqual(store.commentCalls.length, 0);
+  });
+
+  test('handles mix: resets eligible, skips dependency-blocked', async function (assert) {
+    let store = new MockIssueStore([
+      makeIssue({ id: 'A', status: 'in_progress' }),
+      makeIssue({
+        id: 'B',
+        status: 'blocked',
+        blockedBy: ['A'],
+      }),
+      makeIssue({
+        id: 'C',
+        status: 'blocked',
+        blockedBy: [],
+      }),
+    ]);
+
+    await retryBlockedIssues(store);
+
+    assert.strictEqual(store.updateCalls.length, 1);
+    assert.strictEqual(store.updateCalls[0].issueId, 'C');
+  });
+
+  test('no-op when no issues exist', async function (assert) {
+    let store = new MockIssueStore([]);
+
+    await retryBlockedIssues(store);
+
+    assert.strictEqual(store.updateCalls.length, 0);
+    assert.strictEqual(store.commentCalls.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary

CS-10452 makes the factory entrypoint fully idempotent — you can run `factory:go` against the same realm repeatedly and it does the right thing every time, whether it's a fresh run, a resume after a crash, or a retry after blocked issues.

**Key changes:**

- **Removed `--mode` flag.** The bootstrap/implement/resume distinction added complexity without value. Seed issue creation is already idempotent (`createSeedIssue` returns `existing` when the seed already exists) and the loop exits gracefully when there are no issues. The factory now always creates the seed and runs the loop — no flags needed.
- **Blocked issues are auto-retried by default.** Issues blocked by validation failures or max iteration limits (but NOT by dependency on another issue) are reset to `backlog` with `critical` priority before each run. A comment is added for traceability and prior failure context is preserved in comments so the agent knows what went wrong. Pass `--no-retry-blocked` to opt out.
- **Three integration smoke test scenarios** validate the full lifecycle against a live Boxel app.

## Try it out

### Prerequisites

```bash
# Docker running, mise run dev-all
export MATRIX_URL=http://localhost:8008/
export MATRIX_USERNAME=your-username
read -s 'MATRIX_PASSWORD?Matrix password: ' && export MATRIX_PASSWORD
export OPENROUTER_API_KEY=sk-or-v1-your-key-here
cd packages/software-factory
```

### Scenario 1: Bootstrap complete, no code yet

Sets up a Project + Issues in backlog (simulating completed bootstrap), then runs the factory to implement from scratch.

```bash
pnpm smoke:factory-scenarios --scenario 1 --debug
```

**What to verify in the Boxel app** (realm: `<username>/smoke-s1`):
- `Issues/hello-card-define` should be `done` or `in_progress`
- `hello.gts` should exist with a HelloCard definition containing a `greeting` field
- `hello.test.gts` should exist with QUnit tests
- `Test Runs/` should have validation results showing pass/fail details

### Scenario 2: Blocked issue with validation failures

Sets up a blocked issue with buggy code (`hello.gts` renders "Placeholder" instead of the greeting) and a failing test. The factory auto-resets the blocked issue and the agent tries to fix the bug.

```bash
pnpm smoke:factory-scenarios --scenario 2 --debug
```

**What to verify in the Boxel app** (realm: `<username>/smoke-s2`):
- `Issues/hello-card-define` should show the "Retry: resetting blocked status..." comment added by the orchestrator
- `hello.gts` should be updated — the agent should have fixed the template to render the greeting field instead of "Placeholder"
- `Test Runs/` should have new validation results (hopefully passing)
- The original "Blocked: max iteration limit reached..." comment should still be visible

### Scenario 3: Completed project, new enhancement

Sets up a completed project with working HelloCard code + passing tests, then adds a new enhancement issue asking to add a `color` field.

```bash
pnpm smoke:factory-scenarios --scenario 3 --debug
```

**What to verify in the Boxel app** (realm: `<username>/smoke-s3`):
- `Issues/hello-card-define` should still be `done` (untouched)
- `Issues/hello-card-enhance` should be `done` or `in_progress`
- `hello.gts` should have a `color` field added to HelloCard
- `hello.test.gts` should have new test assertions for the color field

### Run all scenarios

```bash
pnpm smoke:factory-scenarios --scenario all --debug
```

## Test plan

- [x] `pnpm test:node` — 358 tests pass
- [x] `pnpm smoke:issue-loop` — 28 mock-based smoke tests pass
- [x] `pnpm lint` — clean
- [x] Manually run each smoke scenario against a live Boxel app and verify the "What to verify" items above

🤖 Generated with [Claude Code](https://claude.com/claude-code)