### PR TITLE
Fix stale module cache errors blocking definition lookups

### DIFF
--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -1196,22 +1196,17 @@ module(basename(__filename), function () {
         async prerenderModule(args: ModulePrerenderArgs) {
           calls++;
           if (shouldError) {
-            return buildModuleResponse(
-              args.url,
-              'TransientError',
-              [],
-              {
-                type: 'module-error',
-                error: {
-                  id: args.url,
-                  message: 'transient prerender failure',
-                  status: 500,
-                  title: 'Render timeout',
-                  deps: [],
-                  additionalErrors: null,
-                },
+            return buildModuleResponse(args.url, 'TransientError', [], {
+              type: 'module-error',
+              error: {
+                id: args.url,
+                message: 'transient prerender failure',
+                status: 500,
+                title: 'Render timeout',
+                deps: [],
+                additionalErrors: null,
               },
-            );
+            });
           }
           return buildModuleResponse(args.url, 'TransientError', []);
         },
@@ -1271,7 +1266,10 @@ module(basename(__filename), function () {
         module: moduleURL,
         name: 'TransientError',
       });
-      assert.ok(definition, 'lookup succeeds after stale error is re-prerendered');
+      assert.ok(
+        definition,
+        'lookup succeeds after stale error is re-prerendered',
+      );
       assert.strictEqual(definition?.displayName, 'TransientError');
       assert.strictEqual(
         calls,

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -1172,5 +1172,124 @@ module(basename(__filename), function () {
         virtualNetwork.unmount(handler);
       }
     });
+
+    test('re-prerenders when cached error entry expires', async function (assert) {
+      await dbAdapter.execute('DELETE FROM modules');
+
+      let moduleURL = `${realmURL}transient-error.gts`;
+      let calls = 0;
+      let shouldError = true;
+
+      let prerenderer: Prerenderer = {
+        async prerenderCard() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderFileExtract() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderFileRender() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls++;
+          if (shouldError) {
+            return buildModuleResponse(
+              args.url,
+              'TransientError',
+              [],
+              {
+                type: 'module-error',
+                error: {
+                  id: args.url,
+                  message: 'transient prerender failure',
+                  status: 500,
+                  title: 'Render timeout',
+                  deps: [],
+                  additionalErrors: null,
+                },
+              },
+            );
+          }
+          return buildModuleResponse(args.url, 'TransientError', []);
+        },
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      // 1. First lookup caches the error
+      await assert.rejects(
+        lookup.lookupDefinition({
+          module: moduleURL,
+          name: 'TransientError',
+        }),
+        /nonexistent type/,
+        'lookup fails with cached error',
+      );
+      assert.strictEqual(calls, 1, 'prerenderModule called once');
+
+      // 2. Error is fresh (within TTL) — should still be served from cache
+      shouldError = false;
+      await assert.rejects(
+        lookup.lookupDefinition({
+          module: moduleURL,
+          name: 'TransientError',
+        }),
+        /nonexistent type/,
+        'lookup still fails with fresh cached error',
+      );
+      assert.strictEqual(
+        calls,
+        1,
+        'prerenderModule not called again — error is still fresh',
+      );
+
+      // 3. Backdate created_at to simulate expired error
+      await dbAdapter.execute(
+        `UPDATE modules SET created_at = $1 WHERE url = $2`,
+        { bind: [Date.now() - 60_000, moduleURL] },
+      );
+
+      // 4. Now the stale error should trigger a re-prerender which succeeds
+      let definition = await lookup.lookupDefinition({
+        module: moduleURL,
+        name: 'TransientError',
+      });
+      assert.ok(definition, 'lookup succeeds after stale error is re-prerendered');
+      assert.strictEqual(definition?.displayName, 'TransientError');
+      assert.strictEqual(
+        calls,
+        2,
+        'prerenderModule called again after error TTL expired',
+      );
+
+      // 5. Subsequent lookups should use the now-healthy cache
+      definition = await lookup.lookupDefinition({
+        module: moduleURL,
+        name: 'TransientError',
+      });
+      assert.ok(definition, 'lookup succeeds from healthy cache');
+      assert.strictEqual(
+        calls,
+        2,
+        'prerenderModule not called again — healthy entry is cached',
+      );
+    });
   });
 });

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -34,6 +34,10 @@ import type { VirtualNetwork } from './virtual-network';
 
 const MODULES_TABLE = 'modules';
 const PREFERRED_EXECUTABLE_EXTENSIONS = ['.gts', '.ts', '.gjs', '.js'];
+// Cached module errors expire after this interval. When a stale error entry
+// is encountered, the prerenderer is called again to get a fresh result.
+// This prevents transient prerender failures from being permanently cached.
+const ERROR_CACHE_TTL_MS = 30_000; // 30 seconds
 const modulesTableCoerceTypes: TypeCoercion = Object.freeze({
   definitions: 'JSON',
   deps: 'JSON',
@@ -97,6 +101,7 @@ export interface ModuleCacheEntry {
   cacheScope: CacheScope;
   authUserId?: string;
   resolvedRealmURL: string;
+  createdAt?: number;
 }
 
 export interface ModuleCacheEntryQuery {
@@ -281,7 +286,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       cacheUserId,
       resolvedRealmURL,
     );
-    if (cached) {
+    if (cached && !this.isExpiredErrorEntry(cached)) {
       return cached;
     }
 
@@ -293,7 +298,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
           cacheUserId,
           resolvedRealmURL,
         );
-        if (candidateCached) {
+        if (candidateCached && !this.isExpiredErrorEntry(candidateCached)) {
           return candidateCached;
         }
       }
@@ -317,6 +322,21 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       );
     }
     return undefined;
+  }
+
+  // Returns true if the cached entry has a top-level error and has exceeded
+  // the error TTL. This causes the entry to be treated as a cache miss so
+  // the prerenderer is called again to get a fresh result. This prevents
+  // transient prerender failures from being permanently cached.
+  private isExpiredErrorEntry(entry: ModuleCacheEntry): boolean {
+    if (!entry.error) {
+      return false;
+    }
+    if (entry.createdAt == null) {
+      // No timestamp — treat as expired so we re-validate
+      return true;
+    }
+    return Date.now() - entry.createdAt > ERROR_CACHE_TTL_MS;
   }
 
   private populationCandidates(moduleURL: string): string[] {
@@ -588,7 +608,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     let moduleAlias = normalizeExecutableURL(moduleUrl);
     let rows = (await this.query(
       [
-        'SELECT definitions, deps, error_doc, cache_scope, auth_user_id, resolved_realm_url',
+        'SELECT definitions, deps, error_doc, cache_scope, auth_user_id, resolved_realm_url, created_at',
         'FROM',
         MODULES_TABLE,
         'WHERE',
@@ -610,6 +630,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       cache_scope: CacheScope;
       auth_user_id: string | null;
       resolved_realm_url: string | null;
+      created_at: string | null;
     }[];
 
     if (!rows.length) {
@@ -626,6 +647,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       deps = [];
     }
     let error = parseJsonValue<ErrorEntry>(row.error_doc) ?? undefined;
+    let createdAt = row.created_at ? parseInt(row.created_at) : undefined;
     return {
       definitions,
       deps,
@@ -633,6 +655,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       cacheScope: row.cache_scope,
       authUserId: row.auth_user_id || undefined,
       resolvedRealmURL: row.resolved_realm_url || '',
+      createdAt,
     };
   }
 


### PR DESCRIPTION
## Summary

- When the prerenderer returns a transient error (timeout, browser crash, dependency briefly unavailable during concurrent indexing), the error was persisted in the `modules` table and served indefinitely on subsequent lookups. Since the underlying file hadn't changed, no invalidation was ever triggered, causing permanent `FilterRefersToNonexistentTypeError` for valid modules.
- Add a 30-second TTL for cached error entries in `CachingDefinitionLookup.loadModuleCacheEntry()`. When an error entry exceeds the TTL, it is treated as a cache miss and the prerenderer is called again. If the re-prerender succeeds, the stale error is overwritten via `ON CONFLICT`. Success entries remain cached indefinitely (invalidated only by file changes).

### Root cause

In `definition-lookup.ts`, `loadModuleCacheEntry` returns cached entries immediately regardless of whether they contain an error. Once a transient prerender failure is cached, it blocks the very mechanism (calling the prerenderer) that would fix it — making the error self-perpetuating until a deployment or manual table clear.

### Changes

- `ERROR_CACHE_TTL_MS` (30s) constant and `isExpiredErrorEntry()` method
- `readFromDatabaseCache()` now selects `created_at` from the modules table
- `loadModuleCacheEntry()` treats expired error entries as cache misses
- New test: `'re-prerenders when cached error entry expires'`

## Test plan

- [ ] New test verifies full lifecycle: cache error → serve fresh error from cache → expire via backdated `created_at` → re-prerender succeeds → healthy cache served
- [ ] Existing definition-lookup tests pass (no behavior change for success entries or fresh error entries)
- [ ] Deploy to staging and monitor for `FilterRefersToNonexistentTypeError` recurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)