### PR TITLE
Implement lint validation step (CS-10714)

### DIFF
--- a/packages/software-factory/.agents/skills/boxel-development/references/dev-qunit-testing.md
+++ b/packages/software-factory/.agents/skills/boxel-development/references/dev-qunit-testing.md
@@ -134,7 +134,7 @@ Add `data-test-*` attributes to card templates for stable test selectors:
 
 When tests fail, the orchestrator feeds test failure details back to the agent. For more detail:
 
-- **TestRun cards** live in the target realm's `Test Runs/` folder. To find all test runs, search by the TestRun card type in the target realm. Each TestRun has a `sequenceNumber` that increases with each iteration. Use `read_file` on a specific TestRun for full details.
+- **TestRun cards** live in the target realm's `Validations/` folder with a `test_` prefix (e.g., `Validations/test_issue-slug-1.json`). To find all test runs, search by the TestRun card type in the target realm. Each TestRun has a `sequenceNumber` that increases with each iteration. Use `read_file` on a specific TestRun for full details.
 
 ## Rules
 

--- a/packages/software-factory/.agents/skills/software-factory-operations/SKILL.md
+++ b/packages/software-factory/.agents/skills/software-factory-operations/SKILL.md
@@ -85,8 +85,9 @@ target-realm/
 │   └── sample-instance.json         # Card instance
 ├── Spec/
 │   └── card-name.json               # Catalog Spec card
-├── Test Runs/
-│   └── issue-slug-1.json            # TestRun card
+├── Validations/
+│   ├── test_issue-slug-1.json       # TestRun card (test results)
+│   └── lint_issue-slug-1.json       # Lint result card
 ├── Projects/
 │   └── project-name.json            # Project card
 ├── Issues/

--- a/packages/software-factory/README.md
+++ b/packages/software-factory/README.md
@@ -24,16 +24,16 @@ The orchestrator (`runIssueLoop`) is a thin scheduler that picks the next unbloc
 
 ### Target Realm Artifact Structure
 
-| Path                  | What it is                                                          |
-| --------------------- | ------------------------------------------------------------------- |
-| `Projects/`           | Project card with objective, scope, success criteria                |
-| `Issues/`             | Issue cards — bootstrap seed + implementation issues                |
-| `Knowledge Articles/` | Context articles derived from the brief                             |
-| `*.gts`               | Card definition files                                               |
-| `*.test.gts`          | Co-located QUnit test files                                         |
-| `CardName/`           | Sample card instances with realistic data                           |
-| `Spec/`               | Catalog Spec cards linking to card definitions and sample instances |
-| `Test Runs/`          | TestRun cards with structured pass/fail results                     |
+| Path                  | What it is                                                           |
+| --------------------- | -------------------------------------------------------------------- |
+| `Projects/`           | Project card with objective, scope, success criteria                 |
+| `Issues/`             | Issue cards — bootstrap seed + implementation issues                 |
+| `Knowledge Articles/` | Context articles derived from the brief                              |
+| `*.gts`               | Card definition files                                                |
+| `*.test.gts`          | Co-located QUnit test files                                          |
+| `CardName/`           | Sample card instances with realistic data                            |
+| `Spec/`               | Catalog Spec cards linking to card definitions and sample instances  |
+| `Validations/`        | Validation artifacts — TestRun cards (test results) and lint results |
 
 ## Prerequisites
 
@@ -99,7 +99,7 @@ The `--debug` flag shows LLM prompts, tool calls and their results, and `console
 | `*.test.gts`                 | Co-located QUnit test file(s)                                            |
 | `CardName/`                  | Sample card instance(s) with realistic data                              |
 | `Spec/`                      | Catalog Spec card(s) linking to the card definition and sample instances |
-| `Test Runs/`                 | TestRun card(s) with validation pipeline results (pass/fail per module)  |
+| `Validations/`               | Validation artifacts — TestRun cards and lint results (pass/fail)        |
 
 ## Architecture
 

--- a/packages/software-factory/docs/phase-1-plan.md
+++ b/packages/software-factory/docs/phase-1-plan.md
@@ -319,17 +319,17 @@ Test execution policy:
 
 - the orchestrator owns test execution — the agent writes test files via `write_file` tool calls, and the orchestrator triggers test execution as a separate phase after the agent finishes its turn
 - the Playwright browser navigates to the host's QUnit live-test page, which discovers `.test.gts` files via `_mtimes` and runs them in the browser
-- test results (pass/fail, error messages, stack traces) are saved as `TestRun` card instances in the target realm's `Validations/` folder
-- on failure, the orchestrator reads the `TestRun` card from the realm to extract detailed failure info (individual test names, error messages, stack traces) and feeds them back to the agent in the iterate prompt. The agent also has access to the `Validations/` folder via `search_realm` and `read_file` for historical test run analysis.
+- test results (pass/fail, error messages, stack traces) are saved as `TestRun` card instances in the target realm's `Test Runs/` folder
+- on failure, the orchestrator reads the `TestRun` card from the realm to extract detailed failure info (individual test names, error messages, stack traces) and feeds them back to the agent in the iterate prompt. The agent also has access to the `Test Runs/` folder via `search_realm` and `read_file` for historical test run analysis.
 - on success, the TestRun card serves as durable proof that the ticket was verified
 
 Target realm artifact structure (QUnit test files co-located with card definitions):
 
 - `<card-name>.test.gts` — the generated QUnit test source (co-located with card definitions in target realm)
-- `Validations/test_<ticket-slug>-<seq>.json` — TestRun card instance with status, results, timing (in target realm)
+- `Test Runs/<ticket-slug>-<seq>.json` — TestRun card instance with status, results, timing (in target realm)
 - `Spec/<card-name>.json` — Catalog Spec card for the top-level card (in target realm)
 
-All card instance folders use plural display names: `Projects/`, `Tickets/`, `Knowledge Articles/`, `Agent Profiles/`, `Validations/`, `Spec/`.
+All card instance folders use plural display names: `Projects/`, `Tickets/`, `Knowledge Articles/`, `Agent Profiles/`, `Test Runs/`, `Spec/`.
 
 #### QUnit Test Page Architecture (CS-10599)
 
@@ -408,7 +408,7 @@ The current behavior is described in prose, but not encoded as a decision engine
 With executable tool functions, the agent handles sequential tool calls naturally — it calls tools in order, sees results, and reacts. However, the execution loop still involves long-running operations like test execution (~10 minutes per run) that require special handling:
 
 1. Write QUnit test file co-located with card definitions in the target realm (via `write_file`)
-2. Write a `TestRun` card to the target realm `Validations/` folder (via `write_file`)
+2. Write a `TestRun` card to the target realm `Test Runs/` folder (via `write_file`)
 3. Execute tests against the target realm (via `run-realm-tests`); the Playwright browser navigates to the QUnit live-test page
 4. Parse and save test results back to the `TestRun` card in the target realm
 5. Feed results back to the agent for the next iteration

--- a/packages/software-factory/docs/phase-1-plan.md
+++ b/packages/software-factory/docs/phase-1-plan.md
@@ -319,17 +319,17 @@ Test execution policy:
 
 - the orchestrator owns test execution — the agent writes test files via `write_file` tool calls, and the orchestrator triggers test execution as a separate phase after the agent finishes its turn
 - the Playwright browser navigates to the host's QUnit live-test page, which discovers `.test.gts` files via `_mtimes` and runs them in the browser
-- test results (pass/fail, error messages, stack traces) are saved as `TestRun` card instances in the target realm's `Test Runs/` folder
-- on failure, the orchestrator reads the `TestRun` card from the realm to extract detailed failure info (individual test names, error messages, stack traces) and feeds them back to the agent in the iterate prompt. The agent also has access to the `Test Runs/` folder via `search_realm` and `read_file` for historical test run analysis.
+- test results (pass/fail, error messages, stack traces) are saved as `TestRun` card instances in the target realm's `Validations/` folder
+- on failure, the orchestrator reads the `TestRun` card from the realm to extract detailed failure info (individual test names, error messages, stack traces) and feeds them back to the agent in the iterate prompt. The agent also has access to the `Validations/` folder via `search_realm` and `read_file` for historical test run analysis.
 - on success, the TestRun card serves as durable proof that the ticket was verified
 
 Target realm artifact structure (QUnit test files co-located with card definitions):
 
 - `<card-name>.test.gts` — the generated QUnit test source (co-located with card definitions in target realm)
-- `Test Runs/<ticket-slug>-<seq>.json` — TestRun card instance with status, results, timing (in target realm)
+- `Validations/test_<ticket-slug>-<seq>.json` — TestRun card instance with status, results, timing (in target realm)
 - `Spec/<card-name>.json` — Catalog Spec card for the top-level card (in target realm)
 
-All card instance folders use plural display names: `Projects/`, `Tickets/`, `Knowledge Articles/`, `Agent Profiles/`, `Test Runs/`, `Spec/`.
+All card instance folders use plural display names: `Projects/`, `Tickets/`, `Knowledge Articles/`, `Agent Profiles/`, `Validations/`, `Spec/`.
 
 #### QUnit Test Page Architecture (CS-10599)
 
@@ -408,7 +408,7 @@ The current behavior is described in prose, but not encoded as a decision engine
 With executable tool functions, the agent handles sequential tool calls naturally — it calls tools in order, sees results, and reacts. However, the execution loop still involves long-running operations like test execution (~10 minutes per run) that require special handling:
 
 1. Write QUnit test file co-located with card definitions in the target realm (via `write_file`)
-2. Write a `TestRun` card to the target realm `Test Runs/` folder (via `write_file`)
+2. Write a `TestRun` card to the target realm `Validations/` folder (via `write_file`)
 3. Execute tests against the target realm (via `run-realm-tests`); the Playwright browser navigates to the QUnit live-test page
 4. Parse and save test results back to the `TestRun` card in the target realm
 5. Feed results back to the agent for the next iteration

--- a/packages/software-factory/docs/phase-2-plan.md
+++ b/packages/software-factory/docs/phase-2-plan.md
@@ -81,9 +81,41 @@ interface ValidationStepRunner {
 **Step-specific failure shapes** — each validation type carries its own structured data in `ValidationStepResult.details` (flattened POJOs, not cards):
 
 - **Test step**: `{ testRunId, passedCount, failedCount, failures: [{ testName, module, message, stackTrace }] }` — reads back the completed TestRun card from the realm for detailed failure data (will become cheap local filesystem reads after boxel-cli integration)
-- **Future parse/lint/evaluate/instantiate steps**: each defines its own `details` shape
+- **Lint step** (CS-10714): `{ lintResultId, filesChecked, filesWithErrors, totalViolations, violations: [{ rule, file, line, message }] }` — calls the realm's `_lint` endpoint (ESLint + Prettier + `@cardstack/boxel` rules) for each `.gts`, `.gjs`, `.ts`, `.js` file. Creates a `LintResult` card as a persistent artifact.
+- **Future parse/evaluate/instantiate steps**: each defines its own `details` shape
 
 **Adding a new validation step** = creating a new module file in `src/validators/` + replacing the `NoOpStepRunner` in `createDefaultPipeline()`.
+
+### Validation Artifacts: Naming and Storage
+
+All validation artifacts (test runs, lint results, future validation types) are stored in a shared `Validations/` directory in the target realm with type-prefixed names:
+
+- Test runs: `Validations/test_{issue-slug}-{seq}.json` (e.g., `Validations/test_sticky-note-define-core-1.json`)
+- Lint results: `Validations/lint_{issue-slug}-{seq}.json` (e.g., `Validations/lint_sticky-note-define-core-1.json`)
+
+Each artifact is a card instance (`TestRun` or `LintResult`) with `linksTo` relationships to the `Issue` and `Project` being validated.
+
+### Validation Context Flow
+
+`Validator.formatForContext()` is the **sole mechanism** for getting validation results into the LLM context:
+
+1. After each agent turn, `validator.validate(targetRealmUrl)` produces `ValidationResults` (used by the loop for pass/fail control flow)
+2. `validator.formatForContext(results)` produces combined markdown from all step runners
+3. This pre-formatted string is stored as `validationContext` on `AgentContext` and rendered in the `ticket-iterate.md` template
+4. The LLM never sees the raw `ValidationResults` struct — only the formatted markdown
+
+The Phase 1 `testResults` field on `AgentContext` is deprecated. All validation flows through `validationResults` (for the loop) and `validationContext` (for the LLM prompt).
+
+### Lint Step Details (CS-10714)
+
+The lint validation step (`src/validators/lint-step.ts`) uses the realm's existing `_lint` endpoint — the same one the Monaco editor uses in code mode. For each lintable file discovered in the realm:
+
+1. Read the file source via `readFile()` 
+2. POST the source to `{realmUrl}_lint` with `X-Filename` header
+3. ESLint runs with `@cardstack/boxel` rules (missing invokables, missing card-api imports, no-duplicate-imports, etc.) and Prettier formatting
+4. Collect `messages` from the response where `severity === 2` (errors)
+
+The `LintResult` card definition (`realm/lint-result.gts`) mirrors the `TestRun` card structure with fitted/embedded/isolated templates, a running state, and links to Issue/Project. Card CRUD is in `src/lint-result-cards.ts`.
 
 ### Handling Failures
 

--- a/packages/software-factory/docs/phase-2-plan.md
+++ b/packages/software-factory/docs/phase-2-plan.md
@@ -110,7 +110,7 @@ The Phase 1 `testResults` field on `AgentContext` is deprecated. All validation 
 
 The lint validation step (`src/validators/lint-step.ts`) uses the realm's existing `_lint` endpoint — the same one the Monaco editor uses in code mode. For each lintable file discovered in the realm:
 
-1. Read the file source via `readFile()` 
+1. Read the file source via `readFile()`
 2. POST the source to `{realmUrl}_lint` with `X-Filename` header
 3. ESLint runs with `@cardstack/boxel` rules (missing invokables, missing card-api imports, no-duplicate-imports, etc.) and Prettier formatting
 4. Collect `messages` from the response where `severity === 2` (errors)

--- a/packages/software-factory/docs/testing-strategy.md
+++ b/packages/software-factory/docs/testing-strategy.md
@@ -51,7 +51,7 @@ Flow per issue:
 
 1. agent implements the card or feature in the target realm
 2. agent generates QUnit test files co-located with card definitions (`.test.gts`)
-3. `executeTestRunFromRealm` creates a TestRun card in the target realm (`Test Runs/<slug>-<seq>.json`) with `status: running` and pre-populated `moduleResults` containing pending entries
+3. `executeTestRunFromRealm` creates a TestRun card in the target realm (`Validations/test_<slug>-<seq>.json`) with `status: running` and pre-populated `moduleResults` containing pending entries
 4. Playwright browser navigates to the host's QUnit live-test page which discovers and runs `.test.gts` files via `_mtimes`
 5. card instances created during test execution live in browser memory only
 6. test results are parsed from the QUnit test output, grouped by module into `TestModuleResult` entries, and written back to the TestRun card's `moduleResults` field. Each TestModuleResult has a `moduleRef` (CodeRefField with `module` = test module URL, `name` = "default") and its own `passedCount`/`failedCount` computeds. TestRun's `passedCount`/`failedCount` are rolled up across all TestModuleResults.
@@ -299,7 +299,7 @@ Suggested acceptance cases:
    - one implementation artifact is created (card definition + card instance)
    - one Catalog Spec card is created in the `Spec/` folder
    - one QUnit test file is created co-located with the card definition (`.test.gts`)
-   - one TestRun card is created in the `Test Runs/` folder with verification results
+   - one TestRun card is created in the `Validations/` folder with verification results
 
 3. Resume after partial progress
    - rerun after partial state

--- a/packages/software-factory/prompts/ticket-iterate.md
+++ b/packages/software-factory/prompts/ticket-iterate.md
@@ -24,32 +24,15 @@ In the previous iteration, you made the following tool calls:
 
 {{/each}}
 
-# Test Results
+# Validation Results
 
-The orchestrator ran tests after your previous attempt. They failed.
+The orchestrator ran validation after your previous attempt. There were failures.
 
-Status: {{testResults.status}}
-Passed: {{testResults.passedCount}}
-Failed: {{testResults.failedCount}}
-Duration: {{testResults.durationMs}}ms
-
-{{#each testResults.failures}}
-
-## Failure: {{testName}}
-
-```
-{{error}}
-```
-
-{{#if stackTrace}}
-Stack trace:
-
-```
-{{stackTrace}}
-```
-
+{{#if validationContext}}
+{{validationContext}}
+{{else}}
+All validation steps passed.
 {{/if}}
-{{/each}}
 
 {{#if toolResults}}
 
@@ -68,11 +51,12 @@ Stack trace:
 
 # Instructions
 
-Fix the failing tests. You have the same tools available. You can:
+Fix the validation failures shown above. You have the same tools available. You can:
 
 - Use read_file to inspect the current state of your implementation
 - Use write_file to update implementation or test files
 - Use search_realm to check what cards exist
+- If a lint violation is in your code, fix the code to pass lint
 - If the test expectation is wrong, fix the test
 - If the implementation is wrong, fix the implementation
 

--- a/packages/software-factory/realm/lint-result.gts
+++ b/packages/software-factory/realm/lint-result.gts
@@ -1,0 +1,590 @@
+import {
+  CardDef,
+  FieldDef,
+  Component,
+  field,
+  contains,
+  containsMany,
+  linksTo,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+import NumberField from 'https://cardstack.com/base/number';
+import DateTimeField from 'https://cardstack.com/base/datetime';
+import enumField from 'https://cardstack.com/base/enum';
+import { Project, Issue } from './darkfactory';
+
+export const LintResultStatusField = enumField(StringField, {
+  options: [
+    { value: 'running', label: 'Running' },
+    { value: 'passed', label: 'Passed' },
+    { value: 'failed', label: 'Failed' },
+    { value: 'error', label: 'Error' },
+  ],
+});
+
+export const LintViolationSeverityField = enumField(StringField, {
+  options: [
+    { value: 'error', label: 'Error' },
+    { value: 'warning', label: 'Warning' },
+  ],
+});
+
+export class LintViolation extends FieldDef {
+  static displayName = 'Lint Violation';
+
+  @field rule = contains(StringField);
+  @field file = contains(StringField);
+  @field line = contains(NumberField);
+  @field column = contains(NumberField);
+  @field message = contains(StringField);
+  @field severity = contains(LintViolationSeverityField);
+
+  get severityIcon() {
+    switch (this.severity) {
+      case 'error':
+        return '\u2717';
+      case 'warning':
+        return '\u26A0';
+      default:
+        return '?';
+    }
+  }
+
+  static embedded = class Embedded extends Component<typeof LintViolation> {
+    <template>
+      <div class='violation-entry'>
+        <span
+          class='severity severity-{{@model.severity}}'
+        >{{@model.severityIcon}}</span>
+        <span class='location'>{{@model.file}}:{{@model.line}}</span>
+        <span class='message'>{{@model.message}}</span>
+        {{#if @model.rule}}
+          <span class='rule'>[{{@model.rule}}]</span>
+        {{/if}}
+      </div>
+      <style scoped>
+        .violation-entry {
+          display: flex;
+          align-items: baseline;
+          gap: 0.5rem;
+          padding: 0.25rem 0;
+          font-size: 0.85rem;
+        }
+        .severity {
+          font-weight: bold;
+          width: 1.25rem;
+          text-align: center;
+          flex-shrink: 0;
+        }
+        .severity-error {
+          color: var(--boxel-red, #dc2626);
+        }
+        .severity-warning {
+          color: var(--boxel-orange, #ea580c);
+        }
+        .location {
+          color: var(--muted-foreground);
+          font-family: monospace;
+          font-size: 0.8rem;
+          flex-shrink: 0;
+        }
+        .message {
+          flex: 1;
+        }
+        .rule {
+          color: var(--boxel-400, #9ca3af);
+          font-size: 0.75rem;
+          flex-shrink: 0;
+        }
+      </style>
+    </template>
+  };
+}
+
+export class LintFileResult extends FieldDef {
+  static displayName = 'Lint File Result';
+
+  @field file = contains(StringField);
+  @field violations = containsMany(LintViolation);
+
+  @field errorCount = contains(NumberField, {
+    computeVia: function (this: LintFileResult) {
+      return (this.violations ?? []).filter((v) => v.severity === 'error')
+        .length;
+    },
+  });
+
+  @field warningCount = contains(NumberField, {
+    computeVia: function (this: LintFileResult) {
+      return (this.violations ?? []).filter((v) => v.severity === 'warning')
+        .length;
+    },
+  });
+
+  get passed() {
+    return (this.errorCount ?? 0) === 0;
+  }
+
+  get totalCount() {
+    return this.violations?.length ?? 0;
+  }
+
+  static embedded = class Embedded extends Component<typeof LintFileResult> {
+    <template>
+      <div class='file-result'>
+        <div class='file-header'>
+          <span class='file-name'>{{@model.file}}</span>
+          {{#if @model.passed}}
+            <span class='file-status passed'>clean</span>
+          {{else}}
+            <span class='file-status failed'>
+              {{@model.errorCount}}
+              error(s)
+              {{#if @model.warningCount}}
+                ,
+                {{@model.warningCount}}
+                warning(s)
+              {{/if}}
+            </span>
+          {{/if}}
+        </div>
+        {{#if @model.totalCount}}
+          <div class='file-violations'>
+            <@fields.violations />
+          </div>
+        {{/if}}
+      </div>
+      <style scoped>
+        .file-result {
+          margin-bottom: 0.75rem;
+        }
+        .file-header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          padding: 0.25rem 0;
+          border-bottom: 1px solid var(--boxel-200, #e5e7eb);
+          margin-bottom: 0.25rem;
+        }
+        .file-name {
+          font-weight: 600;
+          font-size: 0.85rem;
+          font-family: monospace;
+        }
+        .file-status {
+          font-size: 0.8rem;
+        }
+        .file-status.passed {
+          color: var(--boxel-green, #16a34a);
+        }
+        .file-status.failed {
+          color: var(--boxel-red, #dc2626);
+        }
+        .file-violations {
+          padding-left: 0.5rem;
+        }
+      </style>
+    </template>
+  };
+}
+
+export class LintResult extends CardDef {
+  static displayName = 'Lint Result';
+
+  @field sequenceNumber = contains(NumberField);
+  @field runAt = contains(DateTimeField);
+  @field completedAt = contains(DateTimeField);
+  @field project = linksTo(() => Project);
+  @field issue = linksTo(() => Issue);
+  @field status = contains(LintResultStatusField);
+  @field durationMs = contains(NumberField);
+  @field fileResults = containsMany(LintFileResult);
+  @field errorMessage = contains(StringField);
+
+  @field totalErrors = contains(NumberField, {
+    computeVia: function (this: LintResult) {
+      return (this.fileResults ?? []).reduce(
+        (sum, fr) => sum + (fr.errorCount ?? 0),
+        0,
+      );
+    },
+  });
+
+  @field totalWarnings = contains(NumberField, {
+    computeVia: function (this: LintResult) {
+      return (this.fileResults ?? []).reduce(
+        (sum, fr) => sum + (fr.warningCount ?? 0),
+        0,
+      );
+    },
+  });
+
+  @field filesChecked = contains(NumberField, {
+    computeVia: function (this: LintResult) {
+      return this.fileResults?.length ?? 0;
+    },
+  });
+
+  @field title = contains(StringField, {
+    computeVia: function (this: LintResult) {
+      let seq = this.sequenceNumber ?? '?';
+      let status = this.status ?? 'unknown';
+      return `LintResult #${seq} \u2014 ${status}`;
+    },
+  });
+
+  get filesWithErrors() {
+    return (this.fileResults ?? []).filter((fr) => !fr.passed).length;
+  }
+
+  get filesClean() {
+    return (this.filesChecked ?? 0) - this.filesWithErrors;
+  }
+
+  static fitted = class Fitted extends Component<typeof LintResult> {
+    get displayStatus() {
+      if (
+        (this.args.model.filesChecked ?? 0) === 0 &&
+        this.args.model.status === 'passed'
+      ) {
+        return 'empty';
+      }
+      return this.args.model.status;
+    }
+
+    <template>
+      <div class='lint-result compact'>
+        <div class='header'>
+          <strong>#{{@model.sequenceNumber}}</strong>
+          <span
+            class='status status-{{this.displayStatus}}'
+          >{{this.displayStatus}}</span>
+        </div>
+        {{#if @model.issue}}
+          <div class='issue-name'>{{@model.issue.summary}}</div>
+        {{/if}}
+        <div class='counts'>
+          {{@model.filesClean}}/{{@model.filesChecked}}
+          files clean
+          {{#if @model.totalErrors}}
+            <span class='error-label'>
+              ({{@model.totalErrors}}
+              error(s))
+            </span>
+          {{/if}}
+          {{#if @model.durationMs}}
+            <span class='duration'>{{@model.durationMs}}ms</span>
+          {{/if}}
+        </div>
+      </div>
+      <style scoped>
+        .lint-result {
+          display: grid;
+          gap: 0.25rem;
+        }
+        .compact {
+          padding: 0.75rem;
+          border: 1px solid var(--border);
+          border-radius: 0.5rem;
+          background: var(--card);
+        }
+        .header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        }
+        .status {
+          font-size: 0.75rem;
+          text-transform: uppercase;
+          font-weight: 600;
+          padding: 0.125rem 0.5rem;
+          border-radius: 0.25rem;
+        }
+        .status-passed {
+          color: var(--boxel-green, #16a34a);
+          background: #f0fdf4;
+        }
+        .status-failed {
+          color: var(--boxel-red, #dc2626);
+          background: #fef2f2;
+        }
+        .status-error {
+          color: var(--boxel-orange, #ea580c);
+          background: #fff7ed;
+        }
+        .status-running {
+          color: var(--boxel-blue, #2563eb);
+          background: #eff6ff;
+        }
+        .status-empty {
+          color: var(--boxel-400, #9ca3af);
+          background: #f9fafb;
+        }
+        .issue-name {
+          font-size: 0.8rem;
+          color: var(--muted-foreground);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+        .counts {
+          font-size: 0.85rem;
+          color: var(--muted-foreground);
+        }
+        .error-label {
+          color: var(--boxel-red, #dc2626);
+        }
+        .duration {
+          margin-left: 0.5rem;
+          font-size: 0.75rem;
+        }
+      </style>
+    </template>
+  };
+
+  static embedded = this.fitted;
+
+  static isolated = class Isolated extends Component<typeof LintResult> {
+    get displayStatus() {
+      if (
+        (this.args.model.filesChecked ?? 0) === 0 &&
+        this.args.model.status === 'passed'
+      ) {
+        return 'empty';
+      }
+      return this.args.model.status;
+    }
+
+    <template>
+      <article class='surface'>
+        <header>
+          <div class='header-row'>
+            <strong>LintResult #{{@model.sequenceNumber}}</strong>
+            <span
+              class='status status-{{this.displayStatus}}'
+            >{{this.displayStatus}}</span>
+          </div>
+          <div class='summary'>
+            {{@model.filesClean}}/{{@model.filesChecked}}
+            files clean
+            {{#if @model.totalErrors}}
+              ,
+              {{@model.totalErrors}}
+              error(s)
+            {{/if}}
+            {{#if @model.totalWarnings}}
+              ,
+              {{@model.totalWarnings}}
+              warning(s)
+            {{/if}}
+            {{#if @model.durationMs}}
+              in
+              {{@model.durationMs}}ms
+            {{/if}}
+          </div>
+        </header>
+
+        {{#if @model.project}}
+          <section>
+            <h2>Project</h2>
+            <div class='linked-card'>
+              <@fields.project @format='embedded' />
+            </div>
+          </section>
+        {{/if}}
+
+        {{#if @model.issue}}
+          <section>
+            <h2>Issue</h2>
+            <div class='linked-card'>
+              <@fields.issue @format='embedded' />
+            </div>
+          </section>
+        {{/if}}
+
+        {{#if @model.errorMessage}}
+          <section>
+            <h2>Error</h2>
+            <p class='error-message'>{{@model.errorMessage}}</p>
+          </section>
+        {{/if}}
+
+        {{#if @model.fileResults.length}}
+          <section>
+            <h2>File Results</h2>
+            {{#each @model.fileResults as |fileResult|}}
+              <div
+                class='file-group
+                  {{unless fileResult.passed "file-has-errors"}}'
+              >
+                <div class='file-group-header'>
+                  <span class='file-group-name'>{{fileResult.file}}</span>
+                  {{#if fileResult.passed}}
+                    <span class='file-group-status has-passes'>clean</span>
+                  {{else}}
+                    <span class='file-group-status has-errors'>
+                      {{fileResult.errorCount}}
+                      error(s)
+                      {{#if fileResult.warningCount}}
+                        ,
+                        {{fileResult.warningCount}}
+                        warning(s)
+                      {{/if}}
+                    </span>
+                  {{/if}}
+                </div>
+                {{#if fileResult.totalCount}}
+                  <div class='file-group-violations'>
+                    {{#each fileResult.violations as |violation|}}
+                      <div class='violation-item'>
+                        <div class='violation-item-row'>
+                          <span
+                            class='violation-severity severity-{{violation.severity}}'
+                            role='img'
+                            aria-label='{{violation.severity}}'
+                          >{{violation.severityIcon}}</span>
+                          <span
+                            class='violation-location'
+                          >{{violation.line}}:{{violation.column}}</span>
+                          <span
+                            class='violation-message'
+                          >{{violation.message}}</span>
+                          {{#if violation.rule}}
+                            <span
+                              class='violation-rule'
+                            >[{{violation.rule}}]</span>
+                          {{/if}}
+                        </div>
+                      </div>
+                    {{/each}}
+                  </div>
+                {{/if}}
+              </div>
+            {{/each}}
+          </section>
+        {{/if}}
+      </article>
+      <style scoped>
+        .surface {
+          padding: 1.5rem;
+          display: grid;
+          gap: 1rem;
+        }
+        .linked-card {
+          margin-bottom: 0.5rem;
+        }
+        .header-row {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        }
+        .status {
+          font-size: 0.75rem;
+          text-transform: uppercase;
+          font-weight: 600;
+          padding: 0.125rem 0.5rem;
+          border-radius: 0.25rem;
+        }
+        .status-passed {
+          color: var(--boxel-green, #16a34a);
+          background: #f0fdf4;
+        }
+        .status-failed {
+          color: var(--boxel-red, #dc2626);
+          background: #fef2f2;
+        }
+        .status-error {
+          color: var(--boxel-orange, #ea580c);
+          background: #fff7ed;
+        }
+        .status-running {
+          color: var(--boxel-blue, #2563eb);
+          background: #eff6ff;
+        }
+        .status-empty {
+          color: var(--boxel-400, #9ca3af);
+          background: #f9fafb;
+        }
+        .summary {
+          font-size: 0.9rem;
+          color: var(--muted-foreground);
+        }
+        .error-message {
+          color: var(--boxel-red, #dc2626);
+          font-family: monospace;
+          font-size: 0.85rem;
+          white-space: pre-wrap;
+        }
+        .file-group {
+          border: 1px solid var(--boxel-200, #e5e7eb);
+          border-radius: 0.5rem;
+          padding: 0.75rem;
+          margin-bottom: 0.75rem;
+        }
+        .file-has-errors {
+          border-color: var(--boxel-red, #dc2626);
+        }
+        .file-group-header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          padding-bottom: 0.5rem;
+          border-bottom: 1px solid var(--boxel-200, #e5e7eb);
+          margin-bottom: 0.5rem;
+        }
+        .file-group-name {
+          font-weight: 600;
+          font-size: 0.9rem;
+          font-family: monospace;
+        }
+        .file-group-status {
+          font-size: 0.8rem;
+          color: var(--boxel-400, #9ca3af);
+        }
+        .file-group-status.has-passes {
+          color: var(--boxel-green, #16a34a);
+        }
+        .file-group-status.has-errors {
+          color: var(--boxel-red, #dc2626);
+        }
+        .file-group-violations {
+          display: grid;
+          gap: 0.25rem;
+        }
+        .violation-item-row {
+          display: flex;
+          align-items: baseline;
+          gap: 0.5rem;
+          padding: 0.25rem 0;
+          font-size: 0.85rem;
+        }
+        .violation-severity {
+          font-weight: bold;
+          width: 1.25rem;
+          text-align: center;
+          flex-shrink: 0;
+        }
+        .violation-severity.severity-error {
+          color: var(--boxel-red, #dc2626);
+        }
+        .violation-severity.severity-warning {
+          color: var(--boxel-orange, #ea580c);
+        }
+        .violation-location {
+          color: var(--muted-foreground);
+          font-family: monospace;
+          font-size: 0.8rem;
+          flex-shrink: 0;
+        }
+        .violation-message {
+          flex: 1;
+        }
+        .violation-rule {
+          color: var(--boxel-400, #9ca3af);
+          font-size: 0.75rem;
+          flex-shrink: 0;
+        }
+      </style>
+    </template>
+  };
+}

--- a/packages/software-factory/scripts/smoke-tests/issue-loop-smoke.ts
+++ b/packages/software-factory/scripts/smoke-tests/issue-loop-smoke.ts
@@ -150,6 +150,16 @@ class MockValidator implements Validator {
     }
     return this.results[this.callIndex++];
   }
+
+  formatForContext(results: ValidationResults): string {
+    if (results.passed) {
+      return 'All validation steps passed.';
+    }
+    return results.steps
+      .filter((s) => !s.passed)
+      .map((s) => `${s.step}: ${s.errors.map((e) => e.message).join(', ')}`)
+      .join('\n');
+  }
 }
 
 class StubContextBuilder implements IssueContextBuilderLike {

--- a/packages/software-factory/scripts/smoke-tests/smoke-test-realm.ts
+++ b/packages/software-factory/scripts/smoke-tests/smoke-test-realm.ts
@@ -318,12 +318,18 @@ async function main() {
 
   log.info('\n--- Running ValidationPipeline.validate() ---\n');
 
+  let lintResultsModuleUrl = new URL(
+    'software-factory/lint-result',
+    realmServerUrl,
+  ).href;
+
   let pipeline = createDefaultPipeline({
     authorization,
     fetch: fetchImpl,
     realmServerUrl,
     hostAppUrl: realmServerUrl,
     testResultsModuleUrl,
+    lintResultsModuleUrl,
   });
 
   let validationResults = await pipeline.validate(targetRealmUrl);

--- a/packages/software-factory/src/factory-agent-tool-use.ts
+++ b/packages/software-factory/src/factory-agent-tool-use.ts
@@ -287,9 +287,9 @@ export class ToolUseFactoryAgent implements LoopAgent {
         context,
         loader: this.promptLoader,
       });
-    } else if (context.testResults || context.validationResults) {
-      // Phase 1 testResults or Phase 2 validationResults — use iterate prompt
-      // so the agent receives structured failure context for self-correction
+    } else if (context.validationContext) {
+      // Validation failures from prior iteration — use iterate prompt
+      // so the agent receives formatted failure context for self-correction
       userPrompt = assembleIteratePrompt({
         context,
         previousActions: [],

--- a/packages/software-factory/src/factory-agent-types.ts
+++ b/packages/software-factory/src/factory-agent-types.ts
@@ -103,6 +103,7 @@ export interface TestFailure {
   stackTrace?: string;
 }
 
+/** @deprecated Use ValidationResults from the validation pipeline instead. */
 export interface TestResult {
   status: 'passed' | 'failed' | 'error';
   passedCount: number;
@@ -186,6 +187,7 @@ export interface AgentContext {
   skills: ResolvedSkill[];
   /** @deprecated Tools are now provided separately as FactoryTool[] to agent.run(). */
   tools?: ToolManifest[];
+  /** @deprecated Use validationResults/validationContext instead. */
   testResults?: TestResult;
   /** @deprecated Tool results are now returned inline during the agent's turn. */
   toolResults?: ToolResult[];
@@ -194,8 +196,10 @@ export interface AgentContext {
   /** @deprecated Iteration tracking is now owned by the orchestrator. */
   iteration?: number;
   targetRealmUrl: string;
-  /** Validation results from the prior inner-loop iteration. */
+  /** Validation results from the prior inner-loop iteration (used for pass/fail checks). */
   validationResults?: ValidationResults;
+  /** Pre-formatted validation context from Validator.formatForContext() — the sole mechanism for validation reaching the LLM. */
+  validationContext?: string;
   /** Brief URL for bootstrap issues. */
   briefUrl?: string;
 }

--- a/packages/software-factory/src/factory-context-builder.ts
+++ b/packages/software-factory/src/factory-context-builder.ts
@@ -75,7 +75,7 @@ export class ContextBuilder {
     issue: IssueData;
     knowledge: KnowledgeArticleData[];
     targetRealmUrl: string;
-    /** Test results from the previous iteration, if any. */
+    /** @deprecated Use validationResults/validationContext via buildForIssue() instead. */
     testResults?: TestResult;
   }): Promise<AgentContext> {
     let { project, issue, knowledge, targetRealmUrl } = params;
@@ -101,7 +101,7 @@ export class ContextBuilder {
       targetRealmUrl,
     };
 
-    // Include test results when iterating after a failed test run
+    // @deprecated — Phase 1 test results. Use buildForIssue() with validationContext instead.
     if (params.testResults) {
       context.testResults = params.testResults;
     }
@@ -117,13 +117,15 @@ export class ContextBuilder {
    * - project from issue.project
    * - knowledge from issue.relatedKnowledge
    *
-   * Accepts optional validationResults from the prior inner-loop iteration
-   * so the agent can self-correct on failures.
+   * Accepts optional validationResults and pre-formatted validationContext
+   * from the prior inner-loop iteration so the agent can self-correct on failures.
    */
   async buildForIssue(params: {
     issue: IssueData;
     targetRealmUrl: string;
     validationResults?: ValidationResults;
+    /** Pre-formatted validation context string from Validator.formatForContext(). */
+    validationContext?: string;
     briefUrl?: string;
   }): Promise<AgentContext> {
     if (!this.issueLoader) {
@@ -174,6 +176,10 @@ export class ContextBuilder {
 
     if (params.validationResults) {
       context.validationResults = params.validationResults;
+    }
+
+    if (params.validationContext) {
+      context.validationContext = params.validationContext;
     }
 
     if (params.briefUrl) {

--- a/packages/software-factory/src/factory-issue-loop-wiring.ts
+++ b/packages/software-factory/src/factory-issue-loop-wiring.ts
@@ -152,6 +152,10 @@ export async function runFactoryIssueLoop(
     'software-factory/test-results',
     realmServerUrl,
   ).href;
+  let lintResultsModuleUrl = new URL(
+    'software-factory/lint-result',
+    realmServerUrl,
+  ).href;
   let hostAppUrl = config.hostAppUrl ?? realmServerUrl;
   let toolBuilderConfig: ToolBuilderConfig = {
     targetRealmUrl,
@@ -190,6 +194,7 @@ export async function runFactoryIssueLoop(
       fetch: fetchImpl,
       hostAppUrl,
       testResultsModuleUrl,
+      lintResultsModuleUrl,
       issueId,
       fetchFilenames: (realmUrl: string) =>
         fetchRealmFilenames(realmUrl, fetchOptions),

--- a/packages/software-factory/src/factory-prompt-loader.ts
+++ b/packages/software-factory/src/factory-prompt-loader.ts
@@ -6,7 +6,6 @@ import type {
   AgentContext,
   ChatMessage,
   ResolvedSkill,
-  TestFailure,
   ToolManifest,
   ToolResult,
 } from './factory-agent';
@@ -458,14 +457,6 @@ export function assembleIteratePrompt(
     realm: a.realm ?? '(none)',
   }));
 
-  let testFailures = (context.testResults?.failures ?? []).map(
-    (f: TestFailure) => ({
-      testName: f.testName,
-      error: f.error,
-      stackTrace: f.stackTrace,
-    }),
-  );
-
   let toolResultsData = buildToolResultsData(context);
 
   return loader.load('ticket-iterate', {
@@ -473,16 +464,7 @@ export function assembleIteratePrompt(
     issue: context.issue,
     iteration,
     previousActions: previousActionsData,
-    testResults: context.testResults
-      ? {
-          status: context.testResults.status,
-          passedCount: context.testResults.passedCount,
-          failedCount: context.testResults.failedCount,
-          skippedCount: context.testResults.skippedCount,
-          durationMs: context.testResults.durationMs,
-          failures: testFailures,
-        }
-      : undefined,
+    validationContext: context.validationContext,
     toolResults: toolResultsData.length > 0 ? toolResultsData : undefined,
   });
 }

--- a/packages/software-factory/src/issue-loop.ts
+++ b/packages/software-factory/src/issue-loop.ts
@@ -40,8 +40,8 @@ let log = logger('issue-loop');
  */
 export interface Validator {
   validate(targetRealmUrl: string): Promise<ValidationResults>;
-  /** Format validation results for LLM context or issue descriptions. */
-  formatForContext?(results: ValidationResults): string;
+  /** Format validation results for LLM context and issue descriptions. */
+  formatForContext(results: ValidationResults): string;
 }
 
 /**
@@ -51,6 +51,10 @@ export interface Validator {
 export class NoOpValidator implements Validator {
   async validate(): Promise<ValidationResults> {
     return { passed: true, steps: [] };
+  }
+
+  formatForContext(_results: ValidationResults): string {
+    return 'All validation steps passed.';
   }
 }
 
@@ -78,6 +82,8 @@ export interface IssueContextBuilderLike {
     issue: IssueData;
     targetRealmUrl: string;
     validationResults?: ValidationResults;
+    /** Pre-formatted validation context from Validator.formatForContext(). */
+    validationContext?: string;
     briefUrl?: string;
   }): Promise<AgentContext>;
 }
@@ -174,20 +180,7 @@ function buildMaxIterationBlockedComment(
     '',
   ];
 
-  if (validator.formatForContext) {
-    lines.push(validator.formatForContext(validationResults));
-  } else {
-    // Fallback: format from the raw results
-    for (let step of validationResults.steps) {
-      if (!step.passed) {
-        lines.push(`**${step.step}**: FAILED`);
-        for (let error of step.errors) {
-          lines.push(`- ${error.message}`);
-        }
-        lines.push('');
-      }
-    }
-  }
+  lines.push(validator.formatForContext(validationResults));
 
   return lines.join('\n');
 }
@@ -281,6 +274,7 @@ export async function runIssueLoop(
 
     let allToolCalls: ToolCallEntry[] = [];
     let validationResults: ValidationResults | undefined;
+    let validationContext: string | undefined;
     let exitReason: IssueIterationResult['exitReason'] = 'max_iterations';
     let innerIterations = 0;
 
@@ -291,11 +285,12 @@ export async function runIssueLoop(
         `  Inner iteration ${iteration}/${maxIterationsPerIssue} for issue ${issueSummaryLabel(issue)}`,
       );
 
-      // Build context — includes validation results from prior iteration
+      // Build context — includes pre-formatted validation context from prior iteration
       let context = await contextBuilder.buildForIssue({
         issue,
         targetRealmUrl,
         validationResults,
+        validationContext,
         briefUrl,
       });
 
@@ -307,6 +302,10 @@ export async function runIssueLoop(
 
       // Validation — runs after every agent turn
       validationResults = await validator.validate(targetRealmUrl);
+      validationContext =
+        validationResults && !validationResults.passed
+          ? validator.formatForContext(validationResults)
+          : undefined;
       log.info(`  Validation: ${formatValidation(validationResults)}`);
 
       // The loop owns issue status transitions. The agent signals

--- a/packages/software-factory/src/lint-result-cards.ts
+++ b/packages/software-factory/src/lint-result-cards.ts
@@ -1,0 +1,184 @@
+import type { LooseSingleCardDocument } from '@cardstack/runtime-common';
+
+import { readFile, writeFile } from './realm-operations';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface LintViolationData {
+  rule: string | null;
+  file: string;
+  line: number;
+  column: number;
+  message: string;
+  severity: 'error' | 'warning';
+}
+
+export interface LintFileResultData {
+  file: string;
+  violations: LintViolationData[];
+}
+
+export interface LintResultAttributes {
+  status: 'running' | 'passed' | 'failed' | 'error';
+  durationMs?: number;
+  fileResults?: LintFileResultData[];
+  errorMessage?: string;
+}
+
+export interface LintResultRealmOptions {
+  targetRealmUrl: string;
+  authorization?: string;
+  fetch?: typeof globalThis.fetch;
+}
+
+export interface CreateLintResultOptions {
+  sequenceNumber?: number;
+  issueURL?: string;
+  projectCardUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Card lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a `LintResult` card with `status: running`.
+ * Returns the card path as the handle.
+ */
+export async function createLintResult(
+  slug: string,
+  lintResultsModuleUrl: string,
+  options: LintResultRealmOptions & CreateLintResultOptions,
+): Promise<{ lintResultId: string; created: boolean; error?: string }> {
+  let seq = options.sequenceNumber ?? 1;
+  let lintResultId = `Validations/lint_${slug}-${seq}`;
+
+  let document = buildLintResultCardDocument(lintResultsModuleUrl, {
+    sequenceNumber: seq,
+    issueURL: options.issueURL,
+    projectCardUrl: options.projectCardUrl,
+  });
+
+  let result = await writeFile(
+    options.targetRealmUrl,
+    `${lintResultId}.json`,
+    JSON.stringify(document, null, 2),
+    { authorization: options.authorization, fetch: options.fetch },
+  );
+
+  if (!result.ok) {
+    return { lintResultId, created: false, error: result.error };
+  }
+
+  return { lintResultId, created: true };
+}
+
+/**
+ * Update an existing `LintResult` card with lint results and final status.
+ */
+export async function completeLintResult(
+  lintResultId: string,
+  attrs: LintResultAttributes,
+  options: LintResultRealmOptions & { projectCardUrl?: string },
+): Promise<{ updated: boolean; error?: string }> {
+  let fetchOptions = {
+    authorization: options.authorization,
+    fetch: options.fetch,
+  };
+
+  let readResult = await readFile(
+    options.targetRealmUrl,
+    lintResultId,
+    fetchOptions,
+  );
+
+  if (!readResult.ok || !readResult.document) {
+    return {
+      updated: false,
+      error: `Failed to read LintResult: ${readResult.error}`,
+    };
+  }
+
+  let completionAttrs: Record<string, unknown> = {
+    status: attrs.status,
+    completedAt: new Date().toISOString(),
+    durationMs: attrs.durationMs,
+    fileResults: attrs.fileResults,
+  };
+  if (attrs.errorMessage) {
+    completionAttrs.errorMessage = attrs.errorMessage;
+  }
+
+  readResult.document.data.attributes = {
+    ...readResult.document.data.attributes,
+    ...completionAttrs,
+  };
+
+  if (options.projectCardUrl) {
+    let existingRelationships =
+      (readResult.document.data as Record<string, unknown>).relationships ?? {};
+    (readResult.document.data as Record<string, unknown>).relationships = {
+      ...(existingRelationships as Record<string, unknown>),
+      project: { links: { self: options.projectCardUrl } },
+    };
+  }
+
+  let writeResult = await writeFile(
+    options.targetRealmUrl,
+    `${lintResultId}.json`,
+    JSON.stringify(readResult.document, null, 2),
+    fetchOptions,
+  );
+
+  if (!writeResult.ok) {
+    return {
+      updated: false,
+      error: `Failed to update LintResult: ${writeResult.error}`,
+    };
+  }
+
+  return { updated: true };
+}
+
+/**
+ * Build the initial card document for a LintResult with `status: running`.
+ */
+export function buildLintResultCardDocument(
+  lintResultsModuleUrl: string,
+  options?: CreateLintResultOptions,
+): LooseSingleCardDocument {
+  let attributes: Record<string, unknown> = {
+    sequenceNumber: options?.sequenceNumber ?? 1,
+    runAt: new Date().toISOString(),
+    status: 'running',
+  };
+
+  let relationships:
+    | Record<string, { links: { self: string | null } }>
+    | undefined;
+  if (options?.projectCardUrl || options?.issueURL) {
+    relationships = {};
+    if (options?.projectCardUrl) {
+      relationships.project = { links: { self: options.projectCardUrl } };
+    }
+    if (options?.issueURL) {
+      relationships.issue = { links: { self: options.issueURL } };
+    }
+  }
+
+  return {
+    data: {
+      type: 'card',
+      attributes,
+      ...(relationships ? { relationships } : {}),
+      meta: {
+        adoptsFrom: {
+          module: lintResultsModuleUrl,
+          name: 'LintResult',
+        },
+      },
+    },
+  } as LooseSingleCardDocument;
+}

--- a/packages/software-factory/src/realm-operations.ts
+++ b/packages/software-factory/src/realm-operations.ts
@@ -919,6 +919,62 @@ export async function lintFile(
 }
 
 // ---------------------------------------------------------------------------
+// Validation Artifact Sequence Numbers
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the next sequence number for a validation artifact by searching
+ * existing cards of the given type in the realm. Each slug (issue) gets its
+ * own independent sequence starting from 1.
+ *
+ * Shared by TestValidationStep and LintValidationStep so that sequence
+ * numbering is derived from realm state (survives process restarts).
+ */
+export async function getNextValidationSequenceNumber(
+  slug: string,
+  prefix: string,
+  moduleUrl: string,
+  cardName: string,
+  options: RealmFetchOptions & { targetRealmUrl: string },
+): Promise<number> {
+  let result = await searchRealm(
+    options.targetRealmUrl,
+    {
+      filter: {
+        on: { module: moduleUrl, name: cardName },
+      },
+      sort: [{ by: 'sequenceNumber', direction: 'desc' }],
+    },
+    { authorization: options.authorization, fetch: options.fetch },
+  );
+
+  if (!result?.ok || !result.data) {
+    return 1;
+  }
+
+  let targetRealmUrl = ensureTrailingSlash(options.targetRealmUrl);
+  let fullPrefix = `${prefix}${slug}-`;
+  let maxSeq = 0;
+
+  for (let card of result.data) {
+    let cardId = (card as { id?: string }).id ?? '';
+    let relativePath = cardId.startsWith(targetRealmUrl)
+      ? cardId.slice(targetRealmUrl.length)
+      : cardId;
+    if (relativePath.startsWith(fullPrefix)) {
+      let attrs = (card as { attributes?: { sequenceNumber?: number } })
+        .attributes;
+      let seq = attrs?.sequenceNumber ?? 0;
+      if (seq > maxSeq) {
+        maxSeq = seq;
+      }
+    }
+  }
+
+  return maxSeq + 1;
+}
+
+// ---------------------------------------------------------------------------
 // Fetch Realm Filenames
 // ---------------------------------------------------------------------------
 

--- a/packages/software-factory/src/realm-operations.ts
+++ b/packages/software-factory/src/realm-operations.ts
@@ -857,6 +857,68 @@ async function addRealmToMatrixAccountData(
 }
 
 // ---------------------------------------------------------------------------
+// Lint
+// ---------------------------------------------------------------------------
+
+/** A single lint diagnostic message (mirrors ESLint's Linter.LintMessage). */
+export interface LintMessage {
+  ruleId: string | null;
+  severity: 1 | 2; // 1 = warning, 2 = error
+  message: string;
+  line: number;
+  column: number;
+  endLine?: number;
+  endColumn?: number;
+}
+
+/** Response from the realm `_lint` endpoint (mirrors ESLint's Linter.FixReport). */
+export interface LintFileResponse {
+  fixed: boolean;
+  output: string;
+  messages: LintMessage[];
+}
+
+/**
+ * Lint a single file's source code via the realm's `_lint` endpoint.
+ * The endpoint runs ESLint with `@cardstack/boxel` rules and Prettier formatting.
+ */
+export async function lintFile(
+  realmUrl: string,
+  source: string,
+  filename: string,
+  options?: RealmFetchOptions,
+): Promise<LintFileResponse> {
+  let fetchImpl = options?.fetch ?? globalThis.fetch;
+  let normalizedUrl = ensureTrailingSlash(realmUrl);
+  let lintUrl = `${normalizedUrl}_lint`;
+
+  let headers: Record<string, string> = {
+    Accept: SupportedMimeType.JSON,
+    'Content-Type': SupportedMimeType.CardSource,
+    'X-Filename': filename,
+    'X-HTTP-Method-Override': 'QUERY',
+  };
+  if (options?.authorization) {
+    headers['Authorization'] = options.authorization;
+  }
+
+  let response = await fetchImpl(lintUrl, {
+    method: 'POST',
+    headers,
+    body: source,
+  });
+
+  if (!response.ok) {
+    let body = await response.text().catch(() => '(no body)');
+    throw new Error(
+      `_lint returned HTTP ${response.status}: ${body.slice(0, 300)}`,
+    );
+  }
+
+  return (await response.json()) as LintFileResponse;
+}
+
+// ---------------------------------------------------------------------------
 // Fetch Realm Filenames
 // ---------------------------------------------------------------------------
 

--- a/packages/software-factory/src/test-run-cards.ts
+++ b/packages/software-factory/src/test-run-cards.ts
@@ -19,7 +19,7 @@ export async function createTestRun(
   options: TestRunRealmOptions & CreateTestRunOptions,
 ): Promise<{ testRunId: string; created: boolean; error?: string }> {
   let seq = options.sequenceNumber ?? 1;
-  let testRunId = `Test Runs/${slug}-${seq}`;
+  let testRunId = `Validations/test_${slug}-${seq}`;
 
   let document = buildTestRunCardDocument(
     testNames,

--- a/packages/software-factory/src/test-run-execution.ts
+++ b/packages/software-factory/src/test-run-execution.ts
@@ -6,7 +6,11 @@ import { logger } from './logger';
 
 import { chromium } from '@playwright/test';
 
-import { ensureTrailingSlash, searchRealm } from './realm-operations';
+import {
+  ensureTrailingSlash,
+  getNextValidationSequenceNumber,
+  searchRealm,
+} from './realm-operations';
 import { createTestRun, completeTestRun } from './test-run-cards';
 import { parseQunitResults } from './test-run-parsing';
 import type {
@@ -145,49 +149,26 @@ async function findResumableTestRun(
 
 /**
  * Get the next sequence number for a given slug by searching existing
- * TestRun cards in the realm and filtering by card ID. Each slug (issue)
- * gets its own independent sequence starting from 1.
+ * TestRun cards in the realm. Delegates to the shared utility in
+ * realm-operations.ts.
  */
 async function getNextSequenceNumber(
   slug: string,
   options: TestRunRealmOptions,
   minSequenceNumber = 0,
 ): Promise<number> {
-  let result = await searchRealm(
-    options.targetRealmUrl,
+  let seq = await getNextValidationSequenceNumber(
+    slug,
+    'Validations/test_',
+    options.testResultsModuleUrl,
+    'TestRun',
     {
-      filter: {
-        on: { module: options.testResultsModuleUrl, name: 'TestRun' },
-      },
-      sort: [{ by: 'sequenceNumber', direction: 'desc' }],
+      targetRealmUrl: options.targetRealmUrl,
+      authorization: options.authorization,
+      fetch: options.fetch,
     },
-    { authorization: options.authorization, fetch: options.fetch },
   );
-
-  if (!result?.ok || !result.data) {
-    return minSequenceNumber + 1;
-  }
-
-  let targetRealmUrl = ensureTrailingSlash(options.targetRealmUrl);
-  let prefix = `Validations/test_${slug}-`;
-  let maxSeq = 0;
-
-  for (let card of result.data) {
-    let cardId = (card as { id?: string }).id ?? '';
-    let relativePath = cardId.startsWith(targetRealmUrl)
-      ? cardId.slice(targetRealmUrl.length)
-      : cardId;
-    if (relativePath.startsWith(prefix)) {
-      let attrs = (card as { attributes?: { sequenceNumber?: number } })
-        .attributes;
-      let seq = attrs?.sequenceNumber ?? 0;
-      if (seq > maxSeq) {
-        maxSeq = seq;
-      }
-    }
-  }
-
-  return Math.max(maxSeq, minSequenceNumber) + 1;
+  return Math.max(seq, minSequenceNumber + 1);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/software-factory/src/test-run-execution.ts
+++ b/packages/software-factory/src/test-run-execution.ts
@@ -169,7 +169,7 @@ async function getNextSequenceNumber(
   }
 
   let targetRealmUrl = ensureTrailingSlash(options.targetRealmUrl);
-  let prefix = `Test Runs/${slug}-`;
+  let prefix = `Validations/test_${slug}-`;
   let maxSeq = 0;
 
   for (let card of result.data) {

--- a/packages/software-factory/src/validators/lint-step.ts
+++ b/packages/software-factory/src/validators/lint-step.ts
@@ -84,6 +84,7 @@ export class LintValidationStep implements ValidationStepRunner {
   readonly step = 'lint' as const;
 
   private config: LintValidationStepConfig;
+  private lastSequenceNumber = 0;
 
   private fetchFilenamesFn: (
     realmUrl: string,
@@ -163,12 +164,16 @@ export class LintValidationStep implements ValidationStepRunner {
 
     let seq: number;
     try {
-      seq = await this.getNextSeqFn(slug, targetRealmUrl);
+      let realmSeq = await this.getNextSeqFn(slug, targetRealmUrl);
+      // Use the higher of realm state vs in-memory floor. The realm index
+      // may be stale if the prior lint run just completed (lint is fast),
+      // so the floor prevents sequence reuse / artifact overwrite.
+      seq = Math.max(realmSeq, this.lastSequenceNumber + 1);
     } catch (err) {
       log.warn(
-        `Failed to resolve sequence number, defaulting to 1: ${err instanceof Error ? err.message : String(err)}`,
+        `Failed to resolve sequence number, using floor: ${err instanceof Error ? err.message : String(err)}`,
       );
-      seq = 1;
+      seq = this.lastSequenceNumber + 1;
     }
 
     let lintResultId: string;
@@ -192,6 +197,7 @@ export class LintValidationStep implements ValidationStepRunner {
         );
       } else {
         artifactCreated = true;
+        this.lastSequenceNumber = seq;
       }
     } catch (err) {
       log.warn(

--- a/packages/software-factory/src/validators/lint-step.ts
+++ b/packages/software-factory/src/validators/lint-step.ts
@@ -12,6 +12,7 @@ import { deriveIssueSlug } from '../factory-agent-types';
 
 import {
   fetchRealmFilenames,
+  getNextValidationSequenceNumber,
   lintFile,
   readFile,
   type LintFileResponse,
@@ -57,6 +58,11 @@ export interface LintValidationStepConfig {
     path: string,
     options?: RealmFetchOptions,
   ) => Promise<{ ok: boolean; content?: string; error?: string }>;
+  /** Injected for testing — defaults to getNextValidationSequenceNumber. */
+  getNextSequenceNumber?: (
+    slug: string,
+    targetRealmUrl: string,
+  ) => Promise<number>;
 }
 
 /** Flattened POJO for lint validation details — not a card, just data. */
@@ -78,7 +84,6 @@ export class LintValidationStep implements ValidationStepRunner {
   readonly step = 'lint' as const;
 
   private config: LintValidationStepConfig;
-  private lastSequenceNumber = 0;
 
   private fetchFilenamesFn: (
     realmUrl: string,
@@ -95,12 +100,30 @@ export class LintValidationStep implements ValidationStepRunner {
     path: string,
     options?: RealmFetchOptions,
   ) => Promise<{ ok: boolean; content?: string; error?: string }>;
+  private getNextSeqFn: (
+    slug: string,
+    targetRealmUrl: string,
+  ) => Promise<number>;
 
   constructor(config: LintValidationStepConfig) {
     this.config = config;
     this.fetchFilenamesFn = config.fetchFilenames ?? fetchRealmFilenames;
     this.lintFileFn = config.lintFileFn ?? lintFile;
     this.readFileFn = config.readFileFn ?? readFile;
+    this.getNextSeqFn =
+      config.getNextSequenceNumber ??
+      ((slug: string, targetRealmUrl: string) =>
+        getNextValidationSequenceNumber(
+          slug,
+          'Validations/lint_',
+          config.lintResultsModuleUrl,
+          'LintResult',
+          {
+            targetRealmUrl,
+            authorization: config.authorization,
+            fetch: config.fetch,
+          },
+        ));
   }
 
   async run(targetRealmUrl: string): Promise<ValidationStepResult> {
@@ -138,8 +161,18 @@ export class LintValidationStep implements ValidationStepRunner {
       ? new URL(this.config.issueId, targetRealmUrl).href
       : undefined;
 
-    let seq = this.lastSequenceNumber + 1;
+    let seq: number;
+    try {
+      seq = await this.getNextSeqFn(slug, targetRealmUrl);
+    } catch (err) {
+      log.warn(
+        `Failed to resolve sequence number, defaulting to 1: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      seq = 1;
+    }
+
     let lintResultId: string;
+    let artifactCreated = false;
     try {
       let createResult = await createLintResult(
         slug,
@@ -153,11 +186,14 @@ export class LintValidationStep implements ValidationStepRunner {
         },
       );
       lintResultId = createResult.lintResultId;
-      if (createResult.created) {
-        this.lastSequenceNumber = seq;
+      if (!createResult.created) {
+        log.warn(
+          `LintResult card creation returned created: false: ${createResult.error ?? 'unknown'}`,
+        );
+      } else {
+        artifactCreated = true;
       }
     } catch (err) {
-      // If card creation fails, still run lint but without artifact
       log.warn(
         `Failed to create LintResult card: ${err instanceof Error ? err.message : String(err)}`,
       );
@@ -176,10 +212,42 @@ export class LintValidationStep implements ValidationStepRunner {
     for (let file of lintableFiles) {
       try {
         let readResult = await this.readFileFn(targetRealmUrl, file, fetchOpts);
-        if (!readResult.ok || !readResult.content) {
-          log.warn(
-            `Could not read ${file}: ${readResult.error ?? 'no content'}`,
-          );
+        if (!readResult.ok) {
+          let message = `Could not read ${file}: ${readResult.error ?? 'read failed'}`;
+          log.warn(message);
+          allFileResults.push({
+            file,
+            violations: [
+              {
+                rule: 'lint-error',
+                file,
+                line: 0,
+                column: 0,
+                message,
+                severity: 'error',
+              },
+            ],
+          });
+          allViolations.push({ rule: 'lint-error', file, line: 0, message });
+          continue;
+        }
+        if (readResult.content == null) {
+          let message = `Could not read ${file}: no content`;
+          log.warn(message);
+          allFileResults.push({
+            file,
+            violations: [
+              {
+                rule: 'lint-error',
+                file,
+                line: 0,
+                column: 0,
+                message,
+                severity: 'error',
+              },
+            ],
+          });
+          allViolations.push({ rule: 'lint-error', file, line: 0, message });
           continue;
         }
 
@@ -215,9 +283,8 @@ export class LintValidationStep implements ValidationStepRunner {
           }
         }
       } catch (err) {
-        log.warn(
-          `Error linting ${file}: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        let message = `Lint failed: ${err instanceof Error ? err.message : String(err)}`;
+        log.warn(`Error linting ${file}: ${message}`);
         allFileResults.push({
           file,
           violations: [
@@ -226,17 +293,12 @@ export class LintValidationStep implements ValidationStepRunner {
               file,
               line: 0,
               column: 0,
-              message: `Lint failed: ${err instanceof Error ? err.message : String(err)}`,
+              message,
               severity: 'error',
             },
           ],
         });
-        allViolations.push({
-          rule: 'lint-error',
-          file,
-          line: 0,
-          message: `Lint failed: ${err instanceof Error ? err.message : String(err)}`,
-        });
+        allViolations.push({ rule: 'lint-error', file, line: 0, message });
       }
     }
 
@@ -244,8 +306,8 @@ export class LintValidationStep implements ValidationStepRunner {
     let passed = allViolations.length === 0;
 
     // Step 4: Complete the LintResult card
-    try {
-      await completeLintResult(
+    if (artifactCreated) {
+      let completeResult = await completeLintResult(
         lintResultId,
         {
           status: passed ? 'passed' : 'failed',
@@ -258,10 +320,11 @@ export class LintValidationStep implements ValidationStepRunner {
           fetch: this.config.fetch,
         },
       );
-    } catch (err) {
-      log.warn(
-        `Failed to complete LintResult card: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      if (!completeResult.updated) {
+        log.warn(
+          `Failed to complete LintResult card ${lintResultId}: ${completeResult.error ?? 'unknown'}`,
+        );
+      }
     }
 
     // Step 5: Build result
@@ -339,8 +402,8 @@ export class LintValidationStep implements ValidationStepRunner {
       throw new Error(result.error);
     }
 
-    return result.filenames.filter((f) =>
-      LINTABLE_EXTENSIONS.some((ext) => f.endsWith(ext)),
-    );
+    return result.filenames
+      .filter((f) => LINTABLE_EXTENSIONS.some((ext) => f.endsWith(ext)))
+      .sort((a, b) => a.localeCompare(b));
   }
 }

--- a/packages/software-factory/src/validators/lint-step.ts
+++ b/packages/software-factory/src/validators/lint-step.ts
@@ -1,0 +1,346 @@
+/**
+ * Lint validation step — runs ESLint + Prettier on lintable files in the
+ * target realm via the realm's `_lint` endpoint.
+ *
+ * For each `.gts`, `.gjs`, `.ts`, `.js` file discovered in the realm,
+ * reads the source and posts it to `_lint`. Collects violations and
+ * persists a LintResult card as the validation artifact.
+ */
+
+import type { ValidationStepResult } from '../factory-agent';
+import { deriveIssueSlug } from '../factory-agent-types';
+
+import {
+  fetchRealmFilenames,
+  lintFile,
+  readFile,
+  type LintFileResponse,
+  type RealmFetchOptions,
+} from '../realm-operations';
+import {
+  createLintResult,
+  completeLintResult,
+  type LintFileResultData,
+  type LintViolationData,
+} from '../lint-result-cards';
+import { logger } from '../logger';
+
+import type { ValidationStepRunner } from './validation-pipeline';
+
+let log = logger('lint-validation-step');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface LintValidationStepConfig {
+  authorization?: string;
+  fetch?: typeof globalThis.fetch;
+  realmServerUrl: string;
+  lintResultsModuleUrl: string;
+  issueId?: string;
+  /** Injected for testing — defaults to fetchRealmFilenames. */
+  fetchFilenames?: (
+    realmUrl: string,
+    options?: RealmFetchOptions,
+  ) => Promise<{ filenames: string[]; error?: string }>;
+  /** Injected for testing — defaults to lintFile from realm-operations. */
+  lintFileFn?: (
+    realmUrl: string,
+    source: string,
+    filename: string,
+    options?: RealmFetchOptions,
+  ) => Promise<LintFileResponse>;
+  /** Injected for testing — defaults to readFile from realm-operations. */
+  readFileFn?: (
+    realmUrl: string,
+    path: string,
+    options?: RealmFetchOptions,
+  ) => Promise<{ ok: boolean; content?: string; error?: string }>;
+}
+
+/** Flattened POJO for lint validation details — not a card, just data. */
+export interface LintValidationDetails {
+  lintResultId: string;
+  filesChecked: number;
+  filesWithErrors: number;
+  totalViolations: number;
+  violations: { rule: string; file: string; line: number; message: string }[];
+}
+
+const LINTABLE_EXTENSIONS = ['.gts', '.gjs', '.ts', '.js'];
+
+// ---------------------------------------------------------------------------
+// LintValidationStep
+// ---------------------------------------------------------------------------
+
+export class LintValidationStep implements ValidationStepRunner {
+  readonly step = 'lint' as const;
+
+  private config: LintValidationStepConfig;
+  private lastSequenceNumber = 0;
+
+  private fetchFilenamesFn: (
+    realmUrl: string,
+    options?: RealmFetchOptions,
+  ) => Promise<{ filenames: string[]; error?: string }>;
+  private lintFileFn: (
+    realmUrl: string,
+    source: string,
+    filename: string,
+    options?: RealmFetchOptions,
+  ) => Promise<LintFileResponse>;
+  private readFileFn: (
+    realmUrl: string,
+    path: string,
+    options?: RealmFetchOptions,
+  ) => Promise<{ ok: boolean; content?: string; error?: string }>;
+
+  constructor(config: LintValidationStepConfig) {
+    this.config = config;
+    this.fetchFilenamesFn = config.fetchFilenames ?? fetchRealmFilenames;
+    this.lintFileFn = config.lintFileFn ?? lintFile;
+    this.readFileFn = config.readFileFn ?? readFile;
+  }
+
+  async run(targetRealmUrl: string): Promise<ValidationStepResult> {
+    // Step 1: Discover lintable files
+    let lintableFiles: string[];
+    try {
+      lintableFiles = await this.discoverLintableFiles(targetRealmUrl);
+    } catch (err) {
+      return {
+        step: 'lint',
+        passed: false,
+        errors: [
+          {
+            message: `Failed to discover lintable files: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        ],
+      };
+    }
+
+    if (lintableFiles.length === 0) {
+      log.info('No lintable files found — nothing to validate');
+      return { step: 'lint', passed: true, files: [], errors: [] };
+    }
+
+    log.info(
+      `Found ${lintableFiles.length} lintable file(s): ${lintableFiles.join(', ')}`,
+    );
+
+    // Step 2: Create the LintResult card (status: running)
+    let slug = this.config.issueId
+      ? deriveIssueSlug(this.config.issueId)
+      : 'validation';
+
+    let issueURL = this.config.issueId
+      ? new URL(this.config.issueId, targetRealmUrl).href
+      : undefined;
+
+    let seq = this.lastSequenceNumber + 1;
+    let lintResultId: string;
+    try {
+      let createResult = await createLintResult(
+        slug,
+        this.config.lintResultsModuleUrl,
+        {
+          targetRealmUrl,
+          authorization: this.config.authorization,
+          fetch: this.config.fetch,
+          sequenceNumber: seq,
+          issueURL,
+        },
+      );
+      lintResultId = createResult.lintResultId;
+      if (createResult.created) {
+        this.lastSequenceNumber = seq;
+      }
+    } catch (err) {
+      // If card creation fails, still run lint but without artifact
+      log.warn(
+        `Failed to create LintResult card: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      lintResultId = `Validations/lint_${slug}-${seq}`;
+    }
+
+    // Step 3: Lint each file
+    let startedAt = Date.now();
+    let allFileResults: LintFileResultData[] = [];
+    let allViolations: LintValidationDetails['violations'] = [];
+    let fetchOpts: RealmFetchOptions = {
+      authorization: this.config.authorization,
+      fetch: this.config.fetch,
+    };
+
+    for (let file of lintableFiles) {
+      try {
+        let readResult = await this.readFileFn(targetRealmUrl, file, fetchOpts);
+        if (!readResult.ok || !readResult.content) {
+          log.warn(
+            `Could not read ${file}: ${readResult.error ?? 'no content'}`,
+          );
+          continue;
+        }
+
+        let lintResponse = await this.lintFileFn(
+          targetRealmUrl,
+          readResult.content,
+          file,
+          fetchOpts,
+        );
+
+        let violations: LintViolationData[] = lintResponse.messages.map(
+          (msg) => ({
+            rule: msg.ruleId ?? 'unknown',
+            file,
+            line: msg.line,
+            column: msg.column,
+            message: msg.message,
+            severity:
+              msg.severity === 2 ? ('error' as const) : ('warning' as const),
+          }),
+        );
+
+        allFileResults.push({ file, violations });
+
+        for (let v of violations) {
+          if (v.severity === 'error') {
+            allViolations.push({
+              rule: v.rule ?? 'unknown',
+              file: v.file,
+              line: v.line,
+              message: v.message,
+            });
+          }
+        }
+      } catch (err) {
+        log.warn(
+          `Error linting ${file}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        allFileResults.push({
+          file,
+          violations: [
+            {
+              rule: 'lint-error',
+              file,
+              line: 0,
+              column: 0,
+              message: `Lint failed: ${err instanceof Error ? err.message : String(err)}`,
+              severity: 'error',
+            },
+          ],
+        });
+        allViolations.push({
+          rule: 'lint-error',
+          file,
+          line: 0,
+          message: `Lint failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    }
+
+    let durationMs = Date.now() - startedAt;
+    let passed = allViolations.length === 0;
+
+    // Step 4: Complete the LintResult card
+    try {
+      await completeLintResult(
+        lintResultId,
+        {
+          status: passed ? 'passed' : 'failed',
+          durationMs,
+          fileResults: allFileResults,
+        },
+        {
+          targetRealmUrl,
+          authorization: this.config.authorization,
+          fetch: this.config.fetch,
+        },
+      );
+    } catch (err) {
+      log.warn(
+        `Failed to complete LintResult card: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    // Step 5: Build result
+    let details: LintValidationDetails = {
+      lintResultId,
+      filesChecked: allFileResults.length,
+      filesWithErrors: allFileResults.filter((fr) =>
+        fr.violations.some((v) => v.severity === 'error'),
+      ).length,
+      totalViolations: allViolations.length,
+      violations: allViolations,
+    };
+
+    let errors = allViolations.map((v) => ({
+      file: v.file,
+      message: `${v.file}:${v.line} [${v.rule}] ${v.message}`,
+    }));
+
+    return {
+      step: 'lint',
+      passed,
+      files: lintableFiles,
+      errors,
+      details: details as unknown as Record<string, unknown>,
+    };
+  }
+
+  formatForContext(result: ValidationStepResult): string {
+    if (result.passed) {
+      let details = result.details as unknown as
+        | LintValidationDetails
+        | undefined;
+      if (details && details.filesChecked > 0) {
+        return `## Lint Validation: PASSED\n${details.filesChecked} file(s) checked, no lint errors. (LintResult: ${details.lintResultId})`;
+      }
+      return '';
+    }
+
+    let details = result.details as unknown as
+      | LintValidationDetails
+      | undefined;
+    if (!details) {
+      let errorLines = result.errors.map((e) => `- ${e.message}`).join('\n');
+      return `## Lint Validation: FAILED\n${errorLines}`;
+    }
+
+    let lines: string[] = [
+      `## Lint Validation: FAILED`,
+      `${details.filesChecked} file(s) checked, ${details.totalViolations} violation(s) in ${details.filesWithErrors} file(s) (LintResult: ${details.lintResultId})`,
+    ];
+
+    for (let violation of details.violations) {
+      lines.push(
+        `  ${violation.file}:${violation.line} [${violation.rule}] ${violation.message}`,
+      );
+    }
+
+    return lines.join('\n');
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private async discoverLintableFiles(
+    targetRealmUrl: string,
+  ): Promise<string[]> {
+    let result = await this.fetchFilenamesFn(targetRealmUrl, {
+      authorization: this.config.authorization,
+      fetch: this.config.fetch,
+    });
+
+    if (result.error) {
+      log.warn(`Failed to fetch realm filenames: ${result.error}`);
+      throw new Error(result.error);
+    }
+
+    return result.filenames.filter((f) =>
+      LINTABLE_EXTENSIONS.some((ext) => f.endsWith(ext)),
+    );
+  }
+}

--- a/packages/software-factory/src/validators/validation-pipeline.ts
+++ b/packages/software-factory/src/validators/validation-pipeline.ts
@@ -17,8 +17,10 @@ import type { Validator } from '../issue-loop';
 
 import { NoOpStepRunner } from './noop-step';
 import { TestValidationStep } from './test-step';
+import { LintValidationStep } from './lint-step';
 
 import type { TestValidationStepConfig } from './test-step';
+import type { LintValidationStepConfig } from './lint-step';
 
 import { logger } from '../logger';
 
@@ -144,8 +146,9 @@ export interface ValidationPipelineConfig {
   realmServerUrl: string;
   hostAppUrl: string;
   testResultsModuleUrl: string;
+  lintResultsModuleUrl: string;
   issueId?: string;
-  /** Injected for testing — passed through to TestValidationStep. */
+  /** Injected for testing — passed through to TestValidationStep and LintValidationStep. */
   fetchFilenames?: TestValidationStepConfig['fetchFilenames'];
 }
 
@@ -166,9 +169,18 @@ export function createDefaultPipeline(
     fetchFilenames: config.fetchFilenames,
   };
 
+  let lintConfig: LintValidationStepConfig = {
+    authorization: config.authorization,
+    fetch: config.fetch,
+    realmServerUrl: config.realmServerUrl,
+    lintResultsModuleUrl: config.lintResultsModuleUrl,
+    issueId: config.issueId,
+    fetchFilenames: config.fetchFilenames,
+  };
+
   return new ValidationPipeline([
     new NoOpStepRunner('parse'),
-    new NoOpStepRunner('lint'),
+    new LintValidationStep(lintConfig),
     new NoOpStepRunner('evaluate'),
     new NoOpStepRunner('instantiate'),
     new TestValidationStep(testConfig),

--- a/packages/software-factory/tests/factory-prompt-loader.test.ts
+++ b/packages/software-factory/tests/factory-prompt-loader.test.ts
@@ -491,19 +491,8 @@ module('factory-prompt-loader > assembleIteratePrompt', function () {
         summary: 'Define core card',
         description: 'Create the card definition.',
       },
-      testResults: {
-        status: 'failed',
-        passedCount: 1,
-        failedCount: 1,
-        failures: [
-          {
-            testName: 'renders card',
-            error: 'Element not found',
-            stackTrace: 'at test.spec.ts:10',
-          },
-        ],
-        durationMs: 3000,
-      },
+      validationContext:
+        '## Test Validation: FAILED\n1 passed, 1 failed\n\nFAILED: "renders card"\n  Element not found\n  at test.spec.ts:10',
     });
 
     let previousActions: AgentAction[] = [
@@ -543,15 +532,15 @@ module('factory-prompt-loader > assembleIteratePrompt', function () {
       'includes previous action content',
     );
 
-    // Test results
-    assert.ok(result.includes('failed'), 'includes test status');
+    // Validation context
+    assert.ok(result.includes('FAILED'), 'includes validation status');
     assert.ok(result.includes('renders card'), 'includes failure test name');
     assert.ok(result.includes('Element not found'), 'includes failure error');
     assert.ok(result.includes('at test.spec.ts:10'), 'includes stack trace');
 
     // Instructions
     assert.ok(
-      result.includes('Fix the failing tests'),
+      result.includes('Fix the validation failures'),
       'includes fix instructions',
     );
   });
@@ -606,13 +595,7 @@ module('factory-prompt-loader > assembleIteratePrompt', function () {
           outputFormat: 'json' as const,
         },
       ],
-      testResults: {
-        status: 'failed',
-        passedCount: 0,
-        failedCount: 1,
-        failures: [{ testName: 'basic', error: 'fail' }],
-        durationMs: 1000,
-      },
+      validationContext: '## Test Validation: FAILED\nbasic: fail',
       toolResults: [
         {
           tool: 'run-tests',
@@ -644,7 +627,7 @@ module('factory-prompt-loader > assembleIteratePrompt', function () {
     );
   });
 
-  test('is self-contained: includes project, issue, actions, test results', function (assert) {
+  test('is self-contained: includes project, issue, actions, validation context', function (assert) {
     let loader = new FilePromptLoader();
     let ctx = makeMinimalContext({
       project: { id: 'Projects/app', objective: 'Build the app' },
@@ -653,16 +636,8 @@ module('factory-prompt-loader > assembleIteratePrompt', function () {
         summary: 'First issue',
         description: 'Do the thing.',
       },
-      testResults: {
-        status: 'failed',
-        passedCount: 0,
-        failedCount: 2,
-        failures: [
-          { testName: 'test-a', error: 'error-a' },
-          { testName: 'test-b', error: 'error-b' },
-        ],
-        durationMs: 5000,
-      },
+      validationContext:
+        '## Test Validation: FAILED\n0 passed, 2 failed\n\nFAILED: "test-a"\n  error-a\n\nFAILED: "test-b"\n  error-b',
     });
 
     let previousActions: AgentAction[] = [
@@ -688,9 +663,12 @@ module('factory-prompt-loader > assembleIteratePrompt', function () {
     assert.ok(result.includes('Do the thing'), 'issue description');
     assert.ok(result.includes('iteration 3'), 'iteration number');
     assert.ok(result.includes('card.gts'), 'previous action');
-    assert.ok(result.includes('error-a'), 'test failure 1');
-    assert.ok(result.includes('error-b'), 'test failure 2');
-    assert.ok(result.includes('Fix the failing tests'), 'fix instructions');
+    assert.ok(result.includes('error-a'), 'validation failure 1');
+    assert.ok(result.includes('error-b'), 'validation failure 2');
+    assert.ok(
+      result.includes('Fix the validation failures'),
+      'fix instructions',
+    );
   });
 });
 
@@ -787,13 +765,8 @@ module(
           summary: 'First issue',
           description: 'Implement the feature.',
         },
-        testResults: {
-          status: 'failed',
-          passedCount: 0,
-          failedCount: 1,
-          failures: [{ testName: 'basic', error: 'boom' }],
-          durationMs: 2000,
-        },
+        validationContext:
+          '## Test Validation: FAILED\n0 passed, 1 failed\n\nFAILED: "basic"\n  boom',
       });
 
       let previousActions: AgentAction[] = [
@@ -824,7 +797,7 @@ module(
       assert.ok(messages[1].content.includes('Previous Attempt'));
       assert.ok(messages[1].content.includes('card.gts'));
       assert.ok(messages[1].content.includes('boom'));
-      assert.ok(messages[1].content.includes('Fix the failing tests'));
+      assert.ok(messages[1].content.includes('Fix the validation failures'));
     });
 
     test('each LLM call is exactly [system, user] — no multi-turn', function (assert) {

--- a/packages/software-factory/tests/factory-test-realm.spec.ts
+++ b/packages/software-factory/tests/factory-test-realm.spec.ts
@@ -111,7 +111,7 @@ test.describe('factory-test-realm e2e', () => {
     });
 
     // Handle assertions
-    expect(handle.testRunId).toContain('Test Runs/hello-e2e');
+    expect(handle.testRunId).toContain('Validations/test_hello-e2e');
     expect(handle.status).toBe('passed');
     expect(handle.errorMessage).toBeUndefined();
 
@@ -178,7 +178,7 @@ test.describe('factory-test-realm e2e', () => {
     });
 
     // Handle assertions
-    expect(handle.testRunId).toContain('Test Runs/hello-fail');
+    expect(handle.testRunId).toContain('Validations/test_hello-fail');
     expect(handle.status).toBe('failed');
 
     // Read the TestRun card back and verify its persisted state

--- a/packages/software-factory/tests/factory-test-realm.test.ts
+++ b/packages/software-factory/tests/factory-test-realm.test.ts
@@ -415,10 +415,13 @@ module('factory-test-realm > createTestRun', function () {
     );
 
     assert.true(result.created);
-    assert.strictEqual(result.testRunId, 'Test Runs/define-sticky-note-1');
+    assert.strictEqual(
+      result.testRunId,
+      'Validations/test_define-sticky-note-1',
+    );
     assert.strictEqual(
       capturedUrl,
-      'https://realms.example.test/user/personal-tests/Test%20Runs/define-sticky-note-1.json',
+      'https://realms.example.test/user/personal-tests/Validations/test_define-sticky-note-1.json',
     );
     assert.strictEqual(capturedInit?.method, 'POST');
 
@@ -513,7 +516,7 @@ module('factory-test-realm > completeTestRun', function () {
     };
 
     let result = await completeTestRun(
-      'Test Runs/define-sticky-note-1',
+      'Validations/test_define-sticky-note-1',
       attrs,
       { ...testRealmOptions, fetch: mockFetch },
     );
@@ -522,7 +525,9 @@ module('factory-test-realm > completeTestRun', function () {
     assert.strictEqual(calls.length, 2);
     assert.strictEqual(calls[0].method, 'GET');
     assert.strictEqual(calls[1].method, 'POST');
-    assert.true(calls[1].url.includes('Test%20Runs/define-sticky-note-1.json'));
+    assert.true(
+      calls[1].url.includes('Validations/test_define-sticky-note-1.json'),
+    );
   });
 
   test('returns error when read fails', async function (assert) {
@@ -538,7 +543,7 @@ module('factory-test-realm > completeTestRun', function () {
       moduleResults: [],
     };
 
-    let result = await completeTestRun('Test Runs/missing-1', attrs, {
+    let result = await completeTestRun('Validations/test_missing-1', attrs, {
       ...testRealmOptions,
       fetch: mockFetch,
     });
@@ -609,7 +614,7 @@ module('factory-test-realm > resolveTestRun', function () {
     });
 
     assert.strictEqual(handle.status, 'running');
-    assert.strictEqual(handle.testRunId, 'Test Runs/my-issue-1');
+    assert.strictEqual(handle.testRunId, 'Validations/test_my-issue-1');
   });
 
   test('creates new TestRun when most recent is completed', async function (assert) {
@@ -621,12 +626,16 @@ module('factory-test-realm > resolveTestRun', function () {
       realmServerUrl: 'https://realms.example.test/',
       hostAppUrl: 'https://realms.example.test/',
       fetch: buildMockSearchFetch([
-        { id: 'Test Runs/my-issue-2', status: 'passed', sequenceNumber: 2 },
+        {
+          id: 'Validations/test_my-issue-2',
+          status: 'passed',
+          sequenceNumber: 2,
+        },
       ]),
     });
 
     assert.strictEqual(handle.status, 'running');
-    assert.strictEqual(handle.testRunId, 'Test Runs/my-issue-3');
+    assert.strictEqual(handle.testRunId, 'Validations/test_my-issue-3');
   });
 
   test('resumes most recent running TestRun by default', async function (assert) {
@@ -639,7 +648,7 @@ module('factory-test-realm > resolveTestRun', function () {
       hostAppUrl: 'https://realms.example.test/',
       fetch: buildMockSearchFetch([
         {
-          id: 'Test Runs/my-issue-2',
+          id: 'Validations/test_my-issue-2',
           status: 'running',
           sequenceNumber: 2,
           moduleResults: [
@@ -655,7 +664,7 @@ module('factory-test-realm > resolveTestRun', function () {
     });
 
     assert.strictEqual(handle.status, 'running');
-    assert.strictEqual(handle.testRunId, 'Test Runs/my-issue-2');
+    assert.strictEqual(handle.testRunId, 'Validations/test_my-issue-2');
   });
 
   test('ignores partial TestRun with forceNew: true', async function (assert) {
@@ -668,13 +677,17 @@ module('factory-test-realm > resolveTestRun', function () {
       realmServerUrl: 'https://realms.example.test/',
       hostAppUrl: 'https://realms.example.test/',
       fetch: buildMockSearchFetch([
-        { id: 'Test Runs/my-issue-2', status: 'running', sequenceNumber: 2 },
+        {
+          id: 'Validations/test_my-issue-2',
+          status: 'running',
+          sequenceNumber: 2,
+        },
       ]),
     });
 
     assert.strictEqual(handle.status, 'running');
     // forceNew creates a new run with incremented sequence
-    assert.strictEqual(handle.testRunId, 'Test Runs/my-issue-3');
+    assert.strictEqual(handle.testRunId, 'Validations/test_my-issue-3');
   });
 
   test('does NOT resume older partial TestRun when newer completed exists', async function (assert) {
@@ -688,12 +701,16 @@ module('factory-test-realm > resolveTestRun', function () {
       realmServerUrl: 'https://realms.example.test/',
       hostAppUrl: 'https://realms.example.test/',
       fetch: buildMockSearchFetch([
-        { id: 'Test Runs/my-issue-3', status: 'passed', sequenceNumber: 3 },
+        {
+          id: 'Validations/test_my-issue-3',
+          status: 'passed',
+          sequenceNumber: 3,
+        },
       ]),
     });
 
     assert.strictEqual(handle.status, 'running');
-    assert.strictEqual(handle.testRunId, 'Test Runs/my-issue-4');
+    assert.strictEqual(handle.testRunId, 'Validations/test_my-issue-4');
   });
 
   test('sequence numbers increment correctly', async function (assert) {
@@ -705,11 +722,15 @@ module('factory-test-realm > resolveTestRun', function () {
       realmServerUrl: 'https://realms.example.test/',
       hostAppUrl: 'https://realms.example.test/',
       fetch: buildMockSearchFetch([
-        { id: 'Test Runs/my-issue-7', status: 'failed', sequenceNumber: 7 },
+        {
+          id: 'Validations/test_my-issue-7',
+          status: 'failed',
+          sequenceNumber: 7,
+        },
       ]),
     });
 
-    assert.strictEqual(handle.testRunId, 'Test Runs/my-issue-8');
+    assert.strictEqual(handle.testRunId, 'Validations/test_my-issue-8');
   });
 
   test('consecutive forceNew calls create separate TestRuns with incrementing sequences', async function (assert) {
@@ -727,7 +748,7 @@ module('factory-test-realm > resolveTestRun', function () {
       fetch: buildMockSearchFetch([]),
     });
 
-    assert.strictEqual(handle1.testRunId, 'Test Runs/my-issue-1');
+    assert.strictEqual(handle1.testRunId, 'Validations/test_my-issue-1');
     assert.false(handle1.resumed, 'first run is not resumed');
 
     // Second call with forceNew — should get sequence 2, not resume sequence 1
@@ -741,14 +762,14 @@ module('factory-test-realm > resolveTestRun', function () {
       hostAppUrl: 'https://realms.example.test/',
       fetch: buildMockSearchFetch([
         {
-          id: 'Test Runs/my-issue-1',
+          id: 'Validations/test_my-issue-1',
           status: 'running',
           sequenceNumber: 1,
         },
       ]),
     });
 
-    assert.strictEqual(handle2.testRunId, 'Test Runs/my-issue-2');
+    assert.strictEqual(handle2.testRunId, 'Validations/test_my-issue-2');
     assert.false(handle2.resumed, 'second run is not resumed');
     assert.notStrictEqual(
       handle1.testRunId,
@@ -773,7 +794,7 @@ module('factory-test-realm > resolveTestRun', function () {
       fetch: buildMockSearchFetch([]),
     });
 
-    assert.strictEqual(handle1.testRunId, 'Test Runs/my-ticket-1');
+    assert.strictEqual(handle1.testRunId, 'Validations/test_my-ticket-1');
 
     // Second call — search index is STALE (still returns empty), but
     // lastSequenceNumber=1 prevents reusing sequence 1.
@@ -791,7 +812,7 @@ module('factory-test-realm > resolveTestRun', function () {
 
     assert.strictEqual(
       handle2.testRunId,
-      'Test Runs/my-ticket-2',
+      'Validations/test_my-ticket-2',
       'uses lastSequenceNumber as floor even when index returns nothing',
     );
 
@@ -810,7 +831,7 @@ module('factory-test-realm > resolveTestRun', function () {
 
     assert.strictEqual(
       handle3.testRunId,
-      'Test Runs/my-ticket-3',
+      'Validations/test_my-ticket-3',
       'continues incrementing from lastSequenceNumber floor',
     );
   });

--- a/packages/software-factory/tests/index.ts
+++ b/packages/software-factory/tests/index.ts
@@ -15,3 +15,4 @@ import './issue-loop.test';
 import './issue-scheduler.test';
 import './validation-pipeline.test';
 import './test-step.test';
+import './lint-step.test';

--- a/packages/software-factory/tests/issue-loop.test.ts
+++ b/packages/software-factory/tests/issue-loop.test.ts
@@ -187,6 +187,16 @@ class MockValidator implements Validator {
     return this.results[this.callIndex++];
   }
 
+  formatForContext(results: ValidationResults): string {
+    if (results.passed) {
+      return 'All validation steps passed.';
+    }
+    let lines = results.steps
+      .filter((s) => !s.passed)
+      .map((s) => `${s.step}: ${s.errors.map((e) => e.message).join(', ')}`);
+    return lines.join('\n');
+  }
+
   get callCount(): number {
     return this.callIndex;
   }

--- a/packages/software-factory/tests/lint-step.test.ts
+++ b/packages/software-factory/tests/lint-step.test.ts
@@ -22,6 +22,8 @@ function makeConfig(
   return {
     realmServerUrl: 'https://example.test/',
     lintResultsModuleUrl: 'https://example.test/lint-result',
+    // Default to a no-op sequence resolver for unit tests
+    getNextSequenceNumber: async () => 1,
     ...overrides,
   };
 }
@@ -213,6 +215,38 @@ module('LintValidationStep', function () {
 
     assert.true(result.passed, 'warnings only should pass');
     assert.strictEqual(result.errors.length, 0, 'no errors for warnings');
+  });
+
+  test('file read failure treated as lint error (not silently skipped)', async function (assert) {
+    let step = new LintValidationStep(
+      makeConfig({
+        fetchFilenames: makeFetchFilenames(['hello.gts', 'broken.gts']),
+        readFileFn: makeReadFile({
+          'hello.gts': 'export class Hello {}',
+          // broken.gts not in map → readFile returns { ok: false }
+        }),
+        lintFileFn: makeLintFile({
+          'hello.gts': { fixed: false, output: '', messages: [] },
+        }),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.false(result.passed, 'read failure should cause lint failure');
+    assert.ok(result.errors.length > 0, 'has errors for unreadable file');
+    assert.ok(
+      result.errors[0].message.includes('broken.gts'),
+      'error mentions the unreadable file',
+    );
+
+    let details = result.details as unknown as LintValidationDetails;
+    assert.strictEqual(details.filesChecked, 2, 'both files counted');
+    assert.strictEqual(
+      details.filesWithErrors,
+      1,
+      'unreadable file counted as error',
+    );
   });
 
   test('lintFile throws returns failed with error message', async function (assert) {

--- a/packages/software-factory/tests/lint-step.test.ts
+++ b/packages/software-factory/tests/lint-step.test.ts
@@ -1,0 +1,384 @@
+import { module, test } from 'qunit';
+
+import type { ValidationStepResult } from '../src/factory-agent';
+
+import {
+  LintValidationStep,
+  type LintValidationStepConfig,
+  type LintValidationDetails,
+} from '../src/validators/lint-step';
+import type {
+  LintFileResponse,
+  RealmFetchOptions,
+} from '../src/realm-operations';
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(
+  overrides: Partial<LintValidationStepConfig> = {},
+): LintValidationStepConfig {
+  return {
+    realmServerUrl: 'https://example.test/',
+    lintResultsModuleUrl: 'https://example.test/lint-result',
+    ...overrides,
+  };
+}
+
+function makeFetchFilenames(
+  filenames: string[],
+): (
+  realmUrl: string,
+  options?: RealmFetchOptions,
+) => Promise<{ filenames: string[]; error?: string }> {
+  return async () => ({ filenames });
+}
+
+function makeFetchFilenamesError(
+  error: string,
+): (
+  realmUrl: string,
+  options?: RealmFetchOptions,
+) => Promise<{ filenames: string[]; error?: string }> {
+  return async () => ({ filenames: [], error });
+}
+
+function makeLintFile(
+  responses: Record<string, LintFileResponse>,
+): (
+  realmUrl: string,
+  source: string,
+  filename: string,
+  options?: RealmFetchOptions,
+) => Promise<LintFileResponse> {
+  return async (_realmUrl, _source, filename) =>
+    responses[filename] ?? { fixed: false, output: '', messages: [] };
+}
+
+function makeLintFileThrows(
+  errorMessage: string,
+): (
+  realmUrl: string,
+  source: string,
+  filename: string,
+  options?: RealmFetchOptions,
+) => Promise<LintFileResponse> {
+  return async () => {
+    throw new Error(errorMessage);
+  };
+}
+
+function makeReadFile(
+  contents: Record<string, string>,
+): (
+  realmUrl: string,
+  path: string,
+  options?: RealmFetchOptions,
+) => Promise<{ ok: boolean; content?: string; error?: string }> {
+  return async (_realmUrl, path) => {
+    let content = contents[path];
+    if (content != null) {
+      return { ok: true, content };
+    }
+    return { ok: false, error: `File not found: ${path}` };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+module('LintValidationStep', function () {
+  test('no lintable files returns passed', async function (assert) {
+    let step = new LintValidationStep(
+      makeConfig({
+        fetchFilenames: makeFetchFilenames([
+          'Cards/my-card.json',
+          'index.json',
+          '.realm.json',
+        ]),
+        readFileFn: makeReadFile({}),
+        lintFileFn: makeLintFile({}),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.true(result.passed);
+    assert.strictEqual(result.step, 'lint');
+    assert.strictEqual(result.errors.length, 0);
+    assert.deepEqual(result.files, []);
+  });
+
+  test('files exist and all pass lint', async function (assert) {
+    let step = new LintValidationStep(
+      makeConfig({
+        fetchFilenames: makeFetchFilenames([
+          'hello.gts',
+          'hello.test.gts',
+          'index.json',
+        ]),
+        readFileFn: makeReadFile({
+          'hello.gts': 'export class Hello {}',
+          'hello.test.gts': 'import { test } from "qunit";',
+        }),
+        lintFileFn: makeLintFile({
+          'hello.gts': { fixed: false, output: '', messages: [] },
+          'hello.test.gts': { fixed: false, output: '', messages: [] },
+        }),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.true(result.passed);
+    assert.strictEqual(result.step, 'lint');
+    assert.deepEqual(result.files, ['hello.gts', 'hello.test.gts']);
+    assert.ok(result.details, 'has details');
+
+    let details = result.details as unknown as LintValidationDetails;
+    assert.strictEqual(details.filesChecked, 2);
+    assert.strictEqual(details.filesWithErrors, 0);
+    assert.strictEqual(details.totalViolations, 0);
+  });
+
+  test('files with lint errors returns failed with violations', async function (assert) {
+    let step = new LintValidationStep(
+      makeConfig({
+        fetchFilenames: makeFetchFilenames(['hello.gts']),
+        readFileFn: makeReadFile({
+          'hello.gts': 'let x = 1;',
+        }),
+        lintFileFn: makeLintFile({
+          'hello.gts': {
+            fixed: false,
+            output: 'let x = 1;',
+            messages: [
+              {
+                ruleId: 'no-unused-vars',
+                severity: 2,
+                message: "'x' is assigned a value but never used",
+                line: 1,
+                column: 5,
+              },
+            ],
+          },
+        }),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.false(result.passed);
+    assert.strictEqual(result.step, 'lint');
+    assert.ok(result.errors.length > 0, 'has errors');
+    assert.ok(result.details, 'has details');
+
+    let details = result.details as unknown as LintValidationDetails;
+    assert.strictEqual(details.filesChecked, 1);
+    assert.strictEqual(details.filesWithErrors, 1);
+    assert.strictEqual(details.totalViolations, 1);
+    assert.strictEqual(details.violations[0].rule, 'no-unused-vars');
+    assert.strictEqual(details.violations[0].file, 'hello.gts');
+    assert.strictEqual(details.violations[0].line, 1);
+  });
+
+  test('warnings do not cause failure', async function (assert) {
+    let step = new LintValidationStep(
+      makeConfig({
+        fetchFilenames: makeFetchFilenames(['hello.gts']),
+        readFileFn: makeReadFile({
+          'hello.gts': 'export const x = 1;',
+        }),
+        lintFileFn: makeLintFile({
+          'hello.gts': {
+            fixed: false,
+            output: 'export const x = 1;',
+            messages: [
+              {
+                ruleId: 'no-css-position-fixed',
+                severity: 1,
+                message: 'Avoid position: fixed',
+                line: 5,
+                column: 1,
+              },
+            ],
+          },
+        }),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.true(result.passed, 'warnings only should pass');
+    assert.strictEqual(result.errors.length, 0, 'no errors for warnings');
+  });
+
+  test('lintFile throws returns failed with error message', async function (assert) {
+    let step = new LintValidationStep(
+      makeConfig({
+        fetchFilenames: makeFetchFilenames(['hello.gts']),
+        readFileFn: makeReadFile({
+          'hello.gts': 'export class Hello {}',
+        }),
+        lintFileFn: makeLintFileThrows('Lint service unavailable'),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.false(result.passed);
+    assert.ok(result.errors.length > 0);
+    assert.ok(result.errors[0].message.includes('Lint service unavailable'));
+  });
+
+  test('fetchFilenames fails returns failed with error', async function (assert) {
+    let step = new LintValidationStep(
+      makeConfig({
+        fetchFilenames: makeFetchFilenamesError('Network timeout'),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.false(result.passed);
+    assert.ok(result.errors[0].message.includes('Network timeout'));
+  });
+
+  test('.test.gts files are linted (all lintable extensions eligible)', async function (assert) {
+    let step = new LintValidationStep(
+      makeConfig({
+        fetchFilenames: makeFetchFilenames([
+          'hello.gts',
+          'hello.test.gts',
+          'utils.ts',
+          'helper.js',
+          'template.gjs',
+          'data.json',
+        ]),
+        readFileFn: makeReadFile({
+          'hello.gts': 'export class Hello {}',
+          'hello.test.gts': 'import { test } from "qunit";',
+          'utils.ts': 'export const x = 1;',
+          'helper.js': 'export const y = 2;',
+          'template.gjs': '<template>hi</template>',
+        }),
+        lintFileFn: makeLintFile({}),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.true(result.passed);
+    assert.deepEqual(result.files, [
+      'hello.gts',
+      'hello.test.gts',
+      'helper.js',
+      'template.gjs',
+      'utils.ts',
+    ]);
+  });
+
+  test('issueId is used for slug derivation in artifact naming', async function (assert) {
+    let step = new LintValidationStep(
+      makeConfig({
+        issueId: 'Issues/sticky-note-define-core',
+        fetchFilenames: makeFetchFilenames(['hello.gts']),
+        readFileFn: makeReadFile({
+          'hello.gts': 'export class Hello {}',
+        }),
+        lintFileFn: makeLintFile({}),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.true(result.passed);
+    let details = result.details as unknown as LintValidationDetails;
+    assert.ok(
+      details.lintResultId.includes('lint_sticky-note-define-core'),
+      `lintResultId "${details.lintResultId}" includes issue slug`,
+    );
+  });
+
+  test('formatForContext with passing result and details', function (assert) {
+    let step = new LintValidationStep(makeConfig());
+
+    let result: ValidationStepResult = {
+      step: 'lint',
+      passed: true,
+      errors: [],
+      details: {
+        lintResultId: 'Validations/lint_validation-1',
+        filesChecked: 3,
+        filesWithErrors: 0,
+        totalViolations: 0,
+        violations: [],
+      },
+    };
+
+    let formatted = step.formatForContext(result);
+    assert.ok(formatted.includes('PASSED'));
+    assert.ok(formatted.includes('3'));
+    assert.ok(formatted.includes('no lint errors'));
+  });
+
+  test('formatForContext with empty pass returns empty string', function (assert) {
+    let step = new LintValidationStep(makeConfig());
+
+    let result: ValidationStepResult = {
+      step: 'lint',
+      passed: true,
+      errors: [],
+    };
+
+    let formatted = step.formatForContext(result);
+    assert.strictEqual(formatted, '');
+  });
+
+  test('formatForContext with failing result and detailed violations', function (assert) {
+    let step = new LintValidationStep(makeConfig());
+
+    let result: ValidationStepResult = {
+      step: 'lint',
+      passed: false,
+      errors: [{ message: 'hello.gts:1 [no-unused-vars] x is unused' }],
+      details: {
+        lintResultId: 'Validations/lint_validation-1',
+        filesChecked: 2,
+        filesWithErrors: 1,
+        totalViolations: 1,
+        violations: [
+          {
+            rule: 'no-unused-vars',
+            file: 'hello.gts',
+            line: 1,
+            message: "'x' is assigned a value but never used",
+          },
+        ],
+      },
+    };
+
+    let formatted = step.formatForContext(result);
+    assert.ok(formatted.includes('FAILED'));
+    assert.ok(formatted.includes('2 file(s) checked'));
+    assert.ok(formatted.includes('1 violation(s)'));
+    assert.ok(formatted.includes('no-unused-vars'));
+    assert.ok(formatted.includes('hello.gts'));
+  });
+
+  test('formatForContext without details falls back to errors', function (assert) {
+    let step = new LintValidationStep(makeConfig());
+
+    let result: ValidationStepResult = {
+      step: 'lint',
+      passed: false,
+      errors: [{ message: 'Lint service failed' }],
+    };
+
+    let formatted = step.formatForContext(result);
+    assert.ok(formatted.includes('FAILED'));
+    assert.ok(formatted.includes('Lint service failed'));
+  });
+});

--- a/packages/software-factory/tests/lint-validation.spec.ts
+++ b/packages/software-factory/tests/lint-validation.spec.ts
@@ -1,0 +1,134 @@
+import { resolve } from 'node:path';
+
+import { expect, test } from './fixtures';
+
+import {
+  lintFile,
+  readFile,
+  writeFile,
+  waitForRealmFile,
+} from '../src/realm-operations';
+import { LintValidationStep } from '../src/validators/lint-step';
+import type { LintValidationDetails } from '../src/validators/lint-step';
+
+const fixtureRealmDir = resolve(
+  process.cwd(),
+  'test-fixtures',
+  'test-realm-runner',
+);
+
+// A .gts file with a lint violation that can't be auto-fixed.
+// The `no-unused-vars` rule flags `unusedVar` and auto-fix cannot remove it.
+const BAD_LINT_GTS = `import {
+  CardDef,
+} from 'https://cardstack.com/base/card-api';
+
+let unusedVar = 42;
+
+export class BadCard extends CardDef {}
+`;
+
+test.use({ realmDir: fixtureRealmDir });
+test.use({ realmServerMode: 'isolated' });
+
+test.describe('lint-validation e2e', () => {
+  test('lintFile() realm API: clean file returns no errors', async ({
+    realm,
+  }) => {
+    let realmUrl = realm.realmURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+
+    // Read the existing hello.gts from the fixture realm
+    let readResult = await readFile(realmUrl, 'hello.gts', { authorization });
+    expect(readResult.ok).toBe(true);
+    expect(readResult.content).toBeTruthy();
+
+    let lintResult = await lintFile(
+      realmUrl,
+      readResult.content!,
+      'hello.gts',
+      { authorization },
+    );
+
+    // The fixture's hello.gts should be clean
+    let errors = lintResult.messages.filter((m) => m.severity === 2);
+    expect(errors).toEqual([]);
+  });
+
+  test('lintFile() realm API: file with violations returns lint messages', async ({
+    realm,
+  }) => {
+    let realmUrl = realm.realmURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+
+    // Write a file with lint issues
+    let writeResult = await writeFile(realmUrl, 'bad-lint.gts', BAD_LINT_GTS, {
+      authorization,
+    });
+    expect(writeResult.ok).toBe(true);
+
+    let indexed = await waitForRealmFile(realmUrl, 'bad-lint.gts', {
+      authorization,
+      pollMs: 300,
+      timeoutMs: 30_000,
+    });
+    expect(indexed).toBe(true);
+
+    let lintResult = await lintFile(realmUrl, BAD_LINT_GTS, 'bad-lint.gts', {
+      authorization,
+    });
+
+    // Should have at least one error (unused variable)
+    let errors = lintResult.messages.filter((m) => m.severity === 2);
+    expect(errors.length).toBeGreaterThan(0);
+
+    // Verify the message shape
+    let firstError = errors[0];
+    expect(firstError.message).toBeTruthy();
+    expect(firstError.line).toBeGreaterThan(0);
+    expect(typeof firstError.severity).toBe('number');
+  });
+
+  test('LintValidationStep e2e: runs lint against realm and returns structured result', async ({
+    realm,
+  }) => {
+    let realmUrl = realm.realmURL.href;
+    let realmServerUrl = realm.realmServerURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let lintResultsModuleUrl = `${realmServerUrl}software-factory/lint-result`;
+
+    let step = new LintValidationStep({
+      authorization,
+      fetch: globalThis.fetch,
+      realmServerUrl,
+      lintResultsModuleUrl,
+      issueId: 'Issues/lint-e2e',
+    });
+
+    let result = await step.run(realmUrl);
+
+    // The fixture realm has hello.gts and hello.test.gts — both lintable.
+    // hello.gts should be clean; result should reflect that.
+    expect(result.step).toBe('lint');
+    expect(result.files).toBeTruthy();
+    expect(result.files!.length).toBeGreaterThan(0);
+
+    // Verify we get the details shape
+    let details = result.details as unknown as LintValidationDetails;
+    expect(details).toBeTruthy();
+    expect(details.lintResultId).toContain('Validations/lint_lint-e2e');
+    expect(details.filesChecked).toBeGreaterThan(0);
+
+    // Read back the LintResult card from the realm to verify it was persisted
+    let cardRead = await readFile(realmUrl, details.lintResultId, {
+      authorization,
+    });
+    expect(cardRead.ok).toBe(true);
+
+    let attrs = cardRead.document?.data.attributes;
+    expect(attrs).toBeTruthy();
+    expect(['passed', 'failed']).toContain(attrs?.status);
+    expect(attrs?.sequenceNumber).toBe(1);
+    expect(attrs?.completedAt).toBeTruthy();
+  });
+});

--- a/packages/software-factory/tests/test-step.test.ts
+++ b/packages/software-factory/tests/test-step.test.ts
@@ -147,7 +147,7 @@ module('TestValidationStep', function () {
       makeConfig({
         fetchFilenames: makeFetchFilenames(['hello.gts', 'hello.test.gts']),
         executeTestRun: makeExecuteTestRun({
-          testRunId: 'Test Runs/validation-1',
+          testRunId: 'Validations/test_validation-1',
           status: 'passed',
           sequenceNumber: 1,
         }),
@@ -163,7 +163,7 @@ module('TestValidationStep', function () {
     assert.ok(result.details, 'has details');
 
     let details = result.details as unknown as TestValidationDetails;
-    assert.strictEqual(details.testRunId, 'Test Runs/validation-1');
+    assert.strictEqual(details.testRunId, 'Validations/test_validation-1');
     assert.strictEqual(details.passedCount, 3);
     assert.strictEqual(details.failedCount, 0);
     assert.strictEqual(details.failures.length, 0);
@@ -196,7 +196,7 @@ module('TestValidationStep', function () {
       makeConfig({
         fetchFilenames: makeFetchFilenames(['hello.test.gts']),
         executeTestRun: makeExecuteTestRun({
-          testRunId: 'Test Runs/validation-1',
+          testRunId: 'Validations/test_validation-1',
           status: 'failed',
           sequenceNumber: 1,
         }),
@@ -256,7 +256,7 @@ module('TestValidationStep', function () {
         executeTestRun: async (options) => {
           capturedOptions.push(options);
           return {
-            testRunId: `Test Runs/validation-${capturedOptions.length}`,
+            testRunId: `Validations/test_validation-${capturedOptions.length}`,
             status: 'passed' as const,
             sequenceNumber: capturedOptions.length,
           };
@@ -284,7 +284,7 @@ module('TestValidationStep', function () {
       makeConfig({
         fetchFilenames: makeFetchFilenames(['hello.test.gts']),
         executeTestRun: makeExecuteTestRun({
-          testRunId: 'Test Runs/validation-1',
+          testRunId: 'Validations/test_validation-1',
           status: 'failed',
           errorMessage: '2 tests failed',
           sequenceNumber: 1,
@@ -309,7 +309,7 @@ module('TestValidationStep', function () {
       passed: true,
       errors: [],
       details: {
-        testRunId: 'Test Runs/validation-1',
+        testRunId: 'Validations/test_validation-1',
         passedCount: 5,
         failedCount: 0,
         skippedCount: 0,
@@ -335,7 +335,7 @@ module('TestValidationStep', function () {
       passed: true,
       errors: [],
       details: {
-        testRunId: 'Test Runs/validation-1',
+        testRunId: 'Validations/test_validation-1',
         passedCount: 3,
         failedCount: 0,
         skippedCount: 2,
@@ -358,7 +358,7 @@ module('TestValidationStep', function () {
       passed: false,
       errors: [{ message: 'shows author: Expected Alice but got empty' }],
       details: {
-        testRunId: 'Test Runs/validation-1',
+        testRunId: 'Validations/test_validation-1',
         passedCount: 2,
         failedCount: 1,
         skippedCount: 0,
@@ -389,7 +389,7 @@ module('TestValidationStep', function () {
       passed: false,
       errors: [{ message: 'shows author: Expected Alice but got empty' }],
       details: {
-        testRunId: 'Test Runs/validation-1',
+        testRunId: 'Validations/test_validation-1',
         passedCount: 2,
         failedCount: 1,
         skippedCount: 3,
@@ -433,7 +433,7 @@ module('TestValidationStep', function () {
         executeTestRun: async (options) => {
           capturedOptions = options;
           return {
-            testRunId: 'Test Runs/sticky-note-define-core-1',
+            testRunId: 'Validations/test_sticky-note-define-core-1',
             status: 'passed' as const,
             sequenceNumber: 1,
           };

--- a/packages/software-factory/tests/validation-pipeline.test.ts
+++ b/packages/software-factory/tests/validation-pipeline.test.ts
@@ -207,8 +207,9 @@ module('ValidationPipeline', function () {
       realmServerUrl: 'https://example.test/',
       hostAppUrl: 'https://example.test/',
       testResultsModuleUrl: 'https://example.test/test-results',
-      // Inject a fetchFilenames that returns no test files so the test
-      // step returns "nothing to validate" without hitting a real realm
+      lintResultsModuleUrl: 'https://example.test/lint-result',
+      // Inject a fetchFilenames that returns no files so the test and lint
+      // steps return "nothing to validate" without hitting a real realm
       fetchFilenames: async () => ({ filenames: [] }),
     });
 


### PR DESCRIPTION
## Summary

- Replace `NoOpStepRunner('lint')` with a real `LintValidationStep` that calls the realm's `_lint` endpoint (ESLint + Prettier + `@cardstack/boxel` rules) on all `.gts`, `.gjs`, `.ts`, `.js` files
- Create `LintResult` card definition with fitted/embedded/isolated templates (styled like `TestRun`), including running state
- Rename `Test Runs/` directory to `Validations/` with type-prefixed naming (`test_{slug}-{seq}`, `lint_{slug}-{seq}`)
- Make `Validator.formatForContext()` required and the sole path for validation results reaching the LLM — update iterate prompt template to use generic `validationContext` block
- Deprecate Phase 1 `AgentContext.testResults` / `TestResult` in favor of `validationResults` + `validationContext`

## Test plan

- [x] 358/358 QUnit unit tests pass (including 12 new lint-step tests)
- [x] 3/3 new Playwright E2E tests pass against real realm server (clean file, violation file, full step with card verification)
- [x] 3/3 existing test-realm Playwright tests pass (validates `Validations/test_` rename)
- [x] `pnpm lint` passes (js, format, types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)