### PR TITLE
Add non-URL identifier types and utilities to process

### DIFF
--- a/packages/realm-server/tests/card-reference-resolver-test.ts
+++ b/packages/realm-server/tests/card-reference-resolver-test.ts
@@ -279,39 +279,27 @@ module(basename(__filename), function () {
     // --- Absolute references (return as-is) ---
 
     test('absolute scoped identifier without relativeTo', function (assert) {
-      let result = resolveRRI(
-        '@cardstack/base/string',
-      );
+      let result = resolveRRI('@cardstack/base/string');
       assert.strictEqual(result, '@cardstack/base/string');
     });
 
     test('absolute scoped identifier with relativeTo is returned as-is', function (assert) {
-      let result = resolveRRI(
-        '@cardstack/base/string',
-        catalogPrefix,
-      );
+      let result = resolveRRI('@cardstack/base/string', catalogPrefix);
       assert.strictEqual(result, '@cardstack/base/string');
     });
 
     test('absolute HTTP URL without relativeTo', function (assert) {
-      let result = resolveRRI(
-        'http://localhost:4201/realm/card',
-      );
+      let result = resolveRRI('http://localhost:4201/realm/card');
       assert.strictEqual(result, 'http://localhost:4201/realm/card');
     });
 
     test('absolute HTTP URL with relativeTo is returned as-is', function (assert) {
-      let result = resolveRRI(
-        'http://localhost:4201/realm/card',
-        basePrefix,
-      );
+      let result = resolveRRI('http://localhost:4201/realm/card', basePrefix);
       assert.strictEqual(result, 'http://localhost:4201/realm/card');
     });
 
     test('absolute HTTPS URL is returned as-is', function (assert) {
-      let result = resolveRRI(
-        'https://example.com/card/123',
-      );
+      let result = resolveRRI('https://example.com/card/123');
       assert.strictEqual(result, 'https://example.com/card/123');
     });
 

--- a/packages/realm-server/tests/card-reference-resolver-test.ts
+++ b/packages/realm-server/tests/card-reference-resolver-test.ts
@@ -546,9 +546,7 @@ module(basename(__filename), function () {
     });
 
     module('constructed from RealmIdentifier', function () {
-      let paths = new RealmPaths(
-        '@cardstack/base/' as RealmIdentifier,
-      );
+      let paths = new RealmPaths('@cardstack/base/' as RealmIdentifier);
 
       test('realmId returns the scoped identifier', function (assert) {
         assert.strictEqual(paths.realmId, '@cardstack/base/');
@@ -568,9 +566,7 @@ module(basename(__filename), function () {
 
       test('inRealmRRI matches realm root without trailing slash', function (assert) {
         assert.true(
-          paths.inRealmRRI(
-            '@cardstack/base' as RealmResourceIdentifier,
-          ),
+          paths.inRealmRRI('@cardstack/base' as RealmResourceIdentifier),
         );
       });
 

--- a/packages/realm-server/tests/card-reference-resolver-test.ts
+++ b/packages/realm-server/tests/card-reference-resolver-test.ts
@@ -403,22 +403,14 @@ module(basename(__filename), function () {
 
     test('throws for absolute path prefix', function (assert) {
       assert.throws(
-        () =>
-          resolveRRI(
-            '/string' as RealmResourceIdentifier,
-            basePrefix,
-          ),
+        () => resolveRRI('/string' as RealmResourceIdentifier, basePrefix),
         /"\/" and "~\/" prefixes are not supported/,
       );
     });
 
     test('throws for tilde-slash prefix', function (assert) {
       assert.throws(
-        () =>
-          resolveRRI(
-            '~/card' as RealmResourceIdentifier,
-            basePrefix,
-          ),
+        () => resolveRRI('~/card' as RealmResourceIdentifier, basePrefix),
         /"\/" and "~\/" prefixes are not supported/,
       );
     });
@@ -459,5 +451,4 @@ module(basename(__filename), function () {
       );
     });
   });
-
 });

--- a/packages/realm-server/tests/card-reference-resolver-test.ts
+++ b/packages/realm-server/tests/card-reference-resolver-test.ts
@@ -600,6 +600,34 @@ module(basename(__filename), function () {
           '@cardstack/base/fields/',
         );
       });
+
+      test('fileURL throws for scoped RealmIdentifier', function (assert) {
+        assert.throws(
+          () => paths.fileURL('card-api'),
+          /fileURL\(\) requires a URL-based RealmPaths/,
+        );
+      });
+
+      test('directoryURL throws for scoped RealmIdentifier', function (assert) {
+        assert.throws(
+          () => paths.directoryURL('fields'),
+          /directoryURL\(\) requires a URL-based RealmPaths/,
+        );
+      });
+
+      test('inRealm throws for scoped RealmIdentifier', function (assert) {
+        assert.throws(
+          () => paths.inRealm(new URL('http://example.com/foo')),
+          /inRealm\(\) requires a URL-based RealmPaths/,
+        );
+      });
+
+      test('local throws for scoped RealmIdentifier', function (assert) {
+        assert.throws(
+          () => paths.local(new URL('http://example.com/foo')),
+          /local\(\) requires a URL-based RealmPaths/,
+        );
+      });
     });
   });
 });

--- a/packages/realm-server/tests/card-reference-resolver-test.ts
+++ b/packages/realm-server/tests/card-reference-resolver-test.ts
@@ -5,10 +5,12 @@ import {
   unregisterCardReferencePrefix,
   resolveCardReference,
   resolveRRI,
+  RealmPaths,
 } from '@cardstack/runtime-common';
 import type {
   SingleCardDocument,
   RealmResourceIdentifier,
+  RealmIdentifier,
 } from '@cardstack/runtime-common';
 import { relativizeDocument } from '@cardstack/runtime-common/realm-index-query-engine';
 
@@ -449,6 +451,159 @@ module(basename(__filename), function () {
         () => resolveRRI('card' as RealmResourceIdentifier),
         /Cannot resolve "card" without a relativeTo/,
       );
+    });
+  });
+
+  module('RealmPaths RRI methods', function () {
+    module('constructed from URL', function () {
+      let paths = new RealmPaths(new URL('http://localhost:4201/base/'));
+
+      test('realmId returns RealmIdentifier', function (assert) {
+        assert.strictEqual(paths.realmId, 'http://localhost:4201/base/');
+      });
+
+      test('inRealmRRI matches resource in realm', function (assert) {
+        assert.true(
+          paths.inRealmRRI(
+            'http://localhost:4201/base/card-api' as RealmResourceIdentifier,
+          ),
+        );
+      });
+
+      test('inRealmRRI matches realm root without trailing slash', function (assert) {
+        assert.true(
+          paths.inRealmRRI(
+            'http://localhost:4201/base' as RealmResourceIdentifier,
+          ),
+        );
+      });
+
+      test('inRealmRRI rejects resource outside realm', function (assert) {
+        assert.false(
+          paths.inRealmRRI(
+            'http://localhost:4201/other/card' as RealmResourceIdentifier,
+          ),
+        );
+      });
+
+      test('localFromRRI strips realm prefix', function (assert) {
+        assert.strictEqual(
+          paths.localFromRRI(
+            'http://localhost:4201/base/Card/my-instance' as RealmResourceIdentifier,
+          ),
+          'Card/my-instance',
+        );
+      });
+
+      test('localFromRRI strips trailing slashes', function (assert) {
+        assert.strictEqual(
+          paths.localFromRRI(
+            'http://localhost:4201/base/directory/' as RealmResourceIdentifier,
+          ),
+          'directory',
+        );
+      });
+
+      test('localFromRRI returns empty string for realm root', function (assert) {
+        assert.strictEqual(
+          paths.localFromRRI(
+            'http://localhost:4201/base/' as RealmResourceIdentifier,
+          ),
+          '',
+        );
+      });
+
+      test('localFromRRI throws for resource outside realm', function (assert) {
+        assert.throws(
+          () =>
+            paths.localFromRRI(
+              'http://localhost:4201/other/card' as RealmResourceIdentifier,
+            ),
+          /does not contain/,
+        );
+      });
+
+      test('fileRRI joins realm prefix and local path', function (assert) {
+        assert.strictEqual(
+          paths.fileRRI('Card/my-instance'),
+          'http://localhost:4201/base/Card/my-instance',
+        );
+      });
+
+      test('directoryRRI joins realm prefix, local path, and trailing slash', function (assert) {
+        assert.strictEqual(
+          paths.directoryRRI('Card'),
+          'http://localhost:4201/base/Card/',
+        );
+      });
+
+      test('directoryRRI returns realm root for empty path', function (assert) {
+        assert.strictEqual(
+          paths.directoryRRI(''),
+          'http://localhost:4201/base/',
+        );
+      });
+    });
+
+    module('constructed from RealmIdentifier', function () {
+      let paths = new RealmPaths(
+        '@cardstack/base/' as RealmIdentifier,
+      );
+
+      test('realmId returns the scoped identifier', function (assert) {
+        assert.strictEqual(paths.realmId, '@cardstack/base/');
+      });
+
+      test('url stores the scoped identifier', function (assert) {
+        assert.strictEqual(paths.url, '@cardstack/base/');
+      });
+
+      test('inRealmRRI matches scoped resource', function (assert) {
+        assert.true(
+          paths.inRealmRRI(
+            '@cardstack/base/card-api' as RealmResourceIdentifier,
+          ),
+        );
+      });
+
+      test('inRealmRRI matches realm root without trailing slash', function (assert) {
+        assert.true(
+          paths.inRealmRRI(
+            '@cardstack/base' as RealmResourceIdentifier,
+          ),
+        );
+      });
+
+      test('inRealmRRI rejects resource in different scope', function (assert) {
+        assert.false(
+          paths.inRealmRRI(
+            '@cardstack/catalog/card' as RealmResourceIdentifier,
+          ),
+        );
+      });
+
+      test('localFromRRI strips scoped prefix', function (assert) {
+        assert.strictEqual(
+          paths.localFromRRI(
+            '@cardstack/base/Card/my-instance' as RealmResourceIdentifier,
+          ),
+          'Card/my-instance',
+        );
+      });
+
+      test('fileRRI joins scoped prefix and local path', function (assert) {
+        assert.strictEqual(
+          paths.fileRRI('card-api'),
+          '@cardstack/base/card-api',
+        );
+      });
+
+      test('directoryRRI joins scoped prefix, local path, and trailing slash', function (assert) {
+        assert.strictEqual(
+          paths.directoryRRI('fields'),
+          '@cardstack/base/fields/',
+        );
+      });
     });
   });
 });

--- a/packages/realm-server/tests/card-reference-resolver-test.ts
+++ b/packages/realm-server/tests/card-reference-resolver-test.ts
@@ -280,14 +280,14 @@ module(basename(__filename), function () {
 
     test('absolute scoped identifier without relativeTo', function (assert) {
       let result = resolveRRI(
-        '@cardstack/base/string' as RealmResourceIdentifier,
+        '@cardstack/base/string',
       );
       assert.strictEqual(result, '@cardstack/base/string');
     });
 
     test('absolute scoped identifier with relativeTo is returned as-is', function (assert) {
       let result = resolveRRI(
-        '@cardstack/base/string' as RealmResourceIdentifier,
+        '@cardstack/base/string',
         catalogPrefix,
       );
       assert.strictEqual(result, '@cardstack/base/string');
@@ -295,14 +295,14 @@ module(basename(__filename), function () {
 
     test('absolute HTTP URL without relativeTo', function (assert) {
       let result = resolveRRI(
-        'http://localhost:4201/realm/card' as RealmResourceIdentifier,
+        'http://localhost:4201/realm/card',
       );
       assert.strictEqual(result, 'http://localhost:4201/realm/card');
     });
 
     test('absolute HTTP URL with relativeTo is returned as-is', function (assert) {
       let result = resolveRRI(
-        'http://localhost:4201/realm/card' as RealmResourceIdentifier,
+        'http://localhost:4201/realm/card',
         basePrefix,
       );
       assert.strictEqual(result, 'http://localhost:4201/realm/card');
@@ -310,7 +310,7 @@ module(basename(__filename), function () {
 
     test('absolute HTTPS URL is returned as-is', function (assert) {
       let result = resolveRRI(
-        'https://example.com/card/123' as RealmResourceIdentifier,
+        'https://example.com/card/123',
       );
       assert.strictEqual(result, 'https://example.com/card/123');
     });
@@ -319,7 +319,7 @@ module(basename(__filename), function () {
 
     test('dot-slash relative against scoped base', function (assert) {
       let result = resolveRRI(
-        './string' as RealmResourceIdentifier,
+        './string',
         '@cardstack/base/' as RealmResourceIdentifier,
       );
       assert.strictEqual(result, '@cardstack/base/string');
@@ -327,7 +327,7 @@ module(basename(__filename), function () {
 
     test('bare name against scoped base', function (assert) {
       let result = resolveRRI(
-        'card' as RealmResourceIdentifier,
+        'card',
         '@cardstack/base/' as RealmResourceIdentifier,
       );
       assert.strictEqual(result, '@cardstack/base/card');
@@ -335,7 +335,7 @@ module(basename(__filename), function () {
 
     test('dot-dot-slash against scoped base with subdirectory', function (assert) {
       let result = resolveRRI(
-        '../card' as RealmResourceIdentifier,
+        '../card',
         '@cardstack/base/fields/' as RealmResourceIdentifier,
       );
       assert.strictEqual(result, '@cardstack/base/card');
@@ -343,7 +343,7 @@ module(basename(__filename), function () {
 
     test('dot-slash against scoped base without trailing slash', function (assert) {
       let result = resolveRRI(
-        './string' as RealmResourceIdentifier,
+        './string',
         '@cardstack/base/card-api' as RealmResourceIdentifier,
       );
       assert.strictEqual(result, '@cardstack/base/string');
@@ -353,7 +353,7 @@ module(basename(__filename), function () {
 
     test('dot-slash relative against URL base', function (assert) {
       let result = resolveRRI(
-        './card' as RealmResourceIdentifier,
+        './card',
         'http://localhost:4201/realm/' as RealmResourceIdentifier,
       );
       assert.strictEqual(result, 'http://localhost:4201/realm/card');
@@ -361,7 +361,7 @@ module(basename(__filename), function () {
 
     test('dot-dot-slash against URL base with subdirectory', function (assert) {
       let result = resolveRRI(
-        '../card' as RealmResourceIdentifier,
+        '../card',
         'http://localhost:4201/realm/directory/' as RealmResourceIdentifier,
       );
       assert.strictEqual(result, 'http://localhost:4201/realm/card');
@@ -369,7 +369,7 @@ module(basename(__filename), function () {
 
     test('bare name against URL base', function (assert) {
       let result = resolveRRI(
-        'card' as RealmResourceIdentifier,
+        'card',
         'http://localhost:4201/realm/' as RealmResourceIdentifier,
       );
       assert.strictEqual(result, 'http://localhost:4201/realm/card');
@@ -379,7 +379,7 @@ module(basename(__filename), function () {
 
     test('$thisRealm against scoped base', function (assert) {
       let result = resolveRRI(
-        '$thisRealm/string' as RealmResourceIdentifier,
+        '$thisRealm/string',
         '@cardstack/base/fields/number' as RealmResourceIdentifier,
       );
       assert.strictEqual(result, '@cardstack/base/string');
@@ -392,7 +392,7 @@ module(basename(__filename), function () {
       );
       try {
         let result = resolveRRI(
-          '$thisRealm/card' as RealmResourceIdentifier,
+          '$thisRealm/card',
           'https://home.boxel.ai/contact/users/' as RealmResourceIdentifier,
         );
         assert.strictEqual(result, 'https://home.boxel.ai/contact/card');
@@ -405,14 +405,14 @@ module(basename(__filename), function () {
 
     test('throws for absolute path prefix', function (assert) {
       assert.throws(
-        () => resolveRRI('/string' as RealmResourceIdentifier, basePrefix),
+        () => resolveRRI('/string', basePrefix),
         /"\/" and "~\/" prefixes are not supported/,
       );
     });
 
     test('throws for tilde-slash prefix', function (assert) {
       assert.throws(
-        () => resolveRRI('~/card' as RealmResourceIdentifier, basePrefix),
+        () => resolveRRI('~/card', basePrefix),
         /"\/" and "~\/" prefixes are not supported/,
       );
     });
@@ -421,7 +421,7 @@ module(basename(__filename), function () {
       assert.throws(
         () =>
           resolveRRI(
-            '/card' as RealmResourceIdentifier,
+            '/card',
             'http://localhost:4201/realm/directory/' as RealmResourceIdentifier,
           ),
         /"\/" and "~\/" prefixes are not supported/,
@@ -441,14 +441,14 @@ module(basename(__filename), function () {
 
     test('throws when relativeTo is missing for relative reference', function (assert) {
       assert.throws(
-        () => resolveRRI('./foo' as RealmResourceIdentifier),
+        () => resolveRRI('./foo'),
         /Cannot resolve "\.\/foo" without a relativeTo/,
       );
     });
 
     test('throws when relativeTo is missing for bare name', function (assert) {
       assert.throws(
-        () => resolveRRI('card' as RealmResourceIdentifier),
+        () => resolveRRI('card'),
         /Cannot resolve "card" without a relativeTo/,
       );
     });

--- a/packages/realm-server/tests/card-reference-resolver-test.ts
+++ b/packages/realm-server/tests/card-reference-resolver-test.ts
@@ -4,8 +4,12 @@ import {
   registerCardReferencePrefix,
   unregisterCardReferencePrefix,
   resolveCardReference,
+  resolveRRI,
 } from '@cardstack/runtime-common';
-import type { SingleCardDocument } from '@cardstack/runtime-common';
+import type {
+  SingleCardDocument,
+  RealmResourceIdentifier,
+} from '@cardstack/runtime-common';
 import { relativizeDocument } from '@cardstack/runtime-common/realm-index-query-engine';
 
 module(basename(__filename), function () {
@@ -249,4 +253,211 @@ module(basename(__filename), function () {
       }
     });
   });
+
+  module('resolveRRI', function (hooks) {
+    let basePrefix = '@cardstack/base/' as RealmResourceIdentifier;
+    let catalogPrefix = '@cardstack/catalog/' as RealmResourceIdentifier;
+
+    hooks.beforeEach(function () {
+      registerCardReferencePrefix(
+        '@cardstack/base/',
+        'http://localhost:4201/base/',
+      );
+      registerCardReferencePrefix(
+        '@cardstack/catalog/',
+        'http://localhost:4201/catalog/',
+      );
+    });
+
+    hooks.afterEach(function () {
+      unregisterCardReferencePrefix('@cardstack/base/');
+      unregisterCardReferencePrefix('@cardstack/catalog/');
+    });
+
+    // --- Absolute references (return as-is) ---
+
+    test('absolute scoped identifier without relativeTo', function (assert) {
+      let result = resolveRRI(
+        '@cardstack/base/string' as RealmResourceIdentifier,
+      );
+      assert.strictEqual(result, '@cardstack/base/string');
+    });
+
+    test('absolute scoped identifier with relativeTo is returned as-is', function (assert) {
+      let result = resolveRRI(
+        '@cardstack/base/string' as RealmResourceIdentifier,
+        catalogPrefix,
+      );
+      assert.strictEqual(result, '@cardstack/base/string');
+    });
+
+    test('absolute HTTP URL without relativeTo', function (assert) {
+      let result = resolveRRI(
+        'http://localhost:4201/realm/card' as RealmResourceIdentifier,
+      );
+      assert.strictEqual(result, 'http://localhost:4201/realm/card');
+    });
+
+    test('absolute HTTP URL with relativeTo is returned as-is', function (assert) {
+      let result = resolveRRI(
+        'http://localhost:4201/realm/card' as RealmResourceIdentifier,
+        basePrefix,
+      );
+      assert.strictEqual(result, 'http://localhost:4201/realm/card');
+    });
+
+    test('absolute HTTPS URL is returned as-is', function (assert) {
+      let result = resolveRRI(
+        'https://example.com/card/123' as RealmResourceIdentifier,
+      );
+      assert.strictEqual(result, 'https://example.com/card/123');
+    });
+
+    // --- Relative resolution against scoped base ---
+
+    test('dot-slash relative against scoped base', function (assert) {
+      let result = resolveRRI(
+        './string' as RealmResourceIdentifier,
+        '@cardstack/base/' as RealmResourceIdentifier,
+      );
+      assert.strictEqual(result, '@cardstack/base/string');
+    });
+
+    test('bare name against scoped base', function (assert) {
+      let result = resolveRRI(
+        'card' as RealmResourceIdentifier,
+        '@cardstack/base/' as RealmResourceIdentifier,
+      );
+      assert.strictEqual(result, '@cardstack/base/card');
+    });
+
+    test('dot-dot-slash against scoped base with subdirectory', function (assert) {
+      let result = resolveRRI(
+        '../card' as RealmResourceIdentifier,
+        '@cardstack/base/fields/' as RealmResourceIdentifier,
+      );
+      assert.strictEqual(result, '@cardstack/base/card');
+    });
+
+    test('dot-slash against scoped base without trailing slash', function (assert) {
+      let result = resolveRRI(
+        './string' as RealmResourceIdentifier,
+        '@cardstack/base/card-api' as RealmResourceIdentifier,
+      );
+      assert.strictEqual(result, '@cardstack/base/string');
+    });
+
+    // --- Relative resolution against URL base ---
+
+    test('dot-slash relative against URL base', function (assert) {
+      let result = resolveRRI(
+        './card' as RealmResourceIdentifier,
+        'http://localhost:4201/realm/' as RealmResourceIdentifier,
+      );
+      assert.strictEqual(result, 'http://localhost:4201/realm/card');
+    });
+
+    test('dot-dot-slash against URL base with subdirectory', function (assert) {
+      let result = resolveRRI(
+        '../card' as RealmResourceIdentifier,
+        'http://localhost:4201/realm/directory/' as RealmResourceIdentifier,
+      );
+      assert.strictEqual(result, 'http://localhost:4201/realm/card');
+    });
+
+    test('bare name against URL base', function (assert) {
+      let result = resolveRRI(
+        'card' as RealmResourceIdentifier,
+        'http://localhost:4201/realm/' as RealmResourceIdentifier,
+      );
+      assert.strictEqual(result, 'http://localhost:4201/realm/card');
+    });
+
+    // --- $thisRealm resolution ---
+
+    test('$thisRealm against scoped base', function (assert) {
+      let result = resolveRRI(
+        '$thisRealm/string' as RealmResourceIdentifier,
+        '@cardstack/base/fields/number' as RealmResourceIdentifier,
+      );
+      assert.strictEqual(result, '@cardstack/base/string');
+    });
+
+    test('$thisRealm against URL base', function (assert) {
+      registerCardReferencePrefix(
+        '@test/contact/',
+        'https://home.boxel.ai/contact/',
+      );
+      try {
+        let result = resolveRRI(
+          '$thisRealm/card' as RealmResourceIdentifier,
+          'https://home.boxel.ai/contact/users/' as RealmResourceIdentifier,
+        );
+        assert.strictEqual(result, 'https://home.boxel.ai/contact/card');
+      } finally {
+        unregisterCardReferencePrefix('@test/contact/');
+      }
+    });
+
+    // --- Invalid references ---
+
+    test('throws for absolute path prefix', function (assert) {
+      assert.throws(
+        () =>
+          resolveRRI(
+            '/string' as RealmResourceIdentifier,
+            basePrefix,
+          ),
+        /"\/" and "~\/" prefixes are not supported/,
+      );
+    });
+
+    test('throws for tilde-slash prefix', function (assert) {
+      assert.throws(
+        () =>
+          resolveRRI(
+            '~/card' as RealmResourceIdentifier,
+            basePrefix,
+          ),
+        /"\/" and "~\/" prefixes are not supported/,
+      );
+    });
+
+    test('throws for absolute path against URL base', function (assert) {
+      assert.throws(
+        () =>
+          resolveRRI(
+            '/card' as RealmResourceIdentifier,
+            'http://localhost:4201/realm/directory/' as RealmResourceIdentifier,
+          ),
+        /"\/" and "~\/" prefixes are not supported/,
+      );
+    });
+
+    test('throws for tilde-slash against URL base', function (assert) {
+      assert.throws(
+        () =>
+          resolveRRI(
+            '~/card' as RealmResourceIdentifier,
+            'http://localhost:4201/realm/directory/' as RealmResourceIdentifier,
+          ),
+        /"\/" and "~\/" prefixes are not supported/,
+      );
+    });
+
+    test('throws when relativeTo is missing for relative reference', function (assert) {
+      assert.throws(
+        () => resolveRRI('./foo' as RealmResourceIdentifier),
+        /Cannot resolve "\.\/foo" without a relativeTo/,
+      );
+    });
+
+    test('throws when relativeTo is missing for bare name', function (assert) {
+      assert.throws(
+        () => resolveRRI('card' as RealmResourceIdentifier),
+        /Cannot resolve "card" without a relativeTo/,
+      );
+    });
+  });
+
 });

--- a/packages/runtime-common/card-reference-resolver.ts
+++ b/packages/runtime-common/card-reference-resolver.ts
@@ -119,7 +119,7 @@ export function cardIdToURL(id: string): URL {
  * - `/` or `~/` prefixed → throw (not valid RRI forms)
  */
 export function resolveRRI(
-  reference: RealmResourceIdentifier,
+  reference: string,
   relativeTo?: RealmResourceIdentifier,
 ): RealmResourceIdentifier {
   // Absolute URL — already resolved

--- a/packages/runtime-common/card-reference-resolver.ts
+++ b/packages/runtime-common/card-reference-resolver.ts
@@ -3,7 +3,7 @@
  * May be either a scoped identifier (e.g. `@cardstack/base/card-api`)
  * or a full URL (e.g. `https://my-realm.com/cards/person`).
  *
- * Do NOT pass directly to `new URL()` — use `resolveRRI()` (forthcoming).
+ * Do NOT pass directly to `new URL()` — use `resolveCardReference()`.
  */
 export type RealmResourceIdentifier = string & { __rriBrand: unknown };
 

--- a/packages/runtime-common/card-reference-resolver.ts
+++ b/packages/runtime-common/card-reference-resolver.ts
@@ -124,12 +124,12 @@ export function resolveRRI(
 ): RealmResourceIdentifier {
   // Absolute URL — already resolved
   if (reference.startsWith('http://') || reference.startsWith('https://')) {
-    return reference;
+    return reference as RealmResourceIdentifier;
   }
 
   // Starts with a registered prefix — already resolved
   if (isRegisteredPrefix(reference)) {
-    return reference;
+    return reference as RealmResourceIdentifier;
   }
 
   // "/" and "~/" are not valid RRI reference forms

--- a/packages/runtime-common/card-reference-resolver.ts
+++ b/packages/runtime-common/card-reference-resolver.ts
@@ -1,3 +1,23 @@
+/**
+ * A card instance ID, module path, or any resource reference in a realm.
+ * May be either a scoped identifier (e.g. `@cardstack/base/card-api`)
+ * or a full URL (e.g. `https://my-realm.com/cards/person`).
+ *
+ * Do NOT pass directly to `new URL()` — use `resolveRRI()` or
+ * `toNetworkURL()` for safe resolution.
+ */
+export type RealmResourceIdentifier = string & { __rriBrand: unknown };
+
+/**
+ * A realm identifier — always has a trailing slash.
+ * May be either a scoped identifier (e.g. `@cardstack/base/`)
+ * or a full URL (e.g. `https://my-realm.com/foo/`).
+ *
+ * Do NOT pass directly to `new URL()` — use realm-aware utilities
+ * for safe resolution.
+ */
+export type RealmIdentifier = string & { __riBrand: unknown };
+
 const prefixMappings = new Map<string, string>();
 
 export function registerCardReferencePrefix(

--- a/packages/runtime-common/card-reference-resolver.ts
+++ b/packages/runtime-common/card-reference-resolver.ts
@@ -3,8 +3,7 @@
  * May be either a scoped identifier (e.g. `@cardstack/base/card-api`)
  * or a full URL (e.g. `https://my-realm.com/cards/person`).
  *
- * Do NOT pass directly to `new URL()` — use `resolveRRI()` or
- * `toNetworkURL()` for safe resolution.
+ * Do NOT pass directly to `new URL()` — use `resolveRRI()` (forthcoming).
  */
 export type RealmResourceIdentifier = string & { __rriBrand: unknown };
 
@@ -14,7 +13,7 @@ export type RealmResourceIdentifier = string & { __rriBrand: unknown };
  * or a full URL (e.g. `https://my-realm.com/foo/`).
  *
  * Do NOT pass directly to `new URL()` — use realm-aware utilities
- * for safe resolution.
+ * for safe resolution (forthcoming).
  */
 export type RealmIdentifier = string & { __riBrand: unknown };
 

--- a/packages/runtime-common/card-reference-resolver.ts
+++ b/packages/runtime-common/card-reference-resolver.ts
@@ -104,3 +104,95 @@ export function unresolveCardReference(resolvedURL: string): string {
 export function cardIdToURL(id: string): URL {
   return new URL(resolveCardReference(id, undefined));
 }
+
+// ---------------------------------------------------------------------------
+// RRI (RealmResourceIdentifier) resolution — Phase 0 additions
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a reference to an absolute `RealmResourceIdentifier`.
+ *
+ * Resolution rules:
+ * - Absolute URL or registered prefix → return as-is
+ * - Relative (`./`, `../`, bare name) → resolve against `relativeTo`
+ * - `$thisRealm/` → resolve against the realm root of `relativeTo`
+ * - `/` or `~/` prefixed → throw (not valid RRI forms)
+ */
+export function resolveRRI(
+  reference: RealmResourceIdentifier,
+  relativeTo?: RealmResourceIdentifier,
+): RealmResourceIdentifier {
+  // Absolute URL — already resolved
+  if (reference.startsWith('http://') || reference.startsWith('https://')) {
+    return reference;
+  }
+
+  // Starts with a registered prefix — already resolved
+  if (isRegisteredPrefix(reference)) {
+    return reference;
+  }
+
+  // "/" and "~/" are not valid RRI reference forms
+  if (reference.startsWith('/') || reference.startsWith('~/')) {
+    throw new Error(
+      `Invalid RRI reference "${reference}" — "/" and "~/" prefixes are not supported`,
+    );
+  }
+
+  if (!relativeTo) {
+    throw new Error(`Cannot resolve "${reference}" without a relativeTo`);
+  }
+
+  let isUrlRelativeTo =
+    relativeTo.startsWith('http://') || relativeTo.startsWith('https://');
+
+  // $thisRealm/ — resolve against the realm root
+  if (reference.startsWith('$thisRealm/')) {
+    let path = reference.slice('$thisRealm/'.length);
+    if (isUrlRelativeTo) {
+      for (let [, target] of prefixMappings) {
+        if (relativeTo.startsWith(target)) {
+          return new URL(path, target).href as RealmResourceIdentifier;
+        }
+      }
+      throw new Error(
+        `Cannot resolve "$thisRealm/" — no realm root found for "${relativeTo}"`,
+      );
+    }
+    for (let [prefix] of prefixMappings) {
+      if (relativeTo.startsWith(prefix)) {
+        return (
+          prefix.endsWith('/') ? prefix + path : prefix + '/' + path
+        ) as RealmResourceIdentifier;
+      }
+    }
+    throw new Error(
+      `Cannot resolve "${reference}" — relativeTo "${relativeTo}" has no matching prefix mapping`,
+    );
+  }
+
+  // relativeTo is a URL — standard URL resolution
+  if (isUrlRelativeTo) {
+    return new URL(reference, relativeTo).href as RealmResourceIdentifier;
+  }
+
+  // relativeTo starts with a registered prefix — resolve in prefix space
+  // by round-tripping through URL space: prefix→URL, resolve, URL→prefix
+  for (let [prefix, target] of prefixMappings) {
+    if (relativeTo.startsWith(prefix)) {
+      let baseURL = new URL(relativeTo.slice(prefix.length), target);
+      let resolved = new URL(reference, baseURL);
+      // Convert back to scoped form if the resolved URL matches a mapping
+      for (let [p, t] of prefixMappings) {
+        if (resolved.href.startsWith(t)) {
+          return (p + resolved.href.slice(t.length)) as RealmResourceIdentifier;
+        }
+      }
+      return resolved.href as RealmResourceIdentifier;
+    }
+  }
+
+  throw new Error(
+    `Cannot resolve "${reference}" — relativeTo "${relativeTo}" has no matching prefix mapping`,
+  );
+}

--- a/packages/runtime-common/paths.ts
+++ b/packages/runtime-common/paths.ts
@@ -1,11 +1,26 @@
+import type {
+  RealmIdentifier,
+  RealmResourceIdentifier,
+} from './card-reference-resolver';
+
 interface LocalOptions {
   preserveQuerystring?: boolean;
 }
 export class RealmPaths {
   readonly url: string;
 
-  constructor(realmURL: URL) {
-    this.url = ensureTrailingSlash(decodeURI(realmURL.href));
+  constructor(realmURL: URL);
+  constructor(realmId: RealmIdentifier);
+  constructor(realmURLOrId: URL | RealmIdentifier) {
+    if (realmURLOrId instanceof URL) {
+      this.url = ensureTrailingSlash(decodeURI(realmURLOrId.href));
+    } else {
+      this.url = ensureTrailingSlash(realmURLOrId);
+    }
+  }
+
+  get realmId(): RealmIdentifier {
+    return this.url as RealmIdentifier;
   }
 
   local(url: URL, opts: LocalOptions = {}): LocalPath {
@@ -57,6 +72,35 @@ export class RealmPaths {
       decodedHref.startsWith(this.url) ||
       decodedHref.split('?')[0] == this.url.replace(/\/$/, '') // check if url without querystring same as realm url without trailing slash (for detecting root realm urls with missing trailing slash)
     );
+  }
+
+  // ---- RRI-aware methods (Phase 0 — additive, existing methods unchanged) ----
+
+  inRealmRRI(rri: RealmResourceIdentifier): boolean {
+    return (
+      rri.startsWith(this.url) || rri === this.url.replace(/\/$/, '')
+    );
+  }
+
+  localFromRRI(rri: RealmResourceIdentifier): LocalPath {
+    if (!this.inRealmRRI(rri)) {
+      let error = new Error(`realm ${this.url} does not contain ${rri}`);
+      (error as any).status = 404;
+      throw error;
+    }
+    let local = rri.slice(this.url.length);
+    return local.replace(/\/+$/, '');
+  }
+
+  fileRRI(local: LocalPath): RealmResourceIdentifier {
+    return (this.url + local) as RealmResourceIdentifier;
+  }
+
+  directoryRRI(local: LocalPath): RealmResourceIdentifier {
+    if (local === '') {
+      return this.url as RealmResourceIdentifier;
+    }
+    return (this.url + local + '/') as RealmResourceIdentifier;
   }
 }
 

--- a/packages/runtime-common/paths.ts
+++ b/packages/runtime-common/paths.ts
@@ -93,7 +93,16 @@ export class RealmPaths {
   // ---- RRI-aware methods (Phase 0 — additive, existing methods unchanged) ----
 
   inRealmRRI(rri: RealmResourceIdentifier): boolean {
-    return rri.startsWith(this.url) || rri === this.url.replace(/\/$/, '');
+    let decoded: string;
+    try {
+      decoded = decodeURI(rri);
+    } catch {
+      return false;
+    }
+    return (
+      decoded.startsWith(this.url) ||
+      decoded === this.url.replace(/\/$/, '')
+    );
   }
 
   localFromRRI(rri: RealmResourceIdentifier): LocalPath {
@@ -102,7 +111,7 @@ export class RealmPaths {
       (error as any).status = 404;
       throw error;
     }
-    let local = rri.slice(this.url.length);
+    let local = decodeURI(rri).slice(this.url.length);
     return local.replace(/\/+$/, '');
   }
 

--- a/packages/runtime-common/paths.ts
+++ b/packages/runtime-common/paths.ts
@@ -77,9 +77,7 @@ export class RealmPaths {
   // ---- RRI-aware methods (Phase 0 — additive, existing methods unchanged) ----
 
   inRealmRRI(rri: RealmResourceIdentifier): boolean {
-    return (
-      rri.startsWith(this.url) || rri === this.url.replace(/\/$/, '')
-    );
+    return rri.startsWith(this.url) || rri === this.url.replace(/\/$/, '');
   }
 
   localFromRRI(rri: RealmResourceIdentifier): LocalPath {

--- a/packages/runtime-common/paths.ts
+++ b/packages/runtime-common/paths.ts
@@ -107,12 +107,18 @@ export class RealmPaths {
   }
 
   fileRRI(local: LocalPath): RealmResourceIdentifier {
+    if (this.isURLBased) {
+      return new URL(local, this.url).href as RealmResourceIdentifier;
+    }
     return (this.url + local) as RealmResourceIdentifier;
   }
 
   directoryRRI(local: LocalPath): RealmResourceIdentifier {
     if (local === '') {
       return this.url as RealmResourceIdentifier;
+    }
+    if (this.isURLBased) {
+      return new URL(local + '/', this.url).href as RealmResourceIdentifier;
     }
     return (this.url + local + '/') as RealmResourceIdentifier;
   }

--- a/packages/runtime-common/paths.ts
+++ b/packages/runtime-common/paths.ts
@@ -23,7 +23,20 @@ export class RealmPaths {
     return this.url as RealmIdentifier;
   }
 
+  private get isURLBased(): boolean {
+    return this.url.startsWith('http://') || this.url.startsWith('https://');
+  }
+
+  private assertURLBased(method: string): void {
+    if (!this.isURLBased) {
+      throw new Error(
+        `${method}() requires a URL-based RealmPaths, but this instance was constructed from a scoped RealmIdentifier ("${this.url}"). Use the RRI-aware methods instead (e.g. fileRRI, directoryRRI, localFromRRI, inRealmRRI).`,
+      );
+    }
+  }
+
   local(url: URL, opts: LocalOptions = {}): LocalPath {
+    this.assertURLBased('local');
     if (!this.inRealm(url)) {
       let error = new Error(`realm ${this.url} does not contain ${url.href}`);
       (error as any).status = 404;
@@ -47,10 +60,12 @@ export class RealmPaths {
   }
 
   fileURL(local: LocalPath): URL {
+    this.assertURLBased('fileURL');
     return new URL(local, this.url);
   }
 
   directoryURL(local: LocalPath): URL {
+    this.assertURLBased('directoryURL');
     if (local === '') {
       // this preserves a root that is not at the origin of the URL
       return new URL(this.url);
@@ -59,6 +74,7 @@ export class RealmPaths {
   }
 
   inRealm(url: URL): boolean {
+    this.assertURLBased('inRealm');
     let decodedHref: string;
     try {
       decodedHref = decodeURI(url.href);

--- a/packages/runtime-common/paths.ts
+++ b/packages/runtime-common/paths.ts
@@ -100,8 +100,7 @@ export class RealmPaths {
       return false;
     }
     return (
-      decoded.startsWith(this.url) ||
-      decoded === this.url.replace(/\/$/, '')
+      decoded.startsWith(this.url) || decoded === this.url.replace(/\/$/, '')
     );
   }
 


### PR DESCRIPTION
This is a very simple beginning of a multi-phase plan toward migrating `http://cardstack.com/base` to `@cardstack/base`: branded strings to use as resource and realm identifiers, a resolution function, and support in `RealmPaths` to handle them. No functionality is changed.

See the tests for an enumeration of how a `RealmResourceIdentifier` can be split into `RealmIdentifier` and a path within a realm with an optional relative identifier, including a new `$thisRealm/whatever` concept borrowed from the query language to bypass the ambiguity of `/`.