### PR TITLE
Implement module evaluation validation step (CS-10715)

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -417,6 +417,18 @@ export class VisitCardsInput extends CardDef {
   @field commandRef = contains(CodeRefField);
 }
 
+export class EvaluateModuleInput extends CardDef {
+  @field moduleUrl = contains(StringField);
+  @field realmUrl = contains(StringField);
+}
+
+export class EvaluateModuleResult extends CardDef {
+  @field passed = contains(BooleanField);
+  @field error = contains(StringField);
+  @field stackTrace = contains(StringField);
+  @field deps = containsMany(StringField);
+}
+
 export class JsonCard extends CardDef {
   @field json = contains(JsonField);
 }

--- a/packages/host/.gitignore
+++ b/packages/host/.gitignore
@@ -23,3 +23,6 @@
 
 # broccoli-debug
 /DEBUG/
+
+# playwright
+/test-results/

--- a/packages/host/app/commands/evaluate-module.ts
+++ b/packages/host/app/commands/evaluate-module.ts
@@ -32,9 +32,14 @@ export default class EvaluateModuleCommand extends HostBaseCommand<
     input: BaseCommandModule.EvaluateModuleInput,
   ): Promise<BaseCommandModule.EvaluateModuleResult> {
     let moduleUrl = input.moduleUrl;
+    let realmUrl = input.realmUrl;
 
     if (!moduleUrl) {
       throw new Error('moduleUrl is required');
+    }
+
+    if (realmUrl) {
+      this.validateModuleUrl(moduleUrl, realmUrl);
     }
 
     let commandModule = await this.loadCommandModule();
@@ -54,5 +59,52 @@ export default class EvaluateModuleCommand extends HostBaseCommand<
         stackTrace: stack,
       });
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // URL validation helpers (SSRF prevention)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Ensures moduleUrl is an http(s) URL that lives under the given realmUrl.
+   * Throws if validation fails.
+   */
+  private validateModuleUrl(moduleUrl: string, realmUrl: string): void {
+    this.assertHttpOrHttpsUrl(moduleUrl, 'moduleUrl');
+    this.assertHttpOrHttpsUrl(realmUrl, 'realmUrl');
+
+    let mod = new URL(moduleUrl);
+    let realm = new URL(realmUrl);
+
+    if (mod.origin !== realm.origin) {
+      throw new Error(
+        `moduleUrl origin (${mod.origin}) does not match realmUrl origin (${realm.origin})`,
+      );
+    }
+
+    let realmPath = this.normalizeRealmPathname(realm.pathname);
+    if (!mod.pathname.startsWith(realmPath)) {
+      throw new Error(
+        `moduleUrl path (${mod.pathname}) is not under realmUrl path (${realmPath})`,
+      );
+    }
+  }
+
+  private assertHttpOrHttpsUrl(value: string, label: string): void {
+    let url: URL;
+    try {
+      url = new URL(value);
+    } catch {
+      throw new Error(`${label} is not a valid URL: ${value}`);
+    }
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      throw new Error(
+        `${label} must use http or https scheme, got ${url.protocol}`,
+      );
+    }
+  }
+
+  private normalizeRealmPathname(pathname: string): string {
+    return pathname.endsWith('/') ? pathname : `${pathname}/`;
   }
 }

--- a/packages/host/app/commands/evaluate-module.ts
+++ b/packages/host/app/commands/evaluate-module.ts
@@ -1,0 +1,58 @@
+/**
+ * Host command that evaluates a .gts module by importing it via the Loader.
+ * Runs in the prerenderer's headless Chrome — the sandbox for untrusted code.
+ *
+ * Uses `loader.import()` to load the module. If the module or any of its
+ * dependencies fail to load, the Loader throws (the module transitions to
+ * 'broken' state). This catches compile errors, runtime evaluation crashes,
+ * strict-mode template errors, and broken imports (when the import is consumed).
+ *
+ * Used by the software-factory's EvalValidationStep via `_run-command`.
+ */
+
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
+
+import HostBaseCommand from '../lib/host-base-command';
+
+export default class EvaluateModuleCommand extends HostBaseCommand<
+  typeof BaseCommandModule.EvaluateModuleInput,
+  typeof BaseCommandModule.EvaluateModuleResult
+> {
+  description = 'Evaluate a .gts module via the Loader in the prerenderer';
+  static actionVerb = 'Evaluate';
+
+  async getInputType() {
+    let commandModule = await this.loadCommandModule();
+    return commandModule.EvaluateModuleInput;
+  }
+
+  requireInputFields = ['moduleUrl'];
+
+  protected async run(
+    input: BaseCommandModule.EvaluateModuleInput,
+  ): Promise<BaseCommandModule.EvaluateModuleResult> {
+    let moduleUrl = input.moduleUrl;
+
+    if (!moduleUrl) {
+      throw new Error('moduleUrl is required');
+    }
+
+    let commandModule = await this.loadCommandModule();
+
+    try {
+      let loader = this.loaderService.loader;
+      await loader.import(moduleUrl);
+
+      return new commandModule.EvaluateModuleResult({ passed: true });
+    } catch (error: any) {
+      let message = error?.message ?? String(error);
+      let stack = error?.stack;
+
+      return new commandModule.EvaluateModuleResult({
+        passed: false,
+        error: message,
+        stackTrace: stack,
+      });
+    }
+  }
+}

--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -9,7 +9,6 @@ import * as CreateListingPRRequestCommandModule from './bot-requests/create-list
 import * as SendBotTriggerEventCommandModule from './bot-requests/send-bot-trigger-event';
 import * as CancelIndexingJobCommandModule from './cancel-indexing-job';
 import * as CheckCorrectnessCommandModule from './check-correctness';
-import * as EvaluateModuleCommandModule from './evaluate-module';
 import * as CopyAndEditCommandModule from './copy-and-edit';
 import * as CopyCardToRealmModule from './copy-card';
 import * as CopyCardToStackCommandModule from './copy-card-to-stack';
@@ -19,6 +18,7 @@ import * as CreateAIAssistantRoomCommandModule from './create-ai-assistant-room'
 import * as CreateAndOpenSubmissionWorkflowCard from './create-and-open-submission-workflow-card';
 import * as CreateSpecCommandModule from './create-specs';
 import * as CreateSubmissionWorkflowCommandModule from './create-submission-workflow';
+import * as EvaluateModuleCommandModule from './evaluate-module';
 import * as FullReindexRealmCommandModule from './full-reindex-realm';
 import * as GenerateExampleCardsCommandModule from './generate-example-cards';
 import * as GenerateReadmeSpecCommandModule from './generate-readme-spec';

--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -9,6 +9,7 @@ import * as CreateListingPRRequestCommandModule from './bot-requests/create-list
 import * as SendBotTriggerEventCommandModule from './bot-requests/send-bot-trigger-event';
 import * as CancelIndexingJobCommandModule from './cancel-indexing-job';
 import * as CheckCorrectnessCommandModule from './check-correctness';
+import * as EvaluateModuleCommandModule from './evaluate-module';
 import * as CopyAndEditCommandModule from './copy-and-edit';
 import * as CopyCardToRealmModule from './copy-card';
 import * as CopyCardToStackCommandModule from './copy-card-to-stack';
@@ -127,6 +128,10 @@ export function shimHostCommands(virtualNetwork: VirtualNetwork) {
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/check-correctness',
     CheckCorrectnessCommandModule,
+  );
+  virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/evaluate-module',
+    EvaluateModuleCommandModule,
   );
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/cancel-indexing-job',
@@ -462,6 +467,7 @@ export const HostCommandClasses: (typeof HostBaseCommand<any, any>)[] = [
   UnregisterBotCommandModule.default,
   CancelIndexingJobCommandModule.default,
   CheckCorrectnessCommandModule.default,
+  EvaluateModuleCommandModule.default,
   UpdateCodePathWithSelectionCommandModule.default,
   UpdatePlaygroundSelectionCommandModule.default,
   UpdateRoomSkillsCommandModule.default,

--- a/packages/host/tests/integration/commands/evaluate-module-test.gts
+++ b/packages/host/tests/integration/commands/evaluate-module-test.gts
@@ -85,10 +85,5 @@ module('Integration | commands | evaluate-module', function (hooks) {
 
     assert.false(result.passed, 'broken import module should fail');
     assert.ok(result.error, 'should have an error message');
-    console.log('BROKEN IMPORT RESULT:', {
-      passed: result.passed,
-      error: result.error,
-      exports: Object.keys(result),
-    });
   });
 });

--- a/packages/host/tests/integration/commands/evaluate-module-test.gts
+++ b/packages/host/tests/integration/commands/evaluate-module-test.gts
@@ -1,0 +1,94 @@
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import EvaluateModuleCommand from '@cardstack/host/commands/evaluate-module';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  testRealmURL,
+  setupRealmCacheTeardown,
+  withCachedRealmSetup,
+} from '../../helpers';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+const VALID_MODULE = `
+  import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
+  import StringField from "https://cardstack.com/base/string";
+  export class ValidCard extends CardDef {
+    static displayName = 'Valid Card';
+    @field name = contains(StringField);
+  }
+`;
+
+const BROKEN_IMPORT_MODULE = `
+  import { CardDef, field, contains } from "https://cardstack.com/base/card-api";
+  import { Foo } from "./does-not-exist";
+  export class BrokenImportCard extends CardDef {
+    static displayName = 'Broken Import Card';
+    @field brokenField = contains(Foo);
+  }
+`;
+
+module('Integration | commands | evaluate-module', function (hooks) {
+  setupRenderingTest(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+  });
+
+  setupRealmCacheTeardown(hooks);
+
+  hooks.beforeEach(async function () {
+    await withCachedRealmSetup(async () => {
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        realmURL: testRealmURL,
+        contents: {
+          'valid-card.gts': VALID_MODULE,
+          'broken-import-card.gts': BROKEN_IMPORT_MODULE,
+        },
+      });
+    });
+  });
+
+  test('valid module passes evaluation', async function (assert) {
+    let commandService = getService('command-service');
+    let command = new EvaluateModuleCommand(commandService.commandContext);
+
+    let InputType = await command.getInputType();
+    let input = new InputType({
+      moduleUrl: `${testRealmURL}valid-card`,
+      realmUrl: testRealmURL,
+    });
+
+    let result = await command.execute(input);
+
+    assert.true(result.passed, 'valid module should pass');
+    assert.notOk(result.error, 'no error for valid module');
+  });
+
+  test('module with broken import fails evaluation', async function (assert) {
+    let commandService = getService('command-service');
+    let command = new EvaluateModuleCommand(commandService.commandContext);
+
+    let InputType = await command.getInputType();
+    let input = new InputType({
+      moduleUrl: `${testRealmURL}broken-import-card`,
+      realmUrl: testRealmURL,
+    });
+
+    let result = await command.execute(input);
+
+    assert.false(result.passed, 'broken import module should fail');
+    assert.ok(result.error, 'should have an error message');
+    console.log('BROKEN IMPORT RESULT:', {
+      passed: result.passed,
+      error: result.error,
+      exports: Object.keys(result),
+    });
+  });
+});

--- a/packages/software-factory/docs/phase-2-plan.md
+++ b/packages/software-factory/docs/phase-2-plan.md
@@ -82,7 +82,8 @@ interface ValidationStepRunner {
 
 - **Test step**: `{ testRunId, passedCount, failedCount, failures: [{ testName, module, message, stackTrace }] }` — reads back the completed TestRun card from the realm for detailed failure data (will become cheap local filesystem reads after boxel-cli integration)
 - **Lint step** (CS-10714): `{ lintResultId, filesChecked, filesWithErrors, totalViolations, violations: [{ rule, file, line, message }] }` — calls the realm's `_lint` endpoint (ESLint + Prettier + `@cardstack/boxel` rules) for each `.gts`, `.gjs`, `.ts`, `.js` file. Creates a `LintResult` card as a persistent artifact.
-- **Future parse/evaluate/instantiate steps**: each defines its own `details` shape
+- **Eval step** (CS-10715): `{ evalResultId, modulesChecked, modulesWithErrors, modules: [{ path, error, stackTrace? }] }` — evaluates each non-test `.gts` module via `_run-command` → `evaluate-module` host command → `/_prerender-module` (prerenderer sandbox). Creates an `EvalResult` card as a persistent artifact. Files matching `*.test.gts` are excluded.
+- **Future parse/instantiate steps**: each defines its own `details` shape
 
 **Adding a new validation step** = creating a new module file in `src/validators/` + replacing the `NoOpStepRunner` in `createDefaultPipeline()`.
 
@@ -92,6 +93,7 @@ All validation artifacts (test runs, lint results, future validation types) are 
 
 - Test runs: `Validations/test_{issue-slug}-{seq}.json` (e.g., `Validations/test_sticky-note-define-core-1.json`)
 - Lint results: `Validations/lint_{issue-slug}-{seq}.json` (e.g., `Validations/lint_sticky-note-define-core-1.json`)
+- Eval results: `Validations/eval_{issue-slug}-{seq}.json` (e.g., `Validations/eval_sticky-note-define-core-1.json`)
 
 Each artifact is a card instance (`TestRun` or `LintResult`) with `linksTo` relationships to the `Issue` and `Project` being validated.
 
@@ -116,6 +118,20 @@ The lint validation step (`src/validators/lint-step.ts`) uses the realm's existi
 4. Collect `messages` from the response where `severity === 2` (errors)
 
 The `LintResult` card definition (`realm/lint-result.gts`) mirrors the `TestRun` card structure with fitted/embedded/isolated templates, a running state, and links to Issue/Project. Card CRUD is in `src/lint-result-cards.ts`.
+
+### Eval Step Details (CS-10715)
+
+The eval validation step (`src/validators/eval-step.ts`) verifies that `.gts` modules load and evaluate without runtime errors. Module evaluation must happen in a sandbox — the prerenderer's headless Chrome — never directly in the factory's Node process. The step chains through three layers: `_run-command` → `evaluate-module` host command (`packages/host/app/commands/evaluate-module.ts`) → `/_prerender-module` endpoint. The prerenderer returns a `ModuleRenderResponse` with `status: 'ready' | 'error'` and structured error details including message and stack trace.
+
+For each non-test `.gts` file discovered in the realm (files matching `*.test.gts` are excluded — test files are the test step's responsibility):
+
+1. Construct the module URL (strip `.gts` extension, resolve against realm URL)
+2. Call the `evaluate-module` host command via `runRealmCommand()`
+3. The host command calls `/_prerender-module` on the realm server
+4. The prerenderer evaluates the module in headless Chrome and returns success/error
+5. Collect errors with module path, error message, and optional stack trace
+
+The `EvalResult` card definition (`realm/eval-result.gts`) follows the same structure as `LintResult` and `TestRun` — fitted/embedded/isolated templates, a running state, and links to Issue/Project. Card CRUD is in `src/eval-result-cards.ts`. Sequence numbers use the shared `getNextValidationSequenceNumber()` from `realm-operations.ts`.
 
 ### Handling Failures
 

--- a/packages/software-factory/realm/eval-result.gts
+++ b/packages/software-factory/realm/eval-result.gts
@@ -1,0 +1,414 @@
+import {
+  CardDef,
+  FieldDef,
+  Component,
+  field,
+  contains,
+  containsMany,
+  linksTo,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+import NumberField from 'https://cardstack.com/base/number';
+import DateTimeField from 'https://cardstack.com/base/datetime';
+import enumField from 'https://cardstack.com/base/enum';
+import { Project, Issue } from './darkfactory';
+
+export const EvalResultStatusField = enumField(StringField, {
+  options: [
+    { value: 'running', label: 'Running' },
+    { value: 'passed', label: 'Passed' },
+    { value: 'failed', label: 'Failed' },
+    { value: 'error', label: 'Error' },
+  ],
+});
+
+export class EvalModuleResult extends FieldDef {
+  static displayName = 'Eval Module Result';
+
+  @field path = contains(StringField);
+  @field error = contains(StringField);
+  @field stackTrace = contains(StringField);
+
+  get hasError() {
+    return !!this.error;
+  }
+
+  static embedded = class Embedded extends Component<typeof EvalModuleResult> {
+    <template>
+      <div class='module-entry'>
+        {{#if @model.hasError}}
+          <span class='status-icon error-icon'>✗</span>
+        {{else}}
+          <span class='status-icon pass-icon'>✓</span>
+        {{/if}}
+        <span class='module-path'>{{@model.path}}</span>
+        {{#if @model.error}}
+          <span class='module-error'>{{@model.error}}</span>
+        {{/if}}
+      </div>
+      <style scoped>
+        .module-entry {
+          display: flex;
+          align-items: baseline;
+          gap: 0.5rem;
+          padding: 0.25rem 0;
+          font-size: 0.85rem;
+        }
+        .status-icon {
+          font-weight: bold;
+          width: 1.25rem;
+          text-align: center;
+          flex-shrink: 0;
+        }
+        .error-icon {
+          color: var(--boxel-red, #dc2626);
+        }
+        .pass-icon {
+          color: var(--boxel-green, #16a34a);
+        }
+        .module-path {
+          color: var(--muted-foreground);
+          font-family: monospace;
+          font-size: 0.8rem;
+          flex-shrink: 0;
+        }
+        .module-error {
+          flex: 1;
+          color: var(--boxel-red, #dc2626);
+        }
+      </style>
+    </template>
+  };
+}
+
+export class EvalResult extends CardDef {
+  static displayName = 'Eval Result';
+
+  @field sequenceNumber = contains(NumberField);
+  @field runAt = contains(DateTimeField);
+  @field completedAt = contains(DateTimeField);
+  @field project = linksTo(() => Project);
+  @field issue = linksTo(() => Issue);
+  @field status = contains(EvalResultStatusField);
+  @field durationMs = contains(NumberField);
+  @field moduleResults = containsMany(EvalModuleResult);
+  @field errorMessage = contains(StringField);
+
+  @field modulesChecked = contains(NumberField, {
+    computeVia: function (this: EvalResult) {
+      return this.moduleResults?.length ?? 0;
+    },
+  });
+
+  @field modulesWithErrors = contains(NumberField, {
+    computeVia: function (this: EvalResult) {
+      return (this.moduleResults ?? []).filter((m) => !!m.error).length;
+    },
+  });
+
+  @field title = contains(StringField, {
+    computeVia: function (this: EvalResult) {
+      let seq = this.sequenceNumber ?? '?';
+      let status = this.status ?? 'unknown';
+      return `EvalResult #${seq} \u2014 ${status}`;
+    },
+  });
+
+  get modulesPassed() {
+    return (this.modulesChecked ?? 0) - (this.modulesWithErrors ?? 0);
+  }
+
+  static fitted = class Fitted extends Component<typeof EvalResult> {
+    get displayStatus() {
+      if (
+        (this.args.model.modulesChecked ?? 0) === 0 &&
+        this.args.model.status === 'passed'
+      ) {
+        return 'empty';
+      }
+      return this.args.model.status;
+    }
+
+    <template>
+      <div class='eval-result compact'>
+        <div class='header'>
+          <strong>#{{@model.sequenceNumber}}</strong>
+          <span
+            class='status status-{{this.displayStatus}}'
+          >{{this.displayStatus}}</span>
+        </div>
+        {{#if @model.issue}}
+          <div class='issue-name'>{{@model.issue.summary}}</div>
+        {{/if}}
+        <div class='counts'>
+          {{@model.modulesPassed}}/{{@model.modulesChecked}}
+          modules passed
+          {{#if @model.modulesWithErrors}}
+            <span class='error-label'>
+              ({{@model.modulesWithErrors}}
+              error(s))
+            </span>
+          {{/if}}
+          {{#if @model.durationMs}}
+            <span class='duration'>{{@model.durationMs}}ms</span>
+          {{/if}}
+        </div>
+      </div>
+      <style scoped>
+        .eval-result {
+          display: grid;
+          gap: 0.25rem;
+        }
+        .compact {
+          padding: 0.75rem;
+          border: 1px solid var(--border);
+          border-radius: 0.5rem;
+          background: var(--card);
+        }
+        .header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        }
+        .status {
+          font-size: 0.75rem;
+          text-transform: uppercase;
+          font-weight: 600;
+          padding: 0.125rem 0.5rem;
+          border-radius: 0.25rem;
+        }
+        .status-passed {
+          color: var(--boxel-green, #16a34a);
+          background: #f0fdf4;
+        }
+        .status-failed {
+          color: var(--boxel-red, #dc2626);
+          background: #fef2f2;
+        }
+        .status-error {
+          color: var(--boxel-orange, #ea580c);
+          background: #fff7ed;
+        }
+        .status-running {
+          color: var(--boxel-blue, #2563eb);
+          background: #eff6ff;
+        }
+        .status-empty {
+          color: var(--boxel-400, #9ca3af);
+          background: #f9fafb;
+        }
+        .issue-name {
+          font-size: 0.8rem;
+          color: var(--muted-foreground);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+        .counts {
+          font-size: 0.85rem;
+          color: var(--muted-foreground);
+        }
+        .error-label {
+          color: var(--boxel-red, #dc2626);
+        }
+        .duration {
+          margin-left: 0.5rem;
+          font-size: 0.75rem;
+        }
+      </style>
+    </template>
+  };
+
+  static embedded = this.fitted;
+
+  static isolated = class Isolated extends Component<typeof EvalResult> {
+    get displayStatus() {
+      if (
+        (this.args.model.modulesChecked ?? 0) === 0 &&
+        this.args.model.status === 'passed'
+      ) {
+        return 'empty';
+      }
+      return this.args.model.status;
+    }
+
+    <template>
+      <article class='surface'>
+        <header>
+          <div class='header-row'>
+            <strong>EvalResult #{{@model.sequenceNumber}}</strong>
+            <span
+              class='status status-{{this.displayStatus}}'
+            >{{this.displayStatus}}</span>
+          </div>
+          <div class='summary'>
+            {{@model.modulesPassed}}/{{@model.modulesChecked}}
+            modules passed
+            {{#if @model.modulesWithErrors}}
+              ,
+              {{@model.modulesWithErrors}}
+              error(s)
+            {{/if}}
+            {{#if @model.durationMs}}
+              in
+              {{@model.durationMs}}ms
+            {{/if}}
+          </div>
+        </header>
+
+        {{#if @model.project}}
+          <section>
+            <h2>Project</h2>
+            <div class='linked-card'>
+              <@fields.project @format='embedded' />
+            </div>
+          </section>
+        {{/if}}
+
+        {{#if @model.issue}}
+          <section>
+            <h2>Issue</h2>
+            <div class='linked-card'>
+              <@fields.issue @format='embedded' />
+            </div>
+          </section>
+        {{/if}}
+
+        {{#if @model.errorMessage}}
+          <section>
+            <h2>Error</h2>
+            <p class='error-message'>{{@model.errorMessage}}</p>
+          </section>
+        {{/if}}
+
+        {{#if @model.moduleResults.length}}
+          <section>
+            <h2>Module Results</h2>
+            {{#each @model.moduleResults as |moduleResult|}}
+              <div
+                class='module-group
+                  {{if moduleResult.hasError "module-has-errors"}}'
+              >
+                <div class='module-group-header'>
+                  <span class='module-group-name'>{{moduleResult.path}}</span>
+                  {{#if moduleResult.hasError}}
+                    <span class='module-group-status has-errors'>error</span>
+                  {{else}}
+                    <span class='module-group-status has-passes'>passed</span>
+                  {{/if}}
+                </div>
+                {{#if moduleResult.error}}
+                  <div class='module-group-error'>
+                    <pre class='error-code-block'>{{moduleResult.error}}</pre>
+                  </div>
+                {{/if}}
+              </div>
+            {{/each}}
+          </section>
+        {{/if}}
+      </article>
+      <style scoped>
+        .surface {
+          padding: 1.5rem;
+          display: grid;
+          gap: 1rem;
+        }
+        .linked-card {
+          margin-bottom: 0.5rem;
+        }
+        .header-row {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        }
+        .status {
+          font-size: 0.75rem;
+          text-transform: uppercase;
+          font-weight: 600;
+          padding: 0.125rem 0.5rem;
+          border-radius: 0.25rem;
+        }
+        .status-passed {
+          color: var(--boxel-green, #16a34a);
+          background: #f0fdf4;
+        }
+        .status-failed {
+          color: var(--boxel-red, #dc2626);
+          background: #fef2f2;
+        }
+        .status-error {
+          color: var(--boxel-orange, #ea580c);
+          background: #fff7ed;
+        }
+        .status-running {
+          color: var(--boxel-blue, #2563eb);
+          background: #eff6ff;
+        }
+        .status-empty {
+          color: var(--boxel-400, #9ca3af);
+          background: #f9fafb;
+        }
+        .summary {
+          font-size: 0.9rem;
+          color: var(--muted-foreground);
+        }
+        .error-message {
+          color: var(--boxel-red, #dc2626);
+          font-family: monospace;
+          font-size: 0.85rem;
+          white-space: pre-wrap;
+        }
+        .module-group {
+          border: 1px solid var(--boxel-200, #e5e7eb);
+          border-radius: 0.5rem;
+          padding: 0.75rem;
+          margin-bottom: 0.75rem;
+        }
+        .module-has-errors {
+          border-color: var(--boxel-red, #dc2626);
+        }
+        .module-group-header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          padding-bottom: 0.5rem;
+          border-bottom: 1px solid var(--boxel-200, #e5e7eb);
+          margin-bottom: 0.5rem;
+        }
+        .module-group-name {
+          font-weight: 600;
+          font-size: 0.9rem;
+          font-family: monospace;
+        }
+        .module-group-status {
+          font-size: 0.8rem;
+          color: var(--boxel-400, #9ca3af);
+        }
+        .module-group-status.has-passes {
+          color: var(--boxel-green, #16a34a);
+        }
+        .module-group-status.has-errors {
+          color: var(--boxel-red, #dc2626);
+        }
+        .module-group-error {
+          padding: 0.5rem;
+        }
+        .error-code-block {
+          color: var(--boxel-red, #dc2626);
+          background: var(--boxel-100, #f3f4f6);
+          border: 1px solid var(--boxel-200, #e5e7eb);
+          border-radius: 0.375rem;
+          padding: 0.75rem;
+          font-family: monospace;
+          font-size: 0.8rem;
+          white-space: pre-wrap;
+          word-break: break-word;
+          max-height: 15rem;
+          overflow-y: auto;
+          margin: 0;
+          line-height: 1.4;
+        }
+      </style>
+    </template>
+  };
+}

--- a/packages/software-factory/scripts/smoke-tests/smoke-test-realm.ts
+++ b/packages/software-factory/scripts/smoke-tests/smoke-test-realm.ts
@@ -329,7 +329,11 @@ async function main() {
 
   let pipeline = createDefaultPipeline({
     authorization,
-    serverToken: authorization,
+    // In this smoke test `authorization` starts as the server token (line 198)
+    // and is later narrowed to a realm-scoped JWT for realm API calls. The
+    // pipeline's `serverToken` must remain the original server-scoped token so
+    // that _run-command (prerenderer) calls succeed.
+    serverToken,
     fetch: fetchImpl,
     realmServerUrl,
     hostAppUrl: realmServerUrl,

--- a/packages/software-factory/scripts/smoke-tests/smoke-test-realm.ts
+++ b/packages/software-factory/scripts/smoke-tests/smoke-test-realm.ts
@@ -322,14 +322,20 @@ async function main() {
     'software-factory/lint-result',
     realmServerUrl,
   ).href;
+  let evalResultsModuleUrl = new URL(
+    'software-factory/eval-result',
+    realmServerUrl,
+  ).href;
 
   let pipeline = createDefaultPipeline({
     authorization,
+    serverToken: authorization,
     fetch: fetchImpl,
     realmServerUrl,
     hostAppUrl: realmServerUrl,
     testResultsModuleUrl,
     lintResultsModuleUrl,
+    evalResultsModuleUrl,
   });
 
   let validationResults = await pipeline.validate(targetRealmUrl);

--- a/packages/software-factory/src/eval-result-cards.ts
+++ b/packages/software-factory/src/eval-result-cards.ts
@@ -1,0 +1,176 @@
+import type { LooseSingleCardDocument } from '@cardstack/runtime-common';
+
+import { readFile, writeFile } from './realm-operations';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface EvalModuleErrorData {
+  path: string;
+  error: string;
+  stackTrace?: string;
+}
+
+export interface EvalResultAttributes {
+  status: 'running' | 'passed' | 'failed' | 'error';
+  durationMs?: number;
+  moduleResults?: EvalModuleErrorData[];
+  errorMessage?: string;
+}
+
+export interface EvalResultRealmOptions {
+  targetRealmUrl: string;
+  authorization?: string;
+  fetch?: typeof globalThis.fetch;
+}
+
+export interface CreateEvalResultOptions {
+  sequenceNumber?: number;
+  issueURL?: string;
+  projectCardUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Card lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an `EvalResult` card with `status: running`.
+ * Returns the card path as the handle.
+ */
+export async function createEvalResult(
+  slug: string,
+  evalResultsModuleUrl: string,
+  options: EvalResultRealmOptions & CreateEvalResultOptions,
+): Promise<{ evalResultId: string; created: boolean; error?: string }> {
+  let seq = options.sequenceNumber ?? 1;
+  let evalResultId = `Validations/eval_${slug}-${seq}`;
+
+  let document = buildEvalResultCardDocument(evalResultsModuleUrl, {
+    sequenceNumber: seq,
+    issueURL: options.issueURL,
+    projectCardUrl: options.projectCardUrl,
+  });
+
+  let result = await writeFile(
+    options.targetRealmUrl,
+    `${evalResultId}.json`,
+    JSON.stringify(document, null, 2),
+    { authorization: options.authorization, fetch: options.fetch },
+  );
+
+  if (!result.ok) {
+    return { evalResultId, created: false, error: result.error };
+  }
+
+  return { evalResultId, created: true };
+}
+
+/**
+ * Update an existing `EvalResult` card with evaluation results and final status.
+ */
+export async function completeEvalResult(
+  evalResultId: string,
+  attrs: EvalResultAttributes,
+  options: EvalResultRealmOptions & { projectCardUrl?: string },
+): Promise<{ updated: boolean; error?: string }> {
+  let fetchOptions = {
+    authorization: options.authorization,
+    fetch: options.fetch,
+  };
+
+  let readResult = await readFile(
+    options.targetRealmUrl,
+    evalResultId,
+    fetchOptions,
+  );
+
+  if (!readResult.ok || !readResult.document) {
+    return {
+      updated: false,
+      error: `Failed to read EvalResult: ${readResult.error}`,
+    };
+  }
+
+  let completionAttrs: Record<string, unknown> = {
+    status: attrs.status,
+    completedAt: new Date().toISOString(),
+    durationMs: attrs.durationMs,
+    moduleResults: attrs.moduleResults,
+  };
+  if (attrs.errorMessage) {
+    completionAttrs.errorMessage = attrs.errorMessage;
+  }
+
+  readResult.document.data.attributes = {
+    ...readResult.document.data.attributes,
+    ...completionAttrs,
+  };
+
+  if (options.projectCardUrl) {
+    let existingRelationships =
+      (readResult.document.data as Record<string, unknown>).relationships ?? {};
+    (readResult.document.data as Record<string, unknown>).relationships = {
+      ...(existingRelationships as Record<string, unknown>),
+      project: { links: { self: options.projectCardUrl } },
+    };
+  }
+
+  let writeResult = await writeFile(
+    options.targetRealmUrl,
+    `${evalResultId}.json`,
+    JSON.stringify(readResult.document, null, 2),
+    fetchOptions,
+  );
+
+  if (!writeResult.ok) {
+    return {
+      updated: false,
+      error: `Failed to update EvalResult: ${writeResult.error}`,
+    };
+  }
+
+  return { updated: true };
+}
+
+/**
+ * Build the initial card document for an EvalResult with `status: running`.
+ */
+export function buildEvalResultCardDocument(
+  evalResultsModuleUrl: string,
+  options?: CreateEvalResultOptions,
+): LooseSingleCardDocument {
+  let attributes: Record<string, unknown> = {
+    sequenceNumber: options?.sequenceNumber ?? 1,
+    runAt: new Date().toISOString(),
+    status: 'running',
+  };
+
+  let relationships:
+    | Record<string, { links: { self: string | null } }>
+    | undefined;
+  if (options?.projectCardUrl || options?.issueURL) {
+    relationships = {};
+    if (options?.projectCardUrl) {
+      relationships.project = { links: { self: options.projectCardUrl } };
+    }
+    if (options?.issueURL) {
+      relationships.issue = { links: { self: options.issueURL } };
+    }
+  }
+
+  return {
+    data: {
+      type: 'card',
+      attributes,
+      ...(relationships ? { relationships } : {}),
+      meta: {
+        adoptsFrom: {
+          module: evalResultsModuleUrl,
+          name: 'EvalResult',
+        },
+      },
+    },
+  } as LooseSingleCardDocument;
+}

--- a/packages/software-factory/src/factory-issue-loop-wiring.ts
+++ b/packages/software-factory/src/factory-issue-loop-wiring.ts
@@ -166,6 +166,10 @@ export async function runFactoryIssueLoop(
     'software-factory/lint-result',
     realmServerUrl,
   ).href;
+  let evalResultsModuleUrl = new URL(
+    'software-factory/eval-result',
+    realmServerUrl,
+  ).href;
   let hostAppUrl = config.hostAppUrl ?? realmServerUrl;
   let toolBuilderConfig: ToolBuilderConfig = {
     targetRealmUrl,
@@ -201,10 +205,12 @@ export async function runFactoryIssueLoop(
     createDefaultPipeline({
       realmServerUrl,
       authorization: config.authorization,
+      serverToken,
       fetch: fetchImpl,
       hostAppUrl,
       testResultsModuleUrl,
       lintResultsModuleUrl,
+      evalResultsModuleUrl,
       issueId,
       fetchFilenames: (realmUrl: string) =>
         fetchRealmFilenames(realmUrl, fetchOptions),

--- a/packages/software-factory/src/harness/shared.ts
+++ b/packages/software-factory/src/harness/shared.ts
@@ -702,6 +702,24 @@ export function buildRealmToken(
   );
 }
 
+/**
+ * Build a JWT for `_run-command` and other server-level endpoints.
+ *
+ * The `_run-command` route uses `jwtMiddleware(args.realmSecretSeed)` which
+ * verifies with `REALM_SECRET_SEED` (not REALM_SERVER_SECRET_SEED). The
+ * middleware only checks for a valid `user` and `sessionRoom` in the payload.
+ */
+export function buildServerToken(user = DEFAULT_REALM_OWNER): string {
+  return jwt.sign(
+    {
+      user,
+      sessionRoom: `software-factory-session-room-for-${user}`,
+    },
+    REALM_SECRET_SEED,
+    { expiresIn: '7d' },
+  );
+}
+
 export function createProcessExitPromise(
   proc: SpawnedProcess,
   label: string,

--- a/packages/software-factory/src/validators/eval-step.ts
+++ b/packages/software-factory/src/validators/eval-step.ts
@@ -1,0 +1,404 @@
+/**
+ * Eval validation step — evaluates .gts modules in the target realm
+ * via the prerenderer sandbox to ensure they load without runtime errors.
+ *
+ * For each non-test `.gts` file discovered in the realm, invokes the
+ * `evaluate-module` host command via `_run-command`. The host command
+ * calls `/_prerender-module` which runs evaluation in headless Chrome.
+ *
+ * Files matching `*.test.gts` are excluded — test files are the
+ * responsibility of the test validation step.
+ */
+
+import type { ValidationStepResult } from '../factory-agent';
+import { deriveIssueSlug } from '../factory-agent-types';
+
+import {
+  fetchRealmFilenames,
+  getNextValidationSequenceNumber,
+  runRealmCommand,
+  type RealmFetchOptions,
+} from '../realm-operations';
+import {
+  createEvalResult,
+  completeEvalResult,
+  type EvalModuleErrorData,
+} from '../eval-result-cards';
+import { logger } from '../logger';
+
+import type { ValidationStepRunner } from './validation-pipeline';
+
+let log = logger('eval-validation-step');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface EvalModuleResult {
+  passed: boolean;
+  error?: string;
+  stackTrace?: string;
+}
+
+export interface EvalValidationStepConfig {
+  /** Realm-scoped authorization token for realm API calls (readFile, writeFile, _search). */
+  authorization?: string;
+  /** Realm server token for _run-command calls (prerenderer). Distinct from realm-scoped authorization. */
+  serverToken?: string;
+  fetch?: typeof globalThis.fetch;
+  realmServerUrl: string;
+  evalResultsModuleUrl: string;
+  issueId?: string;
+  /** Injected for testing — defaults to fetchRealmFilenames. */
+  fetchFilenames?: (
+    realmUrl: string,
+    options?: RealmFetchOptions,
+  ) => Promise<{ filenames: string[]; error?: string }>;
+  /** Injected for testing — defaults to runRealmCommand calling the evaluate-module host command. */
+  evaluateModuleFn?: (
+    moduleUrl: string,
+    realmUrl: string,
+  ) => Promise<EvalModuleResult>;
+  /** Injected for testing — defaults to getNextValidationSequenceNumber. */
+  getNextSequenceNumber?: (
+    slug: string,
+    targetRealmUrl: string,
+  ) => Promise<number>;
+}
+
+/** Flattened POJO for eval validation details — not a card, just data. */
+export interface EvalValidationDetails {
+  evalResultId: string;
+  modulesChecked: number;
+  modulesWithErrors: number;
+  modules: { path: string; error: string; stackTrace?: string }[];
+}
+
+const EVALUATE_MODULE_COMMAND =
+  '@cardstack/boxel-host/commands/evaluate-module/default';
+
+// ---------------------------------------------------------------------------
+// EvalValidationStep
+// ---------------------------------------------------------------------------
+
+export class EvalValidationStep implements ValidationStepRunner {
+  readonly step = 'evaluate' as const;
+
+  private config: EvalValidationStepConfig;
+  private lastSequenceNumber = 0;
+
+  private fetchFilenamesFn: (
+    realmUrl: string,
+    options?: RealmFetchOptions,
+  ) => Promise<{ filenames: string[]; error?: string }>;
+  private evaluateModuleFn: (
+    moduleUrl: string,
+    realmUrl: string,
+  ) => Promise<EvalModuleResult>;
+  private getNextSeqFn: (
+    slug: string,
+    targetRealmUrl: string,
+  ) => Promise<number>;
+
+  constructor(config: EvalValidationStepConfig) {
+    this.config = config;
+    this.fetchFilenamesFn = config.fetchFilenames ?? fetchRealmFilenames;
+    this.evaluateModuleFn =
+      config.evaluateModuleFn ??
+      ((moduleUrl: string, realmUrl: string) =>
+        this.defaultEvaluateModule(moduleUrl, realmUrl));
+    this.getNextSeqFn =
+      config.getNextSequenceNumber ??
+      ((slug: string, targetRealmUrl: string) =>
+        getNextValidationSequenceNumber(
+          slug,
+          'Validations/eval_',
+          config.evalResultsModuleUrl,
+          'EvalResult',
+          {
+            targetRealmUrl,
+            authorization: config.authorization,
+            fetch: config.fetch,
+          },
+        ));
+  }
+
+  async run(targetRealmUrl: string): Promise<ValidationStepResult> {
+    // Step 1: Discover evaluable files
+    let evaluableFiles: string[];
+    try {
+      evaluableFiles = await this.discoverEvaluableFiles(targetRealmUrl);
+    } catch (err) {
+      return {
+        step: 'evaluate',
+        passed: false,
+        errors: [
+          {
+            message: `Failed to discover evaluable files: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        ],
+      };
+    }
+
+    if (evaluableFiles.length === 0) {
+      log.info('No evaluable .gts files found — nothing to validate');
+      return { step: 'evaluate', passed: true, files: [], errors: [] };
+    }
+
+    log.info(
+      `Found ${evaluableFiles.length} evaluable file(s): ${evaluableFiles.join(', ')}`,
+    );
+
+    // Step 2: Create the EvalResult card (status: running)
+    let slug = this.config.issueId
+      ? deriveIssueSlug(this.config.issueId)
+      : 'validation';
+
+    let issueURL = this.config.issueId
+      ? new URL(this.config.issueId, targetRealmUrl).href
+      : undefined;
+
+    let seq: number;
+    try {
+      let realmSeq = await this.getNextSeqFn(slug, targetRealmUrl);
+      seq = Math.max(realmSeq, this.lastSequenceNumber + 1);
+    } catch (err) {
+      log.warn(
+        `Failed to resolve sequence number, using floor: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      seq = this.lastSequenceNumber + 1;
+    }
+
+    let evalResultId: string;
+    let artifactCreated = false;
+    try {
+      let createResult = await createEvalResult(
+        slug,
+        this.config.evalResultsModuleUrl,
+        {
+          targetRealmUrl,
+          authorization: this.config.authorization,
+          fetch: this.config.fetch,
+          sequenceNumber: seq,
+          issueURL,
+        },
+      );
+      evalResultId = createResult.evalResultId;
+      if (!createResult.created) {
+        log.warn(
+          `EvalResult card creation returned created: false: ${createResult.error ?? 'unknown'}`,
+        );
+      } else {
+        artifactCreated = true;
+        this.lastSequenceNumber = seq;
+      }
+    } catch (err) {
+      log.warn(
+        `Failed to create EvalResult card: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      evalResultId = `Validations/eval_${slug}-${seq}`;
+    }
+
+    // Step 3: Evaluate each module via sandbox (_run-command → host command)
+    let startedAt = Date.now();
+    let allModuleResults: EvalModuleErrorData[] = [];
+    let failedModules: EvalValidationDetails['modules'] = [];
+
+    for (let file of evaluableFiles) {
+      let moduleUrl = new URL(
+        file.replace(/\.gts$/, ''),
+        ensureTrailingSlash(targetRealmUrl),
+      ).href;
+
+      try {
+        let result = await this.evaluateModuleFn(moduleUrl, targetRealmUrl);
+
+        allModuleResults.push({
+          path: file,
+          error: result.error ?? '',
+          stackTrace: result.stackTrace,
+        });
+
+        if (!result.passed) {
+          failedModules.push({
+            path: file,
+            error: result.error ?? 'Module evaluation failed',
+            stackTrace: result.stackTrace,
+          });
+        }
+      } catch (err) {
+        let message = `Eval failed: ${err instanceof Error ? err.message : String(err)}`;
+        log.warn(`Error evaluating ${file}: ${message}`);
+        allModuleResults.push({
+          path: file,
+          error: message,
+        });
+        failedModules.push({
+          path: file,
+          error: message,
+        });
+      }
+    }
+
+    let durationMs = Date.now() - startedAt;
+    let passed = failedModules.length === 0;
+
+    // Step 4: Complete the EvalResult card
+    if (artifactCreated) {
+      let completeResult = await completeEvalResult(
+        evalResultId,
+        {
+          status: passed ? 'passed' : 'failed',
+          durationMs,
+          moduleResults: allModuleResults,
+        },
+        {
+          targetRealmUrl,
+          authorization: this.config.authorization,
+          fetch: this.config.fetch,
+        },
+      );
+      if (!completeResult.updated) {
+        log.warn(
+          `Failed to complete EvalResult card ${evalResultId}: ${completeResult.error ?? 'unknown'}`,
+        );
+      }
+    }
+
+    // Step 5: Build result
+    let details: EvalValidationDetails = {
+      evalResultId,
+      modulesChecked: allModuleResults.length,
+      modulesWithErrors: failedModules.length,
+      modules: failedModules,
+    };
+
+    let errors = failedModules.map((m) => ({
+      file: m.path,
+      message: `${m.path}: ${m.error}`,
+    }));
+
+    return {
+      step: 'evaluate',
+      passed,
+      files: evaluableFiles,
+      errors,
+      details: details as unknown as Record<string, unknown>,
+    };
+  }
+
+  formatForContext(result: ValidationStepResult): string {
+    if (result.passed) {
+      let details = result.details as unknown as
+        | EvalValidationDetails
+        | undefined;
+      if (details && details.modulesChecked > 0) {
+        return `## Eval Validation: PASSED\n${details.modulesChecked} module(s) checked, no evaluation errors. (EvalResult: ${details.evalResultId})`;
+      }
+      return '';
+    }
+
+    let details = result.details as unknown as
+      | EvalValidationDetails
+      | undefined;
+    if (!details) {
+      let errorLines = result.errors.map((e) => `- ${e.message}`).join('\n');
+      return `## Eval Validation: FAILED\n${errorLines}`;
+    }
+
+    let lines: string[] = [
+      `## Eval Validation: FAILED`,
+      `${details.modulesChecked} module(s) checked, ${details.modulesWithErrors} module(s) with errors (EvalResult: ${details.evalResultId})`,
+    ];
+
+    for (let mod of details.modules) {
+      lines.push(`  ${mod.path}: ${mod.error}`);
+    }
+
+    return lines.join('\n');
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private async discoverEvaluableFiles(
+    targetRealmUrl: string,
+  ): Promise<string[]> {
+    let result = await this.fetchFilenamesFn(targetRealmUrl, {
+      authorization: this.config.authorization,
+      fetch: this.config.fetch,
+    });
+
+    if (result.error) {
+      log.warn(`Failed to fetch realm filenames: ${result.error}`);
+      throw new Error(result.error);
+    }
+
+    return result.filenames
+      .filter((f) => f.endsWith('.gts') && !f.endsWith('.test.gts'))
+      .sort((a, b) => a.localeCompare(b));
+  }
+
+  /**
+   * Default evaluateModuleFn: calls the evaluate-module host command
+   * via `_run-command` on the realm server.
+   */
+  private async defaultEvaluateModule(
+    moduleUrl: string,
+    realmUrl: string,
+  ): Promise<EvalModuleResult> {
+    let response = await runRealmCommand(
+      this.config.realmServerUrl,
+      realmUrl,
+      EVALUATE_MODULE_COMMAND,
+      { moduleUrl, realmUrl },
+      {
+        authorization: this.config.serverToken,
+        fetch: this.config.fetch,
+      },
+    );
+
+    log.info(
+      `run-command response for ${moduleUrl}: status=${response.status}, error=${response.error}, result=${response.result?.slice(0, 300)}`,
+    );
+
+    if (response.status === 'error') {
+      return {
+        passed: false,
+        error: response.error ?? 'run-command returned error status',
+      };
+    }
+
+    // Parse the cardResultString to extract EvaluateModuleResult fields
+    if (response.result) {
+      try {
+        let cardDoc = JSON.parse(response.result);
+        let attrs = cardDoc?.data?.attributes ?? cardDoc;
+        if (attrs.passed === false) {
+          return {
+            passed: false,
+            error: attrs.error ?? 'Module evaluation failed',
+            stackTrace: attrs.stackTrace,
+          };
+        }
+        return { passed: true };
+      } catch {
+        log.warn(
+          `Failed to parse run-command result for ${moduleUrl}: ${response.result?.slice(0, 200)}`,
+        );
+        return { passed: true };
+      }
+    }
+
+    return { passed: true };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
+function ensureTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url : `${url}/`;
+}

--- a/packages/software-factory/src/validators/eval-step.ts
+++ b/packages/software-factory/src/validators/eval-step.ts
@@ -348,6 +348,13 @@ export class EvalValidationStep implements ValidationStepRunner {
     moduleUrl: string,
     realmUrl: string,
   ): Promise<EvalModuleResult> {
+    if (!this.config.serverToken) {
+      return {
+        passed: false,
+        error: 'serverToken is required for eval validation via _run-command',
+      };
+    }
+
     let response = await runRealmCommand(
       this.config.realmServerUrl,
       realmUrl,
@@ -363,10 +370,11 @@ export class EvalValidationStep implements ValidationStepRunner {
       `run-command response for ${moduleUrl}: status=${response.status}, error=${response.error}, result=${response.result?.slice(0, 300)}`,
     );
 
-    if (response.status === 'error') {
+    if (response.status !== 'ready') {
       return {
         passed: false,
-        error: response.error ?? 'run-command returned error status',
+        error:
+          response.error ?? `run-command returned ${response.status} status`,
       };
     }
 
@@ -387,11 +395,18 @@ export class EvalValidationStep implements ValidationStepRunner {
         log.warn(
           `Failed to parse run-command result for ${moduleUrl}: ${response.result?.slice(0, 200)}`,
         );
-        return { passed: true };
+        return {
+          passed: false,
+          error:
+            'run-command returned an unparsable result — treating as failure',
+        };
       }
     }
 
-    return { passed: true };
+    return {
+      passed: false,
+      error: 'run-command did not return a result — treating as failure',
+    };
   }
 }
 

--- a/packages/software-factory/src/validators/validation-pipeline.ts
+++ b/packages/software-factory/src/validators/validation-pipeline.ts
@@ -18,9 +18,11 @@ import type { Validator } from '../issue-loop';
 import { NoOpStepRunner } from './noop-step';
 import { TestValidationStep } from './test-step';
 import { LintValidationStep } from './lint-step';
+import { EvalValidationStep } from './eval-step';
 
 import type { TestValidationStepConfig } from './test-step';
 import type { LintValidationStepConfig } from './lint-step';
+import type { EvalValidationStepConfig } from './eval-step';
 
 import { logger } from '../logger';
 
@@ -141,14 +143,18 @@ export class ValidationPipeline implements Validator {
 // ---------------------------------------------------------------------------
 
 export interface ValidationPipelineConfig {
+  /** Realm-scoped authorization token for realm API calls (readFile, writeFile, _lint, _search). */
   authorization?: string;
+  /** Realm server token for _run-command calls (prerenderer). Distinct from realm-scoped authorization. */
+  serverToken?: string;
   fetch?: typeof globalThis.fetch;
   realmServerUrl: string;
   hostAppUrl: string;
   testResultsModuleUrl: string;
   lintResultsModuleUrl: string;
+  evalResultsModuleUrl: string;
   issueId?: string;
-  /** Injected for testing — passed through to TestValidationStep and LintValidationStep. */
+  /** Injected for testing — passed through to TestValidationStep, LintValidationStep, and EvalValidationStep. */
   fetchFilenames?: TestValidationStepConfig['fetchFilenames'];
 }
 
@@ -178,10 +184,20 @@ export function createDefaultPipeline(
     fetchFilenames: config.fetchFilenames,
   };
 
+  let evalConfig: EvalValidationStepConfig = {
+    authorization: config.authorization,
+    serverToken: config.serverToken,
+    fetch: config.fetch,
+    realmServerUrl: config.realmServerUrl,
+    evalResultsModuleUrl: config.evalResultsModuleUrl,
+    issueId: config.issueId,
+    fetchFilenames: config.fetchFilenames,
+  };
+
   return new ValidationPipeline([
     new NoOpStepRunner('parse'),
     new LintValidationStep(lintConfig),
-    new NoOpStepRunner('evaluate'),
+    new EvalValidationStep(evalConfig),
     new NoOpStepRunner('instantiate'),
     new TestValidationStep(testConfig),
   ]);

--- a/packages/software-factory/tests/eval-step.test.ts
+++ b/packages/software-factory/tests/eval-step.test.ts
@@ -1,0 +1,321 @@
+import { module, test } from 'qunit';
+
+import type { ValidationStepResult } from '../src/factory-agent';
+
+import {
+  EvalValidationStep,
+  type EvalValidationStepConfig,
+  type EvalValidationDetails,
+  type EvalModuleResult,
+} from '../src/validators/eval-step';
+import type { RealmFetchOptions } from '../src/realm-operations';
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(
+  overrides: Partial<EvalValidationStepConfig> = {},
+): EvalValidationStepConfig {
+  return {
+    realmServerUrl: 'https://example.test/',
+    evalResultsModuleUrl: 'https://example.test/eval-result',
+    // Default to a no-op sequence resolver for unit tests
+    getNextSequenceNumber: async () => 1,
+    ...overrides,
+  };
+}
+
+function makeFetchFilenames(
+  filenames: string[],
+): (
+  realmUrl: string,
+  options?: RealmFetchOptions,
+) => Promise<{ filenames: string[]; error?: string }> {
+  return async () => ({ filenames });
+}
+
+function makeFetchFilenamesError(
+  error: string,
+): (
+  realmUrl: string,
+  options?: RealmFetchOptions,
+) => Promise<{ filenames: string[]; error?: string }> {
+  return async () => ({ filenames: [], error });
+}
+
+function makeEvaluateModule(
+  results: Record<string, EvalModuleResult>,
+): (moduleUrl: string, realmUrl: string) => Promise<EvalModuleResult> {
+  return async (moduleUrl) => {
+    // Match by the last segment of the module URL (without extension)
+    for (let [key, value] of Object.entries(results)) {
+      if (moduleUrl.includes(key)) {
+        return value;
+      }
+    }
+    return { passed: true };
+  };
+}
+
+function makeEvaluateModuleThrows(
+  errorMessage: string,
+): (moduleUrl: string, realmUrl: string) => Promise<EvalModuleResult> {
+  return async () => {
+    throw new Error(errorMessage);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+module('EvalValidationStep', function () {
+  test('no evaluable files returns passed', async function (assert) {
+    let step = new EvalValidationStep(
+      makeConfig({
+        fetchFilenames: makeFetchFilenames([
+          'Cards/my-card.json',
+          'index.json',
+          '.realm.json',
+          'hello.test.gts',
+        ]),
+        evaluateModuleFn: makeEvaluateModule({}),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.true(result.passed);
+    assert.strictEqual(result.step, 'evaluate');
+    assert.strictEqual(result.errors.length, 0);
+    assert.deepEqual(result.files, []);
+  });
+
+  test('all modules pass evaluation', async function (assert) {
+    let step = new EvalValidationStep(
+      makeConfig({
+        fetchFilenames: makeFetchFilenames([
+          'hello.gts',
+          'utils.gts',
+          'index.json',
+        ]),
+        evaluateModuleFn: makeEvaluateModule({
+          hello: { passed: true },
+          utils: { passed: true },
+        }),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.true(result.passed);
+    assert.strictEqual(result.step, 'evaluate');
+    assert.deepEqual(result.files, ['hello.gts', 'utils.gts']);
+    assert.ok(result.details, 'has details');
+
+    let details = result.details as unknown as EvalValidationDetails;
+    assert.strictEqual(details.modulesChecked, 2);
+    assert.strictEqual(details.modulesWithErrors, 0);
+    assert.strictEqual(details.modules.length, 0);
+  });
+
+  test('module with evaluation error returns failed', async function (assert) {
+    let step = new EvalValidationStep(
+      makeConfig({
+        fetchFilenames: makeFetchFilenames(['hello.gts']),
+        evaluateModuleFn: makeEvaluateModule({
+          hello: {
+            passed: false,
+            error: 'Cannot find module ./does-not-exist',
+            stackTrace: 'Error: Cannot find module...',
+          },
+        }),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.false(result.passed);
+    assert.strictEqual(result.step, 'evaluate');
+    assert.ok(result.errors.length > 0, 'has errors');
+    assert.ok(result.details, 'has details');
+
+    let details = result.details as unknown as EvalValidationDetails;
+    assert.strictEqual(details.modulesChecked, 1);
+    assert.strictEqual(details.modulesWithErrors, 1);
+    assert.strictEqual(details.modules[0].path, 'hello.gts');
+    assert.ok(details.modules[0].error.includes('Cannot find module'));
+  });
+
+  test('*.test.gts files are excluded from evaluation', async function (assert) {
+    let step = new EvalValidationStep(
+      makeConfig({
+        fetchFilenames: makeFetchFilenames([
+          'hello.gts',
+          'hello.test.gts',
+          'utils.gts',
+          'utils.test.gts',
+          'data.json',
+        ]),
+        evaluateModuleFn: makeEvaluateModule({}),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.true(result.passed);
+    assert.deepEqual(result.files, ['hello.gts', 'utils.gts']);
+  });
+
+  test('file discovery failure returns failed', async function (assert) {
+    let step = new EvalValidationStep(
+      makeConfig({
+        fetchFilenames: makeFetchFilenamesError('Network timeout'),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.false(result.passed);
+    assert.ok(result.errors[0].message.includes('Network timeout'));
+  });
+
+  test('evaluateModuleFn throws returns failed with error message', async function (assert) {
+    let step = new EvalValidationStep(
+      makeConfig({
+        fetchFilenames: makeFetchFilenames(['hello.gts']),
+        evaluateModuleFn: makeEvaluateModuleThrows('Prerender unavailable'),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.false(result.passed);
+    assert.ok(result.errors.length > 0);
+    assert.ok(result.errors[0].message.includes('Prerender unavailable'));
+  });
+
+  test('issueId is used for slug derivation in artifact naming', async function (assert) {
+    let step = new EvalValidationStep(
+      makeConfig({
+        issueId: 'Issues/sticky-note-define-core',
+        fetchFilenames: makeFetchFilenames(['hello.gts']),
+        evaluateModuleFn: makeEvaluateModule({}),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.true(result.passed);
+    let details = result.details as unknown as EvalValidationDetails;
+    assert.ok(
+      details.evalResultId.includes('eval_sticky-note-define-core'),
+      `evalResultId "${details.evalResultId}" includes issue slug`,
+    );
+  });
+
+  test('multiple failing modules all reported', async function (assert) {
+    let step = new EvalValidationStep(
+      makeConfig({
+        fetchFilenames: makeFetchFilenames([
+          'card-a.gts',
+          'card-b.gts',
+          'card-c.gts',
+        ]),
+        evaluateModuleFn: makeEvaluateModule({
+          'card-a': { passed: false, error: 'Missing import A' },
+          'card-b': { passed: true },
+          'card-c': { passed: false, error: 'Runtime error in C' },
+        }),
+      }),
+    );
+
+    let result = await step.run('https://example.test/realm/');
+
+    assert.false(result.passed);
+
+    let details = result.details as unknown as EvalValidationDetails;
+    assert.strictEqual(details.modulesChecked, 3);
+    assert.strictEqual(details.modulesWithErrors, 2);
+    assert.strictEqual(details.modules.length, 2);
+    assert.ok(details.modules.some((m) => m.path === 'card-a.gts'));
+    assert.ok(details.modules.some((m) => m.path === 'card-c.gts'));
+  });
+
+  test('formatForContext with passing result and details', function (assert) {
+    let step = new EvalValidationStep(makeConfig());
+
+    let result: ValidationStepResult = {
+      step: 'evaluate',
+      passed: true,
+      errors: [],
+      details: {
+        evalResultId: 'Validations/eval_validation-1',
+        modulesChecked: 3,
+        modulesWithErrors: 0,
+        modules: [],
+      },
+    };
+
+    let formatted = step.formatForContext(result);
+    assert.ok(formatted.includes('PASSED'));
+    assert.ok(formatted.includes('3'));
+    assert.ok(formatted.includes('no evaluation errors'));
+  });
+
+  test('formatForContext with empty pass returns empty string', function (assert) {
+    let step = new EvalValidationStep(makeConfig());
+
+    let result: ValidationStepResult = {
+      step: 'evaluate',
+      passed: true,
+      errors: [],
+    };
+
+    let formatted = step.formatForContext(result);
+    assert.strictEqual(formatted, '');
+  });
+
+  test('formatForContext with failing result and module errors', function (assert) {
+    let step = new EvalValidationStep(makeConfig());
+
+    let result: ValidationStepResult = {
+      step: 'evaluate',
+      passed: false,
+      errors: [{ message: 'hello.gts: Cannot find module ./missing' }],
+      details: {
+        evalResultId: 'Validations/eval_validation-1',
+        modulesChecked: 2,
+        modulesWithErrors: 1,
+        modules: [
+          {
+            path: 'hello.gts',
+            error: 'Cannot find module ./missing',
+          },
+        ],
+      },
+    };
+
+    let formatted = step.formatForContext(result);
+    assert.ok(formatted.includes('FAILED'));
+    assert.ok(formatted.includes('2 module(s) checked'));
+    assert.ok(formatted.includes('1 module(s) with errors'));
+    assert.ok(formatted.includes('hello.gts'));
+    assert.ok(formatted.includes('Cannot find module'));
+  });
+
+  test('formatForContext without details falls back to errors', function (assert) {
+    let step = new EvalValidationStep(makeConfig());
+
+    let result: ValidationStepResult = {
+      step: 'evaluate',
+      passed: false,
+      errors: [{ message: 'Eval service failed' }],
+    };
+
+    let formatted = step.formatForContext(result);
+    assert.ok(formatted.includes('FAILED'));
+    assert.ok(formatted.includes('Eval service failed'));
+  });
+});

--- a/packages/software-factory/tests/eval-validation.spec.ts
+++ b/packages/software-factory/tests/eval-validation.spec.ts
@@ -1,0 +1,204 @@
+import { resolve } from 'node:path';
+
+import { expect, test } from './fixtures';
+
+import { readFile, writeFile, waitForRealmFile } from '../src/realm-operations';
+import { EvalValidationStep } from '../src/validators/eval-step';
+import type { EvalValidationDetails } from '../src/validators/eval-step';
+
+const fixtureRealmDir = resolve(
+  process.cwd(),
+  'test-fixtures',
+  'test-realm-runner',
+);
+
+// A valid .gts card module that should evaluate successfully.
+const VALID_MODULE_GTS = `import {
+  CardDef,
+  field,
+  contains,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+
+export class ValidCard extends CardDef {
+  static displayName = 'Valid Card';
+  @field name = contains(StringField);
+}
+`;
+
+// A .gts module with a broken import that should fail evaluation.
+// Foo is consumed as a field type so the compiler can't tree-shake it.
+const BROKEN_MODULE_GTS = `import {
+  CardDef,
+  field,
+  contains,
+} from 'https://cardstack.com/base/card-api';
+import { Foo } from './does-not-exist';
+
+export class BrokenCard extends CardDef {
+  static displayName = 'Broken Card';
+  @field brokenField = contains(Foo);
+}
+`;
+
+test.use({ realmDir: fixtureRealmDir });
+test.use({ realmServerMode: 'isolated' });
+
+test.describe('eval-validation e2e', () => {
+  test('EvalValidationStep e2e: clean module evaluates successfully', async ({
+    realm,
+  }) => {
+    let realmUrl = realm.realmURL.href;
+    let realmServerUrl = realm.realmServerURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let serverToken = `Bearer ${realm.serverToken}`;
+    let evalResultsModuleUrl = `${realmServerUrl}software-factory/eval-result`;
+
+    // Write a valid module
+    let writeResult = await writeFile(
+      realmUrl,
+      'valid-card.gts',
+      VALID_MODULE_GTS,
+      { authorization },
+    );
+    expect(writeResult.ok).toBe(true);
+
+    let indexed = await waitForRealmFile(realmUrl, 'valid-card.gts', {
+      authorization,
+      pollMs: 300,
+      timeoutMs: 30_000,
+    });
+    expect(indexed).toBe(true);
+
+    let step = new EvalValidationStep({
+      authorization,
+      serverToken,
+      fetch: globalThis.fetch,
+      realmServerUrl,
+      evalResultsModuleUrl,
+      issueId: 'Issues/eval-e2e',
+    });
+
+    let result = await step.run(realmUrl);
+
+    // Must pass — valid modules with correct imports
+    expect(result.step).toBe('evaluate');
+    expect(result.passed).toBe(true);
+    expect(result.files).toBeTruthy();
+    expect(result.files!.length).toBeGreaterThan(0);
+    expect(result.files).not.toContain('hello.test.gts');
+
+    let details = result.details as unknown as EvalValidationDetails;
+    expect(details).toBeTruthy();
+    expect(details.evalResultId).toContain('Validations/eval_eval-e2e');
+    expect(details.modulesChecked).toBeGreaterThan(0);
+    expect(details.modulesWithErrors).toBe(0);
+
+    // Read back the EvalResult card to verify persistence
+    let cardRead = await readFile(realmUrl, details.evalResultId, {
+      authorization,
+    });
+    expect(cardRead.ok).toBe(true);
+
+    let attrs = cardRead.document?.data.attributes;
+    expect(attrs).toBeTruthy();
+    expect(attrs?.status).toBe('passed');
+    expect(attrs?.sequenceNumber).toBe(1);
+    expect(attrs?.completedAt).toBeTruthy();
+  });
+
+  test('EvalValidationStep e2e: module with broken import fails evaluation', async ({
+    realm,
+  }) => {
+    let realmUrl = realm.realmURL.href;
+    let realmServerUrl = realm.realmServerURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let serverToken = `Bearer ${realm.serverToken}`;
+    let evalResultsModuleUrl = `${realmServerUrl}software-factory/eval-result`;
+
+    // Write a module with a broken relative import that is consumed as a field
+    // type. The import must be consumed — unused imports get tree-shaken by the
+    // compiler and the Loader never sees them (lint catches unused imports).
+    let writeResult = await writeFile(
+      realmUrl,
+      'broken-module.gts',
+      BROKEN_MODULE_GTS,
+      { authorization },
+    );
+    expect(writeResult.ok).toBe(true);
+
+    let indexed = await waitForRealmFile(realmUrl, 'broken-module.gts', {
+      authorization,
+      pollMs: 300,
+      timeoutMs: 30_000,
+    });
+    expect(indexed).toBe(true);
+
+    let step = new EvalValidationStep({
+      authorization,
+      serverToken,
+      fetch: globalThis.fetch,
+      realmServerUrl,
+      evalResultsModuleUrl,
+      issueId: 'Issues/eval-fail-e2e',
+    });
+
+    let result = await step.run(realmUrl);
+
+    // Must fail — broken-module.gts imports from a non-existent module
+    expect(result.step).toBe('evaluate');
+    expect(result.passed).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+
+    let details = result.details as unknown as EvalValidationDetails;
+    expect(details).toBeTruthy();
+    expect(details.modulesWithErrors).toBeGreaterThan(0);
+
+    let brokenModule = details.modules.find((m) =>
+      m.path.includes('broken-module'),
+    );
+    expect(brokenModule).toBeTruthy();
+    expect(brokenModule!.error).toBeTruthy();
+    // The error should be a real eval failure from the sandbox, not infrastructure
+    expect(brokenModule!.error).not.toContain('unable to fetch');
+    expect(brokenModule!.error).not.toContain('Command runner failed');
+    expect(brokenModule!.error).not.toContain('Missing Authorization');
+
+    // Read back the EvalResult card to verify it was persisted as failed
+    let cardRead = await readFile(realmUrl, details.evalResultId, {
+      authorization,
+    });
+    expect(cardRead.ok).toBe(true);
+
+    let attrs = cardRead.document?.data.attributes;
+    expect(attrs).toBeTruthy();
+    expect(attrs?.status).toBe('failed');
+  });
+
+  test('EvalValidationStep e2e: test files are excluded', async ({ realm }) => {
+    let realmUrl = realm.realmURL.href;
+    let realmServerUrl = realm.realmServerURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let serverToken = `Bearer ${realm.serverToken}`;
+    let evalResultsModuleUrl = `${realmServerUrl}software-factory/eval-result`;
+
+    let step = new EvalValidationStep({
+      authorization,
+      serverToken,
+      fetch: globalThis.fetch,
+      realmServerUrl,
+      evalResultsModuleUrl,
+      issueId: 'Issues/eval-exclude-e2e',
+    });
+
+    let result = await step.run(realmUrl);
+
+    // The fixture realm has hello.gts and hello.test.gts
+    // Only hello.gts (and home.gts) should be evaluated, not hello.test.gts
+    expect(result.step).toBe('evaluate');
+    expect(result.passed).toBe(true);
+    expect(result.files).toBeTruthy();
+    expect(result.files).toContain('hello.gts');
+    expect(result.files).not.toContain('hello.test.gts');
+  });
+});

--- a/packages/software-factory/tests/evaluate-module-command.spec.ts
+++ b/packages/software-factory/tests/evaluate-module-command.spec.ts
@@ -101,14 +101,6 @@ test.describe('evaluate-module command', () => {
     expect(response.status).toBe(201);
     let body = await response.json();
     let attrs = body?.data?.attributes;
-    console.log(
-      'VALID MODULE prerender:',
-      JSON.stringify(
-        { status: attrs?.status, error: attrs?.error, deps: attrs?.deps },
-        null,
-        2,
-      ),
-    );
     expect(attrs?.status).toBe('ready');
     expect(attrs?.error).toBeFalsy();
   });
@@ -150,14 +142,6 @@ test.describe('evaluate-module command', () => {
     expect(response.status).toBe(201);
     let body = await response.json();
     let attrs = body?.data?.attributes;
-    console.log(
-      'BROKEN IMPORT prerender:',
-      JSON.stringify(
-        { status: attrs?.status, error: attrs?.error, deps: attrs?.deps },
-        null,
-        2,
-      ),
-    );
 
     // This is what we WANT: the prerender should detect the broken import
     // If this assertion fails, it means the prerender/Loader silently
@@ -204,10 +188,6 @@ test.describe('evaluate-module command', () => {
     expect(response.status).toBe(201);
     let body = await response.json();
     let attrs = body?.data?.attributes;
-    console.log(
-      'BROKEN EVAL prerender:',
-      JSON.stringify({ status: attrs?.status, error: attrs?.error }, null, 2),
-    );
     expect(attrs?.status).toBe('error');
     expect(attrs?.error?.error?.message).toBeTruthy();
   });
@@ -229,18 +209,6 @@ test.describe('evaluate-module command', () => {
       { authorization: serverToken },
     );
 
-    console.log(
-      'RUN-COMMAND valid:',
-      JSON.stringify(
-        {
-          status: response.status,
-          error: response.error,
-          result: response.result?.slice(0, 300),
-        },
-        null,
-        2,
-      ),
-    );
     expect(response.status).toBe('ready');
     let result = JSON.parse(response.result!);
     let attrs = result?.data?.attributes ?? result;
@@ -271,24 +239,10 @@ test.describe('evaluate-module command', () => {
       { authorization: serverToken },
     );
 
-    console.log(
-      'RUN-COMMAND broken import:',
-      JSON.stringify(
-        {
-          status: response.status,
-          error: response.error,
-          result: response.result?.slice(0, 500),
-        },
-        null,
-        2,
-      ),
-    );
-
     // If the prerender catches the broken import, the command should return passed=false
     if (response.status === 'ready' && response.result) {
       let result = JSON.parse(response.result);
       let attrs = result?.data?.attributes ?? result;
-      console.log('COMMAND RESULT attrs:', JSON.stringify(attrs, null, 2));
       expect(attrs.passed).toBe(false);
     } else {
       // Command itself errored

--- a/packages/software-factory/tests/evaluate-module-command.spec.ts
+++ b/packages/software-factory/tests/evaluate-module-command.spec.ts
@@ -1,0 +1,298 @@
+/**
+ * Focused tests for the evaluate-module host command and the
+ * /_prerender-module endpoint to debug broken import detection.
+ */
+import { resolve } from 'node:path';
+
+import { expect, test } from './fixtures';
+
+import {
+  runRealmCommand,
+  writeFile,
+  waitForRealmFile,
+} from '../src/realm-operations';
+import { buildServerToken } from '../src/harness/shared';
+
+const fixtureRealmDir = resolve(
+  process.cwd(),
+  'test-fixtures',
+  'test-realm-runner',
+);
+
+const VALID_MODULE = `import {
+  CardDef,
+  field,
+  contains,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+
+export class ValidCard extends CardDef {
+  static displayName = 'Valid Card';
+  @field name = contains(StringField);
+}
+`;
+
+const BROKEN_IMPORT_MODULE = `import {
+  CardDef,
+  field,
+  contains,
+} from 'https://cardstack.com/base/card-api';
+import { Foo } from './does-not-exist';
+
+export class BrokenImportCard extends CardDef {
+  static displayName = 'Broken Import Card';
+  @field brokenField = contains(Foo);
+}
+`;
+
+const BROKEN_EVAL_MODULE = `import {
+  CardDef,
+  Component,
+} from 'https://cardstack.com/base/card-api';
+
+export class BrokenEvalCard extends CardDef {
+  static displayName = 'Broken Eval Card';
+  static isolated = class Isolated extends Component<typeof BrokenEvalCard> {
+    <template>
+      {{nonExistentHelper "strict mode failure"}}
+    </template>
+  };
+}
+`;
+
+test.use({ realmDir: fixtureRealmDir });
+test.use({ realmServerMode: 'isolated' });
+
+test.describe('evaluate-module command', () => {
+  test('/_prerender-module: valid module returns ready', async ({ realm }) => {
+    let realmUrl = realm.realmURL.href;
+    let realmServerUrl = realm.realmServerURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let serverToken = `Bearer ${buildServerToken()}`;
+
+    await writeFile(realmUrl, 'valid-test.gts', VALID_MODULE, {
+      authorization,
+    });
+    await waitForRealmFile(realmUrl, 'valid-test.gts', {
+      authorization,
+      pollMs: 300,
+      timeoutMs: 30_000,
+    });
+
+    let moduleUrl = new URL('valid-test', realmUrl).href;
+    let response = await fetch(
+      new URL('/_prerender-module', realmServerUrl).href,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.api+json',
+          'Content-Type': 'application/vnd.api+json',
+          Authorization: serverToken,
+        },
+        body: JSON.stringify({
+          data: {
+            type: 'prerender-module-request',
+            attributes: { realm: realmUrl, url: moduleUrl },
+          },
+        }),
+      },
+    );
+
+    expect(response.status).toBe(201);
+    let body = await response.json();
+    let attrs = body?.data?.attributes;
+    console.log(
+      'VALID MODULE prerender:',
+      JSON.stringify(
+        { status: attrs?.status, error: attrs?.error, deps: attrs?.deps },
+        null,
+        2,
+      ),
+    );
+    expect(attrs?.status).toBe('ready');
+    expect(attrs?.error).toBeFalsy();
+  });
+
+  test('/_prerender-module: broken import detection', async ({ realm }) => {
+    let realmUrl = realm.realmURL.href;
+    let realmServerUrl = realm.realmServerURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let serverToken = `Bearer ${buildServerToken()}`;
+
+    await writeFile(realmUrl, 'broken-import-test.gts', BROKEN_IMPORT_MODULE, {
+      authorization,
+    });
+    await waitForRealmFile(realmUrl, 'broken-import-test.gts', {
+      authorization,
+      pollMs: 300,
+      timeoutMs: 30_000,
+    });
+
+    let moduleUrl = new URL('broken-import-test', realmUrl).href;
+    let response = await fetch(
+      new URL('/_prerender-module', realmServerUrl).href,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.api+json',
+          'Content-Type': 'application/vnd.api+json',
+          Authorization: serverToken,
+        },
+        body: JSON.stringify({
+          data: {
+            type: 'prerender-module-request',
+            attributes: { realm: realmUrl, url: moduleUrl },
+          },
+        }),
+      },
+    );
+
+    expect(response.status).toBe(201);
+    let body = await response.json();
+    let attrs = body?.data?.attributes;
+    console.log(
+      'BROKEN IMPORT prerender:',
+      JSON.stringify(
+        { status: attrs?.status, error: attrs?.error, deps: attrs?.deps },
+        null,
+        2,
+      ),
+    );
+
+    // This is what we WANT: the prerender should detect the broken import
+    // If this assertion fails, it means the prerender/Loader silently
+    // swallows missing relative imports
+    expect(attrs?.status).toBe('error');
+  });
+
+  test('/_prerender-module: strict-mode eval error detected', async ({
+    realm,
+  }) => {
+    let realmUrl = realm.realmURL.href;
+    let realmServerUrl = realm.realmServerURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let serverToken = `Bearer ${buildServerToken()}`;
+
+    await writeFile(realmUrl, 'broken-eval-test.gts', BROKEN_EVAL_MODULE, {
+      authorization,
+    });
+    await waitForRealmFile(realmUrl, 'broken-eval-test.gts', {
+      authorization,
+      pollMs: 300,
+      timeoutMs: 30_000,
+    });
+
+    let moduleUrl = new URL('broken-eval-test', realmUrl).href;
+    let response = await fetch(
+      new URL('/_prerender-module', realmServerUrl).href,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.api+json',
+          'Content-Type': 'application/vnd.api+json',
+          Authorization: serverToken,
+        },
+        body: JSON.stringify({
+          data: {
+            type: 'prerender-module-request',
+            attributes: { realm: realmUrl, url: moduleUrl },
+          },
+        }),
+      },
+    );
+
+    expect(response.status).toBe(201);
+    let body = await response.json();
+    let attrs = body?.data?.attributes;
+    console.log(
+      'BROKEN EVAL prerender:',
+      JSON.stringify({ status: attrs?.status, error: attrs?.error }, null, 2),
+    );
+    expect(attrs?.status).toBe('error');
+    expect(attrs?.error?.error?.message).toBeTruthy();
+  });
+
+  test('evaluate-module via _run-command: valid module passes', async ({
+    realm,
+  }) => {
+    let realmUrl = realm.realmURL.href;
+    let realmServerUrl = realm.realmServerURL.href;
+    let serverToken = `Bearer ${buildServerToken()}`;
+
+    let moduleUrl = new URL('hello', realmUrl).href; // fixture realm's hello.gts
+
+    let response = await runRealmCommand(
+      realmServerUrl,
+      realmUrl,
+      '@cardstack/boxel-host/commands/evaluate-module/default',
+      { moduleUrl, realmUrl },
+      { authorization: serverToken },
+    );
+
+    console.log(
+      'RUN-COMMAND valid:',
+      JSON.stringify(
+        {
+          status: response.status,
+          error: response.error,
+          result: response.result?.slice(0, 300),
+        },
+        null,
+        2,
+      ),
+    );
+    expect(response.status).toBe('ready');
+    let result = JSON.parse(response.result!);
+    let attrs = result?.data?.attributes ?? result;
+    expect(attrs.passed).toBe(true);
+  });
+
+  test('evaluate-module via _run-command: broken import', async ({ realm }) => {
+    let realmUrl = realm.realmURL.href;
+    let realmServerUrl = realm.realmServerURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let serverToken = `Bearer ${buildServerToken()}`;
+
+    await writeFile(realmUrl, 'broken-cmd-test.gts', BROKEN_IMPORT_MODULE, {
+      authorization,
+    });
+    await waitForRealmFile(realmUrl, 'broken-cmd-test.gts', {
+      authorization,
+      pollMs: 300,
+      timeoutMs: 30_000,
+    });
+
+    let moduleUrl = new URL('broken-cmd-test', realmUrl).href;
+    let response = await runRealmCommand(
+      realmServerUrl,
+      realmUrl,
+      '@cardstack/boxel-host/commands/evaluate-module/default',
+      { moduleUrl, realmUrl },
+      { authorization: serverToken },
+    );
+
+    console.log(
+      'RUN-COMMAND broken import:',
+      JSON.stringify(
+        {
+          status: response.status,
+          error: response.error,
+          result: response.result?.slice(0, 500),
+        },
+        null,
+        2,
+      ),
+    );
+
+    // If the prerender catches the broken import, the command should return passed=false
+    if (response.status === 'ready' && response.result) {
+      let result = JSON.parse(response.result);
+      let attrs = result?.data?.attributes ?? result;
+      console.log('COMMAND RESULT attrs:', JSON.stringify(attrs, null, 2));
+      expect(attrs.passed).toBe(false);
+    } else {
+      // Command itself errored
+      expect(response.status).toBe('error');
+    }
+  });
+});

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -14,7 +14,7 @@ import {
   type PreparedTemplateMetadata,
   readSupportMetadata,
 } from '../src/runtime-metadata';
-import { buildRealmToken } from '../src/harness/shared';
+import { buildRealmToken, buildServerToken } from '../src/harness/shared';
 import { startHarnessPrerenderServer } from '../src/harness/support-services';
 import { buildBrowserState, installBrowserState } from './helpers/browser-auth';
 
@@ -25,6 +25,8 @@ type StartedFactoryRealm = {
   /** The host app URL served by the compat proxy (for QUnit live-test pages). */
   hostAppUrl: string;
   ownerBearerToken: string;
+  /** Realm server JWT for _run-command and other server-level endpoints. */
+  serverToken: string;
   ports: {
     publicPort: number;
     realmServerPort: number;
@@ -389,6 +391,7 @@ async function startRealmProcess(
     realmServerURL: new URL(metadata.realmServerURL),
     hostAppUrl: `http://localhost:${metadata.ports.publicPort}`,
     ownerBearerToken: metadata.ownerBearerToken,
+    serverToken: buildServerToken(),
     ports: metadata.ports,
     cardURL(path: string) {
       return new URL(path, metadata.realmURL).href;

--- a/packages/software-factory/tests/index.ts
+++ b/packages/software-factory/tests/index.ts
@@ -17,3 +17,4 @@ import './retry-blocked-issues.test';
 import './validation-pipeline.test';
 import './test-step.test';
 import './lint-step.test';
+import './eval-step.test';

--- a/packages/software-factory/tests/validation-pipeline.test.ts
+++ b/packages/software-factory/tests/validation-pipeline.test.ts
@@ -208,8 +208,9 @@ module('ValidationPipeline', function () {
       hostAppUrl: 'https://example.test/',
       testResultsModuleUrl: 'https://example.test/test-results',
       lintResultsModuleUrl: 'https://example.test/lint-result',
-      // Inject a fetchFilenames that returns no files so the test and lint
-      // steps return "nothing to validate" without hitting a real realm
+      evalResultsModuleUrl: 'https://example.test/eval-result',
+      // Inject a fetchFilenames that returns no files so the test, lint,
+      // and eval steps return "nothing to validate" without hitting a real realm
       fetchFilenames: async () => ({ filenames: [] }),
     });
 


### PR DESCRIPTION
## Summary

- Replace `NoOpStepRunner('evaluate')` with a real `EvalValidationStep` that validates `.gts` modules load and evaluate without runtime errors
- Module evaluation runs in the prerenderer sandbox via `_run-command` → `evaluate-module` host command → `loader.import()` in headless Chrome
- Creates `EvalResult` card artifacts at `Validations/eval_{slug}-{seq}.json` with running → completed lifecycle
- Feeds eval results back into the agent's issue context through the existing validation pipeline
- Skips `*.test.gts` files (test step's responsibility)
- Uses distinct `serverToken` for `_run-command` auth (not realm-scoped token)

## New files
- `packages/host/app/commands/evaluate-module.ts` — Host command (loader.import in sandbox)
- `packages/base/command.gts` — `EvaluateModuleInput` / `EvaluateModuleResult` card types
- `packages/software-factory/realm/eval-result.gts` — EvalResult card definition
- `packages/software-factory/src/eval-result-cards.ts` — Card CRUD
- `packages/software-factory/src/validators/eval-step.ts` — ValidationStepRunner implementation

## Test plan
- [x] 389/389 QUnit unit tests pass (12 new eval step tests)
- [x] 2/2 host integration tests pass (valid module + broken consumed import)
- [x] 3/3 Playwright e2e tests pass (clean eval, broken import, test exclusion)
- [x] 5/5 focused evaluate-module-command spec tests (prerender + run-command paths)
- [x] Full monorepo `pnpm lint` clean
- [x] E2e factory run completed successfully — eval step caught real strict-mode error, agent self-corrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)