### PR TITLE
Cross file references and packaging upon submission

### DIFF
--- a/packages/catalog-realm/commands/collect-submission-files.ts
+++ b/packages/catalog-realm/commands/collect-submission-files.ts
@@ -18,6 +18,7 @@ import {
   CardDef,
   field,
   contains,
+  containsMany,
 } from 'https://cardstack.com/base/card-api';
 import StringField from 'https://cardstack.com/base/string';
 import GetCardCommand from '@cardstack/boxel-host/commands/get-card';
@@ -25,10 +26,7 @@ import ReadSourceCommand from '@cardstack/boxel-host/commands/read-source';
 import SerializeCardCommand from '@cardstack/boxel-host/commands/serialize-card';
 
 import type { Listing } from '../catalog-app/listing/listing';
-import {
-  FileContentField,
-  FileCollectionResult,
-} from '../fields/file-content';
+import { FileContentField, FileCollectionResult } from '../fields/file-content';
 
 const log = logger('commands:collect-submission-files');
 
@@ -40,6 +38,7 @@ interface FileWithContent {
 class CollectSubmissionFilesInput extends CardDef {
   @field listingId = contains(StringField);
   @field listingRealm = contains(StringField);
+  @field accessibleRealms = containsMany(StringField);
 }
 
 export default class CollectSubmissionFilesCommand extends Command<
@@ -57,13 +56,17 @@ export default class CollectSubmissionFilesCommand extends Command<
   protected async run(
     input: CollectSubmissionFilesInput,
   ): Promise<FileCollectionResult> {
-    let { listingId, listingRealm } = input;
+    let { listingId, listingRealm, accessibleRealms } = input;
 
     if (!listingId || !listingRealm) {
       throw new Error('Missing listingId or listingRealm');
     }
 
-    let files = await this.collectFiles(listingId, listingRealm);
+    let files = await this.collectFiles(
+      listingId,
+      listingRealm,
+      accessibleRealms ?? [],
+    );
     log.debug(`Collected ${files.length} files for submission`);
 
     return new FileCollectionResult({
@@ -80,6 +83,7 @@ export default class CollectSubmissionFilesCommand extends Command<
   private async collectFiles(
     listingId: string,
     listingRealm: string,
+    accessibleRealms: string[],
   ): Promise<FileWithContent[]> {
     let realmUrl = new RealmPaths(new URL(listingRealm)).url;
     let getCardCommand = new GetCardCommand(this.commandContext);
@@ -101,6 +105,16 @@ export default class CollectSubmissionFilesCommand extends Command<
     }
 
     const builder = new PlanBuilder(realmUrl, listing);
+
+    let knownRealmUrls = new Set<string>();
+    knownRealmUrls.add(realmUrl);
+    for (const accessibleRealm of accessibleRealms) {
+      if (!accessibleRealm) continue;
+      let normalized = new RealmPaths(new URL(accessibleRealm)).url;
+      knownRealmUrls.add(normalized);
+      builder.resolver.addKnownRealmURL(new URL(normalized));
+    }
+
     builder
       .addIf(listing.specs?.length > 0, (resolver: ListingPathResolver) =>
         planModuleInstall(listing.specs ?? [], resolver),
@@ -117,23 +131,79 @@ export default class CollectSubmissionFilesCommand extends Command<
 
     const plan = builder.build();
 
-    const toRepoRelativePath = (fullUrl: string, extension: string): string => {
+    const toRepoPathNoExt = (fullUrl: string): string => {
       let path = fullUrl;
-      if (path.startsWith(realmUrl)) {
-        path = path.slice(realmUrl.length);
+      // Try to strip any known realm URL prefix (longest match first
+      // to handle nested realm paths correctly)
+      let sortedRealms = [...knownRealmUrls].sort(
+        (a, b) => b.length - a.length,
+      );
+      for (const realm of sortedRealms) {
+        if (path.startsWith(realm)) {
+          path = path.slice(realm.length);
+          break;
+        }
       }
+      // Fallback: if no realm matched and path is still an absolute URL,
+      // strip the origin and use the decoded pathname — same as
+      // ListingPathResolver.local() fallback.
       try {
-        path = decodeURIComponent(new URL(path).pathname);
+        let url = new URL(path);
+        path = decodeURI(url.pathname);
       } catch {
-        // keep non-URL input as-is
+        // not a URL — already a relative path
       }
       if (path.startsWith('/')) {
         path = path.slice(1);
       }
+      return path;
+    };
+
+    const toRepoRelativePath = (fullUrl: string, extension: string): string => {
+      let path = toRepoPathNoExt(fullUrl);
       if (!path.endsWith(extension)) {
         path = path + extension;
       }
       return path;
+    };
+
+    // Build a map of source URL (extension-less) → PR path (extension-less).
+    // After the PR merges into the catalog, cross-realm references in the
+    // submitted files must resolve to their new co-located files. We rewrite
+    // all references in file contents to relative paths so the submission is
+    // self-contained and deployment-agnostic.
+    let urlToRepoPath = new Map<string, string>();
+    if (listing.id) {
+      urlToRepoPath.set(listing.id, toRepoPathNoExt(listing.id));
+    }
+    for (const moduleMeta of plan.modulesToInstall as CopyModuleMeta[]) {
+      if (moduleMeta?.sourceModule) {
+        urlToRepoPath.set(
+          moduleMeta.sourceModule,
+          toRepoPathNoExt(moduleMeta.sourceModule),
+        );
+      }
+    }
+    for (const copyMeta of plan.instancesCopy as CopyInstanceMeta[]) {
+      if (copyMeta?.sourceCard?.id) {
+        urlToRepoPath.set(
+          copyMeta.sourceCard.id,
+          toRepoPathNoExt(copyMeta.sourceCard.id),
+        );
+      }
+    }
+
+    const rewriteReferences = (content: string, fromPath: string): string => {
+      let entries = [...urlToRepoPath.entries()].sort(
+        (a, b) => b[0].length - a[0].length,
+      );
+      for (const [sourceUrl, targetPath] of entries) {
+        let relative = relativeRepoPath(fromPath, targetPath);
+        let escaped = sourceUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        let pattern = new RegExp(escaped + '(?![a-zA-Z0-9_\\-\\.])', 'g');
+        content = content.replace(pattern, relative);
+      }
+      return content;
     };
 
     const filesWithContent: FileWithContent[] = [];
@@ -146,7 +216,10 @@ export default class CollectSubmissionFilesCommand extends Command<
         let source = await readSourceCommand.execute({
           path: `${listing.id}.json`,
         });
-        filesWithContent.push({ path, content: source.content });
+        filesWithContent.push({
+          path,
+          content: rewriteReferences(source.content, path),
+        });
       }
     }
 
@@ -158,10 +231,22 @@ export default class CollectSubmissionFilesCommand extends Command<
       const path = toRepoRelativePath(moduleMeta.sourceModule, '.gts');
       if (!seenPaths.has(path)) {
         seenPaths.add(path);
-        let source = await readSourceCommand.execute({
-          path: moduleMeta.sourceModule,
-        });
-        filesWithContent.push({ path, content: source.content });
+        try {
+          let source = await readSourceCommand.execute({
+            path: moduleMeta.sourceModule,
+          });
+          filesWithContent.push({
+            path,
+            content: rewriteReferences(source.content, path),
+          });
+        } catch (e: any) {
+          if (isAccessError(e)) {
+            throw new Error(
+              `Cannot collect files: no access to read module ${moduleMeta.sourceModule}`,
+            );
+          }
+          throw e;
+        }
       }
     }
 
@@ -174,10 +259,22 @@ export default class CollectSubmissionFilesCommand extends Command<
       const path = toRepoRelativePath(sourceCardId, '.json');
       if (!seenPaths.has(path)) {
         seenPaths.add(path);
-        let source = await readSourceCommand.execute({
-          path: `${sourceCardId}.json`,
-        });
-        filesWithContent.push({ path, content: source.content });
+        try {
+          let source = await readSourceCommand.execute({
+            path: `${sourceCardId}.json`,
+          });
+          filesWithContent.push({
+            path,
+            content: rewriteReferences(source.content, path),
+          });
+        } catch (e: any) {
+          if (isAccessError(e)) {
+            throw new Error(
+              `Cannot collect files: no access to read card ${sourceCardId}`,
+            );
+          }
+          throw e;
+        }
       }
     }
 
@@ -232,4 +329,30 @@ export default class CollectSubmissionFilesCommand extends Command<
 
     return [...instancesById.values()];
   }
+}
+
+function isAccessError(e: any): boolean {
+  let status = e?.status ?? e?.response?.status ?? e?.code;
+  if (status === 401 || status === 403) {
+    return true;
+  }
+  let msg = typeof e?.message === 'string' ? e.message : '';
+  return msg.includes('Unauthorized') || msg.includes('Forbidden');
+}
+
+function relativeRepoPath(fromPath: string, toPath: string): string {
+  let fromDir = fromPath.split('/').slice(0, -1);
+  let toParts = toPath.split('/');
+  let common = 0;
+  while (
+    common < fromDir.length &&
+    common < toParts.length &&
+    fromDir[common] === toParts[common]
+  ) {
+    common++;
+  }
+  let up = fromDir.length - common;
+  let down = toParts.slice(common);
+  let parts = up > 0 ? [...Array(up).fill('..'), ...down] : ['.', ...down];
+  return parts.join('/');
 }

--- a/packages/host/tests/unit/plan-install-test.ts
+++ b/packages/host/tests/unit/plan-install-test.ts
@@ -16,6 +16,7 @@ import type { Spec } from 'https://cardstack.com/base/spec';
 const sourceRealmURL = new URL('https://localhost:4201/catalog/');
 const targetRealmURL = new URL('https://localhost:4201/experiments/');
 const baseRealmURL = new URL('https://cardstack.com/base/');
+const foreignRealmURL = new URL('https://localhost:4201/user1/personal-realm/');
 
 module('Unit | Catalog | Install Plan Builder', function () {
   test('when listing name is not provided, just provides uuid (in this case uuid="xyz")', function (assert) {
@@ -268,6 +269,161 @@ module('Unit | Catalog | Install Plan Builder', function () {
         module: `${baseRealmURL}skill`,
         name: 'Some Ref Name',
       });
+    });
+  });
+
+  module('cross-realm support', function () {
+    test('ListingPathResolver.local() strips foreign realm prefix when registered', function (assert) {
+      const listing = {
+        name: 'Some Listing',
+        specs: [],
+        examples: [],
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      let resolver = new ListingPathResolver(
+        targetRealmURL.href,
+        listing,
+        'xyz',
+      );
+      resolver.addKnownRealmURL(foreignRealmURL);
+
+      // Same-realm URL resolves as before
+      let sameRealmLocal = resolver.local(
+        `${sourceRealmURL.href}some-folder/Example/1`,
+      );
+      assert.strictEqual(sameRealmLocal, 'some-folder/Example/1');
+
+      // Cross-realm URL with registered realm strips the foreign realm prefix
+      let crossRealmLocal = resolver.local(
+        `${foreignRealmURL.href}CyclingMileageLog/abc`,
+      );
+      assert.strictEqual(crossRealmLocal, 'CyclingMileageLog/abc');
+    });
+
+    test('ListingPathResolver.local() falls back to full path for unregistered foreign realm', function (assert) {
+      const listing = {
+        name: 'Some Listing',
+        specs: [],
+        examples: [],
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      let resolver = new ListingPathResolver(
+        targetRealmURL.href,
+        listing,
+        'xyz',
+      );
+
+      let crossRealmLocal = resolver.local(
+        `${foreignRealmURL.href}CyclingMileageLog/abc`,
+      );
+      assert.strictEqual(
+        crossRealmLocal,
+        'user1/personal-realm/CyclingMileageLog/abc',
+      );
+    });
+
+    test('ListingPathResolver.target() maps cross-realm URLs into target directory', function (assert) {
+      const listing = {
+        name: 'Some Listing',
+        specs: [],
+        examples: [],
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      let resolver = new ListingPathResolver(
+        targetRealmURL.href,
+        listing,
+        'xyz',
+      );
+      resolver.addKnownRealmURL(foreignRealmURL);
+
+      let target = resolver.target(
+        `${foreignRealmURL.href}CyclingMileageLog/abc`,
+      );
+      assert.strictEqual(
+        target,
+        `${targetRealmURL.href}some-listing-xyz/CyclingMileageLog/abc`,
+      );
+    });
+
+    test('planInstanceInstall handles instances from a foreign realm', function (assert) {
+      const instances = [
+        {
+          id: `${foreignRealmURL.href}CyclingMileageLog/abc`,
+          [meta]: {
+            adoptsFrom: {
+              name: 'CyclingMileageLog',
+              module: `${foreignRealmURL.href}cycling-mileage-log`,
+            },
+          },
+          [realmURL]: foreignRealmURL,
+        },
+      ] as CardDef[];
+      const listing = {
+        name: 'Some Listing',
+        specs: [],
+        examples: instances,
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      let resolver = new ListingPathResolver(
+        targetRealmURL.href,
+        listing,
+        'xyz',
+      );
+      resolver.addKnownRealmURL(foreignRealmURL);
+      let { instancesCopy, modulesCopy } = planInstanceInstall(
+        instances,
+        resolver,
+      );
+
+      assert.strictEqual(instancesCopy.length, 1);
+      assert.strictEqual(
+        instancesCopy[0].lid,
+        'some-listing-xyz/CyclingMileageLog/abc',
+      );
+      assert.strictEqual(modulesCopy.length, 1);
+      assert.strictEqual(
+        modulesCopy[0].sourceCodeRef.module,
+        `${foreignRealmURL.href}cycling-mileage-log`,
+      );
+    });
+
+    test('planModuleInstall handles specs from a foreign realm', function (assert) {
+      const specs = [
+        {
+          ref: { name: 'CyclingMileageLog' },
+          moduleHref: `${foreignRealmURL.href}cycling-mileage-log`,
+          [realmURL]: foreignRealmURL,
+        },
+      ] as Spec[];
+      const listing = {
+        name: 'Some Listing',
+        specs,
+        examples: [],
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      let resolver = new ListingPathResolver(
+        targetRealmURL.href,
+        listing,
+        'xyz',
+      );
+      resolver.addKnownRealmURL(foreignRealmURL);
+      let { modulesCopy, modulesToInstall } = planModuleInstall(
+        specs,
+        resolver,
+      );
+
+      assert.strictEqual(modulesCopy.length, 1);
+      assert.deepEqual(modulesToInstall, [
+        {
+          sourceModule: `${foreignRealmURL.href}cycling-mileage-log`,
+          targetModule: `${targetRealmURL.href}some-listing-xyz/cycling-mileage-log`,
+        },
+      ]);
     });
   });
 

--- a/packages/runtime-common/catalog.ts
+++ b/packages/runtime-common/catalog.ts
@@ -85,6 +85,7 @@ export class ListingPathResolver {
   private targetRealmPath: RealmPaths;
   private sourceRealmPath: RealmPaths;
   private targetDirectoryPath: RealmPaths;
+  private foreignRealmPaths: RealmPaths[] = [];
 
   constructor(targetRealm: string, listing: Listing, installDirId?: string) {
     this.targetRealmPath = new RealmPaths(new URL(targetRealm));
@@ -107,11 +108,33 @@ export class ListingPathResolver {
     );
   }
 
+  addKnownRealmURL(url: URL): void {
+    let realmPath = new RealmPaths(url);
+    if (
+      realmPath.url !== this.sourceRealmPath.url &&
+      !this.foreignRealmPaths.some((p) => p.url === realmPath.url)
+    ) {
+      this.foreignRealmPaths.push(realmPath);
+    }
+  }
+
   local(href: string): LocalPath {
-    let local = this.sourceRealmPath.local(
-      new URL(href, this.sourceRealmPath.url),
+    let url = new URL(href, this.sourceRealmPath.url);
+    if (this.sourceRealmPath.inRealm(url)) {
+      return this.sourceRealmPath.local(url);
+    }
+    // Try known foreign realm paths (longest URL first to handle nested realms)
+    let sorted = [...this.foreignRealmPaths].sort(
+      (a, b) => b.url.length - a.url.length,
     );
-    return local;
+    for (let foreignPath of sorted) {
+      if (foreignPath.inRealm(url)) {
+        return foreignPath.local(url);
+      }
+    }
+    // Fallback: strip only the origin, preserving full path for safety
+    let path = decodeURI(url.pathname).replace(/^\//, '').replace(/\/+$/, '');
+    return path;
   }
 
   targetLid(href: string): string {
@@ -133,7 +156,7 @@ type PlanBuilderStep = (
 export class PlanBuilder {
   private steps: PlanBuilderStep[] = [];
   private log = logger('catalog:plan');
-  private resolver: ListingPathResolver;
+  resolver: ListingPathResolver;
 
   constructor(realmUrl: string, listing: Listing) {
     this.resolver = new ListingPathResolver(realmUrl, listing);

--- a/packages/runtime-common/tasks/run-command.ts
+++ b/packages/runtime-common/tasks/run-command.ts
@@ -4,6 +4,7 @@ import type { Task } from './index';
 
 import {
   fetchRealmPermissions,
+  fetchUserPermissions,
   jobIdentity,
   type RunCommandResponse,
   ensureFullMatrixUserId,
@@ -58,9 +59,15 @@ const runCommand: Task<RunCommandArgs, RunCommandResponse> = ({
       };
     }
 
-    let auth = createPrerenderAuth(runAsUserId, {
-      [normalizedRealmURL]: userPermissions,
+    // Include JWTs for all realms the user has access to
+    // Cross-realm card references (e.g. linksToMany to cards in other realms)
+    // require auth when the Loader fetches modules.
+    let allUserPermissions = await fetchUserPermissions(dbAdapter, {
+      userId: runAsUserId,
     });
+    allUserPermissions[normalizedRealmURL] = userPermissions;
+    let auth = createPrerenderAuth(runAsUserId, allUserPermissions);
+    let accessibleRealms = Object.keys(allUserPermissions);
 
     let normalizedCommand = normalizeCommandSpecifier(
       command,
@@ -76,11 +83,15 @@ const runCommand: Task<RunCommandArgs, RunCommandResponse> = ({
       };
     }
 
+    let augmentedCommandInput = commandInput
+      ? { ...commandInput, accessibleRealms }
+      : undefined;
+
     let result = await prerenderer.runCommand({
       userId: runAsUserId,
       auth,
       command: normalizedCommand,
-      commandInput: commandInput ?? undefined,
+      commandInput: augmentedCommandInput,
     });
 
     reportStatus(jobInfo, 'finish');

--- a/packages/runtime-common/tests/run-command-task-shared-tests.ts
+++ b/packages/runtime-common/tests/run-command-task-shared-tests.ts
@@ -133,6 +133,7 @@ const tests = Object.freeze({
         dbRows: [
           {
             username: '@alice:localhost',
+            realm_url: 'http://localhost:4201/experiments/',
             read: true,
             write: true,
             realm_owner: false,
@@ -180,6 +181,7 @@ const tests = Object.freeze({
         dbRows: [
           {
             username: '@alice:localhost',
+            realm_url: 'http://localhost:4201/experiments/',
             read: true,
             write: true,
             realm_owner: false,
@@ -237,6 +239,7 @@ const tests = Object.freeze({
         dbRows: [
           {
             username: '@alice:localhost',
+            realm_url: 'http://localhost:4201/experiments/',
             read: true,
             write: true,
             realm_owner: false,
@@ -263,6 +266,7 @@ const tests = Object.freeze({
     );
     assert.deepEqual(prerenderCall?.commandInput, {
       listingId: 'http://localhost:4201/catalog/AppListing/1',
+      accessibleRealms: ['http://localhost:4201/experiments/'],
     });
   },
 } as SharedTests<{}>);


### PR DESCRIPTION
Fix cross-realm submission PR file collection and rewrite references to relative paths
<img width="1684" height="568" alt="image" src="https://github.com/user-attachments/assets/07f4c31c-db12-4244-a1fe-a975fd7aef13" />

### What is changing 
- Cross-realm auth (run-command.ts): Commands now include JWTs for all realms the user has access to (not just the target realm), fixing 401 errors when deserialising cards with cross-realm linksToMany relationships. Also injects accessibleRealms into commandInput so commands can resolve realm boundaries for any URL.
- Cross-realm path resolution (catalog.ts): ListingPathResolver.local() no longer throws on foreign realm URLs. Uses addKnownRealmURL() registration to strip the correct realm prefix, with fallback to full pathname for unregistered realms.
- Reference rewriting (collect-submission-files.ts): After collecting files, all absolute URLs pointing at submitted files are rewritten to relative paths (e.g. ../cycling-mileage-log). This makes the submission self-contained — adoptsFrom.module in card JSONs and imports in .gts files resolve correctly after the PR merges into the catalog. Example PR submission package output when cross-realm involved: https://github.com/cardstack/boxel-catalog/pull/395/changes
- Add tests