### PR TITLE
CS-10802: Refactor SearchPanel – extract utilities and simplify args

### DIFF
--- a/packages/boxel-ui/addon/src/components/picker/index.gts
+++ b/packages/boxel-ui/addon/src/components/picker/index.gts
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 import type { ComponentLike } from '@glint/template';
 import { modifier } from 'ember-modifier';
 import type { Select } from 'ember-power-select/components/power-select';
-import { includes } from 'lodash';
 
 import type { Icon } from '../../icons/types.ts';
 import LoadingIndicator from '../loading-indicator/index.gts';
@@ -192,7 +191,9 @@ export default class Picker extends Component<PickerSignature> {
   }
 
   get isSelected() {
-    return (option: PickerOption) => includes(this.args.selected, option);
+    return (option: PickerOption) => {
+      return this.args.selected.some((o) => o.id === option.id);
+    };
   }
 
   isLastOption = (option: PickerOption): boolean => {
@@ -251,10 +252,12 @@ export default class Picker extends Component<PickerSignature> {
   }
 
   onToggleItem = (item: PickerOption) => {
-    const isCurrentlySelected = this.args.selected.includes(item);
+    const isCurrentlySelected = this.args.selected.some(
+      (o) => o.id === item.id,
+    );
     let newSelected: PickerOption[];
     if (isCurrentlySelected) {
-      newSelected = this.args.selected.filter((o) => o !== item);
+      newSelected = this.args.selected.filter((o) => o.id !== item.id);
     } else {
       newSelected = [...this.args.selected, item];
     }
@@ -263,7 +266,9 @@ export default class Picker extends Component<PickerSignature> {
 
   onChange = (selected: PickerOption[]) => {
     // Ignore clicks on disabled options
-    const lastAdded = selected.find((opt) => !this.args.selected.includes(opt));
+    const lastAdded = selected.find(
+      (opt) => !this.args.selected.some((o) => o.id === opt.id),
+    );
     if (lastAdded?.disabled) {
       return;
     }

--- a/packages/boxel-ui/test-app/tests/integration/components/picker-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/picker-test.gts
@@ -92,17 +92,25 @@ module('Integration | Component | picker', function (hooks) {
 
     // Selected options should have checked checkboxes in the dropdown
     assert
-      .dom('[data-test-boxel-picker-option-row="1"] .picker-option-row__checkbox--selected')
+      .dom(
+        '[data-test-boxel-picker-option-row="1"] .picker-option-row__checkbox--selected',
+      )
       .exists('Option 1 checkbox is checked');
     assert
-      .dom('[data-test-boxel-picker-option-row="2"] .picker-option-row__checkbox--selected')
+      .dom(
+        '[data-test-boxel-picker-option-row="2"] .picker-option-row__checkbox--selected',
+      )
       .exists('Option 2 checkbox is checked');
     // Unselected options should have unchecked checkboxes
     assert
-      .dom('[data-test-boxel-picker-option-row="3"] .picker-option-row__checkbox--selected')
+      .dom(
+        '[data-test-boxel-picker-option-row="3"] .picker-option-row__checkbox--selected',
+      )
       .doesNotExist('Option 3 checkbox is unchecked');
     assert
-      .dom('[data-test-boxel-picker-option-row="4"] .picker-option-row__checkbox--selected')
+      .dom(
+        '[data-test-boxel-picker-option-row="4"] .picker-option-row__checkbox--selected',
+      )
       .doesNotExist('Option 4 checkbox is unchecked');
   });
 
@@ -224,7 +232,9 @@ module('Integration | Component | picker', function (hooks) {
     );
     // Checkbox should be checked for selected option
     assert
-      .dom('[data-test-boxel-picker-option-row="1"] .picker-option-row__checkbox--selected')
+      .dom(
+        '[data-test-boxel-picker-option-row="1"] .picker-option-row__checkbox--selected',
+      )
       .exists('Option 1 checkbox is checked after selecting');
 
     // Click again to deselect — should fall back to select-all
@@ -238,7 +248,9 @@ module('Integration | Component | picker', function (hooks) {
     );
     // Checkbox should be unchecked after deselecting
     assert
-      .dom('[data-test-boxel-picker-option-row="1"] .picker-option-row__checkbox--selected')
+      .dom(
+        '[data-test-boxel-picker-option-row="1"] .picker-option-row__checkbox--selected',
+      )
       .doesNotExist('Option 1 checkbox is unchecked after deselecting');
   });
 
@@ -347,10 +359,14 @@ module('Integration | Component | picker', function (hooks) {
     );
     // Option 1 checkbox should be checked, select-all unchecked
     assert
-      .dom('[data-test-boxel-picker-option-row="1"] .picker-option-row__checkbox--selected')
+      .dom(
+        '[data-test-boxel-picker-option-row="1"] .picker-option-row__checkbox--selected',
+      )
       .exists('Option 1 checkbox is checked');
     assert
-      .dom('[data-test-boxel-picker-option-row="select-all"] .picker-option-row__checkbox--selected')
+      .dom(
+        '[data-test-boxel-picker-option-row="select-all"] .picker-option-row__checkbox--selected',
+      )
       .doesNotExist('Select-all checkbox is unchecked');
   });
 
@@ -389,10 +405,14 @@ module('Integration | Component | picker', function (hooks) {
     );
     // Select-all checkbox should be checked, Option 1 unchecked
     assert
-      .dom('[data-test-boxel-picker-option-row="select-all"] .picker-option-row__checkbox--selected')
+      .dom(
+        '[data-test-boxel-picker-option-row="select-all"] .picker-option-row__checkbox--selected',
+      )
       .exists('Select-all checkbox is checked');
     assert
-      .dom('[data-test-boxel-picker-option-row="1"] .picker-option-row__checkbox--selected')
+      .dom(
+        '[data-test-boxel-picker-option-row="1"] .picker-option-row__checkbox--selected',
+      )
       .doesNotExist('Option 1 checkbox is unchecked after select-all');
   });
 

--- a/packages/boxel-ui/test-app/tests/integration/components/picker-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/picker-test.gts
@@ -89,6 +89,21 @@ module('Integration | Component | picker', function (hooks) {
     // Check that selected items are displayed (they should be in pills)
     await click('[data-test-boxel-picker-trigger]');
     assert.dom('[data-test-boxel-picker-selected-item]').exists({ count: 2 });
+
+    // Selected options should have checked checkboxes in the dropdown
+    assert
+      .dom('[data-test-boxel-picker-option-row="1"] .picker-option-row__checkbox--selected')
+      .exists('Option 1 checkbox is checked');
+    assert
+      .dom('[data-test-boxel-picker-option-row="2"] .picker-option-row__checkbox--selected')
+      .exists('Option 2 checkbox is checked');
+    // Unselected options should have unchecked checkboxes
+    assert
+      .dom('[data-test-boxel-picker-option-row="3"] .picker-option-row__checkbox--selected')
+      .doesNotExist('Option 3 checkbox is unchecked');
+    assert
+      .dom('[data-test-boxel-picker-option-row="4"] .picker-option-row__checkbox--selected')
+      .doesNotExist('Option 4 checkbox is unchecked');
   });
 
   test('picker opens dropdown when clicked', async function (assert) {
@@ -207,7 +222,12 @@ module('Integration | Component | picker', function (hooks) {
       '1',
       'Should have selected first option',
     );
+    // Checkbox should be checked for selected option
+    assert
+      .dom('[data-test-boxel-picker-option-row="1"] .picker-option-row__checkbox--selected')
+      .exists('Option 1 checkbox is checked after selecting');
 
+    // Click again to deselect — should fall back to select-all
     await click(
       firstOption.closest('.ember-power-select-option') as HTMLElement,
     );
@@ -216,6 +236,10 @@ module('Integration | Component | picker', function (hooks) {
       1,
       'Select-all option cannot be deselected',
     );
+    // Checkbox should be unchecked after deselecting
+    assert
+      .dom('[data-test-boxel-picker-option-row="1"] .picker-option-row__checkbox--selected')
+      .doesNotExist('Option 1 checkbox is unchecked after deselecting');
   });
 
   test('picker shows search input when searchEnabled is true', async function (assert) {
@@ -321,6 +345,13 @@ module('Integration | Component | picker', function (hooks) {
       ['1'],
       'select-all is removed once another option is selected',
     );
+    // Option 1 checkbox should be checked, select-all unchecked
+    assert
+      .dom('[data-test-boxel-picker-option-row="1"] .picker-option-row__checkbox--selected')
+      .exists('Option 1 checkbox is checked');
+    assert
+      .dom('[data-test-boxel-picker-option-row="select-all"] .picker-option-row__checkbox--selected')
+      .doesNotExist('Select-all checkbox is unchecked');
   });
 
   test('picker selects select-all when it is chosen after other options', async function (assert) {
@@ -356,6 +387,13 @@ module('Integration | Component | picker', function (hooks) {
       ['select-all'],
       'select-all replaces existing selections when selected',
     );
+    // Select-all checkbox should be checked, Option 1 unchecked
+    assert
+      .dom('[data-test-boxel-picker-option-row="select-all"] .picker-option-row__checkbox--selected')
+      .exists('Select-all checkbox is checked');
+    assert
+      .dom('[data-test-boxel-picker-option-row="1"] .picker-option-row__checkbox--selected')
+      .doesNotExist('Option 1 checkbox is unchecked after select-all');
   });
 
   test('picker hides remove button for select-all pill', async function (assert) {

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -28,6 +28,8 @@ import {
 
 import type { Query } from '@cardstack/runtime-common/query';
 
+import type { NewCardArgs } from '@cardstack/host/utils/card-search/types';
+
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import {
@@ -46,7 +48,6 @@ import type OperatorModeStateService from '../../services/operator-mode-state-se
 import type RealmService from '../../services/realm';
 import type RealmServerService from '../../services/realm-server';
 import type StoreService from '../../services/store';
-import type { NewCardArgs } from '@cardstack/host/utils/card-search/types';
 
 interface Signature {
   Args: {};

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -33,7 +33,7 @@ import type { Query } from '@cardstack/runtime-common/query';
 import { getFilterTypeRefs } from '@cardstack/host/utils/card-search/type-filter';
 import type { NewCardArgs } from '@cardstack/host/utils/card-search/types';
 
-import type { CardDef } from 'https://cardstack.com/base/card-api';
+import { type CardDef } from 'https://cardstack.com/base/card-api';
 
 import {
   suggestCardChooserTitle,

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -22,12 +22,15 @@ import {
   type CodeRef,
   type CreateNewCard,
   type Filter,
+  type ResolvedCodeRef,
   baseRealm,
   Deferred,
+  isResolvedCodeRef,
 } from '@cardstack/runtime-common';
 
 import type { Query } from '@cardstack/runtime-common/query';
 
+import { getFilterTypeRefs } from '@cardstack/host/utils/card-search/type-filter';
 import type { NewCardArgs } from '@cardstack/host/utils/card-search/types';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
@@ -113,6 +116,7 @@ export default class CardCatalogModal extends Component<Signature> {
             @searchKey={{state.searchKey}}
             @baseFilter={{state.baseFilter}}
             @initialSelectedRealms={{this.initialSelectedRealmsForPanel}}
+            @initialSelectedTypes={{this.initialSelectedTypesForPanel}}
             as |Bar Content|
           >
             <ModalContainer
@@ -245,6 +249,21 @@ export default class CardCatalogModal extends Component<Signature> {
       return undefined;
     }
     return [this.state.consumingRealm];
+  }
+
+  private get initialSelectedTypesForPanel(): ResolvedCodeRef[] | undefined {
+    let baseFilter = this.state?.baseFilter;
+    if (!baseFilter) {
+      return undefined;
+    }
+    let typeRefs = getFilterTypeRefs(baseFilter);
+    if (!typeRefs || typeRefs.length === 0) {
+      return undefined;
+    }
+    let refs = typeRefs
+      .filter((r) => !r.negated && isResolvedCodeRef(r.ref))
+      .map((r) => r.ref as ResolvedCodeRef);
+    return refs.length > 0 ? refs : undefined;
   }
 
   private get offerToCreateArg() {

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -111,9 +111,7 @@ export default class CardCatalogModal extends Component<Signature> {
           <SearchPanel
             @searchKey={{state.searchKey}}
             @baseFilter={{state.baseFilter}}
-            @availableRealmUrls={{state.availableRealmUrls}}
-            @consumingRealm={{state.consumingRealm}}
-            @preselectConsumingRealm={{state.preselectConsumingRealm}}
+            @initialSelectedRealms={{this.initialSelectedRealmsForPanel}}
             as |Bar Content|
           >
             <ModalContainer
@@ -240,6 +238,13 @@ export default class CardCatalogModal extends Component<Signature> {
 
   private get state(): State | undefined {
     return this.stateStack[this.stateStack.length - 1];
+  }
+
+  private get initialSelectedRealmsForPanel(): URL[] | undefined {
+    if (!this.state?.preselectConsumingRealm || !this.state?.consumingRealm) {
+      return undefined;
+    }
+    return [this.state.consumingRealm];
   }
 
   private get offerToCreateArg() {

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -46,7 +46,7 @@ import type OperatorModeStateService from '../../services/operator-mode-state-se
 import type RealmService from '../../services/realm';
 import type RealmServerService from '../../services/realm-server';
 import type StoreService from '../../services/store';
-import type { NewCardArgs } from '../card-search/utils';
+import type { NewCardArgs } from '@cardstack/host/utils/card-search/types';
 
 interface Signature {
   Args: {};

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -33,7 +33,7 @@ import type { Query } from '@cardstack/runtime-common/query';
 import { getFilterTypeRefs } from '@cardstack/host/utils/card-search/type-filter';
 import type { NewCardArgs } from '@cardstack/host/utils/card-search/types';
 
-import { type CardDef } from 'https://cardstack.com/base/card-api';
+import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import {
   suggestCardChooserTitle,

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -132,7 +132,6 @@ export default class CardCatalogModal extends Component<Signature> {
               <:header>
                 <Bar
                   class='card-catalog-search'
-                  @value={{state.searchKey}}
                   @onInput={{this.setSearchKey}}
                   @placeholder='Search for a card or enter card URL'
                   @pickerDestination='card-catalog-picker-wormhole'

--- a/packages/host/app/components/card-search/constants.ts
+++ b/packages/host/app/components/card-search/constants.ts
@@ -36,6 +36,13 @@ export const SECTION_SHOW_MORE_INCREMENT = 5;
 /**
  * Host-local SORT_OPTIONS compatible with realm server query expectations.
  * Aligned with SORT_OPTIONS in packages/base/components/cards-grid-layout.gts.
+ *
+ * Sort is dual-mode:
+ * - Server-side: the `sort` field is embedded in the search Query sent to
+ *   the realm server, affecting prerendered search results (realm sections).
+ * - Client-side: `sortAndFilterRecentCards()` in utils/card-search/recent-cards.ts
+ *   applies the same sort locally to recent cards, matching by `displayName`.
+ * - URL card lookup: no sort (single card).
  */
 export const SORT_OPTIONS: SortOption[] = [
   {

--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -15,9 +15,10 @@ import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import CardRenderer from '../card-renderer';
 
-import { removeFileExtension } from './utils';
-
-import type { NewCardArgs } from './utils';
+import {
+  removeFileExtension,
+  type NewCardArgs,
+} from '@cardstack/host/utils/card-search/types';
 import type { ComponentLike } from '@glint/template';
 
 type ItemType = ComponentLike<{ Element: Element }> | CardDef | NewCardArgs;

--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -11,14 +11,15 @@ import { isCardInstance } from '@cardstack/runtime-common';
 
 import type RealmService from '@cardstack/host/services/realm';
 
-import type { CardDef } from 'https://cardstack.com/base/card-api';
-
-import CardRenderer from '../card-renderer';
-
 import {
   removeFileExtension,
   type NewCardArgs,
 } from '@cardstack/host/utils/card-search/types';
+
+import type { CardDef } from 'https://cardstack.com/base/card-api';
+
+import CardRenderer from '../card-renderer';
+
 import type { ComponentLike } from '@glint/template';
 
 type ItemType = ComponentLike<{ Element: Element }> | CardDef | NewCardArgs;

--- a/packages/host/app/components/card-search/panel.gts
+++ b/packages/host/app/components/card-search/panel.gts
@@ -22,6 +22,7 @@ import {
   baseFieldRef,
   baseRef,
   CardContextName,
+  codeRefFromInternalKey,
   GetCardCollectionContextName,
   internalKeyFor,
   isResolvedCodeRef,
@@ -59,11 +60,10 @@ interface Signature {
   Args: {
     searchKey: string;
     baseFilter?: Filter;
-    initialSelectedType?: ResolvedCodeRef;
-    availableRealmUrls?: string[];
-    consumingRealm?: URL;
-    preselectConsumingRealm?: boolean;
-    onFilterChange?: () => void;
+    initialSelectedTypes?: ResolvedCodeRef[];
+    initialSelectedRealms?: URL[];
+    onRealmChange?: (selectedRealms: URL[]) => void;
+    onTypeChange?: (selectedTypes: ResolvedCodeRef[]) => void;
   };
   Blocks: {
     default: [
@@ -110,30 +110,29 @@ export default class SearchPanel extends Component<Signature> {
   @consume(GetCardCollectionContextName)
   declare private getCardCollection: getCardCollection;
 
-  @tracked private selectedRealms: PickerOption[] = this.initialSelectedRealms;
+  @tracked private selectedRealms: PickerOption[] =
+    this.computeInitialSelectedRealms();
 
-  private get shouldPreselectConsumingRealm(): boolean {
-    return Boolean(this.args.preselectConsumingRealm);
-  }
-
-  private get initialSelectedRealms(): PickerOption[] {
-    let consumingRealm = this.args.consumingRealm;
-    if (!this.shouldPreselectConsumingRealm || !consumingRealm) {
+  private computeInitialSelectedRealms(): PickerOption[] {
+    let realmURLs = this.args.initialSelectedRealms;
+    if (!realmURLs || realmURLs.length === 0) {
       return [];
     }
-    let realmURL = consumingRealm.href;
-    let info = this.realm.info(realmURL);
-    let label = info?.name ?? realmURL;
-    let icon = info?.iconURL ?? undefined;
-    return [{ id: realmURL, icon, label, type: 'option' }];
+    return realmURLs.map((url) => {
+      let realmURL = url.href;
+      let info = this.realm.info(realmURL);
+      let label = info?.name ?? realmURL;
+      let icon = info?.iconURL ?? undefined;
+      return { id: realmURL, icon, label, type: 'option' as const };
+    });
   }
 
   private get initialFocusedSectionId(): string | null {
-    let consumingRealm = this.args.consumingRealm;
-    if (!this.shouldPreselectConsumingRealm || !consumingRealm) {
+    let realmURLs = this.args.initialSelectedRealms;
+    if (!realmURLs || realmURLs.length === 0) {
       return null;
     }
-    return `realm:${consumingRealm.href}`;
+    return `realm:${realmURLs[0].href}`;
   }
 
   @tracked private activeSort: SortOption = SORT_OPTIONS[0];
@@ -163,9 +162,7 @@ export default class SearchPanel extends Component<Signature> {
       (opt) => opt.type === 'select-all',
     );
     if (hasSelectAll || this.selectedRealms.length === 0) {
-      return (
-        this.args.availableRealmUrls ?? this.realmServer.availableRealmURLs
-      );
+      return this.realmServer.availableRealmURLs;
     }
     return this.selectedRealms.map((opt) => opt.id).filter(Boolean);
   }
@@ -229,16 +226,18 @@ export default class SearchPanel extends Component<Signature> {
         this._typesTotalCount = result.meta.page.total;
         this._hasMoreTypes = result.data.length < result.meta.page.total;
 
-        // If there are selected types (or an initialSelectedType) not yet in
+        // If there are selected types (or initialSelectedTypes) not yet in
         // the fetched results, keep fetching more pages until they're found.
         const selectedIds = new Set(
           this._previousSelectedTypes
             .filter((opt) => opt.type !== 'select-all')
             .map((opt) => opt.id),
         );
-        const initialType = this.args.initialSelectedType;
-        if (initialType) {
-          selectedIds.add(internalKeyFor(initialType, undefined));
+        const initialTypes = this.args.initialSelectedTypes;
+        if (initialTypes) {
+          for (const ref of initialTypes) {
+            selectedIds.add(internalKeyFor(ref, undefined));
+          }
         }
 
         if (selectedIds.size > 0 && this._hasMoreTypes) {
@@ -377,28 +376,30 @@ export default class SearchPanel extends Component<Signature> {
     // An empty array lets the Picker's ensureDefaultSelection() handle
     // selecting the built-in select-all option automatically.
     const prev = this._previousSelectedTypes;
-    const initialType = this.args.initialSelectedType;
+    const initialTypes = this.args.initialSelectedTypes;
     const hadSelectAll =
       prev.length === 0 || prev.some((opt) => opt.type === 'select-all');
-    if (initialType && prev.length === 0) {
-      // First launch with initialSelectedType (e.g., from "Find Instances").
+    if (initialTypes && initialTypes.length > 0 && prev.length === 0) {
+      // First launch with initialSelectedTypes (e.g., from "Find Instances").
       // Only applied when prev is empty (first computation). After that,
       // _previousSelectedTypes is always non-empty, preserving user's choice.
-      const typeKey = internalKeyFor(initialType, undefined);
-      const matchingOption = optionsById.get(typeKey);
-      if (matchingOption) {
-        value.selected = [matchingOption];
-      } else {
-        // Type summaries not yet loaded; create a synthetic option so the
-        // search query is type-constrained immediately.
-        value.selected = [
-          {
+      const matched: PickerOption[] = [];
+      for (const ref of initialTypes) {
+        const typeKey = internalKeyFor(ref, undefined);
+        const matchingOption = optionsById.get(typeKey);
+        if (matchingOption) {
+          matched.push(matchingOption);
+        } else {
+          // Type summaries not yet loaded; create a synthetic option so the
+          // search query is type-constrained immediately.
+          matched.push({
             id: typeKey,
-            label: initialType.name,
+            label: ref.name,
             type: 'option',
-          } as PickerOption,
-        ];
+          } as PickerOption);
+        }
       }
+      value.selected = matched;
     } else if (hadSelectAll) {
       // If baseFilter constrains to specific types and they exist in options,
       // auto-select them instead of defaulting to "Any Type"
@@ -456,14 +457,21 @@ export default class SearchPanel extends Component<Signature> {
   @action
   private onRealmChange(selected: PickerOption[]) {
     this.selectedRealms = selected;
-    this.args.onFilterChange?.();
+    const realmURLs = selected
+      .filter((opt) => opt.type !== 'select-all')
+      .map((opt) => new URL(opt.id));
+    this.args.onRealmChange?.(realmURLs);
   }
 
   @action
   private onTypeChange(selected: PickerOption[]) {
     this._previousSelectedTypes = selected;
     this.typeFilter.selected = selected;
-    this.args.onFilterChange?.();
+    const types = selected
+      .filter((opt) => opt.type !== 'select-all')
+      .map((opt) => codeRefFromInternalKey(opt.id))
+      .filter((ref): ref is ResolvedCodeRef => ref !== undefined);
+    this.args.onTypeChange?.(types);
   }
 
   @action

--- a/packages/host/app/components/card-search/panel.gts
+++ b/packages/host/app/components/card-search/panel.gts
@@ -1,60 +1,27 @@
-import { isDestroyed, isDestroying } from '@ember/destroyable';
 import { action } from '@ember/object';
 import { getOwner } from '@ember/owner';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import { cached, tracked } from '@glimmer/tracking';
-
-import { restartableTask, timeout } from 'ember-concurrency';
-import { consume } from 'ember-provide-consume-context';
-
-import { resource, use } from 'ember-resources';
-
-import { TrackedObject } from 'tracked-built-ins';
-
-import type { PickerOption } from '@cardstack/boxel-ui/components';
+import { tracked } from '@glimmer/tracking';
 
 import {
   type Filter,
   type ResolvedCodeRef,
-  type getCardCollection,
-  baseCardRef,
-  baseFieldRef,
-  baseRef,
-  CardContextName,
-  codeRefFromInternalKey,
-  GetCardCollectionContextName,
-  internalKeyFor,
-  isResolvedCodeRef,
 } from '@cardstack/runtime-common';
 
-import { getPrerenderedSearch } from '@cardstack/host/resources/prerendered-search';
-import type RealmService from '@cardstack/host/services/realm';
+import type { RealmFilter } from '@cardstack/host/components/realm-picker';
+import type { TypeFilter } from '@cardstack/host/components/type-picker';
+import {
+  getTypeSummaries,
+  TypeSummariesResource,
+} from '@cardstack/host/resources/type-summaries';
 import type RealmServerService from '@cardstack/host/services/realm-server';
-import type RecentCards from '@cardstack/host/services/recent-cards-service';
-
-import type { CardContext, CardDef } from 'https://cardstack.com/base/card-api';
 
 import { SORT_OPTIONS, type SortOption } from './constants';
 import SearchBar from './search-bar';
 import SearchContent from './search-content';
-import {
-  buildSearchQuery,
-  filterCardsByTypeRefs,
-  getFilterTypeRefs,
-  shouldSkipSearchQuery,
-} from './utils';
 
 import type { WithBoundArgs } from '@glint/template';
-
-const OWNER_DESTROYED_ERROR = 'OWNER_DESTROYED_ERROR';
-
-type TypeSummaryItem = {
-  id: string;
-  type: string;
-  attributes: { displayName: string; total: number; iconHTML: string };
-  meta?: { realmURL: string };
-};
 
 interface Signature {
   Args: {
@@ -69,63 +36,46 @@ interface Signature {
     default: [
       WithBoundArgs<
         typeof SearchBar,
-        | 'selectedRealms'
-        | 'onRealmChange'
-        | 'selectedTypes'
-        | 'onTypeChange'
-        | 'typeOptions'
-        | 'onTypeSearchChange'
-        | 'onLoadMoreTypes'
-        | 'hasMoreTypes'
-        | 'isLoadingTypes'
-        | 'isLoadingMoreTypes'
-        | 'typesTotalCount'
-        | 'disableSelectAll'
+        'value' | 'realmFilter' | 'typeFilter'
       >,
       WithBoundArgs<
         typeof SearchContent,
         | 'searchKey'
-        | 'selectedRealmURLs'
-        | 'selectedCardTypes'
+        | 'realmFilter'
+        | 'typeFilter'
         | 'baseFilter'
-        | 'skipTypeFiltering'
-        | 'searchResource'
         | 'activeSort'
         | 'onSortChange'
-        | 'filteredRecentCards'
         | 'initialFocusedSection'
       >,
-      string,
     ];
   };
 }
 
 export default class SearchPanel extends Component<Signature> {
-  @service declare private realm: RealmService;
   @service declare private realmServer: RealmServerService;
-  @service declare private recentCardsService: RecentCards;
-  @consume(CardContextName) declare private cardContext:
-    | CardContext
-    | undefined;
-  @consume(GetCardCollectionContextName)
-  declare private getCardCollection: getCardCollection;
 
-  @tracked private selectedRealms: PickerOption[] =
-    this.computeInitialSelectedRealms();
+  @tracked private selectedRealms: URL[] =
+    this.args.initialSelectedRealms ?? [];
+  @tracked private activeSort: SortOption = SORT_OPTIONS[0];
 
-  private computeInitialSelectedRealms(): PickerOption[] {
-    let realmURLs = this.args.initialSelectedRealms;
-    if (!realmURLs || realmURLs.length === 0) {
-      return [];
-    }
-    return realmURLs.map((url) => {
-      let realmURL = url.href;
-      let info = this.realm.info(realmURL);
-      let label = info?.name ?? realmURL;
-      let icon = info?.iconURL ?? undefined;
-      return { id: realmURL, icon, label, type: 'option' as const };
-    });
+  // Re-export for tests that override PAGE_SIZE
+  static get PAGE_SIZE() {
+    return TypeSummariesResource.PAGE_SIZE;
   }
+  static set PAGE_SIZE(v: number) {
+    TypeSummariesResource.PAGE_SIZE = v;
+  }
+
+  private typeSummaries = getTypeSummaries(
+    this,
+    getOwner(this)!,
+    () => ({
+      realmURLs: this.selectedRealmURLs,
+      baseFilter: this.args.baseFilter,
+      initialSelectedTypes: this.args.initialSelectedTypes,
+    }),
+  );
 
   private get initialFocusedSectionId(): string | null {
     let realmURLs = this.args.initialSelectedRealms;
@@ -135,343 +85,53 @@ export default class SearchPanel extends Component<Signature> {
     return `realm:${realmURLs[0].href}`;
   }
 
-  @tracked private activeSort: SortOption = SORT_OPTIONS[0];
-
-  // Type summaries state
-  @tracked private _typeSearchKey = '';
-  @tracked private _typeSummariesData: TypeSummaryItem[] = [];
-  @tracked private _isLoadingTypes = false;
-  @tracked private _isLoadingMoreTypes = false;
-  @tracked private _hasMoreTypes = false;
-  @tracked private _typesTotalCount = 0;
-
-  @cached
-  private get recentCardCollection(): ReturnType<getCardCollection> {
-    return this.getCardCollection(
-      this,
-      () => this.recentCardsService.recentCardIds,
-    );
-  }
-
-  // Non-tracked: persists across resource re-runs without creating
-  // tracking dependencies. Updated by onTypeChange and the resource itself.
-  private _previousSelectedTypes: PickerOption[] = [];
-
   private get selectedRealmURLs(): string[] {
-    const hasSelectAll = this.selectedRealms.some(
-      (opt) => opt.type === 'select-all',
-    );
-    if (hasSelectAll || this.selectedRealms.length === 0) {
+    if (this.selectedRealms.length === 0) {
       return this.realmServer.availableRealmURLs;
     }
-    return this.selectedRealms.map((opt) => opt.id).filter(Boolean);
+    return this.selectedRealms.map((url) => url.href);
   }
 
-  private get joinedSelectedRealmURLs(): string {
-    return this.selectedRealmURLs.join(',');
-  }
+  // -- Filter objects --
 
-  private get baseFilteredRecentCards(): CardDef[] {
-    const cards =
-      (this.recentCardCollection?.cards?.filter(Boolean) as
-        | CardDef[]
-        | undefined) ?? [];
-    const realmURLs = this.selectedRealmURLs;
-    const realmFiltered = cards.filter(
-      (c) => c.id && realmURLs.some((url) => c.id.startsWith(url)),
-    );
-    const typeRefs = getFilterTypeRefs(this.args.baseFilter);
-    return filterCardsByTypeRefs(realmFiltered, typeRefs);
-  }
-
-  private get cardComponentModifier() {
-    if (isDestroying(this) || isDestroyed(this)) {
-      return undefined;
-    }
-    try {
-      return this.cardContext?.cardComponentModifier;
-    } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.includes(OWNER_DESTROYED_ERROR)
-      ) {
-        return undefined;
-      }
-      throw error;
-    }
-  }
-
-  @tracked private _currentPage = 0;
-  static PAGE_SIZE = 25;
-
-  private fetchTypeSummariesTask = restartableTask(
-    async (realmURLs: string[], searchKey: string) => {
-      if (searchKey) {
-        await timeout(300); // debounce search
-      } else {
-        await Promise.resolve(); // yield to avoid autotracking assertion
-      }
-      if (isDestroyed(this) || isDestroying(this)) return;
-      this._isLoadingTypes = true;
-      this._currentPage = 0;
-
-      try {
-        let result = await this.realmServer.fetchCardTypeSummaries(realmURLs, {
-          searchKey: searchKey || undefined,
-          page: { number: 0, size: SearchPanel.PAGE_SIZE },
-        });
-        if (isDestroyed(this) || isDestroying(this)) return;
-
-        this._typeSummariesData = result.data;
-        this._typesTotalCount = result.meta.page.total;
-        this._hasMoreTypes = result.data.length < result.meta.page.total;
-
-        // If there are selected types (or initialSelectedTypes) not yet in
-        // the fetched results, keep fetching more pages until they're found.
-        const selectedIds = new Set(
-          this._previousSelectedTypes
-            .filter((opt) => opt.type !== 'select-all')
-            .map((opt) => opt.id),
-        );
-        const initialTypes = this.args.initialSelectedTypes;
-        if (initialTypes) {
-          for (const ref of initialTypes) {
-            selectedIds.add(internalKeyFor(ref, undefined));
-          }
-        }
-
-        if (selectedIds.size > 0 && this._hasMoreTypes) {
-          while (this._hasMoreTypes) {
-            const fetchedIds = new Set(
-              this._typeSummariesData.map((d) => d.id),
-            );
-            if ([...selectedIds].every((id) => fetchedIds.has(id))) break;
-
-            const nextPage = this._currentPage + 1;
-            let moreResult = await this.realmServer.fetchCardTypeSummaries(
-              realmURLs,
-              {
-                searchKey: searchKey || undefined,
-                page: { number: nextPage, size: SearchPanel.PAGE_SIZE },
-              },
-            );
-            if (isDestroyed(this) || isDestroying(this)) return;
-
-            this._currentPage = nextPage;
-            this._typeSummariesData = [
-              ...this._typeSummariesData,
-              ...moreResult.data,
-            ];
-            this._hasMoreTypes =
-              this._typeSummariesData.length < moreResult.meta.page.total;
-          }
-        }
-
-        this._isLoadingTypes = false;
-      } catch (e) {
-        console.error('Failed to fetch card type summaries', e);
-        if (!isDestroyed(this) && !isDestroying(this)) {
-          this._typeSummariesData = [];
-          this._typesTotalCount = 0;
-          this._hasMoreTypes = false;
-          this._isLoadingTypes = false;
-        }
-      }
-    },
-  );
-
-  // Resource that watches selectedRealmURLs and typeSearchKey to trigger fetches
-  @use private _typeFetchTrigger = resource(() => {
-    let realmURLs = this.selectedRealmURLs;
-    let searchKey = this._typeSearchKey;
-
-    this.fetchTypeSummariesTask.perform(realmURLs, searchKey);
-
-    return { realmURLs, searchKey };
-  });
-
-  private get baseFilterCodeRefs(): Set<string> | undefined {
-    const typeRefs = getFilterTypeRefs(this.args.baseFilter);
-    if (!typeRefs || typeRefs.length === 0) {
-      return undefined;
-    }
-    const refs = new Set<string>();
-    for (const { ref, negated } of typeRefs) {
-      if (!negated && isResolvedCodeRef(ref)) {
-        refs.add(internalKeyFor(ref, undefined));
-      }
-    }
-    if (refs.size === 0) return undefined;
-
-    // CardDef/FieldDef are root types — all card types inherit from them,
-    // so filtering by them would incorrectly show zero results. Skip.
-    const baseKeys = new Set([
-      internalKeyFor(baseCardRef, undefined),
-      internalKeyFor(baseFieldRef, undefined),
-      internalKeyFor(baseRef, undefined),
-    ]);
-    if ([...refs].every((r) => baseKeys.has(r))) {
-      return undefined;
-    }
-
-    return refs;
-  }
-
-  private get hasNonRootBaseFilter(): boolean {
-    return this.baseFilterCodeRefs !== undefined;
-  }
-
-  @use private typeFilter = resource(() => {
-    // Access _typeFetchTrigger to ensure we re-run when fetch completes
-    this._typeFetchTrigger;
-
-    let value: { selected: PickerOption[]; options: PickerOption[] } =
-      new TrackedObject({
-        selected: [],
-        options: [],
-      });
-
-    const allowedCodeRefs = this.baseFilterCodeRefs;
-    const optionsById = new Map<string, PickerOption>();
-
-    const rootTypeKeys = new Set([
-      internalKeyFor(baseCardRef, undefined),
-      internalKeyFor(baseFieldRef, undefined),
-      internalKeyFor(baseRef, undefined),
-    ]);
-
-    for (const item of this._typeSummariesData) {
-      const name = item.attributes.displayName;
-      const codeRef = item.id;
-      if (!name) {
-        continue;
-      }
-
-      // Never show root types — they are internal meta types
-      if (rootTypeKeys.has(codeRef)) {
-        continue;
-      }
-
-      // When baseFilter constrains to specific types, only show matching types
-      if (allowedCodeRefs && !allowedCodeRefs.has(codeRef)) {
-        continue;
-      }
-
-      optionsById.set(codeRef, {
-        id: codeRef,
-        label: name,
-        tooltip: codeRef,
-        icon: item.attributes.iconHTML ?? undefined,
-        type: 'option',
-      });
-    }
-
-    value.options = [
-      ...[...optionsById.values()].sort((a, b) =>
-        a.label.localeCompare(b.label),
-      ),
-    ];
-
-    // Recalculate selected based on previous user selection.
-    // An empty array lets the Picker's ensureDefaultSelection() handle
-    // selecting the built-in select-all option automatically.
-    const prev = this._previousSelectedTypes;
-    const initialTypes = this.args.initialSelectedTypes;
-    const hadSelectAll =
-      prev.length === 0 || prev.some((opt) => opt.type === 'select-all');
-    if (initialTypes && initialTypes.length > 0 && prev.length === 0) {
-      // First launch with initialSelectedTypes (e.g., from "Find Instances").
-      // Only applied when prev is empty (first computation). After that,
-      // _previousSelectedTypes is always non-empty, preserving user's choice.
-      const matched: PickerOption[] = [];
-      for (const ref of initialTypes) {
-        const typeKey = internalKeyFor(ref, undefined);
-        const matchingOption = optionsById.get(typeKey);
-        if (matchingOption) {
-          matched.push(matchingOption);
-        } else {
-          // Type summaries not yet loaded; create a synthetic option so the
-          // search query is type-constrained immediately.
-          matched.push({
-            id: typeKey,
-            label: ref.name,
-            type: 'option',
-          } as PickerOption);
-        }
-      }
-      value.selected = matched;
-    } else if (hadSelectAll) {
-      // If baseFilter constrains to specific types and they exist in options,
-      // auto-select them instead of defaulting to "Any Type"
-      const baseTypeRefs = getFilterTypeRefs(this.args.baseFilter);
-      const baseRefs =
-        baseTypeRefs
-          ?.filter((r) => !r.negated && isResolvedCodeRef(r.ref))
-          .map((r) => internalKeyFor(r.ref, undefined)) ?? [];
-      if (baseRefs.length > 0) {
-        const autoSelected = baseRefs
-          .filter((ref) => optionsById.has(ref))
-          .map((ref) => optionsById.get(ref)!);
-        value.selected = autoSelected.length > 0 ? autoSelected : [];
-      } else {
-        value.selected = [];
-      }
-    } else if (this._isLoadingTypes || this._isLoadingMoreTypes) {
-      // Type summaries still loading — keep previous selections
-      // to avoid jarring UI changes.
-      value.selected = prev;
-    } else {
-      // Keep previous selections that still exist in the new options,
-      // mapping to new object references so Picker's isSelected (which
-      // uses reference equality via lodash includes) works correctly.
-      const kept = prev
-        .filter((opt) => opt.type !== 'select-all' && optionsById.has(opt.id))
-        .map((opt) => optionsById.get(opt.id)!);
-      value.selected = kept.length > 0 ? kept : [];
-    }
-
-    this._previousSelectedTypes = value.selected;
-    return value;
-  });
-
-  private searchResource = getPrerenderedSearch(this, getOwner(this)!, () => {
-    // Consume typeFilter.selected outside the ternary so the tracking
-    // dependency is always established, even when the query is skipped.
-    const selectedTypeIds = this.typeFilter.selected.map((opt) => opt.id);
+  private get realmFilter(): RealmFilter {
     return {
-      query: shouldSkipSearchQuery(this.args.searchKey, this.args.baseFilter)
-        ? undefined
-        : buildSearchQuery(
-            this.args.searchKey,
-            this.activeSort,
-            this.args.baseFilter,
-            selectedTypeIds,
-          ),
-      format: 'fitted' as const,
-      realms: this.selectedRealmURLs,
-      isLive: true,
-      cardComponentModifier: this.cardComponentModifier,
+      selected: this.selectedRealms,
+      onChange: this.onRealmChange,
+      selectedURLs: this.selectedRealmURLs,
     };
-  });
+  }
+
+  private get typeFilter(): TypeFilter {
+    let ts = this.typeSummaries;
+    return {
+      options: ts.options,
+      selected: ts.selected,
+      onChange: this.onTypeChange,
+      onSearchChange: this.onTypeSearchChange,
+      onLoadMore: this.onLoadMoreTypes,
+      hasMore: ts.hasMore,
+      isLoading: ts.isLoading,
+      isLoadingMore: ts.isLoadingMore,
+      totalCount: ts.totalCount,
+      disableSelectAll: ts.hasNonRootBaseFilter,
+      skipTypeFiltering: ts.hasNonRootBaseFilter,
+      selectedTypeIds: ts.selectedTypeIds,
+    };
+  }
+
+  // -- Actions --
 
   @action
-  private onRealmChange(selected: PickerOption[]) {
+  private onRealmChange(selected: URL[]) {
     this.selectedRealms = selected;
-    const realmURLs = selected
-      .filter((opt) => opt.type !== 'select-all')
-      .map((opt) => new URL(opt.id));
-    this.args.onRealmChange?.(realmURLs);
+    this.args.onRealmChange?.(selected);
   }
 
   @action
-  private onTypeChange(selected: PickerOption[]) {
-    this._previousSelectedTypes = selected;
-    this.typeFilter.selected = selected;
-    const types = selected
-      .filter((opt) => opt.type !== 'select-all')
-      .map((opt) => codeRefFromInternalKey(opt.id))
-      .filter((ref): ref is ResolvedCodeRef => ref !== undefined);
-    this.args.onTypeChange?.(types);
+  private onTypeChange(selected: ResolvedCodeRef[]) {
+    this.typeSummaries.updateSelected(selected);
+    this.args.onTypeChange?.(selected);
   }
 
   @action
@@ -481,81 +141,32 @@ export default class SearchPanel extends Component<Signature> {
 
   @action
   private onTypeSearchChange(term: string) {
-    this._typeSearchKey = term;
-    this.fetchTypeSummariesTask.perform(this.selectedRealmURLs, term);
+    this.typeSummaries.onSearchChange(term);
   }
-
-  private loadMoreTypesTask = restartableTask(async () => {
-    if (isDestroyed(this) || isDestroying(this)) return;
-    this._isLoadingMoreTypes = true;
-    const nextPage = this._currentPage + 1;
-
-    try {
-      let result = await this.realmServer.fetchCardTypeSummaries(
-        this.selectedRealmURLs,
-        {
-          searchKey: this._typeSearchKey || undefined,
-          page: { number: nextPage, size: SearchPanel.PAGE_SIZE },
-        },
-      );
-      if (isDestroyed(this) || isDestroying(this)) return;
-
-      this._currentPage = nextPage;
-      this._typeSummariesData = [...this._typeSummariesData, ...result.data];
-      const totalFetched = this._typeSummariesData.length;
-      this._hasMoreTypes = totalFetched < result.meta.page.total;
-      this._isLoadingMoreTypes = false;
-    } catch (e) {
-      console.error('Failed to load more card type summaries', e);
-      if (!isDestroyed(this) && !isDestroying(this)) {
-        this._isLoadingMoreTypes = false;
-      }
-    }
-  });
 
   @action
   private onLoadMoreTypes() {
-    if (
-      this._isLoadingTypes ||
-      this._isLoadingMoreTypes ||
-      !this._hasMoreTypes
-    ) {
-      return;
-    }
-    this.loadMoreTypesTask.perform();
+    this.typeSummaries.onLoadMore();
   }
 
   <template>
     {{yield
       (component
         SearchBar
-        selectedRealms=this.selectedRealms
-        onRealmChange=this.onRealmChange
-        selectedTypes=this.typeFilter.selected
-        onTypeChange=this.onTypeChange
-        typeOptions=this.typeFilter.options
-        onTypeSearchChange=this.onTypeSearchChange
-        onLoadMoreTypes=this.onLoadMoreTypes
-        hasMoreTypes=this._hasMoreTypes
-        isLoadingTypes=this._isLoadingTypes
-        isLoadingMoreTypes=this._isLoadingMoreTypes
-        typesTotalCount=this._typesTotalCount
-        disableSelectAll=this.hasNonRootBaseFilter
+        value=@searchKey
+        realmFilter=this.realmFilter
+        typeFilter=this.typeFilter
       )
       (component
         SearchContent
         searchKey=@searchKey
-        selectedRealmURLs=this.selectedRealmURLs
-        selectedCardTypes=this.typeFilter.selected
+        realmFilter=this.realmFilter
+        typeFilter=this.typeFilter
         baseFilter=@baseFilter
-        skipTypeFiltering=this.hasNonRootBaseFilter
-        searchResource=this.searchResource
         activeSort=this.activeSort
         onSortChange=this.onSortChange
-        filteredRecentCards=this.baseFilteredRecentCards
         initialFocusedSection=this.initialFocusedSectionId
       )
-      this.joinedSelectedRealmURLs
     }}
   </template>
 }

--- a/packages/host/app/components/card-search/panel.gts
+++ b/packages/host/app/components/card-search/panel.gts
@@ -4,17 +4,11 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import {
-  type Filter,
-  type ResolvedCodeRef,
-} from '@cardstack/runtime-common';
+import { type Filter, type ResolvedCodeRef } from '@cardstack/runtime-common';
 
 import type { RealmFilter } from '@cardstack/host/components/realm-picker';
 import type { TypeFilter } from '@cardstack/host/components/type-picker';
-import {
-  getTypeSummaries,
-  TypeSummariesResource,
-} from '@cardstack/host/resources/type-summaries';
+import { getTypeSummaries } from '@cardstack/host/resources/type-summaries';
 import type RealmServerService from '@cardstack/host/services/realm-server';
 
 import { SORT_OPTIONS, type SortOption } from './constants';
@@ -34,10 +28,7 @@ interface Signature {
   };
   Blocks: {
     default: [
-      WithBoundArgs<
-        typeof SearchBar,
-        'value' | 'realmFilter' | 'typeFilter'
-      >,
+      WithBoundArgs<typeof SearchBar, 'value' | 'realmFilter' | 'typeFilter'>,
       WithBoundArgs<
         typeof SearchContent,
         | 'searchKey'
@@ -59,23 +50,11 @@ export default class SearchPanel extends Component<Signature> {
     this.args.initialSelectedRealms ?? [];
   @tracked private activeSort: SortOption = SORT_OPTIONS[0];
 
-  // Re-export for tests that override PAGE_SIZE
-  static get PAGE_SIZE() {
-    return TypeSummariesResource.PAGE_SIZE;
-  }
-  static set PAGE_SIZE(v: number) {
-    TypeSummariesResource.PAGE_SIZE = v;
-  }
-
-  private typeSummaries = getTypeSummaries(
-    this,
-    getOwner(this)!,
-    () => ({
-      realmURLs: this.selectedRealmURLs,
-      baseFilter: this.args.baseFilter,
-      initialSelectedTypes: this.args.initialSelectedTypes,
-    }),
-  );
+  private typeSummaries = getTypeSummaries(this, getOwner(this)!, () => ({
+    realmURLs: this.selectedRealmURLs,
+    baseFilter: this.args.baseFilter,
+    initialSelectedTypes: this.args.initialSelectedTypes,
+  }));
 
   private get initialFocusedSectionId(): string | null {
     let realmURLs = this.args.initialSelectedRealms;
@@ -116,7 +95,6 @@ export default class SearchPanel extends Component<Signature> {
       totalCount: ts.totalCount,
       disableSelectAll: ts.hasNonRootBaseFilter,
       skipTypeFiltering: ts.hasNonRootBaseFilter,
-      selectedTypeIds: ts.selectedTypeIds,
     };
   }
 

--- a/packages/host/app/components/card-search/panel.gts
+++ b/packages/host/app/components/card-search/panel.gts
@@ -4,7 +4,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import { type Filter, type ResolvedCodeRef } from '@cardstack/runtime-common';
+import type { Filter, ResolvedCodeRef } from '@cardstack/runtime-common';
 
 import type { RealmFilter } from '@cardstack/host/components/realm-picker';
 import type { TypeFilter } from '@cardstack/host/components/type-picker';

--- a/packages/host/app/components/card-search/search-bar.gts
+++ b/packages/host/app/components/card-search/search-bar.gts
@@ -8,12 +8,15 @@ import {
   BoxelInput,
   type BoxelInputBottomTreatments,
 } from '@cardstack/boxel-ui/components';
-import type { PickerOption } from '@cardstack/boxel-ui/components';
 import { IconSearch } from '@cardstack/boxel-ui/icons';
 import { autoFocus } from '@cardstack/boxel-ui/modifiers';
 
-import RealmPicker from '@cardstack/host/components/realm-picker';
-import TypePicker from '@cardstack/host/components/type-picker';
+import RealmPicker, {
+  type RealmFilter,
+} from '@cardstack/host/components/realm-picker';
+import TypePicker, {
+  type TypeFilter,
+} from '@cardstack/host/components/type-picker';
 
 let elementCallback = modifier(
   (element, [callback]: [((element: HTMLElement) => void) | undefined]) => {
@@ -27,6 +30,8 @@ interface Signature {
   Element: HTMLElement;
   Args: {
     value: string;
+    realmFilter: RealmFilter;
+    typeFilter: TypeFilter;
     placeholder?: string;
     autocomplete?: string;
     onInput?: (value: string) => void;
@@ -34,18 +39,6 @@ interface Signature {
     onBlur?: (ev: Event) => void;
     onKeyDown?: (ev: Event) => void;
     onInputInsertion?: (element: HTMLElement) => void;
-    selectedRealms: PickerOption[];
-    onRealmChange: (selected: PickerOption[]) => void;
-    typeOptions: PickerOption[];
-    selectedTypes: PickerOption[];
-    onTypeChange: (selected: PickerOption[]) => void;
-    onTypeSearchChange?: (term: string) => void;
-    onLoadMoreTypes?: () => void;
-    hasMoreTypes?: boolean;
-    isLoadingTypes?: boolean;
-    isLoadingMoreTypes?: boolean;
-    typesTotalCount?: number;
-    disableSelectAll?: boolean;
     pickerDestination?: string;
     bottomTreatment?: BoxelInputBottomTreatments;
     state?: 'none' | 'valid' | 'invalid' | 'loading' | 'initial';
@@ -75,23 +68,13 @@ export default class SearchBar extends Component<Signature> {
       </div>
       <div class='search-sheet__search-bar-picker'>
         <RealmPicker
-          @selected={{@selectedRealms}}
-          @onChange={{@onRealmChange}}
+          @filter={{@realmFilter}}
           @destination={{@pickerDestination}}
         />
       </div>
       <div class='search-sheet__search-bar-picker'>
         <TypePicker
-          @options={{@typeOptions}}
-          @selected={{@selectedTypes}}
-          @onChange={{@onTypeChange}}
-          @onSearchChange={{@onTypeSearchChange}}
-          @onLoadMore={{@onLoadMoreTypes}}
-          @hasMore={{@hasMoreTypes}}
-          @isLoading={{@isLoadingTypes}}
-          @isLoadingMore={{@isLoadingMoreTypes}}
-          @totalCount={{@typesTotalCount}}
-          @disableSelectAll={{@disableSelectAll}}
+          @filter={{@typeFilter}}
           @destination={{@pickerDestination}}
         />
       </div>

--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -1,4 +1,6 @@
+import { isDestroyed, isDestroying } from '@ember/destroyable';
 import { action } from '@ember/object';
+import { getOwner } from '@ember/owner';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { cached, tracked } from '@glimmer/tracking';
@@ -8,27 +10,27 @@ import { consume } from 'ember-provide-consume-context';
 
 import pluralize from 'pluralize';
 
-import type { PickerOption } from '@cardstack/boxel-ui/components';
-
 import { eq } from '@cardstack/boxel-ui/helpers';
 
 import {
   type CodeRef,
   type Filter,
   type getCard,
+  type getCardCollection,
+  CardContextName,
   GetCardContextName,
+  GetCardCollectionContextName,
 } from '@cardstack/runtime-common';
 
-import { cardTypeDisplayName } from '@cardstack/runtime-common/helpers/card-type-display-name';
-
 import { urlForRealmLookup } from '@cardstack/host/lib/utils';
-import type { PrerenderedSearchResource } from '@cardstack/host/resources/prerendered-search';
+import { getPrerenderedSearch } from '@cardstack/host/resources/prerendered-search';
 import type LoaderService from '@cardstack/host/services/loader-service';
 import type RealmService from '@cardstack/host/services/realm';
 import type RealmServerService from '@cardstack/host/services/realm-server';
+import type RecentCards from '@cardstack/host/services/recent-cards-service';
 import type StoreService from '@cardstack/host/services/store';
 
-import type { CardDef } from 'https://cardstack.com/base/card-api';
+import type { CardContext, CardDef } from 'https://cardstack.com/base/card-api';
 
 import {
   SECTION_DISPLAY_LIMIT_FOCUSED,
@@ -43,7 +45,16 @@ import SearchResultSection from './search-result-section';
 
 import type { PrerenderedCard } from '../prerendered-card-search';
 
-import type { NewCardArgs } from './utils';
+import type { RealmFilter } from '@cardstack/host/components/realm-picker';
+import type { TypeFilter } from '@cardstack/host/components/type-picker';
+import {
+  buildSearchQuery,
+  cardMatchesTypeRef,
+  filterCardsByTypeRefs,
+  getFilterTypeRefs,
+  shouldSkipSearchQuery,
+  type NewCardArgs,
+} from './utils';
 import type { NamedArgs } from 'ember-modifier';
 
 interface ScrollToFocusedSectionSignature {
@@ -136,24 +147,21 @@ interface Signature {
   Element: HTMLElement;
   Args: {
     searchKey: string;
-    selectedRealmURLs: string[];
+    realmFilter: RealmFilter;
+    typeFilter: TypeFilter;
+    baseFilter?: Filter;
     isCompact: boolean;
     handleSelect: (selection: string | NewCardArgs) => void;
     selectedCards?: (string | NewCardArgs)[];
     multiSelect?: boolean;
     onSelectAll?: (cards: string[]) => void;
     onDeselectAll?: () => void;
-    baseFilter?: Filter;
-    skipTypeFiltering?: boolean;
     offerToCreate?: {
       ref: CodeRef;
       relativeTo: URL | undefined;
     };
     onSubmit?: (selection: string | NewCardArgs) => void;
     showHeader?: boolean;
-    selectedCardTypes?: PickerOption[];
-    filteredRecentCards?: CardDef[];
-    searchResource: PrerenderedSearchResource;
     activeSort: SortOption;
     onSortChange: (sort: SortOption) => void;
     initialFocusedSection?: string | null;
@@ -161,11 +169,15 @@ interface Signature {
   Blocks: {};
 }
 
+const OWNER_DESTROYED_ERROR = 'OWNER_DESTROYED_ERROR';
+
 export default class SearchContent extends Component<Signature> {
   @service declare loaderService: LoaderService;
   @service declare realm: RealmService;
   @service declare realmServer: RealmServerService;
   @service declare store: StoreService;
+  @service('recent-cards-service')
+  declare private recentCardsService: RecentCards;
 
   @tracked activeViewId = 'grid';
   /** Section id when focused: 'realm:<url>' or 'recents'. Null = no focus */
@@ -174,6 +186,71 @@ export default class SearchContent extends Component<Signature> {
   @tracked displayedCountBySection: Record<string, number> = {};
 
   @consume(GetCardContextName) declare private getCard: getCard;
+  @consume(CardContextName) declare private cardContext:
+    | CardContext
+    | undefined;
+  @consume(GetCardCollectionContextName)
+  declare private getCardCollection: getCardCollection;
+
+  // -- Internal resources (moved from SearchPanel) --
+
+  private get cardComponentModifier() {
+    if (isDestroying(this) || isDestroyed(this)) {
+      return undefined;
+    }
+    try {
+      return this.cardContext?.cardComponentModifier;
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes(OWNER_DESTROYED_ERROR)
+      ) {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  private searchResource = getPrerenderedSearch(this, getOwner(this)!, () => {
+    // Consume selectedTypeIds outside the ternary so the tracking
+    // dependency is always established, even when the query is skipped.
+    const selectedTypeIds = this.args.typeFilter.selectedTypeIds;
+    return {
+      query: shouldSkipSearchQuery(this.args.searchKey, this.args.baseFilter)
+        ? undefined
+        : buildSearchQuery(
+            this.args.searchKey,
+            this.args.activeSort,
+            this.args.baseFilter,
+            selectedTypeIds,
+          ),
+      format: 'fitted' as const,
+      realms: this.args.realmFilter.selectedURLs,
+      isLive: true,
+      cardComponentModifier: this.cardComponentModifier,
+    };
+  });
+
+  @cached
+  private get recentCardCollection(): ReturnType<getCardCollection> {
+    return this.getCardCollection(
+      this,
+      () => this.recentCardsService.recentCardIds,
+    );
+  }
+
+  private get filteredRecentCards(): CardDef[] {
+    const cards =
+      (this.recentCardCollection?.cards?.filter(Boolean) as
+        | CardDef[]
+        | undefined) ?? [];
+    const realmURLs = this.args.realmFilter.selectedURLs;
+    const realmFiltered = cards.filter(
+      (c) => c.id && realmURLs.some((url) => c.id.startsWith(url)),
+    );
+    const typeRefs = getFilterTypeRefs(this.args.baseFilter);
+    return filterCardsByTypeRefs(realmFiltered, typeRefs);
+  }
 
   @cached
   private get cardResource(): ReturnType<getCard> {
@@ -235,8 +312,8 @@ export default class SearchContent extends Component<Signature> {
 
   private get realms() {
     const urls =
-      this.args.selectedRealmURLs.length > 0
-        ? this.args.selectedRealmURLs
+      this.args.realmFilter.selectedURLs.length > 0
+        ? this.args.realmFilter.selectedURLs
         : this.realmServer.availableRealmURLs;
     return urls ?? [];
   }
@@ -246,7 +323,7 @@ export default class SearchContent extends Component<Signature> {
       return '';
     }
 
-    if (this.args.searchResource.isLoading) {
+    if (this.searchResource.isLoading) {
       return 'Searching…';
     }
 
@@ -259,7 +336,7 @@ export default class SearchContent extends Component<Signature> {
     }
 
     // Query search results
-    const total = this.args.searchResource.meta.page?.total ?? 0;
+    const total = this.searchResource.meta.page?.total ?? 0;
     const realms = this.realms;
 
     // Default: all results across all realms
@@ -267,21 +344,17 @@ export default class SearchContent extends Component<Signature> {
   }
 
   private get sortedRecentCards(): CardDef[] {
-    let cards = [...(this.args.filteredRecentCards ?? [])];
+    let cards = [...(this.filteredRecentCards ?? [])];
 
     // Apply type picker filter (from TypePicker selection).
     // Skip when baseFilter has a non-root type — the server already
     // constrains results via the adoption chain, and recent cards are
     // pre-filtered by filterCardsByTypeRefs which handles subtypes.
-    if (!this.args.skipTypeFiltering) {
-      const pickerSelectedTypeNames = new Set(
-        (this.args.selectedCardTypes ?? [])
-          .filter((opt) => opt.type !== 'select-all')
-          .map((opt) => opt.label),
-      );
-      if (pickerSelectedTypeNames.size > 0) {
+    if (!this.args.typeFilter.skipTypeFiltering) {
+      const selectedTypes = this.args.typeFilter.selected;
+      if (selectedTypes.length > 0) {
         cards = cards.filter((card) =>
-          pickerSelectedTypeNames.has(cardTypeDisplayName(card)),
+          selectedTypes.some((ref) => cardMatchesTypeRef(card, ref)),
         );
       }
     }
@@ -426,7 +499,7 @@ export default class SearchContent extends Component<Signature> {
       return null;
     }
 
-    const cards = this.args.searchResource.instances;
+    const cards = this.searchResource.instances;
     const byRealm = new Map<string, PrerenderedCard[]>();
 
     for (const card of cards) {
@@ -530,7 +603,7 @@ export default class SearchContent extends Component<Signature> {
   private get allCards(): string[] {
     const urls: string[] = [];
     // Cards from search results (realm sections) - respects type filter
-    for (const card of this.args.searchResource.instances) {
+    for (const card of this.searchResource.instances) {
       if (card.url) {
         urls.push(card.url.replace(/\.json$/, ''));
       }
@@ -551,7 +624,7 @@ export default class SearchContent extends Component<Signature> {
   private get hasNoResults(): boolean {
     return (
       this.sections.length === 0 &&
-      !this.args.searchResource.isLoading &&
+      !this.searchResource.isLoading &&
       !this.shouldSkipQuery
     );
   }

--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -20,41 +20,43 @@ import {
   CardContextName,
   GetCardContextName,
   GetCardCollectionContextName,
+  internalKeyFor,
 } from '@cardstack/runtime-common';
 
-import { urlForRealmLookup } from '@cardstack/host/lib/utils';
 import { getPrerenderedSearch } from '@cardstack/host/resources/prerendered-search';
-import type LoaderService from '@cardstack/host/services/loader-service';
 import type RealmService from '@cardstack/host/services/realm';
 import type RealmServerService from '@cardstack/host/services/realm-server';
 import type RecentCards from '@cardstack/host/services/recent-cards-service';
-import type StoreService from '@cardstack/host/services/store';
 
 import type { CardContext, CardDef } from 'https://cardstack.com/base/card-api';
 
-import {
-  SECTION_DISPLAY_LIMIT_FOCUSED,
-  SECTION_DISPLAY_LIMIT_UNFOCUSED,
-  SECTION_SHOW_MORE_INCREMENT,
-  SORT_OPTIONS,
-  VIEW_OPTIONS,
-  type SortOption,
-} from './constants';
+import { SORT_OPTIONS, VIEW_OPTIONS, type SortOption } from './constants';
 import SearchResultHeader from './search-result-header';
 import SearchResultSection from './search-result-section';
-
-import type { PrerenderedCard } from '../prerendered-card-search';
 
 import type { RealmFilter } from '@cardstack/host/components/realm-picker';
 import type { TypeFilter } from '@cardstack/host/components/type-picker';
 import {
   buildSearchQuery,
-  cardMatchesTypeRef,
-  filterCardsByTypeRefs,
-  getFilterTypeRefs,
   shouldSkipSearchQuery,
-  type NewCardArgs,
-} from './utils';
+} from '@cardstack/host/utils/card-search/query-builder';
+import {
+  filterRecentCards,
+  sortAndFilterRecentCards,
+} from '@cardstack/host/utils/card-search/recent-cards';
+import { SectionPagination } from '@cardstack/host/utils/card-search/section-pagination';
+import {
+  assembleSections,
+  buildQuerySections,
+  buildRecentsSection,
+  buildUrlSection,
+  type SearchSheetSection,
+} from '@cardstack/host/utils/card-search/sections';
+import { type NewCardArgs } from '@cardstack/host/utils/card-search/types';
+import {
+  isURLSearchKey,
+  resolveSearchKeyAsURL,
+} from '@cardstack/host/utils/card-search/url';
 import type { NamedArgs } from 'ember-modifier';
 
 interface ScrollToFocusedSectionSignature {
@@ -112,37 +114,6 @@ class ScrollToFocusedSection extends Modifier<ScrollToFocusedSectionSignature> {
   }
 }
 
-export interface RealmSectionInfo {
-  name: string;
-  iconURL: string | null;
-  publishable: boolean | null;
-}
-
-export interface RealmSection {
-  sid: string;
-  type: 'realm';
-  realmUrl: string;
-  realmInfo: RealmSectionInfo;
-  cards: PrerenderedCard[];
-  totalCount: number;
-}
-
-export interface RecentsSection {
-  sid: string;
-  type: 'recents';
-  cards: CardDef[];
-  totalCount: number;
-}
-
-export interface UrlSection {
-  sid: string;
-  type: 'url';
-  card: CardDef;
-  realmInfo: RealmSectionInfo;
-}
-
-export type SearchSheetSection = RealmSection | RecentsSection | UrlSection;
-
 interface Signature {
   Element: HTMLElement;
   Args: {
@@ -172,18 +143,13 @@ interface Signature {
 const OWNER_DESTROYED_ERROR = 'OWNER_DESTROYED_ERROR';
 
 export default class SearchContent extends Component<Signature> {
-  @service declare loaderService: LoaderService;
   @service declare realm: RealmService;
   @service declare realmServer: RealmServerService;
-  @service declare store: StoreService;
   @service('recent-cards-service')
   declare private recentCardsService: RecentCards;
 
   @tracked activeViewId = 'grid';
-  /** Section id when focused: 'realm:<url>' or 'recents'. Null = no focus */
-  @tracked focusedSection: string | null =
-    this.args.initialFocusedSection ?? null;
-  @tracked displayedCountBySection: Record<string, number> = {};
+  private pagination = new SectionPagination(this.args.initialFocusedSection);
 
   @consume(GetCardContextName) declare private getCard: getCard;
   @consume(CardContextName) declare private cardContext:
@@ -192,7 +158,31 @@ export default class SearchContent extends Component<Signature> {
   @consume(GetCardCollectionContextName)
   declare private getCardCollection: getCardCollection;
 
-  // -- Internal resources (moved from SearchPanel) --
+  private get searchKeyIsURL() {
+    return isURLSearchKey(this.args.searchKey);
+  }
+
+  private get searchKeyAsURL() {
+    return resolveSearchKeyAsURL(
+      this.args.searchKey,
+      this.realmServer.availableRealmURLs,
+    );
+  }
+
+  @cached
+  private get cardResource(): ReturnType<getCard> {
+    return this.getCard(this, () => this.searchKeyAsURL);
+  }
+
+  private get resolvedCard(): CardDef | undefined {
+    return this.cardResource?.card;
+  }
+
+  private get isCardResourceLoaded(): boolean {
+    return this.cardResource?.isLoaded ?? false;
+  }
+
+  // -- Card component modifier --
 
   private get cardComponentModifier() {
     if (isDestroying(this) || isDestroyed(this)) {
@@ -214,7 +204,9 @@ export default class SearchContent extends Component<Signature> {
   private searchResource = getPrerenderedSearch(this, getOwner(this)!, () => {
     // Consume selectedTypeIds outside the ternary so the tracking
     // dependency is always established, even when the query is skipped.
-    const selectedTypeIds = this.args.typeFilter.selectedTypeIds;
+    const selectedTypeIds = this.args.typeFilter.selected.map((ref) =>
+      internalKeyFor(ref, undefined),
+    );
     return {
       query: shouldSkipSearchQuery(this.args.searchKey, this.args.baseFilter)
         ? undefined
@@ -244,17 +236,11 @@ export default class SearchContent extends Component<Signature> {
       (this.recentCardCollection?.cards?.filter(Boolean) as
         | CardDef[]
         | undefined) ?? [];
-    const realmURLs = this.args.realmFilter.selectedURLs;
-    const realmFiltered = cards.filter(
-      (c) => c.id && realmURLs.some((url) => c.id.startsWith(url)),
+    return filterRecentCards(
+      cards,
+      this.args.realmFilter.selectedURLs,
+      this.args.baseFilter,
     );
-    const typeRefs = getFilterTypeRefs(this.args.baseFilter);
-    return filterCardsByTypeRefs(realmFiltered, typeRefs);
-  }
-
-  @cached
-  private get cardResource(): ReturnType<getCard> {
-    return this.getCard(this, () => this.searchKeyAsURL);
   }
 
   private get shouldSkipQuery() {
@@ -274,40 +260,11 @@ export default class SearchContent extends Component<Signature> {
     return (this.args.searchKey?.trim() ?? '') === '';
   }
 
-  private get searchKeyIsURL() {
-    try {
-      new URL(this.args.searchKey);
-      return true;
-    } catch (_e) {
-      return false;
-    }
-  }
-
   private get searchTerm(): string | undefined {
     if (this.isSearchKeyEmpty || this.searchKeyIsURL) {
       return undefined;
     }
     return this.args.searchKey?.trim();
-  }
-
-  private get searchKeyAsURL() {
-    if (!this.searchKeyIsURL) {
-      return undefined;
-    }
-    let cardURL = this.args.searchKey;
-
-    let maybeIndexCardURL = this.realmServer.availableRealmURLs.find(
-      (u) => u === cardURL + '/',
-    );
-    return maybeIndexCardURL ?? cardURL;
-  }
-
-  private get resolvedCard() {
-    return this.cardResource?.card;
-  }
-
-  private get isCardResourceLoaded() {
-    return this.cardResource?.isLoaded ?? false;
   }
 
   private get realms() {
@@ -344,75 +301,13 @@ export default class SearchContent extends Component<Signature> {
   }
 
   private get sortedRecentCards(): CardDef[] {
-    let cards = [...(this.filteredRecentCards ?? [])];
-
-    // Apply type picker filter (from TypePicker selection).
-    // Skip when baseFilter has a non-root type — the server already
-    // constrains results via the adoption chain, and recent cards are
-    // pre-filtered by filterCardsByTypeRefs which handles subtypes.
-    if (!this.args.typeFilter.skipTypeFiltering) {
-      const selectedTypes = this.args.typeFilter.selected;
-      if (selectedTypes.length > 0) {
-        cards = cards.filter((card) =>
-          selectedTypes.some((ref) => cardMatchesTypeRef(card, ref)),
-        );
-      }
-    }
-
-    if (this.args.isCompact) {
-      return cards;
-    }
-    let filtered = cards;
-    const term = this.searchTerm;
-    if (term) {
-      const lowerTerm = term.toLowerCase();
-      filtered = cards.filter((c) =>
-        (c.cardTitle ?? '').toLowerCase().includes(lowerTerm),
-      );
-    }
-    const sortOption = this.args.activeSort;
-    const displayName = sortOption.displayName;
-    return [...filtered].sort((a, b) => {
-      if (displayName === 'A-Z') {
-        return (a.cardTitle ?? '').localeCompare(b.cardTitle ?? '');
-      }
-      if (displayName === 'Last Updated') {
-        const aVal =
-          'lastModified' in a
-            ? ((a as Record<string, unknown>).lastModified as number)
-            : 0;
-        const bVal =
-          'lastModified' in b
-            ? ((b as Record<string, unknown>).lastModified as number)
-            : 0;
-        return bVal - aVal;
-      }
-      if (displayName === 'Date Created') {
-        const aVal =
-          'createdAt' in a
-            ? ((a as Record<string, unknown>).createdAt as number)
-            : 0;
-        const bVal =
-          'createdAt' in b
-            ? ((b as Record<string, unknown>).createdAt as number)
-            : 0;
-        return bVal - aVal;
-      }
-      return 0;
+    return sortAndFilterRecentCards(this.filteredRecentCards, {
+      selectedTypes: this.args.typeFilter.selected,
+      skipTypeFiltering: this.args.typeFilter.skipTypeFiltering,
+      searchTerm: this.searchTerm,
+      activeSort: this.args.activeSort,
+      isCompact: this.args.isCompact,
     });
-  }
-
-  private get recentCardsSection(): RecentsSection | undefined {
-    const cards = this.sortedRecentCards;
-    if (cards.length === 0) {
-      return undefined;
-    }
-    return {
-      sid: 'recents',
-      type: 'recents',
-      cards,
-      totalCount: cards.length,
-    };
   }
 
   @action
@@ -427,177 +322,54 @@ export default class SearchContent extends Component<Signature> {
 
   @action
   onFocusSection(sectionId: string | null) {
-    this.focusedSection = sectionId;
-    if (sectionId) {
-      const current = this.displayedCountBySection[sectionId] ?? 0;
-      const limit = SECTION_DISPLAY_LIMIT_FOCUSED;
-      if (current < limit) {
-        this.displayedCountBySection = {
-          ...this.displayedCountBySection,
-          [sectionId]: limit,
-        };
-      }
-    }
+    this.pagination.focus(sectionId);
   }
 
   getDisplayedCount = (sectionId: string, totalCount: number): number => {
-    const isFocused = this.focusedSection === sectionId;
-    const initialLimit = isFocused
-      ? SECTION_DISPLAY_LIMIT_FOCUSED
-      : SECTION_DISPLAY_LIMIT_UNFOCUSED;
-    const current = this.displayedCountBySection[sectionId] ?? initialLimit;
-    return Math.min(current, totalCount);
+    return this.pagination.getDisplayedCount(sectionId, totalCount);
   };
 
   @action
   onShowMore(sectionId: string, totalCount: number) {
-    const current = this.getDisplayedCount(sectionId, totalCount);
-    const next = Math.min(current + SECTION_SHOW_MORE_INCREMENT, totalCount);
-    this.displayedCountBySection = {
-      ...this.displayedCountBySection,
-      [sectionId]: next,
-    };
+    this.pagination.showMore(sectionId, totalCount);
   }
 
-  private realmNameFromUrl(realmUrl: string): string {
-    try {
-      const pathname = new URL(realmUrl).pathname;
-      const segments = pathname.split('/').filter(Boolean);
-      return segments[segments.length - 1] ?? 'Workspace';
-    } catch {
-      return 'Workspace';
-    }
+  private get recentCardsSection() {
+    return buildRecentsSection(this.sortedRecentCards);
   }
 
-  private get cardByUrlSection(): SearchSheetSection | undefined {
-    if (!this.searchKeyIsURL || !this.resolvedCard) {
-      return undefined;
-    }
-    const card = this.resolvedCard;
-    const urlForRealm = urlForRealmLookup(card);
-    const realmUrl = this.realmUrlForCard(urlForRealm);
-    const realmInfo = realmUrl ? this.realm.info(realmUrl) : null;
-    return {
-      sid: `url:${card.id}`,
-      type: 'url',
-      card,
-      realmInfo: {
-        name: realmInfo?.name ?? this.realmNameFromUrl(realmUrl),
-        iconURL: realmInfo?.iconURL ?? null,
-        publishable: realmInfo?.publishable ?? null,
-      },
-    } as UrlSection;
+  private get cardByUrlSection() {
+    return buildUrlSection(
+      this.resolvedCard,
+      this.searchKeyIsURL,
+      this.realms,
+      this.realm,
+    );
   }
 
-  private get cardsByQuerySection(): SearchSheetSection[] | null {
-    if (this.searchKeyIsURL) {
-      return null;
-    }
-
-    // In search-sheet mode (no baseFilter), skip when search key is empty
-    if (!this.args.baseFilter && this.isSearchKeyEmpty) {
-      return null;
-    }
-
-    const cards = this.searchResource.instances;
-    const byRealm = new Map<string, PrerenderedCard[]>();
-
-    for (const card of cards) {
-      const list: PrerenderedCard[] = byRealm.get(card.realmUrl) ?? [];
-      list.push(card);
-      byRealm.set(card.realmUrl, list);
-    }
-
-    const sections: RealmSection[] = [];
-    for (const [realmUrl, realmCards] of byRealm) {
-      const realmInfo = this.realm.info(realmUrl);
-      sections.push({
-        sid: `realm:${realmUrl}`,
-        type: 'realm',
-        realmUrl,
-        realmInfo: {
-          name: realmInfo?.name ?? this.realmNameFromUrl(realmUrl),
-          iconURL: realmInfo?.iconURL ?? null,
-          publishable: realmInfo?.publishable ?? null,
-        },
-        cards: realmCards,
-        totalCount: realmCards.length,
-      });
-    }
-
-    // When offerToCreate is provided, include empty sections for all
-    // available/selected realms that have no results, so users can
-    // create new cards in those realms.
-    if (this.args.offerToCreate) {
-      for (const realmUrl of this.realms) {
-        if (!byRealm.has(realmUrl)) {
-          const realmInfo = this.realm.info(realmUrl);
-          sections.push({
-            sid: `realm:${realmUrl}`,
-            type: 'realm',
-            realmUrl,
-            realmInfo: {
-              name: realmInfo?.name ?? this.realmNameFromUrl(realmUrl),
-              iconURL: realmInfo?.iconURL ?? null,
-              publishable: realmInfo?.publishable ?? null,
-            },
-            cards: [],
-            totalCount: 0,
-          });
-        }
-      }
-    }
-
-    return sections;
+  private get cardsByQuerySection() {
+    return buildQuerySections(this.searchResource.instances, {
+      isURL: this.searchKeyIsURL,
+      isSearchKeyEmpty: this.isSearchKeyEmpty,
+      hasBaseFilter: !!this.args.baseFilter,
+      realmURLs: this.realms,
+      offerToCreate: this.args.offerToCreate,
+      realm: this.realm,
+    });
   }
 
   private get sections(): SearchSheetSection[] {
-    const sections: SearchSheetSection[] = [];
-
-    // Add recents section if present
-    if (this.recentCardsSection) {
-      sections.push(this.recentCardsSection);
-    }
-
-    // Add URL section if present
-    if (this.cardByUrlSection) {
-      sections.push(this.cardByUrlSection);
-    }
-
-    // Add query sections if present
-    if (this.cardsByQuerySection) {
-      sections.push(...this.cardsByQuerySection);
-    }
-
-    // Move focused section to front so it appears at the top
-    if (this.focusedSection) {
-      const idx = sections.findIndex((s) => s.sid === this.focusedSection);
-      if (idx > 0) {
-        const [focused] = sections.splice(idx, 1);
-        sections.unshift(focused);
-      }
-    }
-
-    return sections;
-  }
-
-  private realmUrlForCard(cardIdOrUrl: string): string {
-    for (const realm of this.realms) {
-      if (cardIdOrUrl.startsWith(realm)) {
-        return realm;
-      }
-    }
-    try {
-      const url = new URL(cardIdOrUrl);
-      return `${url.origin}${url.pathname.split('/').slice(0, -1)?.join('/') ?? ''}/`;
-    } catch {
-      return '';
-    }
+    return assembleSections(
+      this.recentCardsSection,
+      this.cardByUrlSection,
+      this.cardsByQuerySection,
+      this.pagination.focusedSection,
+    );
   }
 
   @action
   isSectionCollapsed(sectionId: string): boolean {
-    return !!this.focusedSection && this.focusedSection !== sectionId;
+    return this.pagination.isCollapsed(sectionId);
   }
 
   private get allCards(): string[] {
@@ -632,7 +404,7 @@ export default class SearchContent extends Component<Signature> {
   <template>
     <div
       {{ScrollToFocusedSection
-        focusedSectionSid=this.focusedSection
+        focusedSectionSid=this.pagination.focusedSection
         sectionSelector='[data-section-sid]'
       }}
       class='search-sheet-content {{if @isCompact "compact"}}'
@@ -685,7 +457,7 @@ export default class SearchContent extends Component<Signature> {
             @section={{section}}
             @viewOption={{this.activeViewId}}
             @handleSelect={{@handleSelect}}
-            @isFocused={{eq this.focusedSection section.sid}}
+            @isFocused={{eq this.pagination.focusedSection section.sid}}
             @isCollapsed={{this.isSectionCollapsed section.sid}}
             @onFocusSection={{this.onFocusSection}}
             @getDisplayedCount={{this.getDisplayedCount}}

--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -23,19 +23,13 @@ import {
   internalKeyFor,
 } from '@cardstack/runtime-common';
 
+import type { RealmFilter } from '@cardstack/host/components/realm-picker';
+import type { TypeFilter } from '@cardstack/host/components/type-picker';
 import { getPrerenderedSearch } from '@cardstack/host/resources/prerendered-search';
 import type RealmService from '@cardstack/host/services/realm';
 import type RealmServerService from '@cardstack/host/services/realm-server';
 import type RecentCards from '@cardstack/host/services/recent-cards-service';
 
-import type { CardContext, CardDef } from 'https://cardstack.com/base/card-api';
-
-import { SORT_OPTIONS, VIEW_OPTIONS, type SortOption } from './constants';
-import SearchResultHeader from './search-result-header';
-import SearchResultSection from './search-result-section';
-
-import type { RealmFilter } from '@cardstack/host/components/realm-picker';
-import type { TypeFilter } from '@cardstack/host/components/type-picker';
 import {
   buildSearchQuery,
   shouldSkipSearchQuery,
@@ -52,11 +46,18 @@ import {
   buildUrlSection,
   type SearchSheetSection,
 } from '@cardstack/host/utils/card-search/sections';
-import { type NewCardArgs } from '@cardstack/host/utils/card-search/types';
+import type { NewCardArgs } from '@cardstack/host/utils/card-search/types';
 import {
   isURLSearchKey,
   resolveSearchKeyAsURL,
 } from '@cardstack/host/utils/card-search/url';
+
+import type { CardContext, CardDef } from 'https://cardstack.com/base/card-api';
+
+import { SORT_OPTIONS, VIEW_OPTIONS, type SortOption } from './constants';
+import SearchResultHeader from './search-result-header';
+import SearchResultSection from './search-result-section';
+
 import type { NamedArgs } from 'ember-modifier';
 
 interface ScrollToFocusedSectionSignature {

--- a/packages/host/app/components/card-search/search-result-header.gts
+++ b/packages/host/app/components/card-search/search-result-header.gts
@@ -15,7 +15,7 @@ import { DropdownArrowDown } from '@cardstack/boxel-ui/icons';
 
 import type { SortOption } from './constants';
 import type { ViewOption } from './constants';
-import type { NewCardArgs } from './utils';
+import type { NewCardArgs } from '@cardstack/host/utils/card-search/types';
 
 interface Signature {
   Element: HTMLElement;

--- a/packages/host/app/components/card-search/search-result-header.gts
+++ b/packages/host/app/components/card-search/search-result-header.gts
@@ -13,9 +13,10 @@ import {
 import { MenuItem } from '@cardstack/boxel-ui/helpers';
 import { DropdownArrowDown } from '@cardstack/boxel-ui/icons';
 
+import type { NewCardArgs } from '@cardstack/host/utils/card-search/types';
+
 import type { SortOption } from './constants';
 import type { ViewOption } from './constants';
-import type { NewCardArgs } from '@cardstack/host/utils/card-search/types';
 
 interface Signature {
   Element: HTMLElement;

--- a/packages/host/app/components/card-search/search-result-section.gts
+++ b/packages/host/app/components/card-search/search-result-section.gts
@@ -15,17 +15,18 @@ import type { CodeRef } from '@cardstack/runtime-common';
 import { urlForRealmLookup } from '@cardstack/host/lib/utils';
 import type RealmService from '@cardstack/host/services/realm';
 
-import { SECTION_SHOW_MORE_INCREMENT } from './constants';
-import ItemButton from './item-button';
-import SearchSheetSectionHeader from './section-header';
-
 import type {
   RealmSection,
   RecentsSection,
   SearchSheetSection,
   UrlSection,
 } from '@cardstack/host/utils/card-search/sections';
+
 import type { NewCardArgs } from '@cardstack/host/utils/card-search/types';
+
+import { SECTION_SHOW_MORE_INCREMENT } from './constants';
+import ItemButton from './item-button';
+import SearchSheetSectionHeader from './section-header';
 
 interface Signature {
   Element: HTMLElement;

--- a/packages/host/app/components/card-search/search-result-section.gts
+++ b/packages/host/app/components/card-search/search-result-section.gts
@@ -24,8 +24,8 @@ import type {
   RecentsSection,
   SearchSheetSection,
   UrlSection,
-} from './search-content';
-import type { NewCardArgs } from './utils';
+} from '@cardstack/host/utils/card-search/sections';
+import type { NewCardArgs } from '@cardstack/host/utils/card-search/types';
 
 interface Signature {
   Element: HTMLElement;

--- a/packages/host/app/components/card-search/section-header.gts
+++ b/packages/host/app/components/card-search/section-header.gts
@@ -4,7 +4,7 @@ import Component from '@glimmer/component';
 import { BoxelInput, RealmIcon } from '@cardstack/boxel-ui/components';
 import { eq } from '@cardstack/boxel-ui/helpers';
 
-import type { RealmSectionInfo } from './search-content';
+import type { RealmSectionInfo } from '@cardstack/host/utils/card-search/sections';
 import type { ComponentLike } from '@glint/template';
 
 interface Signature {

--- a/packages/host/app/components/card-search/section-header.gts
+++ b/packages/host/app/components/card-search/section-header.gts
@@ -5,6 +5,7 @@ import { BoxelInput, RealmIcon } from '@cardstack/boxel-ui/components';
 import { eq } from '@cardstack/boxel-ui/helpers';
 
 import type { RealmSectionInfo } from '@cardstack/host/utils/card-search/sections';
+
 import type { ComponentLike } from '@glint/template';
 
 interface Signature {

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -40,6 +40,8 @@ import {
   getMenuItems,
 } from '@cardstack/runtime-common';
 
+import { removeFileExtension } from '@cardstack/host/utils/card-search/types';
+
 import type {
   CardCrudFunctions,
   CardDef,
@@ -48,7 +50,6 @@ import type {
 
 import { detectStackItemTypeForTarget } from '../../lib/stack-item';
 
-import { removeFileExtension } from '@cardstack/host/utils/card-search/types';
 import { knownFileMetaUrls } from '../prerendered-card-search';
 
 import Overlays from './overlays';

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -48,7 +48,7 @@ import type {
 
 import { detectStackItemTypeForTarget } from '../../lib/stack-item';
 
-import { removeFileExtension } from '../card-search/utils';
+import { removeFileExtension } from '@cardstack/host/utils/card-search/types';
 import { knownFileMetaUrls } from '../prerendered-card-search';
 
 import Overlays from './overlays';

--- a/packages/host/app/components/realm-picker/index.gts
+++ b/packages/host/app/components/realm-picker/index.gts
@@ -9,10 +9,16 @@ import type RealmServerService from '@cardstack/host/services/realm-server';
 
 import WithKnownRealmsLoaded from '../with-known-realms-loaded';
 
+export interface RealmFilter {
+  selected: URL[];
+  onChange: (selected: URL[]) => void;
+  /** Resolved realm URL strings (handles select-all → all available realms) */
+  selectedURLs: string[];
+}
+
 interface Signature {
   Args: {
-    selected: PickerOption[];
-    onChange: (selected: PickerOption[]) => void;
+    filter: RealmFilter;
     label?: string;
     placeholder?: string;
     destination?: string;
@@ -39,10 +45,18 @@ export default class RealmPicker extends Component<Signature> {
     };
   }
 
-  get selected(): PickerOption[] {
-    return this.args.selected.length > 0
-      ? this.args.selected
-      : [this.selectAllOption];
+  private get pickerSelected(): PickerOption[] {
+    const selected = this.args.filter.selected;
+    if (selected.length === 0) {
+      return [this.selectAllOption];
+    }
+    return selected.map((url) => {
+      let realmURL = url.href;
+      let info = this.realm.info(realmURL);
+      let label = info?.name ?? this.realmDisplayNameFromURL(realmURL);
+      let icon = info?.iconURL ?? undefined;
+      return { id: realmURL, icon, label, type: 'option' as const };
+    });
   }
 
   get realmOptions(): PickerOption[] {
@@ -61,6 +75,13 @@ export default class RealmPicker extends Component<Signature> {
     }
     return options;
   }
+
+  private onChange = (selected: PickerOption[]) => {
+    const urls = selected
+      .filter((opt) => opt.type !== 'select-all')
+      .map((opt) => new URL(opt.id));
+    this.args.filter.onChange(urls);
+  };
 
   private realmDisplayNameFromURL(realmURL: string): string {
     try {
@@ -81,8 +102,8 @@ export default class RealmPicker extends Component<Signature> {
         <Picker
           @label={{if @label @label 'Realm'}}
           @options={{this.realmOptions}}
-          @selected={{this.selected}}
-          @onChange={{@onChange}}
+          @selected={{this.pickerSelected}}
+          @onChange={{this.onChange}}
           @placeholder={{@placeholder}}
           @searchPlaceholder='Search for a realm'
           @maxSelectedDisplay={{3}}

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -82,7 +82,7 @@ const BASE_FILTER: Filter = {
 
 export default class SearchSheet extends Component<Signature> {
   @tracked private searchKey = '';
-  @tracked private initialSelectedType: ResolvedCodeRef | undefined;
+  @tracked private initialSelectedTypes: ResolvedCodeRef[] | undefined;
 
   @service declare private realmServer: RealmServerService;
   @service declare private store: StoreService;
@@ -157,12 +157,12 @@ export default class SearchSheet extends Component<Signature> {
   @action
   private doExternallyTriggeredSearch(term: string, typeRef?: ResolvedCodeRef) {
     this.searchKey = term;
-    this.initialSelectedType = typeRef;
+    this.initialSelectedTypes = typeRef ? [typeRef] : undefined;
   }
 
   private resetState() {
     this.searchKey = '';
-    this.initialSelectedType = undefined;
+    this.initialSelectedTypes = undefined;
   }
 
   @action private debouncedSetSearchKey(searchKey: string) {
@@ -173,6 +173,14 @@ export default class SearchSheet extends Component<Signature> {
   private setSearchKey(searchKey: string) {
     this.searchKey = searchKey;
     this.args.onSearch?.(searchKey);
+  }
+
+  @action private handleRealmChange(_selectedRealms: URL[]) {
+    this.args.onFilterChange?.();
+  }
+
+  @action private handleTypeChange(_selectedTypes: ResolvedCodeRef[]) {
+    this.args.onFilterChange?.();
   }
 
   @action private onSearchInputKeyDown(e: Event) {
@@ -263,8 +271,9 @@ export default class SearchSheet extends Component<Signature> {
         <SearchPanel
           @searchKey={{this.searchKey}}
           @baseFilter={{BASE_FILTER}}
-          @initialSelectedType={{this.initialSelectedType}}
-          @onFilterChange={{@onFilterChange}}
+          @initialSelectedTypes={{this.initialSelectedTypes}}
+          @onRealmChange={{this.handleRealmChange}}
+          @onTypeChange={{this.handleTypeChange}}
           as |Bar Content joinedRealmURLs|
         >
           <Bar

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -174,15 +174,8 @@ export default class SearchSheet extends Component<Signature> {
     this.args.onSearch?.(searchKey);
   }
 
-  @tracked private selectedRealmURLs: URL[] = [];
-
-  @action private handleRealmChange(selectedRealms: URL[]) {
-    this.selectedRealmURLs = selectedRealms;
+  @action private handleRealmChange(_selectedRealms: URL[]) {
     this.args.onFilterChange?.();
-  }
-
-  private get joinedSelectedRealmURLs(): string {
-    return this.selectedRealmURLs.map((u) => u.href).join(',');
   }
 
   @action private handleTypeChange(_selectedTypes: ResolvedCodeRef[]) {
@@ -287,7 +280,6 @@ export default class SearchSheet extends Component<Signature> {
             @onKeyDown={{this.onSearchInputKeyDown}}
             @onInputInsertion={{@onInputInsertion}}
             @autocomplete='off'
-            data-test-search-realms={{this.joinedSelectedRealmURLs}}
           />
           <Content
             class='search-sheet__content'

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -28,6 +28,10 @@ import {
 } from '@cardstack/runtime-common';
 
 import type RealmServerService from '@cardstack/host/services/realm-server';
+import {
+  isURLSearchKey,
+  resolveSearchKeyAsURL,
+} from '@cardstack/host/utils/card-search/url';
 
 import SearchPanel from '../card-search/panel';
 
@@ -124,12 +128,7 @@ export default class SearchSheet extends Component<Signature> {
   }
 
   private get searchKeyIsURL() {
-    try {
-      new URL(this.searchKey);
-      return true;
-    } catch (_e) {
-      return false;
-    }
+    return isURLSearchKey(this.searchKey);
   }
 
   @action
@@ -203,15 +202,10 @@ export default class SearchSheet extends Component<Signature> {
   }
 
   private get searchKeyAsURL() {
-    if (!this.searchKeyIsURL) {
-      return undefined;
-    }
-    let cardURL = this.searchKey;
-
-    let maybeIndexCardURL = this.realmServer.availableRealmURLs.find(
-      (u) => u === cardURL + '/',
+    return resolveSearchKeyAsURL(
+      this.searchKey,
+      this.realmServer.availableRealmURLs,
     );
-    return maybeIndexCardURL ?? cardURL;
   }
 
   // note that this is a card that is eligible for garbage collection

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -175,8 +175,15 @@ export default class SearchSheet extends Component<Signature> {
     this.args.onSearch?.(searchKey);
   }
 
-  @action private handleRealmChange(_selectedRealms: URL[]) {
+  @tracked private selectedRealmURLs: URL[] = [];
+
+  @action private handleRealmChange(selectedRealms: URL[]) {
+    this.selectedRealmURLs = selectedRealms;
     this.args.onFilterChange?.();
+  }
+
+  private get joinedSelectedRealmURLs(): string {
+    return this.selectedRealmURLs.map((u) => u.href).join(',');
   }
 
   @action private handleTypeChange(_selectedTypes: ResolvedCodeRef[]) {
@@ -274,11 +281,10 @@ export default class SearchSheet extends Component<Signature> {
           @initialSelectedTypes={{this.initialSelectedTypes}}
           @onRealmChange={{this.handleRealmChange}}
           @onTypeChange={{this.handleTypeChange}}
-          as |Bar Content joinedRealmURLs|
+          as |Bar Content|
         >
           <Bar
             class='search-sheet__search-input-group'
-            @value={{this.searchKey}}
             @placeholder={{this.placeholderText}}
             @state={{this.inputValidationState}}
             @bottomTreatment={{this.inputBottomTreatment}}
@@ -287,7 +293,7 @@ export default class SearchSheet extends Component<Signature> {
             @onKeyDown={{this.onSearchInputKeyDown}}
             @onInputInsertion={{@onInputInsertion}}
             @autocomplete='off'
-            data-test-search-realms={{joinedRealmURLs}}
+            data-test-search-realms={{this.joinedSelectedRealmURLs}}
           />
           <Content
             class='search-sheet__content'

--- a/packages/host/app/components/type-picker/index.gts
+++ b/packages/host/app/components/type-picker/index.gts
@@ -24,8 +24,6 @@ export interface TypeFilter {
   disableSelectAll: boolean;
   /** Whether to skip type-based filtering on recent cards */
   skipTypeFiltering: boolean;
-  /** Internal key IDs of selected types, for building search queries */
-  selectedTypeIds: string[];
 }
 
 interface Signature {

--- a/packages/host/app/components/type-picker/index.gts
+++ b/packages/host/app/components/type-picker/index.gts
@@ -52,12 +52,14 @@ export default class TypePicker extends Component<Signature> {
   }
 
   private get pickerOptions(): PickerOption[] {
+    const lockOptions = this.args.filter.disableSelectAll;
     const options: PickerOption[] = this.args.filter.options.map((opt) => ({
       id: opt.id,
       label: opt.displayName,
       tooltip: opt.id,
       icon: opt.icon,
       type: 'option' as const,
+      ...(lockOptions ? { disabled: true } : {}),
     }));
     return [this.selectAllOption, ...options];
   }

--- a/packages/host/app/components/type-picker/index.gts
+++ b/packages/host/app/components/type-picker/index.gts
@@ -3,75 +3,108 @@ import { cached } from '@glimmer/tracking';
 
 import { Picker, type PickerOption } from '@cardstack/boxel-ui/components';
 
+import {
+  type ResolvedCodeRef,
+  codeRefFromInternalKey,
+  internalKeyFor,
+} from '@cardstack/runtime-common';
+
+import type { TypeOption } from '@cardstack/host/resources/type-summaries';
+
+export interface TypeFilter {
+  options: TypeOption[];
+  selected: ResolvedCodeRef[];
+  onChange: (selected: ResolvedCodeRef[]) => void;
+  onSearchChange: (term: string) => void;
+  onLoadMore: () => void;
+  hasMore: boolean;
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  totalCount: number;
+  disableSelectAll: boolean;
+  /** Whether to skip type-based filtering on recent cards */
+  skipTypeFiltering: boolean;
+  /** Internal key IDs of selected types, for building search queries */
+  selectedTypeIds: string[];
+}
+
 interface Signature {
   Args: {
-    disableSelectAll?: boolean;
-    options: PickerOption[];
-    selected: PickerOption[];
-    onChange: (selected: PickerOption[]) => void;
+    filter: TypeFilter;
     label?: string;
-    onSearchChange?: (term: string) => void;
-    onLoadMore?: () => void;
-    hasMore?: boolean;
-    isLoading?: boolean;
-    isLoadingMore?: boolean;
-    totalCount?: number;
     destination?: string;
   };
   Blocks: {};
 }
 
 export default class TypePicker extends Component<Signature> {
-  // Provide a default selection so Picker's ensureDefaultSelection() never
-  // fires onChange to the parent. Without this, Picker sees an empty @selected
-  // on first render and calls onChange([select-all]), which the parent
-  // interprets as a user-initiated filter change (expanding the search sheet).
   @cached
-  get selectAllOption() {
+  get selectAllOption(): PickerOption {
     let count =
-      this.args.totalCount !== undefined
-        ? this.args.totalCount
-        : this.args.options.length;
+      this.args.filter.totalCount !== undefined
+        ? this.args.filter.totalCount
+        : this.args.filter.options.length;
     return {
       id: 'select-all',
       label: `Any Type (${count})`,
       shortLabel: `Any`,
       type: 'select-all',
-      ...(this.args.disableSelectAll ? { disabled: true } : {}),
+      ...(this.args.filter.disableSelectAll ? { disabled: true } : {}),
     };
   }
 
-  get allOptions(): PickerOption[] {
-    return [this.selectAllOption, ...this.args.options];
+  private get pickerOptions(): PickerOption[] {
+    const options: PickerOption[] = this.args.filter.options.map((opt) => ({
+      id: opt.id,
+      label: opt.displayName,
+      tooltip: opt.id,
+      icon: opt.icon,
+      type: 'option' as const,
+    }));
+    return [this.selectAllOption, ...options];
   }
 
-  get selected(): PickerOption[] {
-    return this.args.selected.length > 0
-      ? this.args.selected
-      : [this.selectAllOption];
+  private get pickerSelected(): PickerOption[] {
+    const selectedKeys = new Set(
+      this.args.filter.selected.map((ref) => internalKeyFor(ref, undefined)),
+    );
+    if (selectedKeys.size === 0) {
+      return [this.selectAllOption];
+    }
+    return this.pickerOptions.filter(
+      (opt) => opt.type !== 'select-all' && selectedKeys.has(opt.id),
+    );
   }
 
-  get hasServerSearch(): boolean {
-    return !!this.args.onSearchChange;
+  private get hasServerSearch(): boolean {
+    return !!this.args.filter.onSearchChange;
   }
+
+  private onChange = (selected: PickerOption[]) => {
+    const refs = selected
+      .filter((opt) => opt.type !== 'select-all')
+      .map((opt) => codeRefFromInternalKey(opt.id))
+      .filter((ref): ref is ResolvedCodeRef => ref !== undefined);
+    this.args.filter.onChange(refs);
+  };
 
   <template>
     <Picker
       @label={{if @label @label 'Type'}}
-      @options={{this.allOptions}}
-      @selected={{this.selected}}
-      @onChange={{@onChange}}
+      @options={{this.pickerOptions}}
+      @selected={{this.pickerSelected}}
+      @onChange={{this.onChange}}
       @searchPlaceholder='Search for a type'
       @maxSelectedDisplay={{3}}
       @renderInPlace={{false}}
       @destination={{@destination}}
       @matchTriggerWidth={{false}}
-      @onSearchTermChange={{@onSearchChange}}
+      @onSearchTermChange={{@filter.onSearchChange}}
       @disableClientSideSearch={{this.hasServerSearch}}
-      @isLoading={{@isLoading}}
-      @isLoadingMore={{@isLoadingMore}}
-      @hasMore={{@hasMore}}
-      @onLoadMore={{@onLoadMore}}
+      @isLoading={{@filter.isLoading}}
+      @isLoadingMore={{@filter.isLoadingMore}}
+      @hasMore={{@filter.hasMore}}
+      @onLoadMore={{@filter.onLoadMore}}
       data-test-type-picker
     />
   </template>

--- a/packages/host/app/resources/type-summaries.ts
+++ b/packages/host/app/resources/type-summaries.ts
@@ -148,7 +148,35 @@ export class TypeSummariesResource extends Resource<TypeSummariesArgs> {
     this._selected = selected;
   }
 
-  // -- Private computed --
+  // -- Private helpers --
+
+  /**
+   * Guarded wrapper around realmServer.fetchCardTypeSummaries.
+   * Returns undefined if the realm server can't fetch yet (matrix client not set),
+   * or if the component is destroyed, or if the fetch fails.
+   */
+  private async fetchCardTypeSummaries(
+    realmURLs: string[],
+    options: {
+      searchKey?: string;
+      page: { number: number; size: number };
+    },
+  ) {
+    if (!this.realmServer.canFetch) {
+      return undefined;
+    }
+    try {
+      let result = await this.realmServer.fetchCardTypeSummaries(
+        realmURLs,
+        options,
+      );
+      if (isDestroyed(this) || isDestroying(this)) return undefined;
+      return result;
+    } catch (e) {
+      console.error('Failed to fetch card type summaries', e);
+      return undefined;
+    }
+  }
 
   // -- Private tasks --
 
@@ -160,75 +188,59 @@ export class TypeSummariesResource extends Resource<TypeSummariesArgs> {
         await Promise.resolve(); // yield to avoid autotracking assertion
       }
       if (isDestroyed(this) || isDestroying(this)) return;
+
       this._isLoading = true;
       this._currentPage = 0;
 
-      try {
-        let result = await this.realmServer.fetchCardTypeSummaries(realmURLs, {
-          searchKey: searchKey || undefined,
-          page: {
-            number: 0,
-            size: TypeSummariesResource.PAGE_SIZE,
-          },
-        });
-        if (isDestroyed(this) || isDestroying(this)) return;
-
-        this._typeSummariesData = result.data;
-        this._totalCount = result.meta.page.total;
-        this._hasMore = result.data.length < result.meta.page.total;
-
-        // If there are selected types (or initialSelectedTypes) not yet in
-        // the fetched results, keep fetching more pages until they're found.
-        const selectedIds = new Set(this._previousSelectedKeys);
-        const initialTypes = this.#initialSelectedTypes;
-        if (initialTypes) {
-          for (const ref of initialTypes) {
-            selectedIds.add(internalKeyFor(ref, undefined));
-          }
-        }
-
-        if (selectedIds.size > 0 && this._hasMore) {
-          while (this._hasMore) {
-            const fetchedIds = new Set(
-              this._typeSummariesData.map((d) => d.id),
-            );
-            if ([...selectedIds].every((id) => fetchedIds.has(id))) break;
-
-            const nextPage = this._currentPage + 1;
-            let moreResult = await this.realmServer.fetchCardTypeSummaries(
-              realmURLs,
-              {
-                searchKey: searchKey || undefined,
-                page: {
-                  number: nextPage,
-                  size: TypeSummariesResource.PAGE_SIZE,
-                },
-              },
-            );
-            if (isDestroyed(this) || isDestroying(this)) return;
-
-            this._currentPage = nextPage;
-            this._typeSummariesData = [
-              ...this._typeSummariesData,
-              ...moreResult.data,
-            ];
-            this._hasMore =
-              this._typeSummariesData.length < moreResult.meta.page.total;
-          }
-        }
-
+      let result = await this.fetchCardTypeSummaries(realmURLs, {
+        searchKey: searchKey || undefined,
+        page: { number: 0, size: TypeSummariesResource.PAGE_SIZE },
+      });
+      if (isDestroyed(this) || isDestroying(this)) return;
+      if (!result) {
         this._isLoading = false;
-        this.recomputeTypeFilter();
-      } catch (e) {
-        console.error('Failed to fetch card type summaries', e);
-        if (!isDestroyed(this) && !isDestroying(this)) {
-          this._typeSummariesData = [];
-          this._totalCount = 0;
-          this._hasMore = false;
-          this._isLoading = false;
-          this.recomputeTypeFilter();
+        return;
+      }
+
+      this._typeSummariesData = result.data;
+      this._totalCount = result.meta.page.total;
+      this._hasMore = result.data.length < result.meta.page.total;
+
+      // If there are selected types (or initialSelectedTypes) not yet in
+      // the fetched results, keep fetching more pages until they're found.
+      const selectedIds = new Set(this._previousSelectedKeys);
+      const initialTypes = this.#initialSelectedTypes;
+      if (initialTypes) {
+        for (const ref of initialTypes) {
+          selectedIds.add(internalKeyFor(ref, undefined));
         }
       }
+
+      if (selectedIds.size > 0 && this._hasMore) {
+        while (this._hasMore) {
+          const fetchedIds = new Set(this._typeSummariesData.map((d) => d.id));
+          if ([...selectedIds].every((id) => fetchedIds.has(id))) break;
+
+          const nextPage = this._currentPage + 1;
+          let moreResult = await this.fetchCardTypeSummaries(realmURLs, {
+            searchKey: searchKey || undefined,
+            page: { number: nextPage, size: TypeSummariesResource.PAGE_SIZE },
+          });
+          if (isDestroyed(this) || isDestroying(this)) return;
+          if (!moreResult) break;
+
+          this._currentPage = nextPage;
+          this._typeSummariesData = [
+            ...this._typeSummariesData,
+            ...moreResult.data,
+          ];
+          this._hasMore =
+            this._typeSummariesData.length < moreResult.meta.page.total;
+        }
+      }
+
+      this._isLoading = false;
+      this.recomputeTypeFilter();
     },
   );
 
@@ -237,31 +249,25 @@ export class TypeSummariesResource extends Resource<TypeSummariesArgs> {
     this._isLoadingMore = true;
     const nextPage = this._currentPage + 1;
 
-    try {
-      let result = await this.realmServer.fetchCardTypeSummaries(
-        this.#previousRealmURLs ?? [],
-        {
-          searchKey: this._typeSearchKey || undefined,
-          page: {
-            number: nextPage,
-            size: TypeSummariesResource.PAGE_SIZE,
-          },
-        },
-      );
-      if (isDestroyed(this) || isDestroying(this)) return;
-
-      this._currentPage = nextPage;
-      this._typeSummariesData = [...this._typeSummariesData, ...result.data];
-      const totalFetched = this._typeSummariesData.length;
-      this._hasMore = totalFetched < result.meta.page.total;
+    let result = await this.fetchCardTypeSummaries(
+      this.#previousRealmURLs ?? [],
+      {
+        searchKey: this._typeSearchKey || undefined,
+        page: { number: nextPage, size: TypeSummariesResource.PAGE_SIZE },
+      },
+    );
+    if (isDestroyed(this) || isDestroying(this)) return;
+    if (!result) {
       this._isLoadingMore = false;
-      this.recomputeTypeFilter();
-    } catch (e) {
-      console.error('Failed to load more card type summaries', e);
-      if (!isDestroyed(this) && !isDestroying(this)) {
-        this._isLoadingMore = false;
-      }
+      return;
     }
+
+    this._currentPage = nextPage;
+    this._typeSummariesData = [...this._typeSummariesData, ...result.data];
+    const totalFetched = this._typeSummariesData.length;
+    this._hasMore = totalFetched < result.meta.page.total;
+    this._isLoadingMore = false;
+    this.recomputeTypeFilter();
   });
 
   // -- Type filter computation --

--- a/packages/host/app/resources/type-summaries.ts
+++ b/packages/host/app/resources/type-summaries.ts
@@ -11,17 +11,16 @@ import { Resource } from 'ember-modify-based-class-resource';
 import {
   type Filter,
   type ResolvedCodeRef,
-  baseCardRef,
-  baseFieldRef,
-  baseRef,
   codeRefFromInternalKey,
   internalKeyFor,
   isResolvedCodeRef,
 } from '@cardstack/runtime-common';
 
 import {
+  getBaseFilterTypeKeys,
   getFilterTypeRefs,
-} from '../components/card-search/utils';
+  ROOT_TYPE_KEYS,
+} from '../utils/card-search/type-filter';
 
 import type RealmServerService from '../services/realm-server';
 
@@ -47,12 +46,6 @@ export interface TypeSummariesArgs {
     owner: Owner;
   };
 }
-
-const ROOT_TYPE_KEYS = new Set([
-  internalKeyFor(baseCardRef, undefined),
-  internalKeyFor(baseFieldRef, undefined),
-  internalKeyFor(baseRef, undefined),
-]);
 
 export class TypeSummariesResource extends Resource<TypeSummariesArgs> {
   @service declare private realmServer: RealmServerService;
@@ -131,21 +124,14 @@ export class TypeSummariesResource extends Resource<TypeSummariesArgs> {
   }
 
   get hasNonRootBaseFilter(): boolean {
-    return this.baseFilterCodeRefs !== undefined;
-  }
-
-  get selectedTypeIds(): string[] {
-    return this._selected.map((ref) => internalKeyFor(ref, undefined));
+    return getBaseFilterTypeKeys(this.#baseFilter) !== undefined;
   }
 
   // -- Public methods --
 
   onSearchChange(term: string): void {
     this._typeSearchKey = term;
-    this.fetchTypeSummariesTask.perform(
-      this.#previousRealmURLs ?? [],
-      term,
-    );
+    this.fetchTypeSummariesTask.perform(this.#previousRealmURLs ?? [], term);
   }
 
   onLoadMore(): void {
@@ -163,28 +149,6 @@ export class TypeSummariesResource extends Resource<TypeSummariesArgs> {
   }
 
   // -- Private computed --
-
-  private get baseFilterCodeRefs(): Set<string> | undefined {
-    const typeRefs = getFilterTypeRefs(this.#baseFilter);
-    if (!typeRefs || typeRefs.length === 0) {
-      return undefined;
-    }
-    const refs = new Set<string>();
-    for (const { ref, negated } of typeRefs) {
-      if (!negated && isResolvedCodeRef(ref)) {
-        refs.add(internalKeyFor(ref, undefined));
-      }
-    }
-    if (refs.size === 0) return undefined;
-
-    // CardDef/FieldDef are root types — all card types inherit from them,
-    // so filtering by them would incorrectly show zero results. Skip.
-    if ([...refs].every((r) => ROOT_TYPE_KEYS.has(r))) {
-      return undefined;
-    }
-
-    return refs;
-  }
 
   // -- Private tasks --
 
@@ -303,7 +267,7 @@ export class TypeSummariesResource extends Resource<TypeSummariesArgs> {
   // -- Type filter computation --
 
   private recomputeTypeFilter(): void {
-    const allowedCodeRefs = this.baseFilterCodeRefs;
+    const allowedCodeRefs = getBaseFilterTypeKeys(this.#baseFilter);
     const optionsById = new Map<string, TypeOption>();
 
     for (const item of this._typeSummariesData) {

--- a/packages/host/app/resources/type-summaries.ts
+++ b/packages/host/app/resources/type-summaries.ts
@@ -1,0 +1,400 @@
+import { isDestroyed, isDestroying } from '@ember/destroyable';
+import { registerDestructor } from '@ember/destroyable';
+import type Owner from '@ember/owner';
+import { setOwner } from '@ember/owner';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+import { restartableTask, timeout } from 'ember-concurrency';
+import { Resource } from 'ember-modify-based-class-resource';
+
+import {
+  type Filter,
+  type ResolvedCodeRef,
+  baseCardRef,
+  baseFieldRef,
+  baseRef,
+  codeRefFromInternalKey,
+  internalKeyFor,
+  isResolvedCodeRef,
+} from '@cardstack/runtime-common';
+
+import {
+  getFilterTypeRefs,
+} from '../components/card-search/utils';
+
+import type RealmServerService from '../services/realm-server';
+
+/** Domain-level representation of a type option (no PickerOption dependency). */
+export interface TypeOption {
+  id: string; // internal key
+  displayName: string;
+  icon?: string;
+}
+
+type TypeSummaryItem = {
+  id: string;
+  type: string;
+  attributes: { displayName: string; total: number; iconHTML: string };
+  meta?: { realmURL: string };
+};
+
+export interface TypeSummariesArgs {
+  named: {
+    realmURLs: string[];
+    baseFilter: Filter | undefined;
+    initialSelectedTypes: ResolvedCodeRef[] | undefined;
+    owner: Owner;
+  };
+}
+
+const ROOT_TYPE_KEYS = new Set([
+  internalKeyFor(baseCardRef, undefined),
+  internalKeyFor(baseFieldRef, undefined),
+  internalKeyFor(baseRef, undefined),
+]);
+
+export class TypeSummariesResource extends Resource<TypeSummariesArgs> {
+  @service declare private realmServer: RealmServerService;
+
+  static PAGE_SIZE = 25;
+
+  @tracked private _typeSummariesData: TypeSummaryItem[] = [];
+  @tracked private _isLoading = false;
+  @tracked private _isLoadingMore = false;
+  @tracked private _hasMore = false;
+  @tracked private _totalCount = 0;
+  @tracked private _options: TypeOption[] = [];
+  @tracked private _selected: ResolvedCodeRef[] = [];
+
+  private _currentPage = 0;
+  private _typeSearchKey = '';
+
+  // Non-tracked: persists across resource re-runs without creating
+  // tracking dependencies. Updated by updateSelected and recomputation.
+  private _previousSelectedKeys: Set<string> = new Set();
+
+  #previousRealmURLs: string[] | undefined;
+  #baseFilter: Filter | undefined;
+  #initialSelectedTypes: ResolvedCodeRef[] | undefined;
+
+  constructor(owner: object) {
+    super(owner);
+    registerDestructor(this, () => {
+      this.fetchTypeSummariesTask.cancelAll();
+      this.loadMoreTypesTask.cancelAll();
+    });
+  }
+
+  modify(_positional: never[], named: TypeSummariesArgs['named']) {
+    let { realmURLs, baseFilter, initialSelectedTypes, owner } = named;
+    setOwner(this, owner);
+
+    this.#baseFilter = baseFilter;
+    this.#initialSelectedTypes = initialSelectedTypes;
+
+    // Only re-fetch when realmURLs change (search key changes are handled by onSearchChange)
+    let realmURLsKey = realmURLs.join(',');
+    let prevKey = this.#previousRealmURLs?.join(',');
+
+    if (realmURLsKey !== prevKey) {
+      this.#previousRealmURLs = realmURLs;
+      this._typeSearchKey = '';
+      this.fetchTypeSummariesTask.perform(realmURLs, '');
+    }
+  }
+
+  // -- Public getters --
+
+  get options(): TypeOption[] {
+    return this._options;
+  }
+
+  get selected(): ResolvedCodeRef[] {
+    return this._selected;
+  }
+
+  get isLoading(): boolean {
+    return this._isLoading;
+  }
+
+  get isLoadingMore(): boolean {
+    return this._isLoadingMore;
+  }
+
+  get hasMore(): boolean {
+    return this._hasMore;
+  }
+
+  get totalCount(): number {
+    return this._totalCount;
+  }
+
+  get hasNonRootBaseFilter(): boolean {
+    return this.baseFilterCodeRefs !== undefined;
+  }
+
+  get selectedTypeIds(): string[] {
+    return this._selected.map((ref) => internalKeyFor(ref, undefined));
+  }
+
+  // -- Public methods --
+
+  onSearchChange(term: string): void {
+    this._typeSearchKey = term;
+    this.fetchTypeSummariesTask.perform(
+      this.#previousRealmURLs ?? [],
+      term,
+    );
+  }
+
+  onLoadMore(): void {
+    if (this._isLoading || this._isLoadingMore || !this._hasMore) {
+      return;
+    }
+    this.loadMoreTypesTask.perform();
+  }
+
+  updateSelected(selected: ResolvedCodeRef[]): void {
+    this._previousSelectedKeys = new Set(
+      selected.map((ref) => internalKeyFor(ref, undefined)),
+    );
+    this._selected = selected;
+  }
+
+  // -- Private computed --
+
+  private get baseFilterCodeRefs(): Set<string> | undefined {
+    const typeRefs = getFilterTypeRefs(this.#baseFilter);
+    if (!typeRefs || typeRefs.length === 0) {
+      return undefined;
+    }
+    const refs = new Set<string>();
+    for (const { ref, negated } of typeRefs) {
+      if (!negated && isResolvedCodeRef(ref)) {
+        refs.add(internalKeyFor(ref, undefined));
+      }
+    }
+    if (refs.size === 0) return undefined;
+
+    // CardDef/FieldDef are root types — all card types inherit from them,
+    // so filtering by them would incorrectly show zero results. Skip.
+    if ([...refs].every((r) => ROOT_TYPE_KEYS.has(r))) {
+      return undefined;
+    }
+
+    return refs;
+  }
+
+  // -- Private tasks --
+
+  private fetchTypeSummariesTask = restartableTask(
+    async (realmURLs: string[], searchKey: string) => {
+      if (searchKey) {
+        await timeout(300); // debounce search
+      } else {
+        await Promise.resolve(); // yield to avoid autotracking assertion
+      }
+      if (isDestroyed(this) || isDestroying(this)) return;
+      this._isLoading = true;
+      this._currentPage = 0;
+
+      try {
+        let result = await this.realmServer.fetchCardTypeSummaries(realmURLs, {
+          searchKey: searchKey || undefined,
+          page: {
+            number: 0,
+            size: TypeSummariesResource.PAGE_SIZE,
+          },
+        });
+        if (isDestroyed(this) || isDestroying(this)) return;
+
+        this._typeSummariesData = result.data;
+        this._totalCount = result.meta.page.total;
+        this._hasMore = result.data.length < result.meta.page.total;
+
+        // If there are selected types (or initialSelectedTypes) not yet in
+        // the fetched results, keep fetching more pages until they're found.
+        const selectedIds = new Set(this._previousSelectedKeys);
+        const initialTypes = this.#initialSelectedTypes;
+        if (initialTypes) {
+          for (const ref of initialTypes) {
+            selectedIds.add(internalKeyFor(ref, undefined));
+          }
+        }
+
+        if (selectedIds.size > 0 && this._hasMore) {
+          while (this._hasMore) {
+            const fetchedIds = new Set(
+              this._typeSummariesData.map((d) => d.id),
+            );
+            if ([...selectedIds].every((id) => fetchedIds.has(id))) break;
+
+            const nextPage = this._currentPage + 1;
+            let moreResult = await this.realmServer.fetchCardTypeSummaries(
+              realmURLs,
+              {
+                searchKey: searchKey || undefined,
+                page: {
+                  number: nextPage,
+                  size: TypeSummariesResource.PAGE_SIZE,
+                },
+              },
+            );
+            if (isDestroyed(this) || isDestroying(this)) return;
+
+            this._currentPage = nextPage;
+            this._typeSummariesData = [
+              ...this._typeSummariesData,
+              ...moreResult.data,
+            ];
+            this._hasMore =
+              this._typeSummariesData.length < moreResult.meta.page.total;
+          }
+        }
+
+        this._isLoading = false;
+        this.recomputeTypeFilter();
+      } catch (e) {
+        console.error('Failed to fetch card type summaries', e);
+        if (!isDestroyed(this) && !isDestroying(this)) {
+          this._typeSummariesData = [];
+          this._totalCount = 0;
+          this._hasMore = false;
+          this._isLoading = false;
+          this.recomputeTypeFilter();
+        }
+      }
+    },
+  );
+
+  private loadMoreTypesTask = restartableTask(async () => {
+    if (isDestroyed(this) || isDestroying(this)) return;
+    this._isLoadingMore = true;
+    const nextPage = this._currentPage + 1;
+
+    try {
+      let result = await this.realmServer.fetchCardTypeSummaries(
+        this.#previousRealmURLs ?? [],
+        {
+          searchKey: this._typeSearchKey || undefined,
+          page: {
+            number: nextPage,
+            size: TypeSummariesResource.PAGE_SIZE,
+          },
+        },
+      );
+      if (isDestroyed(this) || isDestroying(this)) return;
+
+      this._currentPage = nextPage;
+      this._typeSummariesData = [...this._typeSummariesData, ...result.data];
+      const totalFetched = this._typeSummariesData.length;
+      this._hasMore = totalFetched < result.meta.page.total;
+      this._isLoadingMore = false;
+      this.recomputeTypeFilter();
+    } catch (e) {
+      console.error('Failed to load more card type summaries', e);
+      if (!isDestroyed(this) && !isDestroying(this)) {
+        this._isLoadingMore = false;
+      }
+    }
+  });
+
+  // -- Type filter computation --
+
+  private recomputeTypeFilter(): void {
+    const allowedCodeRefs = this.baseFilterCodeRefs;
+    const optionsById = new Map<string, TypeOption>();
+
+    for (const item of this._typeSummariesData) {
+      const name = item.attributes.displayName;
+      const codeRef = item.id;
+      if (!name) {
+        continue;
+      }
+
+      // Never show root types — they are internal meta types
+      if (ROOT_TYPE_KEYS.has(codeRef)) {
+        continue;
+      }
+
+      // When baseFilter constrains to specific types, only show matching types
+      if (allowedCodeRefs && !allowedCodeRefs.has(codeRef)) {
+        continue;
+      }
+
+      optionsById.set(codeRef, {
+        id: codeRef,
+        displayName: name,
+        icon: item.attributes.iconHTML ?? undefined,
+      });
+    }
+
+    this._options = [
+      ...[...optionsById.values()].sort((a, b) =>
+        a.displayName.localeCompare(b.displayName),
+      ),
+    ];
+
+    // Recalculate selected based on previous user selection.
+    const prevKeys = this._previousSelectedKeys;
+    const initialTypes = this.#initialSelectedTypes;
+    const hadSelectAll = prevKeys.size === 0;
+
+    if (initialTypes && initialTypes.length > 0 && prevKeys.size === 0) {
+      // First launch with initialSelectedTypes (e.g., from "Find Instances").
+      this._selected = [...initialTypes];
+    } else if (hadSelectAll) {
+      // If baseFilter constrains to specific types and they exist in options,
+      // auto-select them instead of defaulting to "Any Type"
+      const baseTypeRefs = getFilterTypeRefs(this.#baseFilter);
+      const baseRefs =
+        baseTypeRefs
+          ?.filter((r) => !r.negated && isResolvedCodeRef(r.ref))
+          .map((r) => internalKeyFor(r.ref, undefined)) ?? [];
+      if (baseRefs.length > 0) {
+        const autoSelected = baseRefs
+          .filter((ref) => optionsById.has(ref))
+          .map((ref) => codeRefFromInternalKey(ref))
+          .filter((ref): ref is ResolvedCodeRef => ref !== undefined);
+        this._selected = autoSelected.length > 0 ? autoSelected : [];
+      } else {
+        this._selected = [];
+      }
+    } else if (this._isLoading || this._isLoadingMore) {
+      // Type summaries still loading — keep previous selections
+      // to avoid jarring UI changes. No change to _selected.
+    } else {
+      // Keep previous selections that still exist in the new options.
+      const kept = [...prevKeys]
+        .filter((key) => optionsById.has(key))
+        .map((key) => codeRefFromInternalKey(key))
+        .filter((ref): ref is ResolvedCodeRef => ref !== undefined);
+      this._selected = kept.length > 0 ? kept : [];
+    }
+
+    this._previousSelectedKeys = new Set(
+      this._selected.map((ref) => internalKeyFor(ref, undefined)),
+    );
+  }
+}
+
+export function getTypeSummaries(
+  parent: object,
+  owner: Owner,
+  getArgs: () => {
+    realmURLs: string[];
+    baseFilter: Filter | undefined;
+    initialSelectedTypes: ResolvedCodeRef[] | undefined;
+  },
+) {
+  let resource = TypeSummariesResource.from(parent, () => ({
+    named: {
+      realmURLs: getArgs().realmURLs,
+      baseFilter: getArgs().baseFilter,
+      initialSelectedTypes: getArgs().initialSelectedTypes,
+      owner,
+    },
+  }));
+  return resource as TypeSummariesResource;
+}

--- a/packages/host/app/resources/type-summaries.ts
+++ b/packages/host/app/resources/type-summaries.ts
@@ -318,7 +318,15 @@ export class TypeSummariesResource extends Resource<TypeSummariesArgs> {
 
     if (initialTypes && initialTypes.length > 0 && prevKeys.size === 0) {
       // First launch with initialSelectedTypes (e.g., from "Find Instances").
-      this._selected = [...initialTypes];
+      for (const ref of initialTypes) {
+        if (
+          ref.name === 'CardDef' &&
+          ref.module === 'https://cardstack.com/base/card-api'
+        ) {
+          continue; // ignore CardDef from initialSelectedTypes since it's not a type that can be selected
+        }
+        this.selected.push(ref);
+      }
     } else if (hadSelectAll) {
       // If baseFilter constrains to specific types and they exist in options,
       // auto-select them instead of defaulting to "Any Type"

--- a/packages/host/app/resources/type-summaries.ts
+++ b/packages/host/app/resources/type-summaries.ts
@@ -199,6 +199,11 @@ export class TypeSummariesResource extends Resource<TypeSummariesArgs> {
       if (isDestroyed(this) || isDestroying(this)) return;
       if (!result) {
         this._isLoading = false;
+        this._typeSummariesData = [];
+        this._options = [];
+        this._selected = [];
+        this._hasMore = false;
+        this._totalCount = 0;
         return;
       }
 

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -51,7 +51,7 @@ import type { CardDef, Format } from 'https://cardstack.com/base/card-api';
 
 import type { BoxelContext } from 'https://cardstack.com/base/matrix-event';
 
-import { removeFileExtension } from '../components/card-search/utils';
+import { removeFileExtension } from '../utils/card-search/types';
 
 import { ModuleInspectorSelections } from '../utils/local-storage-keys';
 

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -367,7 +367,8 @@ export default class RealmServerService extends Service {
     [realmUrl: string]: string;
   }) {
     if (!this.client) {
-      throw new Error(`Cannot check joined rooms without matrix client`);
+      console.warn(`Cannot check joined rooms without matrix client`);
+      return;
     }
     let { joined_rooms } = await this.client.getJoinedRooms();
     let joinedRoomSet = new Set(joined_rooms ?? []);
@@ -686,7 +687,8 @@ export default class RealmServerService extends Service {
 
   private loginTask = task(async () => {
     if (!this.client) {
-      throw new Error(`Cannot login to realm server without matrix client`);
+      console.warn(`Cannot login to realm server without matrix client`);
+      return;
     }
     try {
       let realmAuthClient = new RealmAuthClient(

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -102,6 +102,10 @@ export default class RealmServerService extends Service {
     return this._ready.promise;
   }
 
+  get canFetch(): boolean {
+    return this.client !== undefined || this.auth.type === 'logged-in';
+  }
+
   resetState() {
     let catalogRealms = this.availableRealms.filter(
       (realm) => realm.type === 'catalog',
@@ -367,8 +371,7 @@ export default class RealmServerService extends Service {
     [realmUrl: string]: string;
   }) {
     if (!this.client) {
-      console.warn(`Cannot check joined rooms without matrix client`);
-      return;
+      throw new Error(`Cannot check joined rooms without matrix client`);
     }
     let { joined_rooms } = await this.client.getJoinedRooms();
     let joinedRoomSet = new Set(joined_rooms ?? []);
@@ -687,8 +690,7 @@ export default class RealmServerService extends Service {
 
   private loginTask = task(async () => {
     if (!this.client) {
-      console.warn(`Cannot login to realm server without matrix client`);
-      return;
+      throw new Error(`Cannot login to realm server without matrix client`);
     }
     try {
       let realmAuthClient = new RealmAuthClient(

--- a/packages/host/app/utils/card-search/query-builder.ts
+++ b/packages/host/app/utils/card-search/query-builder.ts
@@ -3,34 +3,19 @@ import type {
   Filter,
   Query,
   ResolvedCodeRef,
-  TypeRefResult,
 } from '@cardstack/runtime-common';
 import {
   codeRefFromInternalKey,
-  getTypeRefsFromFilter,
-  identifyCard,
   isAnyFilter,
-  isBaseDef,
   isCardTypeFilter,
   isEveryFilter,
   isNotFilter,
-  isResolvedCodeRef,
   specRef,
 } from '@cardstack/runtime-common';
 
-import type { CardDef } from 'https://cardstack.com/base/card-api';
+import type { SortOption } from '@cardstack/host/components/card-search/constants';
 
-import type { SortOption } from './constants';
-
-export interface NewCardArgs {
-  ref: CodeRef;
-  relativeTo: string | undefined;
-  realmURL: string;
-}
-
-export function removeFileExtension(cardId: string | undefined) {
-  return cardId?.replace(/\.[^/.]+$/, '');
-}
+import { isSearchKeyEmpty, isURLSearchKey } from './url';
 
 export function shouldSkipSearchQuery(
   searchKey: string,
@@ -40,71 +25,6 @@ export function shouldSkipSearchQuery(
     return isURLSearchKey(searchKey);
   }
   return isSearchKeyEmpty(searchKey) || isURLSearchKey(searchKey);
-}
-
-function isSearchKeyEmpty(searchKey: string): boolean {
-  return (searchKey?.trim() ?? '') === '';
-}
-
-function isURLSearchKey(searchKey: string): boolean {
-  try {
-    new URL(searchKey);
-    return true;
-  } catch (_e) {
-    return false;
-  }
-}
-
-export function cardMatchesTypeRef(card: CardDef, typeRef: CodeRef): boolean {
-  if (!isResolvedCodeRef(typeRef)) {
-    return false;
-  }
-  let cls: unknown = card.constructor;
-  while (cls && isBaseDef(cls)) {
-    const ref = identifyCard(cls);
-    if (
-      ref &&
-      isResolvedCodeRef(ref) &&
-      ref.module === typeRef.module &&
-      ref.name === typeRef.name
-    ) {
-      return true;
-    }
-    cls = Reflect.getPrototypeOf(cls as object);
-  }
-  return false;
-}
-
-export function getFilterTypeRefs(
-  baseFilter: Filter | undefined,
-): TypeRefResult[] | undefined {
-  if (baseFilter) {
-    return getTypeRefsFromFilter(baseFilter);
-  }
-  return undefined;
-}
-
-export function filterCardsByTypeRefs(
-  cards: CardDef[],
-  typeRefs: TypeRefResult[] | undefined,
-): CardDef[] {
-  if (!typeRefs) {
-    return cards;
-  }
-  const positiveRefs = typeRefs.filter((r) => !r.negated).map((r) => r.ref);
-  const negatedRefs = typeRefs.filter((r) => r.negated).map((r) => r.ref);
-  let filtered = cards;
-  if (positiveRefs.length > 0) {
-    filtered = filtered.filter((c) =>
-      positiveRefs.some((ref) => cardMatchesTypeRef(c, ref)),
-    );
-  }
-  if (negatedRefs.length > 0) {
-    filtered = filtered.filter(
-      (c) => !negatedRefs.some((ref) => cardMatchesTypeRef(c, ref)),
-    );
-  }
-  return filtered;
 }
 
 // Removes CardTypeFilter nodes from a filter tree.

--- a/packages/host/app/utils/card-search/recent-cards.ts
+++ b/packages/host/app/utils/card-search/recent-cards.ts
@@ -1,8 +1,8 @@
 import type { Filter, ResolvedCodeRef } from '@cardstack/runtime-common';
 
-import type { CardDef } from 'https://cardstack.com/base/card-api';
-
 import type { SortOption } from '@cardstack/host/components/card-search/constants';
+
+import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import {
   cardMatchesTypeRef,

--- a/packages/host/app/utils/card-search/recent-cards.ts
+++ b/packages/host/app/utils/card-search/recent-cards.ts
@@ -1,0 +1,104 @@
+import type { Filter, ResolvedCodeRef } from '@cardstack/runtime-common';
+
+import type { CardDef } from 'https://cardstack.com/base/card-api';
+
+import type { SortOption } from '@cardstack/host/components/card-search/constants';
+
+import {
+  cardMatchesTypeRef,
+  filterCardsByTypeRefs,
+  getFilterTypeRefs,
+} from './type-filter';
+
+/**
+ * Filters recent cards by realm URLs and base filter type constraints.
+ */
+export function filterRecentCards(
+  cards: CardDef[],
+  realmURLs: string[],
+  baseFilter?: Filter,
+): CardDef[] {
+  const realmFiltered = cards.filter(
+    (c) => c.id && realmURLs.some((url) => c.id.startsWith(url)),
+  );
+  const typeRefs = getFilterTypeRefs(baseFilter);
+  return filterCardsByTypeRefs(realmFiltered, typeRefs);
+}
+
+/**
+ * Further filters and sorts recent cards based on:
+ * 1. Type picker selection (unless skipTypeFiltering)
+ * 2. Search term matching on card title
+ * 3. Active sort option (A-Z, Last Updated, Date Created)
+ *
+ * In compact mode, skips search term filtering and sorting.
+ */
+export function sortAndFilterRecentCards(
+  cards: CardDef[],
+  opts: {
+    selectedTypes: ResolvedCodeRef[];
+    skipTypeFiltering: boolean;
+    searchTerm: string | undefined;
+    activeSort: SortOption;
+    isCompact: boolean;
+  },
+): CardDef[] {
+  let filtered = [...cards];
+
+  // Apply type picker filter.
+  // Skip when baseFilter has a non-root type — the server already
+  // constrains results via the adoption chain, and recent cards are
+  // pre-filtered by filterCardsByTypeRefs which handles subtypes.
+  if (!opts.skipTypeFiltering && opts.selectedTypes.length > 0) {
+    filtered = filtered.filter((card) =>
+      opts.selectedTypes.some((ref) => cardMatchesTypeRef(card, ref)),
+    );
+  }
+
+  if (opts.isCompact) {
+    return filtered;
+  }
+
+  // Apply search term filter
+  if (opts.searchTerm) {
+    const lowerTerm = opts.searchTerm.toLowerCase();
+    filtered = filtered.filter((c) =>
+      (c.cardTitle ?? '').toLowerCase().includes(lowerTerm),
+    );
+  }
+
+  // Sort
+  return sortCards(filtered, opts.activeSort);
+}
+
+function sortCards(cards: CardDef[], sortOption: SortOption): CardDef[] {
+  const displayName = sortOption.displayName;
+  return [...cards].sort((a, b) => {
+    if (displayName === 'A-Z') {
+      return (a.cardTitle ?? '').localeCompare(b.cardTitle ?? '');
+    }
+    if (displayName === 'Last Updated') {
+      const aVal =
+        'lastModified' in a
+          ? ((a as Record<string, unknown>).lastModified as number)
+          : 0;
+      const bVal =
+        'lastModified' in b
+          ? ((b as Record<string, unknown>).lastModified as number)
+          : 0;
+      return bVal - aVal;
+    }
+    if (displayName === 'Date Created') {
+      const aVal =
+        'createdAt' in a
+          ? ((a as Record<string, unknown>).createdAt as number)
+          : 0;
+      const bVal =
+        'createdAt' in b
+          ? ((b as Record<string, unknown>).createdAt as number)
+          : 0;
+      return bVal - aVal;
+    }
+    return 0;
+  });
+}

--- a/packages/host/app/utils/card-search/section-pagination.ts
+++ b/packages/host/app/utils/card-search/section-pagination.ts
@@ -1,0 +1,57 @@
+import { tracked } from '@glimmer/tracking';
+
+import {
+  SECTION_DISPLAY_LIMIT_FOCUSED,
+  SECTION_DISPLAY_LIMIT_UNFOCUSED,
+  SECTION_SHOW_MORE_INCREMENT,
+} from '@cardstack/host/components/card-search/constants';
+
+/**
+ * Manages pagination and focus state for search result sections.
+ *
+ * Tracks which section is focused ("Show Only"), how many cards
+ * are displayed per section, and handles "Show More" increments.
+ */
+export class SectionPagination {
+  @tracked focusedSection: string | null;
+  @tracked displayedCounts: Record<string, number> = {};
+
+  constructor(initialFocusedSection?: string | null) {
+    this.focusedSection = initialFocusedSection ?? null;
+  }
+
+  getDisplayedCount = (sectionId: string, totalCount: number): number => {
+    const isFocused = this.focusedSection === sectionId;
+    const initialLimit = isFocused
+      ? SECTION_DISPLAY_LIMIT_FOCUSED
+      : SECTION_DISPLAY_LIMIT_UNFOCUSED;
+    const current = this.displayedCounts[sectionId] ?? initialLimit;
+    return Math.min(current, totalCount);
+  };
+
+  showMore(sectionId: string, totalCount: number): void {
+    const current = this.getDisplayedCount(sectionId, totalCount);
+    const next = Math.min(current + SECTION_SHOW_MORE_INCREMENT, totalCount);
+    this.displayedCounts = {
+      ...this.displayedCounts,
+      [sectionId]: next,
+    };
+  }
+
+  focus(sectionId: string | null): void {
+    this.focusedSection = sectionId;
+    if (sectionId) {
+      const current = this.displayedCounts[sectionId] ?? 0;
+      if (current < SECTION_DISPLAY_LIMIT_FOCUSED) {
+        this.displayedCounts = {
+          ...this.displayedCounts,
+          [sectionId]: SECTION_DISPLAY_LIMIT_FOCUSED,
+        };
+      }
+    }
+  }
+
+  isCollapsed(sectionId: string): boolean {
+    return !!this.focusedSection && this.focusedSection !== sectionId;
+  }
+}

--- a/packages/host/app/utils/card-search/sections.ts
+++ b/packages/host/app/utils/card-search/sections.ts
@@ -1,0 +1,212 @@
+import type { CodeRef } from '@cardstack/runtime-common';
+
+import { urlForRealmLookup } from '@cardstack/host/lib/utils';
+
+import type { CardDef } from 'https://cardstack.com/base/card-api';
+
+import type { PrerenderedCard } from '@cardstack/host/components/prerendered-card-search';
+
+// ── Section types ──
+
+export interface RealmSectionInfo {
+  name: string;
+  iconURL: string | null;
+  publishable: boolean | null;
+}
+
+export interface RealmSection {
+  sid: string;
+  type: 'realm';
+  realmUrl: string;
+  realmInfo: RealmSectionInfo;
+  cards: PrerenderedCard[];
+  totalCount: number;
+}
+
+export interface RecentsSection {
+  sid: string;
+  type: 'recents';
+  cards: CardDef[];
+  totalCount: number;
+}
+
+export interface UrlSection {
+  sid: string;
+  type: 'url';
+  card: CardDef;
+  realmInfo: RealmSectionInfo;
+}
+
+export type SearchSheetSection = RealmSection | RecentsSection | UrlSection;
+
+// ── Realm info resolution ──
+
+export interface RealmInfoLookup {
+  info(
+    realmURL: string,
+  ): { name: string; iconURL: string | null; publishable: boolean | null } | null;
+}
+
+function realmNameFromUrl(realmUrl: string): string {
+  try {
+    const pathname = new URL(realmUrl).pathname;
+    const segments = pathname.split('/').filter(Boolean);
+    return segments[segments.length - 1] ?? 'Workspace';
+  } catch {
+    return 'Workspace';
+  }
+}
+
+function resolveRealmInfo(
+  realmUrl: string,
+  realm: RealmInfoLookup,
+): RealmSectionInfo {
+  const info = realm.info(realmUrl);
+  return {
+    name: info?.name ?? realmNameFromUrl(realmUrl),
+    iconURL: info?.iconURL ?? null,
+    publishable: info?.publishable ?? null,
+  };
+}
+
+function realmUrlForCard(cardIdOrUrl: string, realmURLs: string[]): string {
+  for (const realm of realmURLs) {
+    if (cardIdOrUrl.startsWith(realm)) {
+      return realm;
+    }
+  }
+  try {
+    const url = new URL(cardIdOrUrl);
+    return `${url.origin}${url.pathname.split('/').slice(0, -1)?.join('/') ?? ''}/`;
+  } catch {
+    return '';
+  }
+}
+
+// ── Section builders ──
+
+export function buildRecentsSection(
+  cards: CardDef[],
+): RecentsSection | undefined {
+  if (cards.length === 0) {
+    return undefined;
+  }
+  return {
+    sid: 'recents',
+    type: 'recents',
+    cards,
+    totalCount: cards.length,
+  };
+}
+
+export function buildUrlSection(
+  card: CardDef | undefined,
+  isURL: boolean,
+  realmURLs: string[],
+  realm: RealmInfoLookup,
+): UrlSection | undefined {
+  if (!isURL || !card) {
+    return undefined;
+  }
+  const urlForRealm = urlForRealmLookup(card);
+  const realmUrl = realmUrlForCard(urlForRealm, realmURLs);
+  return {
+    sid: `url:${card.id}`,
+    type: 'url',
+    card,
+    realmInfo: resolveRealmInfo(realmUrl, realm),
+  };
+}
+
+export function buildQuerySections(
+  instances: PrerenderedCard[],
+  opts: {
+    isURL: boolean;
+    isSearchKeyEmpty: boolean;
+    hasBaseFilter: boolean;
+    realmURLs: string[];
+    offerToCreate?: { ref: CodeRef; relativeTo: URL | undefined };
+    realm: RealmInfoLookup;
+  },
+): RealmSection[] | null {
+  if (opts.isURL) {
+    return null;
+  }
+  // In search-sheet mode (no baseFilter), skip when search key is empty
+  if (!opts.hasBaseFilter && opts.isSearchKeyEmpty) {
+    return null;
+  }
+
+  const byRealm = new Map<string, PrerenderedCard[]>();
+  for (const card of instances) {
+    const list: PrerenderedCard[] = byRealm.get(card.realmUrl) ?? [];
+    list.push(card);
+    byRealm.set(card.realmUrl, list);
+  }
+
+  const sections: RealmSection[] = [];
+  for (const [realmUrl, realmCards] of byRealm) {
+    sections.push({
+      sid: `realm:${realmUrl}`,
+      type: 'realm',
+      realmUrl,
+      realmInfo: resolveRealmInfo(realmUrl, opts.realm),
+      cards: realmCards,
+      totalCount: realmCards.length,
+    });
+  }
+
+  // When offerToCreate is provided, include empty sections for all
+  // available/selected realms that have no results, so users can
+  // create new cards in those realms.
+  if (opts.offerToCreate) {
+    for (const realmUrl of opts.realmURLs) {
+      if (!byRealm.has(realmUrl)) {
+        sections.push({
+          sid: `realm:${realmUrl}`,
+          type: 'realm',
+          realmUrl,
+          realmInfo: resolveRealmInfo(realmUrl, opts.realm),
+          cards: [],
+          totalCount: 0,
+        });
+      }
+    }
+  }
+
+  return sections;
+}
+
+/**
+ * Combines recents, URL, and query sections into a single ordered list.
+ * Moves the focused section (if any) to the front.
+ */
+export function assembleSections(
+  recents: RecentsSection | undefined,
+  urlSection: UrlSection | undefined,
+  querySections: RealmSection[] | null,
+  focusedSectionId: string | null,
+): SearchSheetSection[] {
+  const sections: SearchSheetSection[] = [];
+
+  if (recents) {
+    sections.push(recents);
+  }
+  if (urlSection) {
+    sections.push(urlSection);
+  }
+  if (querySections) {
+    sections.push(...querySections);
+  }
+
+  // Move focused section to front so it appears at the top
+  if (focusedSectionId) {
+    const idx = sections.findIndex((s) => s.sid === focusedSectionId);
+    if (idx > 0) {
+      const [focused] = sections.splice(idx, 1);
+      sections.unshift(focused);
+    }
+  }
+
+  return sections;
+}

--- a/packages/host/app/utils/card-search/sections.ts
+++ b/packages/host/app/utils/card-search/sections.ts
@@ -1,10 +1,9 @@
 import type { CodeRef } from '@cardstack/runtime-common';
 
+import type { PrerenderedCard } from '@cardstack/host/components/prerendered-card-search';
 import { urlForRealmLookup } from '@cardstack/host/lib/utils';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
-
-import type { PrerenderedCard } from '@cardstack/host/components/prerendered-card-search';
 
 // ── Section types ──
 
@@ -42,9 +41,11 @@ export type SearchSheetSection = RealmSection | RecentsSection | UrlSection;
 // ── Realm info resolution ──
 
 export interface RealmInfoLookup {
-  info(
-    realmURL: string,
-  ): { name: string; iconURL: string | null; publishable: boolean | null } | null;
+  info(realmURL: string): {
+    name: string;
+    iconURL: string | null;
+    publishable: boolean | null;
+  } | null;
 }
 
 function realmNameFromUrl(realmUrl: string): string {

--- a/packages/host/app/utils/card-search/type-filter.ts
+++ b/packages/host/app/utils/card-search/type-filter.ts
@@ -1,0 +1,129 @@
+import type {
+  CodeRef,
+  Filter,
+  ResolvedCodeRef,
+  TypeRefResult,
+} from '@cardstack/runtime-common';
+import {
+  baseCardRef,
+  baseFieldRef,
+  baseRef,
+  getTypeRefsFromFilter,
+  identifyCard,
+  isBaseDef,
+  internalKeyFor,
+  isResolvedCodeRef,
+} from '@cardstack/runtime-common';
+
+import type { CardDef } from 'https://cardstack.com/base/card-api';
+
+/**
+ * Internal key strings for root types (CardDef, FieldDef, BaseDef).
+ * These represent the base of the type hierarchy and are excluded
+ * from type picker options and type-constraint checks.
+ */
+export const ROOT_TYPE_KEYS = new Set([
+  internalKeyFor(baseCardRef, undefined),
+  internalKeyFor(baseFieldRef, undefined),
+  internalKeyFor(baseRef, undefined),
+]);
+
+/**
+ * Extracts type references from a Filter (thin wrapper around runtime-common).
+ */
+export function getFilterTypeRefs(
+  baseFilter: Filter | undefined,
+): TypeRefResult[] | undefined {
+  if (baseFilter) {
+    return getTypeRefsFromFilter(baseFilter);
+  }
+  return undefined;
+}
+
+/**
+ * Extracts non-negated, non-root type internal keys from a base filter.
+ * Returns undefined if there are no constraining types (or only root types).
+ *
+ * Used by TypeSummariesResource to constrain available type options,
+ * and to determine `hasNonRootBaseFilter`.
+ */
+export function getBaseFilterTypeKeys(
+  baseFilter: Filter | undefined,
+): Set<string> | undefined {
+  const typeRefs = getFilterTypeRefs(baseFilter);
+  if (!typeRefs || typeRefs.length === 0) {
+    return undefined;
+  }
+  const refs = new Set<string>();
+  for (const { ref, negated } of typeRefs) {
+    if (!negated && isResolvedCodeRef(ref)) {
+      refs.add(internalKeyFor(ref, undefined));
+    }
+  }
+  if (refs.size === 0) return undefined;
+
+  // CardDef/FieldDef are root types — all card types inherit from them,
+  // so filtering by them would incorrectly show zero results. Skip.
+  if ([...refs].every((r) => ROOT_TYPE_KEYS.has(r))) {
+    return undefined;
+  }
+
+  return refs;
+}
+
+/**
+ * Whether a base filter constrains to non-root types.
+ */
+export function hasNonRootBaseFilter(baseFilter: Filter | undefined): boolean {
+  return getBaseFilterTypeKeys(baseFilter) !== undefined;
+}
+
+/**
+ * Checks whether a card matches a type ref by walking its prototype chain.
+ */
+export function cardMatchesTypeRef(card: CardDef, typeRef: CodeRef): boolean {
+  if (!isResolvedCodeRef(typeRef)) {
+    return false;
+  }
+  let cls: unknown = card.constructor;
+  while (cls && isBaseDef(cls)) {
+    const ref = identifyCard(cls);
+    if (
+      ref &&
+      isResolvedCodeRef(ref) &&
+      ref.module === typeRef.module &&
+      ref.name === typeRef.name
+    ) {
+      return true;
+    }
+    cls = Reflect.getPrototypeOf(cls as object);
+  }
+  return false;
+}
+
+/**
+ * Filters cards by type refs extracted from a Filter.
+ * Handles both positive (include) and negated (exclude) type constraints.
+ */
+export function filterCardsByTypeRefs(
+  cards: CardDef[],
+  typeRefs: TypeRefResult[] | undefined,
+): CardDef[] {
+  if (!typeRefs) {
+    return cards;
+  }
+  const positiveRefs = typeRefs.filter((r) => !r.negated).map((r) => r.ref);
+  const negatedRefs = typeRefs.filter((r) => r.negated).map((r) => r.ref);
+  let filtered = cards;
+  if (positiveRefs.length > 0) {
+    filtered = filtered.filter((c) =>
+      positiveRefs.some((ref) => cardMatchesTypeRef(c, ref)),
+    );
+  }
+  if (negatedRefs.length > 0) {
+    filtered = filtered.filter(
+      (c) => !negatedRefs.some((ref) => cardMatchesTypeRef(c, ref)),
+    );
+  }
+  return filtered;
+}

--- a/packages/host/app/utils/card-search/type-filter.ts
+++ b/packages/host/app/utils/card-search/type-filter.ts
@@ -1,9 +1,4 @@
-import type {
-  CodeRef,
-  Filter,
-  ResolvedCodeRef,
-  TypeRefResult,
-} from '@cardstack/runtime-common';
+import type { CodeRef, Filter, TypeRefResult } from '@cardstack/runtime-common';
 import {
   baseCardRef,
   baseFieldRef,

--- a/packages/host/app/utils/card-search/types.ts
+++ b/packages/host/app/utils/card-search/types.ts
@@ -1,0 +1,11 @@
+import type { CodeRef } from '@cardstack/runtime-common';
+
+export interface NewCardArgs {
+  ref: CodeRef;
+  relativeTo: string | undefined;
+  realmURL: string;
+}
+
+export function removeFileExtension(cardId: string | undefined) {
+  return cardId?.replace(/\.[^/.]+$/, '');
+}

--- a/packages/host/app/utils/card-search/url.ts
+++ b/packages/host/app/utils/card-search/url.ts
@@ -1,0 +1,25 @@
+export function isURLSearchKey(searchKey: string): boolean {
+  try {
+    new URL(searchKey);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isSearchKeyEmpty(searchKey: string): boolean {
+  return (searchKey?.trim() ?? '') === '';
+}
+
+export function resolveSearchKeyAsURL(
+  searchKey: string,
+  availableRealmURLs: string[],
+): string | undefined {
+  if (!isURLSearchKey(searchKey)) {
+    return undefined;
+  }
+  let maybeIndexCardURL = availableRealmURLs.find(
+    (u) => u === searchKey + '/',
+  );
+  return maybeIndexCardURL ?? searchKey;
+}

--- a/packages/host/app/utils/card-search/url.ts
+++ b/packages/host/app/utils/card-search/url.ts
@@ -18,8 +18,6 @@ export function resolveSearchKeyAsURL(
   if (!isURLSearchKey(searchKey)) {
     return undefined;
   }
-  let maybeIndexCardURL = availableRealmURLs.find(
-    (u) => u === searchKey + '/',
-  );
+  let maybeIndexCardURL = availableRealmURLs.find((u) => u === searchKey + '/');
   return maybeIndexCardURL ?? searchKey;
 }

--- a/packages/host/tests/integration/components/operator-mode-ui-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-ui-test.gts
@@ -14,8 +14,8 @@ import GlimmerComponent from '@glimmer/component';
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
-import { TypeSummariesResource } from '@cardstack/host/resources/type-summaries';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
+import { TypeSummariesResource } from '@cardstack/host/resources/type-summaries';
 
 import { percySnapshot, testRealmURL } from '../../helpers';
 import { renderComponent } from '../../helpers/render-component';
@@ -557,7 +557,25 @@ module('Integration | operator-mode | ui', function (hooks) {
       '[data-test-boxel-picker-option-row]:not([data-test-boxel-picker-option-row="select-all"])',
     );
     assert.ok(typeOptions.length > 0, 'at least one type option is available');
+    let firstOptionId = typeOptions[0].getAttribute(
+      'data-test-boxel-picker-option-row',
+    );
+
+    // Before selecting, the first type option checkbox should be unchecked
+    assert
+      .dom(
+        `[data-test-boxel-picker-option-row="${firstOptionId}"] .picker-option-row__checkbox--selected`,
+      )
+      .doesNotExist('type option checkbox is unchecked before selecting');
+
     await click(typeOptions[0] as HTMLElement);
+
+    // After selecting, the type option checkbox should be checked
+    assert
+      .dom(
+        `[data-test-boxel-picker-option-row="${firstOptionId}"] .picker-option-row__checkbox--selected`,
+      )
+      .exists('type option checkbox is checked after selecting');
 
     // Sheet should expand to results mode after selecting a type filter
     await waitFor('[data-test-search-sheet="search-results"]');
@@ -602,60 +620,41 @@ module('Integration | operator-mode | ui', function (hooks) {
         'realm picker shows shortLabel "All" when select-all is active',
       );
 
-    // Type a search term to trigger search results
-    await typeIn('[data-test-search-field]', 'Person');
-    await click('[data-test-search-sheet] .search-sheet-content');
-    await waitFor('[data-test-search-label]', { timeout: 8000 });
-    await waitFor('[data-test-search-realms]', { timeout: 3000 });
-
-    // Helper function to get current selected realms
-    const getSelectedRealms = () => {
-      const attr = document
-        .querySelector('[data-test-search-realms]')
-        ?.getAttribute('data-test-search-realms');
-      return attr?.split(',').map((r) => r.trim()) ?? [];
-    };
-
-    // Verify initial realm filtering includes test realm
-    let selectedRealms = getSelectedRealms();
-    assert.ok(
-      selectedRealms.some(
-        (r) => r.includes('test-realm') && r.includes('/test'),
-      ),
-      'search should initially include the test realm',
-    );
-
-    // Select only the test realm in the picker to verify filter updates
-    const trigger =
+    // Open realm picker to verify initial state
+    const realmPickerTrigger =
       document.querySelector(
         '[data-test-realm-picker] .ember-power-select-trigger',
       ) ?? document.querySelector('[data-test-realm-picker]');
-    await click(trigger as HTMLElement);
+    await click(realmPickerTrigger as HTMLElement);
     await waitFor('.ember-power-select-option', { timeout: 3000 });
 
-    // Realm select-all option should show count
+    // Initially, select-all should be selected with checked checkbox
     assert
       .dom('[data-test-boxel-picker-option-row="select-all"]')
       .containsText('Select All (', 'realm select-all shows count');
+    assert
+      .dom(
+        '[data-test-boxel-picker-option-row="select-all"] .picker-option-row__checkbox--selected',
+      )
+      .exists('select-all checkbox is checked by default');
 
-    const options = document.querySelectorAll('.ember-power-select-option');
-    const testRealmOption = Array.from(options).find((el) =>
-      el.textContent?.includes(ctx.realmName),
-    );
-    assert.ok(testRealmOption, `option for "${ctx.realmName}" should exist`);
-    await click(testRealmOption as HTMLElement);
+    // Select only the test realm
+    assert
+      .dom(`[data-test-boxel-picker-option-label="${ctx.realmName}"]`)
+      .exists(`option for "${ctx.realmName}" should exist`);
+    await click(`[data-test-boxel-picker-option-label="${ctx.realmName}"]`);
 
-    // Verify the filter was applied
-    await waitUntil(() => getSelectedRealms().includes(testRealmURL), {
-      timeout: 5000,
-    });
-    selectedRealms = getSelectedRealms();
-    assert.ok(
-      selectedRealms.some(
-        (r) => r.includes('test-realm') && r.includes('/test'),
-      ),
-      'search should be filtered to the test realm after selection',
-    );
+    // Verify the test realm checkbox is checked and select-all is unchecked
+    assert
+      .dom(
+        `[data-test-boxel-picker-option-label="${ctx.realmName}"] .picker-option-row__checkbox--selected`,
+      )
+      .exists('test realm checkbox is checked after clicking');
+    assert
+      .dom(
+        '[data-test-boxel-picker-option-row="select-all"] .picker-option-row__checkbox--selected',
+      )
+      .doesNotExist('select-all checkbox is unchecked after selecting a realm');
   });
 
   test('clicking outside search sheet resets search input and realm filter', async function (assert) {
@@ -669,45 +668,29 @@ module('Integration | operator-mode | ui', function (hooks) {
     await click(`[data-test-boxel-filter-list-button="All Cards"]`);
     await waitFor(`[data-test-cards-grid-item]`);
 
-    // Helper to get selected realm URLs from data attribute
-    const getSelectedRealms = () => {
-      const attr = document
-        .querySelector('[data-test-search-realms]')
-        ?.getAttribute('data-test-search-realms');
-      return attr?.split(',').map((r) => r.trim()) ?? [];
-    };
-
-    // Open search sheet and type a search term
+    // Open search sheet
     await click(`[data-test-open-search-field]`);
     assert.dom(`[data-test-search-sheet="search-prompt"]`).exists();
 
-    await typeIn('[data-test-search-field]', 'Person');
-    await click('[data-test-search-sheet] .search-sheet-content');
-    await waitFor('[data-test-search-label]', { timeout: 8000 });
-    await waitFor('[data-test-search-realms]', { timeout: 3000 });
-
-    // Record initial realm state (all realms selected by default)
-    let initialRealms = getSelectedRealms();
-
-    // Select a specific realm in the picker
-    const trigger =
+    // Open realm picker and select a specific realm
+    let realmPickerTrigger =
       document.querySelector(
         '[data-test-realm-picker] .ember-power-select-trigger',
       ) ?? document.querySelector('[data-test-realm-picker]');
-    await click(trigger as HTMLElement);
+    await click(realmPickerTrigger as HTMLElement);
     await waitFor('.ember-power-select-option', { timeout: 3000 });
 
-    const options = document.querySelectorAll('.ember-power-select-option');
-    const testRealmOption = Array.from(options).find((el) =>
-      el.textContent?.includes(ctx.realmName),
-    );
-    assert.ok(testRealmOption, `option for "${ctx.realmName}" should exist`);
-    await click(testRealmOption as HTMLElement);
+    assert
+      .dom(`[data-test-boxel-picker-option-label="${ctx.realmName}"]`)
+      .exists(`option for "${ctx.realmName}" should exist`);
+    await click(`[data-test-boxel-picker-option-label="${ctx.realmName}"]`);
 
-    // Verify filter was applied (only selected realm)
-    await waitUntil(() => getSelectedRealms().includes(testRealmURL), {
-      timeout: 5000,
-    });
+    // Verify the test realm checkbox is checked
+    assert
+      .dom(
+        `[data-test-boxel-picker-option-label="${ctx.realmName}"] .picker-option-row__checkbox--selected`,
+      )
+      .exists('test realm checkbox is checked after clicking');
 
     // Close by clicking outside
     await click(`[data-test-operator-mode-stack]`);
@@ -722,14 +705,13 @@ module('Integration | operator-mode | ui', function (hooks) {
       .dom('[data-test-search-field]')
       .hasValue('', 'search input is cleared after clicking outside');
 
-    // Assert realm filter is reset to all realms
-    await waitFor('[data-test-search-realms]', { timeout: 3000 });
-    let reopenedRealms = getSelectedRealms();
-    assert.deepEqual(
-      reopenedRealms,
-      initialRealms,
-      'realm filter is reset to all realms after clicking outside',
-    );
+    // Assert realm filter is reset — picker trigger should show "All"
+    assert
+      .dom('[data-test-realm-picker] [data-test-boxel-picker-selected-item]')
+      .hasText(
+        'All',
+        'realm filter is reset to select-all after clicking outside',
+      );
   });
 
   test('displays card in interact mode when clicking `Open in Interact Mode` menu in preview panel', async function (assert) {
@@ -1408,6 +1390,13 @@ module('Integration | operator-mode | ui', function (hooks) {
     // Select Pet
     await click('[data-test-boxel-picker-option-label="Pet"]');
 
+    // Pet checkbox should be checked after selecting
+    assert
+      .dom(
+        '[data-test-boxel-picker-option-label="Pet"] .picker-option-row__checkbox--selected',
+      )
+      .exists('Pet checkbox is checked after selecting');
+
     // Clear the type picker search
     await fillIn('[data-test-boxel-picker-search] input', '');
 
@@ -1422,12 +1411,17 @@ module('Integration | operator-mode | ui', function (hooks) {
       'all type options are restored after clearing search',
     );
 
-    // Pet should still be selected (checked)
+    // Pet should still be selected with checked checkbox
     assert
       .dom(
         '[data-test-type-picker] [data-test-boxel-picker-selected-item="Pet"]',
       )
       .exists('Pet selection is preserved after clearing search');
+    assert
+      .dom(
+        '[data-test-boxel-picker-option-label="Pet"] .picker-option-row__checkbox--selected',
+      )
+      .exists('Pet checkbox is still checked after clearing search');
   });
 
   test('selected types are preserved after clearing type search when selection is beyond first page', async function (assert) {
@@ -1466,6 +1460,11 @@ module('Integration | operator-mode | ui', function (hooks) {
           '[data-test-type-picker] [data-test-boxel-picker-selected-item="Pet"]',
         )
         .exists('Pet is selected');
+      assert
+        .dom(
+          '[data-test-boxel-picker-option-label="Pet"] .picker-option-row__checkbox--selected',
+        )
+        .exists('Pet checkbox is checked after selecting');
 
       // Clear the type picker search — this triggers a fresh fetch from page 0
       // With PAGE_SIZE=3, Pet (alphabetically late) wouldn't be in the first page
@@ -1479,6 +1478,13 @@ module('Integration | operator-mode | ui', function (hooks) {
         )
         .exists(
           'Pet selection is preserved even when it is beyond the first page of results',
+        );
+      assert
+        .dom(
+          '[data-test-boxel-picker-option-label="Pet"] .picker-option-row__checkbox--selected',
+        )
+        .exists(
+          'Pet checkbox is still checked after clearing search beyond first page',
         );
     } finally {
       TypeSummariesResource.PAGE_SIZE = originalPageSize;

--- a/packages/host/tests/integration/components/operator-mode-ui-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-ui-test.gts
@@ -14,7 +14,7 @@ import GlimmerComponent from '@glimmer/component';
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
-import SearchPanel from '@cardstack/host/components/card-search/panel';
+import { TypeSummariesResource } from '@cardstack/host/resources/type-summaries';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 
 import { percySnapshot, testRealmURL } from '../../helpers';
@@ -1432,8 +1432,8 @@ module('Integration | operator-mode | ui', function (hooks) {
 
   test('selected types are preserved after clearing type search when selection is beyond first page', async function (assert) {
     // Use a small page size so selected types may not be in the first page
-    let originalPageSize = SearchPanel.PAGE_SIZE;
-    SearchPanel.PAGE_SIZE = 3;
+    let originalPageSize = TypeSummariesResource.PAGE_SIZE;
+    TypeSummariesResource.PAGE_SIZE = 3;
 
     try {
       ctx.setCardInOperatorModeState(`${testRealmURL}grid`);
@@ -1481,14 +1481,14 @@ module('Integration | operator-mode | ui', function (hooks) {
           'Pet selection is preserved even when it is beyond the first page of results',
         );
     } finally {
-      SearchPanel.PAGE_SIZE = originalPageSize;
+      TypeSummariesResource.PAGE_SIZE = originalPageSize;
     }
   });
 
   test('type picker total count reflects API total, not loaded options count', async function (assert) {
     // Use a small page size so only some types are loaded initially
-    let originalPageSize = SearchPanel.PAGE_SIZE;
-    SearchPanel.PAGE_SIZE = 3;
+    let originalPageSize = TypeSummariesResource.PAGE_SIZE;
+    TypeSummariesResource.PAGE_SIZE = 3;
 
     try {
       ctx.setCardInOperatorModeState(`${testRealmURL}grid`);
@@ -1519,7 +1519,7 @@ module('Integration | operator-mode | ui', function (hooks) {
           'select-all shows total count from API, not loaded options count',
         );
     } finally {
-      SearchPanel.PAGE_SIZE = originalPageSize;
+      TypeSummariesResource.PAGE_SIZE = originalPageSize;
     }
   });
 });


### PR DESCRIPTION
## Summary
- Simplify SearchPanel args to use domain types (`URL[]`, `ResolvedCodeRef[]`) instead of internal concerns (`PickerOption[]`, booleans)
- Extract TypeSummariesResource from SearchPanel; introduce `RealmFilter`/`TypeFilter` interfaces
- Move all card-search utilities to `app/utils/card-search/` (7 focused files: url, query-builder, type-filter, recent-cards, sections, section-pagination, types)
- Deduplicate URL parsing logic shared between search-sheet and search-content into `isURLSearchKey()`/`resolveSearchKeyAsURL()`
- Slim SearchContent from 736 to ~500 lines by extracting section building, pagination, and filtering into pure helpers

## Test plan
- [ ] Existing integration tests pass (card-catalog, operator-mode-ui)
- [ ] Card catalog modal: realm/type pickers, search, pagination, create-new all work
- [ ] Search sheet: search, realm filtering, type filtering, recent cards, URL lookup all work
- [ ] "Show Only" focus/unfocus on sections works
- [ ] "Show More" pagination within sections works

Linear: https://linear.app/cardstack/issue/CS-10802

🤖 Generated with [Claude Code](https://claude.com/claude-code)