### PR TITLE
Add Local environment option to `boxel profile add`

### DIFF
--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -223,17 +223,29 @@ async function addProfile(manager: ProfileManager): Promise<void> {
   console.log(`Which environment?`);
   console.log(`  ${FG_CYAN}1${RESET}) Staging (realms-staging.stack.cards)`);
   console.log(`  ${FG_MAGENTA}2${RESET}) Production (app.boxel.ai)`);
+  console.log(`  ${FG_GREEN}3${RESET}) Local (localhost:4201)`);
 
-  const envChoice = await prompt('\nChoice [1/2]: ');
+  const envChoice = await prompt('\nChoice [1/2/3]: ');
   const isProduction = envChoice === '2';
+  const isLocal = envChoice === '3';
 
-  const domain = isProduction ? 'boxel.ai' : 'stack.cards';
-  const defaultMatrixUrl = isProduction
-    ? 'https://matrix.boxel.ai'
-    : 'https://matrix-staging.stack.cards';
-  const defaultRealmUrl = isProduction
-    ? 'https://app.boxel.ai/'
-    : 'https://realms-staging.stack.cards/';
+  let domain: string;
+  let defaultMatrixUrl: string;
+  let defaultRealmUrl: string;
+
+  if (isLocal) {
+    domain = 'localhost';
+    defaultMatrixUrl = 'http://localhost:8008';
+    defaultRealmUrl = 'http://localhost:4201/';
+  } else if (isProduction) {
+    domain = 'boxel.ai';
+    defaultMatrixUrl = 'https://matrix.boxel.ai';
+    defaultRealmUrl = 'https://app.boxel.ai/';
+  } else {
+    domain = 'stack.cards';
+    defaultMatrixUrl = 'https://matrix-staging.stack.cards';
+    defaultRealmUrl = 'https://realms-staging.stack.cards/';
+  }
 
   console.log(`\nEnter your Boxel username (without @ or domain)`);
   console.log(`${DIM}Example: ctse, aallen90${RESET}`);

--- a/packages/boxel-cli/src/lib/profile-manager.ts
+++ b/packages/boxel-cli/src/lib/profile-manager.ts
@@ -27,7 +27,7 @@ export interface ProfilesConfig {
   activeProfile: string | null;
 }
 
-export type Environment = 'staging' | 'production' | 'unknown';
+export type Environment = 'staging' | 'production' | 'local' | 'unknown';
 
 /**
  * Extract environment from Matrix user ID
@@ -37,6 +37,7 @@ export type Environment = 'staging' | 'production' | 'unknown';
 export function getEnvironmentFromMatrixId(matrixId: string): Environment {
   if (matrixId.endsWith(':stack.cards')) return 'staging';
   if (matrixId.endsWith(':boxel.ai')) return 'production';
+  if (matrixId.endsWith(':localhost')) return 'local';
   return 'unknown';
 }
 
@@ -67,6 +68,8 @@ export function getEnvironmentLabel(env: Environment): string {
       return 'stack.cards';
     case 'production':
       return 'boxel.ai';
+    case 'local':
+      return 'localhost';
     default:
       return 'unknown';
   }


### PR DESCRIPTION
When testing boxel-cli locally I needed an option to save a profile that works in a local setup. I think it would be beneficial to others too.

<img width="603" height="390" alt="image" src="https://github.com/user-attachments/assets/baa89604-c595-4c88-8052-b3c7f0e613e9" />
 