### PR TITLE
Fix memory leak: add missing destructor to LivePrerenderedSearchResource

### DIFF
--- a/packages/host/app/resources/live-prerendered-search.ts
+++ b/packages/host/app/resources/live-prerendered-search.ts
@@ -1,3 +1,4 @@
+import { registerDestructor } from '@ember/destroyable';
 import type Owner from '@ember/owner';
 import { setOwner } from '@ember/owner';
 import { service } from '@ember/service';
@@ -61,6 +62,17 @@ export class LivePrerenderedSearchResource extends Resource<Args> {
   @tracked private _meta: QueryResultsMeta = { page: { total: 0 } };
   #loadedScopedCssModules = new Set<string>();
   #previousSignature: string | undefined;
+
+  constructor(owner: object) {
+    super(owner);
+    registerDestructor(this, () => {
+      this.buildPrerenderedCards.cancelAll();
+      this._instances = new TrackedArray();
+      this._meta = { page: { total: 0 } };
+      this.#loadedScopedCssModules.clear();
+      this.#previousSignature = undefined;
+    });
+  }
 
   modify(_positional: never[], named: Args['named']) {
     let {


### PR DESCRIPTION
## Summary

- `LivePrerenderedSearchResource` had no `registerDestructor`, unlike its sibling `PrerenderedSearchResource`. Without cleanup, the `buildPrerenderedCards` restartable task was never cancelled on destruction, `_instances` (TrackedArray of PrerenderedCard objects with HTML strings) was never cleared, and in-flight async renders held the resource alive past component teardown.
- This caused ~58MB/test retention in `create-listing-modal` integration tests, OOMing CI shard 15 (host tests).

## Details

MEMPROBE data from shard 15 showed memory growing from 378MB to 1284MB over 60 tests, crashing at test 66. The `app_instances` count stayed at 0 (the previous ApplicationInstance leak fix is working), so this is a distinct leak.

The `create-listing-modal` tests (tests 42-48 in shard 15) were the worst offenders — each consuming ~58MB and taking ~10.8s. These tests render ~11 Person cards through `LivePrerenderedSearchResource` via `renderService.renderCardComponent`.

The fix adds a destructor matching the cleanup pattern already established in `PrerenderedSearchResource`:
- Cancels the `buildPrerenderedCards` task
- Clears `_instances` and `_meta`
- Clears `#loadedScopedCssModules` Set
- Resets `#previousSignature`

## Test plan

- [ ] CI shard 15 passes without OOM
- [ ] MEMPROBE output in shard 15 shows reduced memory growth during `create-listing-modal` tests
- [ ] `create-listing-modal` integration tests still pass
- [ ] `lint:types` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)