### PR TITLE
Add CI workflow to publish boxel-cli to npm (CS-10689)

### DIFF
--- a/.github/workflows/manual-boxel-cli-publish.yml
+++ b/.github/workflows/manual-boxel-cli-publish.yml
@@ -23,6 +23,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   publish:
@@ -41,8 +42,8 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
-      - name: Configure npm authentication
-        run: echo '//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}' > $HOME/.npmrc
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Bump version
         id: version
@@ -61,9 +62,9 @@ jobs:
         working-directory: packages/boxel-cli
         run: |
           if [ "${{ inputs.environment }}" = "production" ]; then
-            npm publish --access public
+            npm publish --access public --provenance
           else
-            npm publish --access public --tag beta
+            npm publish --access public --provenance --tag beta
           fi
 
       - name: Commit version bump and tag

--- a/.github/workflows/manual-boxel-cli-publish.yml
+++ b/.github/workflows/manual-boxel-cli-publish.yml
@@ -25,6 +25,10 @@ permissions:
   contents: write
   id-token: write
 
+concurrency:
+  group: publish-boxel-cli
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: Build and publish @cardstack/boxel-cli
@@ -42,8 +46,16 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+      - name: Install pinned npm for trusted publishing
+        run: npm install -g npm@10.8.2
+
+      - name: Run unit tests
+        working-directory: packages/boxel-cli
+        run: pnpm test:unit
+
+      - name: Run integration tests
+        working-directory: packages/boxel-cli
+        run: pnpm test:integration
 
       - name: Bump version
         id: version
@@ -58,6 +70,14 @@ jobs:
         run: pnpm build
         working-directory: packages/boxel-cli
 
+      - name: Commit version bump and tag
+        run: |
+          TAG="boxel-cli-v${{ steps.version.outputs.version }}"
+          git add packages/boxel-cli/package.json
+          git commit -m "Release @cardstack/boxel-cli v${{ steps.version.outputs.version }}"
+          git tag "$TAG"
+          git push origin main --tags
+
       - name: Publish to npm
         working-directory: packages/boxel-cli
         run: |
@@ -67,31 +87,24 @@ jobs:
             npm publish --access public --provenance --tag beta
           fi
 
-      - name: Commit version bump and tag
-        run: |
-          TAG="boxel-cli-v${{ steps.version.outputs.version }}"
-          git add packages/boxel-cli/package.json
-          git commit -m "Release @cardstack/boxel-cli v${{ steps.version.outputs.version }}"
-          git tag "$TAG"
-          git push origin main --tags
-
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="boxel-cli-v${{ steps.version.outputs.version }}"
 
-          # Find previous boxel-cli tag for changelog scope
-          PREV_TAG=$(git tag --list 'boxel-cli-v*' --sort=-version:refname | grep -v "$TAG" | head -n 1)
+          PREV_TAG=$(git tag --list 'boxel-cli-v*' --sort=-version:refname | grep -vxF "$TAG" | head -n 1)
 
-          RELEASE_ARGS="--title \"@cardstack/boxel-cli v${{ steps.version.outputs.version }}\" --generate-notes"
+          ARGS=()
+          ARGS+=(--title "@cardstack/boxel-cli v${{ steps.version.outputs.version }}")
+          ARGS+=(--generate-notes)
 
           if [ -n "$PREV_TAG" ]; then
-            RELEASE_ARGS="$RELEASE_ARGS --notes-start-tag $PREV_TAG"
+            ARGS+=(--notes-start-tag "$PREV_TAG")
           fi
 
           if [ "${{ inputs.environment }}" = "staging" ]; then
-            RELEASE_ARGS="$RELEASE_ARGS --prerelease"
+            ARGS+=(--prerelease)
           fi
 
-          eval gh release create "$TAG" $RELEASE_ARGS
+          gh release create "$TAG" "${ARGS[@]}"

--- a/.github/workflows/manual-boxel-cli-publish.yml
+++ b/.github/workflows/manual-boxel-cli-publish.yml
@@ -1,0 +1,96 @@
+name: Manual Publish [boxel-cli]
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Semver bump level"
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      environment:
+        description: "Publish environment (staging = beta tag, production = latest tag)"
+        required: false
+        default: staging
+        type: choice
+        options:
+          - staging
+          - production
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Build and publish @cardstack/boxel-cli
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: ./.github/actions/init
+
+      - name: Configure git
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Configure npm authentication
+        run: echo '//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}' > $HOME/.npmrc
+
+      - name: Bump version
+        id: version
+        working-directory: packages/boxel-cli
+        run: |
+          npm version ${{ inputs.bump }} --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Bumped to version $VERSION"
+
+      - name: Build boxel-cli
+        run: pnpm build
+        working-directory: packages/boxel-cli
+
+      - name: Publish to npm
+        working-directory: packages/boxel-cli
+        run: |
+          if [ "${{ inputs.environment }}" = "production" ]; then
+            npm publish --access public
+          else
+            npm publish --access public --tag beta
+          fi
+
+      - name: Commit version bump and tag
+        run: |
+          TAG="boxel-cli-v${{ steps.version.outputs.version }}"
+          git add packages/boxel-cli/package.json
+          git commit -m "Release @cardstack/boxel-cli v${{ steps.version.outputs.version }}"
+          git tag "$TAG"
+          git push origin main --tags
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="boxel-cli-v${{ steps.version.outputs.version }}"
+
+          # Find previous boxel-cli tag for changelog scope
+          PREV_TAG=$(git tag --list 'boxel-cli-v*' --sort=-version:refname | grep -v "$TAG" | head -n 1)
+
+          RELEASE_ARGS="--title \"@cardstack/boxel-cli v${{ steps.version.outputs.version }}\" --generate-notes"
+
+          if [ -n "$PREV_TAG" ]; then
+            RELEASE_ARGS="$RELEASE_ARGS --notes-start-tag $PREV_TAG"
+          fi
+
+          if [ "${{ inputs.environment }}" = "staging" ]; then
+            RELEASE_ARGS="$RELEASE_ARGS --prerelease"
+          fi
+
+          eval gh release create "$TAG" $RELEASE_ARGS

--- a/packages/boxel-cli/README.md
+++ b/packages/boxel-cli/README.md
@@ -49,6 +49,32 @@ pnpm build
 pnpm start
 ```
 
+### Local Development with `npm link`
+
+To use your locally-built `boxel-cli` instead of the npm-installed version:
+
+```bash
+# 1. Build the CLI
+cd packages/boxel-cli
+pnpm build
+
+# 2. Create a global symlink from the package directory
+npm link
+
+# 3. Verify the global `boxel` command now points to your local build
+which boxel
+boxel --version
+```
+
+To revert to the npm-installed version:
+
+```bash
+npm unlink -g @cardstack/boxel-cli
+npm install -g @cardstack/boxel-cli
+```
+
+**Note:** After making source changes, re-run `pnpm build` in `packages/boxel-cli` for the linked command to reflect updates. Alternatively, use `pnpm start` during development to run directly from TypeScript source without rebuilding.
+
 ### Code Quality
 
 ```bash

--- a/packages/boxel-cli/package.json
+++ b/packages/boxel-cli/package.json
@@ -73,6 +73,7 @@
     "publish:dry": "npm publish --dry-run"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/local-types/package.json
+++ b/packages/local-types/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "name": "@cardstack/local-types",
+  "version": "0.0.0",
   "description": "Type declarations for use within this monorepo",
   "types": "index.d.ts",
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Adds a manual GitHub Actions workflow (`manual-boxel-cli-publish.yml`) to publish `@cardstack/boxel-cli` to npm
- Uses **npm trusted publishing (OIDC)** — no long-lived NPM_TOKEN needed
- Accepts semver bump level (patch/minor/major) and environment (staging/production) as inputs
- Automates: version bump → build → npm publish with provenance → git tag → GitHub Release with auto-generated notes

## How it works
1. Trigger from GitHub Actions UI → select bump level and environment
2. Workflow bumps `package.json` version via `npm version`
3. Builds with `pnpm build`
4. Publishes to npm with `--provenance` flag using OIDC authentication (`--tag beta` for staging, `latest` for production)
5. Commits version bump to `main`, creates git tag (`boxel-cli-v<version>`)
6. Creates GitHub Release with auto-generated changelog from commits/PRs

## Prerequisites
- Configure trusted publishing on npmjs.com: go to `https://www.npmjs.com/package/@cardstack/boxel-cli/access` and link to `cardstack/boxel` repo, workflow file `manual-boxel-cli-publish.yml`

## Test plan
- [x] Verify YAML syntax is valid (CI lint)
- [x] Configure trusted publishing on npmjs.com for `@cardstack/boxel-cli`
- [ ] Trigger workflow with `staging` environment to publish a beta version
- [ ] Verify `@cardstack/boxel-cli@beta` appears on npmjs.com with provenance badge
- [ ] Verify GitHub Release is created with auto-generated notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)