### PR TITLE
Fix host-test memory leaks in Monaco modifiers and AiAssistantToast

### DIFF
--- a/.claude/skills/host-test-memory-leak-hunting/SKILL.md
+++ b/.claude/skills/host-test-memory-leak-hunting/SKILL.md
@@ -30,6 +30,7 @@ Three diagnostic scripts in `packages/host/scripts/` (only used during a hunt):
 - `snapshot-diff.js` — top-N constructor counts/retained-sizes that grew between two snapshots.
 - `snapshot-retainers.js` — backward BFS from target nodes to GC roots. Flags: `--type=<native|object|closure|string>`, `--min-size=N`, `--strong` (skips `weak`/`shortcut` AND WeakMap "part of key" internal edges; use this — it's the difference between a misleading WeakMap path and the real strong retainer).
 - `snapshot-by-class.js` — like snapshot-diff but truncates long names so output is scannable.
+- `snapshot-diff-stream.js` / `snapshot-retainers-stream.js` — **use these when a snapshot file is >500 MB.** Same flags and output as the non-streaming versions; they use `stream-json` to avoid `fs.readFileSync('utf8')` (which throws `ERR_STRING_TOO_LONG` above V8's ~512 MB cap). The retainers-stream variant also buffers nodes/edges into a growable `Float64Array` so huge snapshots don't hit `Invalid array length` around 100M+ items. Just swap the script name; all arguments are identical.
 
 See [`packages/host/scripts/HEAP_PROBE.md`](../../../packages/host/scripts/HEAP_PROBE.md) for invocation reference.
 

--- a/.claude/skills/host-test-memory-leak-hunting/known-leaks.md
+++ b/.claude/skills/host-test-memory-leak-hunting/known-leaks.md
@@ -89,6 +89,97 @@ private async setup() {
 
 ---
 
+## 6. `MonacoService.onDidCreateEditor` global listener never disposed
+
+**Commit:** (this branch) "Dispose monaco global listeners on MonacoService destroy"
+**Severity:** ~38 MB / test in shards that inject MonacoService (operator mode / code-submode / markdown-preview / spec-preview tests).
+
+`monaco-editor` is imported as an ES-module singleton, so `monaco.editor.onDidCreateEditor(cb)` registers `cb` on a global emitter (`StandaloneCodeEditorService._onCodeEditorAdd`) that lives for the lifetime of the V8 isolate. `MonacoService` called this from its `loadMonacoSDK` task and threw away the returned `IDisposable`. Every test that injects `MonacoService` leaves one listener behind; each listener's closure captures `this`, which `setOwner` ties to the test's `ApplicationInstance`. The Monaco editor's own live `DOMTimer` is a GC root, so the listener array — and thus every prior owner — is permanently reachable.
+
+Each retained owner pins its 4 Realms → 4 Loaders → 4 copies of every base-realm module source (card-api, field-component, links-to-many-component, etc.), producing the `+42 copies of define("https://cardstack.com/base/card-api"…)` signature between t=10 and t=20.
+
+**Retainer chain:**
+```
+(Global handles) → NativeContext → Window → DOMTimer → ScheduledAction →
+  V8Function → StandaloneEditor → StandaloneCodeEditorService →
+  _onCodeEditorAdd Emitter → _listeners Array → closure → MonacoService →
+  <symbol OWNER> → ApplicationInstance → Registry → Realm → Loader →
+  modules Map → … → Context:src → string::define("…base/card-api"…)
+```
+
+**Fix pattern:** When calling a singleton API that returns an `IDisposable`, push it onto a per-instance list and call `.dispose()` in `registerDestructor`. Applies to **every** `monaco.editor.onDid*`, `monaco.editor.onDidCreateEditor`, and any per-editor `editor.onDidFocusEditorText` / `onDidBlurEditorText` / `onDidChangeCursorSelection` / `onDidDispose` call. `resetState()` is not enough — the service's `this` still exists until the owner tears down, and the listener array has already leaked its closure.
+
+**Diagnostic:** `MEMPROBE` shows `app_instances=0` (so the ApplicationInstance Set leak — #1 — is NOT active), yet heap climbs linearly. Top-growth constructors are `string::define("https://cardstack.com/base/...")` duplicating at ~4 copies per test. `snapshot-retainers.js --strong` on one of the `define()` strings reveals the path through `StandaloneCodeEditorService._onCodeEditorAdd`.
+
+---
+
+## 7. Monaco per-editor `onDid*` subscriptions not disposed in modifiers
+
+**Commit:** (this branch) "Fix host-test memory leaks in Monaco modifiers and AiAssistantToast"
+**Severity:** Contributor to Shard 16 OOM; combined with #6/#8/#9 cut peak heap 602→319 MB.
+
+Same root cause as #6 but at the modifier level. `packages/host/app/modifiers/monaco.ts`, `monaco-editor.gts`, and `monaco-diff-editor.gts` each call `onDidContentSizeChange`, `onDidChangeContent`, `onDidChangeCursorSelection`, or `onDidUpdateDiff` on their per-editor instances. Each returns an `IDisposable`; discarding it leaves the listener on `StandaloneCodeEditorService._codeEditors` / `_diffEditors` whose closure captures the modifier `this`, which transitively retains the owning component (e.g. `HtmlGroupCodeBlock`) and its `ApplicationInstance`.
+
+**Retainer chain (from `_diffEditors` variant):**
+```
+StandaloneCodeEditorService._diffEditors → IDiffEditor:v2:17 →
+  _diffValue → observers[] → updateDiffEditorStats closure →
+  HtmlGroupCodeBlock → ApplicationInstance
+```
+
+**Fix pattern:** Same as #6 — collect every `onDid*` result into a `disposables: IDisposable[]` array (store on `monacoState` if the modifier re-creates the editor during `modify()`), and in `registerDestructor` iterate and call `.dispose()` (wrapped in try/catch: Monaco's own disposal can race with test teardown) before disposing the editor itself.
+
+---
+
+## 8. Monaco `editor.dispose()` deferred to `requestAnimationFrame` never fires in tests
+
+**Commit:** (this branch) "Fix host-test memory leaks in Monaco modifiers and AiAssistantToast"
+**Severity:** Significant in Monaco-heavy shards — the editor stays in `_codeEditors` / `_diffEditors` registries and its `DOMTimer`s keep the owner alive.
+
+Both `monaco.ts` and `monaco-diff-editor.gts` introduced `disposeEditorAfterInitialLayout` that calls `editor.dispose()` inside `requestAnimationFrame` to avoid a Monaco bootstrap race (disposing while contribution setup is still running throws "InstantiationService has been disposed"). In tests, `rAF` never fires between `teardownContext` and the next test — QUnit runs tests back-to-back without yielding to a paint. Result: the dispose callback queues but never runs; the editor stays registered; its internal `setInterval`-driven DOMTimers retain the owner.
+
+**Fix pattern:** Branch on `isTesting()` from `@embroider/macros`: dispose synchronously in tests, keep the `rAF` deferral in production.
+
+```ts
+import { isTesting } from '@embroider/macros';
+
+let dispose = () => {
+  try { editor.dispose(); } catch { /* partially-disposed is fine */ }
+  // ... model cleanup ...
+};
+if (isTesting()) {
+  dispose();
+} else {
+  // eslint-disable-next-line @cardstack/boxel/no-raf-for-state -- Monaco dispose must wait for paint to avoid bootstrap race
+  requestAnimationFrame(dispose);
+}
+```
+
+**Diagnostic:** `native::DOMTimer` constructor count climbs across tests even though your destructors run. Retainer trace on a DOMTimer leads back to a Monaco editor that should have been disposed — check whether the dispose path defers to `rAF` / `setTimeout` / `queueMicrotask` without a testing fast-path.
+
+---
+
+## 9. `ember-lifeline` `pollTask` pins owner via `LIFELINE_QUEUED_POLL_TASKS` global Map
+
+**Commit:** (this branch) "Fix host-test memory leaks in Monaco modifiers and AiAssistantToast"
+**Severity:** Dominant retainer in Shard 16 before fix (~42 MB saved).
+
+`ember-lifeline`'s `pollTask` registers the task's owner in a module-global Map at `window[LIFELINE_QUEUED_POLL_TASKS]`. If the owner is destroyed without first calling `cancelPoll`, the Map entry stays — and because the Map uses the owner object as key, the owner (and everything it transitively retains, including the test's `ApplicationInstance` and all its realm data) leaks until the Map is manually drained.
+
+`AiAssistantToast` used `pollTask` for its auto-hide timer. The getter that triggered the poll had side effects (`onMessageSeen` inside `latestUnseenMessage`), and in some teardown paths the toast was destroyed before `cancelPoll` ran.
+
+**Retainer chain:**
+```
+window[LIFELINE_QUEUED_POLL_TASKS] (Map) → AiAssistantToast →
+  ApplicationInstance → (all the usual card-api retention)
+```
+
+**Fix pattern:** For timers that don't genuinely need `ember-lifeline`'s task lifecycle coordination, use plain `setTimeout` + `clearTimeout` in a `registerDestructor`. Timer closures are GC'd when the timer fires; no global Map is involved. Reserve `pollTask` / `runTask` for cases where you actually need Ember's runloop integration.
+
+**Diagnostic:** Grep for `pollTask` / `runTask` imports in the leaking module. Retainer trace that terminates at a synthetic root labeled "Window" with a property named `LIFELINE_QUEUED_POLL_TASKS` (or similar ember-lifeline symbol) is the smoking gun.
+
+---
+
 ## Patterns to look for when adding new code
 
 These are not bugs — they're shapes of code that have repeatedly turned out to be leaks. Audit your PR for them:
@@ -100,5 +191,8 @@ These are not bugs — they're shapes of code that have repeatedly turned out to
 - **A service that registers itself with another service in `init()`** but doesn't unregister in `willDestroy()`. The other service's registry holds a strong reference.
 - **An `async setup()` or `init()` that creates timers/listeners after an `await`.** Ember destroys services synchronously during test teardown. If the `await` is still pending when `willDestroy` fires, the continuation runs on a dead service. Guard with `isDestroyed(this) || isDestroying(this)` after every `await` before creating any long-lived resource.
 - **A service cache (`this.fooCache`) not cleared in `resetCache()` or `willDestroy()`.** Even if the cache is repopulated next test, the old value is retained until then — and if the old value is a large compiled module graph, that's tens of MB pinned.
+- **A third-party singleton API that returns an `IDisposable` from its `onX` / `addEventListener`-style method.** Monaco (`onDidCreateEditor`, per-editor `onDid*`), VS Code-style APIs, and many RxJS-adjacent libraries return disposables whose callers must hold and later dispose them. Throwing the disposable away leaks the listener *and* everything its closure captured (usually `this` → the service → the owner). Always collect disposables into a per-instance array and call `.dispose()` from `registerDestructor`.
+- **Cleanup deferred to `requestAnimationFrame` / `setTimeout` / `queueMicrotask` without a testing fast-path.** QUnit runs tests back-to-back without yielding to a paint, so deferred dispose callbacks never fire between teardown and the next test. Branch on `isTesting()` and dispose synchronously in tests (the race that the deferral was avoiding usually only matters in production).
+- **`ember-lifeline`'s `pollTask` / `runTask` when a plain `setTimeout` would do.** `pollTask` registers the owner in a module-global Map; if the task isn't cancelled before the owner is destroyed, the Map pins the owner forever. Plain `setTimeout` timers auto-GC their closure when they fire — much safer for simple one-shot delays. Only reach for `ember-lifeline` when you actually need runloop coordination.
 
 When you ship one of these patterns, add a probe of `MEMPROBE` over the relevant test module before declaring done.

--- a/packages/host/app/components/ai-assistant/toast.gts
+++ b/packages/host/app/components/ai-assistant/toast.gts
@@ -204,7 +204,6 @@ export default class AiAssistantToast extends Component<Signature> {
 
     let fifteenMinutesAgo = subMinutes(new Date(), 15);
     if (candidate && isAfter(candidate.message.created, fifteenMinutesAgo)) {
-      // eslint-disable-next-line ember/no-side-effects
       this.onMessageSeen(candidate.message.eventId ?? null);
       return candidate;
     }

--- a/packages/host/app/components/ai-assistant/toast.gts
+++ b/packages/host/app/components/ai-assistant/toast.gts
@@ -1,15 +1,15 @@
+import { isDestroyed, registerDestructor } from '@ember/destroyable';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import type Owner from '@ember/owner';
 
 import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 
 import Component from '@glimmer/component';
+import { cached, tracked } from '@glimmer/tracking';
 
 import { format as formatDate, formatISO, isAfter, subMinutes } from 'date-fns';
-import { cancelPoll, pollTask, runTask } from 'ember-lifeline';
-
-import { TrackedObject } from 'tracked-built-ins';
 
 import { BoxelButton, IconButton } from '@cardstack/boxel-ui/components';
 import { IconX } from '@cardstack/boxel-ui/icons';
@@ -29,6 +29,8 @@ interface Signature {
     onViewInChatClick: () => void;
   };
 }
+
+const AUTO_HIDE_MS = 3000;
 
 export default class AiAssistantToast extends Component<Signature> {
   <template>
@@ -158,95 +160,92 @@ export default class AiAssistantToast extends Component<Signature> {
 
   @service declare private matrixService: MatrixService;
   @service declare private localPersistenceService: LocalPersistenceService;
-  _pollToken: ReturnType<typeof pollTask> | null = null;
 
-  private get state() {
-    const state: {
-      value: {
-        roomId: string;
-        message: Message;
-      } | null;
-      isResetStateValueBlocked: boolean;
-    } = new TrackedObject({
-      value: null,
-      isResetStateValueBlocked: false,
+  @tracked private isForcedHidden = false;
+  @tracked private isResetStateValueBlocked = false;
+  private lastEventIdSeen: string | null = null;
+  private hideTimerId: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(owner: Owner, args: Signature['Args']) {
+    super(owner, args);
+    registerDestructor(this, () => {
+      if (this.hideTimerId !== null) {
+        clearTimeout(this.hideTimerId);
+        this.hideTimerId = null;
+      }
     });
+  }
 
-    // Only cancel and recreate poll if we don't already have one running
-    if (this._pollToken) {
-      // Don't cancel here - let the existing poll continue
-    }
-
-    let lastMessages: Map<string, Message> = new Map();
+  @cached
+  private get latestUnseenMessage(): {
+    roomId: string;
+    message: Message;
+  } | null {
+    let candidate: { roomId: string; message: Message } | null = null;
     for (let resource of this.matrixService.roomResources.values()) {
-      if (!resource.matrixRoom) {
+      if (!resource.matrixRoom || !resource.roomId) {
         continue;
       }
       let finishedMessages = resource.messages.filter(
         (m) => m.isStreamingFinished,
       );
-      if (resource.roomId) {
-        lastMessages.set(
-          resource.roomId,
-          finishedMessages[finishedMessages.length - 1],
-        );
+      let lastMessage = finishedMessages[finishedMessages.length - 1];
+      if (!lastMessage) {
+        continue;
       }
+      if (
+        this.matrixService.currentUserEventReadReceipts.has(lastMessage.eventId)
+      ) {
+        continue;
+      }
+      candidate = { roomId: resource.roomId, message: lastMessage };
+      break;
     }
 
-    let lastMessage =
-      Array.from(lastMessages).filter(
-        (lastMessage) =>
-          lastMessage[1] &&
-          !this.matrixService.currentUserEventReadReceipts.has(
-            lastMessage[1].eventId,
-          ),
-      )[0] ?? null;
     let fifteenMinutesAgo = subMinutes(new Date(), 15);
-    if (lastMessage && isAfter(lastMessage[1].created, fifteenMinutesAgo)) {
-      state.value = {
-        roomId: lastMessage[0],
-        message: lastMessage[1],
-      };
-
-      // Only create a new poll task if we don't have one
-      if (!this._pollToken) {
-        // eslint-disable-next-line ember/no-side-effects
-        this._pollToken = pollTask(this, (next: () => void) => {
-          const resetStateValue = (timeout = 3000) => {
-            runTask(
-              this,
-              () => {
-                if (state.isResetStateValueBlocked) {
-                  resetStateValue(1000);
-                  return;
-                }
-                state.value = null;
-                next(); // Continue polling for new messages
-              },
-              timeout,
-            );
-          };
-          resetStateValue();
-        });
-      }
-    } else {
-      // If no messages and we have a poll running, cancel it
-      if (this._pollToken) {
-        cancelPoll(this, this._pollToken);
-        // eslint-disable-next-line ember/no-side-effects
-        this._pollToken = null;
-      }
+    if (candidate && isAfter(candidate.message.created, fifteenMinutesAgo)) {
+      // eslint-disable-next-line ember/no-side-effects
+      this.onMessageSeen(candidate.message.eventId ?? null);
+      return candidate;
     }
-    return state;
+    return null;
   }
 
+  private onMessageSeen(eventId: string | null) {
+    if (eventId === this.lastEventIdSeen) {
+      return;
+    }
+    this.lastEventIdSeen = eventId;
+    this.isForcedHidden = false;
+    this.scheduleAutoHide();
+  }
+
+  private scheduleAutoHide = () => {
+    if (this.hideTimerId !== null) {
+      clearTimeout(this.hideTimerId);
+      this.hideTimerId = null;
+    }
+    this.hideTimerId = setTimeout(this.onAutoHideTick, AUTO_HIDE_MS);
+  };
+
+  private onAutoHideTick = () => {
+    this.hideTimerId = null;
+    if (isDestroyed(this)) {
+      return;
+    }
+    if (this.isResetStateValueBlocked) {
+      return;
+    }
+    this.isForcedHidden = true;
+  };
+
   private get roomId() {
-    return this.state.value?.roomId ?? '';
+    return this.latestUnseenMessage?.roomId ?? '';
   }
 
   private get unseenMessage() {
     return (
-      this.state.value?.message ??
+      this.latestUnseenMessage?.message ??
       ({
         body: '',
         created: new Date(),
@@ -255,17 +254,25 @@ export default class AiAssistantToast extends Component<Signature> {
   }
 
   private get isVisible() {
-    return this.state.value && !this.args.hide;
+    return (
+      !!this.latestUnseenMessage && !this.isForcedHidden && !this.args.hide
+    );
   }
 
   @action
   private blockResetStateValue() {
-    this.state.isResetStateValueBlocked = true;
+    this.isResetStateValueBlocked = true;
   }
 
   @action
   private unBlockResetStateValue() {
-    this.state.isResetStateValueBlocked = false;
+    if (!this.isResetStateValueBlocked) {
+      return;
+    }
+    this.isResetStateValueBlocked = false;
+    if (this.latestUnseenMessage && !this.isForcedHidden) {
+      this.scheduleAutoHide();
+    }
   }
 
   @action

--- a/packages/host/app/modifiers/monaco-diff-editor.gts
+++ b/packages/host/app/modifiers/monaco-diff-editor.gts
@@ -1,4 +1,5 @@
 import { registerDestructor } from '@ember/destroyable';
+import { isTesting } from '@embroider/macros';
 
 import Modifier from 'ember-modifier';
 
@@ -30,6 +31,7 @@ export interface MonacoDiffEditorSignature {
 export default class MonacoDiffEditor extends Modifier<MonacoDiffEditorSignature> {
   private monacoState: {
     editor: _MonacoSDK.editor.IStandaloneDiffEditor;
+    disposables: _MonacoSDK.IDisposable[];
   } | null = null;
   private hasDestructor = false;
   private waiterManager = createMonacoWaiterManager();
@@ -58,6 +60,7 @@ export default class MonacoDiffEditor extends Modifier<MonacoDiffEditorSignature
 
     if (editor && hasDisposedModels) {
       this.destroyEditor(editor, model);
+      this.disposeListenerDisposables();
       editor = undefined;
       model = undefined;
       originalModel = undefined;
@@ -96,22 +99,30 @@ export default class MonacoDiffEditor extends Modifier<MonacoDiffEditorSignature
         element.style.height = `${contentHeight}px`;
       }
 
-      editor.getModifiedEditor().onDidContentSizeChange(() => {
-        const newHeight = editor.getModifiedEditor().getContentHeight();
-        if (newHeight > 0) {
-          element.style.height = `${newHeight}px`;
-        }
-      });
+      let disposables: _MonacoSDK.IDisposable[] = [];
+      disposables.push(
+        editor.getModifiedEditor().onDidContentSizeChange(() => {
+          const newHeight = editor.getModifiedEditor().getContentHeight();
+          if (newHeight > 0) {
+            element.style.height = `${newHeight}px`;
+          }
+        }),
+      );
 
       this.monacoState = {
         editor,
+        disposables,
       };
 
-      editor.onDidUpdateDiff(() => {
-        if (updateDiffEditorStats) {
-          updateDiffEditorStats(makeCodeDiffStats(this.getLineChanges(editor)));
-        }
-      });
+      disposables.push(
+        editor.onDidUpdateDiff(() => {
+          if (updateDiffEditorStats) {
+            updateDiffEditorStats(
+              makeCodeDiffStats(this.getLineChanges(editor)),
+            );
+          }
+        }),
+      );
 
       // Track editor initialization for test waiters after diff models are ready
       if (this.waiterManager) {
@@ -127,9 +138,26 @@ export default class MonacoDiffEditor extends Modifier<MonacoDiffEditorSignature
         if (editor) {
           this.destroyEditor(editor, editor.getModel());
         }
+        this.disposeListenerDisposables();
         this.monacoState = null;
       });
     }
+  }
+
+  private disposeListenerDisposables() {
+    let disposables = this.monacoState?.disposables;
+    if (!disposables) {
+      return;
+    }
+    for (let d of disposables) {
+      try {
+        d.dispose();
+      } catch {
+        // Monaco listeners can be in a partially-disposed state when tests
+        // tear down mid-turn; ignore so one bad listener doesn't block others.
+      }
+    }
+    disposables.length = 0;
   }
 
   private destroyEditor(
@@ -262,9 +290,11 @@ export default class MonacoDiffEditor extends Modifier<MonacoDiffEditorSignature
     // Diff editors hit the same Monaco bootstrap race as standard editors when
     // search/replace blocks finish streaming and swap render modes within one
     // Glimmer turn. Waiting until the next paint keeps teardown deterministic
-    // without relying on a fixed timeout.
-    // eslint-disable-next-line @cardstack/boxel/no-raf-for-state -- Monaco dispose must wait for paint to avoid bootstrap race
-    requestAnimationFrame(() => {
+    // without relying on a fixed timeout. In tests, rAF may never fire between
+    // teardown and the next test — dispose synchronously there so Monaco's
+    // StandaloneCodeEditorService._diffEditors registry releases its reference
+    // and internal DOMTimers stop retaining the owner.
+    let dispose = () => {
       try {
         editor.dispose();
       } catch {
@@ -276,6 +306,12 @@ export default class MonacoDiffEditor extends Modifier<MonacoDiffEditorSignature
       if (model?.modified) {
         this.disposeModelWhenDetached(model.modified);
       }
-    });
+    };
+    if (isTesting()) {
+      dispose();
+    } else {
+      // eslint-disable-next-line @cardstack/boxel/no-raf-for-state -- Monaco dispose must wait for paint to avoid bootstrap race
+      requestAnimationFrame(dispose);
+    }
   }
 }

--- a/packages/host/app/modifiers/monaco-editor.gts
+++ b/packages/host/app/modifiers/monaco-editor.gts
@@ -1,4 +1,5 @@
 import { registerDestructor } from '@ember/destroyable';
+import { isTesting } from '@embroider/macros';
 
 import Modifier from 'ember-modifier';
 
@@ -193,13 +194,25 @@ export default class MonacoEditorModifier extends Modifier<MonacoEditorSignature
     // paint. When a streaming code block is immediately replaced by a diff
     // block, disposing in the same render turn can race that bootstrap and
     // throw "InstantiationService has been disposed". We therefore teardown on
-    // the next paint instead of using a fixed sleep.
-    // eslint-disable-next-line @cardstack/boxel/no-raf-for-state -- Monaco dispose must wait for paint to avoid bootstrap race
-    requestAnimationFrame(() => {
-      editor.dispose();
+    // the next paint instead of using a fixed sleep. In tests, rAF may never
+    // fire between teardown and the next test — dispose synchronously there so
+    // Monaco's StandaloneCodeEditorService._codeEditors registry releases its
+    // reference and internal DOMTimers stop retaining the owner.
+    let dispose = () => {
+      try {
+        editor.dispose();
+      } catch {
+        // partially-instantiated editor — best-effort cleanup
+      }
       if (model && !model.isDisposed() && !model.isAttachedToEditor()) {
         model.dispose();
       }
-    });
+    };
+    if (isTesting()) {
+      dispose();
+    } else {
+      // eslint-disable-next-line @cardstack/boxel/no-raf-for-state -- Monaco dispose must wait for paint to avoid bootstrap race
+      requestAnimationFrame(dispose);
+    }
   }
 }

--- a/packages/host/app/modifiers/monaco-editor.gts
+++ b/packages/host/app/modifiers/monaco-editor.gts
@@ -1,5 +1,4 @@
 import { registerDestructor } from '@ember/destroyable';
-import { isTesting } from '@embroider/macros';
 
 import Modifier from 'ember-modifier';
 
@@ -193,12 +192,13 @@ export default class MonacoEditorModifier extends Modifier<MonacoEditorSignature
     // Monaco contribution setup can continue past initial layout into the next
     // paint. When a streaming code block is immediately replaced by a diff
     // block, disposing in the same render turn can race that bootstrap and
-    // throw "InstantiationService has been disposed". We therefore teardown on
-    // the next paint instead of using a fixed sleep. In tests, rAF may never
-    // fire between teardown and the next test — dispose synchronously there so
-    // Monaco's StandaloneCodeEditorService._codeEditors registry releases its
-    // reference and internal DOMTimers stop retaining the owner.
-    let dispose = () => {
+    // throw "InstantiationService has been disposed". Unlike the operator-mode
+    // Monaco modifiers, this code-block variant is used inside streaming AI
+    // messages where rapid render/teardown cycles reliably hit that race, so
+    // we defer to the next paint even in tests rather than disposing
+    // synchronously.
+    // eslint-disable-next-line @cardstack/boxel/no-raf-for-state -- Monaco dispose must wait for paint to avoid bootstrap race
+    requestAnimationFrame(() => {
       try {
         editor.dispose();
       } catch {
@@ -207,12 +207,6 @@ export default class MonacoEditorModifier extends Modifier<MonacoEditorSignature
       if (model && !model.isDisposed() && !model.isAttachedToEditor()) {
         model.dispose();
       }
-    };
-    if (isTesting()) {
-      dispose();
-    } else {
-      // eslint-disable-next-line @cardstack/boxel/no-raf-for-state -- Monaco dispose must wait for paint to avoid bootstrap race
-      requestAnimationFrame(dispose);
-    }
+    });
   }
 }

--- a/packages/host/app/modifiers/monaco-editor.gts
+++ b/packages/host/app/modifiers/monaco-editor.gts
@@ -39,6 +39,7 @@ export interface MonacoEditorSignature {
 export default class MonacoEditorModifier extends Modifier<MonacoEditorSignature> {
   private monacoState: {
     editor: _MonacoSDK.editor.IStandaloneCodeEditor;
+    disposables: _MonacoSDK.IDisposable[];
   } | null = null;
   private hasDestructor = false;
   private waiterManager = createMonacoWaiterManager();
@@ -137,15 +138,19 @@ export default class MonacoEditorModifier extends Modifier<MonacoEditorSignature
         element.style.height = `${contentHeight}px`;
       }
 
-      editor.onDidContentSizeChange(() => {
-        const newHeight = editor.getContentHeight();
-        if (newHeight > 0) {
-          element.style.height = `${newHeight}px`;
-        }
-      });
+      let disposables: _MonacoSDK.IDisposable[] = [];
+      disposables.push(
+        editor.onDidContentSizeChange(() => {
+          const newHeight = editor.getContentHeight();
+          if (newHeight > 0) {
+            element.style.height = `${newHeight}px`;
+          }
+        }),
+      );
 
       this.monacoState = {
         editor,
+        disposables,
       };
 
       // Track editor initialization for test waiters after models and language are ready
@@ -160,6 +165,18 @@ export default class MonacoEditorModifier extends Modifier<MonacoEditorSignature
       registerDestructor(this, () => {
         let editor = this.monacoState?.editor;
         let model = editor?.getModel();
+        let disposables = this.monacoState?.disposables;
+        if (disposables) {
+          for (let d of disposables) {
+            try {
+              d.dispose();
+            } catch {
+              // listener disposal during teardown races with Monaco's own
+              // dispose; ignore so one bad listener doesn't block the rest
+            }
+          }
+          disposables.length = 0;
+        }
         if (editor) {
           this.disposeEditorAfterInitialLayout(editor, model);
         }

--- a/packages/host/app/modifiers/monaco.ts
+++ b/packages/host/app/modifiers/monaco.ts
@@ -44,6 +44,7 @@ export default class Monaco extends Modifier<Signature> {
   private lastCursorPosition: MonacoSDK.Position | undefined;
   private waiterManager = createMonacoWaiterManager();
   private onDispose: (() => void) | undefined;
+  private disposables: MonacoSDK.IDisposable[] = [];
   @service declare private monacoService: MonacoService;
 
   modify(
@@ -158,6 +159,15 @@ export default class Monaco extends Modifier<Signature> {
       this.model = undefined;
       let editor = this.editor;
       this.editor = undefined;
+      for (let d of this.disposables) {
+        try {
+          d.dispose();
+        } catch {
+          // listener disposal during teardown races with Monaco's own dispose;
+          // ignore so one bad listener doesn't block the rest
+        }
+      }
+      this.disposables.length = 0;
       if (editor) {
         this.disposeEditorAfterInitialLayout(editor, model);
       }
@@ -165,23 +175,25 @@ export default class Monaco extends Modifier<Signature> {
 
     this.model = this.editor.getModel()!;
 
-    this.model.onDidChangeContent(() =>
-      this.onContentChanged.perform(contentChanged),
-    );
-    this.editor.onDidChangeCursorSelection((event) => {
-      if (
-        this.editor &&
-        event.source !== 'model' &&
-        event.selection.startLineNumber === event.selection.endLineNumber &&
-        event.selection.startColumn === event.selection.endColumn
-      ) {
-        let position = this.editor.getPosition();
-        if (position) {
-          onCursorPositionChange?.(position);
-          this.lastCursorPosition = position;
+    this.disposables.push(
+      this.model.onDidChangeContent(() =>
+        this.onContentChanged.perform(contentChanged),
+      ),
+      this.editor.onDidChangeCursorSelection((event) => {
+        if (
+          this.editor &&
+          event.source !== 'model' &&
+          event.selection.startLineNumber === event.selection.endLineNumber &&
+          event.selection.startColumn === event.selection.endColumn
+        ) {
+          let position = this.editor.getPosition();
+          if (position) {
+            onCursorPositionChange?.(position);
+            this.lastCursorPosition = position;
+          }
         }
-      }
-    });
+      }),
+    );
   }
 
   private onContentChanged = restartableTask(
@@ -222,13 +234,25 @@ export default class Monaco extends Modifier<Signature> {
     // Monaco can still be instantiating editor contributions in the same turn
     // that Glimmer tears the modifier down. Disposing on the next paint avoids
     // tearing down the instantiation service mid-bootstrap without introducing
-    // an arbitrary timer.
-    // eslint-disable-next-line @cardstack/boxel/no-raf-for-state -- Monaco dispose must wait for paint to avoid bootstrap race
-    requestAnimationFrame(() => {
-      editor.dispose();
+    // an arbitrary timer. In tests, rAF may never fire between teardown and
+    // the next test — dispose synchronously there so Monaco's
+    // _codeEditors/_diffEditors registry releases its reference and internal
+    // DOMTimers stop retaining the owner.
+    let dispose = () => {
+      try {
+        editor.dispose();
+      } catch {
+        // partially-instantiated editor — best-effort cleanup
+      }
       if (model && !model.isDisposed() && !model.isAttachedToEditor()) {
         model.dispose();
       }
-    });
+    };
+    if (isTesting()) {
+      dispose();
+    } else {
+      // eslint-disable-next-line @cardstack/boxel/no-raf-for-state -- Monaco dispose must wait for paint to avoid bootstrap race
+      requestAnimationFrame(dispose);
+    }
   }
 }

--- a/packages/host/app/services/monaco-service.ts
+++ b/packages/host/app/services/monaco-service.ts
@@ -1,3 +1,4 @@
+import { registerDestructor } from '@ember/destroyable';
 import type Owner from '@ember/owner';
 import { debounce } from '@ember/runloop';
 import Service, { service } from '@ember/service';
@@ -40,10 +41,27 @@ export default class MonacoService extends Service {
   serverEchoDebounceMs = serverEchoDebounceMs;
 
   private waiterManager = createMonacoWaiterManager();
+  // Disposables returned from monaco event subscriptions. Monaco is a
+  // module-level singleton, so every `onDidCreateEditor` or per-editor
+  // `onDid*` listener we register stays on the global emitter until
+  // explicitly disposed — otherwise the listener closure pins this service
+  // (and its owner's ApplicationInstance) across test teardown.
+  private disposables: Array<{ dispose(): void }> = [];
 
   constructor(owner: Owner) {
     super(owner);
     this.reset.register(this);
+    registerDestructor(this, () => {
+      for (let d of this.disposables) {
+        try {
+          d.dispose();
+        } catch (_) {
+          // Monaco's dispose throws if the editor was already disposed; safe
+          // to ignore since we're tearing down anyway.
+        }
+      }
+      this.disposables.length = 0;
+    });
     this.#ready = this.loadMonacoSDK.perform();
   }
 
@@ -70,42 +88,54 @@ export default class MonacoService extends Service {
       this.extendMonacoLanguage(lang, monaco),
     );
     monaco.editor.setTheme('vs-dark');
-    monaco.editor.onDidCreateEditor((editor: _MonacoSDK.editor.ICodeEditor) => {
-      let isMainEditor = ((editor as any)._domElement as HTMLElement)
-        .getAttributeNames()
-        .includes('data-monaco-container-operator-mode');
+    this.disposables.push(
+      monaco.editor.onDidCreateEditor(
+        (editor: _MonacoSDK.editor.ICodeEditor) => {
+          let isMainEditor = ((editor as any)._domElement as HTMLElement)
+            .getAttributeNames()
+            .includes('data-monaco-container-operator-mode');
 
-      if (!isMainEditor) {
-        // Other editors (code blocks) are read only, so we don't need to track focus
-        return;
-      }
+          if (!isMainEditor) {
+            // Other editors (code blocks) are read only, so we don't need to track focus
+            return;
+          }
 
-      // Track editor initialization with shared waiter manager
-      const initOperation = `editor-init-${editor.getId()}`;
+          // Track editor initialization with shared waiter manager
+          const initOperation = `editor-init-${editor.getId()}`;
 
-      this.editor = editor;
-      this.editor.onDidFocusEditorText(() => {
-        this.hasFocus = true;
-      });
-      this.editor.onDidBlurEditorText(() => {
-        this.hasFocus = false;
-      });
-      this.editor.onDidChangeCursorSelection(() => {
-        debounce(this, this.updateSelection, isTesting() ? 10 : 200);
-      });
-      this.editor.onDidDispose(() => {
-        if (this.editor === editor) {
-          this.editor = null;
-          this.hasFocus = false;
-          this.trackedSelection = undefined;
-        }
-      });
+          this.editor = editor;
+          this.disposables.push(
+            this.editor.onDidFocusEditorText(() => {
+              this.hasFocus = true;
+            }),
+          );
+          this.disposables.push(
+            this.editor.onDidBlurEditorText(() => {
+              this.hasFocus = false;
+            }),
+          );
+          this.disposables.push(
+            this.editor.onDidChangeCursorSelection(() => {
+              debounce(this, this.updateSelection, isTesting() ? 10 : 200);
+            }),
+          );
+          this.disposables.push(
+            this.editor.onDidDispose(() => {
+              if (this.editor === editor) {
+                this.editor = null;
+                this.hasFocus = false;
+                this.trackedSelection = undefined;
+              }
+            }),
+          );
 
-      // Use shared waiter manager to track editor initialization
-      if (this.waiterManager) {
-        this.waiterManager.trackEditorInit(this.editor, initOperation);
-      }
-    });
+          // Use shared waiter manager to track editor initialization
+          if (this.waiterManager) {
+            this.waiterManager.trackEditorInit(this.editor, initOperation);
+          }
+        },
+      ),
+    );
     await Promise.all(promises);
     this.#monacoSDK = monaco;
     return monaco;

--- a/packages/host/app/services/monaco-service.ts
+++ b/packages/host/app/services/monaco-service.ts
@@ -41,18 +41,23 @@ export default class MonacoService extends Service {
   serverEchoDebounceMs = serverEchoDebounceMs;
 
   private waiterManager = createMonacoWaiterManager();
-  // Disposables returned from monaco event subscriptions. Monaco is a
-  // module-level singleton, so every `onDidCreateEditor` or per-editor
-  // `onDid*` listener we register stays on the global emitter until
-  // explicitly disposed — otherwise the listener closure pins this service
-  // (and its owner's ApplicationInstance) across test teardown.
-  private disposables: Array<{ dispose(): void }> = [];
+  // Disposables for global Monaco listeners (e.g. `onDidCreateEditor`). Monaco
+  // is a module-level singleton, so anything we register on it stays on the
+  // global emitter until explicitly disposed — otherwise the listener closure
+  // pins this service (and its owner's ApplicationInstance) across test
+  // teardown.
+  private globalDisposables: Array<{ dispose(): void }> = [];
+  // Disposables for per-editor listeners. Tracked separately so that when the
+  // main editor is disposed and later replaced in the same session, the old
+  // editor's listeners can be released without waiting for service teardown.
+  private editorDisposables: Array<{ dispose(): void }> = [];
 
   constructor(owner: Owner) {
     super(owner);
     this.reset.register(this);
     registerDestructor(this, () => {
-      for (let d of this.disposables) {
+      this.disposeEditorListeners();
+      for (let d of this.globalDisposables) {
         try {
           d.dispose();
         } catch (_) {
@@ -60,9 +65,20 @@ export default class MonacoService extends Service {
           // to ignore since we're tearing down anyway.
         }
       }
-      this.disposables.length = 0;
+      this.globalDisposables.length = 0;
     });
     this.#ready = this.loadMonacoSDK.perform();
+  }
+
+  private disposeEditorListeners() {
+    for (let d of this.editorDisposables) {
+      try {
+        d.dispose();
+      } catch (_) {
+        // see globalDisposables note
+      }
+    }
+    this.editorDisposables.length = 0;
   }
 
   resetState() {
@@ -88,7 +104,7 @@ export default class MonacoService extends Service {
       this.extendMonacoLanguage(lang, monaco),
     );
     monaco.editor.setTheme('vs-dark');
-    this.disposables.push(
+    this.globalDisposables.push(
       monaco.editor.onDidCreateEditor(
         (editor: _MonacoSDK.editor.ICodeEditor) => {
           let isMainEditor = ((editor as any)._domElement as HTMLElement)
@@ -103,35 +119,33 @@ export default class MonacoService extends Service {
           // Track editor initialization with shared waiter manager
           const initOperation = `editor-init-${editor.getId()}`;
 
+          // A new main editor replaces any prior one — release the old
+          // editor's listeners so its closures stop retaining it.
+          this.disposeEditorListeners();
           this.editor = editor;
-          this.disposables.push(
-            this.editor.onDidFocusEditorText(() => {
+          this.editorDisposables.push(
+            editor.onDidFocusEditorText(() => {
               this.hasFocus = true;
             }),
-          );
-          this.disposables.push(
-            this.editor.onDidBlurEditorText(() => {
+            editor.onDidBlurEditorText(() => {
               this.hasFocus = false;
             }),
-          );
-          this.disposables.push(
-            this.editor.onDidChangeCursorSelection(() => {
+            editor.onDidChangeCursorSelection(() => {
               debounce(this, this.updateSelection, isTesting() ? 10 : 200);
             }),
-          );
-          this.disposables.push(
-            this.editor.onDidDispose(() => {
+            editor.onDidDispose(() => {
               if (this.editor === editor) {
                 this.editor = null;
                 this.hasFocus = false;
                 this.trackedSelection = undefined;
+                this.disposeEditorListeners();
               }
             }),
           );
 
           // Use shared waiter manager to track editor initialization
           if (this.waiterManager) {
-            this.waiterManager.trackEditorInit(this.editor, initOperation);
+            this.waiterManager.trackEditorInit(editor, initOperation);
           }
         },
       ),

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -189,6 +189,7 @@
     "start-server-and-test": "catalog:",
     "statuses": "catalog:",
     "stream-browserify": "catalog:",
+    "stream-json": "catalog:",
     "super-fast-md5": "catalog:",
     "testem": "catalog:",
     "testem-multi-reporter": "catalog:",

--- a/packages/host/scripts/snapshot-diff-stream.js
+++ b/packages/host/scripts/snapshot-diff-stream.js
@@ -10,16 +10,36 @@
  * Usage: node --max-old-space-size=16384 scripts/snapshot-diff-stream.js a b
  */
 const fs = require('fs');
-const SJ =
-  '/Users/lmelia/p/cardstack/boxel/node_modules/.pnpm/stream-json@1.9.1/node_modules/stream-json';
-const { parser } = require(SJ + '/Parser.js');
-const Asm = require(SJ + '/Assembler.js');
+const { parser } = require('stream-json/Parser');
+const Asm = require('stream-json/Assembler');
+
+// Growable Float64Array wrapper. Regular JS arrays hit "Invalid array length"
+// on push around ~100M elements when V8 transitions the backing store out of
+// packed mode. Typed arrays stay flat so they scale to the full node count of
+// any heap snapshot the test runner produces.
+class F64List {
+  constructor(initial = 1 << 20) {
+    this.buf = new Float64Array(initial);
+    this.length = 0;
+  }
+  push(v) {
+    if (this.length === this.buf.length) {
+      let next = new Float64Array(this.buf.length * 2);
+      next.set(this.buf);
+      this.buf = next;
+    }
+    this.buf[this.length++] = v;
+  }
+  toTyped() {
+    return this.buf.subarray(0, this.length);
+  }
+}
 
 async function load(snapPath) {
   console.log(`streaming ${snapPath} (${fs.statSync(snapPath).size} bytes)...`);
   return new Promise((resolve, reject) => {
     let meta = null;
-    let nodes = [];
+    let nodes = new F64List();
     let strings = [];
 
     let depth = 0;
@@ -82,10 +102,20 @@ async function load(snapPath) {
             collecting = null;
             asm = null;
           }
-        } else if ((collecting === 'nodes' || collecting === 'strings') && depth === 1) {
+        } else if (
+          (collecting === 'nodes' || collecting === 'strings') &&
+          depth === 1
+        ) {
           collecting = null;
         }
-        if (!finished && meta && nodes.length && strings.length && depth <= 1 && collecting === null) {
+        if (
+          !finished &&
+          meta &&
+          nodes.length &&
+          strings.length &&
+          depth <= 1 &&
+          collecting === null
+        ) {
           p.removeAllListeners('data');
           stream.destroy();
           finish();
@@ -110,9 +140,14 @@ async function load(snapPath) {
       if (finished) return;
       finished = true;
       if (!meta || !nodes.length || !strings.length) {
-        reject(new Error(`did not find all sections: meta=${!!meta}, nodes=${nodes.length}, strings=${strings.length}`));
+        reject(
+          new Error(
+            `did not find all sections: meta=${!!meta}, nodes=${nodes.length}, strings=${strings.length}`,
+          ),
+        );
         return;
       }
+      let nodesTyped = nodes.toTyped();
       let nodeFields = meta.node_fields;
       let nodeTypes = meta.node_types[nodeFields.indexOf('type')];
       let nodeFieldCount = nodeFields.length;
@@ -120,9 +155,9 @@ async function load(snapPath) {
       let typeIdx = nodeFields.indexOf('type');
       let sizeIdx = nodeFields.indexOf('self_size');
       let counts = new Map();
-      for (let i = 0; i < nodes.length; i += nodeFieldCount) {
-        let type = nodeTypes[nodes[i + typeIdx]];
-        let name = strings[nodes[i + nameIdx]];
+      for (let i = 0; i < nodesTyped.length; i += nodeFieldCount) {
+        let type = nodeTypes[nodesTyped[i + typeIdx]];
+        let name = strings[nodesTyped[i + nameIdx]];
         let key = `${type}::${name}`;
         let c = counts.get(key);
         if (!c) {
@@ -130,10 +165,10 @@ async function load(snapPath) {
           counts.set(key, c);
         }
         c.count++;
-        c.size += nodes[i + sizeIdx];
+        c.size += nodesTyped[i + sizeIdx];
       }
       console.log(
-        `  ${(nodes.length / nodeFieldCount).toLocaleString()} nodes, ${counts.size.toLocaleString()} distinct constructors`,
+        `  ${(nodesTyped.length / nodeFieldCount).toLocaleString()} nodes, ${counts.size.toLocaleString()} distinct constructors`,
       );
       resolve(counts);
     }
@@ -143,7 +178,9 @@ async function load(snapPath) {
 (async () => {
   let [a, b] = process.argv.slice(2);
   if (!a || !b) {
-    console.error('usage: snapshot-diff-stream <a.heapsnapshot> <b.heapsnapshot>');
+    console.error(
+      'usage: snapshot-diff-stream <a.heapsnapshot> <b.heapsnapshot>',
+    );
     process.exit(2);
   }
   let ca = await load(a);
@@ -167,7 +204,8 @@ async function load(snapPath) {
     .slice(0, 40)
     .forEach((d) => {
       console.log(
-        `  +${(d.dSize / 1048576).toFixed(1)}MB count ${d.aCount}→${d.bCount} (+${d.dCount}) ` + d.key,
+        `  +${(d.dSize / 1048576).toFixed(1)}MB count ${d.aCount}→${d.bCount} (+${d.dCount}) ` +
+          d.key,
       );
     });
   console.log('\n=== top 20 by count delta ===');
@@ -176,7 +214,8 @@ async function load(snapPath) {
     .slice(0, 20)
     .forEach((d) => {
       console.log(
-        `  +${d.dCount} count ${d.aCount}→${d.bCount} (+${(d.dSize / 1048576).toFixed(1)}MB) ` + d.key,
+        `  +${d.dCount} count ${d.aCount}→${d.bCount} (+${(d.dSize / 1048576).toFixed(1)}MB) ` +
+          d.key,
       );
     });
 })().catch((e) => {

--- a/packages/host/scripts/snapshot-diff-stream.js
+++ b/packages/host/scripts/snapshot-diff-stream.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * Streaming version of snapshot-diff.js for heap snapshots >500MB where V8's
+ * max string length (~0x1fffffe8 bytes) blocks fs.readFileSync('utf8').
+ *
+ * Uses stream-json to pull only `snapshot.meta` (assembled), `nodes` (flat
+ * number array), and `strings` (flat string array) out of the heap snapshot
+ * file, then builds constructor counts identically to the non-streaming diff.
+ *
+ * Usage: node --max-old-space-size=16384 scripts/snapshot-diff-stream.js a b
+ */
+const fs = require('fs');
+const SJ =
+  '/Users/lmelia/p/cardstack/boxel/node_modules/.pnpm/stream-json@1.9.1/node_modules/stream-json';
+const { parser } = require(SJ + '/Parser.js');
+const Asm = require(SJ + '/Assembler.js');
+
+async function load(snapPath) {
+  console.log(`streaming ${snapPath} (${fs.statSync(snapPath).size} bytes)...`);
+  return new Promise((resolve, reject) => {
+    let meta = null;
+    let nodes = [];
+    let strings = [];
+
+    let depth = 0;
+    let collecting = null; // 'snapshot' | 'nodes' | 'strings' | null
+    let asm = null; // only used while collecting 'snapshot'
+    let finished = false;
+
+    const p = parser({ packKeys: true, packStrings: true, packNumbers: true });
+    const stream = fs.createReadStream(snapPath);
+    stream.on('error', reject);
+    stream.pipe(p);
+
+    const feedAsm = (name, value) => {
+      if (!asm) return;
+      if (typeof asm[name] === 'function') asm[name](value);
+    };
+
+    p.on('data', (chunk) => {
+      const n = chunk.name;
+
+      if (n === 'keyValue') {
+        if (depth === 1) {
+          const k = chunk.value;
+          if (k === 'snapshot') {
+            collecting = 'snapshot';
+            asm = new Asm();
+          } else if (k === 'nodes') {
+            collecting = 'nodes';
+            asm = null;
+          } else if (k === 'strings') {
+            collecting = 'strings';
+            asm = null;
+          } else {
+            collecting = null;
+            asm = null;
+          }
+        } else if (collecting === 'snapshot') {
+          feedAsm('keyValue', chunk.value);
+        }
+        return;
+      }
+
+      if (n === 'startObject') {
+        if (collecting === 'snapshot') feedAsm('startObject');
+        depth++;
+        return;
+      }
+      if (n === 'startArray') {
+        if (collecting === 'snapshot') feedAsm('startArray');
+        depth++;
+        return;
+      }
+
+      if (n === 'endObject' || n === 'endArray') {
+        depth--;
+        if (collecting === 'snapshot') {
+          feedAsm(n === 'endObject' ? 'endObject' : 'endArray');
+          if (depth === 1) {
+            meta = asm.current && asm.current.meta;
+            collecting = null;
+            asm = null;
+          }
+        } else if ((collecting === 'nodes' || collecting === 'strings') && depth === 1) {
+          collecting = null;
+        }
+        if (!finished && meta && nodes.length && strings.length && depth <= 1 && collecting === null) {
+          p.removeAllListeners('data');
+          stream.destroy();
+          finish();
+        }
+        return;
+      }
+
+      // Primitive events
+      if (collecting === 'snapshot') {
+        feedAsm(n, chunk.value);
+      } else if (collecting === 'nodes' && n === 'numberValue') {
+        nodes.push(+chunk.value);
+      } else if (collecting === 'strings' && n === 'stringValue') {
+        strings.push(chunk.value);
+      }
+    });
+
+    p.on('end', finish);
+    p.on('error', reject);
+
+    function finish() {
+      if (finished) return;
+      finished = true;
+      if (!meta || !nodes.length || !strings.length) {
+        reject(new Error(`did not find all sections: meta=${!!meta}, nodes=${nodes.length}, strings=${strings.length}`));
+        return;
+      }
+      let nodeFields = meta.node_fields;
+      let nodeTypes = meta.node_types[nodeFields.indexOf('type')];
+      let nodeFieldCount = nodeFields.length;
+      let nameIdx = nodeFields.indexOf('name');
+      let typeIdx = nodeFields.indexOf('type');
+      let sizeIdx = nodeFields.indexOf('self_size');
+      let counts = new Map();
+      for (let i = 0; i < nodes.length; i += nodeFieldCount) {
+        let type = nodeTypes[nodes[i + typeIdx]];
+        let name = strings[nodes[i + nameIdx]];
+        let key = `${type}::${name}`;
+        let c = counts.get(key);
+        if (!c) {
+          c = { count: 0, size: 0 };
+          counts.set(key, c);
+        }
+        c.count++;
+        c.size += nodes[i + sizeIdx];
+      }
+      console.log(
+        `  ${(nodes.length / nodeFieldCount).toLocaleString()} nodes, ${counts.size.toLocaleString()} distinct constructors`,
+      );
+      resolve(counts);
+    }
+  });
+}
+
+(async () => {
+  let [a, b] = process.argv.slice(2);
+  if (!a || !b) {
+    console.error('usage: snapshot-diff-stream <a.heapsnapshot> <b.heapsnapshot>');
+    process.exit(2);
+  }
+  let ca = await load(a);
+  let cb = await load(b);
+  let all = new Set([...ca.keys(), ...cb.keys()]);
+  let deltas = [];
+  for (let key of all) {
+    let av = ca.get(key) || { count: 0, size: 0 };
+    let bv = cb.get(key) || { count: 0, size: 0 };
+    deltas.push({
+      key,
+      dCount: bv.count - av.count,
+      dSize: bv.size - av.size,
+      aCount: av.count,
+      bCount: bv.count,
+    });
+  }
+  console.log('\n=== top 40 by retained-size delta ===');
+  deltas
+    .sort((x, y) => y.dSize - x.dSize)
+    .slice(0, 40)
+    .forEach((d) => {
+      console.log(
+        `  +${(d.dSize / 1048576).toFixed(1)}MB count ${d.aCount}→${d.bCount} (+${d.dCount}) ` + d.key,
+      );
+    });
+  console.log('\n=== top 20 by count delta ===');
+  deltas
+    .sort((x, y) => y.dCount - x.dCount)
+    .slice(0, 20)
+    .forEach((d) => {
+      console.log(
+        `  +${d.dCount} count ${d.aCount}→${d.bCount} (+${(d.dSize / 1048576).toFixed(1)}MB) ` + d.key,
+      );
+    });
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/host/scripts/snapshot-retainers-stream.js
+++ b/packages/host/scripts/snapshot-retainers-stream.js
@@ -1,0 +1,398 @@
+#!/usr/bin/env node
+/**
+ * Streaming version of snapshot-retainers.js for heap snapshots >500MB.
+ * Pulls `snapshot.meta`, `nodes`, `edges`, `strings` out via stream-json,
+ * then runs the same BFS retainer analysis as the non-streaming script.
+ *
+ * Usage: node --max-old-space-size=16384 scripts/snapshot-retainers-stream.js
+ *          <snap.heapsnapshot> <name-pattern> [--max=N] [--depth=D]
+ *          [--min-size=N] [--type=<native|object|closure|string>] [--strong]
+ */
+const fs = require('fs');
+const SJ =
+  '/Users/lmelia/p/cardstack/boxel/node_modules/.pnpm/stream-json@1.9.1/node_modules/stream-json';
+const { parser } = require(SJ + '/Parser.js');
+const Asm = require(SJ + '/Assembler.js');
+
+// Growable Float64Array wrapper. Regular JS arrays work for small snapshots
+// but push throws "Invalid array length" when the array's backing store is
+// grown into a non-packed mode around ~100M elements. Typed arrays don't
+// suffer from that because they're flat.
+class F64List {
+  constructor(initial = 1 << 20) {
+    this.buf = new Float64Array(initial);
+    this.length = 0;
+  }
+  push(v) {
+    if (this.length === this.buf.length) {
+      let next = new Float64Array(this.buf.length * 2);
+      next.set(this.buf);
+      this.buf = next;
+    }
+    this.buf[this.length++] = v;
+  }
+  toTyped() {
+    return this.buf.subarray(0, this.length);
+  }
+}
+
+function loadStream(snapPath) {
+  process.stderr.write(
+    `streaming ${snapPath} (${(fs.statSync(snapPath).size / 1048576).toFixed(1)}MB)...\n`,
+  );
+  return new Promise((resolve, reject) => {
+    let meta = null;
+    let nodes = new F64List();
+    let edges = new F64List();
+    let strings = [];
+    let depth = 0;
+    let collecting = null;
+    let asm = null;
+    let finished = false;
+
+    const p = parser({ packKeys: true, packStrings: true, packNumbers: true });
+    const stream = fs.createReadStream(snapPath);
+    stream.on('error', reject);
+    stream.pipe(p);
+
+    const feedAsm = (name, value) => {
+      if (!asm || typeof asm[name] !== 'function') return;
+      asm[name](value);
+    };
+
+    p.on('data', (chunk) => {
+      const n = chunk.name;
+      if (n === 'keyValue') {
+        if (depth === 1) {
+          const k = chunk.value;
+          if (k === 'snapshot') {
+            collecting = 'snapshot';
+            asm = new Asm();
+          } else if (k === 'nodes') {
+            collecting = 'nodes';
+            asm = null;
+          } else if (k === 'edges') {
+            collecting = 'edges';
+            asm = null;
+          } else if (k === 'strings') {
+            collecting = 'strings';
+            asm = null;
+          } else {
+            collecting = null;
+            asm = null;
+          }
+        } else if (collecting === 'snapshot') {
+          feedAsm('keyValue', chunk.value);
+        }
+        return;
+      }
+      if (n === 'startObject') {
+        if (collecting === 'snapshot') feedAsm('startObject');
+        depth++;
+        return;
+      }
+      if (n === 'startArray') {
+        if (collecting === 'snapshot') feedAsm('startArray');
+        depth++;
+        return;
+      }
+      if (n === 'endObject' || n === 'endArray') {
+        depth--;
+        if (collecting === 'snapshot') {
+          feedAsm(n);
+          if (depth === 1) {
+            meta = asm.current && asm.current.meta;
+            collecting = null;
+            asm = null;
+          }
+        } else if (
+          (collecting === 'nodes' ||
+            collecting === 'edges' ||
+            collecting === 'strings') &&
+          depth === 1
+        ) {
+          collecting = null;
+        }
+        if (
+          !finished &&
+          meta &&
+          nodes.length > 0 &&
+          edges.length > 0 &&
+          strings.length > 0 &&
+          depth <= 1 &&
+          collecting === null
+        ) {
+          p.removeAllListeners('data');
+          stream.destroy();
+          finish();
+        }
+        return;
+      }
+      if (collecting === 'snapshot') {
+        feedAsm(n, chunk.value);
+      } else if (collecting === 'nodes' && n === 'numberValue') {
+        nodes.push(+chunk.value);
+      } else if (collecting === 'edges' && n === 'numberValue') {
+        edges.push(+chunk.value);
+      } else if (collecting === 'strings' && n === 'stringValue') {
+        strings.push(chunk.value);
+      }
+    });
+
+    p.on('end', finish);
+    p.on('error', reject);
+
+    function finish() {
+      if (finished) return;
+      finished = true;
+      if (!meta || !nodes.length || !edges.length || !strings.length) {
+        reject(
+          new Error(
+            `incomplete: meta=${!!meta} nodes=${nodes.length} edges=${edges.length} strings=${strings.length}`,
+          ),
+        );
+        return;
+      }
+      let nodesTyped = nodes.toTyped();
+      let edgesTyped = edges.toTyped();
+      process.stderr.write(
+        `  ${(nodesTyped.length / meta.node_fields.length).toLocaleString()} nodes, ${(edgesTyped.length / meta.edge_fields.length).toLocaleString()} edges, ${strings.length.toLocaleString()} strings\n`,
+      );
+      resolve(buildHeap(meta, nodesTyped, edgesTyped, strings));
+    }
+  });
+}
+
+function buildHeap(meta, nodes, edges, strings) {
+  let nodeFieldsList = meta.node_fields;
+  let edgeFieldsList = meta.edge_fields;
+  let nodeTypes = meta.node_types[nodeFieldsList.indexOf('type')];
+  let edgeTypes = meta.edge_types[edgeFieldsList.indexOf('type')];
+  let NF = nodeFieldsList.length;
+  let EF = edgeFieldsList.length;
+  let nameIdx = nodeFieldsList.indexOf('name');
+  let typeIdx = nodeFieldsList.indexOf('type');
+  let sizeIdx = nodeFieldsList.indexOf('self_size');
+  let idIdx = nodeFieldsList.indexOf('id');
+  let edgeCountIdx = nodeFieldsList.indexOf('edge_count');
+  let eTypeIdx = edgeFieldsList.indexOf('type');
+  let eNameIdx = edgeFieldsList.indexOf('name_or_index');
+  let eToIdx = edgeFieldsList.indexOf('to_node');
+
+  let nodeCount = nodes.length / NF;
+  let edgeOffsets = new Uint32Array(nodeCount + 1);
+  {
+    let off = 0;
+    for (let i = 0; i < nodeCount; i++) {
+      edgeOffsets[i] = off;
+      off += nodes[i * NF + edgeCountIdx] * EF;
+    }
+    edgeOffsets[nodeCount] = off;
+  }
+  return {
+    nodes,
+    edges,
+    strings,
+    NF,
+    EF,
+    nameIdx,
+    typeIdx,
+    sizeIdx,
+    idIdx,
+    edgeCountIdx,
+    eTypeIdx,
+    eNameIdx,
+    eToIdx,
+    nodeTypes,
+    edgeTypes,
+    nodeCount,
+    edgeOffsets,
+  };
+}
+
+function nodeLabel(h, nodeIdx) {
+  let i = nodeIdx * h.NF;
+  let type = h.nodeTypes[h.nodes[i + h.typeIdx]];
+  let name = h.strings[h.nodes[i + h.nameIdx]];
+  let id = h.nodes[i + h.idIdx];
+  let shortName =
+    name && name.length > 80 ? name.slice(0, 60) + '…' : name || '';
+  return `${type}::${shortName}#${id}`;
+}
+
+function buildReverseIndex(h) {
+  process.stderr.write('building reverse edge index...\n');
+  let revCount = new Uint32Array(h.nodeCount);
+  for (let eo = 0; eo < h.edges.length; eo += h.EF) {
+    let toNode = h.edges[eo + h.eToIdx] / h.NF;
+    revCount[toNode]++;
+  }
+  let totalRev = 0;
+  for (let i = 0; i < h.nodeCount; i++) totalRev += revCount[i];
+  process.stderr.write(`  total reverse edges: ${totalRev.toLocaleString()}\n`);
+  let revOffsets = new Uint32Array(h.nodeCount + 1);
+  {
+    let off = 0;
+    for (let i = 0; i < h.nodeCount; i++) {
+      revOffsets[i] = off;
+      off += revCount[i];
+    }
+    revOffsets[h.nodeCount] = off;
+  }
+  let revFrom = new Uint32Array(totalRev);
+  let revEdge = new Uint32Array(totalRev);
+  let cursor = new Uint32Array(h.nodeCount);
+  for (let nodeIdx = 0; nodeIdx < h.nodeCount; nodeIdx++) {
+    let eStart = h.edgeOffsets[nodeIdx];
+    let eEnd = h.edgeOffsets[nodeIdx + 1];
+    for (let eo = eStart; eo < eEnd; eo += h.EF) {
+      let toNode = h.edges[eo + h.eToIdx] / h.NF;
+      let slot = revOffsets[toNode] + cursor[toNode]++;
+      revFrom[slot] = nodeIdx;
+      revEdge[slot] = eo;
+    }
+  }
+  return { revOffsets, revFrom, revEdge };
+}
+
+function edgeDescription(h, edgeOffset) {
+  let eType = h.edgeTypes[h.edges[edgeOffset + h.eTypeIdx]];
+  let nameOrIdx = h.edges[edgeOffset + h.eNameIdx];
+  let nameStr;
+  if (eType === 'element' || eType === 'hidden') {
+    nameStr = `[${nameOrIdx}]`;
+  } else {
+    nameStr = h.strings[nameOrIdx] || '';
+    if (nameStr.length > 40) nameStr = nameStr.slice(0, 30) + '…';
+  }
+  return `${eType}:${nameStr}`;
+}
+
+function findTargets(h, pattern, opts) {
+  let re = new RegExp(pattern);
+  let minSize = opts && opts.minSize ? opts.minSize : 0;
+  let typeFilter = opts && opts.type;
+  let targets = [];
+  for (let n = 0; n < h.nodeCount; n++) {
+    let i = n * h.NF;
+    let type = h.nodeTypes[h.nodes[i + h.typeIdx]];
+    if (typeFilter) {
+      if (type !== typeFilter) continue;
+    } else if (type !== 'object' && type !== 'closure') {
+      continue;
+    }
+    let selfSize = h.nodes[i + h.sizeIdx];
+    if (selfSize < minSize) continue;
+    let name = h.strings[h.nodes[i + h.nameIdx]] || '';
+    if (re.test(name)) targets.push(n);
+  }
+  return targets;
+}
+
+function shortestPathToRoot(h, rev, target, maxDepth, strongOnly) {
+  let visited = new Set();
+  let queue = [{ node: target, path: [] }];
+  let head = 0;
+  visited.add(target);
+  while (head < queue.length) {
+    let { node, path } = queue[head++];
+    if (path.length > maxDepth) return null;
+    let nodeType = h.nodeTypes[h.nodes[node * h.NF + h.typeIdx]];
+    if (node === 0 || (nodeType === 'synthetic' && path.length > 0)) {
+      return path.concat([{ node, edgeDesc: null }]);
+    }
+    let rStart = rev.revOffsets[node];
+    let rEnd = rev.revOffsets[node + 1];
+    for (let k = rStart; k < rEnd; k++) {
+      let from = rev.revFrom[k];
+      if (visited.has(from)) continue;
+      let edgeOffset = rev.revEdge[k];
+      let eType = h.edgeTypes[h.edges[edgeOffset + h.eTypeIdx]];
+      if (strongOnly && (eType === 'weak' || eType === 'shortcut')) continue;
+      if (strongOnly && eType === 'internal') {
+        let nameStr = h.strings[h.edges[edgeOffset + h.eNameIdx]] || '';
+        if (nameStr.indexOf('part of key') !== -1) continue;
+      }
+      visited.add(from);
+      queue.push({
+        node: from,
+        path: path.concat([{ node, edgeDesc: edgeDescription(h, edgeOffset) }]),
+      });
+    }
+  }
+  return null;
+}
+
+function formatPath(h, path) {
+  let parts = [];
+  for (let i = path.length - 1; i >= 0; i--) {
+    parts.push(nodeLabel(h, path[i].node));
+    if (i > 0 && path[i - 1].edgeDesc) {
+      parts.push(`  --[${path[i - 1].edgeDesc}]-->`);
+    }
+  }
+  return parts.join('\n');
+}
+
+async function main() {
+  let args = process.argv.slice(2);
+  let snapPath = args[0];
+  let pattern = args[1];
+  let maxTargets = 10;
+  let maxDepth = 25;
+  let opts = {};
+  for (let a of args.slice(2)) {
+    let m = a.match(/^--max=(\d+)$/);
+    if (m) maxTargets = parseInt(m[1]);
+    m = a.match(/^--depth=(\d+)$/);
+    if (m) maxDepth = parseInt(m[1]);
+    m = a.match(/^--min-size=(\d+)$/);
+    if (m) opts.minSize = parseInt(m[1]);
+    m = a.match(/^--type=(\w+)$/);
+    if (m) opts.type = m[1];
+    if (a === '--strong') opts.strongOnly = true;
+  }
+  if (!snapPath || !pattern) {
+    console.error(
+      'usage: snapshot-retainers-stream <snap.heapsnapshot> <name-pattern> [--max=N] [--depth=D] [--type=T] [--strong]',
+    );
+    process.exit(2);
+  }
+  let h = await loadStream(snapPath);
+  process.stderr.write(`finding targets matching /${pattern}/...\n`);
+  let targets = findTargets(h, pattern, opts);
+  process.stderr.write(`  found ${targets.length} targets\n`);
+  let rev = buildReverseIndex(h);
+
+  let sigGroups = new Map();
+  let sampled = targets.slice(0, maxTargets);
+  for (let t of sampled) {
+    let path = shortestPathToRoot(h, rev, t, maxDepth, opts.strongOnly);
+    if (!path) {
+      console.log(`${nodeLabel(h, t)}: NO PATH WITHIN DEPTH ${maxDepth}`);
+      continue;
+    }
+    let sig = path
+      .slice(0, -1)
+      .map((p) => p.edgeDesc)
+      .filter(Boolean)
+      .join(' | ');
+    if (!sigGroups.has(sig)) sigGroups.set(sig, []);
+    sigGroups.get(sig).push({ target: t, path });
+  }
+  let sorted = [...sigGroups.entries()].sort(
+    (a, b) => b[1].length - a[1].length,
+  );
+  for (let [sig, group] of sorted) {
+    console.log('\n' + '='.repeat(80));
+    console.log(`RETAINER SIGNATURE (${group.length} targets):`);
+    console.log(sig);
+    console.log('\nExample path:');
+    console.log(formatPath(h, group[0].path));
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/host/scripts/snapshot-retainers-stream.js
+++ b/packages/host/scripts/snapshot-retainers-stream.js
@@ -9,10 +9,8 @@
  *          [--min-size=N] [--type=<native|object|closure|string>] [--strong]
  */
 const fs = require('fs');
-const SJ =
-  '/Users/lmelia/p/cardstack/boxel/node_modules/.pnpm/stream-json@1.9.1/node_modules/stream-json';
-const { parser } = require(SJ + '/Parser.js');
-const Asm = require(SJ + '/Assembler.js');
+const { parser } = require('stream-json/Parser');
+const Asm = require('stream-json/Assembler');
 
 // Growable Float64Array wrapper. Regular JS arrays work for small snapshots
 // but push throws "Invalid array length" when the array's backing store is

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2364,6 +2364,9 @@ importers:
       stream-browserify:
         specifier: 'catalog:'
         version: 3.0.0
+      stream-json:
+        specifier: 'catalog:'
+        version: 1.9.1
       super-fast-md5:
         specifier: 'catalog:'
         version: 1.0.3


### PR DESCRIPTION
## Summary

Four independent host-test memory leaks that together drove Shard 16 to OOM (the branch at `cs-10780-register-markdown-in-the-format-type-and-formats-array` tripped this — but every shard that renders Monaco or the AI assistant is affected):

1. **`AiAssistantToast` `pollTask` → `setTimeout`.** `ember-lifeline`'s `pollTask` registers the owner in a module-global Map (`window[LIFELINE_QUEUED_POLL_TASKS]`). Missed `cancelPoll` → the Map pins the toast → `ApplicationInstance` → card-api module graph across every subsequent test. Replaced with plain `setTimeout` + `clearTimeout` in `registerDestructor` — timer closures GC themselves when they fire, no global Map involved.

2. **Monaco per-editor `onDid*` subscriptions in modifiers.** `monaco.ts`, `monaco-editor.gts`, `monaco-diff-editor.gts` all called `onDidContentSizeChange`, `onDidChangeContent`, `onDidChangeCursorSelection`, `onDidUpdateDiff` and discarded the returned `IDisposable`. The listener stayed on `StandaloneCodeEditorService._codeEditors` / `_diffEditors` and its closure retained the modifier → component → owner. Now each modifier collects `onDid*` results into a `disposables: IDisposable[]` array and releases them in `registerDestructor`.

3. **Monaco `editor.dispose()` deferred to `requestAnimationFrame` never fires in tests.** `disposeEditorAfterInitialLayout` used `rAF` to dodge a Monaco bootstrap race in production. QUnit runs tests back-to-back without yielding to a paint, so the dispose callback queues but never runs — the editor stays in Monaco's registry and its `DOMTimer`s keep the owner reachable. Now branches on `isTesting()`: synchronous dispose in tests, `rAF`-deferred dispose in production.

4. **`MonacoService` global `onDidCreateEditor` listener (and per-editor listeners created inside it).** Same pattern as #2 but at the service level. The service is module-singleton-bound, so every test left a listener whose closure captured the test's owner via `setOwner`. Now tracked in `this.disposables` and disposed in a service `registerDestructor`.

**Trajectory (Shard 16 local probe):**

| point | pre-fix | post-fix | Δ |
|---|---|---|---|
| t=60 `used=` | 432 MB | 276 MB | -156 MB |
| t=90 `used=` | 602 MB | 319 MB | -283 MB (47%) |
| t=50→t=90 slope | 5.67 MB/test | 0.51 MB/test | 91% flatter |

Heap oscillates 276–346 MB across the full partition — no climb, just GC wave.

## Commits

1. The five source-file fixes.
2. Tooling/docs — streaming heap-snapshot analyzers (`snapshot-diff-stream.js`, `snapshot-retainers-stream.js`) for snapshots above V8's ~512 MB string limit, and four new entries in the `host-test-memory-leak-hunting` skill catalog documenting the patterns above (#6–#9 in `known-leaks.md`).

## Test plan

- [ ] CI host-test shards all green
- [ ] Shard 16 specifically passes under the default `shardTotal: 20` config
- [ ] Smoke test operator mode (Monaco code editor), code-submode diff view (Monaco diff editor), and the AI assistant toast in development — all three dispose paths exercised

🤖 Generated with [Claude Code](https://claude.com/claude-code)