### PR TITLE
Fix InstantiationService disposed race in monaco-diff-editor

### DIFF
--- a/packages/host/app/modifiers/monaco-diff-editor.gts
+++ b/packages/host/app/modifiers/monaco-diff-editor.gts
@@ -1,5 +1,4 @@
 import { registerDestructor } from '@ember/destroyable';
-import { isTesting } from '@embroider/macros';
 
 import Modifier from 'ember-modifier';
 
@@ -287,18 +286,18 @@ export default class MonacoDiffEditor extends Modifier<MonacoDiffEditorSignature
     editor: _MonacoSDK.editor.IStandaloneDiffEditor,
     model: _MonacoSDK.editor.IDiffEditorModel | null | undefined,
   ) {
-    // Diff editors hit the same Monaco bootstrap race as standard editors when
-    // search/replace blocks finish streaming and swap render modes within one
-    // Glimmer turn. Waiting until the next paint keeps teardown deterministic
-    // without relying on a fixed timeout. In tests, rAF may never fire between
-    // teardown and the next test — dispose synchronously there so Monaco's
-    // StandaloneCodeEditorService._diffEditors registry releases its reference
-    // and internal DOMTimers stop retaining the owner.
-    let dispose = () => {
+    // Diff editors are only rendered inside streaming AI code blocks, where the
+    // modifier is regularly torn down while Monaco's CodeEditorContributions
+    // instantiation is still queued. Synchronous dispose trips "InstantiationService
+    // has been disposed" on the next deferred `_instantiateSome` call — same race
+    // that forced monaco-editor.gts to always defer. Keep the rAF deferral even in
+    // tests; the leak hunt never implicated this code path.
+    // eslint-disable-next-line @cardstack/boxel/no-raf-for-state -- Monaco dispose must wait for paint to avoid bootstrap race
+    requestAnimationFrame(() => {
       try {
         editor.dispose();
       } catch {
-        // See note above: cleanup should be tolerant of partially-disposed editors.
+        // cleanup should be tolerant of partially-disposed editors.
       }
       if (model?.original) {
         this.disposeModelWhenDetached(model.original);
@@ -306,12 +305,6 @@ export default class MonacoDiffEditor extends Modifier<MonacoDiffEditorSignature
       if (model?.modified) {
         this.disposeModelWhenDetached(model.modified);
       }
-    };
-    if (isTesting()) {
-      dispose();
-    } else {
-      // eslint-disable-next-line @cardstack/boxel/no-raf-for-state -- Monaco dispose must wait for paint to avoid bootstrap race
-      requestAnimationFrame(dispose);
-    }
+    });
   }
 }


### PR DESCRIPTION
## Summary
- Host shard 3 started failing on main after #4437 with 13 global errors: `Uncaught Error: InstantiationService has been disposed` in `CodeEditorContributions._instantiateSome`, all attributed to the Code patches "historic/applied" acceptance test.
- Root cause: `monaco-diff-editor.gts` kept the `isTesting()` synchronous-dispose fast-path that #4437 already reverted for `monaco-editor.gts`. But the diff editor is only used inside AI code blocks (`ai-assistant/code-block/index.gts`) — same streaming-teardown context. When the modifier is torn down in the same turn as Monaco's `CodeEditorContributions` setTimeout for `_instantiateSome` is still queued, synchronous `editor.dispose()` kills the InstantiationService before the scheduled work fires.
- Match the monaco-editor.gts pattern: always defer dispose to `requestAnimationFrame`, even in tests. Removes the small leak-fix benefit from synchronous dispose here, but the leak hunt never implicated diff editors.

## Test plan
- [ ] CI Host shard 3 passes (the test that was throwing 13 global errors: `Acceptance | Code patches tests: when code patch is historic ... it will render the code (replace portion of the search/replace block) in a standard (non-diff) editor`).
- [ ] No regression in the memory-leak MEMPROBE signal introduced by #4437 (diff editors were not on the retained-size leader board).

🤖 Generated with [Claude Code](https://claude.com/claude-code)