### PR TITLE
Add CI-parity lint step to pr-listing-create submission flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ traefik/dynamic/*.yml
 .mise.local.toml
 packages/openrouter-realm/OpenRouterModel/
 packages/host/dist
+packages/catalog-realm/__submissions-temp__/

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -231,7 +231,9 @@ export class LintAndFixInput extends CardDef {
 
 export class LintAndFixResult extends CardDef {
   @field output = contains(StringField);
-  @field lintIssues = containsMany(StringField);
+  @field lintIssues = containsMany(StringField); // all remaining issues (errors + warnings)
+  @field lintErrors = containsMany(StringField); // severity 2 only (unfixable errors)
+  @field lintWarnings = containsMany(StringField); // severity 1 only
 }
 
 export class PatchCodeResultField extends FieldDef {

--- a/packages/bot-runner/lib/command-runner.ts
+++ b/packages/bot-runner/lib/command-runner.ts
@@ -15,6 +15,16 @@ import {
   type BotTriggerEventContent,
 } from './create-listing-pr-handler';
 import type { GitHubClient } from './github';
+import {
+  runLintOnSubmissionFiles,
+  type LintOutcome,
+  type SubmissionFile,
+} from '@cardstack/runtime-common/lint/submission-lint';
+
+export type LintSubmissionFilesFn = (
+  files: SubmissionFile[],
+  opts: { roomId: string; listingId: string },
+) => Promise<LintOutcome>;
 
 const log = logger('bot-runner');
 const COLLECT_SUBMISSION_FILES_COMMAND =
@@ -26,14 +36,17 @@ const PATCH_CARD_INSTANCE_COMMAND =
 
 export class CommandRunner {
   private createListingPRHandler: CreateListingPRHandler;
+  private lintSubmissionFiles: LintSubmissionFilesFn;
 
   constructor(
     private submissionBotUserId: string,
     private dbAdapter: DBAdapter,
     private queuePublisher: QueuePublisher,
     githubClient: GitHubClient,
+    lintSubmissionFiles: LintSubmissionFilesFn = runLintOnSubmissionFiles,
   ) {
     this.createListingPRHandler = new CreateListingPRHandler(githubClient);
+    this.lintSubmissionFiles = lintSubmissionFiles;
   }
 
   async maybeEnqueueCommand(
@@ -140,6 +153,108 @@ export class CommandRunner {
           fileCount: allFileContents.length,
         });
 
+        // Step 1.5: Lint & auto-fix collected files
+        if (workflowCardUrl) {
+          await this.enqueueRunCommand({
+            runAs,
+            realmURL: effectiveWorkflowRealm,
+            command: PATCH_CARD_INSTANCE_COMMAND,
+            commandInput: {
+              cardId: workflowCardUrl,
+              patch: {
+                attributes: {
+                  lintStatus: 'in-progress',
+                },
+              },
+            },
+          });
+        }
+
+        log.info('pr-listing-create: linting files', {
+          fileCount: allFileContents.length,
+        });
+        let lintOutcome;
+        try {
+          lintOutcome = await this.lintSubmissionFiles(allFileContents, {
+            roomId,
+            listingId,
+          });
+        } catch (lintError: any) {
+          let errorMessage = lintError?.message ?? 'lint runner crashed';
+          log.error('pr-listing-create: lint runner crashed', {
+            error: errorMessage,
+          });
+          if (workflowCardUrl) {
+            await this.enqueueRunCommand({
+              runAs,
+              realmURL: effectiveWorkflowRealm,
+              command: PATCH_CARD_INSTANCE_COMMAND,
+              commandInput: {
+                cardId: workflowCardUrl,
+                patch: {
+                  attributes: {
+                    lintStatus: 'failed',
+                    lintErrors: [errorMessage],
+                  },
+                },
+              },
+            });
+          }
+          throw new Error(errorMessage);
+        }
+
+        let lintErrors = lintOutcome.lintErrors;
+        let fixedFileCount = lintOutcome.fixedFileCount;
+
+        if (!lintOutcome.passed) {
+          log.error('pr-listing-create: lint found unfixable errors', {
+            errorCount: lintErrors.length,
+          });
+          if (workflowCardUrl) {
+            await this.enqueueRunCommand({
+              runAs,
+              realmURL: effectiveWorkflowRealm,
+              command: PATCH_CARD_INSTANCE_COMMAND,
+              commandInput: {
+                cardId: workflowCardUrl,
+                patch: {
+                  attributes: {
+                    lintStatus: 'failed',
+                    lintErrors,
+                  },
+                },
+              },
+            });
+          }
+          throw new Error(
+            `Lint failed with ${lintErrors.length} unfixable error(s):\n${lintErrors.join('\n')}`,
+          );
+        }
+
+        if (fixedFileCount > 0) {
+          allFileContents = lintOutcome.fixedFiles;
+        }
+
+        log.info('pr-listing-create: lint passed', {
+          fixedFileCount,
+        });
+        if (workflowCardUrl) {
+          await this.enqueueRunCommand({
+            runAs,
+            realmURL: effectiveWorkflowRealm,
+            command: PATCH_CARD_INSTANCE_COMMAND,
+            commandInput: {
+              cardId: workflowCardUrl,
+              patch: {
+                attributes: {
+                  lintStatus: 'passed',
+                  lintFixedCount: fixedFileCount,
+                },
+              },
+            },
+          });
+        }
+
         // Build PR summary from available info
         let listingSummary =
           typeof input.listingSummary === 'string'
@@ -157,81 +272,113 @@ export class CommandRunner {
             : []),
         ].join('\n');
 
-        // Step 2: Create PrCard — runs as SUBMISSION BOT in the SUBMISSIONS realm
-        let prCardResult = await this.enqueueRunCommand({
-          runAs: this.submissionBotUserId,
-          realmURL: submissionRealm,
-          command: CREATE_PR_CARD_COMMAND,
-          commandInput: {
-            realm: submissionRealm,
-            branchName,
-            submittedBy: runAs,
-            prSummary,
-            allFileContents,
-          },
-        });
-
-        if (prCardResult.status !== 'ready') {
-          let errorMessage =
-            prCardResult.error && prCardResult.error.trim()
-              ? prCardResult.error
-              : `create-pr-card returned status "${prCardResult.status}"`;
-          log.error('pr-listing-create: create-pr-card failed', {
-            runAs,
-            submissionBotUserId: this.submissionBotUserId,
-            submissionRealm,
-            branchName,
-            status: prCardResult.status,
-            error: prCardResult.error,
-            cardResultString: prCardResult.cardResultString ?? null,
-            fileCount: allFileContents.length,
-            inputPayloadSize: JSON.stringify(allFileContents).length,
-          });
-          throw new Error(errorMessage);
-        }
-
-        let prCardUrl = getCardUrl(prCardResult.cardResultString);
-        log.info('pr-listing-create: PrCard created', { prCardUrl });
-
-        // Step 3: Create the GitHub PR using file contents from the PrCard
-        await this.createListingPRHandler.ensureCreateListingBranch(
-          eventContent,
-        );
-        await this.createListingPRHandler.addContentsToCommit(
-          eventContent,
-          prCardResult,
-        );
-        let prResult = await this.createListingPRHandler.openCreateListingPR(
-          eventContent,
-          runAs,
-          prCardResult,
-          workflowCardUrl,
-        );
-
-        log.info('pr-listing-create: PR created', {
-          prNumber: prResult?.prNumber,
-          prUrl: prResult?.prUrl,
-        });
-
-        // Step 3: Link PrCard to workflow card
-        if (workflowCardUrl && prCardUrl) {
-          await this.enqueueRunCommand({
-            runAs,
-            realmURL: effectiveWorkflowRealm,
-            command: PATCH_CARD_INSTANCE_COMMAND,
+        // Everything from here through the prCard-link patch must either all
+        // succeed, or we must patch the workflow card back to a failed state.
+        let prCardResult: RunCommandResponse;
+        let prCardUrl: string | null;
+        try {
+          // Step 2: Create PrCard — runs as SUBMISSION BOT in the SUBMISSIONS realm
+          prCardResult = await this.enqueueRunCommand({
+            runAs: this.submissionBotUserId,
+            realmURL: submissionRealm,
+            command: CREATE_PR_CARD_COMMAND,
             commandInput: {
-              cardId: workflowCardUrl,
-              patch: {
-                relationships: {
-                  prCard: {
-                    links: {
-                      self: prCardUrl,
+              realm: submissionRealm,
+              branchName,
+              submittedBy: runAs,
+              prSummary,
+              allFileContents,
+            },
+          });
+
+          if (prCardResult.status !== 'ready') {
+            let errorMessage =
+              prCardResult.error && prCardResult.error.trim()
+                ? prCardResult.error
+                : `create-pr-card returned status "${prCardResult.status}"`;
+            log.error('pr-listing-create: create-pr-card failed', {
+              runAs,
+              submissionBotUserId: this.submissionBotUserId,
+              submissionRealm,
+              branchName,
+              status: prCardResult.status,
+              error: prCardResult.error,
+              cardResultString: prCardResult.cardResultString ?? null,
+              fileCount: allFileContents.length,
+              inputPayloadSize: JSON.stringify(allFileContents).length,
+            });
+            throw new Error(errorMessage);
+          }
+
+          prCardUrl = getCardUrl(prCardResult.cardResultString);
+          log.info('pr-listing-create: PrCard created', { prCardUrl });
+
+          // Step 3: Create the GitHub PR using file contents from the PrCard
+          await this.createListingPRHandler.ensureCreateListingBranch(
+            eventContent,
+          );
+          await this.createListingPRHandler.addContentsToCommit(
+            eventContent,
+            prCardResult,
+          );
+          let prResult = await this.createListingPRHandler.openCreateListingPR(
+            eventContent,
+            runAs,
+            prCardResult,
+            workflowCardUrl,
+          );
+
+          log.info('pr-listing-create: PR created', {
+            prNumber: prResult?.prNumber,
+            prUrl: prResult?.prUrl,
+          });
+
+          // Step 3: Link PrCard to workflow card
+          if (workflowCardUrl && prCardUrl) {
+            await this.enqueueRunCommand({
+              runAs,
+              realmURL: effectiveWorkflowRealm,
+              command: PATCH_CARD_INSTANCE_COMMAND,
+              commandInput: {
+                cardId: workflowCardUrl,
+                patch: {
+                  relationships: {
+                    prCard: {
+                      links: {
+                        self: prCardUrl,
+                      },
                     },
                   },
                 },
               },
-            },
-          });
+            });
+          }
+        } catch (prCreationError: any) {
+          let errorMessage =
+            prCreationError?.message ?? 'unknown PR creation error';
+          if (workflowCardUrl) {
+            try {
+              await this.enqueueRunCommand({
+                runAs,
+                realmURL: effectiveWorkflowRealm,
+                command: PATCH_CARD_INSTANCE_COMMAND,
+                commandInput: {
+                  cardId: workflowCardUrl,
+                  patch: {
+                    attributes: {
+                      prCreationError: `PR creation failed: ${errorMessage}`,
+                    },
+                  },
+                },
+              });
+            } catch (patchError: any) {
+              log.error(
+                'pr-listing-create: failed to patch workflow card after PR creation failure',
+                { patchError: patchError?.message ?? patchError },
+              );
+            }
+          }
+          throw prCreationError;
         }
 
         return prCardResult;

--- a/packages/bot-runner/main.ts
+++ b/packages/bot-runner/main.ts
@@ -7,6 +7,7 @@ import * as Sentry from '@sentry/node';
 import { onMembershipEvent } from './lib/membership-handler';
 import { onTimelineEvent } from './lib/timeline-handler';
 import { createGitHubClientFromEnv } from './lib/github';
+import { cleanupOrphanedSubmissionTemps } from '@cardstack/runtime-common/lint/submission-lint';
 
 const log = logger('bot-runner');
 const startTime = Date.now();
@@ -32,6 +33,8 @@ const botPassword = process.env.SUBMISSION_BOT_PASSWORD || 'password';
   }
 
   log.info(`logged in as ${auth.user_id}`);
+
+  await cleanupOrphanedSubmissionTemps();
 
   let dbAdapter = new PgAdapter();
   let queuePublisher = new PgQueuePublisher(dbAdapter);

--- a/packages/bot-runner/tests/command-runner-test.ts
+++ b/packages/bot-runner/tests/command-runner-test.ts
@@ -7,7 +7,17 @@ import type {
   RunCommandResponse,
 } from '@cardstack/runtime-common';
 import type { GitHubClient } from '../lib/github';
-import { CommandRunner } from '../lib/command-runner';
+import { CommandRunner, type LintSubmissionFilesFn } from '../lib/command-runner';
+
+const passThroughLint: LintSubmissionFilesFn = async (files) => ({
+  passed: true,
+  fixedFiles: files.map((f) => ({
+    filename: f.filename,
+    contents: f.contents ?? '',
+  })),
+  lintErrors: [],
+  fixedFileCount: 0,
+});
 
 const SUBMISSION_REALM_URL = 'http://localhost:4201/submissions/';
 const SUBMISSION_BOT_USER_ID = '@submissionbot:localhost';
@@ -75,6 +85,7 @@ module('command runner', () => {
       dbAdapter,
       queuePublisher,
       githubClient,
+      passThroughLint,
     );
     let result = await commandRunner.maybeEnqueueCommand(
       '@alice:localhost',
@@ -223,6 +234,7 @@ module('command runner', () => {
       dbAdapter,
       queuePublisher,
       githubClient,
+      passThroughLint,
     );
     await commandRunner.maybeEnqueueCommand(
       '@alice:localhost',
@@ -243,34 +255,46 @@ module('command runner', () => {
 
     assert.strictEqual(
       publishedJobs.length,
-      3,
-      'enqueues collect-files, create-pr-card, and patch-card-instance jobs',
+      5,
+      'enqueues collect-files, two lint-status patches, create-pr-card, and prCard-link patch',
     );
     assert.strictEqual(createdBranches.length, 1, 'creates branch');
     assert.strictEqual(branchWrites.length, 1, 'writes files to branch');
     assert.strictEqual(openedPRs.length, 1, 'opens pull request');
 
-    // Job 1 (collect-files) targets the user's realm — default concurrency group
+    // Job 1: collect-files — user realm
     assert.strictEqual(
       (publishedJobs[0] as { concurrencyGroup: string }).concurrencyGroup,
       'command:http://localhost:4201/test/',
       'Job 1 (collect-files) uses default realm concurrency group',
     );
-    // Job 2 (create-pr-card) targets the shared submission realm — default concurrency group
+    // Job 2: patch lintStatus=in-progress — user realm
     assert.strictEqual(
       (publishedJobs[1] as { concurrencyGroup: string }).concurrencyGroup,
-      `command:${SUBMISSION_REALM_URL}`,
-      'Job 2 (create-pr-card) uses submissions realm concurrency group',
+      'command:http://localhost:4201/test/',
+      'Job 2 (lintStatus in-progress) uses default realm concurrency group',
     );
-    // Job 3 (patch-card-instance) targets the user's realm — default concurrency group
+    // Job 3: patch lintStatus=passed — user realm
     assert.strictEqual(
       (publishedJobs[2] as { concurrencyGroup: string }).concurrencyGroup,
       'command:http://localhost:4201/test/',
-      'Job 3 (patch-card-instance) uses default realm concurrency group',
+      'Job 3 (lintStatus passed) uses default realm concurrency group',
+    );
+    // Job 4: create-pr-card — submissions realm
+    assert.strictEqual(
+      (publishedJobs[3] as { concurrencyGroup: string }).concurrencyGroup,
+      `command:${SUBMISSION_REALM_URL}`,
+      'Job 4 (create-pr-card) uses submissions realm concurrency group',
+    );
+    // Job 5: prCard link patch — user realm
+    assert.strictEqual(
+      (publishedJobs[4] as { concurrencyGroup: string }).concurrencyGroup,
+      'command:http://localhost:4201/test/',
+      'Job 5 (prCard link patch) uses default realm concurrency group',
     );
 
     assert.deepEqual(
-      (publishedJobs[1] as { args: Record<string, unknown> }).args,
+      (publishedJobs[3] as { args: Record<string, unknown> }).args,
       {
         realmURL: SUBMISSION_REALM_URL,
         realmUsername: SUBMISSION_BOT_USER_ID,
@@ -292,7 +316,7 @@ module('command runner', () => {
       'enqueues PR card creation in submissions realm',
     );
     assert.deepEqual(
-      (publishedJobs[2] as { args: Record<string, unknown> }).args,
+      (publishedJobs[4] as { args: Record<string, unknown> }).args,
       {
         realmURL: 'http://localhost:4201/test/',
         realmUsername: '@alice:localhost',
@@ -399,6 +423,7 @@ module('command runner', () => {
       dbAdapter,
       queuePublisher,
       githubClient,
+      passThroughLint,
     );
     await commandRunner.maybeEnqueueCommand(
       '@alice:localhost',
@@ -497,6 +522,7 @@ module('command runner', () => {
       dbAdapter,
       queuePublisher,
       githubClient,
+      passThroughLint,
     );
 
     await assert.rejects(
@@ -526,5 +552,184 @@ module('command runner', () => {
       'does not write files to branch',
     );
     assert.strictEqual(openedPRs.length, 0, 'does not open pull request');
+  });
+
+  test('patches prCreationError when create-pr-card fails after lint passes', async (assert) => {
+    let submissionCardUrl =
+      'http://localhost:4201/submissions/SubmissionWorkflowCard/abc-123';
+    let publishedJobs: Array<{
+      args: Record<string, unknown>;
+      concurrencyGroup: string;
+    }> = [];
+    let queuePublisher: QueuePublisher = {
+      publish: async (job: unknown) => {
+        let typedJob = job as {
+          args: Record<string, unknown>;
+          concurrencyGroup: string;
+        };
+        publishedJobs.push(typedJob);
+        // Job 1 (collect-files) → returns one file
+        // Jobs 2-3 (lintStatus patches: in-progress, passed) → ready
+        // Job 4 (create-pr-card in submissions realm) → error
+        // Job 5 (compensating prCreationError patch) → ready
+        let command =
+          (typedJob.args.command as string | undefined)?.toString() ?? '';
+        if (command.endsWith('/collect-submission-files/default')) {
+          return {
+            id: 1,
+            done: Promise.resolve({
+              status: 'ready',
+              cardResultString: JSON.stringify({
+                data: {
+                  id: submissionCardUrl,
+                  attributes: {
+                    allFileContents: [
+                      {
+                        filename: 'catalog/MyListing/listing.json',
+                        contents: '{"data":{"type":"card"}}',
+                      },
+                    ],
+                  },
+                },
+              }),
+            }),
+          } as any;
+        }
+        if (command.endsWith('/create-pr-card/default')) {
+          return {
+            id: 2,
+            done: Promise.resolve({
+              status: 'error',
+              error: 'boom: submissions realm worker exploded',
+            }),
+          } as any;
+        }
+        // patch-card-instance calls — always ready
+        return {
+          id: 3,
+          done: Promise.resolve({ status: 'ready', cardResultString: null }),
+        } as any;
+      },
+      destroy: async () => {},
+    };
+
+    let githubClient: GitHubClient = {
+      createBranch: async () => ({ ref: 'refs/heads/test', sha: 'abc123' }),
+      writeFileToBranch: async () => ({ commitSha: 'def456' }),
+      writeFilesToBranch: async () => ({ commitSha: 'def456' }),
+      openPullRequest: async () => ({
+        number: 1,
+        html_url: 'https://example/pr/1',
+      }),
+    };
+
+    let commandsByRegistrationId = new Map<
+      string,
+      Record<string, PgPrimitive>[]
+    >([
+      [
+        'bot-registration-5',
+        [
+          {
+            command_filter: {
+              type: 'matrix-event',
+              event_type: 'app.boxel.bot-trigger',
+              content_type: 'pr-listing-create',
+            },
+            command:
+              '@cardstack/catalog/commands/collect-submission-files/default',
+          },
+        ],
+      ],
+    ]);
+    let dbAdapter = {
+      kind: 'pg',
+      isClosed: false,
+      execute: async (sql: string, opts?: ExecuteOptions) => {
+        if (sql.includes('FROM bot_commands WHERE bot_id =')) {
+          let registrationId = opts?.bind?.[0];
+          if (typeof registrationId !== 'string') {
+            return [];
+          }
+          return commandsByRegistrationId.get(registrationId) ?? [];
+        }
+        return [];
+      },
+      close: async () => {},
+      getColumnNames: async () => [],
+    } as DBAdapter;
+
+    let commandRunner = new CommandRunner(
+      SUBMISSION_BOT_USER_ID,
+      dbAdapter,
+      queuePublisher,
+      githubClient,
+      passThroughLint,
+    );
+
+    await assert.rejects(
+      commandRunner.maybeEnqueueCommand(
+        '@alice:localhost',
+        {
+          type: 'pr-listing-create',
+          realm: 'http://localhost:4201/test/',
+          userId: '@alice:localhost',
+          input: {
+            roomId: '!abc123:localhost',
+            listingId: 'http://localhost:4201/test/Listing/1',
+            listingName: 'My Listing',
+            workflowCardUrl: submissionCardUrl,
+          },
+        },
+        'bot-registration-5',
+      ),
+      /boom: submissions realm worker exploded/,
+      'original create-pr-card error bubbles up',
+    );
+
+    // Expect 5 jobs: collect-files, lintStatus=in-progress, lintStatus=passed,
+    // create-pr-card (failed), and the compensating prCreationError patch.
+    assert.strictEqual(
+      publishedJobs.length,
+      5,
+      'enqueues collect, two lint patches, create-pr-card, and compensating prCreationError patch',
+    );
+
+    let lastJob = publishedJobs[publishedJobs.length - 1];
+    let lastArgs = lastJob.args as {
+      command: string;
+      commandInput: {
+        cardId: string;
+        patch: { attributes: Record<string, unknown> };
+      };
+    };
+    assert.strictEqual(
+      lastArgs.command,
+      '@cardstack/boxel-host/commands/patch-card-instance/default',
+      'compensating patch uses patch-card-instance',
+    );
+    assert.strictEqual(
+      lastArgs.commandInput.cardId,
+      submissionCardUrl,
+      'compensating patch targets the workflow card',
+    );
+    assert.strictEqual(
+      typeof lastArgs.commandInput.patch.attributes.prCreationError,
+      'string',
+      'compensating patch writes prCreationError',
+    );
+    assert.ok(
+      (lastArgs.commandInput.patch.attributes.prCreationError as string)
+        .startsWith('PR creation failed:'),
+      `prCreationError message is prefixed: ${lastArgs.commandInput.patch.attributes.prCreationError}`,
+    );
+    assert.notOk(
+      'lintStatus' in lastArgs.commandInput.patch.attributes,
+      'compensating patch does NOT touch lintStatus',
+    );
+    assert.notOk(
+      'lintErrors' in lastArgs.commandInput.patch.attributes,
+      'compensating patch does NOT touch lintErrors',
+    );
   });
 });

--- a/packages/bot-runner/tests/index.ts
+++ b/packages/bot-runner/tests/index.ts
@@ -2,3 +2,4 @@ import '../setup-logger';
 import './bot-runner-test';
 import './command-runner-test';
 import './create-listing-pr-handler-test';
+import './lint-runner-test';

--- a/packages/bot-runner/tests/lint-runner-test.ts
+++ b/packages/bot-runner/tests/lint-runner-test.ts
@@ -1,0 +1,204 @@
+import { module, test } from 'qunit';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  parseTscOutput,
+  parseTemplateLintOutput,
+  sanitizeRelativePath,
+} from '@cardstack/runtime-common/lint/submission-lint';
+
+module('lint-runner | sanitizeRelativePath', () => {
+  let tempDir = path.join(os.tmpdir(), 'sub-test-dir');
+
+  test('accepts nested relative path', (assert) => {
+    let rel = sanitizeRelativePath('CardListing/foo.json', tempDir);
+    assert.strictEqual(rel, path.join('CardListing', 'foo.json'));
+  });
+
+  test('rejects absolute paths', (assert) => {
+    assert.throws(
+      () => sanitizeRelativePath('/etc/passwd', tempDir),
+      /absolute/,
+    );
+  });
+
+  test('rejects ".." segments', (assert) => {
+    assert.throws(() => sanitizeRelativePath('foo/../../bar', tempDir), /\.\./);
+  });
+
+  test('rejects null byte', (assert) => {
+    assert.throws(() => sanitizeRelativePath('ok\0.gts', tempDir), /null byte/);
+  });
+
+  test('rejects control characters', (assert) => {
+    assert.throws(
+      () => sanitizeRelativePath('ok\x07.gts', tempDir),
+      /control characters/,
+    );
+  });
+
+  test('rejects empty filename', (assert) => {
+    assert.throws(() => sanitizeRelativePath('', tempDir), /required/);
+  });
+});
+
+module('lint-runner | parseTscOutput', () => {
+  // Matches what runtime passes: path.relative(HOST_DIR, tempDir) has NO
+  // trailing slash, so the parser must tolerate that shape.
+  let runtimePrefix = '../catalog-realm/__submissions-temp__/x';
+
+  test('returns empty array for empty output', (assert) => {
+    assert.deepEqual(parseTscOutput('', runtimePrefix), []);
+  });
+
+  test('filters to errors inside submission temp path', (assert) => {
+    let output = [
+      '../catalog-realm/__submissions-temp__/x/foo.gts(17,1): error TS6133: unused import',
+      '../catalog-realm/todo.gts(117,47): error TS2345: unrelated existing error',
+      '../catalog-realm/__submissions-temp__/x/sub/bar.gts(3,2): error TS2322: Type mismatch',
+    ].join('\n');
+    let errors = parseTscOutput(output, runtimePrefix);
+    assert.strictEqual(errors.length, 2);
+    assert.ok(errors[0].startsWith('foo.gts (17:1)'), errors[0]);
+    assert.ok(errors[1].startsWith('sub/bar.gts (3:2)'), errors[1]);
+    assert.ok(errors[0].includes('TS6133'), errors[0]);
+  });
+
+  test('strips prefix cleanly when it has no trailing slash (regression)', (assert) => {
+    // Regression guard: `split(prefix)[1]` used to leave a leading "/" on
+    // the display path when the prefix didn't end with a slash.
+    let output =
+      '../catalog-realm/__submissions-temp__/x/foo.gts(1,1): error TS1: msg';
+    let errors = parseTscOutput(output, runtimePrefix);
+    assert.strictEqual(errors.length, 1);
+    assert.notOk(errors[0].startsWith('/'), `no leading slash: ${errors[0]}`);
+    assert.ok(errors[0].startsWith('foo.gts '), errors[0]);
+  });
+
+  test('also works when prefix is passed with a trailing slash', (assert) => {
+    let output =
+      '../catalog-realm/__submissions-temp__/x/foo.gts(1,1): error TS1: msg';
+    let errors = parseTscOutput(
+      output,
+      '../catalog-realm/__submissions-temp__/x/',
+    );
+    assert.strictEqual(errors.length, 1);
+    assert.ok(errors[0].startsWith('foo.gts '), errors[0]);
+  });
+
+  test('ignores warnings', (assert) => {
+    let output =
+      '../catalog-realm/__submissions-temp__/x/foo.gts(1,1): warning TS6133: meh';
+    let errors = parseTscOutput(output, runtimePrefix);
+    assert.strictEqual(errors.length, 0);
+  });
+
+  test('ignores non-diagnostic noise lines', (assert) => {
+    let output = [
+      'random log line',
+      'Compiled',
+      '../catalog-realm/__submissions-temp__/x/a.gts(2,3): error TS1234: msg',
+    ].join('\n');
+    let errors = parseTscOutput(output, runtimePrefix);
+    assert.strictEqual(errors.length, 1);
+  });
+});
+
+module('lint-runner | parseTemplateLintOutput', () => {
+  // Simulate realistic runtime inputs: linter cwd is catalog-realm; tempDir
+  // is catalog-realm/__submissions-temp__/<runId>/; JSON keys are relative
+  // to the linter's cwd, so they include the __submissions-temp__ prefix.
+  let catalogRealm = path.join(os.tmpdir(), 'catalog-realm');
+  let tempDir = path.join(catalogRealm, '__submissions-temp__', 'abc');
+
+  test('returns empty array for empty output', (assert) => {
+    assert.deepEqual(parseTemplateLintOutput('', tempDir, catalogRealm), []);
+  });
+
+  test('returns empty array for invalid JSON', (assert) => {
+    assert.deepEqual(
+      parseTemplateLintOutput('not json', tempDir, catalogRealm),
+      [],
+    );
+  });
+
+  test('resolves paths relative to linter cwd, not tempDir (regression)', (assert) => {
+    // ember-template-lint emits keys relative to its cwd (catalog-realm).
+    // Without the linterCwd arg, we used to double-prefix the tempDir.
+    let json = JSON.stringify({
+      '__submissions-temp__/abc/foo/bar.hbs': [
+        {
+          rule: 'no-invalid-role',
+          severity: 2,
+          line: 10,
+          column: 5,
+          message: 'invalid role',
+        },
+      ],
+    });
+    let errors = parseTemplateLintOutput(json, tempDir, catalogRealm);
+    assert.strictEqual(errors.length, 1);
+    assert.ok(errors[0].startsWith('foo/bar.hbs '), errors[0]);
+    assert.notOk(
+      errors[0].includes('__submissions-temp__'),
+      `no temp-dir leak: ${errors[0]}`,
+    );
+  });
+
+  test('ignores severity-1 warnings', (assert) => {
+    let json = JSON.stringify({
+      '__submissions-temp__/abc/foo.hbs': [
+        {
+          rule: 'style-warning',
+          severity: 1,
+          line: 1,
+          column: 1,
+          message: 'just a warning',
+        },
+      ],
+    });
+    let errors = parseTemplateLintOutput(json, tempDir, catalogRealm);
+    assert.strictEqual(errors.length, 0);
+  });
+
+  test('handles empty messages array', (assert) => {
+    let json = JSON.stringify({ '__submissions-temp__/abc/foo.hbs': [] });
+    assert.deepEqual(
+      parseTemplateLintOutput(json, tempDir, catalogRealm),
+      [],
+    );
+  });
+
+  test('handles multiple files', (assert) => {
+    let json = JSON.stringify({
+      '__submissions-temp__/abc/a.hbs': [
+        { rule: 'r1', severity: 2, line: 1, column: 1, message: 'm1' },
+      ],
+      '__submissions-temp__/abc/sub/b.hbs': [
+        { rule: 'r2', severity: 2, line: 2, column: 2, message: 'm2' },
+      ],
+    });
+    let errors = parseTemplateLintOutput(json, tempDir, catalogRealm);
+    assert.strictEqual(errors.length, 2);
+    assert.ok(
+      errors.some((e) => e.startsWith('a.hbs ')),
+      errors.join(' | '),
+    );
+    assert.ok(
+      errors.some((e) => e.startsWith('sub/b.hbs ')),
+      errors.join(' | '),
+    );
+  });
+
+  test('handles absolute paths from linter (fallback)', (assert) => {
+    // Some lint configurations emit absolute paths. Verify we still compute
+    // a sensible display path.
+    let abs = path.join(tempDir, 'foo.hbs');
+    let json = JSON.stringify({
+      [abs]: [{ rule: 'r', severity: 2, line: 1, column: 1, message: 'm' }],
+    });
+    let errors = parseTemplateLintOutput(json, tempDir, catalogRealm);
+    assert.strictEqual(errors.length, 1);
+    assert.ok(errors[0].startsWith('foo.hbs '), errors[0]);
+  });
+});

--- a/packages/catalog-realm/.gitignore
+++ b/packages/catalog-realm/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+__submissions-temp__/

--- a/packages/catalog-realm/submission-workflow-card/submission-workflow-card.gts
+++ b/packages/catalog-realm/submission-workflow-card/submission-workflow-card.gts
@@ -9,6 +9,7 @@ import {
   realmURL,
 } from 'https://cardstack.com/base/card-api';
 import StringField from 'https://cardstack.com/base/string';
+import NumberField from 'https://cardstack.com/base/number';
 import { concat } from '@ember/helper';
 import { htmlSafe } from '@ember/template';
 import { eq } from '@cardstack/boxel-ui/helpers';
@@ -63,8 +64,9 @@ const STEP_DEFINITIONS = [
   },
   {
     key: 'create-pr',
-    label: 'Create PR & PR Card',
-    description: 'Create a GitHub pull request with the listing files',
+    label: 'Lint & Create PR',
+    description:
+      'Lint files, auto-fix issues, and create a GitHub pull request',
   },
   {
     key: 'ci-checks',
@@ -96,6 +98,9 @@ function resolveSubmissionWorkflowState(
   reviewState: string | null,
   isMerged: boolean,
   isClosed: boolean,
+  lintStatus: string | null,
+  lintErrors: string[],
+  prCreationError: string | null,
 ): WorkflowState {
   let steps: ResolvedStep[] = [];
   let firstIncomplete = -1;
@@ -113,6 +118,19 @@ function resolveSubmissionWorkflowState(
         break;
       case 'create-pr':
         completed = hasPr;
+        if (!hasPr && lintStatus === 'in-progress') {
+          inProgress = true;
+          statusDetail = 'Linting files...';
+        } else if (!hasPr && lintStatus === 'failed') {
+          blocked = true;
+          statusDetail = `${lintErrors.length} unfixable lint error${lintErrors.length === 1 ? '' : 's'}`;
+        } else if (!hasPr && prCreationError) {
+          blocked = true;
+          statusDetail = 'PR creation failed';
+        } else if (!hasPr && lintStatus === 'passed') {
+          inProgress = true;
+          statusDetail = 'Creating PR...';
+        }
         break;
       case 'ci-checks':
         completed = hasPr && ciAllPassed;
@@ -259,6 +277,13 @@ export class SubmissionWorkflowCard extends CardDef {
   // ── Links to real cards ──
   @field listing = linksTo(() => Listing);
   @field prCard = linksTo(() => PrCard);
+
+  // ── Lint status ──
+  @field lintStatus = contains(StringField); // 'pending' | 'in-progress' | 'passed' | 'failed'
+  @field lintErrors = containsMany(StringField);
+  @field lintFixedCount = contains(NumberField);
+
+  @field prCreationError = contains(StringField);
 
   // ── Participants ──
   @field participants = containsMany(SubmissionParticipantField);
@@ -422,9 +447,10 @@ export class SubmissionWorkflowCard extends CardDef {
 
     get ciIsLoading() {
       return (
-        this.checkRunEventData?.isLoading ||
-        this.checkSuiteEventData?.isLoading
-      ) ?? false;
+        (this.checkRunEventData?.isLoading ||
+          this.checkSuiteEventData?.isLoading) ??
+        false
+      );
     }
 
     // ── Review state ──
@@ -451,6 +477,9 @@ export class SubmissionWorkflowCard extends CardDef {
         this.reviewState,
         this.isMerged,
         this.isClosed,
+        this.args.model.lintStatus ?? null,
+        this.args.model.lintErrors ?? [],
+        this.args.model.prCreationError ?? null,
       );
     }
 
@@ -503,7 +532,7 @@ export class SubmissionWorkflowCard extends CardDef {
 
           {{! ── Step tracker ── }}
           <div class='sw-steps'>
-            {{#each this.workflowState.steps key="key" as |step idx|}}
+            {{#each this.workflowState.steps key='key' as |step idx|}}
               <div class={{concat 'sw-step ' step.status}}>
                 <div class='sw-step-indicator'>
                   {{#if (eq step.status 'completed')}}
@@ -577,6 +606,33 @@ export class SubmissionWorkflowCard extends CardDef {
                   {{/if}}
 
                   {{#if (eq step.key 'create-pr')}}
+                    {{#if (eq @model.lintStatus 'failed')}}
+                      <div class='sw-step-detail sw-lint-errors'>
+                        <div class='sw-lint-header'>Unfixable Lint Errors</div>
+                        {{#each @model.lintErrors as |err|}}
+                          <div class='sw-lint-error-line'>{{err}}</div>
+                        {{/each}}
+                      </div>
+                    {{/if}}
+                    {{#if @model.prCreationError}}
+                      <div class='sw-step-detail sw-lint-errors'>
+                        <div class='sw-lint-header'>PR Creation Failed</div>
+                        <div class='sw-lint-error-line'>
+                          {{@model.prCreationError}}
+                        </div>
+                      </div>
+                    {{/if}}
+                    {{#if (eq @model.lintStatus 'passed')}}
+                      {{#if @model.lintFixedCount}}
+                        <div class='sw-step-detail sw-lint-info'>
+                          Auto-fixed
+                          {{@model.lintFixedCount}}
+                          file{{#if
+                            (eq @model.lintFixedCount 1)
+                          }}{{else}}s{{/if}}
+                        </div>
+                      {{/if}}
+                    {{/if}}
                     {{#if @model.prCard}}
                       <div class='sw-step-detail sw-embedded-card-container'>
                         <@fields.prCard @format='embedded' />
@@ -611,7 +667,9 @@ export class SubmissionWorkflowCard extends CardDef {
           <div class='sw-progress-section'>
             <div
               class={{concat 'sw-donut ' this.overallStatusTone}}
-              style={{htmlSafe (concat '--pct:' this.workflowState.progressPercent ';')}}
+              style={{htmlSafe
+                (concat '--pct:' this.workflowState.progressPercent ';')
+              }}
             >
               <span
                 class='sw-donut-pct'
@@ -623,7 +681,7 @@ export class SubmissionWorkflowCard extends CardDef {
           {{! Step summary }}
           <div class='sw-sidebar-section'>
             <div class='sw-sidebar-heading'>Steps</div>
-            {{#each this.workflowState.steps key="key" as |step|}}
+            {{#each this.workflowState.steps key='key' as |step|}}
               <div class={{concat 'sw-sidebar-step ' step.status}}>
                 {{#if (eq step.status 'completed')}}
                   <span class='sw-sidebar-icon completed'>
@@ -984,6 +1042,34 @@ export class SubmissionWorkflowCard extends CardDef {
           overflow: hidden;
           border: 1px solid var(--c-border);
           box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+        }
+
+        .sw-lint-errors {
+          background: rgba(239, 68, 68, 0.06);
+          border: 1px solid rgba(239, 68, 68, 0.2);
+          border-radius: 8px;
+          padding: 10px 12px;
+        }
+        .sw-lint-header {
+          font-size: 11px;
+          font-weight: 700;
+          color: var(--c-danger);
+          margin-bottom: 6px;
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+        }
+        .sw-lint-error-line {
+          font-size: 12px;
+          font-family: ui-monospace, 'SF Mono', 'Cascadia Code', monospace;
+          color: var(--c-text);
+          line-height: 1.5;
+          padding: 2px 0;
+          word-break: break-word;
+        }
+        .sw-lint-info {
+          font-size: 12px;
+          color: var(--c-success);
+          font-weight: 600;
         }
 
         /* ── Sidebar ── */

--- a/packages/host/app/commands/lint-and-fix.ts
+++ b/packages/host/app/commands/lint-and-fix.ts
@@ -5,7 +5,10 @@ import { SupportedMimeType } from '@cardstack/runtime-common';
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import HostBaseCommand from '../lib/host-base-command';
-import { formatLintIssues } from '../utils/lint-formatting';
+import {
+  formatLintIssues,
+  formatLintIssuesBySeverity,
+} from '../utils/lint-formatting';
 
 import type NetworkService from '../services/network';
 
@@ -42,9 +45,12 @@ export default class LintAndFixCommand extends HostBaseCommand<
     });
     if (response.status === 200) {
       let result = await response.json();
+      let { errors, warnings } = formatLintIssuesBySeverity(result?.messages);
       return new LintAndFixResult({
         output: result.output,
         lintIssues: formatLintIssues(result?.messages),
+        lintErrors: errors,
+        lintWarnings: warnings,
       });
     }
     let result = await response.json();

--- a/packages/host/app/utils/lint-formatting.ts
+++ b/packages/host/app/utils/lint-formatting.ts
@@ -35,3 +35,23 @@ export function formatLintIssues(
   }
   return messages.map((message) => formatLintIssue(message)).filter(Boolean);
 }
+
+export function formatLintIssuesBySeverity(
+  messages: LintResult['messages'] | undefined,
+): { errors: string[]; warnings: string[] } {
+  if (!Array.isArray(messages)) {
+    return { errors: [], warnings: [] };
+  }
+  let errors: string[] = [];
+  let warnings: string[] = [];
+  for (let message of messages) {
+    let formatted = formatLintIssue(message);
+    if (!formatted) continue;
+    if (message.severity === 2) {
+      errors.push(formatted);
+    } else {
+      warnings.push(formatted);
+    }
+  }
+  return { errors, warnings };
+}

--- a/packages/runtime-common/lint/submission-lint.ts
+++ b/packages/runtime-common/lint/submission-lint.ts
@@ -1,0 +1,412 @@
+import { spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+import { logger } from '../log';
+
+if (typeof (globalThis as any).document !== 'undefined') {
+  throw new Error(
+    'submission-lint can only run in Node (not browser/fastboot)',
+  );
+}
+
+const log = logger('submission-lint');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const CATALOG_REALM_DIR = path.join(REPO_ROOT, 'packages', 'catalog-realm');
+const HOST_DIR = path.join(REPO_ROOT, 'packages', 'host');
+export const SUBMISSIONS_TEMP_ROOT = path.join(
+  CATALOG_REALM_DIR,
+  '__submissions-temp__',
+);
+const TEMPLATE_LINT_BIN = path.join(
+  CATALOG_REALM_DIR,
+  'node_modules',
+  '.bin',
+  'ember-template-lint',
+);
+const EMBER_TSC_BIN = path.join(HOST_DIR, 'node_modules', '.bin', 'ember-tsc');
+
+const TEMPLATE_LINT_EXTENSIONS = ['.hbs', '.gts', '.gjs'];
+const TSC_EXTENSIONS = ['.ts', '.gts'];
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+const MAX_FILE_COUNT = 500;
+
+const SPAWN_TIMEOUT_MS = 120_000;
+
+export interface SubmissionFile {
+  filename: string;
+  contents: string;
+}
+
+export interface LintOutcome {
+  passed: boolean;
+  fixedFiles: SubmissionFile[];
+  lintErrors: string[];
+  fixedFileCount: number;
+}
+
+interface TemplateLintMessage {
+  rule?: string;
+  severity?: number;
+  line?: number;
+  column?: number;
+  message?: string;
+}
+
+export function sanitizeRelativePath(
+  filename: string,
+  tempDir: string,
+): string {
+  if (!filename || typeof filename !== 'string') {
+    throw new Error('filename is required');
+  }
+  if (filename.includes('\0')) {
+    throw new Error(`filename contains null byte: ${filename}`);
+  }
+  for (let i = 0; i < filename.length; i++) {
+    if (filename.charCodeAt(i) < 0x20) {
+      throw new Error(`filename contains control characters: ${filename}`);
+    }
+  }
+  if (path.isAbsolute(filename)) {
+    throw new Error(`filename must not be absolute: ${filename}`);
+  }
+  if (filename.split(/[\\/]/).some((seg) => seg === '..')) {
+    throw new Error(`filename must not contain ..: ${filename}`);
+  }
+  let resolved = path.resolve(tempDir, filename);
+  let anchor = tempDir.endsWith(path.sep) ? tempDir : tempDir + path.sep;
+  if (!resolved.startsWith(anchor)) {
+    throw new Error(`filename escapes temp dir: ${filename}`);
+  }
+  return path.relative(tempDir, resolved);
+}
+
+export function parseTscOutput(
+  output: string,
+  submissionPathPrefix: string,
+): string[] {
+  let errors: string[] = [];
+  // Normalize the prefix: forward slashes, strip any trailing slash so we can
+  // match whether the caller passed a trailing slash or not.
+  let prefix = submissionPathPrefix.replace(/\\/g, '/').replace(/\/+$/, '');
+  if (!prefix) return errors;
+  for (let rawLine of output.split(/\r?\n/)) {
+    let line = rawLine.trim();
+    if (!line) continue;
+    let match = line.match(
+      /^(.+?)\((\d+),(\d+)\):\s+(error|warning)\s+(TS\d+):\s*(.*)$/,
+    );
+    if (!match) continue;
+    let [, filePath, ln, col, level, code, message] = match;
+    if (level !== 'error') continue;
+    let normalizedPath = filePath.replace(/\\/g, '/');
+    let idx = normalizedPath.indexOf(prefix);
+    if (idx < 0) continue;
+    // Drop the prefix and any leading slash so display is always clean,
+    // regardless of whether the caller passed a trailing slash.
+    let displayPath = normalizedPath
+      .slice(idx + prefix.length)
+      .replace(/^\/+/, '');
+    if (!displayPath) continue;
+    errors.push(`${displayPath} (${ln}:${col}) ${code}: ${message}`);
+  }
+  return errors;
+}
+
+export function parseTemplateLintOutput(
+  stdout: string,
+  tempDir: string,
+  linterCwd: string,
+): string[] {
+  let trimmed = stdout.trim();
+  if (!trimmed) return [];
+  let parsed: Record<string, TemplateLintMessage[]>;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== 'object') return [];
+  // ember-template-lint emits keys relative to *its* cwd (the dir where we
+  // spawned it), not to the submission's temp dir. Resolve against the linter
+  // cwd, then compute the display path relative to tempDir so the user sees
+  // just `foo/bar.hbs` instead of `__submissions-temp__/<uuid>/foo/bar.hbs`.
+  let errors: string[] = [];
+  for (let [filePath, messages] of Object.entries(parsed)) {
+    if (!Array.isArray(messages)) continue;
+    let absolute = path.isAbsolute(filePath)
+      ? filePath
+      : path.resolve(linterCwd, filePath);
+    let relDisplay = path.relative(tempDir, absolute).replace(/\\/g, '/');
+    for (let msg of messages) {
+      if (msg.severity !== 2) continue;
+      let line = typeof msg.line === 'number' ? msg.line : 0;
+      let col = typeof msg.column === 'number' ? msg.column : 0;
+      let rule = msg.rule ?? 'unknown';
+      let text = msg.message ?? '';
+      errors.push(`${relDisplay} (${line}:${col}) ${rule}: ${text}`);
+    }
+  }
+  return errors;
+}
+
+export async function runLintOnSubmissionFiles(
+  files: SubmissionFile[],
+  opts: { roomId: string; listingId: string },
+): Promise<LintOutcome> {
+  let passthroughFiles = files.map((f) => ({
+    filename: f.filename,
+    contents: f.contents ?? '',
+  }));
+  let hasLintable = files.some((f) => {
+    let lower = (f.filename ?? '').toLowerCase();
+    return (
+      TEMPLATE_LINT_EXTENSIONS.some((ext) => lower.endsWith(ext)) ||
+      TSC_EXTENSIONS.some((ext) => lower.endsWith(ext))
+    );
+  });
+  if (files.length === 0 || !hasLintable) {
+    return {
+      passed: true,
+      fixedFiles: passthroughFiles,
+      lintErrors: [],
+      fixedFileCount: 0,
+    };
+  }
+  if (files.length > MAX_FILE_COUNT) {
+    throw new Error(
+      `Too many submission files (${files.length} > ${MAX_FILE_COUNT})`,
+    );
+  }
+  let runId = `${sanitizeIdSegment(opts.roomId)}-${sanitizeIdSegment(
+    opts.listingId,
+  )}-${crypto.randomUUID()}`;
+  let tempDir = path.join(SUBMISSIONS_TEMP_ROOT, runId);
+  let tempRelFromCatalog = path.relative(CATALOG_REALM_DIR, tempDir);
+  let tempRelFromHost = path.relative(HOST_DIR, tempDir).replace(/\\/g, '/');
+
+  let relPaths: string[] = [];
+  try {
+    await fs.mkdir(tempDir, { recursive: true });
+    for (let file of files) {
+      let relPath = sanitizeRelativePath(file.filename, tempDir);
+      let contents = file.contents ?? '';
+      if (Buffer.byteLength(contents, 'utf8') > MAX_FILE_SIZE_BYTES) {
+        throw new Error(
+          `File exceeds ${MAX_FILE_SIZE_BYTES} bytes: ${file.filename}`,
+        );
+      }
+      let absPath = path.join(tempDir, relPath);
+      await fs.mkdir(path.dirname(absPath), { recursive: true });
+      await fs.writeFile(absPath, contents, 'utf8');
+      relPaths.push(relPath);
+    }
+
+    let templateLintErrors = await runTemplateLint(
+      relPaths,
+      tempDir,
+      tempRelFromCatalog,
+    );
+    let hasTscFiles = relPaths.some((p) =>
+      TSC_EXTENSIONS.some((ext) => p.toLowerCase().endsWith(ext)),
+    );
+    let tscErrors = hasTscFiles ? await runEmberTsc(tempRelFromHost) : [];
+
+    let fixedFiles: SubmissionFile[] = [];
+    let fixedFileCount = 0;
+    for (let i = 0; i < files.length; i++) {
+      let original = files[i];
+      let relPath = relPaths[i];
+      let absPath = path.join(tempDir, relPath);
+      let fixedContents: string;
+      try {
+        fixedContents = await fs.readFile(absPath, 'utf8');
+      } catch (err: any) {
+        log.warn('Could not read back submission file', {
+          file: original.filename,
+          err: err?.message,
+        });
+        fixedContents = original.contents ?? '';
+      }
+      if (fixedContents !== (original.contents ?? '')) {
+        fixedFileCount++;
+      }
+      fixedFiles.push({
+        filename: original.filename,
+        contents: fixedContents,
+      });
+    }
+
+    let lintErrors = [...templateLintErrors, ...tscErrors];
+    let outcome: LintOutcome = {
+      passed: lintErrors.length === 0,
+      fixedFiles,
+      lintErrors,
+      fixedFileCount,
+    };
+    log.info('Lint complete', {
+      runId,
+      totalFiles: files.length,
+      fixedFileCount,
+      templateLintErrorCount: templateLintErrors.length,
+      tscErrorCount: tscErrors.length,
+      passed: outcome.passed,
+    });
+    return outcome;
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch((err) => {
+      log.warn('Failed to clean up submission temp dir', {
+        tempDir,
+        err: err?.message,
+      });
+    });
+  }
+}
+
+async function runTemplateLint(
+  relPaths: string[],
+  tempDir: string,
+  tempRelFromCatalog: string,
+): Promise<string[]> {
+  let templateFiles = relPaths.filter((p) =>
+    TEMPLATE_LINT_EXTENSIONS.some((ext) => p.toLowerCase().endsWith(ext)),
+  );
+  if (templateFiles.length === 0) return [];
+
+  let args = [
+    '--fix',
+    '--format',
+    'json',
+    '--no-error-on-unmatched-pattern',
+    ...templateFiles.map((rel) =>
+      path.join(tempRelFromCatalog, rel).replace(/\\/g, '/'),
+    ),
+  ];
+  let { stdout, stderr, code } = await spawnCapture(
+    TEMPLATE_LINT_BIN,
+    args,
+    CATALOG_REALM_DIR,
+  );
+  // ember-template-lint: 0 = clean, 1 = lint errors present (with --format
+  // json, stdout still contains the JSON report). Anything else (crash,
+  // bad args, null from signal) is a hard failure — don't let silent
+  // failure let a bad submission sail through.
+  if (code !== 0 && code !== 1) {
+    throw new Error(
+      `ember-template-lint exited with unexpected code ${code}: ${stderr.slice(0, 500)}`,
+    );
+  }
+  return parseTemplateLintOutput(stdout, tempDir, CATALOG_REALM_DIR);
+}
+
+async function runEmberTsc(tempRelFromHost: string): Promise<string[]> {
+  let args = ['--noEmit'];
+  let { stdout, stderr, code } = await spawnCapture(
+    EMBER_TSC_BIN,
+    args,
+    HOST_DIR,
+  );
+  if (code === 0) return [];
+  // tsc exits 1 when it reports type errors, 2 for "fatal" diagnostics.
+  // Anything outside {0,1,2} (e.g. null from a signal, or a much larger
+  // code from a crash) means the type-check didn't run to completion —
+  // treat as a hard failure so we don't ship a bad submission.
+  if (code !== 1 && code !== 2) {
+    throw new Error(
+      `ember-tsc exited with unexpected code ${code}: ${stderr.slice(0, 500)}`,
+    );
+  }
+  let combined = `${stdout}\n${stderr}`;
+  return parseTscOutput(combined, tempRelFromHost);
+}
+
+interface ReadableLike {
+  on(
+    event: 'data',
+    listener: (chunk: { toString(encoding: string): string }) => void,
+  ): unknown;
+}
+
+interface ChildProcessLike {
+  stdout: ReadableLike;
+  stderr: ReadableLike;
+  on(event: 'error', listener: (err: Error) => void): unknown;
+  on(event: 'close', listener: (code: number | null) => void): unknown;
+  kill(signal?: string): boolean;
+}
+
+async function spawnCapture(
+  bin: string,
+  args: string[],
+  cwd: string,
+  timeoutMs: number = SPAWN_TIMEOUT_MS,
+): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  return new Promise((resolve, reject) => {
+    let child = spawn(bin, args, {
+      cwd,
+      shell: false,
+    }) as unknown as ChildProcessLike;
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    // Kill-on-timeout so a hung child-process can't stall the bot-runner
+    // indefinitely. SIGTERM first, then SIGKILL if it ignores SIGTERM.
+    let timer = setTimeout(() => {
+      if (settled) return;
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // ignore — may already be dead
+      }
+      // Give it 5s to shut down gracefully, then force-kill.
+      setTimeout(() => {
+        if (settled) return;
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          // ignore
+        }
+      }, 5_000);
+      settle(
+        null,
+        new Error(
+          `command timed out after ${timeoutMs}ms: ${bin} ${args.join(' ')}`,
+        ),
+      );
+    }, timeoutMs);
+
+    let settle = (
+      result: { stdout: string; stderr: string; code: number | null } | null,
+      err: Error | null,
+    ) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (err) reject(err);
+      else if (result) resolve(result);
+    };
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString('utf8');
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString('utf8');
+    });
+    child.on('error', (err: Error) => settle(null, err));
+    child.on('close', (code: number | null) => {
+      settle({ stdout, stderr, code }, null);
+    });
+  });
+}
+
+function sanitizeIdSegment(s: string): string {
+  return (s || 'unknown').replace(/[^A-Za-z0-9_.-]/g, '_').slice(0, 40);
+}
+
+export async function cleanupOrphanedSubmissionTemps(): Promise<void> {
+  await fs
+    .rm(SUBMISSIONS_TEMP_ROOT, { recursive: true, force: true })
+    .catch(() => {});
+}


### PR DESCRIPTION
### Summary
Adds a new pre-PR lint step to the submission (pr-listing-create) workflow so that submissions are validated against the same tooling CI uses (ember-template-lint + ember-tsc --noEmit) before a PR is opened. If a submission has unfixable lint errors, PR creation is blocked and the workflow card shows the failure to the user inline.

Previously the submission bot went straight from "collect files" → "create PR card" with no validation. Now the flow is "collect files → lint → create PR card", and lint results feed both the block/allow decision and the workflow-card UI.

**Screenshot**
With this submission linter, it can do the same linting as boxel-catalog CI and giving the same result

From submission
<img width="1502" height="745" alt="Screenshot 2026-04-20 at 3 35 10 PM" src="https://github.com/user-attachments/assets/8a1546be-9e18-42bd-8e86-cee69404451a" />
Example if linting from Github CI Lint
<img width="1086" height="205" alt="Screenshot 2026-04-20 at 2 44 52 PM" src="https://github.com/user-attachments/assets/361cb36f-f9b3-41f4-add5-945f2e29b19c" />


**Background**
The submission flow hands a set of catalog files to the bot, which opens a PR against boxel-catalog. CI there runs pnpm run lint in packages/host, which type-checks catalog-realm files (via host's tsconfig.json include: ["../catalog-realm/**/*"]) and template-lints them. A submission that didn't compile under those tools could sail through the bot and fail CI after the PR was already open — no early feedback for the user.

We deliberately don't route this through the existing _lint realm endpoint:

_lint is per-file and has a 10s budget tuned for the code-editor "Format with Boxel" action and AI patch-code flows.
ember-tsc on the host package is 10–30s — it needs the whole package, not one file.
_lint auto-formats via Prettier; the batch flow intentionally doesn't.
So the editor path (_lint) and the submission batch path co-exist — each serves its own use case.