### PR TITLE
Coalesce concurrent #restartBrowser callers

### DIFF
--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -269,29 +269,19 @@ export class PagePool {
         // best effort
       }
     }
-    // Snapshot and clear state up-front so a concurrent caller (or anyone
-    // iterating the pool while we close) sees an empty pool and doesn't try
-    // to close the same BrowserContext twice. Without this, two concurrent
-    // closeAll calls race on the same entries and the second caller hits
-    // "Failed to find context with id <X>" when its context.close() arrives
-    // after the first caller already disposed the context.
-    let poolEntries: PoolEntry[] = [];
     for (let entries of this.#affinityPages.values()) {
       for (let entry of entries) {
-        poolEntries.push(entry);
+        await this.#closeEntry(entry);
       }
     }
-    let standbys = [...this.#standbys.values()];
+    for (let entry of this.#standbys.values()) {
+      await this.#closeEntry(entry);
+    }
     this.#affinityPages.clear();
     this.#standbys.clear();
     this.#lru.clear();
+    this.#ensuringStandbys = null;
     this.#creatingStandbys = 0;
-    for (let entry of poolEntries) {
-      await this.#closeEntry(entry);
-    }
-    for (let entry of standbys) {
-      await this.#closeEntry(entry);
-    }
   }
 
   async #ensureStandbyPool(): Promise<void> {

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -269,19 +269,29 @@ export class PagePool {
         // best effort
       }
     }
+    // Snapshot and clear state up-front so a concurrent caller (or anyone
+    // iterating the pool while we close) sees an empty pool and doesn't try
+    // to close the same BrowserContext twice. Without this, two concurrent
+    // closeAll calls race on the same entries and the second caller hits
+    // "Failed to find context with id <X>" when its context.close() arrives
+    // after the first caller already disposed the context.
+    let poolEntries: PoolEntry[] = [];
     for (let entries of this.#affinityPages.values()) {
       for (let entry of entries) {
-        await this.#closeEntry(entry);
+        poolEntries.push(entry);
       }
     }
-    for (let entry of this.#standbys.values()) {
-      await this.#closeEntry(entry);
-    }
+    let standbys = [...this.#standbys.values()];
     this.#affinityPages.clear();
     this.#standbys.clear();
     this.#lru.clear();
-    this.#ensuringStandbys = null;
     this.#creatingStandbys = 0;
+    for (let entry of poolEntries) {
+      await this.#closeEntry(entry);
+    }
+    for (let entry of standbys) {
+      await this.#closeEntry(entry);
+    }
   }
 
   async #ensureStandbyPool(): Promise<void> {

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -65,6 +65,7 @@ export class Prerenderer {
   #cleanupInterval: NodeJS.Timeout | undefined;
   #affinityIdleEvictMs: number;
   #semaphore: AsyncSemaphore;
+  #restartInFlight: Promise<void> | null = null;
 
   constructor(options: { serverURL: string; maxPages?: number }) {
     let maxPages = options.maxPages ?? 4;
@@ -397,6 +398,23 @@ export class Prerenderer {
   }
 
   async #restartBrowser(): Promise<void> {
+    // Coalesce concurrent callers onto a single in-flight restart. Without
+    // this, multiple failing visits in the same tick each trigger their own
+    // closeAll + browser.close, which race on the same BrowserContexts and
+    // produce "Failed to find context with id <X>" CDP errors as the second
+    // caller tries to dispose contexts the first already disposed. Sharing
+    // the promise also avoids redundantly tearing down + re-warming the
+    // standby pool.
+    if (this.#restartInFlight) {
+      return this.#restartInFlight;
+    }
+    this.#restartInFlight = this.#runRestart().finally(() => {
+      this.#restartInFlight = null;
+    });
+    return this.#restartInFlight;
+  }
+
+  async #runRestart(): Promise<void> {
     log.warn('Restarting prerender browser');
     await this.#pagePool.closeAll();
     await this.#browserManager.restartBrowser();

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -15,6 +15,7 @@ import {
 import type { Prerenderer } from '../prerender/index';
 import { PagePool } from '../prerender/page-pool';
 import { RenderRunner } from '../prerender/render-runner';
+import { BrowserManager } from '../prerender/browser-manager';
 
 import {
   setupPermissionedRealmsCached,
@@ -5212,6 +5213,89 @@ module(basename(__filename), function () {
         );
       } finally {
         RenderRunner.prototype.prerenderVisitAttempt = originalAttempt;
+        await prerenderer?.stop();
+      }
+    });
+  });
+
+  module('prerender - concurrent restart coalescing', function () {
+    test('concurrent failures trigger a single browser restart', async function (assert) {
+      // Regression guard for the race where two visits failing in the same
+      // tick each called #restartBrowser, both closeAll'd the pool
+      // concurrently, and the second caller hit "Failed to find context with
+      // id <X>" as its BrowserContext.close() landed after the first already
+      // disposed the context.
+      let originalAttempt = RenderRunner.prototype.prerenderVisitAttempt;
+      let originalRestart = BrowserManager.prototype.restartBrowser;
+      let prerenderer: Prerenderer | undefined;
+      let restartCount = 0;
+      let retryRealm = 'https://concurrent-restart.example/';
+      let cardURL = `${retryRealm}card`;
+
+      try {
+        // Force every visit attempt to throw an unrecoverable error so the
+        // prerenderer catch block calls #restartBrowser for each caller.
+        RenderRunner.prototype.prerenderVisitAttempt = async function () {
+          throw new Error('simulated unrecoverable prerender failure');
+        };
+        // Introduce a small delay inside restartBrowser so concurrent
+        // callers actually overlap in time — without this the fast
+        // synchronous-ish no-op restart would serialize naturally.
+        BrowserManager.prototype.restartBrowser = async function (
+          this: BrowserManager,
+        ) {
+          restartCount++;
+          await new Promise((resolve) => setTimeout(resolve, 50));
+          return await originalRestart.call(this);
+        };
+
+        prerenderer = getPrerendererForTesting({
+          maxPages: 2,
+          serverURL: 'http://127.0.0.1:4225',
+        });
+
+        // Fire three visits concurrently. Each will fail on its first
+        // attempt, trigger #restartBrowser, and then retry once more (per
+        // the prerenderVisit wrapper in prerenderer.ts). With the mutex
+        // in place, all three callers coalesce onto a single in-flight
+        // restart.
+        let results = await Promise.allSettled([
+          prerenderCard(prerenderer, {
+            affinityType: 'realm',
+            affinityValue: retryRealm,
+            realm: retryRealm,
+            url: cardURL,
+            auth: 'test-auth',
+          }),
+          prerenderCard(prerenderer, {
+            affinityType: 'realm',
+            affinityValue: retryRealm,
+            realm: retryRealm,
+            url: `${cardURL}-2`,
+            auth: 'test-auth',
+          }),
+          prerenderCard(prerenderer, {
+            affinityType: 'realm',
+            affinityValue: retryRealm,
+            realm: retryRealm,
+            url: `${cardURL}-3`,
+            auth: 'test-auth',
+          }),
+        ]);
+
+        assert.strictEqual(
+          results.filter((r) => r.status === 'rejected').length,
+          3,
+          'all three visits fail (no working render path available)',
+        );
+        assert.strictEqual(
+          restartCount,
+          1,
+          'three concurrent failing visits coalesce into a single browser restart',
+        );
+      } finally {
+        RenderRunner.prototype.prerenderVisitAttempt = originalAttempt;
+        BrowserManager.prototype.restartBrowser = originalRestart;
         await prerenderer?.stop();
       }
     });


### PR DESCRIPTION
## Summary

When two prerender visits fail in the same tick, each caller's catch handler invokes `#restartBrowser` concurrently. Both calls enter `pagePool.closeAll` at the same time and iterate the same `#affinityPages` map (which isn't cleared until **after** the loop), so each tries to close the same `BrowserContext`. The first disposes it; the second's `Target.disposeBrowserContext` CDP call fails with `Failed to find context with id <X>` and the race cascades — a third in-flight visit hits `TargetCloseError` on `Runtime.callFunctionOn` because the browser is already closing.

Observed in staging:

```
Error closing context for realm:https://realms-staging.stack.cards/catalog/:
ProtocolError: Protocol error (Target.disposeBrowserContext):
Failed to find context with id 25A167D443219972943FD08C2581D44C
  at PagePool._PagePool_closeEntry (page-pool.ts:661)
  at async PagePool.closeAll (page-pool.ts:274)
  at async Prerenderer._Prerenderer_restartBrowser (prerenderer.ts:401)
```

## Fix

**Mutex `#restartBrowser`** — cache an in-flight restart promise; concurrent callers share it. Same pattern the page pool already uses for `#ensuringStandbys`. Only one `closeAll()` runs at a time on an uncontested map.

Beyond killing the log noise, this also saves real work: every concurrent caller was redundantly tearing the browser down and re-warming standbys.

## Test plan

- [x] `pnpm lint` clean on touched files
- [x] Regression test: `prerendering-test.ts > prerender - concurrent restart coalescing > concurrent failures trigger a single browser restart` — patches `RenderRunner.prototype.prerenderVisitAttempt` to always throw and `BrowserManager.prototype.restartBrowser` to count calls, fires three concurrent failing visits, asserts `restartCount === 1`
- [ ] CI: realm-server prerendering + indexing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)