### PR TITLE
Accept fitted prefix and embedded in BFM size-spec parser

### DIFF
--- a/packages/host/tests/unit/bfm-card-references-test.ts
+++ b/packages/host/tests/unit/bfm-card-references-test.ts
@@ -386,6 +386,68 @@ module('Unit | bfm-card-references', function () {
       );
     });
 
+    test('block ref with embedded format', function (assert) {
+      let markdown = '::card[https://example.com/cards/1 | embedded]\n';
+      let html = markdownToHtml(markdown);
+      assert.true(
+        html.includes('data-boxel-bfm-format="embedded"'),
+        'has embedded format',
+      );
+      assert.false(
+        html.includes('data-boxel-bfm-width'),
+        'no width for embedded',
+      );
+      assert.false(
+        html.includes('data-boxel-bfm-height'),
+        'no height for embedded',
+      );
+    });
+
+    test('block ref with bare fitted format (no size override)', function (assert) {
+      let markdown = '::card[https://example.com/cards/1 | fitted]\n';
+      let html = markdownToHtml(markdown);
+      assert.true(
+        html.includes('data-boxel-bfm-format="fitted"'),
+        'has fitted format',
+      );
+      assert.false(
+        html.includes('data-boxel-bfm-width'),
+        'no width when no size override',
+      );
+      assert.false(
+        html.includes('data-boxel-bfm-height'),
+        'no height when no size override',
+      );
+    });
+
+    test('block ref with "fitted <named>" prefix', function (assert) {
+      let markdown = '::card[https://example.com/cards/1 | fitted strip]\n';
+      let html = markdownToHtml(markdown);
+      assert.true(
+        html.includes('data-boxel-bfm-format="fitted"'),
+        'has fitted format',
+      );
+      assert.true(
+        html.includes('data-boxel-bfm-width="250"'),
+        'width from strip constant',
+      );
+      assert.true(
+        html.includes('data-boxel-bfm-height="40"'),
+        'height from strip constant',
+      );
+    });
+
+    test('block ref with "fitted <WxH>" prefix', function (assert) {
+      let markdown = '::card[https://example.com/cards/1 | fitted 400x200]\n';
+      let html = markdownToHtml(markdown);
+      assert.true(
+        html.includes('data-boxel-bfm-format="fitted"'),
+        'has fitted format',
+      );
+      assert.true(html.includes('data-boxel-bfm-width="400"'), 'width=400');
+      assert.true(html.includes('data-boxel-bfm-height="200"'), 'height=200');
+    });
+
     test('block ref without pipe has no format/size attributes', function (assert) {
       let markdown = '::card[https://example.com/cards/1]\n';
       let html = markdownToHtml(markdown);
@@ -427,6 +489,51 @@ module('Unit | bfm-card-references', function () {
     test('parses isolated keyword case-insensitively', function (assert) {
       let result = parseBfmSizeSpec('Isolated');
       assert.deepEqual(result, { format: 'isolated' });
+    });
+
+    test('parses embedded keyword', function (assert) {
+      let result = parseBfmSizeSpec('embedded');
+      assert.deepEqual(result, { format: 'embedded' });
+    });
+
+    test('parses embedded keyword case-insensitively', function (assert) {
+      let result = parseBfmSizeSpec('Embedded');
+      assert.deepEqual(result, { format: 'embedded' });
+    });
+
+    test('parses bare fitted keyword with no size', function (assert) {
+      let result = parseBfmSizeSpec('fitted');
+      assert.deepEqual(result, { format: 'fitted' });
+    });
+
+    test('parses bare fitted keyword case-insensitively', function (assert) {
+      let result = parseBfmSizeSpec('Fitted');
+      assert.deepEqual(result, { format: 'fitted' });
+    });
+
+    test('parses fitted prefix with named constant', function (assert) {
+      let result = parseBfmSizeSpec('fitted strip');
+      assert.deepEqual(result, { format: 'fitted', width: 250, height: 40 });
+    });
+
+    test('parses fitted prefix with canonical named constant', function (assert) {
+      let result = parseBfmSizeSpec('fitted compact-card');
+      assert.deepEqual(result, { format: 'fitted', width: 400, height: 170 });
+    });
+
+    test('parses fitted prefix with WxH', function (assert) {
+      let result = parseBfmSizeSpec('fitted 400x200');
+      assert.deepEqual(result, { format: 'fitted', width: 400, height: 200 });
+    });
+
+    test('parses fitted prefix with WxH with spaces', function (assert) {
+      let result = parseBfmSizeSpec('fitted 400 x 200');
+      assert.deepEqual(result, { format: 'fitted', width: 400, height: 200 });
+    });
+
+    test('parses fitted prefix case-insensitively', function (assert) {
+      let result = parseBfmSizeSpec('Fitted Strip');
+      assert.deepEqual(result, { format: 'fitted', width: 250, height: 40 });
     });
 
     // Named size constants — Badges

--- a/packages/runtime-common/bfm-card-references.ts
+++ b/packages/runtime-common/bfm-card-references.ts
@@ -67,10 +67,9 @@ export function parseBfmSizeSpec(specifier: string): BfmSizeSpec | null {
     return { format: 'fitted' };
   }
 
-  // Strip optional `fitted ` prefix; everything below already implies fitted.
-  let body = trimmed.startsWith('fitted ')
-    ? trimmed.slice('fitted '.length).trimStart()
-    : trimmed;
+  // Strip optional `fitted` prefix followed by any whitespace;
+  // everything below already implies fitted.
+  let body = trimmed.replace(/^fitted\s+/, '');
 
   // Named size constant
   let constant = SIZE_CONSTANTS.get(body);

--- a/packages/runtime-common/bfm-card-references.ts
+++ b/packages/runtime-common/bfm-card-references.ts
@@ -22,7 +22,7 @@ function resolveUrl(ref: string, baseUrl: string | undefined): string | null {
 // ── BFM size spec parsing ──
 
 export interface BfmSizeSpec {
-  format: 'fitted' | 'isolated';
+  format: 'fitted' | 'isolated' | 'embedded';
   width?: number | string; // number = px, string = e.g. "50%"
   height?: number;
 }
@@ -43,10 +43,14 @@ SIZE_CONSTANTS.set('grid-tile', SIZE_CONSTANTS.get('cardsgrid-tile')!);
  * Parses a BFM size specifier (the part after `|` in `::card[url | spec]`).
  *
  * Supported forms:
- *  - Named constant: `strip`, `tile`, `compact-card`, etc.
- *  - WxH:           `400x200`
- *  - Explicit keys:  `w:400 h:200`, `h:300`, `w:50%`
- *  - Isolated:       `isolated`
+ *  - `isolated`                          — isolated format
+ *  - `embedded`                          — embedded format (explicit)
+ *  - `fitted`                            — fitted at the container's natural size
+ *  - Named constant: `strip`, `tile`, `compact-card`, etc. (fitted implied)
+ *  - `fitted <named-constant>`           — e.g. `fitted strip` (same as `strip`)
+ *  - WxH: `400x200` (fitted implied)
+ *  - `fitted <WxH>`                      — e.g. `fitted 400x200` (same as `400x200`)
+ *  - Explicit keys: `w:400 h:200`, `h:300`, `w:50%` (fitted implied)
  */
 export function parseBfmSizeSpec(specifier: string): BfmSizeSpec | null {
   let trimmed = specifier.trim().toLowerCase();
@@ -55,14 +59,27 @@ export function parseBfmSizeSpec(specifier: string): BfmSizeSpec | null {
     return { format: 'isolated' };
   }
 
+  if (trimmed === 'embedded') {
+    return { format: 'embedded' };
+  }
+
+  if (trimmed === 'fitted') {
+    return { format: 'fitted' };
+  }
+
+  // Strip optional `fitted ` prefix; everything below already implies fitted.
+  let body = trimmed.startsWith('fitted ')
+    ? trimmed.slice('fitted '.length).trimStart()
+    : trimmed;
+
   // Named size constant
-  let constant = SIZE_CONSTANTS.get(trimmed);
+  let constant = SIZE_CONSTANTS.get(body);
   if (constant) {
     return { format: 'fitted', width: constant.width, height: constant.height };
   }
 
   // WxH (e.g. "400x200")
-  let wxhMatch = trimmed.match(/^(\d+)\s*x\s*(\d+)$/);
+  let wxhMatch = body.match(/^(\d+)\s*x\s*(\d+)$/);
   if (wxhMatch) {
     return {
       format: 'fitted',
@@ -72,8 +89,8 @@ export function parseBfmSizeSpec(specifier: string): BfmSizeSpec | null {
   }
 
   // Explicit key syntax: w:N, h:N, w:N%
-  let wMatch = trimmed.match(/\bw:(\d+)(%?)/);
-  let hMatch = trimmed.match(/\bh:(\d+)\b/);
+  let wMatch = body.match(/\bw:(\d+)(%?)/);
+  let hMatch = body.match(/\bh:(\d+)\b/);
 
   if (wMatch || hMatch) {
     let spec: BfmSizeSpec = { format: 'fitted' };


### PR DESCRIPTION
## Summary

Closes [CS-10818](https://linear.app/cardstack/issue/CS-10818/bfm-size-spec-parser-should-accept-fitted-prefix-and-embedded-keyword).

Widen `parseBfmSizeSpec` so authors who reach for ergonomic specs like `fitted 400x200` or `embedded` get the format they asked for instead of silently falling back to embedded with no error, no warning, and no hint why.

- `embedded` → `{ format: 'embedded' }` (format union widened to include `'embedded'`)
- `fitted` alone → `{ format: 'fitted' }` (no size override — container's natural size)
- `fitted <named>` (e.g. `fitted strip`) → same output as bare `strip`
- `fitted <WxH>` (e.g. `fitted 400x200`) → same output as bare `400x200`
- Existing forms (`isolated`, bare named constant, bare `WxH`, `w:N h:N`, `h:N`, `w:N%`) unchanged.

Downstream consumers (`packages/base/default-templates/markdown.gts`, `packages/host/app/components/operator-mode/preview-panel/rendered-markdown.gts`) already fall through to `'embedded'` when `data-boxel-bfm-format` is anything other than `fitted`/`isolated`, so no consumer changes are required — emitting `data-boxel-bfm-format="embedded"` selects embedded naturally.

The [`dev-bfm-syntax` skill](https://github.com/cardstack/boxel-skills/commit/c394808) was already updated to document this grammar.

## Test plan

- [ ] `parseBfmSizeSpec` unit tests cover each new form (embedded, bare fitted, fitted+named, fitted+WxH, plus case-insensitive variants)
- [ ] `markdownToHtml` rendering tests verify the correct `data-boxel-bfm-format/-width/-height` attributes are emitted for each new form
- [ ] Existing `parseBfmSizeSpec` and rendering tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)