### PR TITLE
Report per-affinity vacancy in prerender heartbeat (CS-10758 step 1)

### DIFF
--- a/packages/realm-server/prerender/manager-app.ts
+++ b/packages/realm-server/prerender/manager-app.ts
@@ -250,9 +250,11 @@ export function buildPrerenderManagerApp(options?: {
         existing.warmedAffinities = warmSet;
         changed = true;
       }
-      if (vacancyMap) {
-        existing.affinityVacancy = vacancyMap;
-      }
+      // Always refresh vacancy — treat a missing `affinityVacancy` attribute
+      // on this heartbeat as an explicit empty snapshot so a rollback to a
+      // legacy server (or a server that temporarily stops reporting) can't
+      // leave stale data cached in the registry.
+      existing.affinityVacancy = vacancyMap ?? new Map();
       if (warmSet.size === 0) {
         // server restarted; clear tracked active affinities and mappings
         for (let affinityKey of [...existing.activeAffinities]) {
@@ -417,13 +419,24 @@ export function buildPrerenderManagerApp(options?: {
         typeof attrs.affinityVacancy === 'object' &&
         !Array.isArray(attrs.affinityVacancy)
       ) {
-        let parsed: Record<string, AffinityVacancy> = {};
+        // Null-prototype target + explicit forbidden-key guard so an
+        // untrusted heartbeat payload can't pollute Object.prototype via
+        // keys like `__proto__` / `constructor` / `prototype`.
+        let parsed: Record<string, AffinityVacancy> = Object.create(null);
         for (let [key, value] of Object.entries(attrs.affinityVacancy)) {
+          if (
+            key === '__proto__' ||
+            key === 'constructor' ||
+            key === 'prototype'
+          ) {
+            continue;
+          }
           if (
             value &&
             typeof value === 'object' &&
             typeof (value as AffinityVacancy).idle === 'boolean' &&
-            typeof (value as AffinityVacancy).tabCount === 'number'
+            Number.isInteger((value as AffinityVacancy).tabCount) &&
+            (value as AffinityVacancy).tabCount >= 0
           ) {
             parsed[key] = {
               idle: (value as AffinityVacancy).idle,

--- a/packages/realm-server/prerender/manager-app.ts
+++ b/packages/realm-server/prerender/manager-app.ts
@@ -12,11 +12,22 @@ import {
 import { fromAffinityKey, toAffinityKey } from './affinity';
 import type { AffinityType } from '@cardstack/runtime-common';
 
+// Per-affinity vacancy reported by a prerender server in its heartbeat.
+// Consumed by warm-vacancy-first routing (CS-10758): `idle: true` means
+// every tab for this affinity has an empty render queue; `tabCount`
+// tracks the affinity's claimed tabs.
+export type AffinityVacancy = { idle: boolean; tabCount: number };
+
 type ServerInfo = {
   url: string;
   capacity: number;
   activeAffinities: Set<string>;
   warmedAffinities: Set<string>;
+  // Populated from the `affinityVacancy` field of the server's heartbeat.
+  // Older servers that predate CS-10758 won't include this field; in that
+  // case the Map stays empty and callers should fall back to inferring
+  // warmth from `warmedAffinities` without vacancy information.
+  affinityVacancy: Map<string, AffinityVacancy>;
   status: 'active' | 'draining';
   registeredAt: number;
   lastSeenAt: number;
@@ -204,17 +215,22 @@ export function buildPrerenderManagerApp(options?: {
     capacity,
     status,
     warmedAffinities,
+    affinityVacancy,
   }: {
     url: string;
     capacity?: number;
     status?: 'active' | 'draining';
     warmedAffinities?: string[];
+    affinityVacancy?: Record<string, AffinityVacancy>;
   }) {
     log.debug(
       `received heartbeat from ${url} status=${status} capacity=${capacity} warmedAffinities=${warmedAffinities ? warmedAffinities.join() : 'none'}`,
     );
     let existing = registry.servers.get(url);
     let changed = false;
+    let vacancyMap = affinityVacancy
+      ? new Map<string, AffinityVacancy>(Object.entries(affinityVacancy))
+      : undefined;
     if (existing) {
       let warmSet = new Set(warmedAffinities ?? []);
       existing.lastSeenAt = now();
@@ -233,6 +249,9 @@ export function buildPrerenderManagerApp(options?: {
       ) {
         existing.warmedAffinities = warmSet;
         changed = true;
+      }
+      if (vacancyMap) {
+        existing.affinityVacancy = vacancyMap;
       }
       if (warmSet.size === 0) {
         // server restarted; clear tracked active affinities and mappings
@@ -280,6 +299,7 @@ export function buildPrerenderManagerApp(options?: {
       capacity: capacity || 4,
       activeAffinities: new Set(),
       warmedAffinities: new Set(warmedAffinities ?? []),
+      affinityVacancy: vacancyMap ?? new Map(),
       status: status ?? 'active',
       registeredAt: now(),
       lastSeenAt: now(),
@@ -347,6 +367,7 @@ export function buildPrerenderManagerApp(options?: {
           lastSeenAt: formatTimestampWithTimezone(serverInfo.lastSeenAt),
           status: serverInfo.status,
           warmedAffinities: Array.from(serverInfo.warmedAffinities.values()),
+          affinityVacancy: Object.fromEntries(serverInfo.affinityVacancy),
           affinities,
         },
       });
@@ -390,6 +411,28 @@ export function buildPrerenderManagerApp(options?: {
           (v: unknown): v is string => Boolean(v && typeof v === 'string'),
         );
       }
+      let affinityVacancy: Record<string, AffinityVacancy> | undefined;
+      if (
+        attrs.affinityVacancy &&
+        typeof attrs.affinityVacancy === 'object' &&
+        !Array.isArray(attrs.affinityVacancy)
+      ) {
+        let parsed: Record<string, AffinityVacancy> = {};
+        for (let [key, value] of Object.entries(attrs.affinityVacancy)) {
+          if (
+            value &&
+            typeof value === 'object' &&
+            typeof (value as AffinityVacancy).idle === 'boolean' &&
+            typeof (value as AffinityVacancy).tabCount === 'number'
+          ) {
+            parsed[key] = {
+              idle: (value as AffinityVacancy).idle,
+              tabCount: (value as AffinityVacancy).tabCount,
+            };
+          }
+        }
+        affinityVacancy = parsed;
+      }
       if (!url) {
         log.warn('Heartbeat rejected: prerender server URL not provided');
         ctxt.status = 400;
@@ -400,7 +443,13 @@ export function buildPrerenderManagerApp(options?: {
       }
       url = normalizeURL(url);
 
-      recordHeartbeat({ url, capacity, status, warmedAffinities });
+      recordHeartbeat({
+        url,
+        capacity,
+        status,
+        warmedAffinities,
+        affinityVacancy,
+      });
       ctxt.status = 204;
       ctxt.set('X-Prerender-Server-Id', url);
     } catch (e) {

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -149,6 +149,21 @@ export class PagePool {
     return [...this.#affinityPages.keys()];
   }
 
+  // Per-affinity vacancy snapshot consumed by the prerender manager for
+  // warm-vacancy-first routing (CS-10758). `idle: true` means every tab
+  // currently owned by this affinity has an empty render queue — the next
+  // visit can run without waiting. `tabCount` tracks how many pages the
+  // affinity has claimed (bounded by PRERENDER_AFFINITY_TAB_MAX).
+  getVacancySnapshot(): Record<string, { idle: boolean; tabCount: number }> {
+    let snapshot: Record<string, { idle: boolean; tabCount: number }> = {};
+    for (let [affinityKey, entries] of this.#affinityPages) {
+      let tabCount = entries.size;
+      let idle = [...entries].every((entry) => entry.queue.pendingCount === 0);
+      snapshot[affinityKey] = { idle, tabCount };
+    }
+    return snapshot;
+  }
+
   resetConsoleErrors(pageId: string): void {
     this.#consoleErrorsByPageId.set(pageId, new Map());
   }

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -755,6 +755,10 @@ export function createPrerenderHttpServer(options?: {
             url: serverURL,
             status: status ?? (draining ? 'draining' : 'active'),
             warmedAffinities: prerenderer.getWarmAffinities(),
+            // Per-affinity vacancy snapshot. Consumed by the prerender
+            // manager's warm-vacancy-first routing (CS-10758). Additive to
+            // warmedAffinities for rolling-deploy back-compat.
+            affinityVacancy: prerenderer.getVacancySnapshot(),
           },
         },
       };

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -103,6 +103,10 @@ export class Prerenderer {
     return this.#pagePool.getWarmAffinities();
   }
 
+  getVacancySnapshot(): Record<string, { idle: boolean; tabCount: number }> {
+    return this.#pagePool.getVacancySnapshot();
+  }
+
   async stop(): Promise<void> {
     if (this.#cleanupInterval) {
       clearInterval(this.#cleanupInterval);

--- a/packages/realm-server/tests/prerender-manager-test.ts
+++ b/packages/realm-server/tests/prerender-manager-test.ts
@@ -331,6 +331,135 @@ module(basename(__filename), function () {
       );
     });
 
+    test('heartbeat records affinityVacancy per-affinity {idle, tabCount}', async function (assert) {
+      let { app } = buildPrerenderManagerApp();
+      let request: SuperTest<Test> = supertest(app.callback());
+
+      let warmKey = realmAffinityKey('https://realm.example/A');
+      let busyKey = realmAffinityKey('https://realm.example/B');
+
+      let registration = await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: {
+            capacity: 4,
+            url: serverUrlA,
+            status: 'active',
+            warmedAffinities: [warmKey, busyKey],
+            affinityVacancy: {
+              [warmKey]: { idle: true, tabCount: 1 },
+              [busyKey]: { idle: false, tabCount: 2 },
+            },
+          },
+        },
+      });
+      assert.strictEqual(registration.status, 204, 'heartbeat accepted');
+
+      let health = await request.get('/');
+      let server = (health.body.included as any[]).find(
+        (s) => s.id === serverUrlA,
+      );
+      assert.ok(server, 'server present in health included');
+      assert.deepEqual(
+        server.attributes.affinityVacancy,
+        {
+          [warmKey]: { idle: true, tabCount: 1 },
+          [busyKey]: { idle: false, tabCount: 2 },
+        },
+        'affinityVacancy snapshot round-trips through the heartbeat',
+      );
+
+      // Subsequent heartbeat with updated vacancy overwrites the snapshot.
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: {
+            capacity: 4,
+            url: serverUrlA,
+            status: 'active',
+            warmedAffinities: [warmKey, busyKey],
+            affinityVacancy: {
+              [warmKey]: { idle: true, tabCount: 1 },
+              [busyKey]: { idle: true, tabCount: 2 },
+            },
+          },
+        },
+      });
+      let health2 = await request.get('/');
+      let server2 = (health2.body.included as any[]).find(
+        (s) => s.id === serverUrlA,
+      );
+      assert.deepEqual(
+        server2.attributes.affinityVacancy[busyKey],
+        { idle: true, tabCount: 2 },
+        'busy affinity flips to idle on the next heartbeat',
+      );
+    });
+
+    test('heartbeat without affinityVacancy is accepted (legacy server during rollout)', async function (assert) {
+      let { app } = buildPrerenderManagerApp();
+      let request: SuperTest<Test> = supertest(app.callback());
+
+      let registration = await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: {
+            capacity: 2,
+            url: serverUrlA,
+            status: 'active',
+            warmedAffinities: [realmAffinityKey('https://realm.example/A')],
+            // affinityVacancy intentionally omitted — predates CS-10758
+          },
+        },
+      });
+      assert.strictEqual(registration.status, 204, 'legacy heartbeat accepted');
+
+      let health = await request.get('/');
+      let server = (health.body.included as any[]).find(
+        (s) => s.id === serverUrlA,
+      );
+      assert.deepEqual(
+        server.attributes.affinityVacancy,
+        {},
+        'missing affinityVacancy normalized to empty object, not null',
+      );
+    });
+
+    test('heartbeat drops malformed affinityVacancy entries', async function (assert) {
+      let { app } = buildPrerenderManagerApp();
+      let request: SuperTest<Test> = supertest(app.callback());
+
+      let goodKey = realmAffinityKey('https://realm.example/A');
+
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: {
+            capacity: 2,
+            url: serverUrlA,
+            status: 'active',
+            warmedAffinities: [goodKey],
+            affinityVacancy: {
+              [goodKey]: { idle: true, tabCount: 1 },
+              badShape1: { idle: 'yes', tabCount: 1 }, // wrong type
+              badShape2: { idle: true }, // missing tabCount
+              badShape3: null, // not an object
+            },
+          },
+        },
+      });
+
+      let health = await request.get('/');
+      let server = (health.body.included as any[]).find(
+        (s) => s.id === serverUrlA,
+      );
+      assert.deepEqual(
+        server.attributes.affinityVacancy,
+        { [goodKey]: { idle: true, tabCount: 1 } },
+        'only well-formed entries are recorded',
+      );
+    });
+
     test('heartbeat: url required; heartbeat updates warmed affinities and status', async function (assert) {
       let { app } = buildPrerenderManagerApp();
       let request: SuperTest<Test> = supertest(app.callback());

--- a/packages/realm-server/tests/prerender-manager-test.ts
+++ b/packages/realm-server/tests/prerender-manager-test.ts
@@ -441,9 +441,13 @@ module(basename(__filename), function () {
             warmedAffinities: [goodKey],
             affinityVacancy: {
               [goodKey]: { idle: true, tabCount: 1 },
-              badShape1: { idle: 'yes', tabCount: 1 }, // wrong type
+              badShape1: { idle: 'yes', tabCount: 1 }, // wrong idle type
               badShape2: { idle: true }, // missing tabCount
               badShape3: null, // not an object
+              badTabCountNaN: { idle: true, tabCount: NaN },
+              badTabCountInf: { idle: true, tabCount: Infinity },
+              badTabCountNegative: { idle: true, tabCount: -1 },
+              badTabCountFractional: { idle: true, tabCount: 1.5 },
             },
           },
         },
@@ -456,7 +460,113 @@ module(basename(__filename), function () {
       assert.deepEqual(
         server.attributes.affinityVacancy,
         { [goodKey]: { idle: true, tabCount: 1 } },
-        'only well-formed entries are recorded',
+        'only well-formed entries are recorded (tabCount must be a finite non-negative integer)',
+      );
+    });
+
+    test('heartbeat affinityVacancy rejects prototype-pollution keys', async function (assert) {
+      let { app } = buildPrerenderManagerApp();
+      let request: SuperTest<Test> = supertest(app.callback());
+
+      let goodKey = realmAffinityKey('https://realm.example/A');
+
+      // Build the payload via JSON.parse so `__proto__` is encoded as a
+      // literal property key in the wire payload rather than being treated
+      // as the object-literal prototype-setter shortcut (which would leave
+      // it out of Object.keys entirely).
+      let maliciousPayload = JSON.parse(
+        JSON.stringify({
+          [goodKey]: { idle: true, tabCount: 1 },
+        }).replace(
+          '}',
+          `,"__proto__":{"idle":true,"tabCount":999},"constructor":{"idle":true,"tabCount":999},"prototype":{"idle":true,"tabCount":999}}`,
+        ),
+      );
+
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: {
+            capacity: 2,
+            url: serverUrlA,
+            status: 'active',
+            warmedAffinities: [goodKey],
+            affinityVacancy: maliciousPayload,
+          },
+        },
+      });
+
+      // Object.prototype itself must not have been polluted.
+      assert.strictEqual(
+        ({} as any).tabCount,
+        undefined,
+        'Object.prototype.tabCount unchanged — __proto__ payload ignored',
+      );
+
+      let health = await request.get('/');
+      let server = (health.body.included as any[]).find(
+        (s) => s.id === serverUrlA,
+      );
+      assert.deepEqual(
+        Object.keys(server.attributes.affinityVacancy),
+        [goodKey],
+        'only the legitimate key is recorded; prototype-pollution keys are dropped',
+      );
+    });
+
+    test('heartbeat without affinityVacancy clears previously-reported snapshot (rollback safe)', async function (assert) {
+      let { app } = buildPrerenderManagerApp();
+      let request: SuperTest<Test> = supertest(app.callback());
+
+      let key = realmAffinityKey('https://realm.example/A');
+
+      // First heartbeat: reports vacancy.
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: {
+            capacity: 2,
+            url: serverUrlA,
+            status: 'active',
+            warmedAffinities: [key],
+            affinityVacancy: { [key]: { idle: true, tabCount: 1 } },
+          },
+        },
+      });
+
+      let health1 = await request.get('/');
+      let server1 = (health1.body.included as any[]).find(
+        (s) => s.id === serverUrlA,
+      );
+      assert.deepEqual(
+        server1.attributes.affinityVacancy,
+        { [key]: { idle: true, tabCount: 1 } },
+        'vacancy recorded on the first heartbeat',
+      );
+
+      // Simulate a rollback: same server, next heartbeat omits
+      // affinityVacancy. Stale data must not persist.
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: {
+            capacity: 2,
+            url: serverUrlA,
+            status: 'active',
+            warmedAffinities: [key],
+            // affinityVacancy intentionally omitted
+          },
+        },
+      });
+
+      let health2 = await request.get('/');
+      let server2 = (health2.body.included as any[]).find(
+        (s) => s.id === serverUrlA,
+      );
+      assert.deepEqual(
+        server2.attributes.affinityVacancy,
+        {},
+        'vacancy snapshot is cleared when a subsequent heartbeat omits the field',
       );
     });
 

--- a/packages/realm-server/tests/prerender-server-test.ts
+++ b/packages/realm-server/tests/prerender-server-test.ts
@@ -554,6 +554,46 @@ module(basename(__filename), function () {
       );
     });
 
+    test('reports per-affinity vacancy for warm-vacancy-first routing', async function (assert) {
+      let url = `${realmURL.href}1`;
+      let permissions: Record<string, ('read' | 'write' | 'realm-owner')[]> = {
+        [realmURL.href]: ['read', 'write', 'realm-owner'],
+      };
+      let auth = testCreatePrerenderAuth(testUserId, permissions);
+      // Warm the affinity with a visit.
+      await request
+        .post('/prerender-visit')
+        .set('Accept', 'application/vnd.api+json')
+        .set('Content-Type', 'application/json')
+        .send({
+          data: {
+            type: 'prerender-visit-request',
+            attributes: {
+              url,
+              auth,
+              realm: realmURL.href,
+              affinityType: 'realm',
+              affinityValue: realmURL.href,
+              renderOptions: { cardRender: true },
+            },
+          },
+        });
+
+      let affinityKey = toAffinityKey({
+        affinityType: 'realm',
+        affinityValue: realmURL.href,
+      });
+      let snapshot = prerenderer.getVacancySnapshot();
+      let entry = snapshot[affinityKey];
+      assert.ok(entry, `vacancy snapshot includes ${affinityKey}`);
+      assert.true(entry.idle, 'affinity is idle after the visit completes');
+      assert.strictEqual(
+        entry.tabCount,
+        1,
+        'affinity owns exactly one tab after a single visit',
+      );
+    });
+
     test('responds draining immediately when shutdown begins during an in-flight prerender', async function (assert) {
       let localDraining = false;
       let drainingDeferred = new Deferred<void>();

--- a/packages/realm-server/tests/scripts/run-qunit-with-test-pg.sh
+++ b/packages/realm-server/tests/scripts/run-qunit-with-test-pg.sh
@@ -19,8 +19,15 @@ if [ -n "${JUNIT_OUTPUT_FILE-}" ]; then
   JUNIT_REPORTER_ARGS=(--require "${SCRIPT_DIR}/../../scripts/junit-reporter.js")
 fi
 
+# Disable Node's V8 compile cache (Node 22+). When enabled, it caches
+# transpiled JS of test files at /tmp/node-compile-cache and
+# /tmp/v8-compile-cache-1000, and when a test file changes on disk the
+# cache can serve a stale compiled version — edits to test files then
+# silently don't reach the runner. See:
+# https://nodejs.org/api/module.html#moduleenablecompilecachecachedir
 LOG_LEVELS="$EFFECTIVE_LOG_LEVELS" \
 NODE_NO_WARNINGS=1 \
+NODE_DISABLE_COMPILE_CACHE=1 \
 PGPORT=55436 \
 STRIPE_WEBHOOK_SECRET=stripe-webhook-secret \
 STRIPE_API_KEY=stripe-api-key \


### PR DESCRIPTION
Foundation for [CS-10758](https://linear.app/cardstack/issue/CS-10758) warm-vacancy-first routing. **Additive — no routing behavior changes yet.** The manager records the new field alongside `warmedAffinities`; subsequent PRs in the stack will consume it to prefer **warm+idle > cold+idle > warm+busy** across the prerender fleet.

## Producer (prerender server)

- `PagePool.getVacancySnapshot()` returns `Record<affinityKey, { idle, tabCount }>` derived from the existing `#affinityPages` Map and `TabQueue.pendingCount` — no new bookkeeping.
- `Prerenderer.getVacancySnapshot()` exposes it.
- Heartbeat payload in `prerender-app.ts` includes the snapshot under `attributes.affinityVacancy`, keeping `warmedAffinities` for back-compat during rolling deploys.

## Consumer (prerender manager)

- `ServerInfo` gains `affinityVacancy: Map<string, AffinityVacancy>`.
- `recordHeartbeat` parses `attributes.affinityVacancy` when present, validates each entry's shape (drops malformed), and falls back to an empty Map for legacy servers that predate the field.
- Health endpoint exposes `affinityVacancy` for observability.

## Tests

`prerender-manager-test.ts` (+3 tests):
- Affinity vacancy round-trips through the heartbeat and is visible in the health response.
- Legacy heartbeats without `affinityVacancy` are accepted (normalized to empty object).
- Malformed entries are dropped; well-formed entries are kept.

`prerender-server-test.ts` (+1 integration test):
- After a `prerender-visit` warms an affinity, the server reports `{ idle: true, tabCount: 1 }` for that affinity in its snapshot.

## Test plan

- [x] `pnpm lint` clean on touched files
- [x] `prerender-manager-test.ts` — 34/34 pass locally
- [ ] CI: full realm-server prerender suite
- [ ] CI: `prerender-server-test.ts` — the new integration test exercises real Puppeteer; ran locally but blocked by a pre-existing test-harness port race (CS-10813) intermittent on my machine

## Next in the stack

- **PR 2**: manager vacancy-first routing + eviction/replacement integration. Swaps `chooseServerForAffinity`'s LRU heuristics for the warm+idle > cold+idle > warm+busy priority using the vacancy data this PR introduces.
- **PR 3**: `clearCache` batch ownership. Threads `batchId` through `PrerenderVisitArgs` and strips `clearCache` from batchId-less callers when there's an active owner.
- **[CS-10817](https://linear.app/cardstack/issue/CS-10817)** (sub-ticket): shared `BrowserContext` per auth boundary. Ships after the parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)