### PR TITLE
Gate prerender fatal handler so tests don't kill qunit (CS-10813)

### DIFF
--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -702,13 +702,17 @@ async function unregisterWithManager(serverURL: string) {
 export function createPrerenderHttpServer(options?: {
   maxPages?: number;
   port?: number;
+  // Default true. In tests pass false: the fatal handler calls process.exit(1),
+  // which tears down the qunit runner before teardown hooks can release
+  // hardcoded test ports (CS-10813).
+  fatalExitOnUncaught?: boolean;
 }): Server {
   let draining = false;
   let drainingResolved = false;
   let drainingDeferred = new Deferred<void>();
   let heartbeatTimer: NodeJS.Timeout | undefined;
   let isClosing = false;
-  let fatalExitInProgress = false;
+  let fatalExitOnUncaught = options?.fatalExitOnUncaught ?? true;
   let serverURL = resolvePrerenderServerURL(options?.port);
   let { app, prerenderer } = buildPrerenderApp({
     maxPages: options?.maxPages,
@@ -848,37 +852,46 @@ export function createPrerenderHttpServer(options?: {
   process.on('SIGTERM', shutdownHandler);
   process.on('SIGINT', shutdownHandler);
 
-  async function handleFatal(
-    type: 'uncaughtException' | 'unhandledRejection',
-    err: any,
-  ) {
-    if (fatalExitInProgress) return;
-    fatalExitInProgress = true;
-    log.error(`Fatal ${type}; shutting down prerenderer`, err);
-    try {
-      await prerenderer.stop();
-    } catch (e: any) {
-      log.warn('Error stopping prerenderer during fatal shutdown:', e);
-    }
-    try {
-      server.close();
-    } catch (e: any) {
-      log.warn('Error closing server during fatal shutdown:', e);
-    }
-    setTimeout(() => process.exit(1), 100);
-  }
+  let uncaughtExceptionHandler: ((err: unknown) => void) | undefined;
+  let unhandledRejectionHandler: ((err: unknown) => void) | undefined;
+  if (fatalExitOnUncaught) {
+    let fatalExitInProgress = false;
+    const handleFatal = async (
+      type: 'uncaughtException' | 'unhandledRejection',
+      err: any,
+    ) => {
+      if (fatalExitInProgress) return;
+      fatalExitInProgress = true;
+      log.error(`Fatal ${type}; shutting down prerenderer`, err);
+      try {
+        await prerenderer.stop();
+      } catch (e: any) {
+        log.warn('Error stopping prerenderer during fatal shutdown:', e);
+      }
+      try {
+        server.close();
+      } catch (e: any) {
+        log.warn('Error closing server during fatal shutdown:', e);
+      }
+      setTimeout(() => process.exit(1), 100);
+    };
 
-  const uncaughtExceptionHandler = (err: unknown) =>
-    handleFatal('uncaughtException', err);
-  const unhandledRejectionHandler = (err: unknown) =>
-    handleFatal('unhandledRejection', err);
-  process.on('uncaughtException', uncaughtExceptionHandler);
-  process.on('unhandledRejection', unhandledRejectionHandler);
+    uncaughtExceptionHandler = (err: unknown) =>
+      handleFatal('uncaughtException', err);
+    unhandledRejectionHandler = (err: unknown) =>
+      handleFatal('unhandledRejection', err);
+    process.on('uncaughtException', uncaughtExceptionHandler);
+    process.on('unhandledRejection', unhandledRejectionHandler);
+  }
   server.on('close', () => {
     process.off('SIGTERM', shutdownHandler);
     process.off('SIGINT', shutdownHandler);
-    process.off('uncaughtException', uncaughtExceptionHandler);
-    process.off('unhandledRejection', unhandledRejectionHandler);
+    if (uncaughtExceptionHandler) {
+      process.off('uncaughtException', uncaughtExceptionHandler);
+    }
+    if (unhandledRejectionHandler) {
+      process.off('unhandledRejection', unhandledRejectionHandler);
+    }
   });
   return server;
 }

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -702,9 +702,10 @@ async function unregisterWithManager(serverURL: string) {
 export function createPrerenderHttpServer(options?: {
   maxPages?: number;
   port?: number;
-  // Default true. In tests pass false: the fatal handler calls process.exit(1),
-  // which tears down the qunit runner before teardown hooks can release
-  // hardcoded test ports (CS-10813).
+  // Default true. Gates the process-wide uncaughtException AND
+  // unhandledRejection handlers, both of which call process.exit(1). In tests
+  // pass false so the qunit runner isn't torn down before teardown hooks can
+  // release hardcoded test ports (CS-10813).
   fatalExitOnUncaught?: boolean;
 }): Server {
   let draining = false;

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -579,6 +579,7 @@ async function startTestPrerenderServer(): Promise<string> {
   }
   let server = createPrerenderHttpServer({
     maxPages: 1,
+    fatalExitOnUncaught: false, // tests share the qunit process; see CS-10813
   });
   prerenderServer = server;
   trackServer(server);

--- a/packages/realm-server/tests/prerender-server-test.ts
+++ b/packages/realm-server/tests/prerender-server-test.ts
@@ -4,10 +4,14 @@ import supertest from 'supertest';
 import { basename } from 'path';
 
 import {
+  closeServer,
   setupPermissionedRealmCached,
   testCreatePrerenderAuth,
 } from './helpers';
-import { buildPrerenderApp } from '../prerender/prerender-app';
+import {
+  buildPrerenderApp,
+  createPrerenderHttpServer,
+} from '../prerender/prerender-app';
 import type { Prerenderer } from '../prerender';
 import { baseCardRef } from '@cardstack/runtime-common';
 import {
@@ -680,6 +684,73 @@ module(basename(__filename), function () {
         await built.prerenderer.stop();
       } finally {
         process.off('unhandledRejection', onUnhandled);
+      }
+    });
+  });
+
+  // Regression guard for CS-10813: default handlers would exit the qunit
+  // process before teardown hooks ran, leaving hardcoded test ports bound.
+  module('createPrerenderHttpServer fatal handler gating', function () {
+    test('fatalExitOnUncaught=false does not register process-wide fatal handlers', async function (assert) {
+      let baselineUncaught = process.listenerCount('uncaughtException');
+      let baselineRejection = process.listenerCount('unhandledRejection');
+      let server = createPrerenderHttpServer({
+        maxPages: 1,
+        fatalExitOnUncaught: false,
+      });
+      try {
+        await new Promise<void>((resolve, reject) => {
+          server.once('error', reject);
+          server.listen(0, '127.0.0.1', () => resolve());
+        });
+        assert.strictEqual(
+          process.listenerCount('uncaughtException'),
+          baselineUncaught,
+          'no new uncaughtException listener registered',
+        );
+        assert.strictEqual(
+          process.listenerCount('unhandledRejection'),
+          baselineRejection,
+          'no new unhandledRejection listener registered',
+        );
+      } finally {
+        await closeServer(server);
+      }
+    });
+
+    test('fatalExitOnUncaught default registers process-wide fatal handlers', async function (assert) {
+      let baselineUncaught = process.listenerCount('uncaughtException');
+      let baselineRejection = process.listenerCount('unhandledRejection');
+      let server = createPrerenderHttpServer({ maxPages: 1 });
+      try {
+        await new Promise<void>((resolve, reject) => {
+          server.once('error', reject);
+          server.listen(0, '127.0.0.1', () => resolve());
+        });
+        assert.strictEqual(
+          process.listenerCount('uncaughtException') - baselineUncaught,
+          1,
+          'one new uncaughtException listener registered',
+        );
+        assert.strictEqual(
+          process.listenerCount('unhandledRejection') - baselineRejection,
+          1,
+          'one new unhandledRejection listener registered',
+        );
+      } finally {
+        await closeServer(server);
+        // server.on('close') removes the handlers; confirm they're gone so a
+        // regression here doesn't leak handlers across tests.
+        assert.strictEqual(
+          process.listenerCount('uncaughtException'),
+          baselineUncaught,
+          'uncaughtException listener removed on close',
+        );
+        assert.strictEqual(
+          process.listenerCount('unhandledRejection'),
+          baselineRejection,
+          'unhandledRejection listener removed on close',
+        );
       }
     });
   });


### PR DESCRIPTION
## Summary
- `createPrerenderHttpServer` registers process-wide `uncaughtException` / `unhandledRejection` handlers that call `process.exit(1)` 100ms after firing. When the prerender server is hosted inside the qunit runner, an unrelated fixture error tears the test process down before teardown hooks release hardcoded ports (e.g. 4450, 4444), producing `EADDRINUSE` on the next run.
- Adds a `fatalExitOnUncaught` option (default `true`, so production behavior is unchanged). `startTestPrerenderServer` now opts out.
- Adds a qunit regression test that counts process listeners before/after `createPrerenderHttpServer` to confirm both the default and opt-out paths.

See CS-10813 for the full analysis. This is the last of the three interacting fixes identified in that ticket — the `runTestRealmServer` listener cleanup and `closeServer` force-close landed with CS-10759's cleanup PR.

## Test plan
- [x] `pnpm -C packages/realm-server lint` passes
- [x] `TEST_MODULES="prerender-server-test.ts > createPrerenderHttpServer fatal handler gating" pnpm -C packages/realm-server test` passes (2/2)
- [x] Full realm-server test suite in CI
- [x] Host test suite in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)