### PR TITLE
Add in-memory run_lint agent tool (CS-10776)

### DIFF
--- a/packages/software-factory/.agents/skills/software-factory-operations/SKILL.md
+++ b/packages/software-factory/.agents/skills/software-factory-operations/SKILL.md
@@ -40,6 +40,10 @@ The agent has these tools during the execution loop. Use them by name — they a
 
 - `run_command({ command, commandInput? })` — Execute a host command on the realm server via the prerenderer. Commands run in browser context with full card runtime access (Loader, CardAPI, services). Use the specifier format `@cardstack/boxel-host/commands/<name>/default`.
 
+### Self-Validation (optional, no side effects)
+
+- `run_lint()` — Run ESLint + Prettier (with `@cardstack/boxel` rules) against every `.gts` / `.gjs` / `.ts` / `.js` file in the target realm and return an in-memory result: `status`, `filesChecked`, `errorCount`, `warningCount`, and per-violation `{ rule, file, line, column, message, severity }`. **Does not write a `LintResult` card** — safe to call repeatedly mid-turn to self-check the source you just wrote. The orchestrator still runs the full lint validation (which writes the durable `LintResult`) automatically after `signal_done`, so calling this is optional.
+
 **Example — generate JSON schema for a card type:**
 
 ```

--- a/packages/software-factory/.agents/skills/software-factory-operations/SKILL.md
+++ b/packages/software-factory/.agents/skills/software-factory-operations/SKILL.md
@@ -42,7 +42,7 @@ The agent has these tools during the execution loop. Use them by name — they a
 
 ### Self-Validation (optional, no side effects)
 
-- `run_lint()` — Run ESLint + Prettier (with `@cardstack/boxel` rules) against every `.gts` / `.gjs` / `.ts` / `.js` file in the target realm and return an in-memory result: `status`, `filesChecked`, `errorCount`, `warningCount`, and per-violation `{ rule, file, line, column, message, severity }`. **Does not write a `LintResult` card** — safe to call repeatedly mid-turn to self-check the source you just wrote. The orchestrator still runs the full lint validation (which writes the durable `LintResult`) automatically after `signal_done`, so calling this is optional.
+- `run_lint({ path? })` — Run ESLint + Prettier (with `@cardstack/boxel` rules) and return an in-memory `RunLintResult` with `status`, `filesChecked`, `filesWithErrors`, `errorCount`, `warningCount`, `durationMs`, `lintableFiles`, and per-violation `{ rule, file, line, column, message, severity }`. Without `path`, lints every `.gts` / `.gjs` / `.ts` / `.js` file in the target realm. With `path` (realm-relative file path), lints **only that one file** — prefer this right after writing or editing a single file. **Does not write a `LintResult` card** — safe to call repeatedly mid-turn. The orchestrator still runs the full lint validation (which writes the durable `LintResult`) automatically after `signal_done`, so calling this is optional.
 
 **Example — generate JSON schema for a card type:**
 

--- a/packages/software-factory/docs/phase-2-plan.md
+++ b/packages/software-factory/docs/phase-2-plan.md
@@ -151,6 +151,12 @@ The lint validation step (`src/validators/lint-step.ts`) uses the realm's existi
 
 The `LintResult` card definition (`realm/lint-result.gts`) mirrors the `TestRun` card structure with fitted/embedded/isolated templates, a running state, and links to Issue/Project. Card CRUD is in `src/lint-result-cards.ts`.
 
+**Shared engine.** The per-file discovery and lint loop live in `src/lint-execution.ts` (`discoverLintableFiles` + `lintRealmFiles`). Both the validation pipeline's `LintValidationStep` (which owns `LintResult` artifact lifecycle) and the in-memory `run_lint` agent tool (see below) consume the same engine, so rule coverage and read/lint semantics stay identical.
+
+### In-Memory `run_lint` Agent Tool (CS-10776)
+
+The agent also has a `run_lint` tool exposed on the factory tool set. It runs the same discovery + `_lint` engine as the validation step and returns a flat, JSON-friendly `RunLintResult` (`status`, `filesChecked`, `filesWithErrors`, `errorCount`, `warningCount`, `durationMs`, `lintableFiles`, `violations[{ rule, file, line, column, message, severity }]`). Unlike `LintValidationStep`, it **does not create a `LintResult` card** — no realm artifact is written, so it's safe to call repeatedly for mid-turn self-validation before `signal_done`. The orchestrator's post-`signal_done` lint validation still writes the durable `LintResult`.
+
 ### Eval Step Details (CS-10715)
 
 The eval validation step (`src/validators/eval-step.ts`) verifies that `.gts` modules load and evaluate without runtime errors. Module evaluation must happen in a sandbox — the prerenderer's headless Chrome — never directly in the factory's Node process. The step chains through three layers: `_run-command` → `evaluate-module` host command (`packages/host/app/commands/evaluate-module.ts`) → `/_prerender-module` endpoint. The prerenderer returns a `ModuleRenderResponse` with `status: 'ready' | 'error'` and structured error details including message and stack trace.

--- a/packages/software-factory/docs/phase-2-plan.md
+++ b/packages/software-factory/docs/phase-2-plan.md
@@ -157,6 +157,8 @@ The `LintResult` card definition (`realm/lint-result.gts`) mirrors the `TestRun`
 
 The agent also has a `run_lint` tool exposed on the factory tool set. It runs the same discovery + `_lint` engine as the validation step and returns a flat, JSON-friendly `RunLintResult` (`status`, `filesChecked`, `filesWithErrors`, `errorCount`, `warningCount`, `durationMs`, `lintableFiles`, `violations[{ rule, file, line, column, message, severity }]`). Unlike `LintValidationStep`, it **does not create a `LintResult` card** — no realm artifact is written, so it's safe to call repeatedly for mid-turn self-validation before `signal_done`. The orchestrator's post-`signal_done` lint validation still writes the durable `LintResult`.
 
+The tool accepts an optional `path` argument. When omitted, every lintable file in the realm is linted (matching the validation step's behavior). When supplied, the tool skips discovery and lints only that one realm-relative file — handy for a fast self-check right after writing or editing a single file. Paths with non-lintable extensions (`.json`, etc.) short-circuit to `status: 'error'` without calling the realm.
+
 ### Eval Step Details (CS-10715)
 
 The eval validation step (`src/validators/eval-step.ts`) verifies that `.gts` modules load and evaluate without runtime errors. Module evaluation must happen in a sandbox — the prerenderer's headless Chrome — never directly in the factory's Node process. The step chains through three layers: `_run-command` → `evaluate-module` host command (`packages/host/app/commands/evaluate-module.ts`) → `/_prerender-module` endpoint. The prerenderer returns a `ModuleRenderResponse` with `status: 'ready' | 'error'` and structured error details including message and stack trace.

--- a/packages/software-factory/src/factory-tool-builder.ts
+++ b/packages/software-factory/src/factory-tool-builder.ts
@@ -16,6 +16,11 @@ import type {
 import { buildCardDocument } from './darkfactory-schemas';
 import type { ToolExecutor } from './factory-tool-executor';
 import type { ToolRegistry } from './factory-tool-registry';
+import {
+  runLintInMemory,
+  type RunLintInMemoryOptions,
+  type RunLintResult,
+} from './lint-execution';
 import { logger } from './logger';
 import { ensureJsonExtension, addCommentToIssue } from './realm-operations';
 
@@ -56,6 +61,8 @@ export interface ToolBuilderConfig {
       relationships?: Record<string, unknown>;
     }
   >;
+  /** Injected for testing — defaults to runLintInMemory. */
+  runLintInMemory?: (options: RunLintInMemoryOptions) => Promise<RunLintResult>;
 }
 
 export interface ToolCallEntry {
@@ -100,6 +107,7 @@ export function buildFactoryTools(
     buildFetchTranspiledModuleTool(config),
     buildSearchRealmTool(config),
     buildRunCommandTool(config),
+    buildRunLintTool(config),
     buildSignalDoneTool(),
     buildRequestClarificationTool(),
   ];
@@ -576,6 +584,29 @@ function buildCreateCatalogSpecTool(config: ToolBuilderConfig): FactoryTool {
 
 // Note: buildRunTestsTool was removed — the validation pipeline runs tests
 // automatically via executeTestRunFromRealm after each agent turn.
+
+function buildRunLintTool(config: ToolBuilderConfig): FactoryTool {
+  let execute = config.runLintInMemory ?? runLintInMemory;
+  return {
+    name: 'run_lint',
+    description:
+      'Run ESLint + Prettier (with @cardstack/boxel rules) against every ' +
+      '.gts / .gjs / .ts / .js file in the target realm and return an ' +
+      'in-memory result (status, error/warning counts, per-violation ' +
+      'details). Safe to call repeatedly for mid-turn self-validation — ' +
+      'this tool does NOT create a LintResult card or any other realm ' +
+      'artifact. The orchestrator still runs the full validation pipeline ' +
+      '(which writes a LintResult card) automatically after signal_done, ' +
+      'so calling this is optional. Takes no arguments. Auth: per-realm JWT.',
+    parameters: { type: 'object', properties: {} },
+    execute: async () => {
+      return execute({
+        targetRealmUrl: config.targetRealmUrl,
+        client: config.client,
+      });
+    },
+  };
+}
 
 function buildSignalDoneTool(): FactoryTool {
   return {

--- a/packages/software-factory/src/factory-tool-builder.ts
+++ b/packages/software-factory/src/factory-tool-builder.ts
@@ -590,19 +590,36 @@ function buildRunLintTool(config: ToolBuilderConfig): FactoryTool {
   return {
     name: 'run_lint',
     description:
-      'Run ESLint + Prettier (with @cardstack/boxel rules) against every ' +
-      '.gts / .gjs / .ts / .js file in the target realm and return an ' +
+      'Run ESLint + Prettier (with @cardstack/boxel rules) and return an ' +
       'in-memory result (status, error/warning counts, per-violation ' +
-      'details). Safe to call repeatedly for mid-turn self-validation — ' +
+      'details). Without "path", lints every .gts / .gjs / .ts / .js file ' +
+      'in the target realm. With "path", lints only that single realm-' +
+      'relative file — handy for a quick self-check right after writing ' +
+      'one file. Safe to call repeatedly for mid-turn self-validation — ' +
       'this tool does NOT create a LintResult card or any other realm ' +
       'artifact. The orchestrator still runs the full validation pipeline ' +
       '(which writes a LintResult card) automatically after signal_done, ' +
-      'so calling this is optional. Takes no arguments. Auth: per-realm JWT.',
-    parameters: { type: 'object', properties: {} },
-    execute: async () => {
+      'so calling this is optional. Auth: per-realm JWT.',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description:
+            'Optional realm-relative path to a single .gts / .gjs / .ts / .js file to lint. Omit to lint every lintable file in the target realm.',
+        },
+      },
+    },
+    execute: async (args) => {
+      let rawPath = args.path;
+      let path =
+        typeof rawPath === 'string' && rawPath.trim() !== ''
+          ? rawPath.trim()
+          : undefined;
       return execute({
         targetRealmUrl: config.targetRealmUrl,
         client: config.client,
+        ...(path ? { path } : {}),
       });
     },
   };

--- a/packages/software-factory/src/lint-execution.ts
+++ b/packages/software-factory/src/lint-execution.ts
@@ -1,0 +1,369 @@
+/**
+ * Lint execution — shared engine used by both the validation pipeline's
+ * `LintValidationStep` (which writes a `LintResult` card artifact) and the
+ * in-memory `run_lint` agent tool (which returns results without side
+ * effects).
+ *
+ * The realm's `_lint` endpoint (ESLint + Prettier + `@cardstack/boxel`
+ * rules) is the same endpoint the Monaco editor uses in code mode.
+ */
+
+import type { BoxelCLIClient, LintResult } from '@cardstack/boxel-cli/api';
+
+import type {
+  LintFileResultData,
+  LintViolationData,
+} from './lint-result-cards';
+import { logger } from './logger';
+
+let log = logger('lint-execution');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const LINTABLE_EXTENSIONS = ['.gts', '.gjs', '.ts', '.js'];
+
+// ---------------------------------------------------------------------------
+// Shared engine types
+// ---------------------------------------------------------------------------
+
+/** Flattened error violation — used by both validator details and in-memory. */
+export interface LintErrorViolation {
+  rule: string;
+  file: string;
+  line: number;
+  message: string;
+}
+
+export interface LintRealmFilesOptions {
+  targetRealmUrl: string;
+  client: BoxelCLIClient;
+  /** Injected for testing — defaults to client.listFiles. */
+  fetchFilenames?: (
+    realmUrl: string,
+  ) => Promise<{ filenames: string[]; error?: string }>;
+  /** Injected for testing — defaults to client.lint. */
+  lintFileFn?: (
+    realmUrl: string,
+    source: string,
+    filename: string,
+  ) => Promise<LintResult>;
+  /** Injected for testing — defaults to client.read (content only). */
+  readFileFn?: (
+    realmUrl: string,
+    path: string,
+  ) => Promise<{ ok: boolean; content?: string; error?: string }>;
+}
+
+export interface LintRealmFilesOutput {
+  lintableFiles: string[];
+  fileResults: LintFileResultData[];
+  /** Error-severity violations, flattened across files. */
+  errorViolations: LintErrorViolation[];
+  durationMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory tool types
+// ---------------------------------------------------------------------------
+
+export interface RunLintInMemoryOptions {
+  targetRealmUrl: string;
+  client: BoxelCLIClient;
+}
+
+export interface RunLintViolation {
+  rule: string;
+  file: string;
+  line: number;
+  column: number;
+  message: string;
+  severity: 'error' | 'warning';
+}
+
+export interface RunLintResult {
+  status: 'passed' | 'failed' | 'error';
+  filesChecked: number;
+  filesWithErrors: number;
+  errorCount: number;
+  warningCount: number;
+  durationMs: number;
+  /** Realm-relative lintable file paths discovered before the run. */
+  lintableFiles: string[];
+  /** All violations (errors and warnings) across all files. */
+  violations: RunLintViolation[];
+  /** Set only when `status === 'error'`. */
+  errorMessage?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Public engine
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover lintable files in the target realm — `.gts`, `.gjs`, `.ts`, `.js`.
+ * Returns an alphabetically-sorted list.
+ */
+export async function discoverLintableFiles(
+  options: Pick<
+    LintRealmFilesOptions,
+    'targetRealmUrl' | 'client' | 'fetchFilenames'
+  >,
+): Promise<string[]> {
+  let fetchFilenames =
+    options.fetchFilenames ??
+    ((realmUrl: string) => options.client.listFiles(realmUrl));
+
+  let result = await fetchFilenames(options.targetRealmUrl);
+  if (result.error) {
+    log.warn(`Failed to fetch realm filenames: ${result.error}`);
+    throw new Error(result.error);
+  }
+
+  return result.filenames
+    .filter((f) => LINTABLE_EXTENSIONS.some((ext) => f.endsWith(ext)))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Lint a set of discovered files via the realm's `_lint` endpoint. Returns
+ * per-file violations and a flat list of error-severity violations. Failures
+ * reading or linting a single file are captured in-place as synthetic
+ * `lint-error` entries; they do not abort the run.
+ */
+export async function lintRealmFiles(
+  options: LintRealmFilesOptions,
+  files: string[],
+): Promise<Omit<LintRealmFilesOutput, 'lintableFiles'>> {
+  let lintFileFn =
+    options.lintFileFn ??
+    ((realmUrl: string, source: string, filename: string) =>
+      options.client.lint(realmUrl, source, filename));
+  let readFileFn =
+    options.readFileFn ??
+    (async (realmUrl: string, path: string) => {
+      let result = await options.client.read(realmUrl, path);
+      return {
+        ok: result.ok,
+        content:
+          result.content ??
+          (result.document ? JSON.stringify(result.document) : undefined),
+        error: result.error,
+      };
+    });
+
+  let startedAt = Date.now();
+  let fileResults: LintFileResultData[] = [];
+  let errorViolations: LintErrorViolation[] = [];
+
+  for (let file of files) {
+    try {
+      let readResult = await readFileFn(options.targetRealmUrl, file);
+      if (!readResult.ok) {
+        recordReadError(
+          file,
+          readResult.error ?? 'read failed',
+          fileResults,
+          errorViolations,
+        );
+        continue;
+      }
+      if (readResult.content == null) {
+        recordReadError(file, 'no content', fileResults, errorViolations);
+        continue;
+      }
+
+      let lintResponse = await lintFileFn(
+        options.targetRealmUrl,
+        readResult.content,
+        file,
+      );
+
+      let violations: LintViolationData[] = lintResponse.messages.map(
+        (msg) => ({
+          rule: msg.ruleId ?? 'unknown',
+          file,
+          line: msg.line,
+          column: msg.column,
+          message: msg.message,
+          severity:
+            msg.severity === 2 ? ('error' as const) : ('warning' as const),
+        }),
+      );
+
+      fileResults.push({ file, violations });
+
+      for (let v of violations) {
+        if (v.severity === 'error') {
+          errorViolations.push({
+            rule: v.rule ?? 'unknown',
+            file: v.file,
+            line: v.line,
+            message: v.message,
+          });
+        }
+      }
+    } catch (err) {
+      let message = `Lint failed: ${err instanceof Error ? err.message : String(err)}`;
+      log.warn(`Error linting ${file}: ${message}`);
+      recordSyntheticError(file, message, fileResults, errorViolations);
+    }
+  }
+
+  return {
+    fileResults,
+    errorViolations,
+    durationMs: Date.now() - startedAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// In-memory agent tool
+// ---------------------------------------------------------------------------
+
+/**
+ * Run ESLint + Prettier via the realm's `_lint` endpoint on every lintable
+ * file and return a flat, JSON-friendly result. Unlike `LintValidationStep`,
+ * this does NOT create or update a `LintResult` card — the result is
+ * consumed by the agent directly for mid-turn self-validation.
+ */
+export async function runLintInMemory(
+  options: RunLintInMemoryOptions,
+): Promise<RunLintResult> {
+  let lintableFiles: string[];
+  try {
+    lintableFiles = await discoverLintableFiles({
+      targetRealmUrl: options.targetRealmUrl,
+      client: options.client,
+    });
+  } catch (err) {
+    return emptyErrorResult(
+      `Failed to discover lintable files: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (lintableFiles.length === 0) {
+    return {
+      status: 'passed',
+      filesChecked: 0,
+      filesWithErrors: 0,
+      errorCount: 0,
+      warningCount: 0,
+      durationMs: 0,
+      lintableFiles: [],
+      violations: [],
+    };
+  }
+
+  try {
+    let { fileResults, durationMs } = await lintRealmFiles(
+      {
+        targetRealmUrl: options.targetRealmUrl,
+        client: options.client,
+      },
+      lintableFiles,
+    );
+
+    let violations: RunLintViolation[] = [];
+    let errorCount = 0;
+    let warningCount = 0;
+    let filesWithErrors = 0;
+    for (let fr of fileResults) {
+      let fileHasError = false;
+      for (let v of fr.violations) {
+        violations.push({
+          rule: v.rule ?? 'unknown',
+          file: v.file,
+          line: v.line,
+          column: v.column,
+          message: v.message,
+          severity: v.severity,
+        });
+        if (v.severity === 'error') {
+          errorCount += 1;
+          fileHasError = true;
+        } else {
+          warningCount += 1;
+        }
+      }
+      if (fileHasError) filesWithErrors += 1;
+    }
+
+    return {
+      status: errorCount === 0 ? 'passed' : 'failed',
+      filesChecked: fileResults.length,
+      filesWithErrors,
+      errorCount,
+      warningCount,
+      durationMs,
+      lintableFiles,
+      violations,
+    };
+  } catch (err) {
+    let errorMessage = err instanceof Error ? err.message : String(err);
+    log.error(`runLintInMemory error: ${errorMessage}`);
+    return {
+      status: 'error',
+      filesChecked: 0,
+      filesWithErrors: 0,
+      errorCount: 0,
+      warningCount: 0,
+      durationMs: 0,
+      lintableFiles,
+      violations: [],
+      errorMessage,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function recordReadError(
+  file: string,
+  detail: string,
+  fileResults: LintFileResultData[],
+  errorViolations: LintErrorViolation[],
+): void {
+  let message = `Could not read ${file}: ${detail}`;
+  log.warn(message);
+  recordSyntheticError(file, message, fileResults, errorViolations);
+}
+
+function recordSyntheticError(
+  file: string,
+  message: string,
+  fileResults: LintFileResultData[],
+  errorViolations: LintErrorViolation[],
+): void {
+  fileResults.push({
+    file,
+    violations: [
+      {
+        rule: 'lint-error',
+        file,
+        line: 0,
+        column: 0,
+        message,
+        severity: 'error',
+      },
+    ],
+  });
+  errorViolations.push({ rule: 'lint-error', file, line: 0, message });
+}
+
+function emptyErrorResult(errorMessage: string): RunLintResult {
+  return {
+    status: 'error',
+    filesChecked: 0,
+    filesWithErrors: 0,
+    errorCount: 0,
+    warningCount: 0,
+    durationMs: 0,
+    lintableFiles: [],
+    violations: [],
+    errorMessage,
+  };
+}

--- a/packages/software-factory/src/lint-execution.ts
+++ b/packages/software-factory/src/lint-execution.ts
@@ -57,7 +57,6 @@ export interface LintRealmFilesOptions {
 }
 
 export interface LintRealmFilesOutput {
-  lintableFiles: string[];
   fileResults: LintFileResultData[];
   /** Error-severity violations, flattened across files. */
   errorViolations: LintErrorViolation[];
@@ -71,6 +70,14 @@ export interface LintRealmFilesOutput {
 export interface RunLintInMemoryOptions {
   targetRealmUrl: string;
   client: BoxelCLIClient;
+  /**
+   * When set, lint only this realm-relative file instead of discovering
+   * all lintable files. Useful for mid-turn self-validation right after
+   * writing a single file. The extension must be one of `.gts`, `.gjs`,
+   * `.ts`, or `.js` — other paths return `status: 'error'` without
+   * calling the realm.
+   */
+  path?: string;
 }
 
 export interface RunLintViolation {
@@ -135,7 +142,7 @@ export async function discoverLintableFiles(
 export async function lintRealmFiles(
   options: LintRealmFilesOptions,
   files: string[],
-): Promise<Omit<LintRealmFilesOutput, 'lintableFiles'>> {
+): Promise<LintRealmFilesOutput> {
   let lintFileFn =
     options.lintFileFn ??
     ((realmUrl: string, source: string, filename: string) =>
@@ -232,15 +239,24 @@ export async function runLintInMemory(
   options: RunLintInMemoryOptions,
 ): Promise<RunLintResult> {
   let lintableFiles: string[];
-  try {
-    lintableFiles = await discoverLintableFiles({
-      targetRealmUrl: options.targetRealmUrl,
-      client: options.client,
-    });
-  } catch (err) {
-    return emptyErrorResult(
-      `Failed to discover lintable files: ${err instanceof Error ? err.message : String(err)}`,
-    );
+  if (options.path) {
+    if (!LINTABLE_EXTENSIONS.some((ext) => options.path!.endsWith(ext))) {
+      return emptyErrorResult(
+        `Path "${options.path}" is not lintable — must end with one of ${LINTABLE_EXTENSIONS.join(', ')}`,
+      );
+    }
+    lintableFiles = [options.path];
+  } else {
+    try {
+      lintableFiles = await discoverLintableFiles({
+        targetRealmUrl: options.targetRealmUrl,
+        client: options.client,
+      });
+    } catch (err) {
+      return emptyErrorResult(
+        `Failed to discover lintable files: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   if (lintableFiles.length === 0) {

--- a/packages/software-factory/src/validators/lint-step.ts
+++ b/packages/software-factory/src/validators/lint-step.ts
@@ -12,13 +12,13 @@ import type { BoxelCLIClient, LintResult } from '@cardstack/boxel-cli/api';
 import type { ValidationStepResult } from '../factory-agent';
 import { deriveIssueSlug } from '../factory-agent';
 
-import { getNextValidationSequenceNumber } from '../realm-operations';
 import {
-  createLintResult,
-  completeLintResult,
-  type LintFileResultData,
-  type LintViolationData,
-} from '../lint-result-cards';
+  discoverLintableFiles,
+  lintRealmFiles,
+  type LintErrorViolation,
+} from '../lint-execution';
+import { getNextValidationSequenceNumber } from '../realm-operations';
+import { createLintResult, completeLintResult } from '../lint-result-cards';
 import { logger } from '../logger';
 
 import type { ValidationStepRunner } from './validation-pipeline';
@@ -62,10 +62,8 @@ export interface LintValidationDetails {
   filesChecked: number;
   filesWithErrors: number;
   totalViolations: number;
-  violations: { rule: string; file: string; line: number; message: string }[];
+  violations: LintErrorViolation[];
 }
-
-const LINTABLE_EXTENSIONS = ['.gts', '.gjs', '.ts', '.js'];
 
 // ---------------------------------------------------------------------------
 // LintValidationStep
@@ -77,18 +75,6 @@ export class LintValidationStep implements ValidationStepRunner {
   private config: LintValidationStepConfig;
   private lastSequenceNumber = 0;
 
-  private fetchFilenamesFn: (
-    realmUrl: string,
-  ) => Promise<{ filenames: string[]; error?: string }>;
-  private lintFileFn: (
-    realmUrl: string,
-    source: string,
-    filename: string,
-  ) => Promise<LintResult>;
-  private readFileFn: (
-    realmUrl: string,
-    path: string,
-  ) => Promise<{ ok: boolean; content?: string; error?: string }>;
   private getNextSeqFn: (
     slug: string,
     targetRealmUrl: string,
@@ -96,25 +82,6 @@ export class LintValidationStep implements ValidationStepRunner {
 
   constructor(config: LintValidationStepConfig) {
     this.config = config;
-    this.fetchFilenamesFn =
-      config.fetchFilenames ??
-      ((realmUrl: string) => config.client.listFiles(realmUrl));
-    this.lintFileFn =
-      config.lintFileFn ??
-      ((realmUrl: string, source: string, filename: string) =>
-        config.client.lint(realmUrl, source, filename));
-    this.readFileFn =
-      config.readFileFn ??
-      (async (realmUrl: string, path: string) => {
-        let result = await config.client.read(realmUrl, path);
-        return {
-          ok: result.ok,
-          content:
-            result.content ??
-            (result.document ? JSON.stringify(result.document) : undefined),
-          error: result.error,
-        };
-      });
     this.getNextSeqFn =
       config.getNextSequenceNumber ??
       ((slug: string, targetRealmUrl: string) =>
@@ -135,7 +102,11 @@ export class LintValidationStep implements ValidationStepRunner {
     // Step 1: Discover lintable files
     let lintableFiles: string[];
     try {
-      lintableFiles = await this.discoverLintableFiles(targetRealmUrl);
+      lintableFiles = await discoverLintableFiles({
+        targetRealmUrl,
+        client: this.config.client,
+        fetchFilenames: this.config.fetchFilenames,
+      });
     } catch (err) {
       return {
         step: 'lint',
@@ -213,104 +184,21 @@ export class LintValidationStep implements ValidationStepRunner {
       lintResultId = `Validations/lint_${slug}-${seq}`;
     }
 
-    // Step 3: Lint each file
-    let startedAt = Date.now();
-    let allFileResults: LintFileResultData[] = [];
-    let allViolations: LintValidationDetails['violations'] = [];
+    // Step 3: Lint each file via the shared engine.
+    let {
+      fileResults: allFileResults,
+      errorViolations: allViolations,
+      durationMs,
+    } = await lintRealmFiles(
+      {
+        targetRealmUrl,
+        client: this.config.client,
+        lintFileFn: this.config.lintFileFn,
+        readFileFn: this.config.readFileFn,
+      },
+      lintableFiles,
+    );
 
-    for (let file of lintableFiles) {
-      try {
-        let readResult = await this.readFileFn(targetRealmUrl, file);
-        if (!readResult.ok) {
-          let message = `Could not read ${file}: ${readResult.error ?? 'read failed'}`;
-          log.warn(message);
-          allFileResults.push({
-            file,
-            violations: [
-              {
-                rule: 'lint-error',
-                file,
-                line: 0,
-                column: 0,
-                message,
-                severity: 'error',
-              },
-            ],
-          });
-          allViolations.push({ rule: 'lint-error', file, line: 0, message });
-          continue;
-        }
-        if (readResult.content == null) {
-          let message = `Could not read ${file}: no content`;
-          log.warn(message);
-          allFileResults.push({
-            file,
-            violations: [
-              {
-                rule: 'lint-error',
-                file,
-                line: 0,
-                column: 0,
-                message,
-                severity: 'error',
-              },
-            ],
-          });
-          allViolations.push({ rule: 'lint-error', file, line: 0, message });
-          continue;
-        }
-
-        let lintResponse = await this.lintFileFn(
-          targetRealmUrl,
-          readResult.content,
-          file,
-        );
-
-        let violations: LintViolationData[] = lintResponse.messages.map(
-          (msg) => ({
-            rule: msg.ruleId ?? 'unknown',
-            file,
-            line: msg.line,
-            column: msg.column,
-            message: msg.message,
-            severity:
-              msg.severity === 2 ? ('error' as const) : ('warning' as const),
-          }),
-        );
-
-        allFileResults.push({ file, violations });
-
-        for (let v of violations) {
-          if (v.severity === 'error') {
-            allViolations.push({
-              rule: v.rule ?? 'unknown',
-              file: v.file,
-              line: v.line,
-              message: v.message,
-            });
-          }
-        }
-      } catch (err) {
-        let message = `Lint failed: ${err instanceof Error ? err.message : String(err)}`;
-        log.warn(`Error linting ${file}: ${message}`);
-        allFileResults.push({
-          file,
-          violations: [
-            {
-              rule: 'lint-error',
-              file,
-              line: 0,
-              column: 0,
-              message,
-              severity: 'error',
-            },
-          ],
-        });
-        allViolations.push({ rule: 'lint-error', file, line: 0, message });
-      }
-    }
-
-    let durationMs = Date.now() - startedAt;
     let passed = allViolations.length === 0;
 
     // Step 4: Complete the LintResult card
@@ -390,24 +278,5 @@ export class LintValidationStep implements ValidationStepRunner {
     }
 
     return lines.join('\n');
-  }
-
-  // -------------------------------------------------------------------------
-  // Private helpers
-  // -------------------------------------------------------------------------
-
-  private async discoverLintableFiles(
-    targetRealmUrl: string,
-  ): Promise<string[]> {
-    let result = await this.fetchFilenamesFn(targetRealmUrl);
-
-    if (result.error) {
-      log.warn(`Failed to fetch realm filenames: ${result.error}`);
-      throw new Error(result.error);
-    }
-
-    return result.filenames
-      .filter((f) => LINTABLE_EXTENSIONS.some((ext) => f.endsWith(ext)))
-      .sort((a, b) => a.localeCompare(b));
   }
 }

--- a/packages/software-factory/tests/factory-tool-builder.test.ts
+++ b/packages/software-factory/tests/factory-tool-builder.test.ts
@@ -1013,6 +1013,113 @@ module(
 // removed and is no longer part of buildFactoryTools.
 
 // ---------------------------------------------------------------------------
+// run_lint tool (in-memory validation — CS-10776)
+// ---------------------------------------------------------------------------
+
+module('buildFactoryTools — run_lint', function () {
+  test('registers run_lint with empty parameters', function (assert) {
+    let config = makeConfig();
+    let { executor } = createMockToolExecutor(new Map());
+    let tools = buildFactoryTools(config, executor, new ToolRegistry());
+    let runLint = tools.find((t) => t.name === 'run_lint')!;
+    assert.ok(runLint, 'run_lint tool is registered');
+    assert.deepEqual(
+      runLint.parameters,
+      { type: 'object', properties: {} },
+      'run_lint takes no arguments',
+    );
+  });
+
+  test('delegates to injected runLintInMemory and forwards realm config', async function (assert) {
+    let capturedOptions:
+      | {
+          targetRealmUrl: string;
+          hasClient: boolean;
+        }
+      | undefined;
+    let stubResult = {
+      status: 'passed' as const,
+      filesChecked: 2,
+      filesWithErrors: 0,
+      errorCount: 0,
+      warningCount: 0,
+      durationMs: 17,
+      lintableFiles: ['a.gts', 'b.gts'],
+      violations: [],
+    };
+
+    let config = makeConfig({
+      runLintInMemory: async (options) => {
+        capturedOptions = {
+          targetRealmUrl: options.targetRealmUrl,
+          hasClient: Boolean(options.client),
+        };
+        return stubResult;
+      },
+    });
+    let { executor } = createMockToolExecutor(new Map());
+    let tools = buildFactoryTools(config, executor, new ToolRegistry());
+    let runLint = tools.find((t) => t.name === 'run_lint')!;
+
+    let result = await runLint.execute({});
+
+    assert.deepEqual(result, stubResult, 'tool returns the in-memory result');
+    assert.strictEqual(
+      capturedOptions?.targetRealmUrl,
+      TARGET_REALM,
+      'forwards targetRealmUrl from config',
+    );
+    assert.true(
+      capturedOptions?.hasClient,
+      'forwards the configured BoxelCLIClient',
+    );
+  });
+
+  test('propagates failed lint results unchanged', async function (assert) {
+    let stubResult = {
+      status: 'failed' as const,
+      filesChecked: 1,
+      filesWithErrors: 1,
+      errorCount: 2,
+      warningCount: 0,
+      durationMs: 12,
+      lintableFiles: ['bad.gts'],
+      violations: [
+        {
+          rule: 'no-unused-vars',
+          file: 'bad.gts',
+          line: 4,
+          column: 5,
+          message: "'unusedVar' is assigned a value but never used.",
+          severity: 'error' as const,
+        },
+        {
+          rule: 'prettier/prettier',
+          file: 'bad.gts',
+          line: 7,
+          column: 1,
+          message: 'Insert `;`',
+          severity: 'error' as const,
+        },
+      ],
+    };
+    let config = makeConfig({
+      runLintInMemory: async () => stubResult,
+    });
+    let { executor } = createMockToolExecutor(new Map());
+    let tools = buildFactoryTools(config, executor, new ToolRegistry());
+    let runLint = tools.find((t) => t.name === 'run_lint')!;
+
+    let result = (await runLint.execute({})) as typeof stubResult;
+
+    assert.strictEqual(result.status, 'failed');
+    assert.strictEqual(result.errorCount, 2);
+    assert.strictEqual(result.violations.length, 2);
+    assert.strictEqual(result.violations[0].rule, 'no-unused-vars');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // add_comment tool
 // ---------------------------------------------------------------------------
 

--- a/packages/software-factory/tests/factory-tool-builder.test.ts
+++ b/packages/software-factory/tests/factory-tool-builder.test.ts
@@ -1017,17 +1017,20 @@ module(
 // ---------------------------------------------------------------------------
 
 module('buildFactoryTools — run_lint', function () {
-  test('registers run_lint with empty parameters', function (assert) {
+  test('registers run_lint with an optional path parameter', function (assert) {
     let config = makeConfig();
     let { executor } = createMockToolExecutor(new Map());
     let tools = buildFactoryTools(config, executor, new ToolRegistry());
     let runLint = tools.find((t) => t.name === 'run_lint')!;
     assert.ok(runLint, 'run_lint tool is registered');
-    assert.deepEqual(
-      runLint.parameters,
-      { type: 'object', properties: {} },
-      'run_lint takes no arguments',
-    );
+    let params = runLint.parameters as {
+      type: string;
+      properties: Record<string, { type: string }>;
+      required?: string[];
+    };
+    assert.strictEqual(params.type, 'object');
+    assert.strictEqual(params.properties.path.type, 'string');
+    assert.strictEqual(params.required, undefined, 'path is optional');
   });
 
   test('delegates to injected runLintInMemory and forwards realm config', async function (assert) {
@@ -1035,6 +1038,7 @@ module('buildFactoryTools — run_lint', function () {
       | {
           targetRealmUrl: string;
           hasClient: boolean;
+          path: string | undefined;
         }
       | undefined;
     let stubResult = {
@@ -1053,6 +1057,7 @@ module('buildFactoryTools — run_lint', function () {
         capturedOptions = {
           targetRealmUrl: options.targetRealmUrl,
           hasClient: Boolean(options.client),
+          path: options.path,
         };
         return stubResult;
       },
@@ -1072,6 +1077,86 @@ module('buildFactoryTools — run_lint', function () {
     assert.true(
       capturedOptions?.hasClient,
       'forwards the configured BoxelCLIClient',
+    );
+    assert.strictEqual(
+      capturedOptions?.path,
+      undefined,
+      'path is omitted when not provided',
+    );
+  });
+
+  test('forwards path when provided to single-file lint', async function (assert) {
+    let capturedPath: string | undefined;
+    let stubResult = {
+      status: 'failed' as const,
+      filesChecked: 1,
+      filesWithErrors: 1,
+      errorCount: 1,
+      warningCount: 0,
+      durationMs: 8,
+      lintableFiles: ['my-card.gts'],
+      violations: [
+        {
+          rule: 'no-unused-vars',
+          file: 'my-card.gts',
+          line: 3,
+          column: 5,
+          message: "'unusedVar' is assigned a value but never used.",
+          severity: 'error' as const,
+        },
+      ],
+    };
+
+    let config = makeConfig({
+      runLintInMemory: async (options) => {
+        capturedPath = options.path;
+        return stubResult;
+      },
+    });
+    let { executor } = createMockToolExecutor(new Map());
+    let tools = buildFactoryTools(config, executor, new ToolRegistry());
+    let runLint = tools.find((t) => t.name === 'run_lint')!;
+
+    let result = (await runLint.execute({
+      path: 'my-card.gts',
+    })) as typeof stubResult;
+
+    assert.strictEqual(
+      capturedPath,
+      'my-card.gts',
+      'path is forwarded to the engine',
+    );
+    assert.strictEqual(result.status, 'failed');
+    assert.deepEqual(result.lintableFiles, ['my-card.gts']);
+  });
+
+  test('empty-string path is treated as "no path" (whole-realm lint)', async function (assert) {
+    let capturedPath: string | undefined;
+    let config = makeConfig({
+      runLintInMemory: async (options) => {
+        capturedPath = options.path;
+        return {
+          status: 'passed' as const,
+          filesChecked: 0,
+          filesWithErrors: 0,
+          errorCount: 0,
+          warningCount: 0,
+          durationMs: 0,
+          lintableFiles: [],
+          violations: [],
+        };
+      },
+    });
+    let { executor } = createMockToolExecutor(new Map());
+    let tools = buildFactoryTools(config, executor, new ToolRegistry());
+    let runLint = tools.find((t) => t.name === 'run_lint')!;
+
+    await runLint.execute({ path: '   ' });
+
+    assert.strictEqual(
+      capturedPath,
+      undefined,
+      'whitespace-only path falls back to whole-realm lint',
     );
   });
 

--- a/packages/software-factory/tests/helpers/lint-test-fixtures.ts
+++ b/packages/software-factory/tests/helpers/lint-test-fixtures.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared lint test fixtures used by `lint-validation.spec.ts` (which tests
+ * the full `LintValidationStep` including `LintResult` artifact creation)
+ * and `run-lint-in-memory.spec.ts` (which tests the in-memory agent tool).
+ *
+ * The same dirty source is used by both specs so any future tweak to the
+ * canonical "intentionally broken" sample stays in one place.
+ */
+
+/**
+ * A `.gts` file with a lint violation that the realm's `_lint` endpoint
+ * (ESLint + Prettier + `@cardstack/boxel` rules) reports as an error. The
+ * `no-unused-vars` rule flags `unusedVar` and auto-fix cannot remove it.
+ */
+export const BAD_LINT_GTS = `import {
+  CardDef,
+} from 'https://cardstack.com/base/card-api';
+
+let unusedVar = 42;
+
+export class BadCard extends CardDef {}
+`;

--- a/packages/software-factory/tests/lint-validation.spec.ts
+++ b/packages/software-factory/tests/lint-validation.spec.ts
@@ -4,6 +4,7 @@ import { expect, test } from './fixtures';
 
 import { LintValidationStep } from '../src/validators/lint-step';
 import type { LintValidationDetails } from '../src/validators/lint-step';
+import { BAD_LINT_GTS } from './helpers/lint-test-fixtures';
 import { buildTestClient } from './helpers/test-client';
 
 const fixtureRealmDir = resolve(
@@ -11,17 +12,6 @@ const fixtureRealmDir = resolve(
   'test-fixtures',
   'test-realm-runner',
 );
-
-// A .gts file with a lint violation that can't be auto-fixed.
-// The `no-unused-vars` rule flags `unusedVar` and auto-fix cannot remove it.
-const BAD_LINT_GTS = `import {
-  CardDef,
-} from 'https://cardstack.com/base/card-api';
-
-let unusedVar = 42;
-
-export class BadCard extends CardDef {}
-`;
 
 test.use({ realmDir: fixtureRealmDir });
 test.use({ realmServerMode: 'isolated' });

--- a/packages/software-factory/tests/run-lint-in-memory.spec.ts
+++ b/packages/software-factory/tests/run-lint-in-memory.spec.ts
@@ -179,4 +179,92 @@ test.describe('runLintInMemory e2e', () => {
     expect(result.lintableFiles).toEqual([]);
     expect(result.violations).toEqual([]);
   });
+
+  test('path option: lints only the named file and skips the rest of the realm', async ({
+    realm,
+  }) => {
+    let realmUrl = realm.realmURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let serverToken = `Bearer ${realm.serverToken}`;
+
+    let { client, cleanup } = buildTestClient({
+      realmUrl,
+      realmToken: authorization,
+      realmServerUrl: realm.realmServerURL.href,
+      realmServerToken: serverToken,
+    });
+
+    try {
+      // Seed a dirty file alongside the fixture's clean hello.gts.
+      let writeResult = await client.write(
+        realmUrl,
+        'bad-lint.gts',
+        BAD_LINT_GTS,
+      );
+      expect(writeResult.ok).toBe(true);
+      let indexed = await client.waitForFile(realmUrl, 'bad-lint.gts', {
+        pollMs: 300,
+        timeoutMs: 30_000,
+      });
+      expect(indexed).toBe(true);
+
+      // Lint only the clean file — should pass even though bad-lint.gts is dirty.
+      let cleanOnly = await runLintInMemory({
+        targetRealmUrl: realmUrl,
+        client,
+        path: 'hello.gts',
+      });
+      expect(cleanOnly.status).toBe('passed');
+      expect(cleanOnly.lintableFiles).toEqual(['hello.gts']);
+      expect(cleanOnly.filesChecked).toBe(1);
+      expect(cleanOnly.errorCount).toBe(0);
+
+      // Lint only the dirty file — should fail and mention only that file.
+      let dirtyOnly = await runLintInMemory({
+        targetRealmUrl: realmUrl,
+        client,
+        path: 'bad-lint.gts',
+      });
+      expect(dirtyOnly.status).toBe('failed');
+      expect(dirtyOnly.lintableFiles).toEqual(['bad-lint.gts']);
+      expect(dirtyOnly.filesChecked).toBe(1);
+      expect(dirtyOnly.errorCount).toBeGreaterThan(0);
+      let fileSet = new Set(dirtyOnly.violations.map((v) => v.file));
+      expect(Array.from(fileSet)).toEqual(['bad-lint.gts']);
+
+      // Still no realm artifact written.
+      let listing = await client.listFiles(realmUrl);
+      let validationArtifacts = (listing.filenames ?? []).filter((f) =>
+        f.startsWith('Validations/lint_'),
+      );
+      expect(validationArtifacts).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('path option: non-lintable extension returns status: error without a realm call', async () => {
+    let listFilesCalls = 0;
+    let stubClient: BoxelCLIClient = {
+      listFiles: async () => {
+        listFilesCalls += 1;
+        return { filenames: [] };
+      },
+      lint: async () => {
+        throw new Error('should not be called for non-lintable path');
+      },
+    } as unknown as BoxelCLIClient;
+
+    let result = await runLintInMemory({
+      targetRealmUrl: 'http://localhost:1/',
+      client: stubClient,
+      path: 'Spec/sticky-note.json',
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.errorMessage).toContain('not lintable');
+    expect(result.lintableFiles).toEqual([]);
+    expect(result.violations).toEqual([]);
+    expect(listFilesCalls).toBe(0);
+  });
 });

--- a/packages/software-factory/tests/run-lint-in-memory.spec.ts
+++ b/packages/software-factory/tests/run-lint-in-memory.spec.ts
@@ -1,0 +1,182 @@
+import { resolve } from 'node:path';
+
+import type { BoxelCLIClient } from '@cardstack/boxel-cli/api';
+
+import { expect, test } from './fixtures';
+
+import { runLintInMemory } from '../src/lint-execution';
+import { BAD_LINT_GTS } from './helpers/lint-test-fixtures';
+import { buildTestClient } from './helpers/test-client';
+
+const fixtureRealmDir = resolve(
+  process.cwd(),
+  'test-fixtures',
+  'test-realm-runner',
+);
+
+test.use({ realmDir: fixtureRealmDir });
+test.use({ realmServerMode: 'isolated' });
+
+test.describe('runLintInMemory e2e', () => {
+  test('clean realm returns status: passed with no realm artifacts', async ({
+    realm,
+  }) => {
+    let realmUrl = realm.realmURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let serverToken = `Bearer ${realm.serverToken}`;
+
+    let { client, cleanup } = buildTestClient({
+      realmUrl,
+      realmToken: authorization,
+      realmServerUrl: realm.realmServerURL.href,
+      realmServerToken: serverToken,
+    });
+
+    try {
+      // The fixture realm ships with a clean hello.gts and hello.test.gts.
+      let result = await runLintInMemory({
+        targetRealmUrl: realmUrl,
+        client,
+      });
+
+      expect(result.status).toBe('passed');
+      expect(result.errorCount).toBe(0);
+      expect(result.filesChecked).toBeGreaterThan(0);
+      expect(result.filesWithErrors).toBe(0);
+      expect(result.lintableFiles).toContain('hello.gts');
+      expect(result.violations.filter((v) => v.severity === 'error')).toEqual(
+        [],
+      );
+      expect(result.errorMessage).toBeUndefined();
+
+      // In-memory tool must not write any LintResult card artifact.
+      let listing = await client.listFiles(realmUrl);
+      let validationArtifacts = (listing.filenames ?? []).filter((f) =>
+        f.startsWith('Validations/lint_'),
+      );
+      expect(validationArtifacts).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('dirty file produces status: failed with violation details and no realm artifacts', async ({
+    realm,
+  }) => {
+    let realmUrl = realm.realmURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let serverToken = `Bearer ${realm.serverToken}`;
+
+    let { client, cleanup } = buildTestClient({
+      realmUrl,
+      realmToken: authorization,
+      realmServerUrl: realm.realmServerURL.href,
+      realmServerToken: serverToken,
+    });
+
+    try {
+      let writeResult = await client.write(
+        realmUrl,
+        'bad-lint.gts',
+        BAD_LINT_GTS,
+      );
+      expect(writeResult.ok).toBe(true);
+      let indexed = await client.waitForFile(realmUrl, 'bad-lint.gts', {
+        pollMs: 300,
+        timeoutMs: 30_000,
+      });
+      expect(indexed).toBe(true);
+
+      let result = await runLintInMemory({
+        targetRealmUrl: realmUrl,
+        client,
+      });
+
+      expect(result.status).toBe('failed');
+      expect(result.errorCount).toBeGreaterThan(0);
+      expect(result.lintableFiles).toContain('bad-lint.gts');
+      expect(result.violations.length).toBeGreaterThan(0);
+
+      let errorsOnBadFile = result.violations.filter(
+        (v) => v.file === 'bad-lint.gts' && v.severity === 'error',
+      );
+      expect(errorsOnBadFile.length).toBeGreaterThan(0);
+      let firstError = errorsOnBadFile[0];
+      expect(firstError.message).toBeTruthy();
+      expect(firstError.line).toBeGreaterThan(0);
+      expect(firstError.rule).toBeTruthy();
+      expect(result.filesWithErrors).toBeGreaterThan(0);
+
+      // In-memory tool must not write any LintResult card artifact even
+      // when there are lint failures.
+      let listing = await client.listFiles(realmUrl);
+      let validationArtifacts = (listing.filenames ?? []).filter((f) =>
+        f.startsWith('Validations/lint_'),
+      );
+      expect(validationArtifacts).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('no lintable files produces a vacuous pass', async ({ realm }) => {
+    let realmUrl = realm.realmURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let serverToken = `Bearer ${realm.serverToken}`;
+
+    let { client, cleanup } = buildTestClient({
+      realmUrl,
+      realmToken: authorization,
+      realmServerUrl: realm.realmServerURL.href,
+      realmServerToken: serverToken,
+    });
+
+    try {
+      // Delete all lintable files shipped with the fixture.
+      let listingBefore = await client.listFiles(realmUrl);
+      let lintablePattern = /\.(gts|gjs|ts|js)$/;
+      for (let filename of listingBefore.filenames ?? []) {
+        if (lintablePattern.test(filename)) {
+          let deleteResult = await client.delete(realmUrl, filename);
+          expect(
+            deleteResult.ok,
+            `delete ${filename} failed: ${deleteResult.error}`,
+          ).toBe(true);
+        }
+      }
+
+      let result = await runLintInMemory({
+        targetRealmUrl: realmUrl,
+        client,
+      });
+
+      expect(result.status).toBe('passed');
+      expect(result.errorCount).toBe(0);
+      expect(result.warningCount).toBe(0);
+      expect(result.filesChecked).toBe(0);
+      expect(result.lintableFiles).toEqual([]);
+      expect(result.violations).toEqual([]);
+      expect(result.errorMessage).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('error path: listFiles failure surfaces as status: error', async () => {
+    let thrower: BoxelCLIClient = {
+      listFiles: async () => {
+        throw new Error('ECONNREFUSED');
+      },
+    } as unknown as BoxelCLIClient;
+
+    let result = await runLintInMemory({
+      targetRealmUrl: 'http://localhost:1/',
+      client: thrower,
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.errorMessage).toContain('ECONNREFUSED');
+    expect(result.lintableFiles).toEqual([]);
+    expect(result.violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Expose `run_lint` to the agent as an **in-memory** validator — runs ESLint + Prettier (with `@cardstack/boxel` rules) against every `.gts` / `.gjs` / `.ts` / `.js` file in the target realm via the realm's existing `_lint` endpoint and returns a flat `RunLintResult` (status, error/warning counts, per-violation details). No `LintResult` card is written, so it's safe to call repeatedly mid-turn for self-validation. The orchestrator's post-`signal_done` validation pipeline still writes the durable `LintResult` artifact.
- Extract the per-file discovery + lint loop out of `LintValidationStep` into a shared `lint-execution` engine (`discoverLintableFiles` + `lintRealmFiles`). The card-writing validation path and the new in-memory path both drive this single engine, so rule coverage stays identical.
- Second tool delivered under parent [CS-10775](https://linear.app/cardstack/issue/CS-10775) (agent in-memory validation tools) after CS-10777's `run_tests`.

## Implementation notes

- `src/lint-execution.ts` — new shared engine: `discoverLintableFiles`, `lintRealmFiles`, and the `runLintInMemory` entry point plus its `RunLintInMemoryOptions` / `RunLintResult` / `RunLintViolation` types.
- `src/validators/lint-step.ts` — now delegates discovery and per-file lint to the shared engine; still owns `LintResult` artifact lifecycle and sequence-number bookkeeping. Net diff is a reduction (~180 lines removed from the step).
- `src/factory-tool-builder.ts` — `buildRunLintTool()` wired into `buildFactoryTools()`. Adds a `runLintInMemory` seam on `ToolBuilderConfig` for injection in unit tests.
- `tests/helpers/lint-test-fixtures.ts` — shared `BAD_LINT_GTS` sample, now consumed by the existing `lint-validation.spec.ts` and the new in-memory spec.
- `tests/run-lint-in-memory.spec.ts` — Playwright spec against a real harness realm. Asserts no `Validations/lint_*` artifact is ever written. Covers clean realm, dirty file (violation details), no-lintable-files, and unreachable-realm error paths.
- `tests/factory-tool-builder.test.ts` — three unit tests for the new tool wiring (registration shape, option forwarding, failed-result propagation).
- Docs + `software-factory-operations` skill updated to document `run_lint` as an optional self-validation tool.

## Test plan

- [x] \`pnpm --filter @cardstack/software-factory lint\` (worktree — full per-package lint)
- [x] \`pnpm --filter @cardstack/software-factory exec qunit --require ts-node/register/transpile-only tests/index.ts\` (418 passed)
- [x] \`pnpm --filter @cardstack/software-factory exec playwright test tests/run-lint-in-memory.spec.ts tests/lint-validation.spec.ts\` (7 passed, ~5 min)
- [ ] CI: full factory test matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)