### PR TITLE
Cs 10762/create catalog command for listing cardthumbail creation

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2884,7 +2884,7 @@ export class CardDef extends BaseDef {
   // to use it directly now (or wait until a better image field comes along)
   @field cardThumbnailURL = contains(MaybeBase64Field, {
     computeVia: function (this: CardDef) {
-      return this.cardInfo.cardThumbnail?.url ?? this.cardInfo.cardThumbnailURL;
+      return this.cardInfo.cardThumbnailURL;
     },
   });
   static displayName = 'Card';

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2884,7 +2884,7 @@ export class CardDef extends BaseDef {
   // to use it directly now (or wait until a better image field comes along)
   @field cardThumbnailURL = contains(MaybeBase64Field, {
     computeVia: function (this: CardDef) {
-      return this.cardInfo.cardThumbnailURL;
+      return this.cardInfo.cardThumbnail?.url ?? this.cardInfo.cardThumbnailURL;
     },
   });
   static displayName = 'Card';

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -159,6 +159,31 @@ export class WriteTextFileInput extends CardDef {
   @field useNonConflictingFilename = contains(BooleanField);
 }
 
+export class WriteBinaryFileInput extends CardDef {
+  @field path = contains(StringField);
+  @field realm = contains(StringField);
+  @field base64Content = contains(StringField);
+  @field contentType = contains(StringField);
+  @field useNonConflictingFilename = contains(BooleanField);
+}
+
+export class WriteBinaryFileResult extends CardDef {
+  @field fileUrl = contains(StringField);
+}
+
+export class GenerateThumbnailInput extends CardDef {
+  @field prompt = contains(StringField);
+  @field sourceImageUrl = contains(StringField);
+  @field targetRealmUrl = contains(StringField);
+  @field targetPath = contains(StringField); // optional: subfolder within realm, e.g. "thumbnails"
+  @field targetCardId = contains(StringField);
+  @field llmModel = contains(StringField);
+}
+
+export class GenerateThumbnailOutput extends CardDef {
+  @field imageDefUrl = contains(StringField);
+}
+
 export class CreateInstanceInput extends CardDef {
   @field codeRef = contains(CodeRefField);
   @field realm = contains(StringField);

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -177,6 +177,7 @@ export class GenerateThumbnailInput extends CardDef {
   @field targetRealmUrl = contains(StringField);
   @field targetPath = contains(StringField); // optional: subfolder within realm, e.g. "thumbnails"
   @field targetCardId = contains(StringField);
+  @field cardName = contains(StringField); // card name for filename generation
   @field llmModel = contains(StringField);
 }
 

--- a/packages/base/default-templates/card-info.gts
+++ b/packages/base/default-templates/card-info.gts
@@ -173,7 +173,7 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
           <div class='cardInfo-thumbnail-container'>
             <CardInfoImageContainer
               class='cardInfo-thumbnail-preview'
-              @cardThumbnailURL={{@model.cardInfo.cardThumbnailURL}}
+              @cardThumbnailURL={{@model.cardThumbnailURL}}
               @icon={{@model.constructor.icon}}
               data-test-thumbnail-image
             />

--- a/packages/catalog-realm/commands/create-real-image.gts
+++ b/packages/catalog-realm/commands/create-real-image.gts
@@ -2,6 +2,7 @@ import { CardDef, field, contains } from 'https://cardstack.com/base/card-api';
 import StringField from 'https://cardstack.com/base/string';
 
 import { Command } from '@cardstack/runtime-common';
+import { DEFAULT_IMAGE_GENERATION_LLM } from '@cardstack/runtime-common/matrix-constants';
 import SendRequestViaProxyCommand from '@cardstack/boxel-host/commands/send-request-via-proxy';
 
 import { buildAICues } from '../utils/external/avataar';
@@ -68,7 +69,7 @@ export class CreateRealImage extends Command<
       url: 'https://openrouter.ai/api/v1/chat/completions',
       method: 'POST',
       requestBody: JSON.stringify({
-        model: 'google/gemini-2.5-flash-image-preview',
+        model: DEFAULT_IMAGE_GENERATION_LLM,
         messages: [
           {
             role: 'user',

--- a/packages/catalog-realm/commands/generate-image-command.gts
+++ b/packages/catalog-realm/commands/generate-image-command.gts
@@ -2,6 +2,7 @@ import { CardDef, field, contains } from 'https://cardstack.com/base/card-api';
 import StringField from 'https://cardstack.com/base/string';
 import UrlField from 'https://cardstack.com/base/url';
 import { Command } from '@cardstack/runtime-common';
+import { DEFAULT_IMAGE_GENERATION_LLM } from '@cardstack/runtime-common/matrix-constants';
 import SendRequestViaProxyCommand from '@cardstack/boxel-host/commands/send-request-via-proxy';
 import UploadImageCommand from './upload-image';
 
@@ -114,7 +115,7 @@ export class GenerateImageCommand extends Command<
       url: 'https://openrouter.ai/api/v1/chat/completions',
       method: 'POST',
       requestBody: JSON.stringify({
-        model: 'google/gemini-2.5-flash-image-preview',
+        model: DEFAULT_IMAGE_GENERATION_LLM,
         messages,
       }),
     });

--- a/packages/catalog-realm/commands/generate-images-rotation.gts
+++ b/packages/catalog-realm/commands/generate-images-rotation.gts
@@ -6,9 +6,10 @@ import {
 import StringField from 'https://cardstack.com/base/string';
 
 import { Command } from '@cardstack/runtime-common';
+import { DEFAULT_IMAGE_GENERATION_LLM } from '@cardstack/runtime-common/matrix-constants';
 import SendRequestViaProxyCommand from '@cardstack/boxel-host/commands/send-request-via-proxy';
 
-export const DEFAULT_IMAGE_MODEL = 'google/gemini-2.5-flash-image-preview';
+export const DEFAULT_IMAGE_MODEL = DEFAULT_IMAGE_GENERATION_LLM;
 
 class GenerateImagesRotationInput extends CardDef {
   @field productImages = containsMany(StringField, {

--- a/packages/catalog-realm/commands/generate-thumbnail-command.gts
+++ b/packages/catalog-realm/commands/generate-thumbnail-command.gts
@@ -1,0 +1,1 @@
+export { default as GenerateThumbnailCommand } from '@cardstack/boxel-host/commands/generate-thumbnail';

--- a/packages/host/app/commands/generate-thumbnail.ts
+++ b/packages/host/app/commands/generate-thumbnail.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import { DEFAULT_IMAGE_GENERATION_LLM } from '@cardstack/runtime-common/matrix-constants';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
@@ -44,8 +46,26 @@ function mimeTypeToExtension(mimeType: string): string {
   return map[mimeType] ?? 'png';
 }
 
-function uuidSlug(): string {
-  return Math.random().toString(36).slice(2, 10);
+function generateFilenameFromCardName(cardName: string | undefined): string {
+  const uniqueId = uuidv4().split('-')[0]; // Use first segment of UUID for brevity
+
+  if (!cardName || !cardName.trim()) {
+    return `thumbnail-${uniqueId}`;
+  }
+
+  // Take first two words and slugify
+  const words = cardName
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((word) => word.toLowerCase().replace(/[^a-z0-9]/g, ''))
+    .filter((word) => word.length > 0);
+
+  if (words.length === 0) {
+    return `thumbnail-${uniqueId}`;
+  }
+
+  return `${words.join('-')}-${uniqueId}`;
 }
 
 export default class GenerateThumbnailCommand extends HostBaseCommand<
@@ -67,7 +87,7 @@ export default class GenerateThumbnailCommand extends HostBaseCommand<
   protected async run(
     input: BaseCommandModule.GenerateThumbnailInput,
   ): Promise<BaseCommandModule.GenerateThumbnailOutput> {
-    const { prompt, sourceImageUrl, targetRealmUrl, targetPath, targetCardId } =
+    const { prompt, sourceImageUrl, targetRealmUrl, targetPath, targetCardId, cardName } =
       input;
 
     let promptText = prompt?.trim();
@@ -173,7 +193,7 @@ export default class GenerateThumbnailCommand extends HostBaseCommand<
     const mimeType = mimeMatch[1];
     const extension = mimeTypeToExtension(mimeType);
 
-    const filename = `thumbnail-${uuidSlug()}.${extension}`;
+    const filename = `${generateFilenameFromCardName(cardName)}.${extension}`;
     const filePath = targetPath?.trim()
       ? `${targetPath.trim().replace(/\/$/, '')}/${filename}`
       : filename;

--- a/packages/host/app/commands/generate-thumbnail.ts
+++ b/packages/host/app/commands/generate-thumbnail.ts
@@ -82,13 +82,19 @@ export default class GenerateThumbnailCommand extends HostBaseCommand<
     return GenerateThumbnailInput;
   }
 
-  requireInputFields = ['prompt'];
+  requireInputFields = ['prompt', 'targetRealmUrl'];
 
   protected async run(
     input: BaseCommandModule.GenerateThumbnailInput,
   ): Promise<BaseCommandModule.GenerateThumbnailOutput> {
-    const { prompt, sourceImageUrl, targetRealmUrl, targetPath, targetCardId, cardName } =
-      input;
+    const {
+      prompt,
+      sourceImageUrl,
+      targetRealmUrl,
+      targetPath,
+      targetCardId,
+      cardName,
+    } = input;
 
     let promptText = prompt?.trim();
     if (!promptText) {

--- a/packages/host/app/commands/generate-thumbnail.ts
+++ b/packages/host/app/commands/generate-thumbnail.ts
@@ -1,0 +1,221 @@
+import { DEFAULT_IMAGE_GENERATION_LLM } from '@cardstack/runtime-common/matrix-constants';
+
+import type { CardDef } from 'https://cardstack.com/base/card-api';
+import type * as CardAPI from 'https://cardstack.com/base/card-api';
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
+
+import HostBaseCommand from '../lib/host-base-command';
+
+import PatchCardInstanceCommand from './patch-card-instance';
+import SendRequestViaProxyCommand from './send-request-via-proxy';
+import WriteBinaryFileCommand from './write-binary-file';
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const maybeBuffer = (globalThis as any).Buffer;
+
+  if (typeof maybeBuffer !== 'undefined') {
+    return maybeBuffer.from(buffer).toString('base64');
+  }
+
+  let binary = '';
+  const bytes = new Uint8Array(buffer);
+
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+
+  if (typeof btoa !== 'undefined') {
+    return btoa(binary);
+  }
+
+  throw new Error('Unable to convert image to base64 in this environment');
+}
+
+function mimeTypeToExtension(mimeType: string): string {
+  const map: Record<string, string> = {
+    'image/png': 'png',
+    'image/jpeg': 'jpg',
+    'image/jpg': 'jpg',
+    'image/webp': 'webp',
+    'image/gif': 'gif',
+    'image/svg+xml': 'svg',
+    'image/avif': 'avif',
+  };
+  return map[mimeType] ?? 'png';
+}
+
+function uuidSlug(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+export default class GenerateThumbnailCommand extends HostBaseCommand<
+  typeof BaseCommandModule.GenerateThumbnailInput,
+  typeof BaseCommandModule.GenerateThumbnailOutput
+> {
+  static actionVerb = 'Generate';
+  description =
+    'Generate an AI thumbnail image and save it as an ImageDef in the realm';
+
+  async getInputType() {
+    let commandModule = await this.loadCommandModule();
+    const { GenerateThumbnailInput } = commandModule;
+    return GenerateThumbnailInput;
+  }
+
+  requireInputFields = ['prompt'];
+
+  protected async run(
+    input: BaseCommandModule.GenerateThumbnailInput,
+  ): Promise<BaseCommandModule.GenerateThumbnailOutput> {
+    const { prompt, sourceImageUrl, targetRealmUrl, targetPath, targetCardId } =
+      input;
+
+    let promptText = prompt?.trim();
+    if (!promptText) {
+      throw new Error('A prompt is required to generate a thumbnail.');
+    }
+
+    let imageUrlForMessage: string | undefined;
+    const sourceUrlTrimmed = sourceImageUrl?.trim();
+
+    if (sourceUrlTrimmed) {
+      if (sourceUrlTrimmed.startsWith('data:image/')) {
+        imageUrlForMessage = sourceUrlTrimmed;
+      } else {
+        const imageResponse = await fetch(sourceUrlTrimmed);
+        if (!imageResponse.ok) {
+          throw new Error(
+            `Failed to fetch source image: ${imageResponse.statusText}`,
+          );
+        }
+        const contentType =
+          imageResponse.headers.get('content-type') ?? 'image/png';
+        const arrayBuffer = await imageResponse.arrayBuffer();
+        const base64 = arrayBufferToBase64(arrayBuffer);
+        imageUrlForMessage = `data:${contentType};base64,${base64}`;
+      }
+    }
+
+    const messages: any[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: promptText,
+          },
+          ...(imageUrlForMessage
+            ? [
+                {
+                  type: 'image_url',
+                  image_url: {
+                    url: imageUrlForMessage,
+                  },
+                },
+              ]
+            : []),
+        ],
+      },
+    ];
+
+    const model = input.llmModel?.trim() || DEFAULT_IMAGE_GENERATION_LLM;
+
+    const result = await new SendRequestViaProxyCommand(
+      this.commandContext,
+    ).execute({
+      url: 'https://openrouter.ai/api/v1/chat/completions',
+      method: 'POST',
+      requestBody: JSON.stringify({
+        model,
+        messages,
+      }),
+    });
+
+    if (!result.response.ok) {
+      throw new Error(
+        `Failed to generate thumbnail: ${result.response.statusText}`,
+      );
+    }
+
+    const responseData = await result.response.json();
+    const messageContent = responseData.choices?.[0]?.message;
+
+    if (!messageContent?.images || !Array.isArray(messageContent.images)) {
+      throw new Error('No image was generated in the response.');
+    }
+
+    const generatedDataUrl: string | undefined = messageContent.images
+      .map((img: any) => img.image_url?.url)
+      .find((url: string) => url && url.startsWith('data:image/'));
+
+    if (!generatedDataUrl) {
+      const errorMessage =
+        responseData.choices?.[0]?.message?.content ||
+        'No image was generated in the response.';
+      throw new Error(`Thumbnail generation failed: ${errorMessage}`);
+    }
+
+    // Parse MIME type and base64 content from data URI
+    const commaIndex = generatedDataUrl.indexOf(',');
+    if (commaIndex === -1) {
+      throw new Error(
+        'Generated image data URL is malformed: missing comma separator.',
+      );
+    }
+    const prefix = generatedDataUrl.slice(0, commaIndex);
+    const base64Content = generatedDataUrl.slice(commaIndex + 1);
+    const mimeMatch = prefix.match(/^data:([^;]+);base64$/);
+    if (!mimeMatch) {
+      throw new Error(
+        'Generated image data URL has an unrecognisable MIME type.',
+      );
+    }
+    const mimeType = mimeMatch[1];
+    const extension = mimeTypeToExtension(mimeType);
+
+    const filename = `thumbnail-${uuidSlug()}.${extension}`;
+    const filePath = targetPath?.trim()
+      ? `${targetPath.trim().replace(/\/$/, '')}/${filename}`
+      : filename;
+
+    // Write binary to realm → realm indexes as PngDef/ImageDef automatically
+    const writeResult = await new WriteBinaryFileCommand(
+      this.commandContext,
+    ).execute({
+      path: filePath,
+      realm: targetRealmUrl,
+      base64Content,
+      contentType: mimeType,
+      useNonConflictingFilename: true,
+    });
+
+    if (!writeResult?.fileUrl) {
+      throw new Error('Failed to write binary file to realm.');
+    }
+    const imageDefUrl = writeResult.fileUrl;
+
+    // If a targetCardId is provided, patch cardInfo.cardThumbnail to link the ImageDef
+    if (targetCardId?.trim()) {
+      const cardApiModule = await this.loaderService.loader.import<
+        typeof CardAPI
+      >('https://cardstack.com/base/card-api');
+
+      await new PatchCardInstanceCommand(this.commandContext, {
+        cardType: cardApiModule.CardDef as unknown as typeof CardDef,
+      }).execute({
+        cardId: targetCardId,
+        patch: {
+          relationships: {
+            'cardInfo.cardThumbnail': {
+              links: { self: imageDefUrl },
+            },
+          },
+        },
+      });
+    }
+
+    let commandModule = await this.loadCommandModule();
+    const { GenerateThumbnailOutput } = commandModule;
+    return new GenerateThumbnailOutput({ imageDefUrl });
+  }
+}

--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -28,6 +28,7 @@ import * as FullReindexRealmCommandModule from './full-reindex-realm';
 import * as GenerateExampleCardsCommandModule from './generate-example-cards';
 import * as GenerateReadmeSpecCommandModule from './generate-readme-spec';
 import * as GenerateThemeExampleCommandModule from './generate-theme-example';
+import * as GenerateThumbnailCommandModule from './generate-thumbnail';
 import * as GetAllRealmMetasCommandModule from './get-all-realm-metas';
 import * as GetAvailableRealmUrlsCommandModule from './get-available-realm-urls';
 import * as GetCardCommandModule from './get-card';
@@ -90,6 +91,7 @@ import * as UpdatePlaygroundSelectionCommandModule from './update-playground-sel
 import * as UpdateRoomSkillsCommandModule from './update-room-skills';
 import * as CommandUtilsModule from './utils';
 import * as ValidateRealmCommandModule from './validate-realm';
+import * as WriteBinaryFileCommandModule from './write-binary-file';
 import * as WriteTextFileCommandModule from './write-text-file';
 
 import type HostBaseCommand from '../lib/host-base-command';
@@ -384,6 +386,10 @@ export function shimHostCommands(virtualNetwork: VirtualNetwork) {
     CommandUtilsModule,
   );
   virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/write-binary-file',
+    WriteBinaryFileCommandModule,
+  );
+  virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/write-text-file',
     WriteTextFileCommandModule,
   );
@@ -398,6 +404,10 @@ export function shimHostCommands(virtualNetwork: VirtualNetwork) {
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/generate-readme-spec',
     GenerateReadmeSpecCommandModule,
+  );
+  virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/generate-thumbnail',
+    GenerateThumbnailCommandModule,
   );
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/get-card',
@@ -486,6 +496,7 @@ export const HostCommandClasses: (typeof HostBaseCommand<any, any>)[] = [
   FullReindexRealmCommandModule.default,
   GenerateExampleCardsCommandModule.default,
   GenerateReadmeSpecCommandModule.default,
+  GenerateThumbnailCommandModule.default,
   GetAllRealmMetasCommandModule.default,
   GetAvailableRealmUrlsCommandModule.default,
   GetDefaultWritableRealmCommandModule.default,
@@ -556,5 +567,6 @@ export const HostCommandClasses: (typeof HostBaseCommand<any, any>)[] = [
   UpdateRoomSkillsCommandModule.default,
   UseAiAssistantCommandModule.default,
   ValidateRealmCommandModule.default,
+  WriteBinaryFileCommandModule.default,
   WriteTextFileCommandModule.default,
 ];

--- a/packages/host/app/commands/listing-create.ts
+++ b/packages/host/app/commands/listing-create.ts
@@ -24,6 +24,7 @@ import HostBaseCommand from '../lib/host-base-command';
 
 import AuthedFetchCommand from './authed-fetch';
 import CreateSpecCommand from './create-specs';
+import GenerateThumbnailCommand from './generate-thumbnail';
 import GetCardCommand from './get-card';
 import GetCatalogRealmUrlsCommand from './get-catalog-realm-urls';
 import GetRealmOfUrlCommand from './get-realm-of-url';
@@ -158,6 +159,10 @@ export default class ListingCreateCommand extends HostBaseCommand<
           codeRef.module,
           codeRef,
         ),
+      },
+      {
+        name: 'autoGenerateThumbnail',
+        promise: this.autoGenerateThumbnail(listingCard, codeRef, targetRealm),
       },
     ];
 
@@ -543,6 +548,24 @@ export default class ListingCreateCommand extends HostBaseCommand<
       },
     );
     (listing as any).categories = selected;
+  }
+
+  private async autoGenerateThumbnail(
+    listing: CardAPI.CardDef,
+    codeRef: ResolvedCodeRef,
+    targetRealm: string,
+  ) {
+    if (!listing.id) {
+      return;
+    }
+    const prompt = `Create a square thumbnail for "${codeRef.name}". Top 70%: large centered flat icon (simple, bold, minimal, slightly angled/layered if needed). Bottom 30%: "${codeRef.name}" in big, bold, uppercase sans-serif text. Style: flat vector, solid vivid background, 2–3 colors max. Icon should be white or light-colored, clean geometric shapes, highly recognizable. No gradients, no shadows, no borders, no clutter. Must be clear at small sizes.`;
+
+    await new GenerateThumbnailCommand(this.commandContext).execute({
+      prompt,
+      targetRealmUrl: targetRealm,
+      targetPath: 'ListingThumbnail', // Wrap all thumbnails in a "ListingThumbnail" folder to keep the realm tidy
+      targetCardId: listing.id,
+    });
   }
 
   private async getStringPatch(opts: {

--- a/packages/host/app/commands/listing-create.ts
+++ b/packages/host/app/commands/listing-create.ts
@@ -563,8 +563,9 @@ export default class ListingCreateCommand extends HostBaseCommand<
     await new GenerateThumbnailCommand(this.commandContext).execute({
       prompt,
       targetRealmUrl: targetRealm,
-      targetPath: 'ListingThumbnail', // Wrap all thumbnails in a "ListingThumbnail" folder to keep the realm tidy
+      targetPath: 'ListingThumbnails', // Wrap all thumbnails in a "ListingThumbnails" folder to keep the realm tidy
       targetCardId: listing.id,
+      cardName: codeRef.name,
     });
   }
 

--- a/packages/host/app/commands/listing-create.ts
+++ b/packages/host/app/commands/listing-create.ts
@@ -160,10 +160,6 @@ export default class ListingCreateCommand extends HostBaseCommand<
           codeRef,
         ),
       },
-      {
-        name: 'autoGenerateThumbnail',
-        promise: this.autoGenerateThumbnail(listingCard, codeRef, targetRealm),
-      },
     ];
 
     const backgroundWork = Promise.allSettled(
@@ -177,6 +173,11 @@ export default class ListingCreateCommand extends HostBaseCommand<
           );
         }
       });
+    });
+
+    // Fire-and-forget thumbnail generation (external API call, should not block modal)
+    this.autoGenerateThumbnail(listingCard, codeRef, targetRealm).catch((e) => {
+      console.warn('Failed to auto-generate thumbnail:', e);
     });
 
     const { ListingCreateResult } = commandModule;

--- a/packages/host/app/commands/write-binary-file.ts
+++ b/packages/host/app/commands/write-binary-file.ts
@@ -1,0 +1,119 @@
+import { service } from '@ember/service';
+
+import { v4 as uuidv4 } from 'uuid';
+
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
+
+import HostBaseCommand from '../lib/host-base-command';
+import { findNonConflictingFilename } from '../utils/file-name';
+
+import type CardService from '../services/card-service';
+import type NetworkService from '../services/network';
+import type RealmService from '../services/realm';
+
+function base64ToUint8Array(base64: string): Uint8Array {
+  const maybeBuffer = (globalThis as any).Buffer as
+    | { from(input: string, encoding: string): Buffer }
+    | undefined;
+
+  if (typeof maybeBuffer !== 'undefined') {
+    return new Uint8Array(maybeBuffer.from(base64, 'base64'));
+  }
+
+  if (typeof atob === 'function') {
+    const binaryString = atob(base64);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+    return bytes;
+  }
+
+  throw new Error('No base64 decoder available in this environment');
+}
+
+export default class WriteBinaryFileCommand extends HostBaseCommand<
+  typeof BaseCommandModule.WriteBinaryFileInput,
+  typeof BaseCommandModule.WriteBinaryFileResult
+> {
+  @service declare private cardService: CardService;
+  @service declare private realm: RealmService;
+  @service declare private network: NetworkService;
+
+  description = 'Write a binary file to a realm';
+  static actionVerb = 'Write';
+
+  async getInputType() {
+    let commandModule = await this.loadCommandModule();
+    const { WriteBinaryFileInput } = commandModule;
+    return WriteBinaryFileInput;
+  }
+
+  requireInputFields = ['path', 'base64Content'];
+
+  protected async run(
+    input: BaseCommandModule.WriteBinaryFileInput,
+  ): Promise<BaseCommandModule.WriteBinaryFileResult> {
+    let realm;
+    if (input.realm) {
+      realm = this.realm.realmOfURL(new URL(input.realm));
+      if (!realm) {
+        throw new Error(`Invalid or unknown realm provided: ${input.realm}`);
+      }
+    }
+
+    let path = input.path;
+    if (path.startsWith('/')) {
+      path = path.slice(1);
+    }
+
+    let url = new URL(path, realm?.href);
+    let finalUrl = url;
+
+    if (input.useNonConflictingFilename) {
+      let existing = await this.cardService.getSource(url);
+      if (existing.status === 200 || existing.status === 406) {
+        let nonConflictingUrl = await findNonConflictingFilename(
+          url.href,
+          (candidateUrl) => this.fileExists(candidateUrl),
+        );
+        finalUrl = new URL(nonConflictingUrl);
+      } else if (existing.status !== 404) {
+        throw new Error(
+          `Error checking if file exists at ${url}: ${existing.status}`,
+        );
+      }
+    }
+
+    let bytes = base64ToUint8Array(input.base64Content);
+    let blob = new Blob([bytes.buffer as ArrayBuffer]);
+
+    let clientRequestId = `binary:${uuidv4()}`;
+    this.cardService.clientRequestIds.add(clientRequestId);
+
+    let response = await this.network.authedFetch(finalUrl, {
+      method: 'POST',
+      headers: {
+        // Realm router matches binary uploads by application/octet-stream
+        'Content-Type': 'application/octet-stream',
+        'X-Boxel-Client-Request-Id': clientRequestId,
+      },
+      body: blob,
+    });
+
+    if (!response.ok) {
+      let errorMessage = `Could not write binary file ${finalUrl}, status ${response.status}: ${response.statusText} - ${await response.text()}`;
+      console.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    let commandModule = await this.loadCommandModule();
+    const { WriteBinaryFileResult } = commandModule;
+    return new WriteBinaryFileResult({ fileUrl: finalUrl.href });
+  }
+
+  private async fileExists(fileUrl: string): Promise<boolean> {
+    let getSourceResult = await this.cardService.getSource(new URL(fileUrl));
+    return getSourceResult.status !== 404;
+  }
+}

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -2462,7 +2462,7 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-field="cardInfo-summary"] input')
         .hasValue('The latest novel from John Doe');
-      assert.dom('[data-test-thumbnail-icon]').exists();
+      assert.dom('[data-test-thumbnail-icon]').doesNotExist();
       await click('[data-test-toggle-thumbnail-editor]');
       assert
         .dom('[data-test-thumbnail-placeholder]')

--- a/packages/runtime-common/matrix-constants.ts
+++ b/packages/runtime-common/matrix-constants.ts
@@ -39,6 +39,7 @@ export type LLMMode = 'ask' | 'act';
 export const DEFAULT_LLM = 'anthropic/claude-sonnet-4.6';
 export const DEFAULT_CODING_LLM = 'anthropic/claude-sonnet-4.6';
 export const DEFAULT_REMIX_LLM = 'openai/gpt-5-nano';
+export const DEFAULT_IMAGE_GENERATION_LLM = 'google/gemini-2.5-flash-image';
 
 export const DEFAULT_LLM_ID_TO_NAME: Record<string, string> = {
   'anthropic/claude-3.5-sonnet': 'Anthropic: Claude 3.5 Sonnet',


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-10762/create-catalog-command-for-listing-cardthumbail-creation

# Auto-Generate Thumbnails During Listing Creation

## Changes
- `generate-thumbnail.ts` - New command to generate and save thumbnail images
- `write-binary-file.ts` - New command to persist binary content to realm
- `listing-create.ts` - Wires up auto-generation as background task
- `command.gts` - Adds GenerateThumbnailInput/Output types
- `matrix-constants.ts` - Sets DEFAULT_IMAGE_GENERATION_LLM to google/gemini-2.5-flash-image (several modules were previously using a non-available endpoint, so we centralized it to matrix-constants as a variable for better maintenance going forward)

## How It Works
1. During listing creation, `autoGenerateThumbnail()` runs as non-blocking background task
2. Sends prompt to Gemini 2.5 Flash: 70% icon (top), 30% text (bottom), flat design, square corners
3. Generates image and saves to `ListingThumbnails/<name>-<uuid>.<ext>`
4. Filename uses first 2 words of card name + UUID segment for readability

## Filename Examples
- `User Profile` → `user-profile-a1b2c3d4.png`
- `My Long Component` → `my-long-e5f6g7h8.png`
- No name → `thumbnail-i9j0k1l2.png`



https://github.com/user-attachments/assets/26462c6c-1ff1-4f61-bb0b-c2649e2fa1ea

