### PR TITLE
Add in-memory run_evaluate agent tool (CS-10779)

### DIFF
--- a/packages/software-factory/.agents/skills/software-factory-operations/SKILL.md
+++ b/packages/software-factory/.agents/skills/software-factory-operations/SKILL.md
@@ -36,6 +36,10 @@ The agent has these tools during the execution loop. Use them by name — they a
 - `create_knowledge({ path, attributes, relationships? })` — Create or update a KnowledgeArticle card. Same structured interface with dynamic field schema in the tool parameters.
 - `create_catalog_spec({ path, attributes, relationships? })` — Create a Catalog Spec card in the target realm's `Spec/` folder. Makes a card definition discoverable in the Boxel catalog. Same structured interface with dynamic field schema. The tool auto-constructs the document with `adoptsFrom` pointing to `https://cardstack.com/base/spec#Spec`.
 
+### Self-Validation (in-memory)
+
+- `run_evaluate({ path? })` — Evaluate ESM modules (`.gts` / `.gjs` / `.ts` / `.js`) in the target realm via the prerenderer sandbox and return a `RunEvaluateResult` (status, module counts, per-failure `{ path, error, stackTrace? }`). Without `path`, evaluates every non-test evaluable module. With `path`, evaluates only that single realm-relative file — handy for a quick self-check right after writing one module. Test files (`*.test.*`) are rejected — the test runner validates those. Safe to call repeatedly mid-turn — this tool does NOT create an `EvalResult` card or any other realm artifact. The orchestrator still runs the full validation pipeline (which writes an `EvalResult` card) automatically after `signal_done`, so calling this is optional. When a failure reports a line/column, those numbers refer to the transpiled module — pair with `fetch_transpiled_module` to locate the offending source construct, then fix the `.gts` source (never copy transpiled patterns back into source).
+
 ### Running Host Commands
 
 - `run_command({ command, commandInput? })` — Execute a host command on the realm server via the prerenderer. Commands run in browser context with full card runtime access (Loader, CardAPI, services). Use the specifier format `@cardstack/boxel-host/commands/<name>/default`.

--- a/packages/software-factory/docs/phase-2-plan.md
+++ b/packages/software-factory/docs/phase-2-plan.md
@@ -531,6 +531,14 @@ The `update_issue`, `update_project`, and `create_knowledge` tools perform a **r
 
 The `run_tests` tool is **not exposed** to the agent. The validation pipeline runs tests automatically after every agent turn (after `signal_done`). Giving the agent the tool caused it to waste iterations running tests manually, sometimes before writing test files, and creating duplicate TestRun instances. The system prompt and skills inform the agent that the orchestrator handles test execution.
 
+### run_evaluate: In-Memory Self-Validation (CS-10779)
+
+The `run_evaluate` tool lets the agent evaluate one (or every non-test) ESM module in the target realm via the prerenderer sandbox and get back a flat `RunEvaluateResult` (`status`, `modulesChecked`, `modulesWithErrors`, `durationMs`, `evaluableFiles`, `failures: { path, error, stackTrace? }[]`). Unlike the pipeline's `EvalValidationStep`, it does NOT write an `EvalResult` card — so the agent can call it mid-turn as many times as it likes without creating realm artifacts. The orchestrator still runs the full validation pipeline (which writes the durable `EvalResult` card) after `signal_done`, so calling this tool is optional.
+
+Discovery (all non-test `.gts` / `.gjs` / `.ts` / `.js` files, alphabetical) and per-module evaluation now live in the shared `src/eval-execution.ts` engine, used by both `EvalValidationStep` (card-writing path) and `runEvaluateInMemory` (tool path). The `path` parameter accepts a single realm-relative file; non-evaluable extensions and test files (`*.test.*`) short-circuit to `status: 'error'` without calling the realm.
+
+Failure line/column numbers still reference the transpiled module — the tool description points the agent at `fetch_transpiled_module` for debugging while making explicit that transpiled output is read-only scratch and must never be copied into source.
+
 The `run_command` tool description explicitly states it is for Boxel host commands only (format: `@cardstack/boxel-host/commands/<name>/default`), not shell commands or scripts.
 
 ### Playwright waitForFunction Timeout

--- a/packages/software-factory/src/eval-execution.ts
+++ b/packages/software-factory/src/eval-execution.ts
@@ -1,0 +1,369 @@
+/**
+ * Eval execution — shared engine used by both the validation pipeline's
+ * `EvalValidationStep` (which writes an `EvalResult` card artifact) and the
+ * in-memory `run_evaluate` agent tool (which returns results without side
+ * effects).
+ *
+ * Each file discovered in the realm is evaluated by calling the
+ * `evaluate-module` host command via `_run-command`. The host command hits
+ * `/_prerender-module` which loads and instantiates the module in a
+ * headless Chrome sandbox, so broken imports, circular references, and
+ * top-level runtime errors are all surfaced as a single pass/fail signal
+ * per module.
+ */
+
+import type { BoxelCLIClient } from '@cardstack/boxel-cli/api';
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
+
+import { logger } from './logger';
+
+let log = logger('eval-execution');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** File extensions that can be loaded as ESM modules via the prerenderer. */
+export const EVALUABLE_EXTENSIONS = ['.gts', '.gjs', '.ts', '.js'];
+
+const TEST_FILE_PATTERN = /\.test\.(gts|gjs|ts|js)$/;
+
+const EVALUATE_MODULE_COMMAND =
+  '@cardstack/boxel-host/commands/evaluate-module/default';
+
+// ---------------------------------------------------------------------------
+// Shared engine types
+// ---------------------------------------------------------------------------
+
+export interface EvalModuleResult {
+  passed: boolean;
+  error?: string;
+  stackTrace?: string;
+}
+
+export interface EvalModuleRecord {
+  path: string;
+  error: string;
+  stackTrace?: string;
+}
+
+export interface EvaluateRealmModulesOptions {
+  targetRealmUrl: string;
+  client: BoxelCLIClient;
+  realmServerUrl: string;
+  /** Injected for testing — defaults to client.runCommand → evaluate-module. */
+  evaluateModuleFn?: (
+    moduleUrl: string,
+    realmUrl: string,
+  ) => Promise<EvalModuleResult>;
+}
+
+export interface EvaluateRealmModulesOutput {
+  /** Per-module results for every evaluated file (pass or fail). */
+  moduleResults: EvalModuleRecord[];
+  /** Subset of moduleResults with `passed === false`. */
+  failedModules: EvalModuleRecord[];
+  durationMs: number;
+}
+
+export interface DiscoverEvaluableFilesOptions {
+  targetRealmUrl: string;
+  client: BoxelCLIClient;
+  /** Injected for testing — defaults to client.listFiles. */
+  fetchFilenames?: (
+    realmUrl: string,
+  ) => Promise<{ filenames: string[]; error?: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory tool types
+// ---------------------------------------------------------------------------
+
+export interface RunEvaluateInMemoryOptions {
+  targetRealmUrl: string;
+  realmServerUrl: string;
+  client: BoxelCLIClient;
+  /**
+   * When set, evaluate only this realm-relative file instead of discovering
+   * every non-test ESM module. Useful for mid-turn self-validation right
+   * after writing a single file. The extension must be one of `.gts`,
+   * `.gjs`, `.ts`, or `.js` — other paths return `status: 'error'` without
+   * calling the realm. A `.test.*` path is rejected for the same reason the
+   * whole-realm pass excludes them: the test runner (not the evaluator)
+   * validates test files.
+   */
+  path?: string;
+}
+
+export interface RunEvaluateFailure {
+  path: string;
+  error: string;
+  stackTrace?: string;
+}
+
+export interface RunEvaluateResult {
+  status: 'passed' | 'failed' | 'error';
+  modulesChecked: number;
+  modulesWithErrors: number;
+  durationMs: number;
+  /** Realm-relative evaluable file paths discovered before the run. */
+  evaluableFiles: string[];
+  /** Only the modules that failed to evaluate. */
+  failures: RunEvaluateFailure[];
+  /** Set only when `status === 'error'`. */
+  errorMessage?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Public engine
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover evaluable files in the target realm — `.gts`, `.gjs`, `.ts`,
+ * `.js`, minus any `.test.*` variants. Returns an alphabetically-sorted
+ * list.
+ */
+export async function discoverEvaluableFiles(
+  options: DiscoverEvaluableFilesOptions,
+): Promise<string[]> {
+  let fetchFilenames =
+    options.fetchFilenames ??
+    ((realmUrl: string) => options.client.listFiles(realmUrl));
+
+  let result = await fetchFilenames(options.targetRealmUrl);
+  if (result.error) {
+    log.warn(`Failed to fetch realm filenames: ${result.error}`);
+    throw new Error(result.error);
+  }
+
+  return (result.filenames ?? [])
+    .filter(
+      (f) =>
+        EVALUABLE_EXTENSIONS.some((ext) => f.endsWith(ext)) &&
+        !TEST_FILE_PATTERN.test(f),
+    )
+    .sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Evaluate a set of discovered files via the `evaluate-module` host
+ * command. Failures thrown by a single module evaluation are captured
+ * in-place; they do not abort the run.
+ */
+export async function evaluateRealmModules(
+  options: EvaluateRealmModulesOptions,
+  files: string[],
+): Promise<EvaluateRealmModulesOutput> {
+  let evaluateModuleFn =
+    options.evaluateModuleFn ??
+    ((moduleUrl: string, realmUrl: string) =>
+      defaultEvaluateModule(
+        options.client,
+        options.realmServerUrl,
+        moduleUrl,
+        realmUrl,
+      ));
+
+  let startedAt = Date.now();
+  let moduleResults: EvalModuleRecord[] = [];
+  let failedModules: EvalModuleRecord[] = [];
+
+  for (let file of files) {
+    let moduleUrl = toModuleUrl(file, options.targetRealmUrl);
+
+    try {
+      let result = await evaluateModuleFn(moduleUrl, options.targetRealmUrl);
+      moduleResults.push({
+        path: file,
+        error: result.error ?? '',
+        stackTrace: result.stackTrace,
+      });
+
+      if (!result.passed) {
+        failedModules.push({
+          path: file,
+          error: result.error ?? 'Module evaluation failed',
+          stackTrace: result.stackTrace,
+        });
+      }
+    } catch (err) {
+      let message = `Eval failed: ${err instanceof Error ? err.message : String(err)}`;
+      log.warn(`Error evaluating ${file}: ${message}`);
+      moduleResults.push({ path: file, error: message });
+      failedModules.push({ path: file, error: message });
+    }
+  }
+
+  return {
+    moduleResults,
+    failedModules,
+    durationMs: Date.now() - startedAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// In-memory agent tool
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate every non-test ESM module in the target realm (or just one
+ * named file) via `/_prerender-module` and return a flat, JSON-friendly
+ * result. Unlike `EvalValidationStep`, this does NOT create or update an
+ * `EvalResult` card — the result is consumed by the agent directly for
+ * mid-turn self-validation.
+ */
+export async function runEvaluateInMemory(
+  options: RunEvaluateInMemoryOptions,
+): Promise<RunEvaluateResult> {
+  let evaluableFiles: string[];
+  if (options.path) {
+    let path = options.path;
+    if (!EVALUABLE_EXTENSIONS.some((ext) => path.endsWith(ext))) {
+      return emptyErrorResult(
+        `Path "${path}" is not evaluable — must end with one of ${EVALUABLE_EXTENSIONS.join(', ')}`,
+      );
+    }
+    if (TEST_FILE_PATTERN.test(path)) {
+      return emptyErrorResult(
+        `Path "${path}" is a test file — run_evaluate only evaluates non-test modules. The test runner validates test files.`,
+      );
+    }
+    evaluableFiles = [path];
+  } else {
+    try {
+      evaluableFiles = await discoverEvaluableFiles({
+        targetRealmUrl: options.targetRealmUrl,
+        client: options.client,
+      });
+    } catch (err) {
+      return emptyErrorResult(
+        `Failed to discover evaluable files: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  if (evaluableFiles.length === 0) {
+    return {
+      status: 'passed',
+      modulesChecked: 0,
+      modulesWithErrors: 0,
+      durationMs: 0,
+      evaluableFiles: [],
+      failures: [],
+    };
+  }
+
+  try {
+    let { moduleResults, failedModules, durationMs } =
+      await evaluateRealmModules(
+        {
+          targetRealmUrl: options.targetRealmUrl,
+          realmServerUrl: options.realmServerUrl,
+          client: options.client,
+        },
+        evaluableFiles,
+      );
+
+    return {
+      status: failedModules.length === 0 ? 'passed' : 'failed',
+      modulesChecked: moduleResults.length,
+      modulesWithErrors: failedModules.length,
+      durationMs,
+      evaluableFiles,
+      failures: failedModules.map((m) => ({
+        path: m.path,
+        error: m.error,
+        stackTrace: m.stackTrace,
+      })),
+    };
+  } catch (err) {
+    let errorMessage = err instanceof Error ? err.message : String(err);
+    log.error(`runEvaluateInMemory error: ${errorMessage}`);
+    return {
+      status: 'error',
+      modulesChecked: 0,
+      modulesWithErrors: 0,
+      durationMs: 0,
+      evaluableFiles,
+      failures: [],
+      errorMessage,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toModuleUrl(file: string, realmUrl: string): string {
+  // Strip any ESM extension — the prerenderer's Loader resolves extensionless
+  // URLs to whichever source file exists (.gts, .gjs, .ts, or .js).
+  let withoutExt = file.replace(/\.(gts|gjs|ts|js)$/, '');
+  return new URL(withoutExt, ensureTrailingSlash(realmUrl)).href;
+}
+
+async function defaultEvaluateModule(
+  client: BoxelCLIClient,
+  realmServerUrl: string,
+  moduleUrl: string,
+  realmUrl: string,
+): Promise<EvalModuleResult> {
+  let response = await client.runCommand(
+    realmServerUrl,
+    realmUrl,
+    EVALUATE_MODULE_COMMAND,
+    { moduleUrl, realmUrl },
+  );
+
+  log.info(
+    `run-command response for ${moduleUrl}: status=${response.status}, error=${response.error}, result=${response.result?.slice(0, 300)}`,
+  );
+
+  if (response.status !== 'ready') {
+    return {
+      passed: false,
+      error: response.error ?? `run-command returned ${response.status} status`,
+    };
+  }
+
+  if (response.result) {
+    try {
+      let cardDoc = JSON.parse(response.result);
+      let attrs = cardDoc?.data?.attributes ?? cardDoc;
+      if (attrs.passed === false) {
+        return {
+          passed: false,
+          error: attrs.error ?? 'Module evaluation failed',
+          stackTrace: attrs.stackTrace,
+        };
+      }
+      return { passed: true };
+    } catch {
+      log.warn(
+        `Failed to parse run-command result for ${moduleUrl}: ${response.result?.slice(0, 200)}`,
+      );
+      return {
+        passed: false,
+        error:
+          'run-command returned an unparsable result — treating as failure',
+      };
+    }
+  }
+
+  return {
+    passed: false,
+    error: 'run-command did not return a result — treating as failure',
+  };
+}
+
+function emptyErrorResult(errorMessage: string): RunEvaluateResult {
+  return {
+    status: 'error',
+    modulesChecked: 0,
+    modulesWithErrors: 0,
+    durationMs: 0,
+    evaluableFiles: [],
+    failures: [],
+    errorMessage,
+  };
+}

--- a/packages/software-factory/src/eval-execution.ts
+++ b/packages/software-factory/src/eval-execution.ts
@@ -26,7 +26,24 @@ let log = logger('eval-execution');
 /** File extensions that can be loaded as ESM modules via the prerenderer. */
 export const EVALUABLE_EXTENSIONS = ['.gts', '.gjs', '.ts', '.js'];
 
-const TEST_FILE_PATTERN = /\.test\.(gts|gjs|ts|js)$/;
+/**
+ * Test-runner source files — QUnit (`.test.*`) and Playwright (`.spec.*`).
+ * These import test-runner APIs (qunit, @playwright/test) and Node-only
+ * modules that the prerender sandbox can't resolve, so they must be
+ * skipped even though their extension is in EVALUABLE_EXTENSIONS.
+ */
+const TEST_FILE_PATTERN = /\.(test|spec)\.(gts|gjs|ts|js)$/;
+
+/** TypeScript ambient declaration files — not importable as ESM modules. */
+const AMBIENT_DECLARATION_PATTERN = /\.d\.ts$/;
+
+/**
+ * Precedence used when multiple discovered files collapse to the same
+ * extension-less module URL (e.g. `foo.gts` and `foo.js`). Boxel source
+ * realms are `.gts`-first, so that wins; the rest follow the order Boxel's
+ * Loader resolves extensions.
+ */
+const EXTENSION_PRECEDENCE = ['.gts', '.gjs', '.ts', '.js'];
 
 const EVALUATE_MODULE_COMMAND =
   '@cardstack/boxel-host/commands/evaluate-module/default';
@@ -59,9 +76,9 @@ export interface EvaluateRealmModulesOptions {
 }
 
 export interface EvaluateRealmModulesOutput {
-  /** Per-module results for every evaluated file (pass or fail). */
+  /** Per-module records for every evaluated file (pass or fail). */
   moduleResults: EvalModuleRecord[];
-  /** Subset of moduleResults with `passed === false`. */
+  /** Records for modules that failed to evaluate. */
   failedModules: EvalModuleRecord[];
   durationMs: number;
 }
@@ -120,8 +137,11 @@ export interface RunEvaluateResult {
 
 /**
  * Discover evaluable files in the target realm — `.gts`, `.gjs`, `.ts`,
- * `.js`, minus any `.test.*` variants. Returns an alphabetically-sorted
- * list.
+ * `.js`, minus `.test.*` / `.spec.*` test-runner sources and `.d.ts`
+ * ambient declarations. When multiple files collapse to the same
+ * extension-less module URL (e.g. `foo.gts` and `foo.js`), keeps only the
+ * one with the highest-precedence extension. Returns an
+ * alphabetically-sorted list.
  */
 export async function discoverEvaluableFiles(
   options: DiscoverEvaluableFilesOptions,
@@ -136,13 +156,27 @@ export async function discoverEvaluableFiles(
     throw new Error(result.error);
   }
 
-  return (result.filenames ?? [])
-    .filter(
-      (f) =>
-        EVALUABLE_EXTENSIONS.some((ext) => f.endsWith(ext)) &&
-        !TEST_FILE_PATTERN.test(f),
-    )
-    .sort((a, b) => a.localeCompare(b));
+  let candidates = (result.filenames ?? []).filter(
+    (f) =>
+      EVALUABLE_EXTENSIONS.some((ext) => f.endsWith(ext)) &&
+      !TEST_FILE_PATTERN.test(f) &&
+      !AMBIENT_DECLARATION_PATTERN.test(f),
+  );
+
+  // Dedupe by extension-less module URL, keeping the highest-precedence
+  // extension per basename. The prerender Loader resolves extension-less
+  // URLs, so two source files collapsing to the same URL would otherwise
+  // double-count or misattribute failures.
+  let byBasename = new Map<string, string>();
+  for (let file of candidates) {
+    let basename = stripEsmExtension(file);
+    let existing = byBasename.get(basename);
+    if (!existing || hasHigherPrecedence(file, existing)) {
+      byBasename.set(basename, file);
+    }
+  }
+
+  return Array.from(byBasename.values()).sort((a, b) => a.localeCompare(b));
 }
 
 /**
@@ -218,9 +252,18 @@ export async function runEvaluateInMemory(
   let evaluableFiles: string[];
   if (options.path) {
     let path = options.path;
+    let pathError = validateRealmRelativePath(path);
+    if (pathError) {
+      return emptyErrorResult(pathError);
+    }
     if (!EVALUABLE_EXTENSIONS.some((ext) => path.endsWith(ext))) {
       return emptyErrorResult(
         `Path "${path}" is not evaluable — must end with one of ${EVALUABLE_EXTENSIONS.join(', ')}`,
+      );
+    }
+    if (AMBIENT_DECLARATION_PATTERN.test(path)) {
+      return emptyErrorResult(
+        `Path "${path}" is a TypeScript ambient declaration — run_evaluate only evaluates importable ESM modules.`,
       );
     }
     if (TEST_FILE_PATTERN.test(path)) {
@@ -297,9 +340,51 @@ export async function runEvaluateInMemory(
 
 function toModuleUrl(file: string, realmUrl: string): string {
   // Strip any ESM extension — the prerenderer's Loader resolves extensionless
-  // URLs to whichever source file exists (.gts, .gjs, .ts, or .js).
-  let withoutExt = file.replace(/\.(gts|gjs|ts|js)$/, '');
+  // URLs to whichever source file exists (.gts, .gjs, .ts, or .js). Discovery
+  // dedupes collisions by EXTENSION_PRECEDENCE before we get here, so one
+  // basename → one evaluation.
+  let withoutExt = stripEsmExtension(file);
   return new URL(withoutExt, ensureTrailingSlash(realmUrl)).href;
+}
+
+function stripEsmExtension(file: string): string {
+  return file.replace(/\.(gts|gjs|ts|js)$/, '');
+}
+
+function hasHigherPrecedence(candidate: string, existing: string): boolean {
+  return getExtensionRank(candidate) < getExtensionRank(existing);
+}
+
+function getExtensionRank(file: string): number {
+  for (let i = 0; i < EXTENSION_PRECEDENCE.length; i++) {
+    if (file.endsWith(EXTENSION_PRECEDENCE[i])) {
+      return i;
+    }
+  }
+  return EXTENSION_PRECEDENCE.length;
+}
+
+/**
+ * Validate that the agent-supplied `path` is a safe realm-relative path —
+ * no absolute paths, no `..` traversal, and no URL scheme. Returns an
+ * error message if rejected, or null if the path is acceptable. The
+ * realm-server's `_run-command` is realm-scoped, but rejecting these
+ * cases up-front keeps the tool's contract explicit and prevents an
+ * agent-produced absolute URL or traversal segment from silently
+ * evaluating a module outside the target realm.
+ */
+function validateRealmRelativePath(path: string): string | null {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(path)) {
+    return `Path "${path}" must be realm-relative — absolute URLs (with a scheme) are not accepted.`;
+  }
+  if (path.startsWith('/')) {
+    return `Path "${path}" must be realm-relative — paths starting with "/" are not accepted.`;
+  }
+  let segments = path.split('/');
+  if (segments.some((seg) => seg === '..')) {
+    return `Path "${path}" must not contain ".." segments — the path must stay inside the target realm.`;
+  }
+  return null;
 }
 
 async function defaultEvaluateModule(

--- a/packages/software-factory/src/factory-tool-builder.ts
+++ b/packages/software-factory/src/factory-tool-builder.ts
@@ -14,6 +14,11 @@ import type {
 } from '@cardstack/runtime-common';
 
 import { buildCardDocument } from './darkfactory-schemas';
+import {
+  runEvaluateInMemory,
+  type RunEvaluateInMemoryOptions,
+  type RunEvaluateResult,
+} from './eval-execution';
 import type { ToolExecutor } from './factory-tool-executor';
 import type { ToolRegistry } from './factory-tool-registry';
 import { logger } from './logger';
@@ -56,6 +61,10 @@ export interface ToolBuilderConfig {
       relationships?: Record<string, unknown>;
     }
   >;
+  /** Injected for testing — defaults to runEvaluateInMemory. */
+  runEvaluateInMemory?: (
+    options: RunEvaluateInMemoryOptions,
+  ) => Promise<RunEvaluateResult>;
 }
 
 export interface ToolCallEntry {
@@ -100,6 +109,7 @@ export function buildFactoryTools(
     buildFetchTranspiledModuleTool(config),
     buildSearchRealmTool(config),
     buildRunCommandTool(config),
+    buildRunEvaluateTool(config),
     buildSignalDoneTool(),
     buildRequestClarificationTool(),
   ];
@@ -576,6 +586,52 @@ function buildCreateCatalogSpecTool(config: ToolBuilderConfig): FactoryTool {
 
 // Note: buildRunTestsTool was removed — the validation pipeline runs tests
 // automatically via executeTestRunFromRealm after each agent turn.
+
+function buildRunEvaluateTool(config: ToolBuilderConfig): FactoryTool {
+  let execute = config.runEvaluateInMemory ?? runEvaluateInMemory;
+  return {
+    name: 'run_evaluate',
+    description:
+      'Evaluate ESM modules (.gts / .gjs / .ts / .js) in the target realm ' +
+      'via the prerenderer sandbox and return an in-memory result (status, ' +
+      'module counts, per-failure error + stackTrace). Without "path", ' +
+      'evaluates every non-test evaluable module in the realm. With ' +
+      '"path", evaluates only that single realm-relative file — handy ' +
+      'for a quick self-check right after writing one module. Safe to ' +
+      'call repeatedly for mid-turn self-validation — this tool does NOT ' +
+      'create an EvalResult card or any other realm artifact. The ' +
+      'orchestrator still runs the full validation pipeline (which writes ' +
+      'an EvalResult card) automatically after signal_done, so calling ' +
+      'this is optional. When a failure reports a line/column, those ' +
+      'numbers refer to the transpiled module — use `fetch_transpiled_module` ' +
+      'to locate the offending source construct, then fix the .gts source ' +
+      '(never copy transpiled patterns back into source). Auth: realm ' +
+      'server token.',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description:
+            'Optional realm-relative path to a single .gts / .gjs / .ts / .js file to evaluate. Omit to evaluate every non-test evaluable module in the target realm. Test files (*.test.*) are rejected — the test runner validates those.',
+        },
+      },
+    },
+    execute: async (args) => {
+      let rawPath = args.path;
+      let path =
+        typeof rawPath === 'string' && rawPath.trim() !== ''
+          ? rawPath.trim()
+          : undefined;
+      return execute({
+        targetRealmUrl: config.targetRealmUrl,
+        realmServerUrl: config.realmServerUrl,
+        client: config.client,
+        ...(path ? { path } : {}),
+      });
+    },
+  };
+}
 
 function buildSignalDoneTool(): FactoryTool {
   return {

--- a/packages/software-factory/src/harness/support-services.ts
+++ b/packages/software-factory/src/harness/support-services.ts
@@ -417,25 +417,67 @@ export async function startHarnessPrerenderServer(options: {
     },
   );
 
+  // Ring-buffer the child's stdio so a startup crash surfaces the actual
+  // error (EADDRINUSE, missing dep, puppeteer launch failure, …) instead of
+  // just "exited before it became ready".
+  const STDIO_BUFFER_BYTES = 4096;
+  let recentStdout = '';
+  let recentStderr = '';
+  let appendBounded = (buf: string, chunk: string): string => {
+    let combined = buf + chunk;
+    return combined.length > STDIO_BUFFER_BYTES
+      ? combined.slice(-STDIO_BUFFER_BYTES)
+      : combined;
+  };
+
   child.stdout?.on('data', (data: Buffer) => {
-    log.info(`prerender: ${data.toString()}`);
+    let text = data.toString();
+    recentStdout = appendBounded(recentStdout, text);
+    log.info(`prerender: ${text}`);
   });
   child.stderr?.on('data', (data: Buffer) => {
-    log.error(`prerender: ${data.toString()}`);
+    let text = data.toString();
+    recentStderr = appendBounded(recentStderr, text);
+    log.error(`prerender: ${text}`);
   });
 
+  let exitListener:
+    | ((code: number | null, signal: NodeJS.Signals | null) => void)
+    | undefined;
+  let errorListener: ((err: Error) => void) | undefined;
   let exitPromise = new Promise<never>((_, reject) => {
-    child.once('exit', (code, signal) => {
-      reject(
-        new Error(
-          `prerender server exited before it became ready (code: ${code}, signal: ${signal})`,
-        ),
-      );
-    });
-    child.once('error', reject);
+    exitListener = (code, signal) => {
+      // Give any buffered stdio a final tick to flush before we build the
+      // error message — 'exit' can fire before the last 'data' event.
+      setImmediate(() => {
+        let diagnostic = buildChildExitDiagnostic({
+          recentStdout,
+          recentStderr,
+        });
+        reject(
+          new Error(
+            `prerender server exited before it became ready (code: ${code}, signal: ${signal})${diagnostic}`,
+          ),
+        );
+      });
+    };
+    errorListener = reject;
+    child.once('exit', exitListener);
+    child.once('error', errorListener);
   });
 
-  await Promise.race([waitForHttpReady(url), exitPromise]);
+  try {
+    await Promise.race([waitForHttpReady(url), exitPromise]);
+  } finally {
+    // Detach the startup listeners so a later intentional exit (during
+    // test teardown) doesn't surface as an unhandled rejection on
+    // exitPromise.
+    if (exitListener) child.off('exit', exitListener);
+    if (errorListener) child.off('error', errorListener);
+    // Swallow the now-orphaned rejection if the race was won by
+    // waitForHttpReady but 'exit' still fires later.
+    exitPromise.catch(() => {});
+  }
 
   return {
     url,
@@ -443,6 +485,25 @@ export async function startHarnessPrerenderServer(options: {
       await stopChildProcess(child);
     },
   };
+}
+
+function buildChildExitDiagnostic(buffers: {
+  recentStdout: string;
+  recentStderr: string;
+}): string {
+  let parts: string[] = [];
+  let stderr = buffers.recentStderr.trim();
+  if (stderr) {
+    parts.push(`stderr tail:\n${stderr}`);
+  }
+  let stdout = buffers.recentStdout.trim();
+  if (stdout) {
+    parts.push(`stdout tail:\n${stdout}`);
+  }
+  if (parts.length === 0) {
+    return ' (child produced no stdio before exit)';
+  }
+  return `\n${parts.join('\n\n')}`;
 }
 
 /**

--- a/packages/software-factory/src/validators/eval-step.ts
+++ b/packages/software-factory/src/validators/eval-step.ts
@@ -1,20 +1,26 @@
 /**
- * Eval validation step — evaluates .gts modules in the target realm
- * via the prerenderer sandbox to ensure they load without runtime errors.
+ * Eval validation step — evaluates non-test ESM modules in the target
+ * realm via the prerenderer sandbox to ensure they load without runtime
+ * errors.
  *
- * For each non-test `.gts` file discovered in the realm, invokes the
- * `evaluate-module` host command via `_run-command`. The host command
- * calls `/_prerender-module` which runs evaluation in headless Chrome.
+ * Discovery and per-module evaluation are delegated to the shared
+ * `eval-execution` engine; this step owns the `EvalResult` card artifact
+ * lifecycle (create → complete) and sequence-number bookkeeping.
  *
- * Files matching `*.test.gts` are excluded — test files are the
- * responsibility of the test validation step.
+ * Files matching `*.test.{gts,gjs,ts,js}` are excluded — test files are
+ * the responsibility of the test validation step.
  */
 
 import type { BoxelCLIClient } from '@cardstack/boxel-cli/api';
-import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 
 import type { ValidationStepResult } from '../factory-agent';
 import { deriveIssueSlug } from '../factory-agent';
+import {
+  discoverEvaluableFiles,
+  evaluateRealmModules,
+  type EvalModuleResult,
+  type EvalModuleRecord,
+} from '../eval-execution';
 import { getNextValidationSequenceNumber } from '../realm-operations';
 import {
   createEvalResult,
@@ -31,11 +37,8 @@ let log = logger('eval-validation-step');
 // Types
 // ---------------------------------------------------------------------------
 
-export interface EvalModuleResult {
-  passed: boolean;
-  error?: string;
-  stackTrace?: string;
-}
+// Re-exported for consumers that imported EvalModuleResult from this module.
+export type { EvalModuleResult };
 
 export interface EvalValidationStepConfig {
   client: BoxelCLIClient;
@@ -66,9 +69,6 @@ export interface EvalValidationDetails {
   modules: { path: string; error: string; stackTrace?: string }[];
 }
 
-const EVALUATE_MODULE_COMMAND =
-  '@cardstack/boxel-host/commands/evaluate-module/default';
-
 // ---------------------------------------------------------------------------
 // EvalValidationStep
 // ---------------------------------------------------------------------------
@@ -79,13 +79,6 @@ export class EvalValidationStep implements ValidationStepRunner {
   private config: EvalValidationStepConfig;
   private lastSequenceNumber = 0;
 
-  private fetchFilenamesFn: (
-    realmUrl: string,
-  ) => Promise<{ filenames: string[]; error?: string }>;
-  private evaluateModuleFn: (
-    moduleUrl: string,
-    realmUrl: string,
-  ) => Promise<EvalModuleResult>;
   private getNextSeqFn: (
     slug: string,
     targetRealmUrl: string,
@@ -93,13 +86,6 @@ export class EvalValidationStep implements ValidationStepRunner {
 
   constructor(config: EvalValidationStepConfig) {
     this.config = config;
-    this.fetchFilenamesFn =
-      config.fetchFilenames ??
-      ((realmUrl: string) => config.client.listFiles(realmUrl));
-    this.evaluateModuleFn =
-      config.evaluateModuleFn ??
-      ((moduleUrl: string, realmUrl: string) =>
-        this.defaultEvaluateModule(moduleUrl, realmUrl));
     this.getNextSeqFn =
       config.getNextSequenceNumber ??
       ((slug: string, targetRealmUrl: string) =>
@@ -117,10 +103,14 @@ export class EvalValidationStep implements ValidationStepRunner {
     targetRealmUrl: string,
     iteration?: number,
   ): Promise<ValidationStepResult> {
-    // Step 1: Discover evaluable files
+    // Step 1: Discover evaluable files (shared engine)
     let evaluableFiles: string[];
     try {
-      evaluableFiles = await this.discoverEvaluableFiles(targetRealmUrl);
+      evaluableFiles = await discoverEvaluableFiles({
+        targetRealmUrl,
+        client: this.config.client,
+        fetchFilenames: this.config.fetchFilenames,
+      });
     } catch (err) {
       return {
         step: 'evaluate',
@@ -134,7 +124,7 @@ export class EvalValidationStep implements ValidationStepRunner {
     }
 
     if (evaluableFiles.length === 0) {
-      log.info('No evaluable .gts files found — nothing to validate');
+      log.info('No evaluable modules found — nothing to validate');
       return { step: 'evaluate', passed: true, files: [], errors: [] };
     }
 
@@ -195,58 +185,34 @@ export class EvalValidationStep implements ValidationStepRunner {
       evalResultId = `Validations/eval_${slug}-${seq}`;
     }
 
-    // Step 3: Evaluate each module via sandbox (_run-command → host command)
-    let startedAt = Date.now();
-    let allModuleResults: EvalModuleErrorData[] = [];
-    let failedModules: EvalValidationDetails['modules'] = [];
+    // Step 3: Evaluate each module via the shared engine
+    let {
+      moduleResults: allModuleResults,
+      failedModules,
+      durationMs,
+    } = await evaluateRealmModules(
+      {
+        targetRealmUrl,
+        client: this.config.client,
+        realmServerUrl: this.config.realmServerUrl,
+        evaluateModuleFn: this.config.evaluateModuleFn,
+      },
+      evaluableFiles,
+    );
 
-    for (let file of evaluableFiles) {
-      let moduleUrl = new URL(
-        file.replace(/\.gts$/, ''),
-        ensureTrailingSlash(targetRealmUrl),
-      ).href;
-
-      try {
-        let result = await this.evaluateModuleFn(moduleUrl, targetRealmUrl);
-
-        allModuleResults.push({
-          path: file,
-          error: result.error ?? '',
-          stackTrace: result.stackTrace,
-        });
-
-        if (!result.passed) {
-          failedModules.push({
-            path: file,
-            error: result.error ?? 'Module evaluation failed',
-            stackTrace: result.stackTrace,
-          });
-        }
-      } catch (err) {
-        let message = `Eval failed: ${err instanceof Error ? err.message : String(err)}`;
-        log.warn(`Error evaluating ${file}: ${message}`);
-        allModuleResults.push({
-          path: file,
-          error: message,
-        });
-        failedModules.push({
-          path: file,
-          error: message,
-        });
-      }
-    }
-
-    let durationMs = Date.now() - startedAt;
     let passed = failedModules.length === 0;
 
     // Step 4: Complete the EvalResult card
     if (artifactCreated) {
+      let moduleResultsForCard: EvalModuleErrorData[] = allModuleResults.map(
+        (m) => ({ path: m.path, error: m.error, stackTrace: m.stackTrace }),
+      );
       let completeResult = await completeEvalResult(
         evalResultId,
         {
           status: passed ? 'passed' : 'failed',
           durationMs,
-          moduleResults: allModuleResults,
+          moduleResults: moduleResultsForCard,
         },
         {
           targetRealmUrl,
@@ -265,10 +231,14 @@ export class EvalValidationStep implements ValidationStepRunner {
       evalResultId,
       modulesChecked: allModuleResults.length,
       modulesWithErrors: failedModules.length,
-      modules: failedModules,
+      modules: failedModules.map((m: EvalModuleRecord) => ({
+        path: m.path,
+        error: m.error,
+        stackTrace: m.stackTrace,
+      })),
     };
 
-    let errors = failedModules.map((m) => ({
+    let errors = failedModules.map((m: EvalModuleRecord) => ({
       file: m.path,
       message: `${m.path}: ${m.error}`,
     }));
@@ -311,82 +281,5 @@ export class EvalValidationStep implements ValidationStepRunner {
     }
 
     return lines.join('\n');
-  }
-
-  // -------------------------------------------------------------------------
-  // Private helpers
-  // -------------------------------------------------------------------------
-
-  private async discoverEvaluableFiles(
-    targetRealmUrl: string,
-  ): Promise<string[]> {
-    let result = await this.fetchFilenamesFn(targetRealmUrl);
-
-    if (result.error) {
-      log.warn(`Failed to fetch realm filenames: ${result.error}`);
-      throw new Error(result.error);
-    }
-
-    return result.filenames
-      .filter((f) => f.endsWith('.gts') && !f.endsWith('.test.gts'))
-      .sort((a, b) => a.localeCompare(b));
-  }
-
-  /**
-   * Default evaluateModuleFn: calls the evaluate-module host command
-   * via `_run-command` on the realm server.
-   */
-  private async defaultEvaluateModule(
-    moduleUrl: string,
-    realmUrl: string,
-  ): Promise<EvalModuleResult> {
-    let response = await this.config.client.runCommand(
-      this.config.realmServerUrl,
-      realmUrl,
-      EVALUATE_MODULE_COMMAND,
-      { moduleUrl, realmUrl },
-    );
-
-    log.info(
-      `run-command response for ${moduleUrl}: status=${response.status}, error=${response.error}, result=${response.result?.slice(0, 300)}`,
-    );
-
-    if (response.status !== 'ready') {
-      return {
-        passed: false,
-        error:
-          response.error ?? `run-command returned ${response.status} status`,
-      };
-    }
-
-    // Parse the cardResultString to extract EvaluateModuleResult fields
-    if (response.result) {
-      try {
-        let cardDoc = JSON.parse(response.result);
-        let attrs = cardDoc?.data?.attributes ?? cardDoc;
-        if (attrs.passed === false) {
-          return {
-            passed: false,
-            error: attrs.error ?? 'Module evaluation failed',
-            stackTrace: attrs.stackTrace,
-          };
-        }
-        return { passed: true };
-      } catch {
-        log.warn(
-          `Failed to parse run-command result for ${moduleUrl}: ${response.result?.slice(0, 200)}`,
-        );
-        return {
-          passed: false,
-          error:
-            'run-command returned an unparsable result — treating as failure',
-        };
-      }
-    }
-
-    return {
-      passed: false,
-      error: 'run-command did not return a result — treating as failure',
-    };
   }
 }

--- a/packages/software-factory/tests/eval-execution.test.ts
+++ b/packages/software-factory/tests/eval-execution.test.ts
@@ -1,0 +1,181 @@
+import { module, test } from 'qunit';
+
+import type { BoxelCLIClient } from '@cardstack/boxel-cli/api';
+
+import {
+  discoverEvaluableFiles,
+  runEvaluateInMemory,
+} from '../src/eval-execution';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function stubClient(filenames: string[]): BoxelCLIClient {
+  return {
+    listFiles: async () => ({ filenames }),
+  } as unknown as BoxelCLIClient;
+}
+
+function stubClientAlwaysThrows(): BoxelCLIClient {
+  return {
+    listFiles: async () => {
+      throw new Error('should not reach listFiles');
+    },
+    runCommand: async () => {
+      throw new Error('should not reach runCommand');
+    },
+  } as unknown as BoxelCLIClient;
+}
+
+// ---------------------------------------------------------------------------
+// discoverEvaluableFiles — filter and dedupe behavior
+// ---------------------------------------------------------------------------
+
+module('discoverEvaluableFiles', function () {
+  test('excludes .test.* and .spec.* test-runner files', async function (assert) {
+    let files = await discoverEvaluableFiles({
+      targetRealmUrl: 'https://example.test/realm/',
+      client: stubClient([
+        'hello.gts',
+        'hello.test.gts',
+        'hello.spec.ts',
+        'login.spec.gts',
+        'utils.ts',
+      ]),
+    });
+
+    assert.deepEqual(
+      files.sort(),
+      ['hello.gts', 'utils.ts'],
+      'test and spec files are filtered out; production sources remain',
+    );
+  });
+
+  test('excludes .d.ts ambient declaration files', async function (assert) {
+    let files = await discoverEvaluableFiles({
+      targetRealmUrl: 'https://example.test/realm/',
+      client: stubClient([
+        'app.ts',
+        'globals.d.ts',
+        'ui/components.d.ts',
+        'ui/button.gts',
+      ]),
+    });
+
+    assert.deepEqual(files.sort(), ['app.ts', 'ui/button.gts']);
+  });
+
+  test('dedupes same-basename files by extension precedence (.gts > .gjs > .ts > .js)', async function (assert) {
+    let files = await discoverEvaluableFiles({
+      targetRealmUrl: 'https://example.test/realm/',
+      client: stubClient([
+        'foo.js',
+        'foo.ts',
+        'foo.gjs',
+        'foo.gts',
+        'bar.js',
+        'bar.gjs',
+      ]),
+    });
+
+    assert.deepEqual(
+      files.sort(),
+      ['bar.gjs', 'foo.gts'],
+      '.gts wins over .gjs/.ts/.js; .gjs wins over .js',
+    );
+  });
+
+  test('ignores non-ESM filenames entirely', async function (assert) {
+    let files = await discoverEvaluableFiles({
+      targetRealmUrl: 'https://example.test/realm/',
+      client: stubClient([
+        'Cards/my-card.json',
+        'index.json',
+        '.realm.json',
+        'README.md',
+        'hello.gts',
+      ]),
+    });
+
+    assert.deepEqual(files, ['hello.gts']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runEvaluateInMemory — path validation short-circuits (no realm call)
+// ---------------------------------------------------------------------------
+
+module('runEvaluateInMemory path validation', function () {
+  test('rejects absolute "/..." paths without calling the realm', async function (assert) {
+    let result = await runEvaluateInMemory({
+      targetRealmUrl: 'https://example.test/realm/',
+      realmServerUrl: 'https://example.test/',
+      client: stubClientAlwaysThrows(),
+      path: '/escape.gts',
+    });
+    assert.strictEqual(result.status, 'error');
+    assert.ok(
+      result.errorMessage?.includes('must be realm-relative'),
+      'rejects leading "/"',
+    );
+  });
+
+  test('rejects ".." traversal segments without calling the realm', async function (assert) {
+    let result = await runEvaluateInMemory({
+      targetRealmUrl: 'https://example.test/realm/',
+      realmServerUrl: 'https://example.test/',
+      client: stubClientAlwaysThrows(),
+      path: '../other-realm/foo.gts',
+    });
+    assert.strictEqual(result.status, 'error');
+    assert.ok(result.errorMessage?.includes('".."'), 'rejects ".." segments');
+  });
+
+  test('rejects ".." segments nested inside the path', async function (assert) {
+    let result = await runEvaluateInMemory({
+      targetRealmUrl: 'https://example.test/realm/',
+      realmServerUrl: 'https://example.test/',
+      client: stubClientAlwaysThrows(),
+      path: 'Cards/../../escape.gts',
+    });
+    assert.strictEqual(result.status, 'error');
+    assert.ok(result.errorMessage?.includes('".."'));
+  });
+
+  test('rejects absolute URLs with a scheme', async function (assert) {
+    let result = await runEvaluateInMemory({
+      targetRealmUrl: 'https://example.test/realm/',
+      realmServerUrl: 'https://example.test/',
+      client: stubClientAlwaysThrows(),
+      path: 'https://malicious.test/foo.gts',
+    });
+    assert.strictEqual(result.status, 'error');
+    assert.ok(
+      result.errorMessage?.includes('absolute URLs'),
+      'rejects URL-scheme paths',
+    );
+  });
+
+  test('rejects .d.ts ambient declaration paths', async function (assert) {
+    let result = await runEvaluateInMemory({
+      targetRealmUrl: 'https://example.test/realm/',
+      realmServerUrl: 'https://example.test/',
+      client: stubClientAlwaysThrows(),
+      path: 'types/globals.d.ts',
+    });
+    assert.strictEqual(result.status, 'error');
+    assert.ok(result.errorMessage?.includes('ambient declaration'));
+  });
+
+  test('rejects .spec.ts paths (test-runner source files)', async function (assert) {
+    let result = await runEvaluateInMemory({
+      targetRealmUrl: 'https://example.test/realm/',
+      realmServerUrl: 'https://example.test/',
+      client: stubClientAlwaysThrows(),
+      path: 'login.spec.ts',
+    });
+    assert.strictEqual(result.status, 'error');
+    assert.ok(result.errorMessage?.includes('test file'));
+  });
+});

--- a/packages/software-factory/tests/factory-tool-builder.test.ts
+++ b/packages/software-factory/tests/factory-tool-builder.test.ts
@@ -1287,3 +1287,188 @@ module('factory-tool-builder > add_comment', function () {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// run_evaluate tool (in-memory validation — CS-10779)
+// ---------------------------------------------------------------------------
+
+module('buildFactoryTools — run_evaluate', function () {
+  test('registers run_evaluate with an optional path parameter', function (assert) {
+    let config = makeConfig();
+    let { executor } = createMockToolExecutor(new Map());
+    let tools = buildFactoryTools(config, executor, new ToolRegistry());
+    let runEvaluate = tools.find((t) => t.name === 'run_evaluate');
+    assert.ok(runEvaluate, 'run_evaluate tool is registered');
+    let params = runEvaluate!.parameters as {
+      type: string;
+      properties: Record<string, { type: string }>;
+      required?: string[];
+    };
+    assert.strictEqual(params.type, 'object');
+    assert.strictEqual(params.properties.path?.type, 'string');
+    assert.strictEqual(params.required, undefined, 'path is optional');
+  });
+
+  test('delegates to injected runEvaluateInMemory and forwards realm config', async function (assert) {
+    let capturedOptions:
+      | {
+          targetRealmUrl: string;
+          realmServerUrl: string;
+          hasClient: boolean;
+          path: string | undefined;
+        }
+      | undefined;
+    let stubResult = {
+      status: 'passed' as const,
+      modulesChecked: 2,
+      modulesWithErrors: 0,
+      durationMs: 42,
+      evaluableFiles: ['a.gts', 'b.gts'],
+      failures: [],
+    };
+
+    let config = makeConfig({
+      runEvaluateInMemory: async (options) => {
+        capturedOptions = {
+          targetRealmUrl: options.targetRealmUrl,
+          realmServerUrl: options.realmServerUrl,
+          hasClient: Boolean(options.client),
+          path: options.path,
+        };
+        return stubResult;
+      },
+    });
+    let { executor } = createMockToolExecutor(new Map());
+    let tools = buildFactoryTools(config, executor, new ToolRegistry());
+    let runEvaluate = tools.find((t) => t.name === 'run_evaluate');
+    assert.ok(runEvaluate, 'run_evaluate tool is registered');
+
+    let result = await runEvaluate!.execute({});
+
+    assert.deepEqual(result, stubResult, 'tool returns the in-memory result');
+    assert.strictEqual(
+      capturedOptions?.targetRealmUrl,
+      TARGET_REALM,
+      'forwards targetRealmUrl from config',
+    );
+    assert.strictEqual(
+      capturedOptions?.realmServerUrl,
+      'https://realms.example.test/',
+      'forwards realmServerUrl from config',
+    );
+    assert.true(
+      capturedOptions?.hasClient,
+      'forwards the configured BoxelCLIClient',
+    );
+    assert.strictEqual(
+      capturedOptions?.path,
+      undefined,
+      'path is omitted when not provided',
+    );
+  });
+
+  test('forwards path when provided to single-file evaluate', async function (assert) {
+    let capturedPath: string | undefined;
+    let stubResult = {
+      status: 'failed' as const,
+      modulesChecked: 1,
+      modulesWithErrors: 1,
+      durationMs: 120,
+      evaluableFiles: ['my-card.gts'],
+      failures: [
+        {
+          path: 'my-card.gts',
+          error: 'Cannot find module ./does-not-exist',
+          stackTrace: 'at Loader.load (loader.ts:42:5)',
+        },
+      ],
+    };
+
+    let config = makeConfig({
+      runEvaluateInMemory: async (options) => {
+        capturedPath = options.path;
+        return stubResult;
+      },
+    });
+    let { executor } = createMockToolExecutor(new Map());
+    let tools = buildFactoryTools(config, executor, new ToolRegistry());
+    let runEvaluate = tools.find((t) => t.name === 'run_evaluate');
+    assert.ok(runEvaluate, 'run_evaluate tool is registered');
+
+    let result = (await runEvaluate!.execute({
+      path: 'my-card.gts',
+    })) as typeof stubResult;
+
+    assert.strictEqual(
+      capturedPath,
+      'my-card.gts',
+      'path is forwarded to the engine',
+    );
+    assert.strictEqual(result.status, 'failed');
+    assert.deepEqual(result.evaluableFiles, ['my-card.gts']);
+    assert.strictEqual(result.failures[0].path, 'my-card.gts');
+    assert.strictEqual(
+      result.failures[0].stackTrace,
+      'at Loader.load (loader.ts:42:5)',
+    );
+  });
+
+  test('whitespace-only path is treated as "no path" (whole-realm evaluate)', async function (assert) {
+    let capturedPath: string | undefined;
+    let config = makeConfig({
+      runEvaluateInMemory: async (options) => {
+        capturedPath = options.path;
+        return {
+          status: 'passed' as const,
+          modulesChecked: 0,
+          modulesWithErrors: 0,
+          durationMs: 0,
+          evaluableFiles: [],
+          failures: [],
+        };
+      },
+    });
+    let { executor } = createMockToolExecutor(new Map());
+    let tools = buildFactoryTools(config, executor, new ToolRegistry());
+    let runEvaluate = tools.find((t) => t.name === 'run_evaluate');
+    assert.ok(runEvaluate, 'run_evaluate tool is registered');
+
+    await runEvaluate!.execute({ path: '   ' });
+
+    assert.strictEqual(
+      capturedPath,
+      undefined,
+      'whitespace-only path falls back to whole-realm evaluate',
+    );
+  });
+
+  test('propagates failed evaluate results unchanged', async function (assert) {
+    let stubResult = {
+      status: 'failed' as const,
+      modulesChecked: 2,
+      modulesWithErrors: 1,
+      durationMs: 85,
+      evaluableFiles: ['broken.gts', 'good.gts'],
+      failures: [
+        {
+          path: 'broken.gts',
+          error: 'ReferenceError: nonExistentHelper is not defined',
+        },
+      ],
+    };
+    let config = makeConfig({
+      runEvaluateInMemory: async () => stubResult,
+    });
+    let { executor } = createMockToolExecutor(new Map());
+    let tools = buildFactoryTools(config, executor, new ToolRegistry());
+    let runEvaluate = tools.find((t) => t.name === 'run_evaluate');
+    assert.ok(runEvaluate, 'run_evaluate tool is registered');
+
+    let result = (await runEvaluate!.execute({})) as typeof stubResult;
+
+    assert.strictEqual(result.status, 'failed');
+    assert.strictEqual(result.modulesWithErrors, 1);
+    assert.strictEqual(result.failures.length, 1);
+    assert.strictEqual(result.failures[0].path, 'broken.gts');
+  });
+});

--- a/packages/software-factory/tests/index.ts
+++ b/packages/software-factory/tests/index.ts
@@ -20,5 +20,6 @@ import './validation-pipeline.test';
 import './test-step.test';
 import './lint-step.test';
 import './eval-step.test';
+import './eval-execution.test';
 import './instantiate-step.test';
 import './parse-step.test';

--- a/packages/software-factory/tests/run-evaluate-in-memory.spec.ts
+++ b/packages/software-factory/tests/run-evaluate-in-memory.spec.ts
@@ -1,0 +1,353 @@
+import { resolve } from 'node:path';
+
+import type { BoxelCLIClient } from '@cardstack/boxel-cli/api';
+
+import { expect, test } from './fixtures';
+
+import { runEvaluateInMemory } from '../src/eval-execution';
+import { buildTestClient } from './helpers/test-client';
+
+const fixtureRealmDir = resolve(
+  process.cwd(),
+  'test-fixtures',
+  'test-realm-runner',
+);
+
+// A valid .gts card module that should evaluate successfully.
+const VALID_MODULE_GTS = `import {
+  CardDef,
+  field,
+  contains,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+
+export class ValidCard extends CardDef {
+  static displayName = 'Valid Card';
+  @field name = contains(StringField);
+}
+`;
+
+// A .gts module with a broken import that should fail evaluation. The
+// import must be consumed as a field type — unused imports are tree-shaken
+// by the compiler and the Loader never sees them.
+const BROKEN_MODULE_GTS = `import {
+  CardDef,
+  field,
+  contains,
+} from 'https://cardstack.com/base/card-api';
+import { Foo } from './does-not-exist';
+
+export class BrokenCard extends CardDef {
+  static displayName = 'Broken Card';
+  @field brokenField = contains(Foo);
+}
+`;
+
+test.use({ realmDir: fixtureRealmDir });
+test.use({ realmServerMode: 'isolated' });
+
+test.describe('runEvaluateInMemory e2e', () => {
+  test('clean realm returns status: passed with no realm artifacts', async ({
+    realm,
+  }) => {
+    let realmUrl = realm.realmURL.href;
+    let realmServerUrl = realm.realmServerURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let serverToken = `Bearer ${realm.serverToken}`;
+
+    let { client, cleanup } = buildTestClient({
+      realmUrl,
+      realmToken: authorization,
+      realmServerUrl,
+      realmServerToken: serverToken,
+    });
+
+    try {
+      // The fixture realm ships with a clean hello.gts, home.gts, and a
+      // hello.test.gts (which must be excluded from evaluation).
+      let result = await runEvaluateInMemory({
+        targetRealmUrl: realmUrl,
+        realmServerUrl,
+        client,
+      });
+
+      expect(result.status).toBe('passed');
+      expect(result.modulesWithErrors).toBe(0);
+      expect(result.modulesChecked).toBeGreaterThan(0);
+      expect(result.evaluableFiles).toContain('hello.gts');
+      expect(result.evaluableFiles).not.toContain('hello.test.gts');
+      expect(result.failures).toEqual([]);
+      expect(result.errorMessage).toBeUndefined();
+
+      // In-memory tool must not write any EvalResult card artifact.
+      let listing = await client.listFiles(realmUrl);
+      let validationArtifacts = (listing.filenames ?? []).filter((f) =>
+        f.startsWith('Validations/eval_'),
+      );
+      expect(validationArtifacts).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('module with broken import produces status: failed with no realm artifacts', async ({
+    realm,
+  }) => {
+    let realmUrl = realm.realmURL.href;
+    let realmServerUrl = realm.realmServerURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let serverToken = `Bearer ${realm.serverToken}`;
+
+    let { client, cleanup } = buildTestClient({
+      realmUrl,
+      realmToken: authorization,
+      realmServerUrl,
+      realmServerToken: serverToken,
+    });
+
+    try {
+      let writeResult = await client.write(
+        realmUrl,
+        'broken-module.gts',
+        BROKEN_MODULE_GTS,
+      );
+      expect(writeResult.ok).toBe(true);
+      let indexed = await client.waitForFile(realmUrl, 'broken-module.gts', {
+        pollMs: 300,
+        timeoutMs: 30_000,
+      });
+      expect(indexed).toBe(true);
+
+      let result = await runEvaluateInMemory({
+        targetRealmUrl: realmUrl,
+        realmServerUrl,
+        client,
+      });
+
+      expect(result.status).toBe('failed');
+      expect(result.modulesWithErrors).toBeGreaterThan(0);
+      expect(result.evaluableFiles).toContain('broken-module.gts');
+
+      let brokenFailure = result.failures.find((f) =>
+        f.path.includes('broken-module'),
+      );
+      expect(brokenFailure).toBeTruthy();
+      expect(brokenFailure!.error).toBeTruthy();
+      // The error should be a real eval failure from the sandbox, not
+      // infrastructure noise.
+      expect(brokenFailure!.error).not.toContain('unable to fetch');
+      expect(brokenFailure!.error).not.toContain('Command runner failed');
+      expect(brokenFailure!.error).not.toContain('Missing Authorization');
+
+      // In-memory tool must not write any EvalResult card artifact even
+      // when there are evaluation failures.
+      let listing = await client.listFiles(realmUrl);
+      let validationArtifacts = (listing.filenames ?? []).filter((f) =>
+        f.startsWith('Validations/eval_'),
+      );
+      expect(validationArtifacts).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('no evaluable modules produces a vacuous pass', async ({ realm }) => {
+    let realmUrl = realm.realmURL.href;
+    let realmServerUrl = realm.realmServerURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let serverToken = `Bearer ${realm.serverToken}`;
+
+    let { client, cleanup } = buildTestClient({
+      realmUrl,
+      realmToken: authorization,
+      realmServerUrl,
+      realmServerToken: serverToken,
+    });
+
+    try {
+      // Delete every ESM module shipped with the fixture realm.
+      let listingBefore = await client.listFiles(realmUrl);
+      let esmPattern = /\.(gts|gjs|ts|js)$/;
+      for (let filename of listingBefore.filenames ?? []) {
+        if (esmPattern.test(filename)) {
+          let deleteResult = await client.delete(realmUrl, filename);
+          expect(
+            deleteResult.ok,
+            `delete ${filename} failed: ${deleteResult.error}`,
+          ).toBe(true);
+        }
+      }
+
+      let result = await runEvaluateInMemory({
+        targetRealmUrl: realmUrl,
+        realmServerUrl,
+        client,
+      });
+
+      expect(result.status).toBe('passed');
+      expect(result.modulesChecked).toBe(0);
+      expect(result.modulesWithErrors).toBe(0);
+      expect(result.evaluableFiles).toEqual([]);
+      expect(result.failures).toEqual([]);
+      expect(result.errorMessage).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('error path: listFiles failure surfaces as status: error', async () => {
+    let thrower: BoxelCLIClient = {
+      listFiles: async () => {
+        throw new Error('ECONNREFUSED');
+      },
+    } as unknown as BoxelCLIClient;
+
+    let result = await runEvaluateInMemory({
+      targetRealmUrl: 'http://localhost:1/',
+      realmServerUrl: 'http://localhost:1/',
+      client: thrower,
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.errorMessage).toContain('ECONNREFUSED');
+    expect(result.evaluableFiles).toEqual([]);
+    expect(result.failures).toEqual([]);
+  });
+
+  test('path option: evaluates only the named file and skips the rest of the realm', async ({
+    realm,
+  }) => {
+    let realmUrl = realm.realmURL.href;
+    let realmServerUrl = realm.realmServerURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let serverToken = `Bearer ${realm.serverToken}`;
+
+    let { client, cleanup } = buildTestClient({
+      realmUrl,
+      realmToken: authorization,
+      realmServerUrl,
+      realmServerToken: serverToken,
+    });
+
+    try {
+      // Seed both a clean and a broken module alongside the fixture's clean
+      // hello.gts. Targeting just the broken file should fail; targeting
+      // the clean file should pass even though the broken module is still
+      // present in the realm.
+      let writeClean = await client.write(
+        realmUrl,
+        'valid-card.gts',
+        VALID_MODULE_GTS,
+      );
+      expect(writeClean.ok).toBe(true);
+      expect(
+        await client.waitForFile(realmUrl, 'valid-card.gts', {
+          pollMs: 300,
+          timeoutMs: 30_000,
+        }),
+      ).toBe(true);
+
+      let writeBroken = await client.write(
+        realmUrl,
+        'broken-module.gts',
+        BROKEN_MODULE_GTS,
+      );
+      expect(writeBroken.ok).toBe(true);
+      expect(
+        await client.waitForFile(realmUrl, 'broken-module.gts', {
+          pollMs: 300,
+          timeoutMs: 30_000,
+        }),
+      ).toBe(true);
+
+      // Evaluate only the clean file — should pass.
+      let cleanOnly = await runEvaluateInMemory({
+        targetRealmUrl: realmUrl,
+        realmServerUrl,
+        client,
+        path: 'valid-card.gts',
+      });
+      expect(cleanOnly.status).toBe('passed');
+      expect(cleanOnly.evaluableFiles).toEqual(['valid-card.gts']);
+      expect(cleanOnly.modulesChecked).toBe(1);
+      expect(cleanOnly.modulesWithErrors).toBe(0);
+      expect(cleanOnly.failures).toEqual([]);
+
+      // Evaluate only the broken file — should fail and mention only that file.
+      let brokenOnly = await runEvaluateInMemory({
+        targetRealmUrl: realmUrl,
+        realmServerUrl,
+        client,
+        path: 'broken-module.gts',
+      });
+      expect(brokenOnly.status).toBe('failed');
+      expect(brokenOnly.evaluableFiles).toEqual(['broken-module.gts']);
+      expect(brokenOnly.modulesChecked).toBe(1);
+      expect(brokenOnly.modulesWithErrors).toBe(1);
+      let fileSet = new Set(brokenOnly.failures.map((f) => f.path));
+      expect(Array.from(fileSet)).toEqual(['broken-module.gts']);
+
+      // Still no realm artifact written.
+      let listing = await client.listFiles(realmUrl);
+      let validationArtifacts = (listing.filenames ?? []).filter((f) =>
+        f.startsWith('Validations/eval_'),
+      );
+      expect(validationArtifacts).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('path option: non-evaluable extension returns status: error without a realm call', async () => {
+    let listFilesCalls = 0;
+    let runCommandCalls = 0;
+    let stubClient: BoxelCLIClient = {
+      listFiles: async () => {
+        listFilesCalls += 1;
+        return { filenames: [] };
+      },
+      runCommand: async () => {
+        runCommandCalls += 1;
+        throw new Error('should not be called for non-evaluable path');
+      },
+    } as unknown as BoxelCLIClient;
+
+    let result = await runEvaluateInMemory({
+      targetRealmUrl: 'http://localhost:1/',
+      realmServerUrl: 'http://localhost:1/',
+      client: stubClient,
+      path: 'Spec/sticky-note.json',
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.errorMessage).toContain('not evaluable');
+    expect(result.evaluableFiles).toEqual([]);
+    expect(result.failures).toEqual([]);
+    expect(listFilesCalls).toBe(0);
+    expect(runCommandCalls).toBe(0);
+  });
+
+  test('path option: test file (*.test.gts) returns status: error without a realm call', async () => {
+    let runCommandCalls = 0;
+    let stubClient: BoxelCLIClient = {
+      listFiles: async () => ({ filenames: [] }),
+      runCommand: async () => {
+        runCommandCalls += 1;
+        throw new Error('should not be called for test path');
+      },
+    } as unknown as BoxelCLIClient;
+
+    let result = await runEvaluateInMemory({
+      targetRealmUrl: 'http://localhost:1/',
+      realmServerUrl: 'http://localhost:1/',
+      client: stubClient,
+      path: 'hello.test.gts',
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.errorMessage).toContain('test file');
+    expect(result.evaluableFiles).toEqual([]);
+    expect(result.failures).toEqual([]);
+    expect(runCommandCalls).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Expose `run_evaluate` to the agent as an **in-memory** validator — evaluates ESM modules (`.gts` / `.gjs` / `.ts` / `.js`) in the target realm via the prerenderer sandbox and returns a flat `RunEvaluateResult` (status, module counts, per-failure `{ path, error, stackTrace? }`). No `EvalResult` card is written, so it's safe to call repeatedly mid-turn for self-validation. The orchestrator's post-`signal_done` validation pipeline still writes the durable `EvalResult` artifact.
- Without `path`, evaluates every non-test evaluable module in the realm. With `path`, evaluates only that single realm-relative file — the path-option pattern mirrors #4451 (`run_lint`). Non-evaluable extensions and test files (`*.test.*`) short-circuit to `status: 'error'` without calling the realm.
- Extract the discovery + per-module evaluation loop out of `EvalValidationStep` into a shared `eval-execution` engine (`discoverEvaluableFiles` + `evaluateRealmModules` + the `runEvaluateInMemory` entry point). The card-writing validation path and the new in-memory path both drive this single engine, so coverage stays identical across both surfaces.
- Discovery now spans all four ESM extensions rather than just `.gts`, matching the tool's requirement that "only files that can be imported as ESM modules should be able to be evaluated." Test-file exclusion extends to `.test.{gts,gjs,ts,js}`.
- Third tool delivered under parent [CS-10775](https://linear.app/cardstack/issue/CS-10775) (agent in-memory validation tools), following [CS-10777](https://linear.app/cardstack/issue/CS-10777) (`run_tests`, #4447) and [CS-10776](https://linear.app/cardstack/issue/CS-10776) (`run_lint`, #4451).

## Implementation notes

- `src/eval-execution.ts` — new shared engine: `EVALUABLE_EXTENSIONS`, `discoverEvaluableFiles`, `evaluateRealmModules`, and the `runEvaluateInMemory` entry point plus its `RunEvaluateInMemoryOptions` / `RunEvaluateResult` / `RunEvaluateFailure` types. Default `evaluateModuleFn` calls the `@cardstack/boxel-host/commands/evaluate-module/default` host command via `_run-command` (same path the old step used).
- `src/validators/eval-step.ts` — now delegates discovery and per-module evaluation to the shared engine; still owns `EvalResult` artifact lifecycle and sequence-number bookkeeping. Net diff is a reduction (~130 lines removed from the step). `EvalModuleResult` stays exported (re-exported from the engine) so existing `eval-step` unit tests compile unchanged.
- `src/factory-tool-builder.ts` — `buildRunEvaluateTool()` wired into `buildFactoryTools()`. Adds a `runEvaluateInMemory` seam on `ToolBuilderConfig` for injection in unit tests. Description tells the agent to pair eval failures with `fetch_transpiled_module` for debugging while making explicit that transpiled output is read-only scratch and must never be copied into source.
- `tests/factory-tool-builder.test.ts` — five unit tests for the new tool wiring: registration shape, full-realm option forwarding, single-file `path` forwarding, whitespace-only-path fallback, and failed-result propagation.
- `tests/run-evaluate-in-memory.spec.ts` — Playwright spec against a real harness realm mirroring `eval-validation.spec.ts`. Asserts no `Validations/eval_*` artifact is ever written. Covers clean realm, broken-import realm, empty realm, `listFiles` failure, `path` option (clean vs broken in isolation), non-evaluable extension, and `.test.gts` path.
- Docs + `software-factory-operations` skill updated so `run_evaluate` is documented as an optional mid-turn self-validation tool with the full `RunEvaluateResult` shape.

## Test plan

- [x] `pnpm --filter @cardstack/software-factory lint:js`
- [x] `pnpm --filter @cardstack/software-factory lint:format`
- [x] `pnpm --filter @cardstack/software-factory test --node-only` (420 passed, including the five new `buildFactoryTools — run_evaluate` tests)
- [ ] `pnpm --filter @cardstack/software-factory test:playwright -- tests/run-evaluate-in-memory.spec.ts tests/eval-validation.spec.ts` — deferred to CI (shared cache:prepare contention locally)
- [ ] CI: full factory test matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)