### PR TITLE
Add computed theme field

### DIFF
--- a/.github/workflows/test-web-assets.yaml
+++ b/.github/workflows/test-web-assets.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build host dist (test assets)
         if: steps.restore.outputs.cache-hit != 'true'
-        run: NODE_OPTIONS="--max_old_space_size=6144" pnpm build
+        run: NODE_OPTIONS="--max_old_space_size=4096" pnpm build
         working-directory: packages/host
         env:
           SKIP_CATALOG: ${{ inputs.skip_catalog }}

--- a/.github/workflows/test-web-assets.yaml
+++ b/.github/workflows/test-web-assets.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build host dist (test assets)
         if: steps.restore.outputs.cache-hit != 'true'
-        run: NODE_OPTIONS="--max_old_space_size=4096" pnpm build
+        run: NODE_OPTIONS="--max_old_space_size=6144" pnpm build
         working-directory: packages/host
         env:
           SKIP_CATALOG: ${{ inputs.skip_catalog }}

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2914,7 +2914,7 @@ export class CardDef extends BaseDef {
       return this.cardInfo.summary;
     },
   });
-  @field cardTheme: Theme | null = linksTo(() => Theme, {
+  @field cardTheme: InstanceType<typeof Theme> | null = linksTo(() => Theme, {
     computeVia: function (this: CardDef) {
       return this.cardInfo.theme;
     },

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2914,6 +2914,11 @@ export class CardDef extends BaseDef {
       return this.cardInfo.summary;
     },
   });
+  @field cardTheme: Theme | null = linksTo(() => Theme, {
+    computeVia: function (this: CardDef) {
+      return this.cardInfo.theme;
+    },
+  });
   // TODO: this will probably be an image or image url field card when we have it
   // UPDATE: we now have a Base64ImageField card. we can probably refactor this
   // to use it directly now (or wait until a better image field comes along)

--- a/packages/base/default-templates/card-info.gts
+++ b/packages/base/default-templates/card-info.gts
@@ -18,14 +18,7 @@ import { ChevronRight } from '@cardstack/boxel-ui/icons';
 
 import { startCase } from 'lodash';
 
-import { getFieldIcon } from '@cardstack/runtime-common';
-
-export const cardInfoFields: string[] = [
-  'cardTitle',
-  'cardDescription',
-  'cardThumbnailURL',
-  'cardTheme',
-];
+import { getFieldIcon, cardDefComputedFields } from '@cardstack/runtime-common';
 
 class CardInfoImageContainer extends GlimmerComponent<{
   Args: {
@@ -358,7 +351,7 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
   };
 
   private get previewFields() {
-    return cardInfoFields.map((key) => ({
+    return cardDefComputedFields.map((key) => ({
       key,
       label: startCase(key),
       value: (this.args.model as any)?.[key],

--- a/packages/base/default-templates/card-info.gts
+++ b/packages/base/default-templates/card-info.gts
@@ -322,14 +322,23 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
       .thumbnail-input-container {
         position: relative;
       }
+      .thumbnail-placeholder:not(:has(input)) {
+        position: absolute;
+        top: var(--boxel-sp-xs);
+        left: var(--boxel-sp-sm);
+        color: var(--muted-foreground, var(--boxel-450));
+      }
       .thumbnail-placeholder :deep(input) {
         position: absolute;
         left: 0;
         right: 0;
-        width: 99%;
+        width: 100%;
+        height: 100%;
         padding-block: 0;
         background: none;
         border: none;
+        outline-offset: -1px;
+        outline-width: 2px;
       }
       .null-preview {
         color: var(--muted-foreground, var(--boxel-450));

--- a/packages/base/default-templates/card-info.gts
+++ b/packages/base/default-templates/card-info.gts
@@ -13,7 +13,7 @@ import type { CardOrFieldTypeIcon, CardDef, FieldsTypeFor } from '../card-api';
 import setBackgroundImage from '../helpers/set-background-image';
 
 import { FieldContainer, Button } from '@cardstack/boxel-ui/components';
-import { cn, eq } from '@cardstack/boxel-ui/helpers';
+import { and, cn, eq } from '@cardstack/boxel-ui/helpers';
 import { ChevronRight } from '@cardstack/boxel-ui/icons';
 
 import { startCase } from 'lodash';
@@ -160,7 +160,13 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
                 {{#if item.value}}
                   <Field @format='embedded' />
                 {{else}}
-                  <em class='null-preview'>None</em>
+                  <em class='null-preview'>
+                    {{#if (and (eq item.key 'cardTheme') @hideThemeChooser)}}
+                      (Self)
+                    {{else}}
+                      None
+                    {{/if}}
+                  </em>
                 {{/if}}
               </FieldContainer>
             {{/let}}
@@ -227,7 +233,7 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
           </FieldContainer>
           <FieldContainer
             class='card-info-field'
-            @label='Card Thumbnail URL'
+            @label='Thumbnail URL'
             @tag='label'
             @icon={{LinkIcon}}
             data-test-field='cardInfo-thumbnailURL'

--- a/packages/base/default-templates/card-info.gts
+++ b/packages/base/default-templates/card-info.gts
@@ -2,7 +2,6 @@ import GlimmerComponent from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
 
-import CaptionsIcon from '@cardstack/boxel-icons/captions';
 import NameIcon from '@cardstack/boxel-icons/folder-pen';
 import SummaryIcon from '@cardstack/boxel-icons/notepad-text';
 import LinkIcon from '@cardstack/boxel-icons/link';
@@ -14,10 +13,19 @@ import type { CardOrFieldTypeIcon, CardDef, FieldsTypeFor } from '../card-api';
 import setBackgroundImage from '../helpers/set-background-image';
 
 import { FieldContainer, Button } from '@cardstack/boxel-ui/components';
-import { cn } from '@cardstack/boxel-ui/helpers';
+import { cn, eq } from '@cardstack/boxel-ui/helpers';
 import { ChevronRight } from '@cardstack/boxel-ui/icons';
 
+import { startCase } from 'lodash';
+
 import { getFieldIcon } from '@cardstack/runtime-common';
+
+export const cardInfoFields: string[] = [
+  'cardTitle',
+  'cardDescription',
+  'cardThumbnailURL',
+  'cardTheme',
+];
 
 class CardInfoImageContainer extends GlimmerComponent<{
   Args: {
@@ -140,32 +148,30 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
         <div class='default-preview'>
           <FieldContainer
             @label='Card Type'
-            @icon={{CaptionsIcon}}
+            @icon={{@model.constructor.icon}}
             data-test-edit-preview='cardType'
           >
             {{@model.constructor.displayName}}
           </FieldContainer>
-          <FieldContainer
-            @label='Title'
-            @icon={{getFieldIcon @model 'cardTitle'}}
-            data-test-edit-preview='cardTitle'
-          >
-            <@fields.cardTitle @format='embedded' />
-          </FieldContainer>
-          <FieldContainer
-            @label='Description'
-            @icon={{getFieldIcon @model 'cardDescription'}}
-            data-test-edit-preview='cardDescription'
-          >
-            <@fields.cardDescription @format='embedded' />
-          </FieldContainer>
-          <FieldContainer
-            @label='Thumbnail URL'
-            @icon={{LinkIcon}}
-            data-test-edit-preview='cardThumbnailURL'
-          >
-            <@fields.cardThumbnailURL @format='embedded' />
-          </FieldContainer>
+          {{#each this.previewFields as |item|}}
+            {{#let item.Field as |Field|}}
+              <FieldContainer
+                @label={{item.label}}
+                @icon={{if
+                  (eq item.key 'cardThumbnailURL')
+                  LinkIcon
+                  (getFieldIcon @model item.key)
+                }}
+                data-test-edit-preview={{item.key}}
+              >
+                {{#if item.value}}
+                  <Field @format='embedded' />
+                {{else}}
+                  <em class='null-preview'>None</em>
+                {{/if}}
+              </FieldContainer>
+            {{/let}}
+          {{/each}}
         </div>
       {{/if}}
       <FieldContainer class='main-fields'>
@@ -228,7 +234,7 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
           </FieldContainer>
           <FieldContainer
             class='card-info-field'
-            @label='Thumbnail URL'
+            @label='Card Thumbnail URL'
             @tag='label'
             @icon={{LinkIcon}}
             data-test-field='cardInfo-thumbnailURL'
@@ -325,6 +331,9 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
         background: none;
         border: none;
       }
+      .null-preview {
+        color: var(--muted-foreground, var(--boxel-450));
+      }
     </style>
   </template>
 
@@ -338,6 +347,15 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
   private toggleThumbnailEditor = () => {
     this.isThumbnailEditorVisible = !this.isThumbnailEditorVisible;
   };
+
+  private get previewFields() {
+    return cardInfoFields.map((key) => ({
+      key,
+      label: startCase(key),
+      value: (this.args.model as any)?.[key],
+      Field: (this.args.fields as any)?.[key],
+    }));
+  }
 
   private get showThumbnailPlaceholder() {
     return (

--- a/packages/base/default-templates/card-info.gts
+++ b/packages/base/default-templates/card-info.gts
@@ -158,7 +158,7 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
                 data-test-edit-preview={{item.key}}
               >
                 {{#if item.value}}
-                  <Field @format='embedded' />
+                  <Field @format='atom' />
                 {{else}}
                   <em class='null-preview'>
                     {{#if (and (eq item.key 'cardTheme') @hideThemeChooser)}}

--- a/packages/base/default-templates/head.gts
+++ b/packages/base/default-templates/head.gts
@@ -26,7 +26,7 @@ export default class DefaultHeadTemplate extends GlimmerComponent<{
   }
 
   get themeIcon(): string | undefined {
-    let theme = this.args.model?.cardInfo?.theme;
+    let theme = this.args.model?.cardTheme;
     return (
       (theme as BrandGuide | undefined)?.markUsage?.socialMediaProfileIcon ??
       theme?.cardThumbnailURL

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -4,7 +4,7 @@ import { FieldContainer, Header } from '@cardstack/boxel-ui/components';
 import { cn, eq } from '@cardstack/boxel-ui/helpers';
 import { startCase } from 'lodash';
 import { getFieldIcon, getField } from '@cardstack/runtime-common';
-import CardInfoTemplates from './card-info';
+import CardInfoTemplates, { cardInfoFields } from './card-info';
 
 export default class DefaultCardDefTemplate extends GlimmerComponent<{
   Args: {
@@ -13,22 +13,18 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
     format: Format;
   };
 }> {
-  private specialFields: string[] = [
-    'cardTitle',
-    'cardDescription',
-    'cardThumbnailURL',
-  ];
+  private cardInfoFields = cardInfoFields;
   private excludedFields: string[] = [
     'id',
     'cardInfo',
-    ...this.specialFields,
+    ...this.cardInfoFields,
     'theme',
   ];
 
-  // Logic: If special field (cardTitle, cardDescription, cardThumbnailURL) is NOT computed,
+  // Logic: If cardInfo field is NOT computed,
   // then display its edit format alongside other top-level fields.
-  private get specialDisplayFieldNames(): string[] | undefined {
-    let fieldNames = this.specialFields.filter((fieldName) => {
+  private get cardInfoFieldDisplayNames(): string[] | undefined {
+    let fieldNames = this.cardInfoFields.filter((fieldName) => {
       const field = getField(this.args.model.constructor, fieldName);
       return field?.computeVia == undefined;
     });
@@ -39,7 +35,7 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
   // Fields to display in between the cardInfo header and notes footer
   private get displayFields(): FieldsTypeFor<CardDef> | undefined {
     let excludedFields = this.excludedFields.filter(
-      (name) => !this.specialDisplayFieldNames?.includes(name),
+      (name) => !this.cardInfoFieldDisplayNames?.includes(name),
     );
     let fields = Object.entries(this.args.fields).filter(
       ([key]) => !excludedFields.includes(key),

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -3,8 +3,12 @@ import type { CardDef, FieldsTypeFor, Format } from '../card-api';
 import { FieldContainer, Header } from '@cardstack/boxel-ui/components';
 import { cn, eq } from '@cardstack/boxel-ui/helpers';
 import { startCase } from 'lodash';
-import { getFieldIcon, getField } from '@cardstack/runtime-common';
-import CardInfoTemplates, { cardInfoFields } from './card-info';
+import {
+  getFieldIcon,
+  getField,
+  cardDefComputedFields,
+} from '@cardstack/runtime-common';
+import CardInfoTemplates from './card-info';
 
 export default class DefaultCardDefTemplate extends GlimmerComponent<{
   Args: {
@@ -13,18 +17,18 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
     format: Format;
   };
 }> {
-  private cardInfoFields = cardInfoFields;
+  private standardComputedFields = cardDefComputedFields;
   private excludedFields: string[] = [
     'id',
     'cardInfo',
-    ...this.cardInfoFields,
+    ...this.standardComputedFields,
     'theme',
   ];
 
-  // Logic: If cardInfo field is NOT computed,
+  // Logic: If standardComputedFields is NOT computed due to user override,
   // then display its edit format alongside other top-level fields.
   private get cardInfoFieldDisplayNames(): string[] | undefined {
-    let fieldNames = this.cardInfoFields.filter((fieldName) => {
+    let fieldNames = this.standardComputedFields.filter((fieldName) => {
       const field = getField(this.args.model.constructor, fieldName);
       return field?.computeVia == undefined;
     });

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -234,7 +234,7 @@ export function getBoxComponent(
     }
     let css = isThemeCard(cardDef)
       ? cardDef.cssVariables
-      : cardDef?.cardInfo?.theme?.cssVariables;
+      : cardDef?.cardTheme?.cssVariables;
     return sanitizeHtmlSafe(extractCssVariables(css));
   }
 
@@ -242,7 +242,7 @@ export function getBoxComponent(
     if (isThemeCard(cardDef)) {
       return Boolean(cardDef?.cssVariables?.trim());
     }
-    return cardDef?.cardInfo?.theme != null;
+    return cardDef?.cardTheme != null;
   }
 
   function getCssImports(card?: CardDef) {
@@ -254,7 +254,7 @@ export function getBoxComponent(
         return card.cssImports;
       }
     }
-    return card?.cardInfo?.theme?.cssImports;
+    return card?.cardTheme?.cssImports;
   }
 
   let component = class FieldComponent extends Component<BoxComponentSignature> {

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -32,6 +32,7 @@ import {
   type TestContextWithSave,
   setupAuthEndpoints,
   setupUserSubscription,
+  cardDefFieldCount,
 } from '../../helpers';
 
 import { setupMockMatrix } from '../../helpers/mock-matrix';
@@ -808,8 +809,8 @@ export class TrèsTestCard extends CardDef {
         );
       assert
         .dom('[data-test-total-fields]')
-        .containsText('4')
-        .hasAttribute('title', '4 fields');
+        .containsText(`${cardDefFieldCount}`)
+        .hasAttribute('title', `${cardDefFieldCount} fields`);
     });
 
     test<TestContextWithSave>('can create a new card definition in same realm as inherited definition', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -47,6 +47,7 @@ import {
   type TestContextWithSave,
   setMonacoContent,
   withCachedRealmSetup,
+  cardDefFieldCount,
 } from '../../helpers';
 
 import { setupMockMatrix } from '../../helpers/mock-matrix';
@@ -227,6 +228,8 @@ const inThisFileSource = `
 
   export default class DefaultClass {}
 `;
+
+const exportedCardFieldCount = `${cardDefFieldCount + 1}`; // standard field count + own field
 
 const commandModuleSource = `
   import { Command } from '@cardstack/runtime-common';
@@ -801,7 +804,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
         `[data-test-card-schema="exported card"] [data-test-field-name="someString"] [data-test-card-display-name="String"]`,
       )
       .exists();
-    assert.dom(`[data-test-total-fields]`).containsText('5');
+    assert.dom(`[data-test-total-fields]`).containsText(exportedCardFieldCount);
     assert.true(monacoService.getLineCursorOn()?.includes(elementName));
 
     // clicking on a field
@@ -1877,7 +1880,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       .exists({ count: 1 });
     assert.dom(`[data-test-card-schema="local parent"]`).exists();
     assert.dom(`[data-test-card-schema="local grandparent"]`).exists();
-    assert.dom(`[data-test-total-fields]`).containsText('4');
+    assert.dom(`[data-test-total-fields]`).containsText(`${cardDefFieldCount}`);
     assert.true(monacoService.getLineCursorOn()?.includes(elementName));
     assert.true(monacoService.getLineCursorOn()?.includes('GrandParent'));
 
@@ -2074,7 +2077,7 @@ export class TestCard extends ExportedCard {
     assert
       .dom('[data-test-card-schema]')
       .exists({ count: 4 }, 'the card hierarchy is displayed in schema editor');
-    assert.dom('[data-test-total-fields]').containsText('5');
+    assert.dom('[data-test-total-fields]').containsText(exportedCardFieldCount);
 
     // assert modal state is cleared
     await settled();
@@ -2279,7 +2282,7 @@ export class ExportedCard extends ExportedCardParent {
     assert
       .dom('[data-test-card-schema]')
       .exists({ count: 4 }, 'the card hierarchy is displayed in schema editor');
-    assert.dom('[data-test-total-fields]').containsText('5');
+    assert.dom('[data-test-total-fields]').containsText(exportedCardFieldCount);
   });
 
   test('field error message displays if you try to inherit using a filename that already exists', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -433,7 +433,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
 
     assert
       .dom('[data-test-card-schema="Card"] [data-test-total-fields]')
-      .containsText('+ 4 Fields');
+      .containsText('+ 5 Fields');
     assert
       .dom(
         `[data-test-card-schema="Card"] [data-test-field-name="cardTitle"] [data-test-overridden-field-link]`,
@@ -453,6 +453,11 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
     assert
       .dom(
         `[data-test-card-schema="Card"] [data-test-field-name="cardThumbnailURL"] [data-test-card-display-name="String"]`,
+      )
+      .exists();
+    assert
+      .dom(
+        `[data-test-card-schema="Card"] [data-test-field-name="cardTheme"] [data-test-card-display-name="Theme"]`,
       )
       .exists();
 

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -27,6 +27,7 @@ import {
   setupUserSubscription,
   type TestContextWithSave,
   withCachedRealmSetup,
+  cardDefFieldCount,
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupApplicationTest } from '../../helpers/setup';
@@ -47,6 +48,7 @@ const indexCardSource = `
   }
 `;
 
+const personCardFieldCount = `${cardDefFieldCount + 5}`;
 const personCardSource = `
   import { contains, containsMany, field, linksToMany, CardDef, Component, StringField } from "https://cardstack.com/base/card-api";
   import { Friend } from './friend';
@@ -373,7 +375,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
     await waitFor('[data-test-card-schema]');
 
     assert.dom('[data-test-card-schema]').exists({ count: 3 });
-    assert.dom('[data-test-total-fields]').containsText('9');
+    assert.dom('[data-test-total-fields]').containsText(personCardFieldCount);
 
     assert
       .dom('[data-test-card-schema="Person"] [data-test-total-fields]')
@@ -529,7 +531,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
     await click(`button[data-test-clickable-definition-container`);
     await waitFor('[data-test-card-schema]');
     assert.dom('[data-test-card-schema]').exists({ count: 3 });
-    assert.dom('[data-test-total-fields]').containsText('9');
+    assert.dom('[data-test-total-fields]').containsText(personCardFieldCount);
   });
 
   test('shows displayName of CardResource when field refers to itself', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -48,7 +48,8 @@ const indexCardSource = `
   }
 `;
 
-const personCardFieldCount = `${cardDefFieldCount + 5}`;
+const personOwnFieldCount = 5;
+const personTotalFieldCount = `${cardDefFieldCount + personOwnFieldCount}`;
 const personCardSource = `
   import { contains, containsMany, field, linksToMany, CardDef, Component, StringField } from "https://cardstack.com/base/card-api";
   import { Friend } from './friend';
@@ -375,11 +376,11 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
     await waitFor('[data-test-card-schema]');
 
     assert.dom('[data-test-card-schema]').exists({ count: 3 });
-    assert.dom('[data-test-total-fields]').containsText(personCardFieldCount);
+    assert.dom('[data-test-total-fields]').containsText(personTotalFieldCount);
 
     assert
       .dom('[data-test-card-schema="Person"] [data-test-total-fields]')
-      .containsText('+ 5 Fields');
+      .containsText(`+ ${personOwnFieldCount} Fields`);
     assert
       .dom(
         `[data-test-card-schema="Person"] [data-test-field-name="firstName"] [data-test-card-display-name="String"]`,
@@ -531,7 +532,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
     await click(`button[data-test-clickable-definition-container`);
     await waitFor('[data-test-card-schema]');
     assert.dom('[data-test-card-schema]').exists({ count: 3 });
-    assert.dom('[data-test-total-fields]').containsText(personCardFieldCount);
+    assert.dom('[data-test-total-fields]').containsText(personTotalFieldCount);
   });
 
   test('shows displayName of CardResource when field refers to itself', async function (assert) {
@@ -834,7 +835,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
 
     assert
       .dom('[data-test-card-schema="Person"] [data-test-total-fields]')
-      .containsText('+ 5 Fields');
+      .containsText(`+ ${personOwnFieldCount} Fields`);
 
     assert.true(
       getMonacoContent().includes('firstName = contains(StringField)'),
@@ -877,7 +878,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
     });
     assert
       .dom('[data-test-card-schema="Person"] [data-test-total-fields]')
-      .containsText('+ 4 Fields'); // One field less
+      .containsText(`+ ${personOwnFieldCount - 1} Fields`); // One field less
     assert
       .dom(
         '[data-test-card-schema="Person"] [data-test-field-name="firstName"]',

--- a/packages/host/tests/helpers/base-realm.ts
+++ b/packages/host/tests/helpers/base-realm.ts
@@ -115,6 +115,7 @@ let getFieldDescription: (typeof CardAPIModule)['getFieldDescription'];
 let ReadOnlyField: (typeof CardAPIModule)['ReadOnlyField'];
 let instanceOf: (typeof CardAPIModule)['instanceOf'];
 let CardInfoField: (typeof CardAPIModule)['CardInfoField'];
+let Theme: (typeof CardAPIModule)['Theme'];
 let enumField: (typeof EnumModule)['default'];
 let enumOptions: (typeof EnumModule)['enumOptions'];
 let enumValues: (typeof EnumModule)['enumValues'];
@@ -246,6 +247,7 @@ async function initialize() {
     ReadOnlyField,
     instanceOf,
     CardInfoField,
+    Theme,
   } = cardAPI);
 
   enumField = (await loader.import<typeof EnumModule>(`${baseRealm.url}enum`))
@@ -312,6 +314,7 @@ export {
   Skill,
   instanceOf,
   CardInfoField,
+  Theme,
   enumField,
   enumOptions,
   enumValues,

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -18,6 +18,7 @@ import { validate as uuidValidate } from 'uuid';
 import {
   baseRealm,
   CachingDefinitionLookup,
+  cardDefComputedFields,
   ensureTrailingSlash,
   getCreatedTime,
   IndexWriter,
@@ -105,6 +106,8 @@ export {
 } from '@cardstack/host/lib/utils';
 
 const { sqlSchema } = ENV;
+
+export const cardDefFieldCount = cardDefComputedFields?.length + 1; // standard computeds + `cardInfo`
 
 type CardAPI = typeof import('https://cardstack.com/base/card-api');
 type ModuleHooks = {

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -2335,7 +2335,10 @@ module('Integration | card-basics', function (hooks) {
         .containsText(summary);
       assert
         .dom('[data-test-edit-preview="cardThumbnailURL"]')
-        .hasText('Thumbnail URL');
+        .hasText('Card Thumbnail URL None');
+      assert
+        .dom('[data-test-edit-preview="cardTheme"]')
+        .hasText('Card Theme None');
       assert
         .dom('[data-test-edit-preview] input')
         .doesNotExist('preview fields are not editable');
@@ -2370,8 +2373,12 @@ module('Integration | card-basics', function (hooks) {
           },
         });
       }
-      let localTheme = new Theme({ cardTitle: 'Local Theme' });
-      let linkedTheme = new Theme({ cardTitle: 'Volley Blue' });
+      let localTheme = new Theme({
+        cardInfo: new CardInfoField({ name: 'Local Theme' }),
+      });
+      let linkedTheme = new Theme({
+        cardInfo: new CardInfoField({ name: 'Volley Blue' }),
+      });
       let team = new Team({
         cardInfo: new CardInfoField({
           theme: linkedTheme,
@@ -2399,9 +2406,6 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-field="cardInfo-summary"]')
         .hasText('Volleyball player');
-      assert
-        .dom('[data-test-field="cardTheme"]')
-        .containsText('Local Theme');
 
       await renderCard(loader, instance, 'edit');
       assert.dom('[data-test-field="cardInfo-name"] input').hasValue('Johnny');
@@ -2418,14 +2422,6 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-field="cardInfo-theme"]')
         .containsText('Local Theme');
-      assert
-        .dom('[data-test-field="cardTheme"]')
-        .containsText('Local Theme');
-      assert
-        .dom(
-          '[data-test-field="cardTheme"] [data-test-links-to-editor="cardTheme"]',
-        )
-        .doesNotExist();
       assert.dom('[data-test-field="cardInfo-notes"] textarea').exists();
       assert.dom('[data-test-field="firstName"] input').hasValue('John');
       assert
@@ -2444,6 +2440,9 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-edit-preview="cardThumbnailURL"]')
         .containsText('http://john/pic.jpg');
+      assert
+        .dom('[data-test-edit-preview="cardTheme"]')
+        .containsText('Local Theme');
 
       await percySnapshot(assert);
     });
@@ -2471,16 +2470,15 @@ module('Integration | card-basics', function (hooks) {
             return this.bookCoverImage;
           },
         });
-        @field cardTheme: InstanceType<typeof Theme> | null = linksTo(
-          () => Theme,
-          {
-            computeVia: function (this: Book) {
-              return this.cardInfo.theme ?? this.collection?.cardTheme;
-            },
+        @field cardTheme = linksTo(() => Theme, {
+          computeVia: function (this: Book) {
+            return this.cardInfo.theme ?? this.collection?.cardTheme;
           },
-        );
+        });
       }
-      let linkedTheme = new Theme({ cardTitle: 'Night Library' });
+      let linkedTheme = new Theme({
+        cardInfo: new CardInfoField({ name: 'Night Library' }),
+      });
       let collection = new Collection({
         cardInfo: new CardInfoField({
           theme: linkedTheme,
@@ -2505,7 +2503,6 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-field="cardInfo-summary"]')
         .hasText('This book will keep you up at night');
-      assert.dom('[data-test-field="cardTheme"]').containsText('Night Library');
 
       await renderCard(loader, instance, 'edit');
       assert.dom('[data-test-field="cardInfo-name"] input').hasNoValue();
@@ -2518,16 +2515,10 @@ module('Integration | card-basics', function (hooks) {
         .dom('[data-test-thumbnail-placeholder]')
         .hasText('http://book/pic.jpg');
       assert.dom('[data-test-thumbnail-input] input').hasNoValue();
-      await click('[data-test-toggle-thumbnail-editor]');
       assert
         .dom('[data-test-field="cardInfo-theme"]')
         .doesNotContainText('Night Library');
-      assert.dom('[data-test-field="cardTheme"]').containsText('Night Library');
-      assert
-        .dom(
-          '[data-test-field="cardTheme"] [data-test-links-to-editor="cardTheme"]',
-        )
-        .doesNotExist();
+      await click('[data-test-toggle-thumbnail-editor]');
       assert
         .dom('[data-test-field="bookCoverImage"] input')
         .hasValue('http://book/pic.jpg');
@@ -2544,6 +2535,9 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-edit-preview="cardThumbnailURL"]')
         .containsText('http://book/pic.jpg');
+      assert
+        .dom('[data-test-edit-preview="cardTheme"]')
+        .containsText('Night Library');
     });
 
     test('render card-def instance with cardInfo overrides (not computed)', async function (assert) {
@@ -2554,18 +2548,18 @@ module('Integration | card-basics', function (hooks) {
         @field cardDescription = contains(StringField);
         @field cardThumbnailURL = contains(StringField);
         @field shelf = linksTo(Shelf);
-        @field cardTheme: InstanceType<typeof Theme> | null = linksTo(
-          () => Theme,
-          {
-            computeVia: function (this: Book) {
-              return this.cardInfo.theme ?? this.shelf?.cardTheme;
-            },
-          },
-        );
+        @field cardTheme = linksTo(() => Theme);
       }
 
-      let localTheme = new Theme({ cardTitle: 'Local Theme' });
-      let linkedTheme = new Theme({ cardTitle: 'Sleepless Pages' });
+      let localTheme1 = new Theme({
+        cardInfo: new CardInfoField({ name: 'Local Theme 1' }),
+      });
+      let localTheme2 = new Theme({
+        cardInfo: new CardInfoField({ name: 'Local Theme 2' }),
+      });
+      let linkedTheme = new Theme({
+        cardInfo: new CardInfoField({ name: 'Sleepless Pages' }),
+      });
       let shelf = new Shelf({
         cardInfo: new CardInfoField({
           theme: linkedTheme,
@@ -2577,9 +2571,10 @@ module('Integration | card-basics', function (hooks) {
         cardThumbnailURL: 'http://book/pic.jpg',
         cardInfo: new CardInfoField({
           summary: 'The latest novel from John Doe',
-          theme: localTheme,
+          theme: localTheme1,
         }),
         shelf,
+        cardTheme: localTheme2,
       });
       await renderCard(loader, insomniac, 'isolated');
       assert.dom('[data-test-field="cardInfo-name"]').hasText('Insomniac');
@@ -2599,9 +2594,7 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-field="cardThumbnailURL"]')
         .hasText('Card Thumbnail URL http://book/pic.jpg');
-      assert
-        .dom('[data-test-field="cardTheme"]')
-        .containsText('Local Theme');
+      assert.dom('[data-test-field="cardTheme"]').containsText('Local Theme 2');
 
       await renderCard(loader, insomniac, 'edit');
       assert.dom('[data-test-field="cardInfo-name"] input').hasNoValue();
@@ -2613,6 +2606,9 @@ module('Integration | card-basics', function (hooks) {
         .dom('[data-test-thumbnail-placeholder] input')
         .hasValue('http://book/pic.jpg');
       assert.dom('[data-test-thumbnail-input] input').hasNoValue();
+      assert
+        .dom('[data-test-field="cardInfo-theme"]')
+        .containsText('Local Theme 1');
       await click('[data-test-toggle-thumbnail-editor]');
       assert.dom('[data-test-field="cardTitle"] input').hasValue('Insomniac');
       assert
@@ -2621,17 +2617,6 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-field="cardThumbnailURL"] input')
         .hasValue('http://book/pic.jpg');
-      assert
-        .dom('[data-test-field="cardInfo-theme"]')
-        .containsText('Local Theme');
-      assert
-        .dom('[data-test-field="cardTheme"]')
-        .containsText('Local Theme');
-      assert
-        .dom(
-          '[data-test-field="cardTheme"] [data-test-links-to-editor="cardTheme"]',
-        )
-        .doesNotExist();
 
       // default preview (on edit template)
       await click('[data-test-toggle-preview]');
@@ -2645,6 +2630,9 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-edit-preview="cardThumbnailURL"]')
         .containsText('http://book/pic.jpg');
+      assert
+        .dom('[data-test-edit-preview="cardTheme"]')
+        .containsText('Local Theme 2');
     });
 
     test('render card-def instance with cardInfo overrides (complex)', async function (assert) {
@@ -2693,7 +2681,9 @@ module('Integration | card-basics', function (hooks) {
         );
       }
 
-      let linkedTheme = new Theme({ cardTitle: 'Holiday Departure' });
+      let linkedTheme = new Theme({
+        cardInfo: new CardInfoField({ name: 'Holiday Departure' }),
+      });
       let travelProfile = new TravelProfile({
         cardInfo: new CardInfoField({
           theme: linkedTheme,
@@ -2725,9 +2715,6 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-field="flightNumber"]')
         .hasText('Flight Number 101');
-      assert
-        .dom('[data-test-field="cardTheme"]')
-        .containsText('Holiday Departure');
 
       await renderCard(loader, instance, 'edit');
       assert
@@ -2741,18 +2728,11 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-field="cardInfo-thumbnailURL"] input')
         .hasNoValue();
+      assert
+        .dom('[data-test-field="cardInfo-theme"] [data-test-add-new="theme"]')
+        .exists();
       await click('[data-test-toggle-thumbnail-editor]');
-      assert
-        .dom('[data-test-field="cardInfo-theme"]')
-        .doesNotContainText('Holiday Departure');
-      assert
-        .dom('[data-test-field="cardTheme"]')
-        .containsText('Holiday Departure');
-      assert
-        .dom(
-          '[data-test-field="cardTheme"] [data-test-links-to-editor="cardTheme"]',
-        )
-        .doesNotExist();
+
       assert.dom('[data-test-field="destination"] input').hasValue('LAX');
 
       // default preview (in edit mode)
@@ -2768,6 +2748,9 @@ module('Integration | card-basics', function (hooks) {
         .containsText(
           'Smith Wedding Flight - John, Jane + kids to LA for holiday wedding',
         );
+      assert
+        .dom('[data-test-edit-preview="cardTheme"]')
+        .containsText('Holiday Departure');
     });
 
     test('render default isolated template', async function (assert) {

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -86,6 +86,7 @@ import {
   ReadOnlyField,
   instanceOf,
   CardInfoField,
+  Theme,
 } from '../../helpers/base-realm';
 import { mango } from '../../helpers/image-fixture';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
@@ -2343,33 +2344,51 @@ module('Integration | card-basics', function (hooks) {
     });
 
     test('render card-def instance with cardInfo overrides', async function (assert) {
+      class Team extends CardDef {}
       class Person extends CardDef {
         static displayName = 'Person';
         @field firstName = contains(StringField);
         @field lastName = contains(StringField);
         @field profilePic = contains(StringField);
+        @field team = linksTo(Team);
         @field cardTitle = contains(StringField, {
           computeVia: function (this: Person) {
             return [this.firstName, this.lastName].filter(Boolean).join(' ');
           },
         });
+        @field cardTheme: InstanceType<typeof Theme> | null = linksTo(
+          () => Theme,
+          {
+            computeVia: function (this: Person) {
+              return this.cardInfo.theme ?? this.team?.cardTheme;
+            },
+          },
+        );
         @field cardThumbnailURL = contains(StringField, {
           computeVia: function (this: Person) {
             return this.profilePic;
           },
         });
       }
-      loader.shimModule(`${testRealmURL}test-cards`, { Person });
+      let localTheme = new Theme({ cardTitle: 'Local Theme' });
+      let linkedTheme = new Theme({ cardTitle: 'Volley Blue' });
+      let team = new Team({
+        cardInfo: new CardInfoField({
+          theme: linkedTheme,
+        }),
+      });
 
       let instance = new Person({
         cardInfo: new CardInfoField({
           name: 'Johnny',
           summary: 'Volleyball player',
           cardThumbnailURL: 'http://pic/of/volleyball',
+          theme: localTheme,
         }),
         firstName: 'John',
         lastName: 'Doe',
         profilePic: 'http://john/pic.jpg',
+        team,
       });
       await renderCard(loader, instance, 'isolated');
       assert.dom('[data-test-thumbnail-icon]').doesNotExist();
@@ -2380,6 +2399,9 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-field="cardInfo-summary"]')
         .hasText('Volleyball player');
+      assert
+        .dom('[data-test-field="cardTheme"]')
+        .containsText('Local Theme');
 
       await renderCard(loader, instance, 'edit');
       assert.dom('[data-test-field="cardInfo-name"] input').hasValue('Johnny');
@@ -2393,6 +2415,17 @@ module('Integration | card-basics', function (hooks) {
         .dom('[data-test-field="cardInfo-thumbnailURL"] input')
         .hasValue('http://pic/of/volleyball');
       assert.dom('[data-test-links-to-editor="theme"]').exists();
+      assert
+        .dom('[data-test-field="cardInfo-theme"]')
+        .containsText('Local Theme');
+      assert
+        .dom('[data-test-field="cardTheme"]')
+        .containsText('Local Theme');
+      assert
+        .dom(
+          '[data-test-field="cardTheme"] [data-test-links-to-editor="cardTheme"]',
+        )
+        .doesNotExist();
       assert.dom('[data-test-field="cardInfo-notes"] textarea').exists();
       assert.dom('[data-test-field="firstName"] input').hasValue('John');
       assert
@@ -2416,11 +2449,13 @@ module('Integration | card-basics', function (hooks) {
     });
 
     test('render card-def instance with cardInfo overrides variation', async function (assert) {
+      class Collection extends CardDef {}
       class Book extends CardDef {
         static displayName = 'Book';
         @field bookTitle = contains(StringField);
         @field blurb = contains(StringField);
         @field bookCoverImage = contains(StringField);
+        @field collection = linksTo(Collection);
         @field cardTitle = contains(StringField, {
           computeVia: function (this: Book) {
             return this.bookTitle ?? this.cardInfo.name ?? 'Untitled Book';
@@ -2436,8 +2471,21 @@ module('Integration | card-basics', function (hooks) {
             return this.bookCoverImage;
           },
         });
+        @field cardTheme: InstanceType<typeof Theme> | null = linksTo(
+          () => Theme,
+          {
+            computeVia: function (this: Book) {
+              return this.cardInfo.theme ?? this.collection?.cardTheme;
+            },
+          },
+        );
       }
-      loader.shimModule(`${testRealmURL}test-cards`, { Book });
+      let linkedTheme = new Theme({ cardTitle: 'Night Library' });
+      let collection = new Collection({
+        cardInfo: new CardInfoField({
+          theme: linkedTheme,
+        }),
+      });
 
       let instance = new Book({
         cardInfo: new CardInfoField({
@@ -2446,6 +2494,7 @@ module('Integration | card-basics', function (hooks) {
         bookTitle: 'Insomniac',
         blurb: 'This book will keep you up at night',
         bookCoverImage: 'http://book/pic.jpg',
+        collection,
       });
       await renderCard(loader, instance, 'isolated');
       assert.dom('[data-test-thumbnail-icon]').doesNotExist();
@@ -2456,6 +2505,7 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-field="cardInfo-summary"]')
         .hasText('This book will keep you up at night');
+      assert.dom('[data-test-field="cardTheme"]').containsText('Night Library');
 
       await renderCard(loader, instance, 'edit');
       assert.dom('[data-test-field="cardInfo-name"] input').hasNoValue();
@@ -2469,6 +2519,15 @@ module('Integration | card-basics', function (hooks) {
         .hasText('http://book/pic.jpg');
       assert.dom('[data-test-thumbnail-input] input').hasNoValue();
       await click('[data-test-toggle-thumbnail-editor]');
+      assert
+        .dom('[data-test-field="cardInfo-theme"]')
+        .doesNotContainText('Night Library');
+      assert.dom('[data-test-field="cardTheme"]').containsText('Night Library');
+      assert
+        .dom(
+          '[data-test-field="cardTheme"] [data-test-links-to-editor="cardTheme"]',
+        )
+        .doesNotExist();
       assert
         .dom('[data-test-field="bookCoverImage"] input')
         .hasValue('http://book/pic.jpg');
@@ -2488,20 +2547,39 @@ module('Integration | card-basics', function (hooks) {
     });
 
     test('render card-def instance with cardInfo overrides (not computed)', async function (assert) {
+      class Shelf extends CardDef {}
       class Book extends CardDef {
         static displayName = 'Book';
         @field cardTitle = contains(StringField);
         @field cardDescription = contains(StringField);
         @field cardThumbnailURL = contains(StringField);
+        @field shelf = linksTo(Shelf);
+        @field cardTheme: InstanceType<typeof Theme> | null = linksTo(
+          () => Theme,
+          {
+            computeVia: function (this: Book) {
+              return this.cardInfo.theme ?? this.shelf?.cardTheme;
+            },
+          },
+        );
       }
 
+      let localTheme = new Theme({ cardTitle: 'Local Theme' });
+      let linkedTheme = new Theme({ cardTitle: 'Sleepless Pages' });
+      let shelf = new Shelf({
+        cardInfo: new CardInfoField({
+          theme: linkedTheme,
+        }),
+      });
       let insomniac = new Book({
         cardTitle: 'Insomniac',
         cardDescription: 'This book will keep you up at night',
         cardThumbnailURL: 'http://book/pic.jpg',
         cardInfo: new CardInfoField({
           summary: 'The latest novel from John Doe',
+          theme: localTheme,
         }),
+        shelf,
       });
       await renderCard(loader, insomniac, 'isolated');
       assert.dom('[data-test-field="cardInfo-name"]').hasText('Insomniac');
@@ -2521,6 +2599,9 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-field="cardThumbnailURL"]')
         .hasText('Card Thumbnail URL http://book/pic.jpg');
+      assert
+        .dom('[data-test-field="cardTheme"]')
+        .containsText('Local Theme');
 
       await renderCard(loader, insomniac, 'edit');
       assert.dom('[data-test-field="cardInfo-name"] input').hasNoValue();
@@ -2540,6 +2621,17 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-field="cardThumbnailURL"] input')
         .hasValue('http://book/pic.jpg');
+      assert
+        .dom('[data-test-field="cardInfo-theme"]')
+        .containsText('Local Theme');
+      assert
+        .dom('[data-test-field="cardTheme"]')
+        .containsText('Local Theme');
+      assert
+        .dom(
+          '[data-test-field="cardTheme"] [data-test-links-to-editor="cardTheme"]',
+        )
+        .doesNotExist();
 
       // default preview (on edit template)
       await click('[data-test-toggle-preview]');
@@ -2556,6 +2648,7 @@ module('Integration | card-basics', function (hooks) {
     });
 
     test('render card-def instance with cardInfo overrides (complex)', async function (assert) {
+      class TravelProfile extends CardDef {}
       class FlightBooking extends CardDef {
         static displayName = 'Flight Booking';
         static icon = Plane;
@@ -2563,6 +2656,7 @@ module('Integration | card-basics', function (hooks) {
         @field destination = contains(StringField);
         @field date = contains(DateTimeField);
         @field flightNumber = contains(StringField);
+        @field travelProfile = linksTo(TravelProfile);
 
         @field cardTitle = contains(StringField, {
           computeVia: function (this: FlightBooking) {
@@ -2589,8 +2683,22 @@ module('Integration | card-basics', function (hooks) {
               .join(' - ');
           },
         });
+        @field cardTheme: InstanceType<typeof Theme> | null = linksTo(
+          () => Theme,
+          {
+            computeVia: function (this: FlightBooking) {
+              return this.cardInfo.theme ?? this.travelProfile?.cardTheme;
+            },
+          },
+        );
       }
 
+      let linkedTheme = new Theme({ cardTitle: 'Holiday Departure' });
+      let travelProfile = new TravelProfile({
+        cardInfo: new CardInfoField({
+          theme: linkedTheme,
+        }),
+      });
       let instance = new FlightBooking({
         date: new Date('2025-12-25T21:06:00.000Z'),
         origin: 'JFK',
@@ -2602,6 +2710,7 @@ module('Integration | card-basics', function (hooks) {
         }),
         destination: 'LAX',
         flightNumber: '101',
+        travelProfile,
       });
       await renderCard(loader, instance, 'isolated');
       assert
@@ -2616,6 +2725,9 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-field="flightNumber"]')
         .hasText('Flight Number 101');
+      assert
+        .dom('[data-test-field="cardTheme"]')
+        .containsText('Holiday Departure');
 
       await renderCard(loader, instance, 'edit');
       assert
@@ -2630,6 +2742,17 @@ module('Integration | card-basics', function (hooks) {
         .dom('[data-test-field="cardInfo-thumbnailURL"] input')
         .hasNoValue();
       await click('[data-test-toggle-thumbnail-editor]');
+      assert
+        .dom('[data-test-field="cardInfo-theme"]')
+        .doesNotContainText('Holiday Departure');
+      assert
+        .dom('[data-test-field="cardTheme"]')
+        .containsText('Holiday Departure');
+      assert
+        .dom(
+          '[data-test-field="cardTheme"] [data-test-links-to-editor="cardTheme"]',
+        )
+        .doesNotExist();
       assert.dom('[data-test-field="destination"] input').hasValue('LAX');
 
       // default preview (in edit mode)

--- a/packages/host/tests/integration/components/computed-test.gts
+++ b/packages/host/tests/integration/components/computed-test.gts
@@ -673,7 +673,9 @@ module('Integration | computeds', function (hooks) {
       mockMatrixUtils,
       contents: { 'test-cards.gts': { Article } },
     });
-    let theme = new Theme({ cardInfo: new CardInfoField({ name: 'Ocean Blue' }) });
+    let theme = new Theme({
+      cardInfo: new CardInfoField({ name: 'Ocean Blue' }),
+    });
     let instance = new Article({
       cardInfo: new CardInfoField({ theme }),
     });

--- a/packages/host/tests/integration/components/computed-test.gts
+++ b/packages/host/tests/integration/components/computed-test.gts
@@ -1,5 +1,5 @@
 import type { RenderingTestContext } from '@ember/test-helpers';
-import { settled } from '@ember/test-helpers';
+import { click, settled } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
@@ -673,19 +673,15 @@ module('Integration | computeds', function (hooks) {
       mockMatrixUtils,
       contents: { 'test-cards.gts': { Article } },
     });
-    let theme = new Theme({ cardTitle: 'Ocean Blue' });
+    let theme = new Theme({ cardInfo: new CardInfoField({ name: 'Ocean Blue' }) });
     let instance = new Article({
       cardInfo: new CardInfoField({ theme }),
     });
 
-    await renderCard(loader, instance, 'isolated');
-    assert.dom('[data-test-field="cardTheme"]').containsText('Ocean Blue');
-
     await renderCard(loader, instance, 'edit');
+    await click('[data-test-toggle-preview]');
     assert
-      .dom(
-        '[data-test-field="cardTheme"] [data-test-links-to-editor="cardTheme"]',
-      )
-      .doesNotExist();
+      .dom('[data-test-edit-preview="cardTheme"]')
+      .containsText('Ocean Blue');
   });
 });

--- a/packages/host/tests/integration/components/computed-test.gts
+++ b/packages/host/tests/integration/components/computed-test.gts
@@ -31,6 +31,8 @@ import {
   containsMany,
   linksTo,
   linksToMany,
+  CardInfoField,
+  Theme,
 } from '../../helpers/base-realm';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { renderCard } from '../../helpers/render-component';
@@ -661,5 +663,29 @@ module('Integration | computeds', function (hooks) {
     assert
       .dom('[data-test-categories] [data-test-category-name]')
       .exists({ count: 3 });
+  });
+
+  test('CardDef.cardTheme resolves from cardInfo.theme', async function (assert) {
+    class Article extends CardDef {
+      static displayName = 'Article';
+    }
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: { 'test-cards.gts': { Article } },
+    });
+    let theme = new Theme({ cardTitle: 'Ocean Blue' });
+    let instance = new Article({
+      cardInfo: new CardInfoField({ theme }),
+    });
+
+    await renderCard(loader, instance, 'isolated');
+    assert.dom('[data-test-field="cardTheme"]').containsText('Ocean Blue');
+
+    await renderCard(loader, instance, 'edit');
+    assert
+      .dom(
+        '[data-test-field="cardTheme"] [data-test-links-to-editor="cardTheme"]',
+      )
+      .doesNotExist();
   });
 });

--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -68,6 +68,8 @@ import {
   EthereumAddressField,
   RichMarkdownField,
   getFields,
+  Theme,
+  CardInfoField,
 } from '../../helpers/base-realm';
 
 import { setupMockMatrix } from '../../helpers/mock-matrix';
@@ -3256,6 +3258,7 @@ module('Integration | serialization', function (hooks) {
             links: { self: `${testRealmURL}Pet/mango` },
             data: { id: `${testRealmURL}Pet/mango`, type: 'card' },
           },
+          cardTheme: { links: { self: null } },
         },
         meta: {
           adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Person' },
@@ -3272,6 +3275,9 @@ module('Integration | serialization', function (hooks) {
             cardDescription: 'Pet',
             cardThumbnailURL: '../pet.svg',
             cardInfo,
+          },
+          relationships: {
+            cardTheme: { links: { self: null } },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Pet' },
@@ -3294,6 +3300,7 @@ module('Integration | serialization', function (hooks) {
             },
             friend: { links: { self: null } },
             friendPet: { links: { self: null } },
+            cardTheme: { links: { self: null } },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Person' },
@@ -3448,6 +3455,7 @@ module('Integration | serialization', function (hooks) {
             pet: { links: { self: null } },
             friend: { links: { self: null } },
             friendPet: { links: { self: null } },
+            cardTheme: { links: { self: null } },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Person' },
@@ -3553,6 +3561,27 @@ module('Integration | serialization', function (hooks) {
       assert.deepEqual(friendPetRel, {
         type: 'loaded',
         card: null,
+      });
+    });
+
+    test('can serialize CardDef.cardTheme as a non-null computed linksTo', async function (assert) {
+      class Article extends CardDef {}
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: { 'test-cards.gts': { Article } },
+      });
+      let theme = new Theme();
+      await saveCard(theme, `${testRealmURL}Theme/ocean-blue`, loader);
+      let article = new Article({
+        cardInfo: new CardInfoField({ theme }),
+      });
+      let serialized = serializeCard(article, {
+        includeComputeds: true,
+        includeUnrenderedFields: true,
+      });
+      assert.deepEqual(serialized.data.relationships?.cardTheme, {
+        links: { self: `${testRealmURL}Theme/ocean-blue` },
+        data: { id: `${testRealmURL}Theme/ocean-blue`, type: 'card' },
       });
     });
   });
@@ -5583,6 +5612,11 @@ module('Integration | serialization', function (hooks) {
               self: null,
             },
           },
+          cardTheme: {
+            links: {
+              self: null,
+            },
+          },
         },
         meta: {
           adoptsFrom: {
@@ -6927,6 +6961,7 @@ module('Integration | serialization', function (hooks) {
             links: { self: `${testRealmURL}Pet/van-gogh` },
             data: { id: `${testRealmURL}Pet/van-gogh`, type: 'card' },
           },
+          cardTheme: { links: { self: null } },
         },
         meta: {
           adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Person' },
@@ -6944,6 +6979,9 @@ module('Integration | serialization', function (hooks) {
             cardThumbnailURL: null,
             cardInfo,
           },
+          relationships: {
+            cardTheme: { links: { self: null } },
+          },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Pet' },
           },
@@ -6957,6 +6995,9 @@ module('Integration | serialization', function (hooks) {
             cardDescription: null,
             cardThumbnailURL: null,
             cardInfo,
+          },
+          relationships: {
+            cardTheme: { links: { self: null } },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Pet' },
@@ -6981,6 +7022,7 @@ module('Integration | serialization', function (hooks) {
               links: { self: `${testRealmURL}Pet/van-gogh` },
               data: { id: `${testRealmURL}Pet/van-gogh`, type: 'card' },
             },
+            cardTheme: { links: { self: null } },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Friend' },
@@ -7147,6 +7189,7 @@ module('Integration | serialization', function (hooks) {
           relationships: {
             friend: { links: { self: null } },
             friendPets: { links: { self: null } },
+            cardTheme: { links: { self: null } },
           },
           meta: {
             adoptsFrom: { module: `${testRealmURL}test-cards`, name: 'Person' },
@@ -7310,6 +7353,7 @@ module('Integration | serialization', function (hooks) {
           data: { type: 'card', id: `${testRealmURL}Friend/hassan` },
         },
         friendPets: { links: { self: null } },
+        cardTheme: { links: { self: null } },
         'ownPets.0': {
           links: { self: `${testRealmURL}Pet/mango` },
           data: { type: 'card', id: `${testRealmURL}Pet/mango` },

--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -5612,11 +5612,6 @@ module('Integration | serialization', function (hooks) {
               self: null,
             },
           },
-          cardTheme: {
-            links: {
-              self: null,
-            },
-          },
         },
         meta: {
           adoptsFrom: {
@@ -5645,6 +5640,11 @@ module('Integration | serialization', function (hooks) {
         },
         relationships: {
           'cardInfo.theme': {
+            links: {
+              self: null,
+            },
+          },
+          cardTheme: {
             links: {
               self: null,
             },

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -32,6 +32,14 @@ export const baseFileRef: ResolvedCodeRef = {
   name: 'FileDef',
 };
 
+// standard CardDef fields that are computeds of their cardInfo equivalents
+export const cardDefComputedFields: string[] = [
+  'cardTitle',
+  'cardDescription',
+  'cardThumbnailURL',
+  'cardTheme',
+];
+
 export const isField = Symbol('cardstack-field');
 export const isSpec = Symbol('is-spec');
 export const primitive = Symbol('cardstack-primitive');


### PR DESCRIPTION
- add `CardDef.cardTheme` as a computed alias of `cardInfo.theme` and switch theme consumers to read the resolved `cardTheme`
- extend serialization and schema coverage for the new computed relationship
- update override tests so `cardTheme` precedence is explicit: local `cardInfo.theme` wins, otherwise it falls back to a linked card’s `cardTheme`
- Refactor & simplify edit mode preview and use updated field names
- Fix broken thumbnail-placeholder styles