### PR TITLE
Default rank-desc + per-row MatchesMeta

### DIFF
--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -3207,17 +3207,29 @@ module('Unit | query', function (hooks) {
     await setupIndex(dbAdapter, [
       {
         card: vangogh,
-        data: { markdown: 'Van Gogh is a puppy with a painterly coat.' },
+        data: {
+          search_doc: { name: 'Van Gogh' },
+          markdown: 'Van Gogh is a puppy with a painterly coat.',
+        },
       },
     ]);
 
+    let type = await personCardType(testCards);
     let { cards } = await indexQueryEngine.searchCards(new URL(testRealmURL), {
-      // websearch_to_tsquery semantics: unquoted spaces are AND, so we use
-      // explicit OR here to ensure the row matches. "the" is a stop-word;
-      // "unicorn" is absent from the markdown; "puppy" and "painterly" are
-      // both present. matchedTerms should reflect only the present, non-stop
-      // tokens.
-      filter: { matches: 'puppy or painterly or unicorn or the' },
+      // PG's websearch_to_tsquery uses AND between tokens and SQLite's LIKE
+      // fallback matches the query as a literal substring — both predicates
+      // would reject "puppy painterly unicorn the" for this markdown. Wrap
+      // the matches branch in an `any` alongside an `eq` that selects the
+      // row so matchedTerms synthesis runs on the raw query regardless of
+      // which branch produced the hit. "the" is a stop-word; "unicorn" is
+      // absent from the markdown; "puppy" and "painterly" are both present.
+      filter: {
+        on: type,
+        any: [
+          { matches: 'puppy painterly unicorn the' },
+          { eq: { name: 'Van Gogh' } },
+        ],
+      },
     });
     assert.deepEqual(
       [...cards[0].meta.matchedTerms!].sort(),

--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -3032,9 +3032,12 @@ module('Unit | query', function (hooks) {
       2,
       `union of the 'matches' branch and the 'eq' branch`,
     );
+    // Default order is rank-desc when a matches node is present (CS-10829):
+    // ringo matched the 'matches' branch, so its rank > 0; mango arrived
+    // via the 'eq' branch with rank 0 and sorts after ringo.
     assert.deepEqual(
       getIds(cards),
-      [mango.id, ringo.id],
+      [ringo.id, mango.id],
       'results are correct',
     );
   });
@@ -3209,9 +3212,12 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards } = await indexQueryEngine.searchCards(new URL(testRealmURL), {
-      // "the" is a stop-word; "unicorn" is absent from the markdown; "puppy"
-      // and "painterly" are both present.
-      filter: { matches: 'puppy painterly unicorn the' },
+      // websearch_to_tsquery semantics: unquoted spaces are AND, so we use
+      // explicit OR here to ensure the row matches. "the" is a stop-word;
+      // "unicorn" is absent from the markdown; "puppy" and "painterly" are
+      // both present. matchedTerms should reflect only the present, non-stop
+      // tokens.
+      filter: { matches: 'puppy or painterly or unicorn or the' },
     });
     assert.deepEqual(
       [...cards[0].meta.matchedTerms!].sort(),

--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -3085,6 +3085,172 @@ module('Unit | query', function (hooks) {
     );
   });
 
+  test(`'matches' synthesizes rank, snippet, matchedTerms on meta (SQLite parity with PG)`, async function (assert) {
+    let { mango, vangogh, ringo } = testCards;
+    await setupIndex(dbAdapter, [
+      {
+        card: mango,
+        data: {
+          markdown:
+            'Mango is a puppy. A playful puppy. Such a sweet puppy indeed.',
+        },
+      },
+      {
+        card: vangogh,
+        data: { markdown: 'Van Gogh is a puppy with a painterly coat.' },
+      },
+      {
+        card: ringo,
+        data: { markdown: 'Ringo plays the drums and enjoys long naps.' },
+      },
+    ]);
+
+    let { cards } = await indexQueryEngine.searchCards(new URL(testRealmURL), {
+      filter: { matches: 'puppy' },
+    });
+    assert.strictEqual(cards.length, 2, 'mango and vangogh match');
+    for (let card of cards) {
+      assert.strictEqual(
+        typeof card.meta.rank,
+        'number',
+        `${card.id} has numeric rank`,
+      );
+      assert.ok(Number.isFinite(card.meta.rank!), `${card.id} rank is finite`);
+      assert.strictEqual(
+        typeof card.meta.snippet,
+        'string',
+        `${card.id} has string snippet`,
+      );
+      assert.ok(
+        Array.isArray(card.meta.matchedTerms),
+        `${card.id} has array matchedTerms`,
+      );
+    }
+    // ringo was excluded by the filter, so it should not be in results at all.
+    assert.notOk(
+      cards.some((c) => c.id === ringo.id),
+      'ringo is excluded by the filter',
+    );
+  });
+
+  test(`'matches' synthetic rank defaults to rank-desc on SQLite`, async function (assert) {
+    let { mango, vangogh, ringo } = testCards;
+    await setupIndex(dbAdapter, [
+      {
+        card: mango,
+        data: {
+          markdown:
+            'Mango is a puppy. A playful puppy. Such a sweet puppy indeed.',
+        },
+      },
+      {
+        card: ringo,
+        data: { markdown: 'Ringo plays the drums and enjoys long naps.' },
+      },
+      {
+        card: vangogh,
+        data: { markdown: 'Van Gogh is a puppy with a painterly coat.' },
+      },
+    ]);
+
+    // No explicit sort → synthetic hit-count DESC should fire, pushing the
+    // densest "puppy" row (mango) above the sparser one (vangogh). URL
+    // ordering alone would put mango first anyway (alphabetical), so to
+    // prove the synthetic rank is firing we also verify that a 3-hit row
+    // outranks a 1-hit row by rank value.
+    let { cards } = await indexQueryEngine.searchCards(new URL(testRealmURL), {
+      filter: { matches: 'puppy' },
+    });
+    assert.deepEqual(
+      getIds(cards),
+      [mango.id, vangogh.id],
+      'mango (3 hits) ranks above vangogh (1 hit)',
+    );
+    assert.ok(
+      cards[0].meta.rank! > cards[1].meta.rank!,
+      `mango rank ${cards[0].meta.rank} should exceed vangogh rank ${cards[1].meta.rank}`,
+    );
+  });
+
+  test(`'matches' synthetic snippet wraps the hit in <b>…</b>`, async function (assert) {
+    let { mango } = testCards;
+    await setupIndex(dbAdapter, [
+      {
+        card: mango,
+        data: {
+          markdown:
+            'The quick brown fox jumps over the lazy puppy in the afternoon sun.',
+        },
+      },
+    ]);
+
+    let { cards } = await indexQueryEngine.searchCards(new URL(testRealmURL), {
+      filter: { matches: 'puppy' },
+    });
+    let snippet = cards[0].meta.snippet!;
+    assert.ok(snippet.includes('<b>'), `snippet contains <b>; got: ${snippet}`);
+    assert.ok(
+      snippet.includes('</b>'),
+      `snippet contains </b>; got: ${snippet}`,
+    );
+    assert.ok(
+      /<b>[^<]*puppy[^<]*<\/b>/i.test(snippet),
+      `snippet wraps the hit in <b>…</b>; got: ${snippet}`,
+    );
+  });
+
+  test(`'matches' matchedTerms returns only present tokens and drops stop-words`, async function (assert) {
+    let { vangogh } = testCards;
+    await setupIndex(dbAdapter, [
+      {
+        card: vangogh,
+        data: { markdown: 'Van Gogh is a puppy with a painterly coat.' },
+      },
+    ]);
+
+    let { cards } = await indexQueryEngine.searchCards(new URL(testRealmURL), {
+      // "the" is a stop-word; "unicorn" is absent from the markdown; "puppy"
+      // and "painterly" are both present.
+      filter: { matches: 'puppy painterly unicorn the' },
+    });
+    assert.deepEqual(
+      [...cards[0].meta.matchedTerms!].sort(),
+      ['painterly', 'puppy'],
+      'matchedTerms drops stop-words and absent tokens',
+    );
+  });
+
+  test(`no meta fields are set on cards when filter has no matches node`, async function (assert) {
+    let { mango, vangogh } = testCards;
+    await setupIndex(dbAdapter, [
+      { card: mango, data: { markdown: 'Mango likes fetch.' } },
+      { card: vangogh, data: { markdown: 'Van Gogh likes naps.' } },
+    ]);
+
+    let { cards } = await indexQueryEngine.searchCards(
+      new URL(testRealmURL),
+      {},
+    );
+    assert.ok(cards.length > 0, 'got some cards back');
+    for (let card of cards) {
+      assert.strictEqual(
+        card.meta.rank,
+        undefined,
+        `${card.id} has no rank when filter has no matches`,
+      );
+      assert.strictEqual(
+        card.meta.snippet,
+        undefined,
+        `${card.id} has no snippet when filter has no matches`,
+      );
+      assert.strictEqual(
+        card.meta.matchedTerms,
+        undefined,
+        `${card.id} has no matchedTerms when filter has no matches`,
+      );
+    }
+  });
+
   test('can sort using a general field that is not an attribute of a card', async function (assert) {
     await setupIndex(dbAdapter, [
       {

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -227,6 +227,7 @@ import './command-parsing-utils-test';
 import './query-matches-filter-test';
 import './matches-filter-integration-test';
 import './matches-rank-order-integration-test';
+import './matches-result-meta-integration-test';
 import './delete-boxel-claimed-domain-test';
 import './realm-auth-test';
 import './queries-test';

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -226,6 +226,7 @@ import './bfm-card-references-test';
 import './command-parsing-utils-test';
 import './query-matches-filter-test';
 import './matches-filter-integration-test';
+import './matches-rank-order-integration-test';
 import './delete-boxel-claimed-domain-test';
 import './realm-auth-test';
 import './queries-test';

--- a/packages/realm-server/tests/matches-rank-order-integration-test.ts
+++ b/packages/realm-server/tests/matches-rank-order-integration-test.ts
@@ -1,0 +1,194 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+
+import type { PgAdapter } from '@cardstack/postgres';
+import {
+  IndexQueryEngine,
+  param,
+  query,
+  type DefinitionLookup,
+} from '@cardstack/runtime-common';
+
+import { setupDB } from './helpers';
+
+const testRealmURL = 'http://matches-rank-order-test/';
+
+const stubDefinitionLookup: DefinitionLookup = {
+  async lookupDefinition() {
+    throw new Error(
+      'lookupDefinition should not be called for top-level rank-order tests',
+    );
+  },
+  async lookupCachedDefinition() {
+    return undefined;
+  },
+  async invalidate() {
+    return [];
+  },
+  async clearRealmCache() {},
+  async clearAllModules() {},
+  registerRealm() {},
+  async getModuleCacheEntry() {
+    return undefined;
+  },
+  async getModuleCacheEntries() {
+    return {};
+  },
+  forRealm() {
+    return stubDefinitionLookup;
+  },
+};
+
+async function seedRow(
+  dbAdapter: PgAdapter,
+  { url, markdown }: { url: string; markdown: string | null },
+) {
+  await query(dbAdapter, [
+    `INSERT INTO boxel_index (url, file_alias, realm_url, realm_version, type, pristine_doc, search_doc, deps, types, is_deleted, has_error, indexed_at, markdown)`,
+    `VALUES (`,
+    param(url),
+    `,`,
+    param(url),
+    `,`,
+    param(testRealmURL),
+    `,`,
+    param(1),
+    `,`,
+    param('instance'),
+    `,`,
+    `'{}'::jsonb`,
+    `,`,
+    `'{}'::jsonb`,
+    `,`,
+    `'[]'::jsonb`,
+    `,`,
+    `'[]'::jsonb`,
+    `,`,
+    param(false),
+    `,`,
+    param(false),
+    `,`,
+    param(Date.now()),
+    `,`,
+    param(markdown),
+    `)`,
+  ]);
+}
+
+module(basename(__filename), function () {
+  module('MatchesFilter rank-desc default order', function (hooks) {
+    let dbAdapter: PgAdapter;
+    let engine: IndexQueryEngine;
+
+    setupDB(hooks, {
+      beforeEach: async (_dbAdapter) => {
+        dbAdapter = _dbAdapter;
+        engine = new IndexQueryEngine(dbAdapter, stubDefinitionLookup);
+
+        // mango mentions "puppy" three times → higher ts_rank_cd.
+        // vangogh mentions it once → lower rank.
+        // ringo has no "puppy" at all.
+        // URL ordering alone would put mango before ringo before vangogh
+        // (alphabetical by URL), so rank-desc and URL order disagree here
+        // on whether vangogh or ringo leads, proving the rank clause fires.
+        await seedRow(dbAdapter, {
+          url: `${testRealmURL}mango.json`,
+          markdown: 'Mango is a puppy. A playful puppy. Such a sweet puppy.',
+        });
+        await seedRow(dbAdapter, {
+          url: `${testRealmURL}ringo.json`,
+          markdown: 'Ringo is a dog who plays the drums.',
+        });
+        await seedRow(dbAdapter, {
+          url: `${testRealmURL}vangogh.json`,
+          markdown: 'Van Gogh is a puppy with a painterly coat.',
+        });
+      },
+    });
+
+    test('defaults to rank-desc when matches is present and no sort is supplied', async function (assert) {
+      let { cards } = await engine.searchCards(new URL(testRealmURL), {
+        filter: { matches: 'puppy' },
+      });
+      let urls = cards.map((c) => c.id);
+      assert.deepEqual(
+        urls,
+        [`${testRealmURL}mango.json`, `${testRealmURL}vangogh.json`],
+        'mango (3 hits) ranks above vangogh (1 hit); ringo excluded by filter',
+      );
+    });
+
+    test('caller-supplied sort wins over rank-desc default', async function (assert) {
+      // Sort by URL descending flips alphabetical order to vangogh, mango.
+      // If rank-desc leaked in, mango (3 hits) would lead. Asserting
+      // [vangogh, mango] proves the caller's sort is honored alone.
+      let { cards } = await engine.searchCards(new URL(testRealmURL), {
+        filter: { matches: 'puppy' },
+        sort: [{ by: 'cardURL', direction: 'desc' }],
+      });
+      let urls = cards.map((c) => c.id);
+      assert.deepEqual(
+        urls,
+        [`${testRealmURL}vangogh.json`, `${testRealmURL}mango.json`],
+        'caller sort (cardURL desc) wins; rank-desc default does not apply',
+      );
+    });
+
+    test('rank-desc fires when matches is nested inside any', async function (assert) {
+      let { cards } = await engine.searchCards(new URL(testRealmURL), {
+        filter: {
+          any: [{ matches: 'puppy' }, { matches: 'drums' }],
+        },
+      });
+      let urls = cards.map((c) => c.id);
+      assert.strictEqual(urls.length, 3, 'all three rows match the any clause');
+      assert.strictEqual(
+        urls[0],
+        `${testRealmURL}mango.json`,
+        'mango (3 hits on "puppy") leads by rank-desc even though nested',
+      );
+    });
+
+    test('rank-desc fires when matches is nested inside every', async function (assert) {
+      let { cards } = await engine.searchCards(new URL(testRealmURL), {
+        filter: {
+          every: [{ matches: 'puppy' }],
+        },
+      });
+      let urls = cards.map((c) => c.id);
+      assert.deepEqual(
+        urls,
+        [`${testRealmURL}mango.json`, `${testRealmURL}vangogh.json`],
+        'rank-desc applies through nested every',
+      );
+    });
+
+    test('no matches in tree: URL ordering is preserved', async function (assert) {
+      // With no `matches`, only URL-order applies. mango < ringo < vangogh
+      // alphabetically. Use a filter that returns all rows so ordering is
+      // observable.
+      let { cards } = await engine.searchCards(new URL(testRealmURL), {});
+      let urls = cards.map((c) => c.id);
+      assert.deepEqual(
+        urls,
+        [
+          `${testRealmURL}mango.json`,
+          `${testRealmURL}ringo.json`,
+          `${testRealmURL}vangogh.json`,
+        ],
+        'URL ordering (alphabetical POSIX) when no matches and no sort',
+      );
+    });
+
+    test('empty matches query skips the rank clause (falls back to URL order)', async function (assert) {
+      // Empty matches short-circuits to FALSE so no rows return. Verify
+      // that the query still runs (doesn't crash constructing an empty
+      // tsquery in ORDER BY).
+      let { cards, meta } = await engine.searchCards(new URL(testRealmURL), {
+        filter: { matches: '' },
+      });
+      assert.strictEqual(meta.page.total, 0, 'empty query matches nothing');
+      assert.strictEqual(cards.length, 0);
+    });
+  });
+});

--- a/packages/realm-server/tests/matches-rank-order-integration-test.ts
+++ b/packages/realm-server/tests/matches-rank-order-integration-test.ts
@@ -43,6 +43,12 @@ async function seedRow(
   dbAdapter: PgAdapter,
   { url, markdown }: { url: string; markdown: string | null },
 ) {
+  let doc = {
+    id: url,
+    type: 'card',
+    attributes: {},
+    meta: { adoptsFrom: { module: 'test/card', name: 'TestCard' } },
+  } as Record<string, any>;
   await query(dbAdapter, [
     `INSERT INTO boxel_index (url, file_alias, realm_url, realm_version, type, pristine_doc, search_doc, deps, types, is_deleted, has_error, indexed_at, markdown)`,
     `VALUES (`,
@@ -56,7 +62,7 @@ async function seedRow(
     `,`,
     param('instance'),
     `,`,
-    `'{}'::jsonb`,
+    param(doc as any),
     `,`,
     `'{}'::jsonb`,
     `,`,

--- a/packages/realm-server/tests/matches-result-meta-integration-test.ts
+++ b/packages/realm-server/tests/matches-result-meta-integration-test.ts
@@ -1,0 +1,250 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+
+import type { PgAdapter } from '@cardstack/postgres';
+import {
+  IndexQueryEngine,
+  param,
+  query,
+  type DefinitionLookup,
+} from '@cardstack/runtime-common';
+
+import { setupDB } from './helpers';
+
+const testRealmURL = 'http://matches-result-meta-test/';
+
+const stubDefinitionLookup: DefinitionLookup = {
+  async lookupDefinition() {
+    throw new Error(
+      'lookupDefinition should not be called for top-level meta tests',
+    );
+  },
+  async lookupCachedDefinition() {
+    return undefined;
+  },
+  async invalidate() {
+    return [];
+  },
+  async clearRealmCache() {},
+  async clearAllModules() {},
+  registerRealm() {},
+  async getModuleCacheEntry() {
+    return undefined;
+  },
+  async getModuleCacheEntries() {
+    return {};
+  },
+  forRealm() {
+    return stubDefinitionLookup;
+  },
+};
+
+async function seedRow(
+  dbAdapter: PgAdapter,
+  {
+    url,
+    markdown,
+    pristineDoc,
+  }: {
+    url: string;
+    markdown: string | null;
+    pristineDoc?: Record<string, any>;
+  },
+) {
+  let doc =
+    pristineDoc ??
+    ({
+      id: url,
+      type: 'card',
+      attributes: {},
+      meta: { adoptsFrom: { module: 'test/card', name: 'TestCard' } },
+    } as Record<string, any>);
+  await query(dbAdapter, [
+    `INSERT INTO boxel_index (url, file_alias, realm_url, realm_version, type, pristine_doc, search_doc, deps, types, is_deleted, has_error, indexed_at, markdown)`,
+    `VALUES (`,
+    param(url),
+    `,`,
+    param(url),
+    `,`,
+    param(testRealmURL),
+    `,`,
+    param(1),
+    `,`,
+    param('instance'),
+    `,`,
+    param(doc as any),
+    `,`,
+    `'{}'::jsonb`,
+    `,`,
+    `'[]'::jsonb`,
+    `,`,
+    `'[]'::jsonb`,
+    `,`,
+    param(false),
+    `,`,
+    param(false),
+    `,`,
+    param(Date.now()),
+    `,`,
+    param(markdown),
+    `)`,
+  ]);
+}
+
+module(basename(__filename), function () {
+  module('MatchesFilter result meta (Postgres)', function (hooks) {
+    let dbAdapter: PgAdapter;
+    let engine: IndexQueryEngine;
+
+    setupDB(hooks, {
+      beforeEach: async (_dbAdapter) => {
+        dbAdapter = _dbAdapter;
+        engine = new IndexQueryEngine(dbAdapter, stubDefinitionLookup);
+
+        // Three rows with varying density of "puppy":
+        //   mango:   3 hits → highest rank
+        //   vangogh: 1 hit  → lower rank
+        //   ringo:   0 hits → excluded by filter
+        await seedRow(dbAdapter, {
+          url: `${testRealmURL}mango.json`,
+          markdown:
+            'Mango is a puppy. A playful puppy. Such a sweet puppy indeed.',
+        });
+        await seedRow(dbAdapter, {
+          url: `${testRealmURL}vangogh.json`,
+          markdown: 'Van Gogh is a puppy with a painterly coat.',
+        });
+        await seedRow(dbAdapter, {
+          url: `${testRealmURL}ringo.json`,
+          markdown: 'Ringo plays the drums and enjoys long naps.',
+        });
+      },
+    });
+
+    test('each matching row gets rank, snippet, matchedTerms on meta', async function (assert) {
+      let { cards } = await engine.searchCards(new URL(testRealmURL), {
+        filter: { matches: 'puppy' },
+      });
+      assert.strictEqual(cards.length, 2, 'two rows matched');
+      for (let card of cards) {
+        assert.strictEqual(
+          typeof card.meta.rank,
+          'number',
+          `${card.id} has numeric rank`,
+        );
+        assert.ok(
+          Number.isFinite(card.meta.rank!),
+          `${card.id} rank is finite`,
+        );
+        assert.ok(
+          card.meta.rank! > 0,
+          `${card.id} rank is > 0 (matched rows rank above zero)`,
+        );
+        assert.strictEqual(
+          typeof card.meta.snippet,
+          'string',
+          `${card.id} has string snippet`,
+        );
+        assert.ok(
+          Array.isArray(card.meta.matchedTerms),
+          `${card.id} matchedTerms is an array`,
+        );
+      }
+    });
+
+    test('snippet wraps matching term in <b>…</b>', async function (assert) {
+      let { cards } = await engine.searchCards(new URL(testRealmURL), {
+        filter: { matches: 'puppy' },
+      });
+      for (let card of cards) {
+        let snippet = card.meta.snippet!;
+        assert.ok(
+          /<b>[^<]*<\/b>/i.test(snippet),
+          `${card.id} snippet contains <b>…</b> markup; got: ${snippet}`,
+        );
+        // The stemmed "puppy" should still appear somewhere (case-insensitive).
+        assert.ok(
+          /puppy/i.test(snippet),
+          `${card.id} snippet still contains the matching term; got: ${snippet}`,
+        );
+      }
+    });
+
+    test('rank orders denser matches above sparser ones', async function (assert) {
+      // No explicit sort → rank-desc default fires (CS-10829).
+      let { cards } = await engine.searchCards(new URL(testRealmURL), {
+        filter: { matches: 'puppy' },
+      });
+      assert.deepEqual(
+        cards.map((c) => c.id),
+        [`${testRealmURL}mango.json`, `${testRealmURL}vangogh.json`],
+        'mango (3 hits) ranks above vangogh (1 hit)',
+      );
+      let mangoRank = cards[0].meta.rank!;
+      let vangoghRank = cards[1].meta.rank!;
+      assert.ok(
+        mangoRank > vangoghRank,
+        `mango rank ${mangoRank} should exceed vangogh rank ${vangoghRank}`,
+      );
+    });
+
+    test('matchedTerms includes present query terms, excludes stop-words', async function (assert) {
+      // websearch_to_tsquery treats space as AND; use `or` so the query
+      // matches vangogh even though "unicorn" is absent. "the" is an
+      // English stop-word and must be excluded from matchedTerms; "puppy"
+      // and "painterly" are present in vangogh's markdown; "unicorn" is not.
+      let { cards } = await engine.searchCards(new URL(testRealmURL), {
+        filter: { matches: 'puppy or painterly or unicorn or the' },
+      });
+      let vangogh = cards.find((c) => c.id === `${testRealmURL}vangogh.json`)!;
+      assert.ok(vangogh, 'vangogh is in the results');
+      assert.deepEqual(
+        [...vangogh.meta.matchedTerms!].sort(),
+        ['painterly', 'puppy'],
+        'matchedTerms contains only present, non-stop-word tokens',
+      );
+    });
+
+    test('no meta is added when the filter has no matches node', async function (assert) {
+      let { cards } = await engine.searchCards(new URL(testRealmURL), {});
+      assert.ok(cards.length > 0, 'got some cards back');
+      for (let card of cards) {
+        assert.strictEqual(
+          card.meta.rank,
+          undefined,
+          `${card.id} has no rank when filter has no matches`,
+        );
+        assert.strictEqual(
+          card.meta.snippet,
+          undefined,
+          `${card.id} has no snippet when filter has no matches`,
+        );
+        assert.strictEqual(
+          card.meta.matchedTerms,
+          undefined,
+          `${card.id} has no matchedTerms when filter has no matches`,
+        );
+      }
+    });
+
+    test('meta is synthesized even when matches is nested inside any/every', async function (assert) {
+      let { cards } = await engine.searchCards(new URL(testRealmURL), {
+        filter: {
+          any: [{ matches: 'puppy' }, { matches: 'drums' }],
+        },
+      });
+      assert.strictEqual(cards.length, 3, 'all three rows match the any');
+      for (let card of cards) {
+        assert.strictEqual(
+          typeof card.meta.rank,
+          'number',
+          `${card.id} has rank from the nested matches`,
+        );
+        assert.ok(
+          Array.isArray(card.meta.matchedTerms),
+          `${card.id} has matchedTerms`,
+        );
+      }
+    });
+  });
+});

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -51,6 +51,10 @@ import {
   type RangeFilter,
   RANGE_OPERATORS,
   isCardTypeFilter,
+  isAnyFilter,
+  isEveryFilter,
+  isNotFilter,
+  isMatchesFilter,
 } from './query';
 import type { SerializedError } from './error';
 import type { DBAdapter } from './db';
@@ -460,7 +464,7 @@ export class IndexQueryEngine {
         'WHERE',
         ...everyCondition,
         'GROUP BY url',
-        ...this.orderExpression(sort),
+        ...this.orderExpression(sort, filter),
         ...(page
           ? [`LIMIT ${page.size} OFFSET ${(page.number ?? 0) * page.size}`]
           : []),
@@ -589,8 +593,34 @@ export class IndexQueryEngine {
     }
   }
 
-  private orderExpression(sort: Sort | undefined): CardExpression {
+  private orderExpression(
+    sort: Sort | undefined,
+    filter: Filter | undefined,
+  ): CardExpression {
+    // When the caller didn't supply an explicit sort and the filter tree
+    // contains a `matches` node, default to rank-desc so the top-ranked
+    // full-text hits lead. Empty/whitespace-only match strings are
+    // normalized to FALSE in matchesCondition and contribute nothing to
+    // ranking — skip the rank clause in that case. PG emits
+    // ts_rank_cd(tsvector, tsquery) DESC; SQLite has no native rank, so
+    // the branch is empty and URL ordering takes over (M2 adds a synthetic
+    // rank — out of scope here).
     if (!sort) {
+      let rankedMatch = filter ? findFirstMatchesFilter(filter) : undefined;
+      if (rankedMatch && rankedMatch.matches.trim() !== '') {
+        return [
+          'ORDER BY',
+          dbExpression({
+            pg: [
+              `ts_rank_cd(to_tsvector('english', coalesce(i.markdown, '')), websearch_to_tsquery('english',`,
+              param(rankedMatch.matches),
+              `)) DESC,`,
+            ],
+            sqlite: '',
+          }),
+          'url COLLATE "POSIX"',
+        ];
+      }
       return ['ORDER BY url COLLATE "POSIX"'];
     }
     return [
@@ -1477,6 +1507,37 @@ function tableFromOpts(opts: WIPOptions | undefined) {
 // char itself) with a backslash before binding.
 function escapeSqliteLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, (c) => `\\${c}`);
+}
+
+// Deterministic pre-order walk: recurses into any/every/not and returns the
+// first MatchesFilter encountered, or undefined if the tree has none. The
+// engine uses this to decide whether to default the order-by to rank-desc
+// when the caller didn't supply an explicit sort. If multiple matches
+// terms appear, the first one wins for ranking purposes — acceptable
+// because combined ranking across alternatives has no single right answer
+// and isn't in the spec's test matrix.
+function findFirstMatchesFilter(filter: Filter): MatchesFilter | undefined {
+  if (isMatchesFilter(filter)) {
+    return filter;
+  }
+  if (isAnyFilter(filter)) {
+    for (let child of filter.any) {
+      let found = findFirstMatchesFilter(child);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  if (isEveryFilter(filter)) {
+    for (let child of filter.every) {
+      let found = findFirstMatchesFilter(child);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  if (isNotFilter(filter)) {
+    return findFirstMatchesFilter(filter.not);
+  }
+  return undefined;
 }
 
 function assertNever(value: never) {

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -70,7 +70,84 @@ import {
   type DefinitionLookup,
 } from './definition-lookup';
 import { isScopedCSSRequest } from 'glimmer-scoped-css';
-import type { FileMetaResource } from './resource-types';
+import type { FileMetaResource, MatchesMeta } from './resource-types';
+
+// Centralized ts_headline options so snippet length/markup stays tunable in
+// one place. Kept as plain text because it lives in the PG select-list
+// unchanged per-query.
+const TS_HEADLINE_OPTIONS =
+  'StartSel=<b>, StopSel=</b>, MaxWords=35, MinWords=15, ShortWord=3, HighlightAll=false';
+
+// Window the SQLite synthesized snippet around the first hit. ~80 chars
+// before/after lines up visually with the PG MaxWords default above.
+const SQLITE_SNIPPET_WINDOW = 80;
+
+// English stop-words dropped from matchedTerms so the array matches PG's
+// stemming-aware behavior (which excludes them via the `english` config).
+const ENGLISH_STOP_WORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'been',
+  'being',
+  'but',
+  'by',
+  'do',
+  'does',
+  'did',
+  'for',
+  'from',
+  'had',
+  'has',
+  'have',
+  'he',
+  'her',
+  'him',
+  'his',
+  'i',
+  'if',
+  'in',
+  'is',
+  'it',
+  'its',
+  'me',
+  'my',
+  'no',
+  'not',
+  'of',
+  'on',
+  'or',
+  'our',
+  'she',
+  'so',
+  'that',
+  'the',
+  'their',
+  'them',
+  'then',
+  'there',
+  'these',
+  'they',
+  'this',
+  'those',
+  'to',
+  'us',
+  'was',
+  'we',
+  'were',
+  'what',
+  'which',
+  'who',
+  'will',
+  'with',
+  'would',
+  'you',
+  'your',
+]);
 
 export interface IndexedFile {
   type: 'file';
@@ -422,6 +499,7 @@ export class IndexQueryEngine {
   ): Promise<{
     meta: QueryResultsMeta;
     results: Partial<BoxelIndexTable>[];
+    resultMetas: (MatchesMeta | undefined)[];
   }> {
     try {
       let conditions: CardExpression[] = [
@@ -457,9 +535,39 @@ export class IndexQueryEngine {
         conditions.push(this.filterCondition(filter, baseCardRef));
       }
 
+      // When the filter tree contains a matches node with a non-empty
+      // query, we tack extra columns onto the caller's SELECT so every
+      // row carries the raw material for per-row MatchesMeta. PG computes
+      // rank/snippet server-side via ts_rank_cd / ts_headline; SQLite
+      // synthesizes both in JS from the markdown column (below).
+      let matchesTerm = filter ? findFirstMatchesFilter(filter) : undefined;
+      let matchesQuery =
+        matchesTerm && matchesTerm.matches.trim() !== ''
+          ? matchesTerm.matches
+          : undefined;
+      let augmentedSelect: CardExpression = matchesQuery
+        ? [
+            ...selectClauseExpression,
+            ',',
+            dbExpression({
+              pg: [
+                `ANY_VALUE(ts_rank_cd(to_tsvector('english', coalesce(i.markdown, '')), websearch_to_tsquery('english',`,
+                param(matchesQuery),
+                `))) AS __rank, ANY_VALUE(ts_headline('english', coalesce(i.markdown, ''), websearch_to_tsquery('english',`,
+                param(matchesQuery),
+                `),`,
+                param(TS_HEADLINE_OPTIONS),
+                `)) AS __snippet`,
+              ],
+              sqlite: [`NULL AS __rank, NULL AS __snippet`],
+            }),
+            ', ANY_VALUE(i.markdown) AS __markdown',
+          ]
+        : selectClauseExpression;
+
       let everyCondition = every(conditions);
       let query = [
-        ...selectClauseExpression,
+        ...augmentedSelect,
         `FROM ${tableFromOpts(opts)} AS i ${tableValuedFunctionsPlaceholder}`,
         'WHERE',
         ...everyCondition,
@@ -481,8 +589,15 @@ export class IndexQueryEngine {
         this.#queryCards(queryCount),
       ]);
 
+      let resultMetas: (MatchesMeta | undefined)[] = matchesQuery
+        ? results.map((row) =>
+            buildMatchesMeta(matchesQuery, row as MatchesMetaSource),
+          )
+        : new Array(results.length).fill(undefined);
+
       return {
         results,
+        resultMetas,
         meta: {
           page: { total: Number(totalResults[0].total) },
         },
@@ -491,6 +606,7 @@ export class IndexQueryEngine {
       if (isFilterRefersToNonexistentTypeError(error)) {
         return {
           results: [],
+          resultMetas: [],
           meta: {
             page: { total: 0 },
           },
@@ -507,7 +623,7 @@ export class IndexQueryEngine {
     // TODO this should be returning a CardCollectionDocument--handle that in
     // subsequent PR where we start storing card documents in "pristine_doc"
   ): Promise<{ cards: CardResource[]; meta: QueryResultsMeta }> {
-    let { results, meta } = await this._search(
+    let { results, resultMetas, meta } = await this._search(
       realmURL,
       { filter, sort, page },
       opts,
@@ -517,9 +633,22 @@ export class IndexQueryEngine {
       'instance',
     );
 
-    let cards = results
-      .map((r) => r.pristine_doc)
-      .filter(Boolean) as CardResource[];
+    let cards: CardResource[] = [];
+    results.forEach((row, i) => {
+      let pristine = row.pristine_doc;
+      if (!pristine) return;
+      let searchMeta = resultMetas[i];
+      if (searchMeta) {
+        // Merge per-row search meta into the card's meta without mutating
+        // the pristine_doc JSON stored in the index (which is shared).
+        cards.push({
+          ...(pristine as CardResource),
+          meta: { ...(pristine as CardResource).meta, ...searchMeta },
+        });
+      } else {
+        cards.push(pristine as CardResource);
+      }
+    });
 
     return { cards, meta };
   }
@@ -602,9 +731,9 @@ export class IndexQueryEngine {
     // full-text hits lead. Empty/whitespace-only match strings are
     // normalized to FALSE in matchesCondition and contribute nothing to
     // ranking — skip the rank clause in that case. PG emits
-    // ts_rank_cd(tsvector, tsquery) DESC; SQLite has no native rank, so
-    // the branch is empty and URL ordering takes over (M2 adds a synthetic
-    // rank — out of scope here).
+    // ts_rank_cd(tsvector, tsquery) DESC; SQLite synthesizes a hit-count
+    // via LENGTH-minus-REPLACE of the query substring (case-insensitive),
+    // which is monotonic with the synthetic rank JS computes for meta.
     if (!sort) {
       let rankedMatch = filter ? findFirstMatchesFilter(filter) : undefined;
       if (rankedMatch && rankedMatch.matches.trim() !== '') {
@@ -612,11 +741,15 @@ export class IndexQueryEngine {
           'ORDER BY',
           dbExpression({
             pg: [
-              `ts_rank_cd(to_tsvector('english', coalesce(i.markdown, '')), websearch_to_tsquery('english',`,
+              `ANY_VALUE(ts_rank_cd(to_tsvector('english', coalesce(i.markdown, '')), websearch_to_tsquery('english',`,
               param(rankedMatch.matches),
-              `)) DESC,`,
+              `))) DESC,`,
             ],
-            sqlite: '',
+            sqlite: [
+              `(LENGTH(LOWER(COALESCE(i.markdown, ''))) - LENGTH(REPLACE(LOWER(COALESCE(i.markdown, '')), LOWER(`,
+              param(rankedMatch.matches),
+              `), ''))) DESC,`,
+            ],
           }),
           'url COLLATE "POSIX"',
         ];
@@ -689,6 +822,7 @@ export class IndexQueryEngine {
         html: string | null;
         used_render_type: string | null;
       })[];
+      resultMetas: (MatchesMeta | undefined)[];
     };
 
     // We need a way to get scoped css urls even from cards linked from foreign realms.These are saved in the deps column of instances and modules.
@@ -1507,6 +1641,101 @@ function tableFromOpts(opts: WIPOptions | undefined) {
 // char itself) with a backslash before binding.
 function escapeSqliteLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, (c) => `\\${c}`);
+}
+
+// Shape of a row coming back from _search with match-meta columns tacked
+// on. PG populates __rank/__snippet directly from ts_rank_cd/ts_headline;
+// SQLite returns null for those and relies on JS synthesis from
+// __markdown below.
+type MatchesMetaSource = {
+  __rank?: number | string | null;
+  __snippet?: string | null;
+  __markdown?: string | null;
+};
+
+// Builds the per-row MatchesMeta for a single result. PG columns win when
+// populated (they already reflect stemming + proper ts_headline markup);
+// otherwise we synthesize a substring-based approximation in JS. Either
+// way matchedTerms is computed in JS from the raw query + markdown so the
+// stop-word filtering and tokenization stay consistent across adapters.
+function buildMatchesMeta(
+  rawQuery: string,
+  row: MatchesMetaSource,
+): MatchesMeta {
+  let markdown = row.__markdown ?? null;
+  let pgRank = row.__rank;
+  let rank: number;
+  if (typeof pgRank === 'number') {
+    rank = pgRank;
+  } else if (typeof pgRank === 'string') {
+    let parsed = Number(pgRank);
+    rank = Number.isFinite(parsed)
+      ? parsed
+      : synthesizeRank(rawQuery, markdown);
+  } else {
+    rank = synthesizeRank(rawQuery, markdown);
+  }
+  let snippet =
+    typeof row.__snippet === 'string' && row.__snippet.length > 0
+      ? row.__snippet
+      : synthesizeSnippet(rawQuery, markdown);
+  let matchedTerms = computeMatchedTerms(rawQuery, markdown);
+  return { rank, snippet, matchedTerms };
+}
+
+function synthesizeRank(query: string, markdown: string | null): number {
+  if (!markdown) return 0;
+  let q = query.toLowerCase();
+  let trimmed = q.trim();
+  if (!trimmed) return 0;
+  let haystack = markdown.toLowerCase();
+  let count = 0;
+  let idx = 0;
+  while (idx <= haystack.length) {
+    let found = haystack.indexOf(trimmed, idx);
+    if (found < 0) break;
+    count++;
+    idx = found + trimmed.length;
+  }
+  return count;
+}
+
+function synthesizeSnippet(query: string, markdown: string | null): string {
+  if (!markdown) return '';
+  let trimmed = query.toLowerCase().trim();
+  if (!trimmed) return '';
+  let haystack = markdown.toLowerCase();
+  let idx = haystack.indexOf(trimmed);
+  if (idx < 0) return '';
+  let start = Math.max(0, idx - SQLITE_SNIPPET_WINDOW);
+  let end = Math.min(
+    markdown.length,
+    idx + trimmed.length + SQLITE_SNIPPET_WINDOW,
+  );
+  let before = markdown.slice(start, idx);
+  let hit = markdown.slice(idx, idx + trimmed.length);
+  let after = markdown.slice(idx + trimmed.length, end);
+  let prefix = start > 0 ? '…' : '';
+  let suffix = end < markdown.length ? '…' : '';
+  return `${prefix}${before}<b>${hit}</b>${after}${suffix}`;
+}
+
+function computeMatchedTerms(query: string, markdown: string | null): string[] {
+  if (!markdown) return [];
+  let haystack = markdown.toLowerCase();
+  let out: string[] = [];
+  let seen = new Set<string>();
+  for (let raw of query.split(/\s+/)) {
+    let token = raw.toLowerCase().replace(/[^a-z0-9]+/g, '');
+    if (!token) continue;
+    if (ENGLISH_STOP_WORDS.has(token)) continue;
+    if (seen.has(token)) continue;
+    seen.add(token);
+    if (haystack.includes(token)) {
+      out.push(token);
+    }
+  }
+  return out;
 }
 
 // Deterministic pre-order walk: recurses into any/every/not and returns the

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -383,6 +383,7 @@ export type {
   FileMetaResource,
   ModuleResource,
   CardResourceMeta,
+  MatchesMeta,
   ResourceID,
   Meta,
   Saved,

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -65,12 +65,23 @@ export type Relationship = {
   meta?: Record<string, any>;
 };
 
+// Per-row meta synthesized by the index query engine when the query's
+// filter tree contains a `matches` node. Shape is adapter-agnostic —
+// Postgres emits rank/snippet directly (ts_rank_cd / ts_headline) while
+// SQLite synthesizes the same fields in JS from the raw markdown + query
+// string so consumers don't branch on the backend.
+export interface MatchesMeta {
+  rank: number;
+  snippet: string;
+  matchedTerms: string[];
+}
+
 export type CardResourceMeta = Meta & {
   lastModified?: number;
   resourceCreatedAt?: number;
   realmInfo?: RealmInfo;
   realmURL?: string;
-};
+} & Partial<MatchesMeta>;
 
 export type FileMetaResourceResourceMeta = Meta & {
   realmInfo?: RealmInfo;


### PR DESCRIPTION
## Summary
Bundles three related MatchesFilter slices: rank-desc default ordering (CS-10829), per-row result meta on Postgres (CS-10828), and SQLite parity for both (CS-10832).

### CS-10829 — rank-desc default order
When a query's filter tree contains a `matches` node **and** the caller didn't supply an explicit `sort`, default the order-by to rank-desc so the top-ranked full-text hits lead. Caller-supplied sort always wins — the rank tiebreaker is never silently mixed in.

- **PG**: `ORDER BY ANY_VALUE(ts_rank_cd(...)) DESC, url COLLATE "POSIX"` — `ANY_VALUE` keeps the ungrouped `i.markdown` reference legal under `GROUP BY url`.
- **SQLite**: `ORDER BY (LENGTH(LOWER(...)) - LENGTH(REPLACE(LOWER(...), LOWER($q), ''))) DESC, url COLLATE "POSIX"` — a synthetic hit-count that is monotonic with the JS-synthesized rank.
- Empty / whitespace-only `matches` already short-circuits to FALSE in `matchesCondition()`; we skip the rank clause for that case too.

### CS-10828 — Postgres result meta
`searchCards` now emits per-row `{ rank, snippet, matchedTerms }` on each card's `meta` when a MatchesFilter is present. PG computes `rank` via `ts_rank_cd` and `snippet` via `ts_headline` (`StartSel=<b>, StopSel=</b>, MaxWords=35, MinWords=15, ShortWord=3, HighlightAll=false`), both wrapped in `ANY_VALUE(...)` for GROUP-BY compatibility. `matchedTerms` is synthesized in JS (tokenize + english stop-word filter + presence check) to keep the shape uniform across backends.

### CS-10832 — SQLite parity
SQLite synthesizes the same meta shape in JS from the raw `markdown` column: a case-insensitive substring-count rank, a ±80-char snippet window with `<b>…</b>` highlighting, and the same matchedTerms logic. Result: callers get identical `MatchesMeta` regardless of which backend is serving them.

### Multi-match disambiguation
If multiple `matches` nodes appear in the tree, the first node found by a deterministic pre-order walk (`any` → `every` → `not` → leaf) wins for ranking and meta synthesis. Spec doesn't define combined ranking; this keeps behavior predictable.

Linear:
- [CS-10829](https://linear.app/cardstack/issue/CS-10829/default-order-by-rank-desc-when-matches-is-present-and-caller-provided)
- [CS-10828](https://linear.app/cardstack/issue/CS-10828/emit-per-row-matchesmeta-rank-snippet-matchedterms-from-searchcards-on)
- [CS-10832](https://linear.app/cardstack/issue/CS-10832/sqlite-synthesize-rank-and-substring-snippet-for-meta-parity-with)

## Test plan
- [x] `pnpm -C packages/realm-server test` matches suites — 37/37 passing:
  - `matches-filter-integration-test.ts` (14) — translation + FTS semantics
  - `matches-rank-order-integration-test.ts` (6) — rank-desc default + nesting + caller-sort-wins
  - `matches-result-meta-integration-test.ts` (6, new) — rank/snippet/matchedTerms shape + ordering + stop-word exclusion + no-meta-when-no-matches + nested meta
  - `query-matches-filter-test.ts` (11) — DSL guard
- [ ] Host SQLite unit tests (new): 5 tests covering synthesized meta, rank-desc default, `<b>…</b>` highlighting, stop-word exclusion, and no-meta-when-no-matches. Will be exercised in CI host shard.

## Notes
- Also fixes a pre-existing bug in CS-10829's rank-order integration test, which seeded `pristine_doc` as `'{}'::jsonb` and asserted on `c.id` — changed to seed a realistic card resource shape.
- `ANY_VALUE(ts_rank_cd(...))` in the ORDER BY fixes a pre-existing GROUP BY violation that surfaced once the rank-order test's seed was corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)