### PR TITLE
Add matches-filter coverage for SearchCardsByQueryCommand

### DIFF
--- a/packages/host/tests/integration/commands/search-command-test.gts
+++ b/packages/host/tests/integration/commands/search-command-test.gts
@@ -60,6 +60,7 @@ module('Integration | commands | search', function (hooks) {
       static displayName = 'Author';
       @field firstName = contains(StringField);
       @field lastName = contains(StringField);
+      @field bio = contains(StringField);
       @field cardTitle = contains(StringField, {
         computeVia: function (this: Author) {
           return [this.firstName, this.lastName].filter(Boolean).join(' ');
@@ -71,10 +72,14 @@ module('Integration | commands | search', function (hooks) {
         mockMatrixUtils,
         contents: {
           'author.gts': { Author },
-          'Author/r2.json': new Author({ firstName: 'R2-D2' }),
+          'Author/r2.json': new Author({
+            firstName: 'R2-D2',
+            bio: 'Astromech droid who communicates in beeps and whistles.',
+          }),
           'Author/mark.json': new Author({
             firstName: 'Mark',
             lastName: 'Jackson',
+            bio: 'Novelist specializing in xylophone-themed mystery fiction.',
           }),
           '.realm.json': `{ "name": "${realmName}", "iconURL": "https://boxel-images.boxel.ai/icons/Letter-o.png" }`,
         },
@@ -125,6 +130,45 @@ module('Integration | commands | search', function (hooks) {
       },
     });
     assert.strictEqual(result.cardIds.length, 1);
+    assert.strictEqual(result.cardIds[0], 'http://test-realm/test/Author/r2');
+  });
+
+  test('search with a matches filter', async function (assert) {
+    let commandService = getService('command-service');
+    let searchCommand = new SearchCardsByQueryCommand(
+      commandService.commandContext,
+    );
+    let result = await searchCommand.execute({
+      query: {
+        filter: { matches: 'xylophone' },
+      },
+    });
+    assert.strictEqual(
+      result.cardIds.length,
+      1,
+      'only mark.json has "xylophone" in its markdown',
+    );
+    assert.strictEqual(result.cardIds[0], 'http://test-realm/test/Author/mark');
+  });
+
+  test('search with matches composed inside every + eq', async function (assert) {
+    let commandService = getService('command-service');
+    let searchCommand = new SearchCardsByQueryCommand(
+      commandService.commandContext,
+    );
+    let result = await searchCommand.execute({
+      query: {
+        filter: {
+          on: { module: 'http://test-realm/test/author', name: 'Author' },
+          every: [{ matches: 'droid' }, { eq: { firstName: 'R2-D2' } }],
+        },
+      },
+    });
+    assert.strictEqual(
+      result.cardIds.length,
+      1,
+      'composed matches + eq returns r2.json',
+    );
     assert.strictEqual(result.cardIds[0], 'http://test-realm/test/Author/r2');
   });
 });

--- a/packages/host/tests/integration/commands/search-command-test.gts
+++ b/packages/host/tests/integration/commands/search-command-test.gts
@@ -1,7 +1,7 @@
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
-import { baseRealm } from '@cardstack/runtime-common';
+import { baseRealm, type Query } from '@cardstack/runtime-common';
 import type { Loader } from '@cardstack/runtime-common/loader';
 
 import {
@@ -44,6 +44,25 @@ module('Integration | commands | search', function (hooks) {
     activeRealms: [testRealmURL],
     autostart: true,
   });
+
+  function runTypeTitleSearch(input: {
+    cardType: string | undefined;
+    cardTitle: string | undefined;
+  }) {
+    let commandService = getService('command-service');
+    let searchCommand = new SearchCardsByTypeAndTitleCommand(
+      commandService.commandContext,
+    );
+    return searchCommand.execute(input);
+  }
+
+  function runQuerySearch(query: Query) {
+    let commandService = getService('command-service');
+    let searchCommand = new SearchCardsByQueryCommand(
+      commandService.commandContext,
+    );
+    return searchCommand.execute({ query });
+  }
 
   hooks.beforeEach(async function () {
     loader = getService('loader-service').loader;
@@ -88,11 +107,7 @@ module('Integration | commands | search', function (hooks) {
   });
 
   test('search for a title', async function (assert) {
-    let commandService = getService('command-service');
-    let searchCommand = new SearchCardsByTypeAndTitleCommand(
-      commandService.commandContext,
-    );
-    let result = await searchCommand.execute({
+    let result = await runTypeTitleSearch({
       cardTitle: 'Mark Jackson',
       cardType: undefined,
     });
@@ -101,11 +116,7 @@ module('Integration | commands | search', function (hooks) {
   });
 
   test('search for a card type', async function (assert) {
-    let commandService = getService('command-service');
-    let searchCommand = new SearchCardsByTypeAndTitleCommand(
-      commandService.commandContext,
-    );
-    let result = await searchCommand.execute({
+    let result = await runTypeTitleSearch({
       cardType: 'Author',
       cardTitle: undefined,
     });
@@ -117,16 +128,10 @@ module('Integration | commands | search', function (hooks) {
   });
 
   test('search with a query', async function (assert) {
-    let commandService = getService('command-service');
-    let searchCommand = new SearchCardsByQueryCommand(
-      commandService.commandContext,
-    );
-    let result = await searchCommand.execute({
-      query: {
-        filter: {
-          eq: { firstName: 'R2-D2' },
-          on: { module: 'http://test-realm/test/author', name: 'Author' },
-        },
+    let result = await runQuerySearch({
+      filter: {
+        eq: { firstName: 'R2-D2' },
+        on: { module: 'http://test-realm/test/author', name: 'Author' },
       },
     });
     assert.strictEqual(result.cardIds.length, 1);
@@ -134,14 +139,8 @@ module('Integration | commands | search', function (hooks) {
   });
 
   test('search with a matches filter', async function (assert) {
-    let commandService = getService('command-service');
-    let searchCommand = new SearchCardsByQueryCommand(
-      commandService.commandContext,
-    );
-    let result = await searchCommand.execute({
-      query: {
-        filter: { matches: 'xylophone' },
-      },
+    let result = await runQuerySearch({
+      filter: { matches: 'xylophone' },
     });
     assert.strictEqual(
       result.cardIds.length,
@@ -152,16 +151,10 @@ module('Integration | commands | search', function (hooks) {
   });
 
   test('search with matches composed inside every + eq', async function (assert) {
-    let commandService = getService('command-service');
-    let searchCommand = new SearchCardsByQueryCommand(
-      commandService.commandContext,
-    );
-    let result = await searchCommand.execute({
-      query: {
-        filter: {
-          on: { module: 'http://test-realm/test/author', name: 'Author' },
-          every: [{ matches: 'droid' }, { eq: { firstName: 'R2-D2' } }],
-        },
+    let result = await runQuerySearch({
+      filter: {
+        on: { module: 'http://test-realm/test/author', name: 'Author' },
+        every: [{ matches: 'droid' }, { eq: { firstName: 'R2-D2' } }],
       },
     });
     assert.strictEqual(


### PR DESCRIPTION
## Summary
Verifies the end-to-end agent path wired up by `SearchCardsByQueryCommand` already accepts a `MatchesFilter`, with test-only coverage. No schema changes, no plumbing — the input type is already the full `Query` union, which includes `MatchesFilter` after CS-10825/26/31.

## What changed
Two new integration tests in `packages/host/tests/integration/commands/search-command-test.gts`:

- `search with a matches filter` — `{ filter: { matches: 'xylophone' } }` returns exactly the one author whose bio contains "xylophone" in its rendered markdown.
- `search with matches composed inside every + eq` — `{ filter: { on, every: [{ matches }, { eq }] } }` proves `matches` composes with existing ops inside `every`, scoped by `on`.

Extends the existing `Author` fixture with a `bio: StringField` so the rendered markdown has distinctive, unambiguous text to hit on.

## Out of scope (split to CS-10842)
Threading per-card `MatchesMeta` (rank, snippet, matchedTerms) into the agent-visible payload. That needs a base-realm schema change on `SearchCardSummaryField` and a meta-returning variant on `StoreService.search()`; tracked separately.

## Based on
PR #4458 (CS-10825/26/27/31). Merge that first.

Linear: [CS-10836](https://linear.app/cardstack/issue/CS-10836)

## Test plan
- [ ] CI host shard runs \`search-command-test.gts\` → both new tests pass
- [ ] Existing three tests in that file still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)