### PR TITLE
CS-10834: verify card chooser dialog honors matches filter

### DIFF
--- a/packages/host/tests/integration/components/card-catalog-test.gts
+++ b/packages/host/tests/integration/components/card-catalog-test.gts
@@ -1,6 +1,7 @@
 import {
   waitFor,
   click,
+  fillIn,
   triggerKeyEvent,
   focus,
   doubleClick,
@@ -124,7 +125,8 @@ module('Integration | card-catalog', function (hooks) {
         }),
         'Spec/author.json': new Spec({
           cardTitle: 'Author',
-          cardDescription: 'Spec for Author',
+          cardDescription:
+            'Spec for Author — covers biographical sketches by ornithologists',
           specType: 'card',
           ref: {
             module: `${testRealmURL}author`,
@@ -169,7 +171,8 @@ module('Integration | card-catalog', function (hooks) {
         }),
         'Spec/address.json': new Spec({
           cardTitle: 'Address',
-          cardDescription: 'Spec for Address field',
+          cardDescription:
+            'Spec for Address field — also frequented by ornithologists',
           specType: 'field',
           ref: {
             module: `${testRealmURL}address`,
@@ -432,6 +435,38 @@ module('Integration | card-catalog', function (hooks) {
       await waitFor('[data-test-card-catalog-modal]', { count: 0 });
       assert.dom(`[data-test-stack-card-index="0"]`).exists();
       assert.dom('[data-test-stack-card-index="1"]').doesNotExist();
+    });
+  });
+
+  module('content search', function () {
+    test(`finds cards by description content, not just title, and respects type scoping`, async function (assert) {
+      await waitFor('[data-test-card-catalog-modal]');
+      await waitFor(
+        `[data-test-card-catalog-item="${testRealmURL}Spec/author"]`,
+      );
+
+      // 'ornithologists' appears in both Spec/author (specType: 'card') and
+      // Spec/address (specType: 'field'). The chooser's baseFilter scopes to
+      // card-type specs, so only the Author spec should surface — proving
+      // matches is layered on top of type scoping, not replacing it.
+      await fillIn('[data-test-search-field]', 'ornithologists');
+      await waitFor(
+        `[data-test-realm="${realmName}"] [data-test-card-catalog-item="${testRealmURL}Spec/author"]`,
+      );
+
+      assert
+        .dom(`[data-test-realm="${realmName}"] [data-test-card-catalog-item]`)
+        .exists(
+          { count: 1 },
+          'only the card-type spec is shown; field-type spec with the same content term is filtered out',
+        );
+      assert
+        .dom(
+          `[data-test-realm="${realmName}"] [data-test-card-catalog-item="${testRealmURL}Spec/address"]`,
+        )
+        .doesNotExist(
+          'field-type spec is excluded even though its description matches',
+        );
     });
   });
 });


### PR DESCRIPTION
## Summary

- CS-10833 swapped the global-search `buildSearchQuery` path from `{ contains: { cardTitle } }` to `{ matches }`.
- The card-catalog modal (the "pick a card" chooser dialog) routes through the same `SearchPanel` → `buildSearchQuery` pipeline, so that swap already covers it — no further production-code change is required.
- This PR adds an integration test proving the chooser surface actually reflects the new behavior:
  - a content-only term (present in `cardDescription` but not `cardTitle`) surfaces the matching card
  - the dialog's existing type-scoped `baseFilter` (`specRef` + `isCard=true`, applied by the "create new card" entry point) still excludes wrong-type specs whose content also matches

Stacked on PR #4462 (CS-10833). Base is the CS-10833 branch so the diff stays focused on the chooser-level assertions.

Linear: [CS-10834](https://linear.app/cardstack/issue/CS-10834/host-swap-in-app-card-chooser-dialogs-from-title-like-to-matches)

## Test plan
- [ ] CI passes the new `Integration | card-catalog > content search` test
- [ ] Existing `Integration | card-catalog` tests stay green (only `cardDescription` strings changed, titles/count/specTypes unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)