### PR TITLE
Fix binary file upload WAF false positives by using Uint8Array 

### DIFF
--- a/packages/host/app/commands/write-binary-file.ts
+++ b/packages/host/app/commands/write-binary-file.ts
@@ -86,7 +86,7 @@ export default class WriteBinaryFileCommand extends HostBaseCommand<
     }
 
     let bytes = base64ToUint8Array(input.base64Content);
-    let blob = new Blob([bytes]);
+    let blob = new Blob([bytes as any]);
 
     let clientRequestId = `binary:${uuidv4()}`;
     this.cardService.clientRequestIds.add(clientRequestId);

--- a/packages/host/app/commands/write-binary-file.ts
+++ b/packages/host/app/commands/write-binary-file.ts
@@ -86,7 +86,7 @@ export default class WriteBinaryFileCommand extends HostBaseCommand<
     }
 
     let bytes = base64ToUint8Array(input.base64Content);
-    let blob = new Blob([bytes.buffer as ArrayBuffer]);
+    let blob = new Blob([bytes as any]);
 
     let clientRequestId = `binary:${uuidv4()}`;
     this.cardService.clientRequestIds.add(clientRequestId);
@@ -102,9 +102,24 @@ export default class WriteBinaryFileCommand extends HostBaseCommand<
     });
 
     if (!response.ok) {
-      let errorMessage = `Could not write binary file ${finalUrl}, status ${response.status}: ${response.statusText} - ${await response.text()}`;
-      console.error(errorMessage);
-      throw new Error(errorMessage);
+      let responseText: string;
+      try {
+        responseText = await response.text();
+      } catch {
+        responseText = '(unable to read response body)';
+      }
+      let wafRule = response.headers.get('x-blocked-by-waf-rule');
+      let details = [
+        `[WriteBinaryFile] Failed to write ${finalUrl}`,
+        `Status: ${response.status} ${response.statusText}`,
+        `File size: ${bytes.byteLength} bytes`,
+        wafRule ? `WAF rule: ${wafRule}` : null,
+        `Response: ${responseText}`,
+      ]
+        .filter(Boolean)
+        .join(' | ');
+      console.error(details);
+      throw new Error(details);
     }
 
     let commandModule = await this.loadCommandModule();

--- a/packages/host/app/commands/write-binary-file.ts
+++ b/packages/host/app/commands/write-binary-file.ts
@@ -86,7 +86,7 @@ export default class WriteBinaryFileCommand extends HostBaseCommand<
     }
 
     let bytes = base64ToUint8Array(input.base64Content);
-    let blob = new Blob([bytes as any]);
+    let blob = new Blob([bytes]);
 
     let clientRequestId = `binary:${uuidv4()}`;
     this.cardService.clientRequestIds.add(clientRequestId);
@@ -102,9 +102,15 @@ export default class WriteBinaryFileCommand extends HostBaseCommand<
     });
 
     if (!response.ok) {
+      const MAX_RESPONSE_TEXT_LENGTH = 500;
       let responseText: string;
       try {
-        responseText = await response.text();
+        let rawText = await response.text();
+        responseText =
+          rawText.length > MAX_RESPONSE_TEXT_LENGTH
+            ? rawText.slice(0, MAX_RESPONSE_TEXT_LENGTH) +
+              `… (${rawText.length} chars total)`
+            : rawText;
       } catch {
         responseText = '(unable to read response body)';
       }

--- a/packages/host/tests/integration/commands/write-binary-file-test.gts
+++ b/packages/host/tests/integration/commands/write-binary-file-test.gts
@@ -1,0 +1,169 @@
+import { getOwner } from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import WriteBinaryFileCommand from '@cardstack/host/commands/write-binary-file';
+import type NetworkService from '@cardstack/host/services/network';
+
+import RealmService from '@cardstack/host/services/realm';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  testRealmURL,
+  testRealmInfo,
+  setupRealmCacheTeardown,
+  withCachedRealmSetup,
+} from '../../helpers';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+let fetch: NetworkService['fetch'];
+
+// A tiny valid PNG (1x1 transparent pixel) encoded in base64
+const TINY_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQABNjN9GQAAAABJRkhJRkFJAA==';
+
+class StubRealmService extends RealmService {
+  get defaultReadableRealm() {
+    return {
+      path: testRealmURL,
+      info: testRealmInfo,
+    };
+  }
+
+  realmOfURL(url: URL) {
+    if (url.href.startsWith(testRealmURL)) {
+      return new URL(testRealmURL);
+    }
+    return undefined;
+  }
+}
+
+module('Integration | commands | write-binary-file', function (hooks) {
+  setupRenderingTest(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks);
+
+  hooks.beforeEach(function (this: RenderingTestContext) {
+    getOwner(this)!.register('service:realm', StubRealmService);
+    fetch = getService('network').fetch;
+  });
+
+  setupRealmCacheTeardown(hooks);
+
+  hooks.beforeEach(async function () {
+    await withCachedRealmSetup(async () =>
+      setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {},
+      }),
+    );
+  });
+
+  test('writes a binary file', async function (assert) {
+    let commandService = getService('command-service');
+    let command = new WriteBinaryFileCommand(commandService.commandContext);
+    let result = await command.execute({
+      path: 'test-image.png',
+      realm: testRealmURL,
+      base64Content: TINY_PNG_BASE64,
+    });
+    assert.strictEqual(
+      result.fileUrl,
+      `${testRealmURL}test-image.png`,
+      'returns the correct file URL',
+    );
+    let response = await fetch(new URL('test-image.png', testRealmURL));
+    assert.strictEqual(response.status, 200, 'file is accessible after write');
+  });
+
+  test('a 403 from WAF is surfaced in the error message', async function (assert) {
+    let networkService = getService('network');
+    networkService.virtualNetwork.mount(
+      async (req: Request) => {
+        if (
+          req.method === 'POST' &&
+          req.headers.get('Content-Type') === 'application/octet-stream'
+        ) {
+          return new Response(
+            '{ "message": "Request blocked by Web Application Firewall." }',
+            {
+              status: 403,
+              headers: {
+                'Content-Type': 'application/json',
+                'X-Blocked-By-WAF-Rule': 'CrossSiteScripting_BODY',
+              },
+            },
+          );
+        }
+        return null;
+      },
+      { prepend: true },
+    );
+
+    let commandService = getService('command-service');
+    let command = new WriteBinaryFileCommand(commandService.commandContext);
+    try {
+      await command.execute({
+        path: 'waf-blocked.png',
+        realm: testRealmURL,
+        base64Content: TINY_PNG_BASE64,
+      });
+      assert.notOk(true, 'Should have thrown an error');
+    } catch (error: any) {
+      assert.ok(
+        error.message.includes('403'),
+        'Error message includes status code',
+      );
+      assert.ok(
+        error.message.includes('waf-blocked.png'),
+        'Error message includes the file path',
+      );
+      assert.ok(
+        error.message.includes('WAF rule: CrossSiteScripting_BODY'),
+        'Error message includes the WAF rule',
+      );
+      assert.ok(
+        error.message.includes('bytes'),
+        'Error message includes file size',
+      );
+    }
+  });
+
+  test('handles a leading slash in the path', async function (assert) {
+    let commandService = getService('command-service');
+    let command = new WriteBinaryFileCommand(commandService.commandContext);
+    let result = await command.execute({
+      path: '/test-image.png',
+      realm: testRealmURL,
+      base64Content: TINY_PNG_BASE64,
+    });
+    assert.strictEqual(
+      result.fileUrl,
+      `${testRealmURL}test-image.png`,
+      'leading slash is stripped from path',
+    );
+  });
+
+  test('throws an error when an invalid realm is provided', async function (assert) {
+    let commandService = getService('command-service');
+    let command = new WriteBinaryFileCommand(commandService.commandContext);
+    try {
+      await command.execute({
+        path: 'bad.png',
+        realm: 'https://not-a-known-realm.example/',
+        base64Content: TINY_PNG_BASE64,
+      });
+      assert.notOk(true, 'Should have thrown an error for invalid realm');
+    } catch (error: any) {
+      assert.ok(
+        error.message.includes('Invalid or unknown realm provided'),
+        'Error message should mention invalid realm',
+      );
+    }
+  });
+});

--- a/packages/host/tests/integration/commands/write-binary-file-test.gts
+++ b/packages/host/tests/integration/commands/write-binary-file-test.gts
@@ -79,6 +79,17 @@ module('Integration | commands | write-binary-file', function (hooks) {
     );
     let response = await fetch(new URL('test-image.png', testRealmURL));
     assert.strictEqual(response.status, 200, 'file is accessible after write');
+
+    let expectedBytes = Uint8Array.from(atob(TINY_PNG_BASE64), (char) =>
+      char.charCodeAt(0),
+    );
+    let actualBytes = new Uint8Array(await response.arrayBuffer());
+
+    assert.deepEqual(
+      Array.from(actualBytes),
+      Array.from(expectedBytes),
+      'stored file bytes match the decoded base64 content',
+    );
   });
 
   test('a 403 from WAF is surfaced in the error message', async function (assert) {


### PR DESCRIPTION
Fix binary file upload WAF false positives and improve error reporting

Problem:
<img width="1210" height="170" alt="image" src="https://github.com/user-attachments/assets/36656ae2-8ab7-4fd6-90ce-2e87fc2edda2" />

1. Pass Uint8Array directly to Blob constructor instead of .buffer (an ArrayBuffer) — avoids WAF pattern-matching on base64-like text; the wire payload is raw binary octets with Content-Type: application/octet-stream
2. Enrich the error thrown on non-OK responses: includes file URL, HTTP status, file size in bytes, and the x-blocked-by-waf-rule header value when present, making WAF blocks diagnosable without digging through network logs
3. Add integration tests covering