### PR TITLE
CS-10848: Add `boxel file delete` command

### DIFF
--- a/packages/boxel-cli/src/commands/file/delete.ts
+++ b/packages/boxel-cli/src/commands/file/delete.ts
@@ -1,8 +1,11 @@
 import type { Command } from 'commander';
 import {
   getProfileManager,
+  NO_ACTIVE_PROFILE_ERROR,
   type ProfileManager,
 } from '../../lib/profile-manager';
+import { isProtectedFile, SupportedMimeType } from '../../lib/realm-sync-base';
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { FG_RED, DIM, RESET } from '../../lib/colors';
 
 export interface DeleteResult {
@@ -17,10 +20,6 @@ export interface DeleteCommandOptions {
 interface DeleteCliOptions {
   realm: string;
   json?: boolean;
-}
-
-function ensureTrailingSlash(url: string): string {
-  return url.endsWith('/') ? url : `${url}/`;
 }
 
 /**
@@ -39,7 +38,14 @@ export async function deleteFile(
   if (!active) {
     return {
       ok: false,
-      error: 'No active profile. Run `boxel profile add` to create one.',
+      error: NO_ACTIVE_PROFILE_ERROR,
+    };
+  }
+
+  if (isProtectedFile(path)) {
+    return {
+      ok: false,
+      error: `Cannot delete protected file: ${path}`,
     };
   }
 
@@ -49,7 +55,7 @@ export async function deleteFile(
   try {
     response = await pm.authedRealmFetch(url, {
       method: 'DELETE',
-      headers: { Accept: 'application/vnd.card+source' },
+      headers: { Accept: SupportedMimeType.CardSource },
     });
   } catch (err) {
     return {

--- a/packages/boxel-cli/src/commands/file/delete.ts
+++ b/packages/boxel-cli/src/commands/file/delete.ts
@@ -1,0 +1,98 @@
+import type { Command } from 'commander';
+import { getProfileManager, type ProfileManager } from '../../lib/profile-manager';
+import { FG_RED, DIM, RESET } from '../../lib/colors';
+
+export interface DeleteResult {
+  ok: boolean;
+  error?: string;
+}
+
+export interface DeleteCommandOptions {
+  profileManager?: ProfileManager;
+}
+
+interface DeleteCliOptions {
+  realm: string;
+  json?: boolean;
+}
+
+function ensureTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
+/**
+ * Delete a file from a realm.
+ *
+ * Sends an HTTP DELETE request for the given path within the realm.
+ * Uses the per-realm JWT via `ProfileManager.authedRealmFetch`.
+ */
+export async function deleteFile(
+  realmUrl: string,
+  path: string,
+  options?: DeleteCommandOptions,
+): Promise<DeleteResult> {
+  let pm = options?.profileManager ?? getProfileManager();
+  let active = pm.getActiveProfile();
+  if (!active) {
+    throw new Error(
+      'No active profile. Run `boxel profile add` to create one.',
+    );
+  }
+
+  let url = new URL(path, ensureTrailingSlash(realmUrl)).href;
+
+  let response: Response;
+  try {
+    response = await pm.authedRealmFetch(url, {
+      method: 'DELETE',
+      headers: { Accept: 'application/vnd.card+source' },
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  if (!response.ok) {
+    let body = await response.text().catch(() => '(no body)');
+    return {
+      ok: false,
+      error: `HTTP ${response.status}: ${body.slice(0, 300)}`,
+    };
+  }
+
+  return { ok: true };
+}
+
+export function registerDeleteCommand(parent: Command): void {
+  parent
+    .command('delete')
+    .description('Delete a file from a realm')
+    .argument('<path>', 'Realm-relative file path to delete')
+    .requiredOption('--realm <realm-url>', 'The realm URL to delete from')
+    .option('--json', 'Output raw JSON response')
+    .action(async (filePath: string, opts: DeleteCliOptions) => {
+      let result: DeleteResult;
+      try {
+        result = await deleteFile(opts.realm, filePath);
+      } catch (err) {
+        console.error(
+          `${FG_RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else if (result.ok) {
+        console.log(`${DIM}Deleted:${RESET} ${filePath}`);
+      } else {
+        console.error(`${FG_RED}Error:${RESET} ${result.error}`);
+      }
+
+      if (!result.ok) {
+        process.exit(1);
+      }
+    });
+}

--- a/packages/boxel-cli/src/commands/file/delete.ts
+++ b/packages/boxel-cli/src/commands/file/delete.ts
@@ -4,8 +4,9 @@ import {
   NO_ACTIVE_PROFILE_ERROR,
   type ProfileManager,
 } from '../../lib/profile-manager';
-import { isProtectedFile, SupportedMimeType } from '../../lib/realm-sync-base';
+import { isProtectedFile } from '../../lib/realm-sync-base';
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
+import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
 import { FG_RED, DIM, RESET } from '../../lib/colors';
 
 export interface DeleteResult {

--- a/packages/boxel-cli/src/commands/file/delete.ts
+++ b/packages/boxel-cli/src/commands/file/delete.ts
@@ -1,5 +1,8 @@
 import type { Command } from 'commander';
-import { getProfileManager, type ProfileManager } from '../../lib/profile-manager';
+import {
+  getProfileManager,
+  type ProfileManager,
+} from '../../lib/profile-manager';
 import { FG_RED, DIM, RESET } from '../../lib/colors';
 
 export interface DeleteResult {

--- a/packages/boxel-cli/src/commands/file/delete.ts
+++ b/packages/boxel-cli/src/commands/file/delete.ts
@@ -37,9 +37,10 @@ export async function deleteFile(
   let pm = options?.profileManager ?? getProfileManager();
   let active = pm.getActiveProfile();
   if (!active) {
-    throw new Error(
-      'No active profile. Run `boxel profile add` to create one.',
-    );
+    return {
+      ok: false,
+      error: 'No active profile. Run `boxel profile add` to create one.',
+    };
   }
 
   let url = new URL(path, ensureTrailingSlash(realmUrl)).href;

--- a/packages/boxel-cli/src/commands/file/index.ts
+++ b/packages/boxel-cli/src/commands/file/index.ts
@@ -1,0 +1,10 @@
+import type { Command } from 'commander';
+import { registerDeleteCommand } from './delete';
+
+export function registerFileCommand(program: Command): void {
+  let file = program
+    .command('file')
+    .description('Manage files in a realm');
+
+  registerDeleteCommand(file);
+}

--- a/packages/boxel-cli/src/commands/file/index.ts
+++ b/packages/boxel-cli/src/commands/file/index.ts
@@ -2,9 +2,7 @@ import type { Command } from 'commander';
 import { registerDeleteCommand } from './delete';
 
 export function registerFileCommand(program: Command): void {
-  let file = program
-    .command('file')
-    .description('Manage files in a realm');
+  let file = program.command('file').description('Manage files in a realm');
 
   registerDeleteCommand(file);
 }

--- a/packages/boxel-cli/src/index.ts
+++ b/packages/boxel-cli/src/index.ts
@@ -5,6 +5,7 @@ import { resolve } from 'path';
 import { profileCommand } from './commands/profile';
 import { registerReadTranspiledCommand } from './commands/read-transpiled';
 import { registerRealmCommand } from './commands/realm/index';
+import { registerFileCommand } from './commands/file/index';
 import { registerRunCommand } from './commands/run-command';
 
 const pkg = JSON.parse(
@@ -42,6 +43,7 @@ program
     },
   );
 
+registerFileCommand(program);
 registerRealmCommand(program);
 registerRunCommand(program);
 registerReadTranspiledCommand(program);

--- a/packages/boxel-cli/src/lib/boxel-cli-client.ts
+++ b/packages/boxel-cli/src/lib/boxel-cli-client.ts
@@ -1,3 +1,4 @@
+import { deleteFile } from '../commands/file/delete';
 import {
   readTranspiledModule,
   type ReadTranspiledResult,
@@ -249,32 +250,14 @@ export class BoxelCLIClient {
   }
 
   /**
-   * Delete a file from a realm.
+   * Delete a file from a realm. Delegates to the standalone
+   * `deleteFile()` command in `commands/file/delete.ts` so the CLI
+   * and programmatic API share one implementation.
    */
   async delete(realmUrl: string, path: string): Promise<DeleteResult> {
-    let url = new URL(path, ensureTrailingSlash(realmUrl)).href;
-
-    try {
-      let response = await this.pm.authedRealmFetch(url, {
-        method: 'DELETE',
-        headers: { Accept: MIME.CardSource },
-      });
-
-      if (!response.ok) {
-        let body = await response.text();
-        return {
-          ok: false,
-          error: `HTTP ${response.status}: ${body.slice(0, 300)}`,
-        };
-      }
-
-      return { ok: true };
-    } catch (err) {
-      return {
-        ok: false,
-        error: err instanceof Error ? err.message : String(err),
-      };
-    }
+    return deleteFile(realmUrl, path, {
+      profileManager: this.pm,
+    }) as Promise<DeleteResult>;
   }
 
   /**

--- a/packages/boxel-cli/src/lib/boxel-cli-client.ts
+++ b/packages/boxel-cli/src/lib/boxel-cli-client.ts
@@ -1,4 +1,4 @@
-import { deleteFile } from '../commands/file/delete';
+import { deleteFile, type DeleteResult } from '../commands/file/delete';
 import {
   readTranspiledModule,
   type ReadTranspiledResult,
@@ -62,10 +62,7 @@ export interface WriteResult {
   error?: string;
 }
 
-export interface DeleteResult {
-  ok: boolean;
-  error?: string;
-}
+export type { DeleteResult };
 
 export interface SearchResult {
   ok: boolean;
@@ -257,7 +254,7 @@ export class BoxelCLIClient {
   async delete(realmUrl: string, path: string): Promise<DeleteResult> {
     return deleteFile(realmUrl, path, {
       profileManager: this.pm,
-    }) as Promise<DeleteResult>;
+    });
   }
 
   /**

--- a/packages/boxel-cli/src/lib/profile-manager.ts
+++ b/packages/boxel-cli/src/lib/profile-manager.ts
@@ -13,6 +13,9 @@ import {
 const DEFAULT_CONFIG_DIR = path.join(os.homedir(), '.boxel-cli');
 const PROFILES_FILENAME = 'profiles.json';
 
+export const NO_ACTIVE_PROFILE_ERROR =
+  'No active profile. Run `boxel profile add` to create one.';
+
 export interface Profile {
   displayName: string;
   matrixUrl: string;

--- a/packages/boxel-cli/tests/helpers/integration.ts
+++ b/packages/boxel-cli/tests/helpers/integration.ts
@@ -69,6 +69,7 @@ export async function startTestRealmServer(options?: {
     matrixURL,
     permissions: {
       '*': ['read', 'write'],
+      [`@${TEST_USERNAME}:localhost`]: ['read', 'write', 'realm-owner'],
     },
     prerenderer: noopPrerenderer,
   });

--- a/packages/boxel-cli/tests/integration/file-delete.test.ts
+++ b/packages/boxel-cli/tests/integration/file-delete.test.ts
@@ -23,10 +23,28 @@ beforeAll(async () => {
   await startTestRealmServer({
     fileSystem: {
       'keep-this.json': JSON.stringify({
-        data: { type: 'card', attributes: { title: 'Keep' }, meta: { adoptsFrom: { module: 'https://cardstack.com/base/card-api', name: 'CardDef' } } },
+        data: {
+          type: 'card',
+          attributes: { title: 'Keep' },
+          meta: {
+            adoptsFrom: {
+              module: 'https://cardstack.com/base/card-api',
+              name: 'CardDef',
+            },
+          },
+        },
       }),
       'delete-me.json': JSON.stringify({
-        data: { type: 'card', attributes: { title: 'Delete' }, meta: { adoptsFrom: { module: 'https://cardstack.com/base/card-api', name: 'CardDef' } } },
+        data: {
+          type: 'card',
+          attributes: { title: 'Delete' },
+          meta: {
+            adoptsFrom: {
+              module: 'https://cardstack.com/base/card-api',
+              name: 'CardDef',
+            },
+          },
+        },
       }),
     },
   });
@@ -38,7 +56,10 @@ beforeAll(async () => {
   client = new BoxelCLIClient(profileManager);
 });
 
-afterAll(async () => { cleanupProfile?.(); await stopTestRealmServer(); });
+afterAll(async () => {
+  cleanupProfile?.();
+  await stopTestRealmServer();
+});
 
 describe('file delete (integration)', () => {
   it('deletes a file and confirms it no longer exists via read', async () => {
@@ -47,7 +68,9 @@ describe('file delete (integration)', () => {
     expect(before.ok, 'file should exist before delete').toBe(true);
 
     // Delete it
-    let result = await deleteFile(realmUrl, 'delete-me.json', { profileManager });
+    let result = await deleteFile(realmUrl, 'delete-me.json', {
+      profileManager,
+    });
     expect(result.ok).toBe(true);
 
     // Verify it's gone

--- a/packages/boxel-cli/tests/integration/file-delete.test.ts
+++ b/packages/boxel-cli/tests/integration/file-delete.test.ts
@@ -1,9 +1,10 @@
 import '../helpers/setup-realm-server';
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { deleteFile } from '../../src/commands/file/delete';
+import { BoxelCLIClient } from '../../src/lib/boxel-cli-client';
 import { ProfileManager } from '../../src/lib/profile-manager';
 import {
   startTestRealmServer,
@@ -14,14 +15,18 @@ import {
 } from '../helpers/integration';
 
 let profileManager: ProfileManager;
+let client: BoxelCLIClient;
 let cleanupProfile: () => void;
 let realmUrl: string;
 
 beforeAll(async () => {
   await startTestRealmServer({
     fileSystem: {
-      'to-delete.json': JSON.stringify({
-        data: { type: 'card', attributes: { title: 'Delete Me' }, meta: { adoptsFrom: { module: 'https://cardstack.com/base/card-api', name: 'CardDef' } } },
+      'keep-this.json': JSON.stringify({
+        data: { type: 'card', attributes: { title: 'Keep' }, meta: { adoptsFrom: { module: 'https://cardstack.com/base/card-api', name: 'CardDef' } } },
+      }),
+      'delete-me.json': JSON.stringify({
+        data: { type: 'card', attributes: { title: 'Delete' }, meta: { adoptsFrom: { module: 'https://cardstack.com/base/card-api', name: 'CardDef' } } },
       }),
     },
   });
@@ -30,44 +35,38 @@ beforeAll(async () => {
   profileManager = testProfile.profileManager;
   cleanupProfile = testProfile.cleanup;
   await setupTestProfile(profileManager);
+  client = new BoxelCLIClient(profileManager);
 });
 
 afterAll(async () => { cleanupProfile?.(); await stopTestRealmServer(); });
 
 describe('file delete (integration)', () => {
-  it('sends DELETE request with correct method', async () => {
-    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch');
-    try {
-      await deleteFile(realmUrl, 'to-delete.json', { profileManager });
-      expect(fetchSpy).toHaveBeenCalledOnce();
-      let [url, init] = fetchSpy.mock.calls[0];
-      expect(String(url)).toContain('to-delete.json');
-      expect(init!.method).toBe('DELETE');
-    } finally { fetchSpy.mockRestore(); }
+  it('deletes a file and confirms it no longer exists via read', async () => {
+    // Verify the file exists first
+    let before = await client.read(realmUrl, 'delete-me.json');
+    expect(before.ok, 'file should exist before delete').toBe(true);
+
+    // Delete it
+    let result = await deleteFile(realmUrl, 'delete-me.json', { profileManager });
+    expect(result.ok).toBe(true);
+
+    // Verify it's gone
+    let after = await client.read(realmUrl, 'delete-me.json');
+    expect(after.ok).toBe(false);
+    expect(after.status).toBe(404);
+  });
+
+  it('other files remain after deleting one', async () => {
+    let result = await client.read(realmUrl, 'keep-this.json');
+    expect(result.ok, 'unrelated file should still exist').toBe(true);
   });
 
   it('throws when no active profile', async () => {
     let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
     let emptyManager = new ProfileManager(emptyDir);
-    await expect(deleteFile(realmUrl, 'to-delete.json', { profileManager: emptyManager })).rejects.toThrow('No active profile');
+    await expect(
+      deleteFile(realmUrl, 'keep-this.json', { profileManager: emptyManager }),
+    ).rejects.toThrow('No active profile');
     fs.rmSync(emptyDir, { recursive: true, force: true });
-  });
-
-  it('returns error when fetch throws', async () => {
-    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch').mockRejectedValueOnce(new Error('network failure'));
-    try {
-      let result = await deleteFile(realmUrl, 'to-delete.json', { profileManager });
-      expect(result.ok).toBe(false);
-      expect(result.error).toContain('network failure');
-    } finally { fetchSpy.mockRestore(); }
-  });
-
-  it('returns error on non-2xx response', async () => {
-    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch').mockResolvedValueOnce(new Response('Not Found', { status: 404 }));
-    try {
-      let result = await deleteFile(realmUrl, 'nonexistent.json', { profileManager });
-      expect(result.ok).toBe(false);
-      expect(result.error).toContain('404');
-    } finally { fetchSpy.mockRestore(); }
   });
 });

--- a/packages/boxel-cli/tests/integration/file-delete.test.ts
+++ b/packages/boxel-cli/tests/integration/file-delete.test.ts
@@ -1,0 +1,73 @@
+import '../helpers/setup-realm-server';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { deleteFile } from '../../src/commands/file/delete';
+import { ProfileManager } from '../../src/lib/profile-manager';
+import {
+  startTestRealmServer,
+  stopTestRealmServer,
+  createTestProfileDir,
+  setupTestProfile,
+  TEST_REALM_SERVER_URL,
+} from '../helpers/integration';
+
+let profileManager: ProfileManager;
+let cleanupProfile: () => void;
+let realmUrl: string;
+
+beforeAll(async () => {
+  await startTestRealmServer({
+    fileSystem: {
+      'to-delete.json': JSON.stringify({
+        data: { type: 'card', attributes: { title: 'Delete Me' }, meta: { adoptsFrom: { module: 'https://cardstack.com/base/card-api', name: 'CardDef' } } },
+      }),
+    },
+  });
+  realmUrl = `${TEST_REALM_SERVER_URL}/test/`;
+  let testProfile = createTestProfileDir();
+  profileManager = testProfile.profileManager;
+  cleanupProfile = testProfile.cleanup;
+  await setupTestProfile(profileManager);
+});
+
+afterAll(async () => { cleanupProfile?.(); await stopTestRealmServer(); });
+
+describe('file delete (integration)', () => {
+  it('sends DELETE request with correct method', async () => {
+    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch');
+    try {
+      await deleteFile(realmUrl, 'to-delete.json', { profileManager });
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      let [url, init] = fetchSpy.mock.calls[0];
+      expect(String(url)).toContain('to-delete.json');
+      expect(init!.method).toBe('DELETE');
+    } finally { fetchSpy.mockRestore(); }
+  });
+
+  it('throws when no active profile', async () => {
+    let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
+    let emptyManager = new ProfileManager(emptyDir);
+    await expect(deleteFile(realmUrl, 'to-delete.json', { profileManager: emptyManager })).rejects.toThrow('No active profile');
+    fs.rmSync(emptyDir, { recursive: true, force: true });
+  });
+
+  it('returns error when fetch throws', async () => {
+    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch').mockRejectedValueOnce(new Error('network failure'));
+    try {
+      let result = await deleteFile(realmUrl, 'to-delete.json', { profileManager });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('network failure');
+    } finally { fetchSpy.mockRestore(); }
+  });
+
+  it('returns error on non-2xx response', async () => {
+    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch').mockResolvedValueOnce(new Response('Not Found', { status: 404 }));
+    try {
+      let result = await deleteFile(realmUrl, 'nonexistent.json', { profileManager });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('404');
+    } finally { fetchSpy.mockRestore(); }
+  });
+});

--- a/packages/boxel-cli/tests/integration/file-delete.test.ts
+++ b/packages/boxel-cli/tests/integration/file-delete.test.ts
@@ -84,12 +84,14 @@ describe('file delete (integration)', () => {
     expect(result.ok, 'unrelated file should still exist').toBe(true);
   });
 
-  it('throws when no active profile', async () => {
+  it('returns error result when no active profile', async () => {
     let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
     let emptyManager = new ProfileManager(emptyDir);
-    await expect(
-      deleteFile(realmUrl, 'keep-this.json', { profileManager: emptyManager }),
-    ).rejects.toThrow('No active profile');
+    let result = await deleteFile(realmUrl, 'keep-this.json', {
+      profileManager: emptyManager,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('No active profile');
     fs.rmSync(emptyDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `boxel file delete <path> --realm <url>` CLI command
- Extracts `BoxelCLIClient.delete()` inline implementation into a standalone command function at `src/commands/file/delete.ts`
- Client method now delegates to the command function
- Adds `realm-owner` permission for the test user in integration test setup (required for DELETE operations)

## Why — pattern consistency
The `pull` command already follows this pattern: a standalone exported function that both the CLI and `BoxelCLIClient` delegate to. This PR makes `delete()` consistent with that approach. Every `BoxelCLIClient` method should be backed by a command function that is the single source of truth — the client is a thin delegation layer. This enables CS-10670 (tool definitions) where boxel-cli publishes tool definitions that reference these commands directly.

## Test plan
- [x] Integration tests: seeds a file, deletes it, verifies 404 via read, confirms other files untouched, no-profile error
- [x] Build passes
- [ ] CI green

Closes CS-10848

🤖 Generated with [Claude Code](https://claude.com/claude-code)