### PR TITLE
CS-10852: Add `boxel realm wait-for-ready` command

### DIFF
--- a/packages/boxel-cli/src/commands/realm/index.ts
+++ b/packages/boxel-cli/src/commands/realm/index.ts
@@ -3,6 +3,7 @@ import { registerCreateCommand } from './create';
 import { registerPullCommand } from './pull';
 import { registerPushCommand } from './push';
 import { registerSyncCommand } from './sync';
+import { registerWaitForReadyCommand } from './wait-for-ready';
 
 export function registerRealmCommand(program: Command): void {
   let realm = program
@@ -13,4 +14,5 @@ export function registerRealmCommand(program: Command): void {
   registerPullCommand(realm);
   registerPushCommand(realm);
   registerSyncCommand(realm);
+  registerWaitForReadyCommand(realm);
 }

--- a/packages/boxel-cli/src/commands/realm/wait-for-ready.ts
+++ b/packages/boxel-cli/src/commands/realm/wait-for-ready.ts
@@ -1,30 +1,33 @@
 import type { Command } from 'commander';
 import {
   getProfileManager,
+  NO_ACTIVE_PROFILE_ERROR,
   type ProfileManager,
 } from '../../lib/profile-manager';
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
+import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
 import { FG_GREEN, FG_RED, RESET } from '../../lib/colors';
-
-export interface WaitForReadyCommandOptions {
-  timeoutMs?: number;
-  profileManager?: ProfileManager;
-}
 
 export interface WaitForReadyResult {
   ready: boolean;
   error?: string;
 }
 
-function ensureTrailingSlash(url: string): string {
-  return url.endsWith('/') ? url : `${url}/`;
+export interface WaitForReadyCommandOptions {
+  timeoutMs?: number;
+  profileManager?: ProfileManager;
+}
+
+interface WaitForReadyCliOptions {
+  realm: string;
+  timeout?: string;
 }
 
 /**
- * Poll `_readiness-check` until the realm is ready or the timeout is reached.
+ * Poll a realm's `_readiness-check` endpoint until it responds OK or the
+ * timeout is reached.
  *
- * Suitable for both CLI and programmatic use — no console output or
- * process.exit. The CLI wrapper (`registerWaitForReadyCommand`) handles
- * formatting and exit codes.
+ * Uses the per-realm JWT via `ProfileManager.authedRealmFetch`.
  */
 export async function waitForReady(
   realmUrl: string,
@@ -34,9 +37,10 @@ export async function waitForReady(
   let pm = options.profileManager ?? getProfileManager();
   let active = pm.getActiveProfile();
   if (!active) {
-    throw new Error(
-      'No active profile. Run `boxel profile add` to create one.',
-    );
+    return {
+      ready: false,
+      error: NO_ACTIVE_PROFILE_ERROR,
+    };
   }
 
   let readinessUrl = `${ensureTrailingSlash(realmUrl)}_readiness-check`;
@@ -46,7 +50,7 @@ export async function waitForReady(
     try {
       let response = await pm.authedRealmFetch(readinessUrl, {
         method: 'GET',
-        headers: { Accept: 'application/json' },
+        headers: { Accept: SupportedMimeType.RealmInfo },
       });
       if (response.ok) {
         return { ready: true };
@@ -61,11 +65,6 @@ export async function waitForReady(
     ready: false,
     error: `Realm not ready after ${timeoutMs}ms: ${readinessUrl}`,
   };
-}
-
-interface WaitForReadyCliOptions {
-  realm: string;
-  timeout?: string;
 }
 
 export function registerWaitForReadyCommand(realm: Command): void {
@@ -92,7 +91,9 @@ export function registerWaitForReadyCommand(realm: Command): void {
       if (result.ready) {
         console.log(`${FG_GREEN}Realm is ready.${RESET}`);
       } else {
-        console.error(`${FG_RED}${result.error ?? 'Realm not ready'}${RESET}`);
+        console.error(
+          `${FG_RED}Error:${RESET} ${result.error ?? 'Realm not ready'}`,
+        );
         process.exit(1);
       }
     });

--- a/packages/boxel-cli/src/commands/realm/wait-for-ready.ts
+++ b/packages/boxel-cli/src/commands/realm/wait-for-ready.ts
@@ -1,0 +1,99 @@
+import type { Command } from 'commander';
+import {
+  getProfileManager,
+  type ProfileManager,
+} from '../../lib/profile-manager';
+import { FG_GREEN, FG_RED, RESET } from '../../lib/colors';
+
+export interface WaitForReadyCommandOptions {
+  timeoutMs?: number;
+  profileManager?: ProfileManager;
+}
+
+export interface WaitForReadyResult {
+  ready: boolean;
+  error?: string;
+}
+
+function ensureTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
+/**
+ * Poll `_readiness-check` until the realm is ready or the timeout is reached.
+ *
+ * Suitable for both CLI and programmatic use — no console output or
+ * process.exit. The CLI wrapper (`registerWaitForReadyCommand`) handles
+ * formatting and exit codes.
+ */
+export async function waitForReady(
+  realmUrl: string,
+  options: WaitForReadyCommandOptions = {},
+): Promise<WaitForReadyResult> {
+  let timeoutMs = options.timeoutMs ?? 30_000;
+  let pm = options.profileManager ?? getProfileManager();
+  let active = pm.getActiveProfile();
+  if (!active) {
+    throw new Error(
+      'No active profile. Run `boxel profile add` to create one.',
+    );
+  }
+
+  let readinessUrl = `${ensureTrailingSlash(realmUrl)}_readiness-check`;
+  let startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      let response = await pm.authedRealmFetch(readinessUrl, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+      });
+      if (response.ok) {
+        return { ready: true };
+      }
+    } catch {
+      // retry
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+
+  return {
+    ready: false,
+    error: `Realm not ready after ${timeoutMs}ms: ${readinessUrl}`,
+  };
+}
+
+interface WaitForReadyCliOptions {
+  realm: string;
+  timeout?: string;
+}
+
+export function registerWaitForReadyCommand(realm: Command): void {
+  realm
+    .command('wait-for-ready')
+    .description(
+      'Poll a realm readiness-check endpoint until it responds OK or the timeout is reached',
+    )
+    .requiredOption('--realm <realm-url>', 'The realm URL to check')
+    .option('--timeout <ms>', 'Timeout in milliseconds (default: 30000)')
+    .action(async (opts: WaitForReadyCliOptions) => {
+      let timeoutMs = opts.timeout ? parseInt(opts.timeout, 10) : undefined;
+
+      let result: WaitForReadyResult;
+      try {
+        result = await waitForReady(opts.realm, { timeoutMs });
+      } catch (err) {
+        console.error(
+          `${FG_RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      if (result.ready) {
+        console.log(`${FG_GREEN}Realm is ready.${RESET}`);
+      } else {
+        console.error(`${FG_RED}${result.error ?? 'Realm not ready'}${RESET}`);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/boxel-cli/src/commands/realm/wait-for-ready.ts
+++ b/packages/boxel-cli/src/commands/realm/wait-for-ready.ts
@@ -1,4 +1,4 @@
-import type { Command } from 'commander';
+import { InvalidArgumentError, type Command } from 'commander';
 import {
   getProfileManager,
   NO_ACTIVE_PROFILE_ERROR,
@@ -20,7 +20,17 @@ export interface WaitForReadyCommandOptions {
 
 interface WaitForReadyCliOptions {
   realm: string;
-  timeout?: string;
+  timeout?: number;
+}
+
+function parseTimeoutOption(value: string): number {
+  let n = Number.parseInt(value, 10);
+  if (!Number.isFinite(n) || n < 0 || String(n) !== value.trim()) {
+    throw new InvalidArgumentError(
+      '--timeout must be a non-negative integer (milliseconds).',
+    );
+  }
+  return n;
 }
 
 /**
@@ -34,6 +44,12 @@ export async function waitForReady(
   options: WaitForReadyCommandOptions = {},
 ): Promise<WaitForReadyResult> {
   let timeoutMs = options.timeoutMs ?? 30_000;
+  if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+    return {
+      ready: false,
+      error: `Invalid timeoutMs: must be a finite, non-negative number (got ${options.timeoutMs}).`,
+    };
+  }
   let pm = options.profileManager ?? getProfileManager();
   let active = pm.getActiveProfile();
   if (!active) {
@@ -58,7 +74,9 @@ export async function waitForReady(
     } catch {
       // retry
     }
-    await new Promise((r) => setTimeout(r, 1000));
+    let remaining = timeoutMs - (Date.now() - startedAt);
+    if (remaining <= 0) break;
+    await new Promise((r) => setTimeout(r, Math.min(1000, remaining)));
   }
 
   return {
@@ -74,13 +92,15 @@ export function registerWaitForReadyCommand(realm: Command): void {
       'Poll a realm readiness-check endpoint until it responds OK or the timeout is reached',
     )
     .requiredOption('--realm <realm-url>', 'The realm URL to check')
-    .option('--timeout <ms>', 'Timeout in milliseconds (default: 30000)')
+    .option(
+      '--timeout <ms>',
+      'Timeout in milliseconds (default: 30000)',
+      parseTimeoutOption,
+    )
     .action(async (opts: WaitForReadyCliOptions) => {
-      let timeoutMs = opts.timeout ? parseInt(opts.timeout, 10) : undefined;
-
       let result: WaitForReadyResult;
       try {
-        result = await waitForReady(opts.realm, { timeoutMs });
+        result = await waitForReady(opts.realm, { timeoutMs: opts.timeout });
       } catch (err) {
         console.error(
           `${FG_RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/boxel-cli/src/lib/boxel-cli-client.ts
+++ b/packages/boxel-cli/src/lib/boxel-cli-client.ts
@@ -17,6 +17,7 @@ import { write as coreWrite, type WriteResult } from '../commands/file/write';
 import { createRealm as coreCreateRealm } from '../commands/realm/create';
 import { pull as realmPull } from '../commands/realm/pull';
 import { sync as realmSync, type SyncResult } from '../commands/realm/sync';
+import { waitForReady as coreWaitForReady } from '../commands/realm/wait-for-ready';
 import { getProfileManager, type ProfileManager } from './profile-manager';
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 
@@ -328,28 +329,10 @@ export class BoxelCLIClient {
     realmUrl: string,
     timeoutMs = 30_000,
   ): Promise<WaitForReadyResult> {
-    let readinessUrl = `${ensureTrailingSlash(realmUrl)}_readiness-check`;
-    let startedAt = Date.now();
-
-    while (Date.now() - startedAt < timeoutMs) {
-      try {
-        let response = await this.pm.authedRealmFetch(readinessUrl, {
-          method: 'GET',
-          headers: { Accept: MIME.JSON },
-        });
-        if (response.ok) {
-          return { ready: true };
-        }
-      } catch {
-        // retry
-      }
-      await new Promise((r) => setTimeout(r, 1000));
-    }
-
-    return {
-      ready: false,
-      error: `Realm not ready after ${timeoutMs}ms: ${readinessUrl}`,
-    };
+    return coreWaitForReady(realmUrl, {
+      timeoutMs,
+      profileManager: this.pm,
+    });
   }
 
   /**

--- a/packages/boxel-cli/tests/integration/realm-wait-for-ready.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-wait-for-ready.test.ts
@@ -1,0 +1,59 @@
+import '../helpers/setup-realm-server';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { waitForReady } from '../../src/commands/realm/wait-for-ready';
+import { ProfileManager } from '../../src/lib/profile-manager';
+import {
+  startTestRealmServer,
+  stopTestRealmServer,
+  createTestProfileDir,
+  setupTestProfile,
+  TEST_REALM_SERVER_URL,
+} from '../helpers/integration';
+
+let profileManager: ProfileManager;
+let cleanupProfile: () => void;
+let realmUrl: string;
+
+beforeAll(async () => {
+  await startTestRealmServer();
+  realmUrl = `${TEST_REALM_SERVER_URL}/test/`;
+  let testProfile = createTestProfileDir();
+  profileManager = testProfile.profileManager;
+  cleanupProfile = testProfile.cleanup;
+  await setupTestProfile(profileManager);
+});
+
+afterAll(async () => { cleanupProfile?.(); await stopTestRealmServer(); });
+
+describe('realm wait-for-ready (integration)', () => {
+  it('polls _readiness-check endpoint', async () => {
+    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch');
+    try {
+      let result = await waitForReady(realmUrl, { timeoutMs: 5000, profileManager });
+      expect(result.ready).toBe(true);
+      expect(fetchSpy).toHaveBeenCalled();
+      let [url, init] = fetchSpy.mock.calls[0];
+      expect(String(url)).toContain('_readiness-check');
+      expect(init!.method).toBe('GET');
+    } finally { fetchSpy.mockRestore(); }
+  });
+
+  it('returns not ready on timeout', async () => {
+    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch').mockResolvedValue(new Response('Not Ready', { status: 503 }));
+    try {
+      let result = await waitForReady(realmUrl, { timeoutMs: 100, profileManager });
+      expect(result.ready).toBe(false);
+      expect(result.error).toContain('not ready after');
+    } finally { fetchSpy.mockRestore(); }
+  });
+
+  it('throws when no active profile', async () => {
+    let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
+    let emptyManager = new ProfileManager(emptyDir);
+    await expect(waitForReady(realmUrl, { profileManager: emptyManager })).rejects.toThrow('No active profile');
+    fs.rmSync(emptyDir, { recursive: true, force: true });
+  });
+});

--- a/packages/boxel-cli/tests/integration/realm-wait-for-ready.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-wait-for-ready.test.ts
@@ -26,7 +26,10 @@ beforeAll(async () => {
   await setupTestProfile(profileManager);
 });
 
-afterAll(async () => { cleanupProfile?.(); await stopTestRealmServer(); });
+afterAll(async () => {
+  cleanupProfile?.();
+  await stopTestRealmServer();
+});
 
 describe('realm wait-for-ready (integration)', () => {
   it('returns ready for a running realm', async () => {

--- a/packages/boxel-cli/tests/integration/realm-wait-for-ready.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-wait-for-ready.test.ts
@@ -50,12 +50,12 @@ describe('realm wait-for-ready (integration)', () => {
     expect(result.error).toContain('not ready after');
   });
 
-  it('throws when no active profile', async () => {
+  it('returns an error when no active profile', async () => {
     let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
     let emptyManager = new ProfileManager(emptyDir);
-    await expect(
-      waitForReady(realmUrl, { profileManager: emptyManager }),
-    ).rejects.toThrow('No active profile');
+    let result = await waitForReady(realmUrl, { profileManager: emptyManager });
+    expect(result.ready).toBe(false);
+    expect(result.error).toContain('No active profile');
     fs.rmSync(emptyDir, { recursive: true, force: true });
   });
 });

--- a/packages/boxel-cli/tests/integration/realm-wait-for-ready.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-wait-for-ready.test.ts
@@ -1,5 +1,5 @@
 import '../helpers/setup-realm-server';
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -29,31 +29,30 @@ beforeAll(async () => {
 afterAll(async () => { cleanupProfile?.(); await stopTestRealmServer(); });
 
 describe('realm wait-for-ready (integration)', () => {
-  it('polls _readiness-check endpoint', async () => {
-    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch');
-    try {
-      let result = await waitForReady(realmUrl, { timeoutMs: 5000, profileManager });
-      expect(result.ready).toBe(true);
-      expect(fetchSpy).toHaveBeenCalled();
-      let [url, init] = fetchSpy.mock.calls[0];
-      expect(String(url)).toContain('_readiness-check');
-      expect(init!.method).toBe('GET');
-    } finally { fetchSpy.mockRestore(); }
+  it('returns ready for a running realm', async () => {
+    let result = await waitForReady(realmUrl, {
+      timeoutMs: 5000,
+      profileManager,
+    });
+    expect(result.ready).toBe(true);
+    expect(result.error).toBeUndefined();
   });
 
-  it('returns not ready on timeout', async () => {
-    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch').mockResolvedValue(new Response('Not Ready', { status: 503 }));
-    try {
-      let result = await waitForReady(realmUrl, { timeoutMs: 100, profileManager });
-      expect(result.ready).toBe(false);
-      expect(result.error).toContain('not ready after');
-    } finally { fetchSpy.mockRestore(); }
+  it('returns not ready when realm URL is unreachable', async () => {
+    let result = await waitForReady('http://127.0.0.1:1/fake/', {
+      timeoutMs: 500,
+      profileManager,
+    });
+    expect(result.ready).toBe(false);
+    expect(result.error).toContain('not ready after');
   });
 
   it('throws when no active profile', async () => {
     let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
     let emptyManager = new ProfileManager(emptyDir);
-    await expect(waitForReady(realmUrl, { profileManager: emptyManager })).rejects.toThrow('No active profile');
+    await expect(
+      waitForReady(realmUrl, { profileManager: emptyManager }),
+    ).rejects.toThrow('No active profile');
     fs.rmSync(emptyDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
- Extract readiness-check polling logic from `BoxelCLIClient.waitForReady()` into a standalone command module at `packages/boxel-cli/src/commands/realm/wait-for-ready.ts`
- Register `boxel realm wait-for-ready --realm <url> [--timeout <ms>]` as a CLI subcommand
- Export `waitForReady(realmUrl, options?)` for programmatic use with `WaitForReadyResult` return type
- Refactor `BoxelCLIClient.waitForReady()` to delegate to the new core function
- Add integration tests covering ready realm, timeout error, and missing profile scenarios

## Test plan
- [ ] Unit tests pass (`pnpm test:unit` in boxel-cli)
- [ ] Build succeeds (`pnpm build` in boxel-cli)
- [ ] Type check passes (`tsc --noEmit`)
- [ ] Integration tests pass against a real realm server (`pnpm test:integration` in boxel-cli)
- [ ] CLI help shows `wait-for-ready` subcommand under `boxel realm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)