### PR TITLE
CS-10849: Add `boxel file list` command

### DIFF
--- a/packages/boxel-cli/src/commands/file/index.ts
+++ b/packages/boxel-cli/src/commands/file/index.ts
@@ -1,5 +1,6 @@
 import type { Command } from 'commander';
 import { registerDeleteCommand } from './delete';
+import { registerListCommand } from './list';
 import { registerLintCommand } from './lint';
 import { registerWriteCommand } from './write';
 
@@ -9,6 +10,7 @@ export function registerFileCommand(program: Command): void {
     .description('Read, write, search, and manage files in a realm');
 
   registerDeleteCommand(file);
+  registerListCommand(file);
   registerLintCommand(file);
   registerWriteCommand(file);
 }

--- a/packages/boxel-cli/src/commands/file/list.ts
+++ b/packages/boxel-cli/src/commands/file/list.ts
@@ -111,9 +111,7 @@ export function registerListCommand(file: Command): void {
         for (let filename of result.filenames) {
           console.log(`${DIM}${filename}${RESET}`);
         }
-        console.log(
-          `\n${DIM}${result.filenames.length} file(s)${RESET}`,
-        );
+        console.log(`\n${DIM}${result.filenames.length} file(s)${RESET}`);
       }
     });
 }

--- a/packages/boxel-cli/src/commands/file/list.ts
+++ b/packages/boxel-cli/src/commands/file/list.ts
@@ -1,8 +1,11 @@
 import type { Command } from 'commander';
 import {
   getProfileManager,
+  NO_ACTIVE_PROFILE_ERROR,
   type ProfileManager,
 } from '../../lib/profile-manager';
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
+import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
 import { FG_RED, DIM, RESET } from '../../lib/colors';
 
 export interface ListFilesResult {
@@ -19,10 +22,6 @@ interface ListFilesCliOptions {
   json?: boolean;
 }
 
-function ensureTrailingSlash(url: string): string {
-  return url.endsWith('/') ? url : `${url}/`;
-}
-
 /**
  * List all file paths in a realm via the `_mtimes` endpoint.
  * Returns relative paths (e.g., `hello.gts`, `Cards/my-card.json`).
@@ -36,7 +35,7 @@ export async function listFiles(
   if (!active) {
     return {
       filenames: [],
-      error: 'No active profile. Run `boxel profile add` to create one.',
+      error: NO_ACTIVE_PROFILE_ERROR,
     };
   }
 
@@ -46,11 +45,11 @@ export async function listFiles(
   try {
     let response = await pm.authedRealmFetch(mtimesUrl, {
       method: 'GET',
-      headers: { Accept: 'application/vnd.api+json' },
+      headers: { Accept: SupportedMimeType.Mtimes },
     });
 
     if (!response.ok) {
-      let body = await response.text();
+      let body = await response.text().catch(() => '(no body)');
       return {
         filenames: [],
         error: `_mtimes returned HTTP ${response.status}: ${body.slice(0, 300)}`,

--- a/packages/boxel-cli/src/commands/file/list.ts
+++ b/packages/boxel-cli/src/commands/file/list.ts
@@ -34,9 +34,10 @@ export async function listFiles(
   let pm = options?.profileManager ?? getProfileManager();
   let active = pm.getActiveProfile();
   if (!active) {
-    throw new Error(
-      'No active profile. Run `boxel profile add` to create one.',
-    );
+    return {
+      filenames: [],
+      error: 'No active profile. Run `boxel profile add` to create one.',
+    };
   }
 
   let normalizedRealmUrl = ensureTrailingSlash(realmUrl);
@@ -104,6 +105,9 @@ export function registerListCommand(file: Command): void {
 
       if (opts.json) {
         console.log(JSON.stringify(result, null, 2));
+        if (result.error) {
+          process.exit(1);
+        }
       } else if (result.error) {
         console.error(`${FG_RED}Error:${RESET} ${result.error}`);
         process.exit(1);

--- a/packages/boxel-cli/src/commands/file/list.ts
+++ b/packages/boxel-cli/src/commands/file/list.ts
@@ -1,0 +1,119 @@
+import type { Command } from 'commander';
+import {
+  getProfileManager,
+  type ProfileManager,
+} from '../../lib/profile-manager';
+import { FG_RED, DIM, RESET } from '../../lib/colors';
+
+export interface ListFilesResult {
+  filenames: string[];
+  error?: string;
+}
+
+export interface ListFilesCommandOptions {
+  profileManager?: ProfileManager;
+}
+
+interface ListFilesCliOptions {
+  realm: string;
+  json?: boolean;
+}
+
+function ensureTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
+/**
+ * List all file paths in a realm via the `_mtimes` endpoint.
+ * Returns relative paths (e.g., `hello.gts`, `Cards/my-card.json`).
+ */
+export async function listFiles(
+  realmUrl: string,
+  options?: ListFilesCommandOptions,
+): Promise<ListFilesResult> {
+  let pm = options?.profileManager ?? getProfileManager();
+  let active = pm.getActiveProfile();
+  if (!active) {
+    throw new Error(
+      'No active profile. Run `boxel profile add` to create one.',
+    );
+  }
+
+  let normalizedRealmUrl = ensureTrailingSlash(realmUrl);
+  let mtimesUrl = `${normalizedRealmUrl}_mtimes`;
+
+  try {
+    let response = await pm.authedRealmFetch(mtimesUrl, {
+      method: 'GET',
+      headers: { Accept: 'application/vnd.api+json' },
+    });
+
+    if (!response.ok) {
+      let body = await response.text();
+      return {
+        filenames: [],
+        error: `_mtimes returned HTTP ${response.status}: ${body.slice(0, 300)}`,
+      };
+    }
+
+    let json = (await response.json()) as {
+      data?: { attributes?: { mtimes?: Record<string, number> } };
+    };
+    let mtimes =
+      json?.data?.attributes?.mtimes ??
+      (json as unknown as Record<string, number>);
+
+    let filenames: string[] = [];
+    for (let fullUrl of Object.keys(mtimes)) {
+      if (!fullUrl.startsWith(normalizedRealmUrl)) {
+        continue;
+      }
+      let relativePath = fullUrl.slice(normalizedRealmUrl.length);
+      if (!relativePath || relativePath.endsWith('/')) {
+        continue;
+      }
+      filenames.push(relativePath);
+    }
+
+    return { filenames: filenames.sort() };
+  } catch (err) {
+    return {
+      filenames: [],
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export function registerListCommand(file: Command): void {
+  file
+    .command('list')
+    .alias('ls')
+    .description('List all files in a realm')
+    .requiredOption('--realm <realm-url>', 'The realm URL to list files from')
+    .option('--json', 'Output raw JSON response')
+    .action(async (opts: ListFilesCliOptions) => {
+      let result: ListFilesResult;
+      try {
+        result = await listFiles(opts.realm);
+      } catch (err) {
+        console.error(
+          `${FG_RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else if (result.error) {
+        console.error(`${FG_RED}Error:${RESET} ${result.error}`);
+        process.exit(1);
+      } else {
+        for (let filename of result.filenames) {
+          console.log(`${DIM}${filename}${RESET}`);
+        }
+        console.log(
+          `\n${DIM}${result.filenames.length} file(s)${RESET}`,
+        );
+      }
+    });
+}

--- a/packages/boxel-cli/src/commands/read-transpiled.ts
+++ b/packages/boxel-cli/src/commands/read-transpiled.ts
@@ -1,5 +1,6 @@
 import type { Command } from 'commander';
 import { getProfileManager, type ProfileManager } from '../lib/profile-manager';
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { FG_RED, DIM, RESET } from '../lib/colors';
 
 export interface ReadTranspiledResult {
@@ -17,10 +18,6 @@ export interface ReadTranspiledOptions {
 interface ReadTranspiledCliOptions {
   realm: string;
   json?: boolean;
-}
-
-function ensureTrailingSlash(url: string): string {
-  return url.endsWith('/') ? url : `${url}/`;
 }
 
 /**

--- a/packages/boxel-cli/src/commands/realm/create.ts
+++ b/packages/boxel-cli/src/commands/realm/create.ts
@@ -3,6 +3,7 @@ import {
   iconURLFor,
   getRandomBackgroundURL,
 } from '@cardstack/runtime-common/realm-display-defaults';
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import {
   getProfileManager,
   type ProfileManager,
@@ -238,8 +239,4 @@ function extractRealmUrlFromError(
   throw new Error(
     `Could not determine realm URL from server error response for endpoint "${endpoint}" on "${realmServerUrl}". The response did not include an explicit realm URL.`,
   );
-}
-
-function ensureTrailingSlash(url: string): string {
-  return url.endsWith('/') ? url : `${url}/`;
 }

--- a/packages/boxel-cli/src/lib/boxel-cli-client.ts
+++ b/packages/boxel-cli/src/lib/boxel-cli-client.ts
@@ -5,6 +5,10 @@ import {
   type LintMessage,
 } from '../commands/file/lint';
 import {
+  listFiles as coreListFiles,
+  type ListFilesResult,
+} from '../commands/file/list';
+import {
   readTranspiledModule,
   type ReadTranspiledResult,
 } from '../commands/read-transpiled';
@@ -13,7 +17,7 @@ import { createRealm as coreCreateRealm } from '../commands/realm/create';
 import { pull as realmPull } from '../commands/realm/pull';
 import { getProfileManager, type ProfileManager } from './profile-manager';
 
-export type { ReadTranspiledResult };
+export type { ListFilesResult, ReadTranspiledResult };
 
 const MIME = {
   CardSource: 'application/vnd.card+source',
@@ -70,11 +74,6 @@ export interface SearchResult {
   ok: boolean;
   status?: number;
   data?: Record<string, unknown>[];
-  error?: string;
-}
-
-export interface ListFilesResult {
-  filenames: string[];
   error?: string;
 }
 
@@ -268,49 +267,7 @@ export class BoxelCLIClient {
    * Returns relative paths (e.g., `hello.gts`, `Cards/my-card.json`).
    */
   async listFiles(realmUrl: string): Promise<ListFilesResult> {
-    let normalizedRealmUrl = ensureTrailingSlash(realmUrl);
-    let mtimesUrl = `${normalizedRealmUrl}_mtimes`;
-
-    try {
-      let response = await this.pm.authedRealmFetch(mtimesUrl, {
-        method: 'GET',
-        headers: { Accept: MIME.JSONAPI },
-      });
-
-      if (!response.ok) {
-        let body = await response.text();
-        return {
-          filenames: [],
-          error: `_mtimes returned HTTP ${response.status}: ${body.slice(0, 300)}`,
-        };
-      }
-
-      let json = (await response.json()) as {
-        data?: { attributes?: { mtimes?: Record<string, number> } };
-      };
-      let mtimes =
-        json?.data?.attributes?.mtimes ??
-        (json as unknown as Record<string, number>);
-
-      let filenames: string[] = [];
-      for (let fullUrl of Object.keys(mtimes)) {
-        if (!fullUrl.startsWith(normalizedRealmUrl)) {
-          continue;
-        }
-        let relativePath = fullUrl.slice(normalizedRealmUrl.length);
-        if (!relativePath || relativePath.endsWith('/')) {
-          continue;
-        }
-        filenames.push(relativePath);
-      }
-
-      return { filenames: filenames.sort() };
-    } catch (err) {
-      return {
-        filenames: [],
-        error: err instanceof Error ? err.message : String(err),
-      };
-    }
+    return coreListFiles(realmUrl, { profileManager: this.pm });
   }
 
   /**

--- a/packages/boxel-cli/src/lib/boxel-cli-client.ts
+++ b/packages/boxel-cli/src/lib/boxel-cli-client.ts
@@ -16,6 +16,7 @@ import { write as coreWrite, type WriteResult } from '../commands/file/write';
 import { createRealm as coreCreateRealm } from '../commands/realm/create';
 import { pull as realmPull } from '../commands/realm/pull';
 import { getProfileManager, type ProfileManager } from './profile-manager';
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 
 export type { ListFilesResult, ReadTranspiledResult };
 
@@ -25,10 +26,6 @@ const MIME = {
   JSON: 'application/json',
   JSONAPI: 'application/vnd.api+json',
 } as const;
-
-function ensureTrailingSlash(url: string): string {
-  return url.endsWith('/') ? url : `${url}/`;
-}
 
 export interface CreateRealmOptions {
   /** URL slug for the realm (lowercase, numbers, hyphens). */

--- a/packages/boxel-cli/tests/integration/file-list.test.ts
+++ b/packages/boxel-cli/tests/integration/file-list.test.ts
@@ -1,0 +1,103 @@
+import '../helpers/setup-realm-server';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { listFiles } from '../../src/commands/file/list';
+import { ProfileManager } from '../../src/lib/profile-manager';
+import {
+  startTestRealmServer,
+  stopTestRealmServer,
+  createTestProfileDir,
+  setupTestProfile,
+  TEST_REALM_SERVER_URL,
+} from '../helpers/integration';
+
+let profileManager: ProfileManager;
+let cleanupProfile: () => void;
+let realmUrl: string;
+
+beforeAll(async () => {
+  await startTestRealmServer({
+    fileSystem: {
+      'hello.gts': 'export default class {}',
+      'world.json': '{"data": {}}',
+      'nested/deep.gts': 'export default class {}',
+    },
+  });
+
+  realmUrl = `${TEST_REALM_SERVER_URL}/test/`;
+
+  let testProfile = createTestProfileDir();
+  profileManager = testProfile.profileManager;
+  cleanupProfile = testProfile.cleanup;
+  await setupTestProfile(profileManager);
+});
+
+afterAll(async () => {
+  cleanupProfile?.();
+  await stopTestRealmServer();
+});
+
+describe('file list (integration)', () => {
+  it('returns sorted filenames from the realm', async () => {
+    let result = await listFiles(realmUrl, { profileManager });
+
+    expect(result.error).toBeUndefined();
+    expect(result.filenames).toContain('hello.gts');
+    expect(result.filenames).toContain('world.json');
+    expect(result.filenames).toContain('nested/deep.gts');
+    // Verify sorted order
+    let sorted = [...result.filenames].sort();
+    expect(result.filenames).toEqual(sorted);
+  });
+
+  it('returns JSON-serialisable output (--json mode)', async () => {
+    let result = await listFiles(realmUrl, { profileManager });
+
+    let json = JSON.parse(JSON.stringify(result));
+    expect(json.filenames).toBeInstanceOf(Array);
+    expect(json.filenames.length).toBeGreaterThan(0);
+    expect(json.error).toBeUndefined();
+  });
+
+  it('throws when no active profile', async () => {
+    let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
+    let emptyManager = new ProfileManager(emptyDir);
+
+    await expect(
+      listFiles(realmUrl, { profileManager: emptyManager }),
+    ).rejects.toThrow('No active profile');
+
+    fs.rmSync(emptyDir, { recursive: true, force: true });
+  });
+
+  it('returns error when fetch throws', async () => {
+    let fetchSpy = vi
+      .spyOn(profileManager, 'authedRealmFetch')
+      .mockRejectedValueOnce(new Error('network failure'));
+    try {
+      let result = await listFiles(realmUrl, { profileManager });
+      expect(result.filenames).toEqual([]);
+      expect(result.error).toContain('network failure');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('uses authedRealmFetch with Accept: application/vnd.api+json', async () => {
+    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch');
+    try {
+      await listFiles(realmUrl, { profileManager });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      let [url, init] = fetchSpy.mock.calls[0];
+      expect(String(url)).toContain('_mtimes');
+      expect(init!.method).toBe('GET');
+      let headers = init!.headers as Record<string, string>;
+      expect(headers['Accept']).toBe('application/vnd.api+json');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});

--- a/packages/boxel-cli/tests/integration/file-list.test.ts
+++ b/packages/boxel-cli/tests/integration/file-list.test.ts
@@ -57,13 +57,13 @@ describe('file list (integration)', () => {
     expect(result.error).toBeDefined();
   });
 
-  it('throws when no active profile', async () => {
+  it('returns error result when no active profile', async () => {
     let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
     let emptyManager = new ProfileManager(emptyDir);
 
-    await expect(
-      listFiles(realmUrl, { profileManager: emptyManager }),
-    ).rejects.toThrow('No active profile');
+    let result = await listFiles(realmUrl, { profileManager: emptyManager });
+    expect(result.filenames).toEqual([]);
+    expect(result.error).toContain('No active profile');
 
     fs.rmSync(emptyDir, { recursive: true, force: true });
   });

--- a/packages/boxel-cli/tests/integration/file-list.test.ts
+++ b/packages/boxel-cli/tests/integration/file-list.test.ts
@@ -1,5 +1,5 @@
 import '../helpers/setup-realm-server';
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -40,25 +40,21 @@ afterAll(async () => {
 });
 
 describe('file list (integration)', () => {
-  it('returns sorted filenames from the realm', async () => {
+  it('returns sorted filenames including seeded files', async () => {
     let result = await listFiles(realmUrl, { profileManager });
 
     expect(result.error).toBeUndefined();
     expect(result.filenames).toContain('hello.gts');
     expect(result.filenames).toContain('world.json');
     expect(result.filenames).toContain('nested/deep.gts');
-    // Verify sorted order
     let sorted = [...result.filenames].sort();
     expect(result.filenames).toEqual(sorted);
   });
 
-  it('returns JSON-serialisable output (--json mode)', async () => {
-    let result = await listFiles(realmUrl, { profileManager });
-
-    let json = JSON.parse(JSON.stringify(result));
-    expect(json.filenames).toBeInstanceOf(Array);
-    expect(json.filenames.length).toBeGreaterThan(0);
-    expect(json.error).toBeUndefined();
+  it('returns error for an unreachable realm', async () => {
+    let result = await listFiles('http://127.0.0.1:1/', { profileManager });
+    expect(result.filenames).toEqual([]);
+    expect(result.error).toBeDefined();
   });
 
   it('throws when no active profile', async () => {
@@ -70,34 +66,5 @@ describe('file list (integration)', () => {
     ).rejects.toThrow('No active profile');
 
     fs.rmSync(emptyDir, { recursive: true, force: true });
-  });
-
-  it('returns error when fetch throws', async () => {
-    let fetchSpy = vi
-      .spyOn(profileManager, 'authedRealmFetch')
-      .mockRejectedValueOnce(new Error('network failure'));
-    try {
-      let result = await listFiles(realmUrl, { profileManager });
-      expect(result.filenames).toEqual([]);
-      expect(result.error).toContain('network failure');
-    } finally {
-      fetchSpy.mockRestore();
-    }
-  });
-
-  it('uses authedRealmFetch with Accept: application/vnd.api+json', async () => {
-    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch');
-    try {
-      await listFiles(realmUrl, { profileManager });
-
-      expect(fetchSpy).toHaveBeenCalledOnce();
-      let [url, init] = fetchSpy.mock.calls[0];
-      expect(String(url)).toContain('_mtimes');
-      expect(init!.method).toBe('GET');
-      let headers = init!.headers as Record<string, string>;
-      expect(headers['Accept']).toBe('application/vnd.api+json');
-    } finally {
-      fetchSpy.mockRestore();
-    }
   });
 });


### PR DESCRIPTION
## Summary
- Adds `boxel file list --realm <url> [--json]` CLI command (alias: `boxel file ls`)
- Extracts `BoxelCLIClient.listFiles()` inline implementation into a standalone command function at `src/commands/file/list.ts`
- Client method now delegates to the command function

## Why — pattern consistency
The `pull` command already follows this pattern: a standalone exported function that both the CLI and `BoxelCLIClient` delegate to. This PR makes `listFiles()` consistent with that approach. Every `BoxelCLIClient` method should be backed by a command function that is the single source of truth — the client is a thin delegation layer. This enables CS-10670 (tool definitions) where boxel-cli publishes tool definitions that reference these commands directly.

Note: This lists files *within* a realm (via `_mtimes`), distinct from CS-10620 (`boxel realm list`) which lists the user's realms/workspaces.

## Test plan
- [x] Integration tests: seeds files, verifies filenames appear sorted, unreachable realm error, no-profile error
- [x] Build passes
- [ ] CI green

Closes CS-10849

🤖 Generated with [Claude Code](https://claude.com/claude-code)