### PR TITLE
CS-10853: Add `boxel realm cancel-indexing` command

### DIFF
--- a/packages/boxel-cli/src/commands/realm/cancel-indexing.ts
+++ b/packages/boxel-cli/src/commands/realm/cancel-indexing.ts
@@ -22,7 +22,10 @@ export function registerCancelIndexingCommand(realm: Command): void {
   realm
     .command('cancel-indexing')
     .description('Cancel all indexing jobs (running + pending) for a realm')
-    .requiredOption('--realm <realm-url>', 'URL of the realm to cancel indexing for')
+    .requiredOption(
+      '--realm <realm-url>',
+      'URL of the realm to cancel indexing for',
+    )
     .action(async (options: { realm: string }) => {
       let result = await cancelIndexing(options.realm);
       if (result.ok) {
@@ -30,9 +33,7 @@ export function registerCancelIndexingCommand(realm: Command): void {
           `${FG_GREEN}Cancelled indexing jobs for ${options.realm}${RESET}`,
         );
       } else {
-        console.error(
-          `${FG_RED}Error: ${result.error}${RESET}`,
-        );
+        console.error(`${FG_RED}Error: ${result.error}${RESET}`);
         process.exit(1);
       }
     });

--- a/packages/boxel-cli/src/commands/realm/cancel-indexing.ts
+++ b/packages/boxel-cli/src/commands/realm/cancel-indexing.ts
@@ -9,6 +9,8 @@ import { FG_GREEN, FG_RED, RESET } from '../../lib/colors';
 
 export interface CancelIndexingCommandOptions {
   profileManager?: ProfileManager;
+  /** Also cancel queued/pending jobs. Defaults to false (running-only). */
+  cancelPending?: boolean;
 }
 
 export interface CancelIndexingResult {
@@ -18,12 +20,16 @@ export interface CancelIndexingResult {
 
 interface CancelIndexingCliOptions {
   realm: string;
+  cancelPending?: boolean;
   json?: boolean;
 }
 
 /**
- * Cancel all indexing jobs (running + pending) for a realm.
- * Sends a POST to `<realmUrl>/_cancel-indexing-job` with `{ cancelPending: true }`.
+ * Cancel indexing jobs for a realm.
+ *
+ * Sends a POST to `<realmUrl>/_cancel-indexing-job` with `{ cancelPending }`.
+ * By default cancels only running jobs; pass `cancelPending: true` to also
+ * cancel queued/pending jobs.
  */
 export async function cancelIndexing(
   realmUrl: string,
@@ -38,6 +44,7 @@ export async function cancelIndexing(
     };
   }
 
+  let cancelPending = options?.cancelPending ?? false;
   let cancelUrl = `${ensureTrailingSlash(realmUrl)}_cancel-indexing-job`;
 
   try {
@@ -47,7 +54,7 @@ export async function cancelIndexing(
         Accept: 'application/json',
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ cancelPending: true }),
+      body: JSON.stringify({ cancelPending }),
     });
 
     if (!response.ok) {
@@ -70,14 +77,22 @@ export async function cancelIndexing(
 export function registerCancelIndexingCommand(realm: Command): void {
   realm
     .command('cancel-indexing')
-    .description('Cancel all indexing jobs (running + pending) for a realm')
+    .description(
+      'Cancel running indexing jobs for a realm (use --cancel-pending to also cancel queued jobs)',
+    )
     .requiredOption(
       '--realm <realm-url>',
       'URL of the realm to cancel indexing for',
     )
+    .option(
+      '--cancel-pending',
+      'Also cancel queued/pending indexing jobs (default: cancel running only)',
+    )
     .option('--json', 'Output raw JSON response')
     .action(async (opts: CancelIndexingCliOptions) => {
-      let result = await cancelIndexing(opts.realm);
+      let result = await cancelIndexing(opts.realm, {
+        cancelPending: opts.cancelPending,
+      });
 
       if (opts.json) {
         console.log(JSON.stringify(result, null, 2));
@@ -85,8 +100,9 @@ export function registerCancelIndexingCommand(realm: Command): void {
           process.exit(1);
         }
       } else if (result.ok) {
+        let scope = opts.cancelPending ? 'running and pending' : 'running';
         console.log(
-          `${FG_GREEN}Cancelled indexing jobs for ${opts.realm}${RESET}`,
+          `${FG_GREEN}Cancelled ${scope} indexing jobs for ${opts.realm}${RESET}`,
         );
       } else {
         console.error(`${FG_RED}Error:${RESET} ${result.error}`);

--- a/packages/boxel-cli/src/commands/realm/cancel-indexing.ts
+++ b/packages/boxel-cli/src/commands/realm/cancel-indexing.ts
@@ -1,13 +1,11 @@
 import type { Command } from 'commander';
 import {
   getProfileManager,
+  NO_ACTIVE_PROFILE_ERROR,
   type ProfileManager,
 } from '../../lib/profile-manager';
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { FG_GREEN, FG_RED, RESET } from '../../lib/colors';
-
-function ensureTrailingSlash(url: string): string {
-  return url.endsWith('/') ? url : `${url}/`;
-}
 
 export interface CancelIndexingCommandOptions {
   profileManager?: ProfileManager;
@@ -18,25 +16,9 @@ export interface CancelIndexingResult {
   error?: string;
 }
 
-export function registerCancelIndexingCommand(realm: Command): void {
-  realm
-    .command('cancel-indexing')
-    .description('Cancel all indexing jobs (running + pending) for a realm')
-    .requiredOption(
-      '--realm <realm-url>',
-      'URL of the realm to cancel indexing for',
-    )
-    .action(async (options: { realm: string }) => {
-      let result = await cancelIndexing(options.realm);
-      if (result.ok) {
-        console.log(
-          `${FG_GREEN}Cancelled indexing jobs for ${options.realm}${RESET}`,
-        );
-      } else {
-        console.error(`${FG_RED}Error: ${result.error}${RESET}`);
-        process.exit(1);
-      }
-    });
+interface CancelIndexingCliOptions {
+  realm: string;
+  json?: boolean;
 }
 
 /**
@@ -45,14 +27,14 @@ export function registerCancelIndexingCommand(realm: Command): void {
  */
 export async function cancelIndexing(
   realmUrl: string,
-  options: CancelIndexingCommandOptions = {},
+  options?: CancelIndexingCommandOptions,
 ): Promise<CancelIndexingResult> {
-  let pm = options.profileManager ?? getProfileManager();
+  let pm = options?.profileManager ?? getProfileManager();
   let active = pm.getActiveProfile();
   if (!active) {
     return {
       ok: false,
-      error: 'No active profile. Run `boxel profile add` to create one.',
+      error: NO_ACTIVE_PROFILE_ERROR,
     };
   }
 
@@ -69,7 +51,7 @@ export async function cancelIndexing(
     });
 
     if (!response.ok) {
-      let body = await response.text();
+      let body = await response.text().catch(() => '(no body)');
       return {
         ok: false,
         error: `HTTP ${response.status}: ${body.slice(0, 300)}`,
@@ -83,4 +65,32 @@ export async function cancelIndexing(
       error: err instanceof Error ? err.message : String(err),
     };
   }
+}
+
+export function registerCancelIndexingCommand(realm: Command): void {
+  realm
+    .command('cancel-indexing')
+    .description('Cancel all indexing jobs (running + pending) for a realm')
+    .requiredOption(
+      '--realm <realm-url>',
+      'URL of the realm to cancel indexing for',
+    )
+    .option('--json', 'Output raw JSON response')
+    .action(async (opts: CancelIndexingCliOptions) => {
+      let result = await cancelIndexing(opts.realm);
+
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        if (!result.ok) {
+          process.exit(1);
+        }
+      } else if (result.ok) {
+        console.log(
+          `${FG_GREEN}Cancelled indexing jobs for ${opts.realm}${RESET}`,
+        );
+      } else {
+        console.error(`${FG_RED}Error:${RESET} ${result.error}`);
+        process.exit(1);
+      }
+    });
 }

--- a/packages/boxel-cli/src/commands/realm/cancel-indexing.ts
+++ b/packages/boxel-cli/src/commands/realm/cancel-indexing.ts
@@ -1,0 +1,85 @@
+import type { Command } from 'commander';
+import {
+  getProfileManager,
+  type ProfileManager,
+} from '../../lib/profile-manager';
+import { FG_GREEN, FG_RED, RESET } from '../../lib/colors';
+
+function ensureTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
+export interface CancelIndexingCommandOptions {
+  profileManager?: ProfileManager;
+}
+
+export interface CancelIndexingResult {
+  ok: boolean;
+  error?: string;
+}
+
+export function registerCancelIndexingCommand(realm: Command): void {
+  realm
+    .command('cancel-indexing')
+    .description('Cancel all indexing jobs (running + pending) for a realm')
+    .requiredOption('--realm <realm-url>', 'URL of the realm to cancel indexing for')
+    .action(async (options: { realm: string }) => {
+      let result = await cancelIndexing(options.realm);
+      if (result.ok) {
+        console.log(
+          `${FG_GREEN}Cancelled indexing jobs for ${options.realm}${RESET}`,
+        );
+      } else {
+        console.error(
+          `${FG_RED}Error: ${result.error}${RESET}`,
+        );
+        process.exit(1);
+      }
+    });
+}
+
+/**
+ * Cancel all indexing jobs (running + pending) for a realm.
+ * Sends a POST to `<realmUrl>/_cancel-indexing-job` with `{ cancelPending: true }`.
+ */
+export async function cancelIndexing(
+  realmUrl: string,
+  options: CancelIndexingCommandOptions = {},
+): Promise<CancelIndexingResult> {
+  let pm = options.profileManager ?? getProfileManager();
+  let active = pm.getActiveProfile();
+  if (!active) {
+    return {
+      ok: false,
+      error: 'No active profile. Run `boxel profile add` to create one.',
+    };
+  }
+
+  let cancelUrl = `${ensureTrailingSlash(realmUrl)}_cancel-indexing-job`;
+
+  try {
+    let response = await pm.authedRealmFetch(cancelUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ cancelPending: true }),
+    });
+
+    if (!response.ok) {
+      let body = await response.text();
+      return {
+        ok: false,
+        error: `HTTP ${response.status}: ${body.slice(0, 300)}`,
+      };
+    }
+
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/packages/boxel-cli/src/commands/realm/index.ts
+++ b/packages/boxel-cli/src/commands/realm/index.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import { registerCancelIndexingCommand } from './cancel-indexing';
 import { registerCreateCommand } from './create';
 import { registerPullCommand } from './pull';
 import { registerPushCommand } from './push';
@@ -9,6 +10,7 @@ export function registerRealmCommand(program: Command): void {
     .command('realm')
     .description('Manage realms on the realm server');
 
+  registerCancelIndexingCommand(realm);
   registerCreateCommand(realm);
   registerPullCommand(realm);
   registerPushCommand(realm);

--- a/packages/boxel-cli/src/lib/boxel-cli-client.ts
+++ b/packages/boxel-cli/src/lib/boxel-cli-client.ts
@@ -14,6 +14,10 @@ import {
   type ReadTranspiledResult,
 } from '../commands/read-transpiled';
 import { write as coreWrite, type WriteResult } from '../commands/file/write';
+import {
+  cancelIndexing as coreCancelIndexing,
+  type CancelIndexingResult,
+} from '../commands/realm/cancel-indexing';
 import { createRealm as coreCreateRealm } from '../commands/realm/create';
 import { pull as realmPull } from '../commands/realm/pull';
 import { getProfileManager, type ProfileManager } from './profile-manager';
@@ -90,10 +94,7 @@ export interface AtomicResult {
   error?: string;
 }
 
-export interface CancelIndexingResult {
-  ok: boolean;
-  error?: string;
-}
+export type { CancelIndexingResult };
 
 export class BoxelCLIClient {
   private pm: ProfileManager;
@@ -405,33 +406,7 @@ export class BoxelCLIClient {
    * Cancel all indexing jobs (running + pending) for a realm.
    */
   async cancelAllIndexingJobs(realmUrl: string): Promise<CancelIndexingResult> {
-    let cancelUrl = `${ensureTrailingSlash(realmUrl)}_cancel-indexing-job`;
-
-    try {
-      let response = await this.pm.authedRealmFetch(cancelUrl, {
-        method: 'POST',
-        headers: {
-          Accept: MIME.JSON,
-          'Content-Type': MIME.JSON,
-        },
-        body: JSON.stringify({ cancelPending: true }),
-      });
-
-      if (!response.ok) {
-        let body = await response.text();
-        return {
-          ok: false,
-          error: `HTTP ${response.status}: ${body.slice(0, 300)}`,
-        };
-      }
-
-      return { ok: true };
-    } catch (err) {
-      return {
-        ok: false,
-        error: err instanceof Error ? err.message : String(err),
-      };
-    }
+    return coreCancelIndexing(realmUrl, { profileManager: this.pm });
   }
 
   /**

--- a/packages/boxel-cli/src/lib/boxel-cli-client.ts
+++ b/packages/boxel-cli/src/lib/boxel-cli-client.ts
@@ -406,7 +406,10 @@ export class BoxelCLIClient {
    * Cancel all indexing jobs (running + pending) for a realm.
    */
   async cancelAllIndexingJobs(realmUrl: string): Promise<CancelIndexingResult> {
-    return coreCancelIndexing(realmUrl, { profileManager: this.pm });
+    return coreCancelIndexing(realmUrl, {
+      profileManager: this.pm,
+      cancelPending: true,
+    });
   }
 
   /**

--- a/packages/boxel-cli/tests/integration/realm-cancel-indexing.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-cancel-indexing.test.ts
@@ -26,7 +26,10 @@ beforeAll(async () => {
   await setupTestProfile(profileManager);
 });
 
-afterAll(async () => { cleanupProfile?.(); await stopTestRealmServer(); });
+afterAll(async () => {
+  cleanupProfile?.();
+  await stopTestRealmServer();
+});
 
 describe('realm cancel-indexing (integration)', () => {
   it('cancels indexing on a running realm and returns ok', async () => {
@@ -36,7 +39,9 @@ describe('realm cancel-indexing (integration)', () => {
   });
 
   it('returns error for an unreachable realm', async () => {
-    let result = await cancelIndexing('http://127.0.0.1:1/fake/', { profileManager });
+    let result = await cancelIndexing('http://127.0.0.1:1/fake/', {
+      profileManager,
+    });
     expect(result.ok).toBe(false);
     expect(result.error).toBeDefined();
   });

--- a/packages/boxel-cli/tests/integration/realm-cancel-indexing.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-cancel-indexing.test.ts
@@ -46,12 +46,14 @@ describe('realm cancel-indexing (integration)', () => {
     expect(result.error).toBeDefined();
   });
 
-  it('throws when no active profile', async () => {
+  it('returns error result when no active profile', async () => {
     let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
     let emptyManager = new ProfileManager(emptyDir);
-    await expect(
-      cancelIndexing(realmUrl, { profileManager: emptyManager }),
-    ).rejects.toThrow('No active profile');
+    let result = await cancelIndexing(realmUrl, {
+      profileManager: emptyManager,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('No active profile');
     fs.rmSync(emptyDir, { recursive: true, force: true });
   });
 });

--- a/packages/boxel-cli/tests/integration/realm-cancel-indexing.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-cancel-indexing.test.ts
@@ -1,0 +1,71 @@
+import '../helpers/setup-realm-server';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { cancelIndexing } from '../../src/commands/realm/cancel-indexing';
+import { ProfileManager } from '../../src/lib/profile-manager';
+import {
+  startTestRealmServer,
+  stopTestRealmServer,
+  createTestProfileDir,
+  setupTestProfile,
+  TEST_REALM_SERVER_URL,
+} from '../helpers/integration';
+
+let profileManager: ProfileManager;
+let cleanupProfile: () => void;
+let realmUrl: string;
+
+beforeAll(async () => {
+  await startTestRealmServer();
+  realmUrl = `${TEST_REALM_SERVER_URL}/test/`;
+  let testProfile = createTestProfileDir();
+  profileManager = testProfile.profileManager;
+  cleanupProfile = testProfile.cleanup;
+  await setupTestProfile(profileManager);
+});
+
+afterAll(async () => { cleanupProfile?.(); await stopTestRealmServer(); });
+
+describe('realm cancel-indexing (integration)', () => {
+  it('sends POST to _cancel-indexing-job with cancelPending: true', async () => {
+    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch');
+    try {
+      await cancelIndexing(realmUrl, { profileManager });
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      let [url, init] = fetchSpy.mock.calls[0];
+      expect(String(url)).toContain('_cancel-indexing-job');
+      expect(init!.method).toBe('POST');
+      let body = JSON.parse(init!.body as string);
+      expect(body).toEqual({ cancelPending: true });
+    } finally { fetchSpy.mockRestore(); }
+  });
+
+  it('returns error when no active profile', async () => {
+    let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
+    let emptyManager = new ProfileManager(emptyDir);
+    let result = await cancelIndexing(realmUrl, { profileManager: emptyManager });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('No active profile');
+    fs.rmSync(emptyDir, { recursive: true, force: true });
+  });
+
+  it('returns error when fetch throws', async () => {
+    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch').mockRejectedValueOnce(new Error('network failure'));
+    try {
+      let result = await cancelIndexing(realmUrl, { profileManager });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('network failure');
+    } finally { fetchSpy.mockRestore(); }
+  });
+
+  it('returns error on non-2xx response', async () => {
+    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch').mockResolvedValueOnce(new Response('Server Error', { status: 500 }));
+    try {
+      let result = await cancelIndexing(realmUrl, { profileManager });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('500');
+    } finally { fetchSpy.mockRestore(); }
+  });
+});

--- a/packages/boxel-cli/tests/integration/realm-cancel-indexing.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-cancel-indexing.test.ts
@@ -1,5 +1,5 @@
 import '../helpers/setup-realm-server';
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -44,6 +44,43 @@ describe('realm cancel-indexing (integration)', () => {
     });
     expect(result.ok).toBe(false);
     expect(result.error).toBeDefined();
+  });
+
+  it('POSTs `{ cancelPending: true }` to the cancel-indexing endpoint', async () => {
+    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch');
+    try {
+      await cancelIndexing(realmUrl, { profileManager });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      let [url, init] = fetchSpy.mock.calls[0];
+      expect(String(url)).toBe(`${realmUrl}_cancel-indexing-job`);
+      expect(init!.method).toBe('POST');
+      let headers = init!.headers as Record<string, string>;
+      expect(headers['Content-Type']).toBe('application/json');
+      expect(headers['Accept']).toBe('application/json');
+      expect(JSON.parse(init!.body as string)).toEqual({ cancelPending: true });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('returns an error with HTTP status when the realm responds non-2xx', async () => {
+    let fetchSpy = vi
+      .spyOn(profileManager, 'authedRealmFetch')
+      .mockResolvedValueOnce(
+        new Response('forbidden', {
+          status: 403,
+          statusText: 'Forbidden',
+        }),
+      );
+    try {
+      let result = await cancelIndexing(realmUrl, { profileManager });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('HTTP 403');
+      expect(result.error).toContain('forbidden');
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it('returns error result when no active profile', async () => {

--- a/packages/boxel-cli/tests/integration/realm-cancel-indexing.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-cancel-indexing.test.ts
@@ -1,5 +1,5 @@
 import '../helpers/setup-realm-server';
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -29,43 +29,24 @@ beforeAll(async () => {
 afterAll(async () => { cleanupProfile?.(); await stopTestRealmServer(); });
 
 describe('realm cancel-indexing (integration)', () => {
-  it('sends POST to _cancel-indexing-job with cancelPending: true', async () => {
-    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch');
-    try {
-      await cancelIndexing(realmUrl, { profileManager });
-      expect(fetchSpy).toHaveBeenCalledOnce();
-      let [url, init] = fetchSpy.mock.calls[0];
-      expect(String(url)).toContain('_cancel-indexing-job');
-      expect(init!.method).toBe('POST');
-      let body = JSON.parse(init!.body as string);
-      expect(body).toEqual({ cancelPending: true });
-    } finally { fetchSpy.mockRestore(); }
+  it('cancels indexing on a running realm and returns ok', async () => {
+    let result = await cancelIndexing(realmUrl, { profileManager });
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeUndefined();
   });
 
-  it('returns error when no active profile', async () => {
+  it('returns error for an unreachable realm', async () => {
+    let result = await cancelIndexing('http://127.0.0.1:1/fake/', { profileManager });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('throws when no active profile', async () => {
     let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
     let emptyManager = new ProfileManager(emptyDir);
-    let result = await cancelIndexing(realmUrl, { profileManager: emptyManager });
-    expect(result.ok).toBe(false);
-    expect(result.error).toContain('No active profile');
+    await expect(
+      cancelIndexing(realmUrl, { profileManager: emptyManager }),
+    ).rejects.toThrow('No active profile');
     fs.rmSync(emptyDir, { recursive: true, force: true });
-  });
-
-  it('returns error when fetch throws', async () => {
-    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch').mockRejectedValueOnce(new Error('network failure'));
-    try {
-      let result = await cancelIndexing(realmUrl, { profileManager });
-      expect(result.ok).toBe(false);
-      expect(result.error).toContain('network failure');
-    } finally { fetchSpy.mockRestore(); }
-  });
-
-  it('returns error on non-2xx response', async () => {
-    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch').mockResolvedValueOnce(new Response('Server Error', { status: 500 }));
-    try {
-      let result = await cancelIndexing(realmUrl, { profileManager });
-      expect(result.ok).toBe(false);
-      expect(result.error).toContain('500');
-    } finally { fetchSpy.mockRestore(); }
   });
 });

--- a/packages/boxel-cli/tests/integration/realm-cancel-indexing.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-cancel-indexing.test.ts
@@ -46,7 +46,7 @@ describe('realm cancel-indexing (integration)', () => {
     expect(result.error).toBeDefined();
   });
 
-  it('POSTs `{ cancelPending: true }` to the cancel-indexing endpoint', async () => {
+  it('POSTs `{ cancelPending: false }` by default (running-only)', async () => {
     let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch');
     try {
       await cancelIndexing(realmUrl, { profileManager });
@@ -58,6 +58,24 @@ describe('realm cancel-indexing (integration)', () => {
       let headers = init!.headers as Record<string, string>;
       expect(headers['Content-Type']).toBe('application/json');
       expect(headers['Accept']).toBe('application/json');
+      expect(JSON.parse(init!.body as string)).toEqual({
+        cancelPending: false,
+      });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('POSTs `{ cancelPending: true }` when cancelPending option is set', async () => {
+    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch');
+    try {
+      await cancelIndexing(realmUrl, {
+        profileManager,
+        cancelPending: true,
+      });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      let [, init] = fetchSpy.mock.calls[0];
       expect(JSON.parse(init!.body as string)).toEqual({ cancelPending: true });
     } finally {
       fetchSpy.mockRestore();


### PR DESCRIPTION
## Summary
- Extract cancel-indexing logic from `BoxelCLIClient.cancelAllIndexingJobs()` into a standalone command module at `packages/boxel-cli/src/commands/realm/cancel-indexing.ts`
- Register `boxel realm cancel-indexing --realm <url>` as a CLI subcommand
- Export `cancelIndexing(realmUrl, options?)` for programmatic use
- Refactor `BoxelCLIClient.cancelAllIndexingJobs()` to delegate to the new standalone function
- Add integration tests covering: correct POST body, no-profile error, fetch failure, and non-2xx response handling

## Test plan
- [ ] Integration tests pass in CI (requires Synapse/Matrix infrastructure)
- [ ] `boxel realm cancel-indexing --realm <url>` works from the CLI
- [ ] Existing `BoxelCLIClient.cancelAllIndexingJobs()` callers continue to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)