### PR TITLE
CS-10851: Add `boxel file lint` command

### DIFF
--- a/packages/boxel-cli/src/commands/file/index.ts
+++ b/packages/boxel-cli/src/commands/file/index.ts
@@ -1,5 +1,6 @@
 import type { Command } from 'commander';
 import { registerDeleteCommand } from './delete';
+import { registerLintCommand } from './lint';
 import { registerWriteCommand } from './write';
 
 export function registerFileCommand(program: Command): void {
@@ -8,5 +9,6 @@ export function registerFileCommand(program: Command): void {
     .description('Read, write, search, and manage files in a realm');
 
   registerDeleteCommand(file);
+  registerLintCommand(file);
   registerWriteCommand(file);
 }

--- a/packages/boxel-cli/src/commands/file/lint.ts
+++ b/packages/boxel-cli/src/commands/file/lint.ts
@@ -1,19 +1,14 @@
 import type { Command } from 'commander';
-import { readFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import {
   getProfileManager,
+  NO_ACTIVE_PROFILE_ERROR,
   type ProfileManager,
 } from '../../lib/profile-manager';
-import { FG_RED, FG_YELLOW, DIM, RESET } from '../../lib/colors';
-
-const MIME = {
-  CardSource: 'application/vnd.card+source',
-  JSON: 'application/json',
-} as const;
-
-function ensureTrailingSlash(url: string): string {
-  return url.endsWith('/') ? url : `${url}/`;
-}
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
+import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
+import { FG_GREEN, FG_RED, FG_YELLOW, DIM, RESET } from '../../lib/colors';
+import { write } from './write';
 
 export interface LintMessage {
   ruleId: string | null;
@@ -26,9 +21,11 @@ export interface LintMessage {
 }
 
 export interface LintResult {
-  fixed: boolean;
-  output: string;
-  messages: LintMessage[];
+  ok: boolean;
+  error?: string;
+  fixed?: boolean;
+  output?: string;
+  messages?: LintMessage[];
 }
 
 export interface LintCommandOptions {
@@ -42,7 +39,7 @@ export interface LintCommandOptions {
  * `X-HTTP-Method-Override: QUERY` headers. Returns the lint result
  * containing messages and optionally auto-fixed output.
  *
- * Throws on HTTP errors (different from read/write which return error objects).
+ * Uses the per-realm JWT via `ProfileManager.authedRealmFetch`.
  */
 export async function lint(
   realmUrl: string,
@@ -53,40 +50,63 @@ export async function lint(
   let pm = options?.profileManager ?? getProfileManager();
   let active = pm.getActiveProfile();
   if (!active) {
-    throw new Error(
-      'No active profile. Run `boxel profile add` to create one.',
-    );
+    return {
+      ok: false,
+      error: NO_ACTIVE_PROFILE_ERROR,
+    };
   }
 
   let lintUrl = `${ensureTrailingSlash(realmUrl)}_lint`;
-  let response = await pm.authedRealmFetch(lintUrl, {
-    method: 'POST',
-    headers: {
-      Accept: MIME.JSON,
-      'Content-Type': MIME.CardSource,
-      'X-Filename': filename,
-      'X-HTTP-Method-Override': 'QUERY',
-    },
-    body: source,
-  });
 
-  if (!response.ok) {
-    let body = await response.text().catch(() => '(no body)');
-    throw new Error(
-      `_lint returned HTTP ${response.status}: ${body.slice(0, 300)}`,
-    );
+  try {
+    let response = await pm.authedRealmFetch(lintUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': SupportedMimeType.CardSource,
+        'X-Filename': filename,
+        'X-HTTP-Method-Override': 'QUERY',
+      },
+      body: source,
+    });
+
+    if (!response.ok) {
+      let body = await response.text().catch(() => '(no body)');
+      return {
+        ok: false,
+        error: `HTTP ${response.status}: ${body.slice(0, 300)}`,
+      };
+    }
+
+    let json = (await response.json()) as {
+      fixed: boolean;
+      output: string;
+      messages: LintMessage[];
+    };
+
+    return {
+      ok: true,
+      fixed: json.fixed,
+      output: json.output,
+      messages: json.messages,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
   }
-
-  return (await response.json()) as LintResult;
 }
 
 interface LintCliOptions {
   realm: string;
   file?: string;
+  json?: boolean;
+  fix?: boolean;
 }
 
-export function registerLintCommand(file: Command): void {
-  file
+export function registerLintCommand(parent: Command): void {
+  parent
     .command('lint')
     .description('Lint a file in a realm using the realm lint endpoint')
     .argument('<path>', 'Realm-relative file path to lint (e.g., my-card.gts)')
@@ -95,7 +115,16 @@ export function registerLintCommand(file: Command): void {
       '--file <local-filepath>',
       'Read source from a local file instead of fetching from the realm',
     )
+    .option('--json', 'Output raw JSON response')
+    .option('--fix', 'Write auto-fixed output back to the source')
     .action(async (filePath: string, opts: LintCliOptions) => {
+      let pm = getProfileManager();
+      let active = pm.getActiveProfile();
+      if (!active) {
+        console.error(`${FG_RED}Error:${RESET} ${NO_ACTIVE_PROFILE_ERROR}`);
+        process.exit(1);
+      }
+
       let source: string;
 
       if (opts.file) {
@@ -108,13 +137,11 @@ export function registerLintCommand(file: Command): void {
           process.exit(1);
         }
       } else {
-        // Fetch source from realm using read
-        let pm = getProfileManager();
         let readUrl = new URL(filePath, ensureTrailingSlash(opts.realm)).href;
         try {
           let response = await pm.authedRealmFetch(readUrl, {
             method: 'GET',
-            headers: { Accept: MIME.CardSource },
+            headers: { Accept: SupportedMimeType.CardSource },
           });
           if (!response.ok) {
             let body = await response.text().catch(() => '(no body)');
@@ -134,7 +161,9 @@ export function registerLintCommand(file: Command): void {
 
       let result: LintResult;
       try {
-        result = await lint(opts.realm, source, filePath);
+        result = await lint(opts.realm, source, filePath, {
+          profileManager: pm,
+        });
       } catch (err) {
         console.error(
           `${FG_RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}`,
@@ -142,15 +171,50 @@ export function registerLintCommand(file: Command): void {
         process.exit(1);
       }
 
-      let errors = result.messages.filter((m) => m.severity === 2);
-      let warnings = result.messages.filter((m) => m.severity === 1);
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        if (!result.ok) {
+          process.exit(1);
+        }
+        return;
+      }
 
-      if (result.messages.length === 0) {
+      if (!result.ok) {
+        console.error(`${FG_RED}Error:${RESET} ${result.error}`);
+        process.exit(1);
+      }
+
+      // Handle --fix: write fixed output back to the source
+      if (opts.fix && result.fixed && result.output) {
+        if (opts.file) {
+          writeFileSync(opts.file, result.output, 'utf-8');
+          console.log(`${FG_GREEN}Fixed:${RESET} ${opts.file}`);
+        } else {
+          let writeResult = await write(opts.realm, filePath, result.output, {
+            profileManager: pm,
+          });
+          if (!writeResult.ok) {
+            console.error(
+              `${FG_RED}Error:${RESET} Could not write fixed file: ${writeResult.error}`,
+            );
+            process.exit(1);
+          }
+          console.log(
+            `${FG_GREEN}Fixed:${RESET} ${filePath} ${DIM}→${RESET} ${opts.realm}`,
+          );
+        }
+      }
+
+      let messages = result.messages ?? [];
+      let errors = messages.filter((m) => m.severity === 2);
+      let warnings = messages.filter((m) => m.severity === 1);
+
+      if (messages.length === 0) {
         console.log(`${DIM}No lint issues found.${RESET}`);
         return;
       }
 
-      for (let msg of result.messages) {
+      for (let msg of messages) {
         let color = msg.severity === 2 ? FG_RED : FG_YELLOW;
         let level = msg.severity === 2 ? 'error' : 'warning';
         let rule = msg.ruleId ? ` (${msg.ruleId})` : '';

--- a/packages/boxel-cli/src/commands/file/lint.ts
+++ b/packages/boxel-cli/src/commands/file/lint.ts
@@ -89,10 +89,7 @@ export function registerLintCommand(file: Command): void {
   file
     .command('lint')
     .description('Lint a file in a realm using the realm lint endpoint')
-    .argument(
-      '<path>',
-      'Realm-relative file path to lint (e.g., my-card.gts)',
-    )
+    .argument('<path>', 'Realm-relative file path to lint (e.g., my-card.gts)')
     .requiredOption('--realm <realm-url>', 'The realm URL to lint against')
     .option(
       '--file <local-filepath>',
@@ -113,10 +110,7 @@ export function registerLintCommand(file: Command): void {
       } else {
         // Fetch source from realm using read
         let pm = getProfileManager();
-        let readUrl = new URL(
-          filePath,
-          ensureTrailingSlash(opts.realm),
-        ).href;
+        let readUrl = new URL(filePath, ensureTrailingSlash(opts.realm)).href;
         try {
           let response = await pm.authedRealmFetch(readUrl, {
             method: 'GET',

--- a/packages/boxel-cli/src/commands/file/lint.ts
+++ b/packages/boxel-cli/src/commands/file/lint.ts
@@ -1,0 +1,176 @@
+import type { Command } from 'commander';
+import { readFileSync } from 'fs';
+import {
+  getProfileManager,
+  type ProfileManager,
+} from '../../lib/profile-manager';
+import { FG_RED, FG_YELLOW, DIM, RESET } from '../../lib/colors';
+
+const MIME = {
+  CardSource: 'application/vnd.card+source',
+  JSON: 'application/json',
+} as const;
+
+function ensureTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
+export interface LintMessage {
+  ruleId: string | null;
+  severity: 1 | 2;
+  message: string;
+  line: number;
+  column: number;
+  endLine?: number;
+  endColumn?: number;
+}
+
+export interface LintResult {
+  fixed: boolean;
+  output: string;
+  messages: LintMessage[];
+}
+
+export interface LintCommandOptions {
+  profileManager?: ProfileManager;
+}
+
+/**
+ * Lint a single file's source code via the realm's `_lint` endpoint.
+ *
+ * Sends the source to `POST <realmUrl>/_lint` with `X-Filename` and
+ * `X-HTTP-Method-Override: QUERY` headers. Returns the lint result
+ * containing messages and optionally auto-fixed output.
+ *
+ * Throws on HTTP errors (different from read/write which return error objects).
+ */
+export async function lint(
+  realmUrl: string,
+  source: string,
+  filename: string,
+  options?: LintCommandOptions,
+): Promise<LintResult> {
+  let pm = options?.profileManager ?? getProfileManager();
+  let active = pm.getActiveProfile();
+  if (!active) {
+    throw new Error(
+      'No active profile. Run `boxel profile add` to create one.',
+    );
+  }
+
+  let lintUrl = `${ensureTrailingSlash(realmUrl)}_lint`;
+  let response = await pm.authedRealmFetch(lintUrl, {
+    method: 'POST',
+    headers: {
+      Accept: MIME.JSON,
+      'Content-Type': MIME.CardSource,
+      'X-Filename': filename,
+      'X-HTTP-Method-Override': 'QUERY',
+    },
+    body: source,
+  });
+
+  if (!response.ok) {
+    let body = await response.text().catch(() => '(no body)');
+    throw new Error(
+      `_lint returned HTTP ${response.status}: ${body.slice(0, 300)}`,
+    );
+  }
+
+  return (await response.json()) as LintResult;
+}
+
+interface LintCliOptions {
+  realm: string;
+  file?: string;
+}
+
+export function registerLintCommand(file: Command): void {
+  file
+    .command('lint')
+    .description('Lint a file in a realm using the realm lint endpoint')
+    .argument(
+      '<path>',
+      'Realm-relative file path to lint (e.g., my-card.gts)',
+    )
+    .requiredOption('--realm <realm-url>', 'The realm URL to lint against')
+    .option(
+      '--file <local-filepath>',
+      'Read source from a local file instead of fetching from the realm',
+    )
+    .action(async (filePath: string, opts: LintCliOptions) => {
+      let source: string;
+
+      if (opts.file) {
+        try {
+          source = readFileSync(opts.file, 'utf-8');
+        } catch (err) {
+          console.error(
+            `${FG_RED}Error:${RESET} Could not read local file: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          process.exit(1);
+        }
+      } else {
+        // Fetch source from realm using read
+        let pm = getProfileManager();
+        let readUrl = new URL(
+          filePath,
+          ensureTrailingSlash(opts.realm),
+        ).href;
+        try {
+          let response = await pm.authedRealmFetch(readUrl, {
+            method: 'GET',
+            headers: { Accept: MIME.CardSource },
+          });
+          if (!response.ok) {
+            let body = await response.text().catch(() => '(no body)');
+            console.error(
+              `${FG_RED}Error:${RESET} Could not read file from realm: HTTP ${response.status}: ${body.slice(0, 300)}`,
+            );
+            process.exit(1);
+          }
+          source = await response.text();
+        } catch (err) {
+          console.error(
+            `${FG_RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}`,
+          );
+          process.exit(1);
+        }
+      }
+
+      let result: LintResult;
+      try {
+        result = await lint(opts.realm, source, filePath);
+      } catch (err) {
+        console.error(
+          `${FG_RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      let errors = result.messages.filter((m) => m.severity === 2);
+      let warnings = result.messages.filter((m) => m.severity === 1);
+
+      if (result.messages.length === 0) {
+        console.log(`${DIM}No lint issues found.${RESET}`);
+        return;
+      }
+
+      for (let msg of result.messages) {
+        let color = msg.severity === 2 ? FG_RED : FG_YELLOW;
+        let level = msg.severity === 2 ? 'error' : 'warning';
+        let rule = msg.ruleId ? ` (${msg.ruleId})` : '';
+        console.log(
+          `${color}${level}${RESET} ${msg.line}:${msg.column} ${msg.message}${DIM}${rule}${RESET}`,
+        );
+      }
+
+      console.log(
+        `\n${DIM}${errors.length} error(s), ${warnings.length} warning(s)${RESET}`,
+      );
+
+      if (errors.length > 0) {
+        process.exit(1);
+      }
+    });
+}

--- a/packages/boxel-cli/src/lib/boxel-cli-client.ts
+++ b/packages/boxel-cli/src/lib/boxel-cli-client.ts
@@ -1,5 +1,10 @@
 import { deleteFile, type DeleteResult } from '../commands/file/delete';
 import {
+  lint as coreLint,
+  type LintResult,
+  type LintMessage,
+} from '../commands/file/lint';
+import {
   readTranspiledModule,
   type ReadTranspiledResult,
 } from '../commands/read-transpiled';
@@ -80,21 +85,7 @@ export interface RunCommandResult {
   error?: string | null;
 }
 
-export interface LintMessage {
-  ruleId: string | null;
-  severity: 1 | 2;
-  message: string;
-  line: number;
-  column: number;
-  endLine?: number;
-  endColumn?: number;
-}
-
-export interface LintResult {
-  fixed: boolean;
-  output: string;
-  messages: LintMessage[];
-}
+export type { LintMessage, LintResult };
 
 export interface WaitForReadyResult {
   ready: boolean;
@@ -387,32 +378,14 @@ export class BoxelCLIClient {
 
   /**
    * Lint a single file's source code via the realm's `_lint` endpoint.
+   * Delegates to the standalone `lint()` in `commands/file/lint.ts`.
    */
   async lint(
     realmUrl: string,
     source: string,
     filename: string,
   ): Promise<LintResult> {
-    let lintUrl = `${ensureTrailingSlash(realmUrl)}_lint`;
-    let response = await this.pm.authedRealmFetch(lintUrl, {
-      method: 'POST',
-      headers: {
-        Accept: MIME.JSON,
-        'Content-Type': MIME.CardSource,
-        'X-Filename': filename,
-        'X-HTTP-Method-Override': 'QUERY',
-      },
-      body: source,
-    });
-
-    if (!response.ok) {
-      let body = await response.text().catch(() => '(no body)');
-      throw new Error(
-        `_lint returned HTTP ${response.status}: ${body.slice(0, 300)}`,
-      );
-    }
-
-    return (await response.json()) as LintResult;
+    return coreLint(realmUrl, source, filename, { profileManager: this.pm });
   }
 
   /**

--- a/packages/boxel-cli/tests/integration/file-lint.test.ts
+++ b/packages/boxel-cli/tests/integration/file-lint.test.ts
@@ -26,7 +26,10 @@ beforeAll(async () => {
   await setupTestProfile(profileManager);
 });
 
-afterAll(async () => { cleanupProfile?.(); await stopTestRealmServer(); });
+afterAll(async () => {
+  cleanupProfile?.();
+  await stopTestRealmServer();
+});
 
 describe('file lint (integration)', () => {
   it('lints source via the realm _lint endpoint and returns a result', async () => {
@@ -42,7 +45,9 @@ describe('file lint (integration)', () => {
     let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
     let emptyManager = new ProfileManager(emptyDir);
     await expect(
-      lint(realmUrl, 'let x = 1;', 'test.gts', { profileManager: emptyManager }),
+      lint(realmUrl, 'let x = 1;', 'test.gts', {
+        profileManager: emptyManager,
+      }),
     ).rejects.toThrow('No active profile');
     fs.rmSync(emptyDir, { recursive: true, force: true });
   });

--- a/packages/boxel-cli/tests/integration/file-lint.test.ts
+++ b/packages/boxel-cli/tests/integration/file-lint.test.ts
@@ -1,0 +1,68 @@
+import '../helpers/setup-realm-server';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { lint } from '../../src/commands/file/lint';
+import { ProfileManager } from '../../src/lib/profile-manager';
+import {
+  startTestRealmServer,
+  stopTestRealmServer,
+  createTestProfileDir,
+  setupTestProfile,
+  TEST_REALM_SERVER_URL,
+} from '../helpers/integration';
+
+let profileManager: ProfileManager;
+let cleanupProfile: () => void;
+let realmUrl: string;
+
+beforeAll(async () => {
+  await startTestRealmServer();
+  realmUrl = `${TEST_REALM_SERVER_URL}/test/`;
+  let testProfile = createTestProfileDir();
+  profileManager = testProfile.profileManager;
+  cleanupProfile = testProfile.cleanup;
+  await setupTestProfile(profileManager);
+});
+
+afterAll(async () => { cleanupProfile?.(); await stopTestRealmServer(); });
+
+describe('file lint (integration)', () => {
+  it('sends POST to _lint with correct headers and body', async () => {
+    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch');
+    try {
+      await lint(realmUrl, 'let x = 1;', 'test.gts', { profileManager });
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      let [url, init] = fetchSpy.mock.calls[0];
+      expect(String(url)).toContain('_lint');
+      expect(init!.method).toBe('POST');
+      let headers = init!.headers as Record<string, string>;
+      expect(headers['X-Filename']).toBe('test.gts');
+      expect(headers['X-HTTP-Method-Override']).toBe('QUERY');
+      expect(headers['Content-Type']).toBe('application/vnd.card+source');
+      expect(init!.body).toBe('let x = 1;');
+    } finally { fetchSpy.mockRestore(); }
+  });
+
+  it('throws when no active profile', async () => {
+    let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
+    let emptyManager = new ProfileManager(emptyDir);
+    await expect(lint(realmUrl, 'let x = 1;', 'test.gts', { profileManager: emptyManager })).rejects.toThrow('No active profile');
+    fs.rmSync(emptyDir, { recursive: true, force: true });
+  });
+
+  it('throws on non-2xx response', async () => {
+    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch').mockResolvedValueOnce(new Response('Server Error', { status: 500 }));
+    try {
+      await expect(lint(realmUrl, 'let x = 1;', 'test.gts', { profileManager })).rejects.toThrow('500');
+    } finally { fetchSpy.mockRestore(); }
+  });
+
+  it('throws when fetch fails', async () => {
+    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch').mockRejectedValueOnce(new Error('network failure'));
+    try {
+      await expect(lint(realmUrl, 'let x = 1;', 'test.gts', { profileManager })).rejects.toThrow('network failure');
+    } finally { fetchSpy.mockRestore(); }
+  });
+});

--- a/packages/boxel-cli/tests/integration/file-lint.test.ts
+++ b/packages/boxel-cli/tests/integration/file-lint.test.ts
@@ -4,26 +4,43 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { lint } from '../../src/commands/file/lint';
+import { write } from '../../src/commands/file/write';
+import { createRealm } from '../../src/commands/realm/create';
 import { ProfileManager } from '../../src/lib/profile-manager';
 import {
   startTestRealmServer,
   stopTestRealmServer,
   createTestProfileDir,
   setupTestProfile,
-  TEST_REALM_SERVER_URL,
+  uniqueRealmName,
 } from '../helpers/integration';
 
 let profileManager: ProfileManager;
 let cleanupProfile: () => void;
 let realmUrl: string;
 
+async function createTestRealm(): Promise<string> {
+  let name = uniqueRealmName();
+  await createRealm(name, `Test ${name}`, { profileManager });
+
+  let realmTokens =
+    profileManager.getActiveProfile()!.profile.realmTokens ?? {};
+  let entry = Object.entries(realmTokens).find(([url]) => url.includes(name));
+  if (!entry) {
+    throw new Error(`No realm JWT stored for ${name}`);
+  }
+  return entry[0];
+}
+
 beforeAll(async () => {
   await startTestRealmServer();
-  realmUrl = `${TEST_REALM_SERVER_URL}/test/`;
+
   let testProfile = createTestProfileDir();
   profileManager = testProfile.profileManager;
   cleanupProfile = testProfile.cleanup;
   await setupTestProfile(profileManager);
+
+  realmUrl = await createTestRealm();
 });
 
 afterAll(async () => {
@@ -36,19 +53,167 @@ describe('file lint (integration)', () => {
     let source = 'export const x = 1;\n';
     let result = await lint(realmUrl, source, 'test.gts', { profileManager });
 
+    expect(result.ok).toBe(true);
     expect(result).toHaveProperty('messages');
     expect(Array.isArray(result.messages)).toBe(true);
     expect(result).toHaveProperty('output');
   });
 
-  it('throws when no active profile', async () => {
+  it('returns fixed output for source with formatting issues', async () => {
+    let source = `import{CardDef}from 'https://cardstack.com/base/card-api';
+export class MyCard extends CardDef {
+@field name = contains(StringField);
+}
+`;
+    let result = await lint(realmUrl, source, 'test.gts', { profileManager });
+
+    expect(result.ok).toBe(true);
+    expect(result.fixed).toBe(true);
+    expect(result.output).toBeDefined();
+    // ESLint should add the missing StringField import
+    expect(result.output).toContain('import StringField from');
+    // Prettier should fix indentation
+    expect(result.output).toContain('  @field name = contains(StringField);');
+  });
+
+  it('returns fixed output with proper single-quote formatting', async () => {
+    let source = `import { CardDef } from "https://cardstack.com/base/card-api";
+export class MyCard extends CardDef {
+@field name = contains(StringField);
+}
+`;
+    let result = await lint(realmUrl, source, 'test.gts', { profileManager });
+
+    expect(result.ok).toBe(true);
+    expect(result.fixed).toBe(true);
+    expect(result.output).toBeDefined();
+    // Prettier should convert double quotes to single quotes
+    expect(result.output).toContain("'https://cardstack.com/base/card-api'");
+  });
+
+  it('reports lint messages for unfixable issues', async () => {
+    let source = `import { CardDef } from 'https://cardstack.com/base/card-api';
+export class MyCard extends CardDef {
+}
+<template>
+  <div class="my-card">Hello</div>
+  <style scoped>
+    .my-card {
+      position: fixed;
+      top: 0;
+    }
+  </style>
+</template>
+`;
+    let result = await lint(realmUrl, source, 'test.gts', { profileManager });
+
+    expect(result.ok).toBe(true);
+    expect(result.messages).toBeDefined();
+    let positionFixedWarning = result.messages!.find(
+      (m) => m.ruleId === '@cardstack/boxel/no-css-position-fixed',
+    );
+    expect(positionFixedWarning).toBeDefined();
+    expect(positionFixedWarning!.severity).toBe(1);
+  });
+
+  describe('--fix with --file (local file)', () => {
+    it('writes fixed output back to a local file', async () => {
+      let unfixedSource = `import{CardDef}from 'https://cardstack.com/base/card-api';
+export class MyCard extends CardDef {
+@field name = contains(StringField);
+}
+`;
+      let tmpFile = path.join(
+        fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-fix-')),
+        'test-card.gts',
+      );
+      fs.writeFileSync(tmpFile, unfixedSource, 'utf-8');
+
+      try {
+        let source = fs.readFileSync(tmpFile, 'utf-8');
+        let result = await lint(realmUrl, source, 'test-card.gts', {
+          profileManager,
+        });
+
+        expect(result.ok).toBe(true);
+        expect(result.fixed).toBe(true);
+        expect(result.output).toBeDefined();
+
+        // Simulate what the CLI --fix does for local files
+        fs.writeFileSync(tmpFile, result.output!, 'utf-8');
+
+        let fixedContent = fs.readFileSync(tmpFile, 'utf-8');
+        expect(fixedContent).toContain('import StringField from');
+        expect(fixedContent).toContain(
+          '  @field name = contains(StringField);',
+        );
+
+        // Lint the fixed content again — should have no more fixable changes
+        let secondPass = await lint(realmUrl, fixedContent, 'test-card.gts', {
+          profileManager,
+        });
+        expect(secondPass.ok).toBe(true);
+        expect(secondPass.fixed).toBe(false);
+      } finally {
+        fs.rmSync(path.dirname(tmpFile), { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('--fix without --file (realm file)', () => {
+    it('writes fixed output back to the realm via write()', async () => {
+      let unfixedSource = `import{CardDef}from 'https://cardstack.com/base/card-api';
+export class MyCard extends CardDef {
+@field name = contains(StringField);
+}
+`;
+      let filePath = 'fix-test-card.gts';
+
+      // Upload unfixed source to the realm
+      let uploadResult = await write(realmUrl, filePath, unfixedSource, {
+        profileManager,
+      });
+      expect(uploadResult.ok).toBe(true);
+
+      // Lint it
+      let result = await lint(realmUrl, unfixedSource, filePath, {
+        profileManager,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.fixed).toBe(true);
+      expect(result.output).toBeDefined();
+
+      // Simulate what the CLI --fix does for realm files
+      let writeResult = await write(realmUrl, filePath, result.output!, {
+        profileManager,
+      });
+      expect(writeResult.ok).toBe(true);
+
+      // Read the file back from the realm and verify it's fixed
+      let readUrl = new URL(filePath, realmUrl).href;
+      let response = await profileManager.authedRealmFetch(readUrl, {
+        method: 'GET',
+        headers: { Accept: 'application/vnd.card+source' },
+      });
+      expect(response.ok).toBe(true);
+      let fixedContent = await response.text();
+      expect(fixedContent).toContain('import StringField from');
+      expect(fixedContent).toContain('  @field name = contains(StringField);');
+    });
+  });
+
+  it('returns error result when no active profile', async () => {
     let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
     let emptyManager = new ProfileManager(emptyDir);
-    await expect(
-      lint(realmUrl, 'let x = 1;', 'test.gts', {
+
+    try {
+      let result = await lint(realmUrl, 'let x = 1;', 'test.gts', {
         profileManager: emptyManager,
-      }),
-    ).rejects.toThrow('No active profile');
-    fs.rmSync(emptyDir, { recursive: true, force: true });
+      });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('No active profile');
+    } finally {
+      fs.rmSync(emptyDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/boxel-cli/tests/integration/file-lint.test.ts
+++ b/packages/boxel-cli/tests/integration/file-lint.test.ts
@@ -1,5 +1,5 @@
 import '../helpers/setup-realm-server';
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -29,40 +29,21 @@ beforeAll(async () => {
 afterAll(async () => { cleanupProfile?.(); await stopTestRealmServer(); });
 
 describe('file lint (integration)', () => {
-  it('sends POST to _lint with correct headers and body', async () => {
-    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch');
-    try {
-      await lint(realmUrl, 'let x = 1;', 'test.gts', { profileManager });
-      expect(fetchSpy).toHaveBeenCalledOnce();
-      let [url, init] = fetchSpy.mock.calls[0];
-      expect(String(url)).toContain('_lint');
-      expect(init!.method).toBe('POST');
-      let headers = init!.headers as Record<string, string>;
-      expect(headers['X-Filename']).toBe('test.gts');
-      expect(headers['X-HTTP-Method-Override']).toBe('QUERY');
-      expect(headers['Content-Type']).toBe('application/vnd.card+source');
-      expect(init!.body).toBe('let x = 1;');
-    } finally { fetchSpy.mockRestore(); }
+  it('lints source via the realm _lint endpoint and returns a result', async () => {
+    let source = 'export const x = 1;\n';
+    let result = await lint(realmUrl, source, 'test.gts', { profileManager });
+
+    expect(result).toHaveProperty('messages');
+    expect(Array.isArray(result.messages)).toBe(true);
+    expect(result).toHaveProperty('output');
   });
 
   it('throws when no active profile', async () => {
     let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
     let emptyManager = new ProfileManager(emptyDir);
-    await expect(lint(realmUrl, 'let x = 1;', 'test.gts', { profileManager: emptyManager })).rejects.toThrow('No active profile');
+    await expect(
+      lint(realmUrl, 'let x = 1;', 'test.gts', { profileManager: emptyManager }),
+    ).rejects.toThrow('No active profile');
     fs.rmSync(emptyDir, { recursive: true, force: true });
-  });
-
-  it('throws on non-2xx response', async () => {
-    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch').mockResolvedValueOnce(new Response('Server Error', { status: 500 }));
-    try {
-      await expect(lint(realmUrl, 'let x = 1;', 'test.gts', { profileManager })).rejects.toThrow('500');
-    } finally { fetchSpy.mockRestore(); }
-  });
-
-  it('throws when fetch fails', async () => {
-    let fetchSpy = vi.spyOn(profileManager, 'authedRealmFetch').mockRejectedValueOnce(new Error('network failure'));
-    try {
-      await expect(lint(realmUrl, 'let x = 1;', 'test.gts', { profileManager })).rejects.toThrow('network failure');
-    } finally { fetchSpy.mockRestore(); }
   });
 });

--- a/packages/software-factory/src/lint-execution.ts
+++ b/packages/software-factory/src/lint-execution.ts
@@ -188,7 +188,7 @@ export async function lintRealmFiles(
         file,
       );
 
-      let violations: LintViolationData[] = lintResponse.messages.map(
+      let violations: LintViolationData[] = (lintResponse.messages ?? []).map(
         (msg) => ({
           rule: msg.ruleId ?? 'unknown',
           file,

--- a/packages/software-factory/tests/lint-step.test.ts
+++ b/packages/software-factory/tests/lint-step.test.ts
@@ -108,8 +108,13 @@ module('LintValidationStep', function () {
           'hello.test.gts': 'import { test } from "qunit";',
         }),
         lintFileFn: makeLintFile({
-          'hello.gts': { fixed: false, output: '', messages: [] },
-          'hello.test.gts': { fixed: false, output: '', messages: [] },
+          'hello.gts': { ok: true, fixed: false, output: '', messages: [] },
+          'hello.test.gts': {
+            ok: true,
+            fixed: false,
+            output: '',
+            messages: [],
+          },
         }),
       }),
     );
@@ -136,6 +141,7 @@ module('LintValidationStep', function () {
         }),
         lintFileFn: makeLintFile({
           'hello.gts': {
+            ok: true,
             fixed: false,
             output: 'let x = 1;',
             messages: [
@@ -177,6 +183,7 @@ module('LintValidationStep', function () {
         }),
         lintFileFn: makeLintFile({
           'hello.gts': {
+            ok: true,
             fixed: false,
             output: 'export const x = 1;',
             messages: [
@@ -208,7 +215,7 @@ module('LintValidationStep', function () {
           // broken.gts not in map → readFile returns { ok: false }
         }),
         lintFileFn: makeLintFile({
-          'hello.gts': { fixed: false, output: '', messages: [] },
+          'hello.gts': { ok: true, fixed: false, output: '', messages: [] },
         }),
       }),
     );

--- a/packages/software-factory/tests/lint-validation.spec.ts
+++ b/packages/software-factory/tests/lint-validation.spec.ts
@@ -42,7 +42,7 @@ test.describe('lint-validation e2e', () => {
       );
 
       // The fixture's hello.gts should be clean
-      let errors = lintResult.messages.filter((m) => m.severity === 2);
+      let errors = (lintResult.messages ?? []).filter((m) => m.severity === 2);
       expect(errors).toEqual([]);
     } finally {
       cleanup();
@@ -85,7 +85,7 @@ test.describe('lint-validation e2e', () => {
       );
 
       // Should have at least one error (unused variable)
-      let errors = lintResult.messages.filter((m) => m.severity === 2);
+      let errors = (lintResult.messages ?? []).filter((m) => m.severity === 2);
       expect(errors.length).toBeGreaterThan(0);
 
       // Verify the message shape


### PR DESCRIPTION
## Summary
- Adds `boxel file lint <path> --realm <url> [--file <local>]` CLI command
- Extracts `BoxelCLIClient.lint()` inline implementation into a standalone command function at `src/commands/file/lint.ts`
- Client method now delegates to the command function
- CLI displays errors (red) and warnings (yellow) with line:column format

## Why — pattern consistency
The `pull` command already follows this pattern: a standalone exported function that both the CLI and `BoxelCLIClient` delegate to. This PR makes `lint()` consistent with that approach. Every `BoxelCLIClient` method should be backed by a command function that is the single source of truth — the client is a thin delegation layer. This enables CS-10670 (tool definitions) where boxel-cli publishes tool definitions that reference these commands directly.

## Test plan
- [x] Integration tests: lints source via real `_lint` endpoint, no-profile error
- [x] Build passes
- [ ] CI green

Closes CS-10851

🤖 Generated with [Claude Code](https://claude.com/claude-code)