### PR TITLE
Cache realm image responses with explicit Cache-Control (CS-10592)

### DIFF
--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -1100,6 +1100,29 @@ module(basename(__filename), function () {
 
           assert.strictEqual(response.status, 204, 'HTTP 204 status');
         });
+
+        test('image GET on a non-public realm uses private Cache-Control', async function (assert) {
+          let bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+          let jwt = createJWT(testRealm, 'john', ['read', 'write']);
+
+          await request
+            .post('/private-icon.png')
+            .set('Content-Type', 'application/octet-stream')
+            .set('Authorization', `Bearer ${jwt}`)
+            .send(Buffer.from(bytes));
+
+          let response = await request
+            .get('/private-icon.png')
+            .set('Accept', 'image/*')
+            .set('Authorization', `Bearer ${jwt}`);
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.headers['cache-control'],
+            'private, max-age=60, must-revalidate',
+            'auth-gated image uses private Cache-Control so shared caches cannot serve it to other users',
+          );
+        });
       });
     });
 
@@ -1212,7 +1235,7 @@ module(basename(__filename), function () {
           );
         });
 
-        test('image 304 response carries Cache-Control', async function (assert) {
+        test('image 304 response carries Cache-Control, ETag, and Last-Modified', async function (assert) {
           let bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
           await request
             .post('/revalidate.png')
@@ -1235,6 +1258,15 @@ module(basename(__filename), function () {
             second.headers['cache-control'],
             'public, max-age=60, must-revalidate',
             '304 responses include Cache-Control so browsers can refresh their cached directive',
+          );
+          assert.strictEqual(
+            second.headers['etag'],
+            etag,
+            '304 echoes the matched ETag (RFC 9110)',
+          );
+          assert.ok(
+            second.headers['last-modified'],
+            '304 includes Last-Modified so caches can update stored metadata',
           );
         });
 

--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -1165,6 +1165,98 @@ module(basename(__filename), function () {
           );
         });
 
+        test('image GET returns explicit Cache-Control for browser image requests', async function (assert) {
+          let bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+          await request
+            .post('/icon.png')
+            .set('Content-Type', 'application/octet-stream')
+            .send(Buffer.from(bytes));
+
+          let response = await request
+            .get('/icon.png')
+            .set('Accept', 'image/*');
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.headers['content-type'],
+            'image/png',
+            'content-type is image/png for .png files',
+          );
+          assert.strictEqual(
+            response.headers['cache-control'],
+            'public, max-age=60, must-revalidate',
+            'image responses set an explicit Cache-Control instead of relying on Last-Modified heuristics',
+          );
+          assert.ok(
+            response.headers['etag'],
+            'ETag header is present so browsers can revalidate when the image changes',
+          );
+        });
+
+        test('image GET returns the same Cache-Control when requested via card+source Accept', async function (assert) {
+          let bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+          await request
+            .post('/bg.png')
+            .set('Content-Type', 'application/octet-stream')
+            .send(Buffer.from(bytes));
+
+          let response = await request
+            .get('/bg.png')
+            .set('Accept', 'application/vnd.card+source');
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.headers['cache-control'],
+            'public, max-age=60, must-revalidate',
+            'image Cache-Control applies regardless of Accept header',
+          );
+        });
+
+        test('image 304 response carries Cache-Control', async function (assert) {
+          let bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+          await request
+            .post('/revalidate.png')
+            .set('Content-Type', 'application/octet-stream')
+            .send(Buffer.from(bytes));
+
+          let first = await request
+            .get('/revalidate.png')
+            .set('Accept', 'image/*');
+          let etag = first.headers['etag'];
+          assert.ok(etag, 'first response has ETag');
+
+          let second = await request
+            .get('/revalidate.png')
+            .set('Accept', 'image/*')
+            .set('If-None-Match', etag);
+
+          assert.strictEqual(second.status, 304, 'HTTP 304 status');
+          assert.strictEqual(
+            second.headers['cache-control'],
+            'public, max-age=60, must-revalidate',
+            '304 responses include Cache-Control so browsers can refresh their cached directive',
+          );
+        });
+
+        test('non-image file GET keeps max-age=0 Cache-Control', async function (assert) {
+          let bytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // %PDF
+          await request
+            .post('/doc.pdf')
+            .set('Content-Type', 'application/octet-stream')
+            .send(Buffer.from(bytes));
+
+          let response = await request
+            .get('/doc.pdf')
+            .set('Accept', 'application/vnd.card+source');
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.headers['cache-control'],
+            'public, max-age=0',
+            'non-image files keep the default revalidate-always Cache-Control',
+          );
+        });
+
         test('card source GET returns correct content-type for PDF files', async function (assert) {
           let bytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // %PDF
           await request

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2098,25 +2098,39 @@ export class Realm {
     },
   ): Promise<ResponseWithNodeStream> {
     let contentType = options?.defaultHeaders?.['content-type'];
+    // Only advertise `public` caching when the realm is world-readable;
+    // otherwise the response is auth-gated and must not be stored by shared
+    // caches (e.g. CDNs) where it could be served to another user.
+    let cacheVisibility = requestContext.permissions['*']?.includes('read')
+      ? 'public'
+      : 'private';
     // Serve realm-hosted images (e.g. realm icons and backgrounds) with an
     // explicit Cache-Control so browsers don't fall back to Last-Modified
     // heuristics. must-revalidate + ETag keeps updates responsive while
     // avoiding repeated revalidation within a browsing session.
     let cacheControl = contentType?.startsWith('image/')
-      ? 'public, max-age=60, must-revalidate'
-      : 'public, max-age=0';
+      ? `${cacheVisibility}, max-age=60, must-revalidate`
+      : `${cacheVisibility}, max-age=0`;
     let etag = buildEtag(ref.lastModified, options?.etagVariant);
+    let lastModified = formatRFC7231(ref.lastModified * 1000);
     if (etag && request.headers.get('if-none-match') === etag) {
       return createResponse({
         body: null,
-        init: { status: 304, headers: { 'cache-control': cacheControl } },
+        init: {
+          status: 304,
+          headers: {
+            'cache-control': cacheControl,
+            'last-modified': lastModified,
+            etag,
+          },
+        },
         requestContext,
       });
     }
     let createdFromDb = await this.getCreatedTime(ref.path);
     let headers: Record<string, string> = {
       ...(options?.defaultHeaders || {}),
-      'last-modified': formatRFC7231(ref.lastModified * 1000),
+      'last-modified': lastModified,
       ...(Symbol.for('shimmed-module') in ref
         ? { 'X-Boxel-Shimmed-Module': 'true' }
         : {}),

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2097,11 +2097,19 @@ export class Realm {
       etagVariant?: string;
     },
   ): Promise<ResponseWithNodeStream> {
+    let contentType = options?.defaultHeaders?.['content-type'];
+    // Serve realm-hosted images (e.g. realm icons and backgrounds) with an
+    // explicit Cache-Control so browsers don't fall back to Last-Modified
+    // heuristics. must-revalidate + ETag keeps updates responsive while
+    // avoiding repeated revalidation within a browsing session.
+    let cacheControl = contentType?.startsWith('image/')
+      ? 'public, max-age=60, must-revalidate'
+      : 'public, max-age=0';
     let etag = buildEtag(ref.lastModified, options?.etagVariant);
     if (etag && request.headers.get('if-none-match') === etag) {
       return createResponse({
         body: null,
-        init: { status: 304 },
+        init: { status: 304, headers: { 'cache-control': cacheControl } },
         requestContext,
       });
     }
@@ -2113,7 +2121,7 @@ export class Realm {
         ? { 'X-Boxel-Shimmed-Module': 'true' }
         : {}),
       ...(etag ? { etag } : {}),
-      'cache-control': 'public, max-age=0', // instructs the browser to check with server before using cache
+      'cache-control': cacheControl,
     };
     if (createdFromDb != null) {
       headers['x-created'] = formatRFC7231(createdFromDb * 1000);


### PR DESCRIPTION
## Summary

Realm-hosted image files (icons, backgrounds) were served with `public, max-age=0`, which forced a revalidation on every use and — worse — left browsers falling back to `Last-Modified` heuristics when no explicit directive applied. Caching was unreliable as a result.

## What changed

In `serveLocalFile` (`packages/runtime-common/realm.ts`):

- **Explicit Cache-Control for images.** Image content now gets `max-age=60, must-revalidate`; non-image content keeps `max-age=0`. Combined with the existing ETag, browsers serve cached images locally for 60s and then revalidate cheaply (304) when the freshness window expires.
- **Visibility keyed to realm permissions.** Responses from world-readable realms use `public`; responses from auth-gated realms use `private`, so shared caches (CDNs, corporate proxies) cannot store and replay authenticated assets across users. The check mirrors the one `createResponse` already uses for `X-Boxel-Realm-Public-Readable`.
- **Richer 304 responses.** Conditional revalidations now echo `ETag` and `Last-Modified` alongside `Cache-Control`, per RFC 9110, so intermediary caches can refresh stored metadata.

## Why `private` rather than `Vary: Authorization`

Every authenticated user of a realm gets the same icon bytes, but their JWTs are unique and short-lived — `Vary: Authorization` would cause a CDN to store N identical copies (one per JWT) with no actual sharing. `private` gives the same practical result (per-user browser caching, no CDN storage) without the surface area of `Vary` bugs in intermediaries leaking content across users. If CDN-level caching for authenticated assets becomes valuable later, we can revisit with a stable user-scoped vary key.

## Test plan

- [x] `pnpm lint` passes in `runtime-common` and `realm-server`.
- [x] New `packages/realm-server/tests/card-source-endpoints-test.ts` cases cover:
  - image GET with `Accept: image/*` → `public, max-age=60, must-revalidate` + ETag.
  - image GET with `Accept: application/vnd.card+source` → same directive (Cache-Control doesn't depend on Accept).
  - 304 revalidation → Cache-Control + echoed ETag + Last-Modified.
  - non-image GET → `public, max-age=0` unchanged.
  - permissioned-realm image GET → `private, max-age=60, must-revalidate`.

Closes [CS-10592](https://linear.app/cardstack/issue/CS-10592/add-cache-control-headers-for-realm-images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)