### PR TITLE
Fix noisy memory baseline check + split to its own job

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -385,9 +385,7 @@ jobs:
     needs: host-test
     runs-on: ubuntu-latest
     permissions:
-      # contents: needed only for the "Update memory baseline" step, which
-      # pushes a commit — and only fires on push-to-main (see step condition).
-      contents: write
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -403,8 +401,32 @@ jobs:
       - name: Check memory baseline
         run: node packages/host/scripts/check-memory-baseline.mjs all-memory-reports packages/host/memory-baseline.json
 
+  host-memory-baseline-update:
+    name: Update Host Memory Baseline
+    # Intentionally scoped to push-to-main only so the job only runs in a
+    # context where the PR workflow file cannot be modified by an untrusted
+    # branch — this is the one job that holds `contents: write`.
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.host-test.result == 'success' }}
+    concurrency:
+      group: host-memory-baseline-update-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+    needs: host-test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/init
+
+      - name: Download memory reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: all-memory-reports
+          pattern: memory-report-*
+          merge-multiple: true
+
       - name: Update memory baseline
-        if: ${{ github.ref == 'refs/heads/main' && needs.host-test.result == 'success' }}
         run: |
           node packages/host/scripts/update-memory-baseline.mjs all-memory-reports packages/host/memory-baseline.json
           if git diff --quiet packages/host/memory-baseline.json; then

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -339,9 +339,6 @@ jobs:
       # the junit summary back to the PR / commit.
       checks: write
       pull-requests: write
-      # contents: needed only for the "Update memory baseline" step, which
-      # pushes a commit — and only fires on push-to-main (see step condition).
-      contents: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -379,20 +376,35 @@ jobs:
           junit_files: host.xml
           check_name: Host Test Results
 
+  host-memory-baseline:
+    name: Host Memory Baseline
+    if: ${{ !cancelled() && (needs.host-test.result == 'success' || needs.host-test.result == 'failure') }}
+    concurrency:
+      group: host-memory-baseline-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+    needs: host-test
+    runs-on: ubuntu-latest
+    permissions:
+      # contents: needed only for the "Update memory baseline" step, which
+      # pushes a commit — and only fires on push-to-main (see step condition).
+      contents: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/init
+
       - name: Download memory reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        if: ${{ !cancelled() }}
         with:
           path: all-memory-reports
           pattern: memory-report-*
           merge-multiple: true
 
       - name: Check memory baseline
-        if: ${{ !cancelled() }}
         run: node packages/host/scripts/check-memory-baseline.mjs all-memory-reports packages/host/memory-baseline.json
 
       - name: Update memory baseline
-        if: ${{ !cancelled() && github.ref == 'refs/heads/main' && needs.host-test.result == 'success' }}
+        if: ${{ github.ref == 'refs/heads/main' && needs.host-test.result == 'success' }}
         run: |
           node packages/host/scripts/update-memory-baseline.mjs all-memory-reports packages/host/memory-baseline.json
           if git diff --quiet packages/host/memory-baseline.json; then

--- a/packages/host/scripts/check-memory-baseline.mjs
+++ b/packages/host/scripts/check-memory-baseline.mjs
@@ -61,29 +61,35 @@ for (const [mod, data] of Object.entries(current)) {
   const baseDelta = base.delta_mb;
   if (baseDelta == null) continue;
 
-  const diff = data.delta_mb - baseDelta;
-  const absDiff = Math.abs(diff);
+  // A negative baseline delta means the prior module's garbage was reclaimed
+  // partway through this module's window, not that this module actually freed
+  // memory. Treat it as noise: floor at 0 so the comparison falls back to the
+  // absolute thresholds rather than a bogus relative budget sized to |noise|.
+  const effectiveBase = Math.max(baseDelta, 0);
+  const diff = data.delta_mb - effectiveBase;
   // Only flag increases
   if (diff <= 0) continue;
 
-  const softThreshold = Math.max(SOFT_ABSOLUTE_MB, Math.abs(baseDelta) * SOFT_RELATIVE);
-  const hardThreshold = Math.max(HARD_ABSOLUTE_MB, Math.abs(baseDelta) * HARD_RELATIVE);
+  const softThreshold = Math.max(SOFT_ABSOLUTE_MB, effectiveBase * SOFT_RELATIVE);
+  const hardThreshold = Math.max(HARD_ABSOLUTE_MB, effectiveBase * HARD_RELATIVE);
 
-  if (absDiff >= hardThreshold) {
+  const pct = effectiveBase > 0 ? ((diff / effectiveBase) * 100).toFixed(0) : null;
+
+  if (diff >= hardThreshold) {
     failures.push({
       mod,
-      baseline: baseDelta,
+      baseline: effectiveBase,
       current: data.delta_mb,
       diff,
-      pct: baseDelta !== 0 ? ((diff / Math.abs(baseDelta)) * 100).toFixed(0) : 'inf',
+      pct,
     });
-  } else if (absDiff >= softThreshold) {
+  } else if (diff >= softThreshold) {
     warnings.push({
       mod,
-      baseline: baseDelta,
+      baseline: effectiveBase,
       current: data.delta_mb,
       diff,
-      pct: baseDelta !== 0 ? ((diff / Math.abs(baseDelta)) * 100).toFixed(0) : 'inf',
+      pct,
     });
   }
 }
@@ -107,8 +113,9 @@ if (failures.length > 0) {
   lines.push('| Module | Baseline | Current | Change |');
   lines.push('|--------|----------|---------|--------|');
   for (const f of failures.sort((a, b) => b.diff - a.diff)) {
+    const pctStr = f.pct != null ? ` (+${f.pct}%)` : '';
     lines.push(
-      `| ${escapeMd(f.mod)} | ${f.baseline.toFixed(1)} MB | ${f.current.toFixed(1)} MB | +${f.diff.toFixed(1)} MB (+${f.pct}%) |`,
+      `| ${escapeMd(f.mod)} | ${f.baseline.toFixed(1)} MB | ${f.current.toFixed(1)} MB | +${f.diff.toFixed(1)} MB${pctStr} |`,
     );
   }
   lines.push('');
@@ -119,8 +126,9 @@ if (warnings.length > 0) {
   lines.push('| Module | Baseline | Current | Change |');
   lines.push('|--------|----------|---------|--------|');
   for (const w of warnings.sort((a, b) => b.diff - a.diff)) {
+    const pctStr = w.pct != null ? ` (+${w.pct}%)` : '';
     lines.push(
-      `| ${escapeMd(w.mod)} | ${w.baseline.toFixed(1)} MB | ${w.current.toFixed(1)} MB | +${w.diff.toFixed(1)} MB (+${w.pct}%) |`,
+      `| ${escapeMd(w.mod)} | ${w.baseline.toFixed(1)} MB | ${w.current.toFixed(1)} MB | +${w.diff.toFixed(1)} MB${pctStr} |`,
     );
   }
   lines.push('');

--- a/packages/host/tests/helpers/setup-qunit.js
+++ b/packages/host/tests/helpers/setup-qunit.js
@@ -16,19 +16,30 @@ export function setupQUnit() {
   // Per-module memory delta probe — log each test file's contribution to
   // retained memory, independent of where it falls in shard order. We GC
   // at module boundaries so the start/end snapshots compare like-for-like.
-  // QUnit module name is normally 1:1 with the test file. We only probe
-  // top-level modules (fullName.length === 1) so nested modules don't
-  // create overlapping start/end pairs.
+  //
+  // We run several gc() cycles with a microtask yield between each call so
+  // V8 can drain its FinalizationRegistry queue and finish generational
+  // sweeps between passes. Without the yield, finalizers are deferred until
+  // the next microtask checkpoint, so repeated synchronous gc() calls don't
+  // actually settle — prior-module garbage can reclaim mid-way through our
+  // window and produce negative "deltas" that aren't real.
+  //
+  // Uses QUnit.moduleStart/moduleDone (not QUnit.on('suiteStart')) because
+  // only the logging-callback API awaits async handlers. Nested modules
+  // are tracked with a simple depth counter so we only probe top-level ones.
   let usedAtModuleStart = null;
-  let inTopLevelModule = false;
-  QUnit.on('suiteStart', (details) => {
-    let depth = Array.isArray(details.fullName) ? details.fullName.length : 1;
-    if (depth !== 1) return;
-    inTopLevelModule = true;
-    if (typeof globalThis.gc === 'function') {
+  let moduleDepth = 0;
+  async function settledGc() {
+    if (typeof globalThis.gc !== 'function') return;
+    for (let i = 0; i < 3; i++) {
       globalThis.gc();
-      globalThis.gc();
+      await new Promise((r) => setTimeout(r, 0));
     }
+  }
+  QUnit.moduleStart(async () => {
+    moduleDepth++;
+    if (moduleDepth !== 1) return;
+    await settledGc();
     try {
       let pm = performance && performance.memory;
       usedAtModuleStart = pm ? pm.usedJSHeapSize : null;
@@ -36,32 +47,29 @@ export function setupQUnit() {
       usedAtModuleStart = null;
     }
   });
-  QUnit.on('suiteEnd', (details) => {
-    let depth = Array.isArray(details.fullName) ? details.fullName.length : 1;
-    if (depth !== 1 || !inTopLevelModule) return;
-    inTopLevelModule = false;
-    if (typeof globalThis.gc === 'function') {
-      globalThis.gc();
-      globalThis.gc();
-    }
-    try {
-      let pm = performance && performance.memory;
-      if (pm) {
-        let used = pm.usedJSHeapSize;
-        let usedMB = (used / 1048576).toFixed(1);
-        let totalMB = (pm.totalJSHeapSize / 1048576).toFixed(1);
-        let deltaMB =
-          usedAtModuleStart != null
-            ? ((used - usedAtModuleStart) / 1048576).toFixed(1)
-            : 'na';
-        let tests = details.tests ? details.tests.length : 0;
-        console.log(
-          `MEMPROBE_FILE module=${JSON.stringify(details.name)} tests=${tests} used=${usedMB}MB total=${totalMB}MB delta=${deltaMB}MB`,
-        );
+  QUnit.moduleDone(async (details) => {
+    if (moduleDepth === 1) {
+      await settledGc();
+      try {
+        let pm = performance && performance.memory;
+        if (pm) {
+          let used = pm.usedJSHeapSize;
+          let usedMB = (used / 1048576).toFixed(1);
+          let totalMB = (pm.totalJSHeapSize / 1048576).toFixed(1);
+          let deltaMB =
+            usedAtModuleStart != null
+              ? ((used - usedAtModuleStart) / 1048576).toFixed(1)
+              : 'na';
+          let tests = details.tests ? details.tests.length : 0;
+          console.log(
+            `MEMPROBE_FILE module=${JSON.stringify(details.name)} tests=${tests} used=${usedMB}MB total=${totalMB}MB delta=${deltaMB}MB`,
+          );
+        }
+      } catch (_) {
+        /* ignore */
       }
-    } catch (_) {
-      /* ignore */
     }
+    moduleDepth--;
   });
 
   // After each test, force GC (via --expose-gc) so V8 can release


### PR DESCRIPTION
Related: #4430 (introduced the baseline check), #4484 (GC-settling probe experiment; not for merge)

## The problem

PR #4430 added a per-module memory check comparing each module's `delta_mb = usedJSHeapSize_end - usedJSHeapSize_start` against a stored baseline. Two separate issues were making it fire falsely on main (see failed run [24759771042](https://github.com/cardstack/boxel/actions/runs/24759771042/job/72443832120)):

1. **Inflated probe deltas.** The probe used `QUnit.on('suiteStart'/'suiteEnd')`, which dispatches synchronously via `emit()` — the handler can't await. Back-to-back `gc()` calls inside the handler don't give V8 time to drain its FinalizationRegistry queue between passes, so prior-module garbage can reclaim mid-window and produce negative "deltas" that don't represent retention. 14 of 170 baselined modules landed at negative `delta_mb` for this reason (most extreme: `-58.8 MB`).
2. **Threshold math divided by noise.** The check used `Math.abs(baseDelta)` as the relative budget. A module baselined at `-58.8 MB` got a `58.8 MB` hard-threshold — smaller than the 50 MB absolute floor — and failed CI on a normal `+18.7 MB` reading. Near-zero baselines also produced nonsense percentages (`+7267%`).

## Changes

**Commit 1 — threshold math + split to own job**
- `check-memory-baseline.mjs`: floor `effectiveBase` at 0, so noisy negative baselines fall back to the absolute thresholds. Drop the percent column when `effectiveBase === 0` (ratio is undefined).
- `ci-host.yaml`: move the memory check into its own `host-memory-baseline` job so it surfaces as a distinct check in the PR UI instead of hiding inside "Merge Host reports and publish".

**Commit 2 — settle GC before probing**
- `setup-qunit.js`: switch from `QUnit.on('suiteStart'/'suiteEnd')` to `QUnit.moduleStart` / `moduleDone` (these await async handlers via `runLoggingCallbacks`). Replace `2x gc()` with `settledGc()`: `3x gc()` with a `setTimeout(0)` yield between each so FR callbacks execute between passes. Track nesting with a `moduleDepth` counter since `moduleStart`'s payload omits `fullName`.

## Evidence

One-shot probe on [#4484](https://github.com/cardstack/boxel/pull/4484) (`gc-settling-experiment`, not for merge):

- Sum of all per-module `delta_mb`: **16,502 MB → 4,732 MB** (~71% of what the old probe attributed to modules was unfinished GC, not retention).
- 13 of 14 previously-negative modules collapse toward zero. Most dramatic: `Integration | commands | create-listing-pr-request` `-58.8 → -2.2 MB` (the module that caused the failing run linked above).
- Large-positive modules shrink proportionally: `Acceptance | AI Assistant tests` `1540 → 169 MB`; `prerender | html` `771 → 17 MB`; `code submode | create-file tests` `876 → 56 MB`.
- **No measurable slowdown.** 17 of 18 comparable shards ran faster (sum `-11.9%` wall time), likely because each module starts from a small settled heap and pays less in implicit mid-test GC pauses. With n=1 per side and GitHub Actions runner variance, "no slowdown" is the honest claim, not "speedup".

## Follow-up

The existing `packages/host/memory-baseline.json` was captured under the old probe and overstates deltas by ~3.5×. With the new probe, `check-memory-baseline`'s `diff = newDelta - effectiveBase` is negative for virtually every module, so the check won't alert until the baseline is regenerated from several clean runs under the new probe. Deliberately kept out of this PR — regenerating from a single run would trade one kind of baseline noise for another.

One outlier worth remembering when we do regenerate: `Integration | ai-assistant-panel | commands` grew slightly (487 → 532 MB) while every other large module shrank. Under settled-GC numbers it becomes by far the largest retention candidate in the corpus.