### PR TITLE
Remove Sentry calls for generation cost failures

### DIFF
--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -118,9 +118,9 @@ class Assistant {
         if (fetchedCost !== null) {
           await spendUsageCost(this.pgAdapter, matrixUserId, fetchedCost);
         } else {
-          const message = `Failed to fetch generation cost for user ${matrixUserId} (generationId: ${generationId}), credit deduction skipped`;
-          log.error(message);
-          Sentry.captureMessage(message, 'error');
+          log.warn(
+            `Failed to fetch generation cost for user ${matrixUserId} (generationId: ${generationId}), credit deduction skipped`,
+          );
         }
       } else {
         log.warn(

--- a/packages/realm-server/lib/credit-strategies.ts
+++ b/packages/realm-server/lib/credit-strategies.ts
@@ -3,7 +3,6 @@ import {
   MINIMUM_AI_CREDITS_TO_CONTINUE,
   logger,
 } from '@cardstack/runtime-common';
-import * as Sentry from '@sentry/node';
 import {
   validateAICredits,
   spendUsageCost as spendUsageCostFromBilling,
@@ -78,9 +77,9 @@ export class OpenRouterCreditStrategy implements CreditStrategy {
       if (fetchedCost !== null) {
         await spendUsageCostFromBilling(dbAdapter, matrixUserId, fetchedCost);
       } else {
-        const message = `Failed to fetch generation cost for user ${matrixUserId} (generationId: ${generationId}), credit deduction skipped`;
-        log.error(message);
-        Sentry.captureMessage(message, 'error');
+        log.warn(
+          `Failed to fetch generation cost for user ${matrixUserId} (generationId: ${generationId}), credit deduction skipped`,
+        );
       }
     } else {
       log.warn(


### PR DESCRIPTION
We get Sentry errors for this but it’s not actionable, so this just changes it to warnings in the logs:

<img width="1420" height="1608" alt="Image 2026-04-22 14-43-56" src="https://github.com/user-attachments/assets/af995460-7800-442a-8818-65d466ae3cc1" />
