### PR TITLE
Enable parallel tool calls on OpenRouter factory agent (CS-10814)

### DIFF
--- a/packages/software-factory/src/factory-agent/openrouter.ts
+++ b/packages/software-factory/src/factory-agent/openrouter.ts
@@ -181,7 +181,12 @@ export class OpenRouterFactoryAgent implements LoopAgent {
         tool_calls: assistantToolCalls,
       });
 
-      // Execute each tool call
+      // Execute each tool call. With `parallel_tool_calls: true` a single
+      // assistant turn can carry multiple tool_calls[]; if the batch contains
+      // a terminal signal (signal_done / request_clarification) alongside
+      // other tools, we still execute the whole batch so the model's other
+      // side effects land, then return the first terminal signal observed.
+      let terminalResult: AgentRunResult | undefined;
       for (let toolCall of assistantToolCalls) {
         let toolName = toolCall.function.name;
         let tool = tools.find((t) => t.name === toolName);
@@ -232,13 +237,13 @@ export class OpenRouterFactoryAgent implements LoopAgent {
         if (result && typeof result === 'object' && 'signal' in result) {
           let signal = (result as Record<string, unknown>).signal;
           if (signal === DONE_SIGNAL) {
-            // Add tool result to messages so conversation is well-formed
             messages.push({
               role: 'tool',
               tool_call_id: toolCall.id,
               content: JSON.stringify({ status: 'done' }),
             });
-            return { status: 'done', toolCalls: toolCallLog };
+            terminalResult ??= { status: 'done', toolCalls: toolCallLog };
+            continue;
           }
           if (signal === CLARIFICATION_SIGNAL) {
             let clarificationMessage = (result as Record<string, unknown>)
@@ -251,11 +256,12 @@ export class OpenRouterFactoryAgent implements LoopAgent {
                 message: clarificationMessage,
               }),
             });
-            return {
+            terminalResult ??= {
               status: 'blocked',
               toolCalls: toolCallLog,
               message: clarificationMessage,
             };
+            continue;
           }
         }
 
@@ -265,6 +271,10 @@ export class OpenRouterFactoryAgent implements LoopAgent {
           tool_call_id: toolCall.id,
           content: JSON.stringify(result),
         });
+      }
+
+      if (terminalResult) {
+        return terminalResult;
       }
     }
 

--- a/packages/software-factory/src/factory-agent/openrouter.ts
+++ b/packages/software-factory/src/factory-agent/openrouter.ts
@@ -362,6 +362,11 @@ export class OpenRouterFactoryAgent implements LoopAgent {
 
     if (tools.length > 0) {
       body.tools = tools;
+      // Opt in to OpenAI-compatible parallel tool calls so a single assistant
+      // turn can emit multiple tool_calls[]. Without this, OpenRouter routes
+      // to Anthropic serialize 1 call/turn and re-send the full context each
+      // round, producing the O(n²) context blow-up observed in CS-10814.
+      body.parallel_tool_calls = true;
     }
 
     let response: Response;

--- a/packages/software-factory/tests/factory-agent-schema-boundary.test.ts
+++ b/packages/software-factory/tests/factory-agent-schema-boundary.test.ts
@@ -209,6 +209,16 @@ module('factory-agent-schema-boundary / runtime', function () {
       (params as { _def?: unknown })._def,
       'OpenRouter path: parameters do NOT carry Zod internal "_def"',
     );
+
+    // CS-10814: the OpenAI-compatible `parallel_tool_calls` flag must be
+    // asserted on the wire so the route batches multiple tool_use blocks
+    // per assistant turn instead of serializing them 1-per-turn.
+    let parallelToolCalls = (capturedBody as { parallel_tool_calls?: boolean })
+      .parallel_tool_calls;
+    assert.true(
+      parallelToolCalls,
+      'OpenRouter body sets parallel_tool_calls: true when tools are present',
+    );
   });
 
   test('Claude path: run() does not touch OPENROUTER_CHAT_URL', async function (assert) {

--- a/packages/software-factory/tests/factory-agent-schema-boundary.test.ts
+++ b/packages/software-factory/tests/factory-agent-schema-boundary.test.ts
@@ -24,6 +24,7 @@ import { OpenRouterFactoryAgent } from '../src/factory-agent/openrouter';
 import { OPENROUTER_CHAT_URL } from '../src/factory-agent';
 import type { AgentContext } from '../src/factory-agent';
 import type { FactoryTool } from '../src/factory-tool-builder';
+import { DONE_SIGNAL } from '../src/factory-tool-builder';
 import type { PromptLoader } from '../src/factory-prompt-loader';
 import type { BoxelCLIClient } from '@cardstack/boxel-cli/api';
 
@@ -218,6 +219,105 @@ module('factory-agent-schema-boundary / runtime', function () {
     assert.true(
       parallelToolCalls,
       'OpenRouter body sets parallel_tool_calls: true when tools are present',
+    );
+  });
+
+  test('OpenRouter path: batched turn with signal_done still runs every tool in the batch', async function (assert) {
+    // CS-10814 review follow-up: with parallel_tool_calls enabled the model
+    // can emit `signal_done` alongside other tool_calls in a single assistant
+    // turn. Returning as soon as we saw `signal_done` used to drop the
+    // siblings; assert every tool in the batch executes before we report
+    // `done`.
+    let savedApiKey = process.env.OPENROUTER_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+
+    let writeCount = 0;
+    let writeTool: FactoryTool = {
+      name: 'write_file',
+      description: 'write a file',
+      parameters: { type: 'object', properties: {}, required: [] },
+      execute: async () => {
+        writeCount += 1;
+        return { ok: true };
+      },
+    };
+    let doneTool: FactoryTool = {
+      name: 'signal_done',
+      description: 'signal the agent is done',
+      parameters: { type: 'object', properties: {}, required: [] },
+      execute: async () => ({ signal: DONE_SIGNAL }),
+    };
+
+    let fakeClient = {
+      authedServerFetch: async () => {
+        return new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  role: 'assistant',
+                  content: null,
+                  tool_calls: [
+                    {
+                      id: 'call_write_1',
+                      type: 'function',
+                      function: { name: 'write_file', arguments: '{}' },
+                    },
+                    {
+                      id: 'call_done_1',
+                      type: 'function',
+                      function: { name: 'signal_done', arguments: '{}' },
+                    },
+                    {
+                      id: 'call_write_2',
+                      type: 'function',
+                      function: { name: 'write_file', arguments: '{}' },
+                    },
+                  ],
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': SupportedMimeType.JSON },
+          },
+        );
+      },
+    } as unknown as BoxelCLIClient;
+
+    let agent = new OpenRouterFactoryAgent(
+      {
+        model: 'anthropic/claude-opus-4',
+        realmServerUrl: 'https://realms.example.test/',
+        client: fakeClient,
+      },
+      stubPromptLoader,
+    );
+
+    let result;
+    try {
+      result = await agent.run(makeContext(), [writeTool, doneTool]);
+    } finally {
+      if (savedApiKey !== undefined) {
+        process.env.OPENROUTER_API_KEY = savedApiKey;
+      }
+    }
+
+    assert.strictEqual(
+      writeCount,
+      2,
+      'both write_file calls in the batch execute even when signal_done appears between them',
+    );
+    assert.strictEqual(
+      result.status,
+      'done',
+      'run() still reports done when the batch contained signal_done',
+    );
+    assert.strictEqual(
+      result.toolCalls.length,
+      3,
+      'toolCalls log captures every call in the batch, not just the ones before signal_done',
     );
   });
 


### PR DESCRIPTION
## Summary

- Set `parallel_tool_calls: true` on the OpenRouter request body when tools are present, so a single assistant turn can emit multiple `tool_calls[]` — same spot in `packages/software-factory/src/factory-agent/openrouter.ts` the ticket called out.
- Without this flag, the OpenRouter → Anthropic route serialized one tool call per turn and re-sent the full \~30K-token prompt each round, producing the O(n²) context blow-up that made `--agent openrouter` runs take 40+ minutes where `--agent claude` finished in \~3.
- Extended the existing schema-boundary wire-body test to assert the flag lands on the outgoing request.

## Test plan

- [x] `pnpm lint` in `packages/software-factory` — clean (js, types, format)
- [x] `pnpm exec qunit tests/factory-agent-schema-boundary.test.ts` — 3/3 pass, including the new assertion
- [ ] **End-to-end validation still pending** (acceptance criterion #1): run a real `--agent openrouter` bootstrap on `anthropic/claude-opus-4` and confirm at least one observed turn carries `choice.message.tool_calls.length >= 2`. If the flag is silently ignored on that route, follow the ticket's fallback: document it in a comment next to the option.

Linear: CS-10814

🤖 Generated with [Claude Code](https://claude.com/claude-code)