### PR TITLE
Temporary skip submission linter in submission workflow card

### DIFF
--- a/packages/bot-runner/lib/command-runner.ts
+++ b/packages/bot-runner/lib/command-runner.ts
@@ -154,6 +154,31 @@ export class CommandRunner {
         });
 
         // Step 1.5: Lint & auto-fix collected files
+        // TEMP: lint step skipped while we investigate OOM in staging/prod.
+        // To restore: delete the skip block below and uncomment the original
+        // Step 1.5 block that follows it.
+        log.info('pr-listing-create: lint skipped (temporary)', {
+          fileCount: allFileContents.length,
+        });
+        void this.lintSubmissionFiles; // keep field marked "used" while skipped
+        if (workflowCardUrl) {
+          await this.enqueueRunCommand({
+            runAs,
+            realmURL: effectiveWorkflowRealm,
+            command: PATCH_CARD_INSTANCE_COMMAND,
+            commandInput: {
+              cardId: workflowCardUrl,
+              patch: {
+                attributes: {
+                  lintStatus: 'passed',
+                  lintFixedCount: 0,
+                },
+              },
+            },
+          });
+        }
+        /* TEMP: original Step 1.5 (lint & auto-fix) preserved below.
+           Uncomment this block and delete the skip block above to restore.
         if (workflowCardUrl) {
           await this.enqueueRunCommand({
             runAs,
@@ -254,6 +279,7 @@ export class CommandRunner {
             },
           });
         }
+        */
 
         // Build PR summary from available info
         let listingSummary =

--- a/packages/bot-runner/tests/command-runner-test.ts
+++ b/packages/bot-runner/tests/command-runner-test.ts
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import type {
   DBAdapter,
   ExecuteOptions,
@@ -7,7 +7,10 @@ import type {
   RunCommandResponse,
 } from '@cardstack/runtime-common';
 import type { GitHubClient } from '../lib/github';
-import { CommandRunner, type LintSubmissionFilesFn } from '../lib/command-runner';
+import {
+  CommandRunner,
+  type LintSubmissionFilesFn,
+} from '../lib/command-runner';
 
 const passThroughLint: LintSubmissionFilesFn = async (files) => ({
   passed: true,
@@ -207,7 +210,8 @@ module('command runner', () => {
               event_type: 'app.boxel.bot-trigger',
               content_type: 'pr-listing-create',
             },
-            command: '@cardstack/catalog/commands/collect-submission-files/default',
+            command:
+              '@cardstack/catalog/commands/collect-submission-files/default',
           },
         ],
       ],
@@ -255,8 +259,8 @@ module('command runner', () => {
 
     assert.strictEqual(
       publishedJobs.length,
-      5,
-      'enqueues collect-files, two lint-status patches, create-pr-card, and prCard-link patch',
+      4,
+      'enqueues collect-files, lintStatus=passed patch, create-pr-card, and prCard-link patch (lint step skipped)',
     );
     assert.strictEqual(createdBranches.length, 1, 'creates branch');
     assert.strictEqual(branchWrites.length, 1, 'writes files to branch');
@@ -268,33 +272,35 @@ module('command runner', () => {
       'command:http://localhost:4201/test/',
       'Job 1 (collect-files) uses default realm concurrency group',
     );
-    // Job 2: patch lintStatus=in-progress — user realm
+    // TEMP: lint step skipped — the lintStatus=in-progress patch is not
+    // enqueued. Uncomment and shift indices below back up by 1 when the
+    // lint step is restored in command-runner.ts.
+    // assert.strictEqual(
+    //   (publishedJobs[1] as { concurrencyGroup: string }).concurrencyGroup,
+    //   'command:http://localhost:4201/test/',
+    //   'Job 2 (lintStatus in-progress) uses default realm concurrency group',
+    // );
+    // Job 2: patch lintStatus=passed — user realm
     assert.strictEqual(
       (publishedJobs[1] as { concurrencyGroup: string }).concurrencyGroup,
       'command:http://localhost:4201/test/',
-      'Job 2 (lintStatus in-progress) uses default realm concurrency group',
+      'Job 2 (lintStatus passed) uses default realm concurrency group',
     );
-    // Job 3: patch lintStatus=passed — user realm
+    // Job 3: create-pr-card — submissions realm
     assert.strictEqual(
       (publishedJobs[2] as { concurrencyGroup: string }).concurrencyGroup,
-      'command:http://localhost:4201/test/',
-      'Job 3 (lintStatus passed) uses default realm concurrency group',
+      `command:${SUBMISSION_REALM_URL}`,
+      'Job 3 (create-pr-card) uses submissions realm concurrency group',
     );
-    // Job 4: create-pr-card — submissions realm
+    // Job 4: prCard link patch — user realm
     assert.strictEqual(
       (publishedJobs[3] as { concurrencyGroup: string }).concurrencyGroup,
-      `command:${SUBMISSION_REALM_URL}`,
-      'Job 4 (create-pr-card) uses submissions realm concurrency group',
-    );
-    // Job 5: prCard link patch — user realm
-    assert.strictEqual(
-      (publishedJobs[4] as { concurrencyGroup: string }).concurrencyGroup,
       'command:http://localhost:4201/test/',
-      'Job 5 (prCard link patch) uses default realm concurrency group',
+      'Job 4 (prCard link patch) uses default realm concurrency group',
     );
 
     assert.deepEqual(
-      (publishedJobs[3] as { args: Record<string, unknown> }).args,
+      (publishedJobs[2] as { args: Record<string, unknown> }).args,
       {
         realmURL: SUBMISSION_REALM_URL,
         realmUsername: SUBMISSION_BOT_USER_ID,
@@ -316,7 +322,7 @@ module('command runner', () => {
       'enqueues PR card creation in submissions realm',
     );
     assert.deepEqual(
-      (publishedJobs[4] as { args: Record<string, unknown> }).args,
+      (publishedJobs[3] as { args: Record<string, unknown> }).args,
       {
         realmURL: 'http://localhost:4201/test/',
         realmUsername: '@alice:localhost',
@@ -396,7 +402,8 @@ module('command runner', () => {
               event_type: 'app.boxel.bot-trigger',
               content_type: 'pr-listing-create',
             },
-            command: '@cardstack/catalog/commands/collect-submission-files/default',
+            command:
+              '@cardstack/catalog/commands/collect-submission-files/default',
           },
         ],
       ],
@@ -495,7 +502,8 @@ module('command runner', () => {
               event_type: 'app.boxel.bot-trigger',
               content_type: 'pr-listing-create',
             },
-            command: '@cardstack/catalog/commands/collect-submission-files/default',
+            command:
+              '@cardstack/catalog/commands/collect-submission-files/default',
           },
         ],
       ],
@@ -554,7 +562,8 @@ module('command runner', () => {
     assert.strictEqual(openedPRs.length, 0, 'does not open pull request');
   });
 
-  test('patches prCreationError when create-pr-card fails after lint passes', async (assert) => {
+  // TEMP: Re-enable this test when lint is restored.
+  skip('patches prCreationError when create-pr-card fails after lint passes', async (assert) => {
     let submissionCardUrl =
       'http://localhost:4201/submissions/SubmissionWorkflowCard/abc-123';
     let publishedJobs: Array<{
@@ -719,8 +728,9 @@ module('command runner', () => {
       'compensating patch writes prCreationError',
     );
     assert.ok(
-      (lastArgs.commandInput.patch.attributes.prCreationError as string)
-        .startsWith('PR creation failed:'),
+      (
+        lastArgs.commandInput.patch.attributes.prCreationError as string
+      ).startsWith('PR creation failed:'),
       `prCreationError message is prefixed: ${lastArgs.commandInput.patch.attributes.prCreationError}`,
     );
     assert.notOk(

--- a/packages/catalog-realm/submission-workflow-card/submission-workflow-card.gts
+++ b/packages/catalog-realm/submission-workflow-card/submission-workflow-card.gts
@@ -66,9 +66,8 @@ const STEP_DEFINITIONS = [
   },
   {
     key: 'create-pr',
-    label: 'Lint & Create PR',
-    description:
-      'Lint files, auto-fix issues, and create a GitHub pull request',
+    label: 'Create PR',
+    description: 'Create a GitHub pull request for the selected listing',
   },
   {
     key: 'ci-checks',


### PR DESCRIPTION
Skip temporary until we address [this ticket](https://linear.app/cardstack/issue/CS-10861/run-submission-linter-in-workeras-a-job)  so it wont be a blocker to make a PR to Github