### PR TITLE
Fix boxel-cli bin warning on fresh clone/worktree

### DIFF
--- a/packages/boxel-cli/.eslintignore
+++ b/packages/boxel-cli/.eslintignore
@@ -1,4 +1,5 @@
 node_modules/
 dist/
+bin/
 *.tgz
 *.log

--- a/packages/boxel-cli/README.md
+++ b/packages/boxel-cli/README.md
@@ -49,31 +49,42 @@ pnpm build
 pnpm start
 ```
 
-### Local Development with `npm link`
+### Local Development
 
-To use your locally-built `boxel-cli` instead of the npm-installed version:
+Run directly from TypeScript source without building:
 
 ```bash
-# 1. Build the CLI
 cd packages/boxel-cli
-pnpm build
+pnpm start -- <command> [args]
 
-# 2. Create a global symlink from the package directory
-npm link
-
-# 3. Verify the global `boxel` command now points to your local build
-which boxel
-boxel --version
+# Examples:
+pnpm start -- --help
+pnpm start -- sync .
+pnpm start -- profile list
 ```
 
-To revert to the npm-installed version:
+No build step needed — changes to source are reflected immediately.
+
+### Local Development with `npm link`
+
+To use the `boxel` command globally during development:
+
+```bash
+# From packages/boxel-cli
+npm link
+
+# Now you can use `boxel` anywhere — no build required
+boxel --help
+boxel sync .
+```
+
+The linked command automatically uses `dist/index.js` if built, or falls back to running TypeScript source via `tsx`.
+
+To unlink:
 
 ```bash
 npm unlink -g @cardstack/boxel-cli
-npm install -g @cardstack/boxel-cli
 ```
-
-**Note:** After making source changes, re-run `pnpm build` in `packages/boxel-cli` for the linked command to reflect updates. Alternatively, use `pnpm start` during development to run directly from TypeScript source without rebuilding.
 
 ### Code Quality
 

--- a/packages/boxel-cli/README.md
+++ b/packages/boxel-cli/README.md
@@ -78,7 +78,7 @@ boxel --help
 boxel sync .
 ```
 
-The linked command automatically uses `dist/index.js` if built, or falls back to running TypeScript source via `tsx`.
+The linked command automatically uses `dist/index.js` if built, or falls back to running TypeScript source via `ts-node`.
 
 To unlink:
 

--- a/packages/boxel-cli/bin/boxel.js
+++ b/packages/boxel-cli/bin/boxel.js
@@ -9,7 +9,7 @@ const distEntry = path.resolve(__dirname, '..', 'dist', 'index.js');
 if (fs.existsSync(distEntry)) {
   require(distEntry);
 } else {
-  // Development fallback: run from TypeScript source via tsx
-  require('tsx/cjs');
+  // Development fallback: run from TypeScript source via ts-node
+  require('ts-node').register({ transpileOnly: true });
   require('../src/index.ts');
 }

--- a/packages/boxel-cli/bin/boxel.js
+++ b/packages/boxel-cli/bin/boxel.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const fs = require('fs');
+
+// Use the built dist version if available, otherwise fall back to ts-node
+const distEntry = path.resolve(__dirname, '..', 'dist', 'index.js');
+
+if (fs.existsSync(distEntry)) {
+  require(distEntry);
+} else {
+  // Development fallback: run from TypeScript source via tsx
+  require('tsx/cjs');
+  require('../src/index.ts');
+}

--- a/packages/boxel-cli/package.json
+++ b/packages/boxel-cli/package.json
@@ -5,7 +5,7 @@
   "description": "CLI tools for Boxel workspace management",
   "main": "./dist/index.js",
   "bin": {
-    "boxel": "./dist/index.js"
+    "boxel": "./bin/boxel.js"
   },
   "files": [
     "dist/**/*",
@@ -48,7 +48,6 @@
     "eslint-plugin-n": "catalog:",
     "eslint-plugin-prettier": "catalog:",
     "prettier": "catalog:",
-    "ts-node": "^10.9.1",
     "tsx": "^4.0.0",
     "typescript": "catalog:",
     "vite": "catalog:",
@@ -57,7 +56,7 @@
   "scripts": {
     "build": "pnpm clean && tsx scripts/build.ts",
     "clean": "rm -rf dist/*",
-    "start": "NODE_NO_WARNINGS=1 ts-node --transpileOnly src/index.ts",
+    "start": "tsx src/index.ts",
     "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"pnpm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --report-unused-disable-directives --cache",
@@ -75,6 +74,9 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true
+    "provenance": true,
+    "bin": {
+      "boxel": "./dist/index.js"
+    }
   }
 }

--- a/packages/boxel-cli/package.json
+++ b/packages/boxel-cli/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-n": "catalog:",
     "eslint-plugin-prettier": "catalog:",
     "prettier": "catalog:",
+    "ts-node": "^10.9.1",
     "tsx": "^4.0.0",
     "typescript": "catalog:",
     "vite": "catalog:",
@@ -56,7 +57,7 @@
   "scripts": {
     "build": "pnpm clean && tsx scripts/build.ts",
     "clean": "rm -rf dist/*",
-    "start": "tsx src/index.ts",
+    "start": "NODE_NO_WARNINGS=1 ts-node --transpileOnly src/index.ts",
     "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"pnpm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --report-unused-disable-directives --cache",

--- a/packages/boxel-cli/package.json
+++ b/packages/boxel-cli/package.json
@@ -49,13 +49,12 @@
     "eslint-plugin-prettier": "catalog:",
     "prettier": "catalog:",
     "ts-node": "^10.9.1",
-    "tsx": "^4.0.0",
     "typescript": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"
   },
   "scripts": {
-    "build": "pnpm clean && tsx scripts/build.ts",
+    "build": "pnpm clean && NODE_NO_WARNINGS=1 ts-node --transpileOnly scripts/build.ts",
     "clean": "rm -rf dist/*",
     "start": "NODE_NO_WARNINGS=1 ts-node --transpileOnly src/index.ts",
     "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1098,6 +1098,9 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.7.4
+      ts-node:
+        specifier: ^10.9.1
+        version: 10.9.2(@types/node@24.10.8)(typescript@5.9.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1098,9 +1098,6 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.7.4
-      ts-node:
-        specifier: ^10.9.1
-        version: 10.9.2(@types/node@24.10.8)(typescript@5.9.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1101,9 +1101,6 @@ importers:
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@types/node@24.10.8)(typescript@5.9.3)
-      tsx:
-        specifier: ^4.0.0
-        version: 4.21.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
## Summary
- Move published `bin` target to `publishConfig` so pnpm doesn't warn about missing `dist/index.js` on fresh clones/worktrees
- Add `bin/boxel.js` wrapper that uses built dist when available, falls back to `ts-node` for development (no build required)
- Remove `tsx` dependency, use `ts-node` exclusively for consistency with monorepo conventions (migration to Node 24 native TS tracked in CS-10712)

## Test plan
- [ ] `rm -rf packages/boxel-cli/dist && pnpm install` — no warning
- [ ] `npm link` from `packages/boxel-cli` — `boxel --help` works without building
- [ ] `pnpm build && boxel --help` — uses built dist
- [ ] `pnpm publish:dry` — verify published package has correct bin

Fixes CS-10877

🤖 Generated with [Claude Code](https://claude.com/claude-code)