### PR TITLE
Fix catalog:update silently keeping stale contents/ when dirty

### DIFF
--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
-    "catalog:setup": "[ -d contents ] || (git clone git@github.com:cardstack/boxel-catalog.git contents || git clone https://github.com/cardstack/boxel-catalog.git contents)",
-    "catalog:update": "pnpm catalog:setup && cd contents && git pull",
+    "catalog:setup": "[ -d contents ] || git clone git@github.com:cardstack/boxel-catalog.git contents || git clone https://github.com/cardstack/boxel-catalog.git contents || { echo 'both ssh and https clone failed; check GitHub auth and network'; exit 1; }",
+    "catalog:update": "sh scripts/catalog-update.sh",
     "catalog:reset": "rm -rf contents && pnpm catalog:setup"
   }
 }

--- a/packages/catalog/scripts/catalog-update.sh
+++ b/packages/catalog/scripts/catalog-update.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Pulls latest boxel-catalog into contents/.
+#
+# Tries `git pull` first so non-conflicting local edits (the documented
+# local-dev workflow in ../README.md) are preserved in place. If the pull
+# is rejected specifically because local/untracked files would be
+# overwritten, stashes those (with a UTC-timestamped label) and retries.
+# Any other failure — network, auth, diverged branch — is surfaced with
+# git's original message.
+set -e
+
+# Anchor to packages/catalog/ so the script works regardless of CWD
+# (e.g. `sh packages/catalog/scripts/catalog-update.sh` from repo root).
+SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPTS_DIR/.."
+
+pnpm catalog:setup
+cd contents
+
+# Force English error messages so the detection grep below is locale-safe.
+export LANG=C
+export LC_ALL=C
+
+if PULL_OUT=$(git pull 2>&1); then
+  echo "$PULL_OUT"
+  exit 0
+fi
+
+if echo "$PULL_OUT" | grep -qE 'untracked working tree files would be overwritten|Your local changes to the following files would be overwritten'; then
+  STASH_LABEL="catalog:update autostash $(date -u +%Y%m%dT%H%M%SZ)"
+  echo "catalog: pull blocked by local changes, stashing as '${STASH_LABEL}' and retrying..."
+  git stash push --include-untracked -m "${STASH_LABEL}"
+  git pull
+  echo "catalog: updated. Stashed changes saved — review with:"
+  echo "  (cd packages/catalog/contents && git stash list)"
+  echo "Reapply with:"
+  echo "  (cd packages/catalog/contents && git stash pop)"
+  exit 0
+fi
+
+# Surface the original failure (network/auth/diverged/etc.)
+echo "$PULL_OUT" >&2
+exit 1


### PR DESCRIPTION
## Summary

`pnpm catalog:update` was failing silently when `packages/catalog/contents/`
had untracked files or local edits that collided with incoming commits — the
outer dev startup script doesn't propagate the failure, so the realm server
kept booting against a stale checkout. This looked like "dev just works" but
with old catalog data.

This PR moves the update logic out of a one-line `package.json` script into
`packages/catalog/scripts/catalog-update.sh` with named steps and `set -e`,
and fixes the staleness bug by auto-stashing local changes only when git
specifically reports they would be overwritten by the incoming merge.

## Behavior

- **Happy path (clean tree or non-conflicting local WIP):** `git pull` runs
  normally. The [documented local-dev workflow](packages/catalog/README.md)
  — editing files directly in `contents/` — keeps working; your WIP stays
  in place across realm restarts when it doesn't collide with upstream.
- **Stashes the entire working tree:** when git rejects the pull with
  `The following untracked working tree files would be overwritten` or
  `Your local changes to the following files would be overwritten`, the
  script stashes the offending changes (tracked + untracked) with a
  UTC-timestamped label (`catalog:update autostash 20260423T110004Z`),
  retries the pull, and prints recovery instructions:
  - Review: `(cd packages/catalog/contents && git stash list)`
  - Reapply: `(cd packages/catalog/contents && git stash pop)`
- **Other failures (network, auth, diverged branch):** git's original
  error is echoed to stderr and the script exits non-zero — no more
  misleading "stashing..." logs masking the real cause.
- **`catalog:setup`:** clone failures (both ssh and https) now exit with
  a clearer operator-facing message on a fresh box instead of a bare
  non-zero exit.