### PR TITLE
Stabilize flaky atomic update test with index poll

### DIFF
--- a/packages/realm-server/tests/atomic-endpoints-test.ts
+++ b/packages/realm-server/tests/atomic-endpoints-test.ts
@@ -898,6 +898,8 @@ module(basename(__filename), function () {
               return updatedCard?.data?.attributes?.firstName === 'Updated';
             },
             {
+              timeout: 3000,
+              interval: 50,
               timeoutMessage:
                 'updated firstName was not visible via /update-person',
             },

--- a/packages/realm-server/tests/atomic-endpoints-test.ts
+++ b/packages/realm-server/tests/atomic-endpoints-test.ts
@@ -12,6 +12,7 @@ import {
   setupPermissionedRealmCached,
   createJWT,
   type RealmRequest,
+  waitUntil,
   withRealmPath,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
@@ -883,11 +884,28 @@ module(basename(__filename), function () {
           assert.strictEqual(response.status, 201);
           assert.strictEqual(response.body['atomic:results'].length, 1);
 
-          let updatedCardResponse = await request
-            .get('/update-person')
-            .set('Accept', SupportedMimeType.CardJson);
-          let updatedCard = updatedCardResponse.body as LooseSingleCardDocument;
-          assert.strictEqual(updatedCard.data.attributes?.firstName, 'Updated');
+          // GET reads via the index; under load the index write can briefly
+          // lag the 201 response, so poll until it catches up.
+          let updatedCard: LooseSingleCardDocument | undefined;
+          await waitUntil(
+            async () => {
+              let updatedCardResponse = await request
+                .get('/update-person')
+                .set('Accept', SupportedMimeType.CardJson);
+              updatedCard = updatedCardResponse.body as
+                | LooseSingleCardDocument
+                | undefined;
+              return updatedCard?.data?.attributes?.firstName === 'Updated';
+            },
+            {
+              timeoutMessage:
+                'updated firstName was not visible via /update-person',
+            },
+          );
+          assert.strictEqual(
+            updatedCard?.data.attributes?.firstName,
+            'Updated',
+          );
         });
       });
       module('validation', function (hooks) {


### PR DESCRIPTION
## Summary
- `atomic-endpoints-test > error handling > can update an existing instance` has been flaking in CI with `actual: Initial, expected: Updated` ([example run](https://github.com/cardstack/boxel/actions/runs/24836291910/job/72697947528)).
- The `/_atomic` handler awaits `writeMany → performIndex → job.done`, so in steady state the update is indexed before 201 is returned. Under CI load the index-backed GET can still briefly return the pre-update value.
- Wrap the final GET + assertion in `waitUntil` so the test polls the index until it sees `firstName: 'Updated'`, with a `timeoutMessage` that fails loudly if the update truly never lands.

## Test plan
- [ ] CI green on `atomic-endpoints-test.ts` across reruns
- [ ] Revert the write path locally and confirm the test still fails (with the new `timeoutMessage`) rather than hanging or flaking further

🤖 Generated with [Claude Code](https://claude.com/claude-code)