### PR TITLE
Reduce flakiness in AI assistant panel skills + commands tests

### DIFF
--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -35,6 +35,7 @@ import type { BoxelContext } from 'https://cardstack.com/base/matrix-event';
 
 import {
   setupLocalIndexing,
+  addSkillToAiAssistant,
   setupOnSave,
   setupAuthEndpoints,
   setupUserSubscription,
@@ -2860,16 +2861,8 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await waitFor(`[data-room-settled]`);
 
     // First, let's add some skills to the current room
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await waitFor('[data-test-skill-menu]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await click(`[data-test-card-catalog-item="${testRealmURL}Skill/example"]`);
-    await click('[data-test-card-catalog-go-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await click(
-      `[data-test-card-catalog-item="${testRealmURL}Skill/example2"]`,
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/example`);
+    await addSkillToAiAssistant(`${testRealmURL}Skill/example2`);
 
     await waitUntil(
       () =>

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -2855,15 +2855,15 @@ module('Acceptance | AI Assistant tests', function (hooks) {
           },
         ],
       ],
+      aiAssistantOpen: true,
     });
 
-    await click('[data-test-open-ai-assistant]');
     await waitFor(`[data-room-settled]`);
 
     // First, let's add some skills to the current room
     await addSkillToAiAssistant(`${testRealmURL}Skill/example`);
     await addSkillToAiAssistant(`${testRealmURL}Skill/example2`);
-
+    await click('[data-test-skill-menu]');
     await waitUntil(
       () =>
         document.querySelectorAll(

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -344,10 +344,9 @@ ${REPLACE_MARKER}\n\`\`\``;
           },
         ],
       ],
+      aiAssistantOpen: true,
     });
     assert.dom(`[data-test-stack-card="${testRealmURL}index"]`).exists();
-
-    await click('[data-test-open-ai-assistant]');
     await waitFor('[data-room-settled]');
 
     await addSkillToAiAssistant(`${testRealmURL}Skill/useful-commands`);
@@ -599,10 +598,9 @@ ${REPLACE_MARKER}\n\`\`\``;
           },
         ],
       ],
+      aiAssistantOpen: true,
     });
     assert.dom(`[data-test-stack-card="${testRealmURL}index"]`).exists();
-
-    await click('[data-test-open-ai-assistant]');
     await waitFor('[data-room-settled]');
 
     await addSkillToAiAssistant(`${testRealmURL}Skill/useful-commands`);

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -28,6 +28,7 @@ import {
 } from '@cardstack/runtime-common/matrix-constants';
 
 import {
+  addSkillToAiAssistant,
   setupLocalIndexing,
   setupOnSave,
   setupRealmCacheTeardown,
@@ -349,15 +350,7 @@ ${REPLACE_MARKER}\n\`\`\``;
     await click('[data-test-open-ai-assistant]');
     await waitFor('[data-room-settled]');
 
-    // open skill menu
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-
-    // add useful-commands skill, which includes the switch-submode command
-    await click(
-      `[data-test-card-catalog-item="${testRealmURL}Skill/useful-commands"]`,
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/useful-commands`);
 
     // there are 3 patches in the message
     // 1. hello.txt: Hello, world! -> Hi, world!
@@ -612,15 +605,7 @@ ${REPLACE_MARKER}\n\`\`\``;
     await click('[data-test-open-ai-assistant]');
     await waitFor('[data-room-settled]');
 
-    // open skill menu
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-
-    // add useful-commands skill, which includes the switch-submode command
-    await click(
-      `[data-test-card-catalog-item="${testRealmURL}Skill/useful-commands"]`,
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/useful-commands`);
 
     // there are 3 patches in the message
     // 1. hello.txt: Hello, world! -> Hi, world! # will apply

--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -50,6 +50,7 @@ import type { SearchCardsByTypeAndTitleInput } from 'https://cardstack.com/base/
 import type { Skill } from 'https://cardstack.com/base/skill';
 
 import {
+  addSkillToAiAssistant,
   setupLocalIndexing,
   setupOnSave,
   testRealmURL,
@@ -649,19 +650,10 @@ module('Acceptance | Commands tests', function (hooks) {
           },
         ],
       ],
+      aiAssistantOpen: true,
     });
-    // open assistant
-    await click('[data-test-open-ai-assistant]');
     await waitFor('[data-room-settled]');
-    // open skill menu
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-
-    // add useful-commands skill, which includes the switch-submode command
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/useful-commands"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/useful-commands`);
 
     // simulate message
     let roomId = getRoomIds().pop()!;
@@ -739,18 +731,10 @@ module('Acceptance | Commands tests', function (hooks) {
           },
         ],
       ],
+      aiAssistantOpen: true,
     });
-    // open assistant
-    await click('[data-test-open-ai-assistant]');
     await waitFor('[data-room-settled]');
-    // open skill menu
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    // add useful-commands skill, which includes the switch-submode command
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/useful-commands"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/useful-commands`);
     // simulate message
     let roomId = getRoomIds().pop()!;
     simulateRemoteMessage(roomId, '@aibot:localhost', {
@@ -817,18 +801,10 @@ module('Acceptance | Commands tests', function (hooks) {
           },
         ],
       ],
+      aiAssistantOpen: true,
     });
-    // open assistant
-    await click('[data-test-open-ai-assistant]');
     await waitFor('[data-room-settled]');
-    // open skill menu
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    // add useful-commands skill, which includes the switch-submode command
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/useful-commands"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/useful-commands`);
     // simulate message
     let roomId = getRoomIds().pop()!;
     simulateRemoteMessage(roomId, '@aibot:localhost', {
@@ -869,15 +845,10 @@ module('Acceptance | Commands tests', function (hooks) {
           },
         ],
       ],
+      aiAssistantOpen: true,
     });
-    await click('[data-test-open-ai-assistant]');
     await waitFor('[data-room-settled]');
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/useful-commands"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/useful-commands`);
 
     let roomId = getRoomIds().pop()!;
     let description = 'Switching to code submode during preparation';
@@ -919,11 +890,10 @@ module('Acceptance | Commands tests', function (hooks) {
           },
         ],
       ],
+      aiAssistantOpen: true,
     });
     let roomId = getRoomIds().pop()!;
-    // open assistant, ShowCard command is part of default CardEditing skill
-    await click('[data-test-open-ai-assistant]');
-
+    // ShowCard command is part of default CardEditing skill
     // Need to create a new room so this new room will include skills card
     await waitFor('[data-test-message-field]');
     await fillIn(
@@ -948,7 +918,7 @@ module('Acceptance | Commands tests', function (hooks) {
             description:
               'Displaying the card with the Latin word for milkweed in the title.',
             attributes: {
-              cardId: 'http://test-realm/test/Person/hassan',
+              cardId: `${testRealmURL}Person/hassan`,
               cardInfo: { name: 'Asclepias' },
             },
           }),
@@ -1009,12 +979,10 @@ module('Acceptance | Commands tests', function (hooks) {
           },
         ],
       ],
+      aiAssistantOpen: true,
     });
     let roomId = getRoomIds().pop()!;
-    // open assistant, ShowCard command is part of default CardEditing skill
-    await click('[data-test-open-ai-assistant]');
-    await waitFor('[data-test-message-field]');
-
+    // ShowCard command is part of default CardEditing skill
     // Need to create a new room so this new room will include skills card
     await waitFor('[data-test-message-field]');
     await fillIn(
@@ -1039,7 +1007,7 @@ module('Acceptance | Commands tests', function (hooks) {
             description:
               'Displaying the card with the Latin word for milkweed in the title.',
             attributes: {
-              id: 'http://test-realm/test/Person/hassan',
+              id: `${testRealmURL}Person/hassan`,
               title: 'Asclepias',
             },
           }),
@@ -1064,16 +1032,10 @@ module('Acceptance | Commands tests', function (hooks) {
   test('multiple commands can be requested in a single aibot message', async function (assert) {
     await visitOperatorMode({
       stacks: [[{ id: `${testRealmURL}index`, format: 'isolated' }]],
+      aiAssistantOpen: true,
     });
-    await click('[data-test-open-ai-assistant]');
-    // open skill menu
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/useful-commands"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await waitFor('[data-room-settled]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/useful-commands`);
 
     // simulate message
     let roomId = getRoomIds().pop()!;
@@ -1114,20 +1076,12 @@ module('Acceptance | Commands tests', function (hooks) {
           },
         ],
       ],
+      aiAssistantOpen: true,
     });
 
-    await click('[data-test-open-ai-assistant]');
     await waitFor(`[data-room-settled]`);
 
-    // open skill menu
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-
-    // add useful-commands skill, which includes the switch-submode command
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/useful-commands"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/useful-commands`);
     await click(
       '[data-test-skill-menu] [data-test-pill-menu-header] [data-test-pill-menu-button]',
     );
@@ -1328,7 +1282,7 @@ module('Acceptance | Commands tests', function (hooks) {
             description:
               'Displaying the card with the Latin word for milkweed in the title.',
             attributes: {
-              id: 'http://test-realm/test/Person/hassan',
+              id: `${testRealmURL}Person/hassan`,
               title: 'Asclepias',
             },
           }),

--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -1082,6 +1082,7 @@ module('Acceptance | Commands tests', function (hooks) {
     await waitFor(`[data-room-settled]`);
 
     await addSkillToAiAssistant(`${testRealmURL}Skill/useful-commands`);
+    await click('[data-test-skill-menu]');
     await click(
       '[data-test-skill-menu] [data-test-pill-menu-header] [data-test-pill-menu-button]',
     );

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -6,7 +6,7 @@ import {
   visit,
   settled,
 } from '@ember/test-helpers';
-import { fillIn, findAll, waitUntil, waitFor, click } from '@ember/test-helpers';
+import { click, findAll, waitUntil, waitFor } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
@@ -42,6 +42,7 @@ import {
   type RenderError,
 } from '@cardstack/runtime-common';
 
+import UpdateRoomSkillsCommand from '@cardstack/host/commands/update-room-skills';
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import ENV from '@cardstack/host/config/environment';
 import {
@@ -1993,24 +1994,60 @@ export async function verifyJSONWithUUIDInFolder(
 
 export async function addSkillToAiAssistant(
   skillCardId: string,
-  search?: string,
+  _search?: string,
+  roomId?: string,
 ) {
-  if (!document.querySelector('[data-test-skill-menu] [data-test-pill-menu-add-button]')) {
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
+  let resolvedRoomId =
+    roomId ??
+    document.querySelector('[data-test-room]')?.getAttribute('data-test-room');
+
+  if (!resolvedRoomId) {
+    throw new Error(
+      `Expected an active AI assistant room before adding skill "${skillCardId}"`,
+    );
   }
-  await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-  if (search) {
-    await fillIn('[data-test-search-field]', search);
-  }
-  await click(`[data-test-card-catalog-item="${skillCardId}"]`);
-  await click('[data-test-card-catalog-go-button]');
+
+  let command = new UpdateRoomSkillsCommand(
+    getService('command-service').commandContext,
+  );
+  await command.execute({
+    roomId: resolvedRoomId,
+    skillCardIdsToActivate: [skillCardId],
+  });
+
+  let matrixService = getService('matrix-service') as {
+    getRoomData(roomId: string): {
+      skillsConfig: {
+        enabledSkillCards?: Array<{ sourceUrl?: string }>;
+      };
+    } | null;
+  };
+
   await waitUntil(
     () =>
       Boolean(
-        document.querySelector(
-          `[data-test-skill-options-button="${skillCardId}"]`,
-        ),
+        matrixService
+          .getRoomData(resolvedRoomId)
+          ?.skillsConfig.enabledSkillCards?.some(
+            (fileDef) => fileDef.sourceUrl === skillCardId,
+          ),
       ),
-    { timeoutMessage: `Timed out waiting for skill options button for "${skillCardId}"` },
+    {
+      timeoutMessage: `Timed out waiting for room skill state for "${skillCardId}"`,
+    },
   );
+
+  if (document.querySelector('[data-test-skill-menu]')) {
+    await waitUntil(
+      () =>
+        Boolean(
+          document.querySelector(
+            `[data-test-skill-options-button="${skillCardId}"]`,
+          ),
+        ),
+      {
+        timeoutMessage: `Timed out waiting for skill options button for "${skillCardId}"`,
+      },
+    );
+  }
 }

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -1994,7 +1994,6 @@ export async function verifyJSONWithUUIDInFolder(
 
 export async function addSkillToAiAssistant(
   skillCardId: string,
-  _search?: string,
   roomId?: string,
 ) {
   let resolvedRoomId =
@@ -2033,21 +2032,9 @@ export async function addSkillToAiAssistant(
           ),
       ),
     {
+      timeout: 5000,
       timeoutMessage: `Timed out waiting for room skill state for "${skillCardId}"`,
     },
   );
 
-  if (document.querySelector('[data-test-skill-menu]')) {
-    await waitUntil(
-      () =>
-        Boolean(
-          document.querySelector(
-            `[data-test-skill-options-button="${skillCardId}"]`,
-          ),
-        ),
-      {
-        timeoutMessage: `Timed out waiting for skill options button for "${skillCardId}"`,
-      },
-    );
-  }
 }

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -2036,5 +2036,4 @@ export async function addSkillToAiAssistant(
       timeoutMessage: `Timed out waiting for room skill state for "${skillCardId}"`,
     },
   );
-
 }

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -6,7 +6,7 @@ import {
   visit,
   settled,
 } from '@ember/test-helpers';
-import { findAll, waitUntil, waitFor, click } from '@ember/test-helpers';
+import { fillIn, findAll, waitUntil, waitFor, click } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
@@ -1989,4 +1989,28 @@ export async function verifyJSONWithUUIDInFolder(
       'file name shape not as expected when checking for [uuid].[extension]',
     );
   }
+}
+
+export async function addSkillToAiAssistant(
+  skillCardId: string,
+  search?: string,
+) {
+  if (!document.querySelector('[data-test-skill-menu] [data-test-pill-menu-add-button]')) {
+    await click('[data-test-skill-menu][data-test-pill-menu-button]');
+  }
+  await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
+  if (search) {
+    await fillIn('[data-test-search-field]', search);
+  }
+  await click(`[data-test-card-catalog-item="${skillCardId}"]`);
+  await click('[data-test-card-catalog-go-button]');
+  await waitUntil(
+    () =>
+      Boolean(
+        document.querySelector(
+          `[data-test-skill-options-button="${skillCardId}"]`,
+        ),
+      ),
+    { timeoutMessage: `Timed out waiting for skill options button for "${skillCardId}"` },
+  );
 }

--- a/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
@@ -1369,7 +1369,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     await waitFor('[data-test-room-name="test room 1"]', { timeout: 10000 });
 
     // add environment skill
-    await addSkillToAiAssistant('http://test-realm/test/Skill/boxel-environment');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/boxel-environment`);
 
     simulateRemoteMessage(roomId, '@aibot:localhost', {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
@@ -1460,7 +1460,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     await waitFor('[data-test-room-name="test room 1"]', { timeout: 10000 });
 
     // add environment skill
-    await addSkillToAiAssistant('http://test-realm/test/Skill/boxel-environment');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/boxel-environment`);
 
     simulateRemoteMessage(roomId, '@aibot:localhost', {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,

--- a/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
@@ -23,6 +23,7 @@ import OperatorMode from '@cardstack/host/components/operator-mode/container';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import {
+  addSkillToAiAssistant,
   percySnapshot,
   testRealmURL,
   setupCardLogs,
@@ -1368,13 +1369,10 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     await waitFor('[data-test-room-name="test room 1"]', { timeout: 10000 });
 
     // add environment skill
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await fillIn('[data-test-search-field]', 'boxel environment');
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/boxel-environment"]',
+    await addSkillToAiAssistant(
+      'http://test-realm/test/Skill/boxel-environment',
+      'boxel environment',
     );
-    await click('[data-test-card-catalog-go-button]');
 
     simulateRemoteMessage(roomId, '@aibot:localhost', {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
@@ -1465,13 +1463,10 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     await waitFor('[data-test-room-name="test room 1"]', { timeout: 10000 });
 
     // add environment skill
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await fillIn('[data-test-search-field]', 'boxel environment');
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/boxel-environment"]',
+    await addSkillToAiAssistant(
+      'http://test-realm/test/Skill/boxel-environment',
+      'boxel environment',
     );
-    await click('[data-test-card-catalog-go-button]');
 
     simulateRemoteMessage(roomId, '@aibot:localhost', {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,

--- a/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
@@ -1369,10 +1369,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     await waitFor('[data-test-room-name="test room 1"]', { timeout: 10000 });
 
     // add environment skill
-    await addSkillToAiAssistant(
-      'http://test-realm/test/Skill/boxel-environment',
-      'boxel environment',
-    );
+    await addSkillToAiAssistant('http://test-realm/test/Skill/boxel-environment');
 
     simulateRemoteMessage(roomId, '@aibot:localhost', {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
@@ -1463,10 +1460,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     await waitFor('[data-test-room-name="test room 1"]', { timeout: 10000 });
 
     // add environment skill
-    await addSkillToAiAssistant(
-      'http://test-realm/test/Skill/boxel-environment',
-      'boxel environment',
-    );
+    await addSkillToAiAssistant('http://test-realm/test/Skill/boxel-environment');
 
     simulateRemoteMessage(roomId, '@aibot:localhost', {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,

--- a/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
@@ -388,7 +388,10 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
             APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
           )?.enabledSkillCards?.some((card: any) => card.sourceUrl === skillId),
         ),
-      { timeoutMessage: `timed out waiting for ${skillId} to be enabled` },
+      {
+        timeout: 5000,
+        timeoutMessage: `timed out waiting for ${skillId} to be enabled`,
+      },
     );
     await click('[data-test-skill-menu]');
     assert

--- a/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
@@ -365,6 +365,55 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
     );
   });
 
+  test('skill picker can add a skill through the UI', async function (assert) {
+    const roomId = await renderAiAssistantPanel();
+    let skillId = `${testRealmURL}Skill/example`;
+
+    await click('[data-test-skill-menu][data-test-pill-menu-button]');
+    await waitFor('[data-test-skill-menu] [data-test-pill-menu-add-button]');
+    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
+    await waitFor(`[data-test-card-catalog-item="${skillId}"]`);
+    await click(`[data-test-card-catalog-item="${skillId}"]`);
+    await click('[data-test-card-catalog-go-button]');
+
+    await waitUntil(
+      () =>
+        Boolean(
+          getRoomState(
+            roomId,
+            APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
+          )?.enabledSkillCards?.some((card: any) => card.sourceUrl === skillId),
+        ),
+      { timeoutMessage: `timed out waiting for ${skillId} to be enabled` },
+    );
+
+    assert
+      .dom(`[data-test-skill-options-button="${skillId}"]`)
+      .exists('selected skill is shown in the skill menu');
+    assert.dom('[data-test-skill-menu]').containsText('Skills: 2 of 2 active');
+  });
+
+  test('skill picker excludes already-enabled skills', async function (assert) {
+    await renderAiAssistantPanel();
+    let enabledSkillId = `${testRealmURL}Skill/example`;
+    let availableSkillId = `${testRealmURL}Skill/example2`;
+
+    await addSkillToAiAssistant(enabledSkillId);
+
+    await click('[data-test-skill-menu][data-test-pill-menu-button]');
+    await waitFor('[data-test-skill-menu] [data-test-pill-menu-add-button]');
+    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
+    await fillIn('[data-test-search-field]', 'Exanple');
+    await waitFor(`[data-test-card-catalog-item="${availableSkillId}"]`);
+
+    assert
+      .dom(`[data-test-card-catalog-item="${enabledSkillId}"]`)
+      .doesNotExist('already-enabled skill is excluded from the picker');
+    assert
+      .dom(`[data-test-card-catalog-item="${availableSkillId}"]`)
+      .exists('a different skill remains available in the picker');
+  });
+
   test('skill pill menu opens the skill card', async function (assert) {
     await renderAiAssistantPanel();
 

--- a/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
@@ -28,6 +28,7 @@ import type OperatorModeStateService from '@cardstack/host/services/operator-mod
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 import {
+  addSkillToAiAssistant,
   envSkillId,
   testRealmURL,
   setupCardLogs,
@@ -282,19 +283,23 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
     });
   });
 
-  async function setCardInOperatorModeState(
-    cardURL?: string,
-    format: 'isolated' | 'edit' = 'isolated',
-  ) {
-    await operatorModeStateService.restore({
-      stacks: cardURL ? [[{ id: cardURL, format }]] : [[]],
+  async function renderAiAssistantPanel(id?: string) {
+    operatorModeStateService.restore({
+      stacks: id ? [[{ id, format: 'isolated' }]] : [[]],
+      aiAssistantOpen: true,
     });
-  }
-
-  async function openAiAssistant(): Promise<string> {
-    await waitFor('[data-test-open-ai-assistant]');
-    await click('[data-test-open-ai-assistant]');
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
     await waitFor('[data-test-room-settled]');
+    await waitUntil(
+      () =>
+        document
+          .querySelector('[data-test-active-skills-count]')
+          ?.textContent?.trim() === '1 Skill',
+    );
     let roomId = document
       .querySelector('[data-test-room]')
       ?.getAttribute('data-test-room');
@@ -304,37 +309,15 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
     return roomId;
   }
 
-  async function renderAiAssistantPanel(id?: string) {
-    await setCardInOperatorModeState(id);
-    await renderComponent(
-      class TestDriver extends GlimmerComponent {
-        <template><OperatorMode @onClose={{noop}} /></template>
-      },
-    );
-    let roomId = await openAiAssistant();
-    return roomId;
-  }
-
   test('same skill card added twice with no changes results in no-op', async function (assert) {
     const roomId = await renderAiAssistantPanel(
       `${testRealmURL}Person/fadhlan`,
     );
 
-    await waitFor('[data-test-room-settled]');
-    await waitUntil(
-      () =>
-        document
-          .querySelector('[data-test-active-skills-count]')
-          ?.textContent?.trim() === '1 Skill',
-    );
     assert.dom('[data-test-active-skills-count]').containsText('1 Skill');
     await click('[data-test-skill-menu][data-test-pill-menu-button]');
     assert.dom('[data-test-skill-menu]').containsText('Skills: 1 of 1 active');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/example"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/example`);
     await waitUntil(() =>
       document
         .querySelector('[data-test-skill-menu]')
@@ -384,19 +367,9 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
 
   test('skill pill menu opens the skill card', async function (assert) {
     await renderAiAssistantPanel();
-    await waitFor('[data-test-room-settled]');
 
     let skillId = `${testRealmURL}Skill/example`;
-
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await click(`[data-test-card-catalog-item="${skillId}"]`);
-    await click('[data-test-card-catalog-go-button]');
-    await waitUntil(() =>
-      Boolean(
-        document.querySelector(`[data-test-skill-options-button="${skillId}"]`),
-      ),
-    );
+    await addSkillToAiAssistant(skillId);
 
     assert.false(
       operatorModeStateService.getOpenCardIds().includes(skillId),
@@ -418,12 +391,9 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
 
   test('skill pill menu opens the skill card while in code mode', async function (assert) {
     await renderAiAssistantPanel(`${testRealmURL}Skill/example`);
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
 
     let skillId = `${testRealmURL}Skill/example`;
-    await click(`[data-test-card-catalog-item="${skillId}"]`);
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(skillId);
 
     await click('[data-test-submode-switcher] button');
     await click('[data-test-boxel-menu-item-text="Code"]');
@@ -453,22 +423,8 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
     const roomId1 = await renderAiAssistantPanel(
       `${testRealmURL}Skill/example`,
     );
-
-    await waitFor('[data-test-room-settled]');
-    await waitUntil(
-      () =>
-        document
-          .querySelector('[data-test-active-skills-count]')
-          ?.textContent?.trim() === '1 Skill',
-    );
-    assert.dom('[data-test-active-skills-count]').containsText('1 Skill');
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    assert.dom('[data-test-skill-menu]').containsText('Skills: 1 of 1 active');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/example"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    const skillId = `${testRealmURL}Skill/example`;
+    await addSkillToAiAssistant(skillId);
     await fillIn(
       '[data-test-boxel-input-id="ai-chat-input"]',
       'Upload the skill cards and command definitions',
@@ -491,12 +447,7 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
     }
 
     // Add the same skill card without changes
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/example"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(skillId);
     await fillIn(
       '[data-test-boxel-input-id="ai-chat-input"]',
       'Use the previous command definition',
@@ -553,12 +504,7 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
     }
 
     // Add the skill card with modified command
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/example"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(skillId);
     await fillIn(
       '[data-test-boxel-input-id="ai-chat-input"]',
       'Change the command',
@@ -624,11 +570,7 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
     assert.dom('[data-test-active-skills-count]').containsText('1 Skill');
     await click('[data-test-skill-menu][data-test-pill-menu-button]');
     assert.dom('[data-test-skill-menu]').containsText('Skills: 1 of 1 active');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/example"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/example`);
     await fillIn(
       '[data-test-boxel-input-id="ai-chat-input"]',
       'Upload the skill cards and command definitions',
@@ -719,12 +661,7 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
   test('updated skill card instructions result in new event and updated room state when sending message', async function (assert) {
     const roomId = await renderAiAssistantPanel(`${testRealmURL}Skill/example`);
 
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/example"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/example`);
 
     const initialRoomStateSkillsJson = getRoomState(
       roomId,
@@ -800,12 +737,7 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
   test('updated skill card instructions result in new event and updated room state when command is completing', async function (assert) {
     const roomId = await renderAiAssistantPanel(`${testRealmURL}Skill/example`);
 
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/example"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/example`);
 
     const initialRoomStateSkillsJson = getRoomState(
       roomId,
@@ -900,12 +832,7 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
   test('updated skill card instructions result in new event and updated room state when code patch is completing', async function (assert) {
     const roomId = await renderAiAssistantPanel(`${testRealmURL}Skill/example`);
 
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/example"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/example`);
 
     const initialRoomStateSkillsJson = getRoomState(
       roomId,
@@ -993,12 +920,7 @@ ${REPLACE_MARKER}
   test('updated command definition results in new event and updated room state', async function (assert) {
     const roomId = await renderAiAssistantPanel(`${testRealmURL}Skill/example`);
 
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/example"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/example`);
 
     const initialRoomStateSkillsJson = getRoomState(
       roomId,
@@ -1139,12 +1061,7 @@ ${REPLACE_MARKER}
   test('adding skill card results in new command definitions being added but not duplicated', async function (assert) {
     const roomId = await renderAiAssistantPanel(`${testRealmURL}Skill/example`);
 
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/example"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/example`);
     await click('[data-test-send-message-btn]');
     await click('[data-test-pill-menu-button]');
 
@@ -1168,12 +1085,7 @@ ${REPLACE_MARKER}
       'placeholder is not present',
     );
     // Attach the second skill card
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
-    await click(
-      '[data-test-card-catalog-item="http://test-realm/test/Skill/example2"]',
-    );
-    await click('[data-test-card-catalog-go-button]');
+    await addSkillToAiAssistant(`${testRealmURL}Skill/example2`);
     await click('[data-test-send-message-btn]');
     const finalRoomStateSkillsJson = getRoomState(
       roomId,

--- a/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
@@ -299,7 +299,10 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
         document
           .querySelector('[data-test-active-skills-count]')
           ?.textContent?.trim() === '1 Skill',
-      { timeout: 5000, timeoutMessage: 'Timed out waiting for env skill to be active' },
+      {
+        timeout: 5000,
+        timeoutMessage: 'Timed out waiting for env skill to be active',
+      },
     );
     let roomId = document
       .querySelector('[data-test-room]')
@@ -387,7 +390,7 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
         ),
       { timeoutMessage: `timed out waiting for ${skillId} to be enabled` },
     );
-
+    await click('[data-test-skill-menu]');
     assert
       .dom(`[data-test-skill-options-button="${skillId}"]`)
       .exists('selected skill is shown in the skill menu');
@@ -401,7 +404,11 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
 
     await addSkillToAiAssistant(enabledSkillId);
 
-    if (!document.querySelector('[data-test-skill-menu] [data-test-pill-menu-add-button]')) {
+    if (
+      !document.querySelector(
+        '[data-test-skill-menu] [data-test-pill-menu-add-button]',
+      )
+    ) {
       await click('[data-test-skill-menu][data-test-pill-menu-button]');
     }
     await waitFor('[data-test-skill-menu] [data-test-pill-menu-add-button]');
@@ -422,12 +429,12 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
 
     let skillId = `${testRealmURL}Skill/example`;
     await addSkillToAiAssistant(skillId);
-
     assert.false(
       operatorModeStateService.getOpenCardIds().includes(skillId),
       'skill card is not open before using the menu',
     );
 
+    await click('[data-test-skill-menu]');
     await click(`[data-test-skill-options-button="${skillId}"]`);
     await waitFor('[data-test-boxel-menu-item-text="Open Skill Card"]');
     await click('[data-test-boxel-menu-item-text="Open Skill Card"]');

--- a/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
@@ -299,6 +299,7 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
         document
           .querySelector('[data-test-active-skills-count]')
           ?.textContent?.trim() === '1 Skill',
+      { timeout: 5000, timeoutMessage: 'Timed out waiting for env skill to be active' },
     );
     let roomId = document
       .querySelector('[data-test-room]')
@@ -400,7 +401,9 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
 
     await addSkillToAiAssistant(enabledSkillId);
 
-    await click('[data-test-skill-menu][data-test-pill-menu-button]');
+    if (!document.querySelector('[data-test-skill-menu] [data-test-pill-menu-add-button]')) {
+      await click('[data-test-skill-menu][data-test-pill-menu-button]');
+    }
     await waitFor('[data-test-skill-menu] [data-test-pill-menu-add-button]');
     await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
     await fillIn('[data-test-search-field]', 'Exanple');
@@ -1112,7 +1115,6 @@ ${REPLACE_MARKER}
 
     await addSkillToAiAssistant(`${testRealmURL}Skill/example`);
     await click('[data-test-send-message-btn]');
-    await click('[data-test-pill-menu-button]');
 
     const initialRoomStateSkillsJson = getRoomState(
       roomId,


### PR DESCRIPTION
## Summary

- Introduces a shared `addSkillToAiAssistant` helper that activates a skill card by directly invoking `UpdateRoomSkillsCommand` instead of clicking through the card catalog UI. This removes a class of flakiness caused by catalog animations and timing races. Used across 5 test files (~30 call sites) replacing repeated 4–5 click sequences.
- Passes `aiAssistantOpen: true` to `visitOperatorMode` wherever the AI panel was opened as pure setup. This encodes the open state in the URL before the app boots, eliminating the animation race from `click('[data-test-open-ai-assistant]')`. --> Note: Only updated this in test files I was already touching. There are probably more cases throughout the tests where this query param can be used.
- Adds `waitFor('[data-test-room-settled]')` to tests that were missing it, ensuring room state is fully initialized before each test proceeds.
- Adds explicit `timeout` and `timeoutMessage` to `waitUntil` calls that depend on indexing or matrix state propagation, so slow CI environments get a clearer failure message instead of a silent 1-second default timeout.
- Extracts `renderAiAssistantPanel` in `skills-test.gts`, consolidating the setup pattern (state restore → render → wait for room → wait for env skill) into one reusable function.
- Adds two focused tests for the skill picker UI (`skill picker can add a skill through the UI`, `skill picker excludes already-enabled skills`) that were previously untested as isolated scenarios. --> these specifically test the UI interaction pattern, instead of doing the UI clicks in every single test that didn't really need to do it.

## Test plan

- [x] Run `packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts` locally — all tests pass
- [x] Run `packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts` locally — all tests pass
- [x] Run `packages/host/tests/acceptance/commands-test.gts` locally — all tests pass
~- [ ] Confirm no new `click('[data-test-open-ai-assistant]')` calls appear where `aiAssistantOpen: true` could be used instead~ --> Note: Only updated this in test files I was already touching. There are probably more cases throughout the tests where this query param can be used.
- [x] Verify CI run passes without the flaky failures seen previously in the AI assistant panel tests


🤖 Generated with [Claude Code](https://claude.com/claude-code)