### PR TITLE
CS-10873: cancel prerender on client abort

### DIFF
--- a/packages/realm-server/prerender/manager-app.ts
+++ b/packages/realm-server/prerender/manager-app.ts
@@ -820,6 +820,37 @@ export function buildPrerenderManagerApp(options?: {
       randomUUID();
     ctxt.set(PRERENDER_REQUEST_ID_HEADER, requestId);
     let proxyStart = now();
+    // Propagate client-disconnect into the upstream fetch so the
+    // prerender server can cancel whatever it was doing and free
+    // the tab for another request. Without this, a worker that
+    // aborts at 150 s leaves the prerender server rendering for
+    // another ~15-20 s and discards the result — ~2x render budget
+    // per timeout under saturation. `currentAc` is the attempt's
+    // live AbortController, set at the top of each retry iteration
+    // so the close listener aborts the right one.
+    let clientAborted = false;
+    let currentAc: AbortController | undefined;
+    let clientAbortAffinity: string | undefined;
+    let clientAbortTarget: string | undefined;
+    const onClientClose = () => {
+      // ServerResponse 'close' fires after the response is flushed on
+      // normal completion (writableEnded=true) OR when the connection
+      // is torn down prematurely (writableEnded=false). We want the
+      // latter. Note: we listen on `ctxt.res`, NOT `ctxt.req` — Node
+      // 17+ auto-destroys IncomingMessage after the body is consumed,
+      // firing `req.close` long before the response is sent, which
+      // would false-trigger this handler on every normal request.
+      if (ctxt.res.writableEnded) return;
+      if (clientAborted) return;
+      clientAborted = true;
+      log.info(
+        `client-aborted after ${now() - proxyStart}ms requestId=${requestId} ` +
+          `affinity=${clientAbortAffinity ?? '<unknown>'} ` +
+          `target=${clientAbortTarget ?? '<unassigned>'}`,
+      );
+      currentAc?.abort();
+    };
+    ctxt.res.on('close', onClientClose);
     try {
       if (options?.isDraining?.()) {
         ctxt.status = PRERENDER_SERVER_DRAINING_STATUS_CODE;
@@ -887,9 +918,11 @@ export function buildPrerenderManagerApp(options?: {
         return;
       }
       let affinityKey = toAffinityKey({ affinityType, affinityValue });
+      clientAbortAffinity = affinityKey;
       if (registry.servers.size === 0 && discoveryWaitMs > 0) {
         let start = now();
         while (registry.servers.size === 0 && now() - start < discoveryWaitMs) {
+          if (clientAborted) return;
           await delay(discoveryPollMs);
         }
       }
@@ -901,6 +934,10 @@ export function buildPrerenderManagerApp(options?: {
       }
       let attempts = new Set<string>();
       while (attempts.size < registry.servers.size) {
+        // Short-circuit the retry loop on client abort — the
+        // caller gave up, so don't waste another server's render
+        // budget on a retry no one is waiting for.
+        if (clientAborted) return;
         let target = chooseServerForAffinity(affinityType, affinityValue, {
           exclude: attempts,
         });
@@ -918,6 +955,7 @@ export function buildPrerenderManagerApp(options?: {
         attempts.add(target);
 
         const targetURL = `${normalizeURL(target)}/${pathSuffix}`;
+        clientAbortTarget = target;
         let logTarget = attrs.url ?? attrs.command ?? '<unknown>';
         let queueMs = now() - proxyStart;
         log.info(
@@ -925,6 +963,17 @@ export function buildPrerenderManagerApp(options?: {
         );
         let abortedDueToDrain = false;
         const ac = new AbortController();
+        // Expose this attempt's controller so the ctxt.res 'close'
+        // listener can abort the current upstream fetch
+        // immediately when the client disconnects. If the client
+        // already disconnected before we got here, abort pre-flight
+        // so the upstream server can drop the request as cheaply
+        // as possible.
+        currentAc = ac;
+        if (clientAborted) {
+          ac.abort();
+          return;
+        }
         const timer = setTimeout(() => ac.abort(), proxyTimeoutMs).unref?.();
         const drainPoll =
           options?.isDraining && proxyTimeoutMs > 50
@@ -948,6 +997,14 @@ export function buildPrerenderManagerApp(options?: {
           body: raw,
           signal: ac.signal,
         }).catch((e) => {
+          if (e?.name === 'AbortError' && clientAborted) {
+            // Client gave up — not our fault, not the upstream's
+            // fault. Don't prune, don't mark drain. The outer
+            // `if (clientAborted) return;` below will short-circuit
+            // and the client's HTTP connection is already dead so
+            // nothing we write here matters.
+            return null as any;
+          }
           if (e?.name === 'AbortError' && options?.isDraining?.()) {
             abortedDueToDrain = true;
           } else {
@@ -960,6 +1017,11 @@ export function buildPrerenderManagerApp(options?: {
         });
         clearTimeout(timer as any);
         if (drainPoll) clearInterval(drainPoll as any);
+        // If the client aborted at any point during this attempt,
+        // stop here — we've already told the upstream to bail via
+        // `currentAc.abort()` and the response socket is already
+        // closed.
+        if (clientAborted) return;
 
         let draining =
           abortedDueToDrain ||
@@ -1049,6 +1111,11 @@ export function buildPrerenderManagerApp(options?: {
       log.error(`Error in /${pathSuffix} proxy requestId=${requestId}:`, e);
       ctxt.status = 500;
       ctxt.body = { errors: [{ status: 500, message: 'Proxy error' }] };
+    } finally {
+      // Always detach the close listener; otherwise a later route
+      // on this same socket (keep-alive) would dispatch stale
+      // aborts.
+      ctxt.res.off('close', onClientClose);
     }
   }
 

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -32,9 +32,11 @@ class TabQueue {
       onAbortPromise = new Promise<never>((_, reject) => {
         let onAbort = () => {
           reject(
-            new PrerenderCancelledError(
-              typeof signal.reason === 'string' ? signal.reason : undefined,
-            ),
+            new PrerenderCancelledError({
+              state: 'queued',
+              reason:
+                typeof signal.reason === 'string' ? signal.reason : undefined,
+            }),
           );
         };
         signal.addEventListener('abort', onAbort, { once: true });

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -9,7 +9,9 @@ type RenderSemaphore = {
   acquire(signal?: AbortSignal): Promise<() => void>;
 };
 
-class TabQueue {
+// Exported so cancellation-plumbing unit tests can drive it
+// directly — it's a pure in-memory FIFO with no Chrome dependency.
+export class TabQueue {
   #pending: Promise<void> = Promise.resolve();
   #depth = 0;
 

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -3,16 +3,18 @@ import type { ConsoleMessage, Page } from 'puppeteer';
 import type { BrowserContext } from 'puppeteer';
 import { resolvePrerenderManagerURL } from './config';
 import type { BrowserManager } from './browser-manager';
+import { PrerenderCancelledError, throwIfAborted } from './prerender-cancel';
 
 type RenderSemaphore = {
-  acquire(): Promise<() => void>;
+  acquire(signal?: AbortSignal): Promise<() => void>;
 };
 
 class TabQueue {
   #pending: Promise<void> = Promise.resolve();
   #depth = 0;
 
-  async acquire(): Promise<() => void> {
+  async acquire(signal?: AbortSignal): Promise<() => void> {
+    throwIfAborted(signal);
     let release!: () => void;
     let next = new Promise<void>((resolve) => {
       release = resolve;
@@ -20,7 +22,45 @@ class TabQueue {
     let prev = this.#pending;
     this.#pending = prev.catch(() => {}).then(() => next);
     this.#depth++;
-    await prev.catch(() => {});
+    // Race the prior-slot wait against the caller's abort signal.
+    // If the signal fires first, release our slot immediately so
+    // downstream waiters aren't blocked on a cancelled holder,
+    // then throw so `getPage` can bail out.
+    let onAbortPromise: Promise<never> | null = null;
+    let onAbortCleanup: (() => void) | undefined;
+    if (signal) {
+      onAbortPromise = new Promise<never>((_, reject) => {
+        let onAbort = () => {
+          reject(
+            new PrerenderCancelledError(
+              typeof signal.reason === 'string' ? signal.reason : undefined,
+            ),
+          );
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+        onAbortCleanup = () => signal.removeEventListener('abort', onAbort);
+      });
+    }
+    try {
+      if (onAbortPromise) {
+        await Promise.race([prev.catch(() => {}), onAbortPromise]);
+      } else {
+        await prev.catch(() => {});
+      }
+    } catch (e) {
+      this.#depth--;
+      release();
+      throw e;
+    } finally {
+      onAbortCleanup?.();
+    }
+    // A late abort between Promise.race resolving and us returning
+    // — treat as the same cancellation.
+    if (signal?.aborted) {
+      this.#depth--;
+      release();
+      throwIfAborted(signal);
+    }
     let released = false;
     return () => {
       if (released) return;
@@ -312,7 +352,10 @@ export class PagePool {
     return evicted;
   }
 
-  async getPage(affinityKey: string): Promise<{
+  async getPage(
+    affinityKey: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<{
     page: Page;
     reused: boolean;
     launchMs: number;
@@ -324,14 +367,27 @@ export class PagePool {
     pageId: string;
     release: () => void;
   }> {
+    let signal = opts?.signal;
+    throwIfAborted(signal);
     let t0 = Date.now();
     let startupStart = Date.now();
     await this.#ensureStandbyPool();
     let tabStartupMs = Date.now() - startupStart;
+    throwIfAborted(signal);
     let tabQueueStart = Date.now();
-    let { entry, reused, releaseTab } =
-      await this.#selectEntryForAffinity(affinityKey);
+    let { entry, reused, releaseTab } = await this.#selectEntryForAffinity(
+      affinityKey,
+      signal,
+    );
     let tabQueueMs = Date.now() - tabQueueStart;
+    // Race between the tab being acquired and the signal firing:
+    // if the signal fired while `#selectEntryForAffinity` was
+    // resolving, release the tab we just got so the next
+    // queued acquirer isn't blocked, then throw.
+    if (signal?.aborted) {
+      releaseTab();
+      throwIfAborted(signal);
+    }
     if (entry.affinityKey !== affinityKey) {
       entry = this.#reassignAffinityTab(entry, affinityKey);
       reused = false;
@@ -340,9 +396,18 @@ export class PagePool {
       entry.transitioning = false;
     }
     let semaphoreStart = Date.now();
-    let releaseGlobal = this.#renderSemaphore
-      ? await this.#renderSemaphore.acquire()
-      : undefined;
+    let releaseGlobal: (() => void) | undefined;
+    try {
+      releaseGlobal = this.#renderSemaphore
+        ? await this.#renderSemaphore.acquire(signal)
+        : undefined;
+    } catch (e) {
+      // Semaphore cancelled before we got a slot. Release the tab
+      // (we acquired it before queueing on the semaphore) so
+      // downstream requests for the same affinity aren't stuck.
+      releaseTab();
+      throw e;
+    }
     let semaphoreMs = Date.now() - semaphoreStart;
     entry.lastUsedAt = Date.now();
     this.#touchLRU(affinityKey);
@@ -679,6 +744,7 @@ export class PagePool {
 
   async #selectEntryForAffinity(
     affinityKey: string,
+    signal?: AbortSignal,
   ): Promise<{ entry: PoolEntry; reused: boolean; releaseTab: () => void }> {
     let entries = this.#affinityPages.get(affinityKey);
     let entryList = entries
@@ -687,7 +753,7 @@ export class PagePool {
     let idle = entryList.filter((entry) => entry.queue.pendingCount === 0);
     if (idle.length > 0) {
       let entry = this.#selectLRUTab(idle);
-      let releaseTab = await entry.queue.acquire();
+      let releaseTab = await entry.queue.acquire(signal);
       return { entry, reused: true, releaseTab };
     }
     if (entryList.length < this.#affinityTabMax) {
@@ -706,13 +772,13 @@ export class PagePool {
       }
       let commandeered = this.#commandeerDormantTab(affinityKey);
       if (commandeered) {
-        let releaseTab = await commandeered.queue.acquire();
+        let releaseTab = await commandeered.queue.acquire(signal);
         return { entry: commandeered, reused: false, releaseTab };
       }
     }
     if (entryList.length > 0) {
       let entry = this.#selectLeastPendingTab(entryList);
-      let releaseTab = await entry.queue.acquire();
+      let releaseTab = await entry.queue.acquire(signal);
       return { entry, reused: true, releaseTab };
     }
     let fallbackShared = this.#tryClaimOrphanContext(affinityKey);
@@ -727,7 +793,7 @@ export class PagePool {
     }
     let fallback = this.#commandeerDormantTab(affinityKey);
     if (fallback) {
-      let releaseTab = await fallback.queue.acquire();
+      let releaseTab = await fallback.queue.acquire(signal);
       return { entry: fallback, reused: false, releaseTab };
     }
     if (entryList.length === 0) {
@@ -744,7 +810,7 @@ export class PagePool {
         let entry = this.#selectLeastPendingTab(crossAffinityEntries);
         entry.transitioning = true;
         try {
-          let releaseTab = await entry.queue.acquire();
+          let releaseTab = await entry.queue.acquire(signal);
           return { entry, reused: false, releaseTab };
         } catch (error) {
           entry.transitioning = false;

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -261,7 +261,10 @@ export function buildPrerenderApp(options: {
       infoLabel: string;
       warnTimeoutMessage: (target: string) => string;
       errorContext: string;
-      execute: (args: A) => Promise<PrerenderExecResult<R>>;
+      execute: (
+        args: A,
+        opts: { signal: AbortSignal },
+      ) => Promise<PrerenderExecResult<R>>;
       afterResponse?: (target: string, response: R) => void;
       parseAttributes: (attrs: any) => RouteParseResult<A>;
       errorMessage?: string | ((err: any) => string);
@@ -277,6 +280,21 @@ export function buildPrerenderApp(options: {
         sanitizePrerenderRequestId(ctxt.get(PRERENDER_REQUEST_ID_HEADER)) ??
         randomUUID();
       ctxt.set(PRERENDER_REQUEST_ID_HEADER, requestId);
+      // Propagate client-disconnect through to the Prerenderer so a
+      // queued render can bail out of the semaphore / tab-queue wait
+      // instead of finishing work no one is waiting for. The manager
+      // aborts its upstream `fetch` on client close, which closes
+      // this request's socket. We listen on `ctxt.res` (not
+      // `ctxt.req`) because Node 17+ auto-destroys IncomingMessage
+      // after the body is consumed, firing `req.close` during normal
+      // flow; `res.close` fires after flushing on success or on
+      // real connection tear-down before the response is sent.
+      let ac = new AbortController();
+      const onClientClose = () => {
+        if (ctxt.res.writableEnded) return;
+        ac.abort();
+      };
+      ctxt.res.on('close', onClientClose);
       try {
         let request = await fetchRequestFromContext(ctxt);
         let raw = await request.text();
@@ -335,7 +353,7 @@ export function buildPrerenderApp(options: {
 
         let start = Date.now();
         let execPromise = options
-          .execute(routeArgs)
+          .execute(routeArgs, { signal: ac.signal })
           .then((result) => ({ result }));
         let drainPromise = options.drainingPromise
           ? options.drainingPromise.then(() => ({ draining: true as const }))
@@ -415,6 +433,14 @@ export function buildPrerenderApp(options: {
         }
         options.afterResponse?.(parsed.logTarget, response);
       } catch (err: any) {
+        // Swallow caller-cancelled: the socket is already closed,
+        // nothing to report to them, no error metric to emit.
+        if ((err as { name?: string })?.name === 'PrerenderCancelledError') {
+          log.debug(
+            `prerender cancelled before completion requestId=${requestId}`,
+          );
+          return;
+        }
         Sentry.captureException(err);
         log.error(`Unhandled error in ${options.errorContext}:`, err);
         ctxt.status = 500;
@@ -430,6 +456,8 @@ export function buildPrerenderApp(options: {
             },
           ],
         };
+      } finally {
+        ctxt.res.off('close', onClientClose);
       }
     });
   }
@@ -441,7 +469,8 @@ export function buildPrerenderApp(options: {
     warnTimeoutMessage: (url) => `module render of ${url} timed out`,
     errorContext: '/prerender-module',
     parseAttributes: parseDefaultPrerenderAttributes,
-    execute: (args) => prerenderer.prerenderModule(args),
+    execute: (args, { signal }) =>
+      prerenderer.prerenderModule({ ...args, signal }),
     drainingPromise: options.drainingPromise,
     afterResponse: (url, response) => {
       const moduleResponse = response as ModuleRenderResponse;
@@ -463,12 +492,13 @@ export function buildPrerenderApp(options: {
       errorContext: '/run-command',
       errorMessage: 'Error running command',
       parseAttributes: parseRunCommandAttributes,
-      execute: (args) =>
+      execute: (args, { signal }) =>
         prerenderer.runCommand({
           userId: args.affinityValue,
           auth: args.auth,
           command: args.command,
           commandInput: args.commandInput as Record<string, unknown> | null,
+          signal,
         }),
       drainingPromise: options.drainingPromise,
     },
@@ -484,6 +514,14 @@ export function buildPrerenderApp(options: {
       sanitizePrerenderRequestId(ctxt.get(PRERENDER_REQUEST_ID_HEADER)) ??
       randomUUID();
     ctxt.set(PRERENDER_REQUEST_ID_HEADER, requestId);
+    // Client-disconnect → cancel the render. See the note on the
+    // shared `registerPrerenderRoute` wrapper above.
+    let ac = new AbortController();
+    const onClientClose = () => {
+      if (ctxt.res.writableEnded) return;
+      ac.abort();
+    };
+    ctxt.res.on('close', onClientClose);
     try {
       let request = await fetchRequestFromContext(ctxt);
       let raw = await request.text();
@@ -603,6 +641,7 @@ export function buildPrerenderApp(options: {
           ...(fileData ? { fileData } : {}),
           ...(Array.isArray(types) ? { types } : {}),
           ...(batchId ? { batchId } : {}),
+          signal: ac.signal,
         })
         .then((result) => ({ result }));
       let drainPromise = options.drainingPromise
@@ -687,6 +726,12 @@ export function buildPrerenderApp(options: {
         );
       }
     } catch (err: any) {
+      if ((err as { name?: string })?.name === 'PrerenderCancelledError') {
+        log.debug(
+          `prerender-visit cancelled before completion requestId=${requestId}`,
+        );
+        return;
+      }
       Sentry.captureException(err);
       log.error('Unhandled error in /prerender-visit:', err);
       ctxt.status = 500;
@@ -698,6 +743,8 @@ export function buildPrerenderApp(options: {
           },
         ],
       };
+    } finally {
+      ctxt.res.off('close', onClientClose);
     }
   });
 

--- a/packages/realm-server/prerender/prerender-cancel.ts
+++ b/packages/realm-server/prerender/prerender-cancel.ts
@@ -1,0 +1,34 @@
+// Cancellation plumbing shared across the prerender server.
+//
+// The manager wires a `ctxt.res` close listener into the upstream
+// `AbortController` so a worker that gives up at 150 s propagates
+// through to whichever attempt is live. The prerender server takes
+// that signal from its Koa handler and threads it down through
+// `Prerenderer` → `RenderRunner` → `PagePool.getPage` so queued
+// waits (render semaphore, per-affinity tab queue) can bail out
+// without entering render, and an in-flight render can be torn
+// down cleanly via `#maybeEvict`.
+//
+// `PrerenderCancelledError` is the distinct-named rejection
+// callers look for to decide "this is a user cancel, route the tab
+// through eviction" rather than "this is a hard error, propagate
+// up".
+
+export class PrerenderCancelledError extends Error {
+  name = 'PrerenderCancelledError';
+  constructor(reason?: string) {
+    super(reason ? `prerender cancelled: ${reason}` : 'prerender cancelled');
+  }
+}
+
+export function isPrerenderCancellation(err: unknown): boolean {
+  return err instanceof PrerenderCancelledError;
+}
+
+export function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new PrerenderCancelledError(
+      typeof signal.reason === 'string' ? signal.reason : undefined,
+    );
+  }
+}

--- a/packages/realm-server/prerender/prerender-cancel.ts
+++ b/packages/realm-server/prerender/prerender-cancel.ts
@@ -14,10 +14,33 @@
 // through eviction" rather than "this is a hard error, propagate
 // up".
 
+// Which phase of the render the cancellation interrupted. `queued`
+// is the saturation win — the render never started, so the only
+// cost was the time spent waiting on the semaphore/tab queue.
+// `rendering` means we already had a page and were inside the
+// render body; the tab state is uncertain and the Prerenderer will
+// dispose the affinity so the next render starts clean.
+// `releasing` is the narrow window after render completed but
+// before we serialized the response; the result is still valid,
+// but the client isn't listening, so we just drop the bytes.
+export type PrerenderCancelState = 'queued' | 'rendering' | 'releasing';
+
 export class PrerenderCancelledError extends Error {
   name = 'PrerenderCancelledError';
-  constructor(reason?: string) {
+  state: PrerenderCancelState;
+  constructor(
+    opts?: { state?: PrerenderCancelState; reason?: string } | string,
+  ) {
+    let reason: string | undefined;
+    let state: PrerenderCancelState = 'queued';
+    if (typeof opts === 'string') {
+      reason = opts;
+    } else if (opts) {
+      reason = opts.reason;
+      state = opts.state ?? 'queued';
+    }
     super(reason ? `prerender cancelled: ${reason}` : 'prerender cancelled');
+    this.state = state;
   }
 }
 
@@ -25,10 +48,14 @@ export function isPrerenderCancellation(err: unknown): boolean {
   return err instanceof PrerenderCancelledError;
 }
 
-export function throwIfAborted(signal: AbortSignal | undefined): void {
+export function throwIfAborted(
+  signal: AbortSignal | undefined,
+  state: PrerenderCancelState = 'queued',
+): void {
   if (signal?.aborted) {
-    throw new PrerenderCancelledError(
-      typeof signal.reason === 'string' ? signal.reason : undefined,
-    );
+    throw new PrerenderCancelledError({
+      state,
+      reason: typeof signal.reason === 'string' ? signal.reason : undefined,
+    });
   }
 }

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -73,9 +73,11 @@ class AsyncSemaphore {
           let idx = this.#queue.indexOf(entry);
           if (idx !== -1) this.#queue.splice(idx, 1);
           reject(
-            new PrerenderCancelledError(
-              typeof signal?.reason === 'string' ? signal!.reason : undefined,
-            ),
+            new PrerenderCancelledError({
+              state: 'queued',
+              reason:
+                typeof signal?.reason === 'string' ? signal!.reason : undefined,
+            }),
           );
         },
       };
@@ -311,6 +313,37 @@ export class Prerenderer {
     await this.#pagePool.disposeAffinity(affinityKey);
   }
 
+  // Emit the `render cancelled` log line (format from CS-10872)
+  // and, on a `rendering`-state cancel, tear down the affinity so
+  // the next request gets a fresh tab rather than one whose
+  // Puppeteer ops are still running from the cancelled render.
+  // Best-effort: disposal failure is logged but not propagated —
+  // the caller already left, there's no response to fail.
+  async #handlePrerenderCancel(
+    err: PrerenderCancelledError,
+    affinityKey: string,
+    startedAt: number,
+    target: string,
+  ): Promise<void> {
+    let elapsed = Date.now() - startedAt;
+    log.info(
+      `render cancelled after ${elapsed}ms in state=${err.state} ` +
+        `affinity=${affinityKey} target=${target}`,
+    );
+    if (err.state === 'rendering') {
+      try {
+        await this.#pagePool.disposeAffinity(affinityKey);
+        this.#renderRunner.clearAuthCache(affinityKey);
+      } catch (disposeErr: any) {
+        log.warn(
+          `failed to dispose affinity ${affinityKey} after cancel: ${
+            disposeErr?.message ?? disposeErr
+          }`,
+        );
+      }
+    }
+  }
+
   // Release this batch's ownership of an affinity's warm loader (CS-10758
   // step 3). Called from `IndexRunner`'s `finally` blocks and via the
   // `/release-batch` HTTP endpoint. No-ops if the caller isn't the current
@@ -431,6 +464,8 @@ export class Prerenderer {
     if (this.#stopped) {
       throw new Error('Prerenderer has been stopped and cannot be used');
     }
+    let affinityKey = toAffinityKey({ affinityType, affinityValue });
+    let overallStart = Date.now();
     let attemptOptions = renderOptions;
     let lastResult:
       | {
@@ -463,9 +498,12 @@ export class Prerenderer {
           signal,
         });
       } catch (e) {
-        // Caller cancelled — don't restart the browser for the
-        // next-attempt retry, just propagate.
-        if (e instanceof PrerenderCancelledError) throw e;
+        // Caller cancelled — log + conditionally evict, then
+        // propagate. Don't restart the browser.
+        if (e instanceof PrerenderCancelledError) {
+          await this.#handlePrerenderCancel(e, affinityKey, overallStart, url);
+          throw e;
+        }
         log.error(
           `module prerender attempt for ${url} (realm ${realm}) failed with error, restarting browser`,
           e,
@@ -483,7 +521,15 @@ export class Prerenderer {
             signal,
           });
         } catch (e2) {
-          if (e2 instanceof PrerenderCancelledError) throw e2;
+          if (e2 instanceof PrerenderCancelledError) {
+            await this.#handlePrerenderCancel(
+              e2,
+              affinityKey,
+              overallStart,
+              url,
+            );
+            throw e2;
+          }
           log.error(
             `module prerender attempt for ${url} (realm ${realm}) failed again after browser restart`,
             e2,
@@ -565,6 +611,10 @@ export class Prerenderer {
       throw new Error('Prerenderer has been stopped and cannot be used');
     }
     let commandStart = Date.now();
+    let affinityKey = toAffinityKey({
+      affinityType: 'user',
+      affinityValue: userId,
+    });
     try {
       let result = await this.#renderRunner.runCommandAttempt({
         affinityType: 'user',
@@ -582,6 +632,15 @@ export class Prerenderer {
       );
       return result;
     } catch (e) {
+      if (e instanceof PrerenderCancelledError) {
+        await this.#handlePrerenderCancel(
+          e,
+          affinityKey,
+          commandStart,
+          command,
+        );
+        throw e;
+      }
       log.error(`command run attempt failed (user ${userId})`, e);
       throw e;
     }
@@ -617,6 +676,8 @@ export class Prerenderer {
       opts,
     } = this.#gateClearCache(rawArgs);
     let signal = (rawArgs as { signal?: AbortSignal }).signal;
+    let affinityKey = toAffinityKey({ affinityType, affinityValue });
+    let overallStart = Date.now();
     let attemptOptions = renderOptions;
     let lastResult:
       | {
@@ -650,9 +711,12 @@ export class Prerenderer {
           signal,
         });
       } catch (e) {
-        // Caller cancelled — don't restart the browser for a retry
-        // on behalf of a caller that left.
-        if (e instanceof PrerenderCancelledError) throw e;
+        // Caller cancelled — log + conditionally evict, then
+        // propagate. Don't restart the browser.
+        if (e instanceof PrerenderCancelledError) {
+          await this.#handlePrerenderCancel(e, affinityKey, overallStart, url);
+          throw e;
+        }
         log.error(
           `visit prerender attempt for ${url} (realm ${realm}) failed with error, restarting browser`,
           e,
@@ -672,7 +736,15 @@ export class Prerenderer {
             signal,
           });
         } catch (e2) {
-          if (e2 instanceof PrerenderCancelledError) throw e2;
+          if (e2 instanceof PrerenderCancelledError) {
+            await this.#handlePrerenderCancel(
+              e2,
+              affinityKey,
+              overallStart,
+              url,
+            );
+            throw e2;
+          }
           log.error(
             `visit prerender attempt for ${url} (realm ${realm}) failed again after browser restart`,
             e2,

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -31,7 +31,10 @@ type PoolMeta = {
   timedOut: boolean;
 };
 
-class AsyncSemaphore {
+// Exported so cancellation-plumbing unit tests can drive it
+// directly — it's a pure in-memory counting semaphore with no
+// Chrome dependency.
+export class AsyncSemaphore {
   #available: number;
   // `resolve` hands the acquirer the release function once a slot
   // frees. `onCancel` gives the cancellation path a way to splice

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -13,6 +13,7 @@ import { PagePool, StandbyTargetNotReadyError } from './page-pool';
 import { RenderRunner, type Timings } from './render-runner';
 import { isEnvironmentMode, serviceURL } from '../lib/dev-service-registry';
 import { toAffinityKey } from './affinity';
+import { PrerenderCancelledError, throwIfAborted } from './prerender-cancel';
 
 const log = logger('prerenderer');
 const defaultHostURL = isEnvironmentMode()
@@ -32,26 +33,62 @@ type PoolMeta = {
 
 class AsyncSemaphore {
   #available: number;
-  #queue: Array<(release: () => void) => void> = [];
+  // `resolve` hands the acquirer the release function once a slot
+  // frees. `onCancel` gives the cancellation path a way to splice
+  // the entry out of the queue without racing #release.
+  #queue: Array<{
+    resolve: (release: () => void) => void;
+    onCancel: () => void;
+  }> = [];
 
   constructor(max: number) {
     this.#available = Math.max(1, max);
   }
 
-  async acquire(): Promise<() => void> {
+  async acquire(signal?: AbortSignal): Promise<() => void> {
+    throwIfAborted(signal);
     if (this.#available > 0) {
       this.#available--;
       return this.#release;
     }
-    return await new Promise<() => void>((resolve) => {
-      this.#queue.push(resolve);
+    return await new Promise<() => void>((resolve, reject) => {
+      let settled = false;
+      let entry = {
+        resolve: (release: () => void) => {
+          if (settled) {
+            // The caller cancelled right as a slot became available.
+            // Hand the slot off to the next waiter (or restore the
+            // count) by calling release immediately, so the queue
+            // doesn't deadlock.
+            release();
+            return;
+          }
+          settled = true;
+          signal?.removeEventListener('abort', onAbort);
+          resolve(release);
+        },
+        onCancel: () => {
+          if (settled) return;
+          settled = true;
+          let idx = this.#queue.indexOf(entry);
+          if (idx !== -1) this.#queue.splice(idx, 1);
+          reject(
+            new PrerenderCancelledError(
+              typeof signal?.reason === 'string' ? signal!.reason : undefined,
+            ),
+          );
+        },
+      };
+      let onAbort = entry.onCancel;
+      this.#queue.push(entry);
+      signal?.addEventListener('abort', onAbort, { once: true });
     });
   }
 
   #release = () => {
     let next = this.#queue.shift();
     if (next) {
-      next(this.#release);
+      next.resolve(this.#release);
       return;
     }
     this.#available++;
@@ -376,6 +413,7 @@ export class Prerenderer {
     auth,
     opts,
     renderOptions,
+    signal,
   }: {
     affinityType: AffinityType;
     affinityValue: string;
@@ -384,6 +422,7 @@ export class Prerenderer {
     auth: string;
     opts?: { timeoutMs?: number; simulateTimeoutMs?: number };
     renderOptions?: RenderRouteOptions;
+    signal?: AbortSignal;
   }): Promise<{
     response: ModuleRenderResponse;
     timings: Timings;
@@ -405,6 +444,7 @@ export class Prerenderer {
     // top of each iteration so launch+render still sums to ~total.
     let attemptStart = Date.now();
     for (let attempt = 0; attempt < 3; attempt++) {
+      throwIfAborted(signal);
       attemptStart = Date.now();
       let result: {
         response: ModuleRenderResponse;
@@ -420,8 +460,12 @@ export class Prerenderer {
           auth,
           opts,
           renderOptions: attemptOptions,
+          signal,
         });
       } catch (e) {
+        // Caller cancelled — don't restart the browser for the
+        // next-attempt retry, just propagate.
+        if (e instanceof PrerenderCancelledError) throw e;
         log.error(
           `module prerender attempt for ${url} (realm ${realm}) failed with error, restarting browser`,
           e,
@@ -436,8 +480,10 @@ export class Prerenderer {
             auth,
             opts,
             renderOptions: attemptOptions,
+            signal,
           });
         } catch (e2) {
+          if (e2 instanceof PrerenderCancelledError) throw e2;
           log.error(
             `module prerender attempt for ${url} (realm ${realm}) failed again after browser restart`,
             e2,
@@ -502,12 +548,14 @@ export class Prerenderer {
     command,
     commandInput,
     opts,
+    signal,
   }: {
     userId: string;
     auth: string;
     command: string;
     commandInput?: Record<string, unknown> | null;
     opts?: { timeoutMs?: number; simulateTimeoutMs?: number };
+    signal?: AbortSignal;
   }): Promise<{
     response: RunCommandResponse;
     timings: Timings;
@@ -525,6 +573,7 @@ export class Prerenderer {
         command,
         commandInput,
         opts,
+        signal,
       });
       Prerenderer.decorateRenderErrorsWithTimings(
         result.response,
@@ -541,6 +590,7 @@ export class Prerenderer {
   async prerenderVisit(
     rawArgs: PrerenderVisitArgs & {
       opts?: { timeoutMs?: number; simulateTimeoutMs?: number };
+      signal?: AbortSignal;
     },
   ): Promise<{
     response: RenderVisitResponse;
@@ -566,6 +616,7 @@ export class Prerenderer {
       types,
       opts,
     } = this.#gateClearCache(rawArgs);
+    let signal = (rawArgs as { signal?: AbortSignal }).signal;
     let attemptOptions = renderOptions;
     let lastResult:
       | {
@@ -578,6 +629,7 @@ export class Prerenderer {
     // attempt-local rather than loop-wide.
     let attemptStart = Date.now();
     for (let attempt = 0; attempt < 3; attempt++) {
+      throwIfAborted(signal);
       attemptStart = Date.now();
       let result: {
         response: RenderVisitResponse;
@@ -595,8 +647,12 @@ export class Prerenderer {
           renderOptions: attemptOptions,
           fileData,
           types,
+          signal,
         });
       } catch (e) {
+        // Caller cancelled — don't restart the browser for a retry
+        // on behalf of a caller that left.
+        if (e instanceof PrerenderCancelledError) throw e;
         log.error(
           `visit prerender attempt for ${url} (realm ${realm}) failed with error, restarting browser`,
           e,
@@ -613,8 +669,10 @@ export class Prerenderer {
             renderOptions: attemptOptions,
             fileData,
             types,
+            signal,
           });
         } catch (e2) {
+          if (e2 instanceof PrerenderCancelledError) throw e2;
           log.error(
             `visit prerender attempt for ${url} (realm ${realm}) failed again after browser restart`,
             e2,

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -17,6 +17,7 @@ import {
 import type { SerializedError } from '@cardstack/runtime-common/error';
 import type { ConsoleErrorEntry, PagePool } from './page-pool';
 import { toAffinityKey } from './affinity';
+import { throwIfAborted } from './prerender-cancel';
 import {
   captureResult,
   captureModule,
@@ -171,6 +172,13 @@ export class RenderRunner {
       }
     };
     try {
+      // Page acquired but untouched — a cancel in this window doesn't
+      // need eviction (the tab is still clean), so tag it `'queued'`.
+      // Once `page.evaluate` runs below, any further cancel becomes a
+      // `'rendering'` cancel and does trigger affinity disposal. The
+      // check lives inside the try so `finally { release() }` frees the
+      // tab slot if the caller aborted during the getPage handoff.
+      throwIfAborted(signal, 'queued');
       let renderStart = Date.now();
       let requestId = randomUUID();
       let nonce = String(this.#nonce);
@@ -368,6 +376,10 @@ export class RenderRunner {
       }
     };
     try {
+      // See runCommandAttempt: tag as 'queued' and keep the check
+      // inside the try so `finally { release() }` frees the tab slot
+      // if the caller aborted during the getPage handoff.
+      throwIfAborted(signal, 'queued');
       await page.evaluate((sessionAuth) => {
         localStorage.setItem('boxel-session', sessionAuth);
       }, auth);
@@ -542,6 +554,11 @@ export class RenderRunner {
     let didStashFileRenderData = false;
 
     try {
+      // Page acquired but untouched — tag as 'queued'. The between-pass
+      // checks below use 'rendering' since by then page.evaluate has run.
+      // The check lives inside the try so `finally { release() }` frees
+      // the tab slot if the caller aborted during the getPage handoff.
+      throwIfAborted(signal, 'queued');
       await page.evaluate((sessionAuth) => {
         localStorage.setItem('boxel-session', sessionAuth);
       }, auth);
@@ -738,6 +755,7 @@ export class RenderRunner {
       }
 
       // ── cardRender pass ────────────────────────────────────────────────
+      throwIfAborted(signal, 'rendering');
       if (requested.cardRender) {
         let cardOptions = optionsForPass('cardRender');
         let serializedOptions = serializeRenderRouteOptions(cardOptions);
@@ -957,6 +975,7 @@ export class RenderRunner {
       }
 
       // ── fileRender pass ────────────────────────────────────────────────
+      throwIfAborted(signal, 'rendering');
       if (requested.fileRender) {
         // If fileExtract ran earlier in this visit and produced a resource,
         // use it to populate fileData/types so the caller doesn't need to

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -90,7 +90,11 @@ export class RenderRunner {
     this.#boxelHostURL = options.boxelHostURL;
   }
 
-  async #getPageForAffinity(affinityKey: string, auth: string) {
+  async #getPageForAffinity(
+    affinityKey: string,
+    auth: string,
+    signal?: AbortSignal,
+  ) {
     let lastAuth = this.#lastAuthByAffinity.get(affinityKey);
     if (lastAuth) {
       let lastKeys = this.#authKeys(lastAuth);
@@ -105,7 +109,7 @@ export class RenderRunner {
         this.#lastAuthByAffinity.delete(affinityKey);
       }
     }
-    let pageInfo = await this.#pagePool.getPage(affinityKey);
+    let pageInfo = await this.#pagePool.getPage(affinityKey, { signal });
     this.#lastAuthByAffinity.set(affinityKey, auth);
     return pageInfo;
   }
@@ -130,6 +134,7 @@ export class RenderRunner {
     command,
     commandInput,
     opts,
+    signal,
   }: {
     affinityType: AffinityType;
     affinityValue: string;
@@ -137,6 +142,7 @@ export class RenderRunner {
     command: string;
     commandInput?: Record<string, unknown> | null;
     opts?: { timeoutMs?: number; simulateTimeoutMs?: number };
+    signal?: AbortSignal;
   }): Promise<{
     response: RunCommandResponse;
     timings: Timings;
@@ -149,7 +155,7 @@ export class RenderRunner {
     );
 
     const { page, reused, launchMs, waits, pageId, release } =
-      await this.#getPageForAffinity(affinityKey, auth);
+      await this.#getPageForAffinity(affinityKey, auth, signal);
     const poolInfo: PoolInfo = {
       pageId: pageId ?? 'unknown',
       affinityType,
@@ -324,6 +330,7 @@ export class RenderRunner {
     auth,
     opts,
     renderOptions,
+    signal,
   }: {
     affinityType: AffinityType;
     affinityValue: string;
@@ -332,6 +339,7 @@ export class RenderRunner {
     auth: string;
     opts?: { timeoutMs?: number; simulateTimeoutMs?: number };
     renderOptions?: RenderRouteOptions;
+    signal?: AbortSignal;
   }): Promise<{
     response: ModuleRenderResponse;
     timings: Timings;
@@ -344,7 +352,7 @@ export class RenderRunner {
     );
 
     const { page, reused, launchMs, waits, pageId, release } =
-      await this.#getPageForAffinity(affinityKey, auth);
+      await this.#getPageForAffinity(affinityKey, auth, signal);
     const poolInfo: PoolInfo = {
       pageId: pageId ?? 'unknown',
       affinityType,
@@ -490,8 +498,10 @@ export class RenderRunner {
     renderOptions,
     fileData,
     types,
+    signal,
   }: PrerenderVisitArgs & {
     opts?: { timeoutMs?: number; simulateTimeoutMs?: number };
+    signal?: AbortSignal;
   }): Promise<{
     response: RenderVisitResponse;
     timings: Timings;
@@ -510,7 +520,7 @@ export class RenderRunner {
     );
 
     const { page, reused, launchMs, waits, pageId, release } =
-      await this.#getPageForAffinity(affinityKey, auth);
+      await this.#getPageForAffinity(affinityKey, auth, signal);
     const poolInfo: PoolInfo = {
       pageId: pageId ?? 'unknown',
       affinityType,

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -175,6 +175,7 @@ import './prerendering-test';
 import './prerender-server-test';
 import './prerender-manager-test';
 import './prerender-batch-ownership-test';
+import './prerender-cancellation-test';
 import './prerender-proxy-test';
 import './queue-test';
 import './run-command-task-test';

--- a/packages/realm-server/tests/prerender-cancellation-test.ts
+++ b/packages/realm-server/tests/prerender-cancellation-test.ts
@@ -1,0 +1,272 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import {
+  PrerenderCancelledError,
+  isPrerenderCancellation,
+  throwIfAborted,
+} from '../prerender/prerender-cancel';
+import { TabQueue } from '../prerender/page-pool';
+import { AsyncSemaphore } from '../prerender/prerenderer';
+
+// These tests cover the cancellation plumbing added in CS-10873 at the
+// level closest to the logic — no Chrome, no HTTP. They pin down the
+// behaviors that the manager / prerender-server rely on:
+//
+//   1. An abort delivered *while queued* produces a `'queued'`-state
+//      `PrerenderCancelledError` and releases the slot so later
+//      waiters aren't blocked behind a cancelled holder.
+//   2. An abort delivered *after* acquisition is the caller's
+//      responsibility to react to via `throwIfAborted(signal, state)`,
+//      which the render path does at pass boundaries.
+//   3. The error shape is what the prerenderer's cancel-handler
+//      branches on — `name`, `state`, and the `instanceof` guard.
+//
+// Holding these invariants down means the manager-level client-abort
+// tests don't have to re-verify them end to end.
+
+module(basename(__filename), function () {
+  module('PrerenderCancelledError shape', function () {
+    test('defaults to queued state with no reason', function (assert) {
+      let err = new PrerenderCancelledError();
+      assert.strictEqual(err.name, 'PrerenderCancelledError', 'name tag');
+      assert.strictEqual(err.state, 'queued', 'defaults to queued');
+      assert.strictEqual(err.message, 'prerender cancelled', 'default message');
+    });
+
+    test('accepts a bare reason string for backward compatibility', function (assert) {
+      let err = new PrerenderCancelledError('client closed');
+      assert.strictEqual(err.state, 'queued', 'string arg still defaults');
+      assert.strictEqual(
+        err.message,
+        'prerender cancelled: client closed',
+        'reason in message',
+      );
+    });
+
+    test('accepts { state, reason } options', function (assert) {
+      let err = new PrerenderCancelledError({
+        state: 'rendering',
+        reason: 'req-closed',
+      });
+      assert.strictEqual(err.state, 'rendering', 'state carried through');
+      assert.strictEqual(
+        err.message,
+        'prerender cancelled: req-closed',
+        'reason in message',
+      );
+    });
+
+    test('isPrerenderCancellation matches only this error', function (assert) {
+      assert.true(isPrerenderCancellation(new PrerenderCancelledError()));
+      assert.false(isPrerenderCancellation(new Error('boom')));
+      assert.false(isPrerenderCancellation('string'));
+      assert.false(isPrerenderCancellation(undefined));
+    });
+  });
+
+  module('throwIfAborted', function () {
+    test('does nothing when signal is undefined', function (assert) {
+      assert.expect(0);
+      throwIfAborted(undefined);
+    });
+
+    test('does nothing when signal is not aborted', function (assert) {
+      assert.expect(0);
+      let ac = new AbortController();
+      throwIfAborted(ac.signal);
+    });
+
+    test('throws PrerenderCancelledError tagged with provided state', function (assert) {
+      let ac = new AbortController();
+      ac.abort('client-left');
+      try {
+        throwIfAborted(ac.signal, 'rendering');
+        assert.ok(false, 'should have thrown');
+      } catch (e) {
+        assert.true(isPrerenderCancellation(e), 'is cancel error');
+        assert.strictEqual((e as PrerenderCancelledError).state, 'rendering');
+        assert.ok(
+          ((e as PrerenderCancelledError).message ?? '').includes(
+            'client-left',
+          ),
+          'reason threaded through',
+        );
+      }
+    });
+
+    test('defaults to queued when no state provided', function (assert) {
+      let ac = new AbortController();
+      ac.abort();
+      try {
+        throwIfAborted(ac.signal);
+        assert.ok(false, 'should have thrown');
+      } catch (e) {
+        assert.strictEqual(
+          (e as PrerenderCancelledError).state,
+          'queued',
+          'queued default',
+        );
+      }
+    });
+  });
+
+  module('TabQueue cancellation', function () {
+    test('acquire on an unaborted signal resolves normally', async function (assert) {
+      let q = new TabQueue();
+      let ac = new AbortController();
+      let release = await q.acquire(ac.signal);
+      assert.strictEqual(q.pendingCount, 1, 'depth=1 while held');
+      release();
+      assert.strictEqual(q.pendingCount, 0, 'depth=0 after release');
+    });
+
+    test('acquire rejects synchronously when signal already aborted', async function (assert) {
+      let q = new TabQueue();
+      let ac = new AbortController();
+      ac.abort();
+      try {
+        await q.acquire(ac.signal);
+        assert.ok(false, 'should have rejected');
+      } catch (e) {
+        assert.true(isPrerenderCancellation(e), 'is cancel error');
+        assert.strictEqual(
+          (e as PrerenderCancelledError).state,
+          'queued',
+          'queued state',
+        );
+      }
+      assert.strictEqual(q.pendingCount, 0, 'no leak');
+    });
+
+    test('aborting a queued waiter releases its slot for later acquirers', async function (assert) {
+      let q = new TabQueue();
+      let ac1 = new AbortController();
+      let ac2 = new AbortController();
+      let release1 = await q.acquire();
+      // Waiter B goes behind A
+      let acquireB = q.acquire(ac1.signal);
+      // Waiter C goes behind B
+      let acquireC = q.acquire(ac2.signal);
+      assert.strictEqual(q.pendingCount, 3, 'three queued entries');
+
+      // Cancel B while it's waiting.
+      ac1.abort('gave up');
+      await acquireB.then(
+        () => assert.ok(false, 'B should have rejected'),
+        (err) => {
+          assert.true(isPrerenderCancellation(err), 'B is cancel error');
+          assert.strictEqual(
+            (err as PrerenderCancelledError).state,
+            'queued',
+            'B tagged queued',
+          );
+        },
+      );
+      // B's slot was released so the depth should have dropped by one.
+      assert.strictEqual(q.pendingCount, 2, 'B slot released');
+
+      // Releasing A should hand the slot directly to C, skipping cancelled B.
+      release1();
+      let releaseC = await acquireC;
+      assert.strictEqual(typeof releaseC, 'function', 'C acquired');
+      releaseC();
+      assert.strictEqual(q.pendingCount, 0, 'fully drained');
+    });
+
+    test('aborting the only holder after it acquired does not double-release', async function (assert) {
+      let q = new TabQueue();
+      let ac = new AbortController();
+      let release = await q.acquire(ac.signal);
+      // Abort after acquire — TabQueue stops listening once it returns,
+      // so the abort is the caller's problem (render path catches via
+      // throwIfAborted at pass boundaries). The queue must NOT react.
+      ac.abort();
+      assert.strictEqual(q.pendingCount, 1, 'still held');
+      release();
+      assert.strictEqual(q.pendingCount, 0, 'clean release');
+    });
+  });
+
+  module('AsyncSemaphore cancellation', function () {
+    test('acquires immediately when slots available', async function (assert) {
+      let sem = new AsyncSemaphore(2);
+      let r1 = await sem.acquire();
+      let r2 = await sem.acquire();
+      assert.strictEqual(typeof r1, 'function', 'got release 1');
+      assert.strictEqual(typeof r2, 'function', 'got release 2');
+      r1();
+      r2();
+    });
+
+    test('rejects immediately when signal is already aborted', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let ac = new AbortController();
+      ac.abort();
+      try {
+        await sem.acquire(ac.signal);
+        assert.ok(false, 'should have rejected');
+      } catch (e) {
+        assert.true(isPrerenderCancellation(e), 'cancel error');
+        assert.strictEqual(
+          (e as PrerenderCancelledError).state,
+          'queued',
+          'queued state',
+        );
+      }
+    });
+
+    test('aborting a queued waiter splices it out and lets later waiters acquire', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let ac = new AbortController();
+
+      let r1 = await sem.acquire();
+
+      let acquiredB = false;
+      let acquireB = sem.acquire(ac.signal).then(
+        () => (acquiredB = true),
+        (err) => err,
+      );
+      let waiterC = sem.acquire();
+
+      // Abort B while it's queued.
+      ac.abort('left');
+      let bResult = await acquireB;
+      assert.false(acquiredB, 'B did not acquire');
+      assert.true(isPrerenderCancellation(bResult), 'B got cancel error');
+
+      // Releasing the initial slot should hand it to C, not to the
+      // cancelled B entry.
+      r1();
+      let rC = await waiterC;
+      assert.strictEqual(typeof rC, 'function', 'C acquired after A released');
+      rC();
+    });
+
+    test('cancel after slot is already handed off releases gracefully', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let ac = new AbortController();
+
+      let r1 = await sem.acquire();
+
+      // Start B with a signal, but we'll abort right as the slot is
+      // being handed off. The settled check inside AsyncSemaphore should
+      // release the slot onward without deadlocking.
+      let waiterB = sem.acquire(ac.signal);
+      let waiterC = sem.acquire();
+
+      // Release A — this synchronously calls B's resolve, which marks
+      // B settled before we fire the abort below.
+      r1();
+      // Now abort — B has already acquired, so this is a no-op.
+      ac.abort();
+
+      let rB = await waiterB;
+      assert.strictEqual(typeof rB, 'function', 'B acquired before abort');
+      rB();
+
+      let rC = await waiterC;
+      assert.strictEqual(typeof rC, 'function', 'C acquired after B released');
+      rC();
+    });
+  });
+});

--- a/packages/realm-server/tests/prerender-manager-test.ts
+++ b/packages/realm-server/tests/prerender-manager-test.ts
@@ -5,7 +5,7 @@ import { basename } from 'path';
 import Koa from 'koa';
 import Router from '@koa/router';
 import type { Server } from 'http';
-import { createServer } from 'http';
+import http, { createServer } from 'http';
 import { buildPrerenderManagerApp } from '../prerender/manager-app';
 import {
   PRERENDER_SERVER_DRAINING_STATUS_CODE,
@@ -2369,6 +2369,192 @@ module(basename(__filename), function () {
         'sets draining header',
       );
       assert.strictEqual(hits, 0, 'does not proxy to prerender server');
+    });
+
+    module('client-abort propagation (CS-10873)', function () {
+      // The manager's `proxyStart`/ctxt.req close hook aborts the
+      // upstream fetch when the client disconnects mid-flight.
+      // Exercise it by spinning up a real HTTP listener (supertest's
+      // in-memory transport can't simulate a socket close cleanly)
+      // and tearing down the client request while the mock prerender
+      // is deliberately hung.
+      test('client closing the socket aborts the upstream fetch', async function (assert) {
+        let { app } = buildPrerenderManagerApp();
+        let managerServer = createServer(app.callback());
+        await new Promise<void>((resolve) =>
+          managerServer.listen(0, () => resolve()),
+        );
+        let managerPort = (managerServer.address() as any).port;
+        try {
+          let realm = 'https://realm.example/abort-test';
+          let cardURL = `${realm}/1`;
+
+          // Tell the mock to hang on the request and report back
+          // whether its inbound TCP socket closes (which is what we
+          // get from undici when it cancels the fetch). We watch the
+          // socket rather than `ctxt.req` because Node 17+ auto-
+          // destroys IncomingMessage after the body is consumed —
+          // `ctxt.req.close` fires during normal flow and wouldn't
+          // distinguish "manager aborted us" from "body read done".
+          let upstreamHit = new Deferred<void>();
+          let upstreamSocketClosed = new Deferred<void>();
+          mockPrerenderA!.setResponder(async (ctxt) => {
+            upstreamHit.fulfill();
+            ctxt.req.socket?.on('close', () => upstreamSocketClosed.fulfill());
+            // Never respond — wait forever. The outer test cleanup
+            // will tear down the server and flush this handler.
+            await new Promise(() => {});
+          });
+
+          // Register the mock.
+          await new Promise<void>((resolve, reject) => {
+            let req = http.request(
+              {
+                hostname: '127.0.0.1',
+                port: managerPort,
+                path: '/prerender-servers',
+                method: 'POST',
+                headers: { 'Content-Type': 'application/vnd.api+json' },
+              },
+              (res) => {
+                res.resume();
+                res.on('end', () => resolve());
+              },
+            );
+            req.on('error', reject);
+            req.write(
+              JSON.stringify({
+                data: {
+                  type: 'prerender-server',
+                  attributes: { capacity: 2, url: serverUrlA },
+                },
+              }),
+            );
+            req.end();
+          });
+
+          // Fire the prerender-visit request via a raw http client
+          // so we can destroy the socket mid-flight (which is what a
+          // real worker-gave-up scenario looks like).
+          let clientReq = http.request({
+            hostname: '127.0.0.1',
+            port: managerPort,
+            path: '/prerender-visit',
+            method: 'POST',
+            headers: { 'Content-Type': 'application/vnd.api+json' },
+          });
+          clientReq.on('error', () => {
+            // expected on destroy
+          });
+          clientReq.write(JSON.stringify(makeBody(realm, cardURL)));
+          clientReq.end();
+
+          // Wait until the mock has the request in hand, then kill
+          // the client side.
+          await upstreamHit.promise;
+          clientReq.destroy();
+
+          // Manager should have propagated the abort to the upstream.
+          // We wait (bounded) for the mock's inbound socket to close.
+          let closedInTime = await Promise.race([
+            upstreamSocketClosed.promise.then(() => true),
+            new Promise<boolean>((resolve) =>
+              setTimeout(() => resolve(false), 2000),
+            ),
+          ]);
+          assert.true(
+            closedInTime,
+            'manager aborted upstream fetch after client disconnect',
+          );
+        } finally {
+          await new Promise<void>((resolve) =>
+            managerServer.close(() => resolve()),
+          );
+        }
+      });
+
+      test('aborting before discovery completes does not route to any server', async function (assert) {
+        // When the registry is empty and discoveryWaitMs is high,
+        // the manager polls waiting for a server to register. A
+        // client abort during that wait must exit the poll loop
+        // without later falling through to a proxy attempt.
+        process.env.PRERENDER_SERVER_DISCOVERY_WAIT_MS = '5000';
+        process.env.PRERENDER_SERVER_DISCOVERY_POLL_MS = '25';
+        let { app } = buildPrerenderManagerApp();
+        let managerServer = createServer(app.callback());
+        await new Promise<void>((resolve) =>
+          managerServer.listen(0, () => resolve()),
+        );
+        let managerPort = (managerServer.address() as any).port;
+        try {
+          let proxiedHits = 0;
+          mockPrerenderA!.setResponder((ctxt) => {
+            proxiedHits++;
+            ctxt.status = 201;
+            ctxt.body = '{}';
+          });
+
+          let realm = 'https://realm.example/no-servers';
+          let clientReq = http.request({
+            hostname: '127.0.0.1',
+            port: managerPort,
+            path: '/prerender-visit',
+            method: 'POST',
+            headers: { 'Content-Type': 'application/vnd.api+json' },
+          });
+          clientReq.on('error', () => {});
+          clientReq.write(JSON.stringify(makeBody(realm, `${realm}/1`)));
+          clientReq.end();
+
+          // Give the manager a tick to start the discovery wait,
+          // then kill the client before registering any server.
+          await new Promise((r) => setTimeout(r, 100));
+          clientReq.destroy();
+
+          // Register a server *after* the abort. If the manager were
+          // to continue the poll loop past the disconnect, it would
+          // proxy to this server once it appears.
+          await new Promise<void>((resolve, reject) => {
+            let req = http.request(
+              {
+                hostname: '127.0.0.1',
+                port: managerPort,
+                path: '/prerender-servers',
+                method: 'POST',
+                headers: { 'Content-Type': 'application/vnd.api+json' },
+              },
+              (res) => {
+                res.resume();
+                res.on('end', () => resolve());
+              },
+            );
+            req.on('error', reject);
+            req.write(
+              JSON.stringify({
+                data: {
+                  type: 'prerender-server',
+                  attributes: { capacity: 2, url: serverUrlA },
+                },
+              }),
+            );
+            req.end();
+          });
+
+          // Wait long enough that a not-cancelled poll would have
+          // picked up the new server and proxied.
+          await new Promise((r) => setTimeout(r, 300));
+
+          assert.strictEqual(
+            proxiedHits,
+            0,
+            'no upstream proxy after client abort during discovery wait',
+          );
+        } finally {
+          await new Promise<void>((resolve) =>
+            managerServer.close(() => resolve()),
+          );
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

When a worker gave up on a prerender at its 150 s deadline and closed the connection, the prerender server kept rendering for another ~15-20 s anyway and discarded the result — ~2× the render budget wasted per timeout under saturation (CS-10820). This PR plumbs the client-disconnect signal end-to-end so the render can bail out as close to immediately as possible.

## Why this is worth explaining

If you haven't spent time in the prerender internals, here's the layering we care about:

- **Worker (HTTP client)** asks the **prerender manager** to render a card. The manager picks an upstream **prerender server** and forwards the request via `fetch`.
- Each prerender server owns a pool of Chrome tabs through a **page pool**. Requests for the same "affinity" (realm URL or user ID) get routed to the same tab so module imports stay warm.
- Two layers of queueing sit in front of actually touching Chrome:
  1. **Render semaphore** — a global cap on how many renders run in parallel (protects against starting too many Puppeteer operations at once).
  2. **Tab queue** — per-affinity FIFO so two requests for the same realm serialize on that realm's warm tab.

Before this change, the cancel signal stopped at the manager's Koa handler — the upstream `fetch` and everything downstream kept going. The big win below is that a cancel delivered *while the request is sitting in one of those two queues* — the common case under load — can now exit cleanly, no wasted render.

## What changes

### 1. Manager propagates client disconnect to its upstream fetch
`manager-app.ts`: attach a close listener to `ctxt.res`. When it fires before we've written the response, abort the current retry attempt's `fetch` — the prerender server sees the inbound connection close and can stop working. Short-circuits the retry loop too — no point trying another server for a caller that already left.

### 2. Prerender server threads `AbortSignal` through its queues
`prerender-app.ts` → `Prerenderer` → `RenderRunner` → `PagePool`. Both the render semaphore and the per-affinity tab queue honor the signal:
- Already-aborted signal → reject synchronously (the saturation win — never touched a tab).
- Waiter cancelled while queued → splice out of the queue and release any slot that was being passed along, so later waiters aren't stranded.

### 3. Mid-render cancels dispose the affinity
Puppeteer's `page.evaluate` / `waitForFunction` aren't interruptible — once a render is in flight we can't actually stop it. What we can do: tag the cancel with *where* it caught us (`queued` / `rendering` / `releasing`) and, for the `rendering` case, dispose the affinity afterwards so the next request gets a fresh tab rather than one whose Puppeteer ops may still be running.

### 4. Tests
- `prerender-cancellation-test.ts` (new) — unit-level coverage of `PrerenderCancelledError` shape, `throwIfAborted` state tagging, and the queued-cancel behavior of `TabQueue` and `AsyncSemaphore`.
- `prerender-manager-test.ts` — two new tests using raw `http.request` + `clientReq.destroy()` (supertest's in-memory transport can't simulate mid-flight disconnect). The first watches the mock upstream's TCP socket for close to confirm the manager aborts the fetch; the second covers a client abort during the manager's server-discovery wait — no proxy attempt should happen if a server registers later.

## One footgun worth knowing about

There's a comment block in `manager-app.ts:835-850` (and parallel in `prerender-app.ts`) explaining why we listen on `ctxt.res` instead of `ctxt.req`. Short version: Node 17+ auto-destroys `IncomingMessage` after the body is consumed, which fires `req.close` during *normal* flow before the response is sent. Using `req.close` would false-trigger the abort handler on every single successful request. `res.close` fires after the response is flushed (no-op guarded by `writableEnded`) or on real connection tear-down.

Not academic — this is the root cause of a test regression I had to chase down mid-PR. Keeping the note to prevent anyone else from switching back.

## Test plan
- [x] `prerender-cancellation-test.ts` — 16/16 pass
- [x] `prerender-manager-test.ts` — 50/50 pass (includes 2 new CS-10873 tests + all prior tests still green)
- [x] `prerender-batch-ownership-test.ts` + `prerender-proxy-test.ts` — 16/16 pass
- [x] Full realm-server lint clean
- [x] CI run covers the broader integration test suite
- [ ] Bench under saturation in staging to confirm the worker-timeout recovery win

🤖 Generated with [Claude Code](https://claude.com/claude-code)
