### PR TITLE
Refresh memory baseline on partial host-test runs; preserve missing modules

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -406,7 +406,14 @@ jobs:
     # Intentionally scoped to push-to-main only so the job only runs in a
     # context where the PR workflow file cannot be modified by an untrusted
     # branch — this is the one job that holds `contents: write`.
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.host-test.result == 'success' }}
+    #
+    # We refresh the baseline whenever host-test completes (success OR failure),
+    # not only on full green. An unrelated shard flake otherwise freezes the
+    # baseline indefinitely, which then blocks downstream PRs on drift that has
+    # nothing to do with their diffs. Modules missing from the current reports
+    # (because a shard failed to upload) keep their prior baseline values —
+    # the merge is handled in update-memory-baseline.mjs.
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled() && (needs.host-test.result == 'success' || needs.host-test.result == 'failure') }}
     concurrency:
       group: host-memory-baseline-update-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true

--- a/packages/host/scripts/update-memory-baseline.mjs
+++ b/packages/host/scripts/update-memory-baseline.mjs
@@ -4,8 +4,15 @@
 // Used by CI on main merge (auto-update) or locally by developers.
 //
 // Usage: node update-memory-baseline.mjs <reports-dir> <baseline-json>
+//
+// Missing-shard policy: modules present in the current reports are updated
+// from those readings. Modules absent from the current reports (because a
+// shard failed to upload, or was renamed/removed) retain their prior baseline
+// entries. CI runs this job even when host-test reports partial failure, so
+// retaining prior values avoids silently dropping baseline coverage for a
+// module the run simply didn't observe.
 
-import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const [reportsDir, baselinePath] = process.argv.slice(2);
@@ -17,6 +24,19 @@ if (!reportsDir || !baselinePath) {
   process.exit(1);
 }
 
+// Load prior baseline, if any — we merge its entries with the current run.
+let prior = {};
+if (existsSync(baselinePath)) {
+  try {
+    prior = JSON.parse(readFileSync(baselinePath, 'utf8')).modules ?? {};
+  } catch (e) {
+    console.error(
+      `update-memory-baseline: failed to parse existing baseline at ${baselinePath}, starting fresh. ${e.message}`,
+    );
+    prior = {};
+  }
+}
+
 // Merge all shard reports
 const merged = {};
 for (const file of readdirSync(reportsDir)) {
@@ -25,24 +45,41 @@ for (const file of readdirSync(reportsDir)) {
   Object.assign(merged, shard);
 }
 
-// Build baseline — exclude warmup since it varies by environment
-const modules = {};
-for (const [mod, data] of Object.entries(merged).sort(([a], [b]) =>
-  a.localeCompare(b),
-)) {
+// Start from the prior baseline, then overlay current readings. Warmup is
+// excluded from both sources since it varies by environment.
+const modules = { ...prior };
+delete modules.__shard_warmup__;
+
+let updated = 0;
+let added = 0;
+for (const [mod, data] of Object.entries(merged)) {
   if (mod === '__shard_warmup__') continue;
   if (data.delta_mb == null) continue;
-  modules[mod] = { delta_mb: Math.round(data.delta_mb * 10) / 10 };
+  const next = { delta_mb: Math.round(data.delta_mb * 10) / 10 };
+  if (mod in modules) updated++;
+  else added++;
+  modules[mod] = next;
 }
+
+const retained =
+  Object.keys(modules).length -
+  Object.keys(merged).filter(
+    (m) => m !== '__shard_warmup__' && merged[m].delta_mb != null,
+  ).length;
+
+// Sort modules alphabetically for stable diffs.
+const sortedModules = Object.fromEntries(
+  Object.entries(modules).sort(([a], [b]) => a.localeCompare(b)),
+);
 
 const baseline = {
   version: 1,
   generated: new Date().toISOString().slice(0, 10),
   threshold: { relative: 0.1, absolute_mb: 5 },
-  modules,
+  modules: sortedModules,
 };
 
 writeFileSync(baselinePath, JSON.stringify(baseline, null, 2) + '\n');
 console.log(
-  `update-memory-baseline: wrote ${Object.keys(modules).length} modules to ${baselinePath}`,
+  `update-memory-baseline: wrote ${Object.keys(sortedModules).length} modules to ${baselinePath} (${added} added, ${updated} updated, ${retained} retained from prior baseline)`,
 );


### PR DESCRIPTION
## Summary

- Drop the `needs.host-test.result == 'success'` gate on `host-memory-baseline-update`. Previously, any unrelated shard flake on main froze the baseline forever — downstream PRs then failed the memory check on accumulated drift that had nothing to do with their diffs. New gate matches the `host-merge-reports-and-publish` pattern: run whenever `host-test` completed, skip only on cancel/skip.
- Update `update-memory-baseline.mjs` to merge current readings on top of the prior baseline instead of rewriting from scratch. Modules missing from the current run (e.g. shard OOM'd before upload) retain their prior `delta_mb`; present modules get their current reading. Logs added / updated / retained counts for auditability.

Motivation: the baseline hadn't refreshed since 2026-04-15 because every push-to-main CI Host run since Apr 22 failed at host-test for unrelated reasons. PR #4495 and others were being blocked on drift, not real regressions. See analysis in https://github.com/cardstack/boxel/actions/runs/24841856201/job/72722953072 — one hard-fail module (`Acceptance | file chooser keyboard tests` at 1.8 MB baseline, a clear floor-noise outlier) and 26 "new" modules that simply didn't exist when the baseline was frozen.

## Test plan

- [x] Smoke-tested `update-memory-baseline.mjs` locally with a synthetic prior baseline + partial reports: verifies modules missing from current run are retained, observed modules are updated, new modules are added, `__shard_warmup__` is excluded from both sides. Log summary reports expected counts.
- [x] Smoke-tested the no-prior-baseline case: fresh-setup path still works, reports "0 retained."
- [ ] Once merged, confirm the next push-to-main CI Host run with any shard failure still triggers `host-memory-baseline-update` and commits an updated baseline.
- [ ] Confirm a push-to-main with all shards green still produces an unchanged-or-updated commit (the `git diff --quiet` guard no-ops when nothing changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)