### PR TITLE
CS-10872: persist render-timeout diagnostics to error_doc

### DIFF
--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -36,6 +36,41 @@ type PrerenderServer = Server & {
 let log = logger('prerender-server');
 const defaultPrerenderServerPort = 4221;
 
+// CS-10872: walk any RenderError embedded in a response and stamp
+// the per-request `requestId` onto the inner `SerializedError`'s
+// `diagnostics` block (the outer wrapper is transient — only the
+// inner is persisted into `boxel_index.error_doc`). The
+// launch/waits/render/total timings are already attached inside
+// Prerenderer (so they land regardless of whether the caller came
+// through HTTP or in-process tests); this layer just adds the
+// HTTP-only correlation id for cross-log grepping. Exported so the
+// diagnostics-persistence regression tests can exercise it directly.
+export function decorateRenderErrorDiagnostics(
+  response: any,
+  requestId: string,
+): void {
+  if (!response || typeof response !== 'object') {
+    return;
+  }
+  let visit = (wrapper: any) => {
+    if (!wrapper || typeof wrapper !== 'object') return;
+    let inner = wrapper.error;
+    if (!inner || typeof inner !== 'object') return;
+    if (!inner.diagnostics || typeof inner.diagnostics !== 'object') {
+      inner.diagnostics = {};
+    }
+    inner.diagnostics.requestId = requestId;
+  };
+  visit(response.error);
+  visit((response as any).pageUnusableError);
+  for (let key of ['card', 'fileExtract', 'fileRender'] as const) {
+    let sub = response[key];
+    if (sub && typeof sub === 'object') {
+      visit((sub as any).error);
+    }
+  }
+}
+
 export function buildPrerenderApp(options: {
   serverURL: string;
   maxPages?: number;
@@ -121,36 +156,6 @@ export function buildPrerenderApp(options: {
       timedOut: boolean;
     };
   };
-
-  // CS-10872: walk any RenderError embedded in a response and stamp
-  // the per-request `requestId` onto its `diagnostics` block. The
-  // launch/waits/render/total timings are already attached inside
-  // Prerenderer (so they land regardless of whether the caller came
-  // through HTTP or in-process tests); this layer just adds the
-  // HTTP-only correlation id for cross-log grepping.
-  function decorateRenderErrorDiagnostics(
-    response: any,
-    requestId: string,
-  ): void {
-    if (!response || typeof response !== 'object') {
-      return;
-    }
-    let visit = (err: any) => {
-      if (!err || typeof err !== 'object') return;
-      if (!err.diagnostics || typeof err.diagnostics !== 'object') {
-        err.diagnostics = {};
-      }
-      err.diagnostics.requestId = requestId;
-    };
-    visit(response.error);
-    visit((response as any).pageUnusableError);
-    for (let key of ['card', 'fileExtract', 'fileRender'] as const) {
-      let sub = response[key];
-      if (sub && typeof sub === 'object') {
-        visit((sub as any).error);
-      }
-    }
-  }
 
   let isNonEmptyString = (value: unknown): value is string =>
     typeof value === 'string' && value.trim().length > 0;

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -376,8 +376,11 @@ export class Prerenderer {
   }
 
   // CS-10872: walk any RenderError embedded in a response and merge
-  // server-observed timings into its `diagnostics` block. The
-  // prerender server's HTTP layer additionally attaches a
+  // server-observed timings into the inner `SerializedError`'s
+  // `diagnostics` block. Diagnostics must live on the inner
+  // `SerializedError` (not the outer `RenderError` wrapper) because
+  // that's what the indexer persists into `boxel_index.error_doc`.
+  // The prerender server's HTTP layer additionally attaches a
   // `requestId` via `decorateRenderErrorDiagnostics` — this method
   // covers the in-process path (test harnesses, co-located callers)
   // so the diagnostics payload is consistent regardless of how the
@@ -396,13 +399,21 @@ export class Prerenderer {
       renderElapsedMs: timings.renderMs,
       totalElapsedMs: totalMs,
     };
-    let visit = (err: unknown) => {
-      if (!err || typeof err !== 'object') return;
-      let e = err as { diagnostics?: Record<string, unknown> };
-      if (!e.diagnostics || typeof e.diagnostics !== 'object') {
-        e.diagnostics = {};
+    // `wrapper` is a RenderError / ErrorEntry (with an inner
+    // `error: SerializedError`); attach to the inner so diagnostics
+    // survive serialization into `error_doc`.
+    // `wrapper` is a RenderError / ErrorEntry (with an inner
+    // `error: SerializedError`); attach to the inner so diagnostics
+    // survive serialization into `error_doc`.
+    let visit = (wrapper: unknown) => {
+      if (!wrapper || typeof wrapper !== 'object') return;
+      let w = wrapper as { error?: unknown };
+      if (!w.error || typeof w.error !== 'object') return;
+      let inner = w.error as { diagnostics?: Record<string, unknown> };
+      if (!inner.diagnostics || typeof inner.diagnostics !== 'object') {
+        inner.diagnostics = {};
       }
-      Object.assign(e.diagnostics, serverContext);
+      Object.assign(inner.diagnostics, serverContext);
     };
     let r = response as Record<string, unknown>;
     visit(r.error);

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -1181,6 +1181,71 @@ export async function withTimeout<T>(
         ` evaluating=${richDiagnostics?.currentlyEvaluatingModule ?? 'none'}` +
         ` DOM:\n${dom?.trim()}`,
     );
+    // Diagnostics live on the inner `SerializedError` (not the outer
+    // `RenderError` wrapper) because that's what the indexer persists
+    // into `boxel_index.error_doc` — the outer wrapper is transient
+    // plumbing between the prerender response and the index writer.
+    let diagnostics: Record<string, unknown> = {
+      ...(richDiagnostics?.renderStage
+        ? { renderStage: richDiagnostics.renderStage }
+        : {}),
+      ...(typeof richDiagnostics?.stageAgeMs === 'number'
+        ? { stageAgeMs: richDiagnostics.stageAgeMs }
+        : {}),
+      ...(Array.isArray(richDiagnostics?.cardDocsInFlight)
+        ? { cardDocsInFlight: richDiagnostics!.cardDocsInFlight }
+        : {}),
+      ...(Array.isArray(richDiagnostics?.fileMetaDocsInFlight)
+        ? { fileMetaDocsInFlight: richDiagnostics!.fileMetaDocsInFlight }
+        : {}),
+      ...(Array.isArray(richDiagnostics?.inFlightModuleImports)
+        ? { inFlightModuleImports: richDiagnostics!.inFlightModuleImports }
+        : {}),
+      ...(richDiagnostics?.currentlyEvaluatingModule !== undefined
+        ? {
+            currentlyEvaluatingModule:
+              richDiagnostics.currentlyEvaluatingModule,
+          }
+        : {}),
+      ...(Array.isArray(richDiagnostics?.recentModuleEvaluations)
+        ? {
+            recentModuleEvaluations: richDiagnostics!.recentModuleEvaluations,
+          }
+        : {}),
+      ...(Array.isArray(richDiagnostics?.queryLoadsInFlight)
+        ? {
+            queryLoadsInFlight: richDiagnostics!.queryLoadsInFlight as Array<
+              Record<string, unknown>
+            >,
+          }
+        : {}),
+      ...(Array.isArray(richDiagnostics?.recentQueryLoads)
+        ? {
+            recentQueryLoads: richDiagnostics!.recentQueryLoads as Array<
+              Record<string, unknown>
+            >,
+          }
+        : {}),
+      ...(Array.isArray(richDiagnostics?.cardDocLoadsInFlight)
+        ? { cardDocLoadsInFlight: richDiagnostics!.cardDocLoadsInFlight }
+        : {}),
+      ...(Array.isArray(richDiagnostics?.fileMetaDocLoadsInFlight)
+        ? {
+            fileMetaDocLoadsInFlight: richDiagnostics!.fileMetaDocLoadsInFlight,
+          }
+        : {}),
+      ...(Array.isArray(richDiagnostics?.recentCardDocLoads)
+        ? { recentCardDocLoads: richDiagnostics!.recentCardDocLoads }
+        : {}),
+      ...(Array.isArray(richDiagnostics?.recentFileMetaLoads)
+        ? { recentFileMetaLoads: richDiagnostics!.recentFileMetaLoads }
+        : {}),
+      ...(typeof docsInFlight === 'number' ? { docsInFlight } : {}),
+      ...(dom ? { capturedDom: dom } : {}),
+      ...(typeof timerSummary === 'string' && timerSummary.trim()
+        ? { blockedTimerSummary: timerSummary.trim() }
+        : {}),
+    };
     let timeoutError: RenderError = {
       type: 'instance-error',
       error: {
@@ -1189,70 +1254,9 @@ export async function withTimeout<T>(
         title: 'Render timeout',
         message,
         additionalErrors: null,
+        diagnostics,
       },
       evict: true,
-      diagnostics: {
-        ...(richDiagnostics?.renderStage
-          ? { renderStage: richDiagnostics.renderStage }
-          : {}),
-        ...(typeof richDiagnostics?.stageAgeMs === 'number'
-          ? { stageAgeMs: richDiagnostics.stageAgeMs }
-          : {}),
-        ...(Array.isArray(richDiagnostics?.cardDocsInFlight)
-          ? { cardDocsInFlight: richDiagnostics!.cardDocsInFlight }
-          : {}),
-        ...(Array.isArray(richDiagnostics?.fileMetaDocsInFlight)
-          ? { fileMetaDocsInFlight: richDiagnostics!.fileMetaDocsInFlight }
-          : {}),
-        ...(Array.isArray(richDiagnostics?.inFlightModuleImports)
-          ? { inFlightModuleImports: richDiagnostics!.inFlightModuleImports }
-          : {}),
-        ...(richDiagnostics?.currentlyEvaluatingModule !== undefined
-          ? {
-              currentlyEvaluatingModule:
-                richDiagnostics.currentlyEvaluatingModule,
-            }
-          : {}),
-        ...(Array.isArray(richDiagnostics?.recentModuleEvaluations)
-          ? {
-              recentModuleEvaluations: richDiagnostics!.recentModuleEvaluations,
-            }
-          : {}),
-        ...(Array.isArray(richDiagnostics?.queryLoadsInFlight)
-          ? {
-              queryLoadsInFlight: richDiagnostics!.queryLoadsInFlight as Array<
-                Record<string, unknown>
-              >,
-            }
-          : {}),
-        ...(Array.isArray(richDiagnostics?.recentQueryLoads)
-          ? {
-              recentQueryLoads: richDiagnostics!.recentQueryLoads as Array<
-                Record<string, unknown>
-              >,
-            }
-          : {}),
-        ...(Array.isArray(richDiagnostics?.cardDocLoadsInFlight)
-          ? { cardDocLoadsInFlight: richDiagnostics!.cardDocLoadsInFlight }
-          : {}),
-        ...(Array.isArray(richDiagnostics?.fileMetaDocLoadsInFlight)
-          ? {
-              fileMetaDocLoadsInFlight:
-                richDiagnostics!.fileMetaDocLoadsInFlight,
-            }
-          : {}),
-        ...(Array.isArray(richDiagnostics?.recentCardDocLoads)
-          ? { recentCardDocLoads: richDiagnostics!.recentCardDocLoads }
-          : {}),
-        ...(Array.isArray(richDiagnostics?.recentFileMetaLoads)
-          ? { recentFileMetaLoads: richDiagnostics!.recentFileMetaLoads }
-          : {}),
-        ...(typeof docsInFlight === 'number' ? { docsInFlight } : {}),
-        ...(dom ? { capturedDom: dom } : {}),
-        ...(typeof timerSummary === 'string' && timerSummary.trim()
-          ? { blockedTimerSummary: timerSummary.trim() }
-          : {}),
-      },
     };
     if (typeof timerSummary === 'string' && timerSummary.trim()) {
       timeoutError.error.stack = timerSummary.trim();

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -176,6 +176,7 @@ import './prerender-server-test';
 import './prerender-manager-test';
 import './prerender-batch-ownership-test';
 import './prerender-cancellation-test';
+import './prerender-diagnostics-persistence-test';
 import './prerender-proxy-test';
 import './queue-test';
 import './run-command-task-test';

--- a/packages/realm-server/tests/prerender-diagnostics-persistence-test.ts
+++ b/packages/realm-server/tests/prerender-diagnostics-persistence-test.ts
@@ -1,0 +1,205 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { Prerenderer } from '../prerender/prerenderer';
+import { decorateRenderErrorDiagnostics } from '../prerender/prerender-app';
+
+// Regression coverage for the "render-timeout diagnostics are
+// collected but silently dropped at persistence" bug (CS-10872
+// follow-up). The persistence layer (`IndexWriter.updateEntry`) only
+// serializes the **inner** `SerializedError` into
+// `boxel_index.error_doc`:
+//
+//   error_doc: errorEntry?.error ?? entry.error   // <- inner only
+//
+// …but the two decorator helpers that stamp diagnostics onto a
+// render-timeout response originally wrote them onto the **outer**
+// `RenderError` wrapper. That meant diagnostics rode the response all
+// the way through the fused visit, the card indexer, and the update
+// path — and then vanished when the row was written to disk.
+//
+// These tests pin both decorators down to the inner
+// `SerializedError` so the diagnostics payload survives persistence
+// and can be surfaced by the in-UI error banner. Running them under
+// the original outer-wrapper implementation fails on the
+// `inner.diagnostics` assertions; running under the fix passes.
+
+type FakeVisitResponse = {
+  card?: {
+    error?: {
+      type: 'instance-error';
+      error: {
+        id: string;
+        status: number;
+        title: string;
+        message: string;
+        additionalErrors: unknown[] | null;
+        diagnostics?: Record<string, unknown>;
+      };
+      evict?: boolean;
+      // If the old (buggy) code path is restored, diagnostics would
+      // appear here instead. We assert this field stays `undefined`
+      // so the test isn't silently passing because the decorator
+      // happened to stamp both places.
+      diagnostics?: Record<string, unknown>;
+    };
+  };
+  pageUnusableError?: unknown;
+};
+
+function buildFakeVisitResponse(): FakeVisitResponse {
+  return {
+    card: {
+      error: {
+        type: 'instance-error',
+        error: {
+          id: 'https://realm.example/c/1.json',
+          status: 504,
+          title: 'Render timeout',
+          message: 'Render timed-out after 90000 ms',
+          additionalErrors: null,
+        },
+        evict: true,
+      },
+    },
+  };
+}
+
+module(basename(__filename), function () {
+  module(
+    'render-timeout diagnostics persistence (CS-10872 follow-up)',
+    function () {
+      test('Prerenderer.decorateRenderErrorsWithTimings writes to the inner SerializedError (where error_doc reads from)', function (assert) {
+        let response = buildFakeVisitResponse();
+        Prerenderer.decorateRenderErrorsWithTimings(
+          response,
+          {
+            launchMs: 42,
+            renderMs: 90000,
+            waits: {
+              semaphoreMs: 3,
+              tabQueueMs: 5,
+              tabStartupMs: 10,
+            },
+          },
+          90042,
+        );
+
+        // The inner SerializedError is what `IndexWriter.updateEntry`
+        // persists into `boxel_index.error_doc`. Diagnostics must
+        // land here.
+        let inner = response.card?.error?.error;
+        assert.ok(inner, 'inner SerializedError still present');
+        assert.ok(inner?.diagnostics, 'diagnostics attached to inner');
+        assert.strictEqual(
+          typeof inner?.diagnostics,
+          'object',
+          'diagnostics is an object',
+        );
+        assert.strictEqual(
+          (inner!.diagnostics as any).launchMs,
+          42,
+          'launchMs present on inner',
+        );
+        assert.strictEqual(
+          (inner!.diagnostics as any).renderElapsedMs,
+          90000,
+          'renderElapsedMs present on inner',
+        );
+        assert.strictEqual(
+          (inner!.diagnostics as any).totalElapsedMs,
+          90042,
+          'totalElapsedMs present on inner',
+        );
+        assert.deepEqual(
+          (inner!.diagnostics as any).waits,
+          { semaphoreMs: 3, tabQueueMs: 5, tabStartupMs: 10 },
+          'waits breakdown present on inner',
+        );
+
+        // And must NOT land on the outer RenderError wrapper —
+        // that's the field the index writer ignores, so populating
+        // it silently loses the data.
+        assert.strictEqual(
+          response.card?.error?.diagnostics,
+          undefined,
+          'diagnostics NOT attached to outer RenderError wrapper',
+        );
+      });
+
+      test('decorateRenderErrorDiagnostics stamps requestId on the inner SerializedError', function (assert) {
+        let response = buildFakeVisitResponse();
+        decorateRenderErrorDiagnostics(response, 'req-abc-123');
+
+        let inner = response.card?.error?.error;
+        assert.ok(inner?.diagnostics, 'diagnostics block created on inner');
+        assert.strictEqual(
+          typeof inner?.diagnostics,
+          'object',
+          'diagnostics is an object',
+        );
+        assert.strictEqual(
+          (inner!.diagnostics as any).requestId,
+          'req-abc-123',
+          'requestId threaded through to inner',
+        );
+        assert.strictEqual(
+          response.card?.error?.diagnostics,
+          undefined,
+          'diagnostics NOT attached to outer RenderError wrapper',
+        );
+      });
+
+      test('stacking both decorators leaves a single diagnostics object on the inner SerializedError', function (assert) {
+        // In production these run back-to-back: Prerenderer attaches
+        // launch/render/waits timings, then the HTTP handler stamps
+        // requestId. Both must target the same location so the
+        // second merges with the first rather than clobbering or
+        // shadowing on a different level.
+        let response = buildFakeVisitResponse();
+        Prerenderer.decorateRenderErrorsWithTimings(
+          response,
+          { launchMs: 1, renderMs: 2, waits: {} },
+          3,
+        );
+        decorateRenderErrorDiagnostics(response, 'req-xyz');
+
+        let inner = response.card!.error!.error;
+        assert.strictEqual(
+          (inner.diagnostics as any)?.launchMs,
+          1,
+          'launchMs retained after second decorator ran',
+        );
+        assert.strictEqual(
+          (inner.diagnostics as any)?.requestId,
+          'req-xyz',
+          'requestId merged into the same diagnostics object',
+        );
+        assert.strictEqual(
+          response.card?.error?.diagnostics,
+          undefined,
+          'outer wrapper still clean (no shadow copy)',
+        );
+      });
+
+      test('decorators are no-ops when there is no embedded error', function (assert) {
+        // Successful responses should not sprout an empty
+        // diagnostics object — that would confuse downstream UI into
+        // showing a details section for an error that never happened.
+        let response: { card: { serialized: null; error?: unknown } } = {
+          card: { serialized: null },
+        };
+        Prerenderer.decorateRenderErrorsWithTimings(
+          response,
+          { launchMs: 1, renderMs: 2, waits: {} },
+          3,
+        );
+        decorateRenderErrorDiagnostics(response, 'req-xyz');
+        assert.strictEqual(
+          response.card.error,
+          undefined,
+          'no error slot materialized',
+        );
+      });
+    },
+  );
+});

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -1486,10 +1486,13 @@ module(basename(__filename), function () {
           'timeout retains page identifier',
         );
 
-        // CS-10872: the timeout RenderError must carry the structured
+        // CS-10872: the timeout error must carry the structured
         // diagnostics block so operators reading the persisted error
         // document see launch-vs-render breakdown + the host hooks.
-        let diagnostics = (timedOut.response.error as any)?.diagnostics;
+        // Diagnostics live on the inner SerializedError (RenderError
+        // → error → diagnostics) because that's what IndexWriter
+        // persists into `boxel_index.error_doc`.
+        let diagnostics = (timedOut.response.error?.error as any)?.diagnostics;
         assert.strictEqual(
           typeof diagnostics,
           'object',
@@ -1601,7 +1604,10 @@ module(basename(__filename), function () {
             'error title is "Render timeout"',
           );
 
-          let diagnostics = timeoutError?.diagnostics;
+          // Diagnostics live on the inner SerializedError (the field
+          // IndexWriter persists into `error_doc`), not on the outer
+          // RenderError wrapper.
+          let diagnostics = (timeoutError?.error as any)?.diagnostics;
           assert.strictEqual(
             typeof diagnostics,
             'object',

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -147,7 +147,6 @@ export interface RenderTimeoutDiagnostics {
 
 export interface RenderError extends ErrorEntry {
   evict?: boolean;
-  diagnostics?: RenderTimeoutDiagnostics;
 }
 
 export interface FileExtractResponse {


### PR DESCRIPTION
## Summary

Discovered while poking at CS-10793: the `NorthwindDashboard` instance that's routinely timing out in the `small-northwind-ctse-healthy-ape` realm has an `error_doc` in `boxel_index`, but the structured diagnostics CS-10872 added (launch/waits breakdown, render stage, in-flight loads, etc.) aren't there. So: nobody chasing these timeouts gets the payload CS-10872 was supposed to surface.

### The bug

`IndexWriter.updateEntry` (packages/runtime-common/index-writer.ts:354) persists the **inner** `SerializedError` into `boxel_index.error_doc`:

```ts
error_doc: errorEntry?.error ?? entry.error,  // <- entry.error = inner SerializedError
```

But the three decorator sites that stamp diagnostics onto a render-timeout response all wrote them onto the **outer** `RenderError` wrapper:

- `prerender/utils.ts` `withTimeout` — the timeout constructor
- `prerender/prerenderer.ts` `decorateRenderErrorsWithTimings` — server-side launch/waits/render timings
- `prerender/prerender-app.ts` `decorateRenderErrorDiagnostics` — HTTP-layer `requestId` stamp

Both `RenderError.diagnostics` and `SerializedError.diagnostics` exist in the type graph; the outer one was effectively a dead channel. Diagnostics rode the response through the fused visit, past the card indexer — and got dropped the moment the row was serialized.

### The fix

Attach diagnostics to the **inner** `SerializedError` at all three source sites. Remove the now-dead `RenderError.diagnostics` field so future writers can't accidentally resurrect the bug. `decorateRenderErrorDiagnostics` lifted from a `buildPrerenderApp` closure to a module-scope export so the regression test can drive it directly.

### Regression test

`tests/prerender-diagnostics-persistence-test.ts` locks the invariant down: "diagnostics live on the inner SerializedError where `error_doc` reads from". Each test asserts both:
- the expected diagnostics fields appear on `response.card.error.error.diagnostics` (inner), and
- `response.card.error.diagnostics` (outer) stays `undefined`.

I verified the test by temporarily reverting the fix — 3 of the 4 tests fail under the old outer-wrapper behavior, all 4 pass under the fix. The 4th test (decorators no-op on success responses) stays green either way — it covers a separate invariant I didn't want to lose.

## Test plan
- [x] `prerender-diagnostics-persistence-test.ts` — 4/4 pass
- [x] Full sweep of related modules: `prerender-cancellation-test`, `prerender-manager-test`, `prerender-batch-ownership-test`, `prerender-proxy-test` — 86/86 pass
- [x] Full realm-server lint clean
- [ ] CI for the broader integration suite
- [ ] Re-reindex the dashboard locally after merge and confirm `error_doc` now contains a `diagnostics` block with `renderStage`, `launchMs`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
