### PR TITLE
CS-10887: Create realm_registry table migration

### DIFF
--- a/packages/host/config/schema/1776960113000_schema.sql
+++ b/packages/host/config/schema/1776960113000_schema.sql
@@ -125,6 +125,20 @@
    PRIMARY KEY ( realm_url, realm_version ) 
 );
 
+ CREATE TABLE IF NOT EXISTS realm_registry (
+   id DEFAULT (hex(randomblob(16))) NOT NULL,
+   url TEXT NOT NULL,
+   kind TEXT NOT NULL,
+   disk_id TEXT NOT NULL,
+   owner_username TEXT NOT NULL,
+   source_url TEXT,
+   last_published_at,
+   pinned BOOLEAN DEFAULT false NOT NULL,
+   created_at DEFAULT CURRENT_TIMESTAMP NOT NULL,
+   updated_at DEFAULT CURRENT_TIMESTAMP NOT NULL,
+   PRIMARY KEY ( id ) 
+);
+
  CREATE TABLE IF NOT EXISTS realm_user_permissions (
    realm_url TEXT NOT NULL,
    username TEXT NOT NULL,

--- a/packages/postgres/migrations/1776960113000_create-realm-registry.js
+++ b/packages/postgres/migrations/1776960113000_create-realm-registry.js
@@ -7,28 +7,61 @@ exports.up = (pgm) => {
       primaryKey: true,
       default: pgm.func('gen_random_uuid()'),
     },
+    // Canonical URL of the realm (e.g., https://app.boxel.com/user/my-realm/). Realms
+    // are addressed by URL everywhere in the code; this is the primary lookup key, and
+    // a UNIQUE index enforces one row per URL.
     url: {
       type: 'varchar',
       notNull: true,
     },
+    // Classifies how the realm is stored and what operations are allowed:
+    //   'source'    — user-created source realm; on disk at
+    //                 <realmsRootPath>/<owner>/<endpoint>/.
+    //   'published' — published snapshot of a source realm; on disk at
+    //                 <realmsRootPath>/<PUBLISHED_DIRECTORY_NAME>/<uuid>/.
+    //   'bootstrap' — CLI-seeded well-known realm (base, catalog, etc.); mutation
+    //                 handlers reject operations targeting these rows.
+    // A CHECK constraint enforces the enum.
     kind: {
       type: 'varchar',
       notNull: true,
     },
+    // Identifier used to compose the on-disk path; meaning depends on `kind`:
+    //   source:    "<owner>/<endpoint>" segment under realmsRootPath
+    //   published: UUID of the published directory (matches published_realms.id while
+    //              the legacy table exists)
+    //   bootstrap: absolute path supplied via the --path CLI arg (these realms live
+    //              outside realmsRootPath)
     disk_id: {
       type: 'varchar',
       notNull: true,
     },
+    // Matrix username that owns this realm. Used for permission checks in mutation
+    // handlers. Bootstrap rows use the sentinel 'system' since they have no real owner.
     owner_username: {
       type: 'varchar',
       notNull: true,
     },
+    // For kind='published': the URL of the source realm it was published from (soft
+    // foreign key to another row's `url`; not enforced by the DB so that source and
+    // published rows can be manipulated independently during migration).
+    // For kind='source' or 'bootstrap': always NULL.
     source_url: {
       type: 'varchar',
     },
+    // Milliseconds since epoch of the most recent publish. Only meaningful for
+    // kind='published'; NULL otherwise.
     last_published_at: {
       type: 'bigint',
     },
+    // Mount policy:
+    //   true  — reconciler mounts this realm eagerly at boot and on NOTIFY upsert, on
+    //           every realm-server instance. Pinned rows are also exempt from future
+    //           idle eviction.
+    //   false — mount-on-demand on first request via ensureMounted().
+    // Bootstrap rows are seeded with pinned=true; source and published rows default to
+    // pinned=false. A partial index exists for WHERE pinned = true to make the
+    // reconciler's boot-time "mount the pinned set" query cheap.
     pinned: {
       type: 'boolean',
       notNull: true,

--- a/packages/postgres/migrations/1776960113000_create-realm-registry.js
+++ b/packages/postgres/migrations/1776960113000_create-realm-registry.js
@@ -43,14 +43,18 @@ exports.up = (pgm) => {
       notNull: true,
     },
     // For kind='published': the URL of the source realm it was published from (soft
-    // foreign key to another row's `url`; not enforced by the DB so that source and
+    // foreign key to another row's `url`; intentionally not an FK so that source and
     // published rows can be manipulated independently during migration).
     // For kind='source' or 'bootstrap': always NULL.
+    // Enforced by realm_registry_source_url_by_kind.
     source_url: {
       type: 'varchar',
     },
-    // Milliseconds since epoch of the most recent publish. Only meaningful for
-    // kind='published'; NULL otherwise.
+    // Milliseconds since epoch of the most recent publish. Populated for
+    // kind='published'; always NULL otherwise (enforced by
+    // realm_registry_last_published_by_kind). May still be NULL for a kind='published'
+    // row during transitional states (e.g., a row inserted before its first publish
+    // completes), so the constraint only enforces the "NULL for non-published" half.
     last_published_at: {
       type: 'bigint',
     },
@@ -82,6 +86,13 @@ exports.up = (pgm) => {
   pgm.addConstraint('realm_registry', 'realm_registry_kind_check', {
     check: "kind in ('source','published','bootstrap')",
   });
+  pgm.addConstraint('realm_registry', 'realm_registry_source_url_by_kind', {
+    check:
+      "(kind = 'published' AND source_url IS NOT NULL) OR (kind <> 'published' AND source_url IS NULL)",
+  });
+  pgm.addConstraint('realm_registry', 'realm_registry_last_published_by_kind', {
+    check: "kind = 'published' OR last_published_at IS NULL",
+  });
 
   pgm.createIndex('realm_registry', ['url'], {
     unique: true,
@@ -104,6 +115,11 @@ exports.down = (pgm) => {
   pgm.dropIndex('realm_registry', ['url'], {
     name: 'realm_registry_url_uniq',
   });
+  pgm.dropConstraint(
+    'realm_registry',
+    'realm_registry_last_published_by_kind',
+  );
+  pgm.dropConstraint('realm_registry', 'realm_registry_source_url_by_kind');
   pgm.dropConstraint('realm_registry', 'realm_registry_kind_check');
   pgm.dropTable('realm_registry');
 };

--- a/packages/postgres/migrations/1776960113000_create-realm-registry.js
+++ b/packages/postgres/migrations/1776960113000_create-realm-registry.js
@@ -1,0 +1,76 @@
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.createTable('realm_registry', {
+    id: {
+      type: 'uuid',
+      primaryKey: true,
+      default: pgm.func('gen_random_uuid()'),
+    },
+    url: {
+      type: 'varchar',
+      notNull: true,
+    },
+    kind: {
+      type: 'varchar',
+      notNull: true,
+    },
+    disk_id: {
+      type: 'varchar',
+      notNull: true,
+    },
+    owner_username: {
+      type: 'varchar',
+      notNull: true,
+    },
+    source_url: {
+      type: 'varchar',
+    },
+    last_published_at: {
+      type: 'bigint',
+    },
+    pinned: {
+      type: 'boolean',
+      notNull: true,
+      default: false,
+    },
+    created_at: {
+      type: 'timestamp',
+      notNull: true,
+      default: pgm.func('now()'),
+    },
+    updated_at: {
+      type: 'timestamp',
+      notNull: true,
+      default: pgm.func('now()'),
+    },
+  });
+
+  pgm.addConstraint('realm_registry', 'realm_registry_kind_check', {
+    check: "kind in ('source','published','bootstrap')",
+  });
+
+  pgm.createIndex('realm_registry', ['url'], {
+    unique: true,
+    name: 'realm_registry_url_uniq',
+  });
+  pgm.createIndex('realm_registry', ['source_url']);
+  pgm.createIndex('realm_registry', ['kind']);
+  pgm.createIndex('realm_registry', ['pinned'], {
+    where: 'pinned = true',
+    name: 'realm_registry_pinned_idx',
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropIndex('realm_registry', ['pinned'], {
+    name: 'realm_registry_pinned_idx',
+  });
+  pgm.dropIndex('realm_registry', ['kind']);
+  pgm.dropIndex('realm_registry', ['source_url']);
+  pgm.dropIndex('realm_registry', ['url'], {
+    name: 'realm_registry_url_uniq',
+  });
+  pgm.dropConstraint('realm_registry', 'realm_registry_kind_check');
+  pgm.dropTable('realm_registry');
+};


### PR DESCRIPTION
## Summary

- Adds the `realm_registry` table — the schema that backs the DB-authoritative realm registry project ([CS-10887](https://linear.app/cardstack/issue/CS-10887))
- Shadow data only: no readers yet, no handler changes yet. Phase 1 dual-writes land in a follow-up ([CS-10889](https://linear.app/cardstack/issue/CS-10889))
- Inline comments on each column document the per-`kind` interpretations of `disk_id`, the `'system'` owner sentinel for bootstrap rows, the mount-policy role of `pinned`, and the soft-FK semantics of `source_url`

## Schema highlights

- `kind` CHECK constraint enforces `('source','published','bootstrap')`
- Unique index on `url` (`realm_registry_url_uniq`)
- Partial index on `pinned WHERE pinned = true` for the reconciler's boot-time "mount the pinned set" query
- Indexes on `source_url` and `kind`
- `pinned` defaults to false; bootstrap rows will be seeded with `pinned=true` in CS-10888

No ownership column: "any instance can handle any realm" is a project-level design choice; coordination happens via per-realm advisory locks + NOTIFY channels, not an ownership bookkeeping column. Rationale in the [project spec](https://linear.app/cardstack/project/db-authoritative-realm-registry-39806e82c7c6) §10 resolved questions.

## Test plan

- [x] `pnpm lint:migrations` passes
- [x] `migrate up` applies cleanly against local boxel DB
- [x] `migrate down` rolls back cleanly (drops indexes, constraint, table)
- [x] Re-applied after rollback — idempotent
- [x] CHECK constraint rejects invalid `kind` (tested with `'invalid'` value)
- [x] Unique constraint rejects duplicate `url`
- [x] `pnpm make-schema` regenerated the schema dump (see renamed `*_schema.sql`)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)