### PR TITLE
Solidify software-factory Playwright port allocation

### DIFF
--- a/packages/software-factory/src/harness/support-services.ts
+++ b/packages/software-factory/src/harness/support-services.ts
@@ -400,11 +400,12 @@ export async function startHarnessPrerenderServer(options: {
   stop(): Promise<void>;
 }> {
   // findAvailablePort picks a port, closes its probe socket, and hands the
-  // number back. Between close and the child binding, another process in
-  // the same CI worker can snatch the port and the child dies with
-  // EADDRINUSE. Retry with a fresh port when that happens. If the caller
-  // pinned the port explicitly, don't second-guess them — try once.
-  let maxAttempts = options.port ? 1 : 4;
+  // number back. Between close and the child binding, another process on
+  // the same host can snatch the port and the child dies with EADDRINUSE.
+  // Retry on contention in either case: if the caller supplied an explicit
+  // port the collision is usually transient (another process in TIME_WAIT
+  // or a briefly-bound prober), so a short backoff is typically enough.
+  const maxAttempts = 4;
   for (let attempt = 1; ; attempt++) {
     try {
       return await attemptStartHarnessPrerenderServer(options);
@@ -416,6 +417,10 @@ export async function startHarnessPrerenderServer(options: {
         log.warn(
           `prerender server port ${err.port} contended at bind — retrying (attempt ${attempt + 1}/${maxAttempts})`,
         );
+        // Short backoff before retrying. When the port is explicit we are
+        // retrying the same port, so give any transient blocker a moment
+        // to release.
+        await new Promise((resolve) => setTimeout(resolve, 200 * attempt));
         continue;
       }
       throw err;

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -209,57 +209,7 @@ async function startRealmProcess(
   // next few milliseconds; we reacquire the holders inside `stop()` below
   // after the child has exited so the ports stay ours between tests.
   await testWorkerPortSet.releaseRealmServerPorts();
-  let child = spawn(
-    tsNodeBin,
-    [
-      '--transpileOnly',
-      'src/cli/serve-realm.ts',
-      realmDir,
-      `--compatRealmServerPort=${testWorkerPortSet.compatRealmServerPort}`,
-      `--realmServerPort=${testWorkerPortSet.realmServerPort}`,
-      `--prerenderURL=${testWorkerPrerenderURL}`,
-    ],
-    {
-      cwd: packageRoot,
-      detached: true,
-      env: {
-        ...process.env,
-        NODE_NO_WARNINGS: '1',
-        SOFTWARE_FACTORY_METADATA_FILE: metadataFile,
-        ...(supportMetadata?.context
-          ? {
-              SOFTWARE_FACTORY_CONTEXT: JSON.stringify(supportMetadata.context),
-            }
-          : {}),
-        ...(preparedTemplate
-          ? {
-              SOFTWARE_FACTORY_TEMPLATE_DATABASE_NAME:
-                preparedTemplate.templateDatabaseName,
-            }
-          : {}),
-        ...(preparedTemplate
-          ? {
-              SOFTWARE_FACTORY_TEMPLATE_REALM_SERVER_URL:
-                preparedTemplate.templateRealmServerURL,
-            }
-          : {}),
-        ...(permissions
-          ? {
-              SOFTWARE_FACTORY_PERMISSIONS: JSON.stringify(permissions),
-            }
-          : {}),
-      },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    },
-  );
-
-  child.stdout?.on('data', (chunk) => {
-    logs = appendLog(logs, String(chunk));
-  });
-  child.stderr?.on('data', (chunk) => {
-    logs = appendLog(logs, String(chunk));
-  });
-
+  let child: ReturnType<typeof spawn> | undefined;
   let metadata: {
     realmDir: string;
     realmURL: string;
@@ -272,37 +222,100 @@ async function startRealmProcess(
     sampleCardURL: string;
     ownerBearerToken: string;
   };
-
   try {
-    metadata = await waitForMetadataFile<{
-      realmDir: string;
-      realmURL: string;
-      realmServerURL: string;
-      ports: {
-        publicPort: number;
-        realmServerPort: number;
-        workerManagerPort: number;
-      };
-      sampleCardURL: string;
-      ownerBearerToken: string;
-    }>(metadataFile, child, () => logs);
+    child = spawn(
+      tsNodeBin,
+      [
+        '--transpileOnly',
+        'src/cli/serve-realm.ts',
+        realmDir,
+        `--compatRealmServerPort=${testWorkerPortSet.compatRealmServerPort}`,
+        `--realmServerPort=${testWorkerPortSet.realmServerPort}`,
+        `--prerenderURL=${testWorkerPrerenderURL}`,
+      ],
+      {
+        cwd: packageRoot,
+        detached: true,
+        env: {
+          ...process.env,
+          NODE_NO_WARNINGS: '1',
+          SOFTWARE_FACTORY_METADATA_FILE: metadataFile,
+          ...(supportMetadata?.context
+            ? {
+                SOFTWARE_FACTORY_CONTEXT: JSON.stringify(
+                  supportMetadata.context,
+                ),
+              }
+            : {}),
+          ...(preparedTemplate
+            ? {
+                SOFTWARE_FACTORY_TEMPLATE_DATABASE_NAME:
+                  preparedTemplate.templateDatabaseName,
+              }
+            : {}),
+          ...(preparedTemplate
+            ? {
+                SOFTWARE_FACTORY_TEMPLATE_REALM_SERVER_URL:
+                  preparedTemplate.templateRealmServerURL,
+              }
+            : {}),
+          ...(permissions
+            ? {
+                SOFTWARE_FACTORY_PERMISSIONS: JSON.stringify(permissions),
+              }
+            : {}),
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+
+    child.stdout?.on('data', (chunk) => {
+      logs = appendLog(logs, String(chunk));
+    });
+    child.stderr?.on('data', (chunk) => {
+      logs = appendLog(logs, String(chunk));
+    });
+
+    // Race the metadata-file poll against an early `'error'` from the
+    // child. Without this, a spawn-level failure (e.g. ENOENT on the
+    // ts-node binary) leaves waitForMetadataFile polling until its
+    // 300-second timeout before the startup error surfaces.
+    let earlyError = new Promise<never>((_, reject) => {
+      child!.once('error', reject);
+    });
+    // Prevent the losing side of the race from emitting an unhandled
+    // rejection after the winner has settled.
+    earlyError.catch(() => {});
+    metadata = await Promise.race([
+      waitForMetadataFile<typeof metadata>(metadataFile, child, () => logs),
+      earlyError,
+    ]);
   } catch (error) {
-    // Fully tear down the half-started child before re-acquiring our port
-    // holders. Without the wait, the still-alive child can keep the ports
-    // bound and the reacquire throws, leaving the ports unheld for the
-    // rest of the worker's tests.
+    // Fully tear down the half-started child (if it got as far as
+    // being spawned) before re-acquiring our port holders. Without the
+    // wait, a still-alive child can keep the ports bound and the
+    // reacquire would throw, leaving the ports unheld for the rest of
+    // the worker's tests. A synchronous `spawn` throw (e.g. missing
+    // binary) skips the kill path entirely and lands straight on
+    // reacquire.
     try {
-      if (child.exitCode === null) {
-        killProcessGroup(child.pid!, 'SIGTERM');
+      let halfStartedChild = child;
+      if (
+        halfStartedChild &&
+        halfStartedChild.pid != null &&
+        halfStartedChild.exitCode === null
+      ) {
+        let pid = halfStartedChild.pid;
+        killProcessGroup(pid, 'SIGTERM');
         await new Promise<void>((resolvePromise) => {
           let timeout = setTimeout(() => {
-            killProcessGroup(child.pid!, 'SIGKILL');
+            killProcessGroup(pid, 'SIGKILL');
           }, 15_000);
-          child.once('exit', () => {
+          halfStartedChild!.once('exit', () => {
             clearTimeout(timeout);
             resolvePromise();
           });
-          child.once('error', () => {
+          halfStartedChild!.once('error', () => {
             clearTimeout(timeout);
             resolvePromise();
           });
@@ -315,20 +328,23 @@ async function startRealmProcess(
     throw error;
   }
 
+  // Narrow `child` for the rest of the function — if we reached here the
+  // metadata was read successfully, which means spawn succeeded.
+  let runningChild = child;
   let stop = async () => {
     try {
-      if (child.exitCode === null) {
-        killProcessGroup(child.pid!, 'SIGTERM');
+      if (runningChild.exitCode === null) {
+        killProcessGroup(runningChild.pid!, 'SIGTERM');
         await new Promise<void>((resolve, reject) => {
           let timeout = setTimeout(() => {
-            killProcessGroup(child.pid!, 'SIGKILL');
+            killProcessGroup(runningChild.pid!, 'SIGKILL');
           }, 15_000);
 
-          child.once('error', (error) => {
+          runningChild.once('error', (error) => {
             clearTimeout(timeout);
             reject(error);
           });
-          child.once('exit', () => {
+          runningChild.once('exit', () => {
             clearTimeout(timeout);
             resolve();
           });

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -287,11 +287,31 @@ async function startRealmProcess(
       ownerBearerToken: string;
     }>(metadataFile, child, () => logs);
   } catch (error) {
-    killProcessGroup(child.pid!, 'SIGTERM');
-    // Port holders were released just before spawn; re-acquire so we don't
-    // leave them unheld after a startup failure. Ignore any reacquire error
-    // because the original spawn error is what we want to surface.
-    await testWorkerPortSet.reacquireRealmServerPorts().catch(() => undefined);
+    // Fully tear down the half-started child before re-acquiring our port
+    // holders. Without the wait, the still-alive child can keep the ports
+    // bound and the reacquire throws, leaving the ports unheld for the
+    // rest of the worker's tests.
+    try {
+      if (child.exitCode === null) {
+        killProcessGroup(child.pid!, 'SIGTERM');
+        await new Promise<void>((resolvePromise) => {
+          let timeout = setTimeout(() => {
+            killProcessGroup(child.pid!, 'SIGKILL');
+          }, 15_000);
+          child.once('exit', () => {
+            clearTimeout(timeout);
+            resolvePromise();
+          });
+          child.once('error', () => {
+            clearTimeout(timeout);
+            resolvePromise();
+          });
+        });
+      }
+      await testWorkerPortSet.reacquireRealmServerPorts();
+    } catch {
+      // Cleanup errors must not mask the original startup failure.
+    }
     throw error;
   }
 

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -17,6 +17,10 @@ import {
 import { buildRealmToken, buildServerToken } from '../src/harness/shared';
 import { startHarnessPrerenderServer } from '../src/harness/support-services';
 import { buildBrowserState, installBrowserState } from './helpers/browser-auth';
+import {
+  allocateTestWorkerPortSet,
+  type TestWorkerPortReservation,
+} from './helpers/port-allocator';
 
 type StartedFactoryRealm = {
   realmDir: string;
@@ -56,7 +60,7 @@ type FactoryRealmOptions = {
 };
 
 type FactoryRealmWorkerFixtures = {
-  testWorkerPortSet: TestWorkerPortSet;
+  testWorkerPortSet: TestWorkerPortReservation;
   testWorkerPrerender: {
     url: string;
     stop(): Promise<void>;
@@ -72,12 +76,6 @@ type SharedRealmHandle = {
   refCount: number;
 };
 
-type TestWorkerPortSet = {
-  compatRealmServerPort: number;
-  realmServerPort: number;
-  prerenderPort: number;
-};
-
 const packageRoot = resolve(process.cwd());
 const tsNodeBin = resolve(packageRoot, 'node_modules', '.bin', 'ts-node');
 const defaultRealmDir = resolve(
@@ -85,15 +83,6 @@ const defaultRealmDir = resolve(
   process.env.SOFTWARE_FACTORY_REALM_DIR ?? 'test-fixtures/darkfactory-adopter',
 );
 const sharedRealms = new Map<string, Promise<SharedRealmHandle>>();
-const testWorkerPortBlockSize = 10;
-const testWorkerPortSearchStride = 200;
-const testWorkerRunOffset = Number(
-  process.env.SOFTWARE_FACTORY_TEST_WORKER_RUN_OFFSET ??
-    ((process.pid * 31 + process.ppid) % 1000) * testWorkerPortBlockSize,
-);
-const testWorkerPortBase = Number(
-  process.env.SOFTWARE_FACTORY_TEST_WORKER_PORT_BASE ?? 43100,
-);
 
 function appendLog(buffer: string, chunk: string): string {
   let combined = `${buffer}${chunk}`;
@@ -146,65 +135,6 @@ async function waitForPortFree(
   throw new Error(`Port ${port} still in use after ${timeoutMs}ms`);
 }
 
-async function isPortFree(port: number): Promise<boolean> {
-  return await new Promise<boolean>((resolve, reject) => {
-    let server = createServer();
-    server.once('error', (error: NodeJS.ErrnoException) => {
-      server.close(() => {
-        if (error.code === 'EADDRINUSE') {
-          resolve(false);
-        } else {
-          reject(error);
-        }
-      });
-    });
-    server.listen(port, '127.0.0.1', () => {
-      server.close((closeError) => {
-        if (closeError) {
-          reject(closeError);
-        } else {
-          resolve(true);
-        }
-      });
-    });
-  });
-}
-
-async function allocateTestWorkerPortSet(
-  testWorkerIndex: number,
-): Promise<TestWorkerPortSet> {
-  // Reserve one stable port block per Playwright testWorker for services whose
-  // URLs must remain constant across test restarts within the same worker:
-  // compat proxy and realm-server (for BOXEL_HOST_URL stability) and prerender
-  // (standby target). The worker-manager port is NOT pre-allocated here — it is
-  // dynamically assigned via findAvailablePort() each time a realm stack starts,
-  // since its URL does not need to be stable. Include a per-process offset so
-  // concurrent Playwright runs with the same worker index do not all probe the
-  // same block first.
-  for (let attempt = 0; attempt < 100; attempt++) {
-    let blockStart =
-      testWorkerPortBase +
-      testWorkerRunOffset +
-      testWorkerIndex * testWorkerPortBlockSize +
-      attempt * testWorkerPortSearchStride;
-    let candidate: TestWorkerPortSet = {
-      compatRealmServerPort: blockStart,
-      realmServerPort: blockStart + 1,
-      prerenderPort: blockStart + 2,
-    };
-    let ports = Object.values(candidate);
-    if (
-      (await Promise.all(ports.map((port) => isPortFree(port)))).every(Boolean)
-    ) {
-      return candidate;
-    }
-  }
-
-  throw new Error(
-    `Unable to allocate a stable software-factory port block for testWorker ${testWorkerIndex}`,
-  );
-}
-
 async function waitForMetadataFile<T>(
   metadataFile: string,
   child: ReturnType<typeof spawn>,
@@ -234,7 +164,7 @@ async function waitForMetadataFile<T>(
 
 async function startRealmProcess(
   realmDir = defaultRealmDir,
-  testWorkerPortSet: TestWorkerPortSet,
+  testWorkerPortSet: TestWorkerPortReservation,
   testWorkerPrerenderURL: string,
   permissions?: RealmPermissions,
 ) {
@@ -274,6 +204,11 @@ async function startRealmProcess(
         }
       : undefined);
 
+  // Release our holder sockets on the compat + realm-server ports right
+  // before spawning the child. The realm child will bind to them in the
+  // next few milliseconds; we reacquire the holders inside `stop()` below
+  // after the child has exited so the ports stay ours between tests.
+  await testWorkerPortSet.releaseRealmServerPorts();
   let child = spawn(
     tsNodeBin,
     [
@@ -353,6 +288,10 @@ async function startRealmProcess(
     }>(metadataFile, child, () => logs);
   } catch (error) {
     killProcessGroup(child.pid!, 'SIGTERM');
+    // Port holders were released just before spawn; re-acquire so we don't
+    // leave them unheld after a startup failure. Ignore any reacquire error
+    // because the original spawn error is what we want to surface.
+    await testWorkerPortSet.reacquireRealmServerPorts().catch(() => undefined);
     throw error;
   }
 
@@ -380,6 +319,9 @@ async function startRealmProcess(
         waitForPortFree(metadata.ports.publicPort),
         waitForPortFree(metadata.ports.workerManagerPort),
       ]);
+      // Child has fully released its sockets; reclaim our holders on
+      // compat + realm-server before the next test-scoped realm starts.
+      await testWorkerPortSet.reacquireRealmServerPorts();
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -437,7 +379,7 @@ function sharedRealmKey(
 async function acquireSharedRealm(
   key: string,
   realmDir: string,
-  testWorkerPortSet: TestWorkerPortSet,
+  testWorkerPortSet: TestWorkerPortReservation,
   testWorkerPrerenderURL: string,
 ): Promise<StartedFactoryRealm> {
   let existing = sharedRealms.get(key);
@@ -489,8 +431,14 @@ export const test = base.extend<
       // port assignments stable for the lifetime of a Playwright testWorker.
       // That gives each testWorker a consistent harness URL set even as the
       // underlying realm stack is torn down and recreated between tests.
-      let portSet = await allocateTestWorkerPortSet(workerInfo.parallelIndex);
-      await use(portSet);
+      let reservation = await allocateTestWorkerPortSet(
+        workerInfo.parallelIndex,
+      );
+      try {
+        await use(reservation);
+      } finally {
+        await reservation.stop();
+      }
     },
     { scope: 'worker' },
   ],
@@ -501,6 +449,10 @@ export const test = base.extend<
       // for the same Playwright testWorker, each restarted realm stack can
       // point back to the same prerender process without changing BOXEL_HOST_URL.
       let boxelHostURL = `http://localhost:${testWorkerPortSet.compatRealmServerPort}`;
+      // Release the holder socket on the prerender port so the child can
+      // bind. Prerender keeps this port for the rest of the worker's
+      // lifetime, so there is no matching reacquire.
+      await testWorkerPortSet.releasePrerenderPort();
       let prerender = await startHarnessPrerenderServer({
         boxelHostURL,
         port: testWorkerPortSet.prerenderPort,

--- a/packages/software-factory/tests/helpers/port-allocator.ts
+++ b/packages/software-factory/tests/helpers/port-allocator.ts
@@ -1,0 +1,244 @@
+import { createServer, type Server } from 'node:net';
+
+// Port-allocation strategy for per-worker service blocks:
+//
+//   - The Playwright harness pre-reserves a 3-port block per worker for
+//     compat, realm-server, and prerender, and keeps those ports stable
+//     for the worker's lifetime so BOXEL_HOST_URL does not change between
+//     tests.
+//   - The Linux ephemeral port range is typically 32768-60999. Any port
+//     chosen by OS port-0 allocation (Node's `server.listen(0)`, used by
+//     `findAvailablePort` in isolated-realm-stack.ts / support-services.ts)
+//     will fall in that range. If our reserved blocks overlapped it, a
+//     different worker's dynamic allocation could return a port that
+//     another worker has "reserved" but not actually bound, producing
+//     EADDRINUSE when the reserver later tries to listen.
+//   - We therefore confine reserved blocks to [20000, 32000), below the
+//     ephemeral range, and (for defense in depth) bind a holder socket to
+//     each reserved port for the worker's lifetime, closing it only for
+//     the microseconds between "about to spawn a child" and "child has
+//     bound".
+export const TEST_WORKER_PORT_BLOCK_SIZE = 10;
+
+export const TEST_WORKER_PORT_RANGE_START = Number(
+  process.env.SOFTWARE_FACTORY_TEST_WORKER_PORT_RANGE_START ?? 20000,
+);
+export const TEST_WORKER_PORT_RANGE_END = Number(
+  process.env.SOFTWARE_FACTORY_TEST_WORKER_PORT_RANGE_END ?? 32000,
+);
+
+// Coprime stride for linear-probe search so repeated attempts cover a wide
+// portion of the slot space before wrapping. 7 is coprime with 1200 slots.
+const TEST_WORKER_PORT_SEARCH_STRIDE = 7;
+
+const TEST_WORKER_PORT_NUM_SLOTS = Math.floor(
+  (TEST_WORKER_PORT_RANGE_END - TEST_WORKER_PORT_RANGE_START) /
+    TEST_WORKER_PORT_BLOCK_SIZE,
+);
+
+const TEST_WORKER_RUN_OFFSET = Number(
+  process.env.SOFTWARE_FACTORY_TEST_WORKER_RUN_OFFSET ??
+    (process.pid * 31 + process.ppid) % TEST_WORKER_PORT_NUM_SLOTS,
+);
+
+if (
+  !Number.isInteger(TEST_WORKER_PORT_RANGE_START) ||
+  !Number.isInteger(TEST_WORKER_PORT_RANGE_END) ||
+  TEST_WORKER_PORT_RANGE_START < 1024 ||
+  TEST_WORKER_PORT_RANGE_END > 32768 ||
+  TEST_WORKER_PORT_RANGE_END - TEST_WORKER_PORT_RANGE_START <
+    TEST_WORKER_PORT_BLOCK_SIZE * 4
+) {
+  throw new Error(
+    `Invalid software-factory test worker port range [${TEST_WORKER_PORT_RANGE_START}, ${TEST_WORKER_PORT_RANGE_END}); must be a subrange of [1024, 32768) with room for several blocks. See port-allocator.ts comment.`,
+  );
+}
+
+export type TestWorkerPortSet = {
+  compatRealmServerPort: number;
+  realmServerPort: number;
+  prerenderPort: number;
+};
+
+export type PortHolder = {
+  readonly port: number;
+  /** Close the holding socket so the port is free for a child to bind. */
+  release(): Promise<void>;
+  /** Re-bind the holding socket after a transient consumer released the port. */
+  reacquire(): Promise<void>;
+  /** Permanently close the holding socket (idempotent). */
+  stop(): Promise<void>;
+};
+
+export type TestWorkerPortReservation = TestWorkerPortSet & {
+  /**
+   * Release the compat + realm-server port holders right before spawning
+   * a realm child that will bind to those ports. Must be paired with
+   * `reacquireRealmServerPorts()` once the child exits (typically inside
+   * the realm's `stop()` method), so the next test in this worker starts
+   * with the ports held again.
+   */
+  releaseRealmServerPorts(): Promise<void>;
+  reacquireRealmServerPorts(): Promise<void>;
+  /**
+   * Release the prerender port holder once. The prerender child takes
+   * ownership for the remainder of the worker's lifetime, so there is
+   * intentionally no matching reacquire.
+   */
+  releasePrerenderPort(): Promise<void>;
+  /** Stop all port holders. Called at worker-fixture teardown. */
+  stop(): Promise<void>;
+};
+
+async function bindHolderSocket(port: number): Promise<Server | null> {
+  // Bind a `net.Server` to the given port and return it (still listening).
+  // Returns null if the port is already in use.
+  return await new Promise<Server | null>((resolvePromise, rejectPromise) => {
+    let s = createServer();
+    let onError = (error: NodeJS.ErrnoException) => {
+      s.close();
+      if (error.code === 'EADDRINUSE' || error.code === 'EACCES') {
+        resolvePromise(null);
+      } else {
+        rejectPromise(error);
+      }
+    };
+    s.once('error', onError);
+    s.listen(port, '127.0.0.1', () => {
+      s.off('error', onError);
+      // Swallow late errors so they don't become unhandled 'error' events.
+      s.on('error', () => {});
+      resolvePromise(s);
+    });
+  });
+}
+
+async function closeHolderSocket(server: Server): Promise<void> {
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    server.close((err) => (err ? rejectPromise(err) : resolvePromise()));
+  });
+}
+
+export async function tryHoldPort(port: number): Promise<PortHolder | null> {
+  let server = await bindHolderSocket(port);
+  if (!server) {
+    return null;
+  }
+  let held: Server | null = server;
+  let stopped = false;
+  return {
+    port,
+    async release() {
+      if (!held) return;
+      let s = held;
+      held = null;
+      await closeHolderSocket(s);
+    },
+    async reacquire() {
+      if (held || stopped) return;
+      let next = await bindHolderSocket(port);
+      if (!next) {
+        throw new Error(
+          `Unable to re-acquire hold on software-factory port ${port}: port is now occupied by another process`,
+        );
+      }
+      held = next;
+    },
+    async stop() {
+      if (stopped) return;
+      stopped = true;
+      if (held) {
+        let s = held;
+        held = null;
+        await closeHolderSocket(s);
+      }
+    },
+  };
+}
+
+export async function allocateTestWorkerPortSet(
+  testWorkerIndex: number,
+): Promise<TestWorkerPortReservation> {
+  // Reserve one stable port block per Playwright testWorker for services
+  // whose URLs must remain constant across test restarts within the same
+  // worker: compat proxy, realm-server (for BOXEL_HOST_URL stability), and
+  // prerender (standby target). The worker-manager port is NOT pre-allocated
+  // here — it is assigned dynamically via findAvailablePort() each time a
+  // realm stack starts, since its URL does not need to be stable.
+  let baseSlot =
+    (TEST_WORKER_RUN_OFFSET + testWorkerIndex) % TEST_WORKER_PORT_NUM_SLOTS;
+  let maxAttempts = Math.min(100, TEST_WORKER_PORT_NUM_SLOTS);
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    let slot =
+      (baseSlot + attempt * TEST_WORKER_PORT_SEARCH_STRIDE) %
+      TEST_WORKER_PORT_NUM_SLOTS;
+    let blockStart =
+      TEST_WORKER_PORT_RANGE_START + slot * TEST_WORKER_PORT_BLOCK_SIZE;
+    let candidate: TestWorkerPortSet = {
+      compatRealmServerPort: blockStart,
+      realmServerPort: blockStart + 1,
+      prerenderPort: blockStart + 2,
+    };
+    let compatHolder: PortHolder | null = null;
+    let realmHolder: PortHolder | null = null;
+    let prerenderHolder: PortHolder | null = null;
+    try {
+      compatHolder = await tryHoldPort(candidate.compatRealmServerPort);
+      if (!compatHolder) continue;
+      realmHolder = await tryHoldPort(candidate.realmServerPort);
+      if (!realmHolder) {
+        await compatHolder.stop();
+        compatHolder = null;
+        continue;
+      }
+      prerenderHolder = await tryHoldPort(candidate.prerenderPort);
+      if (!prerenderHolder) {
+        await Promise.allSettled([compatHolder.stop(), realmHolder.stop()]);
+        compatHolder = null;
+        realmHolder = null;
+        continue;
+      }
+    } catch (error) {
+      lastError = error;
+      await Promise.allSettled([
+        compatHolder?.stop(),
+        realmHolder?.stop(),
+        prerenderHolder?.stop(),
+      ]);
+      throw error;
+    }
+    let holders = {
+      compat: compatHolder,
+      realm: realmHolder,
+      prerender: prerenderHolder,
+    };
+    return {
+      ...candidate,
+      async releaseRealmServerPorts() {
+        await Promise.all([holders.compat.release(), holders.realm.release()]);
+      },
+      async reacquireRealmServerPorts() {
+        await Promise.all([
+          holders.compat.reacquire(),
+          holders.realm.reacquire(),
+        ]);
+      },
+      async releasePrerenderPort() {
+        await holders.prerender.release();
+      },
+      async stop() {
+        await Promise.allSettled([
+          holders.compat.stop(),
+          holders.realm.stop(),
+          holders.prerender.stop(),
+        ]);
+      },
+    };
+  }
+
+  throw new Error(
+    `Unable to allocate a stable software-factory port block for testWorker ${testWorkerIndex} within [${TEST_WORKER_PORT_RANGE_START}, ${TEST_WORKER_PORT_RANGE_END})` +
+      (lastError ? ` — last error: ${(lastError as Error).message}` : ''),
+  );
+}

--- a/packages/software-factory/tests/helpers/port-allocator.ts
+++ b/packages/software-factory/tests/helpers/port-allocator.ts
@@ -27,14 +27,34 @@ export const TEST_WORKER_PORT_RANGE_END = Number(
   process.env.SOFTWARE_FACTORY_TEST_WORKER_PORT_RANGE_END ?? 32000,
 );
 
-// Coprime stride for linear-probe search so repeated attempts cover a wide
-// portion of the slot space before wrapping. 7 is coprime with 1200 slots.
-const TEST_WORKER_PORT_SEARCH_STRIDE = 7;
+function gcd(a: number, b: number): number {
+  let x = Math.abs(a);
+  let y = Math.abs(b);
+  while (y !== 0) {
+    let remainder = x % y;
+    x = y;
+    y = remainder;
+  }
+  return x;
+}
 
 const TEST_WORKER_PORT_NUM_SLOTS = Math.floor(
   (TEST_WORKER_PORT_RANGE_END - TEST_WORKER_PORT_RANGE_START) /
     TEST_WORKER_PORT_BLOCK_SIZE,
 );
+
+// Preferred stride for linear-probe search so repeated attempts cover a wide
+// portion of the slot space before wrapping. 7 is coprime with the default
+// 1200-slot range. If the configured slot count is a multiple of 7 (possible
+// via env-var overrides) the probe would only visit 1/7 of the slots, so
+// fall back to a pure linear probe (stride=1) in that case.
+const TEST_WORKER_PORT_PREFERRED_SEARCH_STRIDE = 7;
+const TEST_WORKER_PORT_SEARCH_STRIDE =
+  TEST_WORKER_PORT_NUM_SLOTS > 0 &&
+  gcd(TEST_WORKER_PORT_PREFERRED_SEARCH_STRIDE, TEST_WORKER_PORT_NUM_SLOTS) ===
+    1
+    ? TEST_WORKER_PORT_PREFERRED_SEARCH_STRIDE
+    : 1;
 
 const TEST_WORKER_RUN_OFFSET = Number(
   process.env.SOFTWARE_FACTORY_TEST_WORKER_RUN_OFFSET ??

--- a/packages/software-factory/tests/index.ts
+++ b/packages/software-factory/tests/index.ts
@@ -23,3 +23,4 @@ import './eval-step.test';
 import './eval-execution.test';
 import './instantiate-step.test';
 import './parse-step.test';
+import './port-allocator.test';

--- a/packages/software-factory/tests/port-allocator.test.ts
+++ b/packages/software-factory/tests/port-allocator.test.ts
@@ -92,6 +92,38 @@ module('port-allocator', function () {
     }
   });
 
+  test('IPv4 holder blocks a default (dual-stack) bind on the same port', async function (assert) {
+    // prerender-server and realm-server call .listen(port) without a host,
+    // which Node resolves to '::' (IPv6 wildcard, dual-stack on Linux). The
+    // holder must block that bind pattern, not just explicit 127.0.0.1.
+    let reservation = await allocateTestWorkerPortSet(0);
+    let port = reservation.prerenderPort;
+    let attempt = await new Promise<{ ok: boolean; code?: string }>(
+      (resolve) => {
+        let s = createServer();
+        s.once('error', (err: NodeJS.ErrnoException) =>
+          resolve({ ok: false, code: err.code }),
+        );
+        s.listen(port, () => {
+          s.close(() => resolve({ ok: true }));
+        });
+      },
+    );
+    try {
+      assert.false(
+        attempt.ok,
+        `default (::) bind to held port ${port} should fail`,
+      );
+      assert.strictEqual(
+        attempt.code,
+        'EADDRINUSE',
+        `default (::) bind fails with EADDRINUSE, got ${attempt.code}`,
+      );
+    } finally {
+      await reservation.stop();
+    }
+  });
+
   test('a dynamic (OS-assigned) port never lands inside our reserved block', async function (assert) {
     // This is the exact collision vector that caused the CI failure:
     // another worker's `findAvailablePort()` landed on a pre-reserved port.

--- a/packages/software-factory/tests/port-allocator.test.ts
+++ b/packages/software-factory/tests/port-allocator.test.ts
@@ -1,0 +1,188 @@
+import { createServer } from 'node:net';
+import { module, test } from 'qunit';
+
+import {
+  TEST_WORKER_PORT_RANGE_END,
+  TEST_WORKER_PORT_RANGE_START,
+  allocateTestWorkerPortSet,
+  tryHoldPort,
+} from './helpers/port-allocator';
+
+async function isListeningOn(port: number): Promise<boolean> {
+  // Returns true if attempting to bind a fresh server to the port fails
+  // with EADDRINUSE — i.e., something else holds it.
+  return await new Promise<boolean>((resolve, reject) => {
+    let server = createServer();
+    server.once('error', (error: NodeJS.ErrnoException) => {
+      server.close(() => {
+        if (error.code === 'EADDRINUSE') {
+          resolve(true);
+        } else {
+          reject(error);
+        }
+      });
+    });
+    server.listen(port, '127.0.0.1', () => {
+      server.close(() => resolve(false));
+    });
+  });
+}
+
+module('port-allocator', function () {
+  test('reserved ports live below the Linux ephemeral port range', function (assert) {
+    // The Linux default ephemeral range is 32768-60999. Anything up to 32768
+    // is safe. We keep an extra 768-port margin for good measure.
+    assert.ok(
+      TEST_WORKER_PORT_RANGE_START >= 1024,
+      `range start ${TEST_WORKER_PORT_RANGE_START} is above the privileged-port range`,
+    );
+    assert.ok(
+      TEST_WORKER_PORT_RANGE_END <= 32768,
+      `range end ${TEST_WORKER_PORT_RANGE_END} is below the ephemeral port range (32768-60999)`,
+    );
+  });
+
+  test('concurrent allocations produce disjoint blocks entirely inside the safe range', async function (assert) {
+    // Simulate 8 Playwright workers concurrently asking for reservations.
+    let reservations = await Promise.all(
+      Array.from({ length: 8 }, (_, i) => allocateTestWorkerPortSet(i)),
+    );
+    try {
+      let allPorts = reservations.flatMap((r) => [
+        r.compatRealmServerPort,
+        r.realmServerPort,
+        r.prerenderPort,
+      ]);
+      // All distinct.
+      assert.strictEqual(
+        new Set(allPorts).size,
+        allPorts.length,
+        'every reserved port is unique across workers',
+      );
+      // All in the safe range.
+      for (let port of allPorts) {
+        let inRange =
+          port >= TEST_WORKER_PORT_RANGE_START &&
+          port < TEST_WORKER_PORT_RANGE_END;
+        assert.true(
+          inRange,
+          `port ${port} lives in [${TEST_WORKER_PORT_RANGE_START}, ${TEST_WORKER_PORT_RANGE_END})`,
+        );
+      }
+    } finally {
+      await Promise.allSettled(reservations.map((r) => r.stop()));
+    }
+  });
+
+  test('holder socket actually binds the port — another listener sees EADDRINUSE', async function (assert) {
+    let reservation = await allocateTestWorkerPortSet(0);
+    try {
+      for (let port of [
+        reservation.compatRealmServerPort,
+        reservation.realmServerPort,
+        reservation.prerenderPort,
+      ]) {
+        assert.true(
+          await isListeningOn(port),
+          `port ${port} is held by our allocator (bind fails with EADDRINUSE)`,
+        );
+      }
+    } finally {
+      await reservation.stop();
+    }
+  });
+
+  test('a dynamic (OS-assigned) port never lands inside our reserved block', async function (assert) {
+    // This is the exact collision vector that caused the CI failure:
+    // another worker's `findAvailablePort()` landed on a pre-reserved port.
+    // Because our reserved range is below 32768, OS port-0 allocation (which
+    // picks from 32768-60999) cannot hand out any of these ports.
+    let reservation = await allocateTestWorkerPortSet(0);
+    try {
+      // Do many port-0 allocations and assert none fall in the reserved range.
+      let dynamicPorts = await Promise.all(
+        Array.from(
+          { length: 50 },
+          () =>
+            new Promise<number>((resolve, reject) => {
+              let s = createServer();
+              s.once('error', reject);
+              s.listen(0, '127.0.0.1', () => {
+                let address = s.address();
+                if (!address || typeof address === 'string') {
+                  reject(new Error('no address'));
+                  return;
+                }
+                let port = address.port;
+                s.close(() => resolve(port));
+              });
+            }),
+        ),
+      );
+      for (let port of dynamicPorts) {
+        let outsideRange =
+          port < TEST_WORKER_PORT_RANGE_START ||
+          port >= TEST_WORKER_PORT_RANGE_END;
+        assert.true(
+          outsideRange,
+          `OS-assigned port ${port} is outside the reserved range [${TEST_WORKER_PORT_RANGE_START}, ${TEST_WORKER_PORT_RANGE_END})`,
+        );
+      }
+    } finally {
+      await reservation.stop();
+    }
+  });
+
+  test('release + reacquire round-trip keeps ownership', async function (assert) {
+    let reservation = await allocateTestWorkerPortSet(0);
+    try {
+      let port = reservation.compatRealmServerPort;
+      assert.true(await isListeningOn(port), 'port is held initially');
+
+      await reservation.releaseRealmServerPorts();
+      assert.false(
+        await isListeningOn(port),
+        'port is free right after releaseRealmServerPorts()',
+      );
+
+      await reservation.reacquireRealmServerPorts();
+      assert.true(
+        await isListeningOn(port),
+        'port is held again after reacquireRealmServerPorts()',
+      );
+    } finally {
+      await reservation.stop();
+    }
+  });
+
+  test('stop() releases all holders (port becomes free)', async function (assert) {
+    let reservation = await allocateTestWorkerPortSet(0);
+    let ports = [
+      reservation.compatRealmServerPort,
+      reservation.realmServerPort,
+      reservation.prerenderPort,
+    ];
+    await reservation.stop();
+    for (let port of ports) {
+      assert.false(
+        await isListeningOn(port),
+        `port ${port} is free after stop()`,
+      );
+    }
+  });
+
+  test('tryHoldPort returns null when the port is already in use', async function (assert) {
+    // Take any free port, then try to hold it again.
+    let first = await allocateTestWorkerPortSet(0);
+    try {
+      let conflict = await tryHoldPort(first.compatRealmServerPort);
+      assert.strictEqual(
+        conflict,
+        null,
+        'tryHoldPort returns null for an occupied port instead of throwing',
+      );
+    } finally {
+      await first.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Move per-worker reserved port blocks from 43100+ (inside the Linux ephemeral port range 32768-60999) to `[20000, 32000)`, so OS port-0 allocation (`findAvailablePort`) can no longer hand back a port that another worker has "reserved."
- Each of the 3 reserved ports per worker (compat, realm-server, prerender) is now held by a bound `net.Server` for the worker's lifetime — released only for the microseconds between spawn and the child binding, and re-acquired after the child exits.
- Retry prerender-server startup on `EADDRINUSE` even with an explicit port (short backoff), as insurance against any residual race.
- Extract the allocator to `tests/helpers/port-allocator.ts` with 8 qunit tests covering the safe range, disjoint concurrent allocation, holder-binding (incl. dual-stack), OS-dynamic-port-never-in-reserved-range, release/reacquire, `stop()`, and `tryHoldPort` null-on-busy.

## Background

CI run https://github.com/cardstack/boxel/actions/runs/24846259466/job/72734488803?pr=4498 failed with `listen EADDRINUSE: address already in use :::45212` in a worker's prerender-server. Root cause: the harness pre-reserved a 3-port block per worker via `isPortFree()`, which only probes the port (opens then closes) — leaving a TOCTOU window of minutes where the port is "ours" in name only. Because 43100+ sits inside the Linux ephemeral range, another worker's `findAvailablePort()` (OS port-0 allocation) could be handed back 45212, bind it, and leave the reserver to die with EADDRINUSE.

## Test plan

- [x] `pnpm exec qunit tests/port-allocator.test.ts` — 8/8 pass
- [x] `pnpm lint:js` clean
- [x] `pnpm lint:format` clean
- [x] Stress test: 8 concurrent "workers" × 20 dynamic port-0 allocations × 5 release/reacquire cycles each → 0 collisions, 24/24 unique reserved ports in [20000, 32000), dynamic ports all in [32768, 60999)
- [x] Full `pnpm test:playwright` run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)