### PR TITLE
Persist timing diagnostics on every index row

### DIFF
--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -1,38 +1,152 @@
 ---
-name: prerender-timeout-diagnostics
-description: Interpret the diagnostics attached to a prerender-timeout error document (and the matching prerender-server/manager logs) to decide which part of the pipeline stalled. Use when indexing fails with "Render timeout", when a user sees a 504 on a live render, or when investigating the CS-10820 saturation class of incidents.
+name: indexing-diagnostics
+description: Investigate slow or failing indexing using the diagnostics persisted on every `boxel_index` row (`timing_diagnostics` JSONB column, mirrored onto `error_doc.diagnostics` for error rows) plus the matching prerender-server / manager logs. Covers (1) a render inside indexing timed out — classify which part of the prerender pipeline stalled, and (2) an incremental or full reindex was slow but didn't fail — attribute time across the invalidation fan-out and find the rows that cost the most. Use when indexing fails with "Render timeout", when a user sees a 504, when a reindex took much longer than expected, when an `.gts` edit triggers a surprising amount of re-render work, or when investigating the CS-10820 saturation class of incidents.
 allowed-tools: Read, Grep, Glob, Bash
 ---
 
-# Prerender timeout diagnostics
+# Indexing diagnostics
 
-A "Render timeout" error document is the persisted outcome of a prerender whose render phase (not launch, not proxy hop) blew the `RENDER_TIMEOUT_MS` budget. As of CS-10872 the error document and the accompanying log lines carry enough signal to classify the stall in a single pass, without having to re-run the scenario.
+Every indexer write (`IndexWriter.updateEntry`) persists a diagnostic blob on the row it wrote. The blob captures what the prerender pipeline spent its time on and what category of stall (if any) the render was stuck in. It's the primary tool for investigating:
 
-This skill exists because the timeout message alone — `Render timed-out after 90000 ms` — does not distinguish the four very different failure modes:
+- **A render that timed out during indexing** — classify the stall, fix the right layer. (Also applies to user-facing 504s since the UI path goes through the same prerender.)
+- **A reindex that was slow but succeeded** — attribute wall-clock across the cards that got re-rendered, find the real culprit in the fan-out.
+
+Both use cases read from the same data. The difference is the query you start with.
+
+## Where the diagnostics live
+
+Three places, all correlated:
+
+1. **`boxel_index.timing_diagnostics` (and `boxel_index_working.timing_diagnostics`)** — JSONB column, populated for **every** row the indexer writes, regardless of `has_error`. Source of truth. Carries the full `RenderTimeoutDiagnostics` payload plus three write-side stamps: `invalidationId`, `indexedAt`, `requestId`.
+2. **`error_doc.diagnostics`** — derived copy of `timing_diagnostics`, written only for error rows. Exists so the existing UI read path (`error_doc` → `CardErrorJSONAPI.meta.diagnostics` via `formattedError`) keeps working without a schema rename. Non-error rows have `error_doc = null`; go to `timing_diagnostics` directly.
+3. **Logs** — `prerender-server`, `manager`, and `remote-prerenderer` lines all carry `requestId=…`. `grep requestId=<uuid>` collates one call across all three processes. For saturation incidents there's also the periodic `prerender-queue-snapshot` line on each prerender server.
+
+For UI triage you'll typically read the JSON error response (which surfaces `error_doc.diagnostics` as `meta.diagnostics`). For operator / SQL triage — especially slow non-failing reindexes — query the `timing_diagnostics` column directly.
+
+## The four stall categories
+
+Every slow or timed-out render falls into one of:
 
 - **Launch stall**: the request waited in the render-semaphore or tab queue and never got a real render attempt. Fix is capacity, not host code.
 - **Loader stall**: the render started but was still pulling `.gts` modules when the timer fired. Fix is module graph / network.
 - **Data stall**: the render got past module load but is still fetching cards, file-meta, or query-field results. Fix is the host data layer or the backend search.
 - **Render stall**: the render is in DOM rendering / stability-wait but nothing is in flight. Fix is Glimmer / template side.
 
-If you pick the wrong category you waste a day. The diagnostics below tell you which one.
+If you pick the wrong category you waste a day. The diagnostic fields in the [Classify in one pass](#classify-in-one-pass) table below pick it for you.
 
-## Where the diagnostics live
+## Mode A — a render timed out
 
-Two places, same correlation ID:
+Pull the diagnostic JSON for the erroring row:
 
-1. **The persisted error document** (`error_doc` JSONB column, e.g. `boxel_index_card` / `modules`). `error.diagnostics` was added in CS-10872.
-2. **Logs** — the `prerender-server`, `manager`, and `remote-prerenderer` lines all carry `requestId=…` after CS-10872. `grep requestId=<uuid>` collates one call across all three processes. For saturation incidents there is also the periodic `prerender-queue-snapshot` line on each prerender server.
+```sql
+SELECT timing_diagnostics
+FROM boxel_index
+WHERE url = '<errored-card-url>'
+  AND type = 'instance';
+```
 
-Expect both. If one is missing (e.g. older rollout), you can fall back to `capturedDom` / `blockedTimerSummary` which are still attached.
+(Or read `error_doc.diagnostics` from the JSON:API error response — same shape.)
+
+Walk the fields per [Classify in one pass](#classify-in-one-pass). The *first* positive signal wins; stop there.
+
+## Mode B — an incremental reindex was slow
+
+Every `Batch.invalidate(urls)` call mints a UUID stashed into `timing_diagnostics.invalidationId` for every row written during that fan-out. If a `.gts` edit invalidates 8 rows (one file + seven card instances), all eight carry the same `invalidationId` — so you can look at the whole reindex as a group.
+
+**Step 1 — find the invalidation you care about.** If you don't already have the ID, discover recent big ones:
+
+```sql
+-- Biggest fan-outs in the realm, most recent first
+SELECT
+  timing_diagnostics->>'invalidationId' AS id,
+  count(*)                              AS rows_touched,
+  to_timestamp(
+    max((timing_diagnostics->>'indexedAt')::bigint) / 1000
+  )                                     AS last_indexed_at,
+  sum((timing_diagnostics->>'renderElapsedMs')::int)
+                                        AS total_render_ms,
+  max((timing_diagnostics->>'renderElapsedMs')::int)
+                                        AS slowest_ms
+FROM boxel_index
+WHERE realm_url = 'http://localhost:4201/user/your-realm/'
+  AND timing_diagnostics->>'invalidationId' IS NOT NULL
+GROUP BY 1
+ORDER BY last_indexed_at DESC
+LIMIT 20;
+```
+
+**Step 2 — walk the fan-out.** Given an `invalidationId`, pull every row it touched, ordered by render cost:
+
+```sql
+SELECT
+  url,
+  type,
+  has_error,
+  timing_diagnostics->>'renderStage'                  AS stage,
+  (timing_diagnostics->>'renderElapsedMs')::int       AS render_ms,
+  (timing_diagnostics->>'launchMs')::int              AS launch_ms,
+  timing_diagnostics->'waits'                         AS waits,
+  jsonb_array_length(
+    COALESCE(timing_diagnostics->'queryLoadsInFlight', '[]'::jsonb)
+  )                                                   AS queries_stuck,
+  jsonb_array_length(
+    COALESCE(timing_diagnostics->'inFlightModuleImports', '[]'::jsonb)
+  )                                                   AS modules_stuck,
+  to_timestamp((timing_diagnostics->>'indexedAt')::bigint / 1000)
+                                                      AS indexed_at
+FROM boxel_index
+WHERE realm_url = 'http://localhost:4201/user/your-realm/'
+  AND timing_diagnostics->>'invalidationId' = '<uuid>'
+ORDER BY render_ms DESC NULLS LAST;
+```
+
+**Step 3 — classify each slow row.** For the top offenders, pull the full `timing_diagnostics` and apply the [Classify in one pass](#classify-in-one-pass) table to each. Common patterns:
+
+- One row dominates (e.g. a dashboard card) and the rest are cheap. The big row is the real target — investigate its `queryLoadsInFlight` / `recentModuleEvaluations` / `cardDocLoadsInFlight`.
+- All rows share a large `launchMs`. Capacity contention during the reindex, not the cards' fault.
+- The first row in the batch (min `indexedAt`) has a large `renderElapsedMs` but the rest are cheap — this is the cold-loader tax paid by whichever card was rendered first after `clearCache: true` fired. Expected on any executable invalidation; only worth chasing if the cold cost is disproportionate to the dep closure.
+- The `deps` / `types` columns on the same rows tell you *why* each row was invalidated — useful for discovering unintentionally-heavy transitive deps (e.g. a dashboard re-renders because one of its metrics modules has a runtime reference to the changed module).
+
+**Other useful queries:**
+
+```sql
+-- Slowest single renders in the realm, regardless of error state
+SELECT
+  url,
+  to_timestamp((timing_diagnostics->>'indexedAt')::bigint / 1000) AS indexed_at,
+  (timing_diagnostics->>'renderElapsedMs')::int                   AS render_ms,
+  timing_diagnostics->>'renderStage'                              AS stage,
+  timing_diagnostics->>'invalidationId'                           AS group,
+  has_error
+FROM boxel_index
+WHERE realm_url = 'http://localhost:4201/user/your-realm/'
+ORDER BY render_ms DESC NULLS LAST
+LIMIT 20;
+
+-- p95 render time by realm
+SELECT
+  realm_url,
+  avg((timing_diagnostics->>'renderElapsedMs')::int) AS avg_ms,
+  percentile_cont(0.95) WITHIN GROUP (
+    ORDER BY (timing_diagnostics->>'renderElapsedMs')::int
+  )                                                   AS p95_ms,
+  count(*)                                            AS rows
+FROM boxel_index
+WHERE timing_diagnostics->>'renderElapsedMs' IS NOT NULL
+GROUP BY 1
+ORDER BY p95_ms DESC NULLS LAST
+LIMIT 20;
+```
 
 ## Field-by-field reading
 
-`error.diagnostics` is an optional object on any `RenderError` with the shape defined in `packages/runtime-common/index.ts` (`RenderTimeoutDiagnostics`). Every field is optional — absent means the hook wasn't available in that build or the timeout killed the page before we could read it.
+`timing_diagnostics` carries `RenderTimeoutDiagnostics` (defined in `packages/runtime-common/index.ts`) plus `invalidationId` / `indexedAt` / `requestId`. Every render-side field is optional — absent means the hook wasn't available in that build or the page died before the capture could read it.
 
 ```jsonc
 {
   "requestId": "b14e…",          // single ID across client/manager/prerender-server
+  "invalidationId": "a3e1…",     // single ID across every row written by the same Batch.invalidate()
+  "indexedAt": 1776964391615,    // wall-clock ms when IndexWriter.updateEntry ran
   "launchMs": 18720,             // waiting-in-page-pool time (server-side)
   "waits": {
     "semaphoreMs": 18500,        //   └ of that, waiting on the global render semaphore
@@ -40,7 +154,7 @@ Expect both. If one is missing (e.g. older rollout), you can fall back to `captu
     "tabStartupMs": 20           //   └ warming a fresh tab / standby
   },
   "renderElapsedMs": 71280,      // time inside withTimeout()
-  "totalElapsedMs": 90000,       // launch + render (should match the timeout)
+  "totalElapsedMs": 90000,       // launch + render (matches the timeout on errored rows)
   "renderStage": "waiting-stability", // last breadcrumb set by the host route
   "stageAgeMs": 62110,           // ms since `renderStage` was last set
   "cardDocsInFlight": ["…/CardA.json", …], // URLs the store was still loading (legacy, strings only)
@@ -101,7 +215,7 @@ All ms values are server-observed walltime.
 - `cardDocLoadsInFlight[*].ageMs` / `fileMetaDocLoadsInFlight[*].ageMs` mirror the query version for linked-field (card doc) / file-meta loads. One URL with a very large `ageMs` = one slow linksTo target; many URLs with small `ageMs` = fan-out.
 - `recentCardDocLoads[*].ms` / `recentFileMetaLoads[*].ms` are the completed-load histories; same usage as `recentQueryLoads`.
 
-These field names are stable after CS-10872; the skill and the type in `packages/runtime-common/index.ts` should stay in lock-step.
+Keep the field names in lock-step with the type in `packages/runtime-common/index.ts`.
 
 ### Classify in one pass
 
@@ -122,14 +236,14 @@ Walk the fields top-down. The *first* positive signal wins; stop there.
 
 ### Special cases
 
-- **`launchMs` is tiny AND `renderElapsedMs` ≈ `totalElapsedMs` but `renderStage` is `null`** — the host's stage hook didn't install. Either the render.ts deactivate ran before the capture, or you're on a pre-CS-10872 host build. Look at `capturedDom` for the last prerender status.
-- **`totalElapsedMs` substantially less than the configured `RENDER_TIMEOUT_MS`** — the outer request aborted, not the inner render timeout. That's a client/manager timeout (remote-prerenderer's abort message includes the elapsed — see its error text). The stall is still meaningful but the budget isn't the render-timeout budget.
+- **`launchMs` is tiny AND `renderElapsedMs` ≈ `totalElapsedMs` but `renderStage` is `null`** — the host's stage hook didn't install. Either the render.ts deactivate ran before the capture, or you're on an older host build. Look at `capturedDom` for the last prerender status.
+- **`totalElapsedMs` substantially less than the configured `RENDER_TIMEOUT_MS`** — the outer request aborted, not the inner render timeout. That's a client/manager timeout (remote-prerenderer's abort message includes the elapsed). The stall is still meaningful but the budget isn't the render-timeout budget.
 - **`queryLoadsInFlight` but no `fieldName`** — this is an ad-hoc `store.search()` call, not a query field. The `source` string carries the SearchResource's `source` tag (`seed` / `search` / `live-refresh`) to help.
-- **`launchMs + renderElapsedMs ≠ totalElapsedMs`** — possible under retry, since render-runner re-enters with `clearCache: true` on known error signatures. Treat each attempt as its own story; the final error wins.
+- **`launchMs + renderElapsedMs ≠ totalElapsedMs`** — possible under retry, since render-runner re-enters with `clearCache: true` on known error signatures. Treat each attempt as its own story; the final stored attempt wins.
 
 ## Cross-referencing logs
 
-Every log line emitted after CS-10872 for an indexing/user prerender carries `requestId=<uuid>`. Join them:
+Every prerender log line carries `requestId=<uuid>`. Join them:
 
 ```sh
 # Manager proxy lines (including queueMs + target assignment)
@@ -150,7 +264,7 @@ prerender-queue-snapshot totalTabs=4 totalPending=7 affinities=3 | realm:acme(ta
 
 Read this alongside a timeout when `waits.semaphoreMs` is large. A snapshot with `totalPending >> totalTabs` near the timestamp confirms saturation.
 
-## Quick triage rubric
+## Quick triage rubric (Mode A — timeout)
 
 1. **Is `waits.semaphoreMs` > 50% of totalElapsedMs?** If yes, this is capacity. Go look at fleet snapshots, not host code.
 2. **Is `renderStage` still a `buildModel:*` stage?** If yes, the render never started real template work — it's upstream of the host.
@@ -162,9 +276,18 @@ Read this alongside a timeout when `waits.semaphoreMs` is large. A snapshot with
 
 In practice steps 1-5 catch ~90% of timeouts.
 
+## Quick triage rubric (Mode B — slow reindex)
+
+1. **Pull the fan-out with the `invalidationId` query above** — you now have every row touched.
+2. **Does one row dominate total `render_ms`?** If yes, it's the real target. Read its `timing_diagnostics` and apply Mode A's rubric to it.
+3. **Are `launch_ms` and `waits.semaphoreMs` large across all rows?** If yes, capacity contention during the reindex, not the cards' fault.
+4. **Is only the first-indexed row (min `indexedAt`) slow and the rest fast?** That's the cold-loader tax paid by the first render after a `.gts` invalidation (`clearCache: true` fired once for the batch). Expected on any executable invalidation — only worth chasing if the cold cost is disproportionate to the module graph.
+5. **Is the sum of `render_ms` wildly larger than the card count × a reasonable per-card budget?** Look for `queryLoadsInFlight` / `recentQueryLoads` entries that repeat across rows — that's a query-field that multiple dependents all wait on.
+6. **Is the fan-out bigger than you expected?** The `types` and `deps` columns on the same rows tell you *why* each row was invalidated — useful for discovering unintentionally-heavy transitive deps (e.g. a dashboard re-renders because one of its metrics modules has a runtime reference to the changed module).
+
 ## When the diagnostics disagree with each other
 
-The hooks are best-effort and the page may die mid-capture. Trust this precedence:
+The host-side hooks are best-effort and the page may die mid-capture. Trust this precedence:
 
 1. `renderStage` — set synchronously by the host.
 2. `inFlightModuleImports` — read from the loader which is still alive even after the timeout.
@@ -175,6 +298,6 @@ If `renderStage` says `buildModel:fetching-source` but `cardDocsInFlight` is emp
 
 ## Extending the diagnostics
 
-If you find you want a signal that isn't here, add it to `RenderTimeoutDiagnostics` in `packages/runtime-common/index.ts` (optional field), populate it in `packages/realm-server/prerender/utils.ts` (the `withTimeout` capture block) by evaluating a new globalThis hook on the page, and expose that hook from `packages/host/app/routes/render.ts::__boxelRenderDiagnostics`. The server-side enrichment in `packages/realm-server/prerender/prerender-app.ts::decorateRenderErrorDiagnostics` then carries it to the error document unchanged.
+If you find you want a signal that isn't here, add it to `RenderTimeoutDiagnostics` in `packages/runtime-common/index.ts` (optional field), populate it in `packages/realm-server/prerender/utils.ts` (the `withTimeout` capture block) by evaluating a new globalThis hook on the page, and expose that hook from `packages/host/app/routes/render.ts::__boxelRenderDiagnostics`. The Prerenderer decorator lifts it onto `response.meta.diagnostics` and the indexer persists it into `timing_diagnostics` unchanged.
 
 Remember to also surface it on the error log line in `withTimeout` so operators see it without opening the JSON.

--- a/packages/host/config/schema/1776964391615_schema.sql
+++ b/packages/host/config/schema/1776964391615_schema.sql
@@ -42,6 +42,7 @@
    has_error BOOLEAN DEFAULT false NOT NULL,
    last_known_good_deps BLOB,
    markdown TEXT,
+   timing_diagnostics BLOB,
    PRIMARY KEY ( url, realm_url, type ) 
 );
 
@@ -70,6 +71,7 @@
    has_error BOOLEAN DEFAULT false NOT NULL,
    last_known_good_deps BLOB,
    markdown TEXT,
+   timing_diagnostics BLOB,
    PRIMARY KEY ( url, realm_url, type ) 
 );
 

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -630,6 +630,7 @@ module('Unit | index-writer', function (hooks) {
         icon_html: '<svg>test icon</svg>',
         markdown: null,
         is_deleted: null,
+        timing_diagnostics: null,
       },
       'the copied instance is correct',
     );
@@ -720,10 +721,28 @@ module('Unit | index-writer', function (hooks) {
     });
     await batch.done();
 
-    let [{ indexed_at: _remove, ...errorEntry }] = (await adapter.execute(
+    let [rawErrorEntry] = (await adapter.execute(
       'SELECT * FROM boxel_index WHERE realm_version = 2 AND type = \'instance\' AND has_error = TRUE ORDER BY url COLLATE "POSIX"',
       { coerceTypes },
     )) as unknown as BoxelIndexTable[];
+    // Strip non-deterministic write-time stamps from both the row and
+    // the error_doc (the indexer mirrors timing_diagnostics onto
+    // error_doc.diagnostics for UI compat); they're verified
+    // separately below.
+    let {
+      indexed_at: _remove,
+      timing_diagnostics,
+      ...errorEntry
+    } = rawErrorEntry;
+    assert.ok(errorEntry.error_doc, 'row has an error_doc');
+    // The indexer mirrors `timing_diagnostics` onto `error_doc.diagnostics`
+    // for UI compat. Strip it out before the deep-equal (and verify the
+    // mirror relationship separately below). `diagnostics` is a declared
+    // optional field on `SerializedError`, so this is a plain destructure
+    // — no cast needed.
+    let { diagnostics: errorDocDiagnostics, ...errorDocWithoutDiagnostics } =
+      errorEntry.error_doc!;
+    errorEntry.error_doc = errorDocWithoutDiagnostics;
     assert.deepEqual(
       errorEntry,
       {
@@ -768,6 +787,17 @@ module('Unit | index-writer', function (hooks) {
       },
       'the error entry includes last known good state of instance',
     );
+    assert.ok(timing_diagnostics, 'timing_diagnostics populated on error row');
+    assert.strictEqual(
+      typeof timing_diagnostics,
+      'object',
+      'timing_diagnostics is an object',
+    );
+    assert.deepEqual(
+      errorDocDiagnostics,
+      timing_diagnostics,
+      'error_doc.diagnostics mirrors timing_diagnostics',
+    );
   });
 
   test('error entry does not include last known good state when not available', async function (assert) {
@@ -787,10 +817,24 @@ module('Unit | index-writer', function (hooks) {
     });
     await batch.done();
 
-    let [{ indexed_at: _remove, ...errorEntry }] = (await adapter.execute(
+    let [rawErrorEntry] = (await adapter.execute(
       'SELECT * FROM boxel_index WHERE realm_version = 2 AND type = \'instance\' AND has_error = TRUE ORDER BY url COLLATE "POSIX"',
       { coerceTypes },
     )) as unknown as BoxelIndexTable[];
+    let {
+      indexed_at: _remove,
+      timing_diagnostics,
+      ...errorEntry
+    } = rawErrorEntry;
+    assert.ok(errorEntry.error_doc, 'row has an error_doc');
+    // The indexer mirrors `timing_diagnostics` onto `error_doc.diagnostics`
+    // for UI compat. Strip it out before the deep-equal (and verify the
+    // mirror relationship separately below). `diagnostics` is a declared
+    // optional field on `SerializedError`, so this is a plain destructure
+    // — no cast needed.
+    let { diagnostics: errorDocDiagnostics, ...errorDocWithoutDiagnostics } =
+      errorEntry.error_doc!;
+    errorEntry.error_doc = errorDocWithoutDiagnostics;
     assert.deepEqual(
       errorEntry,
       {
@@ -824,6 +868,17 @@ module('Unit | index-writer', function (hooks) {
         markdown: null,
       },
       'the error entry does not include last known good state of instance',
+    );
+    assert.ok(timing_diagnostics, 'timing_diagnostics populated on error row');
+    assert.strictEqual(
+      typeof timing_diagnostics,
+      'object',
+      'timing_diagnostics is an object',
+    );
+    assert.deepEqual(
+      errorDocDiagnostics,
+      timing_diagnostics,
+      'error_doc.diagnostics mirrors timing_diagnostics',
     );
   });
 

--- a/packages/postgres/migrations/1776964391615_add-timing-diagnostics-to-index.js
+++ b/packages/postgres/migrations/1776964391615_add-timing-diagnostics-to-index.js
@@ -1,0 +1,15 @@
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.addColumns('boxel_index', {
+    timing_diagnostics: { type: 'jsonb' },
+  });
+  pgm.addColumns('boxel_index_working', {
+    timing_diagnostics: { type: 'jsonb' },
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropColumns('boxel_index', ['timing_diagnostics']);
+  pgm.dropColumns('boxel_index_working', ['timing_diagnostics']);
+};

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -36,15 +36,14 @@ type PrerenderServer = Server & {
 let log = logger('prerender-server');
 const defaultPrerenderServerPort = 4221;
 
-// CS-10872: walk any RenderError embedded in a response and stamp
-// the per-request `requestId` onto the inner `SerializedError`'s
-// `diagnostics` block (the outer wrapper is transient — only the
-// inner is persisted into `boxel_index.error_doc`). The
-// launch/waits/render/total timings are already attached inside
-// Prerenderer (so they land regardless of whether the caller came
-// through HTTP or in-process tests); this layer just adds the
-// HTTP-only correlation id for cross-log grepping. Exported so the
-// diagnostics-persistence regression tests can exercise it directly.
+// Stamp the per-request `requestId` onto `response.meta.requestId`
+// so it flows through the same channel as timings / host-side
+// diagnostics and ends up on `boxel_index.timing_diagnostics` for
+// cross-log grepping. The launch/waits/render/total timings are
+// already attached inside Prerenderer (regardless of HTTP vs
+// in-process); this layer just adds the HTTP-only correlation id.
+// Exported so the diagnostics-persistence regression tests can
+// exercise it directly.
 export function decorateRenderErrorDiagnostics(
   response: any,
   requestId: string,
@@ -52,23 +51,10 @@ export function decorateRenderErrorDiagnostics(
   if (!response || typeof response !== 'object') {
     return;
   }
-  let visit = (wrapper: any) => {
-    if (!wrapper || typeof wrapper !== 'object') return;
-    let inner = wrapper.error;
-    if (!inner || typeof inner !== 'object') return;
-    if (!inner.diagnostics || typeof inner.diagnostics !== 'object') {
-      inner.diagnostics = {};
-    }
-    inner.diagnostics.requestId = requestId;
+  response.meta = {
+    ...(response.meta ?? {}),
+    requestId,
   };
-  visit(response.error);
-  visit((response as any).pageUnusableError);
-  for (let key of ['card', 'fileExtract', 'fileRender'] as const) {
-    let sub = response[key];
-    if (sub && typeof sub === 'object') {
-      visit((sub as any).error);
-    }
-  }
 }
 
 export function buildPrerenderApp(options: {
@@ -415,6 +401,18 @@ export function buildPrerenderApp(options: {
           poolFlagSuffix,
         );
         decorateRenderErrorDiagnostics(response, requestId);
+        // Timings are already embedded inside `response.meta.diagnostics`
+        // by `Prerenderer.decorateRenderErrorsWithTimings` — the indexer
+        // reads them from there. Keep the envelope `meta.timing`
+        // populated (at the JSON:API envelope level) so existing
+        // log/telemetry consumers that read the envelope don't have
+        // to migrate.
+        let envelopeTiming = {
+          launchMs: timings.launchMs,
+          renderMs: timings.renderMs,
+          totalMs,
+          waits: timings.waits,
+        };
         ctxt.status = 201;
         ctxt.set('Content-Type', 'application/vnd.api+json');
         ctxt.body = {
@@ -424,12 +422,7 @@ export function buildPrerenderApp(options: {
             attributes: response,
           },
           meta: {
-            timing: {
-              launchMs: timings.launchMs,
-              renderMs: timings.renderMs,
-              totalMs,
-              waits: timings.waits,
-            },
+            timing: envelopeTiming,
             pool,
           },
         };
@@ -704,6 +697,15 @@ export function buildPrerenderApp(options: {
         poolFlagSuffix,
       );
       decorateRenderErrorDiagnostics(response, requestId);
+      // Timings are already inside `response.meta.diagnostics`. Here
+      // we just populate the JSON:API envelope `meta.timing` that
+      // existing telemetry consumers still read.
+      let envelopeTiming = {
+        launchMs: timings.launchMs,
+        renderMs: timings.renderMs,
+        totalMs,
+        waits: timings.waits,
+      };
       ctxt.status = 201;
       ctxt.set('Content-Type', 'application/vnd.api+json');
       ctxt.body = {
@@ -713,12 +715,7 @@ export function buildPrerenderApp(options: {
           attributes: response,
         },
         meta: {
-          timing: {
-            launchMs: timings.launchMs,
-            renderMs: timings.renderMs,
-            totalMs,
-            waits: timings.waits,
-          },
+          timing: envelopeTiming,
           pool,
         },
       };

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -1,6 +1,8 @@
 import {
   type AffinityType,
+  type PrerenderResponseMeta,
   type RenderRouteOptions,
+  type RenderTimeoutDiagnostics,
   type ModuleRenderResponse,
   type PrerenderVisitArgs,
   type ReleaseBatchArgs,
@@ -375,55 +377,66 @@ export class Prerenderer {
     return owner ? { batchId: owner.batchId, since: owner.since } : undefined;
   }
 
-  // CS-10872: walk any RenderError embedded in a response and merge
-  // server-observed timings into the inner `SerializedError`'s
-  // `diagnostics` block. Diagnostics must live on the inner
-  // `SerializedError` (not the outer `RenderError` wrapper) because
-  // that's what the indexer persists into `boxel_index.error_doc`.
-  // The prerender server's HTTP layer additionally attaches a
-  // `requestId` via `decorateRenderErrorDiagnostics` — this method
-  // covers the in-process path (test harnesses, co-located callers)
-  // so the diagnostics payload is consistent regardless of how the
-  // prerender was invoked.
+  // Consolidate all diagnostic payloads onto `response.meta.diagnostics`
+  // so the indexer can pick them up uniformly and persist into
+  // `boxel_index.timing_diagnostics`. We merge two sources:
+  //
+  //   - Server-observed timings (launchMs / waits / renderElapsedMs /
+  //     totalElapsedMs) from the Prerenderer's own measurements.
+  //   - Host-side breadcrumbs (renderStage, in-flight loads, etc.)
+  //     lifted out of every embedded `RenderError.diagnostics` —
+  //     the transient transport set by `withTimeout`. We delete the
+  //     outer field after lifting so nothing downstream has to know
+  //     about the two-channel layout.
+  //
+  // The HTTP response envelope also carries `meta`, but
+  // remote-prerenderer only forwards `data.attributes`, not the
+  // envelope — so the values have to live inside the response body.
   static decorateRenderErrorsWithTimings(
     response: unknown,
-    timings: { launchMs: number; renderMs: number; waits: unknown },
+    timings: {
+      launchMs: number;
+      renderMs: number;
+      waits: RenderTimeoutDiagnostics['waits'];
+    },
     totalMs: number,
   ): void {
     if (!response || typeof response !== 'object') {
       return;
     }
-    let serverContext = {
+    let r = response as Record<string, unknown>;
+    // Walk every embedded RenderError and lift its `.diagnostics` into
+    // a single aggregated block on response.meta. Typical case: one
+    // RenderError carries the full payload; aggregation covers the
+    // rare case where multiple pass errors each contributed fields.
+    let lifted: RenderTimeoutDiagnostics = {};
+    let lift = (wrapper: unknown) => {
+      if (!wrapper || typeof wrapper !== 'object') return;
+      let w = wrapper as { diagnostics?: RenderTimeoutDiagnostics };
+      if (!w.diagnostics || typeof w.diagnostics !== 'object') return;
+      lifted = { ...lifted, ...w.diagnostics };
+      delete w.diagnostics;
+    };
+    lift(r.error);
+    lift(r.pageUnusableError);
+    for (let key of ['card', 'fileExtract', 'fileRender'] as const) {
+      let sub = r[key];
+      if (sub && typeof sub === 'object') {
+        lift((sub as { error?: unknown }).error);
+      }
+    }
+    let diagnostics: RenderTimeoutDiagnostics = {
+      ...lifted,
       launchMs: timings.launchMs,
       waits: timings.waits,
       renderElapsedMs: timings.renderMs,
       totalElapsedMs: totalMs,
     };
-    // `wrapper` is a RenderError / ErrorEntry (with an inner
-    // `error: SerializedError`); attach to the inner so diagnostics
-    // survive serialization into `error_doc`.
-    // `wrapper` is a RenderError / ErrorEntry (with an inner
-    // `error: SerializedError`); attach to the inner so diagnostics
-    // survive serialization into `error_doc`.
-    let visit = (wrapper: unknown) => {
-      if (!wrapper || typeof wrapper !== 'object') return;
-      let w = wrapper as { error?: unknown };
-      if (!w.error || typeof w.error !== 'object') return;
-      let inner = w.error as { diagnostics?: Record<string, unknown> };
-      if (!inner.diagnostics || typeof inner.diagnostics !== 'object') {
-        inner.diagnostics = {};
-      }
-      Object.assign(inner.diagnostics, serverContext);
+    let existingMeta = (r.meta as PrerenderResponseMeta | undefined) ?? {};
+    r.meta = {
+      ...existingMeta,
+      diagnostics,
     };
-    let r = response as Record<string, unknown>;
-    visit(r.error);
-    visit(r.pageUnusableError);
-    for (let key of ['card', 'fileExtract', 'fileRender'] as const) {
-      let sub = r[key];
-      if (sub && typeof sub === 'object') {
-        visit((sub as { error?: unknown }).error);
-      }
-    }
   }
 
   #gateClearCache<

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -1181,10 +1181,11 @@ export async function withTimeout<T>(
         ` evaluating=${richDiagnostics?.currentlyEvaluatingModule ?? 'none'}` +
         ` DOM:\n${dom?.trim()}`,
     );
-    // Diagnostics live on the inner `SerializedError` (not the outer
-    // `RenderError` wrapper) because that's what the indexer persists
-    // into `boxel_index.error_doc` — the outer wrapper is transient
-    // plumbing between the prerender response and the index writer.
+    // Diagnostics ride on the outer `RenderError.diagnostics` as a
+    // transient transport; the Prerenderer lifts them to
+    // `response.meta.diagnostics` before returning, where the indexer
+    // reads them and persists into `timing_diagnostics`. The field is
+    // dropped from the final response.
     let diagnostics: Record<string, unknown> = {
       ...(richDiagnostics?.renderStage
         ? { renderStage: richDiagnostics.renderStage }
@@ -1254,9 +1255,9 @@ export async function withTimeout<T>(
         title: 'Render timeout',
         message,
         additionalErrors: null,
-        diagnostics,
       },
       evict: true,
+      diagnostics,
     };
     if (typeof timerSummary === 'string' && timerSummary.trim()) {
       timeoutError.error.stack = timerSummary.trim();

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -4,6 +4,7 @@ import {
   logger,
   type PrerenderMeta,
   type RenderError,
+  type RenderTimeoutDiagnostics,
 } from '@cardstack/runtime-common';
 import { prerenderRenderTimeoutMs } from './prerender-constants';
 
@@ -1186,7 +1187,7 @@ export async function withTimeout<T>(
     // `response.meta.diagnostics` before returning, where the indexer
     // reads them and persists into `timing_diagnostics`. The field is
     // dropped from the final response.
-    let diagnostics: Record<string, unknown> = {
+    let diagnostics: RenderTimeoutDiagnostics = {
       ...(richDiagnostics?.renderStage
         ? { renderStage: richDiagnostics.renderStage }
         : {}),

--- a/packages/realm-server/tests/prerender-diagnostics-persistence-test.ts
+++ b/packages/realm-server/tests/prerender-diagnostics-persistence-test.ts
@@ -3,25 +3,17 @@ import { basename } from 'path';
 import { Prerenderer } from '../prerender/prerenderer';
 import { decorateRenderErrorDiagnostics } from '../prerender/prerender-app';
 
-// Regression coverage for the "render-timeout diagnostics are
-// collected but silently dropped at persistence" bug (CS-10872
-// follow-up). The persistence layer (`IndexWriter.updateEntry`) only
-// serializes the **inner** `SerializedError` into
-// `boxel_index.error_doc`:
-//
-//   error_doc: errorEntry?.error ?? entry.error   // <- inner only
-//
-// …but the two decorator helpers that stamp diagnostics onto a
-// render-timeout response originally wrote them onto the **outer**
-// `RenderError` wrapper. That meant diagnostics rode the response all
-// the way through the fused visit, the card indexer, and the update
-// path — and then vanished when the row was written to disk.
-//
-// These tests pin both decorators down to the inner
-// `SerializedError` so the diagnostics payload survives persistence
-// and can be surfaced by the in-UI error banner. Running them under
-// the original outer-wrapper implementation fails on the
-// `inner.diagnostics` assertions; running under the fix passes.
+// Locks down the consolidated diagnostic channel: every payload the
+// Prerenderer or HTTP layer knows about (server timings, host-side
+// breadcrumbs lifted from `RenderError.diagnostics`, and the HTTP
+// correlation ID) ends up on `response.meta`, not on any embedded
+// inner `SerializedError`. The indexer reads from `response.meta`
+// and persists into `boxel_index.timing_diagnostics`; the error-row
+// write path also copies the same blob onto `error_doc.diagnostics`
+// so the UI read surface (CardErrorJSONAPI.meta.diagnostics) keeps
+// working without a schema rename. The point of these tests is to
+// catch any regression that reintroduces the old "stuff diagnostics
+// into the inner SerializedError" pattern.
 
 type FakeVisitResponse = {
   card?: {
@@ -33,20 +25,24 @@ type FakeVisitResponse = {
         title: string;
         message: string;
         additionalErrors: unknown[] | null;
+        // Must stay undefined post-consolidation — the decorator
+        // lifts diagnostics off the outer wrapper, not onto the inner.
         diagnostics?: Record<string, unknown>;
       };
-      evict?: boolean;
-      // If the old (buggy) code path is restored, diagnostics would
-      // appear here instead. We assert this field stays `undefined`
-      // so the test isn't silently passing because the decorator
-      // happened to stamp both places.
+      // The transient transport from `withTimeout`; lifted to
+      // `response.meta.diagnostics` and then deleted.
       diagnostics?: Record<string, unknown>;
     };
+  };
+  meta?: {
+    timing?: Record<string, unknown>;
+    requestId?: string;
+    diagnostics?: Record<string, unknown>;
   };
   pageUnusableError?: unknown;
 };
 
-function buildFakeVisitResponse(): FakeVisitResponse {
+function buildFakeVisitResponseWithTimeoutError(): FakeVisitResponse {
   return {
     card: {
       error: {
@@ -58,148 +54,154 @@ function buildFakeVisitResponse(): FakeVisitResponse {
           message: 'Render timed-out after 90000 ms',
           additionalErrors: null,
         },
-        evict: true,
+        // Mirror what `withTimeout` produces today — host-side
+        // breadcrumbs attached on the outer wrapper as a transient
+        // transport. The decorator should lift these to response.meta.
+        diagnostics: {
+          renderStage: 'waiting-stability',
+          stageAgeMs: 89696,
+          queryLoadsInFlight: [{ ageMs: 89721 }],
+        },
       },
     },
   };
 }
 
+function buildFakeSuccessVisitResponse(): FakeVisitResponse {
+  return {
+    card: {
+      // Successful visit — no error wrapper at all.
+    } as FakeVisitResponse['card'],
+  };
+}
+
 module(basename(__filename), function () {
-  module(
-    'render-timeout diagnostics persistence (CS-10872 follow-up)',
-    function () {
-      test('Prerenderer.decorateRenderErrorsWithTimings writes to the inner SerializedError (where error_doc reads from)', function (assert) {
-        let response = buildFakeVisitResponse();
-        Prerenderer.decorateRenderErrorsWithTimings(
-          response,
-          {
-            launchMs: 42,
-            renderMs: 90000,
-            waits: {
-              semaphoreMs: 3,
-              tabQueueMs: 5,
-              tabStartupMs: 10,
-            },
+  module('render diagnostics persistence — consolidated channel', function () {
+    test('Prerenderer.decorateRenderErrorsWithTimings lifts outer RenderError.diagnostics onto response.meta and leaves the inner SerializedError clean', function (assert) {
+      let response = buildFakeVisitResponseWithTimeoutError();
+      Prerenderer.decorateRenderErrorsWithTimings(
+        response,
+        {
+          launchMs: 42,
+          renderMs: 90000,
+          waits: {
+            semaphoreMs: 3,
+            tabQueueMs: 5,
+            tabStartupMs: 10,
           },
-          90042,
-        );
+        },
+        90042,
+      );
 
-        // The inner SerializedError is what `IndexWriter.updateEntry`
-        // persists into `boxel_index.error_doc`. Diagnostics must
-        // land here.
-        let inner = response.card?.error?.error;
-        assert.ok(inner, 'inner SerializedError still present');
-        assert.ok(inner?.diagnostics, 'diagnostics attached to inner');
-        assert.strictEqual(
-          typeof inner?.diagnostics,
-          'object',
-          'diagnostics is an object',
-        );
-        assert.strictEqual(
-          (inner!.diagnostics as any).launchMs,
-          42,
-          'launchMs present on inner',
-        );
-        assert.strictEqual(
-          (inner!.diagnostics as any).renderElapsedMs,
-          90000,
-          'renderElapsedMs present on inner',
-        );
-        assert.strictEqual(
-          (inner!.diagnostics as any).totalElapsedMs,
-          90042,
-          'totalElapsedMs present on inner',
-        );
-        assert.deepEqual(
-          (inner!.diagnostics as any).waits,
-          { semaphoreMs: 3, tabQueueMs: 5, tabStartupMs: 10 },
-          'waits breakdown present on inner',
-        );
+      // Host-side breadcrumbs lifted off the outer RenderError and
+      // merged with the server timing measurements into a single
+      // block on response.meta.diagnostics.
+      let meta = response.meta;
+      assert.ok(meta, 'response.meta populated');
+      let diagnostics = meta?.diagnostics;
+      assert.ok(diagnostics, 'diagnostics block on response.meta');
+      assert.strictEqual(diagnostics?.launchMs, 42, 'server launchMs present');
+      assert.strictEqual(
+        diagnostics?.renderElapsedMs,
+        90000,
+        'server renderElapsedMs present',
+      );
+      assert.strictEqual(
+        diagnostics?.totalElapsedMs,
+        90042,
+        'server totalElapsedMs present',
+      );
+      assert.deepEqual(
+        diagnostics?.waits,
+        { semaphoreMs: 3, tabQueueMs: 5, tabStartupMs: 10 },
+        'waits breakdown present',
+      );
+      assert.strictEqual(
+        diagnostics?.renderStage,
+        'waiting-stability',
+        'host-side renderStage lifted from RenderError.diagnostics',
+      );
+      assert.deepEqual(
+        diagnostics?.queryLoadsInFlight,
+        [{ ageMs: 89721 }],
+        'host-side queryLoadsInFlight lifted',
+      );
 
-        // And must NOT land on the outer RenderError wrapper —
-        // that's the field the index writer ignores, so populating
-        // it silently loses the data.
-        assert.strictEqual(
-          response.card?.error?.diagnostics,
-          undefined,
-          'diagnostics NOT attached to outer RenderError wrapper',
-        );
-      });
+      // Outer RenderError.diagnostics was a transient transport —
+      // deleted after the lift so nothing downstream has to know
+      // about the two-channel layout.
+      assert.strictEqual(
+        response.card?.error?.diagnostics,
+        undefined,
+        'outer RenderError.diagnostics cleared after lift',
+      );
+      // Inner SerializedError.diagnostics must NOT be populated by
+      // the decorator. This catches any regression that reintroduces
+      // the pre-consolidation dual-write pattern.
+      assert.strictEqual(
+        response.card?.error?.error.diagnostics,
+        undefined,
+        'inner SerializedError.diagnostics remains untouched',
+      );
+    });
 
-      test('decorateRenderErrorDiagnostics stamps requestId on the inner SerializedError', function (assert) {
-        let response = buildFakeVisitResponse();
-        decorateRenderErrorDiagnostics(response, 'req-abc-123');
+    test('decorateRenderErrorDiagnostics stamps requestId onto response.meta, not the inner error', function (assert) {
+      let response = buildFakeVisitResponseWithTimeoutError();
+      decorateRenderErrorDiagnostics(response, 'req-abc-123');
 
-        let inner = response.card?.error?.error;
-        assert.ok(inner?.diagnostics, 'diagnostics block created on inner');
-        assert.strictEqual(
-          typeof inner?.diagnostics,
-          'object',
-          'diagnostics is an object',
-        );
-        assert.strictEqual(
-          (inner!.diagnostics as any).requestId,
-          'req-abc-123',
-          'requestId threaded through to inner',
-        );
-        assert.strictEqual(
-          response.card?.error?.diagnostics,
-          undefined,
-          'diagnostics NOT attached to outer RenderError wrapper',
-        );
-      });
+      assert.strictEqual(
+        response.meta?.requestId,
+        'req-abc-123',
+        'requestId stamped on response.meta',
+      );
+      assert.strictEqual(
+        response.card?.error?.error.diagnostics,
+        undefined,
+        'inner SerializedError left alone',
+      );
+    });
 
-      test('stacking both decorators leaves a single diagnostics object on the inner SerializedError', function (assert) {
-        // In production these run back-to-back: Prerenderer attaches
-        // launch/render/waits timings, then the HTTP handler stamps
-        // requestId. Both must target the same location so the
-        // second merges with the first rather than clobbering or
-        // shadowing on a different level.
-        let response = buildFakeVisitResponse();
-        Prerenderer.decorateRenderErrorsWithTimings(
-          response,
-          { launchMs: 1, renderMs: 2, waits: {} },
-          3,
-        );
-        decorateRenderErrorDiagnostics(response, 'req-xyz');
+    test('decorator populates response.meta even when there is no embedded error (successful render)', function (assert) {
+      // Successful renders still get timing summaries so the indexer
+      // can persist them onto `timing_diagnostics` — that's the whole
+      // point of the consolidated column: operators can retrospectively
+      // ask "why did this instance take N seconds?" regardless of
+      // error status.
+      let response = buildFakeSuccessVisitResponse();
+      Prerenderer.decorateRenderErrorsWithTimings(
+        response,
+        { launchMs: 1, renderMs: 2, waits: {} },
+        3,
+      );
 
-        let inner = response.card!.error!.error;
-        assert.strictEqual(
-          (inner.diagnostics as any)?.launchMs,
-          1,
-          'launchMs retained after second decorator ran',
-        );
-        assert.strictEqual(
-          (inner.diagnostics as any)?.requestId,
-          'req-xyz',
-          'requestId merged into the same diagnostics object',
-        );
-        assert.strictEqual(
-          response.card?.error?.diagnostics,
-          undefined,
-          'outer wrapper still clean (no shadow copy)',
-        );
-      });
+      assert.ok(response.meta?.diagnostics, 'meta.diagnostics populated');
+      assert.strictEqual(response.meta?.diagnostics?.launchMs, 1);
+      assert.strictEqual(response.meta?.diagnostics?.renderElapsedMs, 2);
+      assert.strictEqual(response.meta?.diagnostics?.totalElapsedMs, 3);
+      assert.deepEqual(response.meta?.diagnostics?.waits, {});
+    });
 
-      test('decorators are no-ops when there is no embedded error', function (assert) {
-        // Successful responses should not sprout an empty
-        // diagnostics object — that would confuse downstream UI into
-        // showing a details section for an error that never happened.
-        let response: { card: { serialized: null; error?: unknown } } = {
-          card: { serialized: null },
-        };
-        Prerenderer.decorateRenderErrorsWithTimings(
-          response,
-          { launchMs: 1, renderMs: 2, waits: {} },
-          3,
-        );
-        decorateRenderErrorDiagnostics(response, 'req-xyz');
-        assert.strictEqual(
-          response.card.error,
-          undefined,
-          'no error slot materialized',
-        );
-      });
-    },
-  );
+    test('both decorators stack: host-lifted diagnostics + server timings + requestId coexist on response.meta', function (assert) {
+      let response = buildFakeVisitResponseWithTimeoutError();
+      Prerenderer.decorateRenderErrorsWithTimings(
+        response,
+        { launchMs: 7, renderMs: 13, waits: { semaphoreMs: 1 } },
+        20,
+      );
+      decorateRenderErrorDiagnostics(response, 'req-xyz');
+
+      let meta = response.meta;
+      assert.strictEqual(meta?.diagnostics?.launchMs, 7, 'timing retained');
+      assert.strictEqual(
+        meta?.diagnostics?.renderStage,
+        'waiting-stability',
+        'host-side breadcrumb retained',
+      );
+      assert.strictEqual(
+        meta?.requestId,
+        'req-xyz',
+        'requestId present on same meta block',
+      );
+    });
+  });
 });

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -1486,13 +1486,13 @@ module(basename(__filename), function () {
           'timeout retains page identifier',
         );
 
-        // CS-10872: the timeout error must carry the structured
-        // diagnostics block so operators reading the persisted error
-        // document see launch-vs-render breakdown + the host hooks.
-        // Diagnostics live on the inner SerializedError (RenderError
-        // → error → diagnostics) because that's what IndexWriter
-        // persists into `boxel_index.error_doc`.
-        let diagnostics = (timedOut.response.error?.error as any)?.diagnostics;
+        // The timeout error must carry the structured diagnostics
+        // block so operators can classify the stall. Diagnostics
+        // live on `response.meta.diagnostics` (the consolidated
+        // channel — the indexer reads from there and persists into
+        // `boxel_index.timing_diagnostics`, mirroring to
+        // `error_doc.diagnostics` at write time for UI compat).
+        let diagnostics = (timedOut.response as any)?.meta?.diagnostics;
         assert.strictEqual(
           typeof diagnostics,
           'object',
@@ -1604,10 +1604,11 @@ module(basename(__filename), function () {
             'error title is "Render timeout"',
           );
 
-          // Diagnostics live on the inner SerializedError (the field
-          // IndexWriter persists into `error_doc`), not on the outer
-          // RenderError wrapper.
-          let diagnostics = (timeoutError?.error as any)?.diagnostics;
+          // Diagnostics live on `response.meta.diagnostics` — the
+          // consolidated channel the indexer reads from and persists
+          // onto `boxel_index.timing_diagnostics` (mirrored to
+          // `error_doc.diagnostics` for UI compat).
+          let diagnostics = (result.response as any)?.meta?.diagnostics;
           assert.strictEqual(
             typeof diagnostics,
             'object',

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -27,10 +27,12 @@ export interface SerializedError {
   isCardError?: true;
   deps?: string[];
   stack?: string;
-  // CS-10872: structured prerender-timeout diagnostics (e.g. launchMs,
-  // waits, renderStage, queryLoadsInFlight). Populated by
-  // prerender/utils.ts::withTimeout for render-timeout errors and
-  // copied into CardErrorJSONAPI.meta.diagnostics by formattedError.
+  // Structured render-timeout diagnostics (e.g. launchMs, waits,
+  // renderStage, queryLoadsInFlight). The source of truth is the
+  // `boxel_index.timing_diagnostics` column; the IndexWriter copies
+  // the payload onto this field when persisting an error row so the
+  // existing UI read path (formattedError → CardErrorJSONAPI.meta.
+  // diagnostics) continues to work unchanged.
   diagnostics?: Record<string, unknown>;
 }
 

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -27,6 +27,7 @@ import {
   type LocalPath,
   type Reader,
   type Stats,
+  type TimingDiagnostics,
 } from './index';
 import { moduleFrom } from './code-ref';
 import type { CacheScope, DefinitionLookup } from './definition-lookup';
@@ -522,6 +523,7 @@ export class IndexRunner {
     resourceCreatedAt,
     resource,
     renderResult,
+    timingDiagnostics,
   }: {
     path: LocalPath;
     lastModified: number;
@@ -531,6 +533,7 @@ export class IndexRunner {
     renderResult: NonNullable<
       Parameters<typeof performCardIndexing>[0]['precomputedRenderResult']
     >;
+    timingDiagnostics?: TimingDiagnostics;
   }): Promise<void> {
     let fileURL = this.#realmPaths.fileURL(path).href;
     let instanceURL = new URL(
@@ -556,6 +559,7 @@ export class IndexRunner {
         auth: this.#auth,
         jobInfo: this.#jobInfo,
         precomputedRenderResult: renderResult,
+        timingDiagnostics,
         dependencyResolver: this.#dependencyResolver,
         updateEntry: async (entryURL, entry) =>
           await this.updateEntry(entryURL, entry),
@@ -574,6 +578,7 @@ export class IndexRunner {
     hasModulePrerender,
     extractResult,
     renderResult,
+    timingDiagnostics,
   }: {
     path: LocalPath;
     lastModified: number;
@@ -588,6 +593,7 @@ export class IndexRunner {
     renderResult?: Parameters<
       typeof performFileIndexing
     >[0]['precomputedRenderResult'];
+    timingDiagnostics?: TimingDiagnostics;
   }): Promise<void> {
     let fileURL = this.#realmPaths.fileURL(path).href;
     let result = await performFileIndexing({
@@ -601,6 +607,7 @@ export class IndexRunner {
       jobInfo: this.#jobInfo,
       precomputedExtractResult: extractResult,
       precomputedRenderResult: renderResult,
+      timingDiagnostics,
       dependencyResolver: this.#dependencyResolver,
       updateEntry: async (entryURL, entry) => {
         await this.batch.updateEntry(entryURL, entry);

--- a/packages/runtime-common/index-runner/card-indexer.ts
+++ b/packages/runtime-common/index-runner/card-indexer.ts
@@ -11,6 +11,7 @@ import {
   type LocalPath,
   type LooseCardResource,
   type RenderResponse,
+  type TimingDiagnostics,
 } from '../index';
 import { CardError, isCardError, serializableError } from '../error';
 import { unresolveResourceInstanceURLs } from '../url';
@@ -31,6 +32,9 @@ export interface CardIndexerOptions {
   // Render result from the fused visit's cardRender pass. Always supplied
   // by the fused indexer.
   precomputedRenderResult: RenderResponse;
+  // Timing / diagnostic payload attached to the fused-visit
+  // response; persisted onto `boxel_index.timing_diagnostics`.
+  timingDiagnostics?: TimingDiagnostics;
   dependencyResolver: IndexRunnerDependencyManager;
   updateEntry(
     instanceURL: URL,
@@ -50,6 +54,7 @@ export async function performCardIndexing({
   auth: _auth,
   jobInfo,
   precomputedRenderResult,
+  timingDiagnostics,
   dependencyResolver,
   updateEntry,
   logWarn,
@@ -176,7 +181,7 @@ export async function performCardIndexing({
     logWarn(
       `${jobIdentity(jobInfo)} encountered error indexing card instance ${path}: ${renderError.error.message}`,
     );
-    await updateEntry(instanceURL, renderError);
+    await updateEntry(instanceURL, { ...renderError, timingDiagnostics });
     return;
   }
 
@@ -214,6 +219,7 @@ export async function performCardIndexing({
         typeof searchDoc?._cardType === 'string'
           ? searchDoc._cardType
           : undefined,
+      timingDiagnostics,
     });
     return;
   }
@@ -234,5 +240,6 @@ export async function performCardIndexing({
     types: types!,
     displayNames: displayNames ?? [],
     deps,
+    timingDiagnostics,
   });
 }

--- a/packages/runtime-common/index-runner/file-indexer.ts
+++ b/packages/runtime-common/index-runner/file-indexer.ts
@@ -10,6 +10,7 @@ import {
   type JobInfo,
   type LocalPath,
   type ResolvedCodeRef,
+  type TimingDiagnostics,
 } from '../index';
 import { CardError, isCardError, serializableError } from '../error';
 import type { IndexRunnerDependencyManager } from './dependency-resolver';
@@ -34,6 +35,9 @@ export interface FileIndexerOptions {
   // module files, which produce HTML via their own module prerender).
   precomputedExtractResult: FileExtractResponse | undefined;
   precomputedRenderResult?: FileRenderResponse;
+  // Timing / diagnostic payload attached to the fused-visit response;
+  // persisted onto `boxel_index.timing_diagnostics` for this file's row.
+  timingDiagnostics?: TimingDiagnostics;
   dependencyResolver: IndexRunnerDependencyManager;
   updateEntry(
     entryURL: URL,
@@ -53,6 +57,7 @@ export async function performFileIndexing({
   jobInfo,
   precomputedExtractResult,
   precomputedRenderResult,
+  timingDiagnostics,
   dependencyResolver,
   updateEntry,
   logWarn,
@@ -125,7 +130,7 @@ export async function performFileIndexing({
     logWarn(
       `${jobIdentity(jobInfo)} encountered error indexing file ${path}: ${renderError.error.message}`,
     );
-    await updateEntry(entryURL, renderError);
+    await updateEntry(entryURL, { ...renderError, timingDiagnostics });
     return 'error';
   }
 
@@ -157,6 +162,7 @@ export async function performFileIndexing({
         ...(extractResult.searchDoc ?? {}),
       },
       types: fileTypes,
+      timingDiagnostics,
     });
     return 'error';
   }
@@ -196,6 +202,7 @@ export async function performFileIndexing({
     fittedHtml: renderResult?.fittedHTML ?? undefined,
     iconHTML: renderResult?.iconHTML ?? undefined,
     markdown: renderResult?.markdown ?? undefined,
+    timingDiagnostics,
   });
 
   return 'indexed';

--- a/packages/runtime-common/index-runner/visit-file.ts
+++ b/packages/runtime-common/index-runner/visit-file.ts
@@ -11,10 +11,12 @@ import {
   type LocalPath,
   type LooseCardResource,
   type Prerenderer,
+  type PrerenderResponseMeta,
   type Reader,
   type RealmPaths,
   type RenderRouteOptions,
   type RenderVisitResponse,
+  type TimingDiagnostics,
 } from '../index';
 import { CardError } from '../error';
 import { resolveFileDefCodeRef } from '../file-def-code-ref';
@@ -43,6 +45,11 @@ interface VisitFileFusedOptions {
     resourceCreatedAt: number;
     resource: LooseCardResource;
     renderResult: NonNullable<RenderVisitResponse['card']>;
+    // Timing / diagnostic payload flattened from the fused visit's
+    // `response.meta` (server timings + host-side breadcrumbs +
+    // HTTP requestId). Persisted onto `boxel_index.timing_diagnostics`
+    // so operators can investigate slow renders after the fact.
+    timingDiagnostics?: TimingDiagnostics;
   }): Promise<void>;
   indexFileWithResults(args: {
     path: LocalPath;
@@ -51,7 +58,26 @@ interface VisitFileFusedOptions {
     hasModulePrerender?: boolean;
     extractResult?: RenderVisitResponse['fileExtract'];
     renderResult?: RenderVisitResponse['fileRender'];
+    timingDiagnostics?: TimingDiagnostics;
   }): Promise<void>;
+}
+
+// Flatten a prerender `response.meta` block into the shape persisted
+// to `boxel_index.timing_diagnostics`. Keeps the rich host-side
+// payload (from `meta.diagnostics`) at the top level and promotes the
+// HTTP `requestId` alongside it for easy jsonb-path querying. Returns
+// `undefined` when there's nothing to persist.
+function flattenMeta(
+  meta: PrerenderResponseMeta | undefined,
+): TimingDiagnostics | undefined {
+  if (!meta) return undefined;
+  let diagnostics = meta.diagnostics ?? {};
+  let hasAny = Object.keys(diagnostics).length > 0 || meta.requestId != null;
+  if (!hasAny) return undefined;
+  return {
+    ...diagnostics,
+    ...(meta.requestId ? { requestId: meta.requestId } : {}),
+  };
 }
 
 // Fused visit: calls prerenderer.prerenderVisit once with whichever of the
@@ -203,6 +229,7 @@ export async function visitFileForIndexingFused({
       resourceCreatedAt,
       resource: parsedCardResource,
       renderResult: cardResult,
+      timingDiagnostics: flattenMeta(visitResponse.meta),
     });
   }
 
@@ -216,6 +243,7 @@ export async function visitFileForIndexingFused({
     hasModulePrerender: isModule,
     extractResult: visitResponse.fileExtract,
     renderResult: visitResponse.fileRender,
+    timingDiagnostics: flattenMeta(visitResponse.meta),
   });
 
   logDebug(

--- a/packages/runtime-common/index-structure.ts
+++ b/packages/runtime-common/index-structure.ts
@@ -34,6 +34,12 @@ export interface BoxelIndexTable {
   last_modified: string | null; // pg represents big integers as strings in javascript
   resource_created_at: string | null; // pg represents big integers as strings in javascript
   is_deleted: boolean | null;
+  // Per-row render timing diagnostics (launch/waits breakdown,
+  // render elapsed, host-side renderStage, top-N module evaluations,
+  // etc.). Populated on every updateEntry — success or error — so
+  // operators can post-hoc investigate slow (but not failing)
+  // renders too.
+  timing_diagnostics: Record<string, unknown> | null;
 }
 
 export interface RealmVersionsTable {
@@ -71,6 +77,7 @@ export const coerceTypes = Object.freeze({
   resource_created_at: 'VARCHAR',
   indexed_at: 'VARCHAR',
   value: 'JSON',
+  timing_diagnostics: 'JSON',
 });
 
 export interface PublishedRealmTable {

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -33,11 +33,13 @@ import type { SerializedError } from './error';
 import type { DBAdapter } from './db';
 import type { RealmMetaTable } from './index-structure';
 import type { FileMetaResource } from './resource-types';
+import type { TimingDiagnostics } from './index';
 import {
   coerceTypes,
   type BoxelIndexTable,
   type RealmVersionsTable,
 } from './index-structure';
+import { v4 as uuidv4 } from '@lukeed/uuid';
 
 export class IndexWriter {
   #dbAdapter: DBAdapter;
@@ -86,6 +88,13 @@ export interface InstanceEntry {
   types: string[];
   displayNames: string[];
   deps: Set<string>;
+  // Per-row render timing diagnostics (launch/waits/render timings
+  // plus host-side breadcrumbs). Populated from the Prerenderer's
+  // `response.meta` and persisted onto `boxel_index.timing_diagnostics`.
+  // Not tied to `has_error` — we persist this for successful rows too
+  // so operators can retrospectively answer "why did this instance
+  // take N seconds on the last reindex?".
+  timingDiagnostics?: TimingDiagnostics;
 }
 
 export interface IndexErrorEntry {
@@ -94,6 +103,10 @@ export interface IndexErrorEntry {
   types?: string[];
   searchData?: Record<string, any>;
   cardType?: string;
+  // See InstanceEntry.timingDiagnostics. On the error path, the
+  // same payload is also copied into `error_doc.diagnostics` at
+  // write time so the UI read path keeps working unchanged.
+  timingDiagnostics?: TimingDiagnostics;
 }
 
 export type InstanceErrorIndexEntry = IndexErrorEntry & {
@@ -137,11 +150,23 @@ export interface FileEntry {
   atomHtml?: string;
   iconHTML?: string;
   markdown?: string;
+  // See InstanceEntry.timingDiagnostics.
+  timingDiagnostics?: TimingDiagnostics;
 }
 
 export class Batch {
   readonly ready: Promise<void>;
   #invalidations = new Set<string>();
+  // Correlation ID minted once per Batch and stamped into every row's
+  // `timing_diagnostics` via `updateEntry`, so operators can
+  // `SELECT ... WHERE timing_diagnostics->>'invalidationId' = '...'`
+  // and see every row that was part of the same indexing fan-out in
+  // one query. Minted in the constructor (not `invalidate()`) so
+  // fromScratch — which doesn't call `invalidate()` — still gets a
+  // correlation ID covering the whole rebuild. Refreshed at the top
+  // of each incremental `invalidate()` call so the ID identifies a
+  // single triggering change, not the whole batch lifetime.
+  #currentInvalidationId: string;
   #dbAdapter: DBAdapter;
   #perfLog = logger('index-perf');
   declare private realmVersion: number;
@@ -152,11 +177,16 @@ export class Batch {
     private jobInfo?: JobInfo,
   ) {
     this.#dbAdapter = dbAdapter;
+    this.#currentInvalidationId = uuidv4();
     this.ready = this.setNextRealmVersion();
   }
 
   get invalidations() {
     return [...this.#invalidations];
+  }
+
+  get currentInvalidationId(): string {
+    return this.#currentInvalidationId;
   }
 
   // Look up created_at for a given file path from realm_file_meta
@@ -281,11 +311,46 @@ export class Batch {
       // drop this band-aid
       return;
     }
-    let errorEntry = isErrorEntry(entry)
-      ? { ...entry, error: this.normalizeErrorDoc(entry.error, url) }
-      : undefined;
     let href = url.href;
     this.#invalidations.add(url.href);
+    // Build the per-row timing_diagnostics blob. Render-side fields
+    // come from the Prerenderer's `response.meta` (already flattened
+    // in `visit-file.ts`); write-side stamps are added here:
+    //
+    //   - `invalidationId` — minted once per Batch (covers both
+    //     incremental `invalidate()` calls and fromScratch), so every
+    //     row from the same indexing pass shares a queryable
+    //     correlation key.
+    //   - `indexedAt` — wall-clock the write happened.
+    //
+    // The canonical storage is the `timing_diagnostics` column. For
+    // error rows we ALSO mirror the blob onto `error_doc.diagnostics`
+    // so the UI read path (error doc → CardErrorJSONAPI.meta.
+    // diagnostics via `formattedError`) keeps working unchanged —
+    // no schema rename needed. The column remains source of truth;
+    // the error-doc copy is derived.
+    let timingDiagnostics: TimingDiagnostics = {
+      ...(entry.timingDiagnostics ?? {}),
+      invalidationId: this.#currentInvalidationId,
+      indexedAt: Date.now(),
+    };
+    let errorEntry = isErrorEntry(entry)
+      ? {
+          ...entry,
+          error: this.normalizeErrorDoc(
+            {
+              ...entry.error,
+              // The SerializedError shape's `diagnostics` is
+              // `Record<string, unknown>` by design (it tolerates
+              // extra fields for derived / legacy payloads);
+              // `TimingDiagnostics` is structurally-compatible
+              // but needs an explicit cast across the boundary.
+              diagnostics: timingDiagnostics as Record<string, unknown>,
+            },
+            url,
+          ),
+        }
+      : undefined;
     let entryPayload;
     switch (entry.type) {
       case 'instance':
@@ -310,6 +375,7 @@ export class Batch {
           resource_created_at: entry.resourceCreatedAt,
           error_doc: null,
           has_error: false,
+          timing_diagnostics: timingDiagnostics,
         };
         break;
       case 'file':
@@ -332,6 +398,7 @@ export class Batch {
           resource_created_at: entry.resourceCreatedAt,
           error_doc: null,
           has_error: false,
+          timing_diagnostics: timingDiagnostics,
         };
         break;
       case 'instance-error':
@@ -353,6 +420,7 @@ export class Batch {
           type: baseTypeFromError(entry),
           error_doc: errorEntry?.error ?? entry.error,
           has_error: true,
+          timing_diagnostics: timingDiagnostics,
         };
         break;
       default:
@@ -738,6 +806,11 @@ export class Batch {
 
   async invalidate(urls: URL[]): Promise<void> {
     await this.ready;
+    // Mint a fresh correlation ID for this invalidation fan-out; every
+    // subsequent `updateEntry` on this batch stamps it into the row's
+    // `timing_diagnostics` so operators can group the rows touched by
+    // the same triggering change.
+    this.#currentInvalidationId = uuidv4();
     let start = Date.now();
     this.#perfLog.debug(
       `${jobIdentity} starting invalidation of ${urls.map((u) => u.href).join()}`,

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -680,7 +680,12 @@ export class Batch {
   }
 
   private async tombstoneEntries(invalidations: string[]) {
-    // insert tombstone into next version of the realm index
+    // insert tombstone into next version of the realm index. Stamp
+    // the current `invalidationId` + `indexedAt` on every tombstone
+    // so fan-out queries (`WHERE timing_diagnostics->>'invalidationId'
+    // = <id>`) also surface the delete rows for this pass — otherwise
+    // tombstones would inherit a stale ID from a prior write or stay
+    // NULL entirely, misattributing deletes in the grouping view.
     let existingTypes = await this.existingIndexTypes(invalidations);
     let columns = [
       'url',
@@ -689,7 +694,18 @@ export class Batch {
       'realm_version',
       'realm_url',
       'is_deleted',
+      'timing_diagnostics',
     ].map((c) => [c]);
+    let tombstoneDiagnostics: TimingDiagnostics = {
+      invalidationId: this.#currentInvalidationId,
+      indexedAt: Date.now(),
+    };
+    // `timing_diagnostics` is a jsonb column. This helper uses
+    // `upsertMultipleRows` which passes each value through `param()`
+    // as a raw `PgPrimitive`, so we pre-serialize the JSON here (the
+    // regular `updateEntry` path reaches jsonb via `asExpressions`
+    // with a `jsonFields` list, which does the same thing).
+    let tombstoneDiagnosticsJson = JSON.stringify(tombstoneDiagnostics);
     let rows = invalidations.flatMap((id) => {
       let types = existingTypes.get(id);
       if (!types || types.length === 0) {
@@ -705,6 +721,7 @@ export class Batch {
           this.realmVersion,
           this.realmURL.href,
           true,
+          tombstoneDiagnosticsJson,
         ].map((v) => [param(v)]),
       );
     });

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -147,6 +147,14 @@ export interface RenderTimeoutDiagnostics {
 
 export interface RenderError extends ErrorEntry {
   evict?: boolean;
+  // Transient carrier for host-side diagnostics (render stage,
+  // in-flight loads, blocked-timer summary, etc.) produced by
+  // `withTimeout`. The Prerenderer lifts these onto
+  // `response.meta.diagnostics` before returning, where the indexer
+  // picks them up and persists them into `timing_diagnostics`. The
+  // field is dropped from the final response — callers should read
+  // `response.meta.diagnostics` instead.
+  diagnostics?: RenderTimeoutDiagnostics;
 }
 
 export interface FileExtractResponse {
@@ -199,7 +207,51 @@ export interface ModulePrerenderModel {
   error?: ErrorEntry;
 }
 
-export interface ModuleRenderResponse extends ModulePrerenderModel {}
+export interface ModuleRenderResponse extends ModulePrerenderModel {
+  // Server-observed timing breakdown, carried in the response body
+  // so the indexer can persist it onto `boxel_index.timing_diagnostics`
+  // for both in-process and remote prerender paths without needing a
+  // separate side channel.
+  meta?: PrerenderResponseMeta;
+}
+
+export interface PrerenderResponseMeta {
+  // Aggregated diagnostic payload — server-observed timings
+  // (launchMs, waits, renderElapsedMs, totalElapsedMs from
+  // `RenderTimeoutDiagnostics`) plus host-side breadcrumbs
+  // (renderStage, in-flight loads, recent module evaluations,
+  // blocked-timer summary, etc.). Populated by the Prerenderer from
+  // both its own timing measurements and any `RenderError.diagnostics`
+  // lifted out of embedded errors. The indexer picks this up, merges
+  // in the HTTP `requestId`, and persists into `timing_diagnostics`.
+  diagnostics?: RenderTimeoutDiagnostics;
+  // HTTP correlation ID stamped by the prerender server's Koa layer.
+  // Lets operators join client → manager → prerender-server logs for
+  // a single request. Absent for in-process (non-HTTP) callers.
+  requestId?: string;
+}
+
+// The shape persisted to `boxel_index.timing_diagnostics`. Extends
+// `RenderTimeoutDiagnostics` with write-side stamps applied at
+// `IndexWriter.updateEntry` time:
+//
+//   - `invalidationId` — one UUID per `Batch.invalidate()` call; every
+//     row touched by the same fan-out shares it, so operators can
+//     `SELECT ... WHERE timing_diagnostics->>'invalidationId' = '<id>'`
+//     and see the whole batch.
+//   - `indexedAt`      — wall-clock the write happened.
+//   - `requestId`      — HTTP correlation ID (HTTP path only).
+//
+// All fields are optional because writers populate incrementally:
+// render-side fields come from the Prerenderer's response meta, the
+// write-side stamps come from the IndexWriter. Any stage may skip
+// pieces that aren't applicable (e.g. non-timeout renders have no
+// `renderStage`, in-process callers have no `requestId`).
+export interface TimingDiagnostics extends RenderTimeoutDiagnostics {
+  requestId?: string;
+  invalidationId?: string;
+  indexedAt?: number;
+}
 
 export type AffinityType = 'realm' | 'user';
 
@@ -271,6 +323,10 @@ export interface RenderVisitResponse {
   fileExtract?: FileExtractResponse;
   fileRender?: FileRenderResponse;
   pageUnusableError?: RenderError;
+  // See ModuleRenderResponse.meta — server-observed timing breakdown
+  // embedded in the response so the indexer can persist it to
+  // `boxel_index.timing_diagnostics`.
+  meta?: PrerenderResponseMeta;
 }
 
 export type RunCommandArgs = {
@@ -284,6 +340,12 @@ export type RunCommandResponse = {
   status: 'ready' | 'error' | 'unusable';
   cardResultString?: string | null;
   error?: string | null;
+  // Server-observed timing meta — same channel as the visit /
+  // module responses. Unused by most callers (command results
+  // aren't persisted to `boxel_index`), but attached uniformly so
+  // `Prerenderer.decorateRenderErrorsWithTimings` can stamp it
+  // without a special-case for commands.
+  meta?: PrerenderResponseMeta;
 };
 
 export interface Prerenderer {

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -232,15 +232,15 @@ export interface PrerenderResponseMeta {
 }
 
 // The shape persisted to `boxel_index.timing_diagnostics`. Extends
-// `RenderTimeoutDiagnostics` with write-side stamps applied at
-// `IndexWriter.updateEntry` time:
+// `RenderTimeoutDiagnostics` (which already carries `requestId`) with
+// two write-side stamps applied at `IndexWriter.updateEntry` time:
 //
-//   - `invalidationId` — one UUID per `Batch.invalidate()` call; every
-//     row touched by the same fan-out shares it, so operators can
-//     `SELECT ... WHERE timing_diagnostics->>'invalidationId' = '<id>'`
-//     and see the whole batch.
-//   - `indexedAt`      — wall-clock the write happened.
-//   - `requestId`      — HTTP correlation ID (HTTP path only).
+//   - `invalidationId` — one UUID per `Batch`; every row touched by
+//     the same indexing pass (incremental fan-out or fromScratch)
+//     shares it, so operators can `SELECT ... WHERE
+//     timing_diagnostics->>'invalidationId' = '<id>'` and see the
+//     whole batch.
+//   - `indexedAt` — wall-clock the write happened.
 //
 // All fields are optional because writers populate incrementally:
 // render-side fields come from the Prerenderer's response meta, the
@@ -248,7 +248,6 @@ export interface PrerenderResponseMeta {
 // pieces that aren't applicable (e.g. non-timeout renders have no
 // `renderStage`, in-process callers have no `requestId`).
 export interface TimingDiagnostics extends RenderTimeoutDiagnostics {
-  requestId?: string;
   invalidationId?: string;
   indexedAt?: number;
 }


### PR DESCRIPTION
## Summary

Adds a proper `timing_diagnostics` JSONB column on `boxel_index` + `boxel_index_working`, populated for **every** indexer write — success or error. Lets operators investigate slow-but-not-failing reindexes, not just timeouts. Consolidates the Prerenderer's diagnostic write path onto a single `response.meta` channel so the inner `SerializedError.diagnostics` workaround can go away.

## Motivating use case

From the CS-10793 investigation: after editing `order.gts` in the small-northwind realm, the incremental reindex took 21 s to re-render 8 rows. Without `timing_diagnostics`, figuring out which of the 8 rows ate the budget meant reading prerender-server logs multiplexed through `run-p -ln` — hard to correlate. With the new column + `invalidationId` correlation key, a single SQL query gives per-row render ms, render stage, in-flight loads, and module-evaluation top-N for the whole fan-out:

```sql
SELECT url, type,
       (timing_diagnostics->>'renderElapsedMs')::int AS ms,
       timing_diagnostics->>'renderStage'           AS stage,
       timing_diagnostics->'waits'                  AS waits
FROM boxel_index
WHERE timing_diagnostics->>'invalidationId' = '<uuid-from-any-row-in-the-fanout>'
ORDER BY ms DESC NULLS LAST;
```

## What changed

### Schema

Migration `add-timing-diagnostics-to-index` adds `timing_diagnostics jsonb NULL` to both `boxel_index` and `boxel_index_working`. Host-side SQLite schema regenerated via `pnpm make-schema`. Added to `coerceTypes` for SQLite JSON parsing.

### Write path

- **`Batch` (in `runtime-common/index-writer.ts`)** mints an `invalidationId` UUID in its constructor and refreshes it at the top of each `invalidate()` call. `updateEntry` always stamps it into the row's `timing_diagnostics` alongside `indexedAt`. fromScratch inherits the constructor-minted ID so full rebuilds are queryable too.
- **`IndexWriter.updateEntry`** persists the blob to the new column on every write. For error rows it also mirrors the same blob into `error_doc.diagnostics` (derived write) so the existing UI read path keeps working without a schema rename.
- **`visit-file.ts` → `card-indexer.ts` / `file-indexer.ts`**: new `flattenMeta(response.meta)` helper turns the Prerenderer's meta into a `TimingDiagnostics` blob, threaded into `performCardIndexing` / `performFileIndexing`.

### Prerenderer consolidation

One channel instead of three. The previous `SerializedError.diagnostics` shuffle (the only way diagnostics reached `error_doc`) is gone:

- `withTimeout` attaches to the outer `RenderError.diagnostics` as a transient transport. `decorateRenderErrorsWithTimings` lifts any `RenderError.diagnostics` off the response, merges with server timings, writes the aggregated payload to `response.meta.diagnostics`, and **deletes** the outer field. `decorateRenderErrorDiagnostics` sets `response.meta.requestId`.
- Inner `SerializedError.diagnostics` is no longer touched at the source — it's populated at the `IndexWriter` boundary as a derived copy for UI compat, keyed off `timing_diagnostics`.

### Types

- New `PrerenderResponseMeta` on `ModuleRenderResponse` / `RenderVisitResponse` / `RunCommandResponse`.
- New `TimingDiagnostics extends RenderTimeoutDiagnostics` with `requestId`, `invalidationId`, `indexedAt`.
- Every `Record<string, unknown>` slot along the indexer→writer path replaced with `TimingDiagnostics`.

### Skill

`.claude/skills/prerender-timeout-diagnostics` renamed to `.claude/skills/indexing-diagnostics`. Reorganized around two modes:

- **Mode A** — a render timed out. Classify which part of the pipeline stalled (launch / loader / data / render).
- **Mode B** — a reindex was slow but succeeded. Pull the fan-out by `invalidationId`, attribute `renderElapsedMs` across rows, zero in on the heavy ones.

Both modes share the same data and the same classification table.

### Tests

`prerender-diagnostics-persistence-test.ts` locks down the new invariant:
- `decorateRenderErrorsWithTimings` lifts `RenderError.diagnostics` to `response.meta.diagnostics` and clears the outer field.
- Inner `SerializedError.diagnostics` must remain `undefined` at the decorator layer (catches any regression that reintroduces the old dual-write pattern).
- `decorateRenderErrorDiagnostics` stamps `response.meta.requestId`, not the inner error.
- Both decorators stack without shadowing.

## Test plan

- [x] `pnpm lint` clean on `packages/postgres`, `packages/runtime-common`, `packages/realm-server`
- [x] `pnpm make-schema` ran; host SQLite schema regenerated
- [x] Migration applied locally
- [x] `TEST_MODULES=prerender-diagnostics-persistence-test.ts,prerender-cancellation-test.ts,prerender-batch-ownership-test.ts,prerender-proxy-test.ts,prerender-manager-test.ts` — **86/86 pass**
- [ ] CI for broader integration suite
- [ ] Post-merge spot-check: edit `order.gts` in a dev realm and run the `invalidationId` grouping query; confirm all 7-8 invalidated rows share the same ID and have non-null `renderElapsedMs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
