### PR TITLE
CS-10889: Dual-write realm_registry from mutation handlers

### DIFF
--- a/packages/realm-server/handlers/handle-delete-realm.ts
+++ b/packages/realm-server/handlers/handle-delete-realm.ts
@@ -30,6 +30,10 @@ import {
   destroyMountedRealm,
   removeRealmDatabaseArtifacts,
 } from './realm-destruction-utils';
+import {
+  deleteFromRegistryByUrl,
+  deletePublishedFromRegistryBySource,
+} from '../lib/realm-registry-writes';
 
 interface DeleteRealmJSON {
   data: {
@@ -184,6 +188,12 @@ export default function handleDeleteRealm({
         `DELETE FROM published_realms WHERE source_realm_url =`,
         param(realmURL),
       ]);
+
+      // Phase 1 dual-write: remove the source realm's registry row plus
+      // every published row sourced from it. Both helpers log and continue
+      // on failure; drift self-heals on next boot.
+      await deletePublishedFromRegistryBySource(dbAdapter, realmURL);
+      await deleteFromRegistryByUrl(dbAdapter, realmURL);
 
       let { nameExpressions, valueExpressions } = asExpressions({
         removed_at: Math.floor(Date.now() / 1000),

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -42,6 +42,7 @@ import type { CreateRoutesArgs } from '../routes';
 import type { RealmServerTokenClaim } from '../utils/jwt';
 import { registerUser } from '../synapse';
 import { passwordFromSeed } from '@cardstack/runtime-common/matrix-client';
+import { mirrorPublishedRealmToRegistry } from '../lib/realm-registry-writes';
 
 const log = logger('handle-publish');
 
@@ -438,6 +439,17 @@ export default function handlePublishRealm({
         removeSync(publishedRealmPath);
         throw dbError;
       }
+
+      // Phase 1 dual-write: mirror the published realm into realm_registry.
+      // Logs and continues on failure (shadow data; boot-time backfill
+      // re-syncs on next boot). See lib/realm-registry-writes.ts.
+      await mirrorPublishedRealmToRegistry(dbAdapter, {
+        publishedRealmURL,
+        publishedRealmId,
+        ownerUsername: realmUsername,
+        sourceRealmURL,
+        lastPublishedAt: Number(lastPublishedAt),
+      });
 
       let response = createResponse({
         body: JSON.stringify(

--- a/packages/realm-server/handlers/handle-unpublish-realm.ts
+++ b/packages/realm-server/handlers/handle-unpublish-realm.ts
@@ -23,6 +23,7 @@ import {
 import type { CreateRoutesArgs } from '../routes';
 import type { RealmServerTokenClaim } from '../utils/jwt';
 import { removeMountedRealm } from './realm-destruction-utils';
+import { deleteFromRegistryByUrl } from '../lib/realm-registry-writes';
 
 const log = logger('handle-unpublish');
 
@@ -125,6 +126,9 @@ export default function handleUnpublishRealm({
         `DELETE FROM published_realms WHERE published_realm_url =`,
         param(publishedRealmURL),
       ]);
+
+      // Phase 1 dual-write: mirror the delete into realm_registry.
+      await deleteFromRegistryByUrl(dbAdapter, publishedRealmURL);
 
       await removeRealmPermissions(dbAdapter, new URL(publishedRealmURL));
 

--- a/packages/realm-server/lib/realm-registry-writes.ts
+++ b/packages/realm-server/lib/realm-registry-writes.ts
@@ -105,9 +105,10 @@ export async function deleteFromRegistryByUrl(
 
 // Delete every kind='published' row whose source_url matches the given source
 // realm URL. Used by handle-delete-realm when a source realm (and all its
-// publications) is being removed. kind != 'bootstrap' is redundant here
-// (bootstrap rows never have source_url populated) but included for symmetry
-// with the other delete helper.
+// publications) is being removed. The kind='published' filter is explicit
+// even though the schema's CHECK constraint already guarantees that only
+// published rows have non-null source_url — stating the contract in the SQL
+// matches the helper's name and survives any future schema changes.
 export async function deletePublishedFromRegistryBySource(
   dbAdapter: DBAdapter,
   sourceUrl: string,
@@ -116,7 +117,7 @@ export async function deletePublishedFromRegistryBySource(
     await query(dbAdapter, [
       `DELETE FROM realm_registry WHERE source_url =`,
       param(sourceUrl),
-      ` AND kind <> 'bootstrap'`,
+      ` AND kind = 'published'`,
     ]);
   } catch (err: unknown) {
     log.warn(

--- a/packages/realm-server/lib/realm-registry-writes.ts
+++ b/packages/realm-server/lib/realm-registry-writes.ts
@@ -1,0 +1,126 @@
+import type { DBAdapter } from '@cardstack/runtime-common';
+import { logger, param, query } from '@cardstack/runtime-common';
+
+// Helpers for mirroring handler-driven realm lifecycle events
+// (publish/unpublish/delete/create) into realm_registry. Phase 1 dual-writes:
+// every helper is wrapped in its own try/catch so that a failure to write the
+// registry row never surfaces as an error to the caller. The registry is
+// shadow data in Phase 1 (no reader depends on it until Phase 3), and any
+// drift from the legacy tables is self-healed by the boot-time backfill in
+// realm-registry-backfill.ts.
+//
+// All mutation helpers include a `kind != 'bootstrap'` guard so a user-facing
+// handler mutation can never affect a bootstrap row (belt-and-suspenders: URLs
+// shouldn't match in practice, but the guard keeps that guarantee enforced at
+// the SQL layer).
+
+const log = logger('realm-server:registry-writes');
+
+// Upsert a published realm into realm_registry. Called from handle-publish-realm
+// after the legacy published_realms write succeeds.
+//
+// On conflict: updates last_published_at/updated_at so repeat publishes
+// advance the timestamp. The ON CONFLICT UPDATE's WHERE clause keeps the
+// update no-oped if the existing row isn't kind='published' — which also
+// serves as the bootstrap guard.
+export async function mirrorPublishedRealmToRegistry(
+  dbAdapter: DBAdapter,
+  args: {
+    publishedRealmURL: string;
+    publishedRealmId: string;
+    ownerUsername: string;
+    sourceRealmURL: string;
+    lastPublishedAt: number;
+  },
+): Promise<void> {
+  try {
+    await query(dbAdapter, [
+      `INSERT INTO realm_registry (url, kind, disk_id, owner_username, source_url, last_published_at, pinned) VALUES (`,
+      param(args.publishedRealmURL),
+      `, 'published', `,
+      param(args.publishedRealmId),
+      `, `,
+      param(args.ownerUsername),
+      `, `,
+      param(args.sourceRealmURL),
+      `, `,
+      param(args.lastPublishedAt),
+      `, false`,
+      `) ON CONFLICT (url) DO UPDATE SET last_published_at = EXCLUDED.last_published_at, updated_at = now() WHERE realm_registry.kind = 'published'`,
+    ]);
+  } catch (err: unknown) {
+    log.warn(
+      `failed to mirror publish to realm_registry for ${args.publishedRealmURL}: ${String(err)}; will self-heal on next boot`,
+    );
+  }
+}
+
+// Insert a source realm into realm_registry. Called from server.ts:createRealm
+// after permissions + .realm.json are written to disk.
+export async function mirrorSourceRealmToRegistry(
+  dbAdapter: DBAdapter,
+  args: {
+    url: string;
+    diskId: string;
+    ownerUsername: string;
+  },
+): Promise<void> {
+  try {
+    await query(dbAdapter, [
+      `INSERT INTO realm_registry (url, kind, disk_id, owner_username, pinned) VALUES (`,
+      param(args.url),
+      `, 'source', `,
+      param(args.diskId),
+      `, `,
+      param(args.ownerUsername),
+      `, false`,
+      `) ON CONFLICT (url) DO NOTHING`,
+    ]);
+  } catch (err: unknown) {
+    log.warn(
+      `failed to mirror source-realm create to realm_registry for ${args.url}: ${String(err)}; will self-heal on next boot`,
+    );
+  }
+}
+
+// Delete a single row from realm_registry by url. Used by
+// handle-unpublish-realm (published row) and handle-delete-realm (source row).
+// kind != 'bootstrap' is the belt-and-suspenders guard.
+export async function deleteFromRegistryByUrl(
+  dbAdapter: DBAdapter,
+  url: string,
+): Promise<void> {
+  try {
+    await query(dbAdapter, [
+      `DELETE FROM realm_registry WHERE url =`,
+      param(url),
+      ` AND kind <> 'bootstrap'`,
+    ]);
+  } catch (err: unknown) {
+    log.warn(
+      `failed to delete realm_registry row for ${url}: ${String(err)}; will self-heal on next boot`,
+    );
+  }
+}
+
+// Delete every kind='published' row whose source_url matches the given source
+// realm URL. Used by handle-delete-realm when a source realm (and all its
+// publications) is being removed. kind != 'bootstrap' is redundant here
+// (bootstrap rows never have source_url populated) but included for symmetry
+// with the other delete helper.
+export async function deletePublishedFromRegistryBySource(
+  dbAdapter: DBAdapter,
+  sourceUrl: string,
+): Promise<void> {
+  try {
+    await query(dbAdapter, [
+      `DELETE FROM realm_registry WHERE source_url =`,
+      param(sourceUrl),
+      ` AND kind <> 'bootstrap'`,
+    ]);
+  } catch (err: unknown) {
+    log.warn(
+      `failed to delete published realm_registry rows for source ${sourceUrl}: ${String(err)}; will self-heal on next boot`,
+    );
+  }
+}

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -53,6 +53,7 @@ import { createRoutes } from './routes';
 import { APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE } from '@cardstack/runtime-common/matrix-constants';
 import type { Prerenderer } from '@cardstack/runtime-common';
 import { retrieveScopedCSS } from './lib/retrieve-scoped-css';
+import { mirrorSourceRealmToRegistry } from './lib/realm-registry-writes';
 import {
   indexURLCandidates,
   indexCandidateExpressions,
@@ -928,6 +929,14 @@ export class RealmServer {
           },
         },
       },
+    });
+
+    // Phase 1 dual-write: register the source realm in realm_registry after
+    // its on-disk representation is in place. Logs and continues on failure.
+    await mirrorSourceRealmToRegistry(this.dbAdapter, {
+      url,
+      diskId: `${ownerUsername}/${endpoint}`,
+      ownerUsername,
     });
 
     let realm = this.createAndMountRealm(

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -182,6 +182,7 @@ import './run-command-task-test';
 import './realm-endpoints-test';
 import './realm-endpoints/dependencies-test';
 import './realm-registry-backfill-test';
+import './realm-registry-writes-test';
 import './realm-endpoints/directory-test';
 import './realm-endpoints/info-test';
 import './realm-endpoints/invalidate-urls-test';

--- a/packages/realm-server/tests/realm-registry-writes-test.ts
+++ b/packages/realm-server/tests/realm-registry-writes-test.ts
@@ -1,0 +1,327 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import type { PgAdapter } from '@cardstack/postgres';
+import { asExpressions, insert, query } from '@cardstack/runtime-common';
+import { setupDB } from './helpers';
+import {
+  deleteFromRegistryByUrl,
+  deletePublishedFromRegistryBySource,
+  mirrorPublishedRealmToRegistry,
+  mirrorSourceRealmToRegistry,
+} from '../lib/realm-registry-writes';
+
+interface RegistryRow {
+  url: string;
+  kind: string;
+  disk_id: string;
+  owner_username: string;
+  source_url: string | null;
+  last_published_at: string | null;
+  pinned: boolean;
+}
+
+async function getRegistryRow(
+  dbAdapter: PgAdapter,
+  url: string,
+): Promise<RegistryRow | undefined> {
+  const rows = (await query(dbAdapter, [
+    `SELECT url, kind, disk_id, owner_username, source_url, last_published_at, pinned FROM realm_registry WHERE url = '${url.replace(/'/g, "''")}'`,
+  ])) as Array<Record<string, unknown>>;
+  if (!rows.length) return undefined;
+  const r = rows[0];
+  return {
+    url: r.url as string,
+    kind: r.kind as string,
+    disk_id: r.disk_id as string,
+    owner_username: r.owner_username as string,
+    source_url: (r.source_url as string | null) ?? null,
+    last_published_at: (r.last_published_at as string | null) ?? null,
+    pinned: r.pinned as boolean,
+  };
+}
+
+async function getAllRegistryRows(
+  dbAdapter: PgAdapter,
+): Promise<RegistryRow[]> {
+  const rows = (await query(dbAdapter, [
+    `SELECT url, kind, disk_id, owner_username, source_url, last_published_at, pinned FROM realm_registry ORDER BY url`,
+  ])) as Array<Record<string, unknown>>;
+  return rows.map((r) => ({
+    url: r.url as string,
+    kind: r.kind as string,
+    disk_id: r.disk_id as string,
+    owner_username: r.owner_username as string,
+    source_url: (r.source_url as string | null) ?? null,
+    last_published_at: (r.last_published_at as string | null) ?? null,
+    pinned: r.pinned as boolean,
+  }));
+}
+
+async function seedBootstrapRow(dbAdapter: PgAdapter, url: string) {
+  const { nameExpressions, valueExpressions } = asExpressions({
+    url,
+    kind: 'bootstrap',
+    disk_id: '/abs/bootstrap',
+    owner_username: 'system',
+    pinned: true,
+  });
+  await query(
+    dbAdapter,
+    insert('realm_registry', nameExpressions, valueExpressions),
+  );
+}
+
+module(basename(__filename), function () {
+  module('mirrorPublishedRealmToRegistry', function (hooks) {
+    let dbAdapter: PgAdapter;
+    setupDB(hooks, {
+      beforeEach: async (adapter) => {
+        dbAdapter = adapter;
+      },
+    });
+
+    test('inserts a published row when absent', async function (assert) {
+      await mirrorPublishedRealmToRegistry(dbAdapter, {
+        publishedRealmURL: 'http://user.localhost:4201/site/',
+        publishedRealmId: '11111111-2222-3333-4444-555555555555',
+        ownerUsername: 'realm/_published_xyz',
+        sourceRealmURL: 'http://localhost:4201/luke/src/',
+        lastPublishedAt: 1_700_000_000_000,
+      });
+
+      const row = await getRegistryRow(
+        dbAdapter,
+        'http://user.localhost:4201/site/',
+      );
+      assert.ok(row, 'row inserted');
+      assert.strictEqual(row!.kind, 'published');
+      assert.strictEqual(row!.disk_id, '11111111-2222-3333-4444-555555555555');
+      assert.strictEqual(row!.owner_username, 'realm/_published_xyz');
+      assert.strictEqual(row!.source_url, 'http://localhost:4201/luke/src/');
+      assert.strictEqual(row!.last_published_at, '1700000000000');
+      assert.false(row!.pinned);
+    });
+
+    test('updates last_published_at on repeat publish', async function (assert) {
+      const url = 'http://user.localhost:4201/site/';
+      await mirrorPublishedRealmToRegistry(dbAdapter, {
+        publishedRealmURL: url,
+        publishedRealmId: 'uuid-1',
+        ownerUsername: 'realm/_published_x',
+        sourceRealmURL: 'http://localhost:4201/luke/src/',
+        lastPublishedAt: 1_700_000_000_000,
+      });
+      await mirrorPublishedRealmToRegistry(dbAdapter, {
+        publishedRealmURL: url,
+        publishedRealmId: 'uuid-1',
+        ownerUsername: 'realm/_published_x',
+        sourceRealmURL: 'http://localhost:4201/luke/src/',
+        lastPublishedAt: 1_800_000_000_000,
+      });
+
+      const row = await getRegistryRow(dbAdapter, url);
+      assert.strictEqual(
+        row!.last_published_at,
+        '1800000000000',
+        'timestamp advanced on repeat publish',
+      );
+    });
+
+    test('does not clobber a bootstrap row that shares the URL', async function (assert) {
+      const url = 'https://cardstack.com/base/';
+      await seedBootstrapRow(dbAdapter, url);
+
+      await mirrorPublishedRealmToRegistry(dbAdapter, {
+        publishedRealmURL: url,
+        publishedRealmId: 'uuid-x',
+        ownerUsername: 'realm/_published_x',
+        sourceRealmURL: 'http://localhost:4201/some/src/',
+        lastPublishedAt: 1_700_000_000_000,
+      });
+
+      const row = await getRegistryRow(dbAdapter, url);
+      assert.strictEqual(row!.kind, 'bootstrap', 'bootstrap row untouched');
+      assert.strictEqual(row!.disk_id, '/abs/bootstrap');
+      assert.strictEqual(row!.source_url, null);
+    });
+  });
+
+  module('mirrorSourceRealmToRegistry', function (hooks) {
+    let dbAdapter: PgAdapter;
+    setupDB(hooks, {
+      beforeEach: async (adapter) => {
+        dbAdapter = adapter;
+      },
+    });
+
+    test('inserts a source row when absent', async function (assert) {
+      await mirrorSourceRealmToRegistry(dbAdapter, {
+        url: 'http://localhost:4201/luke/my-realm/',
+        diskId: 'luke/my-realm',
+        ownerUsername: 'luke',
+      });
+
+      const row = await getRegistryRow(
+        dbAdapter,
+        'http://localhost:4201/luke/my-realm/',
+      );
+      assert.ok(row, 'row inserted');
+      assert.strictEqual(row!.kind, 'source');
+      assert.strictEqual(row!.disk_id, 'luke/my-realm');
+      assert.strictEqual(row!.owner_username, 'luke');
+      assert.strictEqual(row!.source_url, null);
+      assert.false(row!.pinned);
+    });
+
+    test('is a no-op when the url already exists (ON CONFLICT DO NOTHING)', async function (assert) {
+      const url = 'http://localhost:4201/luke/my-realm/';
+      await mirrorSourceRealmToRegistry(dbAdapter, {
+        url,
+        diskId: 'luke/my-realm',
+        ownerUsername: 'luke',
+      });
+      await mirrorSourceRealmToRegistry(dbAdapter, {
+        url,
+        diskId: 'luke/different-path',
+        ownerUsername: 'luke',
+      });
+
+      const row = await getRegistryRow(dbAdapter, url);
+      assert.strictEqual(
+        row!.disk_id,
+        'luke/my-realm',
+        'disk_id from first insert preserved (no conflict update)',
+      );
+    });
+  });
+
+  module('deleteFromRegistryByUrl', function (hooks) {
+    let dbAdapter: PgAdapter;
+    setupDB(hooks, {
+      beforeEach: async (adapter) => {
+        dbAdapter = adapter;
+      },
+    });
+
+    test('deletes a published row', async function (assert) {
+      const url = 'http://user.localhost:4201/site/';
+      await mirrorPublishedRealmToRegistry(dbAdapter, {
+        publishedRealmURL: url,
+        publishedRealmId: 'uuid',
+        ownerUsername: 'realm/_published_x',
+        sourceRealmURL: 'http://localhost:4201/luke/src/',
+        lastPublishedAt: 1_700_000_000_000,
+      });
+      await deleteFromRegistryByUrl(dbAdapter, url);
+      assert.strictEqual(
+        await getRegistryRow(dbAdapter, url),
+        undefined,
+        'published row removed',
+      );
+    });
+
+    test('deletes a source row', async function (assert) {
+      const url = 'http://localhost:4201/luke/src/';
+      await mirrorSourceRealmToRegistry(dbAdapter, {
+        url,
+        diskId: 'luke/src',
+        ownerUsername: 'luke',
+      });
+      await deleteFromRegistryByUrl(dbAdapter, url);
+      assert.strictEqual(
+        await getRegistryRow(dbAdapter, url),
+        undefined,
+        'source row removed',
+      );
+    });
+
+    test('does NOT delete a bootstrap row (kind != bootstrap guard)', async function (assert) {
+      const url = 'https://cardstack.com/base/';
+      await seedBootstrapRow(dbAdapter, url);
+      await deleteFromRegistryByUrl(dbAdapter, url);
+
+      const row = await getRegistryRow(dbAdapter, url);
+      assert.ok(row, 'bootstrap row still exists');
+      assert.strictEqual(row!.kind, 'bootstrap');
+    });
+
+    test('is a no-op when the url is absent', async function (assert) {
+      await deleteFromRegistryByUrl(
+        dbAdapter,
+        'http://does-not-exist.example/',
+      );
+      assert.strictEqual(
+        (await getAllRegistryRows(dbAdapter)).length,
+        0,
+        'nothing removed',
+      );
+    });
+  });
+
+  module('deletePublishedFromRegistryBySource', function (hooks) {
+    let dbAdapter: PgAdapter;
+    setupDB(hooks, {
+      beforeEach: async (adapter) => {
+        dbAdapter = adapter;
+      },
+    });
+
+    test('deletes all published rows sourced from a given url', async function (assert) {
+      const sourceUrl = 'http://localhost:4201/luke/src/';
+      await mirrorPublishedRealmToRegistry(dbAdapter, {
+        publishedRealmURL: 'http://user1.localhost:4201/a/',
+        publishedRealmId: 'uuid-a',
+        ownerUsername: 'realm/_published_a',
+        sourceRealmURL: sourceUrl,
+        lastPublishedAt: 1,
+      });
+      await mirrorPublishedRealmToRegistry(dbAdapter, {
+        publishedRealmURL: 'http://user2.localhost:4201/b/',
+        publishedRealmId: 'uuid-b',
+        ownerUsername: 'realm/_published_b',
+        sourceRealmURL: sourceUrl,
+        lastPublishedAt: 2,
+      });
+      // A published row sourced from a DIFFERENT realm — should survive.
+      await mirrorPublishedRealmToRegistry(dbAdapter, {
+        publishedRealmURL: 'http://user3.localhost:4201/c/',
+        publishedRealmId: 'uuid-c',
+        ownerUsername: 'realm/_published_c',
+        sourceRealmURL: 'http://localhost:4201/someone-else/src/',
+        lastPublishedAt: 3,
+      });
+
+      await deletePublishedFromRegistryBySource(dbAdapter, sourceUrl);
+
+      const rows = await getAllRegistryRows(dbAdapter);
+      assert.strictEqual(rows.length, 1, 'only the unrelated row remains');
+      assert.strictEqual(rows[0].url, 'http://user3.localhost:4201/c/');
+    });
+
+    test('does not touch source rows even if they share the URL', async function (assert) {
+      // A source realm whose URL happens to appear in the source_url field of
+      // some published rows. The helper deletes the published rows but leaves
+      // the source realm's own row alone (it's matched by url, not source_url).
+      const sourceUrl = 'http://localhost:4201/luke/src/';
+      await mirrorSourceRealmToRegistry(dbAdapter, {
+        url: sourceUrl,
+        diskId: 'luke/src',
+        ownerUsername: 'luke',
+      });
+      await mirrorPublishedRealmToRegistry(dbAdapter, {
+        publishedRealmURL: 'http://user.localhost:4201/pub/',
+        publishedRealmId: 'uuid-pub',
+        ownerUsername: 'realm/_published_pub',
+        sourceRealmURL: sourceUrl,
+        lastPublishedAt: 1,
+      });
+
+      await deletePublishedFromRegistryBySource(dbAdapter, sourceUrl);
+
+      const rows = await getAllRegistryRows(dbAdapter);
+      assert.strictEqual(rows.length, 1);
+      assert.strictEqual(rows[0].url, sourceUrl, 'source row preserved');
+      assert.strictEqual(rows[0].kind, 'source');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on #4501. Mirrors handler-driven realm lifecycle events into `realm_registry` alongside the existing `published_realms` writes. Shadow data only — no reader depends on these rows yet.

**Handler changes:**

- **`handle-publish-realm`**: after the legacy `published_realms` INSERT/UPDATE, upsert a `kind='published'` registry row. `ON CONFLICT (url) DO UPDATE` advances `last_published_at` on republish; `WHERE realm_registry.kind = 'published'` guards against ever overwriting a conflicting `kind='bootstrap'` row.
- **`handle-unpublish-realm`**: after `DELETE FROM published_realms`, delete the matching registry row.
- **`handle-delete-realm`**: after `DELETE FROM published_realms`, delete all `kind='published'` rows sourced from this realm + the source row itself.
- **`server.ts:createRealm`**: after `insertPermissions` + on-disk `.realm.json` write, insert a `kind='source'` row.

All four go through four focused helpers in a new `lib/realm-registry-writes.ts`.

## Design choices

### Log-and-continue on failure

Each helper wraps its SQL in its own try/catch that logs a warning and returns cleanly. Rationale:

- Registry is shadow data in Phase 1 — no reader uses it yet
- The boot-time backfill in CS-10888 self-heals drift on next boot
- Handler's user-visible success/failure contract is unchanged
- Registry bugs surface as log warnings, not as user-facing 5xx

Phase 3 will tighten this when the registry becomes load-bearing.

### `kind <> 'bootstrap'` guard at the SQL layer

Every mutation query includes the guard. In practice URLs shouldn't collide (bootstrap URLs are well-known and user-facing UIs don't expose them), but the guard ensures the guarantee is enforced defensively in the data layer rather than relying on upstream checks alone.

### No feature flag

Per the revised CS-10889 decision: shadow-data-in-Phase-1 doesn't warrant per-handler `if (ENABLED)` cruft. Standard deploy rollback is the escape hatch.

## Test plan

- [x] `pnpm lint:types` — clean
- [x] `pnpm lint:js` — clean (including `qunit/no-assert-equal-boolean`)
- [x] New `realm-registry-writes-test.ts` — 11/11 passing:
  - `mirrorPublishedRealmToRegistry` inserts when absent
  - `mirrorPublishedRealmToRegistry` updates `last_published_at` on repeat publish
  - `mirrorPublishedRealmToRegistry` does not clobber a bootstrap row
  - `mirrorSourceRealmToRegistry` inserts when absent
  - `mirrorSourceRealmToRegistry` is a no-op on conflict (first-insert wins)
  - `deleteFromRegistryByUrl` deletes a published row
  - `deleteFromRegistryByUrl` deletes a source row
  - `deleteFromRegistryByUrl` does NOT delete a bootstrap row (the guard)
  - `deleteFromRegistryByUrl` is a no-op when the url is absent
  - `deletePublishedFromRegistryBySource` deletes only matching published rows
  - `deletePublishedFromRegistryBySource` does not touch source rows
- [ ] CI integration-test sweep (server-endpoints delete-realm, publish, etc.) passes with dual-writes wired in

## Review guidance

Stacked on #4501. Please review #4499 → #4501 → this one in order. Land in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)