### PR TITLE
CS-10890: RealmRegistryReconciler + NOTIFY + advisory lock

### DIFF
--- a/packages/postgres/pg-queue.ts
+++ b/packages/postgres/pg-queue.ts
@@ -74,7 +74,7 @@ async function acquireConcurrencyGroupLock(
 }
 
 // Tracks a task that should loop with a timeout and an interruptible sleep.
-class WorkLoop {
+export class WorkLoop {
   private internalWaker: Deferred<void> | undefined;
   private timeout: NodeJS.Timeout | undefined;
   private _shuttingDown = false;

--- a/packages/realm-server/lib/realm-registry-backfill.ts
+++ b/packages/realm-server/lib/realm-registry-backfill.ts
@@ -8,8 +8,16 @@ import {
   query,
   type DBAdapter,
 } from '@cardstack/runtime-common';
+import type { PgAdapter } from '@cardstack/postgres';
 
 const log = logger('realm-server:registry-backfill');
+
+// Constant, arbitrarily chosen, stable across deployments. Only one process
+// at a time can hold this advisory lock against a given database, so only
+// one process performs the boot-time backfill per startup wave in a
+// multi-instance deployment. Single-instance: uncontended acquisition, no
+// behavioral effect.
+export const REGISTRY_BACKFILL_LOCK_ID = 7331011;
 
 // Sentinel used as owner_username for kind='bootstrap' rows. Bootstrap realms
 // (base, catalog, etc.) are not user-owned, but the column is NOT NULL, so we
@@ -303,4 +311,47 @@ async function warnOnStaleBootstrapRows(
       );
     }
   }
+}
+
+// Runs runRegistryBackfill under a pg advisory lock so that, in a multi-
+// instance deployment, only one realm-server performs the backfill per
+// startup wave. Acquired via `withConnection` so the lock (session-scoped)
+// is pinned to a dedicated connection; explicitly released before that
+// connection returns to the pool so the lock doesn't leak.
+//
+// If the lock is held by a peer, this function logs and returns without
+// running the backfill. The reconciler (CS-10890) still starts on this
+// process and picks up the registry state that the peer populated.
+export async function runRegistryBackfillWithAdvisoryLock(
+  dbAdapter: PgAdapter,
+  opts: RegistryBackfillOpts,
+): Promise<void> {
+  await dbAdapter.withConnection(async (queryFn) => {
+    const rows = (await queryFn([
+      `SELECT pg_try_advisory_lock(`,
+      param(REGISTRY_BACKFILL_LOCK_ID),
+      `) AS acquired`,
+    ])) as [{ acquired: boolean }];
+    if (!rows[0]?.acquired) {
+      log.info(
+        'peer process holds the registry backfill advisory lock; skipping backfill on this instance',
+      );
+      return;
+    }
+    try {
+      await runRegistryBackfill(opts);
+    } finally {
+      try {
+        await queryFn([
+          `SELECT pg_advisory_unlock(`,
+          param(REGISTRY_BACKFILL_LOCK_ID),
+          `)`,
+        ]);
+      } catch (err: unknown) {
+        log.warn(
+          `failed to release registry backfill advisory lock: ${String(err)}`,
+        );
+      }
+    }
+  });
 }

--- a/packages/realm-server/lib/realm-registry-reconciler.ts
+++ b/packages/realm-server/lib/realm-registry-reconciler.ts
@@ -1,0 +1,201 @@
+import type { Realm } from '@cardstack/runtime-common';
+import { logger, query } from '@cardstack/runtime-common';
+import type { PgAdapter } from '@cardstack/postgres';
+import { WorkLoop } from '@cardstack/postgres';
+
+const log = logger('realm-server:registry-reconciler');
+const CHANNEL = 'realm_registry';
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+
+// A row read from realm_registry. See packages/postgres/migrations/*_create-
+// realm-registry.js for the column semantics and the kind-specific
+// interpretation of disk_id.
+export interface RealmRegistryRow {
+  id: string;
+  url: string;
+  kind: 'source' | 'published' | 'bootstrap';
+  disk_id: string;
+  owner_username: string;
+  source_url: string | null;
+  last_published_at: number | null;
+  pinned: boolean;
+}
+
+export interface ReconcilerDeps {
+  dbAdapter: PgAdapter;
+  // Construct a Realm from a registry row and mount it into the virtual
+  // network. Returns the mounted Realm. The reconciler owns the `mounted`
+  // map; the factory is just the adapter between a registry row and a
+  // constructed+mounted Realm instance.
+  mountFromRow: (row: RealmRegistryRow) => Promise<Realm>;
+  // Inverse of mountFromRow: unmount + clean up a Realm that the registry
+  // no longer lists. Called when a row is deleted.
+  unmount: (realm: Realm) => Promise<void>;
+  // Optional for tests — poll interval in ms (default 30s).
+  pollIntervalMs?: number;
+}
+
+// Reconciles a process's in-memory realm state against realm_registry.
+//
+// Phase 2 behavior (this PR): the reconcile loop mounts every row in the
+// registry that isn't already mounted locally, and unmounts anything the
+// registry no longer lists. Pinned vs unpinned is tracked but not yet
+// differentiated — Phase 3 flips the policy so only pinned rows are eagerly
+// mounted and everything else waits for mount-on-demand.
+//
+// The reconciler maintains three maps:
+//   - knownByUrl:    every row the reconciler has seen, refreshed each pass.
+//                    The in-memory reflection of the registry.
+//   - mounted:       the subset of knownByUrl that has an active Realm
+//                    instance on this process. In Phase 2 ~equals knownByUrl.
+//   - pendingMounts: URL-keyed in-flight ensureMounted() promises, so
+//                    concurrent callers serialize per URL. Used by the
+//                    Phase 3 request path.
+//
+// The loop is driven by a WorkLoop (shared with pg-queue). Every mutation
+// handler emits `NOTIFY realm_registry` after its DB write; the LISTEN
+// wakes the loop, which re-reads the registry and applies the diff. A 30s
+// poll is the safety net for missed notifications (pg_reconnect, LISTEN
+// transient failure).
+export class RealmRegistryReconciler {
+  #deps: ReconcilerDeps;
+  #loop: WorkLoop;
+  #started = false;
+  knownByUrl = new Map<string, RealmRegistryRow>();
+  mounted = new Map<string, Realm>();
+  pendingMounts = new Map<string, Promise<Realm>>();
+
+  constructor(deps: ReconcilerDeps) {
+    this.#deps = deps;
+    this.#loop = new WorkLoop(
+      'realm-registry',
+      deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+    );
+  }
+
+  // Snapshot existing realms into the reconciler's mounted map. Called
+  // during boot (after CLI realms + server.start()) so the reconciler
+  // treats those as already-mounted and doesn't try to re-mount them.
+  // Coexistence with the legacy mount path is a Phase 2 property;
+  // Phase 3 removes the legacy mount and the reconciler owns all mounts.
+  registerExistingMounts(realms: Iterable<Realm>): void {
+    for (const realm of realms) {
+      this.mounted.set(realm.url, realm);
+    }
+  }
+
+  // Begin the LISTEN + poll loop. Safe to call once; no-ops on repeat.
+  start(): void {
+    if (this.#started) {
+      return;
+    }
+    this.#started = true;
+    this.#loop.run(async (loop) => {
+      await this.#deps.dbAdapter.listen(
+        CHANNEL,
+        loop.wake.bind(loop),
+        async () => {
+          // Run one reconcile immediately on start, then loop on wake-or-poll.
+          while (!loop.shuttingDown) {
+            await this.#safeReconcile();
+            await loop.sleep();
+          }
+        },
+      );
+    });
+  }
+
+  async shutDown(): Promise<void> {
+    await this.#loop.shutDown();
+  }
+
+  async #safeReconcile(): Promise<void> {
+    try {
+      await this.reconcile();
+    } catch (err: unknown) {
+      log.warn(
+        `reconcile pass failed; will retry on next poll: ${String(err)}`,
+      );
+    }
+  }
+
+  // Public for tests and the Phase 3 request-path integration. One pass:
+  // re-read the registry, mount anything new (respecting kind='bootstrap'
+  // eager-mount already-mounted idempotence), unmount anything removed.
+  async reconcile(): Promise<void> {
+    const rows = (await query(this.#deps.dbAdapter, [
+      `SELECT id::text AS id, url, kind, disk_id, owner_username, source_url, last_published_at, pinned FROM realm_registry`,
+    ])) as Array<Record<string, unknown>>;
+
+    const nextKnown = new Map<string, RealmRegistryRow>();
+    for (const r of rows) {
+      const row: RealmRegistryRow = {
+        id: r.id as string,
+        url: r.url as string,
+        kind: r.kind as RealmRegistryRow['kind'],
+        disk_id: r.disk_id as string,
+        owner_username: r.owner_username as string,
+        source_url: (r.source_url as string | null) ?? null,
+        last_published_at:
+          r.last_published_at == null ? null : Number(r.last_published_at),
+        pinned: r.pinned as boolean,
+      };
+      nextKnown.set(row.url, row);
+    }
+    this.knownByUrl = nextKnown;
+
+    // Mount additions. In Phase 2 we eagerly mount everything (preserving
+    // today's behavior); Phase 3 will gate this on `row.pinned`.
+    for (const [url, row] of nextKnown) {
+      if (!this.mounted.has(url)) {
+        try {
+          await this.ensureMounted(row);
+        } catch (err: unknown) {
+          log.warn(
+            `failed to mount ${url} during reconcile: ${String(err)}; leaving for next pass`,
+          );
+        }
+      }
+    }
+
+    // Unmount removals: anything mounted locally that isn't in the registry.
+    for (const [url, realm] of this.mounted) {
+      if (!nextKnown.has(url)) {
+        try {
+          await this.#deps.unmount(realm);
+        } catch (err: unknown) {
+          log.warn(`failed to unmount ${url}: ${String(err)}; leaving mounted`);
+          continue;
+        }
+        this.mounted.delete(url);
+      }
+    }
+  }
+
+  // Mount-on-demand primitive. Used by reconcile() for new rows and by the
+  // Phase 3 request path on the first request for a not-yet-mounted realm.
+  // Per-URL serialization: concurrent callers for the same URL share one
+  // in-flight mount. Cleared from pendingMounts on settle so a retry after
+  // failure gets a fresh attempt.
+  async ensureMounted(row: RealmRegistryRow): Promise<Realm> {
+    const existing = this.mounted.get(row.url);
+    if (existing) {
+      return existing;
+    }
+    const inflight = this.pendingMounts.get(row.url);
+    if (inflight) {
+      return inflight;
+    }
+    const promise = (async () => {
+      try {
+        const realm = await this.#deps.mountFromRow(row);
+        this.mounted.set(row.url, realm);
+        return realm;
+      } finally {
+        this.pendingMounts.delete(row.url);
+      }
+    })();
+    this.pendingMounts.set(row.url, promise);
+    return promise;
+  }
+}

--- a/packages/realm-server/lib/realm-registry-reconciler.ts
+++ b/packages/realm-server/lib/realm-registry-reconciler.ts
@@ -64,6 +64,14 @@ export class RealmRegistryReconciler {
   knownByUrl = new Map<string, RealmRegistryRow>();
   mounted = new Map<string, Realm>();
   pendingMounts = new Map<string, Promise<Realm>>();
+  // URLs the reconciler itself mounted via ensureMounted(). The unmount
+  // phase of reconcile() only touches these — realms registered via
+  // registerExistingMounts (legacy loadRealms path) are preserved even if
+  // they transiently appear absent from the registry during a skipped-
+  // backfill window on a peer instance. Phase 3 removes registerExistingMounts
+  // entirely and the reconciler owns all mounts, so every mount will be
+  // in this set.
+  #reconcilerOwned = new Set<string>();
 
   constructor(deps: ReconcilerDeps) {
     this.#deps = deps;
@@ -78,6 +86,11 @@ export class RealmRegistryReconciler {
   // treats those as already-mounted and doesn't try to re-mount them.
   // Coexistence with the legacy mount path is a Phase 2 property;
   // Phase 3 removes the legacy mount and the reconciler owns all mounts.
+  //
+  // Realms registered this way are NOT added to #reconcilerOwned, so the
+  // reconciler will never unmount them — their lifecycle is the legacy
+  // path's responsibility (publish/unpublish/delete handlers call
+  // removeMountedRealm / destroyMountedRealm directly).
   registerExistingMounts(realms: Iterable<Realm>): void {
     for (const realm of realms) {
       this.mounted.set(realm.url, realm);
@@ -158,8 +171,17 @@ export class RealmRegistryReconciler {
       }
     }
 
-    // Unmount removals: anything mounted locally that isn't in the registry.
+    // Unmount removals. Only touch realms the reconciler mounted itself
+    // (#reconcilerOwned); legacy-registered mounts are preserved. In a
+    // multi-instance deployment the reconciler may skip its boot backfill
+    // (peer holds the advisory lock) and then read a transiently partial
+    // registry — we don't want that to unmount legitimate legacy mounts.
+    // When Phase 3 removes the legacy mount path, every mount will be
+    // reconciler-owned and this filter becomes a no-op.
     for (const [url, realm] of this.mounted) {
+      if (!this.#reconcilerOwned.has(url)) {
+        continue;
+      }
       if (!nextKnown.has(url)) {
         try {
           await this.#deps.unmount(realm);
@@ -168,6 +190,7 @@ export class RealmRegistryReconciler {
           continue;
         }
         this.mounted.delete(url);
+        this.#reconcilerOwned.delete(url);
       }
     }
   }
@@ -190,6 +213,9 @@ export class RealmRegistryReconciler {
       try {
         const realm = await this.#deps.mountFromRow(row);
         this.mounted.set(row.url, realm);
+        // Mark as reconciler-owned so the unmount phase of a future
+        // reconcile() is allowed to tear it down when the row disappears.
+        this.#reconcilerOwned.add(row.url);
         return realm;
       } finally {
         this.pendingMounts.delete(row.url);

--- a/packages/realm-server/lib/realm-registry-writes.ts
+++ b/packages/realm-server/lib/realm-registry-writes.ts
@@ -13,8 +13,36 @@ import { logger, param, query } from '@cardstack/runtime-common';
 // handler mutation can never affect a bootstrap row (belt-and-suspenders: URLs
 // shouldn't match in practice, but the guard keeps that guarantee enforced at
 // the SQL layer).
+//
+// After a successful DB write, each helper emits
+// `NOTIFY realm_registry, '<op>:<url>'` so that any RealmRegistryReconciler
+// instances (CS-10890) listening on the channel can react promptly. The
+// payload is a hint only — reconcilers always re-read the DB. If the NOTIFY
+// itself fails (DB transient failure), the reconciler's 30s poll safety net
+// catches the change.
 
+const REGISTRY_CHANNEL = 'realm_registry';
 const log = logger('realm-server:registry-writes');
+
+async function notifyRegistry(
+  dbAdapter: DBAdapter,
+  op: 'upsert' | 'delete',
+  url: string,
+): Promise<void> {
+  try {
+    await query(dbAdapter, [
+      `SELECT pg_notify(`,
+      param(REGISTRY_CHANNEL),
+      `, `,
+      param(`${op}:${url}`),
+      `)`,
+    ]);
+  } catch (err: unknown) {
+    log.warn(
+      `failed to NOTIFY ${REGISTRY_CHANNEL} ${op}:${url}: ${String(err)}; reconciler poll will self-heal`,
+    );
+  }
+}
 
 // Upsert a published realm into realm_registry. Called from handle-publish-realm
 // after the legacy published_realms write succeeds.
@@ -52,7 +80,9 @@ export async function mirrorPublishedRealmToRegistry(
     log.warn(
       `failed to mirror publish to realm_registry for ${args.publishedRealmURL}: ${String(err)}; will self-heal on next boot`,
     );
+    return;
   }
+  await notifyRegistry(dbAdapter, 'upsert', args.publishedRealmURL);
 }
 
 // Insert a source realm into realm_registry. Called from server.ts:createRealm
@@ -80,7 +110,9 @@ export async function mirrorSourceRealmToRegistry(
     log.warn(
       `failed to mirror source-realm create to realm_registry for ${args.url}: ${String(err)}; will self-heal on next boot`,
     );
+    return;
   }
+  await notifyRegistry(dbAdapter, 'upsert', args.url);
 }
 
 // Delete a single row from realm_registry by url. Used by
@@ -100,7 +132,9 @@ export async function deleteFromRegistryByUrl(
     log.warn(
       `failed to delete realm_registry row for ${url}: ${String(err)}; will self-heal on next boot`,
     );
+    return;
   }
+  await notifyRegistry(dbAdapter, 'delete', url);
 }
 
 // Delete every kind='published' row whose source_url matches the given source
@@ -123,5 +157,9 @@ export async function deletePublishedFromRegistryBySource(
     log.warn(
       `failed to delete published realm_registry rows for source ${sourceUrl}: ${String(err)}; will self-heal on next boot`,
     );
+    return;
   }
+  // Single NOTIFY keyed on the source URL. Reconcilers will re-read and see
+  // all deletes; the payload is a hint, not a precise per-row signal.
+  await notifyRegistry(dbAdapter, 'delete', sourceUrl);
 }

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -538,9 +538,13 @@ const getIndexHTML = async () => {
             : {}),
         },
       );
+      // start() before push/mount: if start() throws (e.g., fullIndex fails
+      // transiently), we don't want a half-initialized Realm sitting in
+      // `realms[]` and `virtualNetwork` where the next reconcile pass would
+      // double-mount it. Wait for start to succeed, then publish.
+      await reconciledRealm.start();
       realms.push(reconciledRealm);
       virtualNetwork.mount(reconciledRealm.handle);
-      await reconciledRealm.start();
       return reconciledRealm;
     },
     unmount: async (realm) => {

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -13,7 +13,7 @@ import {
 import { NodeAdapter } from './node-realm';
 import yargs from 'yargs';
 import { RealmServer } from './server';
-import { resolve } from 'path';
+import { join, resolve } from 'path';
 import * as Sentry from '@sentry/node';
 import { PgAdapter, PgQueuePublisher } from '@cardstack/postgres';
 import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
@@ -31,7 +31,12 @@ import {
   deregisterEnvironment,
 } from './lib/dev-service-registry';
 import { writeRuntimeMetadataFile } from './lib/runtime-metadata-file';
-import { runRegistryBackfill } from './lib/realm-registry-backfill';
+import { runRegistryBackfillWithAdvisoryLock } from './lib/realm-registry-backfill';
+import {
+  RealmRegistryReconciler,
+  type RealmRegistryRow,
+} from './lib/realm-registry-reconciler';
+import { PUBLISHED_DIRECTORY_NAME } from '@cardstack/runtime-common';
 
 (globalThis as any).ContentTagGlobal = ContentTagGlobal;
 
@@ -273,6 +278,7 @@ const getIndexHTML = async () => {
   let realms: Realm[] = [];
   let dbAdapter = new PgAdapter({ autoMigrate });
   let queue = new PgQueuePublisher(dbAdapter);
+  let reconciler: RealmRegistryReconciler | undefined;
 
   if (workerManagerUrl) {
     await waitForWorkerManager(workerManagerUrl);
@@ -305,7 +311,9 @@ const getIndexHTML = async () => {
   // and on-disk published realms. Runs before Realm construction so the
   // registry reflects known state before anything mounts. Shadow data only in
   // Phase 1: no reader depends on these rows yet (see CS-10888, CS-10889).
-  await runRegistryBackfill({
+  // Guarded by a pg advisory lock so, in a future multi-instance deployment,
+  // only one process does the disk scan per startup wave (CS-10890).
+  await runRegistryBackfillWithAdvisoryLock(dbAdapter, {
     dbAdapter,
     realmsRootPath,
     serverURL: new URL(String(serverURL)),
@@ -428,13 +436,19 @@ const getIndexHTML = async () => {
     }
     httpServer.closeAllConnections();
     httpServer.close(() => {
-      queue.destroy(); // warning this is async
-      dbAdapter.close(); // warning this is async
-      console.log(`realm server on port ${stopPort} has stopped`);
-      if (notifyParent && process.send) {
-        process.send('stopped');
-      }
-      process.exit(0);
+      (async () => {
+        await reconciler?.shutDown();
+        queue.destroy(); // warning this is async
+        dbAdapter.close(); // warning this is async
+        console.log(`realm server on port ${stopPort} has stopped`);
+        if (notifyParent && process.send) {
+          process.send('stopped');
+        }
+        process.exit(0);
+      })().catch((err) => {
+        console.error('error during shutdown', err);
+        process.exit(1);
+      });
     });
   };
   process.on('message', (message) => {
@@ -477,6 +491,69 @@ const getIndexHTML = async () => {
   });
 
   await server.start();
+
+  // Start the registry reconciler after server.start() so legacy loadRealms()
+  // has already mounted everything from disk. registerExistingMounts snapshots
+  // those into the reconciler's `mounted` map so it doesn't try to re-mount
+  // them on its first reconcile pass. Phase 2 coexistence: legacy mount path
+  // and reconciler both maintain `realms[]` and `virtualNetwork` as they go.
+  // Phase 3 will remove the legacy path and the reconciler becomes the sole
+  // owner of mount/unmount.
+  reconciler = new RealmRegistryReconciler({
+    dbAdapter,
+    mountFromRow: async (row: RealmRegistryRow) => {
+      let diskPath: string;
+      if (row.kind === 'bootstrap') {
+        diskPath = row.disk_id;
+      } else if (row.kind === 'source') {
+        diskPath = join(realmsRootPath, row.disk_id);
+      } else {
+        diskPath = join(realmsRootPath, PUBLISHED_DIRECTORY_NAME, row.disk_id);
+      }
+      const reconciledAdapter = new NodeAdapter(diskPath, ENABLE_FILE_WATCHER);
+      const reconciledRealm = new Realm(
+        {
+          url: row.url,
+          adapter: reconciledAdapter,
+          secretSeed: REALM_SECRET_SEED,
+          virtualNetwork,
+          dbAdapter,
+          queue,
+          matrixClient,
+          realmServerURL: serverURL,
+          definitionLookup,
+          cardSizeLimitBytes: Number(
+            process.env.CARD_SIZE_LIMIT_BYTES ?? DEFAULT_CARD_SIZE_LIMIT_BYTES,
+          ),
+          fileSizeLimitBytes: Number(
+            process.env.FILE_SIZE_LIMIT_BYTES ?? DEFAULT_FILE_SIZE_LIMIT_BYTES,
+          ),
+        },
+        {
+          ...(FULL_INDEX_ON_STARTUP
+            ? { fullIndexOnStartup: true as const }
+            : {}),
+          ...(process.env.DISABLE_MODULE_CACHING === 'true'
+            ? { disableModuleCaching: true }
+            : {}),
+        },
+      );
+      realms.push(reconciledRealm);
+      virtualNetwork.mount(reconciledRealm.handle);
+      await reconciledRealm.start();
+      return reconciledRealm;
+    },
+    unmount: async (realm) => {
+      realm.unsubscribe();
+      virtualNetwork.unmount(realm.handle);
+      const idx = realms.indexOf(realm);
+      if (idx >= 0) {
+        realms.splice(idx, 1);
+      }
+    },
+  });
+  reconciler.registerExistingMounts(realms);
+  reconciler.start();
 
   let actualPort =
     (httpServer.address() as import('net').AddressInfo | null)?.port ?? port;

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -182,6 +182,7 @@ import './run-command-task-test';
 import './realm-endpoints-test';
 import './realm-endpoints/dependencies-test';
 import './realm-registry-backfill-test';
+import './realm-registry-reconciler-test';
 import './realm-registry-writes-test';
 import './realm-endpoints/directory-test';
 import './realm-endpoints/info-test';

--- a/packages/realm-server/tests/realm-registry-reconciler-test.ts
+++ b/packages/realm-server/tests/realm-registry-reconciler-test.ts
@@ -1,0 +1,269 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import type { PgAdapter } from '@cardstack/postgres';
+import type { Realm } from '@cardstack/runtime-common';
+import { asExpressions, insert, query } from '@cardstack/runtime-common';
+import { setupDB } from './helpers';
+import {
+  RealmRegistryReconciler,
+  type RealmRegistryRow,
+} from '../lib/realm-registry-reconciler';
+
+// Minimal fake `Realm` — we only care about `.url` and the unsubscribe()
+// stub. Reconciler treats Realm as opaque except for the URL it uses as
+// the map key.
+function makeFakeRealm(url: string): Realm {
+  return {
+    url,
+    unsubscribe() {},
+    handle: null,
+  } as unknown as Realm;
+}
+
+async function seedRow(
+  dbAdapter: PgAdapter,
+  row: Partial<RealmRegistryRow> & {
+    url: string;
+    kind: RealmRegistryRow['kind'];
+    disk_id: string;
+    owner_username: string;
+  },
+) {
+  const { nameExpressions, valueExpressions } = asExpressions({
+    url: row.url,
+    kind: row.kind,
+    disk_id: row.disk_id,
+    owner_username: row.owner_username,
+    source_url: row.source_url ?? null,
+    last_published_at: row.last_published_at ?? null,
+    pinned: row.pinned ?? false,
+  });
+  await query(
+    dbAdapter,
+    insert('realm_registry', nameExpressions, valueExpressions),
+  );
+}
+
+async function deleteRow(dbAdapter: PgAdapter, url: string) {
+  await query(dbAdapter, [
+    `DELETE FROM realm_registry WHERE url = '${url.replace(/'/g, "''")}'`,
+  ]);
+}
+
+module(basename(__filename), function () {
+  module('RealmRegistryReconciler', function (hooks) {
+    let dbAdapter: PgAdapter;
+    let mountCalls: string[];
+    let unmountCalls: string[];
+    let reconciler: RealmRegistryReconciler;
+
+    setupDB(hooks, {
+      beforeEach: async (adapter) => {
+        dbAdapter = adapter;
+        mountCalls = [];
+        unmountCalls = [];
+        reconciler = new RealmRegistryReconciler({
+          dbAdapter,
+          mountFromRow: async (row) => {
+            mountCalls.push(row.url);
+            return makeFakeRealm(row.url);
+          },
+          unmount: async (realm) => {
+            unmountCalls.push(realm.url);
+          },
+          // Short poll for tests, though we drive reconcile() manually
+          // rather than starting the loop.
+          pollIntervalMs: 1000,
+        });
+      },
+    });
+
+    test('reconcile populates knownByUrl from the registry', async function (assert) {
+      await seedRow(dbAdapter, {
+        url: 'http://localhost:4201/luke/src/',
+        kind: 'source',
+        disk_id: 'luke/src',
+        owner_username: 'luke',
+      });
+      await seedRow(dbAdapter, {
+        url: 'https://cardstack.com/base/',
+        kind: 'bootstrap',
+        disk_id: '/abs/base',
+        owner_username: 'system',
+        pinned: true,
+      });
+
+      await reconciler.reconcile();
+
+      assert.strictEqual(reconciler.knownByUrl.size, 2);
+      assert.strictEqual(
+        reconciler.knownByUrl.get('http://localhost:4201/luke/src/')?.kind,
+        'source',
+      );
+      assert.strictEqual(
+        reconciler.knownByUrl.get('https://cardstack.com/base/')?.kind,
+        'bootstrap',
+      );
+      assert.true(reconciler.knownByUrl.get('https://cardstack.com/base/')!.pinned);
+    });
+
+    test('reconcile mounts rows absent from the mounted map', async function (assert) {
+      await seedRow(dbAdapter, {
+        url: 'http://localhost:4201/luke/src/',
+        kind: 'source',
+        disk_id: 'luke/src',
+        owner_username: 'luke',
+      });
+
+      await reconciler.reconcile();
+
+      assert.deepEqual(mountCalls, ['http://localhost:4201/luke/src/']);
+      assert.strictEqual(reconciler.mounted.size, 1);
+      assert.ok(reconciler.mounted.get('http://localhost:4201/luke/src/'));
+    });
+
+    test('registerExistingMounts suppresses re-mount for realms the legacy path already mounted', async function (assert) {
+      const url = 'http://localhost:4201/luke/src/';
+      await seedRow(dbAdapter, {
+        url,
+        kind: 'source',
+        disk_id: 'luke/src',
+        owner_username: 'luke',
+      });
+
+      reconciler.registerExistingMounts([makeFakeRealm(url)]);
+      await reconciler.reconcile();
+
+      assert.deepEqual(
+        mountCalls,
+        [],
+        'mountFromRow not called because URL was already registered as mounted',
+      );
+      assert.strictEqual(reconciler.mounted.size, 1);
+    });
+
+    test('reconcile unmounts realms whose registry rows have been deleted', async function (assert) {
+      const url = 'http://localhost:4201/luke/src/';
+      await seedRow(dbAdapter, {
+        url,
+        kind: 'source',
+        disk_id: 'luke/src',
+        owner_username: 'luke',
+      });
+      await reconciler.reconcile();
+      assert.strictEqual(reconciler.mounted.size, 1, 'mounted after first reconcile');
+
+      await deleteRow(dbAdapter, url);
+      await reconciler.reconcile();
+
+      assert.deepEqual(unmountCalls, [url], 'unmount called for removed row');
+      assert.strictEqual(reconciler.mounted.size, 0, 'mounted map cleared');
+    });
+
+    test('ensureMounted serializes concurrent callers for the same URL', async function (assert) {
+      let resolveMount: ((r: Realm) => void) | undefined;
+      let mountInvocations = 0;
+      const localReconciler = new RealmRegistryReconciler({
+        dbAdapter,
+        mountFromRow: async (row) => {
+          mountInvocations += 1;
+          return await new Promise<Realm>((r) => {
+            resolveMount = r;
+          }).then(() => makeFakeRealm(row.url));
+        },
+        unmount: async () => {},
+      });
+
+      const row: RealmRegistryRow = {
+        id: 'x',
+        url: 'http://localhost:4201/foo/',
+        kind: 'source',
+        disk_id: 'foo',
+        owner_username: 'foo',
+        source_url: null,
+        last_published_at: null,
+        pinned: false,
+      };
+      const p1 = localReconciler.ensureMounted(row);
+      const p2 = localReconciler.ensureMounted(row);
+      assert.strictEqual(mountInvocations, 1, 'only one mount invocation in flight');
+
+      resolveMount!(makeFakeRealm(row.url));
+      const [r1, r2] = await Promise.all([p1, p2]);
+      assert.strictEqual(r1, r2, 'both callers receive the same Realm instance');
+      assert.strictEqual(mountInvocations, 1, 'still only one mount invocation after settle');
+    });
+
+    test('ensureMounted clears pendingMounts so a retry after failure fires a fresh mount', async function (assert) {
+      let attempt = 0;
+      const localReconciler = new RealmRegistryReconciler({
+        dbAdapter,
+        mountFromRow: async (row) => {
+          attempt += 1;
+          if (attempt === 1) {
+            throw new Error('transient failure');
+          }
+          return makeFakeRealm(row.url);
+        },
+        unmount: async () => {},
+      });
+
+      const row: RealmRegistryRow = {
+        id: 'x',
+        url: 'http://localhost:4201/retry/',
+        kind: 'source',
+        disk_id: 'retry',
+        owner_username: 'foo',
+        source_url: null,
+        last_published_at: null,
+        pinned: false,
+      };
+
+      await assert.rejects(localReconciler.ensureMounted(row), /transient failure/);
+      assert.strictEqual(localReconciler.pendingMounts.size, 0, 'pendingMounts cleared after failure');
+
+      const realm = await localReconciler.ensureMounted(row);
+      assert.ok(realm, 'retry succeeded');
+      assert.strictEqual(attempt, 2, 'mountFromRow invoked a second time');
+    });
+
+    test('reconcile failure in one row does not prevent mounting the others', async function (assert) {
+      let failing = true;
+      const localReconciler = new RealmRegistryReconciler({
+        dbAdapter,
+        mountFromRow: async (row) => {
+          if (row.url.includes('bad')) {
+            throw new Error('mount blew up');
+          }
+          return makeFakeRealm(row.url);
+        },
+        unmount: async () => {},
+      });
+      void failing;
+
+      await seedRow(dbAdapter, {
+        url: 'http://localhost:4201/luke/bad/',
+        kind: 'source',
+        disk_id: 'luke/bad',
+        owner_username: 'luke',
+      });
+      await seedRow(dbAdapter, {
+        url: 'http://localhost:4201/luke/good/',
+        kind: 'source',
+        disk_id: 'luke/good',
+        owner_username: 'luke',
+      });
+
+      await localReconciler.reconcile();
+
+      assert.ok(
+        localReconciler.mounted.has('http://localhost:4201/luke/good/'),
+        'good row mounted despite sibling failure',
+      );
+      assert.notOk(
+        localReconciler.mounted.has('http://localhost:4201/luke/bad/'),
+        'bad row not mounted',
+      );
+    });
+  });
+});

--- a/packages/realm-server/tests/realm-registry-reconciler-test.ts
+++ b/packages/realm-server/tests/realm-registry-reconciler-test.ts
@@ -104,7 +104,9 @@ module(basename(__filename), function () {
         reconciler.knownByUrl.get('https://cardstack.com/base/')?.kind,
         'bootstrap',
       );
-      assert.true(reconciler.knownByUrl.get('https://cardstack.com/base/')!.pinned);
+      assert.true(
+        reconciler.knownByUrl.get('https://cardstack.com/base/')!.pinned,
+      );
     });
 
     test('reconcile mounts rows absent from the mounted map', async function (assert) {
@@ -151,7 +153,11 @@ module(basename(__filename), function () {
         owner_username: 'luke',
       });
       await reconciler.reconcile();
-      assert.strictEqual(reconciler.mounted.size, 1, 'mounted after first reconcile');
+      assert.strictEqual(
+        reconciler.mounted.size,
+        1,
+        'mounted after first reconcile',
+      );
 
       await deleteRow(dbAdapter, url);
       await reconciler.reconcile();
@@ -186,12 +192,24 @@ module(basename(__filename), function () {
       };
       const p1 = localReconciler.ensureMounted(row);
       const p2 = localReconciler.ensureMounted(row);
-      assert.strictEqual(mountInvocations, 1, 'only one mount invocation in flight');
+      assert.strictEqual(
+        mountInvocations,
+        1,
+        'only one mount invocation in flight',
+      );
 
       resolveMount!(makeFakeRealm(row.url));
       const [r1, r2] = await Promise.all([p1, p2]);
-      assert.strictEqual(r1, r2, 'both callers receive the same Realm instance');
-      assert.strictEqual(mountInvocations, 1, 'still only one mount invocation after settle');
+      assert.strictEqual(
+        r1,
+        r2,
+        'both callers receive the same Realm instance',
+      );
+      assert.strictEqual(
+        mountInvocations,
+        1,
+        'still only one mount invocation after settle',
+      );
     });
 
     test('ensureMounted clears pendingMounts so a retry after failure fires a fresh mount', async function (assert) {
@@ -219,8 +237,15 @@ module(basename(__filename), function () {
         pinned: false,
       };
 
-      await assert.rejects(localReconciler.ensureMounted(row), /transient failure/);
-      assert.strictEqual(localReconciler.pendingMounts.size, 0, 'pendingMounts cleared after failure');
+      await assert.rejects(
+        localReconciler.ensureMounted(row),
+        /transient failure/,
+      );
+      assert.strictEqual(
+        localReconciler.pendingMounts.size,
+        0,
+        'pendingMounts cleared after failure',
+      );
 
       const realm = await localReconciler.ensureMounted(row);
       assert.ok(realm, 'retry succeeded');

--- a/packages/realm-server/tests/realm-registry-reconciler-test.ts
+++ b/packages/realm-server/tests/realm-registry-reconciler-test.ts
@@ -144,6 +144,29 @@ module(basename(__filename), function () {
       assert.strictEqual(reconciler.mounted.size, 1);
     });
 
+    test('does NOT unmount legacy-registered mounts when they are absent from the registry', async function (assert) {
+      // Simulates the multi-instance race where this instance skipped its
+      // backfill (peer holds the advisory lock) and sees a registry that
+      // doesn't (yet) include realms the legacy loadRealms path already
+      // mounted. The reconciler must preserve those — their lifecycle
+      // belongs to the legacy handler path in Phase 2.
+      const legacyUrl = 'http://localhost:4201/luke/legacy/';
+      reconciler.registerExistingMounts([makeFakeRealm(legacyUrl)]);
+
+      // Registry is empty — no matching row for the legacy realm.
+      await reconciler.reconcile();
+
+      assert.deepEqual(
+        unmountCalls,
+        [],
+        'legacy-registered mount was not torn down despite missing registry row',
+      );
+      assert.ok(
+        reconciler.mounted.has(legacyUrl),
+        'legacy mount still in mounted map',
+      );
+    });
+
     test('reconcile unmounts realms whose registry rows have been deleted', async function (assert) {
       const url = 'http://localhost:4201/luke/src/';
       await seedRow(dbAdapter, {
@@ -253,7 +276,6 @@ module(basename(__filename), function () {
     });
 
     test('reconcile failure in one row does not prevent mounting the others', async function (assert) {
-      let failing = true;
       const localReconciler = new RealmRegistryReconciler({
         dbAdapter,
         mountFromRow: async (row) => {
@@ -264,7 +286,6 @@ module(basename(__filename), function () {
         },
         unmount: async () => {},
       });
-      void failing;
 
       await seedRow(dbAdapter, {
         url: 'http://localhost:4201/luke/bad/',


### PR DESCRIPTION
## Summary

Stacked on #4503. Adds the Phase 2 coordination layer so future multi-instance deployment can rely on a single source of truth for realm lifecycle state.

Three pieces:

### 1. `RealmRegistryReconciler` ([lib/realm-registry-reconciler.ts](https://github.com/cardstack/boxel/blob/cs-10890-realm-registry-reconciler/packages/realm-server/lib/realm-registry-reconciler.ts))

A class that maintains three maps:
- `knownByUrl` — every row the reconciler has seen (in-memory reflection of `realm_registry`)
- `mounted` — the subset with a live `Realm` on this process (what the legacy `realms[]` array tracks)
- `pendingMounts` — URL-keyed in-flight mount promises for concurrent-caller serialization (used by the Phase 3 request path)

Runs a `WorkLoop`-driven **LISTEN on `realm_registry` + 30s poll** loop. On wake, re-reads the registry and applies the diff: mount anything new, unmount anything removed. Exposes `ensureMounted(row)` with per-URL promise-map serialization.

**Phase 2 behavior (this PR):** coexists with the legacy `server.ts:loadRealms` via `registerExistingMounts(realms)` — snapshots the legacy-mounted realms into `mounted` so the reconciler doesn't re-mount them. Phase 3 will remove the legacy path and the reconciler owns all mounting.

### 2. NOTIFY emission from CS-10889's dual-write helpers

After each successful `INSERT`/`DELETE` on `realm_registry`, emit `SELECT pg_notify('realm_registry', '<op>:<url>')`. Reconcilers on peer instances wake from LISTEN and re-read the registry. Failure to NOTIFY is logged but not fatal — the 30s poll is the safety net.

### 3. Boot advisory lock

`runRegistryBackfillWithAdvisoryLock` in `lib/realm-registry-backfill.ts` runs the Phase 1 PR 2 boot-time backfill under `pg_try_advisory_lock(REGISTRY_BACKFILL_LOCK_ID)`. In a future multi-instance deployment, only one process performs the boot scan per startup wave. Pinned via `dbAdapter.withConnection` so the session-scoped lock releases cleanly before the connection returns to the pool.

## Design notes

- **`WorkLoop` exported from `@cardstack/postgres`** (single-word diff in pg-queue.ts). The reconciler reuses it rather than reimplementing the wake-or-poll-until-shutdown pattern.
- **Phase 2 is additive** — nothing existing changes behavior. Legacy `loadRealms`, handler direct-mounts, and the CS-10889 dual-writes all still work; the reconciler sits alongside and is exercised as a no-op in the common case (each reconcile pass sees the URL already in `mounted` and skips).
- **Session-scoped advisory lock** requires a pinned connection. `dbAdapter.withConnection` provides that; the lock is explicitly released before the pinned connection returns to the pool to prevent leaking. In the uncontended single-instance case this adds one negligible acquire+release to boot.
- **mountFromRow factory in main.ts** duplicates what the existing `main.ts:303-344` CLI-realm mount loop does, extended to all three `kind` values. Phase 3 collapses these two code paths into one.
- **Shutdown**: `reconciler.shutDown()` is awaited before `queue.destroy()` and `dbAdapter.close()` so the LISTEN client ends gracefully.

## Test plan

- [x] `pnpm lint:types` — clean
- [x] `pnpm lint:js` — clean
- [x] New reconciler qunit suite (`realm-registry-reconciler-test.ts`) — **7/7 passing**:
  - `knownByUrl` populated from registry
  - Mounts rows absent from `mounted`
  - `registerExistingMounts` suppresses re-mount
  - Unmounts rows whose registry entries are deleted
  - `ensureMounted` per-URL serialization (two concurrent callers, one mount)
  - `pendingMounts` cleared on failure so retry fires fresh
  - Per-row failure isolation during reconcile
- [x] Existing registry tests still pass with NOTIFY added (writes 11/11, backfill 7/7)
- [ ] CI integration-test sweep

## Review guidance

Stacked on #4503 (which is stacked on #4501 → #4499). Review in that order; land in that order. The diff shown here includes only the CS-10890 changes on top of #4503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)