### PR TITLE
Bump atomic update test poll timeout to 30s

### DIFF
--- a/packages/realm-server/tests/atomic-endpoints-test.ts
+++ b/packages/realm-server/tests/atomic-endpoints-test.ts
@@ -884,17 +884,19 @@ module(basename(__filename), function () {
           assert.strictEqual(response.status, 201);
           assert.strictEqual(response.body['atomic:results'].length, 1);
 
-          // GET reads via the index; under CI load the index write can
-          // lag the 201 response, so poll until it catches up. Match the
-          // 30s budget publish-unpublish-realm-test uses for prerender/index
-          // waits — the common failure mode is a slow first-instance
-          // prerender, not a stuck one.
+          // The atomic POST awaits indexing, so by 201 boxel_index should
+          // be updated. The remaining CI flake is read-path readiness —
+          // most often a slow first-instance prerender / module-cache
+          // populate that the GET is waiting on. Match the 30s budget
+          // publish-unpublish-realm-test uses for the same class of wait.
           let updatedCard: LooseSingleCardDocument | undefined;
+          let lastStatus: number | undefined;
           await waitUntil(
             async () => {
               let updatedCardResponse = await request
                 .get('/update-person')
                 .set('Accept', SupportedMimeType.CardJson);
+              lastStatus = updatedCardResponse.status;
               updatedCard = updatedCardResponse.body as
                 | LooseSingleCardDocument
                 | undefined;
@@ -903,8 +905,8 @@ module(basename(__filename), function () {
             {
               timeout: 30_000,
               interval: 100,
-              timeoutMessage:
-                'updated firstName was not visible via /update-person',
+              timeoutMessage: () =>
+                `updated firstName was not visible via /update-person (last GET status=${lastStatus}, last firstName=${JSON.stringify(updatedCard?.data?.attributes?.firstName)})`,
             },
           );
           assert.strictEqual(

--- a/packages/realm-server/tests/atomic-endpoints-test.ts
+++ b/packages/realm-server/tests/atomic-endpoints-test.ts
@@ -884,8 +884,11 @@ module(basename(__filename), function () {
           assert.strictEqual(response.status, 201);
           assert.strictEqual(response.body['atomic:results'].length, 1);
 
-          // GET reads via the index; under load the index write can briefly
-          // lag the 201 response, so poll until it catches up.
+          // GET reads via the index; under CI load the index write can
+          // lag the 201 response, so poll until it catches up. Match the
+          // 30s budget publish-unpublish-realm-test uses for prerender/index
+          // waits — the common failure mode is a slow first-instance
+          // prerender, not a stuck one.
           let updatedCard: LooseSingleCardDocument | undefined;
           await waitUntil(
             async () => {
@@ -898,8 +901,8 @@ module(basename(__filename), function () {
               return updatedCard?.data?.attributes?.firstName === 'Updated';
             },
             {
-              timeout: 3000,
-              interval: 50,
+              timeout: 30_000,
+              interval: 100,
               timeoutMessage:
                 'updated firstName was not visible via /update-person',
             },

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -158,7 +158,7 @@ export async function waitUntil<T>(
   options: {
     timeout?: number;
     interval?: number;
-    timeoutMessage?: string;
+    timeoutMessage?: string | (() => string);
   } = {},
 ): Promise<T> {
   let timeout = options.timeout ?? 1000;
@@ -172,9 +172,12 @@ export async function waitUntil<T>(
     }
     await new Promise((resolve) => setTimeout(resolve, interval));
   }
+  let message =
+    typeof options.timeoutMessage === 'function'
+      ? options.timeoutMessage()
+      : options.timeoutMessage;
   throw new Error(
-    'Timeout waiting for condition' +
-      (options.timeoutMessage ? `: ${options.timeoutMessage}` : ''),
+    'Timeout waiting for condition' + (message ? `: ${message}` : ''),
   );
 }
 


### PR DESCRIPTION
## Summary
- The 3s poll landed in #4494 still times out on CI — see the failure on [run 24858269555](https://github.com/cardstack/boxel/actions/runs/24858269555/job/72777350938?pr=4505): 6s total test time, the full 3s eaten by the poll and \`firstName: 'Updated'\` never observed.
- The atomic endpoint awaits indexing, so by 201 the stable \`boxel_index\` should be updated. The leading hypothesis for the remaining lag is slow first-render prerender under CI load (module cache miss, cold Chrome tab acquisition), which is already the known cause elsewhere in the suite — \`publish-unpublish-realm-test\` keeps a 30s budget for the same class of wait.
- Bump this poll to \`timeout: 30_000, interval: 100\` to match that precedent. If it still flakes at 30s the signal is a real \"update path never propagates\" bug and we'd want diagnostics on the write path, not more polling.

## Test plan
- [ ] CI green on \`atomic-endpoints-test.ts\` across reruns (re-run the specific job from run 24858269555 to confirm)
- [ ] If the timeout is still exhausted, treat it as a write-path bug and file a follow-up rather than bumping again

🤖 Generated with [Claude Code](https://claude.com/claude-code)