### PR TITLE
CS-10947: coalesce concurrent CachingDefinitionLookup requests for the same module

### DIFF
--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -1247,5 +1247,264 @@ module(basename(__filename), function () {
         'prerenderModule not called again — healthy entry is cached',
       );
     });
+
+    test('coalesces concurrent lookups of the same module into one prerender call', async function (assert) {
+      await dbAdapter.execute('DELETE FROM modules');
+
+      let moduleURL = `${realmURL}coalesce-same.gts`;
+      let calls = 0;
+      let releaseGate!: () => void;
+      let gate = new Promise<void>((resolve) => {
+        releaseGate = resolve;
+      });
+
+      let prerenderer: Prerenderer = {
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls++;
+          await gate;
+          return buildModuleResponse(args.url, 'CoalesceSame', []);
+        },
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      let p1 = lookup.lookupDefinition({
+        module: moduleURL,
+        name: 'CoalesceSame',
+      });
+      let p2 = lookup.lookupDefinition({
+        module: moduleURL,
+        name: 'CoalesceSame',
+      });
+      let p3 = lookup.lookupDefinition({
+        module: moduleURL,
+        name: 'CoalesceSame',
+      });
+
+      // Flush queued microtasks so all three calls reach the in-flight gate
+      // before the prerender resolves.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      releaseGate();
+      let [d1, d2, d3] = await Promise.all([p1, p2, p3]);
+
+      assert.strictEqual(
+        calls,
+        1,
+        'prerenderModule called once for three concurrent same-module lookups',
+      );
+      assert.strictEqual(d1?.displayName, 'CoalesceSame');
+      assert.strictEqual(d2?.displayName, 'CoalesceSame');
+      assert.strictEqual(d3?.displayName, 'CoalesceSame');
+    });
+
+    test('does not coalesce concurrent lookups of different modules', async function (assert) {
+      await dbAdapter.execute('DELETE FROM modules');
+
+      let moduleA = `${realmURL}coalesce-a.gts`;
+      let moduleB = `${realmURL}coalesce-b.gts`;
+      let calls = new Map<string, number>();
+      let releaseGate!: () => void;
+      let gate = new Promise<void>((resolve) => {
+        releaseGate = resolve;
+      });
+
+      let prerenderer: Prerenderer = {
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls.set(args.url, (calls.get(args.url) ?? 0) + 1);
+          await gate;
+          let name = args.url === moduleA ? 'CoalesceA' : 'CoalesceB';
+          return buildModuleResponse(args.url, name, []);
+        },
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      let pA = lookup.lookupDefinition({
+        module: moduleA,
+        name: 'CoalesceA',
+      });
+      let pB = lookup.lookupDefinition({
+        module: moduleB,
+        name: 'CoalesceB',
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      releaseGate();
+      let [dA, dB] = await Promise.all([pA, pB]);
+
+      assert.strictEqual(
+        calls.get(moduleA),
+        1,
+        'prerenderModule called once for module A',
+      );
+      assert.strictEqual(
+        calls.get(moduleB),
+        1,
+        'prerenderModule called once for module B',
+      );
+      assert.strictEqual(dA?.displayName, 'CoalesceA');
+      assert.strictEqual(dB?.displayName, 'CoalesceB');
+    });
+
+    test('shares errored prerender result with concurrent waiters and releases in-flight slot on rejection', async function (assert) {
+      await dbAdapter.execute('DELETE FROM modules');
+
+      let moduleURL = `${realmURL}coalesce-error.gts`;
+      let calls = 0;
+      let releaseGate!: () => void;
+      let gate = new Promise<void>((resolve) => {
+        releaseGate = resolve;
+      });
+
+      let prerenderer: Prerenderer = {
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls++;
+          await gate;
+          return buildModuleResponse(args.url, 'CoalesceError', [], {
+            type: 'module-error',
+            error: {
+              id: args.url,
+              message: 'simulated prerender failure',
+              status: 500,
+              title: 'Render error',
+              deps: [],
+              additionalErrors: null,
+            },
+          });
+        },
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      let p1 = lookup.lookupDefinition({
+        module: moduleURL,
+        name: 'CoalesceError',
+      });
+      let p2 = lookup.lookupDefinition({
+        module: moduleURL,
+        name: 'CoalesceError',
+      });
+      let p3 = lookup.lookupDefinition({
+        module: moduleURL,
+        name: 'CoalesceError',
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      releaseGate();
+      let results = await Promise.allSettled([p1, p2, p3]);
+
+      assert.strictEqual(
+        calls,
+        1,
+        'prerenderModule called once for three concurrent erroring lookups',
+      );
+      for (let result of results) {
+        assert.strictEqual(
+          result.status,
+          'rejected',
+          'all concurrent waiters receive the shared rejection',
+        );
+      }
+
+      // The error row is persisted with a fresh timestamp, so a follow-up
+      // lookup should be served from the cache without re-invoking prerender.
+      await assert.rejects(
+        lookup.lookupDefinition({
+          module: moduleURL,
+          name: 'CoalesceError',
+        }),
+        /nonexistent type/,
+      );
+      assert.strictEqual(
+        calls,
+        1,
+        'follow-up lookup after settle hits cached error without a new prerender',
+      );
+
+      // Backdate the cached error past the TTL to simulate a stale error.
+      // The in-flight slot must have been released for the next call to form
+      // a fresh prerender gate rather than awaiting the already-settled
+      // in-flight promise and returning its rejection.
+      await dbAdapter.execute(
+        `UPDATE modules SET created_at = $1 WHERE url = $2`,
+        { bind: [Date.now() - 60_000, moduleURL] },
+      );
+
+      await assert.rejects(
+        lookup.lookupDefinition({
+          module: moduleURL,
+          name: 'CoalesceError',
+        }),
+        /nonexistent type/,
+      );
+      assert.strictEqual(
+        calls,
+        2,
+        'stale cached error triggers a fresh prerender — in-flight slot was released after prior failure',
+      );
+    });
   });
 });

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -1301,8 +1301,11 @@ module(basename(__filename), function () {
         name: 'CoalesceSame',
       });
 
-      // Flush queued microtasks so all three calls reach the in-flight gate
-      // before the prerender resolves.
+      // Yield to the event loop so all three calls drain through the
+      // buildLookupContext awaits and reach the in-flight gate before we
+      // release it. setTimeout(0) crosses the macrotask boundary, which
+      // drains every pending microtask — more reliable than a single
+      // `await Promise.resolve()` when there are several chained awaits.
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       releaseGate();
@@ -1505,6 +1508,105 @@ module(basename(__filename), function () {
         2,
         'stale cached error triggers a fresh prerender — in-flight slot was released after prior failure',
       );
+    });
+
+    test('invalidate drops in-flight entries so post-invalidation lookups do not join the stale promise', async function (assert) {
+      await dbAdapter.execute('DELETE FROM modules');
+
+      let moduleURL = `${realmURL}coalesce-invalidate.gts`;
+      let calls = 0;
+      let releaseGate!: () => void;
+      let gate = new Promise<void>((resolve) => {
+        releaseGate = resolve;
+      });
+
+      let prerenderer: Prerenderer = {
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls++;
+          let version = calls;
+          await gate;
+          let definitionId = internalKeyFor(
+            { module: args.url, name: 'CoalesceInvalidate' },
+            undefined,
+          );
+          let moduleAlias = trimExecutableExtension(new URL(args.url)).href;
+          return {
+            id: args.url,
+            status: 'ready',
+            nonce: 'test-nonce',
+            isShimmed: false,
+            lastModified: Date.now(),
+            createdAt: Date.now(),
+            deps: [],
+            definitions: {
+              [definitionId]: {
+                type: 'definition',
+                moduleURL: moduleAlias,
+                definition: {
+                  type: 'card-def',
+                  codeRef: {
+                    module: moduleAlias,
+                    name: 'CoalesceInvalidate',
+                  },
+                  displayName: `CoalesceInvalidate v${version}`,
+                  fields: {},
+                },
+                types: [],
+              },
+            },
+          };
+        },
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      // Caller A starts the prerender and parks at the gate.
+      let pA = lookup.lookupDefinition({
+        module: moduleURL,
+        name: 'CoalesceInvalidate',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Invalidate while A is still in flight; this must drop the in-flight
+      // slot so caller B doesn't piggyback on A's pre-invalidation promise.
+      await lookup.invalidate(moduleURL);
+
+      let pB = lookup.lookupDefinition({
+        module: moduleURL,
+        name: 'CoalesceInvalidate',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      releaseGate();
+      let [dA, dB] = await Promise.all([pA, pB]);
+
+      assert.strictEqual(
+        calls,
+        2,
+        'invalidate dropped the in-flight entry so caller B triggered its own prerender',
+      );
+      assert.strictEqual(dA?.displayName, 'CoalesceInvalidate v1');
+      assert.strictEqual(dB?.displayName, 'CoalesceInvalidate v2');
     });
   });
 });

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -77,10 +77,13 @@ function normalizeExecutableURL(url: string): string {
   }
 }
 
-// Dedup key matches the module cache row's identity:
-// (resolved_realm_url, cache_scope, auth_user_id, moduleURL). Two concurrent
-// callers that would hit the same row share one in-flight promise; callers
-// that would hit different rows do not collapse.
+// Application-level dedup key. Coalesces two concurrent lookups only when
+// they would hit the same (resolvedRealmURL, cache_scope, auth_user_id,
+// moduleURL) lookup context. This does NOT mirror the modules-table primary
+// key exactly: file_alias variants are intentionally not coalesced, because
+// a caller asking for an extensionless path walks a different
+// populationCandidates loop than a caller asking for `foo.gts` directly —
+// coalescing them could strand one behind the other's narrower search.
 function inFlightKey(args: {
   resolvedRealmURL: string;
   moduleURL: string;
@@ -499,6 +502,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     }
     let uniqueInvalidations = [...new Set(invalidations)];
     await this.deleteModuleAliases(resolvedRealmURL, uniqueInvalidations);
+    this.dropInFlightForRealm(resolvedRealmURL, uniqueInvalidations);
     return uniqueInvalidations;
   }
 
@@ -509,10 +513,47 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       'WHERE',
       ...(every([['resolved_realm_url =', param(realmURL)]]) as Expression),
     ]);
+    this.dropInFlightForRealm(realmURL);
   }
 
   async clearAllModules(): Promise<void> {
     await this.query(['DELETE FROM', MODULES_TABLE]);
+    this.#inFlight.clear();
+  }
+
+  // Drops in-flight entries whose pending prerender result would no longer
+  // be valid after a cache wipe, so post-invalidation callers don't join a
+  // pre-invalidation promise. If `moduleURLs` is provided, only entries
+  // under that realm matching one of those URLs are dropped; otherwise every
+  // in-flight entry for the realm is dropped. The already-running promises
+  // still complete (we can't cancel the prerender) and may re-persist a now-
+  // stale row, but that race is narrower than before and self-heals on the
+  // next fresh prerender. What this fully prevents is waiters joining the
+  // stale promise after the invalidation returned.
+  private dropInFlightForRealm(
+    resolvedRealmURL: string,
+    moduleURLs?: string[],
+  ): void {
+    if (this.#inFlight.size === 0) {
+      return;
+    }
+    if (!moduleURLs) {
+      let prefix = `${resolvedRealmURL}|`;
+      for (let key of [...this.#inFlight.keys()]) {
+        if (key.startsWith(prefix)) {
+          this.#inFlight.delete(key);
+        }
+      }
+      return;
+    }
+    for (let moduleURL of moduleURLs) {
+      let prefix = `${resolvedRealmURL}|${moduleURL}|`;
+      for (let key of [...this.#inFlight.keys()]) {
+        if (key.startsWith(prefix)) {
+          this.#inFlight.delete(key);
+        }
+      }
+    }
   }
 
   registerRealm(realm: LocalRealm): void {

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -77,6 +77,19 @@ function normalizeExecutableURL(url: string): string {
   }
 }
 
+// Dedup key matches the module cache row's identity:
+// (resolved_realm_url, cache_scope, auth_user_id, moduleURL). Two concurrent
+// callers that would hit the same row share one in-flight promise; callers
+// that would hit different rows do not collapse.
+function inFlightKey(args: {
+  resolvedRealmURL: string;
+  moduleURL: string;
+  cacheScope: CacheScope;
+  cacheUserId: string;
+}): string {
+  return `${args.resolvedRealmURL}|${args.moduleURL}|${args.cacheScope}|${args.cacheUserId}`;
+}
+
 function parseJsonValue<T>(value: T | string | null): T | null {
   if (value == null) {
     return null;
@@ -179,6 +192,10 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     userId: string,
     permissions: RealmPermissions,
   ) => string;
+  // Dedupes concurrent loadModuleCacheEntry calls that would hit the same
+  // cache row so a single prerenderer round-trip is shared by all waiters
+  // instead of each caller racing to the prerenderer independently.
+  #inFlight = new Map<string, Promise<ModuleCacheEntry | undefined>>();
 
   constructor(
     dbAdapter: DBAdapter,
@@ -265,7 +282,27 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     return await query(this.#dbAdapter, expression, coerceTypes);
   }
 
-  private async loadModuleCacheEntry({
+  private async loadModuleCacheEntry(args: {
+    moduleURL: string;
+    realmURL: string;
+    resolvedRealmURL: string;
+    cacheScope: CacheScope;
+    cacheUserId: string;
+    prerenderUserId: string;
+  }): Promise<ModuleCacheEntry | undefined> {
+    let key = inFlightKey(args);
+    let existing = this.#inFlight.get(key);
+    if (existing) {
+      return await existing;
+    }
+    let pending = this.loadModuleCacheEntryUncached(args).finally(() => {
+      this.#inFlight.delete(key);
+    });
+    this.#inFlight.set(key, pending);
+    return await pending;
+  }
+
+  private async loadModuleCacheEntryUncached({
     moduleURL,
     realmURL,
     resolvedRealmURL,

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -172,7 +172,7 @@ export interface DefinitionLookup {
     codeRef: ResolvedCodeRef,
   ): Promise<Definition | undefined>;
   invalidate(moduleURL: string): Promise<string[]>;
-  clearRealmCache(realmURL: string): Promise<void>;
+  clearRealmCache(resolvedRealmURL: string): Promise<void>;
   clearAllModules(): Promise<void>;
   registerRealm(realm: LocalRealm): void;
   forRealm(realm: LocalRealm): DefinitionLookup;
@@ -506,14 +506,16 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     return uniqueInvalidations;
   }
 
-  async clearRealmCache(realmURL: string): Promise<void> {
+  async clearRealmCache(resolvedRealmURL: string): Promise<void> {
     await this.query([
       'DELETE FROM',
       MODULES_TABLE,
       'WHERE',
-      ...(every([['resolved_realm_url =', param(realmURL)]]) as Expression),
+      ...(every([
+        ['resolved_realm_url =', param(resolvedRealmURL)],
+      ]) as Expression),
     ]);
-    this.dropInFlightForRealm(realmURL);
+    this.dropInFlightForRealm(resolvedRealmURL);
   }
 
   async clearAllModules(): Promise<void> {
@@ -546,12 +548,12 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       }
       return;
     }
-    for (let moduleURL of moduleURLs) {
-      let prefix = `${resolvedRealmURL}|${moduleURL}|`;
-      for (let key of [...this.#inFlight.keys()]) {
-        if (key.startsWith(prefix)) {
-          this.#inFlight.delete(key);
-        }
+    let prefixes = moduleURLs.map(
+      (moduleURL) => `${resolvedRealmURL}|${moduleURL}|`,
+    );
+    for (let key of [...this.#inFlight.keys()]) {
+      if (prefixes.some((prefix) => key.startsWith(prefix))) {
+        this.#inFlight.delete(key);
       }
     }
   }
@@ -1286,8 +1288,8 @@ class RealmScopedDefinitionLookup implements DefinitionLookup {
     return await this.#inner.invalidate(moduleURL);
   }
 
-  async clearRealmCache(realmURL: string): Promise<void> {
-    await this.#inner.clearRealmCache(realmURL);
+  async clearRealmCache(resolvedRealmURL: string): Promise<void> {
+    await this.#inner.clearRealmCache(resolvedRealmURL);
   }
 
   async clearAllModules(): Promise<void> {


### PR DESCRIPTION
## Summary

- Adds an in-flight dedup gate in `CachingDefinitionLookup.loadModuleCacheEntry` so N concurrent lookups for the same `(resolvedRealmURL, moduleURL, cacheScope, cacheUserId)` share one prerenderer round-trip instead of racing. Before: 10 cards needing `product.gts` → 10 separate `prerenderModule` calls on the module queue. After: 1 call + 9 waiters.
- The original body is renamed to `loadModuleCacheEntryUncached`; the new outer method keeps a `Map<key, pending-promise>`, returns the shared promise to waiters, and uses `.finally` to release the slot so later callers (e.g. after TTL expiry of a cached error) go through the full read/prerender/persist path again.

## Key shape

Key is `${resolvedRealmURL}|${moduleURL}|${cacheScope}|${cacheUserId}` — matches cache row identity at the URL level. Considered normalizing via `normalizeExecutableURL` so `foo.gts` and `foo` would coalesce, but rejected: a caller passing `foo` triggers the multi-extension `populationCandidates` loop, while a caller passing `foo.gts` only tries `foo.gts`. Coalescing them could let caller A return `undefined` (foo.gts missing) and short-circuit caller B's correct multi-extension search. The 10× live repro all pass the same literal URL, so URL-literal is sufficient.

`prerenderUserId` is intentionally NOT in the key. For local realms and private remote realms, `prerenderUserId === cacheUserId`. For public remote realms, `cacheUserId=''` for all callers while `prerenderUserId` varies — they coalesce, which is safe because public-realm prerender auth is interchangeable.

## Test plan

New tests in `packages/realm-server/tests/definition-lookup-test.ts`, each with a controlled gate so concurrent callers stack at the in-flight gate before the prerender resolves:

- [x] `coalesces concurrent lookups of the same module into one prerender call` — 3 concurrent same-URL lookups resolve to one prerender call.
- [x] `does not coalesce concurrent lookups of different modules` — 2 different URLs → 2 prerender calls.
- [x] `shares errored prerender result with concurrent waiters and releases in-flight slot on rejection` — 3 concurrent erroring lookups reject with one prerender call; a follow-up read hits the cached error (TTL fresh); backdating `created_at` past TTL triggers a new prerender (proves the slot was released).
- [ ] Live verification: once this lands, run the repro from the ticket (`DELETE FROM modules WHERE resolved_realm_url=...` + full reindex) and confirm only one `module prerendering url .../product.gts` line per unique URL instead of 3–6.

Linear: https://linear.app/cardstack/issue/CS-10947

🤖 Generated with [Claude Code](https://claude.com/claude-code)