### PR TITLE
CS-10892: realm_file_changes NOTIFY channel + Realm.invalidateCache(path)

### DIFF
--- a/packages/realm-server/lib/realm-file-changes-listener.ts
+++ b/packages/realm-server/lib/realm-file-changes-listener.ts
@@ -1,0 +1,122 @@
+import type { Realm } from '@cardstack/runtime-common';
+import { logger } from '@cardstack/runtime-common';
+import type { PgAdapter } from '@cardstack/postgres';
+import { WorkLoop } from '@cardstack/postgres';
+
+const log = logger('realm-server:file-changes-listener');
+const CHANNEL = 'realm_file_changes';
+const DEFAULT_POLL_INTERVAL_MS = 60_000;
+
+// Cross-instance cache invalidation. When any realm-server emits
+// `NOTIFY realm_file_changes, '<url>:<path>'` (see Realm.#notifyFileChange in
+// runtime-common/realm.ts), every listener subscribed on this channel looks
+// up the URL in its lookup function. If the realm is mounted locally,
+// `realm.invalidateCache(path)` clears the matching #sourceCache /
+// #moduleCache entries. If it's not mounted, the notification is dropped —
+// this instance has no stale state to clear.
+//
+// The LISTEN is backed by `PgAdapter.listen` (dedicated Client, not pool-
+// returned) exactly like the registry reconciler. A poll fallback is not
+// strictly needed here — missed NOTIFYs degrade to cache staleness that the
+// next write will re-invalidate — but the WorkLoop gives us a predictable
+// shutdown path and matches the pattern used elsewhere. We set the poll
+// interval to something long (60s) so the fallback loop doesn't burn CPU
+// on busy instances; it exists to surface connection health, not to
+// re-scan anything.
+export interface RealmFileChangesListenerDeps {
+  dbAdapter: PgAdapter;
+  lookupMountedRealm: (url: string) => Realm | undefined;
+  // Optional for tests.
+  pollIntervalMs?: number;
+}
+
+export class RealmFileChangesListener {
+  #deps: RealmFileChangesListenerDeps;
+  #loop: WorkLoop;
+  #started = false;
+
+  constructor(deps: RealmFileChangesListenerDeps) {
+    this.#deps = deps;
+    this.#loop = new WorkLoop(
+      'realm-file-changes',
+      deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+    );
+  }
+
+  start(): void {
+    if (this.#started) {
+      return;
+    }
+    this.#started = true;
+    this.#loop.run(async (loop) => {
+      await this.#deps.dbAdapter.listen(
+        CHANNEL,
+        (notification: { payload?: string }) => {
+          // Invalidate synchronously on wake rather than forcing a reconcile
+          // pass: there is nothing to poll from the DB side, the whole
+          // payload is in the notification.
+          this.#handleNotification(notification.payload);
+        },
+        async () => {
+          while (!loop.shuttingDown) {
+            await loop.sleep();
+          }
+        },
+      );
+    });
+  }
+
+  async shutDown(): Promise<void> {
+    await this.#loop.shutDown();
+  }
+
+  // Exposed for tests; invoked internally by the LISTEN handler.
+  handleNotification(payload: string | undefined): void {
+    this.#handleNotification(payload);
+  }
+
+  #handleNotification(payload: string | undefined): void {
+    if (!payload) {
+      return;
+    }
+    const parsed = parsePayload(payload);
+    if (!parsed) {
+      log.warn(`ignoring malformed realm_file_changes payload: ${payload}`);
+      return;
+    }
+    const realm = this.#deps.lookupMountedRealm(parsed.url);
+    if (!realm) {
+      // Not mounted on this instance — nothing to invalidate.
+      return;
+    }
+    try {
+      realm.invalidateCache(parsed.path);
+    } catch (err: unknown) {
+      log.warn(
+        `invalidateCache failed for ${parsed.url} ${parsed.path}: ${String(err)}`,
+      );
+    }
+  }
+}
+
+// Payload shape: `<realmURL>:<localPath>`. Realm URLs always carry a
+// trailing slash (enforced by `ensureTrailingSlash` throughout the code),
+// so the separator between URL and path is the first `:` that immediately
+// follows a `/`. That avoids false matches on the scheme colon
+// (`http://...`) and any host:port colon (`localhost:4201`).
+const PAYLOAD_SEPARATOR = /\/:/;
+
+export function parsePayload(
+  payload: string,
+): { url: string; path: string } | undefined {
+  const match = PAYLOAD_SEPARATOR.exec(payload);
+  if (!match) {
+    return undefined;
+  }
+  const url = payload.slice(0, match.index + 1);
+  const path = payload.slice(match.index + 2);
+  if (!url || !path) {
+    return undefined;
+  }
+  return { url, path };
+}

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -36,6 +36,7 @@ import {
   RealmRegistryReconciler,
   type RealmRegistryRow,
 } from './lib/realm-registry-reconciler';
+import { RealmFileChangesListener } from './lib/realm-file-changes-listener';
 import { PUBLISHED_DIRECTORY_NAME } from '@cardstack/runtime-common';
 
 (globalThis as any).ContentTagGlobal = ContentTagGlobal;
@@ -279,6 +280,7 @@ const getIndexHTML = async () => {
   let dbAdapter = new PgAdapter({ autoMigrate });
   let queue = new PgQueuePublisher(dbAdapter);
   let reconciler: RealmRegistryReconciler | undefined;
+  let fileChangesListener: RealmFileChangesListener | undefined;
 
   if (workerManagerUrl) {
     await waitForWorkerManager(workerManagerUrl);
@@ -437,7 +439,10 @@ const getIndexHTML = async () => {
     httpServer.closeAllConnections();
     httpServer.close(() => {
       (async () => {
-        await reconciler?.shutDown();
+        await Promise.all([
+          reconciler?.shutDown(),
+          fileChangesListener?.shutDown(),
+        ]);
         queue.destroy(); // warning this is async
         dbAdapter.close(); // warning this is async
         console.log(`realm server on port ${stopPort} has stopped`);
@@ -558,6 +563,19 @@ const getIndexHTML = async () => {
   });
   reconciler.registerExistingMounts(realms);
   reconciler.start();
+
+  // Cross-instance cache invalidation. Realm.write() emits NOTIFY
+  // realm_file_changes; this listener receives those and forwards to the
+  // local Realm's invalidateCache(path). Under single-instance the writer
+  // has already invalidated its own caches synchronously, so self-echoes
+  // are idempotent no-ops. Lookups go through the same `realms` array the
+  // reconciler uses — in Phase 2 the reconciler and legacy loadRealms()
+  // both keep it in sync.
+  fileChangesListener = new RealmFileChangesListener({
+    dbAdapter,
+    lookupMountedRealm: (url) => realms.find((r) => r.url === url),
+  });
+  fileChangesListener.start();
 
   let actualPort =
     (httpServer.address() as import('net').AddressInfo | null)?.port ?? port;

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -185,6 +185,7 @@ import './realm-advisory-locks-test';
 import './realm-registry-backfill-test';
 import './realm-registry-reconciler-test';
 import './realm-registry-writes-test';
+import './realm-file-changes-listener-test';
 import './realm-endpoints/directory-test';
 import './realm-endpoints/info-test';
 import './realm-endpoints/invalidate-urls-test';

--- a/packages/realm-server/tests/realm-file-changes-listener-test.ts
+++ b/packages/realm-server/tests/realm-file-changes-listener-test.ts
@@ -1,0 +1,221 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import type { PgAdapter } from '@cardstack/postgres';
+import type { Realm } from '@cardstack/runtime-common';
+import { query, param } from '@cardstack/runtime-common';
+import { setupDB } from './helpers';
+import {
+  RealmFileChangesListener,
+  parsePayload,
+} from '../lib/realm-file-changes-listener';
+
+// Minimal fake `Realm` — the listener only calls `.url` (via lookup) and
+// `.invalidateCache(path)`, so that's all we need to stub.
+function makeFakeRealm(
+  url: string,
+  onInvalidate: (path: string) => void,
+): Realm {
+  return {
+    url,
+    invalidateCache(path: string) {
+      onInvalidate(path);
+    },
+  } as unknown as Realm;
+}
+
+function waitFor<T>(
+  getValue: () => T | undefined,
+  timeoutMs = 3000,
+  pollMs = 20,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    const tick = () => {
+      const value = getValue();
+      if (value !== undefined) {
+        resolve(value);
+        return;
+      }
+      if (Date.now() - started > timeoutMs) {
+        reject(new Error(`timeout after ${timeoutMs}ms`));
+        return;
+      }
+      setTimeout(tick, pollMs);
+    };
+    tick();
+  });
+}
+
+module(basename(__filename), function () {
+  module('parsePayload', function () {
+    test('parses url:path with a port in the url', function (assert) {
+      assert.deepEqual(
+        parsePayload('http://localhost:4201/luke/src/:cards/person.gts'),
+        { url: 'http://localhost:4201/luke/src/', path: 'cards/person.gts' },
+      );
+    });
+
+    test('parses url:path without a port in the url', function (assert) {
+      assert.deepEqual(
+        parsePayload('https://cardstack.com/base/:card-api.gts'),
+        {
+          url: 'https://cardstack.com/base/',
+          path: 'card-api.gts',
+        },
+      );
+    });
+
+    test('parses a nested path', function (assert) {
+      assert.deepEqual(
+        parsePayload('http://x.test/r/:a/b/c/deeply-nested.json'),
+        { url: 'http://x.test/r/', path: 'a/b/c/deeply-nested.json' },
+      );
+    });
+
+    test('returns undefined for a malformed payload missing the `/:` boundary', function (assert) {
+      assert.strictEqual(parsePayload('garbage-no-separator'), undefined);
+    });
+
+    test('returns undefined when the path is empty', function (assert) {
+      assert.strictEqual(parsePayload('http://x/:'), undefined);
+    });
+  });
+
+  module('RealmFileChangesListener (dispatch)', function () {
+    test('handleNotification forwards to the mounted realm', function (assert) {
+      const invalidations: Array<{ url: string; path: string }> = [];
+      const realmA = makeFakeRealm('http://x.test/a/', (path) =>
+        invalidations.push({ url: 'http://x.test/a/', path }),
+      );
+      const listener = new RealmFileChangesListener({
+        dbAdapter: {} as unknown as PgAdapter,
+        lookupMountedRealm: (url) =>
+          url === 'http://x.test/a/' ? realmA : undefined,
+      });
+
+      listener.handleNotification('http://x.test/a/:cards/foo.gts');
+
+      assert.deepEqual(invalidations, [
+        { url: 'http://x.test/a/', path: 'cards/foo.gts' },
+      ]);
+    });
+
+    test('handleNotification drops silently when the url is not mounted', function (assert) {
+      const invalidations: string[] = [];
+      const listener = new RealmFileChangesListener({
+        dbAdapter: {} as unknown as PgAdapter,
+        lookupMountedRealm: () => undefined,
+      });
+
+      listener.handleNotification('http://x.test/unmounted/:file.gts');
+
+      assert.deepEqual(
+        invalidations,
+        [],
+        'no invalidations attempted for unmounted url',
+      );
+    });
+
+    test('handleNotification ignores a malformed payload without throwing', function (assert) {
+      const listener = new RealmFileChangesListener({
+        dbAdapter: {} as unknown as PgAdapter,
+        lookupMountedRealm: () => {
+          throw new Error('should not be called for malformed payloads');
+        },
+      });
+
+      // Must not throw. Behavior: warn and return.
+      listener.handleNotification('not a valid payload');
+      assert.ok(true, 'malformed payload did not throw');
+    });
+
+    test('handleNotification ignores an empty payload', function (assert) {
+      const listener = new RealmFileChangesListener({
+        dbAdapter: {} as unknown as PgAdapter,
+        lookupMountedRealm: () => {
+          throw new Error('should not be called for empty payloads');
+        },
+      });
+
+      listener.handleNotification(undefined);
+      listener.handleNotification('');
+      assert.ok(true, 'empty payload did not throw');
+    });
+  });
+
+  module('RealmFileChangesListener (LISTEN end-to-end)', function (hooks) {
+    let dbAdapter: PgAdapter;
+
+    setupDB(hooks, {
+      beforeEach: async (adapter) => {
+        dbAdapter = adapter;
+      },
+    });
+
+    test('NOTIFY realm_file_changes → listener → invalidateCache', async function (assert) {
+      const invalidations: Array<{ url: string; path: string }> = [];
+      const realmUrl = 'http://x.test/listen-e2e/';
+      const realmA = makeFakeRealm(realmUrl, (path) =>
+        invalidations.push({ url: realmUrl, path }),
+      );
+      const listener = new RealmFileChangesListener({
+        dbAdapter,
+        lookupMountedRealm: (url) => (url === realmUrl ? realmA : undefined),
+      });
+      listener.start();
+      try {
+        // Give the LISTEN connection a moment to subscribe.
+        await new Promise((r) => setTimeout(r, 100));
+
+        await query(dbAdapter, [
+          `SELECT pg_notify(`,
+          param('realm_file_changes'),
+          `,`,
+          param(`${realmUrl}:src/greeting.gts`),
+          `)`,
+        ]);
+
+        const received = await waitFor(() =>
+          invalidations.length > 0 ? invalidations : undefined,
+        );
+        assert.deepEqual(received, [
+          { url: realmUrl, path: 'src/greeting.gts' },
+        ]);
+      } finally {
+        await listener.shutDown();
+      }
+    });
+
+    test('NOTIFY for an unmounted realm is dropped silently', async function (assert) {
+      const lookups: string[] = [];
+      const listener = new RealmFileChangesListener({
+        dbAdapter,
+        lookupMountedRealm: (url) => {
+          lookups.push(url);
+          return undefined;
+        },
+      });
+      listener.start();
+      try {
+        await new Promise((r) => setTimeout(r, 100));
+
+        await query(dbAdapter, [
+          `SELECT pg_notify(`,
+          param('realm_file_changes'),
+          `,`,
+          param(`http://x.test/not-mounted/:file.gts`),
+          `)`,
+        ]);
+
+        // Wait for the lookup to be recorded (proves the NOTIFY was received
+        // and dispatched; the lookup miss then silently drops).
+        const seen = await waitFor(() =>
+          lookups.length > 0 ? lookups : undefined,
+        );
+        assert.deepEqual(seen, ['http://x.test/not-mounted/']);
+      } finally {
+        await listener.shutDown();
+      }
+    });
+  });
+});

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -211,6 +211,13 @@ const CACHE_HIT_VALUE = 'hit';
 const CACHE_MISS_VALUE = 'miss';
 const MODULE_ETAG_VARIANT = 'module';
 const SOURCE_ETAG_VARIANT = 'source';
+
+// Postgres NOTIFY channel for cross-instance invalidation of #sourceCache /
+// #moduleCache entries on file writes. Payload shape is `<realmURL>:<path>`.
+// See docs/db-authoritative-realm-registry.md §6 "Cache invalidation channel"
+// and §9 "Cache-invalidation NOTIFY missed" for the semantics (best-effort,
+// missed-NOTIFY is a cache-staleness window, not data corruption).
+export const REALM_FILE_CHANGES_CHANNEL = 'realm_file_changes';
 export const FILE_META_RESERVED_KEYS = new Set([
   'name',
   'url',
@@ -1036,6 +1043,41 @@ export class Realm {
     this.#moduleCache.clear();
   }
 
+  // Invalidate the in-memory byte caches for a single path. Called by the
+  // realm_file_changes LISTEN handler on peer instances after a write lands
+  // somewhere else in the fleet. The shape matches the file-watcher receiver
+  // below — invalidate source always, invalidate module only for executable
+  // extensions. Public so the realm-server process can wire a NOTIFY listener
+  // without reaching into private state.
+  invalidateCache(path: LocalPath): void {
+    this.#sourceCache.invalidate(path);
+    if (hasExecutableExtension(path)) {
+      this.#moduleCache.invalidate(path);
+    }
+  }
+
+  // Broadcast a file-change notification to peer realm-server instances so
+  // they can invalidate their own #sourceCache / #moduleCache entries for the
+  // same path. Best-effort — failures are logged and swallowed because the
+  // local write already succeeded and a missed NOTIFY is a bounded cache-
+  // staleness window (see docs §9 "Cache-invalidation NOTIFY missed"), not
+  // a correctness failure.
+  async #notifyFileChange(path: LocalPath): Promise<void> {
+    try {
+      await query(this.#dbAdapter, [
+        `SELECT pg_notify(`,
+        param(REALM_FILE_CHANGES_CHANNEL),
+        `,`,
+        param(`${this.url}:${path}`),
+        `)`,
+      ]);
+    } catch (err: unknown) {
+      this.#log.warn(
+        `pg_notify ${REALM_FILE_CHANGES_CHANNEL} failed for ${this.url}:${path}: ${String(err)}`,
+      );
+    }
+  }
+
   createJWT(claims: TokenClaims, expiration: ms.StringValue): string {
     return this.#adapter.createJWT(claims, expiration, this.#realmSecretSeed);
   }
@@ -1155,6 +1197,7 @@ export class Realm {
       if (hasExecutableExtension(path)) {
         this.#moduleCache.invalidate(path);
       }
+      await this.#notifyFileChange(path);
       results.push({ path, lastModified });
       fileMetaRows.push({ path, contentHash, contentSize });
       urls.push(url);
@@ -1555,6 +1598,7 @@ export class Realm {
     if (hasExecutableExtension(path)) {
       this.#moduleCache.invalidate(path);
     }
+    await this.#notifyFileChange(path);
     // Remove file meta for this path
     await this.removeFileMeta([path]);
     let invalidations = await this.updateIndexAndCollectInvalidations([url], {
@@ -1582,6 +1626,7 @@ export class Realm {
 
     await Promise.all(trackPromises);
     await Promise.all(removePromises);
+    await Promise.all(paths.map((path) => this.#notifyFileChange(path)));
     this.broadcastRealmEvent({
       eventName: 'update',
       removed: paths,


### PR DESCRIPTION
Stacked on #4507 (CS-10891).

## Summary

- Adds the \`realm_file_changes\` Postgres NOTIFY channel so a \`realm.write()\` on one instance invalidates peer instances' in-memory \`#sourceCache\` / \`#moduleCache\` entries for the same path.
- New \`Realm.invalidateCache(path)\` method mirrors the existing file-watcher invalidation shape.
- New \`RealmFileChangesListener\` wired alongside the registry reconciler in \`main.ts\`; LISTENs on the channel and dispatches invalidations to whichever \`Realm\` is currently mounted locally (dropped silently if not mounted).
- Single-instance behavior is unchanged — the writer already invalidates its own caches synchronously before the NOTIFY fires, so peer self-echoes are idempotent no-ops.

## Scope change vs. original Linear description

This PR was originally scoped to also drop an in-memory permissions cache in \`RealmAuthDataSource\`. That work was removed after investigation: \`realm_user_permissions\` reads are already uncached in the tree (every call goes direct to \`fetchRealmPermissions\` / \`fetchUserPermissions\`), so there was no cache to drop. \`RealmAuthDataSource.visitedRealms\` caches JWT-issuing clients, orthogonal to \`realm_user_permissions\`, and dropping it would be a perf regression without any coherence benefit.

Spec \`docs/db-authoritative-realm-registry.md\` §6 \"Permissions caching\" and §7 Phase 2 PR 3 updated to match. CS-10892 description and the Phase 2 milestone in Linear updated with the same correction.

## Test plan

- [x] \`realm-file-changes-listener-test.ts\` — 11 tests covering \`parsePayload\` + dispatch (mounted hit, unmounted drop, malformed, empty) + LISTEN end-to-end against a real \`PgAdapter\`.
- [x] Adjacent registry test suites still pass (reconciler, advisory locks, writes, backfill — 33 tests total).
- [ ] Full realm-server regression run — deferring to CI (local run of \`indexing-test.ts\` + \`card-endpoints\` + \`card-source-endpoints\` hung on test-pg seed; the code changes are structurally conservative — best-effort pg_notify appended after existing local invalidations, failures logged + swallowed).

## Implementation notes

- NOTIFY emission is \*\*best-effort\*\*. \`Realm.#notifyFileChange\` wraps the \`pg_notify\` call in try/catch and logs-and-swallows on failure — the local write always succeeds even if the NOTIFY can't be emitted. Missed NOTIFYs degrade to a cache-staleness window, not data corruption (spec §9 \"Cache-invalidation NOTIFY missed\").
- Payload format is \`<realmURL>:<localPath>\`. \`parsePayload\` finds the separator as the first \`:\` immediately following a \`/\` — this avoids false matches on the scheme colon (\`http://\`) or any \`host:port\` colon.
- Listener uses \`PgAdapter.listen\` (dedicated client per subscription) matching the pattern established by CS-10890's reconciler. A 60s \`WorkLoop\` poll interval is present for shutdown hygiene; there's nothing to poll from the DB side since the whole payload rides the notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)