### PR TITLE
Fix heartbeat capacity to match bumped pool-size default

### DIFF
--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -930,10 +930,18 @@ export function createPrerenderHttpServer(options?: {
     Number(process.env.PRERENDER_SHUTDOWN_GRACE_MS ?? 10000),
   );
 
+  // Report the same pool size the PagePool was actually constructed
+  // with. `buildPrerenderApp` resolves `maxPages` using the same
+  // precedence (explicit option → env → default), so sharing the
+  // resolved value keeps the heartbeat honest when the default or
+  // env var changes.
+  const resolvedMaxPages =
+    options?.maxPages ?? Number(process.env.PRERENDER_PAGE_POOL_SIZE ?? 5);
+
   async function sendHeartbeat(status?: 'active' | 'draining') {
     try {
       const managerURL = resolvePrerenderManagerURL();
-      const capacity = Number(process.env.PRERENDER_PAGE_POOL_SIZE ?? 4);
+      const capacity = resolvedMaxPages;
       let body = {
         data: {
           type: 'prerender-server',

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -65,6 +65,10 @@ export function buildPrerenderApp(options: {
 }): {
   app: Koa<Koa.DefaultState, Koa.Context>;
   prerenderer: Prerenderer;
+  // Resolved pool size (explicit option → env → default). Returned so
+  // `createPrerenderHttpServer` can report the same value to the
+  // manager in `sendHeartbeat` without duplicating the resolution.
+  maxPages: number;
 } {
   let app = new Koa<Koa.DefaultState, Koa.Context>();
   let router = new Router();
@@ -856,7 +860,7 @@ export function buildPrerenderApp(options: {
     log.error(`prerender server HTTP error: ${err.message}`);
   });
 
-  return { app, prerenderer };
+  return { app, prerenderer, maxPages };
 }
 
 function resolvePrerenderServerURL(port?: number): string {
@@ -897,7 +901,15 @@ export function createPrerenderHttpServer(options?: {
   let isClosing = false;
   let fatalExitOnUncaught = options?.fatalExitOnUncaught ?? true;
   let serverURL = resolvePrerenderServerURL(options?.port);
-  let { app, prerenderer } = buildPrerenderApp({
+  let {
+    app,
+    prerenderer,
+    // Reuse the resolved value `buildPrerenderApp` computed so
+    // `sendHeartbeat` reports the same pool size the PagePool was
+    // actually constructed with — no duplicate resolution, no drift
+    // when the default or env var changes.
+    maxPages: resolvedMaxPages,
+  } = buildPrerenderApp({
     maxPages: options?.maxPages,
     serverURL,
     isDraining: () => draining,
@@ -929,14 +941,6 @@ export function createPrerenderHttpServer(options?: {
     0,
     Number(process.env.PRERENDER_SHUTDOWN_GRACE_MS ?? 10000),
   );
-
-  // Report the same pool size the PagePool was actually constructed
-  // with. `buildPrerenderApp` resolves `maxPages` using the same
-  // precedence (explicit option → env → default), so sharing the
-  // resolved value keeps the heartbeat honest when the default or
-  // env var changes.
-  const resolvedMaxPages =
-    options?.maxPages ?? Number(process.env.PRERENDER_PAGE_POOL_SIZE ?? 5);
 
   async function sendHeartbeat(status?: 'active' | 'draining') {
     try {


### PR DESCRIPTION
Targets #4510's source branch so it folds into that PR.

Addresses Codex P2 on #4512: [\"Report heartbeat capacity from actual maxPages\"](https://github.com/cardstack/boxel/pull/4512#discussion_r3135106825).

## Why

The commit that bumped `buildPrerenderApp`'s default pool size from 4 to 5 missed `sendHeartbeat`, which still hard-coded `process.env.PRERENDER_PAGE_POOL_SIZE ?? 4`. When the env var was unset, the server ran with 5 tabs while advertising 4 to the manager, skewing warm-vacancy routing decisions and the `affinityVacancy` snapshot the manager consumes for CS-10758.

## What changes

`sendHeartbeat` now derives `capacity` from the same `maxPages` value `buildPrerenderApp` resolves (`options?.maxPages ?? Number(process.env.PRERENDER_PAGE_POOL_SIZE ?? 5)`), so the two stay in lockstep when the default or env var changes.

## Test plan
- [ ] realm-server lint passes
- [ ] CI green on #4510 after this merges into its branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)