### PR TITLE
boxel-cli: administrative access to private hosted realms via realm secret seed

### DIFF
--- a/packages/boxel-cli/package.json
+++ b/packages/boxel-cli/package.json
@@ -32,6 +32,7 @@
     "commander": "^13.1.0",
     "dotenv": "^16.4.7",
     "ignore": "catalog:",
+    "jsonwebtoken": "catalog:",
     "p-limit": "^7.3.0"
   },
   "devDependencies": {
@@ -39,6 +40,7 @@
     "@cardstack/postgres": "workspace:*",
     "@cardstack/runtime-common": "workspace:*",
     "content-tag": "catalog:",
+    "@types/jsonwebtoken": "catalog:",
     "@types/node": "catalog:",
     "@typescript-eslint/eslint-plugin": "catalog:",
     "@typescript-eslint/parser": "catalog:",

--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -1,5 +1,3 @@
-import * as readline from 'readline';
-import { Writable } from 'stream';
 import type { ProfileManager } from '../lib/profile-manager';
 import {
   getProfileManager,
@@ -8,6 +6,7 @@ import {
   getEnvironmentLabel,
   getUsernameFromMatrixId,
 } from '../lib/profile-manager';
+import { prompt, promptPassword } from '../lib/prompt';
 import {
   FG_GREEN,
   FG_YELLOW,
@@ -18,88 +17,6 @@ import {
   BOLD,
   RESET,
 } from '../lib/colors';
-
-function prompt(question: string): Promise<string> {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      rl.close();
-      resolve(answer.trim());
-    });
-  });
-}
-
-function promptPassword(question: string): Promise<string> {
-  const mutableOutput = new Writable({
-    write: (_chunk, _encoding, callback) => callback(),
-  });
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: mutableOutput,
-    terminal: true,
-  });
-
-  return new Promise((resolve, reject) => {
-    const stdin = process.stdin;
-    const wasFlowing = stdin.readableFlowing;
-
-    if (stdin.isTTY) {
-      stdin.setRawMode(true);
-    }
-
-    const cleanup = () => {
-      stdin.removeListener('data', onData);
-      if (stdin.isTTY) {
-        stdin.setRawMode(false);
-      }
-      rl.close();
-      if (!wasFlowing) {
-        stdin.pause();
-      }
-    };
-
-    const onData = (char: Buffer) => {
-      try {
-        const c = char.toString();
-        if (c === '\n' || c === '\r') {
-          cleanup();
-          process.stdout.write('\n');
-          resolve(password);
-        } else if (c === '\u0003') {
-          // Ctrl+C
-          cleanup();
-          process.exit();
-        } else if (c === '\u007F' || c === '\b') {
-          // Backspace
-          if (password.length > 0) {
-            password = password.slice(0, -1);
-            process.stdout.write('\b \b');
-          }
-        } else {
-          password += c;
-          process.stdout.write('*');
-        }
-      } catch (e) {
-        cleanup();
-        reject(e);
-      }
-    };
-
-    let password = '';
-    try {
-      process.stdout.write(question);
-      stdin.on('data', onData);
-      stdin.resume();
-    } catch (e) {
-      cleanup();
-      reject(e);
-    }
-  });
-}
 
 export interface ProfileCommandOptions {
   user?: string;

--- a/packages/boxel-cli/src/commands/realm/pull.ts
+++ b/packages/boxel-cli/src/commands/realm/pull.ts
@@ -7,6 +7,7 @@ import {
 import type { ProfileManager } from '../../lib/profile-manager';
 import type { RealmAuthenticator } from '../../lib/realm-authenticator';
 import { resolveRealmAuthenticator } from '../../lib/auth-resolver';
+import { resolveRealmSecretSeed } from '../../lib/prompt';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
@@ -37,7 +38,7 @@ class RealmPuller extends RealmSyncBase {
       console.error('Failed to access realm:', error);
       throw new Error(
         'Cannot proceed with pull: Authentication or access failed. ' +
-          'Please check your Matrix credentials and realm permissions.',
+          'Please check your credentials and realm permissions.',
       );
     }
     console.log('Realm access verified');
@@ -171,13 +172,15 @@ export interface PullCommandOptions {
   dryRun?: boolean;
   profileManager?: ProfileManager;
   /**
-   * Realm secret seed for administrative access. When set, the CLI mints a
-   * JWT locally and skips Matrix login + /_server-session + /_realm-auth.
-   * Falls back to the BOXEL_REALM_SECRET_SEED env var.
+   * Pre-resolved realm secret seed for administrative access. When set, the
+   * CLI mints a JWT locally and skips Matrix login + /_server-session +
+   * /_realm-auth. The `--realm-secret-seed` CLI flag is resolved via
+   * `resolveRealmSecretSeed` (env var or interactive prompt) before being
+   * passed here.
    */
   realmSecretSeed?: string;
   /**
-   * Escape hatch for tests: supply an already-constructed authenticator,
+   * @internal Test hook: supply an already-constructed authenticator,
    * bypassing both seed resolution and the profile flow.
    */
   authenticator?: RealmAuthenticator;
@@ -195,8 +198,8 @@ export function registerPullCommand(realm: Command): void {
     .option('--delete', 'Delete local files that do not exist in the realm')
     .option('--dry-run', 'Show what would be done without making changes')
     .option(
-      '--realm-secret-seed <seed>',
-      'Administrative auth: mint a realm JWT locally using the given seed instead of a Matrix profile (env: BOXEL_REALM_SECRET_SEED)',
+      '--realm-secret-seed',
+      'Administrative auth: prompt for a realm secret seed and mint a JWT locally instead of using a Matrix profile (env: BOXEL_REALM_SECRET_SEED)',
     )
     .action(
       async (
@@ -205,10 +208,17 @@ export function registerPullCommand(realm: Command): void {
         options: {
           delete?: boolean;
           dryRun?: boolean;
-          realmSecretSeed?: string;
+          realmSecretSeed?: boolean;
         },
       ) => {
-        let result = await pull(realmUrl, localDir, options);
+        const realmSecretSeed = await resolveRealmSecretSeed(
+          options.realmSecretSeed === true,
+        );
+        const result = await pull(realmUrl, localDir, {
+          delete: options.delete,
+          dryRun: options.dryRun,
+          realmSecretSeed,
+        });
         if (result.error) {
           console.error(`Error: ${result.error}`);
           process.exit(result.files.length > 0 ? 2 : 1);

--- a/packages/boxel-cli/src/commands/realm/pull.ts
+++ b/packages/boxel-cli/src/commands/realm/pull.ts
@@ -4,10 +4,9 @@ import {
   CheckpointManager,
   type CheckpointChange,
 } from '../../lib/checkpoint-manager';
-import {
-  getProfileManager,
-  type ProfileManager,
-} from '../../lib/profile-manager';
+import type { ProfileManager } from '../../lib/profile-manager';
+import type { RealmAuthenticator } from '../../lib/realm-authenticator';
+import { resolveRealmAuthenticator } from '../../lib/auth-resolver';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
@@ -21,9 +20,9 @@ class RealmPuller extends RealmSyncBase {
 
   constructor(
     private pullOptions: PullOptions,
-    profileManager: ProfileManager,
+    authenticator: RealmAuthenticator,
   ) {
-    super(pullOptions, profileManager);
+    super(pullOptions, authenticator);
   }
 
   async sync(): Promise<void> {
@@ -171,6 +170,17 @@ export interface PullCommandOptions {
   delete?: boolean;
   dryRun?: boolean;
   profileManager?: ProfileManager;
+  /**
+   * Realm secret seed for administrative access. When set, the CLI mints a
+   * JWT locally and skips Matrix login + /_server-session + /_realm-auth.
+   * Falls back to the BOXEL_REALM_SECRET_SEED env var.
+   */
+  realmSecretSeed?: string;
+  /**
+   * Escape hatch for tests: supply an already-constructed authenticator,
+   * bypassing both seed resolution and the profile flow.
+   */
+  authenticator?: RealmAuthenticator;
 }
 
 export function registerPullCommand(realm: Command): void {
@@ -184,11 +194,19 @@ export function registerPullCommand(realm: Command): void {
     .argument('<local-dir>', 'The local directory to sync files to')
     .option('--delete', 'Delete local files that do not exist in the realm')
     .option('--dry-run', 'Show what would be done without making changes')
+    .option(
+      '--realm-secret-seed <seed>',
+      'Administrative auth: mint a realm JWT locally using the given seed instead of a Matrix profile (env: BOXEL_REALM_SECRET_SEED)',
+    )
     .action(
       async (
         realmUrl: string,
         localDir: string,
-        options: { delete?: boolean; dryRun?: boolean },
+        options: {
+          delete?: boolean;
+          dryRun?: boolean;
+          realmSecretSeed?: string;
+        },
       ) => {
         let result = await pull(realmUrl, localDir, options);
         if (result.error) {
@@ -205,13 +223,19 @@ export async function pull(
   localDir: string,
   options: PullCommandOptions,
 ): Promise<{ files: string[]; error?: string }> {
-  let pm = options.profileManager ?? getProfileManager();
-  let active = pm.getActiveProfile();
-  if (!active) {
-    return {
-      files: [],
-      error: 'No active profile. Run `boxel profile add` to create one.',
-    };
+  let authenticator: RealmAuthenticator;
+  if (options.authenticator) {
+    authenticator = options.authenticator;
+  } else {
+    const resolution = resolveRealmAuthenticator({
+      realmUrl,
+      realmSecretSeed: options.realmSecretSeed,
+      profileManager: options.profileManager,
+    });
+    if (!resolution.ok) {
+      return { files: [], error: resolution.error };
+    }
+    authenticator = resolution.authenticator;
   }
 
   try {
@@ -222,7 +246,7 @@ export async function pull(
         deleteLocal: options.delete,
         dryRun: options.dryRun,
       },
-      pm,
+      authenticator,
     );
 
     await puller.sync();

--- a/packages/boxel-cli/src/commands/realm/push.ts
+++ b/packages/boxel-cli/src/commands/realm/push.ts
@@ -11,6 +11,7 @@ import {
 import type { ProfileManager } from '../../lib/profile-manager';
 import type { RealmAuthenticator } from '../../lib/realm-authenticator';
 import { resolveRealmAuthenticator } from '../../lib/auth-resolver';
+import { resolveRealmSecretSeed } from '../../lib/prompt';
 import {
   type SyncManifest,
   computeFileHash,
@@ -308,13 +309,15 @@ export interface PushCommandOptions {
   force?: boolean;
   profileManager?: ProfileManager;
   /**
-   * Realm secret seed for administrative access. When set, the CLI mints a
-   * JWT locally and skips Matrix login + /_server-session + /_realm-auth.
-   * Falls back to the BOXEL_REALM_SECRET_SEED env var.
+   * Pre-resolved realm secret seed for administrative access. When set, the
+   * CLI mints a JWT locally and skips Matrix login + /_server-session +
+   * /_realm-auth. The `--realm-secret-seed` CLI flag is resolved via
+   * `resolveRealmSecretSeed` (env var or interactive prompt) before being
+   * passed here.
    */
   realmSecretSeed?: string;
   /**
-   * Escape hatch for tests: supply an already-constructed authenticator.
+   * @internal Test hook: supply an already-constructed authenticator.
    */
   authenticator?: RealmAuthenticator;
 }
@@ -332,8 +335,8 @@ export function registerPushCommand(realm: Command): void {
     .option('--dry-run', 'Show what would be done without making changes')
     .option('--force', 'Upload all files, even if unchanged')
     .option(
-      '--realm-secret-seed <seed>',
-      'Administrative auth: mint a realm JWT locally using the given seed instead of a Matrix profile (env: BOXEL_REALM_SECRET_SEED)',
+      '--realm-secret-seed',
+      'Administrative auth: prompt for a realm secret seed and mint a JWT locally instead of using a Matrix profile (env: BOXEL_REALM_SECRET_SEED)',
     )
     .action(
       async (
@@ -343,10 +346,18 @@ export function registerPushCommand(realm: Command): void {
           delete?: boolean;
           dryRun?: boolean;
           force?: boolean;
-          realmSecretSeed?: string;
+          realmSecretSeed?: boolean;
         },
       ) => {
-        await pushCommand(localDir, realmUrl, options);
+        const realmSecretSeed = await resolveRealmSecretSeed(
+          options.realmSecretSeed === true,
+        );
+        await pushCommand(localDir, realmUrl, {
+          delete: options.delete,
+          dryRun: options.dryRun,
+          force: options.force,
+          realmSecretSeed,
+        });
       },
     );
 }
@@ -366,9 +377,7 @@ export async function pushCommand(
       profileManager: options.profileManager,
     });
     if (!resolution.ok) {
-      console.error(
-        `Error: ${resolution.error.charAt(0).toLowerCase()}${resolution.error.slice(1)}`,
-      );
+      console.error(`Error: ${resolution.error}`);
       process.exit(1);
     }
     authenticator = resolution.authenticator;

--- a/packages/boxel-cli/src/commands/realm/push.ts
+++ b/packages/boxel-cli/src/commands/realm/push.ts
@@ -8,10 +8,9 @@ import {
   CheckpointManager,
   type CheckpointChange,
 } from '../../lib/checkpoint-manager';
-import {
-  getProfileManager,
-  type ProfileManager,
-} from '../../lib/profile-manager';
+import type { ProfileManager } from '../../lib/profile-manager';
+import type { RealmAuthenticator } from '../../lib/realm-authenticator';
+import { resolveRealmAuthenticator } from '../../lib/auth-resolver';
 import {
   type SyncManifest,
   computeFileHash,
@@ -30,9 +29,9 @@ class RealmPusher extends RealmSyncBase {
 
   constructor(
     private pushOptions: PushOptions,
-    profileManager: ProfileManager,
+    authenticator: RealmAuthenticator,
   ) {
-    super(pushOptions, profileManager);
+    super(pushOptions, authenticator);
   }
 
   async sync(): Promise<void> {
@@ -308,6 +307,16 @@ export interface PushCommandOptions {
   dryRun?: boolean;
   force?: boolean;
   profileManager?: ProfileManager;
+  /**
+   * Realm secret seed for administrative access. When set, the CLI mints a
+   * JWT locally and skips Matrix login + /_server-session + /_realm-auth.
+   * Falls back to the BOXEL_REALM_SECRET_SEED env var.
+   */
+  realmSecretSeed?: string;
+  /**
+   * Escape hatch for tests: supply an already-constructed authenticator.
+   */
+  authenticator?: RealmAuthenticator;
 }
 
 export function registerPushCommand(realm: Command): void {
@@ -322,11 +331,20 @@ export function registerPushCommand(realm: Command): void {
     .option('--delete', 'Delete remote files that do not exist locally')
     .option('--dry-run', 'Show what would be done without making changes')
     .option('--force', 'Upload all files, even if unchanged')
+    .option(
+      '--realm-secret-seed <seed>',
+      'Administrative auth: mint a realm JWT locally using the given seed instead of a Matrix profile (env: BOXEL_REALM_SECRET_SEED)',
+    )
     .action(
       async (
         localDir: string,
         realmUrl: string,
-        options: { delete?: boolean; dryRun?: boolean; force?: boolean },
+        options: {
+          delete?: boolean;
+          dryRun?: boolean;
+          force?: boolean;
+          realmSecretSeed?: string;
+        },
       ) => {
         await pushCommand(localDir, realmUrl, options);
       },
@@ -338,13 +356,22 @@ export async function pushCommand(
   realmUrl: string,
   options: PushCommandOptions,
 ): Promise<void> {
-  let pm = options.profileManager ?? getProfileManager();
-  let active = pm.getActiveProfile();
-  if (!active) {
-    console.error(
-      'Error: no active profile. Run `boxel profile add` to create one.',
-    );
-    process.exit(1);
+  let authenticator: RealmAuthenticator;
+  if (options.authenticator) {
+    authenticator = options.authenticator;
+  } else {
+    const resolution = resolveRealmAuthenticator({
+      realmUrl,
+      realmSecretSeed: options.realmSecretSeed,
+      profileManager: options.profileManager,
+    });
+    if (!resolution.ok) {
+      console.error(
+        `Error: ${resolution.error.charAt(0).toLowerCase()}${resolution.error.slice(1)}`,
+      );
+      process.exit(1);
+    }
+    authenticator = resolution.authenticator;
   }
 
   if (!(await pathExists(localDir))) {
@@ -361,7 +388,7 @@ export async function pushCommand(
         dryRun: options.dryRun,
         force: options.force,
       },
-      pm,
+      authenticator,
     );
 
     await pusher.sync();

--- a/packages/boxel-cli/src/commands/realm/sync.ts
+++ b/packages/boxel-cli/src/commands/realm/sync.ts
@@ -8,10 +8,9 @@ import {
   CheckpointManager,
   type CheckpointChange,
 } from '../../lib/checkpoint-manager';
-import {
-  getProfileManager,
-  type ProfileManager,
-} from '../../lib/profile-manager';
+import type { ProfileManager } from '../../lib/profile-manager';
+import type { RealmAuthenticator } from '../../lib/realm-authenticator';
+import { resolveRealmAuthenticator } from '../../lib/auth-resolver';
 import {
   type SyncManifest,
   computeFileHash,
@@ -49,9 +48,9 @@ class RealmSyncer extends RealmSyncBase {
 
   constructor(
     private syncOptions: BiSyncOptions,
-    profileManager: ProfileManager,
+    authenticator: RealmAuthenticator,
   ) {
-    super(syncOptions, profileManager);
+    super(syncOptions, authenticator);
   }
 
   private get conflictStrategy(): ConflictStrategy | null {
@@ -491,6 +490,16 @@ export interface SyncCommandOptions {
   delete?: boolean;
   dryRun?: boolean;
   profileManager?: ProfileManager;
+  /**
+   * Realm secret seed for administrative access. When set, the CLI mints a
+   * JWT locally and skips Matrix login + /_server-session + /_realm-auth.
+   * Falls back to the BOXEL_REALM_SECRET_SEED env var.
+   */
+  realmSecretSeed?: string;
+  /**
+   * Escape hatch for tests: supply an already-constructed authenticator.
+   */
+  authenticator?: RealmAuthenticator;
 }
 
 export function registerSyncCommand(realm: Command): void {
@@ -509,6 +518,10 @@ export function registerSyncCommand(realm: Command): void {
     .option('--prefer-newest', 'Resolve conflicts by keeping newest version')
     .option('--delete', 'Sync deletions both ways')
     .option('--dry-run', 'Preview without making changes')
+    .option(
+      '--realm-secret-seed <seed>',
+      'Administrative auth: mint a realm JWT locally using the given seed instead of a Matrix profile (env: BOXEL_REALM_SECRET_SEED)',
+    )
     .action(
       async (
         localDir: string,
@@ -519,6 +532,7 @@ export function registerSyncCommand(realm: Command): void {
           preferNewest?: boolean;
           delete?: boolean;
           dryRun?: boolean;
+          realmSecretSeed?: string;
         },
       ) => {
         await syncCommand(localDir, realmUrl, options);
@@ -531,13 +545,22 @@ export async function syncCommand(
   realmUrl: string,
   options: SyncCommandOptions,
 ): Promise<void> {
-  let pm = options.profileManager ?? getProfileManager();
-  let active = pm.getActiveProfile();
-  if (!active) {
-    console.error(
-      'Error: no active profile. Run `boxel profile add` to create one.',
-    );
-    process.exit(1);
+  let authenticator: RealmAuthenticator;
+  if (options.authenticator) {
+    authenticator = options.authenticator;
+  } else {
+    const resolution = resolveRealmAuthenticator({
+      realmUrl,
+      realmSecretSeed: options.realmSecretSeed,
+      profileManager: options.profileManager,
+    });
+    if (!resolution.ok) {
+      console.error(
+        `Error: ${resolution.error.charAt(0).toLowerCase()}${resolution.error.slice(1)}`,
+      );
+      process.exit(1);
+    }
+    authenticator = resolution.authenticator;
   }
 
   // Validate mutually exclusive strategies
@@ -569,7 +592,7 @@ export async function syncCommand(
         deleteSync: options.delete,
         dryRun: options.dryRun,
       },
-      pm,
+      authenticator,
     );
 
     await syncer.sync();

--- a/packages/boxel-cli/src/commands/realm/sync.ts
+++ b/packages/boxel-cli/src/commands/realm/sync.ts
@@ -11,6 +11,7 @@ import {
 import type { ProfileManager } from '../../lib/profile-manager';
 import type { RealmAuthenticator } from '../../lib/realm-authenticator';
 import { resolveRealmAuthenticator } from '../../lib/auth-resolver';
+import { resolveRealmSecretSeed } from '../../lib/prompt';
 import {
   type SyncManifest,
   computeFileHash,
@@ -73,7 +74,7 @@ class RealmSyncer extends RealmSyncBase {
       console.error('Failed to access realm:', error);
       throw new Error(
         'Cannot proceed with sync: Authentication or access failed. ' +
-          'Please check your Matrix credentials and realm permissions.',
+          'Please check your credentials and realm permissions.',
       );
     }
     console.log('Realm access verified');
@@ -491,13 +492,15 @@ export interface SyncCommandOptions {
   dryRun?: boolean;
   profileManager?: ProfileManager;
   /**
-   * Realm secret seed for administrative access. When set, the CLI mints a
-   * JWT locally and skips Matrix login + /_server-session + /_realm-auth.
-   * Falls back to the BOXEL_REALM_SECRET_SEED env var.
+   * Pre-resolved realm secret seed for administrative access. When set, the
+   * CLI mints a JWT locally and skips Matrix login + /_server-session +
+   * /_realm-auth. The `--realm-secret-seed` CLI flag is resolved via
+   * `resolveRealmSecretSeed` (env var or interactive prompt) before being
+   * passed here.
    */
   realmSecretSeed?: string;
   /**
-   * Escape hatch for tests: supply an already-constructed authenticator.
+   * @internal Test hook: supply an already-constructed authenticator.
    */
   authenticator?: RealmAuthenticator;
 }
@@ -519,8 +522,8 @@ export function registerSyncCommand(realm: Command): void {
     .option('--delete', 'Sync deletions both ways')
     .option('--dry-run', 'Preview without making changes')
     .option(
-      '--realm-secret-seed <seed>',
-      'Administrative auth: mint a realm JWT locally using the given seed instead of a Matrix profile (env: BOXEL_REALM_SECRET_SEED)',
+      '--realm-secret-seed',
+      'Administrative auth: prompt for a realm secret seed and mint a JWT locally instead of using a Matrix profile (env: BOXEL_REALM_SECRET_SEED)',
     )
     .action(
       async (
@@ -532,10 +535,20 @@ export function registerSyncCommand(realm: Command): void {
           preferNewest?: boolean;
           delete?: boolean;
           dryRun?: boolean;
-          realmSecretSeed?: string;
+          realmSecretSeed?: boolean;
         },
       ) => {
-        await syncCommand(localDir, realmUrl, options);
+        const realmSecretSeed = await resolveRealmSecretSeed(
+          options.realmSecretSeed === true,
+        );
+        await syncCommand(localDir, realmUrl, {
+          preferLocal: options.preferLocal,
+          preferRemote: options.preferRemote,
+          preferNewest: options.preferNewest,
+          delete: options.delete,
+          dryRun: options.dryRun,
+          realmSecretSeed,
+        });
       },
     );
 }
@@ -555,9 +568,7 @@ export async function syncCommand(
       profileManager: options.profileManager,
     });
     if (!resolution.ok) {
-      console.error(
-        `Error: ${resolution.error.charAt(0).toLowerCase()}${resolution.error.slice(1)}`,
-      );
+      console.error(`Error: ${resolution.error}`);
       process.exit(1);
     }
     authenticator = resolution.authenticator;

--- a/packages/boxel-cli/src/lib/auth-resolver.ts
+++ b/packages/boxel-cli/src/lib/auth-resolver.ts
@@ -1,0 +1,47 @@
+import {
+  getProfileManager,
+  type ProfileManager,
+  NO_ACTIVE_PROFILE_ERROR,
+} from './profile-manager';
+import type { RealmAuthenticator } from './realm-authenticator';
+import { SeedAuthenticator } from './seed-auth';
+
+export interface AuthResolverOptions {
+  /** Realm URL the command is operating on (used for registering the seed-auth cache). */
+  realmUrl: string;
+  /** Explicit seed (from --realm-secret-seed). Wins over BOXEL_REALM_SECRET_SEED. */
+  realmSecretSeed?: string;
+  /** Override the ProfileManager (tests). When seed mode is active we won't touch it. */
+  profileManager?: ProfileManager;
+}
+
+export type AuthResolution =
+  | { ok: true; authenticator: RealmAuthenticator; mode: 'seed' | 'profile' }
+  | { ok: false; error: string };
+
+/**
+ * Pick between seed-based auth and profile-based auth.
+ *
+ * Rules:
+ *  - If `realmSecretSeed` (or `BOXEL_REALM_SECRET_SEED`) is present, use
+ *    `SeedAuthenticator`. We do NOT require a profile in this mode — operators
+ *    using the seed typically don't have a Matrix account configured.
+ *  - Otherwise, fall back to the profile flow and require an active profile,
+ *    preserving the existing error message so callers' handling stays intact.
+ */
+export function resolveRealmAuthenticator(
+  options: AuthResolverOptions,
+): AuthResolution {
+  const seed = options.realmSecretSeed ?? process.env.BOXEL_REALM_SECRET_SEED;
+  if (seed) {
+    const authenticator = new SeedAuthenticator({ seed });
+    authenticator.registerRealmUrl(options.realmUrl);
+    return { ok: true, authenticator, mode: 'seed' };
+  }
+
+  const pm = options.profileManager ?? getProfileManager();
+  if (!pm.getActiveProfile()) {
+    return { ok: false, error: NO_ACTIVE_PROFILE_ERROR };
+  }
+  return { ok: true, authenticator: pm, mode: 'profile' };
+}

--- a/packages/boxel-cli/src/lib/auth-resolver.ts
+++ b/packages/boxel-cli/src/lib/auth-resolver.ts
@@ -9,7 +9,10 @@ import { SeedAuthenticator } from './seed-auth';
 export interface AuthResolverOptions {
   /** Realm URL the command is operating on (used for registering the seed-auth cache). */
   realmUrl: string;
-  /** Explicit seed (from --realm-secret-seed). Wins over BOXEL_REALM_SECRET_SEED. */
+  /**
+   * Already-resolved realm secret seed. Callers who want env + prompt
+   * resolution should go through `resolveRealmSecretSeed` in `./prompt` first.
+   */
   realmSecretSeed?: string;
   /** Override the ProfileManager (tests). When seed mode is active we won't touch it. */
   profileManager?: ProfileManager;
@@ -22,19 +25,18 @@ export type AuthResolution =
 /**
  * Pick between seed-based auth and profile-based auth.
  *
- * Rules:
- *  - If `realmSecretSeed` (or `BOXEL_REALM_SECRET_SEED`) is present, use
- *    `SeedAuthenticator`. We do NOT require a profile in this mode — operators
- *    using the seed typically don't have a Matrix account configured.
- *  - Otherwise, fall back to the profile flow and require an active profile,
- *    preserving the existing error message so callers' handling stays intact.
+ *  - If `realmSecretSeed` is present, use `SeedAuthenticator`. We do NOT
+ *    require a profile in this mode — operators using the seed typically
+ *    don't have a Matrix account configured.
+ *  - Otherwise, fall back to the profile flow and require an active profile.
  */
 export function resolveRealmAuthenticator(
   options: AuthResolverOptions,
 ): AuthResolution {
-  const seed = options.realmSecretSeed ?? process.env.BOXEL_REALM_SECRET_SEED;
-  if (seed) {
-    const authenticator = new SeedAuthenticator({ seed });
+  if (options.realmSecretSeed) {
+    const authenticator = new SeedAuthenticator({
+      seed: options.realmSecretSeed,
+    });
     authenticator.registerRealmUrl(options.realmUrl);
     return { ok: true, authenticator, mode: 'seed' };
   }

--- a/packages/boxel-cli/src/lib/auth-resolver.ts
+++ b/packages/boxel-cli/src/lib/auth-resolver.ts
@@ -34,11 +34,20 @@ export function resolveRealmAuthenticator(
   options: AuthResolverOptions,
 ): AuthResolution {
   if (options.realmSecretSeed) {
-    const authenticator = new SeedAuthenticator({
-      seed: options.realmSecretSeed,
-    });
-    authenticator.registerRealmUrl(options.realmUrl);
-    return { ok: true, authenticator, mode: 'seed' };
+    // registerRealmUrl throws on a malformed realm URL; surface that as a
+    // resolver error so pull/push/sync keep their friendly CLI error path.
+    try {
+      const authenticator = new SeedAuthenticator({
+        seed: options.realmSecretSeed,
+      });
+      authenticator.registerRealmUrl(options.realmUrl);
+      return { ok: true, authenticator, mode: 'seed' };
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
   }
 
   const pm = options.profileManager ?? getProfileManager();

--- a/packages/boxel-cli/src/lib/profile-manager.ts
+++ b/packages/boxel-cli/src/lib/profile-manager.ts
@@ -9,6 +9,7 @@ import {
   addRealmToMatrixAccountData,
   type MatrixAuth,
 } from './auth';
+import type { RealmAuthenticator } from './realm-authenticator';
 
 const DEFAULT_CONFIG_DIR = path.join(os.homedir(), '.boxel-cli');
 const PROFILES_FILENAME = 'profiles.json';
@@ -88,7 +89,7 @@ export function formatProfileBadge(matrixId: string): string {
   return `${DIM}[${RESET}${FG_CYAN}${username}${RESET} ${DIM}\u00b7${RESET} ${FG_MAGENTA}${env}${RESET}${DIM}]${RESET}`;
 }
 
-export class ProfileManager {
+export class ProfileManager implements RealmAuthenticator {
   private config: ProfilesConfig;
   private configDir: string;
   private profilesFile: string;

--- a/packages/boxel-cli/src/lib/prompt.ts
+++ b/packages/boxel-cli/src/lib/prompt.ts
@@ -108,6 +108,10 @@ export function promptPassword(question: string): Promise<string> {
  *   1. `BOXEL_REALM_SECRET_SEED` env var — used silently if set.
  *   2. If `flagPresent` is true, prompt the user (no echo).
  *   3. Otherwise return undefined — caller falls back to profile auth.
+ *
+ * Throws when `--realm-secret-seed` is requested but stdin is not a TTY
+ * (e.g. CI, piped shells) — otherwise `promptPassword` would hang
+ * indefinitely waiting for keypress input it can never receive.
  */
 export async function resolveRealmSecretSeed(
   flagPresent: boolean,
@@ -118,6 +122,12 @@ export async function resolveRealmSecretSeed(
   }
   if (!flagPresent) {
     return undefined;
+  }
+  if (!process.stdin.isTTY) {
+    throw new Error(
+      'Cannot prompt for realm secret seed: stdin is not a TTY. ' +
+        'Set BOXEL_REALM_SECRET_SEED in the environment instead.',
+    );
   }
   return promptPassword('Realm secret seed: ');
 }

--- a/packages/boxel-cli/src/lib/prompt.ts
+++ b/packages/boxel-cli/src/lib/prompt.ts
@@ -1,0 +1,110 @@
+import * as readline from 'readline';
+import { Writable } from 'stream';
+
+export function prompt(question: string): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+/**
+ * Read a secret from stdin without echoing it to the TTY. Keystrokes are
+ * masked with `*` and Ctrl+C exits. Intended for seeds, passwords, and other
+ * sensitive CLI input that must not appear in shell history or `ps aux`.
+ */
+export function promptPassword(question: string): Promise<string> {
+  const mutableOutput = new Writable({
+    write: (_chunk, _encoding, callback) => callback(),
+  });
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: mutableOutput,
+    terminal: true,
+  });
+
+  return new Promise((resolve, reject) => {
+    const stdin = process.stdin;
+    const wasFlowing = stdin.readableFlowing;
+
+    if (stdin.isTTY) {
+      stdin.setRawMode(true);
+    }
+
+    const cleanup = () => {
+      stdin.removeListener('data', onData);
+      if (stdin.isTTY) {
+        stdin.setRawMode(false);
+      }
+      rl.close();
+      if (!wasFlowing) {
+        stdin.pause();
+      }
+    };
+
+    const onData = (char: Buffer) => {
+      try {
+        const c = char.toString();
+        if (c === '\n' || c === '\r') {
+          cleanup();
+          process.stdout.write('\n');
+          resolve(password);
+        } else if (c === '\u0003') {
+          // Ctrl+C
+          cleanup();
+          process.exit();
+        } else if (c === '\u007F' || c === '\b') {
+          // Backspace
+          if (password.length > 0) {
+            password = password.slice(0, -1);
+            process.stdout.write('\b \b');
+          }
+        } else {
+          password += c;
+          process.stdout.write('*');
+        }
+      } catch (e) {
+        cleanup();
+        reject(e);
+      }
+    };
+
+    let password = '';
+    try {
+      process.stdout.write(question);
+      stdin.on('data', onData);
+      stdin.resume();
+    } catch (e) {
+      cleanup();
+      reject(e);
+    }
+  });
+}
+
+/**
+ * Resolve a realm secret seed for administrative CLI operations.
+ *
+ * Precedence:
+ *   1. `BOXEL_REALM_SECRET_SEED` env var — used silently if set.
+ *   2. If `flagPresent` is true, prompt the user (no echo).
+ *   3. Otherwise return undefined — caller falls back to profile auth.
+ */
+export async function resolveRealmSecretSeed(
+  flagPresent: boolean,
+): Promise<string | undefined> {
+  const fromEnv = process.env.BOXEL_REALM_SECRET_SEED;
+  if (fromEnv) {
+    return fromEnv;
+  }
+  if (!flagPresent) {
+    return undefined;
+  }
+  return promptPassword('Realm secret seed: ');
+}

--- a/packages/boxel-cli/src/lib/prompt.ts
+++ b/packages/boxel-cli/src/lib/prompt.ts
@@ -49,26 +49,39 @@ export function promptPassword(question: string): Promise<string> {
       }
     };
 
-    const onData = (char: Buffer) => {
+    const onData = (chunk: Buffer) => {
       try {
-        const c = char.toString();
-        if (c === '\n' || c === '\r') {
-          cleanup();
-          process.stdout.write('\n');
-          resolve(password);
-        } else if (c === '\u0003') {
-          // Ctrl+C
-          cleanup();
-          process.exit();
-        } else if (c === '\u007F' || c === '\b') {
-          // Backspace
-          if (password.length > 0) {
-            password = password.slice(0, -1);
-            process.stdout.write('\b \b');
+        // Pastes arrive as a single data event containing many characters.
+        // Strip bracketed-paste markers if the terminal sent them, then walk
+        // the chunk one code point at a time so newlines, backspace, and
+        // Ctrl+C inside a paste still work.
+        const raw = chunk
+          .toString()
+          .split('[200~')
+          .join('')
+          .split('[201~')
+          .join('');
+        for (const c of raw) {
+          if (c === '\n' || c === '\r') {
+            cleanup();
+            process.stdout.write('\n');
+            resolve(password);
+            return;
+          } else if (c === '\u0003') {
+            // Ctrl+C
+            cleanup();
+            process.exit();
+          } else if (c === '\u007F' || c === '\b') {
+            // Backspace
+            if (password.length > 0) {
+              password = password.slice(0, -1);
+              process.stdout.write('\b \b');
+            }
+          } else if (c >= ' ') {
+            // Printable character; suppress other control bytes entirely.
+            password += c;
+            process.stdout.write('*');
           }
-        } else {
-          password += c;
-          process.stdout.write('*');
         }
       } catch (e) {
         cleanup();

--- a/packages/boxel-cli/src/lib/realm-authenticator.ts
+++ b/packages/boxel-cli/src/lib/realm-authenticator.ts
@@ -1,0 +1,12 @@
+/**
+ * Narrow interface over whatever strategy provides authenticated fetch to a
+ * realm. Both `ProfileManager` (Matrix login + per-realm JWT) and
+ * `SeedAuthenticator` (mint a JWT directly from a shared secret seed) satisfy
+ * this interface, so `RealmSyncBase` can accept either.
+ */
+export interface RealmAuthenticator {
+  authedRealmFetch(
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response>;
+}

--- a/packages/boxel-cli/src/lib/realm-sync-base.ts
+++ b/packages/boxel-cli/src/lib/realm-sync-base.ts
@@ -1,4 +1,4 @@
-import type { ProfileManager } from './profile-manager';
+import type { RealmAuthenticator } from './realm-authenticator';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import ignoreModule from 'ignore';
@@ -49,7 +49,7 @@ export abstract class RealmSyncBase {
 
   constructor(
     protected options: SyncOptions,
-    protected profileManager: ProfileManager,
+    protected authenticator: RealmAuthenticator,
   ) {
     this.normalizedRealmUrl = this.normalizeRealmUrl(options.realmUrl);
   }
@@ -98,7 +98,7 @@ export abstract class RealmSyncBase {
     try {
       const url = this.buildDirectoryUrl(dir);
 
-      const response = await this.profileManager.authedRealmFetch(url, {
+      const response = await this.authenticator.authedRealmFetch(url, {
         headers: {
           Accept: 'application/vnd.api+json',
         },
@@ -178,7 +178,7 @@ export abstract class RealmSyncBase {
     try {
       const url = `${this.normalizedRealmUrl}_mtimes`;
 
-      const response = await this.profileManager.authedRealmFetch(url, {
+      const response = await this.authenticator.authedRealmFetch(url, {
         headers: {
           Accept: SupportedMimeType.Mtimes,
         },
@@ -355,7 +355,7 @@ export abstract class RealmSyncBase {
     const content = await fs.readFile(localPath, 'utf8');
     const url = this.buildFileUrl(relativePath);
 
-    const response = await this.profileManager.authedRealmFetch(url, {
+    const response = await this.authenticator.authedRealmFetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'text/plain;charset=UTF-8',
@@ -423,7 +423,7 @@ export abstract class RealmSyncBase {
     );
 
     const url = `${this.normalizedRealmUrl}_atomic`;
-    const response = await this.profileManager.authedRealmFetch(url, {
+    const response = await this.authenticator.authedRealmFetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/vnd.api+json',
@@ -495,7 +495,7 @@ export abstract class RealmSyncBase {
 
     const url = this.buildFileUrl(relativePath);
 
-    const response = await this.profileManager.authedRealmFetch(url, {
+    const response = await this.authenticator.authedRealmFetch(url, {
       headers: {
         Accept: SupportedMimeType.CardSource,
       },
@@ -531,7 +531,7 @@ export abstract class RealmSyncBase {
 
     const url = this.buildFileUrl(relativePath);
 
-    const response = await this.profileManager.authedRealmFetch(url, {
+    const response = await this.authenticator.authedRealmFetch(url, {
       method: 'DELETE',
       headers: {
         Accept: SupportedMimeType.CardSource,

--- a/packages/boxel-cli/src/lib/seed-auth.ts
+++ b/packages/boxel-cli/src/lib/seed-auth.ts
@@ -151,9 +151,10 @@ export class SeedAuthenticator implements RealmAuthenticator {
   /**
    * Given any URL inside a realm (or the realm root itself), return the realm
    * root URL we'll use to mint the token. We match against the set of realm
-   * URLs we've already minted tokens for, falling back to the request's
-   * origin + first path segment (trailing slash), which matches the
-   * CLI-visible realm URL convention (`https://<host>/<owner>/<realm>/`).
+   * URLs we've already minted tokens for; the fallback (when nothing is
+   * pre-registered) takes the request's origin + first two path segments
+   * with a trailing slash, which matches the CLI-visible realm URL
+   * convention `https://<host>/<owner>/<realm>/`.
    */
   #resolveRealmUrl(requestUrl: string): string {
     for (const realmUrl of this.#tokenCache.keys()) {

--- a/packages/boxel-cli/src/lib/seed-auth.ts
+++ b/packages/boxel-cli/src/lib/seed-auth.ts
@@ -1,0 +1,214 @@
+import jwt from 'jsonwebtoken';
+import type { RealmAuthenticator } from './realm-authenticator';
+
+/**
+ * The realm server's shared matrix-client username in every deployed
+ * environment (local, staging, production). Bot user ids are formed as
+ * `@realm_server:<host>` and the realm short-circuits authorization for that
+ * id — see packages/runtime-common/realm.ts:2221.
+ */
+export const DEFAULT_REALM_BOT_USERNAME = 'realm_server';
+
+/**
+ * Derive the Matrix host portion (`:<host>`) for a bot user id from a realm
+ * URL, mirroring `userIdFromUsername` in
+ * `packages/runtime-common/matrix-client.ts`:
+ *   - hostname ending in `.localhost` (and bare `localhost`) collapses to `localhost`
+ *   - otherwise the last two labels of the hostname are used
+ * So:
+ *   - http://localhost:4201/…             → localhost
+ *   - https://realms-staging.stack.cards/… → stack.cards
+ *   - https://app.boxel.ai/…              → boxel.ai
+ */
+export function deriveHostFromRealmUrl(realmUrl: string): string {
+  const { hostname } = new URL(realmUrl);
+  if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
+    return 'localhost';
+  }
+  const labels = hostname.split('.');
+  if (labels.length <= 2) {
+    return hostname;
+  }
+  return labels.slice(-2).join('.');
+}
+
+export function deriveBotUserId(
+  realmUrl: string,
+  username: string = DEFAULT_REALM_BOT_USERNAME,
+): string {
+  return `@${username}:${deriveHostFromRealmUrl(realmUrl)}`;
+}
+
+/**
+ * Origin (with trailing slash) for the realm server hosting a given realm URL.
+ * This is what the realm embeds in JWT claims as `realmServerURL`.
+ */
+export function deriveRealmServerUrl(realmUrl: string): string {
+  return new URL(realmUrl).origin + '/';
+}
+
+function normalizeRealmUrl(realmUrl: string): string {
+  try {
+    const u = new URL(realmUrl);
+    return u.href.replace(/\/+$/, '') + '/';
+  } catch {
+    throw new Error(`Invalid realm URL: ${realmUrl}`);
+  }
+}
+
+export interface SeedAuthenticatorOptions {
+  /** Raw realm secret seed used to sign JWTs (HS256). */
+  seed: string;
+  /**
+   * Override for the realm-server's matrix-client username. Real deployments
+   * all use `realm_server`, but integration tests use a different username, so
+   * tests can inject their own. Defaults to `realm_server`.
+   */
+  botUsername?: string;
+  /**
+   * Full override for the bot matrix user id (e.g.
+   * `@node-test_realm-server:localhost`). When set, disables the per-realm
+   * host derivation entirely — tests that run against a realm hosted on
+   * `127.0.0.1` (where two-label derivation is nonsense) pass the expected
+   * bot id explicitly.
+   */
+  botUserId?: string;
+  /** Override the 7-day JWT expiry used by real deployments. */
+  expiresIn?: jwt.SignOptions['expiresIn'];
+}
+
+export interface RealmJwtClaims {
+  user: string;
+  realm: string;
+  sessionRoom: undefined;
+  permissions: [];
+  realmServerURL: string;
+}
+
+/**
+ * `RealmAuthenticator` implementation that authenticates via a locally-minted
+ * JWT signed with the realm secret seed, bypassing Matrix login and the
+ * `/_server-session` + `/_realm-auth` handshake.
+ *
+ * How it works: the realm short-circuits authorization when the JWT's `user`
+ * claim equals the realm's own matrix-client user id
+ * (packages/runtime-common/realm.ts:2221). That id is stable per deployment —
+ * `@realm_server:<host>` in every real environment. So given the seed, we mint
+ * a token with `user = @realm_server:<derived-host>`, `realm = <normalized
+ * realm url>`, `realmServerURL = <origin>/`, `permissions = []`, and
+ * everything else is ignored by the short-circuit.
+ */
+export class SeedAuthenticator implements RealmAuthenticator {
+  readonly #seed: string;
+  readonly #botUsername: string;
+  readonly #botUserIdOverride: string | undefined;
+  readonly #expiresIn: jwt.SignOptions['expiresIn'];
+  readonly #tokenCache = new Map<string, string>();
+
+  constructor(options: SeedAuthenticatorOptions) {
+    if (!options.seed) {
+      throw new Error('SeedAuthenticator requires a non-empty seed');
+    }
+    this.#seed = options.seed;
+    this.#botUsername = options.botUsername ?? DEFAULT_REALM_BOT_USERNAME;
+    this.#botUserIdOverride = options.botUserId;
+    this.#expiresIn = options.expiresIn ?? '7d';
+  }
+
+  /**
+   * Build the JWT claims for a given realm URL. Exposed for tests that need
+   * to inspect payload shape without decoding the signed token.
+   */
+  buildClaims(realmUrl: string): RealmJwtClaims {
+    const normalizedRealm = normalizeRealmUrl(realmUrl);
+    const user =
+      this.#botUserIdOverride ??
+      deriveBotUserId(normalizedRealm, this.#botUsername);
+    return {
+      user,
+      realm: normalizedRealm,
+      sessionRoom: undefined,
+      permissions: [],
+      realmServerURL: deriveRealmServerUrl(normalizedRealm),
+    };
+  }
+
+  /**
+   * Mint (or return a cached) JWT for the given realm URL.
+   */
+  mintTokenForRealm(realmUrl: string): string {
+    const normalized = normalizeRealmUrl(realmUrl);
+    const cached = this.#tokenCache.get(normalized);
+    if (cached) {
+      return cached;
+    }
+    const token = jwt.sign(this.buildClaims(normalized), this.#seed, {
+      expiresIn: this.#expiresIn,
+    });
+    this.#tokenCache.set(normalized, token);
+    return token;
+  }
+
+  /**
+   * Given any URL inside a realm (or the realm root itself), return the realm
+   * root URL we'll use to mint the token. We match against the set of realm
+   * URLs we've already minted tokens for, falling back to the request's
+   * origin + first path segment (trailing slash), which matches the
+   * CLI-visible realm URL convention (`https://<host>/<owner>/<realm>/`).
+   */
+  #resolveRealmUrl(requestUrl: string): string {
+    for (const realmUrl of this.#tokenCache.keys()) {
+      if (requestUrl.startsWith(realmUrl)) {
+        return realmUrl;
+      }
+    }
+    const u = new URL(requestUrl);
+    const segments = u.pathname.split('/').filter(Boolean);
+    const realmRootPath =
+      segments.length > 0 ? `/${segments.slice(0, 2).join('/')}/` : '/';
+    return `${u.origin}${realmRootPath}`;
+  }
+
+  async authedRealmFetch(
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const url =
+      input instanceof Request
+        ? input.url
+        : input instanceof URL
+          ? input.href
+          : input;
+
+    const realmUrl = this.#resolveRealmUrl(url);
+    const token = this.mintTokenForRealm(realmUrl);
+    const headers = this.#buildHeaders(input, init, token);
+    return fetch(input, { ...init, headers });
+  }
+
+  #buildHeaders(
+    input: string | URL | Request,
+    init: RequestInit | undefined,
+    token: string,
+  ): Headers {
+    const baseHeaders =
+      input instanceof Request ? new Headers(input.headers) : new Headers();
+    const initHeaders = new Headers(init?.headers);
+    for (const [key, value] of initHeaders) {
+      baseHeaders.set(key, value);
+    }
+    if (!baseHeaders.has('Authorization')) {
+      baseHeaders.set('Authorization', token);
+    }
+    return baseHeaders;
+  }
+
+  /**
+   * Pre-register a realm URL so that requests to sub-paths of it always use
+   * the exact realm URL for token minting. The CLI commands call this with
+   * the user-supplied realm URL before doing any fetches.
+   */
+  registerRealmUrl(realmUrl: string): void {
+    this.mintTokenForRealm(realmUrl);
+  }
+}

--- a/packages/boxel-cli/src/lib/seed-auth.ts
+++ b/packages/boxel-cli/src/lib/seed-auth.ts
@@ -60,20 +60,19 @@ export interface SeedAuthenticatorOptions {
   /** Raw realm secret seed used to sign JWTs (HS256). */
   seed: string;
   /**
-   * Override for the realm-server's matrix-client username. Real deployments
-   * all use `realm_server`, but integration tests use a different username, so
-   * tests can inject their own. Defaults to `realm_server`.
+   * @internal Override the realm-server's matrix-client username. Real
+   * deployments all use `realm_server`; tests against a server with a
+   * different username inject their own.
    */
   botUsername?: string;
   /**
-   * Full override for the bot matrix user id (e.g.
-   * `@node-test_realm-server:localhost`). When set, disables the per-realm
-   * host derivation entirely — tests that run against a realm hosted on
-   * `127.0.0.1` (where two-label derivation is nonsense) pass the expected
-   * bot id explicitly.
+   * @internal Full override for the bot matrix user id (e.g.
+   * `@node-test_realm-server:localhost`). Used by integration tests that run
+   * against a realm on `127.0.0.1`, where the two-label host-derivation
+   * formula is nonsensical.
    */
   botUserId?: string;
-  /** Override the 7-day JWT expiry used by real deployments. */
+  /** @internal Override the 7-day JWT expiry used by real deployments. */
   expiresIn?: jwt.SignOptions['expiresIn'];
 }
 
@@ -137,15 +136,15 @@ export class SeedAuthenticator implements RealmAuthenticator {
    * Mint (or return a cached) JWT for the given realm URL.
    */
   mintTokenForRealm(realmUrl: string): string {
-    const normalized = normalizeRealmUrl(realmUrl);
-    const cached = this.#tokenCache.get(normalized);
+    const claims = this.buildClaims(realmUrl);
+    const cached = this.#tokenCache.get(claims.realm);
     if (cached) {
       return cached;
     }
-    const token = jwt.sign(this.buildClaims(normalized), this.#seed, {
+    const token = jwt.sign(claims, this.#seed, {
       expiresIn: this.#expiresIn,
     });
-    this.#tokenCache.set(normalized, token);
+    this.#tokenCache.set(claims.realm, token);
     return token;
   }
 

--- a/packages/boxel-cli/tests/integration/realm-pull-seed-auth.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-pull-seed-auth.test.ts
@@ -1,0 +1,115 @@
+import '../helpers/setup-realm-server';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { pull } from '../../src/commands/realm/pull';
+import { SeedAuthenticator } from '../../src/lib/seed-auth';
+import {
+  startTestRealmServer,
+  stopTestRealmServer,
+  createTestProfileDir,
+  TEST_REALM_SERVER_URL,
+} from '../helpers/integration';
+
+// The test realm server in helpers/integration.ts uses `realmSecretSeed =
+// "shhh! it's a secret"` to sign realm JWTs and
+// `username = 'node-test_realm-server'` for the realm's matrix client, so the
+// bot id the realm short-circuits on is `@node-test_realm-server:localhost`.
+//
+// In real deployments this would just be `@realm_server:<host>`, but the test
+// helper deviates from the convention — we feed the exact expected bot id to
+// SeedAuthenticator via the `botUserId` override.
+const TEST_REALM_SECRET_SEED = `shhh! it's a secret`;
+const TEST_REALM_BOT_USER_ID = '@node-test_realm-server:localhost';
+
+let realmUrl: string;
+let localDirs: string[] = [];
+
+function makeLocalDir(): string {
+  let dir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-pull-seed-int-'));
+  localDirs.push(dir);
+  return dir;
+}
+
+beforeAll(async () => {
+  await startTestRealmServer({
+    fileSystem: {
+      'hello.gts': 'export const hello = "world";\n',
+      'nested/card.gts': 'export const nested = true;\n',
+    },
+  });
+  realmUrl = `${TEST_REALM_SERVER_URL}/test/`;
+});
+
+afterAll(async () => {
+  for (let dir of localDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  await stopTestRealmServer();
+});
+
+describe('realm pull with seed-based auth (integration)', () => {
+  it('pulls files authenticating via a locally-minted JWT (no Matrix login)', async () => {
+    let localDir = makeLocalDir();
+
+    // Empty profile: no Matrix login credentials exist at all. The CLI must
+    // authenticate purely from the seed.
+    let { profileManager, cleanup } = createTestProfileDir();
+
+    try {
+      let authenticator = new SeedAuthenticator({
+        seed: TEST_REALM_SECRET_SEED,
+        botUserId: TEST_REALM_BOT_USER_ID,
+      });
+
+      let result = await pull(realmUrl, localDir, {
+        authenticator,
+        profileManager,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.files).toContain('hello.gts');
+      expect(result.files).toContain('nested/card.gts');
+
+      let helloPath = path.join(localDir, 'hello.gts');
+      expect(fs.existsSync(helloPath)).toBe(true);
+      expect(fs.readFileSync(helloPath, 'utf8')).toContain('hello = "world"');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('fails cleanly with the "No active profile" error when neither a seed nor a profile is configured', async () => {
+    let localDir = makeLocalDir();
+    let { profileManager, cleanup } = createTestProfileDir();
+    try {
+      let result = await pull(realmUrl, localDir, { profileManager });
+      expect(result.files).toEqual([]);
+      expect(result.error).toContain('No active profile');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('resolves --realm-secret-seed through the CLI resolver without requiring a profile', async () => {
+    // Exercises the flag-driven path end-to-end: the CLI builds a
+    // SeedAuthenticator from the seed using the default `realm_server`
+    // username, no Matrix login is attempted, and no "No active profile"
+    // error surfaces even with an empty profile dir. The test realm permits
+    // read access to any authenticated user (`'*': ['read','write']`), so
+    // the download succeeds whenever the JWT is signed with the right seed.
+    let localDir = makeLocalDir();
+    let emptyProfile = createTestProfileDir();
+    try {
+      let result = await pull(realmUrl, localDir, {
+        realmSecretSeed: TEST_REALM_SECRET_SEED,
+        profileManager: emptyProfile.profileManager,
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.files).toContain('hello.gts');
+    } finally {
+      emptyProfile.cleanup();
+    }
+  });
+});

--- a/packages/boxel-cli/tests/lib/auth-resolver.test.ts
+++ b/packages/boxel-cli/tests/lib/auth-resolver.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { resolveRealmAuthenticator } from '../../src/lib/auth-resolver';
+import { SeedAuthenticator } from '../../src/lib/seed-auth';
+import { ProfileManager } from '../../src/lib/profile-manager';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+describe('resolveRealmAuthenticator', () => {
+  let profileDir: string;
+  let pm: ProfileManager;
+
+  beforeEach(() => {
+    profileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-auth-resolver-'));
+    pm = new ProfileManager(profileDir);
+    delete process.env.BOXEL_REALM_SECRET_SEED;
+  });
+
+  afterEach(() => {
+    fs.rmSync(profileDir, { recursive: true, force: true });
+    delete process.env.BOXEL_REALM_SECRET_SEED;
+  });
+
+  it('returns a SeedAuthenticator when --realm-secret-seed is passed', () => {
+    const result = resolveRealmAuthenticator({
+      realmUrl: 'https://app.boxel.ai/demo/',
+      realmSecretSeed: 'my-seed',
+      profileManager: pm,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.mode).toBe('seed');
+      expect(result.authenticator).toBeInstanceOf(SeedAuthenticator);
+    }
+  });
+
+  it('falls back to BOXEL_REALM_SECRET_SEED env var when the flag is absent', () => {
+    process.env.BOXEL_REALM_SECRET_SEED = 'env-seed';
+    const result = resolveRealmAuthenticator({
+      realmUrl: 'https://app.boxel.ai/demo/',
+      profileManager: pm,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.mode).toBe('seed');
+    }
+  });
+
+  it('prefers the explicit flag over the env var', () => {
+    process.env.BOXEL_REALM_SECRET_SEED = 'env-seed';
+    const result = resolveRealmAuthenticator({
+      realmUrl: 'https://app.boxel.ai/demo/',
+      realmSecretSeed: 'flag-seed',
+      profileManager: pm,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.mode).toBe('seed');
+    }
+  });
+
+  it('returns the profile manager when no seed is supplied and a profile is active', async () => {
+    await pm.addProfile(
+      '@ctse:stack.cards',
+      'password',
+      'Test',
+      'https://matrix-staging.stack.cards',
+      'https://realms-staging.stack.cards/',
+    );
+    const result = resolveRealmAuthenticator({
+      realmUrl: 'https://realms-staging.stack.cards/demo/',
+      profileManager: pm,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.mode).toBe('profile');
+      expect(result.authenticator).toBe(pm);
+    }
+  });
+
+  it('returns an error when no seed and no active profile exist', () => {
+    const result = resolveRealmAuthenticator({
+      realmUrl: 'https://app.boxel.ai/demo/',
+      profileManager: pm,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('No active profile');
+    }
+  });
+});

--- a/packages/boxel-cli/tests/lib/auth-resolver.test.ts
+++ b/packages/boxel-cli/tests/lib/auth-resolver.test.ts
@@ -13,15 +13,13 @@ describe('resolveRealmAuthenticator', () => {
   beforeEach(() => {
     profileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-auth-resolver-'));
     pm = new ProfileManager(profileDir);
-    delete process.env.BOXEL_REALM_SECRET_SEED;
   });
 
   afterEach(() => {
     fs.rmSync(profileDir, { recursive: true, force: true });
-    delete process.env.BOXEL_REALM_SECRET_SEED;
   });
 
-  it('returns a SeedAuthenticator when --realm-secret-seed is passed', () => {
+  it('returns a SeedAuthenticator when a seed is supplied', () => {
     const result = resolveRealmAuthenticator({
       realmUrl: 'https://app.boxel.ai/demo/',
       realmSecretSeed: 'my-seed',
@@ -31,31 +29,6 @@ describe('resolveRealmAuthenticator', () => {
     if (result.ok) {
       expect(result.mode).toBe('seed');
       expect(result.authenticator).toBeInstanceOf(SeedAuthenticator);
-    }
-  });
-
-  it('falls back to BOXEL_REALM_SECRET_SEED env var when the flag is absent', () => {
-    process.env.BOXEL_REALM_SECRET_SEED = 'env-seed';
-    const result = resolveRealmAuthenticator({
-      realmUrl: 'https://app.boxel.ai/demo/',
-      profileManager: pm,
-    });
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.mode).toBe('seed');
-    }
-  });
-
-  it('prefers the explicit flag over the env var', () => {
-    process.env.BOXEL_REALM_SECRET_SEED = 'env-seed';
-    const result = resolveRealmAuthenticator({
-      realmUrl: 'https://app.boxel.ai/demo/',
-      realmSecretSeed: 'flag-seed',
-      profileManager: pm,
-    });
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.mode).toBe('seed');
     }
   });
 

--- a/packages/boxel-cli/tests/lib/auth-resolver.test.ts
+++ b/packages/boxel-cli/tests/lib/auth-resolver.test.ts
@@ -61,4 +61,16 @@ describe('resolveRealmAuthenticator', () => {
       expect(result.error).toContain('No active profile');
     }
   });
+
+  it('returns a friendly error (not a throw) when the realm URL is malformed in seed mode', () => {
+    const result = resolveRealmAuthenticator({
+      realmUrl: 'not-a-url',
+      realmSecretSeed: 'my-seed',
+      profileManager: pm,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/Invalid realm URL/);
+    }
+  });
 });

--- a/packages/boxel-cli/tests/lib/prompt.test.ts
+++ b/packages/boxel-cli/tests/lib/prompt.test.ts
@@ -32,4 +32,13 @@ describe('resolveRealmSecretSeed', () => {
     process.env.BOXEL_REALM_SECRET_SEED = 'env-seed';
     await expect(resolveRealmSecretSeed(true)).resolves.toBe('env-seed');
   });
+
+  it('throws when the flag is requested but stdin is not a TTY', async () => {
+    // In the vitest runner stdin is never a TTY, which is exactly the
+    // non-interactive case (CI, piped shells) we want to fail fast on.
+    expect(process.stdin.isTTY).toBeFalsy();
+    await expect(resolveRealmSecretSeed(true)).rejects.toThrow(
+      /stdin is not a TTY/,
+    );
+  });
 });

--- a/packages/boxel-cli/tests/lib/prompt.test.ts
+++ b/packages/boxel-cli/tests/lib/prompt.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { resolveRealmSecretSeed } from '../../src/lib/prompt';
+
+describe('resolveRealmSecretSeed', () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.BOXEL_REALM_SECRET_SEED;
+    delete process.env.BOXEL_REALM_SECRET_SEED;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.BOXEL_REALM_SECRET_SEED;
+    } else {
+      process.env.BOXEL_REALM_SECRET_SEED = originalEnv;
+    }
+  });
+
+  it('returns undefined when the flag is absent and no env var is set', async () => {
+    await expect(resolveRealmSecretSeed(false)).resolves.toBeUndefined();
+  });
+
+  it('returns the env var silently, even when the flag is absent', async () => {
+    process.env.BOXEL_REALM_SECRET_SEED = 'env-seed';
+    await expect(resolveRealmSecretSeed(false)).resolves.toBe('env-seed');
+  });
+
+  it('prefers the env var over prompting when both would apply', async () => {
+    // If the env var is present, we must NOT prompt the TTY — this test
+    // would hang on stdin if the implementation reached promptPassword.
+    process.env.BOXEL_REALM_SECRET_SEED = 'env-seed';
+    await expect(resolveRealmSecretSeed(true)).resolves.toBe('env-seed');
+  });
+});

--- a/packages/boxel-cli/tests/lib/seed-auth.test.ts
+++ b/packages/boxel-cli/tests/lib/seed-auth.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import jwt from 'jsonwebtoken';
+import {
+  SeedAuthenticator,
+  DEFAULT_REALM_BOT_USERNAME,
+  deriveBotUserId,
+  deriveHostFromRealmUrl,
+  deriveRealmServerUrl,
+} from '../../src/lib/seed-auth';
+
+const SEED = 'shhh-its-a-secret';
+
+describe('deriveHostFromRealmUrl', () => {
+  it('collapses *.localhost to localhost', () => {
+    expect(
+      deriveHostFromRealmUrl('http://realm.localhost:4201/hassan/demo/'),
+    ).toBe('localhost');
+  });
+
+  it('treats bare localhost as localhost', () => {
+    expect(deriveHostFromRealmUrl('http://localhost:4201/hassan/demo/')).toBe(
+      'localhost',
+    );
+  });
+
+  it('returns the last two labels for three-label domains', () => {
+    expect(
+      deriveHostFromRealmUrl('https://realms-staging.stack.cards/hassan/my/'),
+    ).toBe('stack.cards');
+    expect(deriveHostFromRealmUrl('https://app.boxel.ai/')).toBe('boxel.ai');
+  });
+
+  it('returns the whole hostname for two-label domains', () => {
+    expect(deriveHostFromRealmUrl('https://boxel.ai/')).toBe('boxel.ai');
+  });
+
+  it('returns the whole hostname for single-label hosts', () => {
+    expect(deriveHostFromRealmUrl('http://myhost/x/y/')).toBe('myhost');
+  });
+});
+
+describe('deriveBotUserId', () => {
+  it('uses the default realm_server username', () => {
+    expect(deriveBotUserId('http://localhost:4201/demo/')).toBe(
+      `@${DEFAULT_REALM_BOT_USERNAME}:localhost`,
+    );
+    expect(
+      deriveBotUserId('https://realms-staging.stack.cards/hassan/my/'),
+    ).toBe('@realm_server:stack.cards');
+    expect(deriveBotUserId('https://app.boxel.ai/demo/')).toBe(
+      '@realm_server:boxel.ai',
+    );
+  });
+
+  it('honors a username override', () => {
+    expect(
+      deriveBotUserId('http://localhost:4201/demo/', 'node-test_realm-server'),
+    ).toBe('@node-test_realm-server:localhost');
+  });
+});
+
+describe('deriveRealmServerUrl', () => {
+  it('returns origin with trailing slash', () => {
+    expect(deriveRealmServerUrl('https://app.boxel.ai/demo/')).toBe(
+      'https://app.boxel.ai/',
+    );
+    expect(
+      deriveRealmServerUrl('https://realms-staging.stack.cards/hassan/my/'),
+    ).toBe('https://realms-staging.stack.cards/');
+    expect(deriveRealmServerUrl('http://localhost:4201/demo/')).toBe(
+      'http://localhost:4201/',
+    );
+  });
+});
+
+describe('SeedAuthenticator', () => {
+  it('refuses an empty seed', () => {
+    expect(() => new SeedAuthenticator({ seed: '' })).toThrow(/non-empty seed/);
+  });
+
+  it('builds claims with bot user id, realm URL, realmServerURL, and empty permissions', () => {
+    const auth = new SeedAuthenticator({ seed: SEED });
+    const claims = auth.buildClaims('https://app.boxel.ai/demo/');
+    expect(claims).toEqual({
+      user: '@realm_server:boxel.ai',
+      realm: 'https://app.boxel.ai/demo/',
+      sessionRoom: undefined,
+      permissions: [],
+      realmServerURL: 'https://app.boxel.ai/',
+    });
+  });
+
+  it('normalizes realm URLs without trailing slash', () => {
+    const auth = new SeedAuthenticator({ seed: SEED });
+    const claims = auth.buildClaims('https://app.boxel.ai/demo');
+    expect(claims.realm).toBe('https://app.boxel.ai/demo/');
+  });
+
+  it('mints a JWT that verifies against the seed and decodes to the expected payload', () => {
+    const auth = new SeedAuthenticator({ seed: SEED });
+    const token = auth.mintTokenForRealm('https://app.boxel.ai/demo/');
+    const decoded = jwt.verify(token, SEED) as Record<string, unknown>;
+    expect(decoded.user).toBe('@realm_server:boxel.ai');
+    expect(decoded.realm).toBe('https://app.boxel.ai/demo/');
+    expect(decoded.realmServerURL).toBe('https://app.boxel.ai/');
+    expect(decoded.permissions).toEqual([]);
+    expect(typeof decoded.exp).toBe('number');
+    expect(typeof decoded.iat).toBe('number');
+    // 7-day default expiry is in the ballpark of 7 * 24 * 3600 seconds
+    expect((decoded.exp as number) - (decoded.iat as number)).toBe(
+      7 * 24 * 3600,
+    );
+  });
+
+  it('caches tokens per realm URL (same call returns identical string)', () => {
+    const auth = new SeedAuthenticator({ seed: SEED });
+    const realmUrl = 'https://app.boxel.ai/demo/';
+    const first = auth.mintTokenForRealm(realmUrl);
+    const second = auth.mintTokenForRealm(realmUrl);
+    expect(second).toBe(first);
+  });
+
+  it('honors a botUserId override (used by integration tests against IP realms)', () => {
+    const auth = new SeedAuthenticator({
+      seed: SEED,
+      botUserId: '@node-test_realm-server:localhost',
+    });
+    const claims = auth.buildClaims('http://127.0.0.1:4446/test/');
+    expect(claims.user).toBe('@node-test_realm-server:localhost');
+    // realmServerURL is still derived from the realm URL origin
+    expect(claims.realmServerURL).toBe('http://127.0.0.1:4446/');
+  });
+
+  it('honors a botUsername override on top of the derived host', () => {
+    const auth = new SeedAuthenticator({
+      seed: SEED,
+      botUsername: 'custom_bot',
+    });
+    const claims = auth.buildClaims('https://app.boxel.ai/demo/');
+    expect(claims.user).toBe('@custom_bot:boxel.ai');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1055,6 +1055,9 @@ importers:
       ignore:
         specifier: 'catalog:'
         version: 5.3.2
+      jsonwebtoken:
+        specifier: 'catalog:'
+        version: 9.0.3
       p-limit:
         specifier: ^7.3.0
         version: 7.3.0
@@ -1068,6 +1071,9 @@ importers:
       '@cardstack/runtime-common':
         specifier: workspace:*
         version: link:../runtime-common
+      '@types/jsonwebtoken':
+        specifier: 'catalog:'
+        version: 9.0.10
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.8


### PR DESCRIPTION
## Summary

Adds an administrative escape hatch to `boxel realm pull / push / sync` for operators who hold the realm secret seed but don't have a Matrix account configured for a given environment. Intended for diagnosing issues in privately hosted realms (e.g., pulling a realm from staging when the usual Matrix credentials aren't set up on the operator's machine).

New flag on pull / push / sync:

```
--realm-secret-seed   prompt for a realm secret seed instead of using a
                      Matrix profile
                      (env: BOXEL_REALM_SECRET_SEED)
```

The flag is valueless — it triggers a no-echo TTY prompt, so the seed stays out of shell history and `ps aux`. The env var takes precedence over the prompt when set. Fails fast with a clear error when the flag is requested without a TTY (CI, piped shells).

The default profile-based flow is unchanged; this is purely additive.

## Design notes

- New `RealmAuthenticator` interface (just `authedRealmFetch`). Both the existing `ProfileManager` and a new `SeedAuthenticator` implement it. `RealmSyncBase` accepts the interface.
- `auth-resolver.ts`: picks seed mode when a seed is present, otherwise falls back to profile mode (preserving the existing `No active profile` error). Malformed realm URLs surface as a friendly CLI error rather than an uncaught throw.
- `lib/prompt.ts`: hoists `promptPassword` out of `commands/profile.ts` so both the Matrix-password prompt and the new seed prompt share one implementation (including paste handling). Adds `resolveRealmSecretSeed(flagPresent)` layering `BOXEL_REALM_SECRET_SEED` env → TTY prompt → undefined, with a non-TTY guard.
- Test-only fields (`SeedAuthenticator`'s `botUserId` / `botUsername` / `expiresIn`, and the command-level `authenticator` hatch) are marked `@internal`.

## Test plan

- [x] `pnpm lint` inside `packages/boxel-cli` — passes (JS + types).
- [x] `pnpm test:unit` inside `packages/boxel-cli` — 127 passed.
- [ ] Integration: `tests/integration/realm-pull-seed-auth.test.ts` added; requires Postgres via `./tests/scripts/run-integration-with-test-pg.sh`. CI will exercise it.
- [ ] Manual smoke: pull a realm from staging with `BOXEL_REALM_SECRET_SEED=... boxel realm pull https://realms-staging.stack.cards/<owner>/<realm>/ ./local-dir` (and the interactive `--realm-secret-seed` variant).