### PR TITLE
cli: Add support for custom servers in profile add

### DIFF
--- a/packages/boxel-cli/README.md
+++ b/packages/boxel-cli/README.md
@@ -38,7 +38,7 @@ boxel --version
 These are read by `boxel profile add`:
 
 - `BOXEL_PASSWORD` — password for non-interactive profile creation. Preferred over `-p/--password`, which exposes the password in shell history and process listings.
-- `BOXEL_ENVIRONMENT` — env-mode slug (typically a branch name) for per-branch local dev. Interpreted like `mise-tasks/lib/env-vars.sh`: the value is slugified (lowercased, `/` → `-`, other chars stripped) and URLs are derived as `http://matrix.<slug>.localhost` and `http://realm-server.<slug>.localhost/`. Overridden by `--matrix-url` / `--realm-server-url` if those flags are provided. Values that slugify to empty (e.g. `!!!`) exit with an error.
+- `BOXEL_ENVIRONMENT` — env-mode slug (typically a branch name) for per-branch local dev. Interpreted like `scripts/env-slug.sh`: the value is slugified (lowercased, `/` → `-`, other chars stripped) and URLs are derived as `http://matrix.<slug>.localhost` and `http://realm-server.<slug>.localhost/`. Overridden by `--matrix-url` / `--realm-server-url` if those flags are provided. Values that slugify to empty (e.g. `!!!`) exit with an error.
 
 Example — create a profile for a branch running in env mode:
 

--- a/packages/boxel-cli/README.md
+++ b/packages/boxel-cli/README.md
@@ -38,12 +38,13 @@ boxel --version
 These are read by `boxel profile add`:
 
 - `BOXEL_PASSWORD` — password for non-interactive profile creation. Preferred over `-p/--password`, which exposes the password in shell history and process listings.
-- `BOXEL_ENVIRONMENT` — one of `staging`, `production`, or `local`. When set, Matrix and realm server URLs (and the default domain for the interactive flow) are derived from it. Overridden by `--matrix-url` / `--realm-server-url` if those flags are provided. Unknown values exit with an error.
+- `BOXEL_ENVIRONMENT` — env-mode slug (typically a branch name) for per-branch local dev. Interpreted like `mise-tasks/lib/env-vars.sh`: the value is slugified (lowercased, `/` → `-`, other chars stripped) and URLs are derived as `http://matrix.<slug>.localhost` and `http://realm-server.<slug>.localhost/`. Overridden by `--matrix-url` / `--realm-server-url` if those flags are provided. Values that slugify to empty (e.g. `!!!`) exit with an error.
 
-Example — create a staging profile non-interactively:
+Example — create a profile for a branch running in env mode:
 
 ```bash
-BOXEL_PASSWORD=… BOXEL_ENVIRONMENT=staging boxel profile add -u @alice:stack.cards
+BOXEL_PASSWORD=… BOXEL_ENVIRONMENT=cs-10998-my-branch \
+  boxel profile add -u @alice:cs-10998-my-branch.localhost
 ```
 
 Example — create a profile against a custom realm server:

--- a/packages/boxel-cli/README.md
+++ b/packages/boxel-cli/README.md
@@ -33,6 +33,28 @@ boxel --help
 boxel --version
 ```
 
+### Environment variables
+
+These are read by `boxel profile add`:
+
+- `BOXEL_PASSWORD` — password for non-interactive profile creation. Preferred over `-p/--password`, which exposes the password in shell history and process listings.
+- `BOXEL_ENVIRONMENT` — one of `staging`, `production`, or `local`. When set, Matrix and realm server URLs (and the default domain for the interactive flow) are derived from it. Overridden by `--matrix-url` / `--realm-server-url` if those flags are provided. Unknown values exit with an error.
+
+Example — create a staging profile non-interactively:
+
+```bash
+BOXEL_PASSWORD=… BOXEL_ENVIRONMENT=staging boxel profile add -u @alice:stack.cards
+```
+
+Example — create a profile against a custom realm server:
+
+```bash
+BOXEL_PASSWORD=… boxel profile add \
+  -u @alice:my.server \
+  --matrix-url https://matrix.my.server \
+  --realm-server-url https://realms.my.server/
+```
+
 ## Development
 
 ### Building

--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -105,6 +105,8 @@ export interface ProfileCommandOptions {
   user?: string;
   password?: string;
   name?: string;
+  matrixUrl?: string;
+  realmServerUrl?: string;
 }
 
 export async function profileCommand(
@@ -127,6 +129,8 @@ export async function profileCommand(
           options.user,
           password,
           options.name,
+          options.matrixUrl,
+          options.realmServerUrl,
         );
       } else {
         await addProfile(manager);
@@ -224,16 +228,41 @@ async function addProfile(manager: ProfileManager): Promise<void> {
   console.log(`  ${FG_CYAN}1${RESET}) Staging (realms-staging.stack.cards)`);
   console.log(`  ${FG_MAGENTA}2${RESET}) Production (app.boxel.ai)`);
   console.log(`  ${FG_GREEN}3${RESET}) Local (localhost:4201)`);
+  console.log(`  ${FG_YELLOW}4${RESET}) Custom (enter your own URLs)`);
 
-  const envChoice = await prompt('\nChoice [1/2/3]: ');
+  const envChoice = await prompt('\nChoice [1/2/3/4]: ');
   const isProduction = envChoice === '2';
   const isLocal = envChoice === '3';
+  const isCustom = envChoice === '4';
 
   let domain: string;
   let defaultMatrixUrl: string;
   let defaultRealmUrl: string;
 
-  if (isLocal) {
+  if (isCustom) {
+    const matrixUrlInput = await prompt('Matrix server URL: ');
+    if (!matrixUrlInput) {
+      console.error(`${FG_RED}Error:${RESET} Matrix server URL is required.`);
+      process.exit(1);
+    }
+    const realmUrlInput = await prompt('Realm server URL: ');
+    if (!realmUrlInput) {
+      console.error(`${FG_RED}Error:${RESET} Realm server URL is required.`);
+      process.exit(1);
+    }
+    let defaultDomain = 'custom';
+    try {
+      defaultDomain = new URL(matrixUrlInput).hostname || defaultDomain;
+    } catch {
+      // fall back to 'custom'
+    }
+    const domainInput = await prompt(
+      `Domain for Matrix ID [${defaultDomain}]: `,
+    );
+    domain = domainInput || defaultDomain;
+    defaultMatrixUrl = matrixUrlInput;
+    defaultRealmUrl = realmUrlInput;
+  } else if (isLocal) {
     domain = 'localhost';
     defaultMatrixUrl = 'http://localhost:8008';
     defaultRealmUrl = 'http://localhost:4201/';
@@ -381,6 +410,8 @@ async function addProfileNonInteractive(
   matrixId: string,
   password: string,
   displayName?: string,
+  matrixUrl?: string,
+  realmServerUrl?: string,
 ): Promise<void> {
   if (!matrixId.startsWith('@') || !matrixId.includes(':')) {
     console.error(
@@ -403,7 +434,20 @@ async function addProfileNonInteractive(
     return;
   }
 
-  await manager.addProfile(matrixId, password, displayName);
+  try {
+    await manager.addProfile(
+      matrixId,
+      password,
+      displayName,
+      matrixUrl,
+      realmServerUrl,
+    );
+  } catch (err) {
+    console.error(
+      `${FG_RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
   console.log(
     `${FG_GREEN}\u2713${RESET} Profile created: ${formatProfileBadge(matrixId)}`,
   );

--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -179,9 +179,15 @@ export async function profileCommand(
       break;
 
     case 'add': {
-      const envDefaults = resolveBoxelEnvironment();
       const password = options?.password || process.env.BOXEL_PASSWORD;
       if (options?.user && password) {
+        // Only consult BOXEL_ENVIRONMENT when at least one URL isn't already
+        // supplied by a flag — otherwise an invalid env var (e.g. slugs to
+        // empty) would kill a fully-specified invocation where the env var
+        // would have been overridden anyway.
+        const needsEnvDefaults =
+          !options.matrixUrl || !options.realmServerUrl;
+        const envDefaults = needsEnvDefaults ? resolveBoxelEnvironment() : null;
         await addProfileNonInteractive(
           manager,
           options.user,
@@ -191,7 +197,7 @@ export async function profileCommand(
           options.realmServerUrl ?? envDefaults?.realmServerUrl,
         );
       } else {
-        await addProfile(manager, envDefaults);
+        await addProfile(manager, resolveBoxelEnvironment());
       }
       break;
     }

--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -181,12 +181,23 @@ export async function profileCommand(
     case 'add': {
       const password = options?.password || process.env.BOXEL_PASSWORD;
       if (options?.user && password) {
-        // Only consult BOXEL_ENVIRONMENT when at least one URL isn't already
-        // supplied by a flag — otherwise an invalid env var (e.g. slugs to
-        // empty) would kill a fully-specified invocation where the env var
-        // would have been overridden anyway.
-        const needsEnvDefaults = !options.matrixUrl || !options.realmServerUrl;
+        // BOXEL_ENVIRONMENT only fills in URLs when (a) at least one flag is
+        // missing, AND (b) the Matrix ID's domain isn't a known standard
+        // (stack.cards / boxel.ai / localhost). Otherwise an unrelated
+        // BOXEL_ENVIRONMENT in the shell would silently produce a profile
+        // whose Matrix ID and URLs disagree — and an invalid env value
+        // (e.g. one that slugs to empty) would kill a fully-specified
+        // invocation where the env was meant to be overridden anyway.
+        const matrixIdEnv = getEnvironmentFromMatrixId(options.user);
+        const isStandardDomain = matrixIdEnv !== 'unknown';
+        const needsEnvDefaults =
+          !isStandardDomain && (!options.matrixUrl || !options.realmServerUrl);
         const envDefaults = needsEnvDefaults ? resolveBoxelEnvironment() : null;
+        if (envDefaults) {
+          console.log(
+            `${DIM}Using BOXEL_ENVIRONMENT=${process.env.BOXEL_ENVIRONMENT}${RESET}`,
+          );
+        }
         await addProfileNonInteractive(
           manager,
           options.user,

--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -136,6 +136,31 @@ const MENU_ENVIRONMENTS: Record<
   },
 };
 
+// Validate and normalize a Matrix or realm-server URL provided by the user
+// (via --matrix-url / --realm-server-url or the interactive Custom prompt).
+// Returns the trimmed input on success; exits 1 with a clear message
+// otherwise. Without this, downstream code (fetch, realm auth, etc.) would
+// throw on invalid input far away from where the value was entered.
+function validateUrl(input: string, label: string): string {
+  const trimmed = input.trim();
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    console.error(
+      `${FG_RED}Error:${RESET} ${label} "${input}" is not a valid URL.`,
+    );
+    process.exit(1);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    console.error(
+      `${FG_RED}Error:${RESET} ${label} "${input}" must use http:// or https://.`,
+    );
+    process.exit(1);
+  }
+  return trimmed;
+}
+
 // Matches scripts/env-slug.sh: lowercase, "/" -> "-", strip chars outside
 // [a-z0-9-], collapse runs of "-", trim leading/trailing "-".
 function computeEnvSlug(name: string): string {
@@ -181,6 +206,12 @@ export async function profileCommand(
     case 'add': {
       const password = options?.password || process.env.BOXEL_PASSWORD;
       if (options?.user && password) {
+        const matrixUrl = options.matrixUrl
+          ? validateUrl(options.matrixUrl, '--matrix-url')
+          : undefined;
+        const realmServerUrl = options.realmServerUrl
+          ? validateUrl(options.realmServerUrl, '--realm-server-url')
+          : undefined;
         // BOXEL_ENVIRONMENT only fills in URLs when (a) at least one flag is
         // missing, AND (b) the Matrix ID's domain isn't a known standard
         // (stack.cards / boxel.ai / localhost). Otherwise an unrelated
@@ -191,7 +222,7 @@ export async function profileCommand(
         const matrixIdEnv = getEnvironmentFromMatrixId(options.user);
         const isStandardDomain = matrixIdEnv !== 'unknown';
         const needsEnvDefaults =
-          !isStandardDomain && (!options.matrixUrl || !options.realmServerUrl);
+          !isStandardDomain && (!matrixUrl || !realmServerUrl);
         const envDefaults = needsEnvDefaults ? resolveBoxelEnvironment() : null;
         if (envDefaults) {
           console.log(
@@ -203,8 +234,8 @@ export async function profileCommand(
           options.user,
           password,
           options.name,
-          options.matrixUrl ?? envDefaults?.matrixUrl,
-          options.realmServerUrl ?? envDefaults?.realmServerUrl,
+          matrixUrl ?? envDefaults?.matrixUrl,
+          realmServerUrl ?? envDefaults?.realmServerUrl,
         );
       } else {
         await addProfile(manager, resolveBoxelEnvironment());
@@ -307,22 +338,25 @@ async function promptEnvironmentMenu(): Promise<{
   const envChoice = await prompt('\nChoice [1/2/3/4]: ');
 
   if (envChoice === '4') {
-    const matrixUrl = await prompt('Matrix server URL: ');
-    if (!matrixUrl) {
+    const matrixUrlInput = await prompt('Matrix server URL: ');
+    if (!matrixUrlInput) {
       console.error(`${FG_RED}Error:${RESET} Matrix server URL is required.`);
       process.exit(1);
     }
-    const realmServerUrl = await prompt('Realm server URL: ');
-    if (!realmServerUrl) {
+    const matrixUrl = validateUrl(matrixUrlInput, 'Matrix server URL');
+    const realmServerUrlInput = await prompt('Realm server URL: ');
+    if (!realmServerUrlInput) {
       console.error(`${FG_RED}Error:${RESET} Realm server URL is required.`);
       process.exit(1);
     }
-    let defaultDomain = 'custom';
-    try {
-      defaultDomain = new URL(matrixUrl).hostname || defaultDomain;
-    } catch {
-      // fall back to 'custom'
-    }
+    const realmServerUrl = validateUrl(
+      realmServerUrlInput,
+      'Realm server URL',
+    );
+    // matrixUrl is already validated by validateUrl above, so new URL won't
+    // throw — the hostname fallback is just for the unlikely edge case of
+    // a parseable URL with empty hostname (e.g. "http:///path").
+    const defaultDomain = new URL(matrixUrl).hostname || 'custom';
     const domainInput = await prompt(
       `Domain for Matrix ID [${defaultDomain}]: `,
     );

--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -4,8 +4,8 @@ import type { ProfileManager } from '../lib/profile-manager';
 import {
   getProfileManager,
   formatProfileBadge,
-  getDomainFromMatrixId,
   getEnvironmentFromMatrixId,
+  getEnvironmentLabel,
   getUsernameFromMatrixId,
 } from '../lib/profile-manager';
 import {
@@ -105,65 +105,6 @@ export interface ProfileCommandOptions {
   user?: string;
   password?: string;
   name?: string;
-  matrixUrl?: string;
-  realmServerUrl?: string;
-}
-
-interface EnvironmentDefaults {
-  domain: string;
-  matrixUrl: string;
-  realmServerUrl: string;
-}
-
-const MENU_ENVIRONMENTS: Record<
-  'staging' | 'production' | 'local',
-  EnvironmentDefaults
-> = {
-  staging: {
-    domain: 'stack.cards',
-    matrixUrl: 'https://matrix-staging.stack.cards',
-    realmServerUrl: 'https://realms-staging.stack.cards/',
-  },
-  production: {
-    domain: 'boxel.ai',
-    matrixUrl: 'https://matrix.boxel.ai',
-    realmServerUrl: 'https://app.boxel.ai/',
-  },
-  local: {
-    domain: 'localhost',
-    matrixUrl: 'http://localhost:8008',
-    realmServerUrl: 'http://localhost:4201/',
-  },
-};
-
-// Matches scripts/env-slug.sh: lowercase, "/" -> "-", strip chars outside
-// [a-z0-9-], collapse runs of "-", trim leading/trailing "-".
-function computeEnvSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/\//g, '-')
-    .replace(/[^a-z0-9-]/g, '')
-    .replace(/-+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
-
-// Derive URLs from BOXEL_ENVIRONMENT using the same ".${slug}.localhost"
-// pattern that mise-tasks/lib/env-vars.sh produces for env-mode local dev.
-function resolveBoxelEnvironment(): EnvironmentDefaults | null {
-  const raw = process.env.BOXEL_ENVIRONMENT;
-  if (!raw || !raw.trim()) return null;
-  const slug = computeEnvSlug(raw);
-  if (!slug) {
-    console.error(
-      `${FG_RED}Error:${RESET} BOXEL_ENVIRONMENT="${raw}" contains no slug characters (expected letters, digits, or "-").`,
-    );
-    process.exit(1);
-  }
-  return {
-    domain: `${slug}.localhost`,
-    matrixUrl: `http://matrix.${slug}.localhost`,
-    realmServerUrl: `http://realm-server.${slug}.localhost/`,
-  };
 }
 
 export async function profileCommand(
@@ -179,7 +120,6 @@ export async function profileCommand(
       break;
 
     case 'add': {
-      const envDefaults = resolveBoxelEnvironment();
       const password = options?.password || process.env.BOXEL_PASSWORD;
       if (options?.user && password) {
         await addProfileNonInteractive(
@@ -187,11 +127,9 @@ export async function profileCommand(
           options.user,
           password,
           options.name,
-          options.matrixUrl ?? envDefaults?.matrixUrl,
-          options.realmServerUrl ?? envDefaults?.realmServerUrl,
         );
       } else {
-        await addProfile(manager, envDefaults);
+        await addProfile(manager);
       }
       break;
     }
@@ -262,12 +200,14 @@ async function listProfiles(manager: ProfileManager): Promise<void> {
     const env = getEnvironmentFromMatrixId(id);
 
     const marker = isActive ? `${FG_GREEN}\u2605${RESET} ` : '  ';
-    const domain = getDomainFromMatrixId(id);
+    const envLabel = getEnvironmentLabel(env);
     const envColor = env === 'production' ? FG_MAGENTA : FG_CYAN;
 
     console.log(`${marker}${BOLD}${id}${RESET}`);
     console.log(`    ${DIM}Name:${RESET} ${profile.displayName}`);
-    console.log(`    ${DIM}Environment:${RESET} ${envColor}${domain}${RESET}`);
+    console.log(
+      `    ${DIM}Environment:${RESET} ${envColor}${envLabel}${RESET}`,
+    );
     console.log(`    ${DIM}Realm Server:${RESET} ${profile.realmServerUrl}`);
     console.log('');
   }
@@ -277,77 +217,34 @@ async function listProfiles(manager: ProfileManager): Promise<void> {
   }
 }
 
-async function promptEnvironmentMenu(): Promise<{
-  domain: string;
-  matrixUrl: string;
-  realmServerUrl: string;
-}> {
+async function addProfile(manager: ProfileManager): Promise<void> {
+  console.log(`\n${BOLD}Add New Profile${RESET}\n`);
+
   console.log(`Which environment?`);
   console.log(`  ${FG_CYAN}1${RESET}) Staging (realms-staging.stack.cards)`);
   console.log(`  ${FG_MAGENTA}2${RESET}) Production (app.boxel.ai)`);
   console.log(`  ${FG_GREEN}3${RESET}) Local (localhost:4201)`);
-  console.log(`  ${FG_YELLOW}4${RESET}) Custom (enter your own URLs)`);
 
-  const envChoice = await prompt('\nChoice [1/2/3/4]: ');
-
-  if (envChoice === '4') {
-    const matrixUrl = await prompt('Matrix server URL: ');
-    if (!matrixUrl) {
-      console.error(`${FG_RED}Error:${RESET} Matrix server URL is required.`);
-      process.exit(1);
-    }
-    const realmServerUrl = await prompt('Realm server URL: ');
-    if (!realmServerUrl) {
-      console.error(`${FG_RED}Error:${RESET} Realm server URL is required.`);
-      process.exit(1);
-    }
-    let defaultDomain = 'custom';
-    try {
-      defaultDomain = new URL(matrixUrl).hostname || defaultDomain;
-    } catch {
-      // fall back to 'custom'
-    }
-    const domainInput = await prompt(
-      `Domain for Matrix ID [${defaultDomain}]: `,
-    );
-    return {
-      domain: domainInput || defaultDomain,
-      matrixUrl,
-      realmServerUrl,
-    };
-  }
-
-  if (envChoice === '3') {
-    return { ...MENU_ENVIRONMENTS.local };
-  }
-  if (envChoice === '2') {
-    return { ...MENU_ENVIRONMENTS.production };
-  }
-  return { ...MENU_ENVIRONMENTS.staging };
-}
-
-async function addProfile(
-  manager: ProfileManager,
-  envDefaults?: EnvironmentDefaults | null,
-): Promise<void> {
-  console.log(`\n${BOLD}Add New Profile${RESET}\n`);
+  const envChoice = await prompt('\nChoice [1/2/3]: ');
+  const isProduction = envChoice === '2';
+  const isLocal = envChoice === '3';
 
   let domain: string;
   let defaultMatrixUrl: string;
   let defaultRealmUrl: string;
 
-  if (envDefaults) {
-    console.log(
-      `${DIM}Using BOXEL_ENVIRONMENT=${process.env.BOXEL_ENVIRONMENT}${RESET}`,
-    );
-    domain = envDefaults.domain;
-    defaultMatrixUrl = envDefaults.matrixUrl;
-    defaultRealmUrl = envDefaults.realmServerUrl;
+  if (isLocal) {
+    domain = 'localhost';
+    defaultMatrixUrl = 'http://localhost:8008';
+    defaultRealmUrl = 'http://localhost:4201/';
+  } else if (isProduction) {
+    domain = 'boxel.ai';
+    defaultMatrixUrl = 'https://matrix.boxel.ai';
+    defaultRealmUrl = 'https://app.boxel.ai/';
   } else {
-    const menuResult = await promptEnvironmentMenu();
-    domain = menuResult.domain;
-    defaultMatrixUrl = menuResult.matrixUrl;
-    defaultRealmUrl = menuResult.realmServerUrl;
+    domain = 'stack.cards';
+    defaultMatrixUrl = 'https://matrix-staging.stack.cards';
+    defaultRealmUrl = 'https://realms-staging.stack.cards/';
   }
 
   console.log(`\nEnter your Boxel username (without @ or domain)`);
@@ -484,8 +381,6 @@ async function addProfileNonInteractive(
   matrixId: string,
   password: string,
   displayName?: string,
-  matrixUrl?: string,
-  realmServerUrl?: string,
 ): Promise<void> {
   if (!matrixId.startsWith('@') || !matrixId.includes(':')) {
     console.error(
@@ -508,20 +403,7 @@ async function addProfileNonInteractive(
     return;
   }
 
-  try {
-    await manager.addProfile(
-      matrixId,
-      password,
-      displayName,
-      matrixUrl,
-      realmServerUrl,
-    );
-  } catch (err) {
-    console.error(
-      `${FG_RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}`,
-    );
-    process.exit(1);
-  }
+  await manager.addProfile(matrixId, password, displayName);
   console.log(
     `${FG_GREEN}\u2713${RESET} Profile created: ${formatProfileBadge(matrixId)}`,
   );

--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -115,7 +115,10 @@ interface EnvironmentDefaults {
   realmServerUrl: string;
 }
 
-const MENU_ENVIRONMENTS: Record<'staging' | 'production' | 'local', EnvironmentDefaults> = {
+const MENU_ENVIRONMENTS: Record<
+  'staging' | 'production' | 'local',
+  EnvironmentDefaults
+> = {
   staging: {
     domain: 'stack.cards',
     matrixUrl: 'https://matrix-staging.stack.cards',
@@ -264,9 +267,7 @@ async function listProfiles(manager: ProfileManager): Promise<void> {
 
     console.log(`${marker}${BOLD}${id}${RESET}`);
     console.log(`    ${DIM}Name:${RESET} ${profile.displayName}`);
-    console.log(
-      `    ${DIM}Environment:${RESET} ${envColor}${domain}${RESET}`,
-    );
+    console.log(`    ${DIM}Environment:${RESET} ${envColor}${domain}${RESET}`);
     console.log(`    ${DIM}Realm Server:${RESET} ${profile.realmServerUrl}`);
     console.log('');
   }

--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -349,10 +349,7 @@ async function promptEnvironmentMenu(): Promise<{
       console.error(`${FG_RED}Error:${RESET} Realm server URL is required.`);
       process.exit(1);
     }
-    const realmServerUrl = validateUrl(
-      realmServerUrlInput,
-      'Realm server URL',
-    );
+    const realmServerUrl = validateUrl(realmServerUrlInput, 'Realm server URL');
     // matrixUrl is already validated by validateUrl above, so new URL won't
     // throw — the hostname fallback is just for the unlikely edge case of
     // a parseable URL with empty hostname (e.g. "http:///path").

--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -109,7 +109,13 @@ export interface ProfileCommandOptions {
   realmServerUrl?: string;
 }
 
-const ENVIRONMENT_DEFAULTS = {
+interface EnvironmentDefaults {
+  domain: string;
+  matrixUrl: string;
+  realmServerUrl: string;
+}
+
+const MENU_ENVIRONMENTS: Record<'staging' | 'production' | 'local', EnvironmentDefaults> = {
   staging: {
     domain: 'stack.cards',
     matrixUrl: 'https://matrix-staging.stack.cards',
@@ -125,27 +131,36 @@ const ENVIRONMENT_DEFAULTS = {
     matrixUrl: 'http://localhost:8008',
     realmServerUrl: 'http://localhost:4201/',
   },
-} as const;
+};
 
-type EnvironmentDefaults =
-  (typeof ENVIRONMENT_DEFAULTS)[keyof typeof ENVIRONMENT_DEFAULTS];
+// Matches scripts/env-slug.sh: lowercase, "/" -> "-", strip chars outside
+// [a-z0-9-], collapse runs of "-", trim leading/trailing "-".
+function computeEnvSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\//g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
 
+// Derive URLs from BOXEL_ENVIRONMENT using the same ".${slug}.localhost"
+// pattern that mise-tasks/lib/env-vars.sh produces for env-mode local dev.
 function resolveBoxelEnvironment(): EnvironmentDefaults | null {
   const raw = process.env.BOXEL_ENVIRONMENT;
   if (!raw || !raw.trim()) return null;
-  const key = raw.trim().toLowerCase();
-  const defaults = (
-    ENVIRONMENT_DEFAULTS as Record<string, EnvironmentDefaults>
-  )[key];
-  if (!defaults) {
+  const slug = computeEnvSlug(raw);
+  if (!slug) {
     console.error(
-      `${FG_RED}Error:${RESET} Unknown BOXEL_ENVIRONMENT "${raw}". Expected one of: ${Object.keys(
-        ENVIRONMENT_DEFAULTS,
-      ).join(', ')}.`,
+      `${FG_RED}Error:${RESET} BOXEL_ENVIRONMENT="${raw}" contains no slug characters (expected letters, digits, or "-").`,
     );
     process.exit(1);
   }
-  return defaults;
+  return {
+    domain: `${slug}.localhost`,
+    matrixUrl: `http://matrix.${slug}.localhost`,
+    realmServerUrl: `http://realm-server.${slug}.localhost/`,
+  };
 }
 
 export async function profileCommand(
@@ -302,12 +317,12 @@ async function promptEnvironmentMenu(): Promise<{
   }
 
   if (envChoice === '3') {
-    return { ...ENVIRONMENT_DEFAULTS.local };
+    return { ...MENU_ENVIRONMENTS.local };
   }
   if (envChoice === '2') {
-    return { ...ENVIRONMENT_DEFAULTS.production };
+    return { ...MENU_ENVIRONMENTS.production };
   }
-  return { ...ENVIRONMENT_DEFAULTS.staging };
+  return { ...MENU_ENVIRONMENTS.staging };
 }
 
 async function addProfile(

--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -552,6 +552,17 @@ async function addProfileNonInteractive(
     if (displayName) {
       manager.updateDisplayName(matrixId, displayName);
     }
+    if (matrixUrl || realmServerUrl) {
+      const urlsChanged = manager.updateUrls(matrixId, {
+        matrixUrl,
+        realmServerUrl,
+      });
+      if (urlsChanged) {
+        console.log(
+          `${DIM}Updated server URLs and cleared cached realm tokens.${RESET}`,
+        );
+      }
+    }
     console.log(
       `${FG_GREEN}\u2713${RESET} Profile updated: ${formatProfileBadge(matrixId)}`,
     );

--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -185,8 +185,7 @@ export async function profileCommand(
         // supplied by a flag — otherwise an invalid env var (e.g. slugs to
         // empty) would kill a fully-specified invocation where the env var
         // would have been overridden anyway.
-        const needsEnvDefaults =
-          !options.matrixUrl || !options.realmServerUrl;
+        const needsEnvDefaults = !options.matrixUrl || !options.realmServerUrl;
         const envDefaults = needsEnvDefaults ? resolveBoxelEnvironment() : null;
         await addProfileNonInteractive(
           manager,

--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -4,8 +4,8 @@ import type { ProfileManager } from '../lib/profile-manager';
 import {
   getProfileManager,
   formatProfileBadge,
+  getDomainFromMatrixId,
   getEnvironmentFromMatrixId,
-  getEnvironmentLabel,
   getUsernameFromMatrixId,
 } from '../lib/profile-manager';
 import {
@@ -259,13 +259,13 @@ async function listProfiles(manager: ProfileManager): Promise<void> {
     const env = getEnvironmentFromMatrixId(id);
 
     const marker = isActive ? `${FG_GREEN}\u2605${RESET} ` : '  ';
-    const envLabel = getEnvironmentLabel(env);
+    const domain = getDomainFromMatrixId(id);
     const envColor = env === 'production' ? FG_MAGENTA : FG_CYAN;
 
     console.log(`${marker}${BOLD}${id}${RESET}`);
     console.log(`    ${DIM}Name:${RESET} ${profile.displayName}`);
     console.log(
-      `    ${DIM}Environment:${RESET} ${envColor}${envLabel}${RESET}`,
+      `    ${DIM}Environment:${RESET} ${envColor}${domain}${RESET}`,
     );
     console.log(`    ${DIM}Realm Server:${RESET} ${profile.realmServerUrl}`);
     console.log('');

--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -4,8 +4,8 @@ import type { ProfileManager } from '../lib/profile-manager';
 import {
   getProfileManager,
   formatProfileBadge,
+  getDomainFromMatrixId,
   getEnvironmentFromMatrixId,
-  getEnvironmentLabel,
   getUsernameFromMatrixId,
 } from '../lib/profile-manager';
 import {
@@ -105,6 +105,65 @@ export interface ProfileCommandOptions {
   user?: string;
   password?: string;
   name?: string;
+  matrixUrl?: string;
+  realmServerUrl?: string;
+}
+
+interface EnvironmentDefaults {
+  domain: string;
+  matrixUrl: string;
+  realmServerUrl: string;
+}
+
+const MENU_ENVIRONMENTS: Record<
+  'staging' | 'production' | 'local',
+  EnvironmentDefaults
+> = {
+  staging: {
+    domain: 'stack.cards',
+    matrixUrl: 'https://matrix-staging.stack.cards',
+    realmServerUrl: 'https://realms-staging.stack.cards/',
+  },
+  production: {
+    domain: 'boxel.ai',
+    matrixUrl: 'https://matrix.boxel.ai',
+    realmServerUrl: 'https://app.boxel.ai/',
+  },
+  local: {
+    domain: 'localhost',
+    matrixUrl: 'http://localhost:8008',
+    realmServerUrl: 'http://localhost:4201/',
+  },
+};
+
+// Matches scripts/env-slug.sh: lowercase, "/" -> "-", strip chars outside
+// [a-z0-9-], collapse runs of "-", trim leading/trailing "-".
+function computeEnvSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\//g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// Derive URLs from BOXEL_ENVIRONMENT using the same ".${slug}.localhost"
+// pattern that mise-tasks/lib/env-vars.sh produces for env-mode local dev.
+function resolveBoxelEnvironment(): EnvironmentDefaults | null {
+  const raw = process.env.BOXEL_ENVIRONMENT;
+  if (!raw || !raw.trim()) return null;
+  const slug = computeEnvSlug(raw);
+  if (!slug) {
+    console.error(
+      `${FG_RED}Error:${RESET} BOXEL_ENVIRONMENT="${raw}" contains no slug characters (expected letters, digits, or "-").`,
+    );
+    process.exit(1);
+  }
+  return {
+    domain: `${slug}.localhost`,
+    matrixUrl: `http://matrix.${slug}.localhost`,
+    realmServerUrl: `http://realm-server.${slug}.localhost/`,
+  };
 }
 
 export async function profileCommand(
@@ -120,6 +179,7 @@ export async function profileCommand(
       break;
 
     case 'add': {
+      const envDefaults = resolveBoxelEnvironment();
       const password = options?.password || process.env.BOXEL_PASSWORD;
       if (options?.user && password) {
         await addProfileNonInteractive(
@@ -127,9 +187,11 @@ export async function profileCommand(
           options.user,
           password,
           options.name,
+          options.matrixUrl ?? envDefaults?.matrixUrl,
+          options.realmServerUrl ?? envDefaults?.realmServerUrl,
         );
       } else {
-        await addProfile(manager);
+        await addProfile(manager, envDefaults);
       }
       break;
     }
@@ -200,14 +262,12 @@ async function listProfiles(manager: ProfileManager): Promise<void> {
     const env = getEnvironmentFromMatrixId(id);
 
     const marker = isActive ? `${FG_GREEN}\u2605${RESET} ` : '  ';
-    const envLabel = getEnvironmentLabel(env);
+    const domain = getDomainFromMatrixId(id);
     const envColor = env === 'production' ? FG_MAGENTA : FG_CYAN;
 
     console.log(`${marker}${BOLD}${id}${RESET}`);
     console.log(`    ${DIM}Name:${RESET} ${profile.displayName}`);
-    console.log(
-      `    ${DIM}Environment:${RESET} ${envColor}${envLabel}${RESET}`,
-    );
+    console.log(`    ${DIM}Environment:${RESET} ${envColor}${domain}${RESET}`);
     console.log(`    ${DIM}Realm Server:${RESET} ${profile.realmServerUrl}`);
     console.log('');
   }
@@ -217,34 +277,77 @@ async function listProfiles(manager: ProfileManager): Promise<void> {
   }
 }
 
-async function addProfile(manager: ProfileManager): Promise<void> {
-  console.log(`\n${BOLD}Add New Profile${RESET}\n`);
-
+async function promptEnvironmentMenu(): Promise<{
+  domain: string;
+  matrixUrl: string;
+  realmServerUrl: string;
+}> {
   console.log(`Which environment?`);
   console.log(`  ${FG_CYAN}1${RESET}) Staging (realms-staging.stack.cards)`);
   console.log(`  ${FG_MAGENTA}2${RESET}) Production (app.boxel.ai)`);
   console.log(`  ${FG_GREEN}3${RESET}) Local (localhost:4201)`);
+  console.log(`  ${FG_YELLOW}4${RESET}) Custom (enter your own URLs)`);
 
-  const envChoice = await prompt('\nChoice [1/2/3]: ');
-  const isProduction = envChoice === '2';
-  const isLocal = envChoice === '3';
+  const envChoice = await prompt('\nChoice [1/2/3/4]: ');
+
+  if (envChoice === '4') {
+    const matrixUrl = await prompt('Matrix server URL: ');
+    if (!matrixUrl) {
+      console.error(`${FG_RED}Error:${RESET} Matrix server URL is required.`);
+      process.exit(1);
+    }
+    const realmServerUrl = await prompt('Realm server URL: ');
+    if (!realmServerUrl) {
+      console.error(`${FG_RED}Error:${RESET} Realm server URL is required.`);
+      process.exit(1);
+    }
+    let defaultDomain = 'custom';
+    try {
+      defaultDomain = new URL(matrixUrl).hostname || defaultDomain;
+    } catch {
+      // fall back to 'custom'
+    }
+    const domainInput = await prompt(
+      `Domain for Matrix ID [${defaultDomain}]: `,
+    );
+    return {
+      domain: domainInput || defaultDomain,
+      matrixUrl,
+      realmServerUrl,
+    };
+  }
+
+  if (envChoice === '3') {
+    return { ...MENU_ENVIRONMENTS.local };
+  }
+  if (envChoice === '2') {
+    return { ...MENU_ENVIRONMENTS.production };
+  }
+  return { ...MENU_ENVIRONMENTS.staging };
+}
+
+async function addProfile(
+  manager: ProfileManager,
+  envDefaults?: EnvironmentDefaults | null,
+): Promise<void> {
+  console.log(`\n${BOLD}Add New Profile${RESET}\n`);
 
   let domain: string;
   let defaultMatrixUrl: string;
   let defaultRealmUrl: string;
 
-  if (isLocal) {
-    domain = 'localhost';
-    defaultMatrixUrl = 'http://localhost:8008';
-    defaultRealmUrl = 'http://localhost:4201/';
-  } else if (isProduction) {
-    domain = 'boxel.ai';
-    defaultMatrixUrl = 'https://matrix.boxel.ai';
-    defaultRealmUrl = 'https://app.boxel.ai/';
+  if (envDefaults) {
+    console.log(
+      `${DIM}Using BOXEL_ENVIRONMENT=${process.env.BOXEL_ENVIRONMENT}${RESET}`,
+    );
+    domain = envDefaults.domain;
+    defaultMatrixUrl = envDefaults.matrixUrl;
+    defaultRealmUrl = envDefaults.realmServerUrl;
   } else {
-    domain = 'stack.cards';
-    defaultMatrixUrl = 'https://matrix-staging.stack.cards';
-    defaultRealmUrl = 'https://realms-staging.stack.cards/';
+    const menuResult = await promptEnvironmentMenu();
+    domain = menuResult.domain;
+    defaultMatrixUrl = menuResult.matrixUrl;
+    defaultRealmUrl = menuResult.realmServerUrl;
   }
 
   console.log(`\nEnter your Boxel username (without @ or domain)`);
@@ -381,6 +484,8 @@ async function addProfileNonInteractive(
   matrixId: string,
   password: string,
   displayName?: string,
+  matrixUrl?: string,
+  realmServerUrl?: string,
 ): Promise<void> {
   if (!matrixId.startsWith('@') || !matrixId.includes(':')) {
     console.error(
@@ -403,7 +508,20 @@ async function addProfileNonInteractive(
     return;
   }
 
-  await manager.addProfile(matrixId, password, displayName);
+  try {
+    await manager.addProfile(
+      matrixId,
+      password,
+      displayName,
+      matrixUrl,
+      realmServerUrl,
+    );
+  } catch (err) {
+    console.error(
+      `${FG_RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
   console.log(
     `${FG_GREEN}\u2713${RESET} Profile created: ${formatProfileBadge(matrixId)}`,
   );

--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -109,6 +109,45 @@ export interface ProfileCommandOptions {
   realmServerUrl?: string;
 }
 
+const ENVIRONMENT_DEFAULTS = {
+  staging: {
+    domain: 'stack.cards',
+    matrixUrl: 'https://matrix-staging.stack.cards',
+    realmServerUrl: 'https://realms-staging.stack.cards/',
+  },
+  production: {
+    domain: 'boxel.ai',
+    matrixUrl: 'https://matrix.boxel.ai',
+    realmServerUrl: 'https://app.boxel.ai/',
+  },
+  local: {
+    domain: 'localhost',
+    matrixUrl: 'http://localhost:8008',
+    realmServerUrl: 'http://localhost:4201/',
+  },
+} as const;
+
+type EnvironmentDefaults =
+  (typeof ENVIRONMENT_DEFAULTS)[keyof typeof ENVIRONMENT_DEFAULTS];
+
+function resolveBoxelEnvironment(): EnvironmentDefaults | null {
+  const raw = process.env.BOXEL_ENVIRONMENT;
+  if (!raw || !raw.trim()) return null;
+  const key = raw.trim().toLowerCase();
+  const defaults = (
+    ENVIRONMENT_DEFAULTS as Record<string, EnvironmentDefaults>
+  )[key];
+  if (!defaults) {
+    console.error(
+      `${FG_RED}Error:${RESET} Unknown BOXEL_ENVIRONMENT "${raw}". Expected one of: ${Object.keys(
+        ENVIRONMENT_DEFAULTS,
+      ).join(', ')}.`,
+    );
+    process.exit(1);
+  }
+  return defaults;
+}
+
 export async function profileCommand(
   subcommand?: string,
   arg?: string,
@@ -122,6 +161,7 @@ export async function profileCommand(
       break;
 
     case 'add': {
+      const envDefaults = resolveBoxelEnvironment();
       const password = options?.password || process.env.BOXEL_PASSWORD;
       if (options?.user && password) {
         await addProfileNonInteractive(
@@ -129,11 +169,11 @@ export async function profileCommand(
           options.user,
           password,
           options.name,
-          options.matrixUrl,
-          options.realmServerUrl,
+          options.matrixUrl ?? envDefaults?.matrixUrl,
+          options.realmServerUrl ?? envDefaults?.realmServerUrl,
         );
       } else {
-        await addProfile(manager);
+        await addProfile(manager, envDefaults);
       }
       break;
     }
@@ -221,9 +261,11 @@ async function listProfiles(manager: ProfileManager): Promise<void> {
   }
 }
 
-async function addProfile(manager: ProfileManager): Promise<void> {
-  console.log(`\n${BOLD}Add New Profile${RESET}\n`);
-
+async function promptEnvironmentMenu(): Promise<{
+  domain: string;
+  matrixUrl: string;
+  realmServerUrl: string;
+}> {
   console.log(`Which environment?`);
   console.log(`  ${FG_CYAN}1${RESET}) Staging (realms-staging.stack.cards)`);
   console.log(`  ${FG_MAGENTA}2${RESET}) Production (app.boxel.ai)`);
@@ -231,49 +273,65 @@ async function addProfile(manager: ProfileManager): Promise<void> {
   console.log(`  ${FG_YELLOW}4${RESET}) Custom (enter your own URLs)`);
 
   const envChoice = await prompt('\nChoice [1/2/3/4]: ');
-  const isProduction = envChoice === '2';
-  const isLocal = envChoice === '3';
-  const isCustom = envChoice === '4';
 
-  let domain: string;
-  let defaultMatrixUrl: string;
-  let defaultRealmUrl: string;
-
-  if (isCustom) {
-    const matrixUrlInput = await prompt('Matrix server URL: ');
-    if (!matrixUrlInput) {
+  if (envChoice === '4') {
+    const matrixUrl = await prompt('Matrix server URL: ');
+    if (!matrixUrl) {
       console.error(`${FG_RED}Error:${RESET} Matrix server URL is required.`);
       process.exit(1);
     }
-    const realmUrlInput = await prompt('Realm server URL: ');
-    if (!realmUrlInput) {
+    const realmServerUrl = await prompt('Realm server URL: ');
+    if (!realmServerUrl) {
       console.error(`${FG_RED}Error:${RESET} Realm server URL is required.`);
       process.exit(1);
     }
     let defaultDomain = 'custom';
     try {
-      defaultDomain = new URL(matrixUrlInput).hostname || defaultDomain;
+      defaultDomain = new URL(matrixUrl).hostname || defaultDomain;
     } catch {
       // fall back to 'custom'
     }
     const domainInput = await prompt(
       `Domain for Matrix ID [${defaultDomain}]: `,
     );
-    domain = domainInput || defaultDomain;
-    defaultMatrixUrl = matrixUrlInput;
-    defaultRealmUrl = realmUrlInput;
-  } else if (isLocal) {
-    domain = 'localhost';
-    defaultMatrixUrl = 'http://localhost:8008';
-    defaultRealmUrl = 'http://localhost:4201/';
-  } else if (isProduction) {
-    domain = 'boxel.ai';
-    defaultMatrixUrl = 'https://matrix.boxel.ai';
-    defaultRealmUrl = 'https://app.boxel.ai/';
+    return {
+      domain: domainInput || defaultDomain,
+      matrixUrl,
+      realmServerUrl,
+    };
+  }
+
+  if (envChoice === '3') {
+    return { ...ENVIRONMENT_DEFAULTS.local };
+  }
+  if (envChoice === '2') {
+    return { ...ENVIRONMENT_DEFAULTS.production };
+  }
+  return { ...ENVIRONMENT_DEFAULTS.staging };
+}
+
+async function addProfile(
+  manager: ProfileManager,
+  envDefaults?: EnvironmentDefaults | null,
+): Promise<void> {
+  console.log(`\n${BOLD}Add New Profile${RESET}\n`);
+
+  let domain: string;
+  let defaultMatrixUrl: string;
+  let defaultRealmUrl: string;
+
+  if (envDefaults) {
+    console.log(
+      `${DIM}Using BOXEL_ENVIRONMENT=${process.env.BOXEL_ENVIRONMENT}${RESET}`,
+    );
+    domain = envDefaults.domain;
+    defaultMatrixUrl = envDefaults.matrixUrl;
+    defaultRealmUrl = envDefaults.realmServerUrl;
   } else {
-    domain = 'stack.cards';
-    defaultMatrixUrl = 'https://matrix-staging.stack.cards';
-    defaultRealmUrl = 'https://realms-staging.stack.cards/';
+    const menuResult = await promptEnvironmentMenu();
+    domain = menuResult.domain;
+    defaultMatrixUrl = menuResult.matrixUrl;
+    defaultRealmUrl = menuResult.realmServerUrl;
   }
 
   console.log(`\nEnter your Boxel username (without @ or domain)`);

--- a/packages/boxel-cli/src/index.ts
+++ b/packages/boxel-cli/src/index.ts
@@ -41,8 +41,8 @@ program
 Environment variables (for 'add'):
   BOXEL_PASSWORD       Password; preferred over -p to avoid shell history.
   BOXEL_ENVIRONMENT    An env-mode slug (e.g. a branch name), interpreted
-                       like mise-tasks/lib/env-vars.sh: URLs are derived
-                       as http://matrix.<slug>.localhost and
+                       like scripts/env-slug.sh: URLs are derived as
+                       http://matrix.<slug>.localhost and
                        http://realm-server.<slug>.localhost/. Overridden
                        by --matrix-url / --realm-server-url if provided.`,
   )

--- a/packages/boxel-cli/src/index.ts
+++ b/packages/boxel-cli/src/index.ts
@@ -27,11 +27,25 @@ program
   .option('-u, --user <matrixId>', 'Matrix user ID (e.g., @user:boxel.ai)')
   .option('-p, --password <password>', 'Password (for add command)')
   .option('-n, --name <displayName>', 'Display name (for add command)')
+  .option(
+    '-m, --matrix-url <url>',
+    'Matrix server URL (for add command with non-standard domains)',
+  )
+  .option(
+    '-r, --realm-server-url <url>',
+    'Realm server URL (for add command with non-standard domains)',
+  )
   .action(
     async (
       subcommand?: string,
       arg?: string,
-      options?: { user?: string; password?: string; name?: string },
+      options?: {
+        user?: string;
+        password?: string;
+        name?: string;
+        matrixUrl?: string;
+        realmServerUrl?: string;
+      },
     ) => {
       if (options?.password) {
         console.warn(

--- a/packages/boxel-cli/src/index.ts
+++ b/packages/boxel-cli/src/index.ts
@@ -27,11 +27,36 @@ program
   .option('-u, --user <matrixId>', 'Matrix user ID (e.g., @user:boxel.ai)')
   .option('-p, --password <password>', 'Password (for add command)')
   .option('-n, --name <displayName>', 'Display name (for add command)')
+  .option(
+    '-m, --matrix-url <url>',
+    'Matrix server URL (for add command with non-standard domains)',
+  )
+  .option(
+    '-r, --realm-server-url <url>',
+    'Realm server URL (for add command with non-standard domains)',
+  )
+  .addHelpText(
+    'after',
+    `
+Environment variables (for 'add'):
+  BOXEL_PASSWORD       Password; preferred over -p to avoid shell history.
+  BOXEL_ENVIRONMENT    An env-mode slug (e.g. a branch name), interpreted
+                       like mise-tasks/lib/env-vars.sh: URLs are derived
+                       as http://matrix.<slug>.localhost and
+                       http://realm-server.<slug>.localhost/. Overridden
+                       by --matrix-url / --realm-server-url if provided.`,
+  )
   .action(
     async (
       subcommand?: string,
       arg?: string,
-      options?: { user?: string; password?: string; name?: string },
+      options?: {
+        user?: string;
+        password?: string;
+        name?: string;
+        matrixUrl?: string;
+        realmServerUrl?: string;
+      },
     ) => {
       if (options?.password) {
         console.warn(

--- a/packages/boxel-cli/src/index.ts
+++ b/packages/boxel-cli/src/index.ts
@@ -40,9 +40,10 @@ program
     `
 Environment variables (for 'add'):
   BOXEL_PASSWORD       Password; preferred over -p to avoid shell history.
-  BOXEL_ENVIRONMENT    One of: staging, production, local. When set, Matrix
-                       and realm server URLs (and the default domain for
-                       the interactive flow) are derived from it. Overridden
+  BOXEL_ENVIRONMENT    An env-mode slug (e.g. a branch name), interpreted
+                       like mise-tasks/lib/env-vars.sh: URLs are derived
+                       as http://matrix.<slug>.localhost and
+                       http://realm-server.<slug>.localhost/. Overridden
                        by --matrix-url / --realm-server-url if provided.`,
   )
   .action(

--- a/packages/boxel-cli/src/index.ts
+++ b/packages/boxel-cli/src/index.ts
@@ -35,6 +35,16 @@ program
     '-r, --realm-server-url <url>',
     'Realm server URL (for add command with non-standard domains)',
   )
+  .addHelpText(
+    'after',
+    `
+Environment variables (for 'add'):
+  BOXEL_PASSWORD       Password; preferred over -p to avoid shell history.
+  BOXEL_ENVIRONMENT    One of: staging, production, local. When set, Matrix
+                       and realm server URLs (and the default domain for
+                       the interactive flow) are derived from it. Overridden
+                       by --matrix-url / --realm-server-url if provided.`,
+  )
   .action(
     async (
       subcommand?: string,

--- a/packages/boxel-cli/src/index.ts
+++ b/packages/boxel-cli/src/index.ts
@@ -27,36 +27,11 @@ program
   .option('-u, --user <matrixId>', 'Matrix user ID (e.g., @user:boxel.ai)')
   .option('-p, --password <password>', 'Password (for add command)')
   .option('-n, --name <displayName>', 'Display name (for add command)')
-  .option(
-    '-m, --matrix-url <url>',
-    'Matrix server URL (for add command with non-standard domains)',
-  )
-  .option(
-    '-r, --realm-server-url <url>',
-    'Realm server URL (for add command with non-standard domains)',
-  )
-  .addHelpText(
-    'after',
-    `
-Environment variables (for 'add'):
-  BOXEL_PASSWORD       Password; preferred over -p to avoid shell history.
-  BOXEL_ENVIRONMENT    An env-mode slug (e.g. a branch name), interpreted
-                       like mise-tasks/lib/env-vars.sh: URLs are derived
-                       as http://matrix.<slug>.localhost and
-                       http://realm-server.<slug>.localhost/. Overridden
-                       by --matrix-url / --realm-server-url if provided.`,
-  )
   .action(
     async (
       subcommand?: string,
       arg?: string,
-      options?: {
-        user?: string;
-        password?: string;
-        name?: string;
-        matrixUrl?: string;
-        realmServerUrl?: string;
-      },
+      options?: { user?: string; password?: string; name?: string },
     ) => {
       if (options?.password) {
         console.warn(

--- a/packages/boxel-cli/src/lib/profile-manager.ts
+++ b/packages/boxel-cli/src/lib/profile-manager.ts
@@ -313,10 +313,7 @@ export class ProfileManager {
       profile.matrixUrl = urls.matrixUrl;
       changed = true;
     }
-    if (
-      urls.realmServerUrl &&
-      urls.realmServerUrl !== profile.realmServerUrl
-    ) {
+    if (urls.realmServerUrl && urls.realmServerUrl !== profile.realmServerUrl) {
       profile.realmServerUrl = urls.realmServerUrl;
       changed = true;
     }

--- a/packages/boxel-cli/src/lib/profile-manager.ts
+++ b/packages/boxel-cli/src/lib/profile-manager.ts
@@ -80,12 +80,12 @@ export function getEnvironmentLabel(env: Environment): string {
 
 /**
  * Format profile for display in command output
- * @example [ctse · stack.cards]
+ * @example [ctse · staging]
  */
 export function formatProfileBadge(matrixId: string): string {
   const username = getUsernameFromMatrixId(matrixId);
-  const domain = getDomainFromMatrixId(matrixId);
-  return `${DIM}[${RESET}${FG_CYAN}${username}${RESET} ${DIM}\u00b7${RESET} ${FG_MAGENTA}${domain}${RESET}${DIM}]${RESET}`;
+  const env = getEnvironmentLabel(getEnvironmentFromMatrixId(matrixId));
+  return `${DIM}[${RESET}${FG_CYAN}${username}${RESET} ${DIM}\u00b7${RESET} ${FG_MAGENTA}${env}${RESET}${DIM}]${RESET}`;
 }
 
 export class ProfileManager {

--- a/packages/boxel-cli/src/lib/profile-manager.ts
+++ b/packages/boxel-cli/src/lib/profile-manager.ts
@@ -80,12 +80,12 @@ export function getEnvironmentLabel(env: Environment): string {
 
 /**
  * Format profile for display in command output
- * @example [ctse · staging]
+ * @example [ctse · stack.cards]
  */
 export function formatProfileBadge(matrixId: string): string {
   const username = getUsernameFromMatrixId(matrixId);
-  const env = getEnvironmentLabel(getEnvironmentFromMatrixId(matrixId));
-  return `${DIM}[${RESET}${FG_CYAN}${username}${RESET} ${DIM}\u00b7${RESET} ${FG_MAGENTA}${env}${RESET}${DIM}]${RESET}`;
+  const domain = getDomainFromMatrixId(matrixId);
+  return `${DIM}[${RESET}${FG_CYAN}${username}${RESET} ${DIM}\u00b7${RESET} ${FG_MAGENTA}${domain}${RESET}${DIM}]${RESET}`;
 }
 
 export class ProfileManager {

--- a/packages/boxel-cli/src/lib/profile-manager.ts
+++ b/packages/boxel-cli/src/lib/profile-manager.ts
@@ -296,6 +296,38 @@ export class ProfileManager {
     return true;
   }
 
+  // Update one or both server URLs for an existing profile. Cached realm
+  // tokens (and the realm-server token) are tied to the previous servers,
+  // so they're cleared whenever URLs actually change.
+  // Returns true iff at least one URL changed.
+  updateUrls(
+    profileId: string,
+    urls: { matrixUrl?: string; realmServerUrl?: string },
+  ): boolean {
+    const profile = this.config.profiles[profileId];
+    if (!profile) {
+      return false;
+    }
+    let changed = false;
+    if (urls.matrixUrl && urls.matrixUrl !== profile.matrixUrl) {
+      profile.matrixUrl = urls.matrixUrl;
+      changed = true;
+    }
+    if (
+      urls.realmServerUrl &&
+      urls.realmServerUrl !== profile.realmServerUrl
+    ) {
+      profile.realmServerUrl = urls.realmServerUrl;
+      changed = true;
+    }
+    if (changed) {
+      profile.realmTokens = undefined;
+      profile.realmServerToken = undefined;
+      this.saveConfig();
+    }
+    return changed;
+  }
+
   setRealmToken(realmUrl: string, token: string): void {
     let active = this.getActiveProfile();
     if (!active) {

--- a/packages/boxel-cli/tests/commands/profile.test.ts
+++ b/packages/boxel-cli/tests/commands/profile.test.ts
@@ -171,6 +171,77 @@ describe('ProfileManager', () => {
     expect(profile!.displayName).toBe('New Name');
   });
 
+  it('updateUrls replaces stored URLs and clears cached tokens', async () => {
+    await manager.addProfile(
+      '@testuser:my.server',
+      'pass',
+      undefined,
+      'https://matrix.old.server',
+      'https://realms.old.server/',
+    );
+    manager.setRealmServerToken('cached-server-token');
+    manager.setRealmToken('https://realms.old.server/r/', 'cached-realm-token');
+
+    const changed = manager.updateUrls('@testuser:my.server', {
+      matrixUrl: 'https://matrix.new.server',
+      realmServerUrl: 'https://realms.new.server/',
+    });
+
+    expect(changed).toBe(true);
+    const profile = manager.getProfile('@testuser:my.server')!;
+    expect(profile.matrixUrl).toBe('https://matrix.new.server');
+    expect(profile.realmServerUrl).toBe('https://realms.new.server/');
+    expect(profile.realmTokens).toBeUndefined();
+    expect(profile.realmServerToken).toBeUndefined();
+  });
+
+  it('updateUrls returns false and preserves tokens when nothing changes', async () => {
+    await manager.addProfile(
+      '@testuser:my.server',
+      'pass',
+      undefined,
+      'https://matrix.my.server',
+      'https://realms.my.server/',
+    );
+    manager.setRealmServerToken('cached-server-token');
+
+    const changed = manager.updateUrls('@testuser:my.server', {
+      matrixUrl: 'https://matrix.my.server',
+      realmServerUrl: 'https://realms.my.server/',
+    });
+
+    expect(changed).toBe(false);
+    expect(manager.getRealmServerToken()).toBe('cached-server-token');
+  });
+
+  it('updateUrls accepts a partial update', async () => {
+    await manager.addProfile(
+      '@testuser:my.server',
+      'pass',
+      undefined,
+      'https://matrix.old.server',
+      'https://realms.my.server/',
+    );
+
+    const changed = manager.updateUrls('@testuser:my.server', {
+      matrixUrl: 'https://matrix.new.server',
+    });
+
+    expect(changed).toBe(true);
+    const profile = manager.getProfile('@testuser:my.server')!;
+    expect(profile.matrixUrl).toBe('https://matrix.new.server');
+    // realmServerUrl is unchanged
+    expect(profile.realmServerUrl).toBe('https://realms.my.server/');
+  });
+
+  it('updateUrls returns false for nonexistent profile', () => {
+    expect(
+      manager.updateUrls('@nonexistent:my.server', {
+        matrixUrl: 'https://matrix.x',
+      }),
+    ).toBe(false);
+  });
+
   it('handles corrupted config file gracefully', async () => {
     // Write invalid JSON to the config file
     const profilesFile = path.join(tmpDir, 'profiles.json');

--- a/packages/boxel-cli/tests/smoke.test.ts
+++ b/packages/boxel-cli/tests/smoke.test.ts
@@ -79,6 +79,61 @@ describe('boxel profile add (non-interactive)', () => {
     });
   });
 
+  it('exits 1 when --matrix-url is not a parseable URL', () => {
+    try {
+      run([
+        '-u',
+        '@alice:my.server',
+        '-m',
+        'matrix-url',
+        '-r',
+        'https://realms.my.server/',
+      ]);
+      throw new Error('expected command to exit non-zero');
+    } catch (err) {
+      const e = err as { status?: number; stderr?: string };
+      expect(e.status).toBe(1);
+      expect(e.stderr).toMatch(/--matrix-url "matrix-url" is not a valid URL/);
+    }
+  });
+
+  it('exits 1 when --realm-server-url uses a non-http(s) scheme', () => {
+    try {
+      run([
+        '-u',
+        '@alice:my.server',
+        '-m',
+        'https://matrix.my.server',
+        '-r',
+        'file:///etc/passwd',
+      ]);
+      throw new Error('expected command to exit non-zero');
+    } catch (err) {
+      const e = err as { status?: number; stderr?: string };
+      expect(e.status).toBe(1);
+      expect(e.stderr).toMatch(
+        /--realm-server-url "file:\/\/\/etc\/passwd" must use http:\/\/ or https:\/\//,
+      );
+    }
+  });
+
+  it('trims whitespace from URL flag values', () => {
+    run([
+      '-u',
+      '@alice:my.server',
+      '-m',
+      '  https://matrix.my.server  ',
+      '-r',
+      '  https://realms.my.server/  ',
+    ]);
+
+    const config = readProfiles();
+    expect(config.profiles['@alice:my.server']).toMatchObject({
+      matrixUrl: 'https://matrix.my.server',
+      realmServerUrl: 'https://realms.my.server/',
+    });
+  });
+
   it('exits 1 with a clear error for a non-standard domain without URL flags', () => {
     try {
       run(['-u', '@alice:my.server']);

--- a/packages/boxel-cli/tests/smoke.test.ts
+++ b/packages/boxel-cli/tests/smoke.test.ts
@@ -72,10 +72,9 @@ describe('boxel profile add (non-interactive)', () => {
     ]);
 
     const config = readProfiles();
-    // Intentionally-wrong expectation to verify CI produces a clean vitest diff.
     expect(config.profiles['@alice:my.server']).toMatchObject({
-      matrixUrl: 'https://matrix.WRONG.server',
-      realmServerUrl: 'https://realms.WRONG.server/',
+      matrixUrl: 'https://matrix.my.server',
+      realmServerUrl: 'https://realms.my.server/',
       password: 'hunter2',
     });
   });
@@ -103,11 +102,9 @@ describe('boxel profile add (non-interactive)', () => {
     });
 
     const config = readProfiles();
-    // Intentionally-wrong expectation: expects an https URL the implementation
-    // would never produce.
     expect(config.profiles['@alice:cs-10998-foo.localhost']).toMatchObject({
-      matrixUrl: 'https://matrix.cs-10998-foo.localhost',
-      realmServerUrl: 'https://realm-server.cs-10998-foo.localhost/',
+      matrixUrl: 'http://matrix.cs-10998-foo.localhost',
+      realmServerUrl: 'http://realm-server.cs-10998-foo.localhost/',
     });
   });
 
@@ -152,8 +149,8 @@ describe('boxel profile add (non-interactive)', () => {
     } catch (err) {
       const e = err as { status?: number; stderr?: string };
       expect(e.status).toBe(1);
-      // Intentionally-wrong expectation: this regex won't appear in stderr.
-      expect(e.stderr).toMatch(/this text does not appear anywhere/);
+      expect(e.stderr).toMatch(/BOXEL_ENVIRONMENT="!!!"/);
+      expect(e.stderr).toMatch(/no slug characters/);
     }
 
     expect(fs.existsSync(join(tmpHome, '.boxel-cli', 'profiles.json'))).toBe(

--- a/packages/boxel-cli/tests/smoke.test.ts
+++ b/packages/boxel-cli/tests/smoke.test.ts
@@ -72,9 +72,10 @@ describe('boxel profile add (non-interactive)', () => {
     ]);
 
     const config = readProfiles();
+    // Intentionally-wrong expectation to verify CI produces a clean vitest diff.
     expect(config.profiles['@alice:my.server']).toMatchObject({
-      matrixUrl: 'https://matrix.my.server',
-      realmServerUrl: 'https://realms.my.server/',
+      matrixUrl: 'https://matrix.WRONG.server',
+      realmServerUrl: 'https://realms.WRONG.server/',
       password: 'hunter2',
     });
   });
@@ -102,9 +103,11 @@ describe('boxel profile add (non-interactive)', () => {
     });
 
     const config = readProfiles();
+    // Intentionally-wrong expectation: expects an https URL the implementation
+    // would never produce.
     expect(config.profiles['@alice:cs-10998-foo.localhost']).toMatchObject({
-      matrixUrl: 'http://matrix.cs-10998-foo.localhost',
-      realmServerUrl: 'http://realm-server.cs-10998-foo.localhost/',
+      matrixUrl: 'https://matrix.cs-10998-foo.localhost',
+      realmServerUrl: 'https://realm-server.cs-10998-foo.localhost/',
     });
   });
 
@@ -149,8 +152,8 @@ describe('boxel profile add (non-interactive)', () => {
     } catch (err) {
       const e = err as { status?: number; stderr?: string };
       expect(e.status).toBe(1);
-      expect(e.stderr).toMatch(/BOXEL_ENVIRONMENT="!!!"/);
-      expect(e.stderr).toMatch(/no slug characters/);
+      // Intentionally-wrong expectation: this regex won't appear in stderr.
+      expect(e.stderr).toMatch(/this text does not appear anywhere/);
     }
 
     expect(fs.existsSync(join(tmpHome, '.boxel-cli', 'profiles.json'))).toBe(

--- a/packages/boxel-cli/tests/smoke.test.ts
+++ b/packages/boxel-cli/tests/smoke.test.ts
@@ -165,9 +165,11 @@ describe('boxel profile add (non-interactive)', () => {
     });
   });
 
-  it('exits 1 when BOXEL_ENVIRONMENT slugifies to empty', () => {
+  it('exits 1 when BOXEL_ENVIRONMENT slugifies to empty (and is actually consulted)', () => {
+    // Use a non-standard domain so BOXEL_ENVIRONMENT is consulted; a
+    // standard domain like @alice:stack.cards bypasses the env var entirely.
     try {
-      run(['-u', '@alice:stack.cards'], { BOXEL_ENVIRONMENT: '!!!' });
+      run(['-u', '@alice:my.server'], { BOXEL_ENVIRONMENT: '!!!' });
       throw new Error('expected command to exit non-zero');
     } catch (err) {
       const e = err as { status?: number; stderr?: string };
@@ -179,5 +181,19 @@ describe('boxel profile add (non-interactive)', () => {
     expect(fs.existsSync(join(tmpHome, '.boxel-cli', 'profiles.json'))).toBe(
       false,
     );
+  });
+
+  it('ignores BOXEL_ENVIRONMENT when the Matrix ID has a known standard domain', () => {
+    // The Matrix ID's domain is authoritative for known standards
+    // (stack.cards / boxel.ai / localhost). Even an *invalid* env value
+    // (which would otherwise exit 1) must not affect this path — the
+    // resulting profile points at staging, not at env-derived URLs.
+    run(['-u', '@alice:stack.cards'], { BOXEL_ENVIRONMENT: '!!!' });
+
+    const config = readProfiles();
+    expect(config.profiles['@alice:stack.cards']).toMatchObject({
+      matrixUrl: 'https://matrix-staging.stack.cards',
+      realmServerUrl: 'https://realms-staging.stack.cards/',
+    });
   });
 });

--- a/packages/boxel-cli/tests/smoke.test.ts
+++ b/packages/boxel-cli/tests/smoke.test.ts
@@ -238,6 +238,32 @@ describe('boxel profile add (non-interactive)', () => {
     );
   });
 
+  it('updates stored URLs when re-adding an existing profile with new URL flags', () => {
+    run([
+      '-u',
+      '@alice:my.server',
+      '-m',
+      'https://matrix.old.server',
+      '-r',
+      'https://realms.old.server/',
+    ]);
+
+    run([
+      '-u',
+      '@alice:my.server',
+      '-m',
+      'https://matrix.new.server',
+      '-r',
+      'https://realms.new.server/',
+    ]);
+
+    const config = readProfiles();
+    expect(config.profiles['@alice:my.server']).toMatchObject({
+      matrixUrl: 'https://matrix.new.server',
+      realmServerUrl: 'https://realms.new.server/',
+    });
+  });
+
   it('ignores BOXEL_ENVIRONMENT when the Matrix ID has a known standard domain', () => {
     // The Matrix ID's domain is authoritative for known standards
     // (stack.cards / boxel.ai / localhost). Even an *invalid* env value

--- a/packages/boxel-cli/tests/smoke.test.ts
+++ b/packages/boxel-cli/tests/smoke.test.ts
@@ -1,6 +1,8 @@
 import { execFileSync } from 'child_process';
-import { resolve } from 'path';
-import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import { resolve, join } from 'path';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 
 const cliEntry = resolve(__dirname, '../dist/index.js');
 
@@ -18,5 +20,74 @@ describe('boxel-cli', () => {
       encoding: 'utf8',
     });
     expect(output.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});
+
+describe('boxel profile add (non-interactive)', () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(join(os.tmpdir(), 'boxel-cli-smoke-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  const run = (args: string[]) =>
+    execFileSync(process.execPath, [cliEntry, 'profile', 'add', ...args], {
+      encoding: 'utf8',
+      env: { ...process.env, HOME: tmpHome, BOXEL_PASSWORD: 'hunter2' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+  const readProfiles = () =>
+    JSON.parse(
+      fs.readFileSync(join(tmpHome, '.boxel-cli', 'profiles.json'), 'utf8'),
+    );
+
+  it('creates a profile for a standard domain without URL flags', () => {
+    run(['-u', '@alice:stack.cards']);
+
+    const config = readProfiles();
+    expect(config.profiles['@alice:stack.cards']).toMatchObject({
+      matrixUrl: 'https://matrix-staging.stack.cards',
+      realmServerUrl: 'https://realms-staging.stack.cards/',
+    });
+  });
+
+  it('creates a profile for a non-standard domain with URL flags', () => {
+    run([
+      '-u',
+      '@alice:my.server',
+      '-m',
+      'https://matrix.my.server',
+      '-r',
+      'https://realms.my.server/',
+    ]);
+
+    const config = readProfiles();
+    expect(config.profiles['@alice:my.server']).toMatchObject({
+      matrixUrl: 'https://matrix.my.server',
+      realmServerUrl: 'https://realms.my.server/',
+      password: 'hunter2',
+    });
+  });
+
+  it('exits 1 with a clear error for a non-standard domain without URL flags', () => {
+    try {
+      run(['-u', '@alice:my.server']);
+      throw new Error('expected command to exit non-zero');
+    } catch (err) {
+      const e = err as { status?: number; stderr?: string };
+      expect(e.status).toBe(1);
+      expect(e.stderr).toMatch(/Unknown domain/);
+      expect(e.stderr).toMatch(/--matrix-url/);
+      expect(e.stderr).toMatch(/--realm-server-url/);
+    }
+
+    expect(
+      fs.existsSync(join(tmpHome, '.boxel-cli', 'profiles.json')),
+    ).toBe(false);
   });
 });

--- a/packages/boxel-cli/tests/smoke.test.ts
+++ b/packages/boxel-cli/tests/smoke.test.ts
@@ -91,9 +91,9 @@ describe('boxel profile add (non-interactive)', () => {
       expect(e.stderr).toMatch(/--realm-server-url/);
     }
 
-    expect(
-      fs.existsSync(join(tmpHome, '.boxel-cli', 'profiles.json')),
-    ).toBe(false);
+    expect(fs.existsSync(join(tmpHome, '.boxel-cli', 'profiles.json'))).toBe(
+      false,
+    );
   });
 
   it('derives URLs from the BOXEL_ENVIRONMENT slug', () => {
@@ -153,8 +153,8 @@ describe('boxel profile add (non-interactive)', () => {
       expect(e.stderr).toMatch(/no slug characters/);
     }
 
-    expect(
-      fs.existsSync(join(tmpHome, '.boxel-cli', 'profiles.json')),
-    ).toBe(false);
+    expect(fs.existsSync(join(tmpHome, '.boxel-cli', 'profiles.json'))).toBe(
+      false,
+    );
   });
 });

--- a/packages/boxel-cli/tests/smoke.test.ts
+++ b/packages/boxel-cli/tests/smoke.test.ts
@@ -34,10 +34,15 @@ describe('boxel profile add (non-interactive)', () => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  const run = (args: string[]) =>
+  const run = (args: string[], extraEnv: NodeJS.ProcessEnv = {}) =>
     execFileSync(process.execPath, [cliEntry, 'profile', 'add', ...args], {
       encoding: 'utf8',
-      env: { ...process.env, HOME: tmpHome, BOXEL_PASSWORD: 'hunter2' },
+      env: {
+        ...process.env,
+        HOME: tmpHome,
+        BOXEL_PASSWORD: 'hunter2',
+        ...extraEnv,
+      },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
@@ -84,6 +89,54 @@ describe('boxel profile add (non-interactive)', () => {
       expect(e.stderr).toMatch(/Unknown domain/);
       expect(e.stderr).toMatch(/--matrix-url/);
       expect(e.stderr).toMatch(/--realm-server-url/);
+    }
+
+    expect(
+      fs.existsSync(join(tmpHome, '.boxel-cli', 'profiles.json')),
+    ).toBe(false);
+  });
+
+  it('derives URLs from BOXEL_ENVIRONMENT when no URL flags are given', () => {
+    run(['-u', '@alice:my.server'], { BOXEL_ENVIRONMENT: 'production' });
+
+    const config = readProfiles();
+    expect(config.profiles['@alice:my.server']).toMatchObject({
+      matrixUrl: 'https://matrix.boxel.ai',
+      realmServerUrl: 'https://app.boxel.ai/',
+    });
+  });
+
+  it('lets --matrix-url and --realm-server-url override BOXEL_ENVIRONMENT', () => {
+    run(
+      [
+        '-u',
+        '@alice:my.server',
+        '-m',
+        'https://matrix.my.server',
+        '-r',
+        'https://realms.my.server/',
+      ],
+      { BOXEL_ENVIRONMENT: 'production' },
+    );
+
+    const config = readProfiles();
+    expect(config.profiles['@alice:my.server']).toMatchObject({
+      matrixUrl: 'https://matrix.my.server',
+      realmServerUrl: 'https://realms.my.server/',
+    });
+  });
+
+  it('exits 1 on an unknown BOXEL_ENVIRONMENT value', () => {
+    try {
+      run(['-u', '@alice:stack.cards'], { BOXEL_ENVIRONMENT: 'bogus' });
+      throw new Error('expected command to exit non-zero');
+    } catch (err) {
+      const e = err as { status?: number; stderr?: string };
+      expect(e.status).toBe(1);
+      expect(e.stderr).toMatch(/Unknown BOXEL_ENVIRONMENT/);
+      expect(e.stderr).toMatch(/staging/);
+      expect(e.stderr).toMatch(/production/);
+      expect(e.stderr).toMatch(/local/);
     }
 
     expect(

--- a/packages/boxel-cli/tests/smoke.test.ts
+++ b/packages/boxel-cli/tests/smoke.test.ts
@@ -96,13 +96,29 @@ describe('boxel profile add (non-interactive)', () => {
     ).toBe(false);
   });
 
-  it('derives URLs from BOXEL_ENVIRONMENT when no URL flags are given', () => {
-    run(['-u', '@alice:my.server'], { BOXEL_ENVIRONMENT: 'production' });
+  it('derives URLs from the BOXEL_ENVIRONMENT slug', () => {
+    run(['-u', '@alice:cs-10998-foo.localhost'], {
+      BOXEL_ENVIRONMENT: 'cs-10998-foo',
+    });
 
     const config = readProfiles();
-    expect(config.profiles['@alice:my.server']).toMatchObject({
-      matrixUrl: 'https://matrix.boxel.ai',
-      realmServerUrl: 'https://app.boxel.ai/',
+    expect(config.profiles['@alice:cs-10998-foo.localhost']).toMatchObject({
+      matrixUrl: 'http://matrix.cs-10998-foo.localhost',
+      realmServerUrl: 'http://realm-server.cs-10998-foo.localhost/',
+    });
+  });
+
+  it('slugifies BOXEL_ENVIRONMENT like env-slug.sh (case, /, special chars)', () => {
+    // 'My/Branch_Name!' → lowercase 'my/branch_name!' → '/' becomes '-' →
+    // '_' and '!' are stripped (not in [a-z0-9-]) → 'my-branchname'.
+    run(['-u', '@alice:my-branchname.localhost'], {
+      BOXEL_ENVIRONMENT: 'My/Branch_Name!',
+    });
+
+    const config = readProfiles();
+    expect(config.profiles['@alice:my-branchname.localhost']).toMatchObject({
+      matrixUrl: 'http://matrix.my-branchname.localhost',
+      realmServerUrl: 'http://realm-server.my-branchname.localhost/',
     });
   });
 
@@ -116,7 +132,7 @@ describe('boxel profile add (non-interactive)', () => {
         '-r',
         'https://realms.my.server/',
       ],
-      { BOXEL_ENVIRONMENT: 'production' },
+      { BOXEL_ENVIRONMENT: 'cs-10998-foo' },
     );
 
     const config = readProfiles();
@@ -126,17 +142,15 @@ describe('boxel profile add (non-interactive)', () => {
     });
   });
 
-  it('exits 1 on an unknown BOXEL_ENVIRONMENT value', () => {
+  it('exits 1 when BOXEL_ENVIRONMENT slugifies to empty', () => {
     try {
-      run(['-u', '@alice:stack.cards'], { BOXEL_ENVIRONMENT: 'bogus' });
+      run(['-u', '@alice:stack.cards'], { BOXEL_ENVIRONMENT: '!!!' });
       throw new Error('expected command to exit non-zero');
     } catch (err) {
       const e = err as { status?: number; stderr?: string };
       expect(e.status).toBe(1);
-      expect(e.stderr).toMatch(/Unknown BOXEL_ENVIRONMENT/);
-      expect(e.stderr).toMatch(/staging/);
-      expect(e.stderr).toMatch(/production/);
-      expect(e.stderr).toMatch(/local/);
+      expect(e.stderr).toMatch(/BOXEL_ENVIRONMENT="!!!"/);
+      expect(e.stderr).toMatch(/no slug characters/);
     }
 
     expect(

--- a/packages/boxel-cli/tests/smoke.test.ts
+++ b/packages/boxel-cli/tests/smoke.test.ts
@@ -142,6 +142,29 @@ describe('boxel profile add (non-interactive)', () => {
     });
   });
 
+  it('ignores an invalid BOXEL_ENVIRONMENT when both URL flags are supplied', () => {
+    // If both URLs are explicit, BOXEL_ENVIRONMENT is never consulted,
+    // so even a value that would normally exit 1 (slugifies to empty)
+    // must not block the command.
+    run(
+      [
+        '-u',
+        '@alice:my.server',
+        '-m',
+        'https://matrix.my.server',
+        '-r',
+        'https://realms.my.server/',
+      ],
+      { BOXEL_ENVIRONMENT: '!!!' },
+    );
+
+    const config = readProfiles();
+    expect(config.profiles['@alice:my.server']).toMatchObject({
+      matrixUrl: 'https://matrix.my.server',
+      realmServerUrl: 'https://realms.my.server/',
+    });
+  });
+
   it('exits 1 when BOXEL_ENVIRONMENT slugifies to empty', () => {
     try {
       run(['-u', '@alice:stack.cards'], { BOXEL_ENVIRONMENT: '!!!' });

--- a/packages/boxel-cli/tests/smoke.test.ts
+++ b/packages/boxel-cli/tests/smoke.test.ts
@@ -34,11 +34,19 @@ describe('boxel profile add (non-interactive)', () => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 
+  // Strip BOXEL_* from the inherited env so a developer's shell (e.g. one
+  // with BOXEL_ENVIRONMENT set for mise-tasks) can't change test behavior.
+  // Tests that exercise these vars opt in via extraEnv.
+  const sanitizedParentEnv = () =>
+    Object.fromEntries(
+      Object.entries(process.env).filter(([key]) => !key.startsWith('BOXEL_')),
+    );
+
   const run = (args: string[], extraEnv: NodeJS.ProcessEnv = {}) =>
     execFileSync(process.execPath, [cliEntry, 'profile', 'add', ...args], {
       encoding: 'utf8',
       env: {
-        ...process.env,
+        ...sanitizedParentEnv(),
         HOME: tmpHome,
         BOXEL_PASSWORD: 'hunter2',
         ...extraEnv,
@@ -132,6 +140,32 @@ describe('boxel profile add (non-interactive)', () => {
       matrixUrl: 'https://matrix.my.server',
       realmServerUrl: 'https://realms.my.server/',
     });
+  });
+
+  it("does not let the parent process's BOXEL_ENVIRONMENT leak into the child", () => {
+    // A developer running the suite with BOXEL_ENVIRONMENT set in their
+    // shell should see the same behavior as CI. We simulate that by
+    // setting it on this process's env, then assert the child still
+    // exits with the "Unknown domain" error rather than silently
+    // deriving URLs from the leaked value.
+    const previous = process.env.BOXEL_ENVIRONMENT;
+    process.env.BOXEL_ENVIRONMENT = 'leaked-from-shell';
+    try {
+      try {
+        run(['-u', '@alice:my.server']);
+        throw new Error('expected command to exit non-zero');
+      } catch (err) {
+        const e = err as { status?: number; stderr?: string };
+        expect(e.status).toBe(1);
+        expect(e.stderr).toMatch(/Unknown domain/);
+      }
+    } finally {
+      if (previous === undefined) {
+        delete process.env.BOXEL_ENVIRONMENT;
+      } else {
+        process.env.BOXEL_ENVIRONMENT = previous;
+      }
+    }
   });
 
   it('exits 1 with a clear error for a non-standard domain without URL flags', () => {


### PR DESCRIPTION
To review #4517 with environment mode, I needed the ability to specify custom realm and Matrix servers when adding a profile. This also adds the option of using `BOXEL_ENVIRONMENT` to make those servers be derived from the environment name.

Here it is in action, in both interactive and full CLI mode:

```
❯ BOXEL_ENVIRONMENT=cs-10998-boxel-cli-seed-auth ./dist/index.js profile add

Add New Profile

Using BOXEL_ENVIRONMENT=cs-10998-boxel-cli-seed-auth

Enter your Boxel username (without @ or domain)
Example: ctse, aallen90
Username: user
Password: ********
Display name [user · cs-10998-boxel-cli-seed-auth.localhost]:

✓ Profile created: [user · cs-10998-boxel-cli-seed-auth.localhost]
Switch to this profile now? [Y/n]:
✓ Switched to [user · cs-10998-boxel-cli-seed-auth.localhost]
❯ ./dist/index.js profile add -u @test:yes -p pass -r hello -m matrix-url
Warning: Supplying a password via -p/--password may expose it in shell history and process listings. For non-interactive usage, prefer the BOXEL_PASSWORD environment variable or use "boxel profile add" interactively.
✓ Profile created: [test · yes]
Use 'boxel profile switch @test:yes' to switch to this profile.
❯ cat ~/.boxel-cli/profiles.json
{
  "profiles": {
…
    "@user:cs-10998-boxel-cli-seed-auth.localhost": {
      "displayName": "user · cs-10998-boxel-cli-seed-auth.localhost",
      "matrixUrl": "http://matrix.cs-10998-boxel-cli-seed-auth.localhost",
      "realmServerUrl": "http://realm-server.cs-10998-boxel-cli-seed-auth.localhost/",
      "password": "password"
    },
    "@test:yes": {
      "displayName": "test · yes",
      "matrixUrl": "matrix-url",
      "realmServerUrl": "hello",
      "password": "pass"
    }
  },
  "activeProfile": "@user:cs-10998-boxel-cli-seed-auth.localhost"
}
```