### PR TITLE
bot-runner: wrap submission PR files under room-<base64> folder

### DIFF
--- a/packages/bot-runner/lib/create-listing-pr-handler.ts
+++ b/packages/bot-runner/lib/create-listing-pr-handler.ts
@@ -114,18 +114,24 @@ export class CreateListingPRHandler {
     if (!context) {
       return;
     }
-    let branchWrite = await getContentsFromRealm(
+    let rawFiles = await getContentsFromRealm(
       runCommandResult?.cardResultString,
     );
-    if (branchWrite.files.length === 0) {
+    if (rawFiles.length === 0) {
       return;
     }
+    let folderName = buildSubmissionFolderName(context);
+    let files = rawFiles.map((file) => ({
+      ...file,
+      path: `${folderName}/${file.path}`,
+    }));
+    let hash = hashFiles(files);
     await this.githubClient.writeFilesToBranch({
       owner: context.owner,
       repo: context.repoName,
       branch: context.head,
-      files: branchWrite.files,
-      message: `add ${context.listingDisplayName} changes [boxel-content-hash:${branchWrite.hash}]`,
+      files,
+      message: `add ${context.listingDisplayName} changes [boxel-content-hash:${hash}]`,
     });
   }
 
@@ -225,12 +231,19 @@ export class CreateListingPRHandler {
       `- Listing Name: ${context.listingDisplayName}`,
       `- Room ID: \`${context.roomId}\``,
       `- User ID: \`${runAs}\``,
-      `- Number of Files: ${files.files.length}`,
+      `- Number of Files: ${files.length}`,
       ...(workflowCardUrl
         ? [`- Workflow Card: [${workflowCardUrl}](${workflowCardUrl})`]
         : []),
     ].join('\n');
   }
+}
+
+function buildSubmissionFolderName(context: CreateListingPRContext): string {
+  // Wrap files under the room segment of the branch path
+  // ("room-<base64-roomId>"). Each PR is scoped to one branch, so the room
+  // segment alone uniquely identifies the submission's location on disk.
+  return context.head.split('/')[0];
 }
 
 function mapOpenPullRequestResult(
@@ -248,21 +261,17 @@ function mapOpenPullRequestResult(
   };
 }
 
-async function getContentsFromRealm(cardResultString?: string | null): Promise<{
-  files: { path: string; content: string }[];
-  hash: string;
-}> {
+async function getContentsFromRealm(
+  cardResultString?: string | null,
+): Promise<{ path: string; content: string }[]> {
   if (!cardResultString || !cardResultString.trim()) {
-    return { files: [], hash: hashFiles([]) };
+    return [];
   }
-
   let parsed = parseJSONLike(cardResultString);
   if (parsed === undefined) {
-    return { files: [], hash: hashFiles([]) };
+    return [];
   }
-
-  let files = extractFileContents(parsed);
-  return { files, hash: hashFiles(files) };
+  return extractFileContents(parsed);
 }
 
 function parseJSONLike(value: string): unknown | undefined {

--- a/packages/bot-runner/tests/bot-runner-test.ts
+++ b/packages/bot-runner/tests/bot-runner-test.ts
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
-import type {
-  DBAdapter,
-  ExecuteOptions,
-  PgPrimitive,
-  QueuePublisher,
+import {
+  toBranchName,
+  type DBAdapter,
+  type ExecuteOptions,
+  type PgPrimitive,
+  type QueuePublisher,
 } from '@cardstack/runtime-common';
 import type {
   MatrixClient,
@@ -342,19 +343,20 @@ module('timeline handler', () => {
       write.branch?.toString().includes('my-listing'),
       'commit branch includes listing slug',
     );
+    let folder = toBranchName('!abc123:localhost', 'My Listing').split('/')[0];
     assert.deepEqual(
       write.files,
       [
         {
-          path: 'experiments/MyListing/listing.json',
+          path: `${folder}/experiments/MyListing/listing.json`,
           content: '{"data":{"type":"card"}}',
         },
         {
-          path: 'experiments/MyListing/readme.md',
+          path: `${folder}/experiments/MyListing/readme.md`,
           content: '# My Listing',
         },
       ],
-      'commit payload contains parsed files from allFileContents',
+      'commit payload wraps parsed files in room-<base64> folder',
     );
     assert.true(
       write.message

--- a/packages/bot-runner/tests/create-listing-pr-handler-test.ts
+++ b/packages/bot-runner/tests/create-listing-pr-handler-test.ts
@@ -1,9 +1,14 @@
 import { module, test } from 'qunit';
+import { toBranchName } from '@cardstack/runtime-common';
 import type { GitHubClient } from '../lib/github';
 import {
   CreateListingPRHandler,
   type BotTriggerEventContent,
 } from '../lib/create-listing-pr-handler';
+
+function expectedFolderName(roomId: string, listingName: string): string {
+  return toBranchName(roomId, listingName).split('/')[0];
+}
 
 module('create-listing-pr handler', () => {
   test('opens PR with expected params and summary body', async (assert) => {
@@ -188,6 +193,144 @@ module('create-listing-pr handler', () => {
     );
 
     assert.strictEqual(result, null, 'returns null when PR already exists');
+  });
+
+  test('addContentsToCommit wraps files under the room-<base64> folder', async (assert) => {
+    let writeCalls: { files: { path: string; content: string }[]; message: string }[] = [];
+    let githubClient: GitHubClient = {
+      openPullRequest: async () => ({ number: 1, html_url: 'x' }),
+      createBranch: async () => ({ ref: 'refs/heads/test', sha: 'abc123' }),
+      writeFileToBranch: async () => ({ commitSha: 'def456' }),
+      writeFilesToBranch: async (params) => {
+        writeCalls.push({ files: params.files, message: params.message });
+        return { commitSha: 'def456' };
+      },
+    };
+
+    let roomId = '!abc123:localhost';
+    let listingName = 'My Listing';
+    let eventContent: BotTriggerEventContent = {
+      type: 'pr-listing-create',
+      realm: 'http://localhost:4201/test/',
+      userId: '@alice:localhost',
+      input: { roomId, listingName },
+    };
+
+    let handler = new CreateListingPRHandler(githubClient);
+    await handler.addContentsToCommit(eventContent, {
+      status: 'ready',
+      cardResultString: JSON.stringify({
+        data: {
+          attributes: {
+            allFileContents: [
+              { filename: 'CardListing/abc.json', contents: '{}' },
+              { filename: 'Spec/def.json', contents: '{}' },
+              { filename: 'Recipe.gts', contents: 'export const x = 1;' },
+            ],
+          },
+        },
+      }),
+    });
+
+    assert.strictEqual(writeCalls.length, 1, 'writes once');
+    let folder = expectedFolderName(roomId, listingName);
+    assert.deepEqual(
+      writeCalls[0].files.map((f) => f.path).sort(),
+      [
+        `${folder}/CardListing/abc.json`,
+        `${folder}/Recipe.gts`,
+        `${folder}/Spec/def.json`,
+      ],
+      'every file is prefixed with the wrapper folder, inner type-grouped layout preserved',
+    );
+    assert.true(
+      folder.startsWith('room-'),
+      'folder uses the branch room segment as prefix',
+    );
+  });
+
+  test('addContentsToCommit produces the same folder for the same branch (idempotency)', async (assert) => {
+    let writeCalls: { path: string }[][] = [];
+    let githubClient: GitHubClient = {
+      openPullRequest: async () => ({ number: 1, html_url: 'x' }),
+      createBranch: async () => ({ ref: 'refs/heads/test', sha: 'abc123' }),
+      writeFileToBranch: async () => ({ commitSha: 'def456' }),
+      writeFilesToBranch: async (params) => {
+        writeCalls.push(params.files.map((f) => ({ path: f.path })));
+        return { commitSha: 'def456' };
+      },
+    };
+
+    let eventContent: BotTriggerEventContent = {
+      type: 'pr-listing-create',
+      realm: 'http://localhost:4201/test/',
+      userId: '@alice:localhost',
+      input: { roomId: '!abc123:localhost', listingName: 'My Listing' },
+    };
+
+    let handler = new CreateListingPRHandler(githubClient);
+    let runResult = {
+      status: 'ready' as const,
+      cardResultString: JSON.stringify({
+        data: {
+          attributes: {
+            allFileContents: [{ filename: 'Recipe.gts', contents: 'x' }],
+          },
+        },
+      }),
+    };
+    await handler.addContentsToCommit(eventContent, runResult);
+    await handler.addContentsToCommit(eventContent, runResult);
+
+    assert.strictEqual(writeCalls.length, 2, 'writes twice');
+    assert.deepEqual(
+      writeCalls[0],
+      writeCalls[1],
+      'same branch + same files → same prefixed paths across runs',
+    );
+  });
+
+  test('addContentsToCommit uses a different folder for a different room', async (assert) => {
+    let folders: string[] = [];
+    let githubClient: GitHubClient = {
+      openPullRequest: async () => ({ number: 1, html_url: 'x' }),
+      createBranch: async () => ({ ref: 'refs/heads/test', sha: 'abc123' }),
+      writeFileToBranch: async () => ({ commitSha: 'def456' }),
+      writeFilesToBranch: async (params) => {
+        folders.push(params.files[0].path.split('/')[0]);
+        return { commitSha: 'def456' };
+      },
+    };
+
+    let handler = new CreateListingPRHandler(githubClient);
+    let runResult = {
+      status: 'ready' as const,
+      cardResultString: JSON.stringify({
+        data: {
+          attributes: {
+            allFileContents: [{ filename: 'Recipe.gts', contents: 'x' }],
+          },
+        },
+      }),
+    };
+
+    for (let roomId of ['!room-a:localhost', '!room-b:localhost']) {
+      await handler.addContentsToCommit(
+        {
+          type: 'pr-listing-create',
+          realm: 'http://localhost:4201/test/',
+          userId: '@alice:localhost',
+          input: { roomId, listingName: 'My Listing' },
+        },
+        runResult,
+      );
+    }
+
+    assert.notStrictEqual(
+      folders[0],
+      folders[1],
+      'two different rooms with the same listing name produce distinct folders',
+    );
   });
 
   test('returns null when branch has no commits beyond base', async (assert) => {


### PR DESCRIPTION
## Summary
- Each submission's files are now committed under a single `room-<base64-roomId>/` wrapper so multiple submissions don't scatter across the catalog's shared `CardListing/`, `Spec/`, etc. folders.
- Example PR when make a submission: https://github.com/cardstack/boxel-catalog/pull/482/changes#diff-6133c1183855020c02209c11f656c25bb4563cfe568fe90817860f6f5b6d20a7
- Inner type-grouped layout is preserved inside the wrapper — only the GitHub layout changes; PrCard storage and `collect-submission-files` are untouched.

### Before
```
CardListing/<uuid>.json
Spec/<uuid>.json
Recipe.gts
```

### After
```
room-IXBJd3lZZXpYTUZrek9UanhVWTpsb2NhbGhvc3Q/
  CardListing/<uuid>.json
  Spec/<uuid>.json
  Recipe.gts
```

The wrapper is `context.head.split('/')[0]` — the room segment of the branch path, which uniquely identifies the submission session.

## Test plan
- [x] `pnpm --filter @cardstack/bot-runner test` (36 pass / 1 skip / 0 fail)
- [x] New unit tests cover: wrapper layout, idempotency across re-runs, distinct folders for distinct rooms
- [x] Updated `bot-runner-test.ts` integration test to expect the wrapped paths
- [x] End-to-end: submit a listing through the host UI and confirm the resulting PR has all files under one `room-<base64>/` folder
