### PR TITLE
SF harness: preserve cloned modules cache to avoid cold prerender per test

### DIFF
--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -99,6 +99,13 @@ if (process.env.DISABLE_MODULE_CACHING === 'true') {
 const ENABLE_FILE_WATCHER = process.env.ENABLE_FILE_WATCHER === 'true';
 const FULL_INDEX_ON_STARTUP =
   process.env.REALM_SERVER_FULL_INDEX_ON_STARTUP !== 'false';
+// When set to 'true', skip the unconditional modules-cache clear on startup.
+// Used by the software-factory test harness, which restores a known-good
+// modules cache from a template database (URLs already rewritten to match
+// the runtime port) and would otherwise pay a full cold prerender on every
+// test's first lookupDefinition.
+const SKIP_MODULES_CACHE_CLEAR_ON_STARTUP =
+  process.env.REALM_SERVER_SKIP_MODULES_CACHE_CLEAR_ON_STARTUP === 'true';
 
 let {
   port,
@@ -298,8 +305,12 @@ const getIndexHTML = async () => {
     createPrerenderAuth,
   );
 
-  log.info('Clearing modules cache...');
-  await definitionLookup.clearAllModules();
+  if (SKIP_MODULES_CACHE_CLEAR_ON_STARTUP) {
+    log.info('Skipping modules cache clear on startup (opted out via env)');
+  } else {
+    log.info('Clearing modules cache...');
+    await definitionLookup.clearAllModules();
+  }
 
   // Backfill realm_registry from CLI args (bootstrap), on-disk source realms,
   // and on-disk published realms. Runs before Realm construction so the

--- a/packages/software-factory/src/harness/api.ts
+++ b/packages/software-factory/src/harness/api.ts
@@ -62,7 +62,6 @@ import {
 import {
   buildCombinedTemplateDatabase,
   buildTemplateDatabase,
-  clearModuleCache,
   clearRealmPermissions,
   cloneDatabaseFromTemplate,
   databaseExists,
@@ -475,7 +474,6 @@ export async function startFactoryRealmServer(
         );
       }
       await resetQueueState(databaseName);
-      await clearModuleCache(databaseName);
       await rebuildWorkingIndexFromIndex(databaseName);
       await seedRealmPermissions(
         databaseName,

--- a/packages/software-factory/src/harness/database.ts
+++ b/packages/software-factory/src/harness/database.ts
@@ -423,6 +423,26 @@ export async function rewriteClonedRealmServerUrls(
            SET realm_url = replace(realm_url, $1, $2)`,
           [fromURL, toURL],
         );
+        // Without this, lookupDefinition misses every cached module on the
+        // first request after clone and pays a full prerender (~45s for a
+        // module with deep transitive imports), which can blow past the
+        // 60s realm-search tool timeout.
+        await client.query(
+          `UPDATE modules
+           SET url = replace(url, $1, $2),
+               file_alias = replace(file_alias, $1, $2),
+               resolved_realm_url = replace(resolved_realm_url, $1, $2),
+               definitions = replace(definitions::text, $1, $2)::jsonb,
+               deps = replace(deps::text, $1, $2)::jsonb,
+               error_doc = replace(error_doc::text, $1, $2)::jsonb`,
+          [fromURL, toURL],
+        );
+        await client.query(
+          `UPDATE realm_registry
+           SET url = replace(url, $1, $2),
+               source_url = replace(source_url, $1, $2)`,
+          [fromURL, toURL],
+        );
 
         await client.query('COMMIT');
       } catch (error) {

--- a/packages/software-factory/src/harness/isolated-realm-stack.ts
+++ b/packages/software-factory/src/harness/isolated-realm-stack.ts
@@ -421,6 +421,14 @@ export async function startIsolatedRealmStack({
     MATRIX_REGISTRATION_SHARED_SECRET: context.matrixRegistrationSecret,
     REALM_SERVER_MATRIX_USERNAME: DEFAULT_MATRIX_SERVER_USERNAME,
     REALM_SERVER_FULL_INDEX_ON_STARTUP: String(fullIndexOnStartup),
+    // When restoring from a template snapshot, the modules cache has already
+    // been rewritten to the runtime port by `rewriteClonedRealmServerUrls`.
+    // Tell the realm-server to keep that cache instead of wiping it on
+    // startup, so the first lookupDefinition for a fixture-side module hits
+    // the cache instead of paying a cold prerender (~45s for darkfactory.gts).
+    REALM_SERVER_SKIP_MODULES_CACHE_CLEAR_ON_STARTUP: fullIndexOnStartup
+      ? 'false'
+      : 'true',
     LOW_CREDIT_THRESHOLD: '2000',
     LOG_LEVELS: DEFAULT_REALM_LOG_LEVELS,
     BOXEL_TRUST_FORWARDED_URL: 'true',


### PR DESCRIPTION
## Summary

Two failing SF Playwright tests on `main`:
- `tests/factory-tool-executor.spec.ts:574 › realm-search with seeded fixture data › search by type returns matching cards and excludes non-matching types`
- `tests/factory-tool-executor.spec.ts:670 › realm-search on a private realm › search with owner token succeeds, search without token fails`

Both fail with `ToolTimeoutError: Tool \"realm-search\" timed out after 60000ms`.

## Root cause

Trace through the call chain:

1. `realm-search` returns 2 cards in ~30 ms.
2. `searchCards` is called with `loadLinks: true`, which calls `populateQueryFields` for each result, which calls `lookupDefinition(darkfactoryModule)` to resolve the schema for the result's `linksTo`/`linksToMany` fields.
3. The `modules` cache **misses every time on the per-test runtime**, so the lookup falls through to `getModuleDefinitionsViaPrerenderer`.
4. The prerender of `darkfactory.gts` takes ~45–55 s on the cold path: ~9 s for headless-Chrome Ember bootstrap + ~45 s loading the module and its transitive base imports through the realm-server.
5. The 60 s tool timeout fires before the prerender completes.

Why the cache always misses: `cache:prepare` builds the template by running a realm-server at port X (random, whatever was free), so the `modules` table ends up with rows like `resolved_realm_url=http://localhost:35021/software-factory/`. The per-test realm subprocess picks a different random port (e.g. `21710`) and looks up under that URL — every lookup is a structural miss against the template-baked URLs.

The harness already had `rewriteClonedRealmServerUrls` covering `boxel_index`, `realm_versions`, `realm_file_meta`, `realm_user_permissions`, `realm_meta`, `published_realms`, and `session_rooms` for exactly this reason — but **the `modules` table (and `realm_registry`) were left out**. To paper over the gap, `startFactoryRealmServer` was unconditionally calling `clearModuleCache(databaseName)` after clone, throwing away the cache instead of repairing it.

Even after fixing both, a second issue: `realm-server/main.ts` unconditionally calls `definitionLookup.clearAllModules()` on every boot (commit 7d7e536214 made it unconditional), which would wipe the freshly-rewritten cache regardless.

## Changes

- **`packages/software-factory/src/harness/database.ts`** — extend `rewriteClonedRealmServerUrls` to UPDATE `modules` (url, file_alias, resolved_realm_url, and the JSONB columns `definitions`/`deps`/`error_doc`) and `realm_registry` (url, source_url). The URL columns added are exactly the ones the `lookupDefinition` cache-hit predicate keys on.
- **`packages/software-factory/src/harness/api.ts`** — drop the now-redundant `clearModuleCache(databaseName)` call (and its import). The cache is now consistent post-rewrite, so wiping is the wrong behavior.
- **`packages/realm-server/main.ts`** — add an opt-out env var `REALM_SERVER_SKIP_MODULES_CACHE_CLEAR_ON_STARTUP`. When set to `'true'`, the realm-server skips the boot-time `clearAllModules()` and trusts the cache it inherited.
- **`packages/software-factory/src/harness/isolated-realm-stack.ts`** — set the opt-out to `'true'` in the per-test realm subprocess env iff `fullIndexOnStartup === false`. The cache:prepare template-build pass keeps `fullIndexOnStartup=true` and so still wipes the cache (which is correct: it is rebuilding from scratch).

Production behavior is unchanged. The opt-out env var defaults to off, so any non-harness realm-server boot still calls `clearAllModules()` exactly as before.

## Test plan

- [x] `cache:prepare` succeeds locally (template gets built once, then per-test cache hits)
- [x] First failing test (`search by type returns matching cards…`) passes locally in 2.6 m total run time (vs. timing out at 1.8 m before)
- [x] Tracing confirms the per-test realm's first `lookupDefinition(darkfactoryModule)` hits the cloned cache (no prerenderer call) — the 45 s cold prerender is gone from the per-test budget
- [x] CI Software Factory job passes on this PR (confirms the fix in CI's environment too)
- [x] No new lint errors (existing `runtime-common/helpers/ai.ts` `lint:types` errors on `main` are unrelated)

## Notes / follow-ups

- This does not address *why* `darkfactory.gts` takes 45 s to prerender end-to-end (only fixes the test-timeout symptom). I am investigating separately — for a 756-line `.gts` with 7 base imports, that's an order of magnitude slower than expected.
- The schema-coverage comment on `rewriteClonedRealmServerUrls` already warned future maintainers that adding new persisted URL-bearing columns/tables requires extending the rewrite pass — this PR adds two such tables that had been missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)