### PR TITLE
Add diagnostic snapshots to flaky atomic update test

### DIFF
--- a/packages/realm-server/tests/atomic-endpoints-test.ts
+++ b/packages/realm-server/tests/atomic-endpoints-test.ts
@@ -3,6 +3,7 @@ import type { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
 import type { Server } from 'http';
 import type { DirResult } from 'tmp';
+import type { PgAdapter } from '@cardstack/postgres';
 import type { Realm, RealmAdapter } from '@cardstack/runtime-common';
 import {
   type LooseSingleCardDocument,
@@ -53,6 +54,47 @@ function formatDiskSnapshot(snapshot: DiskSnapshot): string {
   }
 }
 
+// Read the raw rows for a URL from boxel_index + boxel_index_working,
+// plus realm_versions, so we can tell whether a stale GET is the index
+// being out of date or the GET path picking up the wrong row.
+async function readIndexSnapshot(
+  dbAdapter: PgAdapter,
+  realmHref: string,
+  cardURL: string,
+  fileURL: string,
+): Promise<{
+  realmVersion: unknown;
+  stable: unknown[];
+  working: unknown[];
+}> {
+  let [versionRow] = (await dbAdapter.execute(
+    `SELECT current_version FROM realm_versions WHERE realm_url = $1`,
+    { bind: [realmHref] },
+  )) as { current_version: number }[];
+
+  let stable = (await dbAdapter.execute(
+    `SELECT url, file_alias, type, realm_version, is_deleted,
+            pristine_doc, last_modified
+       FROM boxel_index
+      WHERE realm_url = $1 AND (url = $2 OR url = $3 OR file_alias = $2 OR file_alias = $3)`,
+    { bind: [realmHref, cardURL, fileURL] },
+  )) as unknown[];
+
+  let working = (await dbAdapter.execute(
+    `SELECT url, file_alias, type, realm_version, is_deleted,
+            pristine_doc, last_modified
+       FROM boxel_index_working
+      WHERE realm_url = $1 AND (url = $2 OR url = $3 OR file_alias = $2 OR file_alias = $3)`,
+    { bind: [realmHref, cardURL, fileURL] },
+  )) as unknown[];
+
+  return {
+    realmVersion: versionRow?.current_version ?? null,
+    stable,
+    working,
+  };
+}
+
 module(basename(__filename), function () {
   module(
     'Realm-specific Endpoints: can make request to post /_atomic',
@@ -61,17 +103,20 @@ module(basename(__filename), function () {
       let testRealmHref = realmURL.href;
       let testRealm: Realm;
       let testRealmAdapter: RealmAdapter;
+      let dbAdapter: PgAdapter;
       let request: RealmRequest;
 
       function onRealmSetup(args: {
         testRealm: Realm;
         testRealmHttpServer: Server;
         testRealmAdapter: RealmAdapter;
+        dbAdapter: PgAdapter;
         request: SuperTest<Test>;
         dir: DirResult;
       }) {
         testRealm = args.testRealm;
         testRealmAdapter = args.testRealmAdapter;
+        dbAdapter = args.dbAdapter;
         request = withRealmPath(args.request, realmURL);
       }
 
@@ -936,12 +981,21 @@ module(basename(__filename), function () {
             testRealmAdapter,
             'update-person.json',
           );
+          // Snapshot boxel_index/boxel_index_working too. With the disk
+          // diagnostic from #4530 we know the file write lands; if the
+          // index rows here have firstName="Initial" it's an indexer/
+          // promotion bug, if they have "Updated" it's a GET-path bug.
+          let postUpdateIndex = await readIndexSnapshot(
+            dbAdapter,
+            testRealmHref,
+            `${testRealmHref}update-person`,
+            `${testRealmHref}update-person.json`,
+          );
 
           // The atomic POST awaits indexing, so by 201 boxel_index should
-          // be updated. The remaining CI flake is read-path readiness —
-          // most often a slow first-instance prerender / module-cache
-          // populate that the GET is waiting on. Match the 30s budget
-          // publish-unpublish-realm-test uses for the same class of wait.
+          // be updated. Poll up to 30s in case CI load delays read-path
+          // readiness; the diagnostics above are captured pre-poll so
+          // the timeout message reflects the immediate post-201 state.
           let updatedCard: LooseSingleCardDocument | undefined;
           let lastStatus: number | undefined;
           await waitUntil(
@@ -967,6 +1021,7 @@ module(basename(__filename), function () {
                   `update 201 body=${JSON.stringify(response.body)}`,
                   `disk after add=${formatDiskSnapshot(postAddDisk)}`,
                   `disk after update=${formatDiskSnapshot(postUpdateDisk)}`,
+                  `index after update=${JSON.stringify(postUpdateIndex)}`,
                 ].join(' | '),
             },
           );

--- a/packages/realm-server/tests/atomic-endpoints-test.ts
+++ b/packages/realm-server/tests/atomic-endpoints-test.ts
@@ -6,6 +6,7 @@ import type { DirResult } from 'tmp';
 import type { Realm, RealmAdapter } from '@cardstack/runtime-common';
 import {
   type LooseSingleCardDocument,
+  readFileAsText,
   SupportedMimeType,
 } from '@cardstack/runtime-common';
 import {
@@ -16,6 +17,41 @@ import {
   withRealmPath,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
+
+type DiskSnapshot =
+  | { kind: 'present'; lastModified: number; content: string }
+  | { kind: 'absent' }
+  | { kind: 'error'; message: string };
+
+async function readDiskSnapshot(
+  adapter: RealmAdapter,
+  path: string,
+): Promise<DiskSnapshot> {
+  try {
+    let file = await readFileAsText(path, (p) => adapter.openFile(p));
+    if (!file) {
+      return { kind: 'absent' };
+    }
+    return {
+      kind: 'present',
+      lastModified: file.lastModified,
+      content: file.content,
+    };
+  } catch (e) {
+    return { kind: 'error', message: (e as Error).message };
+  }
+}
+
+function formatDiskSnapshot(snapshot: DiskSnapshot): string {
+  switch (snapshot.kind) {
+    case 'absent':
+      return '<absent>';
+    case 'error':
+      return `<error: ${snapshot.message}>`;
+    case 'present':
+      return `lastModified=${snapshot.lastModified} content=${JSON.stringify(snapshot.content)}`;
+  }
+}
 
 module(basename(__filename), function () {
   module(
@@ -841,7 +877,7 @@ module(basename(__filename), function () {
             ],
           };
 
-          await request
+          let addResponse = await request
             .post('/_atomic')
             .set('Accept', SupportedMimeType.JSONAPI)
             .set(
@@ -850,6 +886,14 @@ module(basename(__filename), function () {
             )
             .send(JSON.stringify(addDoc))
             .expect(201);
+
+          // Snapshot the on-disk serialized form right after the add so
+          // the timeout message can show whether the update actually
+          // changed the file or not.
+          let postAddDisk = await readDiskSnapshot(
+            testRealmAdapter,
+            'update-person.json',
+          );
 
           let updateDoc = {
             'atomic:operations': [
@@ -884,6 +928,15 @@ module(basename(__filename), function () {
           assert.strictEqual(response.status, 201);
           assert.strictEqual(response.body['atomic:results'].length, 1);
 
+          // Snapshot the on-disk serialized form right after the update.
+          // Together with postAddDisk this distinguishes "write was
+          // skipped (content-equality false positive)" from "write
+          // happened but reindex didn't pick it up".
+          let postUpdateDisk = await readDiskSnapshot(
+            testRealmAdapter,
+            'update-person.json',
+          );
+
           // The atomic POST awaits indexing, so by 201 boxel_index should
           // be updated. The remaining CI flake is read-path readiness —
           // most often a slow first-instance prerender / module-cache
@@ -906,7 +959,15 @@ module(basename(__filename), function () {
               timeout: 30_000,
               interval: 100,
               timeoutMessage: () =>
-                `updated firstName was not visible via /update-person (last GET status=${lastStatus}, last firstName=${JSON.stringify(updatedCard?.data?.attributes?.firstName)})`,
+                [
+                  'updated firstName was not visible via /update-person',
+                  `last GET status=${lastStatus}`,
+                  `last firstName=${JSON.stringify(updatedCard?.data?.attributes?.firstName)}`,
+                  `add 201 body=${JSON.stringify(addResponse.body)}`,
+                  `update 201 body=${JSON.stringify(response.body)}`,
+                  `disk after add=${formatDiskSnapshot(postAddDisk)}`,
+                  `disk after update=${formatDiskSnapshot(postUpdateDisk)}`,
+                ].join(' | '),
             },
           );
           assert.strictEqual(


### PR DESCRIPTION
## Summary
The 30s poll landed in #4509 still times out in CI on the \`can update an existing instance\` test (e.g. [run 25003788139](https://github.com/cardstack/boxel/actions/runs/25003788139/job/73222048638?pr=4524)). The current timeout message says \`last GET status=200, last firstName=\"Initial\"\` — which tells us the read path consistently returns the pre-update value, but doesn't tell us whether:

- the **write was skipped** (content-equality false positive in \`_batchWrite\`, e.g. if \`fileSerialization\` produced identical serialized output for \"Initial\" and \"Updated\"), or
- the **write happened but indexing didn't pick it up**.

Both fail with the same surface symptom. This PR adds the disambiguating diagnostic context to the timeout message so the next failure pins the cause down without a rerun:

- on-disk content + \`lastModified\` of \`update-person.json\` right after the add
- on-disk content + \`lastModified\` right after the update
- both \`atomic:results\` 201 response bodies

Reading patterns to expect:
- \`disk after add\` and \`disk after update\` **identical** → write was no-op'd by content-equality. Almost certainly the serializer is dropping \`firstName\` because the cached \`Person\` definition is missing the field. Fix is in the write path (likely tightening \`fileSerialization\` / definition lookup).
- disk content **differs** but GET stays \`Initial\` → re-index didn't pick up the change. Fix is in the indexing path.

If neither matches, the snapshots will at least point at the next thing to look at.

## Test plan
- [ ] CI still flakes → next failure run includes the snapshots; open a follow-up PR with the actual fix once we see which class above it is
- [ ] CI passes (this PR doesn't change the assertion or timeout, just enriches the failure message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)