### PR TITLE
shimAsyncModule: retry on transient resolver failures

### DIFF
--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -229,6 +229,7 @@ import './claim-boxel-domain-test';
 import './card-reference-resolver-test';
 import './bfm-card-references-test';
 import './loader-retry-test';
+import './package-shim-handler-test';
 import './command-parsing-utils-test';
 import './query-matches-filter-test';
 import './matches-filter-integration-test';

--- a/packages/realm-server/tests/package-shim-handler-test.ts
+++ b/packages/realm-server/tests/package-shim-handler-test.ts
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { runSharedTest } from '@cardstack/runtime-common/helpers';
+import packageShimHandlerTests from '@cardstack/runtime-common/tests/package-shim-handler-test';
+
+module(basename(__filename), function () {
+  module('shimAsyncModule retry (CS-10860 follow-up)', function () {
+    test('returns the resolved module on first attempt when there is no failure', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('retries a transient ChunkLoadError up to the configured budget', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('fails fast on a non-retryable error without burning the retry budget', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('after exhausting all retries, throws the last error from the resolver', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('isRetryableShimResolveError matches webpack ChunkLoadError', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('isRetryableShimResolveError matches generic chunk-load message', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('isRetryableShimResolveError matches native dynamic-import network failure', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('isRetryableShimResolveError matches Chrome ERR_CONNECTION_RESET', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('isRetryableShimResolveError matches Node ECONNRESET via err.code', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('isRetryableShimResolveError matches HTTP 502/503/504 — aligned with loader.ts policy', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('isRetryableShimResolveError does NOT match SyntaxError', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('isRetryableShimResolveError does NOT match TypeError from module evaluation', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('isRetryableShimResolveError handles non-error inputs without throwing', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('shimAsyncModule retries on transient resolver failure and ultimately serves the module', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('shimAsyncModule returns null from handle() when the resolver throws permanently', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+  });
+});

--- a/packages/runtime-common/package-shim-handler.ts
+++ b/packages/runtime-common/package-shim-handler.ts
@@ -63,8 +63,15 @@ const RETRYABLE_ERROR_CODES = new Set([
 ]);
 const RETRYABLE_MESSAGE_PATTERNS: readonly RegExp[] = [
   /Loading (?:CSS )?chunk \S+ failed/i,
+  // Specifically the dynamic-import failure message — a bare
+  // `/Failed to fetch/i` was tempting here but matches too much: any
+  // resolver that throws "Failed to fetch <whatever>" for a non-
+  // chunk reason (deliberate `fetch()` calls inside the resolver,
+  // for instance) would get retried as if it were a chunk-load
+  // transient. The dynamic-import variant is what `import()`
+  // actually throws on a chunk-fetch failure, and that's the case
+  // we want to retry.
   /Failed to fetch dynamically imported module/i,
-  /Failed to fetch/i,
   /NetworkError when attempting to fetch resource/i,
   /ECONNRESET|ECONNREFUSED|ENOTFOUND|EAI_AGAIN/,
   /ERR_(?:CONNECTION_RESET|CONNECTION_REFUSED|NETWORK_CHANGED|INTERNET_DISCONNECTED|EMPTY_RESPONSE|TIMED_OUT)/,
@@ -92,7 +99,8 @@ export function isRetryableShimResolveError(error: unknown): boolean {
 
 export interface ShimRetryDeps {
   // Pluggable for tests so we can assert backoff behavior without
-  // burning real wallclock time. Production passes `setTimeout`.
+  // burning real wallclock time. When omitted, the retry path uses
+  // `defaultDelay` (a thin `setTimeout`-based sleep) below.
   delay?: (ms: number) => Promise<void>;
   // Override the default backoff schedule. Tests can pass `[]` to
   // collapse retries into a single attempt.
@@ -106,6 +114,15 @@ export interface ShimRetryDeps {
 const defaultDelay = (ms: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, ms));
 
+// Minimal logging surface used by `withResolveRetry`. Narrower than
+// `ReturnType<typeof logger>` so tests can pass a no-op stub without
+// having to construct a full `loglevel` instance — the production
+// code only ever calls `warn` and `debug`.
+export interface ShimRetryLogger {
+  warn: (...args: unknown[]) => void;
+  debug: (...args: unknown[]) => void;
+}
+
 // Wraps a shim resolver with retry-on-transient-failure + bounded
 // exponential backoff. Returns a function with the same signature as
 // the input, so `shimAsyncModule` can swap it in transparently.
@@ -117,7 +134,7 @@ const defaultDelay = (ms: number) =>
 // burying it under "tried 3 times".
 export function withResolveRetry<TArgs extends unknown[], TResult>(
   label: string,
-  log: ReturnType<typeof logger>,
+  log: ShimRetryLogger,
   fn: (...args: TArgs) => Promise<TResult>,
   deps: ShimRetryDeps = {},
 ): (...args: TArgs) => Promise<TResult> {

--- a/packages/runtime-common/package-shim-handler.ts
+++ b/packages/runtime-common/package-shim-handler.ts
@@ -11,6 +11,150 @@ function trimModuleIdentifier(moduleIdentifier: string): string {
 
 export const PACKAGES_FAKE_ORIGIN = 'https://packages/';
 
+// Backoff schedule applied between retries for a failed
+// `shimAsyncModule` resolver. Aligned with `loader.ts`'s
+// `DEFAULT_TRANSIENT_RETRY_DELAYS_MS = [100, 300, 900]` so the two
+// retry layers use the same shape — operators investigating a flaky
+// fetch see consistent backoff across realm-source fetches and
+// shim-resolver chunk fetches. Worst-case added latency on a
+// persistent failure: ~1.3s, well under cardRenderTimeout (90s).
+//
+// Each entry is a wallclock delay in ms BEFORE the corresponding
+// retry attempt. The first attempt has no preceding delay, so the
+// schedule starts at `RETRY_DELAYS_MS[0]` for the second attempt.
+// Total maximum elapsed wait = sum of entries.
+const RETRY_DELAYS_MS: readonly number[] = [100, 300, 900];
+
+// Patterns we consider transient for dynamic-import / chunk-fetch
+// failures. Match against `err.name` AND `err.message` because
+// browsers / loaders disagree on which carries the discriminator
+// (Webpack uses `err.name === 'ChunkLoadError'`; native Node
+// `import()` uses message-based identifiers; some bundlers wrap
+// network errors with their own classes that only surface in the
+// message).
+//
+// HTTP statuses: only 502/503/504 match. `loader.ts` explicitly
+// excludes 500 because the loader's own `_fetch` converts network
+// failures into synthetic 500 Response objects, and we don't want
+// to double-retry those. The same policy applies here so the two
+// retry layers can't disagree on what counts as transient.
+//
+// NOTE: anything NOT matched here is surfaced on the first attempt
+// without retry. This is deliberate — retrying a `SyntaxError` from
+// a malformed module just wastes the budget and delays the actual
+// error reaching the operator.
+const RETRYABLE_ERROR_NAMES = new Set([
+  'ChunkLoadError',
+  'NetworkError',
+  'TimeoutError',
+  'AbortError',
+]);
+// Node `err.code` values for transient socket / DNS failures. Distinct
+// from `RETRYABLE_ERROR_NAMES` because Node attaches these on
+// `err.code` (kept in this set) while browsers expose the same class
+// of failure via `err.name` (kept in the names set above).
+const RETRYABLE_ERROR_CODES = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ETIMEDOUT',
+  'EPIPE',
+]);
+const RETRYABLE_MESSAGE_PATTERNS: readonly RegExp[] = [
+  /Loading (?:CSS )?chunk \S+ failed/i,
+  /Failed to fetch dynamically imported module/i,
+  /Failed to fetch/i,
+  /NetworkError when attempting to fetch resource/i,
+  /ECONNRESET|ECONNREFUSED|ENOTFOUND|EAI_AGAIN/,
+  /ERR_(?:CONNECTION_RESET|CONNECTION_REFUSED|NETWORK_CHANGED|INTERNET_DISCONNECTED|EMPTY_RESPONSE|TIMED_OUT)/,
+  /status of 50[234]/i,
+  /returned HTTP 50[234]/i,
+];
+
+export function isRetryableShimResolveError(error: unknown): boolean {
+  if (!error) return false;
+  if (typeof error !== 'object') return false;
+  let err = error as { name?: unknown; message?: unknown; code?: unknown };
+  if (typeof err.name === 'string' && RETRYABLE_ERROR_NAMES.has(err.name)) {
+    return true;
+  }
+  if (typeof err.code === 'string' && RETRYABLE_ERROR_CODES.has(err.code)) {
+    return true;
+  }
+  if (typeof err.message === 'string') {
+    for (let pattern of RETRYABLE_MESSAGE_PATTERNS) {
+      if (pattern.test(err.message)) return true;
+    }
+  }
+  return false;
+}
+
+export interface ShimRetryDeps {
+  // Pluggable for tests so we can assert backoff behavior without
+  // burning real wallclock time. Production passes `setTimeout`.
+  delay?: (ms: number) => Promise<void>;
+  // Override the default backoff schedule. Tests can pass `[]` to
+  // collapse retries into a single attempt.
+  retryDelaysMs?: readonly number[];
+  // Override the retryable-error classifier. Defaults to
+  // `isRetryableShimResolveError`. Tests can force-retry every error
+  // or force-skip every retry to exercise both branches.
+  isRetryable?: (error: unknown) => boolean;
+}
+
+const defaultDelay = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+// Wraps a shim resolver with retry-on-transient-failure + bounded
+// exponential backoff. Returns a function with the same signature as
+// the input, so `shimAsyncModule` can swap it in transparently.
+//
+// On non-retryable errors (SyntaxError, ReferenceError, etc. — see
+// `isRetryableShimResolveError`), the function fails fast on the
+// first attempt with the original error preserved verbatim. This
+// keeps the operator-facing error message intact instead of
+// burying it under "tried 3 times".
+export function withResolveRetry<TArgs extends unknown[], TResult>(
+  label: string,
+  log: ReturnType<typeof logger>,
+  fn: (...args: TArgs) => Promise<TResult>,
+  deps: ShimRetryDeps = {},
+): (...args: TArgs) => Promise<TResult> {
+  let delay = deps.delay ?? defaultDelay;
+  let delaysMs = deps.retryDelaysMs ?? RETRY_DELAYS_MS;
+  let isRetryable = deps.isRetryable ?? isRetryableShimResolveError;
+  return async (...args: TArgs): Promise<TResult> => {
+    let lastError: unknown;
+    let totalAttempts = delaysMs.length + 1;
+    for (let attempt = 0; attempt < totalAttempts; attempt++) {
+      try {
+        return await fn(...args);
+      } catch (err) {
+        lastError = err;
+        if (attempt === totalAttempts - 1) break;
+        if (!isRetryable(err)) {
+          // Fail fast for non-transient errors — retrying a syntax
+          // error or a missing module wastes the budget and delays
+          // the error surfacing to the operator.
+          log.debug(
+            `shim resolver for ${label} failed with non-retryable error; not retrying`,
+            err,
+          );
+          break;
+        }
+        let waitMs = delaysMs[attempt];
+        log.warn(
+          `shim resolver for ${label} failed on attempt ${attempt + 1}/${totalAttempts}; retrying in ${waitMs}ms`,
+          err,
+        );
+        await delay(waitMs);
+      }
+    }
+    throw lastError;
+  };
+}
+
 export class PackageShimHandler {
   private resolveImport: (moduleIdentifier: string) => string;
   private moduleIds = new Map<string, () => Promise<ModuleLike>>();
@@ -55,17 +199,31 @@ export class PackageShimHandler {
     );
   }
 
-  shimAsyncModule(descriptor: ModuleDescriptor) {
+  shimAsyncModule(descriptor: ModuleDescriptor, retryDeps?: ShimRetryDeps) {
+    // Wrap each user-supplied resolver with bounded retry against the
+    // transient-failure error class. The original resolver typically
+    // calls `import('<some-package>')`, which compiles to a runtime
+    // chunk fetch — and chunk fetches can blip on network errors,
+    // mid-deploy chunk-hash swaps, or transient 5xx responses. Without
+    // retry, a single dropped fetch translates into the consumer
+    // seeing `undefined` exports, which is what the whitepaper render
+    // bug looks like to Glimmer's helper-encoder.
+    //
+    // Non-transient errors (SyntaxError from a bad module, missing
+    // module, etc.) fail fast on the first attempt — see
+    // `isRetryableShimResolveError`.
     if ('prefix' in descriptor) {
+      let label = `prefix:${descriptor.prefix}`;
       this.modulePrefixes.set(
         this.resolveImport(descriptor.prefix),
-        descriptor.resolve,
+        withResolveRetry(label, this.log, descriptor.resolve, retryDeps),
       );
     } else {
       let moduleIdentifier = this.resolveImport(descriptor.id);
+      let label = `id:${descriptor.id}`;
       this.moduleIds.set(
         trimModuleIdentifier(moduleIdentifier),
-        descriptor.resolve,
+        withResolveRetry(label, this.log, descriptor.resolve, retryDeps),
       );
     }
   }

--- a/packages/runtime-common/tests/package-shim-handler-test.ts
+++ b/packages/runtime-common/tests/package-shim-handler-test.ts
@@ -4,10 +4,16 @@ import {
   PACKAGES_FAKE_ORIGIN,
   isRetryableShimResolveError,
   withResolveRetry,
+  type ShimRetryLogger,
 } from '../package-shim-handler';
-import { logger as makeLogger } from '../log';
 
-let testLog = makeLogger('shim-handler-test');
+// No-op logger so the retry-focused tests don't print warn/debug
+// noise to CI output. The realm-server harness defaults to
+// `LOG_LEVELS='*=info'`, so a real `loglevel` instance would emit a
+// warn line on every retry — these tests deliberately exercise the
+// retry path many times. The shape matches the `ShimRetryLogger`
+// interface (only warn/debug are called from `withResolveRetry`).
+let testLog: ShimRetryLogger = { warn: () => {}, debug: () => {} };
 
 // Sleep stub that records each delay synchronously instead of
 // burning real wallclock time. Tests inject this via the

--- a/packages/runtime-common/tests/package-shim-handler-test.ts
+++ b/packages/runtime-common/tests/package-shim-handler-test.ts
@@ -1,0 +1,279 @@
+import type { SharedTests } from '../helpers';
+import {
+  PackageShimHandler,
+  PACKAGES_FAKE_ORIGIN,
+  isRetryableShimResolveError,
+  withResolveRetry,
+} from '../package-shim-handler';
+import { logger as makeLogger } from '../log';
+
+let testLog = makeLogger('shim-handler-test');
+
+// Sleep stub that records each delay synchronously instead of
+// burning real wallclock time. Tests inject this via the
+// `delay` knob on `withResolveRetry` / `shimAsyncModule`.
+function makeRecordedDelay() {
+  let recorded: number[] = [];
+  return {
+    delay: async (ms: number) => {
+      recorded.push(ms);
+    },
+    recorded,
+  };
+}
+
+const tests: SharedTests<Record<string, never>> = Object.freeze({
+  'returns the resolved module on first attempt when there is no failure':
+    async (assert) => {
+      let calls = 0;
+      let wrapped = withResolveRetry('test:happy-path', testLog, async () => {
+        calls++;
+        return { x: 1 };
+      });
+      let result = await wrapped();
+      assert.deepEqual(result, { x: 1 }, 'module returned verbatim');
+      assert.strictEqual(calls, 1, 'no extra attempts on success');
+    },
+
+  'retries a transient ChunkLoadError up to the configured budget': async (
+    assert,
+  ) => {
+    let calls = 0;
+    let { delay, recorded } = makeRecordedDelay();
+    let wrapped = withResolveRetry(
+      'test:chunk-load',
+      testLog,
+      async () => {
+        calls++;
+        if (calls < 3) {
+          let err = new Error(`Loading chunk 42 failed (timeout)`);
+          err.name = 'ChunkLoadError';
+          throw err;
+        }
+        return { ok: true };
+      },
+      { delay, retryDelaysMs: [10, 50, 200] },
+    );
+    let result = await wrapped();
+    assert.deepEqual(result, { ok: true }, 'eventually succeeded');
+    assert.strictEqual(calls, 3, 'failed twice, succeeded on third attempt');
+    assert.deepEqual(
+      recorded,
+      [10, 50],
+      'two backoff delays observed before the success',
+    );
+  },
+
+  'fails fast on a non-retryable error without burning the retry budget':
+    async (assert) => {
+      let calls = 0;
+      let { delay, recorded } = makeRecordedDelay();
+      let wrapped = withResolveRetry(
+        'test:syntax-error',
+        testLog,
+        async () => {
+          calls++;
+          throw new SyntaxError(`Unexpected token '<'`);
+        },
+        { delay, retryDelaysMs: [10, 50, 200] },
+      );
+      try {
+        await wrapped();
+        assert.ok(false, 'should have thrown');
+      } catch (err: any) {
+        assert.strictEqual(
+          err?.name,
+          'SyntaxError',
+          'original error surfaced verbatim',
+        );
+      }
+      assert.strictEqual(calls, 1, 'only one attempt for non-retryable error');
+      assert.deepEqual(
+        recorded,
+        [],
+        'no backoff delays consumed for non-retryable error',
+      );
+    },
+
+  'after exhausting all retries, throws the last error from the resolver':
+    async (assert) => {
+      let calls = 0;
+      let wrapped = withResolveRetry(
+        'test:all-retries-fail',
+        testLog,
+        async () => {
+          calls++;
+          throw new Error(`Failed to fetch dynamically imported module: x.js`);
+        },
+        { delay: async () => {}, retryDelaysMs: [10, 50, 200] },
+      );
+      try {
+        await wrapped();
+        assert.ok(false, 'should have thrown after all retries');
+      } catch (err: any) {
+        assert.ok(
+          /Failed to fetch dynamically imported module/.test(err?.message),
+          `surfaces the last error verbatim, got: ${err?.message}`,
+        );
+      }
+      assert.strictEqual(
+        calls,
+        4,
+        'three retries plus the original attempt = four total calls',
+      );
+    },
+
+  'isRetryableShimResolveError matches webpack ChunkLoadError': async (
+    assert,
+  ) => {
+    let err = new Error('Loading chunk 12 failed (network error)');
+    err.name = 'ChunkLoadError';
+    assert.true(isRetryableShimResolveError(err));
+  },
+
+  'isRetryableShimResolveError matches generic chunk-load message': async (
+    assert,
+  ) => {
+    assert.true(
+      isRetryableShimResolveError(
+        new Error('Loading chunk 7 failed.\nReason: timeout'),
+      ),
+    );
+  },
+
+  'isRetryableShimResolveError matches native dynamic-import network failure':
+    async (assert) => {
+      assert.true(
+        isRetryableShimResolveError(
+          new Error('Failed to fetch dynamically imported module: foo.js'),
+        ),
+      );
+    },
+
+  'isRetryableShimResolveError matches Chrome ERR_CONNECTION_RESET': async (
+    assert,
+  ) => {
+    assert.true(
+      isRetryableShimResolveError(
+        new Error('net::ERR_CONNECTION_RESET while fetching x.js'),
+      ),
+    );
+  },
+
+  'isRetryableShimResolveError matches Node ECONNRESET via err.code': async (
+    assert,
+  ) => {
+    let err: any = new Error('socket hang up');
+    err.code = 'ECONNRESET';
+    assert.true(isRetryableShimResolveError(err));
+  },
+
+  'isRetryableShimResolveError matches HTTP 502/503/504 — aligned with loader.ts policy':
+    async (assert) => {
+      assert.true(
+        isRetryableShimResolveError(
+          new Error('upstream returned HTTP 503 Service Unavailable'),
+        ),
+        '503',
+      );
+      assert.true(
+        isRetryableShimResolveError(
+          new Error('upstream returned HTTP 502 Bad Gateway'),
+        ),
+        '502',
+      );
+      assert.true(
+        isRetryableShimResolveError(
+          new Error('upstream returned HTTP 504 Gateway Timeout'),
+        ),
+        '504',
+      );
+      // 500 is NOT in the retryable set — see loader.ts's
+      // RETRYABLE_STATUS_CODES comment for why.
+      assert.false(
+        isRetryableShimResolveError(
+          new Error('upstream returned HTTP 500 Internal Server Error'),
+        ),
+        '500 (deliberately excluded)',
+      );
+    },
+
+  'isRetryableShimResolveError does NOT match SyntaxError': async (assert) => {
+    assert.false(isRetryableShimResolveError(new SyntaxError('bad token')));
+  },
+
+  'isRetryableShimResolveError does NOT match TypeError from module evaluation':
+    async (assert) => {
+      assert.false(
+        isRetryableShimResolveError(new TypeError('foo.bar is not a function')),
+      );
+    },
+
+  'isRetryableShimResolveError handles non-error inputs without throwing':
+    async (assert) => {
+      assert.false(isRetryableShimResolveError(null));
+      assert.false(isRetryableShimResolveError(undefined));
+      assert.false(isRetryableShimResolveError('string error'));
+      assert.false(isRetryableShimResolveError(42));
+    },
+
+  'shimAsyncModule retries on transient resolver failure and ultimately serves the module':
+    async (assert) => {
+      let attempts = 0;
+      let handler = new PackageShimHandler(
+        (id) => `${PACKAGES_FAKE_ORIGIN}${id}`,
+      );
+      handler.shimAsyncModule(
+        {
+          id: 'flaky-module',
+          resolve: async () => {
+            attempts++;
+            if (attempts < 2) {
+              throw new Error('Failed to fetch dynamically imported module');
+            }
+            return { isFlaky: true };
+          },
+        },
+        { delay: async () => {}, retryDelaysMs: [5, 5, 5] },
+      );
+      let response = await handler.handle(
+        new Request(`${PACKAGES_FAKE_ORIGIN}flaky-module`),
+      );
+      assert.ok(response, 'handler returned a Response after retry');
+      let shimmed = (response as any)?.[Symbol.for('shimmed-module')];
+      assert.deepEqual(
+        shimmed,
+        { isFlaky: true },
+        'shimmed-module reflects the eventually-resolved exports',
+      );
+      assert.strictEqual(attempts, 2, 'one retry was sufficient');
+    },
+
+  'shimAsyncModule returns null from handle() when the resolver throws permanently':
+    async (assert) => {
+      let handler = new PackageShimHandler(
+        (id) => `${PACKAGES_FAKE_ORIGIN}${id}`,
+      );
+      handler.shimAsyncModule(
+        {
+          id: 'always-fails',
+          resolve: async () => {
+            throw new Error(
+              'Failed to fetch dynamically imported module: always-fails',
+            );
+          },
+        },
+        { delay: async () => {}, retryDelaysMs: [1, 1] },
+      );
+      let response = await handler.handle(
+        new Request(`${PACKAGES_FAKE_ORIGIN}always-fails`),
+      );
+      assert.strictEqual(
+        response,
+        null,
+        'handler returns null after all retries failed (existing contract preserved)',
+      );
+    },
+});
+
+export default tests;


### PR DESCRIPTION
Brings the lazy-shimmed module loading path to retry-parity with the existing realm-source fetch retry in `loader.ts` (`fetchWithTransientRetry` / `RETRYABLE_STATUS_CODES`). Before this PR, our three loading paths had inconsistent retry coverage:

| Loading path | Where | Transient retry? |
|---|---|---|
| Realm source fetch (cards' `.gts` files) | `loader.ts` `fetchWithTransientRetry` | ✅ already covered |
| Shim async (lazy-imported host packages, e.g. `@cardstack/runtime-common/marked-sync`) | `package-shim-handler.ts` `shimAsyncModule` | ❌ no retry |
| Static shim (eagerly-bundled host modules) | `package-shim-handler.ts` `shimModule` | n/a — can't fail at runtime |

A single dropped chunk fetch on the `shimAsyncModule` path (rolling deploy swapping chunk hashes mid-fetch, ALB hairpin RESET, transient 5xx) translates into the consumer seeing `undefined` exports, which is exactly what the whitepaper-class render bug looks like to Glimmer's helper-encoder. This PR closes that gap.

## What's retried

- Webpack `ChunkLoadError` (`err.name === 'ChunkLoadError'`)
- Native dynamic-import failures: `Failed to fetch dynamically imported module`, `NetworkError when attempting to fetch resource`
- Node socket / DNS error codes via `err.code`: `ECONNRESET`, `ECONNREFUSED`, `ENOTFOUND`, `EAI_AGAIN`, `ETIMEDOUT`, `EPIPE`
- Chrome network strings in the message: `ERR_CONNECTION_RESET`, `ERR_CONNECTION_REFUSED`, `ERR_NETWORK_CHANGED`, `ERR_INTERNET_DISCONNECTED`, `ERR_EMPTY_RESPONSE`, `ERR_TIMED_OUT`
- HTTP 502/503/504 in the message — aligned with `loader.ts`'s `RETRYABLE_STATUS_CODES` (deliberately excludes 500 since `_fetch` already converts network failures into synthetic 500s, and we don't want to double-retry those)

## What's NOT retried (fails fast)

- `SyntaxError` from a malformed module
- `TypeError` from module evaluation (e.g. an export missing on the namespace — see the whitepaper-class deterministic bug below)
- Any error that doesn't match a transient signature

The fail-fast path is important: retrying a `SyntaxError` three times just delays the actual error reaching the operator by ~1.3s.

## Backoff

`[100, 300, 900]` ms — same shape as `loader.ts`'s `DEFAULT_TRANSIENT_RETRY_DELAYS_MS`. Worst case adds ~1.3s on a persistent failure, well under `cardRenderTimeout` (90s). Operators investigating a flaky fetch see consistent backoff across realm-source fetches and shim-resolver chunk fetches.

## What this DOESN'T fix

The retry helps when a fetch genuinely flakes. **It does not help with deterministic failures** — e.g. a card that imports a name from a module that doesn't actually export that name. That class of bug is addressed in a follow-up branch as a "named export missing" check at the loader level. The two fixes are complementary: retry covers the network/transient failure mode, the missing-export check covers the wrong-import-path failure mode.

## Files

- `packages/runtime-common/package-shim-handler.ts` — adds `withResolveRetry`, `isRetryableShimResolveError`, and a `ShimRetryDeps` config knob threaded through `shimAsyncModule` for tests.
- `packages/runtime-common/tests/package-shim-handler-test.ts` *(new)* — 15 SharedTests covering both the wrapper and the integrated `shimAsyncModule` path.
- `packages/realm-server/tests/package-shim-handler-test.ts` *(new)* — registers the shared tests in the realm-server suite.

## Test plan

- [x] All 15 new tests pass locally
- [x] Lint clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)