### PR TITLE
shim-handler: throw on missing named-import access

### DIFF
--- a/packages/host/app/lib/externals.ts
+++ b/packages/host/app/lib/externals.ts
@@ -56,6 +56,7 @@ import * as boxelUiModifiers from '@cardstack/boxel-ui/modifiers';
 
 import * as runtime from '@cardstack/runtime-common';
 import type { VirtualNetwork } from '@cardstack/runtime-common';
+import { fallbackShim } from '@cardstack/runtime-common/package-shim-handler';
 
 import { shimHostCommands } from '../commands';
 
@@ -187,9 +188,13 @@ export function shimExternals(virtualNetwork: VirtualNetwork) {
 
   // Some realm modules use host-only types or helpers. Provide a safe shim so
   // imports resolve even when the host module isn't present in the build.
-  virtualNetwork.shimModule('@cardstack/host/services/store', {
-    default: class {},
-  });
+  // Wrapped in `fallbackShim` so the strict-namespace check in the shim
+  // handler doesn't throw on names this stub doesn't expose — callers that
+  // reach beyond `default` here are expected to no-op in non-host envs.
+  virtualNetwork.shimModule(
+    '@cardstack/host/services/store',
+    fallbackShim({ default: class {} }),
+  );
 
   shimHostCommands(virtualNetwork);
 }
@@ -199,22 +204,44 @@ export function shimExternals(virtualNetwork: VirtualNetwork) {
 // environment without crashing. These are never actually called in production
 // — they just prevent import resolution errors.
 //
+// Each fallback is wrapped in `fallbackShim` so the strict-namespace check
+// in the shim handler doesn't throw `ReferenceError` on the names a card's
+// test code references (e.g. `setupCardTest`, `mockMatrixForTesting`). The
+// fallback's only job here is to keep import resolution from failing; the
+// names that get accessed return `undefined` in non-test envs, which is the
+// pre-strict-check behavior callers depend on.
+//
 // In live-test runs, live-test.js overrides these at the *realm loader* level
 // (via loader.shimModule) with the real implementations before importing test
 // modules. The loader-level shim takes precedence over this network-level
 // fallback, so the real helpers are used during test execution.
 export function shimModulesForLiveTests(virtualNetwork: VirtualNetwork) {
   virtualNetwork.shimModule('@ember/test-helpers', emberTestHelpers);
-  virtualNetwork.shimModule('@cardstack/host/tests/helpers', {});
-  virtualNetwork.shimModule('@cardstack/host/tests/helpers/mock-matrix', {});
-  virtualNetwork.shimModule('@cardstack/host/tests/helpers/setup', {});
-  virtualNetwork.shimModule('@cardstack/host/tests/helpers/adapter', {});
+  virtualNetwork.shimModule('@cardstack/host/tests/helpers', fallbackShim());
+  virtualNetwork.shimModule(
+    '@cardstack/host/tests/helpers/mock-matrix',
+    fallbackShim(),
+  );
+  virtualNetwork.shimModule(
+    '@cardstack/host/tests/helpers/setup',
+    fallbackShim(),
+  );
+  virtualNetwork.shimModule(
+    '@cardstack/host/tests/helpers/adapter',
+    fallbackShim(),
+  );
   virtualNetwork.shimModule(
     '@cardstack/host/tests/helpers/render-component',
-    {},
+    fallbackShim(),
   );
-  virtualNetwork.shimModule('@cardstack/host/tests/helpers/base-realm', {});
-  virtualNetwork.shimModule('@universal-ember/test-support', {});
-  virtualNetwork.shimModule('@ember/owner', {});
-  virtualNetwork.shimModule('@cardstack/host/config/environment', {});
+  virtualNetwork.shimModule(
+    '@cardstack/host/tests/helpers/base-realm',
+    fallbackShim(),
+  );
+  virtualNetwork.shimModule('@universal-ember/test-support', fallbackShim());
+  virtualNetwork.shimModule('@ember/owner', fallbackShim());
+  virtualNetwork.shimModule(
+    '@cardstack/host/config/environment',
+    fallbackShim(),
+  );
 }

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -229,6 +229,7 @@ import './claim-boxel-domain-test';
 import './card-reference-resolver-test';
 import './bfm-card-references-test';
 import './loader-retry-test';
+import './package-shim-handler-test';
 import './command-parsing-utils-test';
 import './query-matches-filter-test';
 import './matches-filter-integration-test';

--- a/packages/realm-server/tests/package-shim-handler-test.ts
+++ b/packages/realm-server/tests/package-shim-handler-test.ts
@@ -20,6 +20,12 @@ module(basename(__filename), function () {
     test('wrapWithStrictNamespace passes Symbol gets through without throwing', async function (assert) {
       await runSharedTest(packageShimHandlerTests, assert, {});
     });
+    test('wrapWithStrictNamespace allows runtime-probe `then` (await thenable detection)', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('wrapWithStrictNamespace allows runtime-probe `__esModule`, `toJSON`, and Object.prototype methods', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
     test('wrapWithStrictNamespace honors the ALLOW_MISSING_NAMED_EXPORTS escape hatch', async function (assert) {
       await runSharedTest(packageShimHandlerTests, assert, {});
     });

--- a/packages/realm-server/tests/package-shim-handler-test.ts
+++ b/packages/realm-server/tests/package-shim-handler-test.ts
@@ -29,7 +29,7 @@ module(basename(__filename), function () {
     test('PackageShimHandler#handle wraps the served module with the strict Proxy', async function (assert) {
       await runSharedTest(packageShimHandlerTests, assert, {});
     });
-    test('PackageShimHandler error message names the requested URL — useful for cards that import from a typo URL', async function (assert) {
+    test('PackageShimHandler error message names the full requested URL — useful for cards that import from a typo URL', async function (assert) {
       await runSharedTest(packageShimHandlerTests, assert, {});
     });
   });

--- a/packages/realm-server/tests/package-shim-handler-test.ts
+++ b/packages/realm-server/tests/package-shim-handler-test.ts
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { runSharedTest } from '@cardstack/runtime-common/helpers';
+import packageShimHandlerTests from '@cardstack/runtime-common/tests/package-shim-handler-test';
+
+module(basename(__filename), function () {
+  module('Strict named-export check (CS-10860 follow-up)', function () {
+    test('wrapWithStrictNamespace returns existing exports unchanged', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('wrapWithStrictNamespace throws ReferenceError on missing string-key access', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('wrapWithStrictNamespace allows `in` checks without throwing', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('wrapWithStrictNamespace allows Object.keys to enumerate present exports', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('wrapWithStrictNamespace passes Symbol gets through without throwing', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('wrapWithStrictNamespace honors the ALLOW_MISSING_NAMED_EXPORTS escape hatch', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('wrapWithStrictNamespace returns null/undefined namespaces unchanged', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('PackageShimHandler#handle wraps the served module with the strict Proxy', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('PackageShimHandler error message names the requested URL — useful for cards that import from a typo URL', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+  });
+});

--- a/packages/runtime-common/package-shim-handler.ts
+++ b/packages/runtime-common/package-shim-handler.ts
@@ -16,12 +16,29 @@ export const PACKAGES_FAKE_ORIGIN = 'https://packages/';
 // exports are intentionally dynamic (e.g. test-only scaffolding) or
 // for explicit interop with code that probes for optional keys.
 //
-// Reflect.has(ns, ALLOW_MISSING_NAMED_EXPORTS) === true → no throw on
-// missing-key access; the Proxy returns the underlying value (which
-// may be `undefined`, matching pre-existing behavior).
+// Specifically: when the namespace has the property
+// `ALLOW_MISSING_NAMED_EXPORTS` set to the literal value `true`, the
+// strict wrapper is skipped and the namespace is returned verbatim.
+// Missing-key access then returns `undefined`, matching pre-Proxy
+// behavior. The `=== true` check (rather than truthy/`Reflect.has`)
+// avoids stray inherited properties or sentinel-shaped values from
+// accidentally opting a module out.
 export const ALLOW_MISSING_NAMED_EXPORTS = Symbol.for(
   'shim-handler.allowMissingNamedExports',
 );
+
+// Helper for shims that are intentional fallbacks — empty-or-stub
+// namespaces that exist only to keep import resolution from
+// crashing when the real module isn't present in the build (e.g.
+// the live-test scaffolding shims in `host/app/lib/externals.ts`).
+// Marks the returned object with `ALLOW_MISSING_NAMED_EXPORTS` so
+// the strict-namespace Proxy won't throw on names that the
+// fallback doesn't actually expose.
+export function fallbackShim(extras?: ModuleLike): ModuleLike {
+  let stub: ModuleLike = { ...(extras ?? {}) };
+  (stub as any)[ALLOW_MISSING_NAMED_EXPORTS] = true;
+  return stub;
+}
 
 // Wraps a shimmed module with a Proxy that throws a clear,
 // actionable error when an importer reads a name that doesn't
@@ -55,15 +72,19 @@ export function wrapWithStrictNamespace(
   }
   return new Proxy(namespace, {
     get(target, prop, receiver) {
-      // Symbol properties (Symbol.toPrimitive, Symbol.iterator, etc.)
-      // and inherited properties pass through — they're never the
-      // "I imported a name that doesn't exist" pattern. Same for
-      // own-property hits, which may be falsy/undefined values that
-      // were intentionally exported (rare, but legal).
+      // Symbol properties (Symbol.toPrimitive, Symbol.iterator,
+      // etc.) pass through — they're never the "I imported a name
+      // that doesn't exist" pattern.
       if (typeof prop !== 'string') {
         return Reflect.get(target, prop, receiver);
       }
-      if (prop in target) {
+      // Own-property check, NOT `prop in target`. An "exported
+      // member" of a namespace is an own property; inherited names
+      // like `toString`, `hasOwnProperty`, `constructor` from
+      // `Object.prototype` aren't exports. Treating them as exports
+      // (via `prop in target`) would silently let a card read those
+      // values and bypass the missing-import check.
+      if (Object.prototype.hasOwnProperty.call(target, prop)) {
         return Reflect.get(target, prop, receiver);
       }
       throw new ReferenceError(

--- a/packages/runtime-common/package-shim-handler.ts
+++ b/packages/runtime-common/package-shim-handler.ts
@@ -40,6 +40,39 @@ export function fallbackShim(extras?: ModuleLike): ModuleLike {
   return stub;
 }
 
+// Names the JS runtime and common library code probe on arbitrary
+// objects, NOT real named imports. Critical inclusions:
+//
+//   • `then` — `await ns` and `Promise.resolve(ns).then(...)` both
+//     call `Reflect.get(value, 'then')` to detect thenables. If the
+//     strict Proxy throws on this lookup, every awaited shimmed
+//     module breaks (we observed exactly this in CI: cascading
+//     `ReferenceError: Module '...' has no exported member 'then'`
+//     across host / matrix / realm-server suites).
+//   • `__esModule` — bundler CJS/ESM interop probes this to decide
+//     how to bridge default exports.
+//   • `toJSON` — `JSON.stringify(ns)` probes for it.
+//   • Object.prototype method names (`toString`, `valueOf`, etc.) —
+//     runtime + library code commonly probes these. They aren't
+//     real exports either.
+//
+// All of these pass through unchanged; missing ones return whatever
+// the underlying namespace would have returned (typically `undefined`
+// for `then`/`__esModule`, the inherited Object.prototype method for
+// the others).
+const RUNTIME_PROBE_NAMES = new Set<string>([
+  'then',
+  '__esModule',
+  'toJSON',
+  'toString',
+  'valueOf',
+  'hasOwnProperty',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+  'toLocaleString',
+  'constructor',
+]);
+
 // Wraps a shimmed module with a Proxy that throws a clear,
 // actionable error when an importer reads a name that doesn't
 // exist on the namespace. Plain JavaScript silently produces
@@ -50,10 +83,10 @@ export function fallbackShim(extras?: ModuleLike): ModuleLike {
 // exactly this footgun.
 //
 // Scope: every property *get* with a string key that isn't on the
-// namespace throws. Symbol gets, `has`, `ownKeys`, and
-// `getOwnPropertyDescriptor` traps pass through unchanged so
-// runtime introspection (`'foo' in ns`, `Object.keys(ns)`,
-// `Reflect.has(...)`) keeps working.
+// namespace AND isn't a runtime-probe name throws. Symbol gets,
+// `has`, `ownKeys`, and `getOwnPropertyDescriptor` traps pass
+// through unchanged so runtime introspection (`'foo' in ns`,
+// `Object.keys(ns)`, `Reflect.has(...)`) keeps working.
 //
 // Escape hatch: if the namespace exposes
 // `ALLOW_MISSING_NAMED_EXPORTS`, the Proxy returns `undefined` for
@@ -85,6 +118,11 @@ export function wrapWithStrictNamespace(
       // (via `prop in target`) would silently let a card read those
       // values and bypass the missing-import check.
       if (Object.prototype.hasOwnProperty.call(target, prop)) {
+        return Reflect.get(target, prop, receiver);
+      }
+      // Runtime probe — let it through to whatever the underlying
+      // object would return. NOT a missing-import case.
+      if (RUNTIME_PROBE_NAMES.has(prop)) {
         return Reflect.get(target, prop, receiver);
       }
       throw new ReferenceError(

--- a/packages/runtime-common/package-shim-handler.ts
+++ b/packages/runtime-common/package-shim-handler.ts
@@ -11,6 +11,73 @@ function trimModuleIdentifier(moduleIdentifier: string): string {
 
 export const PACKAGES_FAKE_ORIGIN = 'https://packages/';
 
+// Marker key the strict-namespace Proxy honors — modules tagged with
+// this opt out of the missing-export check. Useful for modules whose
+// exports are intentionally dynamic (e.g. test-only scaffolding) or
+// for explicit interop with code that probes for optional keys.
+//
+// Reflect.has(ns, ALLOW_MISSING_NAMED_EXPORTS) === true → no throw on
+// missing-key access; the Proxy returns the underlying value (which
+// may be `undefined`, matching pre-existing behavior).
+export const ALLOW_MISSING_NAMED_EXPORTS = Symbol.for(
+  'shim-handler.allowMissingNamedExports',
+);
+
+// Wraps a shimmed module with a Proxy that throws a clear,
+// actionable error when an importer reads a name that doesn't
+// exist on the namespace. Plain JavaScript silently produces
+// `undefined` for missing named imports, which then surfaces as a
+// confusing "Cannot convert undefined or null to object" deep in
+// Glimmer's helper-encoder (or wherever the importer eventually
+// uses the binding) — the deterministic whitepaper render bug is
+// exactly this footgun.
+//
+// Scope: every property *get* with a string key that isn't on the
+// namespace throws. Symbol gets, `has`, `ownKeys`, and
+// `getOwnPropertyDescriptor` traps pass through unchanged so
+// runtime introspection (`'foo' in ns`, `Object.keys(ns)`,
+// `Reflect.has(...)`) keeps working.
+//
+// Escape hatch: if the namespace exposes
+// `ALLOW_MISSING_NAMED_EXPORTS`, the Proxy returns `undefined` for
+// missing string keys (pre-Proxy behavior). Modules that
+// intentionally expose a dynamic shape can opt out this way.
+export function wrapWithStrictNamespace(
+  moduleIdentifier: string,
+  namespace: ModuleLike,
+): ModuleLike {
+  if (
+    namespace == null ||
+    typeof namespace !== 'object' ||
+    (namespace as any)[ALLOW_MISSING_NAMED_EXPORTS] === true
+  ) {
+    return namespace;
+  }
+  return new Proxy(namespace, {
+    get(target, prop, receiver) {
+      // Symbol properties (Symbol.toPrimitive, Symbol.iterator, etc.)
+      // and inherited properties pass through — they're never the
+      // "I imported a name that doesn't exist" pattern. Same for
+      // own-property hits, which may be falsy/undefined values that
+      // were intentionally exported (rare, but legal).
+      if (typeof prop !== 'string') {
+        return Reflect.get(target, prop, receiver);
+      }
+      if (prop in target) {
+        return Reflect.get(target, prop, receiver);
+      }
+      throw new ReferenceError(
+        `Module '${moduleIdentifier}' has no exported member '${prop}'. ` +
+          `If this is a card, check the import statement that names '${prop}' — ` +
+          `you may be importing from the wrong module ID. ` +
+          `(JavaScript silently produces \`undefined\` for missing named imports, ` +
+          `which then surfaces as confusing downstream errors. This Proxy ` +
+          `surfaces the missing import directly.)`,
+      );
+    },
+  });
+}
+
 export class PackageShimHandler {
   private resolveImport: (moduleIdentifier: string) => string;
   private moduleIds = new Map<string, () => Promise<ModuleLike>>();
@@ -32,7 +99,15 @@ export class PackageShimHandler {
           (await this.getModuleByPrefix(request.url));
         if (shimmedModule) {
           let response = new Response();
-          (response as any)[Symbol.for('shimmed-module')] = shimmedModule;
+          // Wrap with the strict-namespace Proxy so importers that
+          // name a non-existent export get a clear ReferenceError at
+          // the access site instead of silently consuming `undefined`
+          // and surfacing a confusing downstream error. The wrapped
+          // namespace preserves the underlying module's shape for all
+          // existing keys; only missing-key string reads change
+          // behavior.
+          (response as any)[Symbol.for('shimmed-module')] =
+            wrapWithStrictNamespace(request.url, shimmedModule);
           return response;
         }
         return null;

--- a/packages/runtime-common/tests/package-shim-handler-test.ts
+++ b/packages/runtime-common/tests/package-shim-handler-test.ts
@@ -1,0 +1,172 @@
+import type { SharedTests } from '../helpers';
+import {
+  PackageShimHandler,
+  PACKAGES_FAKE_ORIGIN,
+  ALLOW_MISSING_NAMED_EXPORTS,
+  wrapWithStrictNamespace,
+} from '../package-shim-handler';
+
+const tests: SharedTests<Record<string, never>> = Object.freeze({
+  'wrapWithStrictNamespace returns existing exports unchanged': async (
+    assert,
+  ) => {
+    let ns = wrapWithStrictNamespace('@cardstack/runtime-common', {
+      foo: 1,
+      bar: 'hello',
+    });
+    assert.strictEqual(ns.foo, 1, 'numeric export passes through');
+    assert.strictEqual(ns.bar, 'hello', 'string export passes through');
+  },
+
+  'wrapWithStrictNamespace throws ReferenceError on missing string-key access':
+    async (assert) => {
+      let ns = wrapWithStrictNamespace('@cardstack/runtime-common', {
+        existing: 'value',
+      });
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        let _missing = ns.markdownToHtml;
+        assert.ok(false, 'should have thrown on missing-key access');
+      } catch (err: any) {
+        assert.true(
+          err instanceof ReferenceError,
+          'throws ReferenceError (matches the JS spec for unresolved bindings)',
+        );
+        assert.ok(
+          /has no exported member 'markdownToHtml'/.test(err?.message ?? ''),
+          `error message names the missing export, got: ${err?.message}`,
+        );
+        assert.ok(
+          /'@cardstack\/runtime-common'/.test(err?.message ?? ''),
+          `error message names the source module, got: ${err?.message}`,
+        );
+      }
+    },
+
+  'wrapWithStrictNamespace allows `in` checks without throwing': async (
+    assert,
+  ) => {
+    let ns = wrapWithStrictNamespace('@cardstack/runtime-common', {
+      foo: 1,
+    });
+    assert.true('foo' in ns, 'present key reports as in');
+    assert.false('bar' in ns, 'missing key reports as not in (no throw)');
+  },
+
+  'wrapWithStrictNamespace allows Object.keys to enumerate present exports':
+    async (assert) => {
+      let ns = wrapWithStrictNamespace('@cardstack/runtime-common', {
+        a: 1,
+        b: 2,
+      });
+      assert.deepEqual(
+        Object.keys(ns).sort(),
+        ['a', 'b'],
+        'Object.keys works without triggering the strict get trap',
+      );
+    },
+
+  'wrapWithStrictNamespace passes Symbol gets through without throwing': async (
+    assert,
+  ) => {
+    let ns = wrapWithStrictNamespace('@cardstack/runtime-common', {
+      foo: 1,
+    });
+    // Random symbol access — common in framework internals (e.g.
+    // Glimmer's tagged values). The Proxy must not throw on these.
+    let testSymbol = Symbol.for('boxel-test:does-not-exist');
+    assert.strictEqual(
+      (ns as any)[testSymbol],
+      undefined,
+      'symbol access passes through and returns the underlying value',
+    );
+  },
+
+  'wrapWithStrictNamespace honors the ALLOW_MISSING_NAMED_EXPORTS escape hatch':
+    async (assert) => {
+      let opted: any = { foo: 1 };
+      opted[ALLOW_MISSING_NAMED_EXPORTS] = true;
+      let ns = wrapWithStrictNamespace('@cardstack/runtime-common', opted);
+      // Module that opts out of strict checking gets pre-Proxy
+      // behavior — missing-key access returns undefined, no throw.
+      assert.strictEqual(
+        ns.somethingMissing,
+        undefined,
+        'opted-out module returns undefined for missing keys',
+      );
+      assert.strictEqual(ns.foo, 1, 'present keys still pass through');
+    },
+
+  'wrapWithStrictNamespace returns null/undefined namespaces unchanged': async (
+    assert,
+  ) => {
+    assert.strictEqual(
+      wrapWithStrictNamespace('x', null as any),
+      null,
+      'null passes through',
+    );
+    assert.strictEqual(
+      wrapWithStrictNamespace('x', undefined as any),
+      undefined,
+      'undefined passes through',
+    );
+  },
+
+  'PackageShimHandler#handle wraps the served module with the strict Proxy':
+    async (assert) => {
+      let handler = new PackageShimHandler(
+        (id) => `${PACKAGES_FAKE_ORIGIN}${id}`,
+      );
+      handler.shimModule('test-module', { existing: 1 });
+      let response = await handler.handle(
+        new Request(`${PACKAGES_FAKE_ORIGIN}test-module`),
+      );
+      assert.ok(response, 'handler returned a Response');
+      let shimmed = (response as any)?.[Symbol.for('shimmed-module')];
+      assert.strictEqual(shimmed.existing, 1, 'present export readable');
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        let _missing = shimmed.notExported;
+        assert.ok(false, 'should have thrown on missing-key access');
+      } catch (err: any) {
+        assert.true(
+          err instanceof ReferenceError,
+          'served module is wrapped with the strict Proxy',
+        );
+      }
+    },
+
+  'PackageShimHandler error message names the requested URL — useful for cards that import from a typo URL':
+    async (assert) => {
+      let handler = new PackageShimHandler(
+        (id) => `${PACKAGES_FAKE_ORIGIN}${id}`,
+      );
+      handler.shimModule('@cardstack/runtime-common', {
+        Loader: class {},
+        baseRealm: 'https://cardstack.com/base/',
+      });
+      let response = await handler.handle(
+        new Request(`${PACKAGES_FAKE_ORIGIN}@cardstack/runtime-common`),
+      );
+      let shimmed = (response as any)?.[Symbol.for('shimmed-module')];
+      try {
+        // Re-create the deterministic whitepaper bug shape: a card
+        // imports `markdownToHtml` from `@cardstack/runtime-common`,
+        // which doesn't actually export that name.
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        let _ = shimmed.markdownToHtml;
+        assert.ok(false, 'should have thrown');
+      } catch (err: any) {
+        assert.ok(
+          /has no exported member 'markdownToHtml'/.test(err?.message ?? ''),
+          `error names the missing export, got: ${err?.message}`,
+        );
+        assert.ok(
+          /(@cardstack\/runtime-common)/.test(err?.message ?? ''),
+          `error names the source module, got: ${err?.message}`,
+        );
+      }
+    },
+});
+
+export default tests;

--- a/packages/runtime-common/tests/package-shim-handler-test.ts
+++ b/packages/runtime-common/tests/package-shim-handler-test.ts
@@ -136,7 +136,7 @@ const tests: SharedTests<Record<string, never>> = Object.freeze({
       }
     },
 
-  'PackageShimHandler error message names the requested URL — useful for cards that import from a typo URL':
+  'PackageShimHandler error message names the full requested URL — useful for cards that import from a typo URL':
     async (assert) => {
       let handler = new PackageShimHandler(
         (id) => `${PACKAGES_FAKE_ORIGIN}${id}`,
@@ -145,9 +145,8 @@ const tests: SharedTests<Record<string, never>> = Object.freeze({
         Loader: class {},
         baseRealm: 'https://cardstack.com/base/',
       });
-      let response = await handler.handle(
-        new Request(`${PACKAGES_FAKE_ORIGIN}@cardstack/runtime-common`),
-      );
+      let requestUrl = `${PACKAGES_FAKE_ORIGIN}@cardstack/runtime-common`;
+      let response = await handler.handle(new Request(requestUrl));
       let shimmed = (response as any)?.[Symbol.for('shimmed-module')];
       try {
         // Re-create the deterministic whitepaper bug shape: a card
@@ -161,9 +160,14 @@ const tests: SharedTests<Record<string, never>> = Object.freeze({
           /has no exported member 'markdownToHtml'/.test(err?.message ?? ''),
           `error names the missing export, got: ${err?.message}`,
         );
+        // Lock in that the FULL request URL is in the error — not
+        // just the short module-id fragment. The
+        // `https://packages/...` origin is what the loader's logs
+        // and stack traces use, so an operator searching for it
+        // should be able to find this error.
         assert.ok(
-          /(@cardstack\/runtime-common)/.test(err?.message ?? ''),
-          `error names the source module, got: ${err?.message}`,
+          (err?.message ?? '').includes(requestUrl),
+          `error names the full request URL '${requestUrl}', got: ${err?.message}`,
         );
       }
     },

--- a/packages/runtime-common/tests/package-shim-handler-test.ts
+++ b/packages/runtime-common/tests/package-shim-handler-test.ts
@@ -24,8 +24,10 @@ const tests: SharedTests<Record<string, never>> = Object.freeze({
         existing: 'value',
       });
       try {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        let _missing = ns.markdownToHtml;
+        // `void` to invoke the property access for its side effect
+        // (the Proxy throws) without binding the result. `let _ = …`
+        // would trip TS's noUnusedLocals despite the eslint-disable.
+        void ns.markdownToHtml;
         assert.ok(false, 'should have thrown on missing-key access');
       } catch (err: any) {
         assert.true(
@@ -125,8 +127,7 @@ const tests: SharedTests<Record<string, never>> = Object.freeze({
       let shimmed = (response as any)?.[Symbol.for('shimmed-module')];
       assert.strictEqual(shimmed.existing, 1, 'present export readable');
       try {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        let _missing = shimmed.notExported;
+        void shimmed.notExported;
         assert.ok(false, 'should have thrown on missing-key access');
       } catch (err: any) {
         assert.true(
@@ -152,8 +153,7 @@ const tests: SharedTests<Record<string, never>> = Object.freeze({
         // Re-create the deterministic whitepaper bug shape: a card
         // imports `markdownToHtml` from `@cardstack/runtime-common`,
         // which doesn't actually export that name.
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        let _ = shimmed.markdownToHtml;
+        void shimmed.markdownToHtml;
         assert.ok(false, 'should have thrown');
       } catch (err: any) {
         assert.ok(

--- a/packages/runtime-common/tests/package-shim-handler-test.ts
+++ b/packages/runtime-common/tests/package-shim-handler-test.ts
@@ -84,6 +84,60 @@ const tests: SharedTests<Record<string, never>> = Object.freeze({
     );
   },
 
+  'wrapWithStrictNamespace allows runtime-probe `then` (await thenable detection)':
+    async (assert) => {
+      let ns = wrapWithStrictNamespace('@cardstack/runtime-common', {
+        someExport: 1,
+      });
+      // `await ns` does `Reflect.get(value, 'then')`. The Proxy must
+      // not throw on this — otherwise every awaited shimmed module
+      // breaks (we hit exactly this regression in CI: cascading
+      // `ReferenceError: Module '...' has no exported member 'then'`
+      // across host / matrix / realm-server suites).
+      let resolved = await Promise.resolve(ns);
+      assert.strictEqual(
+        resolved,
+        ns,
+        'await on a shimmed namespace returns the namespace (treated as non-thenable)',
+      );
+      assert.strictEqual(
+        (ns as any).then,
+        undefined,
+        '`.then` access returns undefined without throwing',
+      );
+    },
+
+  'wrapWithStrictNamespace allows runtime-probe `__esModule`, `toJSON`, and Object.prototype methods':
+    async (assert) => {
+      let ns = wrapWithStrictNamespace('@cardstack/runtime-common', {
+        someExport: 1,
+      });
+      // `__esModule` is what CJS/ESM interop bridges probe to decide
+      // how to import the default. Should be undefined, not a throw.
+      assert.strictEqual(
+        (ns as any).__esModule,
+        undefined,
+        '__esModule probe returns undefined without throwing',
+      );
+      // `toJSON` is what `JSON.stringify(ns)` probes for.
+      assert.strictEqual(
+        (ns as any).toJSON,
+        undefined,
+        'toJSON probe returns undefined without throwing',
+      );
+      // Object.prototype methods inherited via the prototype chain.
+      assert.strictEqual(
+        typeof (ns as any).toString,
+        'function',
+        'toString returns the inherited Object.prototype method',
+      );
+      assert.strictEqual(
+        typeof (ns as any).hasOwnProperty,
+        'function',
+        'hasOwnProperty returns the inherited Object.prototype method',
+      );
+    },
+
   'wrapWithStrictNamespace honors the ALLOW_MISSING_NAMED_EXPORTS escape hatch':
     async (assert) => {
       let opted: any = { foo: 1 };


### PR DESCRIPTION
Companion to #4531 — the retry PR catches *transient* failures on the lazy-shimmed module loading path; this PR catches the *deterministic* failure mode that retry can't help with.

## The footgun

A card that imports a name from a shimmed module that doesn't actually export that name silently gets `undefined` for the binding. JavaScript namespace imports never error on missing keys at module-link time when running through Cardstack's AMD-style loader transform — they just bind `undefined`. The whitepaper render bug is exactly this:

```ts
// boxel-whitepaper.gts (the actual prod card source)
import {
  markdownToHtml,
  preloadMarkdownLanguages,
} from '@cardstack/runtime-common';
```

`@cardstack/runtime-common`'s `index.ts` doesn't re-export those names — they live in `@cardstack/runtime-common/marked-sync`, which is a separate (lazy) shim. Both shims register fine, but the named import resolves to `undefined` because the namespace simply doesn't have the key. Then at template compile time Glimmer's helper-encoder tries to use the `undefined` reference as a helper, hits `Object.keys(undefined)` (or equivalent) deep in `expr → helper → ifHelper`, and throws `TypeError: Cannot convert undefined or null to object`. Operators see a Glimmer stack pointing at compiled chunk URLs that don't help locate the real cause.

The throw is **100% deterministic** because the wrong import path is baked into the card source. No retry can fix this; the modules load successfully, the *exports* are just missing.

## What this PR does

Wrap each shimmed module returned by `PackageShimHandler#handle` with a Proxy that throws a clear `ReferenceError` when an importer reads a name that doesn't exist on the namespace:

```
ReferenceError: Module '@cardstack/runtime-common' has no exported
member 'markdownToHtml'. If this is a card, check the import
statement that names 'markdownToHtml' — you may be importing from
the wrong module ID. (JavaScript silently produces `undefined` for
missing named imports, which then surfaces as confusing downstream
errors. This Proxy surfaces the missing import directly.)
```

The error fires at the access site (i.e. at module instantiation, when the AMD wrapper does `var markdownToHtml = _runtime.markdownToHtml`), not deep in Glimmer — so the failing card module surfaces with a tight, actionable message instead of a 90s render timeout or a confusing `TypeError`.

## Scope is deliberately narrow

Plenty of legitimate runtime introspection patterns access the namespace, and we don't want to break any of them:

- `'foo' in ns` — `has` trap, returns false safely
- `Object.keys(ns)` — `ownKeys` trap, returns all keys
- `Object.getOwnPropertyDescriptor(ns, 'foo')` — passes through
- Symbol gets (`ns[Symbol.iterator]` etc.) — pass through

Only **direct string-key gets** of names that miss the underlying namespace throw. That's the exact pattern AMD-style named imports compile to (with `noInterop: true`, which we use), so it catches the footgun without changing semantics for introspection.

## Escape hatch + `fallbackShim()` helper

Some shims **intentionally** expose a sparse / empty namespace because their only job is to keep import resolution from failing. The biggest example is the live-test scaffolding in `host/app/lib/externals.ts`:

```ts
// Existing pattern — these were ALL bare `{}` before this PR.
virtualNetwork.shimModule('@cardstack/host/tests/helpers', {});
virtualNetwork.shimModule('@cardstack/host/tests/helpers/mock-matrix', {});
virtualNetwork.shimModule('@cardstack/host/tests/helpers/setup', {});
// …and so on for the other test-helper paths
```

These shims exist so realm cards can co-locate test imports (`*.test.gts`) and still load in non-test environments without crashing on unresolved imports. The host's live-test bootstrap later overrides them at the realm-loader level with the real implementations, so the fallback's `undefined` exports are only ever observed in production — where the test path isn't exercised. Without an opt-out, the strict-namespace Proxy would turn every reference like `_helpers.setupCardTest` from a silent `undefined` (the existing contract) into a `ReferenceError` — breaking every card that has co-located test imports.

The mechanism: a sentinel symbol on the namespace.

```ts
export const ALLOW_MISSING_NAMED_EXPORTS = Symbol.for(
  'shim-handler.allowMissingNamedExports',
);
```

When the wrapper sees `ns[ALLOW_MISSING_NAMED_EXPORTS] === true`, it returns the namespace verbatim — no Proxy, missing-key access reverts to plain JS `undefined`. The `=== true` check (rather than truthy or `Reflect.has`) is deliberate: it requires deliberate opt-in and avoids stray inherited properties or sentinel-shaped values from accidentally exempting a module.

To make the opt-in concise at the call site, the package exports a small helper:

```ts
export function fallbackShim(extras?: ModuleLike): ModuleLike {
  let stub: ModuleLike = { ...(extras ?? {}) };
  (stub as any)[ALLOW_MISSING_NAMED_EXPORTS] = true;
  return stub;
}
```

Then in `externals.ts`:

```ts
import { fallbackShim } from '@cardstack/runtime-common/package-shim-handler';

// Pure empty fallbacks — exist only so import resolution doesn't fail.
virtualNetwork.shimModule('@cardstack/host/tests/helpers', fallbackShim());
virtualNetwork.shimModule('@cardstack/host/tests/helpers/mock-matrix', fallbackShim());
// …

// A fallback with one real export plus the opt-out for everything else.
virtualNetwork.shimModule(
  '@cardstack/host/services/store',
  fallbackShim({ default: class {} }),
);
```

A reader scanning `externals.ts` can now tell at a glance which shims are real (eagerly-imported namespaces), which are lazy (`shimAsyncModule`), and which are intentional fallbacks (`fallbackShim()`). The intent is documented at the call site rather than implied by an empty literal that the next reviewer might mistake for a TODO.

**When to reach for `fallbackShim()`** vs. a regular `shimModule(id, {})`:

- **Use `fallbackShim()`** when the namespace's only purpose is to keep a card's import declaration from failing in an environment where the real module isn't present — e.g. test-only modules in production, dev-only modules in test runs. Callers reaching beyond what's stubbed are expected to no-op.
- **Use a regular `shimModule(id, exports)`** when you're declaring the *real* surface of a module — i.e. the names listed are the only legitimate exports, and a card asking for anything else is a bug worth surfacing.

## What this DOESN'T fix

The whitepaper card itself still has the wrong import path; this PR just makes the error message useful when it happens. **The actual whitepaper card source still needs to be fixed** to import from `@cardstack/runtime-common/marked-sync` instead of `@cardstack/runtime-common` — that's a separate change to the realm content. (Step-by-step instructions for the `whitepaper.boxel.ai` realm maintainer are in the CS-10860 Linear ticket.)

## Files

- `packages/runtime-common/package-shim-handler.ts` — adds `wrapWithStrictNamespace`, `ALLOW_MISSING_NAMED_EXPORTS`, `fallbackShim()`, and threads the wrapper through `handle()`.
- `packages/host/app/lib/externals.ts` — applies `fallbackShim()` to the 9 intentional-fallback `shimModule` call sites (8 live-test scaffolding paths + `@cardstack/host/services/store`).
- `packages/runtime-common/tests/package-shim-handler-test.ts` *(new)* — 9 SharedTests covering present/missing access, the introspection traps, the escape hatch, null/undefined namespaces, and an integrated regression test that re-creates the deterministic whitepaper bug shape.
- `packages/realm-server/tests/package-shim-handler-test.ts` *(new)* — registers the shared tests in the realm-server suite.

## Test plan

- [x] All 9 new tests pass locally
- [x] Lint clean
- [ ] CI green — particularly the prerendering tests, since this change affects every shimmed-module access during card render

🤖 Generated with [Claude Code](https://claude.com/claude-code)