### PR TITLE
Fix flaky scripted-command create/update/show test

### DIFF
--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -588,12 +588,16 @@ module('Acceptance | Commands tests', function (hooks) {
     await click('[data-test-schedule-meeting-button]');
     await waitUntil(() => getRoomIds().length > 0);
     let roomId = getRoomIds().pop()!;
-    let message = (await waitUntil(() =>
-      getRoomEvents(roomId)
-        .slice()
-        .reverse()
-        .find((m) => m.content.msgtype === APP_BOXEL_MESSAGE_MSGTYPE),
-    ))!;
+    let message = (await waitUntil(() => {
+      let roomEvents = getRoomEvents(roomId);
+      for (let i = roomEvents.length - 1; i >= 0; i--) {
+        let event = roomEvents[i];
+        if (event.content.msgtype === APP_BOXEL_MESSAGE_MSGTYPE) {
+          return event;
+        }
+      }
+      return undefined;
+    }))!;
     let boxelMessageData = JSON.parse(message.content.data);
     let meetingCardEventId = boxelMessageData.attachedCards[0];
     let meetingCardId = meetingCardEventId.sourceUrl;

--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -588,8 +588,12 @@ module('Acceptance | Commands tests', function (hooks) {
     await click('[data-test-schedule-meeting-button]');
     await waitUntil(() => getRoomIds().length > 0);
     let roomId = getRoomIds().pop()!;
-    let message = getRoomEvents(roomId).pop()!;
-    assert.strictEqual(message.content.msgtype, APP_BOXEL_MESSAGE_MSGTYPE);
+    let message = (await waitUntil(() =>
+      getRoomEvents(roomId)
+        .slice()
+        .reverse()
+        .find((m) => m.content.msgtype === APP_BOXEL_MESSAGE_MSGTYPE),
+    ))!;
     let boxelMessageData = JSON.parse(message.content.data);
     let meetingCardEventId = boxelMessageData.attachedCards[0];
     let meetingCardId = meetingCardEventId.sourceUrl;


### PR DESCRIPTION
## Summary
- The `a scripted command can create a card, update it and show it` host acceptance test waited for a room to be created, then `pop()`-ed the latest event in that room and asserted its msgtype was `app.boxel.message`.
- In CI (e.g. [run 25009009443 / job 73240209749](https://github.com/cardstack/boxel/actions/runs/25009009443/job/73240209749)) the room sometimes appears before the `app.boxel.message` is dispatched, so the most recent event is a non-message room event (`m.room.create` / `m.room.member`) and the assertion fails.
- Switch to `waitUntil` finding an `app.boxel.message` event in the room (scanning newest-first) before reading it, eliminating the race.

## Test plan
- [ ] CI: `Host Tests` shard 17 passes consistently
- [ ] Local: re-run `commands-test` `a scripted command can create a card, update it and show it` multiple times