### PR TITLE
CI — apply observability config to grafana staging on merge

### DIFF
--- a/.github/actions/install-grafanactl/action.yml
+++ b/.github/actions/install-grafanactl/action.yml
@@ -1,0 +1,34 @@
+name: Install grafanactl
+description: |
+  Download and install the pinned grafanactl release on the Ubuntu runner,
+  verifying the SHA-256 checksum from the release's grafanactl_checksums.txt
+  before placing the binary on PATH. Used by the observability-apply-staging,
+  observability-apply-production, and observability-diff workflows.
+
+inputs:
+  version:
+    description: grafanactl release version (without the leading 'v', e.g. "0.1.10")
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GRAFANACTL_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        TARBALL="grafanactl_Linux_x86_64.tar.gz"
+        CHECKSUMS="grafanactl_checksums.txt"
+        RELEASE_URL="https://github.com/grafana/grafanactl/releases/download/v${GRAFANACTL_VERSION}"
+        TMPDIR="$(mktemp -d)"
+        trap 'rm -rf "$TMPDIR"' EXIT
+
+        curl -fsSL "${RELEASE_URL}/${TARBALL}"   -o "${TMPDIR}/${TARBALL}"
+        curl -fsSL "${RELEASE_URL}/${CHECKSUMS}" -o "${TMPDIR}/${CHECKSUMS}"
+
+        ( cd "$TMPDIR" && grep " ${TARBALL}\$" "${CHECKSUMS}" | sha256sum -c - )
+
+        tar -xzf "${TMPDIR}/${TARBALL}" -C "$TMPDIR" grafanactl
+        sudo install -m 0755 "${TMPDIR}/grafanactl" /usr/local/bin/grafanactl
+        grafanactl --version

--- a/.github/workflows/observability-apply-staging.yml
+++ b/.github/workflows/observability-apply-staging.yml
@@ -1,0 +1,104 @@
+name: Observability — apply to staging
+
+# Push to main with changes under packages/observability/** triggers a
+# `grafanactl resources push` against the staging self-host Grafana.
+# Mirrors the existing terraform-apply-on-merge pattern.
+#
+# Production has its own workflow (observability-apply-production.yml from
+# CS-10936) gated on manual dispatch.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/observability/**"
+      - ".github/workflows/observability-apply-staging.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  # Never run two applies in parallel against the same environment, but
+  # don't cancel an in-flight apply when a new commit lands — let it finish
+  # cleanly so we don't leave Grafana in a half-pushed state.
+  group: observability-apply-staging
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    name: Apply to staging
+    runs-on: ubuntu-latest
+
+    env:
+      AWS_REGION: us-east-1
+      # IAM role used to fetch the grafanactl service-account token from SSM.
+      # Currently uses the existing boxel-host role; if/when that role is too
+      # broad for this purpose, replace with a dedicated
+      # `boxel-observability-apply` role (see CS-10932 design notes — scope
+      # principle prefers the dedicated role). Either way the role needs:
+      #   ssm:GetParameter on /staging/grafana/grafanactl_token
+      AWS_ROLE_ARN: arn:aws:iam::680542703984:role/boxel-host
+      GRAFANA_SERVER: https://grafana-staging.stack.cards
+      # Grafana 12.4.3 is the production pin; grafanactl version should be
+      # current enough to talk to it. Bump as needed.
+      GRAFANACTL_VERSION: "0.7.0"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install grafanactl
+        # Inline curl install rather than a third-party action, since
+        # Grafana Labs does not yet publish an official GitHub Action
+        # for grafanactl. Pinned via $GRAFANACTL_VERSION above.
+        # If the URL pattern changes upstream, update the curl and the
+        # README's install hint together.
+        run: |
+          curl -fsSL \
+            "https://github.com/grafana/grafanactl/releases/download/v${GRAFANACTL_VERSION}/grafanactl_${GRAFANACTL_VERSION}_linux_amd64.tar.gz" \
+            -o /tmp/grafanactl.tar.gz
+          sudo tar -xzf /tmp/grafanactl.tar.gz -C /usr/local/bin grafanactl
+          grafanactl --version
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Source GRAFANA_TOKEN from SSM
+        # Mirrors what packages/observability/scripts/grafanactl-env.sh does
+        # locally. Inline here so the workflow doesn't depend on bash from
+        # the repo working dir before checkout-related env vars are stable.
+        run: |
+          GRAFANA_TOKEN="$(aws ssm get-parameter \
+            --name /staging/grafana/grafanactl_token \
+            --with-decryption \
+            --query 'Parameter.Value' \
+            --output text)"
+          # Mask the token so it doesn't leak into job logs even if a
+          # downstream tool echoes it. Then export to subsequent steps.
+          echo "::add-mask::$GRAFANA_TOKEN"
+          echo "GRAFANA_TOKEN=$GRAFANA_TOKEN" >> "$GITHUB_ENV"
+          echo "GRAFANA_SERVER=$GRAFANA_SERVER" >> "$GITHUB_ENV"
+
+      - name: Apply
+        # apply.sh sources its own grafanactl-env.sh helper, which for
+        # `local` would `unset GRAFANA_TOKEN`. We're using `--env staging`
+        # which fetches from SSM via the helper — but in CI we already have
+        # GRAFANA_TOKEN exported, so the helper will overwrite it with a
+        # fresh fetch. That's fine and consistent.
+        working-directory: packages/observability
+        run: |
+          ./scripts/apply.sh --env staging
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Observability apply" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Target: \`$GRAFANA_SERVER\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- grafanactl: \`$GRAFANACTL_VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Status: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/observability-apply-staging.yml
+++ b/.github/workflows/observability-apply-staging.yml
@@ -33,13 +33,13 @@ jobs:
 
     env:
       AWS_REGION: us-east-1
-      # IAM role used to fetch the grafanactl service-account token from SSM.
-      # Currently uses the existing boxel-host role; if/when that role is too
-      # broad for this purpose, replace with a dedicated
-      # `boxel-observability-apply` role (see CS-10932 design notes — scope
-      # principle prefers the dedicated role). Either way the role needs:
-      #   ssm:GetParameter on /staging/grafana/grafanactl_token
-      AWS_ROLE_ARN: arn:aws:iam::680542703984:role/boxel-host
+      # Dedicated, narrowly-scoped role created in cardstack/infra#665
+      # (configs/boxel-observability-apply/staging). Has exactly one
+      # permission: ssm:GetParameter on /staging/grafana/grafanactl_token.
+      # If the role doesn't exist yet (infra PR not applied), the
+      # configure-aws-credentials step below will fail with "InvalidIdentityToken"
+      # or similar — apply the infra config first.
+      AWS_ROLE_ARN: arn:aws:iam::680542703984:role/boxel-observability-apply
       GRAFANA_SERVER: https://grafana-staging.stack.cards
       # Grafana 12.4.3 is the production pin; grafanactl version should be
       # current enough to talk to it. Bump as needed.

--- a/.github/workflows/observability-apply-staging.yml
+++ b/.github/workflows/observability-apply-staging.yml
@@ -40,7 +40,14 @@ jobs:
       # configure-aws-credentials step below will fail with "InvalidIdentityToken"
       # or similar — apply the infra config first.
       AWS_ROLE_ARN: arn:aws:iam::680542703984:role/boxel-observability-apply
-      GRAFANA_SERVER: https://grafana-staging.stack.cards
+      # Server URL deliberately NOT set here. The committed
+      # packages/observability/grafanactl/config.yaml is the single source of
+      # truth for per-context server URLs (rendered to a tempfile by
+      # scripts/render-config.sh at apply time). Setting GRAFANA_SERVER as
+      # workflow env would silently override the config — if config.yaml's
+      # staging URL ever changes (e.g., Phase 6 cutover dashboard-staging.*
+      # rename), the workflow would still hit the old hostname.
+      #
       # Grafana 12.4.3 is the production pin; grafanactl version should be
       # current enough to talk to it. Bump as needed.
       GRAFANACTL_VERSION: "0.7.0"
@@ -55,11 +62,24 @@ jobs:
         # for grafanactl. Pinned via $GRAFANACTL_VERSION above.
         # If the URL pattern changes upstream, update the curl and the
         # README's install hint together.
+        #
+        # The release artifact's SHA-256 is verified against the published
+        # checksums.txt before installing — guards against a tampered
+        # artifact in transit or on the GitHub release CDN.
         run: |
-          curl -fsSL \
-            "https://github.com/grafana/grafanactl/releases/download/v${GRAFANACTL_VERSION}/grafanactl_${GRAFANACTL_VERSION}_linux_amd64.tar.gz" \
-            -o /tmp/grafanactl.tar.gz
-          sudo tar -xzf /tmp/grafanactl.tar.gz -C /usr/local/bin grafanactl
+          set -euo pipefail
+          TARBALL="grafanactl_${GRAFANACTL_VERSION}_linux_amd64.tar.gz"
+          RELEASE_URL="https://github.com/grafana/grafanactl/releases/download/v${GRAFANACTL_VERSION}"
+          TMPDIR="$(mktemp -d)"
+          trap 'rm -rf "$TMPDIR"' EXIT
+
+          curl -fsSL "${RELEASE_URL}/${TARBALL}"       -o "${TMPDIR}/${TARBALL}"
+          curl -fsSL "${RELEASE_URL}/checksums.txt"    -o "${TMPDIR}/checksums.txt"
+
+          ( cd "$TMPDIR" && grep " ${TARBALL}\$" checksums.txt | sha256sum -c - )
+
+          tar -xzf "${TMPDIR}/${TARBALL}" -C "$TMPDIR" grafanactl
+          sudo install -m 0755 "${TMPDIR}/grafanactl" /usr/local/bin/grafanactl
           grafanactl --version
 
       - name: Configure AWS credentials
@@ -82,7 +102,6 @@ jobs:
           # downstream tool echoes it. Then export to subsequent steps.
           echo "::add-mask::$GRAFANA_TOKEN"
           echo "GRAFANA_TOKEN=$GRAFANA_TOKEN" >> "$GITHUB_ENV"
-          echo "GRAFANA_SERVER=$GRAFANA_SERVER" >> "$GITHUB_ENV"
 
       - name: Apply
         # apply.sh sources its own grafanactl-env.sh helper, which for
@@ -99,6 +118,6 @@ jobs:
         run: |
           echo "## Observability apply" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Target: \`$GRAFANA_SERVER\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Target: staging (server URL from packages/observability/grafanactl/config.yaml)" >> "$GITHUB_STEP_SUMMARY"
           echo "- grafanactl: \`$GRAFANACTL_VERSION\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Status: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/observability-apply-staging.yml
+++ b/.github/workflows/observability-apply-staging.yml
@@ -48,39 +48,18 @@ jobs:
       # staging URL ever changes (e.g., Phase 6 cutover dashboard-staging.*
       # rename), the workflow would still hit the old hostname.
       #
-      # Grafana 12.4.3 is the production pin; grafanactl version should be
-      # current enough to talk to it. Bump as needed.
-      GRAFANACTL_VERSION: "0.7.0"
+      # grafanactl is still pre-1.0 — bump as needed; the install action
+      # (.github/actions/install-grafanactl) verifies the SHA-256.
+      GRAFANACTL_VERSION: "0.1.10"
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install grafanactl
-        # Inline curl install rather than a third-party action, since
-        # Grafana Labs does not yet publish an official GitHub Action
-        # for grafanactl. Pinned via $GRAFANACTL_VERSION above.
-        # If the URL pattern changes upstream, update the curl and the
-        # README's install hint together.
-        #
-        # The release artifact's SHA-256 is verified against the published
-        # checksums.txt before installing — guards against a tampered
-        # artifact in transit or on the GitHub release CDN.
-        run: |
-          set -euo pipefail
-          TARBALL="grafanactl_${GRAFANACTL_VERSION}_linux_amd64.tar.gz"
-          RELEASE_URL="https://github.com/grafana/grafanactl/releases/download/v${GRAFANACTL_VERSION}"
-          TMPDIR="$(mktemp -d)"
-          trap 'rm -rf "$TMPDIR"' EXIT
-
-          curl -fsSL "${RELEASE_URL}/${TARBALL}"       -o "${TMPDIR}/${TARBALL}"
-          curl -fsSL "${RELEASE_URL}/checksums.txt"    -o "${TMPDIR}/checksums.txt"
-
-          ( cd "$TMPDIR" && grep " ${TARBALL}\$" checksums.txt | sha256sum -c - )
-
-          tar -xzf "${TMPDIR}/${TARBALL}" -C "$TMPDIR" grafanactl
-          sudo install -m 0755 "${TMPDIR}/grafanactl" /usr/local/bin/grafanactl
-          grafanactl --version
+        uses: ./.github/actions/install-grafanactl
+        with:
+          version: ${{ env.GRAFANACTL_VERSION }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0


### PR DESCRIPTION
> **Stacked on PR #4535** ([cs-10922-amg-export](https://github.com/cardstack/boxel/pull/4535)) → which is stacked on PR #4533 → which is stacked on PR #4529. Review/merge those first. Draft until CS-10922 merges (this workflow only does meaningful work once dashboard JSON exists in the package).
>
> **Companion infra PR: [cardstack/infra#665](https://github.com/cardstack/infra/pull/665)** — creates the dedicated IAM role this workflow assumes.

## Summary

Adds the GitHub Actions workflow that runs \`grafanactl resources push --context staging\` whenever \`main\` gets a push touching \`packages/observability/**\`. Mirrors the repo's existing terraform-apply-on-merge pattern.

This is the CI half of the dashboard-as-code feedback loop: PR review (CS-10933) → merge to main → automatic apply to staging Grafana.

## File added

\`.github/workflows/observability-apply-staging.yml\` — single \`apply\` job:

1. Checkout
2. Install grafanactl from GitHub releases (\`curl\` + \`tar\`, version pinned via env var, **SHA-256 verified against published checksums.txt** before \`sudo install\` — no unverified binary lands in PATH)
3. Configure AWS credentials via OIDC (\`aws-actions/configure-aws-credentials\`) using the dedicated \`boxel-observability-apply\` role (created in [cardstack/infra#665](https://github.com/cardstack/infra/pull/665))
4. \`aws ssm get-parameter --name /staging/grafana/grafanactl_token\` → exported as \`GRAFANA_TOKEN\` with \`::add-mask::\` so it can't leak in logs
5. \`./scripts/apply.sh --env staging\` (the wrapper from CS-10913, which renders the per-call config tempfile and invokes \`grafanactl resources push\`)
6. Step Summary writes target + grafanactl version + status

## IAM

The workflow assumes \`arn:aws:iam::680542703984:role/boxel-observability-apply\`. That role is created in **[cardstack/infra#665](https://github.com/cardstack/infra/pull/665)** with exactly one permission: \`ssm:GetParameter\` on \`/staging/grafana/grafanactl_token\`. Nothing else.

The dedicated role was a deliberate choice over extending the broader \`boxel-host\` role with SSM permissions: blast radius for an observability-apply-staging.yml compromise should be one parameter, not boxel-host's S3/CloudFront permissions.

## Trigger shape

\`\`\`yaml
on:
  push:
    branches: [main]
    paths:
      - "packages/observability/**"
      - ".github/workflows/observability-apply-staging.yml"
  workflow_dispatch:
\`\`\`

\`workflow_dispatch\` for manual reruns; the workflow file itself is on the paths list so workflow edits self-trigger.

\`\`\`yaml
concurrency:
  group: observability-apply-staging
  cancel-in-progress: false
\`\`\`

Two pushes-in-flight serialize cleanly rather than canceling the in-flight apply mid-push.

## Server URL — single source of truth

Server URL is **deliberately not** set as a workflow env var. The committed \`packages/observability/grafanactl/config.yaml\` is the single source of truth for per-context server URLs, rendered to a tempfile by \`scripts/render-config.sh\` at apply time. Setting \`GRAFANA_SERVER\` in the workflow would silently override the config — if the staging URL ever changes (e.g., Phase 6 cutover renames to \`dashboard-staging.stack.cards\`), the workflow would silently keep hitting the old hostname.

## Apply order

1. Merge + apply [cardstack/infra#665](https://github.com/cardstack/infra/pull/665) → \`boxel-observability-apply\` role exists in the staging account.
2. Land the boxel-side stack: #4529 → #4533 → #4535 → this PR.
3. First push to main touching \`packages/observability/**\` triggers the workflow. Or smoke-test via \`workflow_dispatch\` from the Actions UI.
4. If step 1 hasn't happened: the \`Configure AWS credentials\` step fails with an OIDC error — visible, contained, no silent over-permissioning.

## Test plan

Once CS-10922 merges and brings real dashboards into \`packages/observability/grafanactl/resources/\`:

- [ ] Manually \`workflow_dispatch\` once to confirm OIDC + checksum verify + SSM + apply succeed end-to-end against staging.
- [ ] Touch any file under \`packages/observability/**\` in a follow-up PR; confirm the workflow runs on merge to main.
- [ ] Touch any file outside \`packages/observability/**\`; confirm the workflow does NOT run.
- [ ] Mid-flight: kick off two consecutive merges; confirm the second blocks until the first finishes (concurrency).
- [ ] Pre-flight: confirm \`boxel-observability-apply\` role exists — otherwise the credentials step 401s.
- [ ] Tamper test (optional): bump \`GRAFANACTL_VERSION\` to a value with a mismatched/missing checksum; confirm the install step fails before \`grafanactl --version\` runs.

## Linear

- Closes [CS-10932](https://linear.app/cardstack/issue/CS-10932/github-actions-workflow-apply-to-self-host-staging-on-merge)
- Will benefit from [CS-10959](https://linear.app/cardstack/issue/CS-10959/add-lint-scripts-for-packagesobservability) (lint step before push) once that ticket lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)