### PR TITLE
CS-10933: PR diff comment workflow + scripts/diff.sh

### DIFF
--- a/.github/workflows/observability-diff.yml
+++ b/.github/workflows/observability-diff.yml
@@ -1,0 +1,175 @@
+name: Observability — diff against staging
+
+# Runs on PRs touching packages/observability/** and posts a sticky comment
+# showing the diff between the PR's committed dashboards/folders and the
+# live state of the staging Grafana. Mirrors the existing terraform-plan
+# comment workflow.
+#
+# CS-10933 — implements the "Path B" diff (pull-to-tempdir + git-diff)
+# because grafanactl has no native `resources diff` subcommand. See
+# packages/observability/scripts/diff.sh for the rendering logic.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "packages/observability/**"
+      - ".github/workflows/observability-diff.yml"
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  # Cancel an in-flight diff when a new push lands on the same PR — diff is
+  # cheap and we always want the comment to reflect the latest commit.
+  group: observability-diff-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  diff:
+    name: Diff against staging
+    runs-on: ubuntu-latest
+
+    env:
+      AWS_REGION: us-east-1
+      # Reuses the apply role from cardstack/infra#665. Permission is
+      # `ssm:GetParameter` on /staging/grafana/grafanactl_token only —
+      # which is what the diff workflow needs (read the token, then use
+      # it to pull dashboards/folders from staging Grafana).
+      AWS_ROLE_ARN: arn:aws:iam::680542703984:role/boxel-observability-apply
+      GRAFANACTL_VERSION: "0.7.0"
+      DIFF_MARKER: "<!-- observability-diff -->"
+      MAX_COMMENT_BYTES: 60000
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install grafanactl
+        # Same SHA-256 verified install as the apply workflows.
+        run: |
+          set -euo pipefail
+          TARBALL="grafanactl_${GRAFANACTL_VERSION}_linux_amd64.tar.gz"
+          RELEASE_URL="https://github.com/grafana/grafanactl/releases/download/v${GRAFANACTL_VERSION}"
+          TMPDIR="$(mktemp -d)"
+          trap 'rm -rf "$TMPDIR"' EXIT
+
+          curl -fsSL "${RELEASE_URL}/${TARBALL}"    -o "${TMPDIR}/${TARBALL}"
+          curl -fsSL "${RELEASE_URL}/checksums.txt" -o "${TMPDIR}/checksums.txt"
+
+          ( cd "$TMPDIR" && grep " ${TARBALL}\$" checksums.txt | sha256sum -c - )
+
+          tar -xzf "${TMPDIR}/${TARBALL}" -C "$TMPDIR" grafanactl
+          sudo install -m 0755 "${TMPDIR}/grafanactl" /usr/local/bin/grafanactl
+          grafanactl --version
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Source GRAFANA_TOKEN from SSM
+        run: |
+          GRAFANA_TOKEN="$(aws ssm get-parameter \
+            --name /staging/grafana/grafanactl_token \
+            --with-decryption \
+            --query 'Parameter.Value' \
+            --output text)"
+          echo "::add-mask::$GRAFANA_TOKEN"
+          echo "GRAFANA_TOKEN=$GRAFANA_TOKEN" >> "$GITHUB_ENV"
+
+      - name: Compute diff
+        id: diff
+        working-directory: packages/observability
+        run: |
+          set -eo pipefail
+          DIFF_FILE="$(mktemp)"
+          ./scripts/diff.sh --env staging > "$DIFF_FILE"
+          # Persist the diff path for the next step (raw stdout via $GITHUB_OUTPUT
+          # has multi-line / size limits we want to handle in JS instead).
+          echo "diff_file=$DIFF_FILE" >> "$GITHUB_OUTPUT"
+          # Print to the run log too so the diff is visible without expanding
+          # the PR comment.
+          echo "::group::Computed diff"
+          cat "$DIFF_FILE"
+          echo "::endgroup::"
+
+      - name: Post sticky PR comment
+        uses: actions/github-script@v7
+        env:
+          DIFF_FILE: ${{ steps.diff.outputs.diff_file }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = process.env.DIFF_MARKER;
+            const maxBytes = parseInt(process.env.MAX_COMMENT_BYTES, 10);
+
+            const diff = fs.readFileSync(process.env.DIFF_FILE, 'utf8');
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            let body;
+            if (!diff.trim()) {
+              body = [
+                marker,
+                '## Observability diff (vs staging)',
+                '',
+                'No dashboard / folder changes detected against the staging Grafana.',
+                '',
+                `_(Run: ${runUrl})_`,
+              ].join('\n');
+            } else if (diff.length > maxBytes) {
+              const truncated = diff.slice(0, maxBytes);
+              body = [
+                marker,
+                '## Observability diff (vs staging)',
+                '',
+                `Diff truncated (${diff.length} bytes; limit ${maxBytes}). Full diff: ${runUrl}`,
+                '',
+                '```diff',
+                truncated,
+                '```',
+              ].join('\n');
+            } else {
+              body = [
+                marker,
+                '## Observability diff (vs staging)',
+                '',
+                '```diff',
+                diff,
+                '```',
+                '',
+                `_(Run: ${runUrl})_`,
+              ].join('\n');
+            }
+
+            // Find existing sticky comment.
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              (c) => c.body && c.body.startsWith(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated sticky comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+              core.info('Created sticky comment');
+            }

--- a/.github/workflows/observability-diff.yml
+++ b/.github/workflows/observability-diff.yml
@@ -32,6 +32,14 @@ jobs:
     name: Diff against staging
     runs-on: ubuntu-latest
 
+    # Skip on fork PRs. The job assumes an AWS role and fetches a Grafana
+    # service-account token from SSM, both of which are unsafe to expose
+    # to a workflow whose code is controlled by an untrusted contributor.
+    # GitHub-hosted runners on fork PRs also get reduced token permissions
+    # (no `pull-requests: write`), so the comment-posting step would fail
+    # anyway. Same guard pattern as preview-host.yml elsewhere in the repo.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
     env:
       AWS_REGION: us-east-1
       # Reuses the apply role from cardstack/infra#665. Permission is
@@ -85,7 +93,10 @@ jobs:
           echo "::endgroup::"
 
       - name: Post sticky PR comment
-        uses: actions/github-script@v7
+        # Pinned to SHA (rather than @v7) because this step has
+        # pull-requests: write and runs after assuming an AWS role —
+        # supply-chain risk is non-negligible.
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           DIFF_FILE: ${{ steps.diff.outputs.diff_file }}
         with:
@@ -95,6 +106,10 @@ jobs:
             const maxBytes = parseInt(process.env.MAX_COMMENT_BYTES, 10);
 
             const diff = fs.readFileSync(process.env.DIFF_FILE, 'utf8');
+            // Use byte length, not character/code-unit length, since
+            // GitHub's comment limit is in bytes and dashboard JSON
+            // can include non-ASCII characters in titles/descriptions.
+            const diffBytes = Buffer.byteLength(diff, 'utf8');
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             let body;
@@ -107,13 +122,19 @@ jobs:
                 '',
                 `_(Run: ${runUrl})_`,
               ].join('\n');
-            } else if (diff.length > maxBytes) {
-              const truncated = diff.slice(0, maxBytes);
+            } else if (diffBytes > maxBytes) {
+              // Truncate by bytes, not characters. Walk back from a
+              // character boundary so we don't slice mid-codepoint and
+              // produce invalid UTF-8.
+              const buf = Buffer.from(diff, 'utf8');
+              let cut = maxBytes;
+              while (cut > 0 && (buf[cut] & 0xc0) === 0x80) cut--;
+              const truncated = buf.slice(0, cut).toString('utf8');
               body = [
                 marker,
                 '## Observability diff (vs staging)',
                 '',
-                `Diff truncated (${diff.length} bytes; limit ${maxBytes}). Full diff: ${runUrl}`,
+                `Diff truncated (${diffBytes} bytes; limit ${maxBytes}). Full diff: ${runUrl}`,
                 '',
                 '```diff',
                 truncated,
@@ -132,13 +153,18 @@ jobs:
               ].join('\n');
             }
 
-            // Find existing sticky comment.
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              per_page: 100,
-            });
+            // Find existing sticky comment. Paginate so we don't miss
+            // the marker on PRs with >100 comments (would otherwise
+            // create duplicates on every push).
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              }
+            );
             const existing = comments.find(
               (c) => c.body && c.body.startsWith(marker)
             );

--- a/.github/workflows/observability-diff.yml
+++ b/.github/workflows/observability-diff.yml
@@ -39,7 +39,7 @@ jobs:
       # which is what the diff workflow needs (read the token, then use
       # it to pull dashboards/folders from staging Grafana).
       AWS_ROLE_ARN: arn:aws:iam::680542703984:role/boxel-observability-apply
-      GRAFANACTL_VERSION: "0.7.0"
+      GRAFANACTL_VERSION: "0.1.10"
       DIFF_MARKER: "<!-- observability-diff -->"
       MAX_COMMENT_BYTES: 60000
 
@@ -48,22 +48,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install grafanactl
-        # Same SHA-256 verified install as the apply workflows.
-        run: |
-          set -euo pipefail
-          TARBALL="grafanactl_${GRAFANACTL_VERSION}_linux_amd64.tar.gz"
-          RELEASE_URL="https://github.com/grafana/grafanactl/releases/download/v${GRAFANACTL_VERSION}"
-          TMPDIR="$(mktemp -d)"
-          trap 'rm -rf "$TMPDIR"' EXIT
-
-          curl -fsSL "${RELEASE_URL}/${TARBALL}"    -o "${TMPDIR}/${TARBALL}"
-          curl -fsSL "${RELEASE_URL}/checksums.txt" -o "${TMPDIR}/checksums.txt"
-
-          ( cd "$TMPDIR" && grep " ${TARBALL}\$" checksums.txt | sha256sum -c - )
-
-          tar -xzf "${TMPDIR}/${TARBALL}" -C "$TMPDIR" grafanactl
-          sudo install -m 0755 "${TMPDIR}/grafanactl" /usr/local/bin/grafanactl
-          grafanactl --version
+        uses: ./.github/actions/install-grafanactl
+        with:
+          version: ${{ env.GRAFANACTL_VERSION }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0

--- a/packages/observability/scripts/diff.sh
+++ b/packages/observability/scripts/diff.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# diff.sh — Show the diff between this package's committed
+# `grafanactl/resources/` state and the live state of a target Grafana
+# environment. Used by CS-10933's PR comment workflow + ad-hoc by humans
+# wanting a preview before a `./scripts/apply.sh` push.
+#
+# Usage:
+#   ./scripts/diff.sh [--env local|staging|production]
+#
+# Output: human-readable diff on stdout. Empty output (and exit 0) means
+# the committed state matches the live state.
+#
+# Scope: this only diffs the resources grafanactl manages — dashboards
+# and folders. The `provisioning/` tree (data sources, alert rules) is
+# delivered to Grafana via file mount at startup, not via API push, so
+# there's no live "current state" to diff against from the outside. PR
+# review of those YAMLs is the only check.
+#
+# CS-10933 chose this "Path B" implementation because grafanactl has
+# no native `diff` subcommand — confirmed by `grafanactl resources --help`.
+set -eo pipefail
+
+usage_error() { echo "error: $1" >&2; exit 2; }
+
+env_name=staging
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env)
+      [[ $# -ge 2 && "$2" != --* ]] || usage_error "missing value for --env"
+      env_name="$2"
+      shift 2
+      ;;
+    --env=*)
+      env_name="${1#--env=}"
+      [[ -n "$env_name" ]] || usage_error "missing value for --env"
+      shift
+      ;;
+    *)
+      usage_error "unknown option: $1"
+      ;;
+  esac
+done
+
+cd "$(dirname "$0")/.."
+
+# shellcheck source=./grafanactl-env.sh
+source ./scripts/grafanactl-env.sh "$env_name"
+
+cfg="$(./scripts/render-config.sh "$env_name")"
+remote="$(mktemp -d -t grafanactl-pull.XXXXXX)"
+trap 'rm -rf "$cfg" "$remote"' EXIT
+
+# Pull what's currently live into the tempdir. Suppress stdout so the
+# user sees only the diff at the end; stderr (errors) still surface.
+grafanactl \
+  --config "$cfg" \
+  --context "$env_name" \
+  resources pull \
+  --path "$remote" \
+  >/dev/null
+
+# Diff: <remote-current-state> → <committed-target>. Reading top-to-bottom
+# in the diff shows what would CHANGE if we applied the committed state.
+# Color is disabled because the diff is consumed by GitHub Actions or piped
+# to a PR comment (terminal escapes don't render in either).
+#
+# `|| true`: git diff --no-index returns 1 when there's any diff. We treat
+# that as expected output, not an error — the diff IS the output.
+git diff \
+  --no-index \
+  --no-color \
+  "$remote" \
+  ./grafanactl/resources/ \
+  || true

--- a/packages/observability/scripts/diff.sh
+++ b/packages/observability/scripts/diff.sh
@@ -50,12 +50,21 @@ cfg="$(./scripts/render-config.sh "$env_name")"
 remote="$(mktemp -d -t grafanactl-pull.XXXXXX)"
 trap 'rm -rf "$cfg" "$remote"' EXIT
 
-# Pull what's currently live into the tempdir. Suppress stdout so the
-# user sees only the diff at the end; stderr (errors) still surface.
+# Pull what's currently live into the tempdir. We pass explicit kind
+# arguments (`dashboards folders`) instead of letting grafanactl
+# enumerate everything because the default scan would also try to list
+# `plugins.grafana.app` (the service-account token doesn't have
+# permission — 403) and `features.grafana.app/noop` (404, doesn't exist
+# on the Grafana version we run). Both warnings would fail the pull
+# even though we don't actually want those kinds for the diff.
+#
+# Suppress stdout so the user sees only the diff at the end; stderr
+# (errors) still surface.
 grafanactl \
   --config "$cfg" \
   --context "$env_name" \
   resources pull \
+  dashboards folders \
   --path "$remote" \
   >/dev/null
 

--- a/packages/observability/scripts/diff.sh
+++ b/packages/observability/scripts/diff.sh
@@ -73,11 +73,23 @@ grafanactl \
 # Color is disabled because the diff is consumed by GitHub Actions or piped
 # to a PR comment (terminal escapes don't render in either).
 #
-# `|| true`: git diff --no-index returns 1 when there's any diff. We treat
-# that as expected output, not an error — the diff IS the output.
+# Exit codes from `git diff --no-index`:
+#   0 — files identical (committed == live)
+#   1 — files differ — the diff IS the output, treat as success here
+#   2+ — real error (unreadable paths, internal git error, etc.) — propagate
+#
+# Disable -e around the diff call so exit 1 doesn't kill the script, then
+# explicitly check for 2+ and re-raise.
+set +e
 git diff \
   --no-index \
   --no-color \
   "$remote" \
-  ./grafanactl/resources/ \
-  || true
+  ./grafanactl/resources/
+diff_exit=$?
+set -e
+
+if [[ "$diff_exit" -gt 1 ]]; then
+  echo "git diff --no-index exited with $diff_exit (real error, not just a diff)" >&2
+  exit "$diff_exit"
+fi


### PR DESCRIPTION
> **Stacked on PR #4542** ([cs-10936-production-apply-workflow](https://github.com/cardstack/boxel/pull/4542)) → which is stacked on the rest of the chain. Review/merge those first.
>
> **Draft until staging apply (#4538) is verified working post-merge** — the diff workflow pulls from staging Grafana, so it needs the staging side ready first.

## Summary

When a PR touches \`packages/observability/**\`, post a sticky comment showing the diff between the committed \`grafanactl/resources/\` state and the live state of staging Grafana. Mirrors the existing terraform-plan-comment pattern that the repo uses for infra changes.

This was [Path B in CS-10933's design](https://linear.app/cardstack/issue/CS-10933) — grafanactl has no native \`resources diff\` subcommand (verified via \`grafanactl resources --help\`), so we implement the equivalent: pull live state to a tempdir, \`git diff --no-index\` against the committed tree.

## Files added

- **\`packages/observability/scripts/diff.sh\`** — pulls live grafanactl resources to a tempdir, diffs against committed \`./grafanactl/resources/\`. Empty output (and exit 0) = committed equals live.
- **\`.github/workflows/observability-diff.yml\`** — PR trigger, paths filter on \`packages/observability/**\`, reuses the staging \`boxel-observability-apply\` role, posts a sticky comment with the diff (or "no changes" if empty), truncates at 60KB.

## Scope of the diff

The diff is limited to **grafanactl-managed kinds**: dashboards and folders. The \`provisioning/\` tree (data sources, alert rules) is delivered to Grafana via file mount at startup, not API push — so there's no "live state" to diff against from the outside. PR review of those YAMLs is the only check for that tree.

This is documented inline in \`diff.sh\` so future maintainers don't try to extend the diff to provisioning/ without realizing the architecture mismatch.

## Sticky comment

- Marker: \`<!-- observability-diff -->\` at the top of the comment body.
- On each push: list comments, find one starting with marker, update if exists else create.
- Concurrency group is per-PR with \`cancel-in-progress: true\` — older runs cancel when a new push lands, so the comment always reflects the latest commit.
- Diff is also printed to the run log inside a collapsible \`::group::\` so reviewers can read it without expanding the comment.

## Truncation

GitHub PR comments cap at ~64KB. We truncate at 60KB and append a link to the run details for the full diff. Most observability PRs will be well under this — the synapse dashboard is the only resource large enough to risk overflow, and it changes rarely (vendored from upstream Synapse).

## IAM

Reuses \`arn:aws:iam::680542703984:role/boxel-observability-apply\` (the staging apply role from cardstack/infra#665). The role has \`ssm:GetParameter\` on \`/staging/grafana/grafanactl_token\` only — same scope a diff needs.

Note: the staging Grafana service-account token has Admin role, so technically the diff workflow could push instead of pull (it's just a question of which subcommand we invoke). The boundary between "diff" and "apply" is enforced by the workflow YAML, not by the token's permissions. A separate read-only Grafana service account would be tighter; deferred as a possible follow-up if it becomes valuable.

## Test plan

After staging-apply (#4538) is verified working post-merge:

- [ ] PR touching \`packages/observability/grafanactl/resources/dashboards/\`: comment appears showing the dashboard diff (or "No changes" if the committed state matches what was last applied to staging).
- [ ] Subsequent push to the same PR: existing comment updates in place (no new comment).
- [ ] PR touching only \`packages/observability/scripts/\`: workflow runs but the diff is empty (no resource changes) — comment says "No changes detected".
- [ ] PR touching only \`provisioning/\`: workflow runs, diff is empty (provisioning tree isn't grafanactl-managed). Comment notes the limitation… actually the comment just says "no dashboard/folder changes" which is true. The reviewer is responsible for diffing provisioning/ via the regular GitHub file diff.
- [ ] Forks: TBD — \`pull-requests: write\` permission has limited scope on fork PRs. cardstack/boxel rarely takes fork contributions; if it becomes an issue we add a fork-detection branch.
- [ ] Long diff (Synapse-dashboard scale): truncates at 60KB with a link to the run.

## Linear

- Closes [CS-10933](https://linear.app/cardstack/issue/CS-10933/pr-workflow-post-dashboard-diff-as-a-pr-comment)
- Will benefit from [CS-10959](https://linear.app/cardstack/issue/CS-10959/add-lint-scripts-for-packagesobservability) (lint step before diff) once that ticket lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)