### PR TITLE
Retry memory baseline push on rejection

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -424,6 +424,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Need history past the triggering SHA so the staleness check below
+          # can inspect commits between the workflow's SHA and origin/main.
+          fetch-depth: 0
       - uses: ./.github/actions/init
 
       - name: Download memory reports
@@ -434,16 +438,33 @@ jobs:
           merge-multiple: true
 
       - name: Update memory baseline
-        # Retry with rebase: another PR may merge to main while host CI is
-        # running (~15+ min), causing `git push` to be rejected. We re-run
-        # the merge-aware script against the freshest tip-of-main on each
-        # attempt so prior-baseline preservation stays correct.
+        # Retry from the latest main: another PR may merge to main while host
+        # CI is running (~15+ min), causing `git push` to be rejected. On each
+        # retry we fetch and hard-reset to the freshest tip-of-main, then
+        # re-run the merge-aware script so prior-baseline preservation stays
+        # correct.
+        #
+        # Staleness guard: if a non-baseline commit landed on main since this
+        # workflow was triggered, skip — that newer push triggered its own CI
+        # run which will publish a baseline derived from its own code. We
+        # ignore intervening `[skip ci]` baseline-update commits from this
+        # same job because those don't represent newer code, just concurrent
+        # baseline updates that the merge-aware script handles correctly.
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          WORKFLOW_SHA="${{ github.sha }}"
+
           for attempt in 1 2 3 4 5; do
             git fetch origin main
+
+            if [ "$(git rev-parse origin/main)" != "$WORKFLOW_SHA" ] && \
+               git log --format="%s" "$WORKFLOW_SHA..origin/main" | grep -qv "Update host test memory baseline"; then
+              echo "main has advanced past $WORKFLOW_SHA with non-baseline commits — skipping (a newer CI run will publish the baseline)."
+              exit 0
+            fi
+
             git reset --hard origin/main
 
             node packages/host/scripts/update-memory-baseline.mjs all-memory-reports packages/host/memory-baseline.json

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -434,14 +434,31 @@ jobs:
           merge-multiple: true
 
       - name: Update memory baseline
+        # Retry with rebase: another PR may merge to main while host CI is
+        # running (~15+ min), causing `git push` to be rejected. We re-run
+        # the merge-aware script against the freshest tip-of-main on each
+        # attempt so prior-baseline preservation stays correct.
         run: |
-          node packages/host/scripts/update-memory-baseline.mjs all-memory-reports packages/host/memory-baseline.json
-          if git diff --quiet packages/host/memory-baseline.json; then
-            echo "Baseline unchanged — nothing to commit."
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          for attempt in 1 2 3 4 5; do
+            git fetch origin main
+            git reset --hard origin/main
+
+            node packages/host/scripts/update-memory-baseline.mjs all-memory-reports packages/host/memory-baseline.json
+            if git diff --quiet packages/host/memory-baseline.json; then
+              echo "Baseline unchanged — nothing to commit."
+              exit 0
+            fi
             git add packages/host/memory-baseline.json
             git commit -m "Update host test memory baseline [skip ci]"
-            git push
-          fi
+
+            if git push; then
+              exit 0
+            fi
+            echo "Push rejected on attempt $attempt — retrying after $((attempt * 5))s"
+            sleep $((attempt * 5))
+          done
+          echo "Failed to push memory baseline after 5 attempts"
+          exit 1


### PR DESCRIPTION
## Summary
- The `Update Host Memory Baseline` job in `ci-host.yaml` fails when another PR merges to `main` during the ~15+ min host-test run, because the final `git push` is rejected with `[rejected] main -> main (fetch first)`. Example: [run 25020630883](https://github.com/cardstack/boxel/actions/runs/25020630883/job/73284648375).
- Wraps the step in a 5-attempt retry loop that `git fetch` + `git reset --hard origin/main` and re-runs `update-memory-baseline.mjs` against the freshest tip before each attempt. Re-running the script is required for correctness — it preserves prior-baseline values for shards that didn't upload, so the merge needs the latest baseline as input.

## Test plan
- [ ] Merge and watch the next push-to-main host CI run; the `Update Host Memory Baseline` job should succeed (likely on attempt 1 unless concurrent merges land).
- [ ] If a concurrent merge does happen, confirm logs show the retry kicked in and the second attempt pushed successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)