### PR TITLE
host tests: wait for command-apply button + add flake diagnostics

### DIFF
--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -635,7 +635,47 @@ module('Acceptance | Commands tests', function (hooks) {
     await click('[data-test-open-ai-assistant]');
     await waitFor('[data-room-settled]');
 
-    await click('[data-test-message-idx="1"] [data-test-command-apply]');
+    // The aibot message is delivered via the mock-matrix listener which pushes
+    // it through a 100ms-debounced drain. data-room-settled only tracks
+    // loadAllTimelineEvents, so the second message can lag behind the settled
+    // marker. Wait for the apply button to actually be in the DOM before
+    // clicking, and dump diagnostics if it never shows up so future flakes
+    // are debuggable.
+    let applySelector = '[data-test-message-idx="1"] [data-test-command-apply]';
+    try {
+      await waitFor(applySelector, { timeout: 10_000 });
+    } catch (err) {
+      let messageIdxs = findAll('[data-test-message-idx]').map((el) =>
+        el.getAttribute('data-test-message-idx'),
+      );
+      let applyButtons = findAll('[data-test-command-apply]').map((el) =>
+        el.getAttribute('data-test-command-apply'),
+      );
+      let roomEventsSummary = getRoomEvents(roomId).map((e) => ({
+        eventId: e.event_id,
+        type: e.type,
+        sender: e.sender,
+        msgtype: (e.content as any)?.msgtype,
+        hasCommandRequests: Array.isArray(
+          (e.content as any)?.[APP_BOXEL_COMMAND_REQUESTS_KEY],
+        ),
+      }));
+      console.error(
+        '[scripted-command-test] apply button never rendered. Diagnostic:',
+        JSON.stringify(
+          {
+            roomId,
+            renderedMessageIdxs: messageIdxs,
+            renderedApplyButtonStates: applyButtons,
+            roomEvents: roomEventsSummary,
+          },
+          null,
+          2,
+        ),
+      );
+      throw err;
+    }
+    await click(applySelector);
     await waitUntil(
       () => findAll('[data-test-operator-mode-stack]').length === 2,
     );


### PR DESCRIPTION
## Summary

The acceptance test `Acceptance | Commands tests: a scripted command can create a card, update it and show it` recently flaked again in CI ([run 25022456851](https://github.com/cardstack/boxel/actions/runs/25022456851/job/73286957191?pr=4540)) with:

```
Error: Element not found when calling \`click('[data-test-message-idx="1"] [data-test-command-apply]')\`
```

This is a different race than the one fixed in #4536 — that PR fixed the early read of \`getRoomEvents(roomId).pop()\`; this PR fixes the click that happens later in the same test.

## Root cause

The simulated aibot message reaches the room via two paths:

1. \`loadAllTimelineEvents\` — pagination, drained synchronously inside the load function. Tracked by \`timelineLoadingState\`, which feeds \`data-room-settled\`.
2. The mock-matrix listener — every server-side \`addRoomEvent\` fires via \`setTimeout(0)\` into \`matrix-service.onTimeline\`, which **debounces** \`drainTimeline\` by 100 ms. Not tracked by \`isLoadingTimeline\`.

If \`loadAllTimelineEvents\` finishes pagination before that debounced drain runs, \`data-room-settled\` flips to \`true\` while message idx=1 is still pending in \`timelineQueue\`. The bare \`click('[data-test-message-idx="1"] [data-test-command-apply]')\` then races against a button that hasn't rendered yet.

## Fix

- Wait for the apply button to actually exist in the DOM (\`waitFor(applySelector, { timeout: 10_000 })\`) before clicking. This polls past the 100 ms debounce window regardless of which path delivers the event.
- On timeout, dump diagnostics to \`console.error\` (rendered \`data-test-message-idx\` values, all rendered apply-button states, the room id, and an event summary including type/sender/msgtype/has-command-requests). The output lands in the QUnit \`browser log\` block, the same place the original \`Element not found\` error was reported, so any future flake tells us *what* was actually in the DOM and *what* events the room thinks it has.

## Test plan

- [ ] CI green on this branch
- [ ] (manual, optional) Re-run the host shard a few times to confirm the test no longer flakes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)