### PR TITLE
prerender test patch: cancel delayed search on restore

### DIFF
--- a/packages/realm-server/tests/helpers/prerender-page-patches.ts
+++ b/packages/realm-server/tests/helpers/prerender-page-patches.ts
@@ -135,6 +135,11 @@ export function installDelayedRuntimeRealmSearchPatch(delayMs: number): {
   // prerender waited for query resolution instead of "winning a race" by chance.
   let originalSearch = RuntimeRealm.prototype.search;
   let delayedSearchRequestCount = 0;
+  let restored = false;
+  // Sleeps that have not yet resolved. On restore() we wake them early so
+  // they skip the underlying search; otherwise a long delay (e.g. 8s) can
+  // outlive the realm/db fixture and the resumed call hits a closed pg pool.
+  let pendingSleepCancels = new Set<() => void>();
 
   RuntimeRealm.prototype.search = async function (
     this: RuntimeRealm,
@@ -142,13 +147,41 @@ export function installDelayedRuntimeRealmSearchPatch(delayMs: number): {
   ): Promise<Awaited<ReturnType<RuntimeRealm['search']>>> {
     // Exposed to tests as a stable signal that fallback search actually ran.
     delayedSearchRequestCount++;
-    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    await new Promise<void>((resolve) => {
+      let timer: ReturnType<typeof setTimeout>;
+      let wake = () => {
+        pendingSleepCancels.delete(wake);
+        clearTimeout(timer);
+        resolve();
+      };
+      pendingSleepCancels.add(wake);
+      timer = setTimeout(wake, delayMs);
+    });
+    if (restored) {
+      // The patch has been torn down — the test no longer cares about this
+      // search and the realm fixture (including its pg pool) may already be
+      // closed. Return an empty collection rather than reaching into a
+      // potentially-dead adapter; the caller (handle-search/searchRealms)
+      // will discard the result.
+      return {
+        data: [],
+        meta: { page: { total: 0 } },
+      } as Awaited<ReturnType<RuntimeRealm['search']>>;
+    }
     return await originalSearch.call(this, query);
   };
 
   return {
     getRequestCount: () => delayedSearchRequestCount,
     restore: () => {
+      restored = true;
+      // Wake any in-flight sleepers immediately; the `restored` guard above
+      // makes them skip originalSearch() so they don't query a closed pool.
+      let cancels = [...pendingSleepCancels];
+      pendingSleepCancels.clear();
+      for (let wake of cancels) {
+        wake();
+      }
       RuntimeRealm.prototype.search = originalSearch;
     },
   };


### PR DESCRIPTION
## Summary

Fixes the `Cannot use a pool after calling end on the pool` console.error noise that appears mid-suite in `prerendering-test.ts` (e.g. PR #4541 [shard 3](https://github.com/cardstack/boxel/actions/runs/25024236026/job/73291982380?pr=4541)). The error is unrelated to the PR it surfaces in — same code shape exists on `main`.

### The race

`installDelayedRuntimeRealmSearchPatch(delayMs)` wraps `RuntimeRealm.prototype.search` with a fixed `setTimeout` before calling the original search. The test at `prerendering-test.ts:1577` ("card prerender timeout surfaces query-field and linked-field load timings in diagnostics") pairs an 8s search delay with a 2s prerender timeout:

1. Patched `search()` starts an 8s `setTimeout`.
2. Prerender times out at 2s; test asserts diagnostics; `finally` calls `delayedSearchPatch.restore()`.
3. `restore()` swaps the prototype back, but the in-flight 8s setTimeout still holds a closure reference to `originalSearch` and the realm.
4. Module's `after` teardown closes the `dbAdapter` (`pool.end()`).
5. ~6s later (during the next module's tests) the timer fires, `originalSearch.call(this, query)` runs, reaches `IndexQueryEngine` → `PgAdapter.execute` → `pool.connect()` on a closed pool → noisy console.error.

### Fix

Track every in-flight sleeper. On `restore()`:
- Wake the sleepers immediately (so we don't leak a dangling promise into `searchRealms`).
- A `restored` guard makes the resumed search return an empty collection instead of touching the now-dead adapter — the caller (`handle-search` / `searchRealms`) already moved on so the result is discarded.

## Test plan

- [ ] `prerendering-test.ts > prerender - non-mutating tests` runs clean (no `Cannot use a pool after calling end on the pool` log lines)
- [ ] The 8s-delay test ("card prerender timeout surfaces query-field…") still asserts a non-empty `queryLoadsInFlight`/`recentQueryLoads` (the patched search's request count is still incremented before the sleep)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)