### PR TITLE
Install git in realm-server image so catalog content syncs on deploy

### DIFF
--- a/packages/realm-server/realm-server.Dockerfile
+++ b/packages/realm-server/realm-server.Dockerfile
@@ -6,7 +6,7 @@ ENV realm_server_script=$realm_server_script
 
 WORKDIR /realm-server
 
-RUN apt-get update && apt-get install -y ca-certificates curl unzip postgresql jq rsync
+RUN apt-get update && apt-get install -y ca-certificates curl unzip postgresql jq rsync git
 RUN npm install -g pnpm@10.30.0
 
 COPY pnpm-lock.yaml ./


### PR DESCRIPTION
## Summary
- The realm-server runtime image was missing `git`, so `pnpm catalog:setup` failed on every production/staging boot when trying to clone `boxel-catalog` (both SSH and HTTPS fall through to a `git: not found` error).
- Because the chained `rsync --delete ../catalog/contents/. /persistent/catalog/` ran with a non-existent source, the rsync never executed. The realm server booted against the stale `/persistent/catalog/` EFS volume — which is why files removed from `boxel-catalog` continued to appear in the `/catalog/` realm in production.
- Fix: add `git` to the apt-get install in `packages/realm-server/realm-server.Dockerfile`. With git available, `catalog:setup` HTTPS-clones the public `boxel-catalog` repo on first boot, `catalog-update.sh` keeps it current, and the existing `rsync --delete` properly mirrors the source. The on-startup `fullIndex` then tombstones the deleted files in `boxel_index` automatically — no manual EFS or DB cleanup needed.

Reproduced via `ecsgo` into the production realm-server task:
<img width="1339" height="135" alt="Screenshot 2026-04-28 at 1 21 39 PM" src="https://github.com/user-attachments/assets/4d1be6c1-fa6b-44cc-9435-1f4eb3a03edb" />
