### PR TITLE
allow collecting binary file for submission

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -171,6 +171,15 @@ export class WriteBinaryFileResult extends CardDef {
   @field fileUrl = contains(StringField);
 }
 
+export class ReadBinaryFileInput extends CardDef {
+  @field url = contains(StringField);
+}
+
+export class ReadBinaryFileResult extends CardDef {
+  @field base64Content = contains(StringField);
+  @field contentType = contains(StringField);
+}
+
 export class GenerateThumbnailInput extends CardDef {
   @field prompt = contains(StringField);
   @field sourceImageUrl = contains(StringField);

--- a/packages/bot-runner/lib/command-runner.ts
+++ b/packages/bot-runner/lib/command-runner.ts
@@ -1,4 +1,5 @@
 import {
+  BINARY_FILE_EXTENSIONS,
   isBotCommandFilter,
   logger,
   param,
@@ -147,10 +148,18 @@ export class CommandRunner {
           throw new Error(errorMessage);
         }
 
-        // Extract allFileContents from the result
+        // Extract allFileContents from the result, separating binary files
+        // so they bypass the PrCard 512KB size limit.
         let allFileContents = extractFileContents(filesResult.cardResultString);
+        let binaryFileContents = allFileContents.filter((f) =>
+          isBinaryFilename(f.filename),
+        );
+        let textFileContents = allFileContents.filter(
+          (f) => !isBinaryFilename(f.filename),
+        );
         log.info('pr-listing-create: files collected', {
           fileCount: allFileContents.length,
+          binaryCount: binaryFileContents.length,
         });
 
         // Step 1.5: Lint & auto-fix collected files
@@ -313,7 +322,7 @@ export class CommandRunner {
               branchName,
               submittedBy: runAs,
               prSummary,
-              allFileContents,
+              allFileContents: textFileContents,
             },
           });
 
@@ -346,6 +355,10 @@ export class CommandRunner {
           await this.createListingPRHandler.addContentsToCommit(
             eventContent,
             prCardResult,
+            binaryFileContents.map((f) => ({
+              path: f.filename,
+              content: f.contents,
+            })),
           );
           let prResult = await this.createListingPRHandler.openCreateListingPR(
             eventContent,
@@ -489,6 +502,13 @@ function getCardUrl(cardResultString?: string | null): string | null {
   } catch {
     return null;
   }
+}
+
+
+
+function isBinaryFilename(filename: string): boolean {
+  let ext = filename.slice(filename.lastIndexOf('.')).toLowerCase();
+  return BINARY_FILE_EXTENSIONS.has(ext);
 }
 
 function extractFileContents(

--- a/packages/bot-runner/lib/command-runner.ts
+++ b/packages/bot-runner/lib/command-runner.ts
@@ -1,5 +1,4 @@
 import {
-  BINARY_FILE_EXTENSIONS,
   isBotCommandFilter,
   logger,
   param,
@@ -11,6 +10,7 @@ import {
   type RunCommandResponse,
 } from '@cardstack/runtime-common';
 import { enqueueRunCommandJob } from '@cardstack/runtime-common/jobs/run-command';
+import { isBinaryFilename } from '@cardstack/runtime-common/infer-content-type';
 import {
   CreateListingPRHandler,
   type BotTriggerEventContent,
@@ -505,11 +505,6 @@ function getCardUrl(cardResultString?: string | null): string | null {
 }
 
 
-
-function isBinaryFilename(filename: string): boolean {
-  let ext = filename.slice(filename.lastIndexOf('.')).toLowerCase();
-  return BINARY_FILE_EXTENSIONS.has(ext);
-}
 
 function extractFileContents(
   cardResultString?: string | null,

--- a/packages/bot-runner/lib/create-listing-pr-handler.ts
+++ b/packages/bot-runner/lib/create-listing-pr-handler.ts
@@ -109,6 +109,7 @@ export class CreateListingPRHandler {
   async addContentsToCommit(
     eventContent: BotTriggerEventContent,
     runCommandResult?: RunCommandResponse | null,
+    binaryFiles?: { path: string; content: string }[],
   ): Promise<void> {
     let context = getCreateListingPRContext(eventContent);
     if (!context) {
@@ -117,20 +118,27 @@ export class CreateListingPRHandler {
     let rawFiles = await getContentsFromRealm(
       runCommandResult?.cardResultString,
     );
-    if (rawFiles.length === 0) {
-      return;
-    }
     let folderName = buildSubmissionFolderName(context);
-    let files = rawFiles.map((file) => ({
+    let textFiles = rawFiles.map((file) => ({
       ...file,
       path: `${folderName}/${file.path}`,
+      isBinary: false as const,
     }));
-    let hash = hashFiles(files);
+    let binaryFilesWithFolder = (binaryFiles ?? []).map((file) => ({
+      ...file,
+      path: `${folderName}/${file.path}`,
+      isBinary: true as const,
+    }));
+    let allFiles = [...textFiles, ...binaryFilesWithFolder];
+    if (allFiles.length === 0) {
+      return;
+    }
+    let hash = hashFiles(allFiles);
     await this.githubClient.writeFilesToBranch({
       owner: context.owner,
       repo: context.repoName,
       branch: context.head,
-      files,
+      files: allFiles,
       message: `add ${context.listingDisplayName} changes [boxel-content-hash:${hash}]`,
     });
   }

--- a/packages/bot-runner/lib/github.ts
+++ b/packages/bot-runner/lib/github.ts
@@ -44,7 +44,7 @@ export interface WriteFilesToBranchParams {
   owner: string;
   repo: string;
   branch: string;
-  files: { path: string; content: string }[];
+  files: { path: string; content: string; isBinary?: boolean }[];
   message: string;
 }
 
@@ -166,8 +166,13 @@ export class OctokitGitHubClient implements GitHubClient {
       .map((file) => ({
         path: file.path?.trim(),
         content: file.content ?? '',
+        isBinary: file.isBinary ?? false,
       }))
-      .filter((file) => !!file.path) as { path: string; content: string }[];
+      .filter((file) => !!file.path) as {
+      path: string;
+      content: string;
+      isBinary: boolean;
+    }[];
     if (normalizedFiles.length === 0) {
       throw new Error('at least one file path is required');
     }
@@ -198,7 +203,7 @@ export class OctokitGitHubClient implements GitHubClient {
           path: `/repos/${params.owner}/${params.repo}/git/blobs`,
           body: {
             content: file.content,
-            encoding: 'utf-8',
+            encoding: file.isBinary ? 'base64' : 'utf-8',
           },
         });
 

--- a/packages/bot-runner/tests/bot-runner-test.ts
+++ b/packages/bot-runner/tests/bot-runner-test.ts
@@ -350,10 +350,12 @@ module('timeline handler', () => {
         {
           path: `${folder}/experiments/MyListing/listing.json`,
           content: '{"data":{"type":"card"}}',
+          isBinary: false,
         },
         {
           path: `${folder}/experiments/MyListing/readme.md`,
           content: '# My Listing',
+          isBinary: false,
         },
       ],
       'commit payload wraps parsed files in room-<base64> folder',

--- a/packages/catalog-realm/commands/collect-submission-files.ts
+++ b/packages/catalog-realm/commands/collect-submission-files.ts
@@ -22,6 +22,7 @@ import {
 } from 'https://cardstack.com/base/card-api';
 import StringField from 'https://cardstack.com/base/string';
 import GetCardCommand from '@cardstack/boxel-host/commands/get-card';
+import ReadBinaryFileCommand from '@cardstack/boxel-host/commands/read-binary-file';
 import ReadSourceCommand from '@cardstack/boxel-host/commands/read-source';
 import SerializeCardCommand from '@cardstack/boxel-host/commands/serialize-card';
 
@@ -87,6 +88,7 @@ export default class CollectSubmissionFilesCommand extends Command<
   ): Promise<FileWithContent[]> {
     let realmUrl = new RealmPaths(new URL(listingRealm)).url;
     let getCardCommand = new GetCardCommand(this.commandContext);
+    let readBinaryFileCommand = new ReadBinaryFileCommand(this.commandContext);
     let readSourceCommand = new ReadSourceCommand(this.commandContext);
 
     const listing = (await getCardCommand.execute({
@@ -220,6 +222,18 @@ export default class CollectSubmissionFilesCommand extends Command<
           path,
           content: rewriteReferences(source.content, path),
         });
+
+        // Resolve thumbnail URL against listing.id before rewriteReferences turns it relative.
+        let rawThumbnailUrl = extractThumbnailUrl(source.content);
+        if (rawThumbnailUrl) {
+          let thumbnailUrl = new URL(rawThumbnailUrl, `${listing.id}.json`).href;
+          let thumbnailPath = toRepoRelativePath(thumbnailUrl, '');
+          if (!seenPaths.has(thumbnailPath)) {
+            seenPaths.add(thumbnailPath);
+            let binary = await readBinaryFileCommand.execute({ url: thumbnailUrl });
+            filesWithContent.push({ path: thumbnailPath, content: binary.base64Content ?? '' });
+          }
+        }
       }
     }
 
@@ -328,6 +342,17 @@ export default class CollectSubmissionFilesCommand extends Command<
     }
 
     return [...instancesById.values()];
+  }
+}
+
+function extractThumbnailUrl(listingJsonContent: string): string | null {
+  try {
+    let doc = JSON.parse(listingJsonContent) as Record<string, any>;
+    let thumbnailRel = doc?.data?.relationships?.['cardInfo.cardThumbnail'];
+    let url = thumbnailRel?.links?.self;
+    return typeof url === 'string' && url.trim() ? url.trim() : null;
+  } catch {
+    return null;
   }
 }
 

--- a/packages/catalog-realm/commands/collect-submission-files.ts
+++ b/packages/catalog-realm/commands/collect-submission-files.ts
@@ -169,7 +169,7 @@ export default class CollectSubmissionFilesCommand extends Command<
       return path;
     };
 
-    // Build a map of source URL (extension-less) → PR path (extension-less).
+    // Build a map of source URL → PR path.
     // After the PR merges into the catalog, cross-realm references in the
     // submitted files must resolve to their new co-located files. We rewrite
     // all references in file contents to relative paths so the submission is
@@ -218,21 +218,32 @@ export default class CollectSubmissionFilesCommand extends Command<
         let source = await readSourceCommand.execute({
           path: `${listing.id}.json`,
         });
+
+        // Resolve thumbnail URL before rewriting listing.json so we can
+        // rewrite absolute thumbnail references to the copied PR asset path.
+        let rawThumbnailUrl = extractThumbnailUrl(source.content);
+        let thumbnailUrl: string | undefined;
+        let thumbnailPath: string | undefined;
+        if (rawThumbnailUrl) {
+          thumbnailUrl = new URL(rawThumbnailUrl, `${listing.id}.json`).href;
+          thumbnailPath = toRepoRelativePath(thumbnailUrl, '');
+          urlToRepoPath.set(thumbnailUrl, thumbnailPath);
+        }
+
         filesWithContent.push({
           path,
           content: rewriteReferences(source.content, path),
         });
 
-        // Resolve thumbnail URL against listing.id before rewriteReferences turns it relative.
-        let rawThumbnailUrl = extractThumbnailUrl(source.content);
-        if (rawThumbnailUrl) {
-          let thumbnailUrl = new URL(rawThumbnailUrl, `${listing.id}.json`).href;
-          let thumbnailPath = toRepoRelativePath(thumbnailUrl, '');
-          if (!seenPaths.has(thumbnailPath)) {
-            seenPaths.add(thumbnailPath);
-            let binary = await readBinaryFileCommand.execute({ url: thumbnailUrl });
-            filesWithContent.push({ path: thumbnailPath, content: binary.base64Content ?? '' });
-          }
+        if (thumbnailUrl && thumbnailPath && !seenPaths.has(thumbnailPath)) {
+          seenPaths.add(thumbnailPath);
+          let binary = await readBinaryFileCommand.execute({
+            url: thumbnailUrl,
+          });
+          filesWithContent.push({
+            path: thumbnailPath,
+            content: binary.base64Content ?? '',
+          });
         }
       }
     }

--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -62,6 +62,7 @@ import * as PatchThemeCommandModule from './patch-theme';
 import * as PersistModuleInspectorViewCommandModule from './persist-module-inspector-view';
 import * as PopulateWithSampleDataCommandModule from './populate-with-sample-data';
 import * as PreviewFormatCommandModule from './preview-format';
+import * as ReadBinaryFileCommandModule from './read-binary-file';
 import * as ReadCardForAiAssistantCommandModule from './read-card-for-ai-assistant';
 import * as ReadFileForAiAssistantCommandModule from './read-file-for-ai-assistant';
 import * as ReadSourceCommandModule from './read-source';
@@ -260,6 +261,10 @@ export function shimHostCommands(virtualNetwork: VirtualNetwork) {
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/preview-format',
     PreviewFormatCommandModule,
+  );
+  virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/read-binary-file',
+    ReadBinaryFileCommandModule,
   );
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/read-card-for-ai-assistant',
@@ -532,6 +537,7 @@ export const HostCommandClasses: (typeof HostBaseCommand<any, any>)[] = [
   PersistModuleInspectorViewCommandModule.default,
   PopulateWithSampleDataCommandModule.default,
   PreviewFormatCommandModule.default,
+  ReadBinaryFileCommandModule.default,
   ReadCardForAiAssistantCommandModule.default,
   ReadFileForAiAssistantCommandModule.default,
   ReadSourceCommandModule.default,

--- a/packages/host/app/commands/read-binary-file.ts
+++ b/packages/host/app/commands/read-binary-file.ts
@@ -1,0 +1,62 @@
+import { service } from '@ember/service';
+
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
+
+import HostBaseCommand from '../lib/host-base-command';
+
+import type NetworkService from '../services/network';
+
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+  const maybeBuffer = (globalThis as any).Buffer as
+    | { from(input: Uint8Array): { toString(encoding: string): string } }
+    | undefined;
+
+  if (typeof maybeBuffer !== 'undefined') {
+    return maybeBuffer.from(bytes).toString('base64');
+  }
+
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+export default class ReadBinaryFileCommand extends HostBaseCommand<
+  typeof BaseCommandModule.ReadBinaryFileInput,
+  typeof BaseCommandModule.ReadBinaryFileResult
+> {
+  @service declare private network: NetworkService;
+
+  description =
+    'Read a binary file from a URL and return its content as base64';
+  static actionVerb = 'Read';
+
+  async getInputType() {
+    let commandModule = await this.loadCommandModule();
+    const { ReadBinaryFileInput } = commandModule;
+    return ReadBinaryFileInput;
+  }
+
+  requireInputFields = ['url'];
+
+  protected async run(
+    input: BaseCommandModule.ReadBinaryFileInput,
+  ): Promise<BaseCommandModule.ReadBinaryFileResult> {
+    let response = await this.network.authedFetch(input.url);
+    let { ReadBinaryFileResult } = await this.loadCommandModule();
+
+    if (!response.ok) {
+      throw new Error(
+        `Error reading binary file ${input.url}: ${response.statusText}`,
+      );
+    }
+
+    let arrayBuffer = await response.arrayBuffer();
+    let bytes = new Uint8Array(arrayBuffer);
+    let base64Content = uint8ArrayToBase64(bytes);
+    let contentType = response.headers.get('content-type') ?? '';
+
+    return new ReadBinaryFileResult({ base64Content, contentType });
+  }
+}

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -7,6 +7,25 @@ import {
 
 export const BASE_FILE_DEF_CODE_REF = baseFileRef;
 
+export const BINARY_FILE_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.avif',
+  '.ico',
+  '.bmp',
+  '.tiff',
+  '.tif',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.otf',
+  '.eot',
+  '.pdf',
+]);
+
 function baseModule(name: string): RealmResourceIdentifier {
   return `${baseRealm.url}${name}` as RealmResourceIdentifier;
 }

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -7,25 +7,6 @@ import {
 
 export const BASE_FILE_DEF_CODE_REF = baseFileRef;
 
-export const BINARY_FILE_EXTENSIONS = new Set([
-  '.png',
-  '.jpg',
-  '.jpeg',
-  '.gif',
-  '.webp',
-  '.avif',
-  '.ico',
-  '.bmp',
-  '.tiff',
-  '.tif',
-  '.woff',
-  '.woff2',
-  '.ttf',
-  '.otf',
-  '.eot',
-  '.pdf',
-]);
-
 function baseModule(name: string): RealmResourceIdentifier {
   return `${baseRealm.url}${name}` as RealmResourceIdentifier;
 }

--- a/packages/runtime-common/infer-content-type.ts
+++ b/packages/runtime-common/infer-content-type.ts
@@ -19,3 +19,15 @@ export function inferContentType(filename: string): string {
   let mimeType = lookupMimeType(filename);
   return mimeType ? mimeType : DEFAULT_FILE_CONTENT_TYPE;
 }
+
+export function isBinaryFilename(filename: string): boolean {
+  let mimeType = inferContentType(filename);
+  // SVG is image/* but is XML-based text
+  if (mimeType === 'image/svg+xml') return false;
+  return (
+    mimeType.startsWith('image/') ||
+    mimeType.startsWith('font/') ||
+    mimeType === 'application/pdf' ||
+    mimeType === 'application/vnd.ms-fontobject' // .eot legacy font
+  );
+}


### PR DESCRIPTION
Previously, listing PR creation only had a text-file collection flow. That worked for normal source files, but not for binary assets like thumbnails.

There were two problems with the old behavior. First, we did not have a proper way to read and carry binary file contents through the submission flow. Second, binary content should not be stored inside the PR card payload, because that data can quickly grow the card and contribute to card size limit failures.

This change adds a dedicated ReadBinaryFile command so binary assets can be fetched as base64, and updates the listing PR flow to treat binary files separately from text files.

Text files continue to be collected through the existing PR card content flow. Binary files are now passed separately into addContentsToCommit and written directly to GitHub using base64 blob encoding.

This gives us a proper path for including binary submission assets in generated PRs without storing that binary payload inside PrCardFieldContent.

## Note:
i update the 'collection-submission-file' commands to https://github.com/cardstack/boxel/pull/4550

<img width="1502" height="831" alt="Screenshot 2026-04-28 at 2 25 29 PM" src="https://github.com/user-attachments/assets/f212feec-e239-4314-a52d-ea13d6517320" />
