### PR TITLE
CS-10625: Reimplement `boxel realm history` command

### DIFF
--- a/packages/boxel-cli/src/commands/realm/history.ts
+++ b/packages/boxel-cli/src/commands/realm/history.ts
@@ -1,0 +1,357 @@
+import * as fs from 'fs';
+import type { Command } from 'commander';
+import {
+  CheckpointManager,
+  type Checkpoint,
+} from '../../lib/checkpoint-manager';
+import { prompt } from '../../lib/prompt';
+import {
+  BOLD,
+  DIM,
+  FG_CYAN,
+  FG_GREEN,
+  FG_MAGENTA,
+  FG_RED,
+  FG_YELLOW,
+  RESET,
+} from '../../lib/colors';
+
+const DEFAULT_LIMIT = 100;
+
+export interface HistoryOptions {
+  /** A 1-based index, short hash, or full hash to restore. */
+  restore?: string;
+  /** Create a manual checkpoint with this commit message. */
+  message?: string;
+  /** Max checkpoints to list or consider for restore. Defaults to 100. */
+  limit?: number;
+}
+
+export interface HistoryResult {
+  ok: boolean;
+  /** Populated in view mode. */
+  checkpoints?: Checkpoint[];
+  /** True when the listing was capped by `limit` (view mode only). */
+  truncated?: boolean;
+  /** Populated when `--message` created a checkpoint. */
+  created?: Checkpoint;
+  /** Populated when `--restore` restored a checkpoint. */
+  restored?: Checkpoint;
+  error?: string;
+}
+
+interface HistoryCliOptions {
+  restore?: string;
+  message?: string;
+  yes?: boolean;
+  limit?: string;
+}
+
+type StepResult<T> = ({ ok: true } & T) | { ok: false; error: string };
+
+async function listCheckpointsStep(
+  workspaceDir: string,
+  limit: number,
+): Promise<StepResult<{ checkpoints: Checkpoint[]; truncated: boolean }>> {
+  if (!fs.existsSync(workspaceDir)) {
+    return { ok: false, error: `Directory not found: ${workspaceDir}` };
+  }
+  const manager = new CheckpointManager(workspaceDir);
+  if (!(await manager.isInitialized())) {
+    return { ok: true, checkpoints: [], truncated: false };
+  }
+  // Fetch one extra so we can detect truncation without a separate count query.
+  const fetched = await manager.getCheckpoints(limit + 1);
+  const truncated = fetched.length > limit;
+  const checkpoints = truncated ? fetched.slice(0, limit) : fetched;
+  return { ok: true, checkpoints, truncated };
+}
+
+async function createManualCheckpointStep(
+  workspaceDir: string,
+  rawMessage: string,
+): Promise<StepResult<{ created: Checkpoint }>> {
+  if (!fs.existsSync(workspaceDir)) {
+    return { ok: false, error: `Directory not found: ${workspaceDir}` };
+  }
+  const message = rawMessage.trim();
+  if (!message) {
+    return { ok: false, error: '--message must not be empty.' };
+  }
+  const manager = new CheckpointManager(workspaceDir);
+  if (!(await manager.isInitialized())) {
+    await manager.init();
+  }
+  const changes = await manager.detectCurrentChanges();
+  const created = await manager.createCheckpoint('manual', changes, message);
+  if (!created) {
+    return { ok: false, error: 'No changes to checkpoint.' };
+  }
+  return { ok: true, created };
+}
+
+async function resolveCheckpointRefStep(
+  workspaceDir: string,
+  ref: string,
+  limit: number,
+): Promise<StepResult<{ target: Checkpoint }>> {
+  if (!fs.existsSync(workspaceDir)) {
+    return { ok: false, error: `Directory not found: ${workspaceDir}` };
+  }
+  const manager = new CheckpointManager(workspaceDir);
+  if (!(await manager.isInitialized())) {
+    return {
+      ok: false,
+      error:
+        'No checkpoint history found for this workspace. ' +
+        'Checkpoints are created automatically during sync operations.',
+    };
+  }
+  const checkpoints = await manager.getCheckpoints(limit);
+  const target = findCheckpoint(ref, checkpoints);
+  if (!target) {
+    return {
+      ok: false,
+      error: `Checkpoint not found: ${ref}. Use a number (1-${checkpoints.length}) or a commit hash.`,
+    };
+  }
+  return { ok: true, target };
+}
+
+async function restoreCheckpointStep(
+  workspaceDir: string,
+  hash: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (!fs.existsSync(workspaceDir)) {
+    return { ok: false, error: `Directory not found: ${workspaceDir}` };
+  }
+  const manager = new CheckpointManager(workspaceDir);
+  if (!(await manager.isInitialized())) {
+    return {
+      ok: false,
+      error: 'No checkpoint history found for this workspace.',
+    };
+  }
+  await manager.restore(hash);
+  return { ok: true };
+}
+
+function findCheckpoint(
+  ref: string,
+  checkpoints: Checkpoint[],
+): Checkpoint | undefined {
+  const trimmed = ref.trim();
+  // Digit-only input is always an index lookup. Falling through to hash
+  // matching when out of range would silently match short hashes whose prefix
+  // happens to be digits.
+  if (/^\d+$/.test(trimmed)) {
+    const num = parseInt(trimmed, 10);
+    return num >= 1 && num <= checkpoints.length
+      ? checkpoints[num - 1]
+      : undefined;
+  }
+  return checkpoints.find(
+    (cp) => cp.hash.startsWith(trimmed) || cp.shortHash === trimmed,
+  );
+}
+
+/**
+ * View, restore, or create checkpoints in a workspace's local
+ * `.boxel-history/` git repo. Pure local — does not touch the realm server.
+ *
+ * Programmatic API. Restores immediately without prompting; the CLI wraps
+ * this with a TTY confirmation step (see `registerHistoryCommand`).
+ */
+export async function realmHistory(
+  workspaceDir: string,
+  options: HistoryOptions = {},
+): Promise<HistoryResult> {
+  if (options.restore !== undefined && options.message !== undefined) {
+    return {
+      ok: false,
+      error: 'Only one of --restore or --message may be specified.',
+    };
+  }
+  const limit = options.limit ?? DEFAULT_LIMIT;
+
+  if (options.message !== undefined) {
+    const r = await createManualCheckpointStep(workspaceDir, options.message);
+    return r.ok
+      ? { ok: true, created: r.created }
+      : { ok: false, error: r.error };
+  }
+
+  if (options.restore !== undefined) {
+    const resolved = await resolveCheckpointRefStep(
+      workspaceDir,
+      options.restore,
+      limit,
+    );
+    if (!resolved.ok) return { ok: false, error: resolved.error };
+    const restored = await restoreCheckpointStep(
+      workspaceDir,
+      resolved.target.hash,
+    );
+    if (!restored.ok) return { ok: false, error: restored.error };
+    return { ok: true, restored: resolved.target };
+  }
+
+  const r = await listCheckpointsStep(workspaceDir, limit);
+  return r.ok
+    ? { ok: true, checkpoints: r.checkpoints, truncated: r.truncated }
+    : { ok: false, error: r.error };
+}
+
+function formatSourceTag(source: 'local' | 'remote' | 'manual'): string {
+  if (source === 'local') return `${FG_GREEN}LOCAL${RESET}`;
+  if (source === 'remote') return `${FG_CYAN}SERVER${RESET}`;
+  return `${FG_MAGENTA}MANUAL${RESET}`;
+}
+
+function formatRelativeDate(date: Date): string {
+  const diffMs = Date.now() - date.getTime();
+  const minutes = Math.floor(diffMs / 60_000);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  if (days > 7)
+    return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+  if (days > 0) return `${days} day${days === 1 ? '' : 's'} ago`;
+  if (hours > 0) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  if (minutes > 0) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  return 'just now';
+}
+
+function printCheckpoints(
+  checkpoints: Checkpoint[],
+  truncated: boolean,
+  limit: number,
+): void {
+  if (checkpoints.length === 0) {
+    console.log('No checkpoints found.');
+    return;
+  }
+  console.log(`\n${BOLD}Checkpoint History${RESET}\n`);
+  const width = String(checkpoints.length).length;
+  checkpoints.forEach((cp, i) => {
+    const num = i + 1;
+    const numLabel = `${DIM}${String(num).padStart(width, ' ')}${RESET}`;
+    const majorTag = cp.isMajor
+      ? `${FG_YELLOW}[MAJOR]${RESET}`
+      : `${DIM}[minor]${RESET}`;
+    const milestoneTag = cp.isMilestone
+      ? `${FG_YELLOW}⭐${RESET} ${FG_MAGENTA}[${cp.milestoneName}]${RESET} `
+      : '';
+    console.log(
+      `${numLabel} ${FG_YELLOW}${cp.shortHash}${RESET} ${milestoneTag}${formatSourceTag(cp.source)} ${majorTag} ${cp.message} ${DIM}(${cp.filesChanged} files)${RESET}`,
+    );
+    console.log(`   ${DIM}${formatRelativeDate(cp.date)}${RESET}\n`);
+  });
+  if (truncated) {
+    console.log(
+      `${DIM}Showing first ${limit} checkpoints. Pass --limit <n> to see more.${RESET}`,
+    );
+  }
+  console.log(
+    `${DIM}Restore: boxel realm history <local-dir> -r <ref>${RESET}`,
+  );
+}
+
+function parseLimit(raw: string | undefined): number | null {
+  if (raw === undefined) return DEFAULT_LIMIT;
+  if (!/^\d+$/.test(raw)) return null;
+  const n = parseInt(raw, 10);
+  return n > 0 ? n : null;
+}
+
+function bailout(msg: string): never {
+  console.error(`${FG_RED}Error:${RESET} ${msg}`);
+  process.exit(1);
+}
+
+export function registerHistoryCommand(realm: Command): void {
+  realm
+    .command('history')
+    .alias('hist')
+    .description(
+      'View, restore, or create local checkpoints stored under .boxel-history/',
+    )
+    .argument('<local-dir>', 'The local workspace directory')
+    .option(
+      '-r, --restore <ref>',
+      'Restore the workspace to a checkpoint (1-based index, short hash, or full hash)',
+    )
+    .option(
+      '-m, --message <message>',
+      'Create a manual checkpoint with the given message',
+    )
+    .option(
+      '-y, --yes',
+      'Skip the interactive confirmation prompt before --restore',
+    )
+    .option(
+      '--limit <n>',
+      `Maximum number of checkpoints to list or consider for --restore (default: ${DEFAULT_LIMIT})`,
+    )
+    .action(async (localDir: string, opts: HistoryCliOptions) => {
+      if (opts.restore !== undefined && opts.message !== undefined) {
+        bailout('Only one of --restore or --message may be specified.');
+      }
+
+      const limit = parseLimit(opts.limit);
+      if (limit === null) {
+        bailout('--limit must be a positive integer.');
+      }
+
+      if (opts.message !== undefined) {
+        const r = await createManualCheckpointStep(localDir, opts.message);
+        if (!r.ok) bailout(r.error);
+        console.log(
+          `${FG_GREEN}✓${RESET} Checkpoint created: ${FG_YELLOW}${r.created.shortHash}${RESET} ${r.created.message}`,
+        );
+        return;
+      }
+
+      if (opts.restore !== undefined) {
+        const resolved = await resolveCheckpointRefStep(
+          localDir,
+          opts.restore,
+          limit,
+        );
+        if (!resolved.ok) bailout(resolved.error);
+        const target = resolved.target;
+
+        if (!opts.yes) {
+          if (!process.stdin.isTTY) {
+            bailout(
+              '--restore overwrites local files. Pass --yes to confirm in non-interactive mode.',
+            );
+          }
+          console.log(
+            `\n${BOLD}Restoring to:${RESET} ${FG_YELLOW}${target.shortHash}${RESET} - ${target.message}`,
+          );
+          console.log(`${DIM}${formatRelativeDate(target.date)}${RESET}\n`);
+          const answer = await prompt(
+            `${FG_YELLOW}This will overwrite current files. Continue? (y/N) ${RESET}`,
+          );
+          if (!/^y/i.test(answer)) {
+            console.log(`${DIM}Restore cancelled.${RESET}`);
+            return;
+          }
+        }
+
+        const restored = await restoreCheckpointStep(localDir, target.hash);
+        if (!restored.ok) bailout(restored.error);
+        console.log(
+          `${FG_GREEN}✓${RESET} Restored to ${FG_YELLOW}${target.shortHash}${RESET} ${target.message}`,
+        );
+        console.log(
+          `${DIM}Run 'boxel realm sync <local-dir> <realm-url> --prefer-local' to push the restored state to the realm.${RESET}`,
+        );
+        return;
+      }
+
+      const r = await listCheckpointsStep(localDir, limit);
+      if (!r.ok) bailout(r.error);
+      printCheckpoints(r.checkpoints, r.truncated, limit);
+    });
+}

--- a/packages/boxel-cli/src/commands/realm/history.ts
+++ b/packages/boxel-cli/src/commands/realm/history.ts
@@ -49,6 +49,10 @@ interface HistoryCliOptions {
 
 type StepResult<T> = ({ ok: true } & T) | { ok: false; error: string };
 
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
 async function listCheckpointsStep(
   workspaceDir: string,
   limit: number,
@@ -56,15 +60,22 @@ async function listCheckpointsStep(
   if (!fs.existsSync(workspaceDir)) {
     return { ok: false, error: `Directory not found: ${workspaceDir}` };
   }
-  const manager = new CheckpointManager(workspaceDir);
-  if (!(await manager.isInitialized())) {
-    return { ok: true, checkpoints: [], truncated: false };
+  try {
+    const manager = new CheckpointManager(workspaceDir);
+    if (!(await manager.isInitialized())) {
+      return { ok: true, checkpoints: [], truncated: false };
+    }
+    // Fetch one extra so we can detect truncation without a separate count query.
+    const fetched = await manager.getCheckpoints(limit + 1);
+    const truncated = fetched.length > limit;
+    const checkpoints = truncated ? fetched.slice(0, limit) : fetched;
+    return { ok: true, checkpoints, truncated };
+  } catch (e) {
+    return {
+      ok: false,
+      error: `Failed to read checkpoint history: ${errorMessage(e)}`,
+    };
   }
-  // Fetch one extra so we can detect truncation without a separate count query.
-  const fetched = await manager.getCheckpoints(limit + 1);
-  const truncated = fetched.length > limit;
-  const checkpoints = truncated ? fetched.slice(0, limit) : fetched;
-  return { ok: true, checkpoints, truncated };
 }
 
 async function createManualCheckpointStep(
@@ -78,16 +89,23 @@ async function createManualCheckpointStep(
   if (!message) {
     return { ok: false, error: '--message must not be empty.' };
   }
-  const manager = new CheckpointManager(workspaceDir);
-  if (!(await manager.isInitialized())) {
-    await manager.init();
+  try {
+    const manager = new CheckpointManager(workspaceDir);
+    if (!(await manager.isInitialized())) {
+      await manager.init();
+    }
+    const changes = await manager.detectCurrentChanges();
+    const created = await manager.createCheckpoint('manual', changes, message);
+    if (!created) {
+      return { ok: false, error: 'No changes to checkpoint.' };
+    }
+    return { ok: true, created };
+  } catch (e) {
+    return {
+      ok: false,
+      error: `Failed to create checkpoint: ${errorMessage(e)}`,
+    };
   }
-  const changes = await manager.detectCurrentChanges();
-  const created = await manager.createCheckpoint('manual', changes, message);
-  if (!created) {
-    return { ok: false, error: 'No changes to checkpoint.' };
-  }
-  return { ok: true, created };
 }
 
 async function resolveCheckpointRefStep(
@@ -98,24 +116,42 @@ async function resolveCheckpointRefStep(
   if (!fs.existsSync(workspaceDir)) {
     return { ok: false, error: `Directory not found: ${workspaceDir}` };
   }
-  const manager = new CheckpointManager(workspaceDir);
-  if (!(await manager.isInitialized())) {
+  try {
+    const manager = new CheckpointManager(workspaceDir);
+    if (!(await manager.isInitialized())) {
+      return {
+        ok: false,
+        error:
+          'No checkpoint history found for this workspace. ' +
+          'Checkpoints are created automatically during sync operations.',
+      };
+    }
+    const checkpoints = await manager.getCheckpoints(limit);
+    const found = findCheckpoint(ref, checkpoints);
+    if (found.kind === 'none') {
+      return {
+        ok: false,
+        error: `Checkpoint not found: ${ref}. Use a number (1-${checkpoints.length}) or a commit hash.`,
+      };
+    }
+    if (found.kind === 'ambiguous') {
+      const sample = found.matches
+        .slice(0, 5)
+        .map((cp) => cp.shortHash)
+        .join(', ');
+      const more = found.matches.length > 5 ? ', …' : '';
+      return {
+        ok: false,
+        error: `Ambiguous reference: ${ref} matches ${found.matches.length} checkpoints (${sample}${more}). Use a longer prefix or full hash.`,
+      };
+    }
+    return { ok: true, target: found.target };
+  } catch (e) {
     return {
       ok: false,
-      error:
-        'No checkpoint history found for this workspace. ' +
-        'Checkpoints are created automatically during sync operations.',
+      error: `Failed to read checkpoint history: ${errorMessage(e)}`,
     };
   }
-  const checkpoints = await manager.getCheckpoints(limit);
-  const target = findCheckpoint(ref, checkpoints);
-  if (!target) {
-    return {
-      ok: false,
-      error: `Checkpoint not found: ${ref}. Use a number (1-${checkpoints.length}) or a commit hash.`,
-    };
-  }
-  return { ok: true, target };
 }
 
 async function restoreCheckpointStep(
@@ -125,34 +161,50 @@ async function restoreCheckpointStep(
   if (!fs.existsSync(workspaceDir)) {
     return { ok: false, error: `Directory not found: ${workspaceDir}` };
   }
-  const manager = new CheckpointManager(workspaceDir);
-  if (!(await manager.isInitialized())) {
+  try {
+    const manager = new CheckpointManager(workspaceDir);
+    if (!(await manager.isInitialized())) {
+      return {
+        ok: false,
+        error: 'No checkpoint history found for this workspace.',
+      };
+    }
+    await manager.restore(hash);
+    return { ok: true };
+  } catch (e) {
     return {
       ok: false,
-      error: 'No checkpoint history found for this workspace.',
+      error: `Failed to restore checkpoint: ${errorMessage(e)}`,
     };
   }
-  await manager.restore(hash);
-  return { ok: true };
 }
 
-function findCheckpoint(
-  ref: string,
-  checkpoints: Checkpoint[],
-): Checkpoint | undefined {
+type FindResult =
+  | { kind: 'found'; target: Checkpoint }
+  | { kind: 'none' }
+  | { kind: 'ambiguous'; matches: Checkpoint[] };
+
+function findCheckpoint(ref: string, checkpoints: Checkpoint[]): FindResult {
   const trimmed = ref.trim();
+  // Empty refs would `startsWith('')`-match every hash and silently restore
+  // the newest checkpoint — guard explicitly.
+  if (trimmed === '') return { kind: 'none' };
   // Digit-only input is always an index lookup. Falling through to hash
   // matching when out of range would silently match short hashes whose prefix
   // happens to be digits.
   if (/^\d+$/.test(trimmed)) {
     const num = parseInt(trimmed, 10);
-    return num >= 1 && num <= checkpoints.length
-      ? checkpoints[num - 1]
-      : undefined;
+    if (num >= 1 && num <= checkpoints.length) {
+      return { kind: 'found', target: checkpoints[num - 1] };
+    }
+    return { kind: 'none' };
   }
-  return checkpoints.find(
+  const matches = checkpoints.filter(
     (cp) => cp.hash.startsWith(trimmed) || cp.shortHash === trimmed,
   );
+  if (matches.length === 0) return { kind: 'none' };
+  if (matches.length === 1) return { kind: 'found', target: matches[0] };
+  return { kind: 'ambiguous', matches };
 }
 
 /**
@@ -171,6 +223,12 @@ export async function realmHistory(
       ok: false,
       error: 'Only one of --restore or --message may be specified.',
     };
+  }
+  if (
+    options.limit !== undefined &&
+    (!Number.isInteger(options.limit) || options.limit <= 0)
+  ) {
+    return { ok: false, error: 'limit must be a positive integer.' };
   }
   const limit = options.limit ?? DEFAULT_LIMIT;
 

--- a/packages/boxel-cli/src/commands/realm/index.ts
+++ b/packages/boxel-cli/src/commands/realm/index.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander';
 import { registerCancelIndexingCommand } from './cancel-indexing';
 import { registerCreateCommand } from './create';
+import { registerHistoryCommand } from './history';
 import { registerListCommand } from './list';
 import { registerPullCommand } from './pull';
 import { registerPushCommand } from './push';
@@ -14,6 +15,7 @@ export function registerRealmCommand(program: Command): void {
 
   registerCancelIndexingCommand(realm);
   registerCreateCommand(realm);
+  registerHistoryCommand(realm);
   registerListCommand(realm);
   registerPullCommand(realm);
   registerPushCommand(realm);

--- a/packages/boxel-cli/tests/integration/realm-history.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-history.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { realmHistory } from '../../src/commands/realm/history';
+import { CheckpointManager } from '../../src/lib/checkpoint-manager';
+
+let workspaceDir: string;
+
+function writeFile(relPath: string, content: string): void {
+  const full = path.join(workspaceDir, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf8');
+}
+
+beforeEach(() => {
+  workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-history-int-'));
+});
+
+afterEach(() => {
+  fs.rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe('realm history (integration)', () => {
+  describe('view mode', () => {
+    it('returns an empty list for an uninitialized workspace', async () => {
+      const result = await realmHistory(workspaceDir);
+      expect(result.ok).toBe(true);
+      expect(result.checkpoints).toEqual([]);
+    });
+
+    it('lists checkpoints in reverse-chronological order', async () => {
+      const cm = new CheckpointManager(workspaceDir);
+      writeFile('a.gts', 'first');
+      await cm.createCheckpoint('manual', [{ file: 'a.gts', status: 'added' }]);
+      writeFile('b.gts', 'second');
+      await cm.createCheckpoint('local', [{ file: 'b.gts', status: 'added' }]);
+
+      const result = await realmHistory(workspaceDir);
+
+      expect(result.ok).toBe(true);
+      expect(result.checkpoints).toBeDefined();
+      expect(result.checkpoints!.length).toBe(2);
+      expect(result.checkpoints![0].source).toBe('local');
+      expect(result.checkpoints![1].source).toBe('manual');
+      expect(result.truncated).toBe(false);
+    });
+
+    it('returns truncated=true when checkpoints exceed limit', async () => {
+      const cm = new CheckpointManager(workspaceDir);
+      writeFile('a.gts', '1');
+      await cm.createCheckpoint('manual', [{ file: 'a.gts', status: 'added' }]);
+      writeFile('a.gts', '2');
+      await cm.createCheckpoint('manual', [
+        { file: 'a.gts', status: 'modified' },
+      ]);
+      writeFile('a.gts', '3');
+      await cm.createCheckpoint('manual', [
+        { file: 'a.gts', status: 'modified' },
+      ]);
+
+      const capped = await realmHistory(workspaceDir, { limit: 2 });
+      expect(capped.ok).toBe(true);
+      expect(capped.checkpoints!.length).toBe(2);
+      expect(capped.truncated).toBe(true);
+
+      const all = await realmHistory(workspaceDir, { limit: 10 });
+      expect(all.checkpoints!.length).toBe(3);
+      expect(all.truncated).toBe(false);
+    });
+  });
+
+  describe('manual checkpoint (-m)', () => {
+    it('creates a checkpoint with the provided message', async () => {
+      writeFile('a.gts', 'a');
+
+      const result = await realmHistory(workspaceDir, {
+        message: 'before cleanup',
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.created).toBeDefined();
+      expect(result.created!.source).toBe('manual');
+
+      const cps = await new CheckpointManager(workspaceDir).getCheckpoints();
+      expect(cps[0].message.trim()).toBe('before cleanup');
+    });
+
+    it('initializes the history repo on first use', async () => {
+      writeFile('a.gts', 'a');
+      const historyDir = path.join(workspaceDir, '.boxel-history', '.git');
+      expect(fs.existsSync(historyDir)).toBe(false);
+
+      const result = await realmHistory(workspaceDir, { message: 'first' });
+
+      expect(result.ok).toBe(true);
+      expect(fs.existsSync(historyDir)).toBe(true);
+    });
+
+    it('returns an error when there are no changes to checkpoint', async () => {
+      writeFile('a.gts', 'a');
+      await realmHistory(workspaceDir, { message: 'first' });
+
+      const result = await realmHistory(workspaceDir, { message: 'second' });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('No changes to checkpoint');
+    });
+
+    it('rejects an empty message', async () => {
+      writeFile('a.gts', 'a');
+      const result = await realmHistory(workspaceDir, { message: '   ' });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('--message must not be empty');
+    });
+  });
+
+  describe('restore (-r)', () => {
+    it('restores by 1-based index', async () => {
+      const cm = new CheckpointManager(workspaceDir);
+      writeFile('a.gts', 'original');
+      await cm.createCheckpoint('manual', [{ file: 'a.gts', status: 'added' }]);
+      writeFile('a.gts', 'modified');
+      writeFile('b.gts', 'b');
+      await cm.createCheckpoint('manual', [
+        { file: 'a.gts', status: 'modified' },
+        { file: 'b.gts', status: 'added' },
+      ]);
+
+      // Index 2 is the older "original" checkpoint; getCheckpoints is newest-first.
+      const result = await realmHistory(workspaceDir, { restore: '2' });
+
+      expect(result.ok).toBe(true);
+      expect(result.restored).toBeDefined();
+      expect(fs.readFileSync(path.join(workspaceDir, 'a.gts'), 'utf8')).toBe(
+        'original',
+      );
+      expect(fs.existsSync(path.join(workspaceDir, 'b.gts'))).toBe(false);
+    });
+
+    it('restores by short hash', async () => {
+      const cm = new CheckpointManager(workspaceDir);
+      writeFile('a.gts', 'original');
+      const target = await cm.createCheckpoint('manual', [
+        { file: 'a.gts', status: 'added' },
+      ]);
+      writeFile('a.gts', 'modified');
+      await cm.createCheckpoint('manual', [
+        { file: 'a.gts', status: 'modified' },
+      ]);
+
+      const result = await realmHistory(workspaceDir, {
+        restore: target!.shortHash,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.restored?.hash).toBe(target!.hash);
+      expect(fs.readFileSync(path.join(workspaceDir, 'a.gts'), 'utf8')).toBe(
+        'original',
+      );
+    });
+
+    it('restores by full hash', async () => {
+      const cm = new CheckpointManager(workspaceDir);
+      writeFile('a.gts', 'original');
+      const target = await cm.createCheckpoint('manual', [
+        { file: 'a.gts', status: 'added' },
+      ]);
+      writeFile('a.gts', 'modified');
+      await cm.createCheckpoint('manual', [
+        { file: 'a.gts', status: 'modified' },
+      ]);
+
+      expect(target!.hash.length).toBe(40);
+      const result = await realmHistory(workspaceDir, {
+        restore: target!.hash,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.restored?.hash).toBe(target!.hash);
+      expect(fs.readFileSync(path.join(workspaceDir, 'a.gts'), 'utf8')).toBe(
+        'original',
+      );
+    });
+
+    it('returns an error for an out-of-range numeric index', async () => {
+      const cm = new CheckpointManager(workspaceDir);
+      writeFile('a.gts', 'a');
+      await cm.createCheckpoint('manual', [{ file: 'a.gts', status: 'added' }]);
+      writeFile('b.gts', 'b');
+      await cm.createCheckpoint('manual', [{ file: 'b.gts', status: 'added' }]);
+
+      // Digit-only refs are always treated as index lookups; they must not
+      // silently match a short hash whose prefix happens to be digits.
+      const result = await realmHistory(workspaceDir, { restore: '99' });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('Checkpoint not found');
+    });
+
+    it('preserves .realm.json across restore', async () => {
+      const cm = new CheckpointManager(workspaceDir);
+      writeFile('a.gts', 'original');
+      const target = await cm.createCheckpoint('manual', [
+        { file: 'a.gts', status: 'added' },
+      ]);
+      writeFile('.realm.json', '{"name":"test"}');
+      writeFile('a.gts', 'modified');
+      await cm.createCheckpoint('manual', [
+        { file: 'a.gts', status: 'modified' },
+      ]);
+
+      const result = await realmHistory(workspaceDir, {
+        restore: target!.shortHash,
+      });
+
+      expect(result.ok).toBe(true);
+      const realmJsonPath = path.join(workspaceDir, '.realm.json');
+      expect(fs.existsSync(realmJsonPath)).toBe(true);
+      expect(fs.readFileSync(realmJsonPath, 'utf8')).toBe('{"name":"test"}');
+    });
+
+    it('returns an error for an invalid reference', async () => {
+      const cm = new CheckpointManager(workspaceDir);
+      writeFile('a.gts', 'a');
+      await cm.createCheckpoint('manual', [{ file: 'a.gts', status: 'added' }]);
+
+      const result = await realmHistory(workspaceDir, { restore: 'deadbeef' });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('Checkpoint not found');
+    });
+
+    it('returns an error when the workspace has no history', async () => {
+      const result = await realmHistory(workspaceDir, { restore: '1' });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('No checkpoint history');
+    });
+  });
+
+  describe('argument validation', () => {
+    it('rejects a missing workspace directory', async () => {
+      const result = await realmHistory(
+        path.join(workspaceDir, 'does-not-exist'),
+      );
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('Directory not found');
+    });
+
+    it('rejects --restore and --message together', async () => {
+      const result = await realmHistory(workspaceDir, {
+        restore: '1',
+        message: 'oops',
+      });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('Only one of --restore or --message');
+    });
+  });
+});

--- a/packages/boxel-cli/tests/integration/realm-history.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-history.test.ts
@@ -236,6 +236,60 @@ describe('realm history (integration)', () => {
       expect(result.ok).toBe(false);
       expect(result.error).toContain('No checkpoint history');
     });
+
+    it('rejects an empty restore ref instead of restoring the newest', async () => {
+      const cm = new CheckpointManager(workspaceDir);
+      writeFile('a.gts', 'a');
+      await cm.createCheckpoint('manual', [{ file: 'a.gts', status: 'added' }]);
+      writeFile('b.gts', 'b');
+      await cm.createCheckpoint('manual', [{ file: 'b.gts', status: 'added' }]);
+
+      const result = await realmHistory(workspaceDir, { restore: '' });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('Checkpoint not found');
+      expect(fs.existsSync(path.join(workspaceDir, 'b.gts'))).toBe(true);
+    });
+
+    it('rejects a whitespace-only restore ref', async () => {
+      const cm = new CheckpointManager(workspaceDir);
+      writeFile('a.gts', 'a');
+      await cm.createCheckpoint('manual', [{ file: 'a.gts', status: 'added' }]);
+
+      const result = await realmHistory(workspaceDir, { restore: '   ' });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('Checkpoint not found');
+    });
+
+    it('rejects an ambiguous hash prefix', async () => {
+      const cm = new CheckpointManager(workspaceDir);
+      // Create enough checkpoints that some non-digit hex prefix collides.
+      // Digit-only refs are treated as index lookups, not hash prefixes.
+      for (let i = 0; i < 40; i++) {
+        writeFile('a.gts', `v${i}`);
+        await cm.createCheckpoint('manual', [
+          { file: 'a.gts', status: i === 0 ? 'added' : 'modified' },
+        ]);
+      }
+      const cps = await cm.getCheckpoints(100);
+      const counts = new Map<string, number>();
+      for (const cp of cps) {
+        const c = cp.hash[0];
+        if (/[a-f]/.test(c)) counts.set(c, (counts.get(c) ?? 0) + 1);
+      }
+      const ambiguousPrefix = [...counts.entries()].find(
+        ([, n]) => n >= 2,
+      )?.[0];
+      expect(ambiguousPrefix).toBeDefined();
+
+      const result = await realmHistory(workspaceDir, {
+        restore: ambiguousPrefix!,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('Ambiguous reference');
+    });
   });
 
   describe('argument validation', () => {
@@ -254,6 +308,17 @@ describe('realm history (integration)', () => {
       });
       expect(result.ok).toBe(false);
       expect(result.error).toContain('Only one of --restore or --message');
+    });
+
+    it.each([
+      ['zero', 0],
+      ['negative', -1],
+      ['non-integer', 1.5],
+      ['NaN', Number.NaN],
+    ])('rejects an invalid limit (%s)', async (_name, limit) => {
+      const result = await realmHistory(workspaceDir, { limit });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('positive integer');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Port `boxel history` from the standalone [`cardstack/boxel-cli`](https://github.com/cardstack/boxel-cli/blob/main/src/commands/history.ts) into `packages/boxel-cli/src/commands/realm/history.ts` (alias `hist`)
- Three modes: view (default), restore (`-r <ref>`), manual checkpoint (`-m <message>`)
- Backed by the existing `CheckpointManager` — no new dependencies
- Storage: git-based checkpoints in the workspace's `.boxel-history/`
- Safety net for destructive sync ops (`--prefer-local`, `realm push --delete`)

## Safety
- TTY confirmation prompt before `--restore`; bypass with `-y, --yes`
- Non-interactive `--restore` without `--yes` errors out instead of overwriting silently
- Digit-only `--restore` values are always index lookups (no silent fallthrough to short-hash matching when out of range)

## Other
- `--restore <ref>` accepts 1-based index, short hash, or full hash
- `--limit <n>` (default 100) caps the listing window; view mode shows a "Showing first N" hint when truncated
- Index labels are right-aligned and rendered for every row, not just 1–9

## Linear
[CS-10625](https://linear.app/cardstack/issue/CS-10625) — blocks Claude Code plugin marketplace submission in [CS-10900](https://linear.app/cardstack/issue/CS-10900)

## Test plan
- [x] `pnpm --filter @cardstack/boxel-cli test` passes (16/16 in `realm-history.test.ts`)
- [x] `pnpm --filter @cardstack/boxel-cli lint:types` passes
- [x] `pnpm --filter @cardstack/boxel-cli lint:js` passes
- [ ] Manual TTY: in a synced staging workspace, edit files → \`boxel realm history . -m "test"\` → \`boxel realm history . -r 1\` prompts y/N → restores
- [ ] Manual: \`boxel realm history . -r 1 --yes\` skips the prompt
- [ ] Manual: \`boxel realm history . -r 1 < /dev/null\` errors out (non-TTY without \`--yes\`)
- [ ] Manual: \`boxel realm history . --limit 5\` shows the truncation hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)