### PR TITLE
fix(software-factory): update realm-search integration test for federated search

### DIFF
--- a/.github/workflows/ci-software-factory.yaml
+++ b/.github/workflows/ci-software-factory.yaml
@@ -46,9 +46,12 @@ jobs:
       fail-fast: false
       matrix:
         shard:
-          - { index: 1, total: 3 }
-          - { index: 2, total: 3 }
-          - { index: 3, total: 3 }
+          - index: 1
+            total: 3
+          - index: 2
+            total: 3
+          - index: 3
+            total: 3
     concurrency:
       group: ci-software-factory-shard-${{ matrix.shard.index }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true

--- a/.github/workflows/ci-software-factory.yaml
+++ b/.github/workflows/ci-software-factory.yaml
@@ -39,9 +39,19 @@ jobs:
       caller: ci-software-factory
 
   software-factory-test:
-    name: Software Factory Tests
+    name: Software Factory Tests (shard ${{ matrix.shard.index }}/${{ matrix.shard.total }})
     needs: test-web-assets
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - { index: 1, total: 3 }
+          - { index: 2, total: 3 }
+          - { index: 3, total: 3 }
+    concurrency:
+      group: ci-software-factory-shard-${{ matrix.shard.index }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/init
@@ -59,6 +69,7 @@ jobs:
         run: pnpm exec playwright install
         working-directory: packages/software-factory
       - name: Run Node tests
+        if: ${{ matrix.shard.index == 1 }}
         run: pnpm test:node
         working-directory: packages/software-factory
       - name: Serve test assets (icons + host dist)
@@ -66,13 +77,13 @@ jobs:
           mise run ci:serve-test-assets &
           timeout 180 bash -c 'until curl -sf http://localhost:4200 > /dev/null && curl -sf http://localhost:4206 > /dev/null; do sleep 2; done'
       - name: Run Playwright tests
-        run: pnpm test:playwright
+        run: pnpm test:playwright:shard ${{ matrix.shard.index }}/${{ matrix.shard.total }}
         working-directory: packages/software-factory
       - name: Upload Playwright traces
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: software-factory-playwright-traces
+          name: software-factory-playwright-traces-shard-${{ matrix.shard.index }}
           path: packages/software-factory/test-results/**/trace.zip
           retention-days: 30
           if-no-files-found: ignore

--- a/packages/software-factory/package.json
+++ b/packages/software-factory/package.json
@@ -29,6 +29,7 @@
     "test:node": "NODE_NO_WARNINGS=1 ts-node --transpileOnly scripts/test.ts --node-only",
     "test:playwright": "playwright test",
     "test:playwright:headed": "playwright test --headed",
+    "test:playwright:shard": "playwright test --shard",
     "test:realm": "NODE_NO_WARNINGS=1 ts-node --transpileOnly scripts/run-realm-tests.ts"
   },
   "devDependencies": {

--- a/packages/software-factory/tests/factory-tool-executor.integration.test.ts
+++ b/packages/software-factory/tests/factory-tool-executor.integration.test.ts
@@ -216,7 +216,7 @@ module('factory-tool-executor integration > realm-api requests', function () {
     }
   });
 
-  test('realm-search sends correct QUERY to _search with JSON body', async function (assert) {
+  test('realm-search sends correct QUERY to _federated-search with JSON body', async function (assert) {
     let captured: CapturedRequest | undefined;
 
     let { server, origin } = await startTestServer((req, respond) => {
@@ -253,17 +253,20 @@ module('factory-tool-executor integration > realm-api requests', function () {
 
       assert.strictEqual(result.exitCode, 0);
       assert.strictEqual(captured!.method, 'QUERY');
-      assert.strictEqual(captured!.url, '/user/target/_search');
+      assert.strictEqual(captured!.url, '/_federated-search');
       assert.strictEqual(
         captured!.headers.authorization,
-        'Bearer realm-jwt-for-user',
+        'Bearer realm-server-jwt',
       );
       assert.strictEqual(captured!.headers.accept, SupportedMimeType.CardJson);
       assert.strictEqual(
         captured!.headers['content-type'],
         SupportedMimeType.JSON,
       );
-      assert.strictEqual(captured!.body, query);
+      assert.deepEqual(JSON.parse(captured!.body), {
+        realms: [realmUrl],
+        ...JSON.parse(query),
+      });
     } finally {
       cleanup();
       await stopServer(server);

--- a/packages/software-factory/tests/factory-tool-executor.spec.ts
+++ b/packages/software-factory/tests/factory-tool-executor.spec.ts
@@ -20,6 +20,7 @@ import { buildFactoryTools } from '../src/factory-tool-builder';
 import { fetchCardTypeSchema } from '../src/darkfactory-schemas';
 import {
   baseRealmURLFor,
+  buildServerToken,
   DEFAULT_REALM_OWNER,
   sourceRealmURLFor,
 } from '../src/harness/shared';
@@ -734,11 +735,14 @@ test.describe('realm-search on a private realm', () => {
         '@stranger:localhost',
         [],
       );
+      let unauthorizedRealmServerToken = buildServerToken(
+        '@stranger:localhost',
+      );
       let unauthorizedSetup = buildTestClient({
         realmUrl: realm.realmURL.href,
         realmToken: `Bearer ${unauthorizedToken}`,
         realmServerUrl: realm.realmServerURL.href,
-        realmServerToken: `Bearer ${realm.serverToken}`,
+        realmServerToken: `Bearer ${unauthorizedRealmServerToken}`,
       });
 
       try {


### PR DESCRIPTION
## Summary

CI fixup for #4478 (CS-10643/CS-10850 — `boxel search` federated command). That PR converted `realm-search` to hit `/_federated-search` on the realm server, but the matching integration test in `factory-tool-executor.integration.test.ts` still asserted the old per-realm `_search` shape, so it has been failing on `main` ever since.

In addition, this PR fixes a follow-up integration test for the unauthorized federated-search scenario, and shards the Playwright suite across 3 runners to stop the CI runner from being killed mid-flight.

## What changed

### 1. Updated the unit-level expectations for the federated-search request

| Aspect | Before | After |
| --- | --- | --- |
| URL | `/user/target/_search` | `/_federated-search` |
| Authorization | `Bearer realm-jwt-for-user` | `Bearer realm-server-jwt` (federated uses the server token via `pm.authedRealmServerFetch`) |
| Body | raw `query` JSON string | `{ realms: [realmUrl], ...query }` |

Method (`QUERY`), `Accept` (`CardJson`), and `Content-Type` (`JSON`) were already correct and are unchanged.

The body assertion now uses `assert.deepEqual(JSON.parse(body), …)` rather than a raw string compare — robust to key ordering.

### 2. Fixed the unauthorized search test for the federated-search endpoint

`tests/factory-tool-executor.spec.ts` had a `search with owner token succeeds, search without token fails` test that built a stranger's per-realm token but kept the owner's `realmServerToken`. Since `_federated-search` authenticates via the **realm-server JWT** (not the per-realm one), the unauthorized scenario was being authenticated as the owner and the search was succeeding when it should have been rejected.

Fix: build a dedicated `buildServerToken('@stranger:localhost')` for the unauthorized case so the realm-server JWT also carries a non-permissioned user.

### 3. Shard the Software Factory Playwright job across 3 runners

The single-runner `Software Factory Tests` job was being terminated by GitHub Actions with `The runner has received a shutdown signal` ~9–11 minutes into the Playwright suite. The same shutdown pattern was hitting many recent CI runs across other branches (resource pressure / preemption on the hosted runner). Tests were progressing fine right up to the kill — they just couldn't finish in one runner's lifetime.

Mitigation: fan out the suite using GitHub Actions `strategy.matrix` so each runner only handles ~⅓ of the tests and finishes well within the runner's effective budget.

- New `test:playwright:shard` script forwards to `playwright test --shard`
- `ci-software-factory.yaml` declares a 3-way shard matrix `{index, total}` with per-shard concurrency groups and per-shard trace artifacts
- `pnpm test:node` runs only on shard 1 to avoid duplicating Node-only tests

## Test plan

- [x] `pnpm test:node` in `packages/software-factory` — the renamed `realm-search sends correct QUERY to _federated-search with JSON body` test passes, and `realm-read` / `realm-write` / `realm-delete` integration tests stay green
- [x] `pnpm test:playwright:shard 1/3 -g "search with owner token"` locally — passes
- [x] Verified pre-existing port-allocator IPv4 dual-stack failure is unrelated (fails on `main` too — local macOS quirk, not introduced here)
- [ ] CI green on this branch (3 sharded Software Factory jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)