### PR TITLE
Software factory: fix issue scheduler skipping backlog items after blocker completes

### DIFF
--- a/packages/software-factory/src/issue-scheduler.ts
+++ b/packages/software-factory/src/issue-scheduler.ts
@@ -362,17 +362,30 @@ export class RealmIssueStore implements IssueStore {
 // ---------------------------------------------------------------------------
 
 /**
- * Extract card IDs from a Boxel linksToMany relationship.
+ * Extract card IDs from a Boxel linksToMany relationship, resolved
+ * against the parent card's URL so the result matches `card.id` from
+ * the realm search index.
  *
  * Boxel encodes linksToMany with dotted keys:
  *   "blockedBy.0": { links: { self: "../Issues/abc" } }
  *   "blockedBy.1": { links: { self: "../Issues/def" } }
  *
- * The card ID is extracted from the last path segment of the link URL.
+ * The realm's search index returns each card's `id` as a full URL
+ * (`http://.../Issues/abc`). For the loop's blocker check
+ * (`getUnblockedIssues`) to find a blocker's status in the
+ * `issue.id → status` map, the IDs we put into `blockedBy` must use
+ * the same key space — i.e. also be full URLs. Resolving the
+ * relative `../Issues/abc` link against the parent card's URL gives
+ * us that.
+ *
+ * `parentCardId` is the full URL from `card.id` of the issue whose
+ * relationships we're parsing. Without a valid base we fall back to
+ * the link as-is.
  */
 function extractLinksToManyIds(
   relationships: Record<string, unknown> | undefined,
   fieldName: string,
+  parentCardId: string,
 ): string[] {
   if (!relationships) {
     return [];
@@ -386,16 +399,15 @@ function extractLinksToManyIds(
 
     let rel = value as { links?: { self?: string | null } } | undefined;
     let linkUrl = rel?.links?.self;
-    if (typeof linkUrl === 'string' && linkUrl.length > 0) {
-      // Extract card ID from URL — last path segment
-      // e.g. "../Issues/abc" → "Issues/abc", "https://realm/Issues/abc" → "Issues/abc"
-      let lastSlash = linkUrl.lastIndexOf('/');
-      let secondLastSlash = linkUrl.lastIndexOf('/', lastSlash - 1);
-      if (secondLastSlash >= 0) {
-        ids.push(linkUrl.slice(secondLastSlash + 1));
-      } else {
-        ids.push(linkUrl);
-      }
+    if (typeof linkUrl !== 'string' || linkUrl.length === 0) continue;
+
+    try {
+      ids.push(new URL(linkUrl, parentCardId).href);
+    } catch {
+      // Non-URL parent (e.g. tests using bare ids like "a") — fall
+      // back to the link verbatim. Tests in this case pass already-
+      // matching ids so the lookup still works.
+      ids.push(linkUrl);
     }
   }
 
@@ -413,13 +425,15 @@ function mapCardToSchedulableIssue(
   let attrs = (card.attributes ?? card) as Record<string, unknown>;
   let id = (card.id ?? attrs.id ?? '') as string;
 
-  // Extract blockedBy IDs from relationship links.
-  // Boxel uses dotted keys for linksToMany: "blockedBy.0", "blockedBy.1", etc.
-  // Each has { links: { self: "../Issues/some-id" } } where the last path
-  // segment is the card ID.
+  // Extract blockedBy IDs from relationship links, resolved against
+  // this card's id so the resulting URLs match what other cards'
+  // `card.id` looks like in the search results. Without resolution
+  // the keys would be relative ("Issues/foo") while `issue.id` is
+  // a full URL — getUnblockedIssues would never find the blocker.
   let blockedBy = extractLinksToManyIds(
     card.relationships as Record<string, unknown> | undefined,
     'blockedBy',
+    id,
   );
 
   return {

--- a/packages/software-factory/tests/issue-scheduler.test.ts
+++ b/packages/software-factory/tests/issue-scheduler.test.ts
@@ -389,13 +389,13 @@ module('issue-scheduler > refreshIssueState', function () {
 
 module('issue-scheduler > RealmIssueStore blockedBy resolution', function () {
   // Regression for the production bug observed in factory:go where a
-  // blocked issue ("sticky-board") was never picked even after its
-  // blocker ("sticky-note") had been marked `done`. The realm's
+  // blocked issue ("kanban-board") was never picked even after its
+  // blocker ("kanban-card") had been marked `done`. The realm's
   // search index returns each card's `id` as a full URL
-  // (`http://.../Issues/sticky-note`), but `blockedBy.X.links.self`
-  // is a relative path (`../Issues/sticky-note`). The mapping
+  // (`http://.../Issues/kanban-card`), but `blockedBy.X.links.self`
+  // is a relative path (`../Issues/kanban-card`). The mapping
   // function used to reduce the relative link to its last two path
-  // segments (`Issues/sticky-note`), so the loop's `getUnblockedIssues`
+  // segments (`Issues/kanban-card`), so the loop's `getUnblockedIssues`
   // statusMap (keyed by full URL `issue.id`) never had a hit and
   // every blocked issue stayed blocked forever. Fix resolves the
   // relative link against the parent card's URL so the resulting key
@@ -404,8 +404,8 @@ module('issue-scheduler > RealmIssueStore blockedBy resolution', function () {
     let realmUrl = 'http://localhost:4201/user/my-test-realm/';
     let darkfactoryModuleUrl =
       'http://localhost:4201/software-factory/darkfactory';
-    let stickyNoteId = `${realmUrl}Issues/sticky-note`;
-    let stickyBoardId = `${realmUrl}Issues/sticky-board`;
+    let kanbanCardId = `${realmUrl}Issues/kanban-card`;
+    let kanbanBoardId = `${realmUrl}Issues/kanban-board`;
 
     let mockClient = {
       async search() {
@@ -413,28 +413,28 @@ module('issue-scheduler > RealmIssueStore blockedBy resolution', function () {
           ok: true,
           data: [
             {
-              id: stickyNoteId,
+              id: kanbanCardId,
               attributes: {
                 status: 'done',
                 priority: 'high',
                 order: 1,
-                summary: 'Implement Sticky Note card',
+                summary: 'Implement Kanban Card card',
                 issueType: 'feature',
               },
               relationships: {},
             },
             {
-              id: stickyBoardId,
+              id: kanbanBoardId,
               attributes: {
                 status: 'backlog',
                 priority: 'medium',
                 order: 2,
-                summary: 'Implement Sticky Board card',
+                summary: 'Implement Kanban Board card',
                 issueType: 'feature',
               },
               relationships: {
                 'blockedBy.0': {
-                  links: { self: '../Issues/sticky-note' },
+                  links: { self: '../Issues/kanban-card' },
                 },
               },
             },
@@ -455,13 +455,13 @@ module('issue-scheduler > RealmIssueStore blockedBy resolution', function () {
 
     // The mapping must produce a `blockedBy` entry whose key matches
     // the blocker's `id` exactly. If it doesn't, `getUnblockedIssues`
-    // can't see that the blocker is `done` and `sticky-board` will
+    // can't see that the blocker is `done` and `kanban-board` will
     // be filtered out as still-blocked.
     let picked = scheduler.pickNextIssue();
     assert.strictEqual(
       picked?.id,
-      stickyBoardId,
-      'sticky-board should be picked once sticky-note is done — got: ' +
+      kanbanBoardId,
+      'kanban-board should be picked once kanban-card is done — got: ' +
         (picked === undefined
           ? 'undefined (treated as still blocked)'
           : (picked?.id ?? 'unknown')),

--- a/packages/software-factory/tests/issue-scheduler.test.ts
+++ b/packages/software-factory/tests/issue-scheduler.test.ts
@@ -1,8 +1,14 @@
 import { module, test } from 'qunit';
 
+import type { BoxelCLIClient } from '@cardstack/boxel-cli/api';
+
 import type { SchedulableIssue } from '../src/factory-agent';
 
-import { IssueScheduler, type IssueStore } from '../src/issue-scheduler';
+import {
+  IssueScheduler,
+  RealmIssueStore,
+  type IssueStore,
+} from '../src/issue-scheduler';
 
 // ---------------------------------------------------------------------------
 // MockIssueStore
@@ -374,5 +380,91 @@ module('issue-scheduler > refreshIssueState', function () {
     // Now b should be unblocked
     let next = scheduler.pickNextIssue();
     assert.strictEqual(next?.id, 'b', 'b is now unblocked after a completed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RealmIssueStore.listIssues — regression for blockedBy id resolution
+// ---------------------------------------------------------------------------
+
+module('issue-scheduler > RealmIssueStore blockedBy resolution', function () {
+  // Regression for the production bug observed in factory:go where a
+  // blocked issue ("sticky-board") was never picked even after its
+  // blocker ("sticky-note") had been marked `done`. The realm's
+  // search index returns each card's `id` as a full URL
+  // (`http://.../Issues/sticky-note`), but `blockedBy.X.links.self`
+  // is a relative path (`../Issues/sticky-note`). The mapping
+  // function used to reduce the relative link to its last two path
+  // segments (`Issues/sticky-note`), so the loop's `getUnblockedIssues`
+  // statusMap (keyed by full URL `issue.id`) never had a hit and
+  // every blocked issue stayed blocked forever. Fix resolves the
+  // relative link against the parent card's URL so the resulting key
+  // matches `issue.id`.
+  test('resolves relative blockedBy links against the parent card url', async function (assert) {
+    let realmUrl = 'http://localhost:4201/user/my-test-realm/';
+    let darkfactoryModuleUrl =
+      'http://localhost:4201/software-factory/darkfactory';
+    let stickyNoteId = `${realmUrl}Issues/sticky-note`;
+    let stickyBoardId = `${realmUrl}Issues/sticky-board`;
+
+    let mockClient = {
+      async search() {
+        return {
+          ok: true,
+          data: [
+            {
+              id: stickyNoteId,
+              attributes: {
+                status: 'done',
+                priority: 'high',
+                order: 1,
+                summary: 'Implement Sticky Note card',
+                issueType: 'feature',
+              },
+              relationships: {},
+            },
+            {
+              id: stickyBoardId,
+              attributes: {
+                status: 'backlog',
+                priority: 'medium',
+                order: 2,
+                summary: 'Implement Sticky Board card',
+                issueType: 'feature',
+              },
+              relationships: {
+                'blockedBy.0': {
+                  links: { self: '../Issues/sticky-note' },
+                },
+              },
+            },
+          ],
+        };
+      },
+    } as unknown as BoxelCLIClient;
+
+    let store = new RealmIssueStore({
+      realmUrl,
+      darkfactoryModuleUrl,
+      client: mockClient,
+      workspaceDir: '/tmp/scheduler-blockedby-resolution-fixture',
+    });
+
+    let scheduler = new IssueScheduler(store);
+    await scheduler.loadIssues();
+
+    // The mapping must produce a `blockedBy` entry whose key matches
+    // the blocker's `id` exactly. If it doesn't, `getUnblockedIssues`
+    // can't see that the blocker is `done` and `sticky-board` will
+    // be filtered out as still-blocked.
+    let picked = scheduler.pickNextIssue();
+    assert.strictEqual(
+      picked?.id,
+      stickyBoardId,
+      'sticky-board should be picked once sticky-note is done — got: ' +
+        (picked === undefined
+          ? 'undefined (treated as still blocked)'
+          : (picked?.id ?? 'unknown')),
+    );
   });
 });


### PR DESCRIPTION
As I was exercising the software factory post https://github.com/cardstack/boxel/pull/4492 merge, specifically I was running the `software-factory/Wiki/kanban-board` example, I discovered a bug where the kanban card got created (status = done), but the kanban board was stuck (status = backlog) after the software factory run finished. This fixes the bug so that the scheduler continues working through the backlog. 

## Summary

The scheduler had two ways of writing the same issue's ID, and they didn't match.                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                                           
When it loaded an issue from the realm, it stored its own ID as a full URL: http://localhost:4201/user/my-test-realm/Issues/kanban-card.                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                                                           
But when it read another issue's blockedBy (the list of issues that must finish first), it stored those IDs as relative paths: ../Issues/kanban-card.                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                                                                           
Then when checking "is this blocker done?", it tried to look up ../Issues/kanban-card in a map keyed by the full URL. No match. The scheduler concluded "blocker status unknown, treat as not done", and skipped the dependent issue. Forever.                                                                                                                                                                                                           
                                                                             
The fix: when reading blockedBy, resolve the relative path against the parent issue's URL so both sides use the same full URL. Now the lookup matches.    

