### PR TITLE
Add Alloy log scraper to local observability stack

### DIFF
--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -74,6 +74,14 @@ docker compose up -d
 In Grafana, run a LogQL query like `{env="local"}` against the Loki data
 source to see lines from any other container running on the host.
 
+> **Note**: the local Alloy pipeline drops Docker log entries older than
+> 24 hours before they reach Loki. Loki itself is configured to accept
+> historical entries (`reject_old_samples: false` in `loki/config.yaml`),
+> but Alloy's `stage.drop { older_than = "24h" }` filter prevents the
+> initial backfill of long-lived containers (e.g. a `boxel-pg` that's
+> been up for months) from flooding Loki on first attach. Edit
+> `alloy/config.alloy` and restart the stack if you want a wider window.
+
 ## Loki label schema
 
 The label set is **load-bearing**: dashboards written in LogQL select on

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -35,6 +35,12 @@ grafanactl/
 provisioning/          # mounted into Grafana at /etc/grafana/provisioning/
   datasources/         # data sources (Loki, Postgres, CloudWatch, Prometheus)
   alerting/            # alert rule groups, contact points, notification policies
+alloy/
+  config.alloy         # local log scraper config — discovers Docker containers
+                       # and ships their stdout into Loki
+loki/
+  config.yaml          # local Loki config (single-node, filesystem, accepts
+                       # historical Docker logs)
 scripts/
   apply.sh             # ./scripts/apply.sh --env <local|staging|production>
   pull.sh              # ./scripts/pull.sh  --env <name> --path <dir>
@@ -43,7 +49,7 @@ scripts/
   grafanactl-env.sh    # sourceable; exports GRAFANA_TOKEN from SSM for staging/prod
 templates/
   env-vars.env.example
-docker-compose.yml     # local Grafana 12.4.3 + Loki 3.4.4 (Alloy commented out)
+docker-compose.yml     # local Grafana 12.4.3 + Loki 3.4.4 + Alloy 1.10.0
 ```
 
 ## Local workflow
@@ -52,16 +58,42 @@ docker-compose.yml     # local Grafana 12.4.3 + Loki 3.4.4 (Alloy commented out)
 # One-time: install grafanactl
 brew install --formula grafanactl
 
-# Bring up local Grafana + Loki
+# Bring up local Grafana + Loki + Alloy (log scraper)
 docker compose up -d
 # Grafana: http://localhost:3001  (admin / admin)
 # Loki:    http://localhost:3100
+# Alloy:   http://localhost:12345  (target / pipeline debug UI)
 
 # Verify connectivity
 ./scripts/check.sh --env local
 
 # Apply (no-op until Phase 3 imports dashboards from AMG)
 ./scripts/apply.sh --env local
+```
+
+In Grafana, run a LogQL query like `{env="local"}` against the Loki data
+source to see lines from any other container running on the host.
+
+## Loki label schema
+
+The label set is **load-bearing**: dashboards written in LogQL select on
+these labels, so the local scraper, staging FireLens, and production
+FireLens must all emit the same shape. Pick the schema once, here.
+
+| Label     | Source (local)                              | Source (staging / production)             |
+| --------- | ------------------------------------------- | ----------------------------------------- |
+| `env`     | constant `local` (set in `alloy/config.alloy`) | constant `staging` / `production` (FireLens record_modifier) |
+| `service` | Docker container name, leading `/` stripped | ECS task family, e.g. `realm-server`, `worker`, `synapse` |
+| `realm`   | opt-in via Docker label `boxel.realm=<name>` | realm name from worker/realm-server task env |
+
+The local scraper drops `grafana`, `loki`, and `alloy`'s own log streams
+to keep `{env="local"}` queries clean and avoid a Grafana → Loki feedback
+loop.
+
+To tag a custom local container so dashboards pick it up by realm:
+
+```sh
+docker run --label boxel.realm=test_realm --name my-realm-worker ...
 ```
 
 ## Staging / production workflow
@@ -92,7 +124,8 @@ CI will run `apply.sh --env staging` on merge to main once Phase 4 (CS-10932) la
 | CS-10912  | 2     | landed      | Local `docker-compose.yml` for Grafana   |
 | CS-10913  | 2     | landed      | grafanactl `local`/`staging`/`prod` ctxs |
 | CS-10918  | 2.5   | landed      | Loki container + data source             |
-| CS-10922  | 3     | this PR     | AMG export and reformat                  |
+| CS-10916  | 2.5   | this PR     | Alloy log scraper for local              |
+| CS-10922  | 3     | landed      | AMG export and reformat                  |
 | CS-10932  | 4     | not started | CI: apply to staging on merge            |
 | CS-10933  | 4     | not started | CI: post diff comment on PRs             |
 | CS-10936  | 5     | not started | CI: apply to production                  |
@@ -103,7 +136,6 @@ CI will run `apply.sh --env staging` on merge to main once Phase 4 (CS-10932) la
 
 ## Known cleanups (deferred)
 
-- **Alloy log scraping config.** docker-compose has Alloy commented out; un-comment + add `alloy/config.alloy` to ship logs into local Loki. Separate ticket — not strictly required for Loki data source to be useful.
 - **Staging/production Loki ECS deployment.** Currently no Loki running in staging or production. Staging/production Grafana provisioning expects `${LOKI_URL}` to be set on the ECS task; that's an infra ticket.
 - **`provisioning/` delivery to staging/production ECS.** The provisioning files (data sources + alert rules) need to land on the ECS Grafana container — image bake, S3-init, or EFS mount. Decide and ship as a separate infra ticket.
 - **Secret env-var wiring for data sources.** `provisioning/datasources/*.json` omits `secureJsonData` (passwords, API keys). The staging/production ECS Grafana task needs those env vars set from SSM (`GRAFANA_DB_PASSWORD` etc.) and the provisioning files updated to reference them via `${ENV_VAR}`.

--- a/packages/observability/alloy/config.alloy
+++ b/packages/observability/alloy/config.alloy
@@ -19,13 +19,14 @@ discovery.docker "containers" {
 discovery.relabel "containers" {
 	targets = discovery.docker.containers.targets
 
-	// Drop the observability stack's own containers — querying their logs
-	// in Grafana creates runaway noise and a Grafana → Loki feedback loop.
-	// Matches any container name that contains grafana / loki / alloy
-	// (compose names look like "/<project>-<service>-<replica>").
+	// Drop the observability stack's own Compose services — querying their
+	// logs in Grafana creates runaway noise and a Grafana → Loki feedback
+	// loop. Match the exact Compose service label so unrelated containers
+	// whose names merely contain grafana / loki / alloy (e.g. "loki-migrator")
+	// aren't dropped accidentally.
 	rule {
-		source_labels = ["__meta_docker_container_name"]
-		regex         = ".*(grafana|loki|alloy).*"
+		source_labels = ["__meta_docker_container_label_com_docker_compose_service"]
+		regex         = "^(grafana|loki|alloy)$"
 		action        = "drop"
 	}
 
@@ -36,9 +37,13 @@ discovery.relabel "containers" {
 		target_label  = "service"
 	}
 
-	// Optional realm label, opt-in via Docker label `boxel.realm`.
+	// Optional realm label — only set when the container exposes
+	// `boxel.realm`. Without the (.+) match, the rule would always set the
+	// label (to an empty string), so queries like `realm!=""` would behave
+	// differently from "realm absent".
 	rule {
 		source_labels = ["__meta_docker_container_label_boxel_realm"]
+		regex         = "(.+)"
 		target_label  = "realm"
 	}
 

--- a/packages/observability/alloy/config.alloy
+++ b/packages/observability/alloy/config.alloy
@@ -1,0 +1,77 @@
+// Local-dev log scraper. Discovers running Docker containers via the Docker
+// socket and ships their stdout into Loki with a label schema that mirrors
+// what staging / production FireLens emits.
+//
+// Label schema (load-bearing — see packages/observability/README.md):
+//   env      — environment marker; constant "local" here, "staging" / "production" hosted
+//   service  — container/process name (e.g. realm-server, worker, synapse, postgres)
+//   realm    — opt-in realm name; set per-container via the `boxel.realm` Docker label
+
+logging {
+	level  = "info"
+	format = "logfmt"
+}
+
+discovery.docker "containers" {
+	host = "unix:///var/run/docker.sock"
+}
+
+discovery.relabel "containers" {
+	targets = discovery.docker.containers.targets
+
+	// Drop the observability stack's own containers — querying their logs
+	// in Grafana creates runaway noise and a Grafana → Loki feedback loop.
+	// Matches any container name that contains grafana / loki / alloy
+	// (compose names look like "/<project>-<service>-<replica>").
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = ".*(grafana|loki|alloy).*"
+		action        = "drop"
+	}
+
+	// Docker exposes container name as "/<name>"; strip the leading slash.
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = "/(.*)"
+		target_label  = "service"
+	}
+
+	// Optional realm label, opt-in via Docker label `boxel.realm`.
+	rule {
+		source_labels = ["__meta_docker_container_label_boxel_realm"]
+		target_label  = "realm"
+	}
+
+	// Constant env marker so dashboards can filter local vs hosted in mixed setups.
+	rule {
+		target_label = "env"
+		replacement  = "local"
+		action       = "replace"
+	}
+}
+
+loki.source.docker "containers" {
+	host       = "unix:///var/run/docker.sock"
+	targets    = discovery.relabel.containers.output
+	forward_to = [loki.process.filter_old.receiver]
+}
+
+// Long-running containers (e.g. a `boxel-pg` that's been up for a year)
+// hand Alloy their entire log history when it first attaches. Loki rejects
+// anything outside its small ordering window, generating a 400-storm. Drop
+// anything older than 24h before forwarding so the local feed shows just
+// what's recent.
+loki.process "filter_old" {
+	forward_to = [loki.write.local.receiver]
+
+	stage.drop {
+		older_than          = "24h"
+		drop_counter_reason = "too_old"
+	}
+}
+
+loki.write "local" {
+	endpoint {
+		url = "http://loki:3100/loki/api/v1/push"
+	}
+}

--- a/packages/observability/docker-compose.yml
+++ b/packages/observability/docker-compose.yml
@@ -48,11 +48,11 @@ services:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
     volumes:
-      # In grafana/loki:3.4.4 the bundled local-config.yaml uses /loki as
-      # `path_prefix` (chunks_directory: /loki/chunks, etc.), so the named
-      # volume mounts there to persist the WAL / chunks / TSDB across
-      # container recreates. Verified locally with a push → down/up →
-      # query round-trip.
+      # Custom config (mounted to the same path Loki's image expects so the
+      # default command line keeps working). The on-disk path_prefix is
+      # /loki, so the named volume below mounts there to persist the WAL /
+      # chunks / TSDB across container recreates.
+      - ./loki/config.yaml:/etc/loki/local-config.yaml:ro
       - loki_data:/loki
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3100/ready"]
@@ -62,23 +62,26 @@ services:
       start_period: 5s
     restart: unless-stopped
 
-  # Optional: log scraper (Alloy). Commented out by default — local dev
-  # works without it (Loki is reachable, the data source resolves, queries
-  # return empty until logs are shipped). Uncomment + start once you have
-  # an alloy/config.alloy that scrapes whatever you need locally.
-  #
-  # alloy:
-  #   image: grafana/alloy:v1.10.0
-  #   command:
-  #     - run
-  #     - /etc/alloy/config.alloy
-  #     - --server.http.listen-addr=0.0.0.0:12345
-  #   volumes:
-  #     - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
-  #     - /var/run/docker.sock:/var/run/docker.sock:ro
-  #   depends_on:
-  #     - loki
-  #   restart: unless-stopped
+  # Log scraper. Discovers running Docker containers via the host's
+  # Docker socket and ships their stdout into Loki. See alloy/config.alloy
+  # for the label schema.
+  alloy:
+    image: grafana/alloy:v1.10.0
+    command:
+      - run
+      - /etc/alloy/config.alloy
+      - --server.http.listen-addr=0.0.0.0:12345
+    ports:
+      # Alloy's own UI / debug endpoints — handy for verifying targets are
+      # being discovered (http://localhost:12345/graph). Optional.
+      - "12345:12345"
+    volumes:
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on:
+      loki:
+        condition: service_healthy
+    restart: unless-stopped
 
 volumes:
   grafana_data:

--- a/packages/observability/docker-compose.yml
+++ b/packages/observability/docker-compose.yml
@@ -73,10 +73,15 @@ services:
       - --server.http.listen-addr=0.0.0.0:12345
     ports:
       # Alloy's own UI / debug endpoints — handy for verifying targets are
-      # being discovered (http://localhost:12345/graph). Optional.
-      - "12345:12345"
+      # being discovered (http://localhost:12345/graph). Bound to localhost
+      # so the debug UI isn't reachable from the LAN.
+      - "127.0.0.1:12345:12345"
     volumes:
       - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+      # WARNING: mounting the Docker socket gives this container effective
+      # control of the host's Docker daemon (any container, exec'd as root).
+      # Acceptable for local dev only — never replicate this pattern in
+      # staging/production.
       - /var/run/docker.sock:/var/run/docker.sock:ro
     depends_on:
       loki:

--- a/packages/observability/loki/config.yaml
+++ b/packages/observability/loki/config.yaml
@@ -1,0 +1,40 @@
+# Local-dev Loki config. Single-node, filesystem storage. Tuned for the
+# laptop case: any container the host happens to be running gets scraped,
+# including containers with a year of accumulated stdout from before Alloy
+# was ever pointed at them.
+#
+# `reject_old_samples` is disabled so that historical Docker logs ingest
+# without a 400. Production Loki should not run with this off — that's a
+# separate config in the staging/production ECS deployment.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  # Accept Docker logs of any age — local containers may have months of
+  # backlog when they're first picked up by Alloy.
+  reject_old_samples: false
+  # No rate-limiting needed locally; bump the per-tenant defaults
+  # generously so an initial backfill of N containers doesn't 429.
+  ingestion_rate_mb: 64
+  ingestion_burst_size_mb: 128


### PR DESCRIPTION
## Summary

- Picks up where [PR #4533 (CS-10918)](https://github.com/cardstack/boxel/pull/4533) left off — un-comments the Alloy service in `packages/observability/docker-compose.yml` and ships `alloy/config.alloy` that discovers Docker containers and forwards their stdout into local Loki.
- Locks in the **load-bearing** Loki label schema — `env` / `service` / `realm` — that staging + production FireLens will have to emit identically (companion ticket [CS-10917](https://linear.app/cardstack/issue/CS-10917/dual-ship-realm-server-and-worker-logs-to-cloudwatch-and-loki-via-firelens)).
- Adds a minimal `loki/config.yaml`. The image's bundled config rejects entries older than a few minutes, which generates a 400-storm the first time Alloy attaches to a long-lived container with months of stdout.

## Label schema

| Label     | Source (local)                              | Source (hosted, future FireLens)         |
| --------- | ------------------------------------------- | ----------------------------------------- |
| `env`     | constant `local`                            | constant `staging` / `production`         |
| `service` | Docker container name, leading `/` stripped | ECS task family (`realm-server`, etc.)    |
| `realm`   | opt-in via Docker label `boxel.realm=<name>` | realm name from worker/realm-server task env |

The local scraper drops `grafana` / `loki` / `alloy`'s own log streams to keep `{env="local"}` clean and avoid a Grafana → Loki feedback loop.

`stage.drop { older_than = "24h" }` filters out Docker's archived backlog before it reaches Loki — recent stuff still flows through, but a `boxel-pg` container that's been up for two years no longer 400s the ingester.

## Test plan

- [x] `docker compose up -d` brings up Grafana + Loki + Alloy, all healthy.
- [x] `curl http://localhost:3100/ready` → `200`.
- [x] `curl http://localhost:3100/loki/api/v1/labels` returns `env`, `service`, `service_name`.
- [x] Spinning up `docker run --label boxel.realm=test_realm --name <foo> busybox …` produces a stream in Loki tagged `{env="local", service="<foo>", realm="test_realm"}` after Alloy's ~60s discovery refresh.
- [x] Querying through the Grafana → Loki proxy (`/api/datasources/proxy/uid/loki/loki/api/v1/query_range`) returns the same data.
- [x] `observability-grafana-1` / `observability-loki-1` / `observability-alloy-1` are correctly dropped from `{env="local"}`.
- [x] Alloy log shows `0` errors after 30s of operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)