### PR TITLE
Stateless mutation handlers - realm creation and publishing/unpublishing

### DIFF
--- a/packages/realm-server/handlers/handle-create-realm.ts
+++ b/packages/realm-server/handlers/handle-create-realm.ts
@@ -6,13 +6,8 @@ import {
   setContextResponse,
 } from '../middleware';
 import type Koa from 'koa';
-import type { Realm, RealmInfo } from '@cardstack/runtime-common';
-import {
-  createResponse,
-  DEFAULT_PERMISSIONS,
-  logger,
-  SupportedMimeType,
-} from '@cardstack/runtime-common';
+import type { RealmInfo } from '@cardstack/runtime-common';
+import { logger, SupportedMimeType } from '@cardstack/runtime-common';
 import * as Sentry from '@sentry/node';
 import type { CreateRoutesArgs } from '../routes';
 
@@ -66,21 +61,17 @@ export default function handleCreateRealmRequest({
       return;
     }
 
-    let realm: Realm | undefined;
+    let url: string | undefined;
     let info: Partial<RealmInfo> | undefined;
     let start = Date.now();
-    let indexStart: number | undefined;
     try {
       let result = await createRealm({
         ownerUserId,
         ...json.data.attributes,
       });
-      realm = result.realm;
+      url = result.url;
       info = result.info;
-      log.debug(`created new realm ${realm.url} in ${Date.now() - start} ms`);
-      log.debug(`indexing new realm ${realm.url}`);
-      indexStart = Date.now();
-      await realm.start();
+      log.debug(`created new realm ${url} in ${Date.now() - start} ms`);
     } catch (e: any) {
       if ('status' in e && e.status === 400) {
         await sendResponseForBadRequest(ctxt, e.message);
@@ -93,14 +84,6 @@ export default function handleCreateRealmRequest({
       }
       return;
     } finally {
-      if (realm != null && indexStart != null) {
-        log.debug(
-          `indexing of new realm ${realm.url} ended in ${
-            Date.now() - indexStart
-          } ms`,
-        );
-      }
-
       let creationTimeMs = Date.now() - start;
       if (creationTimeMs > 30_000) {
         let msg = `it took a long time, ${creationTimeMs} ms, to create realm for ${ownerUserId}, ${JSON.stringify(
@@ -111,31 +94,34 @@ export default function handleCreateRealmRequest({
       }
     }
 
-    let response = createResponse({
-      body: JSON.stringify(
+    // Phase 3 PR 2: handler is stateless. createRealm wrote the realm
+    // directory + dual-wrote realm_registry + emitted NOTIFY. The
+    // reconciler on every instance picks up the row and lazy-mounts on
+    // first request. status:'pending' tells the client to poll
+    // /<url>/_readiness-check before treating the realm as ready.
+    let response = new Response(
+      JSON.stringify(
         {
           data: {
             type: 'realm',
-            id: realm.url,
-            attributes: { ...json.data.attributes, ...info },
+            id: url,
+            attributes: {
+              ...json.data.attributes,
+              ...info,
+              status: 'pending',
+            },
           },
         },
         null,
         2,
       ),
-      init: {
-        status: 201,
+      {
+        status: 202,
         headers: {
           'content-type': SupportedMimeType.JSONAPI,
         },
       },
-      requestContext: {
-        realm,
-        permissions: {
-          [ownerUserId]: DEFAULT_PERMISSIONS,
-        },
-      },
-    });
+    );
     await setContextResponse(ctxt, response);
     return;
   };

--- a/packages/realm-server/handlers/handle-create-realm.ts
+++ b/packages/realm-server/handlers/handle-create-realm.ts
@@ -6,8 +6,13 @@ import {
   setContextResponse,
 } from '../middleware';
 import type Koa from 'koa';
-import type { RealmInfo } from '@cardstack/runtime-common';
-import { logger, SupportedMimeType } from '@cardstack/runtime-common';
+import type { Realm, RealmInfo } from '@cardstack/runtime-common';
+import {
+  createResponse,
+  DEFAULT_PERMISSIONS,
+  logger,
+  SupportedMimeType,
+} from '@cardstack/runtime-common';
 import * as Sentry from '@sentry/node';
 import type { CreateRoutesArgs } from '../routes';
 
@@ -62,6 +67,7 @@ export default function handleCreateRealmRequest({
     }
 
     let url: string | undefined;
+    let realm: Realm | undefined;
     let info: Partial<RealmInfo> | undefined;
     let start = Date.now();
     try {
@@ -70,6 +76,7 @@ export default function handleCreateRealmRequest({
         ...json.data.attributes,
       });
       url = result.url;
+      realm = result.realm;
       info = result.info;
       log.debug(`created new realm ${url} in ${Date.now() - start} ms`);
     } catch (e: any) {
@@ -94,13 +101,15 @@ export default function handleCreateRealmRequest({
       }
     }
 
-    // Phase 3 PR 2: handler is stateless. createRealm wrote the realm
-    // directory + dual-wrote realm_registry + emitted NOTIFY. The
-    // reconciler on every instance picks up the row and lazy-mounts on
-    // first request. status:'pending' tells the client to poll
-    // /<url>/_readiness-check before treating the realm as ready.
-    let response = new Response(
-      JSON.stringify(
+    // Phase 3 PR 2: createRealm wrote the realm directory + the
+    // realm_registry row, then mounted + started the realm via the
+    // reconciler so it's fully indexed on this instance. The 202 +
+    // status:'pending' is for sibling instances — they pick up the
+    // realm via NOTIFY realm_registry and lazy-mount on first
+    // request. Clients should poll /<url>/_readiness-check before
+    // treating the realm as ready globally.
+    let response = createResponse({
+      body: JSON.stringify(
         {
           data: {
             type: 'realm',
@@ -115,13 +124,19 @@ export default function handleCreateRealmRequest({
         null,
         2,
       ),
-      {
+      init: {
         status: 202,
         headers: {
           'content-type': SupportedMimeType.JSONAPI,
         },
       },
-    );
+      requestContext: {
+        realm,
+        permissions: {
+          [ownerUserId]: DEFAULT_PERMISSIONS,
+        },
+      },
+    });
     await setContextResponse(ctxt, response);
     return;
   };

--- a/packages/realm-server/handlers/handle-delete-realm.ts
+++ b/packages/realm-server/handlers/handle-delete-realm.ts
@@ -12,7 +12,6 @@ import {
   type PublishedRealmTable,
   update,
 } from '@cardstack/runtime-common';
-import { pathExistsSync, removeSync } from 'fs-extra';
 import { join } from 'path';
 import * as Sentry from '@sentry/node';
 import {
@@ -27,8 +26,8 @@ import {
 import type { CreateRoutesArgs } from '../routes';
 import type { RealmServerTokenClaim } from '../utils/jwt';
 import {
-  destroyMountedRealm,
   removeRealmDatabaseArtifacts,
+  removeRealmFiles,
 } from './realm-destruction-utils';
 import {
   deleteFromRegistryByUrl,
@@ -45,9 +44,7 @@ interface DeleteRealmJSON {
 
 export default function handleDeleteRealm({
   dbAdapter,
-  realms,
   realmsRootPath,
-  virtualNetwork,
 }: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
     let token = ctxt.state.token as RealmServerTokenClaim;
@@ -93,13 +90,20 @@ export default function handleDeleteRealm({
     let realmURL = parsedRealmURL.href;
 
     try {
-      let sourceRealm = realms.find(
-        (realm) => ensureTrailingSlash(realm.url) === realmURL,
-      );
-      if (!sourceRealm) {
+      // Phase 3 PR 2: source-realm existence and disk location come from
+      // realm_registry, not from realms[]. The handler is stateless — it
+      // doesn't read or mutate realms[]/virtualNetwork. The reconciler
+      // does the unmount on every instance after the registry DELETE +
+      // NOTIFY.
+      let sourceRow = (await query(dbAdapter, [
+        `SELECT disk_id FROM realm_registry WHERE url =`,
+        param(realmURL),
+      ])) as { disk_id: string }[];
+      if (sourceRow.length === 0) {
         await sendResponseForNotFound(ctxt, `Realm not found: ${realmURL}`);
         return;
       }
+      let sourceRealmPath = join(realmsRootPath, sourceRow[0].disk_id);
 
       let publishedRealmMatch = (await query(dbAdapter, [
         `SELECT id FROM published_realms WHERE published_realm_url =`,
@@ -135,14 +139,6 @@ export default function handleDeleteRealm({
         return;
       }
 
-      if (!sourceRealm.dir) {
-        await sendResponseForNotFound(
-          ctxt,
-          `Realm files not found on disk for ${realmURL}`,
-        );
-        return;
-      }
-
       // Serialize concurrent writers for this source realm. Lock is on the
       // source URL — a concurrent unpublish of one of the associated
       // published realms uses a different lock key (its own published URL),
@@ -156,31 +152,15 @@ export default function handleDeleteRealm({
         ])) as Pick<PublishedRealmTable, 'id' | 'published_realm_url'>[];
 
         for (let publishedRealm of publishedRealms) {
-          let mountedPublishedRealm = realms.find(
-            (realm) =>
-              ensureTrailingSlash(realm.url) ===
-              ensureTrailingSlash(publishedRealm.published_realm_url),
-          );
           let publishedRealmPath = join(
             realmsRootPath,
             PUBLISHED_DIRECTORY_NAME,
             publishedRealm.id,
           );
-          if (mountedPublishedRealm) {
-            destroyMountedRealm({
-              realm: mountedPublishedRealm,
-              realmPath: publishedRealmPath,
-              realms,
-              virtualNetwork,
-            });
-          } else {
-            try {
-              if (pathExistsSync(publishedRealmPath)) {
-                removeSync(publishedRealmPath);
-              }
-            } catch (error) {
-              Sentry.captureException(error);
-            }
+          try {
+            removeRealmFiles(publishedRealmPath);
+          } catch (error) {
+            Sentry.captureException(error);
           }
           await removeRealmPermissions(
             dbAdapter,
@@ -197,9 +177,10 @@ export default function handleDeleteRealm({
           param(realmURL),
         ]);
 
-        // Phase 1 dual-write: remove the source realm's registry row plus
-        // every published row sourced from it. Both helpers log and continue
-        // on failure; drift self-heals on next boot.
+        // Removes the source realm's registry row plus every published
+        // row sourced from it; both DELETEs emit NOTIFY realm_registry
+        // so the reconciler unmounts the affected realms on every
+        // instance.
         await deletePublishedFromRegistryBySource(dbAdapter, realmURL);
         await deleteFromRegistryByUrl(dbAdapter, realmURL);
 
@@ -217,15 +198,7 @@ export default function handleDeleteRealm({
           ` AND removed_at IS NULL`,
         ]);
 
-        destroyMountedRealm({
-          realm: sourceRealm,
-          // Non-null assertion: we early-returned above if sourceRealm.dir was
-          // undefined. TS narrowing doesn't propagate into this async closure,
-          // so we reassert.
-          realmPath: sourceRealm.dir!,
-          realms,
-          virtualNetwork,
-        });
+        removeRealmFiles(sourceRealmPath);
         await removeRealmPermissions(dbAdapter, parsedRealmURL);
         await removeRealmDatabaseArtifacts({
           dbAdapter,

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -4,7 +4,6 @@ import {
   query,
   SupportedMimeType,
   logger,
-  createResponse,
   insertPermissions,
   insert,
   asExpressions,
@@ -42,6 +41,7 @@ import type { CreateRoutesArgs } from '../routes';
 import type { RealmServerTokenClaim } from '../utils/jwt';
 import { registerUser } from '../synapse';
 import { passwordFromSeed } from '@cardstack/runtime-common/matrix-client';
+import { enqueueReindexRealmJob } from '@cardstack/runtime-common/jobs/reindex-realm';
 import { mirrorPublishedRealmToRegistry } from '../lib/realm-registry-writes';
 import { withRealmWriteLock } from '../lib/realm-advisory-locks';
 
@@ -141,13 +141,13 @@ function rewriteHostHomeForPublishedRealm(
 export default function handlePublishRealm({
   dbAdapter,
   matrixClient,
+  queue,
   realmSecretSeed,
   serverURL,
   virtualNetwork,
   realms,
   realmsRootPath,
   getMatrixRegistrationSecret,
-  createAndMountRealm,
   domainsForPublishedRealms,
 }: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
@@ -295,29 +295,26 @@ export default function handlePublishRealm({
       // race through those pre-lock steps (which would otherwise orphan a
       // Matrix user / permissions row when one of them fails on the
       // published_realms insert).
-      let { realm, lastPublishedAt, publishedRealmId } =
-        await withRealmWriteLock(dbAdapter, publishedRealmURL, async () => {
-          let existingPublishedRealm = realms.find(
-            (r) => r.url === publishedRealmURL,
-          );
+      //
+      // Phase 3 PR 2: handler is stateless. After the FS swap + DB write +
+      // NOTIFY realm_registry, the reconciler on every instance lazily
+      // mounts the (re-)published realm on its first request. The
+      // response is 202 Accepted with status:'pending'; the client polls
+      // /<publishedRealmURL>/_readiness-check to learn when it's ready.
+      let { lastPublishedAt, publishedRealmId } = await withRealmWriteLock(
+        dbAdapter,
+        publishedRealmURL,
+        async () => {
+          let existingRows = (await query(dbAdapter, [
+            `SELECT id, owner_username FROM published_realms WHERE published_realm_url =`,
+            param(publishedRealmURL),
+          ])) as Pick<PublishedRealmTable, 'id' | 'owner_username'>[];
+          let isNewRealm = existingRows.length === 0;
 
-          let userId;
-          let realmUsername;
           let publishedRealmId: string;
+          let realmUsername: string;
 
-          if (existingPublishedRealm) {
-            let results = (await query(dbAdapter, [
-              `SELECT id, owner_username FROM published_realms WHERE published_realm_url =`,
-              param(publishedRealmURL),
-            ])) as Pick<PublishedRealmTable, 'id' | 'owner_username'>[];
-            if (!results.length) {
-              throw new Error(
-                `Published realm record not found for ${publishedRealmURL}`,
-              );
-            }
-            publishedRealmId = results[0].id;
-            realmUsername = `realm/${PUBLISHED_DIRECTORY_NAME}_${publishedRealmId}`;
-          } else {
+          if (isNewRealm) {
             publishedRealmId = uuidv4();
             realmUsername = `realm/${PUBLISHED_DIRECTORY_NAME}_${publishedRealmId}`;
 
@@ -328,15 +325,24 @@ export default function handlePublishRealm({
               password: await passwordFromSeed(realmUsername, realmSecretSeed),
               registrationSecret: await getMatrixRegistrationSecret(),
             });
-            userId = newUserId;
 
             await insertPermissions(dbAdapter, new URL(publishedRealmURL), {
-              [userId]: ['read', 'realm-owner'],
+              [newUserId]: ['read', 'realm-owner'],
               [ownerUserId]: ['read', 'realm-owner'],
               '*': ['read'],
             });
+          } else {
+            publishedRealmId = existingRows[0].id;
+            realmUsername = `realm/${PUBLISHED_DIRECTORY_NAME}_${publishedRealmId}`;
           }
 
+          // Read the source realm's mount state for `.indexing()` /
+          // `.flushUpdateEvents()` / `.dir`. Reading realms[] is allowed
+          // — the stateless rule prohibits *mutating* realms[] /
+          // virtualNetwork. The source realm is necessarily mounted on
+          // this instance (the publish request hits this realm-server,
+          // and the request path lazy-mounts it via findOrMountRealm
+          // upstream of this handler).
           let sourceRealm = realms.find((r) => r.url === sourceRealmURL);
           if (!sourceRealm?.dir) {
             throw new Error(
@@ -354,18 +360,17 @@ export default function handlePublishRealm({
           // Copy source to a temporary directory first, then swap it into
           // place so that a failed copy doesn't destroy the existing
           // published realm (e.g. due to disk-full or permission errors).
+          //
+          // Phase 3 PR 2: no unmount-before-swap here. The currently-mounted
+          // realm (if this is a republish) keeps serving from its existing
+          // mount during the swap window; its NodeAdapter file watcher
+          // picks up the post-swap files. We follow up with an
+          // enqueueReindexRealmJob below to refresh the index.
           let tempCopyPath = `${publishedRealmPath}.tmp`;
           let backupPath = `${publishedRealmPath}.backup`;
           removeSync(tempCopyPath);
           removeSync(backupPath);
           copySync(sourceRealmPath, tempCopyPath);
-          // Unmount the existing published realm before swapping the
-          // directory so it can't serve requests from a partially
-          // replaced filesystem.
-          if (existingPublishedRealm) {
-            realms.splice(realms.indexOf(existingPublishedRealm), 1);
-            virtualNetwork.unmount(existingPublishedRealm.handle);
-          }
           try {
             if (existsSync(publishedRealmPath)) {
               moveSync(publishedRealmPath, backupPath);
@@ -405,30 +410,9 @@ export default function handlePublishRealm({
             param(publishedRealmURL),
           ]);
 
-          let mountedRealm = createAndMountRealm(
-            publishedRealmPath,
-            publishedRealmURL,
-            new URL(sourceRealmURL),
-            false,
-          );
-          await mountedRealm.start();
-
-          // reindexing is to ensure that prerendered templates that get copied over
-          // to the published realm get regenerated - we want this so that the
-          // places in the templates that refer to model.id are updated to the new
-          // published realm URL (for example in the og:url meta tag).
-          await mountedRealm.fullIndex(userInitiatedPriority);
-
           let lastPublishedAt = Date.now().toString();
           try {
-            if (existingPublishedRealm) {
-              await query(dbAdapter, [
-                `UPDATE published_realms SET last_published_at =`,
-                param(lastPublishedAt),
-                `WHERE published_realm_url =`,
-                param(publishedRealmURL),
-              ]);
-            } else {
+            if (isNewRealm) {
               let { valueExpressions, nameExpressions } = asExpressions({
                 id: publishedRealmId,
                 owner_username: realmUsername,
@@ -440,19 +424,26 @@ export default function handlePublishRealm({
                 dbAdapter,
                 insert('published_realms', nameExpressions, valueExpressions),
               );
+            } else {
+              await query(dbAdapter, [
+                `UPDATE published_realms SET last_published_at =`,
+                param(lastPublishedAt),
+                `WHERE published_realm_url =`,
+                param(publishedRealmURL),
+              ]);
             }
           } catch (dbError: any) {
-            // Clean up the mounted realm so we don't leave an orphan
-            // without a corresponding published_realms DB record
-            realms.splice(realms.indexOf(mountedRealm), 1);
-            virtualNetwork.unmount(mountedRealm.handle);
+            // Phase 3 PR 2 rollback simplification: no in-memory
+            // realms[]/virtualNetwork state to unwind. Just remove the
+            // FS swap that we just put in place.
             removeSync(publishedRealmPath);
             throw dbError;
           }
 
-          // Phase 1 dual-write: mirror the published realm into realm_registry.
-          // Logs and continues on failure (shadow data; boot-time backfill
-          // re-syncs on next boot). See lib/realm-registry-writes.ts.
+          // Mirror the published realm into realm_registry. The DELETE +
+          // INSERT inside this helper emits NOTIFY realm_registry; the
+          // reconciler on every instance reacts by populating
+          // knownByUrl. The realm itself is lazy-mounted on first request.
           await mirrorPublishedRealmToRegistry(dbAdapter, {
             publishedRealmURL,
             publishedRealmId,
@@ -461,11 +452,30 @@ export default function handlePublishRealm({
             lastPublishedAt: Number(lastPublishedAt),
           });
 
-          return { realm: mountedRealm, lastPublishedAt, publishedRealmId };
-        });
+          // Refresh the index. For a new publish this is redundant
+          // (lazy-mount's first start() does its own fullIndex on a
+          // fresh DB), but the from-scratch-index coalesce handler
+          // (CS-10893) collapses both into a single canonical job. For
+          // a republish where the realm is already mounted with a
+          // resolved #startedUp, this is the only mechanism that
+          // re-indexes against the swapped files. clearLastModified
+          // forces every row to re-render even if mtimes appear
+          // unchanged (file copies preserve mtimes).
+          await enqueueReindexRealmJob(
+            publishedRealmURL,
+            realmUsername,
+            queue,
+            dbAdapter,
+            userInitiatedPriority,
+            { clearLastModified: true },
+          );
 
-      let response = createResponse({
-        body: JSON.stringify(
+          return { lastPublishedAt, publishedRealmId };
+        },
+      );
+
+      let response = new Response(
+        JSON.stringify(
           {
             data: {
               type: 'published_realm',
@@ -473,26 +483,21 @@ export default function handlePublishRealm({
               attributes: {
                 sourceRealmURL,
                 publishedRealmURL,
-                lastPublishedAt: lastPublishedAt,
+                lastPublishedAt,
+                status: 'pending',
               },
             },
           },
           null,
           2,
         ),
-        init: {
-          status: 201,
+        {
+          status: 202,
           headers: {
             'content-type': SupportedMimeType.JSONAPI,
           },
         },
-        requestContext: {
-          realm: realm,
-          permissions: {
-            [ownerUserId]: ['read'],
-          },
-        },
-      });
+      );
       await setContextResponse(ctxt, response);
       return;
     } catch (error: any) {

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -483,6 +483,19 @@ export default function handlePublishRealm({
         },
       );
 
+      // Mount + start the published realm on this instance now. The
+      // reconciler's prepareRealmFromRow constructs a Realm and adds
+      // it to realms[] / virtualNetwork; ensureMounted then awaits
+      // realm.start() which awaits the from-scratch-index job we
+      // enqueued above (the chooseFromScratch coalesce JOINs the
+      // start()-enqueued job with ours). By the time we return 202,
+      // indexing is complete on this instance — sibling instances
+      // pick the published realm up via NOTIFY and lazy-mount on
+      // first request. This preserves the test-suite's synchronous-
+      // publish semantics while keeping the handler purely registry-
+      // driven.
+      await reconciler.lookupOrMount(publishedRealmURL);
+
       let response = new Response(
         JSON.stringify(
           {

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -494,10 +494,19 @@ export default function handlePublishRealm({
       // first request. This preserves the test-suite's synchronous-
       // publish semantics while keeping the handler purely registry-
       // driven.
-      await reconciler.lookupOrMount(publishedRealmURL);
+      let publishedRealm = await reconciler.lookupOrMount(publishedRealmURL);
+      if (!publishedRealm) {
+        throw new Error(
+          `expected published realm ${publishedRealmURL} to be mounted after publish — registry row missing or mount failed`,
+        );
+      }
+      let publishedPermissions = await fetchRealmPermissions(
+        dbAdapter,
+        new URL(publishedRealmURL),
+      );
 
-      let response = new Response(
-        JSON.stringify(
+      let response = createResponse({
+        body: JSON.stringify(
           {
             data: {
               type: 'published_realm',
@@ -513,13 +522,17 @@ export default function handlePublishRealm({
           null,
           2,
         ),
-        {
+        init: {
           status: 202,
           headers: {
             'content-type': SupportedMimeType.JSONAPI,
           },
         },
-      );
+        requestContext: {
+          realm: publishedRealm,
+          permissions: publishedPermissions,
+        },
+      });
       await setContextResponse(ctxt, response);
       return;
     } catch (error: any) {

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -145,7 +145,7 @@ export default function handlePublishRealm({
   realmSecretSeed,
   serverURL,
   virtualNetwork,
-  realms,
+  reconciler,
   realmsRootPath,
   getMatrixRegistrationSecret,
   domainsForPublishedRealms,
@@ -337,13 +337,13 @@ export default function handlePublishRealm({
           }
 
           // Read the source realm's mount state for `.indexing()` /
-          // `.flushUpdateEvents()` / `.dir`. Reading realms[] is allowed
-          // — the stateless rule prohibits *mutating* realms[] /
-          // virtualNetwork. The source realm is necessarily mounted on
-          // this instance (the publish request hits this realm-server,
-          // and the request path lazy-mounts it via findOrMountRealm
-          // upstream of this handler).
-          let sourceRealm = realms.find((r) => r.url === sourceRealmURL);
+          // `.flushUpdateEvents()` / `.dir`. Reading the Realm instance
+          // is allowed — the stateless rule prohibits *mutating*
+          // realms[] / virtualNetwork. /_publish-realm is a server-level
+          // endpoint and doesn't pass through serveFromRealm, so the
+          // source realm isn't lazy-mounted upstream; call lookupOrMount
+          // here to mount it on this instance if it isn't already.
+          let sourceRealm = await reconciler.lookupOrMount(sourceRealmURL);
           if (!sourceRealm?.dir) {
             throw new Error(
               `Could not determine filesystem path for source realm ${sourceRealmURL}`,

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -1,5 +1,6 @@
 import type Koa from 'koa';
 import {
+  createResponse,
   fetchUserPermissions,
   query,
   SupportedMimeType,

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -251,6 +251,19 @@ export default function handlePublishRealm({
         userId: ownerUserId,
       });
 
+      // Phase 3: /_publish-realm is a server-level endpoint and bypasses
+      // serveFromRealm, so the source realm isn't lazy-mounted by request
+      // routing. Mount it here on this instance — every downstream call
+      // (the _info fetch below, sourceRealm.indexing()/flushUpdateEvents()/.dir
+      // inside the write lock) needs it published into virtualNetwork.
+      let sourceRealm = await reconciler.lookupOrMount(sourceRealmURL);
+      if (!sourceRealm) {
+        return sendResponseForBadRequest(
+          ctxt,
+          `Source realm ${sourceRealmURL} does not exist`,
+        );
+      }
+
       let sourceRealmSession = createJWT(
         {
           user: ownerUserId,
@@ -336,14 +349,10 @@ export default function handlePublishRealm({
             realmUsername = `realm/${PUBLISHED_DIRECTORY_NAME}_${publishedRealmId}`;
           }
 
-          // Read the source realm's mount state for `.indexing()` /
-          // `.flushUpdateEvents()` / `.dir`. Reading the Realm instance
-          // is allowed — the stateless rule prohibits *mutating*
-          // realms[] / virtualNetwork. /_publish-realm is a server-level
-          // endpoint and doesn't pass through serveFromRealm, so the
-          // source realm isn't lazy-mounted upstream; call lookupOrMount
-          // here to mount it on this instance if it isn't already.
-          let sourceRealm = await reconciler.lookupOrMount(sourceRealmURL);
+          // The source realm was lookupOrMounted at the top of the
+          // handler. Use it for `.indexing()` / `.flushUpdateEvents()` /
+          // `.dir`. Reading the Realm instance is allowed — the
+          // stateless rule prohibits *mutating* realms[] / virtualNetwork.
           if (!sourceRealm?.dir) {
             throw new Error(
               `Could not determine filesystem path for source realm ${sourceRealmURL}`,

--- a/packages/realm-server/handlers/handle-unpublish-realm.ts
+++ b/packages/realm-server/handlers/handle-unpublish-realm.ts
@@ -3,7 +3,6 @@ import {
   query,
   SupportedMimeType,
   logger,
-  createResponse,
   param,
   removeRealmPermissions,
   type PublishedRealmTable,
@@ -22,7 +21,7 @@ import {
 } from '../middleware';
 import type { CreateRoutesArgs } from '../routes';
 import type { RealmServerTokenClaim } from '../utils/jwt';
-import { removeMountedRealm } from './realm-destruction-utils';
+import { removeRealmFiles } from './realm-destruction-utils';
 import { deleteFromRegistryByUrl } from '../lib/realm-registry-writes';
 import { withRealmWriteLock } from '../lib/realm-advisory-locks';
 
@@ -30,8 +29,6 @@ const log = logger('handle-unpublish');
 
 export default function handleUnpublishRealm({
   dbAdapter,
-  virtualNetwork,
-  realms,
   realmsRootPath,
 }: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
@@ -102,43 +99,32 @@ export default function handleUnpublishRealm({
         return;
       }
 
-      let existingPublishedRealm = realms.find(
-        (r) => r.url === publishedRealmURL,
-      );
-      if (!existingPublishedRealm) {
-        throw new Error(
-          `No realm instance found for published realm ${publishedRealmURL}`,
-        );
-      }
-
       let publishedRealmPath = join(
         realmsRootPath,
         PUBLISHED_DIRECTORY_NAME,
         publishedRealmInfo.id,
       );
-      // Serialize concurrent writers for this realm URL (publish/unpublish/
-      // realm.write). Lock released on callback exit.
+      // Phase 3 PR 2: handler is stateless. Serialize concurrent writers
+      // for this realm URL via the per-URL advisory lock, then do FS +
+      // DB only — no realms[]/virtualNetwork mutation here. The
+      // deleteFromRegistryByUrl emits NOTIFY realm_registry; the
+      // reconciler on every instance (origin included) reacts by
+      // unmounting the realm.
       await withRealmWriteLock(dbAdapter, publishedRealmURL, async () => {
-        await removeMountedRealm({
-          realm: existingPublishedRealm,
-          realmPath: publishedRealmPath,
-          realms,
-          virtualNetwork,
-        });
+        removeRealmFiles(publishedRealmPath);
 
         await query(dbAdapter, [
           `DELETE FROM published_realms WHERE published_realm_url =`,
           param(publishedRealmURL),
         ]);
 
-        // Phase 1 dual-write: mirror the delete into realm_registry.
         await deleteFromRegistryByUrl(dbAdapter, publishedRealmURL);
 
         await removeRealmPermissions(dbAdapter, new URL(publishedRealmURL));
       });
 
-      let response = createResponse({
-        body: JSON.stringify(
+      let response = new Response(
+        JSON.stringify(
           {
             data: {
               type: 'unpublished_realm',
@@ -153,29 +139,13 @@ export default function handleUnpublishRealm({
           null,
           2,
         ),
-        init: {
+        {
           status: 200,
           headers: {
             'content-type': SupportedMimeType.JSONAPI,
           },
         },
-        requestContext: existingPublishedRealm
-          ? {
-              realm: existingPublishedRealm,
-              permissions: {
-                [ownerUserId]: ['read'],
-              },
-            }
-          : {
-              realm:
-                realms.find(
-                  (r) => r.url === publishedRealmInfo.source_realm_url,
-                ) || realms[0],
-              permissions: {
-                [ownerUserId]: ['read'],
-              },
-            },
-      });
+      );
       await setContextResponse(ctxt, response);
       return;
     } catch (error: any) {

--- a/packages/realm-server/handlers/handle-unpublish-realm.ts
+++ b/packages/realm-server/handlers/handle-unpublish-realm.ts
@@ -1,5 +1,6 @@
 import type Koa from 'koa';
 import {
+  createResponse,
   query,
   SupportedMimeType,
   logger,
@@ -21,6 +22,7 @@ import {
 } from '../middleware';
 import type { CreateRoutesArgs } from '../routes';
 import type { RealmServerTokenClaim } from '../utils/jwt';
+import type { Realm } from '@cardstack/runtime-common';
 import {
   collectAllFilePaths,
   removeRealmFiles,
@@ -142,8 +144,16 @@ export default function handleUnpublishRealm({
         await removeRealmPermissions(dbAdapter, new URL(publishedRealmURL));
       });
 
-      let response = new Response(
-        JSON.stringify(
+      // Permissions for the published realm were removed inside the
+      // write lock above, so fetchRealmPermissions(publishedRealmURL)
+      // would return nothing useful for X-Boxel-Realm-Public-Readable.
+      // Pass an empty permissions map — createResponse just needs
+      // realm.url for X-Boxel-Realm-Url.
+      let realmForResponse = publishedRealm ?? {
+        url: publishedRealmURL,
+      };
+      let response = createResponse({
+        body: JSON.stringify(
           {
             data: {
               type: 'unpublished_realm',
@@ -158,13 +168,17 @@ export default function handleUnpublishRealm({
           null,
           2,
         ),
-        {
+        init: {
           status: 200,
           headers: {
             'content-type': SupportedMimeType.JSONAPI,
           },
         },
-      );
+        requestContext: {
+          realm: realmForResponse as Realm,
+          permissions: {},
+        },
+      });
       await setContextResponse(ctxt, response);
       return;
     } catch (error: any) {

--- a/packages/realm-server/handlers/handle-unpublish-realm.ts
+++ b/packages/realm-server/handlers/handle-unpublish-realm.ts
@@ -21,7 +21,10 @@ import {
 } from '../middleware';
 import type { CreateRoutesArgs } from '../routes';
 import type { RealmServerTokenClaim } from '../utils/jwt';
-import { removeRealmFiles } from './realm-destruction-utils';
+import {
+  collectAllFilePaths,
+  removeRealmFiles,
+} from './realm-destruction-utils';
 import { deleteFromRegistryByUrl } from '../lib/realm-registry-writes';
 import { withRealmWriteLock } from '../lib/realm-advisory-locks';
 
@@ -30,6 +33,7 @@ const log = logger('handle-unpublish');
 export default function handleUnpublishRealm({
   dbAdapter,
   realmsRootPath,
+  reconciler,
 }: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
     let token = ctxt.state.token as RealmServerTokenClaim;
@@ -104,13 +108,28 @@ export default function handleUnpublishRealm({
         PUBLISHED_DIRECTORY_NAME,
         publishedRealmInfo.id,
       );
-      // Phase 3 PR 2: handler is stateless. Serialize concurrent writers
-      // for this realm URL via the per-URL advisory lock, then do FS +
-      // DB only — no realms[]/virtualNetwork mutation here. The
-      // deleteFromRegistryByUrl emits NOTIFY realm_registry; the
-      // reconciler on every instance (origin included) reacts by
-      // unmounting the realm.
+
+      // Mount the published realm on this instance (no-op if already
+      // mounted) so we have a Realm instance to drive the tombstone
+      // path before deleting files. Phase 3 sibling-instance behavior
+      // is unchanged: those instances see deleteFromRegistryByUrl's
+      // NOTIFY realm_registry and unmount via the reconciler.
+      let publishedRealm = await reconciler.lookupOrMount(publishedRealmURL);
+
+      // Serialize concurrent writers for this realm URL via the per-
+      // URL advisory lock, then drive tombstones via realm.deleteAll
+      // (bumps realm_version + marks every boxel_index entry as
+      // deleted, matching the legacy unpublish behavior), then do FS
+      // + DB cleanup. realms[] / virtualNetwork mutation stays in the
+      // reconciler's hands — it reacts to the registry DELETE +
+      // NOTIFY below.
       await withRealmWriteLock(dbAdapter, publishedRealmURL, async () => {
+        if (publishedRealm) {
+          let allFilePaths = collectAllFilePaths(publishedRealmPath);
+          if (allFilePaths.length > 0) {
+            await publishedRealm.deleteAll(allFilePaths);
+          }
+        }
         removeRealmFiles(publishedRealmPath);
 
         await query(dbAdapter, [

--- a/packages/realm-server/handlers/realm-destruction-utils.ts
+++ b/packages/realm-server/handlers/realm-destruction-utils.ts
@@ -1,140 +1,28 @@
-import type {
-  DBAdapter,
-  Realm,
-  VirtualNetwork,
-} from '@cardstack/runtime-common';
+import type { DBAdapter } from '@cardstack/runtime-common';
 import {
   cancelRunningJobsInConcurrencyGroup,
-  ensureTrailingSlash,
   param,
   query,
 } from '@cardstack/runtime-common';
-import { pathExistsSync, readdirSync, removeSync } from 'fs-extra';
-import { join, relative } from 'path';
+import { pathExistsSync, removeSync } from 'fs-extra';
 
-export function collectAllFilePaths(realmPath: string): string[] {
-  let allPaths: string[] = [];
-
-  function traverseDirectory(currentPath: string, basePath: string) {
-    if (!pathExistsSync(currentPath)) {
-      return;
-    }
-
-    let entries;
-    try {
-      entries = readdirSync(currentPath, { withFileTypes: true });
-    } catch {
-      return;
-    }
-
-    for (let entry of entries) {
-      let fullPath = join(currentPath, entry.name);
-
-      if (entry.isDirectory()) {
-        traverseDirectory(fullPath, basePath);
-      } else {
-        let relativePath = relative(basePath, fullPath).replace(/\\/g, '/');
-        if (relativePath) {
-          allPaths.push(relativePath);
-        }
-      }
-    }
-  }
-
-  traverseDirectory(realmPath, realmPath);
-  return allPaths;
-}
-
-export async function removeMountedRealm(args: {
-  realm: Realm;
-  realmPath: string;
-  realms: Realm[];
-  virtualNetwork: VirtualNetwork;
-}) {
-  let { realm, realmPath, realms, virtualNetwork } = args;
-  let cleanupError: Error | undefined;
-
-  realm.unsubscribe();
-
-  try {
-    let allFilePaths = collectAllFilePaths(realmPath);
-    if (allFilePaths.length > 0) {
-      await realm.deleteAll(allFilePaths);
-    }
-
-    if (pathExistsSync(realmPath)) {
-      removeSync(realmPath);
-    }
-  } catch (error) {
-    cleanupError =
-      error instanceof Error
-        ? error
-        : new Error(`Failed to remove realm at ${realmPath}: ${String(error)}`);
-  }
-
-  try {
-    virtualNetwork.unmount(realm.handle);
-  } catch (error) {
-    cleanupError ??=
-      error instanceof Error
-        ? error
-        : new Error(`Failed to unmount realm ${realm.url}: ${String(error)}`);
-  }
-
-  let realmIndex = realms.findIndex(
-    (candidate) =>
-      ensureTrailingSlash(candidate.url) === ensureTrailingSlash(realm.url),
-  );
-  if (realmIndex !== -1) {
-    realms.splice(realmIndex, 1);
-  }
-
-  if (cleanupError) {
-    throw cleanupError;
-  }
-}
-
-export function destroyMountedRealm(args: {
-  realm: Realm;
-  realmPath: string;
-  realms: Realm[];
-  virtualNetwork: VirtualNetwork;
-}) {
-  let { realm, realmPath, realms, virtualNetwork } = args;
-  let cleanupError: Error | undefined;
-
-  realm.unsubscribe();
-
-  try {
-    if (pathExistsSync(realmPath)) {
-      removeSync(realmPath);
-    }
-  } catch (error) {
-    cleanupError =
-      error instanceof Error
-        ? error
-        : new Error(`Failed to remove realm at ${realmPath}: ${String(error)}`);
-  }
-
-  try {
-    virtualNetwork.unmount(realm.handle);
-  } catch (error) {
-    cleanupError ??=
-      error instanceof Error
-        ? error
-        : new Error(`Failed to unmount realm ${realm.url}: ${String(error)}`);
-  }
-
-  let realmIndex = realms.findIndex(
-    (candidate) =>
-      ensureTrailingSlash(candidate.url) === ensureTrailingSlash(realm.url),
-  );
-  if (realmIndex !== -1) {
-    realms.splice(realmIndex, 1);
-  }
-
-  if (cleanupError) {
-    throw cleanupError;
+// Phase 3 PR 2: handlers stop touching mount state. This util is a
+// pure FS removal — `rm -rf` against the realm directory. The realm-
+// registry DELETE that the caller performs in the same transaction
+// emits a realm_registry NOTIFY; the reconciler on every instance
+// (including the origin) reacts to that NOTIFY by unmounting the
+// realm and unsubscribing it. Handlers no longer need to call
+// `virtualNetwork.unmount`, `realms.splice`, or `realm.unsubscribe`.
+//
+// Per-file `realm.deleteAll(...)` is also gone: the previous
+// implementation broadcast Matrix `realm-event:remove` messages for
+// each file, but those events were a side-effect of the old
+// handler-owned mount lifecycle. Subscribers that care about realm
+// removal can listen to the realm_registry NOTIFY directly (or its
+// downstream effect — reconciler → virtualNetwork.unmount).
+export function removeRealmFiles(realmPath: string): void {
+  if (pathExistsSync(realmPath)) {
+    removeSync(realmPath);
   }
 }
 

--- a/packages/realm-server/handlers/realm-destruction-utils.ts
+++ b/packages/realm-server/handlers/realm-destruction-utils.ts
@@ -4,7 +4,44 @@ import {
   param,
   query,
 } from '@cardstack/runtime-common';
-import { pathExistsSync, removeSync } from 'fs-extra';
+import { pathExistsSync, readdirSync, removeSync } from 'fs-extra';
+import { join, relative } from 'path';
+
+// Walk a realm's on-disk directory and return every file's path relative
+// to the realm root. Used by the unpublish handler to drive tombstone
+// inserts via Realm.deleteAll() before the directory is removed.
+export function collectAllFilePaths(realmPath: string): string[] {
+  let allPaths: string[] = [];
+
+  function traverseDirectory(currentPath: string, basePath: string) {
+    if (!pathExistsSync(currentPath)) {
+      return;
+    }
+
+    let entries;
+    try {
+      entries = readdirSync(currentPath, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (let entry of entries) {
+      let fullPath = join(currentPath, entry.name);
+
+      if (entry.isDirectory()) {
+        traverseDirectory(fullPath, basePath);
+      } else {
+        let relativePath = relative(basePath, fullPath).replace(/\\/g, '/');
+        if (relativePath) {
+          allPaths.push(relativePath);
+        }
+      }
+    }
+  }
+
+  traverseDirectory(realmPath, realmPath);
+  return allPaths;
+}
 
 // Phase 3 PR 2: handlers stop touching mount state. This util is a
 // pure FS removal — `rm -rf` against the realm directory. The realm-

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -92,7 +92,7 @@ export type CreateRoutesArgs = {
     name: string;
     backgroundURL?: string;
     iconURL?: string;
-  }) => Promise<{ url: string; info: Partial<RealmInfo> }>;
+  }) => Promise<{ url: string; realm: Realm; info: Partial<RealmInfo> }>;
   serveHostApp: (ctxt: Koa.Context, next: Koa.Next) => Promise<any>;
   serveIndex: (ctxt: Koa.Context, next: Koa.Next) => Promise<any>;
   serveFromRealm: (ctxt: Koa.Context, next: Koa.Next) => Promise<any>;

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -80,13 +80,6 @@ export type CreateRoutesArgs = {
   reconciler: RealmRegistryReconciler;
   realmsRootPath: string;
   getMatrixRegistrationSecret: () => Promise<string>;
-  createAndMountRealm: (
-    path: string,
-    url: string,
-    copiedFromRealm?: URL,
-    enableFileWatcher?: boolean,
-    fromScratchIndexPriority?: number,
-  ) => Realm;
   createRealm: ({
     ownerUserId,
     endpoint,
@@ -99,7 +92,7 @@ export type CreateRoutesArgs = {
     name: string;
     backgroundURL?: string;
     iconURL?: string;
-  }) => Promise<{ realm: Realm; info: Partial<RealmInfo> }>;
+  }) => Promise<{ url: string; info: Partial<RealmInfo> }>;
   serveHostApp: (ctxt: Koa.Context, next: Koa.Next) => Promise<any>;
   serveIndex: (ctxt: Koa.Context, next: Koa.Next) => Promise<any>;
   serveFromRealm: (ctxt: Koa.Context, next: Koa.Next) => Promise<any>;

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -19,7 +19,6 @@ import {
   DEFAULT_FILE_SIZE_LIMIT_BYTES,
   RealmPaths,
   fetchSessionRoom,
-  userInitiatedPriority,
   hasExtension,
   executableExtensions,
 } from '@cardstack/runtime-common';
@@ -35,7 +34,6 @@ import {
 } from './middleware';
 import convertAcceptHeaderQueryParam from './middleware/convert-accept-header-qp';
 import convertAuthHeaderQueryParam from './middleware/convert-auth-header-qp';
-import { NodeAdapter } from './node-realm';
 import { resolve, join } from 'path';
 import merge from 'lodash/merge';
 
@@ -89,7 +87,6 @@ export class RealmServer {
   private getRegistrationSecret:
     | (() => Promise<string | undefined>)
     | undefined;
-  private enableFileWatcher: boolean;
   private cardSizeLimitBytes: number;
   private fileSizeLimitBytes: number;
   private domainsForPublishedRealms:
@@ -118,7 +115,6 @@ export class RealmServer {
     getIndexHTML,
     matrixRegistrationSecret,
     getRegistrationSecret,
-    enableFileWatcher,
     domainsForPublishedRealms,
     prerenderer,
   }: {
@@ -174,7 +170,6 @@ export class RealmServer {
     this.getIndexHTML = getIndexHTML;
     this.matrixRegistrationSecret = matrixRegistrationSecret;
     this.getRegistrationSecret = getRegistrationSecret;
-    this.enableFileWatcher = enableFileWatcher ?? false;
     this.domainsForPublishedRealms = domainsForPublishedRealms;
     // Pass-by-reference: handlers and the reconciler both mutate this
     // array. Copying it would create two divergent views of mounted
@@ -240,7 +235,6 @@ export class RealmServer {
           assetsURL: this.assetsURL,
           realmsRootPath: this.realmsRootPath,
           getMatrixRegistrationSecret: this.getMatrixRegistrationSecret,
-          createAndMountRealm: this.createAndMountRealm,
           domainsForPublishedRealms: this.domainsForPublishedRealms,
           prerenderer: this.prerenderer,
           reconciler: this.reconciler,
@@ -938,20 +932,20 @@ export class RealmServer {
     name: string;
     backgroundURL?: string;
     iconURL?: string;
-  }): Promise<{ realm: Realm; info: Partial<RealmInfo> }> => {
-    let realmAtServerRoot = this.realms.find((r) => {
-      let realmUrl = new URL(r.url);
-
-      return (
-        realmUrl.href.replace(/\/$/, '') === realmUrl.origin &&
-        realmUrl.hostname === this.serverURL.hostname
-      );
-    });
-
-    if (realmAtServerRoot) {
+  }): Promise<{ url: string; info: Partial<RealmInfo> }> => {
+    // Server-root collision check uses the registry as the source of
+    // truth — every realm on this server has a realm_registry row, so
+    // the realms[] array isn't needed here. (Phase 3 PR 2: handlers
+    // don't read or mutate realms[].)
+    let serverRootUrl = this.serverURL.origin + '/';
+    let serverRootRows = (await query(this.dbAdapter, [
+      `SELECT url FROM realm_registry WHERE url =`,
+      param(serverRootUrl),
+    ])) as { url: string }[];
+    if (serverRootRows.length > 0) {
       throw errorWithStatus(
         400,
-        `Cannot create a realm: a realm is already mounted at the origin of this server: ${realmAtServerRoot.url}`,
+        `Cannot create a realm: a realm is already registered at the origin of this server: ${serverRootRows[0].url}`,
       );
     }
     if (!endpoint.match(/^[a-z0-9-]+$/)) {
@@ -970,8 +964,11 @@ export class RealmServer {
       this.serverURL,
     ).href;
 
-    let existingRealmURLs = this.realms.map((r) => r.url);
-    if (existingRealmURLs.includes(url)) {
+    let existingRows = (await query(this.dbAdapter, [
+      `SELECT url FROM realm_registry WHERE url =`,
+      param(url),
+    ])) as { url: string }[];
+    if (existingRows.length > 0) {
       throw errorWithStatus(
         400,
         `realm '${url}' already exists on this server`,
@@ -992,10 +989,7 @@ export class RealmServer {
     // same URL (concurrent createRealm for the same endpoint, or a
     // concurrent publish/unpublish/delete). This is almost never a real
     // concurrency concern — the endpoint was already checked above for
-    // collision. realm.write() and /_atomic are NOT yet wired into
-    // withRealmWriteLock (that requires moving the lock primitive into
-    // runtime-common or threading it through the Realm constructor — a
-    // deferred follow-up tracked alongside CS-10898).
+    // collision.
     await withRealmWriteLock(this.dbAdapter, url, async () => {
       await insertPermissions(this.dbAdapter, new URL(url), {
         [ownerUserId]: DEFAULT_PERMISSIONS,
@@ -1014,8 +1008,9 @@ export class RealmServer {
         },
       });
 
-      // Phase 1 dual-write: register the source realm in realm_registry after
-      // its on-disk representation is in place. Logs and continues on failure.
+      // Register the source realm in realm_registry. The INSERT emits
+      // NOTIFY realm_registry; the reconciler on every instance picks
+      // up the row, and the realm is lazy-mounted on first request.
       await mirrorSourceRealmToRegistry(this.dbAdapter, {
         url,
         diskId: `${ownerUsername}/${endpoint}`,
@@ -1023,69 +1018,18 @@ export class RealmServer {
       });
     });
 
-    let realm = this.createAndMountRealm(
-      realmPath,
-      url,
-      undefined,
-      undefined,
-      userInitiatedPriority,
-    );
+    // virtualNetwork URL mapping was historically bridged here so a
+    // virtual realm URL (e.g. cardstack.com/base/) routed to the
+    // physical localhost URL. For dynamically-created realms via
+    // /_create-realm, the URL is already a physical
+    // serverURL-rooted URL (no remap needed), but preserve the
+    // detection-and-add for any environment that maps it.
     let actualRealmURL = this.virtualNetwork.mapURL(url, 'virtual-to-real');
     if (actualRealmURL && actualRealmURL.href !== url) {
       this.virtualNetwork.addURLMapping(new URL(url), actualRealmURL);
     }
 
-    return {
-      realm,
-      info,
-    };
-  };
-
-  private createAndMountRealm = (
-    path: string,
-    url: string,
-    copiedFromRealm?: URL,
-    enableFileWatcher?: boolean,
-    fromScratchIndexPriority?: number,
-  ) => {
-    let adapter = new NodeAdapter(
-      resolve(path),
-      enableFileWatcher ?? this.enableFileWatcher,
-    );
-    const realmOptions: {
-      copiedFromRealm?: URL;
-      fromScratchIndexPriority?: number;
-    } = {};
-    if (copiedFromRealm) {
-      realmOptions.copiedFromRealm = copiedFromRealm;
-    }
-    if (fromScratchIndexPriority !== undefined) {
-      realmOptions.fromScratchIndexPriority = fromScratchIndexPriority;
-    }
-    let realm = new Realm(
-      {
-        url,
-        adapter,
-        secretSeed: this.realmSecretSeed,
-        virtualNetwork: this.virtualNetwork,
-        dbAdapter: this.dbAdapter,
-        queue: this.queue,
-        matrixClient: this.matrixClient,
-        realmServerURL: this.serverURL.href,
-        definitionLookup: this.definitionLookup,
-        cardSizeLimitBytes: this.cardSizeLimitBytes,
-        fileSizeLimitBytes: this.fileSizeLimitBytes,
-      },
-      Object.keys(realmOptions).length ? realmOptions : undefined,
-    );
-    this.realms.push(realm);
-    this.virtualNetwork.mount(realm.handle);
-    // Tell the reconciler this realm is already mounted on this process so a
-    // subsequent reconcile() pass that sees the row doesn't double-mount it
-    // via mountFromRow. Phase 3 PR 1: handlers still own this push/mount;
-    // Phase 3 PR 2 will hand the lifecycle to the reconciler entirely.
-    this.reconciler.registerExistingMounts([realm]);
-    return realm;
+    return { url, info };
   };
 
   private sendEvent = async (

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -315,6 +315,13 @@ export class RealmServer {
     return this.findOrMountRealm(requestURL);
   }
 
+  // Test-only synchronous reconcile pass. The production reconciler
+  // wakes on NOTIFY realm_registry, but tests need a deterministic
+  // way to drive the post-DELETE unmount path without polling.
+  testingOnlyReconcile(): Promise<void> {
+    return this.reconciler.reconcile();
+  }
+
   private serveIndex = async (ctxt: Koa.Context, next: Koa.Next) => {
     let acceptHeader = ctxt.header.accept ?? '';
     let lowerAcceptHeader = acceptHeader.toLowerCase();

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -1,9 +1,12 @@
 import Koa from 'koa';
 import cors from '@koa/cors';
 import { Memoize } from 'typescript-memoize';
-import type { DefinitionLookup, RealmInfo } from '@cardstack/runtime-common';
-import {
+import type {
+  DefinitionLookup,
   Realm,
+  RealmInfo,
+} from '@cardstack/runtime-common';
+import {
   logger,
   SupportedMimeType,
   insertPermissions,

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -1065,10 +1065,11 @@ export class RealmServer {
       this.virtualNetwork.addURLMapping(new URL(url), actualRealmURL);
     }
 
-    // Phase 3: enqueue the from-scratch index job synchronously so the
-    // queue worker can pick it up regardless of which instance ends up
-    // mounting the realm. Previously this was implicit in
-    // `realm.start()`, which the stateless handler no longer calls.
+    // Phase 3: enqueue the from-scratch-index job at userInitiatedPriority
+    // so the canonical (post-coalesce) job carries that priority — even
+    // if reconciler.lookupOrMount below also enqueues one at the default
+    // systemInitiatedPriority via realm.start(). The chooseFromScratch
+    // coalesce JOINs same-realm jobs and keeps maxPriority.
     await enqueueReindexRealmJob(
       url,
       ownerUsername,
@@ -1076,6 +1077,14 @@ export class RealmServer {
       this.dbAdapter,
       userInitiatedPriority,
     );
+
+    // Mount + start the realm on this instance now. ensureMounted
+    // awaits realm.start(), which awaits the from-scratch-index job.
+    // By the time we return 202, indexing is complete on this
+    // instance, so the queue is idle by the time the test framework
+    // tears down. Sibling instances pick the realm up via NOTIFY and
+    // lazy-mount on first request.
+    await this.reconciler.lookupOrMount(url);
 
     return { url, info };
   };

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -636,8 +636,10 @@ export class RealmServer {
     // boot + LISTEN/poll. A request that arrives between a sibling
     // instance's POST /_create-realm (or /_publish-realm) and this
     // instance's reconciler picking up NOTIFY would otherwise 404.
-    // Fall through to a direct registry probe — try descending path
-    // prefixes against realm_registry.url.
+    // Fall through to a direct registry probe — match on every path
+    // prefix and let Postgres pick the longest URL so a request to
+    // `/foo/bar/baz/file.json` resolves to `/foo/bar/baz/` if that's
+    // registered, not `/foo/` (both prefixes are valid candidates).
     let candidatePaths = candidateRealmURLs(requestURL);
     if (candidatePaths.length === 0) {
       return undefined;
@@ -651,7 +653,7 @@ export class RealmServer {
     let rows = (await query(this.dbAdapter, [
       `SELECT url FROM realm_registry WHERE url IN`,
       ...inClause,
-      `LIMIT 1`,
+      `ORDER BY LENGTH(url) DESC LIMIT 1`,
     ])) as { url: string }[];
     if (rows.length === 0) {
       return undefined;
@@ -968,7 +970,7 @@ export class RealmServer {
     name: string;
     backgroundURL?: string;
     iconURL?: string;
-  }): Promise<{ url: string; info: Partial<RealmInfo> }> => {
+  }): Promise<{ url: string; realm: Realm; info: Partial<RealmInfo> }> => {
     // Server-root collision check. Read realms[] AND realm_registry —
     // every production realm has a registry row, but test fixtures
     // construct CLI-style realms via runTestRealmServer that don't
@@ -1093,15 +1095,24 @@ export class RealmServer {
       userInitiatedPriority,
     );
 
-    // Mount + start the realm on this instance now. ensureMounted
-    // awaits realm.start(), which awaits the from-scratch-index job.
-    // By the time we return 202, indexing is complete on this
-    // instance, so the queue is idle by the time the test framework
-    // tears down. Sibling instances pick the realm up via NOTIFY and
-    // lazy-mount on first request.
-    await this.reconciler.lookupOrMount(url);
+    // Synchronously mount + start the realm on the *handling* instance.
+    // The 202 response with status:'pending' is for sibling instances —
+    // they pick up the realm via NOTIFY realm_registry and lazy-mount
+    // on first request. On this instance the realm is fully ready by
+    // the time we return: ensureMounted publishes into realms[] /
+    // virtualNetwork via prepareRealmFromRow and awaits realm.start(),
+    // which awaits the from-scratch-index job. Mounting eagerly here
+    // also drains the queue locally so the test framework's teardown
+    // (close server → drain runner → close DB) doesn't race a worker
+    // mid-fetch on the now-closed HTTP listener.
+    let realm = await this.reconciler.lookupOrMount(url);
+    if (!realm) {
+      throw new Error(
+        `expected realm ${url} to be mounted after createRealm — registry row missing or mount failed`,
+      );
+    }
 
-    return { url, info };
+    return { url, realm, info };
   };
 
   private sendEvent = async (

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -969,11 +969,26 @@ export class RealmServer {
     backgroundURL?: string;
     iconURL?: string;
   }): Promise<{ url: string; info: Partial<RealmInfo> }> => {
-    // Server-root collision check uses the registry as the source of
-    // truth — every realm on this server has a realm_registry row, so
-    // the realms[] array isn't needed here. (Phase 3 PR 2: handlers
-    // don't read or mutate realms[].)
+    // Server-root collision check. Read realms[] AND realm_registry —
+    // every production realm has a registry row, but test fixtures
+    // construct CLI-style realms via runTestRealmServer that don't
+    // mirror to the registry. Either source matching the origin is a
+    // collision. (Phase 3 PR 2: handlers don't *mutate* realms[]; read
+    // is fine.)
     let serverRootUrl = this.serverURL.origin + '/';
+    let realmAtServerRoot = this.realms.find((r) => {
+      let realmUrl = new URL(r.url);
+      return (
+        realmUrl.href.replace(/\/$/, '') === realmUrl.origin &&
+        realmUrl.hostname === this.serverURL.hostname
+      );
+    });
+    if (realmAtServerRoot) {
+      throw errorWithStatus(
+        400,
+        `Cannot create a realm: a realm is already mounted at the origin of this server: ${realmAtServerRoot.url}`,
+      );
+    }
     let serverRootRows = (await query(this.dbAdapter, [
       `SELECT url FROM realm_registry WHERE url =`,
       param(serverRootUrl),
@@ -981,7 +996,7 @@ export class RealmServer {
     if (serverRootRows.length > 0) {
       throw errorWithStatus(
         400,
-        `Cannot create a realm: a realm is already registered at the origin of this server: ${serverRootRows[0].url}`,
+        `Cannot create a realm: a realm is already mounted at the origin of this server: ${serverRootRows[0].url}`,
       );
     }
     if (!endpoint.match(/^[a-z0-9-]+$/)) {

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -24,7 +24,9 @@ import {
   fetchSessionRoom,
   hasExtension,
   executableExtensions,
+  userInitiatedPriority,
 } from '@cardstack/runtime-common';
+import { enqueueReindexRealmJob } from '@cardstack/runtime-common/jobs/reindex-realm';
 import { ensureDirSync, writeJSONSync, existsSync } from 'fs-extra';
 import { setupCloseHandler } from './node-realm';
 import {
@@ -630,7 +632,31 @@ export class RealmServer {
         return await this.reconciler.lookupOrMount(url);
       }
     }
-    return undefined;
+    // Phase 3: knownByUrl is populated by reconciler.reconcile() on
+    // boot + LISTEN/poll. A request that arrives between a sibling
+    // instance's POST /_create-realm (or /_publish-realm) and this
+    // instance's reconciler picking up NOTIFY would otherwise 404.
+    // Fall through to a direct registry probe — try descending path
+    // prefixes against realm_registry.url.
+    let candidatePaths = candidateRealmURLs(requestURL);
+    if (candidatePaths.length === 0) {
+      return undefined;
+    }
+    let inClause: (string | ReturnType<typeof param>)[] = ['('];
+    candidatePaths.forEach((u, idx) => {
+      if (idx > 0) inClause.push(',');
+      inClause.push(param(u));
+    });
+    inClause.push(')');
+    let rows = (await query(this.dbAdapter, [
+      `SELECT url FROM realm_registry WHERE url IN`,
+      ...inClause,
+      `LIMIT 1`,
+    ])) as { url: string }[];
+    if (rows.length === 0) {
+      return undefined;
+    }
+    return await this.reconciler.lookupOrMount(rows[0].url);
   }
 
   private async getPublishedRealmInfo(
@@ -1039,6 +1065,18 @@ export class RealmServer {
       this.virtualNetwork.addURLMapping(new URL(url), actualRealmURL);
     }
 
+    // Phase 3: enqueue the from-scratch index job synchronously so the
+    // queue worker can pick it up regardless of which instance ends up
+    // mounting the realm. Previously this was implicit in
+    // `realm.start()`, which the stateless handler no longer calls.
+    await enqueueReindexRealmJob(
+      url,
+      ownerUsername,
+      this.queue,
+      this.dbAdapter,
+      userInitiatedPriority,
+    );
+
     return { url, info };
   };
 
@@ -1117,4 +1155,19 @@ function errorWithStatus(
   let error = new Error(message);
   (error as Error & { status: number }).status = status;
   return error as Error & { status: number };
+}
+
+// Build candidate realm URLs from a request URL by trimming the
+// pathname segment-by-segment. Used by findOrMountRealm's registry
+// fallback when knownByUrl is stale. Includes the origin-only form
+// (root realm) and every prefix that ends with a slash.
+function candidateRealmURLs(requestURL: URL): string[] {
+  let segments = requestURL.pathname.split('/').filter(Boolean);
+  let candidates: string[] = [];
+  // Try longest-prefix first.
+  for (let i = segments.length; i >= 0; i--) {
+    let path = i === 0 ? '/' : '/' + segments.slice(0, i).join('/') + '/';
+    candidates.push(`${requestURL.origin}${path}`);
+  }
+  return [...new Set(candidates)];
 }

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -259,26 +259,84 @@ export function createVirtualNetwork() {
 
 let testDbCounter = 0;
 
-// Build a reconciler suitable for tests that already construct Realms via
-// the test helpers. The realms are pre-mounted by the helper, so we just
-// register them with the reconciler so subsequent lookupOrMount() calls
-// resolve from `mounted`. mountFromRow throws if the request path ever asks
-// the reconciler to mount a URL it wasn't told about — that would indicate
-// a test reaching for a realm the helper didn't construct. unmount is a
-// no-op because tests tear down via closeServer(); the reconciler itself
-// has no row-deletion path to exercise here.
+// Build a reconciler suitable for tests. Pre-constructed realms (passed
+// via `realms`) are registered into `mounted` so subsequent
+// lookupOrMount() calls resolve from the fast path.
+//
+// When `dynamicMountDeps` is provided, prepareRealmFromRow constructs a
+// real Realm from a registry row — required by Phase 3 stateless
+// handler tests where /_create-realm + /_publish-realm only write to
+// realm_registry and rely on the reconciler / lazy mount to mount on
+// first request. Without these deps, lookupOrMount on an
+// unpre-mounted URL throws (used by tests that don't exercise the
+// dynamic-creation path).
+//
+// unmount on the test reconciler calls realm.unsubscribe() (matches
+// production) and removes the realm from realms[] / virtualNetwork so
+// the deletion-path assertions about file-watcher cleanup work the
+// same way they did pre-Phase 3.
 export function makeTestReconciler(
   dbAdapter: PgAdapter,
   realms: Realm[],
+  dynamicMountDeps?: {
+    realmsRootPath: string;
+    virtualNetwork: VirtualNetwork;
+    queue: QueuePublisher;
+    matrixClient: MatrixClient;
+    serverURL: URL;
+    definitionLookup: CachingDefinitionLookup;
+    enableFileWatcher?: boolean;
+  },
 ): RealmRegistryReconciler {
   let reconciler = new RealmRegistryReconciler({
     dbAdapter,
     prepareRealmFromRow: (row: RealmRegistryRow) => {
-      throw new Error(
-        `test reconciler cannot construct realms; URL not pre-mounted: ${row.url}`,
+      if (!dynamicMountDeps) {
+        throw new Error(
+          `test reconciler cannot construct realms; URL not pre-mounted: ${row.url}`,
+        );
+      }
+      let diskPath: string;
+      if (row.kind === 'bootstrap') {
+        diskPath = row.disk_id;
+      } else if (row.kind === 'source') {
+        diskPath = join(dynamicMountDeps.realmsRootPath, row.disk_id);
+      } else {
+        diskPath = join(
+          dynamicMountDeps.realmsRootPath,
+          PUBLISHED_DIRECTORY_NAME,
+          row.disk_id,
+        );
+      }
+      let adapter = new NodeAdapter(
+        diskPath,
+        dynamicMountDeps.enableFileWatcher,
       );
+      let reconciledRealm = new Realm({
+        url: row.url,
+        adapter,
+        secretSeed: realmSecretSeed,
+        virtualNetwork: dynamicMountDeps.virtualNetwork,
+        dbAdapter,
+        queue: dynamicMountDeps.queue,
+        matrixClient: dynamicMountDeps.matrixClient,
+        realmServerURL: dynamicMountDeps.serverURL.href,
+        definitionLookup: dynamicMountDeps.definitionLookup,
+      });
+      realms.push(reconciledRealm);
+      dynamicMountDeps.virtualNetwork.mount(reconciledRealm.handle);
+      return reconciledRealm;
     },
-    unmount: async () => {},
+    unmount: async (realm) => {
+      realm.unsubscribe();
+      if (dynamicMountDeps) {
+        dynamicMountDeps.virtualNetwork.unmount(realm.handle);
+      }
+      let idx = realms.findIndex((r) => r.url === realm.url);
+      if (idx !== -1) {
+        realms.splice(idx, 1);
+      }
+    },
   });
   reconciler.registerExistingMounts(realms);
   return reconciler;
@@ -1004,7 +1062,15 @@ export async function runTestRealmServer({
     seed: realmSecretSeed,
   });
 
-  let reconciler = makeTestReconciler(dbAdapter, realms);
+  let reconciler = makeTestReconciler(dbAdapter, realms, {
+    realmsRootPath,
+    virtualNetwork,
+    queue: publisher,
+    matrixClient,
+    serverURL: new URL(realmURL.origin),
+    definitionLookup,
+    enableFileWatcher,
+  });
   let testRealmServer = new RealmServer({
     realms,
     reconciler,
@@ -1144,7 +1210,15 @@ export async function runTestRealmServerWithRealms({
   });
 
   let serverURL = new URL(realms[0].realmURL.origin);
-  let reconciler = makeTestReconciler(dbAdapter, createdRealms);
+  let reconciler = makeTestReconciler(dbAdapter, createdRealms, {
+    realmsRootPath,
+    virtualNetwork,
+    queue: publisher,
+    matrixClient,
+    serverURL,
+    definitionLookup,
+    enableFileWatcher,
+  });
   let testRealmServer = new RealmServer({
     realms: createdRealms,
     reconciler,

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -831,6 +831,10 @@ module(basename(__filename), function () {
           );
 
         assert.strictEqual(unpublishResponse.status, 200, 'HTTP 200 status');
+        // Phase 3: unmount is reconciler-driven (NOTIFY realm_registry).
+        // Force a reconcile pass so the published realm is unmounted on
+        // this instance before the "404 after unpublish" assertion below.
+        await testRealmServer.testingOnlyReconcile();
         assert.strictEqual(
           unpublishResponse.body.data.type,
           'unpublished_realm',

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -721,7 +721,7 @@ module(basename(__filename), function () {
 
         assert.strictEqual(
           firstPublishResponse.status,
-          201,
+          202,
           'First publish succeeds',
         );
 
@@ -1227,7 +1227,7 @@ module(basename(__filename), function () {
 
         assert.strictEqual(
           republishAfterUnpublishResponse.status,
-          201,
+          202,
           'Republish after unpublish succeeds',
         );
         assert.notEqual(

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -39,7 +39,9 @@ module(basename(__filename), function () {
   module('publish and unpublish realm tests', function (hooks) {
     let testRealmHttpServer: Server;
     let testRealm: Realm;
-    let testRealmServer: Awaited<ReturnType<typeof runTestRealmServer>>['testRealmServer'];
+    let testRealmServer: Awaited<
+      ReturnType<typeof runTestRealmServer>
+    >['testRealmServer'];
     let dbAdapter: PgAdapter;
     let publisher: QueuePublisher;
     let runner: QueueRunner;
@@ -73,23 +75,23 @@ module(basename(__filename), function () {
         testRealmServer: testRealmServer,
         testRealmHttpServer: testRealmHttpServer,
       } = await runTestRealmServer({
-          virtualNetwork,
-          testRealmDir,
-          realmsRootPath: join(dir.name, 'realm_server_3'),
-          realmURL: new URL(testRealm2URL),
-          dbAdapter,
-          publisher,
-          runner,
-          matrixURL,
-          permissions: {
-            '*': ['read', 'write'],
-            [ownerUserId]: DEFAULT_PERMISSIONS,
-          },
-          domainsForPublishedRealms: {
-            boxelSpace: 'localhost',
-            boxelSite: 'localhost:4445',
-          },
-        }));
+        virtualNetwork,
+        testRealmDir,
+        realmsRootPath: join(dir.name, 'realm_server_3'),
+        realmURL: new URL(testRealm2URL),
+        dbAdapter,
+        publisher,
+        runner,
+        matrixURL,
+        permissions: {
+          '*': ['read', 'write'],
+          [ownerUserId]: DEFAULT_PERMISSIONS,
+        },
+        domainsForPublishedRealms: {
+          boxelSpace: 'localhost',
+          boxelSite: 'localhost:4445',
+        },
+      }));
       request = supertest(testRealmHttpServer);
     }
 

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -39,6 +39,7 @@ module(basename(__filename), function () {
   module('publish and unpublish realm tests', function (hooks) {
     let testRealmHttpServer: Server;
     let testRealm: Realm;
+    let testRealmServer: Awaited<ReturnType<typeof runTestRealmServer>>['testRealmServer'];
     let dbAdapter: PgAdapter;
     let publisher: QueuePublisher;
     let runner: QueueRunner;
@@ -67,8 +68,11 @@ module(basename(__filename), function () {
       runner: QueueRunner,
     ) {
       virtualNetwork = createVirtualNetwork();
-      ({ testRealm: testRealm, testRealmHttpServer: testRealmHttpServer } =
-        await runTestRealmServer({
+      ({
+        testRealm: testRealm,
+        testRealmServer: testRealmServer,
+        testRealmHttpServer: testRealmHttpServer,
+      } = await runTestRealmServer({
           virtualNetwork,
           testRealmDir,
           realmsRootPath: join(dir.name, 'realm_server_3'),
@@ -190,7 +194,7 @@ module(basename(__filename), function () {
             }),
           );
 
-        assert.strictEqual(response.status, 201, 'HTTP 201 status');
+        assert.strictEqual(response.status, 202, 'HTTP 202 status');
         assert.strictEqual(response.body.data.type, 'published_realm');
         assert.ok(response.body.data.id, 'published realm has an ID');
         assert.strictEqual(
@@ -205,6 +209,34 @@ module(basename(__filename), function () {
         assert.ok(
           response.body.data.attributes.lastPublishedAt,
           'last published at timestamp is present',
+        );
+        assert.strictEqual(
+          response.body.data.attributes.status,
+          'pending',
+          'status is pending — client should poll _readiness-check',
+        );
+
+        // Phase 3: publish only writes registry + NOTIFY + enqueues
+        // an indexing job. Drive a reconcile pass to mount the new
+        // published realm, then wait for the from-scratch-index job
+        // to populate boxel_index before asserting on it below.
+        let publishedRealmURLEarly =
+          response.body.data.attributes.publishedRealmURL;
+        await testRealmServer.testingOnlyReconcile();
+        await waitUntil(
+          async () => {
+            let rows = await dbAdapter.execute(
+              `SELECT 1 FROM boxel_index WHERE realm_url = $1 LIMIT 1`,
+              { bind: [publishedRealmURLEarly] },
+            );
+            return rows.length > 0 ? rows : undefined;
+          },
+          {
+            timeout: 30_000,
+            interval: 100,
+            timeoutMessage:
+              'boxel_index entries for published realm did not appear',
+          },
         );
 
         // Verify that the correct directory within _published was created
@@ -428,7 +460,7 @@ module(basename(__filename), function () {
             }),
           );
 
-        assert.strictEqual(publishResponse.status, 201, 'HTTP 201 status');
+        assert.strictEqual(publishResponse.status, 202, 'HTTP 202 status');
         let publishedRealmURL =
           publishResponse.body.data.attributes.publishedRealmURL;
         let publishedRealmPath = new URL(publishedRealmURL).pathname;
@@ -543,7 +575,7 @@ module(basename(__filename), function () {
             }),
           );
 
-        assert.strictEqual(response.status, 201, 'HTTP 201 status');
+        assert.strictEqual(response.status, 202, 'HTTP 202 status');
 
         let publishedRealmId = response.body.data.id;
         let publishedRealmPath = join(
@@ -587,7 +619,7 @@ module(basename(__filename), function () {
             }),
           );
 
-        assert.strictEqual(firstResponse.status, 201, 'First publish succeeds');
+        assert.strictEqual(firstResponse.status, 202, 'First publish succeeds');
         let firstTimestamp = firstResponse.body.data.attributes.lastPublishedAt;
 
         // Wait a bit to ensure timestamp difference
@@ -612,7 +644,7 @@ module(basename(__filename), function () {
             }),
           );
 
-        assert.strictEqual(secondResponse.status, 201, 'Republish succeeds');
+        assert.strictEqual(secondResponse.status, 202, 'Republish succeeds');
         assert.strictEqual(
           secondResponse.body.data.id,
           firstResponse.body.data.id,
@@ -729,7 +761,7 @@ module(basename(__filename), function () {
             }),
           );
 
-        assert.strictEqual(republishResponse.status, 201, 'Republish succeeds');
+        assert.strictEqual(republishResponse.status, 202, 'Republish succeeds');
 
         // Verify the file no longer exists on disk in the published realm
         assert.notOk(
@@ -758,7 +790,7 @@ module(basename(__filename), function () {
             }),
           );
 
-        assert.strictEqual(publishResponse.status, 201, 'Publish succeeds');
+        assert.strictEqual(publishResponse.status, 202, 'Publish succeeds');
         let publishedRealmURL =
           publishResponse.body.data.attributes.publishedRealmURL;
 
@@ -959,7 +991,7 @@ module(basename(__filename), function () {
             }),
           );
 
-        assert.strictEqual(publishResponse.status, 201, 'Publish succeeds');
+        assert.strictEqual(publishResponse.status, 202, 'Publish succeeds');
         let publishedRealmURL =
           publishResponse.body.data.attributes.publishedRealmURL;
 
@@ -1048,7 +1080,7 @@ module(basename(__filename), function () {
             }),
           );
 
-        assert.strictEqual(firstResponse.status, 201, 'First publish succeeds');
+        assert.strictEqual(firstResponse.status, 202, 'First publish succeeds');
 
         // Simulate a stale modules cache entry with an error for the published realm
         let moduleUrl = `${publishedRealmURL}my-module`;
@@ -1090,7 +1122,7 @@ module(basename(__filename), function () {
             }),
           );
 
-        assert.strictEqual(secondResponse.status, 201, 'Republish succeeds');
+        assert.strictEqual(secondResponse.status, 202, 'Republish succeeds');
 
         // Verify the stale modules cache entries were cleared
         let modulesAfter = await dbAdapter.execute(
@@ -1127,7 +1159,7 @@ module(basename(__filename), function () {
             }),
           );
 
-        assert.strictEqual(firstResponse.status, 201, 'First publish succeeds');
+        assert.strictEqual(firstResponse.status, 202, 'First publish succeeds');
 
         let republishResponse = await request
           .post('/_publish-realm')
@@ -1147,7 +1179,7 @@ module(basename(__filename), function () {
             }),
           );
 
-        assert.strictEqual(republishResponse.status, 201, `Republish succeeds`);
+        assert.strictEqual(republishResponse.status, 202, `Republish succeeds`);
         assert.strictEqual(
           republishResponse.body.data.id,
           firstResponse.body.data.id,

--- a/packages/realm-server/tests/server-endpoints/delete-realm-test.ts
+++ b/packages/realm-server/tests/server-endpoints/delete-realm-test.ts
@@ -43,7 +43,7 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
         }),
       );
 
-    if (response.status !== 201) {
+    if (response.status !== 202) {
       throw new Error(
         `/_create-realm failed: ${JSON.stringify(response.body)}`,
       );

--- a/packages/realm-server/tests/server-endpoints/delete-realm-test.ts
+++ b/packages/realm-server/tests/server-endpoints/delete-realm-test.ts
@@ -128,8 +128,13 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
         }),
       );
 
-    assert.strictEqual(publishResponse.status, 201, 'published realm created');
+    assert.strictEqual(publishResponse.status, 202, 'published realm created');
     let publishedRealmId = publishResponse.body.data.id as string;
+
+    // Phase 3: publish only writes registry + NOTIFY; drive a reconcile
+    // pass to mount the published realm so the spy assertions below
+    // observe its post-DELETE unmount.
+    await context.testRealmServer.testingOnlyReconcile();
 
     let sourceIndexURL = `${realmURL}cleanup-${uuidv4()}.json`;
     let publishedIndexURL = `${publishedRealmURL}cleanup-${uuidv4()}.json`;
@@ -277,6 +282,9 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
       insert('claimed_domains_for_sites', nameExpressions, valueExpressions),
     );
 
+    // Phase 3: source realm is mounted lazily. The publish handler
+    // above called reconciler.lookupOrMount(sourceRealmURL), so by now
+    // the source realm is in realms[].
     let sourceRealm = context.testRealmServer.testingOnlyRealms.find(
       (realm) => realm.url === realmURL,
     )!;
@@ -308,6 +316,10 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
       );
 
     assert.strictEqual(deleteResponse.status, 204, 'realm deleted');
+    // Phase 3: unmount is reconciler-driven (NOTIFY → reconcile()).
+    // Force a reconcile pass synchronously so the assertion below
+    // doesn't race the LISTEN callback.
+    await context.testRealmServer.testingOnlyReconcile();
     assert.true(
       unsubscribeCalled,
       'file watcher was unsubscribed during realm destruction',
@@ -665,8 +677,10 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
         }),
       );
 
-    assert.strictEqual(publishResponse.status, 201, 'published realm created');
+    assert.strictEqual(publishResponse.status, 202, 'published realm created');
     let publishedRealmId = publishResponse.body.data.id as string;
+    // Phase 3: drive reconcile so the published realm shows up in realms[].
+    await context.testRealmServer.testingOnlyReconcile();
     let publishedRealmPath = join(
       context.dir.name,
       'realm_server_1',
@@ -720,6 +734,8 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
       );
 
     assert.strictEqual(deleteResponse.status, 204, 'realm deleted');
+    // Phase 3: unmount is reconciler-driven.
+    await context.testRealmServer.testingOnlyReconcile();
     assert.false(
       existsSync(publishedRealmPath),
       'published realm directory is removed even when unmounted',

--- a/packages/realm-server/tests/server-endpoints/index-responses-test.ts
+++ b/packages/realm-server/tests/server-endpoints/index-responses-test.ts
@@ -1401,7 +1401,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
               }),
             );
 
-          if (createResponse.status !== 201) {
+          if (createResponse.status !== 202) {
             throw new Error(
               `/_create-realm failed with status ${createResponse.status}: ` +
                 (createResponse.text ||
@@ -1505,7 +1505,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
                 publishedRealmURL: publishedRealmURLString,
               }),
             );
-          if (publishResponse.status !== 201) {
+          if (publishResponse.status !== 202) {
             throw new Error(
               `Failed to publish realm: ${publishResponse.status} ${publishResponse.text}`,
             );

--- a/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
@@ -481,7 +481,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
                 },
               }),
             );
-          assert.strictEqual(response.status, 201, 'HTTP 201 status');
+          assert.strictEqual(response.status, 202, 'HTTP 202 status');
           realmURL = response.body.data.id;
         }
         let initialJobs = await context.dbAdapter.execute('select * from jobs');
@@ -606,7 +606,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
                 },
               }),
             );
-          assert.strictEqual(response.status, 201, 'HTTP 201 status');
+          assert.strictEqual(response.status, 202, 'HTTP 202 status');
           realmURL = response.body.data.id;
         }
         let initialJobs = await context.dbAdapter.execute('select * from jobs');
@@ -840,7 +840,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
                 },
               }),
             );
-          assert.strictEqual(response.status, 201, 'HTTP 201 status');
+          assert.strictEqual(response.status, 202, 'HTTP 202 status');
           realmURL = response.body.data.id;
         }
         let initialJobs = await context.dbAdapter.execute('select * from jobs');
@@ -932,7 +932,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
                 },
               }),
             );
-          assert.strictEqual(response.status, 201, 'HTTP 201 status');
+          assert.strictEqual(response.status, 202, 'HTTP 202 status');
           botRealmURL = response.body.data.id;
         }
 

--- a/packages/realm-server/tests/server-endpoints/realm-lifecycle-test.ts
+++ b/packages/realm-server/tests/server-endpoints/realm-lifecycle-test.ts
@@ -14,7 +14,7 @@ import type { CardCollectionDocument } from '@cardstack/runtime-common/document-
 import { cardSrc } from '@cardstack/runtime-common/etc/test-fixtures';
 import {
   closeServer,
-  createJWT,
+  createJWTForRealmURL,
   matrixURL,
   realmSecretSeed,
   runTestRealmServer,
@@ -63,7 +63,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
             }),
           );
 
-        assert.strictEqual(response.status, 201, 'HTTP 201 status');
+        assert.strictEqual(response.status, 202, 'HTTP 202 status');
         let json = response.body;
         assert.deepEqual(
           json,
@@ -77,6 +77,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
                 backgroundURL: 'http://example.com/background.jpg',
                 iconURL: 'http://example.com/icon.jpg',
                 publishable: true,
+                status: 'pending',
               },
             },
           },
@@ -124,9 +125,10 @@ module(`server-endpoints/${basename(__filename)}`, function () {
         });
 
         let id: string;
-        let realm = context.testRealmServer.testingOnlyRealms.find(
-          (r) => r.url === json.data.id,
-        )!;
+        // Phase 3 lazy mount: the realm isn't in realms[] yet — the
+        // follow-up POST/GET below triggers findOrMountRealm.
+        let realmURL = json.data.id as string;
+        let realmServerURL = testRealmURL.origin + '/';
         {
           // owner can create an instance
           let response = await context.request
@@ -146,11 +148,12 @@ module(`server-endpoints/${basename(__filename)}`, function () {
             .set('Accept', 'application/vnd.card+json')
             .set(
               'Authorization',
-              `Bearer ${createJWT(realm, ownerUserId, [
-                'read',
-                'write',
-                'realm-owner',
-              ])}`,
+              `Bearer ${createJWTForRealmURL({
+                realmURL,
+                realmServerURL,
+                user: ownerUserId,
+                permissions: ['read', 'write', 'realm-owner'],
+              })}`,
             );
 
           assert.strictEqual(response.status, 201, 'HTTP 201 status');
@@ -165,11 +168,12 @@ module(`server-endpoints/${basename(__filename)}`, function () {
             .set('Accept', 'application/vnd.card+json')
             .set(
               'Authorization',
-              `Bearer ${createJWT(realm, ownerUserId, [
-                'read',
-                'write',
-                'realm-owner',
-              ])}`,
+              `Bearer ${createJWTForRealmURL({
+                realmURL,
+                realmServerURL,
+                user: ownerUserId,
+                permissions: ['read', 'write', 'realm-owner'],
+              })}`,
             );
 
           assert.strictEqual(response.status, 200, 'HTTP 200 status');
@@ -184,16 +188,17 @@ module(`server-endpoints/${basename(__filename)}`, function () {
         {
           // owner can search in the realm
           let response = await context.request
-            .post(`${new URL(realm.url).pathname}_search`)
+            .post(`${new URL(realmURL).pathname}_search`)
             .set('Accept', 'application/vnd.card+json')
             .set('X-HTTP-Method-Override', 'QUERY')
             .set(
               'Authorization',
-              `Bearer ${createJWT(realm, ownerUserId, [
-                'read',
-                'write',
-                'realm-owner',
-              ])}`,
+              `Bearer ${createJWTForRealmURL({
+                realmURL,
+                realmServerURL,
+                user: ownerUserId,
+                permissions: ['read', 'write', 'realm-owner'],
+              })}`,
             )
             .send({
               filter: {
@@ -239,17 +244,22 @@ module(`server-endpoints/${basename(__filename)}`, function () {
           );
 
         let realmURL = response.body.data.id;
-        assert.strictEqual(response.status, 201, 'HTTP 201 status');
-        let realm = context.testRealmServer.testingOnlyRealms.find(
-          (r) => r.url === realmURL,
-        )!;
+        assert.strictEqual(response.status, 202, 'HTTP 202 status');
+        let realmServerURL = testRealmURL.origin + '/';
 
         {
           let response = await context.request
             .post(`${new URL(realmURL).pathname}_search`)
             .set('Accept', 'application/vnd.card+json')
             .set('X-HTTP-Method-Override', 'QUERY')
-            .set('Authorization', `Bearer ${createJWT(realm, 'rando')}`)
+            .set(
+              'Authorization',
+              `Bearer ${createJWTForRealmURL({
+                realmURL,
+                realmServerURL,
+                user: 'rando',
+              })}`,
+            )
             .send({
               filter: {
                 on: baseCardRef,
@@ -278,7 +288,14 @@ module(`server-endpoints/${basename(__filename)}`, function () {
               },
             })
             .set('Accept', 'application/vnd.card+json')
-            .set('Authorization', `Bearer ${createJWT(realm, 'rando')}`);
+            .set(
+              'Authorization',
+              `Bearer ${createJWTForRealmURL({
+                realmURL,
+                realmServerURL,
+                user: 'rando',
+              })}`,
+            );
 
           assert.strictEqual(response.status, 403, 'HTTP 403 status');
         }
@@ -315,13 +332,11 @@ module(`server-endpoints/${basename(__filename)}`, function () {
                 },
               }),
             );
-          assert.strictEqual(response.status, 201, 'HTTP 201 status');
+          assert.strictEqual(response.status, 202, 'HTTP 202 status');
           realmURL = response.body.data.id;
         }
 
-        let realm = context.testRealmServer.testingOnlyRealms.find(
-          (r) => r.url === realmURL,
-        )!;
+        let realmServerURL = testRealmURL.origin + '/';
         {
           let response = await context.request
             .post(`/${owner}/${endpoint}/`)
@@ -340,11 +355,12 @@ module(`server-endpoints/${basename(__filename)}`, function () {
             .set('Accept', 'application/vnd.card+json')
             .set(
               'Authorization',
-              `Bearer ${createJWT(realm, ownerUserId, [
-                'read',
-                'write',
-                'realm-owner',
-              ])}`,
+              `Bearer ${createJWTForRealmURL({
+                realmURL,
+                realmServerURL,
+                user: ownerUserId,
+                permissions: ['read', 'write', 'realm-owner'],
+              })}`,
             );
 
           assert.strictEqual(response.status, 201, 'HTTP 201 status');
@@ -590,7 +606,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
               },
             }),
           );
-        assert.strictEqual(response.status, 201, 'HTTP 201 status');
+        assert.strictEqual(response.status, 202, 'HTTP 202 status');
         {
           let response = await context.request
             .post('/_create-realm')
@@ -718,12 +734,10 @@ module(`server-endpoints/${basename(__filename)}`, function () {
                 },
               }),
             );
-          assert.strictEqual(response.status, 201, 'HTTP 201 status');
+          assert.strictEqual(response.status, 202, 'HTTP 202 status');
           providerRealmURL = response.body.data.id;
         }
-        let providerRealm = context.testRealmServer.testingOnlyRealms.find(
-          (r) => r.url === providerRealmURL,
-        )!;
+        let realmServerURL = testRealmURL.origin + '/';
         {
           // create a card def
           let response = await context.request
@@ -731,11 +745,12 @@ module(`server-endpoints/${basename(__filename)}`, function () {
             .set('Accept', 'application/vnd.card+source')
             .set(
               'Authorization',
-              `Bearer ${createJWT(providerRealm, ownerUserId, [
-                'read',
-                'write',
-                'realm-owner',
-              ])}`,
+              `Bearer ${createJWTForRealmURL({
+                realmURL: providerRealmURL,
+                realmServerURL,
+                user: ownerUserId,
+                permissions: ['read', 'write', 'realm-owner'],
+              })}`,
             )
             .send(cardSrc);
           assert.strictEqual(response.status, 204, 'HTTP 204 status');
@@ -769,13 +784,10 @@ module(`server-endpoints/${basename(__filename)}`, function () {
                 },
               }),
             );
-          assert.strictEqual(response.status, 201, 'HTTP 201 status');
+          assert.strictEqual(response.status, 202, 'HTTP 202 status');
           consumerRealmURL = response.body.data.id;
         }
 
-        let consumerRealm = context.testRealmServer.testingOnlyRealms.find(
-          (r) => r.url === consumerRealmURL,
-        )!;
         let id: string;
         {
           // create an instance using card def in different private realm
@@ -798,11 +810,12 @@ module(`server-endpoints/${basename(__filename)}`, function () {
             .set('Accept', 'application/vnd.card+json')
             .set(
               'Authorization',
-              `Bearer ${createJWT(consumerRealm, ownerUserId, [
-                'read',
-                'write',
-                'realm-owner',
-              ])}`,
+              `Bearer ${createJWTForRealmURL({
+                realmURL: consumerRealmURL,
+                realmServerURL,
+                user: ownerUserId,
+                permissions: ['read', 'write', 'realm-owner'],
+              })}`,
             );
 
           assert.strictEqual(response.status, 201, 'HTTP 201 status');
@@ -817,11 +830,12 @@ module(`server-endpoints/${basename(__filename)}`, function () {
             .set('Accept', 'application/vnd.card+json')
             .set(
               'Authorization',
-              `Bearer ${createJWT(consumerRealm, ownerUserId, [
-                'read',
-                'write',
-                'realm-owner',
-              ])}`,
+              `Bearer ${createJWTForRealmURL({
+                realmURL: consumerRealmURL,
+                realmServerURL,
+                user: ownerUserId,
+                permissions: ['read', 'write', 'realm-owner'],
+              })}`,
             );
 
           assert.strictEqual(response.status, 200, 'HTTP 200 status');


### PR DESCRIPTION
## Summary

Phase 3 PR 2 of the DB-Authoritative Realm Registry project. Makes the realm-server's mutation handlers stateless: POST /_create-realm, POST /_publish-realm, DELETE /<published>, and DELETE /<source> no longer mutate \`realms[]\` or \`virtualNetwork\`. The reconciler (or first-request lazy mount via \`findOrMountRealm\`) owns mount lifecycle on every instance.

Stacked on #4537 (CS-10894). Merge that first.

## Changes

**Source — handlers/server**
- \`handle-create-realm\`: drops \`await realm.start()\`. Returns 202 Accepted with \`status: 'pending'\` so the client polls \`_readiness-check\` before treating the realm as ready.
- \`handle-publish-realm\`: stateless cp/swap on disk + DELETE/INSERT in \`published_realms\` + mirror to \`realm_registry\` + enqueue from-scratch index job. Returns 202. The CS-10893 from-scratch-index coalesce makes the enqueue safe on new publishes (deduped against the lazy-mount fullIndex) and load-bearing on republishes. Calls \`reconciler.lookupOrMount(sourceRealmURL)\` to ensure the source realm is mounted on this instance — \`/_publish-realm\` is a server-level endpoint that bypasses \`serveFromRealm\`.
- \`handle-unpublish-realm\` + \`handle-delete-realm\`: drop \`realms[]\`/\`virtualNetwork\` mutation. Source-realm existence check now reads \`realm_registry.disk_id\`. FS removal stays inline; the registry DELETE + NOTIFY drives the reconciler-owned unmount on every instance.
- \`realm-destruction-utils\`: collapse \`removeMountedRealm\` / \`destroyMountedRealm\` into a single FS-only \`removeRealmFiles\`.
- \`server.ts\`: delete \`createAndMountRealm\`. \`createRealm\` returns \`{url, info}\` (no Realm instance). Server-root collision and duplicate-URL checks now query \`realm_registry\` instead of \`this.realms\`. Added \`testingOnlyReconcile()\` so tests can drive a deterministic reconcile pass.
- \`routes.ts\`: drop \`createAndMountRealm\` from \`CreateRoutesArgs\`.

**Tests**
- \`makeTestReconciler\` now optionally accepts \`dynamicMountDeps\` — when provided, \`prepareRealmFromRow\` constructs a real Realm from a registry row (matches main.ts production path); \`unmount\` calls \`realm.unsubscribe()\` and removes from \`realms[]\`/\`virtualNetwork\`. Required by Phase 3 stateless handler tests where \`/_create-realm\` and \`/_publish-realm\` only write to \`realm_registry\` + NOTIFY.
- \`realm-lifecycle-test.ts\`: 201→202, asserts \`status: 'pending'\` in response body, replaces \`testingOnlyRealms.find()\` + \`createJWT(realm,…)\` with \`createJWTForRealmURL\` (Phase 3 lazy-mount-friendly, added in CS-10894).
- \`delete-realm-test.ts\`: 201→202 on publishResponse; \`testingOnlyReconcile()\` after publish so the source realm is in \`realms[]\` for the \`unsubscribe\` spy, and after DELETE so the reconciler-owned unmount completes before assertions.
- \`publish-unpublish-realm-test.ts\`: 201→202 across 12 publish status assertions. The smoke test additionally asserts \`status: 'pending'\` and waits for \`boxel_index\` entries via \`waitUntil\` before downstream assertions.
- \`maintenance-endpoints-test.ts\`, \`index-responses-test.ts\`: 201→202 sweep.

## Test plan
- [ ] CI: realm-server unit tests pass
- [ ] CI: server-endpoints tests pass
- [ ] Local: smoke-publish + indexing job populates \`boxel_index\` (blocked locally by Chrome/Puppeteer env issue that also affects cs-10894 unchanged — CI will validate)
- [ ] Manual: \`/_create-realm\` 202 + \`status: 'pending'\` shape
- [ ] Manual: \`/_publish-realm\` 202 + republish updates timestamp
- [ ] Manual: \`/_delete-realm\` cascades to published copies via reconciler

🤖 Generated with [Claude Code](https://claude.com/claude-code)