### PR TITLE
Fix flaky realm-server test DB-name collisions

### DIFF
--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -252,8 +252,14 @@ export function createVirtualNetwork() {
   return virtualNetwork;
 }
 
+let testDbCounter = 0;
 export function prepareTestDB(): void {
-  process.env.PGDATABASE = `test_db_${Math.floor(10000000 * Math.random())}`;
+  // PID + monotonic counter rules out same-process collisions and makes
+  // cross-process collisions essentially impossible. The previous
+  // `Math.random() * 10_000_000` form had ~0.6% birthday-paradox collision
+  // probability across ~350 tests in a shard, which surfaced in CI as
+  // `database "test_db_<n>" already exists` from cloneTestDBFromTemplate.
+  process.env.PGDATABASE = `test_db_${process.pid}_${++testDbCounter}`;
 }
 
 function pgAdminConnectionConfig() {
@@ -357,6 +363,18 @@ async function cloneTestDBFromTemplate(
   let client = new PgClient(pgAdminConnectionConfig());
   try {
     await client.connect();
+    // Defensive: drop a same-named DB before creating. prepareTestDB() now
+    // produces unique names, but a stray DB from a crashed prior run or a
+    // shared cluster could otherwise resurface as "database already exists".
+    await client.query(
+      `SELECT pg_terminate_backend(pid)
+         FROM pg_stat_activity
+        WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [database],
+    );
+    await client.query(
+      `DROP DATABASE IF EXISTS ${quotePgIdentifier(database)}`,
+    );
     await client.query(
       `CREATE DATABASE ${quotePgIdentifier(database)} TEMPLATE ${quotePgIdentifier(
         templateDatabaseName,
@@ -655,9 +673,9 @@ export function setupDB(
     templateDatabase?: TestDatabaseTemplateProvider;
   } = {},
 ) {
-  let dbAdapter: PgAdapter;
-  let publisher: QueuePublisher;
-  let runner: QueueRunner;
+  let dbAdapter: PgAdapter | undefined;
+  let publisher: QueuePublisher | undefined;
+  let runner: QueueRunner | undefined;
 
   const runBeforeHook = async () => {
     prepareTestDB();
@@ -676,17 +694,29 @@ export function setupDB(
   };
 
   const runAfterHook = async () => {
-    await publisher?.destroy();
+    // Clear refs as we go so a partial-setup beforeEach (e.g. the
+    // create-DB step throws after the previous test already closed
+    // its adapter) can't cascade into "Called end on pool more than
+    // once" when the next afterEach runs against stale closure state.
     if (publisher) {
-      trackedQueuePublishers.delete(publisher);
+      let p = publisher;
+      publisher = undefined;
+      trackedQueuePublishers.delete(p);
+      await p.destroy();
     }
-    await runner?.destroy();
     if (runner) {
-      trackedQueueRunners.delete(runner);
+      let r = runner;
+      runner = undefined;
+      trackedQueueRunners.delete(r);
+      await r.destroy();
     }
-    await dbAdapter?.close();
     if (dbAdapter) {
-      trackedDbAdapters.delete(dbAdapter);
+      let a = dbAdapter;
+      dbAdapter = undefined;
+      trackedDbAdapters.delete(a);
+      if (!a.isClosed) {
+        await a.close();
+      }
     }
   };
 
@@ -702,11 +732,13 @@ export function setupDB(
     }
     hooks.before(async function () {
       await runBeforeHook();
-      await args.before!(dbAdapter, publisher, runner);
+      await args.before!(dbAdapter!, publisher!, runner!);
     });
 
     hooks.after(async function () {
-      await args.after?.(dbAdapter, publisher, runner);
+      if (dbAdapter && publisher && runner) {
+        await args.after?.(dbAdapter, publisher, runner);
+      }
       await runAfterHook();
     });
   }
@@ -719,11 +751,13 @@ export function setupDB(
     }
     hooks.beforeEach(async function () {
       await runBeforeHook();
-      await args.beforeEach!(dbAdapter, publisher, runner);
+      await args.beforeEach!(dbAdapter!, publisher!, runner!);
     });
 
     hooks.afterEach(async function () {
-      await args.afterEach?.(dbAdapter, publisher, runner);
+      if (dbAdapter && publisher && runner) {
+        await args.afterEach?.(dbAdapter, publisher, runner);
+      }
       await runAfterHook();
     });
   }

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -360,21 +360,13 @@ async function cloneTestDBFromTemplate(
     );
   }
 
+  // Defensive: drop a same-named DB before creating. prepareTestDB() now
+  // produces unique names, but a stray DB from a crashed prior run or a
+  // shared cluster could otherwise resurface as "database already exists".
+  await dropDatabase(database);
   let client = new PgClient(pgAdminConnectionConfig());
   try {
     await client.connect();
-    // Defensive: drop a same-named DB before creating. prepareTestDB() now
-    // produces unique names, but a stray DB from a crashed prior run or a
-    // shared cluster could otherwise resurface as "database already exists".
-    await client.query(
-      `SELECT pg_terminate_backend(pid)
-         FROM pg_stat_activity
-        WHERE datname = $1 AND pid <> pg_backend_pid()`,
-      [database],
-    );
-    await client.query(
-      `DROP DATABASE IF EXISTS ${quotePgIdentifier(database)}`,
-    );
     await client.query(
       `CREATE DATABASE ${quotePgIdentifier(database)} TEMPLATE ${quotePgIdentifier(
         templateDatabaseName,
@@ -694,28 +686,46 @@ export function setupDB(
   };
 
   const runAfterHook = async () => {
-    // Clear refs as we go so a partial-setup beforeEach (e.g. the
-    // create-DB step throws after the previous test already closed
-    // its adapter) can't cascade into "Called end on pool more than
-    // once" when the next afterEach runs against stale closure state.
-    if (publisher) {
-      let p = publisher;
-      publisher = undefined;
+    // Snapshot and clear closure refs up front so that, regardless of
+    // how cleanup goes, the next test's beforeEach starts from a clean
+    // slate. A partial-setup beforeEach (e.g. the create-DB step throws
+    // after the previous test already closed its adapter) used to
+    // cascade into "Called end on pool more than once" when the next
+    // afterEach ran against stale closure state.
+    let p = publisher;
+    let r = runner;
+    let a = dbAdapter;
+    publisher = undefined;
+    runner = undefined;
+    dbAdapter = undefined;
+
+    // Each resource's cleanup is independent — a failure in one must
+    // not skip the others. Matches the best-effort pattern used by
+    // closeTrackedDbAdapters / destroyTrackedQueuePublishers / etc.
+    if (p) {
       trackedQueuePublishers.delete(p);
-      await p.destroy();
+      try {
+        await p.destroy();
+      } catch {
+        // best-effort cleanup
+      }
     }
-    if (runner) {
-      let r = runner;
-      runner = undefined;
+    if (r) {
       trackedQueueRunners.delete(r);
-      await r.destroy();
+      try {
+        await r.destroy();
+      } catch {
+        // best-effort cleanup
+      }
     }
-    if (dbAdapter) {
-      let a = dbAdapter;
-      dbAdapter = undefined;
+    if (a) {
       trackedDbAdapters.delete(a);
       if (!a.isClosed) {
-        await a.close();
+        try {
+          await a.close();
+        } catch {
+          // best-effort cleanup
+        }
       }
     }
   };


### PR DESCRIPTION
## Summary

Fixes the `database "test_db_<n>" already exists` flake observed on shard 3 of run 25081996895 (and intermittently elsewhere).

`prepareTestDB()` was generating DB names from a 10M-value space (`Math.random() * 10_000_000`), giving ~0.6% birthday-paradox collision probability across ~350 tests in a shard. When two tests rolled the same name, the cascade was:

1. **beforeEach**: `cloneTestDBFromTemplate` fails — `database "test_db_1300229" already exists`
2. **test body**: runs against partial state, returns 404 instead of expected 403
3. **afterEach**: `Called end on pool more than once` — `setupDB`'s closure-scoped `dbAdapter` still pointed at the *previous* test's already-closed adapter, because the failing assignment in the next beforeEach never reset it.

## What's in this PR

Three changes in `packages/realm-server/tests/helpers/index.ts`:

- **`prepareTestDB`** — names DBs as `test_db_${pid}_${++counter}`. Same-process collisions are impossible; cross-process effectively impossible.
- **`cloneTestDBFromTemplate`** — adds a defensive `pg_terminate_backend` + `DROP DATABASE IF EXISTS` before `CREATE`, so any stray same-named DB (crashed prior run, shared cluster) is auto-recovered.
- **`setupDB.runAfterHook`** — nulls `dbAdapter` / `publisher` / `runner` as it destroys/closes them, and the wrapping `hooks.after` / `hooks.afterEach` skip the user callback when setup never completed. A failed `beforeEach` can no longer cascade into a double-close on stale closure refs.

## Test plan

- [x] `pnpm lint` (full, in `packages/realm-server`) clean.
- [ ] CI green on this branch — particularly the realm-server-test shards that exhibited the original flake. The probabilistic nature means a green run isn't a strong proof, but the same-process collision path is deterministically gone.