### PR TITLE
CS-10103: clamp error_doc on persistence to dodge jsonb 256 MiB array limit

### DIFF
--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -939,6 +939,145 @@ module('Unit | index-writer', function (hooks) {
     );
   });
 
+  test('error_doc within budget is persisted unchanged', async function (assert) {
+    await setupIndex(
+      adapter,
+      [{ realm_url: testRealmURL, current_version: 1 }],
+      [],
+    );
+    let inputError = {
+      message: 'small parent error',
+      status: 500,
+      title: 'Render error',
+      stack: 'Error: small\n    at thing (/x.js:1:1)',
+      additionalErrors: [
+        {
+          status: 500,
+          message: 'inner err',
+          stack: 'Error: inner\n    at inner (/y.js:1:1)',
+          additionalErrors: [
+            {
+              status: 500,
+              message: 'inner inner — preserved end-to-end',
+              additionalErrors: null,
+            },
+          ],
+        },
+      ],
+    };
+    let batch = await indexWriter.createBatch(new URL(testRealmURL));
+    await batch.updateEntry(new URL(`${testRealmURL}1.json`), {
+      type: 'instance-error',
+      error: { ...inputError },
+    });
+    await batch.done();
+
+    let [{ error_doc: errorDoc }] = (await adapter.execute(
+      "SELECT error_doc FROM boxel_index WHERE has_error = TRUE AND type = 'instance'",
+      { coerceTypes },
+    )) as Pick<BoxelIndexTable, 'error_doc'>[];
+
+    assert.ok(errorDoc, 'error_doc was persisted');
+    assert.strictEqual(
+      errorDoc!.message,
+      inputError.message,
+      'message preserved verbatim',
+    );
+    assert.strictEqual(
+      errorDoc!.stack,
+      inputError.stack,
+      'top-level stack preserved verbatim',
+    );
+    assert.strictEqual(
+      errorDoc!.additionalErrors!.length,
+      1,
+      'additionalErrors length preserved',
+    );
+    let kept = errorDoc!.additionalErrors![0];
+    assert.strictEqual(
+      kept.message,
+      'inner err',
+      'inherited message preserved',
+    );
+    assert.ok(
+      Array.isArray(kept.additionalErrors),
+      'nested additionalErrors retained for in-budget docs',
+    );
+    assert.strictEqual(
+      kept.additionalErrors![0].message,
+      'inner inner — preserved end-to-end',
+      'second-level nesting preserved verbatim',
+    );
+  });
+
+  test('oversized error_doc is shed progressively until it fits', async function (assert) {
+    await setupIndex(
+      adapter,
+      [{ realm_url: testRealmURL, current_version: 1 }],
+      [],
+    );
+    // Deliberately pathological: 50 entries × ~1 MiB stacks (≈50 MiB)
+    // plus an inflated top-level stack. Step 1 of the clamp is enough
+    // to bring this back under 8 MiB; later steps must NOT run.
+    let entries = Array.from({ length: 50 }, (_, i) => ({
+      status: 500,
+      message: `dep err ${i}`,
+      stack: 'x'.repeat(1024 * 1024),
+      additionalErrors: [
+        {
+          status: 500,
+          message: 'inherited nested',
+          additionalErrors: null,
+        },
+      ],
+    }));
+    let batch = await indexWriter.createBatch(new URL(testRealmURL));
+    await batch.updateEntry(new URL(`${testRealmURL}1.json`), {
+      type: 'instance-error',
+      error: {
+        message: 'parent',
+        status: 500,
+        stack: 'short',
+        additionalErrors: entries,
+      },
+    });
+    await batch.done();
+
+    let [{ error_doc: errorDoc }] = (await adapter.execute(
+      "SELECT error_doc FROM boxel_index WHERE has_error = TRUE AND type = 'instance'",
+      { coerceTypes },
+    )) as Pick<BoxelIndexTable, 'error_doc'>[];
+
+    assert.ok(errorDoc, 'error_doc was persisted');
+    assert.ok(
+      JSON.stringify(errorDoc).length <= 8 * 1024 * 1024,
+      'persisted error_doc fits the 8 MiB budget',
+    );
+    assert.strictEqual(
+      errorDoc!.message,
+      'parent',
+      'top-level message untouched',
+    );
+    assert.strictEqual(
+      errorDoc!.additionalErrors!.length,
+      50,
+      'entry count preserved (no late-stage capping)',
+    );
+    assert.strictEqual(
+      errorDoc!.additionalErrors![0].message,
+      'dep err 0',
+      'per-entry message untouched',
+    );
+    assert.ok(
+      Array.isArray(errorDoc!.additionalErrors![0].additionalErrors),
+      'nested additionalErrors retained (step 4 did not run)',
+    );
+    assert.ok(
+      errorDoc!.additionalErrors![0].stack.length < 1024 * 1024,
+      'per-entry stacks were trimmed (step 1 ran)',
+    );
+  });
+
   test('can get an error doc', async function (assert) {
     await setupIndex(adapter, [
       {

--- a/packages/realm-server/tests/clamp-serialized-error-test.ts
+++ b/packages/realm-server/tests/clamp-serialized-error-test.ts
@@ -261,19 +261,20 @@ module(basename(__filename), function () {
     );
     assert.strictEqual(
       clamped.additionalErrors!.length,
-      ERROR_DOC_MAX_ADDITIONAL_ERRORS + 1,
-      'step 5 DID run: capped at MAX + sentinel',
+      ERROR_DOC_MAX_ADDITIONAL_ERRORS,
+      'step 5 DID run: array length matches the constant (MAX-1 entries + sentinel)',
     );
-    let sentinel = clamped.additionalErrors![ERROR_DOC_MAX_ADDITIONAL_ERRORS];
+    let sentinel =
+      clamped.additionalErrors![ERROR_DOC_MAX_ADDITIONAL_ERRORS - 1];
     assert.ok(
       isOmittedSentinel(sentinel),
       'sentinel entry recorded the omission',
     );
     assert.ok(
-      new RegExp(`${count - ERROR_DOC_MAX_ADDITIONAL_ERRORS}`).test(
+      new RegExp(`${count - (ERROR_DOC_MAX_ADDITIONAL_ERRORS - 1)}`).test(
         sentinel.message,
       ),
-      'sentinel records the number dropped',
+      'sentinel records the original count minus the preserved entries',
     );
   });
 
@@ -302,9 +303,14 @@ module(basename(__filename), function () {
       1,
       'step 6 DID run: only sentinel left',
     );
+    let sentinel = clamped.additionalErrors![0];
     assert.ok(
-      isOmittedSentinel(clamped.additionalErrors![0]),
+      isOmittedSentinel(sentinel),
       'lone entry is the omitted-sentinel',
+    );
+    assert.ok(
+      new RegExp(`\\b${count}\\b`).test(sentinel.message),
+      'step 6 sentinel reports the ORIGINAL additionalErrors count, not the post-step-5 count',
     );
   });
 

--- a/packages/realm-server/tests/clamp-serialized-error-test.ts
+++ b/packages/realm-server/tests/clamp-serialized-error-test.ts
@@ -1,0 +1,379 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import {
+  clampSerializedError,
+  ERROR_DOC_MAX_ADDITIONAL_ERRORS,
+  ERROR_DOC_MAX_BYTES,
+  type SerializedError,
+} from '@cardstack/runtime-common';
+
+// Verifies the progressive clamp applied to error_doc on its way
+// into the database (boxel_index.error_doc / modules.error_doc).
+// Postgres jsonb arrays cap at 256 MiB of element bytes — a format-
+// level constraint, not a column setting — and dependency-error
+// fan-out has produced rows that hit that ceiling in production. The
+// clamp is the chokepoint that guarantees we never persist more than
+// `ERROR_DOC_MAX_BYTES` (8 MiB) per error doc.
+//
+// In normal operation the clamp is a pure pass-through: when the doc
+// already fits, the input is returned unchanged. Each test below
+// exercises one step of the over-budget shedding ladder and asserts
+// that *only* that step ran (the doc fit afterwards) and that the
+// later steps left the doc alone.
+
+function jsonByteSize(value: unknown): number {
+  return JSON.stringify(value).length;
+}
+
+function bigString(byteCount: number): string {
+  return 'x'.repeat(byteCount);
+}
+
+function isOmittedSentinel(entry: any): boolean {
+  return (
+    entry &&
+    typeof entry === 'object' &&
+    entry.title === 'Errors omitted' &&
+    typeof entry.message === 'string' &&
+    /omitted to satisfy error_doc size budget/.test(entry.message)
+  );
+}
+
+module(basename(__filename), function () {
+  test('returns the input unchanged when the doc fits the budget', function (assert) {
+    let input: SerializedError = {
+      message: 'boom',
+      status: 500,
+      title: 'Internal Server Error',
+      stack: 'Error: boom\n    at thing (/x.js:1:1)',
+      additionalErrors: [
+        {
+          status: 500,
+          message: 'inner err',
+          stack: 'Error: inner\n    at thing (/y.js:1:1)',
+          additionalErrors: [
+            {
+              status: 500,
+              message: 'inner inner',
+              additionalErrors: null,
+            },
+          ],
+        },
+      ],
+      diagnostics: { invalidationId: 'abc', launchMs: 1234 },
+      deps: ['a', 'b', 'c'],
+    };
+    let clamped = clampSerializedError(input);
+    assert.strictEqual(clamped, input, 'identity preserved when under budget');
+  });
+
+  test('step 1 only: trims per-entry stacks when that is enough', function (assert) {
+    // 100 entries × 1 MiB stack each ≈ 100 MiB → over the 8 MiB
+    // budget. After trimming each stack to 64 KiB the doc fits, so
+    // steps 2-7 must NOT run.
+    let entries = Array.from({ length: 100 }, (_, i) => ({
+      status: 500,
+      message: `dep err ${i}`,
+      stack: bigString(1024 * 1024),
+      additionalErrors: [
+        { status: 500, message: 'nested', additionalErrors: null },
+      ],
+    }));
+    let topLevelStack = bigString(2_000);
+    let topLevelMessage = bigString(2_000);
+    let input: SerializedError = {
+      message: topLevelMessage,
+      status: 500,
+      stack: topLevelStack,
+      additionalErrors: entries,
+    };
+
+    let clamped = clampSerializedError(input);
+
+    assert.ok(
+      jsonByteSize(clamped) <= ERROR_DOC_MAX_BYTES,
+      `clamped doc fits the budget (${jsonByteSize(clamped)} bytes)`,
+    );
+    assert.strictEqual(
+      clamped.stack,
+      topLevelStack,
+      'step 2 did NOT run: top-level stack untouched',
+    );
+    assert.strictEqual(
+      clamped.message,
+      topLevelMessage,
+      'step 3+ did NOT run: top-level message untouched',
+    );
+    assert.strictEqual(
+      clamped.additionalErrors!.length,
+      100,
+      'step 5 did NOT run: entry count preserved',
+    );
+    let entry = clamped.additionalErrors![0];
+    assert.strictEqual(
+      entry.message,
+      'dep err 0',
+      'step 3 did NOT run: per-entry message untouched',
+    );
+    assert.ok(
+      Array.isArray(entry.additionalErrors),
+      'step 4 did NOT run: nested additionalErrors retained',
+    );
+    assert.ok(
+      entry.stack.length < 1024 * 1024,
+      'step 1 DID run: per-entry stack was trimmed',
+    );
+  });
+
+  test('step 2: trims top-level stack when per-entry stacks alone are not enough', function (assert) {
+    let entries = Array.from({ length: 5 }, (_, i) => ({
+      status: 500,
+      message: `dep err ${i}`,
+      stack: 'short',
+      additionalErrors: [
+        { status: 500, message: 'nested', additionalErrors: null },
+      ],
+    }));
+    let input: SerializedError = {
+      message: 'parent',
+      status: 500,
+      stack: bigString(9 * 1024 * 1024),
+      additionalErrors: entries,
+    };
+
+    let clamped = clampSerializedError(input);
+
+    assert.ok(
+      jsonByteSize(clamped) <= ERROR_DOC_MAX_BYTES,
+      'clamped doc fits the budget',
+    );
+    assert.ok(
+      clamped.stack!.length < 9 * 1024 * 1024,
+      'step 2 DID run: top-level stack trimmed',
+    );
+    assert.strictEqual(
+      clamped.message,
+      'parent',
+      'step 3+ did NOT run: top-level message untouched',
+    );
+    let entry = clamped.additionalErrors![0];
+    assert.strictEqual(
+      entry.message,
+      'dep err 0',
+      'step 3 did NOT run: per-entry messages untouched',
+    );
+    assert.ok(
+      Array.isArray(entry.additionalErrors),
+      'step 4 did NOT run: nested additionalErrors retained',
+    );
+  });
+
+  test('step 3: trims per-entry messages once stacks are not the offender', function (assert) {
+    let entries = Array.from({ length: 100 }, (_, i) => ({
+      status: 500,
+      message: `dep err ${i} ${bigString(200_000)}`,
+      additionalErrors: [
+        { status: 500, message: 'nested', additionalErrors: null },
+      ],
+    }));
+    let input: SerializedError = {
+      message: 'parent',
+      status: 500,
+      additionalErrors: entries,
+    };
+
+    let clamped = clampSerializedError(input);
+
+    assert.ok(
+      jsonByteSize(clamped) <= ERROR_DOC_MAX_BYTES,
+      'clamped doc fits the budget',
+    );
+    let entry = clamped.additionalErrors![0];
+    assert.ok(
+      entry.message.length < 200_000,
+      'step 3 DID run: per-entry message trimmed',
+    );
+    assert.ok(
+      Array.isArray(entry.additionalErrors),
+      'step 4 did NOT run: nested additionalErrors retained',
+    );
+    assert.strictEqual(
+      clamped.additionalErrors!.length,
+      100,
+      'step 5 did NOT run: entry count preserved',
+    );
+  });
+
+  test('step 4: collapses nested additionalErrors of inherited entries', function (assert) {
+    let entries = Array.from({ length: 100 }, (_, i) => ({
+      status: 500,
+      message: `dep err ${i}`,
+      additionalErrors: Array.from({ length: 200 }, (_, j) => ({
+        status: 500,
+        message: `nested ${i}/${j} ${bigString(2_000)}`,
+        additionalErrors: null,
+      })),
+    }));
+    let input: SerializedError = {
+      message: 'parent',
+      status: 500,
+      additionalErrors: entries,
+    };
+
+    let clamped = clampSerializedError(input);
+
+    assert.ok(
+      jsonByteSize(clamped) <= ERROR_DOC_MAX_BYTES,
+      'clamped doc fits the budget',
+    );
+    assert.strictEqual(
+      clamped.additionalErrors!.length,
+      100,
+      'step 5 did NOT run: parent entry count preserved',
+    );
+    for (let entry of clamped.additionalErrors!) {
+      assert.strictEqual(
+        entry.additionalErrors,
+        null,
+        'step 4 DID run: nested additionalErrors collapsed',
+      );
+    }
+  });
+
+  test('step 5: caps entry count with a sentinel when collapsing nesting was not enough', function (assert) {
+    let count = 5_000;
+    let entries = Array.from({ length: count }, (_, i) => ({
+      status: 500,
+      message: `dep err ${i} ${bigString(2_500)}`,
+      additionalErrors: null,
+    }));
+    let input: SerializedError = {
+      message: 'parent',
+      status: 500,
+      additionalErrors: entries,
+    };
+
+    let clamped = clampSerializedError(input);
+
+    assert.ok(
+      jsonByteSize(clamped) <= ERROR_DOC_MAX_BYTES,
+      'clamped doc fits the budget',
+    );
+    assert.strictEqual(
+      clamped.additionalErrors!.length,
+      ERROR_DOC_MAX_ADDITIONAL_ERRORS + 1,
+      'step 5 DID run: capped at MAX + sentinel',
+    );
+    let sentinel = clamped.additionalErrors![ERROR_DOC_MAX_ADDITIONAL_ERRORS];
+    assert.ok(
+      isOmittedSentinel(sentinel),
+      'sentinel entry recorded the omission',
+    );
+    assert.ok(
+      new RegExp(`${count - ERROR_DOC_MAX_ADDITIONAL_ERRORS}`).test(
+        sentinel.message,
+      ),
+      'sentinel records the number dropped',
+    );
+  });
+
+  test('step 6: drops additionalErrors when capping at MAX is still not enough', function (assert) {
+    let count = 1_000;
+    let entries = Array.from({ length: count }, (_, i) => ({
+      status: 500,
+      message: `dep err ${i}`,
+      stack: bigString(64 * 1024),
+      additionalErrors: null,
+    }));
+    let input: SerializedError = {
+      message: 'parent',
+      status: 500,
+      additionalErrors: entries,
+    };
+
+    let clamped = clampSerializedError(input);
+
+    assert.ok(
+      jsonByteSize(clamped) <= ERROR_DOC_MAX_BYTES,
+      'clamped doc fits the budget',
+    );
+    assert.strictEqual(
+      clamped.additionalErrors!.length,
+      1,
+      'step 6 DID run: only sentinel left',
+    );
+    assert.ok(
+      isOmittedSentinel(clamped.additionalErrors![0]),
+      'lone entry is the omitted-sentinel',
+    );
+  });
+
+  test('step 7: shrinks the top-level message/stack as a last resort', function (assert) {
+    let input: SerializedError = {
+      message: bigString(9 * 1024 * 1024),
+      status: 500,
+      stack: bigString(9 * 1024 * 1024),
+      additionalErrors: null,
+    };
+
+    let clamped = clampSerializedError(input);
+
+    assert.ok(
+      jsonByteSize(clamped) <= ERROR_DOC_MAX_BYTES,
+      'clamped doc fits the budget',
+    );
+    assert.ok(
+      clamped.message.length < 9 * 1024 * 1024,
+      'step 7 DID run: top-level message shrunk',
+    );
+    assert.ok(
+      (clamped.stack?.length ?? 0) < 9 * 1024 * 1024,
+      'top-level stack shrunk',
+    );
+  });
+
+  test('preserves diagnostics on the top-level error', function (assert) {
+    let input: SerializedError = {
+      message: 'parent',
+      status: 500,
+      additionalErrors: null,
+      diagnostics: { invalidationId: 'abc', launchMs: 1234 },
+    };
+    let clamped = clampSerializedError(input);
+    assert.deepEqual(clamped.diagnostics, {
+      invalidationId: 'abc',
+      launchMs: 1234,
+    });
+  });
+
+  test('does not mutate the input when shedding', function (assert) {
+    let input: SerializedError = {
+      message: 'parent',
+      status: 500,
+      stack: bigString(9 * 1024 * 1024),
+      additionalErrors: [
+        {
+          status: 500,
+          message: 'kept-by-reference',
+          stack: bigString(1_000_000),
+          additionalErrors: null,
+        },
+      ],
+    };
+    let originalEntry = input.additionalErrors![0];
+
+    let clamped = clampSerializedError(input);
+
+    assert.notStrictEqual(clamped, input, 'returns a new object when shedding');
+    assert.strictEqual(
+      input.stack!.length,
+      9 * 1024 * 1024,
+      'input stack untouched',
+    );
+    assert.strictEqual(
+      originalEntry.stack.length,
+      1_000_000,
+      'original additionalErrors entry untouched',
+    );
+  });
+});

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -178,6 +178,7 @@ import './prerender-affinity-activity-test';
 import './prerender-batch-ownership-test';
 import './prerender-cancellation-test';
 import './runtime-exception-capture-test';
+import './clamp-serialized-error-test';
 import './prerender-diagnostics-persistence-test';
 import './prerender-proxy-test';
 import './queue-test';

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -9,7 +9,7 @@ import {
   separatedByCommas,
   type Expression,
 } from './expression';
-import type { SerializedError } from './error';
+import { clampSerializedError, type SerializedError } from './error';
 import {
   fetchUserPermissions,
   internalKeyFor,
@@ -852,7 +852,16 @@ export class CachingDefinitionLookup implements DefinitionLookup {
           [param(moduleAlias)],
           [param(JSON.stringify(definitions ?? {}))],
           [param(JSON.stringify(deps ?? []))],
-          [param(errorDoc ? JSON.stringify(errorDoc) : null)],
+          [
+            param(
+              errorDoc
+                ? JSON.stringify({
+                    ...errorDoc,
+                    error: clampSerializedError(errorDoc.error),
+                  })
+                : null,
+            ),
+          ],
           [param(Date.now())],
           [param(resolvedRealmURL)],
           [param(cacheScope)],

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -36,6 +36,152 @@ export interface SerializedError {
   diagnostics?: Record<string, unknown>;
 }
 
+// Postgres `jsonb` containers store child offsets in 28 bits, so a
+// single jsonb array's elements must total < 256 MiB — a format-level
+// constraint baked into jsonb, not a column setting we can raise.
+// `clampSerializedError` is the chokepoint that guarantees an
+// error_doc never reaches that ceiling on the upsert path.
+//
+// In normal operation it is a pure pass-through: if the doc already
+// serializes under `ERROR_DOC_MAX_BYTES` we hand the input back
+// unchanged. Only when over budget do we progressively shed
+// structure, in this order, stopping as soon as we fit:
+//
+//   1. truncate each `additionalErrors[i].stack` to ~64 KiB
+//   2. truncate the top-level `stack` to ~64 KiB
+//   3. truncate each `additionalErrors[i].message` to ~16 KiB
+//   4. collapse nested `additionalErrors` of inherited entries
+//      (drop only the second level of nesting)
+//   5. cap the array length to MAX_ADDITIONAL_ERRORS, with a
+//      sentinel entry recording how many were omitted
+//   6. drop `additionalErrors` entirely with a sentinel — last
+//      resort, only reached if even one entry's scalars overflow
+//   7. aggressively shrink the top-level `stack`/`message` if even
+//      the bare envelope is still too big
+//
+// The budget is set to 8 MiB: 32× under the jsonb limit, plenty of
+// debug headroom for healthy errors, and small enough to leave room
+// for the rest of the row (`pristine_doc` / `search_doc` etc.).
+export const ERROR_DOC_MAX_BYTES = 8 * 1024 * 1024;
+export const ERROR_DOC_MAX_ADDITIONAL_ERRORS = 200;
+const ENTRY_STACK_BUDGET = 64 * 1024;
+const ENTRY_MESSAGE_BUDGET = 16 * 1024;
+
+function clampString(s: string, maxBytes: number): string {
+  // Per-character clamp — UTF-16 code units are a close-enough proxy
+  // for byte budgeting at this scale. The goal is "stay under 256 MB
+  // of jsonb", not byte-exact.
+  if (s.length <= maxBytes) return s;
+  let suffix = ' …[truncated]';
+  return s.slice(0, Math.max(0, maxBytes - suffix.length)) + suffix;
+}
+
+function jsonByteSize(value: unknown): number {
+  try {
+    return JSON.stringify(value)?.length ?? 0;
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+export function clampSerializedError(error: SerializedError): SerializedError {
+  if (jsonByteSize(error) <= ERROR_DOC_MAX_BYTES) {
+    return error;
+  }
+
+  // Deep-copy so the input remains untouched. JSON round-trip is
+  // safe here because SerializedError is already a JSON-shape value
+  // (it is what we persist into a jsonb column).
+  let working: SerializedError = JSON.parse(JSON.stringify(error));
+
+  let entries = (): any[] | null =>
+    Array.isArray(working.additionalErrors) ? working.additionalErrors : null;
+
+  // 1. Per-entry stacks.
+  let arr = entries();
+  if (arr) {
+    for (let entry of arr) {
+      if (typeof entry?.stack === 'string') {
+        entry.stack = clampString(entry.stack, ENTRY_STACK_BUDGET);
+      }
+    }
+  }
+  if (jsonByteSize(working) <= ERROR_DOC_MAX_BYTES) return working;
+
+  // 2. Top-level stack.
+  if (typeof working.stack === 'string') {
+    working.stack = clampString(working.stack, ENTRY_STACK_BUDGET);
+  }
+  if (jsonByteSize(working) <= ERROR_DOC_MAX_BYTES) return working;
+
+  // 3. Per-entry messages.
+  arr = entries();
+  if (arr) {
+    for (let entry of arr) {
+      if (typeof entry?.message === 'string') {
+        entry.message = clampString(entry.message, ENTRY_MESSAGE_BUDGET);
+      }
+    }
+  }
+  if (jsonByteSize(working) <= ERROR_DOC_MAX_BYTES) return working;
+
+  // 4. Collapse nested additionalErrors on inherited entries — only
+  //    the second level of nesting is dropped, not the parent's
+  //    flat list of contributors.
+  arr = entries();
+  if (arr) {
+    for (let entry of arr) {
+      if (
+        Array.isArray(entry?.additionalErrors) &&
+        entry.additionalErrors.length > 0
+      ) {
+        entry.additionalErrors = null;
+      }
+    }
+  }
+  if (jsonByteSize(working) <= ERROR_DOC_MAX_BYTES) return working;
+
+  // 5. Cap entry count.
+  arr = entries();
+  if (arr && arr.length > ERROR_DOC_MAX_ADDITIONAL_ERRORS) {
+    let omitted = arr.length - ERROR_DOC_MAX_ADDITIONAL_ERRORS;
+    working.additionalErrors = [
+      ...arr.slice(0, ERROR_DOC_MAX_ADDITIONAL_ERRORS),
+      omittedSentinel(omitted),
+    ];
+  }
+  if (jsonByteSize(working) <= ERROR_DOC_MAX_BYTES) return working;
+
+  // 6. Drop additionalErrors entirely.
+  let omittedCount = entries()?.length ?? 0;
+  working.additionalErrors =
+    omittedCount > 0 ? [omittedSentinel(omittedCount)] : null;
+  if (jsonByteSize(working) <= ERROR_DOC_MAX_BYTES) return working;
+
+  // 7. Aggressively shrink the envelope itself.
+  if (typeof working.stack === 'string') {
+    working.stack = clampString(working.stack, 1024);
+  }
+  working.message = clampString(working.message ?? '', 1024);
+  return working;
+}
+
+function omittedSentinel(count: number): {
+  status: number;
+  title: string;
+  message: string;
+  additionalErrors: null;
+} {
+  return {
+    status: 500,
+    title: 'Errors omitted',
+    message: `${count} additional error${
+      count === 1 ? '' : 's'
+    } omitted to satisfy error_doc size budget`,
+    additionalErrors: null,
+  };
+}
+
 export interface CardErrorJSONAPI {
   id?: string; // 404 errors won't necessarily have an id
   status: number;

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -97,6 +97,12 @@ export function clampSerializedError(error: SerializedError): SerializedError {
   let entries = (): any[] | null =>
     Array.isArray(working.additionalErrors) ? working.additionalErrors : null;
 
+  // Capture once up front so the omitted-sentinel messages emitted by
+  // steps 5 and 6 can report the *original* count even after step 5
+  // has already replaced the array with a (preserved + sentinel)
+  // shorter form.
+  let originalAdditionalCount = entries()?.length ?? 0;
+
   // 1. Per-entry stacks.
   let arr = entries();
   if (arr) {
@@ -141,21 +147,30 @@ export function clampSerializedError(error: SerializedError): SerializedError {
   }
   if (jsonByteSize(working) <= ERROR_DOC_MAX_BYTES) return working;
 
-  // 5. Cap entry count.
+  // 5. Cap entry count. The final array length is exactly
+  //    ERROR_DOC_MAX_ADDITIONAL_ERRORS — `MAX - 1` real entries plus
+  //    one sentinel summarising the rest — so the constant name and
+  //    the resulting array length agree.
   arr = entries();
   if (arr && arr.length > ERROR_DOC_MAX_ADDITIONAL_ERRORS) {
-    let omitted = arr.length - ERROR_DOC_MAX_ADDITIONAL_ERRORS;
-    working.additionalErrors = [
-      ...arr.slice(0, ERROR_DOC_MAX_ADDITIONAL_ERRORS),
-      omittedSentinel(omitted),
-    ];
+    let preservedCount = Math.max(ERROR_DOC_MAX_ADDITIONAL_ERRORS - 1, 0);
+    working.additionalErrors =
+      preservedCount > 0
+        ? [
+            ...arr.slice(0, preservedCount),
+            omittedSentinel(originalAdditionalCount - preservedCount),
+          ]
+        : [omittedSentinel(originalAdditionalCount - preservedCount)];
   }
   if (jsonByteSize(working) <= ERROR_DOC_MAX_BYTES) return working;
 
-  // 6. Drop additionalErrors entirely.
-  let omittedCount = entries()?.length ?? 0;
+  // 6. Drop additionalErrors entirely. The sentinel reports the
+  //    original count regardless of how many entries step 5 left
+  //    behind.
   working.additionalErrors =
-    omittedCount > 0 ? [omittedSentinel(omittedCount)] : null;
+    originalAdditionalCount > 0
+      ? [omittedSentinel(originalAdditionalCount)]
+      : null;
   if (jsonByteSize(working) <= ERROR_DOC_MAX_BYTES) return working;
 
   // 7. Aggressively shrink the envelope itself.

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -31,7 +31,7 @@ import {
   dbExpression,
   upsertMultipleRows,
 } from './expression';
-import type { SerializedError } from './error';
+import { clampSerializedError, type SerializedError } from './error';
 import type { DBAdapter } from './db';
 import type { RealmMetaTable } from './index-structure';
 import type { FileMetaResource } from './resource-types';
@@ -1148,11 +1148,14 @@ export class Batch {
           ),
         ]
       : undefined;
-    return {
+    // Clamp before persistence so a runaway `additionalErrors` tree
+    // (or an oversized stack/message) can't trip Postgres's 256 MiB
+    // jsonb-array container limit on upsert.
+    return clampSerializedError({
       ...error,
       id: error.id ?? entryURL.href,
       ...(deps ? { deps } : {}),
-    };
+    });
   }
 
   private normalizeDependency(

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -421,6 +421,9 @@ export {
   type CardErrorJSONAPI,
   type CardErrorsJSONAPI,
   isCardErrorJSONAPI,
+  clampSerializedError,
+  ERROR_DOC_MAX_BYTES,
+  ERROR_DOC_MAX_ADDITIONAL_ERRORS,
 } from './error';
 export { validateWriteSize } from './write-size-validation';
 export {


### PR DESCRIPTION
## Summary

Fixes CS-10103 — the production Sentry where `boxel_index.error_doc` upserts fail with `total size of jsonb array elements exceeds the maximum of 268435455 bytes`. Postgres jsonb stores child offsets in 28 bits, so a single jsonb array's elements must total < 256 MiB — that's a format-level constraint baked into jsonb, not a column setting we can raise.

The triggering pattern in production: dependency-error fan-out repeatedly copies each dep row's full `error_doc` (nested `additionalErrors` and all) into its parent during indexing. Across many indexing cycles in a realm with chained errors, the `additionalErrors` tree compounds without bound and eventually hits the jsonb limit on upsert.

## What this changes

- New `clampSerializedError` in `runtime-common/error.ts`. It is the chokepoint that runs on every `error_doc` going into the database (both `boxel_index.error_doc` via `IndexWriter.normalizeErrorDoc` and `modules.error_doc` via `CachingDefinitionLookup.writeToDatabaseCache`).
- **In normal operation it is a pure pass-through.** When an error_doc already serializes under `ERROR_DOC_MAX_BYTES` (8 MiB — 32× under the jsonb limit), the input is returned unchanged. Nothing is dropped.
- **When over budget it sheds structure progressively**, stopping as soon as the doc fits:
  1. truncate each `additionalErrors[i].stack` to ~64 KiB
  2. truncate the top-level `stack` to ~64 KiB
  3. truncate each `additionalErrors[i].message` to ~16 KiB
  4. collapse nested `additionalErrors` of inherited entries (drop only the second level of nesting)
  5. cap the array length to 200 with a sentinel entry recording how many were omitted
  6. drop `additionalErrors` entirely with a sentinel — last resort
  7. aggressively shrink the top-level `stack`/`message` if even the bare envelope is still too big
- Top-level `id`, `status`, `title`, `deps`, `source`, `diagnostics`, `isCardError` are never touched — they're scalars/small.

The dep-error propagation paths in `index-runner/index-backed-dependency-errors.ts` and `definition-lookup.ts` are intentionally **unchanged** — preserving full additionalErrors trees for debug visibility was a hard requirement. The clamp is a safety net at the persistence layer, not a routine truncation in the propagators.

## Test plan

- [x] `clamp-serialized-error-test.ts` — 10 unit tests, one per shedding step, each asserting that *only* the targeted step ran (later steps left the doc alone). Verifies pass-through for in-budget docs and no-mutation of the input.
- [x] `index-writer-test.ts` — 2 integration tests: one verifying an in-budget error_doc is persisted verbatim through the IndexWriter, one verifying an oversized doc is shed progressively until it fits.
- [x] `pnpm lint` clean for `runtime-common`, `realm-server`, `host`.
- [ ] Indexing-test in realm-server (in progress — full integration run with the dep-error fan-out path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)