### PR TITLE
Use content-hash ETag on source endpoint (fixes flaky atomic update)

### DIFF
--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -13,6 +13,7 @@ import {
   removeSync,
   writeFileSync,
 } from 'fs-extra';
+import { utimesSync } from 'fs';
 import type { Realm } from '@cardstack/runtime-common';
 import {
   baseRealm,
@@ -72,6 +73,7 @@ module(basename(__filename), function () {
     let testRealmURL = realmURL;
     let testRealm: Realm;
     let testRealmHttpServer: Server;
+    let testRealmPath: string;
     let request: RealmRequest;
     let serverRequest: SuperTest<Test>;
     let dir: DirResult;
@@ -86,12 +88,14 @@ module(basename(__filename), function () {
     function onRealmSetup(args: {
       testRealm: Realm;
       testRealmHttpServer: Server;
+      testRealmPath: string;
       request: SuperTest<Test>;
       dir: DirResult;
       dbAdapter: PgAdapter;
     }) {
       testRealm = args.testRealm;
       testRealmHttpServer = args.testRealmHttpServer;
+      testRealmPath = args.testRealmPath;
       serverRequest = args.request;
       request = withRealmPath(args.request, realmURL);
       dir = args.dir;
@@ -917,6 +921,66 @@ module(basename(__filename), function () {
         notModifiedModuleResponse.headers['etag'],
         moduleEtag,
         '304 response echoes module variant ETag',
+      );
+    });
+
+    // Regression test for the flaky `atomic-endpoints-test > can update an
+    // existing instance` failure. The bug: source ETags were keyed by
+    // `lastModified` in whole unix seconds, so two writes landing in the
+    // same second produced identical ETags — `cachedFetch` then returned
+    // a 304-cached stale body. Force the same on-disk mtime across two
+    // different writes and assert the source ETag is content-derived.
+    test('source ETag distinguishes content even when on-disk lastModified collides', async function (assert) {
+      let modulePath = 'etag-collision-test.json';
+      let initial = JSON.stringify({ value: 'initial' });
+      let updated = JSON.stringify({ value: 'updated' });
+      // Both writes are pinned to the same wall-clock second below.
+      let collidingMtime = new Date('2026-01-01T00:00:00Z');
+      let absolutePath = join(testRealmPath, modulePath);
+      let authHeader = `Bearer ${createJWT(testRealm, 'user', ['read', 'write'])}`;
+
+      await testRealm.write(modulePath, initial);
+      utimesSync(absolutePath, collidingMtime, collidingMtime);
+
+      let firstResponse = await request
+        .get(`/${modulePath}`)
+        .set('Accept', SupportedMimeType.CardSource)
+        .set('Authorization', authHeader);
+      assert.strictEqual(firstResponse.status, 200, 'first request succeeds');
+      let firstEtag = firstResponse.headers['etag'];
+      assert.ok(firstEtag, 'first response carries an ETag');
+
+      await testRealm.write(modulePath, updated);
+      utimesSync(absolutePath, collidingMtime, collidingMtime);
+
+      let secondResponse = await request
+        .get(`/${modulePath}`)
+        .set('Accept', SupportedMimeType.CardSource)
+        .set('Authorization', authHeader);
+      assert.strictEqual(secondResponse.status, 200, 'second request succeeds');
+      let secondEtag = secondResponse.headers['etag'];
+      assert.ok(secondEtag, 'second response carries an ETag');
+
+      assert.notStrictEqual(
+        firstEtag,
+        secondEtag,
+        'distinct content yields distinct ETags despite identical lastModified',
+      );
+
+      let conditionalResponse = await request
+        .get(`/${modulePath}`)
+        .set('Accept', SupportedMimeType.CardSource)
+        .set('Authorization', authHeader)
+        .set('If-None-Match', firstEtag);
+      assert.strictEqual(
+        conditionalResponse.status,
+        200,
+        'conditional GET with the prior ETag must not return 304',
+      );
+      assert.strictEqual(
+        conditionalResponse.text.trim(),
+        updated,
+        'conditional GET serves the updated body, not the cached prior body',
       );
     });
 

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -231,6 +231,10 @@ type CachedSourceFileEntry = {
   ref: FileRef;
   defaultHeaders: Record<string, string>;
   canonicalPath: LocalPath;
+  // md5 of the materialized body, computed once on cache populate. Used
+  // as the ETag base so two writes within the same unix second still
+  // produce distinct ETags — see `buildEtag` for the rationale.
+  contentHash: string | undefined;
 };
 
 type CachedSourceRedirectEntry = {
@@ -265,15 +269,24 @@ type ModuleLoadResult =
       headers: Record<string, string>;
     };
 
+// ETag base prefers a content fingerprint (md5 of the file body) over
+// `lastModified` because the unix-second timestamp collides for two
+// writes that land in the same second — and `cachedFetch` (loader →
+// cached-fetch) will then serve a stale 304-cached body. We compute the
+// content hash on the cache-miss path of the source endpoint, where the
+// content is already being materialized into memory, and stash it on the
+// cache entry so subsequent serves reuse it. Adapters that don't yet
+// surface a content fingerprint fall back to `lastModified` and keep the
+// pre-existing behavior.
 function buildEtag(
-  lastModified: number | undefined,
+  base: string | number | undefined,
   variant?: string,
 ): string | undefined {
-  if (lastModified == null) {
+  if (base == null) {
     return undefined;
   }
-  let base = String(lastModified);
-  return variant ? `${base}:${variant}` : base;
+  let baseStr = String(base);
+  return variant ? `${baseStr}:${variant}` : baseStr;
 }
 
 function computeContentHash(content: string | Uint8Array): string {
@@ -289,6 +302,21 @@ function computeContentHash(content: string | Uint8Array): string {
       throw new Error('Failed to compute content hash');
     }
   }
+}
+
+// Cheap helper for the source endpoint: returns md5 of the body when the
+// ref has already been materialized to a string or Uint8Array. Returns
+// undefined for stream refs (the caller falls back to lastModified).
+function contentHashFromMaterializedRef(ref: FileRef): string | undefined {
+  let { content } = ref;
+  if (typeof content === 'string' || content instanceof Uint8Array) {
+    try {
+      return computeContentHash(content);
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
 }
 
 function computeContentSize(content: string | Uint8Array): number {
@@ -2125,6 +2153,11 @@ export class Realm {
     options?: {
       defaultHeaders?: Record<string, string>;
       etagVariant?: string;
+      // Optional content-derived fingerprint (e.g. md5 of body bytes).
+      // Takes precedence over `ref.lastModified` for the ETag — see
+      // `buildEtag`. Callers that have the materialized body already
+      // (the source endpoint cache-miss path) compute this for free.
+      etagBase?: string;
     },
   ): Promise<ResponseWithNodeStream> {
     let contentType = options?.defaultHeaders?.['content-type'];
@@ -2141,7 +2174,10 @@ export class Realm {
     let cacheControl = contentType?.startsWith('image/')
       ? `${cacheVisibility}, max-age=60, must-revalidate`
       : `${cacheVisibility}, max-age=0`;
-    let etag = buildEtag(ref.lastModified, options?.etagVariant);
+    let etag = buildEtag(
+      options?.etagBase ?? ref.lastModified,
+      options?.etagVariant,
+    );
     let lastModified = formatRFC7231(ref.lastModified * 1000);
     if (etag && request.headers.get('if-none-match') === etag) {
       return createResponse({
@@ -2399,6 +2435,7 @@ export class Realm {
                 [CACHE_HEADER]: CACHE_HIT_VALUE,
               },
               etagVariant: SOURCE_ETAG_VARIANT,
+              etagBase: cached.contentHash,
             },
           );
         } finally {
@@ -2466,15 +2503,21 @@ export class Realm {
         });
       } else {
         let cachedRef = await this.materializeFileRef(handle);
+        // Compute the content fingerprint while we have the body in
+        // memory — `cachedRef.content` is already a string/Uint8Array
+        // post-materialization, so this is a single md5 with no extra I/O.
+        let contentHash = contentHashFromMaterializedRef(cachedRef);
         this.#sourceCache.set(localName, {
           type: 'file',
           ref: cachedRef,
           defaultHeaders,
           canonicalPath: handle.path,
+          contentHash,
         });
         return await this.serveLocalFile(request, cachedRef, requestContext, {
           defaultHeaders,
           etagVariant: SOURCE_ETAG_VARIANT,
+          etagBase: contentHash,
         });
       }
     } finally {


### PR DESCRIPTION
## Summary

Diagnoses and fixes the long-running flake on \`atomic-endpoints-test > error handling > can update an existing instance\`. The diagnostic snapshots added in #4530 made the failure mode unambiguous: disk-after-update had \`firstName="Updated"\` but \`boxel_index\` (both stable and working at \`realm_version=3\`) held \`firstName="Initial"\`. The indexer ran, but it ingested **stale** content. Sample failure: [run 25084279746](https://github.com/cardstack/boxel/actions/runs/25084279746/job/73496468826).

## Root cause

\`buildEtag\` is keyed by \`fileRef.lastModified\`, which is **whole unix seconds** (\`unixTime(stat.mtime.getTime())\`). When two writes land in the same second, they produce identical ETags. The browser-side \`cachedFetch\` (loader.ts → cached-fetch.ts) sends \`If-None-Match\` on the indexer's source-endpoint reads, the realm server matches the (collided) ETag and returns **304 Not Modified**, and \`cachedFetch\` returns its **cached \"Initial\" body** from the previous request. The indexer then writes that stale body into \`boxel_index\`.

CI runs on ext4 with nanosecond mtime precision, but \`unixTime\` floors to whole seconds — so any two atomic ops landing in the same wall-clock second hit this.

The diagnostic from the most recent failure shows the exact signature:
- \`disk after update=lastModified=1777422280 content=\"...firstName: Updated...\"\`  ← disk write OK
- \`stable[type=instance].pristine_doc.attributes.firstName = \"Initial\"\` ← indexer ingested stale
- \`stable[type=file].pristine_doc.attributes.contentHash = 26b7e75700a7be2f314525fef2025715\` ← md5 of *Initial* body
- Both writes share \`lastModified=1777422280\` (same second)

## Fix

ETag the source endpoint by **md5 of the body**, not by mtime.

- The cache-miss path in \`getSourceOrRedirect\` already calls \`materializeFileRef\` to read the full body into memory. We md5 that buffer once and stash the hash on \`CachedSourceFileEntry.contentHash\`.
- The hash flows into a new \`etagBase\` option on \`serveLocalFile\`. Cache-hit serves reuse the stored hash; on the next write the source cache is invalidated and we re-hash from the fresh disk read.
- \`buildEtag\` now accepts a \`string | number\` base — content fingerprint when available, \`lastModified\` otherwise.
- The module endpoint and any other caller that doesn't supply \`etagBase\` falls back to \`ref.lastModified\`, preserving existing behavior outside the source path.

Two writes with different content → different md5 → different ETags → no 304 collision regardless of mtime resolution. Same-content reserves still revalidate cleanly.

## Why content hash, not mtimeMs / size

Both were considered:

- **mtimeMs**: works on ext4/APFS but depends on filesystem precision (FAT32 has 2-second resolution; some networked filesystems are coarser). Not bulletproof.
- **stat doesn't expose a content hash** — \`fs.stat\` is pure metadata; you have to read the bytes yourself.
- **\`realm_file_meta.content_hash\`**: persisted by \`_batchWrite\` before \`performIndex\`, so it's actually up-to-date for the failing path — but coupling the source endpoint to that invariant is fragile (any out-of-band write or indexer issue would diverge it from disk).
- **Hashing the materialized body**: free for cache-miss (we already read the body), reused on cache-hit, and content-correct regardless of any other system's state. This is the choice.

## Test plan
- [ ] CI green on \`atomic-endpoints-test.ts > error handling > can update an existing instance\` across reruns
- [ ] Source-endpoint ETag still revalidates correctly when content is unchanged (200 OK with same etag would be a regression)
- [ ] Module endpoint behavior unchanged (still uses \`lastModified\` — separate path, separate variant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)