### PR TITLE
Document Loki querying + ship tail-logs.sh and Claude skill

### DIFF
--- a/.claude/skills/tail-logs/SKILL.md
+++ b/.claude/skills/tail-logs/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: tail-logs
+description: Tail Loki logs from local / staging / production for any boxel ECS task family — realm-server, worker, prerender, prerender-manager, synapse. Use when you need to debug an incident, follow live activity, or correlate request IDs across services. Wraps `packages/observability/scripts/tail-logs.sh` so the LogQL + auth + URL plumbing is hidden.
+allowed-tools: Read, Bash
+---
+
+# tail-logs
+
+Tail Loki logs from a laptop. The script handles auth (SSM bearer token), URL resolution (SSM public URL), the `/loki` URL gotcha, and LogQL selector construction. You provide environment + service.
+
+## When to invoke
+
+- Debugging an incident in staging or production
+- Following live realm-server / worker activity while reproducing a bug locally
+- Correlating a request id, job id, or realm name across services
+- Cross-checking that something just shipped a log line you expect
+
+If the user is asking what *changed* (deploy diffs, code history) rather than what *happened*, this is the wrong tool — go to git/PR APIs instead.
+
+## How to invoke
+
+```bash
+packages/observability/scripts/tail-logs.sh --env <local|staging|production> --service <name> [flags]
+```
+
+Common flag patterns:
+
+```bash
+# What happened to realm-server in the last 15 min on staging?
+./scripts/tail-logs.sh --env staging --service realm-server --since 15m --no-follow
+
+# Live tail with an error filter
+./scripts/tail-logs.sh --env staging --service worker --regex '(?i)error|exception|fatal'
+
+# Drill to a specific job
+./scripts/tail-logs.sh --env staging --service worker --filter 'job_id=42' --since 1h --no-follow
+
+# Production requires --confirm (intentional friction)
+./scripts/tail-logs.sh --env production --service synapse --since 30m --no-follow --confirm
+```
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--env` | (required) | `local`, `staging`, `production` |
+| `--service` | (required) | `realm-server`, `worker`, `prerender`, `prerender-manager`, `synapse` (or any local container name) |
+| `--realm` | unset | Filter to a single realm. Only set on tasks where realm is meaningful. |
+| `--worker-id` | unset | Per-Fargate-task id; only available on workers. |
+| `--filter` | unset | LogQL line-filter (`\|=` literal substring). Mutually exclusive with `--regex`. |
+| `--regex` | unset | LogQL line-regex (`\|~`). |
+| `--since` | `15m` | `30s`, `15m`, `1h`, `2d` — anything matching `^\d+[smhd]$`. |
+| `--limit` | `200` | Max lines per batch. |
+| `--no-follow` | follow on | One-shot mode for diagnostics. **Always use `--no-follow` from a skill** — follow mode is interactive. |
+| `--json` | text | Raw Loki response per batch. Use when you need to parse beyond the formatted line. |
+| `--confirm` | n/a | Required for `--env production`. |
+
+## Auth requirements
+
+For staging / production: AWS credentials must be active for the env's account, with `ssm:GetParameter` on `/<env>/loki/*`. Locally: no auth, just `docker compose up -d` from `packages/observability/`.
+
+## Output shape
+
+Default text format is `<rfc3339>  [<labels>]  <line>`:
+
+```
+2026-04-28T22:06:11Z  [env=staging,service=realm-server,realm=catalog]  realm: indexing batch complete duration_ms=412
+```
+
+Labels are sorted alphabetically inside the brackets. With `--json`, you get the raw Loki HTTP response — useful for `jq '.data.result[]'`-style structured analysis.
+
+## Patterns by task family
+
+| You want to... | Suggested invocation |
+|---|---|
+| Find the last 100 errors in any staging service | `--env staging --service <each one> --regex '(?i)error\|exception\|fatal' --since 1h --limit 100 --no-follow` (run per service; LogQL doesn't take an OR over labels in one query) |
+| Watch a slow indexer batch | `--env staging --service realm-server --regex 'duration_ms=[0-9]{4,}'` |
+| See what one Fargate worker is doing | `--env staging --service worker --worker-id <id> --since 30m --no-follow` |
+| Tail synapse | `--env staging --service synapse --since 15m --no-follow` |
+
+## Limits and caveats
+
+- The hosted Loki has a 7-day default `reject_old_samples_max_age`. Queries beyond that window will return zero results even if S3 still has the chunks.
+- Production retention is 180 days (S3 lifecycle); local has no retention enforcement and `reject_old_samples=false`.
+- The dual-ship to CloudWatch is still on through the Phase 7 migration bake — for very long forensics windows or AWS-internal debug, query CloudWatch via `aws logs tail` instead of this skill.
+- `--filter` uses literal substring match; `--regex` uses Loki's RE2 dialect. Anchors (`^`, `$`) work; lookarounds don't.
+
+## See also
+
+- `packages/observability/README.md` — full label schema, LogQL cookbook, Loki vs CloudWatch decision table
+- The script itself — `packages/observability/scripts/tail-logs.sh`

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -45,6 +45,7 @@ scripts/
   apply.sh             # ./scripts/apply.sh --env <local|staging|production>
   pull.sh              # ./scripts/pull.sh  --env <name> --path <dir>
   check.sh             # ./scripts/check.sh --env <name>  (connectivity smoke test)
+  tail-logs.sh         # ./scripts/tail-logs.sh --env <name> --service <task family>
   render-config.sh     # internal — renders grafanactl config.yaml per-invocation
   grafanactl-env.sh    # sourceable; exports GRAFANA_TOKEN from SSM for staging/prod
 templates/
@@ -180,20 +181,42 @@ to avoid escaping `"` and `$` inside the query.
 
 ### `tail-logs.sh`
 
-A laptop-side wrapper around `logcli` with the auth + URL plumbing
-pre-baked is planned in [CS-10920](https://linear.app/cardstack/issue/CS-10920).
-Until that lands, the curl shape above is the equivalent.
-
-Sketch of the planned interface:
+`scripts/tail-logs.sh` wraps the curl shape above with auth + URL +
+LogQL selector building pre-baked. Local mode hits the localhost Loki
+without auth; staging / production fetch the bearer token and public
+URL from SSM.
 
 ```sh
-./scripts/tail-logs.sh --env staging --service realm-server --since 15m
-./scripts/tail-logs.sh --env staging --service worker --worker-id abc123 --filter "job_id=42"
-./scripts/tail-logs.sh --env production --service synapse --since 1h --confirm
+# Local — no auth, expects docker compose up from this directory
+./scripts/tail-logs.sh --env local --service realm-server
+
+# Tail staging worker errors
+./scripts/tail-logs.sh --env staging --service worker --regex '(?i)error|exception'
+
+# Drill to one job id
+./scripts/tail-logs.sh --env staging --service worker --filter 'job_id=42' --since 1h --no-follow
+
+# Production requires --confirm
+./scripts/tail-logs.sh --env production --service synapse --since 30m --no-follow --confirm
 ```
 
-(`--confirm` will be required for production to keep accidental prod
-queries out of the default flow.)
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--env` | (required) | `local`, `staging`, `production` |
+| `--service` | (required) | `realm-server`, `worker`, `prerender`, `prerender-manager`, `synapse` (or any local container name) |
+| `--realm` | unset | Restrict to a single realm. |
+| `--worker-id` | unset | Per-Fargate-task id; workers only. |
+| `--filter` | unset | LogQL line-filter (`\|=`); literal substring. |
+| `--regex` | unset | LogQL line-regex (`\|~`). Mutually exclusive with `--filter`. |
+| `--since` | `15m` | `30s`, `15m`, `1h`, `2d` — pattern `^\d+[smhd]$`. |
+| `--limit` | `200` | Max lines per batch. |
+| `--follow` / `--no-follow` | follow | Default polls every 5 s until ctrl-C. |
+| `--json` | text | Raw Loki response per batch (pipe to jq). |
+| `--confirm` | n/a | Required for `--env production`. |
+
+The same script powers the `tail-logs` Claude agent skill at
+`.claude/skills/tail-logs/SKILL.md` — agents call the script with
+`--no-follow` for diagnostics.
 
 ## Loki vs CloudWatch Logs Insights
 
@@ -257,8 +280,9 @@ CI will run `apply.sh --env staging` on merge to main once Phase 4 (CS-10932) la
 | CS-10916  | 2.5   | landed      | Alloy log scraper for local              |
 | CS-10919  | 2.5   | landed      | Loki on ECS (staging + production)       |
 | CS-10917  | 2.5   | landed      | FireLens dual-ship (5 task families × 2 envs) |
-| CS-10920  | 2.5   | not started | `tail-logs.sh` + Claude agent skill      |
-| CS-10921  | 2.5   | this PR     | Loki + tail-logs README                  |
+| CS-10920  | 2.5   | this PR     | `tail-logs.sh` + Claude agent skill      |
+| CS-10921  | 2.5   | landed      | Loki + tail-logs README                  |
+| CS-10968  | 2.5   | not started | Hosted Grafana → Loki data source wiring |
 | CS-10922  | 3     | landed      | AMG export and reformat                  |
 | CS-10932  | 4     | landed      | CI: apply to staging on merge            |
 | CS-10933  | 4     | not started | CI: post diff comment on PRs             |

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -86,23 +86,145 @@ source to see lines from any other container running on the host.
 
 The label set is **load-bearing**: dashboards written in LogQL select on
 these labels, so the local scraper, staging FireLens, and production
-FireLens must all emit the same shape. Pick the schema once, here.
+FireLens must all emit the same shape. Pick the schema once, here. If
+you change it, change it everywhere — `alloy/config.alloy` (local) and
+`cardstack/infra:modules/aws/ecs/firelens/templates/extra.conf.tftpl`
+(staging + production).
 
-| Label     | Source (local)                              | Source (staging / production)             |
-| --------- | ------------------------------------------- | ----------------------------------------- |
-| `env`     | constant `local` (set in `alloy/config.alloy`) | constant `staging` / `production` (FireLens record_modifier) |
-| `service` | Docker container name, leading `/` stripped | ECS task family, e.g. `realm-server`, `worker`, `synapse` |
-| `realm`   | opt-in via Docker label `boxel.realm=<name>` | realm name from worker/realm-server task env |
+| Label       | Local source                                          | Staging / production source                                        | When set                          |
+| ----------- | ----------------------------------------------------- | ------------------------------------------------------------------ | --------------------------------- |
+| `env`       | constant `local` (Alloy relabel rule)                 | constant `staging` / `production` (Fluent Bit static `Labels`)     | always                            |
+| `service`   | Docker container name, leading `/` stripped           | ECS task family — `realm-server`, `worker`, `prerender`, `prerender-manager`, `synapse` | always |
+| `realm`     | opt-in via Docker label `boxel.realm=<name>`          | task env when the task pins a single realm (omitted on multi-realm workloads) | when meaningful |
+| `worker_id` | not set locally                                       | per-Fargate-task `ecs_task_id` injected by FireLens (worker only)  | worker tasks only                 |
 
-The local scraper drops `grafana`, `loki`, and `alloy`'s own log streams
-to keep `{env="local"}` queries clean and avoid a Grafana → Loki feedback
-loop.
+The local Alloy scraper drops the observability stack's own Compose
+services (`grafana`, `loki`, `alloy`) so `{env="local"}` queries don't
+echo through a Grafana → Loki feedback loop.
 
-To tag a custom local container so dashboards pick it up by realm:
+To tag a custom local container so its lines pick up the `realm` label:
 
 ```sh
 docker run --label boxel.realm=test_realm --name my-realm-worker ...
 ```
+
+## Querying Loki
+
+### Locally
+
+Loki listens on `http://localhost:3100`. Either query in Grafana
+(http://localhost:3001 → Explore → Loki) or curl it directly:
+
+```sh
+curl -sS 'http://localhost:3100/loki/api/v1/labels' | jq
+curl -sS 'http://localhost:3100/loki/api/v1/label/service/values' | jq
+```
+
+### Staging or production
+
+The hosted Loki sits behind the Grafana ALB at the `/loki*` path, gated
+by a bearer token written to SSM. Two pieces of `${ENV}` plumbing:
+
+```sh
+ENV=staging   # or production
+TOKEN=$(aws ssm get-parameter --name /$ENV/loki/auth_token --with-decryption --query 'Parameter.Value' --output text)
+BASE=$(aws ssm get-parameter --name /$ENV/loki/public_url --query 'Parameter.Value' --output text)
+# BASE is e.g. https://grafana-staging.stack.cards/loki
+```
+
+> **URL gotcha**: the ALB rule path (`/loki*`) and Loki's own API
+> namespace (`/loki/api/v1/...`) happen to share the literal `/loki`
+> segment. The right call shape is `$BASE/api/v1/labels`, which resolves
+> to `https://.../loki/api/v1/labels` — Loki's native endpoint. Do not
+> double the segment (`$BASE/loki/api/v1/labels` 404s).
+
+```sh
+curl -sS -H "Authorization: Bearer $TOKEN" "$BASE/api/v1/labels" | jq
+curl -sS -H "Authorization: Bearer $TOKEN" "$BASE/api/v1/label/service/values" | jq
+```
+
+### LogQL cookbook
+
+These run identically against local, staging, and production — only the
+URL/token plumbing differs. Replace `<env>` with `local`, `staging`, or
+`production`.
+
+```logql
+# All lines from the realm-server in the last hour
+{env="<env>", service="realm-server"}
+
+# Errors in any service in the last 15m
+{env="<env>"} |~ "(?i)error|exception|fatal"
+
+# Lines for one realm across all services
+{env="<env>", realm="example_realm"}
+
+# Per-worker tail
+{env="<env>", service="worker", worker_id="abc123def456"}
+
+# Logs around a specific job id (LogQL line-filter, not regex)
+{env="<env>", service="worker"} |= "job_id=42"
+
+# Error rate over the last day, sliced by service
+sum by (service) (count_over_time({env="<env>"} |~ "ERROR" [1d]))
+
+# Slowest indexer batches in the last hour (matches a known log shape)
+{env="<env>", service="realm-server"} |~ "indexer.*duration_ms=[0-9]{4,}"
+
+# Drop noisy keep-alive lines, keep the rest
+{env="<env>", service="prerender"} != "GET /health"
+```
+
+Quoting: LogQL is JSON-y. Single-quote the whole expression in shell
+to avoid escaping `"` and `$` inside the query.
+
+### `tail-logs.sh`
+
+A laptop-side wrapper around `logcli` with the auth + URL plumbing
+pre-baked is planned in [CS-10920](https://linear.app/cardstack/issue/CS-10920).
+Until that lands, the curl shape above is the equivalent.
+
+Sketch of the planned interface:
+
+```sh
+./scripts/tail-logs.sh --env staging --service realm-server --since 15m
+./scripts/tail-logs.sh --env staging --service worker --worker-id abc123 --filter "job_id=42"
+./scripts/tail-logs.sh --env production --service synapse --since 1h --confirm
+```
+
+(`--confirm` will be required for production to keep accidental prod
+queries out of the default flow.)
+
+## Loki vs CloudWatch Logs Insights
+
+Through the Phase 7 migration bake, every staging / production task
+that ships to Loki **also** ships the same lines to CloudWatch — see
+`cardstack/infra:modules/aws/ecs/firelens/templates/extra.conf.tftpl`,
+the FireLens config emits two `[OUTPUT]` blocks per task. Pick which
+backend to query based on what you're doing:
+
+| Use case                                                          | Query target | Why                                                                                                                       |
+| ----------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| Reproducing a dashboard panel locally                             | Loki         | Dashboards under `grafanactl/resources/dashboards/` use LogQL — same syntax, same labels, same answer.                    |
+| Tailing live activity from a laptop                               | Loki         | `tail-logs.sh` (CS-10920) / `logcli` keep the same labels and a uniform shell.                                            |
+| Cross-service queries (e.g. "all errors in staging in the last hour") | Loki     | One label plane (`env=staging`) covers everything. CloudWatch needs a Logs Insights query per log group.                  |
+| Long-window forensics (>30 days)                                  | CloudWatch   | CloudWatch retention is set per-log-group on the existing infra; Loki's S3 lifecycle expires chunks at 180 days.          |
+| AMG-era saved query / runbook you remember                        | CloudWatch   | The CloudWatch shape didn't change — paste the old Logs Insights query and it still works through Phase 7.                |
+| AWS-side troubleshooting (ECS Agent, FireLens itself)             | CloudWatch   | Loki only sees the application's stdout. ECS-internal events are CloudWatch only.                                         |
+
+The dual-ship goes away (CloudWatch-only drop) in a follow-up ticket
+once Loki has been load-bearing for a full release cycle.
+
+## Hosted vs local Loki
+
+| Trait                  | Local                                | Staging / production                                            |
+| ---------------------- | ------------------------------------ | --------------------------------------------------------------- |
+| Storage                | filesystem, named volume `loki_data` | S3 bucket `boxel-loki-chunks-<env>`                             |
+| Persistence            | survives `docker compose restart`; lost on `down -v` | indefinite, governed by S3 lifecycle                            |
+| Retention              | none enforced (devs prune manually)  | transition to IA at 30 d, expire at 180 d (S3 lifecycle)        |
+| `reject_old_samples`   | `false` (so backfills work)          | `true` (default, ~7d window)                                    |
+| Auth                   | none                                 | bearer token at the Grafana ALB (`/loki*` path rule); SG-only on internal NLB |
+| Reachable from         | localhost only                       | Grafana ECS tasks + FireLens log_router sidecars; laptops via the public path |
 
 ## Staging / production workflow
 
@@ -131,12 +253,16 @@ CI will run `apply.sh --env staging` on merge to main once Phase 4 (CS-10932) la
 | CS-10914  | 2     | landed      | Package skeleton                         |
 | CS-10912  | 2     | landed      | Local `docker-compose.yml` for Grafana   |
 | CS-10913  | 2     | landed      | grafanactl `local`/`staging`/`prod` ctxs |
-| CS-10918  | 2.5   | landed      | Loki container + data source             |
-| CS-10916  | 2.5   | this PR     | Alloy log scraper for local              |
+| CS-10918  | 2.5   | landed      | Loki container + data source (local)     |
+| CS-10916  | 2.5   | landed      | Alloy log scraper for local              |
+| CS-10919  | 2.5   | landed      | Loki on ECS (staging + production)       |
+| CS-10917  | 2.5   | landed      | FireLens dual-ship (5 task families × 2 envs) |
+| CS-10920  | 2.5   | not started | `tail-logs.sh` + Claude agent skill      |
+| CS-10921  | 2.5   | this PR     | Loki + tail-logs README                  |
 | CS-10922  | 3     | landed      | AMG export and reformat                  |
-| CS-10932  | 4     | not started | CI: apply to staging on merge            |
+| CS-10932  | 4     | landed      | CI: apply to staging on merge            |
 | CS-10933  | 4     | not started | CI: post diff comment on PRs             |
-| CS-10936  | 5     | not started | CI: apply to production                  |
+| CS-10936  | 5     | landed      | CI: apply to production                  |
 
 ## Vendored content
 
@@ -144,7 +270,8 @@ CI will run `apply.sh --env staging` on merge to main once Phase 4 (CS-10932) la
 
 ## Known cleanups (deferred)
 
-- **Staging/production Loki ECS deployment.** Currently no Loki running in staging or production. Staging/production Grafana provisioning expects `${LOKI_URL}` to be set on the ECS task; that's an infra ticket.
+- **Hosted Grafana → Loki data source wiring.** The staging / production ECS Grafana tasks don't yet have `LOKI_URL` set or `provisioning/datasources/loki.yaml` mounted, so Grafana → Explore → Loki returns "no data source" against the hosted environments even though Loki itself is up. Direct curl / `logcli` against `/<env>/loki/public_url` works today.
 - **`provisioning/` delivery to staging/production ECS.** The provisioning files (data sources + alert rules) need to land on the ECS Grafana container — image bake, S3-init, or EFS mount. Decide and ship as a separate infra ticket.
 - **Secret env-var wiring for data sources.** `provisioning/datasources/*.json` omits `secureJsonData` (passwords, API keys). The staging/production ECS Grafana task needs those env vars set from SSM (`GRAFANA_DB_PASSWORD` etc.) and the provisioning files updated to reference them via `${ENV_VAR}`.
+- **Drop the dual-ship to CloudWatch** once Loki has been load-bearing for a release cycle. Until then both backends receive identical lines through the FireLens config in `cardstack/infra:modules/aws/ecs/firelens/templates/extra.conf.tftpl`.
 - **CODEOWNERS.** No file in the repo today — if the team wants observability-specific reviewer requirements, file a separate ticket.

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -114,11 +114,23 @@ docker run --label boxel.realm=test_realm --name my-realm-worker ...
 ### Locally
 
 Loki listens on `http://localhost:3100`. Either query in Grafana
-(http://localhost:3001 → Explore → Loki) or curl it directly:
+(http://localhost:3001 → Explore → Loki), inspect metadata with curl,
+or fetch log lines directly from the CLI:
 
 ```sh
+# Metadata discovery
 curl -sS 'http://localhost:3100/loki/api/v1/labels' | jq
 curl -sS 'http://localhost:3100/loki/api/v1/label/service/values' | jq
+
+# Fetch lines for one service over the last 15 minutes
+END=$(date -u +%s)
+START=$((END - 15 * 60))
+curl -sS -G 'http://localhost:3100/loki/api/v1/query_range' \
+  --data-urlencode 'query={service="my-realm-worker"}' \
+  --data-urlencode "start=${START}000000000" \
+  --data-urlencode "end=${END}000000000" \
+  --data-urlencode 'limit=100' \
+  --data-urlencode 'direction=backward' | jq
 ```
 
 ### Staging or production
@@ -150,11 +162,17 @@ These run identically against local, staging, and production — only the
 URL/token plumbing differs. Replace `<env>` with `local`, `staging`, or
 `production`.
 
+A LogQL selector by itself doesn't carry a time window — that comes
+from the client (Grafana Explore's range picker, `tail-logs.sh
+--since`, or `start`/`end` on the `query_range` HTTP API). The `[1d]`,
+`[5m]` etc. inside `count_over_time(... [N])` are the *aggregation*
+window, not the query window.
+
 ```logql
-# All lines from the realm-server in the last hour
+# All lines from the realm-server in the selected time range
 {env="<env>", service="realm-server"}
 
-# Errors in any service in the last 15m
+# Errors in any service in the selected time range
 {env="<env>"} |~ "(?i)error|exception|fatal"
 
 # Lines for one realm across all services
@@ -166,10 +184,11 @@ URL/token plumbing differs. Replace `<env>` with `local`, `staging`, or
 # Logs around a specific job id (LogQL line-filter, not regex)
 {env="<env>", service="worker"} |= "job_id=42"
 
-# Error rate over the last day, sliced by service
+# Error rate sliced by service — the [1d] is the aggregation window,
+# the query time range still comes from the client
 sum by (service) (count_over_time({env="<env>"} |~ "ERROR" [1d]))
 
-# Slowest indexer batches in the last hour (matches a known log shape)
+# Slowest indexer batches (matches a known log shape)
 {env="<env>", service="realm-server"} |~ "indexer.*duration_ms=[0-9]{4,}"
 
 # Drop noisy keep-alive lines, keep the rest

--- a/packages/observability/scripts/tail-logs.sh
+++ b/packages/observability/scripts/tail-logs.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Tail Loki logs from a laptop. Wraps the same /loki/api/v1/query_range
+# call that `logcli` makes, with auth + URL plumbing pre-baked from SSM.
+#
+# Usage:
+#   ./scripts/tail-logs.sh --env local|staging|production
+#                          --service realm-server|worker|prerender|prerender-manager|synapse
+#                         [--realm <name>]
+#                         [--worker-id <id>]
+#                         [--filter <substring>]      # LogQL line-filter (|=)
+#                         [--regex <pattern>]         # LogQL line-regex (|~)
+#                         [--since <duration>]        # 15m | 1h | 30s | 2d (default 15m)
+#                         [--limit <n>]               # batch size per poll (default 200)
+#                         [--no-follow]               # one-shot, exit after the first batch
+#                         [--json]                    # raw Loki response per batch
+#                         [--confirm]                 # required for --env production
+#
+# Auth and URL come from SSM:
+#   /<env>/loki/auth_token  — bearer token
+#   /<env>/loki/public_url  — e.g. https://grafana-staging.stack.cards/loki
+# Local mode hits http://localhost:3100 without auth.
+#
+# Examples:
+#   ./scripts/tail-logs.sh --env local --service realm-server
+#   ./scripts/tail-logs.sh --env staging --service realm-server --since 1h --regex 'error|exception'
+#   ./scripts/tail-logs.sh --env staging --service worker --worker-id abc123 --filter 'job_id=42'
+#   ./scripts/tail-logs.sh --env production --service synapse --since 30m --confirm
+set -eo pipefail
+
+POLL_INTERVAL_SECONDS=5
+
+usage_error() { printf 'error: %s\n' "$1" >&2; exit 2; }
+fail() { printf 'error: %s\n' "$1" >&2; exit 1; }
+
+# Defaults
+env_name=""
+service=""
+realm=""
+worker_id=""
+line_filter=""
+line_regex=""
+since="15m"
+limit=200
+follow="yes"
+json_out="no"
+confirm_prod="no"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env)        env_name="$2"; shift 2;;
+    --service)    service="$2"; shift 2;;
+    --realm)      realm="$2"; shift 2;;
+    --worker-id)  worker_id="$2"; shift 2;;
+    --filter)     line_filter="$2"; shift 2;;
+    --regex)      line_regex="$2"; shift 2;;
+    --since)      since="$2"; shift 2;;
+    --limit)      limit="$2"; shift 2;;
+    --follow)     follow="yes"; shift;;
+    --no-follow)  follow="no"; shift;;
+    --json)       json_out="yes"; shift;;
+    --confirm)    confirm_prod="yes"; shift;;
+    -h | --help)
+      sed -n '/^# Usage:/,/^set -/{ /^set -/d; s/^# \?//; p; }' "$0"
+      exit 0;;
+    *) usage_error "unknown option: $1";;
+  esac
+done
+
+[[ -n "$env_name" ]] || usage_error "missing --env"
+[[ "$env_name" == "local" || "$env_name" == "staging" || "$env_name" == "production" ]] \
+  || usage_error "--env must be local, staging, or production (got: $env_name)"
+[[ -n "$service" ]] || usage_error "missing --service"
+[[ -z "$line_filter" || -z "$line_regex" ]] || usage_error "use --filter OR --regex, not both"
+
+if [[ "$env_name" == "production" && "$confirm_prod" != "yes" ]]; then
+  fail "querying production requires --confirm (production logs flow through the same Grafana ALB everyone uses)"
+fi
+
+# Convert "15m" / "1h" / "30s" / "2d" → seconds.
+parse_duration_seconds() {
+  local d="$1"
+  [[ "$d" =~ ^([0-9]+)([smhd])$ ]] || fail "invalid duration: $d (expected e.g. 15m, 1h, 30s, 2d)"
+  local n="${BASH_REMATCH[1]}"
+  case "${BASH_REMATCH[2]}" in
+    s) printf '%d\n' "$n" ;;
+    m) printf '%d\n' "$((n * 60))" ;;
+    h) printf '%d\n' "$((n * 3600))" ;;
+    d) printf '%d\n' "$((n * 86400))" ;;
+  esac
+}
+
+since_seconds="$(parse_duration_seconds "$since")"
+
+# Resolve auth + URL. The base URL always has Loki's `/loki` path segment
+# baked in: locally that's Loki's native API namespace; for staging /
+# production it's the ALB rule prefix (the hosted API URLs happen to align
+# because the ALB rule prefix and Loki's native namespace are both `/loki`).
+auth_header=()
+case "$env_name" in
+  local)
+    base="http://localhost:3100/loki"
+    ;;
+  staging | production)
+    token="$(aws ssm get-parameter \
+      --name "/${env_name}/loki/auth_token" \
+      --with-decryption --query 'Parameter.Value' --output text 2>/dev/null)" \
+      || fail "couldn't fetch /${env_name}/loki/auth_token from SSM (is AWS auth active for the ${env_name} account?)"
+    base="$(aws ssm get-parameter \
+      --name "/${env_name}/loki/public_url" \
+      --query 'Parameter.Value' --output text 2>/dev/null)" \
+      || fail "couldn't fetch /${env_name}/loki/public_url from SSM"
+    auth_header=(-H "Authorization: Bearer ${token}")
+    ;;
+esac
+
+# Build the LogQL selector. `service` is required, the rest are optional.
+selector="{env=\"${env_name}\", service=\"${service}\""
+[[ -n "$realm"     ]] && selector="${selector}, realm=\"${realm}\""
+[[ -n "$worker_id" ]] && selector="${selector}, worker_id=\"${worker_id}\""
+selector="${selector}}"
+
+query="$selector"
+if [[ -n "$line_filter" ]]; then
+  query="${query} |= \"${line_filter}\""
+elif [[ -n "$line_regex" ]]; then
+  query="${query} |~ \"${line_regex}\""
+fi
+
+# Format a Loki response into "<rfc3339> <labels> <line>" per row.
+format_lines() {
+  if [[ "$json_out" == "yes" ]]; then
+    jq .
+    return
+  fi
+  jq -r '
+    .data.result[]?
+    | (.stream | to_entries | map("\(.key)=\(.value)") | join(",")) as $labels
+    | .values[]?
+    | ((.[0] | tonumber) / 1e9 | todate) + "  [" + $labels + "]  " + .[1]
+  '
+}
+
+# Single query_range fetch over [start_ns, end_ns). Validates that the
+# response is JSON and `status: success` before handing it to the formatter
+# — Loki's auth / 5xx error pages aren't JSON, and an unguarded jq pipe
+# emits cryptic parse errors that hide the real problem.
+fetch_range() {
+  local start_ns="$1" end_ns="$2"
+  local body http_status
+  body="$(curl -sS -w '\n__HTTP_STATUS__%{http_code}\n' "${auth_header[@]}" -G \
+    --data-urlencode "query=${query}" \
+    --data-urlencode "start=${start_ns}" \
+    --data-urlencode "end=${end_ns}" \
+    --data-urlencode "limit=${limit}" \
+    --data-urlencode "direction=forward" \
+    "${base}/api/v1/query_range")"
+  http_status="$(printf '%s\n' "$body" | sed -n 's/^__HTTP_STATUS__//p' | tail -1)"
+  body="$(printf '%s\n' "$body" | sed '/^__HTTP_STATUS__/d')"
+
+  if [[ "$http_status" != 2?? ]]; then
+    printf 'error: Loki query returned HTTP %s\n%s\n' "$http_status" "$body" >&2
+    return 1
+  fi
+  if ! printf '%s' "$body" | jq -e '.status == "success"' >/dev/null 2>&1; then
+    printf 'error: Loki response not in expected shape\n%s\n' "$body" >&2
+    return 1
+  fi
+  printf '%s\n' "$body"
+}
+
+now_ns="$(date -u +%s)000000000"
+since_ns=$(( now_ns - since_seconds * 1000000000 ))
+
+# Header so the user knows what they're tailing.
+{
+  printf '# tail-logs.sh\n'
+  printf '#   env:      %s\n' "$env_name"
+  printf '#   query:    %s\n' "$query"
+  printf '#   since:    %s\n' "$since"
+  printf '#   limit:    %s per batch\n' "$limit"
+  printf '#   follow:   %s\n' "$follow"
+  printf '#   endpoint: %s/api/v1/query_range\n' "$base"
+  printf '#\n'
+} >&2
+
+fetch_range "$since_ns" "$now_ns" | format_lines
+
+if [[ "$follow" != "yes" ]]; then
+  exit 0
+fi
+
+# Live tail: poll the next [last_end, now] window every POLL_INTERVAL_SECONDS.
+last_end_ns="$now_ns"
+while sleep "$POLL_INTERVAL_SECONDS"; do
+  now_ns="$(date -u +%s)000000000"
+  fetch_range "$last_end_ns" "$now_ns" | format_lines
+  last_end_ns="$now_ns"
+done


### PR DESCRIPTION
## Summary

Bundles **CS-10921** (docs) and **CS-10920** (script + agent skill) since the docs reference the script extensively.

### CS-10921 — `packages/observability/README.md`

- Complete label schema table (env / service / realm / worker_id) with per-env source + "when set" semantics
- Querying Loki section covering local + hosted curl plumbing, with the `$BASE/api/v1/...` URL gotcha called out (we hit it during staging deploy)
- 8-query LogQL cookbook (the patterns the team actually ran during the migration)
- Loki vs CloudWatch decision table for the dual-ship bake window
- Hosted vs local Loki traits table (storage / retention / auth / reach)
- `tail-logs.sh` flag reference (no longer "planned" — script lives in this PR)
- Refreshed phase-status table; cleaned up "Known cleanups"

### CS-10920 — `packages/observability/scripts/tail-logs.sh` + `.claude/skills/tail-logs/`

A laptop-side wrapper that hides the curl + LogQL + auth + URL plumbing. Local mode hits `http://localhost:3100/loki`; staging / production fetch the bearer token (`/<env>/loki/auth_token`) and public URL (`/<env>/loki/public_url`) from SSM. Production requires `--confirm`.

Default output: `<rfc3339>  [<labels>]  <line>`. `--json` for raw response. Default mode polls every 5s like `logcli --tail`; `--no-follow` exits after the first batch.

The Claude agent skill at `.claude/skills/tail-logs/SKILL.md` invokes the script with `--no-follow` for diagnostics.

## Test plan

- [x] `--help` prints the usage block
- [x] Invalid `--env` rejected
- [x] `--env production` without `--confirm` rejected
- [x] Local end-to-end: spin up a labelled busybox container, `--no-follow` returns formatted lines
- [x] `--filter` (LogQL `\|=`) and `--regex` (LogQL `\|~`) both work
- [x] `--json` returns raw Loki response
- [x] Empty result returns cleanly (no error)
- [ ] Staging: `--env staging --service realm-server --since 5m --no-follow` (run after merge against your AWS creds)

## Acceptance check from CS-10921

- [x] Every label in the schema appears in at least one example query
- [x] Schema cross-links to `alloy/config.alloy` and the FireLens template in cardstack/infra
- [x] A new teammate following only this README can `curl` (or `tail-logs.sh`) staging realm-server logs from their laptop in well under five minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)