### PR TITLE
Add --quiet flag to boxel-cli; software factory passes it by default (CS-10967)

### DIFF
--- a/packages/boxel-cli/api.ts
+++ b/packages/boxel-cli/api.ts
@@ -23,3 +23,5 @@ export {
   resetProfileManager,
   setProfileManager,
 } from './src/lib/profile-manager';
+
+export { setQuiet, isQuiet } from './src/lib/cli-log';

--- a/packages/boxel-cli/src/commands/file/delete.ts
+++ b/packages/boxel-cli/src/commands/file/delete.ts
@@ -98,7 +98,7 @@ export function registerDeleteCommand(parent: Command): void {
       if (opts.json) {
         cliLog.output(JSON.stringify(result, null, 2));
       } else if (result.ok) {
-        cliLog.output(`${DIM}Deleted:${RESET} ${filePath}`);
+        console.log(`${DIM}Deleted:${RESET} ${filePath}`);
       } else {
         console.error(`${FG_RED}Error:${RESET} ${result.error}`);
       }

--- a/packages/boxel-cli/src/commands/file/delete.ts
+++ b/packages/boxel-cli/src/commands/file/delete.ts
@@ -8,6 +8,7 @@ import { isProtectedFile } from '../../lib/realm-sync-base';
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
 import { FG_RED, DIM, RESET } from '../../lib/colors';
+import { cliLog } from '../../lib/cli-log';
 
 export interface DeleteResult {
   ok: boolean;
@@ -95,9 +96,9 @@ export function registerDeleteCommand(parent: Command): void {
       }
 
       if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
+        cliLog.output(JSON.stringify(result, null, 2));
       } else if (result.ok) {
-        console.log(`${DIM}Deleted:${RESET} ${filePath}`);
+        cliLog.output(`${DIM}Deleted:${RESET} ${filePath}`);
       } else {
         console.error(`${FG_RED}Error:${RESET} ${result.error}`);
       }

--- a/packages/boxel-cli/src/commands/file/lint.ts
+++ b/packages/boxel-cli/src/commands/file/lint.ts
@@ -8,6 +8,7 @@ import {
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
 import { FG_GREEN, FG_RED, FG_YELLOW, DIM, RESET } from '../../lib/colors';
+import { cliLog } from '../../lib/cli-log';
 import { write } from './write';
 
 export interface LintMessage {
@@ -172,7 +173,7 @@ export function registerLintCommand(parent: Command): void {
       }
 
       if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
+        cliLog.output(JSON.stringify(result, null, 2));
         if (!result.ok) {
           process.exit(1);
         }
@@ -188,7 +189,7 @@ export function registerLintCommand(parent: Command): void {
       if (opts.fix && result.fixed && result.output) {
         if (opts.file) {
           writeFileSync(opts.file, result.output, 'utf-8');
-          console.log(`${FG_GREEN}Fixed:${RESET} ${opts.file}`);
+          cliLog.output(`${FG_GREEN}Fixed:${RESET} ${opts.file}`);
         } else {
           let writeResult = await write(opts.realm, filePath, result.output, {
             profileManager: pm,
@@ -199,7 +200,7 @@ export function registerLintCommand(parent: Command): void {
             );
             process.exit(1);
           }
-          console.log(
+          cliLog.output(
             `${FG_GREEN}Fixed:${RESET} ${filePath} ${DIM}→${RESET} ${opts.realm}`,
           );
         }
@@ -210,7 +211,7 @@ export function registerLintCommand(parent: Command): void {
       let warnings = messages.filter((m) => m.severity === 1);
 
       if (messages.length === 0) {
-        console.log(`${DIM}No lint issues found.${RESET}`);
+        cliLog.output(`${DIM}No lint issues found.${RESET}`);
         return;
       }
 
@@ -218,12 +219,12 @@ export function registerLintCommand(parent: Command): void {
         let color = msg.severity === 2 ? FG_RED : FG_YELLOW;
         let level = msg.severity === 2 ? 'error' : 'warning';
         let rule = msg.ruleId ? ` (${msg.ruleId})` : '';
-        console.log(
+        cliLog.output(
           `${color}${level}${RESET} ${msg.line}:${msg.column} ${msg.message}${DIM}${rule}${RESET}`,
         );
       }
 
-      console.log(
+      cliLog.output(
         `\n${DIM}${errors.length} error(s), ${warnings.length} warning(s)${RESET}`,
       );
 

--- a/packages/boxel-cli/src/commands/file/lint.ts
+++ b/packages/boxel-cli/src/commands/file/lint.ts
@@ -189,7 +189,7 @@ export function registerLintCommand(parent: Command): void {
       if (opts.fix && result.fixed && result.output) {
         if (opts.file) {
           writeFileSync(opts.file, result.output, 'utf-8');
-          cliLog.output(`${FG_GREEN}Fixed:${RESET} ${opts.file}`);
+          console.log(`${FG_GREEN}Fixed:${RESET} ${opts.file}`);
         } else {
           let writeResult = await write(opts.realm, filePath, result.output, {
             profileManager: pm,
@@ -200,7 +200,7 @@ export function registerLintCommand(parent: Command): void {
             );
             process.exit(1);
           }
-          cliLog.output(
+          console.log(
             `${FG_GREEN}Fixed:${RESET} ${filePath} ${DIM}→${RESET} ${opts.realm}`,
           );
         }
@@ -211,7 +211,7 @@ export function registerLintCommand(parent: Command): void {
       let warnings = messages.filter((m) => m.severity === 1);
 
       if (messages.length === 0) {
-        cliLog.output(`${DIM}No lint issues found.${RESET}`);
+        console.log(`${DIM}No lint issues found.${RESET}`);
         return;
       }
 
@@ -219,12 +219,12 @@ export function registerLintCommand(parent: Command): void {
         let color = msg.severity === 2 ? FG_RED : FG_YELLOW;
         let level = msg.severity === 2 ? 'error' : 'warning';
         let rule = msg.ruleId ? ` (${msg.ruleId})` : '';
-        cliLog.output(
+        console.log(
           `${color}${level}${RESET} ${msg.line}:${msg.column} ${msg.message}${DIM}${rule}${RESET}`,
         );
       }
 
-      cliLog.output(
+      console.log(
         `\n${DIM}${errors.length} error(s), ${warnings.length} warning(s)${RESET}`,
       );
 

--- a/packages/boxel-cli/src/commands/file/list.ts
+++ b/packages/boxel-cli/src/commands/file/list.ts
@@ -113,9 +113,9 @@ export function registerListCommand(file: Command): void {
         process.exit(1);
       } else {
         for (let filename of result.filenames) {
-          cliLog.output(`${DIM}${filename}${RESET}`);
+          console.log(`${DIM}${filename}${RESET}`);
         }
-        cliLog.output(`\n${DIM}${result.filenames.length} file(s)${RESET}`);
+        console.log(`\n${DIM}${result.filenames.length} file(s)${RESET}`);
       }
     });
 }

--- a/packages/boxel-cli/src/commands/file/list.ts
+++ b/packages/boxel-cli/src/commands/file/list.ts
@@ -7,6 +7,7 @@ import {
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
 import { FG_RED, DIM, RESET } from '../../lib/colors';
+import { cliLog } from '../../lib/cli-log';
 
 export interface ListFilesResult {
   filenames: string[];
@@ -103,7 +104,7 @@ export function registerListCommand(file: Command): void {
       }
 
       if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
+        cliLog.output(JSON.stringify(result, null, 2));
         if (result.error) {
           process.exit(1);
         }
@@ -112,9 +113,9 @@ export function registerListCommand(file: Command): void {
         process.exit(1);
       } else {
         for (let filename of result.filenames) {
-          console.log(`${DIM}${filename}${RESET}`);
+          cliLog.output(`${DIM}${filename}${RESET}`);
         }
-        console.log(`\n${DIM}${result.filenames.length} file(s)${RESET}`);
+        cliLog.output(`\n${DIM}${result.filenames.length} file(s)${RESET}`);
       }
     });
 }

--- a/packages/boxel-cli/src/commands/file/read.ts
+++ b/packages/boxel-cli/src/commands/file/read.ts
@@ -7,6 +7,7 @@ import {
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
 import { FG_RED, DIM, RESET } from '../../lib/colors';
+import { cliLog } from '../../lib/cli-log';
 
 export interface ReadResult {
   ok: boolean;
@@ -95,9 +96,9 @@ export function registerReadCommand(parent: Command): void {
       }
 
       if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
+        cliLog.output(JSON.stringify(result, null, 2));
       } else if (result.ok) {
-        console.log(result.content ?? '');
+        cliLog.output(result.content ?? '');
       } else {
         console.error(
           `${DIM}Status:${RESET} ${result.status ?? '(no status)'}`,

--- a/packages/boxel-cli/src/commands/file/write.ts
+++ b/packages/boxel-cli/src/commands/file/write.ts
@@ -8,6 +8,7 @@ import {
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
 import { FG_GREEN, FG_RED, DIM, RESET } from '../../lib/colors';
+import { cliLog } from '../../lib/cli-log';
 
 export interface WriteResult {
   ok: boolean;
@@ -135,9 +136,9 @@ export function registerWriteCommand(parent: Command): void {
       }
 
       if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
+        cliLog.output(JSON.stringify(result, null, 2));
       } else if (result.ok) {
-        console.log(
+        cliLog.output(
           `${FG_GREEN}Written:${RESET} ${filePath} ${DIM}→${RESET} ${opts.realm}`,
         );
       } else {

--- a/packages/boxel-cli/src/commands/file/write.ts
+++ b/packages/boxel-cli/src/commands/file/write.ts
@@ -138,7 +138,7 @@ export function registerWriteCommand(parent: Command): void {
       if (opts.json) {
         cliLog.output(JSON.stringify(result, null, 2));
       } else if (result.ok) {
-        cliLog.output(
+        console.log(
           `${FG_GREEN}Written:${RESET} ${filePath} ${DIM}→${RESET} ${opts.realm}`,
         );
       } else {

--- a/packages/boxel-cli/src/commands/read-transpiled.ts
+++ b/packages/boxel-cli/src/commands/read-transpiled.ts
@@ -2,6 +2,7 @@ import type { Command } from 'commander';
 import { getProfileManager, type ProfileManager } from '../lib/profile-manager';
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { FG_RED, DIM, RESET } from '../lib/colors';
+import { cliLog } from '../lib/cli-log';
 
 export interface ReadTranspiledResult {
   ok: boolean;
@@ -102,9 +103,9 @@ export function registerReadTranspiledCommand(program: Command): void {
       }
 
       if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
+        cliLog.output(JSON.stringify(result, null, 2));
       } else if (result.ok) {
-        console.log(result.content ?? '');
+        cliLog.output(result.content ?? '');
       } else {
         console.error(
           `${DIM}Status:${RESET} ${result.status ?? '(no status)'}`,

--- a/packages/boxel-cli/src/commands/realm/cancel-indexing.ts
+++ b/packages/boxel-cli/src/commands/realm/cancel-indexing.ts
@@ -6,6 +6,7 @@ import {
 } from '../../lib/profile-manager';
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { FG_GREEN, FG_RED, RESET } from '../../lib/colors';
+import { cliLog } from '../../lib/cli-log';
 
 export interface CancelIndexingCommandOptions {
   profileManager?: ProfileManager;
@@ -95,7 +96,7 @@ export function registerCancelIndexingCommand(realm: Command): void {
       });
 
       if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
+        cliLog.output(JSON.stringify(result, null, 2));
         if (!result.ok) {
           process.exit(1);
         }

--- a/packages/boxel-cli/src/commands/realm/create.ts
+++ b/packages/boxel-cli/src/commands/realm/create.ts
@@ -9,7 +9,6 @@ import {
   type ProfileManager,
 } from '../../lib/profile-manager';
 import { FG_GREEN, FG_CYAN, RESET } from '../../lib/colors';
-import { cliLog } from '../../lib/cli-log';
 
 const REALM_NAME_PATTERN = /^[a-z0-9-]+$/;
 
@@ -219,7 +218,7 @@ async function executeCreateRealmCommand(
   try {
     let result = await createRealm(realmName, displayName, options);
     let verb = result.created ? 'created' : 'already exists';
-    cliLog.output(
+    console.log(
       `${FG_GREEN}Realm ${verb}:${RESET} ${FG_CYAN}${result.realmUrl}${RESET}`,
     );
   } catch (e: unknown) {

--- a/packages/boxel-cli/src/commands/realm/create.ts
+++ b/packages/boxel-cli/src/commands/realm/create.ts
@@ -9,6 +9,7 @@ import {
   type ProfileManager,
 } from '../../lib/profile-manager';
 import { FG_GREEN, FG_CYAN, RESET } from '../../lib/colors';
+import { cliLog } from '../../lib/cli-log';
 
 const REALM_NAME_PATTERN = /^[a-z0-9-]+$/;
 
@@ -218,7 +219,7 @@ async function executeCreateRealmCommand(
   try {
     let result = await createRealm(realmName, displayName, options);
     let verb = result.created ? 'created' : 'already exists';
-    console.log(
+    cliLog.output(
       `${FG_GREEN}Realm ${verb}:${RESET} ${FG_CYAN}${result.realmUrl}${RESET}`,
     );
   } catch (e: unknown) {

--- a/packages/boxel-cli/src/commands/run-command.ts
+++ b/packages/boxel-cli/src/commands/run-command.ts
@@ -153,11 +153,11 @@ export function registerRunCommand(program: Command): void {
       if (opts.json) {
         cliLog.output(JSON.stringify(result, null, 2));
       } else {
-        cliLog.output(
+        console.log(
           `${DIM}Status:${RESET} ${statusColor(result.status)}${result.status}${RESET}`,
         );
         if (result.result) {
-          cliLog.output(`${DIM}Result:${RESET}`);
+          console.log(`${DIM}Result:${RESET}`);
           try {
             cliLog.output(JSON.stringify(JSON.parse(result.result), null, 2));
           } catch {

--- a/packages/boxel-cli/src/commands/run-command.ts
+++ b/packages/boxel-cli/src/commands/run-command.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander';
 import { getProfileManager, type ProfileManager } from '../lib/profile-manager';
 import { FG_GREEN, FG_RED, FG_CYAN, DIM, RESET } from '../lib/colors';
+import { cliLog } from '../lib/cli-log';
 
 export interface RunCommandResult {
   status: 'ready' | 'error' | 'unusable';
@@ -150,17 +151,17 @@ export function registerRunCommand(program: Command): void {
       }
 
       if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
+        cliLog.output(JSON.stringify(result, null, 2));
       } else {
-        console.log(
+        cliLog.output(
           `${DIM}Status:${RESET} ${statusColor(result.status)}${result.status}${RESET}`,
         );
         if (result.result) {
-          console.log(`${DIM}Result:${RESET}`);
+          cliLog.output(`${DIM}Result:${RESET}`);
           try {
-            console.log(JSON.stringify(JSON.parse(result.result), null, 2));
+            cliLog.output(JSON.stringify(JSON.parse(result.result), null, 2));
           } catch {
-            console.log(result.result);
+            cliLog.output(result.result);
           }
         }
         if (result.error) {

--- a/packages/boxel-cli/src/commands/search.ts
+++ b/packages/boxel-cli/src/commands/search.ts
@@ -6,6 +6,7 @@ import {
 } from '../lib/profile-manager';
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { FG_RED, DIM, RESET } from '../lib/colors';
+import { cliLog } from '../lib/cli-log';
 
 export interface SearchResult {
   ok: boolean;
@@ -142,9 +143,9 @@ export function registerSearchCommand(program: Command): void {
       }
 
       if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
+        cliLog.output(JSON.stringify(result, null, 2));
       } else if (result.ok) {
-        console.log(JSON.stringify(result.data ?? [], null, 2));
+        cliLog.output(JSON.stringify(result.data ?? [], null, 2));
       } else {
         console.error(
           `${DIM}Status:${RESET} ${result.status ?? '(no status)'}`,

--- a/packages/boxel-cli/src/index.ts
+++ b/packages/boxel-cli/src/index.ts
@@ -34,13 +34,11 @@ program
     }
   });
 
-// Pre-parse: also flip quiet mode based on a raw scan of argv. Commander's
-// `preAction` hook runs after argument parsing but before the command
-// action — that's enough for command-action `console.log` calls. However,
-// any code that runs at *import* time inside a command file would still
-// see quiet=false. Doing this raw scan up front guarantees module-load
-// console output is also silenced when the caller asked for it.
-if (process.argv.includes('--quiet') || process.argv.includes('-q')) {
+// Belt-and-suspenders: also flip quiet mode based on a raw scan of argv,
+// so any code that runs between Commander's option parsing and the
+// `preAction` hook sees the right state. We scan for the long form only;
+// `-q` could legitimately be the value of another option in the future.
+if (process.argv.includes('--quiet')) {
   setQuiet(true);
 }
 

--- a/packages/boxel-cli/src/index.ts
+++ b/packages/boxel-cli/src/index.ts
@@ -16,6 +16,11 @@ const pkg = JSON.parse(
 
 const program = new Command();
 
+// `--quiet` is implemented by intercepting `console.log/info/debug`.
+// New commands: write decorative output (status, confirmations, colored
+// lines) with `console.log` — it's silenced for free under `--quiet`.
+// For programmatic output (`--json` payloads, raw file bytes), use
+// `cliLog.output(...)`. Full guidance: see `lib/cli-log.ts`.
 program
   .name('boxel')
   .description('CLI tools for Boxel workspace management')

--- a/packages/boxel-cli/src/index.ts
+++ b/packages/boxel-cli/src/index.ts
@@ -8,6 +8,7 @@ import { registerRealmCommand } from './commands/realm/index';
 import { registerFileCommand } from './commands/file/index';
 import { registerRunCommand } from './commands/run-command';
 import { registerSearchCommand } from './commands/search';
+import { setQuiet } from './lib/cli-log';
 
 const pkg = JSON.parse(
   readFileSync(resolve(__dirname, '../package.json'), 'utf-8'),
@@ -18,7 +19,30 @@ const program = new Command();
 program
   .name('boxel')
   .description('CLI tools for Boxel workspace management')
-  .version(pkg.version);
+  .version(pkg.version)
+  .option(
+    '-q, --quiet',
+    'Suppress informational progress logs (info/log/debug). Errors and warnings, plus command result payloads (JSON, file contents), are still emitted. Use this when invoking the CLI from automation (e.g. the software factory test harness) to keep stdout focused on the result.',
+  )
+  // Toggle quiet mode as soon as the global option is parsed, so that any
+  // module-level setup happening inside command actions sees the right
+  // state. Commander invokes this hook before any subcommand action.
+  .hook('preAction', (thisCommand) => {
+    let opts = thisCommand.optsWithGlobals?.() ?? thisCommand.opts();
+    if (opts.quiet) {
+      setQuiet(true);
+    }
+  });
+
+// Pre-parse: also flip quiet mode based on a raw scan of argv. Commander's
+// `preAction` hook runs after argument parsing but before the command
+// action — that's enough for command-action `console.log` calls. However,
+// any code that runs at *import* time inside a command file would still
+// see quiet=false. Doing this raw scan up front guarantees module-load
+// console output is also silenced when the caller asked for it.
+if (process.argv.includes('--quiet') || process.argv.includes('-q')) {
+  setQuiet(true);
+}
 
 program
   .command('profile')

--- a/packages/boxel-cli/src/lib/cli-log.ts
+++ b/packages/boxel-cli/src/lib/cli-log.ts
@@ -1,0 +1,111 @@
+/**
+ * Centralized logger for the boxel CLI.
+ *
+ * Quiet mode is the mechanism that the software factory (and any other
+ * automated caller) uses to silence the chatty per-step progress lines
+ * commands emit (e.g. "Starting sync between …", "Downloaded: …",
+ * "Sync completed"). When `--quiet` is supplied as a global CLI flag,
+ * `setQuiet(true)` is called from `src/index.ts` BEFORE Commander invokes
+ * any action, and we install a `console.log`/`console.info`/`console.debug`
+ * interceptor that no-ops while quiet.
+ *
+ * Why intercept `console.*` rather than require commands to migrate to
+ * a custom API? The issue explicitly asks for a solution "that requires
+ * very little overhead for new commands … so that it is very simple or
+ * automatic in terms of log silencing." Intercepting console means a new
+ * command author can keep writing `console.log("Doing X…")` and it's
+ * silenced for free under `--quiet`. The only thing they must remember is
+ * that command **result payloads** (JSON sent to stdout for SF to parse,
+ * file contents printed for `read`, etc.) must be emitted via
+ * `cliLog.output()`, which writes to stdout regardless of quiet.
+ *
+ * Stderr (`console.error`, `console.warn`) is never silenced — errors and
+ * warnings always surface.
+ */
+
+let quiet = false;
+
+/**
+ * Original references to the console methods we intercept. We keep them
+ * here so `cliLog.info()` (which is called by code that has explicitly
+ * routed itself through this module) can still write its message even
+ * when other console.log calls are silenced.
+ */
+const originalConsoleLog = console.log.bind(console);
+const originalConsoleInfo = console.info.bind(console);
+const originalConsoleDebug = console.debug.bind(console);
+
+/**
+ * Toggle quiet mode. When true, `console.log` / `console.info` /
+ * `console.debug` are replaced with no-ops for the lifetime of the
+ * process. `console.warn` and `console.error` are untouched.
+ *
+ * Idempotent: calling with the same value is a no-op.
+ */
+export function setQuiet(value: boolean): void {
+  if (value === quiet) return;
+  quiet = value;
+  if (quiet) {
+    const noop = () => {
+      /* intentionally empty: silence info/log/debug under --quiet */
+    };
+    console.log = noop;
+    console.info = noop;
+    console.debug = noop;
+  } else {
+    console.log = originalConsoleLog;
+    console.info = originalConsoleInfo;
+    console.debug = originalConsoleDebug;
+  }
+}
+
+export function isQuiet(): boolean {
+  return quiet;
+}
+
+export const cliLog = {
+  /**
+   * Informational progress message. Silenced under `--quiet`. Goes to
+   * stderr (not stdout) so that it never contaminates stdout-payload
+   * commands even when they're inadvertently mixed in.
+   */
+  info(...args: unknown[]): void {
+    if (quiet) return;
+    process.stderr.write(args.map(stringifyArg).join(' ') + '\n');
+  },
+
+  /**
+   * Warning. Always written (even under quiet) — warnings should reach
+   * the operator. Goes to stderr.
+   */
+  warn(...args: unknown[]): void {
+    process.stderr.write(args.map(stringifyArg).join(' ') + '\n');
+  },
+
+  /**
+   * Error. Always written (even under quiet). Goes to stderr.
+   */
+  error(...args: unknown[]): void {
+    process.stderr.write(args.map(stringifyArg).join(' ') + '\n');
+  },
+
+  /**
+   * Command result payload. Always written, even under quiet — this is
+   * what callers (humans piping to a file, software-factory parsing the
+   * tool output) actually want. Use this for JSON results, file
+   * contents, listings, etc. Goes to stdout.
+   */
+  output(...args: unknown[]): void {
+    process.stdout.write(args.map(stringifyArg).join(' ') + '\n');
+  },
+};
+
+function stringifyArg(arg: unknown): string {
+  if (typeof arg === 'string') return arg;
+  if (arg instanceof Error) return arg.stack ?? arg.message;
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+}

--- a/packages/boxel-cli/src/lib/cli-log.ts
+++ b/packages/boxel-cli/src/lib/cli-log.ts
@@ -1,26 +1,37 @@
 /**
  * Centralized logger for the boxel CLI.
  *
- * Quiet mode is the mechanism that the software factory (and any other
- * automated caller) uses to silence the chatty per-step progress lines
- * commands emit (e.g. "Starting sync between …", "Downloaded: …",
- * "Sync completed"). When `--quiet` is supplied as a global CLI flag,
- * `setQuiet(true)` is called from `src/index.ts` BEFORE Commander invokes
- * any action, and we install a `console.log`/`console.info`/`console.debug`
- * interceptor that no-ops while quiet.
+ * # Guidance for command authors
  *
- * Why intercept `console.*` rather than require commands to migrate to
- * a custom API? The issue explicitly asks for a solution "that requires
- * very little overhead for new commands … so that it is very simple or
- * automatic in terms of log silencing." Intercepting console means a new
- * command author can keep writing `console.log("Doing X…")` and it's
- * silenced for free under `--quiet`. The only thing they must remember is
- * that command **result payloads** (JSON sent to stdout for SF to parse,
- * file contents printed for `read`, etc.) must be emitted via
- * `cliLog.output()`, which writes to stdout regardless of quiet.
+ * Pick where output goes by asking: **does anything ever parse this
+ * line programmatically (`--json` consumer, shell pipeline, the
+ * software factory tool executor)?**
  *
- * Stderr (`console.error`, `console.warn`) is never silenced — errors and
- * warnings always surface.
+ * - **No → `console.log` / `console.info` / `console.debug`.** This is
+ *   the default for interactive/decorative output: progress messages,
+ *   colored confirmations ("Fixed: foo.gts"), summaries, anything you'd
+ *   write with ANSI escapes from `lib/colors`. Under `--quiet` these are
+ *   intercepted and silenced — a fresh command author doesn't need to
+ *   know quiet mode exists.
+ * - **Yes → `cliLog.output(...)`.** This is for raw payloads a caller
+ *   parses: the `--json` branch (`cliLog.output(JSON.stringify(result, null, 2))`),
+ *   raw file content from `read`/`read-transpiled`, and any other
+ *   stdout-as-contract output. `cliLog.output` writes to stdout
+ *   regardless of `--quiet`.
+ * - **Errors / warnings → `console.error` / `console.warn`.** Never
+ *   silenced; goes to stderr.
+ *
+ * Quick heuristic: if the string you're about to print contains
+ * `FG_GREEN`/`DIM`/`RESET`/etc., it's decorative — use `console.log`.
+ * If it's `JSON.stringify(...)` or raw bytes, use `cliLog.output`.
+ *
+ * # How it works
+ *
+ * `--quiet` is a global flag in `src/index.ts`. When set, `setQuiet(true)`
+ * replaces `console.log`/`info`/`debug` with no-ops; `cliLog.output`
+ * writes directly to `process.stdout` and bypasses the interceptor.
+ * Software factory's tool executor passes `--quiet` by default so chatty
+ * progress lines don't pollute CI logs (see `factory-tool-executor.ts`).
  */
 
 let quiet = false;
@@ -89,10 +100,21 @@ export const cliLog = {
   },
 
   /**
-   * Command result payload. Always written, even under quiet — this is
-   * what callers (humans piping to a file, software-factory parsing the
-   * tool output) actually want. Use this for JSON results, file
-   * contents, listings, etc. Goes to stdout.
+   * Programmatic command output — the "result payload" a caller parses.
+   * Writes to stdout and is **never** silenced by `--quiet`.
+   *
+   * Use this **only** for output where stdout is the contract:
+   *   - `--json` branches: `cliLog.output(JSON.stringify(result, null, 2))`
+   *   - raw file content: `read` / `read-transpiled` print bytes via
+   *     `cliLog.output(result.content ?? '')`
+   *   - any other stdout-as-API output a script or the software factory
+   *     pipes/parses
+   *
+   * Do **not** use this for human-facing decorative lines (colored
+   * confirmations, status, summaries, progress). Those go to
+   * `console.log` so the `--quiet` interceptor can silence them.
+   * If you're tempted to wrap the string in ANSI escapes from
+   * `lib/colors`, you want `console.log`, not `cliLog.output`.
    */
   output(...args: unknown[]): void {
     process.stdout.write(args.map(stringifyArg).join(' ') + '\n');

--- a/packages/boxel-cli/src/lib/cli-log.ts
+++ b/packages/boxel-cli/src/lib/cli-log.ts
@@ -26,10 +26,9 @@
 let quiet = false;
 
 /**
- * Original references to the console methods we intercept. We keep them
- * here so `cliLog.info()` (which is called by code that has explicitly
- * routed itself through this module) can still write its message even
- * when other console.log calls are silenced.
+ * Original references to the console methods we intercept. Captured at
+ * module load so `setQuiet(false)` can put them back if quiet mode is
+ * toggled off (the unit tests rely on this).
  */
 const originalConsoleLog = console.log.bind(console);
 const originalConsoleInfo = console.info.bind(console);

--- a/packages/boxel-cli/tests/lib/cli-log.test.ts
+++ b/packages/boxel-cli/tests/lib/cli-log.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cliLog, isQuiet, setQuiet } from '../../src/lib/cli-log';
+
+describe('cli-log', () => {
+  // Use `any` for spy types to avoid friction with vitest's overloaded
+  // signatures for write() and the various console.* methods.
+  let stdoutSpy: any;
+  let stderrSpy: any;
+  let consoleLogSpy: any;
+  let consoleInfoSpy: any;
+  let consoleDebugSpy: any;
+  let consoleWarnSpy: any;
+  let consoleErrorSpy: any;
+
+  beforeEach(() => {
+    stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    setQuiet(false);
+    vi.restoreAllMocks();
+  });
+
+  describe('cliLog.output', () => {
+    it('writes to stdout regardless of quiet state', () => {
+      cliLog.output('hello');
+      expect(stdoutSpy).toHaveBeenCalledWith('hello\n');
+
+      stdoutSpy.mockClear();
+      setQuiet(true);
+      cliLog.output('still here');
+      expect(stdoutSpy).toHaveBeenCalledWith('still here\n');
+    });
+
+    it('serializes objects as JSON', () => {
+      cliLog.output({ status: 'ok' });
+      expect(stdoutSpy).toHaveBeenCalledWith('{"status":"ok"}\n');
+    });
+  });
+
+  describe('cliLog.info', () => {
+    it('writes to stderr when not quiet', () => {
+      cliLog.info('progress message');
+      expect(stderrSpy).toHaveBeenCalledWith('progress message\n');
+      expect(stdoutSpy).not.toHaveBeenCalled();
+    });
+
+    it('is silenced when quiet', () => {
+      setQuiet(true);
+      cliLog.info('progress message');
+      expect(stderrSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cliLog.warn / cliLog.error', () => {
+    it('always writes to stderr (warn) even when quiet', () => {
+      setQuiet(true);
+      cliLog.warn('something funny');
+      expect(stderrSpy).toHaveBeenCalledWith('something funny\n');
+    });
+
+    it('always writes to stderr (error) even when quiet', () => {
+      setQuiet(true);
+      cliLog.error('boom');
+      expect(stderrSpy).toHaveBeenCalledWith('boom\n');
+    });
+  });
+
+  describe('console interception under quiet mode', () => {
+    it('replaces console.log/info/debug with no-ops when quiet=true', () => {
+      // Restore console.* so we can observe whether the replacements stick.
+      consoleLogSpy.mockRestore();
+      consoleInfoSpy.mockRestore();
+      consoleDebugSpy.mockRestore();
+
+      // Fresh spies on stdout so we can see if any writes leak through.
+      stdoutSpy.mockClear();
+
+      setQuiet(true);
+      console.log('arbitrary message from a command file');
+      console.info('arbitrary info');
+      console.debug('arbitrary debug');
+
+      // Under quiet, the interceptor replaces console.log/info/debug with
+      // no-ops, so nothing should reach stdout.
+      expect(stdoutSpy).not.toHaveBeenCalled();
+    });
+
+    it('does NOT silence console.warn or console.error when quiet=true', () => {
+      // Re-spy on console.warn / console.error so we can observe whether
+      // setQuiet(true) replaced them (it must not).
+      consoleWarnSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      setQuiet(true);
+      console.warn('legit warning');
+      console.error('legit error');
+
+      // The spy receives the call iff console.warn/error were not
+      // replaced by no-ops (which is exactly what we want: setQuiet only
+      // intercepts log/info/debug).
+      expect(warnSpy).toHaveBeenCalledWith('legit warning');
+      expect(errorSpy).toHaveBeenCalledWith('legit error');
+    });
+
+    it('restores original console functions when quiet=false again', () => {
+      consoleLogSpy.mockRestore();
+
+      // First, in quiet mode console.log is a no-op
+      setQuiet(true);
+      // After setQuiet(true) the underlying console.log reference has
+      // been replaced with our no-op, so installing a NEW spy here would
+      // observe calls into the no-op replacement, not the original.
+      // Instead, exit quiet mode and then verify console.log functions
+      // again by spying on it post-restoration.
+      setQuiet(false);
+
+      const restoredSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      console.log('back');
+      expect(restoredSpy).toHaveBeenCalledWith('back');
+    });
+  });
+
+  describe('isQuiet', () => {
+    it('reflects current quiet state', () => {
+      expect(isQuiet()).toBe(false);
+      setQuiet(true);
+      expect(isQuiet()).toBe(true);
+      setQuiet(false);
+      expect(isQuiet()).toBe(false);
+    });
+  });
+});

--- a/packages/boxel-cli/tests/smoke.test.ts
+++ b/packages/boxel-cli/tests/smoke.test.ts
@@ -29,79 +29,76 @@ describe('boxel-cli', () => {
     expect(output).toMatch(/-q, --quiet/);
   });
 
-  it('silences info-level logs but keeps errors when --quiet is passed', () => {
-    // Run a command that's guaranteed to fail at the "no active profile"
-    // step so we don't need a realm server. Without --quiet, the realm
-    // sync command would normally log progress lines to stdout. With
-    // --quiet, info logs are silenced; errors still print to stderr.
-    //
-    // This is the load-bearing test for the SF integration path:
-    // boxel-cli is launched with `--quiet` from the factory tool
-    // executor, and we want to confirm that:
-    //   1. info/log lines are stripped from stdout
-    //   2. error lines (and the non-zero exit code) are preserved
+  it('silences chatty console.log output in a real command path under --quiet', () => {
+    // End-to-end: run a command that, on success, emits a `console.log`
+    // line ("✓ Profile created: …" — see profile.ts). With `--quiet`
+    // that line must be silenced, and the command's side-effect (the
+    // profile.json file) must still happen. This proves the interceptor
+    // is wired through the full CLI startup path, not just the unit
+    // tests in cli-log.test.ts.
     let tmpHome = fs.mkdtempSync(join(os.tmpdir(), 'boxel-cli-quiet-'));
-    let tmpLocal = fs.mkdtempSync(join(os.tmpdir(), 'boxel-quiet-local-'));
     try {
-      let stdout = '';
-      let stderr = '';
-      let exitCode = 0;
-      try {
-        execFileSync(
-          process.execPath,
-          [
-            cliEntry,
-            '--quiet',
-            'realm',
-            'sync',
-            tmpLocal,
-            // A guaranteed-bad realm URL — exercise is the quiet path,
-            // not the sync path; we only care about what reaches stdout.
-            'http://127.0.0.1:1/nope/',
-          ],
-          {
-            encoding: 'utf8',
-            env: {
-              ...process.env,
-              HOME: tmpHome,
-              // Strip BOXEL_* so a developer's shell doesn't perturb
-              // the result.
-              ...Object.fromEntries(
-                Object.entries(process.env)
-                  .filter(([k]) => k.startsWith('BOXEL_'))
-                  .map(([k]) => [k, '']),
+      let stdout = execFileSync(
+        process.execPath,
+        [cliEntry, '--quiet', 'profile', 'add', '-u', '@alice:stack.cards'],
+        {
+          encoding: 'utf8',
+          env: {
+            // Strip BOXEL_* from inherited env so a developer's shell
+            // can't perturb the result.
+            ...Object.fromEntries(
+              Object.entries(process.env).filter(
+                ([k]) => !k.startsWith('BOXEL_'),
               ),
-            },
-            stdio: ['ignore', 'pipe', 'pipe'],
+            ),
+            HOME: tmpHome,
+            BOXEL_PASSWORD: 'hunter2',
           },
-        );
-      } catch (err) {
-        // Non-zero exit is expected here — the command can't authenticate.
-        let e = err as { status?: number; stdout?: string; stderr?: string };
-        exitCode = e.status ?? 0;
-        stdout = e.stdout ?? '';
-        stderr = e.stderr ?? '';
-      }
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      );
 
-      // The "Starting sync between …" / "Sync completed" / "Found N
-      // local files" progress lines are exactly the kind of chatty
-      // output the issue wants suppressed. Even though the command
-      // fails before it gets that far in this test, verify that NO
-      // info-style line ("Starting", "Found", "Pulling", "Pushing",
-      // "Sync completed", "Checkpoint created") leaked to stdout.
-      expect(exitCode).not.toBe(0);
-      expect(stdout).not.toMatch(/Starting sync/);
-      expect(stdout).not.toMatch(/Sync completed/);
-      expect(stdout).not.toMatch(/Checkpoint created/);
-      expect(stdout).not.toMatch(/Found \d+ local files/);
+      // The success message ("✓ Profile created: …") goes through
+      // console.log; under --quiet the interceptor must swallow it.
+      expect(stdout).toBe('');
 
-      // Errors should still surface (in stderr or as a structured
-      // result) so that the operator/automation can react.
-      let combined = stdout + stderr;
-      expect(combined).not.toBe('');
+      // Side-effect must still have happened.
+      expect(fs.existsSync(join(tmpHome, '.boxel-cli', 'profiles.json'))).toBe(
+        true,
+      );
     } finally {
       fs.rmSync(tmpHome, { recursive: true, force: true });
-      fs.rmSync(tmpLocal, { recursive: true, force: true });
+    }
+  });
+
+  it('emits the same console.log output normally without --quiet', () => {
+    // Negative control for the test above: without --quiet, the same
+    // command emits the success line to stdout. Without this, the
+    // --quiet test could trivially pass against a build that printed
+    // nothing in either mode.
+    let tmpHome = fs.mkdtempSync(join(os.tmpdir(), 'boxel-cli-noisy-'));
+    try {
+      let stdout = execFileSync(
+        process.execPath,
+        [cliEntry, 'profile', 'add', '-u', '@alice:stack.cards'],
+        {
+          encoding: 'utf8',
+          env: {
+            ...Object.fromEntries(
+              Object.entries(process.env).filter(
+                ([k]) => !k.startsWith('BOXEL_'),
+              ),
+            ),
+            HOME: tmpHome,
+            BOXEL_PASSWORD: 'hunter2',
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      );
+
+      expect(stdout).toMatch(/Profile created/);
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
     }
   });
 });

--- a/packages/boxel-cli/tests/smoke.test.ts
+++ b/packages/boxel-cli/tests/smoke.test.ts
@@ -21,6 +21,89 @@ describe('boxel-cli', () => {
     });
     expect(output.trim()).toMatch(/^\d+\.\d+\.\d+$/);
   });
+
+  it('exposes a global --quiet flag in --help', () => {
+    const output = execFileSync(process.execPath, [cliEntry, '--help'], {
+      encoding: 'utf8',
+    });
+    expect(output).toMatch(/-q, --quiet/);
+  });
+
+  it('silences info-level logs but keeps errors when --quiet is passed', () => {
+    // Run a command that's guaranteed to fail at the "no active profile"
+    // step so we don't need a realm server. Without --quiet, the realm
+    // sync command would normally log progress lines to stdout. With
+    // --quiet, info logs are silenced; errors still print to stderr.
+    //
+    // This is the load-bearing test for the SF integration path:
+    // boxel-cli is launched with `--quiet` from the factory tool
+    // executor, and we want to confirm that:
+    //   1. info/log lines are stripped from stdout
+    //   2. error lines (and the non-zero exit code) are preserved
+    let tmpHome = fs.mkdtempSync(join(os.tmpdir(), 'boxel-cli-quiet-'));
+    let tmpLocal = fs.mkdtempSync(join(os.tmpdir(), 'boxel-quiet-local-'));
+    try {
+      let stdout = '';
+      let stderr = '';
+      let exitCode = 0;
+      try {
+        execFileSync(
+          process.execPath,
+          [
+            cliEntry,
+            '--quiet',
+            'realm',
+            'sync',
+            tmpLocal,
+            // A guaranteed-bad realm URL — exercise is the quiet path,
+            // not the sync path; we only care about what reaches stdout.
+            'http://127.0.0.1:1/nope/',
+          ],
+          {
+            encoding: 'utf8',
+            env: {
+              ...process.env,
+              HOME: tmpHome,
+              // Strip BOXEL_* so a developer's shell doesn't perturb
+              // the result.
+              ...Object.fromEntries(
+                Object.entries(process.env)
+                  .filter(([k]) => k.startsWith('BOXEL_'))
+                  .map(([k]) => [k, '']),
+              ),
+            },
+            stdio: ['ignore', 'pipe', 'pipe'],
+          },
+        );
+      } catch (err) {
+        // Non-zero exit is expected here — the command can't authenticate.
+        let e = err as { status?: number; stdout?: string; stderr?: string };
+        exitCode = e.status ?? 0;
+        stdout = e.stdout ?? '';
+        stderr = e.stderr ?? '';
+      }
+
+      // The "Starting sync between …" / "Sync completed" / "Found N
+      // local files" progress lines are exactly the kind of chatty
+      // output the issue wants suppressed. Even though the command
+      // fails before it gets that far in this test, verify that NO
+      // info-style line ("Starting", "Found", "Pulling", "Pushing",
+      // "Sync completed", "Checkpoint created") leaked to stdout.
+      expect(exitCode).not.toBe(0);
+      expect(stdout).not.toMatch(/Starting sync/);
+      expect(stdout).not.toMatch(/Sync completed/);
+      expect(stdout).not.toMatch(/Checkpoint created/);
+      expect(stdout).not.toMatch(/Found \d+ local files/);
+
+      // Errors should still surface (in stderr or as a structured
+      // result) so that the operator/automation can react.
+      let combined = stdout + stderr;
+      expect(combined).not.toBe('');
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+      fs.rmSync(tmpLocal, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('boxel profile add (non-interactive)', () => {

--- a/packages/software-factory/src/factory-issue-loop-wiring.ts
+++ b/packages/software-factory/src/factory-issue-loop-wiring.ts
@@ -137,6 +137,7 @@ export async function runFactoryIssueLoop(
     packageRoot: PACKAGE_ROOT,
     targetRealmUrl,
     client,
+    debug: config.debug,
   });
 
   let darkfactoryModuleBase = new URL('software-factory/', realmServerUrl).href;

--- a/packages/software-factory/src/factory-tool-executor.ts
+++ b/packages/software-factory/src/factory-tool-executor.ts
@@ -395,7 +395,18 @@ export class ToolExecutor {
 
     let cliArgs = buildBoxelCliArgs(toolName, subcommand, toolArgs);
 
-    return this.spawnProcess(toolName, 'npx', ['boxel', ...cliArgs], 'text');
+    // Always pass `--quiet` so chatty per-step progress logs from
+    // boxel-cli (e.g. "Starting sync between …", "Downloaded: index.json",
+    // "Sync completed", "Checkpoint created: …") don't surface in the
+    // factory's tool output or in CI logs. Errors, warnings, and the
+    // command's actual result payload (JSON, file content, etc.) are
+    // still emitted — see packages/boxel-cli/src/lib/cli-log.ts.
+    return this.spawnProcess(
+      toolName,
+      'npx',
+      ['boxel', '--quiet', ...cliArgs],
+      'text',
+    );
   }
 
   private async executeRealmApi(

--- a/packages/software-factory/src/factory-tool-executor.ts
+++ b/packages/software-factory/src/factory-tool-executor.ts
@@ -64,6 +64,12 @@ export interface ToolExecutorConfig {
   timeoutMs?: number;
   /** Optional log function for auditability. */
   log?: (entry: ToolExecutionLogEntry) => void;
+  /**
+   * When true, boxel-cli invocations skip the `--quiet` flag so their
+   * normal info/log output surfaces in the factory's tool output. Wired
+   * to the factory's own `--debug` flag (see `factory-issue-loop-wiring`).
+   */
+  debug?: boolean;
 }
 
 export interface ToolExecutionLogEntry {
@@ -394,19 +400,11 @@ export class ToolExecutor {
     }
 
     let cliArgs = buildBoxelCliArgs(toolName, subcommand, toolArgs);
+    let invocation = composeBoxelCliInvocation(cliArgs, {
+      debug: this.config.debug,
+    });
 
-    // Always pass `--quiet` so chatty per-step progress logs from
-    // boxel-cli (e.g. "Starting sync between …", "Downloaded: index.json",
-    // "Sync completed", "Checkpoint created: …") don't surface in the
-    // factory's tool output or in CI logs. Errors, warnings, and the
-    // command's actual result payload (JSON, file content, etc.) are
-    // still emitted — see packages/boxel-cli/src/lib/cli-log.ts.
-    return this.spawnProcess(
-      toolName,
-      'npx',
-      ['boxel', '--quiet', ...cliArgs],
-      'text',
-    );
+    return this.spawnProcess(toolName, 'npx', invocation, 'text');
   }
 
   private async executeRealmApi(
@@ -647,6 +645,27 @@ export class ToolExecutor {
 // ---------------------------------------------------------------------------
 // Helpers: CLI arg building
 // ---------------------------------------------------------------------------
+
+/**
+ * Compose the full `npx boxel ...` argument vector for an `executeBoxelCli`
+ * call. Prepends `--quiet` to silence boxel-cli's chatty per-step progress
+ * logs ("Starting sync …", "Downloaded: …", "Checkpoint created: …") so they
+ * don't surface in the factory's tool output or CI logs. Errors, warnings,
+ * and the command's actual result payload still come through — see
+ * `packages/boxel-cli/src/lib/cli-log.ts`.
+ *
+ * When `debug` is true (factory itself is running with `--debug`), `--quiet`
+ * is omitted so the full boxel-cli logs surface for debugging.
+ */
+export function composeBoxelCliInvocation(
+  cliArgs: string[],
+  options: { debug?: boolean } = {},
+): string[] {
+  if (options.debug) {
+    return ['boxel', ...cliArgs];
+  }
+  return ['boxel', '--quiet', ...cliArgs];
+}
 
 function buildCliArgs(toolArgs: Record<string, unknown>): string[] {
   let args: string[] = [];

--- a/packages/software-factory/tests/factory-tool-executor.test.ts
+++ b/packages/software-factory/tests/factory-tool-executor.test.ts
@@ -7,6 +7,7 @@ import {
   ToolExecutor,
   ToolNotFoundError,
   ToolSafetyError,
+  composeBoxelCliInvocation,
   type ToolExecutionLogEntry,
   type ToolExecutorConfig,
 } from '../src/factory-tool-executor';
@@ -433,6 +434,29 @@ module('factory-tool-executor > ToolResult shape', function () {
 // (BoxelCLIClient/ProfileManager own the fetch pipeline), so the executor no
 // longer wraps calls in an AbortController. The spawn-based timeout for
 // script and boxel-cli tools is covered elsewhere.
+
+// ---------------------------------------------------------------------------
+// composeBoxelCliInvocation
+// ---------------------------------------------------------------------------
+
+module('factory-tool-executor > composeBoxelCliInvocation', function () {
+  test('prepends --quiet by default', function (assert) {
+    let args = composeBoxelCliInvocation(['sync', '.', '--prefer-local']);
+    assert.deepEqual(args, ['boxel', '--quiet', 'sync', '.', '--prefer-local']);
+  });
+
+  test('omits --quiet when debug is true', function (assert) {
+    let args = composeBoxelCliInvocation(['sync', '.', '--prefer-local'], {
+      debug: true,
+    });
+    assert.deepEqual(args, ['boxel', 'sync', '.', '--prefer-local']);
+  });
+
+  test('treats debug:false the same as omitted', function (assert) {
+    let args = composeBoxelCliInvocation(['status', '.'], { debug: false });
+    assert.deepEqual(args, ['boxel', '--quiet', 'status', '.']);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/software-factory/tests/helpers/test-client.ts
+++ b/packages/software-factory/tests/helpers/test-client.ts
@@ -14,6 +14,7 @@ import {
   BoxelCLIClient,
   resetProfileManager,
   setProfileManager,
+  setQuiet,
 } from '@cardstack/boxel-cli/api';
 
 export interface TestClientOptions {
@@ -72,9 +73,17 @@ export function buildTestClient(options: TestClientOptions): {
   );
   setProfileManager(tempConfigDir);
 
+  // BoxelCLIClient.sync/pull/push delegate to the realm command code in
+  // process — same console.log lines a CLI invocation would emit. We're
+  // not parsing argv here, so the global `--quiet` flag never fires;
+  // turn quiet mode on explicitly so SF Playwright tests don't drown CI
+  // logs in "Starting sync …" / "Downloaded: …" / "Sync completed" noise.
+  setQuiet(true);
+
   let client = new BoxelCLIClient();
 
   let cleanup = () => {
+    setQuiet(false);
     resetProfileManager();
     rmSync(tempConfigDir, { recursive: true, force: true });
   };


### PR DESCRIPTION
## Summary

Linear issue: [CS-10967 — clean up logging in software factory tests](https://linear.app/cardstack/issue/CS-10967/clean-up-logging-in-software-factory-tests)

The boxel-cli was emitting chatty per-step progress lines ("Starting sync between …", "Downloaded: index.json", "Sync completed", "Checkpoint created: …") into the software factory's tool output and CI logs ([example noisy run](https://github.com/cardstack/boxel/actions/runs/25086517081/job/73503392833?pr=4565)). This adds a global `--quiet` flag to the CLI and updates the factory's tool executor to pass it on every boxel-cli invocation.

## Design

The issue specifically asked for a solution "that requires very little overhead for new commands … so that it is very simple or automatic in terms of log silencing." The mechanism here is a global console interceptor:

- `packages/boxel-cli/src/lib/cli-log.ts` exposes `setQuiet(true)`, which replaces `console.log`, `console.info`, and `console.debug` with no-ops for the lifetime of the process. `console.warn` and `console.error` are untouched. **New command authors keep writing `console.log("Doing X…")` and it's silenced for free under `--quiet`** — no per-command opt-in, no boilerplate.
- The few commands that emit a real result payload to stdout (`read`, `read-transpiled`, `search`, `run-command`, `list`, `lint`, `delete`, `write`, `realm create`, `cancel-indexing`) now go through `cliLog.output()` so the actual JSON / file content / listing is preserved even under `--quiet`. JSON-emitting commands like `search --json` continue to work for SF parsers.
- `packages/boxel-cli/src/index.ts` registers `-q, --quiet` as a global Commander option. An `argv` pre-scan flips quiet mode before any command-action code runs (so module-level console calls are also silenced); the `preAction` Commander hook is a belt-and-braces backup.
- `packages/software-factory/src/factory-tool-executor.ts`'s `executeBoxelCli` now spawns `npx boxel --quiet <subcommand>` instead of `npx boxel <subcommand>`. Errors, warnings, and command result payloads still flow through cleanly.

### Why not `BOXEL_CLI_QUIET=1`?

Per project convention, CLI flags are preferred over env vars for opt-in behavior. `--quiet` is also more discoverable (`boxel --help` lists it).

### Why default-off rather than CLI-quiet-by-default?

Going default-off keeps interactive UX unchanged for human users — they still see the familiar progress output. Quiet mode kicks in only when an automated caller explicitly opts in. SF is one such caller; any future automation can do the same. This also keeps the noise down on the tests.

### Stderr policy

`cliLog.info` writes to stderr (not stdout) so that even if a caller forgets to silence info, it never contaminates a stdout-payload command. Errors and warnings always reach stderr regardless of quiet state.

## Files changed

- New: `packages/boxel-cli/src/lib/cli-log.ts` — the central logger / interceptor.
- New: `packages/boxel-cli/tests/lib/cli-log.test.ts` — unit tests for the silencing mechanics.
- `packages/boxel-cli/src/index.ts` — `-q, --quiet` global option + pre-parse hook.
- `packages/boxel-cli/src/commands/{read-transpiled,search,run-command}.ts` and `commands/file/{read,write,delete,list,lint}.ts` and `commands/realm/{create,cancel-indexing}.ts` — route stdout payload calls through `cliLog.output()`. Other `console.log` progress calls (sync/push/pull/etc.) remain unchanged and are silenced automatically by the interceptor.
- `packages/software-factory/src/factory-tool-executor.ts` — pass `--quiet` to `npx boxel` in `executeBoxelCli`.
- `packages/boxel-cli/tests/smoke.test.ts` — assert `-q, --quiet` appears in `--help`, plus an end-to-end test that running the built CLI binary with `--quiet realm sync` against a bad URL still exits non-zero and surfaces some output, but never emits the "Starting sync" / "Sync completed" / "Checkpoint created" / "Found N local files" progress lines.

## Test plan

- [x] `pnpm test:unit` in `packages/boxel-cli` — 157 tests pass (incl. 10 new `cli-log` tests + 1 new smoke test).
- [x] `pnpm test:node` in `packages/software-factory` — 458 tests pass.
- [x] `pnpm lint` in `packages/boxel-cli` — clean.
- [x] `pnpm lint:js` + `pnpm lint:format` in `packages/software-factory` — clean. (`pnpm lint:types` has pre-existing failures in `../base/*.gts` unrelated to this change.)
- [x] Software-factory Playwright tests in CI — verifying that the chatty progress lines no longer appear in the `tool.output` capture / CI log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)