### PR TITLE
Hold dynamic SF harness ports across spawn gaps

### DIFF
--- a/packages/software-factory/src/harness/database.ts
+++ b/packages/software-factory/src/harness/database.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_BASE_REALM_PERMISSIONS,
   DEFAULT_MIGRATED_TEMPLATE_DB,
   DEFAULT_SOURCE_REALM_PERMISSIONS,
-  findAvailablePort,
+  findAndHoldAvailablePort,
   logTimed,
   pgAdminConnectionConfig,
   quotePgIdentifier,
@@ -778,10 +778,17 @@ export async function buildCombinedTemplateDatabase({
         username: `additional_realm_${i}`,
       }));
 
-      let wmPort = await findAvailablePort();
+      // Hold the worker-manager port across the gap between allocation and
+      // the actual child bind inside startIsolatedRealmStack — without the
+      // hold, sibling findAvailablePort() calls (for the realm-server,
+      // prerender, etc) can be handed back the same port number by the OS
+      // and the worker-manager later races them and dies with EADDRINUSE.
+      // startIsolatedRealmStack releases the holder right before spawning
+      // the worker-manager child.
+      let wmReservation = await findAndHoldAvailablePort();
       // base + source + each fixture realm
       let progress = startIndexingProgressReporter(
-        wmPort,
+        wmReservation.port,
         2 + realmFixtures.length,
       );
 
@@ -796,10 +803,13 @@ export async function buildCombinedTemplateDatabase({
           migrateDB: !hasMigratedTemplate,
           fullIndexOnStartup: true,
           additionalRealms,
-          workerManagerPort: wmPort,
+          workerManagerPort: wmReservation,
         });
       } catch (error) {
         progress.stop();
+        // startIsolatedRealmStack releases its own holders on failure, but
+        // be defensive in case the throw happened before it took ownership.
+        await wmReservation.release().catch(() => undefined);
         throw error;
       }
 
@@ -875,9 +885,11 @@ export async function buildTemplateDatabase({
         DEFAULT_SOURCE_REALM_PERMISSIONS,
       );
 
-      let wmPort = await findAvailablePort();
+      // See buildCombinedTemplateDatabase above for why this is a holder
+      // reservation rather than a bare findAvailablePort.
+      let wmReservation = await findAndHoldAvailablePort();
       // base + source + test realm
-      let progress = startIndexingProgressReporter(wmPort, 3);
+      let progress = startIndexingProgressReporter(wmReservation.port, 3);
 
       let stack;
       try {
@@ -889,10 +901,11 @@ export async function buildTemplateDatabase({
           context,
           migrateDB: !hasMigratedTemplate,
           fullIndexOnStartup: true,
-          workerManagerPort: wmPort,
+          workerManagerPort: wmReservation,
         });
       } catch (error) {
         progress.stop();
+        await wmReservation.release().catch(() => undefined);
         throw error;
       }
 

--- a/packages/software-factory/src/harness/database.ts
+++ b/packages/software-factory/src/harness/database.ts
@@ -550,9 +550,16 @@ interface IndexingStatus {
 async function queryIndexingStatus(
   workerManagerPort: number,
 ): Promise<IndexingStatus | undefined> {
+  // Bound the fetch so a hung connection (the worker-manager hasn't bound
+  // yet, or is wedged) can't pin `polling = true` in the progress reporter
+  // and freeze it. The reporter retries every 2s, so 1.5s is comfortably
+  // under one polling interval.
+  let abort = new AbortController();
+  let timeout = setTimeout(() => abort.abort(), 1500);
   try {
     let response = await fetch(
       `http://localhost:${workerManagerPort}/_indexing-status`,
+      { signal: abort.signal },
     );
     if (!response.ok) {
       return undefined;
@@ -560,6 +567,8 @@ async function queryIndexingStatus(
     return (await response.json()) as IndexingStatus;
   } catch {
     return undefined;
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/packages/software-factory/src/harness/isolated-realm-stack.ts
+++ b/packages/software-factory/src/harness/isolated-realm-stack.ts
@@ -75,7 +75,12 @@ async function resolvePortReservation(
 ): Promise<ResolvedPortReservation> {
   if (passed == null || passed === 0) {
     let reservation = await findAndHoldAvailablePort();
-    return { port: reservation.port, releaseHolder: reservation.release };
+    // Wrap so a future PortReservation implementation that binds `this`
+    // inside `release()` still gets called with its own receiver.
+    return {
+      port: reservation.port,
+      releaseHolder: () => reservation.release(),
+    };
   }
   if (typeof passed === 'number') {
     // Caller supplied an explicit port number. They are responsible for
@@ -83,7 +88,7 @@ async function resolvePortReservation(
     return { port: passed, releaseHolder: async () => {} };
   }
   // Caller supplied a PortReservation — we own releasing it at spawn time.
-  return { port: passed.port, releaseHolder: passed.release };
+  return { port: passed.port, releaseHolder: () => passed.release() };
 }
 
 async function readIncomingRequestBody(

--- a/packages/software-factory/src/harness/isolated-realm-stack.ts
+++ b/packages/software-factory/src/harness/isolated-realm-stack.ts
@@ -28,7 +28,7 @@ import {
   DEFAULT_PG_PORT,
   DEFAULT_PG_USER,
   DEFAULT_REALM_LOG_LEVELS,
-  findAvailablePort,
+  findAndHoldAvailablePort,
   FIXTURE_SOURCE_REALM_URL_PLACEHOLDER,
   FULL_INDEX_REALM_STARTUP_TIMEOUT_MS,
   INCLUDE_SKILLS,
@@ -51,6 +51,7 @@ import {
   DEFAULT_REALM_STARTUP_TIMEOUT_MS,
   stopManagedProcess,
   type FactorySupportContext,
+  type PortReservation,
   type RunningFactoryStack,
   type SpawnedProcess,
   type StartedCompatRealmProxy,
@@ -58,6 +59,32 @@ import {
 import { startHarnessPrerenderServer } from './support-services';
 
 const { copySync, ensureDirSync } = fsExtra;
+
+type ResolvedPortReservation = {
+  port: number;
+  /**
+   * Closes any holder socket we (or the caller) bound to keep this port
+   * exclusive. Call this immediately before spawning the child that will
+   * bind the port. Idempotent — calling it twice is a no-op.
+   */
+  releaseHolder(): Promise<void>;
+};
+
+async function resolvePortReservation(
+  passed: number | PortReservation | undefined,
+): Promise<ResolvedPortReservation> {
+  if (passed == null || passed === 0) {
+    let reservation = await findAndHoldAvailablePort();
+    return { port: reservation.port, releaseHolder: reservation.release };
+  }
+  if (typeof passed === 'number') {
+    // Caller supplied an explicit port number. They are responsible for
+    // any pre-binding it may need; we don't hold it ourselves.
+    return { port: passed, releaseHolder: async () => {} };
+  }
+  // Caller supplied a PortReservation — we own releasing it at spawn time.
+  return { port: passed.port, releaseHolder: passed.release };
+}
 
 async function readIncomingRequestBody(
   req: IncomingMessage,
@@ -303,11 +330,14 @@ export async function startIsolatedRealmStack({
   additionalRealms?: AdditionalRealm[];
   /** When provided, the worker-manager will listen on this port instead of
    *  picking one dynamically. This lets callers know the port upfront (e.g.
-   *  for progress monitoring via /_indexing-status). */
-  workerManagerPort?: number;
+   *  for progress monitoring via /_indexing-status). Pass a `PortReservation`
+   *  (from `findAndHoldAvailablePort()`) when the caller pre-allocated the
+   *  port so we can release the holder socket at the exact moment the
+   *  worker-manager child is about to bind. */
+  workerManagerPort?: number | PortReservation;
   /** When provided, the realm-server will listen on this port instead of
-   *  picking one dynamically. */
-  realmServerPort?: number;
+   *  picking one dynamically. Same `PortReservation` handoff as above. */
+  realmServerPort?: number | PortReservation;
   /** When provided, reuse this existing prerender server URL instead of
    *  starting a new one. The Playwright harness keeps prerender alive for
    *  the lifetime of a testWorker and passes its URL here. */
@@ -326,322 +356,367 @@ export async function startIsolatedRealmStack({
   let testRealmDir = join(rootDir, 'test');
   let workerManagerMetadataFile = join(rootDir, 'worker-manager.runtime.json');
   let realmServerMetadataFile = join(rootDir, 'realm-server.runtime.json');
-  let actualWorkerManagerPort =
-    explicitWorkerManagerPort ?? (await findAvailablePort());
-  let actualRealmServerPort =
-    explicitRealmServerPort && explicitRealmServerPort !== 0
-      ? explicitRealmServerPort
-      : await findAvailablePort();
-  let actualRealmServerURL = withPort(realmServerURL, actualRealmServerPort);
-  let actualRealmPath = realmRelativePath(realmURL, realmServerURL);
-  let actualRealmURL = realmURLWithinServer(
-    actualRealmServerURL,
-    actualRealmPath,
+
+  // Hold the worker-manager and realm-server ports across the (multi-second)
+  // gap between allocation and actual child bind. Without the hold, sibling
+  // findAvailablePort() calls inside this same process — for the prerender
+  // server, host serve, etc — can be handed back the same port number by
+  // the OS port-0 allocator, and the child process eventually races us and
+  // dies with EADDRINUSE.
+  let workerManagerPortInfo = await resolvePortReservation(
+    explicitWorkerManagerPort,
   );
-  let legacyRealmServerURL = new URL('http://localhost:4205/');
-  let legacyRealmURL = new URL('test/', legacyRealmServerURL);
-  let publicBaseRealmURL = baseRealmURLFor(realmServerURL);
-  let actualBaseRealmURL = baseRealmURLFor(actualRealmServerURL);
-  let sourceRealmURL = sourceRealmURLFor(realmServerURL);
-  let actualSourceRealmURL = sourceRealmURLFor(actualRealmServerURL);
-  let legacySourceRealmURL = sourceRealmURLFor(legacyRealmServerURL);
-  let skillsRealmURL = skillsRealmURLFor(realmServerURL);
-  let actualSkillsRealmURL = skillsRealmURLFor(actualRealmServerURL);
-  let legacySkillsRealmURL = skillsRealmURLFor(legacyRealmServerURL);
-  ensureDirSync(testRealmDir);
-  copyRealmFixture(realmDir, testRealmDir, sourceRealmURL);
-  realmLog.debug(
-    `startIsolatedRealmStack: copied fixture ${realmDir} -> ${testRealmDir}`,
-  );
-
-  // Copy and resolve additional realm fixtures.
-  let resolvedAdditionalRealms: {
-    realmDir: string;
-    localDir: string;
-    realmURL: URL;
-    actualRealmURL: URL;
-    username: string;
-  }[] = [];
-  for (let i = 0; i < (additionalRealms ?? []).length; i++) {
-    let additional = additionalRealms![i];
-    let additionalLocalDir = join(rootDir, `additional-${i}`);
-    let additionalPath = realmRelativePath(additional.realmURL, realmServerURL);
-    let additionalActualURL = realmURLWithinServer(
-      actualRealmServerURL,
-      additionalPath,
-    );
-    let username = additional.username ?? `additional_realm_${i}`;
-    ensureDirSync(additionalLocalDir);
-    copyRealmFixture(additional.realmDir, additionalLocalDir, sourceRealmURL);
-    realmLog.debug(
-      `startIsolatedRealmStack: copied additional fixture ${additional.realmDir} -> ${additionalLocalDir}`,
-    );
-    resolvedAdditionalRealms.push({
-      realmDir: additional.realmDir,
-      localDir: additionalLocalDir,
-      realmURL: additional.realmURL,
-      actualRealmURL: additionalActualURL,
-      username,
-    });
-  }
-  let compatProxy = await startCompatRealmProxy({
-    listenPort: Number(realmServerURL.port),
-  });
-  // The software-factory Playwright harness can keep prerender alive for the
-  // lifetime of a Playwright testWorker even though the realm stack itself is
-  // recreated per test. When provided, reuse that long-lived prerender URL so
-  // we only restart realm-server and worker-manager here.
-  let prerender = explicitPrerenderURL
-    ? undefined
-    : await startHarnessPrerenderServer({
-        boxelHostURL: realmServerURL.href.replace(/\/$/, ''),
-      });
-  let prerenderURL = explicitPrerenderURL ?? prerender?.url;
-  if (!prerenderURL) {
-    throw new Error(
-      'Unable to determine prerender URL for isolated realm stack',
-    );
-  }
-
-  let env = {
-    ...process.env,
-    PGHOST: DEFAULT_PG_HOST,
-    PGPORT: DEFAULT_PG_PORT,
-    PGUSER: DEFAULT_PG_USER,
-    PG_POOL_MAX: String(DEFAULT_PG_POOL_MAX),
-    PGDATABASE: databaseName,
-    NODE_NO_WARNINGS: '1',
-    NODE_ENV: 'test',
-    REALM_SERVER_SECRET_SEED,
-    REALM_SECRET_SEED,
-    GRAFANA_SECRET,
-    HOST_URL: context.hostURL,
-    MATRIX_URL: context.matrixURL,
-    MATRIX_SERVER_NAME: new URL(context.matrixURL).hostname,
-    MATRIX_REGISTRATION_SHARED_SECRET: context.matrixRegistrationSecret,
-    REALM_SERVER_MATRIX_USERNAME: DEFAULT_MATRIX_SERVER_USERNAME,
-    REALM_SERVER_FULL_INDEX_ON_STARTUP: String(fullIndexOnStartup),
-    // When restoring from a template snapshot, the modules cache has already
-    // been rewritten to the runtime port by `rewriteClonedRealmServerUrls`.
-    // Tell the realm-server to keep that cache instead of wiping it on
-    // startup, so the first lookupDefinition for a fixture-side module hits
-    // the cache instead of paying a cold prerender (~45s for darkfactory.gts).
-    REALM_SERVER_SKIP_MODULES_CACHE_CLEAR_ON_STARTUP: fullIndexOnStartup
-      ? 'false'
-      : 'true',
-    LOW_CREDIT_THRESHOLD: '2000',
-    LOG_LEVELS: DEFAULT_REALM_LOG_LEVELS,
-    BOXEL_TRUST_FORWARDED_URL: 'true',
-    PUBLISHED_REALM_BOXEL_SPACE_DOMAIN: `localhost:${compatProxy.listenPort}`,
-    PUBLISHED_REALM_BOXEL_SITE_DOMAIN: `localhost:${compatProxy.listenPort}`,
-    SOFTWARE_FACTORY_WORKER_MANAGER_METADATA_FILE: workerManagerMetadataFile,
-    SOFTWARE_FACTORY_REALM_SERVER_METADATA_FILE: realmServerMetadataFile,
-  };
-
-  let workerArgs = [
-    '--transpileOnly',
-    'worker-manager',
-    `--port=${actualWorkerManagerPort}`,
-    `--matrixURL=${context.matrixURL}`,
-    `--prerendererUrl=${prerenderURL}`,
-    `--fromUrl=${realmURL.href}`,
-    `--toUrl=${actualRealmURL.href}`,
-    `--fromUrl=${publicBaseRealmURL.href}`,
-    `--toUrl=${actualBaseRealmURL.href}`,
-    '--fromUrl=https://cardstack.com/base/',
-    `--toUrl=${publicBaseRealmURL.href}`,
-    `--fromUrl=${sourceRealmURL.href}`,
-    `--toUrl=${actualSourceRealmURL.href}`,
-  ];
-  if (INCLUDE_SKILLS) {
-    workerArgs.push(
-      `--fromUrl=${skillsRealmURL.href}`,
-      `--toUrl=${actualSkillsRealmURL.href}`,
-    );
-  }
-  workerArgs.push(
-    `--fromUrl=${legacyRealmURL.href}`,
-    `--toUrl=${actualRealmURL.href}`,
-    `--fromUrl=${legacySourceRealmURL.href}`,
-    `--toUrl=${actualSourceRealmURL.href}`,
-  );
-  if (INCLUDE_SKILLS) {
-    workerArgs.push(
-      `--fromUrl=${legacySkillsRealmURL.href}`,
-      `--toUrl=${actualSkillsRealmURL.href}`,
-    );
-  }
-  for (let additional of resolvedAdditionalRealms) {
-    workerArgs.push(
-      `--fromUrl=${additional.realmURL.href}`,
-      `--toUrl=${additional.actualRealmURL.href}`,
-    );
-  }
-  if (migrateDB) {
-    workerArgs.splice(5, 0, '--migrateDB');
-  }
-
-  let workerManager = spawn('ts-node', workerArgs, {
-    cwd: realmServerDir,
-    env,
-    stdio: managedProcessStdio,
-  }) as SpawnedProcess;
-  let getWorkerLogs = captureProcessLogs(workerManager);
-  workerManager.on('exit', (code, signal) => {
-    if (code === 0 || signal === 'SIGTERM' || signal === 'SIGINT') {
-      return;
-    }
-    realmLog.warn(
-      `worker manager exited unexpectedly (code: ${code}, signal: ${signal})\n${getWorkerLogs()}`,
-    );
-  });
-  let workerManagerRuntime = await waitForJsonFile<{
-    pid: number;
-    port: number;
-    url: string;
-  }>(workerManagerMetadataFile, getWorkerLogs, {
-    label: 'worker manager',
-    process: workerManager,
-  });
-
-  let serverArgs = [
-    '--transpileOnly',
-    'main',
-    `--port=${actualRealmServerPort}`,
-    `--serverURL=${realmServerURL.href}`,
-    `--matrixURL=${context.matrixURL}`,
-    `--realmsRootPath=${rootDir}`,
-    `--workerManagerUrl=${workerManagerRuntime.url}`,
-    `--prerendererUrl=${prerenderURL}`,
-    '--username=base_realm',
-    `--path=${baseRealmDir}`,
-    `--fromUrl=${publicBaseRealmURL.href}`,
-    `--toUrl=${actualBaseRealmURL.href}`,
-    '--username=software_factory_realm',
-    `--path=${filteredSourceRealmDir}`,
-    `--fromUrl=${sourceRealmURL.href}`,
-    `--toUrl=${actualSourceRealmURL.href}`,
-    '--username=test_realm',
-    `--path=${testRealmDir}`,
-    `--fromUrl=${realmURL.href}`,
-    `--toUrl=${actualRealmURL.href}`,
-  ];
-  for (let additional of resolvedAdditionalRealms) {
-    serverArgs.push(
-      `--username=${additional.username}`,
-      `--path=${additional.localDir}`,
-      `--fromUrl=${additional.realmURL.href}`,
-      `--toUrl=${additional.actualRealmURL.href}`,
-    );
-  }
-  if (INCLUDE_SKILLS) {
-    serverArgs.splice(
-      16,
-      0,
-      '--username=skills_realm',
-      `--path=${skillsRealmDir}`,
-      `--fromUrl=${skillsRealmURL.href}`,
-      `--toUrl=${actualSkillsRealmURL.href}`,
-    );
-  }
-  serverArgs.push(
-    `--fromUrl=${legacyRealmURL.href}`,
-    `--toUrl=${actualRealmURL.href}`,
-    `--fromUrl=${legacySourceRealmURL.href}`,
-    `--toUrl=${actualSourceRealmURL.href}`,
-  );
-  if (INCLUDE_SKILLS) {
-    serverArgs.push(
-      `--fromUrl=${legacySkillsRealmURL.href}`,
-      `--toUrl=${actualSkillsRealmURL.href}`,
-    );
-  }
-  // Map the canonical base realm URL so the realm server's virtual network
-  // can resolve definitions referenced via https://cardstack.com/base/...
-  serverArgs.push(
-    '--fromUrl=https://cardstack.com/base/',
-    `--toUrl=${actualBaseRealmURL.href}`,
-  );
-
-  let realmServer = spawn('ts-node', serverArgs, {
-    cwd: realmServerDir,
-    env,
-    stdio: managedProcessStdio,
-  }) as SpawnedProcess;
-  let getServerLogs = captureProcessLogs(realmServer);
-  realmServer.on('exit', (code, signal) => {
-    if (code === 0 || signal === 'SIGTERM' || signal === 'SIGINT') {
-      return;
-    }
-    realmLog.warn(
-      `realm server exited unexpectedly (code: ${code}, signal: ${signal})\n${getServerLogs()}`,
-    );
-  });
-
+  let realmServerPortInfo: ResolvedPortReservation;
   try {
-    let realmServerRuntime = await waitForJsonFile<{
+    realmServerPortInfo = await resolvePortReservation(explicitRealmServerPort);
+  } catch (error) {
+    await workerManagerPortInfo.releaseHolder();
+    throw error;
+  }
+  let actualWorkerManagerPort = workerManagerPortInfo.port;
+  let actualRealmServerPort = realmServerPortInfo.port;
+  // From this point on, any thrown error must release both port holders so
+  // they don't leak until process exit. The releases are idempotent: the
+  // happy path releases each holder just before its respective child is
+  // spawned, and the cleanup below is a no-op for already-released holders.
+  let releaseHoldersOnFailure = async () => {
+    try {
+      await workerManagerPortInfo.releaseHolder();
+    } catch {
+      // best effort
+    }
+    try {
+      await realmServerPortInfo.releaseHolder();
+    } catch {
+      // best effort
+    }
+  };
+  try {
+    let actualRealmServerURL = withPort(realmServerURL, actualRealmServerPort);
+    let actualRealmPath = realmRelativePath(realmURL, realmServerURL);
+    let actualRealmURL = realmURLWithinServer(
+      actualRealmServerURL,
+      actualRealmPath,
+    );
+    let legacyRealmServerURL = new URL('http://localhost:4205/');
+    let legacyRealmURL = new URL('test/', legacyRealmServerURL);
+    let publicBaseRealmURL = baseRealmURLFor(realmServerURL);
+    let actualBaseRealmURL = baseRealmURLFor(actualRealmServerURL);
+    let sourceRealmURL = sourceRealmURLFor(realmServerURL);
+    let actualSourceRealmURL = sourceRealmURLFor(actualRealmServerURL);
+    let legacySourceRealmURL = sourceRealmURLFor(legacyRealmServerURL);
+    let skillsRealmURL = skillsRealmURLFor(realmServerURL);
+    let actualSkillsRealmURL = skillsRealmURLFor(actualRealmServerURL);
+    let legacySkillsRealmURL = skillsRealmURLFor(legacyRealmServerURL);
+    ensureDirSync(testRealmDir);
+    copyRealmFixture(realmDir, testRealmDir, sourceRealmURL);
+    realmLog.debug(
+      `startIsolatedRealmStack: copied fixture ${realmDir} -> ${testRealmDir}`,
+    );
+
+    // Copy and resolve additional realm fixtures.
+    let resolvedAdditionalRealms: {
+      realmDir: string;
+      localDir: string;
+      realmURL: URL;
+      actualRealmURL: URL;
+      username: string;
+    }[] = [];
+    for (let i = 0; i < (additionalRealms ?? []).length; i++) {
+      let additional = additionalRealms![i];
+      let additionalLocalDir = join(rootDir, `additional-${i}`);
+      let additionalPath = realmRelativePath(
+        additional.realmURL,
+        realmServerURL,
+      );
+      let additionalActualURL = realmURLWithinServer(
+        actualRealmServerURL,
+        additionalPath,
+      );
+      let username = additional.username ?? `additional_realm_${i}`;
+      ensureDirSync(additionalLocalDir);
+      copyRealmFixture(additional.realmDir, additionalLocalDir, sourceRealmURL);
+      realmLog.debug(
+        `startIsolatedRealmStack: copied additional fixture ${additional.realmDir} -> ${additionalLocalDir}`,
+      );
+      resolvedAdditionalRealms.push({
+        realmDir: additional.realmDir,
+        localDir: additionalLocalDir,
+        realmURL: additional.realmURL,
+        actualRealmURL: additionalActualURL,
+        username,
+      });
+    }
+    let compatProxy = await startCompatRealmProxy({
+      listenPort: Number(realmServerURL.port),
+    });
+    // The software-factory Playwright harness can keep prerender alive for the
+    // lifetime of a Playwright testWorker even though the realm stack itself is
+    // recreated per test. When provided, reuse that long-lived prerender URL so
+    // we only restart realm-server and worker-manager here.
+    let prerender = explicitPrerenderURL
+      ? undefined
+      : await startHarnessPrerenderServer({
+          boxelHostURL: realmServerURL.href.replace(/\/$/, ''),
+        });
+    let prerenderURL = explicitPrerenderURL ?? prerender?.url;
+    if (!prerenderURL) {
+      throw new Error(
+        'Unable to determine prerender URL for isolated realm stack',
+      );
+    }
+
+    let env = {
+      ...process.env,
+      PGHOST: DEFAULT_PG_HOST,
+      PGPORT: DEFAULT_PG_PORT,
+      PGUSER: DEFAULT_PG_USER,
+      PG_POOL_MAX: String(DEFAULT_PG_POOL_MAX),
+      PGDATABASE: databaseName,
+      NODE_NO_WARNINGS: '1',
+      NODE_ENV: 'test',
+      REALM_SERVER_SECRET_SEED,
+      REALM_SECRET_SEED,
+      GRAFANA_SECRET,
+      HOST_URL: context.hostURL,
+      MATRIX_URL: context.matrixURL,
+      MATRIX_SERVER_NAME: new URL(context.matrixURL).hostname,
+      MATRIX_REGISTRATION_SHARED_SECRET: context.matrixRegistrationSecret,
+      REALM_SERVER_MATRIX_USERNAME: DEFAULT_MATRIX_SERVER_USERNAME,
+      REALM_SERVER_FULL_INDEX_ON_STARTUP: String(fullIndexOnStartup),
+      // When restoring from a template snapshot, the modules cache has already
+      // been rewritten to the runtime port by `rewriteClonedRealmServerUrls`.
+      // Tell the realm-server to keep that cache instead of wiping it on
+      // startup, so the first lookupDefinition for a fixture-side module hits
+      // the cache instead of paying a cold prerender (~45s for darkfactory.gts).
+      REALM_SERVER_SKIP_MODULES_CACHE_CLEAR_ON_STARTUP: fullIndexOnStartup
+        ? 'false'
+        : 'true',
+      LOW_CREDIT_THRESHOLD: '2000',
+      LOG_LEVELS: DEFAULT_REALM_LOG_LEVELS,
+      BOXEL_TRUST_FORWARDED_URL: 'true',
+      PUBLISHED_REALM_BOXEL_SPACE_DOMAIN: `localhost:${compatProxy.listenPort}`,
+      PUBLISHED_REALM_BOXEL_SITE_DOMAIN: `localhost:${compatProxy.listenPort}`,
+      SOFTWARE_FACTORY_WORKER_MANAGER_METADATA_FILE: workerManagerMetadataFile,
+      SOFTWARE_FACTORY_REALM_SERVER_METADATA_FILE: realmServerMetadataFile,
+    };
+
+    let workerArgs = [
+      '--transpileOnly',
+      'worker-manager',
+      `--port=${actualWorkerManagerPort}`,
+      `--matrixURL=${context.matrixURL}`,
+      `--prerendererUrl=${prerenderURL}`,
+      `--fromUrl=${realmURL.href}`,
+      `--toUrl=${actualRealmURL.href}`,
+      `--fromUrl=${publicBaseRealmURL.href}`,
+      `--toUrl=${actualBaseRealmURL.href}`,
+      '--fromUrl=https://cardstack.com/base/',
+      `--toUrl=${publicBaseRealmURL.href}`,
+      `--fromUrl=${sourceRealmURL.href}`,
+      `--toUrl=${actualSourceRealmURL.href}`,
+    ];
+    if (INCLUDE_SKILLS) {
+      workerArgs.push(
+        `--fromUrl=${skillsRealmURL.href}`,
+        `--toUrl=${actualSkillsRealmURL.href}`,
+      );
+    }
+    workerArgs.push(
+      `--fromUrl=${legacyRealmURL.href}`,
+      `--toUrl=${actualRealmURL.href}`,
+      `--fromUrl=${legacySourceRealmURL.href}`,
+      `--toUrl=${actualSourceRealmURL.href}`,
+    );
+    if (INCLUDE_SKILLS) {
+      workerArgs.push(
+        `--fromUrl=${legacySkillsRealmURL.href}`,
+        `--toUrl=${actualSkillsRealmURL.href}`,
+      );
+    }
+    for (let additional of resolvedAdditionalRealms) {
+      workerArgs.push(
+        `--fromUrl=${additional.realmURL.href}`,
+        `--toUrl=${additional.actualRealmURL.href}`,
+      );
+    }
+    if (migrateDB) {
+      workerArgs.splice(5, 0, '--migrateDB');
+    }
+
+    // Release the worker-manager port holder right before the child binds.
+    await workerManagerPortInfo.releaseHolder();
+    let workerManager = spawn('ts-node', workerArgs, {
+      cwd: realmServerDir,
+      env,
+      stdio: managedProcessStdio,
+    }) as SpawnedProcess;
+    let getWorkerLogs = captureProcessLogs(workerManager);
+    workerManager.on('exit', (code, signal) => {
+      if (code === 0 || signal === 'SIGTERM' || signal === 'SIGINT') {
+        return;
+      }
+      realmLog.warn(
+        `worker manager exited unexpectedly (code: ${code}, signal: ${signal})\n${getWorkerLogs()}`,
+      );
+    });
+    let workerManagerRuntime = await waitForJsonFile<{
       pid: number;
       port: number;
-    }>(realmServerMetadataFile, getServerLogs, {
-      label: 'realm server',
-      process: realmServer,
+      url: string;
+    }>(workerManagerMetadataFile, getWorkerLogs, {
+      label: 'worker manager',
+      process: workerManager,
     });
-    compatProxy.setTargetPort(realmServerRuntime.port);
-    await Promise.race([
-      waitForReady(
-        realmServer,
-        'realm server',
-        fullIndexOnStartup
-          ? FULL_INDEX_REALM_STARTUP_TIMEOUT_MS
-          : DEFAULT_REALM_STARTUP_TIMEOUT_MS,
-        () =>
-          [
-            'realm server logs:',
-            getServerLogs(),
-            'worker manager logs:',
-            getWorkerLogs(),
-          ]
-            .filter((entry) => entry && entry.trim().length > 0)
-            .join('\n\n'),
-      ),
-      createProcessExitPromise(workerManager, 'worker manager'),
-    ]);
 
-    return {
-      compatProxy,
-      prerender,
-      realmServer,
-      realmServerURL,
-      ports: {
-        publicPort: compatProxy.listenPort,
-        realmServerPort: realmServerRuntime.port,
-        workerManagerPort: workerManagerRuntime.port,
-      },
-      workerManager,
-      rootDir,
-    };
+    let serverArgs = [
+      '--transpileOnly',
+      'main',
+      `--port=${actualRealmServerPort}`,
+      `--serverURL=${realmServerURL.href}`,
+      `--matrixURL=${context.matrixURL}`,
+      `--realmsRootPath=${rootDir}`,
+      `--workerManagerUrl=${workerManagerRuntime.url}`,
+      `--prerendererUrl=${prerenderURL}`,
+      '--username=base_realm',
+      `--path=${baseRealmDir}`,
+      `--fromUrl=${publicBaseRealmURL.href}`,
+      `--toUrl=${actualBaseRealmURL.href}`,
+      '--username=software_factory_realm',
+      `--path=${filteredSourceRealmDir}`,
+      `--fromUrl=${sourceRealmURL.href}`,
+      `--toUrl=${actualSourceRealmURL.href}`,
+      '--username=test_realm',
+      `--path=${testRealmDir}`,
+      `--fromUrl=${realmURL.href}`,
+      `--toUrl=${actualRealmURL.href}`,
+    ];
+    for (let additional of resolvedAdditionalRealms) {
+      serverArgs.push(
+        `--username=${additional.username}`,
+        `--path=${additional.localDir}`,
+        `--fromUrl=${additional.realmURL.href}`,
+        `--toUrl=${additional.actualRealmURL.href}`,
+      );
+    }
+    if (INCLUDE_SKILLS) {
+      serverArgs.splice(
+        16,
+        0,
+        '--username=skills_realm',
+        `--path=${skillsRealmDir}`,
+        `--fromUrl=${skillsRealmURL.href}`,
+        `--toUrl=${actualSkillsRealmURL.href}`,
+      );
+    }
+    serverArgs.push(
+      `--fromUrl=${legacyRealmURL.href}`,
+      `--toUrl=${actualRealmURL.href}`,
+      `--fromUrl=${legacySourceRealmURL.href}`,
+      `--toUrl=${actualSourceRealmURL.href}`,
+    );
+    if (INCLUDE_SKILLS) {
+      serverArgs.push(
+        `--fromUrl=${legacySkillsRealmURL.href}`,
+        `--toUrl=${actualSkillsRealmURL.href}`,
+      );
+    }
+    // Map the canonical base realm URL so the realm server's virtual network
+    // can resolve definitions referenced via https://cardstack.com/base/...
+    serverArgs.push(
+      '--fromUrl=https://cardstack.com/base/',
+      `--toUrl=${actualBaseRealmURL.href}`,
+    );
+
+    // Release the realm-server port holder right before the child binds.
+    await realmServerPortInfo.releaseHolder();
+    let realmServer = spawn('ts-node', serverArgs, {
+      cwd: realmServerDir,
+      env,
+      stdio: managedProcessStdio,
+    }) as SpawnedProcess;
+    let getServerLogs = captureProcessLogs(realmServer);
+    realmServer.on('exit', (code, signal) => {
+      if (code === 0 || signal === 'SIGTERM' || signal === 'SIGINT') {
+        return;
+      }
+      realmLog.warn(
+        `realm server exited unexpectedly (code: ${code}, signal: ${signal})\n${getServerLogs()}`,
+      );
+    });
+
+    try {
+      let realmServerRuntime = await waitForJsonFile<{
+        pid: number;
+        port: number;
+      }>(realmServerMetadataFile, getServerLogs, {
+        label: 'realm server',
+        process: realmServer,
+      });
+      compatProxy.setTargetPort(realmServerRuntime.port);
+      await Promise.race([
+        waitForReady(
+          realmServer,
+          'realm server',
+          fullIndexOnStartup
+            ? FULL_INDEX_REALM_STARTUP_TIMEOUT_MS
+            : DEFAULT_REALM_STARTUP_TIMEOUT_MS,
+          () =>
+            [
+              'realm server logs:',
+              getServerLogs(),
+              'worker manager logs:',
+              getWorkerLogs(),
+            ]
+              .filter((entry) => entry && entry.trim().length > 0)
+              .join('\n\n'),
+        ),
+        createProcessExitPromise(workerManager, 'worker manager'),
+      ]);
+
+      return {
+        compatProxy,
+        prerender,
+        realmServer,
+        realmServerURL,
+        ports: {
+          publicPort: compatProxy.listenPort,
+          realmServerPort: realmServerRuntime.port,
+          workerManagerPort: workerManagerRuntime.port,
+        },
+        workerManager,
+        rootDir,
+      };
+    } catch (error) {
+      try {
+        await prerender?.stop();
+      } catch {
+        // best effort cleanup
+      }
+      try {
+        await stopManagedProcess(realmServer);
+      } catch {
+        // best effort cleanup
+      }
+      try {
+        await stopManagedProcess(workerManager);
+      } catch {
+        // best effort cleanup
+      }
+      try {
+        await compatProxy?.stop();
+      } catch {
+        // best effort cleanup
+      }
+      rmSync(rootDir, { recursive: true, force: true });
+      throw error;
+    }
   } catch (error) {
-    try {
-      await prerender?.stop();
-    } catch {
-      // best effort cleanup
-    }
-    try {
-      await stopManagedProcess(realmServer);
-    } catch {
-      // best effort cleanup
-    }
-    try {
-      await stopManagedProcess(workerManager);
-    } catch {
-      // best effort cleanup
-    }
-    try {
-      await compatProxy?.stop();
-    } catch {
-      // best effort cleanup
-    }
-    rmSync(rootDir, { recursive: true, force: true });
+    // Outer catch covering the long stretch between port-holder allocation
+    // and the realm-server spawn. Releases any still-held port holders so
+    // they don't leak past this function on early failures (compat-proxy
+    // start, prerender start, worker-manager spawn / metadata wait, etc).
+    await releaseHoldersOnFailure();
     throw error;
   }
 }

--- a/packages/software-factory/src/harness/shared.ts
+++ b/packages/software-factory/src/harness/shared.ts
@@ -332,7 +332,16 @@ export type PortReservation = {
 
 export async function findAndHoldAvailablePort(): Promise<PortReservation> {
   return await new Promise<PortReservation>((resolveOuter, rejectOuter) => {
-    let server = createNetServer();
+    // Immediately destroy any incoming connection. The holder exists only
+    // to keep the kernel from handing the port to a sibling allocator;
+    // accepting traffic would let an unsuspecting HTTP client (e.g. the
+    // indexing-progress poller) connect to a socket with no HTTP server
+    // behind it and hang waiting for a response that never comes.
+    // Destroying on connect surfaces as ECONNRESET on the client side,
+    // which fetch reports as a TypeError — the poller's catch handler
+    // treats that as a transient failure and tries again on the next
+    // tick.
+    let server = createNetServer((socket) => socket.destroy());
     let onError = (error: NodeJS.ErrnoException) => {
       server.close();
       rejectOuter(error);

--- a/packages/software-factory/src/harness/shared.ts
+++ b/packages/software-factory/src/harness/shared.ts
@@ -297,21 +297,76 @@ export function hashString(value: string): string {
 }
 
 export async function findAvailablePort(): Promise<number> {
-  return await new Promise<number>((resolve, reject) => {
+  let reservation = await findAndHoldAvailablePort();
+  await reservation.release();
+  return reservation.port;
+}
+
+/**
+ * A port number plus a `release()` that closes the holder socket keeping
+ * the port reserved. Prefer this over `findAvailablePort()` whenever there
+ * is a non-trivial gap between "I picked a port" and "the child process
+ * actually binds to it". Without the hold the OS port-0 allocator can
+ * hand the same port to a sibling caller in the same process (the
+ * concrete failure mode that hit the cache:prepare path of the SF
+ * harness, where the realm-server, worker-manager, prerender, host-dist
+ * and compat-proxy ports were all picked back-to-back from the ephemeral
+ * range and could collide before any subprocess had a chance to bind).
+ *
+ * Usage:
+ *
+ *   let reservation = await findAndHoldAvailablePort();
+ *   try {
+ *     // ... long-running setup that allocates other ports ...
+ *     await reservation.release();
+ *     spawn('child', ['--port', String(reservation.port)]);
+ *   } catch (err) {
+ *     await reservation.release();
+ *     throw err;
+ *   }
+ */
+export type PortReservation = {
+  readonly port: number;
+  release(): Promise<void>;
+};
+
+export async function findAndHoldAvailablePort(): Promise<PortReservation> {
+  return await new Promise<PortReservation>((resolveOuter, rejectOuter) => {
     let server = createNetServer();
-    server.once('error', reject);
+    let onError = (error: NodeJS.ErrnoException) => {
+      server.close();
+      rejectOuter(error);
+    };
+    server.once('error', onError);
     server.listen(0, '127.0.0.1', () => {
       let address = server.address();
       if (!address || typeof address === 'string') {
-        reject(new Error('Unable to determine allocated port'));
+        server.close();
+        rejectOuter(new Error('Unable to determine allocated port'));
         return;
       }
-      server.close((error) => {
-        if (error) {
-          reject(error);
-        } else {
-          resolve(address.port);
-        }
+      server.off('error', onError);
+      // Swallow late errors after a successful bind so they don't surface
+      // as unhandled 'error' events.
+      server.on('error', () => {});
+      let released = false;
+      resolveOuter({
+        port: address.port,
+        release: () =>
+          new Promise<void>((resolveClose, rejectClose) => {
+            if (released) {
+              resolveClose();
+              return;
+            }
+            released = true;
+            server.close((closeError) => {
+              if (closeError) {
+                rejectClose(closeError);
+              } else {
+                resolveClose();
+              }
+            });
+          }),
       });
     });
   });

--- a/packages/software-factory/src/harness/support-services.ts
+++ b/packages/software-factory/src/harness/support-services.ts
@@ -14,7 +14,7 @@ import {
   DEFAULT_PG_HOST,
   DEFAULT_PG_PORT,
   CONFIGURED_HOST_URL,
-  findAvailablePort,
+  findAndHoldAvailablePort,
   findHostDistPackageDir,
   findRootRepoCheckoutDir,
   hostDir,
@@ -241,7 +241,11 @@ async function ensureHostReady(): Promise<{
       }
       ensureBoxelUIDist(hostPackageDir);
       assertUsableHostDist(hostPackageDir);
-      let port = await findAvailablePort();
+      // Hold the port until just before spawn so a sibling allocation
+      // cannot race in and take it. See findAndHoldAvailablePort comment
+      // for the full failure mode this guards against.
+      let portReservation = await findAndHoldAvailablePort();
+      let port = portReservation.port;
       let hostURL = `http://localhost:${port}/`;
       let hostDistDir = join(hostPackageDir, 'dist');
       let serveConfigPath = join(hostPackageDir, 'tests', 'serve.json');
@@ -249,6 +253,7 @@ async function ensureHostReady(): Promise<{
         `serving built host dist from ${hostPackageDir} at ${hostURL}`,
       );
 
+      await portReservation.release();
       let child = spawn(
         'npx',
         [
@@ -435,11 +440,21 @@ async function attemptStartHarnessPrerenderServer(options: {
   url: string;
   stop(): Promise<void>;
 }> {
-  let port = options.port ?? 0;
-  if (port === 0) {
-    port = await findAvailablePort();
+  let port: number;
+  let portReservation: Awaited<
+    ReturnType<typeof findAndHoldAvailablePort>
+  > | null = null;
+  if (options.port && options.port !== 0) {
+    port = options.port;
+  } else {
+    portReservation = await findAndHoldAvailablePort();
+    port = portReservation.port;
   }
   let url = `http://localhost:${port}`;
+  // Release the holder right before the child binds (only if we allocated).
+  if (portReservation) {
+    await portReservation.release();
+  }
   let child = spawn(
     'ts-node',
     ['--transpileOnly', 'prerender/prerender-server', `--port=${port}`],

--- a/packages/software-factory/tests/find-and-hold-available-port.test.ts
+++ b/packages/software-factory/tests/find-and-hold-available-port.test.ts
@@ -87,6 +87,39 @@ module('findAndHoldAvailablePort', function () {
     }
   });
 
+  test('held port immediately rejects HTTP clients instead of hanging', async function (assert) {
+    // Regression test for codex-flagged P1: the indexing-progress poller
+    // does `fetch(http://localhost:<port>/_indexing-status)` against the
+    // worker-manager port. If the holder were a passive net.Server, fetch
+    // would connect, send headers, and hang forever waiting for a
+    // response. The holder must destroy the socket on connect so fetch
+    // fails fast and the poller retries on its next interval.
+    let reservation = await findAndHoldAvailablePort();
+    try {
+      let abort = new AbortController();
+      let timer = setTimeout(() => abort.abort(), 2000);
+      let result = await fetch(`http://localhost:${reservation.port}/`, {
+        signal: abort.signal,
+      })
+        .then(() => ({ ok: true }) as const)
+        .catch((err: Error) => ({ ok: false, name: err.name }) as const);
+      clearTimeout(timer);
+      assert.false(
+        result.ok,
+        'fetch against held port must fail rather than hang',
+      );
+      if (!result.ok) {
+        assert.notStrictEqual(
+          result.name,
+          'AbortError',
+          `fetch errored quickly (got ${result.name}); a hung connection would have been aborted`,
+        );
+      }
+    } finally {
+      await reservation.release();
+    }
+  });
+
   test('successive findAndHoldAvailablePort + release cycles never produce a duplicate-while-held port', async function (assert) {
     // The exact race that caused the cache:prepare EADDRINUSE: caller A
     // takes a port and holds it, caller B takes a *different* port (must

--- a/packages/software-factory/tests/find-and-hold-available-port.test.ts
+++ b/packages/software-factory/tests/find-and-hold-available-port.test.ts
@@ -1,0 +1,109 @@
+import { createServer } from 'node:net';
+import { module, test } from 'qunit';
+
+import { findAndHoldAvailablePort } from '../src/harness/shared';
+
+async function bindOn(port: number): Promise<{
+  ok: boolean;
+  code?: string;
+  close: () => Promise<void>;
+}> {
+  return await new Promise((resolve) => {
+    let s = createServer();
+    s.once('error', (err: NodeJS.ErrnoException) =>
+      resolve({
+        ok: false,
+        code: err.code,
+        close: async () => {},
+      }),
+    );
+    s.listen(port, () => {
+      resolve({
+        ok: true,
+        close: () =>
+          new Promise<void>((resolveClose) => s.close(() => resolveClose())),
+      });
+    });
+  });
+}
+
+module('findAndHoldAvailablePort', function () {
+  test('returns a port that is currently bound by the holder', async function (assert) {
+    let reservation = await findAndHoldAvailablePort();
+    try {
+      // The port should be held — a fresh dual-stack bind on it must fail.
+      let attempt = await bindOn(reservation.port);
+      assert.false(
+        attempt.ok,
+        `port ${reservation.port} bind attempt should fail while held`,
+      );
+      assert.strictEqual(
+        attempt.code,
+        'EADDRINUSE',
+        'rejected bind reports EADDRINUSE',
+      );
+    } finally {
+      await reservation.release();
+    }
+  });
+
+  test('release frees the port for subsequent binders', async function (assert) {
+    let reservation = await findAndHoldAvailablePort();
+    let port = reservation.port;
+    await reservation.release();
+    let attempt = await bindOn(port);
+    assert.true(attempt.ok, `port ${port} should be free after release`);
+    await attempt.close();
+  });
+
+  test('release is idempotent', async function (assert) {
+    let reservation = await findAndHoldAvailablePort();
+    await reservation.release();
+    // Second release must not throw.
+    await reservation.release();
+    assert.true(true, 'release called twice without throwing');
+  });
+
+  test('many concurrent reservations all return distinct ports and hold each', async function (assert) {
+    // This is the scenario the cache:prepare path was failing on: many
+    // concurrent allocations had to coexist without colliding mid-flight.
+    let reservations = await Promise.all(
+      Array.from({ length: 16 }, () => findAndHoldAvailablePort()),
+    );
+    try {
+      let ports = reservations.map((r) => r.port);
+      assert.strictEqual(
+        new Set(ports).size,
+        ports.length,
+        'every concurrently-held reservation has a distinct port',
+      );
+      // Each one is currently held — bind attempts must all fail.
+      for (let port of ports) {
+        let attempt = await bindOn(port);
+        assert.false(attempt.ok, `port ${port} held — bind rejected`);
+      }
+    } finally {
+      await Promise.allSettled(reservations.map((r) => r.release()));
+    }
+  });
+
+  test('successive findAndHoldAvailablePort + release cycles never produce a duplicate-while-held port', async function (assert) {
+    // The exact race that caused the cache:prepare EADDRINUSE: caller A
+    // takes a port and holds it, caller B takes a *different* port (must
+    // not get A's port back even though A's socket is still listening).
+    let outer = await findAndHoldAvailablePort();
+    try {
+      for (let i = 0; i < 20; i++) {
+        let inner = await findAndHoldAvailablePort();
+        assert.notStrictEqual(
+          inner.port,
+          outer.port,
+          `iteration ${i}: inner port ${inner.port} differs from held outer port ${outer.port}`,
+        );
+        await inner.release();
+      }
+    } finally {
+      await outer.release();
+    }
+  });
+});

--- a/packages/software-factory/tests/index.ts
+++ b/packages/software-factory/tests/index.ts
@@ -24,3 +24,4 @@ import './eval-execution.test';
 import './instantiate-step.test';
 import './parse-step.test';
 import './port-allocator.test';
+import './find-and-hold-available-port.test';


### PR DESCRIPTION
## Summary

Follow-up to #4500. That PR fixed the per-test fixture path; this one fixes the **cache:prepare global setup** path, which still failed with `EADDRINUSE` (e.g. https://github.com/cardstack/boxel/actions/runs/25111401985/job/73587404002).

The cache:prepare path allocates every port dynamically via `findAvailablePort()` — compat URL, worker-manager, realm-server, prerender, host serve. Each call probe-binds port 0, takes the OS-assigned ephemeral port, closes the probe, and returns the number — leaving the port free until the actual subprocess binds it **seconds later**. With many sibling allocations in the same process, the OS could legitimately hand back a number that a prior sibling had already "claimed", and whoever spawned its child last would race in and die with `EADDRINUSE`.

- New `findAndHoldAvailablePort()` returns a `PortReservation { port; release() }` whose holder socket stays bound until `release()` is called.
- Worker-manager + realm-server (`isolated-realm-stack.ts`), prerender + host serve (`support-services.ts`), and the cache:prepare worker-manager (`database.ts`) now use the holder variant and release immediately before each subprocess is spawned.
- `startIsolatedRealmStack` gained an outer try/catch that releases any still-held holders on early failure (compat-proxy or prerender startup, worker-manager metadata wait, etc).
- API extension on `startIsolatedRealmStack`: `workerManagerPort` / `realmServerPort` now accept either a plain number (caller manages, no internal hold) or a `PortReservation` (caller pre-allocated via `findAndHoldAvailablePort`, we release at the right moment). The plain-number form remains backward-compatible.

## Test plan

- [x] 5 new qunit cases in `find-and-hold-available-port.test.ts`: held-bind-fails, release-frees-port, idempotent release, many-concurrent-distinct, and the exact "no-duplicate-while-held" property that caused the cache:prepare failure.
- [x] All 13 port-related qunit tests pass (8 from #4500 + 5 new).
- [x] `pnpm lint:js`, `pnpm lint:format`, `pnpm lint:types` all clean.
- [x] 30-iteration local stress run of the cache:prepare allocation pattern: 0 collisions.
- [ ] Full `pnpm test:playwright` cache:prepare on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)