### PR TITLE
ci: Move Actions-produced comments into one

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -404,6 +404,11 @@ jobs:
       - host-merge-reports-and-publish
     if: ${{ !cancelled() && needs.host-merge-reports-and-publish.result == 'success' }}
     uses: ./.github/workflows/pr-status-comment.yml
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      actions: read
     with:
       head-sha: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -398,6 +398,16 @@ jobs:
           path: slot/
           retention-days: 7
 
+  post-pr-status:
+    name: Update PR status comment
+    needs:
+      - host-merge-reports-and-publish
+    if: ${{ !cancelled() && needs.host-merge-reports-and-publish.result == 'success' }}
+    uses: ./.github/workflows/pr-status-comment.yml
+    with:
+      head-sha: ${{ github.event.pull_request.head.sha || github.sha }}
+    secrets: inherit
+
   host-memory-baseline:
     name: Host Memory Baseline
     if: ${{ !cancelled() && (needs.host-test.result == 'success' || needs.host-test.result == 'failure') }}

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -370,11 +370,33 @@ jobs:
           retention-days: 30
 
       - name: Publish test results
+        id: publish-tests
         uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # 2.18.0
         if: ${{ !cancelled() }}
         with:
           junit_files: host.xml
           check_name: Host Test Results
+          comment_mode: "off"
+          json_file: test-results.json
+
+      - name: Build host-tests slot
+        if: ${{ !cancelled() && hashFiles('test-results.json') != '' }}
+        run: |
+          set -euo pipefail
+          mkdir -p slot
+          {
+            echo "### Host Test Results"
+            echo
+            jq -r '.summary' test-results.json
+          } > slot/slot.md
+
+      - name: Upload host-tests slot
+        if: ${{ !cancelled() && hashFiles('slot/slot.md') != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-comment-slot-host-tests
+          path: slot/
+          retention-days: 7
 
   host-memory-baseline:
     name: Host Memory Baseline

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -411,7 +411,7 @@ jobs:
       actions: read
     with:
       head-sha: ${{ github.event.pull_request.head.sha || github.sha }}
-      slot: host-tests
+      slots: host-tests
     secrets: inherit
 
   host-memory-baseline:

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -411,6 +411,7 @@ jobs:
       actions: read
     with:
       head-sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      slot: host-tests
     secrets: inherit
 
   host-memory-baseline:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -694,6 +694,11 @@ jobs:
       - realm-server-merge-reports
     if: ${{ !cancelled() && needs.realm-server-merge-reports.result == 'success' }}
     uses: ./.github/workflows/pr-status-comment.yml
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      actions: read
     with:
       head-sha: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -701,6 +701,7 @@ jobs:
       actions: read
     with:
       head-sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      slot: realm-tests
     secrets: inherit
 
   vscode-boxel-tools-package:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -701,7 +701,7 @@ jobs:
       actions: read
     with:
       head-sha: ${{ github.event.pull_request.head.sha || github.sha }}
-      slot: realm-tests
+      slots: realm-tests
     secrets: inherit
 
   vscode-boxel-tools-package:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -660,11 +660,33 @@ jobs:
           path: realm-server.xml
           retention-days: 30
       - name: Publish test results
+        id: publish-tests
         uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # 2.18.0
         if: ${{ !cancelled() }}
         with:
           junit_files: realm-server.xml
           check_name: Realm Server Test Results
+          comment_mode: "off"
+          json_file: test-results.json
+
+      - name: Build realm-tests slot
+        if: ${{ !cancelled() && hashFiles('test-results.json') != '' }}
+        run: |
+          set -euo pipefail
+          mkdir -p slot
+          {
+            echo "### Realm Server Test Results"
+            echo
+            jq -r '.summary' test-results.json
+          } > slot/slot.md
+
+      - name: Upload realm-tests slot
+        if: ${{ !cancelled() && hashFiles('slot/slot.md') != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-comment-slot-realm-tests
+          path: slot/
+          retention-days: 7
 
   vscode-boxel-tools-package:
     name: Boxel Tools VS Code Extension package

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -688,6 +688,16 @@ jobs:
           path: slot/
           retention-days: 7
 
+  post-pr-status:
+    name: Update PR status comment
+    needs:
+      - realm-server-merge-reports
+    if: ${{ !cancelled() && needs.realm-server-merge-reports.result == 'success' }}
+    uses: ./.github/workflows/pr-status-comment.yml
+    with:
+      head-sha: ${{ github.event.pull_request.head.sha || github.sha }}
+    secrets: inherit
+
   vscode-boxel-tools-package:
     name: Boxel Tools VS Code Extension package
     needs: [change-check, test-web-assets]

--- a/.github/workflows/pr-boxel-ui.yml
+++ b/.github/workflows/pr-boxel-ui.yml
@@ -74,3 +74,13 @@ jobs:
     with:
       head-sha: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
+
+  post-pr-status:
+    name: Update PR status comment
+    needs:
+      - post-preview-comment
+    if: ${{ !cancelled() && needs.post-preview-comment.result == 'success' }}
+    uses: ./.github/workflows/pr-status-comment.yml
+    with:
+      head-sha: ${{ github.event.pull_request.head.sha }}
+    secrets: inherit

--- a/.github/workflows/pr-boxel-ui.yml
+++ b/.github/workflows/pr-boxel-ui.yml
@@ -72,6 +72,5 @@ jobs:
     if: ${{ !cancelled() && needs.deploy-ui-preview-staging.result == 'success' }}
     uses: ./.github/workflows/preview-comment.yml
     with:
-      pr-number: ${{ github.event.pull_request.number }}
       head-sha: ${{ github.event.pull_request.head.sha }}
     secrets: inherit

--- a/.github/workflows/pr-boxel-ui.yml
+++ b/.github/workflows/pr-boxel-ui.yml
@@ -81,6 +81,11 @@ jobs:
       - post-preview-comment
     if: ${{ !cancelled() && needs.post-preview-comment.result == 'success' }}
     uses: ./.github/workflows/pr-status-comment.yml
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      actions: read
     with:
       head-sha: ${{ github.event.pull_request.head.sha }}
     secrets: inherit

--- a/.github/workflows/pr-boxel-ui.yml
+++ b/.github/workflows/pr-boxel-ui.yml
@@ -79,7 +79,7 @@ jobs:
     name: Update PR status comment
     needs:
       - post-preview-comment
-    if: ${{ !cancelled() && needs.post-preview-comment.result == 'success' }}
+    if: ${{ !cancelled() && needs.post-preview-comment.result == 'success' && needs.post-preview-comment.outputs.slots != '' }}
     uses: ./.github/workflows/pr-status-comment.yml
     permissions:
       contents: read
@@ -88,5 +88,5 @@ jobs:
       actions: read
     with:
       head-sha: ${{ github.event.pull_request.head.sha }}
-      slot: preview
+      slots: ${{ needs.post-preview-comment.outputs.slots }}
     secrets: inherit

--- a/.github/workflows/pr-boxel-ui.yml
+++ b/.github/workflows/pr-boxel-ui.yml
@@ -88,4 +88,5 @@ jobs:
       actions: read
     with:
       head-sha: ${{ github.event.pull_request.head.sha }}
+      slot: preview
     secrets: inherit

--- a/.github/workflows/pr-status-comment.yml
+++ b/.github/workflows/pr-status-comment.yml
@@ -1,35 +1,29 @@
 name: PR Status Comment
 
-# Aggregates per-workflow "slot" artifacts (named pr-comment-slot-*) into a
-# single sticky PR comment with header `pr-status`. Producing workflows upload
-# a `slot/slot.md` artifact; this workflow rebuilds the whole comment from
-# whatever slots currently exist for the PR's head SHA.
-#
-# Note: workflow_run runs in the context of the default branch, so edits to
-# this file only take effect after they land on main.
+# Reusable: invoked by each workflow that uploads a `pr-comment-slot-*`
+# artifact. Rebuilds the unified sticky comment (header `pr-status`) from
+# whatever slots currently exist for the given head SHA. Cross-workflow
+# concurrency is enforced at the job level so calls from different parent
+# workflows serialize for the same branch and don't clobber each other.
 
 on:
-  workflow_run:
-    workflows:
-      - Preview Host
-      - CI [boxel-ui]
-      - CI Host
-      - CI
-    types:
-      - completed
-
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
-  actions: read
+  workflow_call:
+    inputs:
+      head-sha:
+        description: Commit SHA to aggregate slot artifacts for
+        required: true
+        type: string
 
 jobs:
   update-comment:
-    if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      actions: read
     concurrency:
-      group: pr-status-comment-${{ github.event.workflow_run.head_branch }}
+      group: pr-status-comment-${{ github.head_ref || inputs.head-sha }}
       cancel-in-progress: false
     steps:
       - name: Resolve PR and check freshness
@@ -37,38 +31,37 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          SHA: ${{ github.event.workflow_run.head_sha }}
-          PR_FROM_EVENT: ${{ github.event.workflow_run.pull_requests[0].number }}
+          SHA: ${{ inputs.head-sha }}
         run: |
           set -euo pipefail
-          pr="$PR_FROM_EVENT"
-          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
-            echo "No PR in event payload; skipping."
+          pr=$(gh api "/repos/$REPO/commits/$SHA/pulls" --jq '.[0].number // empty')
+          if [ -z "$pr" ]; then
+            echo "No PR for $SHA, skipping."
             echo "skip=true" >>"$GITHUB_OUTPUT"
             exit 0
           fi
           latest=$(gh api "/repos/$REPO/pulls/$pr" --jq '.head.sha')
           if [ "$latest" != "$SHA" ]; then
-            echo "PR #$pr head is now $latest, event SHA $SHA is stale; skipping."
+            echo "PR #$pr head is now $latest; event SHA $SHA stale; skipping."
             echo "skip=true" >>"$GITHUB_OUTPUT"
             exit 0
           fi
           echo "number=$pr" >>"$GITHUB_OUTPUT"
-          echo "sha=$SHA"   >>"$GITHUB_OUTPUT"
 
       - name: Collect slot artifacts for this commit
         if: steps.pr.outputs.skip != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          SHA: ${{ steps.pr.outputs.sha }}
+          SHA: ${{ inputs.head-sha }}
         run: |
           set -euo pipefail
           mkdir -p slots
 
-          # Most recent runs first; first download per slot name wins.
+          # No status filter: the calling workflow run is still in_progress.
+          # Most recent runs are returned first; first download per slot wins.
           gh api -X GET "/repos/$REPO/actions/runs" \
-            -f head_sha="$SHA" -f status=completed --paginate \
+            -f head_sha="$SHA" --paginate \
             --jq '.workflow_runs[].id' > runs.txt
 
           while read -r run_id; do
@@ -92,7 +85,7 @@ jobs:
         run: |
           set -euo pipefail
           : > comment.md
-          # Fixed slot order. Add new slot names here as we migrate emitters.
+          # Fixed slot order. Add new slot names here as we add emitters.
           for slot in preview host-tests realm-tests; do
             f="slots/pr-comment-slot-$slot/slot.md"
             if [ -s "$f" ]; then

--- a/.github/workflows/pr-status-comment.yml
+++ b/.github/workflows/pr-status-comment.yml
@@ -1,16 +1,28 @@
 name: PR Status Comment
 
-# Reusable: invoked by each workflow that uploads a `pr-comment-slot-*`
-# artifact. Rebuilds the unified sticky comment (header `pr-status`) from
-# whatever slots currently exist for the given head SHA. Cross-workflow
-# concurrency is enforced at the job level so calls from different parent
-# workflows serialize for the same branch and don't clobber each other.
+# Reusable: invoked by each workflow that uploads a `pr-comment-slot-<slot>`
+# artifact. Updates only the named slot's section of the unified sticky
+# comment (header `pr-status`); other sections are preserved from the
+# existing comment so a slow-finishing workflow doesn't wipe out sections
+# that finished earlier (including those from a prior commit).
+#
+# Each section is delimited in the comment body with HTML markers:
+#   <!-- pr-status-slot:<slot> -->
+#   ...
+#   <!-- /pr-status-slot:<slot> -->
+#
+# Cross-workflow concurrency is enforced at the job level so calls from
+# different parent workflows serialize for the same branch.
 
 on:
   workflow_call:
     inputs:
       head-sha:
-        description: Commit SHA to aggregate slot artifacts for
+        description: Commit SHA the calling run is targeting
+        required: true
+        type: string
+      slot:
+        description: Slot name being refreshed (e.g. preview, host-tests, realm-tests)
         required: true
         type: string
 
@@ -48,49 +60,68 @@ jobs:
           fi
           echo "number=$pr" >>"$GITHUB_OUTPUT"
 
-      - name: Collect slot artifacts for this commit
+      - name: Download fresh slot artifact from this run
         if: steps.pr.outputs.skip != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          SHA: ${{ inputs.head-sha }}
+          RUN_ID: ${{ github.run_id }}
+          SLOT: ${{ inputs.slot }}
         run: |
           set -euo pipefail
-          mkdir -p slots
+          mkdir -p fresh
+          # The slot was uploaded by an earlier job in the same workflow run.
+          # Failures here (e.g. uploader skipped) fall through to preserving
+          # whatever the existing comment has for this slot.
+          gh run download -R "$REPO" "$RUN_ID" \
+            -n "pr-comment-slot-$SLOT" -D fresh/ 2>/dev/null || true
 
-          # No status filter: the calling workflow run is still in_progress.
-          # Most recent runs are returned first; first download per slot wins.
-          gh api -X GET "/repos/$REPO/actions/runs" \
-            -f head_sha="$SHA" --paginate \
-            --jq '.workflow_runs[].id' > runs.txt
-
-          while read -r run_id; do
-            [ -n "$run_id" ] || continue
-            artifacts=$(
-              gh api "/repos/$REPO/actions/runs/$run_id/artifacts" --paginate \
-                --jq '.artifacts[].name' \
-              | grep '^pr-comment-slot-' || true
-            )
-            [ -n "$artifacts" ] || continue
-            while read -r name; do
-              [ -n "$name" ] || continue
-              [ -d "slots/$name" ] && continue
-              gh run download -R "$REPO" "$run_id" -n "$name" -D "slots/$name" || true
-            done <<<"$artifacts"
-          done < runs.txt
+      - name: Fetch existing pr-status comment body
+        if: steps.pr.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          : > existing.md
+          # marocchino sticky-pull-request-comment marks its comment with
+          # this header so it can find and update it. Filter on that and on
+          # the github-actions bot author for safety.
+          gh api --paginate "/repos/$REPO/issues/$PR/comments?per_page=100" \
+            --jq '.[] | select(
+                    .user.login == "github-actions[bot]"
+                    and (.body | contains("<!-- Sticky Pull Request Commentpr-status -->"))
+                  ) | .body' \
+            > existing.md || true
 
       - name: Assemble comment body
         if: steps.pr.outputs.skip != 'true'
         id: body
+        env:
+          SLOT: ${{ inputs.slot }}
         run: |
           set -euo pipefail
           : > comment.md
           # Fixed slot order. Add new slot names here as we add emitters.
           for slot in preview host-tests realm-tests; do
-            f="slots/pr-comment-slot-$slot/slot.md"
-            if [ -s "$f" ]; then
-              cat "$f" >> comment.md
-              printf '\n\n' >> comment.md
+            content=""
+            if [ "$slot" = "$SLOT" ] && [ -s "fresh/slot.md" ]; then
+              content=$(cat fresh/slot.md)
+            else
+              content=$(awk -v s="$slot" '
+                $0 == "<!-- pr-status-slot:" s " -->" { flag=1; next }
+                $0 == "<!-- /pr-status-slot:" s " -->" { flag=0 }
+                flag
+              ' existing.md)
+            fi
+            if [ -n "$content" ]; then
+              {
+                echo "<!-- pr-status-slot:$slot -->"
+                printf '%s\n' "$content"
+                echo "<!-- /pr-status-slot:$slot -->"
+                echo
+              } >> comment.md
             fi
           done
           if [ ! -s comment.md ]; then

--- a/.github/workflows/pr-status-comment.yml
+++ b/.github/workflows/pr-status-comment.yml
@@ -1,10 +1,10 @@
 name: PR Status Comment
 
-# Reusable: invoked by each workflow that uploads a `pr-comment-slot-<slot>`
-# artifact. Updates only the named slot's section of the unified sticky
+# Reusable: invoked by each workflow that uploads `pr-comment-slot-<slot>`
+# artifacts. Updates only the named slots' sections of the unified sticky
 # comment (header `pr-status`); other sections are preserved from the
-# existing comment so a slow-finishing workflow doesn't wipe out sections
-# that finished earlier (including those from a prior commit).
+# existing comment so a slow-finishing workflow doesn't wipe sections that
+# finished earlier (including those from a prior commit).
 #
 # Each section is delimited in the comment body with HTML markers:
 #   <!-- pr-status-slot:<slot> -->
@@ -21,8 +21,8 @@ on:
         description: Commit SHA the calling run is targeting
         required: true
         type: string
-      slot:
-        description: Slot name being refreshed (e.g. preview, host-tests, realm-tests)
+      slots:
+        description: Space-separated list of slot names this invocation refreshes
         required: true
         type: string
 
@@ -60,21 +60,20 @@ jobs:
           fi
           echo "number=$pr" >>"$GITHUB_OUTPUT"
 
-      - name: Download fresh slot artifact from this run
+      - name: Download fresh slot artifacts from this run
         if: steps.pr.outputs.skip != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
-          SLOT: ${{ inputs.slot }}
+          SLOTS: ${{ inputs.slots }}
         run: |
           set -euo pipefail
           mkdir -p fresh
-          # The slot was uploaded by an earlier job in the same workflow run.
-          # Failures here (e.g. uploader skipped) fall through to preserving
-          # whatever the existing comment has for this slot.
-          gh run download -R "$REPO" "$RUN_ID" \
-            -n "pr-comment-slot-$SLOT" -D fresh/ 2>/dev/null || true
+          for slot in $SLOTS; do
+            gh run download -R "$REPO" "$RUN_ID" \
+              -n "pr-comment-slot-$slot" -D "fresh/$slot/" 2>/dev/null || true
+          done
 
       - name: Fetch existing pr-status comment body
         if: steps.pr.outputs.skip != 'true'
@@ -85,9 +84,6 @@ jobs:
         run: |
           set -euo pipefail
           : > existing.md
-          # marocchino sticky-pull-request-comment marks its comment with
-          # this header so it can find and update it. Filter on that and on
-          # the github-actions bot author for safety.
           gh api --paginate "/repos/$REPO/issues/$PR/comments?per_page=100" \
             --jq '.[] | select(
                     .user.login == "github-actions[bot]"
@@ -99,31 +95,68 @@ jobs:
         if: steps.pr.outputs.skip != 'true'
         id: body
         env:
-          SLOT: ${{ inputs.slot }}
+          SLOTS: ${{ inputs.slots }}
         run: |
           set -euo pipefail
-          : > comment.md
-          # Fixed slot order. Add new slot names here as we add emitters.
-          for slot in preview host-tests realm-tests; do
-            content=""
-            if [ "$slot" = "$SLOT" ] && [ -s "fresh/slot.md" ]; then
-              content=$(cat fresh/slot.md)
-            else
-              content=$(awk -v s="$slot" '
-                $0 == "<!-- pr-status-slot:" s " -->" { flag=1; next }
-                $0 == "<!-- /pr-status-slot:" s " -->" { flag=0 }
-                flag
-              ' existing.md)
-            fi
+
+          get_content() {
+            local slot="$1"
+            local fresh_file="fresh/$slot/slot.md"
+            case " $SLOTS " in
+              *" $slot "*)
+                if [ -s "$fresh_file" ]; then
+                  cat "$fresh_file"
+                  return
+                fi
+                ;;
+            esac
+            awk -v s="$slot" '
+              $0 == "<!-- pr-status-slot:" s " -->" { flag=1; next }
+              $0 == "<!-- /pr-status-slot:" s " -->" { flag=0 }
+              flag
+            ' existing.md
+          }
+
+          emit_section() {
+            local slot="$1"
+            local content
+            content=$(get_content "$slot")
             if [ -n "$content" ]; then
-              {
-                echo "<!-- pr-status-slot:$slot -->"
-                printf '%s\n' "$content"
-                echo "<!-- /pr-status-slot:$slot -->"
-                echo
-              } >> comment.md
+              echo "<!-- pr-status-slot:$slot -->"
+              printf '%s\n' "$content"
+              echo "<!-- /pr-status-slot:$slot -->"
+              return 0
+            fi
+            return 1
+          }
+
+          : > comment.md
+
+          # Preview group: header rendered iff at least one preview-* slot
+          # has content; each link's bullet is its own delimited slot.
+          preview_buf=$(mktemp)
+          : > "$preview_buf"
+          have_preview=false
+          for slot in preview-host-staging preview-host-production preview-ui-staging; do
+            if emit_section "$slot" >>"$preview_buf"; then
+              have_preview=true
             fi
           done
+          if $have_preview; then
+            {
+              echo "### Preview deployments"
+              echo
+              cat "$preview_buf"
+              echo
+            } >> comment.md
+          fi
+
+          for slot in host-tests realm-tests; do
+            if emit_section "$slot" >>comment.md; then
+              echo >> comment.md
+            fi
+          done
+
           if [ ! -s comment.md ]; then
             echo "empty=true" >>"$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/pr-status-comment.yml
+++ b/.github/workflows/pr-status-comment.yml
@@ -75,7 +75,7 @@ jobs:
             while read -r name; do
               [ -n "$name" ] || continue
               [ -d "slots/$name" ] && continue
-              gh run download "$run_id" -n "$name" -D "slots/$name" || true
+              gh run download -R "$REPO" "$run_id" -n "$name" -D "slots/$name" || true
             done <<<"$artifacts"
           done < runs.txt
 

--- a/.github/workflows/pr-status-comment.yml
+++ b/.github/workflows/pr-status-comment.yml
@@ -1,0 +1,113 @@
+name: PR Status Comment
+
+# Aggregates per-workflow "slot" artifacts (named pr-comment-slot-*) into a
+# single sticky PR comment with header `pr-status`. Producing workflows upload
+# a `slot/slot.md` artifact; this workflow rebuilds the whole comment from
+# whatever slots currently exist for the PR's head SHA.
+#
+# Note: workflow_run runs in the context of the default branch, so edits to
+# this file only take effect after they land on main.
+
+on:
+  workflow_run:
+    workflows:
+      - Preview Host
+      - CI [boxel-ui]
+      - CI Host
+      - CI
+    types:
+      - completed
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  update-comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-status-comment-${{ github.event.workflow_run.head_branch }}
+      cancel-in-progress: false
+    steps:
+      - name: Resolve PR and check freshness
+        id: pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_FROM_EVENT: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          set -euo pipefail
+          pr="$PR_FROM_EVENT"
+          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
+            echo "No PR in event payload; skipping."
+            echo "skip=true" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          latest=$(gh api "/repos/$REPO/pulls/$pr" --jq '.head.sha')
+          if [ "$latest" != "$SHA" ]; then
+            echo "PR #$pr head is now $latest, event SHA $SHA is stale; skipping."
+            echo "skip=true" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "number=$pr" >>"$GITHUB_OUTPUT"
+          echo "sha=$SHA"   >>"$GITHUB_OUTPUT"
+
+      - name: Collect slot artifacts for this commit
+        if: steps.pr.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ steps.pr.outputs.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p slots
+
+          # Most recent runs first; first download per slot name wins.
+          gh api -X GET "/repos/$REPO/actions/runs" \
+            -f head_sha="$SHA" -f status=completed --paginate \
+            --jq '.workflow_runs[].id' > runs.txt
+
+          while read -r run_id; do
+            [ -n "$run_id" ] || continue
+            artifacts=$(
+              gh api "/repos/$REPO/actions/runs/$run_id/artifacts" --paginate \
+                --jq '.artifacts[].name' \
+              | grep '^pr-comment-slot-' || true
+            )
+            [ -n "$artifacts" ] || continue
+            while read -r name; do
+              [ -n "$name" ] || continue
+              [ -d "slots/$name" ] && continue
+              gh run download "$run_id" -n "$name" -D "slots/$name" || true
+            done <<<"$artifacts"
+          done < runs.txt
+
+      - name: Assemble comment body
+        if: steps.pr.outputs.skip != 'true'
+        id: body
+        run: |
+          set -euo pipefail
+          : > comment.md
+          # Fixed slot order. Add new slot names here as we migrate emitters.
+          for slot in preview host-tests realm-tests; do
+            f="slots/pr-comment-slot-$slot/slot.md"
+            if [ -s "$f" ]; then
+              cat "$f" >> comment.md
+              printf '\n\n' >> comment.md
+            fi
+          done
+          if [ ! -s comment.md ]; then
+            echo "empty=true" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Upsert sticky comment
+        if: steps.pr.outputs.skip != 'true' && steps.body.outputs.empty != 'true'
+        uses: marocchino/sticky-pull-request-comment@5060d4700a91de252c87eeddd2da026382d9298a # 2.9.4
+        with:
+          header: pr-status
+          number: ${{ steps.pr.outputs.number }}
+          path: comment.md

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -7,6 +7,10 @@ on:
         description: Commit SHA that produced the preview
         required: true
         type: string
+    outputs:
+      slots:
+        description: Space-separated list of preview slot names that were uploaded
+        value: ${{ jobs.publish-preview-comment.outputs.slots }}
 
 permissions:
   contents: read
@@ -14,11 +18,13 @@ permissions:
 jobs:
   publish-preview-comment:
     runs-on: ubuntu-latest
+    outputs:
+      slots: ${{ steps.gather.outputs.slots }}
     concurrency:
       group: publish-preview-comment-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - name: Gather preview links
+      - name: Gather preview links and write per-link slot files
         id: gather
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -39,37 +45,46 @@ jobs:
           host_production="$(echo "$statuses" | jq -r 'map(select(.context == "Preview boxel-host production")) | .[0].target_url // empty')"
           ui_staging="$(echo "$statuses" | jq -r 'map(select(.context == "Preview boxel-ui staging")) | .[0].target_url // empty')"
 
-          if [ -z "$host_staging$host_production$ui_staging" ]; then
-            echo "empty=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          slots=""
+          if [ -n "$host_staging" ]; then
+            mkdir -p slot-host-staging
+            printf -- '- [Host staging preview](%s)\n' "$host_staging" > slot-host-staging/slot.md
+            slots="$slots preview-host-staging"
+          fi
+          if [ -n "$host_production" ]; then
+            mkdir -p slot-host-production
+            printf -- '- [Host production preview](%s)\n' "$host_production" > slot-host-production/slot.md
+            slots="$slots preview-host-production"
+          fi
+          if [ -n "$ui_staging" ]; then
+            mkdir -p slot-ui-staging
+            printf -- '- [Boxel UI staging preview](%s)\n' "$ui_staging" > slot-ui-staging/slot.md
+            slots="$slots preview-ui-staging"
           fi
 
-          {
-            echo "message<<EOF"
-            echo "### Preview deployments"
-            echo
-            if [ -n "$host_staging" ]; then
-              echo "- [Host staging preview]($host_staging)"
-            fi
-            if [ -n "$host_production" ]; then
-              echo "- [Host production preview]($host_production)"
-            fi
-            if [ -n "$ui_staging" ]; then
-              echo "- [Boxel UI staging preview]($ui_staging)"
-            fi
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-      - name: Write preview slot file
-        if: steps.gather.outputs.empty != 'true'
-        env:
-          MESSAGE: ${{ steps.gather.outputs.message }}
-        run: |
-          mkdir -p slot
-          printf '%s\n' "$MESSAGE" > slot/slot.md
-      - name: Upload preview slot
-        if: steps.gather.outputs.empty != 'true'
+          slots="${slots# }"
+          echo "slots=$slots" >> "$GITHUB_OUTPUT"
+
+      - name: Upload host staging preview slot
+        if: contains(steps.gather.outputs.slots, 'preview-host-staging')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: pr-comment-slot-preview
-          path: slot/
+          name: pr-comment-slot-preview-host-staging
+          path: slot-host-staging/
+          retention-days: 7
+
+      - name: Upload host production preview slot
+        if: contains(steps.gather.outputs.slots, 'preview-host-production')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-comment-slot-preview-host-production
+          path: slot-host-production/
+          retention-days: 7
+
+      - name: Upload UI staging preview slot
+        if: contains(steps.gather.outputs.slots, 'preview-ui-staging')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-comment-slot-preview-ui-staging
+          path: slot-ui-staging/
           retention-days: 7

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -3,10 +3,6 @@ name: Preview Deployment Comment
 on:
   workflow_call:
     inputs:
-      pr-number:
-        description: Pull request number to comment on
-        required: true
-        type: number
       head-sha:
         description: Commit SHA that produced the preview
         required: true
@@ -14,8 +10,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 jobs:
   publish-preview-comment:
@@ -65,10 +59,17 @@ jobs:
             fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
-      - name: Post preview links comment
+      - name: Write preview slot file
         if: steps.gather.outputs.empty != 'true'
-        uses: marocchino/sticky-pull-request-comment@5060d4700a91de252c87eeddd2da026382d9298a # 2.9.4
+        env:
+          MESSAGE: ${{ steps.gather.outputs.message }}
+        run: |
+          mkdir -p slot
+          printf '%s\n' "$MESSAGE" > slot/slot.md
+      - name: Upload preview slot
+        if: steps.gather.outputs.empty != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          header: preview-deployments
-          number: ${{ inputs.pr-number }}
-          message: ${{ steps.gather.outputs.message }}
+          name: pr-comment-slot-preview
+          path: slot/
+          retention-days: 7

--- a/.github/workflows/preview-host.yml
+++ b/.github/workflows/preview-host.yml
@@ -129,4 +129,5 @@ jobs:
       actions: read
     with:
       head-sha: ${{ github.event.pull_request.head.sha }}
+      slot: preview
     secrets: inherit

--- a/.github/workflows/preview-host.yml
+++ b/.github/workflows/preview-host.yml
@@ -115,3 +115,13 @@ jobs:
     with:
       head-sha: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
+
+  post-pr-status:
+    name: Update PR status comment
+    needs:
+      - post-preview-comment
+    if: ${{ !cancelled() && needs.post-preview-comment.result == 'success' }}
+    uses: ./.github/workflows/pr-status-comment.yml
+    with:
+      head-sha: ${{ github.event.pull_request.head.sha }}
+    secrets: inherit

--- a/.github/workflows/preview-host.yml
+++ b/.github/workflows/preview-host.yml
@@ -120,7 +120,7 @@ jobs:
     name: Update PR status comment
     needs:
       - post-preview-comment
-    if: ${{ !cancelled() && needs.post-preview-comment.result == 'success' }}
+    if: ${{ !cancelled() && needs.post-preview-comment.result == 'success' && needs.post-preview-comment.outputs.slots != '' }}
     uses: ./.github/workflows/pr-status-comment.yml
     permissions:
       contents: read
@@ -129,5 +129,5 @@ jobs:
       actions: read
     with:
       head-sha: ${{ github.event.pull_request.head.sha }}
-      slot: preview
+      slots: ${{ needs.post-preview-comment.outputs.slots }}
     secrets: inherit

--- a/.github/workflows/preview-host.yml
+++ b/.github/workflows/preview-host.yml
@@ -113,6 +113,5 @@ jobs:
     if: ${{ !cancelled() && (needs.deploy-host-preview-staging.result == 'success' || needs.deploy-host-preview-production.result == 'success') }}
     uses: ./.github/workflows/preview-comment.yml
     with:
-      pr-number: ${{ github.event.pull_request.number }}
       head-sha: ${{ github.event.pull_request.head.sha }}
     secrets: inherit

--- a/.github/workflows/preview-host.yml
+++ b/.github/workflows/preview-host.yml
@@ -122,6 +122,11 @@ jobs:
       - post-preview-comment
     if: ${{ !cancelled() && needs.post-preview-comment.result == 'success' }}
     uses: ./.github/workflows/pr-status-comment.yml
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      actions: read
     with:
       head-sha: ${{ github.event.pull_request.head.sha }}
     secrets: inherit

--- a/packages/boxel-ui/README.md
+++ b/packages/boxel-ui/README.md
@@ -1,4 +1,4 @@
-## How to build this addon!
+## How to build this addon
 
 ### `pnpm build` in the addon/ dir
 

--- a/packages/boxel-ui/README.md
+++ b/packages/boxel-ui/README.md
@@ -1,4 +1,4 @@
-## How to build this addon
+## How to build this addon!
 
 ### `pnpm build` in the addon/ dir
 


### PR DESCRIPTION
Instead of three comments (and therefore emails), I want them to all be in one:

<img width="906" height="873" alt="image" src="https://github.com/user-attachments/assets/28233f4f-20e6-4659-8534-561ad63cd25c" />

You can see the three-in-one comment in this PR, each “slot” can be independently updated as jobs finish, leaving the other slots alone.