### PR TITLE
Wire Loki as a Grafana data source on staging + production

### DIFF
--- a/.github/workflows/observability-apply-production.yml
+++ b/.github/workflows/observability-apply-production.yml
@@ -122,7 +122,11 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Source GRAFANA_TOKEN from SSM
+      - name: Source GRAFANA_TOKEN and LOKI_URL from SSM
+        # GRAFANA_TOKEN authenticates `grafanactl resources push` (dashboards
+        # + folders) and `apply-datasources.sh` (data sources via HTTP API).
+        # LOKI_URL is substituted into provisioning/datasources/loki.yaml at
+        # push time so the data source points at the in-VPC Loki NLB.
         run: |
           GRAFANA_TOKEN="$(aws ssm get-parameter \
             --name /production/grafana/grafanactl_token \
@@ -131,6 +135,12 @@ jobs:
             --output text)"
           echo "::add-mask::$GRAFANA_TOKEN"
           echo "GRAFANA_TOKEN=$GRAFANA_TOKEN" >> "$GITHUB_ENV"
+
+          LOKI_URL="$(aws ssm get-parameter \
+            --name /production/loki/internal_url \
+            --query 'Parameter.Value' \
+            --output text)"
+          echo "LOKI_URL=$LOKI_URL" >> "$GITHUB_ENV"
 
       - name: Apply
         working-directory: packages/observability

--- a/.github/workflows/observability-apply-production.yml
+++ b/.github/workflows/observability-apply-production.yml
@@ -54,9 +54,10 @@ jobs:
 
     env:
       AWS_REGION: us-east-1
-      # Dedicated, narrowly-scoped role created in cardstack/infra#666
-      # (configs/boxel-observability-apply/production). Has exactly one
-      # permission: ssm:GetParameter on /production/grafana/grafanactl_token.
+      # Dedicated, narrowly-scoped role at configs/boxel-observability-apply/production
+      # in cardstack/infra. Permissions are ssm:GetParameter on:
+      #   /production/grafana/grafanactl_token  (added in cardstack/infra#666)
+      #   /production/loki/internal_url         (added in cardstack/infra#674, CS-10968)
       AWS_ROLE_ARN: arn:aws:iam::120317779495:role/boxel-observability-apply
       # Server URL is NOT set here — single source of truth is
       # packages/observability/grafanactl/config.yaml (see staging workflow

--- a/.github/workflows/observability-apply-staging.yml
+++ b/.github/workflows/observability-apply-staging.yml
@@ -67,10 +67,12 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Source GRAFANA_TOKEN from SSM
+      - name: Source GRAFANA_TOKEN and LOKI_URL from SSM
         # Mirrors what packages/observability/scripts/grafanactl-env.sh does
         # locally. Inline here so the workflow doesn't depend on bash from
         # the repo working dir before checkout-related env vars are stable.
+        # LOKI_URL is read by apply-datasources.sh and substituted into the
+        # provisioning/datasources/loki.yaml at push time.
         run: |
           GRAFANA_TOKEN="$(aws ssm get-parameter \
             --name /staging/grafana/grafanactl_token \
@@ -81,6 +83,12 @@ jobs:
           # downstream tool echoes it. Then export to subsequent steps.
           echo "::add-mask::$GRAFANA_TOKEN"
           echo "GRAFANA_TOKEN=$GRAFANA_TOKEN" >> "$GITHUB_ENV"
+
+          LOKI_URL="$(aws ssm get-parameter \
+            --name /staging/loki/internal_url \
+            --query 'Parameter.Value' \
+            --output text)"
+          echo "LOKI_URL=$LOKI_URL" >> "$GITHUB_ENV"
 
       - name: Apply
         # apply.sh sources its own grafanactl-env.sh helper, which for

--- a/.github/workflows/observability-apply-staging.yml
+++ b/.github/workflows/observability-apply-staging.yml
@@ -33,12 +33,13 @@ jobs:
 
     env:
       AWS_REGION: us-east-1
-      # Dedicated, narrowly-scoped role created in cardstack/infra#665
-      # (configs/boxel-observability-apply/staging). Has exactly one
-      # permission: ssm:GetParameter on /staging/grafana/grafanactl_token.
-      # If the role doesn't exist yet (infra PR not applied), the
-      # configure-aws-credentials step below will fail with "InvalidIdentityToken"
-      # or similar — apply the infra config first.
+      # Dedicated, narrowly-scoped role at configs/boxel-observability-apply/staging
+      # in cardstack/infra. Permissions are ssm:GetParameter on:
+      #   /staging/grafana/grafanactl_token  (added in cardstack/infra#665)
+      #   /staging/loki/internal_url         (added in cardstack/infra#674, CS-10968)
+      # If the role doesn't exist or is missing one of those grants, the
+      # configure-aws-credentials step below will succeed but the SSM
+      # fetch step will fail with AccessDenied — apply the infra config first.
       AWS_ROLE_ARN: arn:aws:iam::680542703984:role/boxel-observability-apply
       # Server URL deliberately NOT set here. The committed
       # packages/observability/grafanactl/config.yaml is the single source of

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -19,9 +19,9 @@ There are **two source-of-truth trees** in this package, because Grafana 12 mana
 | `grafanactl/resources/` | `grafanactl resources push` | Dashboards, folders                       | API push (CI on merge)                            |
 | `provisioning/`        | Grafana built-in file provisioning | Data sources, alert rules, contact points | Files mounted at `/etc/grafana/provisioning/`, read at startup |
 
-**Why two trees?** `grafanactl` (Grafana Labs' official CLI replacing the archived Grizzly) only manages App Platform resources — `grafanactl resources list` shows dashboards, folders, playlists, snapshots, but **not data sources or alert rules**. Those still live behind the legacy HTTP API and are best managed via Grafana's built-in file provisioning, which natively supports `${ENV_VAR}` substitution at startup.
+**Why two trees?** `grafanactl` (Grafana Labs' official CLI replacing the archived Grizzly) only manages App Platform resources — `grafanactl resources list` shows dashboards, folders, playlists, snapshots, but **not data sources or alert rules**. Those still live behind the legacy HTTP API.
 
-For staging and production, the `provisioning/` tree gets delivered to the ECS Grafana container (via image bake, S3-init, or EFS mount — TBD in a separate infra ticket). Container restart picks up changes; a Grafana admin API endpoint (`/api/admin/provisioning/datasources/reload`) can refresh without restart if needed.
+Locally, `provisioning/` files are mounted into the Grafana container by `docker-compose.yml` and read at startup with `${ENV_VAR}` substitution. **For staging and production, `apply-datasources.sh` reads the same YAML files, env-var-substitutes them (e.g. `${LOKI_URL}` from SSM `/<env>/loki/internal_url`), and upserts each entry through Grafana's `/api/datasources` HTTP API** — a small bridge that gives us file-as-source-of-truth without needing image bakes or EFS mounts on the hosted side.
 
 ## Layout
 
@@ -43,6 +43,8 @@ loki/
                        # historical Docker logs)
 scripts/
   apply.sh             # ./scripts/apply.sh --env <local|staging|production>
+  apply-datasources.sh # internal — pushes provisioning/datasources/* via HTTP API
+                       # (called by apply.sh; staging/production only)
   pull.sh              # ./scripts/pull.sh  --env <name> --path <dir>
   check.sh             # ./scripts/check.sh --env <name>  (connectivity smoke test)
   tail-logs.sh         # ./scripts/tail-logs.sh --env <name> --service <task family>
@@ -301,7 +303,7 @@ CI will run `apply.sh --env staging` on merge to main once Phase 4 (CS-10932) la
 | CS-10917  | 2.5   | landed      | FireLens dual-ship (5 task families × 2 envs) |
 | CS-10920  | 2.5   | this PR     | `tail-logs.sh` + Claude agent skill      |
 | CS-10921  | 2.5   | landed      | Loki + tail-logs README                  |
-| CS-10968  | 2.5   | not started | Hosted Grafana → Loki data source wiring |
+| CS-10968  | 2.5   | this PR     | Hosted Grafana → Loki data source wiring |
 | CS-10922  | 3     | landed      | AMG export and reformat                  |
 | CS-10932  | 4     | landed      | CI: apply to staging on merge            |
 | CS-10933  | 4     | not started | CI: post diff comment on PRs             |
@@ -313,8 +315,6 @@ CI will run `apply.sh --env staging` on merge to main once Phase 4 (CS-10932) la
 
 ## Known cleanups (deferred)
 
-- **Hosted Grafana → Loki data source wiring.** The staging / production ECS Grafana tasks don't yet have `LOKI_URL` set or `provisioning/datasources/loki.yaml` mounted, so Grafana → Explore → Loki returns "no data source" against the hosted environments even though Loki itself is up. Direct curl / `logcli` against `/<env>/loki/public_url` works today.
-- **`provisioning/` delivery to staging/production ECS.** The provisioning files (data sources + alert rules) need to land on the ECS Grafana container — image bake, S3-init, or EFS mount. Decide and ship as a separate infra ticket.
-- **Secret env-var wiring for data sources.** `provisioning/datasources/*.json` omits `secureJsonData` (passwords, API keys). The staging/production ECS Grafana task needs those env vars set from SSM (`GRAFANA_DB_PASSWORD` etc.) and the provisioning files updated to reference them via `${ENV_VAR}`.
+- **Secret env-var wiring for data sources.** `apply-datasources.sh` doesn't yet support `secureJsonData` (passwords, API keys). Loki doesn't need any (auth at the ALB layer). When Postgres / Prometheus / CloudWatch migrate over from the AMG-era `boxel-dashboard/` Terraform, the script needs SSM-backed secret resolution.
 - **Drop the dual-ship to CloudWatch** once Loki has been load-bearing for a release cycle. Until then both backends receive identical lines through the FireLens config in `cardstack/infra:modules/aws/ecs/firelens/templates/extra.conf.tftpl`.
 - **CODEOWNERS.** No file in the repo today — if the team wants observability-specific reviewer requirements, file a separate ticket.

--- a/packages/observability/scripts/apply-datasources.sh
+++ b/packages/observability/scripts/apply-datasources.sh
@@ -40,9 +40,17 @@ fail() { echo "error: $1" >&2; exit 1; }
 env_name=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --env)    env_name="$2"; shift 2;;
-    --env=*)  env_name="${1#--env=}"; shift;;
-    *)        usage_error "unknown option: $1";;
+    --env)
+      [[ $# -ge 2 && "$2" != -* ]] || usage_error "--env requires a value"
+      env_name="$2"
+      shift 2
+      ;;
+    --env=*)
+      env_name="${1#--env=}"
+      [[ -n "$env_name" ]] || usage_error "--env requires a value"
+      shift
+      ;;
+    *) usage_error "unknown option: $1";;
   esac
 done
 
@@ -87,10 +95,13 @@ upsert() {
     -H "Authorization: Bearer ${GRAFANA_TOKEN}" \
     "${grafana_server}/api/datasources/uid/${uid}")"
 
+  # `--fail-with-body` makes curl exit non-zero on 4xx/5xx and still print
+  # the response body, so a 401/403/500 on the upsert fails the script
+  # instead of silently logging a "successful" no-op.
   case "$http_status" in
     200)
       echo "  ↻ updating ${uid}" >&2
-      curl -sS -X PUT \
+      curl -sS --fail-with-body -X PUT \
         -H "Authorization: Bearer ${GRAFANA_TOKEN}" \
         -H "Content-Type: application/json" \
         --data-binary "$payload" \
@@ -99,7 +110,7 @@ upsert() {
       ;;
     404)
       echo "  + creating ${uid}" >&2
-      curl -sS -X POST \
+      curl -sS --fail-with-body -X POST \
         -H "Authorization: Bearer ${GRAFANA_TOKEN}" \
         -H "Content-Type: application/json" \
         --data-binary "$payload" \
@@ -115,6 +126,17 @@ upsert() {
 shopt -s nullglob
 files=(provisioning/datasources/*.yaml)
 [[ "${#files[@]}" -gt 0 ]] || { echo "no datasource yaml files found" >&2; exit 0; }
+
+# Loud warning if the AMG-extracted JSON manifests are still around but
+# unprocessed — see CS-10978 follow-up. They have hardcoded staging
+# hostnames, so blindly pushing them to prod would silently create
+# wrong-pointing data sources. Migrate to YAML + ${VAR} placeholders
+# before adding them to the glob.
+skipped=(provisioning/datasources/*.json)
+if [[ "${#skipped[@]}" -gt 0 ]]; then
+  echo "apply-datasources: WARN — skipping JSON manifests (need per-env URL templating before push, see CS-10978):" >&2
+  for s in "${skipped[@]}"; do echo "    skip: $s" >&2; done
+fi
 
 echo "apply-datasources: env=${env_name} server=${grafana_server} files=${#files[@]}" >&2
 

--- a/packages/observability/scripts/apply-datasources.sh
+++ b/packages/observability/scripts/apply-datasources.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Push data source manifests in `provisioning/datasources/` to a hosted
+# Grafana via the legacy HTTP API. grafanactl doesn't manage data sources
+# (its `resources list` covers App Platform kinds only — dashboards,
+# folders, playlists, etc.), so we go straight to /api/datasources.
+#
+# Local mode is a no-op: docker-compose mounts `provisioning/datasources/`
+# into the container and Grafana provisions from the file directly. This
+# script only runs against staging / production.
+#
+# Usage:
+#   ./scripts/apply-datasources.sh --env <local|staging|production>
+#
+# Required env vars (staging / production only):
+#   GRAFANA_TOKEN — service-account token (sourced by grafanactl-env.sh)
+#   LOKI_URL      — internal Loki NLB URL (e.g. http://<nlb>:3100), pulled
+#                   from SSM /<env>/loki/internal_url at apply time
+#
+# What it pushes:
+#   - Each `.yaml` in `provisioning/datasources/` is read as the standard
+#     Grafana provisioning shape (`apiVersion: 1` + `datasources: [...]`).
+#   - For each datasource entry, env-var references like `${LOKI_URL}`
+#     are substituted from the current shell environment.
+#   - The result is upserted: PUT `/api/datasources/uid/<uid>` if it
+#     exists, POST `/api/datasources` otherwise.
+#
+# Caveats:
+#   - The file-provisioning `editable: false` field doesn't have a direct
+#     HTTP-API equivalent. Hosted data sources created here remain
+#     UI-editable; re-running this script overwrites any UI edits, so
+#     git stays the source of truth in practice.
+#   - `secureJsonData` (passwords, API keys) is not yet supported here —
+#     Loki doesn't need any (auth is at the ALB layer). Add SSM-backed
+#     secret resolution when Postgres / Prometheus migrate over.
+set -eo pipefail
+
+usage_error() { echo "error: $1" >&2; exit 2; }
+fail() { echo "error: $1" >&2; exit 1; }
+
+env_name=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env)    env_name="$2"; shift 2;;
+    --env=*)  env_name="${1#--env=}"; shift;;
+    *)        usage_error "unknown option: $1";;
+  esac
+done
+
+[[ -n "$env_name" ]] || usage_error "missing --env"
+
+case "$env_name" in
+  local)
+    echo "apply-datasources: local — skipped (file provisioning handles it)" >&2
+    exit 0
+    ;;
+  staging | production)
+    ;;
+  *)
+    usage_error "--env must be local, staging, or production (got: $env_name)"
+    ;;
+esac
+
+for cmd in yq jq curl envsubst; do
+  command -v "$cmd" >/dev/null \
+    || fail "missing dependency: ${cmd}. Install via brew (yq, jq, gettext for envsubst) or apt (yq, jq, gettext-base)."
+done
+
+[[ -n "${GRAFANA_TOKEN:-}" ]] || fail "GRAFANA_TOKEN not set; run \`source ./scripts/grafanactl-env.sh ${env_name}\` first"
+[[ -n "${LOKI_URL:-}" ]]      || fail "LOKI_URL not set; expected /\${env}/loki/internal_url to be sourced into the environment"
+
+cd "$(dirname "$0")/.."
+
+# Pull the per-env Grafana server URL from grafanactl's committed config so
+# this script and grafanactl always agree on the target host.
+grafana_server="$(yq -r ".contexts.${env_name}.grafana.server" grafanactl/config.yaml)"
+[[ -n "$grafana_server" && "$grafana_server" != "null" ]] \
+  || fail "couldn't resolve grafana server for context '${env_name}' from grafanactl/config.yaml"
+
+upsert() {
+  local payload="$1"
+  local uid http_status
+  uid="$(jq -r '.uid' <<<"$payload")"
+  [[ -n "$uid" && "$uid" != "null" ]] || fail "datasource entry missing uid: $payload"
+
+  # Probe whether this uid already exists.
+  http_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+    -H "Authorization: Bearer ${GRAFANA_TOKEN}" \
+    "${grafana_server}/api/datasources/uid/${uid}")"
+
+  case "$http_status" in
+    200)
+      echo "  ↻ updating ${uid}" >&2
+      curl -sS -X PUT \
+        -H "Authorization: Bearer ${GRAFANA_TOKEN}" \
+        -H "Content-Type: application/json" \
+        --data-binary "$payload" \
+        "${grafana_server}/api/datasources/uid/${uid}" \
+        | jq -r '.message // .name // .'
+      ;;
+    404)
+      echo "  + creating ${uid}" >&2
+      curl -sS -X POST \
+        -H "Authorization: Bearer ${GRAFANA_TOKEN}" \
+        -H "Content-Type: application/json" \
+        --data-binary "$payload" \
+        "${grafana_server}/api/datasources" \
+        | jq -r '.message // .name // .'
+      ;;
+    *)
+      fail "probe for ${uid} returned HTTP ${http_status} (expected 200 or 404)"
+      ;;
+  esac
+}
+
+shopt -s nullglob
+files=(provisioning/datasources/*.yaml)
+[[ "${#files[@]}" -gt 0 ]] || { echo "no datasource yaml files found" >&2; exit 0; }
+
+echo "apply-datasources: env=${env_name} server=${grafana_server} files=${#files[@]}" >&2
+
+for f in "${files[@]}"; do
+  echo "→ ${f}" >&2
+  # Each file is `apiVersion: 1` + `datasources: [...]`. Pull the entries
+  # out as JSON one per line, envsubst them so ${LOKI_URL} etc. resolve,
+  # then upsert each one.
+  yq -o json -I0 '.datasources[]' "$f" | while IFS= read -r raw; do
+    payload="$(envsubst <<<"$raw")"
+    upsert "$payload"
+  done
+done
+
+echo "apply-datasources: done" >&2

--- a/packages/observability/scripts/apply.sh
+++ b/packages/observability/scripts/apply.sh
@@ -53,3 +53,7 @@ grafanactl \
   resources push \
   --path ./grafanactl/resources \
   "${forwarded_args[@]}"
+
+# Data sources — grafanactl doesn't manage them, so push via HTTP API.
+# Local skips this (docker-compose handles file provisioning).
+./scripts/apply-datasources.sh --env "$env_name"

--- a/packages/observability/scripts/apply.sh
+++ b/packages/observability/scripts/apply.sh
@@ -44,6 +44,20 @@ cd "$(dirname "$0")/.."
 # shellcheck source=./grafanactl-env.sh
 source ./scripts/grafanactl-env.sh "$env_name"
 
+# Pre-flight prereqs for hosted envs BEFORE grafanactl pushes anything.
+# Otherwise a missing LOKI_URL or absent yq would surface only after
+# dashboards/folders had already been re-pushed, leaving a partial apply.
+if [[ "$env_name" != "local" ]]; then
+  for cmd in yq jq curl envsubst; do
+    command -v "$cmd" >/dev/null \
+      || { echo "error: missing dependency: ${cmd}" >&2; exit 1; }
+  done
+  [[ -n "${GRAFANA_TOKEN:-}" ]] \
+    || { echo "error: GRAFANA_TOKEN not set after sourcing grafanactl-env.sh" >&2; exit 1; }
+  [[ -n "${LOKI_URL:-}" ]] \
+    || { echo "error: LOKI_URL not set; expected /${env_name}/loki/internal_url to be sourced into the environment" >&2; exit 1; }
+fi
+
 cfg="$(./scripts/render-config.sh "$env_name")"
 trap 'rm -f "$cfg"' EXIT
 


### PR DESCRIPTION
## Summary

CS-10968. After Phase 2.5 shipped, hosted Grafana didn't know about Loki — direct curl / `logcli` / `tail-logs.sh` worked but **Grafana → Explore → Loki** returned "no data source." This wires it up so dashboard log panels and the Explore UI can hit Loki.

### Approach

`grafanactl` doesn't manage data sources, so we bridge through Grafana's HTTP API:

- New `scripts/apply-datasources.sh` reads each `.yaml` in `provisioning/datasources/`, env-var-substitutes (`${LOKI_URL}` etc.) and upserts via `POST /api/datasources` (or PUT by uid if it exists).
- `scripts/apply.sh` calls it after `grafanactl resources push` so a single command applies dashboards, folders, AND data sources.
- Local mode is a no-op — docker-compose mounts the same `provisioning/` tree into the container, so file-based provisioning handles it. (HTTP API push against the file-provisioned data source fails with "Cannot update read-only" — the script's local skip avoids this.)
- Both `observability-apply-staging.yml` and `observability-apply-production.yml` workflows fetch `LOKI_URL` from `/<env>/loki/internal_url` SSM in addition to the existing `GRAFANA_TOKEN`.

### Why HTTP API and not image bake / EFS / S3-init

Image bake means the boxel CI workflow (this repo) has to push a Docker image to an ECR registry in the infra account, plus there's a cross-repo dependency (the Grafana ECS task in `cardstack/infra` would need to point at our image tag, which complicates rollbacks). EFS / S3-init keep file provisioning but add infra moving parts. The HTTP API bridge keeps everything in this repo, reuses the existing `GRAFANA_TOKEN` auth that grafanactl already uses, and the conversion (yq + envsubst) is one short bash file.

The committed YAML stays the source of truth — if the data source drifts in the UI, the next apply overwrites it. We accept that hosted data sources won't be UI-read-only (HTTP API doesn't honor `editable: false` the same way file provisioning does).

## Companion PR

Requires **[cardstack/infra#674](https://github.com/cardstack/infra/pull/674)** — adds `ssm:GetParameter` on `/<env>/loki/internal_url` to the existing `boxel-observability-apply` IAM role. Apply that first; this workflow fails fetching the SSM parameter otherwise.

## Test plan

- [x] Local: `./scripts/apply.sh --env local` skips `apply-datasources.sh` cleanly (file provisioning still authoritative).
- [x] Manual upsert smoke test against a docker-compose Grafana confirms the PUT/POST/probe flow.
- [ ] After merge + infra#674 apply: next staging observability-apply CI run pushes the Loki data source.
- [ ] In Grafana staging UI, Explore → Loki returns Loki as a data source; `{env="staging", service="realm-server"}` returns lines.
- [ ] Same on production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)