### PR TITLE
claude-aws: add --reset to wipe cached source-profile choices

### DIFF
--- a/.claude/skills/aws-access/SKILL.md
+++ b/.claude/skills/aws-access/SKILL.md
@@ -58,7 +58,7 @@ The first time the user runs `mise run claude-aws staging <token>`, the script w
 Source AWS profile for staging:
 ```
 
-Type the source profile name (e.g. `cardstack`). It's saved to `~/.config/claude-aws/config` and never prompted for again unless the user passes `--source-profile <name>` to override. Same dance for prod the first time `mise run claude-aws prod <token>` is run.
+Type the source profile name (e.g. `cardstack`). It's saved to `${XDG_CONFIG_HOME:-~/.config}/claude-aws/config` (the XDG config directory; default is `~/.config/claude-aws/config`) and never prompted for again unless the user passes `--source-profile <name>` to override. Same dance for prod the first time `mise run claude-aws prod <token>` is run.
 
 If you typed the wrong profile name (or want to clear the cache for any reason), run:
 
@@ -66,7 +66,7 @@ If you typed the wrong profile name (or want to clear the cache for any reason),
 mise run claude-aws --reset
 ```
 
-That wipes `~/.config/claude-aws/config` so the next normal invocation prompts again from scratch. `--reset` takes no other arguments — just `--reset`, no env, no token. Equivalent shortcut to deleting the config file by hand.
+That wipes the config file (path above) so the next normal invocation prompts again from scratch. `--reset` takes no other arguments — just `--reset`, no env, no token. It does not require `aws` / `jq` to be installed, so it's also the right recovery path on a freshly-cloned machine before the rest of the prereqs are in place. Equivalent shortcut to deleting the config file by hand.
 
 ### 3. Per-session — refresh the role-assumed credentials (every ~12h)
 

--- a/.claude/skills/aws-access/SKILL.md
+++ b/.claude/skills/aws-access/SKILL.md
@@ -60,6 +60,14 @@ Source AWS profile for staging:
 
 Type the source profile name (e.g. `cardstack`). It's saved to `~/.config/claude-aws/config` and never prompted for again unless the user passes `--source-profile <name>` to override. Same dance for prod the first time `mise run claude-aws prod <token>` is run.
 
+If you typed the wrong profile name (or want to clear the cache for any reason), run:
+
+```sh
+mise run claude-aws --reset
+```
+
+That wipes `~/.config/claude-aws/config` so the next normal invocation prompts again from scratch. `--reset` takes no other arguments — just `--reset`, no env, no token. Equivalent shortcut to deleting the config file by hand.
+
 ### 3. Per-session — refresh the role-assumed credentials (every ~12h)
 
 ```sh
@@ -78,7 +86,7 @@ After that, Claude can run any `aws --profile claude-staging ...` or `aws --prof
 | `mise ERROR no task claude-aws found` | They typed it wrong (common: `cluade-aws`) or the mise task file is missing — re-clone or pull main. |
 | `An error occurred (AccessDenied) … MultiFactorAuthentication failed with invalid MFA one time pass code` | The token expired before they hit enter. Wait for a fresh code and try again. |
 | `No source AWS profile is configured for 'staging'.` followed by a list | Expected on first run. Type the source profile name (most teammates use `cardstack` / `cardstack-prod` but it varies). |
-| `No MFA device registered for profile <name>` | They picked the wrong source profile, or their IAM user actually has no MFA. List MFA devices: `aws iam list-mfa-devices --profile <profile>`. |
+| `No MFA device registered for profile <name>` | They picked the wrong source profile (cached on first run). List MFA devices: `aws iam list-mfa-devices --profile <profile>`. To clear the bad choice and re-prompt, run `mise run claude-aws --reset`, then re-run with the right profile. |
 | `An error occurred (AccessDenied) when calling the AssumeRole operation: User: ... is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::...:role/boxel-claude-readonly` | Either the infra side of CS-10962 hasn't been applied to that account yet (so the role doesn't exist or doesn't trust the user's group), or the user's IAM user isn't in `read-only` or `full-access`. Check role existence: `aws --profile <source> iam get-role --role-name boxel-claude-readonly`. |
 | `An error occurred (NoRegion)` when Claude later runs `aws --profile claude-staging …` | They ran the script on an old version that didn't carry region forward. Either re-run `mise run claude-aws <env> <token>` (the current script copies the region from the source profile), or set it manually: `aws configure set region us-east-1 --profile claude-staging`. |
 

--- a/scripts/claude-aws.sh
+++ b/scripts/claude-aws.sh
@@ -33,6 +33,13 @@
 #   --source-profile <name>   override / set the source AWS profile to use
 #                             for this env (cached for next time)
 #
+# Reset:
+#   claude-aws --reset        wipes ~/.config/claude-aws/config so the
+#                             interactive source-profile prompt fires
+#                             from scratch on the next run. Useful if
+#                             you typed the wrong profile name. Takes
+#                             no other arguments.
+#
 # On first run for a given env, the script prompts for the source AWS
 # profile (since teammates pick their own profile names) and caches the
 # choice in ~/.config/claude-aws/config.
@@ -69,6 +76,7 @@ ROLE_DURATION_SECONDS=43200
 
 usage() {
     echo "Usage: $0 <staging|prod> <MFA_TOKEN> [--source-profile <name>]" >&2
+    echo "   or: $0 --reset       (wipe cached source-profile choices)" >&2
     echo "Example: $0 staging 123456" >&2
     exit 1
 }
@@ -78,6 +86,7 @@ usage() {
 ENV_NAME=""
 MFA_TOKEN=""
 SOURCE_PROFILE_OVERRIDE=""
+RESET=0
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -88,6 +97,13 @@ while [ "$#" -gt 0 ]; do
                 usage
             fi
             shift 2
+            ;;
+        --reset)
+            # Wipe ~/.config/claude-aws/config — forgets all cached
+            # source-profile choices. Useful when you typed the wrong
+            # profile name and want the prompt back from a clean slate.
+            RESET=1
+            shift
             ;;
         -h|--help)
             usage
@@ -105,6 +121,20 @@ while [ "$#" -gt 0 ]; do
             ;;
     esac
 done
+
+if [ "$RESET" -eq 1 ]; then
+    if [ -n "$ENV_NAME" ] || [ -n "$MFA_TOKEN" ] || [ -n "$SOURCE_PROFILE_OVERRIDE" ]; then
+        echo "--reset takes no other arguments" >&2
+        usage
+    fi
+    if [ -f "$CONFIG_FILE" ]; then
+        rm -f "$CONFIG_FILE"
+        echo "Cleared $CONFIG_FILE" >&2
+    else
+        echo "Nothing to clear (no $CONFIG_FILE)" >&2
+    fi
+    exit 0
+fi
 
 if [ -z "$ENV_NAME" ] || [ -z "$MFA_TOKEN" ]; then
     usage

--- a/scripts/claude-aws.sh
+++ b/scripts/claude-aws.sh
@@ -34,15 +34,16 @@
 #                             for this env (cached for next time)
 #
 # Reset:
-#   claude-aws --reset        wipes ~/.config/claude-aws/config so the
-#                             interactive source-profile prompt fires
-#                             from scratch on the next run. Useful if
-#                             you typed the wrong profile name. Takes
-#                             no other arguments.
+#   claude-aws --reset        wipes ${XDG_CONFIG_HOME:-~/.config}/claude-aws/config
+#                             so the interactive source-profile prompt
+#                             fires from scratch on the next run. Useful
+#                             if you typed the wrong profile name. Takes
+#                             no other arguments. Does not need aws/jq
+#                             installed.
 #
 # On first run for a given env, the script prompts for the source AWS
 # profile (since teammates pick their own profile names) and caches the
-# choice in ~/.config/claude-aws/config.
+# choice at ${XDG_CONFIG_HOME:-~/.config}/claude-aws/config.
 #
 # After running, Claude can run:
 #   aws --profile claude-staging <command>
@@ -52,6 +53,9 @@ set -euo pipefail
 
 # Fail early with a clear hint if a required dep is missing — without
 # this, the user gets an opaque "jq: command not found" mid-script.
+# Defined here, but the aws/jq invocations live below the --reset
+# early-exit so a teammate without aws/jq installed can still run
+# `claude-aws --reset` to recover from a bad cached source-profile.
 require_command() {
     if ! command -v "$1" >/dev/null 2>&1; then
         echo "Error: required command '$1' is not installed or not on PATH." >&2
@@ -59,8 +63,6 @@ require_command() {
         exit 1
     fi
 }
-require_command aws
-require_command jq
 
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/claude-aws"
 CONFIG_FILE="$CONFIG_DIR/config"
@@ -99,9 +101,9 @@ while [ "$#" -gt 0 ]; do
             shift 2
             ;;
         --reset)
-            # Wipe ~/.config/claude-aws/config — forgets all cached
-            # source-profile choices. Useful when you typed the wrong
-            # profile name and want the prompt back from a clean slate.
+            # Wipe $CONFIG_FILE — forgets all cached source-profile
+            # choices. Useful when you typed the wrong profile name and
+            # want the prompt back from a clean slate.
             RESET=1
             shift
             ;;
@@ -139,6 +141,10 @@ fi
 if [ -z "$ENV_NAME" ] || [ -z "$MFA_TOKEN" ]; then
     usage
 fi
+
+# Tools needed for the AWS path (not for --reset).
+require_command aws
+require_command jq
 
 case "$ENV_NAME" in
     staging) TARGET_PROFILE="claude-staging" ;;


### PR DESCRIPTION
## Summary

Addresses [@backspace's comment](https://github.com/cardstack/boxel/pull/4557#issuecomment-4344712547) on the merged CS-10962 PR:

> I typed the wrong AWS profile name and had to use `--source-profile` to overwrite it, it might be nice to have a `--reset` or the like, or I guess people can edit the config file after locating it

Adds a top-level `--reset` that wipes the entire `~/.config/claude-aws/config` so the next normal invocation re-prompts from scratch. Equivalent shortcut to deleting the config file by hand.

## Usage

```sh
mise run claude-aws --reset
```

Takes no other arguments — env name and MFA token are not allowed in the same invocation. Errors with a usage hint if combined:

```
$ claude-aws --reset staging 123456
--reset takes no other arguments
Usage: claude-aws.sh <staging|prod> <MFA_TOKEN> [--source-profile <name>]
   or: claude-aws.sh --reset       (wipe cached source-profile choices)
```

`--source-profile <name>` (the existing flag) is unchanged — it sets/overrides a single env's cached choice without prompting. `--reset` is for "I want to start over from a clean slate".

## Skill update

- "First-time configuration" section now mentions the `--reset` shortcut for fixing a wrong-profile choice.
- The troubleshooting row for `No MFA device registered for profile <name>` (the symptom you'd see if you cached the wrong source profile on first run) now points at `--reset` as the fix.

## Test plan

- [x] `bash -n scripts/claude-aws.sh` passes.
- [x] `claude-aws --reset` deletes `~/.config/claude-aws/config` and exits 0 — no AssumeRole call, no MFA needed.
- [x] `claude-aws --reset staging 123456` errors with the combined-args message and prints usage.
- [x] `claude-aws` (no args) still prints usage as before.
- [x] After `--reset`, the next `mise run claude-aws staging <token>` re-prompts for the source profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
