### PR TITLE
Use authType=default on AWS-backed data sources

### DIFF
--- a/packages/observability/provisioning/datasources/boxel-cloudwatch.yaml
+++ b/packages/observability/provisioning/datasources/boxel-cloudwatch.yaml
@@ -18,5 +18,9 @@ datasources:
     isDefault: false
     editable: false
     jsonData:
-      authType: ec2_iam_role
+      # `default` makes the AWS SDK use its default credential chain, which
+      # on ECS picks up the task role. AMG's `ec2_iam_role` value is a
+      # legacy alias that newer Grafana refuses (see staging health check:
+      # "trying to use non-allowed auth method ec2_iam_role").
+      authType: default
       defaultRegion: us-east-1

--- a/packages/observability/provisioning/datasources/synapse-prometheus.yaml
+++ b/packages/observability/provisioning/datasources/synapse-prometheus.yaml
@@ -24,6 +24,9 @@ datasources:
     jsonData:
       httpMethod: POST
       sigV4Auth: true
-      sigV4AuthType: ec2_iam_role
+      # `default` so SigV4 uses the AWS SDK default credential chain (ECS
+      # task role here). AMG's `ec2_iam_role` is a legacy alias newer
+      # Grafana rejects with a 403.
+      sigV4AuthType: default
       sigV4Region: us-east-1
       sigV4Service: aps


### PR DESCRIPTION
## Summary

After CS-10978 pushed all four data sources to staging, two failed health checks:

- **boxel-cloudwatch**: \`CloudWatch metrics query failed: trying to use non-allowed auth method ec2_iam_role\`
- **synapse-prometheus**: \`403 Forbidden\`

Both use the legacy AMG-era \`authType: ec2_iam_role\` / \`sigV4AuthType: ec2_iam_role\` value, which newer Grafana rejects. \`default\` tells Grafana to use the AWS SDK's default credential chain, which on ECS picks up the task role.

The project plan flagged this as expected (auth method differences AMG → self-host). My CS-10978 conversion just preserved the original AMG values; this fix swaps them to \`default\` per the plan.

The Grafana ECS task role already has the matching CloudWatch + AMP perms from CS-10907, so the auth flow is unchanged in spirit.

Loki and boxel-db were unaffected — they don't use AWS-side auth at all (Loki via NLB+SG, Postgres via password).

## Test plan

- [ ] On merge: staging \`observability-apply\` runs, pushes the corrected data sources.
- [ ] \`/api/datasources/uid/cef5x9o3yzawwf/health\` returns OK (boxel-cloudwatch).
- [ ] \`/api/datasources/uid/bes7ustjf8w74b/health\` returns OK (synapse-prometheus).
- [ ] Same after dispatching the prod workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)