### PR TITLE
Add claude-prerender-token: Claude-driven live render investigation

### DIFF
--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -747,16 +747,125 @@ If `renderStage` says `buildModel:fetching-source` but `cardDocsInFlight` is emp
 
 ## Reproducing a render interactively
 
-Sometimes the written diagnostics aren't enough — you want to replay the exact render the indexer saw in a real browser (Chrome MCP, Puppeteer, or your own tab) to step through it, watch network, edit source and reload, etc. Every ingredient is already in the system; you just have to wire them up.
+Sometimes the written diagnostics aren't enough — you want to replay the exact render the indexer saw in a real browser (Chrome MCP, Puppeteer, or your own tab) to step through it, watch network, edit source and reload, etc.
 
-Two separate tokens are involved; keep them straight up front:
+There are two paths, depending on what you have access to:
 
-- **User JWT** — a *realm-scoped* token you mint yourself, used to call the authenticated reindex endpoint (`POST <realm-url>_full-reindex` or `_reindex`). Without this you can't trigger the reindex, which means you don't get the artifacts below. This is the only reason you'll do the Matrix dance by hand.
-- **Indexer `boxel-session` value** — the full `boxel-session` localStorage value the indexer's prerender tab uses. You never construct this yourself; you read it verbatim out of the `prerenderer-reproduce` log for the card you want to replay, and paste it into `localStorage['boxel-session']` so the prerender tab authenticates as the indexer did. Format: a JSON-stringified map `{ <realmUrl>: <realm-scoped-JWT>, … }`, one entry per realm the indexer has auth for — the host reads it with `JSON.parse(...)` and picks the right JWT per cross-realm fetch. **Copy the whole string from the log**, not just one of the inner JWTs.
+- **Path A — direct token mint via `mise run claude-prerender-token`** (preferred for staging/prod when you have the realm secret seed). Skip the Matrix login and reindex steps; the script mints the same shape of token the indexer mints, then you drive Chrome MCP straight at the `/render` route. Works for any card on a server you have the seed for, without changing server config or triggering a reindex.
+- **Path B — the `prerenderer-reproduce` log channel** (local dev, or when you need the indexer's exact historical session). Turn on a debug log level on the realm server, trigger a reindex, and copy the URL + session value verbatim from the log line.
 
-So the end-to-end flow is: mint user JWT → call `_full-reindex` with it → indexer runs → log emits render URLs + session values → paste into browser. Mint-your-own-JWT and read-value-from-log are *both* needed; they're not alternatives.
+Path A is faster, doesn't require server config changes, and works against staging/prod without touching the running fleet. Path B captures the indexer's exact multi-realm session at a point in time — the right choice when you suspect cross-realm fetch auth or want to replay a render that already happened. The "Visiting a render page" / Chrome MCP / `__boxelRenderDiagnostics()` recipe below is shared between the two paths.
 
-### The `prerenderer-reproduce` log channel
+### Path A — direct token mint (the common case)
+
+The user runs `mise run claude-prerender-token <realm-url> [<seed>]`. The script (`packages/realm-server/scripts/claude-prerender-token.ts`, executed via `ts-node --transpileOnly` from inside `packages/realm-server`) mints a `boxel-session` JWT the same way the indexer does — same claims, same HS256/1d, same `JSON.stringify({ <realmUrl>: <jwt> })` map shape that lands in `localStorage['boxel-session']`. Faithful CLI port of `buildCreatePrerenderAuth` (`packages/realm-server/prerender/auth.ts`).
+
+**The CLI is intentionally minimal: just `<realm-url>` and an optional `<seed>` positional.** If `<seed>` is omitted the script silently prompts on `/dev/tty` (paste-friendly, no shell history). Optional flags: `--user <matrix-id>` (required only for system realms), `--output <path>`, `--no-output`. That's it. The token is realm-scoped, not card-scoped — Claude builds the `/render` URL itself for whichever card it's investigating.
+
+#### Hard rule: Claude never sees the seed
+
+- Do NOT ask the user for the seed.
+- Do NOT propose pasting the seed into the conversation, into a file Claude can read, or via any other channel.
+- Do NOT call `aws ssm get-parameter` against `REALM_SECRET_SEED` — Claude's `boxel-claude-readonly` role rejects it anyway, but don't try.
+
+The user fetches the seed however they like (SSM, dev-env, prompt) and runs the script in their own shell. Claude consumes only the artifact below.
+
+Why: the seed mints arbitrary user-impersonating tokens with arbitrary permissions. A 1-day JWT for one user is a bounded leak; the seed is unbounded.
+
+#### The artifact Claude reads
+
+`/tmp/claude-prerender.json` (chmod 600), written by the script:
+
+```json
+{
+  "mintedAt":   "<iso>",
+  "expiresAt":  "<iso>",  // 1d from mintedAt
+  "user":       "@ctse:stack.cards",
+  "realmUrl":   "https://realms-staging.stack.cards/ctse/concrete-mockingbird/",
+  "hostUrl":    "https://boxel-host-staging.stack.cards",
+  "jwt":        "eyJ...",
+  "session":    "{\"<realmUrl>\":\"eyJ...\"}"
+}
+```
+
+Before using it, Claude must check:
+
+- `expiresAt` is in the future
+- `mintedAt` is recent enough that this is for the *current* investigation (not a leftover artifact)
+- `realmUrl` matches the realm of the card you're rendering — different realm = ask for re-mint
+
+If any check fails, ask the user to re-run. Do not reuse stale artifacts.
+
+#### Building the `/render` URL (Claude's responsibility)
+
+Once Claude has the artifact, it constructs the URL the prerender uses, mirroring `packages/realm-server/prerender/render-runner.ts:832`:
+
+```
+<hostUrl>/render/<encodeURIComponent(cardUrl)>/<nonce>/<encodeURIComponent(JSON.stringify(options))>/html/<format>/0
+```
+
+Slot-by-slot:
+
+- **`<hostUrl>`** — straight from the artifact's `hostUrl` field.
+- **`<encodeURIComponent(cardUrl)>`** — the card you're investigating, NO trailing `.json`. `https://realms-staging.stack.cards/ctse/concrete-mockingbird/Environment/demo` → `https%3A%2F%2Frealms-staging.stack.cards%2Fctse%2Fconcrete-mockingbird%2FEnvironment%2Fdemo`.
+- **`<nonce>`** — any string. The indexer uses a monotonic counter; for manual replays `1` is fine.
+- **`<encodeURIComponent(JSON.stringify(options))>`** — the render-route options object, JSON-encoded then URL-encoded. The shape lives in `packages/runtime-common/render-route-options.ts`. Common values:
+  - `{"cardRender":true}` → `%7B%22cardRender%22%3Atrue%7D` (the indexer's card-render pass — what you want for a card desync repro)
+  - `{}` → `%7B%7D` (no special pass)
+  - `{"cardRender":true,"clearCache":true}` (drops the loader cache before the render — helpful when stale modules might be the cause)
+- **`<format>`** — `isolated` (matches the indexer for card-render), `embedded`, `fitted`, or `atom`. Default to `isolated`.
+- **`/0`** — recursion-depth segment. Always `0` for card render.
+
+Worked example for the demo card:
+
+```
+https://boxel-host-staging.stack.cards/render/https%3A%2F%2Frealms-staging.stack.cards%2Fctse%2Fconcrete-mockingbird%2FEnvironment%2Fdemo/1/%7B%22cardRender%22%3Atrue%7D/html/isolated/0
+```
+
+The Chrome MCP recipe (set `localStorage['boxel-session']` first, then navigate, then poll status / call `__boxelRenderDiagnostics()`) is shared with Path B — see [Chrome MCP / headful replay recipe](#chrome-mcp--headful-replay-recipe) below.
+
+#### How auth actually clears the realm-server
+
+The realm-server's `checkPermission` (`packages/runtime-common/realm.ts:2249`) does two things in order:
+
+1. **Verify the JWT signature** against `REALM_SECRET_SEED`. Anyone with the seed can mint a valid signature — that's the diagnostic gate.
+2. **Look up the token's `user` claim in the realm's permission table** via `RealmPermissionChecker.for(username)` (`packages/runtime-common/realm-permission-checker.ts`). The `permissions` array in the JWT is advisory; the checker actually reads `realm_user_permissions[realm][username]` plus the `'*'` wildcard.
+
+So the `user` claim has to be a real Matrix ID with real DB permissions on the target realm. A made-up user passes signature verification but fails the checker → 401. The script's default derivation (`realms-staging.stack.cards/ctse/realm/` → `@ctse:stack.cards`) hits the realm owner's row — works for any 2-segment user-realm URL. For system realms (`/catalog/`, `/experiments/`), the script errors and asks for `--user @realm:<matrix-domain>` (the realm-server bot).
+
+For local dev: matrix `server_name` is `localhost` (`packages/matrix/docker/synapse/dev/homeserver.yaml:1`), so user IDs are `@<username>:localhost`. The script auto-handles `*.localhost` hosts.
+
+**Public realms (`'*': ['read']` in the permissions table) don't need a JWT.** Published realms always get this set (`packages/realm-server/handlers/handle-publish-realm.ts:326`). If you're rendering a published card, no token is needed — though minting still works, the request just doesn't depend on it.
+
+#### Cross-realm linksTo (when the simple flow isn't enough)
+
+The default session map has only the target realm. If the card pulls private cross-realm `linksTo`, the host's loader will 401 those fetches.
+
+For now this isn't auto-handled; if you hit a cross-realm 401, the user can extend the session map themselves by minting tokens for the additional realms (same secret signs them all) and merging the maps. The DB has the answer for which realms a user owns — query `realm_user_permissions` excluding published realms:
+
+```sql
+SELECT rup.realm_url
+FROM realm_user_permissions rup
+LEFT JOIN published_realms pr ON pr.published_realm_url = rup.realm_url
+WHERE rup.username = '@ctse:stack.cards'
+  AND rup.read = TRUE
+  AND pr.published_realm_url IS NULL
+ORDER BY rup.realm_url;
+```
+
+This matches the indexer's `fetchUserPermissions` (`packages/runtime-common/db-queries/realm-permission-queries.ts:127`) → `buildCreatePrerenderAuth` chain. Auto-discovery is a follow-up — for now, ask the user if cross-realm support is needed for a specific repro.
+
+#### When this is the right path
+
+- A specific card is failing in indexing on staging/prod and you want unminified Chrome stack frames + a `__boxelRenderDiagnostics()` snapshot.
+- You're iterating on a card template locally and want to skip the reindex step entirely.
+- You want to compare a render under different `RenderRouteOptions` (e.g. with vs without `clearCache`).
+
+When this is **not** the right path:
+- You need the indexer's exact session at the moment of a *historical* render (cross-realm auth that's since changed, etc.) — use Path B.
+- You're triaging a stall during the indexer's own pass and want diagnostics on the *real* indexer's tab — Path A reproduces in a fresh tab; the indexer's tab is its own thing.
+
+### Path B — the `prerenderer-reproduce` log channel
 
 `packages/realm-server/prerender/render-runner.ts` defines a dedicated logger `prerenderer-reproduce` that emits a line **per card render** with a ready-to-use URL and the exact `boxel-session` value the indexer used (a JSON-stringified map from realm URL to realm-scoped JWT):
 

--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -760,7 +760,7 @@ Path A is faster, doesn't require server config changes, and works against stagi
 
 The user runs `mise run claude-prerender-token <realm-url> [<seed>]`. The script (`packages/realm-server/scripts/claude-prerender-token.ts`, executed via `ts-node --transpileOnly` from inside `packages/realm-server`) mints a `boxel-session` JWT the same way the indexer does — same claims, same HS256/1d, same `JSON.stringify({ <realmUrl>: <jwt> })` map shape that lands in `localStorage['boxel-session']`. Faithful CLI port of `buildCreatePrerenderAuth` (`packages/realm-server/prerender/auth.ts`).
 
-**The CLI is intentionally minimal: just `<realm-url>` and an optional `<seed>` positional.** If `<seed>` is omitted the script silently prompts on `/dev/tty` (paste-friendly, no shell history). Optional flags: `--user <matrix-id>` (required only for system realms), `--output <path>`, `--no-output`. That's it. The token is realm-scoped, not card-scoped — Claude builds the `/render` URL itself for whichever card it's investigating.
+**The CLI is intentionally minimal: just `<realm-url>` and an optional `<seed>` positional.** If `<seed>` is omitted the script reads from `process.stdin` — interactively that's a masked TTY paste prompt (each char echoes as `*`, paste-friendly, no shell history); piped/redirected stdin is read in full and trimmed. Optional flags: `--user <matrix-id>` (required only for system realms), `--permissions <list>`, `--host-url <url>`, `--output <path>`, `--no-output`. That's it. The token is realm-scoped, not card-scoped — Claude builds the `/render` URL itself for whichever card it's investigating.
 
 #### Hard rule: Claude never sees the seed
 

--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -782,11 +782,13 @@ Why: the seed mints arbitrary user-impersonating tokens with arbitrary permissio
   "expiresAt":  "<iso>",  // 1d from mintedAt
   "user":       "@ctse:stack.cards",
   "realmUrl":   "https://realms-staging.stack.cards/ctse/concrete-mockingbird/",
-  "hostUrl":    "https://boxel-host-staging.stack.cards",
+  "hostUrl":    "https://boxel-host-staging.stack.cards",  // may be null if realm host is unknown
   "jwt":        "eyJ...",
   "session":    "{\"<realmUrl>\":\"eyJ...\"}"
 }
 ```
+
+If `hostUrl` is `null` in the artifact, the script couldn't infer the boxel-host-app URL from the realm hostname — the JWT/session are still valid, but Claude needs the host URL separately to build a `/render` URL. Ask the user, or have them re-run with `--host-url <url>` to fill it in.
 
 Before using it, Claude must check:
 

--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -807,7 +807,7 @@ Once Claude has the artifact, it constructs the URL the prerender uses, mirrorin
 Slot-by-slot:
 
 - **`<hostUrl>`** — straight from the artifact's `hostUrl` field.
-- **`<encodeURIComponent(cardUrl)>`** — the card you're investigating, NO trailing `.json`. `https://realms-staging.stack.cards/ctse/concrete-mockingbird/Environment/demo` → `https%3A%2F%2Frealms-staging.stack.cards%2Fctse%2Fconcrete-mockingbird%2FEnvironment%2Fdemo`.
+- **`<encodeURIComponent(cardUrl)>`** — the card's full file URL **including `.json`** (the indexer renders against the .json file, not the bare card-id). `https://realms-staging.stack.cards/ctse/concrete-mockingbird/Environment/demo.json` → `https%3A%2F%2Frealms-staging.stack.cards%2Fctse%2Fconcrete-mockingbird%2FEnvironment%2Fdemo.json`. Omitting `.json` lands you on the host's login page because the route doesn't match.
 - **`<nonce>`** — any string. The indexer uses a monotonic counter; for manual replays `1` is fine.
 - **`<encodeURIComponent(JSON.stringify(options))>`** — the render-route options object, JSON-encoded then URL-encoded. The shape lives in `packages/runtime-common/render-route-options.ts`. Common values:
   - `{"cardRender":true}` → `%7B%22cardRender%22%3Atrue%7D` (the indexer's card-render pass — what you want for a card desync repro)
@@ -816,22 +816,62 @@ Slot-by-slot:
 - **`<format>`** — `isolated` (matches the indexer for card-render), `embedded`, `fitted`, or `atom`. Default to `isolated`.
 - **`/0`** — recursion-depth segment. Always `0` for card render.
 
+All six dynamic segments must be present and correctly encoded. If any is missing or malformed, the route doesn't match and the host falls through to its login page — easy to diagnose because you'll see a login form instead of a prerender container.
+
 Worked example for the demo card:
 
 ```
-https://boxel-host-staging.stack.cards/render/https%3A%2F%2Frealms-staging.stack.cards%2Fctse%2Fconcrete-mockingbird%2FEnvironment%2Fdemo/1/%7B%22cardRender%22%3Atrue%7D/html/isolated/0
+https://boxel-host-staging.stack.cards/render/https%3A%2F%2Frealms-staging.stack.cards%2Fctse%2Fconcrete-mockingbird%2FEnvironment%2Fdemo.json/1/%7B%22cardRender%22%3Atrue%7D/html/isolated/0
 ```
 
-The Chrome MCP recipe (set `localStorage['boxel-session']` first, then navigate, then poll status / call `__boxelRenderDiagnostics()`) is shared with Path B — see [Chrome MCP / headful replay recipe](#chrome-mcp--headful-replay-recipe) below.
+#### Chrome MCP recipe (Path A specific — order matters)
+
+`localStorage['boxel-session']` must be set BEFORE navigating to `/render`. The render route reads it on initial load; if the session isn't there yet, the auth resolves as anonymous and the route 401s before any of the diagnostic surface is reachable.
+
+```
+1. mcp__chrome-devtools__new_page → <hostUrl>/   (lands on the login page or homepage —
+                                                  doesn't matter, we just need a same-origin
+                                                  document to set localStorage on)
+2. mcp__chrome-devtools__evaluate_script → localStorage.setItem('boxel-session', <session-from-artifact>)
+                                           where <session-from-artifact> is the artifact's
+                                           `session` field verbatim — a JSON-stringified map,
+                                           NOT a bare JWT.
+3. mcp__chrome-devtools__navigate_page → <render-url built above>
+4. mcp__chrome-devtools__evaluate_script → document.querySelector('[data-prerender]')?.dataset.prerenderStatus
+                                           polls 'loading' → 'ready' / 'error' / 'unusable'.
+5. Once stable, evaluate __boxelRenderDiagnostics?.() to grab the live diagnostic blob,
+   and inspect the console / DOM for the unminified throw.
+```
+
+If step 4 returns `null` (no `[data-prerender]` element at all) and the body shows a JSON `instance-error`, the request reached the host but failed auth — usually one of:
+
+- The `permissions` array in the JWT doesn't match the user's DB row exactly (see "How auth actually clears" below — re-mint with `--permissions` matching the DB).
+- The card URL in the render URL is missing `.json`.
+- localStorage wasn't set before navigation (set it, then reload — don't expect the host to pick it up mid-request).
 
 #### How auth actually clears the realm-server
 
 The realm-server's `checkPermission` (`packages/runtime-common/realm.ts:2249`) does two things in order:
 
 1. **Verify the JWT signature** against `REALM_SECRET_SEED`. Anyone with the seed can mint a valid signature — that's the diagnostic gate.
-2. **Look up the token's `user` claim in the realm's permission table** via `RealmPermissionChecker.for(username)` (`packages/runtime-common/realm-permission-checker.ts`). The `permissions` array in the JWT is advisory; the checker actually reads `realm_user_permissions[realm][username]` plus the `'*'` wildcard.
+2. **Look up the token's `user` claim in the realm's permission table** via `RealmPermissionChecker.for(username)` (`packages/runtime-common/realm-permission-checker.ts`).
+3. **Compare the JWT's `permissions` array against the DB's permissions array, sorted, byte-for-byte equal** (`packages/runtime-common/realm.ts:2306-2316`). This is the gotcha. The check is `JSON.stringify(token.permissions.sort()) === JSON.stringify(userPermissions.sort())`. So a JWT claiming `['read','realm-owner']` for a user whose DB row is `read=t,write=t,realm_owner=t` (which translates to `['read','write','realm-owner']`) is rejected with `PermissionMismatch` (401). Sub-set isn't enough; the arrays must be equal.
 
-So the `user` claim has to be a real Matrix ID with real DB permissions on the target realm. A made-up user passes signature verification but fails the checker → 401. The script's default derivation (`realms-staging.stack.cards/ctse/realm/` → `@ctse:stack.cards`) hits the realm owner's row — works for any 2-segment user-realm URL. For system realms (`/catalog/`, `/experiments/`), the script errors and asks for `--user @realm:<matrix-domain>` (the realm-server bot).
+Practical implications:
+
+- The `user` claim has to be a real Matrix ID — a made-up user passes signature verification but fails the lookup → 401. The script's default derivation (`realms-staging.stack.cards/ctse/realm/` → `@ctse:stack.cards`) hits the realm owner's row.
+- The `permissions` claim has to mirror the DB exactly. The script defaults to `['read','write','realm-owner']` because that's the standard realm-owner shape, but if the user has a non-default permission set on this realm (read-only collaborator, write-without-owner, etc.) you'll hit `PermissionMismatch`. The fix is `--permissions <list>` matching the DB row.
+- For system realms (`/catalog/`, `/experiments/`), the script errors and asks for `--user @realm:<matrix-domain>` (the realm-server bot).
+
+When the `instance-error` body says `User permissions in the JWT payload do not match the server's permissions`, it's specifically this check failing. Query the DB to see what the row actually is:
+
+```sql
+SELECT username, read, write, realm_owner
+FROM realm_user_permissions
+WHERE realm_url = '<realm-url>' AND username = '<user-from-artifact>';
+```
+
+Then re-mint with `--permissions read,write,realm-owner` (or whatever the columns are). Booleans translate one-to-one to array entries; column `realm_owner` becomes `realm-owner` (note the dash).
 
 For local dev: matrix `server_name` is `localhost` (`packages/matrix/docker/synapse/dev/homeserver.yaml:1`), so user IDs are `@<username>:localhost`. The script auto-handles `*.localhost` hosts.
 

--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -782,13 +782,12 @@ Why: the seed mints arbitrary user-impersonating tokens with arbitrary permissio
   "expiresAt":  "<iso>",  // 1d from mintedAt
   "user":       "@ctse:stack.cards",
   "realmUrl":   "https://realms-staging.stack.cards/ctse/concrete-mockingbird/",
-  "hostUrl":    "https://boxel-host-staging.stack.cards",  // may be null if realm host is unknown
   "jwt":        "eyJ...",
   "session":    "{\"<realmUrl>\":\"eyJ...\"}"
 }
 ```
 
-If `hostUrl` is `null` in the artifact, the script couldn't infer the boxel-host-app URL from the realm hostname — the JWT/session are still valid, but Claude needs the host URL separately to build a `/render` URL. Ask the user, or have them re-run with `--host-url <url>` to fill it in.
+The host URL isn't in the artifact — Claude derives it from the realm URL when building the `/render` URL (recipe below). Matrix isn't involved in this flow at all; the realm-server's `checkPermission` just verifies the HS256 signature against the seed and looks up the user's row in `realm_user_permissions`.
 
 Before using it, Claude must check:
 
@@ -808,7 +807,16 @@ Once Claude has the artifact, it constructs the URL the prerender uses, mirrorin
 
 Slot-by-slot:
 
-- **`<hostUrl>`** — straight from the artifact's `hostUrl` field.
+- **`<hostUrl>`** — derive from the artifact's `realmUrl` host. The boxel-host-app URL (NOT matrix — matrix isn't involved in this flow). Recognised patterns, mirroring the deployed-env Caddy config + local dev / env-mode Traefik labels in `mise-tasks/lib/env-vars.sh`:
+
+  | Realm host | Host-app URL |
+  |---|---|
+  | `realms-staging.stack.cards` | `https://boxel-host-staging.stack.cards` |
+  | `realms.stack.cards` | `https://boxel-host.stack.cards` |
+  | `realm-server.<slug>.localhost` | `http://host.<slug>.localhost` (BOXEL_ENVIRONMENT mode) |
+  | `localhost` or `*.localhost` (standard) | `http://localhost:4200` |
+
+  If the realm host doesn't match any of these patterns, ask the user — don't guess. Constrain `realms-` matching to `*.stack.cards` so any future deployment using a `realms-` prefix on a different domain isn't silently mapped to a wrong (and possibly non-existent) host.
 - **`<encodeURIComponent(cardUrl)>`** — the card's full file URL **including `.json`** (the indexer renders against the .json file, not the bare card-id). `https://realms-staging.stack.cards/ctse/concrete-mockingbird/Environment/demo.json` → `https%3A%2F%2Frealms-staging.stack.cards%2Fctse%2Fconcrete-mockingbird%2FEnvironment%2Fdemo.json`. Omitting `.json` lands you on the host's login page because the route doesn't match.
 - **`<nonce>`** — any string. The indexer uses a monotonic counter; for manual replays `1` is fine.
 - **`<encodeURIComponent(JSON.stringify(options))>`** — the render-route options object, JSON-encoded then URL-encoded. The shape lives in `packages/runtime-common/render-route-options.ts`. Common values:
@@ -877,10 +885,10 @@ Then re-mint with `--permissions read,write,realm-owner` (or whatever the column
 
 For local dev: matrix `server_name` is `localhost` (`packages/matrix/docker/synapse/dev/homeserver.yaml:1`), so user IDs are `@<username>:localhost`. Two local-dev modes are supported:
 
-- **Standard mode** (no `BOXEL_ENVIRONMENT` set) — realm at `http://localhost:4201/...`, host at `http://localhost:4200`. The script's `inferHost` returns `http://localhost:4200`.
-- **Environment mode** (`BOXEL_ENVIRONMENT=<name>` set) — realm at `http://realm-server.<slug>.localhost/...`, host at `http://host.<slug>.localhost` (Traefik routing per `mise-tasks/lib/env-vars.sh`). The script's `inferHost` extracts `<slug>` from the realm host and emits the matching `host.<slug>.localhost`.
+- **Standard mode** (no `BOXEL_ENVIRONMENT` set) — realm at `http://localhost:4201/...`, host-app at `http://localhost:4200`.
+- **Environment mode** (`BOXEL_ENVIRONMENT=<name>` set) — realm at `http://realm-server.<slug>.localhost/...`, host-app at `http://host.<slug>.localhost` (Traefik routing per `mise-tasks/lib/env-vars.sh`).
 
-Both modes share `@<user>:localhost` for the matrix-domain part of user IDs. If you've configured a non-default matrix `server_name`, pass `--host-url` (and `--user` if needed) explicitly.
+Both modes share `@<user>:localhost` for the matrix-domain part of user IDs. The host-app URL Claude needs to build the `/render` URL is derived from the realm URL per the table in the URL recipe section above. If you've configured a non-default matrix `server_name`, pass `--user` to the script explicitly.
 
 **Public realms (`'*': ['read']` in the permissions table) don't need a JWT.** Published realms always get this set (`packages/realm-server/handlers/handle-publish-realm.ts:326`). If you're rendering a published card, no token is needed — though minting still works, the request just doesn't depend on it.
 

--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -861,7 +861,7 @@ Practical implications:
 
 - The `user` claim has to be a real Matrix ID — a made-up user passes signature verification but fails the lookup → 401. The script's default derivation (`realms-staging.stack.cards/ctse/realm/` → `@ctse:stack.cards`) hits the realm owner's row.
 - The `permissions` claim has to mirror the DB exactly. The script defaults to `['read','write','realm-owner']` because that's the standard realm-owner shape, but if the user has a non-default permission set on this realm (read-only collaborator, write-without-owner, etc.) you'll hit `PermissionMismatch`. The fix is `--permissions <list>` matching the DB row.
-- For system realms (`/catalog/`, `/experiments/`), the script errors and asks for `--user @realm:<matrix-domain>` (the realm-server bot).
+- For system realms (`/catalog/`, `/experiments/`), the script errors and asks for `--user @realm_server:<matrix-domain>` (the realm-server bot — `REALM_SERVER_MATRIX_USERNAME=realm_server` in `packages/realm-server/scripts/start-staging.sh`/`start-production.sh`).
 
 When the `instance-error` body says `User permissions in the JWT payload do not match the server's permissions`, it's specifically this check failing. Query the DB to see what the row actually is:
 
@@ -873,7 +873,12 @@ WHERE realm_url = '<realm-url>' AND username = '<user-from-artifact>';
 
 Then re-mint with `--permissions read,write,realm-owner` (or whatever the columns are). Booleans translate one-to-one to array entries; column `realm_owner` becomes `realm-owner` (note the dash).
 
-For local dev: matrix `server_name` is `localhost` (`packages/matrix/docker/synapse/dev/homeserver.yaml:1`), so user IDs are `@<username>:localhost`. The script auto-handles `*.localhost` hosts.
+For local dev: matrix `server_name` is `localhost` (`packages/matrix/docker/synapse/dev/homeserver.yaml:1`), so user IDs are `@<username>:localhost`. Two local-dev modes are supported:
+
+- **Standard mode** (no `BOXEL_ENVIRONMENT` set) — realm at `http://localhost:4201/...`, host at `http://localhost:4200`. The script's `inferHost` returns `http://localhost:4200`.
+- **Environment mode** (`BOXEL_ENVIRONMENT=<name>` set) — realm at `http://realm-server.<slug>.localhost/...`, host at `http://host.<slug>.localhost` (Traefik routing per `mise-tasks/lib/env-vars.sh`). The script's `inferHost` extracts `<slug>` from the realm host and emits the matching `host.<slug>.localhost`.
+
+Both modes share `@<user>:localhost` for the matrix-domain part of user IDs. If you've configured a non-default matrix `server_name`, pass `--host-url` (and `--user` if needed) explicitly.
 
 **Public realms (`'*': ['read']` in the permissions table) don't need a JWT.** Published realms always get this set (`packages/realm-server/handlers/handle-publish-realm.ts:326`). If you're rendering a published card, no token is needed — though minting still works, the request just doesn't depend on it.
 

--- a/mise-tasks/claude-prerender-token
+++ b/mise-tasks/claude-prerender-token
@@ -1,5 +1,5 @@
 #!/bin/sh
-#MISE description="Mint a realm-scoped JWT + /render URL the way the indexer does, for live browser repro"
+#MISE description="Mint a realm-scoped boxel-session JWT (the way the indexer does) for live browser repro"
 #MISE dir="packages/realm-server"
 
 exec ts-node --transpileOnly ./scripts/claude-prerender-token.ts "$@"

--- a/mise-tasks/claude-prerender-token
+++ b/mise-tasks/claude-prerender-token
@@ -1,0 +1,5 @@
+#!/bin/sh
+#MISE description="Mint a realm-scoped JWT + /render URL the way the indexer does, for live browser repro"
+#MISE dir="packages/realm-server"
+
+exec ts-node --transpileOnly ./scripts/claude-prerender-token.ts "$@"

--- a/mise-tasks/claude-prerender-token
+++ b/mise-tasks/claude-prerender-token
@@ -1,5 +1,5 @@
 #!/bin/sh
-#MISE description="Mint a realm-scoped boxel-session JWT (the way the indexer does) for live browser repro"
+#MISE description="Mint a realm-scoped boxel-session JWT (the indexer's auth shape) and write to /tmp/claude-prerender.json for Claude to drive a live browser render"
 #MISE dir="packages/realm-server"
 
 exec ts-node --transpileOnly ./scripts/claude-prerender-token.ts "$@"

--- a/packages/realm-server/scripts/claude-prerender-token.ts
+++ b/packages/realm-server/scripts/claude-prerender-token.ts
@@ -14,9 +14,10 @@
 
 import * as readline from 'node:readline';
 import { Writable } from 'node:stream';
-import { writeFileSync, chmodSync, mkdirSync } from 'node:fs';
+import { writeFileSync, mkdirSync, unlinkSync } from 'node:fs';
 import { dirname } from 'node:path';
 import jwt from 'jsonwebtoken';
+import { DEFAULT_PERMISSIONS } from '@cardstack/runtime-common';
 
 // Default file Claude reads to pick up the artifacts without the user
 // pasting anything. Bounded leak window — the JWT inside is 1d.
@@ -60,13 +61,19 @@ function usage(): void {
       `                         DB, so it MUST be a user that actually has perms on\n` +
       `                         the target realm.\n` +
       `  --permissions <list>   Comma-separated permissions for the JWT claim. Default:\n` +
-      `                         'read,write,realm-owner' (the realm-owner shape).\n` +
+      `                         DEFAULT_PERMISSIONS from runtime-common — the same shape new\n` +
+      `                         realms grant their owner ('${DEFAULT_PERMISSIONS.join(',')}').\n` +
       `                         The realm-server requires this to EXACTLY match the user's\n` +
       `                         row in realm_user_permissions — not a subset. If the default\n` +
       `                         fails with PermissionMismatch (401), query the DB:\n` +
       `                           SELECT read, write, realm_owner FROM realm_user_permissions\n` +
       `                           WHERE realm_url = '<url>' AND username = '<user>';\n` +
       `                         and pass exactly those columns as the list.\n` +
+      `  --host-url <url>       Override the boxel-host base URL recorded in the artifact.\n` +
+      `                         Default: inferred from realm host (realms-staging.stack.cards →\n` +
+      `                         boxel-host-staging.stack.cards, realms.stack.cards →\n` +
+      `                         boxel-host.stack.cards, *.localhost → http://localhost:4200).\n` +
+      `                         REQUIRED when the realm host doesn't match these patterns.\n` +
       `  --output <path>        Override output path. Default: ${DEFAULT_OUTPUT_PATH}.\n` +
       `  --no-output            Don't write the JSON artifact (stdout only).\n` +
       `  --help                 Show this help.\n`,
@@ -245,10 +252,19 @@ async function main(): Promise<void> {
   }
   const realmURL = ensureTrailingSlash(positional[0]);
   const realmOrigin = ensureTrailingSlash(new URL(realmURL).origin);
-  const secret =
+  const rawSecret =
     positional.length >= 2
       ? positional[1]
       : await promptSeedSilently('Paste seed: ');
+  const secret = rawSecret.trim();
+  if (!secret) {
+    process.stderr.write(
+      `error: empty seed. Pass the seed as the second positional argument or\n` +
+        `       paste it at the prompt (Ctrl+C cancels). An empty seed would mint\n` +
+        `       a JWT that fails signature verification on the server.\n`,
+    );
+    process.exit(2);
+  }
 
   let userId = opts.user as string | undefined;
   if (!userId) {
@@ -269,15 +285,16 @@ async function main(): Promise<void> {
   // The realm-server's checkPermission (`packages/runtime-common/realm.ts:2308`)
   // requires JSON.stringify(token.permissions.sort()) === JSON.stringify(
   // userPermissions.sort()) — the token's permissions must EXACTLY match
-  // what the realm's DB has for this user. Default ['read','write','realm-owner']
-  // matches the standard realm-owner shape; pass --permissions for other
-  // users (e.g. read-only collaborator, write-without-owner).
-  const permissionsRaw =
-    (opts.permissions as string | undefined) ?? 'read,write,realm-owner';
-  const permissions = permissionsRaw
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
+  // what the realm's DB has for this user. Default = DEFAULT_PERMISSIONS from
+  // runtime-common (the same shape new realms grant their owner); pass
+  // --permissions for non-owner users (read-only collaborator, etc.).
+  const permissionsOpt = opts.permissions as string | undefined;
+  const permissions = permissionsOpt
+    ? permissionsOpt
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [...DEFAULT_PERMISSIONS];
 
   const claims: TokenClaims = {
     user: userId,
@@ -292,6 +309,23 @@ async function main(): Promise<void> {
   process.stdout.write(`JWT=${token}\n`);
   process.stdout.write(`SESSION=${session}\n`);
 
+  // Resolve hostUrl: explicit --host-url override wins; otherwise infer
+  // from realm host. Fail fast (rather than emitting a `null` hostUrl
+  // into the artifact) when inference can't produce a usable value —
+  // every downstream consumer needs hostUrl to build the /render URL.
+  const hostUrl =
+    (opts['host-url'] as string | undefined) ?? inferHost(realmURL);
+  if (!hostUrl) {
+    process.stderr.write(
+      `error: cannot infer boxel-host URL from realm host '${new URL(realmURL).hostname}'.\n` +
+        `       Pass --host-url <url> explicitly. Recognised patterns:\n` +
+        `         realms-staging.stack.cards → boxel-host-staging.stack.cards\n` +
+        `         realms.stack.cards         → boxel-host.stack.cards\n` +
+        `         *.localhost / localhost    → http://localhost:4200\n`,
+    );
+    process.exit(2);
+  }
+
   if (opts['no-output']) return;
 
   const outputPath = (opts.output as string | undefined) ?? DEFAULT_OUTPUT_PATH;
@@ -302,14 +336,25 @@ async function main(): Promise<void> {
       decoded?.exp != null ? new Date(decoded.exp * 1000).toISOString() : null,
     user: userId,
     realmUrl: realmURL,
-    hostUrl: inferHost(realmURL),
+    hostUrl,
     jwt: token,
     session,
   };
   try {
     mkdirSync(dirname(outputPath), { recursive: true });
-    writeFileSync(outputPath, JSON.stringify(artifact, null, 2) + '\n');
-    chmodSync(outputPath, 0o600);
+    // Open with mode 0o600 from the start — `writeFileSync(path, data,
+    // {mode})` honors mode only when the path doesn't already exist, so
+    // first delete any prior file. The unlink + create-with-mode dance
+    // closes the umask-window the chmod-after-write pattern leaves open
+    // on multi-user systems.
+    try {
+      unlinkSync(outputPath);
+    } catch {
+      // not present, nothing to remove
+    }
+    writeFileSync(outputPath, JSON.stringify(artifact, null, 2) + '\n', {
+      mode: 0o600,
+    });
     process.stderr.write(`\nWrote artifact: ${outputPath}\n`);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/packages/realm-server/scripts/claude-prerender-token.ts
+++ b/packages/realm-server/scripts/claude-prerender-token.ts
@@ -74,7 +74,9 @@ function usage(): void {
       `                           SELECT read, write, realm_owner FROM realm_user_permissions\n` +
       `                           WHERE realm_url = '<url>' AND username = '<user>';\n` +
       `                         and pass exactly those columns as the list.\n` +
-      `  --host-url <url>       Override the boxel-host base URL recorded in the artifact.\n` +
+      `  --host-url <url>       Override the boxel-host-app base URL recorded in the\n` +
+      `                         artifact (NOT matrix — matrix isn't used here; the host\n` +
+      `                         app is where the /render route lives that Claude navigates to).\n` +
       `                         Default: inferred from realm host —\n` +
       `                           realms-staging.stack.cards         → boxel-host-staging.stack.cards\n` +
       `                           realms.stack.cards                 → boxel-host.stack.cards\n` +
@@ -117,9 +119,16 @@ function parseArgs(argv: string[]): ParsedArgs {
   return { positional, opts };
 }
 
-// Infer the boxel-host base URL from the realm host. Recognised patterns
-// (mirrors the deployed-env Caddy config + local dev / env-mode Traefik
-// labels in `mise-tasks/lib/env-vars.sh`):
+// Infer the boxel-HOST-APP base URL from the realm host. (Not matrix —
+// matrix isn't involved in this flow at all: we bypass Matrix login by
+// signing the JWT directly against REALM_SECRET_SEED. The
+// realm-server's `checkPermission` only verifies the HS256 signature
+// against the seed — no contact with matrix.) The host-app URL goes
+// into the artifact's `hostUrl` because Claude needs it to build the
+// /render URL — the prerender route lives on the host app.
+//
+// Recognised patterns (mirrors the deployed-env Caddy config + local
+// dev / env-mode Traefik labels in `mise-tasks/lib/env-vars.sh`):
 //
 //   • realms-staging.stack.cards         → boxel-host-staging.stack.cards
 //   • realms.stack.cards                 → boxel-host.stack.cards
@@ -344,21 +353,24 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  // Resolve hostUrl before signing/printing — failing here would leak a
-  // valid JWT to stdout while exiting with a usage error.
-  const hostUrl =
+  // Resolve hostUrl. The JWT/session don't depend on it — host inference
+  // only fills the artifact's `hostUrl` field, which Claude later uses
+  // to build the /render URL. So a missing hostUrl is a warning, not an
+  // error: emit a JWT regardless, mark hostUrl null in the artifact, and
+  // let the consumer (Claude or a human) supply the host downstream.
+  const hostUrl: string | null =
     (opts['host-url'] as string | undefined) ?? inferHost(realmURL);
   if (!hostUrl) {
     process.stderr.write(
-      `error: cannot infer boxel-host URL from realm host '${new URL(realmURL).hostname}'.\n` +
-        `       Pass --host-url <url> explicitly. Recognised patterns:\n` +
-        `         realms-staging.stack.cards         → boxel-host-staging.stack.cards\n` +
-        `         realms.stack.cards                 → boxel-host.stack.cards\n` +
-        `         realm-server.<slug>.localhost      → host.<slug>.localhost\n` +
-        `                                              (BOXEL_ENVIRONMENT mode)\n` +
-        `         localhost / *.localhost (standard) → http://localhost:4200\n`,
+      `warning: cannot infer boxel-host URL from realm host '${new URL(realmURL).hostname}';\n` +
+        `         artifact will record hostUrl=null. Pass --host-url <url> to fill it in.\n` +
+        `         Recognised patterns:\n` +
+        `           realms-staging.stack.cards         → boxel-host-staging.stack.cards\n` +
+        `           realms.stack.cards                 → boxel-host.stack.cards\n` +
+        `           realm-server.<slug>.localhost      → host.<slug>.localhost\n` +
+        `                                                (BOXEL_ENVIRONMENT mode)\n` +
+        `           localhost / *.localhost (standard) → http://localhost:4200\n`,
     );
-    process.exit(2);
   }
 
   // Seed last — by this point everything else has validated, so the seed

--- a/packages/realm-server/scripts/claude-prerender-token.ts
+++ b/packages/realm-server/scripts/claude-prerender-token.ts
@@ -74,16 +74,6 @@ function usage(): void {
       `                           SELECT read, write, realm_owner FROM realm_user_permissions\n` +
       `                           WHERE realm_url = '<url>' AND username = '<user>';\n` +
       `                         and pass exactly those columns as the list.\n` +
-      `  --host-url <url>       Override the boxel-host-app base URL recorded in the\n` +
-      `                         artifact (NOT matrix — matrix isn't used here; the host\n` +
-      `                         app is where the /render route lives that Claude navigates to).\n` +
-      `                         Default: inferred from realm host —\n` +
-      `                           realms-staging.stack.cards         → boxel-host-staging.stack.cards\n` +
-      `                           realms.stack.cards                 → boxel-host.stack.cards\n` +
-      `                           realm-server.<slug>.localhost      → host.<slug>.localhost\n` +
-      `                                                                (BOXEL_ENVIRONMENT mode)\n` +
-      `                           localhost / *.localhost (standard) → http://localhost:4200\n` +
-      `                         REQUIRED when the realm host doesn't match these patterns.\n` +
       `  --output <path>        Override output path. Default: ${DEFAULT_OUTPUT_PATH}.\n` +
       `  --no-output            Don't write the JSON artifact (stdout only).\n` +
       `  --help                 Show this help.\n`,
@@ -117,49 +107,6 @@ function parseArgs(argv: string[]): ParsedArgs {
     }
   }
   return { positional, opts };
-}
-
-// Infer the boxel-HOST-APP base URL from the realm host. (Not matrix —
-// matrix isn't involved in this flow at all: we bypass Matrix login by
-// signing the JWT directly against REALM_SECRET_SEED. The
-// realm-server's `checkPermission` only verifies the HS256 signature
-// against the seed — no contact with matrix.) The host-app URL goes
-// into the artifact's `hostUrl` because Claude needs it to build the
-// /render URL — the prerender route lives on the host app.
-//
-// Recognised patterns (mirrors the deployed-env Caddy config + local
-// dev / env-mode Traefik labels in `mise-tasks/lib/env-vars.sh`):
-//
-//   • realms-staging.stack.cards         → boxel-host-staging.stack.cards
-//   • realms.stack.cards                 → boxel-host.stack.cards
-//   • realm-server.<slug>.localhost      → host.<slug>.localhost  (env mode)
-//   • localhost(:NNNN) / *.localhost     → http://localhost:4200  (standard mode)
-//
-// Returns null for anything else; main() then prompts the operator to
-// pass --host-url. Constrained to `.stack.cards` so any future deployment
-// using a `realms-` prefix on a different domain isn't silently mapped
-// to a wrong (and non-existent) host.
-function inferHost(realmURL: string): string | null {
-  const u = new URL(realmURL);
-  const hostname = u.hostname;
-  // Env-mode local: realm-server.<slug>.localhost → host.<slug>.localhost
-  const envMatch = hostname.match(/^realm-server\.(.+)\.localhost$/);
-  if (envMatch) {
-    return `${u.protocol}//host.${envMatch[1]}.localhost`;
-  }
-  // Standard local: any *.localhost (including bare 'localhost'). Standard
-  // dev-server boxel-host is always on :4200.
-  if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
-    return `${u.protocol}//localhost:4200`;
-  }
-  // Deployed: realms-<env>.stack.cards → boxel-host-<env>.stack.cards
-  if (hostname.startsWith('realms-') && hostname.endsWith('.stack.cards')) {
-    return `${u.protocol}//${hostname.replace(/^realms-/, 'boxel-host-')}`;
-  }
-  if (hostname === 'realms.stack.cards') {
-    return `${u.protocol}//boxel-host.stack.cards`;
-  }
-  return null;
 }
 
 // Mirrors `userIdFromUsername` in
@@ -353,26 +300,6 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  // Resolve hostUrl. The JWT/session don't depend on it — host inference
-  // only fills the artifact's `hostUrl` field, which Claude later uses
-  // to build the /render URL. So a missing hostUrl is a warning, not an
-  // error: emit a JWT regardless, mark hostUrl null in the artifact, and
-  // let the consumer (Claude or a human) supply the host downstream.
-  const hostUrl: string | null =
-    (opts['host-url'] as string | undefined) ?? inferHost(realmURL);
-  if (!hostUrl) {
-    process.stderr.write(
-      `warning: cannot infer boxel-host URL from realm host '${new URL(realmURL).hostname}';\n` +
-        `         artifact will record hostUrl=null. Pass --host-url <url> to fill it in.\n` +
-        `         Recognised patterns:\n` +
-        `           realms-staging.stack.cards         → boxel-host-staging.stack.cards\n` +
-        `           realms.stack.cards                 → boxel-host.stack.cards\n` +
-        `           realm-server.<slug>.localhost      → host.<slug>.localhost\n` +
-        `                                                (BOXEL_ENVIRONMENT mode)\n` +
-        `           localhost / *.localhost (standard) → http://localhost:4200\n`,
-    );
-  }
-
   // Seed last — by this point everything else has validated, so the seed
   // is the final input we ask for.
   const rawSecret =
@@ -412,7 +339,6 @@ async function main(): Promise<void> {
       decoded?.exp != null ? new Date(decoded.exp * 1000).toISOString() : null,
     user: userId,
     realmUrl: realmURL,
-    hostUrl,
     jwt: token,
     session,
   };

--- a/packages/realm-server/scripts/claude-prerender-token.ts
+++ b/packages/realm-server/scripts/claude-prerender-token.ts
@@ -59,6 +59,14 @@ function usage(): void {
       `                         The realm-server checks this against its permissions\n` +
       `                         DB, so it MUST be a user that actually has perms on\n` +
       `                         the target realm.\n` +
+      `  --permissions <list>   Comma-separated permissions for the JWT claim. Default:\n` +
+      `                         'read,write,realm-owner' (the realm-owner shape).\n` +
+      `                         The realm-server requires this to EXACTLY match the user's\n` +
+      `                         row in realm_user_permissions — not a subset. If the default\n` +
+      `                         fails with PermissionMismatch (401), query the DB:\n` +
+      `                           SELECT read, write, realm_owner FROM realm_user_permissions\n` +
+      `                           WHERE realm_url = '<url>' AND username = '<user>';\n` +
+      `                         and pass exactly those columns as the list.\n` +
       `  --output <path>        Override output path. Default: ${DEFAULT_OUTPUT_PATH}.\n` +
       `  --no-output            Don't write the JSON artifact (stdout only).\n` +
       `  --help                 Show this help.\n`,
@@ -258,11 +266,24 @@ async function main(): Promise<void> {
     userId = derived;
   }
 
+  // The realm-server's checkPermission (`packages/runtime-common/realm.ts:2308`)
+  // requires JSON.stringify(token.permissions.sort()) === JSON.stringify(
+  // userPermissions.sort()) — the token's permissions must EXACTLY match
+  // what the realm's DB has for this user. Default ['read','write','realm-owner']
+  // matches the standard realm-owner shape; pass --permissions for other
+  // users (e.g. read-only collaborator, write-without-owner).
+  const permissionsRaw =
+    (opts.permissions as string | undefined) ?? 'read,write,realm-owner';
+  const permissions = permissionsRaw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
   const claims: TokenClaims = {
     user: userId,
     realm: realmURL,
     sessionRoom: '',
-    permissions: ['read', 'realm-owner'],
+    permissions,
     realmServerURL: realmOrigin,
   };
   const token = jwt.sign(claims, secret, { expiresIn: '1d' });

--- a/packages/realm-server/scripts/claude-prerender-token.ts
+++ b/packages/realm-server/scripts/claude-prerender-token.ts
@@ -27,7 +27,7 @@ import {
   DEFAULT_PERMISSIONS,
   ensureTrailingSlash,
 } from '@cardstack/runtime-common';
-import type { TokenClaims } from '@cardstack/runtime-common';
+import type { RealmAction, TokenClaims } from '@cardstack/runtime-common';
 
 // Default file Claude reads to pick up the artifacts without the user
 // pasting anything. Bounded leak window — the JWT inside is 1d.
@@ -226,7 +226,7 @@ function promptSeedSilently(question: string): Promise<string> {
   });
 }
 
-const VALID_PERMISSIONS = new Set([
+const VALID_PERMISSIONS = new Set<RealmAction>([
   'read',
   'write',
   'realm-owner',
@@ -285,13 +285,15 @@ async function main(): Promise<void> {
 
   // Validate permissions before the seed prompt, same reasoning.
   const permissionsOpt = opts.permissions as string | undefined;
-  const permissions = permissionsOpt
+  const rawPermissions = permissionsOpt
     ? permissionsOpt
         .split(',')
         .map((s) => s.trim())
         .filter(Boolean)
     : [...DEFAULT_PERMISSIONS];
-  const invalidPerms = permissions.filter((p) => !VALID_PERMISSIONS.has(p));
+  const invalidPerms = rawPermissions.filter(
+    (p): p is string => !VALID_PERMISSIONS.has(p as RealmAction),
+  );
   if (invalidPerms.length) {
     process.stderr.write(
       `error: --permissions contains unknown values: ${invalidPerms.join(', ')}\n` +
@@ -299,6 +301,8 @@ async function main(): Promise<void> {
     );
     process.exit(2);
   }
+  // Narrow to RealmAction[] now that VALID_PERMISSIONS has gated the values.
+  const permissions = rawPermissions as RealmAction[];
 
   // Seed last — by this point everything else has validated, so the seed
   // is the final input we ask for.

--- a/packages/realm-server/scripts/claude-prerender-token.ts
+++ b/packages/realm-server/scripts/claude-prerender-token.ts
@@ -14,10 +14,20 @@
 
 import * as readline from 'node:readline';
 import { Writable } from 'node:stream';
-import { writeFileSync, mkdirSync, unlinkSync } from 'node:fs';
+import {
+  openSync,
+  writeSync,
+  closeSync,
+  mkdirSync,
+  constants as fsConstants,
+} from 'node:fs';
 import { dirname } from 'node:path';
 import jwt from 'jsonwebtoken';
-import { DEFAULT_PERMISSIONS } from '@cardstack/runtime-common';
+import {
+  DEFAULT_PERMISSIONS,
+  ensureTrailingSlash,
+} from '@cardstack/runtime-common';
+import type { TokenClaims } from '@cardstack/runtime-common';
 
 // Default file Claude reads to pick up the artifacts without the user
 // pasting anything. Bounded leak window — the JWT inside is 1d.
@@ -26,14 +36,6 @@ const DEFAULT_OUTPUT_PATH = '/tmp/claude-prerender.json';
 interface ParsedArgs {
   positional: string[];
   opts: { [k: string]: string | boolean };
-}
-
-interface TokenClaims {
-  user: string;
-  realm: string;
-  sessionRoom: string;
-  permissions: string[];
-  realmServerURL: string;
 }
 
 function usage(): void {
@@ -51,12 +53,15 @@ function usage(): void {
       `               If omitted, prompts interactively (paste-friendly, masked\n` +
       `               with '*' so you can see each char landed; the seed itself\n` +
       `               never echoes to the terminal or shell history).\n` +
+      `               WARNING: passing the seed positionally exposes it via\n` +
+      `               'ps' / /proc/<pid>/cmdline and may persist in shell\n` +
+      `               history. Prefer the prompt or piped stdin.\n` +
       `\n` +
       `Options:\n` +
       `  --user <matrix-id>     Override the Matrix user ID claim. Default: derived\n` +
       `                         from the realm URL path (e.g. /ctse/realm/ → @ctse:stack.cards).\n` +
       `                         REQUIRED for system realms (1-segment paths like /catalog/),\n` +
-      `                         where the owner is typically @realm:<matrix-domain>.\n` +
+      `                         where the owner is the realm-server bot @realm_server:<matrix-domain>.\n` +
       `                         The realm-server checks this against its permissions\n` +
       `                         DB, so it MUST be a user that actually has perms on\n` +
       `                         the target realm.\n` +
@@ -70,9 +75,12 @@ function usage(): void {
       `                           WHERE realm_url = '<url>' AND username = '<user>';\n` +
       `                         and pass exactly those columns as the list.\n` +
       `  --host-url <url>       Override the boxel-host base URL recorded in the artifact.\n` +
-      `                         Default: inferred from realm host (realms-staging.stack.cards →\n` +
-      `                         boxel-host-staging.stack.cards, realms.stack.cards →\n` +
-      `                         boxel-host.stack.cards, *.localhost → http://localhost:4200).\n` +
+      `                         Default: inferred from realm host —\n` +
+      `                           realms-staging.stack.cards         → boxel-host-staging.stack.cards\n` +
+      `                           realms.stack.cards                 → boxel-host.stack.cards\n` +
+      `                           realm-server.<slug>.localhost      → host.<slug>.localhost\n` +
+      `                                                                (BOXEL_ENVIRONMENT mode)\n` +
+      `                           localhost / *.localhost (standard) → http://localhost:4200\n` +
       `                         REQUIRED when the realm host doesn't match these patterns.\n` +
       `  --output <path>        Override output path. Default: ${DEFAULT_OUTPUT_PATH}.\n` +
       `  --no-output            Don't write the JSON artifact (stdout only).\n` +
@@ -109,22 +117,40 @@ function parseArgs(argv: string[]): ParsedArgs {
   return { positional, opts };
 }
 
+// Infer the boxel-host base URL from the realm host. Recognised patterns
+// (mirrors the deployed-env Caddy config + local dev / env-mode Traefik
+// labels in `mise-tasks/lib/env-vars.sh`):
+//
+//   • realms-staging.stack.cards         → boxel-host-staging.stack.cards
+//   • realms.stack.cards                 → boxel-host.stack.cards
+//   • realm-server.<slug>.localhost      → host.<slug>.localhost  (env mode)
+//   • localhost(:NNNN) / *.localhost     → http://localhost:4200  (standard mode)
+//
+// Returns null for anything else; main() then prompts the operator to
+// pass --host-url. Constrained to `.stack.cards` so any future deployment
+// using a `realms-` prefix on a different domain isn't silently mapped
+// to a wrong (and non-existent) host.
 function inferHost(realmURL: string): string | null {
   const u = new URL(realmURL);
-  if (u.hostname === 'localhost' || u.hostname.endsWith('.localhost')) {
+  const hostname = u.hostname;
+  // Env-mode local: realm-server.<slug>.localhost → host.<slug>.localhost
+  const envMatch = hostname.match(/^realm-server\.(.+)\.localhost$/);
+  if (envMatch) {
+    return `${u.protocol}//host.${envMatch[1]}.localhost`;
+  }
+  // Standard local: any *.localhost (including bare 'localhost'). Standard
+  // dev-server boxel-host is always on :4200.
+  if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
     return `${u.protocol}//localhost:4200`;
   }
-  if (u.hostname.startsWith('realms-')) {
-    return `${u.protocol}//${u.hostname.replace(/^realms-/, 'boxel-host-')}`;
+  // Deployed: realms-<env>.stack.cards → boxel-host-<env>.stack.cards
+  if (hostname.startsWith('realms-') && hostname.endsWith('.stack.cards')) {
+    return `${u.protocol}//${hostname.replace(/^realms-/, 'boxel-host-')}`;
   }
-  if (u.hostname === 'realms.stack.cards') {
+  if (hostname === 'realms.stack.cards') {
     return `${u.protocol}//boxel-host.stack.cards`;
   }
   return null;
-}
-
-function ensureTrailingSlash(s: string): string {
-  return s.endsWith('/') ? s : s + '/';
 }
 
 // Mirrors `userIdFromUsername` in
@@ -244,14 +270,99 @@ function promptSeedSilently(question: string): Promise<string> {
   });
 }
 
+const VALID_PERMISSIONS = new Set([
+  'read',
+  'write',
+  'realm-owner',
+  'assume-user',
+]);
+// Loose Matrix-ID validation — the realm-server has stricter rules but a
+// fail-fast here prevents typos like `@ctse-stack.cards` (missing colon)
+// from minting a token that produces a confusing 401 minutes later.
+const MATRIX_ID_RE = /^@[A-Za-z0-9._=\-/+]+:[A-Za-z0-9.\-:]+$/;
+
 async function main(): Promise<void> {
   const { positional, opts } = parseArgs(process.argv.slice(2));
   if (opts.help || positional.length < 1) {
     usage();
     process.exit(opts.help ? 0 : 2);
   }
-  const realmURL = ensureTrailingSlash(positional[0]);
+  // Validate the realm URL up front with an actionable error rather
+  // than letting `new URL()` throw bare "Invalid URL" deep in main.
+  let realmURL: string;
+  try {
+    realmURL = ensureTrailingSlash(new URL(positional[0]).href);
+  } catch {
+    process.stderr.write(
+      `error: <realm-url> is not a valid URL: ${positional[0]}\n` +
+        `       Expected something like https://realms-staging.stack.cards/ctse/myrealm/.\n`,
+    );
+    process.exit(2);
+  }
   const realmOrigin = ensureTrailingSlash(new URL(realmURL).origin);
+
+  // Resolve userId before requesting the seed: bad URL/system-realm/bad
+  // --user should fail fast without prompting (and discarding) a
+  // freshly-pasted seed.
+  let userId = opts.user as string | undefined;
+  if (userId) {
+    if (!MATRIX_ID_RE.test(userId)) {
+      process.stderr.write(
+        `error: --user must be a Matrix ID like '@user:host', got '${userId}'\n`,
+      );
+      process.exit(2);
+    }
+  } else {
+    const derived = deriveUserFromURL(realmURL);
+    if (!derived) {
+      process.stderr.write(
+        `error: cannot derive user from realm URL ${realmURL}.\n` +
+          `       This looks like a system realm (single-segment path).\n` +
+          `       Pass --user <matrix-id> explicitly. System realms are\n` +
+          `       owned by the realm-server bot, typically\n` +
+          `       @realm_server:${deriveMatrixDomain(realmURL)}.\n`,
+      );
+      process.exit(2);
+    }
+    userId = derived;
+  }
+
+  // Validate permissions before the seed prompt, same reasoning.
+  const permissionsOpt = opts.permissions as string | undefined;
+  const permissions = permissionsOpt
+    ? permissionsOpt
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [...DEFAULT_PERMISSIONS];
+  const invalidPerms = permissions.filter((p) => !VALID_PERMISSIONS.has(p));
+  if (invalidPerms.length) {
+    process.stderr.write(
+      `error: --permissions contains unknown values: ${invalidPerms.join(', ')}\n` +
+        `       Valid values: ${[...VALID_PERMISSIONS].join(', ')}\n`,
+    );
+    process.exit(2);
+  }
+
+  // Resolve hostUrl before signing/printing — failing here would leak a
+  // valid JWT to stdout while exiting with a usage error.
+  const hostUrl =
+    (opts['host-url'] as string | undefined) ?? inferHost(realmURL);
+  if (!hostUrl) {
+    process.stderr.write(
+      `error: cannot infer boxel-host URL from realm host '${new URL(realmURL).hostname}'.\n` +
+        `       Pass --host-url <url> explicitly. Recognised patterns:\n` +
+        `         realms-staging.stack.cards         → boxel-host-staging.stack.cards\n` +
+        `         realms.stack.cards                 → boxel-host.stack.cards\n` +
+        `         realm-server.<slug>.localhost      → host.<slug>.localhost\n` +
+        `                                              (BOXEL_ENVIRONMENT mode)\n` +
+        `         localhost / *.localhost (standard) → http://localhost:4200\n`,
+    );
+    process.exit(2);
+  }
+
+  // Seed last — by this point everything else has validated, so the seed
+  // is the final input we ask for.
   const rawSecret =
     positional.length >= 2
       ? positional[1]
@@ -266,36 +377,6 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  let userId = opts.user as string | undefined;
-  if (!userId) {
-    const derived = deriveUserFromURL(realmURL);
-    if (!derived) {
-      process.stderr.write(
-        `error: cannot derive user from realm URL ${realmURL}.\n` +
-          `       This looks like a system realm (single-segment path).\n` +
-          `       Pass --user <matrix-id> explicitly. For system realms\n` +
-          `       owned by the realm-server bot, that's typically\n` +
-          `       @realm:${deriveMatrixDomain(realmURL)}.\n`,
-      );
-      process.exit(2);
-    }
-    userId = derived;
-  }
-
-  // The realm-server's checkPermission (`packages/runtime-common/realm.ts:2308`)
-  // requires JSON.stringify(token.permissions.sort()) === JSON.stringify(
-  // userPermissions.sort()) — the token's permissions must EXACTLY match
-  // what the realm's DB has for this user. Default = DEFAULT_PERMISSIONS from
-  // runtime-common (the same shape new realms grant their owner); pass
-  // --permissions for non-owner users (read-only collaborator, etc.).
-  const permissionsOpt = opts.permissions as string | undefined;
-  const permissions = permissionsOpt
-    ? permissionsOpt
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean)
-    : [...DEFAULT_PERMISSIONS];
-
   const claims: TokenClaims = {
     user: userId,
     realm: realmURL,
@@ -308,23 +389,6 @@ async function main(): Promise<void> {
 
   process.stdout.write(`JWT=${token}\n`);
   process.stdout.write(`SESSION=${session}\n`);
-
-  // Resolve hostUrl: explicit --host-url override wins; otherwise infer
-  // from realm host. Fail fast (rather than emitting a `null` hostUrl
-  // into the artifact) when inference can't produce a usable value —
-  // every downstream consumer needs hostUrl to build the /render URL.
-  const hostUrl =
-    (opts['host-url'] as string | undefined) ?? inferHost(realmURL);
-  if (!hostUrl) {
-    process.stderr.write(
-      `error: cannot infer boxel-host URL from realm host '${new URL(realmURL).hostname}'.\n` +
-        `       Pass --host-url <url> explicitly. Recognised patterns:\n` +
-        `         realms-staging.stack.cards → boxel-host-staging.stack.cards\n` +
-        `         realms.stack.cards         → boxel-host.stack.cards\n` +
-        `         *.localhost / localhost    → http://localhost:4200\n`,
-    );
-    process.exit(2);
-  }
 
   if (opts['no-output']) return;
 
@@ -342,19 +406,30 @@ async function main(): Promise<void> {
   };
   try {
     mkdirSync(dirname(outputPath), { recursive: true });
-    // Open with mode 0o600 from the start — `writeFileSync(path, data,
-    // {mode})` honors mode only when the path doesn't already exist, so
-    // first delete any prior file. The unlink + create-with-mode dance
-    // closes the umask-window the chmod-after-write pattern leaves open
-    // on multi-user systems.
+    // The default output path is in /tmp, which is shared on multi-user
+    // hosts and the filename is predictable — defend against a prior
+    // attacker-planted symlink (which `writeFileSync` would follow,
+    // dumping the JWT into an attacker-controlled location).
+    //
+    // `O_NOFOLLOW` makes the kernel refuse the open if the final path
+    // component is a symlink. `O_TRUNC` clears any prior content;
+    // `O_CREAT` creates the file with `0o600` from the start (no umask
+    // window). The `unlink+writeFileSync` two-call pattern has a TOCTOU
+    // race in between; a single `openSync` with these flags is atomic.
+    const data = Buffer.from(JSON.stringify(artifact, null, 2) + '\n');
+    const fd = openSync(
+      outputPath,
+      fsConstants.O_WRONLY |
+        fsConstants.O_CREAT |
+        fsConstants.O_TRUNC |
+        fsConstants.O_NOFOLLOW,
+      0o600,
+    );
     try {
-      unlinkSync(outputPath);
-    } catch {
-      // not present, nothing to remove
+      writeSync(fd, data);
+    } finally {
+      closeSync(fd);
     }
-    writeFileSync(outputPath, JSON.stringify(artifact, null, 2) + '\n', {
-      mode: 0o600,
-    });
     process.stderr.write(`\nWrote artifact: ${outputPath}\n`);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/packages/realm-server/scripts/claude-prerender-token.ts
+++ b/packages/realm-server/scripts/claude-prerender-token.ts
@@ -1,0 +1,305 @@
+// Mint a realm-scoped JWT (boxel-session value) the way the indexer
+// does. Lets Claude (via Chrome MCP) reproduce a render in a real
+// browser without going through Matrix login.
+//
+// Mirrors `buildCreatePrerenderAuth` in
+// `packages/realm-server/prerender/auth.ts`.
+//
+// This script is intentionally narrow: the JWT/session is realm-scoped,
+// not card-scoped — once Claude has the session, it constructs the
+// /render URL itself for whichever card it's investigating. The URL
+// recipe is documented in the indexing-diagnostics skill.
+
+/* eslint-env node */
+
+import * as readline from 'node:readline';
+import { Writable } from 'node:stream';
+import { writeFileSync, chmodSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import jwt from 'jsonwebtoken';
+
+// Default file Claude reads to pick up the artifacts without the user
+// pasting anything. Bounded leak window — the JWT inside is 1d.
+const DEFAULT_OUTPUT_PATH = '/tmp/claude-prerender.json';
+
+interface ParsedArgs {
+  positional: string[];
+  opts: { [k: string]: string | boolean };
+}
+
+interface TokenClaims {
+  user: string;
+  realm: string;
+  sessionRoom: string;
+  permissions: string[];
+  realmServerURL: string;
+}
+
+function usage(): void {
+  process.stderr.write(
+    `Usage: claude-prerender-token <realm-url> [<seed>] [options]\n` +
+      `\n` +
+      `Mints a realm-scoped boxel-session JWT (the same shape the indexer's\n` +
+      `prerender tab uses) and writes a JSON artifact to ${DEFAULT_OUTPUT_PATH}\n` +
+      `for Claude to pick up. Claude builds the /render URL itself per the\n` +
+      `recipe in the indexing-diagnostics skill — no card needed here.\n` +
+      `\n` +
+      `Args:\n` +
+      `  <realm-url>  e.g. https://realms-staging.stack.cards/ctse/myrealm/\n` +
+      `  <seed>       REALM_SECRET_SEED for the target environment.\n` +
+      `               If omitted, prompts interactively (paste-friendly, masked\n` +
+      `               with '*' so you can see each char landed; the seed itself\n` +
+      `               never echoes to the terminal or shell history).\n` +
+      `\n` +
+      `Options:\n` +
+      `  --user <matrix-id>     Override the Matrix user ID claim. Default: derived\n` +
+      `                         from the realm URL path (e.g. /ctse/realm/ → @ctse:stack.cards).\n` +
+      `                         REQUIRED for system realms (1-segment paths like /catalog/),\n` +
+      `                         where the owner is typically @realm:<matrix-domain>.\n` +
+      `                         The realm-server checks this against its permissions\n` +
+      `                         DB, so it MUST be a user that actually has perms on\n` +
+      `                         the target realm.\n` +
+      `  --output <path>        Override output path. Default: ${DEFAULT_OUTPUT_PATH}.\n` +
+      `  --no-output            Don't write the JSON artifact (stdout only).\n` +
+      `  --help                 Show this help.\n`,
+  );
+}
+
+const BOOLEAN_FLAGS = new Set(['no-output']);
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const positional: string[] = [];
+  const opts: ParsedArgs['opts'] = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      opts.help = true;
+    } else if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      if (BOOLEAN_FLAGS.has(key)) {
+        opts[key] = true;
+        continue;
+      }
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        process.stderr.write(`error: --${key} requires a value\n`);
+        process.exit(2);
+      }
+      opts[key] = next;
+      i++;
+    } else {
+      positional.push(arg);
+    }
+  }
+  return { positional, opts };
+}
+
+function inferHost(realmURL: string): string | null {
+  const u = new URL(realmURL);
+  if (u.hostname === 'localhost' || u.hostname.endsWith('.localhost')) {
+    return `${u.protocol}//localhost:4200`;
+  }
+  if (u.hostname.startsWith('realms-')) {
+    return `${u.protocol}//${u.hostname.replace(/^realms-/, 'boxel-host-')}`;
+  }
+  if (u.hostname === 'realms.stack.cards') {
+    return `${u.protocol}//boxel-host.stack.cards`;
+  }
+  return null;
+}
+
+function ensureTrailingSlash(s: string): string {
+  return s.endsWith('/') ? s : s + '/';
+}
+
+// Mirrors `userIdFromUsername` in
+// `packages/runtime-common/matrix-client.ts`: take the matrix server's
+// host (here, derived from the realm URL) and produce the second-level
+// domain — `realms-staging.stack.cards` → `stack.cards`. *.localhost
+// stays `localhost` to match the dev-environment routing convention.
+function deriveMatrixDomain(realmURL: string): string {
+  const hostname = new URL(realmURL).hostname;
+  if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
+    return 'localhost';
+  }
+  return hostname.split('.').slice(-2).join('.');
+}
+
+// Derive the realm-owner Matrix user ID from a realm URL of shape
+// `<host>/<username>/<realmname>/`. Returns null for system realms
+// (single-segment paths like `/catalog/`, `/experiments/`) — those
+// have no path-derivable owner and require --user.
+function deriveUserFromURL(realmURL: string): string | null {
+  const u = new URL(realmURL);
+  const segments = u.pathname.split('/').filter(Boolean);
+  if (segments.length < 2) {
+    return null;
+  }
+  const username = segments[0];
+  return `@${username}:${deriveMatrixDomain(realmURL)}`;
+}
+
+// Read the seed from stdin. If stdin is a TTY, each keystroke is echoed
+// as `*` so the user has visual confirmation that paste landed — ported
+// from `packages/boxel-cli/src/lib/prompt.ts`'s `promptPassword`
+// (handles bracketed-paste markers, backspace, Ctrl+C). If stdin is
+// piped/redirected, reads it all synchronously and returns trimmed.
+function promptSeedSilently(question: string): Promise<string> {
+  if (!process.stdin.isTTY) {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      process.stdin.on('data', (chunk: Buffer) => chunks.push(chunk));
+      process.stdin.on('end', () =>
+        resolve(Buffer.concat(chunks).toString('utf8').trim()),
+      );
+      process.stdin.on('error', reject);
+      process.stdin.resume();
+    });
+  }
+  const mutableOutput = new Writable({
+    write: (_chunk, _encoding, callback) => callback(),
+  });
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: mutableOutput,
+    terminal: true,
+  });
+
+  return new Promise((resolve, reject) => {
+    const stdin = process.stdin;
+    const wasFlowing = stdin.readableFlowing;
+
+    if (stdin.isTTY) {
+      stdin.setRawMode(true);
+    }
+
+    const cleanup = () => {
+      stdin.removeListener('data', onData);
+      if (stdin.isTTY) {
+        stdin.setRawMode(false);
+      }
+      rl.close();
+      if (!wasFlowing) {
+        stdin.pause();
+      }
+    };
+
+    let password = '';
+    const onData = (chunk: Buffer) => {
+      try {
+        const raw = chunk
+          .toString()
+          .split('[200~')
+          .join('')
+          .split('[201~')
+          .join('');
+        for (const c of raw) {
+          if (c === '\n' || c === '\r') {
+            cleanup();
+            process.stderr.write('\n');
+            resolve(password);
+            return;
+          } else if (c === '\x03') {
+            cleanup();
+            process.exit(130);
+          } else if (c === '\x7f' || c === '\b') {
+            if (password.length > 0) {
+              password = password.slice(0, -1);
+              process.stderr.write('\b \b');
+            }
+          } else if (c >= ' ') {
+            password += c;
+            process.stderr.write('*');
+          }
+        }
+      } catch (e) {
+        cleanup();
+        reject(e);
+      }
+    };
+
+    try {
+      process.stderr.write(question);
+      stdin.on('data', onData);
+      stdin.resume();
+    } catch (e) {
+      cleanup();
+      reject(e);
+    }
+  });
+}
+
+async function main(): Promise<void> {
+  const { positional, opts } = parseArgs(process.argv.slice(2));
+  if (opts.help || positional.length < 1) {
+    usage();
+    process.exit(opts.help ? 0 : 2);
+  }
+  const realmURL = ensureTrailingSlash(positional[0]);
+  const realmOrigin = ensureTrailingSlash(new URL(realmURL).origin);
+  const secret =
+    positional.length >= 2
+      ? positional[1]
+      : await promptSeedSilently('Paste seed: ');
+
+  let userId = opts.user as string | undefined;
+  if (!userId) {
+    const derived = deriveUserFromURL(realmURL);
+    if (!derived) {
+      process.stderr.write(
+        `error: cannot derive user from realm URL ${realmURL}.\n` +
+          `       This looks like a system realm (single-segment path).\n` +
+          `       Pass --user <matrix-id> explicitly. For system realms\n` +
+          `       owned by the realm-server bot, that's typically\n` +
+          `       @realm:${deriveMatrixDomain(realmURL)}.\n`,
+      );
+      process.exit(2);
+    }
+    userId = derived;
+  }
+
+  const claims: TokenClaims = {
+    user: userId,
+    realm: realmURL,
+    sessionRoom: '',
+    permissions: ['read', 'realm-owner'],
+    realmServerURL: realmOrigin,
+  };
+  const token = jwt.sign(claims, secret, { expiresIn: '1d' });
+  const session = JSON.stringify({ [realmURL]: token });
+
+  process.stdout.write(`JWT=${token}\n`);
+  process.stdout.write(`SESSION=${session}\n`);
+
+  if (opts['no-output']) return;
+
+  const outputPath = (opts.output as string | undefined) ?? DEFAULT_OUTPUT_PATH;
+  const decoded = jwt.decode(token) as { iat?: number; exp?: number } | null;
+  const artifact = {
+    mintedAt: new Date().toISOString(),
+    expiresAt:
+      decoded?.exp != null ? new Date(decoded.exp * 1000).toISOString() : null,
+    user: userId,
+    realmUrl: realmURL,
+    hostUrl: inferHost(realmURL),
+    jwt: token,
+    session,
+  };
+  try {
+    mkdirSync(dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, JSON.stringify(artifact, null, 2) + '\n');
+    chmodSync(outputPath, 0o600);
+    process.stderr.write(`\nWrote artifact: ${outputPath}\n`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    process.stderr.write(
+      `warning: failed to write artifact to ${outputPath}: ${msg}\n` +
+        `         (stdout output above is the same data; pass --no-output to silence this.)\n`,
+    );
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`error: ${err instanceof Error ? err.message : err}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a CLI tool (`mise run claude-prerender-token`) that lets Claude reproduce a card render in a real browser via Chrome MCP, against any environment (local / staging / prod). Faithful CLI port of the indexer's `buildCreatePrerenderAuth` (`packages/realm-server/prerender/auth.ts`) — same claims, same HS256/1d, same `JSON.stringify({ <realmUrl>: <jwt> })` map shape that lands in `localStorage['boxel-session']`.

The motivation is replacing Path B's "turn on `prerenderer-reproduce=debug`, trigger a reindex, scrape the log line" loop with a direct mint that doesn't require server config changes. Particularly useful on staging/prod where the log channel is off and CloudWatch's filter doesn't always retain enough history.

The script is intentionally narrow — it mints the JWT/session and nothing else. Claude reads the artifact at `/tmp/claude-prerender.json`, derives the host-app URL from the realm URL per the table in the skill, and builds the `/render` URL itself for whichever card is being investigated.

## How a user authorizes Claude to perform a prerender investigation

The flow is structured so the user's `REALM_SECRET_SEED` never enters Claude's context — neither typed in chat, pasted, nor read from a file Claude can access. The asymmetry is deliberate: the seed mints arbitrary user-impersonating tokens with arbitrary permissions on every realm on the realm-server. A 1-day JWT for a single user is a bounded leak; the seed is unbounded. We never grant SSM read perms on the seed parameter to any programmatic identity (Claude's `boxel-claude-readonly` IAM role can't read it, and we don't recommend any wrapper script that does either) — **the seed must be obtained manually via the AWS Console UI**.

### What the user does

```bash
# 1. Fetch the seed via AWS Console UI:
#    SSM → Parameter Store → /staging/boxel/REALM_SECRET_SEED → "Show"
#    (or /production/boxel/REALM_SECRET_SEED for prod)
#    Copy the value to the clipboard.

# 2. Run the mise task. URL is the only required argument; the seed
#    is prompted interactively with masked input (each char echoes as
#    '*' so paste lands visibly, but the seed itself never appears in
#    the terminal scrollback or shell history).
cd .claude/worktrees/claude-prerender-token-skill   # or wherever the branch is checked out
mise run claude-prerender-token https://realms-staging.stack.cards/ctse/concrete-mockingbird/

# Paste seed (input hidden, press Enter when done): *********************************
#
# JWT=eyJ...
# SESSION={"https://realms-staging.stack.cards/ctse/concrete-mockingbird/":"eyJ..."}
#
# Wrote artifact: /tmp/claude-prerender.json

# 3. Tell Claude you've run it. Claude reads /tmp/claude-prerender.json
#    directly — no paste-back needed.
```

For local dev the seed is the hardcoded `"shhh! it's a secret"` string from the dev mise tasks; pass it positionally (mind the warning that positional args are visible in `ps` and may persist in shell history):

```bash
# Standard local dev
mise run claude-prerender-token http://localhost:4201/ctse/myrealm/ "shhh! it's a secret"

# BOXEL_ENVIRONMENT=parallel mode
mise run claude-prerender-token http://realm-server.parallel.localhost/ctse/myrealm/ "shhh! it's a secret"
```

For non-owner users (read-only collaborators, etc.), pass `--user @collab:host --permissions read` so the JWT's permissions array matches the DB row exactly.

### What Claude does

1. Reads `/tmp/claude-prerender.json`.
2. Sanity-checks `expiresAt` is in the future, `mintedAt` is recent, and `realmUrl` matches the realm of the card under investigation. If any check fails, asks the user to re-mint instead of reusing.
3. Derives the host-app URL from the realm URL per the inference table in the skill (deployed-env Caddy + local-dev/env-mode Traefik patterns). Asks the user if the realm host doesn't match any known pattern.
4. Builds the `/render` URL for the specific card per the formula documented in the skill: `<hostUrl>/render/<encodeURIComponent(cardUrl-with-.json)>/<nonce>/<encodeURIComponent(JSON.stringify(options))>/html/<format>/0`.
5. Drives Chrome MCP: opens the host, sets `localStorage['boxel-session']` to the `session` field, navigates to the render URL, polls `data-prerender-status`, calls `__boxelRenderDiagnostics()`, and inspects the console for unminified stack frames.

Hard rules baked into the skill (and Claude's per-project memory):

- Claude does not ask for the seed.
- Claude does not propose pasting it into the conversation.
- Claude does not call `aws ssm get-parameter` on `REALM_SECRET_SEED` or recommend the user do so (we never grant SSM read perms on the seed; AWS Console UI only).

If a teammate accidentally pastes the seed in chat, Claude flags the slip and asks them to rotate it rather than acting on it.

## Auth model (why the user-derivation matters)

The realm-server's `checkPermission` (`packages/runtime-common/realm.ts:2249`) does three things in order:

1. **Verify the JWT signature** against `REALM_SECRET_SEED` (HS256). Anyone with the seed can mint a valid signature — that's the diagnostic gate.
2. **Look up the token's `user` claim in the realm's permission table** via `RealmPermissionChecker.for(username)` (`packages/runtime-common/realm-permission-checker.ts`).
3. **Compare the JWT's `permissions` array against the DB's permissions array, sorted, byte-for-byte equal** (`runtime-common/realm.ts:2306-2316`). The check is `JSON.stringify(token.permissions.sort()) === JSON.stringify(userPermissions.sort())`. A subset isn't enough.

So the `user` claim has to be a real Matrix ID — the script's default derivation matches: `https://realms-staging.stack.cards/ctse/realm/` → `@ctse:stack.cards` (the realm-owner row). And the `permissions` claim has to exactly equal the DB row — defaulting to `DEFAULT_PERMISSIONS` from `runtime-common` (the standard realm-owner shape `['read','write','realm-owner']`), with `--permissions` for non-owner users.

For system realms (`/catalog/`, `/experiments/`, etc., 1-segment paths), the script errors and asks for `--user @realm_server:<matrix-domain>` (the realm-server bot — `REALM_SERVER_MATRIX_USERNAME=realm_server`).

For local dev: matrix `server_name` is `localhost`, so user IDs are `@<username>:localhost`. Both standard mode (`http://localhost:4201`) and `BOXEL_ENVIRONMENT` mode (`http://realm-server.<slug>.localhost`) are supported by the host inference Claude does in the skill — matrix isn't part of this flow at all (the realm-server's auth check is HS256-signature + DB-row equality, no matrix contact).

Public realms with `'*': ['read']` need no token — published realms always get this set.

## Test plan

- [x] `pnpm lint:js` passes in `packages/realm-server`.
- [x] Smoke-tested every input path from a non-TTY environment: positional seed, piped stdin, empty seed (rejected), bad URL (rejected), bad `--user` / `--permissions` (rejected), `--user` override for system realms, `--no-output`, `--output <path>`.
- [x] JWT structure verified: header `{"alg":"HS256","typ":"JWT"}`, payload contains the expected `{user, realm, sessionRoom: '', permissions, realmServerURL, iat, exp}` claims, signature matches `jsonwebtoken.sign(claims, seed, {expiresIn: '1d'})`, `exp - iat = 86400`.
- [x] Auto-derived user `@ctse:stack.cards` confirmed against the staging `realm_user_permissions` table.
- [x] BOXEL_ENVIRONMENT-mode local pattern produces `host.<slug>.localhost` correctly when Claude derives it from the realm URL.
- [x] Artifact created with mode `0600` from the start (verified via `stat`).
- [x] `O_NOFOLLOW` open prevents writing through a planted symlink in /tmp.
- [x] JWT/SESSION not leaked to stdout when validation fails.
- [x] End-to-end Chrome MCP repro of a real failing render against staging — used to expose the original `Render binding desync` (PermissionMismatch finding led to the `--permissions` flag and `DEFAULT_PERMISSIONS` default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)