### PR TITLE
Surface additionalErrors in error pane and Fix-with-AI

### DIFF
--- a/packages/base/matrix-event.gts
+++ b/packages/base/matrix-event.gts
@@ -176,6 +176,17 @@ export interface BoxelErrorForContext {
   message: string;
   stack?: string;
   sourceUrl?: string;
+  // CS-10977: optional structured payload carried alongside the message/stack
+  // so consumers (CopyButton, AI assistant, error context) can include the
+  // captured browser console errors and prerender diagnostics that the
+  // render runner attached to the error doc.
+  additionalErrors?: Array<{
+    message?: string;
+    stack?: string;
+    status?: number;
+    title?: string;
+  }> | null;
+  diagnostics?: Record<string, unknown>;
 }
 
 export interface BoxelContext {

--- a/packages/host/app/components/operator-mode/card-error-detail.gts
+++ b/packages/host/app/components/operator-mode/card-error-detail.gts
@@ -33,6 +33,24 @@ export default class CardErrorDetail extends Component<Signature> {
     return this.args.error.meta.diagnostics ?? undefined;
   }
 
+  private get additionalErrors():
+    | Array<{
+        message?: string;
+        stack?: string;
+        status?: number;
+        title?: string;
+      }>
+    | undefined {
+    let raw = this.args.error.additionalErrors;
+    if (!raw) return undefined;
+    return raw as Array<{
+      message?: string;
+      stack?: string;
+      status?: number;
+      title?: string;
+    }>;
+  }
+
   <template>
     <div class='error-detail' ...attributes>
       <ErrorDisplay
@@ -41,6 +59,7 @@ export default class CardErrorDetail extends Component<Signature> {
         @message={{if this.message this.message @error.title}}
         @stack={{this.stack}}
         @diagnostics={{this.diagnostics}}
+        @additionalErrors={{this.additionalErrors}}
         @fileToAttach={{@fileToFixWithAi}}
         @viewInCodeMode={{@viewInCodeMode}}
         @cardId={{@error.id}}

--- a/packages/host/app/components/operator-mode/error-display.gts
+++ b/packages/host/app/components/operator-mode/error-display.gts
@@ -213,7 +213,8 @@ export default class ErrorDisplay
   // (full display bounds) and runs its own AI-prompt budget on top.
   getError(): BoxelErrorForContext {
     return {
-      message: truncate(this.args.message ?? '', CONTEXT_MESSAGE_MAX_CHARS) ?? '',
+      message:
+        truncate(this.args.message ?? '', CONTEXT_MESSAGE_MAX_CHARS) ?? '',
       stack: truncate(this.args.stack, CONTEXT_STACK_MAX_CHARS),
       additionalErrors: this.contextAdditionalErrors,
       diagnostics: this.args.diagnostics,

--- a/packages/host/app/components/operator-mode/error-display.gts
+++ b/packages/host/app/components/operator-mode/error-display.gts
@@ -57,16 +57,30 @@ interface Signature {
 
 // Truncation budgets for the human-facing pane. The serialized error doc
 // is already clamped server-side (see clampSerializedError), but the
-// operator shouldn't see a 64KiB stack trace inline.
+// operator shouldn't see a 64KiB stack trace inline. These count UTF-16
+// code units (string.length), not bytes.
 const ADDITIONAL_ERRORS_DISPLAY_LIMIT = 20;
-const ADDITIONAL_ERROR_MESSAGE_MAX_BYTES = 2 * 1024;
-const ADDITIONAL_ERROR_STACK_MAX_BYTES = 4 * 1024;
+const ADDITIONAL_ERROR_MESSAGE_MAX_CHARS = 2 * 1024;
+const ADDITIONAL_ERROR_STACK_MAX_CHARS = 4 * 1024;
+
+// Tighter budget for the context payload that flows to AI assistant
+// chat sends via getError() / errorsDisplayed. Every chat message
+// includes this on every error currently visible, so it has to fit
+// well below the Matrix event size limit even with multiple errors
+// on screen. Tuned for ~7-8KB max per error.
+const ADDITIONAL_ERRORS_CONTEXT_LIMIT = 5;
+const ADDITIONAL_ERROR_CONTEXT_MESSAGE_MAX_CHARS = 512;
+const ADDITIONAL_ERROR_CONTEXT_STACK_MAX_CHARS = 1024;
+const CONTEXT_STACK_MAX_CHARS = 4 * 1024;
+const CONTEXT_MESSAGE_MAX_CHARS = 2 * 1024;
+
 const TRUNCATION_SUFFIX = ' …[truncated]';
 
 function truncate(s: string | undefined, max: number): string | undefined {
   if (s == null) return s;
   if (s.length <= max) return s;
-  return s.slice(0, max) + TRUNCATION_SUFFIX;
+  let body = Math.max(0, max - TRUNCATION_SUFFIX.length);
+  return s.slice(0, body) + TRUNCATION_SUFFIX;
 }
 
 export default class ErrorDisplay
@@ -96,11 +110,15 @@ export default class ErrorDisplay
 
   private toggleDetails = () => (this.showDetails = !this.showDetails);
 
+  // Payload for CopyButton (clipboard copy, no transit constraint) and
+  // the Fix-with-AI button (which applies its own AI-prompt budget on
+  // top). Uses the display-pane bounds so users get the same view they
+  // see in the overlay.
   private get errorObject() {
     return {
       message: this.args.message ?? '',
       stack: this.args.stack,
-      additionalErrors: this.args.additionalErrors ?? undefined,
+      additionalErrors: this.normalizedAdditionalErrors,
       diagnostics: this.args.diagnostics,
     };
   }
@@ -113,16 +131,50 @@ export default class ErrorDisplay
         title?: string;
       }>
     | undefined {
+    return this.boundAdditionalErrors(
+      ADDITIONAL_ERRORS_DISPLAY_LIMIT,
+      ADDITIONAL_ERROR_MESSAGE_MAX_CHARS,
+      ADDITIONAL_ERROR_STACK_MAX_CHARS,
+    );
+  }
+
+  private get contextAdditionalErrors():
+    | Array<{
+        message?: string;
+        stack?: string;
+        status?: number;
+        title?: string;
+      }>
+    | undefined {
+    return this.boundAdditionalErrors(
+      ADDITIONAL_ERRORS_CONTEXT_LIMIT,
+      ADDITIONAL_ERROR_CONTEXT_MESSAGE_MAX_CHARS,
+      ADDITIONAL_ERROR_CONTEXT_STACK_MAX_CHARS,
+    );
+  }
+
+  private boundAdditionalErrors(
+    entryLimit: number,
+    messageMax: number,
+    stackMax: number,
+  ):
+    | Array<{
+        message?: string;
+        stack?: string;
+        status?: number;
+        title?: string;
+      }>
+    | undefined {
     let raw = this.args.additionalErrors;
     if (!raw || raw.length === 0) return undefined;
-    let entries = raw.slice(0, ADDITIONAL_ERRORS_DISPLAY_LIMIT).map((e) => ({
-      message: truncate(e?.message, ADDITIONAL_ERROR_MESSAGE_MAX_BYTES),
-      stack: truncate(e?.stack, ADDITIONAL_ERROR_STACK_MAX_BYTES),
+    let entries = raw.slice(0, entryLimit).map((e) => ({
+      message: truncate(e?.message, messageMax),
+      stack: truncate(e?.stack, stackMax),
       status: e?.status,
       title: e?.title,
     }));
-    if (raw.length > ADDITIONAL_ERRORS_DISPLAY_LIMIT) {
-      let omitted = raw.length - ADDITIONAL_ERRORS_DISPLAY_LIMIT;
+    if (raw.length > entryLimit) {
+      let omitted = raw.length - entryLimit;
       entries.push({
         title: 'Errors omitted',
         message: `${omitted} additional errors hidden`,
@@ -137,13 +189,34 @@ export default class ErrorDisplay
     return this.args.additionalErrors?.length ?? 0;
   }
 
+  // diagnostics/additionalErrors can in principle contain
+  // non-JSON-serializable values (circulars, getters that throw). Fall
+  // back to the minimal payload so the overlay never breaks on a copy
+  // request.
   private get errorText() {
-    return JSON.stringify(this.errorObject);
+    try {
+      return JSON.stringify(this.errorObject);
+    } catch {
+      return JSON.stringify({
+        message: this.args.message ?? '',
+        stack: this.args.stack,
+      });
+    }
   }
 
+  // errorsDisplayed flows on every chat message context build (see
+  // OperatorModeStateService.getSummaryForAIBot → errorDisplay
+  // .getDisplayedErrors), so this payload has to stay small even with
+  // multiple errors visible. Tighter than errorObject's display bounds:
+  // 5 entries, 1KiB stack, 512B message per entry, plus top-level
+  // message/stack capped. Fix-with-AI receives errorObject directly
+  // (full display bounds) and runs its own AI-prompt budget on top.
   getError(): BoxelErrorForContext {
     return {
-      ...this.errorObject,
+      message: truncate(this.args.message ?? '', CONTEXT_MESSAGE_MAX_CHARS) ?? '',
+      stack: truncate(this.args.stack, CONTEXT_STACK_MAX_CHARS),
+      additionalErrors: this.contextAdditionalErrors,
+      diagnostics: this.args.diagnostics,
       sourceUrl: this.args.fileToAttach?.sourceUrl,
     };
   }

--- a/packages/host/app/components/operator-mode/error-display.gts
+++ b/packages/host/app/components/operator-mode/error-display.gts
@@ -38,11 +38,35 @@ interface Signature {
     // beneath the stack trace so operators can classify a timeout
     // without opening the DB or correlating CloudWatch logs.
     diagnostics?: Record<string, unknown>;
+    // CS-10977: additional errors carried on the error doc — typically
+    // browser console errors captured by the prerender runner.
+    // Shown as a collapsed list under the stack trace so the operator
+    // can see the underlying template throw that the runloop swallowed.
+    additionalErrors?: Array<{
+      message?: string;
+      stack?: string;
+      status?: number;
+      title?: string;
+    }> | null;
     openDetails?: boolean;
     fileToAttach?: FileDef;
     viewInCodeMode?: boolean;
     cardId?: string;
   };
+}
+
+// Truncation budgets for the human-facing pane. The serialized error doc
+// is already clamped server-side (see clampSerializedError), but the
+// operator shouldn't see a 64KiB stack trace inline.
+const ADDITIONAL_ERRORS_DISPLAY_LIMIT = 20;
+const ADDITIONAL_ERROR_MESSAGE_MAX_BYTES = 2 * 1024;
+const ADDITIONAL_ERROR_STACK_MAX_BYTES = 4 * 1024;
+const TRUNCATION_SUFFIX = ' …[truncated]';
+
+function truncate(s: string | undefined, max: number): string | undefined {
+  if (s == null) return s;
+  if (s.length <= max) return s;
+  return s.slice(0, max) + TRUNCATION_SUFFIX;
 }
 
 export default class ErrorDisplay
@@ -76,7 +100,41 @@ export default class ErrorDisplay
     return {
       message: this.args.message ?? '',
       stack: this.args.stack,
+      additionalErrors: this.args.additionalErrors ?? undefined,
+      diagnostics: this.args.diagnostics,
     };
+  }
+
+  private get normalizedAdditionalErrors():
+    | Array<{
+        message?: string;
+        stack?: string;
+        status?: number;
+        title?: string;
+      }>
+    | undefined {
+    let raw = this.args.additionalErrors;
+    if (!raw || raw.length === 0) return undefined;
+    let entries = raw.slice(0, ADDITIONAL_ERRORS_DISPLAY_LIMIT).map((e) => ({
+      message: truncate(e?.message, ADDITIONAL_ERROR_MESSAGE_MAX_BYTES),
+      stack: truncate(e?.stack, ADDITIONAL_ERROR_STACK_MAX_BYTES),
+      status: e?.status,
+      title: e?.title,
+    }));
+    if (raw.length > ADDITIONAL_ERRORS_DISPLAY_LIMIT) {
+      let omitted = raw.length - ADDITIONAL_ERRORS_DISPLAY_LIMIT;
+      entries.push({
+        title: 'Errors omitted',
+        message: `${omitted} additional errors hidden`,
+        stack: undefined,
+        status: undefined,
+      });
+    }
+    return entries;
+  }
+
+  private get additionalErrorsCount(): number {
+    return this.args.additionalErrors?.length ?? 0;
   }
 
   private get errorText() {
@@ -247,6 +305,39 @@ export default class ErrorDisplay
               >{{this.diagnosticsText}}</pre>
             </div>
           {{/if}}
+          {{#if this.normalizedAdditionalErrors}}
+            <div
+              class='detail-item'
+              data-test-error-additional-errors
+              data-test-error-additional-errors-count={{this.additionalErrorsCount}}
+            >
+              <div class='detail-title'>Additional Errors:</div>
+              {{#each this.normalizedAdditionalErrors as |entry index|}}
+                <div
+                  class='additional-error-entry'
+                  data-test-error-additional-error
+                  data-test-error-additional-error-index={{index}}
+                >
+                  <div
+                    class='additional-error-heading'
+                    data-test-error-additional-heading
+                  >{{if entry.title entry.title entry.message}}</div>
+                  {{#if entry.message}}
+                    <p
+                      class='additional-error-message'
+                      data-test-error-additional-message
+                    >{{entry.message}}</p>
+                  {{/if}}
+                  {{#if entry.stack}}
+                    <pre
+                      data-test-error-additional-stack
+                      data-test-percy-hide
+                    >{{entry.stack}}</pre>
+                  {{/if}}
+                </div>
+              {{/each}}
+            </div>
+          {{/if}}
         </div>
       {{/if}}
     </div>
@@ -393,6 +484,30 @@ export default class ErrorDisplay
         justify-content: center;
         gap: var(--boxel-sp);
         margin-top: var(--boxel-sp-lg);
+      }
+
+      .additional-error-entry {
+        margin-bottom: var(--boxel-sp);
+        padding-bottom: var(--boxel-sp-xs);
+        border-bottom: 1px solid var(--boxel-200, #ddd);
+      }
+
+      .additional-error-entry:last-child {
+        margin-bottom: 0;
+        padding-bottom: 0;
+        border-bottom: none;
+      }
+
+      .additional-error-heading {
+        font-weight: 600;
+        margin-bottom: var(--boxel-sp-xxs);
+        word-break: break-word;
+      }
+
+      .additional-error-message {
+        margin: 0 0 var(--boxel-sp-xs) 0;
+        font-size: var(--boxel-font-size-sm);
+        word-break: break-word;
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/error-display.gts
+++ b/packages/host/app/components/operator-mode/error-display.gts
@@ -318,10 +318,12 @@ export default class ErrorDisplay
                   data-test-error-additional-error
                   data-test-error-additional-error-index={{index}}
                 >
-                  <div
-                    class='additional-error-heading'
-                    data-test-error-additional-heading
-                  >{{if entry.title entry.title entry.message}}</div>
+                  {{#if entry.title}}
+                    <div
+                      class='additional-error-heading'
+                      data-test-error-additional-heading
+                    >{{entry.title}}</div>
+                  {{/if}}
                   {{#if entry.message}}
                     <p
                       class='additional-error-message'

--- a/packages/host/app/components/operator-mode/send-error-to-ai-assistant.gts
+++ b/packages/host/app/components/operator-mode/send-error-to-ai-assistant.gts
@@ -21,10 +21,32 @@ interface Signature {
     error: {
       message: string;
       stack?: string;
+      // CS-10977: optional structured payload — additional errors
+      // captured by the prerender runner and prerender diagnostics
+      // pulled off the error doc. Forwarded into the AI prompt body
+      // so the assistant has the underlying template throw and the
+      // timing context, not just the swallowed top-level message.
+      additionalErrors?: Array<{
+        message?: string;
+        stack?: string;
+        status?: number;
+        title?: string;
+      }>;
+      diagnostics?: Record<string, unknown>;
     };
     errorType: 'syntax' | 'runtime';
     fileToAttach: FileDef;
   };
+}
+
+const AI_ADDITIONAL_ERROR_STACK_MAX_BYTES = 8 * 1024;
+const AI_ADDITIONAL_ERRORS_LIMIT = 50;
+const AI_TRUNCATION_SUFFIX = ' …[truncated]';
+
+function truncateForAi(s: string | undefined, max: number): string | undefined {
+  if (s == null) return s;
+  if (s.length <= max) return s;
+  return s.slice(0, max) + AI_TRUNCATION_SUFFIX;
 }
 
 export default class SendErrorToAIAssistant extends Component<Signature> {
@@ -38,7 +60,45 @@ export default class SendErrorToAIAssistant extends Component<Signature> {
     let message = error.message;
     let stack = error.stack ? `\n\nStack trace:\n${error.stack}` : '';
 
-    return `${prefix}\n\n${message}${stack}`;
+    let diagnosticsSection = '';
+    if (
+      error.diagnostics &&
+      typeof error.diagnostics === 'object' &&
+      Object.keys(error.diagnostics).length > 0
+    ) {
+      try {
+        diagnosticsSection = `\n\nDiagnostics:\n${JSON.stringify(
+          error.diagnostics,
+          null,
+          2,
+        )}`;
+      } catch {
+        // best-effort: skip diagnostics if unserializable
+      }
+    }
+
+    let additionalErrorsSection = '';
+    let entries = error.additionalErrors;
+    if (entries && entries.length > 0) {
+      let shown = entries.slice(0, AI_ADDITIONAL_ERRORS_LIMIT);
+      let parts = shown.map((e, i) => {
+        let title = e?.title ?? `Error ${i + 1}`;
+        let body = e?.message ? `\n${e.message}` : '';
+        let entryStack = truncateForAi(
+          e?.stack,
+          AI_ADDITIONAL_ERROR_STACK_MAX_BYTES,
+        );
+        let stackPart = entryStack ? `\nStack:\n${entryStack}` : '';
+        return `--- ${title} ---${body}${stackPart}`;
+      });
+      let footer =
+        entries.length > AI_ADDITIONAL_ERRORS_LIMIT
+          ? `\n\n(${entries.length - AI_ADDITIONAL_ERRORS_LIMIT} additional errors omitted)`
+          : '';
+      additionalErrorsSection = `\n\nAdditional Errors:\n${parts.join('\n\n')}${footer}`;
+    }
+
+    return `${prefix}\n\n${message}${stack}${diagnosticsSection}${additionalErrorsSection}`;
   }
 
   get commandContext() {

--- a/packages/host/app/components/operator-mode/send-error-to-ai-assistant.gts
+++ b/packages/host/app/components/operator-mode/send-error-to-ai-assistant.gts
@@ -39,14 +39,25 @@ interface Signature {
   };
 }
 
-const AI_ADDITIONAL_ERROR_STACK_MAX_BYTES = 8 * 1024;
+// Per-entry / per-call budgets (UTF-16 code units, not bytes). Truncation
+// keeps the final string at or below the configured max, including the
+// suffix.
+const AI_ADDITIONAL_ERROR_STACK_MAX_CHARS = 8 * 1024;
+const AI_ADDITIONAL_ERROR_MESSAGE_MAX_CHARS = 4 * 1024;
+const AI_TOP_LEVEL_STACK_MAX_CHARS = 16 * 1024;
+const AI_TOP_LEVEL_MESSAGE_MAX_CHARS = 4 * 1024;
 const AI_ADDITIONAL_ERRORS_LIMIT = 50;
+// Total prompt cap. Matrix events are typically capped at 65 KB. Stay
+// well below so the rest of the message envelope (room + headers + the
+// fixed prefix the assistant adds) has room.
+const AI_PROMPT_TOTAL_MAX_CHARS = 48 * 1024;
 const AI_TRUNCATION_SUFFIX = ' …[truncated]';
 
 function truncateForAi(s: string | undefined, max: number): string | undefined {
   if (s == null) return s;
   if (s.length <= max) return s;
-  return s.slice(0, max) + AI_TRUNCATION_SUFFIX;
+  let body = Math.max(0, max - AI_TRUNCATION_SUFFIX.length);
+  return s.slice(0, body) + AI_TRUNCATION_SUFFIX;
 }
 
 export default class SendErrorToAIAssistant extends Component<Signature> {
@@ -57,8 +68,13 @@ export default class SendErrorToAIAssistant extends Component<Signature> {
   private get errorMessage() {
     let { error, errorType } = this.args;
     let prefix = errorType === 'syntax' ? 'Syntax Error' : 'Card Error';
-    let message = error.message;
-    let stack = error.stack ? `\n\nStack trace:\n${error.stack}` : '';
+    let message =
+      truncateForAi(error.message, AI_TOP_LEVEL_MESSAGE_MAX_CHARS) ?? '';
+    let truncatedStack = truncateForAi(
+      error.stack,
+      AI_TOP_LEVEL_STACK_MAX_CHARS,
+    );
+    let stack = truncatedStack ? `\n\nStack trace:\n${truncatedStack}` : '';
 
     let diagnosticsSection = '';
     if (
@@ -83,10 +99,14 @@ export default class SendErrorToAIAssistant extends Component<Signature> {
       let shown = entries.slice(0, AI_ADDITIONAL_ERRORS_LIMIT);
       let parts = shown.map((e, i) => {
         let title = e?.title ?? `Error ${i + 1}`;
-        let body = e?.message ? `\n${e.message}` : '';
+        let truncatedMessage = truncateForAi(
+          e?.message,
+          AI_ADDITIONAL_ERROR_MESSAGE_MAX_CHARS,
+        );
+        let body = truncatedMessage ? `\n${truncatedMessage}` : '';
         let entryStack = truncateForAi(
           e?.stack,
-          AI_ADDITIONAL_ERROR_STACK_MAX_BYTES,
+          AI_ADDITIONAL_ERROR_STACK_MAX_CHARS,
         );
         let stackPart = entryStack ? `\nStack:\n${entryStack}` : '';
         return `--- ${title} ---${body}${stackPart}`;
@@ -98,7 +118,13 @@ export default class SendErrorToAIAssistant extends Component<Signature> {
       additionalErrorsSection = `\n\nAdditional Errors:\n${parts.join('\n\n')}${footer}`;
     }
 
-    return `${prefix}\n\n${message}${stack}${diagnosticsSection}${additionalErrorsSection}`;
+    let assembled = `${prefix}\n\n${message}${stack}${diagnosticsSection}${additionalErrorsSection}`;
+    // Final safety net: per-entry budgets above bound the assembled
+    // string at roughly 50 × (4 + 8) KiB ≈ 600 KiB worst case (50 entries
+    // each at the per-entry max), still well over Matrix's typical 65 KB
+    // event ceiling. Cap the whole string here so a pathological doc
+    // can't make Fix-with-AI fail to send.
+    return truncateForAi(assembled, AI_PROMPT_TOTAL_MAX_CHARS) ?? assembled;
   }
 
   get commandContext() {

--- a/packages/host/app/utils/render-desync-detector.ts
+++ b/packages/host/app/utils/render-desync-detector.ts
@@ -144,19 +144,11 @@ export const DEFAULT_SETTLE_HOPS_MS: readonly number[] = [
 
 export const DESYNC_ERROR_TITLE = 'Render binding desync';
 export const DESYNC_ERROR_MESSAGE =
-  "Render route flipped model.status to 'ready' but the " +
-  '[data-prerender-status] DOM attribute never updated to match. ' +
-  "This means Glimmer's template binding for the prerender " +
-  'container did not re-render, which only happens when the ' +
-  "card's template threw during render and the Ember runloop " +
-  'caught the exception in a way that no JS-level event ' +
-  '(window.error / unhandledrejection / RSVP.on(error)) fires. ' +
-  "Chrome's DevTools console typically shows 'Uncaught (in " +
-  "promise) ...' for this class of failure, but that signal is " +
-  'browser-internal and invisible to JavaScript. Inspect the card ' +
-  "template — and any captured console errors in this doc's " +
-  '`additionalErrors` — for a getter, helper, or computed that ' +
-  'throws on the model state at render time.';
+  'Encountered an Ember rendering error while rendering this card. ' +
+  'The template threw during render and the runloop swallowed the ' +
+  'exception, so no JS-level error event fired. Browser console ' +
+  'errors captured during the render (if any) are listed in the ' +
+  'Additional Errors section below.';
 
 export interface DesyncDetectorContext {
   cardId: string;

--- a/packages/host/tests/integration/components/operator-mode/error-display-test.gts
+++ b/packages/host/tests/integration/components/operator-mode/error-display-test.gts
@@ -307,6 +307,51 @@ module(
       );
     });
 
+    test('does not duplicate message when entry has no title', async function (assert) {
+      let error: CardErrorJSONAPI = {
+        id: 'https://example.com/x',
+        status: 500,
+        title: 'Render error',
+        message: 'boom',
+        realm: 'https://example.com/',
+        meta: {
+          lastKnownGoodHtml: null,
+          cardTitle: null,
+          scopedCssUrls: [],
+          stack: null,
+        },
+        additionalErrors: [
+          {
+            message: 'TypeError: only message, no title',
+            stack: 'TypeError\n  at template (foo.gts:10:5)',
+          } as any,
+        ],
+      };
+
+      await render(<template><CardErrorDetail @error={{error}} /></template>);
+      await click('[data-test-toggle-details]');
+      await waitFor('[data-test-error-additional-errors]');
+
+      assert
+        .dom('[data-test-error-additional-heading]')
+        .doesNotExist('no heading rendered when entry has no title');
+      assert
+        .dom('[data-test-error-additional-message]')
+        .hasText(
+          'TypeError: only message, no title',
+          'message body renders exactly once',
+        );
+      let entry = document.querySelector('[data-test-error-additional-error]');
+      let occurrences = (
+        entry?.textContent?.match(/TypeError: only message, no title/g) ?? []
+      ).length;
+      assert.strictEqual(
+        occurrences,
+        1,
+        'message text appears exactly once in the entry',
+      );
+    });
+
     test('omits Additional Errors block when array is empty/absent', async function (assert) {
       // absent
       let absent: CardErrorJSONAPI = {

--- a/packages/host/tests/integration/components/operator-mode/error-display-test.gts
+++ b/packages/host/tests/integration/components/operator-mode/error-display-test.gts
@@ -155,6 +155,191 @@ module(
         .doesNotExist('no diagnostics section when meta.diagnostics is absent');
     });
 
+    // CS-10977: additionalErrors carried on the error doc — typically
+    // browser console errors enriched by the prerender runner — are
+    // surfaced under the stack trace so the operator can see the
+    // underlying template throw the runloop swallowed.
+    test('renders additionalErrors when provided', async function (assert) {
+      let error: CardErrorJSONAPI = {
+        id: 'https://example.com/x',
+        status: 500,
+        title: 'Render binding desync',
+        message: 'Encountered an Ember rendering error',
+        realm: 'https://example.com/',
+        meta: {
+          lastKnownGoodHtml: null,
+          cardTitle: null,
+          scopedCssUrls: [],
+          stack: 'Error: outer\n  at frame',
+        },
+        additionalErrors: [
+          {
+            title: 'Console error 1',
+            message: 'TypeError: cannot read properties of undefined',
+            stack: 'TypeError\n  at template (foo.gts:10:5)',
+          } as any,
+          {
+            title: 'Console error 2',
+            message: 'Uncaught (in promise) Error: ohno',
+            stack: 'Error\n  at promise (bar.gts:42:1)',
+          } as any,
+        ],
+      };
+
+      await render(<template><CardErrorDetail @error={{error}} /></template>);
+      assert
+        .dom('[data-test-error-additional-errors]')
+        .doesNotExist('hidden until the caller opens details');
+
+      await click('[data-test-toggle-details]');
+      await waitFor('[data-test-error-additional-errors]');
+
+      assert
+        .dom('[data-test-error-additional-errors]')
+        .hasAttribute('data-test-error-additional-errors-count', '2');
+      assert
+        .dom('[data-test-error-additional-error]')
+        .exists({ count: 2 }, 'each additional error renders its own block');
+
+      let entries = document.querySelectorAll(
+        '[data-test-error-additional-error]',
+      );
+      let firstText = entries[0]?.textContent ?? '';
+      assert.ok(
+        firstText.includes('Console error 1'),
+        'first entry shows its title',
+      );
+      assert.ok(
+        firstText.includes('TypeError: cannot read properties of undefined'),
+        'first entry shows its message',
+      );
+      assert.ok(
+        firstText.includes('at template (foo.gts:10:5)'),
+        'first entry shows its stack',
+      );
+      let secondText = entries[1]?.textContent ?? '';
+      assert.ok(
+        secondText.includes('Uncaught (in promise) Error: ohno'),
+        'second entry shows its message',
+      );
+      assert.ok(
+        secondText.includes('at promise (bar.gts:42:1)'),
+        'second entry shows its stack',
+      );
+    });
+
+    test('truncates long additional error stacks', async function (assert) {
+      let longStack = 'a'.repeat(10 * 1024);
+      let error: CardErrorJSONAPI = {
+        id: 'https://example.com/x',
+        status: 500,
+        title: 'Render error',
+        message: 'boom',
+        realm: 'https://example.com/',
+        meta: {
+          lastKnownGoodHtml: null,
+          cardTitle: null,
+          scopedCssUrls: [],
+          stack: null,
+        },
+        additionalErrors: [
+          { title: 'Big stack', message: 'long', stack: longStack } as any,
+        ],
+      };
+
+      await render(<template><CardErrorDetail @error={{error}} /></template>);
+      await click('[data-test-toggle-details]');
+      await waitFor('[data-test-error-additional-errors]');
+
+      let stackEl = document.querySelector(
+        '[data-test-error-additional-stack]',
+      );
+      let rendered = stackEl?.textContent ?? '';
+      assert.ok(
+        rendered.includes('…[truncated]'),
+        `truncation suffix is appended (got length ${rendered.length})`,
+      );
+      assert.ok(
+        rendered.length < longStack.length,
+        'rendered stack is shorter than the input stack',
+      );
+    });
+
+    test('caps additional errors at 20 with omitted summary', async function (assert) {
+      let raw = Array.from({ length: 25 }, (_v, i) => ({
+        title: `Console error ${i + 1}`,
+        message: `msg ${i + 1}`,
+        stack: `stack ${i + 1}`,
+      }));
+      let error: CardErrorJSONAPI = {
+        id: 'https://example.com/x',
+        status: 500,
+        title: 'Render error',
+        message: 'boom',
+        realm: 'https://example.com/',
+        meta: {
+          lastKnownGoodHtml: null,
+          cardTitle: null,
+          scopedCssUrls: [],
+          stack: null,
+        },
+        additionalErrors: raw as any,
+      };
+
+      await render(<template><CardErrorDetail @error={{error}} /></template>);
+      await click('[data-test-toggle-details]');
+      await waitFor('[data-test-error-additional-errors]');
+
+      assert
+        .dom('[data-test-error-additional-errors]')
+        .hasAttribute(
+          'data-test-error-additional-errors-count',
+          '25',
+          'count attribute reflects the raw input length',
+        );
+      // 20 real entries + 1 synthetic "Errors omitted" placeholder
+      assert.dom('[data-test-error-additional-error]').exists({ count: 21 });
+      let block = document.querySelector('[data-test-error-additional-errors]');
+      let blockText = block?.textContent ?? '';
+      assert.ok(
+        blockText.includes('5 additional errors hidden'),
+        `omitted summary indicates the dropped count (got "${blockText.slice(0, 200)}…")`,
+      );
+    });
+
+    test('omits Additional Errors block when array is empty/absent', async function (assert) {
+      // absent
+      let absent: CardErrorJSONAPI = {
+        id: 'https://example.com/x',
+        status: 500,
+        title: 'x',
+        message: 'm',
+        realm: 'https://example.com/',
+        meta: {
+          lastKnownGoodHtml: null,
+          cardTitle: null,
+          scopedCssUrls: [],
+          stack: null,
+        },
+      };
+      await render(<template><CardErrorDetail @error={{absent}} /></template>);
+      await click('[data-test-toggle-details]');
+      assert
+        .dom('[data-test-error-additional-errors]')
+        .doesNotExist('absent additionalErrors → no block');
+
+      // empty
+      let empty: CardErrorJSONAPI = {
+        ...absent,
+        additionalErrors: [],
+      };
+      await render(<template><CardErrorDetail @error={{empty}} /></template>);
+      await click('[data-test-toggle-details]');
+      assert
+        .dom('[data-test-error-additional-errors]')
+        .doesNotExist('empty additionalErrors → no block');
+    });
+
     test('renders when diagnostics only has per-item load fields (no launch timing)', async function (assert) {
       // Simulates a best-effort capture where launch timing wasn't
       // available but the host-side hooks still produced some data —

--- a/packages/host/tests/integration/components/operator-mode/error-display-test.gts
+++ b/packages/host/tests/integration/components/operator-mode/error-display-test.gts
@@ -307,6 +307,45 @@ module(
       );
     });
 
+    test('truncate caps final length at the configured max including suffix', async function (assert) {
+      // 4KB stack budget, suffix is ' …[truncated]' (14 chars). The
+      // rendered length must be <= 4096, not 4096 + suffix length.
+      let longStack = 'b'.repeat(20 * 1024);
+      let error: CardErrorJSONAPI = {
+        id: 'https://example.com/x',
+        status: 500,
+        title: 'Render error',
+        message: 'boom',
+        realm: 'https://example.com/',
+        meta: {
+          lastKnownGoodHtml: null,
+          cardTitle: null,
+          scopedCssUrls: [],
+          stack: null,
+        },
+        additionalErrors: [
+          { title: 'Big stack', message: 'long', stack: longStack } as any,
+        ],
+      };
+
+      await render(<template><CardErrorDetail @error={{error}} /></template>);
+      await click('[data-test-toggle-details]');
+      await waitFor('[data-test-error-additional-errors]');
+
+      let stackEl = document.querySelector(
+        '[data-test-error-additional-stack]',
+      );
+      let rendered = stackEl?.textContent ?? '';
+      assert.ok(
+        rendered.endsWith(' …[truncated]'),
+        'truncation suffix is at the end',
+      );
+      assert.ok(
+        rendered.length <= 4 * 1024,
+        `rendered stack length (${rendered.length}) is at or below the 4KiB budget`,
+      );
+    });
+
     test('does not duplicate message when entry has no title', async function (assert) {
       let error: CardErrorJSONAPI = {
         id: 'https://example.com/x',

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -1420,10 +1420,16 @@ module(basename(__filename), function () {
           'desync surfaces as 500',
         );
         assert.ok(
-          result.response.error?.error.message?.includes(
-            '[data-prerender-status]',
-          ),
-          `desync message names the DOM signal that never updated, got: ${result.response.error?.error.message}`,
+          result.response.error?.error.message
+            ?.toLowerCase()
+            .includes('ember rendering error'),
+          `desync message names the failure class (Ember rendering error), got: ${result.response.error?.error.message}`,
+        );
+        assert.ok(
+          result.response.error?.error.message
+            ?.toLowerCase()
+            .includes('additional errors'),
+          `desync message points users at the Additional Errors section, got: ${result.response.error?.error.message}`,
         );
         // Desync IS the signal that the runloop stopped advancing this
         // card's render — Glimmer's binding never landed. The page is


### PR DESCRIPTION
## Why

The runtime-error overlay rendered when a card fails to render had an inconsistency between **what it told the user** and **what it actually showed**. The `DESYNC_ERROR_MESSAGE` body told users to "Inspect... any captured console errors in this doc's `additionalErrors`" — but `additionalErrors` was never surfaced anywhere a user could see it:

- The `ErrorDisplay` Show-Details pane only rendered `message`, `stack`, and (CS-10872) `diagnostics`. `additionalErrors` was dropped at the `CardErrorDetail → ErrorDisplay` boundary.
- The "Fix with AI" button only sent `message + stack` in its markdown prompt — neither `additionalErrors` nor `diagnostics`.
- So a user clicking "Show Details" or "Fix with AI" received less information than the error message claimed was available, and the AI assistant couldn't see the underlying template throw that the runloop swallowed (which is the *only* meaningful pointer at the root cause of a desync).

This PR closes that gap end-to-end and tightens the misleading message.

## What changed

- **`ErrorDisplay`** now accepts and renders `additionalErrors` under the stack trace. Each entry shows its title (if present), message, and stack. Per-entry truncation: 2KB message, 4KB stack. Display cap: 20 entries with a synthetic "Errors omitted" sentinel for the rest.
- **`CardErrorDetail`** forwards `@error.additionalErrors` (already on `CardErrorJSONAPI` from runtime-common — the data was always reaching the host, just not displayed).
- **`SendErrorToAIAssistant`** payload now includes a `Diagnostics:` section (pretty-printed JSON) and an `Additional Errors:` section with each entry's title/message/stack. More generous truncation budgets than the human pane (8KB per stack, 50 entries) since the assistant tolerates large prompts well.
- **`BoxelErrorForContext`** in `packages/base/matrix-event.gts` extended to carry `additionalErrors` + `diagnostics` so the typed contract stays clean end-to-end (used by `CopyButton` payload + AI-assistant attachment context).
- **`DESYNC_ERROR_MESSAGE`** rewritten from a 13-line wall of mechanism prose into a concise user-facing message. The mechanism explanation already exists as a comment block above the constant — that's the right place for it.

  Old:
  > Render route flipped model.status to 'ready' but the [data-prerender-status] DOM attribute never updated to match. This means Glimmer's template binding for the prerender container did not re-render, which only happens when the card's template threw during render and the Ember runloop caught the exception in a way that no JS-level event (window.error / unhandledrejection / RSVP.on(error)) fires. Chrome's DevTools console typically shows 'Uncaught (in promise) ...' for this class of failure, but that signal is browser-internal and invisible to JavaScript. Inspect the card template — and any captured console errors in this doc's \`additionalErrors\` — for a getter, helper, or computed that throws on the model state at render time.

  New:
  > Encountered an Ember rendering error while rendering this card. The template threw during render and the runloop swallowed the exception, so no JS-level error event fired. Browser console errors captured during the render (if any) are listed in the Additional Errors section below.

## Test plan

- [x] \`pnpm lint\` passes in \`packages/host\`, \`packages/base\`, and \`packages/realm-server\`
- [x] New \`error-display-test.gts\` integration tests:
  - renders provided \`additionalErrors\` entries (title + message + stack)
  - truncates long stacks with \`…[truncated]\` suffix
  - caps at 20 entries with omitted-summary entry when more
  - omits the block entirely when \`additionalErrors\` is absent or empty
  - does not duplicate the message when an entry has only \`message\` and no \`title\` (commit 21c23b75)
- [x] Updated \`prerendering-test.ts\` desync assertion to match the new message contract (asserts on "Ember rendering error" + "Additional Errors", not on \`[data-prerender-status]\` jargon)
- [ ] Smoke-test the staging preview: visit a card that errors, toggle Show Details, confirm Additional Errors block renders; click Fix with AI and confirm the prompt body in the assistant transcript includes the additionalErrors section

🤖 Generated with [Claude Code](https://claude.com/claude-code)