### PR TITLE
host: keep StackItem on isolated/edit format toggle

### DIFF
--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -546,13 +546,11 @@ export default class OperatorModeStackItem extends Component<Signature> {
     if (this.card) {
       request?.fulfill(this.card.id);
     }
-    this.operatorModeStateService.replaceItemInStack(
-      item,
-      item.clone({
-        request,
-        format: 'isolated',
-      }),
-    );
+    // Mutate format in place — keeps the StackItem instance, so the
+    // CardRenderer subtree stays mounted (no remount, no scroll loss,
+    // no width snap from prefersWideFormat re-evaluation) for CardDefs
+    // that share a template between isolated + edit formats.
+    this.operatorModeStateService.setItemFormat(item, 'isolated', { request });
   };
 
   private scrollIntoViewTask = restartableTask(async (selector: string) => {

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -1,3 +1,5 @@
+import { tracked } from '@glimmer/tracking';
+
 import { isFileDefInstance } from '@cardstack/runtime-common';
 import type { Deferred } from '@cardstack/runtime-common';
 import type { Store, StoreReadType } from '@cardstack/runtime-common';
@@ -52,11 +54,20 @@ export function detectStackItemTypeForTarget(
 }
 
 export class StackItem {
-  format: Format;
-  request?: Deferred<string>;
+  // `format`, `request`, `closeAfterSaving`, `useBaseTemplate` are
+  // tracked so that callers can mutate them IN PLACE (e.g. flipping
+  // `format` from 'isolated' → 'edit') without replacing the StackItem
+  // instance. Replacing the instance forces Glimmer's `{{#each}}` to
+  // destroy and re-mount the entire stack-item subtree — losing scroll
+  // position, DOM state, view transitions, and triggering
+  // prefersWideFormat to narrow then re-expand. In-place mutation lets
+  // shared-template formats (CardDef where `static isolated === static
+  // edit`) flip without remounting.
+  @tracked format: Format;
+  @tracked request?: Deferred<string>;
+  @tracked closeAfterSaving?: boolean;
+  @tracked useBaseTemplate?: boolean;
   stackIndex: number;
-  closeAfterSaving?: boolean;
-  useBaseTemplate?: boolean;
   type: StackItemType;
   #id: string;
   relationshipContext?:

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -482,6 +482,9 @@ export default class OperatorModeStateService extends Service {
     opts?: { useBaseTemplate?: boolean },
   ): void {
     let item = this.findCardInStack(card, stackIndex);
+    if (item.type === 'file') {
+      return;
+    }
     this.setItemFormat(item, 'edit', {
       request: new Deferred(),
       useBaseTemplate: opts?.useBaseTemplate,
@@ -494,6 +497,9 @@ export default class OperatorModeStateService extends Service {
     opts?: { useBaseTemplate?: boolean },
   ): void {
     let item = this.findCardInStack(card, stackIndex);
+    if (item.type === 'file') {
+      return;
+    }
     this.setItemFormat(item, 'isolated', {
       request: new Deferred(),
       useBaseTemplate: opts?.useBaseTemplate,

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -452,23 +452,40 @@ export default class OperatorModeStateService extends Service {
     return item;
   }
 
+  // Mutate a stack item's format in place (and any related transient
+  // fields) instead of replacing the item. The StackItem class marks
+  // format/request/useBaseTemplate as @tracked, so consumers re-render
+  // reactively. Crucially, the item's IDENTITY is preserved — Glimmer's
+  // {{#each}} keeps the same stack-item component instance, so the
+  // CardRenderer (and the user's CardDef component beneath it) are NOT
+  // remounted on a format swap. CardDefs whose `static isolated ===
+  // static edit` keep DOM state, scroll position, and view-transition
+  // continuity across the toggle.
+  setItemFormat(
+    item: StackItem,
+    format: Format,
+    opts?: { request?: Deferred<string>; useBaseTemplate?: boolean },
+  ): void {
+    if (item.type === 'file') {
+      return;
+    }
+    item.format = format;
+    if (opts && 'request' in opts) item.request = opts.request;
+    if (opts && 'useBaseTemplate' in opts)
+      item.useBaseTemplate = opts.useBaseTemplate;
+    this.schedulePersist();
+  }
+
   editCardOnStack(
     stackIndex: number,
     card: CardDef,
     opts?: { useBaseTemplate?: boolean },
   ): void {
     let item = this.findCardInStack(card, stackIndex);
-    if (item.type === 'file') {
-      return;
-    }
-    this.replaceItemInStack(
-      item,
-      item.clone({
-        request: new Deferred(),
-        format: 'edit',
-        useBaseTemplate: opts?.useBaseTemplate,
-      }),
-    );
+    this.setItemFormat(item, 'edit', {
+      request: new Deferred(),
+      useBaseTemplate: opts?.useBaseTemplate,
+    });
   }
 
   viewCardOnStack(
@@ -477,17 +494,10 @@ export default class OperatorModeStateService extends Service {
     opts?: { useBaseTemplate?: boolean },
   ): void {
     let item = this.findCardInStack(card, stackIndex);
-    if (item.type === 'file') {
-      return;
-    }
-    this.replaceItemInStack(
-      item,
-      item.clone({
-        request: new Deferred(),
-        format: 'isolated',
-        useBaseTemplate: opts?.useBaseTemplate,
-      }),
-    );
+    this.setItemFormat(item, 'isolated', {
+      request: new Deferred(),
+      useBaseTemplate: opts?.useBaseTemplate,
+    });
   }
 
   clearStackAndAdd(stackIndex: number, newItem: StackItem) {

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -272,6 +272,62 @@ module('Integration | operator-mode | basics', function (hooks) {
       .exists('last known good state is displayed in isolated mode');
   });
 
+  test('toggling edit format mutates the StackItem in place (no remount)', async function (assert) {
+    ctx.setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await waitFor('[data-test-stack-item-content]');
+
+    let stackBefore = ctx.operatorModeStateService.state.stacks[0];
+    let itemBefore = stackBefore[0];
+    assert.strictEqual(itemBefore.format, 'isolated', 'starts in isolated');
+    let wrapperBefore = document.querySelector(
+      '[data-test-stack-item-content]',
+    );
+
+    await click('[data-test-edit-button]');
+    await waitFor('[data-test-field="firstName"]');
+
+    let stackAfter = ctx.operatorModeStateService.state.stacks[0];
+    let itemAfter = stackAfter[0];
+    assert.strictEqual(
+      itemAfter,
+      itemBefore,
+      'StackItem instance is preserved (mutated in place, not replaced)',
+    );
+    assert.strictEqual(itemAfter.format, 'edit', 'format is now edit');
+
+    let wrapperAfter = document.querySelector('[data-test-stack-item-content]');
+    assert.strictEqual(
+      wrapperAfter,
+      wrapperBefore,
+      'stack-item content wrapper is the same DOM node (no remount)',
+    );
+
+    await click('[data-test-edit-button]');
+    await waitFor('[data-test-person]');
+
+    let stackBack = ctx.operatorModeStateService.state.stacks[0];
+    assert.strictEqual(
+      stackBack[0],
+      itemBefore,
+      'StackItem identity preserved across edit → isolated round-trip',
+    );
+    assert.strictEqual(
+      stackBack[0].format,
+      'isolated',
+      'format is back to isolated',
+    );
+    assert.strictEqual(
+      document.querySelector('[data-test-stack-item-content]'),
+      wrapperBefore,
+      'wrapper still the same DOM node after round-trip',
+    );
+  });
+
   test('a 403 from Web Application Firewall is handled gracefully when auto-saving', async function (assert) {
     let networkService = getService('network');
     networkService.virtualNetwork.mount(

--- a/packages/host/tests/unit/services/operator-mode-state-service-test.ts
+++ b/packages/host/tests/unit/services/operator-mode-state-service-test.ts
@@ -1,0 +1,90 @@
+import { getService } from '@universal-ember/test-support';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import { Deferred } from '@cardstack/runtime-common';
+
+import { StackItem } from '@cardstack/host/lib/stack-item';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+
+module('Unit | Service | operator-mode-state-service', function (hooks) {
+  setupTest(hooks);
+
+  let service: OperatorModeStateService;
+
+  hooks.beforeEach(function () {
+    service = getService('operator-mode-state-service');
+  });
+
+  module('setItemFormat', function () {
+    test('mutates an item in place; preserves identity', function (assert) {
+      let item = new StackItem({
+        id: 'test-card',
+        format: 'isolated',
+        stackIndex: 0,
+      });
+      let before = item;
+      let request = new Deferred<string>();
+
+      service.setItemFormat(item, 'edit', { request });
+
+      assert.strictEqual(item, before, 'item instance preserved');
+      assert.strictEqual(item.format, 'edit', 'format is mutated');
+      assert.strictEqual(item.request, request, 'request is set');
+    });
+
+    test('keeps prior request and useBaseTemplate when not passed', function (assert) {
+      let priorRequest = new Deferred<string>();
+      let item = new StackItem({
+        id: 'test-card',
+        format: 'isolated',
+        stackIndex: 0,
+        request: priorRequest,
+        useBaseTemplate: true,
+      });
+
+      service.setItemFormat(item, 'edit');
+
+      assert.strictEqual(item.format, 'edit', 'format is mutated');
+      assert.strictEqual(
+        item.request,
+        priorRequest,
+        'request is unchanged when not passed in opts',
+      );
+      assert.true(
+        item.useBaseTemplate,
+        'useBaseTemplate is unchanged when not passed in opts',
+      );
+    });
+
+    test('clears useBaseTemplate when explicitly set to undefined', function (assert) {
+      let item = new StackItem({
+        id: 'test-card',
+        format: 'isolated',
+        stackIndex: 0,
+        useBaseTemplate: true,
+      });
+
+      service.setItemFormat(item, 'edit', { useBaseTemplate: undefined });
+
+      assert.strictEqual(item.useBaseTemplate, undefined);
+    });
+
+    test('no-ops on file items', function (assert) {
+      let item = new StackItem({
+        id: 'test-file',
+        format: 'isolated',
+        stackIndex: 0,
+        type: 'file',
+      });
+
+      service.setItemFormat(item, 'edit');
+
+      assert.strictEqual(
+        item.format,
+        'isolated',
+        'file items are not mutated by setItemFormat',
+      );
+    });
+  });
+});


### PR DESCRIPTION
Toggling between isolated and edit on a stack item used to clone the StackItem and replace it via replaceItemInStack. The new identity caused Glimmer's {{#each}} to destroy + remount the entire stack-item subtree -> CardRenderer remounted, scroll position lost, prefersWideFormat re-evaluated against a momentarily-undefined card, width snapped.

Mutate item.format in place via @tracked instead. The StackItem identity is preserved, the {{#each}} keeps its component instance, and CardDefs whose `static isolated === static edit` re-render as a pure prop change rather than a remount.

Demo: https://screen.studio/share/XOqnzIbP