### PR TITLE
Migrate reads off published_realms

### DIFF
--- a/packages/realm-server/handlers/handle-delete-realm.ts
+++ b/packages/realm-server/handlers/handle-delete-realm.ts
@@ -106,11 +106,13 @@ export default function handleDeleteRealm({
       let sourceRealmPath = join(realmsRootPath, sourceRow[0].disk_id);
 
       // Phase 4: existence check on realm_registry (kind='published')
-      // instead of the legacy published_realms table.
+      // instead of the legacy published_realms table. SELECT 1 is aliased
+      // to AS found rather than relying on Postgres's default `?column?`
+      // unnamed-column label, which isn't portable across SQL adapters.
       let publishedRealmMatch = (await query(dbAdapter, [
-        `SELECT 1 FROM realm_registry WHERE kind = 'published' AND url =`,
+        `SELECT 1 AS found FROM realm_registry WHERE kind = 'published' AND url =`,
         param(realmURL),
-      ])) as { '?column?': number }[];
+      ])) as { found: number }[];
       if (publishedRealmMatch.length > 0) {
         await sendResponseForUnprocessableEntity(
           ctxt,

--- a/packages/realm-server/handlers/handle-delete-realm.ts
+++ b/packages/realm-server/handlers/handle-delete-realm.ts
@@ -105,10 +105,12 @@ export default function handleDeleteRealm({
       }
       let sourceRealmPath = join(realmsRootPath, sourceRow[0].disk_id);
 
+      // Phase 4: existence check on realm_registry (kind='published')
+      // instead of the legacy published_realms table.
       let publishedRealmMatch = (await query(dbAdapter, [
-        `SELECT id FROM published_realms WHERE published_realm_url =`,
+        `SELECT 1 FROM realm_registry WHERE kind = 'published' AND url =`,
         param(realmURL),
-      ])) as Pick<PublishedRealmTable, 'id'>[];
+      ])) as { '?column?': number }[];
       if (publishedRealmMatch.length > 0) {
         await sendResponseForUnprocessableEntity(
           ctxt,
@@ -146,8 +148,11 @@ export default function handleDeleteRealm({
       // per-URL granularity rather than globally. Pragmatic for this PR;
       // multi-instance hardening could tighten this later.
       await withRealmWriteLock(dbAdapter, realmURL, async () => {
+        // Phase 4: cascade lookup reads realm_registry rather than
+        // published_realms. SQL aliases keep the loop body's field
+        // accessors stable.
         let publishedRealms = (await query(dbAdapter, [
-          `SELECT id, published_realm_url FROM published_realms WHERE source_realm_url =`,
+          `SELECT disk_id AS id, url AS published_realm_url FROM realm_registry WHERE kind = 'published' AND source_url =`,
           param(realmURL),
         ])) as Pick<PublishedRealmTable, 'id' | 'published_realm_url'>[];
 

--- a/packages/realm-server/handlers/handle-download-realm.ts
+++ b/packages/realm-server/handlers/handle-download-realm.ts
@@ -215,8 +215,11 @@ async function resolveRealmPath({
   realmURL: string;
   realmsRootPath: string;
 }): Promise<string | null> {
+  // Phase 4: read from realm_registry. published_realms.id and
+  // realm_registry.disk_id hold the same UUID for kind='published' rows
+  // by design (see migration 1776960113000).
   let published = (await query(dbAdapter, [
-    'SELECT id FROM published_realms WHERE published_realm_url =',
+    "SELECT disk_id AS id FROM realm_registry WHERE kind = 'published' AND url =",
     param(realmURL),
   ])) as PublishedRealmRow[];
   if (published.length > 0) {

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -12,7 +12,6 @@ import {
   PUBLISHED_DIRECTORY_NAME,
   ensureTrailingSlash,
   type DBAdapter,
-  type PublishedRealmTable,
   fetchRealmPermissions,
   uuidv4,
   userInitiatedPriority,
@@ -319,10 +318,13 @@ export default function handlePublishRealm({
         dbAdapter,
         publishedRealmURL,
         async () => {
+          // Phase 4: read existence + identity from realm_registry. The
+          // legacy published_realms table is still dual-written below
+          // until Phase 4 PR 2 drops the writes.
           let existingRows = (await query(dbAdapter, [
-            `SELECT id, owner_username FROM published_realms WHERE published_realm_url =`,
+            `SELECT disk_id, owner_username FROM realm_registry WHERE kind = 'published' AND url =`,
             param(publishedRealmURL),
-          ])) as Pick<PublishedRealmTable, 'id' | 'owner_username'>[];
+          ])) as { disk_id: string; owner_username: string }[];
           let isNewRealm = existingRows.length === 0;
 
           let publishedRealmId: string;
@@ -346,7 +348,7 @@ export default function handlePublishRealm({
               '*': ['read'],
             });
           } else {
-            publishedRealmId = existingRows[0].id;
+            publishedRealmId = existingRows[0].disk_id;
             realmUsername = `realm/${PUBLISHED_DIRECTORY_NAME}_${publishedRealmId}`;
           }
 

--- a/packages/realm-server/handlers/handle-unpublish-realm.ts
+++ b/packages/realm-server/handlers/handle-unpublish-realm.ts
@@ -70,8 +70,11 @@ export default function handleUnpublishRealm({
       : `${json.publishedRealmURL}/`;
 
     try {
+      // Phase 4: read from realm_registry; alias the columns so the
+      // downstream field accessors stay the same as when this read
+      // pointed at published_realms.
       let publishedRealmData = (await query(dbAdapter, [
-        `SELECT * FROM published_realms WHERE published_realm_url =`,
+        `SELECT disk_id AS id, owner_username, source_url AS source_realm_url, url AS published_realm_url, last_published_at FROM realm_registry WHERE kind = 'published' AND url =`,
         param(publishedRealmURL),
       ])) as Pick<
         PublishedRealmTable,

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -393,7 +393,7 @@ export class RealmServer {
         let originParameter = new URL(decodeURIComponent(connectMatch[1])).href;
 
         let publishedRealms = await query(this.dbAdapter, [
-          `SELECT published_realm_url FROM published_realms WHERE published_realm_url LIKE `,
+          `SELECT url FROM realm_registry WHERE kind = 'published' AND url LIKE `,
           param(`${originParameter}%`),
         ]);
 
@@ -671,7 +671,7 @@ export class RealmServer {
     }
 
     let rows = await query(this.dbAdapter, [
-      `SELECT last_published_at FROM published_realms WHERE published_realm_url =`,
+      `SELECT last_published_at FROM realm_registry WHERE kind = 'published' AND url =`,
       param(realm.url),
     ]);
 

--- a/packages/realm-server/tests/full-reindex-test.ts
+++ b/packages/realm-server/tests/full-reindex-test.ts
@@ -17,6 +17,7 @@ import {
   uuidv4,
 } from '@cardstack/runtime-common';
 
+import { mirrorPublishedRealmToRegistry } from '../lib/realm-registry-writes';
 import { setupDB } from './helpers';
 
 module(basename(__filename), function (hooks) {
@@ -60,17 +61,26 @@ module(basename(__filename), function (hooks) {
     publishedRealmURL: string;
     ownerUsername: string;
   }) {
+    let publishedRealmId = uuidv4();
+    let lastPublishedAt = Date.now();
     let { nameExpressions, valueExpressions } = asExpressions({
-      id: uuidv4(),
+      id: publishedRealmId,
       owner_username: ownerUsername,
       source_realm_url: sourceRealmURL,
       published_realm_url: publishedRealmURL,
-      last_published_at: Date.now().toString(),
+      last_published_at: lastPublishedAt.toString(),
     });
     await query(
       dbAdapter,
       insert('published_realms', nameExpressions, valueExpressions),
     );
+    await mirrorPublishedRealmToRegistry(dbAdapter, {
+      publishedRealmURL,
+      publishedRealmId,
+      ownerUsername,
+      sourceRealmURL,
+      lastPublishedAt,
+    });
   }
 
   test('enqueues jobs for source and published realms using the source owner', async function (assert) {

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -52,6 +52,7 @@ import {
   RealmRegistryReconciler,
   type RealmRegistryRow,
 } from '../../lib/realm-registry-reconciler';
+import { mirrorPublishedRealmToRegistry } from '../../lib/realm-registry-writes';
 
 import {
   PgAdapter,
@@ -1700,6 +1701,9 @@ async function startPermissionedRealmFixture(
 
   if (published) {
     let publishedRealmId = uuidv4();
+    let lastPublishedAt = Date.now();
+    let ownerUsername = '@user:localhost';
+    let sourceRealmURL = 'http://example.localhost/source';
 
     testRealmDir = join(
       dir.name,
@@ -1715,12 +1719,19 @@ async function startPermissionedRealmFixture(
         VALUES
         (
           '${publishedRealmId}',
-          '@user:localhost',
-          'http://example.localhost/source',
+          '${ownerUsername}',
+          '${sourceRealmURL}',
           '${resolvedRealmURL.href}',
-          '${Date.now()}'
+          '${lastPublishedAt}'
         )`,
     );
+    await mirrorPublishedRealmToRegistry(dbAdapter, {
+      publishedRealmURL: resolvedRealmURL.href,
+      publishedRealmId,
+      ownerUsername,
+      sourceRealmURL,
+      lastPublishedAt,
+    });
   } else {
     testRealmDir = join(dir.name, 'realm_server_1', 'test');
   }

--- a/packages/realm-server/tests/queries-test.ts
+++ b/packages/realm-server/tests/queries-test.ts
@@ -12,6 +12,7 @@ import {
   query,
 } from '@cardstack/runtime-common';
 
+import { mirrorPublishedRealmToRegistry } from '../lib/realm-registry-writes';
 import { setupDB } from './helpers';
 
 module(basename(__filename), function () {
@@ -38,17 +39,25 @@ module(basename(__filename), function () {
       ownerUsername?: string;
     }) {
       let publishedRealmId = uuidv4();
+      let lastPublishedAt = Date.now();
       let { nameExpressions, valueExpressions } = asExpressions({
         id: publishedRealmId,
         owner_username: ownerUsername,
         source_realm_url: sourceRealmURL,
         published_realm_url: publishedRealmURL,
-        last_published_at: Date.now().toString(),
+        last_published_at: lastPublishedAt.toString(),
       });
       await query(
         dbAdapter,
         insert('published_realms', nameExpressions, valueExpressions),
       );
+      await mirrorPublishedRealmToRegistry(dbAdapter, {
+        publishedRealmURL,
+        publishedRealmId,
+        ownerUsername,
+        sourceRealmURL,
+        lastPublishedAt,
+      });
     }
 
     test('can fetch only own realms, filtering out public and published realms', async function (assert) {
@@ -168,17 +177,25 @@ module(basename(__filename), function () {
       ownerUsername?: string;
     }) {
       let publishedRealmId = uuidv4();
+      let lastPublishedAt = Date.now();
       let { nameExpressions, valueExpressions } = asExpressions({
         id: publishedRealmId,
         owner_username: ownerUsername,
         source_realm_url: sourceRealmURL,
         published_realm_url: publishedRealmURL,
-        last_published_at: Date.now().toString(),
+        last_published_at: lastPublishedAt.toString(),
       });
       await query(
         dbAdapter,
         insert('published_realms', nameExpressions, valueExpressions),
       );
+      await mirrorPublishedRealmToRegistry(dbAdapter, {
+        publishedRealmURL,
+        publishedRealmId,
+        ownerUsername,
+        sourceRealmURL,
+        lastPublishedAt,
+      });
     }
 
     test('uses source realm owner when published realm permissions are missing', async function (assert) {

--- a/packages/realm-server/tests/server-endpoints/index-responses-test.ts
+++ b/packages/realm-server/tests/server-endpoints/index-responses-test.ts
@@ -1312,9 +1312,14 @@ module(`server-endpoints/${basename(__filename)}`, function () {
       let firstEtag = firstResponse.headers['etag'];
       assert.ok(firstEtag, 'first response has ETag');
 
-      // Simulate a republish by updating last_published_at
+      // Simulate a republish by updating last_published_at on both the
+      // legacy table and realm_registry (the source of truth for reads).
+      let newLastPublishedAt = Date.now() + 1000;
       await dbAdapter.execute(
-        `UPDATE published_realms SET last_published_at = '${Date.now() + 1000}' WHERE published_realm_url = '${realmURL.href}'`,
+        `UPDATE published_realms SET last_published_at = '${newLastPublishedAt}' WHERE published_realm_url = '${realmURL.href}'`,
+      );
+      await dbAdapter.execute(
+        `UPDATE realm_registry SET last_published_at = ${newLastPublishedAt}, updated_at = now() WHERE url = '${realmURL.href}' AND kind = 'published'`,
       );
 
       let secondResponse = await request

--- a/packages/realm-server/utils/realm-readability.ts
+++ b/packages/realm-server/utils/realm-readability.ts
@@ -16,15 +16,14 @@ export async function getPublishedRealmURLs(
     return new Set();
   }
 
+  // Phase 4: read from realm_registry instead of published_realms.
   let publishedRealms = (await query(dbAdapter, [
-    'SELECT published_realm_url FROM published_realms WHERE published_realm_url IN (',
+    "SELECT url FROM realm_registry WHERE kind = 'published' AND url IN (",
     ...separatedByCommas(realmList.map((realmURL) => [param(realmURL)])),
     ')',
-  ] as Expression)) as { published_realm_url: string }[];
+  ] as Expression)) as { url: string }[];
 
-  return new Set(
-    publishedRealms.map((row) => ensureTrailingSlash(row.published_realm_url)),
-  );
+  return new Set(publishedRealms.map((row) => ensureTrailingSlash(row.url)));
 }
 
 export function buildReadableRealms(

--- a/packages/runtime-common/db-queries/realm-permission-queries.ts
+++ b/packages/runtime-common/db-queries/realm-permission-queries.ts
@@ -147,7 +147,7 @@ export async function fetchUserPermissions(
       `SELECT realm_url, read, write, realm_owner FROM realm_user_permissions WHERE username =`,
       param(userId),
       `AND realm_owner = true
-       AND realm_url NOT IN (SELECT published_realm_url FROM published_realms)`,
+       AND realm_url NOT IN (SELECT url FROM realm_registry WHERE kind = 'published')`,
     ])) as {
       realm_url: string;
       read: boolean;
@@ -160,13 +160,13 @@ export async function fetchUserPermissions(
     permissions = (await query(dbAdapter, [
       `SELECT realm_url, read, write, realm_owner FROM realm_user_permissions WHERE username =`,
       param(userId),
-      `AND realm_url NOT IN (SELECT published_realm_url FROM published_realms)
+      `AND realm_url NOT IN (SELECT url FROM realm_registry WHERE kind = 'published')
        UNION
        SELECT realm_url, true as read, false as write, false as realm_owner FROM realm_user_permissions WHERE username = '*' AND read = true
        AND realm_url NOT IN (SELECT realm_url FROM realm_user_permissions WHERE username =`,
       param(userId),
       `)
-       AND realm_url NOT IN (SELECT published_realm_url FROM published_realms)`,
+       AND realm_url NOT IN (SELECT url FROM realm_registry WHERE kind = 'published')`,
     ])) as {
       realm_url: string;
       read: boolean;
@@ -246,8 +246,9 @@ export async function fetchAllRealmsWithOwners(
 
   // Published realms may not have realm_user_permissions entries in older data.
   // Fall back to the published realm's owner (or source realm owner) when missing.
+  // Phase 4: read from realm_registry; aliases keep the loop accessors stable.
   const publishedRealms = (await query(dbAdapter, [
-    `SELECT published_realm_url, source_realm_url, owner_username FROM published_realms`,
+    `SELECT url AS published_realm_url, source_url AS source_realm_url, owner_username FROM realm_registry WHERE kind = 'published'`,
   ])) as {
     published_realm_url: string;
     source_realm_url: string;

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -4544,8 +4544,9 @@ export class Realm {
     last_published_at: string;
   } | null> {
     try {
+      // Phase 4: read from realm_registry instead of published_realms.
       let results = (await query(this.#dbAdapter, [
-        `SELECT last_published_at FROM published_realms WHERE published_realm_url =`,
+        `SELECT last_published_at FROM realm_registry WHERE kind = 'published' AND url =`,
         param(this.url),
       ])) as { last_published_at: string }[];
 
@@ -4560,8 +4561,9 @@ export class Realm {
     { published_realm_url: string; last_published_at: string }[]
   > {
     try {
+      // Phase 4: read from realm_registry; aliases keep callers stable.
       let results = (await query(this.#dbAdapter, [
-        `SELECT published_realm_url, last_published_at FROM published_realms WHERE source_realm_url =`,
+        `SELECT url AS published_realm_url, last_published_at FROM realm_registry WHERE kind = 'published' AND source_url =`,
         param(this.url),
       ])) as { published_realm_url: string; last_published_at: string }[];
 


### PR DESCRIPTION
## Summary

Phase 4 PR 1 of the DB-Authoritative Realm Registry project. Switches every runtime read of \`published_realms\` to \`realm_registry\` (gated on \`kind = 'published'\`). The legacy table is still dual-written from mutation handlers — Phase 4 PR 2 drops those writes and the table itself.

Stacked on #4561 (CS-10895). Merge that first.

## Sites migrated

**Enumerated in the spec:**
- \`server.ts:395\` — POST /connect origin lookup
- \`server.ts:673\` — \`getPublishedRealmInfo\` lastPublishedAt read
- \`handle-publish-realm.ts\` — existence check + identity before INSERT/UPDATE
- \`handle-unpublish-realm.ts\` — full-row read for response/permission/path
- \`handle-delete-realm.ts\` — existence check rejecting deletes on published URLs + cascade lookup of published copies

**Additional sites found via grep:**
- \`handle-download-realm.ts\` — path resolution for published realms
- \`utils/realm-readability.ts\` — \`getPublishedRealmURLs\` membership probe
- \`runtime-common/db-queries/realm-permission-queries.ts\` — 3 \`NOT IN (SELECT … FROM published_realms)\` subqueries + the published-owner fallback
- \`runtime-common/realm.ts\` — \`queryPublishedRealm\` + \`querySourceRealmPublications\`

## Approach

Each migrated query gates on \`kind = 'published'\` and reads from \`realm_registry\`'s columns (\`url\` / \`source_url\` / \`disk_id\` / \`last_published_at\` / \`owner_username\`). Where the legacy caller used \`published_realms\` field names (\`id\`, \`source_realm_url\`, \`published_realm_url\`), SQL column aliases preserve the in-process accessor names — so this PR is a pure data-source swap with no caller-side renames.

The one place where the field name changes is \`handle-publish-realm.ts\` existence check, which now uses \`existingRows[0].disk_id\` instead of \`existingRows[0].id\` (\`realm_registry.id\` is a separate uuid from \`published_realms.id\` — the latter matches \`realm_registry.disk_id\` for kind='published' rows by design, see migration \`1776960113000\`).

## Out of scope

- Test files (\`delete-realm-test.ts\` etc.) keep their direct \`published_realms\` reads — they're verifying the dual-write side that this PR doesn't touch.
- \`realm-registry-backfill.ts\` keeps its read — it's the backfill source by design.

## Test plan
- [ ] CI: realm-server tests pass
- [ ] CI: matrix tests pass
- [ ] Manual: publish, unpublish, delete still work end-to-end without any \`published_realms\` read at runtime (DB-side audit during smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)