### PR TITLE
Place all six dashboards in the Boxel Status folder

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-jobs.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-jobs.json
@@ -2,7 +2,10 @@
   "apiVersion": "dashboard.grafana.app/v1beta1",
   "kind": "Dashboard",
   "metadata": {
-    "name": "aetquzjcf2znke"
+    "name": "aetquzjcf2znke",
+    "annotations": {
+      "grafana.app/folder": "defd2d156sav4d"
+    }
   },
   "spec": {
     "annotations": {

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-logs.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-logs.json
@@ -2,7 +2,10 @@
   "apiVersion": "dashboard.grafana.app/v1beta1",
   "kind": "Dashboard",
   "metadata": {
-    "name": "fetquzizsej28b"
+    "name": "fetquzizsej28b",
+    "annotations": {
+      "grafana.app/folder": "defd2d156sav4d"
+    }
   },
   "spec": {
     "annotations": {

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/realm-permissions.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/realm-permissions.json
@@ -2,7 +2,10 @@
   "apiVersion": "dashboard.grafana.app/v1beta1",
   "kind": "Dashboard",
   "metadata": {
-    "name": "bfbgdczbhebr4c"
+    "name": "bfbgdczbhebr4c",
+    "annotations": {
+      "grafana.app/folder": "defd2d156sav4d"
+    }
   },
   "spec": {
     "annotations": {

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/synapse.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/synapse.json
@@ -2,7 +2,10 @@
   "apiVersion": "dashboard.grafana.app/v1beta1",
   "kind": "Dashboard",
   "metadata": {
-    "name": "000000012"
+    "name": "000000012",
+    "annotations": {
+      "grafana.app/folder": "defd2d156sav4d"
+    }
   },
   "spec": {
     "__elements": {},

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/user-credits.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/user-credits.json
@@ -2,7 +2,10 @@
   "apiVersion": "dashboard.grafana.app/v1beta1",
   "kind": "Dashboard",
   "metadata": {
-    "name": "eetquziy9np4wa"
+    "name": "eetquziy9np4wa",
+    "annotations": {
+      "grafana.app/folder": "defd2d156sav4d"
+    }
   },
   "spec": {
     "annotations": {

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/worker-status.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/worker-status.json
@@ -2,7 +2,10 @@
   "apiVersion": "dashboard.grafana.app/v1beta1",
   "kind": "Dashboard",
   "metadata": {
-    "name": "aetquzj0mdb7kb"
+    "name": "aetquzj0mdb7kb",
+    "annotations": {
+      "grafana.app/folder": "defd2d156sav4d"
+    }
   },
   "spec": {
     "annotations": {


### PR DESCRIPTION
## Summary

Grafana 12's App Platform tracks a dashboard's folder via the \`grafana.app/folder\` metadata annotation, set to the folder's \`metadata.name\` (UID). The six dashboards CS-10922 extracted from AMG don't carry that annotation, so every push has landed them at Grafana's root.

Symptom: staging Grafana's **Boxel Status** folder shows up but is empty, even though \`grafanactl resources push\` reports \`✔ 7 resources pushed, 0 errors\` (1 folder + 6 dashboards — they're being created, just not associated).

This adds \`metadata.annotations."grafana.app/folder": "defd2d156sav4d"\` to all six dashboards. \`defd2d156sav4d\` is the folder UID committed under \`packages/observability/grafanactl/resources/folders/\` and already created in staging + production Grafana.

## Test plan

- [ ] On merge: staging \`observability-apply\` runs, re-pushes the dashboards, and they appear under **Boxel Status** in \`grafana-staging.stack.cards\`.
- [ ] Same on production after dispatch.
- [ ] No "duplicate dashboard" errors — same UIDs as before, only the folder annotation changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)