### PR TITLE
Normalize the pulled tree before diffing so the comment is readable

### DIFF
--- a/packages/observability/scripts/diff.sh
+++ b/packages/observability/scripts/diff.sh
@@ -48,7 +48,8 @@ source ./scripts/grafanactl-env.sh "$env_name"
 
 cfg="$(./scripts/render-config.sh "$env_name")"
 remote="$(mktemp -d -t grafanactl-pull.XXXXXX)"
-trap 'rm -rf "$cfg" "$remote"' EXIT
+remote_norm="$(mktemp -d -t grafanactl-norm.XXXXXX)"
+trap 'rm -rf "$cfg" "$remote" "$remote_norm"' EXIT
 
 # Pull what's currently live into the tempdir. We pass explicit kind
 # arguments (`dashboards folders`) instead of letting grafanactl
@@ -68,23 +69,68 @@ grafanactl \
   --path "$remote" \
   >/dev/null
 
-# Diff: <remote-current-state> → <committed-target>. Reading top-to-bottom
-# in the diff shows what would CHANGE if we applied the committed state.
-# Color is disabled because the diff is consumed by GitHub Actions or piped
-# to a PR comment (terminal escapes don't render in either).
+# Normalize the pulled tree so it has the same layout as the committed
+# tree, matching by UID. Two reasons:
+#
+#   1. grafanactl pull writes `<remote>/Dashboard/<uid>.json` (and
+#      `<remote>/Folder/<uid>.json`); the committed tree groups
+#      dashboards under a folder name. Without normalization,
+#      `git diff --no-index` would render every file as a full add+
+#      delete pair even when the dashboard is unchanged.
+#   2. `grafanactl resources push` is upsert-only — it does NOT delete
+#      live resources missing from our manifest set. Pulled files with
+#      no committed counterpart (UI-created dashboards, AMG-era
+#      artefacts) would otherwise show as "deleted file" in the diff,
+#      suggesting an action that doesn't actually happen.
+#
+# So: for each committed file, look up the matching pulled file by UID
+# (`metadata.name` in the App Platform schema, falling back to legacy
+# spec.uid) and copy it to the same relative path inside $remote_norm.
+# Pulled files without a committed counterpart get dropped silently.
+# Committed files without a pulled counterpart leave their slot empty
+# in $remote_norm so the diff renders them as "new file" (apply would
+# create).
+extract_uid() {  # $1: path to a committed manifest
+  jq -r '.metadata.name // .spec.uid // .uid // empty' "$1"
+}
+
+normalize() {  # $1: subdir under grafanactl/resources, $2: pulled-kind dirname
+  local subdir="$1" kind="$2"
+  shopt -s nullglob globstar
+  for committed in ./grafanactl/resources/${subdir}/**/*.json ./grafanactl/resources/${subdir}/*.json; do
+    [[ -f "$committed" ]] || continue
+    local uid pulled rel target
+    uid="$(extract_uid "$committed")"
+    [[ -n "$uid" ]] || continue
+    pulled="${remote}/${kind}/${uid}.json"
+    [[ -f "$pulled" ]] || continue
+    rel="${committed#./grafanactl/resources/}"
+    target="${remote_norm}/${rel}"
+    mkdir -p "$(dirname "$target")"
+    cp "$pulled" "$target"
+  done
+}
+
+normalize dashboards Dashboard
+normalize folders Folder
+
+# Diff: <remote-current-state, normalized> → <committed-target>. Reading
+# top-to-bottom shows what would CHANGE on apply. Pulled resources that
+# aren't in our committed set are deliberately absent from the normalized
+# tree (push won't touch them).
+#
+# Color is disabled because the diff is consumed by GitHub Actions or
+# piped to a PR comment (terminal escapes don't render in either).
 #
 # Exit codes from `git diff --no-index`:
 #   0 — files identical (committed == live)
 #   1 — files differ — the diff IS the output, treat as success here
 #   2+ — real error (unreadable paths, internal git error, etc.) — propagate
-#
-# Disable -e around the diff call so exit 1 doesn't kill the script, then
-# explicitly check for 2+ and re-raise.
 set +e
 git diff \
   --no-index \
   --no-color \
-  "$remote" \
+  "$remote_norm" \
   ./grafanactl/resources/
 diff_exit=$?
 set -e


### PR DESCRIPTION
## Summary

The Observability diff PR comment is unusable on real PRs:

- 199 KB of output truncated to 60 KB (PR #4582 hit the cap)
- Almost all of it is dashboards that exist on staging but not in our committed set, rendered as \`deleted file mode 100644\` entries
- Even unchanged dashboards render as full add+delete pairs

## Two underlying issues

1. **Tree layouts don't match.** \`grafanactl resources pull\` writes \`<remote>/Dashboard/<uid>.json\`. The committed tree is organized by folder/name (\`dashboards/boxel-status/boxel-jobs.json\`). \`git diff --no-index\` treats those as completely different paths.
2. **\`grafanactl push\` is upsert-only.** Pulled files with no committed counterpart shouldn't be in the diff — they're not touched by an apply.

## Fix

Normalize the pulled tree before diffing:
- For each committed manifest, extract its UID (\`metadata.name\` or fallback to \`spec.uid\`) and copy the matching pulled file to the committed file's relative path inside a fresh tempdir.
- Pulled files without a committed counterpart get dropped silently.
- Committed files without a pulled counterpart leave their slot empty, so the diff shows them as "new file" (apply would create).

The diff then renders only what an apply would actually change.

## Test plan

- [ ] On merge: the next PR touching \`packages/observability/**\` gets a much smaller, focused observability-diff comment.
- [ ] Specifically: PR #4582 (which adds the folder annotation) should show a small diff hunk per dashboard adding the \`grafana.app/folder\` annotation, not 199 KB of unrelated noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)