### PR TITLE
Rewrite log panels from CloudWatch Logs Insights to LogQL

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-logs.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-logs.json
@@ -32,8 +32,8 @@
     "panels": [
       {
         "datasource": {
-          "type": "cloudwatch",
-          "uid": "cef5x9o3yzawwf"
+          "type": "loki",
+          "uid": "loki"
         },
         "description": "This panel displays the logs for the job selected in the drop down above. Make sure to set the date range wide enough to capture the selected logs.",
         "gridPos": {
@@ -56,32 +56,12 @@
         "targets": [
           {
             "datasource": {
-              "type": "cloudwatch",
-              "uid": "cef5x9o3yzawwf"
+              "type": "loki",
+              "uid": "loki"
             },
-            "dimensions": {},
-            "expression": "fields @timestamp, @message |\n parse @message /\\[job: (?<jobId>.*?)\\]/ |\n filter (jobId = \"$job_id\") |\n sort @timestamp asc",
-            "id": "",
-            "label": "",
-            "logGroups": [
-              {
-                "accountId": "680542703984",
-                "arn": "arn:aws:logs:us-east-1:680542703984:log-group:ecs-boxel-worker-staging",
-                "name": "ecs-boxel-worker-staging"
-              }
-            ],
-            "matchExact": true,
-            "metricEditorMode": 0,
-            "metricName": "",
-            "metricQueryType": 0,
-            "namespace": "",
-            "period": "",
-            "queryMode": "Logs",
-            "refId": "A",
-            "region": "default",
-            "sqlExpression": "",
-            "statistic": "Average",
-            "statsGroups": []
+            "expr": "{service=~\"realm-server|worker|prerender|prerender-manager\"} |= \"[job: $job_id]\"",
+            "queryType": "range",
+            "refId": "A"
           }
         ],
         "title": "Job Logs",
@@ -89,8 +69,8 @@
       },
       {
         "datasource": {
-          "type": "cloudwatch",
-          "uid": "cef5x9o3yzawwf"
+          "type": "loki",
+          "uid": "loki"
         },
         "description": "This panel displays the logs for the selected worker. Make sure to set the date range wide enough to capture the selected logs.",
         "gridPos": {
@@ -113,32 +93,12 @@
         "targets": [
           {
             "datasource": {
-              "type": "cloudwatch",
-              "uid": "cef5x9o3yzawwf"
+              "type": "loki",
+              "uid": "loki"
             },
-            "dimensions": {},
-            "expression": "fields @timestamp, @message |\n parse @message /^\\[worker (?<workerId>.*?) / |\n filter (workerId = \"$worker_id\") |\n sort @timestamp asc",
-            "id": "4",
-            "label": "",
-            "logGroups": [
-              {
-                "accountId": "680542703984",
-                "arn": "arn:aws:logs:us-east-1:680542703984:log-group:ecs-boxel-worker-staging",
-                "name": "ecs-boxel-worker-staging"
-              }
-            ],
-            "matchExact": true,
-            "metricEditorMode": 0,
-            "metricName": "",
-            "metricQueryType": 0,
-            "namespace": "",
-            "period": "",
-            "queryMode": "Logs",
-            "refId": "A",
-            "region": "default",
-            "sqlExpression": "",
-            "statistic": "Average",
-            "statsGroups": []
+            "expr": "{service=\"worker\"} |~ \"^\\\\[worker $worker_id \"",
+            "queryType": "range",
+            "refId": "A"
           }
         ],
         "title": "Worker Logs",
@@ -146,8 +106,8 @@
       },
       {
         "datasource": {
-          "type": "cloudwatch",
-          "uid": "cef5x9o3yzawwf"
+          "type": "loki",
+          "uid": "loki"
         },
         "description": "The realm server logs. Make sure to set the duration to the value that encapsulates time frame for the logs that you want. Note that these logs have been truncated to 1000 lines.",
         "gridPos": {
@@ -170,32 +130,12 @@
         "targets": [
           {
             "datasource": {
-              "type": "cloudwatch",
-              "uid": "cef5x9o3yzawwf"
+              "type": "loki",
+              "uid": "loki"
             },
-            "dimensions": {},
-            "expression": "fields @timestamp, @message |\n sort @timestamp desc |\n limit 1000",
-            "id": "",
-            "label": "",
-            "logGroups": [
-              {
-                "accountId": "680542703984",
-                "arn": "arn:aws:logs:us-east-1:680542703984:log-group:ecs-boxel-realm-server-staging",
-                "name": "ecs-boxel-realm-server-staging"
-              }
-            ],
-            "matchExact": true,
-            "metricEditorMode": 0,
-            "metricName": "",
-            "metricQueryType": 0,
-            "namespace": "",
-            "period": "",
-            "queryMode": "Logs",
-            "refId": "A",
-            "region": "default",
-            "sqlExpression": "",
-            "statistic": "Average",
-            "statsGroups": []
+            "expr": "{service=\"realm-server\"}",
+            "queryType": "range",
+            "refId": "A"
           }
         ],
         "title": "Realm Server Logs",


### PR DESCRIPTION
## Summary

CS-10925. Three log panels in \`boxel-logs.json\` were the only CloudWatch panels left after CS-10978 wired up the new data sources. They were rendering empty/errored. Rewrites each to LogQL against the Loki data source.

## The three rewrites

| Panel | LogQL |
|---|---|
| Job Logs | \`{service=~"realm-server\|worker\|prerender\|prerender-manager"} \|= "[job: \$job_id]"\` |
| Worker Logs | \`{service="worker"} \|~ "^\\\\[worker \$worker_id "\` |
| Realm Server Logs | \`{service="realm-server"}\` |

## Two design calls worth flagging

**No \`env=\` filter on any selector.** Each Grafana instance only sees its own Loki via the SSM-resolved \`LOKI_URL\` — staging Grafana → staging Loki, prod → prod. Adding \`env="staging"\` to the committed YAML would break the production push (single set of dashboard files apply to both envs). Natural data isolation handles it.

**Worker Logs uses a line-content regex, not the Loki worker_id label.** The dashboard's \`\$worker_id\` template variable comes from \`SELECT worker_id FROM job_reservations\` — the realm-server's internal identifier (e.g. \`worker-1\`). The Loki \`worker_id\` label is the Fargate task ID (e.g. \`abc123def456\`). Different value spaces. Regex match against the existing \`[worker <id> ...]\` log prefix is the bridge until **CS-10985** unifies them.

## Out-of-scope follow-ups (already filed)

- **[CS-10985](https://linear.app/cardstack/issue/CS-10985)** — Make Loki worker_id label match the realm-server's internal worker identifier. Once landed, the Worker Logs panel becomes a label match and drops the regex.
- **[CS-10984](https://linear.app/cardstack/issue/CS-10984)** — Scrape local realm-server logs into local Loki. Required to satisfy this ticket's "dev runs local Grafana and confirms local realm-server logs show up" acceptance criterion. Local realm-server runs natively (not in Docker) so today's docker-socket-based Alloy scraper can't see it.

## Test plan

- [x] Three CloudWatch panels removed; zero \`datasource.type == "cloudwatch"\` panels remain in any dashboard.
- [ ] After staging apply: each of the three log panels renders non-empty data when its template variables resolve to real job / worker IDs.
- [ ] Drill-through links from metric panels (none found in audit) — N/A.
- [ ] Synapse dashboard log panels — N/A (zero CloudWatch panels there; synapse-prometheus is metrics-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)