### PR TITLE
Substitute realm_server URL per env at apply time

### DIFF
--- a/.github/workflows/observability-apply-production.yml
+++ b/.github/workflows/observability-apply-production.yml
@@ -142,10 +142,11 @@ jobs:
             echo "${var}=${val}" >> "$GITHUB_ENV"
           }
 
-          fetch GRAFANA_TOKEN          /production/grafana/grafanactl_token   --with-decryption
+          fetch GRAFANA_TOKEN          /production/grafana/grafanactl_token       --with-decryption
           fetch LOKI_URL               /production/loki/internal_url
           fetch BOXEL_DB_HOST          /production/boxel-grafana/db_host
           fetch SYNAPSE_PROMETHEUS_URL /production/boxel-grafana/prometheus_url
+          fetch REALM_SERVER_URL       /production/boxel-grafana/realm_server_url
           fetch BOXEL_DB_NAME          /production/boxel/PGDATABASE
           fetch BOXEL_DB_USER          /production/boxel/GRAFANA_DB_USER
           fetch BOXEL_DB_PASSWORD      /production/boxel/GRAFANA_DB_PASSWORD  --with-decryption

--- a/.github/workflows/observability-apply-staging.yml
+++ b/.github/workflows/observability-apply-staging.yml
@@ -89,10 +89,11 @@ jobs:
             echo "${var}=${val}" >> "$GITHUB_ENV"
           }
 
-          fetch GRAFANA_TOKEN          /staging/grafana/grafanactl_token   --with-decryption
+          fetch GRAFANA_TOKEN          /staging/grafana/grafanactl_token       --with-decryption
           fetch LOKI_URL               /staging/loki/internal_url
           fetch BOXEL_DB_HOST          /staging/boxel-grafana/db_host
           fetch SYNAPSE_PROMETHEUS_URL /staging/boxel-grafana/prometheus_url
+          fetch REALM_SERVER_URL       /staging/boxel-grafana/realm_server_url
           fetch BOXEL_DB_NAME          /staging/boxel/PGDATABASE
           fetch BOXEL_DB_USER          /staging/boxel/GRAFANA_DB_USER
           fetch BOXEL_DB_PASSWORD      /staging/boxel/GRAFANA_DB_PASSWORD  --with-decryption

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-jobs.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-jobs.json
@@ -523,7 +523,7 @@
         {
           "hide": 2,
           "name": "realm_server",
-          "query": "https://realms-staging.stack.cards/",
+          "query": "__REALM_SERVER_URL__",
           "skipUrlSync": false,
           "type": "constant"
         },

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/realm-permissions.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/realm-permissions.json
@@ -297,7 +297,7 @@
         {
           "hide": 2,
           "name": "realm_server",
-          "query": "https://realms-staging.stack.cards/",
+          "query": "__REALM_SERVER_URL__",
           "skipUrlSync": false,
           "type": "constant"
         }

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/user-credits.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/user-credits.json
@@ -286,7 +286,7 @@
         {
           "hide": 2,
           "name": "realm_server",
-          "query": "https://realms-staging.stack.cards/",
+          "query": "__REALM_SERVER_URL__",
           "skipUrlSync": false,
           "type": "constant"
         }

--- a/packages/observability/scripts/apply.sh
+++ b/packages/observability/scripts/apply.sh
@@ -62,6 +62,9 @@ if [[ "$env_name" != "local" ]]; then
     BOXEL_DB_USER
     BOXEL_DB_PASSWORD
     SYNAPSE_PROMETHEUS_URL
+    # Per-env realm-server base URL substituted into dashboards' realm_server
+    # constant template variable — CS-10923
+    REALM_SERVER_URL
   )
   for v in "${required_env_vars[@]}"; do
     [[ -n "${!v:-}" ]] \
@@ -70,13 +73,45 @@ if [[ "$env_name" != "local" ]]; then
 fi
 
 cfg="$(./scripts/render-config.sh "$env_name")"
-trap 'rm -f "$cfg"' EXIT
+
+# Render dashboards: copy the committed grafanactl/resources/ tree to a
+# tempdir and substitute env-specific values into each dashboard's
+# `templating.list[].query` for matching constant variables. Currently
+# substitutes:
+#   __REALM_SERVER_URL__  → REALM_SERVER_URL  (CS-10923)
+# Local mode uses a hardcoded http://localhost:4201/ default so devs
+# don't need any extra setup.
+rendered="$(mktemp -d -t grafanactl-render.XXXXXX)"
+trap 'rm -f "$cfg"; rm -rf "$rendered"' EXIT
+cp -R ./grafanactl/resources/. "$rendered/"
+
+case "$env_name" in
+  local) realm_server_url="${REALM_SERVER_URL:-http://localhost:4201/}" ;;
+  *)     realm_server_url="$REALM_SERVER_URL" ;;
+esac
+
+shopt -s globstar nullglob
+for f in "$rendered"/dashboards/**/*.json; do
+  [[ -f "$f" ]] || continue
+  jq --arg url "$realm_server_url" '
+    walk(
+      if type == "object"
+         and .name? == "realm_server"
+         and .type? == "constant"
+      then
+        .query = $url
+        | (if .current then .current.value = $url | .current.text = $url else . end)
+      else . end
+    )
+  ' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+done
+shopt -u globstar nullglob
 
 grafanactl \
   --config "$cfg" \
   --context "$env_name" \
   resources push \
-  --path ./grafanactl/resources \
+  --path "$rendered" \
   "${forwarded_args[@]}"
 
 # Data sources — grafanactl doesn't manage them, so push via HTTP API.

--- a/packages/observability/scripts/apply.sh
+++ b/packages/observability/scripts/apply.sh
@@ -44,11 +44,17 @@ cd "$(dirname "$0")/.."
 # shellcheck source=./grafanactl-env.sh
 source ./scripts/grafanactl-env.sh "$env_name"
 
+# `jq` is needed for the dashboard render step below in every env (including
+# local), so always check it. The other dependencies are only needed for the
+# hosted-env data-source push; check them inside the env-specific block.
+command -v jq >/dev/null \
+  || { echo "error: missing dependency: jq" >&2; exit 1; }
+
 # Pre-flight prereqs for hosted envs BEFORE grafanactl pushes anything.
 # Otherwise a missing env var or absent yq would surface only after
 # dashboards/folders had already been re-pushed, leaving a partial apply.
 if [[ "$env_name" != "local" ]]; then
-  for cmd in yq jq curl envsubst; do
+  for cmd in yq curl envsubst; do
     command -v "$cmd" >/dev/null \
       || { echo "error: missing dependency: ${cmd}" >&2; exit 1; }
   done
@@ -93,6 +99,10 @@ esac
 shopt -s globstar nullglob
 for f in "$rendered"/dashboards/**/*.json; do
   [[ -f "$f" ]] || continue
+  # `set -e` aborts on a non-zero exit, but only for "simple commands" — a
+  # `jq ... > out && mv ...` chain swallows jq's failure inside the &&,
+  # leaving the script to continue with an unrendered file. Run as two
+  # separate statements so a jq error fails the script.
   jq --arg url "$realm_server_url" '
     walk(
       if type == "object"
@@ -103,7 +113,8 @@ for f in "$rendered"/dashboards/**/*.json; do
         | (if .current then .current.value = $url | .current.text = $url else . end)
       else . end
     )
-  ' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+  ' "$f" > "$f.tmp"
+  mv "$f.tmp" "$f"
 done
 shopt -u globstar nullglob
 


### PR DESCRIPTION
## Summary

CS-10923. Three dashboards (\`boxel-jobs\`, \`realm-permissions\`, \`user-credits\`) define a \`realm_server\` Grafana **constant** template variable that operator-action button URLs concatenate against (\`\${realm_server}_grafana-reindex?...\`). The committed JSON had it hardcoded to the staging URL, so production Grafana's buttons silently linked at the **staging** realm-server.

Replace the staging URL with a \`__REALM_SERVER_URL__\` placeholder token. \`apply.sh\` adds a render step that copies \`grafanactl/resources/\` to a tempdir and jq-substitutes the placeholder with the per-env value before \`grafanactl push\`.

| Env | Source | Value |
|---|---|---|
| local | apply.sh hardcoded default | \`http://localhost:4201/\` |
| staging | \`/staging/boxel-grafana/realm_server_url\` | \`https://realms-staging.stack.cards/\` |
| production | \`/production/boxel-grafana/realm_server_url\` | \`https://app.boxel.ai/\` |

(SSM publishing is in companion infra PR.)

## Why surgical substitution (jq + walk) instead of envsubst

The dashboards have many other \`\${var}\` patterns that are correct **Grafana template-variable references** (e.g. \`\${full_index_realm}\` in panel titles, \`\${grafana_secret}\` in URLs — CS-10924's territory). Running envsubst over the whole file would clobber them with empty strings. Instead, the render step uses jq's \`walk\` to match only \`{name: "realm_server", type: "constant"}\` objects and rewrite their \`.query\` field — nothing else.

## Companion PR

Requires **[cardstack/infra#678](https://github.com/cardstack/infra/pull/678)** — publishes the SSM values and extends the \`boxel-observability-apply\` IAM grant. Apply that first or the workflow's SSM fetch returns AccessDenied.

## Test plan

- [x] Render step verified locally: \`__REALM_SERVER_URL__\` → expected URL across all three dashboards; nothing else in the JSON changes (\`diff -r\` on rendered vs committed shows only the three lines).
- [ ] After merge + infra apply: staging \`observability-apply\` CI run renders + pushes the dashboards. The Reindex / Add credit / Grant permission buttons in staging Grafana point at \`realms-staging.stack.cards\`.
- [ ] After dispatching prod: same buttons in production Grafana point at \`app.boxel.ai\`.
- [ ] No regression on \`grep \\\$\\{realm_server\\}\` in the committed dashboards — the \`\${realm_server}\` references in panel link templates remain intact (they're Grafana template-variable references, resolved at view time).

## Out-of-scope (still open)

- **CS-10924** — \`grafana_secret\` removal. Same dashboards still embed an auth-token reference; that's the next ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)