### PR TITLE
bot: Add check for OpenRouter API key

### DIFF
--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -205,6 +205,10 @@ let assistant: Assistant;
 
 (async () => {
   const matrixUrl = process.env.MATRIX_URL || 'http://localhost:8008';
+  if (!process.env.OPENROUTER_API_KEY) {
+    log.error('OPENROUTER_API_KEY is required.');
+    process.exit(1);
+  }
   let matrixDebugLogger = !process.env.DISABLE_MATRIX_JS_LOGGING
     ? new DebugLogger(debug(`matrix-js-sdk:${aiBotUsername}`))
     : undefined;


### PR DESCRIPTION
I got a misleading error trying to start the bot without `OPENROUTER_API_KEY` set:

```
OpenAIError: The OPENAI_API_KEY environment variable is missing or empty; either provide it, or instantiate the OpenAI client with an apiKey option, like new OpenAI({ apiKey: 'My API Key' }).
    at new OpenAI (/Users/b/Documents/Cardstack/Code/boxel-motion-worktrees/cs-block-param-tag-shadow-skill/node_modules/.pnpm/openai@5.12.2_patch_hash=6833f1bcf56cde16edb25881777c31d2745994c6ea992d1e2051d1248d213449_ws@8.19.0_zod@3.25.76/node_modules/openai/src/client.ts:343:13)
    at new Assistant (/Users/b/Documents/Cardstack/Code/boxel-motion-worktrees/cs-block-param-tag-shadow-skill/packages/ai-bot/main.ts:86:19)
    at /Users/b/Documents/Cardstack/Code/boxel-motion-worktrees/cs-block-param-tag-shadow-skill/packages/ai-bot/main.ts:269:15
    at processTicksAndRejections (node:internal/process/task_queues:103:5)
 ELIFECYCLE  Command failed with exit code 1.
```

Setting `OPENAI_API_KEY` lets the bot start but then you get 401s:

```
AuthenticationError: 401 Missing Authentication header
    at APIError.generate (/Users/b/Documents/Cardstack/Code/boxel-motion-worktrees/cs-block-param-tag-shadow-skill/node_modules/.pnpm/openai@5.12.2_patch_hash=6833f1bcf56cde16edb25881777c31d2745994c6ea992d1e2051d1248d213449_ws@8.19.0_zod@3.25.76/node_modules/openai/src/core/error.ts:76:14)
    at OpenAI.makeStatusError (/Users/b/Documents/Cardstack/Code/boxel-motion-worktrees/cs-block-param-tag-shadow-skill/node_modules/.pnpm/openai@5.12.2_patch_hash=6833f1bcf56cde16edb25881777c31d2745994c6ea992d1e2051d1248d213449_ws@8.19.0_zod@3.25.76/node_modules/openai/src/client.ts:445:28)
    at OpenAI.makeRequest (/Users/b/Documents/Cardstack/Code/boxel-motion-worktrees/cs-block-param-tag-shadow-skill/node_modules/.pnpm/openai@5.12.2_patch_hash=6833f1bcf56cde16edb25881777c31d2745994c6ea992d1e2051d1248d213449_ws@8.19.0_zod@3.25.76/node_modules/openai/src/client.ts:668:24)
    at processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async ChatCompletionStream._createChatCompletion (/Users/b/Documents/Cardstack/Code/boxel-motion-worktrees/cs-block-param-tag-shadow-skill/node_modules/.pnpm/openai@5.12.2_patch_hash=6833f1bcf56cde16edb25881777c31d2745994c6ea992d1e2051d1248d213449_ws@8.19.0_zod@3.25.76/node_modules/openai/src/lib/ChatCompletionStream.ts:383:20)
    at async ChatCompletionStream._runChatCompletion (/Users/b/Documents/Cardstack/Code/boxel-motion-worktrees/cs-block-param-tag-shadow-skill/node_modules/.pnpm/openai@5.12.2_patch_hash=6833f1bcf56cde16edb25881777c31d2745994c6ea992d1e2051d1248d213449_ws@8.19.0_zod@3.25.76/node_modules/openai/src/lib/AbstractChatCompletionRunner.ts:251:12) {
  status: 401,
  headers: Headers {
    date: 'Thu, 30 Apr 2026 12:54:38 GMT',
    'content-type': 'application/json',
    'transfer-encoding': 'chunked',
    connection: 'keep-alive',
    'access-control-allow-origin': '*',
    'access-control-expose-headers': 'X-Generation-Id,cf-ray',
    'permissions-policy': 'payment=(self "https://checkout.stripe.com" "https://connect-js.stripe.com" "https://js.stripe.com" "https://*.js.stripe.com" "https://hooks.stripe.com")',
    'referrer-policy': 'no-referrer, strict-origin-when-cross-origin',
    'x-content-type-options': 'nosniff',
    server: 'cloudflare',
    'cf-ray': '9f46b2378c97863e-ORD'
  },
  requestID: null,
  error: { message: 'Missing Authentication header', code: 401 },
  code: 401,
  param: undefined,
  type: undefined
}
Error - 401 Missing Authentication header
```

Since we actually require the OpenRouter API key, we should say so to save developer confusion.