### PR TITLE
host: Add form attributes for password manager autofill

### DIFF
--- a/packages/boxel-ui/addon/src/components/input-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/index.gts
@@ -35,6 +35,7 @@ export interface Signature {
     id?: string;
     inputmode?: string;
     invalidIcon?: Icon;
+    name?: string;
     onBlur?: (ev: Event) => void;
     onFocus?: (ev: Event) => void;
     onInput?: (val: string) => void;
@@ -111,6 +112,7 @@ export default class InputGroup extends Component<Signature> {
           {{else}}
             <InputControl
               id={{this.elementId}}
+              name={{@name}}
               type={{@type}}
               @placeholder={{@placeholder}}
               @disabled={{@disabled}}

--- a/packages/boxel-ui/addon/src/components/input-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/index.gts
@@ -35,7 +35,6 @@ export interface Signature {
     id?: string;
     inputmode?: string;
     invalidIcon?: Icon;
-    name?: string;
     onBlur?: (ev: Event) => void;
     onFocus?: (ev: Event) => void;
     onInput?: (val: string) => void;
@@ -112,7 +111,6 @@ export default class InputGroup extends Component<Signature> {
           {{else}}
             <InputControl
               id={{this.elementId}}
-              name={{@name}}
               type={{@type}}
               @placeholder={{@placeholder}}
               @disabled={{@disabled}}

--- a/packages/boxel-ui/addon/src/components/input-group/usage.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/usage.gts
@@ -47,6 +47,7 @@ export default class BoxelInputGroupUsage extends Component {
   @tracked placeholder: string | undefined;
   @tracked autocomplete: string | undefined;
   @tracked inputmode: string | undefined;
+  @tracked name: string | undefined;
   @tracked helperText = 'Please enter an amount';
   @tracked errorMessage = '';
   @tracked disabled = false;
@@ -129,6 +130,7 @@ export default class BoxelInputGroupUsage extends Component {
           @placeholder={{this.placeholder}}
           @autocomplete={{this.autocomplete}}
           @inputmode={{this.inputmode}}
+          @name={{this.name}}
           @onInput={{this.set}}
           @state={{this.state}}
           @validIcon={{this.validIcon}}
@@ -212,6 +214,12 @@ export default class BoxelInputGroupUsage extends Component {
           @description='The inputmode attribute value for the input (ignored when a default block is supplied)'
           @value={{this.inputmode}}
           @onInput={{fn (mut this.inputmode)}}
+        />
+        <Args.String
+          @name='name'
+          @description='The name attribute value for the input (ignored when a default block is supplied)'
+          @value={{this.name}}
+          @onInput={{fn (mut this.name)}}
         />
         <Args.String
           @name='value'

--- a/packages/boxel-ui/addon/src/components/input-group/usage.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/usage.gts
@@ -47,7 +47,6 @@ export default class BoxelInputGroupUsage extends Component {
   @tracked placeholder: string | undefined;
   @tracked autocomplete: string | undefined;
   @tracked inputmode: string | undefined;
-  @tracked name: string | undefined;
   @tracked helperText = 'Please enter an amount';
   @tracked errorMessage = '';
   @tracked disabled = false;
@@ -130,7 +129,6 @@ export default class BoxelInputGroupUsage extends Component {
           @placeholder={{this.placeholder}}
           @autocomplete={{this.autocomplete}}
           @inputmode={{this.inputmode}}
-          @name={{this.name}}
           @onInput={{this.set}}
           @state={{this.state}}
           @validIcon={{this.validIcon}}
@@ -214,12 +212,6 @@ export default class BoxelInputGroupUsage extends Component {
           @description='The inputmode attribute value for the input (ignored when a default block is supplied)'
           @value={{this.inputmode}}
           @onInput={{fn (mut this.inputmode)}}
-        />
-        <Args.String
-          @name='name'
-          @description='The name attribute value for the input (ignored when a default block is supplied)'
-          @value={{this.name}}
-          @onInput={{fn (mut this.name)}}
         />
         <Args.String
           @name='value'

--- a/packages/boxel-ui/test-app/tests/integration/components/input-group-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/input-group-test.gts
@@ -53,4 +53,14 @@ module('Integration | Component | InputGroup', function (hooks) {
 
     assert.dom('[data-test-override-icon]').exists();
   });
+
+  test('forwards the @name arg to the inner input element', async function (assert) {
+    await render(
+      <template>
+        <BoxelInputGroup @name='username' @value='' />
+      </template>,
+    );
+
+    assert.dom('input').hasAttribute('name', 'username');
+  });
 });

--- a/packages/boxel-ui/test-app/tests/integration/components/input-group-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/input-group-test.gts
@@ -56,9 +56,7 @@ module('Integration | Component | InputGroup', function (hooks) {
 
   test('forwards the @name arg to the inner input element', async function (assert) {
     await render(
-      <template>
-        <BoxelInputGroup @name='username' @value='' />
-      </template>,
+      <template><BoxelInputGroup @name='username' @value='' /></template>,
     );
 
     assert.dom('input').hasAttribute('name', 'username');

--- a/packages/host/app/components/matrix/forgot-password.gts
+++ b/packages/host/app/components/matrix/forgot-password.gts
@@ -55,6 +55,8 @@ export default class ForgotPassword extends Component<Signature> {
         <BoxelInput
           data-test-email-field
           type='text'
+          name='email'
+          autocomplete='email'
           @errorMessage={{this.emailError}}
           @state={{this.emailInputState}}
           @value={{this.email}}
@@ -104,6 +106,8 @@ export default class ForgotPassword extends Component<Signature> {
         <BoxelInput
           data-test-password-field
           type='password'
+          name='password'
+          autocomplete='new-password'
           @errorMessage={{this.passwordError}}
           @state={{this.passwordInputState}}
           @value={{this.password}}
@@ -120,6 +124,8 @@ export default class ForgotPassword extends Component<Signature> {
         <BoxelInput
           data-test-confirm-password-field
           type='password'
+          name='confirm-password'
+          autocomplete='new-password'
           @errorMessage={{this.confirmPasswordError}}
           @state={{this.confirmPasswordInputState}}
           @value={{this.confirmPassword}}

--- a/packages/host/app/components/matrix/forgot-password.gts
+++ b/packages/host/app/components/matrix/forgot-password.gts
@@ -55,8 +55,6 @@ export default class ForgotPassword extends Component<Signature> {
         <BoxelInput
           data-test-email-field
           type='text'
-          name='email'
-          autocomplete='email'
           @errorMessage={{this.emailError}}
           @state={{this.emailInputState}}
           @value={{this.email}}
@@ -106,8 +104,6 @@ export default class ForgotPassword extends Component<Signature> {
         <BoxelInput
           data-test-password-field
           type='password'
-          name='password'
-          autocomplete='new-password'
           @errorMessage={{this.passwordError}}
           @state={{this.passwordInputState}}
           @value={{this.password}}
@@ -124,8 +120,6 @@ export default class ForgotPassword extends Component<Signature> {
         <BoxelInput
           data-test-confirm-password-field
           type='password'
-          name='confirm-password'
-          autocomplete='new-password'
           @errorMessage={{this.confirmPasswordError}}
           @state={{this.confirmPasswordInputState}}
           @value={{this.confirmPassword}}

--- a/packages/host/app/components/matrix/login.gts
+++ b/packages/host/app/components/matrix/login.gts
@@ -45,6 +45,7 @@ export default class Login extends Component<Signature> {
           data-test-username-field
           type='text'
           id='boxel-login-username'
+          name='username'
           autocomplete='username'
           @value={{this.username}}
           @onInput={{this.setUsername}}
@@ -61,6 +62,7 @@ export default class Login extends Component<Signature> {
           data-test-password-field
           type='password'
           id='boxel-login-password'
+          name='password'
           autocomplete='current-password'
           @value={{this.password}}
           @onInput={{this.setPassword}}

--- a/packages/host/app/components/matrix/login.gts
+++ b/packages/host/app/components/matrix/login.gts
@@ -45,7 +45,6 @@ export default class Login extends Component<Signature> {
           data-test-username-field
           type='text'
           id='boxel-login-username'
-          name='username'
           autocomplete='username'
           @value={{this.username}}
           @onInput={{this.setUsername}}
@@ -62,7 +61,6 @@ export default class Login extends Component<Signature> {
           data-test-password-field
           type='password'
           id='boxel-login-password'
-          name='password'
           autocomplete='current-password'
           @value={{this.password}}
           @onInput={{this.setPassword}}

--- a/packages/host/app/components/matrix/register-user.gts
+++ b/packages/host/app/components/matrix/register-user.gts
@@ -132,6 +132,8 @@ export default class RegisterUser extends Component<Signature> {
         >
           <BoxelInput
             data-test-email-field
+            name='email'
+            autocomplete='email'
             @state={{this.emailInputState}}
             @value={{this.email}}
             @errorMessage={{this.emailError}}
@@ -148,6 +150,7 @@ export default class RegisterUser extends Component<Signature> {
           <BoxelInputGroup
             data-test-username-field
             id='boxel-register-username'
+            @name='username'
             autocomplete='username'
             @state={{this.usernameInputState}}
             @value={{this.username}}
@@ -173,6 +176,7 @@ export default class RegisterUser extends Component<Signature> {
           <BoxelInput
             data-test-password-field
             id='boxel-register-password'
+            name='password'
             autocomplete='new-password'
             @type='password'
             @value={{this.password}}
@@ -191,6 +195,7 @@ export default class RegisterUser extends Component<Signature> {
           <BoxelInput
             data-test-confirm-password-field
             id='boxel-register-confirm-password'
+            name='confirm-password'
             autocomplete='new-password'
             @type='password'
             @value={{this.confirmPassword}}

--- a/packages/host/app/components/matrix/register-user.gts
+++ b/packages/host/app/components/matrix/register-user.gts
@@ -132,8 +132,6 @@ export default class RegisterUser extends Component<Signature> {
         >
           <BoxelInput
             data-test-email-field
-            name='email'
-            autocomplete='email'
             @state={{this.emailInputState}}
             @value={{this.email}}
             @errorMessage={{this.emailError}}
@@ -150,7 +148,6 @@ export default class RegisterUser extends Component<Signature> {
           <BoxelInputGroup
             data-test-username-field
             id='boxel-register-username'
-            @name='username'
             autocomplete='username'
             @state={{this.usernameInputState}}
             @value={{this.username}}
@@ -176,7 +173,6 @@ export default class RegisterUser extends Component<Signature> {
           <BoxelInput
             data-test-password-field
             id='boxel-register-password'
-            name='password'
             autocomplete='new-password'
             @type='password'
             @value={{this.password}}
@@ -195,7 +191,6 @@ export default class RegisterUser extends Component<Signature> {
           <BoxelInput
             data-test-confirm-password-field
             id='boxel-register-confirm-password'
-            name='confirm-password'
             autocomplete='new-password'
             @type='password'
             @value={{this.confirmPassword}}

--- a/packages/matrix/tests/forgot-password.spec.ts
+++ b/packages/matrix/tests/forgot-password.spec.ts
@@ -30,6 +30,10 @@ test.describe('Forgot password', () => {
     await expect(
       page.locator('[data-test-reset-your-password-btn]'),
     ).toBeDisabled();
+    await expect(page.locator('[data-test-email-field]')).toHaveAttribute(
+      'name',
+      'email',
+    );
     await page.locator('[data-test-email-field]').fill(userEmail);
     await expect(
       page.locator('[data-test-reset-your-password-btn]'),
@@ -63,6 +67,12 @@ test.describe('Forgot password', () => {
     await expect(
       resetPasswordPage.locator('[data-test-reset-password-btn]'),
     ).toBeDisabled();
+    await expect(
+      resetPasswordPage.locator('[data-test-password-field]'),
+    ).toHaveAttribute('name', 'password');
+    await expect(
+      resetPasswordPage.locator('[data-test-confirm-password-field]'),
+    ).toHaveAttribute('name', 'confirm-password');
     await resetPasswordPage
       .locator('[data-test-password-field]')
       .fill(newPassword);

--- a/packages/matrix/tests/login.spec.ts
+++ b/packages/matrix/tests/login.spec.ts
@@ -34,6 +34,15 @@ test.beforeEach(async () => {
   }) => {
     await page.goto(appURL);
 
+    await expect(page.locator('[data-test-username-field]')).toHaveAttribute(
+      'name',
+      'username',
+    );
+    await expect(page.locator('[data-test-password-field]')).toHaveAttribute(
+      'name',
+      'password',
+    );
+
     await expect(page.locator('[data-test-login-btn]')).toBeDisabled();
     await page.locator('[data-test-username-field]').fill(username);
     await expect(page.locator('[data-test-login-btn]')).toBeDisabled();

--- a/packages/matrix/tests/registration-with-token.spec.ts
+++ b/packages/matrix/tests/registration-with-token.spec.ts
@@ -63,6 +63,22 @@ test.describe('User Registration w/ Token', () => {
       'token field is not displayed',
     ).toHaveCount(0);
     await expect(page.locator('[data-test-register-btn]')).toBeDisabled();
+
+    await expect(page.locator('[data-test-email-field]')).toHaveAttribute(
+      'name',
+      'email',
+    );
+    await expect(
+      page.locator('[data-test-username-field] input'),
+    ).toHaveAttribute('name', 'username');
+    await expect(page.locator('[data-test-password-field]')).toHaveAttribute(
+      'name',
+      'password',
+    );
+    await expect(
+      page.locator('[data-test-confirm-password-field]'),
+    ).toHaveAttribute('name', 'confirm-password');
+
     await page.locator('[data-test-name-field]').fill(firstUser.displayName);
     await expect(page.locator('[data-test-register-btn]')).toBeDisabled();
     await page.locator('[data-test-email-field]').fill(firstUser.email);


### PR DESCRIPTION
I’ve noticed for a while that when I use a password manager autofill shortcut it ignores the username:

<img width="626" height="555" alt="image" src="https://github.com/user-attachments/assets/4b2376af-9023-4dc3-aad0-bde5a6310928" />

This adds the relevant hint attributes for password managers and other autofill features.

`boxel-ui` [test failure](https://github.com/cardstack/boxel/actions/runs/25179058804/job/73819372084?pr=4588#step:6:184) about `@name` being passed through on `InputGroup`:
```
not ok 12 Chrome 147.0 - [42 ms] - Integration | Component | InputGroup: forwards the @name arg to the inner input element
    ---
        actual: >
            Element input does not have attribute "name"
        expected: >
            Element input has attribute "name" with value "username"
        stack: >
                at DOMAssertions.hasAttribute (webpack://test-app/../../../../../../node_modules/.pnpm/qunit-dom@3.5.0/node_modules/qunit-dom/dist/es/index.js?:692:12)
                at Object.eval (webpack://test-app/./tests/integration/components/input-group-test.ts?:109:25)
        message: >
            Element input has attribute "name" with value "username"
        negative: >
            false
        browser log: |
```

Matrix [test](https://boxel-matrix-playwright-reports.stack.cards/host/login-autofill-attributes-cs-10986/20260430_175447Z/index.html#?testId=852acb1e2419f9f859ad-d3be2a06a4a3ba93cf2c) [failures](https://boxel-matrix-playwright-reports.stack.cards/host/login-autofill-attributes-cs-10986/20260430_175447Z/index.html#?testId=41d3fd2474a19feb00a1-7e76617881caf0857399):

```
await expect(page.locator('[data-test-email-field]')).toHaveAttribute(
                                                      ^
  'name',
  'email',
);
```

```
await expect(page.locator('[data-test-username-field]')).toHaveAttribute(
                                                         ^
  'name',
  'username',
);
```