### PR TITLE
CS-10976 PR 1: AsyncSemaphore.setCapacity + in-flight tracking

### DIFF
--- a/packages/realm-server/prerender/async-semaphore.ts
+++ b/packages/realm-server/prerender/async-semaphore.ts
@@ -27,7 +27,7 @@ export class AsyncSemaphore {
   }> = [];
 
   constructor(max: number) {
-    this.#capacity = Math.max(1, max);
+    this.#capacity = normalizeCapacity(max);
     this.#inUse = 0;
   }
 
@@ -95,9 +95,13 @@ export class AsyncSemaphore {
   // Resize the semaphore. Growing wakes queued waiters up to the new
   // cap. Shrinking is best-effort: in-flight slots are never preempted,
   // but no new waiters are admitted until #inUse falls under the new
-  // cap. `n` is clamped to a minimum of 1.
+  // cap. `n` is normalized through `normalizeCapacity`: NaN, non-finite,
+  // and non-integer values fall back to a clamped integer (`1` floor),
+  // matching the constructor's contract — `#inUse` is an integer
+  // counter, so a fractional cap would silently allow `floor(n)+1`
+  // concurrent holders.
   setCapacity(n: number): void {
-    let newCap = Math.max(1, n);
+    let newCap = normalizeCapacity(n);
     if (newCap === this.#capacity) return;
     this.#capacity = newCap;
     // Wake waiters up to the new cap. Same hand-off shape as #release
@@ -120,4 +124,17 @@ export class AsyncSemaphore {
       next.resolve(this.#release);
     }
   };
+}
+
+// Reject NaN / non-finite / non-integer / sub-1 values so the cap is
+// always a positive integer. This matters for resize callers (PagePool
+// expansion contraction in PR 7) where a malformed env-var or upstream
+// math would otherwise propagate `NaN` into `#capacity` and stall every
+// future acquire/release — comparisons against `NaN` are always false.
+// Floor on non-integers because `#inUse` is integer-counted and a
+// fractional cap effectively rounds up at the `<` comparison.
+function normalizeCapacity(n: number): number {
+  if (!Number.isFinite(n)) return 1;
+  let floored = Math.floor(n);
+  return floored < 1 ? 1 : floored;
 }

--- a/packages/realm-server/prerender/async-semaphore.ts
+++ b/packages/realm-server/prerender/async-semaphore.ts
@@ -4,10 +4,20 @@ import { PrerenderCancelledError, throwIfAborted } from './prerender-cancel';
 // Exported so cancellation-plumbing unit tests can drive it directly
 // — no Chrome dependency. Used by:
 //   - Prerenderer (global render-concurrency cap)
+//   - PagePool global render-semaphore (per-server tab cap)
 //   - PagePool file-queue admission control (CS-10946)
+//
+// Capacity is mutable post-construction via `setCapacity(n)` so callers
+// (PagePool dynamic tab expansion / contraction in CS-10976) can grow
+// the concurrency cap without rebuilding the semaphore. In-flight slots
+// are never preempted on shrink — `setCapacity(smaller)` just stops
+// admitting new waiters until `inUseCount` falls back under the new cap.
 export class AsyncSemaphore {
   #capacity: number;
-  #available: number;
+  // Tracked directly so resize works correctly. The original
+  // `#capacity - #available` formulation fell apart when capacity could
+  // change while requests were in flight.
+  #inUse: number;
   // `resolve` hands the acquirer the release function once a slot
   // frees. `onCancel` gives the cancellation path a way to splice
   // the entry out of the queue without racing #release.
@@ -18,16 +28,17 @@ export class AsyncSemaphore {
 
   constructor(max: number) {
     this.#capacity = Math.max(1, max);
-    this.#available = this.#capacity;
+    this.#inUse = 0;
   }
 
-  // Total slots (from construction). Stable for the semaphore's lifetime.
+  // Current cap. Mutable via `setCapacity`; callers reading this
+  // observe the live value.
   get capacity(): number {
     return this.#capacity;
   }
 
   // Waiters currently queued behind an exhausted semaphore. Zero when
-  // `#available > 0` (no one is waiting because slots are free).
+  // `inUseCount < capacity` (no one is waiting because slots are free).
   get pendingCount(): number {
     return this.#queue.length;
   }
@@ -36,13 +47,13 @@ export class AsyncSemaphore {
   // released. `inUseCount === 0 && pendingCount === 0` means the
   // semaphore is idle and safe for a caller to drop.
   get inUseCount(): number {
-    return this.#capacity - this.#available;
+    return this.#inUse;
   }
 
   async acquire(signal?: AbortSignal): Promise<() => void> {
     throwIfAborted(signal);
-    if (this.#available > 0) {
-      this.#available--;
+    if (this.#inUse < this.#capacity) {
+      this.#inUse++;
       return this.#release;
     }
     return await new Promise<() => void>((resolve, reject) => {
@@ -81,12 +92,32 @@ export class AsyncSemaphore {
     });
   }
 
-  #release = () => {
-    let next = this.#queue.shift();
-    if (next) {
+  // Resize the semaphore. Growing wakes queued waiters up to the new
+  // cap. Shrinking is best-effort: in-flight slots are never preempted,
+  // but no new waiters are admitted until #inUse falls under the new
+  // cap. `n` is clamped to a minimum of 1.
+  setCapacity(n: number): void {
+    let newCap = Math.max(1, n);
+    if (newCap === this.#capacity) return;
+    this.#capacity = newCap;
+    // Wake waiters up to the new cap. Same hand-off shape as #release
+    // (increment inUse, resolve the next waiter), iterated.
+    while (this.#inUse < this.#capacity && this.#queue.length > 0) {
+      let next = this.#queue.shift()!;
+      this.#inUse++;
       next.resolve(this.#release);
-      return;
     }
-    this.#available++;
+  }
+
+  #release = () => {
+    this.#inUse--;
+    // If a waiter is queued AND we have spare capacity, hand it the
+    // slot (no net change in `#inUse`). Otherwise the slot stays free
+    // until the next acquire.
+    if (this.#inUse < this.#capacity && this.#queue.length > 0) {
+      let next = this.#queue.shift()!;
+      this.#inUse++;
+      next.resolve(this.#release);
+    }
   };
 }

--- a/packages/realm-server/tests/async-semaphore-test.ts
+++ b/packages/realm-server/tests/async-semaphore-test.ts
@@ -1,0 +1,350 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { AsyncSemaphore } from '../prerender/async-semaphore';
+import { isPrerenderCancellation } from '../prerender/prerender-cancel';
+
+// Tests for AsyncSemaphore's resize-aware behaviour added in CS-10976.
+// The cancellation tests live in prerender-cancellation-test.ts; this
+// file owns the contract of `setCapacity(n)` plus the in-flight
+// tracking the resize requires.
+//
+// What we pin down here:
+//   1. The basic invariants (capacity / inUseCount / pendingCount)
+//      remain correct when in-flight slots cross the cap because of a
+//      shrink — i.e. release() decrements inUseCount monotonically and
+//      doesn't admit new waiters while inUse > capacity.
+//   2. setCapacity(grow) wakes queued waiters up to the new cap, in
+//      FIFO order, in a single pass — not one wake per future release.
+//   3. setCapacity(shrink) is best-effort: never preempts in-flight,
+//      stalls future admissions until inUse falls under the new cap.
+//   4. Edge cases: clamping to 1, no-op resize, resize while empty,
+//      cancelled waiters mixed with grow.
+
+module(basename(__filename), function () {
+  module('AsyncSemaphore basic state', function () {
+    test('reports correct counts at construction', function (assert) {
+      let sem = new AsyncSemaphore(3);
+      assert.strictEqual(sem.capacity, 3);
+      assert.strictEqual(sem.inUseCount, 0);
+      assert.strictEqual(sem.pendingCount, 0);
+    });
+
+    test('clamps construction capacity to 1 minimum', function (assert) {
+      let sem = new AsyncSemaphore(0);
+      assert.strictEqual(sem.capacity, 1, 'cap=0 clamped to 1');
+      let sem2 = new AsyncSemaphore(-5);
+      assert.strictEqual(sem2.capacity, 1, 'cap=-5 clamped to 1');
+    });
+
+    test('inUseCount tracks acquire / release directly', async function (assert) {
+      let sem = new AsyncSemaphore(2);
+      let r1 = await sem.acquire();
+      assert.strictEqual(sem.inUseCount, 1);
+      let r2 = await sem.acquire();
+      assert.strictEqual(sem.inUseCount, 2);
+      r1();
+      assert.strictEqual(sem.inUseCount, 1);
+      r2();
+      assert.strictEqual(sem.inUseCount, 0);
+    });
+
+    test('pendingCount reflects queued waiters', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let r1 = await sem.acquire();
+      let p2 = sem.acquire();
+      let p3 = sem.acquire();
+      // Allow microtask flush so the queueing has settled.
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 2);
+      r1();
+      let r2 = await p2;
+      assert.strictEqual(sem.pendingCount, 1);
+      r2();
+      let r3 = await p3;
+      assert.strictEqual(sem.pendingCount, 0);
+      r3();
+    });
+  });
+
+  module('setCapacity grow', function () {
+    test('grow wakes queued waiters up to the new cap', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let r1 = await sem.acquire();
+
+      let acquired: number[] = [];
+      let p2 = sem.acquire().then((r) => {
+        acquired.push(2);
+        return r;
+      });
+      let p3 = sem.acquire().then((r) => {
+        acquired.push(3);
+        return r;
+      });
+      let p4 = sem.acquire().then((r) => {
+        acquired.push(4);
+        return r;
+      });
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 3, '3 waiters queued');
+      assert.deepEqual(acquired, [], 'no one acquired yet');
+
+      // Grow to 3: should wake exactly 2 waiters (1 in-flight + 2 new
+      // = 3 total).
+      sem.setCapacity(3);
+      let r2 = await p2;
+      let r3 = await p3;
+      assert.deepEqual(acquired, [2, 3], 'FIFO: 2 and 3 woke, in order');
+      assert.strictEqual(sem.inUseCount, 3, 'inUse at new cap');
+      assert.strictEqual(sem.pendingCount, 1, 'one waiter still queued');
+
+      // Grow further: should wake the last one.
+      sem.setCapacity(4);
+      let r4 = await p4;
+      assert.deepEqual(acquired, [2, 3, 4]);
+      assert.strictEqual(sem.inUseCount, 4);
+      assert.strictEqual(sem.pendingCount, 0);
+
+      r1();
+      r2();
+      r3();
+      r4();
+      assert.strictEqual(sem.inUseCount, 0);
+    });
+
+    test('grow with empty queue is a no-op against state', function (assert) {
+      let sem = new AsyncSemaphore(2);
+      sem.setCapacity(5);
+      assert.strictEqual(sem.capacity, 5);
+      assert.strictEqual(sem.inUseCount, 0);
+      assert.strictEqual(sem.pendingCount, 0);
+    });
+
+    test('grow when not saturated does not over-admit', async function (assert) {
+      let sem = new AsyncSemaphore(3);
+      let r1 = await sem.acquire();
+      sem.setCapacity(5);
+      assert.strictEqual(sem.inUseCount, 1);
+      assert.strictEqual(sem.capacity, 5);
+      // Verify we can still acquire up to the new cap.
+      let r2 = await sem.acquire();
+      let r3 = await sem.acquire();
+      let r4 = await sem.acquire();
+      let r5 = await sem.acquire();
+      assert.strictEqual(sem.inUseCount, 5);
+      r1();
+      r2();
+      r3();
+      r4();
+      r5();
+    });
+  });
+
+  module('setCapacity shrink', function () {
+    test('shrink does not preempt in-flight slots', async function (assert) {
+      let sem = new AsyncSemaphore(5);
+      let r1 = await sem.acquire();
+      let r2 = await sem.acquire();
+      let r3 = await sem.acquire();
+      let r4 = await sem.acquire();
+      let r5 = await sem.acquire();
+      assert.strictEqual(sem.inUseCount, 5);
+
+      sem.setCapacity(2);
+      assert.strictEqual(sem.capacity, 2, 'capacity reflects shrink');
+      assert.strictEqual(
+        sem.inUseCount,
+        5,
+        'in-flight slots untouched by shrink',
+      );
+
+      r1();
+      r2();
+      r3();
+      assert.strictEqual(sem.inUseCount, 2);
+      r4();
+      r5();
+      assert.strictEqual(sem.inUseCount, 0);
+    });
+
+    test('shrink stalls new acquires until inUse drops under the new cap', async function (assert) {
+      let sem = new AsyncSemaphore(4);
+      let r1 = await sem.acquire();
+      let r2 = await sem.acquire();
+      let r3 = await sem.acquire();
+
+      // Shrink to 2 with 3 in-flight (over-cap by 1).
+      sem.setCapacity(2);
+      let admitted = false;
+      let p4 = sem.acquire().then((r) => {
+        admitted = true;
+        return r;
+      });
+      await Promise.resolve();
+      assert.false(admitted, 'over-cap blocks new acquire');
+      assert.strictEqual(sem.pendingCount, 1);
+
+      // Drop one in-flight: still over-cap (2 in-flight, cap 2). Should
+      // not admit.
+      r1();
+      await Promise.resolve();
+      assert.false(admitted, 'still blocked at inUse===cap');
+
+      // Drop another: now under-cap (1 in-flight, cap 2). Waiter wakes.
+      r2();
+      let r4 = await p4;
+      assert.true(admitted, 'admitted after inUse fell under cap');
+      assert.strictEqual(sem.inUseCount, 2);
+
+      r3();
+      r4();
+      assert.strictEqual(sem.inUseCount, 0);
+    });
+
+    test('grow then shrink in same tick preserves correct count', async function (assert) {
+      let sem = new AsyncSemaphore(2);
+      let r1 = await sem.acquire();
+      let r2 = await sem.acquire();
+      let p3 = sem.acquire();
+      let p4 = sem.acquire();
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 2);
+
+      sem.setCapacity(4);
+      let r3 = await p3;
+      let r4 = await p4;
+      assert.strictEqual(sem.inUseCount, 4);
+      assert.strictEqual(sem.pendingCount, 0);
+
+      sem.setCapacity(1);
+      assert.strictEqual(sem.capacity, 1);
+      assert.strictEqual(sem.inUseCount, 4, 'shrink preserves in-flight');
+
+      r1();
+      r2();
+      r3();
+      assert.strictEqual(sem.inUseCount, 1, 'three drained');
+      r4();
+      assert.strictEqual(sem.inUseCount, 0, 'all drained');
+    });
+
+    test('shrink to 0 clamps to 1', function (assert) {
+      let sem = new AsyncSemaphore(3);
+      sem.setCapacity(0);
+      assert.strictEqual(sem.capacity, 1, 'cap=0 clamped to 1');
+      sem.setCapacity(-2);
+      assert.strictEqual(sem.capacity, 1, 'cap=-2 clamped to 1');
+    });
+
+    test('no-op when new capacity equals current', function (assert) {
+      let sem = new AsyncSemaphore(3);
+      sem.setCapacity(3);
+      assert.strictEqual(sem.capacity, 3);
+      assert.strictEqual(sem.inUseCount, 0);
+    });
+  });
+
+  module('setCapacity interactions with cancellation', function () {
+    test('cancelled waiter is skipped during grow wake', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let r1 = await sem.acquire();
+
+      let ac = new AbortController();
+      let pCancelled = sem.acquire(ac.signal).then(
+        () => 'acquired',
+        (e) => (isPrerenderCancellation(e) ? 'cancelled' : 'other'),
+      );
+      let acquiredAfter: number[] = [];
+      let pNext = sem.acquire().then((r) => {
+        acquiredAfter.push(1);
+        return r;
+      });
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 2, 'two queued');
+
+      // Cancel the first waiter: it gets spliced out of the queue.
+      ac.abort('test');
+      assert.strictEqual(await pCancelled, 'cancelled');
+      assert.strictEqual(sem.pendingCount, 1, 'cancelled waiter spliced');
+
+      // Grow: the surviving waiter wakes.
+      sem.setCapacity(2);
+      let r2 = await pNext;
+      assert.deepEqual(acquiredAfter, [1]);
+      assert.strictEqual(sem.inUseCount, 2);
+      r1();
+      r2();
+    });
+
+    test('cancellation while slot in-flight does not corrupt count after a shrink', async function (assert) {
+      let sem = new AsyncSemaphore(3);
+      let r1 = await sem.acquire();
+      let r2 = await sem.acquire();
+      let r3 = await sem.acquire();
+
+      // Shrink to 1 — over-cap by 2.
+      sem.setCapacity(1);
+      assert.strictEqual(sem.inUseCount, 3);
+
+      // Queue a waiter under a signal we'll abort before any release.
+      let ac = new AbortController();
+      let pCancelled = sem.acquire(ac.signal).then(
+        () => 'acquired',
+        (e) => (isPrerenderCancellation(e) ? 'cancelled' : 'other'),
+      );
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 1);
+
+      ac.abort();
+      assert.strictEqual(await pCancelled, 'cancelled');
+      assert.strictEqual(sem.pendingCount, 0);
+
+      // Drain: no waiters should magically appear.
+      r1();
+      r2();
+      r3();
+      assert.strictEqual(sem.inUseCount, 0);
+      assert.strictEqual(sem.pendingCount, 0);
+    });
+  });
+
+  module('AsyncSemaphore concurrent operations', function () {
+    test('many concurrent acquires + setCapacity admits exactly N', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let acquired = 0;
+      let releases: Array<() => void> = [];
+
+      // Queue 10 acquirers. Only the first one will fit at cap=1.
+      let acquirers = Array.from({ length: 10 }, () =>
+        sem.acquire().then((r) => {
+          acquired++;
+          releases.push(r);
+        }),
+      );
+      await Promise.resolve();
+      assert.strictEqual(acquired, 1, 'one in flight at cap=1');
+      assert.strictEqual(sem.pendingCount, 9);
+
+      // Grow to 5: 4 more should wake (5 - 1 already in flight = 4
+      // immediate hand-offs).
+      sem.setCapacity(5);
+      // Allow promise resolutions to flush.
+      await Promise.resolve();
+      await Promise.resolve();
+      assert.strictEqual(acquired, 5, 'five in flight at cap=5');
+      assert.strictEqual(sem.pendingCount, 5);
+
+      // Drain by releasing one at a time. Each release should wake one
+      // waiter until queue empties.
+      while (releases.length > 0) {
+        let r = releases.shift()!;
+        r();
+        await Promise.resolve();
+        await Promise.resolve();
+      }
+      await Promise.all(acquirers);
+      assert.strictEqual(acquired, 10, 'all eventually acquired');
+      assert.strictEqual(sem.inUseCount, 0);
+      assert.strictEqual(sem.pendingCount, 0);
+    });
+  });
+});

--- a/packages/realm-server/tests/async-semaphore-test.ts
+++ b/packages/realm-server/tests/async-semaphore-test.ts
@@ -36,6 +36,28 @@ module(basename(__filename), function () {
       assert.strictEqual(sem2.capacity, 1, 'cap=-5 clamped to 1');
     });
 
+    test('rejects non-finite construction capacity (NaN / Infinity)', function (assert) {
+      // Addresses Codex P2 + Copilot review on PR 4589: `Math.max(1, NaN)
+      // === NaN` would have permanently stalled every future acquire
+      // because comparisons against NaN are always false.
+      let nanSem = new AsyncSemaphore(NaN);
+      assert.strictEqual(nanSem.capacity, 1, 'NaN falls back to 1');
+      let infSem = new AsyncSemaphore(Infinity);
+      assert.strictEqual(infSem.capacity, 1, 'Infinity falls back to 1');
+      let negInfSem = new AsyncSemaphore(-Infinity);
+      assert.strictEqual(negInfSem.capacity, 1, '-Infinity falls back to 1');
+    });
+
+    test('floors fractional construction capacity', function (assert) {
+      // `#inUse` is an integer counter, so a fractional cap (e.g. 2.7)
+      // would let `2 < 2.7` admit a 3rd holder despite operator intent
+      // of "two slots".
+      let sem = new AsyncSemaphore(2.7);
+      assert.strictEqual(sem.capacity, 2, '2.7 floors to 2');
+      let sem2 = new AsyncSemaphore(0.9);
+      assert.strictEqual(sem2.capacity, 1, '0.9 floors-then-clamps to 1');
+    });
+
     test('inUseCount tracks acquire / release directly', async function (assert) {
       let sem = new AsyncSemaphore(2);
       let r1 = await sem.acquire();
@@ -233,6 +255,19 @@ module(basename(__filename), function () {
       assert.strictEqual(sem.capacity, 1, 'cap=0 clamped to 1');
       sem.setCapacity(-2);
       assert.strictEqual(sem.capacity, 1, 'cap=-2 clamped to 1');
+    });
+
+    test('rejects non-finite + fractional resize values', function (assert) {
+      // Same Codex/Copilot concern as the constructor — protected here
+      // because PagePool dynamic resize (PR 7) reads env-vars and
+      // arithmetic results, both of which can produce NaN/floats.
+      let sem = new AsyncSemaphore(3);
+      sem.setCapacity(NaN);
+      assert.strictEqual(sem.capacity, 1, 'NaN normalized to 1');
+      sem.setCapacity(Infinity);
+      assert.strictEqual(sem.capacity, 1, 'Infinity normalized to 1');
+      sem.setCapacity(4.7);
+      assert.strictEqual(sem.capacity, 4, '4.7 floors to 4');
     });
 
     test('no-op when new capacity equals current', function (assert) {

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -177,6 +177,7 @@ import './prerender-manager-test';
 import './prerender-affinity-activity-test';
 import './prerender-batch-ownership-test';
 import './prerender-cancellation-test';
+import './async-semaphore-test';
 import './runtime-exception-capture-test';
 import './clamp-serialized-error-test';
 import './prerender-diagnostics-persistence-test';


### PR DESCRIPTION
## Summary

Foundation PR for CS-10976 dynamic tab expansion. Adds `setCapacity(n)` to `AsyncSemaphore` and switches the internal model from `inUseCount = capacity - available` to direct in-flight tracking — the original formulation breaks when capacity can change while requests are in flight.

No call sites change in this PR. `setCapacity` has no callers yet; PagePool will start using it in PR 7.

## Behaviour

- **Grow**: wakes queued waiters up to the new cap, FIFO, in a single pass.
- **Shrink**: never preempts in-flight slots; new acquires stall until `inUse` falls back under the new cap.
- **Clamping**: cap is clamped to 1 minimum on construction and on `setCapacity`.
- **Cancellation**: existing splice-on-abort behaviour is preserved.

## Why direct in-flight tracking

The original `#capacity - #available` formulation maintains an invariant that `available` and `capacity` track each other through `acquire`/`release`. Once `capacity` becomes mutable, that invariant breaks: a shrink moves `capacity` down while `available` is already at zero, leaving `inUseCount` reading higher than the new cap. Switching to a direct `#inUse` counter lets shrink simply "wait for in-flight to drain" without any consistency contortions.

External API surface is unchanged: `capacity`, `inUseCount`, `pendingCount`, `acquire(signal)` all behave the same. Only difference is `capacity` is no longer "stable for the semaphore's lifetime" — JSDoc updated.

## Test plan

- [x] New `tests/async-semaphore-test.ts` — 15 tests covering grow / shrink / clamping / cancel-during-grow / cancel-after-shrink / concurrent acquire+resize. All pass.
- [x] Existing `tests/prerender-cancellation-test.ts` — 16 tests still pass; the abort-mid-handoff case is intentionally retained as the trickiest invariant.
- [x] `pnpm lint` clean on changed files (the unrelated 6 911 lint errors live in `realms/localhost_4201/user/working-loon/jqxl/parser/...` realm content and are pre-existing).
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` reports no errors in `prerender/*` or `tests/async-semaphore-test.ts`.

## Stack

Part of the CS-10976 stacked PR series. See the [plan comment on CS-10976](https://linear.app/cardstack/issue/CS-10976/create-prerendering-prioritization) for the full PR-by-PR breakdown. Next PRs in the stack will build on this:

- **PR 2** — Real deadlock-scenario test
- **PR 3** — Wire format threading (priority through producer pipeline)
- **PR 4** — Server-side priority dequeue (TabQueue + render-semaphore use priority)
- **PR 7** — PagePool dynamic expansion (first caller of setCapacity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)