### PR TITLE
CS-10976 PR 2: real deadlock-scenario test (regression guard)

### DIFF
--- a/packages/realm-server/prerender/async-semaphore.ts
+++ b/packages/realm-server/prerender/async-semaphore.ts
@@ -4,10 +4,20 @@ import { PrerenderCancelledError, throwIfAborted } from './prerender-cancel';
 // Exported so cancellation-plumbing unit tests can drive it directly
 // — no Chrome dependency. Used by:
 //   - Prerenderer (global render-concurrency cap)
+//   - PagePool global render-semaphore (per-server tab cap)
 //   - PagePool file-queue admission control (CS-10946)
+//
+// Capacity is mutable post-construction via `setCapacity(n)` so callers
+// (PagePool dynamic tab expansion / contraction in CS-10976) can grow
+// the concurrency cap without rebuilding the semaphore. In-flight slots
+// are never preempted on shrink — `setCapacity(smaller)` just stops
+// admitting new waiters until `inUseCount` falls back under the new cap.
 export class AsyncSemaphore {
   #capacity: number;
-  #available: number;
+  // Tracked directly so resize works correctly. The original
+  // `#capacity - #available` formulation fell apart when capacity could
+  // change while requests were in flight.
+  #inUse: number;
   // `resolve` hands the acquirer the release function once a slot
   // frees. `onCancel` gives the cancellation path a way to splice
   // the entry out of the queue without racing #release.
@@ -18,16 +28,17 @@ export class AsyncSemaphore {
 
   constructor(max: number) {
     this.#capacity = Math.max(1, max);
-    this.#available = this.#capacity;
+    this.#inUse = 0;
   }
 
-  // Total slots (from construction). Stable for the semaphore's lifetime.
+  // Current cap. Mutable via `setCapacity`; callers reading this
+  // observe the live value.
   get capacity(): number {
     return this.#capacity;
   }
 
   // Waiters currently queued behind an exhausted semaphore. Zero when
-  // `#available > 0` (no one is waiting because slots are free).
+  // `inUseCount < capacity` (no one is waiting because slots are free).
   get pendingCount(): number {
     return this.#queue.length;
   }
@@ -36,13 +47,13 @@ export class AsyncSemaphore {
   // released. `inUseCount === 0 && pendingCount === 0` means the
   // semaphore is idle and safe for a caller to drop.
   get inUseCount(): number {
-    return this.#capacity - this.#available;
+    return this.#inUse;
   }
 
   async acquire(signal?: AbortSignal): Promise<() => void> {
     throwIfAborted(signal);
-    if (this.#available > 0) {
-      this.#available--;
+    if (this.#inUse < this.#capacity) {
+      this.#inUse++;
       return this.#release;
     }
     return await new Promise<() => void>((resolve, reject) => {
@@ -81,12 +92,32 @@ export class AsyncSemaphore {
     });
   }
 
-  #release = () => {
-    let next = this.#queue.shift();
-    if (next) {
+  // Resize the semaphore. Growing wakes queued waiters up to the new
+  // cap. Shrinking is best-effort: in-flight slots are never preempted,
+  // but no new waiters are admitted until #inUse falls under the new
+  // cap. `n` is clamped to a minimum of 1.
+  setCapacity(n: number): void {
+    let newCap = Math.max(1, n);
+    if (newCap === this.#capacity) return;
+    this.#capacity = newCap;
+    // Wake waiters up to the new cap. Same hand-off shape as #release
+    // (increment inUse, resolve the next waiter), iterated.
+    while (this.#inUse < this.#capacity && this.#queue.length > 0) {
+      let next = this.#queue.shift()!;
+      this.#inUse++;
       next.resolve(this.#release);
-      return;
     }
-    this.#available++;
+  }
+
+  #release = () => {
+    this.#inUse--;
+    // If a waiter is queued AND we have spare capacity, hand it the
+    // slot (no net change in `#inUse`). Otherwise the slot stays free
+    // until the next acquire.
+    if (this.#inUse < this.#capacity && this.#queue.length > 0) {
+      let next = this.#queue.shift()!;
+      this.#inUse++;
+      next.resolve(this.#release);
+    }
   };
 }

--- a/packages/realm-server/tests/async-semaphore-test.ts
+++ b/packages/realm-server/tests/async-semaphore-test.ts
@@ -1,0 +1,350 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { AsyncSemaphore } from '../prerender/async-semaphore';
+import { isPrerenderCancellation } from '../prerender/prerender-cancel';
+
+// Tests for AsyncSemaphore's resize-aware behaviour added in CS-10976.
+// The cancellation tests live in prerender-cancellation-test.ts; this
+// file owns the contract of `setCapacity(n)` plus the in-flight
+// tracking the resize requires.
+//
+// What we pin down here:
+//   1. The basic invariants (capacity / inUseCount / pendingCount)
+//      remain correct when in-flight slots cross the cap because of a
+//      shrink — i.e. release() decrements inUseCount monotonically and
+//      doesn't admit new waiters while inUse > capacity.
+//   2. setCapacity(grow) wakes queued waiters up to the new cap, in
+//      FIFO order, in a single pass — not one wake per future release.
+//   3. setCapacity(shrink) is best-effort: never preempts in-flight,
+//      stalls future admissions until inUse falls under the new cap.
+//   4. Edge cases: clamping to 1, no-op resize, resize while empty,
+//      cancelled waiters mixed with grow.
+
+module(basename(__filename), function () {
+  module('AsyncSemaphore basic state', function () {
+    test('reports correct counts at construction', function (assert) {
+      let sem = new AsyncSemaphore(3);
+      assert.strictEqual(sem.capacity, 3);
+      assert.strictEqual(sem.inUseCount, 0);
+      assert.strictEqual(sem.pendingCount, 0);
+    });
+
+    test('clamps construction capacity to 1 minimum', function (assert) {
+      let sem = new AsyncSemaphore(0);
+      assert.strictEqual(sem.capacity, 1, 'cap=0 clamped to 1');
+      let sem2 = new AsyncSemaphore(-5);
+      assert.strictEqual(sem2.capacity, 1, 'cap=-5 clamped to 1');
+    });
+
+    test('inUseCount tracks acquire / release directly', async function (assert) {
+      let sem = new AsyncSemaphore(2);
+      let r1 = await sem.acquire();
+      assert.strictEqual(sem.inUseCount, 1);
+      let r2 = await sem.acquire();
+      assert.strictEqual(sem.inUseCount, 2);
+      r1();
+      assert.strictEqual(sem.inUseCount, 1);
+      r2();
+      assert.strictEqual(sem.inUseCount, 0);
+    });
+
+    test('pendingCount reflects queued waiters', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let r1 = await sem.acquire();
+      let p2 = sem.acquire();
+      let p3 = sem.acquire();
+      // Allow microtask flush so the queueing has settled.
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 2);
+      r1();
+      let r2 = await p2;
+      assert.strictEqual(sem.pendingCount, 1);
+      r2();
+      let r3 = await p3;
+      assert.strictEqual(sem.pendingCount, 0);
+      r3();
+    });
+  });
+
+  module('setCapacity grow', function () {
+    test('grow wakes queued waiters up to the new cap', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let r1 = await sem.acquire();
+
+      let acquired: number[] = [];
+      let p2 = sem.acquire().then((r) => {
+        acquired.push(2);
+        return r;
+      });
+      let p3 = sem.acquire().then((r) => {
+        acquired.push(3);
+        return r;
+      });
+      let p4 = sem.acquire().then((r) => {
+        acquired.push(4);
+        return r;
+      });
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 3, '3 waiters queued');
+      assert.deepEqual(acquired, [], 'no one acquired yet');
+
+      // Grow to 3: should wake exactly 2 waiters (1 in-flight + 2 new
+      // = 3 total).
+      sem.setCapacity(3);
+      let r2 = await p2;
+      let r3 = await p3;
+      assert.deepEqual(acquired, [2, 3], 'FIFO: 2 and 3 woke, in order');
+      assert.strictEqual(sem.inUseCount, 3, 'inUse at new cap');
+      assert.strictEqual(sem.pendingCount, 1, 'one waiter still queued');
+
+      // Grow further: should wake the last one.
+      sem.setCapacity(4);
+      let r4 = await p4;
+      assert.deepEqual(acquired, [2, 3, 4]);
+      assert.strictEqual(sem.inUseCount, 4);
+      assert.strictEqual(sem.pendingCount, 0);
+
+      r1();
+      r2();
+      r3();
+      r4();
+      assert.strictEqual(sem.inUseCount, 0);
+    });
+
+    test('grow with empty queue is a no-op against state', function (assert) {
+      let sem = new AsyncSemaphore(2);
+      sem.setCapacity(5);
+      assert.strictEqual(sem.capacity, 5);
+      assert.strictEqual(sem.inUseCount, 0);
+      assert.strictEqual(sem.pendingCount, 0);
+    });
+
+    test('grow when not saturated does not over-admit', async function (assert) {
+      let sem = new AsyncSemaphore(3);
+      let r1 = await sem.acquire();
+      sem.setCapacity(5);
+      assert.strictEqual(sem.inUseCount, 1);
+      assert.strictEqual(sem.capacity, 5);
+      // Verify we can still acquire up to the new cap.
+      let r2 = await sem.acquire();
+      let r3 = await sem.acquire();
+      let r4 = await sem.acquire();
+      let r5 = await sem.acquire();
+      assert.strictEqual(sem.inUseCount, 5);
+      r1();
+      r2();
+      r3();
+      r4();
+      r5();
+    });
+  });
+
+  module('setCapacity shrink', function () {
+    test('shrink does not preempt in-flight slots', async function (assert) {
+      let sem = new AsyncSemaphore(5);
+      let r1 = await sem.acquire();
+      let r2 = await sem.acquire();
+      let r3 = await sem.acquire();
+      let r4 = await sem.acquire();
+      let r5 = await sem.acquire();
+      assert.strictEqual(sem.inUseCount, 5);
+
+      sem.setCapacity(2);
+      assert.strictEqual(sem.capacity, 2, 'capacity reflects shrink');
+      assert.strictEqual(
+        sem.inUseCount,
+        5,
+        'in-flight slots untouched by shrink',
+      );
+
+      r1();
+      r2();
+      r3();
+      assert.strictEqual(sem.inUseCount, 2);
+      r4();
+      r5();
+      assert.strictEqual(sem.inUseCount, 0);
+    });
+
+    test('shrink stalls new acquires until inUse drops under the new cap', async function (assert) {
+      let sem = new AsyncSemaphore(4);
+      let r1 = await sem.acquire();
+      let r2 = await sem.acquire();
+      let r3 = await sem.acquire();
+
+      // Shrink to 2 with 3 in-flight (over-cap by 1).
+      sem.setCapacity(2);
+      let admitted = false;
+      let p4 = sem.acquire().then((r) => {
+        admitted = true;
+        return r;
+      });
+      await Promise.resolve();
+      assert.false(admitted, 'over-cap blocks new acquire');
+      assert.strictEqual(sem.pendingCount, 1);
+
+      // Drop one in-flight: still over-cap (2 in-flight, cap 2). Should
+      // not admit.
+      r1();
+      await Promise.resolve();
+      assert.false(admitted, 'still blocked at inUse===cap');
+
+      // Drop another: now under-cap (1 in-flight, cap 2). Waiter wakes.
+      r2();
+      let r4 = await p4;
+      assert.true(admitted, 'admitted after inUse fell under cap');
+      assert.strictEqual(sem.inUseCount, 2);
+
+      r3();
+      r4();
+      assert.strictEqual(sem.inUseCount, 0);
+    });
+
+    test('grow then shrink in same tick preserves correct count', async function (assert) {
+      let sem = new AsyncSemaphore(2);
+      let r1 = await sem.acquire();
+      let r2 = await sem.acquire();
+      let p3 = sem.acquire();
+      let p4 = sem.acquire();
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 2);
+
+      sem.setCapacity(4);
+      let r3 = await p3;
+      let r4 = await p4;
+      assert.strictEqual(sem.inUseCount, 4);
+      assert.strictEqual(sem.pendingCount, 0);
+
+      sem.setCapacity(1);
+      assert.strictEqual(sem.capacity, 1);
+      assert.strictEqual(sem.inUseCount, 4, 'shrink preserves in-flight');
+
+      r1();
+      r2();
+      r3();
+      assert.strictEqual(sem.inUseCount, 1, 'three drained');
+      r4();
+      assert.strictEqual(sem.inUseCount, 0, 'all drained');
+    });
+
+    test('shrink to 0 clamps to 1', function (assert) {
+      let sem = new AsyncSemaphore(3);
+      sem.setCapacity(0);
+      assert.strictEqual(sem.capacity, 1, 'cap=0 clamped to 1');
+      sem.setCapacity(-2);
+      assert.strictEqual(sem.capacity, 1, 'cap=-2 clamped to 1');
+    });
+
+    test('no-op when new capacity equals current', function (assert) {
+      let sem = new AsyncSemaphore(3);
+      sem.setCapacity(3);
+      assert.strictEqual(sem.capacity, 3);
+      assert.strictEqual(sem.inUseCount, 0);
+    });
+  });
+
+  module('setCapacity interactions with cancellation', function () {
+    test('cancelled waiter is skipped during grow wake', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let r1 = await sem.acquire();
+
+      let ac = new AbortController();
+      let pCancelled = sem.acquire(ac.signal).then(
+        () => 'acquired',
+        (e) => (isPrerenderCancellation(e) ? 'cancelled' : 'other'),
+      );
+      let acquiredAfter: number[] = [];
+      let pNext = sem.acquire().then((r) => {
+        acquiredAfter.push(1);
+        return r;
+      });
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 2, 'two queued');
+
+      // Cancel the first waiter: it gets spliced out of the queue.
+      ac.abort('test');
+      assert.strictEqual(await pCancelled, 'cancelled');
+      assert.strictEqual(sem.pendingCount, 1, 'cancelled waiter spliced');
+
+      // Grow: the surviving waiter wakes.
+      sem.setCapacity(2);
+      let r2 = await pNext;
+      assert.deepEqual(acquiredAfter, [1]);
+      assert.strictEqual(sem.inUseCount, 2);
+      r1();
+      r2();
+    });
+
+    test('cancellation while slot in-flight does not corrupt count after a shrink', async function (assert) {
+      let sem = new AsyncSemaphore(3);
+      let r1 = await sem.acquire();
+      let r2 = await sem.acquire();
+      let r3 = await sem.acquire();
+
+      // Shrink to 1 — over-cap by 2.
+      sem.setCapacity(1);
+      assert.strictEqual(sem.inUseCount, 3);
+
+      // Queue a waiter under a signal we'll abort before any release.
+      let ac = new AbortController();
+      let pCancelled = sem.acquire(ac.signal).then(
+        () => 'acquired',
+        (e) => (isPrerenderCancellation(e) ? 'cancelled' : 'other'),
+      );
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 1);
+
+      ac.abort();
+      assert.strictEqual(await pCancelled, 'cancelled');
+      assert.strictEqual(sem.pendingCount, 0);
+
+      // Drain: no waiters should magically appear.
+      r1();
+      r2();
+      r3();
+      assert.strictEqual(sem.inUseCount, 0);
+      assert.strictEqual(sem.pendingCount, 0);
+    });
+  });
+
+  module('AsyncSemaphore concurrent operations', function () {
+    test('many concurrent acquires + setCapacity admits exactly N', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let acquired = 0;
+      let releases: Array<() => void> = [];
+
+      // Queue 10 acquirers. Only the first one will fit at cap=1.
+      let acquirers = Array.from({ length: 10 }, () =>
+        sem.acquire().then((r) => {
+          acquired++;
+          releases.push(r);
+        }),
+      );
+      await Promise.resolve();
+      assert.strictEqual(acquired, 1, 'one in flight at cap=1');
+      assert.strictEqual(sem.pendingCount, 9);
+
+      // Grow to 5: 4 more should wake (5 - 1 already in flight = 4
+      // immediate hand-offs).
+      sem.setCapacity(5);
+      // Allow promise resolutions to flush.
+      await Promise.resolve();
+      await Promise.resolve();
+      assert.strictEqual(acquired, 5, 'five in flight at cap=5');
+      assert.strictEqual(sem.pendingCount, 5);
+
+      // Drain by releasing one at a time. Each release should wake one
+      // waiter until queue empties.
+      while (releases.length > 0) {
+        let r = releases.shift()!;
+        r();
+        await Promise.resolve();
+        await Promise.resolve();
+      }
+      await Promise.all(acquirers);
+      assert.strictEqual(acquired, 10, 'all eventually acquired');
+      assert.strictEqual(sem.inUseCount, 0);
+      assert.strictEqual(sem.pendingCount, 0);
+    });
+  });
+});

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -177,6 +177,7 @@ import './prerender-manager-test';
 import './prerender-affinity-activity-test';
 import './prerender-batch-ownership-test';
 import './prerender-cancellation-test';
+import './async-semaphore-test';
 import './runtime-exception-capture-test';
 import './clamp-serialized-error-test';
 import './prerender-diagnostics-persistence-test';

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -178,6 +178,7 @@ import './prerender-affinity-activity-test';
 import './prerender-batch-ownership-test';
 import './prerender-cancellation-test';
 import './async-semaphore-test';
+import './prerender-deadlock-test';
 import './runtime-exception-capture-test';
 import './clamp-serialized-error-test';
 import './prerender-diagnostics-persistence-test';

--- a/packages/realm-server/tests/prerender-deadlock-test.ts
+++ b/packages/realm-server/tests/prerender-deadlock-test.ts
@@ -192,22 +192,31 @@ module(basename(__filename), function () {
         // Tight deadlock-detection budget. The non-deadlocked path
         // returns in milliseconds; with the reservation removed and no
         // expansion (the PR 10 → revert case), this hangs forever.
+        // Clear the timer when the work resolves so it doesn't keep the
+        // node event loop alive after the test exits — addresses
+        // Copilot review on PR 4590.
         let deadlockBudgetMs = 3000;
-        let raceWithDeadlock = (label: string) =>
-          Promise.race([
-            runFileRenderWithModuleSubCall(label),
-            new Promise<never>((_, reject) =>
-              setTimeout(
-                () =>
-                  reject(
-                    new Error(
-                      `deadlock-prevention-failed: file render '${label}' did not complete within ${deadlockBudgetMs}ms`,
-                    ),
-                  ),
-                deadlockBudgetMs,
-              ),
-            ),
-          ]);
+        let raceWithDeadlock = async (label: string) => {
+          let timer: NodeJS.Timeout | undefined;
+          let timerPromise = new Promise<never>((_, reject) => {
+            timer = setTimeout(() => {
+              reject(
+                new Error(
+                  `deadlock-prevention-failed: file render '${label}' did not complete within ${deadlockBudgetMs}ms`,
+                ),
+              );
+            }, deadlockBudgetMs);
+            timer.unref?.();
+          });
+          try {
+            return await Promise.race([
+              runFileRenderWithModuleSubCall(label),
+              timerPromise,
+            ]);
+          } finally {
+            if (timer) clearTimeout(timer);
+          }
+        };
 
         let results = await Promise.all([
           raceWithDeadlock('A'),
@@ -255,22 +264,30 @@ module(basename(__filename), function () {
 
         // Module call should bypass admission entirely and get the
         // reserved tab. If the reservation invariant is broken, this
-        // call queues behind tab availability instead.
+        // call queues behind tab availability instead. Same timer
+        // hygiene as above — clear on completion so a leaked handle
+        // doesn't keep the event loop alive (Copilot review).
         let moduleStart = Date.now();
-        let moduleLease = await Promise.race([
-          pool.getPage('realm-a', 'module'),
-          new Promise<never>((_, reject) =>
-            setTimeout(
-              () =>
-                reject(
-                  new Error(
-                    'reservation-failed: module call did not get a tab while file admission was held',
-                  ),
-                ),
-              2000,
-            ),
-          ),
-        ]);
+        let raceTimer: NodeJS.Timeout | undefined;
+        let moduleTimerPromise = new Promise<never>((_, reject) => {
+          raceTimer = setTimeout(() => {
+            reject(
+              new Error(
+                'reservation-failed: module call did not get a tab while file admission was held',
+              ),
+            );
+          }, 2000);
+          raceTimer.unref?.();
+        });
+        let moduleLease;
+        try {
+          moduleLease = await Promise.race([
+            pool.getPage('realm-a', 'module'),
+            moduleTimerPromise,
+          ]);
+        } finally {
+          if (raceTimer) clearTimeout(raceTimer);
+        }
         let moduleAcquireMs = Date.now() - moduleStart;
         assert.ok(
           moduleAcquireMs < 1000,

--- a/packages/realm-server/tests/prerender-deadlock-test.ts
+++ b/packages/realm-server/tests/prerender-deadlock-test.ts
@@ -1,0 +1,314 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { PagePool } from '../prerender/page-pool';
+import { AsyncSemaphore } from '../prerender/async-semaphore';
+
+// CS-10976 PR 2: regression test for the self-referential prerender
+// deadlock that the `affinityTabMax − 1` file-admission ceiling (CS-10946)
+// is currently preventing.
+//
+// The deadlock is shaped as:
+//   1. A `.gts` card render acquires a tab on its affinity.
+//   2. While rendering, the host code calls `getCards({ filter: { eq: { _cardType:
+//      'X' } } })`. The realm-server's `CachingDefinitionLookup` cache misses on
+//      the type's module and fires a same-affinity `prerenderModule` to extract it.
+//   3. The module sub-prerender wants a tab on the same affinity.
+//   4. The first render is *waiting on* the module sub-prerender's result —
+//      it can't return its tab until the module call finishes.
+//   5. If a *second* concurrent file render has also taken the affinity's
+//      remaining tab and is in the same waiting state, neither file render
+//      can free a tab, so neither module sub-prerender ever runs. Deadlock.
+//
+// The reservation prevents this by capping per-affinity *file* renders at
+// `affinityTabMax − 1`, so at least one tab on each affinity is always
+// available for the `module` / `command` work the file render is waiting
+// on. This test reproduces the exact wait-shape — concurrent file renders
+// that each fire a same-affinity module sub-call mid-flight — and asserts
+// the reservation keeps the system live.
+//
+// PR 10 will re-run this same test against the post-removal code path,
+// where deadlock prevention shifts from the reservation to PR 7's dynamic
+// tab expansion. If PR 10's re-run doesn't pass we don't drop the
+// reservation.
+//
+// Why no real Chrome: the deadlock condition lives in `PagePool`'s
+// admission + queue contract. The cardType-filter chain in real Chrome is
+// just the production *trigger* — it ends up in the same `getPage` calls
+// this test makes directly. Real Chrome would reproduce the same wait
+// graph at ~10× the runtime, so a follow-up PR can layer a real-Chrome
+// test on top if it ever finds a discrepancy. For the regression-guard
+// purpose this test is the right level.
+
+interface StubBrowser {
+  contextsCreated: string[];
+  contextsClosed: string[];
+}
+
+function makeStubPagePool(opts: {
+  maxPages: number;
+  renderSemaphore?: { acquire(): Promise<() => void> };
+}): { pool: PagePool; stub: StubBrowser } {
+  function makeStorage(): Storage {
+    let values: Record<string, string> = {};
+    return {
+      getItem(key) {
+        return values[key] ?? null;
+      },
+      setItem(key, value) {
+        values[key] = value;
+      },
+      removeItem(key) {
+        delete values[key];
+      },
+      clear() {
+        values = {};
+      },
+      key(index) {
+        return Object.keys(values)[index] ?? null;
+      },
+      get length() {
+        return Object.keys(values).length;
+      },
+    } as Storage;
+  }
+
+  let contextCounter = 0;
+  let stub: StubBrowser = { contextsCreated: [], contextsClosed: [] };
+  let browser = {
+    async createBrowserContext() {
+      let counter = ++contextCounter;
+      let id = `ctx-${counter}`;
+      stub.contextsCreated.push(id);
+      let localStorage = makeStorage();
+      let context = {
+        async newPage() {
+          return {
+            async goto() {
+              return;
+            },
+            async waitForFunction() {
+              return true;
+            },
+            async evaluate(fn: (...args: any[]) => any, ...args: any[]) {
+              let original = (globalThis as any).localStorage;
+              (globalThis as any).localStorage = localStorage;
+              try {
+                return await fn(...args);
+              } finally {
+                (globalThis as any).localStorage = original;
+              }
+            },
+            async close() {
+              return;
+            },
+            browserContext() {
+              return context;
+            },
+            removeAllListeners() {
+              return;
+            },
+            on() {
+              return;
+            },
+          } as any;
+        },
+        async close() {
+          stub.contextsClosed.push(id);
+          return;
+        },
+      } as any;
+      return context;
+    },
+  };
+  let browserManager = {
+    async getBrowser() {
+      return browser as any;
+    },
+    async cleanupUserDataDirs() {
+      return;
+    },
+  };
+  let pool = new PagePool({
+    maxPages: opts.maxPages,
+    serverURL: 'http://localhost',
+    browserManager: browserManager as any,
+    boxelHostURL: 'http://localhost:4200',
+    standbyTimeoutMs: 500,
+    renderSemaphore: opts.renderSemaphore,
+    disableFileAdmission: false,
+  });
+  return { pool, stub };
+}
+
+module(basename(__filename), function () {
+  module('CS-10976: deadlock-safety reservation', function (hooks) {
+    let prevTabMax: string | undefined;
+
+    hooks.beforeEach(function () {
+      prevTabMax = process.env.PRERENDER_AFFINITY_TAB_MAX;
+      process.env.PRERENDER_AFFINITY_TAB_MAX = '2';
+    });
+
+    hooks.afterEach(function () {
+      if (prevTabMax === undefined) {
+        delete process.env.PRERENDER_AFFINITY_TAB_MAX;
+      } else {
+        process.env.PRERENDER_AFFINITY_TAB_MAX = prevTabMax;
+      }
+    });
+
+    test('two concurrent file renders that each fire a same-affinity module sub-call complete', async function (assert) {
+      // The `runFileRenderWithModuleSubCall` function below mimics the
+      // exact wait-shape produced by the cardType-filter chain in
+      // production: a `.gts` render holds a tab while it fires (and
+      // waits for) a same-affinity module sub-prerender, then releases.
+      // Two concurrent invocations of this on the same affinity exhibit
+      // the deadlock condition we're guarding against.
+      let semaphore = new AsyncSemaphore(2);
+      let { pool } = makeStubPagePool({
+        maxPages: 2,
+        renderSemaphore: semaphore,
+      });
+      try {
+        await pool.warmStandbys();
+
+        let runFileRenderWithModuleSubCall = async (
+          tag: string,
+        ): Promise<{ tag: string; phase: string }> => {
+          let fileLease = await pool.getPage('realm-a', 'file');
+          try {
+            // The render is now in flight on this tab. Mid-render, fire
+            // the same-affinity module sub-prerender that the host code
+            // would issue via `CachingDefinitionLookup`. The render
+            // CANNOT return its tab until this module call finishes.
+            let moduleLease = await pool.getPage('realm-a', 'module');
+            moduleLease.release();
+          } finally {
+            fileLease.release();
+          }
+          return { tag, phase: 'done' };
+        };
+
+        // Tight deadlock-detection budget. The non-deadlocked path
+        // returns in milliseconds; with the reservation removed and no
+        // expansion (the PR 10 → revert case), this hangs forever.
+        let deadlockBudgetMs = 3000;
+        let raceWithDeadlock = (label: string) =>
+          Promise.race([
+            runFileRenderWithModuleSubCall(label),
+            new Promise<never>((_, reject) =>
+              setTimeout(
+                () =>
+                  reject(
+                    new Error(
+                      `deadlock-prevention-failed: file render '${label}' did not complete within ${deadlockBudgetMs}ms`,
+                    ),
+                  ),
+                deadlockBudgetMs,
+              ),
+            ),
+          ]);
+
+        let results = await Promise.all([
+          raceWithDeadlock('A'),
+          raceWithDeadlock('B'),
+        ]);
+        assert.deepEqual(
+          results.map((r) => r.tag).sort(),
+          ['A', 'B'],
+          'both concurrent file+module pairs completed',
+        );
+      } finally {
+        await pool.closeAll();
+      }
+    });
+
+    test('module / command sub-call gets the reserved tab even when file admission is fully utilised', async function (assert) {
+      // Tighter version of the above: explicitly hold the file
+      // admission slot, queue another file admission behind it, and fire
+      // a module call. The reservation guarantees the module call gets
+      // the reserved tab without waiting for the held file render to
+      // release.
+      let semaphore = new AsyncSemaphore(2);
+      let { pool } = makeStubPagePool({
+        maxPages: 2,
+        renderSemaphore: semaphore,
+      });
+      try {
+        await pool.warmStandbys();
+
+        let firstFile = await pool.getPage('realm-a', 'file');
+        let secondFileAdmitted = false;
+        let secondFilePromise = pool
+          .getPage('realm-a', 'file')
+          .then((lease) => {
+            secondFileAdmitted = true;
+            return lease;
+          });
+        // Allow the second file's admission attempt to settle into the
+        // queue so the assertion is not racy.
+        await new Promise((r) => setTimeout(r, 10));
+        assert.false(
+          secondFileAdmitted,
+          'second concurrent file render correctly queues behind admission cap=1',
+        );
+
+        // Module call should bypass admission entirely and get the
+        // reserved tab. If the reservation invariant is broken, this
+        // call queues behind tab availability instead.
+        let moduleStart = Date.now();
+        let moduleLease = await Promise.race([
+          pool.getPage('realm-a', 'module'),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () =>
+                reject(
+                  new Error(
+                    'reservation-failed: module call did not get a tab while file admission was held',
+                  ),
+                ),
+              2000,
+            ),
+          ),
+        ]);
+        let moduleAcquireMs = Date.now() - moduleStart;
+        assert.ok(
+          moduleAcquireMs < 1000,
+          `module call landed quickly (${moduleAcquireMs}ms) without waiting for file admission to release`,
+        );
+        moduleLease.release();
+
+        firstFile.release();
+        let secondFile = await secondFilePromise;
+        assert.true(
+          secondFileAdmitted,
+          'releasing first file lets second file enter admission',
+        );
+        secondFile.release();
+      } finally {
+        await pool.closeAll();
+      }
+    });
+
+    test('deadlock-safety warning fires when affinityTabMax < 2', async function (assert) {
+      // Sanity check: the page-pool startup warning that flagged the
+      // degenerate config also lives in this code path. Once PR 10
+      // removes the reservation we want the warning gone — this test
+      // pins down the current state so PR 10's removal is visible.
+      // (We just exercise construction; the warning goes to log, no
+      // user-visible state to assert here. The earlier tests are the
+      // real regression guards.)
+      process.env.PRERENDER_AFFINITY_TAB_MAX = '1';
+      let { pool } = makeStubPagePool({ maxPages: 1 });
+      try {
+        await pool.warmStandbys();
+        // Reaching this point without throw is the assertion. PR 10's
+        // removal will leave the construction path intact but eliminate
+        // the warning's reason for existing.
+        assert.ok(true, 'pool construction succeeded at degenerate tabMax=1');
+      } finally {
+        await pool.closeAll();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Pins down the deadlock-prevention contract that the `affinityTabMax − 1` file-admission ceiling (CS-10946) provides today, so PR 10 can remove the ceiling and prove via the same test that PR 7's dynamic tab expansion takes over correctly.

## What deadlock are we guarding against

A `.gts` card render calls `getCards({ filter: { eq: { _cardType: 'X' } } })` mid-flight. The realm-server's `CachingDefinitionLookup` cache misses on type X's module and fires a same-affinity `prerenderModule` to extract it. The render is then **waiting on** that module sub-prerender's result — its tab cannot be released until the module call finishes.

If two such renders run concurrently on the same affinity, and the file-admission cap permits both to acquire tabs, both module sub-calls queue on tab availability while both file renders block on the module results. Neither file lease ever releases, neither module call ever runs. **Deadlock.**

The reservation prevents this by capping per-affinity *file* renders at `max(1, affinityTabMax − 1)` — at least one tab per affinity is always reserved for `module` / `command` work.

## What the test does

`tests/prerender-deadlock-test.ts` has three cases:

1. **Two concurrent file renders that each fire a same-affinity module sub-call complete.** This is the load-bearing one: it reproduces the exact wait-shape (`fileLease → moduleLease → fileLease.release`) twice concurrently and asserts both pairs finish under a tight 3 s deadlock-detection budget. Without the reservation and without expansion, this hangs forever.
2. **Module / command sub-call gets the reserved tab even when file admission is fully utilised.** Pins down the timing assertion: the module call lands in < 1 s without waiting for the held file lease to release.
3. **Pool construction succeeds at `affinityTabMax = 1` (degenerate config).** The `< 2` startup warning's invariant; locked down so PR 10's removal is visible.

All three pass at `tabMax=2` against the current reservation-bearing code.

## Why no real Chrome

The deadlock condition lives in `PagePool`'s admission + queue contract — the cardType-filter chain in production is the *trigger*, but the actual wait graph that needs guarding is the `fileLease → moduleLease` shape this test reproduces directly via `getPage`. Real Chrome would exercise the same graph at ~10× the runtime. If a discrepancy ever shows up, a follow-up can layer a real-Chrome test on top.

## Test plan

- [x] `TEST_MODULE='prerender-deadlock-test.ts' pnpm test-module` passes 3/3.
- [x] Existing `prerendering-test.ts` admission tests (lines 4847+) still pass — no regression.
- [x] `pnpm lint` clean on changed files.
- [x] PR 10 will re-run this test against the post-removal code path; if it fails there, we don't drop the reservation.

## Stack

Part of the CS-10976 stacked PR series. See the [plan comment on CS-10976](https://linear.app/cardstack/issue/CS-10976/create-prerendering-prioritization). Independent of PR 1 (`AsyncSemaphore.setCapacity`); both can land in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)