### PR TITLE
CS-10976 PR 4: server-side priority dequeue (TabQueue + render-semaphore)

### DIFF
--- a/packages/realm-server/prerender/async-semaphore.ts
+++ b/packages/realm-server/prerender/async-semaphore.ts
@@ -27,7 +27,7 @@ export class AsyncSemaphore {
   }> = [];
 
   constructor(max: number) {
-    this.#capacity = Math.max(1, max);
+    this.#capacity = normalizeCapacity(max);
     this.#inUse = 0;
   }
 
@@ -95,9 +95,13 @@ export class AsyncSemaphore {
   // Resize the semaphore. Growing wakes queued waiters up to the new
   // cap. Shrinking is best-effort: in-flight slots are never preempted,
   // but no new waiters are admitted until #inUse falls under the new
-  // cap. `n` is clamped to a minimum of 1.
+  // cap. `n` is normalized through `normalizeCapacity`: NaN, non-finite,
+  // and non-integer values fall back to a clamped integer (`1` floor),
+  // matching the constructor's contract — `#inUse` is an integer
+  // counter, so a fractional cap would silently allow `floor(n)+1`
+  // concurrent holders.
   setCapacity(n: number): void {
-    let newCap = Math.max(1, n);
+    let newCap = normalizeCapacity(n);
     if (newCap === this.#capacity) return;
     this.#capacity = newCap;
     // Wake waiters up to the new cap. Same hand-off shape as #release
@@ -120,4 +124,17 @@ export class AsyncSemaphore {
       next.resolve(this.#release);
     }
   };
+}
+
+// Reject NaN / non-finite / non-integer / sub-1 values so the cap is
+// always a positive integer. This matters for resize callers (PagePool
+// expansion contraction in PR 7) where a malformed env-var or upstream
+// math would otherwise propagate `NaN` into `#capacity` and stall every
+// future acquire/release — comparisons against `NaN` are always false.
+// Floor on non-integers because `#inUse` is integer-counted and a
+// fractional cap effectively rounds up at the `<` comparison.
+function normalizeCapacity(n: number): number {
+  if (!Number.isFinite(n)) return 1;
+  let floored = Math.floor(n);
+  return floored < 1 ? 1 : floored;
 }

--- a/packages/realm-server/prerender/async-semaphore.ts
+++ b/packages/realm-server/prerender/async-semaphore.ts
@@ -4,10 +4,20 @@ import { PrerenderCancelledError, throwIfAborted } from './prerender-cancel';
 // Exported so cancellation-plumbing unit tests can drive it directly
 // — no Chrome dependency. Used by:
 //   - Prerenderer (global render-concurrency cap)
+//   - PagePool global render-semaphore (per-server tab cap)
 //   - PagePool file-queue admission control (CS-10946)
+//
+// Capacity is mutable post-construction via `setCapacity(n)` so callers
+// (PagePool dynamic tab expansion / contraction in CS-10976) can grow
+// the concurrency cap without rebuilding the semaphore. In-flight slots
+// are never preempted on shrink — `setCapacity(smaller)` just stops
+// admitting new waiters until `inUseCount` falls back under the new cap.
 export class AsyncSemaphore {
   #capacity: number;
-  #available: number;
+  // Tracked directly so resize works correctly. The original
+  // `#capacity - #available` formulation fell apart when capacity could
+  // change while requests were in flight.
+  #inUse: number;
   // `resolve` hands the acquirer the release function once a slot
   // frees. `onCancel` gives the cancellation path a way to splice
   // the entry out of the queue without racing #release.
@@ -18,16 +28,17 @@ export class AsyncSemaphore {
 
   constructor(max: number) {
     this.#capacity = Math.max(1, max);
-    this.#available = this.#capacity;
+    this.#inUse = 0;
   }
 
-  // Total slots (from construction). Stable for the semaphore's lifetime.
+  // Current cap. Mutable via `setCapacity`; callers reading this
+  // observe the live value.
   get capacity(): number {
     return this.#capacity;
   }
 
   // Waiters currently queued behind an exhausted semaphore. Zero when
-  // `#available > 0` (no one is waiting because slots are free).
+  // `inUseCount < capacity` (no one is waiting because slots are free).
   get pendingCount(): number {
     return this.#queue.length;
   }
@@ -36,13 +47,13 @@ export class AsyncSemaphore {
   // released. `inUseCount === 0 && pendingCount === 0` means the
   // semaphore is idle and safe for a caller to drop.
   get inUseCount(): number {
-    return this.#capacity - this.#available;
+    return this.#inUse;
   }
 
   async acquire(signal?: AbortSignal): Promise<() => void> {
     throwIfAborted(signal);
-    if (this.#available > 0) {
-      this.#available--;
+    if (this.#inUse < this.#capacity) {
+      this.#inUse++;
       return this.#release;
     }
     return await new Promise<() => void>((resolve, reject) => {
@@ -81,12 +92,32 @@ export class AsyncSemaphore {
     });
   }
 
-  #release = () => {
-    let next = this.#queue.shift();
-    if (next) {
+  // Resize the semaphore. Growing wakes queued waiters up to the new
+  // cap. Shrinking is best-effort: in-flight slots are never preempted,
+  // but no new waiters are admitted until #inUse falls under the new
+  // cap. `n` is clamped to a minimum of 1.
+  setCapacity(n: number): void {
+    let newCap = Math.max(1, n);
+    if (newCap === this.#capacity) return;
+    this.#capacity = newCap;
+    // Wake waiters up to the new cap. Same hand-off shape as #release
+    // (increment inUse, resolve the next waiter), iterated.
+    while (this.#inUse < this.#capacity && this.#queue.length > 0) {
+      let next = this.#queue.shift()!;
+      this.#inUse++;
       next.resolve(this.#release);
-      return;
     }
-    this.#available++;
+  }
+
+  #release = () => {
+    this.#inUse--;
+    // If a waiter is queued AND we have spare capacity, hand it the
+    // slot (no net change in `#inUse`). Otherwise the slot stays free
+    // until the next acquire.
+    if (this.#inUse < this.#capacity && this.#queue.length > 0) {
+      let next = this.#queue.shift()!;
+      this.#inUse++;
+      next.resolve(this.#release);
+    }
   };
 }

--- a/packages/realm-server/prerender/async-semaphore.ts
+++ b/packages/realm-server/prerender/async-semaphore.ts
@@ -20,10 +20,13 @@ export class AsyncSemaphore {
   #inUse: number;
   // `resolve` hands the acquirer the release function once a slot
   // frees. `onCancel` gives the cancellation path a way to splice
-  // the entry out of the queue without racing #release.
+  // the entry out of the queue without racing #release. `priority`
+  // (CS-10976 PR 4) controls dequeue order: higher priority first,
+  // FIFO within the same priority. Default priority is `0`.
   #queue: Array<{
     resolve: (release: () => void) => void;
     onCancel: () => void;
+    priority: number;
   }> = [];
 
   constructor(max: number) {
@@ -50,7 +53,10 @@ export class AsyncSemaphore {
     return this.#inUse;
   }
 
-  async acquire(signal?: AbortSignal): Promise<() => void> {
+  async acquire(
+    signal?: AbortSignal,
+    priority: number = 0,
+  ): Promise<() => void> {
     throwIfAborted(signal);
     if (this.#inUse < this.#capacity) {
       this.#inUse++;
@@ -85,9 +91,20 @@ export class AsyncSemaphore {
             }),
           );
         },
+        priority,
       };
       let onAbort = entry.onCancel;
-      this.#queue.push(entry);
+      // Priority-ordered insertion: highest priority first, FIFO within
+      // the same priority. Find the first existing entry with strictly
+      // lower priority and insert before it; if none, append. Same-
+      // priority entries land after all existing same-priority entries
+      // → FIFO preserved.
+      let insertIdx = this.#queue.findIndex((e) => e.priority < priority);
+      if (insertIdx === -1) {
+        this.#queue.push(entry);
+      } else {
+        this.#queue.splice(insertIdx, 0, entry);
+      }
       signal?.addEventListener('abort', onAbort, { once: true });
     });
   }

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -13,76 +13,107 @@ import { AsyncSemaphore } from './async-semaphore';
 import { attachRuntimeExceptionCapture } from './runtime-exception-capture';
 
 type RenderSemaphore = {
-  acquire(signal?: AbortSignal): Promise<() => void>;
+  acquire(signal?: AbortSignal, priority?: number): Promise<() => void>;
 };
 
 // Exported so cancellation-plumbing unit tests can drive it
-// directly — it's a pure in-memory FIFO with no Chrome dependency.
+// directly — it's a per-tab serializer with no Chrome dependency.
+//
+// CS-10976 PR 4: replaces the prior FIFO promise-chain with a
+// priority-bucketed queue. Higher priority dequeues first, FIFO
+// within the same priority. Default priority is `0` so existing
+// callers that don't specify keep the old FIFO behaviour.
 export class TabQueue {
-  #pending: Promise<void> = Promise.resolve();
-  #depth = 0;
+  // `held` is true while a caller holds the lease (post-acquire,
+  // pre-release). Subsequent acquires queue rather than running.
+  #held = false;
+  #queue: Array<{
+    resolve: () => void;
+    reject: (err: unknown) => void;
+    priority: number;
+    settled: boolean;
+  }> = [];
 
-  async acquire(signal?: AbortSignal): Promise<() => void> {
+  async acquire(
+    signal?: AbortSignal,
+    priority: number = 0,
+  ): Promise<() => void> {
     throwIfAborted(signal);
-    let release!: () => void;
-    let next = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    let prev = this.#pending;
-    this.#pending = prev.catch(() => {}).then(() => next);
-    this.#depth++;
-    // Race the prior-slot wait against the caller's abort signal.
-    // If the signal fires first, release our slot immediately so
-    // downstream waiters aren't blocked on a cancelled holder,
-    // then throw so `getPage` can bail out.
-    let onAbortPromise: Promise<never> | null = null;
-    let onAbortCleanup: (() => void) | undefined;
-    if (signal) {
-      onAbortPromise = new Promise<never>((_, reject) => {
-        let onAbort = () => {
-          reject(
-            new PrerenderCancelledError({
-              state: 'queued',
-              reason:
-                typeof signal.reason === 'string' ? signal.reason : undefined,
-            }),
-          );
-        };
-        signal.addEventListener('abort', onAbort, { once: true });
-        onAbortCleanup = () => signal.removeEventListener('abort', onAbort);
-      });
+    if (!this.#held) {
+      this.#held = true;
+      return this.#makeRelease();
     }
+    // Queue and wait for the lease. On abort while queued, splice the
+    // entry out so downstream waiters aren't blocked on a cancelled
+    // holder; throw a `'queued'`-state cancellation so `getPage` can
+    // bail out cleanly.
+    let entry: {
+      resolve: () => void;
+      reject: (err: unknown) => void;
+      priority: number;
+      settled: boolean;
+    };
+    let onAbort: (() => void) | undefined;
     try {
-      if (onAbortPromise) {
-        await Promise.race([prev.catch(() => {}), onAbortPromise]);
-      } else {
-        await prev.catch(() => {});
-      }
-    } catch (e) {
-      this.#depth--;
-      release();
-      throw e;
+      await new Promise<void>((resolve, reject) => {
+        entry = { resolve, reject, priority, settled: false };
+        // Priority-ordered insertion (matches `AsyncSemaphore`):
+        // highest priority first, FIFO within priority.
+        let insertIdx = this.#queue.findIndex((e) => e.priority < priority);
+        if (insertIdx === -1) {
+          this.#queue.push(entry);
+        } else {
+          this.#queue.splice(insertIdx, 0, entry);
+        }
+        if (signal) {
+          onAbort = () => {
+            if (entry.settled) return;
+            entry.settled = true;
+            let idx = this.#queue.indexOf(entry);
+            if (idx !== -1) this.#queue.splice(idx, 1);
+            reject(
+              new PrerenderCancelledError({
+                state: 'queued',
+                reason:
+                  typeof signal.reason === 'string' ? signal.reason : undefined,
+              }),
+            );
+          };
+          signal.addEventListener('abort', onAbort, { once: true });
+        }
+      });
     } finally {
-      onAbortCleanup?.();
+      if (signal && onAbort) signal.removeEventListener('abort', onAbort);
     }
-    // A late abort between Promise.race resolving and us returning
-    // — treat as the same cancellation.
-    if (signal?.aborted) {
-      this.#depth--;
-      release();
-      throwIfAborted(signal);
-    }
+    // Lease handed off — `#held` was already true before our resolve.
+    return this.#makeRelease();
+  }
+
+  #makeRelease(): () => void {
     let released = false;
     return () => {
       if (released) return;
       released = true;
-      this.#depth--;
-      release();
+      // Highest-priority oldest waiter (front of queue) gets the lease.
+      // Skip already-settled (cancelled) entries — they were spliced
+      // by `onAbort` but for safety we tolerate stale entries here.
+      while (this.#queue.length > 0) {
+        let next = this.#queue.shift()!;
+        if (next.settled) continue;
+        next.settled = true;
+        // `#held` stays true: the lease just transferred.
+        next.resolve();
+        return;
+      }
+      this.#held = false;
     };
   }
 
+  // Live count = (active holder ? 1 : 0) + queued waiters. Matches the
+  // pre-PR-4 semantics: callers use `pendingCount === 0` to mean "idle"
+  // and `pendingCount > 1` to mean "queue is forming behind the holder".
   get pendingCount(): number {
-    return this.#depth;
+    return (this.#held ? 1 : 0) + this.#queue.length;
   }
 }
 
@@ -513,7 +544,7 @@ export class PagePool {
   async getPage(
     affinityKey: string,
     queue: PrerenderQueue = 'file',
-    opts?: { signal?: AbortSignal },
+    opts?: { signal?: AbortSignal; priority?: number },
   ): Promise<{
     page: Page;
     reused: boolean;
@@ -533,6 +564,12 @@ export class PagePool {
     release: () => void;
   }> {
     let signal = opts?.signal;
+    // CS-10976 PR 4: priority threaded from the producer side. Higher
+    // priority requests jump to the head of the per-server file
+    // admission semaphore, the per-affinity tab queue, and the global
+    // render semaphore — without preempting in-flight work. `0` is the
+    // back-compat default so callers that don't care continue to FIFO.
+    let priority = opts?.priority ?? 0;
     throwIfAborted(signal);
     let t0 = Date.now();
     // File-queue admission control. Acquired BEFORE tab selection so
@@ -544,7 +581,11 @@ export class PagePool {
     let admissionMs = 0;
     if (queue === 'file') {
       let admissionStart = Date.now();
-      releaseAdmission = await this.#acquireFileAdmission(affinityKey, signal);
+      releaseAdmission = await this.#acquireFileAdmission(
+        affinityKey,
+        signal,
+        priority,
+      );
       admissionMs = Date.now() - admissionStart;
     }
     // Every release path (success + the error paths below) funnels
@@ -572,6 +613,7 @@ export class PagePool {
       ({ entry, reused, releaseTab } = await this.#selectEntryForAffinity(
         affinityKey,
         signal,
+        priority,
       ));
     } catch (e) {
       releaseAdmission?.();
@@ -599,7 +641,7 @@ export class PagePool {
     let releaseGlobal: (() => void) | undefined;
     try {
       releaseGlobal = this.#renderSemaphore
-        ? await this.#renderSemaphore.acquire(signal)
+        ? await this.#renderSemaphore.acquire(signal, priority)
         : undefined;
     } catch (e) {
       // Semaphore cancelled before we got a slot. Release the tab
@@ -963,6 +1005,7 @@ export class PagePool {
   async #acquireFileAdmission(
     affinityKey: string,
     signal?: AbortSignal,
+    priority: number = 0,
   ): Promise<() => void> {
     if (this.#disableFileAdmission) {
       // Test opt-out — existing tab-routing unit tests predate the
@@ -976,7 +1019,7 @@ export class PagePool {
       semaphore = new AsyncSemaphore(this.#fileAdmissionCap);
       this.#fileAdmission.set(affinityKey, semaphore);
     }
-    let rawRelease = await semaphore.acquire(signal);
+    let rawRelease = await semaphore.acquire(signal, priority);
     // Wrap the raw release so every release path (success or any of
     // `getPage`'s mid-setup error bailouts) also attempts idle cleanup
     // of the semaphore map entry. Without this, an erroring file call
@@ -1014,6 +1057,7 @@ export class PagePool {
   async #selectEntryForAffinity(
     affinityKey: string,
     signal?: AbortSignal,
+    priority: number = 0,
   ): Promise<{ entry: PoolEntry; reused: boolean; releaseTab: () => void }> {
     let entries = this.#affinityPages.get(affinityKey);
     let entryList = entries
@@ -1022,7 +1066,7 @@ export class PagePool {
     let idle = entryList.filter((entry) => entry.queue.pendingCount === 0);
     if (idle.length > 0) {
       let entry = this.#selectLRUTab(idle);
-      let releaseTab = await entry.queue.acquire(signal);
+      let releaseTab = await entry.queue.acquire(signal, priority);
       return { entry, reused: true, releaseTab };
     }
     if (entryList.length < this.#affinityTabMax) {
@@ -1041,13 +1085,13 @@ export class PagePool {
       }
       let commandeered = this.#commandeerDormantTab(affinityKey);
       if (commandeered) {
-        let releaseTab = await commandeered.queue.acquire(signal);
+        let releaseTab = await commandeered.queue.acquire(signal, priority);
         return { entry: commandeered, reused: false, releaseTab };
       }
     }
     if (entryList.length > 0) {
       let entry = this.#selectLeastPendingTab(entryList);
-      let releaseTab = await entry.queue.acquire(signal);
+      let releaseTab = await entry.queue.acquire(signal, priority);
       return { entry, reused: true, releaseTab };
     }
     let fallbackShared = this.#tryClaimOrphanContext(affinityKey);
@@ -1062,7 +1106,7 @@ export class PagePool {
     }
     let fallback = this.#commandeerDormantTab(affinityKey);
     if (fallback) {
-      let releaseTab = await fallback.queue.acquire(signal);
+      let releaseTab = await fallback.queue.acquire(signal, priority);
       return { entry: fallback, reused: false, releaseTab };
     }
     if (entryList.length === 0) {
@@ -1079,7 +1123,7 @@ export class PagePool {
         let entry = this.#selectLeastPendingTab(crossAffinityEntries);
         entry.transitioning = true;
         try {
-          let releaseTab = await entry.queue.acquire(signal);
+          let releaseTab = await entry.queue.acquire(signal, priority);
           return { entry, reused: false, releaseTab };
         } catch (error) {
           entry.transitioning = false;

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -346,6 +346,7 @@ export class Prerenderer {
             auth,
             opts,
             renderOptions: attemptOptions,
+            priority,
             signal,
             onTabAcquired: activity.markRunning,
           });
@@ -492,6 +493,7 @@ export class Prerenderer {
         command,
         commandInput,
         opts,
+        priority,
         signal,
       });
       Prerenderer.decorateRenderErrorsWithTimings(
@@ -606,6 +608,7 @@ export class Prerenderer {
             renderOptions: attemptOptions,
             fileData,
             types,
+            priority,
             signal,
             onTabAcquired,
           });
@@ -637,6 +640,7 @@ export class Prerenderer {
               renderOptions: attemptOptions,
               fileData,
               types,
+              priority,
               signal,
               onTabAcquired,
             });

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -376,6 +376,7 @@ export class Prerenderer {
               auth,
               opts,
               renderOptions: attemptOptions,
+              priority,
               signal,
               onTabAcquired: activity.markRunning,
             });

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -136,6 +136,7 @@ export class RenderRunner {
     auth: string,
     queue: PrerenderQueue,
     signal?: AbortSignal,
+    priority?: number,
   ) {
     let lastAuth = this.#lastAuthByAffinity.get(affinityKey);
     if (lastAuth) {
@@ -153,6 +154,7 @@ export class RenderRunner {
     }
     let pageInfo = await this.#pagePool.getPage(affinityKey, queue, {
       signal,
+      ...(priority !== undefined ? { priority } : {}),
     });
     this.#lastAuthByAffinity.set(affinityKey, auth);
     return pageInfo;
@@ -178,6 +180,7 @@ export class RenderRunner {
     command,
     commandInput,
     opts,
+    priority,
     signal,
   }: {
     affinityType: AffinityType;
@@ -186,6 +189,7 @@ export class RenderRunner {
     command: string;
     commandInput?: Record<string, unknown> | null;
     opts?: { timeoutMs?: number; simulateTimeoutMs?: number };
+    priority?: number;
     signal?: AbortSignal;
   }): Promise<{
     response: RunCommandResponse;
@@ -199,7 +203,13 @@ export class RenderRunner {
     );
 
     const { page, reused, launchMs, waits, pageId, release } =
-      await this.#getPageForAffinity(affinityKey, auth, 'command', signal);
+      await this.#getPageForAffinity(
+        affinityKey,
+        auth,
+        'command',
+        signal,
+        priority,
+      );
     const poolInfo: PoolInfo = {
       pageId: pageId ?? 'unknown',
       affinityType,
@@ -381,6 +391,7 @@ export class RenderRunner {
     auth,
     opts,
     renderOptions,
+    priority,
     signal,
     onTabAcquired,
   }: {
@@ -391,6 +402,7 @@ export class RenderRunner {
     auth: string;
     opts?: { timeoutMs?: number; simulateTimeoutMs?: number };
     renderOptions?: RenderRouteOptions;
+    priority?: number;
     signal?: AbortSignal;
     // Fires after `getPageForAffinity` resolves AND the per-page
     // console/exception bucket has been reset — i.e. when this attempt
@@ -416,7 +428,13 @@ export class RenderRunner {
     );
 
     const { page, reused, launchMs, waits, pageId, release } =
-      await this.#getPageForAffinity(affinityKey, auth, 'module', signal);
+      await this.#getPageForAffinity(
+        affinityKey,
+        auth,
+        'module',
+        signal,
+        priority,
+      );
     const poolInfo: PoolInfo = {
       pageId: pageId ?? 'unknown',
       affinityType,
@@ -567,6 +585,7 @@ export class RenderRunner {
     renderOptions,
     fileData,
     types,
+    priority,
     signal,
     onTabAcquired,
   }: PrerenderVisitArgs & {
@@ -592,7 +611,13 @@ export class RenderRunner {
     );
 
     const { page, reused, launchMs, waits, pageId, release } =
-      await this.#getPageForAffinity(affinityKey, auth, 'file', signal);
+      await this.#getPageForAffinity(
+        affinityKey,
+        auth,
+        'file',
+        signal,
+        priority,
+      );
     const poolInfo: PoolInfo = {
       pageId: pageId ?? 'unknown',
       affinityType,

--- a/packages/realm-server/tests/async-semaphore-test.ts
+++ b/packages/realm-server/tests/async-semaphore-test.ts
@@ -1,0 +1,350 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { AsyncSemaphore } from '../prerender/async-semaphore';
+import { isPrerenderCancellation } from '../prerender/prerender-cancel';
+
+// Tests for AsyncSemaphore's resize-aware behaviour added in CS-10976.
+// The cancellation tests live in prerender-cancellation-test.ts; this
+// file owns the contract of `setCapacity(n)` plus the in-flight
+// tracking the resize requires.
+//
+// What we pin down here:
+//   1. The basic invariants (capacity / inUseCount / pendingCount)
+//      remain correct when in-flight slots cross the cap because of a
+//      shrink — i.e. release() decrements inUseCount monotonically and
+//      doesn't admit new waiters while inUse > capacity.
+//   2. setCapacity(grow) wakes queued waiters up to the new cap, in
+//      FIFO order, in a single pass — not one wake per future release.
+//   3. setCapacity(shrink) is best-effort: never preempts in-flight,
+//      stalls future admissions until inUse falls under the new cap.
+//   4. Edge cases: clamping to 1, no-op resize, resize while empty,
+//      cancelled waiters mixed with grow.
+
+module(basename(__filename), function () {
+  module('AsyncSemaphore basic state', function () {
+    test('reports correct counts at construction', function (assert) {
+      let sem = new AsyncSemaphore(3);
+      assert.strictEqual(sem.capacity, 3);
+      assert.strictEqual(sem.inUseCount, 0);
+      assert.strictEqual(sem.pendingCount, 0);
+    });
+
+    test('clamps construction capacity to 1 minimum', function (assert) {
+      let sem = new AsyncSemaphore(0);
+      assert.strictEqual(sem.capacity, 1, 'cap=0 clamped to 1');
+      let sem2 = new AsyncSemaphore(-5);
+      assert.strictEqual(sem2.capacity, 1, 'cap=-5 clamped to 1');
+    });
+
+    test('inUseCount tracks acquire / release directly', async function (assert) {
+      let sem = new AsyncSemaphore(2);
+      let r1 = await sem.acquire();
+      assert.strictEqual(sem.inUseCount, 1);
+      let r2 = await sem.acquire();
+      assert.strictEqual(sem.inUseCount, 2);
+      r1();
+      assert.strictEqual(sem.inUseCount, 1);
+      r2();
+      assert.strictEqual(sem.inUseCount, 0);
+    });
+
+    test('pendingCount reflects queued waiters', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let r1 = await sem.acquire();
+      let p2 = sem.acquire();
+      let p3 = sem.acquire();
+      // Allow microtask flush so the queueing has settled.
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 2);
+      r1();
+      let r2 = await p2;
+      assert.strictEqual(sem.pendingCount, 1);
+      r2();
+      let r3 = await p3;
+      assert.strictEqual(sem.pendingCount, 0);
+      r3();
+    });
+  });
+
+  module('setCapacity grow', function () {
+    test('grow wakes queued waiters up to the new cap', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let r1 = await sem.acquire();
+
+      let acquired: number[] = [];
+      let p2 = sem.acquire().then((r) => {
+        acquired.push(2);
+        return r;
+      });
+      let p3 = sem.acquire().then((r) => {
+        acquired.push(3);
+        return r;
+      });
+      let p4 = sem.acquire().then((r) => {
+        acquired.push(4);
+        return r;
+      });
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 3, '3 waiters queued');
+      assert.deepEqual(acquired, [], 'no one acquired yet');
+
+      // Grow to 3: should wake exactly 2 waiters (1 in-flight + 2 new
+      // = 3 total).
+      sem.setCapacity(3);
+      let r2 = await p2;
+      let r3 = await p3;
+      assert.deepEqual(acquired, [2, 3], 'FIFO: 2 and 3 woke, in order');
+      assert.strictEqual(sem.inUseCount, 3, 'inUse at new cap');
+      assert.strictEqual(sem.pendingCount, 1, 'one waiter still queued');
+
+      // Grow further: should wake the last one.
+      sem.setCapacity(4);
+      let r4 = await p4;
+      assert.deepEqual(acquired, [2, 3, 4]);
+      assert.strictEqual(sem.inUseCount, 4);
+      assert.strictEqual(sem.pendingCount, 0);
+
+      r1();
+      r2();
+      r3();
+      r4();
+      assert.strictEqual(sem.inUseCount, 0);
+    });
+
+    test('grow with empty queue is a no-op against state', function (assert) {
+      let sem = new AsyncSemaphore(2);
+      sem.setCapacity(5);
+      assert.strictEqual(sem.capacity, 5);
+      assert.strictEqual(sem.inUseCount, 0);
+      assert.strictEqual(sem.pendingCount, 0);
+    });
+
+    test('grow when not saturated does not over-admit', async function (assert) {
+      let sem = new AsyncSemaphore(3);
+      let r1 = await sem.acquire();
+      sem.setCapacity(5);
+      assert.strictEqual(sem.inUseCount, 1);
+      assert.strictEqual(sem.capacity, 5);
+      // Verify we can still acquire up to the new cap.
+      let r2 = await sem.acquire();
+      let r3 = await sem.acquire();
+      let r4 = await sem.acquire();
+      let r5 = await sem.acquire();
+      assert.strictEqual(sem.inUseCount, 5);
+      r1();
+      r2();
+      r3();
+      r4();
+      r5();
+    });
+  });
+
+  module('setCapacity shrink', function () {
+    test('shrink does not preempt in-flight slots', async function (assert) {
+      let sem = new AsyncSemaphore(5);
+      let r1 = await sem.acquire();
+      let r2 = await sem.acquire();
+      let r3 = await sem.acquire();
+      let r4 = await sem.acquire();
+      let r5 = await sem.acquire();
+      assert.strictEqual(sem.inUseCount, 5);
+
+      sem.setCapacity(2);
+      assert.strictEqual(sem.capacity, 2, 'capacity reflects shrink');
+      assert.strictEqual(
+        sem.inUseCount,
+        5,
+        'in-flight slots untouched by shrink',
+      );
+
+      r1();
+      r2();
+      r3();
+      assert.strictEqual(sem.inUseCount, 2);
+      r4();
+      r5();
+      assert.strictEqual(sem.inUseCount, 0);
+    });
+
+    test('shrink stalls new acquires until inUse drops under the new cap', async function (assert) {
+      let sem = new AsyncSemaphore(4);
+      let r1 = await sem.acquire();
+      let r2 = await sem.acquire();
+      let r3 = await sem.acquire();
+
+      // Shrink to 2 with 3 in-flight (over-cap by 1).
+      sem.setCapacity(2);
+      let admitted = false;
+      let p4 = sem.acquire().then((r) => {
+        admitted = true;
+        return r;
+      });
+      await Promise.resolve();
+      assert.false(admitted, 'over-cap blocks new acquire');
+      assert.strictEqual(sem.pendingCount, 1);
+
+      // Drop one in-flight: still over-cap (2 in-flight, cap 2). Should
+      // not admit.
+      r1();
+      await Promise.resolve();
+      assert.false(admitted, 'still blocked at inUse===cap');
+
+      // Drop another: now under-cap (1 in-flight, cap 2). Waiter wakes.
+      r2();
+      let r4 = await p4;
+      assert.true(admitted, 'admitted after inUse fell under cap');
+      assert.strictEqual(sem.inUseCount, 2);
+
+      r3();
+      r4();
+      assert.strictEqual(sem.inUseCount, 0);
+    });
+
+    test('grow then shrink in same tick preserves correct count', async function (assert) {
+      let sem = new AsyncSemaphore(2);
+      let r1 = await sem.acquire();
+      let r2 = await sem.acquire();
+      let p3 = sem.acquire();
+      let p4 = sem.acquire();
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 2);
+
+      sem.setCapacity(4);
+      let r3 = await p3;
+      let r4 = await p4;
+      assert.strictEqual(sem.inUseCount, 4);
+      assert.strictEqual(sem.pendingCount, 0);
+
+      sem.setCapacity(1);
+      assert.strictEqual(sem.capacity, 1);
+      assert.strictEqual(sem.inUseCount, 4, 'shrink preserves in-flight');
+
+      r1();
+      r2();
+      r3();
+      assert.strictEqual(sem.inUseCount, 1, 'three drained');
+      r4();
+      assert.strictEqual(sem.inUseCount, 0, 'all drained');
+    });
+
+    test('shrink to 0 clamps to 1', function (assert) {
+      let sem = new AsyncSemaphore(3);
+      sem.setCapacity(0);
+      assert.strictEqual(sem.capacity, 1, 'cap=0 clamped to 1');
+      sem.setCapacity(-2);
+      assert.strictEqual(sem.capacity, 1, 'cap=-2 clamped to 1');
+    });
+
+    test('no-op when new capacity equals current', function (assert) {
+      let sem = new AsyncSemaphore(3);
+      sem.setCapacity(3);
+      assert.strictEqual(sem.capacity, 3);
+      assert.strictEqual(sem.inUseCount, 0);
+    });
+  });
+
+  module('setCapacity interactions with cancellation', function () {
+    test('cancelled waiter is skipped during grow wake', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let r1 = await sem.acquire();
+
+      let ac = new AbortController();
+      let pCancelled = sem.acquire(ac.signal).then(
+        () => 'acquired',
+        (e) => (isPrerenderCancellation(e) ? 'cancelled' : 'other'),
+      );
+      let acquiredAfter: number[] = [];
+      let pNext = sem.acquire().then((r) => {
+        acquiredAfter.push(1);
+        return r;
+      });
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 2, 'two queued');
+
+      // Cancel the first waiter: it gets spliced out of the queue.
+      ac.abort('test');
+      assert.strictEqual(await pCancelled, 'cancelled');
+      assert.strictEqual(sem.pendingCount, 1, 'cancelled waiter spliced');
+
+      // Grow: the surviving waiter wakes.
+      sem.setCapacity(2);
+      let r2 = await pNext;
+      assert.deepEqual(acquiredAfter, [1]);
+      assert.strictEqual(sem.inUseCount, 2);
+      r1();
+      r2();
+    });
+
+    test('cancellation while slot in-flight does not corrupt count after a shrink', async function (assert) {
+      let sem = new AsyncSemaphore(3);
+      let r1 = await sem.acquire();
+      let r2 = await sem.acquire();
+      let r3 = await sem.acquire();
+
+      // Shrink to 1 — over-cap by 2.
+      sem.setCapacity(1);
+      assert.strictEqual(sem.inUseCount, 3);
+
+      // Queue a waiter under a signal we'll abort before any release.
+      let ac = new AbortController();
+      let pCancelled = sem.acquire(ac.signal).then(
+        () => 'acquired',
+        (e) => (isPrerenderCancellation(e) ? 'cancelled' : 'other'),
+      );
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 1);
+
+      ac.abort();
+      assert.strictEqual(await pCancelled, 'cancelled');
+      assert.strictEqual(sem.pendingCount, 0);
+
+      // Drain: no waiters should magically appear.
+      r1();
+      r2();
+      r3();
+      assert.strictEqual(sem.inUseCount, 0);
+      assert.strictEqual(sem.pendingCount, 0);
+    });
+  });
+
+  module('AsyncSemaphore concurrent operations', function () {
+    test('many concurrent acquires + setCapacity admits exactly N', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let acquired = 0;
+      let releases: Array<() => void> = [];
+
+      // Queue 10 acquirers. Only the first one will fit at cap=1.
+      let acquirers = Array.from({ length: 10 }, () =>
+        sem.acquire().then((r) => {
+          acquired++;
+          releases.push(r);
+        }),
+      );
+      await Promise.resolve();
+      assert.strictEqual(acquired, 1, 'one in flight at cap=1');
+      assert.strictEqual(sem.pendingCount, 9);
+
+      // Grow to 5: 4 more should wake (5 - 1 already in flight = 4
+      // immediate hand-offs).
+      sem.setCapacity(5);
+      // Allow promise resolutions to flush.
+      await Promise.resolve();
+      await Promise.resolve();
+      assert.strictEqual(acquired, 5, 'five in flight at cap=5');
+      assert.strictEqual(sem.pendingCount, 5);
+
+      // Drain by releasing one at a time. Each release should wake one
+      // waiter until queue empties.
+      while (releases.length > 0) {
+        let r = releases.shift()!;
+        r();
+        await Promise.resolve();
+        await Promise.resolve();
+      }
+      await Promise.all(acquirers);
+      assert.strictEqual(acquired, 10, 'all eventually acquired');
+      assert.strictEqual(sem.inUseCount, 0);
+      assert.strictEqual(sem.pendingCount, 0);
+    });
+  });
+});

--- a/packages/realm-server/tests/async-semaphore-test.ts
+++ b/packages/realm-server/tests/async-semaphore-test.ts
@@ -36,6 +36,28 @@ module(basename(__filename), function () {
       assert.strictEqual(sem2.capacity, 1, 'cap=-5 clamped to 1');
     });
 
+    test('rejects non-finite construction capacity (NaN / Infinity)', function (assert) {
+      // Addresses Codex P2 + Copilot review on PR 4589: `Math.max(1, NaN)
+      // === NaN` would have permanently stalled every future acquire
+      // because comparisons against NaN are always false.
+      let nanSem = new AsyncSemaphore(NaN);
+      assert.strictEqual(nanSem.capacity, 1, 'NaN falls back to 1');
+      let infSem = new AsyncSemaphore(Infinity);
+      assert.strictEqual(infSem.capacity, 1, 'Infinity falls back to 1');
+      let negInfSem = new AsyncSemaphore(-Infinity);
+      assert.strictEqual(negInfSem.capacity, 1, '-Infinity falls back to 1');
+    });
+
+    test('floors fractional construction capacity', function (assert) {
+      // `#inUse` is an integer counter, so a fractional cap (e.g. 2.7)
+      // would let `2 < 2.7` admit a 3rd holder despite operator intent
+      // of "two slots".
+      let sem = new AsyncSemaphore(2.7);
+      assert.strictEqual(sem.capacity, 2, '2.7 floors to 2');
+      let sem2 = new AsyncSemaphore(0.9);
+      assert.strictEqual(sem2.capacity, 1, '0.9 floors-then-clamps to 1');
+    });
+
     test('inUseCount tracks acquire / release directly', async function (assert) {
       let sem = new AsyncSemaphore(2);
       let r1 = await sem.acquire();
@@ -233,6 +255,19 @@ module(basename(__filename), function () {
       assert.strictEqual(sem.capacity, 1, 'cap=0 clamped to 1');
       sem.setCapacity(-2);
       assert.strictEqual(sem.capacity, 1, 'cap=-2 clamped to 1');
+    });
+
+    test('rejects non-finite + fractional resize values', function (assert) {
+      // Same Codex/Copilot concern as the constructor — protected here
+      // because PagePool dynamic resize (PR 7) reads env-vars and
+      // arithmetic results, both of which can produce NaN/floats.
+      let sem = new AsyncSemaphore(3);
+      sem.setCapacity(NaN);
+      assert.strictEqual(sem.capacity, 1, 'NaN normalized to 1');
+      sem.setCapacity(Infinity);
+      assert.strictEqual(sem.capacity, 1, 'Infinity normalized to 1');
+      sem.setCapacity(4.7);
+      assert.strictEqual(sem.capacity, 4, '4.7 floors to 4');
     });
 
     test('no-op when new capacity equals current', function (assert) {

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -177,6 +177,7 @@ import './prerender-manager-test';
 import './prerender-affinity-activity-test';
 import './prerender-batch-ownership-test';
 import './prerender-cancellation-test';
+import './async-semaphore-test';
 import './runtime-exception-capture-test';
 import './clamp-serialized-error-test';
 import './prerender-diagnostics-persistence-test';

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -178,6 +178,7 @@ import './prerender-affinity-activity-test';
 import './prerender-batch-ownership-test';
 import './prerender-cancellation-test';
 import './async-semaphore-test';
+import './page-pool-priority-test';
 import './runtime-exception-capture-test';
 import './clamp-serialized-error-test';
 import './prerender-diagnostics-persistence-test';

--- a/packages/realm-server/tests/page-pool-priority-test.ts
+++ b/packages/realm-server/tests/page-pool-priority-test.ts
@@ -1,0 +1,215 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { AsyncSemaphore } from '../prerender/async-semaphore';
+import { TabQueue } from '../prerender/page-pool';
+
+// CS-10976 PR 4: priority-aware dequeue for both `AsyncSemaphore`
+// (the per-server render-cap + per-affinity file-admission) and
+// `TabQueue` (the per-tab serializer).
+//
+// Two contracts being pinned down:
+//   1. Higher priority dequeues first when capacity / the lease frees.
+//   2. Same-priority entries are served in FIFO order (no reordering
+//      *within* a priority bucket).
+//
+// Why it matters in production: a user-priority incremental render
+// arriving while a system-priority full reindex has saturated the
+// queue should NOT wait behind every queued background entry.
+
+module(basename(__filename), function () {
+  module('AsyncSemaphore priority dequeue', function () {
+    test('higher priority jumps the queue ahead of lower-priority pending work', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      // Hold the only slot.
+      let r1 = await sem.acquire();
+
+      // Queue four priority=0 entries first.
+      let order: string[] = [];
+      let wait = (label: string, priority?: number) =>
+        sem.acquire(undefined, priority).then((r) => {
+          order.push(label);
+          return r;
+        });
+      let pA = wait('A0');
+      let pB = wait('B0');
+      // Now queue a priority=10 entry. It should jump ahead of A0/B0.
+      let pHi = wait('HI', 10);
+      let pC = wait('C0');
+      // Allow microtasks to flush the queue insertions.
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 4, 'four queued');
+
+      // Release the holder. Highest priority (HI) wakes first.
+      r1();
+      let rHi = await pHi;
+      assert.deepEqual(order, ['HI'], 'priority-10 dequeued first');
+
+      // The remaining priority-0 entries dequeue FIFO.
+      rHi();
+      let rA = await pA;
+      assert.deepEqual(order, ['HI', 'A0'], 'A0 next (FIFO within priority)');
+      rA();
+      let rB = await pB;
+      assert.deepEqual(order, ['HI', 'A0', 'B0'], 'B0 next');
+      rB();
+      let rC = await pC;
+      assert.deepEqual(order, ['HI', 'A0', 'B0', 'C0'], 'C0 last');
+      rC();
+    });
+
+    test('multiple priority tiers — strict ordering by priority', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let r1 = await sem.acquire();
+
+      let order: string[] = [];
+      let releases: Record<string, () => void> = {};
+      let wait = (label: string, priority?: number) =>
+        sem.acquire(undefined, priority).then((r) => {
+          order.push(label);
+          releases[label] = r;
+          return r;
+        });
+
+      // Insertion order: P5a, P10a, P5b, P0a, P10b, P0b.
+      // Expected drain order: P10a, P10b, P5a, P5b, P0a, P0b.
+      let pP5a = wait('P5a', 5);
+      let pP10a = wait('P10a', 10);
+      let pP5b = wait('P5b', 5);
+      let pP0a = wait('P0a', 0);
+      let pP10b = wait('P10b', 10);
+      let pP0b = wait('P0b', 0);
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 6);
+
+      // Drain in strict order, releasing each before the next can proceed.
+      r1();
+      let rP10a = await pP10a;
+      assert.deepEqual(order, ['P10a'], 'P10a first');
+      rP10a();
+      let rP10b = await pP10b;
+      assert.deepEqual(order, ['P10a', 'P10b']);
+      rP10b();
+      let rP5a = await pP5a;
+      assert.deepEqual(order, ['P10a', 'P10b', 'P5a']);
+      rP5a();
+      let rP5b = await pP5b;
+      assert.deepEqual(order, ['P10a', 'P10b', 'P5a', 'P5b']);
+      rP5b();
+      let rP0a = await pP0a;
+      assert.deepEqual(order, ['P10a', 'P10b', 'P5a', 'P5b', 'P0a']);
+      rP0a();
+      let rP0b = await pP0b;
+      assert.deepEqual(order, ['P10a', 'P10b', 'P5a', 'P5b', 'P0a', 'P0b']);
+      rP0b();
+    });
+
+    test('priority undefined defaults to 0 (FIFO with explicit 0)', async function (assert) {
+      let sem = new AsyncSemaphore(1);
+      let r1 = await sem.acquire();
+      let order: string[] = [];
+      let pDefault = sem.acquire().then((r) => {
+        order.push('default');
+        return r;
+      });
+      let pExplicit0 = sem.acquire(undefined, 0).then((r) => {
+        order.push('explicit-0');
+        return r;
+      });
+      let pP5 = sem.acquire(undefined, 5).then((r) => {
+        order.push('p5');
+        return r;
+      });
+      await Promise.resolve();
+
+      r1();
+      let rP5 = await pP5;
+      assert.deepEqual(order, ['p5'], 'priority-5 wakes first');
+      rP5();
+      let rDefault = await pDefault;
+      assert.deepEqual(order, ['p5', 'default'], 'undefined-priority next');
+      rDefault();
+      let rExplicit = await pExplicit0;
+      assert.deepEqual(
+        order,
+        ['p5', 'default', 'explicit-0'],
+        'explicit-0 last (FIFO equal-priority)',
+      );
+      rExplicit();
+    });
+  });
+
+  module('TabQueue priority dequeue', function () {
+    test('higher priority jumps tab queue ahead of lower-priority waiters', async function (assert) {
+      let q = new TabQueue();
+      let r1 = await q.acquire();
+
+      let order: string[] = [];
+      let wait = (label: string, priority?: number) =>
+        q.acquire(undefined, priority).then((r) => {
+          order.push(label);
+          return r;
+        });
+      let pA = wait('A0');
+      let pB = wait('B0');
+      let pHi = wait('HI', 10);
+      let pC = wait('C0');
+      await Promise.resolve();
+      // pendingCount = (held ? 1 : 0) + queue.length = 1 + 4 = 5
+      assert.strictEqual(q.pendingCount, 5, 'four queued + held = 5');
+
+      // Drain in expected order: HI, A0, B0, C0.
+      r1();
+      let rHi = await pHi;
+      assert.deepEqual(order, ['HI'], 'priority-10 dequeued first');
+      rHi();
+      let rA = await pA;
+      assert.deepEqual(order, ['HI', 'A0'], 'A0 next');
+      rA();
+      let rB = await pB;
+      assert.deepEqual(order, ['HI', 'A0', 'B0'], 'B0 next');
+      rB();
+      let rC = await pC;
+      assert.deepEqual(order, ['HI', 'A0', 'B0', 'C0'], 'C0 last');
+      rC();
+    });
+
+    test('cancellation while queued at high priority still splices the entry out', async function (assert) {
+      let q = new TabQueue();
+      let r1 = await q.acquire();
+      let ac = new AbortController();
+
+      let order: string[] = [];
+      let waitLow = q.acquire(undefined, 0).then((r) => {
+        order.push('low');
+        return r;
+      });
+      let waitHi = q.acquire(ac.signal, 10).then(
+        (r) => {
+          order.push('hi');
+          return r;
+        },
+        (err) => {
+          order.push('hi-cancelled');
+          return err;
+        },
+      );
+      await Promise.resolve();
+
+      // Cancel the high-priority waiter before the holder releases.
+      ac.abort();
+      await waitHi;
+      assert.deepEqual(order, ['hi-cancelled'], 'hi cancelled while queued');
+
+      // Releasing the holder should now hand off to the low-priority
+      // waiter — the cancelled hi entry is gone.
+      r1();
+      let rLow = await waitLow;
+      assert.deepEqual(
+        order,
+        ['hi-cancelled', 'low'],
+        'low woke after hi-cancelled',
+      );
+      rLow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Replaces FIFO ordering with priority-aware dequeue inside the three queues `PagePool` acquires through:

- Per-server render semaphore (`#renderSemaphore`)
- Per-affinity file admission semaphore (`#fileAdmission`)
- Per-tab serialization queue (`TabQueue`)

Higher priority dequeues first; FIFO is preserved within a priority bucket. **No preemption** — an in-flight low-priority render runs to completion; the next free slot goes to the highest-priority waiter.

## Threading

Builds on PR 1 (#4589, AsyncSemaphore foundation) and PR 3 (#4591, wire-format priority threading from producer side). PR 4 adds the consumer-side ordering effect:

```
Prerenderer.{prerenderModule, prerenderVisit, runCommand}
  → renderRunner.{prerenderModuleAttempt, prerenderVisitAttempt, runCommandAttempt}
  → renderRunner.#getPageForAffinity
  → PagePool.getPage(affinityKey, queue, { priority, signal })
  → priority threaded into all three acquires
```

## Implementation

- **AsyncSemaphore** — `acquire(signal?, priority?)` does sorted insertion: find the first existing entry with strictly lower priority and insert before it; otherwise append. Same-priority entries land at the end of their bucket → FIFO preserved.
- **TabQueue** — rewritten from a promise-chain to a held-flag + sorted-insertion array. `pendingCount` keeps the pre-PR-4 semantics: `(held ? 1 : 0) + queue.length`, so `pendingCount === 0` still means "idle" and `pendingCount > 1` still means "queue forming behind the holder."
- **PagePool.getPage** threads `priority` from `opts` into the file-admission, tab-queue, and global render-semaphore acquires.
- **render-runner**'s three `*Attempt` methods accept `priority?` and forward through `#getPageForAffinity`.
- **Prerenderer** call sites pass the priority captured from PR 3's wire-format args into the runner.

## Tests

Five new tests in `page-pool-priority-test.ts`:

- AsyncSemaphore: priority-10 jumps ahead of queued priority-0.
- AsyncSemaphore: multi-tier strict ordering (P10/P5/P0 mix).
- AsyncSemaphore: `undefined` priority FIFOs with explicit `0`.
- TabQueue: priority dequeue parallel to AsyncSemaphore.
- TabQueue: cancel-while-queued at high priority correctly splices the entry without blocking lower-priority waiters.

Existing `prerender-cancellation-test.ts` (16 tests) still passes — the TabQueue rewrite preserved abort/release semantics. Existing `async-semaphore-test.ts` (18 tests) still passes — sorted insertion is back-compat with the no-priority-arg path.

## Test plan

- [x] `TEST_MODULE='page-pool-priority-test.ts' pnpm test-module` passes 5/5.
- [x] `TEST_MODULE='prerender-cancellation-test.ts' pnpm test-module` passes 16/16.
- [x] `TEST_MODULE='async-semaphore-test.ts' pnpm test-module` passes 18/18.
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` clean.
- [x] `pnpm lint` clean on all touched files.

## Stack

Stacked on PR 3 (#4591). Includes commits from PR 1 (#4589) via merge. When PR 1 + PR 3 land, this PR rebases onto main and the stack collapses naturally.

Next: PR 5 (manager-side priority routing — heartbeat carries `minPendingPriority` so `scoreCandidate` steers high-priority requests to servers without higher-priority pending work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)