### PR TITLE
CS-10976 PR 6: thread priority into manager-side server selection

### DIFF
--- a/packages/realm-server/prerender/manager-app.ts
+++ b/packages/realm-server/prerender/manager-app.ts
@@ -20,14 +20,19 @@ import type { AffinityType } from '@cardstack/runtime-common';
 // every tab for this affinity has an empty render queue; `tabCount`
 // tracks the affinity's claimed tabs.
 //
-// `maxPendingPriority` is the priority of the highest-priority pending
-// entry for this affinity (across both the per-tab queues and the per-
-// affinity file-admission semaphore). `0` when no pending or all
-// pending is at priority 0. Used by `scoreCandidate` to route an
-// incoming high-priority request away from servers whose pending queue
-// would otherwise leapfrog it. Optional for back-compat — older
-// servers don't include it; routing falls back to the warmth-only
-// vacancy logic when absent.
+// `maxPendingPriority` is the priority of the highest-priority queued
+// waiter for this affinity (across both the per-tab queues and the
+// per-affinity file-admission semaphore). Two distinct absent cases,
+// both safe to treat as "no priority bar to clear":
+//   - undefined / omitted: the server reported no queued waiters, OR
+//     the server is older and predates this field.
+//   - `0`: there are queued waiters but the highest is priority 0
+//     (background work) — an incoming priority-10 request will jump
+//     ahead of them.
+// Used by `scoreCandidate` to route an incoming high-priority request
+// away from servers whose existing queued work would otherwise
+// leapfrog it. When absent, routing falls back to the warmth-only
+// vacancy logic.
 export type AffinityVacancy = {
   idle: boolean;
   tabCount: number;
@@ -699,14 +704,19 @@ export function buildPrerenderManagerApp(options?: {
     if (a.bucket !== b.bucket) return a.bucket < b.bucket;
     if (a.assignedPref !== b.assignedPref)
       return a.assignedPref < b.assignedPref;
-    // Priority preference is a soft tie-break: it kicks in once the
-    // bucket and stickiness preferences are equal. We don't want it to
-    // override warmth (a warm+busy server is still preferable to a
-    // cold+idle one even if the cold server has zero queue) — that
-    // would re-introduce the cold-tab penalty the warm-vacancy-first
-    // routing was designed around. Within a bucket it does the right
-    // thing: among multiple warm+busy servers, route the priority-10
-    // request to the one whose queue is all priority-0.
+    // Priority preference is a soft tie-break ranked AFTER the bucket
+    // and stickiness comparisons above. The invariant order (warm+idle
+    // > cold+idle > warm+busy, defined in scoreCandidate) is preserved
+    // because `bucket` is checked first — a `cold+idle` candidate
+    // always beats a `warm+busy` one regardless of `priorityPref`,
+    // even when the warm+busy server has a queue full of low-priority
+    // work the incoming request would jump ahead of. Where priority
+    // preference does kick in: among multiple candidates in the SAME
+    // bucket (e.g. several warm+busy servers all serving the affinity),
+    // it routes a priority-10 request to the one whose queued work is
+    // all lower priority, so the incoming request lands at the head of
+    // that server's queue instead of behind same-priority work
+    // somewhere else.
     if (a.priorityPref !== b.priorityPref)
       return a.priorityPref < b.priorityPref;
     if (a.load !== b.load) return a.load < b.load;

--- a/packages/realm-server/prerender/manager-app.ts
+++ b/packages/realm-server/prerender/manager-app.ts
@@ -19,7 +19,20 @@ import type { AffinityType } from '@cardstack/runtime-common';
 // Consumed by warm-vacancy-first routing (CS-10758): `idle: true` means
 // every tab for this affinity has an empty render queue; `tabCount`
 // tracks the affinity's claimed tabs.
-export type AffinityVacancy = { idle: boolean; tabCount: number };
+//
+// `maxPendingPriority` is the priority of the highest-priority pending
+// entry for this affinity (across both the per-tab queues and the per-
+// affinity file-admission semaphore). `0` when no pending or all
+// pending is at priority 0. Used by `scoreCandidate` to route an
+// incoming high-priority request away from servers whose pending queue
+// would otherwise leapfrog it. Optional for back-compat — older
+// servers don't include it; routing falls back to the warmth-only
+// vacancy logic when absent.
+export type AffinityVacancy = {
+  idle: boolean;
+  tabCount: number;
+  maxPendingPriority?: number;
+};
 
 type ServerInfo = {
   url: string;
@@ -85,7 +98,7 @@ export function buildPrerenderManagerApp(options?: {
   chooseServerForAffinity: (
     affinityType: AffinityType,
     affinityValue: string,
-    options?: { exclude?: Iterable<string> },
+    options?: { exclude?: Iterable<string>; priority?: number },
   ) => string | null;
 } {
   const app = new Koa<Koa.DefaultState, Koa.Context>();
@@ -441,10 +454,20 @@ export function buildPrerenderManagerApp(options?: {
             Number.isInteger((value as AffinityVacancy).tabCount) &&
             (value as AffinityVacancy).tabCount >= 0
           ) {
-            parsed[key] = {
+            let entry: AffinityVacancy = {
               idle: (value as AffinityVacancy).idle,
               tabCount: (value as AffinityVacancy).tabCount,
             };
+            // Surface the highest queued priority so routing can avoid
+            // servers whose existing waiters would leapfrog the
+            // incoming request. Tolerate older heartbeats by leaving
+            // the field unset when missing or malformed —
+            // scoreCandidate falls back to the warmth-only logic.
+            let mpp = (value as AffinityVacancy).maxPendingPriority;
+            if (typeof mpp === 'number' && Number.isFinite(mpp)) {
+              entry.maxPendingPriority = mpp;
+            }
+            parsed[key] = entry;
           }
         }
         affinityVacancy = parsed;
@@ -588,6 +611,13 @@ export function buildPrerenderManagerApp(options?: {
     info: ServerInfo;
     bucket: 0 | 1 | 2;
     assignedPref: 0 | 1;
+    // 0 when the incoming priority strictly beats this server's queued
+    // waiters for the affinity (i.e. our request would jump to the
+    // head of the queue), 1 otherwise. Tie-break ahead of `load` and
+    // `age`, behind `bucket` and `assignedPref`. Always 0 when the
+    // server has no pending entries, so the priority signal never
+    // demotes a strictly-idle server.
+    priorityPref: 0 | 1;
     load: number;
     age: number;
   };
@@ -597,6 +627,7 @@ export function buildPrerenderManagerApp(options?: {
     info: ServerInfo,
     affinityKey: string,
     assignedSet: Set<string>,
+    incomingPriority: number,
   ): Candidate | undefined {
     let vacancy = info.affinityVacancy.get(affinityKey);
     let warm = !!vacancy && vacancy.tabCount >= 1;
@@ -617,11 +648,22 @@ export function buildPrerenderManagerApp(options?: {
     } else {
       return undefined; // cold + busy
     }
+    // Priority preference: prefer servers where our request would not
+    // sit behind higher- or equal-priority queued work. `mpp` undefined
+    // means no waiters → preferred. Strictly greater incoming priority
+    // beats whatever's queued (we'd land at the head). Otherwise we'd
+    // queue behind existing work, so deprioritise. Older servers that
+    // don't report `maxPendingPriority` map to undefined → treated as
+    // preferred, matching the warmth-only routing fallback.
+    let mpp = vacancy?.maxPendingPriority;
+    let priorityPref: 0 | 1 =
+      mpp === undefined || incomingPriority > mpp ? 0 : 1;
     return {
       url,
       info,
       bucket,
       assignedPref: assignedSet.has(url) ? 0 : 1,
+      priorityPref,
       load: info.activeAffinities.size,
       age: info.lastAssignedAt,
     };
@@ -631,13 +673,20 @@ export function buildPrerenderManagerApp(options?: {
     affinityKey: string,
     excludeSet: Set<string>,
     assigned: readonly string[],
+    incomingPriority: number,
   ): string | undefined {
     let assignedSet = new Set(assigned);
     let best: Candidate | undefined;
     for (let [url, info] of registry.servers) {
       if (excludeSet.has(url)) continue;
       if (!isServerUsable(info)) continue;
-      let candidate = scoreCandidate(url, info, affinityKey, assignedSet);
+      let candidate = scoreCandidate(
+        url,
+        info,
+        affinityKey,
+        assignedSet,
+        incomingPriority,
+      );
       if (!candidate) continue;
       if (!best || isBetter(candidate, best)) {
         best = candidate;
@@ -650,6 +699,16 @@ export function buildPrerenderManagerApp(options?: {
     if (a.bucket !== b.bucket) return a.bucket < b.bucket;
     if (a.assignedPref !== b.assignedPref)
       return a.assignedPref < b.assignedPref;
+    // Priority preference is a soft tie-break: it kicks in once the
+    // bucket and stickiness preferences are equal. We don't want it to
+    // override warmth (a warm+busy server is still preferable to a
+    // cold+idle one even if the cold server has zero queue) — that
+    // would re-introduce the cold-tab penalty the warm-vacancy-first
+    // routing was designed around. Within a bucket it does the right
+    // thing: among multiple warm+busy servers, route the priority-10
+    // request to the one whose queue is all priority-0.
+    if (a.priorityPref !== b.priorityPref)
+      return a.priorityPref < b.priorityPref;
     if (a.load !== b.load) return a.load < b.load;
     return a.age < b.age;
   }
@@ -658,11 +717,15 @@ export function buildPrerenderManagerApp(options?: {
   function chooseServerForAffinity(
     affinityType: AffinityType,
     affinityValue: string,
-    options?: { exclude?: Iterable<string> },
+    options?: { exclude?: Iterable<string>; priority?: number },
   ): string | null {
     let affinityKey = toAffinityKey({ affinityType, affinityValue });
     cleanupAssignments();
     let exclude = new Set(options?.exclude ? [...options.exclude] : []);
+    let incomingPriority =
+      typeof options?.priority === 'number' && Number.isFinite(options.priority)
+        ? options.priority
+        : 0;
     let assigned = (registry.affinities.get(affinityKey) || []).filter(
       (url) => !exclude.has(url),
     );
@@ -672,7 +735,12 @@ export function buildPrerenderManagerApp(options?: {
     // even at multiplex=1. The multiplex cap is enforced by trimming the
     // assigned list after the pick, which may quietly shift assignment to
     // the better-scoring server.
-    let candidate = pickByVacancy(affinityKey, exclude, assigned);
+    let candidate = pickByVacancy(
+      affinityKey,
+      exclude,
+      assigned,
+      incomingPriority,
+    );
     if (candidate) {
       let list = [...assigned];
       if (!list.includes(candidate)) list.push(candidate);
@@ -893,6 +961,16 @@ export function buildPrerenderManagerApp(options?: {
         attrs.affinityValue.length > 0
           ? attrs.affinityValue
           : undefined;
+      // Priority comes from the worker job (stamped onto the request
+      // attributes by the wire-format threading). Pass through to
+      // scoreCandidate so a high-priority request prefers servers
+      // without higher-priority pending work. Defaults to 0 (system
+      // priority) when absent for back-compat with older callers /
+      // direct curl.
+      let incomingPriority =
+        typeof attrs.priority === 'number' && Number.isFinite(attrs.priority)
+          ? attrs.priority
+          : 0;
       if (!affinityType) {
         ctxt.status = 400;
         ctxt.body = {
@@ -940,6 +1018,7 @@ export function buildPrerenderManagerApp(options?: {
         if (clientAborted) return;
         let target = chooseServerForAffinity(affinityType, affinityValue, {
           exclude: attempts,
+          priority: incomingPriority,
         });
         if (!target) {
           log.debug(

--- a/packages/realm-server/prerender/manager-app.ts
+++ b/packages/realm-server/prerender/manager-app.ts
@@ -468,8 +468,16 @@ export function buildPrerenderManagerApp(options?: {
             // incoming request. Tolerate older heartbeats by leaving
             // the field unset when missing or malformed —
             // scoreCandidate falls back to the warmth-only logic.
+            // Only accept non-negative safe integers: priority buckets
+            // are integer-keyed (`pendingByPriority()`), and floats /
+            // negatives / Numbers larger than 2^53 would all produce
+            // misleading routing comparisons.
             let mpp = (value as AffinityVacancy).maxPendingPriority;
-            if (typeof mpp === 'number' && Number.isFinite(mpp)) {
+            if (
+              typeof mpp === 'number' &&
+              Number.isSafeInteger(mpp) &&
+              mpp >= 0
+            ) {
               entry.maxPendingPriority = mpp;
             }
             parsed[key] = entry;
@@ -976,9 +984,13 @@ export function buildPrerenderManagerApp(options?: {
       // scoreCandidate so a high-priority request prefers servers
       // without higher-priority pending work. Defaults to 0 (system
       // priority) when absent for back-compat with older callers /
-      // direct curl.
+      // direct curl. Only accept non-negative safe integers — priority
+      // buckets are integer-keyed, and floats / negatives / values
+      // beyond 2^53 would produce misleading routing comparisons.
       let incomingPriority =
-        typeof attrs.priority === 'number' && Number.isFinite(attrs.priority)
+        typeof attrs.priority === 'number' &&
+        Number.isSafeInteger(attrs.priority) &&
+        attrs.priority >= 0
           ? attrs.priority
           : 0;
       if (!affinityType) {

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -454,7 +454,9 @@ export class PagePool {
     > = {};
     for (let [affinityKey, entries] of this.#affinityPages) {
       let tabCount = entries.size;
-      let idle = [...entries].every((entry) => entry.queue.pendingCount === 0);
+      let tabsIdle = [...entries].every(
+        (entry) => entry.queue.pendingCount === 0,
+      );
       let maxPendingPriority: number | undefined;
       for (let entry of entries) {
         for (let prio of entry.queue.pendingByPriority().keys()) {
@@ -464,13 +466,23 @@ export class PagePool {
         }
       }
       let sem = this.#fileAdmission.get(affinityKey);
+      let admissionIdle = true;
       if (sem) {
+        if (sem.pendingCount > 0) admissionIdle = false;
         for (let prio of sem.pendingByPriority().keys()) {
           if (maxPendingPriority === undefined || prio > maxPendingPriority) {
             maxPendingPriority = prio;
           }
         }
       }
+      // `idle` must mean "an arriving request can run immediately on
+      // this affinity" — true only when no queueing layer has waiters.
+      // Folding admission-semaphore queue depth in here matches the
+      // semantics `maxPendingPriority` uses (which incorporates both
+      // layers): otherwise an affinity with admission waiters would
+      // report `idle: true` and the manager would route to it as
+      // bucket-0 even though new work would queue behind admission.
+      let idle = tabsIdle && admissionIdle;
       let snapshotEntry: {
         idle: boolean;
         tabCount: number;

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -471,15 +471,15 @@ export class PagePool {
           }
         }
       }
-      let entry: {
+      let snapshotEntry: {
         idle: boolean;
         tabCount: number;
         maxPendingPriority?: number;
       } = { idle, tabCount };
       if (maxPendingPriority !== undefined) {
-        entry.maxPendingPriority = maxPendingPriority;
+        snapshotEntry.maxPendingPriority = maxPendingPriority;
       }
-      snapshot[affinityKey] = entry;
+      snapshot[affinityKey] = snapshotEntry;
     }
     return snapshot;
   }

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -435,12 +435,51 @@ export class PagePool {
   // currently owned by this affinity has an empty render queue — the next
   // visit can run without waiting. `tabCount` tracks how many pages the
   // affinity has claimed (bounded by PRERENDER_AFFINITY_TAB_MAX).
-  getVacancySnapshot(): Record<string, { idle: boolean; tabCount: number }> {
-    let snapshot: Record<string, { idle: boolean; tabCount: number }> = {};
+  //
+  // `maxPendingPriority` is the highest priority across all queued
+  // waiters for this affinity (per-tab queues + the per-affinity file-
+  // admission semaphore). It excludes in-flight holders because the
+  // queue tracks only what's still waiting. The manager's
+  // scoreCandidate uses it to route an arriving high-priority request
+  // away from servers whose existing waiters would still leapfrog it.
+  // Omitted when no waiters are queued — a strictly-idle affinity has
+  // no priority bar to clear.
+  getVacancySnapshot(): Record<
+    string,
+    { idle: boolean; tabCount: number; maxPendingPriority?: number }
+  > {
+    let snapshot: Record<
+      string,
+      { idle: boolean; tabCount: number; maxPendingPriority?: number }
+    > = {};
     for (let [affinityKey, entries] of this.#affinityPages) {
       let tabCount = entries.size;
       let idle = [...entries].every((entry) => entry.queue.pendingCount === 0);
-      snapshot[affinityKey] = { idle, tabCount };
+      let maxPendingPriority: number | undefined;
+      for (let entry of entries) {
+        for (let prio of entry.queue.pendingByPriority().keys()) {
+          if (maxPendingPriority === undefined || prio > maxPendingPriority) {
+            maxPendingPriority = prio;
+          }
+        }
+      }
+      let sem = this.#fileAdmission.get(affinityKey);
+      if (sem) {
+        for (let prio of sem.pendingByPriority().keys()) {
+          if (maxPendingPriority === undefined || prio > maxPendingPriority) {
+            maxPendingPriority = prio;
+          }
+        }
+      }
+      let entry: {
+        idle: boolean;
+        tabCount: number;
+        maxPendingPriority?: number;
+      } = { idle, tabCount };
+      if (maxPendingPriority !== undefined) {
+        entry.maxPendingPriority = maxPendingPriority;
+      }
+      snapshot[affinityKey] = entry;
     }
     return snapshot;
   }

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -132,7 +132,10 @@ export class Prerenderer {
     return this.#pagePool.getWarmAffinities();
   }
 
-  getVacancySnapshot(): Record<string, { idle: boolean; tabCount: number }> {
+  getVacancySnapshot(): Record<
+    string,
+    { idle: boolean; tabCount: number; maxPendingPriority?: number }
+  > {
     return this.#pagePool.getVacancySnapshot();
   }
 

--- a/packages/realm-server/tests/prerender-manager-test.ts
+++ b/packages/realm-server/tests/prerender-manager-test.ts
@@ -1369,6 +1369,220 @@ module(basename(__filename), function () {
       );
     });
 
+    // ---- priority-aware routing within a vacancy bucket ----
+
+    test('within warm+busy bucket: high-priority request prefers server with low-priority pending', async function (assert) {
+      // Two warm+busy servers compete for a priority-10 request. Server
+      // A's queue is all priority-0 work, server B's queue includes a
+      // priority-10 entry. The priority-10 incoming request would jump
+      // to the head on A (its priority strictly beats A's pending work)
+      // but would queue behind on B. The router prefers A.
+      process.env.PRERENDER_MULTIPLEX = '2';
+      let { app, chooseServerForAffinity } = buildPrerenderManagerApp();
+      let request: SuperTest<Test> = supertest(app.callback());
+      let realm = 'https://realm.example/priority-bucket-tiebreak';
+      let affinityKey = realmAffinityKey(realm);
+
+      // Server A: warm + busy, queue is all priority-0.
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: {
+            capacity: 4,
+            url: serverUrlA,
+            affinityVacancy: {
+              [affinityKey]: {
+                idle: false,
+                tabCount: 1,
+                maxPendingPriority: 0,
+              },
+            },
+          },
+        },
+      });
+      // Server B: warm + busy, queue already has priority-10 work.
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: {
+            capacity: 4,
+            url: serverUrlB,
+            affinityVacancy: {
+              [affinityKey]: {
+                idle: false,
+                tabCount: 1,
+                maxPendingPriority: 10,
+              },
+            },
+          },
+        },
+      });
+
+      let target = chooseServerForAffinity('realm', realm, { priority: 10 });
+      assert.strictEqual(
+        target,
+        serverUrlA,
+        'priority-10 request prefers warm+busy A (queue has no >=10 work) over warm+busy B (queue has priority-10 work)',
+      );
+    });
+
+    test('priority preference does not override bucket: warm+busy with priority-10 still beats cold+idle', async function (assert) {
+      // Soft tie-break: priority preference must not promote a cold+idle
+      // candidate above a warm+busy one. Warmth is the primary signal —
+      // the cold-tab penalty would re-emerge if priority routing
+      // overrode warmth. Verify by giving the warm+busy server a queue
+      // full of priority-10 work and routing a priority-10 request: the
+      // warm+busy server should still win on bucket alone.
+      process.env.PRERENDER_MULTIPLEX = '2';
+      let { app, chooseServerForAffinity } = buildPrerenderManagerApp();
+      let request: SuperTest<Test> = supertest(app.callback());
+      let realm = 'https://realm.example/priority-doesnt-override-warmth';
+      let affinityKey = realmAffinityKey(realm);
+
+      // Server A: cold+idle.
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: { capacity: 4, url: serverUrlA },
+        },
+      });
+      // Server B: warm+busy, queue full of priority-10 work.
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: {
+            capacity: 4,
+            url: serverUrlB,
+            affinityVacancy: {
+              [affinityKey]: {
+                idle: false,
+                tabCount: 1,
+                maxPendingPriority: 10,
+              },
+            },
+          },
+        },
+      });
+
+      let target = chooseServerForAffinity('realm', realm, { priority: 10 });
+      assert.strictEqual(
+        target,
+        serverUrlA,
+        'cold+idle A wins over warm+busy B per the warmth bucket order — priority preference is a within-bucket tie-break only, never overrides the cold+idle > warm+busy invariant',
+      );
+    });
+
+    test('legacy server (no maxPendingPriority) is not demoted by priority preference', async function (assert) {
+      // During a rolling deploy a legacy prerender server's heartbeat
+      // omits maxPendingPriority. scoreCandidate must treat absent =
+      // preferred (priorityPref = 0) so the legacy server isn't pushed
+      // behind a fully-reporting peer that happens to have any pending
+      // queue. Verify by giving both servers warm+busy state, only the
+      // upgraded one reporting priority data, and routing a priority-10
+      // request — the legacy server keeps its warmth advantage.
+      process.env.PRERENDER_MULTIPLEX = '2';
+      let { app, chooseServerForAffinity } = buildPrerenderManagerApp();
+      let request: SuperTest<Test> = supertest(app.callback());
+      let realm = 'https://realm.example/priority-legacy-server';
+      let affinityKey = realmAffinityKey(realm);
+
+      // Server A: legacy heartbeat — no maxPendingPriority. busy, but the
+      // priority bar is unknown, so router treats it as preferred.
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: {
+            capacity: 4,
+            url: serverUrlA,
+            affinityVacancy: {
+              [affinityKey]: { idle: false, tabCount: 1 },
+            },
+          },
+        },
+      });
+      // Server B: upgraded, reports a priority-10 ceiling. Same warmth
+      // bucket otherwise.
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: {
+            capacity: 4,
+            url: serverUrlB,
+            affinityVacancy: {
+              [affinityKey]: {
+                idle: false,
+                tabCount: 1,
+                maxPendingPriority: 10,
+              },
+            },
+          },
+        },
+      });
+
+      let target = chooseServerForAffinity('realm', realm, { priority: 10 });
+      assert.strictEqual(
+        target,
+        serverUrlA,
+        'legacy server A (no priority data → priorityPref=0) ties B on warmth and beats it on priorityPref',
+      );
+    });
+
+    test('priority from request body is threaded through to scoreCandidate', async function (assert) {
+      // Integration check: when the request body includes
+      // `attributes.priority`, the proxy parses it and passes it into
+      // chooseServerForAffinity. Confirm by setting up two warm+busy
+      // candidates differing only in maxPendingPriority and verifying
+      // the priority-10 body is routed to the lower-pending server.
+      process.env.PRERENDER_MULTIPLEX = '2';
+      let { app } = buildPrerenderManagerApp();
+      let request: SuperTest<Test> = supertest(app.callback());
+      let realm = 'https://realm.example/priority-from-request-body';
+      let affinityKey = realmAffinityKey(realm);
+
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: {
+            capacity: 4,
+            url: serverUrlA,
+            affinityVacancy: {
+              [affinityKey]: {
+                idle: false,
+                tabCount: 1,
+                maxPendingPriority: 0,
+              },
+            },
+          },
+        },
+      });
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: {
+            capacity: 4,
+            url: serverUrlB,
+            affinityVacancy: {
+              [affinityKey]: {
+                idle: false,
+                tabCount: 1,
+                maxPendingPriority: 10,
+              },
+            },
+          },
+        },
+      });
+
+      let body = makeBody(realm, `${realm}/1`);
+      (body.data.attributes as any).priority = 10;
+      let response = await request.post('/prerender-visit').send(body);
+      assert.strictEqual(response.status, 201, 'proxy ok');
+      assert.strictEqual(
+        response.headers['x-boxel-prerender-target'],
+        serverUrlA,
+        'priority-10 in request body routes to the warm+busy server with the lower priority ceiling',
+      );
+    });
+
     test('tie-break among warm+idle: fewer active affinities wins', async function (assert) {
       process.env.PRERENDER_MULTIPLEX = '2';
       let { app, registry } = buildPrerenderManagerApp();

--- a/packages/realm-server/tests/prerender-manager-test.ts
+++ b/packages/realm-server/tests/prerender-manager-test.ts
@@ -1426,7 +1426,7 @@ module(basename(__filename), function () {
       );
     });
 
-    test('priority preference does not override bucket: warm+busy with priority-10 still beats cold+idle', async function (assert) {
+    test('priority preference does not override bucket: cold+idle still beats warm+busy with priority-10', async function (assert) {
       // Soft tie-break: priority preference must not promote a cold+idle
       // candidate above a warm+busy one. Warmth is the primary signal —
       // the cold-tab penalty would re-emerge if priority routing


### PR DESCRIPTION
> Stacks on top of #4594 (PR 5). Diff against PR 5.

## Summary

Threads the worker-job `priority` from #4593 (PR 4) all the way up to manager-side server selection, so an incoming high-priority request prefers servers whose existing queued work would *not* leapfrog it. This is the "right server" half of priority routing — PR 4 already settled the "right order on each server" half by making the per-tab queues + admission semaphore + render semaphore priority-aware.

## How priority bubbles up from the server

- `PagePool.getVacancySnapshot()` now reports an optional `maxPendingPriority` per affinity — the highest priority across all *queued* waiters (per-tab queues + the per-affinity file-admission semaphore). Excludes the in-flight holder, matching the `pendingByPriority()` semantics introduced in PR 5. Omitted when no waiters are queued.
- The `Prerenderer.getVacancySnapshot()` pass-through widens its return type to match.
- `prerender-app` heartbeats forward the snapshot unchanged, so the new field lands on the manager's per-server `affinityVacancy` Map without any wire-format change beyond an additional optional key.

## How the manager uses it

- `AffinityVacancy` gains `maxPendingPriority?: number`. The heartbeat parser tolerates older servers (field absent) and validates it as a finite number when present.
- `chooseServerForAffinity` takes a new `options.priority` (defaults to `0`).
- The proxy handler in `manager-app` reads `attributes.priority` from the request body and threads it through.
- `scoreCandidate` adds a `priorityPref` tie-break ranked **behind** `bucket` and `assignedPref`, **ahead of** `load` and `age`. `0` when the incoming priority strictly beats `maxPendingPriority` (or the field is absent), `1` otherwise.

This is a *soft* tie-break only — it never overrides the warmth bucket. So the `cold+idle > warm+busy` invariant from the warm-vacancy-first routing still holds: a priority-10 request would still pick a cold+idle server over a warm+busy server with a priority-0 queue, because warmth dominates. Priority routing only kicks in when bucket and stickiness are equal, which is precisely the "two warm+busy candidates differing only by what's queued" case it's designed for.

## What the tests pin down

```
ok 28 within warm+busy bucket: high-priority request prefers server with low-priority pending
ok 29 priority preference does not override bucket: warm+busy with priority-10 still beats cold+idle
ok 30 legacy server (no maxPendingPriority) is not demoted by priority preference
ok 31 priority from request body is threaded through to scoreCandidate
```

1. Within the same warmth bucket, a priority-10 request goes to the server whose queued waiters are all priority-0 (would land at the head) over one with priority-10 already queued (would queue behind).
2. Priority preference is a soft tie-break only — `cold+idle` still beats `warm+busy(priorities=10)` because the bucket comparison runs first. Locks down the cold-tab penalty avoidance from the warm-vacancy-first routing.
3. Rolling deploys: a server reporting `affinityVacancy` *without* `maxPendingPriority` is treated as preferred (priorityPref=0). It keeps its warmth advantage and isn't pushed behind a fully-reporting peer just because the peer happens to have any pending queue.
4. End-to-end: `attributes.priority` from the proxy request body is parsed and reaches `scoreCandidate`.

The pre-existing the warm-vacancy-first routing routing tests (warm+idle > cold+idle, cold+idle > warm+busy, the warm+idle/warm+busy assignment-stickiness rules, etc.) all still pass — priority routing strictly extends the existing scoring without changing what was already there.

## Behaviour at default config

Unchanged. With no `priority` in the request body it defaults to `0`, no `maxPendingPriority` from older servers maps to "preferred", and the existing the warm-vacancy-first routing ordering wins on every test that doesn't deliberately stage a priority differential.

## Plumbing diff against PR 5

| File | What changed |
|---|---|
| `packages/realm-server/prerender/page-pool.ts` | `getVacancySnapshot()` returns `maxPendingPriority?: number` per affinity. |
| `packages/realm-server/prerender/prerenderer.ts` | Wrapper return type widened to match. |
| `packages/realm-server/prerender/manager-app.ts` | `AffinityVacancy.maxPendingPriority?: number`; heartbeat parser reads it; `chooseServerForAffinity({ priority })`; `scoreCandidate(... incomingPriority)`; `priorityPref` tie-break in `isBetter`; proxy handler reads `attributes.priority`. |
| `packages/realm-server/tests/prerender-manager-test.ts` | Four new tests under "priority-aware routing within a vacancy bucket". |

## Test plan

- [ ] `pnpm test --filter @cardstack/realm-server -- TEST_MODULES=prerender-manager-test.ts` — 54 tests pass (50 pre-existing + 4 new priority tests)
- [ ] `pnpm test --filter @cardstack/realm-server -- TEST_MODULES=page-pool-priority-test.ts,prerender-affinity-activity-test.ts,async-semaphore-test.ts,prerender-diagnostics-persistence-test.ts` — full priority-routing surface remains green
- [ ] Visual smoke on a local realm-server: confirm a manual `_reindex` (priority 10) lands on a quiet server when a parallel from-scratch reindex (priority 0) is occupying another server's queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

