### PR TITLE
host: drop dead StackItem.closeAfterSaving / CreateCardFn.closeAfterCreating

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2330,7 +2330,6 @@ export type CreateCardFn = (
   ref: CodeRef,
   relativeTo: URL | undefined,
   opts?: {
-    closeAfterCreating?: boolean;
     realmURL?: URL; // the realm to create the card in
     localDir?: LocalPath; // the local directory path within the realm to create the card file
     doc?: LooseSingleCardDocument; // initial data for the card

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -158,7 +158,6 @@ export default class InteractSubmode extends Component {
     opts?: {
       realmURL?: URL;
       localDir?: LocalPath;
-      closeAfterCreating?: boolean;
       doc?: LooseSingleCardDocument; // fill in card data with values
       cardModeAfterCreation?: Format;
     },

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -188,7 +188,6 @@ export default class InteractSubmode extends Component {
       id: localId,
       format: opts?.cardModeAfterCreation ?? 'edit',
       request: new Deferred(),
-      closeAfterSaving: opts?.closeAfterCreating,
       stackIndex,
       type: 'card',
     });

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -12,7 +12,6 @@ interface Args {
   stackIndex: number;
   id: string;
   type?: StackItemType;
-  closeAfterSaving?: boolean;
   useBaseTemplate?: boolean;
   relationshipContext?: {
     fieldName?: string;
@@ -54,18 +53,16 @@ export function detectStackItemTypeForTarget(
 }
 
 export class StackItem {
-  // `format`, `request`, `closeAfterSaving`, `useBaseTemplate` are
-  // tracked so that callers can mutate them IN PLACE (e.g. flipping
-  // `format` from 'isolated' → 'edit') without replacing the StackItem
-  // instance. Replacing the instance forces Glimmer's `{{#each}}` to
-  // destroy and re-mount the entire stack-item subtree — losing scroll
-  // position, DOM state, view transitions, and triggering
-  // prefersWideFormat to narrow then re-expand. In-place mutation lets
-  // shared-template formats (CardDef where `static isolated === static
-  // edit`) flip without remounting.
+  // `format`, `request`, `useBaseTemplate` are tracked so that callers
+  // can mutate them IN PLACE (e.g. flipping `format` from 'isolated' →
+  // 'edit') without replacing the StackItem instance. Replacing the
+  // instance forces Glimmer's `{{#each}}` to destroy and re-mount the
+  // entire stack-item subtree — losing scroll position, DOM state,
+  // view transitions, and triggering prefersWideFormat to narrow then
+  // re-expand. In-place mutation lets shared-template formats (CardDef
+  // where `static isolated === static edit`) flip without remounting.
   @tracked format: Format;
   @tracked request?: Deferred<string>;
-  @tracked closeAfterSaving?: boolean;
   @tracked useBaseTemplate?: boolean;
   stackIndex: number;
   type: StackItemType;
@@ -84,7 +81,6 @@ export class StackItem {
       stackIndex,
       id,
       type,
-      closeAfterSaving,
       useBaseTemplate,
       relationshipContext,
     } = args;
@@ -94,7 +90,6 @@ export class StackItem {
     this.request = request;
     this.stackIndex = stackIndex;
     this.type = inferStackItemType(type);
-    this.closeAfterSaving = closeAfterSaving;
     this.useBaseTemplate = useBaseTemplate;
     this.relationshipContext = relationshipContext;
   }
@@ -108,7 +103,6 @@ export class StackItem {
       id,
       format,
       request,
-      closeAfterSaving,
       stackIndex,
       relationshipContext,
       type,
@@ -117,7 +111,6 @@ export class StackItem {
     return new StackItem({
       format,
       request,
-      closeAfterSaving,
       id,
       type,
       stackIndex,


### PR DESCRIPTION
## Summary

Follow-up to #4580. Three of the four `@tracked` additions to `StackItem` (`format`, `request`, `useBaseTemplate`) flow into reactive contexts that genuinely need them. The fourth — `closeAfterSaving` — and the public `CreateCardFn.closeAfterCreating` option that feeds it have been a **runtime no-op for ~2 years**.

## History
- **May 2023** (PR #361, `4bba130e8f`): Introduced as `isLinkedCard` with a real reader: the save handler had `if (item.isLinkedCard) splice` to close the editor when finishing creation of a linked card.
- **March 2024** (PR #1076, `e26d5b8ebf`): The save handler was reworked. The `if (item.isLinkedCard)` branch was removed and replaced by `if (!item.card.id && updatedCard.id) trimItemsFromStack`, which subsumed the linked-card case. **From this commit forward, the field was set but never read.**
- **April 2025** (`0b1341e4fe`): Dead field renamed `isLinkedCard` → `closeAfterSaving`/`closeAfterCreating`. Still no reader.
- **April 2026** (#4580): Dead field gained `@tracked`. Still no reader.

`grep -rn closeAfterSaving packages/host/app` finds only the assignment in `interact-submode.gts`. `grep -rn 'closeAfterCreating: ' packages/` finds zero call-sites passing it. Anyone outside the monorepo passing `closeAfterCreating: true` has been getting identical runtime behavior to omitting it — there is no contract to break.

## Changes
- Drop `closeAfterSaving` from `StackItem` (declaration, `@tracked`, constructor destructuring + assignment, `clone()` body, `Args` interface, the comment listing tracked fields).
- Drop the no-op forwarding `closeAfterSaving: opts?.closeAfterCreating` in `interact-submode.gts:191`.
- Drop `closeAfterCreating` from the public `CreateCardFn` type (`packages/base/card-api.gts:2333`).
- Drop `closeAfterCreating` from the local opts of the private `createCard` in `interact-submode.gts:158-164`.

## Test plan
- [x] `pnpm lint` (js + types) in `packages/host`
- [ ] CI runs the full host suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)