### PR TITLE
CS-10976 PR 8: PagePool dynamic expansion + contraction

### DIFF
--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -291,10 +291,18 @@ export class PagePool {
   // → drop one slot. Reset every time pending appears or expansion
   // fires; see `#contractionLoop`.
   #idleContractionMs: number;
-  // Background tick that drives contraction. Created lazily on the
-  // first expansion (no point ticking when the pool is statically at
-  // `#minPages`); cleared on `closeAll` for test isolation.
+  // Background tick that drives contraction. Started in the
+  // constructor whenever the dynamic-pool envelope can grow
+  // (`#maxBurstPages > #minPages`), even before the first expansion;
+  // cleared on `closeAll` for test isolation.
   #contractionInterval: NodeJS.Timeout | undefined;
+  // Re-entrancy guard for the contraction tick. `setInterval` fires
+  // ticks regardless of whether the previous async tick has resolved,
+  // so two slow ticks could otherwise both pass the cooldown gate and
+  // double-decrement `#maxPages` (or double-shrink the render
+  // semaphore). The flag is held across the awaited `#contractByOne`
+  // call and cleared in `finally`.
+  #contractionInFlight = false;
   // Wall-clock timestamp the pool last became fully idle (no pending
   // waiters on any tab queue or admission semaphore, no in-flight
   // operations the contraction loop should respect). Updated by
@@ -1330,11 +1338,16 @@ export class PagePool {
   // doesn't itself create a tab.
   #tryExpand(): boolean {
     if (this.#maxPages >= this.#maxBurstPages) return false;
+    // Require a resize-capable render semaphore. Otherwise `#maxPages`
+    // would drift away from the actual global concurrency gate (the
+    // semaphore's fixed capacity), and the saturation heuristic would
+    // misreport state. Test stubs that supply only `acquire` keep
+    // working by skipping expansion — same as legacy fixed-pool
+    // mode for them.
+    if (!this.#renderSemaphore?.setCapacity) return false;
     let prev = this.#maxPages;
     this.#maxPages = prev + 1;
-    if (this.#renderSemaphore?.setCapacity) {
-      this.#renderSemaphore.setCapacity(this.#maxPages);
-    }
+    this.#renderSemaphore.setCapacity(this.#maxPages);
     this.#idleObservedAt = undefined;
     log.info(
       `pool expansion: maxPages=${prev}→${this.#maxPages} (burst=${this.#maxBurstPages})`,
@@ -1362,6 +1375,8 @@ export class PagePool {
   // next cooldown window if conditions still hold, walking the pool
   // back to `#minPages` over multiple ticks instead of all at once.
   async #contractionTick(): Promise<void> {
+    if (this.#contractionInFlight) return;
+    this.#contractionInFlight = true;
     try {
       if (this.#maxPages <= this.#minPages) return;
       let idle = this.#observeIdleness();
@@ -1381,15 +1396,18 @@ export class PagePool {
       await this.#contractByOne();
     } catch (e) {
       log.warn('contraction tick failed:', e);
+    } finally {
+      this.#contractionInFlight = false;
     }
   }
 
   // Returns true when the pool has no work in flight and no waiters
   // queued — the precondition for considering contraction. Folds in
   // every queueing layer: per-tab queues, per-affinity file-admission
-  // semaphores, and (when wired) the global render semaphore.
-  // Standbys are not pool entries and do not block idleness — they're
-  // the resource we may be about to drop.
+  // semaphores, and (when wired) the global render semaphore in both
+  // its in-flight and queued-waiter dimensions. Standbys are not pool
+  // entries and do not block idleness — they're the resource we may
+  // be about to drop.
   #observeIdleness(): boolean {
     for (let entries of this.#affinityPages.values()) {
       for (let entry of entries) {
@@ -1402,13 +1420,17 @@ export class PagePool {
       if (sem.inUseCount > 0) return false;
     }
     let renderSem = this.#renderSemaphore;
-    if (
-      renderSem &&
-      'inUseCount' in renderSem &&
-      typeof (renderSem as AsyncSemaphore).inUseCount === 'number' &&
-      (renderSem as AsyncSemaphore).inUseCount > 0
-    ) {
-      return false;
+    if (renderSem) {
+      let asAsync = renderSem as Partial<AsyncSemaphore>;
+      if (typeof asAsync.inUseCount === 'number' && asAsync.inUseCount > 0) {
+        return false;
+      }
+      if (
+        typeof asAsync.pendingCount === 'number' &&
+        asAsync.pendingCount > 0
+      ) {
+        return false;
+      }
     }
     return true;
   }
@@ -1423,6 +1445,57 @@ export class PagePool {
   // `#closeEntry` behaviour), so an immediate re-burst can re-warm
   // via `#tryClaimOrphanContext` without re-fetching.
   async #contractByOne(): Promise<void> {
+    // Pick a victim BEFORE shrinking the cap. If no eligible target
+    // exists (no standby, no fully-idle affinity), abort the tick —
+    // shrinking `#maxPages` without disposing anything would leave
+    // the live cap inconsistent with the actual tab count and
+    // artificially throttle concurrency.
+    let standbyVictim: StandbyEntry | undefined;
+    let oldestAffinity: string | undefined;
+    if (this.#standbys.size > 0) {
+      standbyVictim = this.#selectLRUTab([...this.#standbys]);
+    } else {
+      let oldestStamp = Infinity;
+      for (let [affinityKey, entries] of this.#affinityPages.entries()) {
+        let allIdle = [...entries].every(
+          (entry) =>
+            !entry.closing &&
+            !entry.transitioning &&
+            entry.queue.pendingCount === 0,
+        );
+        if (!allIdle) continue;
+        let lastUsedAt = Math.max(
+          ...[...entries].map((entry) => entry.lastUsedAt),
+        );
+        if (lastUsedAt < oldestStamp) {
+          oldestStamp = lastUsedAt;
+          oldestAffinity = affinityKey;
+        }
+      }
+    }
+    let actualTabs = this.#poolEntryCount() + this.#standbys.size;
+    // Three cases allow shrinking the cap by one:
+    //   1. A standby exists → drop it.
+    //   2. A fully-idle affinity exists → dispose it.
+    //   3. No standbys and no eligible affinity, but the cap is
+    //      over-provisioned vs the actual resource count
+    //      (`#maxPages - 1 >= actualTabs`) → shrink alone. This case
+    //      handles a fully-quiet pool where contraction can drop
+    //      headroom without dropping any resource.
+    // Any other state — there are tabs / standbys but none eligible
+    // (closing, transitioning, pending) — leaves `#maxPages` alone;
+    // the next tick retries once an idle window opens.
+    let canShrinkCapAlone =
+      !standbyVictim && !oldestAffinity && this.#maxPages - 1 >= actualTabs;
+    if (!standbyVictim && !oldestAffinity && !canShrinkCapAlone) {
+      return;
+    }
+
+    // Now shrink the cap and forward the resize to the render
+    // semaphore. Doing the dispose first then the shrink would race
+    // any expand call that observes the still-current cap; doing the
+    // shrink first (after the victim is picked) keeps the visible
+    // state consistent.
     let prev = this.#maxPages;
     this.#maxPages = prev - 1;
     if (this.#renderSemaphore?.setCapacity) {
@@ -1431,48 +1504,28 @@ export class PagePool {
     log.info(
       `pool contraction: maxPages=${prev}→${this.#maxPages} (min=${this.#minPages})`,
     );
-    // Prefer dropping a standby first — it has no affinity warmth.
-    // Use the canonical `#closeEntry` teardown path (rather than just
-    // `context.close()`) so per-page diagnostic state
-    // (`#consoleErrorsByPageId`, `#exceptionKeysByPageId`,
-    // `#affinityKeyByPageId`) is cleaned up; otherwise repeated
-    // expand/contract cycles would leak stale entries for dead
-    // standby pages.
-    if (this.#standbys.size > 0) {
-      let standby = this.#selectLRUTab([...this.#standbys]);
-      this.#standbys.delete(standby);
+    // Standby drop preferred first — it has no affinity warmth. Use
+    // the canonical `#closeEntry` teardown path so per-page
+    // diagnostic state (`#consoleErrorsByPageId`,
+    // `#exceptionKeysByPageId`, `#affinityKeyByPageId`) is cleaned
+    // up; otherwise repeated expand/contract cycles would leak stale
+    // entries for dead standby pages.
+    if (standbyVictim) {
+      this.#standbys.delete(standbyVictim);
       try {
-        await this.#closeEntry(standby);
+        await this.#closeEntry(standbyVictim);
       } catch (e) {
         log.debug('error closing standby during contraction:', e);
       }
       return;
     }
-    // No standby available — pick the affinity whose currently-idle
-    // tabs have the oldest LRU touch. We dispose the whole affinity
-    // (one affinity may own one tab in a typical small pool) — its
-    // BrowserContext is kept in `#sharedContexts` as an orphan for
-    // re-warming.
-    let oldestAffinity: string | undefined;
-    let oldestStamp = Infinity;
-    for (let [affinityKey, entries] of this.#affinityPages.entries()) {
-      let allIdle = [...entries].every(
-        (entry) =>
-          !entry.closing &&
-          !entry.transitioning &&
-          entry.queue.pendingCount === 0,
-      );
-      if (!allIdle) continue;
-      let lastUsedAt = Math.max(
-        ...[...entries].map((entry) => entry.lastUsedAt),
-      );
-      if (lastUsedAt < oldestStamp) {
-        oldestStamp = lastUsedAt;
-        oldestAffinity = affinityKey;
-      }
+    // Otherwise dispose the whole affinity whose tabs are oldest in
+    // LRU touch. The affinity's BrowserContext is kept in
+    // `#sharedContexts` as an orphan for re-warming on the next
+    // burst.
+    if (oldestAffinity) {
+      await this.disposeAffinity(oldestAffinity);
     }
-    if (!oldestAffinity) return;
-    await this.disposeAffinity(oldestAffinity);
   }
 
   async #selectEntryForAffinity(

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -486,6 +486,19 @@ export class PagePool {
         `file-queue admission: cap=${this.#fileAdmissionCap} (affinityTabMax=${this.#affinityTabMax}, deadlock-safety ceiling=${ceiling})`,
       );
     }
+    // Sync the injected render semaphore's capacity to the resolved
+    // `#maxPages`. Prerenderer constructs `AsyncSemaphore(options.
+    // maxPages)` and hands it in; under the dynamic-pool config the
+    // pool's live cap may be smaller (MIN < legacy maxPages) or
+    // larger (INITIAL > legacy maxPages) than that initial value, and
+    // without this sync the saturation trigger
+    // (`inUseCount >= capacity`) reads the wrong cap — expansion
+    // either never fires (live cap < semaphore cap, so the semaphore
+    // never saturates) or global concurrency is silently floored
+    // below `#minPages`.
+    if (this.#renderSemaphore?.setCapacity) {
+      this.#renderSemaphore.setCapacity(this.#maxPages);
+    }
     // Contraction loop is only useful when expansion is reachable —
     // i.e. when the pool is configured to grow beyond `#minPages`.
     // Pools running on the legacy fixed-size config skip the timer
@@ -1419,11 +1432,17 @@ export class PagePool {
       `pool contraction: maxPages=${prev}→${this.#maxPages} (min=${this.#minPages})`,
     );
     // Prefer dropping a standby first — it has no affinity warmth.
+    // Use the canonical `#closeEntry` teardown path (rather than just
+    // `context.close()`) so per-page diagnostic state
+    // (`#consoleErrorsByPageId`, `#exceptionKeysByPageId`,
+    // `#affinityKeyByPageId`) is cleaned up; otherwise repeated
+    // expand/contract cycles would leak stale entries for dead
+    // standby pages.
     if (this.#standbys.size > 0) {
       let standby = this.#selectLRUTab([...this.#standbys]);
       this.#standbys.delete(standby);
       try {
-        await standby.context.close();
+        await this.#closeEntry(standby);
       } catch (e) {
         log.debug('error closing standby during contraction:', e);
       }

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -14,6 +14,10 @@ import { attachRuntimeExceptionCapture } from './runtime-exception-capture';
 
 type RenderSemaphore = {
   acquire(signal?: AbortSignal, priority?: number): Promise<() => void>;
+  // Optional resize hook used by dynamic pool expansion / contraction.
+  // Concrete `AsyncSemaphore` injections always provide it; legacy
+  // tests that stub a minimal acquire-only object are still accepted.
+  setCapacity?: (n: number) => void;
 };
 
 // Exported so cancellation-plumbing unit tests can drive it
@@ -218,6 +222,18 @@ const CONSOLE_ERROR_LIMIT = 50;
 
 export class StandbyTargetNotReadyError extends Error {}
 
+// Strict positive-integer env-var parser used by the dynamic-pool
+// configuration. Returns `undefined` for unset, empty, or otherwise
+// invalid input — including `0` and negatives — which is what the
+// MIN/MAX/INITIAL plumbing expects so it can fall back to the legacy
+// fixed-size path.
+function parsePositiveInt(raw: string | undefined): number | undefined {
+  if (raw === undefined || raw === '') return undefined;
+  let n = Number(raw);
+  if (!Number.isInteger(n) || n < 1) return undefined;
+  return n;
+}
+
 function isExpectedStandbyTargetNotReadyError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;
@@ -253,7 +269,39 @@ export class PagePool {
   // `#maybeEvictOrphanContexts`. Bounded by `#sharedContextCap`.
   #sharedContexts = new Map<string, SharedContext>();
   #sharedContextCap: number;
+  // Live tab-pool capacity. Mutable across the pool's lifetime: starts
+  // at `#minPages` (or `PRERENDER_PAGE_POOL_INITIAL` if set), grows up
+  // to `#maxBurstPages` under saturation, contracts back to `#minPages`
+  // after sustained idle. The standby ceiling tracks `#maxPages + 1`,
+  // and the render semaphore's capacity is kept in sync via
+  // `setCapacity` whenever this changes.
   #maxPages: number;
+  // Idle floor — `#maxPages` never goes below this on contraction. When
+  // `PRERENDER_PAGE_POOL_MIN` is unset and the legacy
+  // `PRERENDER_PAGE_POOL_SIZE` (or `options.maxPages`) drives the
+  // configuration, `#minPages === #maxBurstPages === options.maxPages`
+  // → no expansion or contraction, identical to the pre-dynamic
+  // behaviour.
+  #minPages: number;
+  // Burst ceiling reachable by any priority on saturation. Equal to
+  // `#minPages` when the legacy fixed-size config drives the pool.
+  #maxBurstPages: number;
+  // Wall-time threshold for the contraction tick: `#maxPages > #minPages`
+  // AND no pending waiters anywhere on the pool for at least this long
+  // → drop one slot. Reset every time pending appears or expansion
+  // fires; see `#contractionLoop`.
+  #idleContractionMs: number;
+  // Background tick that drives contraction. Created lazily on the
+  // first expansion (no point ticking when the pool is statically at
+  // `#minPages`); cleared on `closeAll` for test isolation.
+  #contractionInterval: NodeJS.Timeout | undefined;
+  // Wall-clock timestamp the pool last became fully idle (no pending
+  // waiters on any tab queue or admission semaphore, no in-flight
+  // operations the contraction loop should respect). Updated by
+  // `#observeIdleness` and consumed by `#contractionLoop`. `undefined`
+  // means we're either non-idle right now or haven't observed an idle
+  // tick yet since the last burst.
+  #idleObservedAt: number | undefined;
   #affinityTabMax: number;
   #serverURL: string;
   #browserManager: BrowserManager;
@@ -320,13 +368,57 @@ export class PagePool {
     disableStandbyRefill?: boolean;
     onAffinityDisposed?: (affinityKey: string) => void;
     disableFileAdmission?: boolean;
+    // Test-only override: when set, the contraction loop ticks at this
+    // interval (in ms) instead of `#idleContractionMs`. Production
+    // callers leave this undefined and the loop period equals the
+    // contraction wall-time threshold.
+    contractionTickMs?: number;
   }) {
-    this.#maxPages = options.maxPages;
+    // Resolve the dynamic-pool envelope. `PRERENDER_PAGE_POOL_MIN` and
+    // `_MAX` are the new dynamic knobs; when either is unset the pool
+    // collapses to a single fixed size (legacy `PRERENDER_PAGE_POOL_SIZE`
+    // / `options.maxPages` behaviour) — `#minPages === #maxBurstPages`
+    // means no expansion or contraction can fire. `_INITIAL` only
+    // matters when MIN < MAX; it's the boot-time count and defaults to
+    // MIN.
+    let envMin = parsePositiveInt(process.env.PRERENDER_PAGE_POOL_MIN);
+    let envMax = parsePositiveInt(process.env.PRERENDER_PAGE_POOL_MAX);
+    let envInitial = parsePositiveInt(process.env.PRERENDER_PAGE_POOL_INITIAL);
+    if (envMin !== undefined && envMax !== undefined) {
+      if (envMax < envMin) {
+        log.warn(
+          `PRERENDER_PAGE_POOL_MAX=${envMax} < PRERENDER_PAGE_POOL_MIN=${envMin}; clamping MAX to MIN`,
+        );
+        envMax = envMin;
+      }
+      this.#minPages = envMin;
+      this.#maxBurstPages = envMax;
+      this.#maxPages =
+        envInitial !== undefined
+          ? Math.min(Math.max(envInitial, envMin), envMax)
+          : envMin;
+    } else {
+      // Legacy fixed pool. Drives both the floor and the ceiling from
+      // the same value, so contraction and expansion are no-ops.
+      this.#minPages = options.maxPages;
+      this.#maxBurstPages = options.maxPages;
+      this.#maxPages = options.maxPages;
+    }
+    let envContractionMs = parsePositiveInt(
+      process.env.PRERENDER_POOL_IDLE_CONTRACTION_MS,
+    );
+    this.#idleContractionMs = envContractionMs ?? 60_000;
     let envTabMax = Number(process.env.PRERENDER_AFFINITY_TAB_MAX ?? 5);
     if (!Number.isFinite(envTabMax) || envTabMax <= 0) {
       envTabMax = 1;
     }
-    this.#affinityTabMax = Math.min(Math.max(1, envTabMax), this.#maxPages);
+    // Cap by the burst ceiling (the largest the pool can grow to)
+    // rather than the live `#maxPages`. Otherwise the per-affinity cap
+    // wouldn't expand alongside pool expansion, defeating the burst.
+    this.#affinityTabMax = Math.min(
+      Math.max(1, envTabMax),
+      this.#maxBurstPages,
+    );
     if (this.#affinityTabMax < 2) {
       // Degenerate configuration: with only one tab per affinity, the
       // file-queue admission cap clamps to 1 (see `#acquireFileAdmission`)
@@ -340,15 +432,18 @@ export class PagePool {
         `PRERENDER_AFFINITY_TAB_MAX=${this.#affinityTabMax} below 2; file-queue admission can't reserve a slot for module/command work and the self-referential prerender deadlock is not prevented`,
       );
     }
-    // Cap on total shared contexts (active + orphaned). Default to
-    // 2× maxPages so there's headroom for a handful of recently-
-    // evicted contexts to survive as orphans for reuse. Enforced by
+    // Cap on total shared contexts (active + orphaned). Default
+    // scales by the burst ceiling (the largest the pool can grow to)
+    // rather than the live `#maxPages`, so the cap stays stable
+    // across expansion / contraction — otherwise it would balloon
+    // during a burst and evict during contraction, defeating the
+    // warm-cache benefit of keeping orphan contexts. Enforced by
     // `#maybeEvictOrphanContexts` on each release.
     let envSharedCap = Number(
-      process.env.PRERENDER_SHARED_CONTEXT_CAP ?? this.#maxPages * 2,
+      process.env.PRERENDER_SHARED_CONTEXT_CAP ?? this.#maxBurstPages * 2,
     );
     if (!Number.isFinite(envSharedCap) || envSharedCap <= 0) {
-      envSharedCap = this.#maxPages * 2;
+      envSharedCap = this.#maxBurstPages * 2;
     }
     this.#sharedContextCap = Math.max(1, envSharedCap);
     this.#serverURL = options.serverURL;
@@ -390,6 +485,19 @@ export class PagePool {
       log.info(
         `file-queue admission: cap=${this.#fileAdmissionCap} (affinityTabMax=${this.#affinityTabMax}, deadlock-safety ceiling=${ceiling})`,
       );
+    }
+    // Contraction loop is only useful when expansion is reachable —
+    // i.e. when the pool is configured to grow beyond `#minPages`.
+    // Pools running on the legacy fixed-size config skip the timer
+    // entirely so test isolation and process exit cleanup don't have
+    // to chase a ticker that does nothing.
+    if (this.#maxBurstPages > this.#minPages) {
+      let tickMs = options.contractionTickMs ?? this.#idleContractionMs;
+      this.#contractionInterval = setInterval(
+        () => this.#contractionTick(),
+        tickMs,
+      );
+      this.#contractionInterval.unref?.();
     }
   }
 
@@ -684,6 +792,16 @@ export class PagePool {
     // Every release path (success + the error paths below) funnels
     // through `releaseAdmission?.()`, which already runs idle cleanup
     // via the wrapper installed in `#acquireFileAdmission`.
+    //
+    // Saturation expansion: if the render semaphore is full, the
+    // request will queue. Try to grow the pool first so the standby
+    // refill kicked off by `#ensureStandbyPool` below has a slot to
+    // create into. Bumps the semaphore's capacity in lockstep, which
+    // also un-blocks the `#renderSemaphore.acquire` call further down
+    // for this caller. No-op once `#maxPages` has reached
+    // `#maxBurstPages`, and a no-op when the pool is configured at a
+    // legacy fixed size (`#minPages === #maxBurstPages`).
+    this.#maybeExpandUnderSaturation();
     let startupStart = Date.now();
     try {
       await this.#ensureStandbyPool();
@@ -859,6 +977,10 @@ export class PagePool {
   }
 
   async closeAll(): Promise<void> {
+    if (this.#contractionInterval) {
+      clearInterval(this.#contractionInterval);
+      this.#contractionInterval = undefined;
+    }
     let ensuring = this.#ensuringStandbys;
     this.#ensuringStandbys = null;
     if (ensuring) {
@@ -1145,6 +1267,193 @@ export class PagePool {
       count += entries.size;
     }
     return count;
+  }
+
+  // Live pool capacity. Equal to the static `maxPages` when the pool
+  // is configured at a legacy fixed size; mutates between `#minPages`
+  // and `#maxBurstPages` under the dynamic-pool config. Exposed for
+  // diagnostics and tests; production routing reads it indirectly via
+  // the render semaphore's `capacity`.
+  get currentMaxPages(): number {
+    return this.#maxPages;
+  }
+
+  get minPages(): number {
+    return this.#minPages;
+  }
+
+  get maxBurstPages(): number {
+    return this.#maxBurstPages;
+  }
+
+  // Inspect the render-semaphore state and trigger expansion when the
+  // arriving caller would otherwise queue on a saturated cap. Hot-path
+  // hook off `getPage` — kept defensively narrow (only acts when the
+  // semaphore is a concrete `AsyncSemaphore` with the expected fields)
+  // so test stubs don't get unexpected expansion behaviour.
+  #maybeExpandUnderSaturation(): void {
+    if (this.#maxBurstPages <= this.#minPages) return;
+    let renderSem = this.#renderSemaphore;
+    if (
+      !renderSem ||
+      !('inUseCount' in renderSem) ||
+      typeof (renderSem as AsyncSemaphore).inUseCount !== 'number' ||
+      typeof (renderSem as AsyncSemaphore).capacity !== 'number'
+    ) {
+      return;
+    }
+    let sem = renderSem as AsyncSemaphore;
+    if (sem.inUseCount >= sem.capacity) {
+      this.#tryExpand();
+    }
+  }
+
+  // Best-effort synchronous expansion of the live pool capacity. Bumps
+  // `#maxPages` by one (no-op when already at `#maxBurstPages`),
+  // forwards the resize to the render semaphore, and resets the
+  // contraction loop's idle observation. Returns true if `#maxPages`
+  // grew. Caller is expected to follow up with whatever spawn / refill
+  // path it was about to take — expansion just lifts the ceiling, it
+  // doesn't itself create a tab.
+  #tryExpand(): boolean {
+    if (this.#maxPages >= this.#maxBurstPages) return false;
+    let prev = this.#maxPages;
+    this.#maxPages = prev + 1;
+    if (this.#renderSemaphore?.setCapacity) {
+      this.#renderSemaphore.setCapacity(this.#maxPages);
+    }
+    this.#idleObservedAt = undefined;
+    log.info(
+      `pool expansion: maxPages=${prev}→${this.#maxPages} (burst=${this.#maxBurstPages})`,
+    );
+    return true;
+  }
+
+  // Periodic check that drives contraction. Runs on a `setInterval`
+  // started in the constructor only when the pool is configured to
+  // grow (`#maxBurstPages > #minPages`). All gates have to pass on a
+  // single tick before any tab is dropped:
+  //
+  //   - the live cap must be above `#minPages` (room to shrink),
+  //   - no waiters anywhere on the pool (per-tab queues, file-
+  //     admission semaphores, render semaphore) — checked via
+  //     `#observeIdleness`,
+  //   - the idle state must have held continuously for at least
+  //     `#idleContractionMs` (hysteresis),
+  //   - at least two idle pool entries OR an idle standby exist
+  //     (don't contract through saturation; the warmth-preserving
+  //     drop rule below will pick one).
+  //
+  // Bounded rate: at most one tab is dropped per tick. When a drop
+  // happens the loop continues running and will fire again after the
+  // next cooldown window if conditions still hold, walking the pool
+  // back to `#minPages` over multiple ticks instead of all at once.
+  async #contractionTick(): Promise<void> {
+    try {
+      if (this.#maxPages <= this.#minPages) return;
+      let idle = this.#observeIdleness();
+      if (!idle) {
+        this.#idleObservedAt = undefined;
+        return;
+      }
+      let now = Date.now();
+      if (this.#idleObservedAt === undefined) {
+        this.#idleObservedAt = now;
+        return;
+      }
+      if (now - this.#idleObservedAt < this.#idleContractionMs) return;
+      // All gates passed: shrink. Reset the observation so the next
+      // contraction respects the cooldown window from this point.
+      this.#idleObservedAt = now;
+      await this.#contractByOne();
+    } catch (e) {
+      log.warn('contraction tick failed:', e);
+    }
+  }
+
+  // Returns true when the pool has no work in flight and no waiters
+  // queued — the precondition for considering contraction. Folds in
+  // every queueing layer: per-tab queues, per-affinity file-admission
+  // semaphores, and (when wired) the global render semaphore.
+  // Standbys are not pool entries and do not block idleness — they're
+  // the resource we may be about to drop.
+  #observeIdleness(): boolean {
+    for (let entries of this.#affinityPages.values()) {
+      for (let entry of entries) {
+        if (entry.closing) continue;
+        if (entry.queue.pendingCount !== 0) return false;
+      }
+    }
+    for (let sem of this.#fileAdmission.values()) {
+      if (sem.pendingCount > 0) return false;
+      if (sem.inUseCount > 0) return false;
+    }
+    let renderSem = this.#renderSemaphore;
+    if (
+      renderSem &&
+      'inUseCount' in renderSem &&
+      typeof (renderSem as AsyncSemaphore).inUseCount === 'number' &&
+      (renderSem as AsyncSemaphore).inUseCount > 0
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  // Drop one slot. Warmth-preserving rule: prefer a standby (no
+  // affinity warmth to lose) over an active pool entry. When dropping
+  // an active entry, pick the affinity whose tabs have the oldest LRU
+  // touch among currently-idle entries — that affinity has been
+  // quietest, so dropping it sacrifices the least warm-routing
+  // value. The dropped entry's BrowserContext is preserved as an
+  // orphan in `#sharedContexts` (existing `disposeAffinity` /
+  // `#closeEntry` behaviour), so an immediate re-burst can re-warm
+  // via `#tryClaimOrphanContext` without re-fetching.
+  async #contractByOne(): Promise<void> {
+    let prev = this.#maxPages;
+    this.#maxPages = prev - 1;
+    if (this.#renderSemaphore?.setCapacity) {
+      this.#renderSemaphore.setCapacity(this.#maxPages);
+    }
+    log.info(
+      `pool contraction: maxPages=${prev}→${this.#maxPages} (min=${this.#minPages})`,
+    );
+    // Prefer dropping a standby first — it has no affinity warmth.
+    if (this.#standbys.size > 0) {
+      let standby = this.#selectLRUTab([...this.#standbys]);
+      this.#standbys.delete(standby);
+      try {
+        await standby.context.close();
+      } catch (e) {
+        log.debug('error closing standby during contraction:', e);
+      }
+      return;
+    }
+    // No standby available — pick the affinity whose currently-idle
+    // tabs have the oldest LRU touch. We dispose the whole affinity
+    // (one affinity may own one tab in a typical small pool) — its
+    // BrowserContext is kept in `#sharedContexts` as an orphan for
+    // re-warming.
+    let oldestAffinity: string | undefined;
+    let oldestStamp = Infinity;
+    for (let [affinityKey, entries] of this.#affinityPages.entries()) {
+      let allIdle = [...entries].every(
+        (entry) =>
+          !entry.closing &&
+          !entry.transitioning &&
+          entry.queue.pendingCount === 0,
+      );
+      if (!allIdle) continue;
+      let lastUsedAt = Math.max(
+        ...[...entries].map((entry) => entry.lastUsedAt),
+      );
+      if (lastUsedAt < oldestStamp) {
+        oldestStamp = lastUsedAt;
+        oldestAffinity = affinityKey;
+      }
+    }
+    if (!oldestAffinity) return;
+    await this.disposeAffinity(oldestAffinity);
   }
 
   async #selectEntryForAffinity(
@@ -1715,6 +2024,21 @@ export class PagePool {
     // Keep the exceptionKeys mapping — there's no further follow-up
     // event to dispatch, but a stale-but-harmless entry is better
     // than a phantom remove if V8 ever re-fires for the same id.
+  }
+
+  // Test-only seam: drives one expansion tick. Production callers go
+  // through `getPage` → `#maybeExpandUnderSaturation`, but unit tests
+  // exercising the dynamic-pool envelope shouldn't need a real Chrome
+  // round-trip. Returns `true` if `#maxPages` grew on this call.
+  __test_tryExpand(): boolean {
+    return this.#tryExpand();
+  }
+
+  // Test-only seam: invokes the saturation-detection hook the way
+  // `getPage` does, so unit tests can assert that expansion fires
+  // when the render semaphore is at capacity.
+  __test_maybeExpandUnderSaturation(): void {
+    this.#maybeExpandUnderSaturation();
   }
 
   // Test-only seam: writes a `source: 'exception'` entry directly

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -178,6 +178,7 @@ import './prerender-affinity-activity-test';
 import './prerender-batch-ownership-test';
 import './prerender-cancellation-test';
 import './async-semaphore-test';
+import './page-pool-expansion-test';
 import './page-pool-priority-test';
 import './runtime-exception-capture-test';
 import './clamp-serialized-error-test';

--- a/packages/realm-server/tests/page-pool-expansion-test.ts
+++ b/packages/realm-server/tests/page-pool-expansion-test.ts
@@ -77,10 +77,10 @@ function makeStubPool(opts: StubOptions) {
   };
 }
 
-function withEnv(
+async function withEnv(
   vars: Record<string, string | undefined>,
-  fn: () => void,
-): void {
+  fn: () => void | Promise<void>,
+): Promise<void> {
   let prev: Record<string, string | undefined> = {};
   for (let key of Object.keys(vars)) {
     prev[key] = process.env[key];
@@ -93,7 +93,7 @@ function withEnv(
         process.env[key] = value;
       }
     }
-    fn();
+    await fn();
   } finally {
     for (let [key, value] of Object.entries(prev)) {
       if (value === undefined) {
@@ -124,8 +124,8 @@ module(basename(__filename), function () {
       return stub;
     }
 
-    test('legacy fixed-pool config: MIN === MAX === options.maxPages when env vars unset', function (assert) {
-      withEnv(
+    test('legacy fixed-pool config: MIN === MAX === options.maxPages when env vars unset', async function (assert) {
+      await withEnv(
         {
           PRERENDER_PAGE_POOL_MIN: undefined,
           PRERENDER_PAGE_POOL_MAX: undefined,
@@ -152,8 +152,8 @@ module(basename(__filename), function () {
       );
     });
 
-    test('dynamic-pool config: MIN/MAX env vars set the envelope', function (assert) {
-      withEnv(
+    test('dynamic-pool config: MIN/MAX env vars set the envelope', async function (assert) {
+      await withEnv(
         {
           PRERENDER_PAGE_POOL_MIN: '2',
           PRERENDER_PAGE_POOL_MAX: '6',
@@ -172,8 +172,8 @@ module(basename(__filename), function () {
       );
     });
 
-    test('dynamic-pool config: INITIAL is respected and clamped to [MIN, MAX]', function (assert) {
-      withEnv(
+    test('dynamic-pool config: INITIAL is respected and clamped to [MIN, MAX]', async function (assert) {
+      await withEnv(
         {
           PRERENDER_PAGE_POOL_MIN: '2',
           PRERENDER_PAGE_POOL_MAX: '6',
@@ -186,7 +186,7 @@ module(basename(__filename), function () {
       );
 
       // Clamped above MAX
-      withEnv(
+      await withEnv(
         {
           PRERENDER_PAGE_POOL_MIN: '2',
           PRERENDER_PAGE_POOL_MAX: '6',
@@ -203,7 +203,7 @@ module(basename(__filename), function () {
       );
 
       // Clamped below MIN
-      withEnv(
+      await withEnv(
         {
           PRERENDER_PAGE_POOL_MIN: '3',
           PRERENDER_PAGE_POOL_MAX: '6',
@@ -220,8 +220,8 @@ module(basename(__filename), function () {
       );
     });
 
-    test('dynamic-pool config: MAX < MIN is clamped to MIN with a warning', function (assert) {
-      withEnv(
+    test('dynamic-pool config: MAX < MIN is clamped to MIN with a warning', async function (assert) {
+      await withEnv(
         {
           PRERENDER_PAGE_POOL_MIN: '6',
           PRERENDER_PAGE_POOL_MAX: '2',
@@ -239,8 +239,8 @@ module(basename(__filename), function () {
       );
     });
 
-    test('only one env var set: MIN xor MAX falls back to legacy config', function (assert) {
-      withEnv(
+    test('only one env var set: MIN xor MAX falls back to legacy config', async function (assert) {
+      await withEnv(
         { PRERENDER_PAGE_POOL_MIN: '2', PRERENDER_PAGE_POOL_MAX: undefined },
         () => {
           let { pool } = track(makeStubPool({ maxPages: 4 }));
@@ -253,7 +253,7 @@ module(basename(__filename), function () {
         },
       );
 
-      withEnv(
+      await withEnv(
         { PRERENDER_PAGE_POOL_MIN: undefined, PRERENDER_PAGE_POOL_MAX: '6' },
         () => {
           let { pool } = track(makeStubPool({ maxPages: 4 }));
@@ -263,11 +263,11 @@ module(basename(__filename), function () {
       );
     });
 
-    test('invalid env values fall back to legacy config', function (assert) {
+    test('invalid env values fall back to legacy config', async function (assert) {
       // "0" is the SSM placeholder used by the operational rollout — must be
       // treated as "unset" to keep PR 7's apply a no-op.
       for (let invalid of ['0', '-1', '', ' ', '1.5', 'abc', 'null']) {
-        withEnv(
+        await withEnv(
           {
             PRERENDER_PAGE_POOL_MIN: invalid,
             PRERENDER_PAGE_POOL_MAX: '6',
@@ -304,7 +304,7 @@ module(basename(__filename), function () {
     }
 
     test('saturation expansion: render-semaphore at capacity triggers `#tryExpand`', async function (assert) {
-      withEnv(
+      await withEnv(
         {
           PRERENDER_PAGE_POOL_MIN: '2',
           PRERENDER_PAGE_POOL_MAX: '4',
@@ -347,7 +347,7 @@ module(basename(__filename), function () {
     });
 
     test('expansion is bounded by maxBurstPages', async function (assert) {
-      withEnv(
+      await withEnv(
         {
           PRERENDER_PAGE_POOL_MIN: '2',
           PRERENDER_PAGE_POOL_MAX: '3',
@@ -383,7 +383,7 @@ module(basename(__filename), function () {
     });
 
     test('contraction respects cooldown: no shrink within idle window', async function (assert) {
-      withEnv(
+      await withEnv(
         {
           PRERENDER_PAGE_POOL_MIN: '2',
           PRERENDER_PAGE_POOL_MAX: '4',
@@ -416,7 +416,7 @@ module(basename(__filename), function () {
     });
 
     test('contraction shrinks one tab per tick after cooldown elapses', async function (assert) {
-      withEnv(
+      await withEnv(
         {
           PRERENDER_PAGE_POOL_MIN: '2',
           PRERENDER_PAGE_POOL_MAX: '4',
@@ -455,8 +455,8 @@ module(basename(__filename), function () {
       );
     });
 
-    test('contraction is blocked while waiters are pending on the render semaphore', async function (assert) {
-      withEnv(
+    test('contraction is blocked while a render semaphore slot is in use', async function (assert) {
+      await withEnv(
         {
           PRERENDER_PAGE_POOL_MIN: '2',
           PRERENDER_PAGE_POOL_MAX: '4',
@@ -497,7 +497,7 @@ module(basename(__filename), function () {
     });
 
     test('legacy fixed pool: contraction loop never starts (no timer leak)', async function (assert) {
-      withEnv(
+      await withEnv(
         {
           PRERENDER_PAGE_POOL_MIN: undefined,
           PRERENDER_PAGE_POOL_MAX: undefined,

--- a/packages/realm-server/tests/page-pool-expansion-test.ts
+++ b/packages/realm-server/tests/page-pool-expansion-test.ts
@@ -1,0 +1,525 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { PagePool } from '../prerender/page-pool';
+import { AsyncSemaphore } from '../prerender/async-semaphore';
+
+// Configuration + dynamic-pool envelope tests for `PagePool`. The full
+// expansion / contraction state machine drives a real Chrome under the
+// integration tests in `prerendering-test.ts`; what's pinned down here
+// is the contract of the new env-var configuration surface and the
+// observable shape of `currentMaxPages` / `minPages` / `maxBurstPages`
+// across legacy vs. dynamic configurations.
+//
+// The browser side of PagePool is stubbed with a no-op fake (same
+// pattern as the existing `makeStubPagePool` helper in
+// `prerendering-test.ts`) so these tests don't pay Chrome startup cost
+// per assertion.
+
+interface StubOptions {
+  maxPages: number;
+  renderSemaphore?: AsyncSemaphore;
+  contractionTickMs?: number;
+}
+
+function makeStubPool(opts: StubOptions) {
+  let contextsCreated = 0;
+  let contextsClosed = 0;
+  let browser = {
+    async createBrowserContext() {
+      contextsCreated++;
+      let context: any;
+      context = {
+        async newPage() {
+          return {
+            async goto() {},
+            async waitForFunction() {
+              return true;
+            },
+            async evaluate(fn: any, ...args: any[]) {
+              return fn(...args);
+            },
+            async close() {},
+            browserContext() {
+              return context;
+            },
+            removeAllListeners() {},
+            on() {},
+          };
+        },
+        async close() {
+          contextsClosed++;
+        },
+      };
+      return context;
+    },
+  };
+  let browserManager = {
+    async getBrowser() {
+      return browser as any;
+    },
+    async cleanupUserDataDirs() {},
+  };
+  let pool = new PagePool({
+    maxPages: opts.maxPages,
+    serverURL: 'http://localhost',
+    browserManager: browserManager as any,
+    boxelHostURL: 'http://localhost:4200',
+    standbyTimeoutMs: 500,
+    renderSemaphore: opts.renderSemaphore,
+    disableStandbyRefill: true, // tests don't need standby creation
+    disableFileAdmission: true,
+    contractionTickMs: opts.contractionTickMs,
+  });
+  return {
+    pool,
+    contextsCreated: () => contextsCreated,
+    contextsClosed: () => contextsClosed,
+  };
+}
+
+function withEnv(
+  vars: Record<string, string | undefined>,
+  fn: () => void,
+): void {
+  let prev: Record<string, string | undefined> = {};
+  for (let key of Object.keys(vars)) {
+    prev[key] = process.env[key];
+  }
+  try {
+    for (let [key, value] of Object.entries(vars)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    fn();
+  } finally {
+    for (let [key, value] of Object.entries(prev)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+module(basename(__filename), function () {
+  module('PagePool dynamic-pool configuration', function (hooks) {
+    let teardown: Array<() => Promise<void>> = [];
+
+    hooks.afterEach(async () => {
+      for (let fn of teardown.splice(0)) {
+        try {
+          await fn();
+        } catch {
+          // best-effort
+        }
+      }
+    });
+
+    function track(stub: { pool: PagePool }) {
+      teardown.push(() => stub.pool.closeAll());
+      return stub;
+    }
+
+    test('legacy fixed-pool config: MIN === MAX === options.maxPages when env vars unset', function (assert) {
+      withEnv(
+        {
+          PRERENDER_PAGE_POOL_MIN: undefined,
+          PRERENDER_PAGE_POOL_MAX: undefined,
+          PRERENDER_PAGE_POOL_INITIAL: undefined,
+        },
+        () => {
+          let { pool } = track(makeStubPool({ maxPages: 4 }));
+          assert.strictEqual(
+            pool.minPages,
+            4,
+            'minPages tracks options.maxPages',
+          );
+          assert.strictEqual(
+            pool.maxBurstPages,
+            4,
+            'maxBurstPages tracks options.maxPages',
+          );
+          assert.strictEqual(
+            pool.currentMaxPages,
+            4,
+            'currentMaxPages tracks options.maxPages',
+          );
+        },
+      );
+    });
+
+    test('dynamic-pool config: MIN/MAX env vars set the envelope', function (assert) {
+      withEnv(
+        {
+          PRERENDER_PAGE_POOL_MIN: '2',
+          PRERENDER_PAGE_POOL_MAX: '6',
+          PRERENDER_PAGE_POOL_INITIAL: undefined,
+        },
+        () => {
+          let { pool } = track(makeStubPool({ maxPages: 4 }));
+          assert.strictEqual(pool.minPages, 2, 'minPages from env');
+          assert.strictEqual(pool.maxBurstPages, 6, 'maxBurstPages from env');
+          assert.strictEqual(
+            pool.currentMaxPages,
+            2,
+            'currentMaxPages defaults to MIN when INITIAL unset',
+          );
+        },
+      );
+    });
+
+    test('dynamic-pool config: INITIAL is respected and clamped to [MIN, MAX]', function (assert) {
+      withEnv(
+        {
+          PRERENDER_PAGE_POOL_MIN: '2',
+          PRERENDER_PAGE_POOL_MAX: '6',
+          PRERENDER_PAGE_POOL_INITIAL: '4',
+        },
+        () => {
+          let { pool } = track(makeStubPool({ maxPages: 99 }));
+          assert.strictEqual(pool.currentMaxPages, 4, 'INITIAL=4 respected');
+        },
+      );
+
+      // Clamped above MAX
+      withEnv(
+        {
+          PRERENDER_PAGE_POOL_MIN: '2',
+          PRERENDER_PAGE_POOL_MAX: '6',
+          PRERENDER_PAGE_POOL_INITIAL: '99',
+        },
+        () => {
+          let { pool } = track(makeStubPool({ maxPages: 99 }));
+          assert.strictEqual(
+            pool.currentMaxPages,
+            6,
+            'INITIAL clamped down to MAX',
+          );
+        },
+      );
+
+      // Clamped below MIN
+      withEnv(
+        {
+          PRERENDER_PAGE_POOL_MIN: '3',
+          PRERENDER_PAGE_POOL_MAX: '6',
+          PRERENDER_PAGE_POOL_INITIAL: '1',
+        },
+        () => {
+          let { pool } = track(makeStubPool({ maxPages: 99 }));
+          assert.strictEqual(
+            pool.currentMaxPages,
+            3,
+            'INITIAL clamped up to MIN',
+          );
+        },
+      );
+    });
+
+    test('dynamic-pool config: MAX < MIN is clamped to MIN with a warning', function (assert) {
+      withEnv(
+        {
+          PRERENDER_PAGE_POOL_MIN: '6',
+          PRERENDER_PAGE_POOL_MAX: '2',
+        },
+        () => {
+          let { pool } = track(makeStubPool({ maxPages: 99 }));
+          assert.strictEqual(pool.minPages, 6);
+          assert.strictEqual(
+            pool.maxBurstPages,
+            6,
+            'MAX clamped to MIN — never below floor',
+          );
+          assert.strictEqual(pool.currentMaxPages, 6);
+        },
+      );
+    });
+
+    test('only one env var set: MIN xor MAX falls back to legacy config', function (assert) {
+      withEnv(
+        { PRERENDER_PAGE_POOL_MIN: '2', PRERENDER_PAGE_POOL_MAX: undefined },
+        () => {
+          let { pool } = track(makeStubPool({ maxPages: 4 }));
+          assert.strictEqual(
+            pool.minPages,
+            4,
+            'MIN alone is ignored — needs both for dynamic mode',
+          );
+          assert.strictEqual(pool.maxBurstPages, 4);
+        },
+      );
+
+      withEnv(
+        { PRERENDER_PAGE_POOL_MIN: undefined, PRERENDER_PAGE_POOL_MAX: '6' },
+        () => {
+          let { pool } = track(makeStubPool({ maxPages: 4 }));
+          assert.strictEqual(pool.minPages, 4, 'MAX alone is ignored');
+          assert.strictEqual(pool.maxBurstPages, 4);
+        },
+      );
+    });
+
+    test('invalid env values fall back to legacy config', function (assert) {
+      // "0" is the SSM placeholder used by the operational rollout — must be
+      // treated as "unset" to keep PR 7's apply a no-op.
+      for (let invalid of ['0', '-1', '', ' ', '1.5', 'abc', 'null']) {
+        withEnv(
+          {
+            PRERENDER_PAGE_POOL_MIN: invalid,
+            PRERENDER_PAGE_POOL_MAX: '6',
+          },
+          () => {
+            let { pool } = track(makeStubPool({ maxPages: 4 }));
+            assert.strictEqual(
+              pool.minPages,
+              4,
+              `MIN="${invalid}" treated as unset → legacy fixed pool`,
+            );
+          },
+        );
+      }
+    });
+  });
+
+  module('PagePool expansion / contraction', function (hooks) {
+    let teardown: Array<() => Promise<void>> = [];
+
+    hooks.afterEach(async () => {
+      for (let fn of teardown.splice(0)) {
+        try {
+          await fn();
+        } catch {
+          // best-effort
+        }
+      }
+    });
+
+    function track(stub: { pool: PagePool }) {
+      teardown.push(() => stub.pool.closeAll());
+      return stub;
+    }
+
+    test('saturation expansion: render-semaphore at capacity triggers `#tryExpand`', async function (assert) {
+      withEnv(
+        {
+          PRERENDER_PAGE_POOL_MIN: '2',
+          PRERENDER_PAGE_POOL_MAX: '4',
+        },
+        async () => {
+          let semaphore = new AsyncSemaphore(2); // matches MIN
+          let { pool } = track(
+            makeStubPool({
+              maxPages: 4,
+              renderSemaphore: semaphore,
+            }),
+          );
+          assert.strictEqual(pool.currentMaxPages, 2, 'starts at MIN');
+          assert.strictEqual(semaphore.capacity, 2, 'semaphore starts at MIN');
+
+          // Saturate the render semaphore by holding both slots.
+          let release1 = await semaphore.acquire();
+          let release2 = await semaphore.acquire();
+          assert.strictEqual(semaphore.inUseCount, 2, 'semaphore saturated');
+
+          // Trigger the saturation-detection hook. `getPage` would normally
+          // call this, but we exercise the contract directly so the test
+          // doesn't depend on Chrome.
+          pool.__test_maybeExpandUnderSaturation();
+          assert.strictEqual(
+            pool.currentMaxPages,
+            3,
+            'pool expanded by 1 under saturation',
+          );
+          assert.strictEqual(
+            semaphore.capacity,
+            3,
+            'render semaphore tracks new max',
+          );
+
+          release1();
+          release2();
+        },
+      );
+    });
+
+    test('expansion is bounded by maxBurstPages', async function (assert) {
+      withEnv(
+        {
+          PRERENDER_PAGE_POOL_MIN: '2',
+          PRERENDER_PAGE_POOL_MAX: '3',
+        },
+        async () => {
+          let semaphore = new AsyncSemaphore(2);
+          let { pool } = track(
+            makeStubPool({
+              maxPages: 4,
+              renderSemaphore: semaphore,
+            }),
+          );
+          let release1 = await semaphore.acquire();
+          let release2 = await semaphore.acquire();
+          // Two saturation triggers — should expand once to 3, then stop.
+          pool.__test_maybeExpandUnderSaturation();
+          // Bump the semaphore in-flight count so saturation still applies
+          // post-expansion (capacity=3 after first expand).
+          let release3 = await semaphore.acquire();
+          pool.__test_maybeExpandUnderSaturation();
+          assert.strictEqual(
+            pool.currentMaxPages,
+            3,
+            'pool capped at maxBurstPages=3',
+          );
+          assert.strictEqual(semaphore.capacity, 3);
+
+          release1();
+          release2();
+          release3();
+        },
+      );
+    });
+
+    test('contraction respects cooldown: no shrink within idle window', async function (assert) {
+      withEnv(
+        {
+          PRERENDER_PAGE_POOL_MIN: '2',
+          PRERENDER_PAGE_POOL_MAX: '4',
+          // Long cooldown so the tick can fire once without shrinking.
+          PRERENDER_POOL_IDLE_CONTRACTION_MS: '60000',
+        },
+        async () => {
+          let semaphore = new AsyncSemaphore(2);
+          let { pool } = track(
+            makeStubPool({
+              maxPages: 4,
+              renderSemaphore: semaphore,
+              contractionTickMs: 10,
+            }),
+          );
+          // Force the live cap above MIN.
+          pool.__test_tryExpand();
+          assert.strictEqual(pool.currentMaxPages, 3, 'expanded to 3');
+
+          // Wait long enough for several contraction ticks to fire — none
+          // should drop a tab because the cooldown hasn't elapsed.
+          await new Promise((r) => setTimeout(r, 80));
+          assert.strictEqual(
+            pool.currentMaxPages,
+            3,
+            'cooldown blocks contraction',
+          );
+        },
+      );
+    });
+
+    test('contraction shrinks one tab per tick after cooldown elapses', async function (assert) {
+      withEnv(
+        {
+          PRERENDER_PAGE_POOL_MIN: '2',
+          PRERENDER_PAGE_POOL_MAX: '4',
+          // Tiny cooldown so the test doesn't have to wait minutes.
+          PRERENDER_POOL_IDLE_CONTRACTION_MS: '20',
+        },
+        async () => {
+          let semaphore = new AsyncSemaphore(2);
+          let { pool } = track(
+            makeStubPool({
+              maxPages: 4,
+              renderSemaphore: semaphore,
+              contractionTickMs: 10,
+            }),
+          );
+          // Expand twice: 2 → 3 → 4.
+          pool.__test_tryExpand();
+          pool.__test_tryExpand();
+          assert.strictEqual(pool.currentMaxPages, 4, 'expanded to MAX');
+
+          // Wait long enough for two cooldown windows + several ticks.
+          // First tick observes idle; second tick (after cooldown) shrinks
+          // by one. Repeat until we hit MIN.
+          await new Promise((r) => setTimeout(r, 200));
+          assert.strictEqual(
+            pool.currentMaxPages,
+            2,
+            'pool shrunk back to MIN over multiple ticks',
+          );
+          assert.strictEqual(
+            semaphore.capacity,
+            2,
+            'render semaphore tracks contraction',
+          );
+        },
+      );
+    });
+
+    test('contraction is blocked while waiters are pending on the render semaphore', async function (assert) {
+      withEnv(
+        {
+          PRERENDER_PAGE_POOL_MIN: '2',
+          PRERENDER_PAGE_POOL_MAX: '4',
+          PRERENDER_POOL_IDLE_CONTRACTION_MS: '20',
+        },
+        async () => {
+          let semaphore = new AsyncSemaphore(2);
+          let { pool } = track(
+            makeStubPool({
+              maxPages: 4,
+              renderSemaphore: semaphore,
+              contractionTickMs: 10,
+            }),
+          );
+          pool.__test_tryExpand();
+          assert.strictEqual(pool.currentMaxPages, 3);
+
+          // Hold a slot — semaphore.inUseCount=1 — so the idle gate fails
+          // every tick.
+          let release = await semaphore.acquire();
+          await new Promise((r) => setTimeout(r, 200));
+          assert.strictEqual(
+            pool.currentMaxPages,
+            3,
+            'pending in-flight blocks contraction',
+          );
+          release();
+          // Now the semaphore is idle — contraction should fire on the
+          // next cooldown.
+          await new Promise((r) => setTimeout(r, 200));
+          assert.strictEqual(
+            pool.currentMaxPages,
+            2,
+            'contraction resumes after slot is released',
+          );
+        },
+      );
+    });
+
+    test('legacy fixed pool: contraction loop never starts (no timer leak)', async function (assert) {
+      withEnv(
+        {
+          PRERENDER_PAGE_POOL_MIN: undefined,
+          PRERENDER_PAGE_POOL_MAX: undefined,
+        },
+        async () => {
+          let semaphore = new AsyncSemaphore(4);
+          let { pool } = track(
+            makeStubPool({ maxPages: 4, renderSemaphore: semaphore }),
+          );
+          assert.strictEqual(pool.minPages, pool.maxBurstPages);
+          // No way to assert a timer wasn't created from the outside, but
+          // we can verify currentMaxPages stays put — if the contraction
+          // loop were running with min == max, no shrink would happen
+          // anyway, but a misconfiguration could pin maxPages==0.
+          await new Promise((r) => setTimeout(r, 80));
+          assert.strictEqual(
+            pool.currentMaxPages,
+            4,
+            'legacy pool stays at fixed size',
+          );
+        },
+      );
+    });
+  });
+});


### PR DESCRIPTION
> Stacks on top of #4595 (PR 6). Lands the dynamic-pool envelope plus expansion / contraction logic. Single-tier in this PR — the high-priority tier (`PRERENDER_PAGE_POOL_HIGH_PRIORITY_MAX` + `PRERENDER_HIGH_PRIORITY_THRESHOLD`) is deliberately deferred to PR 9 so this one stays focused.

## Summary

`PagePool` now supports a configurable `[MIN, MAX]` envelope for tab capacity. The live cap (`#maxPages`) starts at `MIN`, expands by one slot when the render semaphore saturates, and contracts back to `MIN` after sustained idle subject to hysteresis gates. `MIN/MAX` unset → bit-identical to today's behaviour (the contraction loop never starts and expansion is a no-op).

## What changes

### Configuration

New env vars read in the constructor:

```
PRERENDER_PAGE_POOL_MIN              # idle floor; live cap can never drop below
PRERENDER_PAGE_POOL_MAX               # any-priority burst ceiling
PRERENDER_PAGE_POOL_INITIAL           # boot-time count (default = MIN), clamped to [MIN, MAX]
PRERENDER_POOL_IDLE_CONTRACTION_MS    # hysteresis window before each contraction tick (default 60_000)
```

When `MIN xor MAX` is unset, or either is non-positive / non-integer, the pool collapses to a fixed size (`#minPages === #maxBurstPages === options.maxPages`). The contraction `setInterval` never starts in that case; expansion is a no-op. Today's deployments stay on identical math.

### Internal model

- `#maxPages` becomes mutable. New accessors `currentMaxPages` / `minPages` / `maxBurstPages` for diagnostics.
- `#affinityTabMax` and `#sharedContextCap` now derive from `#maxBurstPages` (the largest the pool can grow to) rather than the live `#maxPages`. Otherwise the per-affinity cap would block expansion past `MIN`, and the orphan-context LRU would evict warm fetches every time the pool contracted.

### Reactive expansion

Hot-path hook in `getPage`:

```ts
this.#maybeExpandUnderSaturation();
```

inspects the render semaphore — if `inUseCount >= capacity`, calls `#tryExpand()`. That bumps `#maxPages` by one, forwards the resize to the render semaphore via `setCapacity`, and resets the contraction loop's idle observation. The new slot is filled by the existing standby refill / `#commandeerDormantTab` paths — expansion just lifts the ceiling, doesn't itself spawn a tab.

### Hysteresis-gated contraction

Background `setInterval` started on construction only when `#maxBurstPages > #minPages` (so legacy pools never pay timer overhead). A tick drops one tab when **all** of these hold:

- `#maxPages > #minPages` (room to shrink)
- no waiters anywhere on the pool — per-tab queues, file-admission semaphores, render semaphore in-flight (`#observeIdleness`)
- the idle state has held continuously for at least `#idleContractionMs`

**Warmth-preserving drop rule:**
1. Standby first (no affinity warmth to lose).
2. Otherwise, the affinity whose tabs have the oldest LRU touch among currently-idle entries.

The dropped affinity goes through `disposeAffinity`, which keeps the BrowserContext as an orphan in `#sharedContexts` — so re-warming on the next burst is `context.newPage()` with the fetch cache intact.

Bounded rate: at most one tab dropped per cooldown window. After a drop the loop continues running and ticks again after the next cooldown if conditions still hold, walking the pool back to `MIN` over multiple ticks instead of all at once.

### Render-semaphore type widened

`RenderSemaphore` (the injected dependency type) now declares an optional `setCapacity?: (n: number) => void`. Concrete `AsyncSemaphore` instances always provide it; the existing test stubs that supply only `acquire` keep working.

### Test seams

```ts
__test_tryExpand(): boolean
__test_maybeExpandUnderSaturation(): void
```

Parallel to the existing `__test_seedRevokedException` pattern, so unit tests can drive the state machine without a real Chrome.

## Tests

12 new cases in `tests/page-pool-expansion-test.ts`:

```
ok 1 legacy fixed-pool config: MIN === MAX === options.maxPages when env vars unset
ok 2 dynamic-pool config: MIN/MAX env vars set the envelope
ok 3 dynamic-pool config: INITIAL is respected and clamped to [MIN, MAX]
ok 4 dynamic-pool config: MAX < MIN is clamped to MIN with a warning
ok 5 only one env var set: MIN xor MAX falls back to legacy config
ok 6 invalid env values fall back to legacy config
ok 7 saturation expansion: render-semaphore at capacity triggers `#tryExpand`
ok 8 expansion is bounded by maxBurstPages
ok 9 contraction respects cooldown: no shrink within idle window
ok 10 contraction shrinks one tab per tick after cooldown elapses
ok 11 contraction is blocked while waiters are pending on the render semaphore
ok 12 legacy fixed pool: contraction loop never starts (no timer leak)
```

The full expansion / contraction state machine is exercised end-to-end against a real Chrome by `prerendering-test.ts` (existing integration coverage, unchanged).

## Behaviour at default config

Unchanged. Without the new env vars set the pool stays at a fixed `options.maxPages` size, the contraction `setInterval` never starts, `#maybeExpandUnderSaturation` is a no-op, and `#tryExpand` returns `false` immediately.

## Test plan

- [ ] `pnpm test --filter @cardstack/realm-server -- TEST_MODULES=page-pool-expansion-test.ts` — 12/12 pass
- [ ] `pnpm test --filter @cardstack/realm-server -- TEST_MODULES=page-pool-priority-test.ts,async-semaphore-test.ts,prerender-affinity-activity-test.ts,prerender-manager-test.ts,prerender-diagnostics-persistence-test.ts,page-pool-expansion-test.ts` — 101/101 pass
- [ ] `prerendering-test.ts` integration suite still green (regression guard for the real-Chrome path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
