### PR TITLE
Strip stale App Platform-managed fields from dashboard JSONs

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-jobs.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-jobs.json
@@ -27,7 +27,6 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
-    "id": 27,
     "links": [
       {
         "asDropdown": false,
@@ -543,8 +542,6 @@
     "timepicker": {},
     "timezone": "browser",
     "title": "Boxel Jobs",
-    "uid": "aetquzjcf2znke",
-    "version": 5,
     "weekStart": ""
   }
 }

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-logs.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-logs.json
@@ -27,7 +27,6 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
-    "id": 25,
     "links": [],
     "panels": [
       {
@@ -256,8 +255,6 @@
     "timepicker": {},
     "timezone": "browser",
     "title": "Boxel Logs",
-    "uid": "fetquzizsej28b",
-    "version": 1,
     "weekStart": ""
   }
 }

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/realm-permissions.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/realm-permissions.json
@@ -27,7 +27,6 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
-    "id": 29,
     "links": [
       {
         "asDropdown": false,
@@ -310,8 +309,6 @@
     "timepicker": {},
     "timezone": "browser",
     "title": "Realm Permissions",
-    "uid": "bfbgdczbhebr4c",
-    "version": 1,
     "weekStart": ""
   }
 }

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/synapse.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/synapse.json
@@ -72,7 +72,6 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
-    "id": 28,
     "links": [
       {
         "asDropdown": false,
@@ -13472,8 +13471,6 @@
     },
     "timezone": "",
     "title": "Synapse",
-    "uid": "000000012",
-    "version": 1,
     "weekStart": ""
   }
 }

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/user-credits.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/user-credits.json
@@ -27,7 +27,6 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
-    "id": 24,
     "links": [
       {
         "asDropdown": false,
@@ -299,8 +298,6 @@
     "timepicker": {},
     "timezone": "browser",
     "title": "User Credits",
-    "uid": "eetquziy9np4wa",
-    "version": 1,
     "weekStart": ""
   }
 }

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/worker-status.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/worker-status.json
@@ -27,7 +27,6 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
-    "id": 26,
     "links": [],
     "panels": [
       {
@@ -71,8 +70,6 @@
     "timepicker": {},
     "timezone": "browser",
     "title": "Worker Status",
-    "uid": "aetquzj0mdb7kb",
-    "version": 1,
     "weekStart": ""
   }
 }


### PR DESCRIPTION
## Summary

- Removes leftover `spec.id`, `spec.uid`, `spec.version` from the six `boxel-status` dashboard JSONs.
- These fields are App Platform-managed (`grafanactl pull` always returns them as null); leaving them in the source of truth caused production observability applies to fail with `400 BadRequest: cannot change the ID of a dashboard. set the label grafana.app/deprecatedInternalID to the previous value`.
- Production stored each dashboard's legacy id in `metadata.labels."grafana.app/deprecatedInternalID"` (values 34–38), but the committed JSONs carried `spec.id` 24–29 from the original export. Staging happened to accept the same payload only because it was the first env we pushed to, so the committed values became canonical there.

## Root cause confirmation

| UID | committed `spec.id` | prod stored `deprecatedInternalID` |
|---|---|---|
| `aetquzjcf2znke` (boxel-jobs) | 27 | 35 |
| `aetquzj0mdb7kb` (worker-status) | 26 | 38 |
| `bfbgdczbhebr4c` (realm-permissions) | 29 | 36 |
| `eetquziy9np4wa` (user-credits) | 24 | 37 |
| `fetquzizsej28b` (boxel-logs) | 25 | 34 |
| `000000012` (synapse) | 28 | (also mismatched) |

## Test plan

- [x] `grafanactl resources push --dry-run` against production with the un-stripped (HEAD) JSONs — reproduces 6 errors with the exact 400 message.
- [x] `grafanactl resources push --dry-run` against production with the stripped JSONs — 7 resources pushed, 0 errors.
- [ ] After merge, watch `observability-apply-staging` on the merge commit — should stay green.
- [ ] Manually dispatch `observability-apply-production` against `main` — should now succeed for all six dashboards.

## Stacking note

Based on `cs-10923-replace-tf-interpolated-urls` (#4585) so the diff is clean against that branch's URL placeholder change. GitHub will auto-retarget this PR's base to `main` when #4585 merges; nothing extra to do here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)