### PR TITLE
CS-10985: drop regex from Worker Logs panel; use worker_id label match

### DIFF
--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -99,7 +99,7 @@ you change it, change it everywhere — `alloy/config.alloy` (local) and
 | `env`       | constant `local` (Alloy relabel rule)                 | constant `staging` / `production` (Fluent Bit static `Labels`)     | always                            |
 | `service`   | Docker container name, leading `/` stripped           | ECS task family — `realm-server`, `worker`, `prerender`, `prerender-manager`, `synapse` | always |
 | `realm`     | opt-in via Docker label `boxel.realm=<name>`          | task env when the task pins a single realm (omitted on multi-realm workloads) | when meaningful |
-| `worker_id` | not set locally                                       | per-Fargate-task `ecs_task_id` injected by FireLens (worker only)  | worker tasks only                 |
+| `worker_id` | not set locally                                       | per-process worker id (`<runtime-id>-pid-<pid>`), parsed from `[worker <id> priority N]:` log line prefixes by a Fluent Bit Lua filter. Matches `job_reservations.worker_id`. | worker tasks only, lines with the prefix |
 
 The local Alloy scraper drops the observability stack's own Compose
 services (`grafana`, `loki`, `alloy`) so `{env="local"}` queries don't
@@ -180,8 +180,9 @@ window, not the query window.
 # Lines for one realm across all services
 {env="<env>", realm="example_realm"}
 
-# Per-worker tail
-{env="<env>", service="worker", worker_id="abc123def456"}
+# Per-worker tail (worker_id matches job_reservations.worker_id —
+# look it up there, e.g. for the worker that ran a specific job).
+{env="<env>", service="worker", worker_id="abc123-3236013547-pid-42"}
 
 # Logs around a specific job id (LogQL line-filter, not regex)
 {env="<env>", service="worker"} |= "job_id=42"

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-logs.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-logs.json
@@ -96,7 +96,7 @@
               "type": "loki",
               "uid": "loki"
             },
-            "expr": "{service=\"worker\"} |~ \"^\\\\[worker $worker_id \"",
+            "expr": "{service=\"worker\", worker_id=\"$worker_id\"}",
             "queryType": "range",
             "refId": "A"
           }


### PR DESCRIPTION
## Summary

- Switches the Worker Logs panel in `boxel-logs.json` from a line-content regex (`{service="worker"} |~ "^\[worker $worker_id "`) to a clean label match (`{service="worker", worker_id="$worker_id"}`).
- Updates `packages/observability/README.md` label schema to document the new `worker_id` source.

## Why this is now possible

CS-10925 had to fall back to a regex because FireLens's `worker_id` Loki label was a per-Fargate-task value (`ecs_task_id`), while `job_reservations.worker_id` is per-process. Different value spaces.

[cardstack/infra#681](https://github.com/cardstack/infra/pull/681) changes the FireLens config for the worker task family to populate `worker_id` from the realm-server's per-process identifier (parsed by a Lua filter from `[worker <id> priority N]:` log line prefixes) — so the label and the dashboard variable now share the same value space.

## Test plan

- [ ] Merge cardstack/infra#681 first; apply to staging.
- [ ] After staging task replacement, in Grafana Explore: `{service="worker", worker_id=~".+"}` returns lines from worker children with values matching `job_reservations.worker_id`.
- [ ] Merge cs-10925 (#4584).
- [ ] Merge this PR; let `observability-apply-staging` run on the merge commit; confirm the Worker Logs panel works for a real `$worker_id` from the dropdown (logs render, no errors).
- [ ] Manually dispatch `observability-apply-production` against `main`.

## Stacking

Base set to `cs-10925-rewrite-log-panels-to-logql` (#4584) so the diff applies cleanly on top of CS-10925's LogQL rewrite. GitHub will auto-retarget to `main` when #4584 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)