### PR TITLE
CS-10988: canonicalize JSON before observability diff

### DIFF
--- a/packages/observability/scripts/diff.sh
+++ b/packages/observability/scripts/diff.sh
@@ -120,16 +120,21 @@ normalize folders Folder
 # four classes of noise that have nothing to do with what an apply would
 # actually change:
 #
-#   1. Unicode-escape style. `jq` writes `&` as `&` and `>` as `>`;
-#      our committed JSON has them as `&` / `>` (an artefact of
-#      the original extract pipeline in CS-10922). Every URL / query
-#      string with `&` becomes a diff line. Re-emitting both sides
-#      through `jq` collapses them.
+#   1. Unicode-escape style. The committed JSON encodes `&` as the
+#      6-byte escape sequence `&` and `>` as `>` (an artefact
+#      of CS-10922's original extract pipeline). `jq` decodes both back
+#      to literal `&` and `>` on re-emit, while the live API returns
+#      them already decoded. Every URL / query-string with `&` becomes
+#      a diff line. Re-emitting both sides through `jq` collapses them.
 #   2. App Platform server-injected metadata. Pulled state has
 #      `metadata.id` (server-assigned int), an empty `metadata.labels`,
 #      `metadata.namespace: "default"`, and may grow
 #      resourceVersion/creationTimestamp/uid. Our committed JSON omits
-#      all of these because they don't round-trip on push.
+#      all of these because they don't round-trip on push. Note:
+#      `metadata.uid` is the App Platform's server-assigned UUID — a
+#      Kubernetes-style resource id, distinct from `metadata.name`
+#      (the user-facing identifier we ship in committed JSON). Stripping
+#      it cannot hide a real diff.
 #   3. Key order inside `metadata`. `--sort-keys` makes order stable on
 #      both sides.
 #   4. (Not handled here.) Default values like `"value": null` injected
@@ -152,15 +157,18 @@ JQ_NORMALIZE='
 
 normalize_json_content() {  # $1: src dir, $2: dest dir
   local src="$1" dest="$2"
-  shopt -s nullglob globstar
+  # `find -print0` + a NUL-delimited read loop rather than `**/*.json` —
+  # macOS's default bash 3.2 doesn't support `shopt -s globstar`, and
+  # enabling shell options inside a function leaks them back to the
+  # caller anyway. This pattern is portable across bash 3.2 / 4.x / 5.x
+  # and zsh and has no shell-state side effects.
   local f rel target
-  for f in "$src"/**/*.json "$src"/*.json; do
-    [[ -f "$f" ]] || continue
+  while IFS= read -r -d '' f; do
     rel="${f#$src/}"
     target="$dest/$rel"
     mkdir -p "$(dirname "$target")"
     jq --sort-keys "$JQ_NORMALIZE" "$f" > "$target"
-  done
+  done < <(find "$src" -type f -name '*.json' -print0)
 }
 
 # Re-process both trees through jq into matching canonicalized layouts.
@@ -173,7 +181,9 @@ normalize_json_content "./grafanactl/resources" "$committed_canon"
 # Diff: <remote-current-state, canonicalized> → <committed-target,
 # canonicalized>. Reading top-to-bottom shows what would CHANGE on apply.
 # Pulled resources that aren't in our committed set are deliberately
-# absent from remote_norm (push won't touch them).
+# absent from remote_canon (the layout-normalize step in `normalize`
+# drops them from remote_norm, and remote_canon is just remote_norm
+# re-canonicalized — push won't touch them).
 #
 # Color is disabled because the diff is consumed by GitHub Actions or
 # piped to a PR comment (terminal escapes don't render in either).

--- a/packages/observability/scripts/diff.sh
+++ b/packages/observability/scripts/diff.sh
@@ -49,7 +49,9 @@ source ./scripts/grafanactl-env.sh "$env_name"
 cfg="$(./scripts/render-config.sh "$env_name")"
 remote="$(mktemp -d -t grafanactl-pull.XXXXXX)"
 remote_norm="$(mktemp -d -t grafanactl-norm.XXXXXX)"
-trap 'rm -rf "$cfg" "$remote" "$remote_norm"' EXIT
+remote_canon="$(mktemp -d -t remote-canon.XXXXXX)"
+committed_canon="$(mktemp -d -t committed-canon.XXXXXX)"
+trap 'rm -rf "$cfg" "$remote" "$remote_norm" "$remote_canon" "$committed_canon"' EXIT
 
 # Pull what's currently live into the tempdir. We pass explicit kind
 # arguments (`dashboards folders`) instead of letting grafanactl
@@ -114,10 +116,64 @@ normalize() {  # $1: subdir under grafanactl/resources, $2: pulled-kind dirname
 normalize dashboards Dashboard
 normalize folders Folder
 
-# Diff: <remote-current-state, normalized> → <committed-target>. Reading
-# top-to-bottom shows what would CHANGE on apply. Pulled resources that
-# aren't in our committed set are deliberately absent from the normalized
-# tree (push won't touch them).
+# Normalize JSON content (CS-10988). Without this, `git diff` surfaces
+# four classes of noise that have nothing to do with what an apply would
+# actually change:
+#
+#   1. Unicode-escape style. `jq` writes `&` as `&` and `>` as `>`;
+#      our committed JSON has them as `&` / `>` (an artefact of
+#      the original extract pipeline in CS-10922). Every URL / query
+#      string with `&` becomes a diff line. Re-emitting both sides
+#      through `jq` collapses them.
+#   2. App Platform server-injected metadata. Pulled state has
+#      `metadata.id` (server-assigned int), an empty `metadata.labels`,
+#      `metadata.namespace: "default"`, and may grow
+#      resourceVersion/creationTimestamp/uid. Our committed JSON omits
+#      all of these because they don't round-trip on push.
+#   3. Key order inside `metadata`. `--sort-keys` makes order stable on
+#      both sides.
+#   4. (Not handled here.) Default values like `"value": null` injected
+#      into threshold step arrays. The acceptance criteria flagged this
+#      as optional, and a generic null-strip risks dropping legitimate
+#      explicit nulls. Deferred to a follow-up if it dominates a future
+#      diff.
+JQ_NORMALIZE='
+  if type == "object" and has("metadata") and (.metadata | type) == "object" then
+    .metadata |= (
+      del(.id)
+      | del(.resourceVersion)
+      | del(.creationTimestamp)
+      | del(.uid)
+      | (if has("labels") and (.labels | type) == "object" and (.labels | length) == 0 then del(.labels) else . end)
+      | (if .namespace == "default" then del(.namespace) else . end)
+    )
+  else . end
+'
+
+normalize_json_content() {  # $1: src dir, $2: dest dir
+  local src="$1" dest="$2"
+  shopt -s nullglob globstar
+  local f rel target
+  for f in "$src"/**/*.json "$src"/*.json; do
+    [[ -f "$f" ]] || continue
+    rel="${f#$src/}"
+    target="$dest/$rel"
+    mkdir -p "$(dirname "$target")"
+    jq --sort-keys "$JQ_NORMALIZE" "$f" > "$target"
+  done
+}
+
+# Re-process both trees through jq into matching canonicalized layouts.
+# Output goes into separate temp dirs (remote_canon / committed_canon)
+# rather than overwriting the layout-normalized inputs, so a debugger
+# inspecting the temp tree can see each step independently.
+normalize_json_content "$remote_norm" "$remote_canon"
+normalize_json_content "./grafanactl/resources" "$committed_canon"
+
+# Diff: <remote-current-state, canonicalized> → <committed-target,
+# canonicalized>. Reading top-to-bottom shows what would CHANGE on apply.
+# Pulled resources that aren't in our committed set are deliberately
+# absent from remote_norm (push won't touch them).
 #
 # Color is disabled because the diff is consumed by GitHub Actions or
 # piped to a PR comment (terminal escapes don't render in either).
@@ -130,8 +186,8 @@ set +e
 git diff \
   --no-index \
   --no-color \
-  "$remote_norm" \
-  ./grafanactl/resources/
+  "$remote_canon" \
+  "$committed_canon"
 diff_exit=$?
 set -e
 


### PR DESCRIPTION
## Summary

- Adds a JSON canonicalization step to `packages/observability/scripts/diff.sh` so the observability-diff PR comment surfaces only real changes.
- Strips round-trip-only metadata (`metadata.id`, empty `metadata.labels`, default `metadata.namespace`, plus `resourceVersion`/`creationTimestamp`/`uid`) and re-emits both sides through `jq --sort-keys` to collapse Unicode-escape and key-order differences.
- Defers the `"value": null` threshold-step strip — flagged as optional in the ticket and a generic null-cleanup risks dropping legitimate explicit nulls.

Closes [CS-10988](https://linear.app/cardstack/issue/CS-10988).

## Why

CI's observability diff comment was hitting its 60 KB truncation cap on PRs that changed one or two lines (~98 KB on PR #4585) because four classes of normalization differences between pulled state and committed state always showed up:

1. **Unicode-escape style.** `jq` emits `&` as `&`; the committed JSON has the Unicode escapes from the original CS-10922 extract pipeline. Every URL with `&` was a diff line.
2. **App Platform server-injected metadata.** Pulled state has `metadata.id`, empty `metadata.labels`, `metadata.namespace = \"default\"`, and may grow `resourceVersion`/`creationTimestamp`/`uid`. None of these round-trip on push.
3. **Key order inside `metadata`.** Pulled `name` lands after `annotations`; committed has `name` first.
4. **Default null threshold-step entries** (deferred).

Fix is entirely in `diff.sh`. Committed files on disk are not touched; the canonicalize step writes to fresh temp dirs (`remote_canon` / `committed_canon`) so each step can be inspected independently.

## Test plan

- [x] `bash -n diff.sh` — no syntax errors.
- [x] Local simulation: derived a synthetic \"remote\" tree from a committed dashboard with `metadata.labels = {}`, `metadata.namespace = \"default\"`, and a fake title change. Without canonicalize the diff showed labels/namespace/key-order noise plus the title; with canonicalize, only the title change.
- [ ] Run `./scripts/diff.sh --env staging` against real staging and confirm the diff body shrinks from ~98 KB to a small handful of lines (or empty if staging matches `main`). Best done as a comment on this PR once CI runs.
- [ ] Confirm a PR that touches multiple dashboards still surfaces every real change (no over-aggressive normalization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)