### PR TITLE
Fix apply.sh + diff.sh on macOS default bash 3.2

### DIFF
--- a/packages/observability/scripts/apply.sh
+++ b/packages/observability/scripts/apply.sh
@@ -96,9 +96,11 @@ case "$env_name" in
   *)     realm_server_url="$REALM_SERVER_URL" ;;
 esac
 
-shopt -s globstar nullglob
-for f in "$rendered"/dashboards/**/*.json; do
-  [[ -f "$f" ]] || continue
+# `find -print0` + a NUL-delimited read loop rather than a `**/*.json` glob —
+# macOS's default bash 3.2 doesn't support `shopt -s globstar` and `set -eo`
+# would abort apply.sh before any push. This pattern is portable across bash
+# 3.2 / 4.x / 5.x and zsh.
+while IFS= read -r -d '' f; do
   # `set -e` aborts on a non-zero exit, but only for "simple commands" — a
   # `jq ... > out && mv ...` chain swallows jq's failure inside the &&,
   # leaving the script to continue with an unrendered file. Run as two
@@ -115,8 +117,7 @@ for f in "$rendered"/dashboards/**/*.json; do
     )
   ' "$f" > "$f.tmp"
   mv "$f.tmp" "$f"
-done
-shopt -u globstar nullglob
+done < <(find "$rendered/dashboards" -type f -name '*.json' -print0)
 
 grafanactl \
   --config "$cfg" \

--- a/packages/observability/scripts/diff.sh
+++ b/packages/observability/scripts/diff.sh
@@ -96,10 +96,12 @@ extract_uid() {  # $1: path to a committed manifest
 
 normalize() {  # $1: subdir under grafanactl/resources, $2: pulled-kind dirname
   local subdir="$1" kind="$2"
-  shopt -s nullglob globstar
-  for committed in ./grafanactl/resources/${subdir}/**/*.json ./grafanactl/resources/${subdir}/*.json; do
-    [[ -f "$committed" ]] || continue
-    local uid pulled rel target
+  # `find -print0` + a NUL-delimited read loop rather than a `**/*.json` glob —
+  # macOS's default bash 3.2 doesn't support `shopt -s globstar` and `set -eo`
+  # would abort diff.sh before it could produce output. Portable across
+  # bash 3.2 / 4.x / 5.x and zsh.
+  local committed uid pulled rel target
+  while IFS= read -r -d '' committed; do
     uid="$(extract_uid "$committed")"
     [[ -n "$uid" ]] || continue
     pulled="${remote}/${kind}/${uid}.json"
@@ -108,7 +110,7 @@ normalize() {  # $1: subdir under grafanactl/resources, $2: pulled-kind dirname
     target="${remote_norm}/${rel}"
     mkdir -p "$(dirname "$target")"
     cp "$pulled" "$target"
-  done
+  done < <(find "./grafanactl/resources/${subdir}" -type f -name '*.json' -print0 2>/dev/null)
 }
 
 normalize dashboards Dashboard


### PR DESCRIPTION
## Summary

- Replace `shopt -s globstar` + `**/*.json` glob with `find … -print0 | while read -d ''` in both `packages/observability/scripts/apply.sh` and `scripts/diff.sh`.
- Both scripts were aborting on macOS's default bash 3.2 (which doesn't support `globstar`):

```
./scripts/apply.sh: line 99: shopt: globstar: invalid shell option name
```

  with `set -eo pipefail` propagating the failure as a non-zero exit before any work happened. Surfaced while walking through CS-10926's local verification checklist.

## Why this happened

`shopt -s globstar` was introduced into `apply.sh` by PR #4585 (CS-10923) and `diff.sh` by the diff-noise PR. Both worked for whoever wrote them because their shells resolved `/usr/bin/env bash` to homebrew bash 5.x. On a stock Mac without homebrew bash, `/usr/bin/env bash` → `/bin/bash` (3.2.57) → no globstar → script exits.

## Fix

`find … -print0` + a NUL-delimited read loop is the portable equivalent. Same one-iteration-per-`.json` behavior across bash 3.2 / 4.x / 5.x and zsh. Functional behavior of both scripts is unchanged.

## Test plan

- [x] `./scripts/apply.sh --env local` → "✔ 7 resources pushed, 0 errors" on a Mac with `/bin/bash` 3.2.57.
- [x] `./scripts/diff.sh --env local` → produces the expected diff output (exit 0).
- [ ] No change expected for CI runners (Ubuntu has bash 5.x); the fix is pure compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)