### PR TITLE
CS-10983: bump bench gate noise floor 0.3ms → 1.5ms

### DIFF
--- a/packages/runtime-common/scripts/bench-amd/README.md
+++ b/packages/runtime-common/scripts/bench-amd/README.md
@@ -101,7 +101,7 @@ above baseline) per CS-10983.
   "iterations": 100,
   "warmup": 10,
   "tolerance": 1.25,
-  "noise_floor_ms": 0.3,
+  "noise_floor_ms": 1.5,
   "candidate": "production",
   "fixtures": {
     "enum.js": { "median_ms": 0.65 },
@@ -119,18 +119,41 @@ allowed = max(baseline × tolerance, baseline + noise_floor_ms)
 ```
 
 The relative `tolerance` (×1.25) handles regression detection for
-mid-to-large fixtures. The absolute `noise_floor_ms` handles the
-small-fixture case: at sub-ms baselines, GH-runner jitter (observed up
-to ~0.21ms across runs) can swamp the relative tolerance. With a 0.3ms
-floor, a 0.65ms baseline gets `max(0.81ms, 0.95ms) = 0.95ms` allowed —
-absorbs the noise without losing 2× regression sensitivity. For a 10ms
-baseline, relative dominates: `max(12.55ms, 10.34ms) = 12.55ms`. Same
-relative+absolute pattern as `check-memory-baseline.mjs` uses for the
-host-memory gate.
+larger fixtures. The absolute `noise_floor_ms` handles smaller fixtures
+where GH-runner jitter is similar in absolute ms terms regardless of
+fixture size — observed up to ~0.92ms for `spec.js` and ~0.21ms for
+`enum.js` across a handful of runs. A flat absolute floor matches that
+shape: every fixture gets a budget that absorbs sub-1.5ms jitter, while
+larger fixtures fall through to the relative tolerance.
 
-Bump `noise_floor_ms` higher if a fixture keeps tripping on noise.
-Lower (or remove) once you have a fixture that's consistently larger
-and the absolute jitter no longer dominates.
+| Fixture        | Baseline | × 1.25  | Baseline + 1.5ms | Allowed (max) |
+| -------------- | -------- | ------- | ---------------- | ------------- |
+| `enum.js`      | 0.65ms   | 0.81ms  | 2.15ms           | **2.15ms**    |
+| `skill-set.js` | 1.85ms   | 2.31ms  | 3.35ms           | **3.35ms**    |
+| `spec.js`      | 2.14ms   | 2.68ms  | 3.64ms           | **3.64ms**    |
+| `card-api.js`  | 10.04ms  | 12.55ms | 11.54ms          | **12.55ms**   |
+
+**Regression-detection trade-off.** A 1.5ms floor means the gate
+can't distinguish sub-1.5ms regressions from runner noise on the
+smaller fixtures. Concretely:
+
+- `enum.js` (0.65ms): catches > 3.3× regressions (a 2× regression at
+  1.30ms falls under the 2.15ms ceiling and would not trip).
+- `skill-set.js` (1.85ms): catches > 1.8× regressions.
+- `spec.js` (2.14ms): catches > 1.7× regressions.
+- `card-api.js` (10.04ms): catches > 1.25× regressions (relative
+  dominates).
+
+We accept the lower sensitivity on the tiny fixtures as the cost of
+stable CI; the bench primarily exists to catch the 2×+ class of
+regressions (e.g. an accidental `setTimeout` in the rewriter, an
+O(N²) where O(N) suffices, a redundant pass added to the pipeline) on
+the larger fixtures, where the gate still catches them comfortably.
+
+If a future fixture refresh produces a baseline where 1.5ms over-
+relaxes the relative tolerance (i.e. the fixture is large enough that
+the absolute floor is dead weight), drop `noise_floor_ms` lower so
+`× 1.25` resumes as the binding constraint.
 
 ### When the gate trips
 

--- a/packages/runtime-common/scripts/bench-amd/baseline.json
+++ b/packages/runtime-common/scripts/bench-amd/baseline.json
@@ -4,7 +4,7 @@
   "iterations": 100,
   "warmup": 10,
   "tolerance": 1.25,
-  "noise_floor_ms": 0.3,
+  "noise_floor_ms": 1.5,
   "candidate": "production",
   "fixtures": {
     "card-api.js": { "median_ms": 10.04 },


### PR DESCRIPTION
## Summary

The bench gate tripped on a post-merge main run ([job 73874465949](https://github.com/cardstack/boxel/actions/runs/25195309264/job/73874465949)) — **same code, no real regression**, just GH-runner jitter on `spec.js`. Bumping `noise_floor_ms` 0.3ms → 1.5ms to absorb the wider absolute jitter we've now seen across the four fixtures.

## What tripped

```
production median for spec.js is 3.0449ms,
exceeds allowed 2.6750ms (with +0.3ms noise floor)
(baseline 2.1400ms × 1.25 tolerance)
```

`spec.js`'s distribution this run was unusually wide — min 1.99ms, max 5.20ms, p95 4.08ms — the median moved 42% from baseline while `card-api` / `enum` / `skill-set` stayed flat. The 0.3ms floor I'd sized to `enum.js`'s 0.21ms spread isn't wide enough to catch `spec.js`'s 0.92ms spread.

## Variance across 5 captured CI runs

| Fixture | observed range | absolute spread |
|---------|----------------|-----------------|
| `enum.js` | 0.62 – 0.83ms | 0.21ms |
| `skill-set.js` | 1.80 – 1.88ms | 0.08ms |
| `spec.js` | 2.12 – **3.04ms** | **0.92ms** ← was the trip |
| `card-api.js` | 9.47 – 10.04ms | 0.57ms |

A 1.5ms floor absorbs sub-1.5ms jitter on every fixture with comfortable margin over observed worst-case:

| Fixture | Baseline | × 1.25 | Baseline + 1.5ms | Allowed | Worst observed | Headroom |
|---------|---------:|-------:|-----------------:|--------:|---------------:|---------:|
| `enum.js` | 0.65ms | 0.81ms | 2.15ms | **2.15ms** | 0.83ms | 159% |
| `skill-set.js` | 1.85ms | 2.31ms | 3.35ms | **3.35ms** | 1.88ms | 78% |
| `spec.js` | 2.14ms | 2.68ms | 3.64ms | **3.64ms** | 3.04ms | 20% |
| `card-api.js` | 10.04ms | 12.55ms | 11.54ms | **12.55ms** | 10.04ms | 25% |

## Regression-sensitivity trade-off

A 1.5ms absolute floor is large relative to `enum.js`'s 0.65ms baseline, so the gate's detection sensitivity on tiny fixtures drops:

| Fixture | catches regressions ≥ |
|---------|----------------------:|
| `enum.js` | **3.3×** (2× = 1.30ms is under the 2.15ms ceiling) |
| `skill-set.js` | 1.8× |
| `spec.js` | 1.7× |
| `card-api.js` | 1.25× |

The bench primarily exists to catch 2×+ regressions on the larger fixtures (`spec.js`, `card-api.js`) — e.g. an accidental `setTimeout` in the rewriter, an O(N²) where O(N) suffices, a redundant pass added to the pipeline. Those still trip cleanly. We accept the lower sensitivity on tiny fixtures as the cost of stable CI.

If `spec.js` keeps tripping, next move is per-fixture `noise_floor_ms` (the schema's already room for it) so we can re-tighten `enum.js` while keeping `spec.js` loose.

## Test plan

- [x] `pnpm --filter @cardstack/runtime-common lint` clean.
- [x] `prettier --check` clean on changed files.
- [x] `bench:amd:check:trip-test` and `bench:amd:trip-drill` paths still work — both unchanged from #4592.
- [ ] First CI run on this PR stays green; spec.js measurement comes in below 3.64ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)