### PR TITLE
Stabilize flaky schema editor tests

### DIFF
--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -34,6 +34,39 @@ import { setupApplicationTest } from '../../helpers/setup';
 
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 
+// Realm icons render via `realm.info(url)`, which returns a placeholder
+// (no `data-test-realm-icon-url` attribute) until the async fetch resolves.
+// This wrapper gives the wait a generous timeout and, on timeout, logs
+// surrounding DOM state so future flakes are easier to diagnose.
+async function waitForRealmIcon(selector: string, timeoutMs = 5000) {
+  try {
+    await waitFor(selector, { timeout: timeoutMs });
+  } catch (e) {
+    let parentSelector = selector
+      .replace(/\s*\[data-test-realm-icon-url\][^[]*$/, '')
+      .trim();
+    let parent = parentSelector ? document.querySelector(parentSelector) : null;
+    let allIcons = Array.from(
+      document.querySelectorAll('[data-test-realm-icon-url]'),
+    ).map((el) => ({
+      url: el.getAttribute('data-test-realm-icon-url'),
+      schema: el
+        .closest('[data-test-card-schema]')
+        ?.getAttribute('data-test-card-schema'),
+      fieldName: el
+        .closest('[data-test-field-name]')
+        ?.getAttribute('data-test-field-name'),
+    }));
+    console.error(
+      `[schema-editor diagnostic] waitFor("${selector}") timed out after ${timeoutMs}ms. ` +
+        `Parent ("${parentSelector}") HTML: ${
+          parent?.outerHTML?.slice(0, 2000) ?? '<missing>'
+        } | All [data-test-realm-icon-url] in DOM: ${JSON.stringify(allIcons)}`,
+    );
+    throw e;
+  }
+}
+
 const indexCardSource = `
   import { CardDef, Component } from "https://cardstack.com/base/card-api";
 
@@ -474,7 +507,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
     let realm1IconUrl = 'https://i.postimg.cc/L8yXRvws/icon.png';
     let realm2IconUrl = 'https://boxel-images.boxel.ai/icons/cardstack.png';
 
-    await waitFor(
+    await waitForRealmIcon(
       // using non test selectors to disambiguate what we are waiting for, as
       // without these the selectors are matching DOM that is not being tested
       '[data-test-card-schema="Person"] .pill .icon [data-test-realm-icon-url]',
@@ -483,7 +516,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
       .dom(`[data-test-card-schema="Person"] [data-test-realm-icon-url]`)
       .hasAttribute('data-test-realm-icon-url', realm1IconUrl);
 
-    await waitFor(
+    await waitForRealmIcon(
       '[data-test-card-schema="Person"] [data-test-field-name="firstName"] [data-test-realm-icon-url]',
     );
 
@@ -493,7 +526,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
       )
       .hasAttribute('data-test-realm-icon-url', realm2IconUrl);
 
-    await waitFor(
+    await waitForRealmIcon(
       // using non test selectors to disambiguate what we are waiting for, as
       // without these the selectors are matching DOM that is not being tested
       '[data-test-card-schema="Card"] .pill .icon [data-test-realm-icon-url]',
@@ -643,6 +676,9 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
         ?.textContent?.includes('BigInteger'),
     );
 
+    await waitForRealmIcon(
+      '[data-test-selected-type] [data-test-realm-icon-url]',
+    );
     await assert
       .dom('[data-test-selected-type] [data-test-realm-icon-url]')
       .exists();


### PR DESCRIPTION
## Summary
- Two acceptance tests in `schema-editor-test.ts` flake when `realm.info(url)` hasn't resolved before the realm-icon assertion. The realm-icon component renders no `data-test-realm-icon-url` attribute until the async fetch completes, so selectors like `[data-test-realm-icon-url]` momentarily miss.
- `schema editor lists the inheritance chain` waited for the `firstName` field's icon with the default 1000ms `waitFor` timeout (insufficient on slow CI).
- `adding a field from schema editor - whole flow test` asserted on `[data-test-selected-type] [data-test-realm-icon-url]` existence with no preceding wait at all.
- Failure observed in: https://github.com/cardstack/boxel/actions/runs/25197056006/job/73880194517

## Fix
- Add a `waitForRealmIcon(selector, timeoutMs = 5000)` helper at the top of the test file. It wraps `waitFor` with a generous timeout, and on timeout logs:
  - The parent element's `outerHTML` (so we can see whether the field row even rendered)
  - Every `[data-test-realm-icon-url]` currently in the DOM, with its url, schema, and field name (so we can see if some are still in placeholder/loading state)
- Use the helper for all realm-icon waits in the two flaky tests, and add a missing wait before the assertion in the "whole flow" test.

## Test plan
- [ ] Existing CI passes on this branch
- [ ] Re-run shard 15 several times to check flake rate has dropped
- [ ] If a future flake hits, the `[schema-editor diagnostic]` log line in the QUnit `browser log:` block will tell us what state the DOM was actually in

🤖 Generated with [Claude Code](https://claude.com/claude-code)