### PR TITLE
CS-10926: wire BOXEL_DB_* env vars into local Grafana container

### DIFF
--- a/packages/observability/docker-compose.yml
+++ b/packages/observability/docker-compose.yml
@@ -31,6 +31,14 @@ services:
       GF_AUTH_ANONYMOUS_ENABLED: "false"
       # Substituted into provisioning/datasources/loki.yaml at startup.
       LOKI_URL: http://loki:3100
+      # Substituted into provisioning/datasources/boxel-db.yaml at startup.
+      # Defaults target the local boxel-pg container reachable via the
+      # host-gateway alias below; override by exporting these (or via a
+      # `.env` file in this directory) before `docker compose up`.
+      BOXEL_DB_HOST: ${BOXEL_DB_HOST:-host.docker.internal:5435}
+      BOXEL_DB_NAME: ${BOXEL_DB_NAME:-boxel}
+      BOXEL_DB_USER: ${BOXEL_DB_USER:-postgres}
+      BOXEL_DB_PASSWORD: ${BOXEL_DB_PASSWORD:-postgres}
     extra_hosts:
       # Lets the Grafana container reach the host's Postgres
       # (boxel-pg on 5435) for the local postgres data source.


### PR DESCRIPTION
## Summary

- `provisioning/datasources/boxel-db.yaml` references `${BOXEL_DB_HOST/NAME/USER/PASSWORD}`, which Grafana resolves from its container env at startup. The local `docker-compose.yml` only forwarded `LOKI_URL`, so a fresh `compose up` left every placeholder empty and the Postgres data source came up with `connection refused`.
- Forwards the four vars with local defaults (`host.docker.internal:5435`, `boxel`, `postgres`, `postgres`) so Postgres-backed dashboards render out of the box. Shell or `.env` override via the `${VAR:-default}` form.
- Surfaced while verifying CS-10926. Without this, AC #3 ("≥1 panel renders real data per dashboard") fails for the four Postgres-backed dashboards (boxel-jobs, realm-permissions, user-credits, plus the Postgres half of worker-status).

## Test plan

- [ ] `cd packages/observability && docker compose down -v && docker compose up -d`
- [ ] Wait for Grafana, then `curl -sS -u admin:admin 'http://localhost:3001/api/datasources/uid/cef5v5sl9k7i8f/health'` returns `"status":"OK"` / `"Database Connection OK"`
- [ ] `./scripts/apply.sh --env local` succeeds
- [ ] `http://localhost:3001/d/aetquzjcf2znke/boxel-jobs` Finished Jobs panel renders rows from the local boxel-pg
- [ ] `http://localhost:3001/d/bfbgdczbhebr4c/realm-permissions?var-realm_url=http://localhost:4201/catalog/` renders 3 rows
- [ ] `http://localhost:3001/d/eetquziy9np4wa/user-credits?var-matrix_user_id=@user2:localhost` renders 1 row
- [ ] Confirm staging/production unaffected (vars come from CI/SSM, defaults only apply when unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)