### PR TITLE
Reduce observability diff noise to zero

### DIFF
--- a/.github/workflows/observability-diff.yml
+++ b/.github/workflows/observability-diff.yml
@@ -66,7 +66,12 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Source GRAFANA_TOKEN from SSM
+      - name: Source diff-time secrets from SSM
+        # GRAFANA_TOKEN: pull-from-staging auth.
+        # REALM_SERVER_URL: needed by diff.sh's __REALM_SERVER_URL__
+        # substitution (CS-10990); committed JSON carries the placeholder
+        # and apply.sh substitutes per-env, so diff.sh has to know the
+        # same per-env value to compare apples-to-apples.
         run: |
           GRAFANA_TOKEN="$(aws ssm get-parameter \
             --name /staging/grafana/grafanactl_token \
@@ -75,6 +80,12 @@ jobs:
             --output text)"
           echo "::add-mask::$GRAFANA_TOKEN"
           echo "GRAFANA_TOKEN=$GRAFANA_TOKEN" >> "$GITHUB_ENV"
+
+          REALM_SERVER_URL="$(aws ssm get-parameter \
+            --name /staging/boxel-grafana/realm_server_url \
+            --query 'Parameter.Value' \
+            --output text)"
+          echo "REALM_SERVER_URL=$REALM_SERVER_URL" >> "$GITHUB_ENV"
 
       - name: Compute diff
         id: diff

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-jobs.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-jobs.json
@@ -2,10 +2,10 @@
   "apiVersion": "dashboard.grafana.app/v1beta1",
   "kind": "Dashboard",
   "metadata": {
-    "name": "aetquzjcf2znke",
     "annotations": {
       "grafana.app/folder": "defd2d156sav4d"
-    }
+    },
+    "name": "aetquzjcf2znke"
   },
   "spec": {
     "annotations": {
@@ -78,8 +78,7 @@
               "mode": "absolute",
               "steps": [
                 {
-                  "color": "green",
-                  "value": null
+                  "color": "green"
                 },
                 {
                   "color": "red",
@@ -213,8 +212,7 @@
               "mode": "absolute",
               "steps": [
                 {
-                  "color": "green",
-                  "value": null
+                  "color": "green"
                 },
                 {
                   "color": "red",
@@ -381,8 +379,7 @@
               "mode": "absolute",
               "steps": [
                 {
-                  "color": "green",
-                  "value": null
+                  "color": "green"
                 },
                 {
                   "color": "red",
@@ -496,7 +493,7 @@
       }
     ],
     "refresh": "5s",
-    "schemaVersion": 39,
+    "schemaVersion": 42,
     "tags": [],
     "templating": {
       "list": [

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-logs.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-logs.json
@@ -2,10 +2,10 @@
   "apiVersion": "dashboard.grafana.app/v1beta1",
   "kind": "Dashboard",
   "metadata": {
-    "name": "fetquzizsej28b",
     "annotations": {
       "grafana.app/folder": "defd2d156sav4d"
-    }
+    },
+    "name": "fetquzizsej28b"
   },
   "spec": {
     "annotations": {
@@ -142,7 +142,7 @@
       }
     ],
     "refresh": "",
-    "schemaVersion": 39,
+    "schemaVersion": 42,
     "tags": [],
     "templating": {
       "list": [

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/realm-permissions.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/realm-permissions.json
@@ -2,10 +2,10 @@
   "apiVersion": "dashboard.grafana.app/v1beta1",
   "kind": "Dashboard",
   "metadata": {
-    "name": "bfbgdczbhebr4c",
     "annotations": {
       "grafana.app/folder": "defd2d156sav4d"
-    }
+    },
+    "name": "bfbgdczbhebr4c"
   },
   "spec": {
     "annotations": {
@@ -67,8 +67,7 @@
               "mode": "absolute",
               "steps": [
                 {
-                  "color": "green",
-                  "value": null
+                  "color": "green"
                 }
               ]
             }
@@ -181,7 +180,7 @@
       }
     ],
     "refresh": "5s",
-    "schemaVersion": 39,
+    "schemaVersion": 42,
     "tags": [],
     "templating": {
       "list": [

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/synapse.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/synapse.json
@@ -2,45 +2,12 @@
   "apiVersion": "dashboard.grafana.app/v1beta1",
   "kind": "Dashboard",
   "metadata": {
-    "name": "000000012",
     "annotations": {
       "grafana.app/folder": "defd2d156sav4d"
-    }
+    },
+    "name": "000000012"
   },
   "spec": {
-    "__elements": {},
-    "__requires": [
-      {
-        "id": "grafana",
-        "name": "Grafana",
-        "type": "grafana",
-        "version": "9.2.2"
-      },
-      {
-        "id": "graph",
-        "name": "Graph (old)",
-        "type": "panel",
-        "version": ""
-      },
-      {
-        "id": "heatmap",
-        "name": "Heatmap",
-        "type": "panel",
-        "version": ""
-      },
-      {
-        "id": "prometheus",
-        "name": "Prometheus",
-        "type": "datasource",
-        "version": "1.0.0"
-      },
-      {
-        "id": "timeseries",
-        "name": "Time series",
-        "type": "panel",
-        "version": ""
-      }
-    ],
     "annotations": {
       "list": [
         {
@@ -155,7 +122,6 @@
         "legend": {
           "show": false
         },
-        "links": [],
         "options": {
           "calculate": false,
           "calculation": {},
@@ -227,6 +193,7 @@
       },
       {
         "aliasColors": {},
+        "autoMigrateFrom": "graph",
         "bars": false,
         "dashLength": 10,
         "dashes": false,
@@ -262,7 +229,6 @@
         },
         "lines": true,
         "linewidth": 0,
-        "links": [],
         "nullPointMode": "connected",
         "options": {
           "alertThreshold": true
@@ -430,7 +396,7 @@
           "sort": 2,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "mode": "time",
           "show": true,
@@ -460,6 +426,7 @@
       },
       {
         "aliasColors": {},
+        "autoMigrateFrom": "graph",
         "bars": false,
         "dashLength": 10,
         "dashes": false,
@@ -493,7 +460,6 @@
         },
         "lines": true,
         "linewidth": 3,
-        "links": [],
         "nullPointMode": "null",
         "options": {
           "alertThreshold": true
@@ -539,7 +505,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "mode": "time",
           "show": true,
@@ -567,6 +533,7 @@
       },
       {
         "aliasColors": {},
+        "autoMigrateFrom": "graph",
         "bars": false,
         "dashLength": 10,
         "dashes": false,
@@ -603,7 +570,6 @@
         },
         "lines": true,
         "linewidth": 3,
-        "links": [],
         "nullPointMode": "null",
         "options": {
           "alertThreshold": true
@@ -651,8 +617,7 @@
           "sort": 0,
           "value_type": "cumulative"
         },
-        "transformations": [],
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "mode": "time",
           "show": true,
@@ -723,8 +688,7 @@
               "mode": "absolute",
               "steps": [
                 {
-                  "color": "green",
-                  "value": null
+                  "color": "green"
                 }
               ]
             }
@@ -768,6 +732,7 @@
       },
       {
         "aliasColors": {},
+        "autoMigrateFrom": "graph",
         "bars": false,
         "dashLength": 10,
         "dashes": false,
@@ -801,7 +766,6 @@
         },
         "lines": true,
         "linewidth": 1,
-        "links": [],
         "nullPointMode": "null",
         "options": {
           "alertThreshold": true
@@ -860,7 +824,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "mode": "time",
           "show": true,
@@ -901,6 +865,7 @@
         "panels": [
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -942,7 +907,6 @@
             },
             "lines": true,
             "linewidth": 3,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -1033,7 +997,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -1127,7 +1091,6 @@
             },
             "id": 105,
             "interval": "",
-            "links": [],
             "options": {
               "legend": {
                 "calcs": [],
@@ -1209,6 +1172,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -1245,7 +1209,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -1293,7 +1256,7 @@
               "value_type": "cumulative"
             },
             "transformations": [],
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -1318,6 +1281,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -1351,7 +1315,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -1394,7 +1357,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -1423,6 +1386,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -1457,7 +1421,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -1514,7 +1477,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -1538,6 +1501,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -1571,7 +1535,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null as zero",
             "options": {
               "alertThreshold": true
@@ -1629,7 +1592,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -1655,6 +1618,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -1733,7 +1697,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -1919,7 +1883,6 @@
             "legend": {
               "show": false
             },
-            "links": [],
             "options": {
               "calculate": false,
               "calculation": {},
@@ -1990,6 +1953,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -2027,7 +1991,6 @@
             },
             "lines": true,
             "linewidth": 2,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -2065,7 +2028,7 @@
               "sort": 0,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -2091,6 +2054,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -2119,7 +2083,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -2153,7 +2116,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -2179,6 +2142,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -2207,7 +2171,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -2243,7 +2206,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -2270,6 +2233,7 @@
             "aliasColors": {
               "irc-freenode (local)": "#EAB839"
             },
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -2301,7 +2265,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -2336,7 +2299,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -2361,6 +2324,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -2393,7 +2357,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -2430,7 +2393,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -2457,6 +2420,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -2491,7 +2455,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -2583,7 +2546,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -2746,6 +2709,7 @@
         "panels": [
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -2787,7 +2751,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -2842,7 +2805,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -2868,6 +2831,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -2905,7 +2869,6 @@
             },
             "lines": true,
             "linewidth": 2,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -2941,7 +2904,7 @@
               "sort": 2,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -2967,6 +2930,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -3008,7 +2972,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -3063,7 +3026,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -3089,6 +3052,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -3130,7 +3094,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -3185,7 +3148,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -3211,6 +3174,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -3251,7 +3215,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -3287,7 +3250,7 @@
               "sort": 2,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -3313,6 +3276,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -3353,7 +3317,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -3390,7 +3353,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -3414,6 +3377,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -3447,7 +3411,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -3498,7 +3461,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -3549,6 +3512,7 @@
         "panels": [
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -3582,7 +3546,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -3618,7 +3581,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -3642,6 +3605,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -3675,7 +3639,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -3711,7 +3674,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -3735,6 +3698,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -3799,7 +3763,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -3850,6 +3814,7 @@
         "panels": [
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -3883,7 +3848,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -3926,7 +3890,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -3950,6 +3914,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -3983,7 +3948,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -4028,7 +3992,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -4052,6 +4016,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -4086,7 +4051,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -4134,7 +4098,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -4158,6 +4122,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -4192,7 +4157,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -4230,7 +4194,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -4331,7 +4295,7 @@
                       "id": "custom.hideFrom",
                       "value": {
                         "legend": false,
-                        "tooltip": false,
+                        "tooltip": true,
                         "viz": true
                       }
                     }
@@ -4453,7 +4417,7 @@
                       "id": "custom.hideFrom",
                       "value": {
                         "legend": false,
-                        "tooltip": false,
+                        "tooltip": true,
                         "viz": true
                       }
                     }
@@ -4500,6 +4464,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -4580,7 +4545,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -4609,6 +4574,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -4643,7 +4609,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -4739,7 +4704,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -4806,7 +4771,6 @@
             "legend": {
               "show": false
             },
-            "links": [],
             "options": {
               "calculate": false,
               "calculation": {},
@@ -4884,6 +4848,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -4918,7 +4883,6 @@
             },
             "lines": true,
             "linewidth": 0,
-            "links": [],
             "nullPointMode": "connected",
             "options": {
               "alertThreshold": true
@@ -5072,7 +5036,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -5142,7 +5106,6 @@
             "legend": {
               "show": false
             },
-            "links": [],
             "options": {
               "calculate": false,
               "calculation": {},
@@ -5220,6 +5183,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -5257,7 +5221,6 @@
             },
             "lines": true,
             "linewidth": 2,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -5297,7 +5260,7 @@
               "sort": 0,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -5324,6 +5287,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -5361,7 +5325,6 @@
             },
             "lines": true,
             "linewidth": 2,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -5401,7 +5364,7 @@
               "sort": 0,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -5428,6 +5391,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -5489,7 +5453,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -5894,6 +5858,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -5930,7 +5895,6 @@
             },
             "lines": true,
             "linewidth": 0,
-            "links": [],
             "nullPointMode": "connected",
             "options": {
               "alertThreshold": true
@@ -6110,7 +6074,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -6338,7 +6302,6 @@
               "y": 155
             },
             "id": 51,
-            "links": [],
             "options": {
               "legend": {
                 "calcs": [],
@@ -6386,6 +6349,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -6452,7 +6416,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -6503,6 +6467,7 @@
         "panels": [
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -6538,7 +6503,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -6578,7 +6542,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -6604,6 +6568,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -6639,7 +6604,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -6679,7 +6643,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -6705,6 +6669,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -6740,7 +6705,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -6799,7 +6763,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -6828,6 +6792,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -6863,7 +6828,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -6922,7 +6886,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -6949,6 +6913,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -6984,7 +6949,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -7043,7 +7007,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -7158,7 +7122,6 @@
               "y": 35
             },
             "id": 48,
-            "links": [],
             "options": {
               "legend": {
                 "calcs": [],
@@ -7190,6 +7153,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -7225,7 +7189,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -7293,7 +7256,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -7319,6 +7282,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -7357,7 +7321,6 @@
             },
             "lines": true,
             "linewidth": 2,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -7394,7 +7357,7 @@
               "sort": 0,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -7419,6 +7382,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -7457,7 +7421,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -7495,7 +7458,7 @@
               "sort": 0,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -7519,6 +7482,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -7557,7 +7521,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": false
@@ -7595,7 +7558,7 @@
               "sort": 0,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -7619,6 +7582,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -7652,7 +7616,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -7716,7 +7679,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -7771,6 +7734,7 @@
         "panels": [
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -7808,7 +7772,6 @@
             },
             "lines": true,
             "linewidth": 2,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -7845,7 +7808,7 @@
               "sort": 2,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -7869,6 +7832,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -7906,7 +7870,6 @@
             },
             "lines": true,
             "linewidth": 2,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -7943,7 +7906,7 @@
               "sort": 2,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -7967,6 +7930,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -8005,7 +7969,6 @@
             },
             "lines": true,
             "linewidth": 2,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -8044,7 +8007,7 @@
               "sort": 2,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -8071,6 +8034,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -8109,7 +8073,6 @@
             },
             "lines": true,
             "linewidth": 2,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -8146,7 +8109,7 @@
               "sort": 2,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -8170,6 +8133,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -8206,7 +8170,6 @@
             },
             "lines": true,
             "linewidth": 2,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -8243,7 +8206,7 @@
               "sort": 0,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -8267,6 +8230,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -8303,7 +8267,6 @@
             },
             "lines": true,
             "linewidth": 2,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -8340,7 +8303,7 @@
               "sort": 0,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -8366,6 +8329,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -8426,7 +8390,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -8477,6 +8441,7 @@
         "panels": [
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -8517,7 +8482,6 @@
             },
             "lines": true,
             "linewidth": 2,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -8553,7 +8517,7 @@
               "sort": 0,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -8580,6 +8544,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -8618,7 +8583,6 @@
             },
             "lines": true,
             "linewidth": 2,
-            "links": [],
             "nullPointMode": "connected",
             "options": {
               "alertThreshold": true
@@ -8655,7 +8619,7 @@
               "sort": 0,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -8680,6 +8644,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -8718,7 +8683,6 @@
             },
             "lines": true,
             "linewidth": 2,
-            "links": [],
             "nullPointMode": "connected",
             "options": {
               "alertThreshold": true
@@ -8754,7 +8718,7 @@
               "sort": 0,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -8779,6 +8743,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -8818,7 +8783,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -8854,7 +8818,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -8880,6 +8844,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -8914,7 +8879,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -8949,7 +8913,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -9001,6 +8965,7 @@
         "panels": [
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -9067,7 +9032,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -9091,6 +9056,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -9166,7 +9132,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -9219,6 +9185,7 @@
         "panels": [
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -9253,7 +9220,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -9288,7 +9254,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -9313,6 +9279,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -9352,7 +9319,6 @@
             },
             "lines": true,
             "linewidth": 2,
-            "links": [],
             "nullPointMode": "null as zero",
             "options": {
               "alertThreshold": true
@@ -9388,7 +9354,7 @@
               "sort": 0,
               "value_type": "cumulative"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -9412,6 +9378,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -9449,7 +9416,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -9488,7 +9454,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -9514,6 +9480,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -9548,7 +9515,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "connected",
             "options": {
               "alertThreshold": true
@@ -9582,7 +9548,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -9606,6 +9572,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -9640,7 +9607,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -9674,7 +9640,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -9732,7 +9698,6 @@
             "legend": {
               "show": true
             },
-            "links": [],
             "reverseYBuckets": false,
             "targets": [
               {
@@ -9792,6 +9757,7 @@
         "panels": [
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -9826,7 +9792,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -9862,7 +9827,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -9951,7 +9916,6 @@
               "y": 162
             },
             "id": 41,
-            "links": [],
             "options": {
               "legend": {
                 "calcs": [],
@@ -10050,7 +10014,6 @@
               "y": 169
             },
             "id": 42,
-            "links": [],
             "options": {
               "legend": {
                 "calcs": [],
@@ -10150,7 +10113,6 @@
               "y": 169
             },
             "id": 220,
-            "links": [],
             "options": {
               "legend": {
                 "calcs": [],
@@ -10185,6 +10147,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -10253,7 +10216,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -10279,6 +10242,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -10313,7 +10277,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -10348,7 +10311,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -10374,6 +10337,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -10407,7 +10371,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -10452,7 +10415,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -10504,6 +10467,7 @@
         "panels": [
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -10537,7 +10501,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "connected",
             "options": {
               "alertThreshold": true
@@ -10573,7 +10536,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -10599,6 +10562,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -10632,7 +10596,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "connected",
             "options": {
               "alertThreshold": true
@@ -10669,7 +10632,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -10694,6 +10657,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -10728,7 +10692,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "connected",
             "options": {
               "alertThreshold": true
@@ -10765,7 +10728,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -10860,7 +10823,6 @@
             "legend": {
               "show": true
             },
-            "links": [],
             "options": {
               "calculate": false,
               "calculation": {},
@@ -10933,6 +10895,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -10968,7 +10931,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "connected",
             "options": {
               "alertThreshold": true
@@ -11003,7 +10965,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -11071,7 +11033,6 @@
             "legend": {
               "show": true
             },
-            "links": [],
             "options": {
               "calculate": false,
               "calculation": {},
@@ -11144,6 +11105,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -11178,7 +11140,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -11242,7 +11203,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -11311,7 +11272,6 @@
             "legend": {
               "show": true
             },
-            "links": [],
             "options": {
               "calculate": false,
               "calculation": {},
@@ -11384,6 +11344,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -11418,7 +11379,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -11482,7 +11442,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -11551,7 +11511,6 @@
             "legend": {
               "show": true
             },
-            "links": [],
             "options": {
               "calculate": false,
               "calculation": {},
@@ -11625,6 +11584,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -11661,7 +11621,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -11731,7 +11690,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -11757,6 +11716,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -11835,7 +11795,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -11886,6 +11846,7 @@
         "panels": [
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -11920,7 +11881,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -11977,7 +11937,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -12004,6 +11964,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -12063,7 +12024,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -12114,6 +12075,7 @@
         "panels": [
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -12148,7 +12110,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -12187,7 +12148,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -12213,6 +12174,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -12247,7 +12209,6 @@
             },
             "lines": true,
             "linewidth": 1,
-            "links": [],
             "nullPointMode": "null",
             "options": {
               "alertThreshold": true
@@ -12285,7 +12246,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -12339,6 +12300,7 @@
         "panels": [
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -12401,7 +12363,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -12427,6 +12389,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -12489,7 +12452,7 @@
               "sort": 0,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -12542,6 +12505,7 @@
         "panels": [
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -12637,7 +12601,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -12661,6 +12625,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -12723,7 +12688,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -12749,6 +12714,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -12811,7 +12777,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -12957,6 +12923,7 @@
           },
           {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
@@ -13020,7 +12987,7 @@
               "sort": 2,
               "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
               "mode": "time",
               "show": true,
@@ -13089,7 +13056,6 @@
             "legend": {
               "show": false
             },
-            "links": [],
             "options": {
               "calculate": false,
               "calculation": {},
@@ -13270,8 +13236,7 @@
       }
     ],
     "refresh": "5s",
-    "schemaVersion": 37,
-    "style": "dark",
+    "schemaVersion": 42,
     "tags": [],
     "templating": {
       "list": [
@@ -13456,17 +13421,6 @@
         "1h",
         "2h",
         "1d"
-      ],
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
       ]
     },
     "timezone": "",

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/user-credits.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/user-credits.json
@@ -2,10 +2,10 @@
   "apiVersion": "dashboard.grafana.app/v1beta1",
   "kind": "Dashboard",
   "metadata": {
-    "name": "eetquziy9np4wa",
     "annotations": {
       "grafana.app/folder": "defd2d156sav4d"
-    }
+    },
+    "name": "eetquziy9np4wa"
   },
   "spec": {
     "annotations": {
@@ -88,8 +88,7 @@
               "mode": "absolute",
               "steps": [
                 {
-                  "color": "yellow",
-                  "value": null
+                  "color": "yellow"
                 }
               ]
             }
@@ -252,7 +251,7 @@
       }
     ],
     "refresh": "5s",
-    "schemaVersion": 39,
+    "schemaVersion": 42,
     "tags": [],
     "templating": {
       "list": [

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/worker-status.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/worker-status.json
@@ -2,10 +2,10 @@
   "apiVersion": "dashboard.grafana.app/v1beta1",
   "kind": "Dashboard",
   "metadata": {
-    "name": "aetquzj0mdb7kb",
     "annotations": {
       "grafana.app/folder": "defd2d156sav4d"
-    }
+    },
+    "name": "aetquzj0mdb7kb"
   },
   "spec": {
     "annotations": {
@@ -58,7 +58,8 @@
         "type": "alertlist"
       }
     ],
-    "schemaVersion": 39,
+    "refresh": "",
+    "schemaVersion": 42,
     "tags": [],
     "templating": {
       "list": []

--- a/packages/observability/scripts/diff.sh
+++ b/packages/observability/scripts/diff.sh
@@ -46,6 +46,20 @@ cd "$(dirname "$0")/.."
 # shellcheck source=./grafanactl-env.sh
 source ./scripts/grafanactl-env.sh "$env_name"
 
+# Mirror apply.sh's per-env REALM_SERVER_URL handling so the
+# `__REALM_SERVER_URL__` placeholder substitution below produces the
+# same value diff.sh expects to find in the live (pulled) state. CI
+# sources REALM_SERVER_URL from SSM in observability-diff.yml; locally
+# we default to apply.sh's hardcoded http://localhost:4201/.
+case "$env_name" in
+  local) realm_server_url="${REALM_SERVER_URL:-http://localhost:4201/}" ;;
+  *)
+    [[ -n "${REALM_SERVER_URL:-}" ]] \
+      || { echo "error: REALM_SERVER_URL not set; required for diff.sh --env ${env_name}" >&2; exit 1; }
+    realm_server_url="$REALM_SERVER_URL"
+    ;;
+esac
+
 cfg="$(./scripts/render-config.sh "$env_name")"
 remote="$(mktemp -d -t grafanactl-pull.XXXXXX)"
 remote_norm="$(mktemp -d -t grafanactl-norm.XXXXXX)"
@@ -118,9 +132,9 @@ normalize() {  # $1: subdir under grafanactl/resources, $2: pulled-kind dirname
 normalize dashboards Dashboard
 normalize folders Folder
 
-# Normalize JSON content (CS-10988). Without this, `git diff` surfaces
-# four classes of noise that have nothing to do with what an apply would
-# actually change:
+# Normalize JSON content (CS-10988 + CS-10990 + CS-10991). Without
+# this, `git diff` surfaces several classes of noise that have nothing
+# to do with what an apply would actually change:
 #
 #   1. Unicode-escape style. The committed JSON encodes `&` as the
 #      6-byte escape sequence `&` and `>` as `>` (an artefact
@@ -139,22 +153,52 @@ normalize folders Folder
 #      it cannot hide a real diff.
 #   3. Key order inside `metadata`. `--sort-keys` makes order stable on
 #      both sides.
-#   4. (Not handled here.) Default values like `"value": null` injected
-#      into threshold step arrays. The acceptance criteria flagged this
-#      as optional, and a generic null-strip risks dropping legitimate
-#      explicit nulls. Deferred to a follow-up if it dominates a future
-#      diff.
+#   4. `__REALM_SERVER_URL__` placeholder (CS-10923 / CS-10990). apply.sh
+#      walks the committed JSON and substitutes the per-env realm-server
+#      URL into the `realm_server` constant template variable's `query`
+#      before pushing. Pulled state therefore always shows the substituted
+#      value. We mirror the same walk here so the committed side ends up
+#      with the same value pre-diff. Substitution is a no-op when run on
+#      the pulled side (the placeholder isn't there).
+#   5. Default `"value": null` on threshold step zero (CS-10991). Grafana
+#      fills in `value: null` on the lowest threshold step (the implicit
+#      `-Infinity` floor) when it stores a dashboard. AMG-era exports
+#      and humans omit the key. The match is scoped to objects that
+#      look like a thresholds container (`mode` + `steps`) at index 0
+#      so a `value: null` higher up the steps array (a malformed
+#      threshold worth surfacing) still shows in the diff.
 JQ_NORMALIZE='
-  if type == "object" and has("metadata") and (.metadata | type) == "object" then
-    .metadata |= (
-      del(.id)
-      | del(.resourceVersion)
-      | del(.creationTimestamp)
-      | del(.uid)
-      | (if has("labels") and (.labels | type) == "object" and (.labels | length) == 0 then del(.labels) else . end)
-      | (if .namespace == "default" then del(.namespace) else . end)
+  walk(
+    if type == "object"
+       and .name? == "realm_server"
+       and .type? == "constant"
+    then
+      .query = $url
+      | (if .current then .current.value = $url | .current.text = $url else . end)
+    else . end
+  )
+  | walk(
+      if type == "object"
+         and has("mode")
+         and (.steps? | type) == "array"
+         and (.steps | length) > 0
+         and (.steps[0] | type) == "object"
+         and (.steps[0] | has("value"))
+         and (.steps[0].value == null)
+      then
+        .steps[0] |= del(.value)
+      else . end
     )
-  else . end
+  | (if type == "object" and has("metadata") and (.metadata | type) == "object" then
+      .metadata |= (
+        del(.id)
+        | del(.resourceVersion)
+        | del(.creationTimestamp)
+        | del(.uid)
+        | (if has("labels") and (.labels | type) == "object" and (.labels | length) == 0 then del(.labels) else . end)
+        | (if .namespace == "default" then del(.namespace) else . end)
+      )
+    else . end)
 '
 
 normalize_json_content() {  # $1: src dir, $2: dest dir
@@ -169,7 +213,7 @@ normalize_json_content() {  # $1: src dir, $2: dest dir
     rel="${f#$src/}"
     target="$dest/$rel"
     mkdir -p "$(dirname "$target")"
-    jq --sort-keys "$JQ_NORMALIZE" "$f" > "$target"
+    jq --sort-keys --arg url "$realm_server_url" "$JQ_NORMALIZE" "$f" > "$target"
   done < <(find "$src" -type f -name '*.json' -print0)
 }
 

--- a/packages/observability/scripts/diff.sh
+++ b/packages/observability/scripts/diff.sh
@@ -50,12 +50,15 @@ source ./scripts/grafanactl-env.sh "$env_name"
 # `__REALM_SERVER_URL__` placeholder substitution below produces the
 # same value diff.sh expects to find in the live (pulled) state. CI
 # sources REALM_SERVER_URL from SSM in observability-diff.yml; locally
-# we default to apply.sh's hardcoded http://localhost:4201/.
+# we default to apply.sh's hardcoded http://localhost:4201/. For
+# staging/production ad-hoc runs, the operator must export the same
+# value apply.sh uses (CI fetches it from /<env>/boxel-grafana/realm_server_url
+# — see observability-apply-${env_name}.yml).
 case "$env_name" in
   local) realm_server_url="${REALM_SERVER_URL:-http://localhost:4201/}" ;;
   *)
     [[ -n "${REALM_SERVER_URL:-}" ]] \
-      || { echo "error: REALM_SERVER_URL not set; required for diff.sh --env ${env_name}" >&2; exit 1; }
+      || { echo "error: REALM_SERVER_URL not set; CI fetches it from /${env_name}/boxel-grafana/realm_server_url in observability-diff.yml — for a local hosted run, export it manually first (same SSM path apply-${env_name}.yml uses)" >&2; exit 1; }
     realm_server_url="$REALM_SERVER_URL"
     ;;
 esac
@@ -158,8 +161,12 @@ normalize folders Folder
 #      URL into the `realm_server` constant template variable's `query`
 #      before pushing. Pulled state therefore always shows the substituted
 #      value. We mirror the same walk here so the committed side ends up
-#      with the same value pre-diff. Substitution is a no-op when run on
-#      the pulled side (the placeholder isn't there).
+#      with the same value pre-diff. The match is GUARDED by
+#      `.query == "__REALM_SERVER_URL__"` so the substitution only
+#      rewrites the committed side; the pulled side always carries the
+#      live URL (never the placeholder), so leaving it untouched lets
+#      real drift between $REALM_SERVER_URL and what's actually
+#      provisioned in Grafana surface in the diff.
 #   5. Default `"value": null` on threshold step zero (CS-10991). Grafana
 #      fills in `value: null` on the lowest threshold step (the implicit
 #      `-Infinity` floor) when it stores a dashboard. AMG-era exports
@@ -172,6 +179,7 @@ JQ_NORMALIZE='
     if type == "object"
        and .name? == "realm_server"
        and .type? == "constant"
+       and .query? == "__REALM_SERVER_URL__"
     then
       .query = $url
       | (if .current then .current.value = $url | .current.text = $url else . end)

--- a/packages/observability/scripts/diff.sh
+++ b/packages/observability/scripts/diff.sh
@@ -196,6 +196,7 @@ JQ_NORMALIZE='
         | del(.creationTimestamp)
         | del(.uid)
         | (if has("labels") and (.labels | type) == "object" and (.labels | length) == 0 then del(.labels) else . end)
+        | (if has("annotations") and (.annotations | type) == "object" and (.annotations | length) == 0 then del(.annotations) else . end)
         | (if .namespace == "default" then del(.namespace) else . end)
       )
     else . end)


### PR DESCRIPTION
## Summary

PR #4611's first observability-diff comment showed ~2,473 residual lines after CS-10988's canonicalizer ran. This bundles the three follow-ups so the comment goes from 2.5k lines to empty:

- **CS-10991** — strip default `value: null` on threshold step zero in `diff.sh`'s canonicalizer (Grafana fills in the implicit -Infinity floor; committed JSON omits it). Match scoped to thresholds-shaped objects (`mode` + `steps`), index 0 only, so a `value: null` higher up the array — a malformed threshold worth surfacing — still shows in the diff.
- **CS-10990** — apply `__REALM_SERVER_URL__` substitution in `diff.sh` too. `apply.sh` substitutes the placeholder per env at push time; `diff.sh` didn't, so every round-trip diff permanently showed the placeholder vs the live URL. Mirrors the same `walk` filter; sources `REALM_SERVER_URL` from SSM in `observability-diff.yml` (same path the apply workflow already uses).
- **CS-10989** — capture Grafana 12 schemaVersion 42 form into committed dashboard JSON. Applied locally against a Grafana 12.4.3 container, pulled via `grafanactl`, jq-filtered to reverse the realm-server URL substitution and strip non-round-trippable App Platform metadata. Synapse panels move from `type: graph` (vendored at schemaVersion 37) to `type: timeseries` as Grafana 12's auto-migration produces them.
- One-line bonus: strip empty `metadata.annotations: {}` from the canonicalizer the same way the existing rule strips empty `metadata.labels: {}`. Folder JSON had this leftover.

## Test plan

- [ ] `cd packages/observability && ./scripts/apply.sh --env local` (presumes #4611's docker-compose env-var fix is in place if doing a fresh `compose up -d`)
- [ ] `./scripts/diff.sh --env local` returns zero lines
- [ ] All 6 dashboards still render in `http://localhost:3001` — confirmed locally for synapse (post panel-type migration: `type: timeseries` works as expected, no JSON parse errors) and boxel-jobs (Postgres-backed table still renders rows)
- [ ] Re-applying `apply.sh` after `diff.sh` is a no-op on the diff (idempotent round-trip)
- [ ] CI's observability-diff comment on this PR should show "No dashboard / folder changes detected" once it runs against staging
- [ ] Local round-trip went 2,473 → 2,386 (CS-10990 + CS-10991) → 12 (CS-10989) → 0 (annotations strip) lines

## Notes

- Synapse migration is appropriate maintenance for vendored content (per the README's "Vendored content" section): Grafana 12 doesn't accept upstream's panels at schemaVersion 37 without auto-migrating them, so we either ship the migrated form or accept the diff churn forever. Next time we re-pull from upstream Synapse contrib, rebase against this migrated form.
- Closes CS-10989, CS-10990, CS-10991. Unblocks AC #4 of CS-10926.

🤖 Generated with [Claude Code](https://claude.com/claude-code)