### PR TITLE
CS-10924: remove auth secrets from dashboard bodies + add CI scan

### DIFF
--- a/.github/workflows/observability-check.yml
+++ b/.github/workflows/observability-check.yml
@@ -1,0 +1,35 @@
+name: Observability — secret scan
+
+# Per-PR sanity check that nothing committed under packages/observability/**
+# matches a credential-shaped pattern (Grafana auth-in-querystring, baked
+# data-source passwords, hard-coded Bearer tokens, AWS access keys, literal
+# password / api_key values). The patterns and allowlist live in
+# packages/observability/scripts/check-no-secrets.sh — keeping the rules
+# next to the resources they guard means changes to one are reviewed
+# alongside changes to the other.
+#
+# History: CS-10924 stripped `?authHeader=${grafana_secret}` from every
+# operator-action URL after that pattern leaked into committed dashboard
+# JSON. This workflow is the regression guard.
+
+on:
+  pull_request:
+    paths:
+      - "packages/observability/**"
+      - ".github/workflows/observability-check.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  no-secrets:
+    name: Observability — secret scan
+    runs-on: ubuntu-latest
+    concurrency:
+      group: observability-check-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: check-no-secrets
+        working-directory: packages/observability
+        run: ./scripts/check-no-secrets.sh

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -319,3 +319,11 @@ CI will run `apply.sh --env staging` on merge to main once Phase 4 (CS-10932) la
 - **Decommission the AMG-era `boxel-dashboard/` Terraform** in `cardstack/infra` once a full release cycle has gone by on the new flow. Tracked as CS-10942. After it lands, `configs/boxel-grafana-data-sources/` (in cardstack/infra) becomes the sole owner of the per-env data the boxel CI workflow reads.
 - **Drop the dual-ship to CloudWatch** once Loki has been load-bearing for a release cycle. Until then both backends receive identical lines through the FireLens config in `cardstack/infra:modules/aws/ecs/firelens/templates/extra.conf.tftpl`.
 - **CODEOWNERS.** No file in the repo today — if the team wants observability-specific reviewer requirements, file a separate ticket.
+
+### TODO(Phase 3.5): operator-action links are temporarily broken
+
+CS-10924 stripped `?authHeader=${grafana_secret}` from every operator-action URL in the dashboards (reindex / full-reindex / complete-job in `boxel-jobs.json`, add-credit in `user-credits.json`, upsert-realm-user-permission in `realm-permissions.json`) and removed the matching `grafana_secret` template variable. The links remain in the JSON so the Phase 3.5 ticket has a concrete target to retrofit, but **clicking them now hits the realm-server operator endpoints with no auth and will 401**.
+
+Phase 3.5 (CS-10987 — operator-endpoint cleanup, deferred to after the cutover) replaces the GET-link pattern with Grafana button panels that POST to the same endpoints with an `Authorization: Bearer <token>` header sourced from a Grafana-managed secret, not a querystring. Until that lands, dashboard operators run those actions via `boxel realm reindex` (CLI) or by hitting the endpoints directly with `curl -H "Authorization: ..."`.
+
+The pre-existing `grafana_secret` value that was previously baked into Terraform / piped through CI logs **must be rotated** as part of the Phase 3.5 cutover — assume compromised. (CS-10924 acceptance criteria carry-over.)

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-jobs.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/boxel-jobs.json
@@ -38,7 +38,7 @@
         "title": "Reindex ${full_index_realm}",
         "tooltip": "",
         "type": "link",
-        "url": "${realm_server}_grafana-reindex?authHeader=${grafana_secret}&realm=${full_index_realm}"
+        "url": "${realm_server}_grafana-reindex?realm=${full_index_realm}"
       },
       {
         "asDropdown": false,
@@ -50,7 +50,7 @@
         "title": "Reindex All Realms",
         "tooltip": "",
         "type": "link",
-        "url": "${realm_server}_grafana-full-reindex?authHeader=${grafana_secret}"
+        "url": "${realm_server}_grafana-full-reindex"
       }
     ],
     "panels": [
@@ -101,7 +101,7 @@
                     {
                       "targetBlank": true,
                       "title": "Delete",
-                      "url": "${realm_server}_grafana-complete-job?authHeader=${grafana_secret}&job_id=${__value.raw}"
+                      "url": "${realm_server}_grafana-complete-job?job_id=${__value.raw}"
                     }
                   ]
                 },
@@ -269,7 +269,7 @@
                     {
                       "targetBlank": true,
                       "title": "Delete",
-                      "url": "${realm_server}_grafana-complete-job?authHeader=${grafana_secret}&reservation_id=${__value.raw}"
+                      "url": "${realm_server}_grafana-complete-job?reservation_id=${__value.raw}"
                     }
                   ]
                 },
@@ -523,13 +523,6 @@
           "hide": 2,
           "name": "realm_server",
           "query": "__REALM_SERVER_URL__",
-          "skipUrlSync": false,
-          "type": "constant"
-        },
-        {
-          "hide": 2,
-          "name": "grafana_secret",
-          "query": "REPLACE_AT_APPLY_TIME",
           "skipUrlSync": false,
           "type": "constant"
         }

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/realm-permissions.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/realm-permissions.json
@@ -38,7 +38,7 @@
         "title": "Grant ${permission_label} to ${matrix_username}",
         "tooltip": "",
         "type": "link",
-        "url": "${realm_server}_grafana-upsert-realm-user-permission?authHeader=${grafana_secret}&realm=${realm_url}&user=${matrix_username}&read=${read_flag}&write=${write_flag}"
+        "url": "${realm_server}_grafana-upsert-realm-user-permission?realm=${realm_url}&user=${matrix_username}&read=${read_flag}&write=${write_flag}"
       }
     ],
     "panels": [
@@ -285,13 +285,6 @@
           "skipUrlSync": true,
           "sort": 0,
           "type": "query"
-        },
-        {
-          "hide": 2,
-          "name": "grafana_secret",
-          "query": "REPLACE_AT_APPLY_TIME",
-          "skipUrlSync": false,
-          "type": "constant"
         },
         {
           "hide": 2,

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/user-credits.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/user-credits.json
@@ -38,7 +38,7 @@
         "title": "Add 1,000 Credits",
         "tooltip": "",
         "type": "link",
-        "url": "${realm_server}_grafana-add-credit?authHeader=${grafana_secret}&user=${matrix_user_id}&credit=1000"
+        "url": "${realm_server}_grafana-add-credit?user=${matrix_user_id}&credit=1000"
       },
       {
         "asDropdown": false,
@@ -50,7 +50,7 @@
         "title": "Add 10,000 Credits",
         "tooltip": "",
         "type": "link",
-        "url": "${realm_server}_grafana-add-credit?authHeader=${grafana_secret}&user=${matrix_user_id}&credit=10000"
+        "url": "${realm_server}_grafana-add-credit?user=${matrix_user_id}&credit=10000"
       },
       {
         "asDropdown": false,
@@ -62,7 +62,7 @@
         "title": "Add 100,000 Credits",
         "tooltip": "",
         "type": "link",
-        "url": "${realm_server}_grafana-add-credit?authHeader=${grafana_secret}&user=${matrix_user_id}&credit=100000"
+        "url": "${realm_server}_grafana-add-credit?user=${matrix_user_id}&credit=100000"
       }
     ],
     "panels": [
@@ -274,13 +274,6 @@
           "skipUrlSync": false,
           "sort": 1,
           "type": "query"
-        },
-        {
-          "hide": 2,
-          "name": "grafana_secret",
-          "query": "REPLACE_AT_APPLY_TIME",
-          "skipUrlSync": false,
-          "type": "constant"
         },
         {
           "hide": 2,

--- a/packages/observability/scripts/check-no-secrets.sh
+++ b/packages/observability/scripts/check-no-secrets.sh
@@ -69,7 +69,7 @@ ALLOWLIST=(
   # Comments and rationale fields that mention these patterns by name
   # for documentation purposes (this script's own comments, README
   # callouts, etc.). Match a leading `#`, `//`, or markdown-list `-`.
-  '^[[:space:]]*(#|//|--|\*)'
+  '^[[:space:]]*(#|//|-|\*)'
   # JSON keys that contain the word "password"/"api_key"/"secret" but
   # whose values are placeholders or empty strings — e.g. the
   # secureJsonData scaffolding pattern.

--- a/packages/observability/scripts/check-no-secrets.sh
+++ b/packages/observability/scripts/check-no-secrets.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# check-no-secrets.sh — Fail if any committed file under this package
+# contains a credential-shaped string. Wired into a GitHub Actions
+# workflow (.github/workflows/observability-check.yml) and intended to
+# be runnable locally for the same exit semantics.
+#
+# Usage:
+#   ./scripts/check-no-secrets.sh
+#
+# Exit 0 when nothing matches, 1 with grep output when something does.
+#
+# Why this lives in the observability package and not at the repo root:
+# the patterns we care about here (Grafana auth-in-querystring, baked
+# data-source passwords, hard-coded Bearer tokens) are specific to
+# Grafana resource files. Running these patterns repo-wide would catch
+# things like "password" in test fixtures, doc strings, etc., and we'd
+# spend our time tuning allowlists instead of catching real misuses.
+#
+# History: CS-10924 stripped `?authHeader=${grafana_secret}` from every
+# operator-action URL in the dashboards (reindex / full-reindex /
+# complete-job / add-credit / upsert-realm-user-permission). This
+# script is the regression guard so that pattern can't sneak back.
+
+set -eo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Patterns + descriptions, in parallel arrays so the regexes can contain
+# colons (POSIX character classes like `[[:space:]]`) without breaking
+# a single-string `name:regex` parser.
+#
+# Pattern design notes:
+# - `authHeader=` — the specific anti-pattern CS-10924 removed. Zero
+#   tolerance: we don't want this to come back even gated on a Grafana
+#   variable, because the pattern leaks the auth token through URL bars,
+#   browser history, copy/paste, and screenshots once Grafana expands it
+#   client-side.
+# - `Bearer <long token>` — match Bearer followed by 30+ token-shaped
+#   chars to avoid hitting placeholders like `Bearer <token>` or
+#   `Bearer ${...}`.
+# - `AKIA[A-Z0-9]{16}` — AWS access key ID prefix, fixed format.
+# - `password[:=] ... 8+ non-placeholder chars` — excludes `${VAR}`
+#   substitutions, `<value>` placeholders, empty strings, whitespace.
+# - `api[_-]?key[:=] ... 16+ non-placeholder chars` — same shape; longer
+#   minimum because API keys are typically longer than passwords.
+PATTERN_REGEXES=(
+  'authHeader='
+  '[Bb]earer [A-Za-z0-9._/+=-]{30,}'
+  'AKIA[A-Z0-9]{16}'
+  'password[[:space:]]*[:=][[:space:]]*["'"'"']?[^$<[:space:]"'"'"']{8,}'
+  'api[_-]?key[[:space:]]*[:=][[:space:]]*["'"'"']?[^$<[:space:]"'"'"']{16,}'
+)
+PATTERN_DESCS=(
+  'authHeader= (Grafana auth-in-querystring; rotate via Phase 3.5 button panels)'
+  'long Bearer token'
+  'AWS access key ID'
+  'literal password value'
+  'literal API key value'
+)
+
+# Per-line allowlist. Lines matching any allowlist regex are excluded
+# from secret-scan results. Add narrowly-scoped entries here when the
+# scanner is wrong; never broaden to "anything in tests/" or similar.
+ALLOWLIST=(
+  # Grafana variable interpolations and Bash/YAML template placeholders
+  # are by design — the actual value lives in SSM and gets substituted
+  # at apply time, never in git.
+  '\$\{[A-Za-z_][A-Za-z0-9_]*\}'
+  # Comments and rationale fields that mention these patterns by name
+  # for documentation purposes (this script's own comments, README
+  # callouts, etc.). Match a leading `#`, `//`, or markdown-list `-`.
+  '^[[:space:]]*(#|//|--|\*)'
+  # JSON keys that contain the word "password"/"api_key"/"secret" but
+  # whose values are placeholders or empty strings — e.g. the
+  # secureJsonData scaffolding pattern.
+  '"password":[[:space:]]*"\$\{[^}]+\}"'
+  '"password":[[:space:]]*""'
+)
+
+# Scope: everything under this package, but skip generated/temp files
+# and the script itself (its pattern table would always match).
+FIND_ROOT="."
+EXCLUDE_DIRS=(
+  "./node_modules"
+  "./dist"
+  "./.tmp"
+)
+
+# Build a `find` invocation that prunes excluded dirs, then filters to
+# the file types we care about. We intentionally cast a wide net (any
+# text file) so future YAML / TS / Markdown additions are covered, and
+# rely on the allowlist + comment-prefix filter to drop noise.
+prune_args=()
+for d in "${EXCLUDE_DIRS[@]}"; do
+  prune_args+=(-path "$d" -prune -o)
+done
+
+# Compose ALLOWLIST into one OR'd ERE.
+allowlist_re="$(IFS='|'; echo "${ALLOWLIST[*]}")"
+
+violations=0
+violation_buf=""
+
+# Walk files. We can't use `git ls-files` because the script must work
+# during a fresh CI checkout where the package may be the only thing
+# being inspected and we want to flag uncommitted local edits too when
+# run by hand.
+while IFS= read -r -d '' file; do
+  # Skip self.
+  [[ "$file" == *"check-no-secrets.sh" ]] && continue
+  # Skip binary files quickly.
+  if file -b --mime "$file" 2>/dev/null | grep -q 'charset=binary'; then
+    continue
+  fi
+  for i in "${!PATTERN_REGEXES[@]}"; do
+    pat="${PATTERN_REGEXES[$i]}"
+    desc="${PATTERN_DESCS[$i]}"
+    # Use grep -nE for ERE + line numbers; -I skips binary. We then
+    # re-filter by the allowlist.
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      # `line` is "<lineno>:<text>".
+      text="${line#*:}"
+      # Apply allowlist.
+      if grep -Eq "$allowlist_re" <<<"$text"; then
+        continue
+      fi
+      violations=$((violations + 1))
+      violation_buf+="${file}:${line%%:*}: [${desc}] ${text}"$'\n'
+    done < <(grep -nIE -- "$pat" "$file" 2>/dev/null || true)
+  done
+done < <(find "$FIND_ROOT" "${prune_args[@]}" -type f -print0)
+
+if [[ $violations -gt 0 ]]; then
+  echo "check-no-secrets: found $violations potential secret-shaped strings:" >&2
+  printf '%s' "$violation_buf" >&2
+  echo "" >&2
+  echo "If this is a false positive, narrow the ALLOWLIST in scripts/check-no-secrets.sh." >&2
+  echo "If this is real, remove the value and source it from SSM via apply-time substitution." >&2
+  exit 1
+fi
+
+echo "check-no-secrets: no credential-shaped strings found in $(pwd)"


### PR DESCRIPTION
## Summary

- Strip `?authHeader=${grafana_secret}` (and trailing `&` / leading `?`) from every operator-action URL across `boxel-jobs.json`, `user-credits.json`, and `realm-permissions.json`. Drop the now-orphaned `grafana_secret` template variable definition from each.
- Document the Phase 3.5 handoff in `packages/observability/README.md` — links remain present but unauthenticated, so clicking them 401s until CS-10987 replaces them with button panels that POST + `Authorization` header.
- New `scripts/check-no-secrets.sh` + `.github/workflows/observability-check.yml`: per-PR regression guard scoped to `packages/observability/**`. Catches `authHeader=`, long `Bearer` tokens, AWS access key IDs, literal `password`/`api_key` values; allowlists `${VAR}` substitutions, comment lines, and known-good `secureJsonData` scaffolding.

Closes [CS-10924](https://linear.app/cardstack/issue/CS-10924).

## Why

The literal grafana auth token never lived in this tree (the dashboards stored `REPLACE_AT_APPLY_TIME` and substituted at apply time), but the *pattern* — token in URL querystring — flows into browser history, copy/paste, screenshots, and bug reports the moment Grafana expands it client-side. Once an `authHeader=` querystring lands in git, copy/pasted dashboards inherit it forever.

## Out of scope (carry-over)

- **Rotate the existing `grafana_secret` value.** It has been baked into Terraform state and piped through CI logs. Rotation has to happen as part of the Phase 3.5 cutover so the new value is installed in SSM at the same time the new POST flow lands.

## Test plan

- [x] `./scripts/check-no-secrets.sh` exits 0 on the cleaned tree.
- [x] Local synthetic test: a YAML file with `authHeader=`, `AKIA…`, long `Bearer`, `password: literal…`, and `api_key: …` → exit 1 with all four detection types reported.
- [x] Allowlist works: `password: ${BOXEL_DB_PASSWORD}` and `password: ""` are not flagged (verified in the same synthetic file).
- [ ] Push an intentional fake-secret commit to a throwaway PR and confirm the new `Observability — secret scan` workflow fails. (Best done on a follow-up PR rather than dirtying this one's history; happy to do so on request.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)