### PR TITLE
CS-10987 prep: accept POST + Bearer auth on grafana operator endpoints

### DIFF
--- a/packages/realm-server/middleware/index.ts
+++ b/packages/realm-server/middleware/index.ts
@@ -209,7 +209,18 @@ export function grafanaAuthorization(
 ): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
   return async function (ctxt: Koa.Context, next: Koa.Next) {
     let authorization = ctxt.req.headers['authorization'];
-    if (!authorization || authorization !== grafanaSecret) {
+    // Accept either the bare secret (legacy form: link-style `?authHeader=`
+    // promoted to a header by convertAuthHeaderQueryParam) or the
+    // standards-compliant `Bearer <secret>` form (CS-10987 button-panel
+    // dashboards). Both routes through the same downstream handler. Once
+    // the GET-link dashboards have been retired for a release cycle, drop
+    // the bare-secret branch + the convertAuthHeaderQueryParam middleware
+    // in one cleanup PR.
+    let isValid =
+      !!authorization &&
+      (authorization === grafanaSecret ||
+        authorization === `Bearer ${grafanaSecret}`);
+    if (!isValid) {
       await sendResponseForUnauthorizedRequest(
         ctxt,
         AuthenticationErrorMessages.MissingAuthHeader,

--- a/packages/realm-server/middleware/index.ts
+++ b/packages/realm-server/middleware/index.ts
@@ -228,11 +228,12 @@ export function grafanaAuthorization(
     let trimmed = authorization.trim();
     let isValid = trimmed === grafanaSecret;
     if (!isValid) {
-      let parts = trimmed.split(/\s+/);
-      isValid =
-        parts.length === 2 &&
-        parts[0].toLowerCase() === 'bearer' &&
-        parts[1] === grafanaSecret;
+      // Match only the first whitespace run so a secret that itself
+      // contains whitespace stays intact in the captured token. A greedy
+      // /\s+/ split produced parts.length > 2 for any such secret and
+      // false-rejected the request.
+      let bearerMatch = trimmed.match(/^bearer\s+(.+)$/i);
+      isValid = !!bearerMatch && bearerMatch[1] === grafanaSecret;
     }
     if (!isValid) {
       await sendResponseForUnauthorizedRequest(

--- a/packages/realm-server/middleware/index.ts
+++ b/packages/realm-server/middleware/index.ts
@@ -212,18 +212,32 @@ export function grafanaAuthorization(
     // Accept either the bare secret (legacy form: link-style `?authHeader=`
     // promoted to a header by convertAuthHeaderQueryParam) or the
     // standards-compliant `Bearer <secret>` form (CS-10987 button-panel
-    // dashboards). Both routes through the same downstream handler. Once
-    // the GET-link dashboards have been retired for a release cycle, drop
-    // the bare-secret branch + the convertAuthHeaderQueryParam middleware
-    // in one cleanup PR.
-    let isValid =
-      !!authorization &&
-      (authorization === grafanaSecret ||
-        authorization === `Bearer ${grafanaSecret}`);
-    if (!isValid) {
+    // dashboards). The Bearer parse follows RFC 6750: scheme name is
+    // case-insensitive and any 1+ whitespace separator is allowed. Both
+    // shapes route through the same downstream handler. Once the GET-link
+    // dashboards have been retired for a release cycle, drop the
+    // bare-secret branch + the convertAuthHeaderQueryParam middleware in
+    // one cleanup PR.
+    if (!authorization) {
       await sendResponseForUnauthorizedRequest(
         ctxt,
         AuthenticationErrorMessages.MissingAuthHeader,
+      );
+      return;
+    }
+    let trimmed = authorization.trim();
+    let isValid = trimmed === grafanaSecret;
+    if (!isValid) {
+      let parts = trimmed.split(/\s+/);
+      isValid =
+        parts.length === 2 &&
+        parts[0].toLowerCase() === 'bearer' &&
+        parts[1] === grafanaSecret;
+    }
+    if (!isValid) {
+      await sendResponseForUnauthorizedRequest(
+        ctxt,
+        AuthenticationErrorMessages.TokenInvalid,
       );
       return;
     }

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -226,8 +226,21 @@ export function createRoutes(args: CreateRoutesArgs) {
     handleUnpublishRealm(args),
   );
 
-  // it's awkward that these are GET's but we are working around grafana's limitations
+  // GET registrations are the legacy Grafana-link dashboards; POST
+  // registrations are the Grafana-button-panel dashboards from CS-10987,
+  // which carry auth in an `Authorization: Bearer <token>` header rather
+  // than a querystring. Both verbs share the same handler + auth check —
+  // handlers read params from `ctxt.URL.searchParams`, which Koa
+  // populates the same way for both GET and POST. The dual registration
+  // is intentional for the CS-10987 cutover; once every operator has
+  // pulled the new dashboards (one release cycle), drop the GETs and
+  // the convertAuthHeaderQueryParam middleware in one cleanup PR.
   router.get(
+    '/_grafana-reindex',
+    grafanaAuthorization(args.grafanaSecret),
+    handleReindex(args),
+  );
+  router.post(
     '/_grafana-reindex',
     grafanaAuthorization(args.grafanaSecret),
     handleReindex(args),
@@ -237,12 +250,27 @@ export function createRoutes(args: CreateRoutesArgs) {
     grafanaAuthorization(args.grafanaSecret),
     handleRemoveJob(args),
   );
+  router.post(
+    '/_grafana-complete-job',
+    grafanaAuthorization(args.grafanaSecret),
+    handleRemoveJob(args),
+  );
   router.get(
     '/_grafana-add-credit',
     grafanaAuthorization(args.grafanaSecret),
     handleAddCredit(args),
   );
+  router.post(
+    '/_grafana-add-credit',
+    grafanaAuthorization(args.grafanaSecret),
+    handleAddCredit(args),
+  );
   router.get(
+    '/_grafana-full-reindex',
+    grafanaAuthorization(args.grafanaSecret),
+    handleFullReindex(args),
+  );
+  router.post(
     '/_grafana-full-reindex',
     grafanaAuthorization(args.grafanaSecret),
     handleFullReindex(args),

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -235,46 +235,15 @@ export function createRoutes(args: CreateRoutesArgs) {
   // is intentional for the CS-10987 cutover; once every operator has
   // pulled the new dashboards (one release cycle), drop the GETs and
   // the convertAuthHeaderQueryParam middleware in one cleanup PR.
-  router.get(
-    '/_grafana-reindex',
-    grafanaAuthorization(args.grafanaSecret),
-    handleReindex(args),
-  );
-  router.post(
-    '/_grafana-reindex',
-    grafanaAuthorization(args.grafanaSecret),
-    handleReindex(args),
-  );
-  router.get(
-    '/_grafana-complete-job',
-    grafanaAuthorization(args.grafanaSecret),
-    handleRemoveJob(args),
-  );
-  router.post(
-    '/_grafana-complete-job',
-    grafanaAuthorization(args.grafanaSecret),
-    handleRemoveJob(args),
-  );
-  router.get(
-    '/_grafana-add-credit',
-    grafanaAuthorization(args.grafanaSecret),
-    handleAddCredit(args),
-  );
-  router.post(
-    '/_grafana-add-credit',
-    grafanaAuthorization(args.grafanaSecret),
-    handleAddCredit(args),
-  );
-  router.get(
-    '/_grafana-full-reindex',
-    grafanaAuthorization(args.grafanaSecret),
-    handleFullReindex(args),
-  );
-  router.post(
-    '/_grafana-full-reindex',
-    grafanaAuthorization(args.grafanaSecret),
-    handleFullReindex(args),
-  );
+  let registerGrafanaEndpoint = (path: string, handler: Koa.Middleware) => {
+    let auth = grafanaAuthorization(args.grafanaSecret);
+    router.get(path, auth, handler);
+    router.post(path, auth, handler);
+  };
+  registerGrafanaEndpoint('/_grafana-reindex', handleReindex(args));
+  registerGrafanaEndpoint('/_grafana-complete-job', handleRemoveJob(args));
+  registerGrafanaEndpoint('/_grafana-add-credit', handleAddCredit(args));
+  registerGrafanaEndpoint('/_grafana-full-reindex', handleFullReindex(args));
   router.post('/_post-deployment', handlePostDeployment(args));
   router.post(
     '/_realm-auth',

--- a/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
@@ -366,6 +366,81 @@ module(`server-endpoints/${basename(__filename)}`, function () {
         );
       });
 
+      // CS-10987 cutover prep: every grafana operator endpoint accepts
+      // both verbs (GET for legacy link dashboards, POST for the
+      // upcoming button-panel dashboards) and both auth header shapes
+      // (bare secret for legacy `?authHeader=` link promotion, `Bearer
+      // <secret>` for the standards-compliant button-panel form). Once
+      // the link dashboards retire, the legacy GET routes + bare-secret
+      // branch + convertAuthHeaderQueryParam middleware come out in one
+      // cleanup PR.
+      async function insertCancellableJob(): Promise<string> {
+        let [{ id }] = (await context.dbAdapter.execute(`INSERT INTO jobs
+        (args, job_type, concurrency_group, timeout, priority)
+        VALUES
+        (
+          '{"realmURL": "${testRealmURL.href}", "realmUsername":"node-test_realm"}',
+          'from-scratch-index',
+          'indexing:${testRealmURL.href}',
+          180,
+          0
+        ) RETURNING id`)) as { id: string }[];
+        return id;
+      }
+      async function assertJobRejected(assert: Assert, id: string) {
+        let [job] = await context.dbAdapter.execute(
+          `SELECT status FROM jobs WHERE id = ${id}`,
+        );
+        assert.strictEqual(job.status, 'rejected', 'job was rejected');
+      }
+
+      test('grafana endpoint accepts POST with Authorization: Bearer header (CS-10987 button-panel form)', async function (assert) {
+        let id = await insertCancellableJob();
+        let response = await context.request
+          .post(`/_grafana-complete-job?job_id=${id}`)
+          .set('Authorization', `Bearer ${grafanaSecret}`)
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 204, 'HTTP 204 response');
+        await assertJobRejected(assert, id);
+      });
+
+      test('grafana endpoint accepts POST with Authorization: <bare-secret> header', async function (assert) {
+        let id = await insertCancellableJob();
+        let response = await context.request
+          .post(`/_grafana-complete-job?job_id=${id}`)
+          .set('Authorization', grafanaSecret)
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 204, 'HTTP 204 response');
+        await assertJobRejected(assert, id);
+      });
+
+      test('grafana endpoint accepts GET with Authorization: Bearer header (no querystring)', async function (assert) {
+        let id = await insertCancellableJob();
+        let response = await context.request
+          .get(`/_grafana-complete-job?job_id=${id}`)
+          .set('Authorization', `Bearer ${grafanaSecret}`)
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 204, 'HTTP 204 response');
+        await assertJobRejected(assert, id);
+      });
+
+      test('grafana endpoint rejects POST with wrong Bearer token', async function (assert) {
+        let id = await insertCancellableJob();
+        let response = await context.request
+          .post(`/_grafana-complete-job?job_id=${id}`)
+          .set('Authorization', 'Bearer not-the-real-secret')
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 401, 'HTTP 401 status');
+        let [job] = await context.dbAdapter.execute(
+          `SELECT status FROM jobs WHERE id = ${id}`,
+        );
+        assert.strictEqual(
+          job.status,
+          'unfulfilled',
+          'job not touched on auth failure',
+        );
+      });
+
       test('can add user credit via grafana endpoint', async function (assert) {
         let user = await insertUser(
           context.dbAdapter,

--- a/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
@@ -431,6 +431,10 @@ module(`server-endpoints/${basename(__filename)}`, function () {
           .set('Authorization', 'Bearer not-the-real-secret')
           .set('Content-Type', 'application/json');
         assert.strictEqual(response.status, 401, 'HTTP 401 status');
+        assert.true(
+          response.text.includes('Token invalid'),
+          'reports invalid token (not missing-header) when an Authorization header is present but wrong',
+        );
         let [job] = await context.dbAdapter.execute(
           `SELECT status FROM jobs WHERE id = ${id}`,
         );
@@ -439,6 +443,16 @@ module(`server-endpoints/${basename(__filename)}`, function () {
           'unfulfilled',
           'job not touched on auth failure',
         );
+      });
+
+      test('grafana endpoint accepts lowercase scheme + extra whitespace in Bearer header', async function (assert) {
+        let id = await insertCancellableJob();
+        let response = await context.request
+          .post(`/_grafana-complete-job?job_id=${id}`)
+          .set('Authorization', `  bearer   ${grafanaSecret}  `)
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 204, 'HTTP 204 response');
+        await assertJobRejected(assert, id);
       });
 
       test('can add user credit via grafana endpoint', async function (assert) {


### PR DESCRIPTION
## Summary

Server-side preparation for the CS-10987 cutover so it can swap dashboards without server downtime.

Today, the four `_grafana-*` operator endpoints accept GET only, and the `grafanaAuthorization` middleware compares the `Authorization` header to the bare secret (no `Bearer ` prefix). The current dashboards send the secret via `?authHeader=` querystring, which `convertAuthHeaderQueryParam` (`server.ts:221`) promotes to a bare-secret `Authorization` header before any handler runs. CS-10987's button-panel dashboards send `POST` with `Authorization: Bearer <token>`. With only one shape supported at a time, the cutover would break operators on either side of it.

This PR makes both shapes work concurrently:

- **`routes.ts`**: register `router.post(...)` alongside each existing `router.get(...)` for `/_grafana-{reindex,complete-job,add-credit,full-reindex}`. Same handler + auth middleware. Handlers read params from `ctxt.URL.searchParams`, which Koa populates the same way for both verbs, so no body-parsing / shape changes.
- **`middleware/index.ts`**: extend `grafanaAuthorization` to accept either the bare secret (legacy `?authHeader=` link form) or `Bearer <secret>` (CS-10987 button form). Same secret either way; the check just recognizes both shapes.
- **Tests**: four new cases against `_grafana-complete-job` covering POST + Bearer (the new flow), POST + bare secret (defensive), GET + Bearer (proves the new auth shape works on the legacy verb), POST + wrong Bearer (negative). Existing GET + bare-secret tests are unchanged.

## Cutover plan

1. Land this PR — server now speaks both dialects.
2. Land CS-10987 — dashboards switch to POST + Bearer.
3. After one release of soak: drop the legacy GET routes, the bare-secret branch in `grafanaAuthorization`, and `convertAuthHeaderQueryParam`. All three are flagged with comments pointing at this same followup.

## Pre-existing dead link, not addressed here

`realm-permissions.json` references `_grafana-upsert-realm-user-permission`, which has no handler registered in `routes.ts`. CS-10987 will either add the handler or drop the link.

## Test plan

- [x] Visual review: dual route registrations + middleware match the existing pattern; tests model on existing `_grafana-complete-job` GET cases.
- [ ] CI runs `pnpm test` against the realm-server suite. The four new cases live next to the existing grafana-endpoint tests in `maintenance-endpoints-test.ts` and use the same `setupServerEndpointsTest` harness.
- [ ] Local validation requires `pnpm install` in the worktree (currently absent here); CI will catch any type / runtime issue on the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)