### PR TITLE
Stabilize 'it shows card preview errors' + unhandled-rejection diagnostics

### DIFF
--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -1046,11 +1046,16 @@ module('Acceptance | code submode tests', function (_hooks) {
       });
 
       await waitFor('[data-test-card-error]');
+      // drain pending card-type priming async before navigating again — otherwise
+      // an in-flight fetch from the first navigation can reject after teardown
+      // and surface as an unowned "A network error occurred." rejection.
+      await settled();
 
       await click('[data-test-toggle-details]');
       assert
         .dom('[data-test-error-details]')
         .includesText(`${testRealmURL}non-card not found`);
+      await settled();
 
       await visitOperatorMode({
         submode: 'code',
@@ -1058,6 +1063,7 @@ module('Acceptance | code submode tests', function (_hooks) {
       });
 
       await waitFor('[data-test-card-error]');
+      await settled();
 
       await click('[data-test-toggle-details]');
       assert

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -16,11 +16,17 @@ import { clearRemoteRealmCache } from './realm-server-mock/routes';
 
 import { cleanupMonacoEditorModels } from './index';
 
+// Per-test set of fetch URLs currently in flight. Snapshotted by the
+// unhandled-rejection diagnostics helper so we can see what was outstanding
+// when an unowned rejection surfaced. Cleared in beforeEach.
+let inFlightFetches = new Set<string>();
+
 function setupFetchDebugging(hooks: NestedHooks) {
   let originalFetch: typeof globalThis.fetch | undefined;
   let wrappedFetch: typeof globalThis.fetch | undefined;
 
   hooks.beforeEach(function () {
+    inFlightFetches = new Set<string>();
     if (!globalThis.fetch) {
       return;
     }
@@ -28,6 +34,8 @@ function setupFetchDebugging(hooks: NestedHooks) {
     let boundFetch = globalThis.fetch.bind(globalThis);
     wrappedFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       let { method, url } = describeFetchRequest(input, init);
+      let tag = `${method} ${url}`;
+      inFlightFetches.add(tag);
       try {
         return await boundFetch(input, init);
       } catch (error) {
@@ -35,6 +43,8 @@ function setupFetchDebugging(hooks: NestedHooks) {
           `[test-fetch] ${method} ${url} failed: ${formatErrorForLog(error)}`,
         );
         throw error;
+      } finally {
+        inFlightFetches.delete(tag);
       }
     };
     globalThis.fetch = wrappedFetch;
@@ -46,7 +56,92 @@ function setupFetchDebugging(hooks: NestedHooks) {
     }
     originalFetch = undefined;
     wrappedFetch = undefined;
+    inFlightFetches = new Set<string>();
   });
+}
+
+// surface unhandled rejections during tests with full stacks + in-flight URLs
+function setupUnhandledRejectionDiagnostics(hooks: NestedHooks) {
+  let handler: ((event: PromiseRejectionEvent) => void) | undefined;
+  let target: EventTarget | undefined;
+
+  hooks.beforeEach(function () {
+    target =
+      typeof window !== 'undefined'
+        ? (window as unknown as EventTarget)
+        : typeof globalThis !== 'undefined'
+          ? (globalThis as unknown as EventTarget)
+          : undefined;
+    if (!target) {
+      return;
+    }
+    handler = (event: PromiseRejectionEvent) => {
+      // Observation only — do NOT call event.preventDefault(). QUnit's own
+      // unhandled-rejection handling must still run and fail the test.
+      let inFlightSnapshot = Array.from(inFlightFetches);
+      console.error(
+        [
+          '[test-unhandled-rejection]',
+          formatRejectionReason(event.reason),
+          inFlightSnapshot.length
+            ? `in-flight fetches at rejection time (${inFlightSnapshot.length}):\n  ${inFlightSnapshot.join('\n  ')}`
+            : 'in-flight fetches at rejection time: <none>',
+        ].join('\n'),
+      );
+    };
+    target.addEventListener(
+      'unhandledrejection',
+      handler as unknown as EventListener,
+    );
+  });
+
+  hooks.afterEach(function () {
+    if (target && handler) {
+      target.removeEventListener(
+        'unhandledrejection',
+        handler as unknown as EventListener,
+      );
+    }
+    handler = undefined;
+    target = undefined;
+  });
+}
+
+function formatRejectionReason(reason: unknown): string {
+  let lines: string[] = [];
+  let seen = new Set<unknown>();
+  let current: unknown = reason;
+  let depth = 0;
+  while (current && !seen.has(current) && depth < 5) {
+    seen.add(current);
+    let prefix = depth === 0 ? 'reason' : `cause[${depth}]`;
+    if (current instanceof Error) {
+      let header = current.name
+        ? `${current.name}: ${current.message}`
+        : current.message;
+      let stack = current.stack?.trim();
+      lines.push(`${prefix}: ${header}`);
+      if (stack) {
+        lines.push(stack);
+      }
+      current = (current as { cause?: unknown }).cause;
+    } else if (typeof current === 'string') {
+      lines.push(`${prefix}: ${current}`);
+      current = undefined;
+    } else {
+      try {
+        lines.push(`${prefix}: ${JSON.stringify(current)}`);
+      } catch (_e) {
+        lines.push(`${prefix}: ${String(current)}`);
+      }
+      current = undefined;
+    }
+    depth++;
+  }
+  if (lines.length === 0) {
+    lines.push(`reason: ${String(reason)}`);
+  }
+  return lines.join('\n');
 }
 
 function describeFetchRequest(input: RequestInfo | URL, init?: RequestInit) {
@@ -85,6 +180,7 @@ export function setupApplicationTest(hooks: NestedHooks) {
   emberSetupApplicationTest(hooks);
   setupWindowMock(hooks);
   setupFetchDebugging(hooks);
+  setupUnhandledRejectionDiagnostics(hooks);
   hooks.afterEach(async function () {
     resetServiceIfPresent(this.owner, 'service:ai-assistant-panel-service');
     resetServiceIfPresent(this.owner, 'service:matrix-service');
@@ -103,6 +199,7 @@ export function setupRenderingTest(hooks: NestedHooks) {
   emberSetupRenderingTest(hooks);
   setupWindowMock(hooks);
   setupFetchDebugging(hooks);
+  setupUnhandledRejectionDiagnostics(hooks);
   hooks.afterEach(async function () {
     await settled();
     (

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -16,17 +16,22 @@ import { clearRemoteRealmCache } from './realm-server-mock/routes';
 
 import { cleanupMonacoEditorModels } from './index';
 
-// Per-test set of fetch URLs currently in flight. Snapshotted by the
-// unhandled-rejection diagnostics helper so we can see what was outstanding
-// when an unowned rejection surfaced. Cleared in beforeEach.
-let inFlightFetches = new Set<string>();
+// Map of fetch calls currently in flight, keyed by a globally-unique per-call
+// id so overlapping identical requests each occupy their own slot, and so a
+// late `finally` from a prior test can never collide with the current test's
+// ids. The map reference is constant; we `clear()` it between tests rather
+// than reassigning, otherwise late-resolving fetches would mutate the next
+// test's tracking container. Snapshotted by the unhandled-rejection
+// diagnostics helper to surface what was outstanding when a rejection fired.
+const inFlightFetches = new Map<number, string>();
+let nextFetchId = 0;
 
 function setupFetchDebugging(hooks: NestedHooks) {
   let originalFetch: typeof globalThis.fetch | undefined;
   let wrappedFetch: typeof globalThis.fetch | undefined;
 
   hooks.beforeEach(function () {
-    inFlightFetches = new Set<string>();
+    inFlightFetches.clear();
     if (!globalThis.fetch) {
       return;
     }
@@ -34,8 +39,8 @@ function setupFetchDebugging(hooks: NestedHooks) {
     let boundFetch = globalThis.fetch.bind(globalThis);
     wrappedFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       let { method, url } = describeFetchRequest(input, init);
-      let tag = `${method} ${url}`;
-      inFlightFetches.add(tag);
+      let id = nextFetchId++;
+      inFlightFetches.set(id, `${method} ${url}`);
       try {
         return await boundFetch(input, init);
       } catch (error) {
@@ -44,7 +49,7 @@ function setupFetchDebugging(hooks: NestedHooks) {
         );
         throw error;
       } finally {
-        inFlightFetches.delete(tag);
+        inFlightFetches.delete(id);
       }
     };
     globalThis.fetch = wrappedFetch;
@@ -56,29 +61,30 @@ function setupFetchDebugging(hooks: NestedHooks) {
     }
     originalFetch = undefined;
     wrappedFetch = undefined;
-    inFlightFetches = new Set<string>();
+    inFlightFetches.clear();
   });
 }
 
 // surface unhandled rejections during tests with full stacks + in-flight URLs
 function setupUnhandledRejectionDiagnostics(hooks: NestedHooks) {
   let handler: ((event: PromiseRejectionEvent) => void) | undefined;
-  let target: EventTarget | undefined;
+  let target: Window | undefined;
 
   hooks.beforeEach(function () {
+    // Host tests run in the browser; if `window` is missing or doesn't expose
+    // an event listener API for some reason, skip rather than throw.
     target =
-      typeof window !== 'undefined'
-        ? (window as unknown as EventTarget)
-        : typeof globalThis !== 'undefined'
-          ? (globalThis as unknown as EventTarget)
-          : undefined;
+      typeof window !== 'undefined' &&
+      typeof window.addEventListener === 'function'
+        ? window
+        : undefined;
     if (!target) {
       return;
     }
     handler = (event: PromiseRejectionEvent) => {
       // Observation only — do NOT call event.preventDefault(). QUnit's own
       // unhandled-rejection handling must still run and fail the test.
-      let inFlightSnapshot = Array.from(inFlightFetches);
+      let inFlightSnapshot = Array.from(inFlightFetches.values());
       console.error(
         [
           '[test-unhandled-rejection]',
@@ -89,18 +95,12 @@ function setupUnhandledRejectionDiagnostics(hooks: NestedHooks) {
         ].join('\n'),
       );
     };
-    target.addEventListener(
-      'unhandledrejection',
-      handler as unknown as EventListener,
-    );
+    target.addEventListener('unhandledrejection', handler);
   });
 
   hooks.afterEach(function () {
     if (target && handler) {
-      target.removeEventListener(
-        'unhandledrejection',
-        handler as unknown as EventListener,
-      );
+      target.removeEventListener('unhandledrejection', handler);
     }
     handler = undefined;
     target = undefined;


### PR DESCRIPTION
## Summary

CI run [25215316783 / Host Tests shard 4](https://github.com/cardstack/boxel/actions/runs/25215316783/job/73934617657) failed `Acceptance | code submode tests > single realm: it shows card preview errors` with `Promise rejected during \"it shows card preview errors\": A network error occurred.` — confirmed flaky (next run on the same commit `01f53e16f4` passed). The trailing-period message is the platform XHR/fetch error format; the chunk traces in the browser logs implicate the card-type-priming machinery (`#primeCardType` -> `Loader.import` -> `fetchWithTransientRetry` -> `withRetries`). The test does two `visitOperatorMode` calls back-to-back, so an in-flight fetch from the first navigation can reject after teardown of its owning state and surface as an unowned rejection under the parent test's name.

- Stabilization: insert `await settled()` after each `waitFor('[data-test-card-error]')` (and once after the first assertion) so pending priming async resolves/rejects within its original navigation's owner before we navigate again. Test stays as one test; Percy snapshot at the end is preserved.
- Diagnostics: add a new `setupUnhandledRejectionDiagnostics(hooks)` helper alongside the existing `setupFetchDebugging` in `tests/helpers/setup.ts`, wired into both `setupApplicationTest` and `setupRenderingTest`. On `unhandledrejection` it `console.error`s the reason name+message+stack, walks the `.cause` chain (depth-limited, cycle-safe), and snapshots in-flight fetch URLs (now tracked by `setupFetchDebugging`). Observation only — does not call `event.preventDefault()`, so QUnit's failure handling is unchanged. Listener is attached in `beforeEach` and removed in `afterEach`.

Next time this kind of flake appears, the TAP browser-log block will contain a single `[test-unhandled-rejection]` entry with: the rejection's name, message, stack, any cause chain, and a list of fetch URLs that were in flight at the moment of rejection — which is exactly the signal missing from the failing run above.

## Test plan

- [x] `pnpm lint` (full) clean inside `packages/host`
- [ ] CI host shards green on this branch
- [ ] Percy clean (snapshot at end of `it shows card preview errors` unchanged)