### PR TITLE
Fix flaky realm-lifecycle + publish-unpublish tests

### DIFF
--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -812,6 +812,12 @@ module(basename(__filename), function () {
           );
         }
 
+        let versionBeforeUnpublish = (
+          await dbAdapter.execute(
+            `SELECT current_version FROM realm_versions WHERE realm_url = '${publishedRealmURL}'`,
+          )
+        )[0]?.current_version as number | undefined;
+
         // Now unpublish the realm
         let unpublishResponse = await request
           .post('/_unpublish-realm')
@@ -873,10 +879,14 @@ module(basename(__filename), function () {
           await dbAdapter.execute(
             `SELECT current_version FROM realm_versions WHERE realm_url = '${publishedRealmURL}'`,
           )
-        )[0];
-        assert.strictEqual(
-          realmVersion.current_version,
-          3,
+        )[0] as { current_version: number };
+        assert.notStrictEqual(
+          versionBeforeUnpublish,
+          undefined,
+          'realm version of published realm is set before unpublish',
+        );
+        assert.ok(
+          realmVersion.current_version > (versionBeforeUnpublish ?? 0),
           'realm version of published realm is increased',
         );
 

--- a/packages/realm-server/tests/server-endpoints/realm-lifecycle-test.ts
+++ b/packages/realm-server/tests/server-endpoints/realm-lifecycle-test.ts
@@ -124,13 +124,15 @@ module(`server-endpoints/${basename(__filename)}`, function () {
           'seed file index.json exists',
         );
 
-        let job = (await context.dbAdapter.execute(
-          `SELECT priority FROM jobs WHERE job_type = 'from-scratch-index' AND args->>'realmURL' = '${json.data.id}' ORDER BY created_at DESC LIMIT 1`,
+        let jobs = (await context.dbAdapter.execute(
+          `SELECT priority FROM jobs WHERE job_type = 'from-scratch-index' AND args->>'realmURL' = '${json.data.id}'`,
         )) as { priority: number }[];
-        assert.ok(job[0], 'found from-scratch index job for created realm');
-        assert.strictEqual(
-          job[0].priority,
-          userInitiatedPriority,
+        assert.ok(
+          jobs.length > 0,
+          'found from-scratch index job for created realm',
+        );
+        assert.ok(
+          jobs.some((j) => j.priority === userInitiatedPriority),
           'user initiated realm indexing uses high priority queue',
         );
 


### PR DESCRIPTION
## Summary

Two test-only fixes for the same root cause — exact-count assertions on jobs/versions that flake under a known coalesce race.

**The race:** `POST /_create-realm` and `POST /_publish-realm` both enqueue an explicit `from-scratch-index` job at `userInitiatedPriority`, then call `lookupOrMount` which mounts the realm and runs `realm.start()` → `#startup` → if `isNewIndex()` is true, `fullIndex(systemInitiatedPriority)` enqueues a second `from-scratch-index` job. They share `concurrencyGroup` and are designed to coalesce, but `pg-queue.findPendingCandidates` excludes already-reserved jobs — so when a worker reserves the first job before the second one publishes, the second is **inserted** as a separate row at priority 0 instead of merging. Each from-scratch-index also bumps `realm_versions.current_version`.

Two tests were over-specific:
1. `realm-lifecycle-test.ts:127-135` — `ORDER BY created_at DESC LIMIT 1` for the priority field, expecting `userInitiatedPriority`. Found the redundant priority-0 row instead.
2. `publish-unpublish-realm-test.ts:872-881` — `current_version === 3` absolute, expecting exactly two version bumps from publish + unpublish. Got 4 from the extra startup-driven from-scratch-index.

## Fixes

- Realm-lifecycle test now asserts *some* `from-scratch-index` job for the realm carries `userInitiatedPriority` (the actual design contract).
- Publish-unpublish test captures the version before unpublish and asserts it strictly increased — preserves the intent ("unpublish bumps the version") without depending on a specific absolute count.

Production code is untouched. The redundant priority-0 row is wasteful (a no-op re-index) but correct — workers drain higher priority first, and the second from-scratch is idempotent against a fresh index.

Failing runs:
- `Realm Server Tests (2, 6)`: https://github.com/cardstack/boxel/actions/runs/25215324039/job/73934711253
- `Realm Server Tests (1, 6)`: https://github.com/cardstack/boxel/actions/runs/25217782741/job/73942959413

## Test plan

- [ ] Re-run CI on `main` after merge — both `Realm Server Tests` shards should stop flaking on these assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)