### PR TITLE
Fix og:title regression on published realms after CS-10895

### DIFF
--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -501,6 +501,27 @@ export default function handlePublishRealm({
           `expected published realm ${publishedRealmURL} to be mounted after publish — registry row missing or mount failed`,
         );
       }
+      // Re-run a full index after start()'s pass so the RealmConfig card
+      // at /realm.json is queryable by parseRealmInfo before /index is
+      // re-rendered. start()'s from-scratch pass walks files in order and
+      // typically renders /index before /realm.json — at which point
+      // attachRealmInfo → getRealmInfo → parseRealmInfo finds /realm.json
+      // not yet indexed, falls back to "Unnamed Workspace", and caches
+      // that. The prerendered head HTML for /index is baked with the
+      // stale value, surfacing as og:title="Unnamed Workspace" on the
+      // published page.
+      //
+      // clearLastModified: true forces every row to re-render on this
+      // pass even though copySync preserves mtimes — without it, the
+      // indexer's mtime-cache check would skip the already-rendered
+      // /index and the stale prerendered HTML would persist.
+      // Realm.fullIndex clears #cachedRealmInfo before this pass so the
+      // first attachRealmInfo call re-reads parseRealmInfo against the
+      // now-populated index and bakes the correct realm name into the
+      // re-rendered prerendered HTML.
+      await publishedRealm.fullIndex(userInitiatedPriority, {
+        clearLastModified: true,
+      });
       let publishedPermissions = await fetchRealmPermissions(
         dbAdapter,
         new URL(publishedRealmURL),

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1073,8 +1073,25 @@ export class Realm {
     await this.#startedUp.promise;
   }
 
-  async fullIndex(priority?: number) {
-    await this.realmIndexUpdater.fullIndex(priority);
+  async fullIndex(priority?: number, opts?: { clearLastModified?: boolean }) {
+    // Clear the realmInfo cache before re-indexing so cards rendered
+    // during this pass read /realm.json from the now-populated index
+    // rather than a stale "Unnamed Workspace" cached during an earlier
+    // from-scratch pass that processed /index before /realm.json.
+    // CardsGrid.cardTitle → realmInfo.name drives og:title, which is
+    // baked into the prerendered HTML — clearing only after the pass
+    // would be too late.
+    this.#cachedRealmInfo = null;
+    let { completed } = this.#realmIndexUpdater.publishFullIndex(
+      priority ?? systemInitiatedPriority,
+      { clearLastModified: opts?.clearLastModified },
+    );
+    try {
+      await completed;
+    } catch (e: any) {
+      this.#log.error(`Error running from-scratch-index: ${e.message}`);
+    }
+    this.#cachedRealmInfo = null;
   }
 
   async flushUpdateEvents() {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1086,11 +1086,7 @@ export class Realm {
       priority ?? systemInitiatedPriority,
       { clearLastModified: opts?.clearLastModified },
     );
-    try {
-      await completed;
-    } catch (e: any) {
-      this.#log.error(`Error running from-scratch-index: ${e.message}`);
-    }
+    await completed;
     this.#cachedRealmInfo = null;
   }
 


### PR DESCRIPTION
## Summary

Restore the explicit `await publishedRealm.fullIndex(...)` pass that CS-10895 (#4561) collapsed out of `handle-publish-realm`, and have `Realm.fullIndex` clear the realmInfo cache before the pass. Without this, the Matrix Client `head-tags.spec.ts:80` test ("the HTML response from a published realm has relevant meta tags") fails on every CI run on main with `og:title="Unnamed Workspace"` instead of the realm's actual name.

## Why this is broken on main right now

- og:title for `/index` on a published realm comes from the prerendered head HTML written during indexing.
- On a `CardsGrid` (the default `/index`), `cardTitle = realmName = realmInfo.name`.
- Per PR #4508, `realmInfo.name` is overlaid from the indexed `RealmConfig` card at `/realm.json`. Without it, `parseRealmInfo` falls back to `"Unnamed Workspace"`, and that value is cached on the `Realm` instance.
- A fresh from-scratch index walks files in order and typically renders `/index` before `/realm.json`. The cache is populated with the fallback during the `/index` render and the prerendered HTML for `/index` is baked with `og:title="Unnamed Workspace"`.

Pre-CS-10895 the publish handler did `start()` **followed by** an explicit `realm.fullIndex(userInitiatedPriority)`. The second pass guaranteed `/realm.json` was in the index by the time `/index` was re-rendered. CS-10895 collapsed those into just `lookupOrMount(...)`, on the assumption that the `chooseFromScratch` coalesce of `start()`'s job with the explicit enqueue would suffice. It doesn't on a fresh publish: only one pass runs, and it bakes the stale value into the prerendered HTML.

## What this PR changes

**`packages/realm-server/handlers/handle-publish-realm.ts`**
- After `reconciler.lookupOrMount(publishedRealmURL)`, call `publishedRealm.fullIndex(userInitiatedPriority, { clearLastModified: true })`.
- `clearLastModified: true` is required because `copySync` preserves source mtimes — without it, the second pass would skip every file the first pass already wrote and the stale prerendered HTML would persist.

**`packages/runtime-common/realm.ts`**
- `Realm.fullIndex` now accepts `opts?: { clearLastModified?: boolean }` and threads it to `realmIndexUpdater.publishFullIndex`.
- Clears `#cachedRealmInfo` **before** the pass (so the first `attachRealmInfo` call inside this pass re-reads `parseRealmInfo` against the now-populated index) and again after, belt-and-suspenders.
- Backwards-compatible signature: existing `realm.fullIndex()` callers in `host/tests/integration/realm-indexing-test.gts` are unaffected.

## What this PR does not change

- The `realm-lifecycle-test.ts:131` priority assertion intermittent failure is a separate flake (race between `enqueueReindexRealmJob` and `start()`'s enqueue when the worker has already drained the first job; the test queries `ORDER BY created_at DESC LIMIT 1` and sees the second, lower-priority job). Different failure mode, will address separately.
- The recurring Host Tests `(4, 20)` shard failures predate CS-10895 and are unrelated to this fix.

## Note on cost

This adds a second full-index pass during publish — the same shape main had pre-CS-10895. It isn't desirable in steady state. A more efficient fix (e.g. ordering `/realm.json` before `/index` in `fullIndex`, or invalidating the cache the moment `/realm.json` is indexed) is left for follow-up. This PR is the smallest restoration of the historical behavior to unblock CI.

## Test plan

- [ ] CI: Matrix Client Tests `(1, 3)` passes (head-tags.spec.ts:80 stops failing)
- [ ] CI: `publish-unpublish-realm-test.ts` "POST /_unpublish-realm can unpublish realm successfully" passes — `realm_versions.current_version` should now reach 3 (matching the existing `expected: 3` assertion)
- [ ] CI: Realm Server Tests pass overall

🤖 Generated with [Claude Code](https://claude.com/claude-code)