### PR TITLE
CS-11002: persist module-render diagnostics on modules.timing_diagnostics

### DIFF
--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -15,11 +15,12 @@ Both use cases read from the same data. The difference is the query you start wi
 
 ## Where the diagnostics live
 
-Three places, all correlated:
+Four places, all correlated:
 
-1. **`boxel_index.timing_diagnostics` (and `boxel_index_working.timing_diagnostics`)** — JSONB column, populated for **every** row the indexer writes, regardless of `has_error`. Source of truth. Carries the full `RenderTimeoutDiagnostics` payload plus three write-side stamps: `invalidationId`, `indexedAt`, `requestId`.
-2. **`error_doc.diagnostics`** — derived copy of `timing_diagnostics`, written only for error rows. Exists so the existing UI read path (`error_doc` → `CardErrorJSONAPI.meta.diagnostics` via `formattedError`) keeps working without a schema rename. Non-error rows have `error_doc = null`; go to `timing_diagnostics` directly.
-3. **Logs** — `prerender-server`, `manager`, and `remote-prerenderer` lines all carry `requestId=…`. `grep requestId=<uuid>` collates one call across all three processes. For saturation incidents there's also the periodic `prerender-queue-snapshot` line on each prerender server.
+1. **`boxel_index.timing_diagnostics` (and `boxel_index_working.timing_diagnostics`)** — JSONB column, populated for **every** row the indexer writes, regardless of `has_error`. Source of truth for **card** renders. Carries the full `RenderTimeoutDiagnostics` payload plus three write-side stamps: `invalidationId`, `indexedAt`, `requestId`.
+2. **`modules.timing_diagnostics`** — JSONB column, populated for every row `persistModuleCacheEntry` writes (success and error paths). Source of truth for **module** renders (`prerenderModule` → definition extraction). Same `RenderTimeoutDiagnostics` shape with `requestId` flattened in; no `invalidationId` (modules don't go through `Batch.invalidate`). The row's existing `created_at` column is the wall-clock stamp for cross-table joins. See [Mode D](#mode-d--a-module-render-was-slow-or-hung) below.
+3. **`error_doc.diagnostics`** — derived copy of `timing_diagnostics`, written only for error rows on `boxel_index`. Exists so the existing UI read path (`error_doc` → `CardErrorJSONAPI.meta.diagnostics` via `formattedError`) keeps working without a schema rename. Non-error rows have `error_doc = null`; go to `timing_diagnostics` directly.
+4. **Logs** — `prerender-server`, `manager`, and `remote-prerenderer` lines all carry `requestId=…`. `grep requestId=<uuid>` collates one call across all three processes. The same `requestId` lands on both `boxel_index.timing_diagnostics->>'requestId'` and `modules.timing_diagnostics->>'requestId'`, so a hung card render and the module renders it triggered (via `getDefinition`) can be joined back to one investigation. For saturation incidents there's also the periodic `prerender-queue-snapshot` line on each prerender server.
 
 For UI triage you'll typically read the JSON error response (which surfaces `error_doc.diagnostics` as `meta.diagnostics`). For operator / SQL triage — especially slow non-failing reindexes — query the `timing_diagnostics` column directly.
 
@@ -539,6 +540,67 @@ A short rubric for the most common shapes:
 - If the worker died *before* any DB write — crashed during `discoverInvalidations`, OOM-killed during the mtime walk, or threw inside `Batch.invalidate`'s own SQL — `boxel_index_working` will have no rows for this batch's `invalidationId`. The `Batch` object mints the `invalidationId` in its constructor, but it only lands on disk when the first `updateEntry` or `tombstoneEntries` call runs. Until then the only diagnostic signals are the worker log and the EFS state. Mode C cannot reconstruct *which* file the worker was processing in that case — you need either `index-runner=debug` log output or a Sentry trace.
 - The `timing_diagnostics` for partial-progress rows is the **per-render** capture for that row's prerender call. It won't tell you why the *next* render froze. If the bottom-row's diagnostic is clean (low `renderElapsedMs`, no in-flight loads), the stall is between renders — usually `Batch.invalidate` recursion against a tightly-cycled module graph, or DB contention on the `boxel_index_working` upsert. The `index-perf` `time to determine items that reference …` lines are the only fingerprints of that loop.
 - A `boxel_index` row's `timing_diagnostics` reflects the **last successful** indexing pass, not the in-flight one. Don't confuse a stale `boxel_index` `indexedAt` with the stuck job — always cross-reference against the matching `boxel_index_working` row (same `(url, realm_url)`) before drawing conclusions.
+
+## Mode D — a module render was slow or hung
+
+Module renders (`prerenderModule`, used by `getDefinition` to convert filter JSON into SQL on `_federated-search`, plus everywhere else a card definition is needed without a card render) go through the same prerender pipeline as card renders, but they land in the `modules` table — not `boxel_index`. The `timing_diagnostics` JSONB column on `modules` carries the same `RenderTimeoutDiagnostics`-with-`requestId` shape, so the field-by-field reading and the [Classify in one pass](#classify-in-one-pass) table apply unchanged. Only the lookup queries differ.
+
+**When to use this mode:** a card render hung waiting on `getDefinition` (Mode A captured `cardDocLoadsInFlight = 0`, `queryLoadsInFlight = 0`, but the realm-server's reply to `_federated-search` itself was slow); an investigation needs to attribute time across both card renders and the module renders they triggered; or you want to find the slowest module renders fleet-wide. Same payload shape, queryable via SQL.
+
+**Step 1 — slowest module renders in a realm.**
+
+```sql
+SELECT m.url,
+       (m.timing_diagnostics->>'renderElapsedMs')::int AS render_ms,
+       m.timing_diagnostics->>'renderStage'            AS stage,
+       m.timing_diagnostics->>'requestId'              AS request_id,
+       to_timestamp(m.created_at::bigint / 1000)       AS created_at,
+       m.error_doc IS NOT NULL                         AS has_error
+FROM modules m
+WHERE m.resolved_realm_url = '<realm-url>'
+  AND m.timing_diagnostics IS NOT NULL
+ORDER BY render_ms DESC NULLS LAST
+LIMIT 20;
+```
+
+**Step 2 — find module renders correlated with a known time window.** Useful when a card render timed out at wall-clock T and you want to know whether a slow module render was happening at the same moment.
+
+```sql
+SELECT m.url,
+       (m.timing_diagnostics->>'renderElapsedMs')::int AS render_ms,
+       m.timing_diagnostics->>'requestId'              AS request_id,
+       to_timestamp(m.created_at::bigint / 1000)       AS created_at
+FROM modules m
+WHERE m.resolved_realm_url = '<realm-url>'
+  AND (m.timing_diagnostics->>'renderElapsedMs')::int > 5000
+  AND m.created_at BETWEEN <window_start_ms> AND <window_end_ms>
+ORDER BY render_ms DESC;
+```
+
+`window_start_ms` and `window_end_ms` are epoch milliseconds bracketing the suspect period (e.g. the 90s before and including the hung card render's `indexedAt`).
+
+**Step 3 — join card hang to its triggering module render via `requestId`.** When the realm-server's `getDefinition` round-trip is in scope of a single card render, the `requestId` propagates from card → manager → module-extract round-trip, so both rows carry the same value.
+
+```sql
+-- Full diagnostic picture for one requestId — card + module(s) that
+-- the same investigation should walk together.
+SELECT 'card'   AS kind, url, jsonb_pretty(timing_diagnostics) AS diagnostics
+FROM boxel_index
+WHERE timing_diagnostics->>'requestId' = '<request-id>'
+UNION ALL
+SELECT 'module' AS kind, url, jsonb_pretty(timing_diagnostics) AS diagnostics
+FROM modules
+WHERE timing_diagnostics->>'requestId' = '<request-id>';
+```
+
+(In practice the card-side `requestId` is the original outer call. Internal sub-prerenders fired by `CachingDefinitionLookup` typically mint their own `requestId` per `_prerender-module` call, so the time-window join in step 2 is usually the one that catches them. The `requestId` join here works for the rarer in-line case.)
+
+**Step 4 — classify the module render with the same rubric.** Once you have a slow module's `timing_diagnostics`, walk it through the [Classify in one pass](#classify-in-one-pass) table the same way you would a card render. The interpretation is identical: `waiting-stability + queryLoadsInFlight=N` is a data stall on a `_search` (rare for module renders but possible for query-field driven module-extract paths), `model:start + inFlightModuleImports>0` is the loader stall, etc. The only field that's not present on module rows is `invalidationId` (modules don't go through `Batch.invalidate`), so any Mode B-style cross-row grouping has to use `requestId` or `created_at` windows instead.
+
+### What Mode D can't tell you
+
+- **No partial-progress equivalent.** `modules` has no working-table sibling; the row only lands on `persistModuleCacheEntry` after the prerender returns. If a `prerenderModule` call hangs forever and the worker is killed, no row is written and Mode D has nothing to query. Cross-reference against the prerender server logs for `requestId=…` directly, same as a hung card render before the host's withTimeout fires.
+- **No invalidationId, so no Mode B fan-out.** Module renders are independent units; they don't belong to a "batch" that you can group by. If you need to attribute a slow `getDefinition` storm across many concurrent searches, you're stuck doing it via `created_at` time windows + the `#inFlight` dedupe behavior in `CachingDefinitionLookup` — i.e. one slow row may have been the bottleneck for many in-flight callers, but the `modules` table doesn't record those waiters.
 
 ## Field-by-field reading
 

--- a/packages/host/config/schema/1777647429391_schema.sql
+++ b/packages/host/config/schema/1777647429391_schema.sql
@@ -98,6 +98,7 @@
    created_at,
    file_alias TEXT,
    url_hash TEXT GENERATED ALWAYS AS (url) STORED NOT NULL,
+   timing_diagnostics BLOB,
    PRIMARY KEY ( url, cache_scope, auth_user_id ) 
 );
 

--- a/packages/postgres/migrations/1777647429391_add-timing-diagnostics-column-to-modules.js
+++ b/packages/postgres/migrations/1777647429391_add-timing-diagnostics-column-to-modules.js
@@ -1,0 +1,11 @@
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.addColumns('modules', {
+    timing_diagnostics: { type: 'jsonb' },
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropColumns('modules', ['timing_diagnostics']);
+};

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -15,6 +15,8 @@ import {
 import {
   setupPermissionedRealmsCached,
   createVirtualNetwork,
+  createTestPgAdapter,
+  prepareTestDB,
   testCreatePrerenderAuth,
 } from './helpers';
 import type { PgAdapter } from '@cardstack/postgres/pg-adapter';
@@ -1611,6 +1613,144 @@ module(basename(__filename), function () {
       );
       assert.strictEqual(dA?.displayName, 'CoalesceInvalidate v1');
       assert.strictEqual(dB?.displayName, 'CoalesceInvalidate v2');
+    });
+  });
+
+  // Lightweight tests for the modules-table diagnostics persistence.
+  // Uses createTestPgAdapter + an in-memory CachingDefinitionLookup directly
+  // rather than the heavier setupPermissionedRealmsCached fixture, because
+  // we only need a working pg adapter + a registered fake realm. Spinning
+  // up the real realm-server / prerender-server / Chromium for a SQL-shape
+  // assertion would dwarf the test's actual cost (and was timing out the
+  // outer 60s qunit budget on cold runs).
+  module('module-cache timing diagnostics', function (hooks) {
+    let adapter: PgAdapter;
+    let definitionLookup: CachingDefinitionLookup;
+    let realmURL = 'http://127.0.0.1:4451/';
+    let testUserId = '@user1:localhost';
+    let nextPrerenderMeta:
+      | import('@cardstack/runtime-common').PrerenderResponseMeta
+      | undefined;
+
+    hooks.beforeEach(async function () {
+      prepareTestDB();
+      adapter = await createTestPgAdapter();
+      let virtualNetwork = createVirtualNetwork();
+      let mockPrerenderer: Prerenderer = {
+        async prerenderModule(args: ModulePrerenderArgs) {
+          let moduleURL = new URL(args.url);
+          let modulePathWithoutExtension = moduleURL.href.replace(/\.gts$/, '');
+          return Promise.resolve({
+            id: 'example-id',
+            status: 'ready',
+            nonce: '12345',
+            isShimmed: false,
+            lastModified: +new Date(),
+            createdAt: +new Date(),
+            deps: ['dep/a'],
+            definitions: {
+              [`${modulePathWithoutExtension}/Person`]: {
+                type: 'definition',
+                moduleURL: moduleURL.href,
+                definition: {
+                  type: 'card-def',
+                  codeRef: { module: rri(moduleURL.href), name: 'Person' },
+                  displayName: 'Person',
+                  fields: {},
+                },
+                types: [],
+              },
+            },
+            ...(nextPrerenderMeta ? { meta: nextPrerenderMeta } : {}),
+          });
+        },
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+      };
+      definitionLookup = new CachingDefinitionLookup(
+        adapter,
+        mockPrerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      definitionLookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+      // Insert the user permission row required by the lookup's
+      // permission probe — the row connects userId → realm so the lookup's
+      // cache scope resolves cleanly.
+      await adapter.execute(
+        `INSERT INTO realm_user_permissions (realm_url, username, read, write, realm_owner)
+         VALUES ($1, $2, true, true, true)`,
+        { bind: [realmURL, testUserId] },
+      );
+    });
+
+    hooks.afterEach(async function () {
+      await adapter.close();
+      nextPrerenderMeta = undefined;
+    });
+
+    test('persists timing_diagnostics from prerender meta on module rows', async function (assert) {
+      nextPrerenderMeta = {
+        requestId: 'req-test-123',
+        diagnostics: {
+          renderStage: 'waiting-stability',
+          launchMs: 12,
+          renderElapsedMs: 4321,
+          totalElapsedMs: 4334,
+        },
+      };
+      let definition = await definitionLookup.lookupDefinition({
+        module: rri(`${realmURL}person.gts`),
+        name: 'Person',
+      });
+      assert.strictEqual(definition?.displayName, 'Person');
+
+      let rows = (await adapter.execute(
+        `SELECT timing_diagnostics FROM modules WHERE url = $1`,
+        { bind: [`${realmURL}person.gts`] },
+      )) as { timing_diagnostics: unknown }[];
+      assert.strictEqual(rows.length, 1, 'one modules row was written');
+      let raw = rows[0].timing_diagnostics;
+      let persisted =
+        typeof raw === 'string'
+          ? (JSON.parse(raw) as Record<string, any>)
+          : (raw as Record<string, any>);
+      assert.strictEqual(persisted?.requestId, 'req-test-123');
+      assert.strictEqual(persisted?.renderStage, 'waiting-stability');
+      assert.strictEqual(persisted?.renderElapsedMs, 4321);
+      assert.strictEqual(persisted?.launchMs, 12);
+      assert.strictEqual(persisted?.totalElapsedMs, 4334);
+    });
+
+    test('persists null timing_diagnostics when prerender returns no meta', async function (assert) {
+      let definition = await definitionLookup.lookupDefinition({
+        module: rri(`${realmURL}person.gts`),
+        name: 'Person',
+      });
+      assert.strictEqual(definition?.displayName, 'Person');
+
+      let rows = (await adapter.execute(
+        `SELECT timing_diagnostics FROM modules WHERE url = $1`,
+        { bind: [`${realmURL}person.gts`] },
+      )) as { timing_diagnostics: unknown }[];
+      assert.strictEqual(rows.length, 1, 'one modules row was written');
+      assert.strictEqual(
+        rows[0].timing_diagnostics,
+        null,
+        'timing_diagnostics is null when meta is absent',
+      );
     });
   });
 });

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -12,6 +12,7 @@ import {
 import { clampSerializedError, type SerializedError } from './error';
 import {
   fetchUserPermissions,
+  flattenPrerenderMeta,
   internalKeyFor,
   type Definition,
   type ErrorEntry,
@@ -21,6 +22,7 @@ import {
   type Realm,
   type RealmPermissions,
   type ResolvedCodeRef,
+  type TimingDiagnostics,
   executableExtensions,
   hasExecutableExtension,
   trimExecutableExtension,
@@ -139,6 +141,11 @@ interface WriteToDatabaseCacheParams {
   resolvedRealmURL: string;
   cacheScope: CacheScope;
   authUserId: string;
+  // Server-observed render timings + host-side breadcrumbs flattened from
+  // the prerender response's `meta` block (same shape as
+  // `boxel_index.timing_diagnostics`). Lets operators query slow / hung
+  // module renders the same way they query slow / hung card renders.
+  timingDiagnostics?: TimingDiagnostics;
 }
 
 export class FilterRefersToNonexistentTypeError extends Error {
@@ -828,6 +835,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     resolvedRealmURL,
     cacheScope,
     authUserId,
+    timingDiagnostics,
   }: WriteToDatabaseCacheParams): Promise<void> {
     await this.query([
       'INSERT INTO',
@@ -843,6 +851,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
           ['resolved_realm_url'],
           ['cache_scope'],
           ['auth_user_id'],
+          ['timing_diagnostics'],
         ]),
       ) as Expression),
       'VALUES',
@@ -866,6 +875,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
           [param(resolvedRealmURL)],
           [param(cacheScope)],
           [param(authUserId)],
+          [param(timingDiagnostics ? JSON.stringify(timingDiagnostics) : null)],
         ]),
       ) as Expression),
       'ON CONFLICT ON CONSTRAINT modules_pkey DO UPDATE SET',
@@ -876,6 +886,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
         ['error_doc = excluded.error_doc'],
         ['created_at = excluded.created_at'],
         ['resolved_realm_url = excluded.resolved_realm_url'],
+        ['timing_diagnostics = excluded.timing_diagnostics'],
       ]) as Expression),
     ]);
   }
@@ -931,6 +942,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       resolvedRealmURL,
       cacheScope,
       authUserId: cacheScope === 'public' ? '' : userId,
+      timingDiagnostics: flattenPrerenderMeta(response.meta),
     });
     return cacheEntry;
   }

--- a/packages/runtime-common/index-runner/visit-file.ts
+++ b/packages/runtime-common/index-runner/visit-file.ts
@@ -1,6 +1,7 @@
 import type { Ignore } from 'ignore';
 
 import {
+  flattenPrerenderMeta,
   hasExecutableExtension,
   isCardResource,
   isIgnored,
@@ -11,7 +12,6 @@ import {
   type LocalPath,
   type LooseCardResource,
   type Prerenderer,
-  type PrerenderResponseMeta,
   type Reader,
   type RealmPaths,
   type RenderRouteOptions,
@@ -65,24 +65,6 @@ interface VisitFileFusedOptions {
     renderResult?: RenderVisitResponse['fileRender'];
     timingDiagnostics?: TimingDiagnostics;
   }): Promise<void>;
-}
-
-// Flatten a prerender `response.meta` block into the shape persisted
-// to `boxel_index.timing_diagnostics`. Keeps the rich host-side
-// payload (from `meta.diagnostics`) at the top level and promotes the
-// HTTP `requestId` alongside it for easy jsonb-path querying. Returns
-// `undefined` when there's nothing to persist.
-function flattenMeta(
-  meta: PrerenderResponseMeta | undefined,
-): TimingDiagnostics | undefined {
-  if (!meta) return undefined;
-  let diagnostics = meta.diagnostics ?? {};
-  let hasAny = Object.keys(diagnostics).length > 0 || meta.requestId != null;
-  if (!hasAny) return undefined;
-  return {
-    ...diagnostics,
-    ...(meta.requestId ? { requestId: meta.requestId } : {}),
-  };
 }
 
 // Fused visit: calls prerenderer.prerenderVisit once with whichever of the
@@ -236,7 +218,7 @@ export async function visitFileForIndexingFused({
       resourceCreatedAt,
       resource: parsedCardResource,
       renderResult: cardResult,
-      timingDiagnostics: flattenMeta(visitResponse.meta),
+      timingDiagnostics: flattenPrerenderMeta(visitResponse.meta),
     });
   }
 
@@ -250,7 +232,7 @@ export async function visitFileForIndexingFused({
     hasModulePrerender: isModule,
     extractResult: visitResponse.fileExtract,
     renderResult: visitResponse.fileRender,
-    timingDiagnostics: flattenMeta(visitResponse.meta),
+    timingDiagnostics: flattenPrerenderMeta(visitResponse.meta),
   });
 
   logDebug(

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -307,11 +307,12 @@ export function flattenPrerenderMeta(
 ): TimingDiagnostics | undefined {
   if (!meta) return undefined;
   let diagnostics = meta.diagnostics ?? {};
-  let hasAny = Object.keys(diagnostics).length > 0 || meta.requestId != null;
+  let hasRequestId = meta.requestId != null;
+  let hasAny = Object.keys(diagnostics).length > 0 || hasRequestId;
   if (!hasAny) return undefined;
   return {
     ...diagnostics,
-    ...(meta.requestId ? { requestId: meta.requestId } : {}),
+    ...(hasRequestId ? { requestId: meta.requestId } : {}),
   };
 }
 

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -296,6 +296,25 @@ export interface TimingDiagnostics extends RenderTimeoutDiagnostics {
   indexedAt?: number;
 }
 
+// Flatten a prerender `response.meta` block into the shape persisted to
+// `*.timing_diagnostics` columns. Keeps the rich host-side payload (from
+// `meta.diagnostics`) at the top level and promotes the HTTP `requestId`
+// alongside it for jsonb-path querying. Returns `undefined` when there's
+// nothing to persist. Used by both the indexer (boxel_index rows) and the
+// definition-lookup module-cache writer (modules rows).
+export function flattenPrerenderMeta(
+  meta: PrerenderResponseMeta | undefined,
+): TimingDiagnostics | undefined {
+  if (!meta) return undefined;
+  let diagnostics = meta.diagnostics ?? {};
+  let hasAny = Object.keys(diagnostics).length > 0 || meta.requestId != null;
+  if (!hasAny) return undefined;
+  return {
+    ...diagnostics,
+    ...(meta.requestId ? { requestId: meta.requestId } : {}),
+  };
+}
+
 export type AffinityType = 'realm' | 'user';
 
 // Routing dimension orthogonal to `AffinityType`. Inside one


### PR DESCRIPTION
## Summary

- Adds `timing_diagnostics` JSONB column to the `modules` table, mirroring the existing `boxel_index.timing_diagnostics` shape so module renders are queryable via SQL the same way card renders already are.
- `persistModuleCacheEntry` lifts `response.meta.diagnostics` (with `requestId` flattened in) into the new column on every write — success and error paths.
- Lifts the `flattenMeta` helper from `index-runner/visit-file.ts` into a shared runtime-common export (`flattenPrerenderMeta`) so the indexer and the definition-lookup cache writer share one implementation instead of duplicating.
- Updates the `indexing-diagnostics` skill to document the new column and adds **Mode D** with example queries, mirroring Mode A / Mode B for card renders.

## Why

Sub-issue of [CS-10505](https://linear.app/cardstack/issue/CS-10505). The asymmetry today: a card render that hangs leaves a fully-classifiable row in `boxel_index`; a module render that hangs leaves no diagnostic trail at all once `persistModuleCacheEntry` finishes. That makes any investigation that needs to attribute time to module renders blind — e.g. "is this 90s `_federated-search` hang correlated with a slow `card-api` prerender on the same affinity?" is unanswerable today, and that's exactly the question parked on [CS-10995 (F1)](https://linear.app/cardstack/issue/CS-10995) until this lands.

`CachingDefinitionLookup.#inFlight` dedupes concurrent calls for the same module, so a single slow `prerenderModule` for a hot module can be the bottleneck for many concurrent searches. Without persisted module diagnostics that 1:N amplification is invisible in production telemetry.

## Test plan

- [x] `pnpm tsc --noEmit` passes for runtime-common against my changes
- [x] `pnpm lint` passes for `packages/postgres`, `packages/runtime-common` (no new errors in `packages/realm-server` from my changes)
- [x] Existing `definition-lookup-test.ts` tests still pass
- [x] New `module-cache timing diagnostics` qunit module: `persists timing_diagnostics from prerender meta on module rows` ✓
- [x] New `module-cache timing diagnostics` qunit module: `persists null timing_diagnostics when prerender returns no meta` ✓
- [ ] Verify migration applies cleanly in staging deploy
- [ ] After deploy, query staging to confirm new module-cache writes carry `timing_diagnostics`:
  ```sql
  SELECT count(*) FILTER (WHERE timing_diagnostics IS NOT NULL) AS with_diag,
         count(*) AS total
  FROM modules;
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)