### PR TITLE
Fix flaky card catalog tests racing realm-info fetch

### DIFF
--- a/packages/host/app/components/card-search/search-result-section.gts
+++ b/packages/host/app/components/card-search/search-result-section.gts
@@ -2,9 +2,11 @@ import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { isTesting } from '@embroider/macros';
 import Component from '@glimmer/component';
 
 import HistoryIcon from '@cardstack/boxel-icons/history';
+import { modifier } from 'ember-modifier';
 import pluralize from 'pluralize';
 
 import { Button, GridContainer } from '@cardstack/boxel-ui/components';
@@ -14,6 +16,7 @@ import type { CodeRef } from '@cardstack/runtime-common';
 
 import { urlForRealmLookup } from '@cardstack/host/lib/utils';
 import type RealmService from '@cardstack/host/services/realm';
+import { UNKNOWN_REALM_NAME } from '@cardstack/host/services/realm';
 
 import type {
   RealmSection,
@@ -31,16 +34,32 @@ import { SECTION_SHOW_MORE_INCREMENT } from './constants';
 import ItemButton from './item-button';
 import SearchSheetSectionHeader from './section-header';
 
-// Matches the placeholder returned by RealmService#info while fetchInfo
-// is in flight. When a section renders this name, the realm-info fetch
-// hasn't resolved yet — see the diagnostic warning below.
-const PLACEHOLDER_REALM_NAME = 'Unknown Workspace';
-
-// Tracks which realm URLs we've already warned about to keep the warning
-// to one-per-realm-per-page-lifetime. This intentionally lives at module
-// scope so it survives component teardown across test reruns; a leak of a
-// few strings is fine.
+// Tracks which realm URLs we've already warned about to keep the diagnostic
+// to one-per-realm-per-test-run. Only populated under `isTesting()` (the
+// warning is silenced in production), so growth is bounded by realms
+// touched within a single test run / page session — typically a handful.
 const placeholderWarnedFor = new Set<string>();
+
+// did-insert / did-update modifier that emits a one-shot console.warn per
+// realm URL when the section renders with the placeholder realm name.
+// The warning lands in the browser log captured by Ember Exam, so a
+// future recurrence of the realm-info race shows up in CI logs even
+// without a DOM dump. Kept off the render path (no side effects in
+// getters) and gated to test runs (no production logging or set growth).
+const warnPlaceholderModifier = modifier(
+  (
+    _element: Element,
+    [realmUrl, isPlaceholder]: [string | undefined, boolean],
+  ) => {
+    if (!isTesting()) return;
+    if (!isPlaceholder || !realmUrl) return;
+    if (placeholderWarnedFor.has(realmUrl)) return;
+    placeholderWarnedFor.add(realmUrl);
+    console.warn(
+      `search-result-section: rendering with placeholder realm name for ${realmUrl} — realm.info() returned "${UNKNOWN_REALM_NAME}" because fetchInfo has not resolved yet. If a test failed selecting on data-test-realm here, this is the race.`,
+    );
+  },
+);
 
 interface Signature {
   Element: HTMLElement;
@@ -109,31 +128,12 @@ export default class SearchResultSection extends Component<Signature> {
 
   // True when the section header is showing the placeholder name returned
   // by `RealmService#info()` before its fetchInfo resolves. Surfaced as a
-  // data-test attribute and consumed by `maybeWarnPlaceholder` so future
-  // CI failures involving `[data-test-realm="<Name>"]` selectors are
-  // immediately diagnosable (the browser log will show which realm URL
-  // raced its info fetch).
+  // data-test attribute and consumed by `warnPlaceholderModifier`, so
+  // future CI failures involving `[data-test-realm="<Name>"]` selectors
+  // are immediately diagnosable (the browser log will show which realm
+  // URL raced its info fetch).
   get sectionRealmInfoIsPlaceholder(): boolean {
-    return this.sectionRealmName === PLACEHOLDER_REALM_NAME;
-  }
-
-  // Reading this getter from the template emits a one-shot warning per
-  // realm URL when the section is rendered with a placeholder name. The
-  // warning lands in the browser log captured by Ember Exam, so a future
-  // recurrence of the realm-info race shows up in CI logs even without
-  // a DOM dump.
-  get maybeWarnPlaceholder(): null {
-    if (
-      this.sectionRealmInfoIsPlaceholder &&
-      this.sectionRealmUrl &&
-      !placeholderWarnedFor.has(this.sectionRealmUrl)
-    ) {
-      placeholderWarnedFor.add(this.sectionRealmUrl);
-      console.warn(
-        `search-result-section: rendering with placeholder realm name for ${this.sectionRealmUrl} — realm.info() returned "${PLACEHOLDER_REALM_NAME}" because fetchInfo has not resolved yet. If a test failed selecting on data-test-realm here, this is the race.`,
-      );
-    }
-    return null;
+    return this.sectionRealmName === UNKNOWN_REALM_NAME;
   }
 
   @action
@@ -298,12 +298,12 @@ export default class SearchResultSection extends Component<Signature> {
         this.sectionRealmInfoIsPlaceholder
         'true'
       }}
+      {{warnPlaceholderModifier
+        this.sectionRealmUrl
+        this.sectionRealmInfoIsPlaceholder
+      }}
       ...attributes
     >
-      {{! Reading `maybeWarnPlaceholder` is a side effect that emits a
-          one-shot console.warn when the section renders with a placeholder
-          realm name. The warning is the diagnostic; the value is always null. }}
-      {{this.maybeWarnPlaceholder}}
       {{#if this.realmSection}}
         <SearchSheetSectionHeader
           @realmInfo={{this.realmSection.realmInfo}}

--- a/packages/host/app/components/card-search/search-result-section.gts
+++ b/packages/host/app/components/card-search/search-result-section.gts
@@ -31,6 +31,17 @@ import { SECTION_SHOW_MORE_INCREMENT } from './constants';
 import ItemButton from './item-button';
 import SearchSheetSectionHeader from './section-header';
 
+// Matches the placeholder returned by RealmService#info while fetchInfo
+// is in flight. When a section renders this name, the realm-info fetch
+// hasn't resolved yet — see the diagnostic warning below.
+const PLACEHOLDER_REALM_NAME = 'Unknown Workspace';
+
+// Tracks which realm URLs we've already warned about to keep the warning
+// to one-per-realm-per-page-lifetime. This intentionally lives at module
+// scope so it survives component teardown across test reruns; a leak of a
+// few strings is fine.
+const placeholderWarnedFor = new Set<string>();
+
 interface Signature {
   Element: HTMLElement;
   Args: {
@@ -79,6 +90,50 @@ export default class SearchResultSection extends Component<Signature> {
       return this.urlSection.realmInfo.name;
     }
     return undefined;
+  }
+
+  // Stable identifier for the realm section regardless of whether
+  // `realm.info()` has resolved the user-visible name yet. When
+  // `data-test-realm` (the name) is still showing the placeholder
+  // ("Unknown Workspace"), this attribute pins the section to a known
+  // URL so failures are diagnosable and tests can wait reliably.
+  get sectionRealmUrl(): string | undefined {
+    if (this.realmSection) {
+      return this.realmSection.realmUrl;
+    }
+    if (this.urlSection) {
+      return this.urlSection.realmUrl;
+    }
+    return undefined;
+  }
+
+  // True when the section header is showing the placeholder name returned
+  // by `RealmService#info()` before its fetchInfo resolves. Surfaced as a
+  // data-test attribute and consumed by `maybeWarnPlaceholder` so future
+  // CI failures involving `[data-test-realm="<Name>"]` selectors are
+  // immediately diagnosable (the browser log will show which realm URL
+  // raced its info fetch).
+  get sectionRealmInfoIsPlaceholder(): boolean {
+    return this.sectionRealmName === PLACEHOLDER_REALM_NAME;
+  }
+
+  // Reading this getter from the template emits a one-shot warning per
+  // realm URL when the section is rendered with a placeholder name. The
+  // warning lands in the browser log captured by Ember Exam, so a future
+  // recurrence of the realm-info race shows up in CI logs even without
+  // a DOM dump.
+  get maybeWarnPlaceholder(): null {
+    if (
+      this.sectionRealmInfoIsPlaceholder &&
+      this.sectionRealmUrl &&
+      !placeholderWarnedFor.has(this.sectionRealmUrl)
+    ) {
+      placeholderWarnedFor.add(this.sectionRealmUrl);
+      console.warn(
+        `search-result-section: rendering with placeholder realm name for ${this.sectionRealmUrl} — realm.info() returned "${PLACEHOLDER_REALM_NAME}" because fetchInfo has not resolved yet. If a test failed selecting on data-test-realm here, this is the race.`,
+      );
+    }
+    return null;
   }
 
   @action
@@ -238,8 +293,17 @@ export default class SearchResultSection extends Component<Signature> {
         search-result-block--collapsed=@isCollapsed
       }}
       data-test-realm={{this.sectionRealmName}}
+      data-test-realm-url={{this.sectionRealmUrl}}
+      data-test-realm-info-placeholder={{if
+        this.sectionRealmInfoIsPlaceholder
+        'true'
+      }}
       ...attributes
     >
+      {{! Reading `maybeWarnPlaceholder` is a side effect that emits a
+          one-shot console.warn when the section renders with a placeholder
+          realm name. The warning is the diagnostic; the value is always null. }}
+      {{this.maybeWarnPlaceholder}}
       {{#if this.realmSection}}
         <SearchSheetSectionHeader
           @realmInfo={{this.realmSection.realmInfo}}

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -62,6 +62,12 @@ import type ResetService from './reset';
 
 const log = logger('service:realm');
 
+// The name returned by `RealmService#info()` when the corresponding realm
+// resource hasn't yet resolved its `_info` document. Exported so consumers
+// (e.g. SearchResultSection's render-race diagnostic) can detect the
+// placeholder without duplicating the literal string.
+export const UNKNOWN_REALM_NAME = 'Unknown Workspace';
+
 export type EnhancedRealmInfo = RealmInfo & {
   isIndexing: boolean;
   isPublic: boolean;
@@ -807,7 +813,7 @@ export default class RealmService extends Service {
       this.identifyRealmTracker;
 
       return {
-        name: 'Unknown Workspace',
+        name: UNKNOWN_REALM_NAME,
         backgroundURL: null,
         iconURL: null,
         showAsCatalog: null,
@@ -824,7 +830,7 @@ export default class RealmService extends Service {
     if (!resource.info) {
       resource.fetchInfo();
       return {
-        name: 'Unknown Workspace',
+        name: UNKNOWN_REALM_NAME,
         backgroundURL: null,
         iconURL: null,
         showAsCatalog: null,

--- a/packages/host/app/utils/card-search/sections.ts
+++ b/packages/host/app/utils/card-search/sections.ts
@@ -42,6 +42,7 @@ export interface UrlSection {
   sid: string;
   type: 'url';
   card: CardDef;
+  realmUrl: string;
   realmInfo: RealmSectionInfo;
 }
 
@@ -140,6 +141,7 @@ export function buildUrlSection(
     sid: `url:${card.id}`,
     type: 'url',
     card,
+    realmUrl,
     realmInfo: resolveRealmInfo(realmUrl, realm),
   };
 }

--- a/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
@@ -564,6 +564,14 @@ module('Integration | operator-mode | card catalog', function (hooks) {
       count: 1,
     });
 
+    // The section block is keyed by realm name, but `realm.info()` returns a
+    // "Unknown Workspace" placeholder until `fetchInfo` resolves. Selecting
+    // the section by its stable URL avoids racing the info fetch, then we
+    // wait for the human-visible name before asserting on it.
+    await waitFor(
+      `[data-test-realm-url="${baseRealm.url}"][data-test-realm="Base Workspace"]`,
+    );
+
     assert
       .dom(`[data-test-realm="Base Workspace"] [data-test-results-count]`)
       .hasText('1 result');
@@ -709,6 +717,18 @@ module('Integration | operator-mode | card catalog', function (hooks) {
     await waitFor(`[data-test-cards-grid-item]`);
     await click(`[data-test-create-new-card-button]`);
     await waitFor('[data-test-card-catalog-item]');
+    // The section block's `data-test-realm` attribute is keyed by realm
+    // name (rendered from `realm.info(url).name`). When the realm info
+    // fetch hasn't resolved yet, `realm.info()` returns a "Unknown
+    // Workspace" placeholder and the section briefly carries that name
+    // until fetchInfo resolves. Anchor on the stable `data-test-realm-url`
+    // first so subsequent name-based assertions don't race the info fetch.
+    await waitFor(
+      `[data-test-realm-url="${testRealmURL}"][data-test-realm="Operator Mode Workspace"]`,
+    );
+    await waitFor(
+      `[data-test-realm-url="${baseRealm.url}"][data-test-realm="Base Workspace"]`,
+    );
     assert
       .dom(
         `[data-test-realm="Operator Mode Workspace"] [data-test-card-catalog-item]`,
@@ -723,6 +743,16 @@ module('Integration | operator-mode | card catalog', function (hooks) {
     await waitFor(
       `[data-test-card-catalog-item="${testRealmURL}Spec/pet-card"]`,
       { count: 0 },
+    );
+
+    // Re-anchor after the search query mutates the section list — Glimmer
+    // will rebuild the realm sections, and the placeholder-name race window
+    // can re-open if a section is destroyed and recreated.
+    await waitFor(
+      `[data-test-realm-url="${testRealmURL}"][data-test-realm="Operator Mode Workspace"]`,
+    );
+    await waitFor(
+      `[data-test-realm-url="${baseRealm.url}"][data-test-realm="Base Workspace"]`,
     );
 
     assert
@@ -772,6 +802,14 @@ module('Integration | operator-mode | card catalog', function (hooks) {
 
     // Switch to All Realms by clicking All Realms option
     await click('[data-test-boxel-picker-option-row="select-all"]');
+
+    // Same realm-name placeholder race as above — anchor on the URL.
+    await waitFor(
+      `[data-test-realm-url="${testRealmURL}"][data-test-realm="Operator Mode Workspace"]`,
+    );
+    await waitFor(
+      `[data-test-realm-url="${baseRealm.url}"][data-test-realm="Base Workspace"]`,
+    );
 
     assert.dom('[data-test-realm="Operator Mode Workspace"]').exists();
     assert.dom('[data-test-realm="Base Workspace"]').exists();

--- a/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
@@ -564,12 +564,15 @@ module('Integration | operator-mode | card catalog', function (hooks) {
       count: 1,
     });
 
-    // The section block is keyed by realm name, but `realm.info()` returns a
-    // "Unknown Workspace" placeholder until `fetchInfo` resolves. Selecting
-    // the section by its stable URL avoids racing the info fetch, then we
-    // wait for the human-visible name before asserting on it.
+    // The section block is keyed by realm name, but `realm.info()` returns
+    // a "Unknown Workspace" placeholder until `fetchInfo` resolves.
+    // Selecting on the stable URL alongside the human-visible name avoids
+    // racing the info fetch. Default `waitFor` timeout (1s) can be tight
+    // on a loaded CI shard, so use the file's long-running cap (10s)
+    // consistent with `displays searching results` above.
     await waitFor(
       `[data-test-realm-url="${baseRealm.url}"][data-test-realm="Base Workspace"]`,
+      { timeout: 10000 },
     );
 
     assert
@@ -722,12 +725,15 @@ module('Integration | operator-mode | card catalog', function (hooks) {
     // fetch hasn't resolved yet, `realm.info()` returns a "Unknown
     // Workspace" placeholder and the section briefly carries that name
     // until fetchInfo resolves. Anchor on the stable `data-test-realm-url`
-    // first so subsequent name-based assertions don't race the info fetch.
+    // first so subsequent name-based assertions don't race the info
+    // fetch. Bump past the default 1s so a loaded CI shard isn't tight.
     await waitFor(
       `[data-test-realm-url="${testRealmURL}"][data-test-realm="Operator Mode Workspace"]`,
+      { timeout: 10000 },
     );
     await waitFor(
       `[data-test-realm-url="${baseRealm.url}"][data-test-realm="Base Workspace"]`,
+      { timeout: 10000 },
     );
     assert
       .dom(
@@ -750,9 +756,11 @@ module('Integration | operator-mode | card catalog', function (hooks) {
     // can re-open if a section is destroyed and recreated.
     await waitFor(
       `[data-test-realm-url="${testRealmURL}"][data-test-realm="Operator Mode Workspace"]`,
+      { timeout: 10000 },
     );
     await waitFor(
       `[data-test-realm-url="${baseRealm.url}"][data-test-realm="Base Workspace"]`,
+      { timeout: 10000 },
     );
 
     assert
@@ -806,9 +814,11 @@ module('Integration | operator-mode | card catalog', function (hooks) {
     // Same realm-name placeholder race as above — anchor on the URL.
     await waitFor(
       `[data-test-realm-url="${testRealmURL}"][data-test-realm="Operator Mode Workspace"]`,
+      { timeout: 10000 },
     );
     await waitFor(
       `[data-test-realm-url="${baseRealm.url}"][data-test-realm="Base Workspace"]`,
+      { timeout: 10000 },
     );
 
     assert.dom('[data-test-realm="Operator Mode Workspace"]').exists();


### PR DESCRIPTION
## Summary

Two host integration tests in `Integration | operator-mode | card catalog` flake on shard 20 (`can specify a card by URL in the card chooser` and `can filter by realm after searching in card catalog` — see [run 25223454975/job 73962282596](https://github.com/cardstack/boxel/actions/runs/25223454975/job/73962282596)). Both fail selecting on `[data-test-realm="Base Workspace"]`.

The selector races `RealmService#info(url)`: that getter returns the synchronous `"Unknown Workspace"` placeholder while the async `fetchInfo` resolves, so the section block briefly carries `data-test-realm="Unknown Workspace"` and the named selector misses it.

## Changes

- `UrlSection` now carries `realmUrl` directly (`RealmSection` already did) so the consuming component has a stable identifier alongside the user-visible name.
- `SearchResultSection` adds three diagnostics:
  - `data-test-realm-url` on the section block — stable identifier regardless of info-fetch state.
  - `data-test-realm-info-placeholder="true"` while the rendered name is the `"Unknown Workspace"` placeholder.
  - One-shot `console.warn` per realm URL when the section actually renders with the placeholder, so a future recurrence shows up directly in the browser log captured by Ember Exam.
- The two failing tests now `await waitFor("[data-test-realm-url=...][data-test-realm=<Name>]")` before any subsequent name-based assertion. Re-anchored after the in-test `fillIn` and after the realm picker re-adds Base, since both events tear down and rebuild the realm sections.

## Test plan

- [ ] Host CI shard 20 (`Host Tests (20, 20)`) passes on this branch.
- [ ] Re-run shard 20 several times and confirm both targeted tests stay green.
- [ ] Other shards remain green (no regressions from the new section attributes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)