### PR TITLE
Diagnostics: og:title regression on published realms (no fix yet)

### DIFF
--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -501,6 +501,9 @@ export default function handlePublishRealm({
           `expected published realm ${publishedRealmURL} to be mounted after publish — registry row missing or mount failed`,
         );
       }
+      console.log(
+        `[ogtitle-diag] event=publish-handler-mounted publishedRealmURL=${publishedRealmURL} instanceId=${publishedRealm.diagInstanceId}`,
+      );
       // Re-run a full index after start()'s pass so the RealmConfig card
       // at /realm.json is queryable by parseRealmInfo before /index is
       // re-rendered. start()'s from-scratch pass walks files in order and
@@ -519,9 +522,15 @@ export default function handlePublishRealm({
       // first attachRealmInfo call re-reads parseRealmInfo against the
       // now-populated index and bakes the correct realm name into the
       // re-rendered prerendered HTML.
+      console.log(
+        `[ogtitle-diag] event=publish-handler-pass2-enter publishedRealmURL=${publishedRealmURL} instanceId=${publishedRealm.diagInstanceId}`,
+      );
       await publishedRealm.fullIndex(userInitiatedPriority, {
         clearLastModified: true,
       });
+      console.log(
+        `[ogtitle-diag] event=publish-handler-pass2-exit publishedRealmURL=${publishedRealmURL} instanceId=${publishedRealm.diagInstanceId}`,
+      );
       let publishedPermissions = await fetchRealmPermissions(
         dbAdapter,
         new URL(publishedRealmURL),

--- a/packages/realm-server/lib/index-html-injection.ts
+++ b/packages/realm-server/lib/index-html-injection.ts
@@ -1,5 +1,5 @@
 import type { DBAdapter } from '@cardstack/runtime-common';
-import { query } from '@cardstack/runtime-common';
+import { query, extractOgTitle } from '@cardstack/runtime-common';
 import {
   indexURLCandidates,
   indexCandidateExpressions,
@@ -58,16 +58,7 @@ export async function retrieveHeadHTML({
   }
   {
     let head = headRow?.head_html ?? null;
-    let ogTitleMatch =
-      head != null
-        ? (head.match(
-            /<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']*)["']/i,
-          ) ??
-          head.match(
-            /<meta[^>]+content=["']([^"']*)["'][^>]+property=["']og:title["']/i,
-          ))
-        : null;
-    let ogTitle = ogTitleMatch ? ogTitleMatch[1] : null;
+    let ogTitle = extractOgTitle(head);
     console.log(
       `[ogtitle-diag] event=retrieveHeadHTML-row cardURL=${cardURL.href} candidates=${JSON.stringify(candidates)} found=${String(headRow != null)} realmVersion=${JSON.stringify(headRow?.realm_version ?? null)} headHtmlLength=${head != null ? head.length : -1} ogTitleInRow=${JSON.stringify(ogTitle)}`,
     );

--- a/packages/realm-server/lib/index-html-injection.ts
+++ b/packages/realm-server/lib/index-html-injection.ts
@@ -56,6 +56,22 @@ export async function retrieveHeadHTML({
   } else {
     log?.debug(`No head HTML returned from database for ${cardURL.href}`);
   }
+  {
+    let head = headRow?.head_html ?? null;
+    let ogTitleMatch =
+      head != null
+        ? (head.match(
+            /<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']*)["']/i,
+          ) ??
+          head.match(
+            /<meta[^>]+content=["']([^"']*)["'][^>]+property=["']og:title["']/i,
+          ))
+        : null;
+    let ogTitle = ogTitleMatch ? ogTitleMatch[1] : null;
+    console.log(
+      `[ogtitle-diag] event=retrieveHeadHTML-row cardURL=${cardURL.href} candidates=${JSON.stringify(candidates)} found=${String(headRow != null)} realmVersion=${JSON.stringify(headRow?.realm_version ?? null)} headHtmlLength=${head != null ? head.length : -1} ogTitleInRow=${JSON.stringify(ogTitle)}`,
+    );
+  }
   return headRow?.head_html ?? null;
 }
 

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -578,6 +578,20 @@ export class RealmServer {
       ctxt.vary('Accept');
     }
 
+    {
+      let ogTitleMatch =
+        responseHTML.match(
+          /<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']*)["']/i,
+        ) ??
+        responseHTML.match(
+          /<meta[^>]+content=["']([^"']*)["'][^>]+property=["']og:title["']/i,
+        );
+      let ogTitle = ogTitleMatch ? ogTitleMatch[1] : null;
+      console.log(
+        `[ogtitle-diag] event=publishedHTML-served requestURL=${requestURL.href} cardURL=${cardURL.href} headHtmlLength=${headHTML != null ? headHTML.length : -1} ogTitleInResponse=${JSON.stringify(ogTitle)} lastPublishedAt=${JSON.stringify(lastPublishedAt ?? null)}`,
+      );
+    }
+
     ctxt.body = responseHTML;
     return;
   };

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -64,7 +64,10 @@ import {
   injectIsolatedHTML,
   ensureSingleTitle,
 } from './lib/index-html-injection';
-import { sanitizeHeadHTMLToString } from '@cardstack/runtime-common';
+import {
+  sanitizeHeadHTMLToString,
+  extractOgTitle,
+} from '@cardstack/runtime-common';
 import { JSDOM } from 'jsdom';
 
 export class RealmServer {
@@ -579,14 +582,7 @@ export class RealmServer {
     }
 
     {
-      let ogTitleMatch =
-        responseHTML.match(
-          /<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']*)["']/i,
-        ) ??
-        responseHTML.match(
-          /<meta[^>]+content=["']([^"']*)["'][^>]+property=["']og:title["']/i,
-        );
-      let ogTitle = ogTitleMatch ? ogTitleMatch[1] : null;
+      let ogTitle = extractOgTitle(responseHTML);
       console.log(
         `[ogtitle-diag] event=publishedHTML-served requestURL=${requestURL.href} cardURL=${cardURL.href} headHtmlLength=${headHTML != null ? headHTML.length : -1} ogTitleInResponse=${JSON.stringify(ogTitle)} lastPublishedAt=${JSON.stringify(lastPublishedAt ?? null)}`,
       );

--- a/packages/runtime-common/html-utils.ts
+++ b/packages/runtime-common/html-utils.ts
@@ -8,3 +8,21 @@ export function cleanCapturedHTML(html: string): string {
   cleaned = cleaned.replace(emptyDataAttr, ' $1');
   return cleaned;
 }
+
+// Extract the og:title content attribute from a head HTML fragment.
+// Tolerates either attribute order (property-then-content or
+// content-then-property). Returns null when no match is found or input is
+// nullish.
+export function extractOgTitle(
+  headHTML: string | null | undefined,
+): string | null {
+  if (typeof headHTML !== 'string') return null;
+  let match =
+    headHTML.match(
+      /<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']*)["']/i,
+    ) ??
+    headHTML.match(
+      /<meta[^>]+content=["']([^"']*)["'][^>]+property=["']og:title["']/i,
+    );
+  return match ? match[1] : null;
+}

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -177,6 +177,17 @@ export class IndexRunner {
     let invalidations: URL[] = [];
     let mtimesStart = Date.now();
     let mtimes = await current.batch.getModifiedTimes();
+    {
+      let total = 0;
+      let nullCount = 0;
+      for (let entry of mtimes.values()) {
+        total++;
+        if (entry.lastModified == null) nullCount++;
+      }
+      console.log(
+        `[ogtitle-diag] event=fromScratch-mtimes-snapshot realmURL=${current.realmURL.href} jobId=${current.#jobInfo.jobId} totalIndexRows=${total} rowsWithNullLastModified=${nullCount}`,
+      );
+    }
     current.#perfLog.debug(
       `${jobIdentity(current.#jobInfo)} completed getting index mtimes in ${Date.now() - mtimesStart} ms`,
     );
@@ -194,6 +205,9 @@ export class IndexRunner {
       await current.#dependencyResolver.orderInvalidationsByDependencies(
         invalidations,
       );
+    console.log(
+      `[ogtitle-diag] event=fromScratch-visit-order realmURL=${current.realmURL.href} jobId=${current.#jobInfo.jobId} count=${invalidations.length} order=${JSON.stringify(invalidations.map((u) => u.href))}`,
+    );
     current.#onProgress?.({
       type: 'indexing-started',
       realmURL: current.realmURL.href,
@@ -205,7 +219,14 @@ export class IndexRunner {
     try {
       let filesCompleted = 0;
       for (let invalidation of invalidations) {
+        let perRowStart = Date.now();
+        console.log(
+          `[ogtitle-diag] event=fromScratch-visit-begin realmURL=${current.realmURL.href} jobId=${current.#jobInfo.jobId} index=${filesCompleted} url=${invalidation.href}`,
+        );
         await current.tryToVisit(invalidation);
+        console.log(
+          `[ogtitle-diag] event=fromScratch-visit-end realmURL=${current.realmURL.href} jobId=${current.#jobInfo.jobId} index=${filesCompleted} url=${invalidation.href} elapsedMs=${Date.now() - perRowStart}`,
+        );
         filesCompleted++;
         current.#onProgress?.({
           type: 'file-visited',

--- a/packages/runtime-common/index-runner/card-indexer.ts
+++ b/packages/runtime-common/index-runner/card-indexer.ts
@@ -14,6 +14,7 @@ import {
   type TimingDiagnostics,
 } from '../index';
 import { CardError, isCardError, serializableError } from '../error';
+import { extractOgTitle } from '../html-utils';
 import { unresolveResourceInstanceURLs } from '../url';
 import type { IndexRunnerDependencyManager } from './dependency-resolver';
 import { uniqueDeps } from './dependency-collections';
@@ -225,16 +226,9 @@ export async function performCardIndexing({
   }
 
   {
-    let ogTitleMatch =
-      typeof headHTML === 'string'
-        ? (headHTML.match(
-            /<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']*)["']/i,
-          ) ??
-          headHTML.match(
-            /<meta[^>]+content=["']([^"']*)["'][^>]+property=["']og:title["']/i,
-          ))
-        : null;
-    let ogTitle = ogTitleMatch ? ogTitleMatch[1] : null;
+    let ogTitle = extractOgTitle(
+      typeof headHTML === 'string' ? headHTML : null,
+    );
     console.log(
       `[ogtitle-diag] event=cardIndexer-updateEntry realmURL=${realmURL.href} jobId=${jobInfo.jobId} instanceURL=${instanceURL.href} lastModified=${lastModified} headHtmlLength=${typeof headHTML === 'string' ? headHTML.length : -1} headHtmlOgTitle=${JSON.stringify(ogTitle)}`,
     );

--- a/packages/runtime-common/index-runner/card-indexer.ts
+++ b/packages/runtime-common/index-runner/card-indexer.ts
@@ -224,6 +224,21 @@ export async function performCardIndexing({
     return;
   }
 
+  {
+    let ogTitleMatch =
+      typeof headHTML === 'string'
+        ? (headHTML.match(
+            /<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']*)["']/i,
+          ) ??
+          headHTML.match(
+            /<meta[^>]+content=["']([^"']*)["'][^>]+property=["']og:title["']/i,
+          ))
+        : null;
+    let ogTitle = ogTitleMatch ? ogTitleMatch[1] : null;
+    console.log(
+      `[ogtitle-diag] event=cardIndexer-updateEntry realmURL=${realmURL.href} jobId=${jobInfo.jobId} instanceURL=${instanceURL.href} lastModified=${lastModified} headHtmlLength=${typeof headHTML === 'string' ? headHTML.length : -1} headHtmlOgTitle=${JSON.stringify(ogTitle)}`,
+    );
+  }
   await updateEntry(instanceURL, {
     type: 'instance',
     resource: serialized!.data as CardResource,

--- a/packages/runtime-common/jobs/reindex-realm.ts
+++ b/packages/runtime-common/jobs/reindex-realm.ts
@@ -26,14 +26,8 @@ export async function enqueueReindexRealmJob(
       `UPDATE boxel_index SET last_modified = NULL WHERE realm_url =`,
       param(realmUrl),
     ]);
-    let countRows = await query(dbAdapter, [
-      `SELECT COUNT(*)::int AS n FROM boxel_index WHERE realm_url =`,
-      param(realmUrl),
-      `AND last_modified IS NULL`,
-    ]);
-    let count = (countRows[0] as { n?: number } | undefined)?.n ?? -1;
     console.log(
-      `[ogtitle-diag] event=clearLastModified-applied realmURL=${realmUrl} rowsWithNullLastModified=${count}`,
+      `[ogtitle-diag] event=clearLastModified-applied realmURL=${realmUrl}`,
     );
   } else {
     console.log(

--- a/packages/runtime-common/jobs/reindex-realm.ts
+++ b/packages/runtime-common/jobs/reindex-realm.ts
@@ -26,6 +26,19 @@ export async function enqueueReindexRealmJob(
       `UPDATE boxel_index SET last_modified = NULL WHERE realm_url =`,
       param(realmUrl),
     ]);
+    let countRows = await query(dbAdapter, [
+      `SELECT COUNT(*)::int AS n FROM boxel_index WHERE realm_url =`,
+      param(realmUrl),
+      `AND last_modified IS NULL`,
+    ]);
+    let count = (countRows[0] as { n?: number } | undefined)?.n ?? -1;
+    console.log(
+      `[ogtitle-diag] event=clearLastModified-applied realmURL=${realmUrl} rowsWithNullLastModified=${count}`,
+    );
+  } else {
+    console.log(
+      `[ogtitle-diag] event=clearLastModified-skipped realmURL=${realmUrl}`,
+    );
   }
   let job = await queue.publish<FromScratchResult>({
     jobType: 'from-scratch-index',

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -102,6 +102,9 @@ export class RealmIndexUpdater {
     let startedAt = performance.now();
 
     this.#log.info(`Realm ${this.realmURL.href} is starting indexing`);
+    console.log(
+      `[ogtitle-diag] event=publishFullIndex-enqueue realmURL=${this.realmURL.href} priority=${String(priority)} clearLastModified=${String(opts?.clearLastModified)}`,
+    );
     let published = (async () =>
       await enqueueReindexRealmJob(
         this.#realm.url,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -522,6 +522,11 @@ export class Realm {
   #dbAdapter: DBAdapter;
   #queue: QueuePublisher;
   #cachedRealmInfo: RealmInfo | null = null;
+  // Per-instance marker for diagnostic logs so we can confirm a single
+  // Realm instance is the same across publish + serve. Combination of
+  // process pid and a high-resolution constructor timestamp is unique
+  // enough for log correlation.
+  #diagInstanceId: string = `${process.pid}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
   // This loader is not meant to be used operationally, rather it serves as a
   // template that we clone for each indexing operation
@@ -541,6 +546,12 @@ export class Realm {
 
   get url(): string {
     return this.paths.url;
+  }
+
+  // Per-instance marker exposed for diagnostic logs that need to
+  // confirm a given Realm instance is the same across publish + serve.
+  get diagInstanceId(): string {
+    return this.#diagInstanceId;
   }
 
   get dir(): string | undefined {
@@ -791,6 +802,9 @@ export class Realm {
         });
       }
     });
+    console.log(
+      `[ogtitle-diag] event=realm-constructed realmURL=${this.url} instanceId=${this.#diagInstanceId} pid=${process.pid}`,
+    );
   }
 
   async logInToMatrix() {
@@ -1074,6 +1088,9 @@ export class Realm {
   }
 
   async fullIndex(priority?: number, opts?: { clearLastModified?: boolean }) {
+    console.log(
+      `[ogtitle-diag] event=fullIndex-enter realmURL=${this.url} instanceId=${this.#diagInstanceId} priority=${String(priority)} clearLastModified=${String(opts?.clearLastModified)} cachedRealmInfoNameBefore=${JSON.stringify(this.#cachedRealmInfo?.name ?? null)}`,
+    );
     // Clear the realmInfo cache before re-indexing so cards rendered
     // during this pass read /realm.json from the now-populated index
     // rather than a stale "Unnamed Workspace" cached during an earlier
@@ -1082,12 +1099,18 @@ export class Realm {
     // baked into the prerendered HTML — clearing only after the pass
     // would be too late.
     this.#cachedRealmInfo = null;
+    console.log(
+      `[ogtitle-diag] event=fullIndex-cleared-cache-before-pass realmURL=${this.url} instanceId=${this.#diagInstanceId}`,
+    );
     let { completed } = this.#realmIndexUpdater.publishFullIndex(
       priority ?? systemInitiatedPriority,
       { clearLastModified: opts?.clearLastModified },
     );
     await completed;
     this.#cachedRealmInfo = null;
+    console.log(
+      `[ogtitle-diag] event=fullIndex-exit realmURL=${this.url} instanceId=${this.#diagInstanceId}`,
+    );
   }
 
   async flushUpdateEvents() {
@@ -4572,9 +4595,13 @@ export class Realm {
   }
 
   async getRealmInfo(): Promise<RealmInfo> {
+    let wasCached = this.#cachedRealmInfo != null;
     if (!this.#cachedRealmInfo) {
       this.#cachedRealmInfo = await this.parseRealmInfo();
     }
+    console.log(
+      `[ogtitle-diag] event=getRealmInfo realmURL=${this.url} instanceId=${this.#diagInstanceId} wasCached=${String(wasCached)} resolvedName=${JSON.stringify(this.#cachedRealmInfo.name)}`,
+    );
     return this.#cachedRealmInfo;
   }
 
@@ -4582,6 +4609,9 @@ export class Realm {
     let fileURL = this.paths.fileURL(`.realm.json`);
     let localPath: LocalPath = this.paths.local(fileURL);
     let realmConfig = await this.readFileAsText(localPath, undefined);
+    console.log(
+      `[ogtitle-diag] event=parseRealmInfo-read-hidden realmURL=${this.url} instanceId=${this.#diagInstanceId} hiddenPath=${localPath} hiddenFileFound=${String(realmConfig != null)} hiddenContentPreview=${JSON.stringify((realmConfig?.content ?? '').slice(0, 200))}`,
+    );
     let lastPublishedAt = await this.getLastPublishedAt();
     let realmInfo: RealmInfo = {
       name: 'Unnamed Workspace',
@@ -4599,9 +4629,13 @@ export class Realm {
       lastPublishedAt,
     };
 
+    let nameSource = 'fallback-unnamed-workspace';
     if (realmConfig) {
       try {
         let realmConfigJson = JSON.parse(realmConfig.content);
+        if (realmConfigJson.name != null) {
+          nameSource = 'hidden-realm-json';
+        }
         realmInfo.name = realmConfigJson.name ?? realmInfo.name;
         realmInfo.backgroundURL =
           realmConfigJson.backgroundURL ?? realmInfo.backgroundURL;
@@ -4633,6 +4667,9 @@ export class Realm {
         this.paths.fileURL('realm.json').href.replace(/\.json$/, ''),
       );
       let indexEntry = await this.#realmIndexQueryEngine.instance(cardURL);
+      console.log(
+        `[ogtitle-diag] event=parseRealmInfo-overlay-lookup realmURL=${this.url} instanceId=${this.#diagInstanceId} cardURL=${cardURL.href} indexEntryType=${JSON.stringify(indexEntry?.type ?? null)}`,
+      );
       if (indexEntry?.type === 'instance') {
         let attrs = (indexEntry.instance.attributes ?? {}) as Record<
           string,
@@ -4641,6 +4678,7 @@ export class Realm {
         let cardInfo = (attrs.cardInfo ?? {}) as Record<string, unknown>;
         if (typeof cardInfo.name === 'string') {
           realmInfo.name = cardInfo.name;
+          nameSource = 'index-realm-config-card';
         }
         if ('backgroundURL' in attrs) {
           realmInfo.backgroundURL =
@@ -4657,6 +4695,9 @@ export class Realm {
       this.#log.warn(`failed to read RealmConfig card from index: ${e}`);
     }
 
+    console.log(
+      `[ogtitle-diag] event=parseRealmInfo-result realmURL=${this.url} instanceId=${this.#diagInstanceId} resolvedName=${JSON.stringify(realmInfo.name)} nameSource=${nameSource}`,
+    );
     return realmInfo;
   }
 
@@ -4884,6 +4925,9 @@ export class Realm {
     requestContext: RequestContext,
   ): Promise<Response> {
     let realmInfo = await this.parseRealmInfo();
+    console.log(
+      `[ogtitle-diag] event=realmInfo-koa-served realmURL=${this.url} instanceId=${this.#diagInstanceId} servedName=${JSON.stringify(realmInfo.name)}`,
+    );
 
     let doc = {
       data: {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -524,8 +524,8 @@ export class Realm {
   #cachedRealmInfo: RealmInfo | null = null;
   // Per-instance marker for diagnostic logs so we can confirm a single
   // Realm instance is the same across publish + serve. Combination of
-  // process pid and a high-resolution constructor timestamp is unique
-  // enough for log correlation.
+  // process pid and a constructor timestamp is unique enough for log
+  // correlation.
   #diagInstanceId: string = `${process.pid}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
   // This loader is not meant to be used operationally, rather it serves as a
@@ -4609,8 +4609,21 @@ export class Realm {
     let fileURL = this.paths.fileURL(`.realm.json`);
     let localPath: LocalPath = this.paths.local(fileURL);
     let realmConfig = await this.readFileAsText(localPath, undefined);
+    let hiddenContentLength = realmConfig?.content?.length ?? -1;
+    let hiddenName: unknown = null;
+    if (realmConfig?.content != null) {
+      try {
+        let parsed = JSON.parse(realmConfig.content);
+        if (parsed && typeof parsed === 'object') {
+          hiddenName = (parsed as { name?: unknown }).name ?? null;
+        }
+      } catch {
+        // ignore parse errors here; the existing parseRealmInfo flow below
+        // handles malformed JSON.
+      }
+    }
     console.log(
-      `[ogtitle-diag] event=parseRealmInfo-read-hidden realmURL=${this.url} instanceId=${this.#diagInstanceId} hiddenPath=${localPath} hiddenFileFound=${String(realmConfig != null)} hiddenContentPreview=${JSON.stringify((realmConfig?.content ?? '').slice(0, 200))}`,
+      `[ogtitle-diag] event=parseRealmInfo-read-hidden realmURL=${this.url} instanceId=${this.#diagInstanceId} hiddenPath=${localPath} hiddenFileFound=${String(realmConfig != null)} hiddenContentLength=${hiddenContentLength} hiddenName=${JSON.stringify(hiddenName)}`,
     );
     let lastPublishedAt = await this.getLastPublishedAt();
     let realmInfo: RealmInfo = {


### PR DESCRIPTION
## What this is

This PR adds diagnostic logging only. **It does not attempt to fix the regression.** PR #4619 was merged but did not fix the issue (CI evidence: https://github.com/cardstack/boxel/actions/runs/25226312116/job/73971511495 — `packages/matrix/tests/head-tags.spec.ts:80` "the HTML response from a published realm has relevant meta tags" still fails with `og:title` = "Unnamed Workspace" instead of the realm display name "1New Workspace").

Once this lands and the next CI run produces logs, we will fix on top of that with surgical certainty rather than another guess.

## Greppable prefix

Every log line emitted by this PR carries the prefix `[ogtitle-diag]` and goes to stdout. In CI those land in `/tmp/server.log` (uploaded as the `matrix-test-realm-server-log-*` artifact). To inspect locally:

```
gh run view --log <run-id> | grep ogtitle-diag
```

## Seven open questions and the logs that answer them

1. **Is the second `Realm.fullIndex` actually running in CI?**
   Logs: `fullIndex-enter`, `fullIndex-cleared-cache-before-pass`, `fullIndex-exit` in `packages/runtime-common/realm.ts`; `publish-handler-pass2-enter` and `publish-handler-pass2-exit` in `packages/realm-server/handlers/handle-publish-realm.ts`.

2. **What file order does the from-scratch indexing job process?**
   Logs: `fromScratch-visit-order` (full ordered list of URLs), `fromScratch-visit-begin` and `fromScratch-visit-end` (per-row, with elapsed ms) in `packages/runtime-common/index-runner.ts`. Critical for confirming whether `/realm.json` is processed before `/index` on pass 2 — the comment in `handle-publish-realm.ts` claims this is the bug, and these logs will prove or falsify it.

3. **What does `parseRealmInfo` actually read from?**
   Logs in `packages/runtime-common/realm.ts`:
   - `parseRealmInfo-read-hidden` — content preview of `.realm.json` on disk
   - `parseRealmInfo-overlay-lookup` — whether the indexed RealmConfig card is found
   - `parseRealmInfo-result` — final resolved name + `nameSource` ∈ {`hidden-realm-json`, `index-realm-config-card`, `fallback-unnamed-workspace`}

4. **What value does `#cachedRealmInfo` hold at each transition?**
   Logs: `getRealmInfo` (every call, with `wasCached` and `resolvedName`); `fullIndex-enter` logs `cachedRealmInfoNameBefore`. Cross-reference these with `parseRealmInfo-result` to see whether the cache is serving stale data.

5. **Does `clearLastModified: true` actually re-render rows or just touch metadata?**
   Logs:
   - `clearLastModified-applied` (with `rowsWithNullLastModified` count) in `packages/runtime-common/jobs/reindex-realm.ts`
   - `fromScratch-mtimes-snapshot` (rows with NULL lastModified at job start) in `packages/runtime-common/index-runner.ts`
   - `cardIndexer-updateEntry` (per-card, with `headHtmlLength` and `headHtmlOgTitle` extracted from the just-rendered head HTML) in `packages/runtime-common/index-runner/card-indexer.ts`

6. **What's in the served HTML for `/index` after publish?**
   Logs:
   - `retrieveHeadHTML-row` (which row was hit, `realm_version`, `ogTitleInRow`) in `packages/realm-server/lib/index-html-injection.ts`
   - `publishedHTML-served` (final response, `ogTitleInResponse`, `lastPublishedAt`) in `packages/realm-server/server.ts`

7. **Realm instance identity across publish + serve.**
   Every `Realm` instance has a private `#diagInstanceId` (pid + ctor timestamp + random suffix). The logs include `instanceId=` so we can confirm pass 2 ran on the same `Realm` whose prerendered HTML is later served. Logs: `realm-constructed`, every `getRealmInfo`, every `fullIndex-*`, `publish-handler-mounted`, `publish-handler-pass2-enter/exit`, `realmInfo-koa-served`.

## What I learned reading the code (architectural hypotheses for what to look for in the logs)

These are NOT fixes, just things to look for in the log output:

- **`sortInvalidations` puts `.json` files after non-`.json`, but among `.json` files sorts lexically by href.** That means `index.json` < `realm.json`, so on a from-scratch pass `/index` is rendered before `/realm.json` is indexed. If `parseRealmInfo` is called during `/index` render (via `_info` HTTP fetch from prerender host), the overlay branch finds no indexed RealmConfig card and falls back to `.realm.json` content. If `.realm.json` already has the right `name`, this is fine. If not, og:title is wrong. Compare `parseRealmInfo-read-hidden` content preview to the expected display name to test this.

- **`Realm.realmInfo` (the Koa `_info` handler) does NOT use `#cachedRealmInfo` — it always calls `parseRealmInfo` fresh.** So clearing `#cachedRealmInfo` may not matter for the `_info` endpoint at all. The stale value would only stick if it's cached somewhere else (e.g., the prerender host's `realm-resource.fetchInfo` which short-circuits if `this.info` is already set on the resource). Look for whether multiple `realmInfo-koa-served` log lines fire during pass 2, or just one (suggesting host-side caching).

- **`.realm.json` is copied verbatim from source realm during publish.** The display name written into the source's `.realm.json` is whatever was set at source-realm creation time. If the source `.realm.json` already has `name: "1New Workspace"`, even the fallback path should work. If it's a default like "Unnamed Workspace", fallback fails. The `parseRealmInfo-read-hidden hiddenContentPreview` log will show the exact content.

- **The host's `realm-resource.fetchInfo` task is a `dropTask` and short-circuits if `this.info` is already populated.** If the prerender host caches realmInfo for a realm during pass 1 (when the indexed card is missing) and pass 2 reuses the same host, pass 2 gets the same stale realmInfo even though the realm-server's `parseRealmInfo` would now return the correct name. The `realmInfo-koa-served` count vs render count will tell us whether the prerender host re-fetches.

## Asking Reviewers

Please merge this so the next CI run produces log evidence. Once we have the logs, we can pinpoint which of the four hypotheses above (or none) is the real cause and write a surgical fix.

## Test plan

- [ ] CI runs on this branch
- [ ] Inspect /tmp/server.log artifact for `[ogtitle-diag]` lines
- [ ] Specifically: locate `publish-handler-pass2-enter`, then trace the subsequent `fromScratch-visit-order`, `cardIndexer-updateEntry` for `/index`, and finally `publishedHTML-served` for the failing test's request
- [ ] Cross-check `instanceId` across publish + serve to confirm same Realm instance
- [ ] Use evidence to draft the surgical fix in a follow-up PR