### PR TITLE
host: expand isolated view to full width with floating top bar

### DIFF
--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -320,7 +320,6 @@ export default class CardHeader extends Component<Signature> {
           flex-shrink: 1;
           min-width: 0;
           text-align: center;
-          padding-inline: 30px;
         }
         .card-type-display-name-text {
           font: 700 var(--boxel-font-sm);
@@ -429,9 +428,18 @@ export default class CardHeader extends Component<Signature> {
           vertical-align: middle;
         }
 
-        @container card-header (max-width: 30rem) {
+        @container card-header (min-width: 30rem) {
           .card-type-display-name {
-            padding-inline: 0;
+            padding-inline: 1.875rem;
+          }
+        }
+
+        @container card-header (min-width: 28rem) {
+          .realm-icon-container {
+            min-width: var(--boxel-card-header-icon-container-min-width);
+          }
+          .actions {
+            min-width: var(--boxel-card-header-actions-min-width);
           }
         }
 

--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -167,7 +167,7 @@ export default class CardHeader extends Component<Signature> {
                 />
               </:trigger>
               <:content>
-                {{if @isExpanded 'Restore' 'Expand to full width'}}
+                {{if @isExpanded 'Restore' 'Expand to Full Width'}}
               </:content>
             </Tooltip>
           {{/if}}

--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -67,220 +67,213 @@ export default class CardHeader extends Component<Signature> {
         }}
         ...attributes
       >
-        <div
-          class='realm-icon-container'
-          style={{if
-            @headerColor
-            (cssVar
-              boxel-realm-icon-background-color=(getContrastColor
-                @headerColor 'transparent'
+        <div class='boxel-card-header__inner'>
+          <div
+            class='realm-icon-container'
+            style={{if
+              @headerColor
+              (cssVar
+                boxel-realm-icon-background-color=(getContrastColor
+                  @headerColor 'transparent'
+                )
+                boxel-realm-icon-border-color=(getContrastColor
+                  @headerColor 'rgba(0, 0, 0, 0.15)'
+                )
               )
-              boxel-realm-icon-border-color=(getContrastColor
-                @headerColor 'rgba(0, 0, 0, 0.15)'
-              )
-            )
-          }}
-        >
-          {{#if @realmInfo.iconURL}}
-            <Tooltip @placement='right'>
-              <:trigger>
-                <RealmIcon
-                  @canAnimate={{@isTopCard}}
-                  @realmInfo={{@realmInfo}}
-                  class='realm-icon'
-                  data-test-card-header-realm-icon={{@realmInfo.iconURL}}
-                />
-              </:trigger>
-              <:content>
-                In
-                {{@realmInfo.name}}
-              </:content>
-            </Tooltip>
-          {{/if}}
-        </div>
-
-        <div class='card-type-display-name' data-test-boxel-card-header-title>
-          {{#if @cardTypeIcon}}<@cardTypeIcon />{{/if}}
-          {{#if @cardTypeDisplayName}}<span
-              class='card-type-display-name-text'
-            >{{@cardTypeDisplayName}}</span>{{/if}}
-          {{#if (and @cardTypeDisplayName @cardTitle)}}<span
-              class='card-title-text'
-            >-</span>
-          {{/if}}
-          {{#if @cardTitle}}<span class='card-title-text'>
-              {{@cardTitle}}</span>{{/if}}
-          {{#if (or @isSaving (bool @lastSavedMessage))}}
-            <div class='save-indicator' data-test-auto-save-indicator>
-              {{#if @isSaving}}
-                Saving…
-              {{else if (bool @lastSavedMessage)}}
-                <div class='boxel-contents-only' data-test-last-saved>
-                  {{@lastSavedMessage}}
-                </div>
-              {{/if}}
-            </div>
-          {{/if}}
-        </div>
-
-        <div class='actions' data-test-boxel-card-header-actions>
-          {{#if @utilityMenu}}
-            <div class='utility-menu-positioner'>
-              <BoxelDropdown @autoClose={{true}}>
-                <:trigger as |ddModifier|>
-                  <Button class='utility-menu-trigger' {{ddModifier}}>
-                    <span>
-                      {{@utilityMenu.triggerText}}
-                    </span>
-                    <DropdownArrowDown
-                      class='utility-menu-dropdown-arrow'
-                      width='13px'
-                      height='13px'
-                    />
-                  </Button>
-                </:trigger>
-                <:content as |dd|>
-                  <Menu
-                    @items={{@utilityMenu.menuItems}}
-                    @closeMenu={{dd.close}}
+            }}
+          >
+            {{#if @realmInfo.iconURL}}
+              <Tooltip @placement='right'>
+                <:trigger>
+                  <RealmIcon
+                    @canAnimate={{@isTopCard}}
+                    @realmInfo={{@realmInfo}}
+                    class='realm-icon'
+                    data-test-card-header-realm-icon={{@realmInfo.iconURL}}
                   />
+                </:trigger>
+                <:content>
+                  In
+                  {{@realmInfo.name}}
                 </:content>
-              </BoxelDropdown>
-            </div>
-          {{/if}}
-          {{#if @onExpand}}
-            <Tooltip @placement='top'>
-              <:trigger>
-                <ContextButton
-                  class='icon-button icon-button--maximize'
-                  @icon={{Maximize}}
-                  @isActive={{@isExpanded}}
-                  @isToggle={{true}}
-                  @label={{if @isExpanded 'Restore' 'Expand'}}
-                  {{on 'click' @onExpand}}
-                  data-test-expand-button={{if
-                    @isExpanded
-                    'active'
-                    'not-active'
-                  }}
-                />
-              </:trigger>
-              <:content>
-                {{if @isExpanded 'Restore' 'Expand to Full Width'}}
-              </:content>
-            </Tooltip>
-          {{/if}}
-          {{#if @onEdit}}
-            <Tooltip @placement='top'>
-              <:trigger>
-                <ContextButton
-                  class='icon-button'
-                  @icon='edit'
-                  @label='Edit'
-                  {{on 'click' @onEdit}}
-                  data-test-edit-button
-                />
-              </:trigger>
-              <:content>
-                Edit{{#if @editShortcutHint}}
-                  ({{@editShortcutHint}})
+              </Tooltip>
+            {{/if}}
+          </div>
+
+          <div class='card-type-display-name' data-test-boxel-card-header-title>
+            {{#if @cardTypeIcon}}<@cardTypeIcon />{{/if}}
+            {{#if @cardTypeDisplayName}}<span
+                class='card-type-display-name-text'
+              >{{@cardTypeDisplayName}}</span>{{/if}}
+            {{#if (and @cardTypeDisplayName @cardTitle)}}<span
+                class='card-title-text'
+              >-</span>
+            {{/if}}
+            {{#if @cardTitle}}<span class='card-title-text'>
+                {{@cardTitle}}</span>{{/if}}
+            {{#if (or @isSaving (bool @lastSavedMessage))}}
+              <div class='save-indicator' data-test-auto-save-indicator>
+                {{#if @isSaving}}
+                  Saving…
+                {{else if (bool @lastSavedMessage)}}
+                  <div class='boxel-contents-only' data-test-last-saved>
+                    {{@lastSavedMessage}}
+                  </div>
                 {{/if}}
-              </:content>
-            </Tooltip>
-          {{/if}}
-          {{#if @onFinishEditing}}
-            <Tooltip @placement='top'>
-              <:trigger>
-                <ContextButton
-                  class='icon-save'
-                  @icon='edit'
-                  @label='Finish Editing'
-                  {{on 'click' @onFinishEditing}}
-                  data-test-edit-button
-                />
-              </:trigger>
-              <:content>
-                Finish Editing{{#if @finishEditingShortcutHint}}
-                  ({{@finishEditingShortcutHint}})
-                {{/if}}
-              </:content>
-            </Tooltip>
-          {{/if}}
-          {{#if this.hasMoreOptionsMenuItems}}
-            <div>
-              <BoxelDropdown>
-                <:trigger as |bindings|>
-                  <Tooltip @placement='top'>
-                    <:trigger>
-                      <ContextButton
-                        class='icon-button'
-                        @variant={{if isEditing 'ghost'}}
-                        @label='Options'
-                        data-test-more-options-button
-                        {{bindings}}
+              </div>
+            {{/if}}
+          </div>
+
+          <div class='actions' data-test-boxel-card-header-actions>
+            {{#if @utilityMenu}}
+              <div class='utility-menu-positioner'>
+                <BoxelDropdown @autoClose={{true}}>
+                  <:trigger as |ddModifier|>
+                    <Button class='utility-menu-trigger' {{ddModifier}}>
+                      <span>
+                        {{@utilityMenu.triggerText}}
+                      </span>
+                      <DropdownArrowDown
+                        class='utility-menu-dropdown-arrow'
+                        width='13px'
+                        height='13px'
                       />
-                    </:trigger>
-                    <:content>
-                      More Options
-                    </:content>
-                  </Tooltip>
-                </:trigger>
-                <:content as |dd|>
-                  <Menu
-                    @closeMenu={{dd.close}}
-                    @items={{this.safeMoreOptionsMenuItems}}
+                    </Button>
+                  </:trigger>
+                  <:content as |dd|>
+                    <Menu
+                      @items={{@utilityMenu.menuItems}}
+                      @closeMenu={{dd.close}}
+                    />
+                  </:content>
+                </BoxelDropdown>
+              </div>
+            {{/if}}
+            {{#if @onExpand}}
+              <Tooltip class='expand-button-tooltip' @placement='top'>
+                <:trigger>
+                  <ContextButton
+                    class='icon-button icon-button--maximize'
+                    @icon={{Maximize}}
+                    @isActive={{@isExpanded}}
+                    @isToggle={{true}}
+                    @label={{if @isExpanded 'Restore' 'Expand'}}
+                    {{on 'click' @onExpand}}
+                    data-test-expand-button={{if
+                      @isExpanded
+                      'active'
+                      'not-active'
+                    }}
                   />
+                </:trigger>
+                <:content>
+                  {{if @isExpanded 'Restore' 'Expand to Full Width'}}
                 </:content>
-              </BoxelDropdown>
-            </div>
-          {{/if}}
+              </Tooltip>
+            {{/if}}
+            {{#if @onEdit}}
+              <Tooltip @placement='top'>
+                <:trigger>
+                  <ContextButton
+                    class='icon-button'
+                    @icon='edit'
+                    @label='Edit'
+                    {{on 'click' @onEdit}}
+                    data-test-edit-button
+                  />
+                </:trigger>
+                <:content>
+                  Edit{{#if @editShortcutHint}}
+                    ({{@editShortcutHint}})
+                  {{/if}}
+                </:content>
+              </Tooltip>
+            {{/if}}
+            {{#if @onFinishEditing}}
+              <Tooltip @placement='top'>
+                <:trigger>
+                  <ContextButton
+                    class='icon-button icon-save'
+                    @icon='edit'
+                    @label='Finish Editing'
+                    {{on 'click' @onFinishEditing}}
+                    data-test-edit-button
+                  />
+                </:trigger>
+                <:content>
+                  Finish Editing{{#if @finishEditingShortcutHint}}
+                    ({{@finishEditingShortcutHint}})
+                  {{/if}}
+                </:content>
+              </Tooltip>
+            {{/if}}
+            {{#if this.hasMoreOptionsMenuItems}}
+              <div>
+                <BoxelDropdown>
+                  <:trigger as |bindings|>
+                    <Tooltip @placement='top'>
+                      <:trigger>
+                        <ContextButton
+                          class='icon-button'
+                          @variant={{if isEditing 'ghost'}}
+                          @label='Options'
+                          data-test-more-options-button
+                          {{bindings}}
+                        />
+                      </:trigger>
+                      <:content>
+                        More Options
+                      </:content>
+                    </Tooltip>
+                  </:trigger>
+                  <:content as |dd|>
+                    <Menu
+                      @closeMenu={{dd.close}}
+                      @items={{this.safeMoreOptionsMenuItems}}
+                    />
+                  </:content>
+                </BoxelDropdown>
+              </div>
+            {{/if}}
 
-          {{#if @onClose}}
-            <Tooltip @placement='top'>
-              <:trigger>
-                <ContextButton
-                  class='icon-button'
-                  @icon='close'
-                  @variant={{if isEditing 'ghost'}}
-                  @label='Close'
-                  @width='24'
-                  @height='24'
-                  {{on 'click' @onClose}}
-                  data-test-close-button
-                />
-              </:trigger>
-              <:content>
-                Close{{#if @closeShortcutHint}}
-                  ({{@closeShortcutHint}})
-                {{/if}}
-              </:content>
-            </Tooltip>
-          {{/if}}
+            {{#if @onClose}}
+              <Tooltip @placement='top'>
+                <:trigger>
+                  <ContextButton
+                    class='icon-button'
+                    @icon='close'
+                    @variant={{if isEditing 'ghost'}}
+                    @label='Close'
+                    @width='24'
+                    @height='24'
+                    {{on 'click' @onClose}}
+                    data-test-close-button
+                  />
+                </:trigger>
+                <:content>
+                  Close{{#if @closeShortcutHint}}
+                    ({{@closeShortcutHint}})
+                  {{/if}}
+                </:content>
+              </Tooltip>
+            {{/if}}
+          </div>
         </div>
       </header>
     {{/let}}
     <style scoped>
       @layer {
         header {
-          --inner-boxel-card-header-padding: var(
-            --boxel-card-header-padding,
-            var(--boxel-sp-xs)
-          );
-          --inner-boxel-card-header-realm-icon-size: var(
-            --boxel-card-header-realm-icon-size,
-            var(--boxel-icon-med)
-          );
-          --inner-boxel-card-header-card-type-icon-size: var(
-            --boxel-card-header-card-type-icon-size,
-            var(--boxel-icon-sm)
-          );
+          container-type: inline-size;
+          container-name: card-header;
           position: relative;
-          display: flex;
-          align-items: center;
           min-height: var(--boxel-card-header-min-height, 1.875rem); /* 30px */
           width: 100%;
+          max-width: 100%;
           box-sizing: border-box;
           overflow: hidden;
+          display: flex;
+          align-items: center;
           color: var(--boxel-card-header-text-color, var(--boxel-dark));
           background-color: var(
             --boxel-card-header-background-color,
@@ -294,15 +287,9 @@ export default class CardHeader extends Component<Signature> {
             var(--boxel-card-header-border-radius, var(--boxel-border-radius)) -
               1px
           );
-          letter-spacing: var(--boxel-card-header-letter-spacing, normal);
-          text-transform: var(--boxel-card-header-text-transform);
           transition:
             background-color var(--boxel-transition),
             color var(--boxel-transition);
-          gap: var(--boxel-card-header-gap, var(--boxel-sp-xs));
-          padding: var(--inner-boxel-card-header-padding, var(--boxel-sp-xl));
-          font: var(--boxel-card-header-font-weight, 600)
-            var(--boxel-card-header-text-font, var(--boxel-font-sm));
         }
         /* In a stacked (non-expanded) card, the whole header bar
            goes green when editing — original behavior. The expanded-
@@ -312,11 +299,20 @@ export default class CardHeader extends Component<Signature> {
           background-color: var(--boxel-highlight);
           color: var(--boxel-dark);
         }
+        .boxel-card-header__inner {
+          width: 100%;
+          max-width: 100%;
+          display: flex;
+          align-items: center;
+          gap: var(--boxel-card-header-gap, var(--boxel-sp-xs));
+          padding: var(--boxel-card-header-padding, var(--boxel-sp-xs));
+          letter-spacing: var(--boxel-card-header-letter-spacing, normal);
+          text-transform: var(--boxel-card-header-text-transform);
+          font: var(--boxel-card-header-font-weight, 600)
+            var(--boxel-card-header-text-font, var(--boxel-font-sm));
+        }
         header .card-type-display-name {
-          max-width: var(
-            --boxel-card-header-max-width,
-            100%
-          ); /* this includes the space to show the header buttons */
+          max-width: var(--boxel-card-header-max-width, 100%);
           text-overflow: var(--boxel-card-header-text-overflow, ellipsis);
           overflow: hidden;
           text-wrap: nowrap;
@@ -324,7 +320,6 @@ export default class CardHeader extends Component<Signature> {
           flex-shrink: 1;
           min-width: 0;
           text-align: center;
-          padding: 0 30px;
         }
         .card-type-display-name-text {
           font: 700 var(--boxel-font-sm);
@@ -333,12 +328,18 @@ export default class CardHeader extends Component<Signature> {
           font: 500 var(--boxel-font-sm);
         }
 
-        header .card-type-display-name > :deep(svg) {
+        .card-type-display-name > :deep(svg) {
           display: inline-block;
           vertical-align: middle;
-          max-height: var(--inner-boxel-card-header-card-type-icon-size);
-          max-width: var(--inner-boxel-card-header-card-type-icon-size);
-          margin-right: var(--boxel-sp-xxxs);
+          max-height: var(
+            --boxel-card-header-card-type-icon-size,
+            var(--boxel-icon-sm)
+          );
+          max-width: var(
+            --boxel-card-header-card-type-icon-size,
+            var(--boxel-icon-sm)
+          );
+          margin-right: var(--boxel-sp-3xs);
           margin-bottom: calc(1rem - var(--boxel-font-size-sm));
         }
         .save-indicator {
@@ -348,7 +349,6 @@ export default class CardHeader extends Component<Signature> {
         .realm-icon-container {
           display: flex;
           align-items: center;
-          min-width: var(--boxel-card-header-icon-container-min-width);
           justify-content: left;
           --boxel-realm-icon-background-color: var(
             --realm-icon-background-color
@@ -361,8 +361,14 @@ export default class CardHeader extends Component<Signature> {
         }
 
         .realm-icon {
-          width: var(--inner-boxel-card-header-realm-icon-size);
-          height: var(--inner-boxel-card-header-realm-icon-size);
+          width: var(
+            --boxel-card-header-realm-icon-size,
+            var(--boxel-icon-med)
+          );
+          height: var(
+            --boxel-card-header-realm-icon-size,
+            var(--boxel-icon-med)
+          );
         }
 
         .actions {
@@ -370,7 +376,6 @@ export default class CardHeader extends Component<Signature> {
           align-items: center;
           margin-left: auto;
           gap: var(--boxel-sp-5xs);
-          min-width: var(--boxel-card-header-actions-min-width);
           justify-content: right;
         }
 
@@ -421,6 +426,34 @@ export default class CardHeader extends Component<Signature> {
         .utility-menu-dropdown-arrow {
           margin-left: var(--boxel-sp-xl);
           vertical-align: middle;
+        }
+
+        @container card-header (max-width: 20rem) {
+          .boxel-card-header__inner {
+            --boxel-card-header-padding: var(--boxel-sp-4xs);
+            --boxel-card-header-gap: var(--boxel-sp-4xs);
+          }
+          .card-type-display-name {
+            padding-inline: 0;
+          }
+          .card-type-display-name > :deep(svg) {
+            display: none;
+          }
+          .icon-button {
+            width: var(--boxel-button-xs);
+            height: var(--boxel-button-xs);
+          }
+          .icon-button :deep(svg) {
+            width: var(--boxel-icon-xs);
+            height: var(--boxel-icon-xs);
+          }
+          .realm-icon {
+            --boxel-card-header-realm-icon-size: var(--boxel-icon-sm);
+          }
+          .expand-button-tooltip,
+          .icon-button--maximize {
+            display: none;
+          }
         }
       }
     </style>

--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -1,5 +1,6 @@
 import type { MenuDivider } from '@cardstack/boxel-ui/helpers.ts';
 import { DropdownArrowDown } from '@cardstack/boxel-ui/icons';
+import Maximize from '@cardstack/boxel-icons/maximize';
 import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
 import type { ComponentLike } from '@glint/template';
@@ -32,12 +33,14 @@ interface Signature {
     editShortcutHint?: string;
     finishEditingShortcutHint?: string;
     headerColor?: string;
+    isExpanded?: boolean;
     isSaving?: boolean;
     isTopCard?: boolean;
     lastSavedMessage?: string;
     moreOptionsMenuItems?: MenuItem[];
     onClose?: () => void;
     onEdit?: () => void;
+    onExpand?: () => void;
     onFinishEditing?: () => void;
     realmInfo?: RealmDisplayInfo;
     utilityMenu?: CardHeaderUtilityMenu;
@@ -144,6 +147,22 @@ export default class CardHeader extends Component<Signature> {
                 </:content>
               </BoxelDropdown>
             </div>
+          {{/if}}
+          {{#if @onExpand}}
+            <Tooltip @placement='top'>
+              <:trigger>
+                <ContextButton
+                  class={{cn 'icon-button icon-button--maximize' is-active=@isExpanded}}
+                  @icon={{Maximize}}
+                  @label={{if @isExpanded 'Restore' 'Expand'}}
+                  {{on 'click' @onExpand}}
+                  data-test-expand-button
+                />
+              </:trigger>
+              <:content>
+                {{if @isExpanded 'Restore' 'Expand to full width'}}
+              </:content>
+            </Tooltip>
           {{/if}}
           {{#if @onEdit}}
             <Tooltip @placement='top'>
@@ -279,6 +298,10 @@ export default class CardHeader extends Component<Signature> {
           font: var(--boxel-card-header-font-weight, 600)
             var(--boxel-card-header-text-font, var(--boxel-font-sm));
         }
+        /* In a stacked (non-expanded) card, the whole header bar
+           goes green when editing — original behavior. The expanded-
+           card-header-pill in the host's top bar overrides this so
+           only the pencil lights up (see submode-layout CSS). */
         header.is-editing {
           background-color: var(--boxel-highlight);
           color: var(--boxel-dark);
@@ -345,14 +368,33 @@ export default class CardHeader extends Component<Signature> {
           justify-content: right;
         }
 
-        .icon-button,
-        .icon-save {
-          z-index: 1;
-        }
+        /* (z-index removed from icon-button + icon-save — was z-index: 1
+           which created a stacking context that trapped Tooltip's
+           floating-ui popover beneath the pill. Tooltips now escape
+           to #tooltip-overlay (z-index: 10000) and render above the
+           pill cleanly.) */
         .icon-button :deep(svg) {
           stroke-width: 2.5;
         }
+        /* Maximize icon has a 24-unit viewBox vs the pencil's 18.75
+           unit viewBox; same stroke-width renders thinner. Bump it
+           up so the expand icon visually matches the pencil weight. */
+        .icon-button--maximize :deep(svg) {
+          stroke-width: 3.2;
+        }
+        /* Active expand button — solid green pill with dark icon
+           for contrast. Toggle via @isExpanded on CardHeader. */
+        .icon-button.is-active,
+        .icon-button.is-active:hover {
+          background-color: var(--boxel-highlight);
+          color: var(--boxel-dark);
+        }
 
+        /* Pencil button in a stacked (non-expanded) editing card.
+           The header behind it is already green (header.is-editing
+           rule above), so the pencil sits white/light for contrast.
+           Original behavior — the expanded pill overrides this in
+           submode-layout CSS to make the pencil green-on-white. */
         .icon-save {
           background-color: var(--boxel-light);
         }

--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -159,7 +159,11 @@ export default class CardHeader extends Component<Signature> {
                   @icon={{Maximize}}
                   @label={{if @isExpanded 'Restore' 'Expand'}}
                   {{on 'click' @onExpand}}
-                  data-test-expand-button
+                  data-test-expand-button={{if
+                    @isExpanded
+                    'active'
+                    'not-active'
+                  }}
                 />
               </:trigger>
               <:content>

--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -1,6 +1,6 @@
+import Maximize from '@cardstack/boxel-icons/maximize';
 import type { MenuDivider } from '@cardstack/boxel-ui/helpers.ts';
 import { DropdownArrowDown } from '@cardstack/boxel-ui/icons';
-import Maximize from '@cardstack/boxel-icons/maximize';
 import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
 import type { ComponentLike } from '@glint/template';
@@ -152,7 +152,10 @@ export default class CardHeader extends Component<Signature> {
             <Tooltip @placement='top'>
               <:trigger>
                 <ContextButton
-                  class={{cn 'icon-button icon-button--maximize' is-active=@isExpanded}}
+                  class={{cn
+                    'icon-button icon-button--maximize'
+                    is-active=@isExpanded
+                  }}
                   @icon={{Maximize}}
                   @label={{if @isExpanded 'Restore' 'Expand'}}
                   {{on 'click' @onExpand}}

--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -311,7 +311,7 @@ export default class CardHeader extends Component<Signature> {
           font: var(--boxel-card-header-font-weight, 600)
             var(--boxel-card-header-text-font, var(--boxel-font-sm));
         }
-        header .card-type-display-name {
+        .card-type-display-name {
           max-width: var(--boxel-card-header-max-width, 100%);
           text-overflow: var(--boxel-card-header-text-overflow, ellipsis);
           overflow: hidden;
@@ -320,6 +320,7 @@ export default class CardHeader extends Component<Signature> {
           flex-shrink: 1;
           min-width: 0;
           text-align: center;
+          padding-inline: 30px;
         }
         .card-type-display-name-text {
           font: 700 var(--boxel-font-sm);

--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -152,11 +152,10 @@ export default class CardHeader extends Component<Signature> {
             <Tooltip @placement='top'>
               <:trigger>
                 <ContextButton
-                  class={{cn
-                    'icon-button icon-button--maximize'
-                    is-active=@isExpanded
-                  }}
+                  class='icon-button icon-button--maximize'
                   @icon={{Maximize}}
+                  @isActive={{@isExpanded}}
+                  @isToggle={{true}}
                   @label={{if @isExpanded 'Restore' 'Expand'}}
                   {{on 'click' @onExpand}}
                   data-test-expand-button={{if
@@ -388,13 +387,6 @@ export default class CardHeader extends Component<Signature> {
            up so the expand icon visually matches the pencil weight. */
         .icon-button--maximize :deep(svg) {
           stroke-width: 3.2;
-        }
-        /* Active expand button — solid green pill with dark icon
-           for contrast. Toggle via @isExpanded on CardHeader. */
-        .icon-button.is-active,
-        .icon-button.is-active:hover {
-          background-color: var(--boxel-highlight);
-          color: var(--boxel-dark);
         }
 
         /* Pencil button in a stacked (non-expanded) editing card.

--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -429,13 +429,16 @@ export default class CardHeader extends Component<Signature> {
           vertical-align: middle;
         }
 
+        @container card-header (max-width: 30rem) {
+          .card-type-display-name {
+            padding-inline: 0;
+          }
+        }
+
         @container card-header (max-width: 20rem) {
           .boxel-card-header__inner {
             --boxel-card-header-padding: var(--boxel-sp-4xs);
             --boxel-card-header-gap: var(--boxel-sp-4xs);
-          }
-          .card-type-display-name {
-            padding-inline: 0;
           }
           .card-type-display-name > :deep(svg) {
             display: none;

--- a/packages/boxel-ui/addon/src/components/card-header/usage.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/usage.gts
@@ -39,6 +39,7 @@ const Captions: TemplateOnlyComponent<CardTypeIconSignature> = <template>
 </template>;
 
 export default class CardHeaderUsage extends Component {
+  @tracked cardTitle = 'Quarterly Review';
   @tracked cardTypeDisplayName = 'My Card Type';
   @tracked cardTypeIcon: ComponentLike<CardTypeIconSignature> = Captions;
   @tracked detail = undefined;
@@ -64,11 +65,15 @@ export default class CardHeaderUsage extends Component {
     }),
   ];
   @tracked isEditing = false;
+  @tracked isExpanded = false;
   onEdit = () => {
     this.isEditing = true;
   };
   onFinishEditing = () => {
     this.isEditing = false;
+  };
+  onExpand = () => {
+    this.isExpanded = !this.isExpanded;
   };
 
   @tracked utilityMenu?: CardHeaderUtilityMenu = {
@@ -137,15 +142,18 @@ export default class CardHeaderUsage extends Component {
         <:example>
           <CardContainer>
             <CardHeader
+              @cardTitle={{this.cardTitle}}
               @cardTypeDisplayName={{this.cardTypeDisplayName}}
               @cardTypeIcon={{this.cardTypeIcon}}
               @headerColor={{this.headerColor}}
+              @isExpanded={{this.isExpanded}}
               @isSaving={{this.isSaving}}
               @isTopCard={{this.isTopCard}}
               @lastSavedMessage={{this.lastSavedMessage}}
               @moreOptionsMenuItems={{this.moreOptionsMenuItems}}
               @realmInfo={{this.realmInfo}}
               @onEdit={{unless this.isEditing this.onEdit}}
+              @onExpand={{this.onExpand}}
               @onFinishEditing={{if this.isEditing this.onFinishEditing}}
               @onClose={{this.close}}
               @utilityMenu={{this.utilityMenu}}
@@ -153,6 +161,12 @@ export default class CardHeaderUsage extends Component {
           </CardContainer>
         </:example>
         <:api as |Args|>
+          <Args.String
+            @name='cardTitle'
+            @description='optional card title shown after the card type display name'
+            @value={{this.cardTitle}}
+            @onInput={{fn (mut this.cardTitle)}}
+          />
           <Args.String
             @name='cardTypeDisplayName'
             @description='card type display name, shown in the center of the header'
@@ -171,6 +185,12 @@ export default class CardHeaderUsage extends Component {
             @description='background color of the header'
             @value={{this.headerColor}}
             @onInput={{fn (mut this.headerColor)}}
+          />
+          <Args.Bool
+            @name='isExpanded'
+            @description='controls the visual active state of the expand/restore button'
+            @value={{this.isExpanded}}
+            @onInput={{fn (mut this.isExpanded)}}
           />
           <Args.Bool
             @name='isSaving'
@@ -202,8 +222,24 @@ export default class CardHeaderUsage extends Component {
           />
           <Args.Object
             @name='utilityMenu'
-            @description='when present, renders as a dropdown menu'
+            @description='when present, renders a utility dropdown with { triggerText, menuItems }'
             @value={{this.utilityMenu}}
+          />
+          <Args.Action
+            @name='onExpand'
+            @description='when present, renders an expand/restore button and invokes this action when clicked'
+          />
+          <Args.Action
+            @name='onEdit'
+            @description='when present, renders the edit button'
+          />
+          <Args.Action
+            @name='onFinishEditing'
+            @description='when present, renders the finish editing button instead of relying only on @onEdit'
+          />
+          <Args.Action
+            @name='onClose'
+            @description='when present, renders the close button'
           />
         </:api>
         <:cssVars as |Css|>

--- a/packages/boxel-ui/addon/src/components/context-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/context-button/index.gts
@@ -3,7 +3,9 @@ import Plus from '@cardstack/boxel-icons/plus';
 import Trash from '@cardstack/boxel-icons/trash-2';
 import XIcon from '@cardstack/boxel-icons/x';
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import { concat } from '@ember/helper';
 
+import cn from '../../helpers/cn.ts';
 import { IconPencil, ThreeDotsHorizontal } from '../../icons.gts';
 import type { Icon } from '../../icons/types.ts';
 import type { BoxelButtonSize } from '../button/index.gts';
@@ -49,6 +51,8 @@ interface Signature {
     disabled?: boolean;
     height?: string; // iconHeight
     icon?: ContextButtonIcon; // defaults to horizontal 'content-menu'
+    isActive?: boolean;
+    isToggle?: boolean;
     label: string; // aria-label for icon button (required)
     loading?: boolean;
     size?: BoxelButtonSize;
@@ -90,7 +94,11 @@ function getVariant(variant: ContextButtonVariant = 'highlight') {
 const DropdownButton: TemplateOnlyComponent<Signature> = <template>
   {{#let (getVariant @variant) (getIcon @icon) as |variant icon|}}
     <IconButton
-      class='boxel-context-button boxel-context-button--{{variant}}'
+      class={{cn
+        'boxel-context-button'
+        (concat 'boxel-context-button--' variant)
+        boxel-context-button--active=@isActive
+      }}
       @icon={{icon}}
       @size={{if @size @size 'base'}}
       @loading={{@loading}}
@@ -98,6 +106,8 @@ const DropdownButton: TemplateOnlyComponent<Signature> = <template>
       @width={{@width}}
       @height={{@height}}
       aria-label={{@label}}
+      aria-pressed={{if @isToggle (if @isActive 'true' 'false')}}
+      data-active={{if @isActive 'true' 'false'}}
       ...attributes
     />
   {{/let}}
@@ -112,7 +122,12 @@ const DropdownButton: TemplateOnlyComponent<Signature> = <template>
         color: var(--primary, var(--boxel-highlight));
       }
       .boxel-context-button--highlight:hover,
+      .boxel-context-button--highlight.boxel-context-button--active,
       .boxel-context-button--highlight-icon:hover {
+        color: var(--primary-foreground, var(--boxel-dark));
+        background-color: var(--primary, var(--boxel-highlight));
+      }
+      .boxel-context-button--highlight-icon.boxel-context-button--active {
         color: var(--primary-foreground, var(--boxel-dark));
         background-color: var(--primary, var(--boxel-highlight));
       }
@@ -129,6 +144,9 @@ const DropdownButton: TemplateOnlyComponent<Signature> = <template>
       .boxel-context-button--ghost:hover {
         background-color: color-mix(in oklab, currentColor 10%, transparent);
       }
+      .boxel-context-button--ghost.boxel-context-button--active {
+        background-color: color-mix(in oklab, currentColor 10%, transparent);
+      }
       .boxel-context-button--ghost[aria-expanded='true'] {
         background-color: color-mix(in oklab, currentColor 25%, transparent);
       }
@@ -137,7 +155,12 @@ const DropdownButton: TemplateOnlyComponent<Signature> = <template>
         color: var(--destructive, var(--boxel-danger));
       }
       .boxel-context-button--destructive:hover,
+      .boxel-context-button--destructive.boxel-context-button--active,
       .boxel-context-button--destructive-icon:hover {
+        color: var(--destructive-foreground, var(--boxel-light-100));
+        background-color: var(--destructive, var(--boxel-danger));
+      }
+      .boxel-context-button--destructive-icon.boxel-context-button--active {
         color: var(--destructive-foreground, var(--boxel-light-100));
         background-color: var(--destructive, var(--boxel-danger));
       }

--- a/packages/boxel-ui/addon/src/components/context-button/usage.gts
+++ b/packages/boxel-ui/addon/src/components/context-button/usage.gts
@@ -22,6 +22,8 @@ export default class ContextButtonUsage extends Component {
   @tracked private height?: string;
   @tracked private isLoading = false;
   @tracked private isDisabled = false;
+  @tracked private isActive = false;
+  @tracked private isToggle = false;
   @tracked private label = 'context-button usage';
 
   <template>
@@ -34,6 +36,8 @@ export default class ContextButtonUsage extends Component {
           @size={{this.size}}
           @loading={{this.isLoading}}
           @disabled={{this.isDisabled}}
+          @isActive={{this.isActive}}
+          @isToggle={{this.isToggle}}
           @width={{this.width}}
           @height={{this.height}}
         />
@@ -83,6 +87,20 @@ export default class ContextButtonUsage extends Component {
           @optional={{true}}
           @value={{this.isDisabled}}
           @onInput={{fn (mut this.isDisabled)}}
+          @defaultValue='false'
+        />
+        <Args.Bool
+          @name='isActive'
+          @optional={{true}}
+          @value={{this.isActive}}
+          @onInput={{fn (mut this.isActive)}}
+          @defaultValue='false'
+        />
+        <Args.Bool
+          @name='isToggle'
+          @optional={{true}}
+          @value={{this.isToggle}}
+          @onInput={{fn (mut this.isToggle)}}
           @defaultValue='false'
         />
         <Args.String

--- a/packages/host/app/components/ai-assistant/panel-popover.gts
+++ b/packages/host/app/components/ai-assistant/panel-popover.gts
@@ -18,7 +18,7 @@ const AiAssistantPanelPopover: TemplateOnlyComponent<Signature> = <template>
       top: 1.5rem;
       right: 1.875rem;
       margin-top: var(--boxel-sp-sm);
-      width: 320px;
+      max-width: 20rem;
       min-height: 12.5rem;
       max-height: 75vh;
       background: var(--ai-assistant-menu-background);

--- a/packages/host/app/components/matrix/auth-container.gts
+++ b/packages/host/app/components/matrix/auth-container.gts
@@ -45,7 +45,7 @@ const AuthContainer: TemplateOnlyComponent<Signature> = <template>
       border: 1px solid var(--boxel-form-control-border-color);
       border-radius: var(--boxel-form-control-border-radius);
       letter-spacing: var(--boxel-lsp);
-      width: 550px;
+      max-width: 34.375rem;
       position: relative;
     }
     .header {

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -256,6 +256,15 @@ export default class OperatorModeContainer extends Component<Signature> {
         justify: center;
         align-items: center;
       }
+
+      @media (max-width: 30rem) {
+        :global(:root) {
+          --operator-mode-spacing: var(--boxel-sp-3xs);
+        }
+        :deep(.neighbor-stack-trigger) {
+          display: none;
+        }
+      }
     </style>
   </template>
 }

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -178,7 +178,6 @@ export default class OperatorModeContainer extends Component<Signature> {
         --operator-mode-spacing: var(--boxel-sp-xs);
         --operator-mode-top-bar-item-height: var(--container-button-size);
         --operator-mode-bottom-bar-item-height: var(--container-button-size);
-        --submode-new-file-button-width: 96px;
       }
       :global(button:focus:not(:disabled)) {
         outline-color: var(

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -173,7 +173,6 @@ export default class OperatorModeContainer extends Component<Signature> {
         --operator-mode-bg-color: #686283;
         --boxel-modal-max-width: 100%;
         --container-button-size: 2.5rem;
-        --operator-mode-min-width: 20.5rem;
         --operator-mode-left-column: 21.5rem; /* 344px */
         --operator-mode-spacing: var(--boxel-sp-xs);
         --operator-mode-top-bar-item-height: var(--container-button-size);
@@ -204,7 +203,6 @@ export default class OperatorModeContainer extends Component<Signature> {
         top: 0;
         left: 0;
         right: 0;
-        min-width: var(--operator-mode-min-width);
         height: 100%;
         position: fixed;
       }
@@ -260,8 +258,10 @@ export default class OperatorModeContainer extends Component<Signature> {
       @media (max-width: 30rem) {
         :global(:root) {
           --operator-mode-spacing: var(--boxel-sp-3xs);
+          --stack-padding-inline: var(--boxel-sp-xs);
         }
-        :deep(.neighbor-stack-trigger) {
+        :deep(.neighbor-stack-trigger),
+        :deep(.operator-mode-stack ~ .operator-mode-stack) {
           display: none;
         }
       }

--- a/packages/host/app/components/operator-mode/host-submode.gts
+++ b/packages/host/app/components/operator-mode/host-submode.gts
@@ -272,7 +272,7 @@ export default class HostSubmode extends Component<HostSubmodeSignature> {
         --submode-bar-item-box-shadow: var(--boxel-deep-box-shadow);
         --submode-bar-item-outline: var(--boxel-border-flexible);
         --operator-mode-left-column: calc(
-          21.5rem - var(--submode-new-file-button-width)
+          21.5rem - var(--new-file-button-width)
         );
         background-color: var(--host-submode-background);
       }

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -16,13 +16,7 @@ import { consume } from 'ember-provide-consume-context';
 import get from 'lodash/get';
 import { TrackedWeakMap, TrackedSet } from 'tracked-built-ins';
 
-import {
-  cn,
-  eq,
-  gte,
-  MenuItem,
-  MenuDivider,
-} from '@cardstack/boxel-ui/helpers';
+import { cn, gt, MenuItem, MenuDivider } from '@cardstack/boxel-ui/helpers';
 import { IconCode, IconSearch, type Icon } from '@cardstack/boxel-ui/icons';
 
 import {
@@ -613,6 +607,7 @@ export default class InteractSubmode extends Component {
   // (there is a single stack with at least one card in it)
   private get canCreateNeighborStack() {
     return (
+      !this.operatorModeStateService.hasAnyStackItemExpanded &&
       this.allStackItems.length > 0 &&
       this.stacks.length === 1 &&
       !this.operatorModeStateService.workspaceChooserOpened
@@ -851,11 +846,10 @@ export default class InteractSubmode extends Component {
       as |search|
     >
       <div
-        class='interact-submode
-          {{if
-            this.operatorModeStateService.hasAnyStackItemExpanded
-            "has-expanded-card"
-          }}'
+        class={{cn
+          'interact-submode'
+          has-expanded-card=this.operatorModeStateService.hasAnyStackItemExpanded
+        }}
         style={{this.backgroundImageStyle}}
         {{onKeyMod 'Escape' this.handleEscape}}
         {{! Bind Ctrl+E on every platform — Mac users get Ctrl+E too,
@@ -873,7 +867,7 @@ export default class InteractSubmode extends Component {
             }}
           />
         {{/if}}
-        <div class='stacks'>
+        <div class={{cn 'stacks' is-multi-stack=(gt this.stacks.length 1)}}>
           {{#each this.stacks as |stack stackIndex|}}
             {{#let
               (get
@@ -885,9 +879,8 @@ export default class InteractSubmode extends Component {
               <OperatorModeStack
                 data-test-operator-mode-stack={{stackIndex}}
                 class={{cn
+                  'stack'
                   stack-with-bg-image=backgroundImageURLSpecificToThisStack
-                  stack-medium-padding-top=(eq stack.length 2)
-                  stack-small-padding-top=(gte stack.length 3)
                 }}
                 style={{if
                   backgroundImageURLSpecificToThisStack
@@ -974,12 +967,6 @@ export default class InteractSubmode extends Component {
         justify-content: center;
         align-items: center;
       }
-      .stacks > :deep(.operator-mode-stack:first-child) {
-        padding-left: var(--boxel-sp-lg);
-      }
-      .stacks > :deep(.operator-mode-stack:last-child) {
-        padding-right: var(--boxel-sp-lg);
-      }
       .stack-with-bg-image:before {
         content: ' ';
         height: 100%;
@@ -993,37 +980,27 @@ export default class InteractSubmode extends Component {
       .stack-with-bg-image:first-child:before {
         display: none;
       }
-      .stack-medium-padding-top {
-        padding-top: calc(var(--stack-padding-top) / 2);
-      }
-      .stack-small-padding-top {
-        padding-top: var(--operator-mode-spacing);
-      }
       .neighbor-stack-trigger {
         flex: 0;
         flex-basis: var(--container-button-size);
         position: absolute;
         z-index: var(--boxel-layer-floating-button);
       }
-      /* Hide neighbor-stack-trigger arrows when any card is expanded
-         — the focused expanded view shouldn't be cluttered with stack-
-         creation chrome at the edges. */
-      .interact-submode.has-expanded-card .neighbor-stack-trigger {
-        display: none;
+      /* Glass-morphism effect on the background */
+      .interact-submode.has-expanded-card {
+        background-color: var(--boxel-light-hover-35);
+        backdrop-filter: blur(10px) saturate(160%);
+        -webkit-backdrop-filter: blur(10px) saturate(160%);
       }
-      /* Drop the edge padding the .stacks container applies to its
-         first/last stack so an expanded card spans viewport edge to
-         edge — pixel-identical to host-mode's .host-mode-content.is-wide
-         (padding: 0). */
-      .interact-submode.has-expanded-card
-        .stacks
-        > :deep(.operator-mode-stack:first-child) {
-        padding-left: 0;
+      .interact-submode:not(.has-expanded-card)
+        .stacks.is-multi-stack
+        .stack:first-of-type {
+        padding-right: var(--operator-mode-spacing);
       }
-      .interact-submode.has-expanded-card
-        .stacks
-        > :deep(.operator-mode-stack:last-child) {
-        padding-right: 0;
+      .interact-submode:not(.has-expanded-card)
+        .stacks.is-multi-stack
+        .stack:last-of-type {
+        padding-left: var(--operator-mode-spacing);
       }
       /* In a multi-stack layout, collapse the stack that doesn't hold
          the expanded card so the expanded card fills the full width. */

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -1025,6 +1025,13 @@ export default class InteractSubmode extends Component {
         > :deep(.operator-mode-stack:last-child) {
         padding-right: 0;
       }
+      /* In a multi-stack layout, collapse the stack that doesn't hold
+         the expanded card so the expanded card fills the full width. */
+      .interact-submode.has-expanded-card
+        .stacks
+        > :deep(.operator-mode-stack:not(:has(.item.expanded))) {
+        display: none;
+      }
       .stack-trigger-right {
         right: 2px;
       }

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -851,7 +851,11 @@ export default class InteractSubmode extends Component {
       as |search|
     >
       <div
-        class='interact-submode'
+        class='interact-submode
+          {{if
+            this.operatorModeStateService.hasAnyStackItemExpanded
+            "has-expanded-card"
+          }}'
         style={{this.backgroundImageStyle}}
         {{onKeyMod 'Escape' this.handleEscape}}
         {{! Bind Ctrl+E on every platform — Mac users get Ctrl+E too,
@@ -1000,6 +1004,26 @@ export default class InteractSubmode extends Component {
         flex-basis: var(--container-button-size);
         position: absolute;
         z-index: var(--boxel-layer-floating-button);
+      }
+      /* Hide neighbor-stack-trigger arrows when any card is expanded
+         — the focused expanded view shouldn't be cluttered with stack-
+         creation chrome at the edges. */
+      .interact-submode.has-expanded-card .neighbor-stack-trigger {
+        display: none;
+      }
+      /* Drop the edge padding the .stacks container applies to its
+         first/last stack so an expanded card spans viewport edge to
+         edge — pixel-identical to host-mode's .host-mode-content.is-wide
+         (padding: 0). */
+      .interact-submode.has-expanded-card
+        .stacks
+        > :deep(.operator-mode-stack:first-child) {
+        padding-left: 0;
+      }
+      .interact-submode.has-expanded-card
+        .stacks
+        > :deep(.operator-mode-stack:last-child) {
+        padding-right: 0;
       }
       .stack-trigger-right {
         right: 2px;

--- a/packages/host/app/components/operator-mode/new-file-button.gts
+++ b/packages/host/app/components/operator-mode/new-file-button.gts
@@ -1,9 +1,17 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
-import { BoxelDropdown, Button, Menu } from '@cardstack/boxel-ui/components';
+import {
+  BoxelDropdown,
+  Button,
+  Menu,
+  Tooltip,
+} from '@cardstack/boxel-ui/components';
+import { cn } from '@cardstack/boxel-ui/helpers';
 import type { MenuItem } from '@cardstack/boxel-ui/helpers';
 import type { MenuDivider } from '@cardstack/boxel-ui/helpers';
 import { DropdownArrowDown, IconPlus } from '@cardstack/boxel-ui/icons';
+
+import type { ModifierLike } from '@glint/template';
 
 export interface NewFileOptions {
   menuItems: (MenuItem | MenuDivider)[];
@@ -11,84 +19,129 @@ export interface NewFileOptions {
   onClose?: () => void;
 }
 
-interface Signature {
+interface TriggerButtonSignature {
   Args: {
-    dropdownOptions: NewFileOptions;
-    initiallyOpened: boolean;
+    isCollapsed?: boolean;
+    isDisabled?: boolean;
+    bindings: ModifierLike<{ Args: { Positional: unknown[] } }>;
   };
-  Element: HTMLElement;
+  Element: HTMLButtonElement;
 }
 
-const NewFileButton: TemplateOnlyComponent<Signature> = <template>
-  <BoxelDropdown
-    @initiallyOpened={{@initiallyOpened}}
-    @onClose={{@dropdownOptions.onClose}}
-    @contentClass='gap-above'
-  >
-    <:trigger as |bindings|>
-      <Button
-        class='new-file-dropdown-trigger'
-        @kind='primary'
-        @size='tall'
-        @disabled={{@dropdownOptions.isDisabled}}
-        {{bindings}}
-        aria-label='Create new file'
-        ...attributes
-        data-test-new-file-button
-      >
-        <IconPlus
-          class='new-file-button-icon'
-          width='14px'
-          height='14px'
-          role='presentation'
-        />
-        New
+const NewFileTriggerButton: TemplateOnlyComponent<TriggerButtonSignature> =
+  <template>
+    <Button
+      class={{cn
+        'new-file-dropdown-trigger'
+        new-file-dropdown-trigger--collapsed=@isCollapsed
+      }}
+      @kind='primary'
+      @size='auto'
+      @rectangular={{true}}
+      @disabled={{@isDisabled}}
+      {{@bindings}}
+      aria-label='Create new file'
+      data-test-new-file-button
+      ...attributes
+    >
+      <IconPlus
+        class='new-file-button-icon'
+        width='14px'
+        height='14px'
+        role='presentation'
+      />
+      {{#unless @isCollapsed}}
+        <span class='new-file-button-label'>New</span>
         <DropdownArrowDown
           class='dropdown-arrow'
           width='12px'
           height='12px'
           role='presentation'
         />
-      </Button>
-    </:trigger>
-    <:content as |dd|>
-      <Menu
-        class='new-file-menu'
-        @items={{@dropdownOptions.menuItems}}
-        @closeMenu={{dd.close}}
-        data-test-new-file-dropdown-menu
-      />
-    </:content>
-  </BoxelDropdown>
+      {{/unless}}
+    </Button>
+    <style scoped>
+      :global(:root) {
+        --new-file-button-width: 6.25rem;
+        --new-file-button-height: var(--container-button-size);
+      }
+      .new-file-dropdown-trigger {
+        --icon-color: currentColor;
+        height: var(--new-file-button-height);
+        width: var(--new-file-button-width);
+        padding: var(--boxel-sp-2xs) var(--boxel-sp-xs);
+        justify-content: flex-start;
+        gap: var(--boxel-sp-2xs);
+        flex-shrink: 0;
+      }
+      .new-file-dropdown-trigger--collapsed {
+        --new-file-button-width: var(--container-button-size);
+        justify-content: center;
+        padding-inline: var(--boxel-sp-2xs);
+        gap: 0;
+      }
+      .new-file-dropdown-trigger:focus:not(:disabled) {
+        outline-offset: 1px;
+      }
+      .new-file-button-icon > :deep(path) {
+        stroke: none;
+      }
+      .dropdown-arrow {
+        margin-left: auto;
+      }
+      .new-file-dropdown-trigger[aria-expanded='true'] .dropdown-arrow {
+        transform: rotate(180deg);
+      }
+    </style>
+  </template>;
+
+interface Signature {
+  Args: {
+    dropdownOptions: NewFileOptions;
+    initiallyOpened: boolean;
+    isCollapsed?: boolean;
+  };
+  Element: HTMLDivElement;
+}
+
+const NewFileButton: TemplateOnlyComponent<Signature> = <template>
+  <div ...attributes>
+    <BoxelDropdown
+      @initiallyOpened={{@initiallyOpened}}
+      @onClose={{@dropdownOptions.onClose}}
+      @contentClass='gap-above'
+    >
+      <:trigger as |bindings|>
+        {{#if @isCollapsed}}
+          <Tooltip @placement='right'>
+            <:trigger>
+              <NewFileTriggerButton
+                @isCollapsed={{@isCollapsed}}
+                @isDisabled={{@dropdownOptions.isDisabled}}
+                @bindings={{bindings}}
+              />
+            </:trigger>
+            <:content>New</:content>
+          </Tooltip>
+        {{else}}
+          <NewFileTriggerButton
+            @isDisabled={{@dropdownOptions.isDisabled}}
+            @bindings={{bindings}}
+          />
+        {{/if}}
+      </:trigger>
+      <:content as |dd|>
+        <Menu
+          class='new-file-menu'
+          @items={{@dropdownOptions.menuItems}}
+          @closeMenu={{dd.close}}
+          data-test-new-file-dropdown-menu
+        />
+      </:content>
+    </BoxelDropdown>
+  </div>
 
   <style scoped>
-    .new-file-dropdown-trigger {
-      --new-file-button-width: 6.25rem; /* 100px */
-      --new-file-button-height: var(--operator-mode-top-bar-item-height);
-
-      height: var(--new-file-button-height);
-      width: var(--new-file-button-width);
-      padding: var(--boxel-sp-xxs) var(--boxel-sp-xs);
-      justify-content: flex-start;
-      gap: var(--boxel-sp-xxs);
-      flex-shrink: 0;
-    }
-    .new-file-dropdown-trigger:focus:not(:disabled) {
-      outline-offset: 1px;
-    }
-    .new-file-dropdown-trigger svg {
-      --icon-color: currentColor;
-      flex-shrink: 0;
-    }
-    .new-file-button-icon > :deep(path) {
-      stroke: none;
-    }
-    .dropdown-arrow {
-      margin-left: auto;
-    }
-    .new-file-dropdown-trigger[aria-expanded='true'] .dropdown-arrow {
-      transform: rotate(180deg);
-    }
     .new-file-menu {
       --boxel-menu-item-content-padding: var(--boxel-sp-xs);
       width: 19.375rem; /* 310px */

--- a/packages/host/app/components/operator-mode/new-file-button.gts
+++ b/packages/host/app/components/operator-mode/new-file-button.gts
@@ -175,6 +175,12 @@ const NewFileButton: TemplateOnlyComponent<Signature> = <template>
     .new-file-menu :deep(.check-icon) {
       display: none;
     }
+    @media (max-width: 20rem) {
+      .new-file-menu {
+        min-width: 13.5rem;
+        width: fit-content;
+      }
+    }
   </style>
 </template>;
 

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -1290,15 +1290,6 @@ export default class OperatorModeStackItem extends Component<Signature> {
         text-align: left;
         text-box-trim: trim-both;
       }
-      /* Expanded mode editing — DO NOT flip the whole pill green;
-         only the pencil button lights up (rule below). Overrides
-         CardHeader's default header.is-editing green-bar treatment,
-         which is correct for stacked cards but not for the expanded
-         pill (we want the pill to stay white in the bar). */
-      .expanded-card-header-pill.is-editing {
-        background-color: var(--boxel-light);
-        color: var(--boxel-dark);
-      }
       /* Pencil button in expanded edit mode — solid green with dark
          icon for contrast (matches the active expand button). */
       .expanded-card-header-pill :deep(.icon-save),

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -228,6 +228,14 @@ export default class OperatorModeStackItem extends Component<Signature> {
     const isLastCard = this.args.index === numberOfCards - 1;
     const isSecondLastCard = this.args.index === numberOfCards - 2;
 
+    // Expanded mode opts out of stacked-layout sizing — let natural
+    // flow size the card so .item.expanded CSS rules apply cleanly
+    // without fighting inline !important overrides. Mirrors host-mode
+    // pattern: parent constrains height, children inherit.
+    if (this.isExpanded) {
+      return htmlSafe(`z-index: calc(${this.args.index} + 1);`);
+    }
+
     let marginTopPx = 0;
 
     if (invertedIndex > 2) {
@@ -253,8 +261,10 @@ export default class OperatorModeStackItem extends Component<Signature> {
       max-width: ${maxWidthPercent}%;
       z-index: calc(${this.args.index} + 1);
       margin-top: ${marginTopPx}px;
-      transition: margin-top var(--boxel-transition), width var(--boxel-transition);
     `; // using margin-top instead of padding-top to hide scrolled content from view
+    // Transition (280ms ease-out, all geometric props) is on the .item
+    // CSS rule below — no inline override here, so expand/collapse
+    // morph + stacked-layout shifts all use the same curve.
 
     return htmlSafe(styles);
   }
@@ -271,6 +281,16 @@ export default class OperatorModeStackItem extends Component<Signature> {
     return isRealmIndexCardId(this.url, this.realmURL);
   }
 
+  // Element ref captured by submode-layout's expanded-card-header-slot.
+  // Only used when isExpanded — projects the CardHeader into the top
+  // bar pill, replacing the inline card header for the expanded mode.
+  // Returns null when not expanded so the inline header renders as
+  // usual (and the if/else branch picks the inline path).
+  private get expandedCardHeaderSlot() {
+    if (!this.isExpanded) return null;
+    return this.operatorModeStateService.expandedCardHeaderElement;
+  }
+
   @provide(CardContextName)
   // @ts-ignore "context" is declared but not used
   private get context(): StackItemCardContext {
@@ -282,7 +302,136 @@ export default class OperatorModeStackItem extends Component<Signature> {
 
   private closeItem = () => this._closeItem.perform();
 
+  // Per-card expanded state. Persisted on operatorModeStateService
+  // (keyed by stack-item id) so the user's expand intent survives:
+  //   - When this card is buried (pushed deeper in the stack),
+  //     isExpanded reads as false (we render normally), but the
+  //     stored intent is preserved.
+  //   - When the card pops back to the top, isExpanded reads true
+  //     again from storage and the card re-expands.
+  // Only available when the card opts in via `prefersWideFormat`.
+  private get itemExpandKey(): string {
+    return this.args.item.id;
+  }
+  private get isExpandedIntent(): boolean {
+    return this.operatorModeStateService.isStackItemExpanded(this.itemExpandKey);
+  }
+  private get isExpanded(): boolean {
+    return this.isTopCard && this.canExpand && this.isExpandedIntent;
+  }
+  private get canExpand(): boolean {
+    return this.isTopCard && !this.isCardsGridCard;
+  }
+  // Cards-grid (the Workspace's "All Cards" view) opts out of expand
+  // mode — its grid layout assumes scrollable, non-fullscreen content;
+  // forcing it into expanded mode causes child card tiles to overlap.
+  private get isCardsGridCard(): boolean {
+    const ctor = this.card?.constructor as
+      | { displayName?: string }
+      | undefined;
+    return ctor?.displayName === 'Cards Grid';
+  }
+  private toggleExpanded = () => {
+    if (!this.canExpand) return;
+    const cardEl = this.itemEl;
+    const cardFrom = cardEl?.getBoundingClientRect();
+
+    this.operatorModeStateService.setStackItemExpanded(
+      this.itemExpandKey,
+      !this.isExpandedIntent,
+    );
+
+    // FLIP via Web Animations on the card body: measure rect before
+    // state change, animate inverse transform back to identity after
+    // re-render. Works around CSS transitions not firing when changing
+    // properties cross from inline-style to CSS-rule sources mid-frame.
+    if (!cardEl || !cardFrom) return;
+    scheduleOnce('afterRender', this, () => {
+      this.playFlip(cardEl, cardFrom, {
+        duration: 280,
+        easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)',
+      });
+      // Header gets a lightweight fade + small Y slide — suggests
+      // direction without the full FLIP's visual noise. Expand: pill
+      // slides UP into the bar (starts 10px below). Restore: header
+      // slides DOWN onto the card (starts 10px above). One rAF to let
+      // {{#in-element}} settle before measuring.
+      requestAnimationFrame(() => {
+        const headerTo = this.findHeaderEl();
+        if (!headerTo) return;
+        const fromOffsetY = this.isExpandedIntent ? 28 : -28;
+        headerTo.animate(
+          [
+            { opacity: 0, transform: `translateY(${fromOffsetY}px)` },
+            { opacity: 1, transform: 'translateY(0)' },
+          ],
+          {
+            duration: 280,
+            easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)',
+            fill: 'none',
+          },
+        );
+      });
+    });
+  };
+
+  private findHeaderEl(): HTMLElement | null {
+    // After expand: the portaled .expanded-card-header-pill in the bar.
+    // Before expand (or after restore): the inline .stack-item-header
+    // inside this stack-item's DOM.
+    const slot = this.operatorModeStateService.expandedCardHeaderElement;
+    const portaled = slot?.querySelector(
+      '.expanded-card-header-pill',
+    ) as HTMLElement | null;
+    if (portaled) return portaled;
+    return (
+      (this.itemEl?.querySelector(
+        '.stack-item-header',
+      ) as HTMLElement | null) ?? null
+    );
+  }
+
+  private playFlip(
+    el: HTMLElement,
+    fromRect: DOMRect,
+    opts: { duration: number; easing: string },
+  ) {
+    const toRect = el.getBoundingClientRect();
+    const dx = fromRect.left - toRect.left;
+    const dy = fromRect.top - toRect.top;
+    // Guard against zero target dimensions (e.g., during unmount or
+    // before layout settles) — Web Animations would NaN out otherwise.
+    if (toRect.width === 0 || toRect.height === 0) return;
+    const sx = fromRect.width / toRect.width;
+    const sy = fromRect.height / toRect.height;
+    el.animate(
+      [
+        {
+          transform: `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`,
+          transformOrigin: 'top left',
+        },
+        {
+          transform: 'translate(0, 0) scale(1, 1)',
+          transformOrigin: 'top left',
+        },
+      ],
+      {
+        duration: opts.duration,
+        easing: opts.easing,
+        fill: 'none',
+      },
+    );
+  }
+
   private _closeItem = dropTask(async () => {
+    // Clear any persisted expand intent for this item — the item is
+    // about to be removed from the stack, so the entry on the
+    // service map should not linger (would re-apply if a card with
+    // the same id ever returned).
+    this.operatorModeStateService.setStackItemExpanded(
+      this.itemExpandKey,
+      false,
+    );
     await this.args.dismissStackedCardsAbove(this.args.index - 1);
   });
 
@@ -755,6 +904,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
     <div
       class='item
         {{if this.isBuried "buried"}}
+        {{if this.isExpanded "expanded"}}
         {{if this.doOpeningAnimation "opening-animation"}}
         {{if this.doClosingAnimation "closing-animation"}}
         {{if this.doMovingForwardAnimation "move-forward-animation"}}
@@ -816,6 +966,31 @@ export default class OperatorModeStackItem extends Component<Signature> {
         {{else if this.card}}
           {{this.setWindowTitle}}
           {{#let (this.realm.info this.urlForRealmLookup) as |realmInfo|}}
+            {{#if this.expandedCardHeaderSlot}}
+              {{#in-element this.expandedCardHeaderSlot}}
+                <CardHeader
+                  @cardTypeDisplayName={{this.headerType}}
+                  @cardTypeIcon={{cardTypeIcon this.card}}
+                  @cardTitle={{this.headerTitle}}
+                  @isSaving={{this.cardResource.autoSaveState.isSaving}}
+                  @isTopCard={{this.isTopCard}}
+                  @lastSavedMessage={{this.cardResource.autoSaveState.lastSavedErrorMsg}}
+                  @moreOptionsMenuItems={{this.moreOptionsMenuItems}}
+                  @realmInfo={{realmInfo}}
+                  @utilityMenu={{this.utilityMenu}}
+                  @onEdit={{if
+                    this.canEdit
+                    (fn this.cardCrudFunctions.editCard this.card)
+                  }}
+                  @onExpand={{if this.canExpand this.toggleExpanded}}
+                  @isExpanded={{this.isExpanded}}
+                  @onFinishEditing={{if this.isEditing this.doneEditing}}
+                  @onClose={{unless this.isBuried this.closeItem}}
+                  class='expanded-card-header-pill'
+                  data-test-stack-card-header
+                />
+              {{/in-element}}
+            {{else}}
             <CardHeader
               @cardTypeDisplayName={{this.headerType}}
               @cardTypeIcon={{cardTypeIcon this.card}}
@@ -830,6 +1005,8 @@ export default class OperatorModeStackItem extends Component<Signature> {
                 this.canEdit
                 (fn this.cardCrudFunctions.editCard this.card)
               }}
+              @onExpand={{if this.canExpand this.toggleExpanded}}
+              @isExpanded={{this.isExpanded}}
               @onFinishEditing={{if this.isEditing this.doneEditing}}
               @onClose={{unless this.isBuried this.closeItem}}
               @editShortcutHint={{this.keyboardShortcutLabels.edit}}
@@ -861,6 +1038,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
               }}
               data-test-stack-card-header
             />
+            {{/if}}
           {{/let}}
           <div
             class='stack-item-content'
@@ -955,6 +1133,64 @@ export default class OperatorModeStackItem extends Component<Signature> {
         --realm-icon-border-radius: 4px;
       }
 
+      /* Expanded mode — pinned to all edges of .inner (the stack's
+         positioned content box). .operator-mode-stack supplies
+         padding-top: var(--stack-padding-top) so .inner's top edge
+         already sits flush below the floating bar — same offset host-
+         mode gets from its in-flow bar above. inset: 0 inherits that
+         offset; no calc, no !important, no measurement. The :has
+         rule in stack.gts zeroes inline + bottom padding so the
+         card's right/bottom edges land at viewport edges. z-index
+         250 sits above stack background + workspace chooser (200),
+         below search sheet (300) and the floating bar (700). */
+      .item.expanded {
+        top: 0;
+        left: 0;
+        width: 100%;
+        max-width: 100%;
+        height: 100%;
+        margin-top: 0;
+        z-index: 250;
+        pointer-events: auto;
+      }
+      /* Propagate height through the chain so bottom-docked chrome
+         lands at the viewport's bottom edge. .stack-item-content
+         and .stack-item-preview default to overflow: auto with no
+         height — without min-height: 0 the chain breaks and the
+         studio's flex: 1 has no defined parent height. Keep
+         overflow: auto (matches host-mode pattern) so isolated
+         content longer than the viewport can scroll. */
+      .item.expanded .stack-item-content,
+      .item.expanded .stack-item-preview {
+        min-height: 0;
+      }
+      .item.expanded .stack-item-card {
+        border-radius: 0;
+        box-shadow: none;
+        /* Tray "chrome" (rounded corners, shadow, white background)
+           all dissolve at end of morph — the tray becomes a
+           positioning anchor only. Body content (.stack-item-content)
+           inside renders normally without inheriting transparency
+           because background, not opacity, is what's faded. */
+        background: transparent;
+        /* Header is portaled into the top bar pill (see
+           expanded-card-header-slot in submode-layout); the inline
+           CardHeader is not rendered for expanded cards (the if/else
+           in the template picks the in-element branch). Drop the
+           grid header row so the body fills the entire card. */
+        grid-template-rows: 1fr;
+      }
+      /* When the top card is expanded, fade out the underlying
+         buried cards so the user isn't visually distracted by the
+         stack history behind the expanded surface. Sibling selector
+         within .operator-mode-stack > .inner; uses :has() to match
+         buried items that have an expanded sibling AFTER them in the
+         DOM (top card = last in DOM order). */
+      .item:not(.expanded):has(~ .item.expanded) {
+        opacity: 0;
+        transition: opacity 380ms ease;
+      }
+
       .stack-item-card {
         position: relative;
         height: 100%;
@@ -965,7 +1201,6 @@ export default class OperatorModeStackItem extends Component<Signature> {
         pointer-events: auto;
         overflow: hidden;
       }
-
       .stack-item-header {
         --boxel-card-header-padding: var(--boxel-sp-4xs) var(--boxel-sp-xs);
         --boxel-card-header-background-color: var(--boxel-light);

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -648,13 +648,20 @@ export default class OperatorModeStackItem extends Component<Signature> {
     );
 
     if (this.isTopCard && !this.isExpanded) {
-      items.push(
-        new MenuItem({
-          label: 'Expand to Full Width',
-          icon: Maximize,
-          action: this.toggleExpanded,
-        }),
+      let expandItem = new MenuItem({
+        label: 'Expand to Full Width',
+        icon: Maximize,
+        action: this.toggleExpanded,
+      });
+      let copyAsMarkdownIndex = items.findIndex(
+        (item) => item.label === 'Copy as Markdown',
       );
+
+      if (copyAsMarkdownIndex > -1) {
+        items.splice(copyAsMarkdownIndex + 1, 0, expandItem);
+      } else {
+        items.push(expandItem);
+      }
     }
 
     return items;

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -649,9 +649,9 @@ export default class OperatorModeStackItem extends Component<Signature> {
     );
 
     if (this.isTopCard && !this.isExpanded) {
-      items.unshift(
+      items.push(
         new MenuItem({
-          label: 'Expand to full width',
+          label: 'Expand to Full Width',
           icon: Maximize,
           action: this.toggleExpanded,
         }),

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -34,7 +34,7 @@ import {
   getContrastColor,
   toMenuItems,
 } from '@cardstack/boxel-ui/helpers';
-import { cssVar, optional, not } from '@cardstack/boxel-ui/helpers';
+import { cn, cssVar, optional, not } from '@cardstack/boxel-ui/helpers';
 
 import { IconTrash } from '@cardstack/boxel-ui/icons';
 
@@ -304,7 +304,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
   private closeItem = () => this._closeItem.perform();
 
   // Per-card expanded state. Persisted on operatorModeStateService
-  // (keyed by stack-item id) so the user's expand intent survives:
+  // (keyed by stack-item instance) so the user's expand intent survives:
   //   - When this card is buried (pushed deeper in the stack),
   //     isExpanded reads as false (we render normally), but the
   //     stored intent is preserved.
@@ -312,7 +312,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
   //     again from storage and the card re-expands.
   // Only available when the card opts in via `prefersWideFormat`.
   private get itemExpandKey(): string {
-    return this.args.item.id;
+    return this.args.item.instanceId;
   }
   private get isExpandedIntent(): boolean {
     return this.operatorModeStateService.isStackItemExpanded(
@@ -919,13 +919,15 @@ export default class OperatorModeStackItem extends Component<Signature> {
   <template>
     {{consumeContext this.makeCardResource}}
     <div
-      class='item
-        {{if this.isBuried "buried"}}
-        {{if this.isExpanded "expanded"}}
-        {{if this.doOpeningAnimation "opening-animation"}}
-        {{if this.doClosingAnimation "closing-animation"}}
-        {{if this.doMovingForwardAnimation "move-forward-animation"}}
-        {{if this.isTesting "testing"}}'
+      class={{cn
+        'item'
+        buried=this.isBuried
+        expanded=this.isExpanded
+        opening-animation=this.doOpeningAnimation
+        closing-animation=this.doClosingAnimation
+        move-forward-animation=this.doMovingForwardAnimation
+        testing=this.isTesting
+      }}
       data-test-stack-card-index={{@index}}
       data-test-stack-card={{this.cardIdentifier}}
       {{! In order to support scrolling cards into view

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -310,7 +310,6 @@ export default class OperatorModeStackItem extends Component<Signature> {
   //     stored intent is preserved.
   //   - When the card pops back to the top, isExpanded reads true
   //     again from storage and the card re-expands.
-  // Only available when the card opts in via `prefersWideFormat`.
   private get itemExpandKey(): string {
     return this.args.item.instanceId;
   }
@@ -1154,24 +1153,10 @@ export default class OperatorModeStackItem extends Component<Signature> {
         --realm-icon-border-radius: 4px;
       }
 
-      /* Expanded mode — pinned to all edges of .inner (the stack's
-         positioned content box). .operator-mode-stack supplies
-         padding-top: var(--stack-padding-top) so .inner's top edge
-         already sits flush below the floating bar — same offset host-
-         mode gets from its in-flow bar above. inset: 0 inherits that
-         offset; no calc, no !important, no measurement. The :has
-         rule in stack.gts zeroes inline + bottom padding so the
-         card's right/bottom edges land at viewport edges. z-index
-         250 sits above stack background + workspace chooser (200),
-         below search sheet (300) and the floating bar (700). */
       .item.expanded {
         top: 0;
         left: 0;
         width: 100%;
-        max-width: 100%;
-        height: 100%;
-        margin-top: 0;
-        z-index: 250;
         pointer-events: auto;
       }
       /* Propagate height through the chain so bottom-docked chrome
@@ -1278,6 +1263,48 @@ export default class OperatorModeStackItem extends Component<Signature> {
         display: flex;
         justify: center;
         align-items: center;
+      }
+
+      /* The portaled CardHeader inside takes pill styling — white
+         rounded box, realm icon left-docked, actions right-docked,
+         left-justified type/title. Reuses CardHeader's existing
+         actions structure; just re-skinned via this class. */
+      .expanded-card-header-pill {
+        --inner-boxel-card-header-padding: var(--boxel-sp-4xs)
+          var(--boxel-sp-xs);
+        --boxel-card-header-actions-min-width: max-content;
+        --boxel-card-header-icon-container-min-width: max-content;
+        height: var(--container-button-size);
+        max-width: 100%;
+        width: 100%;
+        gap: var(--boxel-sp-2xs);
+        background: var(--boxel-light);
+        border-radius: var(--boxel-border-radius-2xl);
+        box-shadow: var(--submode-bar-item-box-shadow);
+        outline: var(--submode-bar-item-outline);
+      }
+      /* Title in the expanded pill stays left-justified inside the
+         center column (overrides CardHeader's default text-align: center). */
+      .expanded-card-header-pill :deep(.card-type-display-name) {
+        padding-inline: var(--boxel-sp-4xs);
+        text-align: left;
+        text-box-trim: trim-both;
+      }
+      /* Expanded mode editing — DO NOT flip the whole pill green;
+         only the pencil button lights up (rule below). Overrides
+         CardHeader's default header.is-editing green-bar treatment,
+         which is correct for stacked cards but not for the expanded
+         pill (we want the pill to stay white in the bar). */
+      .expanded-card-header-pill.is-editing {
+        background-color: var(--boxel-light);
+        color: var(--boxel-dark);
+      }
+      /* Pencil button in expanded edit mode — solid green with dark
+         icon for contrast (matches the active expand button). */
+      .expanded-card-header-pill :deep(.icon-save),
+      .expanded-card-header-pill :deep(.icon-save:hover) {
+        background-color: var(--boxel-highlight);
+        color: var(--boxel-dark);
       }
     </style>
 

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -15,6 +15,7 @@ import Component from '@glimmer/component';
 import { tracked, cached } from '@glimmer/tracking';
 
 import DeselectIcon from '@cardstack/boxel-icons/deselect';
+import Maximize from '@cardstack/boxel-icons/maximize';
 import SelectAllIcon from '@cardstack/boxel-icons/select-all';
 import { restartableTask, timeout, dropTask } from 'ember-concurrency';
 import Modifier from 'ember-modifier';
@@ -636,7 +637,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
       return undefined;
     }
 
-    return toMenuItems(
+    const items = toMenuItems(
       this.card?.[getMenuItems]?.({
         canEdit: this.url ? this.realm.canWrite(this.url as string) : false,
         cardCrudFunctions: this.cardCrudFunctions,
@@ -646,6 +647,18 @@ export default class OperatorModeStackItem extends Component<Signature> {
         useBaseTemplate: this.args.item.useBaseTemplate,
       }) ?? [],
     );
+
+    if (this.isTopCard && !this.isExpanded) {
+      items.unshift(
+        new MenuItem({
+          label: 'Expand to full width',
+          icon: Maximize,
+          action: this.toggleExpanded,
+        }),
+      );
+    }
+
+    return items;
   }
 
   @cached
@@ -986,7 +999,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
                     this.canEdit
                     (fn this.cardCrudFunctions.editCard this.card)
                   }}
-                  @onExpand={{if this.isTopCard this.toggleExpanded}}
+                  @onExpand={{if this.isExpanded this.toggleExpanded}}
                   @isExpanded={{this.isExpanded}}
                   @onFinishEditing={{if this.isEditing this.doneEditing}}
                   @onClose={{unless this.isBuried this.closeItem}}
@@ -1009,7 +1022,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
                   this.canEdit
                   (fn this.cardCrudFunctions.editCard this.card)
                 }}
-                @onExpand={{if this.isTopCard this.toggleExpanded}}
+                @onExpand={{if this.isExpanded this.toggleExpanded}}
                 @isExpanded={{this.isExpanded}}
                 @onFinishEditing={{if this.isEditing this.doneEditing}}
                 @onClose={{unless this.isBuried this.closeItem}}

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -314,7 +314,9 @@ export default class OperatorModeStackItem extends Component<Signature> {
     return this.args.item.id;
   }
   private get isExpandedIntent(): boolean {
-    return this.operatorModeStateService.isStackItemExpanded(this.itemExpandKey);
+    return this.operatorModeStateService.isStackItemExpanded(
+      this.itemExpandKey,
+    );
   }
   private get isExpanded(): boolean {
     return this.isTopCard && this.isExpandedIntent;
@@ -334,34 +336,48 @@ export default class OperatorModeStackItem extends Component<Signature> {
     // re-render. Works around CSS transitions not firing when changing
     // properties cross from inline-style to CSS-rule sources mid-frame.
     if (!cardEl || !cardFrom) return;
-    scheduleOnce('afterRender', this, () => {
-      this.playFlip(cardEl, cardFrom, {
+    this.pendingFlipEl = cardEl;
+    this.pendingFlipFrom = cardFrom;
+    scheduleOnce('afterRender', this, this.runExpandAnimation);
+  };
+
+  private pendingFlipEl: HTMLElement | null = null;
+  private pendingFlipFrom: DOMRect | null = null;
+
+  private runExpandAnimation() {
+    const cardEl = this.pendingFlipEl;
+    const cardFrom = this.pendingFlipFrom;
+    this.pendingFlipEl = null;
+    this.pendingFlipFrom = null;
+    if (!cardEl || !cardFrom) return;
+    this.playFlip(cardEl, cardFrom, {
+      duration: 280,
+      easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)',
+    });
+    // Header gets a lightweight fade + small Y slide — suggests
+    // direction without the full FLIP's visual noise. Expand: pill
+    // slides UP into the bar (starts 10px below). Restore: header
+    // slides DOWN onto the card (starts 10px above). A second afterRender
+    // pass lets {{#in-element}} settle before measuring.
+    scheduleOnce('afterRender', this, this.animateHeaderTransition);
+  }
+
+  private animateHeaderTransition() {
+    const headerTo = this.findHeaderEl();
+    if (!headerTo) return;
+    const fromOffsetY = this.isExpandedIntent ? 28 : -28;
+    headerTo.animate(
+      [
+        { opacity: 0, transform: `translateY(${fromOffsetY}px)` },
+        { opacity: 1, transform: 'translateY(0)' },
+      ],
+      {
         duration: 280,
         easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)',
-      });
-      // Header gets a lightweight fade + small Y slide — suggests
-      // direction without the full FLIP's visual noise. Expand: pill
-      // slides UP into the bar (starts 10px below). Restore: header
-      // slides DOWN onto the card (starts 10px above). One rAF to let
-      // {{#in-element}} settle before measuring.
-      requestAnimationFrame(() => {
-        const headerTo = this.findHeaderEl();
-        if (!headerTo) return;
-        const fromOffsetY = this.isExpandedIntent ? 28 : -28;
-        headerTo.animate(
-          [
-            { opacity: 0, transform: `translateY(${fromOffsetY}px)` },
-            { opacity: 1, transform: 'translateY(0)' },
-          ],
-          {
-            duration: 280,
-            easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)',
-            fill: 'none',
-          },
-        );
-      });
-    });
-  };
+        fill: 'none',
+      },
+    );
+  }
 
   private findHeaderEl(): HTMLElement | null {
     // After expand: the portaled .expanded-card-header-pill in the bar.
@@ -979,53 +995,55 @@ export default class OperatorModeStackItem extends Component<Signature> {
                 />
               {{/in-element}}
             {{else}}
-            <CardHeader
-              @cardTypeDisplayName={{this.headerType}}
-              @cardTypeIcon={{cardTypeIcon this.card}}
-              @cardTitle={{this.headerTitle}}
-              @isSaving={{this.cardResource.autoSaveState.isSaving}}
-              @isTopCard={{this.isTopCard}}
-              @lastSavedMessage={{this.cardResource.autoSaveState.lastSavedErrorMsg}}
-              @moreOptionsMenuItems={{this.moreOptionsMenuItems}}
-              @realmInfo={{realmInfo}}
-              @utilityMenu={{this.utilityMenu}}
-              @onEdit={{if
-                this.canEdit
-                (fn this.cardCrudFunctions.editCard this.card)
-              }}
-              @onExpand={{if this.isTopCard this.toggleExpanded}}
-              @isExpanded={{this.isExpanded}}
-              @onFinishEditing={{if this.isEditing this.doneEditing}}
-              @onClose={{unless this.isBuried this.closeItem}}
-              @editShortcutHint={{this.keyboardShortcutLabels.edit}}
-              @finishEditingShortcutHint={{this.keyboardShortcutLabels.finishEditing}}
-              @closeShortcutHint={{this.keyboardShortcutLabels.close}}
-              class='stack-item-header'
-              style={{cssVar
-                boxel-card-header-icon-container-min-width=(if
-                  this.isBuried '50px' '95px'
-                )
-                boxel-card-header-actions-min-width=(if
-                  this.isBuried '50px' '95px'
-                )
-                boxel-card-header-background-color=this.headerColor
-                boxel-card-header-text-color=(getContrastColor this.headerColor)
-                realm-icon-background-color=(getContrastColor
-                  this.headerColor 'transparent'
-                )
-                realm-icon-border-color=(getContrastColor
-                  this.headerColor 'transparent' 'rgba(0 0 0 / 15%)'
-                )
-              }}
-              role={{if this.isBuried 'button' 'banner'}}
-              {{on
-                'click'
-                (optional
-                  (if this.isBuried (fn @dismissStackedCardsAbove @index))
-                )
-              }}
-              data-test-stack-card-header
-            />
+              <CardHeader
+                @cardTypeDisplayName={{this.headerType}}
+                @cardTypeIcon={{cardTypeIcon this.card}}
+                @cardTitle={{this.headerTitle}}
+                @isSaving={{this.cardResource.autoSaveState.isSaving}}
+                @isTopCard={{this.isTopCard}}
+                @lastSavedMessage={{this.cardResource.autoSaveState.lastSavedErrorMsg}}
+                @moreOptionsMenuItems={{this.moreOptionsMenuItems}}
+                @realmInfo={{realmInfo}}
+                @utilityMenu={{this.utilityMenu}}
+                @onEdit={{if
+                  this.canEdit
+                  (fn this.cardCrudFunctions.editCard this.card)
+                }}
+                @onExpand={{if this.isTopCard this.toggleExpanded}}
+                @isExpanded={{this.isExpanded}}
+                @onFinishEditing={{if this.isEditing this.doneEditing}}
+                @onClose={{unless this.isBuried this.closeItem}}
+                @editShortcutHint={{this.keyboardShortcutLabels.edit}}
+                @finishEditingShortcutHint={{this.keyboardShortcutLabels.finishEditing}}
+                @closeShortcutHint={{this.keyboardShortcutLabels.close}}
+                class='stack-item-header'
+                style={{cssVar
+                  boxel-card-header-icon-container-min-width=(if
+                    this.isBuried '50px' '95px'
+                  )
+                  boxel-card-header-actions-min-width=(if
+                    this.isBuried '50px' '95px'
+                  )
+                  boxel-card-header-background-color=this.headerColor
+                  boxel-card-header-text-color=(getContrastColor
+                    this.headerColor
+                  )
+                  realm-icon-background-color=(getContrastColor
+                    this.headerColor 'transparent'
+                  )
+                  realm-icon-border-color=(getContrastColor
+                    this.headerColor 'transparent' 'rgba(0 0 0 / 15%)'
+                  )
+                }}
+                role={{if this.isBuried 'button' 'banner'}}
+                {{on
+                  'click'
+                  (optional
+                    (if this.isBuried (fn @dismissStackedCardsAbove @index))
+                  )
+                }}
+                data-test-stack-card-header
+              />
             {{/if}}
           {{/let}}
           <div

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -1134,10 +1134,12 @@ export default class OperatorModeStackItem extends Component<Signature> {
         height: inherit;
         z-index: 0;
         pointer-events: none;
+        transition:
+          margin-top var(--boxel-transition),
+          width var(--boxel-transition);
       }
       .item.opening-animation {
         animation: scaleIn 0.2s forwards;
-        transition: margin-top var(--boxel-transition);
       }
       .item.closing-animation {
         animation: fadeOut 0.2s forwards;

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -647,9 +647,9 @@ export default class OperatorModeStackItem extends Component<Signature> {
       }) ?? [],
     );
 
-    if (this.isTopCard && !this.isExpanded) {
+    if (this.isTopCard) {
       let expandItem = new MenuItem({
-        label: 'Expand to Full Width',
+        label: this.isExpanded ? 'Restore Width' : 'Expand to Full Width',
         icon: Maximize,
         action: this.toggleExpanded,
       });
@@ -1218,13 +1218,11 @@ export default class OperatorModeStackItem extends Component<Signature> {
       }
       .stack-item-header {
         --boxel-card-header-padding: var(--boxel-sp-4xs) var(--boxel-sp-xs);
-        --boxel-card-header-background-color: var(--boxel-light);
         border-radius: 0;
         z-index: 1;
         max-width: max-content;
         height: var(--stack-item-header-height);
         min-width: 100%;
-        gap: var(--boxel-sp-xxs);
       }
 
       .stack-item-content {
@@ -1279,14 +1277,10 @@ export default class OperatorModeStackItem extends Component<Signature> {
          left-justified type/title. Reuses CardHeader's existing
          actions structure; just re-skinned via this class. */
       .expanded-card-header-pill {
-        --inner-boxel-card-header-padding: var(--boxel-sp-4xs)
-          var(--boxel-sp-xs);
-        --boxel-card-header-actions-min-width: max-content;
-        --boxel-card-header-icon-container-min-width: max-content;
+        --boxel-card-header-padding: var(--boxel-sp-4xs)
+          var(--operator-mode-spacing);
+        --boxel-card-header-gap: var(--operator-mode-spacing);
         height: var(--container-button-size);
-        max-width: 100%;
-        width: 100%;
-        gap: var(--boxel-sp-2xs);
         background: var(--boxel-light);
         border-radius: var(--boxel-border-radius-2xl);
         box-shadow: var(--submode-bar-item-box-shadow);
@@ -1295,7 +1289,6 @@ export default class OperatorModeStackItem extends Component<Signature> {
       /* Title in the expanded pill stays left-justified inside the
          center column (overrides CardHeader's default text-align: center). */
       .expanded-card-header-pill :deep(.card-type-display-name) {
-        padding-inline: var(--boxel-sp-4xs);
         text-align: left;
         text-box-trim: trim-both;
       }

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -317,22 +317,10 @@ export default class OperatorModeStackItem extends Component<Signature> {
     return this.operatorModeStateService.isStackItemExpanded(this.itemExpandKey);
   }
   private get isExpanded(): boolean {
-    return this.isTopCard && this.canExpand && this.isExpandedIntent;
-  }
-  private get canExpand(): boolean {
-    return this.isTopCard && !this.isCardsGridCard;
-  }
-  // Cards-grid (the Workspace's "All Cards" view) opts out of expand
-  // mode — its grid layout assumes scrollable, non-fullscreen content;
-  // forcing it into expanded mode causes child card tiles to overlap.
-  private get isCardsGridCard(): boolean {
-    const ctor = this.card?.constructor as
-      | { displayName?: string }
-      | undefined;
-    return ctor?.displayName === 'Cards Grid';
+    return this.isTopCard && this.isExpandedIntent;
   }
   private toggleExpanded = () => {
-    if (!this.canExpand) return;
+    if (!this.isTopCard) return;
     const cardEl = this.itemEl;
     const cardFrom = cardEl?.getBoundingClientRect();
 
@@ -982,7 +970,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
                     this.canEdit
                     (fn this.cardCrudFunctions.editCard this.card)
                   }}
-                  @onExpand={{if this.canExpand this.toggleExpanded}}
+                  @onExpand={{if this.isTopCard this.toggleExpanded}}
                   @isExpanded={{this.isExpanded}}
                   @onFinishEditing={{if this.isEditing this.doneEditing}}
                   @onClose={{unless this.isBuried this.closeItem}}
@@ -1005,7 +993,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
                 this.canEdit
                 (fn this.cardCrudFunctions.editCard this.card)
               }}
-              @onExpand={{if this.canExpand this.toggleExpanded}}
+              @onExpand={{if this.isTopCard this.toggleExpanded}}
               @isExpanded={{this.isExpanded}}
               @onFinishEditing={{if this.isEditing this.doneEditing}}
               @onClose={{unless this.isBuried this.closeItem}}

--- a/packages/host/app/components/operator-mode/stack.gts
+++ b/packages/host/app/components/operator-mode/stack.gts
@@ -155,6 +155,9 @@ export default class OperatorModeStack extends Component<Signature> {
         padding-inline: var(--stack-padding-inline);
         padding-bottom: var(--stack-padding-bottom);
         z-index: 0;
+        transition:
+          padding-top var(--boxel-transition),
+          padding-inline var(--boxel-transition);
       }
       .stack-medium-padding-top:not(:has(.item.expanded)) {
         --stack-padding-top: var(--stack-md-padding-top);

--- a/packages/host/app/components/operator-mode/stack.gts
+++ b/packages/host/app/components/operator-mode/stack.gts
@@ -141,7 +141,28 @@ export default class OperatorModeStack extends Component<Signature> {
         padding-inline: var(--operator-mode-spacing);
         padding-bottom: var(--stack-padding-bottom);
         position: relative;
-        transition: padding-top var(--boxel-transition);
+      }
+      /* When an item is expanded, drop the stack's inline + bottom
+         padding so the expanded card fills the area below the bar
+         edge-to-edge. Top padding is FORCED back to var(--stack-
+         padding-top) — the .stack-item-card "tray" anchors at this
+         offset (right below the floating bar), with its other three
+         edges flush to viewport edges. This is the magic-move target:
+         every animation tick keeps tray-edges aligned with the inner
+         content. */
+      .operator-mode-stack:has(.item.expanded) {
+        padding-top: var(--stack-padding-top);
+        padding-inline: 0;
+        padding-bottom: 0;
+      }
+      /* .inner is display: flex with no explicit width — when its
+         flex children are all position: absolute (the .item rules),
+         flex sees an empty row and collapses .inner to width 0. The
+         expanded .item using inset: 0 then resolves to a 0-width
+         box (containing-block width = 0). Force .inner to fill the
+         stack so inset: 0 spans the viewport. */
+      .operator-mode-stack:has(.item.expanded) .inner {
+        width: 100%;
       }
       .operator-mode-stack
         :deep(.field-component-card.fitted-format .missing-template) {

--- a/packages/host/app/components/operator-mode/stack.gts
+++ b/packages/host/app/components/operator-mode/stack.gts
@@ -5,6 +5,8 @@ import perform from 'ember-concurrency/helpers/perform';
 
 import { provide } from 'ember-provide-consume-context';
 
+import { cn, eq, gte } from '@cardstack/boxel-ui/helpers';
+
 import {
   CardCrudFunctionsContextName,
   type CommandContext,
@@ -105,7 +107,14 @@ export default class OperatorModeStack extends Component<Signature> {
   };
 
   <template>
-    <div class='operator-mode-stack' ...attributes>
+    <div
+      class={{cn
+        'operator-mode-stack'
+        stack-medium-padding-top=(eq @stackItems.length 2)
+        stack-small-padding-top=(gte @stackItems.length 3)
+      }}
+      ...attributes
+    >
       <div class='inner'>
         {{#each @stackItems as |item i|}}
           <OperatorModeStackItem
@@ -125,44 +134,37 @@ export default class OperatorModeStack extends Component<Signature> {
 
     <style scoped>
       :global(:root) {
-        --stack-padding-top: calc(
+        --stack-lg-padding-top: calc(
           var(--operator-mode-top-bar-item-height) +
             (2 * (var(--operator-mode-spacing)))
         );
+        --stack-md-padding-top: calc(var(--stack-lg-padding-top) / 2);
+        --stack-sm-padding-top: var(--operator-mode-spacing);
+
+        --stack-padding-top: var(--stack-lg-padding-top);
         --stack-padding-bottom: var(--boxel-sp-lg);
+        --stack-padding-inline: var(--boxel-sp-lg);
       }
       .operator-mode-stack {
-        z-index: 0;
+        position: relative;
         height: 100%;
         width: 100%;
         background-position: center;
         background-size: cover;
         padding-top: var(--stack-padding-top);
-        padding-inline: var(--operator-mode-spacing);
+        padding-inline: var(--stack-padding-inline);
         padding-bottom: var(--stack-padding-bottom);
-        position: relative;
+        z-index: 0;
       }
-      /* When an item is expanded, drop the stack's inline + bottom
-         padding so the expanded card fills the area below the bar
-         edge-to-edge. Top padding is FORCED back to var(--stack-
-         padding-top) — the .stack-item-card "tray" anchors at this
-         offset (right below the floating bar), with its other three
-         edges flush to viewport edges. This is the magic-move target:
-         every animation tick keeps tray-edges aligned with the inner
-         content. */
+      .stack-medium-padding-top:not(:has(.item.expanded)) {
+        --stack-padding-top: var(--stack-md-padding-top);
+      }
+      .stack-small-padding-top:not(:has(.item.expanded)) {
+        --stack-padding-top: var(--stack-sm-padding-top);
+      }
       .operator-mode-stack:has(.item.expanded) {
-        padding-top: var(--stack-padding-top);
-        padding-inline: 0;
-        padding-bottom: 0;
-      }
-      /* .inner is display: flex with no explicit width — when its
-         flex children are all position: absolute (the .item rules),
-         flex sees an empty row and collapses .inner to width 0. The
-         expanded .item using inset: 0 then resolves to a 0-width
-         box (containing-block width = 0). Force .inner to fill the
-         stack so inset: 0 spans the viewport. */
-      .operator-mode-stack:has(.item.expanded) .inner {
-        width: 100%;
+        --stack-padding-inline: 0;
+        --stack-padding-bottom: 0;
       }
       .operator-mode-stack
         :deep(.field-component-card.fitted-format .missing-template) {
@@ -172,6 +174,7 @@ export default class OperatorModeStack extends Component<Signature> {
         border-bottom-right-radius: var(--boxel-form-control-border-radius);
       }
       .inner {
+        width: 100%;
         height: 100%;
         position: relative;
         display: flex;

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -102,13 +102,25 @@ type PanelWidths = {
   minWidth: number | null;
 };
 
-const COLLAPSED_TOP_BAR_BUTTONS_WIDTH_REM = 56;
+const COLLAPSED_TOP_BAR_BUTTONS_WIDTH_REM = 46;
+const COLLAPSED_TOP_BAR_BUTTONS_NOT_EXPANDED_WIDTH_REM = 26;
 
 export default class SubmodeLayout extends Component<Signature> {
   @tracked private searchSheetMode: SearchSheetMode = SearchSheetModes.Closed;
   @tracked private profileSummaryOpened = false;
   @tracked private topBarCenterElement: Element | null = null;
-  @tracked private topBarButtonsCollapsed = false;
+  @tracked private currentWindowWidth = 0;
+
+  private get topBarButtonsCollapsed(): boolean {
+    let rootFontSize = Number.parseFloat(
+      getComputedStyle(document.documentElement).fontSize,
+    );
+    let threshold = this.operatorModeStateService.hasAnyStackItemExpanded
+      ? COLLAPSED_TOP_BAR_BUTTONS_WIDTH_REM
+      : COLLAPSED_TOP_BAR_BUTTONS_NOT_EXPANDED_WIDTH_REM;
+    return this.currentWindowWidth <= threshold * rootFontSize;
+  }
+
   private aiPanelWidths: PanelWidths = new TrackedObject({
     defaultWidth: 30,
     minWidth: 25,
@@ -146,11 +158,7 @@ export default class SubmodeLayout extends Component<Signature> {
 
   // Handles window resize and initializes AI panel width from localStorage
   onWindowResize = (windowWidth: number) => {
-    let rootFontSize = Number.parseFloat(
-      getComputedStyle(document.documentElement).fontSize,
-    );
-    this.topBarButtonsCollapsed =
-      windowWidth <= COLLAPSED_TOP_BAR_BUTTONS_WIDTH_REM * rootFontSize;
+    this.currentWindowWidth = windowWidth;
 
     let aiPanelDefaultWidthInPixels = 371;
     if (windowWidth < aiPanelDefaultWidthInPixels) {

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -102,10 +102,13 @@ type PanelWidths = {
   minWidth: number | null;
 };
 
+const COLLAPSED_TOP_BAR_BUTTONS_WIDTH_REM = 56;
+
 export default class SubmodeLayout extends Component<Signature> {
   @tracked private searchSheetMode: SearchSheetMode = SearchSheetModes.Closed;
   @tracked private profileSummaryOpened = false;
   @tracked private topBarCenterElement: Element | null = null;
+  @tracked private topBarButtonsCollapsed = false;
   private aiPanelWidths: PanelWidths = new TrackedObject({
     defaultWidth: 30,
     minWidth: 25,
@@ -143,6 +146,12 @@ export default class SubmodeLayout extends Component<Signature> {
 
   // Handles window resize and initializes AI panel width from localStorage
   onWindowResize = (windowWidth: number) => {
+    let rootFontSize = Number.parseFloat(
+      getComputedStyle(document.documentElement).fontSize,
+    );
+    this.topBarButtonsCollapsed =
+      windowWidth <= COLLAPSED_TOP_BAR_BUTTONS_WIDTH_REM * rootFontSize;
+
     let aiPanelDefaultWidthInPixels = 371;
     if (windowWidth < aiPanelDefaultWidthInPixels) {
       aiPanelDefaultWidthInPixels = windowWidth;
@@ -441,6 +450,7 @@ export default class SubmodeLayout extends Component<Signature> {
             {{#if (not this.workspaceChooserOpened)}}
               <SubmodeSwitcher
                 class='submode-switcher'
+                @isCollapsed={{this.topBarButtonsCollapsed}}
                 @submode={{this.operatorModeStateService.state.submode}}
                 @onSubmodeSelect={{this.updateSubmode}}
               />
@@ -451,6 +461,7 @@ export default class SubmodeLayout extends Component<Signature> {
                   @initiallyOpened={{bool
                     this.operatorModeStateService.state.newFileDropdownOpen
                   }}
+                  @isCollapsed={{this.topBarButtonsCollapsed}}
                 />
               {{/if}}
               <div
@@ -606,6 +617,7 @@ export default class SubmodeLayout extends Component<Signature> {
         position: relative;
         width: 100%;
         max-width: 100%;
+        container-type: inline-size;
         /* Lock outer box to exactly var(--stack-padding-top) — the
            same value .operator-mode-stack uses for its padding-top
            offset. Any content the bar contains (workspace button,
@@ -666,7 +678,7 @@ export default class SubmodeLayout extends Component<Signature> {
         border: none;
         border-radius: var(--submode-bar-item-border-radius);
         box-shadow: var(--submode-bar-item-box-shadow);
-        width: var(--submode-new-file-button-width);
+        flex-shrink: 0;
       }
 
       .profile-icon-button {

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -121,6 +121,13 @@ export default class SubmodeLayout extends Component<Signature> {
     return this.currentWindowWidth <= threshold * rootFontSize;
   }
 
+  private get submodeSwitcherCollapsed(): boolean {
+    return (
+      this.operatorModeStateService.hasAnyStackItemExpanded &&
+      this.topBarButtonsCollapsed
+    );
+  }
+
   private aiPanelWidths: PanelWidths = new TrackedObject({
     defaultWidth: 30,
     minWidth: 25,
@@ -458,7 +465,7 @@ export default class SubmodeLayout extends Component<Signature> {
             {{#if (not this.workspaceChooserOpened)}}
               <SubmodeSwitcher
                 class='submode-switcher'
-                @isCollapsed={{this.topBarButtonsCollapsed}}
+                @isCollapsed={{this.submodeSwitcherCollapsed}}
                 @submode={{this.operatorModeStateService.state.submode}}
                 @onSubmodeSelect={{this.updateSubmode}}
               />
@@ -602,6 +609,7 @@ export default class SubmodeLayout extends Component<Signature> {
       }
 
       .ai-assistant-resizable-panel {
+        max-width: 100%;
         overflow: initial;
       }
 

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -20,7 +20,7 @@ import {
   IconButton,
   ResizablePanelGroup,
 } from '@cardstack/boxel-ui/components';
-import { bool, cn, not } from '@cardstack/boxel-ui/helpers';
+import { bool, cn, eq, not } from '@cardstack/boxel-ui/helpers';
 
 import { BoxelIconWithText } from '@cardstack/boxel-ui/icons';
 
@@ -103,7 +103,7 @@ type PanelWidths = {
 };
 
 const COLLAPSED_TOP_BAR_BUTTONS_WIDTH_REM = 46;
-const COLLAPSED_TOP_BAR_BUTTONS_NOT_EXPANDED_WIDTH_REM = 26;
+const COLLAPSED_TOP_BAR_BUTTONS_NOT_EXPANDED_WIDTH_REM = 23;
 
 export default class SubmodeLayout extends Component<Signature> {
   @tracked private searchSheetMode: SearchSheetMode = SearchSheetModes.Closed;
@@ -472,11 +472,18 @@ export default class SubmodeLayout extends Component<Signature> {
                   @isCollapsed={{this.topBarButtonsCollapsed}}
                 />
               {{/if}}
-              <div
-                class='expanded-card-header-slot'
-                data-test-expanded-card-header-slot
-                {{captureElement this.storeExpandedCardHeaderElement}}
-              ></div>
+              {{#if
+                (eq this.operatorModeStateService.state.submode 'interact')
+              }}
+                <div
+                  class={{cn
+                    'expanded-card-header-slot'
+                    has-expanded=this.operatorModeStateService.hasAnyStackItemExpanded
+                  }}
+                  data-test-expanded-card-header-slot
+                  {{captureElement this.storeExpandedCardHeaderElement}}
+                ></div>
+              {{/if}}
               {{yield to='topBar'}}
             {{/if}}
 
@@ -748,6 +755,12 @@ export default class SubmodeLayout extends Component<Signature> {
       :deep(.open-search-field) {
         box-shadow: var(--submode-bar-item-box-shadow);
         outline: var(--submode-bar-item-outline);
+      }
+
+      @media (max-width: 26rem) {
+        .expanded-card-header-slot:not(.has-expanded) {
+          display: none;
+        }
       }
 
       @media print {

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -121,6 +121,12 @@ export default class SubmodeLayout extends Component<Signature> {
   declare private doSearch: (term: string, typeRef?: ResolvedCodeRef) => void;
 
   @action
+  private storeExpandedCardHeaderElement(element: Element) {
+    this.operatorModeStateService.expandedCardHeaderElement =
+      element as HTMLElement;
+  }
+
+  @action
   private storeTopBarCenterElement(element: Element) {
     this.topBarCenterElement = element;
   }
@@ -401,7 +407,9 @@ export default class SubmodeLayout extends Component<Signature> {
   <template>
     <div
       {{handleWindowResizeModifier this.onWindowResize}}
-      class='submode-layout {{this.aiAssistantVisibilityClass}}'
+      class='submode-layout
+        {{this.aiAssistantVisibilityClass}}
+        {{if this.operatorModeStateService.hasAnyStackItemExpanded "has-expanded-card"}}'
       data-test-submode-layout
       ...attributes
     >
@@ -447,6 +455,11 @@ export default class SubmodeLayout extends Component<Signature> {
                   }}
                 />
               {{/if}}
+              <div
+                class='expanded-card-header-slot'
+                data-test-expanded-card-header-slot
+                {{captureElement this.storeExpandedCardHeaderElement}}
+              ></div>
               {{yield to='topBar'}}
             {{/if}}
 
@@ -595,6 +608,17 @@ export default class SubmodeLayout extends Component<Signature> {
         position: relative;
         width: 100%;
         max-width: 100%;
+        /* Lock outer box to exactly var(--stack-padding-top) — the
+           same value .operator-mode-stack uses for its padding-top
+           offset. Any content the bar contains (workspace button,
+           submode switcher, portaled expanded-card-header pill,
+           etc.) renders WITHIN this fixed height; nothing the slot
+           contents do can push the bar taller. This is what lets
+           interact-expanded card positioning match host-mode pixel
+           for pixel — both card-tops sit at y = stack-padding-top
+           and the bar is guaranteed to occupy that exact space. */
+        height: var(--stack-padding-top);
+        box-sizing: border-box;
         padding: var(--operator-mode-spacing);
         z-index: var(--host-top-bar-z-index);
 
@@ -602,12 +626,81 @@ export default class SubmodeLayout extends Component<Signature> {
         align-items: center;
         gap: var(--operator-mode-spacing);
       }
+      /* Subtle glass-morphism behind the top bar when a card is
+         expanded: blurs what's behind, slight white tint, and casts
+         a small drop shadow onto the card's top edge so the toolbar
+         area reads as a distinct layer above the expanded surface. */
+      .submode-layout.has-expanded-card .submode-layout-top-bar {
+        background-color: rgba(255, 255, 255, 0.35);
+        backdrop-filter: blur(10px) saturate(160%);
+        -webkit-backdrop-filter: blur(10px) saturate(160%);
+        box-shadow: 0 2px 6px -2px rgba(15, 23, 42, 0.12);
+      }
 
       .submode-layout-top-bar-center {
         flex: 1;
         display: flex;
         justify-content: center;
         min-width: 0;
+      }
+
+      /* Slot for the expanded stack-item's CardHeader pill. When a
+         card is expanded, stack-item portals its CardHeader here via
+         the in-element block helper. The slot grows to take available
+         space (so the pill can stretch to ~800px) and centers the
+         pill horizontally — same horizontal position the stack card
+         would occupy below. When no card is expanded, the slot is
+         empty (zero rendered children). */
+      .expanded-card-header-slot {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 0;
+        max-width: 800px;
+        margin: 0 auto;
+      }
+      /* The portaled CardHeader inside takes pill styling — white
+         rounded box, realm icon left-docked, actions right-docked,
+         left-justified type/title. Reuses CardHeader's existing
+         actions structure; just re-skinned via this class. */
+      :global(.expanded-card-header-pill) {
+        --inner-boxel-card-header-padding: var(--boxel-sp-4xs) var(--boxel-sp-xs);
+        --boxel-card-header-actions-min-width: max-content;
+        --boxel-card-header-icon-container-min-width: max-content;
+        height: var(--container-button-size);
+        max-width: 100%;
+        width: 100%;
+        gap: var(--boxel-sp-xxs);
+        background: var(--boxel-light);
+        /* Match the other floating-bar elements (Interact, +New,
+           profile avatar): full pill shape (radius: 999px), submode-
+           bar shadow + outline. */
+        border-radius: 999px;
+        box-shadow: var(--submode-bar-item-box-shadow);
+        outline: var(--submode-bar-item-outline);
+      }
+      /* Title in the expanded pill stays left-justified inside the
+         center column (overrides CardHeader's default text-align: center). */
+      :global(.expanded-card-header-pill .card-type-display-name) {
+        text-align: left;
+        padding-left: var(--boxel-sp-xs);
+      }
+      /* Expanded mode editing — DO NOT flip the whole pill green;
+         only the pencil button lights up (rule below). Overrides
+         CardHeader's default header.is-editing green-bar treatment,
+         which is correct for stacked cards but not for the expanded
+         pill (we want the pill to stay white in the bar). */
+      :global(.expanded-card-header-pill.is-editing) {
+        background-color: var(--boxel-light);
+        color: var(--boxel-dark);
+      }
+      /* Pencil button in expanded edit mode — solid green with dark
+         icon for contrast (matches the active expand button). */
+      :global(.expanded-card-header-pill .icon-save),
+      :global(.expanded-card-header-pill .icon-save:hover) {
+        background-color: var(--boxel-highlight);
+        color: var(--boxel-dark);
       }
 
       .submode-switcher {

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -407,11 +407,7 @@ export default class SubmodeLayout extends Component<Signature> {
   <template>
     <div
       {{handleWindowResizeModifier this.onWindowResize}}
-      class={{cn
-        'submode-layout'
-        this.aiAssistantVisibilityClass
-        has-expanded-card=this.operatorModeStateService.hasAnyStackItemExpanded
-      }}
+      class={{cn 'submode-layout' this.aiAssistantVisibilityClass}}
       data-test-submode-layout
       ...attributes
     >
@@ -628,16 +624,6 @@ export default class SubmodeLayout extends Component<Signature> {
         align-items: center;
         gap: var(--operator-mode-spacing);
       }
-      /* Subtle glass-morphism behind the top bar when a card is
-         expanded: blurs what's behind, slight white tint, and casts
-         a small drop shadow onto the card's top edge so the toolbar
-         area reads as a distinct layer above the expanded surface. */
-      .submode-layout.has-expanded-card .submode-layout-top-bar {
-        background-color: rgba(255, 255, 255, 0.35);
-        backdrop-filter: blur(10px) saturate(160%);
-        -webkit-backdrop-filter: blur(10px) saturate(160%);
-        box-shadow: 0 2px 6px -2px rgba(15, 23, 42, 0.12);
-      }
 
       .submode-layout-top-bar-center {
         flex: 1;
@@ -659,51 +645,8 @@ export default class SubmodeLayout extends Component<Signature> {
         align-items: center;
         justify-content: center;
         min-width: 0;
-        max-width: 800px;
+        max-width: 50rem; /* same as `stackItemMaxWidth` in stack-item.gts */
         margin: 0 auto;
-      }
-      /* The portaled CardHeader inside takes pill styling — white
-         rounded box, realm icon left-docked, actions right-docked,
-         left-justified type/title. Reuses CardHeader's existing
-         actions structure; just re-skinned via this class. */
-      :global(.expanded-card-header-pill) {
-        --inner-boxel-card-header-padding: var(--boxel-sp-4xs)
-          var(--boxel-sp-xs);
-        --boxel-card-header-actions-min-width: max-content;
-        --boxel-card-header-icon-container-min-width: max-content;
-        height: var(--container-button-size);
-        max-width: 100%;
-        width: 100%;
-        gap: var(--boxel-sp-xxs);
-        background: var(--boxel-light);
-        /* Match the other floating-bar elements (Interact, +New,
-           profile avatar): full pill shape (radius: 999px), submode-
-           bar shadow + outline. */
-        border-radius: 999px;
-        box-shadow: var(--submode-bar-item-box-shadow);
-        outline: var(--submode-bar-item-outline);
-      }
-      /* Title in the expanded pill stays left-justified inside the
-         center column (overrides CardHeader's default text-align: center). */
-      :global(.expanded-card-header-pill .card-type-display-name) {
-        text-align: left;
-        padding-left: var(--boxel-sp-xs);
-      }
-      /* Expanded mode editing — DO NOT flip the whole pill green;
-         only the pencil button lights up (rule below). Overrides
-         CardHeader's default header.is-editing green-bar treatment,
-         which is correct for stacked cards but not for the expanded
-         pill (we want the pill to stay white in the bar). */
-      :global(.expanded-card-header-pill.is-editing) {
-        background-color: var(--boxel-light);
-        color: var(--boxel-dark);
-      }
-      /* Pencil button in expanded edit mode — solid green with dark
-         icon for contrast (matches the active expand button). */
-      :global(.expanded-card-header-pill .icon-save),
-      :global(.expanded-card-header-pill .icon-save:hover) {
-        background-color: var(--boxel-highlight);
-        color: var(--boxel-dark);
       }
 
       .submode-switcher {

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -407,9 +407,11 @@ export default class SubmodeLayout extends Component<Signature> {
   <template>
     <div
       {{handleWindowResizeModifier this.onWindowResize}}
-      class='submode-layout
-        {{this.aiAssistantVisibilityClass}}
-        {{if this.operatorModeStateService.hasAnyStackItemExpanded "has-expanded-card"}}'
+      class={{cn
+        'submode-layout'
+        this.aiAssistantVisibilityClass
+        has-expanded-card=this.operatorModeStateService.hasAnyStackItemExpanded
+      }}
       data-test-submode-layout
       ...attributes
     >
@@ -665,7 +667,8 @@ export default class SubmodeLayout extends Component<Signature> {
          left-justified type/title. Reuses CardHeader's existing
          actions structure; just re-skinned via this class. */
       :global(.expanded-card-header-pill) {
-        --inner-boxel-card-header-padding: var(--boxel-sp-4xs) var(--boxel-sp-xs);
+        --inner-boxel-card-header-padding: var(--boxel-sp-4xs)
+          var(--boxel-sp-xs);
         --boxel-card-header-actions-min-width: max-content;
         --boxel-card-header-icon-container-min-width: max-content;
         height: var(--container-button-size);

--- a/packages/host/app/components/submode-switcher.gts
+++ b/packages/host/app/components/submode-switcher.gts
@@ -1,3 +1,4 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -8,21 +9,22 @@ import { tracked } from '@glimmer/tracking';
 
 import UserScreen from '@cardstack/boxel-icons/user-screen';
 
-import get from 'lodash/get';
-
-import { BoxelDropdown, Button, Menu } from '@cardstack/boxel-ui/components';
+import {
+  BoxelDropdown,
+  Button,
+  Menu,
+  Tooltip,
+} from '@cardstack/boxel-ui/components';
 
 import type { MenuItem } from '@cardstack/boxel-ui/helpers';
+import { cn } from '@cardstack/boxel-ui/helpers';
 import { menuItemFunc } from '@cardstack/boxel-ui/helpers';
-import {
-  DropdownArrowUp,
-  DropdownArrowDown,
-  Eye,
-  IconCode,
-} from '@cardstack/boxel-ui/icons';
+import { DropdownArrowDown, Eye, IconCode } from '@cardstack/boxel-ui/icons';
 
 import config from '@cardstack/host/config/environment';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+
+import type { ComponentLike, ModifierLike } from '@glint/template';
 
 export const Submodes = {
   Interact: 'interact',
@@ -32,9 +34,90 @@ export const Submodes = {
 type Values<T> = T[keyof T];
 export type Submode = Values<typeof Submodes>;
 
+interface TriggerButtonSignature {
+  Args: {
+    submode: Submode;
+    isCollapsed?: boolean;
+    isExpanded: boolean;
+    appVersion: string;
+    bindings: ModifierLike<{
+      Args: { Positional: unknown[] };
+      Element: HTMLButtonElement | HTMLAnchorElement;
+    }>;
+    onToggle: () => void;
+    icon: ComponentLike<{ Element: SVGSVGElement }>;
+  };
+  Element: HTMLButtonElement;
+}
+
+const SubmodeTriggerButton: TemplateOnlyComponent<TriggerButtonSignature> =
+  <template>
+    <Button
+      class={{cn
+        'submode-switcher-dropdown-trigger'
+        submode-switcher-dropdown-trigger--collapsed=@isCollapsed
+      }}
+      @kind='primary-dark'
+      @size='auto'
+      @rectangular={{true}}
+      aria-label='{{@submode}} submode'
+      title={{@appVersion}}
+      {{on 'click' @onToggle}}
+      {{@bindings}}
+      ...attributes
+    >
+      <@icon width='18px' height='18px' role='presentation' />
+      {{#unless @isCollapsed}}
+        <span class='submode-switcher-label'>{{capitalize @submode}}</span>
+        <DropdownArrowDown
+          class='dropdown-arrow'
+          width='12px'
+          height='12px'
+          role='presentation'
+          data-test-submode-arrow-direction={{if @isExpanded 'up' 'down'}}
+        />
+      {{/unless}}
+    </Button>
+    <style scoped>
+      .submode-switcher-dropdown-trigger {
+        --icon-color: var(--boxel-highlight);
+        position: relative;
+        height: var(--submode-switcher-height);
+        width: var(--submode-switcher-width);
+        padding: var(--boxel-sp-2xs) var(--boxel-sp-xs);
+        justify-content: flex-start;
+        gap: var(--boxel-sp-2xs);
+        flex-shrink: 0;
+        transition:
+          border-bottom-right-radius var(--boxel-transition),
+          border-bottom-left-radius var(--boxel-transition);
+      }
+      .submode-switcher-dropdown-trigger[aria-expanded='true'] {
+        border-bottom-right-radius: 0;
+        border-bottom-left-radius: 0;
+      }
+      .submode-switcher-dropdown-trigger--collapsed {
+        --submode-switcher-width: var(--container-button-size);
+        justify-content: center;
+        padding-inline: var(--boxel-sp-2xs);
+        gap: 0;
+      }
+      .submode-switcher-dropdown-trigger--collapsed[aria-expanded='true'] {
+        border-radius: var(--boxel-border-radius);
+      }
+      .dropdown-arrow {
+        margin-left: auto;
+      }
+      .submode-switcher-dropdown-trigger[aria-expanded='true'] .dropdown-arrow {
+        transform: rotate(180deg);
+      }
+    </style>
+  </template>;
+
 interface Signature {
   Element: HTMLElement;
   Args: {
+    isCollapsed?: boolean;
     submode: Submode;
     onSubmodeSelect: (submode: Submode) => void;
   };
@@ -43,36 +126,39 @@ interface Signature {
 export default class SubmodeSwitcher extends Component<Signature> {
   <template>
     <div data-test-submode-switcher={{@submode}} ...attributes>
-      <BoxelDropdown @contentClass='submode-switcher-dropdown'>
+      <BoxelDropdown
+        @contentClass={{if
+          @isCollapsed
+          'submode-switcher-dropdown submode-switcher-dropdown--detached gap-above'
+          'submode-switcher-dropdown'
+        }}
+      >
         <:trigger as |bindings|>
-          <Button
-            class='submode-switcher-dropdown-trigger'
-            @kind='primary-dark'
-            @size='tall'
-            aria-label='Options'
-            title={{this.appVersion}}
-            {{on 'click' this.toggleDropdown}}
-            {{bindings}}
-          >
-            {{#let (get this.submodeIcons @submode) as |SubmodeIcon|}}
-              <SubmodeIcon width='18px' height='18px' />
-            {{/let}}
-            {{capitalize @submode}}
-            <div
-              class='arrow-icon'
-              data-test-submode-arrow-direction={{if
-                this.isExpanded
-                'up'
-                'down'
-              }}
-            >
-              {{#if this.isExpanded}}
-                <DropdownArrowUp width='12px' height='12px' />
-              {{else}}
-                <DropdownArrowDown width='12px' height='12px' />
-              {{/if}}
-            </div>
-          </Button>
+          {{#if @isCollapsed}}
+            <Tooltip @placement='right'>
+              <:trigger>
+                <SubmodeTriggerButton
+                  @submode={{@submode}}
+                  @isCollapsed={{@isCollapsed}}
+                  @isExpanded={{this.isExpanded}}
+                  @appVersion={{this.appVersion}}
+                  @bindings={{bindings}}
+                  @onToggle={{this.toggleDropdown}}
+                  @icon={{this.currentSubmodeIcon}}
+                />
+              </:trigger>
+              <:content>Change submode</:content>
+            </Tooltip>
+          {{else}}
+            <SubmodeTriggerButton
+              @submode={{@submode}}
+              @isExpanded={{this.isExpanded}}
+              @appVersion={{this.appVersion}}
+              @bindings={{bindings}}
+              @onToggle={{this.toggleDropdown}}
+              @icon={{this.currentSubmodeIcon}}
+            />
+          {{/if}}
         </:trigger>
         <:content as |dd|>
           <Menu
@@ -89,51 +175,18 @@ export default class SubmodeSwitcher extends Component<Signature> {
           var(--boxel-border-radius) var(--boxel-border-radius);
         --submode-switcher-dropdown-content-bg-color: rgba(0, 0, 0, 0.5);
         --submode-switcher-width: 10.5rem; /* 168px */
-        --submode-switcher-height: var(--operator-mode-top-bar-item-height);
-      }
-      .submode-switcher-dropdown-trigger {
-        --icon-color: var(--boxel-highlight);
-
-        padding: var(--boxel-sp-xxs) var(--boxel-sp-xs);
-        background-color: var(--boxel-dark);
-        border-radius: var(--boxel-border-radius);
-
-        position: relative;
-        justify-content: flex-start;
-        width: var(--submode-switcher-width);
-        height: var(--submode-switcher-height);
-        gap: var(--boxel-sp-xs);
-
-        transition:
-          border-bottom-right-radius var(--boxel-transition),
-          border-bottom-left-radius var(--boxel-transition);
-      }
-
-      .submode-switcher-dropdown-trigger .icon {
-        color: var(--icon-color);
-      }
-
-      .submode-switcher-dropdown-trigger[aria-expanded='true'] {
-        border-bottom-right-radius: 0;
-        border-bottom-left-radius: 0;
-
-        transition:
-          border-bottom-right-radius var(--boxel-transition)
-            var(--boxel-transition),
-          border-bottom-left-radius var(--boxel-transition)
-            var(--boxel-transition);
-      }
-      .arrow-icon {
-        margin-left: auto;
-        padding-right: var(--boxel-sp-4xs);
-
-        display: flex;
+        --submode-switcher-height: var(--container-button-size);
       }
       :global(.submode-switcher-dropdown) {
         --boxel-dropdown-content-border-radius: var(
           --submode-switcher-dropdown-content-border-radius
         );
         background-color: var(--submode-switcher-dropdown-content-bg-color);
+      }
+      :global(.submode-switcher-dropdown--detached) {
+        --submode-switcher-dropdown-content-border-radius: var(
+          --boxel-border-radius
+        );
       }
       .submode-switcher-dropdown-menu {
         width: var(--submode-switcher-width);
@@ -160,6 +213,10 @@ export default class SubmodeSwitcher extends Component<Signature> {
     [Submodes.Host]: UserScreen,
   };
   @tracked isExpanded = false;
+
+  get currentSubmodeIcon() {
+    return this.submodeIcons[this.args.submode];
+  }
 
   @action
   toggleDropdown() {

--- a/packages/host/app/components/submode-switcher.gts
+++ b/packages/host/app/components/submode-switcher.gts
@@ -64,6 +64,7 @@ const SubmodeTriggerButton: TemplateOnlyComponent<TriggerButtonSignature> =
       title={{@appVersion}}
       {{on 'click' @onToggle}}
       {{@bindings}}
+      data-test-submode-switcher-button={{@submode}}
       ...attributes
     >
       <@icon width='18px' height='18px' role='presentation' />

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -54,6 +54,7 @@ export function detectStackItemTypeForTarget(
 }
 
 let nextInteractionSequence = 0;
+let nextStackItemInstanceId = 0;
 
 export class StackItem {
   // `format`, `request`, `useBaseTemplate` are tracked so that callers
@@ -76,6 +77,7 @@ export class StackItem {
   // open B, edit A, Escape" target A: clicking edit on A is the most
   // recent interaction even though B was opened more recently.
   lastInteractedAt: number;
+  readonly instanceId: string;
   #id: string;
   relationshipContext?:
     | {
@@ -104,6 +106,7 @@ export class StackItem {
     this.useBaseTemplate = useBaseTemplate;
     this.relationshipContext = relationshipContext;
     this.lastInteractedAt = lastInteractedAt ?? ++nextInteractionSequence;
+    this.instanceId = `stack-item-${++nextStackItemInstanceId}`;
   }
 
   get id() {

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -196,14 +196,6 @@ export default class OperatorModeStateService extends Service {
     }
     this.schedulePersist();
   }
-  // Drop ALL expand intents — called when a new card lands on any
-  // stack so the expanded surface doesn't end up under the new card
-  // (which would otherwise overlap awkwardly on the workspace
-  // background, see addItemToStack).
-  clearAllStackItemExpanded() {
-    this.expandedStackItems.clear();
-    this.schedulePersist();
-  }
   // True when at least one stack's TOP card has expand intent — used
   // to drive the bar's glass-morphism + .has-expanded-card class. Only
   // top cards count: when a card with expand intent gets buried under

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -112,6 +112,11 @@ interface CardItem {
   useBaseTemplate?: boolean;
 }
 
+interface SerializedExpandedStackItem {
+  id: string;
+  stackIndex: number;
+}
+
 export type FileView = 'inspector' | 'browser';
 
 type SerializedItem = CardItem;
@@ -130,6 +135,7 @@ export type SerializedState = {
   moduleInspector?: ModuleInspectorView;
   cardPreviewFormat?: Format;
   workspaceChooserOpened?: boolean;
+  expandedStackItem?: SerializedExpandedStackItem;
 };
 
 interface OpenFileSubscriber {
@@ -174,8 +180,7 @@ export default class OperatorModeStateService extends Service {
   // user's expand intent survives bury/pop cycles within a stack:
   // when a card is pushed deeper, stack-item reads isTopCard=false
   // and renders normally; when it pops back to the top, the stored
-  // intent re-applies and the card re-expands. Only set/read when
-  // the card opts in via `prefersWideFormat`.
+  // intent re-applies and the card re-expands.
   private expandedStackItems: TrackedMap<string, boolean> = new TrackedMap();
   isStackItemExpanded(itemKey: string): boolean {
     return this.expandedStackItems.get(itemKey) ?? false;
@@ -189,6 +194,7 @@ export default class OperatorModeStateService extends Service {
     } else {
       this.expandedStackItems.delete(itemKey);
     }
+    this.schedulePersist();
   }
   // Drop ALL expand intents — called when a new card lands on any
   // stack so the expanded surface doesn't end up under the new card
@@ -196,6 +202,7 @@ export default class OperatorModeStateService extends Service {
   // background, see addItemToStack).
   clearAllStackItemExpanded() {
     this.expandedStackItems.clear();
+    this.schedulePersist();
   }
   // True when at least one stack's TOP card has expand intent — used
   // to drive the bar's glass-morphism + .has-expanded-card class. Only
@@ -331,6 +338,7 @@ export default class OperatorModeStateService extends Service {
     this.moduleInspectorHistory = {};
     this.profileSettingsOpen = false;
     this.createListingModalPayload = undefined;
+    this.expandedStackItems.clear();
     window.localStorage.removeItem(ModuleInspectorSelections);
     this.schedulePersist();
   }
@@ -1055,6 +1063,11 @@ export default class OperatorModeStateService extends Service {
       state.stacks.push(serializedStack);
     }
 
+    let expandedStackItem = this.serializedExpandedStackItem;
+    if (expandedStackItem) {
+      state.expandedStackItem = expandedStackItem;
+    }
+
     return state;
   }
 
@@ -1086,6 +1099,8 @@ export default class OperatorModeStateService extends Service {
   // Deserialize a stringified JSON version of OperatorModeState into a Glimmer tracked object
   // so that templates can react to changes in stacks and their items
   deserialize(rawState: SerializedState): OperatorModeState {
+    this.expandedStackItems.clear();
+
     let openDirs = new TrackedMap<string, string[]>(
       Object.entries(rawState.openDirs ?? {}).map(([realmURL, dirs]) => [
         realmURL,
@@ -1141,7 +1156,35 @@ export default class OperatorModeStateService extends Service {
       stackIndex++;
     }
 
+    let expandedStackItem = rawState.expandedStackItem;
+    if (expandedStackItem) {
+      let stack = newState.stacks[expandedStackItem.stackIndex];
+      let item = stack?.find(
+        (candidate) => candidate.id === expandedStackItem.id,
+      );
+      if (item) {
+        this.expandedStackItems.set(item.instanceId, true);
+      }
+    }
+
     return newState;
+  }
+
+  private get serializedExpandedStackItem():
+    | SerializedExpandedStackItem
+    | undefined {
+    for (let [stackIndex, stack] of this._state.stacks.entries()) {
+      for (let item of stack) {
+        if (item.id && this.expandedStackItems.has(item.instanceId)) {
+          return {
+            id: item.id,
+            stackIndex,
+          };
+        }
+      }
+    }
+
+    return undefined;
   }
 
   get openDirs() {

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -170,7 +170,7 @@ export default class OperatorModeStateService extends Service {
   @tracked profileSettingsOpen = false;
   @tracked createListingModalPayload?: CreateListingModalPayload;
 
-  // Per-card expanded-mode intent. Keyed by stack-item id so the
+  // Per-card expanded-mode intent. Keyed by stack-item instance id so the
   // user's expand intent survives bury/pop cycles within a stack:
   // when a card is pushed deeper, stack-item reads isTopCard=false
   // and renders normally; when it pops back to the top, the stored
@@ -182,6 +182,9 @@ export default class OperatorModeStateService extends Service {
   }
   setStackItemExpanded(itemKey: string, value: boolean) {
     if (value) {
+      // Only one card can be expanded at a time — clear all others so
+      // the same card open in two stacks can't leave both expanded.
+      this.expandedStackItems.clear();
       this.expandedStackItems.set(itemKey, true);
     } else {
       this.expandedStackItems.delete(itemKey);
@@ -208,7 +211,7 @@ export default class OperatorModeStateService extends Service {
     if (this.expandedStackItems.size === 0) return false;
     return this._state.stacks.some((stack) => {
       const top = stack[stack.length - 1];
-      return top && this.expandedStackItems.has(top.id);
+      return top && this.expandedStackItems.has(top.instanceId);
     });
   }
 

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -170,6 +170,56 @@ export default class OperatorModeStateService extends Service {
   @tracked profileSettingsOpen = false;
   @tracked createListingModalPayload?: CreateListingModalPayload;
 
+  // Per-card expanded-mode intent. Keyed by stack-item id so the
+  // user's expand intent survives bury/pop cycles within a stack:
+  // when a card is pushed deeper, stack-item reads isTopCard=false
+  // and renders normally; when it pops back to the top, the stored
+  // intent re-applies and the card re-expands. Only set/read when
+  // the card opts in via `prefersWideFormat`.
+  private expandedStackItems: TrackedMap<string, boolean> = new TrackedMap();
+  isStackItemExpanded(itemKey: string): boolean {
+    return this.expandedStackItems.get(itemKey) ?? false;
+  }
+  setStackItemExpanded(itemKey: string, value: boolean) {
+    if (value) {
+      this.expandedStackItems.set(itemKey, true);
+    } else {
+      this.expandedStackItems.delete(itemKey);
+    }
+  }
+  // Drop ALL expand intents — called when a new card lands on any
+  // stack so the expanded surface doesn't end up under the new card
+  // (which would otherwise overlap awkwardly on the workspace
+  // background, see addItemToStack).
+  clearAllStackItemExpanded() {
+    this.expandedStackItems.clear();
+  }
+  // True when at least one stack's TOP card has expand intent — used
+  // to drive the bar's glass-morphism + .has-expanded-card class. Only
+  // top cards count: when a card with expand intent gets buried under
+  // a new stack item, the intent is retained (so it auto-re-expands
+  // on return) but the bar should drop its frost so the new top card
+  // stacks normally without a frosted scrim. Same per-level: A
+  // expanded → push B → A buried + intent kept, frost off → B top
+  // (no intent yet) → expand B → frost on → push C → B buried +
+  // intent kept, frost off; close C → B top again, intent fires,
+  // frost back on; close B → A top again, intent fires, frost on.
+  get hasAnyStackItemExpanded(): boolean {
+    if (this.expandedStackItems.size === 0) return false;
+    return this._state.stacks.some((stack) => {
+      const top = stack[stack.length - 1];
+      return top && this.expandedStackItems.has(top.id);
+    });
+  }
+
+  // Slot in submode-layout's top bar where an EXPANDED stack item's
+  // CardHeader portals itself. Captured by submode-layout via
+  // captureElement modifier on insert. Stack-item reads this and uses
+  // {{#in-element}} to project its header pill into the bar when
+  // isExpanded — replacing the inline card header for the expanded
+  // mode only. When collapsed, the inline header reappears.
+  @tracked expandedCardHeaderElement: HTMLElement | null = null;
+
   @service declare private cardService: CardService;
   @service declare private codeSemanticsService: CodeSemanticsService;
   @service declare private errorDisplay: ErrorDisplayService;
@@ -299,6 +349,11 @@ export default class OperatorModeStateService extends Service {
       // this card to the top instead?)
       return;
     }
+    // Note: expand intent is retained on the buried card so that
+    // when the topping card closes and the previously-expanded card
+    // returns to top, it auto-re-expands. The visual collapse is
+    // already handled by isExpanded = isTopCard && isExpandedIntent
+    // — a buried card never renders as expanded.
     this._state.stacks[stackIndex].push(item);
     if (item.id) {
       this.recentCardsService.add(item.id);

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -912,7 +912,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     assert.dom('[data-test-llm-select-selected]').hasText(expectedName);
 
     // Switching submodes should not change the active LLM
-    await click('[data-test-submode-switcher] button');
+    await click('[data-test-submode-switcher-button]');
     await click('[data-test-boxel-menu-item-text="Code"]');
     assert.dom('[data-test-llm-select-selected]').hasText(expectedName);
 
@@ -1088,12 +1088,12 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     assert.dom('[data-test-autoattached-file]').doesNotExist();
     assert.dom('[data-test-autoattached-card]').exists();
     // Move to code mode and a file will be attached
-    await click('[data-test-submode-switcher] > [data-test-boxel-button]');
+    await click('[data-test-submode-switcher-button]');
     await click('[data-test-boxel-menu-item-text="Code"]');
     assert.dom('[data-test-autoattached-file]').exists();
     assert.dom('[data-test-autoattached-card]').exists();
     // Move back to interact mode and check the file is not attached
-    await click('[data-test-submode-switcher] > [data-test-boxel-button]');
+    await click('[data-test-submode-switcher-button]');
     await click('[data-test-boxel-menu-item-text="Interact"]');
     assert.dom('[data-test-autoattached-file]').doesNotExist();
     assert.dom('[data-test-autoattached-card]').exists();
@@ -1126,7 +1126,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     );
     assert.dom('[data-test-autoattached-file]').doesNotExist();
     assert.dom('[data-test-autoattached-card]').exists();
-    await click('[data-test-submode-switcher] > [data-test-boxel-button]');
+    await click('[data-test-submode-switcher-button]');
     await click('[data-test-boxel-menu-item-text="Code"]');
     assert.dom('[data-test-autoattached-file]').exists();
     assert.dom('[data-test-autoattached-card]').exists();
@@ -1533,7 +1533,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
 
     // In code mode, auto-attached card must be the playground panel card and the card of the opened file with json extension
     // unless the card is manually chosen
-    await click('[data-test-submode-switcher] > [data-test-boxel-button]');
+    await click('[data-test-submode-switcher-button]');
     await click('[data-test-boxel-menu-item-text="Code"]');
     assert
       .dom(

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -314,7 +314,7 @@ ${REPLACE_MARKER}\n\`\`\``;
     );
 
     // Switch to interact mode so we can test the open in code mode action
-    await click('[data-test-submode-switcher] > [data-test-boxel-button]');
+    await click('[data-test-submode-switcher-button]');
     await click('[data-test-boxel-menu-item-text="Interact"]');
     await click('[data-test-workspace-button="Test Workspace B"]');
     await waitFor('[data-test-submode-switcher="interact"]');
@@ -1091,7 +1091,7 @@ ${REPLACE_MARKER}
       );
 
     // Switch to interact mode so that we can test that "Open in Code Mode" works
-    await click('[data-test-submode-switcher] > [data-test-boxel-button]');
+    await click('[data-test-submode-switcher-button]');
     await click('[data-test-boxel-menu-item-text="Interact"]');
     await click('[data-test-workspace-button="Test Workspace B"]');
     await waitFor('[data-test-submode-switcher="interact"]');

--- a/packages/host/tests/acceptance/host-submode-test.gts
+++ b/packages/host/tests/acceptance/host-submode-test.gts
@@ -550,17 +550,17 @@ module('Acceptance | host submode', function (hooks) {
       assert.dom('[data-test-open-ai-assistant]').exists();
       assert.dom('[data-test-ai-assistant-panel]').exists();
 
-      await click('[data-test-submode-switcher] > [data-test-boxel-button]');
+      await click('[data-test-submode-switcher-button]');
       await click('[data-test-boxel-menu-item-text="Interact"]');
       assert.dom('[data-test-open-ai-assistant]').exists();
       assert.dom('[data-test-ai-assistant-panel]').exists();
 
-      await click('[data-test-submode-switcher] > [data-test-boxel-button]');
+      await click('[data-test-submode-switcher-button]');
       await click('[data-test-boxel-menu-item-text="Host"]');
       assert.dom('[data-test-open-ai-assistant]').doesNotExist();
       assert.dom('[data-test-ai-assistant-panel]').doesNotExist();
 
-      await click('[data-test-submode-switcher] > [data-test-boxel-button]');
+      await click('[data-test-submode-switcher-button]');
       await click('[data-test-boxel-menu-item-text="Code"]');
       assert.dom('[data-test-open-ai-assistant]').exists();
       assert.dom('[data-test-ai-assistant-panel]').exists();

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -7,6 +7,7 @@ import {
   typeIn,
   triggerKeyEvent,
   settled,
+  waitFor,
 } from '@ember/test-helpers';
 
 import { triggerEvent } from '@ember/test-helpers';
@@ -1035,6 +1036,78 @@ module('Acceptance | interact submode tests', function (hooks) {
           `[data-test-stack-card="${testRealmURL}Pet/mango"] [data-test-field="name"] input`,
         )
         .hasValue('Updated Pet');
+    });
+  });
+
+  module('expand to full width', function () {
+    test('expanding a card in a two-stack layout hides the other stack', async function (assert) {
+      let fadhlanId = `${testRealmURL}Person/fadhlan`;
+      let mangoId = `${testRealmURL}Pet/mango`;
+      await visitOperatorMode({
+        stacks: [
+          [{ id: fadhlanId, format: 'isolated' }],
+          [{ id: mangoId, format: 'isolated' }],
+        ],
+      });
+
+      assert
+        .dom('[data-test-operator-mode-stack="0"]')
+        .exists('stack 0 exists');
+      assert
+        .dom('[data-test-operator-mode-stack="1"]')
+        .exists('stack 1 exists');
+
+      await waitFor(
+        '[data-test-operator-mode-stack="0"] [data-test-more-options-button]',
+      );
+      await click(
+        '[data-test-operator-mode-stack="0"] [data-test-more-options-button]',
+      );
+      await click('[data-test-boxel-menu-item-text="Expand to full width"]');
+
+      assert
+        .dom(
+          `[data-test-operator-mode-stack="0"] [data-test-stack-card="${fadhlanId}"]`,
+        )
+        .hasClass('expanded', 'fadhlan card is expanded');
+      assert
+        .dom('[data-test-operator-mode-stack="1"]')
+        .isNotVisible('stack 1 is hidden when stack 0 has an expanded card');
+    });
+
+    test('expanding the same card open in two stacks only expands one', async function (assert) {
+      let fadhlanId = `${testRealmURL}Person/fadhlan`;
+      await visitOperatorMode({
+        stacks: [
+          [{ id: fadhlanId, format: 'isolated' }],
+          [{ id: fadhlanId, format: 'isolated' }],
+        ],
+      });
+
+      assert
+        .dom('[data-test-operator-mode-stack="0"]')
+        .exists('stack 0 exists');
+      assert
+        .dom('[data-test-operator-mode-stack="1"]')
+        .exists('stack 1 exists');
+
+      await waitFor(
+        '[data-test-operator-mode-stack="0"] [data-test-more-options-button]',
+      );
+      await click(
+        '[data-test-operator-mode-stack="0"] [data-test-more-options-button]',
+      );
+      await click('[data-test-boxel-menu-item-text="Expand to full width"]');
+
+      assert
+        .dom('[data-test-operator-mode-stack="0"] [data-test-stack-card]')
+        .hasClass('expanded', 'stack 0 card is expanded');
+      assert
+        .dom('[data-test-operator-mode-stack="1"]')
+        .isNotVisible('stack 1 is hidden');
+      assert
+        .dom('[data-test-stack-card].expanded')
+        .exists({ count: 1 }, 'only one card has the expanded class');
     });
   });
 

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -1063,7 +1063,7 @@ module('Acceptance | interact submode tests', function (hooks) {
       await click(
         '[data-test-operator-mode-stack="0"] [data-test-more-options-button]',
       );
-      await click('[data-test-boxel-menu-item-text="Expand to full width"]');
+      await click('[data-test-boxel-menu-item-text="Expand to Full Width"]');
 
       assert
         .dom(
@@ -1097,7 +1097,7 @@ module('Acceptance | interact submode tests', function (hooks) {
       await click(
         '[data-test-operator-mode-stack="0"] [data-test-more-options-button]',
       );
-      await click('[data-test-boxel-menu-item-text="Expand to full width"]');
+      await click('[data-test-boxel-menu-item-text="Expand to Full Width"]');
 
       assert
         .dom('[data-test-operator-mode-stack="0"] [data-test-stack-card]')

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -785,6 +785,44 @@ module('Integration | operator-mode | basics', function (hooks) {
     );
   });
 
+  module('expand to full width', function () {
+    test('can expand card to full width via more options menu and collapse via header button', async function (assert) {
+      let personCard = `${testRealmURL}Person/fadhlan`;
+      ctx.setCardInOperatorModeState(personCard);
+      await renderComponent(
+        class TestDriver extends GlimmerComponent {
+          <template><OperatorMode @onClose={{noop}} /></template>
+        },
+      );
+      await waitFor(`[data-test-stack-card="${personCard}"]`);
+      assert.dom('[data-test-expand-button]').doesNotExist();
+
+      await click('[data-test-more-options-button]');
+      await click('[data-test-boxel-menu-item-text="Expand to full width"]');
+      assert
+        .dom(`[data-test-stack-card="${personCard}"]`)
+        .hasClass('expanded', 'stack card has expanded class');
+
+      await click('[data-test-more-options-button]');
+      assert
+        .dom('[data-test-boxel-menu-item-text="Expand to full width"]')
+        .doesNotExist(
+          '"Expand to full width" is no longer in the menu after expansion',
+        );
+
+      await click('[data-test-expand-button="active"]');
+      assert
+        .dom(`[data-test-stack-card="${personCard}"]`)
+        .doesNotHaveClass(
+          'expanded',
+          'expanded class is removed after collapse',
+        );
+      assert
+        .dom('[data-test-expand-button]')
+        .doesNotExist('restore button is gone after collapse');
+    });
+  });
+
   test('can toggle isolated template in place when the stack stores a saved card by local id', async function (assert) {
     const cardId = `${testRealmURL}PublishingPacket/story`;
     const customIsolated = '[data-test-pubpacket-isolated]';

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -798,14 +798,14 @@ module('Integration | operator-mode | basics', function (hooks) {
       assert.dom('[data-test-expand-button]').doesNotExist();
 
       await click('[data-test-more-options-button]');
-      await click('[data-test-boxel-menu-item-text="Expand to full width"]');
+      await click('[data-test-boxel-menu-item-text="Expand to Full Width"]');
       assert
         .dom(`[data-test-stack-card="${personCard}"]`)
         .hasClass('expanded', 'stack card has expanded class');
 
       await click('[data-test-more-options-button]');
       assert
-        .dom('[data-test-boxel-menu-item-text="Expand to full width"]')
+        .dom('[data-test-boxel-menu-item-text="Expand to Full Width"]')
         .doesNotExist(
           '"Expand to full width" is no longer in the menu after expansion',
         );

--- a/packages/host/tests/integration/components/operator-mode-ui-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-ui-test.gts
@@ -186,14 +186,14 @@ module('Integration | operator-mode | ui', function (hooks) {
     assert.dom('[data-test-submode-switcher]').exists();
     assert.dom('[data-test-submode-switcher]').hasText('Interact');
 
-    await click('[data-test-submode-switcher] > [data-test-boxel-button]');
+    await click('[data-test-submode-switcher-button]');
 
     await click('[data-test-boxel-menu-item-text="Code"]');
     await waitFor('[data-test-submode-switcher]');
     assert.dom('[data-test-submode-switcher]').hasText('Code');
     assert.dom('[data-test-submode-arrow-direction="down"]').exists();
 
-    await click('[data-test-submode-switcher] > [data-test-boxel-button]');
+    await click('[data-test-submode-switcher-button]');
     await click('[data-test-boxel-menu-item-text="Interact"]');
     await waitFor('[data-test-submode-switcher]');
     assert.dom('[data-test-submode-switcher]').hasText('Interact');

--- a/packages/host/tests/unit/services/operator-mode-state-service-test.ts
+++ b/packages/host/tests/unit/services/operator-mode-state-service-test.ts
@@ -151,4 +151,34 @@ module('Unit | Service | operator-mode-state-service', function (hooks) {
       'after reset, panel respects persisted closed preference',
     );
   });
+
+  test('expanded stack item is serialized and restored', function (assert) {
+    let item = new StackItem({
+      id: 'https://example.com/cards/1',
+      format: 'isolated',
+      stackIndex: 0,
+    });
+
+    service.addItemToStack(item);
+    service.setStackItemExpanded(item.instanceId, true);
+
+    let rawState = JSON.parse(service.serialize());
+    assert.deepEqual(
+      rawState.expandedStackItem,
+      {
+        id: 'https://example.com/cards/1',
+        stackIndex: 0,
+      },
+      'expanded item identity is included in serialized state',
+    );
+
+    service.resetState();
+    service.restore(rawState);
+
+    let restoredItem = service.state.stacks[0][0];
+    assert.true(
+      service.isStackItemExpanded(restoredItem.instanceId),
+      'expanded state is restored onto the rebuilt stack item',
+    );
+  });
 });

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -292,7 +292,7 @@ test.describe('Room messages', () => {
     const testCard = `${appURL}/hassan`;
     await page.locator(`[data-test-cards-grid-item="${testCard}"]`).click();
     await page
-      .locator(`[data-test-submode-switcher] > [data-test-boxel-button]`)
+      .locator(`[data-test-submode-switcher-button]`)
       .click();
     await page.locator(`[data-test-boxel-menu-item-text="Code"]`).click();
 
@@ -353,7 +353,7 @@ test.describe('Room messages', () => {
       page.locator(`[data-test-attached-card="${appURL}/hassan"]`),
     ).toHaveCount(1);
     await page
-      .locator(`[data-test-submode-switcher] > [data-test-boxel-button]`)
+      .locator(`[data-test-submode-switcher-button]`)
       .click();
     await page.locator(`[data-test-boxel-menu-item-text="Code"]`).click();
 


### PR DESCRIPTION
Demo: https://screen.studio/share/zXdc2bHg

Adds an "expand" toggle on the top stack-item's CardHeader that morphs the card to full width below a floating top bar. The bar gains glass- morphism while expanded and the CardHeader portals into a center pill in the bar (replacing the inline header). View-transition pins the bar across the morph so the expand/collapse animates as a single shape.

Positioning is driven by a single CSS variable, --stack-padding-top (item-height + 2 × spacing), shared by:
  * .submode-layout-top-bar height (locked, so portaled content can't push it taller)
  * .operator-mode-stack padding-top when an item is expanded (forced full value, overriding stack-medium/small-padding-top reductions that are correct for the buried-stack visual but not when expanded)
  * .item.expanded inset: 0 of .inner (which sits at y=stack-padding-top)

Result: card top sits flush at bar bottom — pixel-identical to host-mode's in-flow card top. No calc(100vh - X), no JS measurement, no !important.

Buried siblings fade when a top card is expanded; neighbor-stack-trigger arrows hide; cards-grid (Workspace "All Cards") opts out of expand since its child tile overlays would overlap. Per-card expand intent persists on operatorModeStateService (keyed by stack-item id) so it survives buries and restores when the card pops back to the top.
