### PR TITLE
CS-11011: Stop blocking realm writes on queued from-scratch index

### DIFF
--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1647,7 +1647,7 @@ module(basename(__filename), function () {
         }
       });
 
-      test('realm.indexing waits for queued incremental operations', async function (assert) {
+      test('realm.indexing waits for all queued indexing operations', async function (assert) {
         let { blocker, release } = await startIndexingGroupBlocker();
         try {
           let incremental = realm.realmIndexUpdater.update(
@@ -1655,38 +1655,53 @@ module(basename(__filename), function () {
             { clientRequestId: 'indexing-race-incremental' },
           );
           let indexingDuringIncremental = realm.indexing();
+          let full = realm.realmIndexUpdater.fullIndex();
+          let indexingAfterFull = realm.indexing();
           let indexingDuringIncrementalResolved = false;
+          let indexingAfterFullResolved = false;
           indexingDuringIncremental?.then(() => {
             indexingDuringIncrementalResolved = true;
+          });
+          indexingAfterFull?.then(() => {
+            indexingAfterFullResolved = true;
           });
 
           assert.ok(
             indexingDuringIncremental,
-            'indexing promise is exposed for a queued incremental',
+            'indexing promise is exposed for the first queued operation',
+          );
+          assert.ok(
+            indexingAfterFull,
+            'indexing promise is exposed for the later queued operation',
           );
 
           release.fulfill();
           await Promise.all([
             blocker.done,
             incremental,
+            full,
             indexingDuringIncremental,
+            indexingAfterFull,
           ]);
           assert.true(
             indexingDuringIncrementalResolved,
-            'indexing promise resolves once the queued incremental completes',
+            'indexing promise captured before a later queued operation still resolves',
+          );
+          assert.true(
+            indexingAfterFullResolved,
+            'indexing promise captured after the later queued operation resolves too',
           );
         } finally {
           release.fulfill();
         }
       });
 
-      test('realm.indexing does not block on a queued from-scratch job', async function (assert) {
-        // Regression: a from-scratch job sitting in the queue (e.g. behind a
-        // system-wide reindex storm) must not block the realm write-path
-        // gate. The gate exists to serialize file writes with concurrent
-        // *incremental* indexing of the same instance — a bounded ~1-2s
-        // window. From-scratch has no such race and can be queued for hours,
-        // so registering it would stall every PATCH.
+      test('realm.incrementalIndexing does not block on a queued from-scratch job', async function (assert) {
+        // Regression: the realm write-path gate uses incrementalIndexing(),
+        // not indexing(). A from-scratch job sitting in the queue (e.g.
+        // behind a system-wide reindex storm) must not block PATCHes — it
+        // has no file/index race with realm-server writes, and can be queued
+        // for hours.
         let { blocker, release } = await startIndexingGroupBlocker();
         try {
           let full = realm.realmIndexUpdater.fullIndex();
@@ -1710,10 +1725,14 @@ module(basename(__filename), function () {
             },
           );
 
-          assert.strictEqual(
+          assert.ok(
             realm.realmIndexUpdater.indexing(),
+            'indexing() still tracks the queued from-scratch (callers wanting "all settled" semantics rely on this)',
+          );
+          assert.strictEqual(
+            realm.realmIndexUpdater.incrementalIndexing(),
             undefined,
-            'indexing() returns undefined while only a from-scratch job is queued',
+            'incrementalIndexing() returns undefined while only a from-scratch job is queued',
           );
 
           release.fulfill();
@@ -1723,7 +1742,7 @@ module(basename(__filename), function () {
         }
       });
 
-      test('realm.indexing tracks only the incremental when both incremental and from-scratch are queued', async function (assert) {
+      test('realm.incrementalIndexing tracks only the incremental when both incremental and from-scratch are queued', async function (assert) {
         let { blocker, release } = await startIndexingGroupBlocker();
         try {
           let incremental = realm.realmIndexUpdater.update(
@@ -1753,22 +1772,22 @@ module(basename(__filename), function () {
             },
           );
 
-          let indexingPromise = realm.realmIndexUpdater.indexing();
+          let incrementalGate = realm.realmIndexUpdater.incrementalIndexing();
           assert.ok(
-            indexingPromise,
-            'indexing() exposes a promise driven by the incremental',
+            incrementalGate,
+            'incrementalIndexing() exposes a promise driven by the incremental',
           );
 
           release.fulfill();
-          await Promise.all([blocker.done, incremental, indexingPromise]);
+          await Promise.all([blocker.done, incremental, incrementalGate]);
 
-          // After the incremental drains the from-scratch may still be
-          // running; indexing() should already be resolved (gated only on the
-          // incremental).
+          // After the incremental drains, the from-scratch may still be
+          // running; incrementalIndexing() should already be resolved while
+          // indexing() continues to track the from-scratch.
           assert.strictEqual(
-            realm.realmIndexUpdater.indexing(),
+            realm.realmIndexUpdater.incrementalIndexing(),
             undefined,
-            'indexing() returns undefined after the incremental drains, regardless of from-scratch state',
+            'incrementalIndexing() returns undefined after the incremental drains, regardless of from-scratch state',
           );
 
           await full;

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1647,7 +1647,7 @@ module(basename(__filename), function () {
         }
       });
 
-      test('realm.indexing waits for all queued indexing operations', async function (assert) {
+      test('realm.indexing waits for queued incremental operations', async function (assert) {
         let { blocker, release } = await startIndexingGroupBlocker();
         try {
           let incremental = realm.realmIndexUpdater.update(
@@ -1655,42 +1655,123 @@ module(basename(__filename), function () {
             { clientRequestId: 'indexing-race-incremental' },
           );
           let indexingDuringIncremental = realm.indexing();
-          let full = realm.realmIndexUpdater.fullIndex();
-          let indexingAfterFull = realm.indexing();
           let indexingDuringIncrementalResolved = false;
-          let indexingAfterFullResolved = false;
           indexingDuringIncremental?.then(() => {
             indexingDuringIncrementalResolved = true;
-          });
-          indexingAfterFull?.then(() => {
-            indexingAfterFullResolved = true;
           });
 
           assert.ok(
             indexingDuringIncremental,
-            'indexing promise is exposed for the first queued operation',
-          );
-          assert.ok(
-            indexingAfterFull,
-            'indexing promise is exposed for the later queued operation',
+            'indexing promise is exposed for a queued incremental',
           );
 
           release.fulfill();
           await Promise.all([
             blocker.done,
             incremental,
-            full,
             indexingDuringIncremental,
-            indexingAfterFull,
           ]);
           assert.true(
             indexingDuringIncrementalResolved,
-            'indexing promise captured before a later queued operation still resolves',
+            'indexing promise resolves once the queued incremental completes',
           );
-          assert.true(
-            indexingAfterFullResolved,
-            'indexing promise captured after the later queued operation resolves too',
+        } finally {
+          release.fulfill();
+        }
+      });
+
+      test('realm.indexing does not block on a queued from-scratch job', async function (assert) {
+        // Regression: a from-scratch job sitting in the queue (e.g. behind a
+        // system-wide reindex storm) must not block the realm write-path
+        // gate. The gate exists to serialize file writes with concurrent
+        // *incremental* indexing of the same instance — a bounded ~1-2s
+        // window. From-scratch has no such race and can be queued for hours,
+        // so registering it would stall every PATCH.
+        let { blocker, release } = await startIndexingGroupBlocker();
+        try {
+          let full = realm.realmIndexUpdater.fullIndex();
+
+          await waitUntil(
+            async () => {
+              let rows = (await testDbAdapter.execute(
+                `SELECT id
+               FROM jobs
+               WHERE concurrency_group = $1
+                 AND status = 'unfulfilled'
+                 AND job_type = 'from-scratch-index'`,
+                { bind: [`indexing:${realm.url}`] },
+              )) as { id: number }[];
+              return rows.length === 1 ? rows[0] : undefined;
+            },
+            {
+              timeout: 3000,
+              interval: 50,
+              timeoutMessage: 'expected one pending from-scratch job',
+            },
           );
+
+          assert.strictEqual(
+            realm.realmIndexUpdater.indexing(),
+            undefined,
+            'indexing() returns undefined while only a from-scratch job is queued',
+          );
+
+          release.fulfill();
+          await Promise.all([blocker.done, full]);
+        } finally {
+          release.fulfill();
+        }
+      });
+
+      test('realm.indexing tracks only the incremental when both incremental and from-scratch are queued', async function (assert) {
+        let { blocker, release } = await startIndexingGroupBlocker();
+        try {
+          let incremental = realm.realmIndexUpdater.update(
+            [new URL(`${testRealm}mango`)],
+            { clientRequestId: 'indexing-mixed-incremental' },
+          );
+          let full = realm.realmIndexUpdater.fullIndex();
+
+          // Wait until both jobs are pending so the queue state is stable.
+          await waitUntil(
+            async () => {
+              let rows = (await testDbAdapter.execute(
+                `SELECT job_type
+               FROM jobs
+               WHERE concurrency_group = $1
+                 AND status = 'unfulfilled'
+                 AND job_type IN ('incremental-index', 'from-scratch-index')`,
+                { bind: [`indexing:${realm.url}`] },
+              )) as { job_type: string }[];
+              return rows.length === 2 ? rows : undefined;
+            },
+            {
+              timeout: 3000,
+              interval: 50,
+              timeoutMessage:
+                'expected one pending incremental and one pending from-scratch',
+            },
+          );
+
+          let indexingPromise = realm.realmIndexUpdater.indexing();
+          assert.ok(
+            indexingPromise,
+            'indexing() exposes a promise driven by the incremental',
+          );
+
+          release.fulfill();
+          await Promise.all([blocker.done, incremental, indexingPromise]);
+
+          // After the incremental drains the from-scratch may still be
+          // running; indexing() should already be resolved (gated only on the
+          // incremental).
+          assert.strictEqual(
+            realm.realmIndexUpdater.indexing(),
+            undefined,
+            'indexing() returns undefined after the incremental drains, regardless of from-scratch state',
+          );
+
+          await full;
         } finally {
           release.fulfill();
         }

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -28,6 +28,14 @@ export class RealmIndexUpdater {
   #realm: Realm;
   #log = logger('realm-index-updater');
   #ignoreData: Record<string, string> = {};
+  // Bumped every time a from-scratch result writes #ignoreData. Concurrent
+  // incrementals capture this version when they snapshot #ignoreData; if a
+  // from-scratch lands between snapshot and incremental completion, the
+  // incremental's stale result is dropped on the floor instead of clobbering
+  // the fresher data. This is reachable now that incrementals can be queued
+  // alongside an in-flight from-scratch (the write-path gate only awaits
+  // incremental + copy jobs, not from-scratch).
+  #ignoreDataVersion = 0;
   #stats: Stats = {
     instancesIndexed: 0,
     filesIndexed: 0,
@@ -38,7 +46,13 @@ export class RealmIndexUpdater {
   #indexWriter: IndexWriter;
   #dbAdapter: DBAdapter;
   #queue: QueuePublisher;
-  #indexingDeferreds = new Set<Deferred<void>>();
+  // Tracked separately so the realm write-path can wait only for incremental
+  // (and copy) jobs — the ones whose race against concurrent file writes the
+  // gate exists to serialize. From-scratch jobs are tracked too, but only so
+  // that callers wanting "all indexing has settled" semantics (e.g. publish)
+  // continue to see them via `indexing()`.
+  #incrementalIndexingDeferreds = new Set<Deferred<void>>();
+  #fullIndexingDeferreds = new Set<Deferred<void>>();
 
   constructor({
     realm,
@@ -81,12 +95,38 @@ export class RealmIndexUpdater {
     return await this.#indexWriter.isNewIndex(this.realmURL);
   }
 
+  // Awaits every queued/in-flight indexing job — incremental, copy, and
+  // from-scratch. Use this when you genuinely need all indexing to settle
+  // (e.g. before publishing a realm). For the realm write-path gate use
+  // `incrementalIndexing()` instead: blocking writes on from-scratch is
+  // unsafe under reindex storms (a queued from-scratch can sit behind
+  // hundreds of jobs and stall every PATCH for hours).
   indexing() {
-    if (this.#indexingDeferreds.size === 0) {
+    let pending = [
+      ...this.#incrementalIndexingDeferreds,
+      ...this.#fullIndexingDeferreds,
+    ];
+    if (pending.length === 0) {
+      return undefined;
+    }
+    return Promise.all(pending.map((deferred) => deferred.promise)).then(
+      () => undefined,
+    );
+  }
+
+  // Awaits only incremental and copy jobs — the ones whose file/index race
+  // the write-path gate exists to serialize. From-scratch jobs are excluded
+  // because workers read files independently of realm-server writes and each
+  // row write is atomic; a from-scratch sitting queued behind a system-wide
+  // reindex must not block user PATCHes.
+  incrementalIndexing() {
+    if (this.#incrementalIndexingDeferreds.size === 0) {
       return undefined;
     }
     return Promise.all(
-      [...this.#indexingDeferreds].map((deferred) => deferred.promise),
+      [...this.#incrementalIndexingDeferreds].map(
+        (deferred) => deferred.promise,
+      ),
     ).then(() => undefined);
   }
 
@@ -97,13 +137,8 @@ export class RealmIndexUpdater {
     published: Promise<Job<FromScratchResult>>;
     completed: Promise<FromScratchResult>;
   } {
-    // From-scratch jobs intentionally do NOT register in #indexingDeferreds.
-    // The realm write-path gate (`await realm.indexing()` in _batchWrite)
-    // serializes file writes with concurrent *incremental* indexing for the
-    // same instance, a bounded ~1-2s window. From-scratch has no such race —
-    // workers read files independently and each row write is atomic — but it
-    // can sit queued for hours behind a system-wide reindex, so registering
-    // here would block user PATCHes indefinitely.
+    let indexingDeferred = new Deferred<void>();
+    this.#fullIndexingDeferreds.add(indexingDeferred);
     let startedAt = performance.now();
 
     this.#log.info(`Realm ${this.realmURL.href} is starting indexing`);
@@ -119,24 +154,30 @@ export class RealmIndexUpdater {
         },
       ))();
 
-    let completed = published.then(async (job) => {
-      let result = await job.done;
-      let { ignoreData, stats } = result;
-      this.#stats = stats;
-      this.#ignoreData = ignoreData;
-      let indexingDurationSeconds = (
-        (performance.now() - startedAt) /
-        1000
-      ).toFixed(2);
-      this.#log.info(
-        `Realm ${this.realmURL.href} has completed indexing in ${indexingDurationSeconds}s: ${JSON.stringify(
-          stats,
-          null,
-          2,
-        )}`,
-      );
-      return result;
-    });
+    let completed = published
+      .then(async (job) => {
+        let result = await job.done;
+        let { ignoreData, stats } = result;
+        this.#stats = stats;
+        this.#ignoreData = ignoreData;
+        this.#ignoreDataVersion++;
+        let indexingDurationSeconds = (
+          (performance.now() - startedAt) /
+          1000
+        ).toFixed(2);
+        this.#log.info(
+          `Realm ${this.realmURL.href} has completed indexing in ${indexingDurationSeconds}s: ${JSON.stringify(
+            stats,
+            null,
+            2,
+          )}`,
+        );
+        return result;
+      })
+      .finally(() => {
+        indexingDeferred.fulfill();
+        this.#fullIndexingDeferreds.delete(indexingDeferred);
+      });
 
     return {
       published,
@@ -164,7 +205,8 @@ export class RealmIndexUpdater {
     },
   ): Promise<void> {
     let indexingDeferred = new Deferred<void>();
-    this.#indexingDeferreds.add(indexingDeferred);
+    this.#incrementalIndexingDeferreds.add(indexingDeferred);
+    let snapshotVersion = this.#ignoreDataVersion;
     try {
       let args: IncrementalIndexEnqueueArgs = {
         changes: urls.map((url) => ({
@@ -186,7 +228,12 @@ export class RealmIndexUpdater {
       });
       let { invalidations, ignoreData, stats } = await job.done;
       this.#stats = stats;
-      this.#ignoreData = ignoreData;
+      // Drop the result if a from-scratch index landed since we snapshotted.
+      // Its ignoreData was computed from a stale snapshot and would clobber
+      // the fresher full-index data.
+      if (snapshotVersion === this.#ignoreDataVersion) {
+        this.#ignoreData = ignoreData;
+      }
       if (opts?.onInvalidation) {
         await opts.onInvalidation(
           invalidations.map((href) => new URL(href.replace(/\.json$/, ''))),
@@ -197,7 +244,7 @@ export class RealmIndexUpdater {
       throw e;
     } finally {
       indexingDeferred.fulfill();
-      this.#indexingDeferreds.delete(indexingDeferred);
+      this.#incrementalIndexingDeferreds.delete(indexingDeferred);
     }
   }
 
@@ -206,7 +253,7 @@ export class RealmIndexUpdater {
     onInvalidation?: (invalidatedURLs: URL[]) => Promise<void>,
   ): Promise<void> {
     let indexingDeferred = new Deferred<void>();
-    this.#indexingDeferreds.add(indexingDeferred);
+    this.#incrementalIndexingDeferreds.add(indexingDeferred);
     try {
       let args: CopyArgs = {
         realmURL: this.#realm.url,
@@ -231,7 +278,7 @@ export class RealmIndexUpdater {
       throw e;
     } finally {
       indexingDeferred.fulfill();
-      this.#indexingDeferreds.delete(indexingDeferred);
+      this.#incrementalIndexingDeferreds.delete(indexingDeferred);
     }
   }
 

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -97,8 +97,13 @@ export class RealmIndexUpdater {
     published: Promise<Job<FromScratchResult>>;
     completed: Promise<FromScratchResult>;
   } {
-    let indexingDeferred = new Deferred<void>();
-    this.#indexingDeferreds.add(indexingDeferred);
+    // From-scratch jobs intentionally do NOT register in #indexingDeferreds.
+    // The realm write-path gate (`await realm.indexing()` in _batchWrite)
+    // serializes file writes with concurrent *incremental* indexing for the
+    // same instance, a bounded ~1-2s window. From-scratch has no such race —
+    // workers read files independently and each row write is atomic — but it
+    // can sit queued for hours behind a system-wide reindex, so registering
+    // here would block user PATCHes indefinitely.
     let startedAt = performance.now();
 
     this.#log.info(`Realm ${this.realmURL.href} is starting indexing`);
@@ -114,29 +119,24 @@ export class RealmIndexUpdater {
         },
       ))();
 
-    let completed = published
-      .then(async (job) => {
-        let result = await job.done;
-        let { ignoreData, stats } = result;
-        this.#stats = stats;
-        this.#ignoreData = ignoreData;
-        let indexingDurationSeconds = (
-          (performance.now() - startedAt) /
-          1000
-        ).toFixed(2);
-        this.#log.info(
-          `Realm ${this.realmURL.href} has completed indexing in ${indexingDurationSeconds}s: ${JSON.stringify(
-            stats,
-            null,
-            2,
-          )}`,
-        );
-        return result;
-      })
-      .finally(() => {
-        indexingDeferred.fulfill();
-        this.#indexingDeferreds.delete(indexingDeferred);
-      });
+    let completed = published.then(async (job) => {
+      let result = await job.done;
+      let { ignoreData, stats } = result;
+      this.#stats = stats;
+      this.#ignoreData = ignoreData;
+      let indexingDurationSeconds = (
+        (performance.now() - startedAt) /
+        1000
+      ).toFixed(2);
+      this.#log.info(
+        `Realm ${this.realmURL.href} has completed indexing in ${indexingDurationSeconds}s: ${JSON.stringify(
+          stats,
+          null,
+          2,
+        )}`,
+      );
+      return result;
+    });
 
     return {
       published,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -835,6 +835,10 @@ export class Realm {
     return this.#realmIndexUpdater.indexing();
   }
 
+  async incrementalIndexing() {
+    return this.#realmIndexUpdater.incrementalIndexing();
+  }
+
   private startReindex(opts?: {
     clearLastModified?: boolean;
     priority?: number;
@@ -1159,7 +1163,7 @@ export class Realm {
     files: Map<LocalPath, string | Uint8Array>,
     options?: WriteOptions,
   ): Promise<FileWriteResult[]> {
-    await this.indexing();
+    await this.incrementalIndexing();
     let urls: URL[] = [];
     // Collect write results for all files we wrote
     let results: { path: LocalPath; lastModified: number }[] = [];


### PR DESCRIPTION
## Summary
- During a system-wide reindex storm, every user PATCH against an affected realm blocked indefinitely (then 502'd through the ALB) because the realm write-path gate (`await realm.indexing()` in `_batchWrite`) was waiting on the `Deferred` registered by `publishFullIndex` at enqueue time. With ~200 jobs ahead of it, that `Deferred` doesn't fulfill for hours.
- The gate exists to serialize file writes against concurrent **incremental** indexing for the same instance — a bounded ~1-2s race. From-scratch has no such race: workers read files independently from the realm-server's writes, and each row write is atomic.
- Drop the `#indexingDeferreds` registration from `publishFullIndex`. Keep it for `update()` and `copy()` where the per-instance race is real. After the change, a PATCH against a realm with a queued/in-flight from-scratch returns at normal latency, queues a priority-10 incremental, and the from-scratch + incremental sort themselves out by job priority.

See the linked Linear ticket for the full incident timeline (staging 2026-05-04, hassan01/test-1 reindex storm).

## Test plan
- [x] `pnpm lint` passes for `packages/runtime-common` and `packages/realm-server`
- [x] `pnpm test --filter "realm.indexing"` — 3/3 pass (rewritten incremental-only test + 2 new regression tests)
- [x] `pnpm test --filter "indexing-test.ts"` — 54/55 pass (the 1 failure is `EADDRINUSE :::4447` from leftover services on the local box, unrelated)
- [ ] CI green
- [ ] Manual verification on staging: reproduce the reindex-storm scenario (queue a system-priority full reindex on a realm with backlog, then PATCH a card from the host) and confirm the PATCH returns within normal latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)