### PR TITLE
ci-host: reject Percy build when a host-test shard fails

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -322,7 +322,7 @@ jobs:
       - name: Finalise Percy
         id: finalize
         run: |
-          set -e
+          set -eo pipefail
           npx percy build:finalize 2>&1 | tee /tmp/percy-finalize.log
           BUILD_URL=$(grep -oE 'https://percy\.io/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+/builds/[0-9]+' /tmp/percy-finalize.log | tail -1)
           BUILD_ID="${BUILD_URL##*/}"

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -36,6 +36,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # TEMPORARY (PR #4638): force Percy on so the reject-on-failure
+          # step has a real build to reject. Remove this block before merge.
+          echo "percy_needed=true" >> "$GITHUB_OUTPUT"
+          echo "TEMP: Forcing Percy on for reject-on-failure verification"
+          exit 0
+
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
             echo "percy_needed=true" >> "$GITHUB_OUTPUT"
             echo "Not a pull request — Percy will always run"
@@ -210,6 +216,15 @@ jobs:
           HOST_TEST_PARTITION_COUNT: ${{ matrix.shardTotal }}
           DBUS_SYSTEM_BUS_ADDRESS: unix:path=/run/dbus/system_bus_socket
         working-directory: packages/host
+
+      # TEMPORARY (PR #4638): deliberately fail shard 1 after Percy has
+      # already received its snapshots, so the reject-on-failure step in
+      # host-percy-finalize has something to reject. Remove before merge.
+      - name: TEMP — force shard 1 failure to exercise Percy reject path
+        if: matrix.shardIndex == 1
+        run: |
+          echo "::warning::TEMP: failing shard 1 deliberately to verify the percy build:reject step"
+          exit 1
 
       - name: Upload junit report to GitHub Actions Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -320,11 +320,33 @@ jobs:
       - uses: ./.github/actions/init
 
       - name: Finalise Percy
-        run: npx percy build:finalize
+        id: finalize
+        run: |
+          set -e
+          npx percy build:finalize 2>&1 | tee /tmp/percy-finalize.log
+          BUILD_URL=$(grep -oE 'https://percy\.io/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+/builds/[0-9]+' /tmp/percy-finalize.log | tail -1)
+          BUILD_ID="${BUILD_URL##*/}"
+          echo "build_id=$BUILD_ID" >> "$GITHUB_OUTPUT"
+          echo "build_url=$BUILD_URL" >> "$GITHUB_OUTPUT"
         working-directory: packages/host
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_HOST }}
           PERCY_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
+
+      # Auto-approve is enabled on `main`, so a Percy build that finalises
+      # without the snapshots from a failed shard would otherwise lock in a
+      # partial baseline — and the next clean build would surface the missing
+      # snapshots as "new" diffs on PRs. Reject the build when any shard
+      # didn't succeed so it can't become a baseline.
+      - name: Reject Percy build when any host shard failed
+        if: needs.host-test.result != 'success' && steps.finalize.outputs.build_id != ''
+        run: |
+          set -e
+          npx percy build:reject "${{ steps.finalize.outputs.build_id }}"
+          echo "::warning::Rejected Percy build ${{ steps.finalize.outputs.build_url }} because at least one host-test shard did not succeed (host-test result: ${{ needs.host-test.result }}). Partial baselines would otherwise have been auto-approved on main."
+        working-directory: packages/host
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_HOST }}
 
   host-merge-reports-and-publish:
     name: Merge Host reports and publish

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -339,10 +339,18 @@ jobs:
         run: |
           set -eo pipefail
           npx percy build:finalize 2>&1 | tee /tmp/percy-finalize.log
-          BUILD_URL=$(grep -oE 'https://percy\.io/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+/builds/[0-9]+' /tmp/percy-finalize.log | tail -1)
+          # Percy URLs look like https://percy.io/<org>/<product>/<project>/builds/<id>
+          # — three path segments before /builds. Allow 1–3 to be defensive
+          # against future structure changes, and tolerate no-match so a
+          # parse failure here doesn't sink the whole step (the reject step
+          # is gated on a non-empty build_id anyway).
+          BUILD_URL=$(grep -oE 'https://percy\.io/[A-Za-z0-9_-]+(/[A-Za-z0-9_-]+){1,3}/builds/[0-9]+' /tmp/percy-finalize.log | tail -1) || true
           BUILD_ID="${BUILD_URL##*/}"
           echo "build_id=$BUILD_ID" >> "$GITHUB_OUTPUT"
           echo "build_url=$BUILD_URL" >> "$GITHUB_OUTPUT"
+          if [ -z "$BUILD_ID" ]; then
+            echo "::warning::Could not parse Percy build ID from finalize output; reject step will be skipped."
+          fi
         working-directory: packages/host
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_HOST }}


### PR DESCRIPTION
## Summary

Percy auto-approve is enabled on `main`, so a build that finalises without the snapshots from a crashed shard would otherwise lock in a partial baseline — and the next clean build would surface those missing snapshots as "new" diffs on PRs. Host shards do crash periodically (OOM, ChunkLoadError before the retry catches it, etc.), so this is a real source of noise now that the branch filter matches.

Capture the build URL/ID from `percy build:finalize`, and follow up with `percy build:reject <id>` whenever `needs.host-test.result` is anything other than `success`. The reject step is gated on finalize having actually emitted a build URL so we don't try to reject an empty string when finalize itself fails.

Follow-up to #4518 (CS-10954).

## Verification I'd appreciate

- I parsed the build ID from `percy build:finalize` stdout via grep — if Percy CLI changes its log format this becomes brittle. There's no documented "give me the build ID" flag on `build:finalize`. An alternative would be querying `GET /api/v1/builds?filter[parallel_nonce]=...` but that endpoint isn't documented either. Open to a cleaner discovery path.
- `percy build:reject` exists in `@percy/cli` (verified via `--help`) but I haven't manually tested whether it reliably prevents auto-approve. If it doesn't, `build:delete` is a more aggressive alternative.

## Test plan

- [ ] Confirm the workflow still finalises Percy normally on a clean run (open this PR, watch CI)
- [ ] Manually force a shard failure (or wait for one to happen organically) and verify the reject step fires + the build is marked rejected in the Percy UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)