### PR TITLE
CS-11015: route loader retry sleep through native setTimeout during prerender

### DIFF
--- a/packages/host/app/services/loader-service.ts
+++ b/packages/host/app/services/loader-service.ts
@@ -22,6 +22,7 @@ import { clearKnownFileMetaUrls } from '@cardstack/host/components/prerendered-c
 import config from '@cardstack/host/config/environment';
 
 import { authErrorEventMiddleware } from '../utils/auth-error-guard';
+import { scheduleNativeTimeout } from '../utils/render-timer-stub';
 
 import type NetworkService from './network';
 import type RealmService from './realm';
@@ -118,7 +119,16 @@ export default class LoaderService extends Service {
     middlewareStack.push(authorizationMiddleware(this.realm));
     middlewareStack.push(authErrorEventMiddleware());
     let fetch = fetcher(this.network.fetch, middlewareStack);
-    let loader = new Loader(fetch, this.network.resolveImport);
+    let loader = new Loader(fetch, this.network.resolveImport, {
+      // Route the loader's transient-5xx retry backoff sleep through
+      // scheduleNativeTimeout so it bypasses the render-timer-stub during
+      // prerender. Outside prerender this falls back to the native
+      // setTimeout, so behavior is unchanged in the host runtime.
+      retrySleep: (ms) =>
+        new Promise<void>((resolve) =>
+          scheduleNativeTimeout(() => resolve(), ms),
+        ),
+    });
     return loader;
   }
 

--- a/packages/host/tests/unit/render-timer-stub-test.ts
+++ b/packages/host/tests/unit/render-timer-stub-test.ts
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import {
   enableRenderTimerStub,
   beginTimerBlock,
+  scheduleNativeTimeout,
 } from '@cardstack/host/utils/render-timer-stub';
 
 module('Unit | Utils | render timer stub', function () {
@@ -68,6 +69,43 @@ module('Unit | Utils | render timer stub', function () {
         postBlockTimerFired,
         'timer created after block runs normally',
       );
+    } finally {
+      restoreStub();
+    }
+  });
+
+  test('scheduleNativeTimeout resolves a sleep promise while timers are blocked', async function (assert) {
+    // The loader's transient-5xx retry uses an injected sleep that goes
+    // through scheduleNativeTimeout so the retry actually fires during
+    // prerender. Without this bypass, `setTimeout(resolve, ms)` would be
+    // silently swallowed by the stub and the awaited promise would never
+    // resolve, hanging the render until the prerender timeout.
+    assert.expect(2);
+    let restoreStub = enableRenderTimerStub();
+    try {
+      let releaseBlock = beginTimerBlock();
+      try {
+        let stubbedSleepFired = false;
+        window.setTimeout(() => {
+          stubbedSleepFired = true;
+        }, 0);
+
+        let resolved = false;
+        await new Promise<void>((resolve) =>
+          scheduleNativeTimeout(() => {
+            resolved = true;
+            resolve();
+          }, 5),
+        );
+
+        assert.true(resolved, 'native-scheduled sleep promise resolved');
+        assert.false(
+          stubbedSleepFired,
+          'a setTimeout callback scheduled while blocked still does not fire',
+        );
+      } finally {
+        releaseBlock();
+      }
     } finally {
       restoreStub();
     }

--- a/packages/realm-server/tests/helpers/prerender-page-patches.ts
+++ b/packages/realm-server/tests/helpers/prerender-page-patches.ts
@@ -279,14 +279,12 @@ export function installFlakyDepFetchPatch(opts: {
     let page = pageInfo.page as any;
     if (page && !patchedPages.has(page)) {
       patchedPages.add(page);
-      try {
-        await page.setRequestInterception(true);
-        interceptingPages.add(page);
-      } catch {
-        // Best-effort: if interception is already active or the page has
-        // been torn down, skip — the test will surface the failure via
-        // missing failuresInjected count rather than as a setup error.
-      }
+      // Fail fast: request.respond()/request.continue() require interception
+      // to be enabled, so attaching the listener without interception would
+      // turn into a confusing error mid-render. Let the puppeteer error
+      // propagate so the test crashes at setup with a clear stack instead.
+      await page.setRequestInterception(true);
+      interceptingPages.add(page);
       let listener = (request: any) => {
         let url: string;
         try {

--- a/packages/realm-server/tests/helpers/prerender-page-patches.ts
+++ b/packages/realm-server/tests/helpers/prerender-page-patches.ts
@@ -287,8 +287,10 @@ export function installFlakyDepFetchPatch(opts: {
       interceptingPages.add(page);
       let listener = (request: any) => {
         let url: string;
+        let method: string;
         try {
           url = request.url();
+          method = request.method();
         } catch {
           // The request lifecycle ended before we could inspect it.
           try {
@@ -298,6 +300,16 @@ export function installFlakyDepFetchPatch(opts: {
           }
           return;
         }
+        // Let preflight pass through to the real realm-server so its CORS
+        // middleware responds with the standard headers. We only want to
+        // inject 5xx on the actual request, mirroring the real-world
+        // transient-failure shape.
+        if (method === 'OPTIONS') {
+          request.continue().catch(() => {
+            // best-effort
+          });
+          return;
+        }
         if (remainingFailures > 0 && opts.matcher(url)) {
           remainingFailures--;
           failuresInjected++;
@@ -305,6 +317,15 @@ export function installFlakyDepFetchPatch(opts: {
             .respond({
               status,
               contentType: 'text/plain',
+              // Mirror the realm-server's `cors({ origin: '*' })` so the
+              // browser surfaces this 5xx to the host loader instead of
+              // blocking it as a CORS-policy violation upstream of the
+              // retry path. Without this header the browser would treat
+              // the response as opaque and the loader would see a network
+              // error (synthetic 500) rather than the retryable 502.
+              headers: {
+                'access-control-allow-origin': '*',
+              },
               body: 'Bad Gateway (test injection)',
             })
             .catch(() => {

--- a/packages/realm-server/tests/helpers/prerender-page-patches.ts
+++ b/packages/realm-server/tests/helpers/prerender-page-patches.ts
@@ -249,6 +249,106 @@ export function installSearchRequestObserverPatch(): {
 }
 
 /**
+ * Inject transient 5xx responses for a chosen subset of fetches inside the
+ * prerender chrome page. The patch enables Puppeteer request interception
+ * once per page; matched URLs return the configured status until the
+ * `failuresBeforeSuccess` budget is exhausted, after which they pass
+ * through. Used to assert that the loader's transient-retry path actually
+ * fires during prerender — without the native-sleep wiring in
+ * loader-service the retry hangs at `await sleep(delay)` and the render
+ * times out instead of recovering on the next attempt.
+ */
+export function installFlakyDepFetchPatch(opts: {
+  matcher: (url: string) => boolean;
+  failuresBeforeSuccess: number;
+  status?: number;
+}): {
+  failuresInjected: () => number;
+  restore: () => Promise<void>;
+} {
+  let originalGetPage = PagePool.prototype.getPage;
+  let patchedPages = new WeakSet<object>();
+  let listeners = new Map<any, (request: any) => void>();
+  let interceptingPages = new Set<any>();
+  let remainingFailures = opts.failuresBeforeSuccess;
+  let failuresInjected = 0;
+  let status = opts.status ?? 502;
+
+  PagePool.prototype.getPage = async function (this: PagePool, realm: string) {
+    let pageInfo = await originalGetPage.call(this, realm);
+    let page = pageInfo.page as any;
+    if (page && !patchedPages.has(page)) {
+      patchedPages.add(page);
+      try {
+        await page.setRequestInterception(true);
+        interceptingPages.add(page);
+      } catch {
+        // Best-effort: if interception is already active or the page has
+        // been torn down, skip — the test will surface the failure via
+        // missing failuresInjected count rather than as a setup error.
+      }
+      let listener = (request: any) => {
+        let url: string;
+        try {
+          url = request.url();
+        } catch {
+          // The request lifecycle ended before we could inspect it.
+          try {
+            request.continue();
+          } catch {
+            // ignore — request already fulfilled or aborted
+          }
+          return;
+        }
+        if (remainingFailures > 0 && opts.matcher(url)) {
+          remainingFailures--;
+          failuresInjected++;
+          request
+            .respond({
+              status,
+              contentType: 'text/plain',
+              body: 'Bad Gateway (test injection)',
+            })
+            .catch(() => {
+              // best-effort: page may have moved on
+            });
+          return;
+        }
+        request.continue().catch(() => {
+          // best-effort: another handler may have already responded
+        });
+      };
+      listeners.set(page, listener);
+      page.on('request', listener);
+    }
+    return { ...pageInfo, page };
+  };
+
+  return {
+    failuresInjected: () => failuresInjected,
+    restore: async () => {
+      PagePool.prototype.getPage = originalGetPage;
+      for (let [page, listener] of listeners) {
+        try {
+          page.off('request', listener);
+        } catch {
+          // best-effort
+        }
+      }
+      for (let page of interceptingPages) {
+        try {
+          await page.setRequestInterception(false);
+        } catch {
+          // best-effort: page may already be closed
+        }
+      }
+      listeners.clear();
+      interceptingPages.clear();
+    },
+  };
+}
+
+/**
  * Simulate the background-tab RAF throttling that causes the render-ready
  * stability loop to stall. This replaces `requestAnimationFrame` inside
  * prerender pages with a version that delays each callback by `delayMs`.

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -31,6 +31,7 @@ import {
 } from '@cardstack/runtime-common';
 import {
   installDelayedRuntimeRealmSearchPatch,
+  installFlakyDepFetchPatch,
   installRealmServerAssertOwnRealmServerBypassPatch,
   installSearchRequestObserverPatch,
   installThrottledRAFPatch,
@@ -480,6 +481,109 @@ module(basename(__filename), function () {
         result.pool.timedOut,
         'pool should not mark this as a prerender timeout',
       );
+    });
+
+    test('transient 502 on dep fetch retries instead of timing out', async function (assert) {
+      // While prerendering, the host's render-timer-stub suppresses
+      // window.setTimeout. The loader's transient-5xx retry uses setTimeout-
+      // based backoff, so a single 502 on a dep fetch used to hang the
+      // entire render at `await sleep(delayMs)` for the full 90 s render
+      // timeout. The fix routes the loader's retry sleep through
+      // scheduleNativeTimeout (see loader-service.ts), bypassing the stub.
+      // This test simulates a transient 502 on the card's module fetch and
+      // asserts the prerender recovers within the retry budget rather than
+      // timing out.
+      let modulePath = 'flaky-target.gts';
+      let moduleURL = `${realmURL}${modulePath}`;
+      let cardPath = 'flaky-1.json';
+      let cardURL = `${realmURL}flaky-1`;
+
+      await realmAdapter.write(
+        modulePath,
+        `
+          import { CardDef, field, contains, StringField, Component } from 'https://cardstack.com/base/card-api';
+          export class FlakyTarget extends CardDef {
+            static displayName = 'FlakyTarget';
+            @field name = contains(StringField);
+            static isolated = class extends Component<typeof this> {
+              <template><span data-test-name>{{@model.name}}</span></template>
+            }
+          }
+        `,
+      );
+      await realmAdapter.write(
+        cardPath,
+        JSON.stringify(
+          {
+            data: {
+              attributes: { name: 'Recovered' },
+              meta: {
+                adoptsFrom: {
+                  module: rri('./flaky-target'),
+                  name: 'FlakyTarget',
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      await realm.realmIndexUpdater.fullIndex();
+      realm.__testOnlyClearCaches();
+
+      // Match the dep URL exactly. The host's loader fetches modules at
+      // the realm-server URL with the source extension preserved (the
+      // server transpiles in place), so equality against `moduleURL` is
+      // sufficient — we want the next fetch the browser issues for this
+      // module (after clearCache) to be intercepted.
+      let flakyPatch = installFlakyDepFetchPatch({
+        matcher: (url) => url === moduleURL,
+        failuresBeforeSuccess: 1,
+      });
+      try {
+        let started = Date.now();
+        // clearCache forces the host's loader to drop its cached fetch +
+        // module entries before the render, so the dep fetch the patch
+        // is targeting actually goes to the network rather than coming
+        // from the in-process loader cache populated by fullIndex above.
+        let result = await prerenderCard(prerenderer, {
+          affinityType: 'realm',
+          affinityValue: realmURL,
+          realm: realmURL,
+          url: cardURL,
+          auth: auth(),
+          renderOptions: { clearCache: true },
+        });
+        let elapsedMs = Date.now() - started;
+
+        assert.strictEqual(
+          flakyPatch.failuresInjected(),
+          1,
+          'patch injected exactly one transient 502 for the dep fetch',
+        );
+        assert.notOk(
+          result.response.error,
+          `render recovered from transient 502 (error: ${JSON.stringify(
+            result.response.error?.error ?? null,
+          )})`,
+        );
+        assert.false(
+          result.pool.timedOut,
+          'render did not hit the 90s prerender timeout',
+        );
+        assert.true(
+          elapsedMs < 30_000,
+          `render completes within retry budget; observed ${elapsedMs}ms (90s would mean retry sleep is hung)`,
+        );
+        assert.strictEqual(
+          result.response.serialized?.data.attributes?.name,
+          'Recovered',
+          'card data rendered correctly after retry',
+        );
+      } finally {
+        await flakyPatch.restore();
+      }
     });
   });
 

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -28,6 +28,7 @@ import {
   rri,
   baseRealm,
   baseRRI,
+  executableExtensions,
 } from '@cardstack/runtime-common';
 import {
   installDelayedRuntimeRealmSearchPatch,
@@ -532,13 +533,24 @@ module(basename(__filename), function () {
       await realm.realmIndexUpdater.fullIndex();
       realm.__testOnlyClearCaches();
 
-      // Match the dep URL exactly. The host's loader fetches modules at
-      // the realm-server URL with the source extension preserved (the
-      // server transpiles in place), so equality against `moduleURL` is
-      // sufficient — we want the next fetch the browser issues for this
-      // module (after clearCache) to be intercepted.
+      // Strip executable extensions from both sides so the matcher fires
+      // for every fetch shape the loader may issue: `flaky-target.gts`
+      // (the source URL), `flaky-target` (extensionless — what the card's
+      // adoptsFrom.module resolves to via rri), or the canonicalized form
+      // surfaced through X-Boxel-Canonical-Path. Without this, the matcher
+      // would miss the actual fetch and the test would silently pass
+      // without exercising the retry path.
+      let stripExecExt = (u: string) => {
+        for (let ext of executableExtensions) {
+          if (u.endsWith(ext)) {
+            return u.slice(0, -ext.length);
+          }
+        }
+        return u;
+      };
+      let targetTrimmed = stripExecExt(moduleURL);
       let flakyPatch = installFlakyDepFetchPatch({
-        matcher: (url) => url === moduleURL,
+        matcher: (url) => stripExecExt(url) === targetTrimmed,
         failuresBeforeSuccess: 1,
       });
       try {

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -207,18 +207,29 @@ export class Loader {
 
   private fetchImplementation: Fetch;
   private resolveImport: (moduleIdentifier: string) => string;
+  // When the host runs inside a prerender, `setTimeout` is suppressed by
+  // the render-timer-stub so the default sleep used by
+  // `fetchWithTransientRetry` would never resolve and a transient 5xx on
+  // a dep fetch would hang the render until the prerender timeout. The
+  // host injects a sleep that goes through the native (unblocked)
+  // setTimeout so the retry actually fires.
+  private retrySleep: ((ms: number) => Promise<void>) | undefined;
 
   constructor(
     fetch: Fetch,
     resolveImport?: (moduleIdentifier: string) => string,
+    options?: { retrySleep?: (ms: number) => Promise<void> },
   ) {
     this.fetchImplementation = fetch;
     this.resolveImport =
       resolveImport ?? ((moduleIdentifier) => moduleIdentifier);
+    this.retrySleep = options?.retrySleep;
   }
 
   static cloneLoader(loader: Loader): Loader {
-    let clone = new Loader(loader.fetchImplementation, loader.resolveImport);
+    let clone = new Loader(loader.fetchImplementation, loader.resolveImport, {
+      retrySleep: loader.retrySleep,
+    });
     for (let [moduleIdentifier, module] of loader.moduleShims) {
       clone.shimModule(moduleIdentifier, module);
     }
@@ -1003,6 +1014,7 @@ export class Loader {
       // catch as thrown exceptions. The catch here is defensive for any
       // other unexpected throw from the fetch helper itself.
       response = await fetchWithTransientRetry(() => this._fetch(moduleURL), {
+        sleep: this.retrySleep,
         onRetry: ({ attempt, maxAttempts, status, delayMs }) => {
           this.log.debug(
             `retrying module fetch for ${moduleURL.href} after status ${status} (attempt ${attempt} of ${maxAttempts}, waiting ${delayMs}ms)`,


### PR DESCRIPTION
## Summary

Any transient `502`/`503`/`504` on a dep fetch during prerendering would hang the entire render for the full 90-second prerender timeout. Every occurrence cost a worker slot for 90 s and surfaced to users as "indexing timeout" errors.

## Mechanism — two well-intentioned features colliding

**1. The loader retries 5xx with `setTimeout`-based backoff.** `packages/runtime-common/loader.ts` defines `RETRYABLE_STATUS_CODES = {502, 503, 504}`; on a retryable status the loader sleeps with backoff before retrying:

```ts
let defaultSleep = (ms: number) =>
  new Promise((resolve) => setTimeout(resolve, ms));
```

**2. The host disables `setTimeout` during prerender.** `packages/host/app/utils/render-timer-stub.ts` wraps `window.setTimeout` while a prerender is in flight; the wrapper records the call, returns a syntactically valid handle, **and silently drops the callback** (intent: prevent runaway timers from extending render time indefinitely).

Combined, the chain that fires under load is:

1. Browser fetches a dep (e.g. `https://realms-staging.stack.cards/base/default-templates/fitted`).
2. Server returns 502 (transient — under load, event-loop saturation, transient ALB-target glitch, etc.).
3. Loader sees 502, calls `await sleep(delayMs)`.
4. `sleep`'s `setTimeout(resolve, ms)` is intercepted by the prerender stub. The handle is returned but the `resolve` callback is silently dropped.
5. The promise never resolves. The retry loop is parked at `await sleep` forever.
6. After 90 s, the prerender's hard render-timeout fires. Worker logs `Render timed-out after 90000 ms` and the file errors.
7. Tab pool evicts the page; subsequent renders work fine.

A single 502 on any one of dozens of dep fetches hangs the entire render for 90 s. Combine with full-reindex storms or any other event-loop pressure on the realm-server, and the rate spikes sharply.

### Observed on staging 2026-05-04

Job `301138` (incremental-index for `cmgardella/adorn-mockups/BlogPost/main.json`):

* `05:03:03` — fused visit begins
* `05:03:03` — Chrome console errors: `Failed to load resource: the server responded with a status of 502 ()` for `/base/default-templates/fitted` and `/base/default-templates/atom`
* `05:03:03` — Chrome console warning: `[boxel] setTimeout is disabled while prerendering to prevent runaway timers`
* `05:04:33` — prerender server logs `total=90009ms render=90008ms flags=[reused, evicted, timedOut]`; worker logs `Render timed-out after 90000 ms`

The `blog-post.gts` render six seconds earlier on the same `pageId` had completed cleanly in 693 ms. Two specific dep fetches got 502'd; the rest got 304s. That was enough.

## Fix

Make the loader's backoff sleep go through the **native** (unblocked) `setTimeout` when running inside a prerender. The render-timer-stub already exports `scheduleNativeTimeout` for exactly this pattern (the render-ready stability loop already uses it).

The loader already accepted a custom `sleep` per call site, but only at the `fetchWithTransientRetry` helper level. This PR adds an optional `retrySleep` to the `Loader` constructor and threads it through to the existing `fetchWithTransientRetry` call. The host's `LoaderService` injects a `retrySleep` that uses `scheduleNativeTimeout`. Outside prerender, `scheduleNativeTimeout` falls back to `globalThis.setTimeout`, so host-runtime behavior is unchanged.

This is option (a) from the ticket — host knows about both layers; loader stays oblivious to prerender mode.

## Files changed (5)

| File | Change |
|---|---|
| `packages/runtime-common/loader.ts` | Add optional `retrySleep` to `Loader` constructor + `cloneLoader`; pass through to `fetchWithTransientRetry` |
| `packages/host/app/services/loader-service.ts` | Construct the host's `Loader` with `retrySleep` backed by `scheduleNativeTimeout` |
| `packages/host/tests/unit/render-timer-stub-test.ts` | Wiring-coverage test: `scheduleNativeTimeout`-backed promise resolves while the stub is active and a normal `setTimeout` is suppressed |
| `packages/realm-server/tests/helpers/prerender-page-patches.ts` | New `installFlakyDepFetchPatch` helper using Puppeteer's `setRequestInterception` to inject transient 5xx for a matched URL |
| `packages/realm-server/tests/prerendering-test.ts` | Acceptance test: writes a fresh card+module, full-indexes, then prerenders with `clearCache: true` while patching one 502 onto the module fetch — asserts recovery in well under the timeout |

## Why a host-side test alone wouldn't have caught this

`packages/host/app/routes/render.ts` gates `enableRenderTimerStub()` and `beginTimerBlock()` on `!isTesting()`, so host tests never install the stub and therefore never reproduce the bug. `packages/host/app/components/card-prerender.gts` (the parallel test-only prerender component) likewise sidesteps the suppression path. The bug only manifests when production-built host code runs inside a real Chrome with the stub installed — which is exactly what `packages/realm-server/tests/prerendering-test.ts` already does. That's where the acceptance test lives.

The host unit test (`scheduleNativeTimeout resolves a sleep promise while timers are blocked`) is wiring-only — it confirms the building block works, but is honestly framed as such.

## Acceptance criteria mapping

* ✅ **During a prerender, a transient 502/503/504 on a dep fetch retries within the configured backoff ladder (no longer hangs at `await sleep`).** — `retrySleep` uses `scheduleNativeTimeout` which bypasses the stub.
* ✅ **An end-to-end test that simulates a 502 on a dep fetch inside a prerender completes the render within the retry budget, not the 90 s render-timeout.** — new prerender-server test, asserts `elapsedMs < 30000` and `failuresInjected === 1`.
* ✅ **The render-timer-stub still suppresses other setTimeout calls in the host code (no regression in runaway-timer protection).** — only the `Loader`'s injected sleep uses `scheduleNativeTimeout`; everything else still routes through `window.setTimeout` and is suppressed as before. The host wiring test asserts a normal `setTimeout` is still suppressed alongside the native bypass.
* ⏳ **Worker logs no longer show `Render timed-out after 90000 ms` for transient-5xx-only causes after this lands.** — observable post-deploy.

## Out of scope

* Fixing the original cause of the transient 502s on the realm-server. Those are infrequent and the loader's retry is the right shape; this PR just makes the retry actually *work* during prerender.
* Tuning the retry budget / backoff ladder. Existing values are fine for this fix.

## Performance / safety

* No change for non-prerender runtime: `scheduleNativeTimeout` falls back to `globalThis.setTimeout` when no stub is installed.
* No change to retry budget: still 3 retries with `[100, 300, 900] ms` backoff (worst-case ~1.3 s added latency on persistent 5xx).
* The injected `retrySleep` is also propagated through `Loader.cloneLoader`, so loader resets / clones during a session keep the bypass.

## Test plan

- [ ] CI: `transient 502 on dep fetch retries instead of timing out` (realm-server prerender test) passes
- [ ] CI: `scheduleNativeTimeout resolves a sleep promise while timers are blocked` (host unit) passes
- [ ] CI: full lint clean across runtime-common, host, realm-server (verified locally for all three after `pnpm build` for boxel-icons + boxel-ui)
- [ ] CI: existing prerender, host, and runtime-common suites unchanged

## Related

* [CS-11015](https://linear.app/cardstack/issue/CS-11015) — this PR
* CS-11011 — write-path gate. Indirectly related: full-reindex storms increase realm-server load, which increases the rate of transient 5xx, which today means more 90 s render hangs.
* Other indexing-related fixes in the launch performance set: CS-11012, CS-11014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)