### PR TITLE
Re-land CS-10948: discard in-flight prerender result if invalidate ran concurrently

### DIFF
--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -1602,15 +1602,502 @@ module(basename(__filename), function () {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       releaseGate();
-      let [dA, dB] = await Promise.all([pA, pB]);
+      let [resultA, resultB] = await Promise.allSettled([pA, pB]);
 
       assert.strictEqual(
         calls,
         2,
         'invalidate dropped the in-flight entry so caller B triggered its own prerender',
       );
-      assert.strictEqual(dA?.displayName, 'CoalesceInvalidate v1');
-      assert.strictEqual(dB?.displayName, 'CoalesceInvalidate v2');
+      // CS-10948: A's pre-invalidation result is dropped at persist time
+      // rather than served back. lookupDefinition therefore rejects (the
+      // post-skip readFromDatabaseCache misses because invalidate also
+      // deleted the row). Only B — which started after the bump and ran a
+      // fresh prerender — returns a Definition.
+      assert.strictEqual(
+        resultA.status,
+        'rejected',
+        'A is rejected — its pre-invalidation prerender result is discarded',
+      );
+      assert.strictEqual(resultB.status, 'fulfilled');
+      if (resultB.status === 'fulfilled') {
+        assert.strictEqual(resultB.value?.displayName, 'CoalesceInvalidate v2');
+      }
+    });
+
+    test('in-flight prerender result is dropped when invalidate runs concurrently', async function (assert) {
+      await dbAdapter.execute('DELETE FROM modules');
+
+      let moduleURL = `${realmURL}stale-persist-invalidate.gts`;
+      let calls = 0;
+      let releaseGate!: () => void;
+      let gate = new Promise<void>((resolve) => {
+        releaseGate = resolve;
+      });
+
+      let prerenderer: Prerenderer = {
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls++;
+          await gate;
+          return buildModuleResponse(args.url, 'StalePersist', []);
+        },
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      // Caller A starts the prerender and parks at the gate.
+      let pA = lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'StalePersist',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Invalidate while A is mid-prerender.
+      await lookup.invalidate(moduleURL);
+
+      // Release A's prerender. Without the generation guard, A would
+      // INSERT ... ON CONFLICT DO UPDATE and re-create the row that
+      // invalidate just deleted.
+      releaseGate();
+      let result = await Promise.allSettled([pA]);
+      assert.strictEqual(
+        result[0].status,
+        'rejected',
+        'A rejects because the post-skip readFromDatabaseCache misses (row was deleted)',
+      );
+      assert.strictEqual(
+        calls,
+        1,
+        'prerenderModule was still called once (no double-prerender)',
+      );
+
+      let rows = (await dbAdapter.execute(
+        `SELECT url FROM modules WHERE url = $1`,
+        { bind: [moduleURL] },
+      )) as { url: string }[];
+      assert.strictEqual(
+        rows.length,
+        0,
+        'invalidate is honored — no zombie row from A persist',
+      );
+    });
+
+    test('in-flight prerender result is dropped when clearRealmCache runs concurrently', async function (assert) {
+      await dbAdapter.execute('DELETE FROM modules');
+
+      let moduleURL = `${realmURL}stale-persist-clear-realm.gts`;
+      let calls = 0;
+      let releaseGate!: () => void;
+      let gate = new Promise<void>((resolve) => {
+        releaseGate = resolve;
+      });
+
+      let prerenderer: Prerenderer = {
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls++;
+          await gate;
+          return buildModuleResponse(args.url, 'StalePersistClearRealm', []);
+        },
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      let pA = lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'StalePersistClearRealm',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      await lookup.clearRealmCache(realmURL);
+
+      releaseGate();
+      let result = await Promise.allSettled([pA]);
+      assert.strictEqual(
+        result[0].status,
+        'rejected',
+        'A rejects after clearRealmCache leaves an empty cache',
+      );
+      assert.strictEqual(calls, 1);
+
+      let rows = (await dbAdapter.execute(
+        `SELECT url FROM modules WHERE url = $1`,
+        { bind: [moduleURL] },
+      )) as { url: string }[];
+      assert.strictEqual(
+        rows.length,
+        0,
+        'clearRealmCache is honored — A did not re-insert the row',
+      );
+    });
+
+    test('in-flight prerender result is dropped when clearAllModules runs concurrently', async function (assert) {
+      await dbAdapter.execute('DELETE FROM modules');
+
+      // clearAllModules drains state for every realm — including realms
+      // that have never been individually invalidated. Use a fresh module
+      // URL so the realm has no #generations entry going in; this guards
+      // against the per-realm map missing the realm at clear time.
+      let moduleURL = `${realmURL}stale-persist-clear-all.gts`;
+      let calls = 0;
+      let releaseGate!: () => void;
+      let gate = new Promise<void>((resolve) => {
+        releaseGate = resolve;
+      });
+
+      let prerenderer: Prerenderer = {
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls++;
+          await gate;
+          return buildModuleResponse(args.url, 'StalePersistClearAll', []);
+        },
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      let pA = lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'StalePersistClearAll',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      await lookup.clearAllModules();
+
+      releaseGate();
+      let result = await Promise.allSettled([pA]);
+      assert.strictEqual(
+        result[0].status,
+        'rejected',
+        'A rejects after clearAllModules leaves an empty cache',
+      );
+      assert.strictEqual(calls, 1);
+
+      let rows = (await dbAdapter.execute(
+        `SELECT url FROM modules WHERE url = $1`,
+        { bind: [moduleURL] },
+      )) as { url: string }[];
+      assert.strictEqual(
+        rows.length,
+        0,
+        'clearAllModules is honored — A did not re-insert the row',
+      );
+    });
+
+    test('invalidate of one module does not discard in-flight prerender for an unrelated module in the same realm', async function (assert) {
+      // Per-module generation scoping regression guard: a realm-wide bump
+      // would spuriously discard the unrelated in-flight's result.
+      await dbAdapter.execute('DELETE FROM modules');
+
+      let moduleInvalidated = `${realmURL}scoped-invalidate-target.gts`;
+      let moduleUnaffected = `${realmURL}scoped-invalidate-bystander.gts`;
+      let calls = 0;
+      let releaseGate!: () => void;
+      let gate = new Promise<void>((resolve) => {
+        releaseGate = resolve;
+      });
+
+      let prerenderer: Prerenderer = {
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls++;
+          await gate;
+          let name =
+            args.url === moduleUnaffected ? 'ScopedBystander' : 'ScopedTarget';
+          return buildModuleResponse(args.url, name, []);
+        },
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      // Bystander's prerender is in-flight.
+      let pBystander = lookup.lookupDefinition({
+        module: rri(moduleUnaffected),
+        name: 'ScopedBystander',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Invalidate a DIFFERENT module in the same realm. With realm-wide
+      // bumps this would trip the bystander's generation check; with
+      // per-module bumps scoped to uniqueInvalidations, it shouldn't.
+      await lookup.invalidate(moduleInvalidated);
+
+      releaseGate();
+      let definition = await pBystander;
+      assert.strictEqual(
+        definition?.displayName,
+        'ScopedBystander',
+        'bystander persisted normally — invalidate scope respected',
+      );
+      assert.strictEqual(calls, 1);
+
+      let rows = (await dbAdapter.execute(
+        `SELECT url FROM modules WHERE url = $1`,
+        { bind: [moduleUnaffected] },
+      )) as { url: string }[];
+      assert.strictEqual(
+        rows.length,
+        1,
+        'bystander row is persisted, not spuriously discarded',
+      );
+    });
+
+    test('a settled in-flight promise does not delete a newer in-flight under the same key', async function (assert) {
+      // Identity-check regression guard. Without the identity check in
+      // loadModuleCacheEntry's .finally, A's settle would delete B's
+      // freshly-installed entry and cause D to race a third prerender.
+      await dbAdapter.execute('DELETE FROM modules');
+
+      let moduleURL = `${realmURL}identity-check.gts`;
+      let calls = 0;
+      let gates: Array<{ release: () => void; promise: Promise<void> }> = [];
+
+      let prerenderer: Prerenderer = {
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls++;
+          let release!: () => void;
+          let promise = new Promise<void>((resolve) => {
+            release = resolve;
+          });
+          gates.push({ release, promise });
+          await promise;
+          return buildModuleResponse(args.url, 'Identity', []);
+        },
+      };
+
+      // setTimeout(0) is not reliable here: readFromDatabaseCache runs on
+      // the I/O phase of the event loop, which fires after timers, so a
+      // single macrotask yield can return before A has entered the
+      // prerender mock. Poll until the expected number of prerenders have
+      // started, with a generous bound for slow test environments.
+      let waitForCalls = async (expected: number): Promise<void> => {
+        let deadline = Date.now() + 5000;
+        while (calls < expected) {
+          if (Date.now() > deadline) {
+            throw new Error(
+              `waitForCalls timed out: expected ${expected}, saw ${calls}`,
+            );
+          }
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      // A enters #inFlight; parks at gates[0].
+      let pA = lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'Identity',
+      });
+      await waitForCalls(1);
+
+      // invalidate drops A's #inFlight entry synchronously.
+      await lookup.invalidate(moduleURL);
+
+      // B re-enters #inFlight under the same key with a fresh pending.
+      let pB = lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'Identity',
+      });
+      await waitForCalls(2);
+
+      // C joins B's pending (same key, B is still in-flight).
+      let pC = lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'Identity',
+      });
+      // Give C a chance to either coalesce or start its own prerender.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      assert.strictEqual(
+        calls,
+        2,
+        'C coalesced into B without adding a prerender',
+      );
+
+      // Settle A. Its .finally must NOT delete B's entry.
+      gates[0].release();
+      await Promise.allSettled([pA]);
+
+      // D should STILL coalesce into B. If A's finally deleted B's entry,
+      // D would create a third prerender here.
+      let pD = lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'Identity',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      assert.strictEqual(
+        calls,
+        2,
+        "D coalesced into B — A's settle did not delete B's #inFlight entry",
+      );
+
+      // Release B; everyone converges.
+      gates[1].release();
+      let [rB, rC, rD] = await Promise.allSettled([pB, pC, pD]);
+      assert.strictEqual(rB.status, 'fulfilled');
+      assert.strictEqual(rC.status, 'fulfilled');
+      assert.strictEqual(rD.status, 'fulfilled');
+    });
+
+    test('in-flight prerender persists normally when no invalidate runs', async function (assert) {
+      // Regression guard against the generation check skipping persist
+      // in the happy path (no concurrent invalidation).
+      await dbAdapter.execute('DELETE FROM modules');
+
+      let moduleURL = `${realmURL}stale-persist-happy-path.gts`;
+      let calls = 0;
+      let releaseGate!: () => void;
+      let gate = new Promise<void>((resolve) => {
+        releaseGate = resolve;
+      });
+
+      let prerenderer: Prerenderer = {
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls++;
+          await gate;
+          return buildModuleResponse(args.url, 'StalePersistHappy', []);
+        },
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      let pA = lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'StalePersistHappy',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      releaseGate();
+      let definition = await pA;
+      assert.strictEqual(definition?.displayName, 'StalePersistHappy');
+      assert.strictEqual(calls, 1);
+
+      let rows = (await dbAdapter.execute(
+        `SELECT url FROM modules WHERE url = $1`,
+        { bind: [moduleURL] },
+      )) as { url: string }[];
+      assert.strictEqual(
+        rows.length,
+        1,
+        'persist proceeded normally when nothing invalidated mid-flight',
+      );
     });
   });
 

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -89,6 +89,18 @@ function inFlightKey(args: {
   return `${args.resolvedRealmURL}|${args.moduleURL}|${args.cacheScope}|${args.cacheUserId}`;
 }
 
+// Module-generation key. Intentionally keyed on (realm, moduleURL) — not
+// (realm, moduleURL, scope, user) — because the invalidation paths that
+// bump it don't discriminate by cache scope or auth user (they delete all
+// rows for the URL), so every scope/user combo for the same URL shares
+// one counter.
+function moduleGenerationKey(
+  resolvedRealmURL: string,
+  moduleURL: string,
+): string {
+  return `${resolvedRealmURL}|${moduleURL}`;
+}
+
 function parseJsonValue<T>(value: T | string | null): T | null {
   if (value == null) {
     return null;
@@ -200,6 +212,25 @@ export class CachingDefinitionLookup implements DefinitionLookup {
   // cache row so a single prerenderer round-trip is shared by all waiters
   // instead of each caller racing to the prerenderer independently.
   #inFlight = new Map<string, Promise<ModuleCacheEntry | undefined>>();
+  // Invalidation generations. Bumped synchronously by invalidate /
+  // clearRealmCache / clearAllModules before the DB delete.
+  // loadModuleCacheEntryUncached snapshots all three values at entry and
+  // re-checks them just before persist; if any changed, the in-flight
+  // prerender's result is discarded rather than re-inserted, so the cache
+  // wipe isn't undone by a prerender that started against pre-invalidation
+  // state. Three scopes, matching the three invalidation paths exactly:
+  //   - #moduleGenerations: keyed by `${resolvedRealmURL}|${moduleURL}`;
+  //     bumped by invalidate() for each URL in its fan-out. Scoping to the
+  //     specific URLs avoids spuriously discarding an in-flight prerender
+  //     for an unrelated module in the same realm.
+  //   - #realmGenerations: keyed by `resolvedRealmURL`; bumped by
+  //     clearRealmCache() so every in-flight prerender for that realm is
+  //     invalidated, including modules not yet in #moduleGenerations.
+  //   - #globalGeneration: bumped by clearAllModules() so every in-flight
+  //     prerender is invalidated regardless of realm or module URL.
+  #moduleGenerations = new Map<string, number>();
+  #realmGenerations = new Map<string, number>();
+  #globalGeneration = 0;
 
   constructor(
     dbAdapter: DBAdapter,
@@ -302,8 +333,17 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     if (existing) {
       return await existing;
     }
-    let pending = this.loadModuleCacheEntryUncached(args).finally(() => {
-      this.#inFlight.delete(key);
+    let pending: Promise<ModuleCacheEntry | undefined>;
+    pending = this.loadModuleCacheEntryUncached(args).finally(() => {
+      // Identity-check before deletion: an invalidation path may have
+      // dropped our entry mid-flight, after which a newer caller can
+      // install their own pending under the same key. Deleting
+      // unconditionally would remove that newer entry and break coalescing
+      // for its subsequent waiters. We only clean up if the map still
+      // points at *this* pending promise.
+      if (this.#inFlight.get(key) === pending) {
+        this.#inFlight.delete(key);
+      }
     });
     this.#inFlight.set(key, pending);
     return await pending;
@@ -324,6 +364,16 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     cacheUserId: string;
     prerenderUserId: string;
   }): Promise<ModuleCacheEntry | undefined> {
+    // Snapshot invalidation generations BEFORE the first await.
+    // clearRealmCache (and any future synchronous bump) runs entirely before
+    // its first await, so a snapshot taken after an await above would already
+    // include the bump and silently match at persist time. Invalidate happens
+    // to await before bumping, so this point of failure is asymmetric — but
+    // we want both paths to be caught uniformly, so the safe place is entry.
+    // If the cache-hit short-circuits below, we never use this snapshot,
+    // which is fine — capturing it is a few Map.get calls + struct alloc.
+    let startSnapshot = this.snapshotGeneration(resolvedRealmURL, moduleURL);
+
     let cached = await this.readFromDatabaseCache(
       moduleURL,
       cacheScope,
@@ -357,6 +407,19 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       ) {
         continue;
       }
+      if (this.generationChanged(resolvedRealmURL, moduleURL, startSnapshot)) {
+        // Invalidate (or a wider cache wipe) ran while we were prerendering.
+        // Discard our now-stale result rather than re-inserting it. Fall
+        // back to whatever the DB currently has — undefined if the wipe
+        // just deleted, or a fresher row if a peer has already
+        // re-prerendered post-invalidation.
+        return await this.readFromDatabaseCache(
+          candidateURL,
+          cacheScope,
+          cacheUserId,
+          resolvedRealmURL,
+        );
+      }
       return await this.persistModuleCacheEntry(
         candidateURL,
         response,
@@ -366,6 +429,52 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       );
     }
     return undefined;
+  }
+
+  private snapshotGeneration(
+    resolvedRealmURL: string,
+    moduleURL: string,
+  ): { module: number; realm: number; global: number } {
+    return {
+      module:
+        this.#moduleGenerations.get(
+          moduleGenerationKey(resolvedRealmURL, moduleURL),
+        ) ?? 0,
+      realm: this.#realmGenerations.get(resolvedRealmURL) ?? 0,
+      global: this.#globalGeneration,
+    };
+  }
+
+  private generationChanged(
+    resolvedRealmURL: string,
+    moduleURL: string,
+    snapshot: { module: number; realm: number; global: number },
+  ): boolean {
+    return (
+      (this.#moduleGenerations.get(
+        moduleGenerationKey(resolvedRealmURL, moduleURL),
+      ) ?? 0) !== snapshot.module ||
+      (this.#realmGenerations.get(resolvedRealmURL) ?? 0) !== snapshot.realm ||
+      this.#globalGeneration !== snapshot.global
+    );
+  }
+
+  private bumpModuleGeneration(
+    resolvedRealmURL: string,
+    moduleURL: string,
+  ): void {
+    let key = moduleGenerationKey(resolvedRealmURL, moduleURL);
+    this.#moduleGenerations.set(
+      key,
+      (this.#moduleGenerations.get(key) ?? 0) + 1,
+    );
+  }
+
+  private bumpRealmGeneration(resolvedRealmURL: string): void {
+    this.#realmGenerations.set(
+      resolvedRealmURL,
+      (this.#realmGenerations.get(resolvedRealmURL) ?? 0) + 1,
+    );
   }
 
   // Returns true if the cached entry has a top-level error and has exceeded
@@ -505,12 +614,27 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       );
     }
     let uniqueInvalidations = [...new Set(invalidations)];
-    await this.deleteModuleAliases(resolvedRealmURL, uniqueInvalidations);
+    // Order matters: bump the affected modules' generations + drop in-flight
+    // synchronously BEFORE awaiting the DB delete. Any in-flight prerender
+    // for one of these URLs that completes between this point and the
+    // DELETE commit will see the new generation at persist time and discard
+    // its result instead of re-inserting a row that this invalidation just
+    // removed. Scoping to uniqueInvalidations (rather than the whole realm)
+    // leaves unrelated in-flight prerenders in the same realm untouched —
+    // their generations are unchanged, their persists proceed normally.
+    for (let invalidatedURL of uniqueInvalidations) {
+      this.bumpModuleGeneration(resolvedRealmURL, invalidatedURL);
+    }
     this.dropInFlightForRealm(resolvedRealmURL, uniqueInvalidations);
+    await this.deleteModuleAliases(resolvedRealmURL, uniqueInvalidations);
     return uniqueInvalidations;
   }
 
   async clearRealmCache(resolvedRealmURL: string): Promise<void> {
+    // Realm-scope bump: every in-flight prerender for this realm (any
+    // module URL, any scope/user) sees the mismatch at persist time.
+    this.bumpRealmGeneration(resolvedRealmURL);
+    this.dropInFlightForRealm(resolvedRealmURL);
     await this.query([
       'DELETE FROM',
       MODULES_TABLE,
@@ -519,23 +643,28 @@ export class CachingDefinitionLookup implements DefinitionLookup {
         ['resolved_realm_url =', param(resolvedRealmURL)],
       ]) as Expression),
     ]);
-    this.dropInFlightForRealm(resolvedRealmURL);
   }
 
   async clearAllModules(): Promise<void> {
-    await this.query(['DELETE FROM', MODULES_TABLE]);
+    this.#globalGeneration += 1;
     this.#inFlight.clear();
+    await this.query(['DELETE FROM', MODULES_TABLE]);
   }
 
   // Drops in-flight entries whose pending prerender result would no longer
   // be valid after a cache wipe, so post-invalidation callers don't join a
   // pre-invalidation promise. If `moduleURLs` is provided, only entries
   // under that realm matching one of those URLs are dropped; otherwise every
-  // in-flight entry for the realm is dropped. The already-running promises
-  // still complete (we can't cancel the prerender) and may re-persist a now-
-  // stale row, but that race is narrower than before and self-heals on the
-  // next fresh prerender. What this fully prevents is waiters joining the
-  // stale promise after the invalidation returned.
+  // in-flight entry for the realm is dropped. The already-running prerender
+  // round-trip cannot be cancelled and still completes, but because the
+  // invalidation path also bumps the module / realm / global generation
+  // synchronously before awaiting the DB delete, the in-flight's generation
+  // check in loadModuleCacheEntryUncached observes the bump before
+  // persistModuleCacheEntry runs and discards the result via
+  // readFromDatabaseCache instead of repopulating the cleared row. This
+  // drop step is the in-flight-map half of the same fix: it ensures new
+  // callers arriving after the invalidation don't attach to the now-
+  // soon-to-be-discarded promise.
   private dropInFlightForRealm(
     resolvedRealmURL: string,
     moduleURLs?: string[],


### PR DESCRIPTION
Re-lands [#4515](https://github.com/cardstack/boxel/pull/4515) (CS-10948 — discard in-flight prerender result if invalidate ran concurrently) by reverting the [#4527](https://github.com/cardstack/boxel/pull/4527) revert. The race the original PR closes still exists in `main` today.

## Why the original was reverted, and why that reasoning no longer applies

[#4527](https://github.com/cardstack/boxel/pull/4527) reverted both this and [#4521](https://github.com/cardstack/boxel/pull/4521) (CS-10860) "to bisect" two failing SF Playwright tests (`realm-search` 60s tool timeouts). The revert PR was explicit that root cause was unknown.

Within ~2.5 hours of the revert, [#4528](https://github.com/cardstack/boxel/pull/4528) ("SF harness: preserve cloned modules cache to avoid cold prerender per test") root-caused those failures. The cause was unrelated to either reverted PR — `rewriteClonedRealmServerUrls` in the SF harness covered seven URL-bearing tables but had **left out the `modules` table**, so every per-test `lookupDefinition` was a structural cache miss against template-baked URLs and triggered a 45–55 s cold prerender that exceeded the 60 s tool timeout. Plus `realm-server/main.ts` was unconditionally calling `clearAllModules()` on every boot, wiping anything that did get rewritten. Both were fixed in [#4528](https://github.com/cardstack/boxel/pull/4528).

CS-10860 was re-landed cleanly the next day in [#4543](https://github.com/cardstack/boxel/pull/4543) ("Resurrect desync detector"), which described the original revert as having been done "out of an abundance of caution while we sorted out the signal." CS-10948 was the only one that didn't get picked back up — and three days later [CS-10952](https://linear.app/cardstack/issue/CS-10952) and [CS-10953](https://linear.app/cardstack/issue/CS-10953) were filed assuming the generation counters were still in the code. They aren't, today, on `main`. This PR puts them back.

## What's in this PR

`git revert` of the revert merge `5cac64e152`. Auto-merge resolved cleanly against the four intervening PRs that touched the same files:

- [#4564](https://github.com/cardstack/boxel/pull/4564) — clamp error_doc on persistence
- [#4539](https://github.com/cardstack/boxel/pull/4539) — RRI types/casts
- [#4620](https://github.com/cardstack/boxel/pull/4620) (CS-11002) — modules.timing_diagnostics column

Verified post-merge:
- `clampSerializedError` still wraps error_doc on persist (unchanged from #4564).
- `timingDiagnostics` still flows from `flattenPrerenderMeta(response.meta)` → `writeToDatabaseCache` → `timing_diagnostics` column (unchanged from #4620).
- Two CS-11002 tests covering timing_diagnostics persistence are still in the test file alongside the seven re-introduced CS-10948 tests.

## What this fixes (unchanged from the original PR)

The persist-after-invalidate race in `CachingDefinitionLookup`:

1. T0: Caller A starts `loadModuleCacheEntry(foo.gts)`. DB miss; prerenderer round-trip starts (100 ms – 150 s).
2. T1: `invalidate(foo.gts)` runs: `DELETE FROM modules WHERE url='foo.gts'` + `dropInFlightForRealm(...)` + returns.
3. T2: DB row gone, in-flight slot gone.
4. T3: A's prerender completes; `loadModuleCacheEntryUncached` runs `persistModuleCacheEntry(...)` → `INSERT ... ON CONFLICT DO UPDATE` re-inserts the pre-invalidation row.
5. T4: Invalidation effectively undone; next caller reads zombie row.

Symptom: user edits `product.gts` and reloads, sees the pre-edit definition.

## How it's fixed (unchanged from the original PR)

Three in-process generation counters on `CachingDefinitionLookup`:

- `#moduleGenerations` keyed by `(resolvedRealmURL, moduleURL)` — `invalidate(url)` bumps one entry per URL in `uniqueInvalidations` (target + dependency-graph fan-out).
- `#realmGenerations` keyed by `resolvedRealmURL` — `clearRealmCache(url)` bumps once for the whole realm.
- `#globalGeneration` — `clearAllModules()` bumps once for everything.

`loadModuleCacheEntryUncached` snapshots all three at function entry (before the first `await`), and `generationChanged()` re-checks all three between prerender and persist. If any moved, the result is discarded and `readFromDatabaseCache` is called to return whatever the DB now has (undefined if just deleted, or a fresher row if a peer post-invalidation already re-prerendered).

## Test plan

- [ ] `TEST_MODULE=definition-lookup-test.ts pnpm --filter @cardstack/realm-server test-module` — all 25 tests green locally
- [ ] CI Realm Server suite green
- [ ] **CI Software Factory job green** — this is the gate. The original revert was triggered by SF Playwright timeouts; #4528 has since landed and should keep them green now.
- [ ] CI Host suite green

## What this does NOT do (unchanged scope)

- Does not cancel the already-running prerender. The HTTP round-trip completes; we discard the *result*. Per the original CS-10948 spec, that's the right layer.
- Does not address cross-process invalidation. `#generations` is per-process. Two prerender-server processes can still race after one invalidates. That's [CS-10952](https://linear.app/cardstack/issue/CS-10952) (broadcast invalidations via NOTIFY) and [CS-10953](https://linear.app/cardstack/issue/CS-10953) (advisory-lock cross-process populate coalescing), both of which build on this work.

Linear: https://linear.app/cardstack/issue/CS-10948

🤖 Generated with [Claude Code](https://claude.com/claude-code)