### PR TITLE
CS-11014: dedup incremental-index enqueues against an in-flight job

### DIFF
--- a/packages/host/app/lib/browser-queue.ts
+++ b/packages/host/app/lib/browser-queue.ts
@@ -92,7 +92,14 @@ export class BrowserQueue implements QueuePublisher, QueueRunner {
           priority: job.priority,
           args: job.args,
         }));
-      let decision = coalesce({ incoming, candidates });
+      // BrowserQueue runs jobs synchronously after a debounced drain, so
+      // there are no "in-flight" jobs from the publisher's perspective —
+      // every queued workItem is still pending until drainJobs picks it up.
+      let decision = coalesce({
+        incoming,
+        candidates,
+        inFlightCandidates: [],
+      });
 
       if (decision.type === 'insert') {
         let jobSpec = decision.job ?? incoming;

--- a/packages/postgres/pg-queue.ts
+++ b/packages/postgres/pg-queue.ts
@@ -219,34 +219,62 @@ export class PgQueuePublisher implements QueuePublisher {
     }
   }
 
-  private async findPendingCandidates(
+  private async findCoalesceCandidates(
     queryFn: (expression: Expression) => Promise<unknown>,
     concurrencyGroup: string | null,
-  ): Promise<QueueCoalesceCandidate[]> {
+  ): Promise<{
+    pending: QueueCoalesceCandidate[];
+    inFlight: QueueCoalesceCandidate[];
+  }> {
+    // Pending candidates are locked FOR UPDATE so a concurrent publisher
+    // can't merge into the same row. In-flight rows are read in the same
+    // snapshot but not locked: the worker is the only writer that should
+    // commit a status change on them, and our advisory lock prevents
+    // another publisher from racing us on this concurrency group.
     let rows = (await queryFn([
-      `SELECT j.id, j.job_type, j.concurrency_group, j.timeout, j.priority, j.args
+      `SELECT j.id, j.job_type, j.concurrency_group, j.timeout, j.priority, j.args,
+              EXISTS (
+                SELECT 1 FROM job_reservations r
+                WHERE r.job_id = j.id
+                  AND r.locked_until > NOW()
+                  AND r.completed_at IS NULL
+              ) as in_flight
        FROM jobs j
        WHERE j.status='unfulfilled'
          AND j.concurrency_group IS NOT DISTINCT FROM`,
       param(concurrencyGroup),
-      `AND NOT EXISTS (
-          SELECT 1
-          FROM job_reservations r
-          WHERE r.job_id = j.id
-            AND r.locked_until > NOW()
-            AND r.completed_at IS NULL
-       )
-       ORDER BY j.created_at, j.id
-       FOR UPDATE`,
-    ])) as CoalesceCandidateRow[];
-    return rows.map((row) => ({
-      id: row.id,
-      jobType: row.job_type,
-      concurrencyGroup: row.concurrency_group,
-      timeout: row.timeout,
-      priority: row.priority,
-      args: row.args,
-    }));
+      `ORDER BY j.created_at, j.id`,
+    ])) as (CoalesceCandidateRow & { in_flight: boolean })[];
+
+    let pendingIds: number[] = [];
+    let pending: QueueCoalesceCandidate[] = [];
+    let inFlight: QueueCoalesceCandidate[] = [];
+    for (let row of rows) {
+      let candidate: QueueCoalesceCandidate = {
+        id: row.id,
+        jobType: row.job_type,
+        concurrencyGroup: row.concurrency_group,
+        timeout: row.timeout,
+        priority: row.priority,
+        args: row.args,
+      };
+      if (row.in_flight) {
+        inFlight.push(candidate);
+      } else {
+        pending.push(candidate);
+        pendingIds.push(row.id);
+      }
+    }
+
+    if (pendingIds.length > 0) {
+      await queryFn([
+        `SELECT id FROM jobs WHERE`,
+        ...any(pendingIds.map((id) => [`id=`, param(id)])),
+        `FOR UPDATE`,
+      ] as Expression);
+    }
+
+    return { pending, inFlight };
   }
 
   private async insertJob(
@@ -353,11 +381,15 @@ export class PgQueuePublisher implements QueuePublisher {
           await queryFn(['SET TRANSACTION ISOLATION LEVEL SERIALIZABLE']);
           await acquireConcurrencyGroupLock(queryFn, incoming.concurrencyGroup);
 
-          let candidates = await this.findPendingCandidates(
+          let { pending, inFlight } = await this.findCoalesceCandidates(
             queryFn,
             incoming.concurrencyGroup,
           );
-          let decision = coalesce({ incoming, candidates });
+          let decision = coalesce({
+            incoming,
+            candidates: pending,
+            inFlightCandidates: inFlight,
+          });
           let jobId: number;
 
           if (decision.type === 'insert') {
@@ -365,24 +397,42 @@ export class PgQueuePublisher implements QueuePublisher {
             jobId = await this.insertJob(queryFn, insertJob);
           } else {
             jobId = decision.jobId;
-            let isStillPending = await this.jobIsPendingAndUnreserved(
-              queryFn,
-              jobId,
-            );
-            if (!isStillPending) {
-              await queryFn(['ROLLBACK']);
-              continue;
-            }
-
-            if (decision.update) {
-              let wasUpdated = await this.updateJobForCoalesce(
+            let isInFlightTarget = inFlight.some((c) => c.id === jobId);
+            if (isInFlightTarget) {
+              // Attaching as a late waiter on an already-claimed job. The
+              // worker holds the args in memory and won't see DB writes,
+              // so the join must not request an `update`. The waiter is
+              // wired up in `publish()` via `addWaiter(jobId, ...)`.
+              if (decision.update !== undefined) {
+                throw new Error(
+                  `coalesce returned a join with update for in-flight job ${jobId}; updates cannot reach a running worker`,
+                );
+              }
+              log.debug(
+                `attaching late waiter to in-flight job %s (concurrency group %s)`,
+                jobId,
+                incoming.concurrencyGroup,
+              );
+            } else {
+              let isStillPending = await this.jobIsPendingAndUnreserved(
                 queryFn,
                 jobId,
-                decision.update,
               );
-              if (!wasUpdated) {
+              if (!isStillPending) {
                 await queryFn(['ROLLBACK']);
                 continue;
+              }
+
+              if (decision.update) {
+                let wasUpdated = await this.updateJobForCoalesce(
+                  queryFn,
+                  jobId,
+                  decision.update,
+                );
+                if (!wasUpdated) {
+                  await queryFn(['ROLLBACK']);
+                  continue;
+                }
               }
             }
           }

--- a/packages/realm-server/tests/queue-test.ts
+++ b/packages/realm-server/tests/queue-test.ts
@@ -422,6 +422,354 @@ module(basename(__filename), function () {
       }
     });
 
+    test('incremental dedup: a duplicate publish for an in-flight job attaches as a late waiter', async function (assert) {
+      // Closes the staging-observed race where the PATCH-path enqueue
+      // gets claimed by the worker before the file-watcher echo can
+      // pre-claim coalesce. Without dedup, a second 'incremental-index'
+      // row is inserted for the same change set and the worker runs the
+      // same indexing pass twice. With dedup, the second publish reuses
+      // the running job's id and registers a late waiter.
+      await runner.destroy();
+      let realmURL = 'http://example.com/in-flight-dedup-identical/';
+      let started = new Deferred<void>();
+      let release = new Deferred<void>();
+
+      let worker = new PgQueueRunner({
+        adapter,
+        workerId: 'in-flight-dedup-worker',
+      });
+      worker.register(
+        'incremental-index',
+        async (args: { changes: { url: string }[] }) => {
+          started.fulfill();
+          await release.promise;
+          return {
+            invalidations: args.changes.map((change) => change.url),
+            ignoreData: {},
+            stats: {
+              instancesIndexed: 0,
+              filesIndexed: 0,
+              instanceErrors: 0,
+              fileErrors: 0,
+              totalIndexEntries: 0,
+            },
+          };
+        },
+      );
+
+      try {
+        await worker.start();
+
+        let first = await publishIncrementalIndexJob({
+          clientRequestId: 'request-1',
+          args: {
+            realmURL,
+            realmUsername: 'owner',
+            ignoreData: {},
+            changes: [{ url: `${realmURL}a`, operation: 'update' }],
+          },
+        });
+        // Wait for the worker to actually claim and start running the
+        // job before publishing the duplicate, otherwise we'd be testing
+        // pre-claim coalesce instead.
+        await started.promise;
+
+        let second = await publishIncrementalIndexJob({
+          clientRequestId: 'request-2',
+          args: {
+            realmURL,
+            realmUsername: 'owner',
+            ignoreData: {},
+            changes: [{ url: `${realmURL}a`, operation: 'update' }],
+          },
+        });
+
+        assert.strictEqual(
+          first.id,
+          second.id,
+          'duplicate publish reuses the in-flight job id instead of creating a new row',
+        );
+
+        let rows = (await adapter.execute(
+          `SELECT id
+             FROM jobs
+             WHERE concurrency_group = $1
+               AND status = 'unfulfilled'`,
+          { bind: [`indexing:${realmURL}`] },
+        )) as { id: number }[];
+        assert.strictEqual(
+          rows.length,
+          1,
+          'only one incremental-index row exists; duplicate did not enqueue a second job',
+        );
+
+        release.fulfill();
+        let [firstResult, secondResult] = await Promise.all([
+          first.done,
+          second.done,
+        ]);
+        assert.strictEqual(firstResult.clientRequestId, 'request-1');
+        assert.strictEqual(secondResult.clientRequestId, 'request-2');
+        assert.deepEqual(firstResult.invalidations, [`${realmURL}a`]);
+        assert.deepEqual(secondResult.invalidations, [`${realmURL}a`]);
+      } finally {
+        release.fulfill();
+        await worker.destroy();
+      }
+    });
+
+    test('incremental dedup: an incoming subset of the in-flight change set attaches as a late waiter', async function (assert) {
+      // Subset case: in-flight job is processing [a,b] and a new publish
+      // arrives for just [a]. The running indexing pass already covers
+      // url a, so the new caller can reuse it.
+      await runner.destroy();
+      let realmURL = 'http://example.com/in-flight-dedup-subset/';
+      let started = new Deferred<void>();
+      let release = new Deferred<void>();
+
+      let worker = new PgQueueRunner({
+        adapter,
+        workerId: 'in-flight-dedup-subset-worker',
+      });
+      worker.register(
+        'incremental-index',
+        async (args: { changes: { url: string }[] }) => {
+          started.fulfill();
+          await release.promise;
+          return {
+            invalidations: args.changes.map((change) => change.url),
+            ignoreData: {},
+            stats: {
+              instancesIndexed: 0,
+              filesIndexed: 0,
+              instanceErrors: 0,
+              fileErrors: 0,
+              totalIndexEntries: 0,
+            },
+          };
+        },
+      );
+
+      try {
+        await worker.start();
+
+        let first = await publishIncrementalIndexJob({
+          clientRequestId: 'request-1',
+          args: {
+            realmURL,
+            realmUsername: 'owner',
+            ignoreData: {},
+            changes: [
+              { url: `${realmURL}a`, operation: 'update' },
+              { url: `${realmURL}b`, operation: 'update' },
+            ],
+          },
+        });
+        await started.promise;
+
+        let second = await publishIncrementalIndexJob({
+          clientRequestId: 'request-2',
+          args: {
+            realmURL,
+            realmUsername: 'owner',
+            ignoreData: {},
+            changes: [{ url: `${realmURL}a`, operation: 'update' }],
+          },
+        });
+
+        assert.strictEqual(
+          first.id,
+          second.id,
+          'subset publish reuses the in-flight job id',
+        );
+
+        let rows = (await adapter.execute(
+          `SELECT id
+             FROM jobs
+             WHERE concurrency_group = $1
+               AND status = 'unfulfilled'`,
+          { bind: [`indexing:${realmURL}`] },
+        )) as { id: number }[];
+        assert.strictEqual(rows.length, 1);
+
+        release.fulfill();
+        let [firstResult, secondResult] = await Promise.all([
+          first.done,
+          second.done,
+        ]);
+        assert.strictEqual(firstResult.clientRequestId, 'request-1');
+        assert.strictEqual(secondResult.clientRequestId, 'request-2');
+      } finally {
+        release.fulfill();
+        await worker.destroy();
+      }
+    });
+
+    test('incremental dedup: incoming with a non-covered url enqueues a new job', async function (assert) {
+      // The running job is not a superset, so the late publish must
+      // enqueue its own job. Otherwise the new url would never be
+      // indexed.
+      await runner.destroy();
+      let realmURL = 'http://example.com/in-flight-dedup-different/';
+      let started = new Deferred<void>();
+      let release = new Deferred<void>();
+
+      let invocations = 0;
+      let worker = new PgQueueRunner({
+        adapter,
+        workerId: 'in-flight-dedup-diff-worker',
+      });
+      worker.register(
+        'incremental-index',
+        async (args: { changes: { url: string }[] }) => {
+          invocations += 1;
+          if (invocations === 1) {
+            started.fulfill();
+            await release.promise;
+          }
+          return {
+            invalidations: args.changes.map((change) => change.url),
+            ignoreData: {},
+            stats: {
+              instancesIndexed: 0,
+              filesIndexed: 0,
+              instanceErrors: 0,
+              fileErrors: 0,
+              totalIndexEntries: 0,
+            },
+          };
+        },
+      );
+
+      try {
+        await worker.start();
+
+        let first = await publishIncrementalIndexJob({
+          clientRequestId: 'request-1',
+          args: {
+            realmURL,
+            realmUsername: 'owner',
+            ignoreData: {},
+            changes: [{ url: `${realmURL}a`, operation: 'update' }],
+          },
+        });
+        await started.promise;
+
+        let second = await publishIncrementalIndexJob({
+          clientRequestId: 'request-2',
+          args: {
+            realmURL,
+            realmUsername: 'owner',
+            ignoreData: {},
+            changes: [{ url: `${realmURL}b`, operation: 'update' }],
+          },
+        });
+
+        assert.notStrictEqual(
+          first.id,
+          second.id,
+          'non-covered publish does not attach to the in-flight job',
+        );
+
+        let rows = (await adapter.execute(
+          `SELECT id, args
+             FROM jobs
+             WHERE concurrency_group = $1
+               AND status = 'unfulfilled'
+             ORDER BY id`,
+          { bind: [`indexing:${realmURL}`] },
+        )) as { id: number; args: { changes: { url: string }[] } }[];
+        assert.strictEqual(
+          rows.length,
+          2,
+          'two distinct rows exist when the in-flight changes do not cover the incoming changes',
+        );
+      } finally {
+        release.fulfill();
+        await worker.destroy();
+      }
+    });
+
+    test('incremental dedup: operation mismatch enqueues a new job even when urls match', async function (assert) {
+      // An in-flight `update` on url X does not satisfy a new `delete`
+      // on the same X — they are different operations and must run as
+      // separate work.
+      await runner.destroy();
+      let realmURL = 'http://example.com/in-flight-dedup-op-mismatch/';
+      let started = new Deferred<void>();
+      let release = new Deferred<void>();
+
+      let invocations = 0;
+      let worker = new PgQueueRunner({
+        adapter,
+        workerId: 'in-flight-dedup-op-worker',
+      });
+      worker.register(
+        'incremental-index',
+        async (args: { changes: { url: string }[] }) => {
+          invocations += 1;
+          if (invocations === 1) {
+            started.fulfill();
+            await release.promise;
+          }
+          return {
+            invalidations: args.changes.map((change) => change.url),
+            ignoreData: {},
+            stats: {
+              instancesIndexed: 0,
+              filesIndexed: 0,
+              instanceErrors: 0,
+              fileErrors: 0,
+              totalIndexEntries: 0,
+            },
+          };
+        },
+      );
+
+      try {
+        await worker.start();
+
+        let first = await publishIncrementalIndexJob({
+          clientRequestId: 'request-1',
+          args: {
+            realmURL,
+            realmUsername: 'owner',
+            ignoreData: {},
+            changes: [{ url: `${realmURL}a`, operation: 'update' }],
+          },
+        });
+        await started.promise;
+
+        let second = await publishIncrementalIndexJob({
+          clientRequestId: 'request-2',
+          args: {
+            realmURL,
+            realmUsername: 'owner',
+            ignoreData: {},
+            changes: [{ url: `${realmURL}a`, operation: 'delete' }],
+          },
+        });
+
+        assert.notStrictEqual(
+          first.id,
+          second.id,
+          'operation mismatch publish does not attach to the in-flight job',
+        );
+
+        let rows = (await adapter.execute(
+          `SELECT id
+             FROM jobs
+             WHERE concurrency_group = $1
+               AND status = 'unfulfilled'`,
+          { bind: [`indexing:${realmURL}`] },
+        )) as { id: number }[];
+        assert.strictEqual(rows.length, 2);
+      } finally {
+        release.fulfill();
+        await worker.destroy();
+      }
+    });
+
     test('incremental does not coalesce onto pending from-scratch in same group', async function (assert) {
       await runner.destroy();
 

--- a/packages/runtime-common/queue.ts
+++ b/packages/runtime-common/queue.ts
@@ -42,6 +42,14 @@ export interface QueueCoalesceCandidate extends QueueJobSpec {
 export interface QueueCoalesceContext {
   incoming: QueueJobSpec;
   candidates: QueueCoalesceCandidate[];
+  // Unfulfilled jobs in the concurrency group whose worker has already
+  // claimed them (an active job_reservations row exists). The worker has
+  // already loaded args into memory, so DB-side args mutations won't
+  // propagate. Attaching here is purely "register a late waiter on this
+  // jobId"; the publish path will not call the join `update` for an
+  // in-flight target. Handlers must verify the running job's existing
+  // work covers the incoming request before joining.
+  inFlightCandidates: QueueCoalesceCandidate[];
 }
 
 export type QueueCoalesceJoinUpdate = Partial<

--- a/packages/runtime-common/tasks/indexer.ts
+++ b/packages/runtime-common/tasks/indexer.ts
@@ -153,47 +153,87 @@ function parseIncrementalArgsForCoalesce(
   };
 }
 
+function incrementalChangesCover(
+  existing: IncrementalChange[],
+  incoming: IncrementalChange[],
+): boolean {
+  let existingByUrl = new Map<string, IncrementalChange>();
+  for (let change of existing) {
+    existingByUrl.set(change.url, change);
+  }
+  for (let change of incoming) {
+    let match = existingByUrl.get(change.url);
+    if (!match || match.operation !== change.operation) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function chooseIncrementalCoalesceDecision(
   context: QueueCoalesceContext,
 ): QueueCoalesceDecision {
-  let { incoming, candidates } = context;
+  let { incoming, candidates, inFlightCandidates } = context;
   let sameTypeCandidate = candidates.find(
     (candidate) => candidate.jobType === incoming.jobType,
   );
-  if (!sameTypeCandidate) {
-    return { type: 'insert' };
-  }
+  if (sameTypeCandidate) {
+    let existingArgs = parseIncrementalArgsForCoalesce(sameTypeCandidate.args);
+    let incomingArgs = parseIncrementalArgsForCoalesce(incoming.args);
+    if (!existingArgs || !incomingArgs) {
+      return {
+        type: 'join',
+        jobId: sameTypeCandidate.id,
+        update: {
+          ...maxPriorityAndTimeout(sameTypeCandidate, incoming),
+        },
+      };
+    }
 
-  let existingArgs = parseIncrementalArgsForCoalesce(sameTypeCandidate.args);
-  let incomingArgs = parseIncrementalArgsForCoalesce(incoming.args);
-  if (!existingArgs || !incomingArgs) {
     return {
       type: 'join',
       jobId: sameTypeCandidate.id,
       update: {
         ...maxPriorityAndTimeout(sameTypeCandidate, incoming),
+        args: {
+          ...existingArgs,
+          changes: mergeIncrementalChanges(
+            existingArgs.changes,
+            incomingArgs.changes,
+          ),
+          coalescedCallers: mergeCoalescedCallers(
+            existingArgs.coalescedCallers,
+            incomingArgs.coalescedCallers,
+          ),
+        },
       },
     };
   }
 
-  return {
-    type: 'join',
-    jobId: sameTypeCandidate.id,
-    update: {
-      ...maxPriorityAndTimeout(sameTypeCandidate, incoming),
-      args: {
-        ...existingArgs,
-        changes: mergeIncrementalChanges(
-          existingArgs.changes,
-          incomingArgs.changes,
-        ),
-        coalescedCallers: mergeCoalescedCallers(
-          existingArgs.coalescedCallers,
-          incomingArgs.coalescedCallers,
-        ),
-      },
-    },
-  };
+  // No still-pending candidate to merge into. Closes the race where the
+  // PATCH-path enqueue gets claimed by a worker before the file-watcher
+  // echo (or any second wave of callers) can attach via pre-claim
+  // coalesce. We piggyback on the running job, but only when its args
+  // already cover every (url, operation) we need — operation mismatch
+  // (update vs delete) means different work, so we must enqueue a new
+  // job in that case.
+  let incomingArgs = parseIncrementalArgsForCoalesce(incoming.args);
+  if (incomingArgs) {
+    for (let candidate of inFlightCandidates) {
+      if (candidate.jobType !== incoming.jobType) {
+        continue;
+      }
+      let existingArgs = parseIncrementalArgsForCoalesce(candidate.args);
+      if (!existingArgs) {
+        continue;
+      }
+      if (incrementalChangesCover(existingArgs.changes, incomingArgs.changes)) {
+        return { type: 'join', jobId: candidate.id };
+      }
+    }
+  }
+
+  return { type: 'insert' };
 }
 
 function chooseFromScratchCoalesceDecision(


### PR DESCRIPTION
## Problem

A single file edit can enqueue multiple `incremental-index` jobs with identical `args.changes`. They share a `concurrency_group` so they serialize on the same worker, but the worker still runs the same indexing pass twice — fusing, rendering, and committing for module + instance for no behavioral benefit.

### Observed on staging 2026-05-04

A single edit to `cmgardella/adorn-mockups/blog-post.gts` produced two `incremental-index` jobs:

| job | created | claimed | finished | duration | args.changes |
| -- | -- | -- | -- | -- | -- |
| `301763` | 14:09:20.187 | 14:09:20.220 | 14:09:32 | 12s | `[{url: …blog-post.gts, op: update}]` |
| `301772` | 14:09:20.426 | 14:09:32 | 14:09:44 | 12s | `[{url: …blog-post.gts, op: update}]` |

Same `concurrency_group: indexing:https://realms-staging.stack.cards/cmgardella/adorn-mockups/`. **23.7 seconds of indexing for one ~12s pass of real work.**

`301772` had `coalescedCallers` with 8 entries — the existing coalesce did merge 8 simultaneous callers into one job. The race is what `301763` represents: a separate coalescing batch published 240ms earlier and got claimed almost immediately, after which the second wave couldn't merge into it.

## Why the existing coalesce isn't enough

`PgQueuePublisher.coalesceAndGetCanonicalJobId` already serializes publishes against a per–concurrency-group advisory lock and asks the registered handler to either insert a new job or join an existing one. But the candidate set comes from `findPendingCandidates`, which filters to status='unfulfilled' rows that have **no active `job_reservations` row**:

```sql
SELECT j.id, …
FROM jobs j
WHERE j.status='unfulfilled'
  AND j.concurrency_group IS NOT DISTINCT FROM $1
  AND NOT EXISTS (active reservation)
ORDER BY j.created_at, j.id
FOR UPDATE
```

Once a worker has claimed the first job — which happens within tens of milliseconds of the publish — that row is excluded from `candidates`. The second wave of callers sees an empty candidate list and the handler has no choice but to insert a new job. `updateJobForCoalesce` and `jobIsPendingAndUnreserved` both gate on the same "no active reservation" predicate, so even a hypothetical handler that returned `{ type: 'join', jobId: <reserved> }` would force an infinite retry. So the existing pre-claim coalesce only covers callers that arrive while the canonical job is still queueable; it cannot rescue duplicate work that races past that window.

The 240ms gap between `301763` and `301772` is consistent with the file-watcher echo path firing just after the PATCH path's job became claimable.

## Approach

Extend `QueueCoalesceContext` with an `inFlightCandidates: QueueCoalesceCandidate[]` list and let opted-in handlers attach the new caller as a late waiter on a running job — without mutating the running args.

The publisher's transaction already holds an advisory lock on the concurrency group, so the candidate query is widened to all status='unfulfilled' rows in the group, separated into pending vs. in-flight by an `EXISTS` check on `job_reservations`. Pending rows are still locked `FOR UPDATE` — concurrent publishers must mutex on them. In-flight rows are only read; the worker is the only writer that should commit a status change on them, and the advisory lock keeps another publisher off this concurrency group while we decide.

When a handler returns `{ type: 'join', jobId }` and `jobId` belongs to the in-flight set, the publisher skips `jobIsPendingAndUnreserved` and `updateJobForCoalesce` (both reject in-flight rows by design) and goes straight to `addWaiter(jobId, …)`. The worker has already loaded args into memory and would not see a DB-side args mutation, so the join must not include an `update`; this is enforced as a hard error.

Existing handlers (`copy-index`, `from-scratch-index`, `full-reindex`, and the test-only handlers in `queue-test.ts`) continue to ignore `inFlightCandidates`. Their behavior is unchanged — they still see only pending candidates, and `'coalesce does not join pending jobs that already have an active reservation'` and `'coalesce does not join a currently running job in same concurrency group'` keep passing for them.

### Incremental handler dedup criterion

`chooseIncrementalCoalesceDecision` now does:

1. If there's a still-pending `incremental-index` candidate, merge into it (existing union-changes + union-coalescedCallers behavior, **unchanged**).
2. Otherwise, check `inFlightCandidates`: attach if some `incremental-index` candidate's `args.changes` covers every `(url, operation)` in the incoming request.
3. Otherwise, insert.

"Covers" is strict: every incoming `(url, operation)` must appear identically in the existing changes. An in-flight `update` of url X does **not** satisfy a new `delete` of url X — they're different work. A non-covered change forces a new job because the running pass would otherwise never index the new url.

### Why no DB-level args.coalescedCallers update on attach

The running worker has already loaded `args` from its claim-time `SELECT`; it doesn't re-read after starting. Updating `args.coalescedCallers` on the in-flight row would not propagate to the worker — and once the worker commits the finalize, the update would race against status='resolved' and either silently lose or trigger a serialization retry that would attempt to insert a new job (worse than doing nothing). The functional outcome — both callers' `done` promises resolve with the result of the in-flight pass via `addWaiter` and the per-caller `mapResult` mapper — is achieved without mutating the running job. We log the attach at `debug` level for diagnostics; the per-job `coalescedCallers` audit count will undercount late attaches, which is a minor diagnostic regression we can address later if needed.

### Why widening the SELECT is safe

The publisher transaction is `SERIALIZABLE` and holds an advisory lock on the concurrency group. The worker's claim transaction also acquires that advisory lock, so the two cannot interleave during the candidate-selection phase. The worker's finalize transaction does not acquire the advisory lock, so it can commit while the publisher is mid-transaction; if it does, our snapshot may show the row as still 'unfulfilled' with an active reservation. The `addWaiter` path tolerates that: the next `jobs_finished` notification (or the 10s poll fallback) re-queries the row and resolves the late waiter. No new race vs. the existing pre-claim path.

### Why the FROM_SCRATCH / copy / full-reindex handlers are untouched

The duplicates we see in production are incremental-index. From-scratch and copy-index are rare enough that the same race hasn't been observed, and full-reindex's existing coalesce already unions `realmUrls` for callers who arrive before claim. The new `inFlightCandidates` field is opt-in: a handler that doesn't reference it gets no behavior change, so no code change is needed for them.

## Files

- `packages/runtime-common/queue.ts` — adds `inFlightCandidates: QueueCoalesceCandidate[]` to `QueueCoalesceContext`.
- `packages/postgres/pg-queue.ts` — replaces `findPendingCandidates` with `findCoalesceCandidates` returning `{ pending, inFlight }`. `coalesceAndGetCanonicalJobId` short-circuits `jobIsPendingAndUnreserved` + `updateJobForCoalesce` when the chosen jobId is in-flight, and rejects join-with-update for in-flight targets.
- `packages/runtime-common/tasks/indexer.ts` — `chooseIncrementalCoalesceDecision` prefers a pending candidate, then falls back to attaching to an in-flight candidate whose `args.changes` covers the incoming changes.
- `packages/realm-server/tests/queue-test.ts` — four new tests cover identical, subset, non-covered, and operation-mismatch cases.

## Tests

26/26 in `queue-test.ts` pass, including the four new ones:

- `incremental dedup: a duplicate publish for an in-flight job attaches as a late waiter` — staging-mirrored case; same urls, same op.
- `incremental dedup: an incoming subset of the in-flight change set attaches as a late waiter` — running pass already covers more than the incoming caller needs.
- `incremental dedup: incoming with a non-covered url enqueues a new job` — must not attach when the new url would otherwise never index.
- `incremental dedup: operation mismatch enqueues a new job even when urls match` — `update` vs `delete` is different work.

Existing regression coverage that exercises the same publish path:
- `coalesce does not join pending jobs that already have an active reservation` — existing handler ignores `inFlightCandidates`, still inserts.
- `coalesce does not join a currently running job in same concurrency group` — same.
- `incremental coalesce merges mixed operations and persists per-caller metadata` — pre-claim coalesce still wins when a pending candidate exists.
- `coalesced incremental waiters each receive their own clientRequestId in done payload` — per-caller mapper closure unchanged.

## Acceptance criteria — status

- ✅ Single PATCH that triggers both write-path enqueue and file-watcher echo produces exactly **one** `incremental-index` job in `jobs` (verified by the duplicate-publish test).
- ⚠️ "Second enqueue path attaches as a `coalescedCaller`" — realized as an in-memory waiter on the canonical job, not an update of `args.coalescedCallers` in the DB. The functional outcome (one indexing pass, both callers receive the result) holds; the DB audit count for late attaches will undercount. Documented above.
- ✅ Workers don't run the same `incremental-index` `args.changes` payload twice in a row for the same realm under normal write traffic.
- ✅ No regression in N-callers-coalesced-into-one-job behavior — all existing pre-claim coalesce tests pass.

## Out of scope

- Worker rollover orphan recovery — CS-11012.
- Write-path gate latency — CS-11011 (unblocked by this PR: every duplicate eliminated here is one fewer `indexingDeferred` extending CS-11011's gate).
- File-watcher echo suppression at the source (`trackOwnWrite` TTL/timing) — defense in depth, deferred.

## Test plan

- [x] `pnpm test` filtered to `queue-test.ts` in `packages/realm-server` — 26/26 green
- [x] `pnpm exec ember-tsc --noEmit` in `packages/postgres` — clean
- [x] `pnpm exec eslint` on each modified file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)