### PR TITLE
CS-10953: cross-process populate coordination for CachingDefinitionLookup

### DIFF
--- a/packages/realm-server/lib/module-cache-coordination.ts
+++ b/packages/realm-server/lib/module-cache-coordination.ts
@@ -1,0 +1,264 @@
+import { createHash } from 'crypto';
+import {
+  logger,
+  MODULE_CACHE_POPULATED_CHANNEL,
+  param,
+  type Expression,
+  type PgPrimitive,
+  type PopulateCoordinator,
+} from '@cardstack/runtime-common';
+import type { NotificationSubscription, PgAdapter } from '@cardstack/postgres';
+
+const log = logger('realm-server:module-cache-coordination');
+
+// Hash a coalesce key to a stable signed int64 string for use as a
+// pg advisory lock key. Same shape as hashRealmUrlForAdvisoryLock — sha256
+// + readBigInt64BE + toString — so the int64 range is fully utilized and
+// callers don't need BigInt-aware parameter binding. Two separate
+// keyspaces (realm-write locks vs coalesce locks) coexist in pg's single
+// advisory-lock namespace; collision probability is negligible at any
+// realistic scale.
+function hashCoalesceKeyForAdvisoryLock(key: string): string {
+  const digest = createHash('sha256').update(key).digest();
+  return digest.readBigInt64BE(0).toString();
+}
+
+// Implements PopulateCoordinator (CS-10953). Owns:
+//   - a subscription on `module_cache_populated` via the shared multiplexed
+//     notification client (`PgAdapter.subscribe`), same pattern as
+//     ModuleCacheInvalidationListener;
+//   - a Map<coalesceKey, Set<waiter>> that NOTIFY payloads dispatch into;
+//   - a `tryAcquireAndRun` method that opens a pinned pool connection,
+//     attempts a non-blocking advisory xact-lock keyed on the hash of
+//     the coalesce key, and (if won) runs `fn` inside the BEGIN/COMMIT
+//     window with a `pg_notify` emit between persist and commit.
+//
+// The pinned connection ONLY holds the advisory lock and emits the
+// NOTIFY. The `fn` callback issues its DB work (readFromDatabaseCache,
+// persistModuleCacheEntry) through the shared dbAdapter — a separate
+// pool connection autocommits each query as today. Pool pressure is
+// bounded by N processes (each pins one extra client per concurrent
+// coordinated load) rather than N × M concurrent callers, since the
+// in-process #inFlight coalescer fans every same-key callers into one
+// coordinated load per process.
+//
+// `pg_try_advisory_xact_lock` is non-blocking by design: a blocking
+// `pg_advisory_xact_lock` would hold a pool client for the full
+// prerender wall time (up to 150s in production) on every loser,
+// quickly exhausting the pool. Losers release their pinned connection
+// immediately on contention and instead wait on NOTIFY — much cheaper
+// to multiplex.
+//
+// Behavior at N=1: the try-lock always succeeds uncontended; loser
+// path is never taken; self-NOTIFY is dropped because there are no
+// waiters registered.
+//
+// Sqlite/in-memory deployments don't construct a coordinator — when
+// `dbAdapter.kind !== 'pg'` the realm-server `main.ts` skips
+// constructing this and CachingDefinitionLookup runs its uncoordinated
+// path.
+export interface ModuleCacheCoordinatorDeps {
+  dbAdapter: PgAdapter;
+}
+
+interface KeyWaiter {
+  resolve: () => void;
+}
+
+export class ModuleCacheCoordinator implements PopulateCoordinator {
+  #deps: ModuleCacheCoordinatorDeps;
+  #subscription?: NotificationSubscription;
+  #starting?: Promise<void>;
+  #waiters = new Map<string, Set<KeyWaiter>>();
+
+  constructor(deps: ModuleCacheCoordinatorDeps) {
+    this.#deps = deps;
+  }
+
+  async start(): Promise<void> {
+    if (this.#subscription || this.#starting) {
+      await this.#starting;
+      return;
+    }
+    this.#starting = (async () => {
+      this.#subscription = await this.#deps.dbAdapter.subscribe(
+        MODULE_CACHE_POPULATED_CHANNEL,
+        (notification) => {
+          this.#dispatch(notification.payload);
+        },
+      );
+    })();
+    try {
+      await this.#starting;
+    } finally {
+      this.#starting = undefined;
+    }
+  }
+
+  async shutDown(): Promise<void> {
+    // Wait for any in-flight start() to finish wiring up #subscription
+    // before tearing down. Otherwise shutDown can run while subscribe()
+    // is still awaiting the LISTEN, return early with #subscription
+    // still undefined, and the racing start() then installs a live
+    // subscription after we thought we were shut down. Swallow start()
+    // errors here — if startup failed, there's nothing to unsubscribe.
+    try {
+      await this.#starting;
+    } catch {
+      // ignore
+    }
+    const sub = this.#subscription;
+    this.#subscription = undefined;
+    await sub?.unsubscribe();
+    // Resolve any waiters still parked so callers don't hang forever
+    // during a clean shutdown. Their loops will re-read the cache on
+    // wake and either return the row or surface a transient miss as a
+    // normal undefined.
+    for (let waiters of this.#waiters.values()) {
+      for (let waiter of waiters) {
+        waiter.resolve();
+      }
+    }
+    this.#waiters.clear();
+  }
+
+  // PopulateCoordinator — winner path.
+  async tryAcquireAndRun<T>(
+    coalesceKey: string,
+    fn: () => Promise<T>,
+  ): Promise<{ acquired: true; result: T } | { acquired: false }> {
+    const lockKey = hashCoalesceKeyForAdvisoryLock(coalesceKey);
+    return await this.#deps.dbAdapter.withConnection(async (queryFn) => {
+      await queryFn(['BEGIN']);
+      let lockResult: Record<string, PgPrimitive>[];
+      try {
+        lockResult = await queryFn([
+          'SELECT pg_try_advisory_xact_lock(',
+          param(lockKey),
+          '::bigint) AS got',
+        ]);
+      } catch (err: unknown) {
+        await this.#safeRollback(queryFn);
+        throw err;
+      }
+      const got = lockResult[0]?.got === true;
+      if (!got) {
+        // Contended. Release the pool client immediately so the loser
+        // doesn't hold a pinned connection for the duration of the
+        // peer's prerender (could be many seconds; would exhaust the
+        // pool under N>>1 concurrency).
+        await this.#safeRollback(queryFn);
+        return { acquired: false };
+      }
+      try {
+        const result = await fn();
+        // Emit pg_notify INSIDE the same transaction as the lock so
+        // peers only see the signal on commit. The persist itself ran
+        // through the shared dbAdapter (already autocommitted), so the
+        // row is visible by the time peers re-read on wake.
+        //
+        // We notify regardless of whether `fn` produced a row or
+        // undefined — a "no row" outcome (all populationCandidates
+        // produced missing-module errors, or generation-changed
+        // returned post-invalidate state) still wants to wake peers
+        // promptly so they don't sit on the COALESCE_NOTIFY_WAIT_MS
+        // timeout. Peers re-read the cache on wake; if it's empty,
+        // they return undefined and the user sees the same answer
+        // we returned, just faster than a missed-NOTIFY would.
+        await queryFn([
+          'SELECT pg_notify(',
+          param(MODULE_CACHE_POPULATED_CHANNEL),
+          ',',
+          param(coalesceKey),
+          ')',
+        ]);
+        await queryFn(['COMMIT']);
+        return { acquired: true, result };
+      } catch (err: unknown) {
+        await this.#safeRollback(queryFn);
+        throw err;
+      }
+    });
+  }
+
+  // PopulateCoordinator — loser path. Resolves on either NOTIFY or
+  // timeout; the caller's outer loop re-reads the cache regardless.
+  async waitForKey(coalesceKey: string, timeoutMs: number): Promise<void> {
+    return await new Promise((resolve) => {
+      let resolved = false;
+      const settle = () => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(timer);
+        // Best-effort waiter unregister so the dispatch path doesn't
+        // leak a stale entry. If we already left via NOTIFY the entry
+        // is already gone; if we left via timeout we need to clean up.
+        const set = this.#waiters.get(coalesceKey);
+        if (set) {
+          set.delete(waiter);
+          if (set.size === 0) {
+            this.#waiters.delete(coalesceKey);
+          }
+        }
+        resolve();
+      };
+      const waiter: KeyWaiter = { resolve: settle };
+      let set = this.#waiters.get(coalesceKey);
+      if (!set) {
+        set = new Set();
+        this.#waiters.set(coalesceKey, set);
+      }
+      set.add(waiter);
+      const timer = setTimeout(settle, timeoutMs);
+      // unref so a hung waiter doesn't hold the Node event loop open
+      // during shutdown / test teardown. Real workloads won't reach
+      // the timeout in healthy operation.
+      if (typeof (timer as { unref?: () => void }).unref === 'function') {
+        (timer as { unref: () => void }).unref();
+      }
+    });
+  }
+
+  // Exposed for tests.
+  handleNotification(payload: string | undefined): void {
+    this.#dispatch(payload);
+  }
+
+  #dispatch(payload: string | undefined): void {
+    if (!payload) {
+      return;
+    }
+    // Payload is the raw inFlightKey (coalesce key). No structure to
+    // parse — just look it up in the waiter map and resolve everyone
+    // parked on it.
+    const set = this.#waiters.get(payload);
+    if (!set) {
+      return;
+    }
+    this.#waiters.delete(payload);
+    for (let waiter of set) {
+      try {
+        waiter.resolve();
+      } catch (err: unknown) {
+        log.warn(
+          `${MODULE_CACHE_POPULATED_CHANNEL} waiter resolve threw for ${payload}: ${String(err)}`,
+        );
+      }
+    }
+  }
+
+  async #safeRollback(
+    queryFn: (expr: Expression) => Promise<Record<string, PgPrimitive>[]>,
+  ): Promise<void> {
+    try {
+      await queryFn(['ROLLBACK']);
+    } catch (rollbackErr: unknown) {
+      // The xact-lock and any in-tx state release when the connection's
+      // transaction is aborted — pg auto-rolls back on client release —
+      // so we don't have a stale-lock problem. Log for visibility.
+      log.warn(
+        `ROLLBACK after coordinator error failed: ${String(rollbackErr)}`,
+      );
+    }
+  }
+}

--- a/packages/realm-server/lib/module-cache-coordination.ts
+++ b/packages/realm-server/lib/module-cache-coordination.ts
@@ -12,13 +12,24 @@ import type { NotificationSubscription, PgAdapter } from '@cardstack/postgres';
 const log = logger('realm-server:module-cache-coordination');
 
 // Hash a coalesce key to a stable signed int64 string for use as a
-// pg advisory lock key. Same shape as hashRealmUrlForAdvisoryLock — sha256
+// pg advisory lock key AND as the bounded payload we send through
+// pg_notify. Same shape as hashRealmUrlForAdvisoryLock — sha256
 // + readBigInt64BE + toString — so the int64 range is fully utilized and
 // callers don't need BigInt-aware parameter binding. Two separate
 // keyspaces (realm-write locks vs coalesce locks) coexist in pg's single
 // advisory-lock namespace; collision probability is negligible at any
 // realistic scale.
-function hashCoalesceKeyForAdvisoryLock(key: string): string {
+//
+// Using the hashed id as the NOTIFY payload guarantees we stay well
+// under Postgres's ~8000-byte payload cap regardless of how long the
+// raw coalesce key gets (it concatenates realm URL + module URL +
+// scope + user id; pathological URLs could otherwise overflow). The
+// `#waiters` map is keyed off the same hashed id so the dispatch
+// path matches.
+//
+// Exported for tests that manually emit pg_notify and need to address
+// a specific waiter.
+export function hashCoalesceKeyForAdvisoryLock(key: string): string {
   const digest = createHash('sha256').update(key).digest();
   return digest.readBigInt64BE(0).toString();
 }
@@ -169,7 +180,9 @@ export class ModuleCacheCoordinator implements PopulateCoordinator {
           'SELECT pg_notify(',
           param(MODULE_CACHE_POPULATED_CHANNEL),
           ',',
-          param(coalesceKey),
+          // Use the bounded int64 hash, not the raw coalesce key —
+          // see hashCoalesceKeyForAdvisoryLock for the cap rationale.
+          param(lockKey),
           ')',
         ]);
         await queryFn(['COMMIT']);
@@ -184,32 +197,38 @@ export class ModuleCacheCoordinator implements PopulateCoordinator {
   // PopulateCoordinator — loser path. Resolves on either NOTIFY or
   // timeout; the caller's outer loop re-reads the cache regardless.
   async waitForKey(coalesceKey: string, timeoutMs: number): Promise<void> {
+    // Key the waiter off the same bounded hash we use as the NOTIFY
+    // payload, so #dispatch can match incoming notifications.
+    const waiterKey = hashCoalesceKeyForAdvisoryLock(coalesceKey);
     return await new Promise((resolve) => {
       let resolved = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
       const settle = () => {
         if (resolved) return;
         resolved = true;
-        clearTimeout(timer);
+        if (timer !== undefined) {
+          clearTimeout(timer);
+        }
         // Best-effort waiter unregister so the dispatch path doesn't
         // leak a stale entry. If we already left via NOTIFY the entry
         // is already gone; if we left via timeout we need to clean up.
-        const set = this.#waiters.get(coalesceKey);
+        const set = this.#waiters.get(waiterKey);
         if (set) {
           set.delete(waiter);
           if (set.size === 0) {
-            this.#waiters.delete(coalesceKey);
+            this.#waiters.delete(waiterKey);
           }
         }
         resolve();
       };
       const waiter: KeyWaiter = { resolve: settle };
-      let set = this.#waiters.get(coalesceKey);
+      let set = this.#waiters.get(waiterKey);
       if (!set) {
         set = new Set();
-        this.#waiters.set(coalesceKey, set);
+        this.#waiters.set(waiterKey, set);
       }
       set.add(waiter);
-      const timer = setTimeout(settle, timeoutMs);
+      timer = setTimeout(settle, timeoutMs);
       // unref so a hung waiter doesn't hold the Node event loop open
       // during shutdown / test teardown. Real workloads won't reach
       // the timeout in healthy operation.
@@ -228,9 +247,9 @@ export class ModuleCacheCoordinator implements PopulateCoordinator {
     if (!payload) {
       return;
     }
-    // Payload is the raw inFlightKey (coalesce key). No structure to
-    // parse — just look it up in the waiter map and resolve everyone
-    // parked on it.
+    // Payload is the bounded int64 hash of the coalesce key (see
+    // hashCoalesceKeyForAdvisoryLock). #waiters is keyed off the same
+    // hash, so we look up directly with no structure to parse.
     const set = this.#waiters.get(payload);
     if (!set) {
       return;

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -37,6 +37,7 @@ import {
 } from './lib/realm-registry-reconciler';
 import { RealmFileChangesListener } from './lib/realm-file-changes-listener';
 import { ModuleCacheInvalidationListener } from './lib/module-cache-invalidation-listener';
+import { ModuleCacheCoordinator } from './lib/module-cache-coordination';
 import { PUBLISHED_DIRECTORY_NAME } from '@cardstack/runtime-common';
 
 let log = logger('main');
@@ -110,6 +111,14 @@ const FULL_INDEX_ON_STARTUP =
 // test's first lookupDefinition.
 const SKIP_MODULES_CACHE_CLEAR_ON_STARTUP =
   process.env.REALM_SERVER_SKIP_MODULES_CACHE_CLEAR_ON_STARTUP === 'true';
+// CS-10953 cross-process prerender coalesce. Off by default — flip on
+// after a stage burn-in. Effectively inert at N=1 (no contention; the
+// in-process #inFlight coalescer already dedups same-process callers),
+// but the extra BEGIN/try-lock/COMMIT roundtrip on every cache miss is
+// measurable, so we ship dormant and flip explicitly. At N>1 enables
+// 1-prerender-per-fleet on cold fan-out.
+const PRERENDER_COALESCE_ACROSS_PROCESSES =
+  process.env.PRERENDER_COALESCE_ACROSS_PROCESSES === 'true';
 
 let {
   port,
@@ -289,6 +298,7 @@ const getIndexHTML = async () => {
   let moduleCacheInvalidationListener:
     | ModuleCacheInvalidationListener
     | undefined;
+  let moduleCacheCoordinator: ModuleCacheCoordinator | undefined;
 
   if (workerManagerUrl) {
     await waitForWorkerManager(workerManagerUrl);
@@ -307,11 +317,23 @@ const getIndexHTML = async () => {
     serverURL,
   );
 
+  // CS-10953: optionally construct a cross-process prerender coalescer
+  // (advisory-lock + NOTIFY) and wire it into CachingDefinitionLookup.
+  // Off by default — flip via PRERENDER_COALESCE_ACROSS_PROCESSES=true.
+  // The listener has to be `start()`ed before any coordinated load can
+  // park on it, so we spin it up here, before the CachingDefinitionLookup
+  // would ever serve its first lookup.
+  if (PRERENDER_COALESCE_ACROSS_PROCESSES) {
+    moduleCacheCoordinator = new ModuleCacheCoordinator({ dbAdapter });
+    await moduleCacheCoordinator.start();
+  }
+
   let definitionLookup = new CachingDefinitionLookup(
     dbAdapter,
     prerenderer,
     virtualNetwork,
     createPrerenderAuth,
+    moduleCacheCoordinator,
   );
 
   if (SKIP_MODULES_CACHE_CLEAR_ON_STARTUP) {
@@ -501,6 +523,7 @@ const getIndexHTML = async () => {
           reconciler?.shutDown(),
           fileChangesListener?.shutDown(),
           moduleCacheInvalidationListener?.shutDown(),
+          moduleCacheCoordinator?.shutDown(),
         ]);
         queue.destroy(); // warning this is async
         dbAdapter.close(); // warning this is async

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -196,6 +196,7 @@ import './realm-registry-writes-test';
 import './realm-file-changes-listener-test';
 import './module-cache-invalidation-listener-test';
 import './pg-adapter-subscribe-test';
+import './module-cache-coordination-test';
 import './realm-endpoints/directory-test';
 import './realm-endpoints/info-test';
 import './realm-endpoints/invalidate-urls-test';

--- a/packages/realm-server/tests/module-cache-coordination-test.ts
+++ b/packages/realm-server/tests/module-cache-coordination-test.ts
@@ -1,0 +1,500 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import type { PgAdapter } from '@cardstack/postgres';
+import {
+  CachingDefinitionLookup,
+  MODULE_CACHE_POPULATED_CHANNEL,
+  internalKeyFor,
+  param,
+  query,
+  rri,
+  trimExecutableExtension,
+  type ErrorEntry,
+  type ModuleDefinitionResult,
+  type ModulePrerenderArgs,
+  type ModuleRenderResponse,
+  type Prerenderer,
+  type RealmPermissions,
+  type VirtualNetwork,
+} from '@cardstack/runtime-common';
+import { setupDB } from './helpers';
+import { ModuleCacheCoordinator } from '../lib/module-cache-coordination';
+
+// Lightweight helpers — these tests don't need the full
+// setupPermissionedRealmsCached fixture (real realm-server, real
+// prerender-server, Chrome). All they need is a real PgAdapter (for
+// pg_try_advisory_xact_lock + LISTEN) and stub prerenderer wired into
+// CachingDefinitionLookup. Mirrors the lightweight pattern in
+// module-cache-invalidation-listener-test.ts.
+
+const stubVirtualNetwork = {
+  fetch: (async () => {
+    throw new Error('fetch not used in this test');
+  }) as typeof fetch,
+} as unknown as VirtualNetwork;
+const stubCreatePrerenderAuth = (
+  _userId: string,
+  _permissions: RealmPermissions,
+) => 'stub-auth';
+
+function buildDefinition(
+  moduleURL: string,
+  name: string,
+): ModuleDefinitionResult {
+  const moduleAlias = trimExecutableExtension(rri(moduleURL));
+  return {
+    type: 'definition',
+    moduleURL: moduleAlias,
+    definition: {
+      type: 'card-def',
+      codeRef: { module: rri(moduleAlias), name },
+      displayName: name,
+      fields: {},
+      fieldDefs: {},
+    },
+    types: [],
+  };
+}
+
+function buildModuleResponse(
+  moduleURL: string,
+  name: string,
+  deps: string[] = [],
+  error?: ErrorEntry,
+): ModuleRenderResponse {
+  const definitionId = internalKeyFor(
+    { module: rri(moduleURL), name },
+    undefined,
+  );
+  return {
+    id: moduleURL,
+    status: error ? 'error' : 'ready',
+    nonce: 'test-nonce',
+    isShimmed: false,
+    lastModified: Date.now(),
+    createdAt: Date.now(),
+    deps,
+    definitions: error
+      ? {}
+      : { [definitionId]: buildDefinition(moduleURL, name) },
+    error,
+  };
+}
+
+interface GatedPrerendererControls {
+  prerenderer: Prerenderer;
+  release: () => void;
+  callsFor: (url: string) => number;
+}
+function makeGatedPrerenderer(name: string): GatedPrerendererControls {
+  let releaseGate!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    releaseGate = resolve;
+  });
+  const calls = new Map<string, number>();
+  const prerenderer: Prerenderer = {
+    async prerenderModule(args: ModulePrerenderArgs) {
+      calls.set(args.url, (calls.get(args.url) ?? 0) + 1);
+      await gate;
+      return buildModuleResponse(args.url, name);
+    },
+    async prerenderVisit() {
+      throw new Error('prerenderVisit not used in this test');
+    },
+    async runCommand() {
+      throw new Error('runCommand not used in this test');
+    },
+  };
+  return {
+    prerenderer,
+    release: () => releaseGate(),
+    callsFor: (url) => calls.get(url) ?? 0,
+  };
+}
+
+function totalCalls(
+  ...sets: Array<GatedPrerendererControls>
+): (url: string) => number {
+  return (url: string) => sets.reduce((acc, s) => acc + s.callsFor(url), 0);
+}
+
+function makeLookup(
+  dbAdapter: PgAdapter,
+  prerenderer: Prerenderer,
+  coordinator: ModuleCacheCoordinator | undefined,
+  realmURL: string,
+): CachingDefinitionLookup {
+  const lookup = new CachingDefinitionLookup(
+    dbAdapter,
+    prerenderer,
+    stubVirtualNetwork,
+    stubCreatePrerenderAuth,
+    coordinator,
+  );
+  lookup.registerRealm({
+    url: realmURL,
+    async getRealmOwnerUserId() {
+      return '@test-user:localhost';
+    },
+    async visibility() {
+      return 'private';
+    },
+  });
+  return lookup;
+}
+
+module(basename(__filename), function () {
+  module('ModuleCacheCoordinator unit', function (hooks) {
+    let dbAdapter: PgAdapter;
+    setupDB(hooks, {
+      beforeEach: async (adapter) => {
+        dbAdapter = adapter;
+      },
+    });
+
+    test('tryAcquireAndRun: uncontended → acquired:true, fn runs, NOTIFY emitted', async function (assert) {
+      const coordinator = new ModuleCacheCoordinator({ dbAdapter });
+      await coordinator.start();
+      try {
+        // Attach a second coordinator to act as the listening peer so
+        // we can observe the NOTIFY going out without coupling to a
+        // CachingDefinitionLookup.
+        const peerCoordinator = new ModuleCacheCoordinator({ dbAdapter });
+        await peerCoordinator.start();
+        try {
+          await new Promise((r) => setTimeout(r, 100));
+          let resolved = false;
+          // Park a peer waiter on the same key. If the winner's NOTIFY
+          // fires inside the same tx as the lock, the peer waiter
+          // resolves on commit.
+          const waitPromise = peerCoordinator
+            .waitForKey('coalesce-test-key', 5000)
+            .then(() => {
+              resolved = true;
+            });
+
+          await new Promise((r) => setTimeout(r, 50));
+
+          const outcome = await coordinator.tryAcquireAndRun(
+            'coalesce-test-key',
+            async () => 'winner-result',
+          );
+          assert.deepEqual(outcome, {
+            acquired: true,
+            result: 'winner-result',
+          });
+          await waitPromise;
+          assert.true(resolved, 'peer waiter resolved on winner NOTIFY');
+        } finally {
+          await peerCoordinator.shutDown();
+        }
+      } finally {
+        await coordinator.shutDown();
+      }
+    });
+
+    test('tryAcquireAndRun: contended → second caller gets acquired:false', async function (assert) {
+      const coordinator = new ModuleCacheCoordinator({ dbAdapter });
+      await coordinator.start();
+      try {
+        let releaseFn!: () => void;
+        const fnGate = new Promise<void>((resolve) => {
+          releaseFn = resolve;
+        });
+
+        const winnerPromise = coordinator.tryAcquireAndRun(
+          'contention-key',
+          async () => {
+            await fnGate;
+            return 'first';
+          },
+        );
+        // Yield so winner's BEGIN + try-lock have a chance to commit
+        // the lock-acquired state before we contend.
+        await new Promise((r) => setTimeout(r, 50));
+
+        const loserOutcome = await coordinator.tryAcquireAndRun(
+          'contention-key',
+          async () => {
+            throw new Error('loser fn must not run');
+          },
+        );
+        assert.deepEqual(loserOutcome, { acquired: false });
+
+        releaseFn();
+        const winnerOutcome = await winnerPromise;
+        assert.deepEqual(winnerOutcome, {
+          acquired: true,
+          result: 'first',
+        });
+      } finally {
+        await coordinator.shutDown();
+      }
+    });
+
+    test('waitForKey: resolves on NOTIFY before timeout', async function (assert) {
+      const coordinator = new ModuleCacheCoordinator({ dbAdapter });
+      await coordinator.start();
+      try {
+        await new Promise((r) => setTimeout(r, 100));
+        const start = Date.now();
+        const waitPromise = coordinator.waitForKey('notify-key', 5000);
+        // Yield, then send a manual NOTIFY for the key.
+        await new Promise((r) => setTimeout(r, 50));
+        await query(dbAdapter, [
+          'SELECT pg_notify(',
+          param(MODULE_CACHE_POPULATED_CHANNEL),
+          ',',
+          param('notify-key'),
+          ')',
+        ]);
+        await waitPromise;
+        const elapsed = Date.now() - start;
+        assert.ok(
+          elapsed < 4500,
+          `waitForKey resolved on NOTIFY (took ${elapsed}ms; far below 5000ms timeout)`,
+        );
+      } finally {
+        await coordinator.shutDown();
+      }
+    });
+
+    test('waitForKey: resolves on timeout when no NOTIFY arrives', async function (assert) {
+      const coordinator = new ModuleCacheCoordinator({ dbAdapter });
+      await coordinator.start();
+      try {
+        await new Promise((r) => setTimeout(r, 100));
+        const start = Date.now();
+        await coordinator.waitForKey('never-notified-key', 200);
+        const elapsed = Date.now() - start;
+        assert.ok(
+          elapsed >= 180,
+          `waitForKey waited at least ~timeoutMs (got ${elapsed}ms; expected ≥180)`,
+        );
+        assert.ok(
+          elapsed < 1500,
+          `waitForKey did not significantly overshoot timeoutMs (got ${elapsed}ms)`,
+        );
+      } finally {
+        await coordinator.shutDown();
+      }
+    });
+
+    test('waitForKey: NOTIFY for an unrelated key does not resolve', async function (assert) {
+      const coordinator = new ModuleCacheCoordinator({ dbAdapter });
+      await coordinator.start();
+      try {
+        await new Promise((r) => setTimeout(r, 100));
+        let resolved = false;
+        const wait = coordinator.waitForKey('target-key', 400).then(() => {
+          resolved = true;
+        });
+        await new Promise((r) => setTimeout(r, 50));
+        await query(dbAdapter, [
+          'SELECT pg_notify(',
+          param(MODULE_CACHE_POPULATED_CHANNEL),
+          ',',
+          param('different-key'),
+          ')',
+        ]);
+        // Give the dispatch a moment to (correctly) NOT match.
+        await new Promise((r) => setTimeout(r, 100));
+        assert.false(
+          resolved,
+          'waiter not resolved by NOTIFY for an unrelated key',
+        );
+        // Now let the timeout fire.
+        await wait;
+        assert.true(resolved, 'waiter eventually resolved on its own timeout');
+      } finally {
+        await coordinator.shutDown();
+      }
+    });
+
+    test('shutDown resolves any parked waiters so callers do not hang', async function (assert) {
+      const coordinator = new ModuleCacheCoordinator({ dbAdapter });
+      await coordinator.start();
+      await new Promise((r) => setTimeout(r, 100));
+      let resolved = false;
+      const wait = coordinator.waitForKey('shutdown-key', 60_000).then(() => {
+        resolved = true;
+      });
+      await new Promise((r) => setTimeout(r, 50));
+      await coordinator.shutDown();
+      await wait;
+      assert.true(resolved, 'parked waiter resolved on shutdown');
+    });
+  });
+
+  module(
+    'CachingDefinitionLookup coordinated path (integration)',
+    function (hooks) {
+      let dbAdapter: PgAdapter;
+      const realmURL = 'http://x.test/coalesce/';
+
+      setupDB(hooks, {
+        beforeEach: async (adapter) => {
+          dbAdapter = adapter;
+        },
+      });
+
+      test('two instances + concurrent lookup of same module → exactly one prerender call (peer wins, other re-reads)', async function (assert) {
+        const moduleURL = `${realmURL}cards/foo.gts`;
+        const aPrerender = makeGatedPrerenderer('Foo');
+        const bPrerender = makeGatedPrerenderer('Foo');
+        const total = totalCalls(aPrerender, bPrerender);
+
+        const coordinatorA = new ModuleCacheCoordinator({ dbAdapter });
+        await coordinatorA.start();
+        const coordinatorB = new ModuleCacheCoordinator({ dbAdapter });
+        await coordinatorB.start();
+        try {
+          await new Promise((r) => setTimeout(r, 100));
+
+          const lookupA = makeLookup(
+            dbAdapter,
+            aPrerender.prerenderer,
+            coordinatorA,
+            realmURL,
+          );
+          const lookupB = makeLookup(
+            dbAdapter,
+            bPrerender.prerenderer,
+            coordinatorB,
+            realmURL,
+          );
+
+          // A starts first. A's prerender will gate. While A holds the
+          // lock + is awaiting the gate, B issues its lookup; B contends
+          // the lock, observes acquired:false, parks on NOTIFY.
+          const pA = lookupA.getModuleCacheEntry(moduleURL);
+          await new Promise((r) => setTimeout(r, 100));
+          const pB = lookupB.getModuleCacheEntry(moduleURL);
+          await new Promise((r) => setTimeout(r, 100));
+
+          // At this point: A is awaiting the gate (one prerender call
+          // recorded on A), B is parked on NOTIFY (zero prerender calls
+          // on B). Release A.
+          assert.strictEqual(
+            aPrerender.callsFor(moduleURL),
+            1,
+            'A had one prerender call queued before release',
+          );
+          assert.strictEqual(
+            bPrerender.callsFor(moduleURL),
+            0,
+            'B did not call its prerenderer (parked on NOTIFY)',
+          );
+
+          aPrerender.release();
+          bPrerender.release(); // harmless — never reached on B
+
+          const [entryA, entryB] = await Promise.all([pA, pB]);
+          assert.ok(entryA, 'A returned a populated entry');
+          assert.ok(entryB, 'B returned a populated entry');
+          const definitionId = internalKeyFor(
+            { module: rri(moduleURL), name: 'Foo' },
+            undefined,
+          );
+          const defA = entryA?.definitions[definitionId];
+          const defB = entryB?.definitions[definitionId];
+          const defAHasFoo = Boolean(
+            defA &&
+            'definition' in defA &&
+            defA.definition.displayName === 'Foo',
+          );
+          const defBHasFoo = Boolean(
+            defB &&
+            'definition' in defB &&
+            defB.definition.displayName === 'Foo',
+          );
+          assert.ok(defAHasFoo, 'A entry has the Foo definition');
+          assert.ok(defBHasFoo, 'B entry has the Foo definition');
+
+          assert.strictEqual(
+            total(moduleURL),
+            1,
+            'exactly one prerenderer call across both instances',
+          );
+        } finally {
+          await coordinatorA.shutDown();
+          await coordinatorB.shutDown();
+        }
+      });
+
+      test('coordinator-less single instance still works (sqlite/in-memory deployment path)', async function (assert) {
+        // Smoke test: the original uncoordinated path still runs when no
+        // coordinator is provided. This is the path every existing test
+        // exercises; we replicate one minimal case here to guard against
+        // a CS-10953 refactor accidentally requiring the coordinator.
+        const moduleURL = `${realmURL}cards/single.gts`;
+        const aPrerender = makeGatedPrerenderer('Single');
+        const lookup = makeLookup(
+          dbAdapter,
+          aPrerender.prerenderer,
+          undefined,
+          realmURL,
+        );
+        const p = lookup.getModuleCacheEntry(moduleURL);
+        await new Promise((r) => setTimeout(r, 50));
+        aPrerender.release();
+        const entry = await p;
+        assert.ok(entry, 'returned an entry');
+        assert.strictEqual(
+          aPrerender.callsFor(moduleURL),
+          1,
+          'prerenderer called once on coordinator-less path',
+        );
+      });
+
+      test('cache-hit short-circuits before contending the lock', async function (assert) {
+        // First instance writes the row. Second instance with its own
+        // coordinator should hit the cache and never reach the
+        // prerenderer or the lock.
+        const moduleURL = `${realmURL}cards/cached.gts`;
+        const aPrerender = makeGatedPrerenderer('Cached');
+        const coordinatorA = new ModuleCacheCoordinator({ dbAdapter });
+        await coordinatorA.start();
+        try {
+          await new Promise((r) => setTimeout(r, 100));
+          const lookupA = makeLookup(
+            dbAdapter,
+            aPrerender.prerenderer,
+            coordinatorA,
+            realmURL,
+          );
+          const pA = lookupA.getModuleCacheEntry(moduleURL);
+          await new Promise((r) => setTimeout(r, 50));
+          aPrerender.release();
+          await pA;
+
+          // Now a fresh instance B looks up the same URL. B's
+          // prerenderer should never be called.
+          const bPrerender = makeGatedPrerenderer('CachedNeverCalled');
+          const coordinatorB = new ModuleCacheCoordinator({ dbAdapter });
+          await coordinatorB.start();
+          try {
+            await new Promise((r) => setTimeout(r, 100));
+            const lookupB = makeLookup(
+              dbAdapter,
+              bPrerender.prerenderer,
+              coordinatorB,
+              realmURL,
+            );
+            const entryB = await lookupB.getModuleCacheEntry(moduleURL);
+            assert.ok(entryB, 'B returned the cached entry');
+            assert.strictEqual(
+              bPrerender.callsFor(moduleURL),
+              0,
+              'B never called its prerenderer (cache hit on optimistic read)',
+            );
+          } finally {
+            await coordinatorB.shutDown();
+          }
+        } finally {
+          await coordinatorA.shutDown();
+        }
+      });
+    },
+  );
+});

--- a/packages/realm-server/tests/module-cache-coordination-test.ts
+++ b/packages/realm-server/tests/module-cache-coordination-test.ts
@@ -18,7 +18,10 @@ import {
   type VirtualNetwork,
 } from '@cardstack/runtime-common';
 import { setupDB } from './helpers';
-import { ModuleCacheCoordinator } from '../lib/module-cache-coordination';
+import {
+  ModuleCacheCoordinator,
+  hashCoalesceKeyForAdvisoryLock,
+} from '../lib/module-cache-coordination';
 
 // Lightweight helpers — these tests don't need the full
 // setupPermissionedRealmsCached fixture (real realm-server, real
@@ -239,13 +242,14 @@ module(basename(__filename), function () {
         await new Promise((r) => setTimeout(r, 100));
         const start = Date.now();
         const waitPromise = coordinator.waitForKey('notify-key', 5000);
-        // Yield, then send a manual NOTIFY for the key.
+        // Yield, then send a manual NOTIFY for the key. Payload is the
+        // bounded hash, matching what tryAcquireAndRun emits.
         await new Promise((r) => setTimeout(r, 50));
         await query(dbAdapter, [
           'SELECT pg_notify(',
           param(MODULE_CACHE_POPULATED_CHANNEL),
           ',',
-          param('notify-key'),
+          param(hashCoalesceKeyForAdvisoryLock('notify-key')),
           ')',
         ]);
         await waitPromise;
@@ -294,7 +298,7 @@ module(basename(__filename), function () {
           'SELECT pg_notify(',
           param(MODULE_CACHE_POPULATED_CHANNEL),
           ',',
-          param('different-key'),
+          param(hashCoalesceKeyForAdvisoryLock('different-key')),
           ')',
         ]);
         // Give the dispatch a moment to (correctly) NOT match.

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -53,10 +53,33 @@ export const MODULE_CACHE_INVALIDATED_CHANNEL = 'module_cache_invalidated';
 // Postgres caps NOTIFY payloads at 8000 bytes; stay well under so JSON
 // encoding overhead and pathological URL lengths don't blow the limit.
 const NOTIFY_PAYLOAD_BUDGET = 7000;
+// Postgres NOTIFY channel for cross-instance prerender-coalesce wakeups
+// (CS-10953). The winner of a `pg_try_advisory_xact_lock` for a given
+// inFlightKey emits this notify (with the inFlightKey as payload) inside
+// the same transaction as its persistModuleCacheEntry, so peer waiters
+// see the signal only on commit (the cache row is visible to their
+// re-read by the time their wait resolves). Loser path on
+// missed-NOTIFY falls back to a bounded-timeout re-read.
+export const MODULE_CACHE_POPULATED_CHANNEL = 'module_cache_populated';
 // Cached module errors expire after this interval. When a stale error entry
 // is encountered, the prerenderer is called again to get a fresh result.
 // This prevents transient prerender failures from being permanently cached.
 const ERROR_CACHE_TTL_MS = 30_000; // 30 seconds
+// CS-10953 cross-process populate-coalesce loser-path wait timeout. The
+// loser blocks on a peer's NOTIFY; on timeout (peer crashed mid-prerender,
+// missed wakeup, etc.), the loop re-reads the cache and may take another
+// shot at the lock. Set well above realistic prerender wall time
+// (single-module prerenders are sub-second to a few seconds; the absolute
+// upper bound is the prerender request timeout, currently 150s in
+// production) so a healthy peer's prerender always wakes the loser
+// before this fires.
+const COALESCE_NOTIFY_WAIT_MS = 180_000; // 180 seconds
+// Bounded retry loop in the coordinated path. Each iteration re-reads
+// the cache, contends for the lock, and (if losing) waits on NOTIFY. A
+// pathological peer crash-loop or NOTIFY drop sequence could in
+// principle cycle the loser indefinitely; capping at a small number and
+// throwing surfaces it instead of silently hanging.
+const COALESCE_MAX_ITERATIONS = 4;
 const modulesTableCoerceTypes: TypeCoercion = Object.freeze({
   definitions: 'JSON',
   deps: 'JSON',
@@ -190,6 +213,51 @@ export function isFilterRefersToNonexistentTypeError(
   return error instanceof FilterRefersToNonexistentTypeError;
 }
 
+// CS-10953 cross-process prerender-coalesce dependency. When provided,
+// CachingDefinitionLookup routes its uncached load through the coordinator
+// so at most one realm-server process per coalesce key reaches the
+// prerenderer; peer processes block on NOTIFY and re-read the populated
+// row instead of redundant prerender round-trips.
+//
+// Two methods rather than one because the winner's transaction (lock +
+// fn + NOTIFY + commit) and the loser's NOTIFY-or-timeout wait are
+// fundamentally different shapes: the winner runs a critical section
+// pinned to one connection; the loser is a passive subscriber that the
+// winner's NOTIFY (or a timeout) wakes.
+//
+// `tryAcquireAndRun` returns a discriminated union rather than throwing
+// on contention because contention is the expected loser path, not an
+// error condition.
+//
+// `waitForKey` resolves on either the NOTIFY or the timeout — both are
+// acceptable handoffs back to the caller's loop. The loop's next
+// iteration re-reads the cache; on healthy peer the row is now there
+// and the loop exits.
+//
+// Sqlite/in-memory deployments don't construct a coordinator —
+// CachingDefinitionLookup runs its uncoordinated path when this is
+// undefined.
+export interface PopulateCoordinator {
+  // Try to acquire the cross-process coalesce lock for `coalesceKey`. If
+  // acquired, run `fn` inside the same transaction as the lock + emit
+  // pg_notify on the populate channel + commit. If contended, return
+  // `{ acquired: false }` immediately so the caller can transition to
+  // the loser path.
+  //
+  // `fn` runs against the shared dbAdapter (separate pool connections
+  // for any DB work it does). The pinned connection inside this helper
+  // only holds the advisory lock + emits the NOTIFY + commits.
+  tryAcquireAndRun<T>(
+    coalesceKey: string,
+    fn: () => Promise<T>,
+  ): Promise<{ acquired: true; result: T } | { acquired: false }>;
+  // Wait until a NOTIFY for `coalesceKey` arrives on the populate
+  // channel, or `timeoutMs` elapses — whichever comes first. Resolves in
+  // both cases. The caller's loop re-reads the cache regardless of
+  // which path resolved.
+  waitForKey(coalesceKey: string, timeoutMs: number): Promise<void>;
+}
+
 export interface DefinitionLookup {
   lookupDefinition(codeRef: ResolvedCodeRef): Promise<Definition>;
   // Like lookupDefinition but does not trigger a prerenderer call or
@@ -246,6 +314,11 @@ export class CachingDefinitionLookup implements DefinitionLookup {
   #moduleGenerations = new Map<string, number>();
   #realmGenerations = new Map<string, number>();
   #globalGeneration = 0;
+  // CS-10953 cross-process prerender coalescer. Optional — when undefined,
+  // loadModuleCacheEntryUncached runs the original uncoordinated path.
+  // Constructed only by the realm-server main when
+  // PRERENDER_COALESCE_ACROSS_PROCESSES is enabled and the dbAdapter is pg.
+  #populateCoordinator?: PopulateCoordinator;
 
   constructor(
     dbAdapter: DBAdapter,
@@ -255,11 +328,13 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       userId: string,
       permissions: RealmPermissions,
     ) => string,
+    populateCoordinator?: PopulateCoordinator,
   ) {
     this.#dbAdapter = dbAdapter;
     this.#prerenderer = prerenderer;
     this.#fetch = virtualNetwork.fetch;
     this.#createPrerenderAuth = createPrerenderAuth;
+    this.#populateCoordinator = populateCoordinator;
   }
 
   async lookupDefinition(codeRef: ResolvedCodeRef): Promise<Definition> {
@@ -349,7 +424,20 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       return await existing;
     }
     let pending: Promise<ModuleCacheEntry | undefined>;
-    pending = this.loadModuleCacheEntryUncached(args).finally(() => {
+    // Two paths inside #inFlight:
+    //   - With a populate coordinator (CS-10953): coordinated path adds
+    //     a pg_try_advisory_xact_lock around the prerender so at most
+    //     one realm-server process per coalesceKey reaches the
+    //     prerenderer; peer processes block on NOTIFY and re-read the
+    //     populated row. Inert at N=1.
+    //   - Without a coordinator (default): original uncoordinated path
+    //     runs the prerender and persist directly. This is the path
+    //     used by every test that doesn't construct a coordinator and
+    //     by sqlite/in-memory deployments.
+    let core: Promise<ModuleCacheEntry | undefined> = this.#populateCoordinator
+      ? this.loadModuleCacheEntryCoordinated(args, this.#populateCoordinator)
+      : this.loadModuleCacheEntryUncached(args);
+    pending = core.finally(() => {
       // Identity-check before deletion: an invalidation path may have
       // dropped our entry mid-flight, after which a newer caller can
       // install their own pending under the same key. Deleting
@@ -362,6 +450,81 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     });
     this.#inFlight.set(key, pending);
     return await pending;
+  }
+
+  // CS-10953 cross-process prerender coalescer. Wraps the uncoordinated
+  // body in a pg_try_advisory_xact_lock + NOTIFY-wait loop so at most
+  // one process per coalesceKey reaches the prerenderer.
+  //
+  // Iteration shape:
+  //   1. Read the cache (cheap; avoids contending the lock on hits).
+  //   2. Try the advisory lock via the coordinator.
+  //   3. Winner: run the uncoordinated body inside the lock — re-reads
+  //      cache (double-check), prerenders, persists. Coordinator emits
+  //      NOTIFY on commit. Return the result.
+  //   4. Loser: wait for peer's NOTIFY (or timeout). Loop back.
+  //
+  // The outer `for` is bounded by COALESCE_MAX_ITERATIONS so a
+  // pathological peer crash-loop or NOTIFY-drop sequence surfaces as
+  // an error instead of silently hanging.
+  //
+  // Error semantics:
+  //   - If the uncoordinated body throws, the coordinator rolls back
+  //     (releasing the advisory lock) and rethrows. CS-10948-era error
+  //     caching means transient errors are persisted as error rows with
+  //     a TTL, so subsequent callers read the cached error rather than
+  //     re-running the prerender — the retry loop terminates naturally.
+  //   - Generation-changed (invalidate ran during prerender): the body
+  //     returns the post-invalidate cache state (undefined or fresher
+  //     row); coordinator notifies regardless so peer waiters wake
+  //     promptly. Same observable behavior as N=1 generation-mismatch.
+  private async loadModuleCacheEntryCoordinated(
+    args: {
+      moduleURL: string;
+      realmURL: string;
+      resolvedRealmURL: string;
+      cacheScope: CacheScope;
+      cacheUserId: string;
+      prerenderUserId: string;
+    },
+    coordinator: PopulateCoordinator,
+  ): Promise<ModuleCacheEntry | undefined> {
+    let coalesceKey = inFlightKey(args);
+    for (let iteration = 0; iteration < COALESCE_MAX_ITERATIONS; iteration++) {
+      // Optimistic pre-lock cache read. On a hit we skip the lock
+      // contention entirely; on a miss we proceed to the try-lock.
+      // Mirrors the uncoordinated body's first read — when we win the
+      // lock, the body re-reads inside the lock and short-circuits if a
+      // peer committed in between (the double-check).
+      let cached = await this.readFromDatabaseCache(
+        args.moduleURL,
+        args.cacheScope,
+        args.cacheUserId,
+        args.resolvedRealmURL,
+      );
+      if (cached && !this.isExpiredErrorEntry(cached)) {
+        return cached;
+      }
+
+      let outcome = await coordinator.tryAcquireAndRun(coalesceKey, async () =>
+        this.loadModuleCacheEntryUncached(args),
+      );
+      if (outcome.acquired) {
+        // Winner. Result might be undefined if all populationCandidates
+        // produced missing-module errors — that's a legitimate "module
+        // does not exist" answer and we surface it as undefined, same as
+        // the uncoordinated path.
+        return outcome.result;
+      }
+
+      // Loser. Block on peer's NOTIFY (or bounded timeout). On wake,
+      // the next iteration's optimistic cache read picks up the peer's
+      // populated row.
+      await coordinator.waitForKey(coalesceKey, COALESCE_NOTIFY_WAIT_MS);
+    }
+    throw new Error(
+      `loadModuleCacheEntryCoordinated exceeded ${COALESCE_MAX_ITERATIONS} iterations for ${coalesceKey}; peer prerender appears stuck or NOTIFY broadcast is broken`,
+    );
   }
 
   private async loadModuleCacheEntryUncached({


### PR DESCRIPTION
Second sub-issue under the [CS-10950](https://linear.app/cardstack/issue/CS-10950) umbrella. Closes the populate-coalescing half of the cross-process coordination story. CS-10952 (#4644, merged) handles the invalidation half.

## Why

CS-10948 added in-process generation discard. CS-10952 broadcasts invalidations across processes. But cross-process *populate* — coalescing the prerender work itself — still has a gap: each of N realm-server processes independently misses the `modules` cache on cold fan-out and fires its own prerender for the same URL. Prerender servers see N× the work they need. Measurable today during from-scratch indexing.

This PR adds a `pg_try_advisory_xact_lock` + NOTIFY-wait coalescing layer between `CachingDefinitionLookup`'s `#inFlight` coalescer and the prerenderer, so at most one realm-server process per coalesce key reaches the prerenderer. Peer processes block on NOTIFY and re-read the populated row.

## What changes

### `runtime-common/definition-lookup.ts`

- Exports `MODULE_CACHE_POPULATED_CHANNEL` and a new `PopulateCoordinator` interface (two methods: `tryAcquireAndRun(coalesceKey, fn)` and `waitForKey(coalesceKey, timeoutMs)`).
- `CachingDefinitionLookup` constructor takes an optional `populateCoordinator` (5th arg). When provided, `loadModuleCacheEntry` routes through a new `loadModuleCacheEntryCoordinated` that adds an outer `for COALESCE_MAX_ITERATIONS` loop:
  1. Optimistic cache read (avoid contending the lock on hits).
  2. Try the advisory lock via the coordinator.
  3. **Winner**: run the existing uncoordinated body inside the lock — its existing cache double-check + prerender + generation-check + persist. Coordinator emits NOTIFY on commit.
  4. **Loser**: wait for peer's NOTIFY (180 s timeout). Loop. The next iteration's optimistic cache read picks up the peer's row.
  5. Throws after `MAX_ITERATIONS=4` so a pathological peer crash-loop or NOTIFY-drop sequence surfaces as an error instead of silently hanging.
- When no coordinator is provided (default; sqlite/in-memory deployments; the vast majority of test setups), the original uncoordinated path runs unchanged.

### `realm-server/lib/module-cache-coordination.ts` (new)

`ModuleCacheCoordinator implements PopulateCoordinator`. Mirrors the `withRealmWriteLock` pattern but with `pg_try_advisory_xact_lock` (non-blocking) so losers don't pin pool clients for the full prerender wall time (could be 150s in production). `waitForKey` registers a callback on a per-key `Set`; the subscription handler dispatches NOTIFYs into the matching set.

The subscription is backed by `PgAdapter.subscribe` (the shared multiplexed notification client), same pattern as `ModuleCacheInvalidationListener`. `start()` awaits LISTEN establishment; `shutDown()` waits for any in-flight `start()` (race-safe), then unsubscribes, then resolves any parked waiters so callers don't hang during teardown.

`pg_notify` is emitted **inside the same transaction as the lock**, so peers only see the signal on commit. The persist itself ran on the shared `dbAdapter` and is already visible by the time peers re-read on wake.

### `realm-server/main.ts`

Behind `PRERENDER_COALESCE_ACROSS_PROCESSES=true` env flag (default off). When enabled, constructs and `await`s start of a `ModuleCacheCoordinator` and passes it to `CachingDefinitionLookup`. Added to the shutdown `Promise.all` alongside the other listeners.

## Two small spec divergences

**1. NOTIFY on every winner outcome (including missing-module).** The CS-10953 spec says winners don't notify when all populationCandidates produced missing-module errors. We notify regardless. Trade-off: an extra harmless wake for peers vs. a 180 s timeout cycle for parallel callers of a nonexistent URL. Cheap to choose the wake.

**2. `ModuleCacheCoordinator` lives in `realm-server/lib/`, not `runtime-common/`.** Same reason as CS-10952: `runtime-common` doesn't depend on `@cardstack/postgres`, and adding the dep would be circular (`@cardstack/postgres` already depends on `runtime-common` via `DBAdapter`). The `PopulateCoordinator` interface is in `runtime-common`; the implementation is in `realm-server`.

## Behavior

**N=1 (today's production):** effectively inert. Try-lock always succeeds uncontended; loser path is never taken; self-NOTIFY is dropped (no waiters registered). Overhead is one extra `BEGIN; SELECT pg_try_advisory_xact_lock; pg_notify; COMMIT` per cache miss — measurable but sub-millisecond. The `PRERENDER_COALESCE_ACROSS_PROCESSES` flag is **off by default** so this overhead doesn't ship to production until we explicitly flip it.

**N>1 (with the flag on):** N× prerender-server load reduction on cold fan-out. 1 prerender per unique module across the whole fleet instead of N.

## Test plan

- [ ] CI Realm Server suite green
- [ ] CI Software Factory job green
- [ ] CI Host suite green

New tests in `realm-server/tests/module-cache-coordination-test.ts`:

**Coordinator unit tests** (operate on `ModuleCacheCoordinator` directly):

- `tryAcquireAndRun` uncontended → `acquired:true`, fn runs, peer waiter sees the NOTIFY on commit.
- `tryAcquireAndRun` contended → second caller gets `acquired:false` immediately (does not pin the pool).
- `waitForKey` resolves on NOTIFY before timeout.
- `waitForKey` resolves on timeout when no NOTIFY arrives.
- `waitForKey` ignores NOTIFYs for unrelated keys.
- `shutDown` wakes parked waiters so callers don't hang during teardown.

**Integration tests** (full `CachingDefinitionLookup` with coordinator on real PgAdapter):

- Two instances + concurrent same-module lookup → exactly one prerender call total. B parks on NOTIFY, wakes after A persists, re-reads cache, returns A's row.
- Coordinator-less single instance still works (sqlite/in-memory deployment guard).
- Cache hit short-circuits before contending the lock (fresh second instance reading an already-cached row never calls its prerenderer).

## What's NOT in scope (per ticket)

- Unified DB-backed response cache replacing `#moduleCache`.
- ALB sticky routing (infrastructure config; independently tunable).
- Per-waiter `AbortController` cancellation.
- Strict cross-process invalidation closure beyond what NOTIFY latency provides.

## Related

- [CS-10950](https://linear.app/cardstack/issue/CS-10950) — umbrella
- [CS-10952](https://linear.app/cardstack/issue/CS-10952) (#4644) — invalidation broadcast (merged)
- [CS-10948](https://linear.app/cardstack/issue/CS-10948) (#4641) — in-process generation discard
- [CS-10891](https://linear.app/cardstack/issue/CS-10891) — `withRealmWriteLock` / `hashRealmUrlForAdvisoryLock` primitive that the non-blocking try-lock here extends
- [CS-10892](https://linear.app/cardstack/issue/CS-10892) — `realm_file_changes` NOTIFY pattern the populate subscription follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
