### PR TITLE
realm-server: wait for port release in test fixture closeServer

### DIFF
--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -60,6 +60,7 @@ import {
   PgQueueRunner,
 } from '@cardstack/postgres';
 import type { Server } from 'http';
+import { Socket as NetSocket } from 'net';
 import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import {
   Prerenderer as LocalPrerenderer,
@@ -499,6 +500,19 @@ export async function closeServer(server: Server) {
   if (!server) {
     return;
   }
+  // Capture the listening address before close() so we can poll the OS until
+  // the port is fully unbound. node's `server.close(cb)` only waits for the
+  // listener to stop accepting new connections — under load, the kernel can
+  // hold the port in TIME_WAIT briefly and the next bind() races into
+  // EADDRINUSE.
+  let address = server.address();
+  let host: string | undefined;
+  let port: number | undefined;
+  if (address && typeof address === 'object') {
+    host = address.address;
+    port = address.port;
+  }
+
   // Force-close idle keep-alive sockets so server.close() resolves promptly.
   // Without this, a lingering connection from the host page (puppeteer fetching
   // from the realm server) can hold the port bound long after the test moves
@@ -506,6 +520,70 @@ export async function closeServer(server: Server) {
   server.closeIdleConnections?.();
   server.closeAllConnections?.();
   await new Promise<void>((r) => server.close(() => r()));
+
+  if (host && typeof port === 'number' && port > 0) {
+    await awaitPortRelease(host, port);
+  }
+}
+
+/**
+ * Poll a TCP port on `host` until a fresh connect() is refused (i.e. nothing
+ * is LISTENing there anymore). Used after `server.close()` returns to give
+ * the kernel a chance to fully release the bind slot before the next fixture
+ * tries to listen on the same port.
+ *
+ * Resolves on first refusal. Logs a clear diagnostic on timeout so the next
+ * failure points to the leaked port rather than the downstream EADDRINUSE.
+ */
+export async function awaitPortRelease(
+  host: string,
+  port: number,
+  options: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<void> {
+  let timeoutMs = options.timeoutMs ?? 2000;
+  let intervalMs = options.intervalMs ?? 25;
+  // Map the wildcard bind address back to a connectable loopback address.
+  // Server.address() reports `::` for IPv6-any, `0.0.0.0` for IPv4-any —
+  // neither is a valid connect target.
+  let connectHost = host;
+  if (host === '::' || host === '0.0.0.0') {
+    connectHost = '127.0.0.1';
+  }
+
+  let started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    let stillListening = await new Promise<boolean>((resolve) => {
+      let socket = new NetSocket();
+      let settled = false;
+      let done = (listening: boolean) => {
+        if (settled) return;
+        settled = true;
+        socket.destroy();
+        resolve(listening);
+      };
+      socket.setTimeout(Math.max(50, intervalMs * 2));
+      socket.once('connect', () => done(true));
+      socket.once('timeout', () => done(true));
+      socket.once('error', () => {
+        // ECONNREFUSED is the expected signal that the port is fully released.
+        // Anything else (host unreachable, etc.) we also treat as released —
+        // we're not the right place to diagnose upstream network errors and
+        // a non-listening socket is a non-listening socket.
+        done(false);
+      });
+      socket.connect(port, connectHost);
+    });
+
+    if (!stillListening) {
+      return;
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+
+  console.warn(
+    `awaitPortRelease: ${connectHost}:${port} still appears bound after ${timeoutMs}ms; ` +
+      `the next fixture binding this port will likely EADDRINUSE.`,
+  );
 }
 
 function trackServer(server: Server): Server {

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -544,9 +544,14 @@ export async function awaitPortRelease(
   let intervalMs = options.intervalMs ?? 25;
   // Map the wildcard bind address back to a connectable loopback address.
   // Server.address() reports `::` for IPv6-any, `0.0.0.0` for IPv4-any —
-  // neither is a valid connect target.
+  // neither is a valid connect target. Probe in the same address family the
+  // listener was bound to: if we map `::` to `127.0.0.1` and the system has
+  // IPv6-only binding behavior, the IPv4 probe gets ECONNREFUSED while the
+  // original IPv6 listener is still bound, falsely reporting release.
   let connectHost = host;
-  if (host === '::' || host === '0.0.0.0') {
+  if (host === '::') {
+    connectHost = '::1';
+  } else if (host === '0.0.0.0') {
     connectHost = '127.0.0.1';
   }
 


### PR DESCRIPTION
## Summary

Running `packages/realm-server/tests/prerendering-test.ts` locally bails on the very first test with `EADDRINUSE :::4455` from `RealmServer.listen` inside `runTestRealmServer`. The mechanism:

`setupPermissionedRealmsCached` installs **two** `before` hooks:

1. `acquirePermissionedRealmsTemplate` → `buildPermissionedRealmsTemplate` → `startPermissionedRealmsFixture` → `runTestRealmServer` → binds the realm URL's port (e.g. **4455**), runs from-scratch indexing, then calls `teardownPermissionedRealmsFixture` (which calls `closeServer`).
2. `setupPermissionedRealms`'s inner `before` → `startPermissionedRealmsFixture` again, trying to bind the same **4455**.

`closeServer` already does `closeIdleConnections()` + `closeAllConnections()` + `await server.close(...)`, but Node's `server.close(cb)` only waits for the listener to stop accepting new connections — the kernel can still hold the bind slot briefly and the next `bind()` races into EADDRINUSE.

A related symptom of the same lifecycle gap is the warning:

> Shared-context invariant violated for realm:http://127.0.0.1:4455/test/: existing BrowserContext does not match the one being registered.

The page-pool's `#sharedContexts` entry from the cache builder's run is still registered when the test's setup tries to register a fresh context for the same realm URL. That warning is informational; the EADDRINUSE is the bug that actually breaks the run.

## Fix

Add `awaitPortRelease(host, port, { timeoutMs })` and call it from `closeServer` after the existing close path. It opens a TCP probe and resolves on first `ECONNREFUSED` (or any error indicating the socket isn't listening), polling every 25ms with a 2s ceiling. On timeout it logs a clear `awaitPortRelease: 127.0.0.1:4455 still appears bound after 2000ms` warning so the next failure points at the leaked port rather than the downstream EADDRINUSE.

Centralizing the wait in `closeServer` means every fixture path (single-realm, multi-realm, cached, builder) gets the guarantee for free.

### Per-cycle port for the builder — ruled out

The other fix considered was making the cache builder bind a different port from the test (e.g. `original_port + 100`). That turns out to be too invasive: `boxel_index` rows are keyed by `realm_url` in the primary key (`packages/postgres/migrations/1733253128046_remove-type-from-index-pk.js` makes `[url, realm_version, realm_url]` the PK). If the builder rewrote the realm URL, the template DB rows would be keyed under the wrong URL and the test reading them back via the original URL wouldn't find them. Shipping (1) alone is what unblocks local runs.

## Test plan

- [ ] Run `pnpm --filter @cardstack/realm-server test-module --module 'prerender - mutating tests'` (or another `setupPermissionedRealmsCached` consumer) locally and confirm it no longer fails with `EADDRINUSE` on the first test.
- [ ] Confirm full prerendering-test runs cleanly through the cached-template setup without `awaitPortRelease` timeout warnings.
- [ ] CI green for the realm-server suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)