### PR TITLE
Add Linux install steps for grafanactl in observability README

### DIFF
--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -59,7 +59,16 @@ docker-compose.yml     # local Grafana 12.4.3 + Loki 3.4.4 + Alloy 1.10.0
 
 ```sh
 # One-time: install grafanactl
+# macOS:
 brew install --formula grafanactl
+# Linux: download the prebuilt tarball from
+# https://github.com/grafana/grafanactl/releases/latest and drop the
+# binary on your PATH, e.g.:
+#   curl -sSL -o /tmp/grafanactl.tgz \
+#     https://github.com/grafana/grafanactl/releases/latest/download/grafanactl_Linux_x86_64.tar.gz
+#   tar -xzf /tmp/grafanactl.tgz -C /tmp grafanactl
+#   sudo install -m 0755 /tmp/grafanactl /usr/local/bin/grafanactl
+# (swap `Linux_x86_64` for `Linux_arm64` on aarch64.)
 
 # Bring up local Grafana + Loki + Alloy (log scraper)
 docker compose up -d


### PR DESCRIPTION
## Summary

- The `packages/observability/README.md` local-workflow section only listed `brew install --formula grafanactl`, leaving Ubuntu/Linux contributors without a path.
- Add a short tarball-from-GitHub-releases snippet alongside the Homebrew line, using the official `grafanactl_Linux_x86_64.tar.gz` / `grafanactl_Linux_arm64.tar.gz` assets from `https://github.com/grafana/grafanactl/releases/latest`.
- Kept the section terse (a few comment lines under the existing `# One-time: install grafanactl` block) to match the README's tone.

## Test plan

- [ ] Followed the new Linux install steps locally and confirmed `grafanactl` runs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>