### PR TITLE
CS-10630: Reimplement `boxel realm remove` command

### DIFF
--- a/packages/boxel-cli/src/commands/realm/index.ts
+++ b/packages/boxel-cli/src/commands/realm/index.ts
@@ -5,6 +5,7 @@ import { registerHistoryCommand } from './history';
 import { registerListCommand } from './list';
 import { registerPullCommand } from './pull';
 import { registerPushCommand } from './push';
+import { registerRemoveCommand } from './remove';
 import { registerSyncCommand } from './sync';
 import { registerWaitForReadyCommand } from './wait-for-ready';
 
@@ -19,6 +20,7 @@ export function registerRealmCommand(program: Command): void {
   registerListCommand(realm);
   registerPullCommand(realm);
   registerPushCommand(realm);
+  registerRemoveCommand(realm);
   registerSyncCommand(realm);
   registerWaitForReadyCommand(realm);
 }

--- a/packages/boxel-cli/src/commands/realm/remove.ts
+++ b/packages/boxel-cli/src/commands/realm/remove.ts
@@ -1,0 +1,183 @@
+import type { Command } from 'commander';
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
+import {
+  getProfileManager,
+  NO_ACTIVE_PROFILE_ERROR,
+  type ProfileManager,
+} from '../../lib/profile-manager';
+import { prompt } from '../../lib/prompt';
+import { DIM, FG_CYAN, FG_GREEN, FG_RED, RESET } from '../../lib/colors';
+
+export interface RemoveRealmOptions {
+  realmUrl: string;
+  dryRun?: boolean;
+  profileManager?: ProfileManager;
+}
+
+export interface RemoveRealmResult {
+  /** Normalized URL the operation targeted (always trailing-slashed). */
+  realmUrl: string;
+  /** True when account_data was modified. False for dry-run or not-in-list. */
+  removed: boolean;
+  /** Number of entries before the change. */
+  previousCount: number;
+  /** Number of entries the next list would contain (computed even on dry-run). */
+  nextCount: number;
+  /**
+   * True when the URL was not present in `app.boxel.realms`. Mutually
+   * exclusive with a successful real removal.
+   */
+  notInList?: boolean;
+  error?: string;
+}
+
+/**
+ * Soft-remove a realm URL from the active profile's `app.boxel.realms`
+ * Matrix account_data list. Server-side files are untouched.
+ *
+ * Programmatic API. Returns a result object on every code path; never
+ * prompts and never calls `process.exit`. The CLI wraps this with a TTY
+ * confirmation step (see `registerRemoveCommand`).
+ */
+export async function removeRealm(
+  options: RemoveRealmOptions,
+): Promise<RemoveRealmResult> {
+  let realmUrl = ensureTrailingSlash(options.realmUrl.trim());
+  let pm = options.profileManager ?? getProfileManager();
+  let active = pm.getActiveProfile();
+  if (!active) {
+    return {
+      realmUrl,
+      removed: false,
+      previousCount: 0,
+      nextCount: 0,
+      error: NO_ACTIVE_PROFILE_ERROR,
+    };
+  }
+
+  let existing: string[];
+  try {
+    existing = await pm.getUserRealms();
+  } catch (err) {
+    return {
+      realmUrl,
+      removed: false,
+      previousCount: 0,
+      nextCount: 0,
+      error: `Failed to load realm list: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+  let normalized = existing.map(ensureTrailingSlash);
+  let previousCount = normalized.length;
+
+  if (!normalized.includes(realmUrl)) {
+    return {
+      realmUrl,
+      removed: false,
+      previousCount,
+      nextCount: previousCount,
+      notInList: true,
+      error: 'Realm is not in app.boxel.realms. Nothing to remove.',
+    };
+  }
+
+  let nextCount = previousCount - 1;
+
+  if (options.dryRun) {
+    return { realmUrl, removed: false, previousCount, nextCount };
+  }
+
+  try {
+    let removed = await pm.removeFromUserRealms(realmUrl);
+    return { realmUrl, removed, previousCount, nextCount };
+  } catch (err) {
+    return {
+      realmUrl,
+      removed: false,
+      previousCount,
+      nextCount: previousCount,
+      error: `Failed to update Matrix account data: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+}
+
+interface RemoveCliOptions {
+  yes?: boolean;
+  dryRun?: boolean;
+}
+
+export function registerRemoveCommand(realm: Command): void {
+  realm
+    .command('remove')
+    .description(
+      "Soft-remove a realm from the active profile's UI realm list (does not delete server files)",
+    )
+    .argument('<realm-url>', 'realm URL to remove from app.boxel.realms')
+    .option('-y, --yes', 'Skip the interactive confirmation prompt')
+    .option('--dry-run', 'Preview the change without writing to Matrix')
+    .action(async (realmUrlInput: string, opts: RemoveCliOptions) => {
+      let normalized = ensureTrailingSlash(realmUrlInput.trim());
+
+      let preview = await removeRealm({
+        realmUrl: normalized,
+        dryRun: true,
+      });
+
+      if (preview.error && !preview.notInList) {
+        console.error(`${FG_RED}Error:${RESET} ${preview.error}`);
+        process.exit(1);
+      }
+
+      if (preview.notInList) {
+        console.error(`${FG_RED}Error:${RESET} ${preview.error}`);
+        process.exit(1);
+      }
+
+      console.log(`Soft remove target: ${FG_CYAN}${preview.realmUrl}${RESET}`);
+      console.log(
+        `${DIM}app.boxel.realms: ${preview.previousCount} -> ${preview.nextCount}${RESET}`,
+      );
+
+      if (opts.dryRun) {
+        console.log(
+          `${DIM}[DRY RUN] No Matrix account data changes sent.${RESET}`,
+        );
+        return;
+      }
+
+      if (!opts.yes) {
+        if (!process.stdin.isTTY) {
+          console.error(
+            `${FG_RED}Error:${RESET} stdin is not a TTY. Pass --yes to confirm in non-interactive mode.`,
+          );
+          process.exit(1);
+        }
+        let answer = await prompt(
+          'Proceed with soft remove from your realm list? (y/N) ',
+        );
+        if (!/^y/i.test(answer)) {
+          console.log(`${DIM}Cancelled.${RESET}`);
+          return;
+        }
+      }
+
+      let result = await removeRealm({ realmUrl: normalized });
+      if (result.error || !result.removed) {
+        console.error(
+          `${FG_RED}Error:${RESET} ${result.error ?? 'Removal did not complete.'}`,
+        );
+        process.exit(1);
+      }
+
+      console.log(
+        `${FG_GREEN}Removed:${RESET} ${FG_CYAN}${result.realmUrl}${RESET}`,
+      );
+      console.log(
+        `${DIM}Note: server files are not deleted by this command.${RESET}`,
+      );
+    });
+}

--- a/packages/boxel-cli/src/commands/realm/remove.ts
+++ b/packages/boxel-cli/src/commands/realm/remove.ts
@@ -81,8 +81,9 @@ export async function removeRealm(
   }
   let normalized = existing.map(ensureTrailingSlash);
   let previousCount = normalized.length;
+  let matchCount = normalized.filter((u) => u === realmUrl).length;
 
-  if (!normalized.includes(realmUrl)) {
+  if (matchCount === 0) {
     return {
       realmUrl,
       removed: false,
@@ -95,7 +96,7 @@ export async function removeRealm(
     };
   }
 
-  let nextCount = previousCount - 1;
+  let nextCount = previousCount - matchCount;
 
   if (options.dryRun) {
     return {
@@ -166,6 +167,19 @@ export async function removeRealm(
       error: `Server delete succeeded, but Matrix unlink failed: ${
         err instanceof Error ? err.message : String(err)
       }`,
+    };
+  }
+
+  if (!unlinked) {
+    return {
+      realmUrl,
+      removed: false,
+      serverDeleted: true,
+      unlinked: false,
+      previousCount,
+      nextCount: previousCount,
+      error:
+        'Server delete succeeded, but Matrix account_data did not contain the URL by the time we PUT (concurrent edit?). Server-side files are gone; please refresh and check your realm list.',
     };
   }
 

--- a/packages/boxel-cli/src/commands/realm/remove.ts
+++ b/packages/boxel-cli/src/commands/realm/remove.ts
@@ -17,8 +17,12 @@ export interface RemoveRealmOptions {
 export interface RemoveRealmResult {
   /** Normalized URL the operation targeted (always trailing-slashed). */
   realmUrl: string;
-  /** True when account_data was modified. False for dry-run or not-in-list. */
+  /** True only when both server delete and Matrix unlink completed. */
   removed: boolean;
+  /** True when DELETE /_delete-realm returned 204. */
+  serverDeleted: boolean;
+  /** True when Matrix `app.boxel.realms` was rewritten without the URL. */
+  unlinked: boolean;
   /** Number of entries before the change. */
   previousCount: number;
   /** Number of entries the next list would contain (computed even on dry-run). */
@@ -32,8 +36,10 @@ export interface RemoveRealmResult {
 }
 
 /**
- * Soft-remove a realm URL from the active profile's `app.boxel.realms`
- * Matrix account_data list. Server-side files are untouched.
+ * Remove a realm: delete server-side files / index / registry via
+ * `DELETE /_delete-realm`, then unlink the URL from the active profile's
+ * `app.boxel.realms` Matrix account_data list. Mirrors the host UI's
+ * workspace delete flow and inverts `boxel realm create`.
  *
  * Programmatic API. Returns a result object on every code path; never
  * prompts and never calls `process.exit`. The CLI wraps this with a TTY
@@ -49,6 +55,8 @@ export async function removeRealm(
     return {
       realmUrl,
       removed: false,
+      serverDeleted: false,
+      unlinked: false,
       previousCount: 0,
       nextCount: 0,
       error: NO_ACTIVE_PROFILE_ERROR,
@@ -62,6 +70,8 @@ export async function removeRealm(
     return {
       realmUrl,
       removed: false,
+      serverDeleted: false,
+      unlinked: false,
       previousCount: 0,
       nextCount: 0,
       error: `Failed to load realm list: ${
@@ -76,6 +86,8 @@ export async function removeRealm(
     return {
       realmUrl,
       removed: false,
+      serverDeleted: false,
+      unlinked: false,
       previousCount,
       nextCount: previousCount,
       notInList: true,
@@ -86,22 +98,92 @@ export async function removeRealm(
   let nextCount = previousCount - 1;
 
   if (options.dryRun) {
-    return { realmUrl, removed: false, previousCount, nextCount };
+    return {
+      realmUrl,
+      removed: false,
+      serverDeleted: false,
+      unlinked: false,
+      previousCount,
+      nextCount,
+    };
   }
 
+  let realmServerUrl = active.profile.realmServerUrl.replace(/\/$/, '');
+  let response: Response;
   try {
-    let removed = await pm.removeFromUserRealms(realmUrl);
-    return { realmUrl, removed, previousCount, nextCount };
+    response = await pm.authedRealmServerFetch(
+      `${realmServerUrl}/_delete-realm`,
+      {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/vnd.api+json' },
+        body: JSON.stringify({
+          data: { type: 'realm', id: realmUrl },
+        }),
+      },
+    );
   } catch (err) {
     return {
       realmUrl,
       removed: false,
+      serverDeleted: false,
+      unlinked: false,
       previousCount,
       nextCount: previousCount,
-      error: `Failed to update Matrix account data: ${
+      error: `Failed to reach realm server: ${
         err instanceof Error ? err.message : String(err)
       }`,
     };
+  }
+
+  if (!response.ok) {
+    let body = await safeReadResponseText(response);
+    let error =
+      response.status === 403
+        ? `You do not own this realm and cannot delete it on the server. Server returned 403: ${body}`
+        : `Realm server returned ${response.status}: ${body}`;
+    return {
+      realmUrl,
+      removed: false,
+      serverDeleted: false,
+      unlinked: false,
+      previousCount,
+      nextCount: previousCount,
+      error,
+    };
+  }
+
+  let unlinked: boolean;
+  try {
+    unlinked = await pm.removeFromUserRealms(realmUrl);
+  } catch (err) {
+    return {
+      realmUrl,
+      removed: false,
+      serverDeleted: true,
+      unlinked: false,
+      previousCount,
+      nextCount: previousCount,
+      error: `Server delete succeeded, but Matrix unlink failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+
+  return {
+    realmUrl,
+    removed: true,
+    serverDeleted: true,
+    unlinked,
+    previousCount,
+    nextCount,
+  };
+}
+
+async function safeReadResponseText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return '<no response body>';
   }
 }
 
@@ -114,9 +196,9 @@ export function registerRemoveCommand(realm: Command): void {
   realm
     .command('remove')
     .description(
-      "Soft-remove a realm from the active profile's UI realm list (does not delete server files)",
+      'Remove a realm — deletes server-side files and unlinks it from your realm list',
     )
-    .argument('<realm-url>', 'realm URL to remove from app.boxel.realms')
+    .argument('<realm-url>', 'realm URL to remove')
     .option('-y, --yes', 'Skip the interactive confirmation prompt')
     .option('--dry-run', 'Preview the change without writing to Matrix')
     .action(async (realmUrlInput: string, opts: RemoveCliOptions) => {
@@ -137,14 +219,14 @@ export function registerRemoveCommand(realm: Command): void {
         process.exit(1);
       }
 
-      console.log(`Soft remove target: ${FG_CYAN}${preview.realmUrl}${RESET}`);
+      console.log(`Remove target: ${FG_CYAN}${preview.realmUrl}${RESET}`);
       console.log(
         `${DIM}app.boxel.realms: ${preview.previousCount} -> ${preview.nextCount}${RESET}`,
       );
 
       if (opts.dryRun) {
         console.log(
-          `${DIM}[DRY RUN] No Matrix account data changes sent.${RESET}`,
+          `${DIM}[DRY RUN] No server delete or Matrix changes sent.${RESET}`,
         );
         return;
       }
@@ -157,7 +239,7 @@ export function registerRemoveCommand(realm: Command): void {
           process.exit(1);
         }
         let answer = await prompt(
-          'Proceed with soft remove from your realm list? (y/N) ',
+          'This will permanently delete the realm files, indexer state, and registry entry on the server. Proceed? (y/N) ',
         );
         if (!/^y/i.test(answer)) {
           console.log(`${DIM}Cancelled.${RESET}`);
@@ -170,14 +252,16 @@ export function registerRemoveCommand(realm: Command): void {
         console.error(
           `${FG_RED}Error:${RESET} ${result.error ?? 'Removal did not complete.'}`,
         );
+        if (result.serverDeleted && !result.unlinked) {
+          console.error(
+            `${DIM}The realm is gone, but your account_data still references ${result.realmUrl}.${RESET}`,
+          );
+        }
         process.exit(1);
       }
 
       console.log(
         `${FG_GREEN}Removed:${RESET} ${FG_CYAN}${result.realmUrl}${RESET}`,
-      );
-      console.log(
-        `${DIM}Note: server files are not deleted by this command.${RESET}`,
       );
     });
 }

--- a/packages/boxel-cli/src/lib/auth.ts
+++ b/packages/boxel-cli/src/lib/auth.ts
@@ -14,6 +14,7 @@ interface MatrixLoginResponse {
 }
 
 import { APP_BOXEL_REALMS_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 
 export async function matrixLogin(
   matrixUrl: string,
@@ -177,18 +178,23 @@ export async function addRealmToMatrixAccountData(
   }
 }
 
-// Returns true when the URL was present and a write occurred, false when the
-// URL wasn't in the list (caller decides how to surface that to the user).
+// Returns true when at least one entry was removed and a write occurred,
+// false when no entry matched the URL (caller decides how to surface that
+// to the user). Comparison is normalized via `ensureTrailingSlash` and every
+// matching entry is dropped, so legacy duplicates like `https://host/realm`
+// + `https://host/realm/` are both cleaned out in a single PUT.
 export async function removeRealmFromMatrixAccountData(
   matrixAuth: MatrixAuth,
   realmUrl: string,
 ): Promise<boolean> {
+  let target = ensureTrailingSlash(realmUrl);
   let existingRealms = await getUserRealmsFromMatrixAccountData(matrixAuth);
-
-  if (!existingRealms.includes(realmUrl)) {
+  let next = existingRealms.filter(
+    (url) => ensureTrailingSlash(url) !== target,
+  );
+  if (next.length === existingRealms.length) {
     return false;
   }
-  let next = existingRealms.filter((url) => url !== realmUrl);
   let putResponse = await fetch(userRealmsAccountDataUrl(matrixAuth), {
     method: 'PUT',
     headers: {

--- a/packages/boxel-cli/src/lib/auth.ts
+++ b/packages/boxel-cli/src/lib/auth.ts
@@ -176,3 +176,32 @@ export async function addRealmToMatrixAccountData(
     }
   }
 }
+
+// Returns true when the URL was present and a write occurred, false when the
+// URL wasn't in the list (caller decides how to surface that to the user).
+export async function removeRealmFromMatrixAccountData(
+  matrixAuth: MatrixAuth,
+  realmUrl: string,
+): Promise<boolean> {
+  let existingRealms = await getUserRealmsFromMatrixAccountData(matrixAuth);
+
+  if (!existingRealms.includes(realmUrl)) {
+    return false;
+  }
+  let next = existingRealms.filter((url) => url !== realmUrl);
+  let putResponse = await fetch(userRealmsAccountDataUrl(matrixAuth), {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${matrixAuth.accessToken}`,
+    },
+    body: JSON.stringify({ realms: next }),
+  });
+  if (!putResponse.ok) {
+    let text = await putResponse.text();
+    throw new Error(
+      `Failed to update Matrix account data: ${putResponse.status} ${text}`,
+    );
+  }
+  return true;
+}

--- a/packages/boxel-cli/src/lib/profile-manager.ts
+++ b/packages/boxel-cli/src/lib/profile-manager.ts
@@ -7,6 +7,7 @@ import {
   getRealmServerToken as fetchRealmServerToken,
   getRealmTokens,
   addRealmToMatrixAccountData,
+  removeRealmFromMatrixAccountData,
   getUserRealmsFromMatrixAccountData,
   type MatrixAuth,
 } from './auth';
@@ -522,6 +523,11 @@ export class ProfileManager implements RealmAuthenticator {
   async addToUserRealms(realmUrl: string): Promise<void> {
     let matrixAuth = await this.loginToMatrix();
     await addRealmToMatrixAccountData(matrixAuth, realmUrl);
+  }
+
+  async removeFromUserRealms(realmUrl: string): Promise<boolean> {
+    let matrixAuth = await this.loginToMatrix();
+    return removeRealmFromMatrixAccountData(matrixAuth, realmUrl);
   }
 
   async getUserRealms(): Promise<string[]> {

--- a/packages/boxel-cli/tests/helpers/integration.ts
+++ b/packages/boxel-cli/tests/helpers/integration.ts
@@ -14,6 +14,12 @@ import {
 } from '#realm-server/tests/helpers/index';
 import { createJWT as createRealmServerJWT } from '#realm-server/utils/jwt';
 import { registerUser } from '#realm-server/synapse';
+
+export { registerUser } from '#realm-server/synapse';
+export {
+  matrixURL,
+  matrixRegistrationSecret,
+} from '#realm-server/tests/helpers/index';
 import {
   PgQueuePublisher,
   PgQueueRunner,

--- a/packages/boxel-cli/tests/integration/realm-remove.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-remove.test.ts
@@ -129,6 +129,33 @@ describe('realm remove (integration)', () => {
     expect(after).not.toContain(realmUrl);
   });
 
+  it('removes legacy duplicate entries (with and without trailing slash)', async () => {
+    let name = uniqueRealmName();
+    let { realmUrl } = await createRealm(name, `Test ${name}`, {
+      profileManager,
+    });
+    let withoutSlash = realmUrl.replace(/\/$/, '');
+
+    // createRealm adds the trailing-slash form. Inject the trailing-slash-less
+    // form directly so the list looks like a legacy account_data with both
+    // shapes for the same realm.
+    await profileManager.addToUserRealms(withoutSlash);
+    let beforeRemove = await profileManager.getUserRealms();
+    expect(beforeRemove).toContain(realmUrl);
+    expect(beforeRemove).toContain(withoutSlash);
+
+    let result = await removeRealm({ realmUrl, profileManager });
+    expect(result.error).toBeUndefined();
+    expect(result.removed).toBe(true);
+    expect(result.serverDeleted).toBe(true);
+    expect(result.unlinked).toBe(true);
+    expect(result.previousCount - result.nextCount).toBe(2);
+
+    let after = await profileManager.getUserRealms();
+    expect(after).not.toContain(realmUrl);
+    expect(after).not.toContain(withoutSlash);
+  });
+
   it('fails with a 403 error when the caller does not own the realm', async () => {
     let realmName = uniqueRealmName();
     let { realmUrl } = await createRealm(realmName, `Test ${realmName}`, {

--- a/packages/boxel-cli/tests/integration/realm-remove.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-remove.test.ts
@@ -1,0 +1,140 @@
+import '../helpers/setup-realm-server';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { listRealms } from '../../src/commands/realm/list';
+import { removeRealm } from '../../src/commands/realm/remove';
+import { ProfileManager } from '../../src/lib/profile-manager';
+import {
+  startTestRealmServer,
+  stopTestRealmServer,
+  createTestProfileDir,
+  setupTestProfile,
+  TEST_REALM_SERVER_URL,
+} from '../helpers/integration';
+
+let profileManager: ProfileManager;
+let cleanupProfile: () => void;
+
+const realmAUrl = `${TEST_REALM_SERVER_URL}/realm-a/`;
+const realmBUrl = `${TEST_REALM_SERVER_URL}/realm-b/`;
+
+beforeAll(async () => {
+  await startTestRealmServer({
+    realms: [
+      {
+        realmURL: new URL(realmAUrl),
+        permissions: { '*': ['read', 'write'] },
+      },
+      {
+        realmURL: new URL(realmBUrl),
+        permissions: { '*': ['read', 'write'] },
+      },
+    ],
+  });
+  let testProfile = createTestProfileDir();
+  profileManager = testProfile.profileManager;
+  cleanupProfile = testProfile.cleanup;
+  await setupTestProfile(profileManager);
+
+  await profileManager.addToUserRealms(realmAUrl);
+});
+
+afterAll(async () => {
+  cleanupProfile?.();
+  await stopTestRealmServer();
+});
+
+describe('realm remove (integration)', () => {
+  it('removes a realm that is in the user list', async () => {
+    let result = await removeRealm({
+      realmUrl: realmAUrl,
+      profileManager,
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.removed).toBe(true);
+    expect(result.realmUrl).toBe(realmAUrl);
+    expect(result.previousCount).toBeGreaterThanOrEqual(1);
+    expect(result.nextCount).toBe(result.previousCount - 1);
+
+    let userRealms = await profileManager.getUserRealms();
+    expect(userRealms).not.toContain(realmAUrl);
+  });
+
+  it('reports notInList when the URL is not in the user list', async () => {
+    let result = await removeRealm({
+      realmUrl: realmBUrl,
+      profileManager,
+    });
+    expect(result.removed).toBe(false);
+    expect(result.notInList).toBe(true);
+    expect(result.error).toContain('Nothing to remove');
+    expect(result.previousCount).toBe(result.nextCount);
+  });
+
+  it('dry-run computes nextCount but does not write', async () => {
+    await profileManager.addToUserRealms(realmAUrl);
+    let before = await profileManager.getUserRealms();
+
+    let result = await removeRealm({
+      realmUrl: realmAUrl,
+      dryRun: true,
+      profileManager,
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.removed).toBe(false);
+    expect(result.previousCount).toBe(before.length);
+    expect(result.nextCount).toBe(before.length - 1);
+
+    let after = await profileManager.getUserRealms();
+    expect(after.sort()).toEqual(before.sort());
+    expect(after).toContain(realmAUrl);
+  });
+
+  it('normalizes trailing-slash on input', async () => {
+    let userRealms = await profileManager.getUserRealms();
+    expect(userRealms).toContain(realmAUrl);
+
+    let withoutSlash = realmAUrl.replace(/\/$/, '');
+    let result = await removeRealm({
+      realmUrl: withoutSlash,
+      profileManager,
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.removed).toBe(true);
+    expect(result.realmUrl).toBe(realmAUrl);
+
+    let after = await profileManager.getUserRealms();
+    expect(after).not.toContain(realmAUrl);
+  });
+
+  it('does not delete realm files from the server (soft remove)', async () => {
+    // Realm A is still missing from the user list at this point. The realm
+    // server should still know about it — re-adding restores visibility, and
+    // listRealms({ allAccessible }) finds it via the server's _realm-auth.
+    let accessible = await listRealms({
+      allAccessible: true,
+      profileManager,
+    });
+    expect(accessible.error).toBeUndefined();
+    expect(accessible.realms.map((r) => r.url)).toContain(realmAUrl);
+
+    await profileManager.addToUserRealms(realmAUrl);
+    let visible = await listRealms({ profileManager });
+    expect(visible.error).toBeUndefined();
+    expect(visible.realms.map((r) => r.url)).toContain(realmAUrl);
+  });
+
+  it('returns an error when no active profile', async () => {
+    let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
+    let emptyManager = new ProfileManager(emptyDir);
+    let result = await removeRealm({
+      realmUrl: realmAUrl,
+      profileManager: emptyManager,
+    });
+    expect(result.removed).toBe(false);
+    expect(result.error).toContain('No active profile');
+    fs.rmSync(emptyDir, { recursive: true, force: true });
+  });
+});

--- a/packages/boxel-cli/tests/integration/realm-remove.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-remove.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { listRealms } from '../../src/commands/realm/list';
+import { createRealm } from '../../src/commands/realm/create';
 import { removeRealm } from '../../src/commands/realm/remove';
 import { ProfileManager } from '../../src/lib/profile-manager';
 import {
@@ -11,34 +11,22 @@ import {
   stopTestRealmServer,
   createTestProfileDir,
   setupTestProfile,
+  uniqueRealmName,
+  registerUser,
+  matrixURL,
+  matrixRegistrationSecret,
   TEST_REALM_SERVER_URL,
 } from '../helpers/integration';
 
 let profileManager: ProfileManager;
 let cleanupProfile: () => void;
 
-const realmAUrl = `${TEST_REALM_SERVER_URL}/realm-a/`;
-const realmBUrl = `${TEST_REALM_SERVER_URL}/realm-b/`;
-
 beforeAll(async () => {
-  await startTestRealmServer({
-    realms: [
-      {
-        realmURL: new URL(realmAUrl),
-        permissions: { '*': ['read', 'write'] },
-      },
-      {
-        realmURL: new URL(realmBUrl),
-        permissions: { '*': ['read', 'write'] },
-      },
-    ],
-  });
+  await startTestRealmServer();
   let testProfile = createTestProfileDir();
   profileManager = testProfile.profileManager;
   cleanupProfile = testProfile.cleanup;
   await setupTestProfile(profileManager);
-
-  await profileManager.addToUserRealms(realmAUrl);
 });
 
 afterAll(async () => {
@@ -47,90 +35,156 @@ afterAll(async () => {
 });
 
 describe('realm remove (integration)', () => {
-  it('removes a realm that is in the user list', async () => {
-    let result = await removeRealm({
-      realmUrl: realmAUrl,
+  it('hard-deletes the realm on the server and unlinks from Matrix', async () => {
+    let name = uniqueRealmName();
+    let { realmUrl } = await createRealm(name, `Test ${name}`, {
       profileManager,
     });
+
+    let result = await removeRealm({ realmUrl, profileManager });
+
     expect(result.error).toBeUndefined();
     expect(result.removed).toBe(true);
-    expect(result.realmUrl).toBe(realmAUrl);
-    expect(result.previousCount).toBeGreaterThanOrEqual(1);
+    expect(result.serverDeleted).toBe(true);
+    expect(result.unlinked).toBe(true);
+    expect(result.realmUrl).toBe(realmUrl);
     expect(result.nextCount).toBe(result.previousCount - 1);
 
     let userRealms = await profileManager.getUserRealms();
-    expect(userRealms).not.toContain(realmAUrl);
+    expect(userRealms).not.toContain(realmUrl);
+  });
+
+  it('frees the realm name so it can be recreated', async () => {
+    let name = uniqueRealmName();
+    let first = await createRealm(name, `Test ${name}`, { profileManager });
+    let removed = await removeRealm({
+      realmUrl: first.realmUrl,
+      profileManager,
+    });
+    expect(removed.removed).toBe(true);
+
+    let second = await createRealm(name, `Test ${name}`, { profileManager });
+    expect(second.created).toBe(true);
+    expect(second.realmUrl).toBe(first.realmUrl);
+
+    await removeRealm({ realmUrl: second.realmUrl, profileManager });
   });
 
   it('reports notInList when the URL is not in the user list', async () => {
     let result = await removeRealm({
-      realmUrl: realmBUrl,
+      realmUrl: `${TEST_REALM_SERVER_URL}/never-added-${Date.now()}/`,
       profileManager,
     });
     expect(result.removed).toBe(false);
+    expect(result.serverDeleted).toBe(false);
+    expect(result.unlinked).toBe(false);
     expect(result.notInList).toBe(true);
     expect(result.error).toContain('Nothing to remove');
     expect(result.previousCount).toBe(result.nextCount);
   });
 
-  it('dry-run computes nextCount but does not write', async () => {
-    await profileManager.addToUserRealms(realmAUrl);
+  it('dry-run does not hit the server or modify Matrix', async () => {
+    let name = uniqueRealmName();
+    let { realmUrl } = await createRealm(name, `Test ${name}`, {
+      profileManager,
+    });
     let before = await profileManager.getUserRealms();
 
     let result = await removeRealm({
-      realmUrl: realmAUrl,
+      realmUrl,
       dryRun: true,
       profileManager,
     });
+
     expect(result.error).toBeUndefined();
     expect(result.removed).toBe(false);
+    expect(result.serverDeleted).toBe(false);
+    expect(result.unlinked).toBe(false);
     expect(result.previousCount).toBe(before.length);
     expect(result.nextCount).toBe(before.length - 1);
 
     let after = await profileManager.getUserRealms();
-    expect(after.sort()).toEqual(before.sort());
-    expect(after).toContain(realmAUrl);
+    expect(after).toContain(realmUrl);
+
+    let stillThere = await removeRealm({ realmUrl, profileManager });
+    expect(stillThere.serverDeleted).toBe(true);
   });
 
   it('normalizes trailing-slash on input', async () => {
-    let userRealms = await profileManager.getUserRealms();
-    expect(userRealms).toContain(realmAUrl);
+    let name = uniqueRealmName();
+    let { realmUrl } = await createRealm(name, `Test ${name}`, {
+      profileManager,
+    });
 
-    let withoutSlash = realmAUrl.replace(/\/$/, '');
+    let withoutSlash = realmUrl.replace(/\/$/, '');
     let result = await removeRealm({
       realmUrl: withoutSlash,
       profileManager,
     });
     expect(result.error).toBeUndefined();
     expect(result.removed).toBe(true);
-    expect(result.realmUrl).toBe(realmAUrl);
+    expect(result.realmUrl).toBe(realmUrl);
 
     let after = await profileManager.getUserRealms();
-    expect(after).not.toContain(realmAUrl);
+    expect(after).not.toContain(realmUrl);
   });
 
-  it('does not delete realm files from the server (soft remove)', async () => {
-    // Realm A is still missing from the user list at this point. The realm
-    // server should still know about it — re-adding restores visibility, and
-    // listRealms({ allAccessible }) finds it via the server's _realm-auth.
-    let accessible = await listRealms({
-      allAccessible: true,
+  it('fails with a 403 error when the caller does not own the realm', async () => {
+    let realmName = uniqueRealmName();
+    let { realmUrl } = await createRealm(realmName, `Test ${realmName}`, {
       profileManager,
     });
-    expect(accessible.error).toBeUndefined();
-    expect(accessible.realms.map((r) => r.url)).toContain(realmAUrl);
 
-    await profileManager.addToUserRealms(realmAUrl);
-    let visible = await listRealms({ profileManager });
-    expect(visible.error).toBeUndefined();
-    expect(visible.realms.map((r) => r.url)).toContain(realmAUrl);
+    let userBSuffix = `userb-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 6)}`;
+    let userBUsername = `cli-test-${userBSuffix}`;
+    let userBPassword = 'test-password-userb';
+    await registerUser({
+      matrixURL,
+      displayname: 'CLI Test User B',
+      username: userBUsername,
+      password: userBPassword,
+      registrationSecret: matrixRegistrationSecret,
+    });
+
+    let userBProfile = createTestProfileDir();
+    try {
+      await userBProfile.profileManager.addProfile(
+        `@${userBUsername}:localhost`,
+        userBPassword,
+        'CLI Test User B',
+        matrixURL.href,
+        `${TEST_REALM_SERVER_URL}/`,
+      );
+      await userBProfile.profileManager.addToUserRealms(realmUrl);
+
+      let result = await removeRealm({
+        realmUrl,
+        profileManager: userBProfile.profileManager,
+      });
+
+      expect(result.removed).toBe(false);
+      expect(result.serverDeleted).toBe(false);
+      expect(result.unlinked).toBe(false);
+      expect(result.error).toMatch(/403/);
+      expect(result.error).toMatch(/do not own this realm/);
+
+      let listAfter = await profileManager.getUserRealms();
+      expect(listAfter).toContain(realmUrl);
+    } finally {
+      userBProfile.cleanup();
+    }
+
+    let cleanup = await removeRealm({ realmUrl, profileManager });
+    expect(cleanup.removed).toBe(true);
   });
 
   it('returns an error when no active profile', async () => {
     let emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
     let emptyManager = new ProfileManager(emptyDir);
     let result = await removeRealm({
-      realmUrl: realmAUrl,
+      realmUrl: `${TEST_REALM_SERVER_URL}/anything/`,
       profileManager: emptyManager,
     });
     expect(result.removed).toBe(false);


### PR DESCRIPTION
## Summary
- Port `boxel remove` from the standalone [`cardstack/boxel-cli`](https://github.com/cardstack/boxel-cli/blob/main/src/commands/remove.ts) into `packages/boxel-cli/src/commands/realm/remove.ts` as `boxel realm remove <realm-url>`.
- **Hard delete**: calls `DELETE /_delete-realm` (filesystem + indexer + registry), then unlinks the URL from the active profile's `app.boxel.realms` Matrix `account_data` list. Mirrors the host UI's workspace delete flow (`packages/host/app/components/operator-mode/workspace-chooser/workspace.gts:999-1005`) and inverts the existing `boxel realm create` → `/_create-realm` pattern.
- After removal the realm name is recyclable: `boxel realm create <same-name>` now succeeds.

## Why hard delete
The first iteration of this PR was soft-only (Matrix unlink only). [Hassan flagged that as misleading](https://github.com/cardstack/boxel/pull/4655#issuecomment-4379823050) — the user thinks they removed it, but server files / index rows / registry entry remain, and recreating with the same name fails with "already exists". `boxel realm remove` was the asymmetric outlier next to the host UI and `realm create`. Now it matches.

## Safety
- TTY confirmation prompt before the destructive call; bypass with `-y, --yes`.
- Non-interactive invocation without `--yes` errors out instead of deleting silently.
- `--dry-run` previews `previousCount → nextCount` without sending either request.
- 403 from the server (caller doesn't own the realm) surfaces a clear "you do not own this realm" error; no silent fallback to soft-unlink.
- `removeRealm()` returns a structured result on every path (never `process.exit`s), with `serverDeleted` / `unlinked` flags so callers can detect the rare partial-success state (server gone, Matrix list still references the URL).

## Linear
[CS-10630](https://linear.app/cardstack/issue/CS-10630/reimplement-boxel-realm-remove-command) — part of [Incorporate Boxel CLI to Monorepo](https://linear.app/cardstack/issue/CS-10519).

## Test plan
- [x] `pnpm --filter @cardstack/boxel-cli lint:types`
- [x] `pnpm --filter @cardstack/boxel-cli lint:js`
- [x] `pnpm --filter @cardstack/boxel-cli exec vitest run tests/integration/realm-remove.test.ts` (7 tests pass: hard-delete, name-recyclable, notInList, dry-run-server-silent, trailing-slash, 403-not-owner, no-active-profile). Requires test-PG (port 55436) and Synapse running locally with realm users registered.
- [ ] Manual TTY: `boxel realm remove <url>` prompts y/N, deletes on `y`, cancels on `N`.
- [ ] Manual: `boxel realm remove <url> --yes` skips the prompt.
- [ ] Manual: `boxel realm remove <url> < /dev/null` errors out (non-TTY without `--yes`).
- [ ] Manual: `boxel realm remove <url> --dry-run` prints the count delta and exits without writing.
- [ ] Manual: after remove, `boxel realm create <same-name> "Same Name"` succeeds (no "already exists" error).
- [ ] Manual: `boxel realm remove <url-of-realm-you-do-not-own>` fails with a clear 403 message and exit code 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)