### PR TITLE
PgAdapter.subscribe: multiplex LISTEN over a shared client

### DIFF
--- a/packages/postgres/pg-adapter.ts
+++ b/packages/postgres/pg-adapter.ts
@@ -41,12 +41,25 @@ function configuredPoolMax(): number | undefined {
   return Number.isInteger(value) && value > 0 ? value : undefined;
 }
 
+export type NotificationHandler = (notification: Notification) => void;
+
+export interface NotificationSubscription {
+  unsubscribe(): Promise<void>;
+}
+
 export class PgAdapter implements DBAdapter {
   readonly kind = 'pg';
   #isClosed = false;
   private pool: Pool;
   private started: Promise<void>;
   private config: Config;
+  // Shared LISTEN connection used by all subscribe() callers. A dedicated
+  // Client (not Pool-acquired) is required because LISTEN/NOTIFY is
+  // unreliable on pooled connections — see node-postgres#1543. Lazily
+  // opened on first subscribe; closed in close().
+  #notificationClient?: Client;
+  #notificationClientStarting?: Promise<Client>;
+  #subscribers = new Map<string, Set<NotificationHandler>>();
 
   constructor(opts?: { autoMigrate?: boolean; migrationLogging?: boolean }) {
     if (opts?.autoMigrate) {
@@ -81,7 +94,123 @@ export class PgAdapter implements DBAdapter {
     log.debug(`closing ${this.url}`);
     this.#isClosed = true;
     await this.started;
+    if (this.#notificationClient) {
+      const client = this.#notificationClient;
+      this.#notificationClient = undefined;
+      this.#subscribers.clear();
+      try {
+        await client.end();
+      } catch (err: unknown) {
+        log.warn(`failed to end shared notification client: ${String(err)}`);
+      }
+    }
     await this.pool.end();
+  }
+
+  // Subscribe a handler to a Postgres NOTIFY channel. Multiple subscribe()
+  // callers — across channels, or even on the same channel — share one
+  // dedicated Client; the Client is opened lazily on the first subscribe and
+  // closed in close(). Each call returns an `unsubscribe()` that removes
+  // just this handler; UNLISTEN is sent only after the last handler for a
+  // channel is removed. Concurrent subscribes are safe.
+  async subscribe(
+    channel: string,
+    handler: NotificationHandler,
+  ): Promise<NotificationSubscription> {
+    await this.started;
+    if (this.#isClosed) {
+      throw new Error('PgAdapter is closed');
+    }
+    const client = await this.#ensureNotificationClient();
+    let set = this.#subscribers.get(channel);
+    const isFirst = !set || set.size === 0;
+    if (!set) {
+      set = new Set();
+      this.#subscribers.set(channel, set);
+    }
+    set.add(handler);
+    if (isFirst) {
+      try {
+        await client.query(`LISTEN ${safeName(channel)}`);
+      } catch (err) {
+        // Roll back the bookkeeping so a retry is clean.
+        set.delete(handler);
+        if (set.size === 0) {
+          this.#subscribers.delete(channel);
+        }
+        throw err;
+      }
+    }
+    let unsubscribed = false;
+    return {
+      unsubscribe: async () => {
+        if (unsubscribed) {
+          return;
+        }
+        unsubscribed = true;
+        const subs = this.#subscribers.get(channel);
+        if (!subs) {
+          return;
+        }
+        subs.delete(handler);
+        if (subs.size > 0) {
+          return;
+        }
+        this.#subscribers.delete(channel);
+        if (this.#notificationClient && !this.#isClosed) {
+          try {
+            await this.#notificationClient.query(
+              `UNLISTEN ${safeName(channel)}`,
+            );
+          } catch (err: unknown) {
+            log.warn(`UNLISTEN ${channel} failed: ${String(err)}`);
+          }
+        }
+      },
+    };
+  }
+
+  async #ensureNotificationClient(): Promise<Client> {
+    if (this.#notificationClient) {
+      return this.#notificationClient;
+    }
+    if (this.#notificationClientStarting) {
+      return this.#notificationClientStarting;
+    }
+    this.#notificationClientStarting = (async () => {
+      const client = new Client(this.config);
+      client.on('notification', (n) => {
+        log.debug(`heard pg notification for channel %s`, n.channel);
+        const handlers = this.#subscribers.get(n.channel);
+        if (!handlers) {
+          return;
+        }
+        for (const h of [...handlers]) {
+          try {
+            h(n);
+          } catch (err: unknown) {
+            log.warn(
+              `notification handler for channel ${n.channel} threw: ${String(err)}`,
+            );
+          }
+        }
+      });
+      client.on('error', (err) => {
+        // The shared client is the substrate for every subscriber, so a
+        // disconnect silently kills them all. Surface it loudly. Reconnect
+        // is not implemented here; current production has not seen this
+        // path, and the legacy listen() API has the same hazard.
+        log.error(`shared notification client error: ${String(err)}`);
+      });
+      await client.connect();
+      this.#notificationClient = client;
+      return client;
+    })();
+    try {
+      return await this.#notificationClientStarting;
+    } finally {
+      this.#notificationClientStarting = undefined;
+    }
   }
 
   async execute(
@@ -112,6 +241,11 @@ export class PgAdapter implements DBAdapter {
     }
   }
 
+  // @deprecated — prefer `subscribe(channel, handler)`. Each call to listen()
+  // opens its own dedicated Client connection for the duration of `fn`, which
+  // doesn't scale as the number of LISTEN-using callers grows. subscribe()
+  // multiplexes all callers onto a single shared Client. This entry point is
+  // kept for callers that haven't migrated yet (e.g. pg-queue).
   async listen(
     channel: string,
     handler: (notification: Notification) => void,

--- a/packages/postgres/pg-adapter.ts
+++ b/packages/postgres/pg-adapter.ts
@@ -47,6 +47,19 @@ export interface NotificationSubscription {
   unsubscribe(): Promise<void>;
 }
 
+// Per-channel state kept alive while at least one subscriber is registered
+// or while a LISTEN is being established. Each subscribe() pushes its own
+// handler entry and holds a reference to it, so unsubscribing removes the
+// exact entry — even when the same function reference is subscribed twice.
+// `establishment` resolves when LISTEN has succeeded; concurrent subscribers
+// to the same channel join the same promise so a LISTEN failure rejects all
+// of them atomically rather than leaving later subscribers stranded.
+type HandlerEntry = { fn: NotificationHandler };
+type ChannelState = {
+  handlers: HandlerEntry[];
+  establishment: Promise<void>;
+};
+
 export class PgAdapter implements DBAdapter {
   readonly kind = 'pg';
   #isClosed = false;
@@ -59,7 +72,7 @@ export class PgAdapter implements DBAdapter {
   // opened on first subscribe; closed in close().
   #notificationClient?: Client;
   #notificationClientStarting?: Promise<Client>;
-  #subscribers = new Map<string, Set<NotificationHandler>>();
+  #channels = new Map<string, ChannelState>();
 
   constructor(opts?: { autoMigrate?: boolean; migrationLogging?: boolean }) {
     if (opts?.autoMigrate) {
@@ -94,10 +107,23 @@ export class PgAdapter implements DBAdapter {
     log.debug(`closing ${this.url}`);
     this.#isClosed = true;
     await this.started;
-    if (this.#notificationClient) {
-      const client = this.#notificationClient;
-      this.#notificationClient = undefined;
-      this.#subscribers.clear();
+    // Resolve any in-flight notification-client startup so we can end the
+    // resulting Client. Without this await, a close() that races a first
+    // subscribe() can leave the connection alive after #isClosed flipped to
+    // true, because the connect() resolves into #notificationClient only
+    // after we've already returned from close().
+    let pendingStart = this.#notificationClientStarting;
+    if (pendingStart) {
+      try {
+        await pendingStart;
+      } catch {
+        // Startup failed — there's nothing for us to end.
+      }
+    }
+    const client = this.#notificationClient;
+    this.#notificationClient = undefined;
+    this.#channels.clear();
+    if (client) {
       try {
         await client.end();
       } catch (err: unknown) {
@@ -112,62 +138,86 @@ export class PgAdapter implements DBAdapter {
   // dedicated Client; the Client is opened lazily on the first subscribe and
   // closed in close(). Each call returns an `unsubscribe()` that removes
   // just this handler; UNLISTEN is sent only after the last handler for a
-  // channel is removed. Concurrent subscribes are safe.
+  // channel is removed. Concurrent subscribes on the same channel join the
+  // same in-flight LISTEN, so a LISTEN failure rejects all racing callers
+  // atomically — no caller is ever stranded with a registered handler that
+  // the backend isn't actually delivering to.
   async subscribe(
     channel: string,
     handler: NotificationHandler,
   ): Promise<NotificationSubscription> {
     await this.started;
-    if (this.#isClosed) {
-      throw new Error('PgAdapter is closed');
-    }
-    const client = await this.#ensureNotificationClient();
-    let set = this.#subscribers.get(channel);
-    const isFirst = !set || set.size === 0;
-    if (!set) {
-      set = new Set();
-      this.#subscribers.set(channel, set);
-    }
-    set.add(handler);
-    if (isFirst) {
-      try {
-        await client.query(`LISTEN ${safeName(channel)}`);
-      } catch (err) {
-        // Roll back the bookkeeping so a retry is clean.
-        set.delete(handler);
-        if (set.size === 0) {
-          this.#subscribers.delete(channel);
-        }
-        throw err;
+    // Loop in case the channel state we joined gets torn down by a concurrent
+    // unsubscribe (or LISTEN failure) while we were still awaiting establishment.
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (this.#isClosed) {
+        throw new Error('PgAdapter is closed');
       }
-    }
-    let unsubscribed = false;
-    return {
-      unsubscribe: async () => {
-        if (unsubscribed) {
-          return;
-        }
-        unsubscribed = true;
-        const subs = this.#subscribers.get(channel);
-        if (!subs) {
-          return;
-        }
-        subs.delete(handler);
-        if (subs.size > 0) {
-          return;
-        }
-        this.#subscribers.delete(channel);
-        if (this.#notificationClient && !this.#isClosed) {
-          try {
-            await this.#notificationClient.query(
-              `UNLISTEN ${safeName(channel)}`,
-            );
-          } catch (err: unknown) {
-            log.warn(`UNLISTEN ${channel} failed: ${String(err)}`);
+      const client = await this.#ensureNotificationClient();
+      if (this.#isClosed) {
+        throw new Error('PgAdapter is closed');
+      }
+      let state = this.#channels.get(channel);
+      if (!state) {
+        const safeChannel = safeName(channel);
+        const establishment = (async () => {
+          await client.query(`LISTEN ${safeChannel}`);
+        })();
+        const newState: ChannelState = { handlers: [], establishment };
+        this.#channels.set(channel, newState);
+        // If LISTEN ultimately rejects, drop the channel from the map so the
+        // next subscribe gets a fresh attempt rather than re-awaiting a
+        // permanently-rejected promise. Awaiting subscribers see the rejection
+        // through their own `await state.establishment` below.
+        establishment.catch(() => {
+          if (this.#channels.get(channel) === newState) {
+            this.#channels.delete(channel);
           }
-        }
-      },
-    };
+        });
+        state = newState;
+      }
+      const joined = state;
+      await joined.establishment;
+      // A concurrent unsubscribe may have torn the channel state down between
+      // when we joined it and when LISTEN resolved. Re-check, retry from the
+      // top if so.
+      if (this.#channels.get(channel) !== joined) {
+        continue;
+      }
+      const entry: HandlerEntry = { fn: handler };
+      joined.handlers.push(entry);
+      let unsubscribed = false;
+      return {
+        unsubscribe: async () => {
+          if (unsubscribed) {
+            return;
+          }
+          unsubscribed = true;
+          const cur = this.#channels.get(channel);
+          if (!cur) {
+            return;
+          }
+          const idx = cur.handlers.indexOf(entry);
+          if (idx >= 0) {
+            cur.handlers.splice(idx, 1);
+          }
+          if (cur.handlers.length > 0) {
+            return;
+          }
+          this.#channels.delete(channel);
+          if (this.#notificationClient && !this.#isClosed) {
+            try {
+              await this.#notificationClient.query(
+                `UNLISTEN ${safeName(channel)}`,
+              );
+            } catch (err: unknown) {
+              log.warn(`UNLISTEN ${channel} failed: ${String(err)}`);
+            }
+          }
+        },
+      };
+    }
   }
 
   async #ensureNotificationClient(): Promise<Client> {
@@ -181,13 +231,13 @@ export class PgAdapter implements DBAdapter {
       const client = new Client(this.config);
       client.on('notification', (n) => {
         log.debug(`heard pg notification for channel %s`, n.channel);
-        const handlers = this.#subscribers.get(n.channel);
-        if (!handlers) {
+        const state = this.#channels.get(n.channel);
+        if (!state) {
           return;
         }
-        for (const h of [...handlers]) {
+        for (const entry of [...state.handlers]) {
           try {
-            h(n);
+            entry.fn(n);
           } catch (err: unknown) {
             log.warn(
               `notification handler for channel ${n.channel} threw: ${String(err)}`,

--- a/packages/realm-server/lib/realm-file-changes-listener.ts
+++ b/packages/realm-server/lib/realm-file-changes-listener.ts
@@ -1,10 +1,8 @@
 import type { Realm } from '@cardstack/runtime-common';
 import { logger, REALM_FILE_CHANGES_CHANNEL } from '@cardstack/runtime-common';
-import type { PgAdapter } from '@cardstack/postgres';
-import { WorkLoop } from '@cardstack/postgres';
+import type { PgAdapter, NotificationSubscription } from '@cardstack/postgres';
 
 const log = logger('realm-server:file-changes-listener');
-const DEFAULT_POLL_INTERVAL_MS = 60_000;
 
 // Cross-instance cache invalidation. When any realm-server emits
 // `NOTIFY realm_file_changes, '<url>:<path>'` (see Realm.#notifyFileChange in
@@ -14,59 +12,48 @@ const DEFAULT_POLL_INTERVAL_MS = 60_000;
 // #moduleCache entries. If it's not mounted, the notification is dropped —
 // this instance has no stale state to clear.
 //
-// The LISTEN is backed by `PgAdapter.listen` (dedicated Client, not pool-
-// returned) exactly like the registry reconciler. A poll fallback is not
-// strictly needed here — missed NOTIFYs degrade to cache staleness that the
-// next write will re-invalidate — but the WorkLoop gives us a predictable
-// shutdown path and matches the pattern used elsewhere. We set the poll
-// interval to something long (60s) so the fallback loop doesn't burn CPU
-// on busy instances; it exists to surface connection health, not to
-// re-scan anything.
+// The LISTEN is backed by `PgAdapter.subscribe` (shared multiplexed
+// notification client). There is no periodic work to run between
+// notifications — the whole dispatch is in the payload — so we don't keep a
+// WorkLoop here.
 export interface RealmFileChangesListenerDeps {
   dbAdapter: PgAdapter;
   lookupMountedRealm: (url: string) => Realm | undefined;
-  // Optional for tests.
-  pollIntervalMs?: number;
 }
 
 export class RealmFileChangesListener {
   #deps: RealmFileChangesListenerDeps;
-  #loop: WorkLoop;
-  #started = false;
+  #subscription?: NotificationSubscription;
+  #starting?: Promise<void>;
 
   constructor(deps: RealmFileChangesListenerDeps) {
     this.#deps = deps;
-    this.#loop = new WorkLoop(
-      'realm-file-changes',
-      deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
-    );
   }
 
-  start(): void {
-    if (this.#started) {
+  async start(): Promise<void> {
+    if (this.#subscription || this.#starting) {
+      await this.#starting;
       return;
     }
-    this.#started = true;
-    this.#loop.run(async (loop) => {
-      await this.#deps.dbAdapter.listen(
+    this.#starting = (async () => {
+      this.#subscription = await this.#deps.dbAdapter.subscribe(
         REALM_FILE_CHANGES_CHANNEL,
-        (notification: { payload?: string }) => {
-          // Invalidate synchronously on wake rather than forcing a reconcile
-          // pass: there is nothing to poll from the DB side, the whole
-          // payload is in the notification.
+        (notification) => {
           this.#handleNotification(notification.payload);
         },
-        async () => {
-          while (!loop.shuttingDown) {
-            await loop.sleep();
-          }
-        },
       );
-    });
+    })();
+    try {
+      await this.#starting;
+    } finally {
+      this.#starting = undefined;
+    }
   }
 
   async shutDown(): Promise<void> {
-    await this.#loop.shutDown();
+    const sub = this.#subscription;
+    this.#subscription = undefined;
+    await sub?.unsubscribe();
   }
 
   // Exposed for tests; invoked internally by the LISTEN handler.

--- a/packages/realm-server/lib/realm-file-changes-listener.ts
+++ b/packages/realm-server/lib/realm-file-changes-listener.ts
@@ -51,6 +51,17 @@ export class RealmFileChangesListener {
   }
 
   async shutDown(): Promise<void> {
+    // Wait for any in-flight start() to finish wiring up #subscription before
+    // tearing down. Otherwise shutDown can run while subscribe() is still
+    // awaiting the LISTEN, return early with #subscription still undefined,
+    // and the racing start() then installs a live subscription after we
+    // thought we were shut down. Swallow start() errors here — if startup
+    // failed, there's nothing for us to unsubscribe.
+    try {
+      await this.#starting;
+    } catch {
+      // ignore
+    }
     const sub = this.#subscription;
     this.#subscription = undefined;
     await sub?.unsubscribe();

--- a/packages/realm-server/lib/realm-registry-reconciler.ts
+++ b/packages/realm-server/lib/realm-registry-reconciler.ts
@@ -66,6 +66,7 @@ export class RealmRegistryReconciler {
   #loop: WorkLoop;
   #started = false;
   #subscription?: NotificationSubscription;
+  #starting?: Promise<void>;
   knownByUrl = new Map<string, RealmRegistryRow>();
   mounted = new Map<string, Realm>();
   pendingMounts = new Map<string, Promise<Realm>>();
@@ -105,23 +106,41 @@ export class RealmRegistryReconciler {
   // Begin the LISTEN + poll loop. Safe to call once; no-ops on repeat.
   async start(): Promise<void> {
     if (this.#started) {
+      await this.#starting;
       return;
     }
     this.#started = true;
-    this.#subscription = await this.#deps.dbAdapter.subscribe(
-      CHANNEL,
-      this.#loop.wake.bind(this.#loop),
-    );
-    this.#loop.run(async (loop) => {
-      // Run one reconcile immediately on start, then loop on wake-or-poll.
-      while (!loop.shuttingDown) {
-        await this.#safeReconcile();
-        await loop.sleep();
-      }
-    });
+    this.#starting = (async () => {
+      this.#subscription = await this.#deps.dbAdapter.subscribe(
+        CHANNEL,
+        this.#loop.wake.bind(this.#loop),
+      );
+      this.#loop.run(async (loop) => {
+        // Run one reconcile immediately on start, then loop on wake-or-poll.
+        while (!loop.shuttingDown) {
+          await this.#safeReconcile();
+          await loop.sleep();
+        }
+      });
+    })();
+    try {
+      await this.#starting;
+    } finally {
+      this.#starting = undefined;
+    }
   }
 
   async shutDown(): Promise<void> {
+    // Wait for any in-flight start() to finish wiring up #subscription before
+    // tearing down. Otherwise shutDown can race a still-pending subscribe()
+    // and leave a live subscription installed after we thought we were shut
+    // down. Swallow start() errors here — nothing to unsubscribe if startup
+    // failed.
+    try {
+      await this.#starting;
+    } catch {
+      // ignore
+    }
     await this.#loop.shutDown();
     const sub = this.#subscription;
     this.#subscription = undefined;

--- a/packages/realm-server/lib/realm-registry-reconciler.ts
+++ b/packages/realm-server/lib/realm-registry-reconciler.ts
@@ -1,6 +1,6 @@
 import type { Realm } from '@cardstack/runtime-common';
 import { logger, param, query } from '@cardstack/runtime-common';
-import type { PgAdapter } from '@cardstack/postgres';
+import type { PgAdapter, NotificationSubscription } from '@cardstack/postgres';
 import { WorkLoop } from '@cardstack/postgres';
 
 const log = logger('realm-server:registry-reconciler');
@@ -65,6 +65,7 @@ export class RealmRegistryReconciler {
   #deps: ReconcilerDeps;
   #loop: WorkLoop;
   #started = false;
+  #subscription?: NotificationSubscription;
   knownByUrl = new Map<string, RealmRegistryRow>();
   mounted = new Map<string, Realm>();
   pendingMounts = new Map<string, Promise<Realm>>();
@@ -102,28 +103,29 @@ export class RealmRegistryReconciler {
   }
 
   // Begin the LISTEN + poll loop. Safe to call once; no-ops on repeat.
-  start(): void {
+  async start(): Promise<void> {
     if (this.#started) {
       return;
     }
     this.#started = true;
+    this.#subscription = await this.#deps.dbAdapter.subscribe(
+      CHANNEL,
+      this.#loop.wake.bind(this.#loop),
+    );
     this.#loop.run(async (loop) => {
-      await this.#deps.dbAdapter.listen(
-        CHANNEL,
-        loop.wake.bind(loop),
-        async () => {
-          // Run one reconcile immediately on start, then loop on wake-or-poll.
-          while (!loop.shuttingDown) {
-            await this.#safeReconcile();
-            await loop.sleep();
-          }
-        },
-      );
+      // Run one reconcile immediately on start, then loop on wake-or-poll.
+      while (!loop.shuttingDown) {
+        await this.#safeReconcile();
+        await loop.sleep();
+      }
     });
   }
 
   async shutDown(): Promise<void> {
     await this.#loop.shutDown();
+    const sub = this.#subscription;
+    this.#subscription = undefined;
+    await sub?.unsubscribe();
   }
 
   async #safeReconcile(): Promise<void> {

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -544,7 +544,7 @@ const getIndexHTML = async () => {
   // Begin the reconciler's background poll loop (LISTEN realm_registry +
   // 30s safety poll). It picks up changes from peer instances (publish,
   // unpublish, delete) and reconciles them into local mounted state.
-  reconciler.start();
+  await reconciler.start();
 
   // Cross-instance cache invalidation. Realm.write() emits NOTIFY
   // realm_file_changes; this listener receives those and forwards to the
@@ -556,7 +556,7 @@ const getIndexHTML = async () => {
     dbAdapter,
     lookupMountedRealm: (url) => realms.find((r) => r.url === url),
   });
-  fileChangesListener.start();
+  await fileChangesListener.start();
 
   let actualPort =
     (httpServer.address() as import('net').AddressInfo | null)?.port ?? port;

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -194,6 +194,7 @@ import './realm-registry-backfill-test';
 import './realm-registry-reconciler-test';
 import './realm-registry-writes-test';
 import './realm-file-changes-listener-test';
+import './pg-adapter-subscribe-test';
 import './realm-endpoints/directory-test';
 import './realm-endpoints/info-test';
 import './realm-endpoints/invalidate-urls-test';

--- a/packages/realm-server/tests/pg-adapter-subscribe-test.ts
+++ b/packages/realm-server/tests/pg-adapter-subscribe-test.ts
@@ -168,6 +168,54 @@ module(basename(__filename), function () {
       assert.ok(true, 'second unsubscribe did not throw');
     });
 
+    test('concurrent subscribes on the same empty channel both receive notifications', async function (assert) {
+      // Both subscribers race through subscribe() at the same time, joining
+      // the same in-flight LISTEN-establishment promise. Once it resolves,
+      // both add their handlers and both should see every notification.
+      const seenA: string[] = [];
+      const seenB: string[] = [];
+      const [subA, subB] = await Promise.all([
+        dbAdapter.subscribe('mux_test_concurrent', (n) => {
+          if (n.payload) seenA.push(n.payload);
+        }),
+        dbAdapter.subscribe('mux_test_concurrent', (n) => {
+          if (n.payload) seenB.push(n.payload);
+        }),
+      ]);
+      try {
+        await notify(dbAdapter, 'mux_test_concurrent', 'msg');
+        await waitFor(() => (seenA.length > 0 ? true : undefined));
+        await waitFor(() => (seenB.length > 0 ? true : undefined));
+        assert.deepEqual(seenA, ['msg']);
+        assert.deepEqual(seenB, ['msg']);
+      } finally {
+        await subA.unsubscribe();
+        await subB.unsubscribe();
+      }
+    });
+
+    test('subscribing the same handler reference twice yields independent subscriptions', async function (assert) {
+      // Each subscribe() returns its own unsubscribe() that is supposed to
+      // remove only that subscription. If we used a Set keyed on handler
+      // identity, the same fn registered twice would collapse — and either
+      // returned unsubscribe would remove both. The fix is identity-per-call.
+      const seen: string[] = [];
+      const handler = (n: { payload?: string }) => {
+        if (n.payload) seen.push(n.payload);
+      };
+      const subA = await dbAdapter.subscribe('mux_test_dup_fn', handler);
+      const subB = await dbAdapter.subscribe('mux_test_dup_fn', handler);
+      try {
+        await subA.unsubscribe();
+        await notify(dbAdapter, 'mux_test_dup_fn', 'after-A-unsub');
+        await waitFor(() => (seen.length > 0 ? true : undefined));
+        // B's subscription is still live; the same fn fires once for B.
+        assert.deepEqual(seen, ['after-A-unsub']);
+      } finally {
+        await subB.unsubscribe();
+      }
+    });
+
     test('a handler that throws does not break sibling handlers on the same channel', async function (assert) {
       const seen: string[] = [];
       const subThrow = await dbAdapter.subscribe('mux_test_throwing', () => {

--- a/packages/realm-server/tests/pg-adapter-subscribe-test.ts
+++ b/packages/realm-server/tests/pg-adapter-subscribe-test.ts
@@ -1,0 +1,189 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import type { PgAdapter } from '@cardstack/postgres';
+import { query, param } from '@cardstack/runtime-common';
+import { setupDB } from './helpers';
+
+// Tests for the multiplexed LISTEN API on PgAdapter. Every assertion exercises
+// the shared notification client — there is no way to "stub" subscribe(); the
+// API is end-to-end with real LISTEN/NOTIFY round-trips.
+//
+// These tests assume `setupDB` provisions a PgAdapter pointed at the local
+// test postgres (matching the rest of the realm-server test suite).
+
+function waitFor<T>(
+  getValue: () => T | undefined,
+  timeoutMs = 3000,
+  pollMs = 20,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    const tick = () => {
+      const value = getValue();
+      if (value !== undefined) {
+        resolve(value);
+        return;
+      }
+      if (Date.now() - started > timeoutMs) {
+        reject(new Error(`timeout after ${timeoutMs}ms`));
+        return;
+      }
+      setTimeout(tick, pollMs);
+    };
+    tick();
+  });
+}
+
+async function notify(
+  dbAdapter: PgAdapter,
+  channel: string,
+  payload: string,
+): Promise<void> {
+  await query(dbAdapter, [
+    `SELECT pg_notify(`,
+    param(channel),
+    `,`,
+    param(payload),
+    `)`,
+  ]);
+}
+
+module(basename(__filename), function () {
+  module('PgAdapter.subscribe', function (hooks) {
+    let dbAdapter: PgAdapter;
+
+    setupDB(hooks, {
+      beforeEach: async (adapter) => {
+        dbAdapter = adapter;
+      },
+    });
+
+    test('a single subscriber receives notifications on its channel', async function (assert) {
+      const seen: string[] = [];
+      const sub = await dbAdapter.subscribe('mux_test_one', (n) => {
+        if (n.payload) seen.push(n.payload);
+      });
+      try {
+        await notify(dbAdapter, 'mux_test_one', 'hello');
+        const got = await waitFor(() =>
+          seen.length > 0 ? [...seen] : undefined,
+        );
+        assert.deepEqual(got, ['hello']);
+      } finally {
+        await sub.unsubscribe();
+      }
+    });
+
+    test('two subscribers on the same channel both receive every notification', async function (assert) {
+      const seenA: string[] = [];
+      const seenB: string[] = [];
+      const subA = await dbAdapter.subscribe('mux_test_same', (n) => {
+        if (n.payload) seenA.push(n.payload);
+      });
+      const subB = await dbAdapter.subscribe('mux_test_same', (n) => {
+        if (n.payload) seenB.push(n.payload);
+      });
+      try {
+        await notify(dbAdapter, 'mux_test_same', 'msg-1');
+        await waitFor(() => (seenA.length > 0 ? true : undefined));
+        await waitFor(() => (seenB.length > 0 ? true : undefined));
+        assert.deepEqual(seenA, ['msg-1']);
+        assert.deepEqual(seenB, ['msg-1']);
+      } finally {
+        await subA.unsubscribe();
+        await subB.unsubscribe();
+      }
+    });
+
+    test('subscribers on different channels do not see each other’s notifications', async function (assert) {
+      const seenA: string[] = [];
+      const seenB: string[] = [];
+      const subA = await dbAdapter.subscribe('mux_test_chan_a', (n) => {
+        if (n.payload) seenA.push(n.payload);
+      });
+      const subB = await dbAdapter.subscribe('mux_test_chan_b', (n) => {
+        if (n.payload) seenB.push(n.payload);
+      });
+      try {
+        await notify(dbAdapter, 'mux_test_chan_a', 'a-msg');
+        await notify(dbAdapter, 'mux_test_chan_b', 'b-msg');
+        await waitFor(() => (seenA.length > 0 ? true : undefined));
+        await waitFor(() => (seenB.length > 0 ? true : undefined));
+        assert.deepEqual(seenA, ['a-msg']);
+        assert.deepEqual(seenB, ['b-msg']);
+      } finally {
+        await subA.unsubscribe();
+        await subB.unsubscribe();
+      }
+    });
+
+    test('unsubscribing one of two same-channel subscribers leaves the other receiving', async function (assert) {
+      const seenA: string[] = [];
+      const seenB: string[] = [];
+      const subA = await dbAdapter.subscribe('mux_test_partial', (n) => {
+        if (n.payload) seenA.push(n.payload);
+      });
+      const subB = await dbAdapter.subscribe('mux_test_partial', (n) => {
+        if (n.payload) seenB.push(n.payload);
+      });
+      try {
+        await subA.unsubscribe();
+        await notify(dbAdapter, 'mux_test_partial', 'after-unsub');
+        await waitFor(() => (seenB.length > 0 ? true : undefined));
+        assert.deepEqual(seenA, [], 'unsubscribed handler did not fire');
+        assert.deepEqual(seenB, ['after-unsub']);
+      } finally {
+        await subB.unsubscribe();
+      }
+    });
+
+    test('after the last subscriber unsubscribes a channel, re-subscribing still receives', async function (assert) {
+      const seenFirst: string[] = [];
+      const subA = await dbAdapter.subscribe('mux_test_resubscribe', (n) => {
+        if (n.payload) seenFirst.push(n.payload);
+      });
+      await subA.unsubscribe();
+
+      const seenSecond: string[] = [];
+      const subB = await dbAdapter.subscribe('mux_test_resubscribe', (n) => {
+        if (n.payload) seenSecond.push(n.payload);
+      });
+      try {
+        await notify(dbAdapter, 'mux_test_resubscribe', 'resub');
+        await waitFor(() => (seenSecond.length > 0 ? true : undefined));
+        assert.deepEqual(seenFirst, []);
+        assert.deepEqual(seenSecond, ['resub']);
+      } finally {
+        await subB.unsubscribe();
+      }
+    });
+
+    test('repeated unsubscribe is a no-op', async function (assert) {
+      const seen: string[] = [];
+      const sub = await dbAdapter.subscribe('mux_test_idem', (n) => {
+        if (n.payload) seen.push(n.payload);
+      });
+      await sub.unsubscribe();
+      await sub.unsubscribe();
+      assert.ok(true, 'second unsubscribe did not throw');
+    });
+
+    test('a handler that throws does not break sibling handlers on the same channel', async function (assert) {
+      const seen: string[] = [];
+      const subThrow = await dbAdapter.subscribe('mux_test_throwing', () => {
+        throw new Error('boom');
+      });
+      const subOk = await dbAdapter.subscribe('mux_test_throwing', (n) => {
+        if (n.payload) seen.push(n.payload);
+      });
+      try {
+        await notify(dbAdapter, 'mux_test_throwing', 'ok');
+        await waitFor(() => (seen.length > 0 ? true : undefined));
+        assert.deepEqual(seen, ['ok']);
+      } finally {
+        await subThrow.unsubscribe();
+        await subOk.unsubscribe();
+      }
+    });
+  });
+});

--- a/packages/realm-server/tests/realm-file-changes-listener-test.ts
+++ b/packages/realm-server/tests/realm-file-changes-listener-test.ts
@@ -162,11 +162,8 @@ module(basename(__filename), function () {
         dbAdapter,
         lookupMountedRealm: (url) => (url === realmUrl ? realmA : undefined),
       });
-      listener.start();
+      await listener.start();
       try {
-        // Give the LISTEN connection a moment to subscribe.
-        await new Promise((r) => setTimeout(r, 100));
-
         await query(dbAdapter, [
           `SELECT pg_notify(`,
           param('realm_file_changes'),
@@ -195,10 +192,8 @@ module(basename(__filename), function () {
           return undefined;
         },
       });
-      listener.start();
+      await listener.start();
       try {
-        await new Promise((r) => setTimeout(r, 100));
-
         await query(dbAdapter, [
           `SELECT pg_notify(`,
           param('realm_file_changes'),


### PR DESCRIPTION
## Why

Each call to `PgAdapter.listen()` opens its own dedicated `Client` because LISTEN/NOTIFY is unreliable on Pool connections (see [node-postgres#1543](https://github.com/brianc/node-postgres/issues/1543)). With four LISTEN-using callers planned —

1. `RealmFileChangesListener`
2. `RealmRegistryReconciler`
3. `pg-queue` jobs runner
4. CS-10952's module-cache invalidation listener (#4644)

— an N-instance fleet pays `N × 4` listener connections against Postgres `max_connections` for what is observably one notification stream per process. Copilot flagged this on #4644; this PR is the underlying refactor so that PR (and CS-10953's sibling listener) drop in as additional channel handlers on the shared client rather than as additional dedicated connections.

## What

Add `PgAdapter.subscribe(channel, handler) → { unsubscribe() }`:

- Lazily opens a single shared `Client` on the first subscribe.
- Multiplexes any number of channels and per-channel handlers onto it; dispatches incoming notifications by `notification.channel`.
- Sends `LISTEN <channel>` only on the first subscriber, `UNLISTEN <channel>` only when the last unsubscribes.
- Concurrent subscribes await the same in-flight client-start promise (no duplicate Clients).
- A handler that throws is caught so siblings on the same channel still fire.
- Closed in `PgAdapter.close()`.

Migrations in this PR:

- **`RealmFileChangesListener`** drops its `WorkLoop` entirely — it had no periodic work, only used the loop to keep the dedicated LISTEN connection alive. `start()` is now `async` and awaits the subscription; `shutDown()` calls `unsubscribe()`.
- **`RealmRegistryReconciler`** keeps its `WorkLoop` for the periodic `reconcile()` pass; it uses `subscribe()` only for the LISTEN half. `start()` is now `async`. `shutDown()` shuts the loop down then unsubscribes.
- `main.ts` awaits both newly-async `start()` calls.

## What this does NOT do

- **`pg-queue`'s `listen('jobs')`** is not migrated. Its loop body does periodic job processing and is internal to `@cardstack/postgres`; migrating it touches more surface than I wanted in one refactor PR. The legacy `listen()` API is kept (with a deprecation comment) so it keeps working unchanged.
- **Reconnect on disconnect** is explicitly out of scope: the legacy `listen()` API has the same hazard today, and current production has not seen it. The shared client's `error` event is logged loudly so a future occurrence is visible. Reconnect is a separate concern (and a wider change than this).

## Test plan

- [x] Realm Server suite green — exercises both migrated listeners end-to-end (`realm-file-changes-listener-test`, `realm-registry-reconciler-test`).
- [x] New `pg-adapter-subscribe-test`: covers single subscriber, two subscribers same channel, two channels, partial unsubscribe, re-subscribe after the channel was emptied, idempotent unsubscribe, throwing handler doesn't break siblings.
- [x] Host suite green (no host code paths touch this; sanity check).

## Stacks with

- #4644 (CS-10952 cross-process invalidation broadcast) — rebases onto this and uses `subscribe()` instead of standing up its own dedicated `Client`.
- CS-10953 sibling listener will likewise consume `subscribe()` rather than `listen()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)