### PR TITLE
Skip full lint for observability-only changes

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -4,6 +4,15 @@ on:
   push:
     branches: [main]
   pull_request:
+    # Observability has its own lint workflow (observability-diff.yml's
+    # `lint` job) that runs the full lint script — including the prettier
+    # YAML check. Skipping ci-lint on observability-only PRs avoids ~5 min
+    # of unrelated lint work; coverage on observability changes lives in
+    # the dedicated workflow. Deny-list rather than allow-list so adding
+    # a new package automatically gets linted (the inverse failure mode —
+    # silently skipping lint for a new package — is worse).
+    paths-ignore:
+      - "packages/observability/**"
 
 permissions:
   checks: write
@@ -112,11 +121,3 @@ jobs:
         if: ${{ !cancelled() }}
         run: pnpm run lint
         working-directory: packages/boxel-cli
-      - name: Lint Observability
-        # No JS/TS in this package — the lint script wraps shellcheck, jq,
-        # prettier, and a secret-shape regression check on dashboard JSON.
-        # shellcheck and jq are preinstalled on ubuntu-latest; pnpm/prettier
-        # come from the init action above.
-        if: ${{ !cancelled() }}
-        run: pnpm run lint
-        working-directory: packages/observability

--- a/.github/workflows/observability-diff.yml
+++ b/.github/workflows/observability-diff.yml
@@ -28,6 +28,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    # No fork guard: this job needs no AWS credentials or write tokens,
+    # so it's safe on PRs from forks. It exists because ci-lint.yaml's
+    # `paths-ignore` skips the main lint workflow on observability-only
+    # PRs, so this is the dedicated lint coverage for the package
+    # (shellcheck + jq + prettier + manifest/secret regression checks).
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # `init` installs pnpm — required by lint.sh's prettier --check step.
+      - uses: ./.github/actions/init
+      - name: Lint
+        run: pnpm run lint
+        working-directory: packages/observability
+
   diff:
     name: Diff against staging
     runs-on: ubuntu-latest
@@ -86,13 +103,14 @@ jobs:
             --output text)"
           echo "REALM_SERVER_URL=$REALM_SERVER_URL" >> "$GITHUB_ENV"
 
-      - name: Lint
-        # Catch manifest issues at PR time, before the diff step does an
-        # API pull. Same script as ci-lint.yaml runs, but here we have
-        # GRAFANA_TOKEN sourced from SSM, so GRAFANACTL_VALIDATE_ENV adds
-        # the "validate against live staging Grafana" check on top.
-        # PRETTIER_SKIP avoids duplicating ci-lint's YAML format check
-        # (which requires pnpm install — overkill for this focused workflow).
+      - name: Lint (with live-staging validate)
+        # Re-runs lint.sh here because GRAFANA_TOKEN is now available from
+        # SSM, so GRAFANACTL_VALIDATE_ENV=staging adds the "validate
+        # manifests against live staging Grafana" check that the lint job
+        # above can't do (it has no AWS access). Catches manifest issues
+        # before the diff step does an API pull.
+        # PRETTIER_SKIP avoids re-doing the prettier YAML check the lint
+        # job already ran (this job has no pnpm install — staying fast).
         working-directory: packages/observability
         env:
           GRAFANACTL_VALIDATE_ENV: staging


### PR DESCRIPTION
## Summary

Adds `paths-ignore: ['packages/observability/**']` to `ci-lint.yaml`'s `pull_request:` trigger so observability-only PRs skip the ~5-minute lint job of the other 19 packages. The now-redundant `Lint Observability` step is removed from `ci-lint.yaml`.

Coverage moves to a new dedicated `lint` job in `observability-diff.yml` that runs on every observability PR (including from forks — no AWS credentials needed) and executes the full lint script: shellcheck, jq, **prettier YAML check** (no longer skipped), and the manifest/secret regression checks.

## Why this approach

A previous iteration of this PR introduced per-package gating via `dorny/paths-filter` in `ci-lint.yaml`. Review surfaced two correctness regressions vs. the existing pattern (workspace-dep changes wouldn't trigger dependent packages' lint; e.g. a breaking type change in `runtime-common` would not retrigger Host's `ember-tsc --noEmit`) and unnecessary unconditional Boxel UI / Boxel Icons builds. The simpler `paths-ignore` deny-list avoids both: every package other than observability still runs the full existing lint flow on every PR, exactly as it does on `main` today.

The original objection to `paths-ignore` was that `observability-diff.yml`'s lint step set `PRETTIER_SKIP=1`, so the prettier YAML check would never run on observability-only PRs. This PR fixes that root cause by adding a separate `lint` job (no `PRETTIER_SKIP`) inside `observability-diff.yml`.

Deny-list rather than allow-list because the failure modes are asymmetric: forgetting to add a new package to an allow-list silently skips lint for that package; running lint unnecessarily on a deny-list miss is harmless. Observability is the only package with a self-contained dedicated workflow, so it's the only entry on the deny-list.

## What lint coverage looks like after this PR

| PR touches | `ci-lint.yaml` runs? | `observability-diff.yml::lint` runs? | `observability-diff.yml::diff` runs? |
| --- | --- | --- | --- |
| only `packages/observability/**` | skipped | yes (incl. prettier) | yes (live-staging validate; non-fork only) |
| only other packages | yes (existing 19 lints) | not triggered | not triggered |
| both | yes | yes | yes (non-fork only) |
| fork PR, observability only | skipped | yes (incl. prettier) | skipped (fork guard) |
| push to `main` | yes | not triggered | not triggered |

The `diff` job's existing lint step is renamed to "Lint (with live-staging validate)" and retains `GRAFANACTL_VALIDATE_ENV=staging` plus `PRETTIER_SKIP=1` (since the new sibling `lint` job already covers prettier).

## Risk check

- Branch protection on `main` has no `required_status_checks` set in either classic protection or rulesets, so a skipped lint job on observability-only PRs won't block merges.
- New non-observability packages: adding a `pnpm run lint` script still requires adding a `Lint <Package>` step in `ci-lint.yaml` — same as before this PR. No new fragility.
- Fork PRs touching observability: covered by the new `lint` job (no AWS access required), so coverage matches non-fork PRs minus the live-staging validate.

## Test plan

- [ ] PR touching only `packages/observability/**` → `ci-lint.yaml` is skipped; `observability-diff.yml`'s `lint` and `diff` jobs both run; prettier check passes/fails on YAML formatting issues.
- [ ] PR touching only `packages/host/**` → `ci-lint.yaml` runs every existing `Lint <Package>` step; `observability-diff.yml` is not triggered.
- [ ] PR touching both observability and host → `ci-lint.yaml` runs (full sweep), `observability-diff.yml::lint` and `::diff` both run.
- [ ] Fork PR touching only observability → `ci-lint.yaml` skipped, `observability-diff.yml::lint` runs, `::diff` skipped via fork guard.
- [ ] Introduce a YAML formatting violation in `packages/observability/**` → caught by `observability-diff.yml::lint` (the prettier check that previously didn't run on observability-only PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)