### PR TITLE
CS-11040: push provisioning/alerting/* rule groups to hosted Grafana

### DIFF
--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -14,14 +14,17 @@ Part of the AMG → self-host Grafana migration:
 
 There are **two source-of-truth trees** in this package, because Grafana 12 manages different resource kinds through different APIs:
 
-| Tree                   | Tool                  | Resource kinds                               | Apply mechanism                                  |
-| ---------------------- | --------------------- | -------------------------------------------- | ------------------------------------------------ |
-| `grafanactl/resources/` | `grafanactl resources push` | Dashboards, folders                       | API push (CI on merge)                            |
-| `provisioning/`        | Grafana built-in file provisioning | Data sources, alert rules, contact points | Files mounted at `/etc/grafana/provisioning/`, read at startup |
+| Tree                    | Tool                                                                   | Resource kinds                            | Apply mechanism                                                                                                                                                              |
+| ----------------------- | ---------------------------------------------------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `grafanactl/resources/` | `grafanactl resources push`                                            | Dashboards, folders                       | API push (CI on merge)                                                                                                                                                       |
+| `provisioning/`         | Grafana built-in file provisioning (local) + HTTP API bridges (hosted) | Data sources, alert rules, contact points | Local: files mounted at `/etc/grafana/provisioning/`, read at startup. Hosted: `apply-datasources.sh` + `apply-alerting.sh` push the same files through the legacy HTTP API. |
 
 **Why two trees?** `grafanactl` (Grafana Labs' official CLI replacing the archived Grizzly) only manages App Platform resources — `grafanactl resources list` shows dashboards, folders, playlists, snapshots, but **not data sources or alert rules**. Those still live behind the legacy HTTP API.
 
-Locally, `provisioning/` files are mounted into the Grafana container by `docker-compose.yml` and read at startup with `${ENV_VAR}` substitution. **For staging and production, `apply-datasources.sh` reads the same YAML files, env-var-substitutes them (e.g. `${LOKI_URL}` from SSM `/<env>/loki/internal_url`), and upserts each entry through Grafana's `/api/datasources` HTTP API** — a small bridge that gives us file-as-source-of-truth without needing image bakes or EFS mounts on the hosted side.
+Locally, `provisioning/` files are mounted into the Grafana container by `docker-compose.yml` and read at startup with `${ENV_VAR}` substitution. For staging and production, two small bridges read those same files and push them through legacy HTTP APIs — file-as-source-of-truth without needing image bakes or EFS mounts on the hosted side:
+
+- **`apply-datasources.sh`** reads each `provisioning/datasources/*.yaml`, env-var-substitutes (e.g. `${LOKI_URL}` from SSM `/<env>/loki/internal_url`), and upserts via `/api/datasources`.
+- **`apply-alerting.sh`** reads each `provisioning/alerting/*.json`, env-var-substitutes, and upserts each rule group via `/api/v1/provisioning/folder/{folderUID}/rule-groups/{group}` with `X-Disable-Provenance: true` (so each rule stays UI-editable between pushes; file remains canonical).
 
 ## Layout
 
@@ -45,6 +48,8 @@ scripts/
   apply.sh             # ./scripts/apply.sh --env <local|staging|production>
   apply-datasources.sh # internal — pushes provisioning/datasources/* via HTTP API
                        # (called by apply.sh; staging/production only)
+  apply-alerting.sh    # internal — pushes provisioning/alerting/* via the
+                       # provisioning HTTP API (called by apply.sh; staging/production only)
   pull.sh              # ./scripts/pull.sh  --env <name> --path <dir>
   check.sh             # ./scripts/check.sh --env <name>  (connectivity smoke test)
   tail-logs.sh         # ./scripts/tail-logs.sh --env <name> --service <task family>
@@ -103,12 +108,12 @@ you change it, change it everywhere — `alloy/config.alloy` (local) and
 `cardstack/infra:modules/aws/ecs/firelens/templates/extra.conf.tftpl`
 (staging + production).
 
-| Label       | Local source                                          | Staging / production source                                        | When set                          |
-| ----------- | ----------------------------------------------------- | ------------------------------------------------------------------ | --------------------------------- |
-| `env`       | constant `local` (Alloy relabel rule)                 | constant `staging` / `production` (Fluent Bit static `Labels`)     | always                            |
-| `service`   | Docker container name, leading `/` stripped           | ECS task family — `realm-server`, `worker`, `prerender`, `prerender-manager`, `synapse` | always |
-| `realm`     | opt-in via Docker label `boxel.realm=<name>`          | task env when the task pins a single realm (omitted on multi-realm workloads) | when meaningful |
-| `worker_id` | not set locally                                       | per-process worker id (`<runtime-id>-pid-<pid>`), parsed from `[worker <id> priority N]:` log line prefixes by a Fluent Bit Lua filter. Matches `job_reservations.worker_id`. | worker tasks only, lines with the prefix |
+| Label       | Local source                                 | Staging / production source                                                                                                                                                   | When set                                 |
+| ----------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `env`       | constant `local` (Alloy relabel rule)        | constant `staging` / `production` (Fluent Bit static `Labels`)                                                                                                                | always                                   |
+| `service`   | Docker container name, leading `/` stripped  | ECS task family — `realm-server`, `worker`, `prerender`, `prerender-manager`, `synapse`                                                                                       | always                                   |
+| `realm`     | opt-in via Docker label `boxel.realm=<name>` | task env when the task pins a single realm (omitted on multi-realm workloads)                                                                                                 | when meaningful                          |
+| `worker_id` | not set locally                              | per-process worker id (`<runtime-id>-pid-<pid>`), parsed from `[worker <id> priority N]:` log line prefixes by a Fluent Bit Lua filter. Matches `job_reservations.worker_id`. | worker tasks only, lines with the prefix |
 
 The local Alloy scraper drops the observability stack's own Compose
 services (`grafana`, `loki`, `alloy`) so `{env="local"}` queries don't
@@ -176,7 +181,7 @@ URL/token plumbing differs. Replace `<env>` with `local`, `staging`, or
 A LogQL selector by itself doesn't carry a time window — that comes
 from the client (Grafana Explore's range picker, `tail-logs.sh
 --since`, or `start`/`end` on the `query_range` HTTP API). The `[1d]`,
-`[5m]` etc. inside `count_over_time(... [N])` are the *aggregation*
+`[5m]` etc. inside `count_over_time(... [N])` are the _aggregation_
 window, not the query window.
 
 ```logql
@@ -231,19 +236,19 @@ URL from SSM.
 ./scripts/tail-logs.sh --env production --service synapse --since 30m --no-follow --confirm
 ```
 
-| Flag | Default | Notes |
-|------|---------|-------|
-| `--env` | (required) | `local`, `staging`, `production` |
-| `--service` | (required) | `realm-server`, `worker`, `prerender`, `prerender-manager`, `synapse` (or any local container name) |
-| `--realm` | unset | Restrict to a single realm. |
-| `--worker-id` | unset | Per-Fargate-task id; workers only. |
-| `--filter` | unset | LogQL line-filter (`\|=`); literal substring. |
-| `--regex` | unset | LogQL line-regex (`\|~`). Mutually exclusive with `--filter`. |
-| `--since` | `15m` | `30s`, `15m`, `1h`, `2d` — pattern `^\d+[smhd]$`. |
-| `--limit` | `200` | Max lines per batch. |
-| `--follow` / `--no-follow` | follow | Default polls every 5 s until ctrl-C. |
-| `--json` | text | Raw Loki response per batch (pipe to jq). |
-| `--confirm` | n/a | Required for `--env production`. |
+| Flag                       | Default    | Notes                                                                                               |
+| -------------------------- | ---------- | --------------------------------------------------------------------------------------------------- |
+| `--env`                    | (required) | `local`, `staging`, `production`                                                                    |
+| `--service`                | (required) | `realm-server`, `worker`, `prerender`, `prerender-manager`, `synapse` (or any local container name) |
+| `--realm`                  | unset      | Restrict to a single realm.                                                                         |
+| `--worker-id`              | unset      | Per-Fargate-task id; workers only.                                                                  |
+| `--filter`                 | unset      | LogQL line-filter (`\|=`); literal substring.                                                       |
+| `--regex`                  | unset      | LogQL line-regex (`\|~`). Mutually exclusive with `--filter`.                                       |
+| `--since`                  | `15m`      | `30s`, `15m`, `1h`, `2d` — pattern `^\d+[smhd]$`.                                                   |
+| `--limit`                  | `200`      | Max lines per batch.                                                                                |
+| `--follow` / `--no-follow` | follow     | Default polls every 5 s until ctrl-C.                                                               |
+| `--json`                   | text       | Raw Loki response per batch (pipe to jq).                                                           |
+| `--confirm`                | n/a        | Required for `--env production`.                                                                    |
 
 The same script powers the `tail-logs` Claude agent skill at
 `.claude/skills/tail-logs/SKILL.md` — agents call the script with
@@ -257,28 +262,28 @@ that ships to Loki **also** ships the same lines to CloudWatch — see
 the FireLens config emits two `[OUTPUT]` blocks per task. Pick which
 backend to query based on what you're doing:
 
-| Use case                                                          | Query target | Why                                                                                                                       |
-| ----------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| Reproducing a dashboard panel locally                             | Loki         | Dashboards under `grafanactl/resources/dashboards/` use LogQL — same syntax, same labels, same answer.                    |
-| Tailing live activity from a laptop                               | Loki         | `tail-logs.sh` (CS-10920) / `logcli` keep the same labels and a uniform shell.                                            |
-| Cross-service queries (e.g. "all errors in staging in the last hour") | Loki     | One label plane (`env=staging`) covers everything. CloudWatch needs a Logs Insights query per log group.                  |
-| Long-window forensics (>30 days)                                  | CloudWatch   | CloudWatch retention is set per-log-group on the existing infra; Loki's S3 lifecycle expires chunks at 180 days.          |
-| AMG-era saved query / runbook you remember                        | CloudWatch   | The CloudWatch shape didn't change — paste the old Logs Insights query and it still works through Phase 7.                |
-| AWS-side troubleshooting (ECS Agent, FireLens itself)             | CloudWatch   | Loki only sees the application's stdout. ECS-internal events are CloudWatch only.                                         |
+| Use case                                                              | Query target | Why                                                                                                              |
+| --------------------------------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- |
+| Reproducing a dashboard panel locally                                 | Loki         | Dashboards under `grafanactl/resources/dashboards/` use LogQL — same syntax, same labels, same answer.           |
+| Tailing live activity from a laptop                                   | Loki         | `tail-logs.sh` (CS-10920) / `logcli` keep the same labels and a uniform shell.                                   |
+| Cross-service queries (e.g. "all errors in staging in the last hour") | Loki         | One label plane (`env=staging`) covers everything. CloudWatch needs a Logs Insights query per log group.         |
+| Long-window forensics (>30 days)                                      | CloudWatch   | CloudWatch retention is set per-log-group on the existing infra; Loki's S3 lifecycle expires chunks at 180 days. |
+| AMG-era saved query / runbook you remember                            | CloudWatch   | The CloudWatch shape didn't change — paste the old Logs Insights query and it still works through Phase 7.       |
+| AWS-side troubleshooting (ECS Agent, FireLens itself)                 | CloudWatch   | Loki only sees the application's stdout. ECS-internal events are CloudWatch only.                                |
 
 The dual-ship goes away (CloudWatch-only drop) in a follow-up ticket
 once Loki has been load-bearing for a full release cycle.
 
 ## Hosted vs local Loki
 
-| Trait                  | Local                                | Staging / production                                            |
-| ---------------------- | ------------------------------------ | --------------------------------------------------------------- |
-| Storage                | filesystem, named volume `loki_data` | S3 bucket `boxel-loki-chunks-<env>`                             |
-| Persistence            | survives `docker compose restart`; lost on `down -v` | indefinite, governed by S3 lifecycle                            |
-| Retention              | none enforced (devs prune manually)  | transition to IA at 30 d, expire at 180 d (S3 lifecycle)        |
-| `reject_old_samples`   | `false` (so backfills work)          | `true` (default, ~7d window)                                    |
-| Auth                   | none                                 | bearer token at the Grafana ALB (`/loki*` path rule); SG-only on internal NLB |
-| Reachable from         | localhost only                       | Grafana ECS tasks + FireLens log_router sidecars; laptops via the public path |
+| Trait                | Local                                                | Staging / production                                                          |
+| -------------------- | ---------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Storage              | filesystem, named volume `loki_data`                 | S3 bucket `boxel-loki-chunks-<env>`                                           |
+| Persistence          | survives `docker compose restart`; lost on `down -v` | indefinite, governed by S3 lifecycle                                          |
+| Retention            | none enforced (devs prune manually)                  | transition to IA at 30 d, expire at 180 d (S3 lifecycle)                      |
+| `reject_old_samples` | `false` (so backfills work)                          | `true` (default, ~7d window)                                                  |
+| Auth                 | none                                                 | bearer token at the Grafana ALB (`/loki*` path rule); SG-only on internal NLB |
+| Reachable from       | localhost only                                       | Grafana ECS tasks + FireLens log_router sidecars; laptops via the public path |
 
 ## Staging / production workflow
 
@@ -302,22 +307,22 @@ CI will run `apply.sh --env staging` on merge to main once Phase 4 (CS-10932) la
 
 ## Phase status
 
-| Ticket    | Phase | Status      | Description                              |
-| --------- | ----- | ----------- | ---------------------------------------- |
-| CS-10914  | 2     | landed      | Package skeleton                         |
-| CS-10912  | 2     | landed      | Local `docker-compose.yml` for Grafana   |
-| CS-10913  | 2     | landed      | grafanactl `local`/`staging`/`prod` ctxs |
-| CS-10918  | 2.5   | landed      | Loki container + data source (local)     |
-| CS-10916  | 2.5   | landed      | Alloy log scraper for local              |
-| CS-10919  | 2.5   | landed      | Loki on ECS (staging + production)       |
-| CS-10917  | 2.5   | landed      | FireLens dual-ship (5 task families × 2 envs) |
-| CS-10920  | 2.5   | this PR     | `tail-logs.sh` + Claude agent skill      |
-| CS-10921  | 2.5   | landed      | Loki + tail-logs README                  |
-| CS-10968  | 2.5   | this PR     | Hosted Grafana → Loki data source wiring |
-| CS-10922  | 3     | landed      | AMG export and reformat                  |
-| CS-10932  | 4     | landed      | CI: apply to staging on merge            |
-| CS-10933  | 4     | not started | CI: post diff comment on PRs             |
-| CS-10936  | 5     | landed      | CI: apply to production                  |
+| Ticket   | Phase | Status      | Description                                   |
+| -------- | ----- | ----------- | --------------------------------------------- |
+| CS-10914 | 2     | landed      | Package skeleton                              |
+| CS-10912 | 2     | landed      | Local `docker-compose.yml` for Grafana        |
+| CS-10913 | 2     | landed      | grafanactl `local`/`staging`/`prod` ctxs      |
+| CS-10918 | 2.5   | landed      | Loki container + data source (local)          |
+| CS-10916 | 2.5   | landed      | Alloy log scraper for local                   |
+| CS-10919 | 2.5   | landed      | Loki on ECS (staging + production)            |
+| CS-10917 | 2.5   | landed      | FireLens dual-ship (5 task families × 2 envs) |
+| CS-10920 | 2.5   | this PR     | `tail-logs.sh` + Claude agent skill           |
+| CS-10921 | 2.5   | landed      | Loki + tail-logs README                       |
+| CS-10968 | 2.5   | this PR     | Hosted Grafana → Loki data source wiring      |
+| CS-10922 | 3     | landed      | AMG export and reformat                       |
+| CS-10932 | 4     | landed      | CI: apply to staging on merge                 |
+| CS-10933 | 4     | not started | CI: post diff comment on PRs                  |
+| CS-10936 | 5     | landed      | CI: apply to production                       |
 
 ## Vendored content
 

--- a/packages/observability/scripts/apply-alerting.sh
+++ b/packages/observability/scripts/apply-alerting.sh
@@ -102,11 +102,22 @@ interval_seconds() {
 }
 
 # Validate that every ${VAR} the JSON references is set to a non-empty
-# value before we call envsubst. envsubst substitutes unset / empty vars
-# with empty strings, so a typo in a placeholder name OR an empty SSM
-# value would silently push e.g. an empty datasource uid into a rule.
-# Same pattern as apply-datasources.sh.
-assert_placeholders_resolved() {
+# value, then envsubst ONLY those refs. Two reasons we pass an explicit
+# allowlist to envsubst rather than letting it substitute everything:
+#
+#   1. envsubst with no args also expands bare `$VAR` (no braces). Alert
+#      rule queries can contain Grafana template tokens like $__interval,
+#      $__rate_interval, $__range — without an allowlist, envsubst would
+#      silently empty-substitute those (since `__interval` etc. aren't set
+#      in env), corrupting the rule. The allowlist makes Grafana template
+#      syntax pass through literally.
+#   2. envsubst substitutes unset / empty vars with empty strings, so a
+#      typo in a placeholder name OR an empty SSM value would silently
+#      push e.g. an empty datasource uid into a rule. The validate step
+#      catches that before envsubst runs.
+#
+# Same shape as apply-datasources.sh and render-config.sh.
+resolve_placeholders() {
   local raw="$1" file="$2"
   local refs ref name
   refs="$(grep -oE '\$\{[A-Z_][A-Z0-9_]*\}' <<<"$raw" | sort -u || true)"
@@ -115,6 +126,11 @@ assert_placeholders_resolved() {
     name="${ref#\$\{}"; name="${name%\}}"
     [[ -n "${!name:-}" ]] || fail "${file}: \${${name}} referenced but not set (or empty) in environment"
   done <<<"$refs"
+  if [[ -n "$refs" ]]; then
+    envsubst "$(tr '\n' ' ' <<<"$refs")" <<<"$raw"
+  else
+    printf '%s\n' "$raw"
+  fi
 }
 
 upsert_group() {
@@ -124,7 +140,7 @@ upsert_group() {
   # error message (e.g., "rule X is invalid: ..."). curl --fail-with-body
   # would also do this, but using -w lets us include the status code in
   # the failure line uniformly.
-  response="$(mktemp)"
+  response="$(mktemp -t alerting-response.XXXXXX)"
   http_status="$(curl -sS -o "$response" -w '%{http_code}' -X PUT \
     -H "Authorization: Bearer ${GRAFANA_TOKEN}" \
     -H "Content-Type: application/json" \
@@ -158,8 +174,7 @@ for f in "${files[@]}"; do
   # JSON one per line, envsubst them so ${VAR} placeholders resolve, then
   # transform into the AlertRuleGroup body the provisioning API expects.
   jq -c '.groups[]' "$f" | while IFS= read -r raw; do
-    assert_placeholders_resolved "$raw" "$f"
-    resolved="$(envsubst <<<"$raw")"
+    resolved="$(resolve_placeholders "$raw" "$f")"
 
     folder_uid="$(jq -r '.folder' <<<"$resolved")"
     group_name="$(jq -r '.name' <<<"$resolved")"

--- a/packages/observability/scripts/apply-alerting.sh
+++ b/packages/observability/scripts/apply-alerting.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Push alert rule groups in `provisioning/alerting/` to a hosted Grafana
+# via the provisioning HTTP API. grafanactl doesn't manage alert rules
+# (its `resources list` covers App Platform kinds only — dashboards,
+# folders, playlists, etc.), and locally docker-compose mounts
+# `provisioning/alerting/` into the container so Grafana provisions from
+# the file directly. This script only runs against staging / production.
+#
+# Usage:
+#   ./scripts/apply-alerting.sh --env <local|staging|production>
+#
+# Required env vars (staging / production only). The CI apply workflow
+# (.github/workflows/observability-apply-{staging,production}.yml) fetches
+# GRAFANA_TOKEN from SSM and exports it to $GITHUB_ENV. For a local hosted
+# run, source ./scripts/grafanactl-env.sh first.
+#
+#   GRAFANA_TOKEN — service-account token (SecureString)
+#
+# What it pushes:
+#   - Each `.json` in `provisioning/alerting/` is read as the standard
+#     Grafana file-provisioning shape (`apiVersion: 1` + `groups: [...]`).
+#   - For each group, env-var references like `${VAR}` are substituted
+#     from the current shell environment (no placeholders today, but the
+#     pattern matches apply-datasources.sh so future log-group / RDS
+#     instance / datasource-uid parameterization slots in cleanly).
+#   - The result is upserted via PUT
+#     `/api/v1/provisioning/folder/{folderUID}/rule-groups/{group}` with
+#     header `X-Disable-Provenance: true` so each rule stays UI-editable
+#     between pushes (file is canonical; UI edits get overwritten on the
+#     next apply — same trade-off as apply-datasources.sh).
+#
+# Caveats:
+#   - The Grafana provisioning API expects an AlertRuleGroup body of
+#     `{title, folderUid, interval, rules}` with `interval` as integer
+#     seconds. The file format uses `name`, `folder`, and a duration
+#     string like "60s" — this script normalizes those.
+#   - rules[].uid in the file is preserved on PUT, so re-applies are
+#     idempotent (same uid → in-place update, not a duplicate rule).
+set -eo pipefail
+
+usage_error() { echo "error: $1" >&2; exit 2; }
+fail() { echo "error: $1" >&2; exit 1; }
+
+env_name=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env)
+      [[ $# -ge 2 && "$2" != -* ]] || usage_error "--env requires a value"
+      env_name="$2"
+      shift 2
+      ;;
+    --env=*)
+      env_name="${1#--env=}"
+      [[ -n "$env_name" ]] || usage_error "--env requires a value"
+      shift
+      ;;
+    *) usage_error "unknown option: $1";;
+  esac
+done
+
+[[ -n "$env_name" ]] || usage_error "missing --env"
+
+case "$env_name" in
+  local)
+    echo "apply-alerting: local — skipped (file provisioning handles it)" >&2
+    exit 0
+    ;;
+  staging | production)
+    ;;
+  *)
+    usage_error "--env must be local, staging, or production (got: $env_name)"
+    ;;
+esac
+
+for cmd in yq jq curl envsubst; do
+  command -v "$cmd" >/dev/null \
+    || fail "missing dependency: ${cmd}. Install via brew (yq, jq, gettext for envsubst) or apt (yq, jq, gettext-base)."
+done
+
+[[ -n "${GRAFANA_TOKEN:-}" ]] || fail "GRAFANA_TOKEN not set; run \`source ./scripts/grafanactl-env.sh ${env_name}\` first"
+
+cd "$(dirname "$0")/.."
+
+# Pull the per-env Grafana server URL from grafanactl's committed config so
+# this script and grafanactl always agree on the target host.
+grafana_server="$(yq -r ".contexts.${env_name}.grafana.server" grafanactl/config.yaml)"
+[[ -n "$grafana_server" && "$grafana_server" != "null" ]] \
+  || fail "couldn't resolve grafana server for context '${env_name}' from grafanactl/config.yaml"
+
+# Convert a file-provisioning duration string ("60s", "5m", "1h") to
+# integer seconds for the AlertRuleGroup API body. A bare integer passes
+# through unchanged so future files using `interval: 60` still work.
+interval_seconds() {
+  local raw="$1"
+  case "$raw" in
+    "" | null) fail "interval missing on rule group" ;;
+    *s) echo "${raw%s}" ;;
+    *m) echo "$(( ${raw%m} * 60 ))" ;;
+    *h) echo "$(( ${raw%h} * 3600 ))" ;;
+    *)  echo "$raw" ;;
+  esac
+}
+
+# Validate that every ${VAR} the JSON references is set to a non-empty
+# value before we call envsubst. envsubst substitutes unset / empty vars
+# with empty strings, so a typo in a placeholder name OR an empty SSM
+# value would silently push e.g. an empty datasource uid into a rule.
+# Same pattern as apply-datasources.sh.
+assert_placeholders_resolved() {
+  local raw="$1" file="$2"
+  local refs ref name
+  refs="$(grep -oE '\$\{[A-Z_][A-Z0-9_]*\}' <<<"$raw" | sort -u || true)"
+  while IFS= read -r ref; do
+    [[ -z "$ref" ]] && continue
+    name="${ref#\$\{}"; name="${name%\}}"
+    [[ -n "${!name:-}" ]] || fail "${file}: \${${name}} referenced but not set (or empty) in environment"
+  done <<<"$refs"
+}
+
+upsert_group() {
+  local folder_uid="$1" group_name="$2" body="$3"
+  local http_status response
+  # Capture body and status separately so a non-2xx prints the server's
+  # error message (e.g., "rule X is invalid: ..."). curl --fail-with-body
+  # would also do this, but using -w lets us include the status code in
+  # the failure line uniformly.
+  response="$(mktemp)"
+  http_status="$(curl -sS -o "$response" -w '%{http_code}' -X PUT \
+    -H "Authorization: Bearer ${GRAFANA_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -H "X-Disable-Provenance: true" \
+    --data-binary "$body" \
+    "${grafana_server}/api/v1/provisioning/folder/${folder_uid}/rule-groups/${group_name}")"
+
+  case "$http_status" in
+    2??)
+      echo "  ↻ ${folder_uid}/${group_name}" >&2
+      rm -f "$response"
+      ;;
+    *)
+      echo "  ✗ ${folder_uid}/${group_name} → HTTP ${http_status}" >&2
+      sed 's/^/    /' "$response" >&2 || true
+      rm -f "$response"
+      fail "alert rule push failed"
+      ;;
+  esac
+}
+
+shopt -s nullglob
+files=(provisioning/alerting/*.json)
+[[ "${#files[@]}" -gt 0 ]] || { echo "no alert-rule-group json files found" >&2; exit 0; }
+
+echo "apply-alerting: env=${env_name} server=${grafana_server} files=${#files[@]}" >&2
+
+for f in "${files[@]}"; do
+  echo "→ ${f}" >&2
+  # Each file is `apiVersion: 1` + `groups: [...]`. Pull groups out as
+  # JSON one per line, envsubst them so ${VAR} placeholders resolve, then
+  # transform into the AlertRuleGroup body the provisioning API expects.
+  jq -c '.groups[]' "$f" | while IFS= read -r raw; do
+    assert_placeholders_resolved "$raw" "$f"
+    resolved="$(envsubst <<<"$raw")"
+
+    folder_uid="$(jq -r '.folder' <<<"$resolved")"
+    group_name="$(jq -r '.name' <<<"$resolved")"
+    interval_raw="$(jq -r '.interval' <<<"$resolved")"
+    interval_secs="$(interval_seconds "$interval_raw")"
+
+    [[ -n "$folder_uid" && "$folder_uid" != "null" ]] \
+      || fail "${f}: group '${group_name}' missing 'folder' uid"
+    [[ -n "$group_name" && "$group_name" != "null" ]] \
+      || fail "${f}: group missing 'name'"
+
+    body="$(jq -c \
+      --arg title "$group_name" \
+      --arg folderUid "$folder_uid" \
+      --argjson interval "$interval_secs" \
+      '{title: $title, folderUid: $folderUid, interval: $interval, rules: .rules}' \
+      <<<"$resolved")"
+
+    upsert_group "$folder_uid" "$group_name" "$body"
+  done
+done
+
+echo "apply-alerting: done" >&2

--- a/packages/observability/scripts/apply-datasources.sh
+++ b/packages/observability/scripts/apply-datasources.sh
@@ -144,11 +144,20 @@ files=(provisioning/datasources/*.yaml)
 echo "apply-datasources: env=${env_name} server=${grafana_server} files=${#files[@]}" >&2
 
 # Validate that every ${VAR} the YAML references is set to a non-empty
-# value before we call envsubst. envsubst substitutes unset / empty vars
-# with empty strings, so a typo in a placeholder name OR an empty SSM
-# value would silently push e.g. `url: ""` / `password: ""` to Grafana.
-# Catching it here lines up with the stricter preflight in apply.sh.
-assert_placeholders_resolved() {
+# value, then envsubst ONLY those refs. Two reasons we pass an explicit
+# allowlist to envsubst rather than letting it substitute everything:
+#
+#   1. envsubst with no args also expands bare `$VAR` (no braces). If a
+#      datasource entry ever embeds shell-meta or Grafana template syntax,
+#      an empty allowlist would silently empty-substitute it. Pinning to
+#      the discovered ${UPPER_VAR} refs keeps everything else literal.
+#   2. envsubst substitutes unset / empty vars with empty strings, so a
+#      typo in a placeholder name OR an empty SSM value would silently
+#      push e.g. `url: ""` / `password: ""` to Grafana. The validate step
+#      catches that before envsubst runs.
+#
+# Same shape as apply-alerting.sh and render-config.sh.
+resolve_placeholders() {
   local raw="$1" file="$2"
   local refs ref name
   refs="$(grep -oE '\$\{[A-Z_][A-Z0-9_]*\}' <<<"$raw" | sort -u || true)"
@@ -157,6 +166,11 @@ assert_placeholders_resolved() {
     name="${ref#\$\{}"; name="${name%\}}"
     [[ -n "${!name:-}" ]] || fail "${file}: \${${name}} referenced but not set (or empty) in environment"
   done <<<"$refs"
+  if [[ -n "$refs" ]]; then
+    envsubst "$(tr '\n' ' ' <<<"$refs")" <<<"$raw"
+  else
+    printf '%s\n' "$raw"
+  fi
 }
 
 for f in "${files[@]}"; do
@@ -167,8 +181,7 @@ for f in "${files[@]}"; do
   # through the same path — Grafana's HTTP API accepts it on POST/PUT
   # exactly as it appears in the file-provisioning shape.
   yq -o json -I0 '.datasources[]' "$f" | while IFS= read -r raw; do
-    assert_placeholders_resolved "$raw" "$f"
-    payload="$(envsubst <<<"$raw")"
+    payload="$(resolve_placeholders "$raw" "$f")"
     upsert "$payload"
   done
 done

--- a/packages/observability/scripts/apply.sh
+++ b/packages/observability/scripts/apply.sh
@@ -129,3 +129,9 @@ grafanactl \
 # Data sources — grafanactl doesn't manage them, so push via HTTP API.
 # Local skips this (docker-compose handles file provisioning).
 ./scripts/apply-datasources.sh --env "$env_name"
+
+# Alert rule groups — also outside grafanactl's scope. Run after the
+# datasource push so any datasource UIDs the rules reference are
+# guaranteed to exist before the rules land. Local skips this (the
+# docker-compose file mount provisions alerts at container startup).
+./scripts/apply-alerting.sh --env "$env_name"


### PR DESCRIPTION
## Summary

- Adds `packages/observability/scripts/apply-alerting.sh`, mirroring `apply-datasources.sh`: each `provisioning/alerting/*.json` rule group gets envsubst'd, reshaped into the AlertRuleGroup body, and `PUT`d to `/api/v1/provisioning/folder/{folderUID}/rule-groups/{group}` with `X-Disable-Provenance: true`. Local mode no-ops (docker-compose still file-mounts).
- Wires the new script into `apply.sh` after the datasource push so any datasource UID a rule references exists first.
- Updates the README's two-trees architecture section to document the new bridge.

## Why

Hosted Grafana (`grafana-staging.stack.cards`, `grafana.boxel.ai`) had no path for `provisioning/alerting/*` to reach the running instance: `apply.sh` pushed dashboards/folders (via grafanactl) and datasources (via the existing HTTP-API bridge), but the alerting half of the file-provisioning intent was never built. Result: rules like `Worker Startup` / `Worker Reap` lived only in git, the staging Grafana didn't know about them, and the Worker Status dashboard's "Worker Alerts" panel stayed empty (while AMG showed both alerts firing).

This adds the missing bridge using the same file-as-source-of-truth + HTTP-API pattern that already covers datasources. `X-Disable-Provenance: true` keeps rules UI-editable for incident response; CI re-applies overwrite UI edits, same trade-off as datasources.

Linear: [CS-11040](https://linear.app/cardstack/issue/CS-11040/push-provisioningalerting-rule-groups-to-self-host-grafana)

## Test plan

- [x] `shellcheck scripts/apply-alerting.sh` clean
- [x] `./scripts/lint.sh` passes (json parse, manifest shape, secret scan, prettier YAML)
- [x] `./scripts/apply-alerting.sh --env local` correctly no-ops
- [x] Body shape dry-run: existing `worker-status-group.json` produces `{title: "worker-status-group", folderUid: "defd2d156sav4d", interval: 60, rules: <2 rules>}` — matches the AlertRuleGroup schema
- [ ] On merge, the staging apply workflow runs; verify `curl -H "Authorization: Bearer $TOKEN" grafana-staging.stack.cards/api/v1/provisioning/folder/defd2d156sav4d/rule-groups/worker-status-group` returns the two rules
- [ ] Worker Status dashboard's "Worker Alerts" panel populates on staging (parity with AMG)
- [ ] Re-running `./scripts/apply.sh --env staging` is idempotent (rule UIDs in the file → in-place updates, no duplicates)

## Out of scope

- Issue #1 from the original report (Reindex / Full Reindex buttons that rely on `?authHeader=...`) is Phase 6.5 work — tracked separately by CS-10927 (realm-server POST endpoints) and CS-10929 (button-panel migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)