### PR TITLE
boxel-cli: fix flaky realm-history short-hash restore

### DIFF
--- a/packages/boxel-cli/src/commands/realm/history.ts
+++ b/packages/boxel-cli/src/commands/realm/history.ts
@@ -179,19 +179,30 @@ async function restoreCheckpointStep(
   }
 }
 
-type FindResult =
+export type FindResult =
   | { kind: 'found'; target: Checkpoint }
   | { kind: 'none' }
   | { kind: 'ambiguous'; matches: Checkpoint[] };
 
-function findCheckpoint(ref: string, checkpoints: Checkpoint[]): FindResult {
+export function findCheckpoint(
+  ref: string,
+  checkpoints: Checkpoint[],
+): FindResult {
   const trimmed = ref.trim();
   // Empty refs would `startsWith('')`-match every hash and silently restore
   // the newest checkpoint — guard explicitly.
   if (trimmed === '') return { kind: 'none' };
-  // Digit-only input is always an index lookup. Falling through to hash
-  // matching when out of range would silently match short hashes whose prefix
-  // happens to be digits.
+
+  // Exact short-hash match wins before the digit-only branch. SHA-1 short
+  // hashes are 7 hex chars and can be all-digits (~5.9% of hashes), so
+  // routing digit-only input straight to index lookup would lose those.
+  const exactShort = checkpoints.filter((cp) => cp.shortHash === trimmed);
+  if (exactShort.length === 1) return { kind: 'found', target: exactShort[0] };
+  if (exactShort.length > 1) return { kind: 'ambiguous', matches: exactShort };
+
+  // Digit-only input that didn't match a short hash is treated as an index
+  // lookup. Falling through to hash-prefix matching when out of range would
+  // silently match short hashes whose prefix happens to be digits.
   if (/^\d+$/.test(trimmed)) {
     const num = parseInt(trimmed, 10);
     if (num >= 1 && num <= checkpoints.length) {
@@ -199,9 +210,7 @@ function findCheckpoint(ref: string, checkpoints: Checkpoint[]): FindResult {
     }
     return { kind: 'none' };
   }
-  const matches = checkpoints.filter(
-    (cp) => cp.hash.startsWith(trimmed) || cp.shortHash === trimmed,
-  );
+  const matches = checkpoints.filter((cp) => cp.hash.startsWith(trimmed));
   if (matches.length === 0) return { kind: 'none' };
   if (matches.length === 1) return { kind: 'found', target: matches[0] };
   return { kind: 'ambiguous', matches };

--- a/packages/boxel-cli/src/commands/realm/history.ts
+++ b/packages/boxel-cli/src/commands/realm/history.ts
@@ -4,6 +4,7 @@ import {
   CheckpointManager,
   type Checkpoint,
 } from '../../lib/checkpoint-manager';
+import { findCheckpoint } from '../../lib/find-checkpoint';
 import { prompt } from '../../lib/prompt';
 import {
   BOLD,
@@ -177,43 +178,6 @@ async function restoreCheckpointStep(
       error: `Failed to restore checkpoint: ${errorMessage(e)}`,
     };
   }
-}
-
-export type FindResult =
-  | { kind: 'found'; target: Checkpoint }
-  | { kind: 'none' }
-  | { kind: 'ambiguous'; matches: Checkpoint[] };
-
-export function findCheckpoint(
-  ref: string,
-  checkpoints: Checkpoint[],
-): FindResult {
-  const trimmed = ref.trim();
-  // Empty refs would `startsWith('')`-match every hash and silently restore
-  // the newest checkpoint — guard explicitly.
-  if (trimmed === '') return { kind: 'none' };
-
-  // Exact short-hash match wins before the digit-only branch. SHA-1 short
-  // hashes are 7 hex chars and can be all-digits (~5.9% of hashes), so
-  // routing digit-only input straight to index lookup would lose those.
-  const exactShort = checkpoints.filter((cp) => cp.shortHash === trimmed);
-  if (exactShort.length === 1) return { kind: 'found', target: exactShort[0] };
-  if (exactShort.length > 1) return { kind: 'ambiguous', matches: exactShort };
-
-  // Digit-only input that didn't match a short hash is treated as an index
-  // lookup. Falling through to hash-prefix matching when out of range would
-  // silently match short hashes whose prefix happens to be digits.
-  if (/^\d+$/.test(trimmed)) {
-    const num = parseInt(trimmed, 10);
-    if (num >= 1 && num <= checkpoints.length) {
-      return { kind: 'found', target: checkpoints[num - 1] };
-    }
-    return { kind: 'none' };
-  }
-  const matches = checkpoints.filter((cp) => cp.hash.startsWith(trimmed));
-  if (matches.length === 0) return { kind: 'none' };
-  if (matches.length === 1) return { kind: 'found', target: matches[0] };
-  return { kind: 'ambiguous', matches };
 }
 
 /**

--- a/packages/boxel-cli/src/lib/find-checkpoint.ts
+++ b/packages/boxel-cli/src/lib/find-checkpoint.ts
@@ -1,0 +1,65 @@
+import type { Checkpoint } from './checkpoint-manager';
+
+/**
+ * Length of a checkpoint's `shortHash`. SHA-1's first 7 hex chars, set in
+ * `CheckpointManager.createCheckpoint`. Used to short-circuit the exact
+ * short-hash scan for refs that can't possibly be one.
+ */
+const SHORT_HASH_LENGTH = 7;
+
+export type FindResult =
+  | { kind: 'found'; target: Checkpoint }
+  | { kind: 'none' }
+  | { kind: 'ambiguous'; matches: Checkpoint[] };
+
+/**
+ * Resolve a `--restore` ref against a list of checkpoints. The ref may be a
+ * 1-based index (`'2'`), an exact short hash (`'6701186'`), or a hex prefix
+ * of a full hash (`'abc'`).
+ *
+ * Resolution order:
+ *   1. Exact short-hash match. SHA-1 short hashes are all-digits ~5.9% of
+ *      the time, so digit-only refs that match a short hash exactly must
+ *      win before the index branch.
+ *   2. Digit-only refs → 1-based index. Out-of-range returns `none` rather
+ *      than falling through to hash-prefix matching, since silently matching
+ *      a hash whose prefix happens to be digits would surprise users typing
+ *      what they think is an index.
+ *   3. Hex-prefix match against the full hash.
+ */
+export function findCheckpoint(
+  ref: string,
+  checkpoints: Checkpoint[],
+): FindResult {
+  const trimmed = ref.trim();
+  // Empty refs would `startsWith('')`-match every hash and silently restore
+  // the newest checkpoint — guard explicitly.
+  if (trimmed === '') return { kind: 'none' };
+
+  // Exact short-hash match wins before the digit-only branch.
+  if (trimmed.length === SHORT_HASH_LENGTH) {
+    const exactShort = checkpoints.filter((cp) => cp.shortHash === trimmed);
+    if (exactShort.length === 1) {
+      return { kind: 'found', target: exactShort[0] };
+    }
+    if (exactShort.length > 1) {
+      return { kind: 'ambiguous', matches: exactShort };
+    }
+  }
+
+  // Digit-only input is an index lookup. Falling through to hash-prefix
+  // matching when out of range would silently match short hashes whose prefix
+  // happens to be digits.
+  if (/^\d+$/.test(trimmed)) {
+    const num = parseInt(trimmed, 10);
+    if (num >= 1 && num <= checkpoints.length) {
+      return { kind: 'found', target: checkpoints[num - 1] };
+    }
+    return { kind: 'none' };
+  }
+
+  const matches = checkpoints.filter((cp) => cp.hash.startsWith(trimmed));
+  if (matches.length === 0) return { kind: 'none' };
+  if (matches.length === 1) return { kind: 'found', target: matches[0] };
+  return { kind: 'ambiguous', matches };
+}

--- a/packages/boxel-cli/tests/commands/realm-history-find-checkpoint.test.ts
+++ b/packages/boxel-cli/tests/commands/realm-history-find-checkpoint.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { findCheckpoint } from '../../src/commands/realm/history';
+import type { Checkpoint } from '../../src/lib/checkpoint-manager';
+
+function cp(hash: string, shortHash?: string): Checkpoint {
+  return {
+    hash,
+    shortHash: shortHash ?? hash.substring(0, 7),
+    message: 'test',
+    description: '',
+    date: new Date(),
+    isMajor: false,
+    filesChanged: 0,
+    insertions: 0,
+    deletions: 0,
+    source: 'manual',
+    isMilestone: false,
+  };
+}
+
+describe('findCheckpoint', () => {
+  describe('all-digit short hash regression', () => {
+    // SHA-1 short hashes (first 7 hex chars) are all-digits ~5.9% of the time
+    // ((10/16)^7). Routing digit-only refs straight to index lookup loses
+    // those — exact short-hash match must win.
+    const target = cp('6701186b1d624af1b692cbf741c6990fbd10040b');
+    const newer = cp('abc1234deadbeefabc1234deadbeefabc1234dea');
+
+    it('resolves an all-digit short hash to the matching checkpoint', () => {
+      const result = findCheckpoint(target.shortHash, [newer, target]);
+      expect(result.kind).toBe('found');
+      if (result.kind === 'found') {
+        expect(result.target.hash).toBe(target.hash);
+      }
+    });
+
+    it('still treats an out-of-range numeric ref that is not a short hash as none', () => {
+      // '99' is digit-only, not a 7-char short hash, and out of index range.
+      const result = findCheckpoint('99', [newer, target]);
+      expect(result.kind).toBe('none');
+    });
+
+    it('prefers an in-range index over a coincidental hash-prefix match', () => {
+      // '1' is a valid index; do not let an exact-shortHash check
+      // accidentally promote a 1-char ref over the index UX.
+      const result = findCheckpoint('1', [newer, target]);
+      expect(result.kind).toBe('found');
+      if (result.kind === 'found') {
+        expect(result.target.hash).toBe(newer.hash);
+      }
+    });
+
+    it('reports ambiguous when two checkpoints share the same short hash', () => {
+      const a = cp('6701186b1d624af1b692cbf741c6990fbd10040b');
+      const b = cp('6701186cccccccccccccccccccccccccccccccc');
+      const result = findCheckpoint('6701186', [a, b]);
+      expect(result.kind).toBe('ambiguous');
+    });
+  });
+
+  describe('basic resolution', () => {
+    const a = cp('aaaaaaa1234567890aaaaaaa1234567890aaaaaa');
+    const b = cp('bbbbbbb1234567890bbbbbbb1234567890bbbbbb');
+
+    it('returns none for an empty ref', () => {
+      expect(findCheckpoint('', [a, b]).kind).toBe('none');
+      expect(findCheckpoint('   ', [a, b]).kind).toBe('none');
+    });
+
+    it('resolves a 1-based index', () => {
+      const result = findCheckpoint('2', [a, b]);
+      expect(result.kind).toBe('found');
+      if (result.kind === 'found') expect(result.target.hash).toBe(b.hash);
+    });
+
+    it('resolves a hex prefix to the matching checkpoint', () => {
+      const result = findCheckpoint('aaa', [a, b]);
+      expect(result.kind).toBe('found');
+      if (result.kind === 'found') expect(result.target.hash).toBe(a.hash);
+    });
+
+    it('returns ambiguous when a hex prefix matches multiple', () => {
+      const c = cp('aaaaaaaffffffffaaaaaaaffffffffaaaaaaffff');
+      const result = findCheckpoint('aaa', [a, c]);
+      expect(result.kind).toBe('ambiguous');
+    });
+  });
+});

--- a/packages/boxel-cli/tests/lib/find-checkpoint.test.ts
+++ b/packages/boxel-cli/tests/lib/find-checkpoint.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { findCheckpoint } from '../../src/commands/realm/history';
+import { findCheckpoint } from '../../src/lib/find-checkpoint';
 import type { Checkpoint } from '../../src/lib/checkpoint-manager';
 
 function cp(hash: string, shortHash?: string): Checkpoint {


### PR DESCRIPTION
## Why

Two `realm-history` integration tests have been flaky in CI:

- `restore (-r) > restores by short hash`
- `restore (-r) > preserves .realm.json across restore`

Both fail at `expect(result.ok).toBe(true)` and tend to fail *together* (one example: [run 25407181418](https://github.com/cardstack/boxel/actions/runs/25407181418/job/74521281460?pr=4667)).

## Root cause

`findCheckpoint()` in `packages/boxel-cli/src/commands/realm/history.ts` routes any digit-only ref to an index lookup, with an explicit comment that falling through to hash matching would silently match short hashes whose prefix happens to be digits:

```ts
if (/^\d+$/.test(trimmed)) {
  const num = parseInt(trimmed, 10);
  if (num >= 1 && num <= checkpoints.length) {
    return { kind: 'found', target: checkpoints[num - 1] };
  }
  return { kind: 'none' };  // ← never falls through
}
```

But `CheckpointManager.createCheckpoint` returns `shortHash = hash.substring(0, 7)` (a fixed 7-char prefix of the SHA-1, [`checkpoint-manager.ts:257`](https://github.com/cardstack/boxel/blob/main/packages/boxel-cli/src/lib/checkpoint-manager.ts#L257)). When that 7-char prefix happens to be all-digits — probability **~5.9%** per hash, since `(10/16)^7 ≈ 0.0596` — `realmHistory({ restore: target.shortHash })` is misinterpreted as an out-of-range index lookup and short-circuits to `none`. The hash matcher is never consulted.

### Why both tests fail together

Both tests use the same content (`a.gts = 'original'`), the same fixed git author/email, and the same auto-generated commit message. The only varying input to the SHA-1 is the wall-clock timestamp. Within a given second, the two tests produce *identical* commit hashes, so both fail on the same CI run when that second's hash happens to start with 7 digits, and both pass together otherwise. The other restore tests don't share this fate:

- `restores by 1-based index` uses literal `'2'` (a real index)
- `restores by full hash` uses the full 40 hex chars (must contain `a-f`, by pigeonhole)
- The negative tests don't depend on a digit-prone shortHash

### Deterministic repro

```js
findCheckpoint('6701186', [newer, target])
// where target.hash = '6701186b1d624af1b692cbf741c6990fbd10040b'
// returns { kind: 'none' } instead of { kind: 'found', target }
```

That exact hash was reproduced repeatedly in a local stress test of the test fixture's content + author + message: 25 of 200 runs (12.5%) inside that bash loop landed on this hash, because the constant inputs collapse to the same hash whenever the wall-clock second matches.

## Fix

In `findCheckpoint`, do an exact short-hash match first. If exactly one checkpoint's `shortHash` equals the input, that wins regardless of whether the input looks like a number. Otherwise fall through to the existing logic.

```ts
const exactShort = checkpoints.filter((cp) => cp.shortHash === trimmed);
if (exactShort.length === 1) return { kind: 'found', target: exactShort[0] };
if (exactShort.length > 1) return { kind: 'ambiguous', matches: exactShort };

if (/^\d+$/.test(trimmed)) { /* unchanged */ }
```

This preserves the digit-only-is-index UX:

- `'99'` is digit-only, isn't a 7-char short hash, isn't a valid index → `Checkpoint not found` (as before).
- `'1'` is digit-only, isn't a 7-char short hash, is a valid index → resolves to checkpoint #1 (as before).
- `'6701186'` matches a checkpoint's short hash exactly → resolves to that checkpoint (was failing).

The existing comment about "silently matching short hashes whose prefix happens to be digits" still holds for the *prefix* matcher — that branch hasn't moved. We just allow an *exact* short-hash match to win first.

## Tests

A new unit test (`tests/commands/realm-history-find-checkpoint.test.ts`) pins a known all-digit short hash (`6701186…`) so the regression is deterministic, plus checks for:

- Out-of-range digit-only ref that isn't a short hash → `none` (preserves existing UX)
- In-range digit ref → still resolves to that index, not a same-prefix hash
- Two checkpoints with identical short hashes → `ambiguous`
- Hex-prefix matching (non-exact) still works
- Empty / whitespace-only refs → `none`

The existing 23 integration tests in `realm-history.test.ts` continue to pass.

## Test plan

- [x] `pnpm test tests/commands/realm-history-find-checkpoint.test.ts` — 8 passed
- [x] `pnpm test tests/integration/realm-history.test.ts` — 23 passed
- [x] `pnpm lint` clean in `packages/boxel-cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)