### PR TITLE
host tests: stabilize addSkillToAiAssistant + log silent skill-load skips

### DIFF
--- a/packages/host/app/commands/update-room-skills.ts
+++ b/packages/host/app/commands/update-room-skills.ts
@@ -96,9 +96,21 @@ export default class UpdateRoomSkillsCommand extends HostBaseCommand<
               let skillCard = maybeSkillCard as SkillModule.Skill;
               skillCardCache.set(skillId, skillCard);
               skillsNeedingUpload.push(skillCard);
+            } else {
+              // Skill load returned something that isn't a usable skill card
+              // (commonly a CardErrorJSONAPI). The activation is silently
+              // dropped; surface a warning so test flakes / production
+              // regressions don't go unattributed.
+              console.warn(
+                `[UpdateRoomSkillsCommand] skipping activation of "${skillId}": store.get did not return a Skill instance`,
+                maybeSkillCard,
+              );
             }
-          } catch {
-            // Ignore failures to load individual skill cards
+          } catch (err) {
+            console.warn(
+              `[UpdateRoomSkillsCommand] skipping activation of "${skillId}": store.get threw`,
+              err,
+            );
           }
         }
 
@@ -140,8 +152,15 @@ export default class UpdateRoomSkillsCommand extends HostBaseCommand<
                 skillCardCache.set(skillId, skillCard);
                 return skillCard;
               }
-            } catch {
-              // Ignore failures to load individual skill cards
+              console.warn(
+                `[UpdateRoomSkillsCommand] cannot rehydrate enabled skill "${skillId}": store.get did not return a Skill instance`,
+                maybeSkillCard,
+              );
+            } catch (err) {
+              console.warn(
+                `[UpdateRoomSkillsCommand] cannot rehydrate enabled skill "${skillId}": store.get threw`,
+                err,
+              );
             }
             return undefined;
           }),

--- a/packages/host/app/commands/update-room-skills.ts
+++ b/packages/host/app/commands/update-room-skills.ts
@@ -1,6 +1,6 @@
 import { service } from '@ember/service';
 
-import { isCardInstance } from '@cardstack/runtime-common';
+import { isCardErrorJSONAPI, isCardInstance } from '@cardstack/runtime-common';
 import { APP_BOXEL_ROOM_SKILLS_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
@@ -97,19 +97,13 @@ export default class UpdateRoomSkillsCommand extends HostBaseCommand<
               skillCardCache.set(skillId, skillCard);
               skillsNeedingUpload.push(skillCard);
             } else {
-              // Skill load returned something that isn't a usable skill card
-              // (commonly a CardErrorJSONAPI). The activation is silently
-              // dropped; surface a warning so test flakes / production
-              // regressions don't go unattributed.
               console.warn(
-                `[UpdateRoomSkillsCommand] skipping activation of "${skillId}": store.get did not return a Skill instance`,
-                maybeSkillCard,
+                `[UpdateRoomSkillsCommand] skipping activation of "${skillId}": ${describeStoreResult(maybeSkillCard)}`,
               );
             }
           } catch (err) {
             console.warn(
-              `[UpdateRoomSkillsCommand] skipping activation of "${skillId}": store.get threw`,
-              err,
+              `[UpdateRoomSkillsCommand] skipping activation of "${skillId}": store.get threw: ${errorSummary(err)}`,
             );
           }
         }
@@ -153,13 +147,11 @@ export default class UpdateRoomSkillsCommand extends HostBaseCommand<
                 return skillCard;
               }
               console.warn(
-                `[UpdateRoomSkillsCommand] cannot rehydrate enabled skill "${skillId}": store.get did not return a Skill instance`,
-                maybeSkillCard,
+                `[UpdateRoomSkillsCommand] cannot rehydrate enabled skill "${skillId}": ${describeStoreResult(maybeSkillCard)}`,
               );
             } catch (err) {
               console.warn(
-                `[UpdateRoomSkillsCommand] cannot rehydrate enabled skill "${skillId}": store.get threw`,
-                err,
+                `[UpdateRoomSkillsCommand] cannot rehydrate enabled skill "${skillId}": store.get threw: ${errorSummary(err)}`,
               );
             }
             return undefined;
@@ -209,4 +201,31 @@ export default class UpdateRoomSkillsCommand extends HostBaseCommand<
       },
     );
   }
+}
+
+// Stable, redaction-safe one-line summary of whatever `store.get` produced for
+// a skill. Avoids dumping the full instance / error payload (which can be
+// large and may carry user content) while still naming the failure mode.
+function describeStoreResult(result: unknown): string {
+  if (result == null) {
+    return `store.get returned ${result === null ? 'null' : 'undefined'}`;
+  }
+  if (isCardErrorJSONAPI(result)) {
+    let status = (result as { status?: number }).status;
+    let title = (result as { title?: string }).title;
+    return `store.get returned a CardErrorJSONAPI (status=${status ?? 'n/a'}, title=${JSON.stringify(title ?? '')})`;
+  }
+  if (isCardInstance(result)) {
+    return `store.get returned a card instance that is not a Skill (id=${
+      (result as { id?: string }).id ?? '<no id>'
+    })`;
+  }
+  return `store.get returned an unrecognized value of type ${typeof result}`;
+}
+
+function errorSummary(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message || err.name;
+  }
+  return typeof err === 'string' ? err : `<${typeof err}>`;
 }

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -2063,10 +2063,11 @@ export async function addSkillToAiAssistant(
       },
     );
   } catch (err) {
-    // Capture diagnostics so future flakes are easier to attribute. The error
-    // surface from `waitUntil` is intentionally terse — we want a snapshot of
-    // what the matrix-service believed the room contained at the moment of
-    // timeout.
+    // Re-throw with a richer message so the failure report attributes the
+    // flake without us writing to console.* (which can interleave across
+    // parallel runs and trip console-error guards in some setups). The
+    // snapshot describes what the matrix-service believed the room contained
+    // at the moment of timeout.
     let snapshot = matrixService.getRoomData(resolvedRoomId)?.skillsConfig;
     let diagnostic = {
       roomId: resolvedRoomId,
@@ -2078,11 +2079,14 @@ export async function addSkillToAiAssistant(
         snapshot?.disabledSkillCards?.map((f) => f.sourceUrl) ?? null,
       commandDefinitionsCount: snapshot?.commandDefinitions?.length ?? null,
     };
-    console.error(
-      `[addSkillToAiAssistant] timeout diagnostics: ${JSON.stringify(
-        diagnostic,
-      )}`,
+    let originalMessage = err instanceof Error ? err.message : String(err);
+    let enriched = new Error(
+      `${originalMessage} | diagnostics: ${JSON.stringify(diagnostic)}`,
     );
-    throw err;
+    // Preserve the original failure for any tooling that walks .cause without
+    // relying on the es2022 Error constructor option (host targets es2020).
+    (enriched as Error & { cause?: unknown }).cause =
+      err instanceof Error ? err : undefined;
+    throw enriched;
   }
 }

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -2032,26 +2032,57 @@ export async function addSkillToAiAssistant(
     skillCardIdsToActivate: [skillCardId],
   });
 
+  // Allow the matrix-service's debounced room-state drain (~100ms) and the
+  // mock client's setTimeout(0) listener fan-out to flush before we poll, so
+  // waitUntil sees a consistent snapshot rather than racing the runloop.
+  await settled();
+
   let matrixService = getService('matrix-service') as {
     getRoomData(roomId: string): {
       skillsConfig: {
         enabledSkillCards?: Array<{ sourceUrl?: string }>;
+        disabledSkillCards?: Array<{ sourceUrl?: string }>;
+        commandDefinitions?: Array<{ sourceUrl?: string }>;
       };
     } | null;
   };
 
-  await waitUntil(
-    () =>
-      Boolean(
-        matrixService
-          .getRoomData(resolvedRoomId)
-          ?.skillsConfig.enabledSkillCards?.some(
-            (fileDef) => fileDef.sourceUrl === skillCardId,
-          ),
-      ),
-    {
-      timeout: 5000,
-      timeoutMessage: `Timed out waiting for room skill state for "${skillCardId}"`,
-    },
-  );
+  try {
+    await waitUntil(
+      () =>
+        Boolean(
+          matrixService
+            .getRoomData(resolvedRoomId)
+            ?.skillsConfig.enabledSkillCards?.some(
+              (fileDef) => fileDef.sourceUrl === skillCardId,
+            ),
+        ),
+      {
+        timeout: 15000,
+        timeoutMessage: `Timed out waiting for room skill state for "${skillCardId}"`,
+      },
+    );
+  } catch (err) {
+    // Capture diagnostics so future flakes are easier to attribute. The error
+    // surface from `waitUntil` is intentionally terse — we want a snapshot of
+    // what the matrix-service believed the room contained at the moment of
+    // timeout.
+    let snapshot = matrixService.getRoomData(resolvedRoomId)?.skillsConfig;
+    let diagnostic = {
+      roomId: resolvedRoomId,
+      skillCardId,
+      skillsConfigPresent: Boolean(snapshot),
+      enabledSkillCards:
+        snapshot?.enabledSkillCards?.map((f) => f.sourceUrl) ?? null,
+      disabledSkillCards:
+        snapshot?.disabledSkillCards?.map((f) => f.sourceUrl) ?? null,
+      commandDefinitionsCount: snapshot?.commandDefinitions?.length ?? null,
+    };
+    console.error(
+      `[addSkillToAiAssistant] timeout diagnostics: ${JSON.stringify(
+        diagnostic,
+      )}`,
+    );
+    throw err;
+  }
 }

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -2058,7 +2058,7 @@ export async function addSkillToAiAssistant(
             ),
         ),
       {
-        timeout: 15000,
+        timeout: 5000,
         timeoutMessage: `Timed out waiting for room skill state for "${skillCardId}"`,
       },
     );

--- a/packages/host/tests/unit/loader-test.ts
+++ b/packages/host/tests/unit/loader-test.ts
@@ -8,6 +8,7 @@ import {
   baseRealm,
   Loader,
   registerCardReferencePrefix,
+  unregisterCardReferencePrefix,
 } from '@cardstack/runtime-common';
 
 import {
@@ -241,20 +242,27 @@ module('Unit | loader', function (hooks) {
   // getConsumedModules passed these directly to new URL() which throws
   // TypeError: Invalid URL. The fix uses resolveCardReference() first.
   test('can determine consumed modules using prefix-form module identifier', async function (assert) {
+    // Card-reference prefixes are global state — without the finally clause
+    // this registration leaks into later modules in the same shard, causing
+    // skill uploads to canonicalize sourceUrls to @test-loader/... and
+    // breaking strict URL matches in tests that consume them.
     registerCardReferencePrefix('@test-loader/', testRealmURL);
+    try {
+      // Import the module using its regular URL so it's in the loader cache
+      await loader.import(`${testRealmURL}f`);
 
-    // Import the module using its regular URL so it's in the loader cache
-    await loader.import(`${testRealmURL}f`);
-
-    // Now call getConsumedModules with the prefix-form identifier.
-    // Without the fix, this throws TypeError: Invalid URL because
-    // new URL('@test-loader/f') is not a valid URL.
-    let consumed = await loader.getConsumedModules(`@test-loader/f`);
-    assert.deepEqual(
-      consumed,
-      [`${testRealmURL}b`, `${testRealmURL}c`, `${testRealmURL}g`],
-      'consumed modules resolved correctly from prefix-form identifier',
-    );
+      // Now call getConsumedModules with the prefix-form identifier.
+      // Without the fix, this throws TypeError: Invalid URL because
+      // new URL('@test-loader/f') is not a valid URL.
+      let consumed = await loader.getConsumedModules(`@test-loader/f`);
+      assert.deepEqual(
+        consumed,
+        [`${testRealmURL}b`, `${testRealmURL}c`, `${testRealmURL}g`],
+        'consumed modules resolved correctly from prefix-form identifier',
+      );
+    } finally {
+      unregisterCardReferencePrefix('@test-loader/');
+    }
   });
 
   test('isModuleLoaded returns false for a module that has not been imported', function (assert) {


### PR DESCRIPTION
## Summary

Fixes a flake in `Integration | ai-assistant-panel | skills` where the entire 12-test module timed out with `Timed out waiting for room skill state` ([example run](https://github.com/cardstack/boxel/actions/runs/25407088284/job/74521350549?pr=4659)).

**Root cause.** A regression test in `packages/host/tests/unit/loader-test.ts` calls `registerCardReferencePrefix('@test-loader/', testRealmURL)` without ever unregistering. Card-reference prefixes are global state. On host shard 18 the loader module runs immediately before the skills module, so the leaked prefix causes `file-def-manager` to canonicalize every subsequent skill upload's `sourceUrl` to `@test-loader/Skill/example` instead of the http form. The test helper's strict-equality URL match never fires, `waitUntil` times out, and all 12 tests in the module fail in lock-step.

The diagnostic snapshot in `addSkillToAiAssistant` revealed it directly:

```
"enabledSkillCards": [
  "@cardstack/skills/Skill/boxel-environment",
  "@test-loader/Skill/example"            ← skill IS enabled, just under wrong URL
]
"skillCardId": "http://test-realm/test/Skill/example"   ← polled, never matches
```

## Changes

- `packages/host/tests/unit/loader-test.ts` — wrap the prefix registration in `try/finally` and call `unregisterCardReferencePrefix` in the `finally`. The actual fix.
- `packages/host/tests/helpers/index.gts` (`addSkillToAiAssistant`) — `await settled()` between `command.execute` and the poll so the matrix-service's debounced runloop drains before polling; on timeout, throw an `Error` whose message embeds a JSON snapshot of the room's `skillsConfig` (no `console.error`, with the original failure as `.cause`). Keep the original 5s timeout. The diagnostic is what surfaced the URL mismatch and would catch any future similar pollution mode.
- `packages/host/app/commands/update-room-skills.ts` — replace silent `try { ... } catch {}` swallows of skill-load failures with `console.warn` calls that emit a redaction-safe one-liner via two helpers (`describeStoreResult`, `errorSummary`). Names `CardErrorJSONAPI` status/title or non-skill-card id without dumping the full instance/error object into production logs.

## Test plan

- [ ] CI Host shard 18 passes (the shard the skills module lives on).
- [ ] If a similar all-tests-in-module flake recurs, the failing run shows `[addSkillToAiAssistant] ... | diagnostics: { ... }` in the test message and any preceding `[UpdateRoomSkillsCommand] skipping activation of "...": ...` warnings in the browser-log artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)