### PR TITLE
Host tests: settle markdown preview & log fetches on QUnit rejections

### DIFF
--- a/packages/host/tests/acceptance/code-submode/field-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/field-playground-test.gts
@@ -542,6 +542,10 @@ module('Acceptance | code-submode | field playground', function (_hooks) {
       assert.dom('[data-test-fitted-comment]').containsText('by Marco');
 
       await selectFormat('markdown');
+      // The markdown fallback renders a hidden CardRenderer + DefaultMarkdownFallbackTemplate
+      // whose MutationObserver schedules afterRender capture passes; without an
+      // explicit settle the test can finish before the capture chain quiesces.
+      await settled();
       assert.dom('[data-test-format-chooser="markdown"]').hasClass('active');
       assert
         .dom('[data-test-markdown-preview]')

--- a/packages/host/tests/helpers/playground.ts
+++ b/packages/host/tests/helpers/playground.ts
@@ -1,4 +1,4 @@
-import { click } from '@ember/test-helpers';
+import { click, settled } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 
@@ -66,6 +66,11 @@ export const openFileInPlayground = async (
     await selectDeclaration(opts.declaration);
   }
   await togglePlaygroundPanel();
+  // Drain Spec-search subscriptions and any background card-loads kicked off
+  // by the playground panel mount before the test asserts; these don't all
+  // register test waiters, and an in-flight fetch that resolves after a later
+  // navigation can surface as an unowned "A network error occurred." rejection.
+  await settled();
 };
 
 export const selectDeclaration = async (name: string) =>

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -31,8 +31,14 @@ let nextFetchId = 0;
 // failure (which surfaces the generic browser TypeError "A network error
 // occurred." with no URL) can be correlated with the actual request that blew
 // up. Each entry is `${method} ${url}: ${reason}`; cleared in beforeEach.
+//
+// Each fetch captures `currentTestEpoch` at start; on failure, we only push to
+// the buffer when the captured epoch still matches the current one. Without
+// that gate, a fetch from test N rejecting after test N+1's beforeEach has
+// cleared the buffer would repopulate it and misattribute URLs to N+1.
 const recentFailedFetches: string[] = [];
 const RECENT_FAILED_FETCHES_LIMIT = 20;
+let currentTestEpoch = 0;
 
 function setupFetchDebugging(hooks: NestedHooks) {
   let originalFetch: typeof globalThis.fetch | undefined;
@@ -41,6 +47,7 @@ function setupFetchDebugging(hooks: NestedHooks) {
   hooks.beforeEach(function () {
     inFlightFetches.clear();
     recentFailedFetches.length = 0;
+    currentTestEpoch++;
     if (!globalThis.fetch) {
       return;
     }
@@ -49,13 +56,14 @@ function setupFetchDebugging(hooks: NestedHooks) {
     wrappedFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       let { method, url } = describeFetchRequest(input, init);
       let id = nextFetchId++;
+      let epoch = currentTestEpoch;
       inFlightFetches.set(id, `${method} ${url}`);
       try {
         return await boundFetch(input, init);
       } catch (error) {
         let reason = formatErrorForLog(error);
         console.error(`[test-fetch] ${method} ${url} failed: ${reason}`);
-        rememberFailedFetch(method, url, reason);
+        rememberFailedFetch(epoch, method, url, reason);
         throw error;
       } finally {
         inFlightFetches.delete(id);
@@ -74,7 +82,17 @@ function setupFetchDebugging(hooks: NestedHooks) {
   });
 }
 
-function rememberFailedFetch(method: string, url: string, reason: string) {
+function rememberFailedFetch(
+  epoch: number,
+  method: string,
+  url: string,
+  reason: string,
+) {
+  // Drop late rejections from a prior test — the buffer is per-test and would
+  // otherwise contaminate the next test's diagnostic output.
+  if (epoch !== currentTestEpoch) {
+    return;
+  }
   recentFailedFetches.push(`${method} ${url}: ${reason}`);
   if (recentFailedFetches.length > RECENT_FAILED_FETCHES_LIMIT) {
     recentFailedFetches.splice(
@@ -136,7 +154,11 @@ function setupUnhandledRejectionDiagnostics(hooks: NestedHooks) {
           // never let diagnostic logging swallow the original failure
         }
         if (typeof originalOnUncaughtException === 'function') {
-          originalOnUncaughtException(error);
+          // Preserve QUnit as the receiver in case any future hook reads
+          // `this` — current QUnit 2.x reads `config` from closure scope, but
+          // calling via `.call(qunitGlobal, ...)` keeps the wrapper's behavior
+          // identical to the unwrapped path regardless.
+          originalOnUncaughtException.call(qunitGlobal, error);
         }
       };
       qunitGlobal.onUncaughtException = wrappedOnUncaughtException;

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -8,6 +8,7 @@ import {
   setupRenderingTest as emberSetupRenderingTest,
 } from 'ember-qunit';
 import { setupWindowMock } from 'ember-window-mock/test-support';
+import * as QUnit from 'qunit';
 
 import { clearHtmlComponentCache } from '@cardstack/host/lib/html-component';
 import type ResetService from '@cardstack/host/services/reset';
@@ -26,12 +27,20 @@ import { cleanupMonacoEditorModels } from './index';
 const inFlightFetches = new Map<number, string>();
 let nextFetchId = 0;
 
+// Track the most recent failed fetches per test so a "Promise rejected during X"
+// failure (which surfaces the generic browser TypeError "A network error
+// occurred." with no URL) can be correlated with the actual request that blew
+// up. Each entry is `${method} ${url}: ${reason}`; cleared in beforeEach.
+const recentFailedFetches: string[] = [];
+const RECENT_FAILED_FETCHES_LIMIT = 20;
+
 function setupFetchDebugging(hooks: NestedHooks) {
   let originalFetch: typeof globalThis.fetch | undefined;
   let wrappedFetch: typeof globalThis.fetch | undefined;
 
   hooks.beforeEach(function () {
     inFlightFetches.clear();
+    recentFailedFetches.length = 0;
     if (!globalThis.fetch) {
       return;
     }
@@ -44,9 +53,9 @@ function setupFetchDebugging(hooks: NestedHooks) {
       try {
         return await boundFetch(input, init);
       } catch (error) {
-        console.error(
-          `[test-fetch] ${method} ${url} failed: ${formatErrorForLog(error)}`,
-        );
+        let reason = formatErrorForLog(error);
+        console.error(`[test-fetch] ${method} ${url} failed: ${reason}`);
+        rememberFailedFetch(method, url, reason);
         throw error;
       } finally {
         inFlightFetches.delete(id);
@@ -65,10 +74,25 @@ function setupFetchDebugging(hooks: NestedHooks) {
   });
 }
 
+function rememberFailedFetch(method: string, url: string, reason: string) {
+  recentFailedFetches.push(`${method} ${url}: ${reason}`);
+  if (recentFailedFetches.length > RECENT_FAILED_FETCHES_LIMIT) {
+    recentFailedFetches.splice(
+      0,
+      recentFailedFetches.length - RECENT_FAILED_FETCHES_LIMIT,
+    );
+  }
+}
+
 // surface unhandled rejections during tests with full stacks + in-flight URLs
 function setupUnhandledRejectionDiagnostics(hooks: NestedHooks) {
   let handler: ((event: PromiseRejectionEvent) => void) | undefined;
   let target: Window | undefined;
+  let originalOnUncaughtException:
+    | ((error: unknown) => void)
+    | undefined
+    | null;
+  let wrappedOnUncaughtException: ((error: unknown) => void) | undefined;
 
   hooks.beforeEach(function () {
     // Host tests run in the browser; if `window` is missing or doesn't expose
@@ -78,24 +102,45 @@ function setupUnhandledRejectionDiagnostics(hooks: NestedHooks) {
       typeof window.addEventListener === 'function'
         ? window
         : undefined;
-    if (!target) {
-      return;
-    }
-    handler = (event: PromiseRejectionEvent) => {
-      // Observation only — do NOT call event.preventDefault(). QUnit's own
-      // unhandled-rejection handling must still run and fail the test.
-      let inFlightSnapshot = Array.from(inFlightFetches.values());
-      console.error(
-        [
+    if (target) {
+      handler = (event: PromiseRejectionEvent) => {
+        // Observation only — do NOT call event.preventDefault(). QUnit's own
+        // unhandled-rejection handling must still run and fail the test.
+        logRejectionDiagnostics(
           '[test-unhandled-rejection]',
           formatRejectionReason(event.reason),
-          inFlightSnapshot.length
-            ? `in-flight fetches at rejection time (${inFlightSnapshot.length}):\n  ${inFlightSnapshot.join('\n  ')}`
-            : 'in-flight fetches at rejection time: <none>',
-        ].join('\n'),
-      );
+        );
+      };
+      target.addEventListener('unhandledrejection', handler);
+    }
+
+    // Wrap QUnit.onUncaughtException so QUnit-handled rejections (e.g.,
+    // "Promise rejected during X: A network error occurred." — which propagates
+    // via the test's awaited promise chain rather than firing a global
+    // `unhandledrejection` event) also dump in-flight + recently-failed fetch
+    // context. Without this hook, the failure message exposes only the generic
+    // browser TypeError with no URL, making field-playground / code-submode
+    // network-error flakes effectively unattributable.
+    let qunitGlobal = QUnit as unknown as {
+      onUncaughtException?: (error: unknown) => void;
     };
-    target.addEventListener('unhandledrejection', handler);
+    if (qunitGlobal && typeof qunitGlobal === 'object') {
+      originalOnUncaughtException = qunitGlobal.onUncaughtException;
+      wrappedOnUncaughtException = (error: unknown) => {
+        try {
+          logRejectionDiagnostics(
+            '[test-qunit-uncaught]',
+            formatRejectionReason(error),
+          );
+        } catch (_e) {
+          // never let diagnostic logging swallow the original failure
+        }
+        if (typeof originalOnUncaughtException === 'function') {
+          originalOnUncaughtException(error);
+        }
+      };
+      qunitGlobal.onUncaughtException = wrappedOnUncaughtException;
+    }
   });
 
   hooks.afterEach(function () {
@@ -104,7 +149,39 @@ function setupUnhandledRejectionDiagnostics(hooks: NestedHooks) {
     }
     handler = undefined;
     target = undefined;
+
+    let qunitGlobal = QUnit as unknown as {
+      onUncaughtException?: (error: unknown) => void;
+    };
+    if (
+      qunitGlobal &&
+      typeof qunitGlobal === 'object' &&
+      qunitGlobal.onUncaughtException === wrappedOnUncaughtException
+    ) {
+      qunitGlobal.onUncaughtException = originalOnUncaughtException as
+        | ((error: unknown) => void)
+        | undefined;
+    }
+    wrappedOnUncaughtException = undefined;
+    originalOnUncaughtException = undefined;
   });
+}
+
+function logRejectionDiagnostics(prefix: string, formattedReason: string) {
+  let inFlightSnapshot = Array.from(inFlightFetches.values());
+  let recent = recentFailedFetches.slice();
+  console.error(
+    [
+      prefix,
+      formattedReason,
+      inFlightSnapshot.length
+        ? `in-flight fetches at rejection time (${inFlightSnapshot.length}):\n  ${inFlightSnapshot.join('\n  ')}`
+        : 'in-flight fetches at rejection time: <none>',
+      recent.length
+        ? `recent failed fetches this test (${recent.length}):\n  ${recent.join('\n  ')}`
+        : 'recent failed fetches this test: <none>',
+    ].join('\n'),
+  );
 }
 
 function formatRejectionReason(reason: unknown): string {

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -8,7 +8,6 @@ import {
   setupRenderingTest as emberSetupRenderingTest,
 } from 'ember-qunit';
 import { setupWindowMock } from 'ember-window-mock/test-support';
-import * as QUnit from 'qunit';
 
 import { clearHtmlComponentCache } from '@cardstack/host/lib/html-component';
 import type ResetService from '@cardstack/host/services/reset';
@@ -102,6 +101,22 @@ function rememberFailedFetch(
   }
 }
 
+// Resolve the qunit runtime object (the one the qunit package installs on the
+// global) rather than the ES module namespace. Importing `import * as QUnit
+// from 'qunit'` produces a frozen module record where `onUncaughtException`
+// is a getter-only export — assignments throw `TypeError: Cannot set property
+// onUncaughtException of #<Object> which has only a getter`. The runtime
+// global is writable; `suspendGlobalErrorHook` (uncaught-exceptions.ts) reads
+// and reassigns it the same way.
+function getQUnitRuntime():
+  | { onUncaughtException?: (error: unknown) => void }
+  | undefined {
+  let q = (globalThis as { QUnit?: unknown }).QUnit;
+  return q && typeof q === 'object'
+    ? (q as { onUncaughtException?: (error: unknown) => void })
+    : undefined;
+}
+
 // surface unhandled rejections during tests with full stacks + in-flight URLs
 function setupUnhandledRejectionDiagnostics(hooks: NestedHooks) {
   let handler: ((event: PromiseRejectionEvent) => void) | undefined;
@@ -139,10 +154,8 @@ function setupUnhandledRejectionDiagnostics(hooks: NestedHooks) {
     // context. Without this hook, the failure message exposes only the generic
     // browser TypeError with no URL, making field-playground / code-submode
     // network-error flakes effectively unattributable.
-    let qunitGlobal = QUnit as unknown as {
-      onUncaughtException?: (error: unknown) => void;
-    };
-    if (qunitGlobal && typeof qunitGlobal === 'object') {
+    let qunitGlobal = getQUnitRuntime();
+    if (qunitGlobal) {
       originalOnUncaughtException = qunitGlobal.onUncaughtException;
       wrappedOnUncaughtException = (error: unknown) => {
         try {
@@ -172,12 +185,9 @@ function setupUnhandledRejectionDiagnostics(hooks: NestedHooks) {
     handler = undefined;
     target = undefined;
 
-    let qunitGlobal = QUnit as unknown as {
-      onUncaughtException?: (error: unknown) => void;
-    };
+    let qunitGlobal = getQUnitRuntime();
     if (
       qunitGlobal &&
-      typeof qunitGlobal === 'object' &&
       qunitGlobal.onUncaughtException === wrappedOnUncaughtException
     ) {
       qunitGlobal.onUncaughtException = originalOnUncaughtException as


### PR DESCRIPTION
## Summary

`Acceptance | code-submode | field playground > single realm: can preview compound field instance` intermittently fails on CI with:

```
Promise rejected during "can preview compound field instance": A network error occurred.
```

Example failing run: https://github.com/cardstack/boxel/actions/runs/25416793410/job/74551604180?pr=4668

The failure dump shows none of the fetch URLs that were in flight when the rejection fired — only the generic browser TypeError surfaces — because the existing `unhandledrejection` diagnostic listener never sees rejections that propagate through QUnit's awaited-test path.

## Changes

### 1. Settle the markdown preview

`selectFormat('markdown')` mounts `MarkdownPreview` → hidden `CardRenderer` → `DefaultMarkdownFallbackTemplate`. The fallback uses a `MutationObserver` that schedules `afterRender` capture passes; without an explicit `settled()` the test can finish before that chain quiesces. The same defensive `settled()` is added to `openFileInPlayground` after `togglePlaygroundPanel()`, since the spec-search subscriptions kicked off there don't all register test waiters.

### 2. Diagnostic: log fetches on QUnit-handled rejections

`setupUnhandledRejectionDiagnostics` now also wraps `QUnit.onUncaughtException`, so rejections that come through QUnit's awaited-test path (not just `window.unhandledrejection`) dump:
- the formatted rejection reason + stack
- in-flight fetches at rejection time
- the last 20 failed fetches in the current test (`recentFailedFetches`) — this surfaces the actual URL that produced the network `TypeError` so future flakes are attributable.

If the `settled()` doesn't eliminate the flake, the next failure log will name the exact request.

## Test plan

- [ ] CI green
- [ ] If the test flakes again, the failure log includes a `[test-qunit-uncaught]` block naming the failing fetch URL