### PR TITLE
Move promoted field tests from boxel-catalog and enrich base fields

### DIFF
--- a/packages/base/date-range-field.gts
+++ b/packages/base/date-range-field.gts
@@ -12,7 +12,8 @@ import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
 import CalendarIcon from '@cardstack/boxel-icons/calendar';
-import { cn, eq } from '@cardstack/boxel-ui/helpers';
+import CalendarStatsIcon from '@cardstack/boxel-icons/calendar-stats';
+import { eq, formatDateTime } from '@cardstack/boxel-ui/helpers';
 import { formatDateRangeForMarkdown } from './markdown-helpers';
 import { BusinessDays } from './components/business-days';
 
@@ -136,49 +137,58 @@ export default class DateRangeField extends FieldDef {
 
   static edit = Edit;
   static atom = class Atom extends Component<typeof this> {
-    get hasNoDateInfo() {
-      return !this.args.model.start && !this.args.model.end;
-    }
+    get displayValue() {
+      const start = this.args.model?.start;
+      const end = this.args.model?.end;
 
-    get formatted() {
-      return getFormattedDate(this.args.model as DateRange);
-    }
+      if (!start && !end) return 'No date range set';
 
-    get dateIcon() {
-      return this.args.model.constructor?.icon;
+      try {
+        const formatDate = (dateValue: string | Date) => {
+          const date =
+            typeof dateValue === 'string' ? new Date(dateValue) : dateValue;
+          return formatDateTime(date, {
+            preset: 'short',
+            fallback: String(dateValue),
+          });
+        };
+
+        if (!start) return `Until ${formatDate(end!)}`;
+        if (!end) return `From ${formatDate(start)}`;
+
+        return `${formatDate(start)} - ${formatDate(end)}`;
+      } catch {
+        return `${start} - ${end}`;
+      }
     }
 
     <template>
-      <time class='date-info'>
-        {{#if this.dateIcon}}
-          <this.dateIcon class='icon' />
-        {{/if}}
-        <div class={{cn 'text' no-date-info=this.hasNoDateInfo}}>
-          {{this.formatted}}
-        </div>
-      </time>
+      <span class='date-range-atom' data-test-date-range-atom>
+        <CalendarStatsIcon class='range-icon' />
+        <span class='range-value'>{{this.displayValue}}</span>
+      </span>
+
       <style scoped>
-        .date-info {
-          --date-icon-size: 14px;
+        .date-range-atom {
           display: inline-flex;
           align-items: center;
-          font-size: calc(var(--date-icon-size) * 0.9);
-          gap: var(--boxel-sp-xxs);
-          white-space: nowrap;
-          -webkit-line-clamp: 1;
-          overflow: hidden;
-          text-overflow: ellipsis;
+          gap: 0.375rem;
+          padding: 0.25rem 0.5rem;
+          background: var(--primary, #3b82f6);
+          color: var(--primary-foreground, #ffffff);
+          border-radius: var(--radius, 0.375rem);
+          font-size: 0.8125rem;
           font-weight: 500;
         }
-        .icon {
-          width: var(--date-icon-size);
-          height: var(--date-icon-size);
+
+        .range-icon {
+          width: 0.875rem;
+          height: 0.875rem;
+          flex-shrink: 0;
         }
-        .text {
-          color: var(--boxel-600);
-        }
-        .text.no-date-info {
-          color: var(--boxel-600);
+
+        .range-value {
+          white-space: nowrap;
         }
       </style>
     </template>
@@ -193,12 +203,50 @@ export default class DateRangeField extends FieldDef {
       return this.config?.presentation ?? 'standard';
     }
 
+    get displayValue() {
+      const start = this.args.model?.start;
+      const end = this.args.model?.end;
+
+      if (!start && !end) return 'No date range set';
+
+      try {
+        const format = (value: Date) =>
+          formatDateTime(value, {
+            preset: 'long',
+            fallback: 'Invalid date',
+          });
+
+        if (!start) return `Until ${format(end!)}`;
+        if (!end) return `From ${format(start)}`;
+
+        return `${format(start)} → ${format(end)}`;
+      } catch {
+        return 'Invalid date range';
+      }
+    }
+
     <template>
       {{#if (eq this.presentationMode 'businessDays')}}
         <BusinessDays @model={{@model}} @config={{this.config}} />
       {{else}}
-        <@fields.start /> - <@fields.end />
+        <div class='date-range-embedded' data-test-date-range-embedded>
+          <span class='range-value'>{{this.displayValue}}</span>
+        </div>
       {{/if}}
+
+      <style scoped>
+        .date-range-embedded {
+          display: flex;
+          align-items: center;
+          padding: 0.5rem;
+          font-size: 0.875rem;
+          color: var(--foreground, #1a1a1a);
+        }
+
+        .range-value {
+          font-weight: 500;
+        }
+      </style>
     </template>
   };
 

--- a/packages/base/number.gts
+++ b/packages/base/number.gts
@@ -7,10 +7,10 @@ import {
   deserializeForUI,
   serializeForUI,
 } from './card-api';
-import { TextInputValidator } from './text-input-validator';
 import { NumberSerializer } from '@cardstack/runtime-common';
 import { getFormattedDisplayValue } from './number/util/index';
 import HashIcon from '@cardstack/boxel-icons/hash';
+import { TextInputValidator } from './text-input-validator';
 
 import { StatEmbedded, StatAtom } from './number/components/stat';
 import { ScoreEmbedded, ScoreAtom } from './number/components/score';
@@ -225,7 +225,10 @@ export default class NumberField extends BaseNumberField {
         @onInput={{this.textInputValidator.onInput}}
         @errorMessage={{this.textInputValidator.errorMessage}}
         @state={{if this.textInputValidator.isInvalid 'invalid' 'none'}}
+        @min={{numberOption @configuration 'min'}}
+        @max={{numberOption @configuration 'max'}}
         @disabled={{not @canEdit}}
+        data-test-number-input
       />
     </template>
 
@@ -237,4 +240,16 @@ export default class NumberField extends BaseNumberField {
       NumberSerializer.validate,
     );
   };
+}
+
+function numberOption(
+  configuration: unknown,
+  key: 'min' | 'max',
+): number | undefined {
+  let config = configuration as NumberFieldConfiguration | undefined;
+  let raw = (config?.options as { min?: unknown; max?: unknown } | undefined)?.[
+    key
+  ];
+  let num = typeof raw === 'number' ? raw : Number(raw);
+  return Number.isFinite(num) ? num : undefined;
 }

--- a/packages/host/tests/helpers/base-realm.ts
+++ b/packages/host/tests/helpers/base-realm.ts
@@ -8,8 +8,18 @@ import type * as BooleanFieldModule from 'https://cardstack.com/base/boolean';
 import type * as CardAPIModule from 'https://cardstack.com/base/card-api';
 import type * as CardsGridModule from 'https://cardstack.com/base/cards-grid';
 import type * as CodeRefModule from 'https://cardstack.com/base/code-ref';
+import type * as ColorFieldModule from 'https://cardstack.com/base/color';
 import type * as DateFieldModule from 'https://cardstack.com/base/date';
+import type * as DayFieldModule from 'https://cardstack.com/base/date/day';
+import type * as MonthFieldModule from 'https://cardstack.com/base/date/month';
+import type * as MonthDayFieldModule from 'https://cardstack.com/base/date/month-day';
+import type * as MonthYearFieldModule from 'https://cardstack.com/base/date/month-year';
+import type * as QuarterFieldModule from 'https://cardstack.com/base/date/quarter';
+import type * as WeekFieldModule from 'https://cardstack.com/base/date/week';
+import type * as YearFieldModule from 'https://cardstack.com/base/date/year';
+import type * as DateRangeFieldModule from 'https://cardstack.com/base/date-range-field';
 import type * as DateTimeFieldModule from 'https://cardstack.com/base/datetime';
+import type * as DatetimeStampFieldModule from 'https://cardstack.com/base/datetime-stamp';
 import type * as EmailFieldModule from 'https://cardstack.com/base/email';
 import type * as EnumModule from 'https://cardstack.com/base/enum';
 import type * as EthereumAddressModule from 'https://cardstack.com/base/ethereum-address';
@@ -23,6 +33,10 @@ import type * as SkillModule from 'https://cardstack.com/base/skill';
 import type * as StringFieldModule from 'https://cardstack.com/base/string';
 import type * as SystemCardModule from 'https://cardstack.com/base/system-card';
 import type * as TextAreaFieldModule from 'https://cardstack.com/base/text-area';
+import type * as TimeFieldModule from 'https://cardstack.com/base/time';
+import type * as DurationFieldModule from 'https://cardstack.com/base/time/duration';
+import type * as RelativeTimeFieldModule from 'https://cardstack.com/base/time/relative-time';
+import type * as TimeRangeFieldModule from 'https://cardstack.com/base/time/time-range';
 
 type StringField = (typeof StringFieldModule)['default'];
 let StringField: StringField;
@@ -35,6 +49,48 @@ let DateField: DateField;
 
 type DateTimeField = (typeof DateTimeFieldModule)['default'];
 let DateTimeField: DateTimeField;
+
+type ColorField = (typeof ColorFieldModule)['default'];
+let ColorField: ColorField;
+
+type DatetimeStampField = (typeof DatetimeStampFieldModule)['default'];
+let DatetimeStampField: DatetimeStampField;
+
+type DateRangeField = (typeof DateRangeFieldModule)['default'];
+let DateRangeField: DateRangeField;
+
+type DayField = (typeof DayFieldModule)['default'];
+let DayField: DayField;
+
+type MonthField = (typeof MonthFieldModule)['default'];
+let MonthField: MonthField;
+
+type MonthDayField = (typeof MonthDayFieldModule)['default'];
+let MonthDayField: MonthDayField;
+
+type MonthYearField = (typeof MonthYearFieldModule)['default'];
+let MonthYearField: MonthYearField;
+
+type YearField = (typeof YearFieldModule)['default'];
+let YearField: YearField;
+
+type WeekField = (typeof WeekFieldModule)['default'];
+let WeekField: WeekField;
+
+type QuarterField = (typeof QuarterFieldModule)['default'];
+let QuarterField: QuarterField;
+
+type TimeField = (typeof TimeFieldModule)['default'];
+let TimeField: TimeField;
+
+type TimeRangeField = (typeof TimeRangeFieldModule)['default'];
+let TimeRangeField: TimeRangeField;
+
+type DurationField = (typeof DurationFieldModule)['default'];
+let DurationField: DurationField;
+
+type RelativeTimeField = (typeof RelativeTimeFieldModule)['default'];
+let RelativeTimeField: RelativeTimeField;
 
 type EmailField = (typeof EmailFieldModule)['default'];
 let EmailField: EmailField;
@@ -138,6 +194,78 @@ async function initialize() {
 
   DateTimeField = (
     await loader.import<typeof DateTimeFieldModule>(`${baseRealm.url}datetime`)
+  ).default;
+
+  ColorField = (
+    await loader.import<typeof ColorFieldModule>(`${baseRealm.url}color`)
+  ).default;
+
+  DatetimeStampField = (
+    await loader.import<typeof DatetimeStampFieldModule>(
+      `${baseRealm.url}datetime-stamp`,
+    )
+  ).default;
+
+  DateRangeField = (
+    await loader.import<typeof DateRangeFieldModule>(
+      `${baseRealm.url}date-range-field`,
+    )
+  ).default;
+
+  DayField = (
+    await loader.import<typeof DayFieldModule>(`${baseRealm.url}date/day`)
+  ).default;
+
+  MonthField = (
+    await loader.import<typeof MonthFieldModule>(`${baseRealm.url}date/month`)
+  ).default;
+
+  MonthDayField = (
+    await loader.import<typeof MonthDayFieldModule>(
+      `${baseRealm.url}date/month-day`,
+    )
+  ).default;
+
+  MonthYearField = (
+    await loader.import<typeof MonthYearFieldModule>(
+      `${baseRealm.url}date/month-year`,
+    )
+  ).default;
+
+  YearField = (
+    await loader.import<typeof YearFieldModule>(`${baseRealm.url}date/year`)
+  ).default;
+
+  WeekField = (
+    await loader.import<typeof WeekFieldModule>(`${baseRealm.url}date/week`)
+  ).default;
+
+  QuarterField = (
+    await loader.import<typeof QuarterFieldModule>(
+      `${baseRealm.url}date/quarter`,
+    )
+  ).default;
+
+  TimeField = (
+    await loader.import<typeof TimeFieldModule>(`${baseRealm.url}time`)
+  ).default;
+
+  TimeRangeField = (
+    await loader.import<typeof TimeRangeFieldModule>(
+      `${baseRealm.url}time/time-range`,
+    )
+  ).default;
+
+  DurationField = (
+    await loader.import<typeof DurationFieldModule>(
+      `${baseRealm.url}time/duration`,
+    )
+  ).default;
+
+  RelativeTimeField = (
+    await loader.import<typeof RelativeTimeFieldModule>(
+      `${baseRealm.url}time/relative-time`,
+    )
   ).default;
 
   EmailField = (
@@ -270,6 +398,20 @@ export {
   NumberField,
   DateField,
   DateTimeField,
+  ColorField,
+  DatetimeStampField,
+  DateRangeField,
+  DayField,
+  MonthField,
+  MonthDayField,
+  MonthYearField,
+  YearField,
+  WeekField,
+  QuarterField,
+  TimeField,
+  TimeRangeField,
+  DurationField,
+  RelativeTimeField,
   EmailField,
   Base64ImageField,
   CodeRefField,

--- a/packages/host/tests/helpers/field-test-helpers.gts
+++ b/packages/host/tests/helpers/field-test-helpers.gts
@@ -1,0 +1,54 @@
+import { getService } from '@universal-ember/test-support';
+
+import type { Loader } from '@cardstack/runtime-common';
+
+import { field, contains, CardDef, Component } from './base-realm';
+import { renderCard } from './render-component';
+
+export type FieldFormat = 'embedded' | 'atom' | 'edit' | 'fitted';
+
+export function getLoader(): Loader {
+  return getService('loader-service').loader;
+}
+
+export async function renderField(
+  FieldClass: any,
+  value: unknown,
+  format: FieldFormat = 'embedded',
+) {
+  return renderConfiguredField(FieldClass, value, {}, format);
+}
+
+export async function renderConfiguredField(
+  FieldClass: any,
+  value: unknown,
+  configuration: Record<string, unknown> = {},
+  fieldFormat: FieldFormat = 'embedded',
+) {
+  const loader = getLoader();
+  const fieldType = FieldClass;
+
+  class TestCard extends CardDef {
+    @field sample = contains(fieldType, { configuration });
+
+    static isolated = class Isolated extends Component<typeof this> {
+      format: FieldFormat = fieldFormat;
+
+      <template>
+        <div data-test-field-container>
+          <@fields.sample @format={{this.format}} />
+        </div>
+      </template>
+    };
+  }
+
+  let card = new TestCard({ sample: value });
+  await renderCard(loader, card, 'isolated');
+}
+
+export function buildField<T>(
+  FieldClass: new (attrs: Record<string, unknown>) => T,
+  attrs: Record<string, unknown> = {},
+): T {
+  return new FieldClass(attrs);
+}

--- a/packages/host/tests/integration/color-field-test.gts
+++ b/packages/host/tests/integration/color-field-test.gts
@@ -1,0 +1,508 @@
+import { settled } from '@ember/test-helpers';
+
+import { module, test } from 'qunit';
+
+import { setupBaseRealm, ColorField } from '../helpers/base-realm';
+import { renderConfiguredField } from '../helpers/field-test-helpers';
+import { setupRenderingTest } from '../helpers/setup';
+
+module('Integration | color field configuration', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+
+  // ============================================
+  // Valid Variant Configuration Tests
+  // ============================================
+
+  test('standard variant renders color picker', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      { variant: 'standard' },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .color-picker')
+      .exists('standard variant renders color picker');
+  });
+
+  test('swatches-picker variant renders color palette', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      { variant: 'swatches-picker' },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .color-palette-group')
+      .exists('swatches-picker variant renders color palette');
+  });
+
+  test('slider variant renders slider controls', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      { variant: 'slider' },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .slider-controls-editor')
+      .exists('slider variant renders slider controls');
+  });
+
+  test('advanced variant renders advanced editor', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      { variant: 'advanced' },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .advanced-color-editor')
+      .exists('advanced variant renders advanced editor');
+  });
+
+  test('wheel variant renders color wheel', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      { variant: 'wheel' },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .color-wheel-editor')
+      .exists('wheel variant renders color wheel');
+  });
+
+  test('missing variant defaults to standard', async function (assert) {
+    await renderConfiguredField(ColorField, '#3b82f6', {}, 'edit');
+
+    assert
+      .dom('[data-test-field-container] .color-picker')
+      .exists('missing variant defaults to standard');
+  });
+
+  // ============================================
+  // Invalid Variant Configuration Tests
+  // ============================================
+
+  test('invalid variant value falls back to standard variant', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      { variant: 'not-a-real-variant' },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .color-picker')
+      .exists('invalid variant falls back to standard');
+    assert
+      .dom('[data-test-field-container] .advanced-color-editor')
+      .doesNotExist('advanced variant is not rendered');
+  });
+
+  test('null variant value defaults to standard variant', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      { variant: null },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .color-picker')
+      .exists('null variant defaults to standard');
+  });
+
+  // ============================================
+  // Valid Options Configuration Tests
+  // ============================================
+
+  test('showRecent option displays recent colors addon', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      {
+        variant: 'standard',
+        options: { showRecent: true },
+      },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .recent-colors-addon')
+      .exists('showRecent option displays recent colors addon');
+  });
+
+  test('showContrastChecker option displays contrast checker addon', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      {
+        variant: 'standard',
+        options: { showContrastChecker: true },
+      },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .contrast-checker-addon')
+      .exists('showContrastChecker option displays contrast checker addon');
+  });
+
+  test('showRecent defaults to false', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      { variant: 'standard' },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .recent-colors-addon')
+      .doesNotExist('showRecent defaults to false');
+  });
+
+  test('showContrastChecker defaults to false', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      { variant: 'standard' },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .contrast-checker-addon')
+      .doesNotExist('showContrastChecker defaults to false');
+  });
+
+  test('maxRecentHistory option is respected', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      {
+        variant: 'standard',
+        options: {
+          showRecent: true,
+          maxRecentHistory: 5,
+        },
+      },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .recent-colors-addon')
+      .exists('recent colors addon is shown with custom maxRecentHistory');
+  });
+
+  test('swatches-picker variant supports paletteColors option', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      {
+        variant: 'swatches-picker',
+        options: {
+          paletteColors: ['#ff0000', '#00ff00', '#0000ff'],
+        },
+      },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .color-palette-group')
+      .exists('swatches-picker variant renders with palette colors');
+  });
+
+  test('base options are ignored when variant is advanced', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      {
+        variant: 'advanced',
+        options: {
+          showRecent: true,
+          showContrastChecker: true,
+          maxRecentHistory: 5,
+        },
+      },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .advanced-color-editor')
+      .exists('advanced variant renders');
+    assert
+      .dom('[data-test-field-container] .recent-colors-addon')
+      .doesNotExist('base options are ignored for advanced variant');
+    assert
+      .dom('[data-test-field-container] .contrast-checker-addon')
+      .doesNotExist('base options are ignored for advanced variant');
+  });
+
+  // ============================================
+  // Invalid Options Configuration Tests
+  // ============================================
+
+  test('invalid option values are handled gracefully', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      {
+        variant: 'standard',
+        options: {
+          showRecent: true,
+          maxRecentHistory: 'ten' as any, // invalid type
+          unknownProperty: 'should be ignored',
+        } as any,
+      },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .color-picker')
+      .exists('renders with invalid option values');
+    assert
+      .dom('[data-test-field-container] .recent-colors-addon')
+      .exists('addon still renders despite invalid maxRecentHistory');
+  });
+
+  test('null or undefined options are handled', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      {
+        variant: 'standard',
+        options: null,
+      },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .color-picker')
+      .exists('renders with null options');
+  });
+
+  // ============================================
+  // Valid Format Configuration Tests
+  // ============================================
+
+  test('advanced variant renders with configured default format', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      'rgb(59, 130, 246)',
+      {
+        variant: 'advanced',
+        options: { defaultFormat: 'rgb' },
+      },
+      'edit',
+    );
+
+    await settled();
+
+    assert
+      .dom('[data-test-field-container] .advanced-color-editor')
+      .exists('advanced variant renders');
+    assert
+      .dom('[data-test-field-container] .color-value-input')
+      .exists('RGB input section is visible');
+  });
+
+  test('advanced variant parses CSS color names', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      'blue',
+      {
+        variant: 'advanced',
+        options: { defaultFormat: 'hex' },
+      },
+      'edit',
+    );
+
+    await settled();
+
+    assert
+      .dom('[data-test-field-container] .advanced-color-editor')
+      .exists('CSS color name is parsed and component renders');
+  });
+
+  test('advanced variant parses RGB values', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      'rgb(255, 0, 0)',
+      {
+        variant: 'advanced',
+        options: { defaultFormat: 'hsl' },
+      },
+      'edit',
+    );
+
+    await settled();
+
+    assert
+      .dom('[data-test-field-container] .advanced-color-editor')
+      .exists('RGB value is parsed and component renders');
+  });
+
+  test('advanced variant parses hex values', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#ff0000',
+      {
+        variant: 'advanced',
+        options: { defaultFormat: 'rgb' },
+      },
+      'edit',
+    );
+
+    await settled();
+
+    assert
+      .dom('[data-test-field-container] .advanced-color-editor')
+      .exists('hex value is parsed and component renders');
+  });
+
+  test('slider variant displays HSL format when configured', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      {
+        variant: 'slider',
+        options: { defaultFormat: 'hsl' },
+      },
+      'edit',
+    );
+
+    await settled();
+
+    const hslSliders = document.querySelectorAll(
+      '[data-test-field-container] .slider-label.hue, [data-test-field-container] .slider-label.saturation, [data-test-field-container] .slider-label.lightness',
+    );
+
+    assert.ok(
+      hslSliders.length >= 3,
+      'slider variant with HSL format displays HSL sliders',
+    );
+  });
+
+  test('slider variant displays RGB format when configured', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      {
+        variant: 'slider',
+        options: { defaultFormat: 'rgb' },
+      },
+      'edit',
+    );
+
+    await settled();
+
+    const rgbSliders = document.querySelectorAll(
+      '[data-test-field-container] .slider-label.red, [data-test-field-container] .slider-label.green, [data-test-field-container] .slider-label.blue',
+    );
+
+    assert.ok(
+      rgbSliders.length >= 3,
+      'slider variant with RGB format displays RGB sliders',
+    );
+  });
+
+  test('wheel variant displays with configured format', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      {
+        variant: 'wheel',
+        options: { defaultFormat: 'rgb' },
+      },
+      'edit',
+    );
+
+    await settled();
+
+    assert
+      .dom('[data-test-field-container] .color-wheel-editor')
+      .exists('wheel variant renders with RGB format');
+  });
+
+  // ============================================
+  // Invalid Format Configuration Tests
+  // ============================================
+
+  test('invalid defaultFormat falls back to default', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      '#3b82f6',
+      {
+        variant: 'advanced',
+        options: { defaultFormat: 'invalid-format' as any },
+      },
+      'edit',
+    );
+
+    await settled();
+
+    assert
+      .dom('[data-test-field-container] .advanced-color-editor')
+      .exists('editor renders with invalid defaultFormat');
+  });
+
+  // ============================================
+  // Invalid Color Value Handling Tests
+  // ============================================
+
+  test('invalid color values are handled gracefully', async function (assert) {
+    const invalidColors = [
+      null,
+      '',
+      '   ',
+      'not-a-color',
+      '#gggggg',
+      'rgb(999, 999, 999)',
+      '#ff',
+    ];
+
+    for (const color of invalidColors) {
+      await renderConfiguredField(
+        ColorField,
+        color,
+        { variant: 'standard' },
+        'edit',
+      );
+
+      assert
+        .dom('[data-test-field-container] .color-picker')
+        .exists(`color value "${color}" renders without error`);
+    }
+  });
+
+  // ============================================
+  // Edge Cases and Boundary Conditions
+  // ============================================
+
+  test('multiple invalid values are handled gracefully', async function (assert) {
+    await renderConfiguredField(
+      ColorField,
+      'invalid-color',
+      {
+        variant: 'not-a-variant',
+        options: {
+          showRecent: 'yes' as any,
+          maxRecentHistory: 'ten' as any,
+          unknownProperty: 'ignored',
+        } as any,
+      },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] .color-picker')
+      .exists('renders despite multiple invalid values');
+  });
+});

--- a/packages/host/tests/integration/date-time-fields-test.gts
+++ b/packages/host/tests/integration/date-time-fields-test.gts
@@ -1,0 +1,507 @@
+import { click } from '@ember/test-helpers';
+
+import { module, test } from 'qunit';
+
+import {
+  setupBaseRealm,
+  DateField,
+  DateTimeField,
+  DatetimeStampField,
+  DayField,
+  DateRangeField,
+  MonthDayField,
+  YearField,
+  MonthField,
+  MonthYearField,
+  WeekField,
+  QuarterField,
+  TimeField,
+  TimeRangeField,
+  DurationField,
+  RelativeTimeField,
+} from '../helpers/base-realm';
+import {
+  renderField,
+  renderConfiguredField,
+  buildField,
+} from '../helpers/field-test-helpers';
+import { setupRenderingTest } from '../helpers/setup';
+
+module('Integration | date-time fields', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+
+  test('core date & time fields render their embedded views', async function (assert) {
+    await renderField(DateField, '2024-05-01');
+    assert.dom('[data-test-date-embedded]').exists();
+    assert
+      .dom('[data-test-date-embedded]')
+      .doesNotContainText('No date set', 'date value is displayed');
+
+    await renderField(TimeField, buildField(TimeField, { value: '14:00' }));
+    assert
+      .dom('[data-test-time-embedded]')
+      .hasTextContaining('2:00 PM', 'time value is formatted to 12-hour clock');
+
+    await renderField(DateTimeField, '2024-05-01T14:30:00');
+    assert.dom('[data-test-datetime-embedded]').exists();
+    assert
+      .dom('[data-test-datetime-embedded]')
+      .doesNotContainText('No date/time set', 'datetime value is displayed');
+  });
+
+  test('range, duration, and relative fields show formatted summaries', async function (assert) {
+    await renderField(
+      DateRangeField,
+      buildField(DateRangeField, {
+        start: '2024-05-01',
+        end: '2024-05-10',
+      }),
+    );
+    assert
+      .dom('[data-test-date-range-embedded]')
+      .hasText('May 1, 2024 → May 10, 2024');
+
+    await renderField(
+      TimeRangeField,
+      buildField(TimeRangeField, {
+        start: buildField(TimeField, { value: '09:00' }),
+        end: buildField(TimeField, { value: '17:00' }),
+      }),
+    );
+    assert.dom('[data-test-time-range-embedded]').hasText('09:00 → 17:00');
+
+    await renderField(
+      DurationField,
+      buildField(DurationField, {
+        hours: 1,
+        minutes: 30,
+        seconds: 0,
+      }),
+    );
+    assert
+      .dom('[data-test-duration-embedded]')
+      .hasText('1h 30m', 'duration renders in compact notation');
+
+    await renderField(
+      RelativeTimeField,
+      buildField(RelativeTimeField, { amount: 3, unit: 'hours' }),
+    );
+    assert.dom('[data-test-relative-time-embedded]').hasText('In 3 hours');
+  });
+
+  test('partial calendar fields render friendly labels', async function (assert) {
+    await renderField(
+      MonthDayField,
+      buildField(MonthDayField, { month: '05', day: '15' }),
+    );
+    assert
+      .dom('[data-test-month-day-embedded]')
+      .hasText('May 15', 'month/day is spelled out');
+
+    await renderField(YearField, buildField(YearField, { value: 2025 }));
+    assert.dom('[data-test-year-embedded]').hasText('2025');
+
+    await renderField(MonthField, buildField(MonthField, { value: 5 }));
+    assert.dom('[data-test-month-embedded]').hasText('May');
+
+    await renderField(
+      MonthYearField,
+      buildField(MonthYearField, { value: '2025-05' }),
+    );
+    assert.dom('[data-test-month-year-embedded]').hasText('May 2025');
+
+    await renderField(WeekField, buildField(WeekField, { value: '2025-W20' }));
+    assert.dom('[data-test-week-embedded]').hasText('week 20, 2025');
+
+    await renderField(
+      QuarterField,
+      buildField(QuarterField, { quarter: 2, year: 2025 }),
+    );
+    assert.dom('[data-test-quarter-embedded]').hasText('Q2 2025');
+  });
+
+  test('presentation modes render their specialized components', async function (assert) {
+    // DateTimeField presentations
+    await renderConfiguredField(DateTimeField, '2025-01-01T00:00:00Z', {
+      presentation: 'countdown',
+      countdownOptions: { label: 'Launch', showControls: true },
+    });
+    assert.dom('[data-test-countdown]').exists();
+
+    await renderConfiguredField(DateTimeField, '2024-01-01T00:00:00Z', {
+      presentation: 'timeAgo',
+      timeAgoOptions: { eventLabel: 'Last Activity', updateInterval: 60000 },
+    });
+    assert.dom('[data-test-relative-time]').exists();
+
+    await renderConfiguredField(DateTimeField, '2024-06-01T10:00:00Z', {
+      presentation: 'timeline',
+      timelineOptions: { eventName: 'Order Placed', status: 'complete' },
+    });
+    assert.dom('[data-test-timeline-event]').exists();
+
+    await renderConfiguredField(DateTimeField, '2025-06-01T10:00:00Z', {
+      presentation: 'expirationWarning',
+      expirationOptions: { itemName: 'API Token' },
+    });
+    assert.dom('[data-test-expiration-warning]').exists();
+
+    // DateField presentation: age
+    await renderConfiguredField(DateField, '1990-05-01', {
+      presentation: 'age',
+      ageOptions: { showNextBirthday: true },
+    });
+    assert.dom('[data-test-age-calculator]').exists();
+
+    // DateRangeField presentation: businessDays (needs instance)
+    await renderConfiguredField(
+      DateRangeField,
+      buildField(DateRangeField, {
+        start: '2024-05-01',
+        end: '2024-05-10',
+      }),
+      { presentation: 'businessDays' },
+    );
+    assert.dom('[data-test-business-days]').exists();
+
+    // TimeField presentation: timeSlots (needs instance)
+    await renderConfiguredField(
+      TimeField,
+      buildField(TimeField, {
+        value: '09:00',
+      }),
+      {
+        presentation: 'timeSlots',
+        timeSlotsOptions: { availableSlots: ['09:00', '10:00'] },
+      },
+    );
+    assert.dom('[data-test-time-slots]').exists();
+  });
+
+  test('missing values render placeholders in embedded and atom modes', async function (assert) {
+    await renderField(DateField, undefined);
+    assert.dom('[data-test-date-embedded]').hasText('No date set');
+
+    await renderField(DateField, undefined, 'atom');
+    assert.dom('[data-test-date-atom]').hasTextContaining('No date');
+
+    await renderField(TimeField, buildField(TimeField, {}));
+    assert.dom('[data-test-time-embedded]').hasText('No time set');
+
+    await renderField(TimeField, buildField(TimeField, {}), 'atom');
+    assert.dom('[data-test-time-atom]').hasTextContaining('No time');
+
+    await renderField(DateTimeField, undefined);
+    assert
+      .dom('[data-test-datetime-embedded]')
+      .hasTextContaining('No date/time set');
+
+    await renderField(DateTimeField, undefined, 'atom');
+    assert.dom('[data-test-datetime-atom]').hasTextContaining('No date/time');
+  });
+
+  test('datetime supports custom format and invalid fallback', async function (assert) {
+    await renderConfiguredField(DateTimeField, '2024-05-01T14:30:00', {
+      presentation: 'standard',
+      format: 'YYYY-MM-DD HH:mm',
+    });
+    assert
+      .dom('[data-test-datetime-embedded]')
+      .hasTextContaining('2024-05-01 14:30');
+
+    await renderConfiguredField(DateTimeField, 'not-a-date', {
+      presentation: 'standard',
+    });
+    assert.dom('[data-test-datetime-embedded]').hasTextContaining('Invalid');
+  });
+
+  test('date field supports preset and custom format', async function (assert) {
+    await renderConfiguredField(DateField, '2024-05-01', {
+      presentation: 'standard',
+      format: 'YYYY/MM/DD',
+    });
+    assert.dom('[data-test-date-embedded]').hasText('2024/05/01');
+
+    await renderConfiguredField(DateField, '2024-05-01', {
+      presentation: 'standard',
+      preset: 'short',
+    });
+    assert.dom('[data-test-date-embedded]').hasText('5/1/24');
+  });
+
+  test('time formatting respects hourCycle/timeStyle options', async function (assert) {
+    await renderConfiguredField(
+      TimeField,
+      buildField(TimeField, { value: '14:00' }),
+      {
+        presentation: 'standard',
+        hourCycle: 'h24',
+        timeStyle: 'short',
+      },
+    );
+    assert.dom('[data-test-time-embedded]').hasTextContaining('14');
+    assert.dom('[data-test-time-embedded]').doesNotContainText('PM');
+  });
+
+  test('open-ended ranges render friendly phrases (date/time ranges)', async function (assert) {
+    await renderField(
+      DateRangeField,
+      buildField(DateRangeField, { start: '2024-05-01' }),
+    );
+    assert.dom('[data-test-date-range-embedded]').hasText('From May 1, 2024');
+
+    await renderField(
+      DateRangeField,
+      buildField(DateRangeField, { end: '2024-05-10' }),
+    );
+    assert.dom('[data-test-date-range-embedded]').hasText('Until May 10, 2024');
+
+    await renderField(DateRangeField, buildField(DateRangeField, {}));
+    assert.dom('[data-test-date-range-embedded]').hasText('No date range set');
+
+    await renderField(
+      TimeRangeField,
+      buildField(TimeRangeField, {
+        start: buildField(TimeField, { value: '09:00' }),
+      }),
+    );
+    assert.dom('[data-test-time-range-embedded]').hasText('From 09:00');
+
+    await renderField(
+      TimeRangeField,
+      buildField(TimeRangeField, {
+        end: buildField(TimeField, { value: '17:00' }),
+      }),
+    );
+    assert.dom('[data-test-time-range-embedded]').hasText('Until 17:00');
+
+    await renderField(TimeRangeField, buildField(TimeRangeField, {}));
+    assert.dom('[data-test-time-range-embedded]').hasText('No time range set');
+  });
+
+  test('atom mode renders compact badges', async function (assert) {
+    await renderField(
+      DateRangeField,
+      buildField(DateRangeField, {
+        start: '2024-05-01',
+        end: '2024-05-10',
+      }),
+      'atom',
+    );
+    assert
+      .dom('[data-test-date-range-atom]')
+      .hasTextContaining('5/1/24 - 5/10/24');
+
+    await renderField(
+      DurationField,
+      buildField(DurationField, {
+        hours: 1,
+        minutes: 5,
+        seconds: 0,
+      }),
+      'atom',
+    );
+    assert.dom('[data-test-duration-atom]').hasText('1h 5m');
+
+    await renderField(
+      MonthYearField,
+      buildField(MonthYearField, {
+        value: '2025-05',
+      }),
+      'atom',
+    );
+    assert.dom('[data-test-month-year-atom]').hasTextContaining('May 2025');
+
+    await renderField(WeekField, buildField(WeekField, {}), 'atom');
+    assert.dom('[data-test-week-atom]').hasTextContaining('No week');
+
+    await renderField(MonthField, buildField(MonthField, {}), 'atom');
+    assert.dom('[data-test-month-atom]').hasTextContaining('No month');
+
+    await renderField(YearField, buildField(YearField, {}), 'atom');
+    assert.dom('[data-test-year-atom]').hasTextContaining('No year');
+
+    await renderField(MonthDayField, buildField(MonthDayField, {}), 'atom');
+    assert.dom('[data-test-month-day-atom]').hasTextContaining('No date');
+  });
+
+  test('edit mode interactions: time range duration and duration validation', async function (assert) {
+    await renderField(
+      TimeRangeField,
+      buildField(TimeRangeField, {
+        start: buildField(TimeField, { value: '09:00' }),
+        end: buildField(TimeField, { value: '10:00' }),
+      }),
+      'edit',
+    );
+    assert.dom('[data-test-time-input]').exists({ count: 2 });
+    assert
+      .dom('[data-test-field-container]')
+      .hasTextContaining('Duration: 1 hours');
+
+    await renderField(
+      DurationField,
+      buildField(DurationField, { hours: 1, minutes: 30, seconds: 0 }),
+      'edit',
+    );
+    assert.dom('[data-test-field-container]').hasTextContaining('Hours');
+    assert.dom('[data-test-field-container]').hasTextContaining('Minutes');
+    assert.dom('[data-test-field-container]').hasTextContaining('Seconds');
+  });
+
+  test('edit mode interactions: month/day selects update preview', async function (assert) {
+    await renderField(
+      MonthDayField,
+      buildField(MonthDayField, { month: 5, day: 15 }),
+      'edit',
+    );
+    assert.dom('[data-test-month-select]').exists();
+    assert.dom('[data-test-day-select]').exists();
+  });
+
+  test('presentation content reflects configuration', async function (assert) {
+    await renderConfiguredField(DateTimeField, '2999-01-01T00:00:00Z', {
+      presentation: 'countdown',
+      countdownOptions: { label: 'Launch', showControls: true },
+    });
+    assert.dom('[data-test-countdown]').exists();
+    assert.dom('[data-test-countdown]').hasTextContaining('Launch');
+    assert.dom('[data-test-countdown-toggle]').exists();
+    assert.dom('[data-test-countdown-reset]').exists();
+
+    await renderConfiguredField(DateTimeField, '2020-01-01T00:00:00Z', {
+      presentation: 'timeAgo',
+      timeAgoOptions: { eventLabel: 'Last Activity' },
+    });
+    assert.dom('[data-test-relative-time]').exists();
+    assert.dom('[data-test-relative-time]').hasTextContaining('Last Activity');
+    assert.dom('[data-test-relative-time]').hasTextContaining('ago');
+
+    await renderConfiguredField(DateTimeField, '2024-06-01T10:00:00Z', {
+      presentation: 'timeline',
+      timelineOptions: { eventName: 'Order Placed', status: 'complete' },
+    });
+    assert.dom('[data-test-timeline-event]').hasTextContaining('Order Placed');
+
+    await renderConfiguredField(DateTimeField, '2000-01-01T00:00:00Z', {
+      presentation: 'expirationWarning',
+      expirationOptions: { itemName: 'API Token' },
+    });
+    assert.dom('[data-test-expiration-warning]').exists();
+    assert.dom('[data-test-expiration-warning]').hasTextContaining('API Token');
+    assert.dom('[data-test-expiration-warning]').hasTextContaining('Expired');
+
+    await renderConfiguredField(
+      DateRangeField,
+      buildField(DateRangeField, {
+        start: '2024-05-06',
+        end: '2024-05-10',
+      }),
+      { presentation: 'businessDays' },
+    );
+    assert.dom('[data-test-business-days]').exists();
+    assert.dom('[data-test-business-days]').hasTextContaining('Calendar Days:');
+    assert.dom('[data-test-business-days]').hasTextContaining('Business Days:');
+
+    await renderConfiguredField(
+      TimeField,
+      buildField(TimeField, { value: '09:00' }),
+      {
+        presentation: 'timeSlots',
+        timeSlotsOptions: { availableSlots: ['09:00 AM', '10:00 AM'] },
+      },
+    );
+    assert.dom('[data-test-time-slots]').exists();
+    await click('[data-test-slot="10:00 AM"]');
+    assert
+      .dom('[data-test-time-slots]')
+      .hasTextContaining('Selected: 10:00 AM');
+  });
+
+  test('datetime-stamp field renders correctly', async function (assert) {
+    await renderField(DatetimeStampField, '2024-05-01T14:30:00Z');
+    assert.dom('[data-test-datetime-stamp-embedded]').exists();
+    assert
+      .dom('[data-test-datetime-stamp-embedded]')
+      .doesNotContainText('No timestamp set', 'timestamp value is displayed');
+
+    await renderField(DatetimeStampField, undefined);
+    assert
+      .dom('[data-test-datetime-stamp-embedded]')
+      .hasTextContaining('No timestamp set');
+
+    await renderField(DatetimeStampField, '2024-05-01T14:30:00Z', 'atom');
+    assert.dom('[data-test-datetime-stamp-atom]').exists();
+    assert
+      .dom('[data-test-datetime-stamp-atom]')
+      .doesNotContainText('No timestamp');
+  });
+
+  test('day field renders correctly', async function (assert) {
+    await renderField(DayField, buildField(DayField, { value: 15 }));
+    assert.dom('[data-test-day-embedded]').hasText('15th');
+
+    await renderField(DayField, buildField(DayField, {}));
+    assert.dom('[data-test-day-embedded]').hasTextContaining('No day set');
+
+    await renderField(DayField, buildField(DayField, { value: 15 }), 'atom');
+    assert.dom('[data-test-day-atom]').exists();
+    assert.dom('[data-test-day-atom]').hasTextContaining('15');
+
+    await renderField(DayField, buildField(DayField, { value: 15 }), 'edit');
+    assert.dom('[data-test-field-container]').exists();
+  });
+
+  test('relative time field supports negative offsets', async function (assert) {
+    await renderField(
+      RelativeTimeField,
+      buildField(RelativeTimeField, { amount: 5, unit: 'days' }),
+    );
+    assert.dom('[data-test-relative-time-embedded]').hasText('In 5 days');
+
+    await renderField(
+      RelativeTimeField,
+      buildField(RelativeTimeField, { amount: -3, unit: 'hours' }),
+    );
+    assert.dom('[data-test-relative-time-embedded]').hasText('In -3 hours');
+
+    await renderField(
+      RelativeTimeField,
+      buildField(RelativeTimeField, { amount: 2, unit: 'weeks' }),
+    );
+    assert.dom('[data-test-relative-time-embedded]').hasText('In 2 weeks');
+
+    await renderField(
+      RelativeTimeField,
+      buildField(RelativeTimeField, { amount: 30, unit: 'minutes' }),
+    );
+    assert.dom('[data-test-relative-time-embedded]').hasText('In 30 minutes');
+  });
+
+  test('edit mode for partial calendar fields renders correctly', async function (assert) {
+    await renderField(
+      YearField,
+      buildField(YearField, { value: 2024 }),
+      'edit',
+    );
+    assert.dom('[data-test-field-container]').exists();
+
+    await renderField(MonthField, buildField(MonthField, { value: 5 }), 'edit');
+    assert.dom('[data-test-month-select]').exists();
+
+    await renderField(
+      QuarterField,
+      buildField(QuarterField, { quarter: 2, year: 2025 }),
+      'edit',
+    );
+    assert.dom('[data-test-field-container]').exists();
+
+    await renderField(
+      WeekField,
+      buildField(WeekField, { value: '2025-W20' }),
+      'edit',
+    );
+    assert.dom('[data-test-field-container]').exists();
+  });
+});

--- a/packages/host/tests/integration/number-field-test.gts
+++ b/packages/host/tests/integration/number-field-test.gts
@@ -1,0 +1,255 @@
+import { module, test } from 'qunit';
+
+import { setupBaseRealm, NumberField } from '../helpers/base-realm';
+import { renderConfiguredField } from '../helpers/field-test-helpers';
+import { setupRenderingTest } from '../helpers/setup';
+
+module('Integration | number field configuration', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+
+  // ============================================
+  // Presentation Mode Rendering Tests
+  // ============================================
+
+  test('each presentation mode renders correct embedded component', async function (assert) {
+    const presentations = [
+      { mode: 'standard', embeddedClass: '[data-test-number-field-embedded]' },
+      { mode: 'stat', embeddedClass: '.stat-field-embedded' },
+      { mode: 'score', embeddedClass: '.score-field-embedded' },
+      { mode: 'progress-bar', embeddedClass: '.progress-bar-container' },
+      { mode: 'progress-circle', embeddedClass: '.progress-circle-container' },
+      {
+        mode: 'badge-notification',
+        embeddedClass: '.badge-notification-embedded',
+      },
+      { mode: 'badge-metric', embeddedClass: '.badge-metric-embedded' },
+      { mode: 'badge-counter', embeddedClass: '.badge-counter-embedded' },
+      { mode: 'gauge', embeddedClass: '.gauge-embedded' },
+    ];
+
+    for (const { mode, embeddedClass } of presentations) {
+      await renderConfiguredField(
+        NumberField,
+        50,
+        { presentation: mode },
+        'embedded',
+      );
+      assert
+        .dom(`[data-test-field-container] ${embeddedClass}`)
+        .exists(`${mode} presentation renders correct embedded component`);
+    }
+  });
+
+  // ============================================
+  // Options Configuration Tests
+  // ============================================
+
+  test('prefix/suffix/decimals options work correctly', async function (assert) {
+    await renderConfiguredField(
+      NumberField,
+      100.5,
+      {
+        presentation: 'standard',
+        options: {
+          prefix: '$',
+          suffix: ' USD',
+          decimals: 2,
+        },
+      },
+      'atom',
+    );
+
+    assert
+      .dom('[data-test-field-container] [data-test-number-field-atom]')
+      .hasTextContaining('$100.50 USD', 'Prefix/suffix/decimals are applied');
+  });
+
+  test('min/max options work in edit mode', async function (assert) {
+    await renderConfiguredField(
+      NumberField,
+      200,
+      {
+        presentation: 'standard',
+        options: {
+          min: 0,
+          max: 100,
+        },
+      },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] [data-test-number-input]')
+      .hasAttribute('min', '0', 'Edit mode respects min')
+      .hasAttribute('max', '100', 'Edit mode respects max');
+  });
+
+  test('valueFormat percentage with suffix works correctly', async function (assert) {
+    await renderConfiguredField(
+      NumberField,
+      75,
+      {
+        presentation: 'progress-bar',
+        options: {
+          min: 0,
+          max: 100,
+          valueFormat: 'percentage',
+          suffix: 'completed',
+          showValue: true,
+        },
+      },
+      'embedded',
+    );
+
+    assert
+      .dom('[data-test-field-container]')
+      .hasTextContaining('75% completed', 'Percentage format appends suffix');
+  });
+
+  test('badge-notification respects max option for overflow', async function (assert) {
+    await renderConfiguredField(
+      NumberField,
+      150,
+      {
+        presentation: 'badge-notification',
+        options: {
+          max: 99,
+        },
+      },
+      'atom',
+    );
+
+    assert
+      .dom('[data-test-field-container] .badge-count')
+      .hasText('99+', 'Shows overflow indicator when max exceeded');
+  });
+
+  // ============================================
+  // Error Handling and Fallback Tests
+  // ============================================
+
+  test('invalid presentation falls back to standard', async function (assert) {
+    await renderConfiguredField(
+      NumberField,
+      42,
+      {
+        presentation: 'nonexistent-presentation',
+        options: {
+          prefix: '$',
+        },
+      },
+      'atom',
+    );
+
+    assert
+      .dom('[data-test-field-container] [data-test-number-field-atom]')
+      .exists('Invalid presentation falls back to standard');
+
+    assert
+      .dom('[data-test-field-container] [data-test-number-field-atom]')
+      .hasTextContaining('$42', 'Fallback still respects options');
+  });
+
+  test('missing presentation defaults to standard', async function (assert) {
+    await renderConfiguredField(NumberField, 42, {}, 'atom');
+
+    assert
+      .dom('[data-test-field-container] [data-test-number-field-atom]')
+      .exists('Missing presentation defaults to standard');
+  });
+
+  test('wrong type in options is ignored gracefully', async function (assert) {
+    await renderConfiguredField(
+      NumberField,
+      75,
+      {
+        presentation: 'stat',
+        options: {
+          min: 'invalid' as any,
+          max: 'invalid' as any,
+          decimals: 'not-a-number' as any,
+        },
+      },
+      'embedded',
+    );
+
+    assert
+      .dom('[data-test-field-container] .stat-field-embedded')
+      .exists('Renders even with wrong option types');
+
+    assert
+      .dom('[data-test-field-container] .stat-footer')
+      .doesNotExist('Does not show range with invalid min/max');
+  });
+
+  test('null/undefined value is handled gracefully', async function (assert) {
+    await renderConfiguredField(
+      NumberField,
+      null,
+      {
+        presentation: 'stat',
+        options: {
+          placeholder: 'No value',
+        },
+      },
+      'embedded',
+    );
+
+    assert
+      .dom('[data-test-field-container] .stat-value')
+      .hasText('No value', 'Shows placeholder for null value');
+  });
+
+  // ============================================
+  // Edit Mode Tests
+  // ============================================
+
+  test('edit mode always uses NumberInput regardless of presentation', async function (assert) {
+    await renderConfiguredField(
+      NumberField,
+      50,
+      {
+        presentation: 'stat',
+        options: {
+          prefix: '$',
+          suffix: ' USD',
+        },
+      },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] [data-test-number-input]')
+      .exists('Edit mode uses NumberInput for all presentations');
+
+    assert
+      .dom('[data-test-field-container] [data-test-number-input]')
+      .exists('Edit mode renders number input');
+  });
+
+  test('edit mode extracts compatible options from any presentation', async function (assert) {
+    await renderConfiguredField(
+      NumberField,
+      75,
+      {
+        presentation: 'progress-bar',
+        options: {
+          min: 0,
+          max: 100,
+          prefix: '$',
+          suffix: ' USD',
+          decimals: 2,
+          useGradient: true,
+          showValue: true,
+        },
+      },
+      'edit',
+    );
+
+    assert
+      .dom('[data-test-field-container] [data-test-number-input]')
+      .hasAttribute('min', '0', 'Extracts min from options')
+      .hasAttribute('max', '100', 'Extracts max from options');
+  });
+});


### PR DESCRIPTION
Color, number, and most date/time fields were promoted from catalog-realm to base, so their integration tests now live here alongside the base implementations. While moving the tests:

- Update and merge the date-range and number field work which catches in the test.
- Expose the newly-promoted fields (Color, DateRange, DatetimeStamp, Day, Month, MonthDay, MonthYear, Year, Week, Quarter, Time, TimeRange, Duration, RelativeTime) from host/tests/helpers/base-realm.ts and add a renderField / renderConfiguredField / buildField helper so the moved tests can build temporary cards.