### PR TITLE
Re-assert prCard link when clearing workflow error

### DIFF
--- a/packages/bot-runner/lib/pr-listing/pr-listing-workflow-handler.ts
+++ b/packages/bot-runner/lib/pr-listing/pr-listing-workflow-handler.ts
@@ -247,7 +247,9 @@ export class PrListingWorkflowHandler implements BotCommandHandler {
         : await this.runFreshPrCardFlow(ctx);
 
       await runStep('github-pr', () => this.pushToGitHub(ctx, prCardData));
-      await runStep('github-pr', () => this.clearWorkflowError(ctx));
+      await runStep('github-pr', () =>
+        this.clearWorkflowError(ctx, prCardData.prCardUrl),
+      );
 
       return prCardData.prCardResult;
     } catch (err) {
@@ -435,11 +437,19 @@ export class PrListingWorkflowHandler implements BotCommandHandler {
     });
   }
 
-  private async clearWorkflowError(ctx: WorkflowContext): Promise<void> {
+  private async clearWorkflowError(
+    ctx: WorkflowContext,
+    prCardUrl: string | null,
+  ): Promise<void> {
     if (!ctx.workflowCardUrl) return;
-    await this.patchWorkflowCard(ctx, {
+    let patch: Record<string, unknown> = {
       attributes: { prCreationError: null, failedStep: null },
-    });
+    };
+    // Re-assert prCard so a stale fetch can't drop the link.
+    if (prCardUrl) {
+      patch.relationships = { prCard: { links: { self: prCardUrl } } };
+    }
+    await this.patchWorkflowCard(ctx, patch);
   }
 
   private async recordWorkflowFailure(

--- a/packages/bot-runner/tests/command-runner-test.ts
+++ b/packages/bot-runner/tests/command-runner-test.ts
@@ -368,10 +368,17 @@ module('command runner', () => {
               prCreationError: null,
               failedStep: null,
             },
+            relationships: {
+              prCard: {
+                links: {
+                  self: prCardUrl,
+                },
+              },
+            },
           },
         },
       },
-      'clears prior error attributes on the workflow card after the GitHub PR succeeds',
+      'clears prior error attributes on the workflow card after the GitHub PR succeeds, re-asserting the prCard link to survive any stale-fetch race',
     );
     let prBody =
       (


### PR DESCRIPTION
After splitting the post-PR-creation patch into linkPrCardOnWorkflow (relationships) + clearWorkflowError (attributes), the prCard link could disappear from the workflow card mid-flow when the second renderer's fetched doc lagged behind the first patch.

Pass prCardUrl through to clearWorkflowError and re-include the relationship in the same patch so it's self-healing.