### PR TITLE
Fix workspace menu closing when cursor crosses trigger-to-content gap

### DIFF
--- a/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
@@ -94,7 +94,7 @@ export default class Workspace extends Component<Signature> {
           data-test-workspace-favorite-btn={{@realmURL}}
         />
         <div class='tile-menu-btn'>
-          <BoxelDropdown @autoClose={{true}}>
+          <BoxelDropdown>
             <:trigger as |bindings|>
               <ContextButton
                 @label='Options'


### PR DESCRIPTION
As a person who deletes his workspaces a lot, this has been driving me crazy 😀


https://github.com/user-attachments/assets/a3e0712b-da14-4b98-ba0f-3e1d418f5f98

The fix is to simply remove the auto close functionality. I don't think it's useful anyway - it will still close if you open another contextual menu.
