### PR TITLE
Add notify no-op to indexing-event-sink-test DBAdapter mocks

### DIFF
--- a/packages/realm-server/tests/indexing-event-sink-test.ts
+++ b/packages/realm-server/tests/indexing-event-sink-test.ts
@@ -29,6 +29,7 @@ function makeRecordingAdapter(): {
       async getColumnNames() {
         return [];
       },
+      async notify() {},
     },
   };
 }
@@ -374,6 +375,7 @@ module(basename(__filename), function () {
         async getColumnNames() {
           return [];
         },
+        async notify() {},
       };
       let sink = new IndexingEventSink({ flushIntervalMs: 10 });
       sink.setAdapter(slowAdapter);


### PR DESCRIPTION
## Summary
- Two inline `DBAdapter` mocks in `packages/realm-server/tests/indexing-event-sink-test.ts` were missing the `notify(channel, payload)` method that became required when cross-instance NOTIFY moved behind the adapter (#4672).
- `lint:types` was failing on `main` with `TS2741` at lines 18 and 362. Fix matches the no-op convention already used in `prerender-proxy-test.ts:23` and `screenshot-card-test.ts:27`.

Failing run: https://github.com/cardstack/boxel/actions/runs/25434674745/job/74609409700

## Test plan
- [x] CI Lint job passes (Lint Realm Server step in particular)

🤖 Generated with [Claude Code](https://claude.com/claude-code)