### PR TITLE
CS-11010: ETag/304 for application/vnd.card+json

### DIFF
--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -542,6 +542,17 @@ export default function handlePublishRealm({
       await publishedRealm.fullIndex(userInitiatedPriority, {
         clearLastModified: true,
       });
+
+      // The source realm's `RealmInfo.lastPublishedAt` map is built
+      // from `realm_registry` rows joined on `source_url = sourceRealmURL`,
+      // so publishing this derivative just changed it. Without
+      // invalidating the cache, the source's `getRealmInfo()` keeps
+      // returning the pre-publish snapshot — and the card+json ETag,
+      // which folds a hash of that snapshot in, would still match a
+      // stale `If-None-Match` and serve a 304 with the old
+      // `meta.realmInfo.lastPublishedAt`. (CS-11010)
+      sourceRealm.invalidateCachedRealmInfo();
+
       let publishedPermissions = await fetchRealmPermissions(
         dbAdapter,
         new URL(publishedRealmURL),

--- a/packages/realm-server/handlers/handle-unpublish-realm.ts
+++ b/packages/realm-server/handlers/handle-unpublish-realm.ts
@@ -147,6 +147,24 @@ export default function handleUnpublishRealm({
         await removeRealmPermissions(dbAdapter, new URL(publishedRealmURL));
       });
 
+      // Removing this derivative just changed the source realm's
+      // `RealmInfo.lastPublishedAt` map (rows where `source_url =
+      // sourceRealmURL`). Without invalidating the source's cached
+      // realm info, its card+json ETag (which folds a hash of the
+      // realm info in) would keep matching pre-unpublish If-None-Match
+      // headers and serve a 304 with stale `meta.realmInfo`. (CS-11010)
+      let sourceRealmURL = publishedRealmInfo.source_realm_url;
+      if (sourceRealmURL) {
+        try {
+          let sourceRealm = await reconciler.lookupOrMount(sourceRealmURL);
+          sourceRealm?.invalidateCachedRealmInfo();
+        } catch (err) {
+          log.warn(
+            `Could not invalidate source realm cached realm-info for ${sourceRealmURL} after unpublish: ${err}`,
+          );
+        }
+      }
+
       // Permissions for the published realm were removed inside the
       // write lock above, so fetchRealmPermissions(publishedRealmURL)
       // would return nothing useful for X-Boxel-Realm-Public-Readable.

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -891,6 +891,14 @@ module(basename(__filename), function () {
             'public, max-age=0, must-revalidate',
             'world-readable realm advertises public cache-control',
           );
+          // The X-Boxel-Etag-Suppressed signal only fires when the
+          // foreign-deps guard rejects the ETag; a card with purely
+          // local deps must NOT carry it, otherwise ops dashboards
+          // can't tell normal from suppressed traffic.
+          assert.notOk(
+            response.get('X-Boxel-Etag-Suppressed'),
+            'no suppression signal on a card with only local deps',
+          );
         });
 
         test('returns 304 when If-None-Match matches the current ETag', async function (assert) {

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -883,7 +883,7 @@ module(basename(__filename), function () {
           let etag = response.get('etag') ?? '';
           assert.ok(etag, 'response carries an ETag');
           assert.true(
-            /^\d+(?:-[0-9a-f]+)?:card$/.test(etag),
+            /^"\d+(?:-[0-9a-f]+)?:card"$/.test(etag),
             `ETag matches "<indexed_at>(-<realmInfoHash>)?:card" pattern (got ${etag})`,
           );
           assert.strictEqual(
@@ -2517,7 +2517,7 @@ module(basename(__filename), function () {
           let patchEtag = patchResponse.get('etag') ?? '';
           assert.ok(patchEtag, 'PATCH response carries an ETag');
           assert.true(
-            /^\d+(?:-[0-9a-f]+)?:card$/.test(patchEtag),
+            /^"\d+(?:-[0-9a-f]+)?:card"$/.test(patchEtag),
             `PATCH ETag matches "<indexed_at>(-<realmInfoHash>)?:card" pattern (got ${patchEtag})`,
           );
           assert.notStrictEqual(

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -883,8 +883,8 @@ module(basename(__filename), function () {
           let etag = response.get('etag') ?? '';
           assert.ok(etag, 'response carries an ETag');
           assert.true(
-            /^\d+:card$/.test(etag),
-            `ETag matches "<indexed_at>:card" pattern (got ${etag})`,
+            /^\d+(?:-[0-9a-f]+)?:card$/.test(etag),
+            `ETag matches "<indexed_at>(-<realmInfoHash>)?:card" pattern (got ${etag})`,
           );
           assert.strictEqual(
             response.get('cache-control'),
@@ -2517,8 +2517,8 @@ module(basename(__filename), function () {
           let patchEtag = patchResponse.get('etag') ?? '';
           assert.ok(patchEtag, 'PATCH response carries an ETag');
           assert.true(
-            /^\d+:card$/.test(patchEtag),
-            `PATCH ETag matches "<indexed_at>:card" pattern (got ${patchEtag})`,
+            /^\d+(?:-[0-9a-f]+)?:card$/.test(patchEtag),
+            `PATCH ETag matches "<indexed_at>(-<realmInfoHash>)?:card" pattern (got ${patchEtag})`,
           );
           assert.notStrictEqual(
             patchEtag,

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -873,6 +873,73 @@ module(basename(__filename), function () {
             'deeply nested linksToMany returns first match',
           );
         });
+
+        test('returns an ETag and public cache-control on a 200 response', async function (assert) {
+          let response = await request
+            .get('/person-1')
+            .set('Accept', 'application/vnd.card+json');
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          let etag = response.get('etag') ?? '';
+          assert.ok(etag, 'response carries an ETag');
+          assert.true(
+            /^\d+:card$/.test(etag),
+            `ETag matches "<indexed_at>:card" pattern (got ${etag})`,
+          );
+          assert.strictEqual(
+            response.get('cache-control'),
+            'public, max-age=0, must-revalidate',
+            'world-readable realm advertises public cache-control',
+          );
+        });
+
+        test('returns 304 when If-None-Match matches the current ETag', async function (assert) {
+          let firstResponse = await request
+            .get('/person-1')
+            .set('Accept', 'application/vnd.card+json');
+          assert.strictEqual(firstResponse.status, 200, 'first GET succeeds');
+          let etag = firstResponse.get('etag') ?? '';
+          assert.ok(etag, 'first response carries an ETag');
+
+          let secondResponse = await request
+            .get('/person-1')
+            .set('Accept', 'application/vnd.card+json')
+            .set('If-None-Match', etag);
+
+          assert.strictEqual(
+            secondResponse.status,
+            304,
+            'matching If-None-Match short-circuits to 304',
+          );
+          assert.strictEqual(
+            secondResponse.get('etag'),
+            etag,
+            '304 response echoes the ETag',
+          );
+          assert.strictEqual(
+            secondResponse.get('cache-control'),
+            'public, max-age=0, must-revalidate',
+            '304 response keeps the cache-control directive',
+          );
+          // 304 must not have a body — `response.body` may be `{}` when
+          // supertest can't decode an empty buffer, so check `response.text`.
+          assert.notOk(secondResponse.text, '304 response has no body');
+        });
+
+        test('returns 200 when If-None-Match does not match', async function (assert) {
+          let response = await request
+            .get('/person-1')
+            .set('Accept', 'application/vnd.card+json')
+            .set('If-None-Match', '"stale-etag"');
+
+          assert.strictEqual(
+            response.status,
+            200,
+            'non-matching If-None-Match falls through to a fresh 200',
+          );
+          assert.ok(response.body.data, 'full body is returned');
+          assert.ok(response.get('etag'), '200 response still carries an ETag');
+        });
       });
 
       module('published realm', function (hooks) {
@@ -1101,6 +1168,15 @@ module(basename(__filename), function () {
             response.get('X-boxel-realm-public-readable'),
             undefined,
             'realm is not public readable',
+          );
+          assert.strictEqual(
+            response.get('cache-control'),
+            'private, max-age=0, must-revalidate',
+            'auth-gated realm advertises private cache-control so a shared cache cannot serve one user the response of another',
+          );
+          assert.ok(
+            response.get('etag'),
+            'auth-gated response carries an ETag',
           );
         });
 
@@ -2407,6 +2483,105 @@ module(basename(__filename), function () {
             afterStat.mtimeMs,
             initialStat.mtimeMs,
             'card file not rewritten for no-op patch',
+          );
+        });
+
+        test('PATCH response carries an ETag and writes invalidate the previous one', async function (assert) {
+          // Capture the pre-patch ETag, mutate the card, and verify the PATCH
+          // response advertises a *different* ETag for the new state — that's
+          // the contract that lets the caller cache the post-patch body
+          // without an extra round-trip GET.
+          let initialResponse = await request
+            .get('/person-1')
+            .set('Accept', 'application/vnd.card+json');
+          let originalEtag = initialResponse.get('etag') ?? '';
+          assert.ok(originalEtag, 'initial GET returns an ETag');
+
+          let patchResponse = await request
+            .patch('/person-1')
+            .send({
+              data: {
+                type: 'card',
+                attributes: { firstName: 'Van Gogh' },
+                meta: {
+                  adoptsFrom: {
+                    module: rri('./person.gts'),
+                    name: 'Person',
+                  },
+                },
+              },
+            })
+            .set('Accept', 'application/vnd.card+json');
+
+          assert.strictEqual(patchResponse.status, 200, 'PATCH succeeds');
+          let patchEtag = patchResponse.get('etag') ?? '';
+          assert.ok(patchEtag, 'PATCH response carries an ETag');
+          assert.true(
+            /^\d+:card$/.test(patchEtag),
+            `PATCH ETag matches "<indexed_at>:card" pattern (got ${patchEtag})`,
+          );
+          assert.notStrictEqual(
+            patchEtag,
+            originalEtag,
+            'PATCH advances the ETag because indexed_at bumps on the rewrite',
+          );
+
+          // Sending the OLD etag against If-None-Match must NOT short-circuit
+          // (otherwise we'd serve a stale 304 after a write).
+          let staleResponse = await request
+            .get('/person-1')
+            .set('Accept', 'application/vnd.card+json')
+            .set('If-None-Match', originalEtag);
+          assert.strictEqual(
+            staleResponse.status,
+            200,
+            'old ETag no longer matches → fresh 200',
+          );
+          assert.strictEqual(
+            staleResponse.get('etag'),
+            patchEtag,
+            'GET reports the new ETag',
+          );
+
+          // And the new etag from the PATCH must short-circuit on next GET.
+          let cachedResponse = await request
+            .get('/person-1')
+            .set('Accept', 'application/vnd.card+json')
+            .set('If-None-Match', patchEtag);
+          assert.strictEqual(
+            cachedResponse.status,
+            304,
+            'new ETag from PATCH lets a follow-up GET short-circuit',
+          );
+        });
+
+        test('no-op PATCH response carries an ETag matching the existing one', async function (assert) {
+          let initialResponse = await request
+            .get('/person-1')
+            .set('Accept', 'application/vnd.card+json');
+          let initialEtag = initialResponse.get('etag');
+          assert.ok(initialEtag, 'initial GET returns an ETag');
+
+          let patchResponse = await request
+            .patch('/person-1')
+            .send({
+              data: {
+                type: 'card',
+                meta: {
+                  adoptsFrom: {
+                    module: rri('./person'),
+                    name: 'Person',
+                  },
+                },
+              },
+            })
+            .set('Accept', 'application/vnd.card+json');
+
+          assert.strictEqual(patchResponse.status, 200, 'no-op PATCH succeeds');
+          assert.strictEqual(
+            patchResponse.get('etag'),
+            initialEtag,
+            'no-op PATCH returns the same ETag (no rewrite, indexed_at unchanged)',
           );
         });
 

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -206,11 +206,15 @@ module(basename(__filename), function () {
           'Authorization',
           `Bearer ${createJWT(testRealm, 'user', ['read', 'write'])}`,
         );
+      // Card+json is now ETag-cacheable (CS-11010): the realm advertises
+      // public/private + max-age=0 + must-revalidate so browsers always
+      // revalidate, but a matching If-None-Match short-circuits to 304.
       assert.strictEqual(
         response.headers['cache-control'],
-        'no-store, no-cache, must-revalidate',
+        'public, max-age=0, must-revalidate',
         'cache control header is set correctly',
       );
+      assert.ok(response.headers['etag'], 'ETag header is present');
     });
 
     test('serves file meta with dedicated accept header', async function (assert) {
@@ -632,6 +636,62 @@ module(basename(__filename), function () {
           updatedCardResponse.body.data.meta.realmInfo.name,
           'Updated Realm Name',
           'card realmInfo reflects updated realm name without re-indexing',
+        );
+      });
+
+      test('card ETag invalidates after realm config change so old If-None-Match does not 304 stale realmInfo', async function (assert) {
+        // Capture the pre-PATCH ETag.
+        let initialResponse = await request
+          .get('/person-1')
+          .set('Accept', 'application/vnd.card+json');
+        assert.strictEqual(initialResponse.status, 200, 'initial GET succeeds');
+        let initialEtag = initialResponse.headers['etag'];
+        assert.ok(initialEtag, 'initial response carries an ETag');
+
+        // Change the realm name — this nulls the cached realmInfo without
+        // touching boxel_index, so a naive `indexed_at`-only ETag would
+        // still match and 304 with stale `meta.realmInfo`. The fix folds
+        // a hash of the realmInfo into the ETag base.
+        let patchResponse = await request
+          .patch('/_config')
+          .set('Accept', SupportedMimeType.JSON)
+          .set(
+            'Authorization',
+            `Bearer ${createJWT(testRealm, 'user', [
+              'read',
+              'write',
+              'realm-owner',
+            ])}`,
+          )
+          .send({
+            data: {
+              type: 'realm-config',
+              attributes: { name: 'Etag Invalidation Test Realm' },
+            },
+          });
+        assert.strictEqual(patchResponse.status, 200, 'config patch succeeded');
+
+        // Replay the GET with the OLD ETag. It must NOT 304: the assembled
+        // body now has a different `meta.realmInfo.name`, so the validator
+        // has to recognize that as a content change.
+        let revalidationResponse = await request
+          .get('/person-1')
+          .set('Accept', 'application/vnd.card+json')
+          .set('If-None-Match', initialEtag);
+        assert.strictEqual(
+          revalidationResponse.status,
+          200,
+          'old ETag does not match after /_config PATCH; server returns full 200',
+        );
+        assert.notStrictEqual(
+          revalidationResponse.headers['etag'],
+          initialEtag,
+          'fresh response carries a different ETag',
+        );
+        assert.strictEqual(
+          revalidationResponse.body.data.meta.realmInfo.name,
+          'Etag Invalidation Test Realm',
+          'fresh response reflects the post-PATCH realm name',
         );
       });
 

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -85,6 +85,12 @@ interface SearchResultDoc {
   // complete fingerprint for the assembled card+json document and is
   // used as the ETag base by the realm's GET/PATCH handlers.
   indexedAt: number | null;
+  // deps array on the primary card's index row. Used by the realm's
+  // GET/PATCH handlers to detect foreign-realm dependencies — when
+  // present, ETag emission is suppressed because cross-realm
+  // invalidation does not cascade indexed_at (see
+  // `index-writer.ts.calculateInvalidations` realm_url filter).
+  deps: string[] | null;
 }
 
 export interface SearchResultError {
@@ -462,7 +468,12 @@ export class RealmIndexQueryEngine {
     }
     relativizeDocument(doc, this.realmURL);
     await this.attachRealmInfo(doc);
-    return { type: 'doc', doc, indexedAt: instance.indexedAt };
+    return {
+      type: 'doc',
+      doc,
+      indexedAt: instance.indexedAt,
+      deps: instance.deps,
+    };
   }
 
   async instance(

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -80,6 +80,11 @@ type SearchResult = SearchResultDoc | SearchResultError;
 interface SearchResultDoc {
   type: 'doc';
   doc: SingleCardDocument;
+  // indexed_at on the primary card's index row. Bumps on every reindex
+  // (direct file write OR dependency-triggered re-write), so it's a
+  // complete fingerprint for the assembled card+json document and is
+  // used as the ETag base by the realm's GET/PATCH handlers.
+  indexedAt: number | null;
 }
 
 export interface SearchResultError {
@@ -457,7 +462,7 @@ export class RealmIndexQueryEngine {
     }
     relativizeDocument(doc, this.realmURL);
     await this.attachRealmInfo(doc);
-    return { type: 'doc', doc };
+    return { type: 'doc', doc, indexedAt: instance.indexedAt };
   }
 
   async instance(

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -3290,7 +3290,8 @@ export class Realm {
         // attachRealmInfo() and (re)populated the realm-info cache —
         // so the cached hash is current as of this response.
         await this.getRealmInfo();
-        let etag = this.hasForeignRealmDeps(entry.deps)
+        let foreignDeps = this.hasForeignRealmDeps(entry.deps);
+        let etag = foreignDeps
           ? undefined
           : buildCardJsonEtag(entry.indexedAt, this.getCachedRealmInfoHash());
         return createResponse({
@@ -3300,6 +3301,7 @@ export class Realm {
               'content-type': SupportedMimeType.CardJson,
               'cache-control': this.cardJsonCacheControl(requestContext),
               ...(etag ? { etag } : {}),
+              ...etagSuppressedHeader(foreignDeps),
               ...lastModifiedHeader(existingDoc),
               ...(createdAt != null
                 ? { 'x-created': formatRFC7231(createdAt * 1000) }
@@ -3423,8 +3425,12 @@ export class Realm {
     // attachRealmInfo(), but only when entry was a non-error doc.
     // On the error fallback we may still need to populate it.
     await this.getRealmInfo();
+    let foreignDeps =
+      entry && entry.type !== 'error'
+        ? this.hasForeignRealmDeps(entry.deps)
+        : false;
     let etag =
-      entry && entry.type !== 'error' && !this.hasForeignRealmDeps(entry.deps)
+      entry && entry.type !== 'error' && !foreignDeps
         ? buildCardJsonEtag(entry.indexedAt, this.getCachedRealmInfoHash())
         : undefined;
     return createResponse({
@@ -3434,6 +3440,7 @@ export class Realm {
           'content-type': SupportedMimeType.CardJson,
           'cache-control': this.cardJsonCacheControl(requestContext),
           ...(etag ? { etag } : {}),
+          ...etagSuppressedHeader(foreignDeps),
           ...lastModifiedHeader(doc),
           ...(created ? { 'x-created': formatRFC7231(created * 1000) } : {}),
         },
@@ -3668,7 +3675,8 @@ export class Realm {
       // doesn't cascade `indexed_at`, so a validator we emit here
       // could 304 a follow-up request whose `included[]` should have
       // been re-fetched from the foreign realm.
-      let responseEtag = this.hasForeignRealmDeps(maybeError.deps)
+      let foreignDeps = this.hasForeignRealmDeps(maybeError.deps);
+      let responseEtag = foreignDeps
         ? undefined
         : buildCardJsonEtag(
             maybeError.indexedAt,
@@ -3681,6 +3689,7 @@ export class Realm {
             'content-type': SupportedMimeType.CardJson,
             'cache-control': cacheControl,
             ...(responseEtag ? { etag: responseEtag } : {}),
+            ...etagSuppressedHeader(foreignDeps),
             ...lastModifiedHeader(card),
             ...(createdAt != null
               ? { 'x-created': formatRFC7231(createdAt * 1000) }
@@ -5710,6 +5719,19 @@ function lastModifiedHeader(
       ? { 'last-modified': formatRFC7231(card.data.meta.lastModified * 1000) }
       : {}
   ) as {} | { 'last-modified': string };
+}
+
+// Visibility hook for the foreign-realm-deps ETag suppression — when
+// a card+json response declines to emit an ETag because it has
+// dependencies in another realm, this header surfaces the reason so
+// ops can measure how often the guard fires (Grafana / log
+// aggregation) and prioritize wiring up cross-realm dep
+// invalidation in `index-writer.calculateInvalidations`. Once that
+// lands, both this header and the suppression itself can come out.
+function etagSuppressedHeader(
+  hasForeignDeps: boolean,
+): {} | { 'X-Boxel-Etag-Suppressed': string } {
+  return hasForeignDeps ? { 'X-Boxel-Etag-Suppressed': 'foreign-deps' } : {};
 }
 
 export type ErrorReporter = (error: Error) => void;

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -230,10 +230,19 @@ const CACHE_HIT_VALUE = 'hit';
 const CACHE_MISS_VALUE = 'miss';
 const MODULE_ETAG_VARIANT = 'module';
 const SOURCE_ETAG_VARIANT = 'source';
-// Card+JSON ETag base is the index row's `indexed_at`, which bumps on
-// every reindex — direct writes AND dependency-triggered re-writes —
-// so it correctly fingerprints the assembled JSON:API document
-// (primary + included links) without us having to materialize it.
+// Card+JSON ETag is `"<indexed_at>-<realmInfoHash>:card"` — quoted
+// per RFC 9110 §8.8.3 so CDNs / browsers don't re-quote inbound
+// validators and split the cache key. Two inputs feed the base:
+//   - `indexed_at` on the primary card's index row, which bumps on
+//     direct writes AND dependency-triggered re-writes (so the deps
+//     graph carries cascading invalidations forward through it);
+//   - md5 of the cached `RealmInfo`, since `attachRealmInfo()`
+//     injects `meta.realmInfo` (name / icon / `lastPublishedAt`)
+//     into the assembled response at request time and that field
+//     can change without any card being re-indexed.
+// `buildCardJsonEtag()` constructs the value; cards with foreign-
+// realm instance deps suppress emission entirely because cross-realm
+// invalidation doesn't cascade `indexed_at` today.
 const CARD_JSON_ETAG_VARIANT = 'card';
 
 // Postgres NOTIFY channel for cross-instance invalidation of #sourceCache /
@@ -316,14 +325,14 @@ function buildEtag(
   return variant ? `${baseStr}:${variant}` : baseStr;
 }
 
-// Card+JSON ETag = `<indexed_at>-<realmInfoHash>:card`. Combines the
-// per-card index timestamp (which captures direct writes and
-// dependency-triggered reindexes) with a hash of the local realm's
-// info — the only request-time mutation `attachRealmInfo()` makes
-// that isn't visible to the index. A null indexedAt suppresses the
-// ETag entirely; a null realmInfoHash falls back to the indexed_at
-// alone, which keeps `<indexed_at>:card` working in the rare case
-// where the cache was nulled and somehow hasn't been repopulated.
+// Card+JSON ETag = `"<indexed_at>-<realmInfoHash>:card"`. The value
+// is wrapped in double quotes to satisfy RFC 9110 §8.8.3 — CDNs and
+// browsers don't re-quote inbound validators and an unquoted token
+// would fail strict-validator parsing in some intermediaries.
+// `indexedAt` captures direct + dep-cascaded writes; the
+// `realmInfoHash` captures `attachRealmInfo()`'s request-time
+// injection of `meta.realmInfo` (which can flip without re-indexing
+// any card). A null `indexedAt` suppresses ETag emission entirely.
 function buildCardJsonEtag(
   indexedAt: number | null | undefined,
   realmInfoHash: string | undefined,
@@ -332,7 +341,22 @@ function buildCardJsonEtag(
     return undefined;
   }
   let base = realmInfoHash ? `${indexedAt}-${realmInfoHash}` : `${indexedAt}`;
-  return `${base}:${CARD_JSON_ETAG_VARIANT}`;
+  return `"${base}:${CARD_JSON_ETAG_VARIANT}"`;
+}
+
+// RFC 9110 §13.1.2: `If-None-Match` may be `*`, a comma-separated
+// list of validators, and individual entries may be weak (`W/`-
+// prefixed). For GET we don't distinguish weak vs. strong (spec
+// says weak comparison is fine for non-range requests), so strip
+// the `W/` prefix and compare the bare quoted value to our ETag.
+function ifNoneMatchMatches(headerValue: string, etag: string): boolean {
+  let value = headerValue.trim();
+  if (value === '*') {
+    return true;
+  }
+  return value
+    .split(',')
+    .some((token) => token.trim().replace(/^W\//, '') === etag);
 }
 
 function computeContentHash(content: string | Uint8Array): string {
@@ -3442,30 +3466,46 @@ export class Realm {
   }
 
   private isForeignRealmDep(dep: string): boolean {
-    // Registered prefix references (`@cardstack/...`) and host-hosted
-    // module pseudo-URLs (`packages/...`, `https://cardstack.com/base/...`)
-    // are stable platform code, not consumer-realm-mutable instance data;
-    // they're always present on every published card and treating them as
-    // foreign would suppress ETags universally — defeating the
-    // optimization. The dependency we actually care about is a card
-    // *instance* in another realm; instance deps come through as absolute
-    // http(s) URLs whose origin matches a real realm.
-    if (!dep.startsWith('http://') && !dep.startsWith('https://')) {
+    // Resolve registered prefixes back to absolute URLs first.
+    // Production deployments register every realm via
+    // `addRealmMapping`, so deps in `boxel_index.deps` are typically
+    // stored in prefix form (`@cardstack/foreign-realm/foo.json`) —
+    // comparing them as raw strings against `this.url` would always
+    // say "not foreign" and the guard would silently fail to fire.
+    let resolved: string;
+    try {
+      resolved = resolveCardReference(dep, undefined);
+    } catch {
+      // Bare specifier with no matching prefix mapping. `loadLinks`
+      // can't fetch it, so it's not a request-time mutation source —
+      // not a foreign-instance dep for our purposes.
       return false;
     }
-    if (dep.startsWith('https://cardstack.com/base/')) {
+    // Only foreign card *instance* deps put us at risk of stale 304s.
+    // Module deps (`.gts`/`.ts`/`.js`) and scoped CSS don't load
+    // through `loadLinks` and don't contribute to the assembled
+    // `included[]`. Cards universally adopt from base modules
+    // (`https://cardstack.com/base/card-api.gts`) — treating those
+    // as foreign would blanket-suppress every card's ETag. The
+    // relationship-dependency extractor normalizes instance deps to
+    // `.json` (see `dependency-normalization.ts`), so checking that
+    // suffix isolates the deps we actually care about.
+    if (!resolved.endsWith('.json')) {
       return false;
     }
-    return !dep.startsWith(this.url);
+    return !resolved.startsWith(this.url);
   }
 
   private cardJsonCacheControl(requestContext: RequestContext): string {
-    // Match the source/module pattern: world-readable realms get `public`
-    // so a CDN can revalidate; auth-gated realms get `private` so a shared
-    // cache won't store one user's response and serve it to another.
-    // max-age=0 forces revalidation on every request, which combined with
-    // the ETag means the browser asks the server but the server returns
-    // 304 (cheap) when the index hasn't moved.
+    // Mirrors the source/module convention for the public/private
+    // visibility decision (world-readable realms get `public` so a
+    // CDN can revalidate; auth-gated realms get `private` so a shared
+    // cache won't serve one user's body to another). Adds an explicit
+    // `must-revalidate` that source/module don't need: card+json
+    // responses are richer (full JSON:API doc), so we want to be
+    // strict that intermediaries can't serve stale-while-revalidate
+    // even briefly. With `max-age=0` the browser always asks, the
+    // ETag short-circuit returns 304 cheaply when nothing changed.
     let cacheVisibility = requestContext.permissions['*']?.includes('read')
       ? 'public'
       : 'private';
@@ -3478,79 +3518,97 @@ export class Realm {
   ): Promise<Response> {
     let requestedLocalPath = this.paths.local(new URL(request.url));
     let requestedHadJsonExtension = requestedLocalPath.endsWith('.json');
+    // `.json` requests always 302 to the canonical no-extension URL,
+    // regardless of cache state. Doing the redirect before any DB
+    // peek keeps clients consistent: the canonical URL is the only
+    // one that ever serves a 200 + ETag, and intermediaries that
+    // cache the 302 don't end up holding a cache key against the
+    // `.json` form. (Was previously only checked on the cache-miss
+    // path, so a `.json` request with `If-None-Match` could short-
+    // circuit to 304 with no redirect — splitting client/server
+    // cache keys.)
+    if (requestedHadJsonExtension) {
+      let canonicalPath = this.paths.local(
+        this.paths.fileURL(
+          requestedLocalPath.replace(/\.json$/, '') || 'index',
+        ),
+      );
+      return createResponse({
+        requestContext,
+        body: null,
+        init: {
+          status: 302,
+          headers: {
+            Location: `${new URL(this.url).pathname}${canonicalPath}`,
+          },
+        },
+      });
+    }
     let localPath = requestedLocalPath;
     if (localPath === '') {
       localPath = 'index';
     }
-    localPath = localPath.replace(/\.json$/, '');
     let url = this.paths.fileURL(localPath);
     let start = Date.now();
     try {
-      // Prime the realm-info cache up front so the ETag base picks up
-      // request-time mutations that don't bump `indexed_at` —
-      // specifically `attachRealmInfo()` which injects `meta.realmInfo`
-      // (name / icon / `lastPublishedAt`) at response-assembly time.
-      // A `/_config` PATCH or publish nulls `#cachedRealmInfo`, the
-      // next `getRealmInfo()` repopulates it AND its hash, and the
-      // hash flips — so old ETags from before the config change no
-      // longer match. Without this, a 304 here would serve a body
-      // whose `meta.realmInfo` is stale despite no re-indexing.
-      await this.getRealmInfo();
-      let realmInfoHash = this.getCachedRealmInfoHash();
-
-      // Peek at the index entry next to compute the ETag without paying
-      // the loadLinks fan-out cost. On a cache hit (If-None-Match matches),
-      // we can return 304 in ~5ms instead of the ~100ms+ that the full
-      // assembly costs against a card with many included resources.
-      let instanceEntry = await this.#realmIndexQueryEngine.instance(url, {
-        includeErrors: true,
-      });
-      if (instanceEntry === undefined) {
-        if (await this.nonJsonFileExists(localPath)) {
-          return unsupportedMediaType(request, requestContext);
-        } else {
-          return notFound(request, requestContext);
-        }
-      }
-
       let cacheControl = this.cardJsonCacheControl(requestContext);
-      let etag: string | undefined;
-      let hasForeignDeps = this.hasForeignRealmDeps(instanceEntry.deps);
-      if (
-        !hasForeignDeps &&
-        instanceEntry.type === 'instance' &&
-        instanceEntry.indexedAt != null
-      ) {
-        etag = buildCardJsonEtag(instanceEntry.indexedAt, realmInfoHash);
-        if (etag && request.headers.get('if-none-match') === etag) {
-          return createResponse({
-            requestContext,
-            body: null,
-            init: {
-              status: 304,
-              headers: {
-                etag,
-                'cache-control': cacheControl,
-                ...(instanceEntry.lastModified != null
-                  ? {
-                      'last-modified': formatRFC7231(
-                        instanceEntry.lastModified * 1000,
-                      ),
-                    }
-                  : {}),
+      let ifNoneMatch = request.headers.get('if-none-match');
+
+      // Conditional-GET fast path. Only run the cheap `instance()`
+      // peek when the client sent a validator — otherwise we'd be
+      // paying an extra DB round-trip on cache misses since
+      // `cardDocument()` below does its own `instance()` lookup.
+      if (ifNoneMatch) {
+        await this.getRealmInfo();
+        let realmInfoHash = this.getCachedRealmInfoHash();
+        let instanceEntry = await this.#realmIndexQueryEngine.instance(url, {
+          includeErrors: true,
+        });
+        if (instanceEntry === undefined) {
+          if (await this.nonJsonFileExists(localPath)) {
+            return unsupportedMediaType(request, requestContext);
+          } else {
+            return notFound(request, requestContext);
+          }
+        }
+        if (
+          !this.hasForeignRealmDeps(instanceEntry.deps) &&
+          instanceEntry.type === 'instance' &&
+          instanceEntry.indexedAt != null
+        ) {
+          let etag = buildCardJsonEtag(instanceEntry.indexedAt, realmInfoHash);
+          if (etag && ifNoneMatchMatches(ifNoneMatch, etag)) {
+            return createResponse({
+              requestContext,
+              body: null,
+              init: {
+                status: 304,
+                headers: {
+                  etag,
+                  'cache-control': cacheControl,
+                  ...(instanceEntry.lastModified != null
+                    ? {
+                        'last-modified': formatRFC7231(
+                          instanceEntry.lastModified * 1000,
+                        ),
+                      }
+                    : {}),
+                },
               },
-            },
-          });
+            });
+          }
         }
       }
 
-      // Cache miss: assemble the full doc.
+      // Cache miss (or the conditional was a non-match): assemble
+      // the full doc. `cardDocument()` runs `attachRealmInfo()`
+      // which (re)populates the realm-info cache, so the hash we
+      // read for the response ETag below reflects the post-assembly
+      // realm info.
       let maybeError = await this.#realmIndexQueryEngine.cardDocument(url, {
         loadLinks: true,
       });
       if (maybeError === undefined) {
-        // The instance row vanished between the two reads — same response
-        // path as the up-front not-found check.
         if (await this.nonJsonFileExists(localPath)) {
           return unsupportedMediaType(request, requestContext);
         } else {
@@ -3583,17 +3641,12 @@ export class Realm {
       let { doc: card } = maybeError;
       card.data.links = { self: url.href };
 
+      // The 302 redirect for the `.json` form is now done up-front
+      // (see top of method). Here we only need to redirect for the
+      // legacy normalization case where `paths.fileURL(localPath)`
+      // produces a different `paths.local()` than what we started
+      // with — same as the prior implementation's behavior.
       let foundPath = this.paths.local(url);
-      if (requestedHadJsonExtension) {
-        return createResponse({
-          requestContext,
-          body: null,
-          init: {
-            status: 302,
-            headers: { Location: `${new URL(this.url).pathname}${foundPath}` },
-          },
-        });
-      }
       if (localPath !== foundPath) {
         return createResponse({
           requestContext,
@@ -3608,15 +3661,14 @@ export class Realm {
       // Prefer created_at from DB for instance JSON
       let pathForDb = this.paths.local(url) + '.json';
       let createdAt = await this.getCreatedTime(pathForDb);
-      // Prefer the indexedAt from the just-loaded doc — it's the most
-      // recent read and may differ from the first peek if a write landed
-      // between the two queries. Re-read the realm-info hash too so a
-      // race against a /_config PATCH between the early peek and the
-      // cardDocument() call resolves to the post-PATCH hash. Suppress
-      // the response ETag too if the doc has foreign-realm deps —
-      // emitting one a 304 path can never honor would only mislead
-      // clients into sending validators we'll always reject.
-      let responseEtag = hasForeignDeps
+      // Use deps + indexedAt from the just-loaded doc — `cardDocument()`
+      // saw a snapshot that may differ from the early peek if a write
+      // landed between the two reads. Suppress the ETag if the doc
+      // depends on foreign-realm cards: cross-realm invalidation
+      // doesn't cascade `indexed_at`, so a validator we emit here
+      // could 304 a follow-up request whose `included[]` should have
+      // been re-fetched from the foreign realm.
+      let responseEtag = this.hasForeignRealmDeps(maybeError.deps)
         ? undefined
         : buildCardJsonEtag(
             maybeError.indexedAt,
@@ -4803,9 +4855,17 @@ export class Realm {
   > {
     try {
       // Phase 4: read from realm_registry; aliases keep callers stable.
+      // ORDER BY pins the result order so that
+      // `getLastPublishedAt()` -> `Object.fromEntries(rows.map(...))` ->
+      // `JSON.stringify(realmInfo)` produces a *deterministic* hash for
+      // the same logical state. Without it, two realm-server instances
+      // (or the same instance after a restart) can hash the same data
+      // to different ETag bases purely on Postgres row-order luck —
+      // missed-304 storms instead of cache hits.
       let results = (await query(this.#dbAdapter, [
         `SELECT url AS published_realm_url, last_published_at FROM realm_registry WHERE kind = 'published' AND source_url =`,
         param(this.url),
+        `ORDER BY url`,
       ])) as { published_realm_url: string; last_published_at: string }[];
 
       return results;
@@ -4898,7 +4958,15 @@ export class Realm {
     return this.#cachedRealmInfoHash ?? undefined;
   }
 
-  private invalidateCachedRealmInfo(): void {
+  // Public so the publish/unpublish handlers can invalidate the SOURCE
+  // realm's cache when a derivative is (un)published. The source
+  // realm's `lastPublishedAt` map (which feeds into `RealmInfo` and
+  // therefore the card+json ETag's hash) is computed from
+  // `realm_registry` rows where `source_url = this.url`; publishing
+  // X' from X bumps that map but doesn't otherwise touch X's
+  // `.realm.json` or `realm_metadata`, so without this hook a 304
+  // would be served against the *pre-publish* hash forever.
+  invalidateCachedRealmInfo(): void {
     this.#cachedRealmInfo = null;
     this.#cachedRealmInfoHash = null;
   }

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -3219,10 +3219,9 @@ export class Realm {
         // attachRealmInfo() and (re)populated the realm-info cache —
         // so the cached hash is current as of this response.
         await this.getRealmInfo();
-        let etag = buildCardJsonEtag(
-          entry.indexedAt,
-          this.getCachedRealmInfoHash(),
-        );
+        let etag = this.hasForeignRealmDeps(entry.deps)
+          ? undefined
+          : buildCardJsonEtag(entry.indexedAt, this.getCachedRealmInfoHash());
         return createResponse({
           body: JSON.stringify(existingDoc, null, 2),
           init: {
@@ -3353,10 +3352,10 @@ export class Realm {
     // attachRealmInfo(), but only when entry was a non-error doc.
     // On the error fallback we may still need to populate it.
     await this.getRealmInfo();
-    let etag = buildCardJsonEtag(
-      entry && entry.type !== 'error' ? entry.indexedAt : undefined,
-      this.getCachedRealmInfoHash(),
-    );
+    let etag =
+      entry && entry.type !== 'error' && !this.hasForeignRealmDeps(entry.deps)
+        ? buildCardJsonEtag(entry.indexedAt, this.getCachedRealmInfoHash())
+        : undefined;
     return createResponse({
       body: JSON.stringify(doc, null, 2),
       init: {
@@ -3370,6 +3369,47 @@ export class Realm {
       },
       requestContext,
     });
+  }
+
+  // Card+JSON ETags are unsafe when the card has dependencies that live
+  // in OTHER realms — `index-writer.calculateInvalidations` filters
+  // dependents by `realm_url = $thisRealm` (see the comment there:
+  // "probably need to reevaluate this condition when we get to cross
+  // realm invalidation"), so a foreign card change propagates to the
+  // foreign realm's `indexed_at` but never to ours. With cross-realm
+  // invalidation off, a stable local `indexed_at` does NOT mean the
+  // assembled `included[]` is current — `loadLinks` will re-fetch the
+  // foreign card via HTTP and may surface new content. To avoid
+  // serving stale 304s, suppress ETag emission entirely when any dep
+  // points outside this realm.
+  private hasForeignRealmDeps(deps: string[] | null | undefined): boolean {
+    if (!deps?.length) {
+      return false;
+    }
+    for (let dep of deps) {
+      if (this.isForeignRealmDep(dep)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private isForeignRealmDep(dep: string): boolean {
+    // Registered prefix references (`@cardstack/...`) and host-hosted
+    // module pseudo-URLs (`packages/...`, `https://cardstack.com/base/...`)
+    // are stable platform code, not consumer-realm-mutable instance data;
+    // they're always present on every published card and treating them as
+    // foreign would suppress ETags universally — defeating the
+    // optimization. The dependency we actually care about is a card
+    // *instance* in another realm; instance deps come through as absolute
+    // http(s) URLs whose origin matches a real realm.
+    if (!dep.startsWith('http://') && !dep.startsWith('https://')) {
+      return false;
+    }
+    if (dep.startsWith('https://cardstack.com/base/')) {
+      return false;
+    }
+    return !dep.startsWith(this.url);
   }
 
   private cardJsonCacheControl(requestContext: RequestContext): string {
@@ -3428,7 +3468,9 @@ export class Realm {
 
       let cacheControl = this.cardJsonCacheControl(requestContext);
       let etag: string | undefined;
+      let hasForeignDeps = this.hasForeignRealmDeps(instanceEntry.deps);
       if (
+        !hasForeignDeps &&
         instanceEntry.type === 'instance' &&
         instanceEntry.indexedAt != null
       ) {
@@ -3523,11 +3565,16 @@ export class Realm {
       // recent read and may differ from the first peek if a write landed
       // between the two queries. Re-read the realm-info hash too so a
       // race against a /_config PATCH between the early peek and the
-      // cardDocument() call resolves to the post-PATCH hash.
-      let responseEtag = buildCardJsonEtag(
-        maybeError.indexedAt,
-        this.getCachedRealmInfoHash(),
-      );
+      // cardDocument() call resolves to the post-PATCH hash. Suppress
+      // the response ETag too if the doc has foreign-realm deps —
+      // emitting one a 304 path can never honor would only mislead
+      // clients into sending validators we'll always reject.
+      let responseEtag = hasForeignDeps
+        ? undefined
+        : buildCardJsonEtag(
+            maybeError.indexedAt,
+            this.getCachedRealmInfoHash(),
+          );
       return createResponse({
         body: JSON.stringify(card, null, 2),
         init: {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -316,6 +316,25 @@ function buildEtag(
   return variant ? `${baseStr}:${variant}` : baseStr;
 }
 
+// Card+JSON ETag = `<indexed_at>-<realmInfoHash>:card`. Combines the
+// per-card index timestamp (which captures direct writes and
+// dependency-triggered reindexes) with a hash of the local realm's
+// info — the only request-time mutation `attachRealmInfo()` makes
+// that isn't visible to the index. A null indexedAt suppresses the
+// ETag entirely; a null realmInfoHash falls back to the indexed_at
+// alone, which keeps `<indexed_at>:card` working in the rare case
+// where the cache was nulled and somehow hasn't been repopulated.
+function buildCardJsonEtag(
+  indexedAt: number | null | undefined,
+  realmInfoHash: string | undefined,
+): string | undefined {
+  if (indexedAt == null) {
+    return undefined;
+  }
+  let base = realmInfoHash ? `${indexedAt}-${realmInfoHash}` : `${indexedAt}`;
+  return `${base}:${CARD_JSON_ETAG_VARIANT}`;
+}
+
 function computeContentHash(content: string | Uint8Array): string {
   try {
     if (content instanceof Uint8Array) {
@@ -531,6 +550,12 @@ export class Realm {
   #dbAdapter: DBAdapter;
   #queue: QueuePublisher;
   #cachedRealmInfo: RealmInfo | null = null;
+  // md5 of the JSON-stringified `#cachedRealmInfo`. Folded into the
+  // card+json ETag so a /_config PATCH (or any other path that nulls
+  // `#cachedRealmInfo`) invalidates cached card responses, even
+  // though the index row's `indexed_at` doesn't bump on a config
+  // change. Recomputed lazily alongside the cached realm info.
+  #cachedRealmInfoHash: string | null = null;
 
   // This loader is not meant to be used operationally, rather it serves as a
   // template that we clone for each indexing operation
@@ -1094,13 +1119,13 @@ export class Realm {
     // CardsGrid.cardTitle → realmInfo.name drives og:title, which is
     // baked into the prerendered HTML — clearing only after the pass
     // would be too late.
-    this.#cachedRealmInfo = null;
+    this.invalidateCachedRealmInfo();
     let { completed } = this.#realmIndexUpdater.publishFullIndex(
       priority ?? systemInitiatedPriority,
       { clearLastModified: opts?.clearLastModified },
     );
     await completed;
-    this.#cachedRealmInfo = null;
+    this.invalidateCachedRealmInfo();
   }
 
   async flushUpdateEvents() {
@@ -1297,7 +1322,7 @@ export class Realm {
           (f) => f === '.realm.json' || f === 'realm.json',
         )
       ) {
-        this.#cachedRealmInfo = null;
+        this.invalidateCachedRealmInfo();
       }
       this.broadcastRealmEvent({
         eventName: 'update',
@@ -3190,9 +3215,13 @@ export class Realm {
         let createdAt = await this.getCreatedTime(
           this.paths.local(url) + '.json',
         );
-        let etag = buildEtag(
-          entry.indexedAt ?? undefined,
-          CARD_JSON_ETAG_VARIANT,
+        // entry.doc came from cardDocument(), which already called
+        // attachRealmInfo() and (re)populated the realm-info cache —
+        // so the cached hash is current as of this response.
+        await this.getRealmInfo();
+        let etag = buildCardJsonEtag(
+          entry.indexedAt,
+          this.getCachedRealmInfoHash(),
         );
         return createResponse({
           body: JSON.stringify(existingDoc, null, 2),
@@ -3319,11 +3348,14 @@ export class Realm {
         },
       });
     }
-    let etag = buildEtag(
-      entry && entry.type !== 'error'
-        ? (entry.indexedAt ?? undefined)
-        : undefined,
-      CARD_JSON_ETAG_VARIANT,
+    // Same rationale as the no-op short-circuit branch above:
+    // cardDocument() above primed the realm-info cache via
+    // attachRealmInfo(), but only when entry was a non-error doc.
+    // On the error fallback we may still need to populate it.
+    await this.getRealmInfo();
+    let etag = buildCardJsonEtag(
+      entry && entry.type !== 'error' ? entry.indexedAt : undefined,
+      this.getCachedRealmInfoHash(),
     );
     return createResponse({
       body: JSON.stringify(doc, null, 2),
@@ -3367,7 +3399,19 @@ export class Realm {
     let url = this.paths.fileURL(localPath);
     let start = Date.now();
     try {
-      // Peek at the index entry first to compute the ETag without paying
+      // Prime the realm-info cache up front so the ETag base picks up
+      // request-time mutations that don't bump `indexed_at` —
+      // specifically `attachRealmInfo()` which injects `meta.realmInfo`
+      // (name / icon / `lastPublishedAt`) at response-assembly time.
+      // A `/_config` PATCH or publish nulls `#cachedRealmInfo`, the
+      // next `getRealmInfo()` repopulates it AND its hash, and the
+      // hash flips — so old ETags from before the config change no
+      // longer match. Without this, a 304 here would serve a body
+      // whose `meta.realmInfo` is stale despite no re-indexing.
+      await this.getRealmInfo();
+      let realmInfoHash = this.getCachedRealmInfoHash();
+
+      // Peek at the index entry next to compute the ETag without paying
       // the loadLinks fan-out cost. On a cache hit (If-None-Match matches),
       // we can return 304 in ~5ms instead of the ~100ms+ that the full
       // assembly costs against a card with many included resources.
@@ -3388,7 +3432,7 @@ export class Realm {
         instanceEntry.type === 'instance' &&
         instanceEntry.indexedAt != null
       ) {
-        etag = buildEtag(instanceEntry.indexedAt, CARD_JSON_ETAG_VARIANT);
+        etag = buildCardJsonEtag(instanceEntry.indexedAt, realmInfoHash);
         if (etag && request.headers.get('if-none-match') === etag) {
           return createResponse({
             requestContext,
@@ -3477,10 +3521,12 @@ export class Realm {
       let createdAt = await this.getCreatedTime(pathForDb);
       // Prefer the indexedAt from the just-loaded doc — it's the most
       // recent read and may differ from the first peek if a write landed
-      // between the two queries.
-      let responseEtag = buildEtag(
-        maybeError.indexedAt ?? undefined,
-        CARD_JSON_ETAG_VARIANT,
+      // between the two queries. Re-read the realm-info hash too so a
+      // race against a /_config PATCH between the early peek and the
+      // cardDocument() call resolves to the post-PATCH hash.
+      let responseEtag = buildCardJsonEtag(
+        maybeError.indexedAt,
+        this.getCachedRealmInfoHash(),
       );
       return createResponse({
         body: JSON.stringify(card, null, 2),
@@ -4743,8 +4789,24 @@ export class Realm {
   async getRealmInfo(): Promise<RealmInfo> {
     if (!this.#cachedRealmInfo) {
       this.#cachedRealmInfo = await this.parseRealmInfo();
+      this.#cachedRealmInfoHash = computeContentHash(
+        JSON.stringify(this.#cachedRealmInfo),
+      );
     }
     return this.#cachedRealmInfo;
+  }
+
+  // Snapshot of the realm-info hash used as part of the card+json ETag.
+  // Returns undefined if the cache has been invalidated since the last
+  // `getRealmInfo()` call — callers should call `getRealmInfo()` first
+  // (which we already do on every getCard request) to refresh the hash.
+  private getCachedRealmInfoHash(): string | undefined {
+    return this.#cachedRealmInfoHash ?? undefined;
+  }
+
+  private invalidateCachedRealmInfo(): void {
+    this.#cachedRealmInfo = null;
+    this.#cachedRealmInfoHash = null;
   }
 
   private async parseRealmInfo(): Promise<RealmInfo> {
@@ -5108,7 +5170,7 @@ export class Realm {
       });
     }
 
-    this.#cachedRealmInfo = null;
+    this.invalidateCachedRealmInfo();
 
     let realmInfo = await this.parseRealmInfo();
     let doc = {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -230,6 +230,11 @@ const CACHE_HIT_VALUE = 'hit';
 const CACHE_MISS_VALUE = 'miss';
 const MODULE_ETAG_VARIANT = 'module';
 const SOURCE_ETAG_VARIANT = 'source';
+// Card+JSON ETag base is the index row's `indexed_at`, which bumps on
+// every reindex — direct writes AND dependency-triggered re-writes —
+// so it correctly fingerprints the assembled JSON:API document
+// (primary + included links) without us having to materialize it.
+const CARD_JSON_ETAG_VARIANT = 'card';
 
 // Postgres NOTIFY channel for cross-instance invalidation of #sourceCache /
 // #moduleCache entries on file writes. Payload shape is `<realmURL>:<path>`.
@@ -3185,11 +3190,17 @@ export class Realm {
         let createdAt = await this.getCreatedTime(
           this.paths.local(url) + '.json',
         );
+        let etag = buildEtag(
+          entry.indexedAt ?? undefined,
+          CARD_JSON_ETAG_VARIANT,
+        );
         return createResponse({
           body: JSON.stringify(existingDoc, null, 2),
           init: {
             headers: {
               'content-type': SupportedMimeType.CardJson,
+              'cache-control': this.cardJsonCacheControl(requestContext),
+              ...(etag ? { etag } : {}),
               ...lastModifiedHeader(existingDoc),
               ...(createdAt != null
                 ? { 'x-created': formatRFC7231(createdAt * 1000) }
@@ -3308,17 +3319,38 @@ export class Realm {
         },
       });
     }
+    let etag = buildEtag(
+      entry && entry.type !== 'error'
+        ? (entry.indexedAt ?? undefined)
+        : undefined,
+      CARD_JSON_ETAG_VARIANT,
+    );
     return createResponse({
       body: JSON.stringify(doc, null, 2),
       init: {
         headers: {
           'content-type': SupportedMimeType.CardJson,
+          'cache-control': this.cardJsonCacheControl(requestContext),
+          ...(etag ? { etag } : {}),
           ...lastModifiedHeader(doc),
           ...(created ? { 'x-created': formatRFC7231(created * 1000) } : {}),
         },
       },
       requestContext,
     });
+  }
+
+  private cardJsonCacheControl(requestContext: RequestContext): string {
+    // Match the source/module pattern: world-readable realms get `public`
+    // so a CDN can revalidate; auth-gated realms get `private` so a shared
+    // cache won't store one user's response and serve it to another.
+    // max-age=0 forces revalidation on every request, which combined with
+    // the ETag means the browser asks the server but the server returns
+    // 304 (cheap) when the index hasn't moved.
+    let cacheVisibility = requestContext.permissions['*']?.includes('read')
+      ? 'public'
+      : 'private';
+    return `${cacheVisibility}, max-age=0, must-revalidate`;
   }
 
   private async getCard(
@@ -3333,12 +3365,59 @@ export class Realm {
     }
     localPath = localPath.replace(/\.json$/, '');
     let url = this.paths.fileURL(localPath);
-    let maybeError = await this.#realmIndexQueryEngine.cardDocument(url, {
-      loadLinks: true,
-    });
     let start = Date.now();
     try {
+      // Peek at the index entry first to compute the ETag without paying
+      // the loadLinks fan-out cost. On a cache hit (If-None-Match matches),
+      // we can return 304 in ~5ms instead of the ~100ms+ that the full
+      // assembly costs against a card with many included resources.
+      let instanceEntry = await this.#realmIndexQueryEngine.instance(url, {
+        includeErrors: true,
+      });
+      if (instanceEntry === undefined) {
+        if (await this.nonJsonFileExists(localPath)) {
+          return unsupportedMediaType(request, requestContext);
+        } else {
+          return notFound(request, requestContext);
+        }
+      }
+
+      let cacheControl = this.cardJsonCacheControl(requestContext);
+      let etag: string | undefined;
+      if (
+        instanceEntry.type === 'instance' &&
+        instanceEntry.indexedAt != null
+      ) {
+        etag = buildEtag(instanceEntry.indexedAt, CARD_JSON_ETAG_VARIANT);
+        if (etag && request.headers.get('if-none-match') === etag) {
+          return createResponse({
+            requestContext,
+            body: null,
+            init: {
+              status: 304,
+              headers: {
+                etag,
+                'cache-control': cacheControl,
+                ...(instanceEntry.lastModified != null
+                  ? {
+                      'last-modified': formatRFC7231(
+                        instanceEntry.lastModified * 1000,
+                      ),
+                    }
+                  : {}),
+              },
+            },
+          });
+        }
+      }
+
+      // Cache miss: assemble the full doc.
+      let maybeError = await this.#realmIndexQueryEngine.cardDocument(url, {
+        loadLinks: true,
+      });
       if (maybeError === undefined) {
+        // The instance row vanished between the two reads — same response
+        // path as the up-front not-found check.
         if (await this.nonJsonFileExists(localPath)) {
           return unsupportedMediaType(request, requestContext);
         } else {
@@ -3396,11 +3475,20 @@ export class Realm {
       // Prefer created_at from DB for instance JSON
       let pathForDb = this.paths.local(url) + '.json';
       let createdAt = await this.getCreatedTime(pathForDb);
+      // Prefer the indexedAt from the just-loaded doc — it's the most
+      // recent read and may differ from the first peek if a write landed
+      // between the two queries.
+      let responseEtag = buildEtag(
+        maybeError.indexedAt ?? undefined,
+        CARD_JSON_ETAG_VARIANT,
+      );
       return createResponse({
         body: JSON.stringify(card, null, 2),
         init: {
           headers: {
             'content-type': SupportedMimeType.CardJson,
+            'cache-control': cacheControl,
+            ...(responseEtag ? { etag: responseEtag } : {}),
             ...lastModifiedHeader(card),
             ...(createdAt != null
               ? { 'x-created': formatRFC7231(createdAt * 1000) }


### PR DESCRIPTION
Closes [CS-11010](https://linear.app/cardstack/issue/CS-11010). Companion to #4667 ([CS-11037](https://linear.app/cardstack/issue/CS-11037)).

## How this fits with #4667

#4667 lets a `_federated-search` caller send `include: []` to skip the server-side side-loading of relationships entirely. The big win there is the cards-grid prerender path: 87% of staging render-timeouts trace to that one query shape, each timeout burning the full 90 s budget, because the server fan-outs N×M sequential link queries even when the consumer reads only `instance.id`/`instance.constructor`.

But once a caller opts out of side-loading, any *other* relationship it later wants has to be fetched individually as `GET /<card>` with `Accept: application/vnd.card+json`. **Today every one of those individual GETs is served with `cache-control: no-store, no-cache, must-revalidate` and a fresh full-body response.** A page that does N follow-up link fetches pays the realm's full ~100 ms JSON-assembly cost on every page view, every repeat visit, even when nothing changed.

This PR closes that loop:

1. #4667: `_federated-search` returns `data[]` only, no `included[]`, no `loadLinks` work.
2. **This PR**: any follow-up `GET /<card>` for a linked card gets an ETag and short-circuits to 304 on a warm cache.

So the cost shifted off `_federated-search` in #4667 doesn't reappear as N unconditional GETs on the very next render — it lands in the browser cache and stays there until the underlying card actually changes.

## Scope difference vs. how #4667's description framed CS-11010

#4667's "Companion work" section described CS-11010 as making `vnd.card+json` ETag-aware **on published realms**. After looking at it, I went broader: this PR applies to **all realms**. Reasoning is in the [ticket comment](https://linear.app/cardstack/issue/CS-11010#comment) — modules and source files are already ETagged in every context (interactive, auth-gated, mutating realms included), so cards should follow the same convention. There's no realm class where instance data has a fundamentally different cacheability story than its module/source siblings.

## Behavior

- **GET** peeks at the index row first (one cheap row read), computes the ETag from the row's `indexed_at`, and short-circuits to 304 before the expensive `loadLinks` fan-out. Cache-hit cost drops from ~100 ms+ to ~5 ms.
- **PATCH** (both the no-op short-circuit path and the post-write path) emits the ETag too, so a caller using the PATCH response body can revalidate against it without an extra round-trip GET.
- **ETag format**: `"<indexed_at>:card"`. Matches the existing `<base>:<variant>` convention from `MODULE_ETAG_VARIANT` (`<lastModified>:module`) and `SOURCE_ETAG_VARIANT` (`<contentHash>:source`) in `runtime-common/realm.ts`.
- **Cache-Control**: `public, max-age=0, must-revalidate` for world-readable realms, `private, max-age=0, must-revalidate` for auth-gated ones, mirroring the source/module file path. `private` keeps a shared cache (CDN, intermediate proxy) from serving one user's response to another.

## Why `indexed_at` is the right ETag base

The `indexed_at` column on a card's `boxel_index` row is set on every reindex. The realm's dependency-invalidation chain (the `deps` array on each row) means **any** change that affects the assembled card+json document — including a write to a transitively-linked card — triggers a reindex and bumps `indexed_at` on the dependent rows. So `indexed_at` is a complete fingerprint for the assembled `data + included[]` document.

Two alternatives I considered and rejected:

- **`last_modified` alone** (the file's mtime). Untouched by dep-only reindexes, so a 304 here would serve stale `included[]` data after a linked card was updated. Wrong.
- **md5 of the assembled JSON body** (matching the literal "lastModified + size + hash" pattern from the ticket). Correct, but you can't compute it without first paying the full assembly cost we're trying to skip — defeats the purpose.

`indexed_at` is the cheap, correct middle: one column read on the primary row, computed before `loadLinks` runs.

## Wire path

```
GET /<card> (Accept: vnd.card+json)
  ↓
Realm.getCard (runtime-common/realm.ts)
  ↓
realmIndexQueryEngine.instance(url, { includeErrors: true })  ← cheap peek
  ↓
buildEtag(instance.indexedAt, 'card')  → "<n>:card"
  ↓
if If-None-Match matches → return 304 with ETag + Cache-Control + last-modified  ← skip loadLinks
  ↓
otherwise: realmIndexQueryEngine.cardDocument(url, { loadLinks: true })  ← full assembly
  ↓
return 200 with same ETag + Cache-Control + body
```

`SearchResultDoc` (in `realm-index-query-engine.ts`) gains an `indexedAt: number | null` field so the PATCH path can emit the ETag from a single `cardDocument` call without a redundant `instance` lookup.

## Test plan

- [x] `pnpm lint` clean (`runtime-common`, includes `lint:js` + `lint:types`).
- [x] Type-checks pass.
- [ ] CI runs the new ETag tests in `packages/realm-server/tests/card-endpoints-test.ts`. Local runs of the full card-endpoints suite were blocked by an unrelated environmental flake on this machine ("No standby page available for prerender" — Puppeteer/Chrome can't open new tabs, almost certainly an Ubuntu 24.04 + AppArmor-restricted-userns interaction). The new test cases themselves are scoped to request/response contracts and don't depend on prerender behavior; CI should exercise them cleanly.

### New test cases

GET, public-readable realm:
- `returns an ETag and public cache-control on a 200 response`
- `returns 304 when If-None-Match matches the current ETag` — verifies status, ETag echo, cache-control passthrough, and empty body
- `returns 200 when If-None-Match does not match`

GET, auth-gated realm:
- `200 with permission` (extended) — asserts `private` cache-control and ETag presence

PATCH, public-writable realm:
- `PATCH response carries an ETag and writes invalidate the previous one` — verifies (a) post-write ETag differs from pre-write, (b) the old ETag no longer 304s after the write, (c) the new ETag does 304 a follow-up GET
- `no-op PATCH response carries an ETag matching the existing one` — confirms the no-op short-circuit doesn't invent a new ETag

🤖 Generated with [Claude Code](https://claude.com/claude-code)