### PR TITLE
Persist AI Assistant open/closed across sessions

### DIFF
--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -57,7 +57,10 @@ import type { BoxelContext } from 'https://cardstack.com/base/matrix-event';
 
 import { removeFileExtension } from '../utils/card-search/types';
 
-import { ModuleInspectorSelections } from '../utils/local-storage-keys';
+import {
+  AiAssistantOpen,
+  ModuleInspectorSelections,
+} from '../utils/local-storage-keys';
 
 import { normalizeDirPath } from '../utils/normalized-dir-path';
 
@@ -136,6 +139,15 @@ interface OpenFileSubscriber {
 export type ModuleInspectorView = 'schema' | 'spec' | 'preview';
 export const DEFAULT_MODULE_INSPECTOR_VIEW: ModuleInspectorView = 'schema';
 
+// Read the user's persisted AI Assistant open/closed preference. Defaults to
+// `true` for first-ever visits; URL state still takes precedence over this.
+function readPersistedAiAssistantOpen(): boolean {
+  let raw = window.localStorage.getItem(AiAssistantOpen);
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  return true;
+}
+
 export default class OperatorModeStateService extends Service {
   @tracked private _state: OperatorModeState = new TrackedObject({
     stacks: new TrackedArray<Stack>([]),
@@ -144,7 +156,7 @@ export default class OperatorModeStateService extends Service {
     hostModePrimaryCard: null,
     hostModeStack: [],
     openDirs: new TrackedMap<string, string[]>(),
-    aiAssistantOpen: true,
+    aiAssistantOpen: readPersistedAiAssistantOpen(),
     newFileDropdownOpen: false,
     cardPreviewFormat: 'isolated' as Format,
     workspaceChooserOpened: false,
@@ -217,11 +229,13 @@ export default class OperatorModeStateService extends Service {
 
   openAiAssistant = () => {
     this._state.aiAssistantOpen = true;
+    window.localStorage.setItem(AiAssistantOpen, 'true');
     this.schedulePersist();
   };
 
   closeAiAssistant = () => {
     this._state.aiAssistantOpen = false;
+    window.localStorage.setItem(AiAssistantOpen, 'false');
     this.schedulePersist();
   };
 
@@ -252,7 +266,7 @@ export default class OperatorModeStateService extends Service {
       hostModePrimaryCard: null,
       hostModeStack: new TrackedArray([]),
       openDirs: new TrackedMap<string, string[]>(),
-      aiAssistantOpen: false,
+      aiAssistantOpen: readPersistedAiAssistantOpen(),
       moduleInspector: DEFAULT_MODULE_INSPECTOR_VIEW,
       newFileDropdownOpen: false,
       cardPreviewFormat: 'isolated' as Format,
@@ -1027,7 +1041,8 @@ export default class OperatorModeStateService extends Service {
       openDirs,
       codeSelection: rawState.codeSelection,
       fieldSelection: rawState.fieldSelection,
-      aiAssistantOpen: rawState.aiAssistantOpen ?? false,
+      aiAssistantOpen:
+        rawState.aiAssistantOpen ?? readPersistedAiAssistantOpen(),
       moduleInspector:
         rawState.moduleInspector ?? DEFAULT_MODULE_INSPECTOR_VIEW,
       cardPreviewFormat: rawState.cardPreviewFormat ?? 'isolated',

--- a/packages/host/app/utils/local-storage-keys.ts
+++ b/packages/host/app/utils/local-storage-keys.ts
@@ -1,6 +1,7 @@
 export const CurrentRoomIdPersistenceKey = 'aiPanelCurrentRoomId';
 export const NewSessionIdPersistenceKey = 'aiPanelNewSessionId';
 export const AiAssistantPanelWidth = 'ai-assistant-panel-width';
+export const AiAssistantOpen = 'boxel-ai-assistant-open';
 export const CodeModePanelWidths = 'code-mode-panel-widths';
 export const CodeModePanelHeights = 'code-mode-panel-heights';
 export const ModuleInspectorSelections = 'code-mode-panel-selections';

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -503,6 +503,7 @@ module('Acceptance | operator mode tests', function (hooks) {
     assert
       .dom(`[data-test-cards-grid-item="${testRealmURL}grid"]`)
       .doesNotExist('grid cards do not show other grid cards');
+    await click('[data-test-open-ai-assistant]');
     await click('[data-test-close-ai-assistant]');
     assert.dom('[data-test-ask-ai-input]').exists();
 

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -7,10 +7,12 @@ import {
   setupApplicationTest as emberSetupApplicationTest,
   setupRenderingTest as emberSetupRenderingTest,
 } from 'ember-qunit';
+import window from 'ember-window-mock';
 import { setupWindowMock } from 'ember-window-mock/test-support';
 
 import { clearHtmlComponentCache } from '@cardstack/host/lib/html-component';
 import type ResetService from '@cardstack/host/services/reset';
+import { AiAssistantOpen } from '@cardstack/host/utils/local-storage-keys';
 
 import { clearRemoteRealmCache } from './realm-server-mock/routes';
 
@@ -285,9 +287,20 @@ function formatErrorForLog(error: unknown): string {
   return String(error);
 }
 
+// Seed the AI Assistant open/closed preference to 'false' before each test so
+// the existing test helpers (which click to open) are not double-toggled by
+// the persistence behavior added in CS-11071. Keeping tests deterministic and
+// matching the historical default of "panel closed until the test opens it".
+function seedAiAssistantClosed(hooks: NestedHooks) {
+  hooks.beforeEach(function () {
+    window.localStorage.setItem(AiAssistantOpen, 'false');
+  });
+}
+
 export function setupApplicationTest(hooks: NestedHooks) {
   emberSetupApplicationTest(hooks);
   setupWindowMock(hooks);
+  seedAiAssistantClosed(hooks);
   setupFetchDebugging(hooks);
   setupUnhandledRejectionDiagnostics(hooks);
   hooks.afterEach(async function () {
@@ -307,6 +320,7 @@ export function setupApplicationTest(hooks: NestedHooks) {
 export function setupRenderingTest(hooks: NestedHooks) {
   emberSetupRenderingTest(hooks);
   setupWindowMock(hooks);
+  seedAiAssistantClosed(hooks);
   setupFetchDebugging(hooks);
   setupUnhandledRejectionDiagnostics(hooks);
   hooks.afterEach(async function () {

--- a/packages/host/tests/unit/services/operator-mode-state-service-test.ts
+++ b/packages/host/tests/unit/services/operator-mode-state-service-test.ts
@@ -1,14 +1,18 @@
 import { getService } from '@universal-ember/test-support';
 import { setupTest } from 'ember-qunit';
+import { setupWindowMock } from 'ember-window-mock/test-support';
+import window from 'ember-window-mock';
 import { module, test } from 'qunit';
 
 import { Deferred } from '@cardstack/runtime-common';
 
 import { StackItem } from '@cardstack/host/lib/stack-item';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+import { AiAssistantOpen } from '@cardstack/host/utils/local-storage-keys';
 
 module('Unit | Service | operator-mode-state-service', function (hooks) {
   setupTest(hooks);
+  setupWindowMock(hooks);
 
   let service: OperatorModeStateService;
 
@@ -86,5 +90,65 @@ module('Unit | Service | operator-mode-state-service', function (hooks) {
         'file items are not mutated by setItemFormat',
       );
     });
+  });
+
+  test('openAiAssistant / closeAiAssistant persist preference to localStorage', function (assert) {
+    service.openAiAssistant();
+    assert.strictEqual(
+      window.localStorage.getItem(AiAssistantOpen),
+      'true',
+      'open writes true',
+    );
+    service.closeAiAssistant();
+    assert.strictEqual(
+      window.localStorage.getItem(AiAssistantOpen),
+      'false',
+      'close writes false',
+    );
+  });
+
+  test('URL aiAssistantOpen=true wins over localStorage=false', function (assert) {
+    window.localStorage.setItem(AiAssistantOpen, 'false');
+    service.restore({ stacks: [], aiAssistantOpen: true });
+    assert.true(
+      service.aiAssistantOpen,
+      'explicit true in URL overrides persisted closed preference',
+    );
+  });
+
+  test('URL aiAssistantOpen=false wins over localStorage=true', function (assert) {
+    window.localStorage.setItem(AiAssistantOpen, 'true');
+    service.restore({ stacks: [], aiAssistantOpen: false });
+    assert.false(
+      service.aiAssistantOpen,
+      'explicit false in URL overrides persisted open preference',
+    );
+  });
+
+  test('URL with no aiAssistantOpen key falls back to localStorage (closed)', function (assert) {
+    window.localStorage.setItem(AiAssistantOpen, 'false');
+    service.restore({ stacks: [] });
+    assert.false(
+      service.aiAssistantOpen,
+      'panel stays closed when URL state omits the key and localStorage says closed',
+    );
+  });
+
+  test('URL with no aiAssistantOpen key falls back to localStorage (open default)', function (assert) {
+    // no localStorage seeded — first-ever visit
+    service.restore({ stacks: [] });
+    assert.true(
+      service.aiAssistantOpen,
+      'panel opens by default when neither URL nor localStorage carry a preference',
+    );
+  });
+
+  test('resetState rereads persisted preference (logout/login cycle)', function (assert) {
+    window.localStorage.setItem(AiAssistantOpen, 'false');
+    service.resetState();
+    assert.false(
+      service.aiAssistantOpen,
+      'after reset, panel respects persisted closed preference',
+    );
   });
 });

--- a/packages/host/tests/unit/services/operator-mode-state-service-test.ts
+++ b/packages/host/tests/unit/services/operator-mode-state-service-test.ts
@@ -1,7 +1,7 @@
 import { getService } from '@universal-ember/test-support';
 import { setupTest } from 'ember-qunit';
-import { setupWindowMock } from 'ember-window-mock/test-support';
 import window from 'ember-window-mock';
+import { setupWindowMock } from 'ember-window-mock/test-support';
 import { module, test } from 'qunit';
 
 import { Deferred } from '@cardstack/runtime-common';


### PR DESCRIPTION
## Summary

- The AI Assistant panel re-opened on a fresh tab to a bare operator-mode URL (e.g. `realms-staging.stack.cards/ctse/surprising-jay/index`) even when the user had previously closed it. Rich operator-mode URLs already carrying `aiAssistantOpen` were unaffected.
- Root cause: `routes/index.gts:150` synthesizes a fresh `operatorModeState` query param when the URL has none, reading `aiAssistantOpen` from the in-memory service. The service's `TrackedObject` default was hardcoded `true`, so a freshly constructed service always baked `aiAssistantOpen: true` into the URL.
- Fix: back the open/closed state with localStorage (`boxel-ai-assistant-open`). The service constructor, `resetState`, and `deserialize` all fall through to localStorage when no URL state is present; URL state still wins when it explicitly carries the key (true *or* false). First-ever visits with no localStorage default to `open`, matching prior behavior.

Plan and design discussion in [the Linear comment on CS-11071](https://linear.app/cardstack/issue/CS-11071/ai-assistant-panel-keeps-opening-when-you-have-previously-closed-it).

## Test plan

- [ ] **Repro fixed**: log in to staging, close the AI Assistant panel, then open `https://realms-staging.stack.cards/<workspace>/index` in a fresh tab — panel stays closed.
- [ ] Open the panel, reload — stays open.
- [ ] Visit a URL with explicit `?...aiAssistantOpen=true...` after locally closing the panel — opens (URL wins).
- [ ] Visit a URL with explicit `?...aiAssistantOpen=false...` after locally opening the panel — closes (URL wins).
- [ ] First-ever visit on a fresh browser profile — panel opens.
- [ ] Log out / log back in — preference survives (localStorage is per-browser, not cleared on session reset).
- [ ] CI: new unit tests in `packages/host/tests/unit/services/operator-mode-state-service-test.ts` cover the four URL/localStorage permutations plus reset and persistence on open/close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)