### PR TITLE
Fix main CI breakage from PR #4671 (pipefail under dash) + close path-filter gap

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -17,6 +17,11 @@ on:
       - ".github/workflows/ci-host.yaml"
       - "package.json"
       - "pnpm-lock.yaml"
+      # CI boot path: see comment on the equivalent block in ci.yaml.
+      - ".mise.toml"
+      - ".github/actions/**"
+      - "mise-tasks/**"
+      - "packages/observability/scripts/**"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci-software-factory.yaml
+++ b/.github/workflows/ci-software-factory.yaml
@@ -19,6 +19,11 @@ on:
       - "packages/software-factory/**"
       - "package.json"
       - "pnpm-lock.yaml"
+      # CI boot path: see comment on the equivalent block in ci.yaml.
+      - ".mise.toml"
+      - ".github/actions/**"
+      - "mise-tasks/**"
+      - "packages/observability/scripts/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,12 @@ jobs:
               - 'packages/runtime-common/**'
               - 'package.json'
               - 'pnpm-lock.yaml'
+              # Test pipelines boot services via `mise run test-services:*`,
+              # which sources every script under mise-tasks/. dev-log-tee.sh is
+              # a runtime dep of the four service tasks. Treat both as part of
+              # the boot path so changes there don't slip past PR-time CI.
+              - 'mise-tasks/**'
+              - 'packages/observability/scripts/**'
             boxel:
               - *shared
               - '.github/workflows/build-host.yml'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,10 +47,15 @@ jobs:
               - 'packages/runtime-common/**'
               - 'package.json'
               - 'pnpm-lock.yaml'
-              # Test pipelines boot services via `mise run test-services:*`,
-              # which sources every script under mise-tasks/. dev-log-tee.sh is
-              # a runtime dep of the four service tasks. Treat both as part of
-              # the boot path so changes there don't slip past PR-time CI.
+              # CI boot path. Each gated suite runs `./.github/actions/init`
+              # (which calls `jdx/mise-action`, sourcing `.mise.toml` for tool
+              # versions) and then `mise run test-services:*` (which sources
+              # every script under mise-tasks/, with dev-log-tee.sh as a
+              # runtime dep). A breaking change to any of these can take down
+              # all the suites without matching a per-package filter — the
+              # exact failure mode that hid PR #4671.
+              - '.mise.toml'
+              - '.github/actions/**'
               - 'mise-tasks/**'
               - 'packages/observability/scripts/**'
             boxel:

--- a/mise-tasks/services/prerender
+++ b/mise-tasks/services/prerender
@@ -1,11 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #MISE description="Start prerender server for development"
 #MISE depends=["infra:ensure-traefik"]
 #MISE dir="packages/realm-server"
 
 # Propagate the prerender server's exit status through the trailing
 # `| dev-log-tee.sh` pipeline so mise sees crashes instead of the tee stage's
-# clean EOF.
+# clean EOF. `set -o pipefail` is a bashism — Ubuntu CI's /bin/sh is dash and
+# rejects it as "Illegal option", so this script must run under bash.
 set -o pipefail
 
 # Tee stdout+stderr to a per-service log file so the local Alloy scraper

--- a/mise-tasks/services/prerender-mgr
+++ b/mise-tasks/services/prerender-mgr
@@ -1,11 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #MISE description="Start prerender manager for development"
 #MISE depends=["infra:ensure-traefik"]
 #MISE dir="packages/realm-server"
 
 # Propagate the prerender-manager's exit status through the trailing
 # `| dev-log-tee.sh` pipeline so mise sees crashes instead of the tee stage's
-# clean EOF.
+# clean EOF. `set -o pipefail` is a bashism — Ubuntu CI's /bin/sh is dash and
+# rejects it as "Illegal option", so this script must run under bash.
 set -o pipefail
 
 # Tee stdout+stderr to a per-service log file so the local Alloy scraper

--- a/mise-tasks/services/realm-server
+++ b/mise-tasks/services/realm-server
@@ -1,10 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #MISE description="Start realm development server"
 #MISE depends=["infra:ensure-traefik", "infra:ensure-pg", "infra:ensure-db"]
 #MISE dir="packages/realm-server"
 
 # Propagate realm-server's exit status through the trailing `| dev-log-tee.sh`
 # pipeline so mise sees crashes instead of the tee stage's clean EOF.
+# `set -o pipefail` is a bashism — Ubuntu CI's /bin/sh is dash and rejects it
+# as "Illegal option", so this script must run under bash.
 set -o pipefail
 
 SCRIPTS_DIR="./scripts"

--- a/mise-tasks/services/worker
+++ b/mise-tasks/services/worker
@@ -1,10 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #MISE description="Start development worker manager"
 #MISE depends=["infra:ensure-traefik", "infra:ensure-pg", "infra:wait-for-prerender"]
 #MISE dir="packages/realm-server"
 
 # Propagate the worker's exit status through the trailing `| dev-log-tee.sh`
 # pipeline so mise sees crashes instead of the tee stage's clean EOF.
+# `set -o pipefail` is a bashism — Ubuntu CI's /bin/sh is dash and rejects it
+# as "Illegal option", so this script must run under bash.
 set -o pipefail
 
 # Tee stdout+stderr to a per-service log file so the local Alloy scraper


### PR DESCRIPTION
## Summary

Two coupled fixes for the CI failures on `main` since PR #4671 merged:

1. **Root cause** — PR #4671 added `set -o pipefail` to four mise tasks (`prerender`, `prerender-mgr`, `realm-server`, `worker`) that use `#!/bin/sh`. On Ubuntu CI, `/bin/sh` is dash, which rejects pipefail with `Illegal option -o pipefail` and exits immediately. When `services:prerender` died, `run-p` killed every sibling in the parallel group (matrix, smtp, icons, pg…), so Synapse never started and `register-realm-users` failed its 24×5s wait. This took out Host Tests, Live Tests, Matrix Tests, and Realm-Server Tests on every commit to main since c5abbaef. Switched the four scripts to `#!/usr/bin/env bash` and documented the dash incompatibility inline.

2. **Why the PR passed** — it didn't, it just didn't run. dorny/paths-filter only watches package dirs; changes under `mise-tasks/**` and `packages/observability/scripts/**` matched nothing, so every test suite was `SKIPPED` at PR time. Added both globs to the `shared` anchor in `ci.yaml` so they fan out to every gated suite.

Failing run for context: https://github.com/cardstack/boxel/actions/runs/25455491833 — `services:prerender` aborts at `19:11:29.31` with `Illegal option -o pipefail`, then matrix never comes up.

## Test plan

- [x] `bash -n` passes on the four touched mise tasks
- [x] YAML round-trips through a parser; `boxel`, `matrix`, `realm-server` filters pick up the new shared entries via the existing alias-merge pattern
- [ ] CI on this PR runs the full Host/Live/Matrix/Realm-Server suites (proves the path-filter fix took effect)
- [ ] `Create realm users` step succeeds (proves the pipefail fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)