### PR TITLE
CS-10897: drop published_realms table

### DIFF
--- a/packages/host/config/schema/1779100257123_schema.sql
+++ b/packages/host/config/schema/1779100257123_schema.sql
@@ -103,15 +103,6 @@
    PRIMARY KEY ( url, cache_scope, auth_user_id ) 
 );
 
- CREATE TABLE IF NOT EXISTS published_realms (
-   id DEFAULT (hex(randomblob(16))) NOT NULL,
-   owner_username TEXT NOT NULL,
-   source_realm_url TEXT NOT NULL,
-   published_realm_url TEXT NOT NULL,
-   last_published_at,
-   PRIMARY KEY ( id ) 
-);
-
  CREATE TABLE IF NOT EXISTS realm_file_meta (
    realm_url TEXT NOT NULL,
    file_path TEXT NOT NULL,

--- a/packages/matrix/tests/host-mode.spec.ts
+++ b/packages/matrix/tests/host-mode.spec.ts
@@ -314,7 +314,7 @@ test.describe('Host mode', () => {
     );
   });
 
-  test('visiting connect route with origin not in published_realms returns 404', async ({
+  test('visiting connect route with origin not in realm_registry returns 404', async ({
     page,
   }) => {
     let response = await page.goto(

--- a/packages/postgres/migrations/1779100257123_drop-published-realms.js
+++ b/packages/postgres/migrations/1779100257123_drop-published-realms.js
@@ -1,0 +1,44 @@
+exports.shorthands = undefined;
+
+// Phase 4 PR 2: drop the legacy `published_realms` table now that every
+// reader (Phase 4 PR 1, CS-10896) and writer (this PR, CS-10897) is on
+// `realm_registry`. The registry has carried the same data since the
+// Phase 1 backfill (1776961234567_backfill-realm-registry.js).
+//
+// Down migration recreates the table structure but does NOT restore data.
+// Rollback within the first 48 hours after deploy is structural-only; any
+// republishes/unpublishes between deploy and rollback won't be reflected
+// because handlers stop writing to `published_realms` in this PR.
+
+exports.up = (pgm) => {
+  pgm.dropIndex('published_realms', 'source_realm_url');
+  pgm.dropIndex('published_realms', 'published_realm_url');
+  pgm.dropTable('published_realms');
+};
+
+exports.down = (pgm) => {
+  pgm.createTable('published_realms', {
+    id: {
+      type: 'uuid',
+      primaryKey: true,
+      default: pgm.func('gen_random_uuid()'),
+    },
+    owner_username: {
+      type: 'varchar',
+      notNull: true,
+    },
+    source_realm_url: {
+      type: 'varchar',
+      notNull: true,
+    },
+    published_realm_url: {
+      type: 'varchar',
+      notNull: true,
+    },
+    last_published_at: {
+      type: 'bigint',
+    },
+  });
+  pgm.createIndex('published_realms', 'source_realm_url');
+  pgm.createIndex('published_realms', 'published_realm_url');
+};

--- a/packages/realm-server/handlers/handle-delete-realm.ts
+++ b/packages/realm-server/handlers/handle-delete-realm.ts
@@ -9,7 +9,6 @@ import {
   query,
   removeRealmPermissions,
   SupportedMimeType,
-  type PublishedRealmTable,
   update,
 } from '@cardstack/runtime-common';
 import { join } from 'path';
@@ -30,8 +29,8 @@ import {
   removeRealmFiles,
 } from './realm-destruction-utils';
 import {
-  deleteFromRegistryByUrl,
-  deletePublishedFromRegistryBySource,
+  deletePublishedRowsBySourceUrl,
+  deleteRegistryRowByUrl,
 } from '../lib/realm-registry-writes';
 import { withRealmWriteLock } from '../lib/realm-advisory-locks';
 
@@ -105,10 +104,9 @@ export default function handleDeleteRealm({
       }
       let sourceRealmPath = join(realmsRootPath, sourceRow[0].disk_id);
 
-      // Phase 4: existence check on realm_registry (kind='published')
-      // instead of the legacy published_realms table. SELECT 1 is aliased
-      // to AS found rather than relying on Postgres's default `?column?`
-      // unnamed-column label, which isn't portable across SQL adapters.
+      // SELECT 1 is aliased to AS found rather than relying on Postgres's
+      // default `?column?` unnamed-column label, which isn't portable
+      // across SQL adapters.
       let publishedRealmMatch = (await query(dbAdapter, [
         `SELECT 1 AS found FROM realm_registry WHERE kind = 'published' AND url =`,
         param(realmURL),
@@ -150,46 +148,35 @@ export default function handleDeleteRealm({
       // per-URL granularity rather than globally. Pragmatic for this PR;
       // multi-instance hardening could tighten this later.
       await withRealmWriteLock(dbAdapter, realmURL, async () => {
-        // Phase 4: cascade lookup reads realm_registry rather than
-        // published_realms. SQL aliases keep the loop body's field
-        // accessors stable.
         let publishedRealms = (await query(dbAdapter, [
-          `SELECT disk_id AS id, url AS published_realm_url FROM realm_registry WHERE kind = 'published' AND source_url =`,
+          `SELECT disk_id, url FROM realm_registry WHERE kind = 'published' AND source_url =`,
           param(realmURL),
-        ])) as Pick<PublishedRealmTable, 'id' | 'published_realm_url'>[];
+        ])) as { disk_id: string; url: string }[];
 
         for (let publishedRealm of publishedRealms) {
           let publishedRealmPath = join(
             realmsRootPath,
             PUBLISHED_DIRECTORY_NAME,
-            publishedRealm.id,
+            publishedRealm.disk_id,
           );
           try {
             removeRealmFiles(publishedRealmPath);
           } catch (error) {
             Sentry.captureException(error);
           }
-          await removeRealmPermissions(
-            dbAdapter,
-            new URL(publishedRealm.published_realm_url),
-          );
+          await removeRealmPermissions(dbAdapter, new URL(publishedRealm.url));
           await removeRealmDatabaseArtifacts({
             dbAdapter,
-            realmURL: publishedRealm.published_realm_url,
+            realmURL: publishedRealm.url,
           });
         }
-
-        await query(dbAdapter, [
-          `DELETE FROM published_realms WHERE source_realm_url =`,
-          param(realmURL),
-        ]);
 
         // Removes the source realm's registry row plus every published
         // row sourced from it; both DELETEs emit NOTIFY realm_registry
         // so the reconciler unmounts the affected realms on every
         // instance.
-        await deletePublishedFromRegistryBySource(dbAdapter, realmURL);
-        await deleteFromRegistryByUrl(dbAdapter, realmURL);
+        await deletePublishedRowsBySourceUrl(dbAdapter, realmURL);
+        await deleteRegistryRowByUrl(dbAdapter, realmURL);
 
         let { nameExpressions, valueExpressions } = asExpressions({
           removed_at: Math.floor(Date.now() / 1000),

--- a/packages/realm-server/handlers/handle-download-realm.ts
+++ b/packages/realm-server/handlers/handle-download-realm.ts
@@ -31,10 +31,6 @@ import {
 
 const log = logger('download-realm');
 
-type PublishedRealmRow = {
-  id: string;
-};
-
 export default function handleDownloadRealm({
   dbAdapter,
   realmSecretSeed,
@@ -215,15 +211,12 @@ async function resolveRealmPath({
   realmURL: string;
   realmsRootPath: string;
 }): Promise<string | null> {
-  // Phase 4: read from realm_registry. published_realms.id and
-  // realm_registry.disk_id hold the same UUID for kind='published' rows
-  // by design (see migration 1776960113000).
   let published = (await query(dbAdapter, [
-    "SELECT disk_id AS id FROM realm_registry WHERE kind = 'published' AND url =",
+    "SELECT disk_id FROM realm_registry WHERE kind = 'published' AND url =",
     param(realmURL),
-  ])) as PublishedRealmRow[];
+  ])) as { disk_id: string }[];
   if (published.length > 0) {
-    return join(realmsRootPath, PUBLISHED_DIRECTORY_NAME, published[0].id);
+    return join(realmsRootPath, PUBLISHED_DIRECTORY_NAME, published[0].disk_id);
   }
 
   let realm = realms.find((r) => ensureTrailingSlash(r.url) === realmURL);

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -6,8 +6,6 @@ import {
   SupportedMimeType,
   logger,
   insertPermissions,
-  insert,
-  asExpressions,
   param,
   PUBLISHED_DIRECTORY_NAME,
   ensureTrailingSlash,
@@ -42,7 +40,7 @@ import type { RealmServerTokenClaim } from '../utils/jwt';
 import { registerUser } from '../synapse';
 import { passwordFromSeed } from '@cardstack/runtime-common/matrix-client';
 import { enqueueReindexRealmJob } from '@cardstack/runtime-common/jobs/reindex-realm';
-import { mirrorPublishedRealmToRegistry } from '../lib/realm-registry-writes';
+import { upsertPublishedRealmInRegistry } from '../lib/realm-registry-writes';
 import { withRealmWriteLock } from '../lib/realm-advisory-locks';
 
 const log = logger('handle-publish');
@@ -307,7 +305,7 @@ export default function handlePublishRealm({
       // two concurrent publishes for the same publishedRealmURL cannot
       // race through those pre-lock steps (which would otherwise orphan a
       // Matrix user / permissions row when one of them fails on the
-      // published_realms insert).
+      // realm_registry upsert).
       //
       // Phase 3 PR 2: handler is stateless. After the FS swap + DB write +
       // NOTIFY realm_registry, the reconciler on every instance lazily
@@ -318,9 +316,6 @@ export default function handlePublishRealm({
         dbAdapter,
         publishedRealmURL,
         async () => {
-          // Phase 4: read existence + identity from realm_registry. The
-          // legacy published_realms table is still dual-written below
-          // until Phase 4 PR 2 drops the writes.
           let existingRows = (await query(dbAdapter, [
             `SELECT disk_id, owner_username FROM realm_registry WHERE kind = 'published' AND url =`,
             param(publishedRealmURL),
@@ -442,26 +437,13 @@ export default function handlePublishRealm({
 
           let lastPublishedAt = Date.now().toString();
           try {
-            if (isNewRealm) {
-              let { valueExpressions, nameExpressions } = asExpressions({
-                id: publishedRealmId,
-                owner_username: realmUsername,
-                source_realm_url: sourceRealmURL,
-                published_realm_url: publishedRealmURL,
-                last_published_at: lastPublishedAt,
-              });
-              await query(
-                dbAdapter,
-                insert('published_realms', nameExpressions, valueExpressions),
-              );
-            } else {
-              await query(dbAdapter, [
-                `UPDATE published_realms SET last_published_at =`,
-                param(lastPublishedAt),
-                `WHERE published_realm_url =`,
-                param(publishedRealmURL),
-              ]);
-            }
+            await upsertPublishedRealmInRegistry(dbAdapter, {
+              publishedRealmURL,
+              publishedRealmId,
+              ownerUsername: realmUsername,
+              sourceRealmURL,
+              lastPublishedAt: Number(lastPublishedAt),
+            });
           } catch (dbError: any) {
             // Phase 3 PR 2 rollback simplification: no in-memory
             // realms[]/virtualNetwork state to unwind. Just remove the
@@ -469,18 +451,6 @@ export default function handlePublishRealm({
             removeSync(publishedRealmPath);
             throw dbError;
           }
-
-          // Mirror the published realm into realm_registry. The DELETE +
-          // INSERT inside this helper emits NOTIFY realm_registry; the
-          // reconciler on every instance reacts by populating
-          // knownByUrl. The realm itself is lazy-mounted on first request.
-          await mirrorPublishedRealmToRegistry(dbAdapter, {
-            publishedRealmURL,
-            publishedRealmId,
-            ownerUsername: realmUsername,
-            sourceRealmURL,
-            lastPublishedAt: Number(lastPublishedAt),
-          });
 
           // Refresh the index. For a new publish this is redundant
           // (lazy-mount's first start() does its own fullIndex on a

--- a/packages/realm-server/handlers/handle-unpublish-realm.ts
+++ b/packages/realm-server/handlers/handle-unpublish-realm.ts
@@ -6,7 +6,6 @@ import {
   logger,
   param,
   removeRealmPermissions,
-  type PublishedRealmTable,
   fetchRealmPermissions,
   PUBLISHED_DIRECTORY_NAME,
 } from '@cardstack/runtime-common';
@@ -27,7 +26,7 @@ import {
   collectAllFilePaths,
   removeRealmFiles,
 } from './realm-destruction-utils';
-import { deleteFromRegistryByUrl } from '../lib/realm-registry-writes';
+import { deleteRegistryRowByUrl } from '../lib/realm-registry-writes';
 import { withRealmWriteLock } from '../lib/realm-advisory-locks';
 
 const log = logger('handle-unpublish');
@@ -70,20 +69,16 @@ export default function handleUnpublishRealm({
       : `${json.publishedRealmURL}/`;
 
     try {
-      // Phase 4: read from realm_registry; alias the columns so the
-      // downstream field accessors stay the same as when this read
-      // pointed at published_realms.
       let publishedRealmData = (await query(dbAdapter, [
-        `SELECT disk_id AS id, owner_username, source_url AS source_realm_url, url AS published_realm_url, last_published_at FROM realm_registry WHERE kind = 'published' AND url =`,
+        `SELECT disk_id, owner_username, source_url, url, last_published_at FROM realm_registry WHERE kind = 'published' AND url =`,
         param(publishedRealmURL),
-      ])) as Pick<
-        PublishedRealmTable,
-        | 'id'
-        | 'owner_username'
-        | 'source_realm_url'
-        | 'published_realm_url'
-        | 'last_published_at'
-      >[];
+      ])) as {
+        disk_id: string;
+        owner_username: string;
+        source_url: string;
+        url: string;
+        last_published_at: string | number | null;
+      }[];
 
       if (!publishedRealmData.length) {
         await sendResponseForUnprocessableEntity(
@@ -98,7 +93,7 @@ export default function handleUnpublishRealm({
       let { user: ownerUserId } = token;
       let permissions = await fetchRealmPermissions(
         dbAdapter,
-        new URL(publishedRealmInfo.source_realm_url),
+        new URL(publishedRealmInfo.source_url),
       );
       if (!permissions[ownerUserId]?.includes('realm-owner')) {
         await sendResponseForForbiddenRequest(
@@ -111,13 +106,13 @@ export default function handleUnpublishRealm({
       let publishedRealmPath = join(
         realmsRootPath,
         PUBLISHED_DIRECTORY_NAME,
-        publishedRealmInfo.id,
+        publishedRealmInfo.disk_id,
       );
 
       // Mount the published realm on this instance (no-op if already
       // mounted) so we have a Realm instance to drive the tombstone
       // path before deleting files. Phase 3 sibling-instance behavior
-      // is unchanged: those instances see deleteFromRegistryByUrl's
+      // is unchanged: those instances see deleteRegistryRowByUrl's
       // NOTIFY realm_registry and unmount via the reconciler.
       let publishedRealm = await reconciler.lookupOrMount(publishedRealmURL);
 
@@ -137,12 +132,7 @@ export default function handleUnpublishRealm({
         }
         removeRealmFiles(publishedRealmPath);
 
-        await query(dbAdapter, [
-          `DELETE FROM published_realms WHERE published_realm_url =`,
-          param(publishedRealmURL),
-        ]);
-
-        await deleteFromRegistryByUrl(dbAdapter, publishedRealmURL);
+        await deleteRegistryRowByUrl(dbAdapter, publishedRealmURL);
 
         await removeRealmPermissions(dbAdapter, new URL(publishedRealmURL));
       });
@@ -153,7 +143,7 @@ export default function handleUnpublishRealm({
       // realm info, its card+json ETag (which folds a hash of the
       // realm info in) would keep matching pre-unpublish If-None-Match
       // headers and serve a 304 with stale `meta.realmInfo`. (CS-11010)
-      let sourceRealmURL = publishedRealmInfo.source_realm_url;
+      let sourceRealmURL = publishedRealmInfo.source_url;
       if (sourceRealmURL) {
         try {
           let sourceRealm = await reconciler.lookupOrMount(sourceRealmURL);
@@ -178,10 +168,10 @@ export default function handleUnpublishRealm({
           {
             data: {
               type: 'unpublished_realm',
-              id: publishedRealmInfo.id,
+              id: publishedRealmInfo.disk_id,
               attributes: {
-                sourceRealmURL: publishedRealmInfo.source_realm_url,
-                publishedRealmURL: publishedRealmInfo.published_realm_url,
+                sourceRealmURL: publishedRealmInfo.source_url,
+                publishedRealmURL: publishedRealmInfo.url,
                 lastPublishedAt: publishedRealmInfo.last_published_at,
               },
             },

--- a/packages/realm-server/lib/realm-metadata-backfill.ts
+++ b/packages/realm-server/lib/realm-metadata-backfill.ts
@@ -189,12 +189,12 @@ async function backfillPublishedRealms(
   if (!existsSync(publishedRoot)) {
     return 0;
   }
-  // Map disk uuid → published URL via the published_realms table; disk
-  // alone doesn't carry the URL.
+  // Map disk uuid → published URL via realm_registry; disk alone doesn't
+  // carry the URL.
   const rows = (await query(opts.dbAdapter, [
-    `SELECT id::text AS id, published_realm_url FROM published_realms`,
-  ])) as Array<{ id: string; published_realm_url: string }>;
-  const byId = new Map(rows.map((r) => [r.id, r.published_realm_url]));
+    `SELECT disk_id, url FROM realm_registry WHERE kind = 'published'`,
+  ])) as Array<{ disk_id: string; url: string }>;
+  const byId = new Map(rows.map((r) => [r.disk_id, r.url]));
 
   let count = 0;
   for (const entry of readdirSync(publishedRoot, { withFileTypes: true })) {

--- a/packages/realm-server/lib/realm-registry-backfill.ts
+++ b/packages/realm-server/lib/realm-registry-backfill.ts
@@ -45,10 +45,15 @@ export interface RegistryBackfillOpts {
 //   1. Bootstrap rows from CLI args (upserted, always pinned=true)
 //   2. Source rows from realmsRootPath/<owner>/<endpoint>/.realm.json
 //      (inserted if absent, pinned=false)
-//   3. Published rows cross-referenced from published_realms + on-disk
-//      realmsRootPath/_published/<uuid>/ (inserted if absent, pinned=false)
-//   4. Warns on registry rows whose disk path is missing
-//   5. Warns on bootstrap rows that no longer have a matching CLI arg
+//   3. Warns on registry rows whose disk path is missing
+//   4. Warns on bootstrap rows that no longer have a matching CLI arg
+//
+// Published rows are written by handle-publish-realm and persist in
+// realm_registry directly; there is no boot-time disk-scan recovery for them.
+// (Pre-Phase-4-PR-2 the recovery joined the legacy `published_realms` table
+// against the on-disk uuid directories; CS-10897 dropped that table, so the
+// registry is the only source for the URL/owner/source metadata that disk
+// alone doesn't carry.)
 //
 // Called from main.ts before the per-realm mount loop runs, so the registry
 // reflects the full set of known realms before any Realm is constructed. All
@@ -71,24 +76,19 @@ export async function runRegistryBackfill(
   const sourceDiscovered = await safeStep('source', () =>
     upsertSourceRealms(opts),
   );
-  const publishedDiscovered = await safeStep('published', () =>
-    upsertPublishedRealms(opts),
-  );
   await safeStep('orphan-check', () => warnOnOrphans(opts));
   await safeStep('stale-bootstrap-check', () =>
     warnOnStaleBootstrapRows(opts, bootstrapUrls ?? new Set()),
   );
 
-  // Note: `sourceDiscovered` / `publishedDiscovered` are the number of
-  // realm directories seen on disk, not the number of INSERTs actually
-  // executed. Under ON CONFLICT DO NOTHING, a second run reports the same
-  // counts even if no rows change. That's intentional — the count is a
-  // measure of the scan, not the diff.
+  // Note: `sourceDiscovered` is the number of realm directories seen on
+  // disk, not the number of INSERTs actually executed. Under ON CONFLICT DO
+  // NOTHING, a second run reports the same count even if no rows change.
+  // That's intentional — the count is a measure of the scan, not the diff.
   log.info(
     `registry backfill complete in ${Date.now() - started}ms ` +
       `(bootstrap=${bootstrapUrls?.size ?? 0}, ` +
-      `sourceDiscovered=${sourceDiscovered ?? 0}, ` +
-      `publishedDiscovered=${publishedDiscovered ?? 0})`,
+      `sourceDiscovered=${sourceDiscovered ?? 0})`,
   );
 }
 
@@ -185,69 +185,6 @@ async function upsertSourceRealms(opts: RegistryBackfillOpts): Promise<number> {
       ]);
       count += 1;
     }
-  }
-  return count;
-}
-
-async function upsertPublishedRealms(
-  opts: RegistryBackfillOpts,
-): Promise<number> {
-  const publishedRoot = join(opts.realmsRootPath, PUBLISHED_DIRECTORY_NAME);
-  if (!existsSync(publishedRoot)) {
-    return 0;
-  }
-
-  // Correlate on-disk uuid directory names with published_realms rows to get
-  // the url/owner/source/last_published_at metadata that disk alone doesn't
-  // carry. Post-Phase-4 this can read straight from realm_registry; while the
-  // legacy table still exists, this is the authoritative source.
-  const rows = (await query(opts.dbAdapter, [
-    `SELECT id::text AS id, published_realm_url, source_realm_url, owner_username, last_published_at FROM published_realms`,
-  ])) as Array<{
-    id: string;
-    published_realm_url: string;
-    source_realm_url: string;
-    owner_username: string;
-    last_published_at: number | string | null;
-  }>;
-  const byId = new Map(rows.map((r) => [r.id, r]));
-
-  let count = 0;
-  for (const entry of readdirSync(publishedRoot, { withFileTypes: true })) {
-    if (!entry.isDirectory()) {
-      continue;
-    }
-    const uuid = entry.name;
-    if (!existsSync(join(publishedRoot, uuid, '.realm.json'))) {
-      continue;
-    }
-    const row = byId.get(uuid);
-    if (!row) {
-      log.warn(
-        `published realm directory at ${join(publishedRoot, uuid)} has no matching published_realms row; skipping`,
-      );
-      continue;
-    }
-    const lastPublishedAt =
-      row.last_published_at == null ? null : Number(row.last_published_at);
-    await query(opts.dbAdapter, [
-      `INSERT INTO realm_registry (url, kind, disk_id, owner_username, source_url, last_published_at, pinned) VALUES (`,
-      param(row.published_realm_url),
-      `,`,
-      param('published'),
-      `,`,
-      param(uuid),
-      `,`,
-      param(row.owner_username),
-      `,`,
-      param(row.source_realm_url),
-      `,`,
-      param(lastPublishedAt),
-      `,`,
-      param(false),
-      `) ON CONFLICT (url) DO NOTHING`,
-    ]);
-    count += 1;
   }
   return count;
 }

--- a/packages/realm-server/lib/realm-registry-writes.ts
+++ b/packages/realm-server/lib/realm-registry-writes.ts
@@ -1,13 +1,13 @@
 import type { DBAdapter } from '@cardstack/runtime-common';
 import { logger, param, query } from '@cardstack/runtime-common';
 
-// Helpers for mirroring handler-driven realm lifecycle events
-// (publish/unpublish/delete/create) into realm_registry. Phase 1 dual-writes:
-// every helper is wrapped in its own try/catch so that a failure to write the
-// registry row never surfaces as an error to the caller. The registry is
-// shadow data in Phase 1 (no reader depends on it until Phase 3), and any
-// drift from the legacy tables is self-healed by the boot-time backfill in
-// realm-registry-backfill.ts.
+// Helpers that the realm-mutating handlers (publish/unpublish/delete/create)
+// use to write `realm_registry`. Phase 4 PR 2 (CS-10897) made the registry the
+// only source of truth — Phase 1 PR 3 wrote both tables; the legacy
+// `published_realms` table is now dropped — so failures bubble up to the
+// caller. The previous "log-and-swallow" posture matched the Phase 1 shadow-
+// data semantics; under the new authoritative posture, a failed write must
+// surface the same way any other handler DB failure surfaces.
 //
 // All mutation helpers include a `kind != 'bootstrap'` guard so a user-facing
 // handler mutation can never affect a bootstrap row (belt-and-suspenders: URLs
@@ -16,10 +16,11 @@ import { logger, param, query } from '@cardstack/runtime-common';
 //
 // After a successful DB write, each helper emits
 // `NOTIFY realm_registry, '<op>:<url>'` so that any RealmRegistryReconciler
-// instances (CS-10890) listening on the channel can react promptly. The
-// payload is a hint only — reconcilers always re-read the DB. If the NOTIFY
-// itself fails (DB transient failure), the reconciler's 30s poll safety net
-// catches the change.
+// instances listening on the channel can react promptly. The payload is a
+// hint only — reconcilers always re-read the DB. NOTIFY itself is wrapped in
+// its own try/catch and only logs on failure: a dropped notification is
+// recovered by the reconciler's 30s poll safety net, so propagating it would
+// fail an otherwise successful mutation for no benefit.
 
 const REGISTRY_CHANNEL = 'realm_registry';
 const log = logger('realm-server:registry-writes');
@@ -44,14 +45,12 @@ async function notifyRegistry(
   }
 }
 
-// Upsert a published realm into realm_registry. Called from handle-publish-realm
-// after the legacy published_realms write succeeds.
-//
-// On conflict: updates last_published_at/updated_at so repeat publishes
-// advance the timestamp. The ON CONFLICT UPDATE's WHERE clause keeps the
-// update no-oped if the existing row isn't kind='published' — which also
-// serves as the bootstrap guard.
-export async function mirrorPublishedRealmToRegistry(
+// Upsert a published realm row. Called from handle-publish-realm. On
+// conflict, updates last_published_at/updated_at so repeat publishes advance
+// the timestamp. The ON CONFLICT UPDATE's WHERE clause keeps the update
+// no-oped if the existing row isn't kind='published' — which also serves as
+// the bootstrap guard.
+export async function upsertPublishedRealmInRegistry(
   dbAdapter: DBAdapter,
   args: {
     publishedRealmURL: string;
@@ -61,33 +60,26 @@ export async function mirrorPublishedRealmToRegistry(
     lastPublishedAt: number;
   },
 ): Promise<void> {
-  try {
-    await query(dbAdapter, [
-      `INSERT INTO realm_registry (url, kind, disk_id, owner_username, source_url, last_published_at, pinned) VALUES (`,
-      param(args.publishedRealmURL),
-      `, 'published', `,
-      param(args.publishedRealmId),
-      `, `,
-      param(args.ownerUsername),
-      `, `,
-      param(args.sourceRealmURL),
-      `, `,
-      param(args.lastPublishedAt),
-      `, false`,
-      `) ON CONFLICT (url) DO UPDATE SET last_published_at = EXCLUDED.last_published_at, updated_at = now() WHERE realm_registry.kind = 'published'`,
-    ]);
-  } catch (err: unknown) {
-    log.warn(
-      `failed to mirror publish to realm_registry for ${args.publishedRealmURL}: ${String(err)}; will self-heal on next boot`,
-    );
-    return;
-  }
+  await query(dbAdapter, [
+    `INSERT INTO realm_registry (url, kind, disk_id, owner_username, source_url, last_published_at, pinned) VALUES (`,
+    param(args.publishedRealmURL),
+    `, 'published', `,
+    param(args.publishedRealmId),
+    `, `,
+    param(args.ownerUsername),
+    `, `,
+    param(args.sourceRealmURL),
+    `, `,
+    param(args.lastPublishedAt),
+    `, false`,
+    `) ON CONFLICT (url) DO UPDATE SET last_published_at = EXCLUDED.last_published_at, updated_at = now() WHERE realm_registry.kind = 'published'`,
+  ]);
   await notifyRegistry(dbAdapter, 'upsert', args.publishedRealmURL);
 }
 
-// Insert a source realm into realm_registry. Called from server.ts:createRealm
-// after permissions + .realm.json are written to disk.
-export async function mirrorSourceRealmToRegistry(
+// Insert a source realm row. Called from server.ts:createRealm after
+// permissions + .realm.json are written to disk.
+export async function insertSourceRealmInRegistry(
   dbAdapter: DBAdapter,
   args: {
     url: string;
@@ -95,45 +87,31 @@ export async function mirrorSourceRealmToRegistry(
     ownerUsername: string;
   },
 ): Promise<void> {
-  try {
-    await query(dbAdapter, [
-      `INSERT INTO realm_registry (url, kind, disk_id, owner_username, pinned) VALUES (`,
-      param(args.url),
-      `, 'source', `,
-      param(args.diskId),
-      `, `,
-      param(args.ownerUsername),
-      `, false`,
-      `) ON CONFLICT (url) DO NOTHING`,
-    ]);
-  } catch (err: unknown) {
-    log.warn(
-      `failed to mirror source-realm create to realm_registry for ${args.url}: ${String(err)}; will self-heal on next boot`,
-    );
-    return;
-  }
+  await query(dbAdapter, [
+    `INSERT INTO realm_registry (url, kind, disk_id, owner_username, pinned) VALUES (`,
+    param(args.url),
+    `, 'source', `,
+    param(args.diskId),
+    `, `,
+    param(args.ownerUsername),
+    `, false`,
+    `) ON CONFLICT (url) DO NOTHING`,
+  ]);
   await notifyRegistry(dbAdapter, 'upsert', args.url);
 }
 
-// Delete a single row from realm_registry by url. Used by
-// handle-unpublish-realm (published row) and handle-delete-realm (source row).
-// kind != 'bootstrap' is the belt-and-suspenders guard.
-export async function deleteFromRegistryByUrl(
+// Delete a single row by url. Used by handle-unpublish-realm (published row)
+// and handle-delete-realm (source row). The kind != 'bootstrap' guard is
+// belt-and-suspenders.
+export async function deleteRegistryRowByUrl(
   dbAdapter: DBAdapter,
   url: string,
 ): Promise<void> {
-  try {
-    await query(dbAdapter, [
-      `DELETE FROM realm_registry WHERE url =`,
-      param(url),
-      ` AND kind <> 'bootstrap'`,
-    ]);
-  } catch (err: unknown) {
-    log.warn(
-      `failed to delete realm_registry row for ${url}: ${String(err)}; will self-heal on next boot`,
-    );
-    return;
-  }
+  await query(dbAdapter, [
+    `DELETE FROM realm_registry WHERE url =`,
+    param(url),
+    ` AND kind <> 'bootstrap'`,
+  ]);
   await notifyRegistry(dbAdapter, 'delete', url);
 }
 
@@ -143,22 +121,15 @@ export async function deleteFromRegistryByUrl(
 // even though the schema's CHECK constraint already guarantees that only
 // published rows have non-null source_url — stating the contract in the SQL
 // matches the helper's name and survives any future schema changes.
-export async function deletePublishedFromRegistryBySource(
+export async function deletePublishedRowsBySourceUrl(
   dbAdapter: DBAdapter,
   sourceUrl: string,
 ): Promise<void> {
-  try {
-    await query(dbAdapter, [
-      `DELETE FROM realm_registry WHERE source_url =`,
-      param(sourceUrl),
-      ` AND kind = 'published'`,
-    ]);
-  } catch (err: unknown) {
-    log.warn(
-      `failed to delete published realm_registry rows for source ${sourceUrl}: ${String(err)}; will self-heal on next boot`,
-    );
-    return;
-  }
+  await query(dbAdapter, [
+    `DELETE FROM realm_registry WHERE source_url =`,
+    param(sourceUrl),
+    ` AND kind = 'published'`,
+  ]);
   // Single NOTIFY keyed on the source URL. Reconcilers will re-read and see
   // all deletes; the payload is a hint, not a precise per-row signal.
   await notifyRegistry(dbAdapter, 'delete', sourceUrl);

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -51,7 +51,7 @@ import { createRoutes } from './routes';
 import { APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE } from '@cardstack/runtime-common/matrix-constants';
 import type { Prerenderer } from '@cardstack/runtime-common';
 import { retrieveScopedCSS } from './lib/retrieve-scoped-css';
-import { mirrorSourceRealmToRegistry } from './lib/realm-registry-writes';
+import { insertSourceRealmInRegistry } from './lib/realm-registry-writes';
 import { withRealmWriteLock } from './lib/realm-advisory-locks';
 import type { RealmRegistryReconciler } from './lib/realm-registry-reconciler';
 import {
@@ -1093,7 +1093,7 @@ export class RealmServer {
       // Register the source realm in realm_registry. The INSERT emits
       // NOTIFY realm_registry; the reconciler on every instance picks
       // up the row, and the realm is lazy-mounted on first request.
-      await mirrorSourceRealmToRegistry(this.dbAdapter, {
+      await insertSourceRealmInRegistry(this.dbAdapter, {
         url,
         diskId: `${ownerUsername}/${endpoint}`,
         ownerUsername,

--- a/packages/realm-server/tests/full-reindex-test.ts
+++ b/packages/realm-server/tests/full-reindex-test.ts
@@ -8,16 +8,13 @@ import type {
   QueuePublisher,
 } from '@cardstack/runtime-common';
 import {
-  asExpressions,
   fullReindex,
-  insert,
   insertPermissions,
   logger,
-  query,
   uuidv4,
 } from '@cardstack/runtime-common';
 
-import { mirrorPublishedRealmToRegistry } from '../lib/realm-registry-writes';
+import { upsertPublishedRealmInRegistry } from '../lib/realm-registry-writes';
 import { setupDB } from './helpers';
 
 module(basename(__filename), function (hooks) {
@@ -61,25 +58,12 @@ module(basename(__filename), function (hooks) {
     publishedRealmURL: string;
     ownerUsername: string;
   }) {
-    let publishedRealmId = uuidv4();
-    let lastPublishedAt = Date.now();
-    let { nameExpressions, valueExpressions } = asExpressions({
-      id: publishedRealmId,
-      owner_username: ownerUsername,
-      source_realm_url: sourceRealmURL,
-      published_realm_url: publishedRealmURL,
-      last_published_at: lastPublishedAt.toString(),
-    });
-    await query(
-      dbAdapter,
-      insert('published_realms', nameExpressions, valueExpressions),
-    );
-    await mirrorPublishedRealmToRegistry(dbAdapter, {
+    await upsertPublishedRealmInRegistry(dbAdapter, {
       publishedRealmURL,
-      publishedRealmId,
+      publishedRealmId: uuidv4(),
       ownerUsername,
       sourceRealmURL,
-      lastPublishedAt,
+      lastPublishedAt: Date.now(),
     });
   }
 

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -52,7 +52,7 @@ import {
   RealmRegistryReconciler,
   type RealmRegistryRow,
 } from '../../lib/realm-registry-reconciler';
-import { mirrorPublishedRealmToRegistry } from '../../lib/realm-registry-writes';
+import { upsertPublishedRealmInRegistry } from '../../lib/realm-registry-writes';
 
 import {
   PgAdapter,
@@ -1795,20 +1795,7 @@ async function startPermissionedRealmFixture(
       publishedRealmId,
     );
 
-    await dbAdapter.execute(
-      `INSERT INTO
-        published_realms
-        (id, owner_username, source_realm_url, published_realm_url, last_published_at)
-        VALUES
-        (
-          '${publishedRealmId}',
-          '${ownerUsername}',
-          '${sourceRealmURL}',
-          '${resolvedRealmURL.href}',
-          '${lastPublishedAt}'
-        )`,
-    );
-    await mirrorPublishedRealmToRegistry(dbAdapter, {
+    await upsertPublishedRealmInRegistry(dbAdapter, {
       publishedRealmURL: resolvedRealmURL.href,
       publishedRealmId,
       ownerUsername,

--- a/packages/realm-server/tests/queries-test.ts
+++ b/packages/realm-server/tests/queries-test.ts
@@ -4,15 +4,12 @@ import { v4 as uuidv4 } from 'uuid';
 
 import type { PgAdapter } from '@cardstack/postgres';
 import {
-  asExpressions,
   fetchAllRealmsWithOwners,
   fetchUserPermissions,
-  insert,
   insertPermissions,
-  query,
 } from '@cardstack/runtime-common';
 
-import { mirrorPublishedRealmToRegistry } from '../lib/realm-registry-writes';
+import { upsertPublishedRealmInRegistry } from '../lib/realm-registry-writes';
 import { setupDB } from './helpers';
 
 module(basename(__filename), function () {
@@ -38,25 +35,12 @@ module(basename(__filename), function () {
       publishedRealmURL: string;
       ownerUsername?: string;
     }) {
-      let publishedRealmId = uuidv4();
-      let lastPublishedAt = Date.now();
-      let { nameExpressions, valueExpressions } = asExpressions({
-        id: publishedRealmId,
-        owner_username: ownerUsername,
-        source_realm_url: sourceRealmURL,
-        published_realm_url: publishedRealmURL,
-        last_published_at: lastPublishedAt.toString(),
-      });
-      await query(
-        dbAdapter,
-        insert('published_realms', nameExpressions, valueExpressions),
-      );
-      await mirrorPublishedRealmToRegistry(dbAdapter, {
+      await upsertPublishedRealmInRegistry(dbAdapter, {
         publishedRealmURL,
-        publishedRealmId,
+        publishedRealmId: uuidv4(),
         ownerUsername,
         sourceRealmURL,
-        lastPublishedAt,
+        lastPublishedAt: Date.now(),
       });
     }
 
@@ -176,25 +160,12 @@ module(basename(__filename), function () {
       publishedRealmURL: string;
       ownerUsername?: string;
     }) {
-      let publishedRealmId = uuidv4();
-      let lastPublishedAt = Date.now();
-      let { nameExpressions, valueExpressions } = asExpressions({
-        id: publishedRealmId,
-        owner_username: ownerUsername,
-        source_realm_url: sourceRealmURL,
-        published_realm_url: publishedRealmURL,
-        last_published_at: lastPublishedAt.toString(),
-      });
-      await query(
-        dbAdapter,
-        insert('published_realms', nameExpressions, valueExpressions),
-      );
-      await mirrorPublishedRealmToRegistry(dbAdapter, {
+      await upsertPublishedRealmInRegistry(dbAdapter, {
         publishedRealmURL,
-        publishedRealmId,
+        publishedRealmId: uuidv4(),
         ownerUsername,
         sourceRealmURL,
-        lastPublishedAt,
+        lastPublishedAt: Date.now(),
       });
     }
 

--- a/packages/realm-server/tests/realm-metadata-backfill-test.ts
+++ b/packages/realm-server/tests/realm-metadata-backfill-test.ts
@@ -127,7 +127,7 @@ module(basename(__filename), function () {
       );
     });
 
-    test('inserts a row from a published realm sidecar correlated via published_realms', async function (assert) {
+    test('inserts a row from a published realm sidecar correlated via realm_registry', async function (assert) {
       const publishedRoot = join(realmsRootPath, PUBLISHED_DIRECTORY_NAME);
       const uuid = '00000000-0000-0000-0000-000000000001';
       const publishedRealmUrl = 'http://localhost:4201/_published/abc/';
@@ -135,17 +135,17 @@ module(basename(__filename), function () {
         publishable: false,
       });
       await query(dbAdapter, [
-        `INSERT INTO published_realms (id, published_realm_url, source_realm_url, owner_username, last_published_at) VALUES (`,
-        param(uuid),
-        `,`,
+        `INSERT INTO realm_registry (url, kind, disk_id, owner_username, source_url, last_published_at, pinned) VALUES (`,
         param(publishedRealmUrl),
-        `,`,
-        param('http://localhost:4201/luke/my-realm/'),
+        `, 'published', `,
+        param(uuid),
         `,`,
         param('luke'),
         `,`,
+        param('http://localhost:4201/luke/my-realm/'),
+        `,`,
         param(Date.now()),
-        `)`,
+        `, false)`,
       ]);
 
       await runRealmMetadataBackfill({

--- a/packages/realm-server/tests/realm-registry-backfill-test.ts
+++ b/packages/realm-server/tests/realm-registry-backfill-test.ts
@@ -132,9 +132,10 @@ module(basename(__filename), function () {
 
     test('skips the _published directory during source-realm scan', async function (assert) {
       seedRealmJson(join(realmsRootPath, 'luke', 'src'), { name: 'src' });
-      // Create a _published/<uuid>/.realm.json — should NOT be picked up as a
-      // source realm. (Published realms go through a different code path that
-      // cross-references published_realms.)
+      // Create a _published/<uuid>/.realm.json — should NOT be picked up as
+      // a source realm. (Published rows are written by the publish handler
+      // directly into realm_registry; the boot-time scan does not recover
+      // them from disk.)
       seedRealmJson(
         join(realmsRootPath, PUBLISHED_DIRECTORY_NAME, 'some-uuid'),
         { name: 'pub' },
@@ -156,48 +157,8 @@ module(basename(__filename), function () {
       assert.strictEqual(
         rows.filter((r) => r.kind === 'published').length,
         0,
-        '_published dir without a published_realms row yields no registry row',
+        'boot-time scan does not write published rows from disk',
       );
-    });
-
-    test('inserts published rows by cross-referencing published_realms + disk', async function (assert) {
-      const publishedId = '11111111-2222-3333-4444-555555555555';
-      const { valueExpressions, nameExpressions } = asExpressions({
-        id: publishedId,
-        owner_username: 'realm/_published_11111111',
-        source_realm_url: 'http://localhost:4201/luke/src/',
-        published_realm_url: 'http://user.localhost:4201/live/',
-        last_published_at: '1700000000000',
-      });
-      await query(
-        dbAdapter,
-        insert('published_realms', nameExpressions, valueExpressions),
-      );
-
-      seedRealmJson(
-        join(realmsRootPath, PUBLISHED_DIRECTORY_NAME, publishedId),
-        { name: 'live' },
-      );
-      seedRealmJson(join(realmsRootPath, 'luke', 'src'), { name: 'src' });
-
-      await runRegistryBackfill({
-        dbAdapter,
-        realmsRootPath,
-        serverURL,
-        bootstrapRealms: [],
-      });
-
-      const rows = await allRegistryRows(dbAdapter);
-      const published = rows.find((r) => r.kind === 'published');
-      assert.ok(published, 'a published row was written');
-      assert.strictEqual(published!.url, 'http://user.localhost:4201/live/');
-      assert.strictEqual(published!.disk_id, publishedId);
-      assert.strictEqual(
-        published!.source_url,
-        'http://localhost:4201/luke/src/',
-      );
-      assert.strictEqual(published!.last_published_at, '1700000000000');
-      assert.false(published!.pinned);
     });
 
     test('is idempotent: running twice produces the same rows', async function (assert) {

--- a/packages/realm-server/tests/realm-registry-writes-test.ts
+++ b/packages/realm-server/tests/realm-registry-writes-test.ts
@@ -4,10 +4,10 @@ import type { PgAdapter } from '@cardstack/postgres';
 import { asExpressions, insert, query } from '@cardstack/runtime-common';
 import { setupDB } from './helpers';
 import {
-  deleteFromRegistryByUrl,
-  deletePublishedFromRegistryBySource,
-  mirrorPublishedRealmToRegistry,
-  mirrorSourceRealmToRegistry,
+  deleteRegistryRowByUrl,
+  deletePublishedRowsBySourceUrl,
+  upsertPublishedRealmInRegistry,
+  insertSourceRealmInRegistry,
 } from '../lib/realm-registry-writes';
 
 interface RegistryRow {
@@ -72,7 +72,7 @@ async function seedBootstrapRow(dbAdapter: PgAdapter, url: string) {
 }
 
 module(basename(__filename), function () {
-  module('mirrorPublishedRealmToRegistry', function (hooks) {
+  module('upsertPublishedRealmInRegistry', function (hooks) {
     let dbAdapter: PgAdapter;
     setupDB(hooks, {
       beforeEach: async (adapter) => {
@@ -81,7 +81,7 @@ module(basename(__filename), function () {
     });
 
     test('inserts a published row when absent', async function (assert) {
-      await mirrorPublishedRealmToRegistry(dbAdapter, {
+      await upsertPublishedRealmInRegistry(dbAdapter, {
         publishedRealmURL: 'http://user.localhost:4201/site/',
         publishedRealmId: '11111111-2222-3333-4444-555555555555',
         ownerUsername: 'realm/_published_xyz',
@@ -104,14 +104,14 @@ module(basename(__filename), function () {
 
     test('updates last_published_at on repeat publish', async function (assert) {
       const url = 'http://user.localhost:4201/site/';
-      await mirrorPublishedRealmToRegistry(dbAdapter, {
+      await upsertPublishedRealmInRegistry(dbAdapter, {
         publishedRealmURL: url,
         publishedRealmId: 'uuid-1',
         ownerUsername: 'realm/_published_x',
         sourceRealmURL: 'http://localhost:4201/luke/src/',
         lastPublishedAt: 1_700_000_000_000,
       });
-      await mirrorPublishedRealmToRegistry(dbAdapter, {
+      await upsertPublishedRealmInRegistry(dbAdapter, {
         publishedRealmURL: url,
         publishedRealmId: 'uuid-1',
         ownerUsername: 'realm/_published_x',
@@ -131,7 +131,7 @@ module(basename(__filename), function () {
       const url = 'https://cardstack.com/base/';
       await seedBootstrapRow(dbAdapter, url);
 
-      await mirrorPublishedRealmToRegistry(dbAdapter, {
+      await upsertPublishedRealmInRegistry(dbAdapter, {
         publishedRealmURL: url,
         publishedRealmId: 'uuid-x',
         ownerUsername: 'realm/_published_x',
@@ -146,7 +146,7 @@ module(basename(__filename), function () {
     });
   });
 
-  module('mirrorSourceRealmToRegistry', function (hooks) {
+  module('insertSourceRealmInRegistry', function (hooks) {
     let dbAdapter: PgAdapter;
     setupDB(hooks, {
       beforeEach: async (adapter) => {
@@ -155,7 +155,7 @@ module(basename(__filename), function () {
     });
 
     test('inserts a source row when absent', async function (assert) {
-      await mirrorSourceRealmToRegistry(dbAdapter, {
+      await insertSourceRealmInRegistry(dbAdapter, {
         url: 'http://localhost:4201/luke/my-realm/',
         diskId: 'luke/my-realm',
         ownerUsername: 'luke',
@@ -175,12 +175,12 @@ module(basename(__filename), function () {
 
     test('is a no-op when the url already exists (ON CONFLICT DO NOTHING)', async function (assert) {
       const url = 'http://localhost:4201/luke/my-realm/';
-      await mirrorSourceRealmToRegistry(dbAdapter, {
+      await insertSourceRealmInRegistry(dbAdapter, {
         url,
         diskId: 'luke/my-realm',
         ownerUsername: 'luke',
       });
-      await mirrorSourceRealmToRegistry(dbAdapter, {
+      await insertSourceRealmInRegistry(dbAdapter, {
         url,
         diskId: 'luke/different-path',
         ownerUsername: 'luke',
@@ -195,7 +195,7 @@ module(basename(__filename), function () {
     });
   });
 
-  module('deleteFromRegistryByUrl', function (hooks) {
+  module('deleteRegistryRowByUrl', function (hooks) {
     let dbAdapter: PgAdapter;
     setupDB(hooks, {
       beforeEach: async (adapter) => {
@@ -205,14 +205,14 @@ module(basename(__filename), function () {
 
     test('deletes a published row', async function (assert) {
       const url = 'http://user.localhost:4201/site/';
-      await mirrorPublishedRealmToRegistry(dbAdapter, {
+      await upsertPublishedRealmInRegistry(dbAdapter, {
         publishedRealmURL: url,
         publishedRealmId: 'uuid',
         ownerUsername: 'realm/_published_x',
         sourceRealmURL: 'http://localhost:4201/luke/src/',
         lastPublishedAt: 1_700_000_000_000,
       });
-      await deleteFromRegistryByUrl(dbAdapter, url);
+      await deleteRegistryRowByUrl(dbAdapter, url);
       assert.strictEqual(
         await getRegistryRow(dbAdapter, url),
         undefined,
@@ -222,12 +222,12 @@ module(basename(__filename), function () {
 
     test('deletes a source row', async function (assert) {
       const url = 'http://localhost:4201/luke/src/';
-      await mirrorSourceRealmToRegistry(dbAdapter, {
+      await insertSourceRealmInRegistry(dbAdapter, {
         url,
         diskId: 'luke/src',
         ownerUsername: 'luke',
       });
-      await deleteFromRegistryByUrl(dbAdapter, url);
+      await deleteRegistryRowByUrl(dbAdapter, url);
       assert.strictEqual(
         await getRegistryRow(dbAdapter, url),
         undefined,
@@ -238,7 +238,7 @@ module(basename(__filename), function () {
     test('does NOT delete a bootstrap row (kind != bootstrap guard)', async function (assert) {
       const url = 'https://cardstack.com/base/';
       await seedBootstrapRow(dbAdapter, url);
-      await deleteFromRegistryByUrl(dbAdapter, url);
+      await deleteRegistryRowByUrl(dbAdapter, url);
 
       const row = await getRegistryRow(dbAdapter, url);
       assert.ok(row, 'bootstrap row still exists');
@@ -246,10 +246,7 @@ module(basename(__filename), function () {
     });
 
     test('is a no-op when the url is absent', async function (assert) {
-      await deleteFromRegistryByUrl(
-        dbAdapter,
-        'http://does-not-exist.example/',
-      );
+      await deleteRegistryRowByUrl(dbAdapter, 'http://does-not-exist.example/');
       assert.strictEqual(
         (await getAllRegistryRows(dbAdapter)).length,
         0,
@@ -258,7 +255,7 @@ module(basename(__filename), function () {
     });
   });
 
-  module('deletePublishedFromRegistryBySource', function (hooks) {
+  module('deletePublishedRowsBySourceUrl', function (hooks) {
     let dbAdapter: PgAdapter;
     setupDB(hooks, {
       beforeEach: async (adapter) => {
@@ -268,14 +265,14 @@ module(basename(__filename), function () {
 
     test('deletes all published rows sourced from a given url', async function (assert) {
       const sourceUrl = 'http://localhost:4201/luke/src/';
-      await mirrorPublishedRealmToRegistry(dbAdapter, {
+      await upsertPublishedRealmInRegistry(dbAdapter, {
         publishedRealmURL: 'http://user1.localhost:4201/a/',
         publishedRealmId: 'uuid-a',
         ownerUsername: 'realm/_published_a',
         sourceRealmURL: sourceUrl,
         lastPublishedAt: 1,
       });
-      await mirrorPublishedRealmToRegistry(dbAdapter, {
+      await upsertPublishedRealmInRegistry(dbAdapter, {
         publishedRealmURL: 'http://user2.localhost:4201/b/',
         publishedRealmId: 'uuid-b',
         ownerUsername: 'realm/_published_b',
@@ -283,7 +280,7 @@ module(basename(__filename), function () {
         lastPublishedAt: 2,
       });
       // A published row sourced from a DIFFERENT realm — should survive.
-      await mirrorPublishedRealmToRegistry(dbAdapter, {
+      await upsertPublishedRealmInRegistry(dbAdapter, {
         publishedRealmURL: 'http://user3.localhost:4201/c/',
         publishedRealmId: 'uuid-c',
         ownerUsername: 'realm/_published_c',
@@ -291,7 +288,7 @@ module(basename(__filename), function () {
         lastPublishedAt: 3,
       });
 
-      await deletePublishedFromRegistryBySource(dbAdapter, sourceUrl);
+      await deletePublishedRowsBySourceUrl(dbAdapter, sourceUrl);
 
       const rows = await getAllRegistryRows(dbAdapter);
       assert.strictEqual(rows.length, 1, 'only the unrelated row remains');
@@ -303,12 +300,12 @@ module(basename(__filename), function () {
       // some published rows. The helper deletes the published rows but leaves
       // the source realm's own row alone (it's matched by url, not source_url).
       const sourceUrl = 'http://localhost:4201/luke/src/';
-      await mirrorSourceRealmToRegistry(dbAdapter, {
+      await insertSourceRealmInRegistry(dbAdapter, {
         url: sourceUrl,
         diskId: 'luke/src',
         ownerUsername: 'luke',
       });
-      await mirrorPublishedRealmToRegistry(dbAdapter, {
+      await upsertPublishedRealmInRegistry(dbAdapter, {
         publishedRealmURL: 'http://user.localhost:4201/pub/',
         publishedRealmId: 'uuid-pub',
         ownerUsername: 'realm/_published_pub',
@@ -316,7 +313,7 @@ module(basename(__filename), function () {
         lastPublishedAt: 1,
       });
 
-      await deletePublishedFromRegistryBySource(dbAdapter, sourceUrl);
+      await deletePublishedRowsBySourceUrl(dbAdapter, sourceUrl);
 
       const rows = await getAllRegistryRows(dbAdapter);
       assert.strictEqual(rows.length, 1);

--- a/packages/realm-server/tests/server-endpoints/delete-realm-test.ts
+++ b/packages/realm-server/tests/server-endpoints/delete-realm-test.ts
@@ -342,7 +342,7 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
     );
 
     let remainingPublishedRows = await context.dbAdapter.execute(
-      `SELECT * FROM published_realms WHERE source_realm_url = '${realmURL}'`,
+      `SELECT * FROM realm_registry WHERE kind = 'published' AND source_url = '${realmURL}'`,
     );
     assert.strictEqual(
       remainingPublishedRows.length,
@@ -707,7 +707,7 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
     );
 
     let remainingPublishedRows = await context.dbAdapter.execute(
-      `SELECT * FROM published_realms WHERE source_realm_url = '${realmURL}'`,
+      `SELECT * FROM realm_registry WHERE kind = 'published' AND source_url = '${realmURL}'`,
     );
     assert.strictEqual(
       remainingPublishedRows.length,

--- a/packages/realm-server/tests/server-endpoints/index-responses-test.ts
+++ b/packages/realm-server/tests/server-endpoints/index-responses-test.ts
@@ -1312,12 +1312,9 @@ module(`server-endpoints/${basename(__filename)}`, function () {
       let firstEtag = firstResponse.headers['etag'];
       assert.ok(firstEtag, 'first response has ETag');
 
-      // Simulate a republish by updating last_published_at on both the
-      // legacy table and realm_registry (the source of truth for reads).
+      // Simulate a republish by updating last_published_at on the
+      // realm_registry row (the source of truth for reads).
       let newLastPublishedAt = Date.now() + 1000;
-      await dbAdapter.execute(
-        `UPDATE published_realms SET last_published_at = '${newLastPublishedAt}' WHERE published_realm_url = '${realmURL.href}'`,
-      );
       await dbAdapter.execute(
         `UPDATE realm_registry SET last_published_at = ${newLastPublishedAt}, updated_at = now() WHERE url = '${realmURL.href}' AND kind = 'published'`,
       );

--- a/packages/realm-server/utils/realm-readability.ts
+++ b/packages/realm-server/utils/realm-readability.ts
@@ -16,7 +16,6 @@ export async function getPublishedRealmURLs(
     return new Set();
   }
 
-  // Phase 4: read from realm_registry instead of published_realms.
   let publishedRealms = (await query(dbAdapter, [
     "SELECT url FROM realm_registry WHERE kind = 'published' AND url IN (",
     ...separatedByCommas(realmList.map((realmURL) => [param(realmURL)])),

--- a/packages/runtime-common/db-queries/realm-permission-queries.ts
+++ b/packages/runtime-common/db-queries/realm-permission-queries.ts
@@ -195,11 +195,15 @@ export async function fetchUserPermissions(
 }
 
 export async function fetchCatalogRealms(dbAdapter: DBAdapter) {
+  // Catalog realms are publicly-readable realms that aren't themselves
+  // published snapshots — published rows live in realm_registry with
+  // kind='published'.
   let results = (await query(dbAdapter, [
     `SELECT rup.realm_url
      FROM realm_user_permissions rup
-     LEFT JOIN published_realms pr ON rup.realm_url = pr.published_realm_url
-     WHERE rup.username = '*' AND rup.read = true AND pr.published_realm_url IS NULL`,
+     LEFT JOIN realm_registry rr
+       ON rup.realm_url = rr.url AND rr.kind = 'published'
+     WHERE rup.username = '*' AND rup.read = true AND rr.url IS NULL`,
   ])) as {
     realm_url: string;
   }[];

--- a/packages/runtime-common/index-structure.ts
+++ b/packages/runtime-common/index-structure.ts
@@ -85,11 +85,3 @@ export const coerceTypes = Object.freeze({
   value: 'JSON',
   timing_diagnostics: 'JSON',
 });
-
-export interface PublishedRealmTable {
-  id: string;
-  owner_username: string;
-  source_realm_url: string;
-  published_realm_url: string;
-  last_published_at: string;
-}

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -4966,7 +4966,6 @@ export class Realm {
     last_published_at: string;
   } | null> {
     try {
-      // Phase 4: read from realm_registry instead of published_realms.
       let results = (await query(this.#dbAdapter, [
         `SELECT last_published_at FROM realm_registry WHERE kind = 'published' AND url =`,
         param(this.url),

--- a/packages/software-factory/src/harness/database.ts
+++ b/packages/software-factory/src/harness/database.ts
@@ -277,8 +277,8 @@ export async function resetRealmState(
           realmURL.href,
         ]);
         await client.query(
-          `DELETE FROM published_realms
-       WHERE source_realm_url = $1 OR published_realm_url = $1`,
+          `DELETE FROM realm_registry
+       WHERE source_url = $1 OR url = $1`,
           [realmURL.href],
         );
 
@@ -410,12 +410,6 @@ export async function rewriteClonedRealmServerUrls(
           `UPDATE realm_meta
            SET realm_url = replace(realm_url, $1, $2),
                value = replace(value::text, $1, $2)::jsonb`,
-          [fromURL, toURL],
-        );
-        await client.query(
-          `UPDATE published_realms
-           SET source_realm_url = replace(source_realm_url, $1, $2),
-               published_realm_url = replace(published_realm_url, $1, $2)`,
           [fromURL, toURL],
         );
         // Without this, lookupDefinition misses every cached module on the


### PR DESCRIPTION
## Summary

Phase 4 PR 2 of the DB-authoritative realm registry project. Now that every reader is on `realm_registry` (Phase 4 PR 1, [#4581](https://github.com/cardstack/boxel/pull/4581)) and the table has been deployed-and-stable on prod, this PR drops `published_realms`, removes the dual-write added in Phase 1 PR 3 ([#4503](https://github.com/cardstack/boxel/pull/4503)), and migrates the few remaining reads onto the registry.

After this PR there is no escape hatch back to `published_realms` — the data is gone. Down migration recreates the table structure but does not restore data.

## What changed

**Migration**
- `packages/postgres/migrations/1779100000000_drop-published-realms.js` — drops indexes + table; down recreates structure (no backfill — see header comment).

**Mutation handlers** (registry is now the only target)
- `handle-publish-realm.ts` — drop the legacy INSERT/UPDATE branch; the renamed `upsertPublishedRealmInRegistry` is the only write inside the per-realm advisory lock.
- `handle-unpublish-realm.ts` — drop `DELETE FROM published_realms`; read `realm_registry` directly.
- `handle-delete-realm.ts` — drop `DELETE FROM published_realms WHERE source_realm_url`; the cascade loop reads `realm_registry`.
- `server.ts:createRealm` — uses renamed `insertSourceRealmInRegistry`.

**Rename + semantics shift in `lib/realm-registry-writes.ts`**
- `mirrorPublishedRealmToRegistry` → `upsertPublishedRealmInRegistry`
- `mirrorSourceRealmToRegistry` → `insertSourceRealmInRegistry`
- `deleteFromRegistryByUrl` → `deleteRegistryRowByUrl`
- `deletePublishedFromRegistryBySource` → `deletePublishedRowsBySourceUrl`

The Phase-1 try/catch-and-log posture (appropriate for shadow data) is removed — a failed registry write must now surface the same way any other handler DB failure surfaces. NOTIFY failures stay swallowed (reconciler poll is the safety net).

**Remaining `published_realms` readers migrated**
- `fetchCatalogRealms` — joins `realm_registry` filtered to `kind = 'published'` instead of the legacy table.
- `lib/realm-metadata-backfill.ts` — `backfillPublishedRealms` resolves disk uuid → URL via `realm_registry`.
- `lib/realm-registry-backfill.ts` — `upsertPublishedRealms` removed entirely. Disk-only published rows can no longer be recovered (the legacy table was the only source for URL/owner/source/last_published_at metadata that disk doesn't carry); registry is now the sole authority for published rows.
- `software-factory/src/harness/database.ts` — `resetRealmState` deletes from `realm_registry`; the `cloneRealmRename` UPDATE on `published_realms` is removed.

**Cleanups**
- Drop `PublishedRealmTable` interface from `runtime-common/index-structure.ts`.
- Strip stale "Phase 4: read from realm_registry instead of published_realms" inline comments now that there's no contrast to draw.
- Rename a matrix test name: "origin not in `published_realms`" → "origin not in `realm_registry`".

**Schema regen**
- `packages/host/config/schema/1779030457123_schema.sql` → `1779100000000_schema.sql` via `packages/postgres/scripts/schema-dump.sh`. Diff against the old file is the removal of the `published_realms` block.

## Verification

- Migration applies and rolls back cleanly against `boxel-pg`.
- Realm-server unit tests pass: `realm-registry-writes-test` (11/11), `realm-registry-backfill-test` (6/6), `queries-test` (4/4), `full-reindex-test` (2/2).
- Spot-checked `fetchCatalogRealms` against live PG — published `realm_registry` rows are correctly excluded.
- Typecheck (realm-server, runtime-common, host, software-factory) introduces no new errors.
- ESLint clean (auto-fixed two prettier nits).

The matrix-dependent integration tests (`delete-realm-test`, `publish-unpublish-realm-test`) are blocked locally by a stale synapse user — pre-existing environmental issue, not from these changes. CI will exercise them on a fresh synapse.

## Test plan

- [ ] CI green
- [ ] Staging migration runs cleanly against a DB that already completed Phase 4 PR 1
- [ ] Staging smoke: publish, unpublish, delete each succeed with no `published_realms` access
- [ ] Verify staging dashboards / Sentry for unexpected handler errors after deploy
- [ ] Hold prod for ≥1 deploy cycle on staging before rolling forward (per the "no rollback after 48h" rule in the issue description)

## References

- Spec: `docs/db-authoritative-realm-registry.md` §7 Phase 4 PR 2 / §9 "Feature-flag revert mid-rollout"
- Linear: [CS-10897](https://linear.app/cardstack/issue/CS-10897/phase-4-pr-2-drop-published-realms-table)
- Predecessors: [CS-10889](https://github.com/cardstack/boxel/pull/4503) (dual-write), [CS-10896](https://github.com/cardstack/boxel/pull/4581) (reads off legacy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)