### PR TITLE
percySnapshot: tolerate non-critical font load failures

### DIFF
--- a/packages/host/tests/helpers/percy-snapshot.ts
+++ b/packages/host/tests/helpers/percy-snapshot.ts
@@ -28,8 +28,9 @@ export default async function percySnapshot(
   // attached. The hard-coded IBM Plex Sans `document.fonts.check` below stays
   // the load-bearing assertion: if the font that actually moves Percy pixels
   // is missing, fail there with a clear message.
+  let faces = Array.from(document.fonts);
   let fontResults = await Promise.allSettled(
-    Array.from(document.fonts, (f) => f.load().then(() => f)),
+    faces.map((f) => f.load().then(() => f)),
   );
   await document.fonts.ready;
 
@@ -37,22 +38,41 @@ export default async function percySnapshot(
     if (result.status !== 'rejected') {
       return [];
     }
-    let face = Array.from(document.fonts)[idx];
+    let face = faces[idx];
     let descriptor = face
       ? `${face.weight} ${face.style} "${face.family}"`
       : `<font#${idx}>`;
-    let reason = describeFontLoadError(result.reason);
-    return [`${descriptor}: ${reason}`];
+    return [{ face, descriptor, reason: describeFontLoadError(result.reason) }];
   });
-  if (failedFonts.length) {
-    console.warn(
-      `[percy-snapshot] ${failedFonts.length} @font-face load(s) failed; continuing snapshot. Failures:\n  ${failedFonts.join('\n  ')}`,
+
+  // If IBM Plex Sans itself failed to load, fail loud here — `document.fonts
+  // .check(..., '')` below cannot be relied on to catch this: per the WHATWG
+  // spec, `FontFaceSet.check` treats faces in `error` status as settled, and
+  // with empty text it can still return `true` while the required face is
+  // actually unrenderable. Without this explicit guard, Percy would capture
+  // the page with a fallback font silently substituted.
+  let failedRequired = failedFonts.find(
+    ({ face }) => face?.family === 'IBM Plex Sans',
+  );
+  if (failedRequired) {
+    throw new Error(
+      `Required font failed to load: ${failedRequired.descriptor}: ${failedRequired.reason}`,
     );
   }
 
-  // The hard-coded Sans check remains as a load-bearing assertion: this font
-  // is the default body font, and a capture without it shifts every text
-  // element by a fraction of a pixel and turns Percy red across the board.
+  if (failedFonts.length) {
+    let lines = failedFonts.map(
+      ({ descriptor, reason }) => `${descriptor}: ${reason}`,
+    );
+    console.warn(
+      `[percy-snapshot] ${failedFonts.length} @font-face load(s) failed; continuing snapshot. Failures:\n  ${lines.join('\n  ')}`,
+    );
+  }
+
+  // Belt-and-suspenders: even if no Sans face entered the `error` status, the
+  // page may still be missing a Sans weight (e.g. never declared, or evicted
+  // after a teardown). A capture without it shifts every text element by a
+  // fraction of a pixel and turns Percy red across the board.
   for (const weight of ['400', '500', '600', '700']) {
     const descriptor = `${weight} 1em IBM Plex Sans`;
     if (!document.fonts.check(descriptor, '')) {

--- a/packages/host/tests/helpers/percy-snapshot.ts
+++ b/packages/host/tests/helpers/percy-snapshot.ts
@@ -20,8 +20,35 @@ export default async function percySnapshot(
   // Load every @font-face the page has declared, not just a hard-coded list.
   // This covers IBM Plex Sans, IBM Plex Mono (used by Monaco), IBM Plex Serif
   // and any future additions, without needing to keep the helper in sync.
-  await Promise.all(Array.from(document.fonts, (f) => f.load()));
+  //
+  // `allSettled` (not `all`) because Chrome rejects FontFace.load() with a
+  // generic `DOMException: A network error occurred.` when the font fetch
+  // fails — typically a transient hiccup pulling a non-critical font over the
+  // wire in CI. Letting that bubble out turns the *whole* test red with no URL
+  // attached. The hard-coded IBM Plex Sans `document.fonts.check` below stays
+  // the load-bearing assertion: if the font that actually moves Percy pixels
+  // is missing, fail there with a clear message.
+  let fontResults = await Promise.allSettled(
+    Array.from(document.fonts, (f) => f.load().then(() => f)),
+  );
   await document.fonts.ready;
+
+  let failedFonts = fontResults.flatMap((result, idx) => {
+    if (result.status !== 'rejected') {
+      return [];
+    }
+    let face = Array.from(document.fonts)[idx];
+    let descriptor = face
+      ? `${face.weight} ${face.style} "${face.family}"`
+      : `<font#${idx}>`;
+    let reason = describeFontLoadError(result.reason);
+    return [`${descriptor}: ${reason}`];
+  });
+  if (failedFonts.length) {
+    console.warn(
+      `[percy-snapshot] ${failedFonts.length} @font-face load(s) failed; continuing snapshot. Failures:\n  ${failedFonts.join('\n  ')}`,
+    );
+  }
 
   // The hard-coded Sans check remains as a load-bearing assertion: this font
   // is the default body font, and a capture without it shifts every text
@@ -69,4 +96,17 @@ export default async function percySnapshot(
   }
 
   await originalPercySnapshot(...args);
+}
+
+function describeFontLoadError(reason: unknown): string {
+  if (reason instanceof Error) {
+    let header = reason.name
+      ? `${reason.name}: ${reason.message}`
+      : reason.message;
+    return header || 'Unknown error';
+  }
+  if (typeof reason === 'string') {
+    return reason;
+  }
+  return String(reason);
 }


### PR DESCRIPTION
## Summary

Tests that call `percySnapshot` were failing intermittently in CI with `Promise rejected during "<test name>": A network error occurred.` — a generic message with no URL, no stack pointing into our code, and no way to attribute it. The fingerprint matched two unrelated tests in run [25460877925](https://github.com/cardstack/boxel/actions/runs/25460877925/job/74706758962?pr=4666) shard 7 (`field playground > can preview compound field instance` and `preview > renders head meta tags preview for a card head format`). Both call `percySnapshot`; no other tests in those modules failed.

Root cause: `await Promise.all(Array.from(document.fonts, (f) => f.load()))`. Chrome rejects `FontFace.load()` for transient font-fetch failures with exactly `DOMException: A network error occurred.`. With `Promise.all`, a single non-critical font hiccup tanked the whole snapshot path and bubbled out of the test.

## What this PR does in `percy-snapshot.ts`

- **Snapshot `document.fonts` once** before kicking off any `load()` calls. The live set can shift while fonts/stylesheets load, so a later re-enumeration would risk misattributing which face actually failed.
- **`Promise.allSettled` instead of `Promise.all`** so a non-critical font failure no longer poisons the snapshot path.
- **Explicit IBM Plex Sans guard on the rejected-faces list.** Per the WHATWG `FontFaceSet.check` spec, faces in `error` status are treated as settled, and `document.fonts.check(descriptor, '')` with empty text can return `true` even when the required face is unrenderable. So we cannot rely on `check` alone to detect a Sans network failure — we inspect the rejected list directly and throw with the descriptor + rejection reason if any rejected face's family is `"IBM Plex Sans"`. Without this, Percy would capture the page with a fallback font silently substituted in.
- **Belt-and-suspenders `document.fonts.check` loop** stays for the unrelated case where a Sans weight was never declared on the page in the first place.
- **`[percy-snapshot]` warning** when any non-critical font fails, naming each failed face (weight/style/family + rejection reason). If this fingerprint resurfaces, the testem log now points at the offender directly.

## Test plan

- [ ] CI: shard 7 of CI Host passes (and historical runs of these two tests stop matching the `A network error occurred.` fingerprint)
- [ ] Sanity: when IBM Plex Sans really is missing the explicit `Required font failed to load: ...` (rejected face) or `Not ready: IBM Plex Sans font could not be loaded (...)` (never declared) error still fires, so the load-bearing assertion against fallback-font captures isn't lost
- [ ] No new lint warnings in `packages/host`

🤖 Generated with [Claude Code](https://claude.com/claude-code)