### PR TITLE
dev-all: kill subprocess tree on exit so port 4210 is freed

### DIFF
--- a/mise-tasks/dev-all
+++ b/mise-tasks/dev-all
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #MISE description="Start host app + full dev stack (host must be ready before realm server)"
 #MISE dir="packages/realm-server"
 

--- a/mise-tasks/dev-all
+++ b/mise-tasks/dev-all
@@ -8,15 +8,37 @@ PATH="$(pwd)/../../node_modules/.bin:$(pwd)/node_modules/.bin:$PATH"
 
 . "$(cd "$(dirname "$0")" && pwd)/lib/dev-common.sh"
 
+# Enable job control so backgrounded subprocesses run in their own process
+# group. Without this, Ctrl-C is delivered to the whole foreground group;
+# npm-run-all2 (`run-p`) tends to exit before propagating SIGINT to its
+# `npm run` children, which then reparent to init and leak ports — most
+# visibly the worker-manager listening on 4210, which blocks the next
+# `mise dev-all` from binding the port.
+set -m
+
+# Recursively SIGTERM a pid and all its descendants. Walks by parent-pid
+# (independent of pgid, which `mise run` rewrites for its tasks) so we catch
+# the whole tree before any layer dies and orphans its children to init.
+kill_tree() {
+  for child in $(pgrep -P "$1" 2>/dev/null); do
+    kill_tree "$child"
+  done
+  kill -TERM "$1" 2>/dev/null || true
+}
+
 # Start host app in background and wait for it before launching the rest.
 # start-server-and-test v1.x only supports 2 server phases (5 args), so we
 # start the host manually and use wait-on to gate readiness.
 pnpm --filter @cardstack/host start &
 HOST_PID=$!
-cleanup_host() {
-  kill "$HOST_PID" >/dev/null 2>&1 || true
+cleanup() {
+  trap - EXIT INT TERM
+  if [ -n "${SAT_PID:-}" ]; then
+    kill_tree "$SAT_PID"
+  fi
+  kill_tree "$HOST_PID"
 }
-trap cleanup_host EXIT INT TERM
+trap cleanup EXIT INT TERM
 
 HOST_TIMEOUT=120
 ELAPSED=0
@@ -43,4 +65,7 @@ WAIT_ON_TIMEOUT=7200000 NODE_NO_WARNINGS=1 start-server-and-test \
   "$PHASE1_URLS" \
   'run-p -ln start:worker-test start:test-realms' \
   "$NODE_TEST_REALM_READY" \
-  'wait'
+  'wait' &
+SAT_PID=$!
+wait "$SAT_PID"
+exit $?


### PR DESCRIPTION
## Summary
- Killing `mise dev-all` with Ctrl-C left a `worker-manager` listening on 4210, so the next `mise dev-all` couldn't bind the port.
- Root cause: SIGINT goes to the foreground process group, and `run-p` (npm-run-all2) tends to exit before forwarding the signal to its `npm run` children. Those `npm run start:worker-development` processes (and the `mise run` → sh → ts-node chain underneath) get reparented to init and survive.
- Fix: enable job control so `start-server-and-test` runs in its own pgid (Ctrl-C now hits `dev-all` only), then walk the still-intact descendant tree by parent-pid in the cleanup trap and SIGTERM everyone. Walking by PPID rather than pgid matters because `mise run` rewrites pgids for its tasks.

## Test plan
- [ ] `mise run dev-all` boots cleanly as before.
- [ ] After Ctrl-C, `lsof -iTCP:4210 -sTCP:LISTEN` is empty (and same for 4205/4222/etc.).
- [ ] Re-running `mise dev-all` immediately after Ctrl-C succeeds (no port-in-use error).
- [ ] Normal exit (e.g. host-app readiness timeout) still tears everything down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)