### PR TITLE
CS-11077: in-memory parsed module-definition cache

### DIFF
--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -2099,6 +2099,209 @@ module(basename(__filename), function () {
         'persist proceeded normally when nothing invalidated mid-flight',
       );
     });
+
+    test('parsed-entry cache short-circuits the DB read on repeat lookups', async function (assert) {
+      // The parsed cache populates on a successful DB hit, not on
+      // persist-after-prerender. So the first lookup (cold prerender +
+      // persist) leaves the in-memory cache empty; the second lookup
+      // reads the DB row and inserts it into the in-memory cache; the
+      // third lookup is the one we expect to short-circuit before the DB.
+      // Verify that path: after warm-up, deleting the row out from under
+      // the cache doesn't affect the next lookup (no DB read happens).
+      let moduleURL = `${realmURL}parsed-cache-warm.gts`;
+      let calls = 0;
+      let prerenderer: Prerenderer = {
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls++;
+          return buildModuleResponse(args.url, 'ParsedCacheWarm', []);
+        },
+      };
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      // 1. Cold lookup: prerenders + persists.
+      await lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'ParsedCacheWarm',
+      });
+      assert.strictEqual(calls, 1, 'prerender ran once on cold lookup');
+
+      // 2. Warm-up lookup: hits DB and populates the in-memory cache.
+      await lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'ParsedCacheWarm',
+      });
+      assert.strictEqual(calls, 1, 'no re-prerender on second lookup');
+
+      // 3. Delete the row, then look up a third time. If the in-memory
+      // cache is doing its job, the lookup short-circuits before any DB
+      // read and never re-enters the prerender path.
+      await dbAdapter.execute('DELETE FROM modules WHERE url = $1', {
+        bind: [moduleURL],
+      });
+      let third = await lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'ParsedCacheWarm',
+      });
+      assert.strictEqual(
+        third?.displayName,
+        'ParsedCacheWarm',
+        'third lookup served from in-memory parsed cache',
+      );
+      assert.strictEqual(
+        calls,
+        1,
+        'no re-prerender — cache short-circuited before the DB read',
+      );
+    });
+
+    test('bumpModuleGeneration invalidates the parsed-entry cache for that module', async function (assert) {
+      // The cross-process NOTIFY listener (CS-10952) replays peer
+      // invalidations into this process by calling the public
+      // `bumpModuleGeneration`. After the bump, this process's parsed-cache
+      // entries with the matching (realm, moduleURL) snapshot are stale and
+      // must not be returned. Drives the same invalidation contract that
+      // already protects in-flight prerenders, extended to sit-on-the-shelf
+      // parsed entries.
+      let moduleURL = `${realmURL}parsed-cache-bump-module.gts`;
+      let calls = 0;
+      let prerenderer: Prerenderer = {
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls++;
+          return buildModuleResponse(args.url, 'BumpModule', []);
+        },
+      };
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      // Cold lookup + warm-up to populate the in-memory parsed cache.
+      await lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'BumpModule',
+      });
+      await lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'BumpModule',
+      });
+      assert.strictEqual(calls, 1, 'cache warmed up after one prerender');
+
+      // Simulate a peer's invalidation arriving via NOTIFY: the row is
+      // deleted in the DB and the local listener bumps our counter.
+      await dbAdapter.execute('DELETE FROM modules WHERE url = $1', {
+        bind: [moduleURL],
+      });
+      lookup.bumpModuleGeneration(realmURL, moduleURL);
+
+      await lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'BumpModule',
+      });
+      assert.strictEqual(
+        calls,
+        2,
+        'parsed cache dropped on snapshot mismatch — falls through to prerender',
+      );
+    });
+
+    test('bumpGlobalGeneration invalidates the parsed-entry cache for every entry', async function (assert) {
+      // clearAllModules() bumps `#globalGeneration` and CS-10952's listener
+      // calls `bumpGlobalGeneration()` on peers. Either path must
+      // invalidate every parsed-cache entry on next access regardless of
+      // realm or module.
+      let moduleURL = `${realmURL}parsed-cache-bump-global.gts`;
+      let calls = 0;
+      let prerenderer: Prerenderer = {
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls++;
+          return buildModuleResponse(args.url, 'BumpGlobal', []);
+        },
+      };
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      // Cold lookup + warm-up to populate the in-memory parsed cache.
+      await lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'BumpGlobal',
+      });
+      await lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'BumpGlobal',
+      });
+      assert.strictEqual(calls, 1, 'cache warmed up after one prerender');
+
+      await dbAdapter.execute('DELETE FROM modules WHERE url = $1', {
+        bind: [moduleURL],
+      });
+      lookup.bumpGlobalGeneration();
+
+      await lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'BumpGlobal',
+      });
+      assert.strictEqual(
+        calls,
+        2,
+        'global bump invalidates the parsed cache; lookup re-prerendered',
+      );
+    });
   });
 
   // Lightweight tests for the modules-table diagnostics persistence.

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -38,6 +38,13 @@ import type { VirtualNetwork } from './virtual-network';
 
 const MODULES_TABLE = 'modules';
 const PREFERRED_EXECUTABLE_EXTENSIONS = ['.gts', '.ts', '.gjs', '.js'];
+// In-memory cap for the parsed `ModuleCacheEntry` cache, measured against the
+// JSON-text size of the cached `definitions`. Parsed JS objects are roughly
+// 2–3x the JSON-text byte count, so 256 MB of text corresponds to ~0.5–0.75 GB
+// of resident heap once across all entries. Sized to comfortably hold the
+// dominant card-definition modules in production (the largest observed are
+// ~60 MB JSON text). Evict-LRU when the running total exceeds this.
+const PARSED_CACHE_BUDGET_CHARS = 256 * 1024 * 1024;
 // Postgres NOTIFY channel for cross-instance module-cache invalidation
 // (CS-10952). Each invalidation path emits one or more notifications so
 // peer realm-server processes can bump their in-memory generation counters
@@ -128,6 +135,33 @@ function parseJsonValue<T>(value: T | string | null): T | null {
     }
   }
   return value as T;
+}
+
+// Approximate the JSON-text byte size of a `ModuleCacheEntry` for the
+// parsed-cache budget. The `definitions` blob dominates entry size by
+// orders of magnitude in production (the `deps` array and `error_doc`
+// row are bytes, not megabytes), so the size of the rest is negligible
+// for budget accounting.
+//
+// If the source row arrived as a JSON string (Postgres returned text),
+// its `.length` is exact and free. Otherwise (jsonb auto-decoded by the
+// driver to a JS object) we re-stringify the parsed `definitions` —
+// O(N) on the parsed object, but paid once per cache insert and
+// amortized over every subsequent hit. JSON.stringify can throw on
+// unexpected shapes (cycles, BigInts); fall back to 0 so a single
+// pathological insert can't poison the cache.
+function approximateEntrySizeChars(
+  entry: ModuleCacheEntry,
+  rawDefinitions: unknown,
+): number {
+  if (typeof rawDefinitions === 'string') {
+    return rawDefinitions.length;
+  }
+  try {
+    return JSON.stringify(entry.definitions).length;
+  } catch (_err) {
+    return 0;
+  }
 }
 
 export type CacheScope = 'public' | 'realm-auth';
@@ -246,6 +280,25 @@ export class CachingDefinitionLookup implements DefinitionLookup {
   #moduleGenerations = new Map<string, number>();
   #realmGenerations = new Map<string, number>();
   #globalGeneration = 0;
+  // Parsed-entry cache. Front-ends `readFromDatabaseCache` so successful
+  // cache reads avoid re-running the SQL fetch + JSON.parse of the
+  // `modules.definitions` jsonb column on every lookup. Each entry
+  // captures the three-counter generation snapshot at insertion; lookups
+  // validate against the current snapshot and drop stale entries — so a
+  // local invalidate/clearRealmCache/clearAllModules (or a remote bump
+  // arriving via the cross-process NOTIFY listener) self-evicts on next
+  // access. Map insertion order is iteration order in JS, so re-inserting
+  // on hit gives LRU eviction. Bounded by `PARSED_CACHE_BUDGET_CHARS`
+  // (JSON-text-size proxy for heap).
+  #parsedCache = new Map<
+    string,
+    {
+      entry: ModuleCacheEntry;
+      snapshot: { module: number; realm: number; global: number };
+      sizeChars: number;
+    }
+  >();
+  #parsedCacheBytes = 0;
 
   constructor(
     dbAdapter: DBAdapter,
@@ -937,6 +990,43 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     authUserId: string,
     resolvedRealmURL: string,
   ): Promise<ModuleCacheEntry | undefined> {
+    // Parsed-entry cache short-circuit. Snapshot the generation counters
+    // first, then validate the cached entry's snapshot against them — if
+    // any counter has bumped (locally via invalidate/clearRealmCache/
+    // clearAllModules, or remotely via the cross-process NOTIFY listener
+    // calling the public bumpModuleGeneration / bumpRealmGeneration /
+    // bumpGlobalGeneration helpers), drop the entry and fall through to
+    // the SQL+parse path, which will return whatever the DB currently
+    // holds (undefined if the row was deleted, or a fresher row if a
+    // peer has already re-prerendered).
+    //
+    // Same key shape as `#inFlight`: the four-tuple that uniquely
+    // identifies a (realm, module URL, cache scope, auth user) lookup
+    // context.
+    let cacheKey = inFlightKey({
+      resolvedRealmURL,
+      moduleURL: moduleUrl,
+      cacheScope,
+      cacheUserId: authUserId,
+    });
+    let snapshotAtEntry = this.snapshotGeneration(resolvedRealmURL, moduleUrl);
+    let cached = this.#parsedCache.get(cacheKey);
+    if (cached) {
+      if (
+        cached.snapshot.module === snapshotAtEntry.module &&
+        cached.snapshot.realm === snapshotAtEntry.realm &&
+        cached.snapshot.global === snapshotAtEntry.global
+      ) {
+        // LRU touch: re-insert at end of map iteration order so the
+        // entry is youngest under the eviction policy.
+        this.#parsedCache.delete(cacheKey);
+        this.#parsedCache.set(cacheKey, cached);
+        return cached.entry;
+      }
+      this.#parsedCacheBytes -= cached.sizeChars;
+      this.#parsedCache.delete(cacheKey);
+    }
+
     let moduleAlias = normalizeExecutableURL(moduleUrl);
     let rows = (await this.query(
       [
@@ -980,7 +1070,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     }
     let error = parseJsonValue<ErrorEntry>(row.error_doc) ?? undefined;
     let createdAt = row.created_at ? parseInt(row.created_at) : undefined;
-    return {
+    let entry: ModuleCacheEntry = {
       definitions,
       deps,
       error,
@@ -989,6 +1079,54 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       resolvedRealmURL: row.resolved_realm_url || '',
       createdAt,
     };
+
+    // Don't cache error entries: they have a TTL (see `isExpiredErrorEntry`),
+    // and re-checking that TTL against an in-memory copy would either return
+    // a stale-but-still-cached error or require an extra TTL-aware eviction
+    // path. The SQL path handles errors correctly today; let it.
+    //
+    // Re-snapshot before insert: if a generation bumped between entry and
+    // here (e.g. an in-flight peer invalidation arrived during the SQL
+    // round-trip), the row we just read is already stale. Skip the cache
+    // insert; the next caller will re-read.
+    if (!error) {
+      let snapshotAtPersist = this.snapshotGeneration(
+        resolvedRealmURL,
+        moduleUrl,
+      );
+      if (
+        snapshotAtPersist.module === snapshotAtEntry.module &&
+        snapshotAtPersist.realm === snapshotAtEntry.realm &&
+        snapshotAtPersist.global === snapshotAtEntry.global
+      ) {
+        let sizeChars = approximateEntrySizeChars(entry, row.definitions);
+        this.#parsedCache.set(cacheKey, {
+          entry,
+          snapshot: snapshotAtPersist,
+          sizeChars,
+        });
+        this.#parsedCacheBytes += sizeChars;
+        this.evictParsedCacheUntilUnderBudget();
+      }
+    }
+    return entry;
+  }
+
+  private evictParsedCacheUntilUnderBudget(): void {
+    while (
+      this.#parsedCacheBytes > PARSED_CACHE_BUDGET_CHARS &&
+      this.#parsedCache.size > 0
+    ) {
+      let oldestKey = this.#parsedCache.keys().next().value;
+      if (oldestKey === undefined) {
+        return;
+      }
+      let oldest = this.#parsedCache.get(oldestKey);
+      if (oldest) {
+        this.#parsedCacheBytes -= oldest.sizeChars;
+      }
+      this.#parsedCache.delete(oldestKey);
+    }
   }
 
   async getModuleCacheEntries(

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -1100,6 +1100,18 @@ export class CachingDefinitionLookup implements DefinitionLookup {
         snapshotAtPersist.global === snapshotAtEntry.global
       ) {
         let sizeChars = approximateEntrySizeChars(entry, row.definitions);
+        // If a concurrent caller already inserted under this key, subtract
+        // the existing entry's bytes before overwriting. `Map#set`
+        // replaces the value but the bytes counter would otherwise
+        // double-count the replaced entry, drifting permanently above
+        // the actual map weight and forcing spurious evictions.
+        // Reachable because `lookupCachedDefinition` calls this directly,
+        // bypassing `#inFlight`, so two concurrent cache-only readers can
+        // both finish the SQL round-trip for the same cacheKey.
+        let existing = this.#parsedCache.get(cacheKey);
+        if (existing) {
+          this.#parsedCacheBytes -= existing.sizeChars;
+        }
         this.#parsedCache.set(cacheKey, {
           entry,
           snapshot: snapshotAtPersist,

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -137,19 +137,24 @@ function parseJsonValue<T>(value: T | string | null): T | null {
   return value as T;
 }
 
-// Approximate the JSON-text byte size of a `ModuleCacheEntry` for the
+// Approximate the JSON-text size of a `ModuleCacheEntry` for the
 // parsed-cache budget. The `definitions` blob dominates entry size by
 // orders of magnitude in production (the `deps` array and `error_doc`
-// row are bytes, not megabytes), so the size of the rest is negligible
-// for budget accounting.
+// row are bytes, not megabytes), so the rest is negligible for budget
+// accounting.
 //
 // If the source row arrived as a JSON string (Postgres returned text),
 // its `.length` is exact and free. Otherwise (jsonb auto-decoded by the
 // driver to a JS object) we re-stringify the parsed `definitions` —
 // O(N) on the parsed object, but paid once per cache insert and
-// amortized over every subsequent hit. JSON.stringify can throw on
-// unexpected shapes (cycles, BigInts); fall back to 0 so a single
-// pathological insert can't poison the cache.
+// amortized over every subsequent hit.
+//
+// `JSON.stringify` can throw on unexpected shapes (cycles, BigInts).
+// Returns 0 in that case as a "size unknown" sentinel; the caller must
+// treat 0 as "skip caching" so a pathological insert can't bypass the
+// budget cap. (Realistic prerender output won't trigger this — module
+// definitions are plain JSON-shaped — but the safety hatch needs to
+// stay closed.)
 function approximateEntrySizeChars(
   entry: ModuleCacheEntry,
   rawDefinitions: unknown,
@@ -298,7 +303,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       sizeChars: number;
     }
   >();
-  #parsedCacheBytes = 0;
+  #parsedCacheChars = 0;
 
   constructor(
     dbAdapter: DBAdapter,
@@ -540,6 +545,14 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       key,
       (this.#moduleGenerations.get(key) ?? 0) + 1,
     );
+    // Eager-evict matching parsed-cache entries. Snapshot validation in
+    // `readFromDatabaseCache` already drops a stale entry on next access,
+    // so this is for memory hygiene — without it, a stale entry could sit
+    // resident until LRU touches it. The cacheKey shape is
+    // `${resolvedRealmURL}|${moduleURL}|<scope>|<user>`, so the prefix
+    // narrows to entries for this exact module across all (scope, user)
+    // pairs.
+    this.evictParsedCacheByPrefix(`${resolvedRealmURL}|${moduleURL}|`);
   }
 
   bumpRealmGeneration(resolvedRealmURL: string): void {
@@ -547,10 +560,21 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       resolvedRealmURL,
       (this.#realmGenerations.get(resolvedRealmURL) ?? 0) + 1,
     );
+    // Eager-evict every parsed-cache entry for this realm — same memory-
+    // hygiene reasoning as `bumpModuleGeneration`, but the realm-scoped
+    // counter invalidates every (moduleURL, scope, user) combination
+    // under the realm.
+    this.evictParsedCacheByPrefix(`${resolvedRealmURL}|`);
   }
 
   bumpGlobalGeneration(): void {
     this.#globalGeneration += 1;
+    // Every parsed-cache entry is now snapshot-stale by construction.
+    // Drop the whole map so the memory is released immediately rather
+    // than waiting for each entry to be touched and self-evict, or for
+    // LRU pressure to push them out under unrelated work.
+    this.#parsedCache.clear();
+    this.#parsedCacheChars = 0;
   }
 
   // Returns true if the cached entry has a top-level error and has exceeded
@@ -1023,7 +1047,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
         this.#parsedCache.set(cacheKey, cached);
         return cached.entry;
       }
-      this.#parsedCacheBytes -= cached.sizeChars;
+      this.#parsedCacheChars -= cached.sizeChars;
       this.#parsedCache.delete(cacheKey);
     }
 
@@ -1100,33 +1124,56 @@ export class CachingDefinitionLookup implements DefinitionLookup {
         snapshotAtPersist.global === snapshotAtEntry.global
       ) {
         let sizeChars = approximateEntrySizeChars(entry, row.definitions);
-        // If a concurrent caller already inserted under this key, subtract
-        // the existing entry's bytes before overwriting. `Map#set`
-        // replaces the value but the bytes counter would otherwise
-        // double-count the replaced entry, drifting permanently above
-        // the actual map weight and forcing spurious evictions.
-        // Reachable because `lookupCachedDefinition` calls this directly,
-        // bypassing `#inFlight`, so two concurrent cache-only readers can
-        // both finish the SQL round-trip for the same cacheKey.
-        let existing = this.#parsedCache.get(cacheKey);
-        if (existing) {
-          this.#parsedCacheBytes -= existing.sizeChars;
+        // sizeChars === 0 only when `approximateEntrySizeChars` couldn't
+        // determine a size (e.g. JSON.stringify threw on a pathological
+        // shape). Skip the cache write rather than insert a zero-weight
+        // entry that would consume memory without counting against the
+        // budget — that would silently disable budget enforcement for
+        // any pathological row that landed first.
+        if (sizeChars > 0) {
+          // If a concurrent caller already inserted under this key,
+          // subtract the existing entry's chars before overwriting.
+          // `Map#set` replaces the value but the chars counter would
+          // otherwise double-count the replaced entry, drifting
+          // permanently above the actual map weight and forcing
+          // spurious evictions. Reachable because
+          // `lookupCachedDefinition` calls this directly, bypassing
+          // `#inFlight`, so two concurrent cache-only readers can both
+          // finish the SQL round-trip for the same cacheKey.
+          let existing = this.#parsedCache.get(cacheKey);
+          if (existing) {
+            this.#parsedCacheChars -= existing.sizeChars;
+          }
+          this.#parsedCache.set(cacheKey, {
+            entry,
+            snapshot: snapshotAtPersist,
+            sizeChars,
+          });
+          this.#parsedCacheChars += sizeChars;
+          this.evictParsedCacheUntilUnderBudget();
         }
-        this.#parsedCache.set(cacheKey, {
-          entry,
-          snapshot: snapshotAtPersist,
-          sizeChars,
-        });
-        this.#parsedCacheBytes += sizeChars;
-        this.evictParsedCacheUntilUnderBudget();
       }
     }
     return entry;
   }
 
+  // Drop every parsed-cache entry whose key starts with `prefix` and
+  // decrement the chars counter accordingly. Called from the bump
+  // methods so a local invalidation or a cross-process NOTIFY-replay
+  // (via CS-10952's listener) frees memory immediately rather than
+  // waiting for snapshot mismatches to evict on the next access.
+  private evictParsedCacheByPrefix(prefix: string): void {
+    for (let [key, entry] of this.#parsedCache) {
+      if (key.startsWith(prefix)) {
+        this.#parsedCacheChars -= entry.sizeChars;
+        this.#parsedCache.delete(key);
+      }
+    }
+  }
+
   private evictParsedCacheUntilUnderBudget(): void {
     while (
-      this.#parsedCacheBytes > PARSED_CACHE_BUDGET_CHARS &&
+      this.#parsedCacheChars > PARSED_CACHE_BUDGET_CHARS &&
       this.#parsedCache.size > 0
     ) {
       let oldestKey = this.#parsedCache.keys().next().value;
@@ -1135,7 +1182,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       }
       let oldest = this.#parsedCache.get(oldestKey);
       if (oldest) {
-        this.#parsedCacheBytes -= oldest.sizeChars;
+        this.#parsedCacheChars -= oldest.sizeChars;
       }
       this.#parsedCache.delete(oldestKey);
     }


### PR DESCRIPTION
## Summary

Today, every warm-cache `loadLinks` GET against a card whose link tree adopts from a large `software-factory` module re-fetches and re-parses the same `modules.definitions` jsonb row 5–11 times per request. This PR adds a per-process, parsed-form working set above `readFromDatabaseCache` so each realm-server fetches+parses each row at most once between invalidations. The shared DB row stays the authoritative source of truth — nothing is being duplicated, and no per-process state is being introduced that peers need to know about.

## Where state lives — and what this PR does and does not change

It's worth being careful about the term "in-memory cache" given the direction of the DB-Authoritative Realm Registry project. So, concretely:

**Authoritative state, shared across all realm-server processes (DB):**
- `modules.definitions` jsonb — the canonical persisted output of a module prerender. Written once, read by every realm-server process. This PR does not change how it's written, what's stored in it, or who reads it.
- `boxel_index`, `realm_registry`, queue tables — unchanged.

**Per-process state, already in `CachingDefinitionLookup` today:**
- `#moduleGenerations` / `#realmGenerations` / `#globalGeneration` — three counters bumped synchronously by `invalidate` / `clearRealmCache` / `clearAllModules` before the DB DELETE. Used today only to discard mid-flight prerender results that started against a now-stale view.
- `#inFlight` — coalesces concurrent same-key callers within a process so a single SQL round-trip is shared by all waiters; evicts on completion.

**Per-process state added by this PR:**
- `#parsedCache` — a Map of parsed `ModuleCacheEntry` keyed by `(canonicalModuleURL, cacheScope, cacheUserId, resolvedRealmURL)`. Each entry holds the result of one `readFromDatabaseCache` call along with the generation-counter snapshot that was current at insert time. Bounded by total parsed-bytes (`PARSED_CACHE_BUDGET_CHARS` = 256 MB JSON-text proxy for ~0.5–0.75 GB heap). LRU via Map insertion order.

The cache is purely a **parsed-form working set of the DB row**. It is reconcilable from the DB at any time: drop the entire Map and the next lookup re-reads + re-parses the DB row, exactly like today. No process needs to know what's in any other process's `#parsedCache`. There is no new shared state.

## Findings — what we measured

Instrumented warm-cache GET against `e2e-1/Validations/eval_sticky-note-1`. Every relevant `software-factory` module was already populated in the `modules` table; no prerender fired during the measured GET. The realm-server process held a fresh `CachingDefinitionLookup` (in-memory generation counters all zero, `#inFlight` empty between layers).

```
total=28.1s  idxWait=0ms  cardDoc=28.1s
  layer 0 (Validations card)         layerMs=2.9s
  layer 1 (Issues/sticky-note)       layerMs=10.1s
  layer 2 (Project + 3 KAs)          layerMs=15.1s

darkfactory.gts                      ~11 reads, ~22s of read+parse total
eval-result.gts                       1 read,    1.3s
loadModuleCacheEntry events          MISS=14   COALESCE=7   (≈ 33% coalesce rate)
readFromDatabaseCache (per call)     sql ~1.5s   parse ~0.4s   blob ~60 MB
```

`#inFlight` does its job for concurrent same-key callers (layer 2's 4-card `Promise.all` collapses to 1 read), but evicts on completion. Sequential calls within a single GET — across layer boundaries, after each layer's `Promise.all` settles, and inside `executeQueryForField` follow-ups — each re-fetch and re-parse the same 60 MB DB row from scratch. Two-thirds of `loadModuleCacheEntry` invocations did not coalesce.

The DB row sizes are large by design (the dominant module re-exports the entire factory schema, and one-time-cost trimming is tracked separately):

```
eval-result.gts        ~41 MB    instantiate-result.gts ~41 MB
lint-result.gts        ~41 MB    parse-result.gts       ~41 MB
test-results.gts       ~41 MB    darkfactory.gts        ~62 MB
```

A direct DB-only bench (no realm-server, single PG connection) put the floor at 8.7s of read+parse work per such GET; observed end-to-end was 20–28s in production-shape conditions. Five `user/cs-11003-e2e-{1..5}` realms exhibited the same behavior:

```
e2e-1  eval/instantiate         20–22s   (subtype's module already cached)
e2e-1  lint/parse/test (first)  40–43s   (subtype's module is the only cold one)
e2e-1  lint/parse/test (next)   19–23s   (warm)
e2e-2..3                        20–30s
e2e-4..5                        11–22s   (PG + ts-node fully warm)
```

Eliminating the redundancy collapses 28s → ~5s. The residual is `executeQueryForField issues` (4.7s in this GET) + `cloneDeep` + per-resource search — separate concerns, tracked elsewhere.

## Fix

Front-end `readFromDatabaseCache` with `#parsedCache`. Both `lookupDefinition` and `lookupCachedDefinition` paths benefit because both flow through `readFromDatabaseCache`.

- **On lookup**: snapshot the three generation counters as the first synchronous step. Look up the key in `#parsedCache`. If a hit and the cached snapshot equals the current snapshot, LRU-touch it (delete + re-insert at end of Map iteration order) and return the parsed entry. If snapshots disagree (a local invalidation or peer NOTIFY has bumped a counter since insert), drop the entry, decrement byte-count, fall through to the SQL+parse path.
- **On insert**: re-snapshot before writing. If a counter bumped between the lookup snapshot and the post-SQL snapshot — i.e. an invalidation arrived during the SQL round-trip — skip the cache write rather than insert an entry that's stale at birth. Subtract any existing entry's `sizeChars` before overwriting (see [thread](https://github.com/cardstack/boxel/pull/4690#discussion_r3198141672) for the concurrent-replace race).
- **Errors are not cached**: the existing `isExpiredErrorEntry` TTL path already handles them in DB; in-memory caching errors would either return a stale-but-still-cached error or require a TTL-aware in-memory eviction path. Not worth either.
- **Bounded** by total parsed-bytes. Map insertion order = iteration order in JS, so re-inserting on hit gives LRU. Eviction loops while bytes exceed budget.

## Why this stacks on `cs-10952-cross-process-invalidation-broadcast` (#4644)

CS-10952 is the piece that makes a per-process parsed-form cache safe to add at all in a multi-process realm-server topology. Two reasons, both load-bearing:

**1. The bump helpers it makes public are exactly what my snapshot mechanism keys on.** CS-10952 promotes `bumpModuleGeneration` / `bumpRealmGeneration` / `bumpGlobalGeneration` from `private` to public on `CachingDefinitionLookup` so a sibling `ModuleCacheInvalidationListener` can call them. My fix uses those same three counters as its invalidation contract. Landing this PR on top of CS-10952 means I get the public API for free; landing it independently would mean either duplicating the promotion or merging out of order.

**2. The cross-process invalidation channel it adds is what closes the multi-process correctness gap.** At N=1 (today's prod), local `invalidate` / `clearRealmCache` / `clearAllModules` already bump counters synchronously before the DB DELETE — so my snapshot check is sufficient: the next lookup sees the bump and self-evicts. At N>1, that's no longer true. Process A's local bump doesn't reach process B's counters. Without CS-10952, B's `#parsedCache` would happily serve a parsed entry that A has already deleted from the DB.

CS-10952 closes that gap end-to-end:
- Each invalidation path (`invalidate` / `clearRealmCache` / `clearAllModules`) emits `NOTIFY module_cache_invalidated` with a structured payload (URL fan-out / realm scope / global) inside the same transaction as the DB DELETE, so peers only see the signal on commit.
- Each realm-server runs a `ModuleCacheInvalidationListener` (subscribed via the multiplexed `PgAdapter.subscribe` from #4660) that parses incoming payloads and replays them by calling the now-public bump helpers on the local `CachingDefinitionLookup`.

So with both PRs in place, the chain on a peer invalidation is: A invalidates → A bumps locally → A's DELETE commits → NOTIFY fires → B's listener wakes → B's listener calls `bumpModuleGeneration` (etc.) on B's `CachingDefinitionLookup` → B's `#parsedCache` snapshot for the affected entry is now stale → B's next `readFromDatabaseCache` lookup observes the snapshot mismatch on its in-memory entry → B drops the entry and falls through to the (now-empty) DB → returns `undefined` (or the freshly-prerendered row if a peer raced to re-populate). Same persist-after-invalidate protection that already exists for in-flight prerenders today, just extended to longer-lived parsed entries.

End result: this cache ships safely under multi-process from day one, layered cleanly above the shared DB row without introducing any new cross-process state. Landing CS-11077 directly on `main` (without CS-10952 first) would be the failure mode worth being concerned about — *that* would be a per-process cache without a cross-process invalidation contract. With the stack, the contract is intact.

## Out of scope, tracked separately

- The `definitions` jsonb is read whole even though `populateQueryFields` only needs the `fields` slice for one specific card type. A jsonb path read or a sibling slim column would shrink the read from ~60 MB to a few KB and would help every realm-server, not just ones with a warm `#parsedCache`.
- `darkfactory.gts`'s `definitions['…/Issue' | '…/Project' | '…/DarkFactory']` are 20+ MB each because of transitive schema embedding in `definition.fields`. Trimming would help every lookup of that module.
- `executeQueryForField` for `Project.issues` linksToMany was 4.7s on its own in the measured GET — separate index-search question, not module-cache-related.

## Test plan

- [x] `pnpm test-module` for `definition-lookup-test.ts` — all 28 tests green, including 3 new ones:
  - parsed-entry cache short-circuits the DB read on repeat lookups
  - `bumpModuleGeneration` invalidates the parsed-entry cache for that module (the cross-process invalidation arrival from CS-10952's listener is structurally identical to a direct call here)
  - `bumpGlobalGeneration` invalidates the parsed-entry cache for every entry
- [x] `pnpm lint` clean for both `runtime-common` and `realm-server`
- [ ] End-to-end check: re-run the warm-cache Validations GET measurement against a local stack with this branch — expect 28s → ~5s