### PR TITLE
dedupe field-defs in module-definition cache via dictionary + path pointers

### DIFF
--- a/packages/host/app/routes/module.ts
+++ b/packages/host/app/routes/module.ts
@@ -372,11 +372,12 @@ async function makeDefinition(
     let api = await context.loaderService.loader.import<typeof CardAPI>(
       `${baseRealm.url}card-api`,
     );
-    let fields = getFieldDefinitions(api, cardOrFieldDef);
+    let { fields, fieldDefs } = getFieldDefinitions(api, cardOrFieldDef);
     let codeRef = identifyCard(cardOrFieldDef) as ResolvedCodeRef;
     let definition: Definition = {
       codeRef,
       fields,
+      fieldDefs,
       type: isCardDef(cardOrFieldDef) ? 'card-def' : 'field-def',
       displayName: isCardDef(cardOrFieldDef)
         ? cardOrFieldDef.displayName

--- a/packages/host/app/utils/file-def-attributes-extractor.ts
+++ b/packages/host/app/utils/file-def-attributes-extractor.ts
@@ -330,14 +330,15 @@ export class FileDefAttributesExtractor {
       let cardApiModule = await this.#loaderService.loader.import<
         typeof CardAPI
       >('https://cardstack.com/base/card-api');
-      let fields = getFieldDefinitions(
+      let { fields, fieldDefs } = getFieldDefinitions(
         cardApiModule,
         klass as unknown as typeof BaseDef,
       );
       let result: Record<string, QueryFieldMeta> = {};
-      for (let [name, def] of Object.entries(fields)) {
+      for (let [name, defId] of Object.entries(fields)) {
+        let def = fieldDefs[defId];
         if (
-          def.query &&
+          def?.query &&
           (def.type === 'linksTo' || def.type === 'linksToMany')
         ) {
           result[name] = {

--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -200,10 +200,12 @@ module('Unit | query', function (hooks) {
     let api = await loader.import<typeof CardAPI>(`${baseRealm.url}card-api`);
 
     async function buildDefinition(cardDef: typeof CardDef) {
+      let { fields, fieldDefs } = getFieldDefinitions(api, cardDef);
       return {
         codeRef: identifyCard(cardDef),
         displayName: cardDef.displayName,
-        fields: getFieldDefinitions(api, cardDef),
+        fields,
+        fieldDefs,
       } as Definition;
     }
 

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -37,6 +37,7 @@ function buildDefinition(
       },
       displayName: name,
       fields: {},
+      fieldDefs: {},
     },
     types: [],
   };
@@ -129,8 +130,9 @@ module(basename(__filename), function () {
                     name: 'Person',
                   },
                   displayName: 'Person',
-                  fields: {
-                    name: {
+                  fields: { name: 'f0' },
+                  fieldDefs: {
+                    f0: {
                       type: 'contains',
                       isPrimitive: true,
                       isComputed: false,
@@ -356,6 +358,7 @@ module(basename(__filename), function () {
                   },
                   displayName: `Person v${version}`,
                   fields: {},
+                  fieldDefs: {},
                 },
                 types: [],
               },
@@ -1560,6 +1563,7 @@ module(basename(__filename), function () {
                   },
                   displayName: `CoalesceInvalidate v${version}`,
                   fields: {},
+                  fieldDefs: {},
                 },
                 types: [],
               },
@@ -2142,6 +2146,7 @@ module(basename(__filename), function () {
                   codeRef: { module: rri(moduleURL.href), name: 'Person' },
                   displayName: 'Person',
                   fields: {},
+                  fieldDefs: {},
                 },
                 types: [],
               },

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -39,7 +39,7 @@ import {
   type MatrixConfig,
   type QueuePublisher,
   type QueueRunner,
-  type Definition,
+  type FieldDefinition,
   type Prerenderer,
   CachingDefinitionLookup,
 } from '@cardstack/runtime-common';
@@ -2352,7 +2352,12 @@ export const cardInfo = {
   cardThumbnailURL: null,
 };
 
-export const cardDefinition: Definition['fields'] = {
+// Hand-written legacy-shape fixture (pre-CS-11079, before
+// `Definition.fields` switched to a path-to-defId map). Typed as the
+// flat `Record<string, FieldDefinition>` shape directly because no
+// caller uses this through `Definition`. Kept around for any test that
+// wants a realistic-looking field map without booting a host runtime.
+export const cardDefinition: Record<string, FieldDefinition> = {
   id: {
     type: 'contains',
     isComputed: false,

--- a/packages/runtime-common/definitions.ts
+++ b/packages/runtime-common/definitions.ts
@@ -20,13 +20,33 @@ export interface FieldDefinition {
   query?: Query;
 }
 
+// `fields` maps each (possibly-dotted) path to an opaque `fieldDef` id;
+// `fieldDefs` is the dictionary the ids point into. Many paths typically
+// resolve to the same `FieldDefinition` because the recursive walk over
+// `cardInfo.theme.cardInfo.theme.…` keeps re-emitting the same leaf
+// metadata at every cycle. Dedupe shrinks the persisted module-cache
+// row dramatically (orders of magnitude on cards whose link graphs have
+// cycles).
 export interface Definition {
   type: 'card-def' | 'field-def';
   codeRef: CodeRef;
   displayName: string | null;
-  fields: {
-    [fieldName: string]: FieldDefinition;
-  };
+  fields: { [path: string]: string };
+  fieldDefs: { [defId: string]: FieldDefinition };
+}
+
+// Look up the `FieldDefinition` for a path. Hides the indirection
+// through `fieldDefs` so call sites read like the previous
+// `definition.fields[path]` lookups.
+export function getFieldDef(
+  definition: Pick<Definition, 'fields' | 'fieldDefs'>,
+  path: string,
+): FieldDefinition | undefined {
+  let id = definition.fields[path];
+  if (id === undefined) {
+    return undefined;
+  }
+  return definition.fieldDefs[id];
 }
 
 // we are only recursing 3 levels deep when we see a card def that we have already encountered,
@@ -40,41 +60,82 @@ function recursingDepth(): number {
     : RECURSING_DEPTH;
 }
 
+// Stable JSON serialization for content-keyed interning. Keys sorted at
+// every nesting level so logically-equal `FieldDefinition`s collapse to
+// the same string regardless of the order their properties happened to
+// be assigned in.
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map(stableStringify).join(',') + ']';
+  }
+  let entries = Object.keys(value as Record<string, unknown>)
+    .sort()
+    .map(
+      (k) =>
+        JSON.stringify(k) +
+        ':' +
+        stableStringify((value as Record<string, unknown>)[k]),
+    );
+  return '{' + entries.join(',') + '}';
+}
+
 export function getFieldDefinitions(
   api: typeof CardAPI,
   cardDef: typeof BaseDef,
-  results: Definition['fields'] = {},
-  prefix = '',
-  visited: string[] = [],
-) {
-  let cardKey = internalKeyFor(identifyCard(cardDef)!, undefined);
-  let fields = api.getFields(cardDef, { includeComputeds: true });
-  for (let [fieldName, field] of Object.entries(fields)) {
-    let fullFieldName = `${prefix ? prefix + '.' : ''}${fieldName}`;
-    let isPrimitive = primitive in field.card;
-    let queryDefinition = field.queryDefinition
-      ? (JSON.parse(JSON.stringify(field.queryDefinition)) as Query) // ensure this is a plain object
-      : undefined;
-    results[fullFieldName] = {
-      type: field.fieldType,
-      isPrimitive,
-      isComputed: Boolean(field.computeVia),
-      fieldOrCard: identifyCard(field.card)!,
-      serializerName:
-        fieldSerializer in field.card
-          ? (field.card[fieldSerializer] as SerializerName)
-          : undefined,
-      query: queryDefinition,
-    };
-    if (!isPrimitive) {
-      if (visited.filter((v) => v === cardKey).length > recursingDepth()) {
-        return results;
+): { fields: Definition['fields']; fieldDefs: Definition['fieldDefs'] } {
+  let fields: Definition['fields'] = {};
+  let fieldDefs: Definition['fieldDefs'] = {};
+  let internIndex = new Map<string, string>();
+
+  function intern(def: FieldDefinition): string {
+    let contentKey = stableStringify(def);
+    let existing = internIndex.get(contentKey);
+    if (existing !== undefined) {
+      return existing;
+    }
+    let id = `f${internIndex.size}`;
+    internIndex.set(contentKey, id);
+    fieldDefs[id] = def;
+    return id;
+  }
+
+  function walk(
+    klass: typeof BaseDef,
+    prefix: string,
+    visited: string[],
+  ): void {
+    let cardKey = internalKeyFor(identifyCard(klass)!, undefined);
+    let klassFields = api.getFields(klass, { includeComputeds: true });
+    for (let [fieldName, field] of Object.entries(klassFields)) {
+      let fullFieldName = `${prefix ? prefix + '.' : ''}${fieldName}`;
+      let isPrimitive = primitive in field.card;
+      let queryDefinition = field.queryDefinition
+        ? (JSON.parse(JSON.stringify(field.queryDefinition)) as Query) // ensure this is a plain object
+        : undefined;
+      let def: FieldDefinition = {
+        type: field.fieldType,
+        isPrimitive,
+        isComputed: Boolean(field.computeVia),
+        fieldOrCard: identifyCard(field.card)!,
+        serializerName:
+          fieldSerializer in field.card
+            ? (field.card[fieldSerializer] as SerializerName)
+            : undefined,
+        query: queryDefinition,
+      };
+      fields[fullFieldName] = intern(def);
+      if (!isPrimitive) {
+        if (visited.filter((v) => v === cardKey).length > recursingDepth()) {
+          continue;
+        }
+        walk(field.card, fullFieldName, [...visited, cardKey]);
       }
-      getFieldDefinitions(api, field.card, results, fullFieldName, [
-        ...visited,
-        cardKey,
-      ]);
     }
   }
-  return results;
+
+  walk(cardDef, '', []);
+  return { fields, fieldDefs };
 }

--- a/packages/runtime-common/file-serializer.ts
+++ b/packages/runtime-common/file-serializer.ts
@@ -1,4 +1,4 @@
-import type { Definition, FieldDefinition } from './index';
+import { getFieldDef, type Definition, type FieldDefinition } from './index';
 import {
   type LooseSingleCardDocument,
   type CardResource,
@@ -306,7 +306,9 @@ function getFieldDefinition(
   definition: Definition,
   customFieldDefinitions?: Record<string, FieldDefinition>,
 ): FieldDefinition | undefined {
-  return customFieldDefinitions?.[fieldPath] ?? definition.fields[fieldPath];
+  return (
+    customFieldDefinitions?.[fieldPath] ?? getFieldDef(definition, fieldPath)
+  );
 }
 
 function parseRelationshipKey(key: string): string {

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -61,7 +61,11 @@ import {
   type BoxelIndexTable,
   type CardTypeSummary,
 } from './index-structure';
-import type { Definition, FieldDefinition } from './definitions';
+import {
+  getFieldDef,
+  type Definition,
+  type FieldDefinition,
+} from './definitions';
 import {
   isFilterRefersToNonexistentTypeError,
   type DefinitionLookup,
@@ -1531,7 +1535,7 @@ function getField(
   pathTraveled: string,
 ): FieldDefinition {
   let cleansedPath = removeBrackets(pathTraveled);
-  let field = definition.fields[cleansedPath];
+  let field = getFieldDef(definition, cleansedPath);
   if (!field) {
     if (currentField(pathTraveled) === '_cardType') {
       // this is a little awkward--we have the need to treat '_cardType' as a

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -58,7 +58,7 @@ import type {
   QueryFieldMeta,
   Saved,
 } from './resource-types';
-import type { FieldDefinition } from './definitions';
+import { getFieldDef, type FieldDefinition } from './definitions';
 import {
   normalizeQueryDefinition,
   buildQuerySearchURL,
@@ -292,11 +292,14 @@ export class RealmIndexQueryEngine {
       } else {
         definition = await this.#definitionLookup.lookupDefinition(codeRef);
       }
+      if (!definition) {
+        return false;
+      }
       // Strip the linksToMany index suffix (e.g., "friends.0" -> "friends")
       let fieldName = fieldKey.includes('.')
         ? fieldKey.slice(0, fieldKey.indexOf('.'))
         : fieldKey;
-      let fieldDefinition = definition.fields[fieldName];
+      let fieldDefinition = getFieldDef(definition, fieldName);
       if (!fieldDefinition) {
         return false;
       }
@@ -526,9 +529,14 @@ export class RealmIndexQueryEngine {
     } else {
       definition = await this.#definitionLookup.lookupDefinition(codeRef);
     }
-    for (let [fieldName, fieldDefinition] of Object.entries(
-      definition.fields,
-    )) {
+    if (!definition) {
+      return;
+    }
+    for (let [fieldName, defId] of Object.entries(definition.fields)) {
+      let fieldDefinition = definition.fieldDefs[defId];
+      if (!fieldDefinition) {
+        continue;
+      }
       let queryDefinition = this.getQueryDefinition(fieldDefinition);
 
       if (

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -5574,9 +5574,13 @@ export class Realm {
             let fieldDefinition =
               await this.#definitionLookup.lookupDefinition(absoluteCodeRef);
             if (fieldDefinition) {
-              for (const [subFieldName, subFieldDefinition] of Object.entries(
+              for (const [subFieldName, defId] of Object.entries(
                 fieldDefinition.fields,
               )) {
+                let subFieldDefinition = fieldDefinition.fieldDefs[defId];
+                if (!subFieldDefinition) {
+                  continue;
+                }
                 const prefixedFieldPath = `${fieldPath}.${subFieldName}`;
                 customFieldDefinitions[prefixedFieldPath] = subFieldDefinition;
               }
@@ -5599,9 +5603,13 @@ export class Realm {
         let fieldDefinition =
           await this.#definitionLookup.lookupDefinition(absoluteCodeRef);
         if (fieldDefinition) {
-          for (const [subFieldName, subFieldDefinition] of Object.entries(
+          for (const [subFieldName, defId] of Object.entries(
             fieldDefinition.fields,
           )) {
+            let subFieldDefinition = fieldDefinition.fieldDefs[defId];
+            if (!subFieldDefinition) {
+              continue;
+            }
             const prefixedFieldPath = `${fieldPath}.${subFieldName}`;
             customFieldDefinitions[prefixedFieldPath] = subFieldDefinition;
           }


### PR DESCRIPTION
## Summary

Replace the flat `Definition.fields` map (path → FieldDefinition) with a deduplicated shape: `Definition.fields` maps each path to an opaque `defId`, and `Definition.fieldDefs` is a per-card-type dictionary the ids point into. Same information content, dramatically smaller persisted payload because the recursive walk over the field graph turns out to emit the same handful of leaf metadata thousands of times.

## Evidence

The `modules.definitions` jsonb is dominated by combinatorial duplication. Inspecting `software-factory/darkfactory.gts → definitions['…/Issue'] → definition.fields`:

```
total entries:           74,977
top-level (non-dotted):       21
dotted-path entries:     74,956
distinct values:             28          (28 of 74,956 — 99.96% redundancy)
```

Top duplicate, copy-pasted verbatim:

```json
{"type": "contains", "isComputed": false,
 "fieldOrCard": {"name": "StringField", "module": "https://cardstack.com/base/card-api"},
 "isPrimitive": true}
```

Appears **19,290 times** under different path keys. The single most-common pattern — every `*.theme` leaf in `Issue.fields` — has 2,700 keys all holding the **byte-identical** value:

```json
{"type": "linksTo", "isComputed": false,
 "fieldOrCard": {"name": "Theme", "module": "https://cardstack.com/base/card-api"},
 "isPrimitive": false}
```

The recursion driver is `cardInfo` (every `CardDef` carries it). One of its fields is `theme: linksTo Theme`, and `Theme` is itself a `CardDef` (so it has its own `cardInfo`, its own `theme`, …). Combine that with `Issue.project` (linksTo Project → cardInfo → theme → …), `Issue.blockedBy` (linksToMany Issue, recursive), and `Project.issues` (linksToMany back to Issue), and the path graph cycles through the same handful of leaf field-defs at every depth.

The driver code is `getFieldDefinitions` in `runtime-common/definitions.ts` — it walks the field graph with `RECURSING_DEPTH = 3` and emits one entry per traversal path. With cycles, that's tens of thousands of entries per card-type.

## Change

### New shape

```ts
export interface Definition {
  type: 'card-def' | 'field-def';
  codeRef: CodeRef;
  displayName: string | null;
  fields: { [path: string]: string };      // path → defId
  fieldDefs: { [defId: string]: FieldDefinition };
}
```

Concretely, `Issue`'s `definition.fields` becomes:

```jsonc
{
  "fields": {
    "title": "f0",
    "project": "f1",
    "project.issues": "f2",
    "project.issues.project": "f1",
    "cardInfo.theme": "f3",
    "project.cardInfo.theme": "f3",
    "blockedBy.project.cardInfo.theme": "f3",
    // ...75K more paths
  },
  "fieldDefs": {
    "f0": { "type": "contains", "fieldOrCard": { "name": "StringField", … }, … },
    "f1": { "type": "linksTo", "fieldOrCard": { "name": "Project", … }, … },
    "f2": { "type": "linksToMany", "fieldOrCard": { "name": "Issue", … }, "query": {…} },
    "f3": { "type": "linksTo", "fieldOrCard": { "name": "Theme", … }, … }
    // ...28 unique entries total
  }
}
```

### Producer

`getFieldDefinitions` now interns each `FieldDefinition` by stable-stringified content key as it walks. Two different paths whose `FieldDefinition` is byte-identical share one `fieldDefs` entry. The walk-stop semantics (`RECURSING_DEPTH = 3`, prefix accumulation) are unchanged — only the output shape and the storage of the values changed.

### Consumer

A small helper hides the indirection at the call sites that previously did `definition.fields[path]`:

```ts
export function getFieldDef(
  definition: Pick<Definition, 'fields' | 'fieldDefs'>,
  path: string,
): FieldDefinition | undefined {
  let id = definition.fields[path];
  if (id === undefined) return undefined;
  return definition.fieldDefs[id];
}
```

Updated call sites:

- `runtime-common/index-query-engine.ts:getField`
- `runtime-common/realm-index-query-engine.ts:fieldExpectsFileMeta` + `populateQueryFields`
- `runtime-common/realm.ts:buildCustomFieldDefinitions` (two recursion arms)
- `runtime-common/file-serializer.ts:getFieldDefinition`
- `host/app/routes/module.ts` + `host/app/utils/file-def-attributes-extractor.ts` — producers that materialize a `Definition` object now spread both `fields` and `fieldDefs` out of `getFieldDefinitions`'s return.

### Migration

The `modules` table is wiped on every realm-server boot. No tolerant-read path is needed — existing rows refresh to the new shape on next prerender.

## Expected savings

```
Issue.fields:       22 MB → ~4 KB dictionary + ~3.7 MB paths-with-pointers
darkfactory.gts:    62 MB → ~12 MB total (~5×)
per-blob read+parse: ~2s → ~0.4s
```

Compounds with whatever runtime-side caching/memoization gets layered on top later — every blob is now ~5× lighter to read, parse, and hold in memory.

## Out of scope

- Whether `getFieldDefinitions` should generate the dotted-path materialization at all. This PR dedupes the existing shape; revisiting whether the dotted-path expansion is needed (and whether it could be replaced with a lazy traversal at query-execution time) is a separate, larger question.
- Per-request memoization to collapse the same module being read multiple times within one GET — separate ticket, can layer cleanly on top.
- The 4.7s `executeQueryForField` for `Project.issues` linksToMany observed in earlier instrumentation — separate index-search question.

## Test plan

- [x] `pnpm lint` clean for `runtime-common`, `realm-server`, `host`
- [x] `pnpm test-module` for `definition-lookup-test.ts` — 23/25 green; the 2 fails (tests 1 + 2) were a transient port-binding race in the test fixture between `buildPermissionedRealmsTemplate`'s teardown and the first per-test `beforeEach` (EADDRINUSE on 4450). Reproducible without the dedupe changes; not introduced here. Tests 3–25 all green, every test that exercises the dedupe path.
- [ ] End-to-end: re-run the warm-cache `Validations` GET measurement against a stack with this branch — expect ~5× drop in per-blob read+parse cost (~2s → ~0.4s on a previously-60-MB row).