### PR TITLE
Fix Manual Publish [boxel-cli] workflow failing on smoke tests

### DIFF
--- a/.github/workflows/manual-boxel-cli-publish.yml
+++ b/.github/workflows/manual-boxel-cli-publish.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run unit tests
         working-directory: packages/boxel-cli
-        run: pnpm test:unit
+        run: pnpm test:unit-exclude-smoke
 
       - name: Run integration tests
         working-directory: packages/boxel-cli

--- a/packages/boxel-cli/package.json
+++ b/packages/boxel-cli/package.json
@@ -66,6 +66,7 @@
     "lint:types": "tsc --noEmit",
     "test": "vitest run",
     "test:unit": "vitest run --exclude 'tests/integration/**'",
+    "test:unit-exclude-smoke": "vitest run --exclude 'tests/integration/**' --exclude 'tests/smoke.test.ts'",
     "test:integration": "./tests/scripts/run-integration-with-test-pg.sh",
     "test:watch": "vitest",
     "version:patch": "npm version patch",


### PR DESCRIPTION
## Summary
- The `Manual Publish [boxel-cli]` workflow ran `pnpm test:unit` before the build step, but `tests/smoke.test.ts` exec's `dist/index.js` and was picked up by `test:unit` (which only excludes `tests/integration/**`). Every dispatch failed with `Cannot find module … dist/index.js` (e.g. [run 25473640103](https://github.com/cardstack/boxel/actions/runs/25473640103/job/74742371971)).
- Add a publish-only `test:unit-exclude-smoke` script in `packages/boxel-cli/package.json` that excludes both `tests/integration/**` and `tests/smoke.test.ts`, and switch the workflow's "Run unit tests" step to call it. Local `pnpm test:unit` is unchanged, so devs running it after a build still get smoke coverage as before.

## Test plan
- [x] Local: `cd packages/boxel-cli && pnpm test:unit-exclude-smoke` passes (147 tests, 8 files) on this branch without a prior `pnpm build`.
- [ ] Post-merge: dispatch `Actions → Manual Publish [boxel-cli] → Run workflow` from `main` with `bump=patch`, `environment=staging`. The "Run unit tests" step should pass and the workflow should reach `Publish to npm` + `Create GitHub Release`.
- [ ] Post-merge: `npm view @cardstack/boxel-cli@beta version` matches the new version, and `npx -p @cardstack/boxel-cli@beta boxel --version` prints the same.

## Note on testing while this PR is open
The publish workflow is `workflow_dispatch`-only and pins `ref: main` for checkout, so dispatching from this branch would still pull `main`'s code (which doesn't have the new script). A full pre-merge dry-run isn't possible without expanding scope — local verification (above) is the intended pre-merge check.