### PR TITLE
observability: fix local Loki ingest stalls and Alloy flush latency

### DIFF
--- a/packages/observability/alloy/config.alloy
+++ b/packages/observability/alloy/config.alloy
@@ -99,5 +99,12 @@ loki.process "filter_old" {
 loki.write "local" {
 	endpoint {
 		url = "http://loki:3100/loki/api/v1/push"
+		// Default batch_wait is 1s, but indexing jobs frequently emit
+		// only 3 progress lines (started / file-visited / finished)
+		// for incremental updates, which doesn't always trip Alloy's
+		// flush trigger in time. Tighter batch_wait keeps low-volume
+		// flushes responsive — at the cost of slightly more HTTP
+		// traffic to Loki, which is fine for local dev.
+		batch_wait = "500ms"
 	}
 }

--- a/packages/observability/loki/config.yaml
+++ b/packages/observability/loki/config.yaml
@@ -19,6 +19,19 @@ common:
       store: inmemory
   replication_factor: 1
   path_prefix: /loki
+  # Without these, Loki 3.x's filesystem object store calls `mkdir
+  # <tenant>` against its CWD (`/`), which is owned by root and
+  # unwritable by the loki user. Symptom: per-tenant chunk flush fails
+  # with "mkdir fake: permission denied" (the default tenant id is
+  # "fake"), the ingester ring marks itself unhealthy, and Alloy's
+  # writes start returning 500 "empty ring" — silently stalling
+  # ingest of host-process logs while in-memory queries still serve
+  # recent data so it's not obviously broken. See
+  # project_local_loki_chunks_dir.md.
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
 
 schema_config:
   configs:
@@ -29,6 +42,15 @@ schema_config:
       index:
         prefix: index_
         period: 24h
+
+# Loki 3.4 reads the chunks-store path from `storage_config.filesystem.directory`
+# (NOT `common.storage.filesystem.chunks_directory` — that key only feeds a few
+# subsystems). When this is empty, the chunks store falls back to a relative
+# `mkdir <tenant>` against Loki's CWD (`/`), which is unwritable. Confirmed
+# via /config endpoint that this is the field the chunk flusher actually uses.
+storage_config:
+  filesystem:
+    directory: /loki/chunks
 
 limits_config:
   # Accept Docker logs of any age — local containers may have months of

--- a/packages/observability/loki/config.yaml
+++ b/packages/observability/loki/config.yaml
@@ -19,19 +19,6 @@ common:
       store: inmemory
   replication_factor: 1
   path_prefix: /loki
-  # Without these, Loki 3.x's filesystem object store calls `mkdir
-  # <tenant>` against its CWD (`/`), which is owned by root and
-  # unwritable by the loki user. Symptom: per-tenant chunk flush fails
-  # with "mkdir fake: permission denied" (the default tenant id is
-  # "fake"), the ingester ring marks itself unhealthy, and Alloy's
-  # writes start returning 500 "empty ring" — silently stalling
-  # ingest of host-process logs while in-memory queries still serve
-  # recent data so it's not obviously broken. See
-  # project_local_loki_chunks_dir.md.
-  storage:
-    filesystem:
-      chunks_directory: /loki/chunks
-      rules_directory: /loki/rules
 
 schema_config:
   configs:
@@ -43,11 +30,15 @@ schema_config:
         prefix: index_
         period: 24h
 
-# Loki 3.4 reads the chunks-store path from `storage_config.filesystem.directory`
-# (NOT `common.storage.filesystem.chunks_directory` — that key only feeds a few
-# subsystems). When this is empty, the chunks store falls back to a relative
-# `mkdir <tenant>` against Loki's CWD (`/`), which is unwritable. Confirmed
-# via /config endpoint that this is the field the chunk flusher actually uses.
+# Loki 3.x reads the chunks-store path from `storage_config.filesystem.directory`.
+# When unset, the chunks flusher falls back to a relative `mkdir <tenant>`
+# against Loki's CWD (`/`), which the `loki` user cannot write — producing
+# "mkdir fake: permission denied" errors (the default tenant id is `fake`,
+# not a permission name). The flush failures cascade: chunks pile in memory
+# → ingester ring marks itself unhealthy → Alloy's writes get back 500
+# "empty ring" and silently stall ingest. Verified via the `/config`
+# endpoint that this is the field the chunks flusher actually reads;
+# `common.storage.filesystem.chunks_directory` does NOT propagate here.
 storage_config:
   filesystem:
     directory: /loki/chunks


### PR DESCRIPTION
## Summary

Two related local-dev observability fixes — symptom was blank Grafana log panels with no errors visible.

- **`loki/config.yaml`**: explicit `storage_config.filesystem.directory: /loki/chunks`. Without it, Loki 3.x's filesystem object store falls back to `mkdir <tenant>` against the container's CWD `/` (unwritable for the `loki` user), producing `mkdir fake: permission denied` flush errors. The flush failures cascade — chunks pile in memory → ingester ring marks itself unhealthy → Alloy's writes return 500 `empty ring` → Alloy's retry budget exhausts → batches silently drop. Verified via the `/config` endpoint that this is the slot the chunks flusher reads (separate from `common.storage.filesystem.chunks_directory`, which only feeds a few subsystems and does not propagate to chunks).
- **`alloy/config.alloy`**: `batch_wait = "500ms"` on `loki.write.local`. The 1s default was too patient for low-volume host-process streams (a successful incremental indexing job emits only 3 `[indexing-progress]` lines), leaving batches sitting un-flushed for minutes.

## Test plan

- [ ] Bounce local stack: `docker compose up -d` (or restart `observability-loki-1` and `observability-alloy-1` if already up)
- [ ] Verify no `mkdir fake` / `permission denied` errors: `docker logs observability-loki-1 | grep permission`
- [ ] Verify `/loki/chunks/fake/` gets populated as ingest happens: `docker exec observability-loki-1 ls /loki/chunks`
- [ ] Probe latency check — should match within ~1s:
  ```bash
  echo "PROBE-\$(date +%s)" >> /tmp/boxel-logs/worker.log; sleep 2
  curl -sG http://localhost:3100/loki/api/v1/query_range \
    --data-urlencode 'query={service="worker"} |= "PROBE-"' \
    --data-urlencode "start=\$(date -u -v-1M '+%Y-%m-%dT%H:%M:%SZ')" \
    --data-urlencode "end=\$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
    | jq '.data.result | map(.values | length) | add'
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)