### PR TITLE
Manual Publish [boxel-cli]: prepare full dev stack for integration tests

### DIFF
--- a/.github/workflows/manual-boxel-cli-publish.yml
+++ b/.github/workflows/manual-boxel-cli-publish.yml
@@ -30,8 +30,18 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  test-web-assets:
+    name: Build test web assets
+    uses: ./.github/workflows/test-web-assets.yaml
+    with:
+      caller: manual-boxel-cli-publish
+    concurrency:
+      group: manual-boxel-cli-publish-test-web-assets-${{ github.run_id }}
+      cancel-in-progress: false
+
   publish:
     name: Build and publish @cardstack/boxel-cli
+    needs: test-web-assets
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -49,13 +59,42 @@ jobs:
       - name: Install pinned npm for trusted publishing
         run: npm install -g npm@10.8.2
 
+      - name: Download test web assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.test-web-assets.outputs.artifact_name }}
+          path: .test-web-assets-artifact
+
+      - name: Restore test web assets into workspace
+        shell: bash
+        run: |
+          shopt -s dotglob
+          cp -a .test-web-assets-artifact/. ./
+
       - name: Run unit tests
         working-directory: packages/boxel-cli
         run: pnpm test:unit-exclude-smoke
 
+      - name: Start Matrix
+        run: pnpm start:matrix
+        working-directory: packages/realm-server
+
+      - name: Create realm users
+        run: pnpm register-realm-users
+        working-directory: packages/matrix
+
+      - name: Start dev stack (icons + host-dist + base realm + prerenderer)
+        run: |
+          mise run test-services:matrix | tee -a /tmp/server.log &
+          timeout 600 bash -c 'until curl -sf http://localhost:4200 > /dev/null && curl -sf -H "Accept: application/vnd.api+json" http://localhost:4201/base/_readiness-check > /dev/null; do sleep 2; done'
+
       - name: Run integration tests
         working-directory: packages/boxel-cli
         run: pnpm test:integration
+
+      - name: Print server logs
+        if: ${{ !cancelled() }}
+        run: cat /tmp/server.log
 
       - name: Bump version
         id: version


### PR DESCRIPTION
## Summary
- The `Manual Publish [boxel-cli]` workflow now fails at **Run integration tests** with `Missing Matrix registration shared secret` (e.g. [run 25474331539](https://github.com/cardstack/boxel/actions/runs/25474331539/job/74744486564)) because the workflow only started postgres. boxel-cli's integration tests need the same dev stack as `ci.yaml`'s `boxel-cli-test` job: test web assets, Matrix/Synapse, registered realm users, and the `test-services:matrix` mise task (icons + host-dist + base realm + prerenderer).
- Add a `test-web-assets` job that calls the existing `./.github/workflows/test-web-assets.yaml` reusable workflow (same pattern `ci.yaml` uses), and mirror the pre-integration steps from `ci.yaml:891-922` into the publish job: download + restore the artifact into the workspace, `pnpm start:matrix`, `pnpm register-realm-users`, `mise run test-services:matrix &` with a readiness wait, and a trailing `Print server logs` step.
- No change to ordering of unit/integration vs. version bump/build/publish — the new steps slot in between unit tests and integration tests.

## Test plan
- [ ] Post-merge: dispatch `Actions → Manual Publish [boxel-cli] → Run workflow` from `main` with `bump=patch`, `environment=staging`. Both jobs (`Build test web assets` and `Build and publish @cardstack/boxel-cli`) should pass; the workflow should reach `Publish to npm` + `Create GitHub Release`.
- [ ] Post-merge: `npm view @cardstack/boxel-cli@beta version` matches the new version, and `npx -p @cardstack/boxel-cli@beta boxel --version` prints the same.
- [ ] If integration tests fail, inspect the `Print server logs` step output — same diagnostic surface as `ci.yaml`.

## Note on testing while this PR is open
Same constraint as #4693: the publish workflow pins `ref: main` for checkout, so a `workflow_dispatch` from this branch would still run against `main`'s code. A full pre-merge dry-run isn't possible. Pre-merge review is YAML-diff-based.