### PR TITLE
Revert boxel-cli to 0.0.1, drop wrong npm pin in publish workflow

### DIFF
--- a/.github/workflows/manual-boxel-cli-publish.yml
+++ b/.github/workflows/manual-boxel-cli-publish.yml
@@ -56,9 +56,6 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
-      - name: Install pinned npm for trusted publishing
-        run: npm install -g npm@10.8.2
-
       - name: Download test web assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/packages/boxel-cli/package.json
+++ b/packages/boxel-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardstack/boxel-cli",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "license": "MIT",
   "description": "CLI tools for Boxel workspace management",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- The previous Manual Publish dispatch ([run 25475610550](https://github.com/cardstack/boxel/actions/runs/25475610550)) ran `Bump version` and `Commit version bump and tag` successfully — pushing the `boxel-cli-v0.1.0` tag and version-bump commit to main — then failed at `Publish to npm` with `ENEEDAUTH`. Nothing landed on the npm registry, so 0.1.0 is a ghost. This PR resets `packages/boxel-cli/package.json` from 0.1.0 back to 0.0.1 (the pre-dispatch version).
- Drops the `Install pinned npm for trusted publishing` step from `.github/workflows/manual-boxel-cli-publish.yml`. It pinned `npm@10.8.2`, but OIDC trusted publishing requires **npm 11.5.1+**. Node 24.13.1 (from `.mise.toml`, loaded by `./.github/actions/init`) already ships with npm 11.x, so removing the pin actually makes trusted publishing possible.

## Follow-up
- Delete the dangling `boxel-cli-v0.1.0` tag from `origin` once this PR merges (destructive remote op, will run with explicit go-ahead).
- Wire npm auth in a separate PR — either (a) configure trusted publishing on npmjs.com for `@cardstack/boxel-cli` (recommended; no secrets needed), or (b) add an `NPM_TOKEN` secret + auth step. Until then, dispatches will still fail at `Publish to npm` (but cleanly — no further git side-effects beyond what's already on main today).

## Test plan
- [x] `git diff origin/main` shows only the two intended changes (package.json one-line revert + workflow two-line step deletion).
- [x] Local: `node --version` → `v24.13.1`, mise-bundled npm is 11.x — confirms the toolchain CI will use.
- [ ] Post-merge: delete the `boxel-cli-v0.1.0` tag from origin. Verify `git ls-remote --tags origin | grep boxel-cli-v0.1.0` returns empty.
- [ ] Post-auth-setup (separate PR): full publish dispatch from main with `bump=patch`, `environment=staging` succeeds end-to-end.