### PR TITLE
Drop tests from Manual Publish [boxel-cli]

### DIFF
--- a/.github/workflows/manual-boxel-cli-publish.yml
+++ b/.github/workflows/manual-boxel-cli-publish.yml
@@ -30,18 +30,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  test-web-assets:
-    name: Build test web assets
-    uses: ./.github/workflows/test-web-assets.yaml
-    with:
-      caller: manual-boxel-cli-publish
-    concurrency:
-      group: manual-boxel-cli-publish-test-web-assets-${{ github.run_id }}
-      cancel-in-progress: false
-
   publish:
     name: Build and publish @cardstack/boxel-cli
-    needs: test-web-assets
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -55,43 +45,6 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-
-      - name: Download test web assets
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ needs.test-web-assets.outputs.artifact_name }}
-          path: .test-web-assets-artifact
-
-      - name: Restore test web assets into workspace
-        shell: bash
-        run: |
-          shopt -s dotglob
-          cp -a .test-web-assets-artifact/. ./
-
-      - name: Run unit tests
-        working-directory: packages/boxel-cli
-        run: pnpm test:unit-exclude-smoke
-
-      - name: Start Matrix
-        run: pnpm start:matrix
-        working-directory: packages/realm-server
-
-      - name: Create realm users
-        run: pnpm register-realm-users
-        working-directory: packages/matrix
-
-      - name: Start dev stack (icons + host-dist + base realm + prerenderer)
-        run: |
-          mise run test-services:matrix | tee -a /tmp/server.log &
-          timeout 600 bash -c 'until curl -sf http://localhost:4200 > /dev/null && curl -sf -H "Accept: application/vnd.api+json" http://localhost:4201/base/_readiness-check > /dev/null; do sleep 2; done'
-
-      - name: Run integration tests
-        working-directory: packages/boxel-cli
-        run: pnpm test:integration
-
-      - name: Print server logs
-        if: ${{ !cancelled() }}
-        run: cat /tmp/server.log
 
       - name: Bump version
         id: version


### PR DESCRIPTION
## Summary
- The publish workflow has been bundling a full integration test path (test web assets + Matrix + realm users + dev stack + integration tests). That setup keeps producing failures unrelated to publishing — the latest dispatch ([run 25479816469](https://github.com/cardstack/boxel/actions/runs/25479816469)) flaked on `tests/integration/realm-watch.test.ts` with `UND_ERR_SOCKET` against the realm-server, after earlier runs had hit Matrix/Synapse setup issues. None of these failures are about the publish itself.
- `ci.yaml` already runs the same unit + integration suite with the same dev stack on every PR + main push, so anything reaching `main` has already been tested. Re-running the suite from the publish workflow adds infra surface without adding meaningful safety.
- Match the established cardstack pattern. The closest precedent — [`cardstack/glimmer-scoped-css/.github/workflows/publish.yml`](https://github.com/cardstack/glimmer-scoped-css/blob/main/.github/workflows/publish.yml) — runs zero tests, no build orchestration, just `pnpm release-plan publish` with `NODE_AUTH_TOKEN`.

## Changes
Single-file edit, deletions only (`-47, +0`):

- Remove the entire `test-web-assets` reusable-workflow job.
- Drop `needs: test-web-assets` from the `publish` job.
- Drop eight steps from the `publish` job: `Download test web assets`, `Restore test web assets into workspace`, `Run unit tests`, `Start Matrix`, `Create realm users`, `Start dev stack`, `Run integration tests`, `Print server logs`.

The publish job is now: `checkout → init → Configure git → Bump version → Build → Commit/Tag/Push → Publish to npm → Create GitHub Release`.

## Test plan
- [x] `git diff origin/main` shows only deletions (47 lines, single file). No additions.
- [ ] Post-merge (with auth set up): dispatch `Actions → Manual Publish [boxel-cli] → Run workflow` from `main` with `bump=patch`, `environment=staging`. Expect ~1-2 min runtime (vs ~8 min today).
- [ ] Post-merge: `npm view @cardstack/boxel-cli@beta version` matches the bumped version.

## Follow-up (not in this PR)
- npm auth setup — either configure trusted publishing on npmjs.com for `@cardstack/boxel-cli` (recommended; uses the existing `id-token: write` + `--provenance`), or add an `NPM_TOKEN` repo secret + auth step.
- Delete the dangling `boxel-cli-v0.1.0` tag from origin (separate destructive op, pending explicit go).