### PR TITLE
Use static notes for boxel-cli GitHub Release

### DIFF
--- a/.github/workflows/manual-boxel-cli-publish.yml
+++ b/.github/workflows/manual-boxel-cli-publish.yml
@@ -80,17 +80,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="boxel-cli-v${{ steps.version.outputs.version }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="boxel-cli-v${VERSION}"
+          NPM_URL="https://www.npmjs.com/package/@cardstack/boxel-cli/v/${VERSION}"
 
-          PREV_TAG=$(git tag --list 'boxel-cli-v*' --sort=-version:refname | grep -vxF "$TAG" | head -n 1)
-
-          ARGS=()
-          ARGS+=(--title "@cardstack/boxel-cli v${{ steps.version.outputs.version }}")
-          ARGS+=(--generate-notes)
-
-          if [ -n "$PREV_TAG" ]; then
-            ARGS+=(--notes-start-tag "$PREV_TAG")
-          fi
+          ARGS=(
+            --title "@cardstack/boxel-cli v${VERSION}"
+            --notes "Published to npm: ${NPM_URL}"
+          )
 
           if [ "${{ inputs.environment }}" = "staging" ]; then
             ARGS+=(--prerelease)


### PR DESCRIPTION
## Summary
- The latest publish dispatch ([run 25481351678](https://github.com/cardstack/boxel/actions/runs/25481351678/job/74766030991)) succeeded all the way through `Publish to npm` — `@cardstack/boxel-cli@0.1.0` is on the registry — but failed at `Create GitHub Release` with `HTTP 422: body is too long (maximum is 125000 characters)`.
- Root cause: with only one `boxel-cli-v*` tag in git, the `PREV_TAG=... | grep -vxF "$TAG" | head -n 1` resolution returns empty. The script then omits `--notes-start-tag` and runs `gh release create --generate-notes` with no start anchor. The boxel monorepo has zero existing GitHub Releases, so GitHub auto-generates notes from the start of repo history — thousands of PRs, far over GitHub's 125KB API limit.
- Replace auto-generated notes with a short static `--notes` body referencing the npm package URL. Can't blow length limits, doesn't depend on tag bookkeeping.

## Diff
- Drop the `PREV_TAG` resolution and `--generate-notes` / `--notes-start-tag` flags.
- Add `--notes "Published to npm: https://www.npmjs.com/package/@cardstack/boxel-cli/v/${VERSION}"`.
- Keep the existing `--title` and `--prerelease` (when `environment=staging`) unchanged.

## Test plan
- [x] `git diff origin/main` shows only the `Create GitHub Release` step changing (8 added, 11 removed).
- [ ] Post-merge: dispatch the publish workflow again. Expect `Create GitHub Release` to succeed and produce a Release object titled `@cardstack/boxel-cli v<x.y.z>` with body `Published to npm: https://www.npmjs.com/package/@cardstack/boxel-cli/v/<x.y.z>`.

## Note on the existing 0.1.0 release
The 0.1.0 release object never got created (this run failed at that step). The npm package is published, the git tag exists. I can `gh release create boxel-cli-v0.1.0 --title "..." --notes "..." --prerelease` manually after this PR merges — let me know if you want that, or you can do it from the UI.