### PR TITLE
mise/dev-all: kill reparented service processes on cleanup

### DIFF
--- a/mise-tasks/dev-all
+++ b/mise-tasks/dev-all
@@ -6,7 +6,10 @@
 # MISE dir is packages/realm-server, so ../.. is repo root
 PATH="$(pwd)/../../node_modules/.bin:$(pwd)/node_modules/.bin:$PATH"
 
-. "$(cd "$(dirname "$0")" && pwd)/lib/dev-common.sh"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+. "$SCRIPT_DIR/lib/dev-common.sh"
 
 # Enable job control so backgrounded subprocesses run in their own process
 # group. Without this, Ctrl-C is delivered to the whole foreground group;
@@ -37,6 +40,26 @@ cleanup() {
     kill_tree "$SAT_PID"
   fi
   kill_tree "$HOST_PID"
+  # mise's task supervisor reparents long-running task scripts to init, so
+  # kill_tree above can't reach them via PPID. Sweep by absolute paths,
+  # scoped to this checkout (so other worktrees aren't touched). SIGTERM
+  # first for anything that listens, brief grace period, then SIGKILL —
+  # belt-and-suspenders for processes that don't respond to TERM.
+  #
+  # `pkill -f` matches its pattern as ERE, so $REPO_ROOT must be regex-
+  # escaped before interpolating — otherwise a checkout path containing
+  # regex metacharacters (e.g. `boxel.worktrees/...`, where `.` matches
+  # any char) would over-match and signal unrelated processes outside
+  # this checkout. The trailing `node_modules.*--transpileOnly` is an
+  # INTENTIONAL regex (matching whichever node_modules subpath the
+  # worker invocation resolves through), so escaping is applied to the
+  # path prefix only.
+  REPO_ROOT_RE="$(printf '%s' "$REPO_ROOT" | sed -E 's/[][\\.*^$+?(){}|]/\\&/g')"
+  pkill -TERM -f "${REPO_ROOT_RE}/mise-tasks/services/" 2>/dev/null || true
+  pkill -TERM -f "${REPO_ROOT_RE}/packages/realm-server/node_modules.*--transpileOnly worker" 2>/dev/null || true
+  sleep 2
+  pkill -KILL -f "${REPO_ROOT_RE}/mise-tasks/services/" 2>/dev/null || true
+  pkill -KILL -f "${REPO_ROOT_RE}/packages/realm-server/node_modules.*--transpileOnly worker" 2>/dev/null || true
 }
 trap cleanup EXIT INT TERM
 


### PR DESCRIPTION
## Summary

`mise dev-all` was leaving service processes running after Ctrl-C / exit, most visibly the worker-manager holding port 4210 — which then blocks the next `mise dev-all` from starting.

Root cause: mise's task supervisor reparents long-running task scripts (`mise-tasks/services/*` and the `ts-node --transpileOnly worker` child) to init, so the existing PPID-based `kill_tree` can't reach them from dev-all's trap.

Fix: a `pkill` sweep scoped to absolute paths under this checkout's `$REPO_ROOT` so other worktrees aren't disturbed. SIGTERM first, 2s grace window, then SIGKILL for anything that didn't respond.

Patterns matched:
- `$REPO_ROOT/mise-tasks/services/` (realm-server, worker, prerender, prerender-mgr, etc.)
- `$REPO_ROOT/packages/realm-server/node_modules.*--transpileOnly worker`

## ⚠️ Cleanup before merge ✅ 

The PR also adds `tee -a /tmp/dev-all-cleanup.log` lines around each step so the cleanup sequence is observable. These are **WIP debugging output** — should be stripped before merge unless we want a permanent log file. Specifically, the `[dev-all cleanup] ...` echo statements and the `pgrep -lf ...` enumeration lines.

## Test plan

- [ ] `mise dev-all` → wait for stack to come up
- [ ] Ctrl-C → verify in another shell that no `mise-tasks/services/*` processes remain (`pgrep -lf "$REPO_ROOT/mise-tasks/services/"` returns nothing)
- [ ] Verify port 4210 is free: `lsof -nP -i :4210` returns nothing
- [ ] `mise dev-all` again — should start cleanly without "address already in use"
- [ ] Verify other worktrees' running services are untouched (the `$REPO_ROOT`-scoped patterns shouldn't match them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)