### PR TITLE
ci: Retry host shard on Vite dynamic-import flakes too

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -197,12 +197,35 @@ jobs:
           set +e
           dbus-run-session -- $TEST_CMD 2>&1 | tee /tmp/test-output.log
           exit_code=${PIPESTATUS[0]}
-          if [ $exit_code -ne 0 ] && grep -q "ChunkLoadError" /tmp/test-output.log; then
+
+          # Transient chunk-fetch failures present as `ChunkLoadError` under
+          # webpack and as `Failed to fetch dynamically imported module` /
+          # `NetworkError when attempting to fetch resource` under Vite.
+          # Retry the whole shard once when we detect any of these.
+          RETRY_PATTERN='ChunkLoadError|Failed to fetch dynamically imported module|NetworkError when attempting to fetch resource'
+          if [ $exit_code -ne 0 ] && grep -Eq "$RETRY_PATTERN" /tmp/test-output.log; then
             echo ""
-            echo "::warning::ChunkLoadError detected — retrying shard ${{ matrix.shardIndex }}..."
+            echo "::warning::Transient chunk-fetch failure detected — retrying shard ${{ matrix.shardIndex }}"
+            echo "::group::Matched lines (first 5)"
+            grep -E "$RETRY_PATTERN" /tmp/test-output.log | head -5 || true
+            echo "::endgroup::"
             echo ""
-            dbus-run-session -- $TEST_CMD
-            exit_code=$?
+
+            dbus-run-session -- $TEST_CMD 2>&1 | tee /tmp/test-output-retry.log
+            retry_exit_code=${PIPESTATUS[0]}
+            if [ $retry_exit_code -eq 0 ]; then
+              echo "::notice::Shard ${{ matrix.shardIndex }} recovered on retry — original failure was a transient chunk-fetch flake"
+              exit_code=0
+            else
+              echo "::error::Shard ${{ matrix.shardIndex }} failed twice after chunk-fetch retry — investigate as a deterministic failure, not a flake"
+              if grep -Eq "$RETRY_PATTERN" /tmp/test-output-retry.log; then
+                echo "::warning::Retry hit the same transient pattern again — possible persistent network or asset-serving issue"
+                echo "::group::Retry-run matched lines (first 5)"
+                grep -E "$RETRY_PATTERN" /tmp/test-output-retry.log | head -5 || true
+                echo "::endgroup::"
+              fi
+              exit_code=$retry_exit_code
+            fi
           fi
           exit $exit_code
         env:

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -215,6 +215,10 @@ jobs:
             retry_exit_code=${PIPESTATUS[0]}
             if [ $retry_exit_code -eq 0 ]; then
               echo "::notice::Shard ${{ matrix.shardIndex }} recovered on retry — original failure was a transient chunk-fetch flake"
+              # Promote the retry's log so downstream steps (memory-report
+              # extraction, baseline check / update) read from the successful
+              # run, not the failed first attempt.
+              mv /tmp/test-output-retry.log /tmp/test-output.log
               exit_code=0
             else
               echo "::error::Shard ${{ matrix.shardIndex }} failed twice after chunk-fetch retry — investigate as a deterministic failure, not a flake"


### PR DESCRIPTION
## Summary

The host-shard CI retry only matched `ChunkLoadError`, the webpack-era flake signature. After the host build moved to Vite, the same transient class of failure surfaces as `Failed to fetch dynamically imported module` (and occasionally `NetworkError when attempting to fetch resource`), which never tripped the retry and instead failed the shard outright.

A recent example: [Host Tests (4, 20)](https://github.com/cardstack/boxel/actions/runs/25492661248/job/74804742819) failed on `monaco.contribution-DyRU9U2K.js` failing to fetch dynamically. The grep for `ChunkLoadError` returned zero matches, the retry skipped, the shard turned red.

## Changes

- Broaden the retry trigger from `ChunkLoadError` to a regex covering all three transient chunk-fetch signatures.
- Print the first 5 matched lines so the cause shows up directly in the GitHub Actions run log instead of buried in the per-shard testem log artifact.
- Tee the retry attempt's output and emit one of two banners after the retry:
  - `::notice::` "recovered on retry" when the shard turns green — confirms the original failure was a flake.
  - `::error::` "failed twice" when both runs fail — flags the failure as deterministic so investigators don't waste time treating it as flake. If the retry hit the same transient pattern again, that's also called out separately as a possible serving-side issue worth investigating.

The realm-shim layer already enumerates these same signatures for its in-process retry (`packages/runtime-common/package-shim-handler.ts`). This brings the CI shard-retry layer into alignment.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-host.yaml'))"`)
- [x] Inline shell parses (`bash -n` on extracted step)
- [ ] CI green
- [ ] On the next host shard that hits `Failed to fetch dynamically imported module`, the retry triggers and the new diagnostic lines appear in the run log