### PR TITLE
Fix SF /_atomic mock for ?waitForIndex=true; rename test fixture username

### DIFF
--- a/packages/software-factory/tests/factory-agent-claude-code.test.ts
+++ b/packages/software-factory/tests/factory-agent-claude-code.test.ts
@@ -49,7 +49,7 @@ function makeContext(): AgentContext {
     },
     knowledge: [],
     skills: [],
-    targetRealm: 'https://realms.example.test/hassan/personal/',
+    targetRealm: 'https://realms.example.test/testuser/personal/',
     // System-prompt rendering requires this — see requireDarkfactoryModuleUrl.
     darkfactoryModuleUrl:
       'https://realms.example.test/software-factory/darkfactory',

--- a/packages/software-factory/tests/factory-agent-schema-boundary.test.ts
+++ b/packages/software-factory/tests/factory-agent-schema-boundary.test.ts
@@ -58,7 +58,7 @@ function makeContext(): AgentContext {
     issue: { id: 'Issues/demo', issueType: 'feature' },
     knowledge: [],
     skills: [],
-    targetRealm: 'https://realms.example.test/hassan/personal/',
+    targetRealm: 'https://realms.example.test/testuser/personal/',
     // Required for system-prompt rendering (see requireDarkfactoryModuleUrl).
     darkfactoryModuleUrl:
       'https://realms.example.test/software-factory/darkfactory',

--- a/packages/software-factory/tests/factory-entrypoint.integration.test.ts
+++ b/packages/software-factory/tests/factory-entrypoint.integration.test.ts
@@ -195,7 +195,7 @@ module('factory-entrypoint integration', function () {
         response.writeHead(200, { 'content-type': SupportedMimeType.JSONAPI });
         response.end(JSON.stringify({ data: { attributes: { mtimes: {} } } }));
       } else if (
-        request.url === '/hassan/personal/_atomic' &&
+        request.url?.startsWith('/hassan/personal/_atomic') &&
         request.method === 'POST'
       ) {
         // Used by client.sync to atomically push card writes. Parse the

--- a/packages/software-factory/tests/factory-entrypoint.integration.test.ts
+++ b/packages/software-factory/tests/factory-entrypoint.integration.test.ts
@@ -98,12 +98,12 @@ module('factory-entrypoint integration', function () {
           JSON.stringify({
             access_token: 'matrix-access-token',
             device_id: 'device-id',
-            user_id: '@hassan:localhost',
+            user_id: '@testuser:localhost',
           }),
         );
       } else if (
         request.url ===
-          '/_matrix/client/v3/user/%40hassan%3Alocalhost/openid/request_token' &&
+          '/_matrix/client/v3/user/%40testuser%3Alocalhost/openid/request_token' &&
         request.method === 'POST'
       ) {
         response.writeHead(200, { 'content-type': SupportedMimeType.JSON });
@@ -143,14 +143,14 @@ module('factory-entrypoint integration', function () {
         );
       } else if (
         request.url ===
-          '/_matrix/client/v3/user/%40hassan%3Alocalhost/account_data/app.boxel.realms' &&
+          '/_matrix/client/v3/user/%40testuser%3Alocalhost/account_data/app.boxel.realms' &&
         request.method === 'GET'
       ) {
         response.writeHead(200, { 'content-type': SupportedMimeType.JSON });
         response.end(JSON.stringify({ realms: [] }));
       } else if (
         request.url ===
-          '/_matrix/client/v3/user/%40hassan%3Alocalhost/account_data/app.boxel.realms' &&
+          '/_matrix/client/v3/user/%40testuser%3Alocalhost/account_data/app.boxel.realms' &&
         request.method === 'PUT'
       ) {
         response.writeHead(200, { 'content-type': SupportedMimeType.JSON });
@@ -177,7 +177,7 @@ module('factory-entrypoint integration', function () {
           }),
         );
       } else if (
-        request.url === '/hassan/personal/_search' &&
+        request.url === '/testuser/personal/_search' &&
         request.method === 'QUERY'
       ) {
         // Issue store search — return empty so the loop exits cleanly
@@ -185,7 +185,7 @@ module('factory-entrypoint integration', function () {
         response.writeHead(200, { 'content-type': SupportedMimeType.CardJson });
         response.end(JSON.stringify({ data: [] }));
       } else if (
-        request.url === '/hassan/personal/_mtimes' &&
+        request.url === '/testuser/personal/_mtimes' &&
         request.method === 'GET'
       ) {
         // Used by client.pull / client.sync to list remote state. The
@@ -195,7 +195,7 @@ module('factory-entrypoint integration', function () {
         response.writeHead(200, { 'content-type': SupportedMimeType.JSONAPI });
         response.end(JSON.stringify({ data: { attributes: { mtimes: {} } } }));
       } else if (
-        request.url?.startsWith('/hassan/personal/_atomic') &&
+        request.url?.startsWith('/testuser/personal/_atomic') &&
         request.method === 'POST'
       ) {
         // Used by client.sync to atomically push card writes. Parse the
@@ -217,7 +217,7 @@ module('factory-entrypoint integration', function () {
               if (op.op === 'add' || op.op === 'update') {
                 let href = op.href ?? '';
                 let path = href
-                  .replace(/^https?:\/\/[^/]+\/hassan\/personal\//, '')
+                  .replace(/^https?:\/\/[^/]+\/testuser\/personal\//, '')
                   .replace(/^\.\/?/, '')
                   .replace(/\.json$/, '');
                 createdCardPaths.add(path);
@@ -234,7 +234,7 @@ module('factory-entrypoint integration', function () {
         });
         return;
       } else if (
-        request.url === '/hassan/personal/_readiness-check' &&
+        request.url === '/testuser/personal/_readiness-check' &&
         request.method === 'GET'
       ) {
         response.writeHead(200, {
@@ -242,7 +242,7 @@ module('factory-entrypoint integration', function () {
         });
         response.end('');
       } else if (
-        request.url === '/hassan/personal/_session' &&
+        request.url === '/testuser/personal/_session' &&
         request.method === 'POST'
       ) {
         // Realm session for target realm auth
@@ -252,11 +252,11 @@ module('factory-entrypoint integration', function () {
         });
         response.end('');
       } else if (
-        request.url?.startsWith('/hassan/personal/') &&
+        request.url?.startsWith('/testuser/personal/') &&
         request.method === 'GET'
       ) {
         let cardPath = request.url
-          .replace('/hassan/personal/', '')
+          .replace('/testuser/personal/', '')
           .replace(/\.json$/, '');
         if (createdCardPaths.has(cardPath)) {
           response.writeHead(200, { 'content-type': SupportedMimeType.JSON });
@@ -280,11 +280,11 @@ module('factory-entrypoint integration', function () {
           response.end('not found');
         }
       } else if (
-        request.url?.startsWith('/hassan/personal/') &&
+        request.url?.startsWith('/testuser/personal/') &&
         request.method === 'POST'
       ) {
         createdCardPaths.add(
-          request.url.replace('/hassan/personal/', '').replace(/\.json$/, ''),
+          request.url.replace('/testuser/personal/', '').replace(/\.json$/, ''),
         );
         // Card creation — accept it
         response.writeHead(204);
@@ -307,10 +307,10 @@ module('factory-entrypoint integration', function () {
     let origin = `http://127.0.0.1:${address.port}`;
     let briefUrl = `${origin}/software-factory/Wiki/sticky-note`;
     targetRealm = `${origin}/typed-by-user/personal/`;
-    canonicalTargetRealmUrl = `${origin}/hassan/personal/`;
+    canonicalTargetRealmUrl = `${origin}/testuser/personal/`;
 
     let tempHome = createTempProfileHome({
-      username: 'hassan',
+      username: 'testuser',
       matrixUrl: `${origin}/`,
       realmServerUrl: `${origin}/`,
       password: 'secret',
@@ -359,7 +359,7 @@ module('factory-entrypoint integration', function () {
         'note',
       ]);
       assert.strictEqual(summary.targetRealm.url, canonicalTargetRealmUrl);
-      assert.strictEqual(summary.targetRealm.ownerUsername, 'hassan');
+      assert.strictEqual(summary.targetRealm.ownerUsername, 'testuser');
       assert.strictEqual(
         summary.seedIssue.seedIssueId,
         'Issues/bootstrap-seed',
@@ -386,7 +386,7 @@ module('factory-entrypoint integration', function () {
         'factory:go',
         '--',
         '--target-realm',
-        'https://realms.example.test/hassan/personal/',
+        'https://realms.example.test/testuser/personal/',
       ],
       {
         cwd: packageRoot,
@@ -429,7 +429,7 @@ module('factory-entrypoint integration', function () {
 
     try {
       let briefUrl = `http://127.0.0.1:${address.port}/software-factory/Wiki/sticky-note`;
-      let targetRealm = `http://127.0.0.1:${address.port}/hassan/personal/`;
+      let targetRealm = `http://127.0.0.1:${address.port}/testuser/personal/`;
       let result = await runCommand(
         'pnpm',
         [

--- a/packages/software-factory/tests/factory-entrypoint.test.ts
+++ b/packages/software-factory/tests/factory-entrypoint.test.ts
@@ -17,7 +17,7 @@ import { installTestProfile } from './helpers/test-profile';
 
 const briefUrl =
   'https://briefs.example.test/software-factory/Wiki/sticky-note';
-const targetRealm = 'https://realms.example.test/hassan/personal/';
+const targetRealm = 'https://realms.example.test/testuser/personal/';
 const normalizedBrief: FactoryBrief = {
   title: 'Sticky Note',
   sourceUrl: briefUrl,
@@ -30,7 +30,7 @@ const normalizedBrief: FactoryBrief = {
 const bootstrappedTargetRealm: FactoryTargetRealmBootstrapResult = {
   url: targetRealm,
   serverUrl: 'https://realms.example.test/',
-  ownerUsername: 'hassan',
+  ownerUsername: 'testuser',
   createdRealm: true,
 };
 const mockSeedResult: SeedIssueResult = {
@@ -48,7 +48,7 @@ module('factory-entrypoint', function (hooks) {
 
   function useTestProfile() {
     cleanupProfile = installTestProfile({
-      username: 'hassan',
+      username: 'testuser',
       matrixUrl: 'https://matrix.example.test/',
       realmServerUrl: 'https://realms.example.test/',
       password: 'secret',
@@ -236,7 +236,7 @@ module('factory-entrypoint', function (hooks) {
       'note',
     ]);
     assert.strictEqual(summary.targetRealm.url, targetRealm);
-    assert.strictEqual(summary.targetRealm.ownerUsername, 'hassan');
+    assert.strictEqual(summary.targetRealm.ownerUsername, 'testuser');
     assert.deepEqual(
       summary.actions.map((action) => action.name),
       [
@@ -395,7 +395,7 @@ module('factory-entrypoint', function (hooks) {
 
     assert.strictEqual(summary.brief.title, 'Sticky Note');
     assert.strictEqual(summary.brief.sourceUrl, briefUrl);
-    assert.strictEqual(summary.targetRealm.ownerUsername, 'hassan');
+    assert.strictEqual(summary.targetRealm.ownerUsername, 'testuser');
     assert.strictEqual(summary.seedIssue.seedIssueId, 'Issues/bootstrap-seed');
     assert.strictEqual(summary.issueLoop?.outcome, 'all_issues_done');
     assert.strictEqual(summary.result.status, 'completed');

--- a/packages/software-factory/tests/factory-target-realm.test.ts
+++ b/packages/software-factory/tests/factory-target-realm.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../src/factory-target-realm';
 import { installTestProfile } from './helpers/test-profile';
 
-const targetRealm = 'https://realms.example.test/hassan/personal/';
+const targetRealm = 'https://realms.example.test/testuser/personal/';
 
 module('factory-target-realm', function (hooks) {
   let cleanupProfile: (() => void) | undefined;
@@ -27,7 +27,7 @@ module('factory-target-realm', function (hooks) {
 
   function useTestProfile() {
     cleanupProfile = installTestProfile({
-      username: 'hassan',
+      username: 'testuser',
       matrixUrl: 'https://matrix.example.test/',
       realmServerUrl: 'https://realms.example.test/',
       password: 'secret',
@@ -48,14 +48,14 @@ module('factory-target-realm', function (hooks) {
       'https://realms.example.test/',
       'defaults to active profile realmServerUrl when --realm-server-url is not provided',
     );
-    assert.strictEqual(resolution.ownerUsername, 'hassan');
+    assert.strictEqual(resolution.ownerUsername, 'testuser');
   });
 
   test('resolveFactoryTargetRealm accepts an explicit realm server URL override', function (assert) {
     useTestProfile();
 
     let resolution = resolveFactoryTargetRealm({
-      targetRealm: 'https://realms.example.test/boxel/hassan/personal/',
+      targetRealm: 'https://realms.example.test/boxel/testuser/personal/',
       realmServerUrl: 'https://realms.example.test/boxel/',
     });
 
@@ -83,7 +83,7 @@ module('factory-target-realm', function (hooks) {
   test('resolveFactoryTargetRealm rejects when target realm origin does not match profile', function (assert) {
     // Profile points to staging, but target realm is localhost
     cleanupProfile = installTestProfile({
-      username: 'hassan',
+      username: 'testuser',
       matrixUrl: 'https://matrix-staging.stack.cards/',
       realmServerUrl: 'https://realms-staging.stack.cards/',
       password: 'secret',
@@ -92,7 +92,7 @@ module('factory-target-realm', function (hooks) {
     assert.throws(
       () =>
         resolveFactoryTargetRealm({
-          targetRealm: 'http://localhost:4201/hassan/my-realm/',
+          targetRealm: 'http://localhost:4201/testuser/my-realm/',
           realmServerUrl: null,
         }),
       (error: unknown) =>
@@ -180,13 +180,13 @@ module('factory-target-realm', function (hooks) {
     let result = await bootstrapFactoryTargetRealm(resolution, {
       createRealm: async () => ({
         createdRealm: true,
-        url: 'https://realms.example.test/hassan/personal/',
+        url: 'https://realms.example.test/testuser/personal/',
       }),
     });
 
     assert.strictEqual(
       result.url,
-      'https://realms.example.test/hassan/personal/',
+      'https://realms.example.test/testuser/personal/',
     );
   });
 });


### PR DESCRIPTION
## Summary

- **Fix `204 No Content` failure on shard 1/3 of SF Node tests.** The `?waitForIndex=true` opt-in landed in 9444b82262 makes the factory entrypoint append a query string to the `/_atomic` POST URL when syncing the seed batch. The integration mock checked `request.url === '/testuser/personal/_atomic'` (exact match), so the new URL fell through to the generic POST handler and got `204 No Content`. The sync client expects `201` → reported `Atomic upload failed: 204 No Content`, factory:go exited 1, and `pnpm test:node` failed at `factory-entrypoint integration > factory:go --debug prints a structured JSON summary`. Switched the handler to `startsWith('/testuser/personal/_atomic')`, consistent with the other handlers already in this mock.
- **Rename test fixture username from `hassan` to `testuser`** across 5 SF test files (34 occurrences). The fixture had a real teammate's name baked into Matrix user IDs, account-data paths, and realm URLs; `testuser` is neutral.
- This was failing every shard 1 run on `main` since the merge — not flake. Failure example: https://github.com/cardstack/boxel/actions/runs/25493597169/job/74808011882

## Test plan

- [x] `pnpm test:node` in `packages/software-factory` passes locally (440 pass, 0 fail) before and after the rename
- [ ] Software Factory CI shard 1/3 turns green