### PR TITLE
observability-diff: scope PR comment to files the PR actually changes

### DIFF
--- a/.github/workflows/observability-diff.yml
+++ b/.github/workflows/observability-diff.yml
@@ -75,6 +75,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Need full history so `diff.sh --only-changed-since=origin/<base>`
+          # can run `git diff --name-only origin/<base>...HEAD` to scope
+          # the diff to files this PR actually changes (vs total drift
+          # between staging and main).
+          fetch-depth: 0
 
       - name: Install grafanactl
         uses: ./.github/actions/install-grafanactl
@@ -131,10 +137,15 @@ jobs:
       - name: Compute diff
         id: diff
         working-directory: packages/observability
+        env:
+          # Scope the diff to files THIS PR changes (vs total drift between
+          # staging and main, which can be large and unrelated to the PR).
+          # `pull_request.base.ref` is the target branch (typically `main`).
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -eo pipefail
           DIFF_FILE="$(mktemp)"
-          ./scripts/diff.sh --env staging > "$DIFF_FILE"
+          ./scripts/diff.sh --env staging --only-changed-since="origin/${PR_BASE_REF}" > "$DIFF_FILE"
           # Persist the diff path for the next step (raw stdout via $GITHUB_OUTPUT
           # has multi-line / size limits we want to handle in JS instead).
           echo "diff_file=$DIFF_FILE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/observability-diff.yml
+++ b/.github/workflows/observability-diff.yml
@@ -76,11 +76,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Need full history so `diff.sh --only-changed-since=origin/<base>`
-          # can run `git diff --name-only origin/<base>...HEAD` to scope
-          # the diff to files this PR actually changes (vs total drift
-          # between staging and main).
+          # Need history reaching back to the merge-base with the PR's
+          # base branch so `diff.sh --only-changed-since=origin/<base>`
+          # can run `git diff --name-only origin/<base>...HEAD`. Default
+          # fetch-depth: 1 only gives HEAD; 0 = full history.
           fetch-depth: 0
+
+      - name: Fetch PR base ref
+        # Belt-and-suspenders: even with `fetch-depth: 0`, ensure the
+        # PR base ref is available as `origin/<base>` so diff.sh's
+        # `git rev-parse --verify` succeeds. Cheap on already-fetched
+        # history; idempotent if the ref is already up to date.
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: git fetch --no-tags --depth=1 origin "${PR_BASE_REF}"
 
       - name: Install grafanactl
         uses: ./.github/actions/install-grafanactl

--- a/packages/observability/scripts/diff.sh
+++ b/packages/observability/scripts/diff.sh
@@ -6,9 +6,28 @@
 #
 # Usage:
 #   ./scripts/diff.sh [--env local|staging|production]
+#                     [--only-changed-since <git-ref>]
+#
+# Flags:
+#   --env                  Target Grafana environment to compare against
+#                          (default: staging).
+#   --only-changed-since   Restrict the diff to dashboards / folders whose
+#                          files changed in
+#                          `git diff --name-only <ref>...HEAD --diff-filter=ACMRT`
+#                          under `packages/observability/grafanactl/resources/`.
+#                          Used by the PR comment workflow so the diff
+#                          reflects what the PR actually changes (vs total
+#                          drift between staging and main). Deletions are
+#                          excluded since `grafanactl push` is upsert-only —
+#                          deletion-only PRs short-circuit to empty stdout.
+#                          When the filter set is empty (no PR-relevant
+#                          changes) the script exits 0 with no output before
+#                          calling `grafanactl pull`.
 #
 # Output: human-readable diff on stdout. Empty output (and exit 0) means
-# the committed state matches the live state.
+# the committed state matches the live state, or — when
+# --only-changed-since is set — that the PR didn't change any
+# grafanactl-managed resources.
 #
 # Scope: this only diffs the resources grafanactl manages — dashboards
 # and folders. The `provisioning/` tree (data sources, alert rules) is
@@ -72,7 +91,25 @@ cd "$(dirname "$0")/.."
 # so it matches `git diff --name-only` output directly.
 filter_paths=""
 if [[ -n "$only_changed_since" ]]; then
-  filter_paths="$(git diff --name-only "${only_changed_since}...HEAD" -- packages/observability/grafanactl/resources/)"
+  # Validate the ref up front so a missing/invalid ref produces a clear
+  # error rather than a noisy `git diff` failure further down. CI usually
+  # passes `origin/<base-ref>` and we'd rather surface "this ref isn't
+  # available locally" with actionable guidance than git's bare
+  # "fatal: bad revision" exiting under set -e.
+  if ! git rev-parse --verify --quiet "${only_changed_since}^{commit}" >/dev/null; then
+    echo "error: --only-changed-since=$only_changed_since does not resolve to a commit." \
+         "In CI, ensure the workflow does \`git fetch origin <base-ref>\` (or" \
+         "\`actions/checkout\` with \`fetch-depth: 0\`) before invoking diff.sh." >&2
+    exit 1
+  fi
+  # `--diff-filter=ACMRT` — Added / Copied / Modified / Renamed / Type-changed.
+  # Exclude Deleted because `grafanactl push` is upsert-only and never
+  # deletes; a deletion in the PR is a no-op for live state. Without
+  # this, a PR that only deletes a dashboard would skip the empty-set
+  # short-circuit below and trigger a needless `grafanactl pull`.
+  filter_paths="$(git diff --name-only --diff-filter=ACMRT \
+    "${only_changed_since}...HEAD" \
+    -- packages/observability/grafanactl/resources/)"
   if [[ -z "$filter_paths" ]]; then
     # Empty stdout signals "no diff" to the workflow's comment step,
     # which renders the "No dashboard / folder changes detected"

--- a/packages/observability/scripts/diff.sh
+++ b/packages/observability/scripts/diff.sh
@@ -23,6 +23,7 @@ set -eo pipefail
 usage_error() { echo "error: $1" >&2; exit 2; }
 
 env_name=staging
+only_changed_since=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --env)
@@ -35,6 +36,25 @@ while [[ $# -gt 0 ]]; do
       [[ -n "$env_name" ]] || usage_error "missing value for --env"
       shift
       ;;
+    # When set, restrict the diff to dashboards/folders whose files
+    # changed in `git diff --name-only <ref>...HEAD` under
+    # `packages/observability/grafanactl/resources/`. Used by the PR
+    # comment workflow so the diff reflects what THIS PR would do to
+    # staging on apply, rather than total drift between staging and
+    # main (which can be large and unrelated to the PR).
+    #
+    # If no PR-relevant paths changed, the diff is empty and the script
+    # exits 0 immediately (skipping the live pull).
+    --only-changed-since)
+      [[ $# -ge 2 && "$2" != --* ]] || usage_error "missing value for --only-changed-since"
+      only_changed_since="$2"
+      shift 2
+      ;;
+    --only-changed-since=*)
+      only_changed_since="${1#--only-changed-since=}"
+      [[ -n "$only_changed_since" ]] || usage_error "missing value for --only-changed-since"
+      shift
+      ;;
     *)
       usage_error "unknown option: $1"
       ;;
@@ -42,6 +62,39 @@ while [[ $# -gt 0 ]]; do
 done
 
 cd "$(dirname "$0")/.."
+
+# Build the changed-paths filter list BEFORE the expensive grafanactl
+# pull, so a no-op PR exits without touching staging. Stored as a
+# newline-separated string (instead of an associative array) for bash
+# 3.2 compatibility — same constraint the rest of this script honors.
+# Each line is a path relative to repo root (e.g.,
+# `packages/observability/grafanactl/resources/dashboards/.../foo.json`)
+# so it matches `git diff --name-only` output directly.
+filter_paths=""
+if [[ -n "$only_changed_since" ]]; then
+  filter_paths="$(git diff --name-only "${only_changed_since}...HEAD" -- packages/observability/grafanactl/resources/)"
+  if [[ -z "$filter_paths" ]]; then
+    # Empty stdout signals "no diff" to the workflow's comment step,
+    # which renders the "No dashboard / folder changes detected"
+    # comment body.
+    exit 0
+  fi
+fi
+
+# Returns 0 (success) if a path under grafanactl/resources/ should be
+# included in the diff. Always returns 0 when the filter is inactive —
+# preserving the original "diff everything" behavior.
+#   $1 — path relative to grafanactl/resources/ (e.g.
+#        `dashboards/boxel-status/foo.json`).
+is_in_filter_rel() {
+  [[ -z "$filter_paths" ]] && return 0
+  local key="packages/observability/grafanactl/resources/$1"
+  local line
+  while IFS= read -r line; do
+    [[ "$line" == "$key" ]] && return 0
+  done <<< "$filter_paths"
+  return 1
+}
 
 # shellcheck source=./grafanactl-env.sh
 source ./scripts/grafanactl-env.sh "$env_name"
@@ -138,6 +191,7 @@ normalize() {  # $1: subdir under grafanactl/resources, $2: pulled-kind dirname
     pulled="${remote}/${kind}/${uid}.json"
     [[ -f "$pulled" ]] || continue
     rel="${committed#./grafanactl/resources/}"
+    is_in_filter_rel "$rel" || continue
     target="${remote_norm}/${rel}"
     mkdir -p "$(dirname "$target")"
     cp "$pulled" "$target"
@@ -254,6 +308,7 @@ normalize_json_content() {  # $1: src dir, $2: dest dir
   local f rel target
   while IFS= read -r -d '' f; do
     rel="${f#"$src"/}"
+    is_in_filter_rel "$rel" || continue
     target="$dest/$rel"
     mkdir -p "$(dirname "$target")"
     jq --sort-keys --arg url "$realm_server_url" "$JQ_NORMALIZE" "$f" > "$target"


### PR DESCRIPTION
## Summary

The observability-diff PR comment workflow currently shows **total drift** between main + this PR and live staging Grafana. That includes drift from earlier merges that haven't reached staging, manual UI edits in staging, AMG-era residue, etc. — most of which has nothing to do with the PR being reviewed and adds noise.

This PR scopes the diff to **only the dashboard/folder files that changed in the PR**, so the comment reflects what would happen *on apply* of this PR, not accumulated drift.

### Mechanism

- New `diff.sh --only-changed-since=<ref>` flag. When set, runs `git diff --name-only <ref>...HEAD -- packages/observability/grafanactl/resources/` and only includes those files in the canonicalize + diff pipeline.
- If no PR-relevant paths changed, `diff.sh` exits 0 with empty stdout (skipping the expensive `grafanactl pull`). The workflow's comment step then renders the existing "No dashboard / folder changes detected" body.
- The workflow passes `origin/${{ github.event.pull_request.base.ref }}` so the comparison is against the PR's actual target branch.
- `actions/checkout` gains `fetch-depth: 0` so `origin/<base>...HEAD` has both refs available (default `fetch-depth: 1` only fetches HEAD).

### Implementation notes

- Filter is stored as a newline-separated string + `[[ "$line" == "$key" ]]` scan, not `declare -A`, for **bash 3.2 compatibility** — same constraint the rest of the script already honors (see the `find -print0` pattern comments throughout).
- The filter check is applied in both `normalize()` (per-folder layout) and `normalize_json_content()` (jq canonicalization) so unrelated files never reach the final `git diff --no-index`.
- No filter (default behavior, ad-hoc local invocation) preserves the original "diff everything" behavior.

### Effect on the existing stack

For the open dashboard PRs (#4694–#4699):

| PR | Files in `grafanactl/resources/` | Expected comment |
|---|---|---|
| #4694 (Loki/Alloy infra) | none | "No dashboard / folder changes detected" |
| #4695 (job_id correlation) | none | "No dashboard / folder changes detected" |
| #4696 (tag dashboards + Logs vars) | `boxel-logs.json`, `synapse.json` | only those two files' diffs |
| #4697 (split Boxel Jobs) | `indexing.json`, `job-queue.json`, deletion of `boxel-jobs.json` | only those |
| #4698 (Realms + Users) | the 4 entity dashboards | only those |
| #4699 (Overview + service stubs) | the 5 new dashboards, deletion of `worker-status.json` | only those |

Right now every one of those PRs gets the same multi-thousand-line diff dominated by drift unrelated to the PR. After this lands, each comment will be tightly scoped.

## Test plan

- [ ] Locally: `./scripts/diff.sh --env staging --only-changed-since=origin/main` (requires AWS access for SSM token) — verify scope is just files changed since main.
- [ ] Locally: `./scripts/diff.sh --env staging --only-changed-since=<ref-with-no-observability-changes>` — verify exits 0 with empty stdout, no grafanactl pull happened.
- [ ] CI: open any PR touching observability infra (not dashboards) — comment should say "No dashboard / folder changes detected".
- [ ] CI: open a PR modifying one dashboard — comment should show only that dashboard's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)