### PR TITLE
runtime-common: prettier --fix follow-up to #4628

### DIFF
--- a/packages/runtime-common/realm-index-card.ts
+++ b/packages/runtime-common/realm-index-card.ts
@@ -16,10 +16,7 @@ export function isRealmIndexCardId(
       typeof realm === 'string' ? new URL(realm) : realm,
     );
     let cardURL = cardIdToURL(cardId);
-    return (
-      realmPaths.inRealm(cardURL) &&
-      realmPaths.local(cardURL) === 'index'
-    );
+    return realmPaths.inRealm(cardURL) && realmPaths.local(cardURL) === 'index';
   } catch {
     return false;
   }

--- a/packages/runtime-common/url.ts
+++ b/packages/runtime-common/url.ts
@@ -28,10 +28,7 @@ export function relativeURL(
   if (realmURL) {
     let realmPath = new RealmPaths(realmURL);
     // don't return a relative URL for URL that is outside of our realm
-    if (
-      realmPath.inRealm(relativeTo) &&
-      !realmPath.inRealm(url)
-    ) {
+    if (realmPath.inRealm(relativeTo) && !realmPath.inRealm(url)) {
       return undefined;
     }
   }


### PR DESCRIPTION
## Summary

#4628 shortened two expressions in `realm-index-card.ts` and `url.ts` so they now fit on one line but left them wrapped, which prettier flags. The lint job has been failing on every PR opened against main since #4628 merged — confirmed at least three branches affected (#4711, `cs-11082-bench-realm-gate`, `cs-11083-grafana-full-reindex-only-reindexes-lazy-mounted-realms-on`).

Pure formatting; no behavior change.

```diff
-    return (
-      realmPaths.inRealm(cardURL) &&
-      realmPaths.local(cardURL) === 'index'
-    );
+    return realmPaths.inRealm(cardURL) && realmPaths.local(cardURL) === 'index';
```

## Test plan

- [x] `pnpm run lint:js` in `packages/runtime-common` passes after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)