### PR TITLE
software-factory: stabilize factory:go debug summary integration test

### DIFF
--- a/packages/boxel-cli/api.ts
+++ b/packages/boxel-cli/api.ts
@@ -20,6 +20,8 @@ export {
 } from './src/lib/boxel-cli-client';
 
 export {
+  BOXEL_CLI_CONFIG_DIR_ENV,
+  getDefaultProfileConfigDir,
   resetProfileManager,
   setProfileManager,
 } from './src/lib/profile-manager';

--- a/packages/boxel-cli/src/lib/boxel-cli-client.ts
+++ b/packages/boxel-cli/src/lib/boxel-cli-client.ts
@@ -170,6 +170,10 @@ export class BoxelCLIClient {
     };
   }
 
+  getProfileConfigDir(): string {
+    return this.pm.getConfigDir();
+  }
+
   /**
    * Read a file from a realm. Always returns raw text content.
    * Callers should parse the content themselves if needed (e.g. JSON).

--- a/packages/boxel-cli/src/lib/profile-manager.ts
+++ b/packages/boxel-cli/src/lib/profile-manager.ts
@@ -17,10 +17,7 @@ export const BOXEL_CLI_CONFIG_DIR_ENV = 'BOXEL_CLI_CONFIG_DIR';
 const PROFILES_FILENAME = 'profiles.json';
 
 export function getDefaultProfileConfigDir(): string {
-  return (
-    process.env[BOXEL_CLI_CONFIG_DIR_ENV] ??
-    path.join(os.homedir(), '.boxel-cli')
-  );
+  return process.env[BOXEL_CLI_CONFIG_DIR_ENV] || path.join(os.homedir(), '.boxel-cli');
 }
 
 export const NO_ACTIVE_PROFILE_ERROR =
@@ -104,7 +101,7 @@ export class ProfileManager implements RealmAuthenticator {
   private profilesFile: string;
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? getDefaultProfileConfigDir();
+    this.configDir = configDir || getDefaultProfileConfigDir();
     this.profilesFile = path.join(this.configDir, PROFILES_FILENAME);
     this.config = this.loadConfig();
   }

--- a/packages/boxel-cli/src/lib/profile-manager.ts
+++ b/packages/boxel-cli/src/lib/profile-manager.ts
@@ -17,7 +17,10 @@ export const BOXEL_CLI_CONFIG_DIR_ENV = 'BOXEL_CLI_CONFIG_DIR';
 const PROFILES_FILENAME = 'profiles.json';
 
 export function getDefaultProfileConfigDir(): string {
-  return process.env[BOXEL_CLI_CONFIG_DIR_ENV] || path.join(os.homedir(), '.boxel-cli');
+  return (
+    process.env[BOXEL_CLI_CONFIG_DIR_ENV] ||
+    path.join(os.homedir(), '.boxel-cli')
+  );
 }
 
 export const NO_ACTIVE_PROFILE_ERROR =

--- a/packages/boxel-cli/src/lib/profile-manager.ts
+++ b/packages/boxel-cli/src/lib/profile-manager.ts
@@ -13,8 +13,15 @@ import {
 } from './auth';
 import type { RealmAuthenticator } from './realm-authenticator';
 
-const DEFAULT_CONFIG_DIR = path.join(os.homedir(), '.boxel-cli');
+export const BOXEL_CLI_CONFIG_DIR_ENV = 'BOXEL_CLI_CONFIG_DIR';
 const PROFILES_FILENAME = 'profiles.json';
+
+export function getDefaultProfileConfigDir(): string {
+  return (
+    process.env[BOXEL_CLI_CONFIG_DIR_ENV] ??
+    path.join(os.homedir(), '.boxel-cli')
+  );
+}
 
 export const NO_ACTIVE_PROFILE_ERROR =
   'No active profile. Run `boxel profile add` to create one.';
@@ -97,7 +104,7 @@ export class ProfileManager implements RealmAuthenticator {
   private profilesFile: string;
 
   constructor(configDir?: string) {
-    this.configDir = configDir || DEFAULT_CONFIG_DIR;
+    this.configDir = configDir ?? getDefaultProfileConfigDir();
     this.profilesFile = path.join(this.configDir, PROFILES_FILENAME);
     this.config = this.loadConfig();
   }
@@ -171,6 +178,10 @@ export class ProfileManager implements RealmAuthenticator {
     const profile = this.config.profiles[id];
     if (!profile) return null;
     return { id, profile };
+  }
+
+  getConfigDir(): string {
+    return this.configDir;
   }
 
   async addProfile(

--- a/packages/software-factory/src/cli/factory-entrypoint.ts
+++ b/packages/software-factory/src/cli/factory-entrypoint.ts
@@ -42,7 +42,9 @@ async function main(): Promise<void> {
     let active = client.getActiveProfile();
     log.debug(
       `profile config dir=${client.getProfileConfigDir()} source=${
-        process.env[BOXEL_CLI_CONFIG_DIR_ENV] ? BOXEL_CLI_CONFIG_DIR_ENV : 'HOME'
+        process.env[BOXEL_CLI_CONFIG_DIR_ENV] !== undefined
+          ? BOXEL_CLI_CONFIG_DIR_ENV
+          : 'HOME'
       }`,
     );
     log.debug(

--- a/packages/software-factory/src/cli/factory-entrypoint.ts
+++ b/packages/software-factory/src/cli/factory-entrypoint.ts
@@ -1,7 +1,10 @@
 // This should be first
 import '../setup-logger';
 
-import { BoxelCLIClient } from '@cardstack/boxel-cli/api';
+import {
+  BOXEL_CLI_CONFIG_DIR_ENV,
+  BoxelCLIClient,
+} from '@cardstack/boxel-cli/api';
 
 import {
   FactoryEntrypointUsageError,
@@ -33,6 +36,19 @@ async function main(): Promise<void> {
   await BoxelCLIClient.ensureProfile({
     realmServerUrl: options.realmServerUrl ?? undefined,
   });
+
+  if (options.debug) {
+    let client = new BoxelCLIClient();
+    let active = client.getActiveProfile();
+    log.debug(
+      `profile config dir=${client.getProfileConfigDir()} source=${
+        process.env[BOXEL_CLI_CONFIG_DIR_ENV] ? BOXEL_CLI_CONFIG_DIR_ENV : 'HOME'
+      }`,
+    );
+    log.debug(
+      `active profile=${active?.matrixId ?? '(none)'} realmServer=${active?.realmServerUrl ?? '(none)'}`,
+    );
+  }
 
   log.info(`brief=${options.briefUrl}`);
   log.info('Starting seed issue + issue-driven loop...');

--- a/packages/software-factory/tests/factory-entrypoint.integration.test.ts
+++ b/packages/software-factory/tests/factory-entrypoint.integration.test.ts
@@ -345,42 +345,45 @@ module('factory-entrypoint integration', function () {
         },
       );
 
-      if (result.status !== 0) {
-        assert.strictEqual(result.status, 0, formatCommandDiagnostics(result));
-        return;
-      }
+      assert.strictEqual(result.status, 0, formatCommandDiagnostics(result));
 
-      let summary: FactoryEntrypointIntegrationSummary;
-      try {
-        summary = JSON.parse(result.stdout) as FactoryEntrypointIntegrationSummary;
-      } catch (error) {
-        assert.ok(false, formatJsonDiagnostics(result, error));
-        return;
+      if (result.status === 0) {
+        let summary: FactoryEntrypointIntegrationSummary | undefined;
+        try {
+          summary = JSON.parse(
+            result.stdout,
+          ) as FactoryEntrypointIntegrationSummary;
+        } catch (error) {
+          assert.ok(false, formatJsonDiagnostics(result, error));
+        }
+
+        if (summary) {
+          assert.strictEqual(summary.command, 'factory:go');
+          assert.strictEqual(summary.brief.url, briefUrl);
+          assert.strictEqual(summary.brief.title, 'Sticky Note');
+          assert.strictEqual(
+            summary.brief.contentSummary,
+            'Colorful, short-form note designed for spatial arrangement on boards and artboards.',
+          );
+          assert.deepEqual(summary.brief.tags, [
+            'documents-content',
+            'sticky',
+            'note',
+          ]);
+          assert.strictEqual(summary.targetRealm.url, canonicalTargetRealmUrl);
+          assert.strictEqual(summary.targetRealm.ownerUsername, 'testuser');
+          assert.strictEqual(
+            summary.seedIssue.seedIssueId,
+            'Issues/bootstrap-seed',
+          );
+          assert.strictEqual(summary.seedIssue.seedIssueStatus, 'created');
+          // Loop runs and completes immediately (no issues in realm)
+          assert.deepEqual(summary.result, {
+            status: 'completed',
+            nextStep: 'all-issues-completed',
+          });
+        }
       }
-      assert.strictEqual(summary.command, 'factory:go');
-      assert.strictEqual(summary.brief.url, briefUrl);
-      assert.strictEqual(summary.brief.title, 'Sticky Note');
-      assert.strictEqual(
-        summary.brief.contentSummary,
-        'Colorful, short-form note designed for spatial arrangement on boards and artboards.',
-      );
-      assert.deepEqual(summary.brief.tags, [
-        'documents-content',
-        'sticky',
-        'note',
-      ]);
-      assert.strictEqual(summary.targetRealm.url, canonicalTargetRealmUrl);
-      assert.strictEqual(summary.targetRealm.ownerUsername, 'testuser');
-      assert.strictEqual(
-        summary.seedIssue.seedIssueId,
-        'Issues/bootstrap-seed',
-      );
-      assert.strictEqual(summary.seedIssue.seedIssueStatus, 'created');
-      // Loop runs and completes immediately (no issues in realm)
-      assert.deepEqual(summary.result, {
-        status: 'completed',
-        nextStep: 'all-issues-completed',
-      });
     } finally {
       rmSync(tempProfile.homeDir, { recursive: true, force: true });
       await new Promise<void>((resolvePromise, reject) =>
@@ -503,8 +506,12 @@ async function runCommand(
 
 function formatCommandDiagnostics(result: RunCommandResult): string {
   return [
-    result.stderr.trim() ? `stderr:\n${result.stderr.trimEnd()}` : 'stderr: <empty>',
-    result.stdout.trim() ? `stdout:\n${result.stdout.trimEnd()}` : 'stdout: <empty>',
+    result.stderr.trim()
+      ? `stderr:\n${result.stderr.trimEnd()}`
+      : 'stderr: <empty>',
+    result.stdout.trim()
+      ? `stdout:\n${result.stdout.trimEnd()}`
+      : 'stdout: <empty>',
   ].join('\n\n');
 }
 

--- a/packages/software-factory/tests/factory-entrypoint.integration.test.ts
+++ b/packages/software-factory/tests/factory-entrypoint.integration.test.ts
@@ -55,7 +55,7 @@ function createTempProfileHome(options: {
   matrixUrl: string;
   realmServerUrl: string;
   password: string;
-}): string {
+}): { homeDir: string; configDir: string } {
   let tempHome = mkdtempSync(join(tmpdir(), 'boxel-test-'));
   let boxelCliDir = join(tempHome, '.boxel-cli');
   mkdirSync(boxelCliDir, { recursive: true });
@@ -77,7 +77,10 @@ function createTempProfileHome(options: {
     JSON.stringify(config, null, 2),
   );
 
-  return tempHome;
+  return {
+    homeDir: tempHome,
+    configDir: boxelCliDir,
+  };
 }
 
 module('factory-entrypoint integration', function () {
@@ -309,7 +312,7 @@ module('factory-entrypoint integration', function () {
     targetRealm = `${origin}/typed-by-user/personal/`;
     canonicalTargetRealmUrl = `${origin}/testuser/personal/`;
 
-    let tempHome = createTempProfileHome({
+    let tempProfile = createTempProfileHome({
       username: 'testuser',
       matrixUrl: `${origin}/`,
       realmServerUrl: `${origin}/`,
@@ -336,16 +339,24 @@ module('factory-entrypoint integration', function () {
           encoding: 'utf8',
           env: {
             ...process.env,
-            HOME: tempHome,
+            HOME: tempProfile.homeDir,
+            BOXEL_CLI_CONFIG_DIR: tempProfile.configDir,
           },
         },
       );
 
-      assert.strictEqual(result.status, 0, result.stderr);
+      if (result.status !== 0) {
+        assert.strictEqual(result.status, 0, formatCommandDiagnostics(result));
+        return;
+      }
 
-      let summary = JSON.parse(
-        result.stdout,
-      ) as FactoryEntrypointIntegrationSummary;
+      let summary: FactoryEntrypointIntegrationSummary;
+      try {
+        summary = JSON.parse(result.stdout) as FactoryEntrypointIntegrationSummary;
+      } catch (error) {
+        assert.ok(false, formatJsonDiagnostics(result, error));
+        return;
+      }
       assert.strictEqual(summary.command, 'factory:go');
       assert.strictEqual(summary.brief.url, briefUrl);
       assert.strictEqual(summary.brief.title, 'Sticky Note');
@@ -371,7 +382,7 @@ module('factory-entrypoint integration', function () {
         nextStep: 'all-issues-completed',
       });
     } finally {
-      rmSync(tempHome, { recursive: true, force: true });
+      rmSync(tempProfile.homeDir, { recursive: true, force: true });
       await new Promise<void>((resolvePromise, reject) =>
         server.close((error) => (error ? reject(error) : resolvePromise())),
       );
@@ -488,4 +499,22 @@ async function runCommand(
       resolvePromise({ status, stdout, stderr });
     });
   });
+}
+
+function formatCommandDiagnostics(result: RunCommandResult): string {
+  return [
+    result.stderr.trim() ? `stderr:\n${result.stderr.trimEnd()}` : 'stderr: <empty>',
+    result.stdout.trim() ? `stdout:\n${result.stdout.trimEnd()}` : 'stdout: <empty>',
+  ].join('\n\n');
+}
+
+function formatJsonDiagnostics(
+  result: RunCommandResult,
+  error: unknown,
+): string {
+  let message = error instanceof Error ? error.message : String(error);
+  return [
+    `stdout was not valid JSON: ${message}`,
+    formatCommandDiagnostics(result),
+  ].join('\n\n');
 }


### PR DESCRIPTION
## Summary
This stacked PR fixes a flaky Software Factory integration test and adds diagnostics so a future failure is immediately actionable.

Targeted flaky test:
`factory-entrypoint integration > factory:go --debug prints a structured JSON summary`

Observed failing job:
https://github.com/cardstack/boxel/actions/runs/25498085667/job/74823628820

## Stacked PR context
This branch is intentionally based on `cs-11082-bench-realm-gate`, not `main`, so the PR diff only contains the flaky-test fix.

## Failure mode
The failure was intermittent in CI, but the log gave two strong clues in the same test run:

1. The spawned `factory:go --debug` process sometimes exited non-zero because it resolved the wrong active Boxel profile / target realm owner path.
2. The test then attempted to `JSON.parse(result.stdout)` and hit `Unexpected end of JSON input`, which hid the real cause behind a second failure.

From the failing log, the command unexpectedly started operating against a realm path under a different owner instead of the test's isolated `testuser` profile. That means the spawned CLI invocation was not reliably isolated to the temporary test profile configuration.

## Root cause
The integration test only overrode `HOME` and relied on the Boxel CLI's implicit `~/.boxel-cli` discovery behavior in the spawned child process.

That left one fragile edge in the setup:
- the child process had no explicit config-dir contract for profile lookup
- if profile resolution drifted away from the temp home lookup path, the child could pick up a different active profile
- once that happened, the command failed earlier during sync / realm-owner resolution, and the test's JSON parse produced a misleading second error

## Change
### 1. Add an explicit profile config-dir override for Boxel CLI
`ProfileManager` now supports a dedicated environment variable:
`BOXEL_CLI_CONFIG_DIR`

This gives spawned processes an explicit, deterministic profile config directory instead of relying only on `os.homedir()` / `HOME` behavior.

### 2. Surface the resolved config source for debugging
The Boxel CLI API now exposes the resolved profile config dir, and `factory:go --debug` logs:
- the profile config directory it used
- whether it came from `BOXEL_CLI_CONFIG_DIR` or `HOME`
- the active profile matrix ID and realm server URL

If this ever flakes again, the CI stderr should immediately show whether the process loaded the intended test profile.

### 3. Make the integration test explicitly isolate the spawned CLI
The flaky test now passes both:
- `HOME=<temp dir>`
- `BOXEL_CLI_CONFIG_DIR=<temp dir>/.boxel-cli`

That removes the ambiguity from child-process profile discovery.

### 4. Improve failure diagnostics in the test itself
The test no longer reports only a raw `Unexpected end of JSON input` when the child command fails.

If the subprocess exits non-zero, the assertion now includes:
- full stderr
- full stdout

If stdout is not valid JSON, the failure now includes:
- the JSON parse error
- the captured stderr
- the captured stdout

That means future failures should preserve the original command failure context instead of obscuring it behind a follow-on parse exception.

## Files changed
- `packages/boxel-cli/src/lib/profile-manager.ts`
  - add `BOXEL_CLI_CONFIG_DIR`
  - centralize default config-dir resolution
  - expose the active config dir
- `packages/boxel-cli/src/lib/boxel-cli-client.ts`
  - expose the resolved profile config dir to callers
- `packages/boxel-cli/api.ts`
  - export the new public config-dir helpers
- `packages/software-factory/src/cli/factory-entrypoint.ts`
  - add debug-only logging for config-dir source and active profile
- `packages/software-factory/tests/factory-entrypoint.integration.test.ts`
  - explicitly pass `BOXEL_CLI_CONFIG_DIR`
  - improve subprocess and JSON parse diagnostics

## Why this should address the flake
The unstable part of the test was not the JSON shape itself. It was the child process occasionally resolving profile state from the wrong place.

By making the config directory explicit in the spawned process, the test no longer depends on implicit home-directory lookup behavior. That removes the profile-selection ambiguity that led to the wrong owner / realm path in CI.

## Validation
I validated the change in the dedicated worktree at:
`/home/hassan/codez/boxel/.claude/worktrees/cs-11082-sf-go-debug-json-flake`

Executed validation:
- `pnpm --dir /home/hassan/codez/boxel/.claude/worktrees/cs-11082-sf-go-debug-json-flake install --frozen-lockfile`
- `pnpm --dir /home/hassan/codez/boxel/.claude/worktrees/cs-11082-sf-go-debug-json-flake/packages/software-factory exec qunit --require ts-node/register/transpile-only tests/index.ts --filter 'structured JSON summary'`
- repeated the same filtered QUnit invocation 5 times consecutively

Results:
- the targeted test passed
- the same test passed 5 consecutive reruns after the fix
- editor diagnostics reported no errors in the touched files

## Residual note
The targeted test still emits the existing QUnit warning that it takes longer than 3000ms without an explicit timeout. That warning predates this fix and does not fail the test, but it may be worth cleaning up separately if we want to reduce CI noise.
