### PR TITLE
Interact mode: Escape closes the most recently opened stack item

### DIFF
--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -28,6 +28,9 @@ interface Signature {
     cardTitle?: string;
     cardTypeDisplayName?: string;
     cardTypeIcon?: ComponentLike<{ Element: Element }>;
+    closeShortcutHint?: string;
+    editShortcutHint?: string;
+    finishEditingShortcutHint?: string;
     headerColor?: string;
     isSaving?: boolean;
     isTopCard?: boolean;
@@ -154,7 +157,9 @@ export default class CardHeader extends Component<Signature> {
                 />
               </:trigger>
               <:content>
-                Edit
+                Edit{{#if @editShortcutHint}}
+                  ({{@editShortcutHint}})
+                {{/if}}
               </:content>
             </Tooltip>
           {{/if}}
@@ -170,7 +175,9 @@ export default class CardHeader extends Component<Signature> {
                 />
               </:trigger>
               <:content>
-                Finish Editing
+                Finish Editing{{#if @finishEditingShortcutHint}}
+                  ({{@finishEditingShortcutHint}})
+                {{/if}}
               </:content>
             </Tooltip>
           {{/if}}
@@ -218,7 +225,9 @@ export default class CardHeader extends Component<Signature> {
                 />
               </:trigger>
               <:content>
-                Close
+                Close{{#if @closeShortcutHint}}
+                  ({{@closeShortcutHint}})
+                {{/if}}
               </:content>
             </Tooltip>
           {{/if}}

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -174,7 +174,7 @@ export default class InteractSubmode extends Component {
       return;
     }
 
-    let item = this.mostRecentlyOpenedStackItem;
+    let item = this.mostRecentlyInteractedStackItem;
     if (!item) return;
 
     // In edit mode, Escape exits to view mode (one level of "undo open").
@@ -195,7 +195,7 @@ export default class InteractSubmode extends Component {
     // point of the shortcut: flip in/out of edit without first having
     // to click somewhere else. Modals still own the keyboard, though.
     if (document.body.classList.contains('has-modal')) return;
-    let item = this.mostRecentlyOpenedStackItem;
+    let item = this.mostRecentlyInteractedStackItem;
     // Files have no edit format; nothing to toggle.
     if (!item || item.type === 'file') return;
     event.preventDefault();
@@ -205,10 +205,17 @@ export default class InteractSubmode extends Component {
     });
   }
 
-  private get mostRecentlyOpenedStackItem(): StackItem | undefined {
+  // The card the user is currently working with — i.e. the one a
+  // keyboard shortcut should act on. "Last opened" alone is too coarse:
+  // open A, open B, then click edit on A → A is the active card even
+  // though B was opened more recently. Format changes count as
+  // interactions (see StackItem.markInteracted), so this picks A.
+  private get mostRecentlyInteractedStackItem(): StackItem | undefined {
     let topItems = this.operatorModeStateService.topMostStackItems();
     if (topItems.length === 0) return undefined;
-    return topItems.reduce((a, b) => (b.openedAt > a.openedAt ? b : a));
+    return topItems.reduce((a, b) =>
+      b.lastInteractedAt > a.lastInteractedAt ? b : a,
+    );
   }
 
   get stacks() {

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -1,7 +1,6 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { concat, fn } from '@ember/helper';
 import { action } from '@ember/object';
-import type Owner from '@ember/owner';
 import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import { buildWaiter } from '@ember/test-waiters';
@@ -11,6 +10,7 @@ import { tracked } from '@glimmer/tracking';
 
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import perform from 'ember-concurrency/helpers/perform';
+import onKeyMod from 'ember-keyboard/modifiers/on-key';
 import { consume } from 'ember-provide-consume-context';
 
 import get from 'lodash/get';
@@ -126,12 +126,11 @@ interface CardToDelete {
   title: string;
 }
 
-function isFocusInTextInput(): boolean {
-  let el = document.activeElement as HTMLElement | null;
-  if (!el) return false;
-  let tag = el.tagName;
+function isInteractiveTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  let tag = target.tagName;
   if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
-  if (el.isContentEditable) return true;
+  if (target.isContentEditable) return true;
   return false;
 }
 
@@ -157,34 +156,46 @@ export default class InteractSubmode extends Component {
     | ReturnType<getCardCollection>
     | undefined;
 
-  constructor(owner: Owner, args: {}) {
-    super(owner, args);
-    if (typeof window !== 'undefined') {
-      window.addEventListener('keydown', this.onWindowKeydown);
-    }
+  // Skip our shortcut handlers when another part of the UI owns the
+  // keyboard: a modal/dialog is open, or the event came from a text
+  // field (ember-keyboard dispatches at the document level, so we still
+  // need to filter out keystrokes that another component is handling
+  // — e.g. the search sheet's own Escape, which blurs its input
+  // *before* our handler runs).
+  private shouldIgnoreShortcut(event: KeyboardEvent) {
+    if (document.body.classList.contains('has-modal')) return true;
+    if (isInteractiveTarget(event.target)) return true;
+    return false;
   }
 
-  willDestroy() {
-    super.willDestroy();
-    if (typeof window !== 'undefined') {
-      window.removeEventListener('keydown', this.onWindowKeydown);
-    }
-  }
-
-  @action private onWindowKeydown(event: KeyboardEvent) {
-    if (event.key !== 'Escape') return;
-    if (event.defaultPrevented) return;
-    // A modal or dialog is open — let it own the Escape key.
-    if (document.body.classList.contains('has-modal')) return;
-    if (this.cardToDelete) return;
-    // The user is typing in a text field (search sheet, inline rename,
-    // contenteditable card content). Let the field handle its own
-    // Escape semantics (blur, cancel) without closing the card under it.
-    if (isFocusInTextInput()) return;
-
+  @action private handleEscape(event: KeyboardEvent) {
+    if (this.shouldIgnoreShortcut(event)) return;
     let item = this.mostRecentlyOpenedStackItem;
     if (!item) return;
+
+    // In edit mode, Escape exits to view mode (one level of "undo open").
+    // In view mode, Escape closes the item.
+    if (item.format === 'edit' && item.type !== 'file') {
+      event.preventDefault();
+      this.operatorModeStateService.setItemFormat(item, 'isolated', {
+        request: new Deferred(),
+      });
+      return;
+    }
+    event.preventDefault();
     this.close(item);
+  }
+
+  @action private handleToggleEdit(event: KeyboardEvent) {
+    if (this.shouldIgnoreShortcut(event)) return;
+    let item = this.mostRecentlyOpenedStackItem;
+    // Files have no edit format; nothing to toggle.
+    if (!item || item.type === 'file') return;
+    event.preventDefault();
+    let nextFormat: Format = item.format === 'edit' ? 'isolated' : 'edit';
+    this.operatorModeStateService.setItemFormat(item, nextFormat, {
+      request: new Deferred(),
+    });
   }
 
   private get mostRecentlyOpenedStackItem(): StackItem | undefined {
@@ -825,7 +836,12 @@ export default class InteractSubmode extends Component {
       data-test-interact-submode
       as |search|
     >
-      <div class='interact-submode' style={{this.backgroundImageStyle}}>
+      <div
+        class='interact-submode'
+        style={{this.backgroundImageStyle}}
+        {{onKeyMod 'Escape' this.handleEscape}}
+        {{onKeyMod 'cmd+KeyE' this.handleToggleEdit}}
+      >
         {{#if this.canCreateNeighborStack}}
           <NeighborStackTriggerButton
             class='neighbor-stack-trigger stack-trigger-left'

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -156,20 +156,24 @@ export default class InteractSubmode extends Component {
     | ReturnType<getCardCollection>
     | undefined;
 
-  // Skip our shortcut handlers when another part of the UI owns the
-  // keyboard: a modal/dialog is open, or the event came from a text
-  // field (ember-keyboard dispatches at the document level, so we still
-  // need to filter out keystrokes that another component is handling
-  // — e.g. the search sheet's own Escape, which blurs its input
-  // *before* our handler runs).
-  private shouldIgnoreShortcut(event: KeyboardEvent) {
-    if (document.body.classList.contains('has-modal')) return true;
-    if (isInteractiveTarget(event.target)) return true;
-    return false;
-  }
-
   @action private handleEscape(event: KeyboardEvent) {
-    if (this.shouldIgnoreShortcut(event)) return;
+    // A modal owns Escape regardless of where focus is.
+    if (document.body.classList.contains('has-modal')) return;
+
+    if (isInteractiveTarget(event.target)) {
+      let el = event.target as HTMLElement;
+      // Field inside a stack card: peel the focus off first so a
+      // second Escape can fall through to exit edit / close.
+      if (el.closest('[data-stack-card]')) {
+        event.preventDefault();
+        el.blur();
+        return;
+      }
+      // Field outside any stack card (search sheet, AI assistant, etc.):
+      // defer to that field's own Escape handler.
+      return;
+    }
+
     let item = this.mostRecentlyOpenedStackItem;
     if (!item) return;
 
@@ -187,7 +191,10 @@ export default class InteractSubmode extends Component {
   }
 
   @action private handleToggleEdit(event: KeyboardEvent) {
-    if (this.shouldIgnoreShortcut(event)) return;
+    // Ctrl+E works even when focus is in an input — that's the whole
+    // point of the shortcut: flip in/out of edit without first having
+    // to click somewhere else. Modals still own the keyboard, though.
+    if (document.body.classList.contains('has-modal')) return;
     let item = this.mostRecentlyOpenedStackItem;
     // Files have no edit format; nothing to toggle.
     if (!item || item.type === 'file') return;

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -1,6 +1,7 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { concat, fn } from '@ember/helper';
 import { action } from '@ember/object';
+import type Owner from '@ember/owner';
 import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import { buildWaiter } from '@ember/test-waiters';
@@ -125,6 +126,15 @@ interface CardToDelete {
   title: string;
 }
 
+function isFocusInTextInput(): boolean {
+  let el = document.activeElement as HTMLElement | null;
+  if (!el) return false;
+  let tag = el.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (el.isContentEditable) return true;
+  return false;
+}
+
 export default class InteractSubmode extends Component {
   @consume(GetCardContextName) declare private getCard: getCard;
   @consume(GetCardsContextName) declare private getCards: getCards;
@@ -146,6 +156,42 @@ export default class InteractSubmode extends Component {
   @tracked private recentCardCollection:
     | ReturnType<getCardCollection>
     | undefined;
+
+  constructor(owner: Owner, args: {}) {
+    super(owner, args);
+    if (typeof window !== 'undefined') {
+      window.addEventListener('keydown', this.onWindowKeydown);
+    }
+  }
+
+  willDestroy() {
+    super.willDestroy();
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('keydown', this.onWindowKeydown);
+    }
+  }
+
+  @action private onWindowKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Escape') return;
+    if (event.defaultPrevented) return;
+    // A modal or dialog is open — let it own the Escape key.
+    if (document.body.classList.contains('has-modal')) return;
+    if (this.cardToDelete) return;
+    // The user is typing in a text field (search sheet, inline rename,
+    // contenteditable card content). Let the field handle its own
+    // Escape semantics (blur, cancel) without closing the card under it.
+    if (isFocusInTextInput()) return;
+
+    let item = this.mostRecentlyOpenedStackItem;
+    if (!item) return;
+    this.close(item);
+  }
+
+  private get mostRecentlyOpenedStackItem(): StackItem | undefined {
+    let topItems = this.operatorModeStateService.topMostStackItems();
+    if (topItems.length === 0) return undefined;
+    return topItems.reduce((a, b) => (b.openedAt > a.openedAt ? b : a));
+  }
 
   get stacks() {
     return this.operatorModeStateService.state?.stacks ?? [];

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -840,7 +840,9 @@ export default class InteractSubmode extends Component {
         class='interact-submode'
         style={{this.backgroundImageStyle}}
         {{onKeyMod 'Escape' this.handleEscape}}
-        {{onKeyMod 'cmd+KeyE' this.handleToggleEdit}}
+        {{! Bind Ctrl+E on every platform — Mac users get Ctrl+E too,
+           because Cmd+E is taken by browsers ("Use Selection for Find"). }}
+        {{onKeyMod 'ctrl+KeyE' this.handleToggleEdit}}
       >
         {{#if this.canCreateNeighborStack}}
           <NeighborStackTriggerButton

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -88,14 +88,6 @@ import type OperatorModeStateService from '../../services/operator-mode-state-se
 import type RealmService from '../../services/realm';
 import type StoreService from '../../services/store';
 
-function isMacPlatform(): boolean {
-  if (typeof navigator === 'undefined') return false;
-  let platform =
-    (navigator as { userAgentData?: { platform?: string } }).userAgentData
-      ?.platform ?? navigator.platform;
-  return /mac|iphone|ipad|ipod/i.test(platform);
-}
-
 export interface StackItemComponentAPI {
   clearSelections: () => void;
   scrollIntoView: (selector: string) => Promise<void>;
@@ -686,12 +678,12 @@ export default class OperatorModeStackItem extends Component<Signature> {
   }
 
   private get keyboardShortcutLabels() {
-    let toggleEdit = isMacPlatform() ? '⌘E' : 'Ctrl+E';
     return {
-      // Pencil button in view mode → enter edit (Ctrl/Cmd+E).
-      edit: this.isFileCard ? undefined : toggleEdit,
-      // Pencil button in edit mode → exit to view (Esc or Ctrl/Cmd+E).
-      finishEditing: this.isFileCard ? undefined : `Esc or ${toggleEdit}`,
+      // Pencil button in view mode → enter edit (Ctrl+E on every platform;
+      // Cmd+E is reserved by browsers for "Use Selection for Find").
+      edit: this.isFileCard ? undefined : 'Ctrl+E',
+      // Pencil button in edit mode → exit to view (Esc or Ctrl+E).
+      finishEditing: this.isFileCard ? undefined : 'Esc or Ctrl+E',
       // Close button: Esc only closes when not editing — in edit mode
       // Esc means "exit edit", so don't claim it in the close tooltip.
       close: this.isEditing ? undefined : 'Esc',

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -88,6 +88,14 @@ import type OperatorModeStateService from '../../services/operator-mode-state-se
 import type RealmService from '../../services/realm';
 import type StoreService from '../../services/store';
 
+function isMacPlatform(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  let platform =
+    (navigator as { userAgentData?: { platform?: string } }).userAgentData
+      ?.platform ?? navigator.platform;
+  return /mac|iphone|ipad|ipod/i.test(platform);
+}
+
 export interface StackItemComponentAPI {
   clearSelections: () => void;
   scrollIntoView: (selector: string) => Promise<void>;
@@ -677,6 +685,19 @@ export default class OperatorModeStackItem extends Component<Signature> {
     );
   }
 
+  private get keyboardShortcutLabels() {
+    let toggleEdit = isMacPlatform() ? '⌘E' : 'Ctrl+E';
+    return {
+      // Pencil button in view mode → enter edit (Ctrl/Cmd+E).
+      edit: this.isFileCard ? undefined : toggleEdit,
+      // Pencil button in edit mode → exit to view (Esc or Ctrl/Cmd+E).
+      finishEditing: this.isFileCard ? undefined : `Esc or ${toggleEdit}`,
+      // Close button: Esc only closes when not editing — in edit mode
+      // Esc means "exit edit", so don't claim it in the close tooltip.
+      close: this.isEditing ? undefined : 'Esc',
+    };
+  }
+
   private get cardFormat() {
     return this.isFileCard ? 'isolated' : this.args.item.format;
   }
@@ -819,6 +840,9 @@ export default class OperatorModeStackItem extends Component<Signature> {
               }}
               @onFinishEditing={{if this.isEditing this.doneEditing}}
               @onClose={{unless this.isBuried this.closeItem}}
+              @editShortcutHint={{this.keyboardShortcutLabels.edit}}
+              @finishEditingShortcutHint={{this.keyboardShortcutLabels.finishEditing}}
+              @closeShortcutHint={{this.keyboardShortcutLabels.close}}
               class='stack-item-header'
               style={{cssVar
                 boxel-card-header-icon-container-min-width=(if

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -17,7 +17,7 @@ interface Args {
     fieldName?: string;
     fieldType?: 'linksTo' | 'linksToMany';
   };
-  openedAt?: number;
+  lastInteractedAt?: number;
 }
 
 export type StackItemType = 'card' | 'file';
@@ -53,7 +53,7 @@ export function detectStackItemTypeForTarget(
   return fileMetaInstanceOrError ? 'file' : 'card';
 }
 
-let nextOpenedAt = 0;
+let nextInteractionSequence = 0;
 
 export class StackItem {
   // `format`, `request`, `useBaseTemplate` are tracked so that callers
@@ -69,11 +69,13 @@ export class StackItem {
   @tracked useBaseTemplate?: boolean;
   stackIndex: number;
   type: StackItemType;
-  // Monotonic per-construction sequence used to identify the most
-  // recently opened item across multiple stacks (e.g. for Escape-key
-  // close). Construction-time is the right signal: pushing the same id
-  // again creates a new StackItem.
-  readonly openedAt: number;
+  // Monotonic sequence used to identify which item the user most
+  // recently touched, for deciding what Escape / Ctrl+E should target.
+  // Bumped on construction (= a new open) AND on every format change
+  // via `markInteracted()`. The format bump is what makes "open A,
+  // open B, edit A, Escape" target A: clicking edit on A is the most
+  // recent interaction even though B was opened more recently.
+  lastInteractedAt: number;
   #id: string;
   relationshipContext?:
     | {
@@ -91,7 +93,7 @@ export class StackItem {
       type,
       useBaseTemplate,
       relationshipContext,
-      openedAt,
+      lastInteractedAt,
     } = args;
 
     this.#id = id.replace(/\.json$/, '');
@@ -101,11 +103,15 @@ export class StackItem {
     this.type = inferStackItemType(type);
     this.useBaseTemplate = useBaseTemplate;
     this.relationshipContext = relationshipContext;
-    this.openedAt = openedAt ?? ++nextOpenedAt;
+    this.lastInteractedAt = lastInteractedAt ?? ++nextInteractionSequence;
   }
 
   get id() {
     return this.#id;
+  }
+
+  markInteracted() {
+    this.lastInteractedAt = ++nextInteractionSequence;
   }
 
   clone(args: Partial<Args>) {
@@ -117,11 +123,11 @@ export class StackItem {
       relationshipContext,
       type,
       useBaseTemplate,
-      openedAt,
+      lastInteractedAt,
     } = this;
-    // Preserve the original open-time so clones (id swap on persist,
-    // stack shift on left-neighbor drop) don't masquerade as a fresh
-    // open and steal "most recently opened" precedence.
+    // Preserve the original interaction time so clones (id swap on
+    // persist, stack shift on left-neighbor drop) don't masquerade as
+    // a fresh interaction and steal precedence.
     return new StackItem({
       format,
       request,
@@ -130,7 +136,7 @@ export class StackItem {
       stackIndex,
       relationshipContext,
       useBaseTemplate,
-      openedAt,
+      lastInteractedAt,
       ...args,
     });
   }

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -17,6 +17,7 @@ interface Args {
     fieldName?: string;
     fieldType?: 'linksTo' | 'linksToMany';
   };
+  openedAt?: number;
 }
 
 export type StackItemType = 'card' | 'file';
@@ -52,6 +53,8 @@ export function detectStackItemTypeForTarget(
   return fileMetaInstanceOrError ? 'file' : 'card';
 }
 
+let nextOpenedAt = 0;
+
 export class StackItem {
   // `format`, `request`, `useBaseTemplate` are tracked so that callers
   // can mutate them IN PLACE (e.g. flipping `format` from 'isolated' →
@@ -66,6 +69,11 @@ export class StackItem {
   @tracked useBaseTemplate?: boolean;
   stackIndex: number;
   type: StackItemType;
+  // Monotonic per-construction sequence used to identify the most
+  // recently opened item across multiple stacks (e.g. for Escape-key
+  // close). Construction-time is the right signal: pushing the same id
+  // again creates a new StackItem.
+  readonly openedAt: number;
   #id: string;
   relationshipContext?:
     | {
@@ -83,6 +91,7 @@ export class StackItem {
       type,
       useBaseTemplate,
       relationshipContext,
+      openedAt,
     } = args;
 
     this.#id = id.replace(/\.json$/, '');
@@ -92,6 +101,7 @@ export class StackItem {
     this.type = inferStackItemType(type);
     this.useBaseTemplate = useBaseTemplate;
     this.relationshipContext = relationshipContext;
+    this.openedAt = openedAt ?? ++nextOpenedAt;
   }
 
   get id() {
@@ -107,7 +117,11 @@ export class StackItem {
       relationshipContext,
       type,
       useBaseTemplate,
+      openedAt,
     } = this;
+    // Preserve the original open-time so clones (id swap on persist,
+    // stack shift on left-neighbor drop) don't masquerade as a fresh
+    // open and steal "most recently opened" precedence.
     return new StackItem({
       format,
       request,
@@ -116,6 +130,7 @@ export class StackItem {
       stackIndex,
       relationshipContext,
       useBaseTemplate,
+      openedAt,
       ...args,
     });
   }

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -487,10 +487,18 @@ export default class OperatorModeStateService extends Service {
     if (item.type === 'file') {
       return;
     }
+    let formatChanged = item.format !== format;
     item.format = format;
     if (opts && 'request' in opts) item.request = opts.request;
     if (opts && 'useBaseTemplate' in opts)
       item.useBaseTemplate = opts.useBaseTemplate;
+    // A format flip is a deliberate user action ("edit this one") —
+    // mark it as the most recently interacted item so subsequent
+    // keyboard shortcuts target this card, not whatever happened to
+    // be opened most recently.
+    if (formatChanged) {
+      item.markInteracted();
+    }
     this.schedulePersist();
   }
 

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -590,7 +590,7 @@ module('Acceptance | interact submode tests', function (hooks) {
         .doesNotExist('a second Escape from view mode closes the item');
     });
 
-    test('Ctrl+E (or Cmd+E) toggles edit mode on the most recently opened item', async function (assert) {
+    test('Ctrl+E toggles edit mode on the most recently opened item', async function (assert) {
       await visitOperatorMode({
         stacks: [[{ id: `${testRealmURL}Person/fadhlan`, format: 'isolated' }]],
       });
@@ -601,17 +601,18 @@ module('Acceptance | interact submode tests', function (hooks) {
         )
         .exists('card starts in isolated/view mode');
 
-      // Cmd+E on Mac…
+      // Ctrl+E enters edit mode (bound on every platform — Mac too,
+      // because Cmd+E is reserved by browsers).
       await triggerKeyEvent(document.body, 'keydown', 'KeyE', {
-        metaKey: true,
+        ctrlKey: true,
       });
       assert
         .dom(
           `[data-test-stack-card="${testRealmURL}Person/fadhlan"] [data-test-card-format="edit"]`,
         )
-        .exists('Cmd+E flipped the card into edit mode');
+        .exists('Ctrl+E flipped the card into edit mode');
 
-      // …Ctrl+E on other platforms — and the toggle is symmetric.
+      // The toggle is symmetric — pressing again returns to isolated.
       await triggerKeyEvent(document.body, 'keydown', 'KeyE', {
         ctrlKey: true,
       });
@@ -620,6 +621,17 @@ module('Acceptance | interact submode tests', function (hooks) {
           `[data-test-stack-card="${testRealmURL}Person/fadhlan"] [data-test-card-format="isolated"]`,
         )
         .exists('Ctrl+E flipped the card back to isolated mode');
+
+      // Cmd+E (metaKey) is intentionally NOT bound — it stays free for
+      // the browser's "Use Selection for Find" shortcut on Mac.
+      await triggerKeyEvent(document.body, 'keydown', 'KeyE', {
+        metaKey: true,
+      });
+      assert
+        .dom(
+          `[data-test-stack-card="${testRealmURL}Person/fadhlan"] [data-test-card-format="isolated"]`,
+        )
+        .exists('Cmd+E (metaKey) does not toggle edit mode');
     });
 
     test('duplicate card in a stack is not allowed', async function (assert) {

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -461,6 +461,106 @@ module('Acceptance | interact submode tests', function (hooks) {
       assert.dom('[data-test-search-sheet]').hasClass('closed');
     });
 
+    test('Escape closes the most recently opened stack item', async function (assert) {
+      await visitOperatorMode({
+        stacks: [
+          [
+            { id: `${testRealmURL}Person/fadhlan`, format: 'isolated' },
+            { id: `${testRealmURL}Pet/mango`, format: 'isolated' },
+          ],
+        ],
+      });
+
+      assert
+        .dom(`[data-test-stack-card="${testRealmURL}Pet/mango"]`)
+        .exists('top item is rendered before Escape');
+
+      await triggerKeyEvent(document.body, 'keydown', 'Escape');
+
+      assert
+        .dom(`[data-test-stack-card="${testRealmURL}Pet/mango"]`)
+        .doesNotExist('Escape closed the topmost item');
+      assert
+        .dom(`[data-test-stack-card="${testRealmURL}Person/fadhlan"]`)
+        .exists('the underlying item remains open');
+    });
+
+    test('Escape does not close a stack item while a modal is open', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: `${testRealmURL}Person/fadhlan`, format: 'isolated' }]],
+      });
+
+      // Open the delete-confirmation modal via the card's more-options menu.
+      await click(
+        `[data-test-stack-card="${testRealmURL}Person/fadhlan"] [data-test-more-options-button]`,
+      );
+      await click('[data-test-boxel-menu-item-text="Delete"]');
+
+      assert
+        .dom('[data-test-delete-modal-container]')
+        .exists('delete modal is open');
+
+      await triggerKeyEvent(document.body, 'keydown', 'Escape');
+
+      assert
+        .dom(`[data-test-stack-card="${testRealmURL}Person/fadhlan"]`)
+        .exists('the card under the modal stays open');
+    });
+
+    test('Escape closes the most recently opened item when it lives in a non-rightmost stack (left-neighbor drop)', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: `${testRealmURL}Person/fadhlan`, format: 'isolated' }]],
+      });
+
+      // Make Pet/mango clickable in the search prompt as a recent card.
+      let operatorModeStateService = getService('operator-mode-state-service');
+      let recentCardsService = getService('recent-cards-service');
+      operatorModeStateService.state.stacks[0].map((item) =>
+        recentCardsService.add(item.id),
+      );
+      recentCardsService.add(`${testRealmURL}Pet/mango`);
+
+      // Drop a card into a NEW LEFT-side stack: stack 0 becomes [Mango],
+      // the original stack shifts to index 1 with [Fadhlan]. Mango is
+      // now the most recently opened item, even though it sits in the
+      // leftmost (non-rightmost) stack.
+      await click('[data-test-add-card-left-stack]');
+      await click(`[data-test-search-result="${testRealmURL}Pet/mango"]`);
+
+      assert.dom('[data-test-operator-mode-stack="0"]').includesText('Mango');
+      assert.dom('[data-test-operator-mode-stack="1"]').includesText('Fadhlan');
+
+      await triggerKeyEvent(document.body, 'keydown', 'Escape');
+
+      assert
+        .dom(`[data-test-stack-card="${testRealmURL}Pet/mango"]`)
+        .doesNotExist(
+          'Escape closed the leftmost item because it was opened most recently',
+        );
+      assert
+        .dom(`[data-test-stack-card="${testRealmURL}Person/fadhlan"]`)
+        .exists('the right-side stack item remains open');
+    });
+
+    test('Escape does not close a stack item while focus is in a text input', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: `${testRealmURL}Person/fadhlan`, format: 'isolated' }]],
+      });
+
+      // Opening the search sheet focuses its input.
+      await click('[data-test-open-search-field]');
+      assert.dom('[data-test-search-field]').isFocused();
+
+      // Escape from inside the input should dismiss the search sheet
+      // (its own handler) WITHOUT also closing the card beneath it.
+      await triggerKeyEvent('[data-test-search-field]', 'keydown', 'Escape');
+
+      assert.dom('[data-test-search-sheet]').hasClass('closed');
+      assert
+        .dom(`[data-test-stack-card="${testRealmURL}Person/fadhlan"]`)
+        .exists('Escape inside an input did not close the underlying card');
+    });
+
     test('duplicate card in a stack is not allowed', async function (assert) {
       await visitOperatorMode({
         stacks: [

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -561,6 +561,67 @@ module('Acceptance | interact submode tests', function (hooks) {
         .exists('Escape inside an input did not close the underlying card');
     });
 
+    test('Escape on an edit-mode item exits to view mode instead of closing', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: `${testRealmURL}Person/fadhlan`, format: 'edit' }]],
+      });
+
+      assert
+        .dom(
+          `[data-test-stack-card="${testRealmURL}Person/fadhlan"] [data-test-card-format="edit"]`,
+        )
+        .exists('card starts in edit mode');
+
+      await triggerKeyEvent(document.body, 'keydown', 'Escape');
+
+      assert
+        .dom(`[data-test-stack-card="${testRealmURL}Person/fadhlan"]`)
+        .exists('card is still open — Escape did not close it');
+      assert
+        .dom(
+          `[data-test-stack-card="${testRealmURL}Person/fadhlan"] [data-test-card-format="isolated"]`,
+        )
+        .exists('Escape flipped edit mode back to isolated');
+
+      // A second Escape (now in view mode) closes the item.
+      await triggerKeyEvent(document.body, 'keydown', 'Escape');
+      assert
+        .dom(`[data-test-stack-card="${testRealmURL}Person/fadhlan"]`)
+        .doesNotExist('a second Escape from view mode closes the item');
+    });
+
+    test('Ctrl+E (or Cmd+E) toggles edit mode on the most recently opened item', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: `${testRealmURL}Person/fadhlan`, format: 'isolated' }]],
+      });
+
+      assert
+        .dom(
+          `[data-test-stack-card="${testRealmURL}Person/fadhlan"] [data-test-card-format="isolated"]`,
+        )
+        .exists('card starts in isolated/view mode');
+
+      // Cmd+E on Mac…
+      await triggerKeyEvent(document.body, 'keydown', 'KeyE', {
+        metaKey: true,
+      });
+      assert
+        .dom(
+          `[data-test-stack-card="${testRealmURL}Person/fadhlan"] [data-test-card-format="edit"]`,
+        )
+        .exists('Cmd+E flipped the card into edit mode');
+
+      // …Ctrl+E on other platforms — and the toggle is symmetric.
+      await triggerKeyEvent(document.body, 'keydown', 'KeyE', {
+        ctrlKey: true,
+      });
+      assert
+        .dom(
+          `[data-test-stack-card="${testRealmURL}Person/fadhlan"] [data-test-card-format="isolated"]`,
+        )
+        .exists('Ctrl+E flipped the card back to isolated mode');
+    });
+
     test('duplicate card in a stack is not allowed', async function (assert) {
       await visitOperatorMode({
         stacks: [

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -21,8 +21,6 @@ import {
 } from '@cardstack/runtime-common';
 import type { Realm } from '@cardstack/runtime-common/realm';
 
-import type { StackItem } from '@cardstack/host/lib/stack-item';
-
 import type {
   IncrementalIndexEventContent,
   RealmEventContent,
@@ -518,9 +516,9 @@ module('Acceptance | interact submode tests', function (hooks) {
       // Make Pet/mango clickable in the search prompt as a recent card.
       let operatorModeStateService = getService('operator-mode-state-service');
       let recentCardsService = getService('recent-cards-service');
-      operatorModeStateService.state.stacks[0].map((item) =>
-        recentCardsService.add(item.id),
-      );
+      for (let item of operatorModeStateService.state.stacks[0]) {
+        recentCardsService.add(item.id);
+      }
       recentCardsService.add(`${testRealmURL}Pet/mango`);
 
       // Drop a card into a NEW LEFT-side stack: stack 0 becomes [Mango],
@@ -565,29 +563,27 @@ module('Acceptance | interact submode tests', function (hooks) {
     });
 
     test('Escape targets the card the user is editing, not the last-opened card', async function (assert) {
-      // Open A, then open B on top of A, then click edit on A. Even
-      // though B is the most-recently-opened card, the user's most
-      // recent interaction is "start editing A" — so Escape must flip
-      // A back to view, not close B.
+      // Open A in the left stack and B in the right stack — B is the
+      // most-recently-opened card. Then click edit on A. The user's
+      // most recent interaction is "start editing A", so Escape must
+      // flip A back to view, not close B.
       await visitOperatorMode({
         stacks: [
-          [
-            { id: `${testRealmURL}Person/fadhlan`, format: 'isolated' },
-            { id: `${testRealmURL}Pet/mango`, format: 'isolated' },
-          ],
+          [{ id: `${testRealmURL}Person/fadhlan`, format: 'isolated' }],
+          [{ id: `${testRealmURL}Pet/mango`, format: 'isolated' }],
         ],
       });
 
-      // Click edit on A (the buried, non-top card) via its header.
-      // The buried card's header acts as a button to dismiss cards
-      // above it; we instead toggle A directly via the service to
-      // simulate "user enters edit mode on A".
-      let operatorModeStateService = getService('operator-mode-state-service');
-      let stackA = operatorModeStateService.state.stacks[0]!;
-      let itemA = stackA.find(
-        (i: StackItem) => i.id === `${testRealmURL}Person/fadhlan`,
-      )!;
-      operatorModeStateService.setItemFormat(itemA, 'edit');
+      assert
+        .dom('[data-test-operator-mode-stack]')
+        .exists({ count: 2 }, 'two side-by-side stacks');
+
+      // Enter edit mode on A via the pencil button — this is the real
+      // user gesture, not a service-level shortcut. (The pencil only
+      // appears on top, non-buried cards, which both A and B are here.)
+      await click(
+        `[data-test-stack-card="${testRealmURL}Person/fadhlan"] [data-test-edit-button]`,
+      );
 
       assert
         .dom(
@@ -596,7 +592,7 @@ module('Acceptance | interact submode tests', function (hooks) {
         .exists('A is now in edit mode');
       assert
         .dom(`[data-test-stack-card="${testRealmURL}Pet/mango"]`)
-        .exists('B is still on the stack');
+        .exists('B is still on its stack');
 
       await triggerKeyEvent(document.body, 'keydown', 'Escape');
 

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -21,6 +21,8 @@ import {
 } from '@cardstack/runtime-common';
 import type { Realm } from '@cardstack/runtime-common/realm';
 
+import type { StackItem } from '@cardstack/host/lib/stack-item';
+
 import type {
   IncrementalIndexEventContent,
   RealmEventContent,
@@ -560,6 +562,52 @@ module('Acceptance | interact submode tests', function (hooks) {
       assert
         .dom(`[data-test-stack-card="${testRealmURL}Person/fadhlan"]`)
         .exists('Escape inside an input did not close the underlying card');
+    });
+
+    test('Escape targets the card the user is editing, not the last-opened card', async function (assert) {
+      // Open A, then open B on top of A, then click edit on A. Even
+      // though B is the most-recently-opened card, the user's most
+      // recent interaction is "start editing A" — so Escape must flip
+      // A back to view, not close B.
+      await visitOperatorMode({
+        stacks: [
+          [
+            { id: `${testRealmURL}Person/fadhlan`, format: 'isolated' },
+            { id: `${testRealmURL}Pet/mango`, format: 'isolated' },
+          ],
+        ],
+      });
+
+      // Click edit on A (the buried, non-top card) via its header.
+      // The buried card's header acts as a button to dismiss cards
+      // above it; we instead toggle A directly via the service to
+      // simulate "user enters edit mode on A".
+      let operatorModeStateService = getService('operator-mode-state-service');
+      let stackA = operatorModeStateService.state.stacks[0]!;
+      let itemA = stackA.find(
+        (i: StackItem) => i.id === `${testRealmURL}Person/fadhlan`,
+      )!;
+      operatorModeStateService.setItemFormat(itemA, 'edit');
+
+      assert
+        .dom(
+          `[data-test-stack-card="${testRealmURL}Person/fadhlan"] [data-test-card-format="edit"]`,
+        )
+        .exists('A is now in edit mode');
+      assert
+        .dom(`[data-test-stack-card="${testRealmURL}Pet/mango"]`)
+        .exists('B is still on the stack');
+
+      await triggerKeyEvent(document.body, 'keydown', 'Escape');
+
+      assert
+        .dom(`[data-test-stack-card="${testRealmURL}Pet/mango"]`)
+        .exists('B was NOT closed — Escape did not target the last-opened');
+      assert
+        .dom(
+          `[data-test-stack-card="${testRealmURL}Person/fadhlan"] [data-test-card-format="isolated"]`,
+        )
+        .exists('A flipped back to view mode — the actual recent interaction');
     });
 
     test('Escape on an edit-mode item exits to view mode instead of closing', async function (assert) {

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -3,6 +3,7 @@ import {
   click,
   fillIn,
   find,
+  focus,
   typeIn,
   triggerKeyEvent,
   settled,
@@ -588,6 +589,60 @@ module('Acceptance | interact submode tests', function (hooks) {
       assert
         .dom(`[data-test-stack-card="${testRealmURL}Person/fadhlan"]`)
         .doesNotExist('a second Escape from view mode closes the item');
+    });
+
+    test('Escape from a focused field in an edit-mode card blurs first, then exits edit, then closes', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: `${testRealmURL}Person/fadhlan`, format: 'edit' }]],
+      });
+
+      let fieldInput = '[data-test-field="firstName"] input';
+      await focus(fieldInput);
+      assert.dom(fieldInput).isFocused('field is focused at the start');
+
+      // Step 1: Escape from inside the field blurs it (edit mode preserved).
+      await triggerKeyEvent(fieldInput, 'keydown', 'Escape');
+      assert
+        .dom(fieldInput)
+        .isNotFocused('first Escape blurred the field but kept edit mode');
+      assert
+        .dom(
+          `[data-test-stack-card="${testRealmURL}Person/fadhlan"] [data-test-card-format="edit"]`,
+        )
+        .exists('card is still in edit mode after the field blur');
+
+      // Step 2: With nothing focused, Escape exits edit mode.
+      await triggerKeyEvent(document.body, 'keydown', 'Escape');
+      assert
+        .dom(
+          `[data-test-stack-card="${testRealmURL}Person/fadhlan"] [data-test-card-format="isolated"]`,
+        )
+        .exists('second Escape returned the card to view mode');
+
+      // Step 3: A third Escape closes the item.
+      await triggerKeyEvent(document.body, 'keydown', 'Escape');
+      assert
+        .dom(`[data-test-stack-card="${testRealmURL}Person/fadhlan"]`)
+        .doesNotExist('third Escape closed the item');
+    });
+
+    test('Ctrl+E toggles edit mode even while focus is in a field', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: `${testRealmURL}Person/fadhlan`, format: 'edit' }]],
+      });
+
+      let fieldInput = '[data-test-field="firstName"] input';
+      await focus(fieldInput);
+      assert.dom(fieldInput).isFocused();
+
+      // Ctrl+E from inside the input flips edit→isolated without
+      // requiring the user to click out first.
+      await triggerKeyEvent(fieldInput, 'keydown', 'KeyE', { ctrlKey: true });
+      assert
+        .dom(
+          `[data-test-stack-card="${testRealmURL}Person/fadhlan"] [data-test-card-format="isolated"]`,
+        )
+        .exists('Ctrl+E exited edit mode despite the field being focused');
     });
 
     test('Ctrl+E toggles edit mode on the most recently opened item', async function (assert) {


### PR DESCRIPTION
## Summary
- Adds a window-level keydown listener on `InteractSubmode` that closes the most recently opened stack item when the user presses **Escape**.
- Recency is tracked via a monotonic `openedAt` sequence on `StackItem`, preserved through `clone()`, so a left-neighbor drop (which lands the new card in stack 0, not the rightmost) still wins over the existing rightmost top.
- Defers to existing Escape semantics: skips when a modal is open (`body.has-modal`), when the delete-confirmation modal is rendered, when focus is in an `input`/`textarea`/`contenteditable`, or when another listener has already `preventDefault`-ed the event.

## Test plan
- [ ] Acceptance: top-of-stack closes on Escape (single stack, two items).
- [ ] Acceptance: Escape is ignored while the delete-confirmation modal is open.
- [ ] Acceptance: after a left-neighbor drop, Escape closes the leftmost (most recently opened) item, not the rightmost top.
- [ ] Acceptance: Escape inside the search-sheet input dismisses the sheet (existing behavior) and does **not** close the underlying card.
- [ ] Manual smoke in the browser: open a card, push a second card, Escape pops the second; opening AI Assistant or other side panels does not interfere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)