### PR TITLE
CS-10898: wrap unpublish/delete handler cleanup in a DB transaction

### DIFF
--- a/packages/realm-server/handlers/handle-delete-realm.ts
+++ b/packages/realm-server/handlers/handle-delete-realm.ts
@@ -1,6 +1,7 @@
 import type Koa from 'koa';
 import {
   asExpressions,
+  dbAdapterQuerier,
   ensureTrailingSlash,
   fetchRealmPermissions,
   getMatrixUsername,
@@ -141,33 +142,40 @@ export default function handleDeleteRealm({
         return;
       }
 
+      // Look up the published children up-front so the FS removals can
+      // happen before the lock is acquired. The list is only used to drive
+      // FS rms here — the DB cleanup inside the tx re-locates the rows by
+      // source_url, so a concurrent publish that arrives between this
+      // SELECT and the lock acquisition still gets cleaned up.
+      let publishedRealms = (await query(dbAdapter, [
+        `SELECT disk_id, url FROM realm_registry WHERE kind = 'published' AND source_url =`,
+        param(realmURL),
+      ])) as { disk_id: string; url: string }[];
+
       // Serialize concurrent writers for this source realm. Lock is on the
       // source URL — a concurrent unpublish of one of the associated
       // published realms uses a different lock key (its own published URL),
       // so in the rare case of overlap, the handlers interleave at the
       // per-URL granularity rather than globally. Pragmatic for this PR;
       // multi-instance hardening could tighten this later.
-      await withRealmWriteLock(dbAdapter, realmURL, async () => {
-        let publishedRealms = (await query(dbAdapter, [
-          `SELECT disk_id, url FROM realm_registry WHERE kind = 'published' AND source_url =`,
-          param(realmURL),
-        ])) as { disk_id: string; url: string }[];
-
+      //
+      // CS-10898: every DB write inside the callback runs on the lock-
+      // holder's pinned querier, so the entire cleanup (per-published
+      // permissions + DB artifacts, registry-row deletes, claimed-domains
+      // soft-delete, source permissions + DB artifacts) commits atomically
+      // or rolls back atomically. A failure halfway through no longer
+      // leaves the realm half-deleted.
+      await withRealmWriteLock(dbAdapter, realmURL, async (txQuerier) => {
         for (let publishedRealm of publishedRealms) {
-          let publishedRealmPath = join(
-            realmsRootPath,
-            PUBLISHED_DIRECTORY_NAME,
-            publishedRealm.disk_id,
+          await removeRealmPermissions(
+            dbAdapter,
+            new URL(publishedRealm.url),
+            txQuerier,
           );
-          try {
-            removeRealmFiles(publishedRealmPath);
-          } catch (error) {
-            Sentry.captureException(error);
-          }
-          await removeRealmPermissions(dbAdapter, new URL(publishedRealm.url));
           await removeRealmDatabaseArtifacts({
             dbAdapter,
             realmURL: publishedRealm.url,
+            querier: txQuerier,
           });
         }
 
@@ -175,13 +183,14 @@ export default function handleDeleteRealm({
         // row sourced from it; both DELETEs emit NOTIFY realm_registry
         // so the reconciler unmounts the affected realms on every
         // instance.
-        await deletePublishedRowsBySourceUrl(dbAdapter, realmURL);
-        await deleteRegistryRowByUrl(dbAdapter, realmURL);
+        await deletePublishedRowsBySourceUrl(dbAdapter, realmURL, txQuerier);
+        await deleteRegistryRowByUrl(dbAdapter, realmURL, txQuerier);
 
         let { nameExpressions, valueExpressions } = asExpressions({
           removed_at: Math.floor(Date.now() / 1000),
         });
-        await query(dbAdapter, [
+        let q = txQuerier ?? dbAdapterQuerier(dbAdapter);
+        await q([
           ...update(
             'claimed_domains_for_sites',
             nameExpressions,
@@ -192,13 +201,37 @@ export default function handleDeleteRealm({
           ` AND removed_at IS NULL`,
         ]);
 
-        removeRealmFiles(sourceRealmPath);
-        await removeRealmPermissions(dbAdapter, parsedRealmURL);
+        await removeRealmPermissions(dbAdapter, parsedRealmURL, txQuerier);
         await removeRealmDatabaseArtifacts({
           dbAdapter,
           realmURL,
+          querier: txQuerier,
         });
       });
+
+      // FS removals run after the DB transaction commits. If a removeRealmFiles
+      // throws here we capture it but don't re-throw — orphan disk files are
+      // recoverable by an out-of-band sweep, while a re-thrown error after a
+      // successful commit would surface as a 500 on a delete that has, in
+      // fact, succeeded from the DB's point of view (residual gap documented
+      // in CS-10898).
+      for (let publishedRealm of publishedRealms) {
+        let publishedRealmPath = join(
+          realmsRootPath,
+          PUBLISHED_DIRECTORY_NAME,
+          publishedRealm.disk_id,
+        );
+        try {
+          removeRealmFiles(publishedRealmPath);
+        } catch (error) {
+          Sentry.captureException(error);
+        }
+      }
+      try {
+        removeRealmFiles(sourceRealmPath);
+      } catch (error) {
+        Sentry.captureException(error);
+      }
 
       await setContextResponse(
         ctxt,

--- a/packages/realm-server/handlers/handle-delete-realm.ts
+++ b/packages/realm-server/handlers/handle-delete-realm.ts
@@ -142,15 +142,11 @@ export default function handleDeleteRealm({
         return;
       }
 
-      // Look up the published children up-front so the FS removals can
-      // happen before the lock is acquired. The list is only used to drive
-      // FS rms here — the DB cleanup inside the tx re-locates the rows by
-      // source_url, so a concurrent publish that arrives between this
-      // SELECT and the lock acquisition still gets cleaned up.
-      let publishedRealms = (await query(dbAdapter, [
-        `SELECT disk_id, url FROM realm_registry WHERE kind = 'published' AND source_url =`,
-        param(realmURL),
-      ])) as { disk_id: string; url: string }[];
+      // Captured inside the lock from `deletePublishedRowsBySourceUrl`'s
+      // RETURNING so the post-commit FS sweep matches the rows the tx
+      // actually deleted (no TOCTOU window between a pre-lock SELECT and
+      // the in-tx DELETE).
+      let publishedRealms: { url: string; disk_id: string }[] = [];
 
       // Serialize concurrent writers for this source realm. Lock is on the
       // source URL — a concurrent unpublish of one of the associated
@@ -160,12 +156,27 @@ export default function handleDeleteRealm({
       // multi-instance hardening could tighten this later.
       //
       // CS-10898: every DB write inside the callback runs on the lock-
-      // holder's pinned querier, so the entire cleanup (per-published
-      // permissions + DB artifacts, registry-row deletes, claimed-domains
+      // holder's pinned querier, so the entire cleanup (registry-row
+      // deletes, per-published permissions + DB artifacts, claimed-domains
       // soft-delete, source permissions + DB artifacts) commits atomically
       // or rolls back atomically. A failure halfway through no longer
       // leaves the realm half-deleted.
       await withRealmWriteLock(dbAdapter, realmURL, async (txQuerier) => {
+        // Delete the published rows first so the RETURNING set is the
+        // authoritative list of rows the tx will commit. Driving the
+        // per-published cleanup off this set (instead of a pre-lock
+        // SELECT) closes a TOCTOU race where a publish completing
+        // between SELECT and lock would have its registry row deleted
+        // here while its permissions + DB artifacts were never cleaned.
+        // Within the tx, ordering is invisible to other connections —
+        // the NOTIFY queues until COMMIT — so deleting before the
+        // per-row cleanup is safe.
+        publishedRealms = await deletePublishedRowsBySourceUrl(
+          dbAdapter,
+          realmURL,
+          txQuerier,
+        );
+
         for (let publishedRealm of publishedRealms) {
           await removeRealmPermissions(
             dbAdapter,
@@ -179,11 +190,7 @@ export default function handleDeleteRealm({
           });
         }
 
-        // Removes the source realm's registry row plus every published
-        // row sourced from it; both DELETEs emit NOTIFY realm_registry
-        // so the reconciler unmounts the affected realms on every
-        // instance.
-        await deletePublishedRowsBySourceUrl(dbAdapter, realmURL, txQuerier);
+        // Source realm's registry row.
         await deleteRegistryRowByUrl(dbAdapter, realmURL, txQuerier);
 
         let { nameExpressions, valueExpressions } = asExpressions({

--- a/packages/realm-server/handlers/handle-unpublish-realm.ts
+++ b/packages/realm-server/handlers/handle-unpublish-realm.ts
@@ -116,26 +116,47 @@ export default function handleUnpublishRealm({
       // NOTIFY realm_registry and unmount via the reconciler.
       let publishedRealm = await reconciler.lookupOrMount(publishedRealmURL);
 
-      // Serialize concurrent writers for this realm URL via the per-
-      // URL advisory lock, then drive tombstones via realm.deleteAll
-      // (bumps realm_version + marks every boxel_index entry as
-      // deleted, matching the legacy unpublish behavior), then do FS
-      // + DB cleanup. realms[] / virtualNetwork mutation stays in the
-      // reconciler's hands — it reacts to the registry DELETE +
-      // NOTIFY below.
-      await withRealmWriteLock(dbAdapter, publishedRealmURL, async () => {
-        if (publishedRealm) {
-          let allFilePaths = collectAllFilePaths(publishedRealmPath);
-          if (allFilePaths.length > 0) {
-            await publishedRealm.deleteAll(allFilePaths);
-          }
+      // Tombstone *before* the lock: realm.deleteAll enqueues an indexer
+      // job whose execution runs on a worker connection of its own, so it
+      // is not transactional with the lock-holder's DB cleanup either way.
+      // Doing it before the tx keeps the tombstones (which mark every
+      // boxel_index entry as deleted + bump realm_version) in place if
+      // the registry/permissions DELETEs fail — a retry of the same
+      // unpublish will succeed without re-tombstoning the same content.
+      if (publishedRealm) {
+        let allFilePaths = collectAllFilePaths(publishedRealmPath);
+        if (allFilePaths.length > 0) {
+          await publishedRealm.deleteAll(allFilePaths);
         }
-        removeRealmFiles(publishedRealmPath);
+      }
 
-        await deleteRegistryRowByUrl(dbAdapter, publishedRealmURL);
+      // Serialize concurrent writers for this realm URL via the per-
+      // URL advisory lock and group all DB cleanup into one transaction:
+      // CS-10898 routes the registry-row delete and the permissions
+      // delete through the lock-holder's pinned querier, so any failure
+      // mid-cleanup rolls back both DELETEs together. realms[] /
+      // virtualNetwork mutation stays in the reconciler's hands — it
+      // reacts to the registry DELETE + NOTIFY emitted below.
+      await withRealmWriteLock(
+        dbAdapter,
+        publishedRealmURL,
+        async (txQuerier) => {
+          await deleteRegistryRowByUrl(dbAdapter, publishedRealmURL, txQuerier);
+          await removeRealmPermissions(
+            dbAdapter,
+            new URL(publishedRealmURL),
+            txQuerier,
+          );
+        },
+      );
 
-        await removeRealmPermissions(dbAdapter, new URL(publishedRealmURL));
-      });
+      // FS removal happens after the DB transaction commits. If the rm
+      // fails, the realm's row + permissions are already gone and the
+      // user-visible state is "unpublished"; orphan files are
+      // recoverable by an out-of-band sweep (residual gap documented in
+      // CS-10898). Doing it inside the tx would risk the worse failure
+      // mode where we delete files but the registry row sticks around.
+      removeRealmFiles(publishedRealmPath);
 
       // Removing this derivative just changed the source realm's
       // `RealmInfo.lastPublishedAt` map (rows where `source_url =

--- a/packages/realm-server/handlers/realm-destruction-utils.ts
+++ b/packages/realm-server/handlers/realm-destruction-utils.ts
@@ -86,9 +86,12 @@ export async function removeRealmDatabaseArtifacts(args: {
 
   if (pendingJobs.length > 0) {
     let jobIdList: Expression[] = pendingJobs.map(({ id }) => [param(id)]);
+    // separatedByCommas/addExplicitParens overload resolution picks the wider
+    // CardExpression overload first, so we cast back to Expression for the
+    // Querier (which only accepts Expression).
     await q([
       `DELETE FROM job_reservations WHERE job_id IN`,
-      ...addExplicitParens(separatedByCommas(jobIdList)),
+      ...(addExplicitParens(separatedByCommas(jobIdList)) as Expression),
     ]);
   }
 

--- a/packages/realm-server/handlers/realm-destruction-utils.ts
+++ b/packages/realm-server/handlers/realm-destruction-utils.ts
@@ -1,8 +1,8 @@
-import type { DBAdapter } from '@cardstack/runtime-common';
+import type { DBAdapter, Querier } from '@cardstack/runtime-common';
 import {
   cancelRunningJobsInConcurrencyGroup,
+  dbAdapterQuerier,
   param,
-  query,
 } from '@cardstack/runtime-common';
 import { pathExistsSync, readdirSync, removeSync } from 'fs-extra';
 import { join, relative } from 'path';
@@ -66,55 +66,43 @@ export function removeRealmFiles(realmPath: string): void {
 export async function removeRealmDatabaseArtifacts(args: {
   dbAdapter: DBAdapter;
   realmURL: string;
+  querier?: Querier;
 }) {
-  let { dbAdapter, realmURL } = args;
-  await cancelRunningJobsInConcurrencyGroup(dbAdapter, `indexing:${realmURL}`);
+  let { dbAdapter, realmURL, querier } = args;
+  let q = querier ?? dbAdapterQuerier(dbAdapter);
+  await cancelRunningJobsInConcurrencyGroup(
+    dbAdapter,
+    `indexing:${realmURL}`,
+    querier,
+  );
 
-  let pendingJobs = (await query(dbAdapter, [
+  let pendingJobs = (await q([
     `SELECT id FROM jobs WHERE concurrency_group =`,
     param(`indexing:${realmURL}`),
     ` AND status = 'unfulfilled'`,
   ])) as { id: number }[];
 
   if (pendingJobs.length > 0) {
-    await query(dbAdapter, [
+    await q([
       `DELETE FROM job_reservations WHERE job_id IN (${pendingJobs
         .map(({ id }) => id)
         .join(', ')})`,
     ]);
   }
 
-  await query(dbAdapter, [
+  await q([
     `DELETE FROM jobs WHERE concurrency_group =`,
     param(`indexing:${realmURL}`),
     ` AND status = 'unfulfilled'`,
   ]);
-  await query(dbAdapter, [
-    `DELETE FROM modules WHERE resolved_realm_url =`,
-    param(realmURL),
-  ]);
-  await query(dbAdapter, [
+  await q([`DELETE FROM modules WHERE resolved_realm_url =`, param(realmURL)]);
+  await q([
     `DELETE FROM boxel_index_working WHERE realm_url =`,
     param(realmURL),
   ]);
-  await query(dbAdapter, [
-    `DELETE FROM boxel_index WHERE realm_url =`,
-    param(realmURL),
-  ]);
-  await query(dbAdapter, [
-    `DELETE FROM realm_meta WHERE realm_url =`,
-    param(realmURL),
-  ]);
-  await query(dbAdapter, [
-    `DELETE FROM realm_versions WHERE realm_url =`,
-    param(realmURL),
-  ]);
-  await query(dbAdapter, [
-    `DELETE FROM realm_file_meta WHERE realm_url =`,
-    param(realmURL),
-  ]);
-  await query(dbAdapter, [
-    `DELETE FROM realm_metadata WHERE url =`,
-    param(realmURL),
-  ]);
+  await q([`DELETE FROM boxel_index WHERE realm_url =`, param(realmURL)]);
+  await q([`DELETE FROM realm_meta WHERE realm_url =`, param(realmURL)]);
+  await q([`DELETE FROM realm_versions WHERE realm_url =`, param(realmURL)]);
+  await q([`DELETE FROM realm_file_meta WHERE realm_url =`, param(realmURL)]);
+  await q([`DELETE FROM realm_metadata WHERE url =`, param(realmURL)]);
 }

--- a/packages/realm-server/handlers/realm-destruction-utils.ts
+++ b/packages/realm-server/handlers/realm-destruction-utils.ts
@@ -1,8 +1,10 @@
-import type { DBAdapter, Querier } from '@cardstack/runtime-common';
+import type { DBAdapter, Expression, Querier } from '@cardstack/runtime-common';
 import {
+  addExplicitParens,
   cancelRunningJobsInConcurrencyGroup,
   dbAdapterQuerier,
   param,
+  separatedByCommas,
 } from '@cardstack/runtime-common';
 import { pathExistsSync, readdirSync, removeSync } from 'fs-extra';
 import { join, relative } from 'path';
@@ -73,7 +75,7 @@ export async function removeRealmDatabaseArtifacts(args: {
   await cancelRunningJobsInConcurrencyGroup(
     dbAdapter,
     `indexing:${realmURL}`,
-    querier,
+    q,
   );
 
   let pendingJobs = (await q([
@@ -83,10 +85,10 @@ export async function removeRealmDatabaseArtifacts(args: {
   ])) as { id: number }[];
 
   if (pendingJobs.length > 0) {
+    let jobIdList: Expression[] = pendingJobs.map(({ id }) => [param(id)]);
     await q([
-      `DELETE FROM job_reservations WHERE job_id IN (${pendingJobs
-        .map(({ id }) => id)
-        .join(', ')})`,
+      `DELETE FROM job_reservations WHERE job_id IN`,
+      ...addExplicitParens(separatedByCommas(jobIdList)),
     ]);
   }
 

--- a/packages/realm-server/lib/realm-advisory-locks.ts
+++ b/packages/realm-server/lib/realm-advisory-locks.ts
@@ -1,5 +1,10 @@
 import { createHash } from 'crypto';
-import { logger, param, type DBAdapter } from '@cardstack/runtime-common';
+import {
+  logger,
+  param,
+  type DBAdapter,
+  type Querier,
+} from '@cardstack/runtime-common';
 import type { PgAdapter } from '@cardstack/postgres';
 
 const log = logger('realm-server:advisory-locks');
@@ -36,29 +41,37 @@ export function hashRealmUrlForAdvisoryLock(url: string): string {
 // through in-memory caches on the realm-server) without acquiring it.
 // Read-heavy paths should never call this helper.
 //
-// Note on the enclosing transaction: `fn` runs inside BEGIN/COMMIT here
-// only so the advisory lock is correctly scoped. Queries that `fn` issues
-// through the shared `dbAdapter` (not the pinned `queryFn`) go via
-// separate pool connections and are NOT part of this transaction — that's
-// unchanged from the session-scoped version. The realm-server's mutation
-// handlers (Phase 1) are not yet transactional across FS + DB; making
-// them so is CS-10898's territory. The xact-lock pattern here buys correct
-// lock release without requiring the handler bodies themselves to be
-// transactional.
+// Note on the enclosing transaction: `fn` runs inside BEGIN/COMMIT here so
+// the advisory lock is correctly scoped, AND so any DELETEs `fn` runs via
+// the pinned `txQuerier` argument share that transaction's atomicity. CS-10898
+// (this PR) plumbed the pinned querier through the realm-destruction helpers
+// (`removeRealmDatabaseArtifacts`, `removeRealmPermissions`,
+// `deleteRegistryRowByUrl`, `deletePublishedRowsBySourceUrl`,
+// `cancelRunningJobsInConcurrencyGroup`); when callers pass `txQuerier` to
+// those helpers, all their writes commit or roll back together with the
+// advisory lock's own transaction. Queries `fn` issues through the shared
+// `dbAdapter` still go via separate pool connections and are NOT part of
+// this transaction — that's the pre-CS-10898 behavior preserved as the
+// default for callers that don't opt in.
 //
-// Pool-exhaustion caveat: the callback continues to perform DB work via
-// the shared `dbAdapter`, each call of which checks out its own pool
-// client. `withRealmWriteLock` pins one extra client for the lock-holder
-// transaction. Under N concurrent same-URL writers, N-1 block on the
-// advisory lock before doing anything — so this helper does not itself
-// amplify pool pressure. Under N concurrent different-URL writers, each
-// pins one client; if the pool ceiling is less than the realistic write
-// concurrency, callbacks that need additional pool clients could deadlock
-// waiting on the pool. The full fix is threading the pinned `queryFn`
-// through every helper so a single connection serves the whole critical
-// section; that's a larger refactor deferred alongside CS-10898. For
-// current scope (low realistic write concurrency, pool size >= concurrent
-// writers + headroom) this is acceptable.
+// In the SQLite branch (test environments only) `txQuerier` is `undefined`,
+// so helpers fall back to the shared `dbAdapter`. SQLite has no cross-
+// connection concurrency, so neither the lock nor the tx semantics matter
+// there.
+//
+// Pool-exhaustion caveat: when the callback opts into the pinned querier
+// for all of its DB work, only one client is checked out for the entire
+// critical section — both the lock and the destruction queries share that
+// connection. If the callback also issues queries through the shared
+// `dbAdapter` (e.g. existence-check SELECTs that don't need to be inside
+// the tx), each of those checks out an additional pool client briefly.
+// Under N concurrent same-URL writers, N-1 block on the advisory lock
+// before doing anything — so this helper does not itself amplify pool
+// pressure. Under N concurrent different-URL writers, each pins one
+// client; if the pool ceiling is less than realistic write concurrency,
+// callbacks that need additional pool clients could deadlock waiting on
+// the pool. For current scope (low realistic write concurrency, pool size
+// >= concurrent writers + headroom) this is acceptable.
 //
 // Deadlock note: callers should never acquire a second write lock for a
 // different URL while holding one — that's the only way a cycle could
@@ -66,14 +79,14 @@ export function hashRealmUrlForAdvisoryLock(url: string): string {
 export async function withRealmWriteLock<T>(
   dbAdapter: DBAdapter,
   realmUrl: string,
-  fn: () => Promise<T>,
+  fn: (txQuerier: Querier | undefined) => Promise<T>,
 ): Promise<T> {
   // Advisory locks are Postgres-specific. In test environments backed by
   // SQLite (no cross-connection concurrency to worry about anyway) we
   // short-circuit and run fn directly. The PgAdapter branch is the one
   // that does real work.
   if (dbAdapter.kind !== 'pg') {
-    return await fn();
+    return await fn(undefined);
   }
   const pg = dbAdapter as unknown as PgAdapter;
   const lockKey = hashRealmUrlForAdvisoryLock(realmUrl);
@@ -85,7 +98,7 @@ export async function withRealmWriteLock<T>(
         param(lockKey),
         `::bigint)`,
       ]);
-      const result = await fn();
+      const result = await fn(queryFn);
       await queryFn(['COMMIT']);
       return result;
     } catch (err: unknown) {

--- a/packages/realm-server/lib/realm-registry-writes.ts
+++ b/packages/realm-server/lib/realm-registry-writes.ts
@@ -127,18 +127,24 @@ export async function deleteRegistryRowByUrl(
 // even though the schema's CHECK constraint already guarantees that only
 // published rows have non-null source_url — stating the contract in the SQL
 // matches the helper's name and survives any future schema changes.
+//
+// Returns the rows that were actually deleted so the caller can drive
+// per-published cleanup (permissions, DB artifacts, FS) against the
+// authoritative set the tx committed — closes the TOCTOU window where a
+// pre-lock SELECT could miss a row inserted before the tx began.
 export async function deletePublishedRowsBySourceUrl(
   dbAdapter: DBAdapter,
   sourceUrl: string,
   querier?: Querier,
-): Promise<void> {
+): Promise<{ url: string; disk_id: string }[]> {
   let q = querier ?? dbAdapterQuerier(dbAdapter);
-  await q([
+  let deleted = (await q([
     `DELETE FROM realm_registry WHERE source_url =`,
     param(sourceUrl),
-    ` AND kind = 'published'`,
-  ]);
+    ` AND kind = 'published' RETURNING url, disk_id`,
+  ])) as { url: string; disk_id: string }[];
   // Single NOTIFY keyed on the source URL. Reconcilers will re-read and see
   // all deletes; the payload is a hint, not a precise per-row signal.
   await notifyRegistry(q, 'delete', sourceUrl);
+  return deleted;
 }

--- a/packages/realm-server/lib/realm-registry-writes.ts
+++ b/packages/realm-server/lib/realm-registry-writes.ts
@@ -1,5 +1,5 @@
-import type { DBAdapter } from '@cardstack/runtime-common';
-import { logger, param, query } from '@cardstack/runtime-common';
+import type { DBAdapter, Querier } from '@cardstack/runtime-common';
+import { dbAdapterQuerier, logger, param } from '@cardstack/runtime-common';
 
 // Helpers that the realm-mutating handlers (publish/unpublish/delete/create)
 // use to write `realm_registry`. Phase 4 PR 2 (CS-10897) made the registry the
@@ -26,12 +26,12 @@ const REGISTRY_CHANNEL = 'realm_registry';
 const log = logger('realm-server:registry-writes');
 
 async function notifyRegistry(
-  dbAdapter: DBAdapter,
+  querier: Querier,
   op: 'upsert' | 'delete',
   url: string,
 ): Promise<void> {
   try {
-    await query(dbAdapter, [
+    await querier([
       `SELECT pg_notify(`,
       param(REGISTRY_CHANNEL),
       `, `,
@@ -59,8 +59,10 @@ export async function upsertPublishedRealmInRegistry(
     sourceRealmURL: string;
     lastPublishedAt: number;
   },
+  querier?: Querier,
 ): Promise<void> {
-  await query(dbAdapter, [
+  let q = querier ?? dbAdapterQuerier(dbAdapter);
+  await q([
     `INSERT INTO realm_registry (url, kind, disk_id, owner_username, source_url, last_published_at, pinned) VALUES (`,
     param(args.publishedRealmURL),
     `, 'published', `,
@@ -74,7 +76,7 @@ export async function upsertPublishedRealmInRegistry(
     `, false`,
     `) ON CONFLICT (url) DO UPDATE SET last_published_at = EXCLUDED.last_published_at, updated_at = now() WHERE realm_registry.kind = 'published'`,
   ]);
-  await notifyRegistry(dbAdapter, 'upsert', args.publishedRealmURL);
+  await notifyRegistry(q, 'upsert', args.publishedRealmURL);
 }
 
 // Insert a source realm row. Called from server.ts:createRealm after
@@ -86,8 +88,10 @@ export async function insertSourceRealmInRegistry(
     diskId: string;
     ownerUsername: string;
   },
+  querier?: Querier,
 ): Promise<void> {
-  await query(dbAdapter, [
+  let q = querier ?? dbAdapterQuerier(dbAdapter);
+  await q([
     `INSERT INTO realm_registry (url, kind, disk_id, owner_username, pinned) VALUES (`,
     param(args.url),
     `, 'source', `,
@@ -97,7 +101,7 @@ export async function insertSourceRealmInRegistry(
     `, false`,
     `) ON CONFLICT (url) DO NOTHING`,
   ]);
-  await notifyRegistry(dbAdapter, 'upsert', args.url);
+  await notifyRegistry(q, 'upsert', args.url);
 }
 
 // Delete a single row by url. Used by handle-unpublish-realm (published row)
@@ -106,13 +110,15 @@ export async function insertSourceRealmInRegistry(
 export async function deleteRegistryRowByUrl(
   dbAdapter: DBAdapter,
   url: string,
+  querier?: Querier,
 ): Promise<void> {
-  await query(dbAdapter, [
+  let q = querier ?? dbAdapterQuerier(dbAdapter);
+  await q([
     `DELETE FROM realm_registry WHERE url =`,
     param(url),
     ` AND kind <> 'bootstrap'`,
   ]);
-  await notifyRegistry(dbAdapter, 'delete', url);
+  await notifyRegistry(q, 'delete', url);
 }
 
 // Delete every kind='published' row whose source_url matches the given source
@@ -124,13 +130,15 @@ export async function deleteRegistryRowByUrl(
 export async function deletePublishedRowsBySourceUrl(
   dbAdapter: DBAdapter,
   sourceUrl: string,
+  querier?: Querier,
 ): Promise<void> {
-  await query(dbAdapter, [
+  let q = querier ?? dbAdapterQuerier(dbAdapter);
+  await q([
     `DELETE FROM realm_registry WHERE source_url =`,
     param(sourceUrl),
     ` AND kind = 'published'`,
   ]);
   // Single NOTIFY keyed on the source URL. Reconcilers will re-read and see
   // all deletes; the payload is a hint, not a precise per-row signal.
-  await notifyRegistry(dbAdapter, 'delete', sourceUrl);
+  await notifyRegistry(q, 'delete', sourceUrl);
 }

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -190,6 +190,7 @@ import './run-command-task-test';
 import './realm-endpoints-test';
 import './realm-endpoints/dependencies-test';
 import './realm-advisory-locks-test';
+import './realm-cleanup-transaction-test';
 import './realm-registry-backfill-test';
 import './realm-registry-reconciler-test';
 import './realm-registry-writes-test';

--- a/packages/realm-server/tests/realm-cleanup-transaction-test.ts
+++ b/packages/realm-server/tests/realm-cleanup-transaction-test.ts
@@ -3,6 +3,7 @@ import { basename } from 'path';
 import type { PgAdapter } from '@cardstack/postgres';
 import {
   insertPermissions,
+  param,
   permissionsExist,
   query,
   removeRealmPermissions,
@@ -45,7 +46,8 @@ module(basename(__filename), function () {
 
     async function registryRowExists(url: string): Promise<boolean> {
       const rows = (await query(dbAdapter, [
-        `SELECT 1 AS found FROM realm_registry WHERE url = '${url.replace(/'/g, "''")}'`,
+        `SELECT 1 AS found FROM realm_registry WHERE url =`,
+        param(url),
       ])) as { found: number }[];
       return rows.length > 0;
     }

--- a/packages/realm-server/tests/realm-cleanup-transaction-test.ts
+++ b/packages/realm-server/tests/realm-cleanup-transaction-test.ts
@@ -1,0 +1,130 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import type { PgAdapter } from '@cardstack/postgres';
+import {
+  insertPermissions,
+  permissionsExist,
+  query,
+  removeRealmPermissions,
+} from '@cardstack/runtime-common';
+import { setupDB } from './helpers';
+import {
+  deleteRegistryRowByUrl,
+  insertSourceRealmInRegistry,
+} from '../lib/realm-registry-writes';
+import { withRealmWriteLock } from '../lib/realm-advisory-locks';
+
+// CS-10898 regression test: an injected error after a registry-row delete
+// (but before the lock-holder transaction commits) must roll back BOTH the
+// registry-row delete AND the permissions delete. Pre-CS-10898 the handler
+// ran each helper through the shared dbAdapter, so each DELETE committed in
+// its own auto-tx and a mid-cleanup throw left the realm half-deleted.
+module(basename(__filename), function () {
+  module('CS-10898: realm cleanup transactionality', function (hooks) {
+    let dbAdapter: PgAdapter;
+    setupDB(hooks, {
+      beforeEach: async (adapter) => {
+        dbAdapter = adapter;
+      },
+    });
+
+    async function seedSourceRealm(
+      realmURL: string,
+      ownerUsername: string,
+      diskId: string,
+    ) {
+      await insertSourceRealmInRegistry(dbAdapter, {
+        url: realmURL,
+        diskId,
+        ownerUsername,
+      });
+      await insertPermissions(dbAdapter, new URL(realmURL), {
+        [ownerUsername]: ['read', 'write', 'realm-owner'],
+      });
+    }
+
+    async function registryRowExists(url: string): Promise<boolean> {
+      const rows = (await query(dbAdapter, [
+        `SELECT 1 AS found FROM realm_registry WHERE url = '${url.replace(/'/g, "''")}'`,
+      ])) as { found: number }[];
+      return rows.length > 0;
+    }
+
+    test('a throw after deleteRegistryRowByUrl rolls the DELETE back', async function (assert) {
+      const realmURL = 'http://localhost:4201/cs10898/rollback/';
+      await seedSourceRealm(realmURL, '@cs10898:localhost', 'disk-rollback');
+
+      // Sanity: pre-conditions hold.
+      assert.true(await registryRowExists(realmURL), 'registry row seeded');
+      assert.true(
+        await permissionsExist(dbAdapter, new URL(realmURL)),
+        'permissions seeded',
+      );
+
+      await assert.rejects(
+        withRealmWriteLock(dbAdapter, realmURL, async (txQuerier) => {
+          // First DELETE — runs on the lock-holder's pinned querier so it
+          // joins the BEGIN/COMMIT tx instead of auto-committing.
+          await deleteRegistryRowByUrl(dbAdapter, realmURL, txQuerier);
+          // Inject a mid-cleanup failure. Pre-CS-10898 the row above
+          // would have committed in its own auto-tx and would still be
+          // gone after the rollback below.
+          throw new Error('injected mid-cleanup failure');
+        }),
+        /injected mid-cleanup failure/,
+      );
+
+      assert.true(
+        await registryRowExists(realmURL),
+        'registry row restored after rollback',
+      );
+      assert.true(
+        await permissionsExist(dbAdapter, new URL(realmURL)),
+        'permissions still present',
+      );
+    });
+
+    test('a throw between two cleanup DELETEs rolls back BOTH', async function (assert) {
+      const realmURL = 'http://localhost:4201/cs10898/both/';
+      await seedSourceRealm(realmURL, '@cs10898both:localhost', 'disk-both');
+
+      await assert.rejects(
+        withRealmWriteLock(dbAdapter, realmURL, async (txQuerier) => {
+          await deleteRegistryRowByUrl(dbAdapter, realmURL, txQuerier);
+          await removeRealmPermissions(dbAdapter, new URL(realmURL), txQuerier);
+          // Throw after both DELETEs — both should roll back atomically.
+          throw new Error('injected post-cleanup failure');
+        }),
+        /injected post-cleanup failure/,
+      );
+
+      assert.true(
+        await registryRowExists(realmURL),
+        'registry row restored after rollback',
+      );
+      assert.true(
+        await permissionsExist(dbAdapter, new URL(realmURL)),
+        'permissions restored after rollback',
+      );
+    });
+
+    test('the happy path commits all cleanup DELETEs together', async function (assert) {
+      const realmURL = 'http://localhost:4201/cs10898/commit/';
+      await seedSourceRealm(realmURL, '@cs10898ok:localhost', 'disk-commit');
+
+      await withRealmWriteLock(dbAdapter, realmURL, async (txQuerier) => {
+        await deleteRegistryRowByUrl(dbAdapter, realmURL, txQuerier);
+        await removeRealmPermissions(dbAdapter, new URL(realmURL), txQuerier);
+      });
+
+      assert.false(
+        await registryRowExists(realmURL),
+        'registry row gone after successful commit',
+      );
+      assert.false(
+        await permissionsExist(dbAdapter, new URL(realmURL)),
+        'permissions gone after successful commit',
+      );
+    });
+  });
+});

--- a/packages/runtime-common/db-queries/realm-permission-queries.ts
+++ b/packages/runtime-common/db-queries/realm-permission-queries.ts
@@ -1,7 +1,14 @@
 import type { DBAdapter } from '../db';
 import type { RealmAction } from '../index';
 import type { RealmPermissions } from '../index';
-import { query, asExpressions, param, upsert } from '../expression';
+import {
+  asExpressions,
+  dbAdapterQuerier,
+  param,
+  query,
+  type Querier,
+  upsert,
+} from '../expression';
 import { getMatrixUsername } from '../matrix-client';
 
 async function insertPermission(
@@ -53,8 +60,10 @@ async function removePermissions(
 export async function removeRealmPermissions(
   dbAdapter: DBAdapter,
   realmURL: URL,
+  querier?: Querier,
 ) {
-  await query(dbAdapter, [
+  let q = querier ?? dbAdapterQuerier(dbAdapter);
+  await q([
     'DELETE from realm_user_permissions WHERE realm_url =',
     param(realmURL.href),
   ]);

--- a/packages/runtime-common/expression.ts
+++ b/packages/runtime-common/expression.ts
@@ -384,6 +384,20 @@ export function update(
 
 export const tableValuedFunctionsPlaceholder = '__TABLE_VALUED_FUNCTIONS__';
 
+// A connection-pinned query function. PgAdapter.withConnection hands one of
+// these to its callback; it executes against a checked-out client so its
+// queries share that connection (and therefore the connection's transaction
+// state) with whatever else is running inside the same withConnection scope.
+//
+// CS-10898 plumbs an optional `Querier` through the realm-destruction helpers
+// so a transaction wrapper above them can run their DELETEs on a single
+// pinned connection. Helpers default to the shared dbAdapter when no Querier
+// is provided, which preserves their pre-existing semantics for callers that
+// don't need transactional grouping.
+export type Querier = (
+  expression: Expression,
+) => Promise<Record<string, PgPrimitive>[]>;
+
 export async function query(
   dbAdapter: DBAdapter,
   query: Expression,
@@ -394,6 +408,14 @@ export async function query(
     coerceTypes,
     bind: sql.values,
   });
+}
+
+// Build a Querier that runs against the shared `dbAdapter` (i.e. checks out a
+// fresh pool client per call). Helpers use this as the fallback when no
+// pinned Querier is passed in.
+export function dbAdapterQuerier(dbAdapter: DBAdapter): Querier {
+  return (expression: Expression) =>
+    query(dbAdapter, expression) as Promise<Record<string, PgPrimitive>[]>;
 }
 
 export function expressionToSql(

--- a/packages/runtime-common/job-utils.ts
+++ b/packages/runtime-common/job-utils.ts
@@ -1,11 +1,13 @@
 import type { DBAdapter } from './db';
 import {
+  dbAdapterQuerier,
   dbExpression,
   param,
   query,
   separatedByCommas,
   type Expression,
   type PgPrimitive,
+  type Querier,
 } from './expression';
 
 export const userInitiatedJobCancellationResult = Object.freeze({
@@ -17,8 +19,10 @@ export async function forceCancelJobById(
   dbAdapter: DBAdapter,
   jobId: string,
   result: PgPrimitive = userInitiatedJobCancellationResult,
+  querier?: Querier,
 ): Promise<void> {
-  await query(dbAdapter, [
+  let q = querier ?? dbAdapterQuerier(dbAdapter);
+  await q([
     `UPDATE jobs SET`,
     ...separatedByCommas([
       [`result =`, param(result)],
@@ -34,7 +38,7 @@ export async function forceCancelJobById(
     param(jobId),
   ] as Expression);
 
-  await query(dbAdapter, [
+  await q([
     `UPDATE job_reservations SET`,
     dbExpression({
       pg: `completed_at = NOW()`,
@@ -46,7 +50,7 @@ export async function forceCancelJobById(
   ] as Expression);
 
   if (dbAdapter.kind === 'pg') {
-    await query(dbAdapter, [`NOTIFY jobs_finished`] as Expression);
+    await q([`NOTIFY jobs_finished`] as Expression);
   }
 }
 
@@ -65,8 +69,10 @@ export async function findJobIdForReservationId(
 export async function findRunningJobIdsForConcurrencyGroup(
   dbAdapter: DBAdapter,
   concurrencyGroup: string,
+  querier?: Querier,
 ): Promise<string[]> {
-  let rows = (await query(dbAdapter, [
+  let q = querier ?? dbAdapterQuerier(dbAdapter);
+  let rows = (await q([
     `SELECT DISTINCT j.id FROM jobs j`,
     `INNER JOIN job_reservations jr ON jr.job_id = j.id`,
     `WHERE j.concurrency_group =`,
@@ -86,13 +92,20 @@ export async function findRunningJobIdsForConcurrencyGroup(
 export async function cancelRunningJobsInConcurrencyGroup(
   dbAdapter: DBAdapter,
   concurrencyGroup: string,
+  querier?: Querier,
 ): Promise<string[]> {
   let runningJobIds = await findRunningJobIdsForConcurrencyGroup(
     dbAdapter,
     concurrencyGroup,
+    querier,
   );
   for (let jobId of runningJobIds) {
-    await forceCancelJobById(dbAdapter, jobId);
+    await forceCancelJobById(
+      dbAdapter,
+      jobId,
+      userInitiatedJobCancellationResult,
+      querier,
+    );
   }
   return runningJobIds;
 }


### PR DESCRIPTION
## Summary

- **Plumbs an optional pinned `Querier` through every realm-cleanup helper** (`deleteRegistryRowByUrl`, `deletePublishedRowsBySourceUrl`, `removeRealmPermissions`, `removeRealmDatabaseArtifacts`, `cancelRunningJobsInConcurrencyGroup`, `findRunningJobIdsForConcurrencyGroup`, `forceCancelJobById`, plus the registry upsert/insert/notify pair). When a caller passes a pinned querier, the helper runs all its writes on that connection.
- **Extends `withRealmWriteLock`** to pass its BEGIN/COMMIT-scoped `queryFn` into the callback (still backward-compatible — TS lets existing zero-arg callbacks bind).
- **Updates `handle-unpublish-realm.ts`** so the registry-row delete + permissions delete both run on the lock-holder's pinned querier — they commit or roll back as one transaction. Tombstoning (queue-based, runs on a worker connection of its own) moves before the lock; FS rm moves after the commit.
- **Updates `handle-delete-realm.ts`** so all DB cleanup (per-published permissions + DB artifacts, source-row deletes, claimed-domains soft-delete, source permissions + DB artifacts) runs inside one tx. FS rms move after commit and tolerate failure (Sentry capture, no rethrow).
- **Adds `tests/realm-cleanup-transaction-test.ts`** — three regression tests:
  1. throw after `deleteRegistryRowByUrl` restores the row;
  2. throw between two cleanup DELETEs rolls back both;
  3. happy path commits both.

### Why

Pre-CS-10898 each cleanup helper checked out its own pool client, so each DELETE auto-committed in isolation. A failure mid-cleanup left the realm half-deleted (e.g. permissions gone, registry row still present) with no recovery short of manual surgery.

### Residual gap

FS rm runs **after** the DB tx commits. If FS rm fails, orphan files remain on disk — recoverable by an out-of-band sweep. Doing FS rm inside the tx would risk the worse failure mode where files are gone but the registry row sticks around. Tombstoning is queue-based (worker connection), so it can't be transactionally grouped with the handler's DB writes regardless — that's the same constraint that drove CS-10899's revised recommendation.

## Test plan

- [x] `realm-cleanup-transaction-test.ts` — 3 / 3 pass
- [x] `realm-advisory-locks-test.ts` — 4 / 4 pass (no regression in the lock-only behavior)
- [x] `realm-registry-writes-test.ts` — 11 / 11 pass (helpers still work via the no-querier fallback)
- [x] `--filter "POST /_unpublish-realm"` — 5 / 5 pass
- [x] `delete-realm-test.ts` — 3 / 4 pass (the 4th hits a pre-existing 60s timeout when realm-creation alone takes ~38s; passes when run alone)
- [x] `pnpm exec tsc --noEmit` — only pre-existing errors (missing `https://cardstack.com/base/*` declarations), none in changed files
- [x] `pnpm exec eslint` on every changed file — clean
- [ ] Full integration run gated on Matrix/Synapse availability (requires `services-for-matrix-tests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)