### PR TITLE
observability: scrape dev synapse via local Prometheus

### DIFF
--- a/packages/matrix/docker/synapse/dev/homeserver.yaml
+++ b/packages/matrix/docker/synapse/dev/homeserver.yaml
@@ -11,6 +11,15 @@ listeners:
     resources:
       - names: [client, federation]
         compress: false
+  # Prometheus metrics listener — scraped by the local observability stack
+  # (packages/observability/prometheus/prometheus.yml). Only configured for
+  # the dev template because tests spawn many synapse containers and don't
+  # need metrics; production parity is a separate ECS-side decision.
+  - port: 9001
+    bind_addresses: ["::"]
+    type: metrics
+
+enable_metrics: true
 
 database:
   name: "sqlite3"

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -35,12 +35,19 @@ grafanactl/
 provisioning/          # mounted into Grafana at /etc/grafana/provisioning/
   datasources/         # data sources (Loki, Postgres, CloudWatch, Prometheus)
   alerting/            # alert rule groups, contact points, notification policies
+  local-only/          # local-dev overrides — bind-mounted file-by-file over
+                       # `datasources/`. apply-datasources.sh ignores this dir.
 alloy/
   config.alloy         # local log scraper config — discovers Docker containers
                        # and ships their stdout into Loki
 loki/
   config.yaml          # local Loki config (single-node, filesystem, accepts
                        # historical Docker logs)
+prometheus/
+  prometheus.yml       # local Prometheus config — scrapes the dev synapse
+                       # container's /metrics endpoint so the vendored Synapse
+                       # dashboard works locally. Staging/prod use AMP via
+                       # sigV4 and ignore this service.
 scripts/
   apply.sh             # ./scripts/apply.sh --env <local|staging|production>
   apply-datasources.sh # internal — pushes provisioning/datasources/* via HTTP API
@@ -55,6 +62,7 @@ scripts/
 templates/
   env-vars.env.example
 docker-compose.yml     # local Grafana 12.4.3 + Loki 3.4.4 + Alloy 1.10.0
+                       #               + Prometheus 3.0.0 (scrapes synapse)
 ```
 
 ## Local workflow
@@ -72,11 +80,18 @@ brew install --formula grafanactl
 #   sudo install -m 0755 /tmp/grafanactl /usr/local/bin/grafanactl
 # (swap `Linux_x86_64` for `Linux_arm64` on aarch64.)
 
-# Bring up local Grafana + Loki + Alloy (log scraper)
+# Bring up local Grafana + Loki + Alloy (log scraper) + Prometheus
 docker compose up -d
-# Grafana: http://localhost:3001  (admin / admin)
-# Loki:    http://localhost:3100
-# Alloy:   http://localhost:12345  (target / pipeline debug UI)
+# Grafana:    http://localhost:3001    (admin / admin)
+# Loki:       http://localhost:3100
+# Alloy:      http://localhost:12345   (target / pipeline debug UI)
+# Prometheus: http://localhost:9090    (Synapse scrape targets)
+#
+# The Prometheus container joins the `boxel` Docker network so it can
+# reach `boxel-synapse:9001`. That network is created as a side-effect
+# of `mise run start-synapse`. If you bring up the observability stack
+# BEFORE starting synapse for the first time, run
+# `docker network create boxel` first.
 
 # Verify connectivity
 ./scripts/check.sh --env local

--- a/packages/observability/docker-compose.yml
+++ b/packages/observability/docker-compose.yml
@@ -21,6 +21,14 @@ services:
       # Data sources go here because grafanactl does not manage data sources.
       - ./provisioning/datasources:/etc/grafana/provisioning/datasources:ro
       - ./provisioning/alerting:/etc/grafana/provisioning/alerting:ro
+      # Local-only override of the synapse-prometheus datasource — points
+      # at the local Prometheus container instead of AMP. The single-file
+      # bind below is layered ON TOP of the directory mount above, masking
+      # provisioning/datasources/synapse-prometheus.yaml inside the
+      # container only. apply-datasources.sh (staging/prod) iterates the
+      # committed provisioning/datasources/ tree only and never sees this
+      # override. See provisioning/local-only/synapse-prometheus.yaml.
+      - ./provisioning/local-only/synapse-prometheus.yaml:/etc/grafana/provisioning/datasources/synapse-prometheus.yaml:ro
       # Dashboards arrive via grafanactl resources push (Phase 3 / CS-10922).
       # Local file-based dashboard provisioning is also possible — uncomment
       # the next line if a dev wants dashboards baked into the container.
@@ -113,6 +121,39 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  # Local Prometheus — scrapes the dev Synapse container's `/metrics`
+  # endpoint so the vendored Synapse dashboard works without an AMP
+  # workspace. Joined to the `boxel` Docker network (created by
+  # `mise run start-synapse` / packages/matrix/docker/synapse/index.ts)
+  # so it can resolve `boxel-synapse:9001` directly. Staging and
+  # production scrape via AMP and ignore this service entirely.
+  prometheus:
+    image: prom/prometheus:v3.0.0
+    ports:
+      # Exposed for ad-hoc curl/inspection from the host. Grafana itself
+      # reaches Prometheus via the docker network at `prometheus:9090`.
+      - "127.0.0.1:9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    networks:
+      - default
+      - boxel
+    restart: unless-stopped
+
+networks:
+  default:
+  # The synapse dev container runs on the `boxel` Docker network (created
+  # by packages/matrix/docker/synapse/index.ts). Marked external so this
+  # compose project doesn't try to manage its lifecycle. If you bring up
+  # the observability stack BEFORE starting synapse, run
+  # `docker network create boxel` first — or just `mise run start-synapse`,
+  # which creates the network as a side-effect.
+  boxel:
+    name: boxel
+    external: true
+
 volumes:
   grafana_data:
   loki_data:
+  prometheus_data:

--- a/packages/observability/prometheus/prometheus.yml
+++ b/packages/observability/prometheus/prometheus.yml
@@ -16,9 +16,9 @@ global:
 scrape_configs:
   - job_name: synapse
     static_configs:
-      - targets: ['boxel-synapse:9001']
+      - targets: ["boxel-synapse:9001"]
         labels:
           # Match what `synapse-prometheus` AMP returns in staging/prod so
           # the dashboard's metric labels are consistent across envs.
-          instance: 'boxel-synapse'
-          job: 'synapse'
+          instance: "boxel-synapse"
+          job: "synapse"

--- a/packages/observability/prometheus/prometheus.yml
+++ b/packages/observability/prometheus/prometheus.yml
@@ -1,0 +1,24 @@
+# Local Prometheus config — scrapes the dev Synapse container's metrics
+# listener so the vendored Synapse dashboard
+# (grafanactl/resources/dashboards/boxel-status/synapse.json) lights up
+# without an AMP workspace. Staging and production Synapses post to AMP
+# directly; this file is local-only.
+#
+# Synapse exposes its metrics on container port 9001 (see
+# packages/matrix/docker/synapse/dev/homeserver.yaml). This Prometheus
+# joins the `boxel` Docker network where the synapse container also lives,
+# so the scrape target resolves via Docker DNS as `boxel-synapse:9001` —
+# no host port mapping needed.
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+
+scrape_configs:
+  - job_name: synapse
+    static_configs:
+      - targets: ['boxel-synapse:9001']
+        labels:
+          # Match what `synapse-prometheus` AMP returns in staging/prod so
+          # the dashboard's metric labels are consistent across envs.
+          instance: 'boxel-synapse'
+          job: 'synapse'

--- a/packages/observability/provisioning/local-only/synapse-prometheus.yaml
+++ b/packages/observability/provisioning/local-only/synapse-prometheus.yaml
@@ -1,0 +1,31 @@
+# LOCAL ONLY — bind-mounted into the Grafana container at
+# /etc/grafana/provisioning/datasources/synapse-prometheus.yaml by
+# observability/docker-compose.yml, masking the canonical AMP-shaped file
+# in provisioning/datasources/synapse-prometheus.yaml.
+#
+# Why not edit the canonical file?
+#   - The canonical file targets AWS Managed Prometheus (AMP) via sigV4
+#     and is push-applied to staging/production by apply-datasources.sh.
+#     Templating the AMP/local switch through env vars is awkward
+#     (sigV4Auth is bool-typed and Grafana's provisioning loader has no
+#     ${VAR:-default} syntax) — a single-file bind-mount override at the
+#     local mount point is cleaner and keeps the staging/production code
+#     path untouched.
+#   - apply-datasources.sh only iterates provisioning/datasources/*.yaml,
+#     so this directory is invisible to the staging/production push.
+apiVersion: 1
+datasources:
+  - name: synapse-prometheus
+    # Same UID as the canonical datasource so the vendored Synapse
+    # dashboard (boxel-status/synapse.json, datasource uid bes7ustjf8w74b)
+    # binds to it without modification.
+    uid: bes7ustjf8w74b
+    type: prometheus
+    access: proxy
+    # Local Prometheus container, reachable from Grafana on the
+    # observability docker-compose network.
+    url: http://prometheus:9090
+    isDefault: false
+    editable: false
+    jsonData:
+      httpMethod: POST


### PR DESCRIPTION
## Summary

The vendored Synapse dashboard (`boxel-status/synapse.json`) targets the `synapse-prometheus` datasource, which today is AMP-only via sigV4 — so the dashboard always shows \"No data\" against local Grafana. This PR wires up a local Prometheus container that scrapes the dev Synapse, so operators can develop against the Synapse dashboard without a hosted Grafana.

Touches one file outside `packages/observability/`: `packages/matrix/docker/synapse/dev/homeserver.yaml` gains a `type: metrics` listener on port 9001 + `enable_metrics: true`. Test templates are untouched.

## Touch list

- `packages/matrix/docker/synapse/dev/homeserver.yaml` — metrics listener
- `packages/observability/docker-compose.yml` — adds Prometheus 3.0.0 service joined to the external `boxel` Docker network (where `boxel-synapse` already lives), plus a single-file bind-mount that overlays the local-only synapse-prometheus datasource on top of the canonical AMP-shaped one
- `packages/observability/prometheus/prometheus.yml` — scrape config (NEW dir)
- `packages/observability/provisioning/local-only/synapse-prometheus.yaml` — local datasource override; comments explain why a bind-mount override beat env-var templating (sigV4Auth is bool-typed and Grafana's provisioning loader has no `\${VAR:-default}` syntax)
- `packages/observability/README.md` — layout + bring-up notes

apply-datasources.sh is unchanged: it only iterates `provisioning/datasources/*.yaml`, so the local override directory is invisible to staging/production.

## Bring-up gotcha

If you `docker compose up` the observability stack BEFORE starting synapse, the external `boxel` Docker network won't exist and the Prometheus container fails to attach. Run `docker network create boxel` first, or `mise run start-synapse` (which creates the network as a side-effect).

## Test plan

- [ ] Bring up observability stack: \`docker compose up -d\` (after \`docker network create boxel\` if needed)
- [ ] Start dev synapse: \`mise run start-synapse\`
- [ ] Verify Prometheus reaches synapse: \`curl http://localhost:9090/api/v1/targets\` shows \`boxel-synapse:9001\` as healthy
- [ ] Visit \`http://localhost:3001/d/synapse\` (or whichever uid the vendored Synapse dashboard uses) and confirm panels render
- [ ] No regression on staging/prod apply: \`./scripts/apply-datasources.sh --env staging --dry-run\` (or a real apply once a teammate is ready) still uses the AMP-shaped canonical YAML, not the local override

🤖 Generated with [Claude Code](https://claude.com/claude-code)