### PR TITLE
Restore old command names during transition

### DIFF
--- a/packages/host/app/commands/get-available-realm-urls.ts
+++ b/packages/host/app/commands/get-available-realm-urls.ts
@@ -1,0 +1,5 @@
+// Deprecated alias kept for backwards compatibility with cards still
+// referencing the old URL-flavored module path. Remove once all
+// downstream consumers have been on the renamed path for at least one
+// release. Tracked by CS-11046.
+export { default } from './get-available-realm-identifiers';

--- a/packages/host/app/commands/get-catalog-realm-urls.ts
+++ b/packages/host/app/commands/get-catalog-realm-urls.ts
@@ -1,0 +1,5 @@
+// Deprecated alias kept for backwards compatibility with cards still
+// referencing the old URL-flavored module path. Remove once all
+// downstream consumers have been on the renamed path for at least one
+// release. Tracked by CS-11046.
+export { default } from './get-catalog-realm-identifiers';

--- a/packages/host/app/commands/get-realm-of-url.ts
+++ b/packages/host/app/commands/get-realm-of-url.ts
@@ -1,0 +1,5 @@
+// Deprecated alias kept for backwards compatibility with cards still
+// referencing the old URL-flavored module path. Remove once all
+// downstream consumers have been on the renamed path for at least one
+// release. Tracked by CS-11046.
+export { default } from './get-realm-of-resource-identifier';

--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -97,6 +97,17 @@ import * as ValidateRealmCommandModule from './validate-realm';
 import * as WriteBinaryFileCommandModule from './write-binary-file';
 import * as WriteTextFileCommandModule from './write-text-file';
 
+// Deprecated URL-flavored aliases kept for backwards compatibility with
+// boxel-skills/boxel-catalog cards still referencing the old module
+// paths. Each module is a thin re-export of its renamed counterpart.
+// Remove this block (imports + shimModule calls below + the .ts files
+// themselves) once downstream consumers have been on the renamed paths
+// for at least one release. Tracked by CS-11046.
+import * as GetRealmOfUrlCommandModule from './get-realm-of-url';
+import * as GetAvailableRealmUrlsCommandModule from './get-available-realm-urls';
+import * as GetCatalogRealmUrlsCommandModule from './get-catalog-realm-urls';
+import * as InvalidateRealmUrlsCommandModule from './invalidate-realm-urls';
+
 import type HostBaseCommand from '../lib/host-base-command';
 
 export function shimHostCommands(virtualNetwork: VirtualNetwork) {
@@ -487,6 +498,25 @@ export function shimHostCommands(virtualNetwork: VirtualNetwork) {
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/set-user-system-card',
     SetUserSystemCardCommandModule,
+  );
+
+  // Deprecated URL-flavored aliases — see the import-block comment for
+  // these modules above. Tracked by CS-11046.
+  virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/get-realm-of-url',
+    GetRealmOfUrlCommandModule,
+  );
+  virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/get-available-realm-urls',
+    GetAvailableRealmUrlsCommandModule,
+  );
+  virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/get-catalog-realm-urls',
+    GetCatalogRealmUrlsCommandModule,
+  );
+  virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/invalidate-realm-urls',
+    InvalidateRealmUrlsCommandModule,
   );
 }
 

--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -103,10 +103,12 @@ import * as WriteTextFileCommandModule from './write-text-file';
 // Remove this block (imports + shimModule calls below + the .ts files
 // themselves) once downstream consumers have been on the renamed paths
 // for at least one release. Tracked by CS-11046.
+/* eslint-disable import/order */
 import * as GetRealmOfUrlCommandModule from './get-realm-of-url';
 import * as GetAvailableRealmUrlsCommandModule from './get-available-realm-urls';
 import * as GetCatalogRealmUrlsCommandModule from './get-catalog-realm-urls';
 import * as InvalidateRealmUrlsCommandModule from './invalidate-realm-urls';
+/* eslint-enable import/order */
 
 import type HostBaseCommand from '../lib/host-base-command';
 

--- a/packages/host/app/commands/invalidate-realm-urls.ts
+++ b/packages/host/app/commands/invalidate-realm-urls.ts
@@ -1,0 +1,5 @@
+// Deprecated alias kept for backwards compatibility with cards still
+// referencing the old URL-flavored module path. Remove once all
+// downstream consumers have been on the renamed path for at least one
+// release. Tracked by CS-11046.
+export { default } from './invalidate-realm-identifiers';


### PR DESCRIPTION
This is a followup to #4627, as the AI assistant was temporarily broken on staging with incorrect imports:

<img width="552" height="337" alt="image" src="https://github.com/user-attachments/assets/ea79bf78-c61d-4baa-a90d-6847c19abc04" />

The original PR included a script to rewrite imports, but it only worked in CI and development, not deployed environments, because the way skills are read in there is different.

I fixed the problem by [merging this PR](https://github.com/cardstack/boxel-skills/pull/72), but for now we can just have these reexports so there’s no need for perfect timing when deploying to production.