### PR TITLE
Add fixes to properly catch shutdown signals

### DIFF
--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -1,5 +1,26 @@
 import './instrument';
 import './setup-logger'; // This should be first
+
+// During `mise dev-all` Ctrl-C, the bash trap walks the process tree
+// deepest-first. The `dev-log-tee` reader on this process's stdout/stderr
+// can die before this process gets SIGTERM, so any subsequent `log.info` /
+// `console.error` write throws EPIPE. Without these listeners, EPIPE
+// surfaces as an uncaughtException; the existing uncaughtException
+// handler then calls `log.error`, which writes to the same dead stream
+// and throws *again*. Node delivers the throw inside an uncaughtException
+// handler as the next pending exception, so V8 hot-loops re-reporting it
+// (uv__run_check → CheckImmediate → InspectorConsoleCall → Error.stack
+// formatting via ts-node) at ~100% CPU until the process is SIGKILLed —
+// CS-11084. Swallowing EPIPE at the stream level breaks the loop and
+// lets normal SIGTERM-driven shutdown finish.
+const swallowEpipe = (err: NodeJS.ErrnoException) => {
+  if (err?.code !== 'EPIPE') {
+    throw err;
+  }
+};
+process.stdout.on('error', swallowEpipe);
+process.stderr.on('error', swallowEpipe);
+
 import {
   logger,
   userInitiatedPriority,

--- a/packages/realm-server/worker.ts
+++ b/packages/realm-server/worker.ts
@@ -1,5 +1,18 @@
 import './instrument';
 import './setup-logger'; // This should be first
+
+// Swallow EPIPE from stdout/stderr so a torn-down parent (worker manager
+// SIGKILL'd or its dev-log-tee dead during dev-all Ctrl-C) doesn't make
+// every subsequent `log.info` an uncaughtException. See the matching
+// comment in worker-manager.ts (CS-11084).
+const swallowEpipe = (err: NodeJS.ErrnoException) => {
+  if (err?.code !== 'EPIPE') {
+    throw err;
+  }
+};
+process.stdout.on('error', swallowEpipe);
+process.stderr.on('error', swallowEpipe);
+
 import {
   Worker,
   VirtualNetwork,
@@ -154,8 +167,19 @@ let autoMigrate = migrateDB || undefined;
     process.send(`ready:${workerId}`);
   }
 
-  // Handle graceful shutdown
+  // Handle graceful shutdown. Registered against four triggers
+  // (SIGINT/SIGTERM, parent IPC disconnect, and a `'stop'` message from the
+  // manager), so the manager's IPC `'stop'` and a bash-trap SIGTERM can
+  // both fire on the same child during dev-all teardown. The guard makes
+  // shutdown idempotent — without it, the second invocation would call
+  // `pool.end()` a second time and pg-pool throws `Called end on pool
+  // more than once` synchronously from `dbAdapter.close()`.
+  let isShuttingDown = false;
   const shutdown = async () => {
+    if (isShuttingDown) {
+      return;
+    }
+    isShuttingDown = true;
     log.info(`Shutting down worker ${workerId}...`);
     try {
       await queue.destroy();


### PR DESCRIPTION
This is a fix for the underlying problem that #4704 and #4727 were about: lingering worker and worker manager processes after a Ctrl-C on `mise dev-all` or `mise dev`.

I ran this locally with `mise dev`, which still had the dangling process because #4727 hasn’t been merged, you can see when I Ctrl-C, the associated Node process eventually ends.

<img width="800" height="502" alt="CleanShot 2026-05-08 at 14 33 31" src="https://github.com/user-attachments/assets/79cbfe85-3646-487d-90c0-0517eda41845" />
