### PR TITLE
Remove Discord from deployment critical path

### DIFF
--- a/.github/workflows/deploy-host.yml
+++ b/.github/workflows/deploy-host.yml
@@ -58,6 +58,11 @@ jobs:
           EMBER_CLI_DEPLOY_REUSE_BUILD: "1"
 
       - name: Send notification to Discord
+        # Don't let a flaky Discord webhook abort the deployment chain —
+        # downstream jobs (migrate-db, deploy-realm-server, etc.) need this
+        # job to succeed.
+        continue-on-error: true
+        timeout-minutes: 2
         uses: cardstack/gh-actions/discord-notification-deploy@main
         with:
           app: "boxel-host"

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -53,6 +53,10 @@ jobs:
         run: pnpm deploy:boxel-ui ${{ inputs.environment }} --verbose
 
       - name: Send notification to Discord
+        # Don't let a flaky Discord webhook fail the deploy job —
+        # the deploy itself has already happened by this point.
+        continue-on-error: true
+        timeout-minutes: 2
         uses: cardstack/gh-actions/discord-notification-deploy@main
         with:
           app: "boxel-ui"


### PR DESCRIPTION
Deployments are currently failing because Discord is having [downtime](https://discordstatus.com/incidents/4hpm4454hxtx):

<img width="2768" height="1998" alt="CleanShot 2026-05-08 at 16 00 02@2x" src="https://github.com/user-attachments/assets/5fe7fa53-c028-43e5-9656-f38c54898010" />

While it’s unfortunate to lose progress messages, it shouldn’t mean deployments fail.