### PR TITLE
Stabilize flaky head preview playground test

### DIFF
--- a/packages/host/tests/acceptance/code-submode/card-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/card-playground-test.gts
@@ -194,7 +194,8 @@ async function waitForHeadPreviewText(
 ) {
   try {
     await waitUntil(
-      () => document.querySelector(selector)?.textContent?.trim() === expectedText,
+      () =>
+        document.querySelector(selector)?.textContent?.trim() === expectedText,
       { timeout: 5000 },
     );
   } catch (error) {
@@ -203,13 +204,16 @@ async function waitForHeadPreviewText(
         context,
         selector,
         expectedText,
-        actualText: document.querySelector(selector)?.textContent?.trim() ?? null,
+        actualText:
+          document.querySelector(selector)?.textContent?.trim() ?? null,
         googleTitleText:
           document.querySelector('.google-title')?.textContent?.trim() ?? null,
         googleDescriptionText:
-          document.querySelector('.google-description')?.textContent?.trim() ?? null,
+          document.querySelector('.google-description')?.textContent?.trim() ??
+          null,
         googleSiteNameText:
-          document.querySelector('.google-site-name')?.textContent?.trim() ?? null,
+          document.querySelector('.google-site-name')?.textContent?.trim() ??
+          null,
         playgroundPreviewHtml:
           document
             .querySelector('[data-test-playground-panel]')

--- a/packages/host/tests/acceptance/code-submode/card-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/card-playground-test.gts
@@ -187,6 +187,39 @@ const headPreviewCard = `import { contains, field, CardDef, Component } from "ht
   }
 `;
 
+async function waitForHeadPreviewText(
+  selector: string,
+  expectedText: string,
+  context: string,
+) {
+  try {
+    await waitUntil(
+      () => document.querySelector(selector)?.textContent?.trim() === expectedText,
+      { timeout: 5000 },
+    );
+  } catch (error) {
+    console.info(
+      `head preview diagnostics ${JSON.stringify({
+        context,
+        selector,
+        expectedText,
+        actualText: document.querySelector(selector)?.textContent?.trim() ?? null,
+        googleTitleText:
+          document.querySelector('.google-title')?.textContent?.trim() ?? null,
+        googleDescriptionText:
+          document.querySelector('.google-description')?.textContent?.trim() ?? null,
+        googleSiteNameText:
+          document.querySelector('.google-site-name')?.textContent?.trim() ?? null,
+        playgroundPreviewHtml:
+          document
+            .querySelector('[data-test-playground-panel]')
+            ?.innerHTML?.slice(0, 2000) ?? null,
+      })}`,
+    );
+    throw error;
+  }
+}
+
 const localStyleReferenceCard = {
   data: {
     type: 'card',
@@ -575,13 +608,22 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
         declaration: 'HeadPreview',
       });
       await selectFormat('head');
+      await waitForHeadPreviewText(
+        '.google-title',
+        'Definition Title',
+        'initial head preview render in card playground',
+      );
 
       assert.dom('.google-title').hasText('Definition Title');
       assert.dom('.google-description').hasText('Definition description');
       assert.dom('.google-site-name').hasText('example.com');
 
       setMonacoContent(headPreviewCard.replace('</title>', '!!</title>'));
-      await settled();
+      await waitForHeadPreviewText(
+        '.google-title',
+        'Definition Title!!',
+        'updated head preview render in card playground',
+      );
 
       assert.dom('.google-title').hasText('Definition Title!!');
     });

--- a/packages/host/tests/acceptance/code-submode/card-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/card-playground-test.gts
@@ -192,33 +192,67 @@ async function waitForHeadPreviewText(
   expectedText: string,
   context: string,
 ) {
+  let safeQuerySelector = (selector: string) => {
+    try {
+      return { element: document.querySelector(selector), error: null };
+    } catch (error) {
+      if (error instanceof Error) {
+        return {
+          element: null,
+          error: {
+            name: error.name,
+            message: error.message,
+          },
+        };
+      }
+      return {
+        element: null,
+        error: {
+          name: 'UnknownError',
+          message: String(error),
+        },
+      };
+    }
+  };
+
+  let readSelectorText = (selector: string) => {
+    let { element, error } = safeQuerySelector(selector);
+    return {
+      text: element?.textContent?.trim() ?? null,
+      error,
+    };
+  };
+
   try {
-    await waitUntil(
-      () =>
-        document.querySelector(selector)?.textContent?.trim() === expectedText,
-      { timeout: 5000 },
-    );
+    await waitUntil(() => readSelectorText(selector).text === expectedText, {
+      timeout: 5000,
+    });
   } catch (error) {
+    let actual = readSelectorText(selector);
+    let googleTitle = readSelectorText('.google-title');
+    let googleDescription = readSelectorText('.google-description');
+    let googleSiteName = readSelectorText('.google-site-name');
+    let previewPanel = safeQuerySelector('[data-test-playground-panel]');
+
     console.info(
-      `head preview diagnostics ${JSON.stringify({
+      'head preview diagnostics',
+      {
         context,
         selector,
         expectedText,
-        actualText:
-          document.querySelector(selector)?.textContent?.trim() ?? null,
-        googleTitleText:
-          document.querySelector('.google-title')?.textContent?.trim() ?? null,
-        googleDescriptionText:
-          document.querySelector('.google-description')?.textContent?.trim() ??
-          null,
-        googleSiteNameText:
-          document.querySelector('.google-site-name')?.textContent?.trim() ??
-          null,
+        actualText: actual.text,
+        selectorError: actual.error,
+        googleTitleText: googleTitle.text,
+        googleTitleError: googleTitle.error,
+        googleDescriptionText: googleDescription.text,
+        googleDescriptionError: googleDescription.error,
+        googleSiteNameText: googleSiteName.text,
+        googleSiteNameError: googleSiteName.error,
         playgroundPreviewHtml:
-          document
-            .querySelector('[data-test-playground-panel]')
-            ?.innerHTML?.slice(0, 2000) ?? null,
-      })}`,
+          previewPanel.element?.innerHTML?.slice(0, 2000) ?? null,
+        playgroundPreviewError: previewPanel.error,
+      },
+      error,
     );
     throw error;
   }


### PR DESCRIPTION
## Summary
- wait for the head-format preview DOM to finish rendering before asserting in the card playground acceptance test
- add targeted diagnostics so a future timeout captures the current preview text fields and a truncated preview panel HTML snapshot in CI logs

## Context
This PR addresses the flaky failure seen in CI for:
`Acceptance | code-submode | card playground > single realm: head format preview renders for card definitions in playground`

The failure symptom was that `.google-title` sometimes did not exist yet when the test asserted immediately after switching the playground to `head` format. That points to a race between the format change and the preview DOM becoming available.

## Change
The test now waits for the expected `.google-title` text both:
- after initially switching into `head` format
- after editing the `<title>` in Monaco and expecting the preview to update

If that wait still times out, the test logs structured diagnostics with:
- the expected selector and text
- the current `.google-title`, `.google-description`, and `.google-site-name` text values
- a truncated snapshot of the playground preview panel HTML

That should make a future failure actionable instead of only reporting that the element was missing.

## Validation
- editor diagnostics were clean for the modified test file
- `pnpm --dir packages/host lint` completed for the change
- I was not able to get a clean behavior-level local rerun because the local test environment was missing the service expected on `localhost:4201`, so the focused browser run was blocked by environment setup rather than this test change