### PR TITLE
Bump pnpm to 10.33.4

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 node = "24.13.1"
-pnpm = "10.30.0"
+pnpm = "10.33.4"
 
 [env]
 _.source = "./mise-tasks/lib/env-vars.sh"


### PR DESCRIPTION
## Summary
- Bumps pnpm in `.mise.toml` from `10.30.0` → `10.33.4` (latest 10.x patch).
- Stays within the existing `^10` range in `package.json`, so no lockfile or `engines.pnpm` changes are needed; `pnpm install --frozen-lockfile` resolves cleanly with the new version.
- Going to pnpm 11 was considered but deferred: it stops reading `pnpm.*` settings from `package.json` and removes `onlyBuiltDependencies`, so a range bump alone would silently lose every override / patch / built-deps allowlist. There's an official codemod (`pnpx codemod run pnpm-v10-to-v11`) that does most of the migration, but it deserves its own PR with a real test cycle. Planned in [CS-11100](https://linear.app/cardstack/issue/CS-11100/upgrade-pnpm-10-11)

## Test plan
- [x] CI passes (lint, host tests, realm-server tests, software-factory tests, web-assets tests).
- [ ] After merge, contributors run `mise install` to pick up the new pnpm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)