### PR TITLE
Grafana: fix Overview ECS Tasks tile (Container Insights namespace)

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -870,7 +870,7 @@
               "type": "cloudwatch",
               "uid": "cef5x9o3yzawwf"
             },
-            "namespace": "AWS/ECS",
+            "namespace": "ECS/ContainerInsights",
             "metricName": "RunningTaskCount",
             "metricEditorMode": 0,
             "metricQueryType": 0,
@@ -1102,7 +1102,7 @@
               "type": "cloudwatch",
               "uid": "cef5x9o3yzawwf"
             },
-            "namespace": "AWS/ECS",
+            "namespace": "ECS/ContainerInsights",
             "metricName": "RunningTaskCount",
             "metricEditorMode": 0,
             "metricQueryType": 0,
@@ -1334,7 +1334,7 @@
               "type": "cloudwatch",
               "uid": "cef5x9o3yzawwf"
             },
-            "namespace": "AWS/ECS",
+            "namespace": "ECS/ContainerInsights",
             "metricName": "RunningTaskCount",
             "metricEditorMode": 0,
             "metricQueryType": 0,
@@ -1566,7 +1566,7 @@
               "type": "cloudwatch",
               "uid": "cef5x9o3yzawwf"
             },
-            "namespace": "AWS/ECS",
+            "namespace": "ECS/ContainerInsights",
             "metricName": "RunningTaskCount",
             "metricEditorMode": 0,
             "metricQueryType": 0,


### PR DESCRIPTION
## Summary
- The four ECS service tiles on the Overview dashboard query `RunningTaskCount` from `AWS/ECS`, which is the wrong namespace — that metric is published under `ECS/ContainerInsights`. CPU and Mem are unaffected (they're correctly in `AWS/ECS`); Synapse was unaffected (Prometheus-backed)
- With Container Insights now enabled on the staging cluster, point the four `RunningTaskCount` targets at `ECS/ContainerInsights` so the Tasks line renders

## Test plan
- [ ] Apply to staging — Tasks tile on Realm Server, Prerender, Prerender Mgr, Worker shows the running task count instead of "No data"
- [ ] CPU and Mem tiles continue to render (still on `AWS/ECS`)
- [ ] Threshold colors on Tasks (red <1, green ≥1) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)