### PR TITLE
Grafana: bargauge ECS service tiles on Overview dashboard

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -387,7 +387,7 @@
           "type": "grafana-postgresql-datasource",
           "uid": "cef5v5sl9k7i8f"
         },
-        "description": "Worker job throughput and failures, bucketed at 1 minute. Resolved jobs (`status='resolved'`) and rejected jobs (`status='rejected'`) stacked. Legend shows the mean over the visible time range. Counts ALL job types, not just indexing \u2014 for indexing-only throughput see the Indexing dashboard.",
+        "description": "Worker job throughput and failures, bucketed at 1 minute. Resolved jobs (`status='resolved'`) and rejected jobs (`status='rejected'`) stacked. Legend shows the mean over the visible time range. Counts ALL job types, not just indexing — for indexing-only throughput see the Indexing dashboard.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -537,7 +537,7 @@
           "type": "loki",
           "uid": "loki"
         },
-        "description": "Synapse send-event rate \u2014 `PUT /_matrix/client/.../send/<event-type>/<txnId>` requests parsed from synapse access logs. Counts ALL Matrix event types (`m.room.message` for chat, `app.boxel.realm-event` for boxel realm sync, etc.) since boxel uses Matrix as its event bus, not just for chat. Legend shows the mean over the visible time range.",
+        "description": "Synapse send-event rate — `PUT /_matrix/client/.../send/<event-type>/<txnId>` requests parsed from synapse access logs. Counts ALL Matrix event types (`m.room.message` for chat, `app.boxel.realm-event` for boxel realm sync, etc.) since boxel uses Matrix as its event bus, not just for chat. Legend shows the mean over the visible time range.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -660,7 +660,7 @@
           "type": "cloudwatch",
           "uid": "cef5x9o3yzawwf"
         },
-        "description": "ECS resource utilisation for `boxel-realm-server-${env}` on cluster `${env}`. CPU and memory are average over the panel refresh window; Tasks is the latest RunningTaskCount. Locally these show 'No data' \u2014 CloudWatch is staging/production only.",
+        "description": "ECS resource utilisation for `boxel-realm-server-${env}` on cluster `${env}`. CPU and memory are average over the panel refresh window; Tasks is the latest RunningTaskCount. Locally these show 'No data' — CloudWatch is staging/production only.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -800,6 +800,10 @@
                       }
                     ]
                   }
+                },
+                {
+                  "id": "max",
+                  "value": 10
                 }
               ]
             }
@@ -813,19 +817,22 @@
         },
         "id": 13,
         "options": {
-          "colorMode": "background_solid",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "vertical",
+          "displayMode": "gradient",
+          "orientation": "horizontal",
+          "showUnfilled": true,
+          "valueMode": "color",
+          "namePlacement": "auto",
+          "minVizWidth": 0,
+          "minVizHeight": 10,
+          "maxVizHeight": 300,
+          "sizing": "auto",
           "reduceOptions": {
             "calcs": [
               "lastNotNull"
             ],
             "fields": "",
             "values": false
-          },
-          "textMode": "value_and_name",
-          "wideLayout": true
+          }
         },
         "pluginVersion": "12.4.3",
         "targets": [
@@ -885,14 +892,14 @@
           }
         ],
         "title": "Realm Server",
-        "type": "stat"
+        "type": "bargauge"
       },
       {
         "datasource": {
           "type": "cloudwatch",
           "uid": "cef5x9o3yzawwf"
         },
-        "description": "ECS resource utilisation for `boxel-prerender-server-${env}` on cluster `${env}`. CPU and memory are average over the panel refresh window; Tasks is the latest RunningTaskCount. Locally these show 'No data' \u2014 CloudWatch is staging/production only.",
+        "description": "ECS resource utilisation for `boxel-prerender-server-${env}` on cluster `${env}`. CPU and memory are average over the panel refresh window; Tasks is the latest RunningTaskCount. Locally these show 'No data' — CloudWatch is staging/production only.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -1032,6 +1039,10 @@
                       }
                     ]
                   }
+                },
+                {
+                  "id": "max",
+                  "value": 10
                 }
               ]
             }
@@ -1045,19 +1056,22 @@
         },
         "id": 14,
         "options": {
-          "colorMode": "background_solid",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "vertical",
+          "displayMode": "gradient",
+          "orientation": "horizontal",
+          "showUnfilled": true,
+          "valueMode": "color",
+          "namePlacement": "auto",
+          "minVizWidth": 0,
+          "minVizHeight": 10,
+          "maxVizHeight": 300,
+          "sizing": "auto",
           "reduceOptions": {
             "calcs": [
               "lastNotNull"
             ],
             "fields": "",
             "values": false
-          },
-          "textMode": "value_and_name",
-          "wideLayout": true
+          }
         },
         "pluginVersion": "12.4.3",
         "targets": [
@@ -1117,14 +1131,14 @@
           }
         ],
         "title": "Prerender",
-        "type": "stat"
+        "type": "bargauge"
       },
       {
         "datasource": {
           "type": "cloudwatch",
           "uid": "cef5x9o3yzawwf"
         },
-        "description": "ECS resource utilisation for `boxel-prerender-manager-${env}` on cluster `${env}`. CPU and memory are average over the panel refresh window; Tasks is the latest RunningTaskCount. Locally these show 'No data' \u2014 CloudWatch is staging/production only.",
+        "description": "ECS resource utilisation for `boxel-prerender-manager-${env}` on cluster `${env}`. CPU and memory are average over the panel refresh window; Tasks is the latest RunningTaskCount. Locally these show 'No data' — CloudWatch is staging/production only.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -1264,6 +1278,10 @@
                       }
                     ]
                   }
+                },
+                {
+                  "id": "max",
+                  "value": 10
                 }
               ]
             }
@@ -1277,19 +1295,22 @@
         },
         "id": 15,
         "options": {
-          "colorMode": "background_solid",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "vertical",
+          "displayMode": "gradient",
+          "orientation": "horizontal",
+          "showUnfilled": true,
+          "valueMode": "color",
+          "namePlacement": "auto",
+          "minVizWidth": 0,
+          "minVizHeight": 10,
+          "maxVizHeight": 300,
+          "sizing": "auto",
           "reduceOptions": {
             "calcs": [
               "lastNotNull"
             ],
             "fields": "",
             "values": false
-          },
-          "textMode": "value_and_name",
-          "wideLayout": true
+          }
         },
         "pluginVersion": "12.4.3",
         "targets": [
@@ -1349,14 +1370,14 @@
           }
         ],
         "title": "Prerender Mgr",
-        "type": "stat"
+        "type": "bargauge"
       },
       {
         "datasource": {
           "type": "cloudwatch",
           "uid": "cef5x9o3yzawwf"
         },
-        "description": "ECS resource utilisation for `boxel-worker-${env}` on cluster `${env}`. CPU and memory are average over the panel refresh window; Tasks is the latest RunningTaskCount. Locally these show 'No data' \u2014 CloudWatch is staging/production only.",
+        "description": "ECS resource utilisation for `boxel-worker-${env}` on cluster `${env}`. CPU and memory are average over the panel refresh window; Tasks is the latest RunningTaskCount. Locally these show 'No data' — CloudWatch is staging/production only.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -1496,6 +1517,10 @@
                       }
                     ]
                   }
+                },
+                {
+                  "id": "max",
+                  "value": 10
                 }
               ]
             }
@@ -1509,19 +1534,22 @@
         },
         "id": 16,
         "options": {
-          "colorMode": "background_solid",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "vertical",
+          "displayMode": "gradient",
+          "orientation": "horizontal",
+          "showUnfilled": true,
+          "valueMode": "color",
+          "namePlacement": "auto",
+          "minVizWidth": 0,
+          "minVizHeight": 10,
+          "maxVizHeight": 300,
+          "sizing": "auto",
           "reduceOptions": {
             "calcs": [
               "lastNotNull"
             ],
             "fields": "",
             "values": false
-          },
-          "textMode": "value_and_name",
-          "wideLayout": true
+          }
         },
         "pluginVersion": "12.4.3",
         "targets": [
@@ -1581,7 +1609,7 @@
           }
         ],
         "title": "Worker",
-        "type": "stat"
+        "type": "bargauge"
       },
       {
         "datasource": {
@@ -1684,6 +1712,10 @@
                       }
                     ]
                   }
+                },
+                {
+                  "id": "max",
+                  "value": 8589934592
                 }
               ]
             },
@@ -1720,6 +1752,10 @@
                       }
                     ]
                   }
+                },
+                {
+                  "id": "max",
+                  "value": 1
                 }
               ]
             }
@@ -1733,19 +1769,22 @@
         },
         "id": 17,
         "options": {
-          "colorMode": "background_solid",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "vertical",
+          "displayMode": "gradient",
+          "orientation": "horizontal",
+          "showUnfilled": true,
+          "valueMode": "color",
+          "namePlacement": "auto",
+          "minVizWidth": 0,
+          "minVizHeight": 10,
+          "maxVizHeight": 300,
+          "sizing": "auto",
           "reduceOptions": {
             "calcs": [
               "lastNotNull"
             ],
             "fields": "",
             "values": false
-          },
-          "textMode": "value_and_name",
-          "wideLayout": true
+          }
         },
         "pluginVersion": "12.4.3",
         "targets": [
@@ -1781,14 +1820,14 @@
           }
         ],
         "title": "Synapse",
-        "type": "stat"
+        "type": "bargauge"
       },
       {
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "cef5v5sl9k7i8f"
         },
-        "description": "Boxel application database transaction rate (xact_commit + xact_rollback) averaged since the postmaster started. Not a rolling window \u2014 recent spikes will be smoothed. Drill into the DB-specific dashboard for detail.",
+        "description": "Boxel application database transaction rate (xact_commit + xact_rollback) averaged since the postmaster started. Not a rolling window — recent spikes will be smoothed. Drill into the DB-specific dashboard for detail.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -2358,7 +2397,7 @@
             "showLineNumbers": false,
             "showMiniMap": false
           },
-          "content": "### Other dashboards\n\n- **Entity dashboards** \u2014 pick a specific entity to inspect:\n  - [Realms](/d/boxelrealms001) \u2014 counts, permissions, indexing status, recent errors\n  - [Users](/d/boxelusers0001) \u2014 credits, realm permissions, grant access\n- **Workflow dashboards**:\n  - [Indexing](/d/aetquzjcf2znke) \u2014 pipeline metrics + operator actions\n  - [Job Queue](/d/boxeljobqueue1) \u2014 generic worker queue (all job types)\n- **Forensics**: [Logs](/d/fetquzizsej28b) \u2014 filter by service, user, realm\n- **Service deep-dives** (stub \u2014 currently filtered logs only): [Realm Server](/d/boxel-svc-realm-server) \u00b7 [Prerender Server](/d/boxel-svc-prerender-server) \u00b7 [Prerender Manager](/d/boxel-svc-prerender-manager) \u00b7 [Worker](/d/boxel-svc-worker) \u00b7 [Synapse](/d/000000012)",
+          "content": "### Other dashboards\n\n- **Entity dashboards** — pick a specific entity to inspect:\n  - [Realms](/d/boxelrealms001) — counts, permissions, indexing status, recent errors\n  - [Users](/d/boxelusers0001) — credits, realm permissions, grant access\n- **Workflow dashboards**:\n  - [Indexing](/d/aetquzjcf2znke) — pipeline metrics + operator actions\n  - [Job Queue](/d/boxeljobqueue1) — generic worker queue (all job types)\n- **Forensics**: [Logs](/d/fetquzizsej28b) — filter by service, user, realm\n- **Service deep-dives** (stub — currently filtered logs only): [Realm Server](/d/boxel-svc-realm-server) · [Prerender Server](/d/boxel-svc-prerender-server) · [Prerender Manager](/d/boxel-svc-prerender-manager) · [Worker](/d/boxel-svc-worker) · [Synapse](/d/000000012)",
           "mode": "markdown"
         },
         "pluginVersion": "12.4.3",


### PR DESCRIPTION
## Summary
Five service tiles on the Overview dashboard's third row (Realm Server, Prerender, Prerender Mgr, Worker, Synapse) cram three values into a w=4 stat panel — numbers are unreadable. Convert them to horizontal bargauge so each metric gets its own full-width bar + value, scannable at a glance.

- Tasks (CloudWatch `RunningTaskCount`): `max: 10` so the bar fills proportionally for typical task counts
- Synapse Mem (`process_resident_memory_bytes`): `max: 8589934592` (8 GiB)
- Synapse Up (`count(up{job="synapse"} == 1)`): `max: 1`
- CPU / Mem percentages: implicit 0–100 from the `percent` unit
- Existing threshold steps and `displayName` field overrides carry through unchanged, so the green/yellow/red coloring matches today's behavior

Postgres DB tile stays a stat (it already shows one big number).

## Test plan
- [ ] Local Grafana: row 3 Synapse tile renders as a horizontal bargauge with CPU/Mem/Up bars (the four CloudWatch tiles are markdown-stubbed locally so won't show real data)
- [ ] Staging: all five tiles render as bargauges; CPU/Mem bars fill ~proportional to percentage; Tasks fills ~10% per running task; Synapse Up bar full when synapse is healthy
- [ ] Threshold colors match the prior stat tiles (yellow at 70%, red at 90% for CPU/Mem; green at Tasks≥1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)