### PR TITLE
observability: restore GF_INSTALL_PLUGINS in local docker-compose

### DIFF
--- a/packages/observability/docker-compose.yml
+++ b/packages/observability/docker-compose.yml
@@ -37,6 +37,13 @@ services:
     environment:
       GF_SECURITY_ADMIN_PASSWORD: admin
       GF_AUTH_ANONYMOUS_ENABLED: "false"
+      # Volkov Labs Business Forms panel — used by Operator Actions panels
+      # in boxel-status/indexing, realms, users, and job-queue dashboards.
+      # Signed plugin, archived upstream at v6.2.0 (2025-09) but still
+      # functional on Grafana 12.x. Staging / production self-host Grafana
+      # installs this via cardstack/infra
+      # configs/grafana/base/container-definitions/grafana.yaml.
+      GF_INSTALL_PLUGINS: "volkovlabs-form-panel"
       # Substituted into provisioning/datasources/loki.yaml at startup.
       LOKI_URL: http://loki:3100
       # Substituted into provisioning/datasources/boxel-db.yaml at startup.


### PR DESCRIPTION
## Summary
Commit dd94c93210 (\"Operator-action panels: upgrade to Business Forms with live blast radius\") added \`GF_INSTALL_PLUGINS: volkovlabs-form-panel\` to the local Grafana container. A later, unrelated commit (d8e6fc23fb, \"observability: scrape dev synapse via local Prometheus\") accidentally removed that line. Existing dev environments still work because the named \`grafana_data\` volume preserved the plugin install across restarts, so the regression went unnoticed — but a fresh \`docker compose up\` lands on a Grafana without the plugin, matching the staging breakage just fixed in [cardstack/infra#689](https://github.com/cardstack/infra/pull/689).

This restores the line.

## Test plan
- [ ] On a clean machine (or after \`docker compose down -v\` to drop the named volume), \`docker compose up -d\`, then \`docker exec observability-grafana-1 ls /var/lib/grafana/plugins/volkovlabs-form-panel\` succeeds
- [ ] Open `http://localhost:3001/d/aetquzjcf2znke` (Indexing) — the Operator Actions: Full reindex panel renders the form, not the plugin-not-found error

🤖 Generated with [Claude Code](https://claude.com/claude-code)