### PR TITLE
realm-server: add /_grafana-upsert-realm-user-permission endpoint

### DIFF
--- a/packages/realm-server/handlers/handle-upsert-realm-user-permission.ts
+++ b/packages/realm-server/handlers/handle-upsert-realm-user-permission.ts
@@ -1,0 +1,71 @@
+import type Koa from 'koa';
+import {
+  insertPermissions,
+  type RealmAction,
+  SupportedMimeType,
+} from '@cardstack/runtime-common';
+import { sendResponseForBadRequest, setContextResponse } from '../middleware';
+import type { CreateRoutesArgs } from '../routes';
+
+export default function handleUpsertRealmUserPermission({
+  dbAdapter,
+}: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
+  return async function (ctxt: Koa.Context, _next: Koa.Next) {
+    let realm = ctxt.URL.searchParams.get('realm');
+    if (!realm) {
+      await sendResponseForBadRequest(ctxt, `realm param must be specified`);
+      return;
+    }
+    let user = ctxt.URL.searchParams.get('user');
+    if (!user) {
+      await sendResponseForBadRequest(ctxt, `user param must be specified`);
+      return;
+    }
+
+    let realmURL: URL;
+    try {
+      realmURL = new URL(realm);
+    } catch {
+      await sendResponseForBadRequest(ctxt, `realm "${realm}" is not a URL`);
+      return;
+    }
+
+    let read = ctxt.URL.searchParams.get('read') === 'true';
+    let write = ctxt.URL.searchParams.get('write') === 'true';
+    if (!read && !write) {
+      await sendResponseForBadRequest(
+        ctxt,
+        `at least one of read or write must be true (use the realm-permissions delete flow to revoke)`,
+      );
+      return;
+    }
+    if (write && !read) {
+      await sendResponseForBadRequest(
+        ctxt,
+        `write permission requires read permission`,
+      );
+      return;
+    }
+
+    let actions: RealmAction[] = [];
+    if (read) {
+      actions.push('read');
+    }
+    if (write) {
+      actions.push('write');
+    }
+    await insertPermissions(dbAdapter, realmURL, { [user]: actions });
+
+    return setContextResponse(
+      ctxt,
+      new Response(
+        JSON.stringify({
+          message: `Set ${actions.join('+')} on ${realmURL.href} for user "${user}"`,
+        }),
+        {
+          headers: { 'content-type': SupportedMimeType.JSON },
+        },
+      ),
+    );
+  };
+}

--- a/packages/realm-server/handlers/handle-upsert-realm-user-permission.ts
+++ b/packages/realm-server/handlers/handle-upsert-realm-user-permission.ts
@@ -58,10 +58,7 @@ export default function handleUpsertRealmUserPermission({
     realmURL.hash = '';
     let normalizedRealmHref = ensureTrailingSlash(realmURL.href);
 
-    let readResult = parseBoolFlag(
-      ctxt.URL.searchParams.get('read'),
-      'read',
-    );
+    let readResult = parseBoolFlag(ctxt.URL.searchParams.get('read'), 'read');
     if (!readResult.ok) {
       await sendResponseForBadRequest(ctxt, readResult.error);
       return;

--- a/packages/realm-server/handlers/handle-upsert-realm-user-permission.ts
+++ b/packages/realm-server/handlers/handle-upsert-realm-user-permission.ts
@@ -1,11 +1,31 @@
 import type Koa from 'koa';
 import {
+  ensureTrailingSlash,
   insertPermissions,
   type RealmAction,
   SupportedMimeType,
 } from '@cardstack/runtime-common';
 import { sendResponseForBadRequest, setContextResponse } from '../middleware';
 import type { CreateRoutesArgs } from '../routes';
+
+function parseBoolFlag(
+  raw: string | null,
+  name: string,
+): { ok: true; value: boolean } | { ok: false; error: string } {
+  if (raw === 'true') {
+    return { ok: true, value: true };
+  }
+  if (raw === 'false') {
+    return { ok: true, value: false };
+  }
+  if (raw == null) {
+    return { ok: false, error: `${name} param must be specified` };
+  }
+  return {
+    ok: false,
+    error: `${name} param must be "true" or "false" (got "${raw}")`,
+  };
+}
 
 export default function handleUpsertRealmUserPermission({
   dbAdapter,
@@ -29,9 +49,33 @@ export default function handleUpsertRealmUserPermission({
       await sendResponseForBadRequest(ctxt, `realm "${realm}" is not a URL`);
       return;
     }
+    // realm_user_permissions is keyed by exact `realm_url` string. Normalise
+    // to the canonical realm-root form (no querystring or fragment, single
+    // trailing slash) so a caller passing `https://h/r` and another passing
+    // `https://h/r/?token=...` write to the same row instead of a stray
+    // permission whose URL the realm runtime never consults.
+    realmURL.search = '';
+    realmURL.hash = '';
+    let normalizedRealmHref = ensureTrailingSlash(realmURL.href);
 
-    let read = ctxt.URL.searchParams.get('read') === 'true';
-    let write = ctxt.URL.searchParams.get('write') === 'true';
+    let readResult = parseBoolFlag(
+      ctxt.URL.searchParams.get('read'),
+      'read',
+    );
+    if (!readResult.ok) {
+      await sendResponseForBadRequest(ctxt, readResult.error);
+      return;
+    }
+    let writeResult = parseBoolFlag(
+      ctxt.URL.searchParams.get('write'),
+      'write',
+    );
+    if (!writeResult.ok) {
+      await sendResponseForBadRequest(ctxt, writeResult.error);
+      return;
+    }
+    let read = readResult.value;
+    let write = writeResult.value;
     if (!read && !write) {
       await sendResponseForBadRequest(
         ctxt,
@@ -54,13 +98,15 @@ export default function handleUpsertRealmUserPermission({
     if (write) {
       actions.push('write');
     }
-    await insertPermissions(dbAdapter, realmURL, { [user]: actions });
+    await insertPermissions(dbAdapter, new URL(normalizedRealmHref), {
+      [user]: actions,
+    });
 
     return setContextResponse(
       ctxt,
       new Response(
         JSON.stringify({
-          message: `Set ${actions.join('+')} on ${realmURL.href} for user "${user}"`,
+          message: `Set ${actions.join('+')} on ${normalizedRealmHref} for user "${user}"`,
         }),
         {
           headers: { 'content-type': SupportedMimeType.JSON },

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -26,6 +26,7 @@ import handleReindex from './handlers/handle-reindex';
 import handleFullReindex from './handlers/handle-full-reindex';
 import handleRemoveJob from './handlers/handle-remove-job';
 import handleAddCredit from './handlers/handle-add-credit';
+import handleUpsertRealmUserPermission from './handlers/handle-upsert-realm-user-permission';
 import handleCreateStripeSessionRequest from './handlers/handle-create-stripe-session';
 import handleRequestForward from './handlers/handle-request-forward';
 import handlePostDeployment from './handlers/handle-post-deployment';
@@ -250,6 +251,10 @@ export function createRoutes(args: CreateRoutesArgs) {
   registerGrafanaEndpoint('/_grafana-complete-job', handleRemoveJob(args));
   registerGrafanaEndpoint('/_grafana-add-credit', handleAddCredit(args));
   registerGrafanaEndpoint('/_grafana-full-reindex', handleFullReindex(args));
+  registerGrafanaEndpoint(
+    '/_grafana-upsert-realm-user-permission',
+    handleUpsertRealmUserPermission(args),
+  );
   router.post('/_post-deployment', handlePostDeployment(args));
   router.post(
     '/_realm-auth',

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -251,8 +251,13 @@ export function createRoutes(args: CreateRoutesArgs) {
   registerGrafanaEndpoint('/_grafana-complete-job', handleRemoveJob(args));
   registerGrafanaEndpoint('/_grafana-add-credit', handleAddCredit(args));
   registerGrafanaEndpoint('/_grafana-full-reindex', handleFullReindex(args));
-  registerGrafanaEndpoint(
+  // POST-only, Bearer-only — this endpoint is new in CS-10987-era
+  // (Grafana button-panel form) and never had the legacy GET +
+  // `?authHeader=` link form, so skip `registerGrafanaEndpoint`'s dual
+  // GET/POST registration.
+  router.post(
     '/_grafana-upsert-realm-user-permission',
+    grafanaAuthorization(args.grafanaSecret),
     handleUpsertRealmUserPermission(args),
   );
   router.post('/_post-deployment', handlePostDeployment(args));

--- a/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
@@ -1162,12 +1162,13 @@ module(`server-endpoints/${basename(__filename)}`, function () {
       test('grants read-only via grafana upsert-realm-user-permission endpoint', async function (assert) {
         let user = '@op-test:localhost';
         let response = await context.request
-          .get(
-            `/_grafana-upsert-realm-user-permission?authHeader=${grafanaSecret}` +
-              `&realm=${encodeURIComponent(testRealmURL.href)}` +
+          .post(
+            `/_grafana-upsert-realm-user-permission` +
+              `?realm=${encodeURIComponent(testRealmURL.href)}` +
               `&user=${encodeURIComponent(user)}` +
               `&read=true&write=false`,
           )
+          .set('Authorization', `Bearer ${grafanaSecret}`)
           .set('Content-Type', 'application/json');
         assert.strictEqual(response.status, 200, 'HTTP 200 status');
         let perms = await fetchRealmPermissions(
@@ -1180,12 +1181,13 @@ module(`server-endpoints/${basename(__filename)}`, function () {
       test('grants read+write via grafana upsert-realm-user-permission endpoint', async function (assert) {
         let user = '@op-test-rw:localhost';
         let response = await context.request
-          .get(
-            `/_grafana-upsert-realm-user-permission?authHeader=${grafanaSecret}` +
-              `&realm=${encodeURIComponent(testRealmURL.href)}` +
+          .post(
+            `/_grafana-upsert-realm-user-permission` +
+              `?realm=${encodeURIComponent(testRealmURL.href)}` +
               `&user=${encodeURIComponent(user)}` +
               `&read=true&write=true`,
           )
+          .set('Authorization', `Bearer ${grafanaSecret}`)
           .set('Content-Type', 'application/json');
         assert.strictEqual(response.status, 200, 'HTTP 200 status');
         let perms = await fetchRealmPermissions(
@@ -1202,17 +1204,19 @@ module(`server-endpoints/${basename(__filename)}`, function () {
       test('upserts: re-grant on the same user updates instead of duplicating', async function (assert) {
         let user = '@op-test-upsert:localhost';
         let url = (read: string, write: string) =>
-          `/_grafana-upsert-realm-user-permission?authHeader=${grafanaSecret}` +
-          `&realm=${encodeURIComponent(testRealmURL.href)}` +
+          `/_grafana-upsert-realm-user-permission` +
+          `?realm=${encodeURIComponent(testRealmURL.href)}` +
           `&user=${encodeURIComponent(user)}` +
           `&read=${read}&write=${write}`;
         // First call: read only.
         await context.request
-          .get(url('true', 'false'))
+          .post(url('true', 'false'))
+          .set('Authorization', `Bearer ${grafanaSecret}`)
           .set('Content-Type', 'application/json');
         // Second call: upgrade to read+write.
         let response = await context.request
-          .get(url('true', 'true'))
+          .post(url('true', 'true'))
+          .set('Authorization', `Bearer ${grafanaSecret}`)
           .set('Content-Type', 'application/json');
         assert.strictEqual(response.status, 200, 'HTTP 200 status');
         let perms = await fetchRealmPermissions(
@@ -1226,15 +1230,47 @@ module(`server-endpoints/${basename(__filename)}`, function () {
         );
       });
 
+      test('normalises realm URL — trailing slash and stripped querystring/hash', async function (assert) {
+        let user = '@op-test-normalize:localhost';
+        // Pass a URL without trailing slash + with extraneous querystring +
+        // fragment. Both should be normalised before insert so the row keys
+        // exactly to the canonical realm root the runtime consults.
+        let raw = testRealmURL.href.replace(/\/$/, '') + '?token=secret#frag';
+        let response = await context.request
+          .post(
+            `/_grafana-upsert-realm-user-permission` +
+              `?realm=${encodeURIComponent(raw)}` +
+              `&user=${encodeURIComponent(user)}` +
+              `&read=true&write=false`,
+          )
+          .set('Authorization', `Bearer ${grafanaSecret}`)
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 200, 'HTTP 200 status');
+        assert.notOk(
+          response.body.message?.includes('token=secret'),
+          'response message does not echo the raw querystring',
+        );
+        let perms = await fetchRealmPermissions(
+          context.dbAdapter,
+          testRealmURL,
+        );
+        assert.deepEqual(
+          perms[user],
+          ['read'],
+          'permission written under the canonical realm URL',
+        );
+      });
+
       test('rejects write-only (write requires read)', async function (assert) {
         let user = '@op-test-bad:localhost';
         let response = await context.request
-          .get(
-            `/_grafana-upsert-realm-user-permission?authHeader=${grafanaSecret}` +
-              `&realm=${encodeURIComponent(testRealmURL.href)}` +
+          .post(
+            `/_grafana-upsert-realm-user-permission` +
+              `?realm=${encodeURIComponent(testRealmURL.href)}` +
               `&user=${encodeURIComponent(user)}` +
               `&read=false&write=true`,
           )
+          .set('Authorization', `Bearer ${grafanaSecret}`)
           .set('Content-Type', 'application/json');
         assert.strictEqual(response.status, 400, 'HTTP 400 status');
       });
@@ -1242,42 +1278,58 @@ module(`server-endpoints/${basename(__filename)}`, function () {
       test('rejects read=false write=false (use the delete flow to revoke)', async function (assert) {
         let user = '@op-test-revoke:localhost';
         let response = await context.request
-          .get(
-            `/_grafana-upsert-realm-user-permission?authHeader=${grafanaSecret}` +
-              `&realm=${encodeURIComponent(testRealmURL.href)}` +
+          .post(
+            `/_grafana-upsert-realm-user-permission` +
+              `?realm=${encodeURIComponent(testRealmURL.href)}` +
               `&user=${encodeURIComponent(user)}` +
               `&read=false&write=false`,
           )
+          .set('Authorization', `Bearer ${grafanaSecret}`)
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 400, 'HTTP 400 status');
+      });
+
+      test('rejects non-boolean read/write flags', async function (assert) {
+        let response = await context.request
+          .post(
+            `/_grafana-upsert-realm-user-permission` +
+              `?realm=${encodeURIComponent(testRealmURL.href)}` +
+              `&user=${encodeURIComponent('@op-test:localhost')}` +
+              `&read=TRUE&write=false`,
+          )
+          .set('Authorization', `Bearer ${grafanaSecret}`)
           .set('Content-Type', 'application/json');
         assert.strictEqual(response.status, 400, 'HTTP 400 status');
       });
 
       test('rejects missing realm param', async function (assert) {
         let response = await context.request
-          .get(
-            `/_grafana-upsert-realm-user-permission?authHeader=${grafanaSecret}` +
-              `&user=${encodeURIComponent('@op-test:localhost')}` +
+          .post(
+            `/_grafana-upsert-realm-user-permission` +
+              `?user=${encodeURIComponent('@op-test:localhost')}` +
               `&read=true&write=false`,
           )
+          .set('Authorization', `Bearer ${grafanaSecret}`)
           .set('Content-Type', 'application/json');
         assert.strictEqual(response.status, 400, 'HTTP 400 status');
       });
 
       test('rejects non-URL realm param', async function (assert) {
         let response = await context.request
-          .get(
-            `/_grafana-upsert-realm-user-permission?authHeader=${grafanaSecret}` +
-              `&realm=not-a-url` +
+          .post(
+            `/_grafana-upsert-realm-user-permission` +
+              `?realm=not-a-url` +
               `&user=${encodeURIComponent('@op-test:localhost')}` +
               `&read=true&write=false`,
           )
+          .set('Authorization', `Bearer ${grafanaSecret}`)
           .set('Content-Type', 'application/json');
         assert.strictEqual(response.status, 400, 'HTTP 400 status');
       });
 
       test('returns 401 without a grafana secret', async function (assert) {
         let response = await context.request
-          .get(
+          .post(
             `/_grafana-upsert-realm-user-permission` +
               `?realm=${encodeURIComponent(testRealmURL.href)}` +
               `&user=${encodeURIComponent('@op-test:localhost')}` +
@@ -1285,6 +1337,19 @@ module(`server-endpoints/${basename(__filename)}`, function () {
           )
           .set('Content-Type', 'application/json');
         assert.strictEqual(response.status, 401, 'HTTP 401 status');
+      });
+
+      test('returns 404 on legacy GET (POST-only endpoint)', async function (assert) {
+        let response = await context.request
+          .get(
+            `/_grafana-upsert-realm-user-permission` +
+              `?authHeader=${grafanaSecret}` +
+              `&realm=${encodeURIComponent(testRealmURL.href)}` +
+              `&user=${encodeURIComponent('@op-test:localhost')}` +
+              `&read=true&write=false`,
+          )
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 404, 'HTTP 404 status');
       });
     },
   );

--- a/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import { PgAdapter, PgQueueRunner } from '@cardstack/postgres';
 import { sumUpCreditsLedger } from '@cardstack/billing/billing-queries';
 import * as boxelUIChangeChecker from '../../lib/boxel-ui-change-checker';
+import { fetchRealmPermissions } from '@cardstack/runtime-common';
 import { grafanaSecret, insertUser, realmSecretSeed } from '../helpers';
 import { createJWT as createRealmServerJWT } from '../../utils/jwt';
 import { setupServerEndpointsTest, testRealmURL } from './helpers';
@@ -1156,6 +1157,134 @@ module(`server-endpoints/${basename(__filename)}`, function () {
           initialJobs.length,
           'an index job was not created',
         );
+      });
+
+      test('grants read-only via grafana upsert-realm-user-permission endpoint', async function (assert) {
+        let user = '@op-test:localhost';
+        let response = await context.request
+          .get(
+            `/_grafana-upsert-realm-user-permission?authHeader=${grafanaSecret}` +
+              `&realm=${encodeURIComponent(testRealmURL.href)}` +
+              `&user=${encodeURIComponent(user)}` +
+              `&read=true&write=false`,
+          )
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 200, 'HTTP 200 status');
+        let perms = await fetchRealmPermissions(
+          context.dbAdapter,
+          testRealmURL,
+        );
+        assert.deepEqual(perms[user], ['read'], 'user has read only');
+      });
+
+      test('grants read+write via grafana upsert-realm-user-permission endpoint', async function (assert) {
+        let user = '@op-test-rw:localhost';
+        let response = await context.request
+          .get(
+            `/_grafana-upsert-realm-user-permission?authHeader=${grafanaSecret}` +
+              `&realm=${encodeURIComponent(testRealmURL.href)}` +
+              `&user=${encodeURIComponent(user)}` +
+              `&read=true&write=true`,
+          )
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 200, 'HTTP 200 status');
+        let perms = await fetchRealmPermissions(
+          context.dbAdapter,
+          testRealmURL,
+        );
+        assert.deepEqual(
+          perms[user].sort(),
+          ['read', 'write'],
+          'user has read+write',
+        );
+      });
+
+      test('upserts: re-grant on the same user updates instead of duplicating', async function (assert) {
+        let user = '@op-test-upsert:localhost';
+        let url = (read: string, write: string) =>
+          `/_grafana-upsert-realm-user-permission?authHeader=${grafanaSecret}` +
+          `&realm=${encodeURIComponent(testRealmURL.href)}` +
+          `&user=${encodeURIComponent(user)}` +
+          `&read=${read}&write=${write}`;
+        // First call: read only.
+        await context.request
+          .get(url('true', 'false'))
+          .set('Content-Type', 'application/json');
+        // Second call: upgrade to read+write.
+        let response = await context.request
+          .get(url('true', 'true'))
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 200, 'HTTP 200 status');
+        let perms = await fetchRealmPermissions(
+          context.dbAdapter,
+          testRealmURL,
+        );
+        assert.deepEqual(
+          perms[user].sort(),
+          ['read', 'write'],
+          'second call replaced the first',
+        );
+      });
+
+      test('rejects write-only (write requires read)', async function (assert) {
+        let user = '@op-test-bad:localhost';
+        let response = await context.request
+          .get(
+            `/_grafana-upsert-realm-user-permission?authHeader=${grafanaSecret}` +
+              `&realm=${encodeURIComponent(testRealmURL.href)}` +
+              `&user=${encodeURIComponent(user)}` +
+              `&read=false&write=true`,
+          )
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 400, 'HTTP 400 status');
+      });
+
+      test('rejects read=false write=false (use the delete flow to revoke)', async function (assert) {
+        let user = '@op-test-revoke:localhost';
+        let response = await context.request
+          .get(
+            `/_grafana-upsert-realm-user-permission?authHeader=${grafanaSecret}` +
+              `&realm=${encodeURIComponent(testRealmURL.href)}` +
+              `&user=${encodeURIComponent(user)}` +
+              `&read=false&write=false`,
+          )
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 400, 'HTTP 400 status');
+      });
+
+      test('rejects missing realm param', async function (assert) {
+        let response = await context.request
+          .get(
+            `/_grafana-upsert-realm-user-permission?authHeader=${grafanaSecret}` +
+              `&user=${encodeURIComponent('@op-test:localhost')}` +
+              `&read=true&write=false`,
+          )
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 400, 'HTTP 400 status');
+      });
+
+      test('rejects non-URL realm param', async function (assert) {
+        let response = await context.request
+          .get(
+            `/_grafana-upsert-realm-user-permission?authHeader=${grafanaSecret}` +
+              `&realm=not-a-url` +
+              `&user=${encodeURIComponent('@op-test:localhost')}` +
+              `&read=true&write=false`,
+          )
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 400, 'HTTP 400 status');
+      });
+
+      test('returns 401 without a grafana secret', async function (assert) {
+        let response = await context.request
+          .get(
+            `/_grafana-upsert-realm-user-permission` +
+              `?realm=${encodeURIComponent(testRealmURL.href)}` +
+              `&user=${encodeURIComponent('@op-test:localhost')}` +
+              `&read=true&write=false`,
+          )
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 401, 'HTTP 401 status');
       });
     },
   );


### PR DESCRIPTION
## Summary
The Realms-dashboard "Grant Permission" Operator Action panel POSTs to \`/_grafana-upsert-realm-user-permission?realm=...&user=...&read=...&write=...\` with the same \`Authorization: Bearer \${grafana_secret}\` header used by the other grafana endpoints. The realm-server side was deliberately deferred (README phase-3.5 note) and never landed — the button currently authenticates fine and gets a clean 404 because the route doesn't exist.

This adds the missing handler + route registration. Same auth pattern (\`grafanaAuthorization\`), same dual GET/POST registration via \`registerGrafanaEndpoint\` for the CS-10987 cutover window, same upsert path the realm-server's own \`/_realm-permissions\` endpoints use (\`insertPermissions\` from runtime-common).

### Behavior
- Required query params: \`realm\` (URL), \`user\` (Matrix user id).
- \`read\` / \`write\` are \`'true'\` / \`'false'\` flags from the dashboard.
- Read-only and read+write are accepted.
- Write-without-read is rejected (write requires read).
- Both-false is rejected (use the existing delete flow to revoke).

## Depends on
- The dashboard side (#4744 Realms Grant Permission as Business Forms) needs to land alongside this for the operator workflow to be complete; either order works for the merge.
- Local-dev: restart the realm-server to pick up the new route.

## Test plan
- [ ] Test suite added in \`maintenance-endpoints-test.ts\` (read-only grant, read+write grant, idempotent re-grant, write-without-read rejection, both-false rejection, missing realm, non-URL realm, missing auth)
- [ ] Manual: open Realms dashboard, pick a user from the Matrix-username dropdown, choose a permission level, click Grant — confirm dialog → 200 → notify success → refresh shows the new row in the Realm Permissions table

🤖 Generated with [Claude Code](https://claude.com/claude-code)