### PR TITLE
Grafana: add AWS ELB Application Load Balancer dashboard

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/aws-elb.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/aws-elb.json
@@ -1,0 +1,2048 @@
+{
+  "apiVersion": "dashboard.grafana.app/v1beta1",
+  "kind": "Dashboard",
+  "metadata": {
+    "annotations": {
+      "grafana.app/folder": "defd2d156sav4d"
+    },
+    "name": "boxel-aws-elb"
+  },
+  "spec": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "description": "Visualize AWS ELB Application Load Balancer metrics",
+    "editable": false,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "links": [],
+    "panels": [
+      {
+        "datasource": {
+          "uid": "cef5x9o3yzawwf"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": true,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 0,
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "TargetResponseTime"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "s"
+                },
+                {
+                  "id": "custom.axisPlacement",
+                  "value": "right"
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 7,
+        "options": {
+          "dataLinks": [],
+          "legend": {
+            "calcs": [
+              "mean",
+              "max",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.1",
+        "targets": [
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "label": "",
+            "metricEditorMode": 0,
+            "metricName": "RequestCount",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "A",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "label": "",
+            "metricEditorMode": 0,
+            "metricName": "TargetResponseTime",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "B",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Average"
+          }
+        ],
+        "title": "RequestCount/TargetResponseTime",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "cloudwatch",
+          "uid": "cef5x9o3yzawwf"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 10,
+          "w": 24,
+          "x": 0,
+          "y": 7
+        },
+        "id": 1,
+        "options": {
+          "dataLinks": [],
+          "legend": {
+            "calcs": [
+              "mean",
+              "max",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.1",
+        "targets": [
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "HTTPCode_Target_5XX_Count",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "D",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "HTTPCode_Target_4XX_Count",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "C",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "HTTPCode_Target_3XX_Count",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "B",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "HTTPCode_Target_2XX_Count",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "A",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          }
+        ],
+        "title": "HTTPCode_Target",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "uid": "cef5x9o3yzawwf"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 0,
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 17
+        },
+        "id": 12,
+        "options": {
+          "dataLinks": [],
+          "legend": {
+            "calcs": [
+              "mean",
+              "max",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.1",
+        "targets": [
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "HTTPCode_ELB_3XX_Count",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "D",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "HTTPCode_ELB_4XX_Count",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "A",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "HTTPCode_ELB_5XX_Count",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "B",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          }
+        ],
+        "title": "HTTPCode_ELB",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "uid": "cef5x9o3yzawwf"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 0,
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 24
+        },
+        "id": 10,
+        "options": {
+          "dataLinks": [],
+          "legend": {
+            "calcs": [
+              "mean",
+              "max",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.1",
+        "targets": [
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "label": "",
+            "metricEditorMode": 0,
+            "metricName": "ActiveConnectionCount",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "D",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Average"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "label": "",
+            "metricEditorMode": 0,
+            "metricName": "NewConnectionCount",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "C",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Average"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "label": "",
+            "metricEditorMode": 0,
+            "metricName": "RejectedConnectionCount",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "B",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Average"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "label": "",
+            "metricEditorMode": 0,
+            "metricName": "TargetConnectionErrorCount",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "A",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Average"
+          }
+        ],
+        "title": "ConnectionCount",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "cloudwatch",
+          "uid": "cef5x9o3yzawwf"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": true,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "ProcessedBytes_Average"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "bytes"
+                },
+                {
+                  "id": "custom.axisPlacement",
+                  "value": "right"
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 31
+        },
+        "id": 8,
+        "options": {
+          "dataLinks": [],
+          "legend": {
+            "calcs": [
+              "mean",
+              "max",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.1",
+        "targets": [
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "label": "",
+            "metricEditorMode": 0,
+            "metricName": "ConsumedLBCapacityUnits",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "A",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Average"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "label": "",
+            "metricEditorMode": 0,
+            "metricName": "ProcessedBytes",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "B",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Average"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "label": "",
+            "metricEditorMode": 0,
+            "metricName": "ConsumedLCUs",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "C",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Average"
+          }
+        ],
+        "title": "ConsumedLBCapacityUnits/ConsumedLCUs/ProcessedBytes",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "cloudwatch",
+          "uid": "cef5x9o3yzawwf"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 0,
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 39
+        },
+        "id": 11,
+        "options": {
+          "dataLinks": [],
+          "legend": {
+            "calcs": [
+              "mean",
+              "max",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.1",
+        "targets": [
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "TargetTLSNegotiationErrorCount",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "D",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "ClientTLSNegotiationErrorCount",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "C",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          }
+        ],
+        "title": "TLSNegotiationErrorCount",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "uid": "cef5x9o3yzawwf"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 0,
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "IPv6ProcessedBytes_Sum"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "decbytes"
+                },
+                {
+                  "id": "custom.axisPlacement",
+                  "value": "right"
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 46
+        },
+        "id": 15,
+        "options": {
+          "dataLinks": [],
+          "legend": {
+            "calcs": [
+              "mean",
+              "max",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.1",
+        "targets": [
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "IPv6RequestCount",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "D",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "IPv6ProcessedBytes",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "A",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          }
+        ],
+        "title": "IPv6",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "cloudwatch",
+          "uid": "cef5x9o3yzawwf"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 0,
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 53
+        },
+        "id": 13,
+        "options": {
+          "dataLinks": [],
+          "legend": {
+            "calcs": [
+              "mean",
+              "max",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.1",
+        "targets": [
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "RuleEvaluations",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "D",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          }
+        ],
+        "title": "RuleEvaluations",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "cloudwatch",
+          "uid": "cef5x9o3yzawwf"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "normal"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 0,
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "ELBAuthLatency_Average"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "ms"
+                },
+                {
+                  "id": "custom.axisPlacement",
+                  "value": "right"
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 14,
+          "w": 24,
+          "x": 0,
+          "y": 60
+        },
+        "id": 14,
+        "options": {
+          "dataLinks": [],
+          "legend": {
+            "calcs": [
+              "mean",
+              "max",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.1",
+        "targets": [
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "ELBAuthError",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "D",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "ELBAuthFailure",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "B",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "ELBAuthSuccess",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "A",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "ELBAuthRefreshTokenSuccess",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "C",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "ELBAuthUserClaimsSizeExceeded",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "E",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Sum"
+          },
+          {
+            "alias": "",
+            "application": {
+              "filter": ""
+            },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername"
+            },
+            "expression": "",
+            "functions": [],
+            "group": {
+              "filter": ""
+            },
+            "highResolution": false,
+            "host": {
+              "filter": ""
+            },
+            "id": "",
+            "item": {
+              "filter": ""
+            },
+            "metricEditorMode": 0,
+            "metricName": "ELBAuthLatency",
+            "metricQueryType": 0,
+            "mode": 0,
+            "namespace": "AWS/ApplicationELB",
+            "options": {
+              "showDisabledItems": false
+            },
+            "period": "",
+            "refId": "F",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Average"
+          }
+        ],
+        "title": "Auth",
+        "type": "timeseries"
+      },
+      {
+        "gridPos": {
+          "h": 3,
+          "w": 24,
+          "x": 0,
+          "y": 74
+        },
+        "id": 2,
+        "options": {
+          "code": {
+            "language": "plaintext",
+            "showLineNumbers": false,
+            "showMiniMap": false
+          },
+          "content": "<a target=\"_blank\" href=\"http://www.monitoringartist.com\" title=\"Dashboard maintained by Monitoring Artist - DevOps / Docker / Kubernetes / AWS ECS / Google GCP / Zabbix / Zenoss / Terraform / Monitoring\"><img src=\"https://monitoringartist.github.io/monitoring-artist-logo-grafana.png\" height=\"30px\" /></a> | \n<a target=\"_blank\" href=\"https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html\">AWS CloudWatch ELB documentation</a> | \n<a target=\"_blank\" href=\"https://grafana.com/dashboards/650\">Installed from Grafana.com dashboards</a>",
+          "mode": "html"
+        },
+        "pluginVersion": "11.3.1",
+        "title": "Documentation",
+        "type": "text"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 40,
+    "tags": [
+      "monitoringartist",
+      "cloudwatch"
+    ],
+    "templating": {
+      "list": [
+        {
+          "current": {},
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "cef5x9o3yzawwf"
+          },
+          "definition": "regions()",
+          "includeAll": false,
+          "label": "Region",
+          "name": "region",
+          "options": [],
+          "query": "regions()",
+          "refresh": 1,
+          "regex": "",
+          "type": "query"
+        },
+        {
+          "current": {},
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "cef5x9o3yzawwf"
+          },
+          "definition": "dimension_values($region,AWS/ApplicationELB,ActiveConnectionCount,LoadBalancer)",
+          "includeAll": false,
+          "label": "LoadBalancerName",
+          "name": "loadbalancername",
+          "options": [],
+          "query": "dimension_values($region,AWS/ApplicationELB,ActiveConnectionCount,LoadBalancer)",
+          "refresh": 1,
+          "regex": "",
+          "sort": 1,
+          "type": "query"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-7d",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "AWS ELB Application Load Balancer",
+    "weekStart": ""
+  }
+}

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/aws-elb.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/aws-elb.json
@@ -32,7 +32,8 @@
     "panels": [
       {
         "datasource": {
-          "uid": "cef5x9o3yzawwf"
+          "uid": "cef5x9o3yzawwf",
+          "type": "cloudwatch"
         },
         "fieldConfig": {
           "defaults": {
@@ -181,7 +182,8 @@
               "filter": ""
             },
             "datasource": {
-              "uid": "cef5x9o3yzawwf"
+              "uid": "cef5x9o3yzawwf",
+              "type": "cloudwatch"
             },
             "dimensions": {
               "LoadBalancer": "$loadbalancername"
@@ -312,7 +314,8 @@
               "filter": ""
             },
             "datasource": {
-              "uid": "cef5x9o3yzawwf"
+              "uid": "cef5x9o3yzawwf",
+              "type": "cloudwatch"
             },
             "dimensions": {
               "LoadBalancer": "$loadbalancername"
@@ -389,7 +392,8 @@
               "filter": ""
             },
             "datasource": {
-              "uid": "cef5x9o3yzawwf"
+              "uid": "cef5x9o3yzawwf",
+              "type": "cloudwatch"
             },
             "dimensions": {
               "LoadBalancer": "$loadbalancername"
@@ -466,7 +470,8 @@
       },
       {
         "datasource": {
-          "uid": "cef5x9o3yzawwf"
+          "uid": "cef5x9o3yzawwf",
+          "type": "cloudwatch"
         },
         "fieldConfig": {
           "defaults": {
@@ -597,7 +602,8 @@
               "filter": ""
             },
             "datasource": {
-              "uid": "cef5x9o3yzawwf"
+              "uid": "cef5x9o3yzawwf",
+              "type": "cloudwatch"
             },
             "dimensions": {
               "LoadBalancer": "$loadbalancername"
@@ -674,7 +680,8 @@
       },
       {
         "datasource": {
-          "uid": "cef5x9o3yzawwf"
+          "uid": "cef5x9o3yzawwf",
+          "type": "cloudwatch"
         },
         "fieldConfig": {
           "defaults": {
@@ -805,7 +812,8 @@
               "filter": ""
             },
             "datasource": {
-              "uid": "cef5x9o3yzawwf"
+              "uid": "cef5x9o3yzawwf",
+              "type": "cloudwatch"
             },
             "dimensions": {
               "LoadBalancer": "$loadbalancername"
@@ -884,7 +892,8 @@
               "filter": ""
             },
             "datasource": {
-              "uid": "cef5x9o3yzawwf"
+              "uid": "cef5x9o3yzawwf",
+              "type": "cloudwatch"
             },
             "dimensions": {
               "LoadBalancer": "$loadbalancername"
@@ -1031,7 +1040,8 @@
               "filter": ""
             },
             "datasource": {
-              "uid": "cef5x9o3yzawwf"
+              "uid": "cef5x9o3yzawwf",
+              "type": "cloudwatch"
             },
             "dimensions": {
               "LoadBalancer": "$loadbalancername"
@@ -1110,7 +1120,8 @@
               "filter": ""
             },
             "datasource": {
-              "uid": "cef5x9o3yzawwf"
+              "uid": "cef5x9o3yzawwf",
+              "type": "cloudwatch"
             },
             "dimensions": {
               "LoadBalancer": "$loadbalancername"
@@ -1241,7 +1252,8 @@
               "filter": ""
             },
             "datasource": {
-              "uid": "cef5x9o3yzawwf"
+              "uid": "cef5x9o3yzawwf",
+              "type": "cloudwatch"
             },
             "dimensions": {
               "LoadBalancer": "$loadbalancername"
@@ -1318,7 +1330,8 @@
       },
       {
         "datasource": {
-          "uid": "cef5x9o3yzawwf"
+          "uid": "cef5x9o3yzawwf",
+          "type": "cloudwatch"
         },
         "fieldConfig": {
           "defaults": {
@@ -1465,7 +1478,8 @@
               "filter": ""
             },
             "datasource": {
-              "uid": "cef5x9o3yzawwf"
+              "uid": "cef5x9o3yzawwf",
+              "type": "cloudwatch"
             },
             "dimensions": {
               "LoadBalancer": "$loadbalancername"
@@ -1595,7 +1609,8 @@
               "filter": ""
             },
             "datasource": {
-              "uid": "cef5x9o3yzawwf"
+              "uid": "cef5x9o3yzawwf",
+              "type": "cloudwatch"
             },
             "dimensions": {
               "LoadBalancer": "$loadbalancername"
@@ -1742,7 +1757,8 @@
               "filter": ""
             },
             "datasource": {
-              "uid": "cef5x9o3yzawwf"
+              "uid": "cef5x9o3yzawwf",
+              "type": "cloudwatch"
             },
             "dimensions": {
               "LoadBalancer": "$loadbalancername"
@@ -1819,7 +1835,8 @@
               "filter": ""
             },
             "datasource": {
-              "uid": "cef5x9o3yzawwf"
+              "uid": "cef5x9o3yzawwf",
+              "type": "cloudwatch"
             },
             "dimensions": {
               "LoadBalancer": "$loadbalancername"
@@ -1896,7 +1913,8 @@
               "filter": ""
             },
             "datasource": {
-              "uid": "cef5x9o3yzawwf"
+              "uid": "cef5x9o3yzawwf",
+              "type": "cloudwatch"
             },
             "dimensions": {
               "LoadBalancer": "$loadbalancername"


### PR DESCRIPTION
## Summary
Vendored the popular community ELB Application Load Balancer dashboard ([Grafana.com #650, rev 9](https://grafana.com/grafana/dashboards/650-aws-elb-application-load-balancer/)) into our self-host Grafana setup so we can see ALB metrics alongside the rest of the Boxel observability stack.

10 panels: RequestCount / TargetResponseTime, HTTPCode_Target, HTTPCode_ELB, ConnectionCount, LCUs / ProcessedBytes, TLS, IPv6, RuleEvaluations, Auth, plus a Documentation text panel.

### Adapter to our setup
- Replaced every \`$datasource\` reference with the committed CloudWatch UID (\`cef5x9o3yzawwf\`) — matches the convention in \`overview.json\` / \`service-*.json\`. No datasource picker dropdown.
- Dropped the now-unused \`datasource\` template variable; \`region\` and \`loadbalancername\` query variables stay (auto-populate from CloudWatch).
- Wrapped in the grafanactl manifest envelope (\`apiVersion\` / \`kind\` / \`metadata\` / \`spec\`); filed under the **Boxel Status** folder. Dashboard UID \`boxel-aws-elb\`.
- Stripped export-only fields (\`__inputs\` / \`__elements\` / \`__requires\` / \`gnetId\` / top-level \`id\` / \`uid\` / \`version\`).

## Test plan
- [ ] Local: \`./scripts/apply.sh\` succeeds; dashboard shows up in the Boxel Status folder; panels render as markdown placeholders (because the local CloudWatch datasource has no AWS creds — same as the other CloudWatch panels)
- [ ] Staging: \`./scripts/apply.sh --env staging\` deploys it; pick a region + load balancer; panels populate with live ALB metrics
- [ ] Confirm the load-balancer dropdown lists the realm-server and prerender-server ALBs (or whatever ALBs are in the picked region)

🤖 Generated with [Claude Code](https://claude.com/claude-code)