### PR TITLE
observability-diff: scope filter pathspec from repo root, not CWD

### DIFF
--- a/packages/observability/scripts/diff.sh
+++ b/packages/observability/scripts/diff.sh
@@ -107,7 +107,20 @@ if [[ -n "$only_changed_since" ]]; then
   # deletes; a deletion in the PR is a no-op for live state. Without
   # this, a PR that only deletes a dashboard would skip the empty-set
   # short-circuit below and trigger a needless `grafanactl pull`.
-  filter_paths="$(git diff --name-only --diff-filter=ACMRT \
+  #
+  # `git -C <repo-root>` so the path filter and output paths are both
+  # repo-rooted, regardless of where the script was invoked from. The
+  # CI workflow runs us with `working-directory: packages/observability`,
+  # which combined with the `cd "$(dirname "$0")/.."` above leaves
+  # `$PWD` at `packages/observability` — and from there git would
+  # interpret `-- packages/observability/grafanactl/resources/` as a
+  # CWD-relative pathspec (i.e., `packages/observability/packages/observability/...`),
+  # which never matches anything and silently returns an empty set,
+  # short-circuiting every observability PR to a blank diff comment.
+  # `is_in_filter_rel` below also expects repo-rooted paths in the
+  # `filter_paths` strings, so this fix keeps both sides aligned.
+  filter_paths="$(git -C "$(git rev-parse --show-toplevel)" \
+    diff --name-only --diff-filter=ACMRT \
     "${only_changed_since}...HEAD" \
     -- packages/observability/grafanactl/resources/)"
   if [[ -z "$filter_paths" ]]; then


### PR DESCRIPTION
## Summary
Every observability PR since [0356790d8b](https://github.com/cardstack/boxel/commit/0356790d8b) has been silently rendering the same comment:

> ## Observability diff (vs staging)
> No dashboard / folder changes detected against the staging Grafana.

…even when the PR clearly changes dashboards (e.g. #4747's 2k-line ELB dashboard add, #4748's 594-line Job Queue metrics row). The CI never actually pulls staging — diff.sh short-circuits with an empty stdout before the pull.

### Root cause
The workflow runs the script with \`working-directory: packages/observability\`. \`diff.sh\` then \`cd "$(dirname "$0")/.."\`, leaving \`$PWD\` at \`packages/observability\`. The filter command:

\`\`\`bash
git diff --name-only --diff-filter=ACMRT \
  "\${only_changed_since}...HEAD" \
  -- packages/observability/grafanactl/resources/
\`\`\`

uses a CWD-relative pathspec. From \`packages/observability/\`, git resolves it as \`packages/observability/packages/observability/grafanactl/resources/\` — a path that never exists. The filter returns empty, \`filter_paths\` is empty, and the early \`exit 0\` triggers.

\`is_in_filter_rel\` later in the script builds its match key with the full \`packages/observability/grafanactl/resources/...\` prefix, so the fix needs to keep \`filter_paths\` repo-rooted (not just switch to a relative pathspec). Running \`git diff\` via \`git -C "$(git rev-parse --show-toplevel)"\` keeps both the input pathspec and the output paths repo-rooted regardless of CWD.

### Verification
Reproduced + verified locally by simulating the filter from \`packages/observability/\` against #4748's merge ref:

- Pre-fix: filter returns empty
- Post-fix: filter returns \`packages/observability/grafanactl/resources/dashboards/boxel-status/job-queue.json\`

Once this lands on main, existing open observability PRs that rebase (or get a sync push) will start showing real diffs in their PR comments.

## Test plan
- [ ] Merge this; rebase #4748 onto main; confirm its observability-diff comment now shows the actual Job Queue dashboard changes
- [ ] Same for any other open observability PR (#4747, #4744, …)

🤖 Generated with [Claude Code](https://claude.com/claude-code)