### PR TITLE
CS-11028: discard #moduleCache write when invalidate races a transpile

### DIFF
--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -167,6 +167,7 @@ import './file-watcher-events-test';
 import './full-reindex-test';
 import './indexing-test';
 import './lazy-mount-test';
+import './module-cache-race-test';
 import './module-syntax-test';
 import './permissions/permission-checker-test';
 import './prerendering-test';

--- a/packages/realm-server/tests/module-cache-race-test.ts
+++ b/packages/realm-server/tests/module-cache-race-test.ts
@@ -1,0 +1,278 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import type { SuperTest, Test } from 'supertest';
+import type { Server } from 'http';
+import type { Realm } from '@cardstack/runtime-common';
+import { SupportedMimeType } from '@cardstack/runtime-common';
+import {
+  setupPermissionedRealmCached,
+  createJWT,
+  withRealmPath,
+  type RealmRequest,
+} from './helpers';
+
+// CS-11028: regression coverage for the persist-after-invalidate race in
+// Realm.#moduleCache. The scenario: reader A enters fallbackHandle for
+// foo.gts, snapshots the module-cache generation, then awaits transpileJS
+// (50–500 ms). While A is in-flight, invalidateCache(foo.gts) runs —
+// synchronously bumping the per-path generation and clearing whatever was
+// in the cache (a no-op if A hadn't filled it yet). Without the fix A's
+// post-transpile #moduleCache.set re-fills the slot with pre-invalidation
+// bytes, so the next reader sees stale code until something else triggers
+// another invalidate. The fix snapshots the generation BEFORE the first
+// await and discards the cache write when the generation moved.
+//
+// The tests below race a real .gts transpile against invalidateCache /
+// __testOnlyClearCaches by firing the request, waiting a generous slice
+// (50 ms) for fallbackHandle to reach its snapshot and enter transpileJS,
+// then issuing the invalidate synchronously. .gts transpiles are
+// reliably > 50 ms (babel + ember-template-compilation + decorator
+// transforms + scoped-css), so the invalidate lands inside the race
+// window. The observable assertion is on the subsequent request's
+// `x-boxel-cache` header — a miss proves A's cache write was discarded.
+module(basename(__filename), function () {
+  module(
+    'Realm.#moduleCache invalidate-during-transpile race',
+    function (hooks) {
+      let realmURL = new URL('http://127.0.0.1:4444/test/');
+      let testRealm: Realm;
+      let request: RealmRequest;
+
+      function onRealmSetup(args: {
+        testRealm: Realm;
+        testRealmHttpServer: Server;
+        request: SuperTest<Test>;
+      }) {
+        testRealm = args.testRealm;
+        request = withRealmPath(args.request, realmURL);
+      }
+
+      setupPermissionedRealmCached(hooks, {
+        realmURL,
+        permissions: {
+          '*': ['read', 'write'],
+          user: ['read', 'write', 'realm-owner'],
+          '@node-test_realm:localhost': ['read', 'realm-owner'],
+        },
+        onRealmSetup,
+      });
+
+      const transpilerHeavySource = `
+      import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
+      import StringField from "https://cardstack.com/base/string";
+
+      export class RaceCard extends CardDef {
+        @field name = contains(StringField);
+        @field title = contains(StringField);
+        static isolated = class Isolated extends Component<typeof this> {
+          <template>
+            <div data-test-race-isolated>
+              <h1><@fields.name/></h1>
+              <h2><@fields.title/></h2>
+            </div>
+          </template>
+        }
+        static embedded = class Embedded extends Component<typeof this> {
+          <template>
+            <span data-test-race-embedded><@fields.name/></span>
+          </template>
+        }
+      }
+    `;
+
+      function authHeader() {
+        return `Bearer ${createJWT(testRealm, 'user', ['read', 'write'])}`;
+      }
+
+      // supertest's Test is a thenable — the HTTP request fires the first
+      // time .then() is called. Adding an identity .then() now forces the
+      // dispatch so the caller can race other work against the in-flight
+      // request instead of waiting for an `await` to start it.
+      function fireRequest(path: string): Promise<unknown> {
+        return request
+          .get(`/${path}`)
+          .set('Accept', SupportedMimeType.All)
+          .set('Authorization', authHeader())
+          .then((r) => r);
+      }
+
+      test('in-flight transpile result is dropped when invalidateCache fires concurrently', async function (assert) {
+        let modulePath = 'race-invalidate.gts';
+        await testRealm.write(modulePath, transpilerHeavySource);
+        testRealm.__testOnlyClearCaches();
+
+        let inflight = fireRequest(modulePath);
+        // Wait long enough for fallbackHandle to reach its snapshot and
+        // enter transpileJS. .gts transpiles take 50–500 ms; 50 ms is a
+        // comfortable window for the request to reach the snapshot point.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // Invalidate mid-transpile. The generation counter bumps; A's
+        // post-transpile #moduleCache.set will compare its snapshot against
+        // the now-bumped counter and skip the write.
+        testRealm.invalidateCache(modulePath);
+
+        let response = (await inflight) as { status: number };
+        assert.strictEqual(
+          response.status,
+          200,
+          'in-flight request still serves pre-invalidation bytes — the response is a function of what A read at request time',
+        );
+
+        let nextResponse = await request
+          .get(`/${modulePath}`)
+          .set('Accept', SupportedMimeType.All)
+          .set('Authorization', authHeader());
+
+        assert.strictEqual(
+          nextResponse.headers['x-boxel-cache'],
+          'miss',
+          'next request is a cache miss — A’s pre-invalidation transpile did not re-fill the slot invalidate cleared',
+        );
+      });
+
+      test('invalidateCache of an unrelated path does not drop the in-flight cache write', async function (assert) {
+        let primaryPath = 'race-primary.gts';
+        let unrelatedPath = 'race-unrelated.gts';
+        await testRealm.write(primaryPath, transpilerHeavySource);
+        await testRealm.write(unrelatedPath, transpilerHeavySource);
+        testRealm.__testOnlyClearCaches();
+
+        let inflight = fireRequest(primaryPath);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // Invalidate a DIFFERENT path mid-transpile. The per-path counter
+        // for primaryPath is unchanged, so A's cache.set proceeds normally.
+        testRealm.invalidateCache(unrelatedPath);
+
+        let response = (await inflight) as { status: number };
+        assert.strictEqual(response.status, 200);
+
+        let nextResponse = await request
+          .get(`/${primaryPath}`)
+          .set('Accept', SupportedMimeType.All)
+          .set('Authorization', authHeader());
+
+        assert.strictEqual(
+          nextResponse.headers['x-boxel-cache'],
+          'hit',
+          'cross-path invalidate did not poison the in-flight cache write — per-path scoping is correct',
+        );
+      });
+
+      test('in-flight transpile to an extensionless alias is dropped when invalidateCache targets the canonical path', async function (assert) {
+        // getFileWithFallbacks lets a request for /race-alias resolve to
+        // race-alias.gts. The cache entry is then stored under "race-alias"
+        // (the request's localPath) but its canonicalPath is "race-alias.gts".
+        // invalidateCache fires against the canonical, so the discard
+        // check has to compare snapshot vs current generation for the
+        // canonical path — checking only localPath would miss the race
+        // and leave the "race-alias" alias serving stale bytes.
+        let canonicalPath = 'race-alias.gts';
+        let aliasPath = 'race-alias';
+        await testRealm.write(canonicalPath, transpilerHeavySource);
+        testRealm.__testOnlyClearCaches();
+
+        let inflight = fireRequest(aliasPath);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        testRealm.invalidateCache(canonicalPath);
+
+        let response = (await inflight) as { status: number };
+        assert.strictEqual(response.status, 200);
+
+        // Next request to the extensionless alias: must be a cache miss.
+        // Without the canonical-aware discard check this comes back as
+        // 'hit' because the pre-invalidation transpile re-filled the
+        // alias slot.
+        let aliasResponse = await request
+          .get(`/${aliasPath}`)
+          .set('Accept', SupportedMimeType.All)
+          .set('Authorization', authHeader());
+        assert.strictEqual(
+          aliasResponse.headers['x-boxel-cache'],
+          'miss',
+          'alias request is a cache miss — the canonical-aware discard caught the race',
+        );
+
+        // The canonical request side already worked before this fix
+        // (#moduleCache.invalidate cleared the canonical entry), but
+        // verify it still misses so the fix doesn't regress it.
+        let canonicalResponse = await request
+          .get(`/${canonicalPath}`)
+          .set('Accept', SupportedMimeType.All)
+          .set('Authorization', authHeader());
+        assert.strictEqual(
+          canonicalResponse.headers['x-boxel-cache'],
+          'miss',
+          'canonical request is a cache miss too — fresh transpile served',
+        );
+      });
+
+      test('in-flight transpile result is dropped when testRealm.write fires concurrently (user-visible bug)', async function (assert) {
+        // The original bug report: "file edited and saved, host page reload
+        // serves the pre-edit module bytes." A user write goes through
+        // writeMany, which used to mutate #moduleCache directly without
+        // bumping the generation counter — letting an in-flight transpile's
+        // post-await cache.set silently fill the slot writeMany just
+        // cleared. This test exercises the same code path the user does.
+        let modulePath = 'race-write.gts';
+        await testRealm.write(modulePath, transpilerHeavySource);
+        testRealm.__testOnlyClearCaches();
+
+        let inflight = fireRequest(modulePath);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // The "user edits the file" path: writeMany bumps the path's
+        // generation and clears the cache entry. A's transpile (in flight
+        // against pre-edit bytes) must drop its cache.set.
+        await testRealm.write(
+          modulePath,
+          transpilerHeavySource.replace('RaceCard', 'EditedCard'),
+        );
+
+        let response = (await inflight) as { status: number };
+        assert.strictEqual(response.status, 200);
+
+        let nextResponse = await request
+          .get(`/${modulePath}`)
+          .set('Accept', SupportedMimeType.All)
+          .set('Authorization', authHeader());
+
+        assert.strictEqual(
+          nextResponse.headers['x-boxel-cache'],
+          'miss',
+          'next request is a cache miss — the pre-edit transpile did not re-fill the slot writeMany cleared',
+        );
+      });
+
+      test('in-flight transpile result is dropped when __testOnlyClearCaches fires concurrently', async function (assert) {
+        let modulePath = 'race-clear.gts';
+        await testRealm.write(modulePath, transpilerHeavySource);
+        testRealm.__testOnlyClearCaches();
+
+        let inflight = fireRequest(modulePath);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // Global wipe mid-transpile. The path-level counter is reset to 0
+        // alongside A's snapshot value, so only the global counter
+        // distinguishes pre/post-wipe — that's what catches the race here.
+        testRealm.__testOnlyClearCaches();
+
+        let response = (await inflight) as { status: number };
+        assert.strictEqual(response.status, 200);
+
+        let nextResponse = await request
+          .get(`/${modulePath}`)
+          .set('Accept', SupportedMimeType.All)
+          .set('Authorization', authHeader());
+
+        assert.strictEqual(
+          nextResponse.headers['x-boxel-cache'],
+          'miss',
+          'next request is a cache miss — the global generation bump catches the race that the path counter alone would miss',
+        );
+      });
+    },
+  );
+});

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -570,6 +570,18 @@ export class Realm {
   #copiedFromRealm: URL | undefined;
   #sourceCache = new AliasCache<SourceCacheEntry>();
   #moduleCache = new AliasCache<ModuleCacheEntry>();
+  // CS-11028: per-path generation counters for #moduleCache. Bumped
+  // synchronously by invalidateCache(path) before any await. fallbackHandle
+  // snapshots at entry and discards its post-transpile cache write if the
+  // path's generation moved during the in-flight transpile — otherwise the
+  // pre-invalidation bytes would re-populate the slot that invalidate just
+  // cleared and serve stale code until the next invalidate of that path.
+  // #moduleCacheGlobalGeneration covers __testOnlyClearCaches, which wipes
+  // the whole map; a snapshot taken before the wipe sees its `path`
+  // component reset to 0 alongside the live counter, so a global generation
+  // is the only thing that reliably mismatches afterwards.
+  #moduleCacheGenerations: Map<LocalPath, number> = new Map();
+  #moduleCacheGlobalGeneration = 0;
   #cardSizeLimitBytes: number;
   #fileSizeLimitBytes: number;
 
@@ -927,7 +939,7 @@ export class Realm {
 
     let completed = indexingCompleted.then(async ({ invalidations }) => {
       await this.#definitionLookup.clearRealmCache(this.url);
-      this.#moduleCache.clear();
+      this.#dropAllModuleCacheEntries();
       if (invalidations.length > 0) {
         this.broadcastIncrementalInvalidationEvent(invalidations);
       }
@@ -1224,7 +1236,7 @@ export class Realm {
 
   __testOnlyClearCaches() {
     this.#sourceCache.clear();
-    this.#moduleCache.clear();
+    this.#dropAllModuleCacheEntries();
   }
 
   // Invalidate the in-memory byte caches for a single path. Called by the
@@ -1236,8 +1248,82 @@ export class Realm {
   invalidateCache(path: LocalPath): void {
     this.#sourceCache.invalidate(path);
     if (hasExecutableExtension(path)) {
-      this.#moduleCache.invalidate(path);
+      this.#dropModuleCacheEntry(path);
     }
+  }
+
+  // CS-11028: shared drop helper for any in-process site that invalidates a
+  // single #moduleCache entry — writeMany, delete/deleteAll, the local
+  // file-watcher callback, the index-updater's executable-invalidation
+  // cascade, the public invalidateCache entry point, etc. Bumps the
+  // per-path generation BEFORE the cache delete so a concurrent in-flight
+  // transpile for the same path — already past its generation snapshot in
+  // fallbackHandle — observes the new value at persist time and drops its
+  // #moduleCache.set instead of re-filling the slot we're about to empty.
+  #dropModuleCacheEntry(path: LocalPath): void {
+    this.#bumpModuleCacheGeneration(path);
+    this.#moduleCache.invalidate(path);
+  }
+
+  // Wipes every #moduleCache entry and bumps the global generation so any
+  // in-flight transpile whose snapshot was taken before this wipe discards
+  // its post-transpile cache write rather than re-populating the
+  // just-cleared map (CS-11028). The per-path map is cleared because the
+  // generations it held are no longer reachable — the global counter is
+  // what catches in-flight snapshots after a wipe.
+  #dropAllModuleCacheEntries(): void {
+    this.#moduleCache.clear();
+    this.#moduleCacheGenerations.clear();
+    this.#moduleCacheGlobalGeneration += 1;
+  }
+
+  #bumpModuleCacheGeneration(path: LocalPath): void {
+    this.#moduleCacheGenerations.set(
+      path,
+      (this.#moduleCacheGenerations.get(path) ?? 0) + 1,
+    );
+  }
+
+  // Snapshot generations for every path the in-flight request could end
+  // up resolving to. fallbackHandle hands us the request's localPath
+  // (e.g. "foo"), but loadModuleFromDisk's getFileWithFallbacks may
+  // resolve to "foo" or to "foo.<ext>" for each executable extension —
+  // and invalidateCache fires against the canonical (with-extension)
+  // path. Snapshotting only "foo" would let an invalidate of "foo.gts"
+  // bump the canonical's generation while leaving the snapshotted
+  // "foo" gen unchanged, so the post-await check would miss the race
+  // and re-populate the "foo" alias with pre-invalidation bytes. By
+  // snapshotting all candidates here and letting the post-await check
+  // key on result.canonicalPath, we catch the race whether the request
+  // was extensionless or not.
+  #snapshotModuleCacheGeneration(localPath: LocalPath): {
+    pathGens: Map<LocalPath, number>;
+    global: number;
+  } {
+    let pathGens = new Map<LocalPath, number>();
+    pathGens.set(localPath, this.#moduleCacheGenerations.get(localPath) ?? 0);
+    if (!hasExecutableExtension(localPath)) {
+      for (let ext of executableExtensions) {
+        let candidate = localPath + ext;
+        pathGens.set(
+          candidate,
+          this.#moduleCacheGenerations.get(candidate) ?? 0,
+        );
+      }
+    }
+    return { pathGens, global: this.#moduleCacheGlobalGeneration };
+  }
+
+  #moduleCacheGenerationChanged(
+    canonicalPath: LocalPath,
+    snapshot: { pathGens: Map<LocalPath, number>; global: number },
+  ): boolean {
+    if (this.#moduleCacheGlobalGeneration !== snapshot.global) {
+      return true;
+    }
+    let snapGen = snapshot.pathGens.get(canonicalPath) ?? 0;
+    let curGen = this.#moduleCacheGenerations.get(canonicalPath) ?? 0;
+    return curGen !== snapGen;
   }
 
   // Broadcast a file-change notification to peer realm-server instances so
@@ -1395,10 +1481,7 @@ export class Realm {
       await this.trackOwnWrite(path);
       let { lastModified } = await this.#adapter.write(path, content);
       (isNewFile ? addedFiles : updatedFiles).push(path);
-      this.#sourceCache.invalidate(path);
-      if (hasExecutableExtension(path)) {
-        this.#moduleCache.invalidate(path);
-      }
+      this.invalidateCache(path);
       await this.#notifyFileChange(path);
       results.push({ path, lastModified });
       fileMetaRows.push({ path, contentHash, contentSize });
@@ -1876,10 +1959,7 @@ export class Realm {
       removed: [path],
       realmURL: this.url,
     });
-    this.#sourceCache.invalidate(path);
-    if (hasExecutableExtension(path)) {
-      this.#moduleCache.invalidate(path);
-    }
+    this.invalidateCache(path);
     await this.#notifyFileChange(path);
     // Remove file meta for this path
     await this.removeFileMeta([path]);
@@ -1900,10 +1980,7 @@ export class Realm {
       this.sendIndexInitiationEvent(url.href);
       trackPromises.push(this.trackOwnWrite(path, { isDelete: true }));
       removePromises.push(this.#adapter.remove(path));
-      this.#sourceCache.invalidate(path);
-      if (hasExecutableExtension(path)) {
-        this.#moduleCache.invalidate(path);
-      }
+      this.invalidateCache(path);
     }
 
     await Promise.all(trackPromises);
@@ -2231,6 +2308,26 @@ export class Realm {
       }
     }
 
+    // CS-11028: snapshot module-cache generations BEFORE the first await
+    // for every candidate path getFileWithFallbacks could resolve to
+    // (localPath plus each executable-extension fallback when the
+    // request is extensionless). invalidateCache(path) bumps the
+    // counter synchronously, so if it fires while loadModuleFromDisk
+    // is in-flight (typically 50–500 ms for a .gts transpile) the
+    // post-await comparison against result.canonicalPath's snapshotted
+    // gen catches the race and we skip the cache write — otherwise the
+    // pre-invalidation bytes we just produced would re-fill the slot
+    // invalidate just cleared. Checking by canonicalPath rather than
+    // localPath is what makes the discard work for extensionless alias
+    // requests (e.g. /foo → loadModuleFromDisk returns foo.gts);
+    // invalidateCache targets the canonical, so the gen we need to
+    // compare against is the canonical's. We still serve our own
+    // response: it reflects the source A read at request time, which
+    // is consistent with the caller's happens-before ordering.
+    let cacheGenSnapshot = moduleCachingDisabled
+      ? undefined
+      : this.#snapshotModuleCacheGeneration(localPath);
+
     let response: ResponseWithNodeStream;
     try {
       let result = await this.loadModuleFromDisk(
@@ -2240,7 +2337,14 @@ export class Realm {
       );
       switch (result.kind) {
         case 'module': {
-          if (!moduleCachingDisabled) {
+          if (
+            !moduleCachingDisabled &&
+            cacheGenSnapshot &&
+            !this.#moduleCacheGenerationChanged(
+              result.canonicalPath,
+              cacheGenSnapshot,
+            )
+          ) {
             this.#moduleCache.set(localPath, {
               canonicalPath: result.canonicalPath,
               body: result.body,
@@ -2894,7 +2998,7 @@ export class Realm {
     for (const invalidatedURL of invalidatedURLs) {
       if (hasExecutableExtension(invalidatedURL.href)) {
         let invalidatedPath = this.paths.local(invalidatedURL);
-        this.#moduleCache.invalidate(invalidatedPath);
+        this.#dropModuleCacheEntry(invalidatedPath);
         changedDependencyKeys.add(moduleDependencyKey(invalidatedPath));
         definitionInvalidations.push(
           this.#definitionLookup.invalidate(invalidatedURL.href),
@@ -2907,7 +3011,7 @@ export class Realm {
       for (let invalidatedModuleURL of invalidatedModuleURLs) {
         try {
           let invalidatedPath = this.paths.local(new URL(invalidatedModuleURL));
-          this.#moduleCache.invalidate(invalidatedPath);
+          this.#dropModuleCacheEntry(invalidatedPath);
           changedDependencyKeys.add(moduleDependencyKey(invalidatedPath));
         } catch (_err) {
           // ignore invalidations outside this realm
@@ -2919,7 +3023,7 @@ export class Realm {
       this.moduleCacheDependencyEntries(),
     );
     for (let invalidatedPath of dependentInvalidations) {
-      this.#moduleCache.invalidate(invalidatedPath);
+      this.#dropModuleCacheEntry(invalidatedPath);
     }
   }
 
@@ -5547,10 +5651,9 @@ export class Realm {
       }
 
       let localPath = this.paths.local(tracked.url);
-      this.#sourceCache.invalidate(localPath);
+      this.invalidateCache(localPath);
 
       if (hasExecutableExtension(localPath)) {
-        this.#moduleCache.invalidate(localPath);
         await this.#definitionLookup.invalidate(tracked.url.href);
       }
 


### PR DESCRIPTION
## Summary

- Per-path generation counter on `Realm`. `invalidateCache(path)` bumps it synchronously before awaiting the cache delete.
- `fallbackHandle` snapshots at function entry; the post-transpile `#moduleCache.set` is dropped when the generation moved. The response itself is still served — only the cache write is discarded — so the caller sees a result consistent with the source A read at request time, and the next reader re-transpiles against the current bytes.
- Sibling global counter for `__testOnlyClearCaches`, which wipes the whole map; the per-path component alone can match across a wipe when the path's counter was 0 on both sides.
- Cross-process invalidation propagation is unchanged — the existing `realm_file_changes` NOTIFY listener already calls `invalidateCache` on peers, so the local bump fires for remote writes too. [CS-10892](https://linear.app/cardstack/issue/CS-10892).

Same shape as the discard logic [CS-10948](https://linear.app/cardstack/issue/CS-10948) added for `CachingDefinitionLookup`.

Linear: https://linear.app/cardstack/issue/CS-11028

## Test plan

- [x] CI passes `module-cache-race-test.ts`:
  - [x] in-flight transpile result is dropped when `invalidateCache` fires concurrently
  - [x] `invalidateCache` of an unrelated path does not drop the in-flight cache write
  - [x] in-flight transpile result is dropped when `__testOnlyClearCaches` fires concurrently
- [x] Existing module-cache regression tests in `realm-endpoints-test.ts` still pass.
- [x] Existing `realm-file-changes-listener-test.ts` still passes (cross-process invalidate path is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)