### PR TITLE
CS-11029: in-process inflight dedup for #moduleCache transpile

### DIFF
--- a/packages/realm-server/tests/module-cache-race-test.ts
+++ b/packages/realm-server/tests/module-cache-race-test.ts
@@ -275,4 +275,352 @@ module(basename(__filename), function () {
       });
     },
   );
+
+  // CS-11029: concurrent same-path readers used to each independently call
+  // transpileJS (50–500 ms of babel + ember-template-compilation +
+  // decorator transforms). The in-flight dedup map coalesces them onto a
+  // single transpile; later waiters await the same promise. The realm
+  // tracks a monotonic transpile counter exposed via
+  // __testOnlyGetTranspileCallCount so the tests can assert "exactly one
+  // transpile call" directly rather than inferring it from timing.
+  module('Realm.#moduleCache in-flight transpile dedup', function (hooks) {
+    let realmURL = new URL('http://127.0.0.1:4444/test/');
+    let testRealm: Realm;
+    let request: RealmRequest;
+
+    function onRealmSetup(args: {
+      testRealm: Realm;
+      testRealmHttpServer: Server;
+      request: SuperTest<Test>;
+    }) {
+      testRealm = args.testRealm;
+      request = withRealmPath(args.request, realmURL);
+    }
+
+    setupPermissionedRealmCached(hooks, {
+      realmURL,
+      permissions: {
+        '*': ['read', 'write'],
+        user: ['read', 'write', 'realm-owner'],
+        '@node-test_realm:localhost': ['read', 'realm-owner'],
+      },
+      onRealmSetup,
+    });
+
+    const transpilerHeavySource = `
+      import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
+      import StringField from "https://cardstack.com/base/string";
+
+      export class DedupCard extends CardDef {
+        @field name = contains(StringField);
+        static isolated = class Isolated extends Component<typeof this> {
+          <template>
+            <div data-test-dedup><@fields.name/></div>
+          </template>
+        }
+      }
+    `;
+
+    function authHeader() {
+      return `Bearer ${createJWT(testRealm, 'user', ['read', 'write'])}`;
+    }
+
+    function fireRequest(path: string): Promise<{ status: number }> {
+      return request
+        .get(`/${path}`)
+        .set('Accept', SupportedMimeType.All)
+        .set('Authorization', authHeader())
+        .then((r) => r as { status: number });
+    }
+
+    // Poll the realm's in-flight counter until it matches `expected`,
+    // up to `timeoutMs`. Fixed-time setTimeout()s are unreliable in CI
+    // — request startup latency can exceed the wait window — so the
+    // tests below use this helper together with __testOnlyDelayTranspile
+    // to deterministically observe inflight state without racing real
+    // .gts transpile timing.
+    async function waitForInflight(
+      expected: number,
+      timeoutMs = 5000,
+    ): Promise<void> {
+      let deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if (testRealm.__testOnlyGetInFlightTranspileCount() === expected) {
+          return;
+        }
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      throw new Error(
+        `timed out waiting for in-flight count to reach ${expected}; saw ${testRealm.__testOnlyGetInFlightTranspileCount()}`,
+      );
+    }
+
+    test('N concurrent same-path readers trigger exactly one transpile call', async function (assert) {
+      let modulePath = 'dedup-same-path.gts';
+      await testRealm.write(modulePath, transpilerHeavySource);
+      testRealm.__testOnlyClearCaches();
+
+      let before = testRealm.__testOnlyGetTranspileCallCount();
+      let responses = await Promise.all([
+        fireRequest(modulePath),
+        fireRequest(modulePath),
+        fireRequest(modulePath),
+      ]);
+      let delta = testRealm.__testOnlyGetTranspileCallCount() - before;
+
+      assert.deepEqual(
+        responses.map((r) => r.status),
+        [200, 200, 200],
+        'all three concurrent same-path requests succeed',
+      );
+      assert.strictEqual(
+        delta,
+        1,
+        'exactly one transpileJS call serviced three concurrent same-path readers',
+      );
+      assert.strictEqual(
+        testRealm.__testOnlyGetInFlightTranspileCount(),
+        0,
+        'in-flight slot released after the shared transpile settled',
+      );
+    });
+
+    test('concurrent different-path readers each trigger their own transpile (no false coalesce)', async function (assert) {
+      let pathA = 'dedup-a.gts';
+      let pathB = 'dedup-b.gts';
+      await testRealm.write(pathA, transpilerHeavySource);
+      await testRealm.write(pathB, transpilerHeavySource);
+      testRealm.__testOnlyClearCaches();
+
+      let before = testRealm.__testOnlyGetTranspileCallCount();
+      let responses = await Promise.all([
+        fireRequest(pathA),
+        fireRequest(pathB),
+      ]);
+      let delta = testRealm.__testOnlyGetTranspileCallCount() - before;
+
+      assert.deepEqual(
+        responses.map((r) => r.status),
+        [200, 200],
+        'both different-path requests succeed',
+      );
+      assert.strictEqual(
+        delta,
+        2,
+        'each distinct path triggers its own transpile — no cross-path false coalesce',
+      );
+    });
+
+    test('in-flight entry survives an unrelated path’s invalidate', async function (assert) {
+      let primaryPath = 'dedup-primary.gts';
+      let unrelatedPath = 'dedup-unrelated.gts';
+      await testRealm.write(primaryPath, transpilerHeavySource);
+      await testRealm.write(unrelatedPath, transpilerHeavySource);
+      testRealm.__testOnlyClearCaches();
+
+      // Park transpile at a gate so the inflight state is deterministic.
+      let releaseGate: () => void = () => {};
+      let gate = new Promise<void>((r) => {
+        releaseGate = r;
+      });
+      testRealm.__testOnlyDelayTranspile(() => gate);
+
+      try {
+        let before = testRealm.__testOnlyGetTranspileCallCount();
+        let primaryInflight = fireRequest(primaryPath);
+        await waitForInflight(1);
+        assert.strictEqual(
+          testRealm.__testOnlyGetInFlightTranspileCount(),
+          1,
+          'primary path has an in-flight entry',
+        );
+
+        // Invalidate an unrelated path — should not affect primary's entry.
+        testRealm.invalidateCache(unrelatedPath);
+        assert.strictEqual(
+          testRealm.__testOnlyGetInFlightTranspileCount(),
+          1,
+          'unrelated invalidate did not drop the primary in-flight entry',
+        );
+
+        // Release primary so we can verify the end-state. A second
+        // concurrent caller while the gate was held would have joined
+        // primary's pending — covered by the "N concurrent same-path"
+        // test above; here we just confirm primary's transpile
+        // completes normally after the unrelated invalidate.
+        releaseGate();
+        await primaryInflight;
+        let delta = testRealm.__testOnlyGetTranspileCallCount() - before;
+        assert.strictEqual(
+          delta,
+          1,
+          'primary transpiled once — unrelated invalidate did not force a redo',
+        );
+      } finally {
+        testRealm.__testOnlyDelayTranspile(undefined);
+      }
+    });
+
+    test('in-flight entry is dropped when its own path is invalidated; later caller starts a fresh transpile', async function (assert) {
+      let modulePath = 'dedup-self-invalidate.gts';
+      await testRealm.write(modulePath, transpilerHeavySource);
+      testRealm.__testOnlyClearCaches();
+
+      // Both transpiles will await the same gate — releasing it lets
+      // both proceed and complete. The first transpile was orphaned
+      // from the map by invalidateCache; the second installed a fresh
+      // entry. Their .finally identity checks operate on their own
+      // captured `pending` references, so both clean up correctly.
+      let releaseGate: () => void = () => {};
+      let gate = new Promise<void>((r) => {
+        releaseGate = r;
+      });
+      testRealm.__testOnlyDelayTranspile(() => gate);
+
+      try {
+        let before = testRealm.__testOnlyGetTranspileCallCount();
+        let firstInflight = fireRequest(modulePath);
+        await waitForInflight(1);
+
+        // Invalidate the path — drops the in-flight entry from the
+        // map. firstInflight's promise is still alive at the gate.
+        testRealm.invalidateCache(modulePath);
+        assert.strictEqual(
+          testRealm.__testOnlyGetInFlightTranspileCount(),
+          0,
+          'in-flight entry dropped by invalidateCache',
+        );
+
+        // A caller arriving after the invalidate must not join the
+        // dropped pending; it should install a fresh entry.
+        let secondInflight = fireRequest(modulePath);
+        await waitForInflight(1);
+        assert.strictEqual(
+          testRealm.__testOnlyGetInFlightTranspileCount(),
+          1,
+          'second caller installed its own fresh in-flight entry',
+        );
+
+        releaseGate();
+        await firstInflight;
+        await secondInflight;
+        let delta = testRealm.__testOnlyGetTranspileCallCount() - before;
+        assert.strictEqual(
+          delta,
+          2,
+          'invalidate forced a second transpile — the dropped slot is not joined by post-invalidate callers',
+        );
+      } finally {
+        testRealm.__testOnlyDelayTranspile(undefined);
+      }
+    });
+
+    test('identity-checked cleanup: A in-flight + invalidate + B in-flight + A settles → B survives', async function (assert) {
+      let modulePath = 'dedup-identity.gts';
+      await testRealm.write(modulePath, transpilerHeavySource);
+      testRealm.__testOnlyClearCaches();
+
+      // Independent gates per call so A and B can be released
+      // separately. The hook captures `currentGate` by reference each
+      // time the delay is invoked, so swapping after firing A but
+      // before firing B routes B to a fresh gate.
+      let releaseA: () => void = () => {};
+      let gateA = new Promise<void>((r) => {
+        releaseA = r;
+      });
+      let releaseB: () => void = () => {};
+      let gateB = new Promise<void>((r) => {
+        releaseB = r;
+      });
+      let currentGate = gateA;
+      testRealm.__testOnlyDelayTranspile(() => currentGate);
+
+      try {
+        let pendingA = fireRequest(modulePath);
+        await waitForInflight(1);
+
+        // Invalidate drops A from the map. A is still parked at gateA.
+        testRealm.invalidateCache(modulePath);
+        assert.strictEqual(
+          testRealm.__testOnlyGetInFlightTranspileCount(),
+          0,
+          'invalidate dropped A from the map',
+        );
+
+        currentGate = gateB;
+        let pendingB = fireRequest(modulePath);
+        await waitForInflight(1);
+        assert.strictEqual(
+          testRealm.__testOnlyGetInFlightTranspileCount(),
+          1,
+          'B installed a fresh in-flight entry after invalidate dropped A',
+        );
+
+        // Release A. Its .finally identity check: map has B's pending,
+        // not A's — so it must NOT delete the slot.
+        releaseA();
+        await pendingA;
+        assert.strictEqual(
+          testRealm.__testOnlyGetInFlightTranspileCount(),
+          1,
+          'B’s in-flight entry survives A’s settle (identity check held)',
+        );
+
+        // Release B. Its .finally identity check passes; slot cleaned up.
+        releaseB();
+        await pendingB;
+        assert.strictEqual(
+          testRealm.__testOnlyGetInFlightTranspileCount(),
+          0,
+          'B’s in-flight entry cleaned up after B settled',
+        );
+      } finally {
+        testRealm.__testOnlyDelayTranspile(undefined);
+      }
+    });
+
+    test('errored transpile is shared with concurrent waiters and the in-flight slot releases on rejection', async function (assert) {
+      let modulePath = 'dedup-error.gts';
+      // Syntactically invalid .gts source — transpileJS will throw.
+      await testRealm.write(
+        modulePath,
+        'this is not a valid gts file <template>oops</template>',
+      );
+      testRealm.__testOnlyClearCaches();
+
+      let before = testRealm.__testOnlyGetTranspileCallCount();
+      let [resA, resB] = await Promise.all([
+        fireRequest(modulePath),
+        fireRequest(modulePath),
+      ]);
+      let deltaShared = testRealm.__testOnlyGetTranspileCallCount() - before;
+
+      assert.strictEqual(
+        resA.status,
+        406,
+        'first errored request returns a transpile-failed response',
+      );
+      assert.strictEqual(
+        resB.status,
+        406,
+        'concurrent waiter shares the same error response',
+      );
+      assert.strictEqual(
+        deltaShared,
+        1,
+        'concurrent waiters shared exactly one transpile attempt — the rejection propagates without a second babel pass',
+      );
+
+      // After both fail, the in-flight slot must release so a fresh
+      // caller re-attempts transpile against current source.
+      let resC = await fireRequest(modulePath);
+      assert.strictEqual(resC.status, 406);
+      let deltaAfter = testRealm.__testOnlyGetTranspileCallCount() - before;
+      assert.strictEqual(
+        deltaAfter,
+        2,
+        'subsequent caller triggers a fresh transpile attempt — error did not pin the in-flight slot',
+      );
+    });
+  });
 });

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -296,12 +296,14 @@ type ModuleLoadResult =
       canonicalPath: LocalPath;
       headers: Record<string, string>;
     }
-  | {
-      kind: 'module';
-      canonicalPath: LocalPath;
-      body: string;
-      headers: Record<string, string>;
-    };
+  | ModuleTranspileResult;
+
+type ModuleTranspileResult = {
+  kind: 'module';
+  canonicalPath: LocalPath;
+  body: string;
+  headers: Record<string, string>;
+};
 
 // ETag base prefers a content fingerprint (md5 of the file body) over
 // `lastModified` because the unix-second timestamp collides for two
@@ -582,6 +584,27 @@ export class Realm {
   // is the only thing that reliably mismatches afterwards.
   #moduleCacheGenerations: Map<LocalPath, number> = new Map();
   #moduleCacheGlobalGeneration = 0;
+  // CS-11029: in-process inflight dedup for the transpile pipeline.
+  // Concurrent same-path callers that miss #moduleCache used to each call
+  // transpileJS independently — 50–500 ms of babel + ember-template-
+  // compilation + decorator transforms wasted per duplicate. The map is
+  // keyed by local path so the second-and-onward caller awaits the first
+  // caller's promise instead of running babel again. Invalidation paths
+  // (writeMany, invalidateCache, the full-index clear, etc.) drop the
+  // entry through the shared #dropModuleCacheEntry /
+  // #dropAllModuleCacheEntries helpers so post-invalidate callers don't
+  // join a stale transpile whose #moduleCache.set will be discarded by
+  // CS-11028's generation guard anyway. Identity-checked cleanup on
+  // settle is the same shape as CachingDefinitionLookup's #inFlight — a
+  // newer pending entry installed after a drop survives an older
+  // promise's eventual settle.
+  #inFlightTranspiles: Map<LocalPath, Promise<ModuleTranspileResult>> =
+    new Map();
+  // Monotonic count of transpileJS invocations, used by the CS-11029
+  // dedup tests to assert that N concurrent same-path readers triggered
+  // exactly one transpile call. Reset by __testOnlyClearCaches so each
+  // test reasons from a clean baseline.
+  #transpileCallCount = 0;
   #cardSizeLimitBytes: number;
   #fileSizeLimitBytes: number;
 
@@ -1237,7 +1260,33 @@ export class Realm {
   __testOnlyClearCaches() {
     this.#sourceCache.clear();
     this.#dropAllModuleCacheEntries();
+    // Reset the transpile counter so each test reasons about its own
+    // delta. Production never reads this counter — only the CS-11029
+    // dedup tests do (CS-11029).
+    this.#transpileCallCount = 0;
   }
+
+  // CS-11029 test seams: tests need to assert "N concurrent same-path
+  // readers triggered exactly one transpile" and "the in-flight slot
+  // released after the shared transpile settled." Exposing the
+  // monotonic counter + the live map size is the smallest surface that
+  // satisfies both — no externally-observable behavior changes.
+  __testOnlyGetTranspileCallCount(): number {
+    return this.#transpileCallCount;
+  }
+  __testOnlyGetInFlightTranspileCount(): number {
+    return this.#inFlightTranspiles.size;
+  }
+  // Test-only gate: when set, #materializeAndTranspile awaits the
+  // returned promise before calling transpileJS. Lets the dedup tests
+  // park a transpile mid-flight so they can observe inflight state
+  // without racing real .gts transpile timing in CI. The hook fires
+  // BEFORE #transpileCallCount is bumped — when the count rises, the
+  // gate has released and babel is running.
+  __testOnlyDelayTranspile(fn: (() => Promise<void>) | undefined): void {
+    this.#testOnlyTranspileDelay = fn;
+  }
+  #testOnlyTranspileDelay?: () => Promise<void>;
 
   // Invalidate the in-memory byte caches for a single path. Called by the
   // realm_file_changes LISTEN handler on peer instances after a write lands
@@ -1263,6 +1312,14 @@ export class Realm {
   #dropModuleCacheEntry(path: LocalPath): void {
     this.#bumpModuleCacheGeneration(path);
     this.#moduleCache.invalidate(path);
+    // CS-11029: drop the in-flight transpile entry too. Existing
+    // waiters on the old promise still receive its result — their
+    // requests preceded the invalidate, so pre-invalidation bytes are
+    // the correct response. But a caller arriving AFTER this point
+    // must not join the stale transpile (its #moduleCache.set is
+    // about to be discarded by the generation guard); they install
+    // their own pending against current source instead.
+    this.#inFlightTranspiles.delete(path);
   }
 
   // Wipes every #moduleCache entry and bumps the global generation so any
@@ -1275,6 +1332,9 @@ export class Realm {
     this.#moduleCache.clear();
     this.#moduleCacheGenerations.clear();
     this.#moduleCacheGlobalGeneration += 1;
+    // CS-11029: same reason as #dropModuleCacheEntry — post-wipe
+    // callers must not join a stale transpile.
+    this.#inFlightTranspiles.clear();
   }
 
   #bumpModuleCacheGeneration(path: LocalPath): void {
@@ -2459,6 +2519,49 @@ export class Realm {
       };
     }
 
+    return this.#transpileModuleDeduped(localPath, fileRef, etag);
+  }
+
+  // Dedups the materialize + transpile pipeline across concurrent
+  // same-path callers (CS-11029). The first caller installs a pending
+  // promise keyed by localPath; any caller that arrives while it's
+  // in-flight returns the same promise instead of running babel a
+  // second time. Identity-checked cleanup on settle mirrors
+  // CachingDefinitionLookup.#inFlight — a newer pending entry installed
+  // after invalidateCache drops the slot is preserved when the older
+  // promise eventually settles.
+  async #transpileModuleDeduped(
+    localPath: LocalPath,
+    fileRef: FileRef,
+    etag: string | undefined,
+  ): Promise<ModuleTranspileResult> {
+    let existing = this.#inFlightTranspiles.get(localPath);
+    if (existing) {
+      return existing;
+    }
+    // Assign the chained `.finally` to `pending` and store/return THAT
+    // (not the raw `#materializeAndTranspile` promise). If we kept the
+    // raw promise in the map and dangled an unused `.finally(...)`
+    // chain, a rejection from transpileJS would propagate through both
+    // promises but only the raw one has waiters — the chained one would
+    // surface as an unhandled rejection in Node's host hook. Same shape
+    // as CachingDefinitionLookup.#inFlight.
+    let pending: Promise<ModuleTranspileResult>;
+    let core = this.#materializeAndTranspile(fileRef, etag);
+    pending = core.finally(() => {
+      if (this.#inFlightTranspiles.get(localPath) === pending) {
+        this.#inFlightTranspiles.delete(localPath);
+      }
+    });
+    this.#inFlightTranspiles.set(localPath, pending);
+    return pending;
+  }
+
+  async #materializeAndTranspile(
+    fileRef: FileRef,
+    etag: string | undefined,
+  ): Promise<ModuleTranspileResult> {
+    let canonicalPath = this.paths.fileURL(fileRef.path).href;
     let fileWithContent = await this.materializeFileRef(fileRef);
     let source = await fileContentToText(fileWithContent);
     let transpiled: string;
@@ -2471,6 +2574,10 @@ export class Realm {
       let debugFilename = fileWithContent.path.startsWith('/')
         ? fileWithContent.path
         : `/${fileWithContent.path}`;
+      if (this.#testOnlyTranspileDelay) {
+        await this.#testOnlyTranspileDelay();
+      }
+      this.#transpileCallCount += 1;
       transpiled = await transpileJS(source, debugFilename);
     } catch (err: any) {
       let cardError =


### PR DESCRIPTION
**Stacks on #4750 (CS-11028).** Review/merge that first.

## Summary

- Adds `Realm.#inFlightTranspiles` — a `Map<LocalPath, Promise<…>>` keyed by local path. The first caller to miss `#moduleCache` installs a pending entry; concurrent same-path callers `await` the same promise instead of each running babel from scratch (50–500 ms per duplicate transpile saved).
- Refactors `loadModuleFromDisk` to delegate the materialize + transpile step to `#transpileModuleDeduped` / `#materializeAndTranspile`. Public behavior unchanged — same response shape, same etag, same error handling.
- Identity-checked `.finally` cleanup mirrors `CachingDefinitionLookup.#inFlight` ([CS-10947](https://linear.app/cardstack/issue/CS-10947)) — a newer pending entry installed after an invalidate drop is preserved when an older promise eventually settles.
- The `#dropModuleCacheEntry` / `#dropAllModuleCacheEntries` helpers from CS-11028 now also drop the in-flight entry, so every invalidation site (writeMany, delete, file-watcher callback, executable-invalidation cascade, full-index clear, etc.) clears in-flight too. Existing waiters on a dropped promise still receive its bytes — their requests preceded the invalidate, so pre-invalidation bytes are correct for them. New callers don't join the stale transpile because it's no longer in the map.
- Test seams `__testOnlyGetTranspileCallCount()` and `__testOnlyGetInFlightTranspileCount()` let the dedup tests assert "exactly one transpile call serviced N concurrent same-path readers" and "the slot released on settle" directly rather than inferring it from timing.

Same shape as [CS-10947](https://linear.app/cardstack/issue/CS-10947) for `CachingDefinitionLookup`. Stacks well with [CS-11028](https://linear.app/cardstack/issue/CS-11028): the inflight dedup catches the "many readers, one transpile" case; the generation discard catches the "transpile completed against pre-invalidate bytes" case.

Linear: https://linear.app/cardstack/issue/CS-11029

## Test plan

- [x] CI passes the new \`Realm.#moduleCache in-flight transpile dedup\` module in \`module-cache-race-test.ts\`:
  - [x] N concurrent same-path readers trigger exactly one transpile call
  - [x] concurrent different-path readers each trigger their own transpile (no false coalesce)
  - [x] in-flight entry survives an unrelated path's invalidate
  - [x] in-flight entry is dropped when its own path is invalidated; later caller starts a fresh transpile
  - [x] identity-checked cleanup: A in-flight + invalidate + B in-flight + A settles → B survives
  - [x] errored transpile is shared with concurrent waiters and the in-flight slot releases on rejection
- [x] Existing CS-11028 race tests still pass.
- [x] Existing module-cache regression tests in \`realm-endpoints-test.ts\` still pass (etag, 304, content-type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)