### PR TITLE
CS-11030: cross-process transpile coalesce via module_transpile_cache

### DIFF
--- a/packages/host/config/schema/1779100257123_schema.sql
+++ b/packages/host/config/schema/1779100257123_schema.sql
@@ -88,6 +88,17 @@
    PRIMARY KEY ( id ) 
 );
 
+ CREATE TABLE IF NOT EXISTS module_transpile_cache (
+   realm_url TEXT NOT NULL,
+   canonical_path TEXT NOT NULL,
+   body TEXT,
+   headers BLOB,
+   dependency_keys BLOB,
+   generation DEFAULT 0 NOT NULL,
+   created_at,
+   PRIMARY KEY ( realm_url, canonical_path ) 
+);
+
  CREATE TABLE IF NOT EXISTS modules (
    url TEXT NOT NULL,
    cache_scope TEXT NOT NULL,

--- a/packages/postgres/migrations/1778495869867_create-module-transpile-cache-table.js
+++ b/packages/postgres/migrations/1778495869867_create-module-transpile-cache-table.js
@@ -1,0 +1,48 @@
+exports.shorthands = undefined;
+
+let table = 'module_transpile_cache';
+
+// CS-11030: cross-process coalesce for Realm.#moduleCache transpile.
+// Stores the bytes produced by transpileJS keyed on (realm_url,
+// canonical_path) so peer realm-server processes can re-read a row
+// produced by the coordinator winner instead of each running babel on
+// their own. Same UNLOGGED, RAM-backed shape as the `modules` definition
+// cache — losing the data on Postgres restart only forces a re-transpile
+// on next miss; nothing about correctness depends on durability.
+//
+// `generation` is the per-row OCC counter that closes the invalidate-
+// during-transpile race for the L2 layer (mirrors CS-11028's L1 guard).
+// Invalidation upserts a tombstone (body = headers = dependency_keys =
+// NULL) and bumps `generation`. A writer captures the row's generation
+// at the L2 read step, transpiles, then UPSERTs with that captured
+// value via `ON CONFLICT DO UPDATE WHERE existing.generation <=
+// captured` — if any peer's invalidate has bumped the row past the
+// captured value the update is rejected, so a stale transpile started
+// before the invalidate never resurrects the row.
+//
+// body / headers / dependency_keys are nullable so tombstones can sit
+// in the row without bytes. Readers treat `body IS NULL` as a cache
+// miss but still surface the row's generation so the writer can
+// capture it. `created_at` is millis since epoch.
+exports.up = (pgm) => {
+  pgm.createTable(table, {
+    realm_url: { type: 'varchar', notNull: true },
+    canonical_path: { type: 'varchar', notNull: true },
+    body: 'text',
+    headers: 'jsonb',
+    dependency_keys: 'jsonb',
+    generation: { type: 'bigint', notNull: true, default: 0 },
+    created_at: 'bigint',
+  });
+  pgm.sql(`ALTER TABLE ${table} SET UNLOGGED`);
+  pgm.addConstraint(table, `${table}_pkey`, {
+    primaryKey: ['realm_url', 'canonical_path'],
+  });
+  pgm.addIndex(table, ['realm_url']);
+};
+
+exports.down = (pgm) => {
+  pgm.dropIndex(table, ['realm_url']);
+  pgm.dropConstraint(table, `${table}_pkey`);
+  pgm.dropTable(table);
+};

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -433,6 +433,14 @@ const getIndexHTML = async () => {
           matrixClient,
           realmServerURL: serverURL,
           definitionLookup,
+          // CS-11030: reuse the same coordinator that powers
+          // CachingDefinitionLookup's cross-process coalesce. Distinct
+          // coalesce keys ("transpile|..." vs the prerender key shape)
+          // route through the shared MODULE_CACHE_POPULATED_CHANNEL —
+          // waiters key off the int64 hash of the full coalesceKey, so
+          // crosstalk between the two flows is a benign hash miss in
+          // each direction.
+          transpileCoordinator: moduleCacheCoordinator,
           cardSizeLimitBytes: Number(
             process.env.CARD_SIZE_LIMIT_BYTES ?? DEFAULT_CARD_SIZE_LIMIT_BYTES,
           ),

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -39,6 +39,7 @@ import {
   type QueuePublisher,
   type QueueRunner,
   type Prerenderer,
+  type PopulateCoordinator,
   CachingDefinitionLookup,
 } from '@cardstack/runtime-common';
 import { resetCatalogRealms } from '../../handlers/handle-fetch-catalog-realms';
@@ -967,6 +968,7 @@ export async function createRealm({
   enableFileWatcher = false,
   cardSizeLimitBytes,
   fileSizeLimitBytes,
+  transpileCoordinator,
 }: {
   dir: string;
   definitionLookup: DefinitionLookup;
@@ -983,6 +985,12 @@ export async function createRealm({
   enableFileWatcher?: boolean;
   cardSizeLimitBytes?: number;
   fileSizeLimitBytes?: number;
+  // CS-11030: optional cross-process transpile coordinator. Tests that
+  // simulate two peer realms need each peer to hold its own coordinator
+  // pointing at the same dbAdapter so the advisory-lock + NOTIFY plumbing
+  // is the only thing serializing them — that's the behavior we want to
+  // exercise.
+  transpileCoordinator?: PopulateCoordinator;
   // if you are creating a realm  to test it directly without a server, you can
   // also specify `withWorker: true` to also include a worker with your realm
   withWorker?: true;
@@ -1050,6 +1058,7 @@ export async function createRealm({
       Number(
         process.env.FILE_SIZE_LIMIT_BYTES ?? DEFAULT_FILE_SIZE_LIMIT_BYTES,
       ),
+    transpileCoordinator,
   });
   if (worker) {
     virtualNetwork.mount(realm.handle);

--- a/packages/realm-server/tests/module-cache-race-test.ts
+++ b/packages/realm-server/tests/module-cache-race-test.ts
@@ -3,7 +3,8 @@ import { basename } from 'path';
 import type { SuperTest, Test } from 'supertest';
 import type { Server } from 'http';
 import type { Realm } from '@cardstack/runtime-common';
-import { SupportedMimeType } from '@cardstack/runtime-common';
+import { SupportedMimeType, param, query } from '@cardstack/runtime-common';
+import type { PgAdapter } from '@cardstack/postgres';
 import {
   setupPermissionedRealmCached,
   createJWT,
@@ -623,4 +624,283 @@ module(basename(__filename), function () {
       );
     });
   });
+
+  // CS-11030: the L2 cross-process cache lives in module_transpile_cache.
+  // A request that misses L1 (in-memory) writes the transpiled bytes to
+  // L2 after babel finishes; a peer realm-server with its own in-memory
+  // miss can read the row instead of re-running babel. Invalidation
+  // paths drop the L2 row alongside L1. These tests exercise the read /
+  // write / delete paths from one realm — the coordinator's two-instance
+  // coalesce behavior is exercised by module-cache-coordination-test.ts
+  // and reused via the shared MODULE_CACHE_POPULATED_CHANNEL.
+  module(
+    'Realm.#moduleCache L2 module_transpile_cache (DB-backed)',
+    function (hooks) {
+      let realmURL = new URL('http://127.0.0.1:4444/test/');
+      let testRealm: Realm;
+      let request: RealmRequest;
+      let dbAdapter: PgAdapter;
+
+      function onRealmSetup(args: {
+        testRealm: Realm;
+        testRealmHttpServer: Server;
+        request: SuperTest<Test>;
+        dbAdapter: PgAdapter;
+      }) {
+        testRealm = args.testRealm;
+        request = withRealmPath(args.request, realmURL);
+        dbAdapter = args.dbAdapter;
+      }
+
+      setupPermissionedRealmCached(hooks, {
+        realmURL,
+        permissions: {
+          '*': ['read', 'write'],
+          user: ['read', 'write', 'realm-owner'],
+          '@node-test_realm:localhost': ['read', 'realm-owner'],
+        },
+        onRealmSetup,
+      });
+
+      const transpilerHeavySource = `
+        import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
+        import StringField from "https://cardstack.com/base/string";
+
+        export class L2Card extends CardDef {
+          @field name = contains(StringField);
+          static isolated = class Isolated extends Component<typeof this> {
+            <template>
+              <div data-test-l2><@fields.name/></div>
+            </template>
+          }
+        }
+      `;
+
+      function authHeader() {
+        return `Bearer ${createJWT(testRealm, 'user', ['read', 'write'])}`;
+      }
+
+      // Count rows that are NOT tombstones — `body IS NULL` indicates a
+      // tombstone left behind by invalidateCache or the bulk wipe, and
+      // we want the test to reason about "is the L2 entry usable" not
+      // "does any row exist for this path."
+      async function countL2LiveRows(canonicalUrl: string): Promise<number> {
+        let rows = (await query(dbAdapter, [
+          'SELECT COUNT(*)::int AS n FROM module_transpile_cache WHERE realm_url =',
+          param(realmURL.href),
+          'AND canonical_path =',
+          param(canonicalUrl),
+          'AND body IS NOT NULL',
+        ])) as { n: number }[];
+        return rows[0]?.n ?? 0;
+      }
+
+      async function readL2Generation(
+        canonicalUrl: string,
+      ): Promise<number | undefined> {
+        let rows = (await query(dbAdapter, [
+          'SELECT generation FROM module_transpile_cache WHERE realm_url =',
+          param(realmURL.href),
+          'AND canonical_path =',
+          param(canonicalUrl),
+        ])) as { generation: string | number }[];
+        if (!rows.length) {
+          return undefined;
+        }
+        let g = rows[0].generation;
+        return typeof g === 'string' ? Number(g) : g;
+      }
+
+      test('a fresh transpile populates module_transpile_cache', async function (assert) {
+        let modulePath = 'l2-populate.gts';
+        let canonicalUrl = new URL(modulePath, realmURL).href;
+
+        await testRealm.write(modulePath, transpilerHeavySource);
+        testRealm.__testOnlyClearCaches();
+        // Best-effort bulk DELETE is fire-and-forget — give it a moment
+        // to land before we count.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        assert.strictEqual(
+          await countL2LiveRows(canonicalUrl),
+          0,
+          'precondition: L2 row absent after __testOnlyClearCaches',
+        );
+
+        let response = await request
+          .get(`/${modulePath}`)
+          .set('Accept', SupportedMimeType.All)
+          .set('Authorization', authHeader());
+        assert.strictEqual(response.status, 200);
+
+        // L2 write is awaited inside #transpileWithLayers, so by the
+        // time the response returns the row is already committed.
+        assert.strictEqual(
+          await countL2LiveRows(canonicalUrl),
+          1,
+          'L2 row written by the transpile completion path',
+        );
+      });
+
+      test('L2 row serves a subsequent reader after L1 wipe (without re-transpile)', async function (assert) {
+        let modulePath = 'l2-serve.gts';
+        let canonicalUrl = new URL(modulePath, realmURL).href;
+        let authHdr = authHeader();
+
+        await testRealm.write(modulePath, transpilerHeavySource);
+        testRealm.__testOnlyClearCaches();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        let first = await request
+          .get(`/${modulePath}`)
+          .set('Accept', SupportedMimeType.All)
+          .set('Authorization', authHdr);
+        assert.strictEqual(first.status, 200);
+        assert.strictEqual(
+          await countL2LiveRows(canonicalUrl),
+          1,
+          'first request seeded L2',
+        );
+
+        let countBefore = testRealm.__testOnlyGetTranspileCallCount();
+
+        // X-Boxel-Disable-Module-Cache bypasses L1 — both the read AND
+        // the set are skipped — so the request goes through the
+        // L2-aware #transpileWithLayers path. With the L2 row already
+        // seeded from `first`, the second request should find the row
+        // and return without invoking transpileJS again. This stands in
+        // for the cross-process scenario where peer B's L1 is empty
+        // because peer A produced the row.
+        let second = await request
+          .get(`/${modulePath}`)
+          .set('Accept', SupportedMimeType.All)
+          .set('Authorization', authHdr)
+          .set('X-Boxel-Disable-Module-Cache', 'true');
+        assert.strictEqual(second.status, 200);
+        let countAfter = testRealm.__testOnlyGetTranspileCallCount();
+        assert.strictEqual(
+          countAfter - countBefore,
+          0,
+          'second request was served from L2 — no new transpileJS call',
+        );
+      });
+
+      test('invalidateCache tombstones the L2 row and bumps generation', async function (assert) {
+        let modulePath = 'l2-invalidate.gts';
+        let canonicalUrl = new URL(modulePath, realmURL).href;
+
+        await testRealm.write(modulePath, transpilerHeavySource);
+        testRealm.__testOnlyClearCaches();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        let response = await request
+          .get(`/${modulePath}`)
+          .set('Accept', SupportedMimeType.All)
+          .set('Authorization', authHeader());
+        assert.strictEqual(response.status, 200);
+        assert.strictEqual(
+          await countL2LiveRows(canonicalUrl),
+          1,
+          'L2 row seeded (live, non-tombstone)',
+        );
+        let preInvalidateGen = await readL2Generation(canonicalUrl);
+
+        testRealm.invalidateCache(modulePath);
+        // Tombstone is fire-and-forget — short wait to let it land.
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        assert.strictEqual(
+          await countL2LiveRows(canonicalUrl),
+          0,
+          'invalidateCache tombstoned the L2 row — body is NULL so readers miss',
+        );
+        let postInvalidateGen = await readL2Generation(canonicalUrl);
+        assert.notStrictEqual(
+          preInvalidateGen,
+          undefined,
+          'generation populated on the pre-invalidate row',
+        );
+        assert.notStrictEqual(
+          postInvalidateGen,
+          undefined,
+          'generation populated on the post-invalidate tombstone row',
+        );
+        assert.ok(
+          postInvalidateGen! > preInvalidateGen!,
+          `invalidateCache bumped generation from ${preInvalidateGen} to ${postInvalidateGen} — concurrent in-flight writers with the captured pre-invalidate gen will be rejected by the OCC WHERE clause`,
+        );
+      });
+
+      test('in-flight transpile that completes after invalidate cannot resurrect the L2 row (OCC guard)', async function (assert) {
+        // Direct exercise of the L2 OCC WHERE clause. We simulate an
+        // in-flight transpile that captured generation 0 (row absent),
+        // race an invalidate that tombstones-and-bumps to generation 1,
+        // then attempt the writer's UPSERT with the captured value.
+        // The WHERE module_transpile_cache.generation <= captured (0)
+        // must reject the UPSERT — otherwise a stale transpile would
+        // resurrect the row.
+        let modulePath = 'l2-occ-guard.gts';
+        let canonicalUrl = new URL(modulePath, realmURL).href;
+        await testRealm.write(modulePath, transpilerHeavySource);
+        testRealm.__testOnlyClearCaches();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // Tombstone-and-bump (mimics what invalidateCache does post-
+        // capture). After this, generation = 1 on a tombstone row.
+        await query(dbAdapter, [
+          'INSERT INTO module_transpile_cache',
+          '(realm_url, canonical_path, body, headers, dependency_keys, generation, created_at)',
+          'VALUES (',
+          param(realmURL.href),
+          ',',
+          param(canonicalUrl),
+          ',',
+          'NULL, NULL, NULL, 1,',
+          param(Date.now()),
+          ') ON CONFLICT (realm_url, canonical_path) DO UPDATE SET',
+          'body = NULL, headers = NULL, dependency_keys = NULL,',
+          'generation = module_transpile_cache.generation + 1,',
+          'created_at = EXCLUDED.created_at',
+        ]);
+
+        // Stale write attempt: captures generation 0 (the pre-invalidate
+        // value), tries to UPSERT body. The WHERE clause must reject.
+        await query(dbAdapter, [
+          'INSERT INTO module_transpile_cache',
+          '(realm_url, canonical_path, body, headers, dependency_keys, generation, created_at)',
+          'VALUES (',
+          param(realmURL.href),
+          ',',
+          param(canonicalUrl),
+          ',',
+          param('STALE BODY BYTES'),
+          ',',
+          param('{}'),
+          '::jsonb,',
+          param('[]'),
+          '::jsonb,',
+          param(0),
+          ',',
+          param(Date.now()),
+          ') ON CONFLICT (realm_url, canonical_path) DO UPDATE SET',
+          'body = EXCLUDED.body, headers = EXCLUDED.headers,',
+          'dependency_keys = EXCLUDED.dependency_keys,',
+          'generation = EXCLUDED.generation, created_at = EXCLUDED.created_at',
+          'WHERE module_transpile_cache.generation <= EXCLUDED.generation',
+        ]);
+
+        assert.strictEqual(
+          await countL2LiveRows(canonicalUrl),
+          0,
+          'stale write rejected by OCC WHERE clause — row remains a tombstone',
+        );
+
+        let gen = await readL2Generation(canonicalUrl);
+        assert.strictEqual(
+          gen,
+          1,
+          'generation column unchanged at the tombstone value',
+        );
+      });
+    },
+  );
 });

--- a/packages/realm-server/tests/module-cache-race-test.ts
+++ b/packages/realm-server/tests/module-cache-race-test.ts
@@ -845,20 +845,28 @@ module(basename(__filename), function () {
 
       test('in-flight transpile that completes after invalidate cannot resurrect the L2 row (OCC guard)', async function (assert) {
         // Direct exercise of the L2 OCC WHERE clause. We simulate an
-        // in-flight transpile that captured generation 0 (row absent),
-        // race an invalidate that tombstones-and-bumps to generation 1,
-        // then attempt the writer's UPSERT with the captured value.
-        // The WHERE module_transpile_cache.generation <= captured (0)
-        // must reject the UPSERT — otherwise a stale transpile would
+        // in-flight transpile that captured a pre-invalidate generation,
+        // race an invalidate that tombstones-and-bumps the row, then
+        // attempt the writer's UPSERT with the captured value. The
+        // WHERE module_transpile_cache.generation <= captured must
+        // reject the UPSERT — otherwise a stale transpile would
         // resurrect the row.
+        //
+        // Assertions are gen-delta based rather than absolute: realm
+        // setup + write + __testOnlyClearCaches each fire their own
+        // tombstone-and-bump on this path, so the row's starting gen is
+        // unpredictable. What matters is that the explicit tombstone
+        // here bumps it once, and the stale write that follows leaves
+        // it unchanged.
         let modulePath = 'l2-occ-guard.gts';
         let canonicalUrl = new URL(modulePath, realmURL).href;
         await testRealm.write(modulePath, transpilerHeavySource);
         testRealm.__testOnlyClearCaches();
         await new Promise((resolve) => setTimeout(resolve, 50));
 
+        let preTombstoneGen = (await readL2Generation(canonicalUrl)) ?? 0;
         // Tombstone-and-bump (mimics what invalidateCache does post-
-        // capture). After this, generation = 1 on a tombstone row.
+        // capture).
         await query(dbAdapter, [
           'INSERT INTO module_transpile_cache',
           '(realm_url, canonical_path, body, headers, dependency_keys, generation, created_at)',
@@ -874,6 +882,11 @@ module(basename(__filename), function () {
           'generation = module_transpile_cache.generation + 1,',
           'created_at = EXCLUDED.created_at',
         ]);
+        let postTombstoneGen = await readL2Generation(canonicalUrl);
+        assert.ok(
+          postTombstoneGen != null && postTombstoneGen > preTombstoneGen,
+          `tombstone bumped generation (${preTombstoneGen} → ${postTombstoneGen})`,
+        );
 
         // Stale write attempt: captures generation 0 (the pre-invalidate
         // value), tries to UPSERT body. The WHERE clause must reject.
@@ -907,11 +920,11 @@ module(basename(__filename), function () {
           'stale write rejected by OCC WHERE clause — row remains a tombstone',
         );
 
-        let gen = await readL2Generation(canonicalUrl);
+        let finalGen = await readL2Generation(canonicalUrl);
         assert.strictEqual(
-          gen,
-          1,
-          'generation column unchanged at the tombstone value',
+          finalGen,
+          postTombstoneGen,
+          'generation unchanged after the rejected stale write — OCC WHERE clause held',
         );
       });
     },

--- a/packages/realm-server/tests/module-cache-race-test.ts
+++ b/packages/realm-server/tests/module-cache-race-test.ts
@@ -535,9 +535,13 @@ module(basename(__filename), function () {
       testRealm.__testOnlyClearCaches();
 
       // Independent gates per call so A and B can be released
-      // separately. The hook captures `currentGate` by reference each
-      // time the delay is invoked, so swapping after firing A but
-      // before firing B routes B to a fresh gate.
+      // separately. The hook routes by call index rather than a
+      // mutable `currentGate` reference — `waitForInflight` only
+      // confirms the in-flight slot is set, which happens BEFORE the
+      // transpile hook fires, so A may still be racing toward the
+      // hook when the test swaps the gate. Call-index routing plus
+      // explicit hook-entry signals make the test order deterministic
+      // under CI load.
       let releaseA: () => void = () => {};
       let gateA = new Promise<void>((r) => {
         releaseA = r;
@@ -546,12 +550,36 @@ module(basename(__filename), function () {
       let gateB = new Promise<void>((r) => {
         releaseB = r;
       });
-      let currentGate = gateA;
-      testRealm.__testOnlyDelayTranspile(() => currentGate);
+      let signalAEntered: () => void = () => {};
+      let aEntered = new Promise<void>((r) => {
+        signalAEntered = r;
+      });
+      let signalBEntered: () => void = () => {};
+      let bEntered = new Promise<void>((r) => {
+        signalBEntered = r;
+      });
+      let hookCalls = 0;
+      testRealm.__testOnlyDelayTranspile(() => {
+        hookCalls += 1;
+        if (hookCalls === 1) {
+          signalAEntered();
+          return gateA;
+        }
+        signalBEntered();
+        return gateB;
+      });
 
       try {
         let pendingA = fireRequest(modulePath);
-        await waitForInflight(1);
+        // Wait until A is actually parked at gateA — not just until
+        // the in-flight slot is set. Otherwise the invalidate below
+        // can race A's hook invocation.
+        await aEntered;
+        assert.strictEqual(
+          testRealm.__testOnlyGetInFlightTranspileCount(),
+          1,
+          'A installed its in-flight entry',
+        );
 
         // Invalidate drops A from the map. A is still parked at gateA.
         testRealm.invalidateCache(modulePath);
@@ -561,9 +589,8 @@ module(basename(__filename), function () {
           'invalidate dropped A from the map',
         );
 
-        currentGate = gateB;
         let pendingB = fireRequest(modulePath);
-        await waitForInflight(1);
+        await bEntered;
         assert.strictEqual(
           testRealm.__testOnlyGetInFlightTranspileCount(),
           1,
@@ -883,8 +910,13 @@ module(basename(__filename), function () {
           'created_at = EXCLUDED.created_at',
         ]);
         let postTombstoneGen = await readL2Generation(canonicalUrl);
+        assert.notStrictEqual(
+          postTombstoneGen,
+          undefined,
+          'tombstone row carries a generation value',
+        );
         assert.ok(
-          postTombstoneGen != null && postTombstoneGen > preTombstoneGen,
+          postTombstoneGen! > preTombstoneGen,
           `tombstone bumped generation (${preTombstoneGen} → ${postTombstoneGen})`,
         );
 

--- a/packages/realm-server/tests/module-cache-race-test.ts
+++ b/packages/realm-server/tests/module-cache-race-test.ts
@@ -1,13 +1,26 @@
 import { module, test } from 'qunit';
-import { basename } from 'path';
+import { basename, join } from 'path';
+import { ensureDirSync, writeFileSync, writeJSONSync } from 'fs-extra';
+import { dirSync } from 'tmp';
 import type { SuperTest, Test } from 'supertest';
 import type { Server } from 'http';
 import type { Realm } from '@cardstack/runtime-common';
-import { SupportedMimeType, param, query } from '@cardstack/runtime-common';
+import {
+  CachingDefinitionLookup,
+  SupportedMimeType,
+  param,
+  query,
+} from '@cardstack/runtime-common';
 import type { PgAdapter } from '@cardstack/postgres';
+import { ModuleCacheCoordinator } from '../lib/module-cache-coordination';
 import {
   setupPermissionedRealmCached,
+  setupDB,
   createJWT,
+  createRealm,
+  createVirtualNetwork,
+  getTestPrerenderer,
+  testCreatePrerenderAuth,
   withRealmPath,
   type RealmRequest,
 } from './helpers';
@@ -900,6 +913,200 @@ module(basename(__filename), function () {
           1,
           'generation column unchanged at the tombstone value',
         );
+      });
+    },
+  );
+
+  // CS-11030 two-instance integration coverage. The single-realm tests
+  // above prove the row is written / read / tombstoned correctly through
+  // one Realm's plumbing; these tests prove that two peer Realms — each
+  // with its own ModuleCacheCoordinator, both pointing at the same
+  // realm_url + pg — actually coalesce on babel through the L2 row and
+  // the advisory-lock + NOTIFY channel. Mirrors the
+  // CachingDefinitionLookup two-instance test in
+  // module-cache-coordination-test.ts but exercises the transpile flow.
+  module(
+    'Realm.#moduleCache L2 cross-instance coalesce',
+    function (hooks) {
+      let dbAdapter: PgAdapter;
+      let publisher: import('@cardstack/runtime-common').QueuePublisher;
+      let runner: import('@cardstack/runtime-common').QueueRunner;
+      setupDB(hooks, {
+        beforeEach: async (adapter, pub, run) => {
+          dbAdapter = adapter;
+          publisher = pub;
+          runner = run;
+        },
+      });
+
+      const peerRealmURL = 'http://127.0.0.1:5555/peer/';
+      const peerCardSource = `
+        import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
+        import StringField from "https://cardstack.com/base/string";
+
+        export class PeerCard extends CardDef {
+          @field name = contains(StringField);
+          static isolated = class Isolated extends Component<typeof this> {
+            <template>
+              <div data-test-peer><@fields.name/></div>
+            </template>
+          }
+        }
+      `;
+
+      async function buildPeerRealm(args: {
+        dir: string;
+        coordinator: ModuleCacheCoordinator;
+      }): Promise<Realm> {
+        let virtualNetwork = createVirtualNetwork();
+        let prerenderer = await getTestPrerenderer();
+        let definitionLookup = new CachingDefinitionLookup(
+          dbAdapter,
+          prerenderer,
+          virtualNetwork,
+          testCreatePrerenderAuth,
+        );
+        let { realm } = await createRealm({
+          dir: args.dir,
+          definitionLookup,
+          realmURL: peerRealmURL,
+          permissions: { '*': ['read', 'write'] },
+          virtualNetwork,
+          publisher,
+          runner,
+          dbAdapter,
+          transpileCoordinator: args.coordinator,
+        });
+        return realm;
+      }
+
+      async function setupTwoPeers(): Promise<{
+        realmA: Realm;
+        realmB: Realm;
+        coordA: ModuleCacheCoordinator;
+        coordB: ModuleCacheCoordinator;
+        cardPath: string;
+        canonicalUrl: string;
+      }> {
+        let tmp = dirSync();
+        let testRealmDir = join(tmp.name, 'peer-realm');
+        ensureDirSync(testRealmDir);
+        // Minimal .realm.json so the Realm bootstraps a name + readable
+        // visibility; the test only ever asks for module GETs.
+        writeJSONSync(join(testRealmDir, '.realm.json'), {
+          name: 'Peer Realm',
+        });
+        let cardPath = 'peer-card.gts';
+        writeFileSync(join(testRealmDir, cardPath), peerCardSource);
+
+        let coordA = new ModuleCacheCoordinator({ dbAdapter });
+        await coordA.start();
+        let coordB = new ModuleCacheCoordinator({ dbAdapter });
+        await coordB.start();
+        // Give both coordinators a moment to issue their LISTEN before
+        // the test fires NOTIFY traffic — matches the 100ms pause in
+        // module-cache-coordination-test.ts.
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        let realmA = await buildPeerRealm({ dir: testRealmDir, coordinator: coordA });
+        let realmB = await buildPeerRealm({ dir: testRealmDir, coordinator: coordB });
+
+        // Drop anything either realm filled during construction so the
+        // test's request is the only thing that can drive the counter.
+        realmA.__testOnlyClearCaches();
+        realmB.__testOnlyClearCaches();
+        // __testOnlyClearCaches fire-and-forgets the L2 bulk wipe; wait
+        // for it to land before reads.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        let canonicalUrl = new URL(cardPath, peerRealmURL).href;
+        return { realmA, realmB, coordA, coordB, cardPath, canonicalUrl };
+      }
+
+      function moduleRequest(realm: Realm, cardPath: string): Request {
+        return new Request(new URL(cardPath, peerRealmURL).href, {
+          method: 'GET',
+          headers: {
+            Accept: SupportedMimeType.All,
+            Authorization: `Bearer ${createJWT(realm, 'user', ['read'])}`,
+          },
+        });
+      }
+
+      test('L2 row written by peer A is served from L2 by peer B without re-running babel', async function (assert) {
+        let { realmA, realmB, coordA, coordB, cardPath } =
+          await setupTwoPeers();
+        try {
+          let respA = await realmA.handle(moduleRequest(realmA, cardPath));
+          assert.strictEqual(respA?.status, 200, 'peer A served the module');
+          assert.strictEqual(
+            realmA.__testOnlyGetTranspileCallCount(),
+            1,
+            'peer A ran babel exactly once',
+          );
+
+          let bCountBefore = realmB.__testOnlyGetTranspileCallCount();
+          let respB = await realmB.handle(moduleRequest(realmB, cardPath));
+          assert.strictEqual(respB?.status, 200, 'peer B served the module');
+          assert.strictEqual(
+            realmB.__testOnlyGetTranspileCallCount() - bCountBefore,
+            0,
+            'peer B served from the L2 row peer A wrote — no babel ran on peer B',
+          );
+        } finally {
+          await coordA.shutDown();
+          await coordB.shutDown();
+        }
+      });
+
+      test('two peers concurrently transpiling the same path coalesce through the coordinator: exactly one babel call across both', async function (assert) {
+        let { realmA, realmB, coordA, coordB, cardPath } =
+          await setupTwoPeers();
+        try {
+          // Gate babel on both realms so whichever one wins the
+          // advisory lock parks inside transpileJS, holding the lock
+          // open. The loser's tryAcquireAndRun returns acquired:false
+          // BEFORE the runner fn is invoked, so the loser never reaches
+          // the delay — only the winner waits on the gate.
+          let releaseGate!: () => void;
+          let gate = new Promise<void>((resolve) => {
+            releaseGate = resolve;
+          });
+          realmA.__testOnlyDelayTranspile(() => gate);
+          realmB.__testOnlyDelayTranspile(() => gate);
+
+          // Stagger A → B by 100ms so A reliably takes the pg advisory
+          // lock first; B then contends and observes acquired:false.
+          // Mirrors the staggered start in the CachingDefinitionLookup
+          // two-instance test.
+          let pA = realmA.handle(moduleRequest(realmA, cardPath));
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          let pB = realmB.handle(moduleRequest(realmB, cardPath));
+          await new Promise((resolve) => setTimeout(resolve, 100));
+
+          // At this point: A is parked inside materializeAndTranspile
+          // awaiting the gate (transpile counter hasn't bumped yet —
+          // the delay hook runs before the count). B has observed
+          // acquired:false and is parked on waitForKey waiting for the
+          // NOTIFY A will emit when its tx commits.
+          releaseGate();
+          let [respA, respB] = await Promise.all([pA, pB]);
+          assert.strictEqual(respA?.status, 200, 'peer A served 200');
+          assert.strictEqual(respB?.status, 200, 'peer B served 200');
+
+          let aTotal = realmA.__testOnlyGetTranspileCallCount();
+          let bTotal = realmB.__testOnlyGetTranspileCallCount();
+          assert.strictEqual(
+            aTotal + bTotal,
+            1,
+            'exactly one babel call across both peers — the L2 winner wrote and the loser read',
+          );
+        } finally {
+          realmA.__testOnlyDelayTranspile(undefined);
+          realmB.__testOnlyDelayTranspile(undefined);
+          await coordA.shutDown();
+          await coordB.shutDown();
+        }
       });
     },
   );

--- a/packages/realm-server/tests/module-cache-race-test.ts
+++ b/packages/realm-server/tests/module-cache-race-test.ts
@@ -925,22 +925,20 @@ module(basename(__filename), function () {
   // the advisory-lock + NOTIFY channel. Mirrors the
   // CachingDefinitionLookup two-instance test in
   // module-cache-coordination-test.ts but exercises the transpile flow.
-  module(
-    'Realm.#moduleCache L2 cross-instance coalesce',
-    function (hooks) {
-      let dbAdapter: PgAdapter;
-      let publisher: import('@cardstack/runtime-common').QueuePublisher;
-      let runner: import('@cardstack/runtime-common').QueueRunner;
-      setupDB(hooks, {
-        beforeEach: async (adapter, pub, run) => {
-          dbAdapter = adapter;
-          publisher = pub;
-          runner = run;
-        },
-      });
+  module('Realm.#moduleCache L2 cross-instance coalesce', function (hooks) {
+    let dbAdapter: PgAdapter;
+    let publisher: import('@cardstack/runtime-common').QueuePublisher;
+    let runner: import('@cardstack/runtime-common').QueueRunner;
+    setupDB(hooks, {
+      beforeEach: async (adapter, pub, run) => {
+        dbAdapter = adapter;
+        publisher = pub;
+        runner = run;
+      },
+    });
 
-      const peerRealmURL = 'http://127.0.0.1:5555/peer/';
-      const peerCardSource = `
+    const peerRealmURL = 'http://127.0.0.1:5555/peer/';
+    const peerCardSource = `
         import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
         import StringField from "https://cardstack.com/base/string";
 
@@ -954,160 +952,163 @@ module(basename(__filename), function () {
         }
       `;
 
-      async function buildPeerRealm(args: {
-        dir: string;
-        coordinator: ModuleCacheCoordinator;
-      }): Promise<Realm> {
-        let virtualNetwork = createVirtualNetwork();
-        let prerenderer = await getTestPrerenderer();
-        let definitionLookup = new CachingDefinitionLookup(
-          dbAdapter,
-          prerenderer,
-          virtualNetwork,
-          testCreatePrerenderAuth,
+    async function buildPeerRealm(args: {
+      dir: string;
+      coordinator: ModuleCacheCoordinator;
+    }): Promise<Realm> {
+      let virtualNetwork = createVirtualNetwork();
+      let prerenderer = await getTestPrerenderer();
+      let definitionLookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      let { realm } = await createRealm({
+        dir: args.dir,
+        definitionLookup,
+        realmURL: peerRealmURL,
+        permissions: { '*': ['read', 'write'] },
+        virtualNetwork,
+        publisher,
+        runner,
+        dbAdapter,
+        transpileCoordinator: args.coordinator,
+      });
+      return realm;
+    }
+
+    async function setupTwoPeers(): Promise<{
+      realmA: Realm;
+      realmB: Realm;
+      coordA: ModuleCacheCoordinator;
+      coordB: ModuleCacheCoordinator;
+      cardPath: string;
+      canonicalUrl: string;
+    }> {
+      let tmp = dirSync();
+      let testRealmDir = join(tmp.name, 'peer-realm');
+      ensureDirSync(testRealmDir);
+      // Minimal .realm.json so the Realm bootstraps a name + readable
+      // visibility; the test only ever asks for module GETs.
+      writeJSONSync(join(testRealmDir, '.realm.json'), {
+        name: 'Peer Realm',
+      });
+      let cardPath = 'peer-card.gts';
+      writeFileSync(join(testRealmDir, cardPath), peerCardSource);
+
+      let coordA = new ModuleCacheCoordinator({ dbAdapter });
+      await coordA.start();
+      let coordB = new ModuleCacheCoordinator({ dbAdapter });
+      await coordB.start();
+      // Give both coordinators a moment to issue their LISTEN before
+      // the test fires NOTIFY traffic — matches the 100ms pause in
+      // module-cache-coordination-test.ts.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      let realmA = await buildPeerRealm({
+        dir: testRealmDir,
+        coordinator: coordA,
+      });
+      let realmB = await buildPeerRealm({
+        dir: testRealmDir,
+        coordinator: coordB,
+      });
+
+      // Drop anything either realm filled during construction so the
+      // test's request is the only thing that can drive the counter.
+      realmA.__testOnlyClearCaches();
+      realmB.__testOnlyClearCaches();
+      // __testOnlyClearCaches fire-and-forgets the L2 bulk wipe; wait
+      // for it to land before reads.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      let canonicalUrl = new URL(cardPath, peerRealmURL).href;
+      return { realmA, realmB, coordA, coordB, cardPath, canonicalUrl };
+    }
+
+    function moduleRequest(realm: Realm, cardPath: string): Request {
+      return new Request(new URL(cardPath, peerRealmURL).href, {
+        method: 'GET',
+        headers: {
+          Accept: SupportedMimeType.All,
+          Authorization: `Bearer ${createJWT(realm, 'user', ['read'])}`,
+        },
+      });
+    }
+
+    test('L2 row written by peer A is served from L2 by peer B without re-running babel', async function (assert) {
+      let { realmA, realmB, coordA, coordB, cardPath } = await setupTwoPeers();
+      try {
+        let respA = await realmA.handle(moduleRequest(realmA, cardPath));
+        assert.strictEqual(respA?.status, 200, 'peer A served the module');
+        assert.strictEqual(
+          realmA.__testOnlyGetTranspileCallCount(),
+          1,
+          'peer A ran babel exactly once',
         );
-        let { realm } = await createRealm({
-          dir: args.dir,
-          definitionLookup,
-          realmURL: peerRealmURL,
-          permissions: { '*': ['read', 'write'] },
-          virtualNetwork,
-          publisher,
-          runner,
-          dbAdapter,
-          transpileCoordinator: args.coordinator,
-        });
-        return realm;
+
+        let bCountBefore = realmB.__testOnlyGetTranspileCallCount();
+        let respB = await realmB.handle(moduleRequest(realmB, cardPath));
+        assert.strictEqual(respB?.status, 200, 'peer B served the module');
+        assert.strictEqual(
+          realmB.__testOnlyGetTranspileCallCount() - bCountBefore,
+          0,
+          'peer B served from the L2 row peer A wrote — no babel ran on peer B',
+        );
+      } finally {
+        await coordA.shutDown();
+        await coordB.shutDown();
       }
+    });
 
-      async function setupTwoPeers(): Promise<{
-        realmA: Realm;
-        realmB: Realm;
-        coordA: ModuleCacheCoordinator;
-        coordB: ModuleCacheCoordinator;
-        cardPath: string;
-        canonicalUrl: string;
-      }> {
-        let tmp = dirSync();
-        let testRealmDir = join(tmp.name, 'peer-realm');
-        ensureDirSync(testRealmDir);
-        // Minimal .realm.json so the Realm bootstraps a name + readable
-        // visibility; the test only ever asks for module GETs.
-        writeJSONSync(join(testRealmDir, '.realm.json'), {
-          name: 'Peer Realm',
+    test('two peers concurrently transpiling the same path coalesce through the coordinator: exactly one babel call across both', async function (assert) {
+      let { realmA, realmB, coordA, coordB, cardPath } = await setupTwoPeers();
+      try {
+        // Gate babel on both realms so whichever one wins the
+        // advisory lock parks inside transpileJS, holding the lock
+        // open. The loser's tryAcquireAndRun returns acquired:false
+        // BEFORE the runner fn is invoked, so the loser never reaches
+        // the delay — only the winner waits on the gate.
+        let releaseGate!: () => void;
+        let gate = new Promise<void>((resolve) => {
+          releaseGate = resolve;
         });
-        let cardPath = 'peer-card.gts';
-        writeFileSync(join(testRealmDir, cardPath), peerCardSource);
+        realmA.__testOnlyDelayTranspile(() => gate);
+        realmB.__testOnlyDelayTranspile(() => gate);
 
-        let coordA = new ModuleCacheCoordinator({ dbAdapter });
-        await coordA.start();
-        let coordB = new ModuleCacheCoordinator({ dbAdapter });
-        await coordB.start();
-        // Give both coordinators a moment to issue their LISTEN before
-        // the test fires NOTIFY traffic — matches the 100ms pause in
-        // module-cache-coordination-test.ts.
+        // Stagger A → B by 100ms so A reliably takes the pg advisory
+        // lock first; B then contends and observes acquired:false.
+        // Mirrors the staggered start in the CachingDefinitionLookup
+        // two-instance test.
+        let pA = realmA.handle(moduleRequest(realmA, cardPath));
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        let pB = realmB.handle(moduleRequest(realmB, cardPath));
         await new Promise((resolve) => setTimeout(resolve, 100));
 
-        let realmA = await buildPeerRealm({ dir: testRealmDir, coordinator: coordA });
-        let realmB = await buildPeerRealm({ dir: testRealmDir, coordinator: coordB });
+        // At this point: A is parked inside materializeAndTranspile
+        // awaiting the gate (transpile counter hasn't bumped yet —
+        // the delay hook runs before the count). B has observed
+        // acquired:false and is parked on waitForKey waiting for the
+        // NOTIFY A will emit when its tx commits.
+        releaseGate();
+        let [respA, respB] = await Promise.all([pA, pB]);
+        assert.strictEqual(respA?.status, 200, 'peer A served 200');
+        assert.strictEqual(respB?.status, 200, 'peer B served 200');
 
-        // Drop anything either realm filled during construction so the
-        // test's request is the only thing that can drive the counter.
-        realmA.__testOnlyClearCaches();
-        realmB.__testOnlyClearCaches();
-        // __testOnlyClearCaches fire-and-forgets the L2 bulk wipe; wait
-        // for it to land before reads.
-        await new Promise((resolve) => setTimeout(resolve, 50));
-
-        let canonicalUrl = new URL(cardPath, peerRealmURL).href;
-        return { realmA, realmB, coordA, coordB, cardPath, canonicalUrl };
+        let aTotal = realmA.__testOnlyGetTranspileCallCount();
+        let bTotal = realmB.__testOnlyGetTranspileCallCount();
+        assert.strictEqual(
+          aTotal + bTotal,
+          1,
+          'exactly one babel call across both peers — the L2 winner wrote and the loser read',
+        );
+      } finally {
+        realmA.__testOnlyDelayTranspile(undefined);
+        realmB.__testOnlyDelayTranspile(undefined);
+        await coordA.shutDown();
+        await coordB.shutDown();
       }
-
-      function moduleRequest(realm: Realm, cardPath: string): Request {
-        return new Request(new URL(cardPath, peerRealmURL).href, {
-          method: 'GET',
-          headers: {
-            Accept: SupportedMimeType.All,
-            Authorization: `Bearer ${createJWT(realm, 'user', ['read'])}`,
-          },
-        });
-      }
-
-      test('L2 row written by peer A is served from L2 by peer B without re-running babel', async function (assert) {
-        let { realmA, realmB, coordA, coordB, cardPath } =
-          await setupTwoPeers();
-        try {
-          let respA = await realmA.handle(moduleRequest(realmA, cardPath));
-          assert.strictEqual(respA?.status, 200, 'peer A served the module');
-          assert.strictEqual(
-            realmA.__testOnlyGetTranspileCallCount(),
-            1,
-            'peer A ran babel exactly once',
-          );
-
-          let bCountBefore = realmB.__testOnlyGetTranspileCallCount();
-          let respB = await realmB.handle(moduleRequest(realmB, cardPath));
-          assert.strictEqual(respB?.status, 200, 'peer B served the module');
-          assert.strictEqual(
-            realmB.__testOnlyGetTranspileCallCount() - bCountBefore,
-            0,
-            'peer B served from the L2 row peer A wrote — no babel ran on peer B',
-          );
-        } finally {
-          await coordA.shutDown();
-          await coordB.shutDown();
-        }
-      });
-
-      test('two peers concurrently transpiling the same path coalesce through the coordinator: exactly one babel call across both', async function (assert) {
-        let { realmA, realmB, coordA, coordB, cardPath } =
-          await setupTwoPeers();
-        try {
-          // Gate babel on both realms so whichever one wins the
-          // advisory lock parks inside transpileJS, holding the lock
-          // open. The loser's tryAcquireAndRun returns acquired:false
-          // BEFORE the runner fn is invoked, so the loser never reaches
-          // the delay — only the winner waits on the gate.
-          let releaseGate!: () => void;
-          let gate = new Promise<void>((resolve) => {
-            releaseGate = resolve;
-          });
-          realmA.__testOnlyDelayTranspile(() => gate);
-          realmB.__testOnlyDelayTranspile(() => gate);
-
-          // Stagger A → B by 100ms so A reliably takes the pg advisory
-          // lock first; B then contends and observes acquired:false.
-          // Mirrors the staggered start in the CachingDefinitionLookup
-          // two-instance test.
-          let pA = realmA.handle(moduleRequest(realmA, cardPath));
-          await new Promise((resolve) => setTimeout(resolve, 100));
-          let pB = realmB.handle(moduleRequest(realmB, cardPath));
-          await new Promise((resolve) => setTimeout(resolve, 100));
-
-          // At this point: A is parked inside materializeAndTranspile
-          // awaiting the gate (transpile counter hasn't bumped yet —
-          // the delay hook runs before the count). B has observed
-          // acquired:false and is parked on waitForKey waiting for the
-          // NOTIFY A will emit when its tx commits.
-          releaseGate();
-          let [respA, respB] = await Promise.all([pA, pB]);
-          assert.strictEqual(respA?.status, 200, 'peer A served 200');
-          assert.strictEqual(respB?.status, 200, 'peer B served 200');
-
-          let aTotal = realmA.__testOnlyGetTranspileCallCount();
-          let bTotal = realmB.__testOnlyGetTranspileCallCount();
-          assert.strictEqual(
-            aTotal + bTotal,
-            1,
-            'exactly one babel call across both peers — the L2 winner wrote and the loser read',
-          );
-        } finally {
-          realmA.__testOnlyDelayTranspile(undefined);
-          realmB.__testOnlyDelayTranspile(undefined);
-          await coordA.shutDown();
-          await coordB.shutDown();
-        }
-      });
-    },
-  );
+    });
+  });
 });

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -160,6 +160,7 @@ import { filterAtomicOperations } from './atomic-document';
 import {
   isFilterRefersToNonexistentTypeError,
   type DefinitionLookup,
+  type PopulateCoordinator,
 } from './definition-lookup';
 import {
   fetchSessionRoom,
@@ -226,6 +227,14 @@ export interface FileRef {
 const CACHE_HEADER = 'X-Boxel-Cache';
 const CACHE_HIT_VALUE = 'hit';
 const CACHE_MISS_VALUE = 'miss';
+// CS-11030: DB table backing the cross-process transpile cache and
+// the matching budget the loser path waits before re-reading. Same
+// 180 s budget as CachingDefinitionLookup's COALESCE_NOTIFY_WAIT_MS —
+// prerenders + transpiles run on similar timescales; bigger budgets
+// just delay the fallthrough on missed NOTIFY, smaller budgets risk
+// a second transpile before the winner finishes.
+const MODULE_TRANSPILE_CACHE_TABLE = 'module_transpile_cache';
+const COALESCE_NOTIFY_WAIT_MS = 180_000;
 const MODULE_ETAG_VARIANT = 'module';
 const SOURCE_ETAG_VARIANT = 'source';
 // Card+JSON ETag is `"<indexed_at>-<realmInfoHash>:card"` — quoted
@@ -605,6 +614,15 @@ export class Realm {
   // exactly one transpile call. Reset by __testOnlyClearCaches so each
   // test reasons from a clean baseline.
   #transpileCallCount = 0;
+  // CS-11030: optional cross-process coalesce coordinator. When set, the
+  // first realm-server in the fleet to miss the in-memory cache for a
+  // given (realm_url, canonical_path) acquires an advisory lock, writes
+  // the transpiled bytes to module_transpile_cache, and emits NOTIFY;
+  // peers wait on NOTIFY and re-read the row instead of each running
+  // babel independently. Undefined in deployments without pg (sqlite /
+  // in-memory) — the realm then runs the uncoordinated CS-11029 path
+  // and writes nothing to the DB cache.
+  #transpileCoordinator?: PopulateCoordinator;
   #cardSizeLimitBytes: number;
   #fileSizeLimitBytes: number;
 
@@ -669,6 +687,7 @@ export class Realm {
       definitionLookup,
       cardSizeLimitBytes,
       fileSizeLimitBytes,
+      transpileCoordinator,
     }: {
       url: string;
       adapter: RealmAdapter;
@@ -681,6 +700,13 @@ export class Realm {
       definitionLookup: DefinitionLookup;
       cardSizeLimitBytes?: number;
       fileSizeLimitBytes?: number;
+      // CS-11030: when set, the realm coalesces concurrent cross-process
+      // transpiles through an advisory-lock + NOTIFY winner/loser flow
+      // and persists the resulting bytes to `module_transpile_cache` so
+      // peers re-read instead of re-running babel. Optional — sqlite /
+      // in-memory deployments leave this undefined and the uncoordinated
+      // CS-11029 in-process dedup is the only sharing layer.
+      transpileCoordinator?: PopulateCoordinator;
     },
     opts?: Options,
   ) {
@@ -698,6 +724,7 @@ export class Realm {
       this.#matrixClient.matrixURL.href,
     );
     this.#realmServerURL = ensureTrailingSlash(realmServerURL);
+    this.#transpileCoordinator = transpileCoordinator;
     this.#cardSizeLimitBytes =
       cardSizeLimitBytes ?? DEFAULT_CARD_SIZE_LIMIT_BYTES;
     this.#fileSizeLimitBytes =
@@ -1320,6 +1347,16 @@ export class Realm {
     // about to be discarded by the generation guard); they install
     // their own pending against current source instead.
     this.#inFlightTranspiles.delete(path);
+    // CS-11030: also DELETE the cross-process L2 row. Fire-and-forget
+    // because invalidateCache is sync (called from the LISTEN handler
+    // among others). Best-effort by design — every peer's listener
+    // runs the same DELETE for its own copy, so a transient pg
+    // failure on one peer is repaired by the next; and a stale L2
+    // row that survives is corrected on next reader's invalidate
+    // path or by the writer overwriting it via the ON CONFLICT DO
+    // NOTHING (which becomes a no-op once we re-DELETE).
+    let canonicalPath = this.paths.fileURL(path).href;
+    void this.#deleteTranspileCacheRow(canonicalPath);
   }
 
   // Wipes every #moduleCache entry and bumps the global generation so any
@@ -1335,6 +1372,8 @@ export class Realm {
     // CS-11029: same reason as #dropModuleCacheEntry — post-wipe
     // callers must not join a stale transpile.
     this.#inFlightTranspiles.clear();
+    // CS-11030: fire-and-forget bulk DELETE for the realm's L2 rows.
+    void this.#deleteAllTranspileCacheRows();
   }
 
   #bumpModuleCacheGeneration(path: LocalPath): void {
@@ -2540,14 +2579,14 @@ export class Realm {
       return existing;
     }
     // Assign the chained `.finally` to `pending` and store/return THAT
-    // (not the raw `#materializeAndTranspile` promise). If we kept the
-    // raw promise in the map and dangled an unused `.finally(...)`
-    // chain, a rejection from transpileJS would propagate through both
-    // promises but only the raw one has waiters — the chained one would
-    // surface as an unhandled rejection in Node's host hook. Same shape
-    // as CachingDefinitionLookup.#inFlight.
+    // (not the raw layered promise). If we kept the raw promise in the
+    // map and dangled an unused `.finally(...)` chain, a rejection from
+    // transpileJS would propagate through both promises but only the
+    // raw one has waiters — the chained one would surface as an
+    // unhandled rejection in Node's host hook. Same shape as
+    // CachingDefinitionLookup.#inFlight.
     let pending: Promise<ModuleTranspileResult>;
-    let core = this.#materializeAndTranspile(fileRef, etag);
+    let core = this.#transpileWithLayers(fileRef, etag);
     pending = core.finally(() => {
       if (this.#inFlightTranspiles.get(localPath) === pending) {
         this.#inFlightTranspiles.delete(localPath);
@@ -2555,6 +2594,288 @@ export class Realm {
     });
     this.#inFlightTranspiles.set(localPath, pending);
     return pending;
+  }
+
+  // CS-11030: orchestrates the cache layers below the in-process inflight
+  // dedup. Layering:
+  //   1. read module_transpile_cache — a peer (or this process on a
+  //      prior request that fell out of the in-memory cache) may have
+  //      already produced the bytes; just return them.
+  //   2. (with coordinator) tryAcquireAndRun: winner re-reads the DB,
+  //      transpiles on miss, persists to module_transpile_cache, and
+  //      emits NOTIFY before commit; losers waitForKey + re-read.
+  //   3. (no coordinator, or loser fell through) run #materializeAndTranspile
+  //      directly. The L2 DB write still happens — sqlite deployments
+  //      simply skip the cross-process coalesce.
+  //
+  // The L2 write uses an OCC pattern: the writer captures the row's
+  // `generation` at the L2 read step (or 0 if the row is absent) and
+  // UPSERTs with that captured value via `ON CONFLICT DO UPDATE
+  // WHERE existing.generation <= captured`. An invalidate that lands
+  // during the transpile bumps the row's generation past the captured
+  // value, so the writer's UPSERT is rejected by the WHERE clause and
+  // a stale transpile started before the invalidate cannot resurrect
+  // the row. Mirrors CS-11028's L1 generation guard but with a durable
+  // counter visible to every peer.
+  async #transpileWithLayers(
+    fileRef: FileRef,
+    etag: string | undefined,
+  ): Promise<ModuleTranspileResult> {
+    let canonicalPath = this.paths.fileURL(fileRef.path).href;
+    let coordinator = this.#transpileCoordinator;
+
+    // L2 read first — cheap query (UNLOGGED, indexed PK), saves babel.
+    let cached = await this.#readTranspileCacheRow(canonicalPath);
+    if (cached?.result) {
+      return cached.result;
+    }
+    // capturedGeneration is the row's generation observed at this
+    // point in time — 0 if the row was absent, the tombstone's
+    // generation otherwise. The L2 write uses this value as its OCC
+    // token: any invalidate that races the transpile bumps generation
+    // past `capturedGeneration`, so the write's WHERE clause rejects
+    // the UPSERT.
+    let capturedGeneration = cached?.generation ?? 0;
+
+    if (!coordinator) {
+      let result = await this.#materializeAndTranspile(fileRef, etag);
+      await this.#writeTranspileCacheRow(
+        canonicalPath,
+        result,
+        capturedGeneration,
+      );
+      return result;
+    }
+
+    let coalesceKey = `transpile|${this.url}|${canonicalPath}`;
+    let attempt = await coordinator.tryAcquireAndRun(coalesceKey, async () => {
+      // Winner path: a peer may have written between our miss and our
+      // lock acquisition; re-read so we don't redo their work AND
+      // refresh our captured generation in case a tombstone landed.
+      let recheck = await this.#readTranspileCacheRow(canonicalPath);
+      if (recheck?.result) {
+        return recheck.result;
+      }
+      let result = await this.#materializeAndTranspile(fileRef, etag);
+      await this.#writeTranspileCacheRow(
+        canonicalPath,
+        result,
+        recheck?.generation ?? 0,
+      );
+      return result;
+    });
+    if (attempt.acquired) {
+      return attempt.result;
+    }
+
+    // Loser path: park on NOTIFY (resolves on either the populate
+    // signal or a bounded timeout — see CachingDefinitionLookup's
+    // COALESCE_NOTIFY_WAIT_MS for the rationale on the budget). On
+    // wake, re-read; the row should be there if the winner succeeded.
+    await coordinator.waitForKey(coalesceKey, COALESCE_NOTIFY_WAIT_MS);
+    let postWait = await this.#readTranspileCacheRow(canonicalPath);
+    if (postWait?.result) {
+      return postWait.result;
+    }
+    // Missed NOTIFY, peer crashed, or the winner skipped persist (e.g.
+    // a generation discard upstream). Fall through to a local transpile;
+    // we still persist so the NEXT reader sees a cached row. Use the
+    // freshest generation we've observed for the OCC token.
+    let result = await this.#materializeAndTranspile(fileRef, etag);
+    await this.#writeTranspileCacheRow(
+      canonicalPath,
+      result,
+      postWait?.generation ?? 0,
+    );
+    return result;
+  }
+
+  async #readTranspileCacheRow(canonicalPath: string): Promise<
+    | {
+        result?: ModuleTranspileResult;
+        generation: number;
+      }
+    | undefined
+  > {
+    let rows = (await query(this.#dbAdapter, [
+      'SELECT body, headers, dependency_keys, generation',
+      'FROM',
+      MODULE_TRANSPILE_CACHE_TABLE,
+      'WHERE realm_url =',
+      param(this.url),
+      'AND canonical_path =',
+      param(canonicalPath),
+    ])) as {
+      body: string | null;
+      headers: Record<string, string> | string | null;
+      dependency_keys: string[] | string | null;
+      generation: string | number;
+    }[];
+    if (!rows.length) {
+      return undefined;
+    }
+    let row = rows[0];
+    let generation =
+      typeof row.generation === 'string'
+        ? Number(row.generation)
+        : row.generation;
+    if (row.body == null || row.headers == null) {
+      // Tombstone — surface only the generation so the writer can
+      // capture it for OCC.
+      return { generation };
+    }
+    let headers =
+      typeof row.headers === 'string'
+        ? (JSON.parse(row.headers) as Record<string, string>)
+        : row.headers;
+    let canonicalFromHeader = headers['X-Boxel-Canonical-Path'];
+    // canonical_path stores the realm-relative + extension form
+    // matching fileRef.path; the header carries the full URL.
+    // Either is sufficient to reconstruct the result, but the
+    // header is what the response uses, so prefer that and parse
+    // back to the local path for the returned `canonicalPath`.
+    let pathFromHeader: string | undefined = undefined;
+    if (canonicalFromHeader) {
+      try {
+        pathFromHeader = this.paths.local(new URL(canonicalFromHeader));
+      } catch {
+        // ignore
+      }
+    }
+    return {
+      result: {
+        kind: 'module',
+        canonicalPath:
+          pathFromHeader ?? this.paths.local(new URL(canonicalPath)),
+        body: row.body,
+        headers,
+      },
+      generation,
+    };
+  }
+
+  async #writeTranspileCacheRow(
+    canonicalPath: string,
+    result: ModuleTranspileResult,
+    capturedGeneration: number,
+  ): Promise<void> {
+    try {
+      // INSERT a row at `capturedGeneration`. On conflict, UPDATE only
+      // if the row's current generation is still <= capturedGeneration.
+      // If an invalidate has tombstoned-and-bumped the row past that
+      // value, the WHERE clause rejects the UPDATE and the stale
+      // transpile is discarded. capturedGeneration may legitimately be
+      // 0 (row absent at read time, tombstone never created) — in
+      // that case the WHERE 0 <= 0 still allows a no-op same-gen
+      // overwrite which is benign because the bytes are deterministic
+      // for the same source.
+      await query(this.#dbAdapter, [
+        'INSERT INTO',
+        MODULE_TRANSPILE_CACHE_TABLE,
+        '(realm_url, canonical_path, body, headers, dependency_keys, generation, created_at)',
+        'VALUES (',
+        param(this.url),
+        ',',
+        param(canonicalPath),
+        ',',
+        param(result.body),
+        ',',
+        param(JSON.stringify(result.headers)),
+        '::jsonb,',
+        // Dependency keys aren't propagated through #materializeAndTranspile
+        // currently (the in-memory entry derives them lazily from the
+        // transpile body via extractModuleDependencyKeys). Persist an
+        // empty array; the L1 write site recomputes them after the
+        // L2-hit return. A future revision can carry the keys forward to
+        // skip the recomputation on cross-process load.
+        param('[]'),
+        '::jsonb,',
+        param(capturedGeneration),
+        ',',
+        param(Date.now()),
+        ') ON CONFLICT (realm_url, canonical_path) DO UPDATE SET',
+        'body = EXCLUDED.body,',
+        'headers = EXCLUDED.headers,',
+        'dependency_keys = EXCLUDED.dependency_keys,',
+        'generation = EXCLUDED.generation,',
+        'created_at = EXCLUDED.created_at',
+        `WHERE ${MODULE_TRANSPILE_CACHE_TABLE}.generation <= EXCLUDED.generation`,
+      ]);
+    } catch (err: unknown) {
+      // L2 persistence is best-effort. A transient pg failure must not
+      // break the response the caller is about to serve — they already
+      // have the bytes in memory. Log and move on; the next reader will
+      // re-try the write.
+      this.#log.warn(
+        `${MODULE_TRANSPILE_CACHE_TABLE} insert failed for ${this.url}${canonicalPath}: ${String(err)}`,
+      );
+    }
+  }
+
+  async #deleteTranspileCacheRow(canonicalPath: string): Promise<void> {
+    try {
+      // Tombstone-and-bump rather than physically DELETE: an in-flight
+      // writer that captured this path's generation BEFORE the
+      // invalidate needs to observe the bumped generation when it
+      // tries to UPSERT, so its WHERE existing.generation <= captured
+      // clause fails and the stale bytes are rejected. A physical
+      // DELETE would let the writer's INSERT succeed (no conflict, no
+      // row to compare against) and resurrect the stale transpile.
+      await query(this.#dbAdapter, [
+        'INSERT INTO',
+        MODULE_TRANSPILE_CACHE_TABLE,
+        '(realm_url, canonical_path, body, headers, dependency_keys, generation, created_at)',
+        'VALUES (',
+        param(this.url),
+        ',',
+        param(canonicalPath),
+        ',',
+        'NULL, NULL, NULL, 1,',
+        param(Date.now()),
+        ') ON CONFLICT (realm_url, canonical_path) DO UPDATE SET',
+        'body = NULL,',
+        'headers = NULL,',
+        'dependency_keys = NULL,',
+        `generation = ${MODULE_TRANSPILE_CACHE_TABLE}.generation + 1,`,
+        'created_at = EXCLUDED.created_at',
+      ]);
+    } catch (err: unknown) {
+      // Same best-effort posture as #writeTranspileCacheRow — the in-memory
+      // L1 cache for this path was already invalidated, so a stale L2 row
+      // is at worst a brief window before the next reader's transpile
+      // overwrites it (or the next invalidate retries the tombstone).
+      this.#log.warn(
+        `${MODULE_TRANSPILE_CACHE_TABLE} tombstone failed for ${this.url}${canonicalPath}: ${String(err)}`,
+      );
+    }
+  }
+
+  async #deleteAllTranspileCacheRows(): Promise<void> {
+    try {
+      // Bulk tombstone-and-bump rather than DELETE — same reason as
+      // #deleteTranspileCacheRow: any in-flight writer captured the
+      // pre-wipe generation and must see a bumped row when it tries
+      // to UPSERT so the OCC WHERE clause rejects the stale write.
+      // Note that this bumps existing rows but does not create new
+      // tombstones for paths that didn't yet have a row; a writer
+      // for one of those paths that captured generation 0 would still
+      // succeed post-wipe, but that's a narrow window and currently
+      // limited to the __testOnly bulk-wipe path.
+      await query(this.#dbAdapter, [
+        'UPDATE',
+        MODULE_TRANSPILE_CACHE_TABLE,
+        'SET body = NULL, headers = NULL, dependency_keys = NULL,',
+        `generation = ${MODULE_TRANSPILE_CACHE_TABLE}.generation + 1,`,
+        'created_at =',
+        param(Date.now()),
+        'WHERE realm_url =',
+        param(this.url),
+      ]);
+    } catch (err: unknown) {
+      this.#log.warn(
+        `${MODULE_TRANSPILE_CACHE_TABLE} bulk tombstone failed for ${this.url}: ${String(err)}`,
+      );
+    }
   }
 
   async #materializeAndTranspile(

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -312,6 +312,11 @@ type ModuleTranspileResult = {
   canonicalPath: LocalPath;
   body: string;
   headers: Record<string, string>;
+  // Computed once at the transpile/L2-hit boundary so fallbackHandle's L1
+  // write can reuse them instead of re-running extractModuleDependencyKeys
+  // on every L1 miss. Carried through the L2 row so a cross-process L2 hit
+  // also skips the AST scan.
+  dependencyKeys: Set<string>;
 };
 
 // ETag base prefers a content fingerprint (md5 of the file body) over
@@ -2448,12 +2453,7 @@ export class Realm {
               canonicalPath: result.canonicalPath,
               body: result.body,
               headers: result.headers,
-              dependencyKeys: extractModuleDependencyKeys(
-                result.body,
-                result.canonicalPath,
-                this.url,
-                this.paths,
-              ),
+              dependencyKeys: result.dependencyKeys,
             });
           }
           response = createResponse({
@@ -2742,13 +2742,27 @@ export class Realm {
         // ignore
       }
     }
+    let canonicalPathLocal =
+      pathFromHeader ?? this.paths.local(new URL(canonicalPath));
+    let depsArray =
+      typeof row.dependency_keys === 'string'
+        ? (JSON.parse(row.dependency_keys) as string[])
+        : (row.dependency_keys ?? []);
+    // Carry the writer's deps through. The writer always persists the
+    // full set computed from the transpiled body, so an empty array
+    // legitimately means the module has no in-realm imports. A row
+    // written before deps were carried (rollout window) will also read
+    // as empty here — its L1 entry will be missing dep edges until the
+    // next invalidate forces a re-transpile. The table is UNLOGGED, so
+    // pre-rollout rows age out on any pg restart.
+    let dependencyKeys = new Set<string>(depsArray);
     return {
       result: {
         kind: 'module',
-        canonicalPath:
-          pathFromHeader ?? this.paths.local(new URL(canonicalPath)),
+        canonicalPath: canonicalPathLocal,
         body: row.body,
         headers,
+        dependencyKeys,
       },
       generation,
     };
@@ -2782,13 +2796,11 @@ export class Realm {
         ',',
         param(JSON.stringify(result.headers)),
         '::jsonb,',
-        // Dependency keys aren't propagated through #materializeAndTranspile
-        // currently (the in-memory entry derives them lazily from the
-        // transpile body via extractModuleDependencyKeys). Persist an
-        // empty array; the L1 write site recomputes them after the
-        // L2-hit return. A future revision can carry the keys forward to
-        // skip the recomputation on cross-process load.
-        param('[]'),
+        // Persist the full deps set computed once at the transpile
+        // boundary so a cross-process L2 reader can populate its L1
+        // entry directly instead of re-running extractModuleDependencyKeys
+        // on the bytes.
+        param(JSON.stringify([...result.dependencyKeys])),
         '::jsonb,',
         param(capturedGeneration),
         ',',
@@ -2924,11 +2936,22 @@ export class Realm {
     }
     headers['X-Boxel-Canonical-Path'] = canonicalPath;
 
+    // Compute deps once here so callers (L1 write site, L2 persist)
+    // reuse them. Carrying the set through the L2 row lets a peer
+    // skip this scan entirely on a cross-process cache hit.
+    let dependencyKeys = extractModuleDependencyKeys(
+      transpiled,
+      fileRef.path,
+      this.url,
+      this.paths,
+    );
+
     return {
       kind: 'module',
       canonicalPath: fileRef.path,
       body: transpiled,
       headers,
+      dependencyKeys,
     };
   }
 


### PR DESCRIPTION
## Summary

- New `module_transpile_cache` table (UNLOGGED, RAM-backed, like the `modules` definition cache). Keyed on `(realm_url, canonical_path)`. Columns: nullable body/headers/dependency_keys (so tombstones can sit in the row without bytes), `generation` BIGINT NOT NULL DEFAULT 0, created_at.
- Lifts `Realm.#moduleCache` from purely in-memory L1 to L1+L2. L1 stays in-process for hot-path latency; L2 is the cross-process shared layer.
- **OCC writes**. The writer captures the row's `generation` at the L2 read step (or 0 if absent), transpiles, then UPSERTs with that captured value via `ON CONFLICT DO UPDATE WHERE existing.generation <= EXCLUDED.generation`. An invalidate that lands during the transpile bumps the row past the captured value, so the writer's UPSERT is rejected by the WHERE clause and a stale transpile started before the invalidate cannot resurrect the row.
- **Tombstone-and-bump on invalidate**. `#deleteTranspileCacheRow` UPSERTs `body=NULL, generation = generation+1` rather than physically DELETEing. Physical DELETE would let a slow in-flight writer's INSERT succeed (no conflict, no row to compare against) and resurrect the stale bytes. Bulk wipe (`#deleteAllTranspileCacheRows` from `__testOnlyClearCaches`) likewise UPDATEs all rows to tombstones with bumped gen.
- Read path: L1 miss → in-flight dedup (CS-11029) → L2 read → coordinator winner/loser → babel → L2 OCC-protected persist.
- Coordinator: reuses the existing `ModuleCacheCoordinator` (CS-10953) and `MODULE_CACHE_POPULATED_CHANNEL`. The coalesce key prefix (`transpile|...` vs the CachingDefinitionLookup shape) keeps the two flows separate; waiters dispatch off the bounded int64 hash, so crosstalk is a benign hash miss.
- Invalidation: every CS-11028 invalidation site (writeMany, delete/deleteAll, file-watcher callback, handleExecutableInvalidations cascade, full-index clear, public invalidateCache) now fire-and-forget tombstones the matching L2 row alongside the in-memory drop. Every peer's listener runs the same tombstone-and-bump on its own copy → self-healing on transient pg blips and idempotent on the bump.
- `main.ts` passes the existing `moduleCacheCoordinator` as `transpileCoordinator` to every Realm it constructs.

The CS-11028 generation guard protects the in-memory L1 write; the new DB-resident `generation` column protects the L2 write. Together they close both layers of the invalidate-during-transpile race.

Linear: https://linear.app/cardstack/issue/CS-11030

## Test plan

- [ ] CI passes the `Realm.#moduleCache L2 module_transpile_cache (DB-backed)` module:
  - [ ] fresh transpile populates `module_transpile_cache`
  - [ ] L2 row serves a subsequent reader after L1 wipe (no re-transpile)
  - [ ] `invalidateCache` tombstones the L2 row and bumps generation
  - [ ] in-flight transpile that completes after invalidate cannot resurrect the L2 row (direct OCC guard exercise)
- [ ] Existing CS-11028 + CS-11029 race/dedup tests still pass.
- [ ] Existing CS-10953 `ModuleCacheCoordinator` tests still pass — the coordinator is unchanged; we just route a second flow through it.
- [ ] Module-cache regression tests in `realm-endpoints-test.ts` still pass (etag, 304, content-type).

## Follow-ups (NOT in this PR)

- Two-instance integration test mirroring `module-cache-coordination-test.ts` for the transpile flow (gated babel + advisory-lock contention → exactly one transpile across both instances).
- Bulk-wipe edge case: `#deleteAllTranspileCacheRows` bumps existing rows but doesn't tombstone paths that didn't yet have a row, so an in-flight writer for one of those paths could still resurrect. Narrow, only reachable from `__testOnlyClearCaches`.
- Periodic tombstone GC if the table grows materially (UNLOGGED, but still bounded only by total path cardinality).
- Carry dependency_keys through the L2 write so cross-process load skips the `extractModuleDependencyKeys` recomputation in fallbackHandle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)