### PR TITLE
ci: Update github-script action version

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -37,7 +37,7 @@ jobs:
             echo "environment_url=" >> "$GITHUB_OUTPUT"
           fi
       - id: create
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const environment = '${{ inputs.environment }}';
@@ -54,7 +54,7 @@ jobs:
             });
             core.setOutput('deployment_id', response.data.id.toString());
       - name: Mark deployment in progress
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const deployment_id = Number('${{ steps.create.outputs.deployment_id }}');
@@ -360,7 +360,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set deployment status
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           NEEDS: ${{ toJson(needs) }}
           DEPLOYMENT_ID: ${{ needs.create-deployment.outputs.deployment-id }}

--- a/.github/workflows/observability-diff.yml
+++ b/.github/workflows/observability-diff.yml
@@ -165,10 +165,10 @@ jobs:
           echo "::endgroup::"
 
       - name: Post sticky PR comment
-        # Pinned to SHA (rather than @v7) because this step has
+        # Pinned to SHA (rather than @v9) because this step has
         # pull-requests: write and runs after assuming an AWS role —
         # supply-chain risk is non-negligible.
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           DIFF_FILE: ${{ steps.diff.outputs.diff_file }}
         with:


### PR DESCRIPTION
<img width="3362" height="525" alt="CleanShot 2026-05-11 at 08 25 43" src="https://github.com/user-attachments/assets/f2d920e1-e5ad-4d26-974d-54e0e817f284" />

Along with [this `gh-actions` PR](https://github.com/cardstack/gh-actions/pull/37) this should silence deprecation warnings as seen [here](https://github.com/cardstack/boxel/actions/runs/25667483667).