### PR TITLE
fix: prevent large-realm indexing OOM-loop in invalidation ordering

### DIFF
--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -2008,4 +2008,302 @@ module('Unit | index-writer', function (hooks) {
       'resumed row search_doc landed in boxel_index',
     );
   });
+
+  module('getOrderingDependencyRows', function () {
+    test('returns production row when URL exists only in boxel_index', async function (assert) {
+      let url = `${testRealmURL}prod-only.json`;
+      let depUrl = `${testRealmURL}prod-only-dep.json`;
+      await setupIndex(
+        adapter,
+        [{ realm_url: testRealmURL, current_version: 1 }],
+        {
+          working: [],
+          production: [
+            {
+              url,
+              realm_version: 1,
+              realm_url: testRealmURL,
+              type: 'instance',
+              deps: [depUrl],
+              types: [],
+            },
+          ],
+        },
+      );
+
+      let batch = await indexWriter.createBatch(new URL(testRealmURL));
+      let rows = await batch.getOrderingDependencyRows([url]);
+      assert.deepEqual(
+        rows,
+        [{ url, type: 'instance', deps: [depUrl] }],
+        'returns the production row deps',
+      );
+    });
+
+    test('returns working row when URL exists only in boxel_index_working and is not deleted', async function (assert) {
+      let url = `${testRealmURL}working-only.json`;
+      let depUrl = `${testRealmURL}working-only-dep.json`;
+      await setupIndex(
+        adapter,
+        [{ realm_url: testRealmURL, current_version: 1 }],
+        {
+          working: [
+            {
+              url,
+              realm_version: 1,
+              realm_url: testRealmURL,
+              type: 'instance',
+              is_deleted: false,
+              deps: [depUrl],
+              types: [],
+            },
+          ],
+          production: [],
+        },
+      );
+
+      let batch = await indexWriter.createBatch(new URL(testRealmURL));
+      let rows = await batch.getOrderingDependencyRows([url]);
+      assert.deepEqual(
+        rows,
+        [{ url, type: 'instance', deps: [depUrl] }],
+        'returns the working row deps',
+      );
+    });
+
+    test('working non-deleted wins over production when both exist', async function (assert) {
+      let url = `${testRealmURL}both.json`;
+      let workingDep = `${testRealmURL}working-dep.json`;
+      let productionDep = `${testRealmURL}production-dep.json`;
+      await setupIndex(
+        adapter,
+        [{ realm_url: testRealmURL, current_version: 1 }],
+        {
+          working: [
+            {
+              url,
+              realm_version: 1,
+              realm_url: testRealmURL,
+              type: 'instance',
+              is_deleted: false,
+              deps: [workingDep],
+              types: [],
+            },
+          ],
+          production: [
+            {
+              url,
+              realm_version: 1,
+              realm_url: testRealmURL,
+              type: 'instance',
+              deps: [productionDep],
+              types: [],
+            },
+          ],
+        },
+      );
+
+      let batch = await indexWriter.createBatch(new URL(testRealmURL));
+      let rows = await batch.getOrderingDependencyRows([url]);
+      assert.deepEqual(
+        rows,
+        [{ url, type: 'instance', deps: [workingDep] }],
+        'working-non-deleted beat production',
+      );
+    });
+
+    test('production wins over deleted working row', async function (assert) {
+      let url = `${testRealmURL}deleted-working.json`;
+      let workingDep = `${testRealmURL}should-not-appear.json`;
+      let productionDep = `${testRealmURL}production-dep.json`;
+      await setupIndex(
+        adapter,
+        [{ realm_url: testRealmURL, current_version: 1 }],
+        {
+          working: [
+            {
+              url,
+              realm_version: 1,
+              realm_url: testRealmURL,
+              type: 'instance',
+              is_deleted: true,
+              deps: [workingDep],
+              types: [],
+            },
+          ],
+          production: [
+            {
+              url,
+              realm_version: 1,
+              realm_url: testRealmURL,
+              type: 'instance',
+              deps: [productionDep],
+              types: [],
+            },
+          ],
+        },
+      );
+
+      let batch = await indexWriter.createBatch(new URL(testRealmURL));
+      let rows = await batch.getOrderingDependencyRows([url]);
+      assert.deepEqual(
+        rows,
+        [{ url, type: 'instance', deps: [productionDep] }],
+        'production picked when working row is deleted',
+      );
+    });
+
+    test('falls back to deleted working row when no production exists', async function (assert) {
+      let url = `${testRealmURL}deleted-only.json`;
+      let depUrl = `${testRealmURL}deleted-only-dep.json`;
+      await setupIndex(
+        adapter,
+        [{ realm_url: testRealmURL, current_version: 1 }],
+        {
+          working: [
+            {
+              url,
+              realm_version: 1,
+              realm_url: testRealmURL,
+              type: 'instance',
+              is_deleted: true,
+              deps: [depUrl],
+              types: [],
+            },
+          ],
+          production: [],
+        },
+      );
+
+      let batch = await indexWriter.createBatch(new URL(testRealmURL));
+      let rows = await batch.getOrderingDependencyRows([url]);
+      assert.deepEqual(
+        rows,
+        [{ url, type: 'instance', deps: [depUrl] }],
+        'returns deleted working row as last-resort fallback',
+      );
+    });
+
+    test('mixed input returns the correct provenance per URL', async function (assert) {
+      let workingOnlyUrl = `${testRealmURL}mixed-working.json`;
+      let workingOnlyDep = `${testRealmURL}mixed-working-dep.json`;
+      let productionOnlyUrl = `${testRealmURL}mixed-production.json`;
+      let productionOnlyDep = `${testRealmURL}mixed-production-dep.json`;
+      let bothUrl = `${testRealmURL}mixed-both.json`;
+      let bothWorkingDep = `${testRealmURL}mixed-both-working-dep.json`;
+      let bothProductionDep = `${testRealmURL}mixed-both-production-dep.json`;
+      await setupIndex(
+        adapter,
+        [{ realm_url: testRealmURL, current_version: 1 }],
+        {
+          working: [
+            {
+              url: workingOnlyUrl,
+              realm_version: 1,
+              realm_url: testRealmURL,
+              type: 'instance',
+              is_deleted: false,
+              deps: [workingOnlyDep],
+              types: [],
+            },
+            {
+              url: bothUrl,
+              realm_version: 1,
+              realm_url: testRealmURL,
+              type: 'instance',
+              is_deleted: false,
+              deps: [bothWorkingDep],
+              types: [],
+            },
+          ],
+          production: [
+            {
+              url: productionOnlyUrl,
+              realm_version: 1,
+              realm_url: testRealmURL,
+              type: 'instance',
+              deps: [productionOnlyDep],
+              types: [],
+            },
+            {
+              url: bothUrl,
+              realm_version: 1,
+              realm_url: testRealmURL,
+              type: 'instance',
+              deps: [bothProductionDep],
+              types: [],
+            },
+          ],
+        },
+      );
+
+      let batch = await indexWriter.createBatch(new URL(testRealmURL));
+      let rows = await batch.getOrderingDependencyRows([
+        workingOnlyUrl,
+        productionOnlyUrl,
+        bothUrl,
+      ]);
+      let byUrl = new Map(rows.map((r) => [r.url, r]));
+      assert.deepEqual(
+        byUrl.get(workingOnlyUrl),
+        { url: workingOnlyUrl, type: 'instance', deps: [workingOnlyDep] },
+        'working-only URL returns working deps',
+      );
+      assert.deepEqual(
+        byUrl.get(productionOnlyUrl),
+        {
+          url: productionOnlyUrl,
+          type: 'instance',
+          deps: [productionOnlyDep],
+        },
+        'production-only URL returns production deps',
+      );
+      assert.deepEqual(
+        byUrl.get(bothUrl),
+        { url: bothUrl, type: 'instance', deps: [bothWorkingDep] },
+        'URL present in both returns working deps (working wins)',
+      );
+      assert.strictEqual(rows.length, 3, 'one row returned per requested URL');
+    });
+
+    test('projection excludes error_doc, has_error, and is_deleted', async function (assert) {
+      let url = `${testRealmURL}projection.json`;
+      await setupIndex(
+        adapter,
+        [{ realm_url: testRealmURL, current_version: 1 }],
+        {
+          working: [
+            {
+              url,
+              realm_version: 1,
+              realm_url: testRealmURL,
+              type: 'instance',
+              is_deleted: false,
+              has_error: true,
+              error_doc: {
+                id: url,
+                status: 500,
+                title: 'kaboom',
+                message: 'should not be returned',
+                additionalErrors: null,
+              },
+              deps: [],
+              types: [],
+            },
+          ],
+          production: [],
+        },
+      );
+
+      let batch = await indexWriter.createBatch(new URL(testRealmURL));
+      let rows = await batch.getOrderingDependencyRows([url]);
+      assert.strictEqual(rows.length, 1, 'one row returned');
+      let row = rows[0]!;
+      assert.deepEqual(
+        Object.keys(row).sort(),
+        ['deps', 'type', 'url'],
+        'row exposes only url, type, deps — no error_doc / has_error / is_deleted',
+      );
+    });
+  });
 });

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -160,6 +160,8 @@ export class IndexRunner {
       },
       getDependencyRows: async (urls) =>
         await this.batch.getDependencyRows(urls),
+      getOrderingDependencyRows: async (urls) =>
+        await this.batch.getOrderingDependencyRows(urls),
       getInvalidations: () => this.#batch?.invalidations ?? [],
     });
   }

--- a/packages/runtime-common/index-runner/dependency-resolver.ts
+++ b/packages/runtime-common/index-runner/dependency-resolver.ts
@@ -12,10 +12,15 @@ import {
   type RelationshipSource,
 } from './relationship-dependency-extractor';
 
+type OrderingDependencyRow = Pick<DependencyIndexRow, 'url' | 'type' | 'deps'>;
+
 interface DependencyResolverOptions {
   realmURL: URL;
   readModuleCacheEntries(moduleIds: string[]): Promise<ModuleCacheEntries>;
   getDependencyRows(urls: string[]): Promise<DependencyIndexRow[]>;
+  // Slim projection (url, type, deps only) used by invalidation ordering.
+  // Selection priority is applied server-side; see IndexWriter.
+  getOrderingDependencyRows(urls: string[]): Promise<OrderingDependencyRow[]>;
   getInvalidations(): string[];
 }
 
@@ -29,7 +34,9 @@ interface DependencyResolverOptions {
  *   paths when runtime capture can be incomplete (short-circuit failures).
  */
 export class IndexRunnerDependencyManager {
-  #getDependencyRows: (urls: string[]) => Promise<DependencyIndexRow[]>;
+  #getOrderingDependencyRows: (
+    urls: string[],
+  ) => Promise<OrderingDependencyRow[]>;
   #indexBackedDependencyErrors: IndexBackedDependencyErrors;
   #relationshipDependencyExtractor: RelationshipDependencyExtractor;
 
@@ -37,9 +44,10 @@ export class IndexRunnerDependencyManager {
     realmURL,
     readModuleCacheEntries,
     getDependencyRows,
+    getOrderingDependencyRows,
     getInvalidations,
   }: DependencyResolverOptions) {
-    this.#getDependencyRows = getDependencyRows;
+    this.#getOrderingDependencyRows = getOrderingDependencyRows;
     this.#indexBackedDependencyErrors = new IndexBackedDependencyErrors({
       realmURL,
       readModuleCacheEntries,
@@ -71,7 +79,7 @@ export class IndexRunnerDependencyManager {
     let byHref = new Map(urls.map((url) => [url.href, url]));
     let hrefs = [...byHref.keys()];
     let order = new Map(hrefs.map((href, index) => [href, index]));
-    let rows = await this.#getDependencyRows(hrefs);
+    let rows = await this.#getOrderingDependencyRows(hrefs);
 
     let edges = new Map<string, Set<string>>();
     let indegree = new Map<string, number>();

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -965,6 +965,90 @@ export class Batch {
     this.#invalidations = new Set([...this.#invalidations, ...invalidations]);
   }
 
+  // Returns the minimum projection (url, type, deps) needed to order
+  // invalidations by dependency. Server-side selection picks one row per
+  // (url, type) with priority: working-non-deleted > production > working-deleted,
+  // applied via a window function over UNION ALL of both tables. Avoids the
+  // double client-side merge and the dead-weight `error_doc` payload that
+  // `getDependencyRows` carries for the error fan-out path.
+  async getOrderingDependencyRows(
+    urls: string[],
+  ): Promise<Pick<DependencyIndexRow, 'url' | 'type' | 'deps'>[]> {
+    await this.ready;
+    if (urls.length === 0) {
+      return [];
+    }
+
+    let uniqueUrls = [...new Set(urls)];
+    // SQLite has a lower parameter limit than Postgres. Each batch binds
+    // `realm_url` and the URL list once per source table, so the per-batch
+    // param count is roughly 2 * (urlBatchSize + 1). Keep the per-call total
+    // within safe bounds for both adapters.
+    let urlBatchSize = this.#dbAdapter.kind === 'sqlite' ? 450 : 2500;
+    let selected: Pick<DependencyIndexRow, 'url' | 'type' | 'deps'>[] = [];
+    for (let i = 0; i < uniqueUrls.length; i += urlBatchSize) {
+      let urlBatch = uniqueUrls.slice(i, i + urlBatchSize);
+      let batchRows = await this.queryOrderingDependencyRows(urlBatch);
+      selected.push(...batchRows);
+    }
+    return selected;
+  }
+
+  private async queryOrderingDependencyRows(
+    urls: string[],
+  ): Promise<Pick<DependencyIndexRow, 'url' | 'type' | 'deps'>[]> {
+    if (urls.length === 0) {
+      return [];
+    }
+    let rows = (await this.#query([
+      'SELECT url, type, deps FROM (',
+      'SELECT url, type, deps,',
+      'ROW_NUMBER() OVER (PARTITION BY url, type ORDER BY source_priority) AS rn',
+      'FROM (',
+      'SELECT url, type, deps,',
+      'CASE WHEN is_deleted THEN 2 ELSE 0 END AS source_priority',
+      'FROM boxel_index_working WHERE',
+      ...every([
+        ['realm_url =', param(this.realmURL.href)],
+        [
+          'url IN',
+          ...addExplicitParens(
+            separatedByCommas(urls.map((url) => [param(url)])),
+          ),
+        ],
+        any([
+          ['type =', param('instance')],
+          ['type =', param('file')],
+        ]),
+      ]),
+      'UNION ALL',
+      'SELECT url, type, deps, 1 AS source_priority',
+      'FROM boxel_index WHERE',
+      ...every([
+        ['realm_url =', param(this.realmURL.href)],
+        [
+          'url IN',
+          ...addExplicitParens(
+            separatedByCommas(urls.map((url) => [param(url)])),
+          ),
+        ],
+        any([
+          ['type =', param('instance')],
+          ['type =', param('file')],
+        ]),
+      ]),
+      ') candidates',
+      ') ranked',
+      'WHERE rn = 1',
+    ] as Expression)) as Pick<BoxelIndexTable, 'url' | 'type' | 'deps'>[];
+
+    return rows.map((row) => ({
+      url: row.url,
+      type: row.type,
+      deps: row.deps ?? null,
+    }));
+  }
+
   async getDependencyRows(urls: string[]): Promise<DependencyIndexRow[]> {
     await this.ready;
     if (urls.length === 0) {


### PR DESCRIPTION
## Summary

On large realms (>1000 instances with multi-MB jsonb `deps` columns), post-deploy `from-scratch` indexing was OOM-looping silently: workers got SIGKILL'd ~12 s into the job with no FATAL ERROR / no stderr, every reservation closed as `interrupted`, and so the per-job retry cap (2 real attempts) never engaged — the job re-claimed indefinitely until a human cancelled it.

In staging on 2026-05-11 this fired on:

- job **344282** for `buck/ctsepersonal` — 361 reservations across 2h 11m
- job **344373** for `buck/buck` — 202 reservations

Both were finally rejected via "User initiated job cancellation". The visible log shape on each reservation was identical: `starting from scratch indexing` → `discovering invalidations in dir …` → silence for ~12 s → `worker N exited. spawning replacement worker`. No "begin fused visit" line ever appeared, so the death was strictly between `Batch.invalidate` returning and the first per-file visit.

This is a recurring failure mode because every deploy enqueues `from-scratch-index` for every realm (so cards pick up new platform code). A realm too large to ordering-sort fails on every deploy.

The retry-cap bypass that turned a single OOM into a 361-reservation loop is a separate issue, called out under "Not in scope" below.

## Where the OOM happens

In `IndexRunner.fromScratch`, between `Batch.invalidate` returning and the per-file visit loop:

```ts
invalidations = sortInvalidations(invalidations, current.realmURL);
invalidations = await current.#dependencyResolver
  .orderInvalidationsByDependencies(invalidations);
```

`orderInvalidationsByDependencies` calls `Batch.getDependencyRows(allHrefs)`, which issues two parallel SELECTs over the same URL batch — one against `boxel_index_working`, one against `boxel_index` — both pulling `url, type, deps, has_error, is_deleted, error_doc`. The results are merged client-side into `Map<string, {working?, production?}>` and one row per `(url, type)` is selected via these rules:

| state | pick |
| --- | --- |
| working not deleted | working |
| working deleted, production present | production |
| working deleted, no production | working |
| only production | production |

For buck/ctsepersonal:

| table | rows | deps total | pristine_doc total |
| --- | --- | --- | --- |
| `boxel_index`         | 1156 | 22 MB | 55 MB |
| `boxel_index_working` | 1156 | 22 MB | 55 MB |

Both tables are queried in full, materializing ~44 MB of jsonb plus all `error_doc` payloads (98 error rows in production carry captured DOM and `additionalErrors`) just to read `url` and `deps` for the topo sort — `orderInvalidationsByDependencies` only consumes `row.url` and `row.deps`.

## The fix

1. New `Batch.getOrderingDependencyRows(urls)` on `IndexWriter` that picks one row per `(url, type)` server-side via a `ROW_NUMBER()` window over `UNION ALL` of both tables. Selection priority maps exactly to the existing rules above: working-non-deleted (0) > production (1) > working-deleted (2). Projects only `url, type, deps` — no `error_doc`, no `has_error`, no `is_deleted`. One SQL round-trip per URL batch instead of two.

2. `IndexRunnerDependencyManager` (the invalidation ordering path) calls the new slim method via a new `getOrderingDependencyRows` option on `DependencyResolverOptions`. The topo sort body is unchanged; only the input source narrows. The client-side working/production merge `Map` is gone.

3. `getDependencyRows` and `queryDependencyRows` stay as-is — they're still used by `IndexBackedDependencyErrors` and the relationship-extractor path, which legitimately need `has_error`, `is_deleted`, and `error_doc`.

The window-function + `UNION ALL` shape works on Postgres (realm-server) and SQLite 3.25+ (host tests).

## Not in scope (followup)

The per-job retry cap in `pg-queue.ts` (`MAX_RESERVATION_COUNT_PER_JOB = 2`) counts only reservations closed as `completed` or still-open `NULL`. Reservations closed as `interrupted` (from `finalizeOrphanedReservations` after a worker exit) don't count against the cap, so a deterministically OOM-ing job loops indefinitely. That's by design for transient operational interruptions but the wrong shape for repeating OOMs on the same job. Worth a separate ticket to either count consecutive `interrupted` reservations against the cap or treat repeated worker SIGKILLs on the same job as a verdict.

## Test plan

New unit tests in `packages/host/tests/unit/index-writer-test.ts` under module `Unit | index-writer > getOrderingDependencyRows`:

- [x] `returns production row when URL exists only in boxel_index`
- [x] `returns working row when URL exists only in boxel_index_working and is not deleted`
- [x] `working non-deleted wins over production when both exist`
- [x] `production wins over deleted working row`
- [x] `falls back to deleted working row when no production exists`
- [x] `mixed input returns the correct provenance per URL`
- [x] `projection excludes error_doc, has_error, and is_deleted`

All 7 pass locally; the full `Unit | index-writer` module (33 tests) is green. Lint clean on `packages/runtime-common` and `packages/host`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)