### PR TITLE
Fix dev-all/dev Ctrl-C leaking the dev-stack subtree

### DIFF
--- a/mise-tasks/dev
+++ b/mise-tasks/dev
@@ -13,13 +13,18 @@
 set -m
 
 cleanup() {
-  trap - EXIT INT TERM
+  trap - EXIT INT TERM HUP
   if [ -n "${SAT_PID:-}" ]; then
     kill_tree "$SAT_PID"
   fi
   sweep_orphaned_services
 }
-trap cleanup EXIT INT TERM
+# HUP is required: when the user hits Ctrl-C in a terminal running `mise run
+# dev`, mise often exits without forwarding SIGINT to this bash script, and
+# bash then receives SIGHUP from the dying parent. Bash's default action on
+# an untrapped SIGHUP is to terminate *without* running the EXIT trap, so
+# without `HUP` here the cleanup never fires and the entire subtree leaks.
+trap cleanup EXIT INT TERM HUP
 
 WAIT_ON_TIMEOUT=7200000 NODE_NO_WARNINGS=1 start-server-and-test \
   'run-p -ln start:pg start:matrix start:smtp start:prerender-dev start:prerender-manager-dev start:worker-development start:development' \

--- a/mise-tasks/dev-all
+++ b/mise-tasks/dev-all
@@ -18,14 +18,19 @@ set -m
 pnpm --filter @cardstack/host start &
 HOST_PID=$!
 cleanup() {
-  trap - EXIT INT TERM
+  trap - EXIT INT TERM HUP
   if [ -n "${SAT_PID:-}" ]; then
     kill_tree "$SAT_PID"
   fi
   kill_tree "$HOST_PID"
   sweep_orphaned_services
 }
-trap cleanup EXIT INT TERM
+# HUP is required: when the user hits Ctrl-C in a terminal running `mise run
+# dev-all`, mise often exits without forwarding SIGINT to this bash script,
+# and bash then receives SIGHUP from the dying parent. Bash's default action
+# on an untrapped SIGHUP is to terminate *without* running the EXIT trap, so
+# without `HUP` here the cleanup never fires and the entire subtree leaks.
+trap cleanup EXIT INT TERM HUP
 
 HOST_TIMEOUT=120
 ELAPSED=0

--- a/mise-tasks/lib/dev-common.sh
+++ b/mise-tasks/lib/dev-common.sh
@@ -30,32 +30,36 @@ SWEEP_GRACE_SECS=3
 # those grandchildren are still alive, the calling script exits, and they
 # reparent to init and keep their ports bound — which is exactly the leak
 # this helper is supposed to prevent.
+# All locals carry an `_kill_tree_` prefix because this file is sourced, so
+# bare names like `pid` / `elapsed` would become globals in the caller's
+# shell and could clobber its variables. `local` would be cleaner but isn't
+# in POSIX sh and this file runs under `#!/bin/sh`.
 kill_tree() {
   _kill_tree_collect_pids "$1"
   _kill_tree_pids="$_kill_tree_collected"
 
-  for pid in $_kill_tree_pids; do
-    kill -TERM "$pid" 2>/dev/null || true
+  for _kill_tree_pid in $_kill_tree_pids; do
+    kill -TERM "$_kill_tree_pid" 2>/dev/null || true
   done
 
-  elapsed=0
-  while [ "$elapsed" -lt "$KILL_TREE_GRACE_SECS" ]; do
-    any_alive=0
-    for pid in $_kill_tree_pids; do
-      if kill -0 "$pid" 2>/dev/null; then
-        any_alive=1
+  _kill_tree_elapsed=0
+  while [ "$_kill_tree_elapsed" -lt "$KILL_TREE_GRACE_SECS" ]; do
+    _kill_tree_any_alive=0
+    for _kill_tree_pid in $_kill_tree_pids; do
+      if kill -0 "$_kill_tree_pid" 2>/dev/null; then
+        _kill_tree_any_alive=1
         break
       fi
     done
-    if [ "$any_alive" -eq 0 ]; then
+    if [ "$_kill_tree_any_alive" -eq 0 ]; then
       return 0
     fi
     sleep 1
-    elapsed=$((elapsed + 1))
+    _kill_tree_elapsed=$((_kill_tree_elapsed + 1))
   done
 
-  for pid in $_kill_tree_pids; do
-    kill -KILL "$pid" 2>/dev/null || true
+  for _kill_tree_pid in $_kill_tree_pids; do
+    kill -KILL "$_kill_tree_pid" 2>/dev/null || true
   done
 }
 
@@ -69,9 +73,12 @@ _kill_tree_collect_pids() {
   _kill_tree_walk "$1"
 }
 
+# `|| true` because pgrep exits 1 when a pid has no children, which would
+# abort callers running under `set -e` even though "no children" is the
+# normal terminating case for the recursion.
 _kill_tree_walk() {
-  for child in $(pgrep -P "$1" 2>/dev/null); do
-    _kill_tree_walk "$child"
+  for _kill_tree_child in $(pgrep -P "$1" 2>/dev/null || true); do
+    _kill_tree_walk "$_kill_tree_child"
   done
   _kill_tree_collected="$_kill_tree_collected $1"
 }

--- a/mise-tasks/lib/dev-common.sh
+++ b/mise-tasks/lib/dev-common.sh
@@ -10,41 +10,116 @@ REPO_ROOT="$(cd "../.." && pwd)"
 # reliable regardless of how the binary was originally resolved by PATH.
 export PATH="${REPO_ROOT}/node_modules/.bin:${REPO_ROOT}/packages/realm-server/node_modules/.bin:./node_modules/.bin:$PATH"
 
-# Recursively SIGTERM a pid and all its descendants. Walks by parent-pid
-# (independent of pgid, which `mise run` rewrites for its tasks) so we catch
-# the whole tree before any layer dies and orphans its children to init.
+# How long to wait for SIGTERM'd processes to exit before escalating to
+# SIGKILL. The dev stack has slow propagators in it (pnpm, npm exec, vite,
+# start-server-and-test, run-p) that don't immediately forward SIGTERM to
+# their children, so we have to give them a real grace window — but not so
+# long that the user is staring at a hung terminal after Ctrl-C.
+KILL_TREE_GRACE_SECS=5
+SWEEP_GRACE_SECS=3
+
+# Recursively SIGTERM a pid and all its descendants, then wait up to
+# KILL_TREE_GRACE_SECS for them to exit, then SIGKILL anything still alive.
+# Walks by parent-pid (independent of pgid, which `mise run` rewrites for its
+# tasks) so we catch the whole tree before any layer dies and orphans its
+# children to init.
+#
+# Two-phase TERM-then-KILL because the wrapper layers in this stack (pnpm,
+# npm exec, run-p, start-server-and-test) frequently exit *before* relaying
+# SIGTERM to their grandchildren. A bare SIGTERM-only walk returns while
+# those grandchildren are still alive, the calling script exits, and they
+# reparent to init and keep their ports bound — which is exactly the leak
+# this helper is supposed to prevent.
 kill_tree() {
-  for child in $(pgrep -P "$1" 2>/dev/null); do
-    kill_tree "$child"
+  _kill_tree_collect_pids "$1"
+  _kill_tree_pids="$_kill_tree_collected"
+
+  for pid in $_kill_tree_pids; do
+    kill -TERM "$pid" 2>/dev/null || true
   done
-  kill -TERM "$1" 2>/dev/null || true
+
+  elapsed=0
+  while [ "$elapsed" -lt "$KILL_TREE_GRACE_SECS" ]; do
+    any_alive=0
+    for pid in $_kill_tree_pids; do
+      if kill -0 "$pid" 2>/dev/null; then
+        any_alive=1
+        break
+      fi
+    done
+    if [ "$any_alive" -eq 0 ]; then
+      return 0
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+
+  for pid in $_kill_tree_pids; do
+    kill -KILL "$pid" 2>/dev/null || true
+  done
 }
 
-# Sweep orphaned mise services scoped to this checkout. mise's task supervisor
-# reparents long-running task scripts to init, so a tree-walk from a known
-# pid can't reach them via PPID. SIGTERM first for anything that listens,
-# brief grace, then SIGKILL — belt-and-suspenders for processes that don't
-# respond to TERM.
+# Collect the pid and all descendants (post-order: leaves first, root last)
+# into the global $_kill_tree_collected. Doing this up front lets the caller
+# SIGTERM the whole tree, wait once, then SIGKILL stragglers — instead of
+# re-walking after every layer dies (which races children reparenting to
+# init).
+_kill_tree_collect_pids() {
+  _kill_tree_collected=""
+  _kill_tree_walk "$1"
+}
+
+_kill_tree_walk() {
+  for child in $(pgrep -P "$1" 2>/dev/null); do
+    _kill_tree_walk "$child"
+  done
+  _kill_tree_collected="$_kill_tree_collected $1"
+}
+
+# Sweep orphaned dev-stack processes scoped to this checkout. mise's task
+# supervisor reparents long-running task scripts to init, and the wrapper
+# layers above ts-node (pnpm, npm exec, run-p, vite, start-server-and-test)
+# routinely exit without relaying SIGTERM to their grandchildren — so a
+# tree-walk from a known pid can't reach all of them via PPID. SIGTERM first
+# for anything that listens, brief grace, then SIGKILL.
 #
 # `pkill -f` matches its pattern as ERE, so $REPO_ROOT must be regex-escaped
 # before interpolating; otherwise a checkout path with metacharacters (e.g.
 # `boxel.worktrees/...`, where `.` matches any char) would over-match and
-# signal unrelated processes outside this checkout. The trailing
-# `node_modules.*--transpileOnly …` is an INTENTIONAL regex: `node_modules.*`
-# matches whichever subpath the ts-node binary resolves through, and the
-# alternation lists every service entrypoint that holds a port (worker /
-# worker-manager → 4210, main → 4201/4202, prerender/* → 4221/4222).
-# Wrappers that just invoke ts-node don't `exec` it, so killing the wrapper
-# alone leaves the ts-node grandchild reparented to init with its port
-# still bound.
+# signal unrelated processes outside this checkout. Every pattern is
+# anchored to ${REPO_ROOT_RE} so it never matches outside this checkout —
+# the user may have unrelated vite/ember/node processes running for other
+# projects.
+#
+# The patterns:
+#   - mise-tasks/services/* — the bash service entrypoints
+#   - node_modules.*--transpileOnly (worker|main|prerender) — ts-node
+#     grandchildren that actually hold the realm/worker/prerender ports
+#     (4201/4202, 4210/4211, 4221/4222). Wrappers that just invoke ts-node
+#     don't `exec` it, so killing the wrapper alone leaves the ts-node
+#     grandchild reparented to init with its port still bound.
+#   - packages/host/.*vite/bin/vite.js — the host dev server (port 4200)
+#   - node_modules/.*/start-server-and-test/ — the phase-coordinator that
+#     owns the run-p subtree
+#   - node_modules/.*/npm-run-all/.*run-[ps] — run-p / run-s, which spawn
+#     the `npm run start:*` wrappers and don't always forward signals
 sweep_orphaned_services() {
   REPO_ROOT_RE="$(printf '%s' "$REPO_ROOT" | sed -E 's/[][\\.*^$+?(){}|]/\\&/g')"
   TSNODE_RE="${REPO_ROOT_RE}/packages/realm-server/node_modules.*--transpileOnly (worker|main|prerender)"
-  pkill -TERM -f "${REPO_ROOT_RE}/mise-tasks/services/" 2>/dev/null || true
-  pkill -TERM -f "$TSNODE_RE" 2>/dev/null || true
-  sleep 2
-  pkill -KILL -f "${REPO_ROOT_RE}/mise-tasks/services/" 2>/dev/null || true
-  pkill -KILL -f "$TSNODE_RE" 2>/dev/null || true
+  VITE_RE="${REPO_ROOT_RE}/packages/host/.*vite/bin/vite\.js"
+  SAT_RE="${REPO_ROOT_RE}/.*node_modules/.*start-server-and-test/"
+  RUNP_RE="${REPO_ROOT_RE}/.*node_modules/.*npm-run-all/bin/run-[ps]"
+
+  for sig in TERM KILL; do
+    pkill -"$sig" -f "${REPO_ROOT_RE}/mise-tasks/services/" 2>/dev/null || true
+    pkill -"$sig" -f "$TSNODE_RE" 2>/dev/null || true
+    pkill -"$sig" -f "$VITE_RE" 2>/dev/null || true
+    pkill -"$sig" -f "$SAT_RE" 2>/dev/null || true
+    pkill -"$sig" -f "$RUNP_RE" 2>/dev/null || true
+    if [ "$sig" = "TERM" ]; then
+      sleep "$SWEEP_GRACE_SECS"
+    fi
+  done
 }
 
 READY_PATH="_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson"

--- a/mise-tasks/lib/test-dev-common.sh
+++ b/mise-tasks/lib/test-dev-common.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Lightweight self-test for kill_tree in dev-common.sh.
+#
+# Spawns a 3-level sleep tree, asks kill_tree to take it down, and asserts
+# that every pid in the tree is gone by the time kill_tree returns. The
+# point is to catch regressions where kill_tree returns while children are
+# still alive (which is what the original SIGTERM-only walk did, causing
+# leaked dev-stack processes after Ctrl-C).
+#
+# Not wired into CI — running it touches real signals and would race with
+# any concurrent dev-stack on the same host. Invoke directly:
+#   ./mise-tasks/lib/test-dev-common.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+# `dev-common.sh` derives REPO_ROOT from "../.."; load it from a cwd that
+# resolves to the realm-server package so its initial cd doesn't fail.
+cd "$SCRIPT_DIR/../../packages/realm-server"
+# Stub the env-driven globals dev-common.sh references during sourcing so
+# the script doesn't error out before we get to kill_tree.
+: "${REALM_BASE_URL:=http://localhost:4201}"
+: "${REALM_TEST_URL:=http://localhost:4202}"
+: "${MATRIX_URL_VAL:=http://localhost:8008}"
+: "${ICONS_URL:=http://localhost:4206}"
+export REALM_BASE_URL REALM_TEST_URL MATRIX_URL_VAL ICONS_URL
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/dev-common.sh"
+
+# Shorten the grace window so this test runs in a few seconds instead of
+# the default ~5s; we still want >0 to exercise the wait path.
+KILL_TREE_GRACE_SECS=2
+
+fail=0
+
+# Spawn a 3-level tree: bash → bash → sleep
+bash -c 'bash -c "sleep 300 & sleep 300 & wait" &
+         bash -c "sleep 300 & wait" &
+         wait' &
+ROOT_PID=$!
+
+# Give the tree a moment to fully spawn before we collect descendants.
+sleep 1
+
+EXPECTED_PIDS="$ROOT_PID"
+collect_descendants() {
+  for child in $(pgrep -P "$1" 2>/dev/null); do
+    EXPECTED_PIDS="$EXPECTED_PIDS $child"
+    collect_descendants "$child"
+  done
+}
+collect_descendants "$ROOT_PID"
+
+echo "Spawned tree: $EXPECTED_PIDS"
+
+before=0
+for pid in $EXPECTED_PIDS; do
+  if kill -0 "$pid" 2>/dev/null; then
+    before=$((before + 1))
+  fi
+done
+if [ "$before" -lt 3 ]; then
+  echo "FAIL: expected at least 3 live pids before kill_tree, got $before" >&2
+  exit 1
+fi
+
+kill_tree "$ROOT_PID"
+
+# kill_tree must return only after every pid is gone (or after the SIGKILL
+# escalation). Give the OS a beat to reap, then check.
+sleep 1
+alive=0
+for pid in $EXPECTED_PIDS; do
+  if kill -0 "$pid" 2>/dev/null; then
+    echo "FAIL: pid $pid still alive after kill_tree returned" >&2
+    alive=$((alive + 1))
+  fi
+done
+
+if [ "$alive" -gt 0 ]; then
+  fail=1
+fi
+
+# Second scenario: a child that ignores SIGTERM must still be killed via
+# SIGKILL within the grace window. `disown` so bash doesn't print its own
+# job-control "Killed" line when SIGKILL lands; we report success ourselves.
+bash -c 'trap "" TERM; exec sleep 300' &
+STUBBORN_PID=$!
+disown 2>/dev/null || true
+sleep 1
+kill_tree "$STUBBORN_PID"
+sleep 1
+if kill -0 "$STUBBORN_PID" 2>/dev/null; then
+  echo "FAIL: SIGTERM-ignoring child $STUBBORN_PID survived kill_tree" >&2
+  kill -KILL "$STUBBORN_PID" 2>/dev/null || true
+  fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "PASS: kill_tree flattened the tree and killed a SIGTERM-ignoring child"
+fi
+
+exit "$fail"

--- a/mise-tasks/lib/test-dev-common.sh
+++ b/mise-tasks/lib/test-dev-common.sh
@@ -2,10 +2,13 @@
 # Lightweight self-test for kill_tree in dev-common.sh.
 #
 # Spawns a 3-level sleep tree, asks kill_tree to take it down, and asserts
-# that every pid in the tree is gone by the time kill_tree returns. The
-# point is to catch regressions where kill_tree returns while children are
-# still alive (which is what the original SIGTERM-only walk did, causing
-# leaked dev-stack processes after Ctrl-C).
+# every pid is gone shortly after kill_tree returns. The short sleep before
+# the check is for the OS to reap SIGKILL'd descendants — kill_tree itself
+# returns as soon as it has delivered the last signal, not after the kernel
+# has finished tearing down the entries. The point is to catch regressions
+# where kill_tree returns while children are still *running* (which is what
+# the original SIGTERM-only walk did, causing leaked dev-stack processes
+# after Ctrl-C).
 #
 # Not wired into CI — running it touches real signals and would race with
 # any concurrent dev-stack on the same host. Invoke directly:
@@ -45,7 +48,9 @@ sleep 1
 
 EXPECTED_PIDS="$ROOT_PID"
 collect_descendants() {
-  for child in $(pgrep -P "$1" 2>/dev/null); do
+  # `|| true` so the empty-output exit-1 from pgrep doesn't trip set -e
+  # on leaf pids (which is the normal recursion terminator).
+  for child in $(pgrep -P "$1" 2>/dev/null || true); do
     EXPECTED_PIDS="$EXPECTED_PIDS $child"
     collect_descendants "$child"
   done


### PR DESCRIPTION
## Summary

`mise run dev-all` (and `mise run dev`) leak their entire process tree when the user hits Ctrl-C: `pnpm --filter @cardstack/host start`'s subtree (`vite` on 4200), the `start-server-and-test` subtree (`run-p` phase 1+2, `npm run start:*` wrappers, `sh -c "mise run services:..."`, the bash service scripts, and the ts-node service grandchildren on 4201/4202/4210/4211/4221/4222) all survive and reparent to systemd. The next `mise run dev-all` then can't bind those ports.

This PR fixes three independent bugs — one at each layer of the shutdown mechanism — all in `mise-tasks/`. The user-visible result: one Ctrl-C, ~10s later all dev-stack ports are freed and the shell prompt returns.

## Why #4731 is necessary but not sufficient

#4731 fixed a *real* but narrower bug: `worker.ts` and `worker-manager.ts` got stuck in an EPIPE → uncaughtException CPU-hot-loop when their stdout pipe was torn down during shutdown, so they never finished their SIGTERM handler. After that PR, those processes *can* exit cleanly **once they receive SIGTERM**.

But the kill mechanism that's supposed to *send* the SIGTERM lives elsewhere — in `mise-tasks/dev-all`, `mise-tasks/dev`, and `mise-tasks/lib/dev-common.sh` — and has its own independent bugs. Evidence: processes whose names match `sweep_orphaned_services`'s regex (`--transpileOnly main`, `--transpileOnly prerender`, the workers) were observed alive 14 minutes after `dev-all` bash had died. The cleanup trap never ran at all — no SIGTERM was sent in the first place. So both PRs are needed: #4731 lets the workers cleanly handle SIGTERM, and this PR makes sure SIGTERM is actually sent and followed up if ignored.

## The three bugs fixed

### Bug 1 — the trap doesn't catch SIGHUP

**Before** (`mise-tasks/dev-all:28`, `mise-tasks/dev:22`):

```bash
trap cleanup EXIT INT TERM
```

When the user hits Ctrl-C in a terminal running `mise run dev-all`, `mise run` itself catches SIGINT and exits, often *without* forwarding SIGINT to the bash child it spawned. The bash child then receives SIGHUP from its dying parent. From `man bash`:

> The shell exits by default upon receipt of a SIGHUP.

The default disposition for an untrapped SIGHUP is to terminate the shell *without running the EXIT trap*. So `cleanup` never fires and the entire dev-stack subtree is orphaned to PID 1.

**Fix:** add `HUP` to the trap list. One-word fix, with a comment explaining why so a future reader doesn't trim it back to `EXIT INT TERM`.

### Bug 2 — `kill_tree` sends SIGTERM only, no SIGKILL escalation, no wait

**Before** (`mise-tasks/lib/dev-common.sh:16-21`):

```bash
kill_tree() {
  for child in $(pgrep -P "$1" 2>/dev/null); do
    kill_tree "$child"
  done
  kill -TERM "$1" 2>/dev/null || true
}
```

It walks the tree once (post-order, leaves first), fires SIGTERM at each pid, returns. Anything slow to honor SIGTERM — pnpm, npm exec, vite, ember graceful shutdown, `start-server-and-test`, `run-p` — is still alive when `cleanup()` returns and `dev-all` bash exits. Those slow processes then reparent to systemd and keep their ports bound.

**Fix:** `kill_tree` now collects every descendant pid up front (so we have a stable list once children reparent), SIGTERMs all of them, polls for up to `KILL_TREE_GRACE_SECS` (=5s) waiting for them to exit, then SIGKILLs anything that survived. 5s is a deliberate split: long enough that the workers have a real chance to drain jobs and close their DB pool (the goal of #4731), short enough that the user isn't staring at a hung terminal after Ctrl-C. The added self-test verifies the SIGKILL escalation actually works against a `trap "" TERM` child.

### Bug 3 — `sweep_orphaned_services`'s regex is too narrow

**Before** (`mise-tasks/lib/dev-common.sh:40-48`), the sweep only matched:
- `${REPO_ROOT_RE}/mise-tasks/services/`
- `${REPO_ROOT_RE}/packages/realm-server/node_modules.*--transpileOnly (worker|main|prerender)`

It missed the wrapper layers that this stack also leaks:
- `node .../packages/host/.../vite/bin/vite.js` — host dev server (port 4200)
- `node .../node_modules/.../start-server-and-test/...` — the phase coordinator
- `node .../node_modules/.../npm-run-all/bin/run-p` (and `run-s`) — the parallel runners that own the `npm run start:*` wrappers

When the bash `dev-all` parent dies before relaying SIGTERM to these wrappers, they reparent to init. The tree-walk from `$HOST_PID` / `$SAT_PID` can't reach them via PPID anymore, so only the regex sweep can. With the old regex they sat on the host port forever.

**Fix:** widened the regex set to cover those three wrapper layers. Every pattern is still anchored to `${REPO_ROOT_RE}` (regex-escaped checkout path) so it never matches outside this checkout — important because the user may have unrelated vite/node processes running for other projects. Verified the new patterns match the live dev-all tree with `pgrep -af` against each pattern before the SIGTERM/SIGKILL step.

## Test added

`mise-tasks/lib/test-dev-common.sh` — runnable self-test that:
1. Spawns a 3-level sleep tree, calls `kill_tree` on the root, asserts every pid in the tree is gone.
2. Spawns a `trap "" TERM; sleep 300` child (ignores SIGTERM), calls `kill_tree`, asserts the child is gone — exercising the SIGKILL escalation path.

Not wired into CI: it touches real signals and would race any concurrent dev-stack on the same host. Invoke directly:

```bash
./mise-tasks/lib/test-dev-common.sh
```

Smoke-checked the test would have caught the regression by temporarily re-installing the old SIGTERM-only `kill_tree` and confirming the SIGTERM-ignoring child survives.

## How to verify manually

End-to-end (this is what's hard to script in CI because it races dev-stack ports):

1. From a fresh shell with no dev-stack running:
   ```bash
   mise run dev-all
   ```
2. Wait until `curl http://localhost:4200/` returns 200 and `curl http://localhost:4201/base/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson` returns 200.
3. Hit Ctrl-C once.
4. Within ~10s, expect:
   ```bash
   ss -tlnp | grep -E ':(4200|4201|4202|4206|4210|4211|4221|4222) '
   ```
   to print nothing, and:
   ```bash
   ps -ef | grep -E 'boxel/(packages|mise-tasks)' | grep -v grep
   ```
   to print nothing besides the persistent Docker infra (boxel-pg / boxel-synapse / boxel-smtp).
5. Re-run `mise run dev-all` and confirm it starts cleanly without port-already-in-use errors.

**Note:** this PR depends on #4731 (already on `main`, commit `f0c40fedb8`) for the workers to actually finish shutting down when they receive SIGTERM. Without #4731 the workers would hang in the EPIPE loop and only get cleared by this PR's SIGKILL escalation — which works, but isn't a clean drain.

## Test plan

- [ ] `mise-tasks/lib/test-dev-common.sh` passes locally
- [ ] `mise run dev-all` → Ctrl-C frees ports 4200/4201/4202/4206/4210/4211/4221/4222 within ~10s
- [ ] Subsequent `mise run dev-all` binds those ports without conflict
- [ ] `mise run dev` (narrower variant) shows the same clean-shutdown behavior

---

## Local verification (2026-05-11)

Verified end-to-end on a real `mise run dev-all` after merging this branch onto local `main`:

- Started `mise run dev-all` with a cold vite cache (intentionally simulating the worst pre-PR scenario where 73+ PIDs would leak).
- Once host + realm-server were up and all services were running (21 boxel processes across 7 dev-stack ports), sent `kill -INT` to the `mise run dev-all` process.
- All of ports 4200/4201/4202/4206/4210/4211/4221/4222 freed.
- Zero lingering boxel processes (`pnpm host`, `start-server-and-test`, `run-p`, `bash mise-tasks/services/*`, all `ts-node --transpileOnly` services, vite, ember — all gone).
- The cleanup log showed the SIGTERM round followed by SIGKILL escalation for the slow propagator (vite + start-server-and-test), exactly as the new `kill_tree` is designed to do.

This is the first time in this branch's history that a real Ctrl-C on a fully-running `dev-all` has cleanly torn down the stack.
