### PR TITLE
Upgrade pnpm 10 → 11

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 node = "24.13.1"
-pnpm = "10.33.4"
+"npm:pnpm" = "11.0.9"
 
 [env]
 _.source = "./mise-tasks/lib/env-vars.sh"

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-use-node-version=24.13.1

--- a/package.json
+++ b/package.json
@@ -19,49 +19,6 @@
     "openrouter:sync": "OPENROUTER_REALM_URL=${OPENROUTER_REALM_URL:-http://localhost:4201/openrouter/} pnpm --filter @cardstack/realm-server sync-openrouter-models",
     "prepare-worktree-types": "pnpm --filter @cardstack/boxel-icons build && pnpm --filter @cardstack/boxel-ui build:types"
   },
-  "pnpm": {
-    "allowedDeprecatedVersions": {
-      "babel-eslint": "10.1.0"
-    },
-    "overrides": {
-      "@types/eslint": "8.56.5",
-      "@embroider/util": "1.13.1",
-      "@glimmer/tracking>@glimmer/validator": "0.84.3",
-      "@glimmer/component": "^2.0.0",
-      "jsesc": "^3.0.0",
-      "ember-modifier": "^4.1.0",
-      "tracked-built-ins": "^4.1.2"
-    },
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "mustache": "3",
-        "ember-qunit@5.1.2>ember-source": "*"
-      }
-    },
-    "patchedDependencies": {
-      "magic-string@0.25.9": "patches/magic-string@0.25.9.patch",
-      "style-loader@2.0.0": "patches/style-loader@2.0.0.patch",
-      "ember-css-url@1.0.0": "patches/ember-css-url@1.0.0.patch",
-      "ember-basic-dropdown@8.0.4": "patches/ember-basic-dropdown@8.0.4.patch",
-      "monaco-editor@0.52.2": "patches/monaco-editor@0.52.2.patch",
-      "@embroider/compat": "patches/@embroider__compat.patch",
-      "ember-eslint-parser": "patches/ember-eslint-parser.patch",
-      "openai": "patches/openai.patch",
-      "matrix-js-sdk@38.3.0": "patches/matrix-js-sdk@38.3.0.patch",
-      "@embroider/webpack": "patches/@embroider__webpack.patch",
-      "ember-source": "patches/ember-source.patch",
-      "object-inspect": "patches/object-inspect.patch"
-    },
-    "onlyBuiltDependencies": [
-      "@percy/core",
-      "@vscode/vsce-sign",
-      "aws-sdk",
-      "esbuild",
-      "fsevents",
-      "keytar",
-      "puppeteer"
-    ]
-  },
   "devDependencies": {
     "@actions/core": "catalog:",
     "@actions/github": "catalog:",
@@ -89,9 +46,15 @@
     "@glint/ember-tsc": "catalog:"
   },
   "engines": {
-    "pnpm": "^10"
+    "pnpm": "^11"
   },
   "dependencies": {
     "matrix-js-sdk": "38.3.0"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "24.13.1"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -697,42 +697,18 @@ overrides:
 pnpmfileChecksum: sha256-4aYtIGLH5VZ7602JwdeiRO9eMz2VW/CY+BbwLNpu1Bw=
 
 patchedDependencies:
-  '@embroider/compat':
-    hash: db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2
-    path: patches/@embroider__compat.patch
-  '@embroider/webpack':
-    hash: 3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff
-    path: patches/@embroider__webpack.patch
-  ember-basic-dropdown@8.0.4:
-    hash: 19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428
-    path: patches/ember-basic-dropdown@8.0.4.patch
-  ember-css-url@1.0.0:
-    hash: 0e5253a008cc7bf02424d786e7a8fb2397bc48962f3cd1443f2c0fdd8200c96d
-    path: patches/ember-css-url@1.0.0.patch
-  ember-eslint-parser:
-    hash: 0db1e9515cbf9f5b3d3c6509af8967c918c176106e534408441992dd448f2545
-    path: patches/ember-eslint-parser.patch
-  ember-source:
-    hash: ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d
-    path: patches/ember-source.patch
-  magic-string@0.25.9:
-    hash: 32dda55b40f0bc860d0a8e93bee54d8005c34ed7ac5faed23ce9f5e5f57eea39
-    path: patches/magic-string@0.25.9.patch
-  matrix-js-sdk@38.3.0:
-    hash: cee0baf579283943dc5a6b48977e8ed40a13fc111b5de9c91814893f9a4989fb
-    path: patches/matrix-js-sdk@38.3.0.patch
-  monaco-editor@0.52.2:
-    hash: bdefe071221b87c7c15e1add6739d24d486f543dbad0d714ae586085204626cd
-    path: patches/monaco-editor@0.52.2.patch
-  object-inspect:
-    hash: bd295adbd162403eccfdace2cf14691901d878d9d5d6e993bf76eedf238ac5de
-    path: patches/object-inspect.patch
-  openai:
-    hash: 6833f1bcf56cde16edb25881777c31d2745994c6ea992d1e2051d1248d213449
-    path: patches/openai.patch
-  style-loader@2.0.0:
-    hash: 579dd92e6adabd45669f9a99a01c6c28c97488c7bf4ee0d6c1c622a14592e4c8
-    path: patches/style-loader@2.0.0.patch
+  '@embroider/compat@3.9.3': db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2
+  '@embroider/webpack': 3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff
+  ember-basic-dropdown@8.0.4: 19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428
+  ember-css-url@1.0.0: 0e5253a008cc7bf02424d786e7a8fb2397bc48962f3cd1443f2c0fdd8200c96d
+  ember-eslint-parser: 0db1e9515cbf9f5b3d3c6509af8967c918c176106e534408441992dd448f2545
+  ember-source: ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d
+  magic-string@0.25.9: 32dda55b40f0bc860d0a8e93bee54d8005c34ed7ac5faed23ce9f5e5f57eea39
+  matrix-js-sdk@38.3.0: cee0baf579283943dc5a6b48977e8ed40a13fc111b5de9c91814893f9a4989fb
+  monaco-editor@0.52.2: bdefe071221b87c7c15e1add6739d24d486f543dbad0d714ae586085204626cd
+  object-inspect: bd295adbd162403eccfdace2cf14691901d878d9d5d6e993bf76eedf238ac5de
+  openai: 6833f1bcf56cde16edb25881777c31d2745994c6ea992d1e2051d1248d213449
+  style-loader@2.0.0: 579dd92e6adabd45669f9a99a01c6c28c97488c7bf4ee0d6c1c622a14592e4c8
 
 importers:
 
@@ -1280,7 +1256,7 @@ importers:
         version: 2.2.0(@babel/core@7.28.6)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glint/template@1.7.7)
       ember-basic-dropdown:
         specifier: 8.0.4
-        version: 8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/string@4.0.1)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/string@4.0.1)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-concurrency:
         specifier: 'catalog:'
         version: 5.2.0(@babel/core@7.28.6)(@glint/template@1.7.7)
@@ -1307,13 +1283,13 @@ importers:
         version: 4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-power-calendar:
         specifier: ^1.2.0
-        version: 1.8.0(@babel/core@7.28.6)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-concurrency@5.2.0(@babel/core@7.28.6)(@glint/template@1.7.7))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 1.8.0(@babel/core@7.28.6)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-concurrency@5.2.0(@babel/core@7.28.6)(@glint/template@1.7.7))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-power-calendar-moment:
         specifier: ^1.0.2
-        version: 1.0.4(@glint/template@1.7.7)(ember-power-calendar@1.8.0(@babel/core@7.28.6)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-concurrency@5.2.0(@babel/core@7.28.6)(@glint/template@1.7.7))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5)))(moment@2.30.1)
+        version: 1.0.4(@glint/template@1.7.7)(ember-power-calendar@1.8.0(@babel/core@7.28.6)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-concurrency@5.2.0(@babel/core@7.28.6)(@glint/template@1.7.7))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5)))(moment@2.30.1)
       ember-power-select:
         specifier: ^8.0.0
-        version: 8.12.1(e7744023e04e85a9eb52144a9d47350c)
+        version: 8.12.1(@babel/core@7.28.6)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-basic-dropdown@8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/string@4.0.1)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-concurrency@5.2.0(@babel/core@7.28.6)(@glint/template@1.7.7))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-resize-modifier:
         specifier: ^0.7.1
         version: 0.7.1(@babel/core@7.28.6)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))(webpack@5.104.1)
@@ -1461,7 +1437,7 @@ importers:
     dependencies:
       ember-basic-dropdown:
         specifier: 8.0.4
-        version: 8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/string@4.0.1)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/string@4.0.1)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
     devDependencies:
       '@babel/core':
         specifier: 'catalog:'
@@ -2068,7 +2044,7 @@ importers:
         version: 4.1.1(@glint/template@1.7.7)
       '@embroider/compat':
         specifier: ^4.0.3
-        version: 4.1.17(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@4.4.2(@glint/template@1.7.7))(@glint/template@1.7.7)
+        version: 4.1.17(@embroider/core@4.4.2(@glint/template@1.7.7))(@glint/template@1.7.7)
       '@embroider/config-meta-loader':
         specifier: ^1.0.0
         version: 1.0.0
@@ -2227,7 +2203,7 @@ importers:
         version: 2.12.0(@glint/template@1.7.7)(webpack@5.104.1(esbuild@0.27.2))
       ember-basic-dropdown:
         specifier: 8.0.4
-        version: 8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/string@4.0.1)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/string@4.0.1)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cli:
         specifier: ~6.10.0
         version: 6.10.2(@types/node@25.0.8)(ejs@3.1.10)(handlebars@4.7.8)(underscore@1.13.7)
@@ -2272,7 +2248,7 @@ importers:
         version: 1.0.0(patch_hash=0e5253a008cc7bf02424d786e7a8fb2397bc48962f3cd1443f2c0fdd8200c96d)
       ember-elsewhere:
         specifier: ^2.0.0
-        version: 2.0.0(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 2.0.0(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-exam:
         specifier: ^10.1.0
         version: 10.1.0(@glint/template@1.7.7)(ember-qunit@9.0.4(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.25.0)(webpack@5.104.1(esbuild@0.27.2))
@@ -5342,34 +5318,6 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: '>=5.6.0'
-
-  '@glint/environment-ember-loose@1.5.2':
-    resolution: {integrity: sha512-AuYRwZbQZW13WMW9tmyYqSGHLBXbdXn+HqdRDAG1qHItnjON4uv6sJVQUrnadlMT3G2AVRjL6jtfnwHs3t2Kuw==}
-    peerDependencies:
-      '@glimmer/component': ^2.0.0
-      '@glint/template': ^1.5.2
-      '@types/ember__array': ^4.0.2
-      '@types/ember__component': ^4.0.10
-      '@types/ember__controller': ^4.0.2
-      '@types/ember__object': ^4.0.4
-      '@types/ember__routing': ^4.0.11
-      ember-cli-htmlbars: ^6.0.1
-      ember-modifier: ^4.1.0
-    peerDependenciesMeta:
-      '@types/ember__array':
-        optional: true
-      '@types/ember__component':
-        optional: true
-      '@types/ember__controller':
-        optional: true
-      '@types/ember__object':
-        optional: true
-      '@types/ember__routing':
-        optional: true
-      ember-cli-htmlbars:
-        optional: true
-      ember-modifier:
-        optional: true
 
   '@glint/template@1.7.7':
     resolution: {integrity: sha512-jcPdQ3A6cXo5h9RBi0tK4/o5qNn7868Y8xpkwWQNPAd8xQKuRKmG9dGJwUycXvtqISzfrnL1p3MQr3hYN/Ua6Q==}
@@ -17032,7 +16980,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@embroider/compat@4.1.17(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@4.4.2(@glint/template@1.7.7))(@glint/template@1.7.7)':
+  '@embroider/compat@4.1.17(@embroider/core@4.4.2(@glint/template@1.7.7))(@glint/template@1.7.7)':
     dependencies:
       '@babel/code-frame': 7.28.6
       '@babel/core': 7.28.6(supports-color@8.1.1)
@@ -17274,14 +17222,13 @@ snapshots:
       '@embroider/core': 3.5.9(@glint/template@1.7.7)
       '@embroider/webpack': 4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.9(@glint/template@1.7.7))(webpack@5.104.1)
 
-  '@embroider/util@1.13.1(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@embroider/util@1.13.1(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
       ember-source: 6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5)
     optionalDependencies:
-      '@glint/environment-ember-loose': 1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5)))
       '@glint/template': 1.7.7
     transitivePeerDependencies:
       - supports-color
@@ -17967,15 +17914,6 @@ snapshots:
       vscode-uri: 3.1.0
     transitivePeerDependencies:
       - supports-color
-
-  '@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5)))':
-    dependencies:
-      '@glimmer/component': 2.0.0
-      '@glint/template': 1.7.7
-    optionalDependencies:
-      ember-cli-htmlbars: 6.3.0
-      ember-modifier: 4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
-    optional: true
 
   '@glint/template@1.7.7': {}
 
@@ -22869,13 +22807,13 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-basic-dropdown@8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/string@4.0.1)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-basic-dropdown@8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/string@4.0.1)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       '@babel/core': 7.28.6(supports-color@8.1.1)
       '@ember/test-helpers': 5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7)
       '@embroider/addon-shim': 1.10.2
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
-      '@embroider/util': 1.13.1(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@embroider/util': 1.13.1(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@glimmer/component': 2.0.0
       '@glimmer/tracking': 1.1.2
       decorator-transforms: 1.2.1(@babel/core@7.28.6)
@@ -23624,9 +23562,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-elsewhere@2.0.0(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-elsewhere@2.0.0(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
-      '@embroider/util': 1.13.1(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@embroider/util': 1.13.1(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
     transitivePeerDependencies:
@@ -23850,23 +23788,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-power-calendar-moment@1.0.4(@glint/template@1.7.7)(ember-power-calendar@1.8.0(@babel/core@7.28.6)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-concurrency@5.2.0(@babel/core@7.28.6)(@glint/template@1.7.7))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5)))(moment@2.30.1):
+  ember-power-calendar-moment@1.0.4(@glint/template@1.7.7)(ember-power-calendar@1.8.0(@babel/core@7.28.6)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-concurrency@5.2.0(@babel/core@7.28.6)(@glint/template@1.7.7))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5)))(moment@2.30.1):
     dependencies:
       '@embroider/addon-shim': 1.10.2
       '@embroider/macros': 1.16.13(@glint/template@1.7.7)
-      ember-power-calendar: 1.8.0(@babel/core@7.28.6)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-concurrency@5.2.0(@babel/core@7.28.6)(@glint/template@1.7.7))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-power-calendar: 1.8.0(@babel/core@7.28.6)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-concurrency@5.2.0(@babel/core@7.28.6)(@glint/template@1.7.7))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
     optionalDependencies:
       moment: 2.30.1
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  ember-power-calendar@1.8.0(@babel/core@7.28.6)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-concurrency@5.2.0(@babel/core@7.28.6)(@glint/template@1.7.7))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-power-calendar@1.8.0(@babel/core@7.28.6)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-concurrency@5.2.0(@babel/core@7.28.6)(@glint/template@1.7.7))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       '@ember/test-helpers': 5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7)
       '@embroider/addon-shim': 1.10.2
       '@embroider/macros': 1.19.6(@glint/template@1.7.7)
-      '@embroider/util': 1.13.1(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@embroider/util': 1.13.1(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@glimmer/component': 2.0.0
       decorator-transforms: 2.3.1(@babel/core@7.28.6)
       ember-assign-helper: 0.5.1
@@ -23881,15 +23819,15 @@ snapshots:
       - ember-source
       - supports-color
 
-  ember-power-select@8.12.1(e7744023e04e85a9eb52144a9d47350c):
+  ember-power-select@8.12.1(@babel/core@7.28.6)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-basic-dropdown@8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/string@4.0.1)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-concurrency@5.2.0(@babel/core@7.28.6)(@glint/template@1.7.7))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       '@ember/test-helpers': 5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7)
       '@embroider/addon-shim': 1.10.2
-      '@embroider/util': 1.13.1(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@embroider/util': 1.13.1(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@glimmer/component': 2.0.0
       decorator-transforms: 2.3.1(@babel/core@7.28.6)
       ember-assign-helper: 0.5.1
-      ember-basic-dropdown: 8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/string@4.0.1)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.2(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))))(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-basic-dropdown: 8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/string@4.0.1)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.7))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-concurrency: 5.2.0(@babel/core@7.28.6)(@glint/template@1.7.7)
       ember-element-helper: 0.8.8
       ember-modifier: 4.1.0(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.0.0)(rsvp@4.8.5))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -255,3 +255,39 @@ minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - "@glint/ember-tsc"
   - "@glint/template"
+allowedDeprecatedVersions:
+  babel-eslint: 10.1.0
+overrides:
+  '@types/eslint': 8.56.5
+  '@embroider/util': 1.13.1
+  '@glimmer/tracking>@glimmer/validator': 0.84.3
+  '@glimmer/component': ^2.0.0
+  jsesc: ^3.0.0
+  ember-modifier: ^4.1.0
+  tracked-built-ins: ^4.1.2
+peerDependencyRules:
+  allowedVersions:
+    mustache: '3'
+    ember-qunit@5.1.2>ember-source: '*'
+patchedDependencies:
+  magic-string@0.25.9: patches/magic-string@0.25.9.patch
+  style-loader@2.0.0: patches/style-loader@2.0.0.patch
+  ember-css-url@1.0.0: patches/ember-css-url@1.0.0.patch
+  ember-basic-dropdown@8.0.4: patches/ember-basic-dropdown@8.0.4.patch
+  monaco-editor@0.52.2: patches/monaco-editor@0.52.2.patch
+  '@embroider/compat@3.9.3': patches/@embroider__compat.patch
+  ember-eslint-parser: patches/ember-eslint-parser.patch
+  openai: patches/openai.patch
+  matrix-js-sdk@38.3.0: patches/matrix-js-sdk@38.3.0.patch
+  '@embroider/webpack': patches/@embroider__webpack.patch
+  ember-source: patches/ember-source.patch
+  object-inspect: patches/object-inspect.patch
+allowBuilds:
+  '@percy/core': true
+  '@vscode/vsce-sign': true
+  aws-sdk: true
+  core-js: false
+  esbuild: true
+  fsevents: true
+  keytar: true
+  puppeteer: true


### PR DESCRIPTION
Resolves [CS-11100](https://linear.app/cardstack/issue/CS-11100/upgrade-pnpm-10-11).

## Summary

* Ran `pnpx codemod run pnpm-v10-to-v11`: moved `package.json#pnpm.*` → `pnpm-workspace.yaml`, consolidated `onlyBuiltDependencies` into `allowBuilds`, migrated `.npmrc#use-node-version` → `package.json#devEngines.runtime` (and removed the now-empty `.npmrc`).
* Manual: bumped `.mise.toml` to pnpm 11.0.9, bumped `engines.pnpm` to `^11`, regenerated the lockfile.

## Things worth flagging in review

* **`.mise.toml` switched from `pnpm` (aqua) → `"npm:pnpm" = "11.0.9"`.** The aqua manifest for pnpm hasn't been updated to handle v11's new GitHub release asset layout (tarballs vs raw binaries, `darwin-arm64`/`linux-arm64.tar.gz` vs `macos-arm64`/`linux-arm64`). `npm:pnpm` works today and removes the aqua-manifest dependency for this tool. Trade-off: pnpm now installs through npm rather than from a prebuilt binary — a few seconds slower on first install but otherwise transparent (CI uses `jdx/mise-action` which sources `.mise.toml` either way).
* **`@embroider/compat` patch was pinned to `3.9.3` only.** Under pnpm 10 this patch was silently a no-op for v4.1.17 — the package was repackaged with sources under `dist/src/`, so the patch path (`src/compat-app.js`) missed. v11 makes patch-apply failures fatal, so I scoped the patch to `3.9.3` (the version it actually patches) to preserve v10's effective behavior. The `catalog:`-aware codepath in v4.1.17 remains unpatched, same as today.
* **`allowBuilds.core-js: false`.** v11 turns "ignored build scripts" into a hard install failure (`ERR_PNPM_IGNORED_BUILDS`). `core-js@2.6.12` is the only transitive postinstall not already covered by the migrated `onlyBuiltDependencies`. It's the classic opencollective banner — explicitly opting out matches v10 behavior.
* **`minimumReleaseAge: 1440` kept as-is.** The Linear ticket recommends `0`, but this was deliberately added in #3255 with an explicit `minimumReleaseAgeExclude` list — keeping the cooldown matches the team's existing opt-in.
* **Lockfile shrinks by ~60 lines.** v11's stricter peer-dep resolution prunes unused transitive `@glint/environment-ember-loose@1.5.2` (verified nothing in source or build configs imports it). `patchedDependencies` shape collapsed from object → `Record<string, string>` (path moved to `pnpm-workspace.yaml`).
* **Orphan patches in `patches/`** (`ember-window-mock@1.0.0.patch`, `tracked-built-ins.patch`) — not referenced in `patchedDependencies`. Pre-existing on `main`, not removed in this PR to keep scope tight.

## After-merge note for the team

Anyone with a checked-out branch needs to run `mise install` to pick up pnpm 11 before `pnpm install` on their branch. Local-dev `pnpm` will still resolve to whatever your old `.mise.toml` pinned until you `mise install`.

## Test plan

Verified locally on this branch:

- [x] `pnpm install` (non-frozen) succeeds; lockfile diff is structural, no resolution shuffles.
- [x] `pnpm install --frozen-lockfile` (CI mode) succeeds.
- [x] All 12 patches in `patches/` apply cleanly (after pinning `@embroider/compat` to 3.9.3).
- [x] `pnpm --filter @cardstack/boxel-icons build`
- [x] `pnpm --filter @cardstack/boxel-ui build`
- [x] `pnpm --filter @cardstack/host build` (dev) and `build:production`
- [x] `pnpm --filter @cardstack/realm-server lint:types` (realm-server has no separate build)
- [x] `pnpm --filter @cardstack/eslint-plugin-boxel test` (65/65)
- [x] `pnpm --filter bot-runner test` (38/38, 1 skip)

Relying on CI to exercise:

- [ ] `ci.yaml`, `ci-host.yaml`, `ci-lint.yaml`, `ci-software-factory.yaml`, `test-web-assets.yaml`
- [ ] Full host test suite (memory baseline still applies — flag if any shard OOMs)
- [ ] Full realm-server test suite against a fresh test-pg
- [ ] Matrix tests
- [ ] Observability `apply.sh` / `lint.sh` if anything in `packages/observability/` changes on this branch

Draft until CI is green.