### PR TITLE
boxel-cli: publish with pnpm so catalog: deps are resolved

### DIFF
--- a/packages/boxel-cli/package.json
+++ b/packages/boxel-cli/package.json
@@ -74,8 +74,8 @@
     "version:patch": "npm version patch",
     "version:minor": "npm version minor",
     "version:major": "npm version major",
-    "publish:npm": "npm publish",
-    "publish:dry": "npm publish --dry-run"
+    "publish:npm": "pnpm publish --no-git-checks",
+    "publish:dry": "pnpm publish --dry-run --no-git-checks"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
`npm publish` ships the package.json verbatim, leaving the `catalog:` specifiers in `dependencies` (@aws-crypto/sha256-js, ignore, jsonwebtoken) untouched in the registry tarball. Any consumer install fails:

  npm:  EUNSUPPORTEDPROTOCOL — Unsupported URL Type "catalog:"
  pnpm: ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER
        — catalog: only resolves inside the publishing workspace

`pnpm publish` rewrites every `catalog:` specifier to its concrete version from pnpm-workspace.yaml's catalog block before uploading, producing a tarball that any installer can consume.

This unblocks consumers like boxel-catalog's sync-to-staging GitHub Action (`npm install -g @cardstack/boxel-cli`), which is currently broken on every published version of this package.

After merging, cut a new patch release. Existing published versions on npm are not retroactively fixable; consumers will need to pin to the new version (or @latest once it is current).