### PR TITLE
host: Restore version number on submode hover

### DIFF
--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const DEFAULT_CARD_RENDER_TIMEOUT_MS = 30_000;
@@ -7,6 +8,32 @@ const DEFAULT_CARD_SIZE_LIMIT_BYTES = 512 * 1024; // 512KB
 const DEFAULT_FILE_SIZE_LIMIT_BYTES = 5 * 1024 * 1024; // 5MB
 
 let sqlSchema = fs.readFileSync(getLatestSchemaFile(), 'utf8');
+
+// Classic ember-cli injected APP.version automatically; the Vite/Embroider
+// build does not, so we populate it here from package.json + the short git
+// SHA (matching ember-cli's `0.0.0+abcdef12` shape) so the submode-switcher
+// tooltip and any other consumer keeps working.
+function computeAppVersion() {
+  let pkgVersion = '0.0.0';
+  try {
+    pkgVersion = require('../package.json').version || pkgVersion;
+  } catch (_) {
+    // fall through with default
+  }
+  let sha = '';
+  try {
+    sha = execSync('git rev-parse --short=8 HEAD', {
+      cwd: __dirname,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+  } catch (_) {
+    // git unavailable (e.g. docker build without .git); fall back to pkg only
+  }
+  return sha ? `${pkgVersion}+${sha}` : pkgVersion;
+}
+const APP_VERSION = computeAppVersion();
 
 // Environment-mode: when BOXEL_ENVIRONMENT is set, derive default URLs from Traefik hostnames.
 // ENV_SLUG is set by mise's env-vars.sh; fall back to computing it for non-mise contexts.
@@ -68,6 +95,7 @@ module.exports = function (environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+      version: APP_VERSION,
     },
     'ember-cli-mirage': {
       enabled: false,

--- a/packages/host/tests/acceptance/basic-test.gts
+++ b/packages/host/tests/acceptance/basic-test.gts
@@ -1,4 +1,4 @@
-import { click, find, visit } from '@ember/test-helpers';
+import { click, find, visit, waitFor } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
@@ -115,6 +115,27 @@ module('Acceptance | basic tests', function (hooks) {
     assert
       .dom('[data-test-operator-mode-stack="0"] [data-test-index-card]')
       .containsText('Hello, world');
+  });
+
+  test('submode switcher exposes an app version tooltip', async function (assert) {
+    await visit('/');
+    await click('[data-test-workspace-button="Unnamed Workspace"]');
+    await waitFor('[data-test-submode-switcher]');
+
+    let trigger = find(
+      '[data-test-submode-switcher] .submode-switcher-dropdown-trigger',
+    );
+    assert.ok(trigger, 'submode-switcher trigger renders');
+    let title = trigger?.getAttribute('title') ?? '';
+    assert.notStrictEqual(
+      title,
+      'Version undefined',
+      'app version is populated (not the broken Vite default)',
+    );
+    assert.ok(
+      /^Version \S+/.test(title),
+      `app version tooltip has the expected shape, got: ${title}`,
+    );
   });
 
   test('glimmer-scoped-css smoke test', async function (assert) {


### PR DESCRIPTION
`config.APP.version` doesn’t work in Vite:

<img width="490" height="191" alt="image" src="https://github.com/user-attachments/assets/d7a5bdd3-267f-42ca-a257-d0ef637bf09f" />

I use this to know what’s deployed in staging and production. Now backed by a test.

On the [preview deployment](https://host-hidden-version-cs-11103.boxel-host-preview.stack.cards/) (it’s the SHA of the [merge commit](https://github.com/cardstack/boxel/commit/8a1d5496)):

<img width="1174" height="476" alt="CleanShot 2026-05-11 at 13 43 22@2x" src="https://github.com/user-attachments/assets/f3164114-1218-4f7f-adcc-a956a5ade600" />
