### PR TITLE
ci: Update artifact Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1018,7 +1018,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/init
       - name: Download test web assets
-        uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # 4.2.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ needs.test-web-assets.outputs.artifact_name }}
           path: .test-web-assets-artifact
@@ -1031,14 +1031,14 @@ jobs:
         run: mise run ci:cache-index 2>&1 | tee /tmp/cache-index.log
         timeout-minutes: 45
       - name: Upload service logs
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: cache-index-log
           path: /tmp/cache-index.log
           retention-days: 7
       - name: Upload index cache
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: boxel-index-cache
           path: /tmp/boxel-index-cache.sql.gz


### PR DESCRIPTION
This should have been part of #4757, it fixes the final deprecation annotations seen [here](https://github.com/cardstack/boxel/actions/runs/25690439091):

<img width="1756" height="684" alt="CleanShot 2026-05-11 at 15 51 24@2x" src="https://github.com/user-attachments/assets/9b6e4910-1c95-48e0-8edd-07d7fb226a2e" />
