### PR TITLE
Parallelize the indexer visit loop with width-aware bounded concurrency

### DIFF
--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -1216,13 +1216,14 @@ If `GRAFANA_SECRET` is configured on your server, you can skip the user-JWT step
 
 ## Prerender capacity tuning knobs
 
-Three env vars control the per-prerender-server shape. They're resolved once at `PagePool` construction; changes require a process restart.
+Four env vars control the per-prerender-server shape. The first three are resolved once at `PagePool` construction; the indexer-side cap is resolved per visit-loop entry. All require a process restart to change.
 
 | Env var | Default | What it controls | When to change it |
 |---|---|---|---|
 | `PRERENDER_PAGE_POOL_MIN` / `_MAX` | unset → fixed pool of `options.maxPages` (5) | Dynamic-pool envelope. The pool boots at MIN, expands up to MAX under saturation, contracts back to MIN after sustained idle. The live capacity is what the server reports to the manager on each heartbeat, which drives warm-vacancy routing. | Fleet capacity. Raise MAX when `waits.semaphoreMs` dominates `launchMs` across rows from all realms (server-wide saturation); lower MAX if you need to reduce memory footprint and you can confirm from snapshots that pending rarely approaches `totalTabs`. Setting MIN === MAX disables expansion/contraction. |
 | `PRERENDER_AFFINITY_TAB_MAX` | `5` (clamped to the effective pool max: `PRERENDER_PAGE_POOL_MAX` when set, otherwise fixed `maxPages`) | Max tabs a single affinity (realm or user) can simultaneously hold from the pool. | Rarely. Must be ≥ 2 for the self-referential prerender deadlock to be prevented — PagePool logs a warning at startup when it isn't. Lower only if you want to force multi-realm fairness at the tab-routing level. |
 | `PRERENDER_AFFINITY_FILE_CONCURRENCY` | unset → `max(1, PRERENDER_AFFINITY_TAB_MAX − 1)` (the deadlock-safety ceiling) | Cap on concurrent `file` renders within a single affinity. Module and command calls bypass admission; they're never capped by this knob. | Cross-realm fairness. When one realm's fan-out (e.g. a catalog reindex) is stealing render budget from every other realm, lower this below the ceiling to reserve tabs for other affinities. The effective cap is always `min(env, ceiling)` so this can't accidentally break the deadlock-safety invariant. |
+| `INDEX_RUNNER_MAX_CONCURRENCY` | `4` | Hard cap on the number of in-flight file visits a single IndexRunner will keep open during a batch (`fromScratch` and `incremental` paths). Independent of the prerender pool's envelope: the indexer uses `min(envelope = PRERENDER_AFFINITY_TAB_MAX − 1, maxLayerWidth, this knob)` to size visit concurrency. | Throttling. Lower (e.g. `2` or `1`) to slow a noisy realm's reindex on a shared fleet without changing per-affinity prerender invariants. Raise on a fleet with extra capacity if you've also raised `PRERENDER_AFFINITY_TAB_MAX`. Setting to `1` is effectively the pre-parallelism serial behaviour for batches that would otherwise exceed the threshold gates. |
 
 **Default invariant**: when `PRERENDER_AFFINITY_FILE_CONCURRENCY` is unset, the effective file-admission cap equals the deadlock-safety ceiling — same behavior as before the knob existed. Changing the knob is an explicit operator decision driven by `admissionMs` telemetry; don't adjust it without data.
 
@@ -1233,6 +1234,73 @@ file-queue admission: cap=2 (affinityTabMax=5, deadlock-safety ceiling=4)
 ```
 
 Grep for `file-queue admission: cap=` in prerender-server logs to confirm the effective value in a running fleet.
+
+## Indexer-side visit concurrency
+
+`IndexRunner.fromScratch` and `IndexRunner.incremental` no longer visit files serially — they use a bounded-`Promise.allSettled` queue sized from the topological-layer width of the invalidation graph plus the `INDEX_RUNNER_MAX_CONCURRENCY` ceiling. Understanding the sizing rule matters when triaging "why didn't my reindex go faster?" or "why is one realm starving others on the prerender fleet?".
+
+### The sizing rule
+
+For every batch, the runner computes:
+
+```
+let totalWork    = invalidations.length;
+let envelopeMax  = max(1, PRERENDER_AFFINITY_TAB_MAX - 1);   // reserve one tab for module sub-prerenders
+let hardCap      = parseInt(INDEX_RUNNER_MAX_CONCURRENCY ?? '4', 10);
+
+if (totalWork    < 10)  concurrency = 1;   // tiny batch — overhead-dominated, stays serial
+if (maxLayerWidth ≤ 2)  concurrency = 1;   // near-linear chain — extra workers wait on the head
+otherwise              concurrency = min(envelopeMax, maxLayerWidth, hardCap);
+```
+
+Each component is enforced for a separate reason, and observing which one is binding tells you what changes would actually move the needle.
+
+| Constraint | When it binds | What raising/lowering it does |
+|---|---|---|
+| **`totalWork < 10`** | Small incremental edits (e.g. editing one `.gts` that fans out to 1-2 consumers) | Below the threshold the cold-tab tax (3-5s per fresh tab joining the affinity's shared `BrowserContext` + per-tab cardDoc / store / Glimmer-compile warmup) exceeds the parallelism payoff. Threshold is a hard-coded `10` in `index-runner.ts`; lower it only if you have measured benefit on smaller batches. |
+| **`maxLayerWidth ≤ 2`** | Module edits whose consumer chain is essentially linear (A → B → C → D) | Extra workers would all queue behind whichever node is currently in-degree-0. Width is observed by `dependency-resolver.ts::orderInvalidationsByDependencies` during the Kahn walk and reported back to the runner. |
+| **`envelopeMax = PRERENDER_AFFINITY_TAB_MAX − 1`** | High `tabQueueMs` / `admissionMs` on the row's `timing_diagnostics.waits` | Indicates the prerender pool's per-affinity envelope is the bottleneck. Raise `PRERENDER_AFFINITY_TAB_MAX` (subject to the deadlock-safety floor of 2) AND `PRERENDER_PAGE_POOL_MAX`. |
+| **`maxLayerWidth`** | A wide layer in the dep graph (e.g. all card instances depending on a few base modules) | The widest topological layer is the natural upper bound on useful in-flight visits — spawning more workers just leaves them idle. Lowering this isn't a knob; widening the graph is a content-side change. |
+| **`hardCap = INDEX_RUNNER_MAX_CONCURRENCY`** | A single realm's reindex is monopolising the prerender fleet | Default `4`. Lower for throttling; raise when you've also raised the pool max. Setting to `1` is effectively the pre-parallelism serial behaviour. |
+
+### Reading the sizing decision in logs
+
+Every fromScratch / incremental pass logs the inputs and the chosen concurrency at debug level on the `index-perf` logger:
+
+```
+[job: <id>.<rid>] from-scratch visit plan: files=189 maxLayerWidth=91 topoDepth=2 concurrency=4
+[job: <id>.<rid>] incremental visit plan: files=12 maxLayerWidth=11 topoDepth=2 concurrency=4
+```
+
+Match the `concurrency` value to the table above. If it's lower than you'd expect, the binding constraint is whichever of `files` / `maxLayerWidth` / `envelopeMax` / `hardCap` it equals. Patterns to recognise:
+
+- **`concurrency=1` with `files >= 10`**: `maxLayerWidth ≤ 2`. Dep graph is too linear for parallelism to help. Sometimes this is correct (a tight module chain), sometimes the dep resolver is producing a too-conservative ordering — cross-check by reading deps from `boxel_index` for a sample.
+- **`concurrency=1` with `files < 10`**: the small-batch threshold. Single-file incremental edits will always land here; this is by design.
+- **`concurrency=4` with `maxLayerWidth >> 4`**: hard-cap binding. The dep graph has way more parallelism available than the runner is taking. Raise `INDEX_RUNNER_MAX_CONCURRENCY` if the prerender fleet has spare capacity.
+- **`concurrency=4` with `maxLayerWidth=4`**: layer-width binding. Raising the cap doesn't help; widen the graph or accept the floor.
+
+### Per-row priority is unchanged
+
+Parallel visits inherit the same `priority` (0 system-initiated / 10 user-initiated) as the job that enqueued them; nothing in the runner's parallelism touches priority routing. A `priority=10` user reindex with `concurrency=4` issues four priority-10 prerender requests at a time — they compete against other priority-10 work on the fleet, just N at a time instead of one.
+
+### Order independence — why this is safe
+
+The indexer is order-independent by construction, which is what makes the bounded queue safe to run without explicit layer barriers:
+
+1. `Batch.#invalidations` is fully populated by `batch.invalidate(...)` inside `discoverInvalidations` *before* the visit loop starts. The only cross-visit read — `IndexBackedDependencyErrors.collectDirectRelationshipErrors` — uses this stable snapshot to skip propagating errors for deps that are in the current batch, so its answer doesn't depend on which other visits have completed.
+2. Renderer-side reads from `_card-doc` / `_federated-search` go through `boxel_index` (without `useWorkInProgressIndex`), so every visit sees the pre-batch state of every other URL in the batch — the same state the old serial loop saw too. Whether visit A precedes visit B doesn't change what B reads about A. This is documented in `realm.ts::parseRealmInfo` and `index-runner.ts::sortInvalidations`.
+3. Per-row writes to `boxel_index_working` are keyed on `(url, realm_url, type)` — disjoint across visits, so concurrent upserts never contend at the row level.
+4. Postgres pool gives a fresh client per query, so the per-visit `updateEntry` writes run on independent connections.
+
+The topological sort produced by `orderInvalidationsByDependencies` is preserved because it still has heuristic value under parallelism: modules sort ahead of instances, so the first wave of parallel tabs amortises module-extract work through the cross-tab `modules` table.
+
+### When parallelism is the cause of a regression
+
+Symptoms to look for:
+
+- **All-cold-tab batch**: many rows with `tabReused: false` and `tabStartupMs > 0`. With high concurrency and a cold realm affinity, the indexer can spawn N fresh tabs all at once, each paying the full warmup tax. The headline wall-clock will still be lower than serial, but per-row `launchMs` numbers look surprising. Pre-warm via `PRERENDER_PAGE_POOL_MIN` to keep tabs hot between batches if this is a recurring problem.
+- **Cross-realm fairness collapse**: one realm's reindex is starving renders for others. Compare `prerender-queue-snapshot` log lines across realms — if one affinity's `pending` is consistently the maximum allowed by envelope and others see nothing, lower `INDEX_RUNNER_MAX_CONCURRENCY` for the noisy realm or its environment.
+- **Sudden `tabQueueMs` jumps**: parallel visits within one realm filled the affinity's tab budget faster than expected. Either `PRERENDER_AFFINITY_TAB_MAX` is too low for the workload or the realm has unexpectedly high module sub-prerender fan-out per file.
 
 ## Extending the diagnostics
 

--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -1216,7 +1216,7 @@ If `GRAFANA_SECRET` is configured on your server, you can skip the user-JWT step
 
 ## Prerender capacity tuning knobs
 
-Four env vars control the per-prerender-server shape. The first three are resolved once at `PagePool` construction; the indexer-side cap is resolved per visit-loop entry. All require a process restart to change.
+Four env vars control the per-prerender-server shape. All are read once at module load time and require a process restart to change. The first three are PagePool-side; the indexer-side cap is read by the visit-loop sizing helper.
 
 | Env var | Default | What it controls | When to change it |
 |---|---|---|---|

--- a/packages/realm-server/handlers/handle-search.ts
+++ b/packages/realm-server/handlers/handle-search.ts
@@ -2,6 +2,7 @@ import type Koa from 'koa';
 import {
   buildSearchErrorResponse,
   SupportedMimeType,
+  logger,
   parseSearchQueryFromPayload,
   parseSearchQueryFromRequest,
   SearchRequestError,
@@ -17,8 +18,11 @@ import {
   getSearchRequestPayload,
 } from '../middleware/multi-realm-authorization';
 
+const searchLog = logger('realm-server:federated-search');
+
 export default function handleSearch(): (ctxt: Koa.Context) => Promise<void> {
   return async function (ctxt: Koa.Context) {
+    let totalStart = Date.now();
     let { realmList, realmByURL } = getMultiRealmAuthorization(ctxt);
 
     let cardsQuery;
@@ -41,10 +45,29 @@ export default function handleSearch(): (ctxt: Koa.Context) => Promise<void> {
       throw e;
     }
 
+    let searchStart = Date.now();
     let combined = await searchRealms(
       realmList.map((realmURL) => realmByURL.get(realmURL)),
       cardsQuery,
     );
+    let searchMs = Date.now() - searchStart;
+    let totalMs = Date.now() - totalStart;
+
+    // 1s threshold so normal in-cache fetches don't spam logs but the
+    // 90s renders that block prerender tabs are unmissable. The per-
+    // realm phase breakdown (primaryQuery / loadLinks / attachRealmInfo)
+    // is emitted by realm-index-query-engine; this line correlates the
+    // HTTP-level total with that breakdown via realm-list membership.
+    if (totalMs >= 1000) {
+      let resultCount = combined.data?.length ?? 0;
+      let includedCount = combined.included?.length ?? 0;
+      searchLog.info(
+        `slow /_federated-search total=${totalMs}ms searchRealms=${searchMs}ms ` +
+          `realmCount=${realmList.length} realms=${realmList.slice(0, 4).join(',')}` +
+          `${realmList.length > 4 ? `+${realmList.length - 4}` : ''} ` +
+          `data=${resultCount} included=${includedCount}`,
+      );
+    }
 
     await setContextResponse(
       ctxt,

--- a/packages/realm-server/tests/index-runner-concurrency-test.ts
+++ b/packages/realm-server/tests/index-runner-concurrency-test.ts
@@ -1,0 +1,52 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { runSharedTest } from '@cardstack/runtime-common/helpers';
+import concurrencyTests from '@cardstack/runtime-common/tests/index-runner-concurrency-test';
+
+module(basename(__filename), function () {
+  module('index-runner concurrency helpers', function () {
+    test('computeIndexVisitConcurrency: tiny batches stay serial', async function (assert) {
+      await runSharedTest(concurrencyTests, assert, {});
+    });
+
+    test('computeIndexVisitConcurrency: linear chains stay serial', async function (assert) {
+      await runSharedTest(concurrencyTests, assert, {});
+    });
+
+    test('computeIndexVisitConcurrency: wide batches respect the layer width', async function (assert) {
+      await runSharedTest(concurrencyTests, assert, {});
+    });
+
+    test('computeIndexVisitConcurrency: hard cap wins over generous envelopes', async function (assert) {
+      await runSharedTest(concurrencyTests, assert, {});
+    });
+
+    test('computeIndexVisitConcurrency: envelope wins when it is the tightest cap', async function (assert) {
+      await runSharedTest(concurrencyTests, assert, {});
+    });
+
+    test('computeIndexVisitConcurrency: malformed env vars fall back to defaults', async function (assert) {
+      await runSharedTest(concurrencyTests, assert, {});
+    });
+
+    test('runWithBoundedConcurrency: empty input', async function (assert) {
+      await runSharedTest(concurrencyTests, assert, {});
+    });
+
+    test('runWithBoundedConcurrency: collects fulfilled and rejected results in order', async function (assert) {
+      await runSharedTest(concurrencyTests, assert, {});
+    });
+
+    test('runWithBoundedConcurrency: never exceeds the concurrency cap', async function (assert) {
+      await runSharedTest(concurrencyTests, assert, {});
+    });
+
+    test('runWithBoundedConcurrency: concurrency=1 is sequential', async function (assert) {
+      await runSharedTest(concurrencyTests, assert, {});
+    });
+
+    test('runWithBoundedConcurrency: continues past rejections, finishes every item', async function (assert) {
+      await runSharedTest(concurrencyTests, assert, {});
+    });
+  });
+});

--- a/packages/realm-server/tests/index-runner-ordering-test.ts
+++ b/packages/realm-server/tests/index-runner-ordering-test.ts
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { runSharedTest } from '@cardstack/runtime-common/helpers';
+import orderingTests from '@cardstack/runtime-common/tests/index-runner-ordering-test';
+
+module(basename(__filename), function () {
+  module('index-runner dependency ordering', function () {
+    test('orderInvalidationsByDependencies: empty input', async function (assert) {
+      await runSharedTest(orderingTests, assert, {});
+    });
+
+    test('orderInvalidationsByDependencies: single URL', async function (assert) {
+      await runSharedTest(orderingTests, assert, {});
+    });
+
+    test('orderInvalidationsByDependencies: flat fan-out reports correct layer width', async function (assert) {
+      await runSharedTest(orderingTests, assert, {});
+    });
+
+    test('orderInvalidationsByDependencies: linear chain reports width 1 and full depth', async function (assert) {
+      await runSharedTest(orderingTests, assert, {});
+    });
+
+    test('orderInvalidationsByDependencies: diamond reports widest layer', async function (assert) {
+      await runSharedTest(orderingTests, assert, {});
+    });
+  });
+});

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -260,6 +260,8 @@ const ALL_TEST_FILES: string[] = [
   './node-realm-test',
   './session-room-queries-test',
   './indexing-event-sink-test',
+  './index-runner-concurrency-test',
+  './index-runner-ordering-test',
 ];
 
 // TEST_FILES limits which test files are loaded (parsed and executed). Useful
@@ -291,6 +293,7 @@ function parseTestFiles(value: string): string[] {
     .map((entry) => entry.replace(/\.ts$/, ''))
     .map((entry) => (entry.startsWith('./') ? entry : `./${entry}`));
 }
+>>>>>>> 91164b3045 (Parallelize the indexer visit loop with width-aware bounded concurrency)
 
 function parseModules(value: string): string[] {
   return value

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -293,7 +293,6 @@ function parseTestFiles(value: string): string[] {
     .map((entry) => entry.replace(/\.ts$/, ''))
     .map((entry) => (entry.startsWith('./') ? entry : `./${entry}`));
 }
->>>>>>> 91164b3045 (Parallelize the indexer visit loop with width-aware bounded concurrency)
 
 function parseModules(value: string): string[] {
   return value

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -196,11 +196,22 @@ export class IndexRunner {
     );
 
     let visitStart = Date.now();
-    invalidations = sortInvalidations(invalidations, current.realmURL);
-    invalidations =
+    let sortedInvalidations = sortInvalidations(
+      invalidations,
+      current.realmURL,
+    );
+    let { ordered, maxLayerWidth, topoDepth } =
       await current.#dependencyResolver.orderInvalidationsByDependencies(
-        invalidations,
+        sortedInvalidations,
       );
+    invalidations = ordered;
+    let concurrency = computeIndexVisitConcurrency(
+      invalidations.length,
+      maxLayerWidth,
+    );
+    current.#perfLog.debug(
+      `${jobIdentity(current.#jobInfo)} from-scratch visit plan: files=${invalidations.length} maxLayerWidth=${maxLayerWidth} topoDepth=${topoDepth} concurrency=${concurrency}`,
+    );
     let resumedRows = current.batch.resumedRows;
     let resumedSkipped = 0;
     current.#onProgress?.({
@@ -213,42 +224,52 @@ export class IndexRunner {
     });
     try {
       let filesCompleted = 0;
-      for (let invalidation of invalidations) {
-        // Resume guard. If a previous attempt of this same job already
-        // wrote URL_X to the working table AND the EFS mtime hasn't
-        // changed since, skip the visit — the existing working row is
-        // still authoritative and `applyBatchUpdates` will promote it
-        // (the constructor pre-seeded it into `#invalidations`). If
-        // mtime DID change, fall through to a normal visit so the
-        // upsert in `updateEntry` overwrites the resumed row with
-        // current content.
-        let resumedMtime = resumedRows.get(invalidation.href);
-        if (resumedMtime !== undefined) {
-          let currentMtime = discoverResult.filesystemMtimes[invalidation.href];
-          if (currentMtime !== undefined && currentMtime === resumedMtime) {
-            resumedSkipped++;
-            filesCompleted++;
-            current.#onProgress?.({
-              type: 'file-visited',
-              realmURL: current.realmURL.href,
-              jobId: current.#jobInfo.jobId,
-              url: invalidation.href,
-              filesCompleted,
-              totalFiles: invalidations.length,
-            });
-            continue;
+      let visitResults = await runWithBoundedConcurrency(
+        invalidations,
+        concurrency,
+        async (invalidation) => {
+          // Resume guard. If a previous attempt of this same job
+          // already wrote URL_X to the working table AND the EFS
+          // mtime hasn't changed since, skip the visit — the
+          // existing working row is still authoritative and
+          // `applyBatchUpdates` will promote it (the constructor
+          // pre-seeded it into `#invalidations`). If mtime DID
+          // change, fall through to a normal visit so the upsert in
+          // `updateEntry` overwrites the resumed row with current
+          // content.
+          let resumedMtime = resumedRows.get(invalidation.href);
+          if (resumedMtime !== undefined) {
+            let currentMtime =
+              discoverResult.filesystemMtimes[invalidation.href];
+            if (currentMtime !== undefined && currentMtime === resumedMtime) {
+              resumedSkipped++;
+              filesCompleted++;
+              current.#onProgress?.({
+                type: 'file-visited',
+                realmURL: current.realmURL.href,
+                jobId: current.#jobInfo.jobId,
+                url: invalidation.href,
+                filesCompleted,
+                totalFiles: invalidations.length,
+              });
+              return;
+            }
           }
-        }
-        await current.tryToVisit(invalidation);
-        filesCompleted++;
-        current.#onProgress?.({
-          type: 'file-visited',
-          realmURL: current.realmURL.href,
-          jobId: current.#jobInfo.jobId,
-          url: invalidation.href,
-          filesCompleted,
-          totalFiles: invalidations.length,
-        });
+          await current.tryToVisit(invalidation);
+          filesCompleted++;
+          current.#onProgress?.({
+            type: 'file-visited',
+            realmURL: current.realmURL.href,
+            jobId: current.#jobInfo.jobId,
+            url: invalidation.href,
+            filesCompleted,
+            totalFiles: invalidations.length,
+          });
+        },
+      );
+      let rejection = firstRejection(visitResults);
+      if (rejection) {
+        throw rejection.reason;
       }
       if (resumedSkipped > 0) {
         current.#perfLog.debug(
@@ -332,14 +353,22 @@ export class IndexRunner {
       current.#dependencyResolver.invalidateRelationshipDependencyRowCache(url),
     );
     await current.batch.invalidate(urls);
-    let invalidations = sortInvalidations(
+    let sortedInvalidations = sortInvalidations(
       current.batch.invalidations.map((href) => new URL(href)),
       current.realmURL,
     );
-    invalidations =
+    let { ordered, maxLayerWidth, topoDepth } =
       await current.#dependencyResolver.orderInvalidationsByDependencies(
-        invalidations,
+        sortedInvalidations,
       );
+    let invalidations = ordered;
+    let concurrency = computeIndexVisitConcurrency(
+      invalidations.length,
+      maxLayerWidth,
+    );
+    current.#perfLog.debug(
+      `${jobIdentity(current.#jobInfo)} incremental visit plan: files=${invalidations.length} maxLayerWidth=${maxLayerWidth} topoDepth=${topoDepth} concurrency=${concurrency}`,
+    );
     let hasExecutableInvalidation = invalidations.some((url) =>
       hasExecutableExtension(url.href),
     );
@@ -365,30 +394,39 @@ export class IndexRunner {
     });
     try {
       let filesCompleted = 0;
-      for (let invalidation of invalidations) {
-        if (
-          operations.get(invalidation.href) === 'delete' &&
-          hrefs.includes(invalidation.href)
-        ) {
-          // file is deleted, there is nothing to visit
-        } else if (resumedRows.has(invalidation.href)) {
-          // Previous attempt of this job already produced a working
-          // row for this URL. `args.changes` is the deterministic seed
-          // for incremental jobs; if the file changed again, that's a
-          // different changeset enqueued as a separate job. Skip.
-          resumedSkipped++;
-        } else {
-          await current.tryToVisit(invalidation);
-        }
-        filesCompleted++;
-        current.#onProgress?.({
-          type: 'file-visited',
-          realmURL: current.realmURL.href,
-          jobId: current.#jobInfo.jobId,
-          url: invalidation.href,
-          filesCompleted,
-          totalFiles: invalidations.length,
-        });
+      let visitResults = await runWithBoundedConcurrency(
+        invalidations,
+        concurrency,
+        async (invalidation) => {
+          if (
+            operations.get(invalidation.href) === 'delete' &&
+            hrefs.includes(invalidation.href)
+          ) {
+            // file is deleted, there is nothing to visit
+          } else if (resumedRows.has(invalidation.href)) {
+            // Previous attempt of this job already produced a working
+            // row for this URL. `args.changes` is the deterministic
+            // seed for incremental jobs; if the file changed again,
+            // that's a different changeset enqueued as a separate
+            // job. Skip.
+            resumedSkipped++;
+          } else {
+            await current.tryToVisit(invalidation);
+          }
+          filesCompleted++;
+          current.#onProgress?.({
+            type: 'file-visited',
+            realmURL: current.realmURL.href,
+            jobId: current.#jobInfo.jobId,
+            url: invalidation.href,
+            filesCompleted,
+            totalFiles: invalidations.length,
+          });
+        },
+      );
+      let rejection = firstRejection(visitResults);
+      if (rejection) {
+        throw rejection.reason;
       }
       if (resumedSkipped > 0) {
         current.#perfLog.debug(
@@ -713,6 +751,113 @@ function assertURLEndsWithJSON(url: URL): URL {
     return new URL(`${url}.json`);
   }
   return url;
+}
+
+// Below this many invalidations the cold-tab tax dominates any
+// parallelism payoff (a fresh tab joining the shared BrowserContext
+// costs ~3-5s before it can produce useful work, plus per-tab cardDoc
+// / store / Glimmer-compile warmup paid before each tab's first
+// render). 10 lines up roughly with that crossover at the typical
+// per-card render budget of 1-3s.
+const PARALLEL_INDEX_VISIT_THRESHOLD = 10;
+// Topo graphs whose widest layer is this small are effectively linear
+// chains — every additional worker just waits on the head of the
+// chain. Keep visits serial in this case to avoid spawning tabs that
+// have nothing to do.
+const PARALLEL_INDEX_LAYER_MIN_WIDTH = 2;
+// Default cap on the number of in-flight file visits a single
+// IndexRunner will keep open. Overridable via the
+// `INDEX_RUNNER_MAX_CONCURRENCY` env var. The cap is independent of
+// the prerender pool's per-affinity envelope: even when the pool
+// permits more parallelism, this cap prevents a single realm's
+// reindex from monopolising server-fleet capacity.
+const DEFAULT_INDEX_VISIT_MAX_CONCURRENCY = 4;
+
+// Per-tab parallelism envelope. Each file visit can fan out into ~1-2
+// module sub-prerenders (one per `CachingDefinitionLookup` miss), so
+// we reserve one tab against `PRERENDER_AFFINITY_TAB_MAX` to leave
+// headroom for those sub-prerenders to land without queueing behind
+// the file renders that need their results. The fallback default of
+// 5 matches `PRERENDER_AFFINITY_TAB_MAX`'s default in
+// `packages/realm-server/prerender/page-pool.ts`.
+function affinityEnvelopeMax(): number {
+  let raw = process.env.PRERENDER_AFFINITY_TAB_MAX;
+  let parsed = raw != null ? parseInt(raw, 10) : NaN;
+  let envelope = Number.isFinite(parsed) && parsed > 0 ? parsed : 5;
+  return Math.max(1, envelope - 1);
+}
+
+function indexVisitHardCap(): number {
+  let raw = process.env.INDEX_RUNNER_MAX_CONCURRENCY;
+  let parsed = raw != null ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_INDEX_VISIT_MAX_CONCURRENCY;
+}
+
+export function computeIndexVisitConcurrency(
+  totalWork: number,
+  maxLayerWidth: number,
+): number {
+  if (totalWork < PARALLEL_INDEX_VISIT_THRESHOLD) {
+    return 1;
+  }
+  if (maxLayerWidth <= PARALLEL_INDEX_LAYER_MIN_WIDTH) {
+    return 1;
+  }
+  return Math.max(
+    1,
+    Math.min(affinityEnvelopeMax(), maxLayerWidth, indexVisitHardCap()),
+  );
+}
+
+// Run `fn` against each item with at most `concurrency` in flight at
+// once. Returns one `PromiseSettledResult` per input position. Caller
+// chooses how to react to rejected results — the runner re-throws the
+// first one to preserve the serial loop's "abort the batch on
+// unexpected error" semantics.
+export async function runWithBoundedConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  let results: PromiseSettledResult<R>[] = new Array(items.length);
+  if (items.length === 0) {
+    return results;
+  }
+  let n = Math.max(1, Math.min(concurrency, items.length));
+  let next = 0;
+  async function worker() {
+    for (;;) {
+      let i = next++;
+      if (i >= items.length) {
+        return;
+      }
+      try {
+        let value = await fn(items[i]!, i);
+        results[i] = { status: 'fulfilled', value };
+      } catch (reason) {
+        results[i] = { status: 'rejected', reason };
+      }
+    }
+  }
+  let workers: Promise<void>[] = [];
+  for (let w = 0; w < n; w++) {
+    workers.push(worker());
+  }
+  await Promise.all(workers);
+  return results;
+}
+
+function firstRejection<R>(
+  results: PromiseSettledResult<R>[],
+): PromiseRejectedResult | undefined {
+  for (let result of results) {
+    if (result && result.status === 'rejected') {
+      return result;
+    }
+  }
+  return undefined;
 }
 
 function sortInvalidations(urls: URL[], realmURL: URL): URL[] {

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -34,6 +34,7 @@ import type { CacheScope, DefinitionLookup } from './definition-lookup';
 import { resolveCardReference } from './card-reference-resolver';
 import { isCardError } from './error';
 import type { IndexingProgressEvent } from './worker';
+import { canonicalURL } from './index-runner/dependency-url';
 import { IndexRunnerDependencyManager } from './index-runner/dependency-resolver';
 import {
   discoverInvalidations,
@@ -205,6 +206,7 @@ export class IndexRunner {
         sortedInvalidations,
       );
     invalidations = ordered;
+    await current.preWarmModulesTable(invalidations);
     let concurrency = computeIndexVisitConcurrency(
       invalidations.length,
       maxLayerWidth,
@@ -568,6 +570,160 @@ export class IndexRunner {
       authUserId: isPublic ? '' : this.#realmOwnerUserId,
     };
     return this.#moduleCacheContext;
+  }
+
+  // Populate the `modules` table for every module the upcoming visit
+  // loop is likely to need, before the parallel visit phase fires.
+  //
+  // Why: a parallel batch where N concurrent file renders each fire a
+  // same-affinity `prerenderModule` sub-render produces a self-
+  // referential deadlock — the file renders hold the tabs the module
+  // sub-renders need, the module sub-renders are queued behind the
+  // file renders that are waiting on them. PagePool's per-affinity
+  // admission cap is designed to prevent this for a single in-flight
+  // file render, but it can't reserve enough headroom for N parallel
+  // file renders' worth of sub-renders. By pre-rendering modules in
+  // a controlled phase (parallel within the module queue, but never
+  // mixed with file admissions), we ensure every later file render
+  // finds its definitions already in cache and never triggers a mid-
+  // render sub-prerender.
+  //
+  // Signal sources, in priority order:
+  //   1. Existing `boxel_index.deps` — strongest, captured from a
+  //      prior successful render. Used for KNOWN URLs.
+  //   2. `adoptsFrom.module` read from disk — used for NOVEL `.json`
+  //      URLs that don't have a prior `deps` row yet.
+  //   3. The URL itself — used for NOVEL executable files (`.gts`
+  //      etc.); the file IS a module, pre-warm it directly.
+  //
+  // Modules that are already in the cache are skipped (the cache
+  // lookup is O(1) by URL). Misses fire `prerenderer.prerenderModule`
+  // in parallel; module sub-renders go through the module queue and
+  // bypass file admission, so they never deadlock against the (yet
+  // to start) file-visit phase.
+  private async preWarmModulesTable(invalidations: URL[]): Promise<void> {
+    if (invalidations.length === 0) {
+      return;
+    }
+    let preWarmStart = Date.now();
+    let hrefs = invalidations.map((u) => u.href);
+    let existingRows = await this.batch.getDependencyRows(hrefs);
+    let bestByUrl = new Map<string, { url: string; deps: string[] | null }>();
+    for (let row of existingRows) {
+      // Prefer rows that actually carry deps so the lookup below
+      // returns the strongest signal available for each URL.
+      let existing = bestByUrl.get(row.url);
+      if (!existing || (!existing.deps?.length && row.deps?.length)) {
+        bestByUrl.set(row.url, { url: row.url, deps: row.deps ?? null });
+      }
+    }
+
+    let toWarm = new Set<string>();
+    for (let url of invalidations) {
+      let row = bestByUrl.get(url.href);
+      if (row?.deps?.length) {
+        for (let dep of row.deps) {
+          let resolved = canonicalURL(dep, url.href);
+          if (hasExecutableExtension(resolved)) {
+            toWarm.add(resolved);
+          }
+        }
+      } else if (hasExecutableExtension(url.href)) {
+        toWarm.add(url.href);
+      } else if (url.href.endsWith('.json')) {
+        let adoptsFromModule = await this.#readAdoptsFromModuleFromDisk(url);
+        if (adoptsFromModule && hasExecutableExtension(adoptsFromModule)) {
+          toWarm.add(adoptsFromModule);
+        }
+      }
+    }
+
+    if (toWarm.size === 0) {
+      return;
+    }
+
+    let { resolvedRealmURL, cacheScope, authUserId } =
+      await this.getModuleCacheContext();
+    let cached = await this.#definitionLookup.getModuleCacheEntries({
+      moduleUrls: [...toWarm],
+      cacheScope,
+      authUserId,
+      resolvedRealmURL,
+    });
+    let misses: string[] = [];
+    for (let moduleUrl of toWarm) {
+      let entry = cached[moduleUrl];
+      if (!entry || entry.error) {
+        misses.push(moduleUrl);
+      }
+    }
+
+    this.#perfLog.debug(
+      `${jobIdentity(this.#jobInfo)} pre-warm plan: candidates=${toWarm.size} cached=${toWarm.size - misses.length} misses=${misses.length}`,
+    );
+
+    if (misses.length === 0) {
+      this.#perfLog.debug(
+        `${jobIdentity(this.#jobInfo)} pre-warm complete (all cached) in ${Date.now() - preWarmStart} ms`,
+      );
+      return;
+    }
+
+    // Parallel pre-warm. Module sub-renders go through the module
+    // queue and bypass file admission, so spawning many at once
+    // saturates the module queue (good — we want the modules table
+    // populated before the file-visit phase starts) without
+    // contending against the still-to-come file admissions.
+    let results = await Promise.allSettled(
+      misses.map((moduleUrl) =>
+        this.#prerenderer.prerenderModule({
+          affinityType: 'realm',
+          affinityValue: this.#realmURL.href,
+          realm: this.#realmURL.href,
+          url: moduleUrl,
+          auth: this.#auth,
+          renderOptions: {},
+          ...(this.#jobPriority !== undefined
+            ? { priority: this.#jobPriority }
+            : {}),
+        }),
+      ),
+    );
+
+    let failed = 0;
+    for (let result of results) {
+      if (result.status === 'rejected') {
+        failed += 1;
+      }
+    }
+    if (failed > 0) {
+      this.#log.warn(
+        `${jobIdentity(this.#jobInfo)} ${failed} of ${misses.length} module pre-warms failed; the visit phase will retry on-demand if needed`,
+      );
+    }
+
+    this.#perfLog.debug(
+      `${jobIdentity(this.#jobInfo)} pre-warm complete in ${Date.now() - preWarmStart} ms (warmed=${misses.length - failed} failed=${failed})`,
+    );
+  }
+
+  async #readAdoptsFromModuleFromDisk(url: URL): Promise<string | undefined> {
+    try {
+      let fileRef = await this.#reader.readFile(url);
+      if (!fileRef?.content) {
+        return undefined;
+      }
+      let doc = JSON.parse(fileRef.content) as {
+        data?: { meta?: { adoptsFrom?: { module?: unknown } } };
+      };
+      let module = doc?.data?.meta?.adoptsFrom?.module;
+      if (typeof module !== 'string') {
+        return undefined;
+      }
+      return canonicalURL(module, url.href);
+    } catch {
+      return undefined;
+    }
   }
 
   #scheduleClearCacheForNextRender() {

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -381,7 +381,10 @@ export class IndexRunner {
       current.#scheduleClearCacheForNextRender();
     }
 
-    let hrefs = urls.map((u) => u.href);
+    // Set-based membership check so the per-task `delete-and-in-seed`
+    // guard stays O(1). With large fan-outs the inner Array.includes
+    // would otherwise be O(n) per task.
+    let hrefs = new Set(urls.map((u) => u.href));
     let resumedRows = current.batch.resumedRows;
     let resumedSkipped = 0;
     current.#onProgress?.({
@@ -400,7 +403,7 @@ export class IndexRunner {
         async (invalidation) => {
           if (
             operations.get(invalidation.href) === 'delete' &&
-            hrefs.includes(invalidation.href)
+            hrefs.has(invalidation.href)
           ) {
             // file is deleted, there is nothing to visit
           } else if (resumedRows.has(invalidation.href)) {

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -596,11 +596,13 @@ export class IndexRunner {
   //   3. The URL itself — used for NOVEL executable files (`.gts`
   //      etc.); the file IS a module, pre-warm it directly.
   //
-  // Modules that are already in the cache are skipped (the cache
-  // lookup is O(1) by URL). Misses fire `prerenderer.prerenderModule`
-  // in parallel; module sub-renders go through the module queue and
-  // bypass file admission, so they never deadlock against the (yet
-  // to start) file-visit phase.
+  // Modules that are already cached are returned immediately from the
+  // first DB read inside getModuleCacheEntry; cache misses go through
+  // the read-through path (loadModuleCacheEntryUncached →
+  // getModuleDefinitionsViaPrerenderer → persistModuleCacheEntry),
+  // which is the same flow lookupDefinition uses. We never call the
+  // prerenderer directly from here — DefinitionLookup owns the
+  // in-flight dedup, the cross-process coalescer, and the persist.
   private async preWarmModulesTable(invalidations: URL[]): Promise<void> {
     if (invalidations.length === 0) {
       return;
@@ -618,6 +620,10 @@ export class IndexRunner {
       }
     }
 
+    // Resolve the disk-adoptsFrom signal in parallel for any `.json`
+    // URLs missing a prior deps row, so a wide invalidation set
+    // doesn't pay N sequential file reads here.
+    let novelJsonUrls: URL[] = [];
     let toWarm = new Set<string>();
     for (let url of invalidations) {
       let row = bestByUrl.get(url.href);
@@ -631,9 +637,16 @@ export class IndexRunner {
       } else if (hasExecutableExtension(url.href)) {
         toWarm.add(url.href);
       } else if (url.href.endsWith('.json')) {
-        let adoptsFromModule = await this.#readAdoptsFromModuleFromDisk(url);
-        if (adoptsFromModule && hasExecutableExtension(adoptsFromModule)) {
-          toWarm.add(adoptsFromModule);
+        novelJsonUrls.push(url);
+      }
+    }
+    if (novelJsonUrls.length > 0) {
+      let adoptsFrom = await Promise.all(
+        novelJsonUrls.map((u) => this.#readAdoptsFromModuleFromDisk(u)),
+      );
+      for (let module of adoptsFrom) {
+        if (module && hasExecutableExtension(module)) {
+          toWarm.add(module);
         }
       }
     }
@@ -642,51 +655,13 @@ export class IndexRunner {
       return;
     }
 
-    let { resolvedRealmURL, cacheScope, authUserId } =
-      await this.getModuleCacheContext();
-    let cached = await this.#definitionLookup.getModuleCacheEntries({
-      moduleUrls: [...toWarm],
-      cacheScope,
-      authUserId,
-      resolvedRealmURL,
-    });
-    let misses: string[] = [];
-    for (let moduleUrl of toWarm) {
-      let entry = cached[moduleUrl];
-      if (!entry || entry.error) {
-        misses.push(moduleUrl);
-      }
-    }
-
-    this.#perfLog.debug(
-      `${jobIdentity(this.#jobInfo)} pre-warm plan: candidates=${toWarm.size} cached=${toWarm.size - misses.length} misses=${misses.length}`,
-    );
-
-    if (misses.length === 0) {
-      this.#perfLog.debug(
-        `${jobIdentity(this.#jobInfo)} pre-warm complete (all cached) in ${Date.now() - preWarmStart} ms`,
-      );
-      return;
-    }
-
-    // Parallel pre-warm. Module sub-renders go through the module
-    // queue and bypass file admission, so spawning many at once
-    // saturates the module queue (good — we want the modules table
-    // populated before the file-visit phase starts) without
-    // contending against the still-to-come file admissions.
+    // Call definitionLookup.getModuleCacheEntry per URL in parallel.
+    // Each call short-circuits on a DB cache hit (cheap); on a miss
+    // it goes through the full read-through path including the
+    // in-flight dedup map and the cross-process coalescer.
     let results = await Promise.allSettled(
-      misses.map((moduleUrl) =>
-        this.#prerenderer.prerenderModule({
-          affinityType: 'realm',
-          affinityValue: this.#realmURL.href,
-          realm: this.#realmURL.href,
-          url: moduleUrl,
-          auth: this.#auth,
-          renderOptions: {},
-          ...(this.#jobPriority !== undefined
-            ? { priority: this.#jobPriority }
-            : {}),
-        }),
+      [...toWarm].map((moduleUrl) =>
+        this.#definitionLookup.getModuleCacheEntry(moduleUrl),
       ),
     );
 
@@ -698,12 +673,12 @@ export class IndexRunner {
     }
     if (failed > 0) {
       this.#log.warn(
-        `${jobIdentity(this.#jobInfo)} ${failed} of ${misses.length} module pre-warms failed; the visit phase will retry on-demand if needed`,
+        `${jobIdentity(this.#jobInfo)} ${failed} of ${toWarm.size} module pre-warm lookups failed; the visit phase will retry on-demand if needed`,
       );
     }
 
     this.#perfLog.debug(
-      `${jobIdentity(this.#jobInfo)} pre-warm complete in ${Date.now() - preWarmStart} ms (warmed=${misses.length - failed} failed=${failed})`,
+      `${jobIdentity(this.#jobInfo)} pre-warm complete in ${Date.now() - preWarmStart} ms (candidates=${toWarm.size} failed=${failed})`,
     );
   }
 

--- a/packages/runtime-common/index-runner/dependency-resolver.ts
+++ b/packages/runtime-common/index-runner/dependency-resolver.ts
@@ -14,6 +14,20 @@ import {
 
 type OrderingDependencyRow = Pick<DependencyIndexRow, 'url' | 'type' | 'deps'>;
 
+export interface OrderedInvalidations {
+  ordered: URL[];
+  // Largest count of nodes sharing the same topological depth. The
+  // index-runner uses this as the upper bound on useful per-batch
+  // visit concurrency: spawning more parallel visits than the widest
+  // layer wastes resources because the extra workers have no eligible
+  // work to take.
+  maxLayerWidth: number;
+  // Number of distinct topological layers (1 + longest dep chain
+  // length). When this is close to `ordered.length` the graph is
+  // essentially linear and parallelism can't help.
+  topoDepth: number;
+}
+
 interface DependencyResolverOptions {
   realmURL: URL;
   readModuleCacheEntries(moduleIds: string[]): Promise<ModuleCacheEntries>;
@@ -71,9 +85,14 @@ export class IndexRunnerDependencyManager {
     );
   }
 
-  async orderInvalidationsByDependencies(urls: URL[]): Promise<URL[]> {
-    if (urls.length < 2) {
-      return urls;
+  async orderInvalidationsByDependencies(
+    urls: URL[],
+  ): Promise<OrderedInvalidations> {
+    if (urls.length === 0) {
+      return { ordered: urls, maxLayerWidth: 0, topoDepth: 0 };
+    }
+    if (urls.length === 1) {
+      return { ordered: urls, maxLayerWidth: 1, topoDepth: 1 };
     }
 
     let byHref = new Map(urls.map((url) => [url.href, url]));
@@ -109,6 +128,19 @@ export class IndexRunnerDependencyManager {
       }
     }
 
+    // Layer assignment: each href's layer is one greater than the max
+    // layer of any of its prerequisites. Roots (indegree 0) live in
+    // layer 0. We use this only to report `maxLayerWidth` / `topoDepth`
+    // for the caller's parallelism-sizing decision — the actual visit
+    // order produced below is a stable priority-queue traversal that
+    // honors the input ordering, not a strict layered ordering.
+    let layerOf = new Map<string, number>();
+    for (let href of hrefs) {
+      if ((indegree.get(href) ?? 0) === 0) {
+        layerOf.set(href, 0);
+      }
+    }
+
     let queue = hrefs
       .filter((href) => (indegree.get(href) ?? 0) === 0)
       .sort((a, b) => (order.get(a) ?? 0) - (order.get(b) ?? 0));
@@ -132,28 +164,65 @@ export class IndexRunnerDependencyManager {
     while (queue.length > 0) {
       let href = queue.shift()!;
       ordered.push(href);
+      let myLayer = layerOf.get(href) ?? 0;
       for (let dependent of edges.get(href) ?? []) {
         let next = (indegree.get(dependent) ?? 0) - 1;
         indegree.set(dependent, next);
+        let prev = layerOf.get(dependent);
+        let candidate = myLayer + 1;
+        if (prev === undefined || candidate > prev) {
+          layerOf.set(dependent, candidate);
+        }
         if (next === 0) {
           insertByOrder(dependent);
         }
       }
     }
 
+    // Items that didn't make it into `ordered` (e.g. participants in a
+    // dependency cycle) get appended in input order so the caller still
+    // sees every URL. Assign them to the deepest layer + 1 so they
+    // contribute to width / depth in a way that doesn't surprise the
+    // sizing formula.
+    let cycleLayer = 0;
+    for (let depth of layerOf.values()) {
+      if (depth > cycleLayer) {
+        cycleLayer = depth;
+      }
+    }
+    cycleLayer += 1;
     if (ordered.length !== hrefs.length) {
       let orderedSet = new Set(ordered);
       for (let href of hrefs) {
         if (!orderedSet.has(href)) {
           ordered.push(href);
           orderedSet.add(href);
+          if (!layerOf.has(href)) {
+            layerOf.set(href, cycleLayer);
+          }
         }
       }
     }
 
-    return ordered
-      .map((href) => byHref.get(href))
-      .filter((url): url is URL => Boolean(url));
+    let widthByLayer = new Map<number, number>();
+    for (let depth of layerOf.values()) {
+      widthByLayer.set(depth, (widthByLayer.get(depth) ?? 0) + 1);
+    }
+    let maxLayerWidth = 0;
+    for (let width of widthByLayer.values()) {
+      if (width > maxLayerWidth) {
+        maxLayerWidth = width;
+      }
+    }
+    let topoDepth = widthByLayer.size;
+
+    return {
+      ordered: ordered
+        .map((href) => byHref.get(href))
+        .filter((url): url is URL => Boolean(url)),
+      maxLayerWidth,
+      topoDepth,
+    };
   }
 
   extractDirectRelationshipDeps(

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -172,9 +172,14 @@ export class RealmIndexQueryEngine {
     query: Query,
     opts?: Options,
   ): Promise<LinkableCollectionDocument> {
+    let totalStart = Date.now();
     let doc: LinkableCollectionDocument;
+    let phaseStart = Date.now();
     let isFileMetaQuery = await this.queryTargetsFileMeta(query.filter, opts);
+    let queryTargetsMs = Date.now() - phaseStart;
 
+    phaseStart = Date.now();
+    let primaryRows: number;
     if (isFileMetaQuery) {
       let { files, meta } = await this.#indexQueryEngine.searchFiles(
         new URL(this.#realm.url),
@@ -193,6 +198,7 @@ export class RealmIndexQueryEngine {
         data: resources,
         meta,
       };
+      primaryRows = files.length;
     } else {
       let { cards, meta } = await this.#indexQueryEngine.searchCards(
         new URL(this.#realm.url),
@@ -212,12 +218,17 @@ export class RealmIndexQueryEngine {
         data: cardResources,
         meta,
       };
+      primaryRows = cards.length;
     }
+    let primaryQueryMs = Date.now() - phaseStart;
 
     // TODO eventually the links will be cached in the index, and this will only
     // fill in the included resources for links that were not cached (e.g.
     // volatile fields)
+    let loadLinksMs = 0;
+    let includedCount = 0;
     if (opts?.loadLinks) {
+      phaseStart = Date.now();
       let linkFields = isFileMetaQuery
         ? query.fields?.['file-meta']
         : query.fields?.['card'];
@@ -236,9 +247,32 @@ export class RealmIndexQueryEngine {
       );
       if (included.length > 0) {
         doc.included = included;
+        includedCount = included.length;
       }
+      loadLinksMs = Date.now() - phaseStart;
     }
+
+    phaseStart = Date.now();
     await this.attachRealmInfo(doc);
+    let attachRealmInfoMs = Date.now() - phaseStart;
+
+    let totalMs = Date.now() - totalStart;
+    // 1s is the threshold at which a single realm search becomes visible
+    // as a render stall in queryLoadsInFlight; below that it's just normal
+    // overhead. We log at info so a deliberate LOG_LEVELS=realm:index-query-engine=info
+    // can capture every slow path without flooding default-warn pipelines.
+    if (totalMs >= 1000) {
+      let filterDigest = digestQueryFilter(query);
+      this.#log.info(
+        `slow searchCards realm=${this.#realm.url} total=${totalMs}ms ` +
+          `primaryQuery=${primaryQueryMs}ms (rows=${primaryRows}) ` +
+          `loadLinks=${loadLinksMs}ms (included=${includedCount}) ` +
+          `attachRealmInfo=${attachRealmInfoMs}ms ` +
+          `queryTargetsCheck=${queryTargetsMs}ms ` +
+          `loadLinksOpt=${opts?.loadLinks ? 'on' : 'off'} ` +
+          `filter=${filterDigest}`,
+      );
+    }
     return doc;
   }
 
@@ -1437,6 +1471,34 @@ export class RealmIndexQueryEngine {
     );
     return included;
   }
+}
+
+// Compact shape signal for slow-query logs. Returns the high-level type+on
+// codeRefs and the top-level filter operator (every/any/not/eq/...) so a
+// triage reader can tell "Cohort.policies linksToMany" apart from "any-of
+// 12 type filters" without dumping the full JSON. Capped output length so
+// a worst-case filter doesn't bloat the log line.
+function digestQueryFilter(query: Query): string {
+  if (!query.filter) {
+    return 'noFilter';
+  }
+  let refs: CodeRef[] = [];
+  try {
+    collectFilterRefs(query.filter, refs);
+  } catch {
+    // best-effort — fall through with empty refs
+  }
+  let refLabels = refs
+    .map((ref) => {
+      if (ref && typeof ref === 'object' && 'name' in ref && 'module' in ref) {
+        return `${ref.module}/${(ref as { name: string }).name}`;
+      }
+      return '?';
+    })
+    .slice(0, 4);
+  let topKeys = Object.keys(query.filter).slice(0, 4).join('+');
+  let label = `ops=${topKeys || 'leaf'} refs=${refLabels.join(',') || 'none'}`;
+  return label.length > 240 ? `${label.slice(0, 237)}...` : label;
 }
 
 function collectFilterRefs(filter: Filter, refs: CodeRef[]) {

--- a/packages/runtime-common/search-utils.ts
+++ b/packages/runtime-common/search-utils.ts
@@ -1,4 +1,5 @@
 import type { RealmResourceIdentifier } from './card-reference-resolver';
+import { logger } from './log';
 import { ensureTrailingSlash } from './paths';
 import { assertQuery, InvalidQueryError, type Query } from './query';
 import {
@@ -11,6 +12,8 @@ import type {
   PrerenderedCardCollectionDocument,
 } from './document-types';
 import { SupportedMimeType } from './router';
+
+const searchLog = logger('realm:federated-search');
 
 export type SearchRequestErrorCode =
   | 'missing-realms'
@@ -331,9 +334,18 @@ export async function searchRealms(
       realm,
       label: realm.url ? String(realm.url) : undefined,
     }));
-  let searchPromises = realmEntries.map(({ realm }) =>
-    Promise.resolve().then(() => realm.search(query)),
-  );
+  // Per-realm wall-clock so we can attribute a slow federated call to a
+  // specific realm. Timing wraps Promise.resolve().then(...) so the
+  // realm.search() promise's actual scheduling latency is included.
+  let perRealmMs = new Array<number>(realmEntries.length).fill(0);
+  let searchPromises = realmEntries.map(({ realm }, index) => {
+    let realmStart = Date.now();
+    return Promise.resolve()
+      .then(() => realm.search(query))
+      .finally(() => {
+        perRealmMs[index] = Date.now() - realmStart;
+      });
+  });
   let results = await Promise.allSettled(searchPromises);
   let queryLabel = '[unserializable query]';
   try {
@@ -350,6 +362,22 @@ export async function searchRealms(
       );
     }
   });
+  let slowRealms = perRealmMs
+    .map((ms, index) => ({
+      ms,
+      label: realmEntries[index]?.label ?? `index ${index}`,
+    }))
+    .filter((entry) => entry.ms >= 1000)
+    .sort((a, b) => b.ms - a.ms);
+  if (slowRealms.length > 0) {
+    let summary = slowRealms
+      .slice(0, 4)
+      .map((e) => `${e.label}=${e.ms}ms`)
+      .join(' ');
+    searchLog.info(
+      `slow searchRealms realms=${realmEntries.length} slow=${slowRealms.length} ${summary}`,
+    );
+  }
   let docs = results.flatMap((result) =>
     result.status === 'fulfilled' ? [result.value] : [],
   );

--- a/packages/runtime-common/tests/index-runner-concurrency-test.ts
+++ b/packages/runtime-common/tests/index-runner-concurrency-test.ts
@@ -1,0 +1,223 @@
+import type { SharedTests } from '../helpers';
+import {
+  computeIndexVisitConcurrency,
+  runWithBoundedConcurrency,
+} from '../index-runner';
+
+const ORIGINAL_TAB_MAX = process.env.PRERENDER_AFFINITY_TAB_MAX;
+const ORIGINAL_HARD_CAP = process.env.INDEX_RUNNER_MAX_CONCURRENCY;
+
+function setEnv(
+  key: 'PRERENDER_AFFINITY_TAB_MAX' | 'INDEX_RUNNER_MAX_CONCURRENCY',
+  value: string | undefined,
+): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+function restoreEnv(): void {
+  setEnv('PRERENDER_AFFINITY_TAB_MAX', ORIGINAL_TAB_MAX);
+  setEnv('INDEX_RUNNER_MAX_CONCURRENCY', ORIGINAL_HARD_CAP);
+}
+
+const tests = Object.freeze({
+  'computeIndexVisitConcurrency: tiny batches stay serial': async (assert) => {
+    try {
+      setEnv('PRERENDER_AFFINITY_TAB_MAX', '5');
+      setEnv('INDEX_RUNNER_MAX_CONCURRENCY', '4');
+      // Below the size threshold the cold-tab tax exceeds parallelism
+      // payoff, so the formula falls back to serial regardless of how
+      // wide the dep graph happens to be.
+      assert.strictEqual(computeIndexVisitConcurrency(0, 0), 1);
+      assert.strictEqual(computeIndexVisitConcurrency(1, 1), 1);
+      assert.strictEqual(computeIndexVisitConcurrency(9, 9), 1);
+    } finally {
+      restoreEnv();
+    }
+  },
+
+  'computeIndexVisitConcurrency: linear chains stay serial': async (assert) => {
+    try {
+      setEnv('PRERENDER_AFFINITY_TAB_MAX', '5');
+      setEnv('INDEX_RUNNER_MAX_CONCURRENCY', '4');
+      // A 100-file batch with max-layer-width 1 (or 2) is a near-
+      // linear topo chain; spawning extra workers just wastes them on
+      // the head of the chain.
+      assert.strictEqual(computeIndexVisitConcurrency(100, 1), 1);
+      assert.strictEqual(computeIndexVisitConcurrency(100, 2), 1);
+    } finally {
+      restoreEnv();
+    }
+  },
+
+  'computeIndexVisitConcurrency: wide batches respect the layer width': async (
+    assert,
+  ) => {
+    try {
+      setEnv('PRERENDER_AFFINITY_TAB_MAX', '5');
+      setEnv('INDEX_RUNNER_MAX_CONCURRENCY', '8');
+      // With envelope=4 (tabMax 5 - 1) and hardCap=8, a layer width
+      // of 3 caps concurrency to 3 — there is no useful work for a
+      // 4th in-flight visit.
+      assert.strictEqual(computeIndexVisitConcurrency(100, 3), 3);
+    } finally {
+      restoreEnv();
+    }
+  },
+
+  'computeIndexVisitConcurrency: hard cap wins over generous envelopes': async (
+    assert,
+  ) => {
+    try {
+      setEnv('PRERENDER_AFFINITY_TAB_MAX', '10');
+      setEnv('INDEX_RUNNER_MAX_CONCURRENCY', '3');
+      // Layer width and the affinity envelope both permit higher
+      // concurrency, but the explicit cap throttles to 3 — the knob
+      // an operator would reach for to protect prerender capacity
+      // shared across the fleet.
+      assert.strictEqual(computeIndexVisitConcurrency(100, 20), 3);
+    } finally {
+      restoreEnv();
+    }
+  },
+
+  'computeIndexVisitConcurrency: envelope wins when it is the tightest cap':
+    async (assert) => {
+      try {
+        setEnv('PRERENDER_AFFINITY_TAB_MAX', '3');
+        setEnv('INDEX_RUNNER_MAX_CONCURRENCY', '10');
+        // Envelope = tabMax - 1 = 2 (one tab reserved for module
+        // sub-prerenders). Even with a hard cap of 10 and a wide
+        // layer, the envelope is the binding constraint.
+        assert.strictEqual(computeIndexVisitConcurrency(100, 20), 2);
+      } finally {
+        restoreEnv();
+      }
+    },
+
+  'computeIndexVisitConcurrency: malformed env vars fall back to defaults':
+    async (assert) => {
+      try {
+        setEnv('PRERENDER_AFFINITY_TAB_MAX', 'oops');
+        setEnv('INDEX_RUNNER_MAX_CONCURRENCY', 'oops');
+        // Fallback envelope = 5 - 1 = 4. Default hard cap = 4. With a
+        // wide layer (20), concurrency is min(4, 20, 4) = 4.
+        assert.strictEqual(computeIndexVisitConcurrency(100, 20), 4);
+      } finally {
+        restoreEnv();
+      }
+    },
+
+  'runWithBoundedConcurrency: empty input': async (assert) => {
+    let results = await runWithBoundedConcurrency([], 4, async () => 1);
+    assert.deepEqual(results, []);
+  },
+
+  'runWithBoundedConcurrency: collects fulfilled and rejected results in order':
+    async (assert) => {
+      let results = await runWithBoundedConcurrency(
+        [1, 2, 3, 4, 5],
+        2,
+        async (item) => {
+          if (item === 3) {
+            throw new Error(`boom-${item}`);
+          }
+          return item * 10;
+        },
+      );
+      assert.strictEqual(results.length, 5);
+      assert.strictEqual(results[0]!.status, 'fulfilled');
+      assert.strictEqual(
+        (results[0] as PromiseFulfilledResult<number>).value,
+        10,
+      );
+      assert.strictEqual(results[1]!.status, 'fulfilled');
+      assert.strictEqual(
+        (results[1] as PromiseFulfilledResult<number>).value,
+        20,
+      );
+      assert.strictEqual(results[2]!.status, 'rejected');
+      assert.strictEqual(
+        ((results[2] as PromiseRejectedResult).reason as Error).message,
+        'boom-3',
+      );
+      assert.strictEqual(results[3]!.status, 'fulfilled');
+      assert.strictEqual(
+        (results[3] as PromiseFulfilledResult<number>).value,
+        40,
+      );
+      assert.strictEqual(results[4]!.status, 'fulfilled');
+      assert.strictEqual(
+        (results[4] as PromiseFulfilledResult<number>).value,
+        50,
+      );
+    },
+
+  'runWithBoundedConcurrency: never exceeds the concurrency cap': async (
+    assert,
+  ) => {
+    let inFlight = 0;
+    let peakInFlight = 0;
+    let items = Array.from({ length: 20 }, (_, i) => i);
+    await runWithBoundedConcurrency(items, 3, async () => {
+      inFlight++;
+      if (inFlight > peakInFlight) {
+        peakInFlight = inFlight;
+      }
+      // Yield a few times to give the scheduler real opportunities to
+      // overshoot if the queue logic is wrong.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      inFlight--;
+    });
+    assert.ok(
+      peakInFlight <= 3,
+      `expected peak in-flight ≤ 3, got ${peakInFlight}`,
+    );
+    assert.ok(
+      peakInFlight >= 2,
+      `expected peak in-flight ≥ 2 to confirm real parallelism, got ${peakInFlight}`,
+    );
+  },
+
+  'runWithBoundedConcurrency: concurrency=1 is sequential': async (assert) => {
+    let inFlight = 0;
+    let peakInFlight = 0;
+    let items = Array.from({ length: 8 }, (_, i) => i);
+    await runWithBoundedConcurrency(items, 1, async () => {
+      inFlight++;
+      if (inFlight > peakInFlight) {
+        peakInFlight = inFlight;
+      }
+      await Promise.resolve();
+      inFlight--;
+    });
+    assert.strictEqual(peakInFlight, 1);
+  },
+
+  'runWithBoundedConcurrency: continues past rejections, finishes every item':
+    async (assert) => {
+      let visited = new Set<number>();
+      let items = Array.from({ length: 10 }, (_, i) => i);
+      let results = await runWithBoundedConcurrency(items, 3, async (item) => {
+        visited.add(item);
+        if (item % 3 === 0) {
+          throw new Error(`fail-${item}`);
+        }
+        return item;
+      });
+      assert.deepEqual(
+        [...visited].sort((a, b) => a - b),
+        items,
+        'every input was visited even though several rejected',
+      );
+      let rejectedCount = results.filter((r) => r.status === 'rejected').length;
+      assert.strictEqual(rejectedCount, 4); // 0, 3, 6, 9
+    },
+} as SharedTests<unknown>);
+
+export default tests;

--- a/packages/runtime-common/tests/index-runner-ordering-test.ts
+++ b/packages/runtime-common/tests/index-runner-ordering-test.ts
@@ -1,0 +1,127 @@
+import type { SharedTests } from '../helpers';
+import { IndexRunnerDependencyManager } from '../index-runner/dependency-resolver';
+import type { DependencyIndexRow } from '../index';
+
+type Row = Pick<DependencyIndexRow, 'url' | 'type' | 'deps'>;
+
+function buildManager(rowsByURL: Record<string, Row>) {
+  return new IndexRunnerDependencyManager({
+    realmURL: new URL('http://test.localhost/'),
+    readModuleCacheEntries: async () => ({}),
+    getDependencyRows: async () => [],
+    getOrderingDependencyRows: async (urls: string[]) =>
+      urls.map((url) => rowsByURL[url] ?? { url, type: 'file', deps: [] }),
+    getInvalidations: () => [],
+  });
+}
+
+function urls(...hrefs: string[]): URL[] {
+  return hrefs.map((href) => new URL(href));
+}
+
+const tests = Object.freeze({
+  'orderInvalidationsByDependencies: empty input': async (assert) => {
+    let manager = buildManager({});
+    let result = await manager.orderInvalidationsByDependencies([]);
+    assert.deepEqual(result.ordered, []);
+    assert.strictEqual(result.maxLayerWidth, 0);
+    assert.strictEqual(result.topoDepth, 0);
+  },
+
+  'orderInvalidationsByDependencies: single URL': async (assert) => {
+    let manager = buildManager({});
+    let [url] = urls('http://test.localhost/a');
+    let result = await manager.orderInvalidationsByDependencies([url!]);
+    assert.strictEqual(result.ordered.length, 1);
+    assert.strictEqual(result.ordered[0]!.href, url!.href);
+    assert.strictEqual(result.maxLayerWidth, 1);
+    assert.strictEqual(result.topoDepth, 1);
+  },
+
+  'orderInvalidationsByDependencies: flat fan-out reports correct layer width':
+    async (assert) => {
+      // a depends on root; b depends on root; c depends on root.
+      // Layers: [root] (width 1) -> [a, b, c] (width 3). Depth 2.
+      let rootURL = 'http://test.localhost/root';
+      let manager = buildManager({
+        [`${rootURL}`]: { url: rootURL, type: 'file', deps: [] },
+        'http://test.localhost/a': {
+          url: 'http://test.localhost/a',
+          type: 'instance',
+          deps: [rootURL],
+        },
+        'http://test.localhost/b': {
+          url: 'http://test.localhost/b',
+          type: 'instance',
+          deps: [rootURL],
+        },
+        'http://test.localhost/c': {
+          url: 'http://test.localhost/c',
+          type: 'instance',
+          deps: [rootURL],
+        },
+      });
+      let input = urls(
+        rootURL,
+        'http://test.localhost/a',
+        'http://test.localhost/b',
+        'http://test.localhost/c',
+      );
+      let result = await manager.orderInvalidationsByDependencies(input);
+      assert.strictEqual(result.ordered.length, 4);
+      assert.strictEqual(result.ordered[0]!.href, rootURL);
+      assert.strictEqual(result.maxLayerWidth, 3);
+      assert.strictEqual(result.topoDepth, 2);
+    },
+
+  'orderInvalidationsByDependencies: linear chain reports width 1 and full depth':
+    async (assert) => {
+      // a -> b -> c -> d (each depends on the previous one).
+      // Every layer has exactly 1 node, depth 4.
+      let aURL = 'http://test.localhost/a';
+      let bURL = 'http://test.localhost/b';
+      let cURL = 'http://test.localhost/c';
+      let dURL = 'http://test.localhost/d';
+      let manager = buildManager({
+        [aURL]: { url: aURL, type: 'file', deps: [] },
+        [bURL]: { url: bURL, type: 'file', deps: [aURL] },
+        [cURL]: { url: cURL, type: 'file', deps: [bURL] },
+        [dURL]: { url: dURL, type: 'file', deps: [cURL] },
+      });
+      let result = await manager.orderInvalidationsByDependencies(
+        urls(aURL, bURL, cURL, dURL),
+      );
+      assert.strictEqual(result.ordered.length, 4);
+      assert.strictEqual(result.ordered[0]!.href, aURL);
+      assert.strictEqual(result.ordered[3]!.href, dURL);
+      assert.strictEqual(result.maxLayerWidth, 1);
+      assert.strictEqual(result.topoDepth, 4);
+    },
+
+  'orderInvalidationsByDependencies: diamond reports widest layer': async (
+    assert,
+  ) => {
+    // root -> [a, b] -> tail.
+    // Layers: [root] (1), [a, b] (2), [tail] (1). Width 2, depth 3.
+    let rootURL = 'http://test.localhost/root';
+    let aURL = 'http://test.localhost/a';
+    let bURL = 'http://test.localhost/b';
+    let tailURL = 'http://test.localhost/tail';
+    let manager = buildManager({
+      [rootURL]: { url: rootURL, type: 'file', deps: [] },
+      [aURL]: { url: aURL, type: 'instance', deps: [rootURL] },
+      [bURL]: { url: bURL, type: 'instance', deps: [rootURL] },
+      [tailURL]: { url: tailURL, type: 'instance', deps: [aURL, bURL] },
+    });
+    let result = await manager.orderInvalidationsByDependencies(
+      urls(rootURL, aURL, bURL, tailURL),
+    );
+    assert.strictEqual(result.ordered.length, 4);
+    assert.strictEqual(result.ordered[0]!.href, rootURL);
+    assert.strictEqual(result.ordered[3]!.href, tailURL);
+    assert.strictEqual(result.maxLayerWidth, 2);
+    assert.strictEqual(result.topoDepth, 3);
+  },
+} as SharedTests<unknown>);
+
+export default tests;


### PR DESCRIPTION
## Summary

Replaces the indexer's serial file-visit loop with a two-phase pipeline that produces a clean parallelism win without the self-referential prerender deadlock that bare parallelism would induce on realms with query-backed aggregator cards.

**Phase 1 — pre-warm modules table.** Before the file-visit phase starts, collect every module URL the upcoming visits will need and ensure each is present in the `modules` table. Module sub-renders run in parallel within the module queue, bypassing file admission.

**Phase 2 — bounded parallel file visits.** With the modules table populated, file renders proceed with bounded concurrency sized from the topological layer width of the invalidation graph and capped by a new `INDEX_RUNNER_MAX_CONCURRENCY` env var. No file render can fire a mid-flight module sub-prerender for a known module because phase 1 already populated the cache.

## Why this is safe

The indexer is order-independent by construction (verified by tracing — `Batch.#invalidations` is fully populated by `batch.invalidate()` inside `discoverInvalidations` before the visit loop starts, renderer-side reads go through `boxel_index` without `useWorkInProgressIndex`, per-row writes use disjoint primary keys, and the Postgres pool checks out a fresh client per query). The existing topological sort is preserved for its heuristic value — it earns its keep under parallelism because modules sort ahead of instances.

## Pre-warm signal sources

Every URL in the invalidation set contributes module URLs to the pre-warm set, in priority order:

1. **Existing `boxel_index.deps`** — the runtime-captured dep list from the URL's prior successful render. Strongest signal; used for any URL that has a row in `boxel_index_working` ∪ `boxel_index`.
2. **`adoptsFrom.module` read from disk** — used for novel `.json` URLs that don't have a prior `deps` row yet (e.g. new instance files the indexer hasn't visited before).
3. **The URL itself** — used for novel executable files (`.gts` / `.ts` / `.js` / `.gjs`); the file IS a module, pre-warm it directly.

Modules already in the cache are skipped. Misses fire `prerenderer.prerenderModule` in parallel; module sub-renders go through the module queue and never contend against the (yet-to-start) file-visit phase. Failures during pre-warm are warned but don't fail the batch — the visit phase will still fire on-demand sub-prerenders for any module that failed to pre-warm, degrading to pre-PR behavior for that specific module rather than deadlocking.

## Concurrency formula

```ts
let totalWork    = invalidations.length;
let envelopeMax  = max(1, PRERENDER_AFFINITY_TAB_MAX - 1);
let hardCap      = parseInt(INDEX_RUNNER_MAX_CONCURRENCY ?? '4', 10) || 4;

if (totalWork < 10)        return 1;   // overhead-dominated, stays serial
if (maxLayerWidth <= 2)    return 1;   // near-linear chain, parallelism can't help
return min(envelopeMax, maxLayerWidth, hardCap);
```

- **Below 10 files** → serial. Cold-tab tax exceeds parallelism payoff at that scale.
- **Linear-chain dep graphs** → serial. Extra workers would all wait on the head of the chain.
- **Otherwise** → bounded by the per-affinity envelope, the widest topological layer, and the hard cap.

The hard cap (`INDEX_RUNNER_MAX_CONCURRENCY`, default `4`) is independent of the affinity envelope. It protects the prerender fleet from being saturated by one realm's reindex.

## What `Promise.allSettled` buys us in the visit phase

The file-visit phase uses bounded `Promise.allSettled` so an unexpected throw doesn't strand in-flight visits. After all visits settle, the first rejection is re-thrown, which preserves the serial loop's "abort the batch on unexpected error" contract — `tryToVisit`'s existing 404-tolerance is unchanged.

## How each reindex flavour benefits

| Trigger | Modules-table state | Effect of phase 1 |
|---|---|---|
| Incremental on warm realm | Mostly populated | Pre-warm is trivial cache hits |
| `_reindex` (no clearLastModified) | Populated | Same — trivial |
| `_grafana-reindex` | `clearRealmCache(realm)` empties cache | Pre-warm fires serially-parallel module renders, exactly what would have happened mid-render anyway, but on our terms |
| `_grafana-full-reindex` | `clearAllModules()` | Same as above, per realm |
| First-ever from-scratch on a brand-new realm | Empty | Pre-warm uses adoptsFrom + .gts file URLs; modules table is populated before parallel `.json` phase |

The brand-new realm case benefits the most from the adoptsFrom + .gts URL pre-warm path; it goes from "all serial" (no deps signal) to "modules pre-warmed, instances parallel."

## Files

- `packages/runtime-common/index-runner/dependency-resolver.ts` — `orderInvalidationsByDependencies` now returns `{ ordered, maxLayerWidth, topoDepth }` alongside the URL list. The Kahn walk tracks each node's longest dep-chain depth as it's dequeued and reports the layer-width / depth stats.
- `packages/runtime-common/index-runner.ts`
  - New `preWarmModulesTable(invalidations)` method.
  - `fromScratch` / `incremental` visit loops replaced with `runWithBoundedConcurrency` over the topo-ordered URLs, sized via `computeIndexVisitConcurrency`.
  - New `INDEX_RUNNER_MAX_CONCURRENCY` env var.
  - Two new exported helpers: `computeIndexVisitConcurrency`, `runWithBoundedConcurrency`.
- `.claude/skills/indexing-diagnostics/SKILL.md` — documents `INDEX_RUNNER_MAX_CONCURRENCY` in the prerender-tuning-knobs table; adds an "Indexer-side visit concurrency" section covering the sizing formula, the `index-perf` debug log line the runner emits, order-independence guarantees, and the regression symptoms to watch for.

## Tests

Unit tests in `packages/runtime-common/tests/`:
- `index-runner-concurrency-test.ts` — threshold gate, linear-chain gate, layer-width cap, hard-cap, envelope cap, malformed-env fallback for `computeIndexVisitConcurrency`; empty input, mixed fulfilled/rejected results, peak-in-flight bound, `concurrency=1` (sequential), continue-past-rejection for `runWithBoundedConcurrency`.
- `index-runner-ordering-test.ts` — empty / single-URL / flat fan-out / linear chain / diamond shapes for `orderInvalidationsByDependencies`'s new `maxLayerWidth` / `topoDepth` output.

Wired into `packages/realm-server/tests/index.ts`.

## Test plan

- [x] `pnpm lint:types` clean in `@cardstack/runtime-common` and `@cardstack/realm-server`.
- [x] `pnpm lint:js` clean for files this PR touches.
- [x] Unit tests cover the sizing helpers, the concurrency primitive, and the dep-resolver layer stats.
- [ ] Full from-scratch reindex on `/prudent-octopus` (100 files) and `/ambitious-piranha` (461 files); verify no render-timeouts on aggregator cards and wall-clock improvement vs main. Numbers to be added once measured locally.
- [ ] Lower `INDEX_RUNNER_MAX_CONCURRENCY=1` and confirm the indexer respects it (wall-clock matches main, no errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)