### PR TITLE
Add measure-test-file.sh for per-file CS-10009 baselines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,15 @@
   `TEST_MODULE=card-endpoints-test.ts pnpm test-module`
 - Run a list of modules:
   `TEST_MODULES=card-endpoints-test.ts|another-module-test.ts pnpm test`
+- Run only specific test *files* (skip parsing the other ~100):
+  `TEST_FILES=sanitize-head-html-test pnpm test`
+  `TEST_FILES=realm-endpoints/invalidate-urls-test,server-endpoints/queue-status-test pnpm test`
+  Comma-separated paths relative to `tests/`, with or without `./` prefix or `.ts` suffix.
+  Use this — not `TEST_MODULES` — when measuring one file's wall time / peak RSS in isolation:
+  `TEST_MODULES` filters which modules *run*, but every file still gets parsed and required, so per-file deltas get masked by the all-files startup baseline.
+- Measure per-file wall time + peak RSS (median across N runs):
+  `./scripts/measure-test-file.sh sanitize-head-html-test [runs]`
+  Wraps `TEST_FILES` + `/usr/bin/time -l` with a clean per-file signal. Re-preps test-pg between runs. Used for before/after PR baselines on CS-10009 fixture migrations.
 - Focusing on single test or module:
   Add `.only` to module/test declaration (`test.only('returns a 201 response', ...)`)
   Then run `pnpm test`

--- a/packages/realm-server/scripts/measure-test-file.sh
+++ b/packages/realm-server/scripts/measure-test-file.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Measure wall time and peak RSS of running one (or a few) realm-server
+# test files in isolation, using the TEST_FILES env var to skip parsing
+# the other ~100 files in the suite.
+#
+# Intended for before/after comparisons across a PR: run on the merge-base,
+# run on the PR head, paste the medians into the PR body.
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  cat >&2 <<'USAGE'
+Usage: measure-test-file.sh <test-files> [runs]
+  test-files  Comma-separated paths relative to packages/realm-server/tests/,
+              with or without leading ./ or trailing .ts. Passed verbatim
+              as the TEST_FILES env var.
+  runs        Number of measurement runs (default: 5).
+
+For each run: prepares a fresh test-pg, then times one qunit invocation
+that loads only the requested test files. Reports the median wall time
+and median peak RSS across runs (plus min/max for spread).
+
+Examples:
+  measure-test-file.sh sanitize-head-html-test
+  measure-test-file.sh realm-endpoints/invalidate-urls-test 10
+  measure-test-file.sh queue-status-test,invalidate-urls-test 3
+USAGE
+  exit 1
+fi
+
+TEST_FILES_ARG="$1"
+RUNS="${2:-5}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PKG_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TEST_SCRIPTS_DIR="${PKG_DIR}/tests/scripts"
+QUNIT="${PKG_DIR}/node_modules/.bin/qunit"
+
+if [ ! -x "$QUNIT" ]; then
+  echo "qunit binary not found at $QUNIT — run \`pnpm install\` from the repo root first" >&2
+  exit 1
+fi
+
+if ! [[ "$RUNS" =~ ^[0-9]+$ ]] || [ "$RUNS" -lt 1 ]; then
+  echo "runs must be a positive integer, got: $RUNS" >&2
+  exit 1
+fi
+
+cd "$PKG_DIR"
+
+cleanup() {
+  "${TEST_SCRIPTS_DIR}/stop-test-pg.sh" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+times=()
+rss_bytes=()
+
+echo "Measuring TEST_FILES=${TEST_FILES_ARG}  (${RUNS} runs)"
+echo
+
+for i in $(seq 1 "$RUNS"); do
+  "${TEST_SCRIPTS_DIR}/prepare-test-pg.sh" >/dev/null
+
+  timing="$(mktemp)"
+  set +e
+  /usr/bin/time -l \
+    env \
+      LOG_LEVELS="*=error,prerenderer-chrome=none,pg-adapter=warn,realm:requests=warn" \
+      NODE_NO_WARNINGS=1 \
+      NODE_DISABLE_COMPILE_CACHE=1 \
+      PGPORT=55436 \
+      STRIPE_WEBHOOK_SECRET=stripe-webhook-secret \
+      STRIPE_API_KEY=stripe-api-key \
+      MATRIX_REGISTRATION_SHARED_SECRET=fake \
+      TEST_FILES="$TEST_FILES_ARG" \
+    "$QUNIT" --require ts-node/register/transpile-only tests/index.ts \
+    >/dev/null 2>"$timing"
+  qunit_status=$?
+  set -e
+
+  real=$(awk '/real/ && /user/ && /sys/ {print $1}' "$timing")
+  rss=$(awk '/maximum resident set size/ {print $1}' "$timing")
+
+  "${TEST_SCRIPTS_DIR}/stop-test-pg.sh" >/dev/null 2>&1 || true
+
+  if [ "$qunit_status" -ne 0 ] || [ -z "$real" ] || [ -z "$rss" ]; then
+    echo "  run ${i}/${RUNS}: qunit exited with status ${qunit_status}; timing output below" >&2
+    cat "$timing" >&2
+    rm -f "$timing"
+    exit 1
+  fi
+  rm -f "$timing"
+
+  times+=("$real")
+  rss_bytes+=("$rss")
+
+  rss_mb=$(awk -v b="$rss" 'BEGIN{printf "%d", b/1048576}')
+  printf "  run %d/%d:  %ss   %s MB\n" "$i" "$RUNS" "$real" "$rss_mb"
+done
+
+echo
+
+median()  { printf '%s\n' "$@" | sort -n | awk -v n=$# '{a[NR]=$1} END { if (n%2) print a[(n+1)/2]; else printf "%.3f\n", (a[n/2]+a[n/2+1])/2 }'; }
+minimum() { printf '%s\n' "$@" | sort -n | head -1; }
+maximum() { printf '%s\n' "$@" | sort -n | tail -1; }
+to_mb()   { awk -v b="$1" 'BEGIN{printf "%d", b/1048576}'; }
+
+t_med=$(median "${times[@]}")
+t_min=$(minimum "${times[@]}")
+t_max=$(maximum "${times[@]}")
+
+r_med=$(median "${rss_bytes[@]}")
+r_min=$(minimum "${rss_bytes[@]}")
+r_max=$(maximum "${rss_bytes[@]}")
+
+printf "  wall time:  median %ss   min %ss   max %ss\n" "$t_med" "$t_min" "$t_max"
+printf "  peak RSS:   median %s MB   min %s MB   max %s MB\n" \
+  "$(to_mb "$r_med")" "$(to_mb "$r_min")" "$(to_mb "$r_max")"


### PR DESCRIPTION
## Summary

Adds `packages/realm-server/scripts/measure-test-file.sh`, a small wrapper around `/usr/bin/time -l` that runs one qunit invocation N times against the new `TEST_FILES` env var (#4766) and reports the median wall time + peak RSS.

Stacked on #4766 — review that one first; this PR's base will retarget to `main` once it lands.

## Why

CS-10009 will migrate ~40 test files between `blank`/`simple`/`realistic` fixture folders. Each PR wants a before/after measurement for the files it touches. Doing that with raw `time -l pnpm test` is noisy: the pnpm + shell wrapper adds ~3s of fixed overhead and obscures the underlying qunit numbers. This script bypasses the wrapper, invokes the `qunit` binary directly, and re-preps test-pg between runs.

## Output sketch

```
$ ./scripts/measure-test-file.sh sanitize-head-html-test 3
Measuring TEST_FILES=sanitize-head-html-test  (3 runs)

  run 1/3:  2.43s   465 MB
  run 2/3:  1.65s   489 MB
  run 3/3:  1.70s   484 MB

  wall time:  median 1.70s   min 1.65s   max 2.43s
  peak RSS:   median 484 MB   min 465 MB   max 489 MB
```

## Comparison vs. `time -l pnpm test`

For the same `sanitize-head-html-test` run:

| | Wall (median) | Peak RSS (median) |
|---|---|---|
| `time -l pnpm test` | 4.88s | 493 MB |
| `measure-test-file.sh` | **1.70s** | 484 MB |

The peak RSS is unchanged (the qunit/node process is what dominates), but the wall time signal is ~3× cleaner.

## Usage

```
./scripts/measure-test-file.sh <test-files> [runs]
```

- `<test-files>`: comma-separated paths relative to `tests/`, with or without `./` or `.ts`. Passed verbatim to the `TEST_FILES` env var.
- `[runs]`: default 5.

```
./scripts/measure-test-file.sh sanitize-head-html-test
./scripts/measure-test-file.sh realm-endpoints/invalidate-urls-test 10
./scripts/measure-test-file.sh queue-status-test,invalidate-urls-test 3
```

## Test plan

- [x] Runs N times, all completing successfully, with a parseable timing block.
- [x] Handles a qunit failure by surfacing the stderr stream and exiting non-zero.
- [x] `test-pg` is prepped before each run and stopped between runs (and on EXIT/INT/TERM via trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)