### PR TITLE
De-flake 'show-card unknown submode' test against unrelated console.error calls

### DIFF
--- a/packages/host/tests/integration/commands/show-card-test.gts
+++ b/packages/host/tests/integration/commands/show-card-test.gts
@@ -489,22 +489,52 @@ module('Integration | Command | show-card', function (hooks) {
       // @ts-expect-error - intentionally setting invalid submode for testing
       mockOperatorModeStateService.state = { submode: 'unknown' };
 
-      let consoleErrorCalled = false;
+      // Pre-warm the base/command import that `execute()` performs via
+      // `getInputType()`. Without this, a transient fetch failure loading that
+      // module surfaces inside `execute()` as a `[test-fetch] ... failed:
+      // TypeError: Failed to fetch` console.error from helpers/setup.ts's fetch
+      // wrapper — which would race ahead of the 'Unknown submode:' call we are
+      // trying to verify and trip the spy on the wrong message.
+      await command.getInputType();
+
+      // Capture every console.error call rather than asserting on the first
+      // one. Other infra (notably the [test-fetch] wrapper in helpers/setup.ts)
+      // can legitimately call console.error during the run; we must filter for
+      // the specific 'Unknown submode:' message and forward the rest so test
+      // diagnostics aren't swallowed.
+      const capturedErrors: Array<{ message: unknown; args: unknown[] }> = [];
       const originalConsoleError = console.error;
-      console.error = (message: string, submode: string) => {
-        consoleErrorCalled = true;
-        assert.strictEqual(
-          message,
-          'Unknown submode:',
-          'Correct error message logged',
-        );
-        assert.strictEqual(submode, 'unknown', 'Correct submode logged');
+      console.error = (message: unknown, ...args: unknown[]) => {
+        capturedErrors.push({ message, args });
+        originalConsoleError.call(console, message, ...args);
       };
 
       try {
         await command.execute({ cardId });
 
-        assert.ok(consoleErrorCalled, 'console.error was called');
+        const unknownSubmodeError = capturedErrors.find(
+          (e) => e.message === 'Unknown submode:',
+        );
+        if (!unknownSubmodeError) {
+          // Diagnostic: dump everything that was logged so a future flake
+          // points at the colliding caller instead of just reporting an
+          // undefined expected value.
+          const summary = capturedErrors.map((e) => ({
+            message: String(e.message),
+            args: e.args.map((a) => String(a)),
+          }));
+          assert.ok(
+            false,
+            `'Unknown submode:' was not logged. Captured ${capturedErrors.length} console.error call(s): ${JSON.stringify(summary)}`,
+          );
+        } else {
+          assert.strictEqual(
+            unknownSubmodeError.args[0],
+            'unknown',
+            'Correct submode logged',
+          );
+        }
+
         assert.strictEqual(
           mockOperatorModeStateService.addedStackItems.length,
           0,


### PR DESCRIPTION
## Summary
- The test set `console.error` to a spy that asserted on the **first** call's first argument, but `helpers/setup.ts` wraps `globalThis.fetch` to call `console.error('[test-fetch] ... failed: ...')` on any transient network glitch. When `command.execute()` → `getInputType()` → `loader.import('http://localhost:4201/base/command')` hit such a glitch, the wrapper's `console.error` fired first and the spy asserted against `[test-fetch] GET ... failed: TypeError: Failed to fetch` instead of the production `'Unknown submode:'`.
- Capture every `console.error` call, find the specific `'Unknown submode:'` message in the buffer, forward all calls to the original `console.error` so QUnit's diagnostics aren't swallowed.
- Pre-warm `getInputType()` so the `base/command` import isn't on the hot path inside `execute()` — closes the most common race.
- If the expected error never lands, dump the captured calls so a future flake reveals the colliding caller instead of leaving an undefined expected value.

## Observed failure
[Run #25706484750, Host Tests (18, 20)](https://github.com/cardstack/boxel/actions/runs/25706484750/job/75477905759):
```
Expected: Unknown submode:
Result:   [test-fetch] GET http://localhost:4201/base/command failed: TypeError: Failed to fetch
```

## Test plan
- [ ] CI: `Integration | Command | show-card > unknown submode: logs error for unknown submode` passes on this branch.
- [ ] No regression in surrounding `Integration | Command | show-card` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)