### PR TITLE
ci(boxel-cli): use pnpm publish in manual release workflow

### DIFF
--- a/.github/workflows/manual-boxel-cli-publish.yml
+++ b/.github/workflows/manual-boxel-cli-publish.yml
@@ -71,9 +71,9 @@ jobs:
         working-directory: packages/boxel-cli
         run: |
           if [ "${{ inputs.environment }}" = "production" ]; then
-            npm publish --access public --provenance
+            pnpm publish --access public --provenance --no-git-checks
           else
-            npm publish --access public --provenance --tag beta
+            pnpm publish --access public --provenance --no-git-checks --tag beta
           fi
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary

- Follow-up to #4762. That PR changed `packages/boxel-cli/package.json`'s `publish:npm` script to use `pnpm publish`, but the actual release workflow at `.github/workflows/manual-boxel-cli-publish.yml` invokes `npm publish` directly — it never calls the `publish:npm` script. So the fix didn't take effect, and the freshly released `0.1.1` still has raw `catalog:` specifiers in `dependencies` (see `npm view @cardstack/boxel-cli@0.1.1 dependencies`).
- This PR switches the workflow's publish step to `pnpm publish`, which rewrites every `catalog:` specifier to its concrete version from `pnpm-workspace.yaml`'s catalog block before uploading the tarball.
- `--no-git-checks` is needed because the workflow has already committed the version bump and tag at the point publish runs; pnpm would otherwise refuse over the local commit.

## Test plan

- [ ] After merging, run the manual workflow with `patch` + `staging`. Expected: bump to `0.1.2`, beta tag.
- [ ] Verify `npm view @cardstack/boxel-cli@beta dependencies` — should show concrete versions (e.g. `"ignore": "^5.x.x"`), no `catalog:` strings.
- [ ] Smoke test: \`npm install -g @cardstack/boxel-cli@beta && boxel --version\` succeeds.
- [ ] Re-run workflow with `patch` + `production` to publish `@latest`.
- [ ] Re-run the boxel-catalog sync-to-staging workflow — the \`Install boxel-cli\` step should succeed.

Note: `0.1.1` on npm stays as a known-bad release on the `beta` tag. Unpublishing is intentionally avoided (npm restricts removal after 72h and it would invalidate the version number for anyone who already resolved it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)