### PR TITLE
Phase 1: coalesce concurrent searchCards calls (in-flight dedup)

### DIFF
--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -251,6 +251,7 @@ const ALL_TEST_FILES: string[] = [
   './command-parsing-utils-test',
   './query-matches-filter-test',
   './matches-filter-integration-test',
+  './search-in-flight-key-test',
   './delete-boxel-claimed-domain-test',
   './realm-auth-test',
   './queries-test',

--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -521,6 +521,56 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
             'firstName attribute is present',
           );
         });
+
+        test('coalesces concurrent searchCards calls with identical query+opts', async function (assert) {
+          let q = buildPersonQuery('Mango');
+          let [a, b] = await Promise.all([
+            testRealm.realmIndexQueryEngine.searchCards(q, {
+              loadLinks: true,
+            }),
+            testRealm.realmIndexQueryEngine.searchCards(q, {
+              loadLinks: true,
+            }),
+          ]);
+          assert.strictEqual(
+            a,
+            b,
+            'concurrent identical calls share the same resolved doc instance',
+          );
+        });
+
+        test('does not coalesce when filter differs', async function (assert) {
+          let [a, b] = await Promise.all([
+            testRealm.realmIndexQueryEngine.searchCards(
+              buildPersonQuery('Mango'),
+              { loadLinks: true },
+            ),
+            testRealm.realmIndexQueryEngine.searchCards(
+              buildPersonQuery('does-not-exist'),
+              { loadLinks: true },
+            ),
+          ]);
+          assert.notStrictEqual(
+            a,
+            b,
+            'concurrent calls with different filters produce independent results',
+          );
+        });
+
+        test('cleans up in-flight slot after settlement (sequential calls produce fresh results)', async function (assert) {
+          let q = buildPersonQuery('Mango');
+          let a = await testRealm.realmIndexQueryEngine.searchCards(q, {
+            loadLinks: true,
+          });
+          let b = await testRealm.realmIndexQueryEngine.searchCards(q, {
+            loadLinks: true,
+          });
+          assert.notStrictEqual(
+            a,
+            b,
+            'a sequential call after settlement produces a fresh doc (slot was released)',
+          );
+        });
       });
 
       module('fields-based link loading', function (hooks) {

--- a/packages/realm-server/tests/search-in-flight-key-test.ts
+++ b/packages/realm-server/tests/search-in-flight-key-test.ts
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { runSharedTest } from '@cardstack/runtime-common/helpers';
+import searchInFlightKeyTests from '@cardstack/runtime-common/tests/search-in-flight-key-test';
+
+module(basename(__filename), function () {
+  module('searchInFlightKey', function () {
+    test('same query + opts produce the same key', async function (assert) {
+      await runSharedTest(searchInFlightKeyTests, assert, {});
+    });
+
+    test('key is invariant under input property order', async function (assert) {
+      await runSharedTest(searchInFlightKeyTests, assert, {});
+    });
+
+    test('different filters produce different keys', async function (assert) {
+      await runSharedTest(searchInFlightKeyTests, assert, {});
+    });
+
+    test('different realm URLs produce different keys', async function (assert) {
+      await runSharedTest(searchInFlightKeyTests, assert, {});
+    });
+
+    test('undefined opts vs empty-equivalent opts produce different keys', async function (assert) {
+      await runSharedTest(searchInFlightKeyTests, assert, {});
+    });
+
+    test('different linkFields produce different keys', async function (assert) {
+      await runSharedTest(searchInFlightKeyTests, assert, {});
+    });
+
+    test('pagination differences produce different keys', async function (assert) {
+      await runSharedTest(searchInFlightKeyTests, assert, {});
+    });
+  });
+});

--- a/packages/realm-server/tests/search-in-flight-key-test.ts
+++ b/packages/realm-server/tests/search-in-flight-key-test.ts
@@ -21,7 +21,11 @@ module(basename(__filename), function () {
       await runSharedTest(searchInFlightKeyTests, assert, {});
     });
 
-    test('undefined opts vs empty-equivalent opts produce different keys', async function (assert) {
+    test('different opts shapes produce different keys', async function (assert) {
+      await runSharedTest(searchInFlightKeyTests, assert, {});
+    });
+
+    test('undefined opts and empty-object opts produce different keys', async function (assert) {
       await runSharedTest(searchInFlightKeyTests, assert, {});
     });
 

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -36,7 +36,12 @@ import type {
   RealmResourceIdentifier,
   RealmIdentifier,
 } from './card-reference-resolver';
-import type { Filter, Query } from './query';
+import {
+  normalizeQueryForSignature,
+  sortKeysDeep,
+  type Filter,
+  type Query,
+} from './query';
 import { CardError, type SerializedError } from './error';
 import {
   isCodeRef,
@@ -117,6 +122,23 @@ type QueryFieldErrorDetail = {
   status?: number;
 };
 
+// Stable digest key for searchCards in-flight dedup. Returns undefined if
+// the inputs can't be serialized deterministically — caller falls back to
+// running uncoalesced so dedup is best-effort, never a correctness boundary.
+export function searchInFlightKey(
+  realmURL: string,
+  query: Query,
+  opts: Options | undefined,
+): string | undefined {
+  try {
+    let queryDigest = JSON.stringify(normalizeQueryForSignature(query));
+    let optsDigest = opts ? JSON.stringify(sortKeysDeep(opts)) : '';
+    return `${realmURL}|${queryDigest}|${optsDigest}`;
+  } catch {
+    return undefined;
+  }
+}
+
 function absolutizeInstanceURL(
   url: string,
   resourceId: string | undefined,
@@ -140,6 +162,23 @@ export class RealmIndexQueryEngine {
   #indexQueryEngine: IndexQueryEngine;
   #definitionLookup: DefinitionLookup;
   #log = logger('realm:index-query-engine');
+  // In-flight dedup for searchCards: concurrent callers asking for the same
+  // (realm, query, opts) share one in-flight promise instead of each running
+  // an independent SQL + loadLinks walk.
+  //
+  // Safety: this layer is user-agnostic. Per-realm read authorization is
+  // enforced by realm-server middleware (multiRealmAuthorization) BEFORE the
+  // request reaches Realm.search → searchCards; once we're here, every
+  // authorized caller for the same (realm, query, opts) is entitled to the
+  // same bytes. The key intentionally omits caller identity. If per-card
+  // visibility-by-user is ever added at this layer, this key must grow to
+  // include the caller's identity, or the dedup must be moved up the stack
+  // to where auth-equivalence is established.
+  //
+  // The shared resolved document is treated as read-only by all callers
+  // (Realm.search → JSON.stringify → HTTP response). Do not mutate the
+  // returned doc.
+  #inFlightSearch = new Map<string, Promise<LinkableCollectionDocument>>();
 
   constructor({
     realm,
@@ -169,6 +208,31 @@ export class RealmIndexQueryEngine {
   }
 
   async searchCards(
+    query: Query,
+    opts?: Options,
+  ): Promise<LinkableCollectionDocument> {
+    let key = searchInFlightKey(this.#realm.url, query, opts);
+    if (key !== undefined) {
+      let existing = this.#inFlightSearch.get(key);
+      if (existing) {
+        return await existing;
+      }
+      let pending = this.searchCardsUncoalesced(query, opts).finally(() => {
+        // Identity-check before deletion: a concurrent invalidation path
+        // could in principle replace the entry. Only clean up if the map
+        // still points at *this* pending promise. Mirrors
+        // CachingDefinitionLookup#inFlight.
+        if (this.#inFlightSearch.get(key) === pending) {
+          this.#inFlightSearch.delete(key);
+        }
+      });
+      this.#inFlightSearch.set(key, pending);
+      return await pending;
+    }
+    return await this.searchCardsUncoalesced(query, opts);
+  }
+
+  private async searchCardsUncoalesced(
     query: Query,
     opts?: Options,
   ): Promise<LinkableCollectionDocument> {

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -130,10 +130,15 @@ export function searchInFlightKey(
   query: Query,
   opts: Options | undefined,
 ): string | undefined {
+  // Encode the tuple as a JSON array (not a delimited string) so user-supplied
+  // values inside query/opts — e.g. a `matches: 'a|b'` string — can never
+  // collide with the delimiter and cause unrelated searches to coalesce.
   try {
-    let queryDigest = JSON.stringify(normalizeQueryForSignature(query));
-    let optsDigest = opts ? JSON.stringify(sortKeysDeep(opts)) : '';
-    return `${realmURL}|${queryDigest}|${optsDigest}`;
+    return JSON.stringify([
+      realmURL,
+      normalizeQueryForSignature(query),
+      opts ? sortKeysDeep(opts) : null,
+    ]);
   } catch {
     return undefined;
   }
@@ -179,6 +184,23 @@ export class RealmIndexQueryEngine {
   // (Realm.search → JSON.stringify → HTTP response). Do not mutate the
   // returned doc.
   #inFlightSearch = new Map<string, Promise<LinkableCollectionDocument>>();
+
+  // Drop every pending in-flight entry. Callers that registered before the
+  // drop continue to await their existing promise (the underlying SQL was
+  // already in motion); only *new* callers after the drop will miss the map
+  // and fire a fresh search against the now-current index. Wire this to any
+  // event that means "boxel_index has just moved" — typically a worker's
+  // batch.done() swap reaching this realm-server process.
+  //
+  // The clear is local-process only. Cross-process invalidation (peer
+  // realm-server replicas serving live `_search` while a different worker
+  // commits a swap) is closed by Phase 2's NOTIFY-driven eviction. Within a
+  // single process — which covers dev, single-instance deployments, and the
+  // realm-server-drives-its-own-indexing path — this method closes the
+  // post-swap-staleness window.
+  clearInFlightSearch(): void {
+    this.#inFlightSearch.clear();
+  }
 
   constructor({
     realm,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1082,6 +1082,11 @@ export class Realm {
       ...(opts?.delete ? { delete: true } : {}),
       clientRequestId: opts?.clientRequestId ?? null,
       onInvalidation: async (invalidatedURLs: URL[]) => {
+        // Drop the searchCards in-flight map: the worker's batch.done()
+        // swap landed in this realm's boxel_index, so any pending
+        // pre-swap promises must not be coalesced into by post-swap
+        // callers.
+        this.#realmIndexQueryEngine.clearInFlightSearch();
         await this.handleExecutableInvalidations(invalidatedURLs);
         for (let invalidatedURL of invalidatedURLs) {
           invalidations.add(invalidatedURL.href);
@@ -1126,6 +1131,7 @@ export class Realm {
       ...(opts?.delete ? { delete: true } : {}),
       clientRequestId: opts?.clientRequestId ?? null,
       onInvalidation: async (invalidatedURLs: URL[]) => {
+        this.#realmIndexQueryEngine.clearInFlightSearch();
         await this.handleExecutableInvalidations(invalidatedURLs);
         for (let invalidatedURL of invalidatedURLs) {
           invalidations.add(invalidatedURL.href);
@@ -1250,6 +1256,9 @@ export class Realm {
       { clearLastModified: opts?.clearLastModified },
     );
     await completed;
+    // Drop searchCards in-flight entries — the from-scratch swap has
+    // landed in boxel_index, so any pre-swap promise must not be reused.
+    this.#realmIndexQueryEngine.clearInFlightSearch();
     this.invalidateCachedRealmInfo();
   }
 

--- a/packages/runtime-common/tests/search-in-flight-key-test.ts
+++ b/packages/runtime-common/tests/search-in-flight-key-test.ts
@@ -1,0 +1,105 @@
+import type { RealmResourceIdentifier } from '../card-reference-resolver';
+import type { SharedTests } from '../helpers';
+import type { Query } from '../query';
+import { searchInFlightKey } from '../realm-index-query-engine';
+
+const realmURL = 'http://localhost:4201/test/';
+
+const personRef = {
+  module: 'http://localhost:4201/test/person' as RealmResourceIdentifier,
+  name: 'Person',
+};
+
+const baseQuery: Query = {
+  filter: {
+    on: personRef,
+    eq: { firstName: 'Mango' },
+  },
+};
+
+const tests = Object.freeze({
+  'same query + opts produce the same key': async (assert) => {
+    let a = searchInFlightKey(realmURL, baseQuery, { loadLinks: true });
+    let b = searchInFlightKey(realmURL, baseQuery, { loadLinks: true });
+    assert.strictEqual(a, b);
+  },
+
+  'key is invariant under input property order': async (assert) => {
+    let q1: Query = {
+      filter: {
+        on: personRef,
+        eq: { firstName: 'Mango', lastName: 'Abdel-Rahman' },
+      },
+    };
+    let q2: Query = {
+      filter: {
+        eq: { lastName: 'Abdel-Rahman', firstName: 'Mango' },
+        on: {
+          name: 'Person',
+          module:
+            'http://localhost:4201/test/person' as RealmResourceIdentifier,
+        },
+      },
+    };
+    assert.strictEqual(
+      searchInFlightKey(realmURL, q1, undefined),
+      searchInFlightKey(realmURL, q2, undefined),
+    );
+  },
+
+  'different filters produce different keys': async (assert) => {
+    let other: Query = {
+      filter: {
+        on: personRef,
+        eq: { firstName: 'Vango' },
+      },
+    };
+    assert.notStrictEqual(
+      searchInFlightKey(realmURL, baseQuery, undefined),
+      searchInFlightKey(realmURL, other, undefined),
+    );
+  },
+
+  'different realm URLs produce different keys': async (assert) => {
+    assert.notStrictEqual(
+      searchInFlightKey(realmURL, baseQuery, undefined),
+      searchInFlightKey('http://localhost:4201/other/', baseQuery, undefined),
+    );
+  },
+
+  'undefined opts vs empty-equivalent opts produce different keys': async (
+    assert,
+  ) => {
+    // undefined opts → '' digest; {loadLinks:true} → non-empty digest.
+    // This is deliberate — callers passing different opts shapes should not
+    // coalesce, even if those shapes happen to produce the same result.
+    assert.notStrictEqual(
+      searchInFlightKey(realmURL, baseQuery, undefined),
+      searchInFlightKey(realmURL, baseQuery, { loadLinks: true }),
+    );
+  },
+
+  'different linkFields produce different keys': async (assert) => {
+    assert.notStrictEqual(
+      searchInFlightKey(realmURL, baseQuery, {
+        loadLinks: true,
+        linkFields: ['friends'],
+      }),
+      searchInFlightKey(realmURL, baseQuery, {
+        loadLinks: true,
+        linkFields: ['family'],
+      }),
+    );
+  },
+
+  'pagination differences produce different keys': async (assert) => {
+    let p1: Query = { ...baseQuery, page: { number: 0, size: 10 } };
+    let p2: Query = { ...baseQuery, page: { number: 1, size: 10 } };
+    assert.notStrictEqual(
+      searchInFlightKey(realmURL, p1, undefined),
+      searchInFlightKey(realmURL, p2, undefined),
+    );
+  },
+} as SharedTests<{}>);
+
+export default tests;

--- a/packages/runtime-common/tests/search-in-flight-key-test.ts
+++ b/packages/runtime-common/tests/search-in-flight-key-test.ts
@@ -67,15 +67,25 @@ const tests = Object.freeze({
     );
   },
 
-  'undefined opts vs empty-equivalent opts produce different keys': async (
-    assert,
-  ) => {
-    // undefined opts → '' digest; {loadLinks:true} → non-empty digest.
-    // This is deliberate — callers passing different opts shapes should not
-    // coalesce, even if those shapes happen to produce the same result.
+  'different opts shapes produce different keys': async (assert) => {
+    // Callers passing different opts shapes should not coalesce.
     assert.notStrictEqual(
       searchInFlightKey(realmURL, baseQuery, undefined),
       searchInFlightKey(realmURL, baseQuery, { loadLinks: true }),
+    );
+  },
+
+  'undefined opts and empty-object opts produce different keys': async (
+    assert,
+  ) => {
+    // The key intentionally distinguishes `undefined` (no opts at all) from
+    // `{}` (opts object with no flags set). They semantically behave the same
+    // inside searchCards, but keeping them distinct keys avoids any future
+    // surprise if the two shapes ever diverge — coalescing only happens for
+    // callers passing literally the same opts.
+    assert.notStrictEqual(
+      searchInFlightKey(realmURL, baseQuery, undefined),
+      searchInFlightKey(realmURL, baseQuery, {}),
     );
   },
 


### PR DESCRIPTION
## Summary

- Wraps `RealmIndexQueryEngine.searchCards` with an in-flight `Map` keyed by `(realm-url, normalized query, normalized opts)`. Concurrent callers asking for the same search share one underlying SQL + `loadLinks` walk; the entry self-evicts via identity-checked `.finally()` (same shape as `CachingDefinitionLookup#inFlight`).
- The key intentionally omits caller identity. Per-realm read authorization is enforced by `multiRealmAuthorization` middleware **before** the request reaches `Realm.search → searchCards`; once we're at this layer every authorized caller for the same `(realm, query, opts)` is entitled to the same bytes. A code comment locks in this safety invariant — if per-card visibility-by-user is ever added at this layer the key must grow.
- Phase 1 of [CS-11115](https://linear.app/cardstack/issue/CS-11115). Phase 2 (job-scoped same-realm cache that absorbs *sequential* duplicates within a single render) lands as a child PR on top of this branch.

## Bench (local, vite-dev host)

| Realm | Variant | Wall | fed-search hits | Notes |
| --- | --- | ---: | ---: | --- |
| `user/prudent-octopus` (~100 cards) | main | 668 s | 249 | 1 instanceError short-circuited part of the walk |
| `user/prudent-octopus` | **Phase 1** | **226 s** | 390 | clean run, full fan-out fires |
| `user/ambitious-piranha` (~461 cards) | main | 179 s | 18 | rejected — single prerender > 150 s on a heavy cohort |
| `user/ambitious-piranha` | Phase 1 | 168 s | 18 | same rejection point (sequential, not concurrent — Phase 2 territory) |

**Octopus: −66 % wall-clock.** Fed-search HTTP count rose because the previously-errored instance now succeeds and fires its full fan-out; coalescing happens *inside* `searchCards` so the per-HTTP count is mostly orthogonal to the savings. Piranha is unchanged on this rig — its rejection is a single-card prerender stall on vite-dev that this dedup can't help with (no concurrent overlap), and is expected to shift with Phase 2 or a prod-built host.

Caveat: vite-dev runs ~3.5× slower than the prod-built rig that produced the ticket's quoted baselines (190 s octopus, ~585 s piranha). Absolute numbers aren't comparable to the ticket; the same-rig delta across Main → Phase 1 is the load-bearing signal.

## Tests

- New `searchInFlightKey` unit tests (`packages/runtime-common/tests/search-in-flight-key-test.ts`) wired into the realm-server qunit runner. Cover: same query → same key, sort-key invariance, different filter → different key, different realm URL, opts shape variance, `linkFields` variance, pagination variance.
- New integration tests in `packages/realm-server/tests/realm-endpoints/search-test.ts`: concurrent identical calls share the resolved doc instance; concurrent different filters get independent results; sequential calls after settlement get fresh results (slot cleanup).

## Test plan

- [ ] CI runs the new `searchInFlightKey` unit tests + the three new integration cases under `realm-endpoints/search-test.ts` (the local stack's Chrome resources conflicted with the test stack's puppeteer standby pool, so the integration tests are validated by CI rather than locally).
- [ ] CI realm-perf bench job stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up: horizontal scaling

[CS-11119](https://linear.app/cardstack/issue/CS-11119) tracks the cleanup that makes this dedup survive horizontal scaling under the [DB-Authoritative Realm Registry](https://linear.app/cardstack/project/db-authoritative-realm-registry-39806e82c7c6) project. The `#inFlightSearch` map in this PR is single-process; with multi-replica deployments each replica dedupes only its own concurrent callers. That's still a real win per-replica and correctness holds (entries are short-lived and force-cleared on swap), but the cross-replica staleness window deserves a closer look once the registry's NOTIFY/reconcile infrastructure is live — at which point we may also drive `clearInFlightSearch` off that channel.
