### PR TITLE
fix(boxel-cli): release semaphore before recursing in getRemoteFileList

### DIFF
--- a/packages/boxel-cli/src/lib/realm-sync-base.ts
+++ b/packages/boxel-cli/src/lib/realm-sync-base.ts
@@ -125,11 +125,13 @@ export abstract class RealmSyncBase {
     try {
       const url = this.buildDirectoryUrl(dir);
 
-      const response = await this.authenticator.authedRealmFetch(url, {
-        headers: {
-          Accept: 'application/vnd.api+json',
-        },
-      });
+      const response = await this.remoteLimit(() =>
+        this.authenticator.authedRealmFetch(url, {
+          headers: {
+            Accept: 'application/vnd.api+json',
+          },
+        }),
+      );
 
       if (!response.ok) {
         if (response.status === 404) {
@@ -167,10 +169,10 @@ export abstract class RealmSyncBase {
               }
               return [] as Array<[string, boolean]>;
             } else {
-              return this.remoteLimit(async () => {
+              return (async () => {
                 const subdirFiles = await this.getRemoteFileList(entryPath);
                 return Array.from(subdirFiles.entries());
-              });
+              })();
             }
           }),
         );


### PR DESCRIPTION
## Summary
- `getRemoteFileList` wrapped its recursive subdirectory walks in the same `pLimit(10)` semaphore that gated the directory-listing fetch. When a realm's root `Promise.all` fanned out to >10 subdirectory walks, every slot ended up held by a parent waiting on a child that could never acquire one — classic semaphore-recursion deadlock. The Promise never settled, the event loop drained, and the process exited 0 silently (no error event fired). In CI this masqueraded as a successful `boxel realm push`, while EFS-side realm content silently stayed stale.
- Move the semaphore to wrap the fetch only, so slots are released before recursion proceeds. Effective concurrency cap on directory listings is preserved.
- Other `remoteLimit` usages in `pull.ts` / `sync.ts` are flat per-file ops (download / delete) — no recursion, no deadlock risk, unchanged.

## How it was found
The boxel-catalog `Sync to Workspace` workflow reported success on recent run while doing nothing — `boxel realm push` was exiting 0 after only printing `Testing realm access...`. Local repro with debug logs showed `getRemoteFileList` returning successfully for every level-1 subdirectory but never recursing into level-2 dirs that had children, with no exception thrown and no `unhandledRejection` event.
<img width="1055" height="204" alt="Screenshot 2026-05-12 at 10 51 27 PM" src="https://github.com/user-attachments/assets/6e228340-f4c6-491a-993b-04e2df0e9f60" />



## Test plan
- [x] `pnpm --filter @cardstack/boxel-cli build` succeeds.
- [x] Manual: `boxel realm push <local-dir> <staging-catalog-url> --delete --realm-secret-seed` against a realm with multi-level directory structure recurses fully and reaches `Realm access verified` + `Uploading N file(s)...`.

<img width="1003" height="326" alt="Screenshot 2026-05-12 at 10 50 50 PM" src="https://github.com/user-attachments/assets/4b62821e-c718-490f-acdf-f9260f17df27" />


