### PR TITLE
realm-server: opt-in HTTP/2 for faster local indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ For a quickstart, see [here](./QUICKSTART.md)
 
 Two catalog realms run side by side. The **Cardstack Catalog** (served from [cardstack/boxel-catalog](https://github.com/cardstack/boxel-catalog)) is the source of truth for new development and the destination for community submissions. The **Legacy Catalog** (shipped from this monorepo) remains available during the deprecation window for content that hasn't been migrated upstream.
 
-| Realm                  | Source                                                                                  | URL path           | Purpose                                                                                                                          |
-| ---------------------- | --------------------------------------------------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| **Cardstack Catalog**  | `packages/catalog` (clones [boxel-catalog](https://github.com/cardstack/boxel-catalog)) | `/catalog/`        | Official catalog. New listings and community submissions land here via `pr-listing-create` PRs to `cardstack/boxel-catalog`.     |
-| **Legacy Catalog**     | `packages/catalog-realm`                                                                | `/legacy-catalog/` | Historical catalog shipped from this repo. Kept visible in the workspace chooser while existing content migrates upstream.       |
+| Realm                 | Source                                                                                  | URL path           | Purpose                                                                                                                      |
+| --------------------- | --------------------------------------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| **Cardstack Catalog** | `packages/catalog` (clones [boxel-catalog](https://github.com/cardstack/boxel-catalog)) | `/catalog/`        | Official catalog. New listings and community submissions land here via `pr-listing-create` PRs to `cardstack/boxel-catalog`. |
+| **Legacy Catalog**    | `packages/catalog-realm`                                                                | `/legacy-catalog/` | Historical catalog shipped from this repo. Kept visible in the workspace chooser while existing content migrates upstream.   |
 
 Both catalogs appear in the workspace chooser by default; the Cardstack Catalog is sorted first, Legacy Catalog last. Both are controlled by the same `SKIP_CATALOG` flag — setting `SKIP_CATALOG=true` skips setup and startup for both.
 
@@ -195,6 +195,8 @@ Here's what is spun up with `mise run dev`:
 | :4201 | `/skills` skills realm                                                                        | ✅             | 🚫                                    |
 | :4201 | `/experiments` experiments realm                                                              | ✅             | 🚫                                    |
 | :4202 | `/test` host test realm, `/node-test` node test realm                                         | ✅             | 🚫                                    |
+| :4203 | HTTPS/HTTP-2 alias for the :4201 realm-server (opt-in — see "HTTP/2 dev access" below)        | 🟡             | 🟡                                    |
+| :4204 | HTTPS/HTTP-2 alias for the :4202 test realm-server (opt-in — see "HTTP/2 dev access" below)   | 🟡             | 🚫                                    |
 | :4205 | `/test` realm for matrix client tests (playwright controlled)                                 | 🚫             | 🚫                                    |
 | :4206 | Boxel icons server                                                                            | ✅             | 🚫                                    |
 | :4210 | Development Worker Manager (spins up 1 worker by default)                                     | ✅             | 🚫                                    |
@@ -206,6 +208,105 @@ Here's what is spun up with `mise run dev`:
 | :5001 | Mail user interface for viewing emails sent to local SMTP                                     | ✅             | 🚫                                    |
 | :5435 | Postgres DB                                                                                   | ✅             | 🚫                                    |
 | :8008 | Matrix synapse server                                                                         | ✅             | 🚫                                    |
+
+#### HTTP/2 dev access
+
+##### Why this exists
+
+Heavy aggregator cards (Cohort, dashboards) fan out 80+ federated-search
+requests per render. Chrome — including the headless Chromium driving
+the prerender — caps any single origin at 6 concurrent HTTP/1.1 connections,
+so the 80+ requests serialize. A single cohort render takes ~4–5 minutes
+under that ceiling. HTTP/2 multiplexes them over one connection and the
+same render finishes in seconds.
+
+Browsers only do HTTP/2 over TLS, so the realm-server has to terminate a
+cert. We don't want a cert-management story to land in everyone's PATH,
+so HTTP/2 in local dev is **opt-in via one mise task**.
+
+##### Opting in
+
+```
+mise run infra:ensure-dev-cert
+```
+
+That task:
+
+1. Generates a leaf cert at `~/.local/share/boxel/dev-certs/localhost.pem`
+   using [`mkcert`](https://github.com/FiloSottile/mkcert) (install with
+   `sudo apt install -y mkcert libnss3-tools` on Debian/Ubuntu or
+   `brew install mkcert nss` on macOS — the task prints these
+   instructions and exits cleanly if mkcert is missing).
+2. Is idempotent: re-running is a no-op until the cert is within 7 days
+   of expiry.
+3. Does **not** require sudo. The cert is signed by a CA that mkcert
+   keeps in your user data dir; it is not added to the system trust
+   store.
+
+After provisioning, your next `mise run dev` (or `mise run dev-all`)
+will bring up two extra listeners alongside the existing HTTP/1.1
+servers:
+
+- `https://localhost:4203` — h2 alias for `http://localhost:4201`
+- `https://localhost:4204` — h2 alias for `http://localhost:4202`
+
+The h2 endpoints serve the exact same content as their HTTP/1.1 peers —
+they are aliases, not separate realms. A request hitting `:4203` is
+rewritten internally so URL-keyed realm lookup matches the canonical
+`:4201` mounts.
+
+##### What automatically uses HTTP/2
+
+- The prerender service's Chromium pages. They get
+  `--ignore-certificate-errors` plus a `window.__realmH2OriginMappings__`
+  override that tells the host's `VirtualNetwork` to re-route realm
+  fetches from `http://localhost:4201/…` → `https://localhost:4203/…`
+  (and `:4202` → `:4204`). Canonical card URLs are unchanged in card
+  data; only the wire fetch is rewritten.
+- The test-realms server's indexer (via the same shared prerender).
+
+##### What stays on HTTP/1.1
+
+- Your terminal `curl http://localhost:4201/_alive` and other scripts —
+  unchanged.
+- Your manual browser when you visit `http://localhost:4200/…` — that
+  page (and its fetches to `:4201`) continue using HTTP/1.1, so you do
+  _not_ need to trust the cert to keep your daily workflow working.
+
+##### Optional: trust the cert for your own browser
+
+If you want HTTP/2 to also speed up cards you load manually (visiting
+`https://localhost:4203/…` directly), run **once**:
+
+```
+mkcert -install      # one-time, requires sudo
+```
+
+That adds mkcert's root CA to your system trust store so Chrome stops
+warning about the self-signed cert. Your bookmarks stay
+`http://localhost:4201`/`:4200` — the install just unlocks the option
+of visiting the `:4203` alias without click-throughs.
+
+##### Verifying HTTP/2 is live
+
+```
+curl -kI --http2 https://localhost:4203/_alive
+```
+
+Look for `HTTP/2 200`. The dev `mise run dev` log line `Realm server
+listening on port 4203 (https/h2 alias)` also confirms the listener
+came up.
+
+##### Opting out
+
+Delete the cert dir or unset the env vars:
+
+```
+rm -rf ~/.local/share/boxel/dev-certs
+```
+
+The next `mise run dev` reverts to HTTP/1.1-only and indexing falls
+back to the slow serial path for heavy aggregator cards.
 
 #### Using `mise run services:realm-server`
 
@@ -610,12 +711,12 @@ BOXEL_ENVIRONMENT=parallel mise run services:ai-bot
 
 In environment mode, services are available at:
 
-| Service       | Hostname                                  |
-| ------------- | ----------------------------------------- |
-| Host app      | `http://host.<slug>.localhost`            |
-| Realm server  | `http://realm-server.<slug>.localhost`    |
-| Matrix        | `http://matrix.<slug>.localhost`          |
-| Icons         | `http://icons.<slug>.localhost`           |
+| Service      | Hostname                               |
+| ------------ | -------------------------------------- |
+| Host app     | `http://host.<slug>.localhost`         |
+| Realm server | `http://realm-server.<slug>.localhost` |
+| Matrix       | `http://matrix.<slug>.localhost`       |
+| Icons        | `http://icons.<slug>.localhost`        |
 
 Where `<slug>` is the lowercased, sanitized form of `BOXEL_ENVIRONMENT` (e.g., `feature/my-branch` becomes `feature-my-branch`).
 

--- a/mise-tasks/infra/ensure-dev-cert
+++ b/mise-tasks/infra/ensure-dev-cert
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#MISE description="Provision a local dev cert so realm-server can serve HTTPS/HTTP-2"
+#
+# Generates ~/.local/share/boxel/dev-certs/{localhost.pem, localhost-key.pem}
+# using mkcert. Idempotent — re-runs are a no-op if the cert already exists
+# and isn't near expiry.
+#
+# Why: indexing fans out 80+ federated-search requests per heavy aggregator
+# card render. Chrome's HTTP/1.1 per-origin connection limit (6) serializes
+# them and turns a single cohort render into ~4–5 minutes. HTTP/2 multiplexes
+# them over one connection, dropping the same render to seconds. Browsers
+# only do HTTP/2 over TLS, so realm-server needs a cert.
+#
+# Note: this script does NOT run `mkcert -install`. That step adds mkcert's
+# root CA to the system trust store and requires sudo. It's only needed if
+# you want YOUR manual browser sessions (visiting https://localhost:4203
+# directly) to trust the cert without a warning. The prerenderer and the
+# test-harness indexer don't need it — they launch Chromium with
+# `--ignore-certificate-errors`. The hint at the end of this script shows
+# how to opt in.
+
+set -euo pipefail
+
+CERT_DIR="${BOXEL_DEV_CERT_DIR:-$HOME/.local/share/boxel/dev-certs}"
+CERT_FILE="$CERT_DIR/localhost.pem"
+KEY_FILE="$CERT_DIR/localhost-key.pem"
+
+# Idempotent skip when the cert already exists and isn't within 7 days of
+# expiry. openssl's `-checkend` returns 0 if the cert is valid for at least
+# the given number of seconds.
+if [ -f "$CERT_FILE" ] && [ -f "$KEY_FILE" ]; then
+  if openssl x509 -in "$CERT_FILE" -checkend $((7 * 24 * 60 * 60)) -noout >/dev/null 2>&1; then
+    exit 0
+  fi
+  echo "[ensure-dev-cert] Existing cert at $CERT_FILE is near expiry; regenerating."
+fi
+
+if ! command -v mkcert >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+[ensure-dev-cert] mkcert is required but not installed.
+
+Install one of:
+  Linux (Debian/Ubuntu): sudo apt install -y mkcert libnss3-tools
+  Linux (Fedora/RHEL):   sudo dnf install -y mkcert nss-tools
+  macOS (Homebrew):      brew install mkcert nss
+
+Then re-run `mise run infra:ensure-dev-cert` (or just `mise run dev`).
+
+Why mkcert is needed: it provisions a self-signed cert so realm-server can
+speak HTTP/2 on https://localhost:4203. Without it, indexing falls back to
+HTTP/1.1 and aggregator-card renders (cohort, dashboards) get throttled by
+Chrome's 6-per-origin connection cap. See packages/realm-server/README.md
+for the full HTTP/2 dev access guide.
+EOF
+  exit 1
+fi
+
+mkdir -p "$CERT_DIR"
+
+echo "[ensure-dev-cert] Generating cert at $CERT_FILE"
+mkcert \
+  -cert-file "$CERT_FILE" \
+  -key-file "$KEY_FILE" \
+  localhost 127.0.0.1 ::1
+
+if ! mkcert -CAROOT >/dev/null 2>&1; then
+  # mkcert prints CAROOT to stdout; the check above only confirms the binary
+  # works. If a CA root doesn't exist yet on this machine, the cert above
+  # will still have been generated against a freshly created root in mkcert's
+  # own data dir — it just isn't installed into the system trust store.
+  :
+fi
+
+cat <<EOF
+[ensure-dev-cert] Cert provisioned. After your next `mise run dev`, the
+realm-server will accept HTTP/2 on https://localhost:4203 in addition to
+the existing HTTP/1.1 on http://localhost:4201.
+
+The prerenderer and test-harness indexer always use the HTTP/2 alias
+(automatic). If you also want YOUR browser to trust the cert without a
+warning when visiting https://localhost:4203 directly, run:
+
+  mkcert -install      # one-time, requires sudo
+EOF

--- a/mise-tasks/infra/ensure-dev-cert
+++ b/mise-tasks/infra/ensure-dev-cert
@@ -37,22 +37,21 @@ fi
 
 if ! command -v mkcert >/dev/null 2>&1; then
   cat >&2 <<'EOF'
-[ensure-dev-cert] mkcert is required but not installed.
+[ensure-dev-cert] mkcert not installed — skipping HTTP/2 cert provisioning.
+The realm-server will boot HTTP/1.1-only; indexing falls back to the slow
+serial path for heavy aggregator cards. This is a soft warning, not an
+error — `mise run dev` continues normally.
 
-Install one of:
+To enable HTTP/2, install mkcert and re-run this task:
   Linux (Debian/Ubuntu): sudo apt install -y mkcert libnss3-tools
   Linux (Fedora/RHEL):   sudo dnf install -y mkcert nss-tools
   macOS (Homebrew):      brew install mkcert nss
 
-Then re-run `mise run infra:ensure-dev-cert` (or just `mise run dev`).
+Then: `mise run infra:ensure-dev-cert`
 
-Why mkcert is needed: it provisions a self-signed cert so realm-server can
-speak HTTP/2 on https://localhost:4203. Without it, indexing falls back to
-HTTP/1.1 and aggregator-card renders (cohort, dashboards) get throttled by
-Chrome's 6-per-origin connection cap. See packages/realm-server/README.md
-for the full HTTP/2 dev access guide.
+See packages/realm-server/README.md ("HTTP/2 dev access") for the why.
 EOF
-  exit 1
+  exit 0
 fi
 
 mkdir -p "$CERT_DIR"

--- a/mise-tasks/infra/ensure-dev-cert
+++ b/mise-tasks/infra/ensure-dev-cert
@@ -49,7 +49,7 @@ To enable HTTP/2, install mkcert and re-run this task:
 
 Then: `mise run infra:ensure-dev-cert`
 
-See packages/realm-server/README.md ("HTTP/2 dev access") for the why.
+See the repo-root README ("HTTP/2 dev access") for the why.
 EOF
   exit 0
 fi

--- a/mise-tasks/lib/env-vars.sh
+++ b/mise-tasks/lib/env-vars.sh
@@ -22,6 +22,30 @@ unset _ENV_VARS_DIR _REPO_ROOT
 
 export PGPORT="${PGPORT:-5435}"
 
+# HTTP/2 dev access: when the dev cert provisioned by
+# `mise run infra:ensure-dev-cert` is present, expose its paths to the
+# realm-servers so each can bring up an HTTPS/h2 alias listener alongside
+# the existing HTTP/1.1 listener. Two realm-servers run side-by-side in
+# local dev: the development server on 4201 (h2 alias 4203) and the
+# test-realms server on 4202 (h2 alias 4204). REALM_H2_ORIGIN_MAPPINGS
+# tells the prerender's Chromium (via the host's VirtualNetwork) which
+# canonical http origin to rewrite to which https origin so per-page
+# fetches multiplex over h2. Absent → realm-servers stay HTTP-only.
+# See packages/realm-server/README.md ("HTTP/2 dev access") for the why.
+_BOXEL_DEV_CERT_DIR="${BOXEL_DEV_CERT_DIR:-$HOME/.local/share/boxel/dev-certs}"
+_BOXEL_DEV_CERT_FILE="$_BOXEL_DEV_CERT_DIR/localhost.pem"
+_BOXEL_DEV_KEY_FILE="$_BOXEL_DEV_CERT_DIR/localhost-key.pem"
+# Env-mode (BOXEL_ENVIRONMENT) uses Traefik subdomains and has its own
+# routing layer; HTTP/2 wiring is standard-mode only for now.
+if [ -z "${BOXEL_ENVIRONMENT:-}" ] && [ -f "$_BOXEL_DEV_CERT_FILE" ] && [ -f "$_BOXEL_DEV_KEY_FILE" ]; then
+  export REALM_SERVER_TLS_CERT_FILE="$_BOXEL_DEV_CERT_FILE"
+  export REALM_SERVER_TLS_KEY_FILE="$_BOXEL_DEV_KEY_FILE"
+  export REALM_SERVER_TLS_PORT="${REALM_SERVER_TLS_PORT:-4203}"
+  export REALM_TEST_TLS_PORT="${REALM_TEST_TLS_PORT:-4204}"
+  export REALM_H2_ORIGIN_MAPPINGS="${REALM_H2_ORIGIN_MAPPINGS:-[{\"from\":\"http://localhost:4201\",\"to\":\"https://localhost:${REALM_SERVER_TLS_PORT}\"},{\"from\":\"http://localhost:4202\",\"to\":\"https://localhost:${REALM_TEST_TLS_PORT}\"}]}"
+fi
+unset _BOXEL_DEV_CERT_DIR _BOXEL_DEV_CERT_FILE _BOXEL_DEV_KEY_FILE
+
 # Turbo mode: boost parallelism for local development.
 # All turbo defaults can be overridden individually.
 if [ "${BOXEL_TURBO:-}" = "true" ]; then

--- a/mise-tasks/lib/env-vars.sh
+++ b/mise-tasks/lib/env-vars.sh
@@ -31,7 +31,7 @@ export PGPORT="${PGPORT:-5435}"
 # tells the prerender's Chromium (via the host's VirtualNetwork) which
 # canonical http origin to rewrite to which https origin so per-page
 # fetches multiplex over h2. Absent → realm-servers stay HTTP-only.
-# See packages/realm-server/README.md ("HTTP/2 dev access") for the why.
+# See the repo-root README ("HTTP/2 dev access") for the why.
 _BOXEL_DEV_CERT_DIR="${BOXEL_DEV_CERT_DIR:-$HOME/.local/share/boxel/dev-certs}"
 _BOXEL_DEV_CERT_FILE="$_BOXEL_DEV_CERT_DIR/localhost.pem"
 _BOXEL_DEV_KEY_FILE="$_BOXEL_DEV_CERT_DIR/localhost-key.pem"

--- a/mise-tasks/services/realm-server
+++ b/mise-tasks/services/realm-server
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Start realm development server"
-#MISE depends=["infra:ensure-traefik", "infra:ensure-pg", "infra:ensure-db", "infra:wait-for-prerender"]
+#MISE depends=["infra:ensure-dev-cert", "infra:ensure-traefik", "infra:ensure-pg", "infra:ensure-db", "infra:wait-for-prerender"]
 #MISE dir="packages/realm-server"
 
 # Propagate realm-server's exit status through the trailing `| dev-log-tee.sh`

--- a/mise-tasks/services/realm-server-base
+++ b/mise-tasks/services/realm-server-base
@@ -1,6 +1,6 @@
 #!/bin/sh
 #MISE description="Start base realm server only"
-#MISE depends=["infra:ensure-pg", "infra:wait-for-prerender"]
+#MISE depends=["infra:ensure-dev-cert", "infra:ensure-pg", "infra:wait-for-prerender"]
 #MISE dir="packages/realm-server"
 
 if [ -z "$MATRIX_REGISTRATION_SHARED_SECRET" ]; then

--- a/mise-tasks/services/test-realms
+++ b/mise-tasks/services/test-realms
@@ -1,6 +1,6 @@
 #!/bin/sh
 #MISE description="Start test realm servers"
-#MISE depends=["infra:ensure-traefik", "infra:ensure-pg", "infra:wait-for-prerender"]
+#MISE depends=["infra:ensure-dev-cert", "infra:ensure-traefik", "infra:ensure-pg", "infra:wait-for-prerender"]
 #MISE dir="packages/realm-server"
 
 SCRIPTS_DIR="./scripts"
@@ -45,6 +45,7 @@ NODE_ENV=test \
   GRAFANA_SECRET="shhh! it's a secret" \
   MATRIX_URL="${MATRIX_URL_VAL}" \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
+  REALM_SERVER_TLS_PORT="${REALM_TEST_TLS_PORT:-}" \
   ts-node \
   --transpileOnly main \
   --port="${TEST_PORT}" \

--- a/packages/host/app/services/network.ts
+++ b/packages/host/app/services/network.ts
@@ -95,31 +95,10 @@ export default class NetworkService extends Service {
   // the wire fetch is rewritten. See the repo-root README's "HTTP/2 dev
   // access" section.
   private installH2OriginMappings(virtualNetwork: VirtualNetwork) {
-    let h2MappingsRaw = (
-      globalThis as unknown as { __realmH2OriginMappings__?: string }
-    ).__realmH2OriginMappings__;
-    if (!h2MappingsRaw) {
-      return;
-    }
-    let pairs: Array<{ from?: string; to?: string }>;
-    try {
-      let parsed = JSON.parse(h2MappingsRaw);
-      pairs = Array.isArray(parsed) ? parsed : [];
-    } catch {
-      return;
-    }
-    for (let { from, to } of pairs) {
-      if (!from || !to) continue;
-      let fromUrl: URL;
-      let toUrl: URL;
-      try {
-        fromUrl = new URL(from);
-        toUrl = new URL(to);
-      } catch {
-        continue;
-      }
-      if (fromUrl.origin === toUrl.origin) continue;
-      virtualNetwork.addURLMapping(fromUrl, toUrl);
+    let raw = (globalThis as unknown as { __realmH2OriginMappings__?: string })
+      .__realmH2OriginMappings__;
+    for (let { from, to } of parseH2OriginMappings(raw)) {
+      virtualNetwork.addURLMapping(from, to);
     }
   }
 
@@ -136,4 +115,54 @@ declare module '@ember/service' {
 
 function withTrailingSlash(url: string): string {
   return url.endsWith('/') ? url : `${url}/`;
+}
+
+// Parses the JSON-encoded h2 origin mappings injected by the prerender
+// harness. Each entry must have a parseable `from` URL and a `to` URL
+// whose scheme is `https:` and whose hostname is a loopback alias —
+// this contains the `--ignore-certificate-errors` trust relaxation to
+// local-dev only. A malformed input, an empty global, or a `to` that
+// would redirect realm fetches off-loopback returns nothing.
+export function parseH2OriginMappings(
+  raw: string | undefined,
+): Array<{ from: URL; to: URL }> {
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  let mappings: Array<{ from: URL; to: URL }> = [];
+  for (let entry of parsed) {
+    if (!entry || typeof entry !== 'object') continue;
+    let from = (entry as { from?: unknown }).from;
+    let to = (entry as { to?: unknown }).to;
+    if (typeof from !== 'string' || typeof to !== 'string') continue;
+    let fromUrl: URL;
+    let toUrl: URL;
+    try {
+      fromUrl = new URL(from);
+      toUrl = new URL(to);
+    } catch {
+      continue;
+    }
+    if (toUrl.protocol !== 'https:') continue;
+    if (!isLoopbackHostname(toUrl.hostname)) continue;
+    if (fromUrl.origin === toUrl.origin) continue;
+    mappings.push({ from: fromUrl, to: toUrl });
+  }
+  return mappings;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  let h = hostname.toLowerCase();
+  return (
+    h === 'localhost' ||
+    h.endsWith('.localhost') ||
+    h === '127.0.0.1' ||
+    h === '::1' ||
+    h === '[::1]'
+  );
 }

--- a/packages/host/app/services/network.ts
+++ b/packages/host/app/services/network.ts
@@ -92,8 +92,8 @@ export default class NetworkService extends Service {
   // they multiplex over one connection per origin instead of
   // serializing through Chrome's HTTP/1.1 6-per-origin ceiling.
   // Canonical realm URLs (in card data) stay on the http origin — only
-  // the wire fetch is rewritten. See packages/realm-server/README.md
-  // "HTTP/2 dev access".
+  // the wire fetch is rewritten. See the repo-root README's "HTTP/2 dev
+  // access" section.
   private installH2OriginMappings(virtualNetwork: VirtualNetwork) {
     let h2MappingsRaw = (
       globalThis as unknown as { __realmH2OriginMappings__?: string }

--- a/packages/host/app/services/network.ts
+++ b/packages/host/app/services/network.ts
@@ -50,6 +50,7 @@ export default class NetworkService extends Service {
 
   private makeVirtualNetwork() {
     let virtualNetwork = new VirtualNetwork(globalThis.fetch);
+    this.installH2OriginMappings(virtualNetwork);
     let resolvedBaseRealmURL = new URL(
       withTrailingSlash(config.resolvedBaseRealmURL),
     );
@@ -83,6 +84,43 @@ export default class NetworkService extends Service {
       );
     }
     return virtualNetwork;
+  }
+
+  // HTTP/2 alias re-route: when the prerender harness injects a JSON
+  // list of {from, to} origin pairs as window.__realmH2OriginMappings__,
+  // route realm-server fetches through the HTTPS/h2 listener(s) so
+  // they multiplex over one connection per origin instead of
+  // serializing through Chrome's HTTP/1.1 6-per-origin ceiling.
+  // Canonical realm URLs (in card data) stay on the http origin — only
+  // the wire fetch is rewritten. See packages/realm-server/README.md
+  // "HTTP/2 dev access".
+  private installH2OriginMappings(virtualNetwork: VirtualNetwork) {
+    let h2MappingsRaw = (
+      globalThis as unknown as { __realmH2OriginMappings__?: string }
+    ).__realmH2OriginMappings__;
+    if (!h2MappingsRaw) {
+      return;
+    }
+    let pairs: Array<{ from?: string; to?: string }>;
+    try {
+      let parsed = JSON.parse(h2MappingsRaw);
+      pairs = Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return;
+    }
+    for (let { from, to } of pairs) {
+      if (!from || !to) continue;
+      let fromUrl: URL;
+      let toUrl: URL;
+      try {
+        fromUrl = new URL(from);
+        toUrl = new URL(to);
+      } catch {
+        continue;
+      }
+      if (fromUrl.origin === toUrl.origin) continue;
+      virtualNetwork.addURLMapping(fromUrl, toUrl);
+    }
   }
 
   resetState = () => {

--- a/packages/host/tests/unit/services/network-h2-mappings-test.ts
+++ b/packages/host/tests/unit/services/network-h2-mappings-test.ts
@@ -1,0 +1,93 @@
+import { module, test } from 'qunit';
+
+import { parseH2OriginMappings } from '@cardstack/host/services/network';
+
+module('Unit | Service | network | parseH2OriginMappings', function () {
+  test('returns [] when input is undefined', function (assert) {
+    assert.deepEqual(parseH2OriginMappings(undefined), []);
+  });
+
+  test('returns [] when input is the empty string', function (assert) {
+    assert.deepEqual(parseH2OriginMappings(''), []);
+  });
+
+  test('returns [] when input is not valid JSON', function (assert) {
+    assert.deepEqual(parseH2OriginMappings('not-json'), []);
+  });
+
+  test('returns [] when JSON parses to a non-array', function (assert) {
+    assert.deepEqual(parseH2OriginMappings('{"from":"x","to":"y"}'), []);
+  });
+
+  test('accepts a single well-formed loopback https mapping', function (assert) {
+    let raw = JSON.stringify([
+      { from: 'http://localhost:4201', to: 'https://localhost:4203' },
+    ]);
+    let result = parseH2OriginMappings(raw);
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].from.origin, 'http://localhost:4201');
+    assert.strictEqual(result[0].to.origin, 'https://localhost:4203');
+  });
+
+  test('accepts multiple mappings and preserves order', function (assert) {
+    let raw = JSON.stringify([
+      { from: 'http://localhost:4201', to: 'https://localhost:4203' },
+      { from: 'http://localhost:4202', to: 'https://localhost:4204' },
+    ]);
+    let result = parseH2OriginMappings(raw);
+    assert.deepEqual(
+      result.map((m) => [m.from.origin, m.to.origin]),
+      [
+        ['http://localhost:4201', 'https://localhost:4203'],
+        ['http://localhost:4202', 'https://localhost:4204'],
+      ],
+    );
+  });
+
+  test('accepts 127.0.0.1 and ::1 as loopback destinations', function (assert) {
+    let raw = JSON.stringify([
+      { from: 'http://localhost:4201', to: 'https://127.0.0.1:4203' },
+      { from: 'http://localhost:4202', to: 'https://[::1]:4204' },
+    ]);
+    assert.strictEqual(parseH2OriginMappings(raw).length, 2);
+  });
+
+  test('rejects a destination on a non-loopback hostname', function (assert) {
+    let raw = JSON.stringify([
+      { from: 'http://localhost:4201', to: 'https://example.com:4203' },
+    ]);
+    assert.deepEqual(parseH2OriginMappings(raw), []);
+  });
+
+  test('rejects a destination with http scheme', function (assert) {
+    let raw = JSON.stringify([
+      { from: 'http://localhost:4201', to: 'http://localhost:4203' },
+    ]);
+    assert.deepEqual(parseH2OriginMappings(raw), []);
+  });
+
+  test('skips malformed entries but keeps valid ones', function (assert) {
+    let raw = JSON.stringify([
+      { from: 'not-a-url', to: 'https://localhost:4203' },
+      { from: 'http://localhost:4201', to: 'https://localhost:4203' },
+      'unstructured',
+      { from: 'http://localhost:4202', to: 'https://example.com:4204' },
+      { from: 'http://localhost:4202', to: 'https://localhost:4204' },
+    ]);
+    let result = parseH2OriginMappings(raw);
+    assert.deepEqual(
+      result.map((m) => [m.from.origin, m.to.origin]),
+      [
+        ['http://localhost:4201', 'https://localhost:4203'],
+        ['http://localhost:4202', 'https://localhost:4204'],
+      ],
+    );
+  });
+
+  test('skips entries whose from and to share an origin', function (assert) {
+    let raw = JSON.stringify([
+      { from: 'https://localhost:4203', to: 'https://localhost:4203' },
+    ]);
+    assert.deepEqual(parseH2OriginMappings(raw), []);
+  });
+});

--- a/packages/realm-server/lib/dev-service-registry.ts
+++ b/packages/realm-server/lib/dev-service-registry.ts
@@ -2,8 +2,7 @@ import { execSync } from 'child_process';
 import { writeFileSync, renameSync, unlinkSync, readdirSync } from 'fs';
 import { join, resolve } from 'path';
 import { logger } from '@cardstack/runtime-common';
-import type { Server } from 'http';
-import type { AddressInfo } from 'net';
+import type { AddressInfo, Server } from 'net';
 import yaml from 'yaml';
 
 const log = logger('dev-service-registry');

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -497,6 +497,15 @@ const getIndexHTML = async () => {
   });
 
   let httpServer = server.listen(port);
+  // Optional HTTPS/h2 alias listener — used to relieve Chromium's
+  // per-origin HTTP/1.1 6-connection ceiling during aggregator-card
+  // prerender fan-outs. Comes up only when the cert env vars are set
+  // (see `infra:ensure-dev-cert`). Stays undefined in CI / hermetic
+  // test harnesses.
+  let tlsPort = process.env.REALM_SERVER_TLS_PORT
+    ? Number(process.env.REALM_SERVER_TLS_PORT)
+    : undefined;
+  let tlsServer = tlsPort != null ? server.listenSecure(tlsPort) : undefined;
   httpServer.on('listening', () => {
     let actualPort =
       (httpServer.address() as import('net').AddressInfo | null)?.port ?? port;
@@ -515,9 +524,19 @@ const getIndexHTML = async () => {
     if (isEnvironmentMode()) {
       deregisterEnvironment();
     }
+    // http.Server has closeAllConnections() for force-close. Http2SecureServer
+    // does not expose it — graceful close() is sufficient for dev shutdown.
     httpServer.closeAllConnections();
+    let closeTls = new Promise<void>((resolve) => {
+      if (!tlsServer) {
+        resolve();
+        return;
+      }
+      tlsServer.close(() => resolve());
+    });
     httpServer.close(() => {
       (async () => {
+        await closeTls;
         await Promise.all([
           reconciler?.shutDown(),
           fileChangesListener?.shutDown(),

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -501,11 +501,20 @@ const getIndexHTML = async () => {
   // per-origin HTTP/1.1 6-connection ceiling during aggregator-card
   // prerender fan-outs. Comes up only when the cert env vars are set
   // (see `infra:ensure-dev-cert`). Stays undefined in CI / hermetic
-  // test harnesses.
-  let tlsPort = process.env.REALM_SERVER_TLS_PORT
-    ? Number(process.env.REALM_SERVER_TLS_PORT)
-    : undefined;
-  let tlsServer = tlsPort != null ? server.listenSecure(tlsPort) : undefined;
+  // test harnesses. A non-numeric or out-of-range REALM_SERVER_TLS_PORT
+  // logs a warning and skips the alias rather than failing boot.
+  let tlsServer: import('http2').Http2SecureServer | undefined;
+  let rawTlsPort = process.env.REALM_SERVER_TLS_PORT;
+  if (rawTlsPort) {
+    let tlsPort = Number(rawTlsPort);
+    if (Number.isInteger(tlsPort) && tlsPort > 0 && tlsPort < 65536) {
+      tlsServer = server.listenSecure(tlsPort);
+    } else {
+      log.warn(
+        `REALM_SERVER_TLS_PORT="${rawTlsPort}" is not a valid TCP port; skipping HTTPS/h2 alias listener`,
+      );
+    }
+  }
   httpServer.on('listening', () => {
     let actualPort =
       (httpServer.address() as import('net').AddressInfo | null)?.port ?? port;

--- a/packages/realm-server/prerender/browser-manager.ts
+++ b/packages/realm-server/prerender/browser-manager.ts
@@ -33,10 +33,12 @@ export class BrowserManager {
     // fan-outs, the host's VirtualNetwork re-routes per-page fetches
     // inside Chromium to the h2 listener. The cert is a local mkcert
     // leaf, which puppeteer's bundled Chromium doesn't trust by
-    // default, so we skip the check here. Safe for prerender: the
-    // origins are fixed by REALM_H2_ORIGIN_MAPPINGS and the connection
-    // is loopback-only.
-    if (process.env.REALM_H2_ORIGIN_MAPPINGS) {
+    // default, so we skip the check here — but only when every mapping
+    // destination is an https loopback origin. If REALM_H2_ORIGIN_MAPPINGS
+    // is accidentally polluted with an off-loopback destination, leave
+    // Chromium's default trust policy intact so a fetch to that origin
+    // would still fail safely.
+    if (allH2DestinationsAreLoopback(process.env.REALM_H2_ORIGIN_MAPPINGS)) {
       launchArgs.push('--ignore-certificate-errors');
     }
 
@@ -366,4 +368,41 @@ export class BrowserManager {
       this.#browserUserDataDir = undefined;
     }
   }
+}
+
+// Returns true only when REALM_H2_ORIGIN_MAPPINGS parses to at least one
+// well-formed `{from, to}` pair whose destination is an `https:` URL
+// pointing at a loopback hostname. Used as a guard before passing
+// `--ignore-certificate-errors` to Chromium so that a polluted env var
+// can't be used to relax cert trust toward an arbitrary origin.
+function allH2DestinationsAreLoopback(raw: string | undefined): boolean {
+  if (!raw) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return false;
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) return false;
+  for (let entry of parsed) {
+    if (!entry || typeof entry !== 'object') return false;
+    let to = (entry as { to?: unknown }).to;
+    if (typeof to !== 'string') return false;
+    let toUrl: URL;
+    try {
+      toUrl = new URL(to);
+    } catch {
+      return false;
+    }
+    if (toUrl.protocol !== 'https:') return false;
+    let h = toUrl.hostname.toLowerCase();
+    let loopback =
+      h === 'localhost' ||
+      h.endsWith('.localhost') ||
+      h === '127.0.0.1' ||
+      h === '::1' ||
+      h === '[::1]';
+    if (!loopback) return false;
+  }
+  return true;
 }

--- a/packages/realm-server/prerender/browser-manager.ts
+++ b/packages/realm-server/prerender/browser-manager.ts
@@ -29,6 +29,17 @@ export class BrowserManager {
       launchArgs.push('--no-sandbox', '--disable-setuid-sandbox');
     }
 
+    // When the realm-server is exposing an HTTP/2 alias for indexing
+    // fan-outs, the host's VirtualNetwork re-routes per-page fetches
+    // inside Chromium to the h2 listener. The cert is a local mkcert
+    // leaf, which puppeteer's bundled Chromium doesn't trust by
+    // default, so we skip the check here. Safe for prerender: the
+    // origins are fixed by REALM_H2_ORIGIN_MAPPINGS and the connection
+    // is loopback-only.
+    if (process.env.REALM_H2_ORIGIN_MAPPINGS) {
+      launchArgs.push('--ignore-certificate-errors');
+    }
+
     let extraArgs =
       process.env.PUPPETEER_CHROME_ARGS?.split(/\s+/).filter(Boolean);
     if (extraArgs && extraArgs.length > 0) {

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -12,6 +12,24 @@ import { PrerenderCancelledError, throwIfAborted } from './prerender-cancel';
 import { AsyncSemaphore } from './async-semaphore';
 import { attachRuntimeExceptionCapture } from './runtime-exception-capture';
 
+// Browser-side init hook used by `#markPageAsInPrerender`. Declared at
+// module scope so puppeteer can serialize it across the CDP boundary
+// without dragging closure state from PagePool. Receives the JSON-
+// encoded h2 origin mappings (see env-vars.sh / REALM_H2_ORIGIN_MAPPINGS);
+// when present, the host's VirtualNetwork reads them out of
+// `__realmH2OriginMappings__` and re-routes realm fetches to the
+// HTTPS/h2 listener. Empty string when no dev cert is provisioned.
+function installPrerenderGlobals(args: { h2Mappings: string }): void {
+  let g = globalThis as unknown as {
+    __boxelDuringPrerender?: boolean;
+    __realmH2OriginMappings__?: string;
+  };
+  g.__boxelDuringPrerender = true;
+  if (args.h2Mappings) {
+    g.__realmH2OriginMappings__ = args.h2Mappings;
+  }
+}
+
 type RenderSemaphore = {
   acquire(signal?: AbortSignal, priority?: number): Promise<() => void>;
   // Optional resize hook used by dynamic pool expansion / contraction.
@@ -2211,10 +2229,8 @@ export class PagePool {
     if (typeof page.evaluateOnNewDocument !== 'function') {
       return;
     }
-    await page.evaluateOnNewDocument(() => {
-      (
-        globalThis as unknown as { __boxelDuringPrerender?: boolean }
-      ).__boxelDuringPrerender = true;
+    await page.evaluateOnNewDocument(installPrerenderGlobals, {
+      h2Mappings: process.env.REALM_H2_ORIGIN_MAPPINGS ?? '',
     });
   }
 

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -349,23 +349,43 @@ export class RealmServer {
 
   // Start an HTTPS+HTTP/2 listener on the alias port. Returns undefined when
   // cert env vars are unset (e.g., CI, or before the dev cert has been
-  // provisioned). The two listeners share this.app; an alias-host rewrite
-  // middleware (installed by the app getter) normalizes the `Host` header so
-  // URL-keyed routing matches the canonical serverURL on both ports.
+  // provisioned) or when the cert files are missing/malformed. The two
+  // listeners share this.app; an alias-host rewrite middleware (installed
+  // by the app getter) normalizes the `Host` header so URL-keyed routing
+  // matches the canonical serverURL on both ports.
   listenSecure(port: number): http2.Http2SecureServer | undefined {
     let certFile = process.env[TLS_CERT_FILE_ENV];
     let keyFile = process.env[TLS_KEY_FILE_ENV];
     if (!certFile || !keyFile) {
       return undefined;
     }
-    let instance = http2.createSecureServer(
-      {
-        cert: readFileSync(certFile),
-        key: readFileSync(keyFile),
-        allowHTTP1: true,
-      },
-      this.app.callback(),
-    );
+    let cert: Buffer;
+    let key: Buffer;
+    try {
+      cert = readFileSync(certFile);
+      key = readFileSync(keyFile);
+    } catch (e) {
+      this.log.warn(
+        `Unable to read TLS cert/key (%s, %s): %s — skipping HTTPS/h2 alias listener`,
+        certFile,
+        keyFile,
+        (e as Error).message,
+      );
+      return undefined;
+    }
+    let instance: http2.Http2SecureServer;
+    try {
+      instance = http2.createSecureServer(
+        { cert, key, allowHTTP1: true },
+        this.app.callback(),
+      );
+    } catch (e) {
+      this.log.warn(
+        `Unable to construct HTTPS/h2 server (malformed cert?): %s — skipping HTTPS/h2 alias listener`,
+        (e as Error).message,
+      );
+      return undefined;
+    }
     instance.listen(port);
     instance.on('listening', () => {
       let actualPort =

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -91,28 +91,46 @@ export function isTlsEnabled(): boolean {
 // Rewrites the inbound `Host` header to match the canonical serverURL
 // when a request arrives on the h2 alias port. Without this, downstream
 // URL construction (e.g., `fullRequestURL`) would build URLs that
-// don't match any mounted realm. The rewrite is scoped to requests
-// whose port differs from the canonical so wildcard-subdomain
-// (published realm) routing is unaffected.
+// don't match any mounted realm. Wildcard-subdomain (published realm)
+// routing is preserved: subdomains of the canonical hostname keep
+// their subdomain but pick up the canonical port — and when the
+// canonical URL has no explicit port (env-mode), no port is added.
 function aliasHostToCanonical(canonical: URL) {
   let canonicalHost = canonical.host; // e.g., "localhost:4201"
+  let canonicalPort = canonical.port; // e.g., "4201" or "" in env-mode
   let canonicalHostnameLower = canonical.hostname.toLowerCase();
   return async function (ctx: Koa.Context, next: Koa.Next) {
     let host = ctx.req.headers.host;
-    if (typeof host === 'string' && host !== canonicalHost) {
-      // Only rewrite when the hostname matches the canonical hostname (or
-      // is a subdomain of it); leaves cross-host requests alone.
-      let inboundHostname = host.split(':')[0].toLowerCase();
-      if (
-        inboundHostname === canonicalHostnameLower ||
-        inboundHostname.endsWith(`.${canonicalHostnameLower}`)
-      ) {
-        let rewritten =
-          inboundHostname === canonicalHostnameLower
-            ? canonicalHost
-            : `${inboundHostname}:${canonical.port || (canonical.protocol === 'https:' ? '443' : '80')}`;
-        ctx.req.headers.host = rewritten;
-      }
+    if (typeof host !== 'string' || host === canonicalHost) {
+      await next();
+      return;
+    }
+    // Parse via URL so IPv6 literals like `[::1]:4203` are handled
+    // correctly — string-splitting on ':' breaks bracketed authorities.
+    let inboundHostname: string;
+    try {
+      inboundHostname = new URL(`http://${host}`).hostname.toLowerCase();
+    } catch {
+      await next();
+      return;
+    }
+    let isCanonicalHostname = inboundHostname === canonicalHostnameLower;
+    let isCanonicalSubdomain = inboundHostname.endsWith(
+      `.${canonicalHostnameLower}`,
+    );
+    if (!isCanonicalHostname && !isCanonicalSubdomain) {
+      await next();
+      return;
+    }
+    if (isCanonicalHostname) {
+      ctx.req.headers.host = canonicalHost;
+    } else {
+      // Subdomain — preserve it, attach the canonical port if any. In
+      // env-mode (canonicalPort === '') the port is omitted, matching
+      // the realm-server's expectations for Traefik-routed subdomains.
+      ctx.req.headers.host = canonicalPort
+        ? `${inboundHostname}:${canonicalPort}`
+        : inboundHostname;
     }
     await next();
   };

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -1,6 +1,9 @@
 import Koa from 'koa';
 import cors from '@koa/cors';
 import { Memoize } from 'typescript-memoize';
+import http from 'http';
+import http2 from 'http2';
+import { readFileSync } from 'fs';
 import type {
   DefinitionLookup,
   Realm,
@@ -66,6 +69,54 @@ import {
 } from './lib/index-html-injection';
 import { sanitizeHeadHTMLToString } from '@cardstack/runtime-common';
 import { JSDOM } from 'jsdom';
+
+// Optional h2 alias listener: when both files point to readable certs,
+// realm-server also serves HTTPS+HTTP/2 on REALM_SERVER_TLS_PORT (default
+// 4203). The h2 alias lets clients that suffer under HTTP/1.1's 6-per-origin
+// connection limit (Chrome and Chromium-based prerenderers) multiplex
+// many concurrent fetches over one TCP connection. The h2 origin is an
+// alias — incoming `Host` headers get rewritten to the canonical
+// `serverURL` so URL-keyed realm lookup is identical on both ports.
+const TLS_CERT_FILE_ENV = 'REALM_SERVER_TLS_CERT_FILE';
+const TLS_KEY_FILE_ENV = 'REALM_SERVER_TLS_KEY_FILE';
+
+export type RealmHttpServer = http.Server | http2.Http2SecureServer;
+
+export function isTlsEnabled(): boolean {
+  return Boolean(
+    process.env[TLS_CERT_FILE_ENV] && process.env[TLS_KEY_FILE_ENV],
+  );
+}
+
+// Rewrites the inbound `Host` header to match the canonical serverURL
+// when a request arrives on the h2 alias port. Without this, downstream
+// URL construction (e.g., `fullRequestURL`) would build URLs that
+// don't match any mounted realm. The rewrite is scoped to requests
+// whose port differs from the canonical so wildcard-subdomain
+// (published realm) routing is unaffected.
+function aliasHostToCanonical(canonical: URL) {
+  let canonicalHost = canonical.host; // e.g., "localhost:4201"
+  let canonicalHostnameLower = canonical.hostname.toLowerCase();
+  return async function (ctx: Koa.Context, next: Koa.Next) {
+    let host = ctx.req.headers.host;
+    if (typeof host === 'string' && host !== canonicalHost) {
+      // Only rewrite when the hostname matches the canonical hostname (or
+      // is a subdomain of it); leaves cross-host requests alone.
+      let inboundHostname = host.split(':')[0].toLowerCase();
+      if (
+        inboundHostname === canonicalHostnameLower ||
+        inboundHostname.endsWith(`.${canonicalHostnameLower}`)
+      ) {
+        let rewritten =
+          inboundHostname === canonicalHostnameLower
+            ? canonicalHost
+            : `${inboundHostname}:${canonical.port || (canonical.protocol === 'https:' ? '443' : '80')}`;
+        ctx.req.headers.host = rewritten;
+      }
+    }
+    await next();
+  };
+}
 
 export class RealmServer {
   private log = logger('realm-server');
@@ -188,6 +239,7 @@ export class RealmServer {
   @Memoize()
   get app() {
     let app = new Koa<Koa.DefaultState, Koa.Context>()
+      .use(aliasHostToCanonical(this.serverURL))
       .use(httpLogging)
       .use(ecsMetadata)
       .use(
@@ -267,11 +319,43 @@ export class RealmServer {
   }
 
   listen(port: number) {
-    let instance = this.app.listen(port);
+    let instance = http.createServer(this.app.callback());
+    instance.listen(port);
     instance.on('listening', () => {
       let actualPort =
         (instance.address() as import('net').AddressInfo | null)?.port ?? port;
-      this.log.info(`Realm server listening on port %s\n`, actualPort);
+      this.log.info(`Realm server listening on port %s (http)\n`, actualPort);
+    });
+    return instance;
+  }
+
+  // Start an HTTPS+HTTP/2 listener on the alias port. Returns undefined when
+  // cert env vars are unset (e.g., CI, or before the dev cert has been
+  // provisioned). The two listeners share this.app; an alias-host rewrite
+  // middleware (installed by the app getter) normalizes the `Host` header so
+  // URL-keyed routing matches the canonical serverURL on both ports.
+  listenSecure(port: number): http2.Http2SecureServer | undefined {
+    let certFile = process.env[TLS_CERT_FILE_ENV];
+    let keyFile = process.env[TLS_KEY_FILE_ENV];
+    if (!certFile || !keyFile) {
+      return undefined;
+    }
+    let instance = http2.createSecureServer(
+      {
+        cert: readFileSync(certFile),
+        key: readFileSync(keyFile),
+        allowHTTP1: true,
+      },
+      this.app.callback(),
+    );
+    instance.listen(port);
+    instance.on('listening', () => {
+      let actualPort =
+        (instance.address() as import('net').AddressInfo | null)?.port ?? port;
+      this.log.info(
+        `Realm server listening on port %s (https/h2 alias)\n`,
+        actualPort,
+      );
     });
     return instance;
   }


### PR DESCRIPTION
## Summary

DX improvement for local indexing. Heavy aggregator cards (cohort, dashboards) fan out 80+ federated-search requests during a single prerender, and Chrome's HTTP/1.1 6-per-origin connection ceiling serializes them — turning a cohort render into multiple minutes. HTTP/2 multiplexes the same fetches over one connection.

This PR adds an opt-in HTTPS/HTTP-2 alias listener that sits next to the existing HTTP/1.1 server. Indexing automatically uses the h2 alias when a dev cert is provisioned; devs can optionally point their own browser at the same alias for the same speed-up, which better mirrors hosted environments (they already speak HTTP/2 in front of the realm-server).

- Realm-server listens on `https://localhost:4203` (alias for `:4201`) and `https://localhost:4204` (alias for `:4202`) when `REALM_SERVER_TLS_CERT_FILE`/`KEY_FILE` are set. The h2 origin is an alias — an inbound `Host` header rewrite middleware ensures URL-keyed realm lookup matches identically on both ports.
- Prerender Chromium and the test-realms indexer transparently re-route fetches to the h2 alias via a `window.__realmH2OriginMappings__` override injected into every page, consumed by the host's `VirtualNetwork`. Canonical card URLs are unchanged in card data; only the wire fetch is rewritten.
- Puppeteer launches with `--ignore-certificate-errors` so the self-signed dev cert is accepted without `mkcert -install`.
- Absent the cert, env-vars.sh leaves the TLS env vars unset → realm-server stays HTTP-only. CI and the software-factory hermetic harness are untouched.

## Opting in

```
mise run infra:ensure-dev-cert     # one-time, idempotent, no sudo
mise run dev-all                   # picks up the cert automatically
```

That generates a leaf cert via `mkcert` into `~/.local/share/boxel/dev-certs/`. The script prints clear install hints if `mkcert` is missing.

If you also want your manual browser to trust the cert without warnings when visiting `https://localhost:4203/…` directly, run `mkcert -install` once (requires sudo). The prerender / test harness don't need this — they use `--ignore-certificate-errors`.

See the new "HTTP/2 dev access" section in the [README](https://github.com/cardstack/boxel/blob/worktree-cs-11114-http2/README.md#http2-dev-access) for the full guide (port chart, what auto-uses h2, verify command, opt-out).

## Test plan

- [ ] `mise run infra:ensure-dev-cert` is idempotent and exits 0 on subsequent runs.
- [ ] Without the cert (CI path): `mise run dev` boots realm-server HTTP-only, no behavior change.
- [ ] With the cert: `curl -kI --http2 https://localhost:4203/_alive` returns `HTTP/2 200`.
- [ ] `curl -kI --http1.1 https://localhost:4203/_alive` returns `HTTP/1.1 200` (ALPN fallback works).
- [ ] Trigger a base-realm reindex via `/_grafana-reindex?authHeader=…&realm=base/` — completes without errors.
- [ ] Open `https://localhost:4203` in a browser (after `mkcert -install`), log in, load a card — all realm fetches show `h2` protocol in DevTools network panel.
- [ ] `mise run dev` shutdown closes both listeners cleanly.
- [ ] `pnpm lint` passes on `packages/realm-server` and `packages/host` (lint:js + prettier — pre-existing lint:types errors in `../base/*.gts` are unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)