### PR TITLE
Rename realmIdentifier field to realmUrl on realm-targeting cards [CS-11120]

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -115,7 +115,7 @@ export class FileIdentifierCard extends CardDef {
 }
 
 export class RealmIdentifierCard extends CardDef {
-  @field realmIdentifier = contains(StringField);
+  @field realmUrl = contains(StringField);
 }
 
 export class InvalidateRealmIdentifiersInput extends RealmIdentifierCard {
@@ -385,7 +385,7 @@ export class SendAiAssistantMessageInput extends CardDef {
   @field clientGeneratedId = contains(StringField);
   @field attachedCards = linksToMany(CardDef);
   @field attachedFileIdentifiers = containsMany(StringField);
-  @field realmIdentifier = contains(StringField);
+  @field realmUrl = contains(StringField);
   @field openCardIds = containsMany(StringField);
   @field requireCommandCall = contains(BooleanField);
 }
@@ -474,7 +474,7 @@ export class VisitCardsInput extends CardDef {
 
 export class EvaluateModuleInput extends CardDef {
   @field moduleIdentifier = contains(StringField);
-  @field realmIdentifier = contains(StringField);
+  @field realmUrl = contains(StringField);
 }
 
 export class EvaluateModuleResult extends CardDef {
@@ -487,7 +487,7 @@ export class EvaluateModuleResult extends CardDef {
 export class InstantiateCardInput extends CardDef {
   @field moduleIdentifier = contains(StringField);
   @field cardName = contains(StringField);
-  @field realmIdentifier = contains(StringField);
+  @field realmUrl = contains(StringField);
   @field instanceData = contains(StringField);
 }
 
@@ -582,7 +582,7 @@ export class RealmInfoField extends FieldDef {
 export class RealmMetaField extends FieldDef {
   @field info = contains(RealmInfoField);
   @field canWrite = contains(BooleanField);
-  @field realmIdentifier = contains(StringField);
+  @field realmUrl = contains(StringField);
 }
 
 export class GetAllRealmMetasResult extends CardDef {
@@ -590,11 +590,11 @@ export class GetAllRealmMetasResult extends CardDef {
 }
 
 export class GetAvailableRealmIdentifiersResult extends CardDef {
-  @field realmIdentifiers = containsMany(StringField);
+  @field realmUrls = containsMany(StringField);
 }
 
 export class GetCatalogRealmIdentifiersResult extends CardDef {
-  @field realmIdentifiers = containsMany(StringField);
+  @field realmUrls = containsMany(StringField);
 }
 
 export class FetchCardJsonInput extends CardDef {
@@ -606,7 +606,7 @@ export class FetchCardJsonResult extends CardDef {
 }
 
 export class ExecuteAtomicOperationsInput extends CardDef {
-  @field realmIdentifier = contains(StringField);
+  @field realmUrl = contains(StringField);
   @field operations = containsMany(JsonField);
 }
 
@@ -624,11 +624,11 @@ export class GetRealmOfResourceIdentifierInput extends CardDef {
 }
 
 export class GetRealmOfResourceIdentifierResult extends CardDef {
-  @field realmIdentifier = contains(StringField); // empty string if not found
+  @field realmUrl = contains(StringField); // empty string if not found
 }
 
 export class CanReadRealmInput extends CardDef {
-  @field realmIdentifier = contains(StringField);
+  @field realmUrl = contains(StringField);
 }
 
 export class CanReadRealmResult extends CardDef {
@@ -648,15 +648,15 @@ export class AuthedFetchResult extends CardDef {
 }
 
 export class GetDefaultWritableRealmResult extends CardDef {
-  @field realmIdentifier = contains(StringField); // empty string if no writable realm found
+  @field realmUrl = contains(StringField); // empty string if no writable realm found
 }
 
 export class ValidateRealmInput extends CardDef {
-  @field realmIdentifier = contains(StringField);
+  @field realmUrl = contains(StringField);
 }
 
 export class ValidateRealmResult extends CardDef {
-  @field realmIdentifier = contains(StringField); // normalized with trailing slash
+  @field realmUrl = contains(StringField); // normalized with trailing slash
 }
 
 export class SanitizeModuleListInput extends CardDef {

--- a/packages/base/realm.gts
+++ b/packages/base/realm.gts
@@ -17,7 +17,7 @@ import type { GetAllRealmMetasResult } from './command';
 import GetAllRealmMetasCommand from '@cardstack/boxel-host/commands/get-all-realm-metas';
 
 type RealmMeta = {
-  realmIdentifier: string;
+  realmUrl: string;
   canWrite: boolean;
   info: {
     name?: string;
@@ -44,7 +44,7 @@ class EditComponent extends Component<typeof RealmField> {
     if (!this.args.model) {
       return undefined;
     }
-    return this.writableRealms.find((realm) => realm.realmIdentifier === this.args.model);
+    return this.writableRealms.find((realm) => realm.realmUrl === this.args.model);
   }
 
   get selectedRealmLabel(): string {
@@ -55,9 +55,9 @@ class EditComponent extends Component<typeof RealmField> {
     return this.writableRealms.map(
       (realm) =>
         new MenuItem({
-          label: realm.info.name ?? realm.realmIdentifier,
+          label: realm.info.name ?? realm.realmUrl,
           action: () => this.selectRealm(realm),
-          checked: realm.realmIdentifier === this.args.model,
+          checked: realm.realmUrl === this.args.model,
           iconURL: realm.info.iconURL ?? undefined,
         }),
     );
@@ -65,7 +65,7 @@ class EditComponent extends Component<typeof RealmField> {
 
   @action
   selectRealm(realm: RealmMeta) {
-    this.args.set(realm.realmIdentifier);
+    this.args.set(realm.realmUrl);
   }
 
   <template>

--- a/packages/base/system-card.gts
+++ b/packages/base/system-card.gts
@@ -156,7 +156,7 @@ class SystemCardIsolated extends Component<typeof SystemCard> {
           .filter((realmMeta: RealmMetaField) => realmMeta.canWrite)
           .map((realmMeta: RealmMetaField) => ({
             name: realmMeta.info.name,
-            url: realmMeta.realmIdentifier,
+            url: realmMeta.realmUrl,
             iconURL: realmMeta.info.iconURL ?? undefined,
           }));
       }

--- a/packages/catalog-realm/catalog-app/components/listing-fitted.gts
+++ b/packages/catalog-realm/catalog-app/components/listing-fitted.gts
@@ -30,11 +30,11 @@ export class ListingFittedTemplate extends Component<typeof Listing> {
           .filter(
             (realmMeta: RealmMetaField) =>
               realmMeta.canWrite &&
-              realmMeta.realmIdentifier !== this.args.model[realmURL]?.href,
+              realmMeta.realmUrl !== this.args.model[realmURL]?.href,
           )
           .map((realmMeta: RealmMetaField) => ({
             name: realmMeta.info.name,
-            url: realmMeta.realmIdentifier,
+            url: realmMeta.realmUrl,
             iconURL: realmMeta.info.iconURL,
           }));
       }

--- a/packages/catalog-realm/catalog-app/listing/listing.gts
+++ b/packages/catalog-realm/catalog-app/listing/listing.gts
@@ -75,11 +75,11 @@ class EmbeddedTemplate extends Component<typeof Listing> {
           .filter(
             (realmMeta: RealmMetaField) =>
               realmMeta.canWrite &&
-              realmMeta.realmIdentifier !== this.args.model[realmURL]?.href,
+              realmMeta.realmUrl !== this.args.model[realmURL]?.href,
           )
           .map((realmMeta: RealmMetaField) => ({
             name: realmMeta.info.name,
-            url: realmMeta.realmIdentifier,
+            url: realmMeta.realmUrl,
             iconURL: realmMeta.info.iconURL,
           }));
       }

--- a/packages/experiments-realm/submission-card/components/portal/realm-tabs.gts
+++ b/packages/experiments-realm/submission-card/components/portal/realm-tabs.gts
@@ -29,10 +29,10 @@ export class RealmTabs extends GlimmerComponent<RealmTabsSignature> {
       {{#each @realms as |realm|}}
         <Pill
           @kind='button'
-          class='realm-pill {{if (eq @selectedRealm realm.realmIdentifier) "active"}}'
-          aria-pressed={{if (eq @selectedRealm realm.realmIdentifier) 'true' 'false'}}
-          title={{realm.realmIdentifier}}
-          {{on 'click' (fn @onChange realm.realmIdentifier)}}
+          class='realm-pill {{if (eq @selectedRealm realm.realmUrl) "active"}}'
+          aria-pressed={{if (eq @selectedRealm realm.realmUrl) 'true' 'false'}}
+          title={{realm.realmUrl}}
+          {{on 'click' (fn @onChange realm.realmUrl)}}
         >
           <:default>{{realm.info.name}}</:default>
         </Pill>

--- a/packages/experiments-realm/submission-card/submission-card-portal.gts
+++ b/packages/experiments-realm/submission-card/submission-card-portal.gts
@@ -89,7 +89,7 @@ class Isolated extends Component<typeof SubmissionCardPortal> {
     if (resource?.isSuccess && resource.cardResult) {
       return (
         (resource.cardResult as GetAllRealmMetasResult).results?.map(
-          (r) => r.realmIdentifier,
+          (r) => r.realmUrl,
         ) ?? []
       );
     }
@@ -134,7 +134,7 @@ class Isolated extends Component<typeof SubmissionCardPortal> {
       (this.submissionDiscovery?.instancesByRealm ?? []).map((r) => r.realm),
     );
     return this.allRealmMetas.filter((r) =>
-      realmUrlsWithCards.has(r.realmIdentifier),
+      realmUrlsWithCards.has(r.realmUrl),
     );
   }
 
@@ -150,7 +150,7 @@ class Isolated extends Component<typeof SubmissionCardPortal> {
     if (!this.allRealmsInfoResource?.isSuccess) return fallback;
     if (this.selectedRealm) return [this.selectedRealm];
 
-    const availableUrls = this.availableRealms.map((r) => r.realmIdentifier);
+    const availableUrls = this.availableRealms.map((r) => r.realmUrl);
     return availableUrls.length > 0 ? availableUrls : fallback;
   }
 

--- a/packages/host/app/commands/ai-assistant.ts
+++ b/packages/host/app/commands/ai-assistant.ts
@@ -77,7 +77,7 @@ export default class UseAiAssistantCommand extends HostBaseCommand<
         attachedCards: [...(await attachedCardsPromise)],
         attachedFileIdentifiers: input.attachedFileIdentifiers,
         openCardIds: input.openCardIds,
-        realmIdentifier: this.operatorModeStateService.realmURL,
+        realmUrl: this.operatorModeStateService.realmURL,
         requireCommandCall: input.requireCommandCall,
       });
       return sendMessageResult;

--- a/packages/host/app/commands/ask-ai.ts
+++ b/packages/host/app/commands/ask-ai.ts
@@ -52,7 +52,7 @@ export default class AskAiCommand extends HostBaseCommand<
       prompt: input.prompt,
       attachedCards: openCards,
       openCardIds: openCards?.map((c: any) => c.id),
-      realmIdentifier: this.operatorModeStateService.realmURL,
+      realmUrl: this.operatorModeStateService.realmURL,
     });
 
     await openRoomCommand.execute({ roomId });

--- a/packages/host/app/commands/can-read-realm.ts
+++ b/packages/host/app/commands/can-read-realm.ts
@@ -20,7 +20,7 @@ export default class CanReadRealmCommand extends HostBaseCommand<
     return CanReadRealmInput;
   }
 
-  requireInputFields = ['realmIdentifier'];
+  requireInputFields = ['realmUrl'];
 
   protected async run(
     input: BaseCommandModule.CanReadRealmInput,
@@ -28,7 +28,7 @@ export default class CanReadRealmCommand extends HostBaseCommand<
     let commandModule = await this.loadCommandModule();
     const { CanReadRealmResult } = commandModule;
     return new CanReadRealmResult({
-      canRead: this.realm.canRead(input.realmIdentifier),
+      canRead: this.realm.canRead(input.realmUrl),
     });
   }
 }

--- a/packages/host/app/commands/cancel-indexing-job.ts
+++ b/packages/host/app/commands/cancel-indexing-job.ts
@@ -24,6 +24,6 @@ export default class CancelIndexingJobCommand extends HostBaseCommand<
   protected async run(
     input: BaseCommandModule.RealmIdentifierCard,
   ): Promise<undefined> {
-    await this.realm.cancelIndexingJob(input.realmIdentifier);
+    await this.realm.cancelIndexingJob(input.realmUrl);
   }
 }

--- a/packages/host/app/commands/evaluate-module.ts
+++ b/packages/host/app/commands/evaluate-module.ts
@@ -32,7 +32,7 @@ export default class EvaluateModuleCommand extends HostBaseCommand<
     input: BaseCommandModule.EvaluateModuleInput,
   ): Promise<BaseCommandModule.EvaluateModuleResult> {
     let moduleUrl = input.moduleIdentifier;
-    let realmUrl = input.realmIdentifier;
+    let realmUrl = input.realmUrl;
 
     if (!moduleUrl) {
       throw new Error('moduleUrl is required');

--- a/packages/host/app/commands/execute-atomic-operations.ts
+++ b/packages/host/app/commands/execute-atomic-operations.ts
@@ -22,7 +22,7 @@ export default class ExecuteAtomicOperationsCommand extends HostBaseCommand<
     return ExecuteAtomicOperationsInput;
   }
 
-  requireInputFields = ['realmIdentifier', 'operations'];
+  requireInputFields = ['realmUrl', 'operations'];
 
   protected async run(
     input: BaseCommandModule.ExecuteAtomicOperationsInput,
@@ -31,7 +31,7 @@ export default class ExecuteAtomicOperationsCommand extends HostBaseCommand<
     const { ExecuteAtomicOperationsResult } = commandModule;
     const results = await this.cardService.executeAtomicOperations(
       input.operations as AtomicOperation[],
-      new URL(input.realmIdentifier),
+      new URL(input.realmUrl),
     );
     const atomicResults = results['atomic:results'];
     if (!Array.isArray(atomicResults)) {

--- a/packages/host/app/commands/full-reindex-realm.ts
+++ b/packages/host/app/commands/full-reindex-realm.ts
@@ -25,6 +25,11 @@ export default class FullReindexRealmCommand extends HostBaseCommand<
   protected async run(
     input: BaseCommandModule.RealmIdentifierCard,
   ): Promise<undefined> {
+    if (!input.realmIdentifier) {
+      throw new Error(
+        "FullReindexRealmCommand requires a 'realmIdentifier' attribute (the realm URL).",
+      );
+    }
     await this.realm.fullReindex(input.realmIdentifier);
   }
 }

--- a/packages/host/app/commands/full-reindex-realm.ts
+++ b/packages/host/app/commands/full-reindex-realm.ts
@@ -25,11 +25,6 @@ export default class FullReindexRealmCommand extends HostBaseCommand<
   protected async run(
     input: BaseCommandModule.RealmIdentifierCard,
   ): Promise<undefined> {
-    if (!input.realmIdentifier) {
-      throw new Error(
-        "FullReindexRealmCommand requires a 'realmIdentifier' attribute (the realm URL).",
-      );
-    }
-    await this.realm.fullReindex(input.realmIdentifier);
+    await this.realm.fullReindex(input.realmUrl);
   }
 }

--- a/packages/host/app/commands/generate-example-cards.ts
+++ b/packages/host/app/commands/generate-example-cards.ts
@@ -85,7 +85,7 @@ export default class GenerateExampleCardsCommand extends HostBaseCommand<
       prompt: userPrompt,
       attachedCards: input.exampleCard ? [input.exampleCard] : [],
       attachedFileIdentifiers: this.getAttachedFileURLs(input),
-      realmIdentifier: realm,
+      realmUrl: realm,
     });
   }
 }

--- a/packages/host/app/commands/get-all-realm-metas.ts
+++ b/packages/host/app/commands/get-all-realm-metas.ts
@@ -30,7 +30,7 @@ export default class GetAllRealmMetasCommand extends HostBaseCommand<
         return new RealmMetaField({
           info: new RealmInfoField({ ...realmMeta.info }),
           canWrite: realmMeta.canWrite,
-          realmIdentifier: url,
+          realmUrl: url,
         });
       }),
     });

--- a/packages/host/app/commands/get-available-realm-identifiers.ts
+++ b/packages/host/app/commands/get-available-realm-identifiers.ts
@@ -23,7 +23,7 @@ export default class GetAvailableRealmIdentifiersCommand extends HostBaseCommand
     let commandModule = await this.loadCommandModule();
     const { GetAvailableRealmIdentifiersResult } = commandModule;
     return new GetAvailableRealmIdentifiersResult({
-      realmIdentifiers: this.realmServer.availableRealmURLs,
+      realmUrls: this.realmServer.availableRealmURLs,
     });
   }
 }

--- a/packages/host/app/commands/get-catalog-realm-identifiers.ts
+++ b/packages/host/app/commands/get-catalog-realm-identifiers.ts
@@ -23,7 +23,7 @@ export default class GetCatalogRealmIdentifiersCommand extends HostBaseCommand<
     let commandModule = await this.loadCommandModule();
     const { GetCatalogRealmIdentifiersResult } = commandModule;
     return new GetCatalogRealmIdentifiersResult({
-      realmIdentifiers: this.realmServer.catalogRealmURLs,
+      realmUrls: this.realmServer.catalogRealmURLs,
     });
   }
 }

--- a/packages/host/app/commands/get-default-writable-realm.ts
+++ b/packages/host/app/commands/get-default-writable-realm.ts
@@ -22,7 +22,7 @@ export default class GetDefaultWritableRealmCommand extends HostBaseCommand<
     let commandModule = await this.loadCommandModule();
     const { GetDefaultWritableRealmResult } = commandModule;
     return new GetDefaultWritableRealmResult({
-      realmIdentifier: this.realm.defaultWritableRealm?.path ?? '',
+      realmUrl: this.realm.defaultWritableRealm?.path ?? '',
     });
   }
 }

--- a/packages/host/app/commands/get-realm-of-resource-identifier.ts
+++ b/packages/host/app/commands/get-realm-of-resource-identifier.ts
@@ -29,9 +29,9 @@ export default class GetRealmOfResourceIdentifierCommand extends HostBaseCommand
   ): Promise<BaseCommandModule.GetRealmOfResourceIdentifierResult> {
     let commandModule = await this.loadCommandModule();
     const { GetRealmOfResourceIdentifierResult } = commandModule;
-    const realmIdentifier = this.realm.realmOf(rri(input.resourceIdentifier));
+    const realmUrl = this.realm.realmOf(rri(input.resourceIdentifier));
     return new GetRealmOfResourceIdentifierResult({
-      realmIdentifier: realmIdentifier ?? '',
+      realmUrl: realmUrl ?? '',
     });
   }
 }

--- a/packages/host/app/commands/instantiate-card.ts
+++ b/packages/host/app/commands/instantiate-card.ts
@@ -36,14 +36,14 @@ export default class InstantiateCardCommand extends HostBaseCommand<
     return commandModule.InstantiateCardInput;
   }
 
-  requireInputFields = ['moduleIdentifier', 'cardName', 'realmIdentifier'];
+  requireInputFields = ['moduleIdentifier', 'cardName', 'realmUrl'];
 
   protected async run(
     input: BaseCommandModule.InstantiateCardInput,
   ): Promise<BaseCommandModule.InstantiateCardResult> {
     let moduleUrl = input.moduleIdentifier;
     let cardName = input.cardName;
-    let realmUrl = input.realmIdentifier;
+    let realmUrl = input.realmUrl;
 
     if (!moduleUrl) {
       throw new Error('moduleUrl is required');

--- a/packages/host/app/commands/invalidate-realm-identifiers.ts
+++ b/packages/host/app/commands/invalidate-realm-identifiers.ts
@@ -26,7 +26,7 @@ export default class InvalidateRealmIdentifiersCommand extends HostBaseCommand<
     input: BaseCommandModule.InvalidateRealmIdentifiersInput,
   ): Promise<undefined> {
     await this.realm.invalidateUrls(
-      input.realmIdentifier,
+      input.realmUrl,
       input.resourceIdentifiers,
     );
   }

--- a/packages/host/app/commands/listing-create.ts
+++ b/packages/host/app/commands/listing-create.ts
@@ -55,10 +55,10 @@ export default class ListingCreateCommand extends HostBaseCommand<
   description = 'Create a catalog listing for an example card';
 
   private async getCatalogRealm(): Promise<string> {
-    const { realmIdentifiers } = await new GetCatalogRealmIdentifiersCommand(
+    const { realmUrls } = await new GetCatalogRealmIdentifiersCommand(
       this.commandContext,
     ).execute();
-    let catalogRealm = realmIdentifiers.find((realm: string) =>
+    let catalogRealm = realmUrls.find((realm: string) =>
       realm.endsWith('/catalog/'),
     );
     if (!catalogRealm) {
@@ -239,7 +239,7 @@ export default class ListingCreateCommand extends HostBaseCommand<
     moduleUrl: string, // the module URL of the card type being listed
     codeRef: ResolvedCodeRef, // the specific export being listed
   ): Promise<Spec[]> {
-    const { realmIdentifier: resourceRealmIdentifier } =
+    const { realmUrl: resourceRealmIdentifier } =
       await new GetRealmOfResourceIdentifierCommand(
         this.commandContext,
       ).execute({ resourceIdentifier: resourceUrl });

--- a/packages/host/app/commands/listing-generate-example.ts
+++ b/packages/host/app/commands/listing-generate-example.ts
@@ -44,7 +44,7 @@ export default class ListingGenerateExampleCommand extends HostBaseCommand<
       );
     }
 
-    const { realmIdentifier: defaultWritableRealmPath } =
+    const { realmUrl: defaultWritableRealmPath } =
       await new GetDefaultWritableRealmCommand(this.commandContext).execute();
     const targetRealm =
       input.realm ||

--- a/packages/host/app/commands/listing-install.ts
+++ b/packages/host/app/commands/listing-install.ts
@@ -52,9 +52,9 @@ export default class ListingInstallCommand extends HostBaseCommand<
   ): Promise<BaseCommandModule.ListingInstallResult> {
     let { realm, listing: listingInput } = input;
 
-    let { realmIdentifier } = await new ValidateRealmCommand(
+    let { realmUrl } = await new ValidateRealmCommand(
       this.commandContext,
-    ).execute({ realmIdentifier: realm });
+    ).execute({ realmUrl: realm });
 
     // this is intentionally to type because base command cannot interpret Listing type from catalog
     const listing = listingInput as Listing;
@@ -69,7 +69,7 @@ export default class ListingInstallCommand extends HostBaseCommand<
     let selectedCodeRef: ResolvedCodeRef | undefined;
     let skillCardId: string | undefined;
 
-    const builder = new PlanBuilder(realmIdentifier, listing);
+    const builder = new PlanBuilder(realmUrl, listing);
 
     builder
       .addIf(listing.specs?.length > 0, (resolver: ListingPathResolver) => {
@@ -80,13 +80,13 @@ export default class ListingInstallCommand extends HostBaseCommand<
       .addIf(examplesToInstall?.length > 0, (resolver: ListingPathResolver) => {
         let r = planInstanceInstall(examplesToInstall, resolver);
         let firstInstance = r.instancesCopy[0];
-        exampleCardId = join(realmIdentifier, firstInstance.lid);
+        exampleCardId = join(realmUrl, firstInstance.lid);
         selectedCodeRef = firstInstance.targetCodeRef;
         return r;
       })
       .addIf(listing.skills?.length > 0, (resolver: ListingPathResolver) => {
         let r = planInstanceInstall(listing.skills, resolver);
-        skillCardId = join(realmIdentifier, r.instancesCopy[0].lid);
+        skillCardId = join(realmUrl, r.instancesCopy[0].lid);
         return r;
       });
 
@@ -121,7 +121,7 @@ export default class ListingInstallCommand extends HostBaseCommand<
         delete (doc as any).included;
         let cardResource: LooseCardResource = (doc as any)
           .data as LooseCardResource;
-        let href = join(realmIdentifier, copyInstanceMeta.lid) + '.json';
+        let href = join(realmUrl, copyInstanceMeta.lid) + '.json';
         return { op: 'add' as const, href, data: cardResource };
       }),
     );
@@ -132,7 +132,7 @@ export default class ListingInstallCommand extends HostBaseCommand<
     try {
       ({ results: atomicResults } = await new ExecuteAtomicOperationsCommand(
         this.commandContext,
-      ).execute({ realmIdentifier, operations }));
+      ).execute({ realmUrl, operations }));
     } catch (e: any) {
       if (
         typeof e?.message === 'string' &&

--- a/packages/host/app/commands/listing-remix.ts
+++ b/packages/host/app/commands/listing-remix.ts
@@ -109,16 +109,16 @@ export default class RemixCommand extends HostBaseCommand<
     input: BaseCommandModule.ListingInstallInput,
   ): Promise<undefined> {
     let { realm, listing: listingInput } = input;
-    let { realmIdentifier } = await new ValidateRealmCommand(
+    let { realmUrl } = await new ValidateRealmCommand(
       this.commandContext,
-    ).execute({ realmIdentifier: realm });
+    ).execute({ realmUrl: realm });
 
     // this is intentionally to type because base command cannot interpret Listing type from catalog
     const listing = listingInput as Listing;
 
     const { selectedCodeRef, exampleCardId, skillCardId } =
       await new ListingInstallCommand(this.commandContext).execute({
-        realm: realmIdentifier,
+        realm: realmUrl,
         listing,
       });
     await this.navigateView({

--- a/packages/host/app/commands/listing-use.ts
+++ b/packages/host/app/commands/listing-use.ts
@@ -39,9 +39,9 @@ export default class ListingUseCommand extends HostBaseCommand<
 
     const listing = listingInput as Listing;
 
-    let { realmIdentifier } = await new ValidateRealmCommand(
+    let { realmUrl } = await new ValidateRealmCommand(
       this.commandContext,
-    ).execute({ realmIdentifier: realm });
+    ).execute({ realmUrl: realm });
 
     const specsToCopy = listing.specs ?? [];
     const specsWithoutFields = specsToCopy.filter(
@@ -64,7 +64,7 @@ export default class ListingUseCommand extends HostBaseCommand<
       let card = new Klass({}) as CardAPI.CardDef;
       await new SaveCardCommand(this.commandContext).execute({
         card,
-        realm: realmIdentifier,
+        realm: realmUrl,
         localDir,
       });
     }
@@ -76,7 +76,7 @@ export default class ListingUseCommand extends HostBaseCommand<
       for (const card of sourceCards) {
         await new CopyCardToRealmCommand(this.commandContext).execute({
           sourceCard: card,
-          targetRealm: realmIdentifier,
+          targetRealm: realmUrl,
           localDir,
         });
       }
@@ -87,7 +87,7 @@ export default class ListingUseCommand extends HostBaseCommand<
         listing.skills.map((skill: Skill) =>
           new CopyCardToRealmCommand(this.commandContext).execute({
             sourceCard: skill,
-            targetRealm: realmIdentifier,
+            targetRealm: realmUrl,
             localDir,
           }),
         ),

--- a/packages/host/app/commands/open-workspace.ts
+++ b/packages/host/app/commands/open-workspace.ts
@@ -21,17 +21,17 @@ export default class OpenWorkspaceCommand extends HostBaseCommand<
     return RealmIdentifierCard;
   }
 
-  requireInputFields = ['realmIdentifier'];
+  requireInputFields = ['realmUrl'];
 
   protected async run(
     input: BaseCommandModule.RealmIdentifierCard,
   ): Promise<undefined> {
-    let { realmIdentifier } = input;
-    if (!realmIdentifier) {
+    let { realmUrl } = input;
+    if (!realmUrl) {
       throw new Error('Realm identifier is required to open a workspace.');
     }
 
-    await this.operatorModeStateService.openWorkspace(realmIdentifier);
+    await this.operatorModeStateService.openWorkspace(realmUrl);
 
     return undefined;
   }

--- a/packages/host/app/commands/populate-with-sample-data.ts
+++ b/packages/host/app/commands/populate-with-sample-data.ts
@@ -70,7 +70,7 @@ export default class PopulateWithSampleDataCommand extends HostBaseCommand<
       prompt: this.prompt,
       attachedCards: [card],
       attachedFileIdentifiers: this.getAttachedFileURLs(card),
-      realmIdentifier: card[realmURL]?.href,
+      realmUrl: card[realmURL]?.href,
     });
   }
 }

--- a/packages/host/app/commands/reindex-realm.ts
+++ b/packages/host/app/commands/reindex-realm.ts
@@ -25,6 +25,11 @@ export default class ReindexRealmCommand extends HostBaseCommand<
   protected async run(
     input: BaseCommandModule.RealmIdentifierCard,
   ): Promise<undefined> {
+    if (!input.realmIdentifier) {
+      throw new Error(
+        "ReindexRealmCommand requires a 'realmIdentifier' attribute (the realm URL).",
+      );
+    }
     await this.realm.reindex(input.realmIdentifier);
   }
 }

--- a/packages/host/app/commands/reindex-realm.ts
+++ b/packages/host/app/commands/reindex-realm.ts
@@ -25,11 +25,6 @@ export default class ReindexRealmCommand extends HostBaseCommand<
   protected async run(
     input: BaseCommandModule.RealmIdentifierCard,
   ): Promise<undefined> {
-    if (!input.realmIdentifier) {
-      throw new Error(
-        "ReindexRealmCommand requires a 'realmIdentifier' attribute (the realm URL).",
-      );
-    }
-    await this.realm.reindex(input.realmIdentifier);
+    await this.realm.reindex(input.realmUrl);
   }
 }

--- a/packages/host/app/commands/sanitize-module-list.ts
+++ b/packages/host/app/commands/sanitize-module-list.ts
@@ -58,16 +58,16 @@ export default class SanitizeModuleListCommand extends HostBaseCommand<
         }
 
         // Only allow modules that belong to a realm we can read
-        const { realmIdentifier } =
+        const { realmUrl } =
           await new GetRealmOfResourceIdentifierCommand(
             this.commandContext,
           ).execute({ resourceIdentifier: dep });
-        if (!realmIdentifier) {
+        if (!realmUrl) {
           return null;
         }
         const { canRead } = await new CanReadRealmCommand(
           this.commandContext,
-        ).execute({ realmIdentifier });
+        ).execute({ realmUrl });
         return canRead ? dep : null;
       }),
     );

--- a/packages/host/app/commands/send-ai-assistant-message.ts
+++ b/packages/host/app/commands/send-ai-assistant-message.ts
@@ -99,7 +99,7 @@ export default class SendAiAssistantMessageCommand extends HostBaseCommand<
       new Set(attachedOpenCards.map((c) => c.id)),
     );
 
-    context.realmUrl = input.realmIdentifier;
+    context.realmUrl = input.realmUrl;
     context.requireToolCall = requireToolCall;
     context.tools = tools;
     context.functions = [];

--- a/packages/host/app/commands/sync-openrouter-models.ts
+++ b/packages/host/app/commands/sync-openrouter-models.ts
@@ -159,9 +159,9 @@ export default class SyncOpenRouterModelsCommand extends HostBaseCommand<
     input: BaseCommandModule.RealmIdentifierCard,
   ): Promise<BaseCommandModule.SyncOpenRouterModelsResult> {
     let commandModule = await this.loadCommandModule();
-    let realmURL = input.realmIdentifier;
+    let realmURL = input.realmUrl;
     if (!realmURL) {
-      throw new Error('realmIdentifier is required');
+      throw new Error('realmUrl is required');
     }
     if (!realmURL.endsWith('/')) {
       realmURL += '/';

--- a/packages/host/app/commands/validate-realm.ts
+++ b/packages/host/app/commands/validate-realm.ts
@@ -18,23 +18,23 @@ export default class ValidateRealmCommand extends HostBaseCommand<
     return ValidateRealmInput;
   }
 
-  requireInputFields = ['realmIdentifier'];
+  requireInputFields = ['realmUrl'];
 
   protected async run(
     input: BaseCommandModule.ValidateRealmInput,
   ): Promise<BaseCommandModule.ValidateRealmResult> {
-    let realmIdentifier = new RealmPaths(new URL(input.realmIdentifier)).url;
+    let realmUrl = new RealmPaths(new URL(input.realmUrl)).url;
 
-    let { realmIdentifiers } = await new GetAvailableRealmIdentifiersCommand(
+    let { realmUrls } = await new GetAvailableRealmIdentifiersCommand(
       this.commandContext,
     ).execute();
 
-    if (!realmIdentifiers.includes(realmIdentifier)) {
-      throw new Error(`Invalid realm: ${realmIdentifier}`);
+    if (!realmUrls.includes(realmUrl)) {
+      throw new Error(`Invalid realm: ${realmUrl}`);
     }
 
     let commandModule = await this.loadCommandModule();
     const { ValidateRealmResult } = commandModule;
-    return new ValidateRealmResult({ realmIdentifier });
+    return new ValidateRealmResult({ realmUrl });
   }
 }

--- a/packages/host/app/components/operator-mode/ask-ai-container.gts
+++ b/packages/host/app/components/operator-mode/ask-ai-container.gts
@@ -70,7 +70,7 @@ export default class AskAiContainer extends Component<Signature> {
             ? [this.operatorModeStateService.openFileURL]
             : undefined,
           openCardIds: openCards?.map((c) => c.id),
-          realmIdentifier: this.operatorModeStateService.realmURL,
+          realmUrl: this.operatorModeStateService.realmURL,
         }),
       ]);
 

--- a/packages/host/tests/integration/commands/can-read-realm-test.gts
+++ b/packages/host/tests/integration/commands/can-read-realm-test.gts
@@ -69,7 +69,7 @@ module('Integration | commands | can-read-realm', function (hooks) {
     let commandService = getService('command-service');
     let command = new CanReadRealmCommand(commandService.commandContext);
     let result = await command.execute({
-      realmIdentifier: 'https://example.com/readable/',
+      realmUrl: 'https://example.com/readable/',
     });
     assert.true(result.canRead);
   });
@@ -79,7 +79,7 @@ module('Integration | commands | can-read-realm', function (hooks) {
     let commandService = getService('command-service');
     let command = new CanReadRealmCommand(commandService.commandContext);
     let result = await command.execute({
-      realmIdentifier: 'https://example.com/private/',
+      realmUrl: 'https://example.com/private/',
     });
     assert.false(result.canRead);
   });

--- a/packages/host/tests/integration/commands/cancel-indexing-job-test.gts
+++ b/packages/host/tests/integration/commands/cancel-indexing-job-test.gts
@@ -80,7 +80,7 @@ module('Integration | commands | cancel-indexing-job', function (hooks) {
     let realmURL = new URL('test/', realmServer.url).href;
 
     let result = await command.execute({
-      realmIdentifier: realmURL,
+      realmUrl: realmURL,
     });
 
     assert.strictEqual(result, undefined, 'command has no result card');

--- a/packages/host/tests/integration/commands/evaluate-module-test.gts
+++ b/packages/host/tests/integration/commands/evaluate-module-test.gts
@@ -62,7 +62,7 @@ module('Integration | commands | evaluate-module', function (hooks) {
     let InputType = await command.getInputType();
     let input = new InputType({
       moduleIdentifier: `${testRealmURL}valid-card`,
-      realmIdentifier: testRealmURL,
+      realmUrl: testRealmURL,
     });
 
     let result = await command.execute(input);
@@ -78,7 +78,7 @@ module('Integration | commands | evaluate-module', function (hooks) {
     let InputType = await command.getInputType();
     let input = new InputType({
       moduleIdentifier: `${testRealmURL}broken-import-card`,
-      realmIdentifier: testRealmURL,
+      realmUrl: testRealmURL,
     });
 
     let result = await command.execute(input);

--- a/packages/host/tests/integration/commands/execute-atomic-operations-test.gts
+++ b/packages/host/tests/integration/commands/execute-atomic-operations-test.gts
@@ -73,7 +73,7 @@ module('Integration | commands | execute-atomic-operations', function (hooks) {
       commandService.commandContext,
     );
     let result = await command.execute({
-      realmIdentifier: testRealmURL,
+      realmUrl: testRealmURL,
       operations: [{ op: 'add', path: 'card-1' }] as any,
     });
     assert.deepEqual(result.results, [{ id: 'card-1' }, { id: 'card-2' }]);
@@ -89,7 +89,7 @@ module('Integration | commands | execute-atomic-operations', function (hooks) {
     );
     try {
       await command.execute({
-        realmIdentifier: testRealmURL,
+        realmUrl: testRealmURL,
         operations: [{ op: 'add', path: 'card-1' }] as any,
       });
       assert.ok(false, 'should have thrown');

--- a/packages/host/tests/integration/commands/full-reindex-realm-test.gts
+++ b/packages/host/tests/integration/commands/full-reindex-realm-test.gts
@@ -92,7 +92,7 @@ module('Integration | commands | full-reindex-realm', function (hooks) {
     );
 
     let result = await command.execute({
-      realmIdentifier: realmURL,
+      realmUrl: realmURL,
     });
 
     assert.strictEqual(result, undefined, 'command has no result card');
@@ -165,7 +165,7 @@ module('Integration | commands | full-reindex-realm', function (hooks) {
 
     await assert.rejects(
       command.execute({
-        realmIdentifier: realmURL,
+        realmUrl: realmURL,
       }),
       /Full reindex realm failed: 500 - boom/,
       'propagates non-204 failure as an error',

--- a/packages/host/tests/integration/commands/get-available-realm-identifiers-test.gts
+++ b/packages/host/tests/integration/commands/get-available-realm-identifiers-test.gts
@@ -74,7 +74,7 @@ module(
         commandService.commandContext,
       );
       let result = await command.execute();
-      assert.deepEqual(result.realmIdentifiers, [
+      assert.deepEqual(result.realmUrls, [
         'https://example.com/realm-a/',
         'https://example.com/realm-b/',
       ]);

--- a/packages/host/tests/integration/commands/get-catalog-realm-identifiers-test.gts
+++ b/packages/host/tests/integration/commands/get-catalog-realm-identifiers-test.gts
@@ -71,7 +71,7 @@ module(
         commandService.commandContext,
       );
       let result = await command.execute();
-      assert.deepEqual(result.realmIdentifiers, [
+      assert.deepEqual(result.realmUrls, [
         'https://example.com/catalog/',
       ]);
     });

--- a/packages/host/tests/integration/commands/get-default-writable-realm-test.gts
+++ b/packages/host/tests/integration/commands/get-default-writable-realm-test.gts
@@ -61,7 +61,7 @@ module('Integration | commands | get-default-writable-realm', function (hooks) {
       commandService.commandContext,
     );
     let result = await command.execute();
-    assert.strictEqual(result.realmIdentifier, testRealmURL);
+    assert.strictEqual(result.realmUrl, testRealmURL);
   });
 
   test('returns empty string when no default writable realm exists', async function (assert) {
@@ -77,6 +77,6 @@ module('Integration | commands | get-default-writable-realm', function (hooks) {
       commandService.commandContext,
     );
     let result = await command.execute();
-    assert.strictEqual(result.realmIdentifier, '');
+    assert.strictEqual(result.realmUrl, '');
   });
 });

--- a/packages/host/tests/integration/commands/get-realm-of-resource-identifier-test.gts
+++ b/packages/host/tests/integration/commands/get-realm-of-resource-identifier-test.gts
@@ -78,7 +78,7 @@ module(
       let result = await command.execute({
         resourceIdentifier: `${testRealmURL}some-card`,
       });
-      assert.strictEqual(result.realmIdentifier, testRealmURL);
+      assert.strictEqual(result.realmUrl, testRealmURL);
     });
 
     test('returns empty string when resource is not in any realm', async function (assert) {
@@ -90,7 +90,7 @@ module(
       let result = await command.execute({
         resourceIdentifier: 'https://unknown.example.com/card',
       });
-      assert.strictEqual(result.realmIdentifier, '');
+      assert.strictEqual(result.realmUrl, '');
     });
   },
 );

--- a/packages/host/tests/integration/commands/instantiate-card-test.gts
+++ b/packages/host/tests/integration/commands/instantiate-card-test.gts
@@ -76,7 +76,7 @@ module('Integration | commands | instantiate-card', function (hooks) {
     let input = new InputType({
       moduleIdentifier: `${testRealmURL}valid-card`,
       cardName: 'ValidCard',
-      realmIdentifier: testRealmURL,
+      realmUrl: testRealmURL,
       instanceData: JSON.stringify(instanceDoc),
     });
 
@@ -94,7 +94,7 @@ module('Integration | commands | instantiate-card', function (hooks) {
     let input = new InputType({
       moduleIdentifier: `${testRealmURL}valid-card`,
       cardName: 'ValidCard',
-      realmIdentifier: testRealmURL,
+      realmUrl: testRealmURL,
     });
 
     let result = await command.execute(input);
@@ -128,7 +128,7 @@ module('Integration | commands | instantiate-card', function (hooks) {
     let input = new InputType({
       moduleIdentifier: `${testRealmURL}tags-card`,
       cardName: 'TagsCard',
-      realmIdentifier: testRealmURL,
+      realmUrl: testRealmURL,
       instanceData: JSON.stringify(instanceDoc),
     });
 

--- a/packages/host/tests/integration/commands/invalidate-realm-identifiers-test.gts
+++ b/packages/host/tests/integration/commands/invalidate-realm-identifiers-test.gts
@@ -98,7 +98,7 @@ module(
       let realmURL = new URL('test/', realmServer.url).href;
 
       let result = await command.execute({
-        realmIdentifier: realmURL,
+        realmUrl: realmURL,
         resourceIdentifiers: [
           `${realmURL}mango`,
           `${realmURL}mango`,
@@ -168,7 +168,7 @@ module(
 
       await assert.rejects(
         command.execute({
-          realmIdentifier: realmURL,
+          realmUrl: realmURL,
           resourceIdentifiers: [`${realmURL}mango`],
         }),
         /Invalidate urls failed: 500 - boom/,

--- a/packages/host/tests/integration/commands/open-workspace-test.gts
+++ b/packages/host/tests/integration/commands/open-workspace-test.gts
@@ -49,7 +49,7 @@ module('Integration | commands | open-workspace', function (hooks) {
     );
     assert.strictEqual(operatorModeStateService.state?.submode, 'interact');
     await openWorkspaceCommand.execute({
-      realmIdentifier: testRealmURL,
+      realmUrl: testRealmURL,
     });
     assert.strictEqual(operatorModeStateService.state?.submode, 'interact');
     assert.strictEqual(operatorModeStateService.state?.stacks.length, 1);
@@ -68,7 +68,7 @@ module('Integration | commands | open-workspace', function (hooks) {
     let realmUrlWithTrailingSlash = testRealmURL;
     let realmUrlWithoutTrailingSlash = testRealmURL.replace(/\/$/, '');
     await openWorkspaceCommand.execute({
-      realmIdentifier: realmUrlWithoutTrailingSlash,
+      realmUrl: realmUrlWithoutTrailingSlash,
     });
     assert.strictEqual(
       operatorModeStateService.state?.stacks[0][0].id,

--- a/packages/host/tests/integration/commands/reindex-realm-test.gts
+++ b/packages/host/tests/integration/commands/reindex-realm-test.gts
@@ -92,7 +92,7 @@ module('Integration | commands | reindex-realm', function (hooks) {
     );
 
     let result = await command.execute({
-      realmIdentifier: realmURL,
+      realmUrl: realmURL,
     });
 
     assert.strictEqual(result, undefined, 'command has no result card');
@@ -161,7 +161,7 @@ module('Integration | commands | reindex-realm', function (hooks) {
 
     await assert.rejects(
       command.execute({
-        realmIdentifier: realmURL,
+        realmUrl: realmURL,
       }),
       /Reindex realm failed: 500 - boom/,
       'propagates non-204 failure as an error',
@@ -180,7 +180,7 @@ module('Integration | commands | reindex-realm', function (hooks) {
     let realmURL = new URL('test/', realmServer.url).href;
 
     await command.execute({
-      realmIdentifier: realmURL,
+      realmUrl: realmURL,
     });
 
     assert.true(

--- a/packages/host/tests/integration/commands/validate-realm-test.gts
+++ b/packages/host/tests/integration/commands/validate-realm-test.gts
@@ -59,8 +59,8 @@ module('Integration | commands | validate-realm', function (hooks) {
   test('returns normalized realm URL for a valid realm', async function (assert) {
     let commandService = getService('command-service');
     let command = new ValidateRealmCommand(commandService.commandContext);
-    let result = await command.execute({ realmIdentifier: testRealmURL });
-    assert.strictEqual(result.realmIdentifier, testRealmURL);
+    let result = await command.execute({ realmUrl: testRealmURL });
+    assert.strictEqual(result.realmUrl, testRealmURL);
   });
 
   test('throws error for an invalid realm URL', async function (assert) {
@@ -68,7 +68,7 @@ module('Integration | commands | validate-realm', function (hooks) {
     let command = new ValidateRealmCommand(commandService.commandContext);
     try {
       await command.execute({
-        realmIdentifier: 'https://invalid.example.com/realm/',
+        realmUrl: 'https://invalid.example.com/realm/',
       });
       assert.ok(false, 'should have thrown');
     } catch (e: any) {

--- a/packages/software-factory/src/eval-execution.ts
+++ b/packages/software-factory/src/eval-execution.ts
@@ -394,7 +394,7 @@ async function attemptEvaluateModule(
     realmServerUrl,
     realmUrl,
     EVALUATE_MODULE_COMMAND,
-    { moduleIdentifier: moduleUrl, realmIdentifier: realmUrl },
+    { moduleIdentifier: moduleUrl, realmUrl: realmUrl },
   );
 
   log.debug(

--- a/packages/software-factory/src/instantiate-execution.ts
+++ b/packages/software-factory/src/instantiate-execution.ts
@@ -778,7 +778,7 @@ async function attemptInstantiateCard(
   let commandInput: Record<string, unknown> = {
     moduleIdentifier: moduleUrl,
     cardName,
-    realmIdentifier: realmUrl,
+    realmUrl: realmUrl,
   };
   if (instanceData) {
     commandInput.instanceData = instanceData;

--- a/packages/software-factory/tests/evaluate-module-command.spec.ts
+++ b/packages/software-factory/tests/evaluate-module-command.spec.ts
@@ -238,7 +238,7 @@ test.describe('evaluate-module command', () => {
         realmServerUrl,
         realmUrl,
         '@cardstack/boxel-host/commands/evaluate-module/default',
-        { moduleIdentifier: moduleUrl, realmIdentifier: realmUrl },
+        { moduleIdentifier: moduleUrl, realmUrl: realmUrl },
       );
 
       expect(response.status).toBe('ready');
@@ -275,7 +275,7 @@ test.describe('evaluate-module command', () => {
         realmServerUrl,
         realmUrl,
         '@cardstack/boxel-host/commands/evaluate-module/default',
-        { moduleIdentifier: moduleUrl, realmIdentifier: realmUrl },
+        { moduleIdentifier: moduleUrl, realmUrl: realmUrl },
       );
 
       // If the prerender catches the broken import, the command should return passed=false


### PR DESCRIPTION
## Summary
- Renames the `realmIdentifier` / `realmIdentifiers` field on all realm-targeting cards in `packages/base/command.gts` to `realmUrl` / `realmUrls`, and updates every consumer in this repo.
- The field stores a realm URL; the previous name was misleading and caused LLM-driven callers (and humans) to pass `realmUrl` instead, which silently became `undefined` and crashed downstream in `ensureTrailingSlash` with the opaque WebKit error `undefined is not an object (evaluating 'e.endsWith')`.
- Class names (e.g. `RealmIdentifierCard`, `InvalidateRealmIdentifiersInput`, `GetAvailableRealmIdentifiersCommand`) and command file names are unchanged in this pass — only the field properties were renamed.

Affected cards (in `packages/base/command.gts`): `RealmIdentifierCard`, `SendAiAssistantMessageInput`, `EvaluateModuleInput`, `InstantiateCardInput`, `RealmMetaField`, `GetAvailableRealmIdentifiersResult`, `GetCatalogRealmIdentifiersResult`, `ExecuteAtomicOperationsInput`, `GetRealmOfResourceIdentifierResult`, `CanReadRealmInput`, `GetDefaultWritableRealmResult`, `ValidateRealmInput`, `ValidateRealmResult`.

52 files changed in this repo; 119 insertions / 129 deletions.

Related: [CS-11120](https://linear.app/cardstack/issue/CS-11120/reindexrealmcommand-throws-opaque-eendswith-error-when-called-with)

## ⚠️ Coordinated PR required in `boxel-catalog`
`packages/catalog/contents/` is gitignored and tracked in the separate [cardstack/boxel-catalog](https://github.com/cardstack/boxel-catalog) repo. Several files there still read `realmIdentifier` from `ValidateRealmCommand`/`GetCatalogRealmIdentifiersCommand`/`GetDefaultWritableRealmCommand` and write `realmIdentifier:` into `ExecuteAtomicOperationsCommand` input. Those consumers must be updated in lockstep with this PR, otherwise the catalog listing flows will break at runtime.

Files in the catalog repo that need parallel updates:
- `catalog-app/components/listing-fitted.gts`
- `catalog-app/listing/listing.gts`
- `commands/listing-create.ts`
- `commands/listing-generate-example.ts`
- `commands/listing-install.ts`
- `commands/listing-remix.ts`
- `commands/listing-use.ts`

(Also `packages/runtime-common/virtual-network.ts` intentionally retains a function parameter named `realmIdentifier` — it's unrelated to the schema field.)

## Test plan
- [x] `pnpm lint:types` passes in `packages/host`
- [x] `pnpm lint:types` passes in `packages/software-factory`
- [ ] Reindex a realm via the AI assistant using a `realmUrl` attribute — confirm it succeeds instead of producing the `e.endsWith` error.
- [ ] Smoke-test the listing flows that consume `ValidateRealmCommand` / `ExecuteAtomicOperationsCommand` once the matching boxel-catalog PR is in place.
- [ ] Run host integration command tests — `packages/host/tests/integration/commands/*-test.gts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)