### PR TITLE
observability: pin volkovlabs-form-panel to 6.3.3, fix stale comment (CS-10928)

### DIFF
--- a/packages/observability/docker-compose.yml
+++ b/packages/observability/docker-compose.yml
@@ -37,13 +37,20 @@ services:
     environment:
       GF_SECURITY_ADMIN_PASSWORD: admin
       GF_AUTH_ANONYMOUS_ENABLED: "false"
-      # Volkov Labs Business Forms panel — used by Operator Actions panels
-      # in boxel-status/indexing, realms, users, and job-queue dashboards.
-      # Signed plugin, archived upstream at v6.2.0 (2025-09) but still
-      # functional on Grafana 12.x. Staging / production self-host Grafana
-      # installs this via cardstack/infra
-      # configs/grafana/base/container-definitions/grafana.yaml.
-      GF_INSTALL_PLUGINS: "volkovlabs-form-panel"
+      # Business Forms panel — used by the Operator Actions panels in the
+      # boxel-status/indexing, realms, users, and job-queue dashboards.
+      # Community-signed; maintained by Grafana Labs (the original Volkov
+      # Labs repo was archived but Grafana picked up maintenance, so this
+      # is a regular active plugin, not a dead-end).
+      #
+      # Version pin keeps task replacements (local + staging/prod) on
+      # the same release — `customCode` semantics can shift between
+      # versions and we don't want a silent upgrade. Bump deliberately;
+      # check https://grafana.com/api/plugins/volkovlabs-form-panel for
+      # the latest version. Staging / production install via
+      # cardstack/infra configs/grafana/base/container-definitions/grafana.yaml
+      # and need a matching bump there when this one moves.
+      GF_INSTALL_PLUGINS: "volkovlabs-form-panel 6.3.3"
       # Substituted into provisioning/datasources/loki.yaml at startup.
       LOKI_URL: http://loki:3100
       # Substituted into provisioning/datasources/boxel-db.yaml at startup.


### PR DESCRIPTION
## Summary

Two small fixes in `packages/observability/docker-compose.yml`:

1. **Pin `volkovlabs-form-panel` to 6.3.3** in `GF_INSTALL_PLUGINS`. Without a version suffix, Grafana pulls whatever the plugin catalog returns at task-start — and since the plugin is actively maintained, that's a real change-without-PR risk. \`customCode\` semantics can shift between releases; pin and bump deliberately.

2. **Fix the misleading comment.** The previous comment described the plugin as "archived upstream at v6.2.0 (2025-09) but still functional on Grafana 12.x," implying a dead-end. It's not — Grafana Labs has picked up maintenance after the original Volkov Labs repo was archived. Catalog shows v6.3.3 active, last updated 2026-04-30 (12 days ago), orgName "Grafana Labs."

Linear: [CS-10928](https://linear.app/cardstack/issue/CS-10928/install-button-panel-plugin-in-grafana-ecs-task-definition)

### What's left in CS-10928

The matching pin on the staging/prod side lives in `cardstack/infra:configs/grafana/base/container-definitions/grafana.yaml`. That's a separate PR against the infra repo — needs to bump to 6.3.3 in lockstep.

## Test plan

- [ ] `cd packages/observability && docker compose up -d grafana` — confirm Grafana boots and Configuration → Plugins shows "Business Forms 6.3.3" as Installed (not Error).
- [ ] Open one of the operator-action dashboards locally (e.g. \`/d/boxelrealms001\`) and confirm the form-panel buttons render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)