### PR TITLE
Remember prerender scroll position to prevent jump

### DIFF
--- a/packages/host/app/components/host-mode/card.gts
+++ b/packages/host/app/components/host-mode/card.gts
@@ -67,7 +67,7 @@ export default class HostModeCard extends Component<Signature> {
 
     let timer: ReturnType<typeof next> | undefined;
     let attempts = 0;
-    let maxAttempts = 10;
+    const maxAttempts = 10;
 
     let restore = () => {
       attempts++;

--- a/packages/host/app/components/host-mode/card.gts
+++ b/packages/host/app/components/host-mode/card.gts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 import { cached } from '@glimmer/tracking';
 
 import { BoxelButton, CardContainer } from '@cardstack/boxel-ui/components';
-import { bool } from '@cardstack/boxel-ui/helpers';
+import { bool, cn } from '@cardstack/boxel-ui/helpers';
 
 import CardRenderer from '@cardstack/host/components/card-renderer';
 import CardError from '@cardstack/host/components/operator-mode/card-error';
@@ -56,8 +56,9 @@ export default class HostModeCard extends Component<Signature> {
 
   <template>
     <CardContainer
-      class='host-mode-card {{if @isPrimary "is-primary"}}'
+      class={{cn 'host-mode-card' is-primary=@isPrimary}}
       displayBoundaries={{@displayBoundaries}}
+      data-host-mode-card
       data-test-host-mode-card-loaded={{bool this.card}}
       ...attributes
     >

--- a/packages/host/app/components/host-mode/card.gts
+++ b/packages/host/app/components/host-mode/card.gts
@@ -1,6 +1,9 @@
 import { on } from '@ember/modifier';
+import { cancel, next, scheduleOnce } from '@ember/runloop';
 import Component from '@glimmer/component';
 import { cached } from '@glimmer/tracking';
+
+import { modifier } from 'ember-modifier';
 
 import { BoxelButton, CardContainer } from '@cardstack/boxel-ui/components';
 import { bool, cn } from '@cardstack/boxel-ui/helpers';
@@ -54,11 +57,66 @@ export default class HostModeCard extends Component<Signature> {
     );
   }
 
+  // Reads a scroll offset stashed by removeIsolatedMarkup in a <meta> element
+  // and applies it once the primary card's content has rendered and the
+  // actual scroll host is available. Only runs on the primary card.
+  restoreScroll = modifier((element: HTMLElement, [card]: [unknown]) => {
+    if (!card || !this.args.isPrimary) {
+      return;
+    }
+
+    let timer: ReturnType<typeof next> | undefined;
+    let attempts = 0;
+    let maxAttempts = 10;
+
+    let restore = () => {
+      attempts++;
+
+      let meta = document.querySelector('meta[name="boxel-restore-scroll"]');
+      if (!(meta instanceof HTMLMetaElement)) {
+        return;
+      }
+
+      let scrollTop = parseInt(meta.getAttribute('content') ?? '0', 10);
+      if (scrollTop <= 0) {
+        meta.remove();
+        return;
+      }
+
+      let scrollTarget =
+        (element.querySelector(
+          '[data-host-mode-card-scroll-container]',
+        ) as HTMLElement | null) ?? element;
+      let isScrollable = scrollTarget.scrollHeight > scrollTarget.clientHeight;
+      if (!isScrollable && attempts < maxAttempts) {
+        timer = next(restore);
+        return;
+      }
+
+      scrollTarget.scrollTop = scrollTop;
+
+      if (scrollTarget.scrollTop === scrollTop || attempts >= maxAttempts) {
+        meta.remove();
+        return;
+      }
+
+      timer = next(restore);
+    };
+
+    scheduleOnce('afterRender', restore);
+
+    return () => {
+      if (timer) {
+        cancel(timer);
+      }
+    };
+  });
+
   <template>
     <CardContainer
+      {{this.restoreScroll this.card}}
       class={{cn 'host-mode-card' is-primary=@isPrimary}}
       displayBoundaries={{@displayBoundaries}}
-      data-host-mode-card
       data-test-host-mode-card-loaded={{bool this.card}}
       ...attributes
     >
@@ -73,6 +131,7 @@ export default class HostModeCard extends Component<Signature> {
           class='card'
           @card={{this.card}}
           @format='isolated'
+          data-host-mode-card-scroll-container
           data-test-host-mode-card={{@cardId}}
         />
       {{else if this.isLoading}}

--- a/packages/host/app/templates/index.gts
+++ b/packages/host/app/templates/index.gts
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import { getOwner } from '@ember/owner';
 import type RouterService from '@ember/routing/router-service';
+import { scheduleOnce } from '@ember/runloop';
 import { service } from '@ember/service';
 import { isDevelopingApp } from '@embroider/macros';
 import Component from '@glimmer/component';
@@ -205,6 +206,21 @@ export class IndexComponent extends Component<IndexComponentComponentSignature> 
     };
   });
 
+  // Holds the scroll offset captured just before prerendered markup is
+  // removed, so it can be restored on the Ember-rendered card container.
+  #prehydrateScrollTop = 0;
+
+  private restorePrehydrateScrollTop() {
+    if (this.#prehydrateScrollTop === 0) {
+      return;
+    }
+    let cardContainer = document.querySelector('data-host-mode-card');
+    if (cardContainer instanceof HTMLElement) {
+      cardContainer.scrollTop = this.#prehydrateScrollTop;
+    }
+    this.#prehydrateScrollTop = 0;
+  }
+
   // TODO: remove in CS-9977, with rehydration
   removeIsolatedMarkup = modifier(() => {
     if (typeof document === 'undefined') {
@@ -215,11 +231,29 @@ export class IndexComponent extends Component<IndexComponentComponentSignature> 
     if (!start || !end) {
       return;
     }
+
+    // Before hydration the page scrolls at window level; after hydration the
+    // card container becomes the scroll host. Capture both so we cover
+    // whichever is non-zero.
+    let scrollTop = window.scrollY;
+    let prerenderedContainer = start.nextElementSibling;
+    if (
+      prerenderedContainer instanceof HTMLElement &&
+      prerenderedContainer !== end
+    ) {
+      scrollTop = Math.max(scrollTop, prerenderedContainer.scrollTop);
+    }
+
     let node = start.nextSibling;
     while (node && node !== end) {
       let next = node.nextSibling;
       node.parentNode?.removeChild(node);
       node = next;
+    }
+
+    if (scrollTop > 0) {
+      this.#prehydrateScrollTop = scrollTop;
+      scheduleOnce('afterRender', this, this.restorePrehydrateScrollTop);
     }
   });
 

--- a/packages/host/app/templates/index.gts
+++ b/packages/host/app/templates/index.gts
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import { getOwner } from '@ember/owner';
 import type RouterService from '@ember/routing/router-service';
-import { scheduleOnce } from '@ember/runloop';
+
 import { service } from '@ember/service';
 import { isDevelopingApp } from '@embroider/macros';
 import Component from '@glimmer/component';
@@ -206,21 +206,6 @@ export class IndexComponent extends Component<IndexComponentComponentSignature> 
     };
   });
 
-  // Holds the scroll offset captured just before prerendered markup is
-  // removed, so it can be restored on the Ember-rendered card container.
-  #prehydrateScrollTop = 0;
-
-  private restorePrehydrateScrollTop() {
-    if (this.#prehydrateScrollTop === 0) {
-      return;
-    }
-    let cardContainer = document.querySelector('[data-host-mode-card]');
-    if (cardContainer instanceof HTMLElement) {
-      cardContainer.scrollTop = this.#prehydrateScrollTop;
-    }
-    this.#prehydrateScrollTop = 0;
-  }
-
   // TODO: remove in CS-9977, with rehydration
   removeIsolatedMarkup = modifier(() => {
     if (typeof document === 'undefined') {
@@ -235,7 +220,7 @@ export class IndexComponent extends Component<IndexComponentComponentSignature> 
     // Before hydration the page scrolls at window level; after hydration the
     // card container becomes the scroll host. Capture both so we cover
     // whichever is non-zero.
-    let scrollTop = window.scrollY;
+    let scrollTop = 0;
     let prerenderedContainer = start.nextElementSibling;
     if (
       prerenderedContainer instanceof HTMLElement &&
@@ -243,6 +228,7 @@ export class IndexComponent extends Component<IndexComponentComponentSignature> 
     ) {
       scrollTop = Math.max(scrollTop, prerenderedContainer.scrollTop);
     }
+    scrollTop = Math.max(scrollTop, window.scrollY);
 
     let node = start.nextSibling;
     while (node && node !== end) {
@@ -251,9 +237,14 @@ export class IndexComponent extends Component<IndexComponentComponentSignature> 
       node = next;
     }
 
+    // Stash the captured offset in a meta element so HostModeCard can pick it
+    // up and apply it once the card content has rendered and the container is
+    // scrollable.
     if (scrollTop > 0) {
-      this.#prehydrateScrollTop = scrollTop;
-      scheduleOnce('afterRender', this, this.restorePrehydrateScrollTop);
+      let meta = document.createElement('meta');
+      meta.setAttribute('name', 'boxel-restore-scroll');
+      meta.setAttribute('content', String(scrollTop));
+      document.head.appendChild(meta);
     }
   });
 

--- a/packages/host/app/templates/index.gts
+++ b/packages/host/app/templates/index.gts
@@ -214,7 +214,7 @@ export class IndexComponent extends Component<IndexComponentComponentSignature> 
     if (this.#prehydrateScrollTop === 0) {
       return;
     }
-    let cardContainer = document.querySelector('data-host-mode-card');
+    let cardContainer = document.querySelector('[data-host-mode-card]');
     if (cardContainer instanceof HTMLElement) {
       cardContainer.scrollTop = this.#prehydrateScrollTop;
     }

--- a/packages/host/app/templates/index.gts
+++ b/packages/host/app/templates/index.gts
@@ -241,10 +241,15 @@ export class IndexComponent extends Component<IndexComponentComponentSignature> 
     // up and apply it once the card content has rendered and the container is
     // scrollable.
     if (scrollTop > 0) {
-      let meta = document.createElement('meta');
-      meta.setAttribute('name', 'boxel-restore-scroll');
+      let meta = document.head.querySelector(
+        'meta[name="boxel-restore-scroll"]',
+      );
+      if (!meta) {
+        meta = document.createElement('meta');
+        meta.setAttribute('name', 'boxel-restore-scroll');
+        document.head.appendChild(meta);
+      }
       meta.setAttribute('content', String(scrollTop));
-      document.head.appendChild(meta);
     }
   });
 

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -9,6 +9,7 @@ import {
 
 import { getService } from '@universal-ember/test-support';
 import { getPageTitle } from 'ember-page-title/test-support';
+import window from 'ember-window-mock';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
@@ -522,6 +523,47 @@ module('Acceptance | host mode tests', function (hooks) {
 
     // Stack shouldn't exist when there are no stacked cards
     assert.dom('[data-test-host-mode-stack]').doesNotExist();
+  });
+
+  test('scroll position is restored on card container after hydration', async function (assert) {
+    // Simulate the user having scrolled down the prerendered page before JS
+    // loaded. ember-window-mock stores this in its holder object so that
+    // window.scrollY reads back 300 inside the removeIsolatedMarkup modifier.
+    (window as unknown as Record<string, unknown>).scrollY = 300;
+
+    // Constrain the card container and force its inner card renderer to
+    // overflow so that scrollTop can actually be set to a non-zero value.
+    // Browsers clamp scrollTop to (scrollHeight − clientHeight), so the
+    // content must be taller than the container for the restoration to stick.
+    let testStyle = document.createElement('style');
+    testStyle.textContent = `
+      [data-host-mode-card] {
+        height: 100px !important;
+        max-height: 100px !important;
+      }
+      [data-host-mode-card] .card {
+        height: 500px !important;
+        min-height: 500px !important;
+        flex: none !important;
+      }
+    `;
+    document.head.appendChild(testStyle);
+
+    try {
+      await visit('/test/Pet/mango.json');
+      await waitFor('[data-test-pet-isolated="Mango"]');
+
+      let cardContainer = document.querySelector(
+        '[data-host-mode-card]',
+      ) as HTMLElement;
+      assert.ok(cardContainer, 'card container exists');
+      assert.ok(
+        cardContainer.scrollTop > 0,
+        `scroll position is restored onto card container after hydration (scrollTop=${cardContainer.scrollTop})`,
+      );
+    } finally {
+      testStyle.remove();
+    }
   });
 
   module('with a custom subdomain', function (hooks) {

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -131,6 +131,111 @@ module('Acceptance | host mode tests', function (hooks) {
         </template>
       };
     }
+    class Whitepaper extends CardDef {
+      static displayName = 'Boxel Whitepaper';
+      static prefersWideFormat = true;
+
+      @field cardTitle = contains(StringField, {
+        computeVia: function () {
+          return 'Boxel Whitepaper';
+        },
+      });
+
+      static isolated = class Isolated extends Component<typeof this> {
+        <template>
+          <article class='whitepaper' data-test-whitepaper>
+            <header class='wp-header'>
+              <h1>Boxel Whitepaper</h1>
+              <p class='wp-subtitle'>A System for Composable Software in the Age
+                of Abundant Code</p>
+              <p class='wp-byline'>By Chris Tse, Cardstack Foundation — January
+                2026</p>
+            </header>
+            <section>
+              <h2>Executive Summary</h2>
+              <p>We are witnessing the most significant shift in software
+                development since the invention of high-level programming
+                languages. Large language models (LLMs) can now generate
+                functional code in seconds. Yet the infrastructure surrounding
+                that code—the databases, the deployment pipelines, the security
+                models, the economic relationships—remains trapped in paradigms
+                from the 1990s.</p>
+              <p>The result is a peculiar kind of friction. You can ask Claude
+                to write you a React component in thirty seconds, but deploying
+                that component to production still requires navigating a maze of
+                Git repositories, CI/CD pipelines, environment variables, SSL
+                certificates, and cloud provider dashboards. The intelligence
+                has arrived, but the architecture hasn't caught up.</p>
+              <p>Boxel is what comes next: a complete environment where
+                AI-generated software can be created, run, evolved, and
+                monetized without ever leaving a coherent system. Not another
+                tool to add to your stack—a replacement for the stack itself.</p>
+            </section>
+            <section>
+              <h2>1. The Fragmentation Problem</h2>
+              <p>Open your browser tabs right now. If you're building anything
+                with AI, you probably have ChatGPT or Claude open for ideation
+                and code generation. Cursor or Windsurf for editing that code in
+                context. V0 or Lovable for generating UI components. GitHub for
+                version control. Vercel or Netlify for deployment. Notion or
+                Confluence for documentation. Figma for design. Slack or Discord
+                for communication.</p>
+              <p>Each of these tools is excellent at what it does. Each
+                represents millions of dollars in engineering investment and
+                years of refinement. And each is a silo.</p>
+              <p>The workflow: describe an idea to ChatGPT, copy the code into
+                Cursor, commit to GitHub, deploy to Vercel, document in Notion,
+                share in Slack. At each boundary, you lose context. The AI that
+                helped you write the code doesn't know how you deployed it. The
+                documentation system doesn't understand the code it describes.</p>
+              <p>The irony is acute. We have AI systems capable of understanding
+                complex software in its entirety—but we force them to operate
+                through disconnected interfaces, each with its own
+                authentication, its own data model, its own limitations. We have
+                given AI the ability to think holistically while constraining it
+                to act in fragments.</p>
+            </section>
+          </article>
+
+          <style scoped>
+            .whitepaper {
+              max-width: 50rem;
+              margin: 0 auto;
+              padding: 2rem;
+              font-family: Georgia, serif;
+              line-height: 1.7;
+            }
+            .wp-header {
+              border-bottom: 2px solid var(--boxel-purple, #6638d0);
+              margin-bottom: 2rem;
+              padding-bottom: 1rem;
+            }
+            h1 {
+              font-size: 2rem;
+              margin: 0 0 0.5rem;
+            }
+            h2 {
+              font-size: 1.3rem;
+              margin: 2rem 0 0.75rem;
+            }
+            p {
+              margin: 0 0 1rem;
+            }
+            .wp-subtitle {
+              font-style: italic;
+              font-size: 1.1rem;
+              margin: 0 0 0.25rem;
+            }
+            .wp-byline {
+              color: #666;
+              font-size: 0.9rem;
+              margin: 0;
+            }
+          </style>
+        </template>
+      };
+    }
+
     await setupAcceptanceTestRealm({
       realmURL: testHostModeRealmURL,
       mockMatrixUtils,
@@ -140,7 +245,20 @@ module('Acceptance | host mode tests', function (hooks) {
       contents: {
         ...SYSTEM_CARD_FIXTURE_CONTENTS,
         'pet.gts': { Pet },
+        'whitepaper.gts': { Whitepaper },
         'view-card-demo.gts': viewCardDemoCardSource,
+        'Whitepaper/index.json': {
+          data: {
+            type: 'card',
+            attributes: {},
+            meta: {
+              adoptsFrom: {
+                module: `${testHostModeRealmURL}whitepaper`,
+                name: 'Whitepaper',
+              },
+            },
+          },
+        },
         'Pet/mango.json': {
           data: {
             attributes: {
@@ -526,43 +644,45 @@ module('Acceptance | host mode tests', function (hooks) {
   });
 
   test('scroll position is restored on card container after hydration', async function (assert) {
-    // Simulate the user having scrolled down the prerendered page before JS
-    // loaded. ember-window-mock stores this in its holder object so that
-    // window.scrollY reads back 300 inside the removeIsolatedMarkup modifier.
-    (window as unknown as Record<string, unknown>).scrollY = 300;
+    // Inject boundary markers and a fake prerendered card container between
+    // them, simulating the prerendered HTML served before JS loads. The
+    // container has a fixed height so its content overflows and scrollTop can
+    // be set non-zero.
+    let start = document.createElement('div');
+    start.id = 'boxel-isolated-start';
+    let end = document.createElement('div');
+    end.id = 'boxel-isolated-end';
+    let fakeContainer = document.createElement('div');
+    fakeContainer.style.cssText = 'height: 200px; overflow-y: auto;';
+    fakeContainer.innerHTML = '<div style="height: 2000px;"></div>';
+    document.body.appendChild(start);
+    document.body.appendChild(fakeContainer);
+    document.body.appendChild(end);
+    // Must set scrollTop after the element is in the DOM
+    fakeContainer.scrollTop = 150;
 
-    // Constrain the card container and force its inner card renderer to
-    // overflow so that scrollTop can actually be set to a non-zero value.
-    // Browsers clamp scrollTop to (scrollHeight − clientHeight), so the
-    // content must be taller than the container for the restoration to stick.
+    // Constrain the Ember-rendered card container so it can also hold a scroll
+    // offset (overflow-y: auto is already set; we just need a bounded height)
     let testStyle = document.createElement('style');
-    testStyle.textContent = `
-      [data-host-mode-card] {
-        height: 100px !important;
-        max-height: 100px !important;
-      }
-      [data-host-mode-card] .card {
-        height: 500px !important;
-        min-height: 500px !important;
-        flex: none !important;
-      }
-    `;
+    testStyle.setAttribute('data-test-scroll-override', '');
+    testStyle.textContent =
+      '[data-test-host-mode-card-loaded] { height: 400px !important; max-height: 400px !important; }';
     document.head.appendChild(testStyle);
 
     try {
-      await visit('/test/Pet/mango.json');
-      await waitFor('[data-test-pet-isolated="Mango"]');
+      await visit('/test/Whitepaper/index.json');
+      await waitFor('[data-test-whitepaper]');
 
       let cardContainer = document.querySelector(
-        '[data-host-mode-card]',
+        '[data-host-mode-card-scroll-container]',
       ) as HTMLElement;
-      assert.ok(cardContainer, 'card container exists');
-      assert.ok(
-        cardContainer.scrollTop > 0,
-        `scroll position is restored onto card container after hydration (scrollTop=${cardContainer.scrollTop})`,
+      assert.strictEqual(
+        cardContainer.scrollTop,
+        150,
+        'scroll position from prerendered container is restored on the hydrated card scroll host',
       );
     } finally {
-      testStyle.remove();
+      document.querySelector('[data-test-scroll-override]')?.remove();
     }
   });
 

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -673,6 +673,7 @@ module('Acceptance | host mode tests', function (hooks) {
       await visit('/test/Whitepaper/index.json');
       await waitFor('[data-test-whitepaper]');
 
+      assert.dom('[data-host-mode-card-scroll-container]').exists();
       let cardContainer = document.querySelector(
         '[data-host-mode-card-scroll-container]',
       ) as HTMLElement;
@@ -683,6 +684,9 @@ module('Acceptance | host mode tests', function (hooks) {
       );
     } finally {
       document.querySelector('[data-test-scroll-override]')?.remove();
+      start.remove();
+      end.remove();
+      fakeContainer.remove();
     }
   });
 


### PR DESCRIPTION
## Summary
- Preserve host-mode scroll position across hydration by capturing the prerendered/window scroll offset before isolated markup is removed, then restoring it after render onto the hydrated card scroll container
- Add focused host-mode acceptance coverage for that hydration path, including a dedicated wide-format whitepaper fixture and a stable non-test `data-*` selector for the runtime scroll host