### PR TITLE
observability: parameterize worker-status alert log group per env (CS-11107)

### DIFF
--- a/.github/workflows/observability-apply-production.yml
+++ b/.github/workflows/observability-apply-production.yml
@@ -70,6 +70,16 @@ jobs:
       # hostname for paranoia.
       EXPECTED_GRAFANA_HOSTNAME: dashboard.boxel.ai
       GRAFANACTL_VERSION: "0.1.10"
+      # Worker CloudWatch log group + owning AWS account, substituted into
+      # provisioning/alerting/worker-status-group.json at push time
+      # (CS-11107). Hardcoded here rather than fetched from SSM: the log
+      # group name follows the deterministic `ecs-boxel-worker-<env>`
+      # convention and the account-id is already baked into AWS_ROLE_ARN
+      # above. Without this, the same provisioning file shipped to both
+      # envs would have prod querying staging's log group (the original
+      # CS-11107 bug — every evaluation failed with ResourceNotFoundException).
+      WORKER_LOG_GROUP_NAME: ecs-boxel-worker-production
+      WORKER_LOG_GROUP_ACCOUNT_ID: "120317779495"
 
     steps:
       - name: Refuse to apply from non-main branches

--- a/.github/workflows/observability-apply-staging.yml
+++ b/.github/workflows/observability-apply-staging.yml
@@ -57,6 +57,15 @@ jobs:
       # grafanactl is still pre-1.0 — bump as needed; the install action
       # (.github/actions/install-grafanactl) verifies the SHA-256.
       GRAFANACTL_VERSION: "0.1.10"
+      # Worker CloudWatch log group + owning AWS account, substituted into
+      # provisioning/alerting/worker-status-group.json at push time
+      # (CS-11107). Hardcoded here rather than fetched from SSM: the log
+      # group name follows the deterministic `ecs-boxel-worker-<env>`
+      # convention and the account-id is already baked into AWS_ROLE_ARN
+      # above. If the staging account ever moves, both values below and
+      # AWS_ROLE_ARN need to update together.
+      WORKER_LOG_GROUP_NAME: ecs-boxel-worker-staging
+      WORKER_LOG_GROUP_ACCOUNT_ID: "680542703984"
 
     steps:
       - name: Checkout

--- a/packages/observability/docker-compose.yml
+++ b/packages/observability/docker-compose.yml
@@ -61,6 +61,14 @@ services:
       BOXEL_DB_NAME: ${BOXEL_DB_NAME:-boxel}
       BOXEL_DB_USER: ${BOXEL_DB_USER:-postgres}
       BOXEL_DB_PASSWORD: ${BOXEL_DB_PASSWORD:-postgres}
+      # Substituted into provisioning/alerting/worker-status-group.json at
+      # startup (CS-11107). Defaults to staging so the rule loads with a
+      # real-shaped value; local Grafana has no AWS creds so the rule will
+      # never actually evaluate against CloudWatch — substituting empty
+      # strings here would just put a malformed-looking ARN into the rule
+      # body, which Grafana would log at startup.
+      WORKER_LOG_GROUP_NAME: ${WORKER_LOG_GROUP_NAME:-ecs-boxel-worker-staging}
+      WORKER_LOG_GROUP_ACCOUNT_ID: ${WORKER_LOG_GROUP_ACCOUNT_ID:-680542703984}
     extra_hosts:
       # Lets the Grafana container reach the host's Postgres
       # (boxel-pg on 5435) for the local postgres data source.

--- a/packages/observability/provisioning/alerting/worker-status-group.json
+++ b/packages/observability/provisioning/alerting/worker-status-group.json
@@ -36,9 +36,9 @@
                 "label": "",
                 "logGroups": [
                   {
-                    "accountId": "680542703984",
-                    "arn": "arn:aws:logs:us-east-1:680542703984:log-group:ecs-boxel-worker-staging",
-                    "name": "ecs-boxel-worker-staging"
+                    "accountId": "${WORKER_LOG_GROUP_ACCOUNT_ID}",
+                    "arn": "arn:aws:logs:us-east-1:${WORKER_LOG_GROUP_ACCOUNT_ID}:log-group:${WORKER_LOG_GROUP_NAME}",
+                    "name": "${WORKER_LOG_GROUP_NAME}"
                   }
                 ],
                 "matchExact": true,
@@ -184,9 +184,9 @@
                 "label": "",
                 "logGroups": [
                   {
-                    "accountId": "680542703984",
-                    "arn": "arn:aws:logs:us-east-1:680542703984:log-group:ecs-boxel-worker-staging",
-                    "name": "ecs-boxel-worker-staging"
+                    "accountId": "${WORKER_LOG_GROUP_ACCOUNT_ID}",
+                    "arn": "arn:aws:logs:us-east-1:${WORKER_LOG_GROUP_ACCOUNT_ID}:log-group:${WORKER_LOG_GROUP_NAME}",
+                    "name": "${WORKER_LOG_GROUP_NAME}"
                   }
                 ],
                 "matchExact": true,

--- a/packages/observability/scripts/apply.sh
+++ b/packages/observability/scripts/apply.sh
@@ -75,6 +75,13 @@ if [[ "$env_name" != "local" ]]; then
     # constant template variable — CS-10929. Used as `Authorization: Bearer
     # ${grafana_secret}` by the operator-action button panels.
     GRAFANA_SECRET
+    # CloudWatch log group + owning AWS account substituted into the
+    # worker-status-group alert rules at push time — CS-11107. The same
+    # provisioning file is shipped to both envs, so the log-group name
+    # and account-id have to come from outside the file, otherwise prod
+    # ends up querying staging's log group and every evaluation 404s.
+    WORKER_LOG_GROUP_NAME
+    WORKER_LOG_GROUP_ACCOUNT_ID
   )
   for v in "${required_env_vars[@]}"; do
     [[ -n "${!v:-}" ]] \


### PR DESCRIPTION
## Summary

- The same `provisioning/alerting/worker-status-group.json` ships to both staging and production Grafana, but had the staging log group (`ecs-boxel-worker-staging`, account `680542703984`) hardcoded into both `Worker Reap` and `Worker Startup` rules. Prod Grafana queries via the prod task role hit `ResourceNotFoundException` on every evaluation — once per minute × 3 retries × 2 rules — flooding the alert pipeline (and SMTP retries on top of that, tracked separately).
- Replace the hardcoded values with `${WORKER_LOG_GROUP_NAME}` and `${WORKER_LOG_GROUP_ACCOUNT_ID}`. `apply-alerting.sh` already supports `${VAR}` substitution from the shell environment, and its header explicitly calls out log-group / account-id parameterization as the motivating use case.
- Per-env values are set in each apply workflow's job-level `env:` block (staging → `ecs-boxel-worker-staging` / `680542703984`; production → `ecs-boxel-worker-production` / `120317779495`). Hardcoded rather than SSM-sourced: the names follow the deterministic `ecs-boxel-worker-<env>` convention and the account-id is already implicit in `AWS_ROLE_ARN`.
- `docker-compose.yml` gets the same two vars with staging defaults so the local Grafana's file provisioning parses cleanly (local has no AWS creds, so the rule never actually evaluates).

Fixes [CS-11107](https://linear.app/cardstack/issue/CS-11107/fix-worker-reap-worker-startup-alert-rules-querying-staging-log-group).

## Test plan

- [x] `./scripts/lint.sh` clean (JSON parses, manifests valid, shellcheck clean)
- [x] `envsubst` dry-run with staging values yields `name=ecs-boxel-worker-staging`, `accountId=680542703984`, correct ARN
- [x] `envsubst` dry-run with production values yields `name=ecs-boxel-worker-production`, `accountId=120317779495`, correct ARN
- [x] YAML env blocks parse cleanly (`yq -e`)
- [x] `shellcheck` on `apply.sh` + `apply-alerting.sh` clean
- [ ] Stage-1 (merge): `observability-apply-staging.yml` runs against staging. Confirm both rules still evaluate cleanly there (they did before; this should be a no-op for staging).
- [ ] Stage-2 (manual dispatch from `main`): `observability-apply-production.yml`. Tail prod Grafana logs for ≥1h after apply and verify no `ResourceNotFoundException` for `rule_uid=berxlrqsnzoxse` or `eerxlrqsghzwgd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)