### PR TITLE
CS-11123 Phase 1: Pre-warm modules table before indexing (serial)

### DIFF
--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -34,7 +34,9 @@ import type { CacheScope, DefinitionLookup } from './definition-lookup';
 import { resolveCardReference } from './card-reference-resolver';
 import { isCardError } from './error';
 import type { IndexingProgressEvent } from './worker';
+import { canonicalURL } from './index-runner/dependency-url';
 import { IndexRunnerDependencyManager } from './index-runner/dependency-resolver';
+import { isScopedCSSRequest } from './scoped-css';
 import {
   discoverInvalidations,
   type DiscoverInvalidationsResult,
@@ -201,6 +203,7 @@ export class IndexRunner {
       await current.#dependencyResolver.orderInvalidationsByDependencies(
         invalidations,
       );
+    await current.preWarmModulesTable(invalidations);
     let resumedRows = current.batch.resumedRows;
     let resumedSkipped = 0;
     current.#onProgress?.({
@@ -351,6 +354,7 @@ export class IndexRunner {
       }
       current.#scheduleClearCacheForNextRender();
     }
+    await current.preWarmModulesTable(invalidations);
 
     let hrefs = urls.map((u) => u.href);
     let resumedRows = current.batch.resumedRows;
@@ -527,6 +531,138 @@ export class IndexRunner {
       authUserId: isPublic ? '' : this.#realmOwnerUserId,
     };
     return this.#moduleCacheContext;
+  }
+
+  // Populate the `modules` table for every module the upcoming visit
+  // loop is likely to need, before the file-visit phase fires.
+  //
+  // Why: a file render that fires a `_federated-search` calling
+  // `populateQueryFields` → `lookupDefinition` for a definition not
+  // in the modules cache triggers a nested prerender. That nested
+  // prerender enters the same affinity-scoped tab queue the original
+  // render is occupying, deadlocking the pool (PR #4777 papered over
+  // this with `cacheOnlyDefinitions:true`). Pre-warming the modules
+  // table before the visit loop fires means `lookupDefinition` hits
+  // a populated row instead of spawning a sub-prerender.
+  //
+  // Signal sources, in priority order:
+  //   1. Existing `boxel_index.deps` — the runtime-captured dep list
+  //      from the URL's prior successful render. Strongest signal.
+  //   2. `adoptsFrom.module` read from disk — used for novel `.json`
+  //      URLs without a prior `deps` row.
+  //   3. The URL itself — used for novel executable files; the file
+  //      IS a module, pre-warm it directly.
+  //
+  // Cache hits are O(1) DB reads inside DefinitionLookup. Cache
+  // misses go through the read-through path
+  // (loadModuleCacheEntryUncached → getModuleDefinitionsViaPrerenderer
+  // → persistModuleCacheEntry), the same flow `lookupDefinition`
+  // uses; DefinitionLookup owns the in-flight dedup and the cross-
+  // process coalescer, so two callers asking for the same URL share
+  // one prerender.
+  //
+  // Phase 1: serial. Validates that pre-warm as a concept clears the
+  // deadlock without concurrency-driven variability. Phase 2 will
+  // bound-parallelize this loop.
+  //
+  // Failures here are warned but do not fail the batch — a mid-render
+  // sub-prerender will still fire on demand if pre-warm misses a
+  // module.
+  private async preWarmModulesTable(invalidations: URL[]): Promise<void> {
+    if (invalidations.length === 0) {
+      return;
+    }
+    let preWarmStart = Date.now();
+    let hrefs = invalidations.map((u) => u.href);
+    let existingRows = await this.batch.getDependencyRows(hrefs);
+    let bestByUrl = new Map<string, { url: string; deps: string[] | null }>();
+    for (let row of existingRows) {
+      // Prefer rows that actually carry deps so the lookup below
+      // returns the strongest signal available for each URL.
+      let existing = bestByUrl.get(row.url);
+      if (!existing || (!existing.deps?.length && row.deps?.length)) {
+        bestByUrl.set(row.url, { url: row.url, deps: row.deps ?? null });
+      }
+    }
+
+    let toWarm = new Set<string>();
+    let novelJsonUrls: URL[] = [];
+    for (let url of invalidations) {
+      // Module files in the invalidation set are deps that instances
+      // in the same batch will consume — pre-warm them directly. This
+      // covers from-scratch and atomic-update batches where most rows
+      // have no prior `deps` data yet.
+      if (hasExecutableExtension(url.href)) {
+        toWarm.add(url.href);
+      }
+      let row = bestByUrl.get(url.href);
+      if (row?.deps?.length) {
+        for (let dep of row.deps) {
+          let resolved = canonicalURL(dep, url.href);
+          // `.json` marks an instance dep and `.glimmer-scoped.css`
+          // marks an inline-styles artifact; everything else in the
+          // deps array is a module URL (stored extensionless after
+          // normalizeModuleURL / normalizeDependency).
+          if (!resolved.endsWith('.json') && !isScopedCSSRequest(resolved)) {
+            toWarm.add(resolved);
+          }
+        }
+      } else if (url.href.endsWith('.json')) {
+        novelJsonUrls.push(url);
+      }
+    }
+    for (let url of novelJsonUrls) {
+      let adoptsFromModule = await this.#readAdoptsFromModuleFromDisk(url);
+      // adoptsFrom.module is always a module reference. The most common
+      // form is relative + extensionless (e.g. `"../author"`), which
+      // canonicalizes to an extensionless URL; gating on
+      // hasExecutableExtension would drop those entirely and leave
+      // pre-warm missing exactly the module it is supposed to prime.
+      if (adoptsFromModule) {
+        toWarm.add(adoptsFromModule);
+      }
+    }
+
+    if (toWarm.size === 0) {
+      return;
+    }
+
+    let failed = 0;
+    for (let moduleUrl of toWarm) {
+      try {
+        await this.#definitionLookup.getModuleCacheEntry(moduleUrl);
+      } catch {
+        failed += 1;
+      }
+    }
+    if (failed > 0) {
+      this.#log.warn(
+        `${jobIdentity(this.#jobInfo)} ${failed} of ${toWarm.size} module pre-warm lookups failed; the visit phase will retry on-demand if needed`,
+      );
+    }
+
+    this.#perfLog.debug(
+      `${jobIdentity(this.#jobInfo)} pre-warm complete in ${Date.now() - preWarmStart} ms (candidates=${toWarm.size} failed=${failed})`,
+    );
+  }
+
+  async #readAdoptsFromModuleFromDisk(url: URL): Promise<string | undefined> {
+    try {
+      let fileRef = await this.#reader.readFile(url);
+      if (!fileRef?.content) {
+        return undefined;
+      }
+      let doc = JSON.parse(fileRef.content) as {
+        data?: { meta?: { adoptsFrom?: { module?: unknown } } };
+      };
+      let module = doc?.data?.meta?.adoptsFrom?.module;
+      if (typeof module !== 'string') {
+        return undefined;
+      }
+      return canonicalURL(module, url.href);
+    } catch {
+      return undefined;
+    }
   }
 
   #scheduleClearCacheForNextRender() {


### PR DESCRIPTION
## Summary

- Walk the invalidation set before the file-visit loop and ensure every module URL the upcoming renders will need has a populated `modules` row.
- Reads go through `CachingDefinitionLookup.getModuleCacheEntry` — same read-through path `lookupDefinition` uses, so DB hits return immediately and misses share the in-flight dedup + cross-process coalescer with regular lookups.
- Serial pass first: validates that pre-warm as a concept clears the nested-prerender deadlock in isolation from concurrency-driven variability. Phase 2 (separate PR) bound-parallelizes this.

**Why this matters:** A file render that fires `_federated-search` → `populateQueryFields` → `lookupDefinition` for a cold definition spawns a nested prerender into the same affinity-scoped tab queue the original render is holding — deadlock. `cacheOnlyDefinitions:true` papers over this; pre-warming kills it at the root. With the table primed, `lookupDefinition` hits a populated DB row instead of spawning a sub-prerender.

**Signal sources for the URL set, in priority order:**
1. Existing `boxel_index.deps` — the runtime-captured dep list from the URL's prior successful render.
2. `adoptsFrom.module` read via `reader.readFile` — for novel `.json` URLs without a prior `deps` row.
3. The URL itself — for novel executable files; the file IS a module.

Failures in the pre-warm phase are warned but do not fail the batch. A mid-render sub-prerender will still fire on demand if pre-warm misses a module — degrading to the pre-PR behavior for that specific module, not deadlocking the batch.

Wired into both `fromScratch` and `incremental`, called once after `orderInvalidationsByDependencies` and before the visit loop opens.

## Test plan

- [ ] Bench `/prudent-octopus` from-scratch reindex on top of this PR — `wall_seconds` no worse than the main baseline (~190 s prod-built).
- [ ] Bench `/ambitious/prianha` from-scratch reindex on top of this PR — must complete (no rejection at the 150 s prerender abort on the heavy `Tracking/Cohort/*.json` render). Capture `wall_seconds`, `instancesIndexed`, `instanceErrors`, and the `_federated-search` HTTP count.
- [ ] Confirm pre-warm walk wall-clock cost: how many module URLs, how many prerenders fired, total time. Should be a small fraction of the total reindex time.
- [ ] Existing realm-server indexing integration tests still pass.

This is Phase 1 of a 3-PR stack:
- **Phase 1 (this PR)**: serial pre-warm.
- Phase 2: bound-parallelize the pre-warm walk.
- Phase 3: unwind the `cacheOnlyDefinitions` workaround now that pre-warm covers the same ground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Bench results (vite-dev rig, 2026-05-12)

Protocol: `mise run kill-all` → `TRUNCATE job_reservations, jobs, job_progress` → `mise run dev-all` → boot drain (`unfulfilled=0 active=0`) → readiness-check on each realm → mount drain → `time curl /_grafana-reindex?realm=user/<realm>`. Same-rig as the prior `main` baseline (commit `0119bac76d`) captured in the Linear ticket comment.

### Phase 1 — current SHA (`c85633d237`), post the extensionless-`adoptsFrom` fix

| Realm | SHA | Wall (s) | Status | fed-search hits | filesIndexed | instancesIndexed | instanceErrors |
| --- | --- | ---: | --- | ---: | ---: | ---: | ---: |
| `user/prudent-octopus` | `main 0119bac76d` | 617 | resolved | 120 | 118 | 91 | 0 |
| `user/prudent-octopus` | Phase 1 `c85633d237` | **467** | resolved | 176 | 118 | 91 | 0 |
| `user/ambitious-piranha` | `main 0119bac76d` | 652 | rejected (500) | 614 | — | — | — |
| `user/ambitious-piranha` | Phase 1 `c85633d237` | 195 | rejected (500) | 18 | — | — | — |

### Octopus

Phase 1 trims **150 s (~24%)** off the main baseline — pre-warm front-loads the modules a cohort render needs so the visit phase doesn't have to spawn nested prerenders inside `populateQueryFields`. 91 instances / 0 errors matches main exactly; the extensionless-`adoptsFrom` fix on the latest push resolved the earlier 90/1-error result (`adoptsFrom.module` was being filtered out for the common relative-extensionless form like `"../author"`, so the cohort instance referencing it never got its module pre-warmed and errored at index time). fed-search count goes 120 → 176 (+47%) — consistent with more renders completing the live `populateQueryFields` path rather than degrading.

### Piranha

Still rejects with the 150 s prerender-server abort during the first cohort render — same outcome as `main`, which also rejects piranha. The bar is *piranha completes*, and pre-warm alone does **not** clear it (only 18 fed-search hits before the 150 s single-render budget is exhausted on the heavy `Tracking/Cohort/*.json` render). Comparing wall-clock-to-rejection (195 s vs 652 s) is noise — both runs fail the bar, so time-to-failure is not meaningful.

Pre-warm Phase 1 alone is insufficient to clear piranha. The next dependent ticket ([CS-11117](https://linear.app/cardstack/issue/CS-11117) — width-aware parallel visit loop) plus other cohort-render optimizations will be needed. Phase 2 (bounded-parallel pre-warm) and Phase 3 (unwind cacheOnlyDefinitions) bench results will be appended as they come in.

### Pass-bar status for Phase 1

- ✅ Octopus wall-clock no worse than baseline (improved by 24%, no instanceErrors).
- ❌ Piranha does not complete; same end state as `main`, so pre-warm alone is not sufficient. Tracking as a follow-up signal for the broader pre-warm + parallel-visit-loop combination.
