### PR TITLE
CS-11123 Phase 2: Bound-parallelize pre-warm walk

### DIFF
--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -45,6 +45,42 @@ import { visitFileForIndexingFused } from './index-runner/visit-file';
 import { performCardIndexing } from './index-runner/card-indexer';
 import { performFileIndexing } from './index-runner/file-indexer';
 
+// Bound for the pre-warm parallel walk. Each in-flight pre-warm can
+// fire a `prerenderModule` against the prerender pool when the URL
+// isn't already in the modules cache; the prerender server's
+// affinity-scoped admission cap handles the actual back-pressure
+// against the pool, but bounding here keeps the websocket fan-out
+// from spiking on large invalidation sets. The same cap also bounds
+// the upstream `readFile`/JSON parse fan-out for novel `.json`
+// invalidations, since `reader.readFile` is an HTTP fetch in the
+// worker process.
+const PRE_WARM_MAX_CONCURRENCY = 4;
+
+// Run `fn` over `items` with at most `concurrency` outstanding calls.
+// Results are returned in the input order, regardless of completion
+// order. Failures from `fn` propagate — the caller is expected to
+// catch inside `fn` if best-effort semantics are wanted.
+async function runBounded<T, R>(
+  items: T[],
+  fn: (item: T) => Promise<R>,
+  concurrency: number,
+): Promise<R[]> {
+  let results: R[] = new Array(items.length);
+  let next = 0;
+  let limit = Math.min(items.length, concurrency);
+  let worker = async () => {
+    for (let i = next++; i < items.length; i = next++) {
+      results[i] = await fn(items[i]);
+    }
+  };
+  let workers: Promise<void>[] = [];
+  for (let i = 0; i < limit; i++) {
+    workers.push(worker());
+  }
+  await Promise.all(workers);
+  return results;
+}
+
 export class IndexRunner {
   #indexingInstances = new Map<string, Promise<void>>();
   #reader: Reader;
@@ -548,8 +584,10 @@ export class IndexRunner {
   // Signal sources, in priority order:
   //   1. Existing `boxel_index.deps` — the runtime-captured dep list
   //      from the URL's prior successful render. Strongest signal.
-  //   2. `adoptsFrom.module` read from disk — used for novel `.json`
-  //      URLs without a prior `deps` row.
+  //   2. `adoptsFrom.module` read via `reader.readFile` — used for
+  //      novel `.json` URLs without a prior `deps` row. In the
+  //      worker context the reader is HTTP-backed; the call is fast
+  //      but not free.
   //   3. The URL itself — used for novel executable files; the file
   //      IS a module, pre-warm it directly.
   //
@@ -561,9 +599,15 @@ export class IndexRunner {
   // process coalescer, so two callers asking for the same URL share
   // one prerender.
   //
-  // Phase 1: serial. Validates that pre-warm as a concept clears the
-  // deadlock without concurrency-driven variability. Phase 2 will
-  // bound-parallelize this loop.
+  // Parallel: pre-warm lookups fire in bounded parallel batches. The
+  // CachingDefinitionLookup `#inFlight` map coalesces concurrent
+  // same-URL callers into one prerender, so parallel callers asking
+  // for the same URL share work rather than duplicating it.
+  //
+  // The novel `.json` `adoptsFrom` source reads are also parallelized
+  // (under the same concurrency bound) so a wide invalidation set
+  // doesn't pay N sequential `reader.readFile` calls — which are
+  // HTTP fetches in the worker context — for the upfront resolution.
   //
   // Failures here are warned but do not fail the batch — a mid-render
   // sub-prerender will still fire on demand if pre-warm misses a
@@ -611,15 +655,25 @@ export class IndexRunner {
         novelJsonUrls.push(url);
       }
     }
-    for (let url of novelJsonUrls) {
-      let adoptsFromModule = await this.#readAdoptsFromModuleFromDisk(url);
-      // adoptsFrom.module is always a module reference. The most common
-      // form is relative + extensionless (e.g. `"../author"`), which
-      // canonicalizes to an extensionless URL; gating on
+    if (novelJsonUrls.length > 0) {
+      // `reader.readFile` is HTTP in the worker process, so this
+      // fan-out is bounded by the same cap as the module lookups —
+      // a wide invalidation set won't burst N concurrent fetches
+      // against the realm server.
+      let adoptsFrom = await runBounded(
+        novelJsonUrls,
+        (u) => this.#readAdoptsFromModuleViaReader(u),
+        PRE_WARM_MAX_CONCURRENCY,
+      );
+      // adoptsFrom.module is always a module reference. The most
+      // common form is relative + extensionless (e.g. `"../author"`),
+      // which canonicalizes to an extensionless URL; gating on
       // hasExecutableExtension would drop those entirely and leave
       // pre-warm missing exactly the module it is supposed to prime.
-      if (adoptsFromModule) {
-        toWarm.add(adoptsFromModule);
+      for (let module of adoptsFrom) {
+        if (module) {
+          toWarm.add(module);
+        }
       }
     }
 
@@ -627,14 +681,20 @@ export class IndexRunner {
       return;
     }
 
+    let moduleUrls = [...toWarm];
     let failed = 0;
-    for (let moduleUrl of toWarm) {
-      try {
-        await this.#definitionLookup.getModuleCacheEntry(moduleUrl);
-      } catch {
-        failed += 1;
-      }
-    }
+    await runBounded(
+      moduleUrls,
+      async (moduleUrl) => {
+        try {
+          await this.#definitionLookup.getModuleCacheEntry(moduleUrl);
+        } catch {
+          failed += 1;
+        }
+      },
+      PRE_WARM_MAX_CONCURRENCY,
+    );
+
     if (failed > 0) {
       this.#log.warn(
         `${jobIdentity(this.#jobInfo)} ${failed} of ${toWarm.size} module pre-warm lookups failed; the visit phase will retry on-demand if needed`,
@@ -646,7 +706,7 @@ export class IndexRunner {
     );
   }
 
-  async #readAdoptsFromModuleFromDisk(url: URL): Promise<string | undefined> {
+  async #readAdoptsFromModuleViaReader(url: URL): Promise<string | undefined> {
     try {
       let fileRef = await this.#reader.readFile(url);
       if (!fileRef?.content) {


### PR DESCRIPTION
## Summary

- Replace Phase 1's serial pre-warm loop with a bounded-parallel walk: N workers (cap = 4, `PRE_WARM_MAX_CONCURRENCY`) pull from a shared queue of module URLs and call `getModuleCacheEntry` per slot.
- Parallelize the upfront `adoptsFrom.module` source reads (HTTP via `reader.readFile` in the worker process) for novel `.json` invalidations — bounded by the same cap.
- Concurrent same-URL callers continue to coalesce through `CachingDefinitionLookup`'s `#inFlight` map, so parallel pre-warm never duplicates a prerender.

**Bound rationale.** The cap of 4 matches the planned `INDEX_RUNNER_MAX_CONCURRENCY` from the sibling parallel-visit-loop work. The cap is on _admission_ here only — the prerender server's affinity-scoped tab queue still owns the real back-pressure against the pool; bounding here just keeps the websocket fan-out from spiking on large invalidation sets.

Built on top of [Phase 1 (#4799)](https://github.com/cardstack/boxel/pull/4799). Base this PR's merge against `main` after Phase 1 lands; until then it targets the Phase 1 branch.

## Test plan

- [ ] Bench `/prudent-octopus` reindex on top of this PR — total wall-clock drops vs Phase 1, no new `instanceErrors`.
- [ ] Bench `/ambitious/prianha` reindex on top of this PR — still completes, total wall-clock drops vs Phase 1.
- [ ] Confirm pre-warm walk wall-clock drops measurably vs Phase 1 (proportional to module count and concurrency, modulo prerender-pool contention).
- [ ] If Phase 2 does not deliver a measurable win over Phase 1 — for instance because the prerender pool is already saturated by the upcoming parallel file-visit phase — close this PR and ship Phase 1 + Phase 3 only.
- [ ] Existing realm-server indexing integration tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Bench results (vite-dev rig, 2026-05-13)

Same-rig as the prior `main` baseline (commit `0119bac76d`) and the Phase 1 numbers in [#4799](https://github.com/cardstack/boxel/pull/4799). Protocol: `mise run kill-all` → `TRUNCATE job_reservations, jobs, job_progress` → `mise run dev-all` → boot drain → readiness-check mount → mount drain → `time curl /_grafana-reindex`.

| Realm | SHA | Wall (s) | Status | fed-search hits | filesIndexed | instancesIndexed | instanceErrors |
| --- | --- | ---: | --- | ---: | ---: | ---: | ---: |
| `user/prudent-octopus` | `main 0119bac76d` | 617 | resolved | 120 | 118 | 91 | 0 |
| `user/prudent-octopus` | Phase 1 `c85633d237` | 467 | resolved | 176 | 118 | 91 | 0 |
| `user/prudent-octopus` | Phase 2 `d386c145a1` | **512** | resolved | 174 | 118 | 91 | 0 |
| `user/ambitious-piranha` | `main 0119bac76d` | 652 | rejected (500) | 614 | — | — | — |
| `user/ambitious-piranha` | Phase 1 `c85633d237` | 195 | rejected (500) | 18 | — | — | — |
| `user/ambitious-piranha` | Phase 2 `d386c145a1` | 189 | rejected (500) | 18 | — | — | — |

### Phase 2 does not deliver a measurable win

Octopus on Phase 2 is **45 s slower** than Phase 1 (512 s vs 467 s, +9.6 %), not faster. Piranha is unchanged — still rejects at the 150 s prerender-server abort during the first cohort render.

The likeliest read: the prerender pool's affinity-scoped tab queue is already serializing module renders inside the per-realm affinity, so bounded-parallel admission at the indexer doesn't expand the effective concurrency — it just adds a small overhead (extra promise scheduling, more concurrent `#inFlight` map churn) that surfaces as the +45 s drift.

### Phase 2 pass-bar status

- ❌ Octopus wall-clock does **not** drop measurably vs Phase 1; it rises by 45 s.
- ❌ Piranha unchanged — still rejects.
- Phase 2 fails the ticket's pass-bar: *"If Phase 2 doesn't deliver a measurable win over Phase 1 … note it and stop. Don't ship parallelism that doesn't show up in the numbers."*

**Recommendation: close this PR.** Ship Phase 1 (serial pre-warm, with the `adoptsFrom` fix that resolves the octopus `instanceError`) and Phase 3 (`cacheOnlyDefinitions` unwind, conditional on piranha being addressable elsewhere) without the parallel walk.
