### PR TITLE
CS-11123: Unwind cacheOnlyDefinitions workaround

### DIFF
--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -23,7 +23,6 @@ import {
   baseFileRef,
   CardError,
   cardIdToURL,
-  DURING_PRERENDER_HEADER,
   isRegisteredPrefix,
   hasExecutableExtension,
   isCardError,
@@ -119,17 +118,6 @@ let waiter = buildWaiter('store-service');
 const realmEventsLogger = logger('realm:events');
 const storeLogger = logger('store');
 
-// Set by the prerender server's `evaluateOnNewDocument` before the
-// SPA boots — `__boxelDuringPrerender = true`. Read here so the
-// federated-search fetch wrapper can attach the marker header on
-// realm-server-bound calls only, narrowly scoping the signal to the
-// endpoint that needs it. See realm.ts:DURING_PRERENDER_HEADER for
-// the full chain.
-function duringPrerenderHeaders(): Record<string, string> {
-  let flag = (globalThis as unknown as { __boxelDuringPrerender?: boolean })
-    .__boxelDuringPrerender;
-  return flag ? { [DURING_PRERENDER_HEADER]: '1' } : {};
-}
 const queryFieldSeedFromSearchSymbol = Symbol.for(
   'cardstack-query-field-seed-from-search',
 );
@@ -839,7 +827,6 @@ export default class StoreService extends Service implements StoreInterface {
         headers: {
           Accept: SupportedMimeType.CardJson,
           'Content-Type': 'application/json',
-          ...duringPrerenderHeaders(),
         },
         body: JSON.stringify({ ...query, realms }),
       },
@@ -906,7 +893,6 @@ export default class StoreService extends Service implements StoreInterface {
         headers: {
           Accept: SupportedMimeType.CardJson,
           'Content-Type': 'application/json',
-          ...duringPrerenderHeaders(),
         },
         body: JSON.stringify({ ...query, realms }),
       },

--- a/packages/realm-server/handlers/handle-search.ts
+++ b/packages/realm-server/handlers/handle-search.ts
@@ -1,7 +1,6 @@
 import type Koa from 'koa';
 import {
   buildSearchErrorResponse,
-  DURING_PRERENDER_HEADER,
   SupportedMimeType,
   parseSearchQueryFromPayload,
   parseSearchQueryFromRequest,
@@ -42,11 +41,9 @@ export default function handleSearch(): (ctxt: Koa.Context) => Promise<void> {
       throw e;
     }
 
-    let cacheOnlyDefinitions = ctxt.get(DURING_PRERENDER_HEADER).length > 0;
     let combined = await searchRealms(
       realmList.map((realmURL) => realmByURL.get(realmURL)),
       cardsQuery,
-      cacheOnlyDefinitions ? { cacheOnlyDefinitions: true } : undefined,
     );
 
     await setContextResponse(

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -1256,7 +1256,6 @@ export class PagePool {
           'Expected each prerender page to use its own browser context for localStorage isolation',
         );
       }
-      await this.#markPageAsInPrerender(page);
       let pageId = uuidv4();
       await this.#attachPageObservability(page, 'standby', pageId);
       await this.#loadStandbyPage(page, pageId);
@@ -1846,7 +1845,6 @@ export class PagePool {
     let page: Page | undefined;
     try {
       page = await shared.context.newPage();
-      await this.#markPageAsInPrerender(page);
       let pageId = uuidv4();
       await this.#attachPageObservability(page, affinityKey, pageId);
       await this.#loadStandbyPage(page, pageId);
@@ -2191,31 +2189,6 @@ export class PagePool {
     } catch (e) {
       log.warn(`Error closing shared context for ${affinityKey}:`, e);
     }
-  }
-
-  // Inject a window global into every page before any document
-  // loads, so the host SPA can synchronously detect at boot that it's
-  // running inside a prerender tab. Used by the host's
-  // realm-server fetch wrapper to attach `x-boxel-during-prerender`
-  // on _federated-search / _search calls only — narrowly scoped so
-  // unrelated services (icons, vite, etc.) don't see the header on
-  // their CORS preflights. The inbound signal the realm server reads
-  // tells it to pass cacheOnlyDefinitions:true to searchCards,
-  // short-circuiting the recursive lookupDefinition fan-out in
-  // populateQueryFields that causes self-referential prerender
-  // deadlocks under parallel indexing.
-  async #markPageAsInPrerender(page: Page): Promise<void> {
-    // Test stubs of Page in prerender-deadlock-test.ts don't expose
-    // every puppeteer method — guard the call so this stays optional
-    // observability rather than a load-bearing side effect.
-    if (typeof page.evaluateOnNewDocument !== 'function') {
-      return;
-    }
-    await page.evaluateOnNewDocument(() => {
-      (
-        globalThis as unknown as { __boxelDuringPrerender?: boolean }
-      ).__boxelDuringPrerender = true;
-    });
   }
 
   // Attach all per-page error/exception observability surfaces. The

--- a/packages/realm-server/prerender/prerender-constants.ts
+++ b/packages/realm-server/prerender/prerender-constants.ts
@@ -36,22 +36,6 @@ export function sanitizePrerenderRequestId(
 // in worker logs.
 export const PRERENDER_JOB_ID_HEADER = 'x-boxel-job-id';
 
-// Stamped on the host's outbound _federated-search / _search calls
-// when the host SPA detects it's running inside a prerender tab. The
-// prerender server signals "you are in a prerender" by injecting
-// `globalThis.__boxelDuringPrerender = true` via evaluateOnNewDocument
-// before the host SPA boots. The host's realm-server fetch wrapper
-// reads that flag and attaches this header to the request; the
-// search handlers read it inbound and pass `cacheOnlyDefinitions:true`
-// to searchCards, short-circuiting the recursive lookupDefinition
-// fan-out in populateQueryFields that causes self-referential
-// prerender deadlocks under parallel indexing.
-//
-// Defined in runtime-common's realm.ts as the single source of truth
-// so the Realm class can read it without depending on realm-server.
-// Re-exported here for the host fetch wrapper's import-locality.
-export { DURING_PRERENDER_HEADER } from '@cardstack/runtime-common';
-
 // Sanitize the inbound job-id header. Format is `<digits>.<digits>`
 // (job.id + reservation.id, both bigint-shaped); accept up to 32
 // digits per side (so up to 65 chars total including the separator)

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -540,10 +540,10 @@ export class IndexRunner {
   // `populateQueryFields` → `lookupDefinition` for a definition not
   // in the modules cache triggers a nested prerender. That nested
   // prerender enters the same affinity-scoped tab queue the original
-  // render is occupying, deadlocking the pool (PR #4777 papered over
-  // this with `cacheOnlyDefinitions:true`). Pre-warming the modules
-  // table before the visit loop fires means `lookupDefinition` hits
-  // a populated row instead of spawning a sub-prerender.
+  // render is occupying, deadlocking the pool. Pre-warming the
+  // modules table before the visit loop fires means
+  // `lookupDefinition` hits a populated row instead of spawning a
+  // sub-prerender.
   //
   // Signal sources, in priority order:
   //   1. Existing `boxel_index.deps` — the runtime-captured dep list

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -56,12 +56,7 @@ import {
   isLinkableCollectionDocument,
 } from './document-types';
 import { relationshipEntries } from './relationship-utils';
-import type {
-  CardResource,
-  FileMetaResource,
-  QueryFieldMeta,
-  Saved,
-} from './resource-types';
+import type { CardResource, FileMetaResource, Saved } from './resource-types';
 import { getImmediateFieldDef, type FieldDefinition } from './definitions';
 import {
   normalizeQueryDefinition,
@@ -78,11 +73,6 @@ const RECURSING_DEPTH = 3;
 type Options = {
   loadLinks?: true;
   linkFields?: string[];
-  // When true, populateQueryFields will only use cached definitions from the
-  // database and will never trigger a prerenderer call.  This prevents deadlocks
-  // when file-meta responses are served during card prerendering (the single
-  // prerender semaphore permit is already held).
-  cacheOnlyDefinitions?: boolean;
 } & QueryOptions;
 
 type SearchResult = SearchResultDoc | SearchResultError;
@@ -373,16 +363,7 @@ export class RealmIndexQueryEngine {
       return false;
     }
     try {
-      let definition: import('./definitions').Definition | undefined;
-      if (opts?.cacheOnlyDefinitions) {
-        definition =
-          await this.#definitionLookup.lookupCachedDefinition(codeRef);
-        if (!definition) {
-          return false;
-        }
-      } else {
-        definition = await this.#definitionLookup.lookupDefinition(codeRef);
-      }
+      let definition = await this.#definitionLookup.lookupDefinition(codeRef);
       if (!definition) {
         return false;
       }
@@ -611,7 +592,7 @@ export class RealmIndexQueryEngine {
     if (!isResolvedCodeRef(codeRef)) {
       return;
     }
-    let definition = await this.lookupDefinitionForOpts(codeRef, opts);
+    let definition = await this.#definitionLookup.lookupDefinition(codeRef);
     if (!definition) {
       return;
     }
@@ -690,9 +671,8 @@ export class RealmIndexQueryEngine {
       if (visited.filter((v) => v === childCardKey).length > RECURSING_DEPTH) {
         continue;
       }
-      let childDef = await this.lookupDefinitionForOpts(
+      let childDef = await this.#definitionLookup.lookupDefinition(
         fieldDefinition.fieldOrCard,
-        opts,
       );
       if (!childDef) {
         continue;
@@ -705,55 +685,6 @@ export class RealmIndexQueryEngine {
         opts,
         [...visited, childCardKey],
       );
-    }
-  }
-
-  private async lookupDefinitionForOpts(
-    codeRef: import('./code-ref').ResolvedCodeRef,
-    opts: Options | undefined,
-  ): Promise<import('./definitions').Definition | undefined> {
-    if (opts?.cacheOnlyDefinitions) {
-      return await this.#definitionLookup.lookupCachedDefinition(codeRef);
-    }
-    return await this.#definitionLookup.lookupDefinition(codeRef);
-  }
-
-  // Populate query-based relationship fields using pre-extracted metadata
-  // stored in the resource's meta during file indexing. This avoids a
-  // runtime definition lookup (which could deadlock during prerendering).
-  private async populateQueryFieldsFromMeta(
-    resource: LooseCardResource | FileMetaResource,
-    realmURL: URL,
-    queryFieldDefs: Record<string, QueryFieldMeta>,
-    opts?: Options,
-  ): Promise<void> {
-    for (let [fieldName, meta] of Object.entries(queryFieldDefs)) {
-      if (opts?.linkFields && !opts.linkFields.includes(fieldName)) {
-        continue;
-      }
-      let fieldDefinition: FieldDefinition = {
-        type: meta.type,
-        isPrimitive: false,
-        isComputed: true,
-        fieldOrCard: meta.fieldOrCard,
-        query: meta.query,
-      };
-      let { results, errors, searchURL } = await this.executeQueryForField({
-        fieldDefinition,
-        fieldName,
-        queryDefinition: meta.query,
-        resource,
-        realmURL,
-        opts,
-      });
-      this.applyQueryResults({
-        fieldDefinition,
-        fieldName,
-        resource,
-        results,
-        errors,
-        searchURL,
-      });
     }
   }
 
@@ -1170,21 +1101,7 @@ export class RealmIndexQueryEngine {
               : opts?.linkFields
                 ? { ...opts, linkFields: undefined }
                 : opts;
-            let storedDefs = (
-              resource.meta as {
-                queryFieldDefs?: Record<string, QueryFieldMeta>;
-              }
-            )?.queryFieldDefs;
-            if (popOpts?.cacheOnlyDefinitions && storedDefs) {
-              await this.populateQueryFieldsFromMeta(
-                resource,
-                realmURL,
-                storedDefs,
-                popOpts,
-              );
-            } else {
-              await this.populateQueryFields(resource, realmURL, popOpts);
-            }
+            await this.populateQueryFields(resource, realmURL, popOpts);
           }),
         );
       } catch (err: unknown) {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -212,26 +212,6 @@ export type RealmInfo = {
 
 const PROTECTED_REALM_CONFIG_PROPERTIES = ['showAsCatalog'];
 
-// Marker header the host SPA attaches to outbound _federated-search /
-// _search calls when it's running inside a prerender tab. The prerender
-// server uses puppeteer's `evaluateOnNewDocument` to inject a window
-// global (`__boxelDuringPrerender = true`) into every Chrome tab before
-// the host loads; the host's realm-server fetch wrapper then reads that
-// flag and adds this header on its own outbound search requests only —
-// narrowly scoped so non-realm-server origins (icons, vite, etc.) don't
-// see it on a CORS preflight. When the realm sees this on an inbound
-// _search request it knows the caller is the host SPA mid-render and
-// switches the search to cacheOnlyDefinitions:true, which short-circuits
-// the recursive lookupDefinition → prerenderModule path in
-// populateQueryFields that causes self-referential prerender deadlocks
-// under parallel indexing. Kept as a bare string here so runtime-common
-// stays independent of realm-server. The realm-server prerender side
-// re-exports the same value from prerender-constants.ts.
-export const DURING_PRERENDER_HEADER = 'x-boxel-during-prerender';
-function isDuringPrerenderRequest(request: Request): boolean {
-  return (request.headers.get(DURING_PRERENDER_HEADER) ?? '').length > 0;
-}
-
 // Fields owned by the RealmConfig card instance at /realm.json. Anything not
 // in this set is still written to the legacy .realm.json sidecar until
 // CS-10055 moves hostHome / interactHome off-file.
@@ -4608,14 +4588,10 @@ export class Realm {
     return this.#realmIndexUpdater.isIgnored(url);
   }
 
-  public async search(
-    query: Query,
-    opts?: { cacheOnlyDefinitions?: boolean },
-  ): Promise<LinkableCollectionDocument> {
+  public async search(query: Query): Promise<LinkableCollectionDocument> {
     assertQuery(query);
     return await this.#realmIndexQueryEngine.searchCards(query, {
       loadLinks: true,
-      ...(opts?.cacheOnlyDefinitions ? { cacheOnlyDefinitions: true } : {}),
     });
   }
 
@@ -4666,9 +4642,7 @@ export class Realm {
 
     try {
       assertQuery(cardsQuery);
-      let doc = await this.search(cardsQuery, {
-        cacheOnlyDefinitions: isDuringPrerenderRequest(request),
-      });
+      let doc = await this.search(cardsQuery);
       return createResponse({
         body: JSON.stringify(doc, null, 2),
         init: {

--- a/packages/runtime-common/search-utils.ts
+++ b/packages/runtime-common/search-utils.ts
@@ -317,17 +317,13 @@ export function combinePrerenderedSearchResults(
 }
 
 type SearchableRealm = {
-  search: (
-    query: Query,
-    opts?: { cacheOnlyDefinitions?: boolean },
-  ) => Promise<LinkableCollectionDocument>;
+  search: (query: Query) => Promise<LinkableCollectionDocument>;
   url?: string;
 };
 
 export async function searchRealms(
   realms: Array<SearchableRealm | null | undefined>,
   query: Query,
-  opts?: { cacheOnlyDefinitions?: boolean },
 ): Promise<LinkableCollectionDocument> {
   let realmEntries = realms
     .filter((realm): realm is SearchableRealm => Boolean(realm))
@@ -336,7 +332,7 @@ export async function searchRealms(
       label: realm.url ? String(realm.url) : undefined,
     }));
   let searchPromises = realmEntries.map(({ realm }) =>
-    Promise.resolve().then(() => realm.search(query, opts)),
+    Promise.resolve().then(() => realm.search(query)),
   );
   let results = await Promise.allSettled(searchPromises);
   let queryLabel = '[unserializable query]';


### PR DESCRIPTION
## Summary

Cleanup PR. With pre-warm ([#4799](https://github.com/cardstack/boxel/pull/4799)) populating the modules table before every render fires, `lookupDefinition` from inside `populateQueryFields` always hits a populated DB row instead of spawning a nested prerender. The `cacheOnlyDefinitions:true` short-circuit and the `__boxelDuringPrerender` header plumbing are no longer load-bearing in the indexing flow — remove them.

This is **not** a performance PR — the goal is to drop the workaround scaffolding now that the root-cause fix (pre-warm) is in. No measurable wall-clock change expected.

**Removed pieces:**
- `DURING_PRERENDER_HEADER` constant + `isDuringPrerenderRequest` helper in `runtime-common/realm.ts`; matching re-export in `realm-server/prerender/prerender-constants.ts`; import in `realm-server/handlers/handle-search.ts`.
- Host SPA's `duringPrerenderHeaders()` helper and both `_federated-search` fetch call sites in `host/app/services/store.ts`.
- Prerender page-pool's `#markPageAsInPrerender` (which injected `globalThis.__boxelDuringPrerender = true` via `evaluateOnNewDocument`) and its two call sites.
- `handle-search.ts`'s `cacheOnlyDefinitions = ctxt.get(...).length > 0` branch; the search handler now just calls `searchRealms(realms, query)`.
- `Realm.search`'s `opts?: { cacheOnlyDefinitions?: boolean }` parameter and the conditional spread on `searchCards` opts; `searchResponse` no longer threads `cacheOnlyDefinitions` through.
- `searchRealms` / `SearchableRealm.search` lose the `opts` parameter.
- `RealmIndexQueryEngine.Options.cacheOnlyDefinitions` and its three consumers (`fieldExpectsFileMeta` cache-only branch, `lookupDefinitionForOpts` cache-only branch, `populateQueryFieldsFromMeta` short-circuit at the loadLinks layer).
- `lookupDefinitionForOpts` collapses to a direct `lookupDefinition` call — both call sites are inlined.
- `populateQueryFieldsFromMeta` is removed entirely; the loadLinks walker now always calls the live `populateQueryFields`.

**Intentionally left alone:** `QueryFieldMeta` and the indexer's `queryFieldDefs` emission in `host/app/utils/file-def-attributes-extractor.ts`. They're still written into `resource.meta` and consumed elsewhere as metadata; only the cache-only-read short-circuit they served is gone.

Net diff: **-169 lines** across host, realm-server, runtime-common.

Built directly on top of [#4799](https://github.com/cardstack/boxel/pull/4799). Re-target this PR's base to `main` before merging.

## Test plan

- [ ] Verify no remaining references to `DURING_PRERENDER_HEADER`, `duringPrerenderHeaders`, `__boxelDuringPrerender`, `markPageAsInPrerender`, `cacheOnlyDefinitions`, `populateQueryFieldsFromMeta`, or `lookupDefinitionForOpts` in the source tree (excluding the index-runner's `Why:` comment about the historical deadlock).
- [ ] Realm-server search integration tests pass; verify no test relied on the `cacheOnlyDefinitions` flag implicitly.
- [ ] Spot-check a reindex run does not regress on the realms covered by [#4799](https://github.com/cardstack/boxel/pull/4799)'s bench — if the safety net was load-bearing somewhere pre-warm doesn't cover, the cleanup needs to be deferred or scoped down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
