### PR TITLE
Actually fix the software factory shard 1/3 instantiate-validation flake (follow-up to #4782)

### DIFF
--- a/packages/software-factory/tests/helpers/instantiate-test-fixtures.ts
+++ b/packages/software-factory/tests/helpers/instantiate-test-fixtures.ts
@@ -10,7 +10,6 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 import type { BoxelCLIClient } from '@cardstack/boxel-cli/api';
-import { specRef } from '@cardstack/runtime-common/constants';
 import { expect } from '@playwright/test';
 
 // ---------------------------------------------------------------------------
@@ -87,6 +86,36 @@ export function brokenTagsExampleJson(): string {
         attributes: {
           name: 'Bad Tags Card',
           tags: 'not-an-array',
+        },
+        meta: {
+          adoptsFrom: {
+            module: '../tags-card',
+            name: 'TagsCard',
+          },
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+/**
+ * A well-formed `TagsCard` example with an empty tags array. Seeded to
+ * the realm so the indexer's `linkedExamples` walk on the Spec succeeds
+ * cleanly and the Spec actually surfaces in `_federated-search`. The
+ * test then overwrites the *workspace* copy with `brokenTagsExampleJson`
+ * before the validation step reads it — the bad shape never reaches
+ * realm-side indexing.
+ */
+export function validTagsExampleJson(): string {
+  return JSON.stringify(
+    {
+      data: {
+        type: 'card',
+        attributes: {
+          name: 'Tags Card Placeholder',
+          tags: [],
         },
         meta: {
           adoptsFrom: {
@@ -193,32 +222,6 @@ async function seedFilesAndWaitForIndex(
       syncResult.hasError,
       `seed sync to ${realmUrl} reported an error: ${syncResult.error ?? '(no error message)'}`,
     ).toBe(false);
-    console.log(
-      `[seedFilesAndWaitForIndex] realm=${realmUrl} pushed=${JSON.stringify(syncResult.pushed)} skipped=${JSON.stringify(syncResult.skippedConflicts)}`,
-    );
-    // Confirm the realm sees the freshly-seeded Spec in search before
-    // returning. waitForIndex on `_atomic` returns once `performIndex()`
-    // resolves, but the test fixture's `_federated-search` callers
-    // sometimes still get an empty list immediately after — log what
-    // the realm actually has under those conditions.
-    let listing = await client.listFiles(realmUrl).catch((err) => ({
-      filenames: [] as string[],
-      error: err instanceof Error ? err.message : String(err),
-    }));
-    let search = await client
-      .search(realmUrl, { filter: { type: specRef } })
-      .catch((err) => ({
-        ok: false,
-        data: undefined,
-        error: err instanceof Error ? err.message : String(err),
-      }));
-    let cardIds = (search.data ?? []).map(
-      (c) => (c as { id?: unknown }).id ?? '(no id)',
-    );
-    console.log(
-      `[seedFilesAndWaitForIndex] post-sync state: realmFiles=${JSON.stringify(listing.filenames ?? [])} ` +
-        `searchOk=${search.ok ?? false} specHits=${JSON.stringify(cardIds)}`,
-    );
   } finally {
     rmSync(stagingDir, { recursive: true, force: true });
   }
@@ -240,9 +243,21 @@ export async function seedValidCardWithSpec(
 }
 
 /**
- * Seed `tags-card.gts` + the Spec (written first so it's indexed cleanly)
- * + the broken example. Instantiating the example surfaces a field-shape
- * error.
+ * Seed `tags-card.gts`, a well-formed `TagsCard/bad-example.json`, and
+ * a Spec linking to that file. The realm-side example is intentionally
+ * the WELL-FORMED placeholder (`validTagsExampleJson`) — the test
+ * substitutes the broken shape into the workspace copy after
+ * `client.pull` via `overwriteTagsExampleWithBadShape`.
+ *
+ * Why this two-step shape: the realm indexer drops a Spec from
+ * `_federated-search` whenever its `linkedExamples` `loadLinks` walk
+ * can't resolve a target — either the file is missing entirely or the
+ * card is in error_doc state. Writing the broken `containsMany` shape
+ * straight to the realm puts the example in error_doc and silently
+ * disqualifies the Spec from search, which is the original flake this
+ * skill chased. The validation pipeline reads example JSON from the
+ * workspace path (not the realm index), so the bad shape only needs
+ * to live in the workspace at the moment the step reads it.
  */
 export async function seedTagsCardWithBrokenExampleAndSpec(
   client: BoxelCLIClient,
@@ -250,7 +265,21 @@ export async function seedTagsCardWithBrokenExampleAndSpec(
 ): Promise<void> {
   await seedFilesAndWaitForIndex(client, realmUrl, [
     { path: 'tags-card.gts', content: TAGS_CARD_MODULE_GTS },
-    { path: 'TagsCard/bad-example.json', content: brokenTagsExampleJson() },
+    { path: 'TagsCard/bad-example.json', content: validTagsExampleJson() },
     { path: 'Spec/tags-card-spec.json', content: tagsCardSpecJson() },
   ]);
+}
+
+/**
+ * Overwrite the workspace copy of `TagsCard/bad-example.json` with the
+ * broken-shape data the test actually wants to exercise. Call after
+ * `client.pull` (so the pull doesn't immediately overwrite this) and
+ * before constructing the validation step / running runInstantiate. See
+ * `seedTagsCardWithBrokenExampleAndSpec` for why the realm-side copy
+ * stays well-formed.
+ */
+export function overwriteTagsExampleWithBadShape(workspaceDir: string): void {
+  let absolute = join(workspaceDir, 'TagsCard', 'bad-example.json');
+  mkdirSync(dirname(absolute), { recursive: true });
+  writeFileSync(absolute, brokenTagsExampleJson());
 }

--- a/packages/software-factory/tests/helpers/instantiate-test-fixtures.ts
+++ b/packages/software-factory/tests/helpers/instantiate-test-fixtures.ts
@@ -7,7 +7,7 @@
  */
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join } from 'node:path';
 
 import type { BoxelCLIClient } from '@cardstack/boxel-cli/api';
 import { expect } from '@playwright/test';
@@ -210,6 +210,11 @@ async function seedFilesAndWaitForIndex(
   let stagingDir = mkdtempSync(join(tmpdir(), 'sf-instantiate-seed-'));
   try {
     for (let { path, content } of files) {
+      if (isAbsolute(path) || path.split('/').includes('..')) {
+        throw new Error(
+          `seedFilesAndWaitForIndex path must be a realm-relative path under the staging dir; got ${JSON.stringify(path)}`,
+        );
+      }
       let absolute = join(stagingDir, path);
       mkdirSync(dirname(absolute), { recursive: true });
       writeFileSync(absolute, content);

--- a/packages/software-factory/tests/helpers/instantiate-test-fixtures.ts
+++ b/packages/software-factory/tests/helpers/instantiate-test-fixtures.ts
@@ -5,11 +5,13 @@
  * tool). Keeping the card modules, examples, and specs in one place ensures
  * the two surfaces are exercised against identical inputs.
  */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
 import type { BoxelCLIClient } from '@cardstack/boxel-cli/api';
 import { specRef } from '@cardstack/runtime-common/constants';
 import { expect } from '@playwright/test';
-
-import { retryWithPoll } from '../../src/retry-with-poll';
 
 // ---------------------------------------------------------------------------
 // Card modules
@@ -154,116 +156,72 @@ export function tagsCardSpecJson(): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Write a file + await the realm to ack it back via GET. The file is
- * readable here, but realm-side search-index ingestion happens out-of-band
- * — `awaitSpecSearchable` covers that separately for the Spec card the
- * downstream `InstantiateValidationStep` queries for.
- */
-async function writeAndAwaitIndex(
-  client: BoxelCLIClient,
-  realmUrl: string,
-  path: string,
-  content: string,
-): Promise<void> {
-  let writeResult = await client.write(realmUrl, path, content);
-  expect(writeResult.ok, `write ${path} failed: ${writeResult.error}`).toBe(
-    true,
-  );
-  let indexed = await client.waitForFile(realmUrl, path, {
-    pollMs: 300,
-    timeoutMs: 30_000,
-  });
-  expect(indexed, `waiting for ${path} to be indexed timed out`).toBe(true);
-}
-
-/**
- * Diagnostic gate: poll federated search until the just-seeded Spec card
- * surfaces as a Spec-type result, with a generous budget. `waitForFile`
- * only guarantees the file is GET-able; realm-side source POST indexing
- * is async, so there's a window where the file is readable but
- * `client.search({type: spec})` still returns an empty list. The
- * downstream `InstantiateValidationStep`'s 30s discovery poll has been
- * observed timing out in CI under load (the test falls into the
- * "modules exist but no Spec cards" branch, where `result.details` is
- * undefined, and the e2e assertion that triggered this skill's
- * investigation trips on it).
+ * Stage the given files in a fresh temp dir and push them to the realm
+ * with `client.sync(..., { preferLocal: true, waitForIndex: true })`.
+ * The `_atomic` upload appends `?waitForIndex=true`, so the realm-server
+ * returns only after the indexer has processed every uploaded file.
  *
- * Important: this gate is SOFT. If polling times out, we log a
- * diagnostic dump (current search hits, realm file listing, file
- * readability checks) and return — the test then proceeds to its real
- * assertions. The reason: CI evidence shows the realm sometimes never
- * surfaces the Spec for this fixture's containsMany card no matter how
- * long we wait (likely an indexer bug interacting with the broken
- * example's error_doc state). A hard gate just shifts the failure
- * upstream without adding information. The log it emits on the way out
- * is the real value here — pairs with the warn-log in
- * `InstantiateValidationStep` when its discovery poll also comes back
- * empty.
+ * Why this shape instead of per-file `client.write` + a search-poll
+ * gate: realm-side source POST indexing is async, so writing files
+ * one-by-one and waiting for the realm to ack with GET (or for the
+ * downstream `_federated-search` to surface them) is a polling race —
+ * which is exactly the flake this skill was filed to address. CI
+ * evidence on PR #4782 (run 25768256725) showed even a 90s poll
+ * sometimes never sees the Spec surface in search. The `_atomic`
+ * waitForIndex query param is the realm-server's first-class hook for
+ * read-after-write consistency in tests; using it here trades a
+ * one-shot push latency for a deterministic "indexer is settled"
+ * boundary.
  */
-async function awaitSpecSearchable(
+async function seedFilesAndWaitForIndex(
   client: BoxelCLIClient,
   realmUrl: string,
-  specPath: string,
+  files: { path: string; content: string }[],
 ): Promise<void> {
-  let expectedSuffix = specPath.replace(/\.json$/, '');
-  let totalWaitMs = 90_000;
-  let startedAt = Date.now();
-  let result = await retryWithPoll(
-    () => client.search(realmUrl, { filter: { type: specRef } }),
-    (r) => {
-      if (!r.ok) return false;
-      let found = (r.data ?? []).some((card) => {
-        let id = (card as { id?: unknown }).id;
-        return typeof id === 'string' && id.endsWith(expectedSuffix);
-      });
-      return !found;
-    },
-    { totalWaitMs, pollMs: 250 },
-  );
-  let elapsedMs = Date.now() - startedAt;
-
-  if (!result.ok) {
-    console.warn(
-      `[awaitSpecSearchable] search for ${specPath} returned not-ok after ${elapsedMs}ms: ${result.error ?? '(no error message)'}`,
+  let stagingDir = mkdtempSync(join(tmpdir(), 'sf-instantiate-seed-'));
+  try {
+    for (let { path, content } of files) {
+      let absolute = join(stagingDir, path);
+      mkdirSync(dirname(absolute), { recursive: true });
+      writeFileSync(absolute, content);
+    }
+    let syncResult = await client.sync(realmUrl, stagingDir, {
+      preferLocal: true,
+      waitForIndex: true,
+    });
+    expect(
+      syncResult.hasError,
+      `seed sync to ${realmUrl} reported an error: ${syncResult.error ?? '(no error message)'}`,
+    ).toBe(false);
+    console.log(
+      `[seedFilesAndWaitForIndex] realm=${realmUrl} pushed=${JSON.stringify(syncResult.pushed)} skipped=${JSON.stringify(syncResult.skippedConflicts)}`,
     );
-    return;
+    // Confirm the realm sees the freshly-seeded Spec in search before
+    // returning. waitForIndex on `_atomic` returns once `performIndex()`
+    // resolves, but the test fixture's `_federated-search` callers
+    // sometimes still get an empty list immediately after — log what
+    // the realm actually has under those conditions.
+    let listing = await client.listFiles(realmUrl).catch((err) => ({
+      filenames: [] as string[],
+      error: err instanceof Error ? err.message : String(err),
+    }));
+    let search = await client
+      .search(realmUrl, { filter: { type: specRef } })
+      .catch((err) => ({
+        ok: false,
+        data: undefined,
+        error: err instanceof Error ? err.message : String(err),
+      }));
+    let cardIds = (search.data ?? []).map(
+      (c) => (c as { id?: unknown }).id ?? '(no id)',
+    );
+    console.log(
+      `[seedFilesAndWaitForIndex] post-sync state: realmFiles=${JSON.stringify(listing.filenames ?? [])} ` +
+        `searchOk=${search.ok ?? false} specHits=${JSON.stringify(cardIds)}`,
+    );
+  } finally {
+    rmSync(stagingDir, { recursive: true, force: true });
   }
-  let cardIds = (result.data ?? []).map(
-    (c) => (c as { id?: unknown }).id ?? '(no id)',
-  );
-  let found = cardIds.some(
-    (id) => typeof id === 'string' && id.endsWith(expectedSuffix),
-  );
-  if (found) {
-    return;
-  }
-
-  // Soft-fail diagnostic dump. The test will likely fail downstream
-  // when InstantiateValidationStep can't find the Spec either — at
-  // which point this log shows the realm's actual state at the time
-  // we gave up waiting.
-  let readSpecFile = await client.read(realmUrl, specPath).catch((err) => ({
-    ok: false,
-    error: err instanceof Error ? err.message : String(err),
-  }));
-  let listing = await client.listFiles(realmUrl).catch((err) => ({
-    filenames: [] as string[],
-    error: err instanceof Error ? err.message : String(err),
-  }));
-  let specLikeFilenames = (listing.filenames ?? []).filter(
-    (f) =>
-      f.endsWith('.json') && (f.startsWith('Spec/') || f.includes('-spec')),
-  );
-  console.warn(
-    `[awaitSpecSearchable] Spec ${specPath} did not surface in search within ${elapsedMs}ms. ` +
-      `realm=${realmUrl} searchHits=${JSON.stringify(cardIds)} ` +
-      `specSourceFileReadable=${(readSpecFile as { ok?: boolean }).ok ?? false} ` +
-      `totalFiles=${(listing.filenames ?? []).length} ` +
-      `specLikeFilenames=${JSON.stringify(specLikeFilenames)}` +
-      ((listing as { error?: string }).error
-        ? ` listFilesError=${(listing as { error?: string }).error}`
-        : ''),
-  );
 }
 
 /**
@@ -274,25 +232,11 @@ export async function seedValidCardWithSpec(
   client: BoxelCLIClient,
   realmUrl: string,
 ): Promise<void> {
-  await writeAndAwaitIndex(
-    client,
-    realmUrl,
-    'instantiate-test-card.gts',
-    VALID_MODULE_GTS,
-  );
-  await writeAndAwaitIndex(
-    client,
-    realmUrl,
-    'ValidCard/example-1.json',
-    validExampleJson(),
-  );
-  await writeAndAwaitIndex(
-    client,
-    realmUrl,
-    'Spec/valid-card-spec.json',
-    validCardSpecJson(),
-  );
-  await awaitSpecSearchable(client, realmUrl, 'Spec/valid-card-spec.json');
+  await seedFilesAndWaitForIndex(client, realmUrl, [
+    { path: 'instantiate-test-card.gts', content: VALID_MODULE_GTS },
+    { path: 'ValidCard/example-1.json', content: validExampleJson() },
+    { path: 'Spec/valid-card-spec.json', content: validCardSpecJson() },
+  ]);
 }
 
 /**
@@ -304,28 +248,9 @@ export async function seedTagsCardWithBrokenExampleAndSpec(
   client: BoxelCLIClient,
   realmUrl: string,
 ): Promise<void> {
-  await writeAndAwaitIndex(
-    client,
-    realmUrl,
-    'tags-card.gts',
-    TAGS_CARD_MODULE_GTS,
-  );
-  // Write the Spec BEFORE the bad example. Reordering was attempted to
-  // give the indexer a stable Spec target; locally and in CI both
-  // orderings produced the same flake (Spec never surfaces in search
-  // within the budget), so the historic order stands and the
-  // diagnostic gate below documents what we saw when it didn't.
-  await writeAndAwaitIndex(
-    client,
-    realmUrl,
-    'Spec/tags-card-spec.json',
-    tagsCardSpecJson(),
-  );
-  await awaitSpecSearchable(client, realmUrl, 'Spec/tags-card-spec.json');
-  await writeAndAwaitIndex(
-    client,
-    realmUrl,
-    'TagsCard/bad-example.json',
-    brokenTagsExampleJson(),
-  );
+  await seedFilesAndWaitForIndex(client, realmUrl, [
+    { path: 'tags-card.gts', content: TAGS_CARD_MODULE_GTS },
+    { path: 'TagsCard/bad-example.json', content: brokenTagsExampleJson() },
+    { path: 'Spec/tags-card-spec.json', content: tagsCardSpecJson() },
+  ]);
 }

--- a/packages/software-factory/tests/instantiate-validation.spec.ts
+++ b/packages/software-factory/tests/instantiate-validation.spec.ts
@@ -7,6 +7,7 @@ import type { InstantiateValidationDetails } from '../src/validators/instantiate
 import {
   seedTagsCardWithBrokenExampleAndSpec,
   seedValidCardWithSpec,
+  overwriteTagsExampleWithBadShape,
 } from './helpers/instantiate-test-fixtures';
 import { buildTestClient } from './helpers/test-client';
 import { createTestWorkspace } from './helpers/workspace-fixture';
@@ -109,6 +110,7 @@ test.describe('instantiate-validation e2e', () => {
 
       let workspace = createTestWorkspace();
       await client.pull(realmUrl, workspace.dir);
+      overwriteTagsExampleWithBadShape(workspace.dir);
 
       let step = new InstantiateValidationStep({
         client,

--- a/packages/software-factory/tests/run-instantiate-in-memory.spec.ts
+++ b/packages/software-factory/tests/run-instantiate-in-memory.spec.ts
@@ -8,6 +8,7 @@ import { runInstantiateInMemory } from '../src/instantiate-execution';
 import {
   seedTagsCardWithBrokenExampleAndSpec,
   seedValidCardWithSpec,
+  overwriteTagsExampleWithBadShape,
 } from './helpers/instantiate-test-fixtures';
 import { buildTestClient } from './helpers/test-client';
 import { createTestWorkspace } from './helpers/workspace-fixture';
@@ -88,6 +89,7 @@ test.describe('runInstantiateInMemory e2e', () => {
 
       let workspace = createTestWorkspace();
       await client.pull(realmUrl, workspace.dir);
+      overwriteTagsExampleWithBadShape(workspace.dir);
 
       let result = await runInstantiateInMemory({
         targetRealm: realmUrl,
@@ -216,6 +218,7 @@ test.describe('runInstantiateInMemory e2e', () => {
 
       let workspace = createTestWorkspace();
       await client.pull(realmUrl, workspace.dir);
+      overwriteTagsExampleWithBadShape(workspace.dir);
 
       let cleanOnly = await runInstantiateInMemory({
         targetRealm: realmUrl,


### PR DESCRIPTION
## Summary

PR #4782 added diagnostic logging and a soft `awaitSpecSearchable`
gate, but didn't actually fix the underlying flake. After it merged
I confirmed the root cause and landed two more commits on the
branch that didn't make the merge — this PR brings them up.

## The actual bug

The realm-server's indexer drops a Spec from `_federated-search`
whenever its `linkedExamples` `loadLinks` walk can't settle on the
target — *both* when the target file is missing (404) and when the
target card is in error_doc state. In the failing fixture, the Spec
linked to `TagsCard/bad-example.json`, the bad shape
(`containsMany` got a string) put that example in error_doc on
indexing, the Spec got silently disqualified from search, and
`InstantiateValidationStep.discoverRealmSpecs` came back empty.

Confirmed by stripping `linkedExamples` from the Spec in an
experiment — the bare Spec surfaces in search within seconds.

## What this PR does

1. **`Seed instantiate-validation fixtures via sync(waitForIndex:true)`**
   Stages the seed files in a temp dir and pushes via
   `client.sync(..., { preferLocal: true, waitForIndex: true })`. The
   `_atomic` upload appends `?waitForIndex=true`, so the realm-server
   blocks on `performIndex()` before responding. Replaces the
   per-file `client.write` + polling-for-search approach with a
   deterministic "indexer is settled" boundary. (This was the
   intermediate fix I tried before realizing it didn't help on its
   own — but it's still the right shape and pairs cleanly with the
   real fix below.)

2. **`Keep realm-side example well-formed; overwrite workspace copy`**
   Seeds the realm-side `TagsCard/bad-example.json` with a
   well-formed empty-tags placeholder so the Spec's `loadLinks`
   walk completes. New `overwriteTagsExampleWithBadShape(workspaceDir)`
   helper writes the broken `containsMany: "not-an-array"` shape
   into the workspace copy after `client.pull`. The validation
   pipeline reads example JSON from `workspaceDir` (see
   `prepareExampleInstance` in `instantiate-execution.ts`), not from
   the realm index, so the bad shape only needs to live in the
   workspace at the moment the step / in-memory tool reads it.

Both `instantiate-validation.spec.ts:91` and
`run-instantiate-in-memory.spec.ts:71` get the
`overwriteTagsExampleWithBadShape` call after `client.pull`.

## Local verification

Both previously flaking tests now pass deterministically across
local runs. The realm-indexer behavior (Spec dropped from search
whenever its `linkedExamples` target won't settle) is worth filing
separately — this PR just unblocks the e2e on the fixture side.

## Test plan

- [x] `pnpm lint` clean (per-package)
- [x] `pnpm test:playwright tests/instantiate-validation.spec.ts
      tests/run-instantiate-in-memory.spec.ts` — both target tests
      pass; two unrelated tests in the same in-memory spec file
      (197, 295) still flake locally with realm-server "database
      does not exist" errors during harness teardown (separate infra
      issue, not from this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)