### PR TITLE
realm-server: invalidate cachedRealmInfo on cross-replica .realm.json writes (CS-11127)

### DIFF
--- a/packages/realm-server/lib/realm-file-changes-listener.ts
+++ b/packages/realm-server/lib/realm-file-changes-listener.ts
@@ -93,7 +93,30 @@ export class RealmFileChangesListener {
         `invalidateCache failed for ${parsed.url} ${parsed.path}: ${String(err)}`,
       );
     }
+    // `.realm.json` writes change the realm's name / icon / iconURL /
+    // showAsCatalog and bump `cachedRealmInfoHash`, which is folded into
+    // every card+json ETag. The writer side handles this locally in
+    // `_batchWrite` (see runtime-common/realm.ts where the post-write
+    // `addedFiles`/`updatedFiles` set is checked for the same filenames),
+    // but peers see the change only through this NOTIFY. Without this hook
+    // a peer would keep serving the pre-rename realmInfo until restart and
+    // respond 304 Not Modified against pre-rename ETags forever. CS-11127.
+    if (isRealmConfigPath(parsed.path)) {
+      try {
+        realm.invalidateCachedRealmInfo();
+      } catch (err: unknown) {
+        log.warn(
+          `invalidateCachedRealmInfo failed for ${parsed.url} ${parsed.path}: ${String(err)}`,
+        );
+      }
+    }
   }
+}
+
+// Matches the local-path check in Realm._batchWrite that decides whether
+// to invalidate cachedRealmInfo on the writer side — keep the two in sync.
+function isRealmConfigPath(path: string): boolean {
+  return path === '.realm.json' || path === 'realm.json';
 }
 
 // Payload shape: `<realmURL>:<localPath>`. Realm URLs always carry a

--- a/packages/realm-server/tests/realm-file-changes-listener-test.ts
+++ b/packages/realm-server/tests/realm-file-changes-listener-test.ts
@@ -8,16 +8,21 @@ import {
   parsePayload,
 } from '../lib/realm-file-changes-listener';
 
-// Minimal fake `Realm` — the listener only calls `.url` (via lookup) and
-// `.invalidateCache(path)`, so that's all we need to stub.
+// Minimal fake `Realm` — the listener calls `.url` (via lookup),
+// `.invalidateCache(path)`, and (for `.realm.json` / `realm.json` paths)
+// `.invalidateCachedRealmInfo()`. Stub all three.
 function makeFakeRealm(
   url: string,
   onInvalidate: (path: string) => void,
+  onInvalidateRealmInfo?: () => void,
 ): Realm {
   return {
     url,
     invalidateCache(path: string) {
       onInvalidate(path);
+    },
+    invalidateCachedRealmInfo() {
+      onInvalidateRealmInfo?.();
     },
   } as unknown as Realm;
 }
@@ -139,6 +144,78 @@ module(basename(__filename), function () {
       listener.handleNotification(undefined);
       listener.handleNotification('');
       assert.ok(true, 'empty payload did not throw');
+    });
+
+    test('handleNotification invalidates cachedRealmInfo when path is .realm.json (CS-11127)', function (assert) {
+      const realmInfoInvalidations: string[] = [];
+      const byteCacheInvalidations: string[] = [];
+      const url = 'http://x.test/a/';
+      const realmA = makeFakeRealm(
+        url,
+        (path) => byteCacheInvalidations.push(path),
+        () => realmInfoInvalidations.push(url),
+      );
+      const listener = new RealmFileChangesListener({
+        dbAdapter: {} as unknown as PgAdapter,
+        lookupMountedRealm: (u) => (u === url ? realmA : undefined),
+      });
+
+      listener.handleNotification(`${url}:.realm.json`);
+
+      assert.deepEqual(
+        byteCacheInvalidations,
+        ['.realm.json'],
+        'byte caches are still invalidated alongside realmInfo',
+      );
+      assert.deepEqual(
+        realmInfoInvalidations,
+        [url],
+        'cachedRealmInfo invalidated for the .realm.json path',
+      );
+    });
+
+    test('handleNotification invalidates cachedRealmInfo when path is realm.json (alternate name)', function (assert) {
+      const realmInfoInvalidations: string[] = [];
+      const url = 'http://x.test/a/';
+      const realmA = makeFakeRealm(
+        url,
+        () => {},
+        () => realmInfoInvalidations.push(url),
+      );
+      const listener = new RealmFileChangesListener({
+        dbAdapter: {} as unknown as PgAdapter,
+        lookupMountedRealm: (u) => (u === url ? realmA : undefined),
+      });
+
+      listener.handleNotification(`${url}:realm.json`);
+
+      assert.deepEqual(realmInfoInvalidations, [url]);
+    });
+
+    test('handleNotification does NOT invalidate cachedRealmInfo for non-config paths', function (assert) {
+      const realmInfoInvalidations: string[] = [];
+      const byteCacheInvalidations: string[] = [];
+      const url = 'http://x.test/a/';
+      const realmA = makeFakeRealm(
+        url,
+        (path) => byteCacheInvalidations.push(path),
+        () => realmInfoInvalidations.push(url),
+      );
+      const listener = new RealmFileChangesListener({
+        dbAdapter: {} as unknown as PgAdapter,
+        lookupMountedRealm: (u) => (u === url ? realmA : undefined),
+      });
+
+      // A nested path that happens to end in `.realm.json` must not trigger
+      // realmInfo invalidation — only the realm-root config file does.
+      listener.handleNotification(`${url}:cards/foo.gts`);
+      listener.handleNotification(`${url}:nested/.realm.json`);
+
+      assert.deepEqual(byteCacheInvalidations, [
+        'cards/foo.gts',
+        'nested/.realm.json',
+      ]);
+      assert.deepEqual(realmInfoInvalidations, []);
     });
   });
 


### PR DESCRIPTION
## Summary

When `.realm.json` (or `realm.json`) is written, the writer side of `_batchWrite` already clears the local `Realm#cachedRealmInfo`. Peer replicas receive the `realm_file_changes` NOTIFY (CS-10892) and currently only invalidate their `#sourceCache` / `#moduleCache` byte caches — they don't drop `cachedRealmInfo`.

Two consequences for peers under multi-replica:

1. `Realm.realmInfo()` returns the pre-write name / icon / iconURL / showAsCatalog until the replica restarts.
2. `cachedRealmInfoHash` is folded into card+json ETags, so peers permanently hand out wrong ETags after a rename or icon change and serve `304 Not Modified` against pre-rename hashes long after they're stale.

**Fix**: in `realm-file-changes-listener`, when the notified path matches `'.realm.json'` or `'realm.json'` at the realm root (exact match, mirroring the writer's check in `runtime-common/realm.ts` `_batchWrite`), also call `realm.invalidateCachedRealmInfo()` after the byte-cache invalidation.

Smallest of the multi-replica fixes identified by the 2026-05-12 codebase audit for the [Unlock Horizontal Scaling of realm-server](https://linear.app/cardstack/project/unlock-horizontal-scaling-of-realm-server-b7b62c1ef1e8) project. Lands independently of the per-realm advisory-lock work ([CS-11125](https://linear.app/cardstack/issue/CS-11125)) and the permissions-cache invalidation ([CS-11126](https://linear.app/cardstack/issue/CS-11126)).

Fixes [CS-11127](https://linear.app/cardstack/issue/CS-11127).

## Test plan

- [x] New dispatch tests in `tests/realm-file-changes-listener-test.ts`:
  - `.realm.json` NOTIFY triggers `invalidateCachedRealmInfo()` AND `invalidateCache()`
  - `realm.json` (alternate name) NOTIFY triggers `invalidateCachedRealmInfo()`
  - Non-config paths (incl. a nested `*/.realm.json`) do NOT trigger `invalidateCachedRealmInfo()`
- [x] All 14 tests in the file pass (`pnpm test-module TEST_MODULE=realm-file-changes-listener-test.ts`)
- [x] `pnpm lint:types` clean
- [x] `pnpm exec eslint` clean on the two changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)