### PR TITLE
Rename submission branches to {hash}-{listing-slug}

### DIFF
--- a/packages/bot-runner/lib/pr-listing/create-listing-pr-handler.ts
+++ b/packages/bot-runner/lib/pr-listing/create-listing-pr-handler.ts
@@ -61,7 +61,7 @@ function getCreateListingPRContext(
       ? input.branchName.trim()
       : '';
   let headBranch =
-    explicitBranchName || toBranchName(roomId, listingDisplayName);
+    explicitBranchName || toBranchName(listingDisplayName);
 
   if (!headBranch) {
     throw new Error('pr-listing-create trigger must include a valid branch');
@@ -256,10 +256,7 @@ export class CreateListingPRHandler {
 }
 
 function buildSubmissionFolderName(context: CreateListingPRContext): string {
-  // Wrap files under the room segment of the branch path
-  // ("room-<base64-roomId>"). Each PR is scoped to one branch, so the room
-  // segment alone uniquely identifies the submission's location on disk.
-  return context.head.split('/')[0];
+  return context.head;
 }
 
 function mapOpenPullRequestResult(

--- a/packages/bot-runner/lib/pr-listing/pr-listing-workflow-handler.ts
+++ b/packages/bot-runner/lib/pr-listing/pr-listing-workflow-handler.ts
@@ -144,7 +144,7 @@ export class PrListingWorkflowHandler implements BotCommandHandler {
     // and the persisted card attribute all use the exact same string.
     let branchName =
       optionalString(input.branchName) ??
-      toBranchName(roomId, listingName ?? 'UntitledListing');
+      toBranchName(listingName ?? 'UntitledListing');
 
     return {
       runAs,
@@ -157,7 +157,10 @@ export class PrListingWorkflowHandler implements BotCommandHandler {
       workflowCardUrl,
       workflowCardRealm,
       branchName,
-      syntheticCreateEvent: eventContent,
+      syntheticCreateEvent: {
+        ...eventContent,
+        input: { ...(input as Record<string, unknown>), branchName },
+      },
       existingPrCardUrl: null,
     };
   }
@@ -203,7 +206,7 @@ export class PrListingWorkflowHandler implements BotCommandHandler {
       stripSubmitPrefix(optionalString(attrs.title));
     let branchName =
       optionalString(attrs.branchName) ??
-      toBranchName(roomId, listingName ?? 'UntitledListing');
+      toBranchName(listingName ?? 'UntitledListing');
     let rawPrCardSelf = optionalString(rels.prCard?.links?.self);
     let existingPrCardUrl = rawPrCardSelf
       ? new URL(rawPrCardSelf, workflowCardUrl).href

--- a/packages/bot-runner/tests/bot-runner-test.ts
+++ b/packages/bot-runner/tests/bot-runner-test.ts
@@ -1,10 +1,9 @@
 import { module, test } from 'qunit';
-import {
-  toBranchName,
-  type DBAdapter,
-  type ExecuteOptions,
-  type PgPrimitive,
-  type QueuePublisher,
+import type {
+  DBAdapter,
+  ExecuteOptions,
+  PgPrimitive,
+  QueuePublisher,
 } from '@cardstack/runtime-common';
 import type {
   MatrixClient,
@@ -305,6 +304,7 @@ module('timeline handler', () => {
               roomId: '!abc123:localhost',
               listingId: 'http://localhost:4201/test/Listing/1',
               listingName: 'My Listing',
+              branchName: 'a1b2c3-my-listing',
             },
             realm: 'http://localhost:4201/test/',
             userId: '@alice:localhost',
@@ -344,7 +344,7 @@ module('timeline handler', () => {
       write.branch?.toString().includes('my-listing'),
       'commit branch includes listing slug',
     );
-    let folder = toBranchName('!abc123:localhost', 'My Listing').split('/')[0];
+    let folder = 'a1b2c3-my-listing';
     assert.deepEqual(
       write.files,
       [
@@ -359,7 +359,7 @@ module('timeline handler', () => {
           isBinary: false,
         },
       ],
-      'commit payload wraps parsed files in room-<base64> folder',
+      'commit payload wraps parsed files in {hash}-{slug} folder',
     );
     assert.true(
       write.message

--- a/packages/bot-runner/tests/command-runner-test.ts
+++ b/packages/bot-runner/tests/command-runner-test.ts
@@ -258,6 +258,7 @@ module('command runner', () => {
           listingName: 'My Listing Name',
           listingSummary: 'My listing Summary',
           workflowCardUrl: submissionCardUrl,
+          branchName: 'a1b2c3-my-listing-name',
         },
       },
       'bot-registration-2',
@@ -321,7 +322,7 @@ module('command runner', () => {
         command: '@cardstack/catalog/commands/create-pr-card/default',
         commandInput: {
           realm: SUBMISSION_REALM_URL,
-          branchName: 'room-IWFiYzEyMzpsb2NhbGhvc3Q/my-listing-name',
+          branchName: 'a1b2c3-my-listing-name',
           submittedBy: '@alice:localhost',
           prSummary: `## Summary\nMy listing Summary\n\n---\n- Listing Name: My Listing Name\n- Room ID: \`!abc123:localhost\`\n- User ID: \`@alice:localhost\`\n- Number of Files: 1\n- Workflow Card: [${submissionCardUrl}](${submissionCardUrl})`,
           allFileContents: [
@@ -800,7 +801,7 @@ module('command runner', () => {
                             // retry must NOT derive branchName from it.
                             title: 'Submit My Listing',
                             branchName:
-                              'room-IWFiYzEyMzpsb2NhbGhvc3Q/my-listing',
+                              'a1b2c3-my-listing',
                           },
                           relationships: {
                             listing: {
@@ -950,7 +951,7 @@ module('command runner', () => {
     // any previous commits/PR.
     assert.strictEqual(
       (createdBranches[0] as { branch: string }).branch,
-      'room-IWFiYzEyMzpsb2NhbGhvc3Q/my-listing',
+      'a1b2c3-my-listing',
       'retry uses the persisted branchName from the workflow card',
     );
   });

--- a/packages/bot-runner/tests/create-listing-pr-handler-test.ts
+++ b/packages/bot-runner/tests/create-listing-pr-handler-test.ts
@@ -1,14 +1,11 @@
 import { module, test } from 'qunit';
-import { toBranchName } from '@cardstack/runtime-common';
 import type { GitHubClient } from '../lib/github';
 import {
   CreateListingPRHandler,
   type BotTriggerEventContent,
 } from '../lib/pr-listing/create-listing-pr-handler';
 
-function expectedFolderName(roomId: string, listingName: string): string {
-  return toBranchName(roomId, listingName).split('/')[0];
-}
+const BRANCH_PATTERN = /^[a-f0-9]{6}-/;
 
 module('create-listing-pr handler', () => {
   test('opens PR with expected params and summary body', async (assert) => {
@@ -61,8 +58,8 @@ module('create-listing-pr handler', () => {
       'returns PR title',
     );
     assert.true(
-      result?.branchName?.endsWith('/my-listing') ?? false,
-      'returns branch name used to open the PR',
+      /^[a-f0-9]{6}-my-listing$/.test(result?.branchName ?? ''),
+      `returns branch name used to open the PR: ${result?.branchName}`,
     );
     assert.true(
       result?.summary?.includes('## Summary') ?? false,
@@ -195,7 +192,7 @@ module('create-listing-pr handler', () => {
     assert.strictEqual(result, null, 'returns null when PR already exists');
   });
 
-  test('addContentsToCommit wraps files under the room-<base64> folder', async (assert) => {
+  test('addContentsToCommit wraps files under the {hash}-{slug} folder', async (assert) => {
     let writeCalls: { files: { path: string; content: string }[]; message: string }[] = [];
     let githubClient: GitHubClient = {
       openPullRequest: async () => ({ number: 1, html_url: 'x' }),
@@ -207,13 +204,16 @@ module('create-listing-pr handler', () => {
       },
     };
 
-    let roomId = '!abc123:localhost';
-    let listingName = 'My Listing';
+    let branchName = 'a1b2c3-my-listing';
     let eventContent: BotTriggerEventContent = {
       type: 'pr-listing-create',
       realm: 'http://localhost:4201/test/',
       userId: '@alice:localhost',
-      input: { roomId, listingName },
+      input: {
+        roomId: '!abc123:localhost',
+        listingName: 'My Listing',
+        branchName,
+      },
     };
 
     let handler = new CreateListingPRHandler(githubClient);
@@ -233,23 +233,18 @@ module('create-listing-pr handler', () => {
     });
 
     assert.strictEqual(writeCalls.length, 1, 'writes once');
-    let folder = expectedFolderName(roomId, listingName);
     assert.deepEqual(
       writeCalls[0].files.map((f) => f.path).sort(),
       [
-        `${folder}/CardListing/abc.json`,
-        `${folder}/Recipe.gts`,
-        `${folder}/Spec/def.json`,
+        `${branchName}/CardListing/abc.json`,
+        `${branchName}/Recipe.gts`,
+        `${branchName}/Spec/def.json`,
       ],
-      'every file is prefixed with the wrapper folder, inner type-grouped layout preserved',
-    );
-    assert.true(
-      folder.startsWith('room-'),
-      'folder uses the branch room segment as prefix',
+      'every file is prefixed with the branch-name folder, inner layout preserved',
     );
   });
 
-  test('addContentsToCommit produces the same folder for the same branch (idempotency)', async (assert) => {
+  test('addContentsToCommit produces the same folder when branchName is persisted (idempotency)', async (assert) => {
     let writeCalls: { path: string }[][] = [];
     let githubClient: GitHubClient = {
       openPullRequest: async () => ({ number: 1, html_url: 'x' }),
@@ -265,7 +260,11 @@ module('create-listing-pr handler', () => {
       type: 'pr-listing-create',
       realm: 'http://localhost:4201/test/',
       userId: '@alice:localhost',
-      input: { roomId: '!abc123:localhost', listingName: 'My Listing' },
+      input: {
+        roomId: '!abc123:localhost',
+        listingName: 'My Listing',
+        branchName: 'a1b2c3-my-listing',
+      },
     };
 
     let handler = new CreateListingPRHandler(githubClient);
@@ -286,11 +285,11 @@ module('create-listing-pr handler', () => {
     assert.deepEqual(
       writeCalls[0],
       writeCalls[1],
-      'same branch + same files → same prefixed paths across runs',
+      'same persisted branchName → same prefixed paths across runs',
     );
   });
 
-  test('addContentsToCommit uses a different folder for a different room', async (assert) => {
+  test('addContentsToCommit folder matches the {hash}-{slug} pattern when branchName is not provided', async (assert) => {
     let folders: string[] = [];
     let githubClient: GitHubClient = {
       openPullRequest: async () => ({ number: 1, html_url: 'x' }),
@@ -314,22 +313,24 @@ module('create-listing-pr handler', () => {
       }),
     };
 
-    for (let roomId of ['!room-a:localhost', '!room-b:localhost']) {
-      await handler.addContentsToCommit(
-        {
-          type: 'pr-listing-create',
-          realm: 'http://localhost:4201/test/',
-          userId: '@alice:localhost',
-          input: { roomId, listingName: 'My Listing' },
-        },
-        runResult,
-      );
-    }
+    await handler.addContentsToCommit(
+      {
+        type: 'pr-listing-create',
+        realm: 'http://localhost:4201/test/',
+        userId: '@alice:localhost',
+        input: { roomId: '!room-a:localhost', listingName: 'My Listing' },
+      },
+      runResult,
+    );
 
-    assert.notStrictEqual(
-      folders[0],
-      folders[1],
-      'two different rooms with the same listing name produce distinct folders',
+    assert.strictEqual(folders.length, 1, 'wrote once');
+    assert.ok(
+      BRANCH_PATTERN.test(folders[0]),
+      `folder ${folders[0]} matches {hash6}-{slug}`,
+    );
+    assert.ok(
+      folders[0].endsWith('-my-listing'),
+      'folder ends with kebab-cased listing slug',
     );
   });
 

--- a/packages/host/app/commands/create-submission-workflow.ts
+++ b/packages/host/app/commands/create-submission-workflow.ts
@@ -79,9 +79,9 @@ export default class CreateSubmissionWorkflowCommand extends HostBaseCommand<
     });
     let roomId = createRoomResult.roomId;
 
-    // Branch name is derived from (roomId, listingName) and persisted so
-    // retry doesn't have to reconstruct it from the display title.
-    let branchName = toBranchName(roomId, listingName ?? 'UntitledListing');
+    // Branch name is generated once and persisted on the workflow card so
+    // retries reuse the same GitHub branch.
+    let branchName = toBranchName(listingName ?? 'UntitledListing');
 
     // Cleanup window covers everything between "room exists" and "workflow
     // card persisted with roomId baked in". Once the card exists, leaving

--- a/packages/runtime-common/github-submissions.ts
+++ b/packages/runtime-common/github-submissions.ts
@@ -1,29 +1,9 @@
-const ROOM_ID_PREFIX = 'room-';
+const HASH_BYTES = 3;
 
-function toBase64Url(input: string): string {
-  let base64 =
-    typeof btoa === 'function'
-      ? btoa(input)
-      : Buffer.from(input, 'utf8').toString('base64');
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
-}
-
-function fromBase64Url(input: string): string {
-  let base64 = input.replace(/-/g, '+').replace(/_/g, '/');
-  let padding = base64.length % 4;
-  if (padding !== 0) {
-    base64 += '='.repeat(4 - padding);
-  }
-  return typeof atob === 'function'
-    ? atob(base64)
-    : Buffer.from(base64, 'base64').toString('utf8');
-}
-
-function matrixRoomIdToBranchName(matrixRoomId: string): string {
-  if (!matrixRoomId) {
-    throw new Error('matrixRoomId is required');
-  }
-  return `${ROOM_ID_PREFIX}${toBase64Url(matrixRoomId)}`;
+function generateHash(): string {
+  let bytes = new Uint8Array(HASH_BYTES);
+  globalThis.crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
 }
 
 function toKebabSlug(value: string): string {
@@ -35,48 +15,11 @@ function toKebabSlug(value: string): string {
     .replace(/^-+|-+$/g, '');
 }
 
-export function toBranchName(
-  matrixRoomId: string,
-  listingName: string,
-): string {
+export function toBranchName(listingName: string): string {
   if (!listingName) {
     throw new Error('listingName is required');
   }
-  let roomPrefix = matrixRoomIdToBranchName(matrixRoomId);
   let listingSlug = toKebabSlug(listingName);
-  return listingSlug ? `${roomPrefix}/${listingSlug}` : roomPrefix;
-}
-
-export interface SubmissionMeta {
-  matrixRoomId: string;
-  listingName?: string;
-}
-
-export function branchNameToSubmissionMeta(branchName: string): SubmissionMeta {
-  let [roomSegment, ...listingParts] = branchName.split('/');
-  let matrixRoomId = decodeMatrixRoomIdFromBranchSegment(roomSegment);
-  let listingName = listingParts.join('/');
-  return listingName ? { matrixRoomId, listingName } : { matrixRoomId };
-}
-
-function decodeMatrixRoomIdFromBranchSegment(branchName: string): string {
-  if (!branchName) {
-    throw new Error('branchName is required');
-  }
-  let roomSegment = branchName.split('/')[0];
-  if (!roomSegment.startsWith(ROOM_ID_PREFIX)) {
-    throw new Error('branchName does not include a matrix room id prefix');
-  }
-  let encoded = roomSegment.slice(ROOM_ID_PREFIX.length);
-  if (!encoded) {
-    throw new Error('branchName has no encoded matrix room id');
-  }
-  if (!/^[A-Za-z0-9_-]+$/.test(encoded)) {
-    throw new Error('branchName has an invalid encoded matrix room id');
-  }
-  try {
-    return fromBase64Url(encoded);
-  } catch {
-    throw new Error('branchName has an invalid encoded matrix room id');
-  }
+  let hash = generateHash();
+  return listingSlug ? `${hash}-${listingSlug}` : hash;
 }

--- a/packages/runtime-common/tests/github-submissions-test.ts
+++ b/packages/runtime-common/tests/github-submissions-test.ts
@@ -1,94 +1,44 @@
-import {
-  branchNameToSubmissionMeta,
-  toBranchName,
-} from '../github-submissions';
+import { toBranchName } from '../github-submissions';
 import type { SharedTests } from '../helpers';
 
+const BRANCH_PATTERN = /^[a-f0-9]{6}-(.+)$/;
+
 const tests = Object.freeze({
-  'it converts a branch name back to a matrix room id': async (assert) => {
-    let branchName = 'room-IUZFZGlxWXRoRW52WU51QmlnbTpib3hlbC5haQ';
-    assert.deepEqual(branchNameToSubmissionMeta(branchName), {
-      matrixRoomId: '!FEdiqYthEnvYNuBigm:boxel.ai',
-    });
-  },
-
-  'it extracts the room id from a branch name with a suffix': async (
-    assert,
-  ) => {
-    let roomId = '!NVeTCArRGAqTnFzcPU:stack.cards';
-    let roomPrefix = toBranchName(roomId, 'seed').split('/')[0];
-    let branchName = `${roomPrefix}/my-feature`;
-    assert.strictEqual(
-      branchNameToSubmissionMeta(branchName).matrixRoomId,
-      roomId,
-    );
-  },
-
-  'it builds a branch name from a room id and listing name': async (assert) => {
-    let roomId = '!XezEDqUlIJcNdsuaFB:localhost';
-    assert.strictEqual(
-      toBranchName(roomId, 'SomeSampleListing'),
-      'room-IVhlekVEcVVsSUpjTmRzdWFGQjpsb2NhbGhvc3Q/some-sample-listing',
-    );
+  'it builds a branch name from a listing name': async (assert) => {
+    let branch = toBranchName('SomeSampleListing');
+    let match = branch.match(BRANCH_PATTERN);
+    assert.ok(match, `branch ${branch} matches {hash6}-{slug}`);
+    assert.strictEqual(match![1], 'some-sample-listing');
   },
 
   'it normalizes listing names with spaces and punctuation': async (assert) => {
-    let roomId = '!XezEDqUlIJcNdsuaFB:localhost';
-    let roomPrefix = toBranchName(roomId, 'seed').split('/')[0];
-    assert.strictEqual(
-      toBranchName(roomId, '  My  New Listing  '),
-      `${roomPrefix}/my-new-listing`,
-    );
-    assert.strictEqual(
-      toBranchName(roomId, 'Weird---Name!!'),
-      `${roomPrefix}/weird-name`,
-    );
+    let branch = toBranchName('  My  New Listing  ');
+    assert.ok(/^[a-f0-9]{6}-my-new-listing$/.test(branch), branch);
+    let branch2 = toBranchName('Weird---Name!!');
+    assert.ok(/^[a-f0-9]{6}-weird-name$/.test(branch2), branch2);
   },
 
   'it normalizes camelcase listing names': async (assert) => {
-    let roomId = '!XezEDqUlIJcNdsuaFB:localhost';
-    let roomPrefix = toBranchName(roomId, 'seed').split('/')[0];
-    assert.strictEqual(
-      toBranchName(roomId, 'CamelCaseListing'),
-      `${roomPrefix}/camel-case-listing`,
+    let branch = toBranchName('CamelCaseListing');
+    assert.ok(/^[a-f0-9]{6}-camel-case-listing$/.test(branch), branch);
+  },
+
+  'it returns only the hash when the slug is empty': async (assert) => {
+    let branch = toBranchName('   ---   ');
+    assert.ok(/^[a-f0-9]{6}$/.test(branch), branch);
+  },
+
+  'it rejects missing listing names': async (assert) => {
+    assert.throws(() => toBranchName(''), /listingName is required/);
+  },
+
+  'it generates a different hash on each call': async (assert) => {
+    let branches = new Set(
+      Array.from({ length: 10 }, () => toBranchName('same-name')),
     );
-  },
-
-  'it drops the listing segment when the slug is empty': async (assert) => {
-    let roomId = '!XezEDqUlIJcNdsuaFB:localhost';
-    let roomPrefix = toBranchName(roomId, 'seed').split('/')[0];
-    assert.strictEqual(toBranchName(roomId, '   '), roomPrefix);
-  },
-
-  'it rejects missing listing names when building branch names': async (
-    assert,
-  ) => {
-    let roomId = '!XezEDqUlIJcNdsuaFB:localhost';
-    assert.throws(() => toBranchName(roomId, ''), /listingName is required/);
-  },
-
-  'it can invert a branch name into room id and listing name': async (
-    assert,
-  ) => {
-    let roomId = '!XezEDqUlIJcNdsuaFB:localhost';
-    let branchName = toBranchName(roomId, 'SomeSampleListing');
-    let result = branchNameToSubmissionMeta(branchName);
-    assert.strictEqual(result.matrixRoomId, roomId);
-    assert.strictEqual(result.listingName, 'some-sample-listing');
-  },
-
-  'it rejects branch names without the prefix': async (assert) => {
-    assert.throws(
-      () => branchNameToSubmissionMeta('feature/room-abc'),
-      /matrix room id prefix/,
-    );
-  },
-
-  'it rejects branch names with an invalid encoded room id': async (assert) => {
-    assert.throws(
-      () => branchNameToSubmissionMeta('room-@@@'),
-      /invalid encoded matrix room id/,
-    );
+    // Vanishingly small chance of collision; if this flakes we have bigger
+    // problems than this test.
+    assert.ok(branches.size > 1, 'multiple calls produce different hashes');
   },
 } as SharedTests<Record<string, never>>);
 


### PR DESCRIPTION
Replace the room-encoded `room-<base64>/<slug>` branch convention with a short `{6-hex-hash}-{listing-slug}` form. The hash is random per call; determinism for retries is preserved by the persisted `branchName` on the workflow card.