### PR TITLE
flaky tests - percySnapshot: cap upload wait at 25s, log phase timing

### DIFF
--- a/packages/host/tests/helpers/percy-snapshot.ts
+++ b/packages/host/tests/helpers/percy-snapshot.ts
@@ -139,28 +139,34 @@ export default async function percySnapshot(
     await pauseTest();
   }
 
-  // Race the actual Percy upload against `PERCY_SNAPSHOT_BUDGET_MS`. The
-  // upstream promise is attached to `.catch` first so a late rejection (after
-  // we've already moved on) doesn't surface as an unhandled rejection during a
-  // later test.
+  // Race the actual Percy upload against `PERCY_SNAPSHOT_BUDGET_MS`. Errors
+  // that surface BEFORE the budget elapses are real upload failures (Percy
+  // server unreachable, malformed call, etc.) — those propagate through
+  // `Promise.race` and fail the test. The side `.catch` only swallows
+  // rejections that arrive AFTER we've already abandoned the upload, so a
+  // late rejection can't surface as an unhandled rejection in a later test.
   const snapshotName = describeSnapshot(args);
   const percyStart = performance.now();
-  let timedOut = false;
-  const percyPromise = (originalPercySnapshot(...args) as Promise<void>).catch(
-    (err) => {
+  let abandoned = false;
+  const upload = originalPercySnapshot(...args) as Promise<void>;
+  upload.catch((err) => {
+    if (abandoned) {
       console.warn(
-        `[percy-snapshot] late rejection from Percy snapshot "${snapshotName}":`,
+        `[percy-snapshot] late rejection from abandoned snapshot "${snapshotName}":`,
         err,
       );
-    },
-  );
+    }
+    // If `abandoned` is false here, the rejection already surfaced via
+    // `Promise.race` below — nothing more to do.
+  });
   const timeoutPromise = new Promise<void>((resolve) => {
     setTimeout(() => {
-      timedOut = true;
+      abandoned = true;
       resolve();
     }, PERCY_SNAPSHOT_BUDGET_MS);
   });
-  await Promise.race([percyPromise, timeoutPromise]);
+  await Promise.race([upload, timeoutPromise]);
+  const timedOut = abandoned;
   const percyMs = Math.round(performance.now() - percyStart);
   const totalMs = Math.round(performance.now() - overallStart);
 

--- a/packages/host/tests/helpers/percy-snapshot.ts
+++ b/packages/host/tests/helpers/percy-snapshot.ts
@@ -7,6 +7,20 @@ import QUnit from 'qunit';
 
 const PERCY_PAUSE_PARAMETER = 'percypause';
 
+// Cap how long we'll wait for the Percy upload inside a single test. Percy's
+// local SDK retries page navigation on a 30 s budget per attempt, so a single
+// flaky network hiccup can stack two 30 s retries inside one `await
+// percySnapshot(...)` — well past QUnit's 60 s test budget. When QUnit times
+// out the test, the still-pending `await` here eventually resolves, the lines
+// of test code AFTER `await percySnapshot(...)` run, and any `assert.dom(...)`
+// they push lands on a test QUnit already marked dead. QUnit surfaces that as
+// "Assertion occurred after test finished" — attached to whichever test is
+// currently running. That contaminates the next test (or two) and looks like a
+// flake in unrelated tests, but the actual cause is always upstream: a slow
+// Percy snapshot that overran the test budget. Capping well below 60 s lets
+// the test continue and exit cleanly even when Percy is misbehaving.
+const PERCY_SNAPSHOT_BUDGET_MS = 25_000;
+
 QUnit.config.urlConfig.push({
   id: PERCY_PAUSE_PARAMETER,
   label: 'Pause on Percy snapshot',
@@ -15,7 +29,10 @@ QUnit.config.urlConfig.push({
 export default async function percySnapshot(
   ...args: Parameters<typeof originalPercySnapshot>
 ) {
+  const overallStart = performance.now();
+  const settledStart = performance.now();
   await settled();
+  const settledMs = Math.round(performance.now() - settledStart);
 
   // Load every @font-face the page has declared, not just a hard-coded list.
   // This covers IBM Plex Sans, IBM Plex Mono (used by Monaco), IBM Plex Serif
@@ -29,10 +46,12 @@ export default async function percySnapshot(
   // the load-bearing assertion: if the font that actually moves Percy pixels
   // is missing, fail there with a clear message.
   let faces = Array.from(document.fonts);
+  const fontStart = performance.now();
   let fontResults = await Promise.allSettled(
     faces.map((f) => f.load().then(() => f)),
   );
   await document.fonts.ready;
+  const fontMs = Math.round(performance.now() - fontStart);
 
   let failedFonts = fontResults.flatMap((result, idx) => {
     if (result.status !== 'rejected') {
@@ -87,6 +106,10 @@ export default async function percySnapshot(
   // aren't registered as Ember test waiters. Percy would then capture a frame
   // where some images have painted and others haven't — exactly the "card
   // icon inconsistencies" false-positive class.
+  const imageStart = performance.now();
+  const pendingImageCount = Array.from(document.images).filter(
+    (img) => !img.complete,
+  ).length;
   await Promise.all(
     Array.from(document.images)
       .filter((img) => !img.complete)
@@ -98,6 +121,7 @@ export default async function percySnapshot(
           }),
       ),
   );
+  const imageMs = Math.round(performance.now() - imageStart);
 
   // Give the browser one full paint after fonts/images settle. CSS custom
   // properties (e.g. --icon-color cascading from an ancestor) resolve at
@@ -115,7 +139,64 @@ export default async function percySnapshot(
     await pauseTest();
   }
 
-  await originalPercySnapshot(...args);
+  // Race the actual Percy upload against `PERCY_SNAPSHOT_BUDGET_MS`. The
+  // upstream promise is attached to `.catch` first so a late rejection (after
+  // we've already moved on) doesn't surface as an unhandled rejection during a
+  // later test.
+  const snapshotName = describeSnapshot(args);
+  const percyStart = performance.now();
+  let timedOut = false;
+  const percyPromise = (originalPercySnapshot(...args) as Promise<void>).catch(
+    (err) => {
+      console.warn(
+        `[percy-snapshot] late rejection from Percy snapshot "${snapshotName}":`,
+        err,
+      );
+    },
+  );
+  const timeoutPromise = new Promise<void>((resolve) => {
+    setTimeout(() => {
+      timedOut = true;
+      resolve();
+    }, PERCY_SNAPSHOT_BUDGET_MS);
+  });
+  await Promise.race([percyPromise, timeoutPromise]);
+  const percyMs = Math.round(performance.now() - percyStart);
+  const totalMs = Math.round(performance.now() - overallStart);
+
+  if (timedOut) {
+    console.warn(
+      `[percy-snapshot] "${snapshotName}" abandoned after ${percyMs}ms ` +
+        `(budget ${PERCY_SNAPSHOT_BUDGET_MS}ms; settled=${settledMs}ms, ` +
+        `fonts=${fontMs}ms, images=${imageMs}ms over ${pendingImageCount} ` +
+        `pending; total=${totalMs}ms). Percy is likely retrying internally — ` +
+        `letting the test continue so it can exit cleanly before the QUnit ` +
+        `timeout. The visual diff for this test may be missing.`,
+    );
+  } else if (totalMs > 5000) {
+    console.log(
+      `[percy-snapshot] "${snapshotName}" completed in ${totalMs}ms ` +
+        `(settled=${settledMs}ms, fonts=${fontMs}ms, ` +
+        `images=${imageMs}ms over ${pendingImageCount} pending, ` +
+        `percy=${percyMs}ms)`,
+    );
+  }
+}
+
+function describeSnapshot(
+  args: Parameters<typeof originalPercySnapshot>,
+): string {
+  const first = args[0] as unknown;
+  if (first && typeof first === 'object') {
+    const test = (
+      first as { test?: { module?: { name?: string }; testName?: string } }
+    ).test;
+    if (test?.module?.name && test?.testName) {
+      return `${test.module.name} | ${test.testName}`;
+    }
+  }
+  if (typeof first === 'string') return first;
+  return '<unnamed>';
 }
 
 function describeFontLoadError(reason: unknown): string {

--- a/packages/host/tests/helpers/percy-snapshot.ts
+++ b/packages/host/tests/helpers/percy-snapshot.ts
@@ -159,13 +159,22 @@ export default async function percySnapshot(
     // If `abandoned` is false here, the rejection already surfaced via
     // `Promise.race` below — nothing more to do.
   });
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<void>((resolve) => {
-    setTimeout(() => {
+    timeoutHandle = setTimeout(() => {
       abandoned = true;
       resolve();
     }, PERCY_SNAPSHOT_BUDGET_MS);
   });
-  await Promise.race([upload, timeoutPromise]);
+  try {
+    await Promise.race([upload, timeoutPromise]);
+  } finally {
+    // Race settled (upload resolved, upload rejected, or budget fired). In
+    // every case we no longer need the timer — leaving it would fire mid-way
+    // through a later test, mutating a stale `abandoned` closure for no
+    // benefit and holding the snapshot's locals live for 25 s longer.
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+  }
   const timedOut = abandoned;
   const percyMs = Math.round(performance.now() - percyStart);
   const totalMs = Math.round(performance.now() - overallStart);


### PR DESCRIPTION
## The flake

Run [25775029967](https://github.com/cardstack/boxel/actions/runs/25775029967/job/75706442186?pr=4791) (host shard 13) failed three tests in `Acceptance | interact submode tests > 1 stack`:

| # | Test | Wall | Failure |
| -: | --- | -: | --- |
| 12 | restoring the stack from query param | 74907 ms | `Test took longer than 60000ms; test timed out.` |
| 14 | restoring the stack from query param when card is in edit format | 69514 ms | `Assertion occurred after test finished` (referencing test 12's `assert.dom(...).includesText("Person")`) |
| 17 | search can be dismissed with escape | 9755 ms | `Assertion occurred after test finished` (referencing test 14's `assert.dom('[data-test-field="firstName"] input').exists`) |

## Mechanism

The local Percy SDK retries page navigation on a 30 s budget per attempt. Logs show two `[percy] Retrying snapshot` lines spaced ~30 s apart inside test 12 alone — those two stacked retries push `await percySnapshot(...)` past QUnit's 60 s test budget.

When QUnit times out test 12, the still-pending `await` eventually resolves late. The lines AFTER `await percySnapshot(...)` ([test:148](https://github.com/cardstack/boxel/blob/main/packages/host/tests/acceptance/interact-submode-test.gts#L148)) — `assert.dom(...).includesText('Person')` — then run and push assertions onto a test QUnit already marked dead. QUnit reports that as a global failure attached to whichever test is currently running. That's how test 12's leftover assertion ends up failing test 14, and test 14's leftover assertion ends up failing test 17. The actual problem is always upstream: Percy was slow in test 12.

## Fix

- Race the actual `originalPercySnapshot(...)` call against a 25 s budget (well under QUnit's 60 s default). When the budget fires, the await returns; the test continues and exits cleanly within budget. The visual diff for that particular snapshot may be missing, but no late assertions contaminate later tests.
- Attach `.catch` to the upstream Percy promise BEFORE the race, so if it eventually rejects after we've moved on it doesn't surface as an unhandled rejection during a later test.
- Log per-phase timing (`settled` / `fonts` / `images` over pending count / `percy`) when a snapshot abandons OR when it runs over 5 s. If this flake recurs we'll see which phase blew up.

## Test plan

- [ ] CI host shards green on this branch.
- [ ] If a percy snapshot still abandons, the `[percy-snapshot] "<test name>" abandoned after Xms` warning surfaces the timing breakdown so we can decide whether to bump the budget, fix Percy server config, or pursue something else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)