### PR TITLE
manual-deploy: send post-deployment auth as Authorization header [CS-11129]

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -294,15 +294,18 @@ jobs:
       - name: Call post-deployment endpoint on realm server
         run: |
           if [ "${{ inputs.environment }}" = "production" ]; then
-            URL="https://app.boxel.ai/_post-deployment?authHeader=${{ secrets.PRODUCTION_REALM_SERVER_SECRET }}"
+            URL="https://app.boxel.ai/_post-deployment"
+            SECRET="${{ secrets.PRODUCTION_REALM_SERVER_SECRET }}"
           elif [ "${{ inputs.environment }}" = "staging" ]; then
-            URL="https://realms-staging.stack.cards/_post-deployment?authHeader=${{ secrets.STAGING_REALM_SERVER_SECRET }}"
+            URL="https://realms-staging.stack.cards/_post-deployment"
+            SECRET="${{ secrets.STAGING_REALM_SERVER_SECRET }}"
           else
             echo "Unknown environment: ${{ inputs.environment }}"
             exit 1
           fi
 
-          response=$(curl -s -w "\n%{http_code}" -X POST "$URL")
+          response=$(curl -s -w "\n%{http_code}" -X POST \
+            -H "Authorization: $SECRET" "$URL")
           response_body=$(echo "$response" | head -n -1)
           response_code=$(echo "$response" | tail -n 1)
 


### PR DESCRIPTION
## Summary
- The `Manual Deploy [boxel]` workflow's "After realm server stable deployment" job started returning 401 on 2026-05-13 after [`46f7d09c05`](https://github.com/cardstack/boxel/commit/46f7d09c05) (CS-10927) removed the `convertAuthHeaderQueryParam` middleware. That middleware had been silently bridging `?authHeader=<secret>` into `ctx.request.headers.authorization` for every route, including `_post-deployment` — the CS-10927 audit caught the Grafana callers but missed this workflow.
- `handle-post-deployment.ts` still compares the bare secret against `headers.authorization`, so the minimal unblock is to put the secret in that header instead of the query string.

First failing run on main: https://github.com/cardstack/boxel/actions/runs/25780525983/job/75727313989 (commit `18659694cb`, 2026-05-13 06:23 UTC).

Related: [CS-11129](https://linear.app/cardstack/issue/CS-11129/stagingprod-post-deployment-endpoint-returns-401-after)


🤖 Generated with [Claude Code](https://claude.com/claude-code)