### PR TITLE
Fix flaky 'sends read receipts only for bot messages' test

### DIFF
--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -1016,9 +1016,15 @@ export default class Room extends Component<Signature> {
 
   private sendReadReceipt(message: Message) {
     if (this.matrixService.profile.userId === message.author.userId) {
+      console.log(
+        `[read-receipt-trace] skip self event=${message.eventId} room=${this.args.roomId}`,
+      );
       return;
     }
     if (this.matrixService.currentUserEventReadReceipts.has(message.eventId)) {
+      console.log(
+        `[read-receipt-trace] skip already-acked event=${message.eventId} room=${this.args.roomId}`,
+      );
       return;
     }
 
@@ -1031,10 +1037,16 @@ export default class Room extends Component<Signature> {
       getTs: () => message.created.getTime(),
     };
 
+    console.log(
+      `[read-receipt-trace] schedule event=${message.eventId} room=${this.args.roomId}`,
+    );
     // Without scheduling this after render, this produces the "attempted to
     // update value, but it had already been used previously in the same
     // computation" error
     schedule('afterRender', () => {
+      console.log(
+        `[read-receipt-trace] dispatch event=${message.eventId} room=${this.args.roomId}`,
+      );
       this.matrixService.sendReadReceipt(matrixEvent as MatrixEvent);
     });
   }

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -6,6 +6,7 @@ import { action } from '@ember/object';
 import type Owner from '@ember/owner';
 import { schedule } from '@ember/runloop';
 import { service } from '@ember/service';
+import { isTesting } from '@embroider/macros';
 import Component from '@glimmer/component';
 import { cached, tracked } from '@glimmer/tracking';
 
@@ -1016,15 +1017,19 @@ export default class Room extends Component<Signature> {
 
   private sendReadReceipt(message: Message) {
     if (this.matrixService.profile.userId === message.author.userId) {
-      console.log(
-        `[read-receipt-trace] skip self event=${message.eventId} room=${this.args.roomId}`,
-      );
+      if (isTesting()) {
+        console.log(
+          `[read-receipt-trace] skip self event=${message.eventId} room=${this.args.roomId}`,
+        );
+      }
       return;
     }
     if (this.matrixService.currentUserEventReadReceipts.has(message.eventId)) {
-      console.log(
-        `[read-receipt-trace] skip already-acked event=${message.eventId} room=${this.args.roomId}`,
-      );
+      if (isTesting()) {
+        console.log(
+          `[read-receipt-trace] skip already-acked event=${message.eventId} room=${this.args.roomId}`,
+        );
+      }
       return;
     }
 
@@ -1037,16 +1042,20 @@ export default class Room extends Component<Signature> {
       getTs: () => message.created.getTime(),
     };
 
-    console.log(
-      `[read-receipt-trace] schedule event=${message.eventId} room=${this.args.roomId}`,
-    );
+    if (isTesting()) {
+      console.log(
+        `[read-receipt-trace] schedule event=${message.eventId} room=${this.args.roomId}`,
+      );
+    }
     // Without scheduling this after render, this produces the "attempted to
     // update value, but it had already been used previously in the same
     // computation" error
     schedule('afterRender', () => {
-      console.log(
-        `[read-receipt-trace] dispatch event=${message.eventId} room=${this.args.roomId}`,
-      );
+      if (isTesting()) {
+        console.log(
+          `[read-receipt-trace] dispatch event=${message.eventId} room=${this.args.roomId}`,
+        );
+      }
       this.matrixService.sendReadReceipt(matrixEvent as MatrixEvent);
     });
   }

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -282,7 +282,9 @@ export default class MatrixService extends Service {
   }
 
   private addEventReadReceipt(eventId: string, receipt: { readAt: Date }) {
-    console.log(`[read-receipt-trace] arrived event=${eventId}`);
+    if (isTesting()) {
+      console.log(`[read-receipt-trace] arrived event=${eventId}`);
+    }
     this.currentUserEventReadReceipts.set(eventId, receipt);
   }
 

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -282,6 +282,7 @@ export default class MatrixService extends Service {
   }
 
   private addEventReadReceipt(eventId: string, receipt: { readAt: Date }) {
+    console.log(`[read-receipt-trace] arrived event=${eventId}`);
     this.currentUserEventReadReceipts.set(eventId, receipt);
   }
 

--- a/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
@@ -815,7 +815,16 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
     await click(`[data-test-enter-room="${anotherRoomId}"]`);
     await waitFor('[data-test-message-idx="0"]');
 
+    // Read receipts are delivered via IntersectionObserver → afterRender
+    // schedule → matrix client → Receipt event, which is not captured by
+    // `waitFor` settling on a DOM element. Wait until both receipts have
+    // landed before asserting their order.
     let matrixService = getService('matrix-service');
+    await waitUntil(
+      () =>
+        matrixService.currentUserEventReadReceipts.has(eventId2) &&
+        matrixService.currentUserEventReadReceipts.has(eventId3),
+    );
     assert.deepEqual(
       Array.from(matrixService.currentUserEventReadReceipts.keys()),
       [eventId2, eventId3],


### PR DESCRIPTION
## The flake

Run [25785225570](https://github.com/cardstack/boxel/actions/runs/25785225570/job/75737411217?pr=4806) (host shard 14) failed `Integration | ai-assistant-panel | general: sends read receipts only for bot messages`:

```
actual: !mock_event_16
expected: !mock_event_16,!mock_event_22
```

The second room's bot-message event ID never landed in `matrixService.currentUserEventReadReceipts` before the assertion fired.

## Mechanism

After clicking into the second room, the test waits for `[data-test-message-idx=\"0\"]` to render and then asserts the read-receipt map immediately. But the read-receipt path is:

1. `IntersectionObserver` fires (async, post-layout)
2. `Room.sendReadReceipt` schedules an `afterRender` job
3. The job calls `matrixService.sendReadReceipt` → matrix client
4. Matrix client emits a `Receipt` event
5. `onReceipt` → `addEventReadReceipt` → `currentUserEventReadReceipts.set`

None of those steps are gated on DOM mutation, so `waitFor`'s settledness doesn't cover them. The first room's receipt usually wins this race because it has had the whole test duration to fire; the second room's receipt has only the gap between `waitFor` and the next line.

## Fix

- Add a `waitUntil` that blocks the assertion until both event IDs are present in the receipts map. The deep-equal that follows still verifies order and exact contents.
- Add `[read-receipt-trace]` `console.log` calls on the schedule, dispatch, skip-self, skip-already-acked, and arrival paths. If this flake recurs the browser-log section of the failing TAP entry will show which step stalled — without this, the test failure is just \"map is short by one entry\" with no way to tell whether the IntersectionObserver never fired, the afterRender job never ran, the matrix client swallowed the call, or the Receipt event never came back.

## Test plan

- [ ] CI host shards green on this branch.
- [ ] If the test fails again, the `[read-receipt-trace]` lines in the browser log identify the stalled step so we can fix the right layer instead of guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)