### PR TITLE
observability: fix Overview dashboard Tasks panel rendering

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -883,7 +883,7 @@
               "properties": [
                 {
                   "id": "displayName",
-                  "value": "Run"
+                  "value": " "
                 },
                 {
                   "id": "thresholds",
@@ -911,14 +911,14 @@
               "properties": [
                 {
                   "id": "displayName",
-                  "value": "Need"
+                  "value": "/"
                 }
               ]
             }
           ]
         },
         "gridPos": {
-          "h": 2,
+          "h": 3,
           "w": 4,
           "x": 0,
           "y": 20
@@ -1195,7 +1195,7 @@
               "properties": [
                 {
                   "id": "displayName",
-                  "value": "Run"
+                  "value": " "
                 },
                 {
                   "id": "thresholds",
@@ -1223,14 +1223,14 @@
               "properties": [
                 {
                   "id": "displayName",
-                  "value": "Need"
+                  "value": "/"
                 }
               ]
             }
           ]
         },
         "gridPos": {
-          "h": 2,
+          "h": 3,
           "w": 4,
           "x": 4,
           "y": 20
@@ -1507,7 +1507,7 @@
               "properties": [
                 {
                   "id": "displayName",
-                  "value": "Run"
+                  "value": " "
                 },
                 {
                   "id": "thresholds",
@@ -1535,14 +1535,14 @@
               "properties": [
                 {
                   "id": "displayName",
-                  "value": "Need"
+                  "value": "/"
                 }
               ]
             }
           ]
         },
         "gridPos": {
-          "h": 2,
+          "h": 3,
           "w": 4,
           "x": 8,
           "y": 20
@@ -1819,7 +1819,7 @@
               "properties": [
                 {
                   "id": "displayName",
-                  "value": "Run"
+                  "value": " "
                 },
                 {
                   "id": "thresholds",
@@ -1847,14 +1847,14 @@
               "properties": [
                 {
                   "id": "displayName",
-                  "value": "Need"
+                  "value": "/"
                 }
               ]
             }
           ]
         },
         "gridPos": {
-          "h": 2,
+          "h": 3,
           "w": 4,
           "x": 12,
           "y": 20
@@ -2116,7 +2116,7 @@
           "overrides": []
         },
         "gridPos": {
-          "h": 6,
+          "h": 7,
           "w": 4,
           "x": 20,
           "y": 16
@@ -2159,7 +2159,7 @@
           "h": 8,
           "w": 24,
           "x": 0,
-          "y": 32
+          "y": 33
         },
         "id": 6,
         "options": {
@@ -2224,7 +2224,7 @@
           "h": 4,
           "w": 6,
           "x": 0,
-          "y": 22
+          "y": 23
         },
         "id": 7,
         "options": {
@@ -2292,7 +2292,7 @@
           "h": 4,
           "w": 6,
           "x": 6,
-          "y": 22
+          "y": 23
         },
         "id": 8,
         "options": {
@@ -2369,7 +2369,7 @@
           "h": 4,
           "w": 6,
           "x": 12,
-          "y": 22
+          "y": 23
         },
         "id": 9,
         "options": {
@@ -2441,7 +2441,7 @@
           "h": 4,
           "w": 6,
           "x": 18,
-          "y": 22
+          "y": 23
         },
         "id": 10,
         "options": {
@@ -2585,7 +2585,7 @@
           "h": 6,
           "w": 24,
           "x": 0,
-          "y": 26
+          "y": 27
         },
         "id": 11,
         "options": {
@@ -2644,7 +2644,7 @@
           "h": 8,
           "w": 24,
           "x": 0,
-          "y": 40
+          "y": 41
         },
         "id": 12,
         "options": {


### PR DESCRIPTION
## Summary
- The four per-service **Tasks** stat panels in the Overview dashboard (Row 4: Realm Server / Prerender / Prerender Mgr / Worker) were rendering with the **Need** value clipped — only "Run 1" / "Run 4" showed; the matching DesiredTaskCount tile fell off the bottom of the h:2 panel.
- Verified via CloudWatch (`ECS/ContainerInsights:DesiredTaskCount`) that staging is publishing values for all four services — this was a layout problem, not a data problem.
- Fix bumps each Tasks panel from `h:2` → `h:3`, shortens the displayName overrides from `"Run"` / `"Need"` to `" "` / `"/"` so the two tiles render inline as `1 / 1`, and shifts the rows below down by 1 (indexing stats `y:22→23`, throughput `y:26→27`, alerts `y:32→33`, footer `y:40→41`). Postgres DB column bumped `h:6→7` to keep the 4+3=7 stack height aligned.

## Test plan
- [ ] `cd packages/observability && grafanactl resources push grafanactl/resources/dashboards/boxel-status/overview.json` (or whichever invocation is canonical for your env)
- [ ] Load the Overview dashboard against staging — all four Tasks panels should now render `1 / 1`, `4 / 4`, `1 / 1`, `4 / 4` (or the current values) without clipping.
- [ ] Confirm the rows below Tasks (indexing stats, throughput graph, alerts list, footer markdown) haven't moved visually beyond the intended 1-row downshift, and don't overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)