### PR TITLE
Add Concurrent Users panel to boxel-status overview

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -85,7 +85,7 @@
         },
         "gridPos": {
           "h": 8,
-          "w": 12,
+          "w": 8,
           "x": 0,
           "y": 0
         },
@@ -187,8 +187,8 @@
         },
         "gridPos": {
           "h": 8,
-          "w": 12,
-          "x": 12,
+          "w": 8,
+          "x": 8,
           "y": 0
         },
         "id": 22,
@@ -232,6 +232,106 @@
           }
         ],
         "title": "Users",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "loki"
+        },
+        "description": "Concurrent users right now: count of distinct Matrix users seen on the Synapse Sliding Sync endpoint within a rolling 5-minute window, evaluated across the dashboard time range. Big number is the latest 5-minute count; sparkline shows how the active-user count moved over the range. Sourced from Synapse access logs via Loki — matches `Processed request` lines hitting the MSC3575 Sliding Sync path (`simplified_msc3575/sync`) and extracts the `@user:server` token from the log prefix. Path is on the unstable MSC3575 namespace and may shift when sliding-sync stabilises upstream.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 0,
+            "links": [
+              {
+                "title": "Open Synapse dashboard",
+                "url": "/d/000000012",
+                "targetBlank": false
+              }
+            ],
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "transparent",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 0
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Concurrent Users"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "#ff66c4"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 16,
+          "y": 0
+        },
+        "id": 30,
+        "links": [
+          {
+            "title": "Open Synapse dashboard",
+            "url": "/d/000000012",
+            "targetBlank": false,
+            "type": "link",
+            "icon": "external link"
+          }
+        ],
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "value_and_name",
+          "wideLayout": true
+        },
+        "pluginVersion": "12.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "expr": "count(count by (user) (count_over_time({service=\"synapse\"} |~ \"Processed request.*simplified_msc3575/sync\" | regexp `\\{(?P<user>@[^}]+:[^}]+)\\}` [5m]))) or vector(0)",
+            "queryType": "range",
+            "legendFormat": "Concurrent Users",
+            "refId": "A"
+          }
+        ],
+        "title": "Concurrent Users",
         "type": "stat"
       },
       {


### PR DESCRIPTION
## Summary

- New `Concurrent Users` stat panel in the top row of the boxel-status overview dashboard, next to Realms and Users.
- Metric: count of distinct Matrix users that hit Synapse's Sliding Sync (MSC3575) endpoint in a rolling 5-minute window, evaluated across the dashboard time range. The big number is the latest 5-minute count; the area sparkline shows how it moved over the range.
- Sourced from Synapse access logs via Loki — matches `Processed request` lines hitting `simplified_msc3575/sync` (so unauthenticated `Received request` lines that show `{None}` are excluded) and extracts the `@user:server` token from the log prefix.
- Click target is the existing Synapse dashboard (`/d/000000012`), mirroring how the Users panel links out.
- Layout: shrank Realms (id 21) and Users (id 22) from `w:12` to `w:8` to make room. Final top row is three equal `w:8` stat panels at `x:0 / 8 / 16`.
- Note: the unstable MSC3575 path may shift when sliding-sync stabilises upstream — the panel description calls this out.

## Test plan

- [ ] `cd packages/observability && docker compose up -d` (or whatever the local stack command is for this package), wait for Grafana + Loki + Synapse to come up.
- [ ] Open the boxel-status Overview dashboard in local Grafana.
- [ ] Confirm three stat panels in the top row: Realms | Users | Concurrent Users (equal width, sparkline style).
- [ ] Confirm the Concurrent Users panel's external-link icon opens the Synapse dashboard.
- [ ] Start a local host session (sign into Matrix), observe the Concurrent Users count tick up to at least 1 within ~5 minutes.
- [ ] Confirm narrowing/widening the dashboard time picker re-scopes the sparkline (and does not pin to a stale 1-year range like Users does).