### PR TITLE
grafana: clarify Synapse panels in overview

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -105,9 +105,7 @@
           "justifyMode": "auto",
           "orientation": "auto",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           },
@@ -207,9 +205,7 @@
           "justifyMode": "auto",
           "orientation": "auto",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           },
@@ -330,10 +326,13 @@
                 "options": "p50"
               },
               "properties": [
-                {"id": "unit", "value": "s"},
-                {"id": "custom.axisPlacement", "value": "right"},
-                {"id": "custom.fillOpacity", "value": 0},
-                {"id": "color", "value": {"mode": "fixed", "fixedColor": "#73bf69"}}
+                { "id": "unit", "value": "s" },
+                { "id": "custom.axisPlacement", "value": "right" },
+                { "id": "custom.fillOpacity", "value": 0 },
+                {
+                  "id": "color",
+                  "value": { "mode": "fixed", "fixedColor": "#73bf69" }
+                }
               ]
             },
             {
@@ -342,10 +341,13 @@
                 "options": "p95"
               },
               "properties": [
-                {"id": "unit", "value": "s"},
-                {"id": "custom.axisPlacement", "value": "right"},
-                {"id": "custom.fillOpacity", "value": 0},
-                {"id": "color", "value": {"mode": "fixed", "fixedColor": "#ff9830"}}
+                { "id": "unit", "value": "s" },
+                { "id": "custom.axisPlacement", "value": "right" },
+                { "id": "custom.fillOpacity", "value": 0 },
+                {
+                  "id": "color",
+                  "value": { "mode": "fixed", "fixedColor": "#ff9830" }
+                }
               ]
             },
             {
@@ -354,10 +356,13 @@
                 "options": "p99"
               },
               "properties": [
-                {"id": "unit", "value": "s"},
-                {"id": "custom.axisPlacement", "value": "right"},
-                {"id": "custom.fillOpacity", "value": 0},
-                {"id": "color", "value": {"mode": "fixed", "fixedColor": "#f2495c"}}
+                { "id": "unit", "value": "s" },
+                { "id": "custom.axisPlacement", "value": "right" },
+                { "id": "custom.fillOpacity", "value": 0 },
+                {
+                  "id": "color",
+                  "value": { "mode": "fixed", "fixedColor": "#f2495c" }
+                }
               ]
             }
           ]
@@ -371,9 +376,7 @@
         "id": 1,
         "options": {
           "legend": {
-            "calcs": [
-              "mean"
-            ],
+            "calcs": ["mean"],
             "displayMode": "list",
             "placement": "bottom",
             "showLegend": true
@@ -406,12 +409,12 @@
             "refId": "B"
           },
           {
-            "datasource": {"type": "cloudwatch", "uid": "cef5x9o3yzawwf"},
+            "datasource": { "type": "cloudwatch", "uid": "cef5x9o3yzawwf" },
             "namespace": "AWS/ApplicationELB",
             "metricName": "TargetResponseTime",
             "metricEditorMode": 0,
             "metricQueryType": 0,
-            "dimensions": {"LoadBalancer": "$realm_server_alb"},
+            "dimensions": { "LoadBalancer": "$realm_server_alb" },
             "statistic": "p50",
             "period": "",
             "region": "default",
@@ -419,12 +422,12 @@
             "refId": "C"
           },
           {
-            "datasource": {"type": "cloudwatch", "uid": "cef5x9o3yzawwf"},
+            "datasource": { "type": "cloudwatch", "uid": "cef5x9o3yzawwf" },
             "namespace": "AWS/ApplicationELB",
             "metricName": "TargetResponseTime",
             "metricEditorMode": 0,
             "metricQueryType": 0,
-            "dimensions": {"LoadBalancer": "$realm_server_alb"},
+            "dimensions": { "LoadBalancer": "$realm_server_alb" },
             "statistic": "p95",
             "period": "",
             "region": "default",
@@ -432,12 +435,12 @@
             "refId": "D"
           },
           {
-            "datasource": {"type": "cloudwatch", "uid": "cef5x9o3yzawwf"},
+            "datasource": { "type": "cloudwatch", "uid": "cef5x9o3yzawwf" },
             "namespace": "AWS/ApplicationELB",
             "metricName": "TargetResponseTime",
             "metricEditorMode": 0,
             "metricQueryType": 0,
-            "dimensions": {"LoadBalancer": "$realm_server_alb"},
+            "dimensions": { "LoadBalancer": "$realm_server_alb" },
             "statistic": "p99",
             "period": "",
             "region": "default",
@@ -520,9 +523,7 @@
           "justifyMode": "auto",
           "orientation": "vertical",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           },
@@ -641,9 +642,7 @@
         ],
         "options": {
           "legend": {
-            "calcs": [
-              "mean"
-            ],
+            "calcs": ["mean"],
             "displayMode": "list",
             "placement": "bottom",
             "showLegend": true
@@ -666,7 +665,7 @@
             "refId": "A"
           }
         ],
-        "title": "Synapse",
+        "title": "Matrix Events",
         "type": "timeseries"
       },
       {
@@ -801,9 +800,7 @@
           "maxVizHeight": 300,
           "sizing": "auto",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           }
@@ -930,9 +927,7 @@
           "justifyMode": "center",
           "orientation": "horizontal",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           },
@@ -1113,9 +1108,7 @@
           "maxVizHeight": 300,
           "sizing": "auto",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           }
@@ -1242,9 +1235,7 @@
           "justifyMode": "center",
           "orientation": "horizontal",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           },
@@ -1425,9 +1416,7 @@
           "maxVizHeight": 300,
           "sizing": "auto",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           }
@@ -1554,9 +1543,7 @@
           "justifyMode": "center",
           "orientation": "horizontal",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           },
@@ -1737,9 +1724,7 @@
           "maxVizHeight": 300,
           "sizing": "auto",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           }
@@ -1866,9 +1851,7 @@
           "justifyMode": "center",
           "orientation": "horizontal",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           },
@@ -2034,6 +2017,15 @@
           "y": 16
         },
         "id": 17,
+        "links": [
+          {
+            "title": "Open Synapse dashboard",
+            "url": "/d/000000012",
+            "targetBlank": false,
+            "type": "link",
+            "icon": "external link"
+          }
+        ],
         "options": {
           "displayMode": "gradient",
           "orientation": "horizontal",
@@ -2045,9 +2037,7 @@
           "maxVizHeight": 300,
           "sizing": "auto",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           }
@@ -2075,7 +2065,7 @@
             "refId": "B"
           }
         ],
-        "title": "Synapse",
+        "title": "Synapse Process",
         "type": "bargauge"
       },
       {
@@ -2128,9 +2118,7 @@
           "justifyMode": "auto",
           "orientation": "vertical",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           },
@@ -2233,9 +2221,7 @@
           "justifyMode": "auto",
           "orientation": "horizontal",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           },
@@ -2301,9 +2287,7 @@
           "justifyMode": "auto",
           "orientation": "horizontal",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           },
@@ -2378,9 +2362,7 @@
           "justifyMode": "auto",
           "orientation": "horizontal",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           },
@@ -2450,9 +2432,7 @@
           "justifyMode": "auto",
           "orientation": "horizontal",
           "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
+            "calcs": ["lastNotNull"],
             "fields": "",
             "values": false
           },
@@ -2663,9 +2643,7 @@
     ],
     "refresh": "30s",
     "schemaVersion": 42,
-    "tags": [
-      "overview"
-    ],
+    "tags": ["overview"],
     "templating": {
       "list": [
         {
@@ -2677,7 +2655,7 @@
         },
         {
           "current": {},
-          "datasource": {"type": "cloudwatch", "uid": "cef5x9o3yzawwf"},
+          "datasource": { "type": "cloudwatch", "uid": "cef5x9o3yzawwf" },
           "definition": "dimension_values(default,AWS/ApplicationELB,RequestCount,LoadBalancer)",
           "hide": 2,
           "includeAll": false,


### PR DESCRIPTION
## Summary
- Renames the two "Synapse" panels in the overview dashboard so they're distinguishable: events/min timeseries → "Matrix Events", CPU/Mem bargauge → "Synapse Process".
- Adds a missing panel-level `links` array to the CPU/Mem bargauge so its header chain icon navigates to the Synapse dashboard (matching the pattern used by Realms / Users / Web Requests / Matrix Events).

## Test plan
- [ ] Load the Boxel Status > Overview dashboard locally and confirm the two formerly-"Synapse" panels now read "Matrix Events" and "Synapse Process".
- [ ] Click the chain/external-link icon in the header of the "Synapse Process" panel; confirm it navigates to the Synapse dashboard (`/d/000000012`).
- [ ] Confirm the "Matrix Events" panel's existing header link still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)