### PR TITLE
observability: render Tasks panel as inline 'Run / Need'

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -861,61 +861,34 @@
             "color": {
               "mode": "thresholds"
             },
-            "decimals": 0,
-            "mappings": [],
+            "decimals": 2,
+            "mappings": [
+              {
+                "type": "regex",
+                "options": {
+                  "pattern": "^(\\d+)\\.0*(\\d+)$",
+                  "result": {
+                    "text": "$1 / $2"
+                  }
+                }
+              }
+            ],
             "thresholds": {
               "mode": "absolute",
               "steps": [
                 {
-                  "color": "transparent",
+                  "color": "red",
                   "value": null
-                }
-              ]
-            },
-            "unit": "short"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byFrameRefID",
-                "options": "A"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": " "
                 },
                 {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "red",
-                        "value": null
-                      },
-                      {
-                        "color": "green",
-                        "value": 1
-                      }
-                    ]
-                  }
+                  "color": "green",
+                  "value": 1
                 }
               ]
             },
-            {
-              "matcher": {
-                "id": "byFrameRefID",
-                "options": "B"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "/"
-                }
-              ]
-            }
-          ]
+            "unit": "none"
+          },
+          "overrides": []
         },
         "gridPos": {
           "h": 3,
@@ -936,7 +909,7 @@
             "fields": "",
             "values": false
           },
-          "textMode": "value_and_name",
+          "textMode": "value",
           "wideLayout": true
         },
         "pluginVersion": "12.4.3",
@@ -957,7 +930,8 @@
             "statistic": "Maximum",
             "period": "",
             "region": "default",
-            "refId": "A"
+            "refId": "A",
+            "hide": true
           },
           {
             "datasource": {
@@ -975,7 +949,25 @@
             "statistic": "Maximum",
             "period": "",
             "region": "default",
-            "refId": "B"
+            "refId": "B",
+            "hide": true
+          },
+          {
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "expression": "A + B/100",
+            "metricQueryType": 0,
+            "metricEditorMode": 1,
+            "namespace": "",
+            "metricName": "",
+            "dimensions": {},
+            "statistic": "",
+            "period": "",
+            "region": "default",
+            "refId": "e1",
+            "id": "e1"
           }
         ],
         "title": "Tasks",
@@ -1173,61 +1165,34 @@
             "color": {
               "mode": "thresholds"
             },
-            "decimals": 0,
-            "mappings": [],
+            "decimals": 2,
+            "mappings": [
+              {
+                "type": "regex",
+                "options": {
+                  "pattern": "^(\\d+)\\.0*(\\d+)$",
+                  "result": {
+                    "text": "$1 / $2"
+                  }
+                }
+              }
+            ],
             "thresholds": {
               "mode": "absolute",
               "steps": [
                 {
-                  "color": "transparent",
+                  "color": "red",
                   "value": null
-                }
-              ]
-            },
-            "unit": "short"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byFrameRefID",
-                "options": "A"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": " "
                 },
                 {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "red",
-                        "value": null
-                      },
-                      {
-                        "color": "green",
-                        "value": 1
-                      }
-                    ]
-                  }
+                  "color": "green",
+                  "value": 1
                 }
               ]
             },
-            {
-              "matcher": {
-                "id": "byFrameRefID",
-                "options": "B"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "/"
-                }
-              ]
-            }
-          ]
+            "unit": "none"
+          },
+          "overrides": []
         },
         "gridPos": {
           "h": 3,
@@ -1248,7 +1213,7 @@
             "fields": "",
             "values": false
           },
-          "textMode": "value_and_name",
+          "textMode": "value",
           "wideLayout": true
         },
         "pluginVersion": "12.4.3",
@@ -1269,7 +1234,8 @@
             "statistic": "Maximum",
             "period": "",
             "region": "default",
-            "refId": "A"
+            "refId": "A",
+            "hide": true
           },
           {
             "datasource": {
@@ -1287,7 +1253,25 @@
             "statistic": "Maximum",
             "period": "",
             "region": "default",
-            "refId": "B"
+            "refId": "B",
+            "hide": true
+          },
+          {
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "expression": "A + B/100",
+            "metricQueryType": 0,
+            "metricEditorMode": 1,
+            "namespace": "",
+            "metricName": "",
+            "dimensions": {},
+            "statistic": "",
+            "period": "",
+            "region": "default",
+            "refId": "e1",
+            "id": "e1"
           }
         ],
         "title": "Tasks",
@@ -1485,61 +1469,34 @@
             "color": {
               "mode": "thresholds"
             },
-            "decimals": 0,
-            "mappings": [],
+            "decimals": 2,
+            "mappings": [
+              {
+                "type": "regex",
+                "options": {
+                  "pattern": "^(\\d+)\\.0*(\\d+)$",
+                  "result": {
+                    "text": "$1 / $2"
+                  }
+                }
+              }
+            ],
             "thresholds": {
               "mode": "absolute",
               "steps": [
                 {
-                  "color": "transparent",
+                  "color": "red",
                   "value": null
-                }
-              ]
-            },
-            "unit": "short"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byFrameRefID",
-                "options": "A"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": " "
                 },
                 {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "red",
-                        "value": null
-                      },
-                      {
-                        "color": "green",
-                        "value": 1
-                      }
-                    ]
-                  }
+                  "color": "green",
+                  "value": 1
                 }
               ]
             },
-            {
-              "matcher": {
-                "id": "byFrameRefID",
-                "options": "B"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "/"
-                }
-              ]
-            }
-          ]
+            "unit": "none"
+          },
+          "overrides": []
         },
         "gridPos": {
           "h": 3,
@@ -1560,7 +1517,7 @@
             "fields": "",
             "values": false
           },
-          "textMode": "value_and_name",
+          "textMode": "value",
           "wideLayout": true
         },
         "pluginVersion": "12.4.3",
@@ -1581,7 +1538,8 @@
             "statistic": "Maximum",
             "period": "",
             "region": "default",
-            "refId": "A"
+            "refId": "A",
+            "hide": true
           },
           {
             "datasource": {
@@ -1599,7 +1557,25 @@
             "statistic": "Maximum",
             "period": "",
             "region": "default",
-            "refId": "B"
+            "refId": "B",
+            "hide": true
+          },
+          {
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "expression": "A + B/100",
+            "metricQueryType": 0,
+            "metricEditorMode": 1,
+            "namespace": "",
+            "metricName": "",
+            "dimensions": {},
+            "statistic": "",
+            "period": "",
+            "region": "default",
+            "refId": "e1",
+            "id": "e1"
           }
         ],
         "title": "Tasks",
@@ -1797,61 +1773,34 @@
             "color": {
               "mode": "thresholds"
             },
-            "decimals": 0,
-            "mappings": [],
+            "decimals": 2,
+            "mappings": [
+              {
+                "type": "regex",
+                "options": {
+                  "pattern": "^(\\d+)\\.0*(\\d+)$",
+                  "result": {
+                    "text": "$1 / $2"
+                  }
+                }
+              }
+            ],
             "thresholds": {
               "mode": "absolute",
               "steps": [
                 {
-                  "color": "transparent",
+                  "color": "red",
                   "value": null
-                }
-              ]
-            },
-            "unit": "short"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byFrameRefID",
-                "options": "A"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": " "
                 },
                 {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "red",
-                        "value": null
-                      },
-                      {
-                        "color": "green",
-                        "value": 1
-                      }
-                    ]
-                  }
+                  "color": "green",
+                  "value": 1
                 }
               ]
             },
-            {
-              "matcher": {
-                "id": "byFrameRefID",
-                "options": "B"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "/"
-                }
-              ]
-            }
-          ]
+            "unit": "none"
+          },
+          "overrides": []
         },
         "gridPos": {
           "h": 3,
@@ -1872,7 +1821,7 @@
             "fields": "",
             "values": false
           },
-          "textMode": "value_and_name",
+          "textMode": "value",
           "wideLayout": true
         },
         "pluginVersion": "12.4.3",
@@ -1893,7 +1842,8 @@
             "statistic": "Maximum",
             "period": "",
             "region": "default",
-            "refId": "A"
+            "refId": "A",
+            "hide": true
           },
           {
             "datasource": {
@@ -1911,7 +1861,25 @@
             "statistic": "Maximum",
             "period": "",
             "region": "default",
-            "refId": "B"
+            "refId": "B",
+            "hide": true
+          },
+          {
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "expression": "A + B/100",
+            "metricQueryType": 0,
+            "metricEditorMode": 1,
+            "namespace": "",
+            "metricName": "",
+            "dimensions": {},
+            "statistic": "",
+            "period": "",
+            "region": "default",
+            "refId": "e1",
+            "id": "e1"
           }
         ],
         "title": "Tasks",


### PR DESCRIPTION
## Summary

Follow-up to #4811. The two-tile stat layout used by the per-service Tasks panels was still unreliable after the h:3 fix: Grafana auto-flipped the orientation to vertical at that aspect, and the field-B threshold inherited the panel default (`transparent`), hiding the Need value entirely.

This change replaces the two-tile setup with a single math-expression display:

- Two CloudWatch queries (`A = RunningTaskCount`, `B = DesiredTaskCount`) are kept but hidden.
- A new math expression `e1 = A + B/100` encodes Run + Need as a single decimal value (e.g. Run=1, Need=4 → `1.04`).
- The stat panel renders `e1` with `decimals: 2` and a regex value mapping `^(\d+)\.0*(\d+)$` → `$1 / $2`, producing `1 / 4`, `4 / 4`, etc. inline.
- Thresholds: red when `< 1` (i.e. Run = 0), green otherwise. The "Run < Need" warning the previous setup tried to surface via threshold-on-A is lost, but absolute counts are now visible at a glance and `0 / N` shows red.

**Caveat:** the `B/100` encoding assumes `Desired < 100`. All four boxel services currently run with `Desired ≤ 8`, well under that bound.

## Test plan

- [ ] Push `overview.json` to staging Grafana via grafanactl.
- [ ] Confirm all four Tasks panels (Realm Server, Prerender, Prerender Mgr, Worker) render as `1 / 1`, `4 / 4`, `1 / 1`, `4 / 4` (or current counts) inline.
- [ ] Spot-check that the panel turns red when a service has zero running tasks (can verify via the threshold transition by temporarily setting one ECS service to `desired=0` if needed, or trust the threshold config in the JSON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)