### PR TITLE
observability: Concurrent Users list + Synapse panel polish

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -249,7 +249,7 @@
             "links": [
               {
                 "title": "Open Users dashboard",
-                "url": "/d/boxelusers0001",
+                "url": "/d/boxelusers0001?${__url_time_range}",
                 "targetBlank": false
               }
             ],
@@ -297,7 +297,7 @@
         "links": [
           {
             "title": "Open Users dashboard",
-            "url": "/d/boxelusers0001",
+            "url": "/d/boxelusers0001?${__url_time_range}",
             "targetBlank": false,
             "type": "link",
             "icon": "external link"
@@ -325,7 +325,7 @@
               "type": "loki",
               "uid": "loki"
             },
-            "expr": "count(count by (user) (count_over_time({service=\"synapse\"} |~ \"Processed request.*simplified_msc3575/sync\" | regexp `\\{(?P<user>@[^}]+:[^}]+)\\}` [5m]))) or vector(0)",
+            "expr": "count(count by (user) (count_over_time({service=\"synapse\"} |= \"Processed request\" |= \"simplified_msc3575/sync\" | regexp `\\{(?P<user>@[^}]+:[^}]+)\\}` [5m]))) or vector(0)",
             "queryType": "range",
             "legendFormat": "Concurrent Users",
             "refId": "A"
@@ -388,7 +388,7 @@
                   "value": [
                     {
                       "title": "Open in Users dashboard",
-                      "url": "/d/boxelusers0001?${__url_time_range}&var-matrix_user_id=${__value.text}",
+                      "url": "/d/boxelusers0001?${__url_time_range}&var-matrix_user_id=${__value.text:percentencode}",
                       "targetBlank": false
                     }
                   ]
@@ -429,7 +429,7 @@
               "type": "loki",
               "uid": "loki"
             },
-            "expr": "sum by (user) (count_over_time({service=\"synapse\"} |~ \"Processed request.*simplified_msc3575/sync\" | regexp `\\{(?P<user>@[^}]+:[^}]+)\\}` [5m]))",
+            "expr": "sum by (user) (count_over_time({service=\"synapse\"} |= \"Processed request\" |= \"simplified_msc3575/sync\" | regexp `\\{(?P<user>@[^}]+:[^}]+)\\}` [5m]))",
             "queryType": "instant",
             "legendFormat": "{{user}}",
             "refId": "A"

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -248,8 +248,8 @@
             "decimals": 0,
             "links": [
               {
-                "title": "Open Synapse dashboard",
-                "url": "/d/000000012",
+                "title": "Open Users dashboard",
+                "url": "/d/boxelusers0001",
                 "targetBlank": false
               }
             ],
@@ -288,7 +288,7 @@
           ]
         },
         "gridPos": {
-          "h": 8,
+          "h": 5,
           "w": 8,
           "x": 16,
           "y": 0
@@ -296,8 +296,8 @@
         "id": 30,
         "links": [
           {
-            "title": "Open Synapse dashboard",
-            "url": "/d/000000012",
+            "title": "Open Users dashboard",
+            "url": "/d/boxelusers0001",
             "targetBlank": false,
             "type": "link",
             "icon": "external link"
@@ -333,6 +333,126 @@
         ],
         "title": "Concurrent Users",
         "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "loki"
+        },
+        "description": "Matrix user IDs seen on the Synapse Sliding Sync endpoint within the last 5 minutes. Click a user to open the Users dashboard focused on them.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "left",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "filterable": true,
+              "inspect": false,
+              "minWidth": 120
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "transparent",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "user"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Matrix User"
+                },
+                {
+                  "id": "color",
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "#ff66c4"
+                  }
+                },
+                {
+                  "id": "links",
+                  "value": [
+                    {
+                      "title": "Open in Users dashboard",
+                      "url": "/d/boxelusers0001?${__url_time_range}&var-matrix_user_id=${__value.text}",
+                      "targetBlank": false
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 8,
+          "x": 16,
+          "y": 5
+        },
+        "id": 31,
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "fields": "",
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": false,
+          "sortBy": [
+            {
+              "desc": false,
+              "displayName": "Matrix User"
+            }
+          ]
+        },
+        "pluginVersion": "12.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "expr": "sum by (user) (count_over_time({service=\"synapse\"} |~ \"Processed request.*simplified_msc3575/sync\" | regexp `\\{(?P<user>@[^}]+:[^}]+)\\}` [5m]))",
+            "queryType": "instant",
+            "legendFormat": "{{user}}",
+            "refId": "A"
+          }
+        ],
+        "title": "",
+        "transformations": [
+          {
+            "id": "labelsToFields",
+            "options": {
+              "mode": "columns"
+            }
+          },
+          {
+            "id": "filterFieldsByName",
+            "options": {
+              "include": {
+                "pattern": "^user$"
+              }
+            }
+          }
+        ],
+        "type": "table"
       },
       {
         "datasource": {
@@ -2096,7 +2216,7 @@
           ]
         },
         "gridPos": {
-          "h": 4,
+          "h": 7,
           "w": 4,
           "x": 16,
           "y": 16
@@ -2112,6 +2232,10 @@
           "minVizHeight": 10,
           "maxVizHeight": 300,
           "sizing": "auto",
+          "text": {
+            "titleSize": 22,
+            "valueSize": 21
+          },
           "reduceOptions": {
             "calcs": [
               "lastNotNull"


### PR DESCRIPTION
## Summary

- **Concurrent Users panel** — split into two stacked panels: the existing big-number stat (with sparkline) on top, and a headerless list of Matrix user IDs in the rolling 5-minute window below. Each row is a data link to the Users dashboard with `var-matrix_user_id` pre-set, so clicking a user lands on that user's credit/permission view.
- **Retargeted links** — both Concurrent Users panel links now point at the Users dashboard instead of Synapse.
- **Synapse process bar gauge** (CPU / Mem) — stretched `h:4` → `h:7` to match the neighbouring Postgres DB stat and close the gap underneath it; shrank title / value font sizes (~25% off auto) so it sits proportionally with the rest of the bottom row.

## Test plan

- [ ] Apply locally with `cd packages/observability && ./scripts/apply.sh` and check the Overview dashboard top-right column shows a "Concurrent Users" stat with sparkline above a list of user IDs.
- [ ] Click a name in the list — it should open the Users dashboard with that Matrix user pre-selected in the `User` filter.
- [ ] Confirm the Synapse CPU/Mem panel in the bottom row aligns with Postgres DB on the right (no gap below) and the labels/values look proportional to the bargauges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)