### PR TITLE
CS-11106: per-PR preview deployments for grafana dashboards

### DIFF
--- a/.github/workflows/observability-diff.yml
+++ b/.github/workflows/observability-diff.yml
@@ -184,17 +184,43 @@ jobs:
             const diffBytes = Buffer.byteLength(diff, 'utf8');
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
-            let body;
+            // Find existing sticky comment. Paginate so we don't miss
+            // the marker on PRs with >100 comments (would otherwise
+            // create duplicates on every push).
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              }
+            );
+            const existing = comments.find(
+              (c) => c.body && c.body.startsWith(marker)
+            );
+
             if (!diff.trim()) {
-              body = [
-                marker,
-                '## Observability diff (vs staging)',
-                '',
-                'No dashboard / folder changes detected against the staging Grafana.',
-                '',
-                `_(Run: ${runUrl})_`,
-              ].join('\n');
-            } else if (diffBytes > maxBytes) {
+              // No drift between the PR's committed state and live staging.
+              // Don't post a "nothing changed" comment — but if a prior push
+              // left a sticky behind (the PR used to touch dashboards and
+              // now doesn't), delete it so the PR's comment stream matches
+              // its current state.
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                });
+                core.info(`Deleted stale sticky comment ${existing.id}`);
+              } else {
+                core.info('No diff vs staging — nothing to post.');
+              }
+              return;
+            }
+
+            let body;
+            if (diffBytes > maxBytes) {
               // Truncate by bytes, not characters. Walk back from a
               // character boundary so we don't slice mid-codepoint and
               // produce invalid UTF-8.
@@ -224,22 +250,6 @@ jobs:
                 `_(Run: ${runUrl})_`,
               ].join('\n');
             }
-
-            // Find existing sticky comment. Paginate so we don't miss
-            // the marker on PRs with >100 comments (would otherwise
-            // create duplicates on every push).
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                per_page: 100,
-              }
-            );
-            const existing = comments.find(
-              (c) => c.body && c.body.startsWith(marker)
-            );
 
             if (existing) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/observability-diff.yml
+++ b/.github/workflows/observability-diff.yml
@@ -83,13 +83,17 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch PR base ref
-        # Belt-and-suspenders: even with `fetch-depth: 0`, ensure the
-        # PR base ref is available as `origin/<base>` so diff.sh's
-        # `git rev-parse --verify` succeeds. Cheap on already-fetched
-        # history; idempotent if the ref is already up to date.
+        # Ensure the PR base ref is available as `origin/<base>` so
+        # diff.sh's `git rev-parse --verify` and `git diff <base>...HEAD`
+        # both succeed. NOTE: no `--depth=1` here. A shallow fetch makes
+        # origin/<base> an orphan with no parent history; when main has
+        # advanced past the PR's actual merge base (any non-trivial PR
+        # in flight long enough for main to move), `git diff <base>...HEAD`
+        # then fails with "no merge base". Unbounded fetch is cheap
+        # against an already-full repo (`fetch-depth: 0` on checkout).
         env:
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: git fetch --no-tags --depth=1 origin "${PR_BASE_REF}"
+        run: git fetch --no-tags origin "${PR_BASE_REF}"
 
       - name: Install grafanactl
         uses: ./.github/actions/install-grafanactl

--- a/.github/workflows/observability-preview-sweep.yml
+++ b/.github/workflows/observability-preview-sweep.yml
@@ -1,0 +1,148 @@
+name: Observability — preview sweep
+
+# Daily sweep that removes stale preview folders + dashboards from the
+# staging Grafana. Safety net for observability-preview.yml's cleanup-on-
+# close job: a missed `closed` webhook, a job that errored mid-delete, or a
+# preview pushed against a PR that was later deleted from GitHub all leave
+# orphan `pr<n>-*` resources behind. This workflow notices and cleans up.
+#
+# Decision rule per PR number (derived from the `pr<n>-` UID prefix):
+#   - PR is open                → keep
+#   - PR is closed/merged       → delete
+#   - PR doesn't exist on GitHub → delete (PR was deleted from repo state)
+#
+# CS-11106.
+
+on:
+  schedule:
+    # Daily at 06:23 UTC — chosen to avoid the top-of-hour rush. No
+    # particular significance to the minute; deliberately not on :00 so
+    # GHA's "scheduled workflows often run minutes late" behavior doesn't
+    # batch this with other on-the-hour crons.
+    - cron: "23 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  # The sweeper is idempotent, but running two at once would do redundant
+  # API calls against Grafana and GitHub. Serialize; don't cancel an
+  # in-flight run if the cron fires while a manual dispatch is still going.
+  group: observability-preview-sweep
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: us-east-1
+  AWS_ROLE_ARN: arn:aws:iam::680542703984:role/boxel-observability-apply
+  GRAFANACTL_VERSION: "0.1.10"
+
+jobs:
+  sweep:
+    name: Sweep stale previews from staging
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install grafanactl
+        uses: ./.github/actions/install-grafanactl
+        with:
+          version: ${{ env.GRAFANACTL_VERSION }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Source GRAFANA_TOKEN
+        run: |
+          GRAFANA_TOKEN="$(aws ssm get-parameter \
+            --name /staging/grafana/grafanactl_token \
+            --with-decryption \
+            --query 'Parameter.Value' \
+            --output text)"
+          echo "::add-mask::$GRAFANA_TOKEN"
+          echo "GRAFANA_TOKEN=$GRAFANA_TOKEN" >> "$GITHUB_ENV"
+
+      - name: Identify stale previews
+        id: identify
+        working-directory: packages/observability
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -eo pipefail
+          remote="$(mktemp -d)"
+          cfg="$(./scripts/render-config.sh staging)"
+          trap 'rm -rf "$remote"; rm -f "$cfg"' EXIT
+
+          grafanactl --config "$cfg" --context staging \
+            resources pull dashboards folders --path "$remote" >/dev/null
+
+          # Extract the set of unique PR numbers present in preview UIDs.
+          pr_numbers="$(find "$remote" -type f -name '*.json' \
+            -exec jq -r '.metadata.name // ""' {} \; \
+            | grep -E '^pr[0-9]+-' \
+            | sed -E 's/^pr([0-9]+)-.*/\1/' \
+            | sort -u)"
+
+          if [[ -z "$pr_numbers" ]]; then
+            echo "no preview resources present — nothing to sweep"
+            echo "stale_prs=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "found previews for PR(s): $(echo "$pr_numbers" | tr '\n' ' ')"
+
+          # For each PR number, ask GitHub whether it's still open. `gh pr view`
+          # returns nonzero when the PR doesn't exist; we treat that as
+          # "delete" (the PR was deleted from the repo). Open PRs are kept;
+          # everything else (closed, merged, missing) gets swept.
+          stale=""
+          while IFS= read -r pr; do
+            [[ -n "$pr" ]] || continue
+            if state="$(gh pr view "$pr" --repo "$REPO" --json state -q .state 2>/dev/null)"; then
+              if [[ "$state" == "OPEN" ]]; then
+                echo "  PR #${pr}: OPEN — keep"
+                continue
+              fi
+              echo "  PR #${pr}: ${state} — sweep"
+            else
+              echo "  PR #${pr}: not found — sweep"
+            fi
+            stale="${stale}${pr} "
+          done <<< "$pr_numbers"
+
+          echo "stale_prs=${stale}" >> "$GITHUB_OUTPUT"
+
+      - name: Sweep
+        if: steps.identify.outputs.stale_prs != ''
+        working-directory: packages/observability
+        env:
+          STALE_PRS: ${{ steps.identify.outputs.stale_prs }}
+        run: |
+          set -eo pipefail
+          for pr in $STALE_PRS; do
+            echo "::group::Cleanup PR #${pr}"
+            ./scripts/cleanup-preview.sh --pr "$pr" --env staging
+            echo "::endgroup::"
+          done
+
+      - name: Summary
+        if: always()
+        env:
+          STALE_PRS: ${{ steps.identify.outputs.stale_prs }}
+        run: |
+          {
+            echo "## Preview sweep"
+            echo ""
+            if [[ -z "${STALE_PRS:-}" ]]; then
+              echo "No stale previews."
+            else
+              echo "Swept previews for PR(s): \`${STALE_PRS}\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/observability-preview-sweep.yml
+++ b/.github/workflows/observability-preview-sweep.yml
@@ -25,6 +25,12 @@ on:
 permissions:
   contents: read
   id-token: write
+  # `gh pr view` calls in the sweep step need read access to the repo's
+  # pull requests. Without this, every PR-state lookup would return 403
+  # and the sweep would either delete previews for genuinely open PRs
+  # (legacy behavior) or — after the indeterminate-state guard below —
+  # abort the sweep entirely.
+  pull-requests: read
 
 concurrency:
   # The sweeper is idempotent, but running two at once would do redundant
@@ -84,9 +90,12 @@ jobs:
             resources pull dashboards folders --path "$remote" >/dev/null
 
           # Extract the set of unique PR numbers present in preview UIDs.
+          # `grep ... || true` because `set -eo pipefail` would otherwise
+          # abort the step when grep finds no matches — that's the legitimate
+          # "no previews live in staging" path, not an error.
           pr_numbers="$(find "$remote" -type f -name '*.json' \
             -exec jq -r '.metadata.name // ""' {} \; \
-            | grep -E '^pr[0-9]+-' \
+            | { grep -E '^pr[0-9]+-' || true; } \
             | sed -E 's/^pr([0-9]+)-.*/\1/' \
             | sort -u)"
 
@@ -98,23 +107,54 @@ jobs:
 
           echo "found previews for PR(s): $(echo "$pr_numbers" | tr '\n' ' ')"
 
-          # For each PR number, ask GitHub whether it's still open. `gh pr view`
-          # returns nonzero when the PR doesn't exist; we treat that as
-          # "delete" (the PR was deleted from the repo). Open PRs are kept;
-          # everything else (closed, merged, missing) gets swept.
+          # For each PR number, ask GitHub whether it's still open. Use
+          # `gh api` directly (rather than `gh pr view`) so we can
+          # distinguish a real 404 ("PR was deleted from the repo —
+          # safe to sweep") from any other failure ("transient API
+          # error / rate limit / auth glitch — DO NOT sweep, fail the
+          # step so a human can investigate"). Treating every nonzero
+          # exit as "PR doesn't exist → delete its preview" would let
+          # a GitHub outage wipe previews for legitimately open PRs.
           stale=""
           while IFS= read -r pr; do
             [[ -n "$pr" ]] || continue
-            if state="$(gh pr view "$pr" --repo "$REPO" --json state -q .state 2>/dev/null)"; then
-              if [[ "$state" == "OPEN" ]]; then
-                echo "  PR #${pr}: OPEN — keep"
-                continue
-              fi
-              echo "  PR #${pr}: ${state} — sweep"
+            api_out="$(mktemp)"
+            api_err="$(mktemp)"
+            if gh api "repos/${REPO}/pulls/${pr}" \
+                 --jq '.state' \
+                 > "$api_out" 2> "$api_err"; then
+              state="$(cat "$api_out")"
+              rm -f "$api_out" "$api_err"
+              case "$state" in
+                open)
+                  echo "  PR #${pr}: open — keep"
+                  ;;
+                closed)
+                  echo "  PR #${pr}: closed — sweep"
+                  stale="${stale}${pr} "
+                  ;;
+                *)
+                  echo "::error::PR #${pr}: unexpected state '${state}' — aborting sweep"
+                  exit 1
+                  ;;
+              esac
             else
-              echo "  PR #${pr}: not found — sweep"
+              # `gh api` writes the HTTP status in the error body for
+              # non-2xx responses. A 404 is the unambiguous "PR was
+              # deleted from the repo" signal; anything else (network,
+              # rate-limit, 5xx, 403) is indeterminate and we refuse
+              # to sweep on it.
+              err_body="$(cat "$api_err")"
+              rm -f "$api_out" "$api_err"
+              if grep -q 'HTTP 404' <<< "$err_body"; then
+                echo "  PR #${pr}: 404 — sweep (PR deleted from repo)"
+                stale="${stale}${pr} "
+              else
+                echo "::error::PR #${pr}: indeterminate gh-api failure — aborting sweep"
+                echo "::error::${err_body}"
+                exit 1
+              fi
             fi
-            stale="${stale}${pr} "
           done <<< "$pr_numbers"
 
           echo "stale_prs=${stale}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/observability-preview.yml
+++ b/.github/workflows/observability-preview.yml
@@ -61,9 +61,15 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch PR base ref
+        # Ensure origin/<base> is fully available — no `--depth=1`.
+        # A shallow base makes `git diff origin/<base>...HEAD` fail with
+        # "no merge base" whenever main has advanced past the PR's true
+        # merge base (i.e., any PR in flight long enough for a merge to
+        # land on main). Unbounded fetch is cheap against the full repo
+        # the checkout step already pulled (fetch-depth: 0).
         env:
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: git fetch --no-tags --depth=1 origin "${PR_BASE_REF}"
+        run: git fetch --no-tags origin "${PR_BASE_REF}"
 
       - name: Install grafanactl
         uses: ./.github/actions/install-grafanactl

--- a/.github/workflows/observability-preview.yml
+++ b/.github/workflows/observability-preview.yml
@@ -1,0 +1,308 @@
+name: Observability — PR preview
+
+# Spins up a per-PR preview of the dashboards a PR changes inside the staging
+# Grafana, under per-PR-prefixed UIDs (`pr<n>-*`) in a per-PR folder so the
+# preview coexists with the canonical staging copies without overwriting
+# them. On PR close the preview is torn down. A separate sweep workflow
+# (observability-preview-sweep.yml) is the safety net for closes the
+# preview-cleanup job missed.
+#
+# Scope: dashboards + folders only. Data sources, alert rules, and the
+# home-dashboard preference are file-provisioned at Grafana startup and
+# can't be previewed per-PR — the existing observability-diff.yml comment
+# already surfaces their changes. CS-11106.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - "packages/observability/**"
+      - ".github/workflows/observability-preview.yml"
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  # Serialize per-PR so a force-push after an open doesn't race the previous
+  # push, but allow different PRs to run in parallel. Don't cancel in-flight —
+  # we never want to leave the preview in a half-pushed state.
+  group: observability-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: us-east-1
+  # Reuses the apply role from cardstack/infra#665 (same role
+  # observability-apply-staging.yml uses). Permissions cover every SSM path
+  # below — see that workflow's header for the up-to-date list.
+  AWS_ROLE_ARN: arn:aws:iam::680542703984:role/boxel-observability-apply
+  GRAFANACTL_VERSION: "0.1.10"
+  PREVIEW_MARKER: "<!-- observability-preview -->"
+  STAGING_GRAFANA_BASE_URL: "https://dashboard-staging.stack.cards"
+
+jobs:
+  preview-apply:
+    name: Apply preview to staging
+    # Fork-PR guard: this job assumes AWS and pushes to staging Grafana, so
+    # it must not run on PRs whose code we don't trust. Same pattern as
+    # observability-diff.yml and observability-apply-staging.yml.
+    if: >-
+      github.event.action != 'closed'
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # render-preview.sh runs `git diff origin/<base>...HEAD` to detect
+          # changed dashboards, so we need full history to reach the merge-base
+          # (same constraint as observability-diff.yml).
+          fetch-depth: 0
+
+      - name: Fetch PR base ref
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: git fetch --no-tags --depth=1 origin "${PR_BASE_REF}"
+
+      - name: Install grafanactl
+        uses: ./.github/actions/install-grafanactl
+        with:
+          version: ${{ env.GRAFANACTL_VERSION }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Source preview-time secrets from SSM
+        # Subset of what observability-apply-staging.yml fetches. The preview
+        # only touches dashboards + folders, so we don't need the LOKI_URL /
+        # BOXEL_DB_* / WORKER_LOG_* set — those are read by apply-datasources
+        # / apply-alerting, which apply-preview.sh never invokes.
+        run: |
+          GRAFANA_TOKEN="$(aws ssm get-parameter \
+            --name /staging/grafana/grafanactl_token \
+            --with-decryption \
+            --query 'Parameter.Value' \
+            --output text)"
+          echo "::add-mask::$GRAFANA_TOKEN"
+          echo "GRAFANA_TOKEN=$GRAFANA_TOKEN" >> "$GITHUB_ENV"
+
+          REALM_SERVER_URL="$(aws ssm get-parameter \
+            --name /staging/boxel-grafana/realm_server_url \
+            --query 'Parameter.Value' \
+            --output text)"
+          echo "REALM_SERVER_URL=$REALM_SERVER_URL" >> "$GITHUB_ENV"
+
+          GRAFANA_SECRET="$(aws ssm get-parameter \
+            --name /staging/boxel/GRAFANA_SECRET \
+            --with-decryption \
+            --query 'Parameter.Value' \
+            --output text)"
+          echo "::add-mask::$GRAFANA_SECRET"
+          echo "GRAFANA_SECRET=$GRAFANA_SECRET" >> "$GITHUB_ENV"
+
+      - name: Apply preview
+        id: apply
+        working-directory: packages/observability
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -eo pipefail
+          OUT_FILE="$(mktemp)"
+          ./scripts/apply-preview.sh \
+            --pr "$PR_NUMBER" \
+            --base-ref "origin/${PR_BASE_REF}" \
+            --env staging \
+            > "$OUT_FILE"
+          echo "out_file=$OUT_FILE" >> "$GITHUB_OUTPUT"
+          echo "::group::Preview summary"
+          cat "$OUT_FILE"
+          echo "::endgroup::"
+
+      - name: Post sticky PR comment
+        # Pinned to SHA (matches observability-diff.yml's reasoning):
+        # pull-requests: write + AWS role = non-trivial supply-chain exposure.
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          OUT_FILE: ${{ steps.apply.outputs.out_file }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = process.env.PREVIEW_MARKER;
+            const grafanaBase = process.env.STAGING_GRAFANA_BASE_URL;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const raw = fs.readFileSync(process.env.OUT_FILE, 'utf8').trim();
+
+            let body;
+            if (!raw) {
+              // render-preview.sh exits 0 with empty stdout when no
+              // dashboards changed. Render an explicit "no preview"
+              // comment so reviewers don't wonder if the workflow ran.
+              body = [
+                marker,
+                '## Grafana preview',
+                '',
+                'No dashboard changes detected — nothing to preview.',
+                '',
+                'Data-source / alert-rule / home-dashboard changes are file-provisioned at',
+                'Grafana startup and can\'t be previewed per-PR; see the diff comment for those.',
+                '',
+                `_(Run: ${runUrl})_`,
+              ].join('\n');
+            } else {
+              const folders = [];
+              const dashboards = [];
+              for (const line of raw.split('\n')) {
+                // Format: `<KIND>:<uid>:<title>` (title may contain `:`).
+                const m = line.match(/^(FOLDER|DASHBOARD):([^:]+):(.*)$/);
+                if (!m) continue;
+                const [, kind, uid, title] = m;
+                (kind === 'FOLDER' ? folders : dashboards).push({ uid, title });
+              }
+
+              const folderLines = folders.map(f =>
+                `- **Folder:** [${f.title}](${grafanaBase}/dashboards/f/${f.uid}/)`,
+              );
+              const dashboardLines = dashboards.map(d =>
+                `- [${d.title}](${grafanaBase}/d/${d.uid}/)`,
+              );
+
+              body = [
+                marker,
+                '## Grafana preview',
+                '',
+                `Preview deployed for **${dashboards.length} dashboard${dashboards.length === 1 ? '' : 's'}** in the staging Grafana.`,
+                'Cross-dashboard drill-throughs still point at the canonical staging dashboards.',
+                '',
+                ...folderLines,
+                '',
+                '**Dashboards:**',
+                ...dashboardLines,
+                '',
+                'Preview is torn down automatically when this PR is closed or merged.',
+                '',
+                `_(Run: ${runUrl})_`,
+              ].join('\n');
+            }
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              },
+            );
+            const existing = comments.find(
+              c => c.body && c.body.startsWith(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated sticky comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+              core.info('Created sticky comment');
+            }
+
+  preview-cleanup:
+    name: Cleanup preview from staging
+    # Cleanup runs on the `closed` action (covers both merge and close-
+    # without-merge). Same fork-PR guard — cleanup hits staging.
+    if: >-
+      github.event.action == 'closed'
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install grafanactl
+        uses: ./.github/actions/install-grafanactl
+        with:
+          version: ${{ env.GRAFANACTL_VERSION }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Source GRAFANA_TOKEN
+        # Cleanup doesn't need any of the URL/secret substitution values —
+        # it lists live state and deletes by selector. Only the grafanactl
+        # token matters.
+        run: |
+          GRAFANA_TOKEN="$(aws ssm get-parameter \
+            --name /staging/grafana/grafanactl_token \
+            --with-decryption \
+            --query 'Parameter.Value' \
+            --output text)"
+          echo "::add-mask::$GRAFANA_TOKEN"
+          echo "GRAFANA_TOKEN=$GRAFANA_TOKEN" >> "$GITHUB_ENV"
+
+      - name: Cleanup preview
+        working-directory: packages/observability
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: ./scripts/cleanup-preview.sh --pr "$PR_NUMBER" --env staging
+
+      - name: Update sticky PR comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const marker = process.env.PREVIEW_MARKER;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const body = [
+              marker,
+              '## Grafana preview',
+              '',
+              'Preview cleaned up after PR close.',
+              '',
+              `_(Run: ${runUrl})_`,
+            ].join('\n');
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              },
+            );
+            const existing = comments.find(
+              c => c.body && c.body.startsWith(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated sticky comment ${existing.id}`);
+            } else {
+              // No prior preview comment (PR never had a preview) — nothing
+              // to update. Don't create a comment just to say "cleaned up
+              // nothing". Surface it in the run log instead.
+              core.info('No preview comment to update — skipping.');
+            }

--- a/.github/workflows/observability-preview.yml
+++ b/.github/workflows/observability-preview.yml
@@ -119,9 +119,27 @@ jobs:
             --env staging \
             > "$OUT_FILE"
           echo "out_file=$OUT_FILE" >> "$GITHUB_OUTPUT"
+          if [[ -s "$OUT_FILE" ]]; then
+            echo "empty=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "empty=true" >> "$GITHUB_OUTPUT"
+          fi
           echo "::group::Preview summary"
           cat "$OUT_FILE"
           echo "::endgroup::"
+
+      - name: Cleanup stale preview (no changes left)
+        # When the current head of the PR has no dashboard changes vs base,
+        # apply-preview emits empty output and pushes nothing. But a prior
+        # push to the same PR may have already applied a preview that's
+        # still live in staging — revert/rebase scenarios. Run cleanup so
+        # the PR's staging footprint matches its current head; otherwise
+        # the daily sweep wouldn't catch this until PR close.
+        if: steps.apply.outputs.empty == 'true'
+        working-directory: packages/observability
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: ./scripts/cleanup-preview.sh --pr "$PR_NUMBER" --env staging
 
       - name: Post sticky PR comment
         # Pinned to SHA (matches observability-diff.yml's reasoning):
@@ -138,58 +156,8 @@ jobs:
 
             const raw = fs.readFileSync(process.env.OUT_FILE, 'utf8').trim();
 
-            let body;
-            if (!raw) {
-              // render-preview.sh exits 0 with empty stdout when no
-              // dashboards changed. Render an explicit "no preview"
-              // comment so reviewers don't wonder if the workflow ran.
-              body = [
-                marker,
-                '## Grafana preview',
-                '',
-                'No dashboard changes detected — nothing to preview.',
-                '',
-                'Data-source / alert-rule / home-dashboard changes are file-provisioned at',
-                'Grafana startup and can\'t be previewed per-PR; see the diff comment for those.',
-                '',
-                `_(Run: ${runUrl})_`,
-              ].join('\n');
-            } else {
-              const folders = [];
-              const dashboards = [];
-              for (const line of raw.split('\n')) {
-                // Format: `<KIND>:<uid>:<title>` (title may contain `:`).
-                const m = line.match(/^(FOLDER|DASHBOARD):([^:]+):(.*)$/);
-                if (!m) continue;
-                const [, kind, uid, title] = m;
-                (kind === 'FOLDER' ? folders : dashboards).push({ uid, title });
-              }
-
-              const folderLines = folders.map(f =>
-                `- **Folder:** [${f.title}](${grafanaBase}/dashboards/f/${f.uid}/)`,
-              );
-              const dashboardLines = dashboards.map(d =>
-                `- [${d.title}](${grafanaBase}/d/${d.uid}/)`,
-              );
-
-              body = [
-                marker,
-                '## Grafana preview',
-                '',
-                `Preview deployed for **${dashboards.length} dashboard${dashboards.length === 1 ? '' : 's'}** in the staging Grafana.`,
-                'Cross-dashboard drill-throughs still point at the canonical staging dashboards.',
-                '',
-                ...folderLines,
-                '',
-                '**Dashboards:**',
-                ...dashboardLines,
-                '',
-                'Preview is torn down automatically when this PR is closed or merged.',
-                '',
-                `_(Run: ${runUrl})_`,
-              ].join('\n');
-            }
-
+            // Find any prior preview sticky on this PR; we either update or
+            // delete it based on whether there's anything to preview now.
             const comments = await github.paginate(
               github.rest.issues.listComments,
               {
@@ -202,6 +170,59 @@ jobs:
             const existing = comments.find(
               c => c.body && c.body.startsWith(marker),
             );
+
+            if (!raw) {
+              // No dashboards changed at this HEAD. Don't post a "nothing
+              // to see" comment — if a prior push left a sticky behind,
+              // delete it so the PR's comment stream matches its current
+              // state. (Stale preview *resources* from a prior push are
+              // handled by the "Cleanup stale preview" step above.)
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                });
+                core.info(`Deleted stale sticky comment ${existing.id}`);
+              } else {
+                core.info('No dashboard changes — nothing to post.');
+              }
+              return;
+            }
+
+            const folders = [];
+            const dashboards = [];
+            for (const line of raw.split('\n')) {
+              // Format: `<KIND>:<uid>:<title>` (title may contain `:`).
+              const m = line.match(/^(FOLDER|DASHBOARD):([^:]+):(.*)$/);
+              if (!m) continue;
+              const [, kind, uid, title] = m;
+              (kind === 'FOLDER' ? folders : dashboards).push({ uid, title });
+            }
+
+            const folderLines = folders.map(f =>
+              `- **Folder:** [${f.title}](${grafanaBase}/dashboards/f/${f.uid}/)`,
+            );
+            const dashboardLines = dashboards.map(d =>
+              `- [${d.title}](${grafanaBase}/d/${d.uid}/)`,
+            );
+
+            const body = [
+              marker,
+              '## Grafana preview',
+              '',
+              `Preview deployed for **${dashboards.length} dashboard${dashboards.length === 1 ? '' : 's'}** in the staging Grafana.`,
+              'Cross-dashboard drill-throughs still point at the canonical staging dashboards.',
+              '',
+              ...folderLines,
+              '',
+              '**Dashboards:**',
+              ...dashboardLines,
+              '',
+              'Preview is torn down automatically when this PR is closed or merged.',
+              '',
+              `_(Run: ${runUrl})_`,
+            ].join('\n');
 
             if (existing) {
               await github.rest.issues.updateComment({
@@ -263,21 +284,15 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: ./scripts/cleanup-preview.sh --pr "$PR_NUMBER" --env staging
 
-      - name: Update sticky PR comment
+      - name: Delete sticky PR comment
+        # After cleanup, there's nothing left to point at — delete the
+        # sticky entirely rather than leaving a "preview cleaned up"
+        # gravestone. Matches the apply-time policy of not posting a
+        # comment when there's nothing to show.
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const marker = process.env.PREVIEW_MARKER;
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-
-            const body = [
-              marker,
-              '## Grafana preview',
-              '',
-              'Preview cleaned up after PR close.',
-              '',
-              `_(Run: ${runUrl})_`,
-            ].join('\n');
 
             const comments = await github.paginate(
               github.rest.issues.listComments,
@@ -293,16 +308,12 @@ jobs:
             );
 
             if (existing) {
-              await github.rest.issues.updateComment({
+              await github.rest.issues.deleteComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: existing.id,
-                body,
               });
-              core.info(`Updated sticky comment ${existing.id}`);
+              core.info(`Deleted sticky comment ${existing.id}`);
             } else {
-              // No prior preview comment (PR never had a preview) — nothing
-              // to update. Don't create a comment just to say "cleaned up
-              // nothing". Surface it in the run log instead.
-              core.info('No preview comment to update — skipping.');
+              core.info('No preview comment to delete — skipping.');
             }

--- a/packages/observability/scripts/apply-preview.sh
+++ b/packages/observability/scripts/apply-preview.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# apply-preview.sh — Push the per-PR preview tree to a Grafana environment.
+#
+# Wraps render-preview.sh (changed-dashboard filtering + UID rewriting) and
+# `grafanactl resources push`. Used by the observability-preview.yml workflow
+# on PR open/synchronize/reopen.
+#
+# Usage:
+#   ./scripts/apply-preview.sh --pr <n> --base-ref <ref> [--env staging|local|production]
+#
+# Output (stdout) is a structured summary suitable for the workflow's
+# comment-posting step:
+#
+#   FOLDER:<uid>:<title>
+#   DASHBOARD:<uid>:<title>
+#   DASHBOARD:<uid>:<title>
+#   ...
+#
+# Exits 0 with no stdout when the PR didn't change any dashboards (caller
+# treats this as "no preview to apply" and updates the sticky comment
+# accordingly).
+#
+# Prereqs (staging/production): AWS creds with ssm:GetParameter on
+# /<env>/grafana/grafanactl_token plus the same SSM paths apply.sh reads
+# (REALM_SERVER_URL, GRAFANA_SECRET). Local mode uses admin/admin against
+# the docker-compose Grafana — no AWS creds needed.
+set -eo pipefail
+
+usage_error() { echo "error: $1" >&2; exit 2; }
+
+pr_number=""
+base_ref=""
+env_name="staging"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      [[ $# -ge 2 && "$2" != --* ]] || usage_error "missing value for --pr"
+      pr_number="$2"; shift 2 ;;
+    --pr=*)
+      pr_number="${1#--pr=}"; shift ;;
+    --base-ref)
+      [[ $# -ge 2 && "$2" != --* ]] || usage_error "missing value for --base-ref"
+      base_ref="$2"; shift 2 ;;
+    --base-ref=*)
+      base_ref="${1#--base-ref=}"; shift ;;
+    --env)
+      [[ $# -ge 2 && "$2" != --* ]] || usage_error "missing value for --env"
+      env_name="$2"; shift 2 ;;
+    --env=*)
+      env_name="${1#--env=}"; shift ;;
+    *)
+      usage_error "unknown option: $1" ;;
+  esac
+done
+
+[[ -n "$pr_number" ]] || usage_error "--pr <n> is required"
+[[ -n "$base_ref" ]] || usage_error "--base-ref <ref> is required"
+
+cd "$(dirname "$0")/.."
+
+# shellcheck source=./grafanactl-env.sh
+source ./scripts/grafanactl-env.sh "$env_name"
+
+command -v jq >/dev/null || { echo "error: missing dependency: jq" >&2; exit 1; }
+command -v grafanactl >/dev/null \
+  || { echo "error: missing dependency: grafanactl" >&2; exit 1; }
+
+# Render to a tempdir. render-preview.sh emits the tempdir path on stdout
+# (and exits 0 with empty stdout if there are no changed dashboards).
+rendered="$(./scripts/render-preview.sh \
+  --pr "$pr_number" --base-ref "$base_ref" --env "$env_name")"
+
+if [[ -z "$rendered" ]]; then
+  # No-op: signal the caller via empty stdout. Sticky-comment step will
+  # render the "no dashboard changes" body.
+  exit 0
+fi
+trap 'rm -rf "$rendered"' EXIT
+
+cfg="$(./scripts/render-config.sh "$env_name")"
+trap 'rm -rf "$rendered"; rm -f "$cfg"' EXIT
+
+# Push the preview tree. `resources push` is upsert-only — re-running on
+# the same PR (e.g. after a force-push) overwrites the previous preview
+# UIDs in-place, no cleanup needed between pushes.
+#
+# Suppress stdout so the workflow comment captures only our structured
+# summary below; stderr still surfaces in the run log on failure.
+grafanactl \
+  --config "$cfg" \
+  --context "$env_name" \
+  resources push \
+  --path "$rendered" \
+  >/dev/null
+
+# Emit the structured summary. Order: folder first, then dashboards (by UID
+# for stability — the workflow comment renders them as a bullet list).
+# Use a single-pass jq invocation per resource type to avoid a per-file
+# subshell on the typical hot path.
+while IFS= read -r -d '' f; do
+  jq -r '"FOLDER:" + .metadata.name + ":" + (.spec.title // "")' "$f"
+done < <(find "$rendered/folders" -type f -name '*.json' -print0 2>/dev/null)
+
+while IFS= read -r -d '' f; do
+  jq -r '"DASHBOARD:" + .metadata.name + ":" + (.spec.title // "")' "$f"
+done < <(find "$rendered/dashboards" -type f -name '*.json' -print0 2>/dev/null | sort -z)

--- a/packages/observability/scripts/apply-preview.sh
+++ b/packages/observability/scripts/apply-preview.sh
@@ -81,9 +81,20 @@ trap 'rm -rf "$rendered"' EXIT
 cfg="$(./scripts/render-config.sh "$env_name")"
 trap 'rm -rf "$rendered"; rm -f "$cfg"' EXIT
 
-# Push the preview tree. `resources push` is upsert-only — re-running on
-# the same PR (e.g. after a force-push) overwrites the previous preview
-# UIDs in-place, no cleanup needed between pushes.
+# Clean up any pr<n>-* resources from a previous apply BEFORE pushing the
+# new set. `resources push` is upsert-only — it won't delete a dashboard
+# that was in the prior render but isn't in this one. So if a PR push
+# reduces the changed-dashboard set (e.g. a later commit reverts one of
+# two earlier dashboard edits), the dropped dashboard would otherwise
+# linger in staging until PR close. cleanup-preview.sh is idempotent on
+# an empty preview state — first-time applies pay the cost of one extra
+# `grafanactl resources pull` for a no-op delete.
+./scripts/cleanup-preview.sh --pr "$pr_number" --env "$env_name" >&2
+
+# Push the preview tree. `resources push` is upsert-only, which combined
+# with the cleanup above gives us full state replacement: the only
+# pr<n>-* resources in Grafana after this step are exactly those in the
+# rendered tree.
 #
 # Suppress stdout so the workflow comment captures only our structured
 # summary below; stderr still surfaces in the run log on failure.

--- a/packages/observability/scripts/cleanup-preview.sh
+++ b/packages/observability/scripts/cleanup-preview.sh
@@ -3,8 +3,12 @@
 #
 # Pulls the live state of `dashboards` and `folders` from the target Grafana,
 # filters to resources whose UID begins with `pr<n>-` (the prefix render-
-# preview.sh stamps), and deletes them in a single `grafanactl resources
-# delete` call.
+# preview.sh stamps), and deletes them in two `grafanactl resources delete`
+# passes: dashboards first, then the folder containing them. The two-pass
+# split is mandatory — Grafana refuses to delete a non-empty folder
+# ("400 BadRequest: Folder cannot be deleted: folder is not empty"), and
+# a single delete invocation processes selectors in argv order with no
+# dependency awareness, so we'd hit that error every time.
 #
 # Usage:
 #   ./scripts/cleanup-preview.sh --pr <n> [--env staging|local|production]
@@ -13,9 +17,13 @@
 # 0 (the `on-error=ignore` setting below makes grafanactl tolerate missing
 # selectors so we don't have to re-read live state and diff).
 #
-# This script is what the observability-preview.yml workflow calls on
-# pull_request `closed`. It is also what the observability-preview-sweep
-# workflow calls for PRs the sweeper has decided are stale.
+# Callers:
+#   - apply-preview.sh runs this before every push, so a PR that shrinks
+#     its changed-dashboard set (e.g. reverts one of two prior edits)
+#     gets the old preview resources removed before the new tree lands.
+#   - observability-preview.yml runs this on pull_request `closed`.
+#   - observability-preview-sweep.yml runs this for PRs the daily sweep
+#     has decided are stale.
 set -eo pipefail
 
 usage_error() { echo "error: $1" >&2; exit 2; }

--- a/packages/observability/scripts/cleanup-preview.sh
+++ b/packages/observability/scripts/cleanup-preview.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# cleanup-preview.sh — Delete a PR's preview dashboards + folder from Grafana.
+#
+# Pulls the live state of `dashboards` and `folders` from the target Grafana,
+# filters to resources whose UID begins with `pr<n>-` (the prefix render-
+# preview.sh stamps), and deletes them in a single `grafanactl resources
+# delete` call.
+#
+# Usage:
+#   ./scripts/cleanup-preview.sh --pr <n> [--env staging|local|production]
+#
+# Designed to be safe to re-run: deleting an already-absent resource exits
+# 0 (the `on-error=ignore` setting below makes grafanactl tolerate missing
+# selectors so we don't have to re-read live state and diff).
+#
+# This script is what the observability-preview.yml workflow calls on
+# pull_request `closed`. It is also what the observability-preview-sweep
+# workflow calls for PRs the sweeper has decided are stale.
+set -eo pipefail
+
+usage_error() { echo "error: $1" >&2; exit 2; }
+
+pr_number=""
+env_name="staging"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      [[ $# -ge 2 && "$2" != --* ]] || usage_error "missing value for --pr"
+      pr_number="$2"; shift 2 ;;
+    --pr=*)
+      pr_number="${1#--pr=}"; shift ;;
+    --env)
+      [[ $# -ge 2 && "$2" != --* ]] || usage_error "missing value for --env"
+      env_name="$2"; shift 2 ;;
+    --env=*)
+      env_name="${1#--env=}"; shift ;;
+    *)
+      usage_error "unknown option: $1" ;;
+  esac
+done
+
+[[ -n "$pr_number" ]] || usage_error "--pr <n> is required"
+[[ "$pr_number" =~ ^[0-9]+$ ]] || usage_error "--pr must be a positive integer"
+
+cd "$(dirname "$0")/.."
+
+# shellcheck source=./grafanactl-env.sh
+source ./scripts/grafanactl-env.sh "$env_name"
+
+command -v jq >/dev/null || { echo "error: missing dependency: jq" >&2; exit 1; }
+command -v grafanactl >/dev/null \
+  || { echo "error: missing dependency: grafanactl" >&2; exit 1; }
+
+cfg="$(./scripts/render-config.sh "$env_name")"
+remote="$(mktemp -d -t grafanactl-cleanup.XXXXXX)"
+trap 'rm -f "$cfg"; rm -rf "$remote"' EXIT
+
+# Pull live dashboards + folders. Same explicit-kind argument as diff.sh —
+# avoids the spurious 403/404 warnings grafanactl emits when scanning every
+# resource kind.
+grafanactl \
+  --config "$cfg" \
+  --context "$env_name" \
+  resources pull \
+  dashboards folders \
+  --path "$remote" \
+  >/dev/null
+
+# Collect selectors for resources whose UID starts with `pr<n>-`, split by
+# kind. The pulled tree groups manifests under `<remote>/Dashboard/<uid>.json`
+# and `<remote>/Folder/<uid>.json` (kind in PascalCase), but we read kind from
+# inside the file so layout changes in grafanactl wouldn't break this.
+#
+# We split by kind so dashboards can be deleted BEFORE the folder they live
+# in: Grafana refuses to delete a non-empty folder ("400 BadRequest: Folder
+# cannot be deleted: folder is not empty"), and a single
+# `grafanactl resources delete dashboards/... folders/...` call processes
+# selectors in argv order without dependency awareness.
+dashboard_selectors=()
+folder_selectors=()
+while IFS= read -r -d '' f; do
+  uid="$(jq -r '.metadata.name // ""' "$f")"
+  [[ -n "$uid" ]] || continue
+  [[ "$uid" == "pr${pr_number}-"* ]] || continue
+  # grafanactl's resource-selector form is `<plural-lowercase-kind>/<uid>`.
+  # Map Dashboard → dashboards, Folder → folders.
+  case "$(jq -r '.kind // ""' "$f")" in
+    Dashboard) dashboard_selectors+=("dashboards/${uid}") ;;
+    Folder)    folder_selectors+=("folders/${uid}") ;;
+    *)         echo "warning: unknown kind in $f — skipping" >&2 ;;
+  esac
+done < <(find "$remote" -type f -name '*.json' -print0)
+
+total=$(( ${#dashboard_selectors[@]} + ${#folder_selectors[@]} ))
+if [[ "$total" -eq 0 ]]; then
+  echo "no preview resources found for PR #${pr_number}" >&2
+  exit 0
+fi
+
+echo "deleting ${total} preview resource(s) for PR #${pr_number}:" >&2
+printf '  %s\n' "${dashboard_selectors[@]}" "${folder_selectors[@]}" >&2
+
+# Two passes: dashboards first, folders second. --on-error=ignore makes
+# re-runs safe — if a sibling resource was already deleted manually
+# between the pull and this delete, we don't want the rest of the
+# cleanup to abort.
+if [[ ${#dashboard_selectors[@]} -gt 0 ]]; then
+  grafanactl \
+    --config "$cfg" \
+    --context "$env_name" \
+    resources delete \
+    --on-error ignore \
+    "${dashboard_selectors[@]}"
+fi
+
+if [[ ${#folder_selectors[@]} -gt 0 ]]; then
+  grafanactl \
+    --config "$cfg" \
+    --context "$env_name" \
+    resources delete \
+    --on-error ignore \
+    "${folder_selectors[@]}"
+fi

--- a/packages/observability/scripts/render-preview.sh
+++ b/packages/observability/scripts/render-preview.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# render-preview.sh — Render a per-PR preview tree for staging Grafana.
+#
+# Output: prints a tempdir path on stdout. The tree contains only the
+# dashboards the PR changed (vs --base-ref) plus the folder(s) they live in,
+# with `metadata.name` (UID), `spec.title`, and each dashboard's
+# `metadata.annotations["grafana.app/folder"]` rewritten so the resources
+# can coexist with the canonical staging copies. Push or delete the result
+# with `grafanactl resources push|delete --path <out>`.
+#
+# When the PR doesn't change any dashboards, exits 0 with no stdout.
+#
+# Usage:
+#   ./scripts/render-preview.sh --pr <n> --base-ref <ref> [--env <name>]
+#
+# --env defaults to staging and only affects the apply-style template
+# substitutions (REALM_SERVER_URL, GRAFANA_SECRET, __ENV__) — the preview
+# rewrites are env-independent.
+#
+# Scope: dashboards + folders only. Data sources, alert rules, and the home-
+# dashboard preference are file-provisioned at Grafana startup and can't be
+# previewed per-PR; the existing observability-diff.yml comment already
+# surfaces their changes.
+#
+# Cross-dashboard drill-through links inside the dashboard JSON (`/d/<uid>/`
+# strings) are intentionally NOT rewritten — they stay pointing at the
+# canonical staging dashboards (CS-11106 design call). UID references inside
+# `datasource.uid` fields are data-source UIDs, not dashboard UIDs, and are
+# also left alone.
+set -eo pipefail
+
+usage_error() { echo "error: $1" >&2; exit 2; }
+
+pr_number=""
+base_ref=""
+env_name="staging"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      [[ $# -ge 2 && "$2" != --* ]] || usage_error "missing value for --pr"
+      pr_number="$2"; shift 2 ;;
+    --pr=*)
+      pr_number="${1#--pr=}"; shift ;;
+    --base-ref)
+      [[ $# -ge 2 && "$2" != --* ]] || usage_error "missing value for --base-ref"
+      base_ref="$2"; shift 2 ;;
+    --base-ref=*)
+      base_ref="${1#--base-ref=}"; shift ;;
+    --env)
+      [[ $# -ge 2 && "$2" != --* ]] || usage_error "missing value for --env"
+      env_name="$2"; shift 2 ;;
+    --env=*)
+      env_name="${1#--env=}"; shift ;;
+    *)
+      usage_error "unknown option: $1" ;;
+  esac
+done
+
+[[ -n "$pr_number" ]] || usage_error "--pr <n> is required"
+[[ -n "$base_ref" ]] || usage_error "--base-ref <ref> is required"
+[[ "$pr_number" =~ ^[0-9]+$ ]] || usage_error "--pr must be a positive integer"
+
+command -v jq >/dev/null || { echo "error: missing dependency: jq" >&2; exit 1; }
+
+# Validate base ref up front — mirrors diff.sh's check so a missing /
+# unfetched ref surfaces with actionable guidance instead of a noisy
+# git error under set -e.
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "error: --base-ref=$base_ref does not resolve to a commit." \
+       "In CI, ensure the workflow does \`git fetch origin <base-ref>\` (or" \
+       "\`actions/checkout\` with \`fetch-depth: 0\`)." >&2
+  exit 1
+fi
+
+cd "$(dirname "$0")/.."
+
+# Identify PR-changed dashboard files. `git -C <repo-root>` keeps the
+# pathspec repo-rooted regardless of CWD (same pitfall called out in diff.sh).
+# --diff-filter=ACMRT excludes deletions: `push` is upsert-only, so a deleted
+# dashboard simply doesn't appear in the preview tree. Folder-only changes
+# don't produce a preview either — the changed dashboards are what reviewers
+# need to see live, and we only create preview folders for dashboards that
+# land in them.
+repo_root="$(git rev-parse --show-toplevel)"
+changed_paths="$(git -C "$repo_root" diff --name-only --diff-filter=ACMRT \
+  "${base_ref}...HEAD" \
+  -- packages/observability/grafanactl/resources/dashboards/)"
+
+if [[ -z "$changed_paths" ]]; then
+  # No dashboard changes — nothing to preview. Empty stdout signals
+  # "skip" to the caller.
+  exit 0
+fi
+
+# Per-env substitution defaults mirror apply.sh exactly so the rendered
+# preview matches what `apply.sh --env <env>` would push.
+case "$env_name" in
+  local)
+    realm_server_url="${REALM_SERVER_URL:-http://localhost:4201/}"
+    if [[ -n "${GRAFANA_SECRET:-}" ]]; then
+      grafana_secret="$GRAFANA_SECRET"
+    else
+      grafana_secret="shhh! it's a secret"
+    fi
+    ;;
+  staging | production)
+    [[ -n "${REALM_SERVER_URL:-}" ]] \
+      || { echo "error: REALM_SERVER_URL not set; required for --env=$env_name (CI fetches it from /${env_name}/boxel-grafana/realm_server_url)" >&2; exit 1; }
+    [[ -n "${GRAFANA_SECRET:-}" ]] \
+      || { echo "error: GRAFANA_SECRET not set; required for --env=$env_name" >&2; exit 1; }
+    realm_server_url="$REALM_SERVER_URL"
+    grafana_secret="$GRAFANA_SECRET"
+    ;;
+  *)
+    usage_error "unknown env: $env_name (expected local|staging|production)" ;;
+esac
+
+rendered="$(mktemp -d -t grafanactl-preview.XXXXXX)"
+# Intentionally NOT trapping rm on $rendered — the caller (apply-preview.sh,
+# tests) consumes the path from stdout. Caller is responsible for cleanup.
+cp -R ./grafanactl/resources/. "$rendered/"
+
+# Step 1 — apply.sh-style template substitutions on every dashboard. Run
+# before the preview rewrites so the changed-set walk below sees the
+# substituted forms (matters in case any of the substituted fields ever
+# overlap with the preview-rewrite jq paths in the future).
+while IFS= read -r -d '' f; do
+  jq --arg url "$realm_server_url" --arg secret "$grafana_secret" --arg envname "$env_name" '
+    walk(
+      if type == "object"
+         and .name? == "realm_server"
+         and .type? == "constant"
+         and .query? == "__REALM_SERVER_URL__"
+      then
+        .query = $url
+        | (if .current then .current.value = $url | .current.text = $url else . end)
+      elif type == "object"
+         and .name? == "grafana_secret"
+         and .type? == "constant"
+         and .query? == "REPLACE_AT_APPLY_TIME"
+      then
+        .query = $secret
+        | (if .current then .current.value = $secret | .current.text = $secret else . end)
+      elif type == "object"
+         and .name? == "env"
+         and .type? == "constant"
+         and .query? == "__ENV__"
+      then
+        .query = $envname
+        | (if .current then .current.value = $envname | .current.text = $envname else . end)
+      else . end
+    )
+  ' "$f" > "$f.tmp"
+  mv "$f.tmp" "$f"
+done < <(find "$rendered/dashboards" -type f -name '*.json' -print0)
+
+# Build a set of changed dashboard paths relative to grafanactl/resources/,
+# stored as a newline-delimited string for bash 3.2 compatibility (same
+# pattern diff.sh uses for filter_paths). Each entry looks like
+# `dashboards/boxel-status/overview.json`.
+changed_set=""
+while IFS= read -r line; do
+  rel="${line#packages/observability/grafanactl/resources/}"
+  changed_set="${changed_set}${rel}"$'\n'
+done <<< "$changed_paths"
+
+# Grafana UIDs are at most 40 chars and must be alphanumeric / `-` / `_`.
+# `pr<digits>-` adds 3 chars for a PR < 10, up to ~8 for a 5-digit PR.
+# Truncate from the right (the original-uid tail) if combined exceeds 40.
+# This is deterministic — same orig uid + same pr number = same new uid —
+# so dashboard→folder pointers stay aligned even after truncation.
+prefix_uid() {
+  local pr="$1" orig="$2" combined
+  combined="pr${pr}-${orig}"
+  if [[ ${#combined} -gt 40 ]]; then
+    combined="${combined:0:40}"
+  fi
+  echo "$combined"
+}
+
+# Step 2 — filter dashboards to the changed set, rewriting each kept file's
+# UID + folder pointer + title. Collect referenced folder UIDs so we know
+# which folder files to keep & rewrite in step 3.
+referenced_folders=""
+while IFS= read -r -d '' f; do
+  rel="${f#"$rendered/"}"
+  if [[ "$changed_set" != *"${rel}"$'\n'* ]]; then
+    rm "$f"
+    continue
+  fi
+
+  orig_folder="$(jq -r '(.metadata.annotations // {})["grafana.app/folder"] // ""' "$f")"
+  orig_uid="$(jq -r '.metadata.name // ""' "$f")"
+  if [[ -z "$orig_uid" ]]; then
+    echo "error: $f has no metadata.name" >&2
+    exit 1
+  fi
+  new_uid="$(prefix_uid "$pr_number" "$orig_uid")"
+  new_folder=""
+  if [[ -n "$orig_folder" ]]; then
+    new_folder="$(prefix_uid "$pr_number" "$orig_folder")"
+    referenced_folders="${referenced_folders}${orig_folder}"$'\n'
+  fi
+
+  jq --arg uid "$new_uid" \
+     --arg folder "$new_folder" \
+     --arg prefix "[PR #${pr_number}] " '
+    .metadata.name = $uid
+    | (if $folder != "" and (.metadata.annotations // {})["grafana.app/folder"]
+       then .metadata.annotations["grafana.app/folder"] = $folder
+       else . end)
+    | (if .spec.title then .spec.title = ($prefix + .spec.title) else . end)
+  ' "$f" > "$f.tmp"
+  mv "$f.tmp" "$f"
+done < <(find "$rendered/dashboards" -type f -name '*.json' -print0)
+
+# Prune empty subdirectories under dashboards/ left by the filter above so
+# `grafanactl resources push` doesn't recurse into stale empty trees.
+find "$rendered/dashboards" -type d -empty -delete 2>/dev/null || true
+
+# Step 3 — folders: keep only those referenced by a kept dashboard, rewrite
+# UID + title. Drop the rest (so the push doesn't create unused per-PR
+# folders for unchanged areas).
+while IFS= read -r -d '' f; do
+  orig_uid="$(jq -r '.metadata.name // ""' "$f")"
+  if [[ -z "$orig_uid" ]] || [[ "$referenced_folders" != *"${orig_uid}"$'\n'* ]]; then
+    rm "$f"
+    continue
+  fi
+  new_uid="$(prefix_uid "$pr_number" "$orig_uid")"
+  jq --arg uid "$new_uid" --arg prefix "Preview – PR #${pr_number}: " '
+    .metadata.name = $uid
+    | (if .spec.title then .spec.title = ($prefix + .spec.title) else . end)
+  ' "$f" > "$f.tmp"
+  mv "$f.tmp" "$f"
+done < <(find "$rendered/folders" -type f -name '*.json' -print0)
+
+# Final sanity: if everything got pruned (shouldn't happen given the
+# changed_paths early-exit above, but the changed file could be e.g. a
+# README under dashboards/ that's not a JSON manifest), bail cleanly so
+# the caller can short-circuit instead of pushing an empty tree.
+if [[ -z "$(find "$rendered/dashboards" -type f -name '*.json' 2>/dev/null)" ]]; then
+  rm -rf "$rendered"
+  exit 0
+fi
+
+echo "$rendered"


### PR DESCRIPTION
## Summary

Per-PR preview pipeline for Grafana dashboards. When a PR modifies dashboards under `packages/observability/grafanactl/resources/`, the workflow pushes the changed dashboards into staging Grafana under `pr<n>-*` UIDs inside a dedicated `Preview – PR #<n>: …` folder, then posts a sticky PR comment with direct links. Cleanup runs on PR close, plus a daily sweep as a safety net for missed close events.

Scope is **dashboards + folders only** — data sources, alert rules, and the home-dashboard preference are file-provisioned at Grafana startup and can't be previewed per-PR. The existing `observability-diff.yml` comment continues to cover those.

Cross-dashboard drill-through links inside dashboard JSON (`/d/<uid>/`) are intentionally **not** rewritten — they stay pointing at the canonical staging copies. The preview answers "does my changed dashboard look right?" not "does the whole graph navigate correctly?". The latter is rare and high-cost; design call made up-front.

## Implementation

- `packages/observability/scripts/render-preview.sh` — copies `grafanactl/resources/` to a tempdir, runs the same apply.sh template substitutions, then drops dashboards not in the PR's diff and rewrites `metadata.name` / `metadata.annotations["grafana.app/folder"]` / `spec.title` on the kept files. Folder files for unused folders are pruned.
- `packages/observability/scripts/apply-preview.sh` — wraps render + `grafanactl resources push`; emits a structured `FOLDER:<uid>:<title>` / `DASHBOARD:<uid>:<title>` summary for the workflow's comment-posting step.
- `packages/observability/scripts/cleanup-preview.sh` — pulls live state, filters to `pr<n>-` prefixed UIDs, deletes them in two passes (**dashboards first, folders second** — Grafana refuses to delete a non-empty folder).
- `.github/workflows/observability-preview.yml` — `pull_request: [opened, synchronize, reopened, closed]`. Reuses the existing `boxel-observability-apply` IAM role and SSM secret paths (`/staging/grafana/grafanactl_token`, `/staging/boxel-grafana/realm_server_url`, `/staging/boxel/GRAFANA_SECRET`). No new infra grants needed.
- `.github/workflows/observability-preview-sweep.yml` — daily cron. Pulls live state, parses PR numbers from `pr<n>-` UIDs, queries `gh pr view` for each, deletes resources whose PR is closed/merged/missing.

UID length: `pr<n>-<orig>` is truncated to Grafana's 40-char max. Longest existing canonical UID is 27 chars; even a 5-digit PR fits comfortably.

## Verified locally against docker-compose Grafana

- Apply canonical dashboards → 14 dashboards in the `Boxel Status` folder.
- Apply preview for PR #8888 → preview dashboard + folder coexist (15 total dashboards, no UID collisions).
- Re-apply (force-push simulation) → upserts in place, no duplication.
- Cleanup → both resources gone, canonical state untouched.
- Cleanup re-run on already-clean state → idempotent.

Live testing surfaced one bug: a single `grafanactl resources delete dashboards/... folders/...` call processes selectors in argv order with no dependency awareness, so the folder delete fires before its dashboard and Grafana rejects it with `400 BadRequest: Folder cannot be deleted: folder is not empty`. Fixed by splitting the deletion into two passes.

## Test plan

- [ ] On merge: this PR itself is a no-op for the preview workflow (it doesn't change any dashboard JSON), so the preview comment should render the "No dashboard changes detected" body.
- [ ] First follow-up PR that modifies a dashboard: verify the preview comment appears with a working link, click through to the preview folder in staging Grafana, confirm the preview dashboard renders with PR-specific data.
- [ ] Close that follow-up PR: verify the sticky comment updates to "Preview cleaned up" and the preview resources are gone from staging Grafana.
- [ ] Daily sweep: confirm a sweep run with no stale previews logs "No stale previews" and exits cleanly. (Manually triggerable via `gh workflow run "Observability — preview sweep"`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)