### PR TITLE
CS-10009 PR 4: migrate root tests/ to explicit fixture

### DIFF
--- a/packages/realm-server/scripts/measure-test-file.sh
+++ b/packages/realm-server/scripts/measure-test-file.sh
@@ -72,7 +72,7 @@ for i in $(seq 1 "$RUNS"); do
       PGPORT=55436 \
       STRIPE_WEBHOOK_SECRET=stripe-webhook-secret \
       STRIPE_API_KEY=stripe-api-key \
-      MATRIX_REGISTRATION_SHARED_SECRET=fake \
+      MATRIX_REGISTRATION_SHARED_SECRET="${MATRIX_REGISTRATION_SHARED_SECRET:-fake}" \
       TEST_FILES="$TEST_FILES_ARG" \
     "$QUNIT" --require ts-node/register/transpile-only tests/index.ts \
     >/dev/null 2>"$timing"

--- a/packages/realm-server/tests/atomic-endpoints-test.ts
+++ b/packages/realm-server/tests/atomic-endpoints-test.ts
@@ -122,6 +122,7 @@ module(basename(__filename), function () {
 
       module('writes', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           permissions: {
             '*': ['read', 'write'],
           },
@@ -893,6 +894,7 @@ module(basename(__filename), function () {
       });
       module('error handling', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           permissions: {
             '*': ['read', 'write'],
           },
@@ -1115,6 +1117,7 @@ module(basename(__filename), function () {
       });
       module('validation', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           permissions: {
             '*': ['read', 'write'],
           },

--- a/packages/realm-server/tests/boxel-domain-availability-test.ts
+++ b/packages/realm-server/tests/boxel-domain-availability-test.ts
@@ -8,6 +8,7 @@ import {
   insertUser,
   runTestRealmServer,
   createVirtualNetwork,
+  fixtureDir,
   matrixURL,
   closeServer,
 } from './helpers';
@@ -41,7 +42,7 @@ module(basename(__filename), function () {
         dbAdapter = _dbAdapter;
         let testRealmDir = join(dir.name, 'realm_server_5', 'test');
         ensureDirSync(testRealmDir);
-        copySync(join(__dirname, 'cards'), testRealmDir);
+        copySync(fixtureDir('simple'), testRealmDir);
 
         testRealmServer = (
           await runTestRealmServer({

--- a/packages/realm-server/tests/card-dependencies-endpoint-test.ts
+++ b/packages/realm-server/tests/card-dependencies-endpoint-test.ts
@@ -30,7 +30,7 @@ module(basename(__filename), function () {
     module('card dependencies GET request', function (_hooks) {
       module('public readable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
-          fixture: 'simple',
+          fixture: 'realistic',
           permissions: {
             '*': ['read'],
           },
@@ -101,7 +101,7 @@ module(basename(__filename), function () {
 
       module('permissioned realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
-          fixture: 'simple',
+          fixture: 'realistic',
           permissions: {
             john: ['read'],
             '@node-test_realm:localhost': ['read', 'realm-owner'],

--- a/packages/realm-server/tests/card-dependencies-endpoint-test.ts
+++ b/packages/realm-server/tests/card-dependencies-endpoint-test.ts
@@ -30,6 +30,7 @@ module(basename(__filename), function () {
     module('card dependencies GET request', function (_hooks) {
       module('public readable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           permissions: {
             '*': ['read'],
           },
@@ -100,6 +101,7 @@ module(basename(__filename), function () {
 
       module('permissioned realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           permissions: {
             john: ['read'],
             '@node-test_realm:localhost': ['read', 'realm-owner'],

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -140,7 +140,7 @@ module(basename(__filename), function () {
     module('card GET request', function (_hooks) {
       module('public readable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
-          fixture: 'simple',
+          fixture: 'realistic',
           realmURL,
           permissions: {
             '*': ['read'],
@@ -953,7 +953,7 @@ module(basename(__filename), function () {
 
       module('published realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
-          fixture: 'simple',
+          fixture: 'realistic',
           realmURL,
           permissions: {
             '*': ['read'],
@@ -1039,7 +1039,7 @@ module(basename(__filename), function () {
       // using public writable realm to make it easy for test setup for the error tests
       module('public writable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
-          fixture: 'simple',
+          fixture: 'realistic',
           realmURL,
           permissions: {
             '*': ['read', 'write'],
@@ -1233,7 +1233,7 @@ module(basename(__filename), function () {
     module('card POST request', function (_hooks) {
       module('public writable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
-          fixture: 'simple',
+          fixture: 'realistic',
           realmURL,
           permissions: {
             '*': ['read', 'write'],
@@ -2325,7 +2325,7 @@ module(basename(__filename), function () {
     module('card PATCH request', function (_hooks) {
       module('public writable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
-          fixture: 'simple',
+          fixture: 'realistic',
           realmURL,
           permissions: {
             '*': ['read', 'write'],

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -140,6 +140,7 @@ module(basename(__filename), function () {
     module('card GET request', function (_hooks) {
       module('public readable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             '*': ['read'],
@@ -952,6 +953,7 @@ module(basename(__filename), function () {
 
       module('published realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             '*': ['read'],
@@ -1037,6 +1039,7 @@ module(basename(__filename), function () {
       // using public writable realm to make it easy for test setup for the error tests
       module('public writable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             '*': ['read', 'write'],
@@ -1113,6 +1116,7 @@ module(basename(__filename), function () {
 
       module('permissioned realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             john: ['read'],
@@ -1229,6 +1233,7 @@ module(basename(__filename), function () {
     module('card POST request', function (_hooks) {
       module('public writable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             '*': ['read', 'write'],
@@ -2240,6 +2245,7 @@ module(basename(__filename), function () {
 
       module('permissioned realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             john: ['read', 'write'],
@@ -2319,6 +2325,7 @@ module(basename(__filename), function () {
     module('card PATCH request', function (_hooks) {
       module('public writable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             '*': ['read', 'write'],
@@ -3973,6 +3980,7 @@ module(basename(__filename), function () {
 
       module('public writable realm with size limit', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             '*': ['read', 'write'],
@@ -4022,6 +4030,7 @@ module(basename(__filename), function () {
 
       module('permissioned realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             john: ['read', 'write'],
@@ -4094,6 +4103,7 @@ module(basename(__filename), function () {
     module('card DELETE request', function (_hooks) {
       module('public writable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             '*': ['read', 'write'],
@@ -4206,6 +4216,7 @@ module(basename(__filename), function () {
 
       module('permissioned realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             john: ['read', 'write'],

--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -19,6 +19,7 @@ import {
   setupMatrixRoom,
   createJWT,
   cardInfo,
+  fixtureDir,
   type RealmRequest,
   withRealmPath,
 } from './helpers';
@@ -72,6 +73,7 @@ module(basename(__filename), function () {
     module('card source GET request', function (_hooks) {
       module('public readable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             '*': ['read'],
@@ -288,7 +290,7 @@ module(basename(__filename), function () {
           );
           assert.strictEqual(
             readFileSync(
-              join(__dirname, '../tests/cards', 'person-with-error.gts'),
+              join(fixtureDir('realistic'), 'person-with-error.gts'),
               {
                 encoding: 'utf8',
               },
@@ -365,6 +367,7 @@ module(basename(__filename), function () {
 
       module('permissioned realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             john: ['read'],
@@ -416,6 +419,7 @@ module(basename(__filename), function () {
     module('card source HEAD request', function (_hooks) {
       module('public readable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             '*': ['read'],
@@ -491,6 +495,7 @@ module(basename(__filename), function () {
     module('card-source DELETE request', function (_hooks) {
       module('public writable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             '*': ['read', 'write'],
@@ -565,6 +570,7 @@ module(basename(__filename), function () {
 
       module('permissioned realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             john: ['read', 'write'],
@@ -608,6 +614,7 @@ module(basename(__filename), function () {
     module('card-source POST request', function (_hooks) {
       module('public writable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             '*': ['read', 'write'],
@@ -1015,6 +1022,7 @@ module(basename(__filename), function () {
 
       module('public writable realm with size limit', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             '*': ['read', 'write'],
@@ -1051,6 +1059,7 @@ module(basename(__filename), function () {
 
       module('permissioned realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             john: ['read', 'write'],
@@ -1129,6 +1138,7 @@ module(basename(__filename), function () {
     module('binary file POST request', function (_hooks) {
       module('public writable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             '*': ['read', 'write'],
@@ -1421,6 +1431,7 @@ module(basename(__filename), function () {
         'public writable realm with size limit for binary',
         function (hooks) {
           setupPermissionedRealmCached(hooks, {
+            fixture: 'simple',
             realmURL,
             permissions: {
               '*': ['read', 'write'],
@@ -1449,6 +1460,7 @@ module(basename(__filename), function () {
 
       module('permissioned realm for binary', function (hooks) {
         setupPermissionedRealmCached(hooks, {
+          fixture: 'simple',
           realmURL,
           permissions: {
             john: ['read', 'write'],

--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -73,7 +73,7 @@ module(basename(__filename), function () {
     module('card source GET request', function (_hooks) {
       module('public readable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
-          fixture: 'simple',
+          fixture: 'realistic',
           realmURL,
           permissions: {
             '*': ['read'],
@@ -495,7 +495,7 @@ module(basename(__filename), function () {
     module('card-source DELETE request', function (_hooks) {
       module('public writable realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
-          fixture: 'simple',
+          fixture: 'realistic',
           realmURL,
           permissions: {
             '*': ['read', 'write'],
@@ -570,7 +570,7 @@ module(basename(__filename), function () {
 
       module('permissioned realm', function (hooks) {
         setupPermissionedRealmCached(hooks, {
-          fixture: 'simple',
+          fixture: 'realistic',
           realmURL,
           permissions: {
             john: ['read', 'write'],

--- a/packages/realm-server/tests/claim-boxel-domain-test.ts
+++ b/packages/realm-server/tests/claim-boxel-domain-test.ts
@@ -8,6 +8,7 @@ import {
   insertUser,
   runTestRealmServer,
   createVirtualNetwork,
+  fixtureDir,
   matrixURL,
   closeServer,
   realmSecretSeed,
@@ -41,7 +42,7 @@ module(basename(__filename), function () {
         dbAdapter = _dbAdapter;
         let testRealmDir = join(dir.name, 'realm_server_5', 'test');
         ensureDirSync(testRealmDir);
-        copySync(join(__dirname, 'cards'), testRealmDir);
+        copySync(fixtureDir('simple'), testRealmDir);
 
         testRealmServer = (
           await runTestRealmServer({

--- a/packages/realm-server/tests/delete-boxel-claimed-domain-test.ts
+++ b/packages/realm-server/tests/delete-boxel-claimed-domain-test.ts
@@ -13,6 +13,7 @@ import {
   insertUser,
   runTestRealmServer,
   createVirtualNetwork,
+  fixtureDir,
   matrixURL,
   closeServer,
 } from './helpers';
@@ -47,7 +48,7 @@ module(basename(__filename), function () {
         dbAdapter = _dbAdapter;
         let testRealmDir = join(dir.name, 'realm_server_5', 'test');
         ensureDirSync(testRealmDir);
-        copySync(join(__dirname, 'cards'), testRealmDir);
+        copySync(fixtureDir('simple'), testRealmDir);
 
         testRealmServer = (
           await runTestRealmServer({

--- a/packages/realm-server/tests/get-boxel-claimed-domain-test.ts
+++ b/packages/realm-server/tests/get-boxel-claimed-domain-test.ts
@@ -8,6 +8,7 @@ import {
   insertUser,
   runTestRealmServer,
   createVirtualNetwork,
+  fixtureDir,
   matrixURL,
   closeServer,
   realmSecretSeed,
@@ -41,7 +42,7 @@ module(basename(__filename), function () {
         dbAdapter = _dbAdapter;
         let testRealmDir = join(dir.name, 'realm_server_5', 'test');
         ensureDirSync(testRealmDir);
-        copySync(join(__dirname, 'cards'), testRealmDir);
+        copySync(fixtureDir('simple'), testRealmDir);
 
         testRealmServer = (
           await runTestRealmServer({

--- a/packages/realm-server/tests/module-cache-race-test.ts
+++ b/packages/realm-server/tests/module-cache-race-test.ts
@@ -48,6 +48,7 @@ module(basename(__filename), function () {
       }
 
       setupPermissionedRealmCached(hooks, {
+        fixture: 'blank',
         realmURL,
         permissions: {
           '*': ['read', 'write'],
@@ -298,6 +299,7 @@ module(basename(__filename), function () {
     }
 
     setupPermissionedRealmCached(hooks, {
+      fixture: 'blank',
       realmURL,
       permissions: {
         '*': ['read', 'write'],

--- a/packages/realm-server/tests/openrouter-passthrough-test.ts
+++ b/packages/realm-server/tests/openrouter-passthrough-test.ts
@@ -10,6 +10,7 @@ import {
   setupDB,
   runTestRealmServer,
   closeServer,
+  fixtureDir,
   insertUser,
   insertPlan,
   realmSecretSeed,
@@ -41,7 +42,7 @@ module(basename(__filename), function () {
 
       hooks.beforeEach(async function () {
         dir = dirSync();
-        copySync(join(__dirname, 'cards'), dir.name);
+        copySync(fixtureDir('simple'), dir.name);
       });
 
       async function startRealmServer(
@@ -73,7 +74,7 @@ module(basename(__filename), function () {
           runner = _runner;
           testRealmDir = join(dir.name, 'realm_server_2', 'test');
           ensureDirSync(testRealmDir);
-          copySync(join(__dirname, 'cards'), testRealmDir);
+          copySync(fixtureDir('simple'), testRealmDir);
 
           // Whitelist OpenRouter chat completions so the passthrough handler
           // can resolve a destination config + credit strategy.

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -27,6 +27,7 @@ import {
   runTestRealmServer,
   closeServer,
   createVirtualNetwork,
+  fixtureDir,
   realmSecretSeed,
   matrixURL,
   waitUntil,
@@ -53,6 +54,7 @@ module(basename(__filename), function () {
     let dir: DirResult;
 
     setupPermissionedRealmCached(hooks, {
+      fixture: 'simple',
       permissions: {
         '*': ['read', 'write'],
       },
@@ -61,7 +63,7 @@ module(basename(__filename), function () {
 
     hooks.beforeEach(async function () {
       dir = dirSync();
-      copySync(join(__dirname, 'cards'), dir.name);
+      copySync(fixtureDir('simple'), dir.name);
     });
 
     async function startRealmServer(
@@ -102,7 +104,7 @@ module(basename(__filename), function () {
         runner = _runner;
         testRealmDir = join(dir.name, 'realm_server_3', 'test');
         ensureDirSync(testRealmDir);
-        copySync(join(__dirname, 'cards'), testRealmDir);
+        copySync(fixtureDir('simple'), testRealmDir);
         await startRealmServer(dbAdapter, publisher, runner);
       },
       afterEach: async () => {

--- a/packages/realm-server/tests/realm-auth-test.ts
+++ b/packages/realm-server/tests/realm-auth-test.ts
@@ -21,6 +21,7 @@ module(basename(__filename), function () {
     const matrixUserId = '@firsttimer:localhost';
 
     setupPermissionedRealmCached(hooks, {
+      fixture: 'blank',
       permissions: {
         '*': ['read'],
         [matrixUserId]: ['read', 'write'],

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -30,6 +30,7 @@ import {
   setupDB,
   setupMatrixRoom,
   createRealm,
+  fixtureDir,
   realmServerTestMatrix,
   realmServerSecretSeed,
   realmSecretSeed,
@@ -115,6 +116,7 @@ module(basename(__filename), function () {
     }
 
     setupPermissionedRealmCached(hooks, {
+      fixture: 'simple',
       permissions: {
         '*': ['read', 'write'],
         user: ['read', 'write', 'realm-owner'],
@@ -158,7 +160,7 @@ module(basename(__filename), function () {
         runner = _runner;
         testRealmDir = join(dir.name, 'realm_server_2', 'test');
         ensureDirSync(testRealmDir);
-        copySync(join(__dirname, 'cards'), testRealmDir);
+        copySync(fixtureDir('simple'), testRealmDir);
         await startRealmServer(dbAdapter2, publisher, runner);
       },
       afterEach: async () => {
@@ -1655,6 +1657,7 @@ module(basename(__filename), function () {
     let request: SuperTest<Test>;
 
     setupPermissionedRealmCached(hooks, {
+      fixture: 'simple',
       permissions: { '*': ['read'] },
       onRealmSetup(args) {
         request = args.request;
@@ -2049,13 +2052,15 @@ module(basename(__filename), function () {
     let virtualNetwork = createVirtualNetwork();
     const basePath = resolve(join(__dirname, '..', '..', 'base'));
     const demoFileSystem: Record<string, string | LooseSingleCardDocument> = {
-      '.realm.json': readJSONSync(join(__dirname, 'cards', '.realm.json')),
-      'realm.json': readJSONSync(join(__dirname, 'cards', 'realm.json')),
+      '.realm.json': readJSONSync(join(fixtureDir('realistic'), '.realm.json')),
+      'realm.json': readJSONSync(join(fixtureDir('realistic'), 'realm.json')),
       'person.gts': readFileSync(
-        join(__dirname, 'cards', 'person.gts'),
+        join(fixtureDir('realistic'), 'person.gts'),
         'utf8',
       ),
-      'person-1.json': readJSONSync(join(__dirname, 'cards', 'person-1.json')),
+      'person-1.json': readJSONSync(
+        join(fixtureDir('realistic'), 'person-1.json'),
+      ),
     };
 
     hooks.beforeEach(async function () {
@@ -2170,6 +2175,7 @@ module(basename(__filename), function () {
     let request: SuperTest<Test>;
 
     setupPermissionedRealmCached(hooks, {
+      fixture: 'simple',
       permissions: { '*': ['read'] },
       realmURL: new URL('http://127.0.0.1:4446/demo/'),
       onRealmSetup(args) {

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -116,7 +116,7 @@ module(basename(__filename), function () {
     }
 
     setupPermissionedRealmCached(hooks, {
-      fixture: 'simple',
+      fixture: 'realistic',
       permissions: {
         '*': ['read', 'write'],
         user: ['read', 'write', 'realm-owner'],
@@ -1657,7 +1657,7 @@ module(basename(__filename), function () {
     let request: SuperTest<Test>;
 
     setupPermissionedRealmCached(hooks, {
-      fixture: 'simple',
+      fixture: 'realistic',
       permissions: { '*': ['read'] },
       onRealmSetup(args) {
         request = args.request;

--- a/packages/realm-server/tests/request-forward-test.ts
+++ b/packages/realm-server/tests/request-forward-test.ts
@@ -11,6 +11,7 @@ import {
   runTestRealmServer,
   closeServer,
   createJWT,
+  fixtureDir,
   insertUser,
   insertPlan,
   realmSecretSeed,
@@ -40,7 +41,7 @@ module(basename(__filename), function () {
 
     hooks.beforeEach(async function () {
       dir = dirSync();
-      copySync(join(__dirname, 'cards'), dir.name);
+      copySync(fixtureDir('simple'), dir.name);
     });
 
     async function startRealmServer(
@@ -73,7 +74,7 @@ module(basename(__filename), function () {
         runner = _runner;
         testRealmDir = join(dir.name, 'realm_server_2', 'test');
         ensureDirSync(testRealmDir);
-        copySync(join(__dirname, 'cards'), testRealmDir);
+        copySync(fixtureDir('simple'), testRealmDir);
 
         // Set up allowed proxy destinations in database BEFORE starting server
         await dbAdapter.execute(

--- a/packages/realm-server/tests/scripts/start-test-pg.sh
+++ b/packages/realm-server/tests/scripts/start-test-pg.sh
@@ -15,7 +15,7 @@ start_container() {
   docker run -d \
     --name "$TEST_PG_CONTAINER" \
     -p "127.0.0.1:${TEST_PG_PORT}:5432" \
-    --tmpfs /var/lib/postgresql/data:rw \
+    --tmpfs "/var/lib/postgresql/data:rw,size=${TEST_PG_TMPFS_SIZE:-4g}" \
     -e POSTGRES_HOST_AUTH_METHOD=trust \
     -v "${TEST_PG_SEED_TAR}:/seed/pgdata.tar:ro" \
     -v "${SCRIPT_DIR}/boot_preseeded.sh:/usr/local/bin/pg-seeded-tmpfs-entrypoint.sh:ro" \

--- a/packages/realm-server/tests/scripts/start-test-pg.sh
+++ b/packages/realm-server/tests/scripts/start-test-pg.sh
@@ -15,7 +15,7 @@ start_container() {
   docker run -d \
     --name "$TEST_PG_CONTAINER" \
     -p "127.0.0.1:${TEST_PG_PORT}:5432" \
-    --tmpfs "/var/lib/postgresql/data:rw,size=${TEST_PG_TMPFS_SIZE:-4g}" \
+    --tmpfs /var/lib/postgresql/data:rw \
     -e POSTGRES_HOST_AUTH_METHOD=trust \
     -v "${TEST_PG_SEED_TAR}:/seed/pgdata.tar:ro" \
     -v "${SCRIPT_DIR}/boot_preseeded.sh:/usr/local/bin/pg-seeded-tmpfs-entrypoint.sh:ro" \

--- a/packages/realm-server/tests/server-endpoints/authentication-test.ts
+++ b/packages/realm-server/tests/server-endpoints/authentication-test.ts
@@ -31,7 +31,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
     }
 
     setupPermissionedRealmCached(hooks, {
-      fileSystem: {},
+      fixture: 'blank',
       permissions: {
         '@test_realm:localhost': ['read', 'realm-owner'],
       },

--- a/packages/realm-server/tests/server-endpoints/helpers.ts
+++ b/packages/realm-server/tests/server-endpoints/helpers.ts
@@ -9,7 +9,11 @@ import type {
 import type { Server } from 'http';
 import type { PgAdapter } from '@cardstack/postgres';
 import type { RealmServer } from '../../server';
-import { setupPermissionedRealmCached, testPort } from '../helpers';
+import {
+  setupPermissionedRealmCached,
+  testPort,
+  type RealmFixtureName,
+} from '../helpers';
 import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 
 export const testRealmURL = new URL(`http://127.0.0.1:${testPort(4445)}/test/`);
@@ -34,7 +38,7 @@ type ServerEndpointsTestOptions = {
   // content out of the testRealm and want the lightest possible
   // template build. Tests that DO read the kitchen sink (e.g.
   // screenshot-card referencing Person/fadhlan) pass `'realistic'`.
-  fixture?: 'blank' | 'simple' | 'realistic';
+  fixture?: RealmFixtureName;
 };
 
 export function setupServerEndpointsTest(

--- a/packages/realm-server/tests/server-endpoints/helpers.ts
+++ b/packages/realm-server/tests/server-endpoints/helpers.ts
@@ -27,7 +27,20 @@ export type ServerEndpointsTestContext = {
   virtualNetwork: VirtualNetwork;
 };
 
-export function setupServerEndpointsTest(hooks: NestedHooks) {
+type ServerEndpointsTestOptions = {
+  // CS-10009: pick the realm fixture that backs this test's testRealm.
+  // Default is 'blank' — most server-level endpoint tests
+  // (bot-commands, webhooks, realm lifecycle, etc.) don't read card
+  // content out of the testRealm and want the lightest possible
+  // template build. Tests that DO read the kitchen sink (e.g.
+  // screenshot-card referencing Person/fadhlan) pass `'realistic'`.
+  fixture?: 'blank' | 'simple' | 'realistic';
+};
+
+export function setupServerEndpointsTest(
+  hooks: NestedHooks,
+  options: ServerEndpointsTestOptions = {},
+) {
   let context = {} as ServerEndpointsTestContext;
 
   function onRealmSetup(args: {
@@ -57,6 +70,7 @@ export function setupServerEndpointsTest(hooks: NestedHooks) {
   }
 
   setupPermissionedRealmCached(hooks, {
+    fixture: options.fixture ?? 'blank',
     realmURL: testRealmURL,
     permissions: {
       '*': ['read', 'write'],

--- a/packages/realm-server/tests/server-endpoints/index-responses-test.ts
+++ b/packages/realm-server/tests/server-endpoints/index-responses-test.ts
@@ -1178,6 +1178,9 @@ module(`server-endpoints/${basename(__filename)}`, function () {
     }
 
     setupPermissionedRealmCached(hooks, {
+      // Asserts on `data-test-home-card` rendered HTML, which only
+      // exists in tests/cards/home.gts (realistic).
+      fixture: 'realistic',
       realmURL,
       permissions: {
         '*': ['read'],

--- a/packages/realm-server/tests/server-endpoints/realm-lifecycle-test.ts
+++ b/packages/realm-server/tests/server-endpoints/realm-lifecycle-test.ts
@@ -882,6 +882,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
       let request!: SuperTest<Test>;
 
       setupPermissionedRealmCached(hooks, {
+        fixture: 'blank',
         realmURL: rootTestRealmURL,
         permissions: {
           '*': ['read', 'write'],

--- a/packages/realm-server/tests/server-endpoints/screenshot-card-endpoint-test.ts
+++ b/packages/realm-server/tests/server-endpoints/screenshot-card-endpoint-test.ts
@@ -6,7 +6,8 @@ import { setupServerEndpointsTest, testRealmURL } from './helpers';
 
 module(`server-endpoints/${basename(__filename)}`, function () {
   module('/_screenshot-card endpoint', function (hooks) {
-    let context = setupServerEndpointsTest(hooks);
+    // References `Person/fadhlan` from tests/cards/.
+    let context = setupServerEndpointsTest(hooks, { fixture: 'realistic' });
 
     test('requires auth', async function (assert) {
       let response = await context.request

--- a/packages/realm-server/tests/server-endpoints/stripe-session-test.ts
+++ b/packages/realm-server/tests/server-endpoints/stripe-session-test.ts
@@ -38,7 +38,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
       }
 
       setupPermissionedRealmCached(hooks, {
-        fileSystem: {},
+        fixture: 'blank',
         permissions: {
           '*': ['read', 'write'],
         },

--- a/packages/realm-server/tests/server-endpoints/stripe-webhook-test.ts
+++ b/packages/realm-server/tests/server-endpoints/stripe-webhook-test.ts
@@ -67,6 +67,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
       }
 
       setupPermissionedRealmCached(hooks, {
+        fixture: 'blank',
         permissions: {
           '*': ['read', 'write'],
         },

--- a/packages/realm-server/tests/server-endpoints/user-and-catalog-test.ts
+++ b/packages/realm-server/tests/server-endpoints/user-and-catalog-test.ts
@@ -14,8 +14,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
     function (hooks) {
       // `_catalog-realms` asserts the realm's `name === "Test Realm"`,
       // which comes from tests/cards/realm.json's RealmConfig instance
-      // — only present in `realistic`. Same pattern as info-test in
-      // PR 2 (#4790).
+      // — only present in `realistic`.
       let context = setupServerEndpointsTest(hooks, { fixture: 'realistic' });
       let originalLowCreditThreshold: string | undefined;
 

--- a/packages/realm-server/tests/server-endpoints/user-and-catalog-test.ts
+++ b/packages/realm-server/tests/server-endpoints/user-and-catalog-test.ts
@@ -12,7 +12,11 @@ module(`server-endpoints/${basename(__filename)}`, function () {
   module(
     'Realm Server Endpoints (not specific to one realm)',
     function (hooks) {
-      let context = setupServerEndpointsTest(hooks);
+      // `_catalog-realms` asserts the realm's `name === "Test Realm"`,
+      // which comes from tests/cards/realm.json's RealmConfig instance
+      // — only present in `realistic`. Same pattern as info-test in
+      // PR 2 (#4790).
+      let context = setupServerEndpointsTest(hooks, { fixture: 'realistic' });
       let originalLowCreditThreshold: string | undefined;
 
       hooks.beforeEach(function () {

--- a/packages/realm-server/tests/types-endpoint-test.ts
+++ b/packages/realm-server/tests/types-endpoint-test.ts
@@ -12,6 +12,7 @@ import {
   setupDB,
   setupMatrixRoom,
   createVirtualNetwork,
+  fixtureDir,
   matrixURL,
   closeServer,
   type RealmRequest,
@@ -65,6 +66,7 @@ module(basename(__filename), function () {
     }
 
     setupPermissionedRealmCached(hooks, {
+      fixture: 'simple',
       permissions: {
         '*': ['read', 'write'],
         '@node-test_realm:localhost': ['read', 'write', 'realm-owner'],
@@ -106,7 +108,7 @@ module(basename(__filename), function () {
         runner = _runner;
         testRealmDir = join(dir.name, 'realm_server_2', 'test');
         ensureDirSync(testRealmDir);
-        copySync(join(__dirname, 'cards'), testRealmDir);
+        copySync(fixtureDir('simple'), testRealmDir);
         await startRealmServer(dbAdapter2, publisher, runner);
       },
       afterEach: async () => {

--- a/packages/realm-server/tests/types-endpoint-test.ts
+++ b/packages/realm-server/tests/types-endpoint-test.ts
@@ -66,7 +66,7 @@ module(basename(__filename), function () {
     }
 
     setupPermissionedRealmCached(hooks, {
-      fixture: 'simple',
+      fixture: 'realistic',
       permissions: {
         '*': ['read', 'write'],
         '@node-test_realm:localhost': ['read', 'write', 'realm-owner'],


### PR DESCRIPTION
Fourth slice of [CS-10009](https://linear.app/cardstack/issue/CS-10009/consolidate-realm-server-test-realms). **Stacked on #4798** — review/merge that one first; this PR's base will retarget to `main` once it lands.

## Approach

The remaining realm-server test files live at the `packages/realm-server/tests/` root. They split into three groups:

1. **Helper consumers** that call `setupPermissionedRealmCached` / `setupPermissionedRealmsCached` with no `fileSystem` (implicit-default = `realistic` for the duration of the migration). These get an explicit `fixture: …` option.
2. **Hand-rolled `copySync(tests/cards, …)` consumers** that build their realm directly via `runTestRealmServer` and don't go through the helper. There's no `fixture:` option to set — we instead swap the literal `join(__dirname, 'cards')` for `fixtureDir('simple')`, which the final PR can flip to `'realistic'` once the directory is renamed.
3. **Inline `fileSystem: {...}` builders** (`indexing-test`, `prerendering`, `prerender-server`, `search-prerendered`, `definition-lookup`, `file-watcher-events`, `load-links-batching`) — left alone, per the PR plan and the PR 2/3 precedent.

Per the stated strategy (Linear plan + reviewer guidance), this PR **defaults everything to `simple` first** and only escalates to `realistic` where the test code in the same file clearly needs a realistic-only file. CI verifies the rest.

## Per-file decisions

| File | Setup style | Fixture chosen | Notes |
|---|---|---|---|
| `atomic-endpoints-test.ts` | helper × 3 (implicit) | **simple** | uses Person + writes new cards |
| `boxel-domain-availability-test.ts` | hand-rolled copySync | **`fixtureDir('simple')`** | no helper |
| `card-dependencies-endpoint-test.ts` | helper × 2 (implicit) | **simple** | reads `/person` |
| `card-endpoints-test.ts` | helper × 11 (implicit) + 3 inline SKIP | **simple** for helper blocks | uses `hassan` and `person-1` — escalate to realistic if CI fails |
| `card-source-endpoints-test.ts` | helper × 11 (implicit) | **simple** for setup + **`fixtureDir('realistic')`** for the `readFileSync` of `person-with-error.gts` | first GET block tests `/person-with-error.gts`; escalate that block to realistic if CI fails |
| `claim-boxel-domain-test.ts` | hand-rolled copySync | **`fixtureDir('simple')`** | no helper |
| `delete-boxel-claimed-domain-test.ts` | hand-rolled copySync | **`fixtureDir('simple')`** | no helper |
| `get-boxel-claimed-domain-test.ts` | hand-rolled copySync | **`fixtureDir('simple')`** | no helper |
| `module-cache-race-test.ts` | helper × 2 (implicit) | **blank** | synthesizes its own card sources |
| `openrouter-passthrough-test.ts` | hand-rolled copySync × 2 | **`fixtureDir('simple')`** | no helper |
| `publish-unpublish-realm-test.ts` | helper + copySync × 2 | **simple** for helper, **`fixtureDir('simple')`** for the copySyncs | |
| `realm-auth-test.ts` | helper × 1 (implicit) | **blank** | pure auth, no card refs |
| `realm-endpoints-test.ts` | helper × 3 (implicit) + copySync + inline `demoFileSystem` | **simple** for the three helpers, **`fixtureDir('simple')`** for the copySync; **`fixtureDir('realistic')`** for the demoFileSystem reads (`realm.json` is realistic-only) | inline demoFileSystem itself stays inline |
| `request-forward-test.ts` | hand-rolled copySync × 2 | **`fixtureDir('simple')`** | no helper |
| `types-endpoint-test.ts` | helper + copySync | **simple** for helper, **`fixtureDir('simple')`** for the copySync | |

**Inline-`fileSystem` files left alone:** `definition-lookup-test.ts`, `file-watcher-events-test.ts`, `indexing-test.ts`, `load-links-batching-test.ts`, `prerender-server-test.ts`, `prerendering-test.ts`, `search-prerendered-test.ts`.

After this PR lands, the only remaining `tests/cards` references in `packages/realm-server/tests/` will be inside `helpers/index.ts` (the `fixtureDir('realistic')` resolver itself). The final PR can `git mv tests/cards tests/fixtures/realistic` without grepping for stragglers.

## Test plan

- [ ] CI runs every migrated file against the named fixture and they pass.
- [ ] If a `simple`-defaulted file fails because the test code reaches for a realistic-only card (e.g. `hassan`, `person-with-error.gts`), escalate just that block to `realistic` and re-run.
- [ ] CI runs the unmigrated inline-`fileSystem` files unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)