### PR TITLE
realm: gate ::jsonb on pg so module_transpile_cache writes don't error on sqlite

### DIFF
--- a/packages/host/tests/unit/module-transpile-cache-test.ts
+++ b/packages/host/tests/unit/module-transpile-cache-test.ts
@@ -1,0 +1,151 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import { dbExpression, param, query } from '@cardstack/runtime-common';
+
+import type SQLiteAdapter from '@cardstack/host/lib/sqlite-adapter';
+
+import { getDbAdapter, testRealmURL } from '../helpers';
+
+// Mirrors Realm#writeTranspileCacheRow in packages/runtime-common/realm.ts.
+// The production writer is private, so this test re-issues the same UPSERT
+// shape to guarantee the SQL it produces is valid against the host's
+// SQLiteAdapter. The earlier regression hard-coded '::jsonb' next to two
+// param placeholders; on SQLite that landed as `$4 ::jsonb, $5 ::jsonb,`
+// which the parser rejected on the leading `:`. The error was swallowed by
+// the writer's best-effort try/catch and surfaced only as console noise.
+async function upsertTranspileCacheRow(
+  adapter: SQLiteAdapter,
+  {
+    realmUrl,
+    canonicalPath,
+    body,
+    headers,
+    dependencyKeys,
+    generation,
+  }: {
+    realmUrl: string;
+    canonicalPath: string;
+    body: string;
+    headers: Record<string, string>;
+    dependencyKeys: string[];
+    generation: number;
+  },
+) {
+  await query(adapter, [
+    'INSERT INTO module_transpile_cache',
+    '(realm_url, canonical_path, body, headers, dependency_keys, generation, created_at)',
+    'VALUES (',
+    param(realmUrl),
+    ',',
+    param(canonicalPath),
+    ',',
+    param(body),
+    ',',
+    param(JSON.stringify(headers)),
+    dbExpression({ pg: '::jsonb' }),
+    ',',
+    param(JSON.stringify(dependencyKeys)),
+    dbExpression({ pg: '::jsonb' }),
+    ',',
+    param(generation),
+    ',',
+    param(Date.now()),
+    ') ON CONFLICT (realm_url, canonical_path) DO UPDATE SET',
+    'body = EXCLUDED.body,',
+    'headers = EXCLUDED.headers,',
+    'dependency_keys = EXCLUDED.dependency_keys,',
+    'generation = EXCLUDED.generation,',
+    'created_at = EXCLUDED.created_at',
+    'WHERE module_transpile_cache.generation <= EXCLUDED.generation',
+  ]);
+}
+
+module('Unit | module-transpile-cache', function (hooks) {
+  let adapter: SQLiteAdapter;
+  setupTest(hooks);
+
+  hooks.before(async function () {
+    adapter = await getDbAdapter();
+  });
+
+  hooks.beforeEach(async function () {
+    await adapter.reset();
+  });
+
+  test('UPSERT in the shape used by Realm#writeTranspileCacheRow runs against sqlite', async function (assert) {
+    let canonicalPath = `${testRealmURL}example.gts`;
+    let headers = {
+      'Content-Type': 'application/javascript',
+      'X-Boxel-Canonical-Path': canonicalPath,
+    };
+    let dependencyKeys = ['https://cardstack.com/base/card-api'];
+
+    await upsertTranspileCacheRow(adapter, {
+      realmUrl: testRealmURL,
+      canonicalPath,
+      body: 'export const x = 1;',
+      headers,
+      dependencyKeys,
+      generation: 0,
+    });
+
+    let rows = (await adapter.execute(
+      `SELECT body, headers, dependency_keys, generation
+         FROM module_transpile_cache
+        WHERE realm_url = $1 AND canonical_path = $2`,
+      { bind: [testRealmURL, canonicalPath] },
+    )) as {
+      body: string;
+      headers: string;
+      dependency_keys: string;
+      generation: number;
+    }[];
+
+    assert.strictEqual(rows.length, 1, 'one row was inserted');
+    assert.strictEqual(rows[0].body, 'export const x = 1;', 'body persisted');
+    assert.deepEqual(
+      JSON.parse(rows[0].headers),
+      headers,
+      'headers persisted as JSON text',
+    );
+    assert.deepEqual(
+      JSON.parse(rows[0].dependency_keys),
+      dependencyKeys,
+      'dependency_keys persisted as JSON text',
+    );
+    assert.strictEqual(Number(rows[0].generation), 0, 'generation persisted');
+  });
+
+  test('UPSERT on existing row updates body when EXCLUDED.generation >= current', async function (assert) {
+    let canonicalPath = `${testRealmURL}example.gts`;
+    let headers = { 'Content-Type': 'application/javascript' };
+
+    await upsertTranspileCacheRow(adapter, {
+      realmUrl: testRealmURL,
+      canonicalPath,
+      body: 'first',
+      headers,
+      dependencyKeys: [],
+      generation: 0,
+    });
+    await upsertTranspileCacheRow(adapter, {
+      realmUrl: testRealmURL,
+      canonicalPath,
+      body: 'second',
+      headers,
+      dependencyKeys: [],
+      generation: 1,
+    });
+
+    let rows = (await adapter.execute(
+      `SELECT body, generation FROM module_transpile_cache
+        WHERE realm_url = $1 AND canonical_path = $2`,
+      { bind: [testRealmURL, canonicalPath] },
+    )) as { body: string; generation: number }[];
+
+    assert.strictEqual(rows.length, 1);
+    assert.strictEqual(rows[0].body, 'second', 'second write wins');
+    assert.strictEqual(Number(rows[0].generation), 1);
+  });
+});

--- a/packages/host/tests/unit/module-transpile-cache-test.ts
+++ b/packages/host/tests/unit/module-transpile-cache-test.ts
@@ -1,65 +1,11 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-import { dbExpression, param, query } from '@cardstack/runtime-common';
+import { __testOnlyUpsertTranspileCacheRow } from '@cardstack/runtime-common';
 
 import type SQLiteAdapter from '@cardstack/host/lib/sqlite-adapter';
 
 import { getDbAdapter, testRealmURL } from '../helpers';
-
-// Mirrors Realm#writeTranspileCacheRow in packages/runtime-common/realm.ts.
-// The production writer is private, so this test re-issues the same UPSERT
-// shape to guarantee the SQL it produces is valid against the host's
-// SQLiteAdapter. The earlier regression hard-coded '::jsonb' next to two
-// param placeholders; on SQLite that landed as `$4 ::jsonb, $5 ::jsonb,`
-// which the parser rejected on the leading `:`. The error was swallowed by
-// the writer's best-effort try/catch and surfaced only as console noise.
-async function upsertTranspileCacheRow(
-  adapter: SQLiteAdapter,
-  {
-    realmUrl,
-    canonicalPath,
-    body,
-    headers,
-    dependencyKeys,
-    generation,
-  }: {
-    realmUrl: string;
-    canonicalPath: string;
-    body: string;
-    headers: Record<string, string>;
-    dependencyKeys: string[];
-    generation: number;
-  },
-) {
-  await query(adapter, [
-    'INSERT INTO module_transpile_cache',
-    '(realm_url, canonical_path, body, headers, dependency_keys, generation, created_at)',
-    'VALUES (',
-    param(realmUrl),
-    ',',
-    param(canonicalPath),
-    ',',
-    param(body),
-    ',',
-    param(JSON.stringify(headers)),
-    dbExpression({ pg: '::jsonb' }),
-    ',',
-    param(JSON.stringify(dependencyKeys)),
-    dbExpression({ pg: '::jsonb' }),
-    ',',
-    param(generation),
-    ',',
-    param(Date.now()),
-    ') ON CONFLICT (realm_url, canonical_path) DO UPDATE SET',
-    'body = EXCLUDED.body,',
-    'headers = EXCLUDED.headers,',
-    'dependency_keys = EXCLUDED.dependency_keys,',
-    'generation = EXCLUDED.generation,',
-    'created_at = EXCLUDED.created_at',
-    'WHERE module_transpile_cache.generation <= EXCLUDED.generation',
-  ]);
-}
 
 module('Unit | module-transpile-cache', function (hooks) {
   let adapter: SQLiteAdapter;
@@ -73,7 +19,7 @@ module('Unit | module-transpile-cache', function (hooks) {
     await adapter.reset();
   });
 
-  test('UPSERT in the shape used by Realm#writeTranspileCacheRow runs against sqlite', async function (assert) {
+  test('UPSERT runs against sqlite and persists the row', async function (assert) {
     let canonicalPath = `${testRealmURL}example.gts`;
     let headers = {
       'Content-Type': 'application/javascript',
@@ -81,13 +27,13 @@ module('Unit | module-transpile-cache', function (hooks) {
     };
     let dependencyKeys = ['https://cardstack.com/base/card-api'];
 
-    await upsertTranspileCacheRow(adapter, {
+    await __testOnlyUpsertTranspileCacheRow(adapter, {
       realmUrl: testRealmURL,
       canonicalPath,
       body: 'export const x = 1;',
       headers,
       dependencyKeys,
-      generation: 0,
+      capturedGeneration: 0,
     });
 
     let rows = (await adapter.execute(
@@ -121,21 +67,21 @@ module('Unit | module-transpile-cache', function (hooks) {
     let canonicalPath = `${testRealmURL}example.gts`;
     let headers = { 'Content-Type': 'application/javascript' };
 
-    await upsertTranspileCacheRow(adapter, {
+    await __testOnlyUpsertTranspileCacheRow(adapter, {
       realmUrl: testRealmURL,
       canonicalPath,
       body: 'first',
       headers,
       dependencyKeys: [],
-      generation: 0,
+      capturedGeneration: 0,
     });
-    await upsertTranspileCacheRow(adapter, {
+    await __testOnlyUpsertTranspileCacheRow(adapter, {
       realmUrl: testRealmURL,
       canonicalPath,
       body: 'second',
       headers,
       dependencyKeys: [],
-      generation: 1,
+      capturedGeneration: 1,
     });
 
     let rows = (await adapter.execute(

--- a/packages/host/tests/unit/module-transpile-cache-test.ts
+++ b/packages/host/tests/unit/module-transpile-cache-test.ts
@@ -1,25 +1,36 @@
-import { setupTest } from 'ember-qunit';
+import type { RenderingTestContext } from '@ember/test-helpers';
+
 import { module, test } from 'qunit';
 
-import { __testOnlyUpsertTranspileCacheRow } from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common';
 
-import type SQLiteAdapter from '@cardstack/host/lib/sqlite-adapter';
-
-import { getDbAdapter, testRealmURL } from '../helpers';
+import {
+  getDbAdapter,
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupRealmCacheTeardown,
+  testRealmURL,
+  withCachedRealmSetup,
+} from '../helpers';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupRenderingTest } from '../helpers/setup';
 
 module('Unit | module-transpile-cache', function (hooks) {
-  let adapter: SQLiteAdapter;
-  setupTest(hooks);
+  setupRenderingTest(hooks);
+  setupLocalIndexing(hooks);
+  let mockMatrixUtils = setupMockMatrix(hooks);
+  setupRealmCacheTeardown(hooks);
 
-  hooks.before(async function () {
-    adapter = await getDbAdapter();
+  let realm: Realm;
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    let result = await withCachedRealmSetup(async () =>
+      setupIntegrationTestRealm({ mockMatrixUtils, contents: {} }),
+    );
+    realm = result.realm;
   });
 
-  hooks.beforeEach(async function () {
-    await adapter.reset();
-  });
-
-  test('UPSERT runs against sqlite and persists the row', async function (assert) {
+  test('Realm.__testOnlyUpsertTranspileCacheRow persists a row via the production writer', async function (assert) {
     let canonicalPath = `${testRealmURL}example.gts`;
     let headers = {
       'Content-Type': 'application/javascript',
@@ -27,8 +38,7 @@ module('Unit | module-transpile-cache', function (hooks) {
     };
     let dependencyKeys = ['https://cardstack.com/base/card-api'];
 
-    await __testOnlyUpsertTranspileCacheRow(adapter, {
-      realmUrl: testRealmURL,
+    await realm.__testOnlyUpsertTranspileCacheRow({
       canonicalPath,
       body: 'export const x = 1;',
       headers,
@@ -36,6 +46,7 @@ module('Unit | module-transpile-cache', function (hooks) {
       capturedGeneration: 0,
     });
 
+    let adapter = await getDbAdapter();
     let rows = (await adapter.execute(
       `SELECT body, headers, dependency_keys, generation
          FROM module_transpile_cache
@@ -48,6 +59,9 @@ module('Unit | module-transpile-cache', function (hooks) {
       generation: number;
     }[];
 
+    // The row's presence is the assertion that matters: if
+    // #writeTranspileCacheRow's SQL chokes on SQLite the writer
+    // swallows the error and the row never lands.
     assert.strictEqual(rows.length, 1, 'one row was inserted');
     assert.strictEqual(rows[0].body, 'export const x = 1;', 'body persisted');
     assert.deepEqual(
@@ -63,20 +77,18 @@ module('Unit | module-transpile-cache', function (hooks) {
     assert.strictEqual(Number(rows[0].generation), 0, 'generation persisted');
   });
 
-  test('UPSERT on existing row updates body when EXCLUDED.generation >= current', async function (assert) {
+  test('a higher-generation UPSERT overwrites the existing row', async function (assert) {
     let canonicalPath = `${testRealmURL}example.gts`;
     let headers = { 'Content-Type': 'application/javascript' };
 
-    await __testOnlyUpsertTranspileCacheRow(adapter, {
-      realmUrl: testRealmURL,
+    await realm.__testOnlyUpsertTranspileCacheRow({
       canonicalPath,
       body: 'first',
       headers,
       dependencyKeys: [],
       capturedGeneration: 0,
     });
-    await __testOnlyUpsertTranspileCacheRow(adapter, {
-      realmUrl: testRealmURL,
+    await realm.__testOnlyUpsertTranspileCacheRow({
       canonicalPath,
       body: 'second',
       headers,
@@ -84,6 +96,7 @@ module('Unit | module-transpile-cache', function (hooks) {
       capturedGeneration: 1,
     });
 
+    let adapter = await getDbAdapter();
     let rows = (await adapter.execute(
       `SELECT body, generation FROM module_transpile_cache
         WHERE realm_url = $1 AND canonical_path = $2`,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -64,6 +64,7 @@ import {
   unixTime,
   query,
   param,
+  dbExpression,
   isValidPrerenderedHtmlFormat,
   type CodeRef,
   type LooseSingleCardDocument,
@@ -2835,13 +2836,15 @@ export class Realm {
         param(result.body),
         ',',
         param(JSON.stringify(result.headers)),
-        '::jsonb,',
+        dbExpression({ pg: '::jsonb' }),
+        ',',
         // Persist the full deps set computed once at the transpile
         // boundary so a cross-process L2 reader can populate its L1
         // entry directly instead of re-running extractModuleDependencyKeys
         // on the bytes.
         param(JSON.stringify([...result.dependencyKeys])),
-        '::jsonb,',
+        dbExpression({ pg: '::jsonb' }),
+        ',',
         param(capturedGeneration),
         ',',
         param(Date.now()),

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2815,47 +2815,14 @@ export class Realm {
     capturedGeneration: number,
   ): Promise<void> {
     try {
-      // INSERT a row at `capturedGeneration`. On conflict, UPDATE only
-      // if the row's current generation is still <= capturedGeneration.
-      // If an invalidate has tombstoned-and-bumped the row past that
-      // value, the WHERE clause rejects the UPDATE and the stale
-      // transpile is discarded. capturedGeneration may legitimately be
-      // 0 (row absent at read time, tombstone never created) — in
-      // that case the WHERE 0 <= 0 still allows a no-op same-gen
-      // overwrite which is benign because the bytes are deterministic
-      // for the same source.
-      await query(this.#dbAdapter, [
-        'INSERT INTO',
-        MODULE_TRANSPILE_CACHE_TABLE,
-        '(realm_url, canonical_path, body, headers, dependency_keys, generation, created_at)',
-        'VALUES (',
-        param(this.url),
-        ',',
-        param(canonicalPath),
-        ',',
-        param(result.body),
-        ',',
-        param(JSON.stringify(result.headers)),
-        dbExpression({ pg: '::jsonb' }),
-        ',',
-        // Persist the full deps set computed once at the transpile
-        // boundary so a cross-process L2 reader can populate its L1
-        // entry directly instead of re-running extractModuleDependencyKeys
-        // on the bytes.
-        param(JSON.stringify([...result.dependencyKeys])),
-        dbExpression({ pg: '::jsonb' }),
-        ',',
-        param(capturedGeneration),
-        ',',
-        param(Date.now()),
-        ') ON CONFLICT (realm_url, canonical_path) DO UPDATE SET',
-        'body = EXCLUDED.body,',
-        'headers = EXCLUDED.headers,',
-        'dependency_keys = EXCLUDED.dependency_keys,',
-        'generation = EXCLUDED.generation,',
-        'created_at = EXCLUDED.created_at',
-        `WHERE ${MODULE_TRANSPILE_CACHE_TABLE}.generation <= EXCLUDED.generation`,
-      ]);
+      await __testOnlyUpsertTranspileCacheRow(this.#dbAdapter, {
+        realmUrl: this.url,
+        canonicalPath,
+        body: result.body,
+        headers: result.headers,
+        dependencyKeys: result.dependencyKeys,
+        capturedGeneration,
+      });
     } catch (err: unknown) {
       // L2 persistence is best-effort. A transient pg failure must not
       // break the response the caller is about to serve — they already
@@ -6314,6 +6281,65 @@ export class Realm {
       } ${request.headers.get('Accept') ?? ''}`,
     );
   }
+}
+
+// Shared module_transpile_cache UPSERT body, factored out of
+// Realm#writeTranspileCacheRow so the host-side SQLite regression test can
+// run the same SQL the production writer does. Realm's private method is
+// the only production caller and wraps this in the best-effort try/catch +
+// log; tests call this directly so the SQL is the single source of truth.
+export async function __testOnlyUpsertTranspileCacheRow(
+  dbAdapter: DBAdapter,
+  args: {
+    realmUrl: string;
+    canonicalPath: string;
+    body: string;
+    headers: Record<string, string>;
+    dependencyKeys: Iterable<string>;
+    capturedGeneration: number;
+  },
+): Promise<void> {
+  // INSERT a row at `capturedGeneration`. On conflict, UPDATE only
+  // if the row's current generation is still <= capturedGeneration.
+  // If an invalidate has tombstoned-and-bumped the row past that
+  // value, the WHERE clause rejects the UPDATE and the stale
+  // transpile is discarded. capturedGeneration may legitimately be
+  // 0 (row absent at read time, tombstone never created) — in
+  // that case the WHERE 0 <= 0 still allows a no-op same-gen
+  // overwrite which is benign because the bytes are deterministic
+  // for the same source.
+  await query(dbAdapter, [
+    'INSERT INTO',
+    MODULE_TRANSPILE_CACHE_TABLE,
+    '(realm_url, canonical_path, body, headers, dependency_keys, generation, created_at)',
+    'VALUES (',
+    param(args.realmUrl),
+    ',',
+    param(args.canonicalPath),
+    ',',
+    param(args.body),
+    ',',
+    param(JSON.stringify(args.headers)),
+    dbExpression({ pg: '::jsonb' }),
+    ',',
+    // Persist the full deps set computed once at the transpile
+    // boundary so a cross-process L2 reader can populate its L1
+    // entry directly instead of re-running extractModuleDependencyKeys
+    // on the bytes.
+    param(JSON.stringify([...args.dependencyKeys])),
+    dbExpression({ pg: '::jsonb' }),
+    ',',
+    param(args.capturedGeneration),
+    ',',
+    param(Date.now()),
+    ') ON CONFLICT (realm_url, canonical_path) DO UPDATE SET',
+    'body = EXCLUDED.body,',
+    'headers = EXCLUDED.headers,',
+    'dependency_keys = EXCLUDED.dependency_keys,',
+    'generation = EXCLUDED.generation,',
+    'created_at = EXCLUDED.created_at',
+    `WHERE ${MODULE_TRANSPILE_CACHE_TABLE}.generation <= EXCLUDED.generation`,
+  ]);
 }
 
 export type Kind = 'file' | 'directory';

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2815,14 +2815,47 @@ export class Realm {
     capturedGeneration: number,
   ): Promise<void> {
     try {
-      await __testOnlyUpsertTranspileCacheRow(this.#dbAdapter, {
-        realmUrl: this.url,
-        canonicalPath,
-        body: result.body,
-        headers: result.headers,
-        dependencyKeys: result.dependencyKeys,
-        capturedGeneration,
-      });
+      // INSERT a row at `capturedGeneration`. On conflict, UPDATE only
+      // if the row's current generation is still <= capturedGeneration.
+      // If an invalidate has tombstoned-and-bumped the row past that
+      // value, the WHERE clause rejects the UPDATE and the stale
+      // transpile is discarded. capturedGeneration may legitimately be
+      // 0 (row absent at read time, tombstone never created) — in
+      // that case the WHERE 0 <= 0 still allows a no-op same-gen
+      // overwrite which is benign because the bytes are deterministic
+      // for the same source.
+      await query(this.#dbAdapter, [
+        'INSERT INTO',
+        MODULE_TRANSPILE_CACHE_TABLE,
+        '(realm_url, canonical_path, body, headers, dependency_keys, generation, created_at)',
+        'VALUES (',
+        param(this.url),
+        ',',
+        param(canonicalPath),
+        ',',
+        param(result.body),
+        ',',
+        param(JSON.stringify(result.headers)),
+        dbExpression({ pg: '::jsonb' }),
+        ',',
+        // Persist the full deps set computed once at the transpile
+        // boundary so a cross-process L2 reader can populate its L1
+        // entry directly instead of re-running extractModuleDependencyKeys
+        // on the bytes.
+        param(JSON.stringify([...result.dependencyKeys])),
+        dbExpression({ pg: '::jsonb' }),
+        ',',
+        param(capturedGeneration),
+        ',',
+        param(Date.now()),
+        ') ON CONFLICT (realm_url, canonical_path) DO UPDATE SET',
+        'body = EXCLUDED.body,',
+        'headers = EXCLUDED.headers,',
+        'dependency_keys = EXCLUDED.dependency_keys,',
+        'generation = EXCLUDED.generation,',
+        'created_at = EXCLUDED.created_at',
+        `WHERE ${MODULE_TRANSPILE_CACHE_TABLE}.generation <= EXCLUDED.generation`,
+      ]);
     } catch (err: unknown) {
       // L2 persistence is best-effort. A transient pg failure must not
       // break the response the caller is about to serve — they already
@@ -2832,6 +2865,34 @@ export class Realm {
         `${MODULE_TRANSPILE_CACHE_TABLE} insert failed for ${this.url}${canonicalPath}: ${String(err)}`,
       );
     }
+  }
+
+  // Test seam: lets host SQLite tests verify that #writeTranspileCacheRow
+  // produces dialect-correct SQL without re-issuing the UPSERT in a
+  // parallel build. Production code must never call this — go through
+  // the private method directly. The wrapper just forwards arguments;
+  // the swallow-and-log behavior of the private method means the test
+  // confirms success by reading the row back, not by exception.
+  async __testOnlyUpsertTranspileCacheRow(args: {
+    canonicalPath: string;
+    body: string;
+    headers: Record<string, string>;
+    dependencyKeys: Iterable<string>;
+    capturedGeneration: number;
+  }): Promise<void> {
+    let { canonicalPath, body, headers, dependencyKeys, capturedGeneration } =
+      args;
+    await this.#writeTranspileCacheRow(
+      canonicalPath,
+      {
+        kind: 'module',
+        canonicalPath,
+        body,
+        headers,
+        dependencyKeys: new Set(dependencyKeys),
+      },
+      capturedGeneration,
+    );
   }
 
   async #deleteTranspileCacheRow(canonicalPath: string): Promise<void> {
@@ -6281,65 +6342,6 @@ export class Realm {
       } ${request.headers.get('Accept') ?? ''}`,
     );
   }
-}
-
-// Shared module_transpile_cache UPSERT body, factored out of
-// Realm#writeTranspileCacheRow so the host-side SQLite regression test can
-// run the same SQL the production writer does. Realm's private method is
-// the only production caller and wraps this in the best-effort try/catch +
-// log; tests call this directly so the SQL is the single source of truth.
-export async function __testOnlyUpsertTranspileCacheRow(
-  dbAdapter: DBAdapter,
-  args: {
-    realmUrl: string;
-    canonicalPath: string;
-    body: string;
-    headers: Record<string, string>;
-    dependencyKeys: Iterable<string>;
-    capturedGeneration: number;
-  },
-): Promise<void> {
-  // INSERT a row at `capturedGeneration`. On conflict, UPDATE only
-  // if the row's current generation is still <= capturedGeneration.
-  // If an invalidate has tombstoned-and-bumped the row past that
-  // value, the WHERE clause rejects the UPDATE and the stale
-  // transpile is discarded. capturedGeneration may legitimately be
-  // 0 (row absent at read time, tombstone never created) — in
-  // that case the WHERE 0 <= 0 still allows a no-op same-gen
-  // overwrite which is benign because the bytes are deterministic
-  // for the same source.
-  await query(dbAdapter, [
-    'INSERT INTO',
-    MODULE_TRANSPILE_CACHE_TABLE,
-    '(realm_url, canonical_path, body, headers, dependency_keys, generation, created_at)',
-    'VALUES (',
-    param(args.realmUrl),
-    ',',
-    param(args.canonicalPath),
-    ',',
-    param(args.body),
-    ',',
-    param(JSON.stringify(args.headers)),
-    dbExpression({ pg: '::jsonb' }),
-    ',',
-    // Persist the full deps set computed once at the transpile
-    // boundary so a cross-process L2 reader can populate its L1
-    // entry directly instead of re-running extractModuleDependencyKeys
-    // on the bytes.
-    param(JSON.stringify([...args.dependencyKeys])),
-    dbExpression({ pg: '::jsonb' }),
-    ',',
-    param(args.capturedGeneration),
-    ',',
-    param(Date.now()),
-    ') ON CONFLICT (realm_url, canonical_path) DO UPDATE SET',
-    'body = EXCLUDED.body,',
-    'headers = EXCLUDED.headers,',
-    'dependency_keys = EXCLUDED.dependency_keys,',
-    'generation = EXCLUDED.generation,',
-    'created_at = EXCLUDED.created_at',
-    `WHERE ${MODULE_TRANSPILE_CACHE_TABLE}.generation <= EXCLUDED.generation`,
-  ]);
 }
 
 export type Kind = 'file' | 'directory';


### PR DESCRIPTION
## Summary
- Host browser tests have been emitting `SQLITE_ERROR: unrecognized token: ":"` every time a `.gts` file is transpiled. The writer's try/catch swallowed the failure (L2 persistence is best-effort) so tests passed, but the console output was noisy and the L2 transpile cache was effectively disabled in the host.
- Root cause: `Realm#writeTranspileCacheRow` hard-coded `::jsonb` casts on two param placeholders, producing `$N ::jsonb` in the rendered SQL. The host's `SQLiteAdapter.adjustSQL` rewrites many PG-isms but has no rule for this one, so SQLite's parser tripped on the leading `:`.
- Switched the literal fragments to `dbExpression({ pg: '::jsonb' })`, the same dialect-conditional helper already used in `index-writer.ts` and `definition-lookup.ts`. PG still gets the cast; SQLite renders to plain `$N , $N ,`.

## Test plan
- [ ] New unit test `packages/host/tests/unit/module-transpile-cache-test.ts` exercises the writer's UPSERT shape against the real host `SQLiteAdapter` and asserts the row is persisted (it would have failed before this fix because the SQLite parser would throw)
- [ ] Existing realm-server PG-side test `packages/realm-server/tests/module-cache-race-test.ts` still passes (this fix doesn't change PG behavior)
- [ ] Host acceptance tests no longer log `module_transpile_cache insert failed for ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)