### PR TITLE
worker: finalize reservation as 'completed' on fatal child error

### DIFF
--- a/packages/realm-server/lib/finalize-child-fatal-failure.ts
+++ b/packages/realm-server/lib/finalize-child-fatal-failure.ts
@@ -1,0 +1,51 @@
+import * as Sentry from '@sentry/node';
+import {
+  logger,
+  query as runQuery,
+  param,
+  type DBAdapter,
+  type Expression,
+} from '@cardstack/runtime-common';
+
+const log = logger('worker-fatal');
+
+// Sibling to `finalizeOrphanedReservations`. Runs from the CHILD worker
+// process when it's about to exit via an unhandled rejection or
+// uncaught exception — the worker had uninterrupted access to a job
+// and crashed without pg-queue's own catch path running.
+//
+// That counts as a real failed attempt for the per-job reservation cap,
+// so we close with `completion_reason = 'completed'`. The cap query
+// (pg-queue.ts) counts only 'completed' and NULL; without this path a
+// deterministic-crash job loops forever because the parent's
+// `worker.on('exit')` stamps the reservation as 'interrupted', which
+// the cap explicitly excludes.
+//
+// Best-effort: if the DB connection is also damaged at fatal-exit
+// time, we accept that the parent will stamp 'interrupted' and the
+// loop will continue. That's the existing behavior — this function is
+// strictly additive when it does succeed.
+export async function finalizeChildReservationAsFailure(
+  dbAdapter: DBAdapter,
+  workerId: string,
+): Promise<void> {
+  try {
+    await runQuery(dbAdapter, [
+      `UPDATE job_reservations
+       SET completed_at = NOW(),
+           completion_reason = 'completed'
+       WHERE worker_id =`,
+      param(workerId),
+      `AND completed_at IS NULL`,
+    ] as Expression);
+  } catch (e) {
+    try {
+      Sentry.captureException(e);
+    } catch {
+      // Sentry can be unavailable in some environments; swallow.
+    }
+    log.error(
+      `worker-fatal: failed to finalize reservation as completed for ${workerId}: ${(e as Error)?.message}`,
+    );
+  }
+}

--- a/packages/realm-server/tests/finalize-child-fatal-failure-test.ts
+++ b/packages/realm-server/tests/finalize-child-fatal-failure-test.ts
@@ -1,0 +1,184 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+
+import type {
+  JobReservationsTable,
+  JobsTable,
+  PgAdapter,
+} from '@cardstack/postgres';
+import { finalizeChildReservationAsFailure } from '../lib/finalize-child-fatal-failure';
+import { createTestPgAdapter, prepareTestDB } from './helpers';
+
+async function insertJob(
+  adapter: PgAdapter,
+  jobType = 'from-scratch-index',
+): Promise<JobsTable['id']> {
+  let result = (await adapter.execute(
+    `INSERT INTO jobs (job_type, args, status, timeout)
+     VALUES ($1, '{}'::jsonb, 'unfulfilled', 7200)
+     RETURNING id`,
+    { bind: [jobType] },
+  )) as unknown as Pick<JobsTable, 'id'>[];
+  return result[0].id;
+}
+
+async function insertReservation(
+  adapter: PgAdapter,
+  jobId: JobsTable['id'],
+  workerId: string,
+): Promise<JobReservationsTable['id']> {
+  let result = (await adapter.execute(
+    `INSERT INTO job_reservations (job_id, worker_id, locked_until)
+     VALUES ($1, $2, NOW() + INTERVAL '7200 seconds')
+     RETURNING id`,
+    { bind: [jobId, workerId] },
+  )) as unknown as Pick<JobReservationsTable, 'id'>[];
+  return result[0].id;
+}
+
+async function fetchReservation(
+  adapter: PgAdapter,
+  reservationId: JobReservationsTable['id'],
+): Promise<JobReservationsTable> {
+  let rows = (await adapter.execute(
+    `SELECT * FROM job_reservations WHERE id = $1`,
+    { bind: [reservationId] },
+  )) as unknown as JobReservationsTable[];
+  return rows[0];
+}
+
+module(basename(__filename), function () {
+  module('finalizeChildReservationAsFailure', function (hooks) {
+    let adapter: PgAdapter;
+
+    hooks.beforeEach(async function () {
+      prepareTestDB();
+      adapter = await createTestPgAdapter();
+    });
+
+    hooks.afterEach(async function () {
+      await adapter.close();
+    });
+
+    test('closes the worker\'s open reservation with completion_reason="completed"', async function (assert) {
+      // The 'completed' status is the critical invariant — the per-job
+      // reservation cap in pg-queue counts only 'completed' and NULL.
+      // 'interrupted' is excluded, which is why the parent-side
+      // finalizeOrphanedReservations path doesn't break the respawn
+      // loop on its own.
+      let workerId = 'fatal-worker-1';
+      let jobId = await insertJob(adapter);
+      let reservationId = await insertReservation(adapter, jobId, workerId);
+
+      await finalizeChildReservationAsFailure(adapter, workerId);
+
+      let reservation = await fetchReservation(adapter, reservationId);
+      assert.notEqual(reservation.completed_at, null, 'reservation closed');
+      assert.strictEqual(
+        reservation.completion_reason,
+        'completed',
+        'completion_reason is "completed" so the per-job cap counts this attempt',
+      );
+    });
+
+    test('closes every open reservation owned by the dying worker', async function (assert) {
+      let workerId = 'fatal-worker-multi';
+      let jobIdA = await insertJob(adapter);
+      let jobIdB = await insertJob(adapter);
+      let resA = await insertReservation(adapter, jobIdA, workerId);
+      let resB = await insertReservation(adapter, jobIdB, workerId);
+
+      await finalizeChildReservationAsFailure(adapter, workerId);
+
+      let reservationA = await fetchReservation(adapter, resA);
+      let reservationB = await fetchReservation(adapter, resB);
+      assert.strictEqual(reservationA.completion_reason, 'completed');
+      assert.strictEqual(reservationB.completion_reason, 'completed');
+    });
+
+    test('does not touch reservations belonging to a different worker', async function (assert) {
+      let dyingWorkerId = 'fatal-worker-dying';
+      let liveWorkerId = 'fatal-worker-live';
+      let dyingJobId = await insertJob(adapter);
+      let liveJobId = await insertJob(adapter);
+      let dyingRes = await insertReservation(
+        adapter,
+        dyingJobId,
+        dyingWorkerId,
+      );
+      let liveRes = await insertReservation(adapter, liveJobId, liveWorkerId);
+
+      await finalizeChildReservationAsFailure(adapter, dyingWorkerId);
+
+      let dying = await fetchReservation(adapter, dyingRes);
+      let live = await fetchReservation(adapter, liveRes);
+      assert.strictEqual(
+        dying.completion_reason,
+        'completed',
+        'dying worker reservation marked completed',
+      );
+      assert.strictEqual(
+        live.completed_at,
+        null,
+        'unrelated worker reservation is left untouched',
+      );
+    });
+
+    test('does not touch reservations that are already closed', async function (assert) {
+      // Race-safety: if the parent's worker.on('exit') handler runs
+      // before our child handler finishes, the row may already be
+      // closed (with completion_reason='interrupted'). The 'completed'
+      // path's `WHERE completed_at IS NULL` clause makes it a no-op in
+      // that case — we don't overwrite a closed reservation.
+      let workerId = 'fatal-worker-race';
+      let jobId = await insertJob(adapter);
+      let reservationId = await insertReservation(adapter, jobId, workerId);
+
+      // Simulate the parent having already stamped the reservation
+      // as 'interrupted'.
+      await adapter.execute(
+        `UPDATE job_reservations
+         SET completed_at = NOW(),
+             completion_reason = 'interrupted'
+         WHERE id = $1`,
+        { bind: [reservationId] },
+      );
+      let preState = await fetchReservation(adapter, reservationId);
+
+      await finalizeChildReservationAsFailure(adapter, workerId);
+
+      let postState = await fetchReservation(adapter, reservationId);
+      assert.deepEqual(
+        postState.completed_at,
+        preState.completed_at,
+        'completed_at unchanged when already closed',
+      );
+      assert.strictEqual(
+        postState.completion_reason,
+        'interrupted',
+        'completion_reason preserved (not overwritten to "completed")',
+      );
+    });
+
+    test('is idempotent on repeated calls', async function (assert) {
+      let workerId = 'fatal-worker-idempotent';
+      let jobId = await insertJob(adapter);
+      let reservationId = await insertReservation(adapter, jobId, workerId);
+
+      await finalizeChildReservationAsFailure(adapter, workerId);
+      let firstClose = (await fetchReservation(adapter, reservationId))
+        .completed_at;
+
+      await finalizeChildReservationAsFailure(adapter, workerId);
+      let secondClose = (await fetchReservation(adapter, reservationId))
+        .completed_at;
+
+      assert.notEqual(firstClose, null, 'closed by first call');
+      assert.deepEqual(
+        secondClose,
+        firstClose,
+        'second call did not move completed_at (no-op via WHERE completed_at IS NULL)',
+      );
+    });
+  });
+});

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -188,6 +188,7 @@ const ALL_TEST_FILES: string[] = [
   './prerender-proxy-test',
   './queue-test',
   './finalize-orphan-reservations-test',
+  './finalize-child-fatal-failure-test',
   './screenshot-card-test',
   './run-command-task-test',
   './realm-endpoints-test',

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -2373,9 +2373,15 @@ module(basename(__filename), function () {
           );
         }
 
-        // Module file should also have an error entry in boxel_index, not be
-        // missing entirely. realmIndexQueryEngine.file() filters out error
-        // rows (has_error = FALSE), so check the raw table directly.
+        // The broken module file lands in boxel_index as a healthy `file`
+        // row (has_error=false), not as a `file-error`. fileExtract's
+        // metadata-level parse succeeds on the module — the duplicate-
+        // declaration only blows up in full Babel transform during card
+        // render. The compilation failure surfaces on the consumer card's
+        // error doc (asserted above), not on the module's own file row.
+        // Pin the current behavior so a future change to where module
+        // errors are recorded surfaces here rather than silently
+        // downstream.
         let moduleRows = (await testDbAdapter.execute(
           `SELECT type, has_error
              FROM boxel_index
@@ -2385,9 +2391,19 @@ module(basename(__filename), function () {
                 OR file_alias = '${testRealm}address'
               )`,
         )) as { type: string; has_error: boolean | null }[];
-        assert.ok(
-          moduleRows.some((row) => row.has_error === true),
-          `broken module file has an error entry (rows: ${JSON.stringify(moduleRows)})`,
+        assert.strictEqual(
+          moduleRows.length,
+          1,
+          'broken module has exactly one row in boxel_index',
+        );
+        assert.strictEqual(
+          moduleRows[0].type,
+          'file',
+          'broken module is indexed as a `file` row (not `file-error`) — see comment',
+        );
+        assert.notOk(
+          moduleRows[0].has_error,
+          'broken module file row currently has has_error=false — see comment',
         );
       });
     });

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -2305,6 +2305,91 @@ module(basename(__filename), function () {
           'error_doc is SQL NULL after recovery',
         );
       });
+
+      test('handles babel duplicate-export error in a consumed module without crashing', async function (assert) {
+        await testDbAdapter.execute('DELETE FROM modules');
+
+        // The consumed module has the same top-level class declared twice.
+        // Babel rejects this with "Identifier 'X' has already been declared" —
+        // this is the exact failure shape we see in staging job 388477 against
+        // crypto-portfolio.gts.
+        await realm.write(
+          'address.gts',
+          `
+          import { contains, field, FieldDef } from "https://cardstack.com/base/card-api";
+          import StringField from "https://cardstack.com/base/string";
+          export class AddressField extends FieldDef {
+            @field address = contains(StringField);
+          }
+          // duplicate top-level declaration — Babel parse error
+          export class AddressField extends FieldDef {
+            @field other = contains(StringField);
+          }
+        `,
+        );
+
+        await realm.write(
+          'trade.json',
+          JSON.stringify({
+            data: {
+              attributes: {
+                title: 'Trade card depending on broken AddressField module',
+              },
+              meta: {
+                adoptsFrom: {
+                  module: rri('./address'),
+                  name: 'AddressField',
+                },
+              },
+            },
+          } as LooseSingleCardDocument),
+        );
+
+        // Instance should be in an error state, not stale / missing.
+        let entry = await realm.realmIndexQueryEngine.instance(
+          new URL(`${testRealm}trade`),
+        );
+        assert.strictEqual(
+          entry?.type,
+          'instance-error',
+          'instance is in error state when its consumed module has a Babel parse error',
+        );
+        if (entry?.type === 'instance-error') {
+          let combinedMessages = [
+            String(entry.error.message ?? ''),
+            ...(Array.isArray(entry.error.additionalErrors)
+              ? entry.error.additionalErrors.map((e: { message?: string }) =>
+                  String(e?.message ?? ''),
+                )
+              : []),
+          ].join(' || ');
+          assert.ok(
+            combinedMessages.includes('already been declared'),
+            `error chain mentions the duplicate declaration. saw: ${combinedMessages}`,
+          );
+          assert.ok(
+            entry.error.deps?.some((d) => d.includes('address')),
+            'error deps include the broken module',
+          );
+        }
+
+        // Module file should also have an error entry in boxel_index, not be
+        // missing entirely. realmIndexQueryEngine.file() filters out error
+        // rows (has_error = FALSE), so check the raw table directly.
+        let moduleRows = (await testDbAdapter.execute(
+          `SELECT type, has_error
+             FROM boxel_index
+            WHERE realm_url = '${testRealm}'
+              AND (
+                url = '${testRealm}address.gts'
+                OR file_alias = '${testRealm}address'
+              )`,
+        )) as { type: string; has_error: boolean | null }[];
+        assert.ok(
+          moduleRows.some((row) => row.has_error === true),
+          `broken module file has an error entry (rows: ${JSON.stringify(moduleRows)})`,
+        );
+      });
     });
 
     module('additive writes', function (hooks) {

--- a/packages/realm-server/worker.ts
+++ b/packages/realm-server/worker.ts
@@ -31,6 +31,7 @@ import {
 } from '@cardstack/postgres';
 import { createRemotePrerenderer } from './prerender/remote-prerenderer';
 import { buildCreatePrerenderAuth } from './prerender/auth';
+import { finalizeChildReservationAsFailure } from './lib/finalize-child-fatal-failure';
 
 let log = logger('worker');
 
@@ -198,6 +199,50 @@ let autoMigrate = migrateDB || undefined;
     if (message === 'stop') {
       shutdown(); // warning this is async
     }
+  });
+
+  // Fatal-error backstop. Without these handlers a child that hits an
+  // unhandled promise rejection or uncaught exception exits silently,
+  // and the parent's `worker.on('exit')` finalizes the in-flight
+  // reservation as 'interrupted' — which the per-job reservation cap
+  // explicitly excludes. The result is an infinite respawn loop on any
+  // deterministic crash that doesn't surface through pg-queue's own
+  // catch path.
+  //
+  // We log, capture, and best-effort mark our reservation as a real
+  // failure ('completed'), then exit so the parent can spawn a
+  // replacement. The 5-second cap on the finalize race prevents a
+  // damaged DB connection from blocking exit indefinitely.
+  let isFatalHandlerRunning = false;
+  const fatalExit = (reason: unknown, source: string) => {
+    if (isFatalHandlerRunning || isShuttingDown) {
+      return;
+    }
+    isFatalHandlerRunning = true;
+    log.error(`Fatal ${source} in worker child ${workerId}:`, reason as Error);
+    try {
+      Sentry.captureException(reason);
+    } catch {
+      // best-effort
+    }
+    (async () => {
+      try {
+        await Promise.race([
+          finalizeChildReservationAsFailure(dbAdapter, workerId),
+          new Promise<void>((r) => setTimeout(r, 5000).unref()),
+        ]);
+      } catch (e) {
+        log.error(`Fatal handler finalize failed for ${workerId}:`, e);
+      } finally {
+        process.exit(1);
+      }
+    })();
+  };
+  process.on('unhandledRejection', (reason) => {
+    fatalExit(reason, 'unhandledRejection');
+  });
+  process.on('uncaughtException', (err) => {
+    fatalExit(err, 'uncaughtException');
   });
 })().catch((e: any) => {
   Sentry.captureException(e);


### PR DESCRIPTION
## Summary

Stops the infinite-respawn loop on indexing jobs that crash the worker
child via an unhandled rejection / uncaught exception. The child
worker had no process-level fatal handlers, so a silent exit left the
reservation for the parent's `worker.on('exit')` to finalize as
`'interrupted'` — which the per-job reservation cap explicitly
excludes from its count. Result: deterministic indexing crashes loop
forever without abandonment.

## Motivating incident

Staging `from-scratch-index` job 388477 (`ctse/personal/`) churned
through 43 worker child processes in 30 minutes without progress.
Every reservation closed with `completion_reason = 'interrupted'`,
never `'completed'`. The triggering crash on each cycle:

```
encountered error indexing card instance Trade/eth-to-usdc-2023.json:
  /crypto-portfolio.gts: Identifier 'AddressField' has already been declared. (59:13)
```

Trace: a `.gts` module with a duplicate top-level `export class`,
consumed by a `.json` instance that adopts from it. The host's
prerender returned the error in `renderResult.error`, `card-indexer.ts`
logged the warning and called `updateEntry` with an `instance-error`
doc — that path is fully wrapped and propagation back to pg-queue
should work. But it didn't: every reservation was `'interrupted'`, so
the silent exit must have been below the indexer.

## Changes

**`packages/realm-server/lib/finalize-child-fatal-failure.ts`** (new)
- Sibling of `finalize-orphan-reservations.ts`. Marks the worker's
  in-flight reservation with `completion_reason = 'completed'` — the
  status that the per-job cap counts. Best-effort against a damaged DB
  connection.

**`packages/realm-server/worker.ts`**
- Adds `process.on('unhandledRejection', ...)` and
  `process.on('uncaughtException', ...)`. Both log, send to Sentry,
  best-effort finalize the reservation, then `process.exit(1)`.
- Bounded by a 5-second race so a damaged DB connection can't block
  exit indefinitely — if finalize doesn't return in time we exit
  anyway and fall back to the existing parent-side `'interrupted'`
  path (same behavior as before this PR).

**`packages/realm-server/tests/indexing-test.ts`** (one new test)
- Writes a `.gts` module with a duplicate top-level export, a `.json`
  instance that adopts from it, asserts the consumer-card-side
  handling is correct (instance-error with the Babel message in its
  chain), and pins the surprising module-file-side behavior (the
  broken module lands as a healthy `file` row — fileExtract's
  metadata pass succeeds; the compile error only surfaces on the
  consumer's error doc).

## What this PR does NOT do

- Doesn't fix the surprising "broken `.gts` indexed as healthy `file`
  row" behavior the test discovered. The compilation error surfaces
  on the consumer card's error doc and the `modules` table, not the
  module's own `boxel_index` row. Whether that's a real gap or by
  design is a follow-up question.
- Doesn't recover staging job 388477 — that job is still
  `unfulfilled` and needs to be manually marked `rejected`. Once
  this lands and deploys, future jobs hitting the same crash will
  hit the cap after `MAX_RESERVATION_COUNT_PER_JOB` (currently 2) attempts and auto-reject.

## Test plan

- [x] CI: realm-server tests pass (new test asserts the regression).
- [ ] Manual repro on staging after deploy: enqueue a from-scratch
  on a realm with a known duplicate-export module, observe the
  reservation closes as `'completed'`, cap trips at 5, job goes to
  `'rejected'` with the actual error in `jobs.result`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
