### PR TITLE
ci: Move observability diff behind details

### DIFF
--- a/.github/workflows/observability-diff.yml
+++ b/.github/workflows/observability-diff.yml
@@ -238,18 +238,26 @@ jobs:
                 '',
                 `Diff truncated (${diffBytes} bytes; limit ${maxBytes}). Full diff: ${runUrl}`,
                 '',
+                '<details><summary>Show diff</summary>',
+                '',
                 '```diff',
                 truncated,
                 '```',
+                '',
+                '</details>',
               ].join('\n');
             } else {
               body = [
                 marker,
                 '## Observability diff (vs staging)',
                 '',
+                '<details><summary>Show diff</summary>',
+                '',
                 '```diff',
                 diff,
                 '```',
+                '',
+                '</details>',
                 '',
                 `_(Run: ${runUrl})_`,
               ].join('\n');

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -24,7 +24,7 @@
         }
       ]
     },
-    "description": "Top-level health view. Service-health stats use Loki log volume over the dashboard time range as a liveness proxy (CloudWatch-based ECS metrics are deferred until cluster naming is standardized). Narrow the time picker to ~5m for strict liveness; widen to surface bursty local-dev activity. Each service stat drills into the per-service dashboard; each indexing stat drills into the Indexing dashboard.",
+    "description": "Top-level health view. Service-health stats use Loki log volume over the dashboard time range as a liveness proxy (CloudWatch-based ECS metrics are deferred until cluster naming is standardized). Narrow the time picker to ~5m for strict liveness; widen to surface bursty local-dev activity. Each service stat drills into the per-service dashboard; each indexing stat drills into the Indexing dashboard. [diff-test sentinel — revert before merge]",
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -24,7 +24,7 @@
         }
       ]
     },
-    "description": "Top-level health view. Service-health stats use Loki log volume over the dashboard time range as a liveness proxy (CloudWatch-based ECS metrics are deferred until cluster naming is standardized). Narrow the time picker to ~5m for strict liveness; widen to surface bursty local-dev activity. Each service stat drills into the per-service dashboard; each indexing stat drills into the Indexing dashboard. [diff-test sentinel — revert before merge]",
+    "description": "Top-level health view. Service-health stats use Loki log volume over the dashboard time range as a liveness proxy (CloudWatch-based ECS metrics are deferred until cluster naming is standardized). Narrow the time picker to ~5m for strict liveness; widen to surface bursty local-dev activity. Each service stat drills into the per-service dashboard; each indexing stat drills into the Indexing dashboard.",
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,


### PR DESCRIPTION
The observability diff comments can be quite verbose; are they useful? If we want to keep them, this makes it optional to view them, you can see an example [here](https://github.com/cardstack/boxel/pull/4826#issuecomment-4446666558) when I added a nonsense change to a dashboard.

<img width="1553" height="23379" alt="CleanShot 2026-05-13 at 20 43 18@2x" src="https://github.com/user-attachments/assets/d8e5abb6-df12-4a0d-af14-e97738d31b6c" />
