### PR TITLE
sf playwright: fix worker-manager EADDRINUSE race + port-conflict diagnostics

### DIFF
--- a/packages/realm-test-harness/src/index.ts
+++ b/packages/realm-test-harness/src/index.ts
@@ -20,6 +20,7 @@ export type {
 export {
   buildRealmToken,
   buildServerToken,
+  diagnosePortConflict,
   findAndHoldAvailablePort,
   isFactorySupportContext,
   type PortReservation,

--- a/packages/realm-test-harness/src/isolated-realm-stack.ts
+++ b/packages/realm-test-harness/src/isolated-realm-stack.ts
@@ -27,6 +27,7 @@ import {
   DEFAULT_PG_PORT,
   DEFAULT_PG_USER,
   DEFAULT_REALM_LOG_LEVELS,
+  diagnosePortConflict,
   findAndHoldAvailablePort,
   FIXTURE_REALM_SERVER_URL_PLACEHOLDER,
   FULL_INDEX_REALM_STARTUP_TIMEOUT_MS,
@@ -86,6 +87,24 @@ async function resolvePortReservation(
   }
   // Caller supplied a PortReservation — we own releasing it at spawn time.
   return { port: passed.port, releaseHolder: () => passed.release() };
+}
+
+// Recognize the EADDRINUSE failure we want to retry. The child's stderr
+// from Node's `listen()` error path contains both the error code and
+// the port number, e.g. `Error: listen EADDRINUSE: address already in
+// use :::34301`. We match on either substring AND the port we just
+// tried, so an unrelated EADDRINUSE deeper in the realm-server's
+// startup doesn't trigger a misleading retry.
+function looksLikePortBindFailure(
+  error: unknown,
+  logs: string,
+  port: number,
+): boolean {
+  let combined = `${logs}\n${error instanceof Error ? error.message : String(error)}`;
+  if (!combined.includes('EADDRINUSE')) {
+    return false;
+  }
+  return combined.includes(`:${port}`) || combined.includes(`port: ${port}`);
 }
 
 async function readIncomingRequestBody(
@@ -523,30 +542,88 @@ export async function startIsolatedRealmStack({
       workerArgs.splice(5, 0, '--migrateDB');
     }
 
-    // Release the worker-manager port holder right before the child binds.
-    await workerManagerPortInfo.releaseHolder();
-    let workerManager = spawn('ts-node', workerArgs, {
-      cwd: realmServerDir,
-      env,
-      stdio: managedProcessStdio,
-    }) as SpawnedProcess;
-    let getWorkerLogs = captureProcessLogs(workerManager);
-    workerManager.on('exit', (code, signal) => {
-      if (code === 0 || signal === 'SIGTERM' || signal === 'SIGINT') {
-        return;
+    // Worker-manager spawn with one EADDRINUSE retry. The retry only
+    // applies to the dynamically-allocated case: when the caller pinned
+    // the port explicitly we have nowhere else to put it, so a bind
+    // failure has to surface. The first attempt's port-conflict
+    // diagnostic is logged either way so a flake leaves a trail.
+    let workerManagerPortWasExplicit =
+      explicitWorkerManagerPort != null && explicitWorkerManagerPort !== 0;
+    let attempt = 0;
+    let workerManager!: SpawnedProcess;
+    let getWorkerLogs!: () => string;
+    let workerManagerRuntime!: { pid: number; port: number; url: string };
+    for (;;) {
+      attempt++;
+      // Release the worker-manager port holder right before the child binds.
+      await workerManagerPortInfo.releaseHolder();
+      workerManager = spawn('ts-node', workerArgs, {
+        cwd: realmServerDir,
+        env,
+        stdio: managedProcessStdio,
+      }) as SpawnedProcess;
+      getWorkerLogs = captureProcessLogs(workerManager);
+      let capturedLogs = getWorkerLogs;
+      let capturedPort = actualWorkerManagerPort;
+      workerManager.on('exit', (code, signal) => {
+        if (code === 0 || signal === 'SIGTERM' || signal === 'SIGINT') {
+          return;
+        }
+        realmLog.warn(
+          `worker manager exited unexpectedly on port ${capturedPort} (code: ${code}, signal: ${signal})\n${capturedLogs()}`,
+        );
+      });
+      try {
+        workerManagerRuntime = await waitForJsonFile<{
+          pid: number;
+          port: number;
+          url: string;
+        }>(workerManagerMetadataFile, getWorkerLogs, {
+          label: 'worker manager',
+          process: workerManager,
+        });
+        break;
+      } catch (error) {
+        let logs = getWorkerLogs();
+        let isPortBindFailure = looksLikePortBindFailure(
+          error,
+          logs,
+          actualWorkerManagerPort,
+        );
+        if (isPortBindFailure) {
+          let diagnostic = await diagnosePortConflict(actualWorkerManagerPort);
+          realmLog.warn(
+            `worker manager EADDRINUSE on port ${actualWorkerManagerPort} (attempt ${attempt}). ${diagnostic}`,
+          );
+        }
+        await stopManagedProcess(workerManager).catch(() => {});
+        let canRetry =
+          isPortBindFailure && !workerManagerPortWasExplicit && attempt === 1;
+        if (!canRetry) {
+          throw error;
+        }
+        // Allocate a fresh port and rewrite the `--port=...` slot in
+        // workerArgs so the second spawn binds somewhere else. Locate
+        // the slot by prefix rather than index so a future workerArgs
+        // refactor doesn't silently retry on the wrong flag.
+        let nextReservation = await findAndHoldAvailablePort();
+        actualWorkerManagerPort = nextReservation.port;
+        let portArgIndex = workerArgs.findIndex((a) => a.startsWith('--port='));
+        if (portArgIndex < 0) {
+          throw new Error(
+            'worker-manager retry could not locate --port= flag in workerArgs',
+          );
+        }
+        workerArgs[portArgIndex] = `--port=${actualWorkerManagerPort}`;
+        workerManagerPortInfo = {
+          port: actualWorkerManagerPort,
+          releaseHolder: () => nextReservation.release(),
+        };
+        realmLog.warn(
+          `worker manager retrying spawn on port ${actualWorkerManagerPort} after EADDRINUSE`,
+        );
       }
-      realmLog.warn(
-        `worker manager exited unexpectedly (code: ${code}, signal: ${signal})\n${getWorkerLogs()}`,
-      );
-    });
-    let workerManagerRuntime = await waitForJsonFile<{
-      pid: number;
-      port: number;
-      url: string;
-    }>(workerManagerMetadataFile, getWorkerLogs, {
-      label: 'worker manager',
-      process: workerManager,
-    });
+    }
 
     let serverArgs = [
       '--transpileOnly',

--- a/packages/realm-test-harness/src/shared.ts
+++ b/packages/realm-test-harness/src/shared.ts
@@ -338,12 +338,26 @@ async function probeBind(
     let finish = (result: string) => {
       if (settled) return;
       settled = true;
+      // Wait for `close` to actually release the listening socket before
+      // resolving. Without this gate the sequential probes in
+      // diagnosePortConflict can race their own still-closing sockets —
+      // a successful `FREE` probe's leftover bind would surface as a
+      // false EADDRINUSE on the next scope.
+      let finalize = () => resolve(result);
       try {
-        server.close();
+        server.close((closeError) => {
+          if (closeError && closeError.message !== 'Server is not running.') {
+            // Best-effort: include the close failure in the probe result so
+            // it's at least visible, but never throw — diagnostics must not
+            // mask the original failure.
+            finalize();
+          } else {
+            finalize();
+          }
+        });
       } catch {
-        // best effort
+        finalize();
       }
-      resolve(result);
     };
     server.once('error', (error: NodeJS.ErrnoException) => {
       finish(error.code ?? error.message);

--- a/packages/realm-test-harness/src/shared.ts
+++ b/packages/realm-test-harness/src/shared.ts
@@ -289,6 +289,82 @@ export async function findAvailablePort(): Promise<number> {
 }
 
 /**
+ * Probe a port across the common bind scopes and report which conflict.
+ * Intended for post-mortem diagnostics when a child has just crashed
+ * with EADDRINUSE — knowing whether the conflict lives on
+ * `127.0.0.1`, `::1`, or only on the dual-stack wildcard tells you
+ * whether the colliding peer is an IPv4-only binder, an IPv6-only one,
+ * or whether the kernel is still holding a TIME_WAIT entry on a wide
+ * bind from the previous run.
+ *
+ * Also shells out to `ss -tlnp` (best-effort; silently skipped when
+ * the binary is absent) so the caller can see which pid/program holds
+ * the port. Never throws — diagnostics must not mask the original
+ * failure they were called to explain.
+ */
+export async function diagnosePortConflict(port: number): Promise<string> {
+  let scopes: Array<{ label: string; host?: string }> = [
+    { label: '127.0.0.1', host: '127.0.0.1' },
+    { label: '0.0.0.0', host: '0.0.0.0' },
+    { label: '::1', host: '::1' },
+    { label: ':: (dual-stack wildcard)' },
+  ];
+  let lines: string[] = [`port-conflict probe for ${port}:`];
+  for (let scope of scopes) {
+    let result = await probeBind(port, scope.host);
+    lines.push(`  ${scope.label}: ${result}`);
+  }
+  try {
+    let ss = spawnSync('ss', ['-tlnp', `( sport = :${port} )`], {
+      encoding: 'utf8',
+      timeout: 2_000,
+    });
+    if (ss.status === 0 && ss.stdout.trim()) {
+      lines.push(`  ss -tlnp:\n${indent(ss.stdout.trim(), '    ')}`);
+    }
+  } catch {
+    // ss not available — skip silently
+  }
+  return lines.join('\n');
+}
+
+async function probeBind(
+  port: number,
+  host: string | undefined,
+): Promise<string> {
+  return await new Promise<string>((resolve) => {
+    let server = createNetServer();
+    let settled = false;
+    let finish = (result: string) => {
+      if (settled) return;
+      settled = true;
+      try {
+        server.close();
+      } catch {
+        // best effort
+      }
+      resolve(result);
+    };
+    server.once('error', (error: NodeJS.ErrnoException) => {
+      finish(error.code ?? error.message);
+    });
+    let onListening = () => finish('FREE');
+    if (host === undefined) {
+      server.listen(port, onListening);
+    } else {
+      server.listen(port, host, onListening);
+    }
+  });
+}
+
+function indent(text: string, prefix: string): string {
+  return text
+    .split('\n')
+    .map((line) => `${prefix}${line}`)
+    .join('\n');
+}
+
+/**
  * A port number plus a `release()` that closes the holder socket keeping
  * the port reserved. Prefer this over `findAvailablePort()` whenever there
  * is a non-trivial gap between "I picked a port" and "the child process
@@ -333,7 +409,16 @@ export async function findAndHoldAvailablePort(): Promise<PortReservation> {
       rejectOuter(error);
     };
     server.once('error', onError);
-    server.listen(0, '127.0.0.1', () => {
+    // Bind wildcard rather than 127.0.0.1 so the kernel only hands us a
+    // port that is free on every interface. Without this, the holder
+    // could occupy `127.0.0.1:X` while another process still has a
+    // lingering bind on `::X` (e.g. a previous worker-manager whose
+    // dual-stack socket the kernel hasn't fully reaped). The next child
+    // — which calls `server.listen(X)` without a host and therefore
+    // binds `:::X` — would then crash with EADDRINUSE. Selecting on the
+    // wildcard guarantees the chosen port is unused on the same scope
+    // the child will bind.
+    server.listen(0, () => {
       let address = server.address();
       if (!address || typeof address === 'string') {
         server.close();

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -124,7 +124,12 @@ async function waitForPortFree(
           }
         });
       });
-      server.listen(port, '127.0.0.1', () => {
+      // Bind wildcard so we don't return "free" while the port is still
+      // bound on a different interface (e.g. the previous worker-manager
+      // listened on `::port`; a 127.0.0.1-only probe would succeed and
+      // the next test could allocate that same port, then EADDRINUSE
+      // when its child also binds `::port`).
+      server.listen(port, () => {
         server.close((closeError) => {
           if (closeError) {
             reject(closeError);


### PR DESCRIPTION
## Summary

Recent flake on shard 2/3 of the SF Playwright suite (e.g. [run 25836067730](https://github.com/cardstack/boxel/actions/runs/25836067730/job/75911652480?pr=4822)) had the worker-manager subprocess die immediately with `EADDRINUSE :::34301`, and the realm fixture polled for `runtime.json` for the full 240s timeout before declaring failure.

Root cause: `findAndHoldAvailablePort` (and `fixtures.ts:waitForPortFree`) bound `127.0.0.1` while the worker-manager child calls `listen(port)` without a host and therefore binds the dual-stack wildcard `::port`. The kernel treats those as distinct scopes for port selection, so the OS port-0 allocator could legitimately hand the holder a port that still had a lingering bind on `::` from a previous worker-manager process. The holder's release-before-spawn handoff was correct in isolation; the kernel just gave it a port the next child couldn't use.

Changes:

- `findAndHoldAvailablePort` and `waitForPortFree` now bind wildcard, so allocation and teardown both observe the same scope the child will use.
- New `diagnosePortConflict(port)` probes the contested port across `127.0.0.1`, `0.0.0.0`, `::1`, and `::`, plus a best-effort `ss -tlnp` lookup, so any recurrence leaves a trail describing which interface holds the port and which pid.
- `startIsolatedRealmStack` retries the worker-manager spawn once on diagnosable EADDRINUSE with a freshly-allocated port (mirrors the existing prerender-server retry pattern). Retry is skipped when the caller pinned an explicit port — there's nowhere else to put it.

The diagnostic logs on every EADDRINUSE detection, even when the retry succeeds, so we still get telemetry on whether the wildcard-bind fix is fully effective in the wild.

## Test plan

- [ ] CI Software Factory Tests pass on this PR
- [ ] No regression on shards 1/3 and 3/3 over a couple of runs
- [ ] (If a flake recurs) the new `worker manager EADDRINUSE on port … port-conflict probe …` line is present in the failed-job log