### PR TITLE
CS-11145: regression test guarding relativizeDocument's primary-resource round-trip

### DIFF
--- a/packages/realm-server/tests/card-reference-resolver-test.ts
+++ b/packages/realm-server/tests/card-reference-resolver-test.ts
@@ -223,6 +223,47 @@ module(basename(__filename), function () {
       );
     });
 
+    // CS-11145: catalog Listings have a thumbnail relationship like
+    // `cardInfo.cardThumbnail.links.self = "../ListingThumbnails/foo.png"`.
+    // The relationship is stored on the primary card resource, so a round trip
+    // through `relativizeDocument` and back through `resolveCardReference`
+    // against the card's own URL must yield the original absolute URL.
+    test('round-trips a relationship link relative to a deep card path', async function (assert) {
+      let cardURL = 'http://test-host/my-realm/room-XYZ/CardListing/listing-1';
+      let doc: SingleCardDocument = {
+        data: {
+          id: rri(cardURL),
+          type: 'card' as const,
+          attributes: { name: 'Listing' },
+          relationships: {
+            'cardInfo.cardThumbnail': {
+              links: {
+                self: '../ListingThumbnails/foo.png',
+              },
+            },
+          },
+          links: { self: cardURL },
+          meta: {
+            adoptsFrom: {
+              module: rri('../listing'),
+              name: 'CardListing',
+            },
+          },
+        },
+      };
+
+      let realmURL = new URL('http://test-host/my-realm/');
+      relativizeDocument(doc, realmURL);
+
+      let rel = doc.data.relationships?.['cardInfo.cardThumbnail'] as any;
+      let resolved = resolveCardReference(rel.links.self, cardURL);
+      assert.strictEqual(
+        resolved,
+        'http://test-host/my-realm/room-XYZ/ListingThumbnails/foo.png',
+        'round-trip resolves to the original absolute URL (not a doubled path)',
+      );
+    });
+
     test('succeeds when resource ID is a regular URL', async function (assert) {
       let doc: SingleCardDocument = {
         data: {


### PR DESCRIPTION
## Summary

Investigation update for the catalog-thumbnail doubled-path 404s. Adds a focused regression test confirming the primary-resource path through `relativizeDocument` is symmetric for the production scenario (a CardListing with `cardInfo.cardThumbnail.links.self = "../ListingThumbnails/foo.png"`). **This PR is not a fix** — it captures a working baseline so we don't accidentally regress the symmetric path while hunting for the real source of the doubling.

Linear: [CS-11145](https://linear.app/cardstack/issue/CS-11145) (description updated with the deeper findings).

## What we learned

The original ticket pointed at `generate-thumbnail.ts:236` and then `relativizeResource`. Both turn out to be fine for the primary-resource path:

- On-disk Listing card JSONs store `links.self` correctly as `"../ListingThumbnails/foo.png"`.
- The new test runs that through `relativizeDocument` + `resolveCardReference` and gets back the right absolute URL.

The bug must live in one of: the included-resource path in `relativizeResource`, the host's consumer-side resolution in `store.ts:loadRelationshipInstance`, or a URL written into the prerendered HTML that then resolves wrong client-side. The path-arithmetic test `new URL('./room-XYZ/ListingThumbnails/foo.png', '/catalog/room-XYZ/ListingThumbnails/file.json').href` reproduces the exact doubled URL, so the open question is *where* such a base + rel pair gets constructed.

## Next steps (out of this PR)

Local repro of `catalog:update`, then dump `boxel_index.html_format` for an affected CardListing. The literal `<img src=...>` value will tell us whether the bug is at HTML-bake time (may even be fixed by [CS-11146](https://linear.app/cardstack/issue/CS-11146) Mode B's `<base href>`) or at source-fetch time in `file-def-manager`.

## Files

- `packages/realm-server/tests/card-reference-resolver-test.ts` — one new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)