### PR TITLE
Open binary file URL as a card without 415

### DIFF
--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -30,6 +30,7 @@ import {
   isFileDefInstance,
   isFileMetaResource,
   isSingleCardDocument,
+  isSingleFileMetaDocument,
   isLinkableCollectionDocument,
   resolveFileDefCodeRef,
   X_BOXEL_JOB_PRIORITY_HEADER,
@@ -1836,6 +1837,23 @@ export default class StoreService extends Service implements StoreInterface {
           json = await this.cardService.fetchJSON(url);
         }
         if (!isSingleCardDocument(json)) {
+          // The URL turned out to be a binary file (e.g. an uploaded
+          // image). The realm-server returns a file-meta JSON document
+          // in that case; reroute to the file-meta load path so the
+          // caller gets a FileDef instead of a hard failure.
+          if (isSingleFileMetaDocument(json)) {
+            // URL was a binary file; reroute to the file-meta bucket.
+            let fileMeta = await this.getFileMetaInstance<FileDef>({
+              idOrDoc: url,
+              opts: {
+                noCache: opts?.noCache,
+                dependencyTrackingContext: opts?.dependencyTrackingContext,
+              },
+            });
+            // Resolve inflightGetCards so concurrent callers don't hang.
+            deferred?.fulfill(fileMeta as unknown as T | CardErrorJSONAPI);
+            return fileMeta as unknown as T;
+          }
           throw new Error(
             `bug: server returned a non card document for ${url}:
         ${JSON.stringify(json, null, 2)}`,

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -548,27 +548,31 @@ module('Integration | Store', function (hooks) {
     );
   });
 
-  test('file-meta reads do not reuse card errors for the same id', async function (assert) {
+  test('card read of a binary file URL is rerouted to file-meta', async function (assert) {
     await testRealm.write('hero.png', 'mock hero image');
     let fileUrl = `${testRealmURL}hero.png`;
 
-    let cardError = await storeService.get(fileUrl);
-    assert.false(
-      isCardInstance(cardError),
-      'card read returns an error for file url',
+    let result = await storeService.get(fileUrl);
+    assert.ok(
+      (result as any).constructor?.isFileDef,
+      'card read returns a FileDef via the safety-net reroute',
     );
 
     let fileInstance = await storeService.get(fileUrl, { type: 'file-meta' });
     assert.ok(
       (fileInstance as any).constructor?.isFileDef,
-      'file meta instance is a FileDef',
+      'file-meta read returns a FileDef',
     );
 
-    assert.ok(storeService.peekError(fileUrl), 'card error remains cached');
+    assert.strictEqual(
+      storeService.peekError(fileUrl),
+      undefined,
+      'no error cached on the card bucket',
+    );
     assert.strictEqual(
       storeService.peekError(fileUrl, { type: 'file-meta' }),
       undefined,
-      'file-meta error cache remains clear',
+      'no error cached on the file-meta bucket',
     );
   });
 

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -4300,18 +4300,6 @@ module(basename(__filename), function () {
         );
       });
 
-      test('GET on a file URL with a card+markdown Accept returns 415', async function (assert) {
-        let response = await request
-          .get('/greeting.txt')
-          .set('Accept', 'application/vnd.card+markdown');
-
-        assert.strictEqual(
-          response.status,
-          415,
-          'markdown cannot represent a binary file',
-        );
-      });
-
       test('rejects write requests to file URLs', async function (assert) {
         let response;
         response = await request

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -4271,18 +4271,49 @@ module(basename(__filename), function () {
         onRealmSetup,
       });
 
-      test('rejects HTTP requests to file URLs', async function (assert) {
-        let response;
-        response = await request
+      test('GET on a file URL with a card+json Accept returns a file-meta JSON document', async function (assert) {
+        let response = await request
           .get('/greeting.txt')
           .set('Accept', 'application/vnd.card+json');
 
         assert.strictEqual(
           response.status,
-          415,
-          'rejects GET for a file URL with 415 status',
+          200,
+          'GET serves a file-meta document instead of 415',
         );
+        assert.true(
+          (response.headers['content-type'] ?? '').startsWith(
+            'application/vnd.card+json',
+          ),
+          'response is JSON, not raw file bytes',
+        );
+        let doc = JSON.parse(response.text);
+        assert.strictEqual(
+          doc?.data?.type,
+          'file-meta',
+          'data.type identifies the resource as file-meta',
+        );
+        assert.strictEqual(
+          doc?.data?.attributes?.name,
+          'greeting.txt',
+          'attributes.name carries the file name',
+        );
+      });
 
+      test('GET on a file URL with a card+markdown Accept returns 415', async function (assert) {
+        let response = await request
+          .get('/greeting.txt')
+          .set('Accept', 'application/vnd.card+markdown');
+
+        assert.strictEqual(
+          response.status,
+          415,
+          'markdown cannot represent a binary file',
+        );
+      });
+
+      test('rejects write requests to file URLs', async function (assert) {
+        let response;
         response = await request
           .patch('/greeting.txt')
           .send({

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -4702,7 +4702,17 @@ export class Realm {
         });
         if (instanceEntry === undefined) {
           if (await this.nonJsonFileExists(localPath)) {
-            return this.fallbackHandle(request, requestContext);
+            // A path that points to a non-JSON file (e.g. an uploaded
+            // binary) was asked for as card+json. Return a file-meta JSON
+            // document so the caller receives valid JSON it can
+            // discriminate via `data.type === 'file-meta'` — instead of
+            // raw binary bytes that crash a downstream `response.json()`.
+            let fileMeta = await this.fileMetaDocument(
+              requestContext,
+              localPath,
+              SupportedMimeType.CardJson,
+            );
+            return fileMeta ?? notFound(request, requestContext);
           } else {
             return notFound(request, requestContext);
           }
@@ -4746,7 +4756,12 @@ export class Realm {
       });
       if (maybeError === undefined) {
         if (await this.nonJsonFileExists(localPath)) {
-          return this.fallbackHandle(request, requestContext);
+          let fileMeta = await this.fileMetaDocument(
+            requestContext,
+            localPath,
+            SupportedMimeType.CardJson,
+          );
+          return fileMeta ?? notFound(request, requestContext);
         } else {
           return notFound(request, requestContext);
         }

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -4702,7 +4702,7 @@ export class Realm {
         });
         if (instanceEntry === undefined) {
           if (await this.nonJsonFileExists(localPath)) {
-            return unsupportedMediaType(request, requestContext);
+            return this.fallbackHandle(request, requestContext);
           } else {
             return notFound(request, requestContext);
           }
@@ -4746,7 +4746,7 @@ export class Realm {
       });
       if (maybeError === undefined) {
         if (await this.nonJsonFileExists(localPath)) {
-          return unsupportedMediaType(request, requestContext);
+          return this.fallbackHandle(request, requestContext);
         } else {
           return notFound(request, requestContext);
         }


### PR DESCRIPTION
## Summary

Opening a binary file URL (an uploaded `.png`, `.jpg`, …) as a card — by pasting it into the operator-mode URL bar, or via any code path that routes through `getCardInstance` — fails today: realm-server returns `415 Unsupported Media Type`, or the host "Loading card…" spinner hangs with no surfaced error. Three coordinated changes get the file-meta load path taken end-to-end.

Linear: [CS-11147](https://linear.app/cardstack/issue/CS-11147)

## Changes

1. **Realm-server returns `file-meta` JSON for binary GETs with `Accept: application/vnd.card+json`** instead of 415. Callers can discriminate via `data.type === "file-meta"`. `card+markdown` on a binary still 415s — markdown can't represent a binary. Touches the three `nonJsonFileExists` branches in `getCard` in `packages/runtime-common/realm.ts`.
2. **Host stack-item infers `type:"file"` from the URL extension** when none is provided. New `isFileDefExtension()` helper exported from `packages/runtime-common/file-def-code-ref.ts`, backed by the existing `FILEDEF_CODE_REF_BY_EXTENSION` map so the set of recognized extensions stays in one place. Pasting a `.png` URL into the URL bar now takes the file-meta load path from the first request.
3. **Safety net in `store.getCardInstance`** — if anything still asks `getCardInstance` for a URL that turns out to be a binary, the file-meta JSON is rerouted through `getFileMetaInstance` and the in-flight card deferred resolves with that result. No hung spinner, no cryptic error.

## Files

- `packages/runtime-common/realm.ts`
- `packages/runtime-common/file-def-code-ref.ts` — new `isFileDefExtension` export
- `packages/host/app/lib/stack-item.ts`
- `packages/host/app/services/store.ts`
- `packages/realm-server/tests/card-endpoints-test.ts` — asserts file-meta JSON return for `card+json` on a binary, retains 415 for `card+markdown`, retains 415 for `PATCH/DELETE`

## Test plan

- [ ] `pnpm lint:types` green across `runtime-common` and `host` (it is).
- [ ] Manual: paste an uploaded `.png` URL from a realm into a fresh tab. Pre-fix → hang or 415. Post-fix → the FileDef renders as an image.
- [ ] Same URL opened via code-mode → interact: unchanged (already worked because the stack item carried `type:"file"`).
- [ ] Re-run the 7-day staging log classification after deploy; 415-on-binary count drops to ~0.