### PR TITLE
CS-11152: fix catalog remix — resolve scoped prefixes in fetcher

### DIFF
--- a/packages/host/tests/unit/fetcher-test.ts
+++ b/packages/host/tests/unit/fetcher-test.ts
@@ -2,6 +2,8 @@ import { module, test } from 'qunit';
 
 import {
   fetcher,
+  registerCardReferencePrefix,
+  unregisterCardReferencePrefix,
   type FetcherMiddlewareHandler,
 } from '@cardstack/runtime-common';
 
@@ -84,6 +86,27 @@ module('Unit | fetcher', function () {
     assert.strictEqual(attempts, 2, 'second attempt reached fetch impl');
     assert.strictEqual(response.status, 200);
     assert.strictEqual(await response.text(), 'OK');
+  });
+
+  test('resolves a registered scoped prefix before constructing the Request', async function (assert) {
+    assert.expect(1);
+    registerCardReferencePrefix(
+      '@cardstack/catalog/',
+      'https://app.example.com/catalog/',
+    );
+    try {
+      let fetch = fetcher(async function (request) {
+        assert.strictEqual(
+          (request as Request).url,
+          'https://app.example.com/catalog/Foo/abc',
+          'scoped id is resolved to its real URL, not joined onto document.baseURI',
+        );
+        return new Response('OK', { status: 200 });
+      }, []);
+      await fetch('@cardstack/catalog/Foo/abc');
+    } finally {
+      unregisterCardReferencePrefix('@cardstack/catalog/');
+    }
   });
 
   test('handler can call next more than once if needed', async function (assert) {

--- a/packages/runtime-common/fetcher.ts
+++ b/packages/runtime-common/fetcher.ts
@@ -1,3 +1,8 @@
+import {
+  isRegisteredPrefix,
+  resolveCardReference,
+} from './card-reference-resolver';
+
 export type FetcherMiddlewareHandler = (
   req: Request,
   next: (onwardReq: Request) => Promise<Response>,
@@ -20,6 +25,15 @@ export function fetcher(
         }
         return await simulateNetworkBehaviors(onwardReq, response, instance);
       };
+    }
+
+    // Resolve scoped identifiers (e.g. `@cardstack/catalog/...`) before
+    // `new Request(...)` would resolve them against `document.baseURI`
+    // and produce a literal `https://<origin>/@cardstack/catalog/...` URL.
+    // Mirrors VirtualNetwork.fetch — but every authedFetch caller funnels
+    // through fetcher first, so the resolution has to happen here too.
+    if (typeof urlOrRequest === 'string' && isRegisteredPrefix(urlOrRequest)) {
+      urlOrRequest = resolveCardReference(urlOrRequest, undefined);
     }
 
     let request =


### PR DESCRIPTION
## Summary
- Catalog remix and other `authedFetch` calls against scoped card ids (`@cardstack/catalog/...`) were failing with 404 on `https://app.boxel.ai/@cardstack/catalog/<rest>`.
- Root cause: [`fetcher.ts`](../blob/cs-11152-fail-to-remix/packages/runtime-common/fetcher.ts) wraps string inputs in `new Request(string)` before any prefix resolution. `new Request` joins the string against `document.baseURI`, producing the broken URL. `VirtualNetwork.fetch` resolves scoped strings, but it's inside the chain — every `authedFetch` caller passes through `fetcher` first.
- Fix: resolve registered scoped prefixes (`isRegisteredPrefix` / `resolveCardReference`) before the `new Request` step in `fetcher`, mirroring `VirtualNetwork.fetch`.

Trigger from the user's stack: `CardOrFieldListingAdapter.remix` → `RemixCommand` → `ListingInstallCommand` → `FetchCardJsonCommand({ cardIdentifier: sourceCard.id })` where `sourceCard.id` is already in scoped form because the indexer rewrites instance URLs via `unresolveResourceInstanceURLs` (card-indexer.ts:81) for portability.

Linear: https://linear.app/cardstack/issue/CS-11152/fail-to-remix

## Test plan
- [x] New unit test `Unit | fetcher > resolves a registered scoped prefix before constructing the Request` passes (`pnpm test:ember --filter "Unit | fetcher"` in `packages/host`).
- [x] Deployed reproduction (Remix on a catalog listing — Mortgage Calculator / Wine Cellar Card Definition) no longer 404s.
- [ ] Existing fetcher unit tests still pass (no regression in URL/redirect/retry/middleware paths).
- [ ] Existing `auth-error-guard-test` and `index-query-engine-test` paths still pass (they construct `fetcher(virtualNetwork.fetch, ...)`).

Before Fix - Remix failed 
<img width="1054" height="330" alt="Screenshot 2026-05-15 at 12 34 45 AM" src="https://github.com/user-attachments/assets/a67248d1-6e5e-4f08-82ed-eaf202b0cb77" />
After Fix
<img width="2139" height="938" alt="Screenshot 2026-05-15 at 1 00 24 AM" src="https://github.com/user-attachments/assets/255fe0be-6d55-4806-a939-4e2b3a536d0f" />
