### PR TITLE
simplify host ember-cli-build.js

### DIFF
--- a/packages/host/babel.config.cjs
+++ b/packages/host/babel.config.cjs
@@ -28,6 +28,7 @@ module.exports = {
         ],
       },
     ],
+    'ember-concurrency/async-arrow-task-transform',
     [
       'module:decorator-transforms',
       {

--- a/packages/host/ember-cli-build.js
+++ b/packages/host/ember-cli-build.js
@@ -7,17 +7,10 @@ module.exports = async function (defaults) {
 
   const app = new EmberApp(defaults, {
     'ember-cli-babel': {
-      enableTypeScriptTransform: true,
       disableDecoratorTransforms: true,
-    },
-    babel: {
-      plugins: [
-        require.resolve('ember-concurrency/async-arrow-task-transform'),
-      ],
     },
   });
   return compatBuild(app, buildOnce, {
-    staticInvokables: true,
     staticAppPaths: ['lib'],
   });
 };


### PR DESCRIPTION
- manage babel plugins in the actual babel.config.cjs
- staticInvokables: true is the default now