### PR TITLE
CS-11141: Allow X-Grafana-Device-Id in realm-server CORS preflight

### DIFF
--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -193,7 +193,7 @@ export class RealmServer {
         cors({
           origin: '*',
           allowHeaders:
-            'Authorization, Content-Type, If-Match, If-None-Match, X-Requested-With, X-Boxel-Client-Request-Id, X-Boxel-Assume-User, X-HTTP-Method-Override, X-Boxel-Disable-Module-Cache, X-Filename, X-Boxel-During-Prerender, X-Boxel-Consuming-Realm, X-Boxel-Job-Id',
+            'Authorization, Content-Type, If-Match, If-None-Match, X-Requested-With, X-Boxel-Client-Request-Id, X-Boxel-Assume-User, X-HTTP-Method-Override, X-Boxel-Disable-Module-Cache, X-Filename, X-Boxel-During-Prerender, X-Boxel-Consuming-Realm, X-Boxel-Job-Id, X-Grafana-Device-Id',
           allowMethods: 'GET,HEAD,PUT,POST,DELETE,PATCH,OPTIONS,QUERY',
           // Cache the preflight response for 24 h. Without this @koa/cors
           // omits Access-Control-Max-Age and Chrome falls back to its


### PR DESCRIPTION
## Summary
- Grafana auto-attaches `X-Grafana-Device-Id` to button-panel POSTs. Chrome was rejecting the preflight for `_grafana-complete-job` (and the other `_grafana-*` operator actions) because that header was not in `Access-Control-Allow-Headers`.
- Added `X-Grafana-Device-Id` to the `@koa/cors` `allowHeaders` list in `packages/realm-server/server.ts`.

Fixes [CS-11141](https://linear.app/cardstack/issue/CS-11141/error-trying-to-delete-a-job-from-grafana).

## Test plan
- [ ] On staging, open Grafana → Job Queue dashboard, click the "complete job" action on a row, and confirm the request succeeds (no CORS error in DevTools network tab).
- [ ] Spot-check that the other `_grafana-*` operator actions (reindex, full-reindex, add-credit, upsert-realm-user-permission) still work from their button panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)