### PR TITLE
Add cancel button for active indexing jobs (CS-11135)

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/indexing.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/indexing.json
@@ -718,8 +718,57 @@
               },
               "properties": [
                 {
-                  "id": "custom.hidden",
-                  "value": true
+                  "id": "actions",
+                  "value": [
+                    {
+                      "type": "fetch",
+                      "title": "Cancel reservation ${__value.raw}",
+                      "fetch": {
+                        "method": "POST",
+                        "url": "${realm_server}_grafana-complete-job",
+                        "queryParams": [
+                          [
+                            "reservation_id",
+                            "${__value.raw}"
+                          ]
+                        ],
+                        "headers": [
+                          [
+                            "Authorization",
+                            "Bearer ${grafana_secret}"
+                          ]
+                        ],
+                        "body": ""
+                      },
+                      "confirmation": "Cancel running indexing job (reservation ${__value.raw})? The worker will stop processing it.",
+                      "oneClick": false
+                    }
+                  ]
+                },
+                {
+                  "id": "mappings",
+                  "value": [
+                    {
+                      "options": {
+                        "from": 0,
+                        "result": {
+                          "color": "red",
+                          "index": 0,
+                          "text": "Cancel"
+                        },
+                        "to": 9999999999999
+                      },
+                      "type": "range"
+                    }
+                  ]
+                },
+                {
+                  "id": "displayName",
+                  "value": "Action"
+                },
+                {
+                  "id": "custom.filterable",
+                  "value": false
                 }
               ]
             },


### PR DESCRIPTION
- [ ] Relies on #4835 

## Summary
- Adds a per-row **Cancel** action on the Active Indexing panel (`indexing.json`) for currently-running indexing jobs.
- The button POSTs to the existing `_grafana-complete-job` endpoint with the row's `reservation_id`; the handler (`handle-remove-job.ts`) already resolves it via `findJobIdForReservationId` and calls `forceCancelJobById`. No server-side change required.
- Mirrors the existing **Cancel running reservation** pattern in `job-queue.json`'s Running Jobs panel, so all the auth + confirmation plumbing matches what we ship today.

Linear: [CS-11135](https://linear.app/cardstack/issue/CS-11135/add-button-to-cancel-active-indexing-job-in-grafana)

## Test plan
- [ ] Apply dashboards locally (`packages/observability/scripts/apply.sh` against a local Grafana) and confirm the Active Indexing panel renders a red **Cancel** cell instead of a hidden column.
- [ ] Start an indexing job locally, click **Cancel**, confirm the prompt, and verify the row disappears and the job is marked `rejected` (`result.status = 418`) with `finished_at` set.
- [ ] Verify no regression on the Running Jobs panel in `job-queue.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)