### PR TITLE
Grafana: fix Overview Tasks panels showing "No data"

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -1146,6 +1146,7 @@
             "period": "",
             "region": "default",
             "refId": "A",
+            "id": "a",
             "hide": true
           },
           {
@@ -1165,6 +1166,7 @@
             "period": "",
             "region": "default",
             "refId": "B",
+            "id": "b",
             "hide": true
           },
           {
@@ -1172,7 +1174,7 @@
               "type": "cloudwatch",
               "uid": "cef5x9o3yzawwf"
             },
-            "expression": "A + B/100",
+            "expression": "a + b/100",
             "metricQueryType": 0,
             "metricEditorMode": 1,
             "namespace": "",
@@ -1446,6 +1448,7 @@
             "period": "",
             "region": "default",
             "refId": "A",
+            "id": "a",
             "hide": true
           },
           {
@@ -1465,6 +1468,7 @@
             "period": "",
             "region": "default",
             "refId": "B",
+            "id": "b",
             "hide": true
           },
           {
@@ -1472,7 +1476,7 @@
               "type": "cloudwatch",
               "uid": "cef5x9o3yzawwf"
             },
-            "expression": "A + B/100",
+            "expression": "a + b/100",
             "metricQueryType": 0,
             "metricEditorMode": 1,
             "namespace": "",
@@ -1746,6 +1750,7 @@
             "period": "",
             "region": "default",
             "refId": "A",
+            "id": "a",
             "hide": true
           },
           {
@@ -1765,6 +1770,7 @@
             "period": "",
             "region": "default",
             "refId": "B",
+            "id": "b",
             "hide": true
           },
           {
@@ -1772,7 +1778,7 @@
               "type": "cloudwatch",
               "uid": "cef5x9o3yzawwf"
             },
-            "expression": "A + B/100",
+            "expression": "a + b/100",
             "metricQueryType": 0,
             "metricEditorMode": 1,
             "namespace": "",
@@ -2046,6 +2052,7 @@
             "period": "",
             "region": "default",
             "refId": "A",
+            "id": "a",
             "hide": true
           },
           {
@@ -2065,6 +2072,7 @@
             "period": "",
             "region": "default",
             "refId": "B",
+            "id": "b",
             "hide": true
           },
           {
@@ -2072,7 +2080,7 @@
               "type": "cloudwatch",
               "uid": "cef5x9o3yzawwf"
             },
-            "expression": "A + B/100",
+            "expression": "a + b/100",
             "metricQueryType": 0,
             "metricEditorMode": 1,
             "namespace": "",

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -1132,7 +1132,7 @@
           "orientation": "horizontal",
           "reduceOptions": {
             "calcs": ["lastNotNull"],
-            "fields": "Value",
+            "fields": "e1",
             "values": false
           },
           "textMode": "value",
@@ -1459,7 +1459,7 @@
           "orientation": "horizontal",
           "reduceOptions": {
             "calcs": ["lastNotNull"],
-            "fields": "Value",
+            "fields": "e1",
             "values": false
           },
           "textMode": "value",
@@ -1786,7 +1786,7 @@
           "orientation": "horizontal",
           "reduceOptions": {
             "calcs": ["lastNotNull"],
-            "fields": "Value",
+            "fields": "e1",
             "values": false
           },
           "textMode": "value",
@@ -2113,7 +2113,7 @@
           "orientation": "horizontal",
           "reduceOptions": {
             "calcs": ["lastNotNull"],
-            "fields": "Value",
+            "fields": "e1",
             "values": false
           },
           "textMode": "value",

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -1083,9 +1083,20 @@
               {
                 "type": "regex",
                 "options": {
+                  "pattern": "^0\\.0*(\\d+)$",
+                  "result": {
+                    "text": "0 / $1",
+                    "color": "red"
+                  }
+                }
+              },
+              {
+                "type": "regex",
+                "options": {
                   "pattern": "^(\\d+)\\.0*(\\d+)$",
                   "result": {
-                    "text": "$1 / $2"
+                    "text": "$1 / $2",
+                    "color": "green"
                   }
                 }
               }
@@ -1185,6 +1196,20 @@
             "region": "default",
             "refId": "e1",
             "id": "e1"
+          }
+        ],
+        "transformations": [
+          {
+            "id": "convertFieldType",
+            "options": {
+              "fields": {},
+              "conversions": [
+                {
+                  "targetField": "Value",
+                  "destinationType": "string"
+                }
+              ]
+            }
           }
         ],
         "title": "Tasks",
@@ -1385,9 +1410,20 @@
               {
                 "type": "regex",
                 "options": {
+                  "pattern": "^0\\.0*(\\d+)$",
+                  "result": {
+                    "text": "0 / $1",
+                    "color": "red"
+                  }
+                }
+              },
+              {
+                "type": "regex",
+                "options": {
                   "pattern": "^(\\d+)\\.0*(\\d+)$",
                   "result": {
-                    "text": "$1 / $2"
+                    "text": "$1 / $2",
+                    "color": "green"
                   }
                 }
               }
@@ -1487,6 +1523,20 @@
             "region": "default",
             "refId": "e1",
             "id": "e1"
+          }
+        ],
+        "transformations": [
+          {
+            "id": "convertFieldType",
+            "options": {
+              "fields": {},
+              "conversions": [
+                {
+                  "targetField": "Value",
+                  "destinationType": "string"
+                }
+              ]
+            }
           }
         ],
         "title": "Tasks",
@@ -1687,9 +1737,20 @@
               {
                 "type": "regex",
                 "options": {
+                  "pattern": "^0\\.0*(\\d+)$",
+                  "result": {
+                    "text": "0 / $1",
+                    "color": "red"
+                  }
+                }
+              },
+              {
+                "type": "regex",
+                "options": {
                   "pattern": "^(\\d+)\\.0*(\\d+)$",
                   "result": {
-                    "text": "$1 / $2"
+                    "text": "$1 / $2",
+                    "color": "green"
                   }
                 }
               }
@@ -1789,6 +1850,20 @@
             "region": "default",
             "refId": "e1",
             "id": "e1"
+          }
+        ],
+        "transformations": [
+          {
+            "id": "convertFieldType",
+            "options": {
+              "fields": {},
+              "conversions": [
+                {
+                  "targetField": "Value",
+                  "destinationType": "string"
+                }
+              ]
+            }
           }
         ],
         "title": "Tasks",
@@ -1989,9 +2064,20 @@
               {
                 "type": "regex",
                 "options": {
+                  "pattern": "^0\\.0*(\\d+)$",
+                  "result": {
+                    "text": "0 / $1",
+                    "color": "red"
+                  }
+                }
+              },
+              {
+                "type": "regex",
+                "options": {
                   "pattern": "^(\\d+)\\.0*(\\d+)$",
                   "result": {
-                    "text": "$1 / $2"
+                    "text": "$1 / $2",
+                    "color": "green"
                   }
                 }
               }
@@ -2091,6 +2177,20 @@
             "region": "default",
             "refId": "e1",
             "id": "e1"
+          }
+        ],
+        "transformations": [
+          {
+            "id": "convertFieldType",
+            "options": {
+              "fields": {},
+              "conversions": [
+                {
+                  "targetField": "Value",
+                  "destinationType": "string"
+                }
+              ]
+            }
           }
         ],
         "title": "Tasks",

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -1132,7 +1132,7 @@
           "orientation": "horizontal",
           "reduceOptions": {
             "calcs": ["lastNotNull"],
-            "fields": "",
+            "fields": "Value",
             "values": false
           },
           "textMode": "value",
@@ -1459,7 +1459,7 @@
           "orientation": "horizontal",
           "reduceOptions": {
             "calcs": ["lastNotNull"],
-            "fields": "",
+            "fields": "Value",
             "values": false
           },
           "textMode": "value",
@@ -1786,7 +1786,7 @@
           "orientation": "horizontal",
           "reduceOptions": {
             "calcs": ["lastNotNull"],
-            "fields": "",
+            "fields": "Value",
             "values": false
           },
           "textMode": "value",
@@ -2113,7 +2113,7 @@
           "orientation": "horizontal",
           "reduceOptions": {
             "calcs": ["lastNotNull"],
-            "fields": "",
+            "fields": "Value",
             "values": false
           },
           "textMode": "value",


### PR DESCRIPTION
## Summary

- All four service Tasks panels on the Overview dashboard (Realm Server, Prerender, Prerender Mgr, Worker) currently show "No data" on staging despite Container Insights publishing both `RunningTaskCount` and `DesiredTaskCount` for each service.
- Root cause is a Grafana CloudWatch quirk introduced by the recent regex-map rendering approach (#4814): Grafana auto-prefixes uppercase refIds when calling AWS (`refId "A"` → AWS Id `queryA`, since AWS validates `^[a-z][a-zA-Z0-9_]*$`), but it sends the math `expression` string verbatim. So the expression `"A + B/100"` references undefined ids — CloudWatch errors silently — panel shows "No data". See `pkg/tsdb/cloudwatch/models/cloudwatch_query.go` ~L456-468 in `grafana/grafana`.
- Fix: pin the metric targets to explicit lowercase `"id": "a"` / `"id": "b"` (this bypasses Grafana's auto-prefix) and lowercase the expression to `"a + b/100"`. The user-visible `refId` stays `"A"`/`"B"` so the Grafana query editor remains readable.

## Verification

Verified against staging via direct `cloudwatch get-metric-data` that the math `a + b/100` returns `1.01` (Run=1, Need=1) and that the underlying metrics are flowing — only the dashboard's pre-fix expression was failing.

## Test plan

- [ ] Merge → `observability-apply-staging` workflow runs (typically ~1 min).
- [ ] Open Overview dashboard on grafana-staging.stack.cards and confirm all four service Tasks panels render "1 / 1" (or whatever Run / Need actually is) instead of "No data".
- [ ] Click "Need" tile inheritance: with `decimals: 2` and the regex map `^(\d+)\.0*(\d+)$` → `$1 / $2`, value `1.01` formats as `1 / 1`; thresholds remain green when Run ≥ 1, red when Run = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)