### PR TITLE
CS-11156: cross-replica clearLocalCaches broadcast via NOTIFY

### DIFF
--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -240,17 +240,17 @@ module('Unit | query', function (hooks) {
         // no-op for tests
         return [];
       },
-      async clearRealmCache(_realmURL: string): Promise<void> {
+      async clearRealmDefinitions(_realmURL: string): Promise<void> {
         // no-op for tests
       },
-      async getModuleCacheEntry(): Promise<undefined> {
+      async getCachedDefinitions(): Promise<undefined> {
         return undefined;
       },
-      async getModuleCacheEntries(): Promise<Record<string, never>> {
+      async getCachedDefinitionsBatch(): Promise<Record<string, never>> {
         return {};
       },
       registerRealm() {},
-      async clearAllModules(): Promise<void> {
+      async clearAllDefinitions(): Promise<void> {
         // no-op for tests
       },
       forRealm() {

--- a/packages/realm-server/handlers/handle-delete-realm.ts
+++ b/packages/realm-server/handlers/handle-delete-realm.ts
@@ -5,6 +5,7 @@ import {
   ensureTrailingSlash,
   fetchRealmPermissions,
   getMatrixUsername,
+  notifyAllFileChanges,
   param,
   PUBLISHED_DIRECTORY_NAME,
   query,
@@ -238,6 +239,17 @@ export default function handleDeleteRealm({
       } catch (error) {
         Sentry.captureException(error);
       }
+
+      // CS-11156. Broadcast a bulk cache-invalidation for the source realm
+      // and each removed published realm so any peer replicas that still
+      // have these realms mounted drop their #sourceCache / #moduleCache
+      // before the reconciler unmount lands via NOTIFY realm_registry.
+      // Best-effort, fire-and-forget; missed NOTIFY is a bounded
+      // staleness window resolved by the unmount itself.
+      for (let publishedRealm of publishedRealms) {
+        await notifyAllFileChanges(dbAdapter, publishedRealm.url);
+      }
+      await notifyAllFileChanges(dbAdapter, realmURL);
 
       await setContextResponse(
         ctxt,

--- a/packages/realm-server/handlers/handle-delete-realm.ts
+++ b/packages/realm-server/handlers/handle-delete-realm.ts
@@ -242,7 +242,7 @@ export default function handleDeleteRealm({
 
       // CS-11156. Broadcast a bulk cache-invalidation for the source realm
       // and each removed published realm so any peer replicas that still
-      // have these realms mounted drop their #sourceCache / #moduleCache
+      // have these realms mounted drop their #sourceCache / #transpiledModuleCache
       // before the reconciler unmount lands via NOTIFY realm_registry.
       // Best-effort, fire-and-forget; missed NOTIFY is a bounded
       // staleness window resolved by the unmount itself.

--- a/packages/realm-server/handlers/handle-full-reindex.ts
+++ b/packages/realm-server/handlers/handle-full-reindex.ts
@@ -15,7 +15,7 @@ export default function handleFullReindex({
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
     let realmUrls = await getFullReindexRealmUrls(dbAdapter);
 
-    await definitionLookup.clearAllModules();
+    await definitionLookup.clearAllDefinitions();
 
     await queue.publish<void>({
       jobType: `full-reindex`,

--- a/packages/realm-server/handlers/handle-post-deployment.ts
+++ b/packages/realm-server/handlers/handle-post-deployment.ts
@@ -27,7 +27,7 @@ export default function handlePostDeployment({
       return;
     }
 
-    await definitionLookup.clearAllModules();
+    await definitionLookup.clearAllDefinitions();
 
     let boxelUiChangeCheckerResult =
       await compareCurrentBoxelUIChecksum(assetsURL);

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -572,13 +572,11 @@ export default function handlePublishRealm({
           let mountedRealmForCacheClear =
             await reconciler.lookupOrMount(publishedRealmURL);
           if (mountedRealmForCacheClear) {
-            // Sync local clear before the reindex enqueue: this replica's
-            // own prerender fetches must bypass the pre-swap cache. The
-            // broadcast below covers the same staleness on peer replicas
-            // (CS-11156) — self-receive is a no-op since clearLocalCaches
-            // is idempotent.
-            mountedRealmForCacheClear.clearLocalCaches();
-            await mountedRealmForCacheClear.notifyAllFileChanges();
+            // Sync local clear + cross-replica NOTIFY in one call. The
+            // local clear is what this replica's reindex fan-out needs;
+            // the broadcast (CS-11156) covers peers that still have the
+            // realm mounted with pre-swap bytes.
+            await mountedRealmForCacheClear.clearLocalCachesAndBroadcast();
           }
 
           // Refresh the index. For a new publish this is redundant

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -572,7 +572,13 @@ export default function handlePublishRealm({
           let mountedRealmForCacheClear =
             await reconciler.lookupOrMount(publishedRealmURL);
           if (mountedRealmForCacheClear) {
+            // Sync local clear before the reindex enqueue: this replica's
+            // own prerender fetches must bypass the pre-swap cache. The
+            // broadcast below covers the same staleness on peer replicas
+            // (CS-11156) — self-receive is a no-op since clearLocalCaches
+            // is idempotent.
             mountedRealmForCacheClear.clearLocalCaches();
+            await mountedRealmForCacheClear.notifyAllFileChanges();
           }
 
           // Refresh the index. For a new publish this is redundant

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -223,6 +223,7 @@ function ensureRealmIndexBoilerplateOptIn(publishedRealmPath: string): void {
 
 export default function handlePublishRealm({
   dbAdapter,
+  definitionLookup,
   matrixClient,
   queue,
   realmSecretSeed,
@@ -526,12 +527,20 @@ export default function handlePublishRealm({
           // it up.
           ensureRealmIndexBoilerplateOptIn(publishedRealmPath);
 
-          // Clear stale modules cache for the published realm so that
-          // error entries from a previous publish don't persist
-          await query(dbAdapter, [
-            `DELETE FROM modules WHERE resolved_realm_url =`,
-            param(publishedRealmURL),
-          ]);
+          // Clear stale modules cache for the published realm (including
+          // error entries from a previous publish) before the reindex's
+          // prerender fan-out, so its HTTP module fetches don't hit
+          // cached pre-swap state on this replica or its peers.
+          // `clearRealmCache` bundles the DB DELETE + in-flight prerender
+          // drop + per-realm generation bump + cross-instance NOTIFY on
+          // `module_cache_invalidated` — the modules-cache analog of
+          // `clearLocalCachesAndBroadcast()` below. Without those extra
+          // steps (which a raw `DELETE FROM modules` would miss), an
+          // in-flight prerender that started before the DELETE could
+          // re-insert a stale row at persist time, and peer replicas
+          // would keep their cached rows + generation counters until
+          // their own next invalidation arrived.
+          await definitionLookup.clearRealmCache(publishedRealmURL);
 
           let lastPublishedAt = Date.now().toString();
           try {

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -531,7 +531,7 @@ export default function handlePublishRealm({
           // error entries from a previous publish) before the reindex's
           // prerender fan-out, so its HTTP module fetches don't hit
           // cached pre-swap state on this replica or its peers.
-          // `clearRealmCache` bundles the DB DELETE + in-flight prerender
+          // `clearRealmDefinitions` bundles the DB DELETE + in-flight prerender
           // drop + per-realm generation bump + cross-instance NOTIFY on
           // `module_cache_invalidated` — the modules-cache analog of
           // `clearLocalSourceCachesAndBroadcast()` below. Without those extra
@@ -540,7 +540,7 @@ export default function handlePublishRealm({
           // re-insert a stale row at persist time, and peer replicas
           // would keep their cached rows + generation counters until
           // their own next invalidation arrived.
-          await definitionLookup.clearRealmCache(publishedRealmURL);
+          await definitionLookup.clearRealmDefinitions(publishedRealmURL);
 
           let lastPublishedAt = Date.now().toString();
           try {

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -534,7 +534,7 @@ export default function handlePublishRealm({
           // `clearRealmCache` bundles the DB DELETE + in-flight prerender
           // drop + per-realm generation bump + cross-instance NOTIFY on
           // `module_cache_invalidated` — the modules-cache analog of
-          // `clearLocalCachesAndBroadcast()` below. Without those extra
+          // `clearLocalSourceCachesAndBroadcast()` below. Without those extra
           // steps (which a raw `DELETE FROM modules` would miss), an
           // in-flight prerender that started before the DELETE could
           // re-insert a stale row at persist time, and peer replicas
@@ -576,7 +576,7 @@ export default function handlePublishRealm({
           //
           // For a new publish, lookupOrMount mounts the realm fresh
           // (registry row was just upserted above); the cache is
-          // empty so clearLocalCaches is a no-op. Either way the
+          // empty so clearLocalSourceCaches is a no-op. Either way the
           // reindex below sees correct source.
           let mountedRealmForCacheClear =
             await reconciler.lookupOrMount(publishedRealmURL);
@@ -585,7 +585,7 @@ export default function handlePublishRealm({
             // local clear is what this replica's reindex fan-out needs;
             // the broadcast (CS-11156) covers peers that still have the
             // realm mounted with pre-swap bytes.
-            await mountedRealmForCacheClear.clearLocalCachesAndBroadcast();
+            await mountedRealmForCacheClear.clearLocalSourceCachesAndBroadcast();
           }
 
           // Refresh the index. For a new publish this is redundant

--- a/packages/realm-server/handlers/handle-reindex.ts
+++ b/packages/realm-server/handlers/handle-reindex.ts
@@ -80,7 +80,7 @@ export async function reindex({
   definitionLookup: DefinitionLookup;
   priority?: number;
 }) {
-  await definitionLookup.clearRealmCache(realm.url);
+  await definitionLookup.clearRealmDefinitions(realm.url);
   return await enqueueReindexRealmJob(
     realm.url,
     await realm.getRealmOwnerUsername(),

--- a/packages/realm-server/handlers/handle-unpublish-realm.ts
+++ b/packages/realm-server/handlers/handle-unpublish-realm.ts
@@ -4,6 +4,7 @@ import {
   query,
   SupportedMimeType,
   logger,
+  notifyAllFileChanges,
   param,
   removeRealmPermissions,
   fetchRealmPermissions,
@@ -152,6 +153,15 @@ export default function handleUnpublishRealm({
       // CS-10898). Doing it inside the tx would risk the worse failure
       // mode where we delete files but the registry row sticks around.
       removeRealmFiles(publishedRealmPath);
+
+      // CS-11156. Broadcast a bulk cache-invalidation to peer replicas so
+      // any that still have this realm mounted drop their #sourceCache /
+      // #moduleCache before the reconciler unmount lands. The per-file
+      // deleteAll above already emitted per-path NOTIFYs covering bytes
+      // that existed on disk; this bulk emit closes the brief window
+      // between the registry-row delete commit and the peers' reaction.
+      // Best-effort, fire-and-forget.
+      await notifyAllFileChanges(dbAdapter, publishedRealmURL);
 
       // Removing this derivative just changed the source realm's
       // `RealmInfo.lastPublishedAt` map (rows where `source_url =

--- a/packages/realm-server/handlers/handle-unpublish-realm.ts
+++ b/packages/realm-server/handlers/handle-unpublish-realm.ts
@@ -156,7 +156,7 @@ export default function handleUnpublishRealm({
 
       // CS-11156. Broadcast a bulk cache-invalidation to peer replicas so
       // any that still have this realm mounted drop their #sourceCache /
-      // #moduleCache before the reconciler unmount lands. The per-file
+      // #transpiledModuleCache before the reconciler unmount lands. The per-file
       // deleteAll above already emitted per-path NOTIFYs covering bytes
       // that existed on disk; this bulk emit closes the brief window
       // between the registry-row delete commit and the peers' reaction.

--- a/packages/realm-server/lib/module-cache-coordination.ts
+++ b/packages/realm-server/lib/module-cache-coordination.ts
@@ -46,7 +46,7 @@ export function hashCoalesceKeyForAdvisoryLock(key: string): string {
 //
 // The pinned connection ONLY holds the advisory lock and emits the
 // NOTIFY. The `fn` callback issues its DB work (readFromDatabaseCache,
-// persistModuleCacheEntry) through the shared dbAdapter — a separate
+// persistDefinitionCacheEntry) through the shared dbAdapter — a separate
 // pool connection autocommits each query as today. Pool pressure is
 // bounded by N processes (each pins one extra client per concurrent
 // coordinated load) rather than N × M concurrent callers, since the

--- a/packages/realm-server/lib/module-cache-invalidation-listener.ts
+++ b/packages/realm-server/lib/module-cache-invalidation-listener.ts
@@ -9,7 +9,7 @@ const log = logger('realm-server:module-cache-invalidation-listener');
 
 // Cross-instance module-cache invalidation broadcast (CS-10952). Peer
 // realm-server processes emit `NOTIFY module_cache_invalidated, '<payload>'`
-// from CachingDefinitionLookup.invalidate / clearRealmCache / clearAllModules
+// from CachingDefinitionLookup.invalidate / clearRealmDefinitions / clearAllDefinitions
 // after their DELETE commits; this listener parses the payload and replays
 // the appropriate generation bump on the locally-attached
 // CachingDefinitionLookup so its in-flight prerenders observe the

--- a/packages/realm-server/lib/realm-file-changes-listener.ts
+++ b/packages/realm-server/lib/realm-file-changes-listener.ts
@@ -96,16 +96,16 @@ export class RealmFileChangesListener {
       // Not mounted on this instance — nothing to invalidate.
       return;
     }
+    const isWildcard = parsed.path === REALM_FILE_CHANGES_WILDCARD;
     try {
-      if (parsed.path === REALM_FILE_CHANGES_WILDCARD) {
+      if (isWildcard) {
         realm.clearLocalSourceCaches();
       } else {
         realm.invalidateCache(parsed.path);
       }
     } catch (err: unknown) {
-      log.warn(
-        `invalidateCache failed for ${parsed.url} ${parsed.path}: ${String(err)}`,
-      );
+      const op = isWildcard ? 'clearLocalSourceCaches' : 'invalidateCache';
+      log.warn(`${op} failed for ${parsed.url} ${parsed.path}: ${String(err)}`);
     }
   }
 }

--- a/packages/realm-server/lib/realm-file-changes-listener.ts
+++ b/packages/realm-server/lib/realm-file-changes-listener.ts
@@ -1,5 +1,9 @@
 import type { Realm } from '@cardstack/runtime-common';
-import { logger, REALM_FILE_CHANGES_CHANNEL } from '@cardstack/runtime-common';
+import {
+  logger,
+  REALM_FILE_CHANGES_CHANNEL,
+  REALM_FILE_CHANGES_WILDCARD,
+} from '@cardstack/runtime-common';
 import type { PgAdapter, NotificationSubscription } from '@cardstack/postgres';
 
 const log = logger('realm-server:file-changes-listener');
@@ -11,6 +15,12 @@ const log = logger('realm-server:file-changes-listener');
 // `realm.invalidateCache(path)` clears the matching #sourceCache /
 // #moduleCache entries. If it's not mounted, the notification is dropped —
 // this instance has no stale state to clear.
+//
+// Bulk variant: when the path is the wildcard sentinel `*` (CS-11156),
+// `realm.clearLocalCaches()` drops every cached path for that realm. Emitted
+// by the publish-realm / unpublish-realm / delete-realm handlers after the
+// FS swap or removal so peers (whose file-watcher events do NOT cross
+// replicas) bypass their pre-swap cached bytes on the next read.
 //
 // The LISTEN is backed by `PgAdapter.subscribe` (shared multiplexed
 // notification client). There is no periodic work to run between
@@ -87,7 +97,11 @@ export class RealmFileChangesListener {
       return;
     }
     try {
-      realm.invalidateCache(parsed.path);
+      if (parsed.path === REALM_FILE_CHANGES_WILDCARD) {
+        realm.clearLocalCaches();
+      } else {
+        realm.invalidateCache(parsed.path);
+      }
     } catch (err: unknown) {
       log.warn(
         `invalidateCache failed for ${parsed.url} ${parsed.path}: ${String(err)}`,
@@ -96,11 +110,14 @@ export class RealmFileChangesListener {
   }
 }
 
-// Payload shape: `<realmURL>:<localPath>`. Realm URLs always carry a
-// trailing slash (enforced by `ensureTrailingSlash` throughout the code),
-// so the separator between URL and path is the first `:` that immediately
+// Payload shape: `<realmURL>:<localPath>` or `<realmURL>:*` (bulk
+// invalidation — CS-11156). Realm URLs always carry a trailing slash
+// (enforced by `ensureTrailingSlash` throughout the code), so the
+// separator between URL and path is the first `:` that immediately
 // follows a `/`. That avoids false matches on the scheme colon
-// (`http://...`) and any host:port colon (`localhost:4201`).
+// (`http://...`) and any host:port colon (`localhost:4201`). The same
+// regex handles both shapes; the wildcard payload parses as
+// `path = '*'`.
 const PAYLOAD_SEPARATOR = /\/:/;
 
 export function parsePayload(

--- a/packages/realm-server/lib/realm-file-changes-listener.ts
+++ b/packages/realm-server/lib/realm-file-changes-listener.ts
@@ -13,11 +13,11 @@ const log = logger('realm-server:file-changes-listener');
 // runtime-common/realm.ts), every listener subscribed on this channel looks
 // up the URL in its lookup function. If the realm is mounted locally,
 // `realm.invalidateCache(path)` clears the matching #sourceCache /
-// #moduleCache entries. If it's not mounted, the notification is dropped —
+// #transpiledModuleCache entries. If it's not mounted, the notification is dropped —
 // this instance has no stale state to clear.
 //
 // Bulk variant: when the path is the wildcard sentinel `*` (CS-11156),
-// `realm.clearLocalCaches()` drops every cached path for that realm. Emitted
+// `realm.clearLocalSourceCaches()` drops every cached path for that realm. Emitted
 // by the publish-realm / unpublish-realm / delete-realm handlers after the
 // FS swap or removal so peers (whose file-watcher events do NOT cross
 // replicas) bypass their pre-swap cached bytes on the next read.
@@ -98,7 +98,7 @@ export class RealmFileChangesListener {
     }
     try {
       if (parsed.path === REALM_FILE_CHANGES_WILDCARD) {
-        realm.clearLocalCaches();
+        realm.clearLocalSourceCaches();
       } else {
         realm.invalidateCache(parsed.path);
       }

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -339,7 +339,7 @@ const getIndexHTML = async () => {
     log.info('Skipping modules cache clear on startup (opted out via env)');
   } else {
     log.info('Clearing modules cache...');
-    await definitionLookup.clearAllModules();
+    await definitionLookup.clearAllDefinitions();
   }
 
   // Backfill realm_registry from CLI args (bootstrap), on-disk source realms,

--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -234,14 +234,14 @@ module(basename(__filename), function () {
           );
         });
 
-        // CS-11043. clearLocalCaches() is the public surface the
+        // CS-11043. clearLocalSourceCaches() is the public surface the
         // publish-realm handler invokes after the FS swap so that the
-        // pre-swap bytes living in #sourceCache / #moduleCache don't get
+        // pre-swap bytes living in #sourceCache / #transpiledModuleCache don't get
         // served to the reindex job (which would then write stale
         // isolated_html into boxel_index). Functionally equivalent to
         // __testOnlyClearCaches minus the test-only transpile-counter
         // reset.
-        test('clearLocalCaches drops cached source bytes', async function (assert) {
+        test('clearLocalSourceCaches drops cached source bytes', async function (assert) {
           let cacheTestPath = 'clear-local-caches.gts';
           await testRealm.write(
             cacheTestPath,
@@ -260,7 +260,7 @@ module(basename(__filename), function () {
             'precondition: second fetch hits the source cache',
           );
 
-          testRealm.clearLocalCaches();
+          testRealm.clearLocalSourceCaches();
 
           let afterClear = await request
             .get(`/${cacheTestPath}`)
@@ -268,7 +268,7 @@ module(basename(__filename), function () {
           assert.strictEqual(
             afterClear.headers['x-boxel-cache'],
             'miss',
-            'fetch after clearLocalCaches is a miss — the #sourceCache entry was dropped',
+            'fetch after clearLocalSourceCaches is a miss — the #sourceCache entry was dropped',
           );
         });
 

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -1706,7 +1706,7 @@ module(basename(__filename), function () {
       );
     });
 
-    test('in-flight prerender result is dropped when clearRealmCache runs concurrently', async function (assert) {
+    test('in-flight prerender result is dropped when clearRealmDefinitions runs concurrently', async function (assert) {
       await dbAdapter.execute('DELETE FROM modules');
 
       let moduleURL = `${realmURL}stale-persist-clear-realm.gts`;
@@ -1752,14 +1752,14 @@ module(basename(__filename), function () {
       });
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      await lookup.clearRealmCache(realmURL);
+      await lookup.clearRealmDefinitions(realmURL);
 
       releaseGate();
       let result = await Promise.allSettled([pA]);
       assert.strictEqual(
         result[0].status,
         'rejected',
-        'A rejects after clearRealmCache leaves an empty cache',
+        'A rejects after clearRealmDefinitions leaves an empty cache',
       );
       assert.strictEqual(calls, 1);
 
@@ -1770,14 +1770,14 @@ module(basename(__filename), function () {
       assert.strictEqual(
         rows.length,
         0,
-        'clearRealmCache is honored — A did not re-insert the row',
+        'clearRealmDefinitions is honored — A did not re-insert the row',
       );
     });
 
-    test('in-flight prerender result is dropped when clearAllModules runs concurrently', async function (assert) {
+    test('in-flight prerender result is dropped when clearAllDefinitions runs concurrently', async function (assert) {
       await dbAdapter.execute('DELETE FROM modules');
 
-      // clearAllModules drains state for every realm — including realms
+      // clearAllDefinitions drains state for every realm — including realms
       // that have never been individually invalidated. Use a fresh module
       // URL so the realm has no #generations entry going in; this guards
       // against the per-realm map missing the realm at clear time.
@@ -1824,14 +1824,14 @@ module(basename(__filename), function () {
       });
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      await lookup.clearAllModules();
+      await lookup.clearAllDefinitions();
 
       releaseGate();
       let result = await Promise.allSettled([pA]);
       assert.strictEqual(
         result[0].status,
         'rejected',
-        'A rejects after clearAllModules leaves an empty cache',
+        'A rejects after clearAllDefinitions leaves an empty cache',
       );
       assert.strictEqual(calls, 1);
 
@@ -1842,7 +1842,7 @@ module(basename(__filename), function () {
       assert.strictEqual(
         rows.length,
         0,
-        'clearAllModules is honored — A did not re-insert the row',
+        'clearAllDefinitions is honored — A did not re-insert the row',
       );
     });
 
@@ -1925,7 +1925,7 @@ module(basename(__filename), function () {
 
     test('a settled in-flight promise does not delete a newer in-flight under the same key', async function (assert) {
       // Identity-check regression guard. Without the identity check in
-      // loadModuleCacheEntry's .finally, A's settle would delete B's
+      // loadDefinitionCacheEntry's .finally, A's settle would delete B's
       // freshly-installed entry and cause D to race a third prerender.
       await dbAdapter.execute('DELETE FROM modules');
 

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -2007,7 +2007,7 @@ module(basename(__filename), function () {
         );
 
         if (definitionLookup) {
-          let moduleEntries = await definitionLookup.getModuleCacheEntries({
+          let moduleEntries = await definitionLookup.getCachedDefinitionsBatch({
             moduleUrls: [fileDefAlias],
             cacheScope: 'public',
             authUserId: '',
@@ -2138,7 +2138,7 @@ module(basename(__filename), function () {
         if (!definitionLookup) {
           assert.ok(false, 'definition lookup is available');
         } else {
-          let deepModuleEntry = await definitionLookup.getModuleCacheEntry(
+          let deepModuleEntry = await definitionLookup.getCachedDefinitions(
             `${testRealm}deep-card`,
           );
           assert.strictEqual(
@@ -2221,7 +2221,7 @@ module(basename(__filename), function () {
             // definition lookup errors are expected while dependencies are missing
           }
 
-          deepModuleEntry = await definitionLookup.getModuleCacheEntry(
+          deepModuleEntry = await definitionLookup.getCachedDefinitions(
             `${testRealm}deep-card`,
           );
           if (deepModuleEntry?.error?.error) {
@@ -2240,7 +2240,7 @@ module(basename(__filename), function () {
             assert.ok(false, 'expected deep-card module error details');
           }
 
-          let middleModuleEntry = await definitionLookup.getModuleCacheEntry(
+          let middleModuleEntry = await definitionLookup.getCachedDefinitions(
             `${testRealm}middle-field`,
           );
           assert.strictEqual(
@@ -2484,7 +2484,7 @@ module(basename(__filename), function () {
         let definitionLookup = (testRealmServer?.testRealmServer as any)
           ?.definitionLookup as DefinitionLookup | undefined;
         if (definitionLookup) {
-          let moduleBEntry = await definitionLookup.getModuleCacheEntry(
+          let moduleBEntry = await definitionLookup.getCachedDefinitions(
             `${testRealm}module-b`,
           );
           assert.strictEqual(
@@ -2503,7 +2503,7 @@ module(basename(__filename), function () {
             assert.ok(false, 'expected module-b error details');
           }
 
-          let moduleAEntry = await definitionLookup.getModuleCacheEntry(
+          let moduleAEntry = await definitionLookup.getCachedDefinitions(
             `${testRealm}module-a`,
           );
           assert.strictEqual(

--- a/packages/realm-server/tests/matches-filter-integration-test.ts
+++ b/packages/realm-server/tests/matches-filter-integration-test.ts
@@ -25,13 +25,13 @@ const stubDefinitionLookup: DefinitionLookup = {
   async invalidate() {
     return [];
   },
-  async clearRealmCache() {},
-  async clearAllModules() {},
+  async clearRealmDefinitions() {},
+  async clearAllDefinitions() {},
   registerRealm() {},
-  async getModuleCacheEntry() {
+  async getCachedDefinitions() {
     return undefined;
   },
-  async getModuleCacheEntries() {
+  async getCachedDefinitionsBatch() {
     return {};
   },
   forRealm() {

--- a/packages/realm-server/tests/module-cache-coordination-test.ts
+++ b/packages/realm-server/tests/module-cache-coordination-test.ts
@@ -371,9 +371,9 @@ module(basename(__filename), function () {
           // A starts first. A's prerender will gate. While A holds the
           // lock + is awaiting the gate, B issues its lookup; B contends
           // the lock, observes acquired:false, parks on NOTIFY.
-          const pA = lookupA.getModuleCacheEntry(moduleURL);
+          const pA = lookupA.getCachedDefinitions(moduleURL);
           await new Promise((r) => setTimeout(r, 100));
-          const pB = lookupB.getModuleCacheEntry(moduleURL);
+          const pB = lookupB.getCachedDefinitions(moduleURL);
           await new Promise((r) => setTimeout(r, 100));
 
           // At this point: A is awaiting the gate (one prerender call
@@ -439,7 +439,7 @@ module(basename(__filename), function () {
           undefined,
           realmURL,
         );
-        const p = lookup.getModuleCacheEntry(moduleURL);
+        const p = lookup.getCachedDefinitions(moduleURL);
         await new Promise((r) => setTimeout(r, 50));
         aPrerender.release();
         const entry = await p;
@@ -467,7 +467,7 @@ module(basename(__filename), function () {
             coordinatorA,
             realmURL,
           );
-          const pA = lookupA.getModuleCacheEntry(moduleURL);
+          const pA = lookupA.getCachedDefinitions(moduleURL);
           await new Promise((r) => setTimeout(r, 50));
           aPrerender.release();
           await pA;
@@ -485,7 +485,7 @@ module(basename(__filename), function () {
               coordinatorB,
               realmURL,
             );
-            const entryB = await lookupB.getModuleCacheEntry(moduleURL);
+            const entryB = await lookupB.getCachedDefinitions(moduleURL);
             assert.ok(entryB, 'B returned the cached entry');
             assert.strictEqual(
               bPrerender.callsFor(moduleURL),

--- a/packages/realm-server/tests/module-cache-invalidation-listener-test.ts
+++ b/packages/realm-server/tests/module-cache-invalidation-listener-test.ts
@@ -421,7 +421,7 @@ module(basename(__filename), function () {
         }
       });
 
-      test('A.clearRealmCache(url) → B listener bumps B.bumpRealmGeneration', async function (assert) {
+      test('A.clearRealmDefinitions(url) → B listener bumps B.bumpRealmGeneration', async function (assert) {
         const realmURL = 'http://x.test/peer-clear-realm/';
         const instanceB = new CachingDefinitionLookup(
           dbAdapter,
@@ -444,7 +444,7 @@ module(basename(__filename), function () {
             stubVirtualNetwork,
             stubCreatePrerenderAuth,
           );
-          await instanceA.clearRealmCache(realmURL);
+          await instanceA.clearRealmDefinitions(realmURL);
 
           const seen = await waitFor(() =>
             recorderB.realm.length > 0 ? recorderB.realm : undefined,
@@ -455,7 +455,7 @@ module(basename(__filename), function () {
         }
       });
 
-      test('A.clearAllModules() → B listener bumps B.bumpGlobalGeneration', async function (assert) {
+      test('A.clearAllDefinitions() → B listener bumps B.bumpGlobalGeneration', async function (assert) {
         const instanceB = new CachingDefinitionLookup(
           dbAdapter,
           stubPrerenderer,
@@ -477,7 +477,7 @@ module(basename(__filename), function () {
             stubVirtualNetwork,
             stubCreatePrerenderAuth,
           );
-          await instanceA.clearAllModules();
+          await instanceA.clearAllDefinitions();
 
           await waitFor(() => (recorderB.global > 0 ? true : undefined));
           assert.strictEqual(

--- a/packages/realm-server/tests/module-cache-race-test.ts
+++ b/packages/realm-server/tests/module-cache-race-test.ts
@@ -298,32 +298,34 @@ module(basename(__filename), function () {
   // tracks a monotonic transpile counter exposed via
   // __testOnlyGetTranspileCallCount so the tests can assert "exactly one
   // transpile call" directly rather than inferring it from timing.
-  module('Realm.#transpiledModuleCache in-flight transpile dedup', function (hooks) {
-    let realmURL = new URL('http://127.0.0.1:4444/test/');
-    let testRealm: Realm;
-    let request: RealmRequest;
+  module(
+    'Realm.#transpiledModuleCache in-flight transpile dedup',
+    function (hooks) {
+      let realmURL = new URL('http://127.0.0.1:4444/test/');
+      let testRealm: Realm;
+      let request: RealmRequest;
 
-    function onRealmSetup(args: {
-      testRealm: Realm;
-      testRealmHttpServer: Server;
-      request: SuperTest<Test>;
-    }) {
-      testRealm = args.testRealm;
-      request = withRealmPath(args.request, realmURL);
-    }
+      function onRealmSetup(args: {
+        testRealm: Realm;
+        testRealmHttpServer: Server;
+        request: SuperTest<Test>;
+      }) {
+        testRealm = args.testRealm;
+        request = withRealmPath(args.request, realmURL);
+      }
 
-    setupPermissionedRealmCached(hooks, {
-      fixture: 'blank',
-      realmURL,
-      permissions: {
-        '*': ['read', 'write'],
-        user: ['read', 'write', 'realm-owner'],
-        '@node-test_realm:localhost': ['read', 'realm-owner'],
-      },
-      onRealmSetup,
-    });
+      setupPermissionedRealmCached(hooks, {
+        fixture: 'blank',
+        realmURL,
+        permissions: {
+          '*': ['read', 'write'],
+          user: ['read', 'write', 'realm-owner'],
+          '@node-test_realm:localhost': ['read', 'realm-owner'],
+        },
+        onRealmSetup,
+      });
 
-    const transpilerHeavySource = `
+      const transpilerHeavySource = `
       import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
       import StringField from "https://cardstack.com/base/string";
 
@@ -337,335 +339,336 @@ module(basename(__filename), function () {
       }
     `;
 
-    function authHeader() {
-      return `Bearer ${createJWT(testRealm, 'user', ['read', 'write'])}`;
-    }
-
-    function fireRequest(path: string): Promise<{ status: number }> {
-      return request
-        .get(`/${path}`)
-        .set('Accept', SupportedMimeType.All)
-        .set('Authorization', authHeader())
-        .then((r) => r as { status: number });
-    }
-
-    // Poll the realm's in-flight counter until it matches `expected`,
-    // up to `timeoutMs`. Fixed-time setTimeout()s are unreliable in CI
-    // — request startup latency can exceed the wait window — so the
-    // tests below use this helper together with __testOnlyDelayTranspile
-    // to deterministically observe inflight state without racing real
-    // .gts transpile timing.
-    async function waitForInflight(
-      expected: number,
-      timeoutMs = 5000,
-    ): Promise<void> {
-      let deadline = Date.now() + timeoutMs;
-      while (Date.now() < deadline) {
-        if (testRealm.__testOnlyGetInFlightTranspileCount() === expected) {
-          return;
-        }
-        await new Promise((r) => setTimeout(r, 5));
+      function authHeader() {
+        return `Bearer ${createJWT(testRealm, 'user', ['read', 'write'])}`;
       }
-      throw new Error(
-        `timed out waiting for in-flight count to reach ${expected}; saw ${testRealm.__testOnlyGetInFlightTranspileCount()}`,
-      );
-    }
 
-    test('N concurrent same-path readers trigger exactly one transpile call', async function (assert) {
-      let modulePath = 'dedup-same-path.gts';
-      await testRealm.write(modulePath, transpilerHeavySource);
-      testRealm.__testOnlyClearCaches();
+      function fireRequest(path: string): Promise<{ status: number }> {
+        return request
+          .get(`/${path}`)
+          .set('Accept', SupportedMimeType.All)
+          .set('Authorization', authHeader())
+          .then((r) => r as { status: number });
+      }
 
-      let before = testRealm.__testOnlyGetTranspileCallCount();
-      let responses = await Promise.all([
-        fireRequest(modulePath),
-        fireRequest(modulePath),
-        fireRequest(modulePath),
-      ]);
-      let delta = testRealm.__testOnlyGetTranspileCallCount() - before;
+      // Poll the realm's in-flight counter until it matches `expected`,
+      // up to `timeoutMs`. Fixed-time setTimeout()s are unreliable in CI
+      // — request startup latency can exceed the wait window — so the
+      // tests below use this helper together with __testOnlyDelayTranspile
+      // to deterministically observe inflight state without racing real
+      // .gts transpile timing.
+      async function waitForInflight(
+        expected: number,
+        timeoutMs = 5000,
+      ): Promise<void> {
+        let deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+          if (testRealm.__testOnlyGetInFlightTranspileCount() === expected) {
+            return;
+          }
+          await new Promise((r) => setTimeout(r, 5));
+        }
+        throw new Error(
+          `timed out waiting for in-flight count to reach ${expected}; saw ${testRealm.__testOnlyGetInFlightTranspileCount()}`,
+        );
+      }
 
-      assert.deepEqual(
-        responses.map((r) => r.status),
-        [200, 200, 200],
-        'all three concurrent same-path requests succeed',
-      );
-      assert.strictEqual(
-        delta,
-        1,
-        'exactly one transpileJS call serviced three concurrent same-path readers',
-      );
-      assert.strictEqual(
-        testRealm.__testOnlyGetInFlightTranspileCount(),
-        0,
-        'in-flight slot released after the shared transpile settled',
-      );
-    });
+      test('N concurrent same-path readers trigger exactly one transpile call', async function (assert) {
+        let modulePath = 'dedup-same-path.gts';
+        await testRealm.write(modulePath, transpilerHeavySource);
+        testRealm.__testOnlyClearCaches();
 
-    test('concurrent different-path readers each trigger their own transpile (no false coalesce)', async function (assert) {
-      let pathA = 'dedup-a.gts';
-      let pathB = 'dedup-b.gts';
-      await testRealm.write(pathA, transpilerHeavySource);
-      await testRealm.write(pathB, transpilerHeavySource);
-      testRealm.__testOnlyClearCaches();
-
-      let before = testRealm.__testOnlyGetTranspileCallCount();
-      let responses = await Promise.all([
-        fireRequest(pathA),
-        fireRequest(pathB),
-      ]);
-      let delta = testRealm.__testOnlyGetTranspileCallCount() - before;
-
-      assert.deepEqual(
-        responses.map((r) => r.status),
-        [200, 200],
-        'both different-path requests succeed',
-      );
-      assert.strictEqual(
-        delta,
-        2,
-        'each distinct path triggers its own transpile — no cross-path false coalesce',
-      );
-    });
-
-    test('in-flight entry survives an unrelated path’s invalidate', async function (assert) {
-      let primaryPath = 'dedup-primary.gts';
-      let unrelatedPath = 'dedup-unrelated.gts';
-      await testRealm.write(primaryPath, transpilerHeavySource);
-      await testRealm.write(unrelatedPath, transpilerHeavySource);
-      testRealm.__testOnlyClearCaches();
-
-      // Park transpile at a gate so the inflight state is deterministic.
-      let releaseGate: () => void = () => {};
-      let gate = new Promise<void>((r) => {
-        releaseGate = r;
-      });
-      testRealm.__testOnlyDelayTranspile(() => gate);
-
-      try {
         let before = testRealm.__testOnlyGetTranspileCallCount();
-        let primaryInflight = fireRequest(primaryPath);
-        await waitForInflight(1);
-        assert.strictEqual(
-          testRealm.__testOnlyGetInFlightTranspileCount(),
-          1,
-          'primary path has an in-flight entry',
-        );
-
-        // Invalidate an unrelated path — should not affect primary's entry.
-        testRealm.invalidateCache(unrelatedPath);
-        assert.strictEqual(
-          testRealm.__testOnlyGetInFlightTranspileCount(),
-          1,
-          'unrelated invalidate did not drop the primary in-flight entry',
-        );
-
-        // Release primary so we can verify the end-state. A second
-        // concurrent caller while the gate was held would have joined
-        // primary's pending — covered by the "N concurrent same-path"
-        // test above; here we just confirm primary's transpile
-        // completes normally after the unrelated invalidate.
-        releaseGate();
-        await primaryInflight;
+        let responses = await Promise.all([
+          fireRequest(modulePath),
+          fireRequest(modulePath),
+          fireRequest(modulePath),
+        ]);
         let delta = testRealm.__testOnlyGetTranspileCallCount() - before;
+
+        assert.deepEqual(
+          responses.map((r) => r.status),
+          [200, 200, 200],
+          'all three concurrent same-path requests succeed',
+        );
         assert.strictEqual(
           delta,
           1,
-          'primary transpiled once — unrelated invalidate did not force a redo',
+          'exactly one transpileJS call serviced three concurrent same-path readers',
         );
-      } finally {
-        testRealm.__testOnlyDelayTranspile(undefined);
-      }
-    });
-
-    test('in-flight entry is dropped when its own path is invalidated; later caller starts a fresh transpile', async function (assert) {
-      let modulePath = 'dedup-self-invalidate.gts';
-      await testRealm.write(modulePath, transpilerHeavySource);
-      testRealm.__testOnlyClearCaches();
-
-      // Both transpiles will await the same gate — releasing it lets
-      // both proceed and complete. The first transpile was orphaned
-      // from the map by invalidateCache; the second installed a fresh
-      // entry. Their .finally identity checks operate on their own
-      // captured `pending` references, so both clean up correctly.
-      let releaseGate: () => void = () => {};
-      let gate = new Promise<void>((r) => {
-        releaseGate = r;
-      });
-      testRealm.__testOnlyDelayTranspile(() => gate);
-
-      try {
-        let before = testRealm.__testOnlyGetTranspileCallCount();
-        let firstInflight = fireRequest(modulePath);
-        await waitForInflight(1);
-
-        // Invalidate the path — drops the in-flight entry from the
-        // map. firstInflight's promise is still alive at the gate.
-        testRealm.invalidateCache(modulePath);
         assert.strictEqual(
           testRealm.__testOnlyGetInFlightTranspileCount(),
           0,
-          'in-flight entry dropped by invalidateCache',
+          'in-flight slot released after the shared transpile settled',
         );
+      });
 
-        // A caller arriving after the invalidate must not join the
-        // dropped pending; it should install a fresh entry.
-        let secondInflight = fireRequest(modulePath);
-        await waitForInflight(1);
-        assert.strictEqual(
-          testRealm.__testOnlyGetInFlightTranspileCount(),
-          1,
-          'second caller installed its own fresh in-flight entry',
-        );
+      test('concurrent different-path readers each trigger their own transpile (no false coalesce)', async function (assert) {
+        let pathA = 'dedup-a.gts';
+        let pathB = 'dedup-b.gts';
+        await testRealm.write(pathA, transpilerHeavySource);
+        await testRealm.write(pathB, transpilerHeavySource);
+        testRealm.__testOnlyClearCaches();
 
-        releaseGate();
-        await firstInflight;
-        await secondInflight;
+        let before = testRealm.__testOnlyGetTranspileCallCount();
+        let responses = await Promise.all([
+          fireRequest(pathA),
+          fireRequest(pathB),
+        ]);
         let delta = testRealm.__testOnlyGetTranspileCallCount() - before;
+
+        assert.deepEqual(
+          responses.map((r) => r.status),
+          [200, 200],
+          'both different-path requests succeed',
+        );
         assert.strictEqual(
           delta,
           2,
-          'invalidate forced a second transpile — the dropped slot is not joined by post-invalidate callers',
+          'each distinct path triggers its own transpile — no cross-path false coalesce',
         );
-      } finally {
-        testRealm.__testOnlyDelayTranspile(undefined);
-      }
-    });
+      });
 
-    test('identity-checked cleanup: A in-flight + invalidate + B in-flight + A settles → B survives', async function (assert) {
-      let modulePath = 'dedup-identity.gts';
-      await testRealm.write(modulePath, transpilerHeavySource);
-      testRealm.__testOnlyClearCaches();
+      test('in-flight entry survives an unrelated path’s invalidate', async function (assert) {
+        let primaryPath = 'dedup-primary.gts';
+        let unrelatedPath = 'dedup-unrelated.gts';
+        await testRealm.write(primaryPath, transpilerHeavySource);
+        await testRealm.write(unrelatedPath, transpilerHeavySource);
+        testRealm.__testOnlyClearCaches();
 
-      // Independent gates per call so A and B can be released
-      // separately. The hook routes by call index rather than a
-      // mutable `currentGate` reference — `waitForInflight` only
-      // confirms the in-flight slot is set, which happens BEFORE the
-      // transpile hook fires, so A may still be racing toward the
-      // hook when the test swaps the gate. Call-index routing plus
-      // explicit hook-entry signals make the test order deterministic
-      // under CI load.
-      let releaseA: () => void = () => {};
-      let gateA = new Promise<void>((r) => {
-        releaseA = r;
-      });
-      let releaseB: () => void = () => {};
-      let gateB = new Promise<void>((r) => {
-        releaseB = r;
-      });
-      let signalAEntered: () => void = () => {};
-      let aEntered = new Promise<void>((r) => {
-        signalAEntered = r;
-      });
-      let signalBEntered: () => void = () => {};
-      let bEntered = new Promise<void>((r) => {
-        signalBEntered = r;
-      });
-      let hookCalls = 0;
-      testRealm.__testOnlyDelayTranspile(() => {
-        hookCalls += 1;
-        if (hookCalls === 1) {
-          signalAEntered();
-          return gateA;
+        // Park transpile at a gate so the inflight state is deterministic.
+        let releaseGate: () => void = () => {};
+        let gate = new Promise<void>((r) => {
+          releaseGate = r;
+        });
+        testRealm.__testOnlyDelayTranspile(() => gate);
+
+        try {
+          let before = testRealm.__testOnlyGetTranspileCallCount();
+          let primaryInflight = fireRequest(primaryPath);
+          await waitForInflight(1);
+          assert.strictEqual(
+            testRealm.__testOnlyGetInFlightTranspileCount(),
+            1,
+            'primary path has an in-flight entry',
+          );
+
+          // Invalidate an unrelated path — should not affect primary's entry.
+          testRealm.invalidateCache(unrelatedPath);
+          assert.strictEqual(
+            testRealm.__testOnlyGetInFlightTranspileCount(),
+            1,
+            'unrelated invalidate did not drop the primary in-flight entry',
+          );
+
+          // Release primary so we can verify the end-state. A second
+          // concurrent caller while the gate was held would have joined
+          // primary's pending — covered by the "N concurrent same-path"
+          // test above; here we just confirm primary's transpile
+          // completes normally after the unrelated invalidate.
+          releaseGate();
+          await primaryInflight;
+          let delta = testRealm.__testOnlyGetTranspileCallCount() - before;
+          assert.strictEqual(
+            delta,
+            1,
+            'primary transpiled once — unrelated invalidate did not force a redo',
+          );
+        } finally {
+          testRealm.__testOnlyDelayTranspile(undefined);
         }
-        signalBEntered();
-        return gateB;
       });
 
-      try {
-        let pendingA = fireRequest(modulePath);
-        // Wait until A is actually parked at gateA — not just until
-        // the in-flight slot is set. Otherwise the invalidate below
-        // can race A's hook invocation.
-        await aEntered;
+      test('in-flight entry is dropped when its own path is invalidated; later caller starts a fresh transpile', async function (assert) {
+        let modulePath = 'dedup-self-invalidate.gts';
+        await testRealm.write(modulePath, transpilerHeavySource);
+        testRealm.__testOnlyClearCaches();
+
+        // Both transpiles will await the same gate — releasing it lets
+        // both proceed and complete. The first transpile was orphaned
+        // from the map by invalidateCache; the second installed a fresh
+        // entry. Their .finally identity checks operate on their own
+        // captured `pending` references, so both clean up correctly.
+        let releaseGate: () => void = () => {};
+        let gate = new Promise<void>((r) => {
+          releaseGate = r;
+        });
+        testRealm.__testOnlyDelayTranspile(() => gate);
+
+        try {
+          let before = testRealm.__testOnlyGetTranspileCallCount();
+          let firstInflight = fireRequest(modulePath);
+          await waitForInflight(1);
+
+          // Invalidate the path — drops the in-flight entry from the
+          // map. firstInflight's promise is still alive at the gate.
+          testRealm.invalidateCache(modulePath);
+          assert.strictEqual(
+            testRealm.__testOnlyGetInFlightTranspileCount(),
+            0,
+            'in-flight entry dropped by invalidateCache',
+          );
+
+          // A caller arriving after the invalidate must not join the
+          // dropped pending; it should install a fresh entry.
+          let secondInflight = fireRequest(modulePath);
+          await waitForInflight(1);
+          assert.strictEqual(
+            testRealm.__testOnlyGetInFlightTranspileCount(),
+            1,
+            'second caller installed its own fresh in-flight entry',
+          );
+
+          releaseGate();
+          await firstInflight;
+          await secondInflight;
+          let delta = testRealm.__testOnlyGetTranspileCallCount() - before;
+          assert.strictEqual(
+            delta,
+            2,
+            'invalidate forced a second transpile — the dropped slot is not joined by post-invalidate callers',
+          );
+        } finally {
+          testRealm.__testOnlyDelayTranspile(undefined);
+        }
+      });
+
+      test('identity-checked cleanup: A in-flight + invalidate + B in-flight + A settles → B survives', async function (assert) {
+        let modulePath = 'dedup-identity.gts';
+        await testRealm.write(modulePath, transpilerHeavySource);
+        testRealm.__testOnlyClearCaches();
+
+        // Independent gates per call so A and B can be released
+        // separately. The hook routes by call index rather than a
+        // mutable `currentGate` reference — `waitForInflight` only
+        // confirms the in-flight slot is set, which happens BEFORE the
+        // transpile hook fires, so A may still be racing toward the
+        // hook when the test swaps the gate. Call-index routing plus
+        // explicit hook-entry signals make the test order deterministic
+        // under CI load.
+        let releaseA: () => void = () => {};
+        let gateA = new Promise<void>((r) => {
+          releaseA = r;
+        });
+        let releaseB: () => void = () => {};
+        let gateB = new Promise<void>((r) => {
+          releaseB = r;
+        });
+        let signalAEntered: () => void = () => {};
+        let aEntered = new Promise<void>((r) => {
+          signalAEntered = r;
+        });
+        let signalBEntered: () => void = () => {};
+        let bEntered = new Promise<void>((r) => {
+          signalBEntered = r;
+        });
+        let hookCalls = 0;
+        testRealm.__testOnlyDelayTranspile(() => {
+          hookCalls += 1;
+          if (hookCalls === 1) {
+            signalAEntered();
+            return gateA;
+          }
+          signalBEntered();
+          return gateB;
+        });
+
+        try {
+          let pendingA = fireRequest(modulePath);
+          // Wait until A is actually parked at gateA — not just until
+          // the in-flight slot is set. Otherwise the invalidate below
+          // can race A's hook invocation.
+          await aEntered;
+          assert.strictEqual(
+            testRealm.__testOnlyGetInFlightTranspileCount(),
+            1,
+            'A installed its in-flight entry',
+          );
+
+          // Invalidate drops A from the map. A is still parked at gateA.
+          testRealm.invalidateCache(modulePath);
+          assert.strictEqual(
+            testRealm.__testOnlyGetInFlightTranspileCount(),
+            0,
+            'invalidate dropped A from the map',
+          );
+
+          let pendingB = fireRequest(modulePath);
+          await bEntered;
+          assert.strictEqual(
+            testRealm.__testOnlyGetInFlightTranspileCount(),
+            1,
+            'B installed a fresh in-flight entry after invalidate dropped A',
+          );
+
+          // Release A. Its .finally identity check: map has B's pending,
+          // not A's — so it must NOT delete the slot.
+          releaseA();
+          await pendingA;
+          assert.strictEqual(
+            testRealm.__testOnlyGetInFlightTranspileCount(),
+            1,
+            'B’s in-flight entry survives A’s settle (identity check held)',
+          );
+
+          // Release B. Its .finally identity check passes; slot cleaned up.
+          releaseB();
+          await pendingB;
+          assert.strictEqual(
+            testRealm.__testOnlyGetInFlightTranspileCount(),
+            0,
+            'B’s in-flight entry cleaned up after B settled',
+          );
+        } finally {
+          testRealm.__testOnlyDelayTranspile(undefined);
+        }
+      });
+
+      test('errored transpile is shared with concurrent waiters and the in-flight slot releases on rejection', async function (assert) {
+        let modulePath = 'dedup-error.gts';
+        // Syntactically invalid .gts source — transpileJS will throw.
+        await testRealm.write(
+          modulePath,
+          'this is not a valid gts file <template>oops</template>',
+        );
+        testRealm.__testOnlyClearCaches();
+
+        let before = testRealm.__testOnlyGetTranspileCallCount();
+        let [resA, resB] = await Promise.all([
+          fireRequest(modulePath),
+          fireRequest(modulePath),
+        ]);
+        let deltaShared = testRealm.__testOnlyGetTranspileCallCount() - before;
+
         assert.strictEqual(
-          testRealm.__testOnlyGetInFlightTranspileCount(),
+          resA.status,
+          406,
+          'first errored request returns a transpile-failed response',
+        );
+        assert.strictEqual(
+          resB.status,
+          406,
+          'concurrent waiter shares the same error response',
+        );
+        assert.strictEqual(
+          deltaShared,
           1,
-          'A installed its in-flight entry',
+          'concurrent waiters shared exactly one transpile attempt — the rejection propagates without a second babel pass',
         );
 
-        // Invalidate drops A from the map. A is still parked at gateA.
-        testRealm.invalidateCache(modulePath);
+        // After both fail, the in-flight slot must release so a fresh
+        // caller re-attempts transpile against current source.
+        let resC = await fireRequest(modulePath);
+        assert.strictEqual(resC.status, 406);
+        let deltaAfter = testRealm.__testOnlyGetTranspileCallCount() - before;
         assert.strictEqual(
-          testRealm.__testOnlyGetInFlightTranspileCount(),
-          0,
-          'invalidate dropped A from the map',
+          deltaAfter,
+          2,
+          'subsequent caller triggers a fresh transpile attempt — error did not pin the in-flight slot',
         );
-
-        let pendingB = fireRequest(modulePath);
-        await bEntered;
-        assert.strictEqual(
-          testRealm.__testOnlyGetInFlightTranspileCount(),
-          1,
-          'B installed a fresh in-flight entry after invalidate dropped A',
-        );
-
-        // Release A. Its .finally identity check: map has B's pending,
-        // not A's — so it must NOT delete the slot.
-        releaseA();
-        await pendingA;
-        assert.strictEqual(
-          testRealm.__testOnlyGetInFlightTranspileCount(),
-          1,
-          'B’s in-flight entry survives A’s settle (identity check held)',
-        );
-
-        // Release B. Its .finally identity check passes; slot cleaned up.
-        releaseB();
-        await pendingB;
-        assert.strictEqual(
-          testRealm.__testOnlyGetInFlightTranspileCount(),
-          0,
-          'B’s in-flight entry cleaned up after B settled',
-        );
-      } finally {
-        testRealm.__testOnlyDelayTranspile(undefined);
-      }
-    });
-
-    test('errored transpile is shared with concurrent waiters and the in-flight slot releases on rejection', async function (assert) {
-      let modulePath = 'dedup-error.gts';
-      // Syntactically invalid .gts source — transpileJS will throw.
-      await testRealm.write(
-        modulePath,
-        'this is not a valid gts file <template>oops</template>',
-      );
-      testRealm.__testOnlyClearCaches();
-
-      let before = testRealm.__testOnlyGetTranspileCallCount();
-      let [resA, resB] = await Promise.all([
-        fireRequest(modulePath),
-        fireRequest(modulePath),
-      ]);
-      let deltaShared = testRealm.__testOnlyGetTranspileCallCount() - before;
-
-      assert.strictEqual(
-        resA.status,
-        406,
-        'first errored request returns a transpile-failed response',
-      );
-      assert.strictEqual(
-        resB.status,
-        406,
-        'concurrent waiter shares the same error response',
-      );
-      assert.strictEqual(
-        deltaShared,
-        1,
-        'concurrent waiters shared exactly one transpile attempt — the rejection propagates without a second babel pass',
-      );
-
-      // After both fail, the in-flight slot must release so a fresh
-      // caller re-attempts transpile against current source.
-      let resC = await fireRequest(modulePath);
-      assert.strictEqual(resC.status, 406);
-      let deltaAfter = testRealm.__testOnlyGetTranspileCallCount() - before;
-      assert.strictEqual(
-        deltaAfter,
-        2,
-        'subsequent caller triggers a fresh transpile attempt — error did not pin the in-flight slot',
-      );
-    });
-  });
+      });
+    },
+  );
 
   // CS-11030: the L2 cross-process cache lives in module_transpile_cache.
   // A request that misses L1 (in-memory) writes the transpiled bytes to
@@ -973,20 +976,22 @@ module(basename(__filename), function () {
   // the advisory-lock + NOTIFY channel. Mirrors the
   // CachingDefinitionLookup two-instance test in
   // module-cache-coordination-test.ts but exercises the transpile flow.
-  module('Realm.#transpiledModuleCache L2 cross-instance coalesce', function (hooks) {
-    let dbAdapter: PgAdapter;
-    let publisher: import('@cardstack/runtime-common').QueuePublisher;
-    let runner: import('@cardstack/runtime-common').QueueRunner;
-    setupDB(hooks, {
-      beforeEach: async (adapter, pub, run) => {
-        dbAdapter = adapter;
-        publisher = pub;
-        runner = run;
-      },
-    });
+  module(
+    'Realm.#transpiledModuleCache L2 cross-instance coalesce',
+    function (hooks) {
+      let dbAdapter: PgAdapter;
+      let publisher: import('@cardstack/runtime-common').QueuePublisher;
+      let runner: import('@cardstack/runtime-common').QueueRunner;
+      setupDB(hooks, {
+        beforeEach: async (adapter, pub, run) => {
+          dbAdapter = adapter;
+          publisher = pub;
+          runner = run;
+        },
+      });
 
-    const peerRealmURL = 'http://127.0.0.1:5555/peer/';
-    const peerCardSource = `
+      const peerRealmURL = 'http://127.0.0.1:5555/peer/';
+      const peerCardSource = `
         import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
         import StringField from "https://cardstack.com/base/string";
 
@@ -1000,163 +1005,166 @@ module(basename(__filename), function () {
         }
       `;
 
-    async function buildPeerRealm(args: {
-      dir: string;
-      coordinator: ModuleCacheCoordinator;
-    }): Promise<Realm> {
-      let virtualNetwork = createVirtualNetwork();
-      let prerenderer = await getTestPrerenderer();
-      let definitionLookup = new CachingDefinitionLookup(
-        dbAdapter,
-        prerenderer,
-        virtualNetwork,
-        testCreatePrerenderAuth,
-      );
-      let { realm } = await createRealm({
-        dir: args.dir,
-        definitionLookup,
-        realmURL: peerRealmURL,
-        permissions: { '*': ['read', 'write'] },
-        virtualNetwork,
-        publisher,
-        runner,
-        dbAdapter,
-        transpileCoordinator: args.coordinator,
-      });
-      return realm;
-    }
-
-    async function setupTwoPeers(): Promise<{
-      realmA: Realm;
-      realmB: Realm;
-      coordA: ModuleCacheCoordinator;
-      coordB: ModuleCacheCoordinator;
-      cardPath: string;
-      canonicalUrl: string;
-    }> {
-      let tmp = dirSync();
-      let testRealmDir = join(tmp.name, 'peer-realm');
-      ensureDirSync(testRealmDir);
-      // Minimal .realm.json so the Realm bootstraps a name + readable
-      // visibility; the test only ever asks for module GETs.
-      writeJSONSync(join(testRealmDir, '.realm.json'), {
-        name: 'Peer Realm',
-      });
-      let cardPath = 'peer-card.gts';
-      writeFileSync(join(testRealmDir, cardPath), peerCardSource);
-
-      let coordA = new ModuleCacheCoordinator({ dbAdapter });
-      await coordA.start();
-      let coordB = new ModuleCacheCoordinator({ dbAdapter });
-      await coordB.start();
-      // Give both coordinators a moment to issue their LISTEN before
-      // the test fires NOTIFY traffic — matches the 100ms pause in
-      // module-cache-coordination-test.ts.
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      let realmA = await buildPeerRealm({
-        dir: testRealmDir,
-        coordinator: coordA,
-      });
-      let realmB = await buildPeerRealm({
-        dir: testRealmDir,
-        coordinator: coordB,
-      });
-
-      // Drop anything either realm filled during construction so the
-      // test's request is the only thing that can drive the counter.
-      realmA.__testOnlyClearCaches();
-      realmB.__testOnlyClearCaches();
-      // __testOnlyClearCaches fire-and-forgets the L2 bulk wipe; wait
-      // for it to land before reads.
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      let canonicalUrl = new URL(cardPath, peerRealmURL).href;
-      return { realmA, realmB, coordA, coordB, cardPath, canonicalUrl };
-    }
-
-    function moduleRequest(realm: Realm, cardPath: string): Request {
-      return new Request(new URL(cardPath, peerRealmURL).href, {
-        method: 'GET',
-        headers: {
-          Accept: SupportedMimeType.All,
-          Authorization: `Bearer ${createJWT(realm, 'user', ['read'])}`,
-        },
-      });
-    }
-
-    test('L2 row written by peer A is served from L2 by peer B without re-running babel', async function (assert) {
-      let { realmA, realmB, coordA, coordB, cardPath } = await setupTwoPeers();
-      try {
-        let respA = await realmA.handle(moduleRequest(realmA, cardPath));
-        assert.strictEqual(respA?.status, 200, 'peer A served the module');
-        assert.strictEqual(
-          realmA.__testOnlyGetTranspileCallCount(),
-          1,
-          'peer A ran babel exactly once',
+      async function buildPeerRealm(args: {
+        dir: string;
+        coordinator: ModuleCacheCoordinator;
+      }): Promise<Realm> {
+        let virtualNetwork = createVirtualNetwork();
+        let prerenderer = await getTestPrerenderer();
+        let definitionLookup = new CachingDefinitionLookup(
+          dbAdapter,
+          prerenderer,
+          virtualNetwork,
+          testCreatePrerenderAuth,
         );
-
-        let bCountBefore = realmB.__testOnlyGetTranspileCallCount();
-        let respB = await realmB.handle(moduleRequest(realmB, cardPath));
-        assert.strictEqual(respB?.status, 200, 'peer B served the module');
-        assert.strictEqual(
-          realmB.__testOnlyGetTranspileCallCount() - bCountBefore,
-          0,
-          'peer B served from the L2 row peer A wrote — no babel ran on peer B',
-        );
-      } finally {
-        await coordA.shutDown();
-        await coordB.shutDown();
-      }
-    });
-
-    test('two peers concurrently transpiling the same path coalesce through the coordinator: exactly one babel call across both', async function (assert) {
-      let { realmA, realmB, coordA, coordB, cardPath } = await setupTwoPeers();
-      try {
-        // Gate babel on both realms so whichever one wins the
-        // advisory lock parks inside transpileJS, holding the lock
-        // open. The loser's tryAcquireAndRun returns acquired:false
-        // BEFORE the runner fn is invoked, so the loser never reaches
-        // the delay — only the winner waits on the gate.
-        let releaseGate!: () => void;
-        let gate = new Promise<void>((resolve) => {
-          releaseGate = resolve;
+        let { realm } = await createRealm({
+          dir: args.dir,
+          definitionLookup,
+          realmURL: peerRealmURL,
+          permissions: { '*': ['read', 'write'] },
+          virtualNetwork,
+          publisher,
+          runner,
+          dbAdapter,
+          transpileCoordinator: args.coordinator,
         });
-        realmA.__testOnlyDelayTranspile(() => gate);
-        realmB.__testOnlyDelayTranspile(() => gate);
-
-        // Stagger A → B by 100ms so A reliably takes the pg advisory
-        // lock first; B then contends and observes acquired:false.
-        // Mirrors the staggered start in the CachingDefinitionLookup
-        // two-instance test.
-        let pA = realmA.handle(moduleRequest(realmA, cardPath));
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        let pB = realmB.handle(moduleRequest(realmB, cardPath));
-        await new Promise((resolve) => setTimeout(resolve, 100));
-
-        // At this point: A is parked inside materializeAndTranspile
-        // awaiting the gate (transpile counter hasn't bumped yet —
-        // the delay hook runs before the count). B has observed
-        // acquired:false and is parked on waitForKey waiting for the
-        // NOTIFY A will emit when its tx commits.
-        releaseGate();
-        let [respA, respB] = await Promise.all([pA, pB]);
-        assert.strictEqual(respA?.status, 200, 'peer A served 200');
-        assert.strictEqual(respB?.status, 200, 'peer B served 200');
-
-        let aTotal = realmA.__testOnlyGetTranspileCallCount();
-        let bTotal = realmB.__testOnlyGetTranspileCallCount();
-        assert.strictEqual(
-          aTotal + bTotal,
-          1,
-          'exactly one babel call across both peers — the L2 winner wrote and the loser read',
-        );
-      } finally {
-        realmA.__testOnlyDelayTranspile(undefined);
-        realmB.__testOnlyDelayTranspile(undefined);
-        await coordA.shutDown();
-        await coordB.shutDown();
+        return realm;
       }
-    });
-  });
+
+      async function setupTwoPeers(): Promise<{
+        realmA: Realm;
+        realmB: Realm;
+        coordA: ModuleCacheCoordinator;
+        coordB: ModuleCacheCoordinator;
+        cardPath: string;
+        canonicalUrl: string;
+      }> {
+        let tmp = dirSync();
+        let testRealmDir = join(tmp.name, 'peer-realm');
+        ensureDirSync(testRealmDir);
+        // Minimal .realm.json so the Realm bootstraps a name + readable
+        // visibility; the test only ever asks for module GETs.
+        writeJSONSync(join(testRealmDir, '.realm.json'), {
+          name: 'Peer Realm',
+        });
+        let cardPath = 'peer-card.gts';
+        writeFileSync(join(testRealmDir, cardPath), peerCardSource);
+
+        let coordA = new ModuleCacheCoordinator({ dbAdapter });
+        await coordA.start();
+        let coordB = new ModuleCacheCoordinator({ dbAdapter });
+        await coordB.start();
+        // Give both coordinators a moment to issue their LISTEN before
+        // the test fires NOTIFY traffic — matches the 100ms pause in
+        // module-cache-coordination-test.ts.
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        let realmA = await buildPeerRealm({
+          dir: testRealmDir,
+          coordinator: coordA,
+        });
+        let realmB = await buildPeerRealm({
+          dir: testRealmDir,
+          coordinator: coordB,
+        });
+
+        // Drop anything either realm filled during construction so the
+        // test's request is the only thing that can drive the counter.
+        realmA.__testOnlyClearCaches();
+        realmB.__testOnlyClearCaches();
+        // __testOnlyClearCaches fire-and-forgets the L2 bulk wipe; wait
+        // for it to land before reads.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        let canonicalUrl = new URL(cardPath, peerRealmURL).href;
+        return { realmA, realmB, coordA, coordB, cardPath, canonicalUrl };
+      }
+
+      function moduleRequest(realm: Realm, cardPath: string): Request {
+        return new Request(new URL(cardPath, peerRealmURL).href, {
+          method: 'GET',
+          headers: {
+            Accept: SupportedMimeType.All,
+            Authorization: `Bearer ${createJWT(realm, 'user', ['read'])}`,
+          },
+        });
+      }
+
+      test('L2 row written by peer A is served from L2 by peer B without re-running babel', async function (assert) {
+        let { realmA, realmB, coordA, coordB, cardPath } =
+          await setupTwoPeers();
+        try {
+          let respA = await realmA.handle(moduleRequest(realmA, cardPath));
+          assert.strictEqual(respA?.status, 200, 'peer A served the module');
+          assert.strictEqual(
+            realmA.__testOnlyGetTranspileCallCount(),
+            1,
+            'peer A ran babel exactly once',
+          );
+
+          let bCountBefore = realmB.__testOnlyGetTranspileCallCount();
+          let respB = await realmB.handle(moduleRequest(realmB, cardPath));
+          assert.strictEqual(respB?.status, 200, 'peer B served the module');
+          assert.strictEqual(
+            realmB.__testOnlyGetTranspileCallCount() - bCountBefore,
+            0,
+            'peer B served from the L2 row peer A wrote — no babel ran on peer B',
+          );
+        } finally {
+          await coordA.shutDown();
+          await coordB.shutDown();
+        }
+      });
+
+      test('two peers concurrently transpiling the same path coalesce through the coordinator: exactly one babel call across both', async function (assert) {
+        let { realmA, realmB, coordA, coordB, cardPath } =
+          await setupTwoPeers();
+        try {
+          // Gate babel on both realms so whichever one wins the
+          // advisory lock parks inside transpileJS, holding the lock
+          // open. The loser's tryAcquireAndRun returns acquired:false
+          // BEFORE the runner fn is invoked, so the loser never reaches
+          // the delay — only the winner waits on the gate.
+          let releaseGate!: () => void;
+          let gate = new Promise<void>((resolve) => {
+            releaseGate = resolve;
+          });
+          realmA.__testOnlyDelayTranspile(() => gate);
+          realmB.__testOnlyDelayTranspile(() => gate);
+
+          // Stagger A → B by 100ms so A reliably takes the pg advisory
+          // lock first; B then contends and observes acquired:false.
+          // Mirrors the staggered start in the CachingDefinitionLookup
+          // two-instance test.
+          let pA = realmA.handle(moduleRequest(realmA, cardPath));
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          let pB = realmB.handle(moduleRequest(realmB, cardPath));
+          await new Promise((resolve) => setTimeout(resolve, 100));
+
+          // At this point: A is parked inside materializeAndTranspile
+          // awaiting the gate (transpile counter hasn't bumped yet —
+          // the delay hook runs before the count). B has observed
+          // acquired:false and is parked on waitForKey waiting for the
+          // NOTIFY A will emit when its tx commits.
+          releaseGate();
+          let [respA, respB] = await Promise.all([pA, pB]);
+          assert.strictEqual(respA?.status, 200, 'peer A served 200');
+          assert.strictEqual(respB?.status, 200, 'peer B served 200');
+
+          let aTotal = realmA.__testOnlyGetTranspileCallCount();
+          let bTotal = realmB.__testOnlyGetTranspileCallCount();
+          assert.strictEqual(
+            aTotal + bTotal,
+            1,
+            'exactly one babel call across both peers — the L2 winner wrote and the loser read',
+          );
+        } finally {
+          realmA.__testOnlyDelayTranspile(undefined);
+          realmB.__testOnlyDelayTranspile(undefined);
+          await coordA.shutDown();
+          await coordB.shutDown();
+        }
+      });
+    },
+  );
 });

--- a/packages/realm-server/tests/module-cache-race-test.ts
+++ b/packages/realm-server/tests/module-cache-race-test.ts
@@ -26,12 +26,12 @@ import {
 } from './helpers';
 
 // CS-11028: regression coverage for the persist-after-invalidate race in
-// Realm.#moduleCache. The scenario: reader A enters fallbackHandle for
+// Realm.#transpiledModuleCache. The scenario: reader A enters fallbackHandle for
 // foo.gts, snapshots the module-cache generation, then awaits transpileJS
 // (50–500 ms). While A is in-flight, invalidateCache(foo.gts) runs —
 // synchronously bumping the per-path generation and clearing whatever was
 // in the cache (a no-op if A hadn't filled it yet). Without the fix A's
-// post-transpile #moduleCache.set re-fills the slot with pre-invalidation
+// post-transpile #transpiledModuleCache.set re-fills the slot with pre-invalidation
 // bytes, so the next reader sees stale code until something else triggers
 // another invalidate. The fix snapshots the generation BEFORE the first
 // await and discards the cache write when the generation moved.
@@ -46,7 +46,7 @@ import {
 // `x-boxel-cache` header — a miss proves A's cache write was discarded.
 module(basename(__filename), function () {
   module(
-    'Realm.#moduleCache invalidate-during-transpile race',
+    'Realm.#transpiledModuleCache invalidate-during-transpile race',
     function (hooks) {
       let realmURL = new URL('http://127.0.0.1:4444/test/');
       let testRealm: Realm;
@@ -123,7 +123,7 @@ module(basename(__filename), function () {
         await new Promise((resolve) => setTimeout(resolve, 50));
 
         // Invalidate mid-transpile. The generation counter bumps; A's
-        // post-transpile #moduleCache.set will compare its snapshot against
+        // post-transpile #transpiledModuleCache.set will compare its snapshot against
         // the now-bumped counter and skip the write.
         testRealm.invalidateCache(modulePath);
 
@@ -211,7 +211,7 @@ module(basename(__filename), function () {
         );
 
         // The canonical request side already worked before this fix
-        // (#moduleCache.invalidate cleared the canonical entry), but
+        // (#transpiledModuleCache.invalidate cleared the canonical entry), but
         // verify it still misses so the fix doesn't regress it.
         let canonicalResponse = await request
           .get(`/${canonicalPath}`)
@@ -227,7 +227,7 @@ module(basename(__filename), function () {
       test('in-flight transpile result is dropped when testRealm.write fires concurrently (user-visible bug)', async function (assert) {
         // The original bug report: "file edited and saved, host page reload
         // serves the pre-edit module bytes." A user write goes through
-        // writeMany, which used to mutate #moduleCache directly without
+        // writeMany, which used to mutate #transpiledModuleCache directly without
         // bumping the generation counter — letting an in-flight transpile's
         // post-await cache.set silently fill the slot writeMany just
         // cleared. This test exercises the same code path the user does.
@@ -298,7 +298,7 @@ module(basename(__filename), function () {
   // tracks a monotonic transpile counter exposed via
   // __testOnlyGetTranspileCallCount so the tests can assert "exactly one
   // transpile call" directly rather than inferring it from timing.
-  module('Realm.#moduleCache in-flight transpile dedup', function (hooks) {
+  module('Realm.#transpiledModuleCache in-flight transpile dedup', function (hooks) {
     let realmURL = new URL('http://127.0.0.1:4444/test/');
     let testRealm: Realm;
     let request: RealmRequest;
@@ -676,7 +676,7 @@ module(basename(__filename), function () {
   // coalesce behavior is exercised by module-cache-coordination-test.ts
   // and reused via the shared MODULE_CACHE_POPULATED_CHANNEL.
   module(
-    'Realm.#moduleCache L2 module_transpile_cache (DB-backed)',
+    'Realm.#transpiledModuleCache L2 module_transpile_cache (DB-backed)',
     function (hooks) {
       let realmURL = new URL('http://127.0.0.1:4444/test/');
       let testRealm: Realm;
@@ -973,7 +973,7 @@ module(basename(__filename), function () {
   // the advisory-lock + NOTIFY channel. Mirrors the
   // CachingDefinitionLookup two-instance test in
   // module-cache-coordination-test.ts but exercises the transpile flow.
-  module('Realm.#moduleCache L2 cross-instance coalesce', function (hooks) {
+  module('Realm.#transpiledModuleCache L2 cross-instance coalesce', function (hooks) {
     let dbAdapter: PgAdapter;
     let publisher: import('@cardstack/runtime-common').QueuePublisher;
     let runner: import('@cardstack/runtime-common').QueueRunner;

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -905,7 +905,7 @@ module(basename(__filename), function () {
       // file-watcher catches up (potentially many hours later in
       // production), the published URL keeps serving stale HTML.
       //
-      // The fix (handle-publish-realm calling Realm.clearLocalCaches()
+      // The fix (handle-publish-realm calling Realm.clearLocalSourceCaches()
       // before enqueueing the reindex) is verified end-to-end by the
       // matrix Playwright test, but the data-layer invariant is faster
       // to assert here: after republish, the boxel_index row for the

--- a/packages/realm-server/tests/realm-file-changes-listener-test.ts
+++ b/packages/realm-server/tests/realm-file-changes-listener-test.ts
@@ -9,7 +9,7 @@ import {
 } from '../lib/realm-file-changes-listener';
 
 // Minimal fake `Realm` — the listener calls `.url` (via lookup),
-// `.invalidateCache(path)` for per-path payloads, and `.clearLocalCaches()`
+// `.invalidateCache(path)` for per-path payloads, and `.clearLocalSourceCaches()`
 // for wildcard payloads (CS-11156). Stub both; tests pick whichever they
 // care about.
 function makeFakeRealm(
@@ -24,7 +24,7 @@ function makeFakeRealm(
     invalidateCache(path: string) {
       hooks.onInvalidate?.(path);
     },
-    clearLocalCaches() {
+    clearLocalSourceCaches() {
       hooks.onClearAll?.();
     },
   } as unknown as Realm;
@@ -122,7 +122,7 @@ module(basename(__filename), function () {
       ]);
     });
 
-    test('handleNotification with wildcard payload calls clearLocalCaches and not invalidateCache (CS-11156)', function (assert) {
+    test('handleNotification with wildcard payload calls clearLocalSourceCaches and not invalidateCache (CS-11156)', function (assert) {
       const invalidations: string[] = [];
       const clearAllCount = { value: 0 };
       const realmA = makeFakeRealm('http://x.test/a/', {
@@ -140,7 +140,7 @@ module(basename(__filename), function () {
       assert.strictEqual(
         clearAllCount.value,
         1,
-        'clearLocalCaches called exactly once',
+        'clearLocalSourceCaches called exactly once',
       );
       assert.deepEqual(
         invalidations,
@@ -229,7 +229,7 @@ module(basename(__filename), function () {
       }
     });
 
-    test('notifyAllFileChanges round-trip: emitter → NOTIFY → listener → clearLocalCaches (CS-11156)', async function (assert) {
+    test('notifyAllFileChanges round-trip: emitter → NOTIFY → listener → clearLocalSourceCaches (CS-11156)', async function (assert) {
       // Models the cross-replica case: the emitter is what the publish /
       // unpublish / delete realm handlers call after the FS swap; the
       // listener is a peer replica's subscription. End-to-end through the
@@ -253,14 +253,14 @@ module(basename(__filename), function () {
         assert.strictEqual(
           clearAllCount.value,
           1,
-          'peer-side clearLocalCaches called once after the bulk emit',
+          'peer-side clearLocalSourceCaches called once after the bulk emit',
         );
       } finally {
         await listener.shutDown();
       }
     });
 
-    test('NOTIFY realm_file_changes wildcard → listener → clearLocalCaches (CS-11156)', async function (assert) {
+    test('NOTIFY realm_file_changes wildcard → listener → clearLocalSourceCaches (CS-11156)', async function (assert) {
       const invalidations: string[] = [];
       const clearAllCount = { value: 0 };
       const realmUrl = 'http://x.test/listen-e2e-bulk/';
@@ -282,7 +282,7 @@ module(basename(__filename), function () {
         assert.strictEqual(
           clearAllCount.value,
           1,
-          'clearLocalCaches called exactly once',
+          'clearLocalSourceCaches called exactly once',
         );
         assert.deepEqual(
           invalidations,

--- a/packages/realm-server/tests/realm-file-changes-listener-test.ts
+++ b/packages/realm-server/tests/realm-file-changes-listener-test.ts
@@ -1,23 +1,31 @@
 import { module, test } from 'qunit';
 import { basename } from 'path';
 import type { PgAdapter } from '@cardstack/postgres';
-import type { Realm } from '@cardstack/runtime-common';
+import { notifyAllFileChanges, type Realm } from '@cardstack/runtime-common';
 import { setupDB } from './helpers';
 import {
   RealmFileChangesListener,
   parsePayload,
 } from '../lib/realm-file-changes-listener';
 
-// Minimal fake `Realm` — the listener only calls `.url` (via lookup) and
-// `.invalidateCache(path)`, so that's all we need to stub.
+// Minimal fake `Realm` — the listener calls `.url` (via lookup),
+// `.invalidateCache(path)` for per-path payloads, and `.clearLocalCaches()`
+// for wildcard payloads (CS-11156). Stub both; tests pick whichever they
+// care about.
 function makeFakeRealm(
   url: string,
-  onInvalidate: (path: string) => void,
+  hooks: {
+    onInvalidate?: (path: string) => void;
+    onClearAll?: () => void;
+  },
 ): Realm {
   return {
     url,
     invalidateCache(path: string) {
-      onInvalidate(path);
+      hooks.onInvalidate?.(path);
+    },
+    clearLocalCaches() {
+      hooks.onClearAll?.();
     },
   } as unknown as Realm;
 }
@@ -78,14 +86,29 @@ module(basename(__filename), function () {
     test('returns undefined when the path is empty', function (assert) {
       assert.strictEqual(parsePayload('http://x/:'), undefined);
     });
+
+    test('parses a wildcard payload (bulk invalidation, CS-11156)', function (assert) {
+      assert.deepEqual(parsePayload('http://x.test/r/:*'), {
+        url: 'http://x.test/r/',
+        path: '*',
+      });
+    });
+
+    test('parses a wildcard payload against a url with a port (CS-11156)', function (assert) {
+      assert.deepEqual(parsePayload('http://localhost:4201/luke/src/:*'), {
+        url: 'http://localhost:4201/luke/src/',
+        path: '*',
+      });
+    });
   });
 
   module('RealmFileChangesListener (dispatch)', function () {
     test('handleNotification forwards to the mounted realm', function (assert) {
       const invalidations: Array<{ url: string; path: string }> = [];
-      const realmA = makeFakeRealm('http://x.test/a/', (path) =>
-        invalidations.push({ url: 'http://x.test/a/', path }),
-      );
+      const realmA = makeFakeRealm('http://x.test/a/', {
+        onInvalidate: (path) =>
+          invalidations.push({ url: 'http://x.test/a/', path }),
+      });
       const listener = new RealmFileChangesListener({
         dbAdapter: {} as unknown as PgAdapter,
         lookupMountedRealm: (url) =>
@@ -97,6 +120,33 @@ module(basename(__filename), function () {
       assert.deepEqual(invalidations, [
         { url: 'http://x.test/a/', path: 'cards/foo.gts' },
       ]);
+    });
+
+    test('handleNotification with wildcard payload calls clearLocalCaches and not invalidateCache (CS-11156)', function (assert) {
+      const invalidations: string[] = [];
+      const clearAllCount = { value: 0 };
+      const realmA = makeFakeRealm('http://x.test/a/', {
+        onInvalidate: (path) => invalidations.push(path),
+        onClearAll: () => clearAllCount.value++,
+      });
+      const listener = new RealmFileChangesListener({
+        dbAdapter: {} as unknown as PgAdapter,
+        lookupMountedRealm: (url) =>
+          url === 'http://x.test/a/' ? realmA : undefined,
+      });
+
+      listener.handleNotification('http://x.test/a/:*');
+
+      assert.strictEqual(
+        clearAllCount.value,
+        1,
+        'clearLocalCaches called exactly once',
+      );
+      assert.deepEqual(
+        invalidations,
+        [],
+        'invalidateCache not called for wildcard payload',
+      );
     });
 
     test('handleNotification drops silently when the url is not mounted', function (assert) {
@@ -154,9 +204,9 @@ module(basename(__filename), function () {
     test('NOTIFY realm_file_changes → listener → invalidateCache', async function (assert) {
       const invalidations: Array<{ url: string; path: string }> = [];
       const realmUrl = 'http://x.test/listen-e2e/';
-      const realmA = makeFakeRealm(realmUrl, (path) =>
-        invalidations.push({ url: realmUrl, path }),
-      );
+      const realmA = makeFakeRealm(realmUrl, {
+        onInvalidate: (path) => invalidations.push({ url: realmUrl, path }),
+      });
       const listener = new RealmFileChangesListener({
         dbAdapter,
         lookupMountedRealm: (url) => (url === realmUrl ? realmA : undefined),
@@ -174,6 +224,71 @@ module(basename(__filename), function () {
         assert.deepEqual(received, [
           { url: realmUrl, path: 'src/greeting.gts' },
         ]);
+      } finally {
+        await listener.shutDown();
+      }
+    });
+
+    test('notifyAllFileChanges round-trip: emitter → NOTIFY → listener → clearLocalCaches (CS-11156)', async function (assert) {
+      // Models the cross-replica case: the emitter is what the publish /
+      // unpublish / delete realm handlers call after the FS swap; the
+      // listener is a peer replica's subscription. End-to-end through the
+      // shared Postgres NOTIFY channel.
+      const clearAllCount = { value: 0 };
+      const realmUrl = 'http://x.test/listen-e2e-bulk-emit/';
+      const realmA = makeFakeRealm(realmUrl, {
+        onClearAll: () => clearAllCount.value++,
+      });
+      const listener = new RealmFileChangesListener({
+        dbAdapter,
+        lookupMountedRealm: (url) => (url === realmUrl ? realmA : undefined),
+      });
+      await listener.start();
+      try {
+        await notifyAllFileChanges(dbAdapter, realmUrl);
+
+        await waitFor(() =>
+          clearAllCount.value > 0 ? clearAllCount.value : undefined,
+        );
+        assert.strictEqual(
+          clearAllCount.value,
+          1,
+          'peer-side clearLocalCaches called once after the bulk emit',
+        );
+      } finally {
+        await listener.shutDown();
+      }
+    });
+
+    test('NOTIFY realm_file_changes wildcard → listener → clearLocalCaches (CS-11156)', async function (assert) {
+      const invalidations: string[] = [];
+      const clearAllCount = { value: 0 };
+      const realmUrl = 'http://x.test/listen-e2e-bulk/';
+      const realmA = makeFakeRealm(realmUrl, {
+        onInvalidate: (path) => invalidations.push(path),
+        onClearAll: () => clearAllCount.value++,
+      });
+      const listener = new RealmFileChangesListener({
+        dbAdapter,
+        lookupMountedRealm: (url) => (url === realmUrl ? realmA : undefined),
+      });
+      await listener.start();
+      try {
+        await dbAdapter.notify('realm_file_changes', `${realmUrl}:*`);
+
+        await waitFor(() =>
+          clearAllCount.value > 0 ? clearAllCount.value : undefined,
+        );
+        assert.strictEqual(
+          clearAllCount.value,
+          1,
+          'clearLocalCaches called exactly once',
+        );
+        assert.deepEqual(
+          invalidations,
+          [],
+          'invalidateCache not called for wildcard',
+        );
       } finally {
         await listener.shutDown();
       }

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -272,7 +272,9 @@ export interface DefinitionLookup {
   clearAllDefinitions(): Promise<void>;
   registerRealm(realm: LocalRealm): void;
   forRealm(realm: LocalRealm): DefinitionLookup;
-  getCachedDefinitions(moduleUrl: string): Promise<DefinitionCacheEntry | undefined>;
+  getCachedDefinitions(
+    moduleUrl: string,
+  ): Promise<DefinitionCacheEntry | undefined>;
   getCachedDefinitionsBatch(
     query: DefinitionCacheEntryQuery,
   ): Promise<DefinitionCacheEntries>;
@@ -434,8 +436,12 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     //     runs the prerender and persist directly. This is the path
     //     used by every test that doesn't construct a coordinator and
     //     by sqlite/in-memory deployments.
-    let core: Promise<DefinitionCacheEntry | undefined> = this.#populateCoordinator
-      ? this.loadDefinitionCacheEntryCoordinated(args, this.#populateCoordinator)
+    let core: Promise<DefinitionCacheEntry | undefined> = this
+      .#populateCoordinator
+      ? this.loadDefinitionCacheEntryCoordinated(
+          args,
+          this.#populateCoordinator,
+        )
       : this.loadDefinitionCacheEntryUncached(args);
     pending = core.finally(() => {
       // Identity-check before deletion: an invalidation path may have

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -43,8 +43,8 @@ const PREFERRED_EXECUTABLE_EXTENSIONS = ['.gts', '.ts', '.gjs', '.js'];
 // peer realm-server processes can bump their in-memory generation counters
 // in lockstep with the DB. Payload is JSON; one of:
 //   {"k":"module","r":<resolvedRealmURL>,"m":[<moduleURL>,...]} — invalidate fan-out
-//   {"k":"realm","r":<resolvedRealmURL>}                        — clearRealmCache
-//   {"k":"global"}                                              — clearAllModules
+//   {"k":"realm","r":<resolvedRealmURL>}                        — clearRealmDefinitions
+//   {"k":"global"}                                              — clearAllDefinitions
 // Self-notify is idempotent: the emitting process already bumped its
 // counter synchronously before the DB delete, and a second bump on
 // listener receive is observationally equivalent (counters are monotonic
@@ -56,7 +56,7 @@ const NOTIFY_PAYLOAD_BUDGET = 7000;
 // Postgres NOTIFY channel for cross-instance prerender-coalesce wakeups
 // (CS-10953). The winner of a `pg_try_advisory_xact_lock` for a given
 // inFlightKey emits this notify (with the inFlightKey as payload) inside
-// the same transaction as its persistModuleCacheEntry, so peer waiters
+// the same transaction as its persistDefinitionCacheEntry, so peer waiters
 // see the signal only on commit (the cache row is visible to their
 // re-read by the time their wait resolves). Loser path on
 // missed-NOTIFY falls back to a bounded-timeout re-read.
@@ -156,7 +156,7 @@ function parseJsonValue<T>(value: T | string | null): T | null {
 export type CacheScope = 'public' | 'realm-auth';
 type LocalRealm = Pick<Realm, 'url' | 'getRealmOwnerUserId' | 'visibility'>;
 
-export interface ModuleCacheEntry {
+export interface DefinitionCacheEntry {
   definitions: Record<string, ModuleDefinitionResult | ErrorEntry>;
   deps: string[];
   error?: ErrorEntry;
@@ -166,14 +166,14 @@ export interface ModuleCacheEntry {
   createdAt?: number;
 }
 
-export interface ModuleCacheEntryQuery {
+export interface DefinitionCacheEntryQuery {
   moduleUrls: string[];
   cacheScope: CacheScope;
   authUserId: string;
   resolvedRealmURL: string;
 }
 
-export type ModuleCacheEntries = Record<string, ModuleCacheEntry>;
+export type DefinitionCacheEntries = Record<string, DefinitionCacheEntry>;
 
 interface WriteToDatabaseCacheParams {
   moduleUrl: string;
@@ -268,14 +268,14 @@ export interface DefinitionLookup {
     codeRef: ResolvedCodeRef,
   ): Promise<Definition | undefined>;
   invalidate(moduleURL: string): Promise<string[]>;
-  clearRealmCache(resolvedRealmURL: string): Promise<void>;
-  clearAllModules(): Promise<void>;
+  clearRealmDefinitions(resolvedRealmURL: string): Promise<void>;
+  clearAllDefinitions(): Promise<void>;
   registerRealm(realm: LocalRealm): void;
   forRealm(realm: LocalRealm): DefinitionLookup;
-  getModuleCacheEntry(moduleUrl: string): Promise<ModuleCacheEntry | undefined>;
-  getModuleCacheEntries(
-    query: ModuleCacheEntryQuery,
-  ): Promise<ModuleCacheEntries>;
+  getCachedDefinitions(moduleUrl: string): Promise<DefinitionCacheEntry | undefined>;
+  getCachedDefinitionsBatch(
+    query: DefinitionCacheEntryQuery,
+  ): Promise<DefinitionCacheEntries>;
 }
 
 interface LookupContext {
@@ -291,13 +291,13 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     userId: string,
     permissions: RealmPermissions,
   ) => string;
-  // Dedupes concurrent loadModuleCacheEntry calls that would hit the same
+  // Dedupes concurrent loadDefinitionCacheEntry calls that would hit the same
   // cache row so a single prerenderer round-trip is shared by all waiters
   // instead of each caller racing to the prerenderer independently.
-  #inFlight = new Map<string, Promise<ModuleCacheEntry | undefined>>();
+  #inFlight = new Map<string, Promise<DefinitionCacheEntry | undefined>>();
   // Invalidation generations. Bumped synchronously by invalidate /
-  // clearRealmCache / clearAllModules before the DB delete.
-  // loadModuleCacheEntryUncached snapshots all three values at entry and
+  // clearRealmDefinitions / clearAllDefinitions before the DB delete.
+  // loadDefinitionCacheEntryUncached snapshots all three values at entry and
   // re-checks them just before persist; if any changed, the in-flight
   // prerender's result is discarded rather than re-inserted, so the cache
   // wipe isn't undone by a prerender that started against pre-invalidation
@@ -307,15 +307,15 @@ export class CachingDefinitionLookup implements DefinitionLookup {
   //     specific URLs avoids spuriously discarding an in-flight prerender
   //     for an unrelated module in the same realm.
   //   - #realmGenerations: keyed by `resolvedRealmURL`; bumped by
-  //     clearRealmCache() so every in-flight prerender for that realm is
+  //     clearRealmDefinitions() so every in-flight prerender for that realm is
   //     invalidated, including modules not yet in #moduleGenerations.
-  //   - #globalGeneration: bumped by clearAllModules() so every in-flight
+  //   - #globalGeneration: bumped by clearAllDefinitions() so every in-flight
   //     prerender is invalidated regardless of realm or module URL.
   #moduleGenerations = new Map<string, number>();
   #realmGenerations = new Map<string, number>();
   #globalGeneration = 0;
   // CS-10953 cross-process prerender coalescer. Optional — when undefined,
-  // loadModuleCacheEntryUncached runs the original uncoordinated path.
+  // loadDefinitionCacheEntryUncached runs the original uncoordinated path.
   // Constructed only by the realm-server main when
   // PRERENDER_COALESCE_ACROSS_PROCESSES is enabled and the dbAdapter is pg.
   #populateCoordinator?: PopulateCoordinator;
@@ -381,9 +381,9 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     return undefined;
   }
 
-  async getModuleCacheEntry(
+  async getCachedDefinitions(
     moduleUrl: string,
-  ): Promise<ModuleCacheEntry | undefined> {
+  ): Promise<DefinitionCacheEntry | undefined> {
     let canonicalModuleURL = canonicalURL(moduleUrl);
     let context = await this.buildLookupContext(canonicalModuleURL);
     if (!context) {
@@ -396,7 +396,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       cacheScope,
       resolvedRealmURL,
     } = context;
-    return await this.loadModuleCacheEntry({
+    return await this.loadDefinitionCacheEntry({
       moduleURL: canonicalModuleURL,
       realmURL,
       resolvedRealmURL,
@@ -410,20 +410,20 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     return await query(this.#dbAdapter, expression, coerceTypes);
   }
 
-  private async loadModuleCacheEntry(args: {
+  private async loadDefinitionCacheEntry(args: {
     moduleURL: string;
     realmURL: string;
     resolvedRealmURL: string;
     cacheScope: CacheScope;
     cacheUserId: string;
     prerenderUserId: string;
-  }): Promise<ModuleCacheEntry | undefined> {
+  }): Promise<DefinitionCacheEntry | undefined> {
     let key = inFlightKey(args);
     let existing = this.#inFlight.get(key);
     if (existing) {
       return await existing;
     }
-    let pending: Promise<ModuleCacheEntry | undefined>;
+    let pending: Promise<DefinitionCacheEntry | undefined>;
     // Two paths inside #inFlight:
     //   - With a populate coordinator (CS-10953): coordinated path adds
     //     a pg_try_advisory_xact_lock around the prerender so at most
@@ -434,9 +434,9 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     //     runs the prerender and persist directly. This is the path
     //     used by every test that doesn't construct a coordinator and
     //     by sqlite/in-memory deployments.
-    let core: Promise<ModuleCacheEntry | undefined> = this.#populateCoordinator
-      ? this.loadModuleCacheEntryCoordinated(args, this.#populateCoordinator)
-      : this.loadModuleCacheEntryUncached(args);
+    let core: Promise<DefinitionCacheEntry | undefined> = this.#populateCoordinator
+      ? this.loadDefinitionCacheEntryCoordinated(args, this.#populateCoordinator)
+      : this.loadDefinitionCacheEntryUncached(args);
     pending = core.finally(() => {
       // Identity-check before deletion: an invalidation path may have
       // dropped our entry mid-flight, after which a newer caller can
@@ -478,7 +478,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
   //     returns the post-invalidate cache state (undefined or fresher
   //     row); coordinator notifies regardless so peer waiters wake
   //     promptly. Same observable behavior as N=1 generation-mismatch.
-  private async loadModuleCacheEntryCoordinated(
+  private async loadDefinitionCacheEntryCoordinated(
     args: {
       moduleURL: string;
       realmURL: string;
@@ -488,7 +488,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       prerenderUserId: string;
     },
     coordinator: PopulateCoordinator,
-  ): Promise<ModuleCacheEntry | undefined> {
+  ): Promise<DefinitionCacheEntry | undefined> {
     let coalesceKey = inFlightKey(args);
     for (let iteration = 0; iteration < COALESCE_MAX_ITERATIONS; iteration++) {
       // Optimistic pre-lock cache read. On a hit we skip the lock
@@ -507,7 +507,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       }
 
       let outcome = await coordinator.tryAcquireAndRun(coalesceKey, async () =>
-        this.loadModuleCacheEntryUncached(args),
+        this.loadDefinitionCacheEntryUncached(args),
       );
       if (outcome.acquired) {
         // Winner. Result might be undefined if all populationCandidates
@@ -523,11 +523,11 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       await coordinator.waitForKey(coalesceKey, COALESCE_NOTIFY_WAIT_MS);
     }
     throw new Error(
-      `loadModuleCacheEntryCoordinated exceeded ${COALESCE_MAX_ITERATIONS} iterations for ${coalesceKey}; peer prerender appears stuck or NOTIFY broadcast is broken`,
+      `loadDefinitionCacheEntryCoordinated exceeded ${COALESCE_MAX_ITERATIONS} iterations for ${coalesceKey}; peer prerender appears stuck or NOTIFY broadcast is broken`,
     );
   }
 
-  private async loadModuleCacheEntryUncached({
+  private async loadDefinitionCacheEntryUncached({
     moduleURL,
     realmURL,
     resolvedRealmURL,
@@ -541,9 +541,9 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     cacheScope: CacheScope;
     cacheUserId: string;
     prerenderUserId: string;
-  }): Promise<ModuleCacheEntry | undefined> {
+  }): Promise<DefinitionCacheEntry | undefined> {
     // Snapshot invalidation generations BEFORE the first await.
-    // clearRealmCache (and any future synchronous bump) runs entirely before
+    // clearRealmDefinitions (and any future synchronous bump) runs entirely before
     // its first await, so a snapshot taken after an await above would already
     // include the bump and silently match at persist time. Invalidate happens
     // to await before bumping, so this point of failure is asymmetric — but
@@ -598,7 +598,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
           resolvedRealmURL,
         );
       }
-      return await this.persistModuleCacheEntry(
+      return await this.persistDefinitionCacheEntry(
         candidateURL,
         response,
         resolvedRealmURL,
@@ -639,7 +639,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
 
   // Public so the cross-instance ModuleCacheInvalidationListener (CS-10952)
   // can replay an invalidation broadcast from a peer realm-server into this
-  // process's counters. Internal callers in invalidate() / clearRealmCache()
+  // process's counters. Internal callers in invalidate() / clearRealmDefinitions()
   // use the same methods. Bumping is idempotent w.r.t. correctness — a
   // double-bump from the self-notify echo is observationally indistinguishable
   // from a single bump because in-flight prerenders only test for snapshot
@@ -667,7 +667,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
   // the error TTL. This causes the entry to be treated as a cache miss so
   // the prerenderer is called again to get a fresh result. This prevents
   // transient prerender failures from being permanently cached.
-  private isExpiredErrorEntry(entry: ModuleCacheEntry): boolean {
+  private isExpiredErrorEntry(entry: DefinitionCacheEntry): boolean {
     if (!entry.error) {
       return false;
     }
@@ -743,7 +743,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       resolvedRealmURL,
     } = context;
 
-    let moduleEntry = await this.loadModuleCacheEntry({
+    let moduleEntry = await this.loadDefinitionCacheEntry({
       moduleURL: canonicalModuleURL,
       realmURL,
       resolvedRealmURL,
@@ -813,14 +813,14 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     }
     this.dropInFlightForRealm(resolvedRealmURL, uniqueInvalidations);
     await this.deleteModuleAliases(resolvedRealmURL, uniqueInvalidations);
-    await this.notifyModuleCacheInvalidations(
+    await this.notifyDefinitionCacheInvalidations(
       resolvedRealmURL,
       uniqueInvalidations,
     );
     return uniqueInvalidations;
   }
 
-  async clearRealmCache(resolvedRealmURL: string): Promise<void> {
+  async clearRealmDefinitions(resolvedRealmURL: string): Promise<void> {
     // Realm-scope bump: every in-flight prerender for this realm (any
     // module URL, any scope/user) sees the mismatch at persist time.
     this.bumpRealmGeneration(resolvedRealmURL);
@@ -833,14 +833,14 @@ export class CachingDefinitionLookup implements DefinitionLookup {
         ['resolved_realm_url =', param(resolvedRealmURL)],
       ]) as Expression),
     ]);
-    await this.notifyRealmCacheInvalidation(resolvedRealmURL);
+    await this.notifyRealmDefinitionCacheInvalidation(resolvedRealmURL);
   }
 
-  async clearAllModules(): Promise<void> {
+  async clearAllDefinitions(): Promise<void> {
     this.bumpGlobalGeneration();
     this.#inFlight.clear();
     await this.query(['DELETE FROM', MODULES_TABLE]);
-    await this.notifyGlobalCacheInvalidation();
+    await this.notifyGlobalDefinitionCacheInvalidation();
   }
 
   // pg_notify emission helpers. Mirror Realm.#notifyFileChange's best-effort
@@ -862,7 +862,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
   // either way. Postgres caps NOTIFY payloads at 8000 bytes, so the module
   // emitter chunks the URL list to stay under a 7000-byte budget — common
   // case is one notify; pathological fan-out becomes a handful.
-  private async notifyModuleCacheInvalidations(
+  private async notifyDefinitionCacheInvalidations(
     resolvedRealmURL: string,
     moduleURLs: string[],
   ): Promise<void> {
@@ -897,7 +897,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     await flush();
   }
 
-  private async notifyRealmCacheInvalidation(
+  private async notifyRealmDefinitionCacheInvalidation(
     resolvedRealmURL: string,
   ): Promise<void> {
     if (this.#dbAdapter.kind !== 'pg') {
@@ -908,7 +908,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     );
   }
 
-  private async notifyGlobalCacheInvalidation(): Promise<void> {
+  private async notifyGlobalDefinitionCacheInvalidation(): Promise<void> {
     if (this.#dbAdapter.kind !== 'pg') {
       return;
     }
@@ -941,8 +941,8 @@ export class CachingDefinitionLookup implements DefinitionLookup {
   // round-trip cannot be cancelled and still completes, but because the
   // invalidation path also bumps the module / realm / global generation
   // synchronously before awaiting the DB delete, the in-flight's generation
-  // check in loadModuleCacheEntryUncached observes the bump before
-  // persistModuleCacheEntry runs and discards the result via
+  // check in loadDefinitionCacheEntryUncached observes the bump before
+  // persistDefinitionCacheEntry runs and discards the result via
   // readFromDatabaseCache instead of repopulating the cleared row. This
   // drop step is the in-flight-map half of the same fix: it ensures new
   // callers arriving after the invalidation don't attach to the now-
@@ -1099,7 +1099,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     cacheScope: CacheScope,
     authUserId: string,
     resolvedRealmURL: string,
-  ): Promise<ModuleCacheEntry | undefined> {
+  ): Promise<DefinitionCacheEntry | undefined> {
     let moduleAlias = normalizeExecutableURL(moduleUrl);
     let rows = (await this.query(
       [
@@ -1154,9 +1154,9 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     };
   }
 
-  async getModuleCacheEntries(
-    query: ModuleCacheEntryQuery,
-  ): Promise<ModuleCacheEntries> {
+  async getCachedDefinitionsBatch(
+    query: DefinitionCacheEntryQuery,
+  ): Promise<DefinitionCacheEntries> {
     if (query.moduleUrls.length === 0) {
       return {};
     }
@@ -1196,7 +1196,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       resolved_realm_url: string | null;
     }[];
 
-    let entries: ModuleCacheEntries = {};
+    let entries: DefinitionCacheEntries = {};
     let assignEntry = (key: string, row: (typeof rows)[number]) => {
       let definitions =
         parseJsonValue<Record<string, ModuleDefinitionResult | ErrorEntry>>(
@@ -1295,13 +1295,13 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     ]);
   }
 
-  private async persistModuleCacheEntry(
+  private async persistDefinitionCacheEntry(
     moduleUrl: string,
     response: ModuleRenderResponse,
     resolvedRealmURL: string,
     cacheScope: CacheScope,
     userId: string,
-  ): Promise<ModuleCacheEntry> {
+  ): Promise<DefinitionCacheEntry> {
     let entryURL = new URL(moduleUrl);
     let normalizedDeps = this.normalizeDependencies(
       response.deps ?? [],
@@ -1329,7 +1329,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     if (errorEntry?.error.deps?.length) {
       deps = [...new Set([...deps, ...errorEntry.error.deps])];
     }
-    let cacheEntry: ModuleCacheEntry = {
+    let cacheEntry: DefinitionCacheEntry = {
       definitions: response.definitions ?? {},
       deps,
       error: errorEntry,
@@ -1717,12 +1717,12 @@ class RealmScopedDefinitionLookup implements DefinitionLookup {
     return await this.#inner.invalidate(moduleURL);
   }
 
-  async clearRealmCache(resolvedRealmURL: string): Promise<void> {
-    await this.#inner.clearRealmCache(resolvedRealmURL);
+  async clearRealmDefinitions(resolvedRealmURL: string): Promise<void> {
+    await this.#inner.clearRealmDefinitions(resolvedRealmURL);
   }
 
-  async clearAllModules(): Promise<void> {
-    await this.#inner.clearAllModules();
+  async clearAllDefinitions(): Promise<void> {
+    await this.#inner.clearAllDefinitions();
   }
 
   registerRealm(realm: LocalRealm): void {
@@ -1733,15 +1733,15 @@ class RealmScopedDefinitionLookup implements DefinitionLookup {
     return this.#inner.forRealm(realm);
   }
 
-  async getModuleCacheEntry(
+  async getCachedDefinitions(
     moduleUrl: string,
-  ): Promise<ModuleCacheEntry | undefined> {
-    return await this.#inner.getModuleCacheEntry(moduleUrl);
+  ): Promise<DefinitionCacheEntry | undefined> {
+    return await this.#inner.getCachedDefinitions(moduleUrl);
   }
 
-  async getModuleCacheEntries(
-    query: ModuleCacheEntryQuery,
-  ): Promise<ModuleCacheEntries> {
-    return await this.#inner.getModuleCacheEntries(query);
+  async getCachedDefinitionsBatch(
+    query: DefinitionCacheEntryQuery,
+  ): Promise<DefinitionCacheEntries> {
+    return await this.#inner.getCachedDefinitionsBatch(query);
   }
 }

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -147,13 +147,13 @@ export class IndexRunner {
     this.#definitionLookup = definitionLookup;
     this.#dependencyResolver = new IndexRunnerDependencyManager({
       realmURL: this.#realmURL,
-      readModuleCacheEntries: async (moduleIds) => {
+      readDefinitionCacheEntries: async (moduleIds) => {
         if (moduleIds.length === 0) {
           return {};
         }
         let { resolvedRealmURL, cacheScope, authUserId } =
           await this.getModuleCacheContext();
-        return await this.#definitionLookup.getModuleCacheEntries({
+        return await this.#definitionLookup.getCachedDefinitionsBatch({
           moduleUrls: moduleIds,
           cacheScope,
           authUserId,
@@ -555,8 +555,8 @@ export class IndexRunner {
   //
   // Cache hits are O(1) DB reads inside DefinitionLookup. Cache
   // misses go through the read-through path
-  // (loadModuleCacheEntryUncached → getModuleDefinitionsViaPrerenderer
-  // → persistModuleCacheEntry), the same flow `lookupDefinition`
+  // (loadDefinitionCacheEntryUncached → getModuleDefinitionsViaPrerenderer
+  // → persistDefinitionCacheEntry), the same flow `lookupDefinition`
   // uses; DefinitionLookup owns the in-flight dedup and the cross-
   // process coalescer, so two callers asking for the same URL share
   // one prerender.
@@ -630,7 +630,7 @@ export class IndexRunner {
     let failed = 0;
     for (let moduleUrl of toWarm) {
       try {
-        await this.#definitionLookup.getModuleCacheEntry(moduleUrl);
+        await this.#definitionLookup.getCachedDefinitions(moduleUrl);
       } catch {
         failed += 1;
       }

--- a/packages/runtime-common/index-runner/dependency-resolver.ts
+++ b/packages/runtime-common/index-runner/dependency-resolver.ts
@@ -3,7 +3,7 @@ import type {
   SearchIndexErrorEntry,
   SingleCardDocument,
 } from '../index';
-import type { ModuleCacheEntries } from '../definition-lookup';
+import type { DefinitionCacheEntries } from '../definition-lookup';
 import type { SerializedError } from '../error';
 import { canonicalURL } from './dependency-url';
 import { IndexBackedDependencyErrors } from './index-backed-dependency-errors';
@@ -16,7 +16,7 @@ type OrderingDependencyRow = Pick<DependencyIndexRow, 'url' | 'type' | 'deps'>;
 
 interface DependencyResolverOptions {
   realmURL: URL;
-  readModuleCacheEntries(moduleIds: string[]): Promise<ModuleCacheEntries>;
+  readDefinitionCacheEntries(moduleIds: string[]): Promise<DefinitionCacheEntries>;
   getDependencyRows(urls: string[]): Promise<DependencyIndexRow[]>;
   // Slim projection (url, type, deps only) used by invalidation ordering.
   // Selection priority is applied server-side; see IndexWriter.
@@ -42,7 +42,7 @@ export class IndexRunnerDependencyManager {
 
   constructor({
     realmURL,
-    readModuleCacheEntries,
+    readDefinitionCacheEntries,
     getDependencyRows,
     getOrderingDependencyRows,
     getInvalidations,
@@ -50,7 +50,7 @@ export class IndexRunnerDependencyManager {
     this.#getOrderingDependencyRows = getOrderingDependencyRows;
     this.#indexBackedDependencyErrors = new IndexBackedDependencyErrors({
       realmURL,
-      readModuleCacheEntries,
+      readDefinitionCacheEntries,
       getDependencyRows,
       getInvalidations,
     });

--- a/packages/runtime-common/index-runner/dependency-resolver.ts
+++ b/packages/runtime-common/index-runner/dependency-resolver.ts
@@ -16,7 +16,9 @@ type OrderingDependencyRow = Pick<DependencyIndexRow, 'url' | 'type' | 'deps'>;
 
 interface DependencyResolverOptions {
   realmURL: URL;
-  readDefinitionCacheEntries(moduleIds: string[]): Promise<DefinitionCacheEntries>;
+  readDefinitionCacheEntries(
+    moduleIds: string[],
+  ): Promise<DefinitionCacheEntries>;
   getDependencyRows(urls: string[]): Promise<DependencyIndexRow[]>;
   // Slim projection (url, type, deps only) used by invalidation ordering.
   // Selection priority is applied server-side; see IndexWriter.

--- a/packages/runtime-common/index-runner/index-backed-dependency-errors.ts
+++ b/packages/runtime-common/index-runner/index-backed-dependency-errors.ts
@@ -11,14 +11,18 @@ import {
 
 interface IndexBackedDependencyErrorOptions {
   realmURL: URL;
-  readDefinitionCacheEntries(moduleIds: string[]): Promise<DefinitionCacheEntries>;
+  readDefinitionCacheEntries(
+    moduleIds: string[],
+  ): Promise<DefinitionCacheEntries>;
   getDependencyRows(urls: string[]): Promise<DependencyIndexRow[]>;
   getInvalidations(): string[];
 }
 
 export class IndexBackedDependencyErrors {
   #realmURL: URL;
-  #readDefinitionCacheEntries: (moduleIds: string[]) => Promise<DefinitionCacheEntries>;
+  #readDefinitionCacheEntries: (
+    moduleIds: string[],
+  ) => Promise<DefinitionCacheEntries>;
   #getDependencyRows: (urls: string[]) => Promise<DependencyIndexRow[]>;
   #getInvalidations: () => string[];
   #relationshipDependencyRows = new Map<string, DependencyIndexRow[]>();

--- a/packages/runtime-common/index-runner/index-backed-dependency-errors.ts
+++ b/packages/runtime-common/index-runner/index-backed-dependency-errors.ts
@@ -1,5 +1,5 @@
 import type { DependencyIndexRow, SearchIndexErrorEntry } from '../index';
-import type { ModuleCacheEntries } from '../definition-lookup';
+import type { DefinitionCacheEntries } from '../definition-lookup';
 import type { SerializedError } from '../error';
 import { cardIdToURL } from '../card-reference-resolver';
 import { canonicalURL } from './dependency-url';
@@ -11,26 +11,26 @@ import {
 
 interface IndexBackedDependencyErrorOptions {
   realmURL: URL;
-  readModuleCacheEntries(moduleIds: string[]): Promise<ModuleCacheEntries>;
+  readDefinitionCacheEntries(moduleIds: string[]): Promise<DefinitionCacheEntries>;
   getDependencyRows(urls: string[]): Promise<DependencyIndexRow[]>;
   getInvalidations(): string[];
 }
 
 export class IndexBackedDependencyErrors {
   #realmURL: URL;
-  #readModuleCacheEntries: (moduleIds: string[]) => Promise<ModuleCacheEntries>;
+  #readDefinitionCacheEntries: (moduleIds: string[]) => Promise<DefinitionCacheEntries>;
   #getDependencyRows: (urls: string[]) => Promise<DependencyIndexRow[]>;
   #getInvalidations: () => string[];
   #relationshipDependencyRows = new Map<string, DependencyIndexRow[]>();
 
   constructor({
     realmURL,
-    readModuleCacheEntries,
+    readDefinitionCacheEntries,
     getDependencyRows,
     getInvalidations,
   }: IndexBackedDependencyErrorOptions) {
     this.#realmURL = realmURL;
-    this.#readModuleCacheEntries = readModuleCacheEntries;
+    this.#readDefinitionCacheEntries = readDefinitionCacheEntries;
     this.#getDependencyRows = getDependencyRows;
     this.#getInvalidations = getInvalidations;
   }
@@ -194,7 +194,7 @@ export class IndexBackedDependencyErrors {
     if (deps.length === 0) {
       return [];
     }
-    let entries = await this.#readModuleCacheEntries(deps);
+    let entries = await this.#readDefinitionCacheEntries(deps);
     let errors: SerializedError[] = [];
     for (let entry of Object.values(entries)) {
       if (!entry.error?.error) {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -683,7 +683,7 @@ export class Realm {
   // caller's promise instead of running babel again. Invalidation paths
   // (writeMany, invalidateCache, the full-index clear, etc.) drop the
   // entry through the shared #dropTranspiledModuleEntry /
-  // #dropAllTranspiledModuleCacheEntries helpers so post-invalidate callers don't
+  // #dropAllTranspiledDefinitionCacheEntries helpers so post-invalidate callers don't
   // join a stale transpile whose #transpiledModuleCache.set will be discarded by
   // CS-11028's generation guard anyway. Identity-checked cleanup on
   // settle is the same shape as CachingDefinitionLookup's #inFlight — a
@@ -1070,8 +1070,8 @@ export class Realm {
       );
 
     let completed = indexingCompleted.then(async ({ invalidations }) => {
-      await this.#definitionLookup.clearRealmCache(this.url);
-      this.#dropAllTranspiledModuleCacheEntries();
+      await this.#definitionLookup.clearRealmDefinitions(this.url);
+      this.#dropAllTranspiledDefinitionCacheEntries();
       if (invalidations.length > 0) {
         this.broadcastIncrementalInvalidationEvent(invalidations);
       }
@@ -1383,7 +1383,7 @@ export class Realm {
 
   __testOnlyClearCaches() {
     this.#sourceCache.clear();
-    this.#dropAllTranspiledModuleCacheEntries();
+    this.#dropAllTranspiledDefinitionCacheEntries();
     // Reset the transpile counter so each test reasons about its own
     // delta. Production never reads this counter — only the CS-11029
     // dedup tests do (CS-11029).
@@ -1407,7 +1407,7 @@ export class Realm {
   // bulk-invalidate primitive the receiver invokes.
   clearLocalSourceCaches(): void {
     this.#sourceCache.clear();
-    this.#dropAllTranspiledModuleCacheEntries();
+    this.#dropAllTranspiledDefinitionCacheEntries();
   }
 
   // CS-11029 test seams: tests need to assert "N concurrent same-path
@@ -1482,7 +1482,7 @@ export class Realm {
   // just-cleared map (CS-11028). The per-path map is cleared because the
   // generations it held are no longer reachable — the global counter is
   // what catches in-flight snapshots after a wipe.
-  #dropAllTranspiledModuleCacheEntries(): void {
+  #dropAllTranspiledDefinitionCacheEntries(): void {
     this.#transpiledModuleCache.clear();
     this.#transpiledModuleCacheGenerations.clear();
     this.#transpiledModuleCacheGlobalGeneration += 1;
@@ -1570,7 +1570,7 @@ export class Realm {
   // NOTIFY is a no-op since `clearLocalSourceCaches()` is idempotent.
   //
   // Bundles local + broadcast in one call, mirroring
-  // `CachingDefinitionLookup.clearRealmCache(url)` — handlers don't have
+  // `CachingDefinitionLookup.clearRealmDefinitions(url)` — handlers don't have
   // to remember both steps. Callers that only need the peer broadcast
   // (because their own Realm instance is about to be unmounted anyway —
   // unpublish/delete handlers) use the standalone `notifyAllFileChanges`

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -307,10 +307,15 @@ const CARD_JSON_ETAG_VARIANT = 'card';
 export const REALM_FILE_CHANGES_CHANNEL = 'realm_file_changes';
 export const REALM_FILE_CHANGES_WILDCARD = '*';
 
-// Standalone form of `Realm.notifyAllFileChanges()`. Use when the caller
-// has a DBAdapter + realm URL but no mounted `Realm` instance — e.g.
-// the delete-realm handler runs after the realm has already been torn
-// down, so it cannot route through an instance method. Same best-effort
+// Emit a bulk `<realmURL>:*` NOTIFY on the `realm_file_changes` channel so
+// peer realm-server replicas drop every cached path for this realm. Use
+// directly when the caller has a DBAdapter + realm URL but isn't keeping
+// the realm running locally (the unpublish-realm and delete-realm
+// handlers — the realm is about to be torn down, so this replica's own
+// in-process cache will be garbage-collected with the Realm instance).
+// When the caller wants the SAME local cache wipe AND the broadcast
+// — i.e. its own next read must not hit pre-swap bytes — call
+// `Realm.clearLocalCachesAndBroadcast()` instead. Same best-effort
 // semantics as `Realm.#notifyFileChange`: failures are logged and
 // swallowed (missed NOTIFY is a bounded staleness window, not data
 // corruption). See CS-11156.
@@ -1557,15 +1562,22 @@ export class Realm {
     }
   }
 
-  // Bulk variant of `#notifyFileChange` — broadcast "drop every cached path
-  // for this realm" to peer realm-server instances. The publish-realm /
-  // unpublish-realm / delete-realm handlers emit this after the FS swap or
-  // removal so peer replicas (which do NOT see the local file-watcher events
-  // that drive single-file invalidation) drop pre-swap bytes from
-  // `#sourceCache` / `#moduleCache` before the next source read. Receiver
-  // calls `Realm.clearLocalCaches()`. See CS-11156.
-  async notifyAllFileChanges(): Promise<void> {
-    return notifyAllFileChanges(this.#dbAdapter, this.url);
+  // Drop this replica's own `#sourceCache` / `#moduleCache` AND broadcast
+  // the same wipe to peer replicas. Used by the publish-realm handler
+  // before the reindex enqueue: this replica's own prerender fan-out must
+  // bypass its cache (sync local clear), and peer replicas must drop
+  // their pre-swap bytes too (cross-instance NOTIFY). Self-receive of the
+  // NOTIFY is a no-op since `clearLocalCaches()` is idempotent.
+  //
+  // Bundles local + broadcast in one call, mirroring
+  // `CachingDefinitionLookup.clearRealmCache(url)` — handlers don't have
+  // to remember both steps. Callers that only need the peer broadcast
+  // (because their own Realm instance is about to be unmounted anyway —
+  // unpublish/delete handlers) use the standalone `notifyAllFileChanges`
+  // free function above instead.
+  async clearLocalCachesAndBroadcast(): Promise<void> {
+    this.clearLocalCaches();
+    await notifyAllFileChanges(this.#dbAdapter, this.url);
   }
 
   createJWT(claims: TokenClaims, expiration: ms.StringValue): string {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -285,7 +285,7 @@ const SOURCE_ETAG_VARIANT = 'source';
 const CARD_JSON_ETAG_VARIANT = 'card';
 
 // Postgres NOTIFY channel for cross-instance invalidation of #sourceCache /
-// #moduleCache entries on file writes. Two payload shapes:
+// #transpiledModuleCache entries on file writes. Two payload shapes:
 //
 //   `<realmURL>:<path>` — invalidate a single path's cached source +
 //      (for executable extensions) module entry. Emitted by every
@@ -296,8 +296,8 @@ const CARD_JSON_ETAG_VARIANT = 'card';
 //      delete-realm handlers after the FS swap or removal, so peer
 //      replicas (which do NOT receive the file-watcher events that
 //      drive single-file invalidation in-process) drop pre-swap bytes
-//      from `#sourceCache` / `#moduleCache` before serving the next
-//      source read. Receiver calls Realm.clearLocalCaches(). See
+//      from `#sourceCache` / `#transpiledModuleCache` before serving the next
+//      source read. Receiver calls Realm.clearLocalSourceCaches(). See
 //      CS-11156. (`*` is reserved as the wildcard sentinel; real
 //      LocalPath values never contain it.)
 //
@@ -315,7 +315,7 @@ export const REALM_FILE_CHANGES_WILDCARD = '*';
 // in-process cache will be garbage-collected with the Realm instance).
 // When the caller wants the SAME local cache wipe AND the broadcast
 // — i.e. its own next read must not hit pre-swap bytes — call
-// `Realm.clearLocalCachesAndBroadcast()` instead. Same best-effort
+// `Realm.clearLocalSourceCachesAndBroadcast()` instead. Same best-effort
 // semantics as `Realm.#notifyFileChange`: failures are logged and
 // swallowed (missed NOTIFY is a bounded staleness window, not data
 // corruption). See CS-11156.
@@ -366,7 +366,7 @@ type CachedSourceRedirectEntry = {
 
 type SourceCacheEntry = CachedSourceFileEntry | CachedSourceRedirectEntry;
 
-type ModuleCacheEntry = {
+type TranspiledModuleEntry = {
   canonicalPath: LocalPath;
   body: string;
   headers: Record<string, string>;
@@ -662,29 +662,29 @@ export class Realm {
   #definitionLookup: DefinitionLookup;
   #copiedFromRealm: URL | undefined;
   #sourceCache = new AliasCache<SourceCacheEntry>();
-  #moduleCache = new AliasCache<ModuleCacheEntry>();
-  // CS-11028: per-path generation counters for #moduleCache. Bumped
+  #transpiledModuleCache = new AliasCache<TranspiledModuleEntry>();
+  // CS-11028: per-path generation counters for #transpiledModuleCache. Bumped
   // synchronously by invalidateCache(path) before any await. fallbackHandle
   // snapshots at entry and discards its post-transpile cache write if the
   // path's generation moved during the in-flight transpile — otherwise the
   // pre-invalidation bytes would re-populate the slot that invalidate just
   // cleared and serve stale code until the next invalidate of that path.
-  // #moduleCacheGlobalGeneration covers __testOnlyClearCaches, which wipes
+  // #transpiledModuleCacheGlobalGeneration covers __testOnlyClearCaches, which wipes
   // the whole map; a snapshot taken before the wipe sees its `path`
   // component reset to 0 alongside the live counter, so a global generation
   // is the only thing that reliably mismatches afterwards.
-  #moduleCacheGenerations: Map<LocalPath, number> = new Map();
-  #moduleCacheGlobalGeneration = 0;
+  #transpiledModuleCacheGenerations: Map<LocalPath, number> = new Map();
+  #transpiledModuleCacheGlobalGeneration = 0;
   // CS-11029: in-process inflight dedup for the transpile pipeline.
-  // Concurrent same-path callers that miss #moduleCache used to each call
+  // Concurrent same-path callers that miss #transpiledModuleCache used to each call
   // transpileJS independently — 50–500 ms of babel + ember-template-
   // compilation + decorator transforms wasted per duplicate. The map is
   // keyed by local path so the second-and-onward caller awaits the first
   // caller's promise instead of running babel again. Invalidation paths
   // (writeMany, invalidateCache, the full-index clear, etc.) drop the
-  // entry through the shared #dropModuleCacheEntry /
-  // #dropAllModuleCacheEntries helpers so post-invalidate callers don't
-  // join a stale transpile whose #moduleCache.set will be discarded by
+  // entry through the shared #dropTranspiledModuleEntry /
+  // #dropAllTranspiledModuleCacheEntries helpers so post-invalidate callers don't
+  // join a stale transpile whose #transpiledModuleCache.set will be discarded by
   // CS-11028's generation guard anyway. Identity-checked cleanup on
   // settle is the same shape as CachingDefinitionLookup's #inFlight — a
   // newer pending entry installed after a drop survives an older
@@ -1071,7 +1071,7 @@ export class Realm {
 
     let completed = indexingCompleted.then(async ({ invalidations }) => {
       await this.#definitionLookup.clearRealmCache(this.url);
-      this.#dropAllModuleCacheEntries();
+      this.#dropAllTranspiledModuleCacheEntries();
       if (invalidations.length > 0) {
         this.broadcastIncrementalInvalidationEvent(invalidations);
       }
@@ -1383,7 +1383,7 @@ export class Realm {
 
   __testOnlyClearCaches() {
     this.#sourceCache.clear();
-    this.#dropAllModuleCacheEntries();
+    this.#dropAllTranspiledModuleCacheEntries();
     // Reset the transpile counter so each test reasons about its own
     // delta. Production never reads this counter — only the CS-11029
     // dedup tests do (CS-11029).
@@ -1395,7 +1395,7 @@ export class Realm {
   // reindex enqueues — so that subsequent source reads (which the
   // reindex's prerender fans out across many of) bypass any
   // pre-swap bytes the realm still has in `#sourceCache` /
-  // `#moduleCache`. The Phase-3-PR-2 publish flow relies on the
+  // `#transpiledModuleCache`. The Phase-3-PR-2 publish flow relies on the
   // NodeAdapter file-watcher to pick up the swap, but that's an
   // async-event race against the immediately-enqueued reindex; this
   // method makes the invalidation synchronous from the publish
@@ -1405,9 +1405,9 @@ export class Realm {
   // CS-11156 will replace the publish handler's local call here with
   // a cross-replica NOTIFY broadcast; this method stays as the
   // bulk-invalidate primitive the receiver invokes.
-  clearLocalCaches(): void {
+  clearLocalSourceCaches(): void {
     this.#sourceCache.clear();
-    this.#dropAllModuleCacheEntries();
+    this.#dropAllTranspiledModuleCacheEntries();
   }
 
   // CS-11029 test seams: tests need to assert "N concurrent same-path
@@ -1441,26 +1441,26 @@ export class Realm {
   invalidateCache(path: LocalPath): void {
     this.#sourceCache.invalidate(path);
     if (hasExecutableExtension(path)) {
-      this.#dropModuleCacheEntry(path);
+      this.#dropTranspiledModuleEntry(path);
     }
   }
 
   // CS-11028: shared drop helper for any in-process site that invalidates a
-  // single #moduleCache entry — writeMany, delete/deleteAll, the local
+  // single #transpiledModuleCache entry — writeMany, delete/deleteAll, the local
   // file-watcher callback, the index-updater's executable-invalidation
   // cascade, the public invalidateCache entry point, etc. Bumps the
   // per-path generation BEFORE the cache delete so a concurrent in-flight
   // transpile for the same path — already past its generation snapshot in
   // fallbackHandle — observes the new value at persist time and drops its
-  // #moduleCache.set instead of re-filling the slot we're about to empty.
-  #dropModuleCacheEntry(path: LocalPath): void {
-    this.#bumpModuleCacheGeneration(path);
-    this.#moduleCache.invalidate(path);
+  // #transpiledModuleCache.set instead of re-filling the slot we're about to empty.
+  #dropTranspiledModuleEntry(path: LocalPath): void {
+    this.#bumpTranspiledModuleCacheGeneration(path);
+    this.#transpiledModuleCache.invalidate(path);
     // CS-11029: drop the in-flight transpile entry too. Existing
     // waiters on the old promise still receive its result — their
     // requests preceded the invalidate, so pre-invalidation bytes are
     // the correct response. But a caller arriving AFTER this point
-    // must not join the stale transpile (its #moduleCache.set is
+    // must not join the stale transpile (its #transpiledModuleCache.set is
     // about to be discarded by the generation guard); they install
     // their own pending against current source instead.
     this.#inFlightTranspiles.delete(path);
@@ -1476,27 +1476,27 @@ export class Realm {
     void this.#deleteTranspileCacheRow(canonicalPath);
   }
 
-  // Wipes every #moduleCache entry and bumps the global generation so any
+  // Wipes every #transpiledModuleCache entry and bumps the global generation so any
   // in-flight transpile whose snapshot was taken before this wipe discards
   // its post-transpile cache write rather than re-populating the
   // just-cleared map (CS-11028). The per-path map is cleared because the
   // generations it held are no longer reachable — the global counter is
   // what catches in-flight snapshots after a wipe.
-  #dropAllModuleCacheEntries(): void {
-    this.#moduleCache.clear();
-    this.#moduleCacheGenerations.clear();
-    this.#moduleCacheGlobalGeneration += 1;
-    // CS-11029: same reason as #dropModuleCacheEntry — post-wipe
+  #dropAllTranspiledModuleCacheEntries(): void {
+    this.#transpiledModuleCache.clear();
+    this.#transpiledModuleCacheGenerations.clear();
+    this.#transpiledModuleCacheGlobalGeneration += 1;
+    // CS-11029: same reason as #dropTranspiledModuleEntry — post-wipe
     // callers must not join a stale transpile.
     this.#inFlightTranspiles.clear();
     // CS-11030: fire-and-forget bulk DELETE for the realm's L2 rows.
     void this.#deleteAllTranspileCacheRows();
   }
 
-  #bumpModuleCacheGeneration(path: LocalPath): void {
-    this.#moduleCacheGenerations.set(
+  #bumpTranspiledModuleCacheGeneration(path: LocalPath): void {
+    this.#transpiledModuleCacheGenerations.set(
       path,
-      (this.#moduleCacheGenerations.get(path) ?? 0) + 1,
+      (this.#transpiledModuleCacheGenerations.get(path) ?? 0) + 1,
     );
   }
 
@@ -1517,33 +1517,33 @@ export class Realm {
     global: number;
   } {
     let pathGens = new Map<LocalPath, number>();
-    pathGens.set(localPath, this.#moduleCacheGenerations.get(localPath) ?? 0);
+    pathGens.set(localPath, this.#transpiledModuleCacheGenerations.get(localPath) ?? 0);
     if (!hasExecutableExtension(localPath)) {
       for (let ext of executableExtensions) {
         let candidate = localPath + ext;
         pathGens.set(
           candidate,
-          this.#moduleCacheGenerations.get(candidate) ?? 0,
+          this.#transpiledModuleCacheGenerations.get(candidate) ?? 0,
         );
       }
     }
-    return { pathGens, global: this.#moduleCacheGlobalGeneration };
+    return { pathGens, global: this.#transpiledModuleCacheGlobalGeneration };
   }
 
-  #moduleCacheGenerationChanged(
+  #transpiledModuleCacheGenerationChanged(
     canonicalPath: LocalPath,
     snapshot: { pathGens: Map<LocalPath, number>; global: number },
   ): boolean {
-    if (this.#moduleCacheGlobalGeneration !== snapshot.global) {
+    if (this.#transpiledModuleCacheGlobalGeneration !== snapshot.global) {
       return true;
     }
     let snapGen = snapshot.pathGens.get(canonicalPath) ?? 0;
-    let curGen = this.#moduleCacheGenerations.get(canonicalPath) ?? 0;
+    let curGen = this.#transpiledModuleCacheGenerations.get(canonicalPath) ?? 0;
     return curGen !== snapGen;
   }
 
   // Broadcast a file-change notification to peer realm-server instances so
-  // they can invalidate their own #sourceCache / #moduleCache entries for the
+  // they can invalidate their own #sourceCache / #transpiledModuleCache entries for the
   // same path. Best-effort — failures are logged and swallowed because the
   // local write already succeeded and a missed NOTIFY is a bounded cache-
   // staleness window (see docs §9 "Cache-invalidation NOTIFY missed"), not
@@ -1562,12 +1562,12 @@ export class Realm {
     }
   }
 
-  // Drop this replica's own `#sourceCache` / `#moduleCache` AND broadcast
+  // Drop this replica's own `#sourceCache` / `#transpiledModuleCache` AND broadcast
   // the same wipe to peer replicas. Used by the publish-realm handler
   // before the reindex enqueue: this replica's own prerender fan-out must
   // bypass its cache (sync local clear), and peer replicas must drop
   // their pre-swap bytes too (cross-instance NOTIFY). Self-receive of the
-  // NOTIFY is a no-op since `clearLocalCaches()` is idempotent.
+  // NOTIFY is a no-op since `clearLocalSourceCaches()` is idempotent.
   //
   // Bundles local + broadcast in one call, mirroring
   // `CachingDefinitionLookup.clearRealmCache(url)` — handlers don't have
@@ -1575,8 +1575,8 @@ export class Realm {
   // (because their own Realm instance is about to be unmounted anyway —
   // unpublish/delete handlers) use the standalone `notifyAllFileChanges`
   // free function above instead.
-  async clearLocalCachesAndBroadcast(): Promise<void> {
-    this.clearLocalCaches();
+  async clearLocalSourceCachesAndBroadcast(): Promise<void> {
+    this.clearLocalSourceCaches();
     await notifyAllFileChanges(this.#dbAdapter, this.url);
   }
 
@@ -2584,7 +2584,7 @@ export class Realm {
       Boolean(request.headers.get('X-Boxel-Disable-Module-Cache'));
 
     if (!moduleCachingDisabled) {
-      let cached = this.#moduleCache.get(localPath);
+      let cached = this.#transpiledModuleCache.get(localPath);
       if (cached) {
         try {
           let etag = cached.headers.etag;
@@ -2657,12 +2657,12 @@ export class Realm {
           if (
             !moduleCachingDisabled &&
             cacheGenSnapshot &&
-            !this.#moduleCacheGenerationChanged(
+            !this.#transpiledModuleCacheGenerationChanged(
               result.canonicalPath,
               cacheGenSnapshot,
             )
           ) {
-            this.#moduleCache.set(localPath, {
+            this.#transpiledModuleCache.set(localPath, {
               canonicalPath: result.canonicalPath,
               body: result.body,
               headers: result.headers,
@@ -3697,7 +3697,7 @@ export class Realm {
     for (const invalidatedURL of invalidatedURLs) {
       if (hasExecutableExtension(invalidatedURL.href)) {
         let invalidatedPath = this.paths.local(invalidatedURL);
-        this.#dropModuleCacheEntry(invalidatedPath);
+        this.#dropTranspiledModuleEntry(invalidatedPath);
         changedDependencyKeys.add(moduleDependencyKey(invalidatedPath));
         definitionInvalidations.push(
           this.#definitionLookup.invalidate(invalidatedURL.href),
@@ -3710,7 +3710,7 @@ export class Realm {
       for (let invalidatedModuleURL of invalidatedModuleURLs) {
         try {
           let invalidatedPath = this.paths.local(new URL(invalidatedModuleURL));
-          this.#dropModuleCacheEntry(invalidatedPath);
+          this.#dropTranspiledModuleEntry(invalidatedPath);
           changedDependencyKeys.add(moduleDependencyKey(invalidatedPath));
         } catch (_err) {
           // ignore invalidations outside this realm
@@ -3719,15 +3719,15 @@ export class Realm {
     }
     let dependentInvalidations = collectDependentModuleCacheInvalidations(
       changedDependencyKeys,
-      this.moduleCacheDependencyEntries(),
+      this.transpiledModuleDependencyEntries(),
     );
     for (let invalidatedPath of dependentInvalidations) {
-      this.#dropModuleCacheEntry(invalidatedPath);
+      this.#dropTranspiledModuleEntry(invalidatedPath);
     }
   }
 
-  private *moduleCacheDependencyEntries() {
-    for (let [, cachedEntry] of this.#moduleCache.entries()) {
+  private *transpiledModuleDependencyEntries() {
+    for (let [, cachedEntry] of this.#transpiledModuleCache.entries()) {
       yield {
         canonicalPath: cachedEntry.canonicalPath,
         dependencyKeys: cachedEntry.dependencyKeys,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -285,11 +285,51 @@ const SOURCE_ETAG_VARIANT = 'source';
 const CARD_JSON_ETAG_VARIANT = 'card';
 
 // Postgres NOTIFY channel for cross-instance invalidation of #sourceCache /
-// #moduleCache entries on file writes. Payload shape is `<realmURL>:<path>`.
+// #moduleCache entries on file writes. Two payload shapes:
+//
+//   `<realmURL>:<path>` — invalidate a single path's cached source +
+//      (for executable extensions) module entry. Emitted by every
+//      single-file write/delete via Realm.#notifyFileChange. Receiver
+//      calls Realm.invalidateCache(path).
+//   `<realmURL>:*`      — bulk-invalidate every cached path for this
+//      realm. Emitted by the publish-realm / unpublish-realm /
+//      delete-realm handlers after the FS swap or removal, so peer
+//      replicas (which do NOT receive the file-watcher events that
+//      drive single-file invalidation in-process) drop pre-swap bytes
+//      from `#sourceCache` / `#moduleCache` before serving the next
+//      source read. Receiver calls Realm.clearLocalCaches(). See
+//      CS-11156. (`*` is reserved as the wildcard sentinel; real
+//      LocalPath values never contain it.)
+//
 // See docs/db-authoritative-realm-registry.md §6 "Cache invalidation channel"
 // and §9 "Cache-invalidation NOTIFY missed" for the semantics (best-effort,
 // missed-NOTIFY is a cache-staleness window, not data corruption).
 export const REALM_FILE_CHANGES_CHANNEL = 'realm_file_changes';
+export const REALM_FILE_CHANGES_WILDCARD = '*';
+
+// Standalone form of `Realm.notifyAllFileChanges()`. Use when the caller
+// has a DBAdapter + realm URL but no mounted `Realm` instance — e.g.
+// the delete-realm handler runs after the realm has already been torn
+// down, so it cannot route through an instance method. Same best-effort
+// semantics as `Realm.#notifyFileChange`: failures are logged and
+// swallowed (missed NOTIFY is a bounded staleness window, not data
+// corruption). See CS-11156.
+export async function notifyAllFileChanges(
+  dbAdapter: DBAdapter,
+  realmURL: string,
+): Promise<void> {
+  try {
+    await dbAdapter.notify(
+      REALM_FILE_CHANGES_CHANNEL,
+      `${realmURL}:${REALM_FILE_CHANGES_WILDCARD}`,
+    );
+  } catch (err: unknown) {
+    logger('realm').warn(
+      `notify ${REALM_FILE_CHANGES_CHANNEL} (bulk) failed for ${realmURL}: ${String(err)}`,
+    );
+  }
+}
+
 export const FILE_META_RESERVED_KEYS = new Set([
   'name',
   'url',
@@ -1515,6 +1555,17 @@ export class Realm {
         `notify ${REALM_FILE_CHANGES_CHANNEL} failed for ${this.url}:${path}: ${String(err)}`,
       );
     }
+  }
+
+  // Bulk variant of `#notifyFileChange` — broadcast "drop every cached path
+  // for this realm" to peer realm-server instances. The publish-realm /
+  // unpublish-realm / delete-realm handlers emit this after the FS swap or
+  // removal so peer replicas (which do NOT see the local file-watcher events
+  // that drive single-file invalidation) drop pre-swap bytes from
+  // `#sourceCache` / `#moduleCache` before the next source read. Receiver
+  // calls `Realm.clearLocalCaches()`. See CS-11156.
+  async notifyAllFileChanges(): Promise<void> {
+    return notifyAllFileChanges(this.#dbAdapter, this.url);
   }
 
   createJWT(claims: TokenClaims, expiration: ms.StringValue): string {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -683,7 +683,7 @@ export class Realm {
   // caller's promise instead of running babel again. Invalidation paths
   // (writeMany, invalidateCache, the full-index clear, etc.) drop the
   // entry through the shared #dropTranspiledModuleEntry /
-  // #dropAllTranspiledDefinitionCacheEntries helpers so post-invalidate callers don't
+  // #dropAllTranspiledModuleCacheEntries helpers so post-invalidate callers don't
   // join a stale transpile whose #transpiledModuleCache.set will be discarded by
   // CS-11028's generation guard anyway. Identity-checked cleanup on
   // settle is the same shape as CachingDefinitionLookup's #inFlight — a
@@ -1071,7 +1071,7 @@ export class Realm {
 
     let completed = indexingCompleted.then(async ({ invalidations }) => {
       await this.#definitionLookup.clearRealmDefinitions(this.url);
-      this.#dropAllTranspiledDefinitionCacheEntries();
+      this.#dropAllTranspiledModuleCacheEntries();
       if (invalidations.length > 0) {
         this.broadcastIncrementalInvalidationEvent(invalidations);
       }
@@ -1383,7 +1383,7 @@ export class Realm {
 
   __testOnlyClearCaches() {
     this.#sourceCache.clear();
-    this.#dropAllTranspiledDefinitionCacheEntries();
+    this.#dropAllTranspiledModuleCacheEntries();
     // Reset the transpile counter so each test reasons about its own
     // delta. Production never reads this counter — only the CS-11029
     // dedup tests do (CS-11029).
@@ -1402,12 +1402,14 @@ export class Realm {
   // handler's vantage point. Different from `__testOnlyClearCaches`
   // in that it does NOT reset the transpile counter (which is
   // test-only diagnostic state, unrelated to byte-correctness).
-  // CS-11156 will replace the publish handler's local call here with
-  // a cross-replica NOTIFY broadcast; this method stays as the
-  // bulk-invalidate primitive the receiver invokes.
+  // CS-11156: this is the local bulk-invalidate primitive that both the
+  // publish-realm handler and the cross-replica `realm_file_changes:*`
+  // listener invoke. The publish handler reaches it via
+  // `clearLocalSourceCachesAndBroadcast` (local clear + peer broadcast);
+  // the listener invokes it directly (no broadcast — would NOTIFY-loop).
   clearLocalSourceCaches(): void {
     this.#sourceCache.clear();
-    this.#dropAllTranspiledDefinitionCacheEntries();
+    this.#dropAllTranspiledModuleCacheEntries();
   }
 
   // CS-11029 test seams: tests need to assert "N concurrent same-path
@@ -1482,7 +1484,7 @@ export class Realm {
   // just-cleared map (CS-11028). The per-path map is cleared because the
   // generations it held are no longer reachable — the global counter is
   // what catches in-flight snapshots after a wipe.
-  #dropAllTranspiledDefinitionCacheEntries(): void {
+  #dropAllTranspiledModuleCacheEntries(): void {
     this.#transpiledModuleCache.clear();
     this.#transpiledModuleCacheGenerations.clear();
     this.#transpiledModuleCacheGlobalGeneration += 1;

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1517,7 +1517,10 @@ export class Realm {
     global: number;
   } {
     let pathGens = new Map<LocalPath, number>();
-    pathGens.set(localPath, this.#transpiledModuleCacheGenerations.get(localPath) ?? 0);
+    pathGens.set(
+      localPath,
+      this.#transpiledModuleCacheGenerations.get(localPath) ?? 0,
+    );
     if (!hasExecutableExtension(localPath)) {
       for (let ext of executableExtensions) {
         let candidate = localPath + ext;


### PR DESCRIPTION
## Summary
- Pre-CS-11156 the publish-realm handler invalidates `#sourceCache` / `#transpiledModuleCache` only on the replica that processes the request. On 2+ replicas, peers keep pre-swap bytes and the reindex's prerender HTTP fan-out lands stale source in `boxel_index.isolated_html` — served forever. Same shape on unpublish / delete during the window between the registry-row commit and the peer-side reconciler unmount.
- Extends the existing per-path `realm_file_changes` NOTIFY channel with a bulk payload `<realmURL>:*` meaning *"drop every cached path for this realm."* Wired into publish, unpublish, and delete realm handlers; on receive, peers call `Realm.clearLocalSourceCaches()`.
- While there, replace the publish handler's hand-rolled `DELETE FROM modules WHERE resolved_realm_url = $1` with `definitionLookup.clearRealmDefinitions(url)` so the *definitions* cache invalidation gets the same cross-replica treatment (generation bump + in-flight drop + DELETE + NOTIFY) instead of just the DB delete.

Linear: [CS-11156](https://linear.app/cardstack/issue/CS-11156/publish-realm-cross-replica-clearlocalcaches-broadcast-via-notify).

## API surface
Mirrors `CachingDefinitionLookup.clearRealmDefinitions(url)` — one method bundles local invalidation + cross-instance NOTIFY so handlers don't have to remember both steps. Three entry points after this PR:

| Caller need | API |
| --- | --- |
| Local clear AND peer broadcast (realm staying up — publish handler) | `realm.clearLocalSourceCachesAndBroadcast()` |
| Peer broadcast ONLY (realm being torn down — unpublish / delete) | `notifyAllFileChanges(dbAdapter, url)` (free function) |
| Receive-side replay (LISTEN handler, no broadcast, no NOTIFY loop) | `realm.clearLocalSourceCaches()` |

The definitions cache (separate from the in-process byte caches above) keeps its existing `definitionLookup.clearRealmDefinitions(url)` entry point — this PR just stops bypassing it from the publish handler.

## What's in
- `runtime-common/realm.ts` — `REALM_FILE_CHANGES_WILDCARD = '*'` sentinel, standalone `notifyAllFileChanges(dbAdapter, realmURL)` emitter (the single cross-replica emit surface — Realm doesn't need to know about channel names or payload formats), and `Realm.clearLocalSourceCachesAndBroadcast()` instance method that bundles `clearLocalSourceCaches()` + the free-function emit. Same best-effort fire-and-forget shape as `Realm.#notifyFileChange`; missed NOTIFY is a bounded staleness window per §9 of `docs/db-authoritative-realm-registry.md`, not data corruption.
- `realm-file-changes-listener.ts` — dispatch branches on `path === '*'` to `Realm.clearLocalSourceCaches()`. Existing regex parser + realm lookup reused as-is (the wildcard payload parses cleanly with `path = '*'`).
- `handle-publish-realm.ts` —
  - Replaces the raw `DELETE FROM modules WHERE resolved_realm_url = $1` with `await definitionLookup.clearRealmDefinitions(publishedRealmURL)` so the definitions-cache invalidation also bumps the per-realm generation counter, drops in-flight prerender promises, and broadcasts on `module_cache_invalidated` — the modules-table analog of the byte-cache fix this PR is making. Without those extra steps an in-flight prerender that started before the DELETE could re-insert a stale row at persist time, and peer replicas would keep their cached rows + generation counters until their own next invalidation arrived. `clearRealmDefinitions` already runs via the post-fullIndex completion path but that's at the *end* of the reindex — too late for the prerender fan-out at the start.
  - One call (`await mountedRealmForCacheClear.clearLocalSourceCachesAndBroadcast()`) for the byte-cache wipe + cross-replica broadcast before the reindex enqueue. Self-NOTIFY is a no-op since `clearLocalSourceCaches` is idempotent.
- `handle-unpublish-realm.ts` and `handle-delete-realm.ts` — call the standalone `notifyAllFileChanges(dbAdapter, url)` after the FS removal. No local clear needed: the realm is about to be unmounted, so the in-process cache will be garbage-collected with the `Realm` instance. Defense-in-depth against the brief window before peers unmount via `NOTIFY realm_registry`. (Per-file `deleteAll` in unpublish already emits per-path NOTIFYs; this is the catch-all for the registry-commit-to-unmount window.)

## Naming pass
Two follow-up commits in this branch did targeted renames to disambiguate which cache layer each identifier refers to: `#moduleCache` → `#transpiledModuleCache` on `Realm` (the byte cache), and `clearRealmCache` → `clearRealmDefinitions` on `CachingDefinitionLookup` (the definitions cache). Both methods named here were also touched. The renames removed a long-standing "two different things both called modules cache" hazard.

## Tests
`packages/realm-server/tests/realm-file-changes-listener-test.ts` (12 existing pass; 4 new):
- `parsePayload` round-trips `<realmURL>:*` to `path: '*'` for both port-bearing and port-less URLs.
- Dispatch test: wildcard payload calls `clearLocalSourceCaches()` exactly once and never `invalidateCache()`.
- End-to-end through the live LISTEN client: `notifyAllFileChanges` emitter → Postgres NOTIFY → listener → `clearLocalSourceCaches` on a fake peer-side Realm.

## Composition with CS-11119

This PR handles the **byte-cache** side of cross-replica invalidation: write-event triggered (publish/unpublish/delete), drops `#sourceCache` + `#transpiledModuleCache` on peers via `realm_file_changes:*` wildcard.

The orthogonal **read-side-cache** story (`#inFlightSearch` + `#cachedRealmInfo`) is closed by [CS-11119 / PR #4862](https://github.com/cardstack/boxel/pull/4862) on a separate `realm_index_updated` channel that fires at SWAP time rather than write time. The two PRs touch adjacent but non-overlapping surfaces and can land in either order.

## Compatibility
- Single-replica deploys: the local `clearLocalSourceCaches()` inside `clearLocalSourceCachesAndBroadcast()` still runs; the NOTIFY is a no-op when no other replicas are LISTENing. `clearRealmDefinitions` was already in use in the post-fullIndex completion path; calling it pre-reindex too is purely additive.
- SQLite (host) is a passthrough — `notify` is a no-op there.

## Test plan
- [x] `realm-file-changes-listener-test.ts` (16/16) including 4 new wildcard tests
- [x] `tsc` on `packages/runtime-common` + `packages/realm-server` — no new errors
- [x] Prettier clean on all touched files
- [x] CI realm-server suite (passed on the latest commit)
- [x] CI host suite (passed on the latest commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)