### PR TITLE
fix: pin vite to 127.0.0.1 behind same-port dispatcher

### DIFF
--- a/packages/host/scripts/vite-with-traefik.js
+++ b/packages/host/scripts/vite-with-traefik.js
@@ -21,7 +21,7 @@ const { spawn } = require('child_process');
 const path = require('path');
 const net = require('net');
 
-function runVite({ subcommand, port, allHosts, extraEnv, nodeMemory }) {
+function runVite({ subcommand, port, allHosts, host, extraEnv, nodeMemory }) {
   const args = ['vite'];
   if (subcommand) args.push(subcommand);
   args.push('--port', String(port), '--strictPort');
@@ -30,6 +30,8 @@ function runVite({ subcommand, port, allHosts, extraEnv, nodeMemory }) {
     // vite via host.docker.internal:<port>. Vite's default is 127.0.0.1
     // only, which is unreachable from inside the container.
     args.push('--host');
+  } else if (host) {
+    args.push('--host', host);
   }
   const env = { ...process.env, ...(extraEnv || {}) };
   if (nodeMemory) {
@@ -170,12 +172,18 @@ async function runViteBehindRedirectDispatcher({
   nodeMemory,
 }) {
   // Vite binds the internal port; the dispatcher owns the public one.
+  // Force vite onto 127.0.0.1 to match the dispatcher's upstream
+  // net.connect target. Without `--host`, vite default-binds to
+  // `localhost`, which on macOS / Node 17+ resolves to ::1 first — the
+  // dispatcher then can't reach it on 127.0.0.1 and the TLS handshake
+  // dies as ERR_CONNECTION_CLOSED in the browser.
   let viteInternalPort = await pickInternalPort();
   startSamePortRedirectDispatcher({ publicPort, viteInternalPort });
   runVite({
     subcommand,
     port: viteInternalPort,
     allHosts: false,
+    host: '127.0.0.1',
     nodeMemory,
   });
 }


### PR DESCRIPTION
Hi, I'm Claude — Buck asked me to investigate why `pnpm start` in `packages/host` was reporting "Vite appears to be running" but `https://localhost:4200` wouldn't connect. Here's what I found and a one-line-ish fix.

## Problem

The same-port redirect dispatcher introduced in 6c2d7f8318 binds public port 4200 on `127.0.0.1`, peeks the first byte off each connection, then forwards TLS bytes to vite at an internal loopback port via `net.connect(internalPort, '127.0.0.1')` (scripts/vite-with-traefik.js:95).

But `runVite` was invoking `vite --port <p>` with no `--host`, so vite default-binds to `localhost`. On macOS Sonoma+ / Node 17+, `dns.lookup('localhost')` returns `::1` first, so vite ends up listening on `[::1]:<p>` only.

The dispatcher's IPv4 upstream `connect` then fails immediately, its `upstream.on('error', () => socket.destroy())` handler tears down the client socket mid-TLS-handshake, and the browser sees `ERR_CONNECTION_CLOSED` — even though the dispatcher cheerfully logs `Listening on ... → vite at 127.0.0.1:<p>`.

Plain `http://localhost:4200` still works because the 308 response is written directly to the accepted socket without touching upstream, which is why testem and curl-against-http didn't catch this.

Reproduced locally:
- `lsof`: dispatcher on `IPv4 127.0.0.1:4200`, vite on `IPv6 [::1]:53460`.
- `curl -k https://localhost:4200/` → `SSL_ERROR_SYSCALL`.
- Chrome → `net::ERR_CONNECTION_CLOSED`.

## Fix

Pin both ends of the pipe to the same loopback family. Pass `host: '127.0.0.1'` to vite when it runs behind the dispatcher so it explicitly binds the IPv4 loopback the dispatcher connects on. The Traefik / env-mode path is unaffected — that one still passes `--host` (all-interfaces).

After the fix:
- `curl https://localhost:4200/` → `200, http_version 2` ✅
- `curl http://localhost:4200/` → `308 → https://localhost:4200/` ✅
- Chrome loads `https://localhost:4200/` cleanly ✅

## Test plan

- [ ] In a shell where `REALM_SERVER_TLS_CERT_FILE` is set (i.e. the mkcert cert exists), `pnpm start` from `packages/host` and visit `https://localhost:4200` in a browser — should load the host app over HTTP/2, not `ERR_CONNECTION_CLOSED`.
- [ ] `curl http://localhost:4200/` returns a 308 to `https://localhost:4200/`.
- [ ] Env-mode (`BOXEL_ENVIRONMENT=...`) still binds vite on all interfaces so Traefik in Docker can reach it via `host.docker.internal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)