### PR TITLE
createRealm: enqueue exactly one priority-10 index job (CS-11157)

### DIFF
--- a/packages/realm-server/handlers/create-realm.ts
+++ b/packages/realm-server/handlers/create-realm.ts
@@ -219,25 +219,20 @@ export async function createRealm(
     virtualNetwork.addURLMapping(new URL(url), actualRealmURL);
   }
 
-  // Enqueue exactly one from-scratch-index job for this new realm, at
-  // userInitiatedPriority so a backed-up queue of system-priority jobs
-  // (e.g. a deploy-triggered reindex storm) does not stall realm
-  // creation. lookupOrMount is told to skip its own from-scratch
-  // enqueue via skipFromScratchIndex so this remains the only job —
-  // independent of whether the from-scratch coalesce would have caught
-  // a duplicate.
-  let indexJob = await enqueueReindexRealmJob(
-    url,
-    ownerUsername,
-    queue,
-    dbAdapter,
-    userInitiatedPriority,
-  );
-
-  // Synchronously mount the realm on the *handling* instance. The 202
-  // response with status:'pending' is for sibling instances — they
-  // pick up the realm via NOTIFY realm_registry and lazy-mount on
-  // first request. Mounting eagerly here also drains the queue
+  // Mount the realm on the *handling* instance BEFORE publishing the
+  // index job. If a worker claimed the job between publish and the
+  // mount below, the worker's first `_mtimes` fetch against this
+  // server-instance would land in findOrMountRealm, whose lazy-mount
+  // path calls lookupOrMount without `skipFromScratchIndex` — and
+  // that lookupOrMount would enqueue the duplicate priority-0 job
+  // this code is trying to avoid. Mounting first means the realm is
+  // already in `realms[]` / `virtualNetwork` / the reconciler's
+  // `mounted` map by the time any worker fetch can route here, so the
+  // lazy-mount path never fires for it.
+  //
+  // The 202 response with status:'pending' is for sibling instances —
+  // they pick up the realm via NOTIFY realm_registry and lazy-mount
+  // on first request. Mounting eagerly here also drains the queue
   // locally so the test framework's teardown (close server → drain
   // runner → close DB) doesn't race a worker mid-fetch on the now-
   // closed HTTP listener.
@@ -250,10 +245,20 @@ export async function createRealm(
     );
   }
 
+  // Enqueue exactly one from-scratch-index job at userInitiatedPriority
+  // so a backed-up queue of system-priority jobs (e.g. a deploy-
+  // triggered reindex storm) does not stall realm creation.
+  let indexJob = await enqueueReindexRealmJob(
+    url,
+    ownerUsername,
+    queue,
+    dbAdapter,
+    userInitiatedPriority,
+  );
+
   // Wait for the priority-10 job to complete so the realm is fully
   // indexed by the time we return — preserving the prior "fully ready
-  // on this instance" contract without the duplicate-enqueue
-  // workaround.
+  // on this instance" contract.
   await indexJob.done;
 
   return { url, realm, info };

--- a/packages/realm-server/handlers/create-realm.ts
+++ b/packages/realm-server/handlers/create-realm.ts
@@ -219,12 +219,14 @@ export async function createRealm(
     virtualNetwork.addURLMapping(new URL(url), actualRealmURL);
   }
 
-  // Phase 3: enqueue the from-scratch-index job at userInitiatedPriority
-  // so the canonical (post-coalesce) job carries that priority — even
-  // if reconciler.lookupOrMount below also enqueues one at the default
-  // systemInitiatedPriority via realm.start(). The chooseFromScratch
-  // coalesce JOINs same-realm jobs and keeps maxPriority.
-  await enqueueReindexRealmJob(
+  // Enqueue exactly one from-scratch-index job for this new realm, at
+  // userInitiatedPriority so a backed-up queue of system-priority jobs
+  // (e.g. a deploy-triggered reindex storm) does not stall realm
+  // creation. lookupOrMount is told to skip its own from-scratch
+  // enqueue via skipFromScratchIndex so this remains the only job —
+  // independent of whether the from-scratch coalesce would have caught
+  // a duplicate.
+  let indexJob = await enqueueReindexRealmJob(
     url,
     ownerUsername,
     queue,
@@ -232,22 +234,27 @@ export async function createRealm(
     userInitiatedPriority,
   );
 
-  // Synchronously mount + start the realm on the *handling* instance.
-  // The 202 response with status:'pending' is for sibling instances —
-  // they pick up the realm via NOTIFY realm_registry and lazy-mount
-  // on first request. On this instance the realm is fully ready by
-  // the time we return: ensureMounted publishes into realms[] /
-  // virtualNetwork via prepareRealmFromRow and awaits realm.start(),
-  // which awaits the from-scratch-index job. Mounting eagerly here
-  // also drains the queue locally so the test framework's teardown
-  // (close server → drain runner → close DB) doesn't race a worker
-  // mid-fetch on the now-closed HTTP listener.
-  let realm = await reconciler.lookupOrMount(url);
+  // Synchronously mount the realm on the *handling* instance. The 202
+  // response with status:'pending' is for sibling instances — they
+  // pick up the realm via NOTIFY realm_registry and lazy-mount on
+  // first request. Mounting eagerly here also drains the queue
+  // locally so the test framework's teardown (close server → drain
+  // runner → close DB) doesn't race a worker mid-fetch on the now-
+  // closed HTTP listener.
+  let realm = await reconciler.lookupOrMount(url, {
+    skipFromScratchIndex: true,
+  });
   if (!realm) {
     throw new Error(
       `expected realm ${url} to be mounted after createRealm — registry row missing or mount failed`,
     );
   }
+
+  // Wait for the priority-10 job to complete so the realm is fully
+  // indexed by the time we return — preserving the prior "fully ready
+  // on this instance" contract without the duplicate-enqueue
+  // workaround.
+  await indexJob.done;
 
   return { url, realm, info };
 }

--- a/packages/realm-server/handlers/create-realm.ts
+++ b/packages/realm-server/handlers/create-realm.ts
@@ -4,7 +4,6 @@ import { ensureDirSync, writeJSONSync } from 'fs-extra';
 import * as Sentry from '@sentry/node';
 import type {
   DBAdapter,
-  QueuePublisher,
   Realm,
   RealmInfo,
   VirtualNetwork,
@@ -19,7 +18,6 @@ import {
   SupportedMimeType,
   userInitiatedPriority,
 } from '@cardstack/runtime-common';
-import { enqueueReindexRealmJob } from '@cardstack/runtime-common/jobs/reindex-realm';
 import { getMatrixUsername } from '@cardstack/runtime-common/matrix-client';
 import { insertSourceRealmInRegistry } from '../lib/realm-registry-writes';
 import type { RealmRegistryReconciler } from '../lib/realm-registry-reconciler';
@@ -37,7 +35,6 @@ export type CreateRealmDeps = {
   serverURL: URL;
   realms: Realm[];
   dbAdapter: DBAdapter;
-  queue: QueuePublisher;
   virtualNetwork: VirtualNetwork;
   realmsRootPath: string;
   reconciler: RealmRegistryReconciler;
@@ -78,7 +75,6 @@ export async function createRealm(
     serverURL,
     realms,
     dbAdapter,
-    queue,
     virtualNetwork,
     realmsRootPath,
     reconciler,
@@ -219,16 +215,15 @@ export async function createRealm(
     virtualNetwork.addURLMapping(new URL(url), actualRealmURL);
   }
 
-  // Mount the realm on the *handling* instance BEFORE publishing the
-  // index job. If a worker claimed the job between publish and the
-  // mount below, the worker's first `_mtimes` fetch against this
-  // server-instance would land in findOrMountRealm, whose lazy-mount
-  // path calls lookupOrMount without `skipFromScratchIndex` — and
-  // that lookupOrMount would enqueue the duplicate priority-0 job
-  // this code is trying to avoid. Mounting first means the realm is
-  // already in `realms[]` / `virtualNetwork` / the reconciler's
-  // `mounted` map by the time any worker fetch can route here, so the
-  // lazy-mount path never fires for it.
+  // Mount the realm on the *handling* instance and let the mount
+  // pipeline itself drive the one-and-only from-scratch-index, at
+  // userInitiatedPriority so a backed-up queue of system-priority
+  // jobs (e.g. a deploy-triggered reindex storm) does not stall realm
+  // creation. lookupOrMount → ensureMounted → realm.start → #startup
+  // sees `isNewIndex = true` for a freshly-registered realm and
+  // enqueues exactly one job via publishFullIndex, which also updates
+  // the realm's in-memory #stats / #ignoreData / #ignoreDataVersion
+  // when the job completes.
   //
   // The 202 response with status:'pending' is for sibling instances —
   // they pick up the realm via NOTIFY realm_registry and lazy-mount
@@ -237,29 +232,13 @@ export async function createRealm(
   // runner → close DB) doesn't race a worker mid-fetch on the now-
   // closed HTTP listener.
   let realm = await reconciler.lookupOrMount(url, {
-    skipFromScratchIndex: true,
+    fromScratchIndexPriority: userInitiatedPriority,
   });
   if (!realm) {
     throw new Error(
       `expected realm ${url} to be mounted after createRealm — registry row missing or mount failed`,
     );
   }
-
-  // Enqueue exactly one from-scratch-index job at userInitiatedPriority
-  // so a backed-up queue of system-priority jobs (e.g. a deploy-
-  // triggered reindex storm) does not stall realm creation.
-  let indexJob = await enqueueReindexRealmJob(
-    url,
-    ownerUsername,
-    queue,
-    dbAdapter,
-    userInitiatedPriority,
-  );
-
-  // Wait for the priority-10 job to complete so the realm is fully
-  // indexed by the time we return — preserving the prior "fully ready
-  // on this instance" contract.
-  await indexJob.done;
 
   return { url, realm, info };
 }

--- a/packages/realm-server/lib/realm-registry-reconciler.ts
+++ b/packages/realm-server/lib/realm-registry-reconciler.ts
@@ -293,7 +293,7 @@ export class RealmRegistryReconciler {
   // original requester.
   async lookupOrMount(
     url: string,
-    opts?: { skipFromScratchIndex?: boolean },
+    opts?: { fromScratchIndexPriority?: number },
   ): Promise<Realm | undefined> {
     const inflight = this.pendingMounts.get(url);
     if (inflight) {
@@ -352,7 +352,7 @@ export class RealmRegistryReconciler {
   // these lines.
   async ensureMounted(
     row: RealmRegistryRow,
-    opts?: { skipFromScratchIndex?: boolean },
+    opts?: { fromScratchIndexPriority?: number },
   ): Promise<Realm> {
     // pendingMounts checked before mounted: see lookupOrMount() above.
     // The Realm is published into mounted synchronously before its

--- a/packages/realm-server/lib/realm-registry-reconciler.ts
+++ b/packages/realm-server/lib/realm-registry-reconciler.ts
@@ -291,7 +291,10 @@ export class RealmRegistryReconciler {
   // would receive a not-yet-started Realm; routing it through the
   // in-flight promise instead lets the caller await start() like the
   // original requester.
-  async lookupOrMount(url: string): Promise<Realm | undefined> {
+  async lookupOrMount(
+    url: string,
+    opts?: { skipFromScratchIndex?: boolean },
+  ): Promise<Realm | undefined> {
     const inflight = this.pendingMounts.get(url);
     if (inflight) {
       return inflight;
@@ -308,7 +311,7 @@ export class RealmRegistryReconciler {
       }
       this.knownByUrl.set(url, row);
     }
-    return this.ensureMounted(row);
+    return this.ensureMounted(row, opts);
   }
 
   async #lookupRow(url: string): Promise<RealmRegistryRow | undefined> {
@@ -347,7 +350,10 @@ export class RealmRegistryReconciler {
   // rollout safety relies on this signal — Loki/Grafana extract cold-
   // mount latency, mount failure rate, and pinned-vs-lazy ratios from
   // these lines.
-  async ensureMounted(row: RealmRegistryRow): Promise<Realm> {
+  async ensureMounted(
+    row: RealmRegistryRow,
+    opts?: { skipFromScratchIndex?: boolean },
+  ): Promise<Realm> {
     // pendingMounts checked before mounted: see lookupOrMount() above.
     // The Realm is published into mounted synchronously before its
     // start() promise resolves, so a caller hitting the mounted
@@ -386,7 +392,7 @@ export class RealmRegistryReconciler {
     this.#reconcilerOwned.add(row.url);
     const promise = (async () => {
       try {
-        await realm.start();
+        await realm.start(opts);
         log.info(
           `mount ok url=%s kind=%s pinned=%s duration_ms=%d`,
           row.url,

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -121,7 +121,6 @@ export function createRoutes(args: CreateRoutesArgs) {
     serverURL: new URL(args.serverURL),
     realms: args.realms,
     dbAdapter: args.dbAdapter,
-    queue: args.queue,
     virtualNetwork: args.virtualNetwork,
     realmsRootPath: args.realmsRootPath,
     reconciler: args.reconciler,

--- a/packages/realm-server/tests/server-endpoints/realm-lifecycle-test.ts
+++ b/packages/realm-server/tests/server-endpoints/realm-lifecycle-test.ts
@@ -133,13 +133,14 @@ module(`server-endpoints/${basename(__filename)}`, function () {
         let jobs = (await context.dbAdapter.execute(
           `SELECT priority FROM jobs WHERE job_type = 'from-scratch-index' AND args->>'realmURL' = '${json.data.id}'`,
         )) as { priority: number }[];
-        assert.ok(
-          jobs.length > 0,
-          'found from-scratch index job for created realm',
-        );
-        assert.ok(
-          jobs.some((j) => j.priority === userInitiatedPriority),
-          'user initiated realm indexing uses high priority queue',
+        // Contract: realm creation enqueues exactly one
+        // from-scratch-index job, at userInitiatedPriority. A second
+        // job at default priority would block creation behind any
+        // backlog of lower-priority indexing work.
+        assert.deepEqual(
+          jobs.map((j) => j.priority),
+          [userInitiatedPriority],
+          'realm creation enqueues exactly one from-scratch index job at userInitiatedPriority',
         );
 
         let permissions = await fetchRealmPermissions(

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1296,8 +1296,13 @@ export class Realm {
     });
   }
 
-  async start() {
-    this.#startedUp.fulfill((() => this.#startup())());
+  // `skipFromScratchIndex` lets a caller that has already enqueued a
+  // from-scratch-index job for this realm mount the realm without
+  // `#startup` enqueuing its own duplicate. The realm still mounts,
+  // its #startedUp promise still resolves, and request handlers can
+  // route to it — but indexing is then the caller's responsibility.
+  async start(opts?: { skipFromScratchIndex?: boolean }) {
+    this.#startedUp.fulfill((() => this.#startup(opts))());
 
     if (this.#adapter.fileWatcherEnabled) {
       await this.startFileWatcher();
@@ -2174,7 +2179,7 @@ export class Realm {
     await completed;
   }
 
-  async #startup() {
+  async #startup(opts?: { skipFromScratchIndex?: boolean }) {
     await Promise.resolve();
     let startTime = Date.now();
     if (this.#copiedFromRealm) {
@@ -2185,7 +2190,7 @@ export class Realm {
         sourceRealmURL: this.#copiedFromRealm.href,
         realmURL: this.url,
       });
-    } else {
+    } else if (!opts?.skipFromScratchIndex) {
       let isNewIndex = await this.#realmIndexUpdater.isNewIndex();
       if (isNewIndex || this.#fullIndexOnStartup) {
         let promise = this.#realmIndexUpdater.fullIndex(

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1296,12 +1296,13 @@ export class Realm {
     });
   }
 
-  // `skipFromScratchIndex` lets a caller that has already enqueued a
-  // from-scratch-index job for this realm mount the realm without
-  // `#startup` enqueuing its own duplicate. The realm still mounts,
-  // its #startedUp promise still resolves, and request handlers can
-  // route to it — but indexing is then the caller's responsibility.
-  async start(opts?: { skipFromScratchIndex?: boolean }) {
+  // `fromScratchIndexPriority` overrides the realm's default priority
+  // for the from-scratch-index job that `#startup` enqueues when the
+  // realm has no prior index. Callers that mount-on-demand for a
+  // user-initiated flow (e.g. realm creation) pass
+  // `userInitiatedPriority` so the resulting job jumps ahead of any
+  // backlog of system-priority indexing work.
+  async start(opts?: { fromScratchIndexPriority?: number }) {
     this.#startedUp.fulfill((() => this.#startup(opts))());
 
     if (this.#adapter.fileWatcherEnabled) {
@@ -2179,7 +2180,7 @@ export class Realm {
     await completed;
   }
 
-  async #startup(opts?: { skipFromScratchIndex?: boolean }) {
+  async #startup(opts?: { fromScratchIndexPriority?: number }) {
     await Promise.resolve();
     let startTime = Date.now();
     if (this.#copiedFromRealm) {
@@ -2190,12 +2191,12 @@ export class Realm {
         sourceRealmURL: this.#copiedFromRealm.href,
         realmURL: this.url,
       });
-    } else if (!opts?.skipFromScratchIndex) {
+    } else {
       let isNewIndex = await this.#realmIndexUpdater.isNewIndex();
       if (isNewIndex || this.#fullIndexOnStartup) {
-        let promise = this.#realmIndexUpdater.fullIndex(
-          this.#fromScratchIndexPriority,
-        );
+        let priority =
+          opts?.fromScratchIndexPriority ?? this.#fromScratchIndexPriority;
+        let promise = this.#realmIndexUpdater.fullIndex(priority);
         if (isNewIndex) {
           // we only await the full indexing at boot if this is a brand new index
           await promise;


### PR DESCRIPTION
## Summary

Fixes the *"realm creation hangs during deploy-triggered reindex storms"* shape from [CS-11157](https://linear.app/cardstack/issue/CS-11157).

Realm creation now enqueues **exactly one** `from-scratch-index` job for the new realm, at `userInitiatedPriority`, so a backed-up queue of system-priority indexing work (e.g. a deploy-triggered reindex storm) does not stall the HTTP create-realm request.

Stacked on #4846 (the server.ts refactor) because the change lands in the extracted `handlers/create-realm.ts`.

## How

Thread a new `fromScratchIndexPriority` option from the realm-creation handler through the mount pipeline so the realm's own `#startup` produces the single canonical job at the chosen priority:

```
createRealm
  → reconciler.lookupOrMount(url, { fromScratchIndexPriority: userInitiatedPriority })
    → ensureMounted(row, opts)
      → realm.start(opts)
        → #startup(opts)
          → realmIndexUpdater.fullIndex(
              opts.fromScratchIndexPriority ?? this.#fromScratchIndexPriority
            )
            → publishFullIndex(priority)   // .then() updates
                                            // #stats / #ignoreData /
                                            // #ignoreDataVersion
```

The option defaults to `this.#fromScratchIndexPriority` (currently `systemInitiatedPriority`) at every layer, so callers that don't pass it — boot-time pinned-realm mount, lazy-mount on first request — keep their existing behaviour.

`prepareRealmFromRow` (in `main.ts`) publishes the realm into `realms[]` + `virtualNetwork` synchronously, **before** `realm.start()` runs. So a worker `_mtimes` fetch that races the mount resolves via the existing mount in `findOrMountRealm` and never re-enters the lazy-mount path — no duplicate enqueue is possible from inside this server-instance during the mount window.

## Regression test

`realm-lifecycle-test.ts` tightens the `POST /_create-realm` assertion from "at least one priority-10 job exists" to **exactly one job, at `userInitiatedPriority`**. With the previous shape (explicit enqueue at 10 + implicit enqueue at 0 via `realm.start()`, intended to coalesce), a worker claim landing between the two enqueues would have produced two rows and failed this assertion.

## Files

- `packages/runtime-common/realm.ts` — `start()` / `#startup()` accept `{ fromScratchIndexPriority?: number }`
- `packages/realm-server/lib/realm-registry-reconciler.ts` — `lookupOrMount` / `ensureMounted` pass the option through
- `packages/realm-server/handlers/create-realm.ts` — passes `fromScratchIndexPriority: userInitiatedPriority` to `lookupOrMount`; drops the deps it no longer needs (`queue`)
- `packages/realm-server/routes.ts` — drops `queue` from the `CreateRealmDeps` bag
- `packages/realm-server/tests/server-endpoints/realm-lifecycle-test.ts` — tightened assertion

## Out of scope

`handlers/handle-publish-realm.ts` follows the same pattern (explicit `enqueueReindexRealmJob` followed by `reconciler.lookupOrMount` that re-enqueues via `realm.start`). Same fix would apply; deferred to a follow-up since this PR is scoped to realm creation per the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)