### PR TITLE
Stabilize prerender "distinct pages per realm" against cross-affinity steal

### DIFF
--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -992,6 +992,25 @@ export class PagePool {
       throwIfAborted(signal);
     }
     if (entry.affinityKey !== affinityKey) {
+      // The only path that returns an entry tagged for a different
+      // affinity is the brand-new-affinity cross-affinity-steal
+      // fallback in `#selectEntryForAffinity`. It runs only when
+      // `#ensureStandbyPool` couldn't produce a standby — usually a
+      // transient browser-context creation failure. The reassignment
+      // below keeps the donor entry's `pageId`, so callers that ask
+      // "did I get a distinct page from the previous render?" will
+      // observe equality across two different affinities. Surfacing
+      // the path here gives CI logs the breadcrumb when that
+      // assertion trips. Kept at `warn` because hitting this path
+      // also means we're rendering one affinity's content on a tab
+      // whose CDP runtime state was warmed for a different affinity.
+      log.warn(
+        `cross-affinity steal: reassigning pageId=${entry.pageId} ` +
+          `from ${entry.affinityKey} to ${affinityKey} ` +
+          `(standby refill failed to produce a fresh tab; ` +
+          `standbys=${this.#standbys.size} creating=${this.#creatingStandbys} ` +
+          `active=${this.#poolEntryCount()} maxPages=${this.#maxPages})`,
+      );
       entry = this.#reassignAffinityTab(entry, affinityKey);
       reused = false;
     }

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -190,6 +190,15 @@ export class Prerenderer {
     await this.#pagePool.disposeAffinity(affinityKey);
   }
 
+  // Block until the standby pool has reached its desired count. The
+  // constructor and `disposeAffinity` both kick refill fire-and-forget;
+  // tests that need a fresh tab in their *next* `prerenderVisit` call
+  // (rather than racing the kicked refill) await this instead. Wraps
+  // `PagePool.warmStandbys`, which dedupes against any in-flight kick.
+  async warmStandbys(): Promise<void> {
+    await this.#pagePool.warmStandbys();
+  }
+
   // Emit the `render cancelled` log line (format from CS-10872)
   // and, on a `rendering`-state cancel, tear down the affinity so
   // the next request gets a fresh tab rather than one whose

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -3494,6 +3494,16 @@ module(basename(__filename), function () {
             affinityValue: realmURL3,
           }),
         ]);
+        // `disposeAffinity` only KICKS standby refill — it doesn't await
+        // it. If the next test claims a tab before that kick produces a
+        // standby AND `#ensureStandbyPool`'s awaited retry also can't
+        // produce one, `#selectEntryForAffinity` falls through to the
+        // cross-affinity-steal escape hatch and reassigns an idle tab
+        // from another realm — keeping the donor's `pageId`. The
+        // "distinct pages per realm" test then sees `r1.pool.pageId ===
+        // r2.pool.pageId` and fails. Waiting here makes the next
+        // affinity-pooling test deterministic on the standby path.
+        await prerenderer.warmStandbys();
       };
 
       hooks.before(async function () {
@@ -4913,10 +4923,24 @@ module(basename(__filename), function () {
             url: testCardURL2,
             auth: auth(),
           });
+          // When this fails it's almost always the cross-affinity-steal
+          // fallback in `#selectEntryForAffinity` — `pageId` is equal
+          // because realm2's `getPage` repurposed realm1's idle tab
+          // when `#ensureStandbyPool` couldn't conjure a standby. Dump
+          // both call's `tabStartupMs` / `tabQueueMs` (a steal returns
+          // `tabStartupMs=0`, the standby path is non-zero) and the
+          // live queue snapshot so the CI log shows where the standby
+          // pool was when the race fired.
+          let queueSnapshot = prerenderer.getQueueDepthSnapshot();
           assert.notStrictEqual(
             r1.pool.pageId,
             r2.pool.pageId,
-            'distinct pages per realm',
+            `distinct pages per realm — ` +
+              `r1.pageId=${r1.pool.pageId} ` +
+              `r2.pageId=${r2.pool.pageId} ` +
+              `r1.waits=${JSON.stringify(r1.timings.waits)} ` +
+              `r2.waits=${JSON.stringify(r2.timings.waits)} ` +
+              `queueSnapshot=${JSON.stringify(queueSnapshot)}`,
           );
           assert.false(r1.pool.reused, 'first realm first call not reused');
           assert.false(r2.pool.reused, 'second realm first call not reused');


### PR DESCRIPTION
## Summary

- Flake fix for `does not reuse across different realms (default)` in `prerendering-test.ts` ([failing check](https://github.com/cardstack/boxel/runs/76535724790), shard 2 first attempt). Both `r1.pool.pageId` and `r2.pool.pageId` came back equal — the signature of the brand-new-affinity *cross-affinity-steal* fallback in `PagePool.#selectEntryForAffinity`. That path repurposes an idle donor tab when `#ensureStandbyPool` can't produce a fresh standby (a transient browser-context creation failure under CI load); `#reassignAffinityTab` preserves the donor's `pageId`, so two different realms momentarily share the same Chrome page.
- Add `Prerenderer.warmStandbys()` (thin wrapper over `PagePool.warmStandbys`) and `await` it from the `formats and pooling` module's `disposeAllRealms` `beforeEach`. Every affinity-pooling test now starts with a fully warm standby pool, so r2's `getPage` always finds a standby and never reaches the steal.
- Add diagnostics in case the underlying refill failure ever resurfaces:
  - `PagePool.getPage`: `log.warn` when `entry.affinityKey !== requested affinityKey` (uniquely the cross-affinity-steal signature) with live `standbys` / `creating` / `active` / `maxPages` counts and both affinity keys.
  - Test assertion: dumps both `pageId`s, both `timings.waits` blocks, and `getQueueDepthSnapshot()` so a future failure shows exactly which step ran short.

## Test plan

- [ ] CI runs `prerendering-test.ts` shard 2 — the affinity-pooling subtree is deterministic on the standby path now.
- [ ] If CI still flakes here, the warn log + enriched assertion message will show whether `#ensureStandbyPool` is the underlying problem (and which counts looked wrong when the steal fired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)