### PR TITLE
CS-11167: HTTP DELETE card-source returns 204 without awaiting indexing

### DIFF
--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -683,6 +683,106 @@ module(`Integration | realm indexing`, function (hooks) {
     }
   });
 
+  test('HTTP DELETE +source returns before incremental indexing settles', async function (assert) {
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'Pet/mango.json': {
+          data: {
+            id: `${testRealmURL}Pet/mango`,
+            attributes: { firstName: 'Mango' },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/pet',
+                name: 'Pet',
+              },
+            },
+          },
+        },
+      },
+    });
+    let queryEngine = realm.realmIndexQueryEngine;
+
+    // Sanity: drain the from-scratch indexing that setup queues so the
+    // pending-indexing assertion below isolates the DELETE's work.
+    await realm.incrementalIndexing();
+    assert.strictEqual(
+      realm.incrementalIndexing(),
+      undefined,
+      'baseline: no pending indexing before DELETE',
+    );
+
+    let response = await realm.handle(
+      new Request(`${testRealmURL}Pet/mango`, {
+        method: 'DELETE',
+        headers: { Accept: 'application/vnd.card+source' },
+      }),
+    );
+    if (!response) {
+      throw new Error('realm did not handle the DELETE');
+    }
+    assert.strictEqual(response.status, 204, 'DELETE returns 204');
+
+    // The HTTP response landed; the worker settle is fire-and-forget.
+    // The underlying file is already gone from disk (sync part of delete).
+    assert.strictEqual(
+      await adapter.openFile('Pet/mango.json'),
+      undefined,
+      'file is gone from disk before indexing settles',
+    );
+    let pendingIndex = realm.incrementalIndexing();
+    assert.notStrictEqual(
+      pendingIndex,
+      undefined,
+      'DELETE returned before deferred indexing settled',
+    );
+
+    await pendingIndex;
+    assert.strictEqual(
+      realm.incrementalIndexing(),
+      undefined,
+      'incrementalIndexing() drains the deferred delete work',
+    );
+
+    let entry = await queryEngine.cardDocument(
+      new URL(`${testRealmURL}Pet/mango`),
+    );
+    assert.strictEqual(
+      entry,
+      undefined,
+      'index reflects the deletion after the drain',
+    );
+  });
+
+  test('realm.delete() with default options (waitForIndex:true) awaits indexing inline', async function (assert) {
+    let { realm } = await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'Pet/mango.json': {
+          data: {
+            id: `${testRealmURL}Pet/mango`,
+            attributes: { firstName: 'Mango' },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/pet',
+                name: 'Pet',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await realm.incrementalIndexing();
+    await realm.delete('Pet/mango.json');
+
+    assert.strictEqual(
+      realm.incrementalIndexing(),
+      undefined,
+      'no pending indexing remains after a default delete — the await happened inline',
+    );
+  });
+
   test('write with default options (waitForIndex:true) awaits indexing inline', async function (assert) {
     let { realm } = await setupIntegrationTestRealm({
       mockMatrixUtils,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2117,7 +2117,10 @@ export class Realm {
     return { isTracked: false, url };
   }
 
-  async delete(path: LocalPath): Promise<void> {
+  async delete(
+    path: LocalPath,
+    options?: { waitForIndex?: boolean },
+  ): Promise<void> {
     let url = this.paths.fileURL(path);
     this.sendIndexInitiationEvent(url.href);
     await this.trackOwnWrite(path, { isDelete: true });
@@ -2131,10 +2134,34 @@ export class Realm {
     await this.#notifyFileChange(path);
     // Remove file meta for this path
     await this.removeFileMeta([path]);
-    let invalidations = await this.updateIndexAndCollectInvalidations([url], {
-      delete: true,
-    });
-    this.broadcastIncrementalInvalidationEvent(invalidations);
+    let waitForIndex = options?.waitForIndex !== false;
+    if (waitForIndex) {
+      let invalidations = await this.updateIndexAndCollectInvalidations([url], {
+        delete: true,
+      });
+      this.broadcastIncrementalInvalidationEvent(invalidations);
+    } else {
+      // Mirrors the write() waitForIndex:false path: await the durable
+      // enqueue so DB-side failures still bubble out, but fire-and-forget
+      // the worker settle. The post-worker broadcast runs inside the
+      // deferred lifecycle via onSettled so realm.incrementalIndexing()
+      // doesn't resolve before the broadcast.
+      let { settled } = await this.enqueueIndexUpdateAndCollectInvalidations(
+        [url],
+        {
+          delete: true,
+          onSettled: (deferredInvalidations) => {
+            this.broadcastIncrementalInvalidationEvent(deferredInvalidations);
+          },
+        },
+      );
+      settled.catch((err: unknown) => {
+        let message = err instanceof Error ? err.message : String(err);
+        this.#log.error(
+          `Deferred delete-indexing chain failed for ${this.url}${path}: ${message}`,
+        );
+      });
+    }
   }
 
   async deleteAll(paths: LocalPath[]): Promise<void> {
@@ -3465,6 +3492,11 @@ export class Realm {
     request: Request,
     requestContext: RequestContext,
   ): Promise<Response> {
+    // Source-content-type callers, by definition, don't depend on indexed
+    // state — symmetric with upsertCardSource. Return as soon as the file
+    // is gone from disk; indexing happens async and surfaces errors via
+    // error_doc as before. Subscribers to indexing events still see the
+    // broadcast once the worker settles.
     let localName = this.paths.local(new URL(request.url));
     let handle = await this.getFileWithFallbacks(localName, [
       ...executableExtensions,
@@ -3473,7 +3505,7 @@ export class Realm {
     if (!handle) {
       return notFound(request, requestContext, `${localName} not found`);
     }
-    await this.delete(handle.path);
+    await this.delete(handle.path, { waitForIndex: false });
     return createResponse({
       body: null,
       init: { status: 204 },

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2159,13 +2159,16 @@ export class Realm {
       settled.then(
         () => {
           this.#log.info(
-            `Deferred delete-indexing settled for ${this.url}${path} in ${Date.now() - enqueueStart}ms`,
+            `Deferred delete-indexing settled for ${url.href} in ${Date.now() - enqueueStart}ms`,
           );
         },
         (err: unknown) => {
-          let message = err instanceof Error ? err.message : String(err);
+          let detail =
+            err instanceof Error
+              ? `${err.message}${err.stack ? `\n${err.stack}` : ''}`
+              : String(err);
           this.#log.error(
-            `Deferred delete-indexing chain failed for ${this.url}${path} after ${Date.now() - enqueueStart}ms: ${message}`,
+            `Deferred delete-indexing chain failed for ${url.href} after ${Date.now() - enqueueStart}ms: ${detail}`,
           );
         },
       );

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2146,6 +2146,7 @@ export class Realm {
       // the worker settle. The post-worker broadcast runs inside the
       // deferred lifecycle via onSettled so realm.incrementalIndexing()
       // doesn't resolve before the broadcast.
+      let enqueueStart = Date.now();
       let { settled } = await this.enqueueIndexUpdateAndCollectInvalidations(
         [url],
         {
@@ -2155,12 +2156,19 @@ export class Realm {
           },
         },
       );
-      settled.catch((err: unknown) => {
-        let message = err instanceof Error ? err.message : String(err);
-        this.#log.error(
-          `Deferred delete-indexing chain failed for ${this.url}${path}: ${message}`,
-        );
-      });
+      settled.then(
+        () => {
+          this.#log.info(
+            `Deferred delete-indexing settled for ${this.url}${path} in ${Date.now() - enqueueStart}ms`,
+          );
+        },
+        (err: unknown) => {
+          let message = err instanceof Error ? err.message : String(err);
+          this.#log.error(
+            `Deferred delete-indexing chain failed for ${this.url}${path} after ${Date.now() - enqueueStart}ms: ${message}`,
+          );
+        },
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- The realm-server's `DELETE` handler for `application/vnd.card+source` was awaiting the incremental index job's `settled` before returning its 204. Under concurrent realm load the job could sit in the worker queue for tens of seconds, long enough that callers with a normal 30s timeout would give up before the response arrived — the proximate cause of CS-11134 (flaky `re-pushes a file that was deleted on the realm out-of-band` test).
- `POST` card-source already returns immediately via `waitForIndex:false`; `DELETE` now mirrors that contract.
- `Realm.delete` gains an optional `waitForIndex` flag (default `true`, preserving every existing direct caller — two indexing-test cases and the unpublish path). The HTTP `removeCardSource` handler passes `waitForIndex:false`.
- On the `waitForIndex:false` branch, the durable enqueue is still awaited inline so DB-side failures surface to the HTTP client; only the worker settle is fire-and-forget. The post-worker broadcast is routed through `enqueueIndexUpdateAndCollectInvalidations`'s `onSettled`, so `realm.incrementalIndexing()` does not resolve before the broadcast (same shape as the write path).

## Test plan
- [x] Local: `packages/boxel-cli` integration tests pass, including the previously-flaky `re-pushes a file that was deleted on the realm out-of-band` (3 consecutive runs, ~2s for that test vs. 30s timeout before).
- [x] Local: realm-server qunit tests filtered to `--filter "deleted"` — 10/10 pass, including `can incrementally index deleted instance` / `can incrementally index instance that depends on deleted card source` (direct `realm.delete()` callers that still use the default `waitForIndex:true`) and the JSON-API card DELETE.
- [ ] CI: full Boxel CLI Tests + Realm Server Tests shards.

Closes CS-11167. Supersedes CS-11134 (cancelled as duplicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)