### PR TITLE
Opt private realms out of full reindex on startup

### DIFF
--- a/packages/realm-server/lib/full-index-on-startup.ts
+++ b/packages/realm-server/lib/full-index-on-startup.ts
@@ -4,14 +4,18 @@ import type { RealmRegistryRow } from './realm-registry-reconciler';
 // boots, given the registry row's `kind` and the value of
 // REALM_SERVER_FULL_INDEX_ON_STARTUP.
 //
-// Three-state override:
-//   'true'         → every kind full-indexes on startup (legacy behavior).
-//   'false'        → no kind full-indexes on startup (cached-index dev flow).
-//   undefined      → only kind='bootstrap' realms (the CLI --path realms,
-//                    e.g. base / catalog / skills) full-index on startup.
-//                    kind='source' and kind='published' skip the boot
-//                    reindex; a brand-new index still builds lazily via the
-//                    `isNewIndex` branch in Realm.start().
+// Override is matched by exact string value; anything other than the two
+// literals below (undefined, empty string, '1', 'TRUE', etc.) falls through
+// to the kind-based default.
+//   'true'   → every kind full-indexes on startup (legacy behavior).
+//   'false'  → only the `isNewIndex` branch in Realm.start() can full-index
+//              (cached-index dev flow; brand-new realms still index on first
+//              boot regardless of this flag).
+//   default  → only kind='bootstrap' realms (the CLI --path realms, e.g.
+//              base / catalog / skills) full-index on startup. kind='source'
+//              and kind='published' skip the boot reindex; a brand-new index
+//              still builds lazily via the `isNewIndex` branch in
+//              Realm.start().
 //
 // Note: the deploy-time platform-code reindex flows through a separate path
 // (handle-post-deployment.ts + boxel-ui checksum), so this resolution does

--- a/packages/realm-server/lib/full-index-on-startup.ts
+++ b/packages/realm-server/lib/full-index-on-startup.ts
@@ -1,0 +1,30 @@
+import type { RealmRegistryRow } from './realm-registry-reconciler';
+
+// Resolves whether a realm should run a from-scratch index when its process
+// boots, given the registry row's `kind` and the value of
+// REALM_SERVER_FULL_INDEX_ON_STARTUP.
+//
+// Three-state override:
+//   'true'         → every kind full-indexes on startup (legacy behavior).
+//   'false'        → no kind full-indexes on startup (cached-index dev flow).
+//   undefined      → only kind='bootstrap' realms (the CLI --path realms,
+//                    e.g. base / catalog / skills) full-index on startup.
+//                    kind='source' and kind='published' skip the boot
+//                    reindex; a brand-new index still builds lazily via the
+//                    `isNewIndex` branch in Realm.start().
+//
+// Note: the deploy-time platform-code reindex flows through a separate path
+// (handle-post-deployment.ts + boxel-ui checksum), so this resolution does
+// not affect post-deploy reindex storms.
+export function resolveFullIndexOnStartup(
+  kind: RealmRegistryRow['kind'],
+  envOverride: string | undefined,
+): boolean {
+  if (envOverride === 'true') {
+    return true;
+  }
+  if (envOverride === 'false') {
+    return false;
+  }
+  return kind === 'bootstrap';
+}

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -38,6 +38,7 @@ import {
 import { RealmFileChangesListener } from './lib/realm-file-changes-listener';
 import { ModuleCacheInvalidationListener } from './lib/module-cache-invalidation-listener';
 import { ModuleCacheCoordinator } from './lib/module-cache-coordination';
+import { resolveFullIndexOnStartup } from './lib/full-index-on-startup';
 import { PUBLISHED_DIRECTORY_NAME } from '@cardstack/runtime-common';
 
 let log = logger('main');
@@ -101,8 +102,23 @@ if (process.env.DISABLE_MODULE_CACHING === 'true') {
 }
 
 const ENABLE_FILE_WATCHER = process.env.ENABLE_FILE_WATCHER === 'true';
-const FULL_INDEX_ON_STARTUP =
-  process.env.REALM_SERVER_FULL_INDEX_ON_STARTUP !== 'false';
+// REALM_SERVER_FULL_INDEX_ON_STARTUP is a three-state override that controls
+// whether each realm runs a from-scratch index when its process boots:
+//   - unset (default): only kind='bootstrap' realms (the ones passed via the
+//     CLI --path args, e.g. base / catalog / skills) full-index on startup.
+//     kind='source' (user realms) and kind='published' realms skip the boot
+//     reindex — a brand-new index still gets built lazily because the
+//     `isNewIndex` branch in Realm.start() is independent of this flag.
+//   - 'true': every realm full-indexes on startup, regardless of kind.
+//     This matches the pre-flip behavior.
+//   - 'false': no realm full-indexes on startup, regardless of kind. Used by
+//     the cached-index dev flow (scripts/import-cached-index.sh) where the
+//     index tables were just restored from a recent CI snapshot.
+// The deploy-time platform-code reindex flows through a different path
+// (handle-post-deployment.ts + boxel-ui checksum), so flipping the default
+// here does not affect post-deploy reindex storms.
+const FULL_INDEX_ON_STARTUP_OVERRIDE =
+  process.env.REALM_SERVER_FULL_INDEX_ON_STARTUP;
 // When set to 'true', skip the unconditional modules-cache clear on startup.
 // Used by the software-factory test harness, which restores a known-good
 // modules cache from a template database (URLs already rewritten to match
@@ -267,7 +283,7 @@ let autoMigrate = migrateDB || undefined;
 log.info(
   `Realm server boot config: port=${port} serverURL=${serverURL} distURL=${distURL} matrixURL=${matrixURL} realmsRootPath=${realmsRootPath} migrateDB=${Boolean(
     migrateDB,
-  )} workerManagerPort=${workerManagerPort ?? 'none'} prerendererUrl=${prerendererUrl} enableFileWatcher=${ENABLE_FILE_WATCHER} fullIndexOnStartup=${FULL_INDEX_ON_STARTUP}`,
+  )} workerManagerPort=${workerManagerPort ?? 'none'} prerendererUrl=${prerendererUrl} enableFileWatcher=${ENABLE_FILE_WATCHER} fullIndexOnStartupOverride=${FULL_INDEX_ON_STARTUP_OVERRIDE ?? 'unset (bootstrap-only)'}`,
 );
 log.info(`Realm paths: ${paths.map(String).join(', ')}`);
 
@@ -422,6 +438,10 @@ const getIndexHTML = async () => {
         diskPath = join(realmsRootPath, PUBLISHED_DIRECTORY_NAME, row.disk_id);
       }
       const reconciledAdapter = new NodeAdapter(diskPath, ENABLE_FILE_WATCHER);
+      let fullIndexOnStartup = resolveFullIndexOnStartup(
+        row.kind,
+        FULL_INDEX_ON_STARTUP_OVERRIDE,
+      );
       const reconciledRealm = new Realm(
         {
           url: row.url,
@@ -449,9 +469,7 @@ const getIndexHTML = async () => {
           ),
         },
         {
-          ...(FULL_INDEX_ON_STARTUP
-            ? { fullIndexOnStartup: true as const }
-            : {}),
+          ...(fullIndexOnStartup ? { fullIndexOnStartup: true as const } : {}),
           ...(process.env.DISABLE_MODULE_CACHING === 'true'
             ? { disableModuleCaching: true }
             : {}),

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -102,16 +102,18 @@ if (process.env.DISABLE_MODULE_CACHING === 'true') {
 }
 
 const ENABLE_FILE_WATCHER = process.env.ENABLE_FILE_WATCHER === 'true';
-// REALM_SERVER_FULL_INDEX_ON_STARTUP is a three-state override that controls
-// whether each realm runs a from-scratch index when its process boots:
-//   - unset (default): only kind='bootstrap' realms (the ones passed via the
-//     CLI --path args, e.g. base / catalog / skills) full-index on startup.
-//     kind='source' (user realms) and kind='published' realms skip the boot
-//     reindex — a brand-new index still gets built lazily because the
-//     `isNewIndex` branch in Realm.start() is independent of this flag.
+// REALM_SERVER_FULL_INDEX_ON_STARTUP is a three-state override (resolved in
+// lib/full-index-on-startup.ts) that controls whether each realm runs a
+// from-scratch index when its process boots. The `isNewIndex` branch in
+// Realm.start() is independent of this flag, so a brand-new (empty) index
+// still builds on first boot regardless of which value is set here.
+//   - default (unset, or any value other than 'true' / 'false'): only
+//     kind='bootstrap' realms (the ones passed via the CLI --path args,
+//     e.g. base / catalog / skills) full-index on startup. kind='source'
+//     (user realms) and kind='published' realms skip the boot reindex.
 //   - 'true': every realm full-indexes on startup, regardless of kind.
-//     This matches the pre-flip behavior.
-//   - 'false': no realm full-indexes on startup, regardless of kind. Used by
+//     Matches the pre-flip behavior.
+//   - 'false': suppresses the env-driven full-index for every kind. Used by
 //     the cached-index dev flow (scripts/import-cached-index.sh) where the
 //     index tables were just restored from a recent CI snapshot.
 // The deploy-time platform-code reindex flows through a different path

--- a/packages/realm-server/tests/full-index-on-startup-test.ts
+++ b/packages/realm-server/tests/full-index-on-startup-test.ts
@@ -1,0 +1,67 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { resolveFullIndexOnStartup } from '../lib/full-index-on-startup';
+
+module(basename(__filename), function () {
+  module('default behavior (env var unset)', function () {
+    test('bootstrap realms full-index on startup', function (assert) {
+      assert.true(resolveFullIndexOnStartup('bootstrap', undefined));
+    });
+
+    test('source (user/private) realms do not full-index on startup', function (assert) {
+      assert.false(resolveFullIndexOnStartup('source', undefined));
+    });
+
+    test('published realms do not full-index on startup', function (assert) {
+      assert.false(resolveFullIndexOnStartup('published', undefined));
+    });
+  });
+
+  module("explicit 'true' override forces all kinds on", function () {
+    test('bootstrap', function (assert) {
+      assert.true(resolveFullIndexOnStartup('bootstrap', 'true'));
+    });
+
+    test('source', function (assert) {
+      assert.true(resolveFullIndexOnStartup('source', 'true'));
+    });
+
+    test('published', function (assert) {
+      assert.true(resolveFullIndexOnStartup('published', 'true'));
+    });
+  });
+
+  module(
+    "explicit 'false' override forces all kinds off (cached-index flow)",
+    function () {
+      test('bootstrap', function (assert) {
+        assert.false(resolveFullIndexOnStartup('bootstrap', 'false'));
+      });
+
+      test('source', function (assert) {
+        assert.false(resolveFullIndexOnStartup('source', 'false'));
+      });
+
+      test('published', function (assert) {
+        assert.false(resolveFullIndexOnStartup('published', 'false'));
+      });
+    },
+  );
+
+  module('non-boolean env values fall through to default', function () {
+    test("empty string behaves like 'unset'", function (assert) {
+      assert.true(resolveFullIndexOnStartup('bootstrap', ''));
+      assert.false(resolveFullIndexOnStartup('source', ''));
+    });
+
+    test("'1' behaves like 'unset' (does not match 'true')", function (assert) {
+      assert.true(resolveFullIndexOnStartup('bootstrap', '1'));
+      assert.false(resolveFullIndexOnStartup('source', '1'));
+    });
+
+    test("'TRUE' (uppercase) behaves like 'unset' (case-sensitive match)", function (assert) {
+      assert.true(resolveFullIndexOnStartup('bootstrap', 'TRUE'));
+      assert.false(resolveFullIndexOnStartup('source', 'TRUE'));
+    });
+  });
+});

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -177,6 +177,7 @@ const ALL_TEST_FILES: string[] = [
   './card-source-endpoints-test',
   './definition-lookup-test',
   './file-watcher-events-test',
+  './full-index-on-startup-test',
   './full-reindex-test',
   './indexing-test',
   './lazy-mount-test',

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -486,7 +486,13 @@ module(basename(__filename), function () {
       },
     });
 
-    test('realm is full indexed at boot', async function (assert) {
+    // Guards the contract that a brand-new realm (empty boxel_index state)
+    // always full-indexes on first boot — independent of
+    // REALM_SERVER_FULL_INDEX_ON_STARTUP. `createRealm` (the test helper)
+    // never passes `fullIndexOnStartup`, so the realm here has it set to
+    // false; the from-scratch job below is produced by the `isNewIndex`
+    // branch in Realm.start(), not by the env-var-driven branch.
+    test('newly-created realm full-indexes on first boot', async function (assert) {
       let jobs = await testDbAdapter.execute('select * from jobs');
       assert.strictEqual(
         jobs.length,


### PR DESCRIPTION
## Summary

- **Default flip**: only `kind='bootstrap'` realms (the CLI `--path` realms — base, catalog, skills) full-index on realm-server boot. `kind='source'` (user/private) and `kind='published'` realms now skip the boot reindex.
- A brand-new realm still builds its index on first boot — the `isNewIndex` branch in `Realm.start()` is independent of this flag, so first-time indexing of a private realm is unchanged.
- `REALM_SERVER_FULL_INDEX_ON_STARTUP` becomes a three-state override:
  | value     | behavior                                                                                  |
  | --------- | ----------------------------------------------------------------------------------------- |
  | unset     | bootstrap full-indexes; source / published skip (new default)                             |
  | `true`    | all kinds full-index (matches prior behavior)                                             |
  | `false`   | no kind full-indexes (preserves the cached-index dev flow in `scripts/import-cached-index.sh`) |

## Why

On a developer machine, restarting the realm server triggered a from-scratch index of every private user realm under `realms/`, which is expensive and rarely what we want — the realm's existing index is still valid across a process restart. Bootstrap realms (base / catalog / skills) genuinely benefit from a from-scratch index on boot because platform code in those realms can change between boots, so they keep the eager behavior.

A `kind='source'` / `kind='published'` realm that genuinely needs a from-scratch index will still get one: either through `isNewIndex` (first boot of that realm's index) or via the dedicated `/_full-reindex` operator endpoint.

## Compatibility notes

- **Staging/prod post-deploy reindex is unaffected.** That storm is driven by a separate CI hook → `handle-post-deployment.ts:42` → `full-reindex` job, gated on a boxel-ui asset checksum change. It does not flow through `fullIndexOnStartup`. Flipping the startup default does not change post-deploy behavior; if an operator wants every realm to additionally reindex on every process restart in a deployed environment, set `REALM_SERVER_FULL_INDEX_ON_STARTUP=true` in the task definition.
- **`scripts/import-cached-index.sh` flow preserved.** That flow sets the env var to `'false'`, which now disables full-index for all kinds (including bootstrap), matching its prior effect.

## Open question for review

I treated `kind='published'` as "private" (default off), grouping it with `kind='source'`. The user-facing definition of "public" in the original ask was "realms specified in the start script" — that's bootstrap, not published. Holler if `kind='published'` should be kept on the always-full-index path with bootstrap.

## Test plan

- [x] New unit tests `packages/realm-server/tests/full-index-on-startup-test.ts` cover the three-state resolution across all three realm kinds (12 cases, all passing).
- [x] Clarified the existing `packages/realm-server/tests/indexing-test.ts` "newly-created realm full-indexes on first boot" test to explicitly document that it guards the `isNewIndex` branch — independent of `fullIndexOnStartup` — which is what guarantees a brand-new private realm still indexes on first boot after this flip.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)