### PR TITLE
deploy: exec through pnpm/ts-node so PID 1 catches SIGTERM

### DIFF
--- a/packages/realm-server/prerender-manager.Dockerfile
+++ b/packages/realm-server/prerender-manager.Dockerfile
@@ -25,4 +25,4 @@ EXPOSE 4222
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
   CMD curl --fail --silent --show-error --max-time 5 --output /dev/null http://localhost:4222/ || exit 1
 
-CMD pnpm --filter "./packages/realm-server" $prerender_manager_script
+CMD exec pnpm --filter "./packages/realm-server" $prerender_manager_script

--- a/packages/realm-server/prerender.Dockerfile
+++ b/packages/realm-server/prerender.Dockerfile
@@ -79,4 +79,4 @@ EXPOSE 4221
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
   CMD curl --fail --silent --show-error --max-time 5 --output /dev/null http://localhost:4221/ || exit 1
 
-CMD pnpm --filter "./packages/realm-server" $prerender_script
+CMD exec pnpm --filter "./packages/realm-server" $prerender_script

--- a/packages/realm-server/realm-server.Dockerfile
+++ b/packages/realm-server/realm-server.Dockerfile
@@ -22,4 +22,4 @@ RUN CI=1 pnpm install -r --offline
 
 EXPOSE 3000
 
-CMD pnpm --filter "./packages/realm-server" $realm_server_script
+CMD exec pnpm --filter "./packages/realm-server" $realm_server_script

--- a/packages/realm-server/scripts/start-prerender-manager.sh
+++ b/packages/realm-server/scripts/start-prerender-manager.sh
@@ -4,6 +4,6 @@
 
 NODE_ENV=production \
   NODE_NO_WARNINGS=1 \
-  ts-node \
+  exec ts-node \
   --transpileOnly prerender/manager-server \
   --port=${PRERENDER_MANAGER_PORT:-4222}

--- a/packages/realm-server/scripts/start-prerender-production.sh
+++ b/packages/realm-server/scripts/start-prerender-production.sh
@@ -6,6 +6,6 @@
 NODE_ENV=production \
   NODE_NO_WARNINGS=1 \
   BOXEL_HOST_URL=https://app.boxel.ai \
-  ts-node \
+  exec ts-node \
   --transpileOnly prerender/prerender-server \
   --port=${PRERENDER_PORT:-4221}

--- a/packages/realm-server/scripts/start-prerender-staging.sh
+++ b/packages/realm-server/scripts/start-prerender-staging.sh
@@ -6,6 +6,6 @@
 NODE_ENV=production \
   NODE_NO_WARNINGS=1 \
   BOXEL_HOST_URL=https://realms-staging.stack.cards \
-  ts-node \
+  exec ts-node \
   --transpileOnly prerender/prerender-server \
   --port=${PRERENDER_PORT:-4221}

--- a/packages/realm-server/scripts/start-production.sh
+++ b/packages/realm-server/scripts/start-production.sh
@@ -27,7 +27,7 @@ NODE_NO_WARNINGS=1 \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
   PUBLISHED_REALM_BOXEL_SPACE_DOMAIN='boxel.space' \
   PUBLISHED_REALM_BOXEL_SITE_DOMAIN='boxel.site' \
-  ts-node \
+  exec ts-node \
   --transpileOnly main \
   --port=3000 \
   --matrixURL='https://matrix.boxel.ai' \

--- a/packages/realm-server/scripts/start-staging.sh
+++ b/packages/realm-server/scripts/start-staging.sh
@@ -27,7 +27,7 @@ NODE_NO_WARNINGS=1 \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
   PUBLISHED_REALM_BOXEL_SPACE_DOMAIN='staging.boxel.dev' \
   PUBLISHED_REALM_BOXEL_SITE_DOMAIN='staging.boxel.build' \
-  ts-node \
+  exec ts-node \
   --transpileOnly main \
   --port=3000 \
   --matrixURL='https://matrix-staging.stack.cards' \

--- a/packages/realm-server/scripts/start-worker-production.sh
+++ b/packages/realm-server/scripts/start-worker-production.sh
@@ -10,7 +10,7 @@ NODE_NO_WARNINGS=1 \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
   LOW_CREDIT_THRESHOLD=2000 \
   OPENROUTER_REALM_URL='https://app.boxel.ai/openrouter/' \
-  ts-node \
+  exec ts-node \
   --transpileOnly worker-manager \
   --allPriorityCount="${WORKER_ALL_PRIORITY_COUNT:-1}" \
   --highPriorityCount="${WORKER_HIGH_PRIORITY_COUNT:-0}" \

--- a/packages/realm-server/scripts/start-worker-staging.sh
+++ b/packages/realm-server/scripts/start-worker-staging.sh
@@ -10,7 +10,7 @@ NODE_NO_WARNINGS=1 \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
   LOW_CREDIT_THRESHOLD=2000 \
   OPENROUTER_REALM_URL='https://realms-staging.stack.cards/openrouter/' \
-  ts-node \
+  exec ts-node \
   --transpileOnly worker-manager \
   --allPriorityCount="${WORKER_ALL_PRIORITY_COUNT:-1}" \
   --highPriorityCount="${WORKER_HIGH_PRIORITY_COUNT:-0}" \

--- a/packages/realm-server/worker.Dockerfile
+++ b/packages/realm-server/worker.Dockerfile
@@ -22,4 +22,4 @@ RUN CI=1 pnpm install -r --offline
 
 EXPOSE 3000
 
-CMD pnpm --filter "./packages/realm-server" $worker_script
+CMD exec pnpm --filter "./packages/realm-server" $worker_script


### PR DESCRIPTION
## What this changes

Two tiny `exec` insertions in 11 files: each deployed Dockerfile's `CMD pnpm ...` becomes `CMD exec pnpm ...`, and each deployed start script's `ts-node ...` invocation becomes `exec ts-node ...`.

That's it for the diff. The interesting part is why.

## The incident this fixes

Today's staging deploy of `boxel-worker-staging` orphaned 4 indexing-job reservations (jobs 409972, 409988, 409999, 410002). The workers were killed mid-job by ECS during the rolling deploy, but the SIGTERM-driven drain code in `packages/realm-server/worker-manager.ts` — which is supposed to mark in-flight reservations `completion_reason='interrupted'` so a sibling worker can re-claim within ~10s — never ran. So those reservations sat with `completed_at IS NULL` and the jobs are now stalled until the 7200s (2h) lease ages out.

## Why the drain didn't run

The deployed images have a process tree like this:

```
PID 1: /bin/sh -c "pnpm --filter ./packages/realm-server $worker_script"     (Docker shell-form CMD)
PID 2:   pnpm
PID 3:     /bin/sh ./scripts/start-worker-<env>.sh                            (npm script)
PID 4:       ts-node --transpileOnly worker-manager ...                       (the actual app)
```

ECS sends SIGTERM to PID 1. POSIX `sh` with a foreground child and no `trap` does not forward SIGTERM. After `stopTimeout` (60s) ECS sends SIGKILL, which Node cannot catch. So `worker-manager`'s `process.on('SIGTERM', ...)` handler — and therefore the orphan-reservation drain — never fires.

After this PR, both shell layers replace themselves with their child via `exec`, collapsing the tree to:

```
PID 1: pnpm
PID 2:   ts-node ... worker-manager
```

pnpm 11.x forwards signals to its npm-script child, so SIGTERM reaches Node, the registered handler runs, and the drain finalize commits before the process exits.

## Scope

Touches only the 4 deployed Dockerfiles and the 7 deployed start scripts. Dev / local scripts (`start-pg.sh`, `start-matrix.sh`, `start-host-dist.sh`, `start-icons.sh`, `start-without-matrix.sh`) are intentionally left alone — their lifetime model is different (`mise dev-all` Ctrl-C, not ECS rolling deploy).

## Test plan

- [ ] `docker build -f <dockerfile> .` succeeds for each of the 4 modified images.
- [ ] After staging deploy, run `aws ecs update-service --force-new-deployment` on `boxel-worker-staging` and confirm the rolling task shows these lines from `worker-manager` during stop:
  - `Shutting down server for worker manager...`
  - `Stopping N worker(s)...`
  - `Draining reservations for N worker(s)...`
- [ ] Any reservation written during the rollover window should land with `completion_reason = 'interrupted'` (not NULL) in `job_reservations`. A sibling worker should re-claim each affected job within ~10s of the kill.
- [ ] Repeat on `boxel-realm-server-staging` and `boxel-prerender-staging` to confirm the same change works for those containers (the realm-server's own SIGTERM handlers, and prerender's graceful HTTP shutdown).

[Claude Code 🤖]