### PR TITLE
Indexer: pre-warm every realm .gts/.gjs module, not just per-row deps

### DIFF
--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -8,6 +8,7 @@ import { Memoize } from 'typescript-memoize';
 
 import {
   logger,
+  hasCardExtension,
   hasExecutableExtension,
   SupportedMimeType,
   jobIdentity,
@@ -203,7 +204,17 @@ export class IndexRunner {
       await current.#dependencyResolver.orderInvalidationsByDependencies(
         invalidations,
       );
-    await current.preWarmModulesTable(invalidations);
+    // Pre-warm the modules cache. Combines per-row deps (which catch
+    // most modules used during a from-scratch pass) with the realm-
+    // wide `.gts` / `.gjs` sweep (which catches sibling card modules
+    // referenced by string in templates — the typical
+    // `<Search @query={{filter: {type: {module: '.../cohort.gts', name: 'Cohort'}}}}>`
+    // pattern). The filesystem-mtimes walk was already paid by
+    // discoverInvalidations above; we just filter and reuse it.
+    let allRealmCardModules = Object.keys(
+      discoverResult.filesystemMtimes,
+    ).filter(hasCardExtension);
+    await current.preWarmModulesTable(invalidations, allRealmCardModules);
     let resumedRows = current.batch.resumedRows;
     let resumedSkipped = 0;
     current.#onProgress?.({
@@ -354,7 +365,14 @@ export class IndexRunner {
       }
       current.#scheduleClearCacheForNextRender();
     }
-    await current.preWarmModulesTable(invalidations);
+    // Pre-warm: combine per-row deps with a realm-wide `.gts`/`.gjs`
+    // sweep. Incremental skips `discoverInvalidations` so the
+    // filesystem-mtimes walk hasn't happened yet — call it here.
+    // Typical realm sizes make this < 200 ms; one call per job.
+    let incrementalMtimes = await current.#reader.mtimes();
+    let allRealmCardModules =
+      Object.keys(incrementalMtimes).filter(hasCardExtension);
+    await current.preWarmModulesTable(invalidations, allRealmCardModules);
 
     let hrefs = urls.map((u) => u.href);
     let resumedRows = current.batch.resumedRows;
@@ -568,11 +586,26 @@ export class IndexRunner {
   // Failures here are warned but do not fail the batch — a mid-render
   // sub-prerender will still fire on demand if pre-warm misses a
   // module.
-  private async preWarmModulesTable(invalidations: URL[]): Promise<void> {
-    if (invalidations.length === 0) {
+  private async preWarmModulesTable(
+    invalidations: URL[],
+    allRealmCardModules: string[] = [],
+  ): Promise<void> {
+    if (invalidations.length === 0 && allRealmCardModules.length === 0) {
       return;
     }
     let preWarmStart = Date.now();
+
+    // Base layer: every `.gts` / `.gjs` file in the realm, regardless of
+    // whether it appears in this batch's invalidation set. Catches sibling
+    // card modules that are referenced by *string* in templates (e.g.
+    // `<Search @query={{filter: {type: {module: '.../cohort.gts', ...}}}}>`)
+    // and so do not appear in any instance's runtime `deps`. Those
+    // modules are exactly what `_federated-search` needs the modules-
+    // table cache to be warm for; without this layer the search fires a
+    // same-affinity `prerenderModule` mid-card-render and risks the
+    // self-referential prerender deadlock.
+    let toWarm = new Set<string>(allRealmCardModules);
+
     let hrefs = invalidations.map((u) => u.href);
     let existingRows = await this.batch.getDependencyRows(hrefs);
     let bestByUrl = new Map<string, { url: string; deps: string[] | null }>();
@@ -585,13 +618,15 @@ export class IndexRunner {
       }
     }
 
-    let toWarm = new Set<string>();
     let novelJsonUrls: URL[] = [];
     for (let url of invalidations) {
       // Module files in the invalidation set are deps that instances
       // in the same batch will consume — pre-warm them directly. This
       // covers from-scratch and atomic-update batches where most rows
-      // have no prior `deps` data yet.
+      // have no prior `deps` data yet. Unlike the realm-wide layer
+      // above, this includes `.ts` / `.js` helpers — only the ones the
+      // batch is actually touching, so cost is bounded by invalidation
+      // size rather than realm size.
       if (hasExecutableExtension(url.href)) {
         toWarm.add(url.href);
       }

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -8,7 +8,6 @@ import { Memoize } from 'typescript-memoize';
 
 import {
   logger,
-  hasCardExtension,
   hasExecutableExtension,
   SupportedMimeType,
   jobIdentity,
@@ -205,16 +204,26 @@ export class IndexRunner {
         invalidations,
       );
     // Pre-warm the modules cache. Combines per-row deps (which catch
-    // most modules used during a from-scratch pass) with the realm-
-    // wide `.gts` / `.gjs` sweep (which catches sibling card modules
-    // referenced by string in templates — the typical
+    // most modules used during a from-scratch pass) with a realm-wide
+    // sweep of every executable file in the realm — `.gts` / `.gjs`
+    // (cards with Glimmer templates) and `.ts` / `.js` (cards without
+    // templates, e.g. command-input cards in catalog-realm; and pure
+    // helpers). The realm-wide sweep catches sibling modules referenced
+    // by string in card templates, the typical
     // `<Search @query={{filter: {type: {module: '.../cohort.gts', name: 'Cohort'}}}}>`
-    // pattern). The filesystem-mtimes walk was already paid by
+    // pattern that no instance's runtime `deps` will capture. Non-card
+    // modules pre-warmed by this sweep persist to the modules table as
+    // empty-definitions rows (no-card markers — see
+    // `definition-lookup.ts:561-563`), so subsequent
+    // `lookupDefinition` / `getCachedDefinitions` calls short-circuit
+    // at the cache without re-firing the prerenderer.
+    //
+    // The filesystem-mtimes walk was already paid by
     // discoverInvalidations above; we just filter and reuse it.
-    let allRealmCardModules = Object.keys(
+    let allRealmExecutables = Object.keys(
       discoverResult.filesystemMtimes,
-    ).filter(hasCardExtension);
-    await current.preWarmModulesTable(invalidations, allRealmCardModules);
+    ).filter(hasExecutableExtension);
+    await current.preWarmModulesTable(invalidations, allRealmExecutables);
     let resumedRows = current.batch.resumedRows;
     let resumedSkipped = 0;
     current.#onProgress?.({
@@ -365,14 +374,17 @@ export class IndexRunner {
       }
       current.#scheduleClearCacheForNextRender();
     }
-    // Pre-warm: combine per-row deps with a realm-wide `.gts`/`.gjs`
-    // sweep. Incremental skips `discoverInvalidations` so the
-    // filesystem-mtimes walk hasn't happened yet — call it here.
-    // Typical realm sizes make this < 200 ms; one call per job.
+    // Pre-warm: combine per-row deps with a realm-wide sweep of every
+    // executable file in the realm. Incremental skips
+    // `discoverInvalidations` so the filesystem-mtimes walk hasn't
+    // happened yet — call it here. Typical realm sizes make this
+    // < 200 ms; one call per job. Non-card modules pre-warmed by this
+    // sweep persist to the modules table as empty-definitions rows
+    // (no-card markers) and short-circuit subsequent lookups.
     let incrementalMtimes = await current.#reader.mtimes();
-    let allRealmCardModules =
-      Object.keys(incrementalMtimes).filter(hasCardExtension);
-    await current.preWarmModulesTable(invalidations, allRealmCardModules);
+    let allRealmExecutables =
+      Object.keys(incrementalMtimes).filter(hasExecutableExtension);
+    await current.preWarmModulesTable(invalidations, allRealmExecutables);
 
     let hrefs = urls.map((u) => u.href);
     let resumedRows = current.batch.resumedRows;
@@ -588,23 +600,31 @@ export class IndexRunner {
   // module.
   private async preWarmModulesTable(
     invalidations: URL[],
-    allRealmCardModules: string[] = [],
+    allRealmExecutables: string[] = [],
   ): Promise<void> {
-    if (invalidations.length === 0 && allRealmCardModules.length === 0) {
+    if (invalidations.length === 0 && allRealmExecutables.length === 0) {
       return;
     }
     let preWarmStart = Date.now();
 
-    // Base layer: every `.gts` / `.gjs` file in the realm, regardless of
-    // whether it appears in this batch's invalidation set. Catches sibling
-    // card modules that are referenced by *string* in templates (e.g.
+    // Base layer: every executable file in the realm, regardless of
+    // whether it appears in this batch's invalidation set. Catches
+    // sibling card modules referenced by *string* in templates (e.g.
     // `<Search @query={{filter: {type: {module: '.../cohort.gts', ...}}}}>`)
-    // and so do not appear in any instance's runtime `deps`. Those
-    // modules are exactly what `_federated-search` needs the modules-
-    // table cache to be warm for; without this layer the search fires a
-    // same-affinity `prerenderModule` mid-card-render and risks the
-    // self-referential prerender deadlock.
-    let toWarm = new Set<string>(allRealmCardModules);
+    // — those don't appear in any instance's runtime `deps`. They're
+    // exactly what `_federated-search` needs the modules-table cache
+    // to be warm for; without this layer the search fires a same-
+    // affinity `prerenderModule` mid-card-render and risks the self-
+    // referential prerender deadlock.
+    //
+    // Includes `.ts` / `.js` files because card definitions can live
+    // there too (e.g. `catalog-realm/commands/collect-submission-files.ts`
+    // — `class CollectSubmissionFilesInput extends CardDef`). Non-card
+    // helpers in `.ts` / `.js` pre-warmed here persist as empty-
+    // definitions rows in the modules table (no-card markers — see
+    // `definition-lookup.ts:561-563`); subsequent lookups short-circuit
+    // at the cache without re-firing the prerenderer.
+    let toWarm = new Set<string>(allRealmExecutables);
 
     let hrefs = invalidations.map((u) => u.href);
     let existingRows = await this.batch.getDependencyRows(hrefs);

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -8,6 +8,7 @@ import { Memoize } from 'typescript-memoize';
 
 import {
   logger,
+  hasCardExtension,
   hasExecutableExtension,
   SupportedMimeType,
   jobIdentity,
@@ -204,26 +205,16 @@ export class IndexRunner {
         invalidations,
       );
     // Pre-warm the modules cache. Combines per-row deps (which catch
-    // most modules used during a from-scratch pass) with a realm-wide
-    // sweep of every executable file in the realm — `.gts` / `.gjs`
-    // (cards with Glimmer templates) and `.ts` / `.js` (cards without
-    // templates, e.g. command-input cards in catalog-realm; and pure
-    // helpers). The realm-wide sweep catches sibling modules referenced
-    // by string in card templates, the typical
+    // most modules used during a from-scratch pass) with the realm-
+    // wide `.gts` / `.gjs` sweep (which catches sibling card modules
+    // referenced by string in templates — the typical
     // `<Search @query={{filter: {type: {module: '.../cohort.gts', name: 'Cohort'}}}}>`
-    // pattern that no instance's runtime `deps` will capture. Non-card
-    // modules pre-warmed by this sweep persist to the modules table as
-    // empty-definitions rows (no-card markers — see
-    // `definition-lookup.ts:561-563`), so subsequent
-    // `lookupDefinition` / `getCachedDefinitions` calls short-circuit
-    // at the cache without re-firing the prerenderer.
-    //
-    // The filesystem-mtimes walk was already paid by
+    // pattern). The filesystem-mtimes walk was already paid by
     // discoverInvalidations above; we just filter and reuse it.
-    let allRealmExecutables = Object.keys(
+    let allRealmCardModules = Object.keys(
       discoverResult.filesystemMtimes,
-    ).filter(hasExecutableExtension);
-    await current.preWarmModulesTable(invalidations, allRealmExecutables);
+    ).filter(hasCardExtension);
+    await current.preWarmModulesTable(invalidations, allRealmCardModules);
     let resumedRows = current.batch.resumedRows;
     let resumedSkipped = 0;
     current.#onProgress?.({
@@ -374,17 +365,14 @@ export class IndexRunner {
       }
       current.#scheduleClearCacheForNextRender();
     }
-    // Pre-warm: combine per-row deps with a realm-wide sweep of every
-    // executable file in the realm. Incremental skips
-    // `discoverInvalidations` so the filesystem-mtimes walk hasn't
-    // happened yet — call it here. Typical realm sizes make this
-    // < 200 ms; one call per job. Non-card modules pre-warmed by this
-    // sweep persist to the modules table as empty-definitions rows
-    // (no-card markers) and short-circuit subsequent lookups.
+    // Pre-warm: combine per-row deps with a realm-wide `.gts`/`.gjs`
+    // sweep. Incremental skips `discoverInvalidations` so the
+    // filesystem-mtimes walk hasn't happened yet — call it here.
+    // Typical realm sizes make this < 200 ms; one call per job.
     let incrementalMtimes = await current.#reader.mtimes();
-    let allRealmExecutables =
-      Object.keys(incrementalMtimes).filter(hasExecutableExtension);
-    await current.preWarmModulesTable(invalidations, allRealmExecutables);
+    let allRealmCardModules =
+      Object.keys(incrementalMtimes).filter(hasCardExtension);
+    await current.preWarmModulesTable(invalidations, allRealmCardModules);
 
     let hrefs = urls.map((u) => u.href);
     let resumedRows = current.batch.resumedRows;
@@ -600,31 +588,35 @@ export class IndexRunner {
   // module.
   private async preWarmModulesTable(
     invalidations: URL[],
-    allRealmExecutables: string[] = [],
+    allRealmCardModules: string[] = [],
   ): Promise<void> {
-    if (invalidations.length === 0 && allRealmExecutables.length === 0) {
+    if (invalidations.length === 0 && allRealmCardModules.length === 0) {
       return;
     }
     let preWarmStart = Date.now();
 
-    // Base layer: every executable file in the realm, regardless of
-    // whether it appears in this batch's invalidation set. Catches
-    // sibling card modules referenced by *string* in templates (e.g.
+    // Base layer: every `.gts` / `.gjs` file in the realm, regardless of
+    // whether it appears in this batch's invalidation set. Catches sibling
+    // card modules referenced by *string* in templates (e.g.
     // `<Search @query={{filter: {type: {module: '.../cohort.gts', ...}}}}>`)
-    // — those don't appear in any instance's runtime `deps`. They're
-    // exactly what `_federated-search` needs the modules-table cache
-    // to be warm for; without this layer the search fires a same-
-    // affinity `prerenderModule` mid-card-render and risks the self-
-    // referential prerender deadlock.
+    // — those don't appear in any instance's runtime `deps`. Without
+    // this layer the search fires a same-affinity `prerenderModule`
+    // mid-card-render at lookup time, which is the wait-shape the
+    // PagePool's tab-materialization for module/command callers is
+    // meant to relieve.
     //
-    // Includes `.ts` / `.js` files because card definitions can live
-    // there too (e.g. `catalog-realm/commands/collect-submission-files.ts`
-    // — `class CollectSubmissionFilesInput extends CardDef`). Non-card
-    // helpers in `.ts` / `.js` pre-warmed here persist as empty-
-    // definitions rows in the modules table (no-card markers — see
-    // `definition-lookup.ts:561-563`); subsequent lookups short-circuit
-    // at the cache without re-firing the prerenderer.
-    let toWarm = new Set<string>(allRealmExecutables);
+    // `.gts` / `.gjs` only is an optimization, not a correctness gate:
+    // `.ts` / `.js` files CAN host `CardDef` (e.g. command-input
+    // cards). If pre-warm misses such a module, the on-demand
+    // `lookupDefinition` read-through during the visit fires a
+    // `prerenderModule` for it — safe because the PagePool now
+    // materializes a tab for the sub-prerender instead of queueing it
+    // behind the render that triggered the lookup. Restricting the
+    // sweep to the extensions where cards live almost exclusively
+    // avoids paying the prerender cost on every reindex for files that
+    // rarely define a card (typical realms have many helper `.ts`
+    // files alongside their cards).
+    let toWarm = new Set<string>(allRealmCardModules);
 
     let hrefs = invalidations.map((u) => u.href);
     let existingRows = await this.batch.getDependencyRows(hrefs);

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -645,6 +645,19 @@ export * from './pr-manifest';
 export * from './file-def-code-ref';
 
 export const executableExtensions = ['.js', '.gjs', '.ts', '.gts'];
+// Extensions covered by the realm-wide pre-warm sweep that primes the
+// modules cache before the visit loop. This is an optimization, not a
+// correctness gate: a `.ts` / `.js` file CAN host a `CardDef`
+// (e.g. command-input cards), and if pre-warm misses one the on-demand
+// `lookupDefinition` cache read-through fires a `prerenderModule` for
+// it during the visit. The PagePool's tab-materialization for
+// module/command callers makes that on-demand path safe (the sub-
+// prerender gets its own tab instead of queueing behind the render
+// that triggered it). Restricting the sweep to `.gts` / `.gjs` — where
+// cards live almost exclusively in practice — avoids paying the
+// prerender cost on every index for a file type that rarely contains
+// card definitions.
+export const cardExtensions = ['.gts', '.gjs'];
 export { createResponse } from './create-response';
 
 export * from './db-queries/db-types';
@@ -1001,6 +1014,15 @@ export interface CopyCardsWithCodeRef {
 export function hasExecutableExtension(path: string): boolean {
   for (let extension of executableExtensions) {
     if (path.endsWith(extension) && !path.endsWith('.d.ts')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function hasCardExtension(path: string): boolean {
+  for (let extension of cardExtensions) {
+    if (path.endsWith(extension)) {
       return true;
     }
   }

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -645,6 +645,13 @@ export * from './pr-manifest';
 export * from './file-def-code-ref';
 
 export const executableExtensions = ['.js', '.gjs', '.ts', '.gts'];
+// Card / field definitions live in template-bearing modules — `.gts`
+// (Glimmer + TS) or `.gjs` (Glimmer + JS) — since `CardDef` /
+// `FieldDef` components need a Glimmer template surface. Plain `.ts`
+// and `.js` cannot host a card definition and so are excluded from
+// the realm-wide pre-warm sweep that primes the modules cache before
+// the visit loop.
+export const cardExtensions = ['.gts', '.gjs'];
 export { createResponse } from './create-response';
 
 export * from './db-queries/db-types';
@@ -1001,6 +1008,15 @@ export interface CopyCardsWithCodeRef {
 export function hasExecutableExtension(path: string): boolean {
   for (let extension of executableExtensions) {
     if (path.endsWith(extension) && !path.endsWith('.d.ts')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function hasCardExtension(path: string): boolean {
+  for (let extension of cardExtensions) {
+    if (path.endsWith(extension)) {
       return true;
     }
   }

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -645,13 +645,6 @@ export * from './pr-manifest';
 export * from './file-def-code-ref';
 
 export const executableExtensions = ['.js', '.gjs', '.ts', '.gts'];
-// Card / field definitions live in template-bearing modules — `.gts`
-// (Glimmer + TS) or `.gjs` (Glimmer + JS) — since `CardDef` /
-// `FieldDef` components need a Glimmer template surface. Plain `.ts`
-// and `.js` cannot host a card definition and so are excluded from
-// the realm-wide pre-warm sweep that primes the modules cache before
-// the visit loop.
-export const cardExtensions = ['.gts', '.gjs'];
 export { createResponse } from './create-response';
 
 export * from './db-queries/db-types';
@@ -1008,15 +1001,6 @@ export interface CopyCardsWithCodeRef {
 export function hasExecutableExtension(path: string): boolean {
   for (let extension of executableExtensions) {
     if (path.endsWith(extension) && !path.endsWith('.d.ts')) {
-      return true;
-    }
-  }
-  return false;
-}
-
-export function hasCardExtension(path: string): boolean {
-  for (let extension of cardExtensions) {
-    if (path.endsWith(extension)) {
       return true;
     }
   }


### PR DESCRIPTION
> **Stacked on top of #4863.** Merge that first (or retarget this PR's base to `main` after #4863 merges).

## Why

The indexer's pre-warm phase seeds the modules cache before the visit loop runs, so card renders don't have to fire a sub-`prerenderModule` mid-render for a missing definition. The existing pre-warm walks each invalidation's `boxel_index.deps` array and pre-warms every executable URL it finds — i.e. import-graph dependencies. That misses modules referenced by *string* in card templates.

Pattern that triggered every staging failure on `ctse/ambitious-piranha`:

```ts
// dashboard.gts — imports only `card-api`, references cohort.gts by STRING
get cohortRef() { return { module: this.moduleUrl('cohort'), name: 'Cohort' }; }
// then in template:
<Search @query={{filter: {type: this.cohortRef}}} @realms={{this.realmHrefs}} />
```

`cohort.gts` is a parameter to a search filter; it's never an `import`. So:
- `cohort.gts` is not in `dashboard.gts`'s runtime module graph.
- `dashboard.json`'s `deps` row in `boxel_index` does not list `cohort.gts`.
- Pre-warm walks the dashboard's deps and skips `cohort.gts`.
- When the dashboard renders, `<Search>` fires `_federated-search` with `filter.type.module = '.../cohort.gts'` → cache miss → spawns a same-affinity `prerenderModule` for `cohort.gts` mid-card-render → self-referential prerender deadlock.

Verified empirically against the staging index — `dashboard.json` on `ctse/ambitious-piranha` has exactly two Tracking-realm entries in `deps` (`.../Tracking/dashboard` plus a `.glimmer-scoped.css` artifact), and none of the sibling card modules every dashboard render needs.

## What this PR changes

Adds a realm-wide pre-warm layer that runs in addition to the existing per-row deps walk.

**Source of the realm-wide list — filesystem mtimes filtered by extension.**

- From-scratch path: `discoverInvalidations` already calls `reader.mtimes()` and returns the result. Filter to `.gts`/`.gjs` and pass into `preWarmModulesTable` as a new `allRealmCardModules` argument. Zero added cost.
- Incremental path: `reader.mtimes()` hadn't been called yet — add one call before pre-warm. ~< 200 ms on realistic realm sizes, one call per job, dominated by the indexing work that follows.

**Why `.gts` / `.gjs` only — optimization, not correctness gate.** `.ts` / `.js` files CAN host `CardDef` (e.g. command-input cards), but they almost never do in practice. If pre-warm misses such a module, the on-demand `lookupDefinition` cache read-through during the visit fires a `prerenderModule` for it — safe because the PagePool now materializes a tab for non-file callers instead of queueing them behind the render that triggered the lookup (the change in the parent branch). Restricting the sweep to the extensions where cards live almost exclusively avoids paying the prerender cost on every reindex for files that don't define cards (typical realms have many helper `.ts` files alongside their card `.gts`).

**No-card markers in the cache.** A pre-warmed module that turns out not to define any cards (rare among `.gts`; e.g. a `.gts` Glimmer template helper with no `CardDef` export) gets persisted to the modules table with `definitions: {}`. `CachingDefinitionLookup.getCachedDefinitions` treats that as a valid cache hit on subsequent lookups — so the wasted prerender is a one-shot, not a per-call cost.

**Adds `hasCardExtension` / `cardExtensions` to `runtime-common/index.ts`**, parallel in shape to the existing `hasExecutableExtension` / `executableExtensions`.

**Stays serial.** Pre-warm loop body unchanged from the existing serial-await shape; the only behavioral change is *which* modules end up in `toWarm`. Bounded-parallel pre-warm is a separate follow-up after we've measured serial.

## Bench results — local cold full-reindex

Run against a freshly-restarted realm-server with `clearLastModified: true` so the from-scratch path walks the full filesystem mtime sweep.

| realm                    | wall time          | errored rows | deadlock-fingerprint rows |
|--------------------------|--------------------|--------------|---------------------------|
| `user/ambitious-piranha` | **665 s (~11 min)** | **0**        | **0**                     |
| `user/prudent-octopus`   | **145 s (~2.4 min)** | **0**        | **0**                     |

Baseline before this branch on the same workload:
- `ambitious-piranha` was rejected by the manager-side 150 s `/prerender-visit` abort, or completed at ~36 min with multiple errored rows whenever it didn't.
- Errored rows carried the documented self-referential prerender deadlock fingerprint: `renderStage = waiting-stability`, `queryLoadsInFlight` with `source: search-resource:*`, and `affinitySnapshot.sameAffinityActivity` entries of `{queue: 'module', state: 'queued'}` on the same affinity.

Spot-checked `timing_diagnostics` on the heaviest rows post-fix (dashboard cards on both realms): no `{state: queued}` entries in `sameAffinityActivity`, confirming the deadlock path no longer fires.

## Files

- `packages/runtime-common/index.ts` — new `hasCardExtension` / `cardExtensions` exports.
- `packages/runtime-common/index-runner.ts` — `preWarmModulesTable` takes an `allRealmCardModules` arg; the from-scratch and incremental call sites compute the realm-wide list and pass it in.

## Tests

The cache-contract this PR relies on — `definitions: {}` persists as a no-card marker, subsequent lookups short-circuit at the cache — is pinned by `'getCachedDefinitions caches non-card modules as no-card markers'` in the parent branch's `definition-lookup-test.ts`.

A focused integration test for the realm-wide sweep (intercept `getCachedDefinitions`, assert it's invoked for every `.gts`/`.gjs` in the realm including sibling-referenced ones) is worth adding as a follow-up — the bench-time validation is the immediate gate; CI catches regressions on the existing deps-driven layer.

## Test plan

- [x] CI passes
- [x] Local cold full-reindex of `user/prudent-octopus` lands with zero errored rows
- [x] Local cold full-reindex of `user/ambitious-piranha` lands with zero errored rows
- [x] Spot-check `timing_diagnostics` on the heaviest rows post-fix — no `{state: queued}` entries in `sameAffinityActivity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
