### PR TITLE
CS-11170: Include FileDefs in CardsGrid

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,12 @@
 - To run a subset of the tests:
   `ember test --path dist --filter "some text that appears in module name or test name"`  
   Note that the filter is matched against the module name and test name, not the file name! Try to avoid using pipe characters in the filter, since they can confuse auto-approval tool use filters set up by the user.
+- **Always capture test output to a file.** A host test run can produce hundreds of KB of output (browser logs, indexer warnings, per-test diagnostics). If you only pipe through `tail`/`grep`, you lose everything else and have to re-run — which is slow and the bug may not reproduce. Redirect the full run to a file, then grep that file for failures, browser logs around a specific test, etc.
+  ```
+  pnpm exec ember test --path dist --filter "Foo" 2>&1 | tee /tmp/host-test-foo.log
+  grep -E "^(not )?ok |^# " /tmp/host-test-foo.log   # summary + per-test status
+  grep -B2 -A40 "not ok 27" /tmp/host-test-foo.log   # detail for a specific failure
+  ```
 - run `pnpm lint` in this directory to lint changes made to this package
 - run `pnpm lint:fix` directly in this directory to apply fixes for lint failures made to this package that can be automatically fixed.
 - the host tests report this error:

--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -112,6 +112,12 @@ class Isolated extends Component<typeof CardsGrid> {
   @tracked private activeViewId: ViewOption['id'] = this.viewOptions[1].id;
   @tracked private activeFilter!: FilterOption;
   @tracked private activeSort: SortOption = this.sortOptions[0];
+  // Tracked separately from `fileTypeFilters.length` so the All Files
+  // group still appears when the only file summaries the realm has are
+  // bare `FileDef` rows (we exclude those from the leaf list to avoid
+  // duplicating the group's own root). Without this, a realm that only
+  // contains binary/unmapped files would silently hide the entire group.
+  @tracked private hasAnyFileSummary = false;
 
   #unsubscribeFromRealm: (() => void) | undefined;
   #subscribedRealm: string | undefined;
@@ -198,7 +204,7 @@ class Isolated extends Component<typeof CardsGrid> {
     };
   }
 
-  // Derived from tracked state — `isPersonalRealm` and `fileTypeFilters.length`
+  // Derived from tracked state — `isPersonalRealm` and `hasAnyFileSummary`
   // are the only deps that change the visible group set. We avoid the
   // previous `splice + push` approach because mutating a `TrackedArray`
   // during the component constructor (which runs mid-render) fires Glimmer's
@@ -212,11 +218,13 @@ class Isolated extends Component<typeof CardsGrid> {
       options.push(this.highlightFilter);
     }
     options.push(this.allCardsFilter);
-    // Hide the All Files group when the realm has no file rows — matches the
-    // "empty groups: hide" decision in the Linear plan. Reading `.length` on
-    // a TrackedArray sets up a dep so this getter re-runs once
-    // `loadFilterList` finishes its first push into `fileTypeFilters`.
-    if (this.fileTypeFilters.length > 0) {
+    // Hide the All Files group only when the realm has no file rows at all
+    // — matches the "empty groups: hide" decision in the Linear plan. We
+    // can't use `fileTypeFilters.length > 0` here because bare `FileDef`
+    // rows are intentionally excluded from the leaf list (they would be a
+    // duplicate of the group itself), so a realm with only bare FileDef
+    // files would otherwise lose the entire group.
+    if (this.hasAnyFileSummary) {
       options.push(this.allFilesFilter);
     }
     return options;
@@ -349,6 +357,7 @@ class Isolated extends Component<typeof CardsGrid> {
 
     this.cardTypeFilters.splice(0, this.cardTypeFilters.length);
     this.fileTypeFilters.splice(0, this.fileTypeFilters.length);
+    let sawFileSummary = false;
 
     cardTypeSummaries.forEach((summary) => {
       if (!summary.id) {
@@ -360,6 +369,11 @@ class Isolated extends Component<typeof CardsGrid> {
       }
       let kind = summary.attributes.kind ?? 'instance';
       if (kind === 'file') {
+        // Even when the only file summary is the bare-FileDef root (which
+        // we exclude from the leaf list), we still want the All Files
+        // group to appear in the sidebar — otherwise the user has no way
+        // to reach those files. Flip this flag before the leaf-list gate.
+        sawFileSummary = true;
         if (excludedFileTypeIds.includes(summary.id)) {
           return;
         }
@@ -387,6 +401,8 @@ class Isolated extends Component<typeof CardsGrid> {
         },
       });
     });
+
+    this.hasAnyFileSummary = sawFileSummary;
 
     // `filterOptions` is a @cached getter that derives the group list from
     // tracked state — `fileTypeFilters.length` changing here causes it to

--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -1,7 +1,7 @@
 import { registerDestructor } from '@ember/destroyable';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
+import { cached, tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
 import { modifier } from 'ember-modifier';
 import { TrackedArray } from 'tracked-built-ins';
@@ -106,7 +106,6 @@ class Isolated extends Component<typeof CardsGrid> {
   private cardTypeFilters: FilterOption[] = new TrackedArray();
   private fileTypeFilters: FilterOption[] = new TrackedArray();
   private highlightsCards: BoxComponent[] = new TrackedArray();
-  private filterOptions: FilterOption[] = new TrackedArray();
   private viewOptions: ViewOption[] = new TrackedArray([StripView, GridView]);
   private sortOptions: SortOption[] = new TrackedArray(SORT_OPTIONS);
 
@@ -119,7 +118,6 @@ class Isolated extends Component<typeof CardsGrid> {
 
   constructor(owner: any, args: any) {
     super(owner, args);
-    this.setupFilterOptions();
     this.activeFilter = this.filterOptions[0];
     this.loadHighlightsCards.perform();
     registerDestructor(this, () => this.teardownRealmSubscription());
@@ -152,6 +150,12 @@ class Isolated extends Component<typeof CardsGrid> {
     return realmHref?.includes('/personal/') ?? false;
   }
 
+  // The per-group filter wrappers are `@cached` so their object identity
+  // stays stable across re-computations of `filterOptions`. `FilterList`'s
+  // `isSelected` is an identity comparison (`@filter === @activeFilter`), so
+  // returning a fresh object on every getter access would break the active
+  // highlight after the first render.
+  @cached
   private get highlightFilter(): FilterOption {
     return {
       displayName: 'Highlights',
@@ -160,6 +164,7 @@ class Isolated extends Component<typeof CardsGrid> {
     };
   }
 
+  @cached
   private get allCardsFilter(): FilterOption {
     return {
       displayName: 'All Cards',
@@ -178,11 +183,7 @@ class Isolated extends Component<typeof CardsGrid> {
     };
   }
 
-  // The All Files group is only added to the sidebar after `loadFilterList`
-  // detects file-kind summaries in the realm — see how `setupFilterOptions` is
-  // re-called from `loadFilterList`. This satisfies the "hide empty groups"
-  // decision in the Linear plan: realms without any FileDef instances don't
-  // get a stub File branch.
+  @cached
   private get allFilesFilter(): FilterOption {
     return {
       displayName: 'All Files',
@@ -197,15 +198,28 @@ class Isolated extends Component<typeof CardsGrid> {
     };
   }
 
-  private setupFilterOptions() {
-    this.filterOptions.splice(0, this.filterOptions.length);
+  // Derived from tracked state — `isPersonalRealm` and `fileTypeFilters.length`
+  // are the only deps that change the visible group set. We avoid the
+  // previous `splice + push` approach because mutating a `TrackedArray`
+  // during the component constructor (which runs mid-render) fires Glimmer's
+  // "you attempted to update X but it was already used in this computation"
+  // assertion. A `@cached` getter only re-runs when its tracked deps change
+  // and stays stable otherwise, so identity-based comparisons keep working.
+  @cached
+  private get filterOptions(): FilterOption[] {
+    let options: FilterOption[] = [];
     if (this.isPersonalRealm) {
-      this.filterOptions.push(this.highlightFilter);
+      options.push(this.highlightFilter);
     }
-    this.filterOptions.push(this.allCardsFilter);
+    options.push(this.allCardsFilter);
+    // Hide the All Files group when the realm has no file rows — matches the
+    // "empty groups: hide" decision in the Linear plan. Reading `.length` on
+    // a TrackedArray sets up a dep so this getter re-runs once
+    // `loadFilterList` finishes its first push into `fileTypeFilters`.
     if (this.fileTypeFilters.length > 0) {
-      this.filterOptions.push(this.allFilesFilter);
+      options.push(this.allFilesFilter);
     }
+    return options;
   }
 
   private teardownRealmSubscription() {
@@ -374,10 +388,10 @@ class Isolated extends Component<typeof CardsGrid> {
       });
     });
 
-    // Re-run setup so the All Files group appears/disappears as the file leaf
-    // list grows or shrinks. setupFilterOptions inspects `fileTypeFilters` to
-    // decide whether to include the group at all.
-    this.setupFilterOptions();
+    // `filterOptions` is a @cached getter that derives the group list from
+    // tracked state — `fileTypeFilters.length` changing here causes it to
+    // re-compute on the next read, which adds/removes the All Files group
+    // without any imperative array mutation.
 
     let flattenedFilters: FilterOption[] = [];
     this.filterOptions.map((f) =>

--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -12,12 +12,15 @@ import { HighlightIcon } from '@cardstack/boxel-ui/icons';
 import LayoutGridPlusIcon from '@cardstack/boxel-icons/layout-grid-plus';
 import Captions from '@cardstack/boxel-icons/captions';
 import AllCardsIcon from '@cardstack/boxel-icons/square-stack';
+import AllFilesIcon from '@cardstack/boxel-icons/files';
+import FileIcon from '@cardstack/boxel-icons/file';
 
 import {
   cardIdToURL,
   chooseCard,
   specRef,
   baseRealm,
+  baseFileRef,
   isCardInstance,
   SupportedMimeType,
   subscribeToRealm,
@@ -101,8 +104,9 @@ class Isolated extends Component<typeof CardsGrid> {
   </template>
 
   private cardTypeFilters: FilterOption[] = new TrackedArray();
+  private fileTypeFilters: FilterOption[] = new TrackedArray();
   private highlightsCards: BoxComponent[] = new TrackedArray();
-  private filterOptions: FilterOption[] = [];
+  private filterOptions: FilterOption[] = new TrackedArray();
   private viewOptions: ViewOption[] = new TrackedArray([StripView, GridView]);
   private sortOptions: SortOption[] = new TrackedArray(SORT_OPTIONS);
 
@@ -174,12 +178,34 @@ class Isolated extends Component<typeof CardsGrid> {
     };
   }
 
+  // The All Files group is only added to the sidebar after `loadFilterList`
+  // detects file-kind summaries in the realm — see how `setupFilterOptions` is
+  // re-called from `loadFilterList`. This satisfies the "hide empty groups"
+  // decision in the Linear plan: realms without any FileDef instances don't
+  // get a stub File branch.
+  private get allFilesFilter(): FilterOption {
+    return {
+      displayName: 'All Files',
+      icon: AllFilesIcon,
+      query: {
+        filter: {
+          type: baseFileRef,
+        },
+      },
+      filters: this.fileTypeFilters,
+      isExpanded: false,
+    };
+  }
+
   private setupFilterOptions() {
     this.filterOptions.splice(0, this.filterOptions.length);
     if (this.isPersonalRealm) {
       this.filterOptions.push(this.highlightFilter);
     }
     this.filterOptions.push(this.allCardsFilter);
+    if (this.fileTypeFilters.length > 0) {
+      this.filterOptions.push(this.allFilesFilter);
+    }
   }
 
   private teardownRealmSubscription() {
@@ -293,21 +319,48 @@ class Isolated extends Component<typeof CardsGrid> {
         displayName: string;
         total: number;
         iconHTML: string | null;
+        // Older realm-server builds may not stamp `kind` yet — treat missing
+        // as 'instance' so this client stays compatible during a rolling
+        // deploy. New servers always set the discriminator.
+        kind?: 'instance' | 'file';
       };
     }[];
     let excludedCardTypeIds = [
       `${baseRealm.url}card-api/CardDef`,
       `${baseRealm.url}cards-grid/CardsGrid`,
     ];
+    // The "All Files" group already represents the bare FileDef root — listing
+    // it again as a leaf would just be a duplicate row.
+    let excludedFileTypeIds = [`${baseRealm.url}card-api/FileDef`];
 
     this.cardTypeFilters.splice(0, this.cardTypeFilters.length);
+    this.fileTypeFilters.splice(0, this.fileTypeFilters.length);
 
     cardTypeSummaries.forEach((summary) => {
-      if (!summary.id || excludedCardTypeIds.includes(summary.id)) {
+      if (!summary.id) {
         return;
       }
       let codeRef = codeRefFromInternalKey(summary.id);
       if (!codeRef) {
+        return;
+      }
+      let kind = summary.attributes.kind ?? 'instance';
+      if (kind === 'file') {
+        if (excludedFileTypeIds.includes(summary.id)) {
+          return;
+        }
+        this.fileTypeFilters.push({
+          displayName: summary.attributes.displayName ?? codeRef.name,
+          icon: summary.attributes.iconHTML ?? FileIcon,
+          query: {
+            filter: {
+              type: codeRef,
+            },
+          },
+        });
+        return;
+      }
+      if (excludedCardTypeIds.includes(summary.id)) {
         return;
       }
       this.cardTypeFilters.push({
@@ -320,6 +373,11 @@ class Isolated extends Component<typeof CardsGrid> {
         },
       });
     });
+
+    // Re-run setup so the All Files group appears/disappears as the file leaf
+    // list grows or shrinks. setupFilterOptions inspects `fileTypeFilters` to
+    // decide whether to include the group at all.
+    this.setupFilterOptions();
 
     let flattenedFilters: FilterOption[] = [];
     this.filterOptions.map((f) =>

--- a/packages/base/components/card-list.gts
+++ b/packages/base/components/card-list.gts
@@ -65,6 +65,18 @@ export default class CardList extends Component<Signature> {
     }
   }
 
+  // Render the filename fallback only when the prerender pipeline produced
+  // no HTML AND the row is not an error. Error rows have their own
+  // dedicated error component built by PrerenderedCard's constructor, which
+  // also has empty `html`; treating them like file fallbacks would swap a
+  // helpful "rendering error" affordance for a bare filename.
+  shouldRenderFallback(card: {
+    hasHtml?: boolean;
+    isError?: boolean;
+  }): boolean {
+    return card.hasHtml === false && !card.isError;
+  }
+
   <template>
     <ul
       class={{cn
@@ -94,7 +106,7 @@ export default class CardList extends Component<Signature> {
                   'boxel-card-list-item'
                   instance-error=card.isError
                   clickable=(if this.cardCrudFunctions.viewCard true false)
-                  fallback=(eq card.hasHtml false)
+                  fallback=(this.shouldRenderFallback card)
                 }}
                 data-test-instance-error={{card.isError}}
                 data-test-cards-grid-item={{removeFileExtension card.url}}
@@ -104,12 +116,14 @@ export default class CardList extends Component<Signature> {
                 tabindex={{if this.cardCrudFunctions.viewCard '0'}}
                 {{on 'click' (fn this.handleCardClick card.url)}}
               >
-                {{#if (eq card.hasHtml false)}}
+                {{#if (this.shouldRenderFallback card)}}
                   {{! CS-11171: file rows whose prerender produced no HTML
                       (currently `.gts`/`.ts` FileDef rows) — render a name
                       so the row is at least visible and the click handler on
                       this `<li>` can still route the user into interact-mode
-                      (and from there into Code Mode via the kebab menu). }}
+                      (and from there into Code Mode via the kebab menu).
+                      Error rows are excluded so PrerenderedCard's dedicated
+                      error component still gets rendered for them. }}
                   <div class='card-fallback' data-test-card-fallback>
                     <FileIcon class='card-fallback__icon' role='presentation' />
                     <div class='card-fallback__name'>

--- a/packages/base/components/card-list.gts
+++ b/packages/base/components/card-list.gts
@@ -7,6 +7,8 @@ import { consume } from 'ember-provide-consume-context';
 
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
+import FileIcon from '@cardstack/boxel-icons/file';
+
 import { cn, eq } from '@cardstack/boxel-ui/helpers';
 
 import {
@@ -48,6 +50,21 @@ export default class CardList extends Component<Signature> {
     }
   }
 
+  // Last URL segment, used as a visible label when the prerender pipeline
+  // didn't produce HTML for a file row (CS-11171 — `.gts`/`.ts` FileDef rows
+  // currently skip the FileRender pass, so their `fitted_html` is null and
+  // `<card.component />` renders nothing).
+  fileNameFromUrl(url: string): string {
+    try {
+      let pathname = new URL(url).pathname;
+      let segment = pathname.split('/').filter(Boolean).pop();
+      return segment ?? url;
+    } catch {
+      let segments = url.split('/').filter(Boolean);
+      return segments[segments.length - 1] ?? url;
+    }
+  }
+
   <template>
     <ul
       class={{cn
@@ -77,6 +94,7 @@ export default class CardList extends Component<Signature> {
                   'boxel-card-list-item'
                   instance-error=card.isError
                   clickable=(if this.cardCrudFunctions.viewCard true false)
+                  fallback=(eq card.hasHtml false)
                 }}
                 data-test-instance-error={{card.isError}}
                 data-test-cards-grid-item={{removeFileExtension card.url}}
@@ -86,7 +104,21 @@ export default class CardList extends Component<Signature> {
                 tabindex={{if this.cardCrudFunctions.viewCard '0'}}
                 {{on 'click' (fn this.handleCardClick card.url)}}
               >
-                <card.component />
+                {{#if (eq card.hasHtml false)}}
+                  {{! CS-11171: file rows whose prerender produced no HTML
+                      (currently `.gts`/`.ts` FileDef rows) — render a name
+                      so the row is at least visible and the click handler on
+                      this `<li>` can still route the user into interact-mode
+                      (and from there into Code Mode via the kebab menu). }}
+                  <div class='card-fallback' data-test-card-fallback>
+                    <FileIcon class='card-fallback__icon' role='presentation' />
+                    <div class='card-fallback__name'>
+                      {{this.fileNameFromUrl card.url}}
+                    </div>
+                  </div>
+                {{else}}
+                  <card.component />
+                {{/if}}
               </li>
             {{else}}
               <p>No results were found</p>
@@ -146,6 +178,49 @@ export default class CardList extends Component<Signature> {
         height: auto;
         max-width: var(--embedded-card-max-width);
         min-height: var(--embedded-card-min-height);
+      }
+      .boxel-card-list-item.fallback {
+        background-color: var(--boxel-100);
+        border: 1px solid var(--boxel-200);
+        border-radius: var(--boxel-border-radius);
+        padding: var(--boxel-sp-xs);
+        align-items: center;
+        justify-content: flex-start;
+      }
+      .card-fallback {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: var(--boxel-sp-xs);
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        text-align: center;
+      }
+      .card-fallback__icon {
+        width: 2rem;
+        height: 2rem;
+        color: var(--boxel-500);
+        flex-shrink: 0;
+      }
+      .card-fallback__name {
+        font: 500 var(--boxel-font-sm);
+        color: var(--boxel-dark);
+        word-break: break-word;
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+      }
+      .strip-view .card-fallback {
+        flex-direction: row;
+        justify-content: flex-start;
+        text-align: left;
+      }
+      .strip-view .card-fallback__icon {
+        width: 1.5rem;
+        height: 1.5rem;
       }
       .instance-error {
         position: relative;

--- a/packages/base/file-menu-items.ts
+++ b/packages/base/file-menu-items.ts
@@ -4,10 +4,13 @@ import {
 } from '@cardstack/boxel-ui/helpers';
 
 import ArrowLeft from '@cardstack/boxel-icons/arrow-left';
+import ClipboardCopy from '@cardstack/boxel-icons/clipboard-copy';
 import CodeIcon from '@cardstack/boxel-icons/code';
 import Eye from '@cardstack/boxel-icons/eye';
 import LinkIcon from '@cardstack/boxel-icons/link';
+import Trash2Icon from '@cardstack/boxel-icons/trash-2';
 
+import CopyCardAsMarkdownCommand from '@cardstack/boxel-host/commands/copy-card-as-markdown';
 import CopyFileToRealmCommand from '@cardstack/boxel-host/commands/copy-file-to-realm';
 import OpenInInteractModeCommand from '@cardstack/boxel-host/commands/open-in-interact-mode';
 import ShowFileCommand from '@cardstack/boxel-host/commands/show-file';
@@ -36,6 +39,20 @@ export function getDefaultFileMenuItems(
   }
   if (params.menuContext === 'interact') {
     if (fileDefInstanceId) {
+      // Mirror the CardDef menu so users get a consistent set of actions on
+      // file rows. `CopyCardAsMarkdownCommand` is generic — it fetches the
+      // URL with `Accept: text/markdown` — so a file URL works the same way
+      // a card URL does, returning whatever the file row's `markdown`
+      // column holds (populated by the FileRender pass; null today for
+      // `.gts`/`.ts` rows pending CS-11171).
+      menuItems.push({
+        label: 'Copy as Markdown',
+        action: () =>
+          new CopyCardAsMarkdownCommand(params.commandContext).execute({
+            cardId: fileDefInstanceId,
+          }),
+        icon: ClipboardCopy,
+      });
       // Files are read-only in interact-mode (no edit format). The "Open in
       // Code Mode" entry is the canonical way for a user who opened a file
       // via CardsGrid's All Files group to jump to the editing surface.
@@ -49,9 +66,19 @@ export function getDefaultFileMenuItems(
         },
         icon: CodeIcon,
       });
-    }
-    if (fileDefInstanceId && params.canEdit) {
-      // TODO: add menu item to delete the file
+      if (params.canEdit) {
+        // `deleteCard` ultimately routes through `store.delete(id)`, which
+        // calls the realm's source-delete endpoint — the endpoint doesn't
+        // care whether the URL points at a card JSON or some other file
+        // kind, so reusing it for FileDef rows is the right plumbing.
+        menuItems.push({
+          label: 'Delete',
+          action: () =>
+            params.cardCrudFunctions.deleteCard?.(fileDefInstanceId),
+          icon: Trash2Icon,
+          dangerous: true,
+        });
+      }
     }
   }
   if (

--- a/packages/base/file-menu-items.ts
+++ b/packages/base/file-menu-items.ts
@@ -35,6 +35,21 @@ export function getDefaultFileMenuItems(
     });
   }
   if (params.menuContext === 'interact') {
+    if (fileDefInstanceId) {
+      // Files are read-only in interact-mode (no edit format). The "Open in
+      // Code Mode" entry is the canonical way for a user who opened a file
+      // via CardsGrid's All Files group to jump to the editing surface.
+      menuItems.push({
+        label: 'Open in Code Mode',
+        action: async () => {
+          await new SwitchSubmodeCommand(params.commandContext).execute({
+            submode: 'code',
+            codePath: fileDefInstanceId,
+          });
+        },
+        icon: CodeIcon,
+      });
+    }
     if (fileDefInstanceId && params.canEdit) {
       // TODO: add menu item to delete the file
     }

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -25,21 +25,22 @@ import type { CardContext, CardDef } from 'https://cardstack.com/base/card-api';
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 import { type HTMLComponent, htmlComponent } from '../lib/html-component';
-import { getLivePrerenderedSearch } from '../resources/live-prerendered-search';
-import { getPrerenderedSearch } from '../resources/prerendered-search';
-import { getSearch } from '../resources/search';
-
-const OWNER_DESTROYED_ERROR =
-  "Cannot call `.lookup('renderer:-dom')` after the owner has been destroyed";
-
-// The Set itself lives in `lib/known-file-meta-urls` so non-component code
-// (e.g. `lib/stack-item.ts`) can read it without importing a component file.
-// Re-exported here for back-compat with existing call sites.
+// `knownFileMetaUrls` lives in `lib/` so non-component code (e.g.
+// `lib/stack-item.ts`) can read it without importing a component file. We
+// re-export here for back-compat with existing call sites that imported it
+// from this module.
 import {
   knownFileMetaUrls,
   clearKnownFileMetaUrls,
 } from '../lib/known-file-meta-urls';
+import { getLivePrerenderedSearch } from '../resources/live-prerendered-search';
+import { getPrerenderedSearch } from '../resources/prerendered-search';
+import { getSearch } from '../resources/search';
+
 export { knownFileMetaUrls, clearKnownFileMetaUrls };
+
+const OWNER_DESTROYED_ERROR =
+  "Cannot call `.lookup('renderer:-dom')` after the owner has been destroyed";
 
 export class PrerenderedCard implements PrerenderedCardLike {
   component: HTMLComponent;

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -32,14 +32,14 @@ import { getSearch } from '../resources/search';
 const OWNER_DESTROYED_ERROR =
   "Cannot call `.lookup('renderer:-dom')` after the owner has been destroyed";
 
-// Internal registry of URLs known to be file-meta from prerendered search.
-// Used by the overlay system to correctly identify FileDef cards when they
-// haven't been loaded into the store yet (prerendered results are HTML-only).
-export const knownFileMetaUrls = new Set<string>();
-
-export function clearKnownFileMetaUrls() {
-  knownFileMetaUrls.clear();
-}
+// The Set itself lives in `lib/known-file-meta-urls` so non-component code
+// (e.g. `lib/stack-item.ts`) can read it without importing a component file.
+// Re-exported here for back-compat with existing call sites.
+import {
+  knownFileMetaUrls,
+  clearKnownFileMetaUrls,
+} from '../lib/known-file-meta-urls';
+export { knownFileMetaUrls, clearKnownFileMetaUrls };
 
 export class PrerenderedCard implements PrerenderedCardLike {
   component: HTMLComponent;

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -86,6 +86,14 @@ export class PrerenderedCard implements PrerenderedCardLike {
   get usedRenderType(): ResolvedCodeRef | undefined {
     return this.data.usedRenderType;
   }
+  // True iff the prerender pipeline produced HTML for this row. Currently
+  // false for executable-module FileDef rows (`.gts`/`.ts`) because the
+  // fused visit skips the FileRender pass when `isModule` is true — see
+  // CS-11171. CardList consults this to render a filename fallback so the
+  // user can still see and click the row through to interact-mode.
+  get hasHtml(): boolean {
+    return typeof this.data.html === 'string' && this.data.html.length > 0;
+  }
 }
 function getErrorComponent(realmURL: string, url: string) {
   let name = new RealmPaths(new URL(realmURL)).local(new URL(url));

--- a/packages/host/app/lib/known-file-meta-urls.ts
+++ b/packages/host/app/lib/known-file-meta-urls.ts
@@ -1,0 +1,17 @@
+// In-memory registry of URLs that prerendered search has identified as
+// file-meta (FileDef) rather than card instances. Populated as
+// PrerenderedCard wrappers are constructed in `prerendered-card-search.gts`
+// and consulted by `detectStackItemTypeForTarget` (stack-item.ts) and the
+// operator-mode-overlays so that clicking a file row in CardsGrid /
+// embedded-card overlays routes to a file stack item even when the
+// file-meta resource hasn't been loaded into the store yet (prerendered
+// results carry HTML only).
+//
+// Lives in `lib/` rather than under a component so it can be imported from
+// both component-side code (which adds entries) and lib-side type detection
+// (which only reads entries) without creating a lib → components cycle.
+export const knownFileMetaUrls = new Set<string>();
+
+export function clearKnownFileMetaUrls() {
+  knownFileMetaUrls.clear();
+}

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -109,11 +109,16 @@ export class StackItem {
       lastInteractedAt,
     } = args;
 
-    this.#id = id.replace(/\.json$/, '');
+    this.type = inferStackItemType(type);
+    // CardDef instance ids are stored without a `.json` extension, so the
+    // strip sanitizes inputs that erroneously include one. FileDef rows are
+    // a different story — their canonical URL keeps the extension
+    // (`*.json` for JsonFileDef, `*.md` for MarkdownDef, etc.) and stripping
+    // would lose the identity of `.json` FileDef rows in the store.
+    this.#id = this.type === 'file' ? id : id.replace(/\.json$/, '');
     this.format = format;
     this.request = request;
     this.stackIndex = stackIndex;
-    this.type = inferStackItemType(type);
     this.useBaseTemplate = useBaseTemplate;
     this.relationshipContext = relationshipContext;
     this.lastInteractedAt = lastInteractedAt ?? ++nextInteractionSequence;

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -6,6 +6,8 @@ import type { Store, StoreReadType } from '@cardstack/runtime-common';
 
 import type { Format } from 'https://cardstack.com/base/card-api';
 
+import { knownFileMetaUrls } from './known-file-meta-urls';
+
 interface Args {
   format: Format;
   request?: Deferred<string>;
@@ -50,7 +52,18 @@ export function detectStackItemTypeForTarget(
   let fileMetaInstanceOrError =
     store.peek(cardId, { type: 'file-meta' }) ??
     store.peekError(cardId, { type: 'file-meta' });
-  return fileMetaInstanceOrError ? 'file' : 'card';
+  if (fileMetaInstanceOrError) {
+    return 'file';
+  }
+  // CardsGrid and other prerendered-search consumers click URLs whose
+  // file-meta resources may not yet be in the store (prerendered results are
+  // HTML-only). `knownFileMetaUrls` is populated as PrerenderedCard wrappers
+  // are built, so consulting it covers the common "user clicks a file row in
+  // a freshly opened CardsGrid" path.
+  if (knownFileMetaUrls.has(cardId)) {
+    return 'file';
+  }
+  return 'card';
 }
 
 let nextInteractionSequence = 0;

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -503,7 +503,18 @@ export default class RealmServerService extends Service {
     data: {
       id: string;
       type: 'card-type-summary';
-      attributes: { displayName: string; total: number; iconHTML: string };
+      attributes: {
+        displayName: string;
+        total: number;
+        iconHTML: string;
+        // The federated `_types` response now stamps `kind` on every
+        // entry. Keeping it in the declared return type — not just the
+        // local `json` cast — means callers see the discriminator and
+        // can partition card vs file summaries instead of conflating
+        // them. `?` for back-compat with the still-supported legacy
+        // response shape (no kind, treated as 'instance').
+        kind?: 'instance' | 'file';
+      };
       meta?: { realmURL: string };
     }[];
     meta: { page: { total: number } };

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -554,6 +554,7 @@ export default class RealmServerService extends Service {
           displayName: string;
           total: number;
           iconHTML: string;
+          kind?: 'instance' | 'file';
         };
         meta?: { realmURL: string };
       }[];

--- a/packages/host/app/utils/file-def-attributes-extractor.ts
+++ b/packages/host/app/utils/file-def-attributes-extractor.ts
@@ -40,6 +40,7 @@ export type FileDefExtractResult = {
   searchDoc: Record<string, any> | null;
   resource?: FileMetaResource;
   types?: string[];
+  displayNames?: string[];
   deps: string[];
   error?: RenderError;
   mismatch?: true;
@@ -200,6 +201,7 @@ export class FileDefAttributesExtractor {
       if (searchDoc) {
         let typeCodeRefs = getTypes(klass);
         let types = typeCodeRefs.map((type) => internalKeyFor(type, undefined));
+        let displayNames = getDisplayNames(klass);
         let adoptsFrom = typeCodeRefs[0] ?? this.#fileDefCodeRef;
         let queryFieldDefs = await this.extractQueryFieldDefs(klass);
         return {
@@ -212,6 +214,7 @@ export class FileDefAttributesExtractor {
             queryFieldDefs,
           ),
           types,
+          displayNames,
           deps,
           ...(error ? { error } : {}),
           ...(mismatch ? { mismatch: true } : {}),
@@ -375,6 +378,32 @@ export function getTypes(klass: FileDefConstructor): CodeRef[] {
     current = Reflect.getPrototypeOf(current) as FileDefConstructor | undefined;
   }
   return types;
+}
+
+// Walks the FileDef subclass prototype chain and collects each level's
+// `static displayName` (e.g. `MarkdownDef.displayName === 'Markdown'`).
+// Mirrors the card-side getDisplayNames in routes/render/meta.ts so the same
+// `boxel_index.display_names` semantics apply to file rows.
+export function getDisplayNames(klass: FileDefConstructor): string[] {
+  let displayNames: string[] = [];
+  let current: FileDefConstructor | undefined = klass;
+  while (current) {
+    let ref = identifyCard(current as unknown as typeof BaseDef);
+    if (!ref || isEqual(ref, baseRef)) {
+      break;
+    }
+    let kAny = current as {
+      displayName?: string;
+      name?: string;
+    };
+    if (typeof kAny.displayName === 'string' && kAny.displayName) {
+      displayNames.push(kAny.displayName);
+    } else if (typeof kAny.name === 'string' && kAny.name) {
+      displayNames.push(kAny.name);
+    }
+    current = Reflect.getPrototypeOf(current) as FileDefConstructor | undefined;
+  }
+  return displayNames;
 }
 
 export function buildFileResource(

--- a/packages/host/tests/helpers/realm-server-mock/routes.ts
+++ b/packages/host/tests/helpers/realm-server-mock/routes.ts
@@ -263,7 +263,12 @@ function registerTypesRoutes() {
       let allEntries: {
         id: string;
         type: 'card-type-summary';
-        attributes: { displayName: string; total: number; iconHTML: string };
+        attributes: {
+          displayName: string;
+          total: number;
+          iconHTML: string;
+          kind: 'instance' | 'file';
+        };
         meta: { realmURL: string };
       }[] = [];
 

--- a/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
@@ -1399,7 +1399,7 @@ module('Integration | operator-mode | card catalog', function (hooks) {
       .dom(`[data-test-cards-grid-item="${testRealmURL}CardDef/1"]`)
       .exists();
 
-    assert.dom(`[data-test-boxel-filter-list-button]`).exists({ count: 13 });
+    assert.dom(`[data-test-boxel-filter-list-button]`).exists({ count: 14 });
     assert.dom(`[data-test-boxel-filter-list-button="Skill"]`).doesNotExist();
 
     await click('[data-test-create-new-card-button]');
@@ -1413,7 +1413,7 @@ module('Integration | operator-mode | card catalog', function (hooks) {
     await fillIn('[data-test-field="cardTitle"] input', 'New Skill');
     await click('[data-test-close-button]');
 
-    assert.dom(`[data-test-boxel-filter-list-button]`).exists({ count: 14 });
+    assert.dom(`[data-test-boxel-filter-list-button]`).exists({ count: 15 });
     assert.dom(`[data-test-boxel-filter-list-button="Skill"]`).exists();
 
     await click('[data-test-boxel-filter-list-button="Skill"]');
@@ -1426,7 +1426,7 @@ module('Integration | operator-mode | card catalog', function (hooks) {
 
     await click('[data-test-confirm-delete-button]');
 
-    assert.dom(`[data-test-boxel-filter-list-button]`).exists({ count: 13 });
+    assert.dom(`[data-test-boxel-filter-list-button]`).exists({ count: 14 });
     assert.dom(`[data-test-boxel-filter-list-button="Skill"]`).doesNotExist();
   });
 

--- a/packages/host/tests/integration/components/operator-mode-ui-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-ui-test.gts
@@ -592,8 +592,8 @@ module('Integration | operator-mode | ui', function (hooks) {
     ).length;
     assert.strictEqual(
       allTypeOptions,
-      13,
-      `type picker shows 13 types (got ${allTypeOptions})`,
+      15,
+      `type picker shows 15 types (got ${allTypeOptions})`,
     );
   });
 
@@ -1026,7 +1026,7 @@ module('Integration | operator-mode | ui', function (hooks) {
     assert
       .dom('[data-test-boxel-picker-option-row="select-all"]')
       .containsText(
-        'Any Type (14)',
+        'Any Type (16)',
         'select-all shows count of all realm types',
       );
 
@@ -1087,7 +1087,7 @@ module('Integration | operator-mode | ui', function (hooks) {
     assert
       .dom('[data-test-boxel-picker-option-row="select-all"]')
       .containsText(
-        'Any Type (14)',
+        'Any Type (16)',
         'select-all shows count of all realm types',
       );
 
@@ -1096,7 +1096,7 @@ module('Integration | operator-mode | ui', function (hooks) {
     );
     assert.strictEqual(
       nonSelectAllOptions.length,
-      13,
+      15,
       'all realm types are shown even without recent cards',
     );
   });
@@ -1516,12 +1516,12 @@ module('Integration | operator-mode | ui', function (hooks) {
       await click('[data-test-type-picker] [data-test-boxel-picker-trigger]');
       await waitFor('[data-test-boxel-picker-option-row]');
 
-      // "Any Type" count should reflect the total from the API (13 types),
+      // "Any Type" count should reflect the total from the API (15 types),
       // not just the currently loaded page (3 types with PAGE_SIZE=3)
       assert
         .dom('[data-test-boxel-picker-option-row="select-all"]')
         .containsText(
-          'Any Type (14)',
+          'Any Type (16)',
           'select-all shows total count from API, not loaded options count',
         );
     } finally {

--- a/packages/host/tests/unit/file-def-menu-items-test.ts
+++ b/packages/host/tests/unit/file-def-menu-items-test.ts
@@ -58,15 +58,13 @@ module('Unit | FileDef menu items', function (hooks) {
     });
 
     let texts = items.map((i: MenuItemOptions) => i.label);
+    assert.ok(texts.includes('Copy as Markdown'), 'contains Copy as Markdown');
     assert.ok(
-      texts.includes('Copy as Markdown'),
-      'contains Copy as Markdown',
+      texts.includes('Open in Code Mode'),
+      'contains Open in Code Mode',
     );
-    assert.ok(texts.includes('Open in Code Mode'), 'contains Open in Code Mode');
     assert.ok(texts.includes('Delete'), 'contains Delete when canEdit');
-    let deleteItem = items.find(
-      (i: MenuItemOptions) => i.label === 'Delete',
-    );
+    let deleteItem = items.find((i: MenuItemOptions) => i.label === 'Delete');
     assert.true(
       Boolean(deleteItem?.dangerous),
       'Delete is marked as a dangerous action',

--- a/packages/host/tests/unit/file-def-menu-items-test.ts
+++ b/packages/host/tests/unit/file-def-menu-items-test.ts
@@ -46,6 +46,61 @@ module('Unit | FileDef menu items', function (hooks) {
     assert.ok(texts.includes('Copy File URL'), 'contains Copy File URL');
   });
 
+  test('interact context mirrors the CardDef action set (Copy as Markdown, Open in Code Mode, Delete)', function (assert: Assert) {
+    let file = new DummyFile(
+      'https://example.com/realm/file-1.txt',
+    ) as unknown as FileDef;
+    let items = getDefaultFileMenuItems(file, {
+      canEdit: true,
+      cardCrudFunctions: {},
+      menuContext: 'interact',
+      commandContext: {} as any,
+    });
+
+    let texts = items.map((i: MenuItemOptions) => i.label);
+    assert.ok(
+      texts.includes('Copy as Markdown'),
+      'contains Copy as Markdown',
+    );
+    assert.ok(texts.includes('Open in Code Mode'), 'contains Open in Code Mode');
+    assert.ok(texts.includes('Delete'), 'contains Delete when canEdit');
+    let deleteItem = items.find(
+      (i: MenuItemOptions) => i.label === 'Delete',
+    );
+    assert.true(
+      Boolean(deleteItem?.dangerous),
+      'Delete is marked as a dangerous action',
+    );
+  });
+
+  test('interact context omits Delete when canEdit is false', function (assert: Assert) {
+    let file = new DummyFile(
+      'https://example.com/realm/file-2.txt',
+    ) as unknown as FileDef;
+    let items = getDefaultFileMenuItems(file, {
+      canEdit: false,
+      cardCrudFunctions: {},
+      menuContext: 'interact',
+      commandContext: {} as any,
+    });
+
+    let texts = items.map((i: MenuItemOptions) => i.label);
+    assert.notOk(
+      texts.includes('Delete'),
+      'Delete is hidden for read-only contexts',
+    );
+    // Copy as Markdown and Open in Code Mode are not edit operations, so
+    // they remain available even without write permission.
+    assert.ok(
+      texts.includes('Copy as Markdown'),
+      'Copy as Markdown is available read-only',
+    );
+    assert.ok(
+      texts.includes('Open in Code Mode'),
+      'Open in Code Mode is available read-only',
+    );
+  });
+
   test('code-mode-preview includes Copy File URL and Open in Interact Mode', function (assert: Assert) {
     let file = new DummyFile(
       'https://example.com/realm/file-3.txt',

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -1793,6 +1793,215 @@ module('Unit | index-writer', function (hooks) {
     );
   });
 
+  test('update realm meta collapses rows with the same code_ref but mixed display_names', async function (assert) {
+    // Regression: when a realm has been partially re-indexed across a code
+    // change (some file rows have populated `display_names`, some still
+    // have `[]` from the previous indexer), the aggregation must collapse
+    // them into one summary per code_ref — using `MAX(display_name)` so
+    // the populated label wins over the empty/null one. Without the
+    // collapse, CardsGrid's sidebar shows two entries for the same type
+    // (e.g., "Markdown" and "MarkdownDef") that resolve to identical
+    // searches and confuse the user.
+    let iconHTML = '<svg>icon</svg>';
+    let markdownTypes = internalKeysFor(
+      { module: rri('./markdown-file-def'), name: 'MarkdownDef' },
+      { module: rri('./card-api'), name: 'FileDef' },
+    );
+
+    await setupIndex(
+      adapter,
+      [{ realm_url: testRealmURL, current_version: 1 }],
+      [
+        // Two markdown files with the same code_ref but different
+        // display_names — simulates the rolling-deploy state where the
+        // new extractor populated names for one file but not the other.
+        {
+          url: `${testRealmURL}notes/new.md`,
+          realm_version: 1,
+          realm_url: testRealmURL,
+          type: 'file',
+          search_doc: { name: 'new.md', url: `${testRealmURL}notes/new.md` },
+          display_names: ['Markdown', 'File'],
+          types: markdownTypes,
+          icon_html: iconHTML,
+        },
+        {
+          url: `${testRealmURL}notes/old.md`,
+          realm_version: 1,
+          realm_url: testRealmURL,
+          type: 'file',
+          search_doc: { name: 'old.md', url: `${testRealmURL}notes/old.md` },
+          display_names: [],
+          types: markdownTypes,
+          icon_html: iconHTML,
+        },
+      ],
+    );
+
+    let batch = await indexWriter.createBatch(new URL(testRealmURL));
+    await batch.done();
+
+    let realmMeta = await fetchRealmMeta(adapter);
+    assert.deepEqual(
+      realmMeta.files,
+      [
+        makeCardTypeSummary(
+          `${testRealmURL}markdown-file-def/MarkdownDef`,
+          'Markdown',
+          iconHTML,
+          2,
+        ),
+      ],
+      'one summary per code_ref, with the populated display_name picked over the empty one',
+    );
+  });
+
+  test('fetchCardTypeSummary returns the realm_meta row at realm_versions.current_version', async function (assert) {
+    // Regression: the read path JOINs realm_meta against
+    // realm_versions.current_version so it always picks the row that
+    // matches the realm's authoritative current version. Without the JOIN,
+    // a naive SELECT returns an arbitrary realm_meta row when stale rows
+    // linger (e.g., after a from-scratch reindex resets the version) and
+    // CardsGrid's "All Files" group silently vanishes for any realm whose
+    // physical row order happens to surface a legacy array-shape row.
+    let iconHTML = '<svg>icon</svg>';
+    let personTypes = internalKeysFor(
+      { module: rri('./person'), name: 'Person' },
+      baseCardRef,
+    );
+
+    // Seed a CARD row at version 1 — that's the version we'll mark as
+    // current. updateRealmMeta() will aggregate this into realm_meta.value
+    // (new partitioned shape) for v1.
+    await setupIndex(
+      adapter,
+      [{ realm_url: testRealmURL, current_version: 1 }],
+      [
+        {
+          url: `${testRealmURL}1.json`,
+          realm_version: 1,
+          realm_url: testRealmURL,
+          type: 'instance',
+          pristine_doc: makeCardResource('1', 'Mango', {
+            module: rri('./person'),
+            name: 'Person',
+          }) as LooseCardResource,
+          search_doc: { name: 'Mango' },
+          display_names: ['Person'],
+          deps: [`${testRealmURL}person`],
+          types: personTypes,
+          icon_html: iconHTML,
+        },
+      ],
+    );
+
+    // Have the index writer aggregate v1 into realm_meta.value with the
+    // new partitioned shape.
+    let batch = await indexWriter.createBatch(new URL(testRealmURL));
+    await batch.done();
+
+    // Now plant a *stale* legacy-shape row at a HIGHER version number. This
+    // is exactly the layout you get after a from-scratch reindex: the prune
+    // predicate `realm_version < current` doesn't reach v999, so it lingers.
+    // The naive `SELECT … WHERE realm_url=…` (no ORDER BY) would happily
+    // return this row first.
+    await adapter.execute(
+      `INSERT INTO realm_meta (realm_url, realm_version, value, indexed_at)
+       VALUES ($1, $2, $3, $4)`,
+      {
+        bind: [
+          testRealmURL,
+          999,
+          JSON.stringify([
+            {
+              code_ref: `${testRealmURL}stale/Stale`,
+              display_name: 'Stale',
+              total: 42,
+              icon_html: iconHTML,
+            },
+          ]),
+          String(Date.now() - 1000),
+        ],
+      },
+    );
+
+    let summary = await indexQueryEngine.fetchCardTypeSummary(
+      new URL(testRealmURL),
+    );
+    assert.deepEqual(
+      summary.instances.map((s) => s.code_ref),
+      [`${testRealmURL}person/Person`],
+      'fetchCardTypeSummary returns the row at realm_versions.current_version even when a higher-numbered stale row is present',
+    );
+    assert.notOk(
+      summary.instances.find((s) => s.display_name === 'Stale'),
+      'stale row contents do not leak through',
+    );
+  });
+
+  test('done() prunes realm_meta rows at any version, including ones higher than the current', async function (assert) {
+    // Regression: pruneObsoleteEntries uses != instead of < so a
+    // from-scratch reindex (which resets the realm_version to a low
+    // number) doesn't leave older high-version rows orphaned in
+    // realm_meta forever.
+    let iconHTML = '<svg>icon</svg>';
+
+    // realm_versions starts at 0, so the next batch will write at v1.
+    await setupIndex(
+      adapter,
+      [{ realm_url: testRealmURL, current_version: 0 }],
+      [],
+    );
+
+    // Plant stale realm_meta rows at high version numbers — the kind of
+    // residue a long-running realm accumulates before its first
+    // from-scratch reindex.
+    for (let version of [50, 100, 200, 999]) {
+      await adapter.execute(
+        `INSERT INTO realm_meta (realm_url, realm_version, value, indexed_at)
+         VALUES ($1, $2, $3, $4)`,
+        {
+          bind: [
+            testRealmURL,
+            version,
+            JSON.stringify([
+              {
+                code_ref: `${testRealmURL}stale-${version}/Stale`,
+                display_name: `Stale-${version}`,
+                total: version,
+                icon_html: iconHTML,
+              },
+            ]),
+            String(Date.now() - version * 1000),
+          ],
+        },
+      );
+    }
+
+    let rowsBefore = await adapter.execute(
+      `SELECT realm_version FROM realm_meta WHERE realm_url = $1 ORDER BY realm_version`,
+      { bind: [testRealmURL] },
+    );
+    assert.deepEqual(
+      rowsBefore.map((r) => r.realm_version),
+      [50, 100, 200, 999],
+      'stale rows are seeded before the batch runs',
+    );
+
+    let batch = await indexWriter.createBatch(new URL(testRealmURL));
+    await batch.done();
+
+    let rowsAfter = await adapter.execute(
+      `SELECT realm_version FROM realm_meta WHERE realm_url = $1 ORDER BY realm_version`,
+      { bind: [testRealmURL] },
+    );
+    assert.deepEqual(
+      rowsAfter.map((r) => r.realm_version),
+      [1],
+      'pruneObsoleteEntries deletes every row that is not the current version, including higher-numbered stale ones',
+    );
+  });
+
   test('update realm meta includes error entries with last known good state', async function (assert) {
     let iconHTML = '<svg>test icon</svg>';
     let personTypes = internalKeysFor(

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -85,9 +85,13 @@ const fetchRealmMetaRows = async (adapter: SQLiteAdapter) =>
 
 const fetchRealmMeta = async (adapter: SQLiteAdapter) => {
   let rows = await fetchRealmMetaRows(adapter);
+  let raw = rows[0]?.value as
+    | { instances?: RealmMetaValue[]; files?: RealmMetaValue[] }
+    | undefined;
   return {
     rows,
-    value: (rows[0]?.value ?? []) as RealmMetaValue[],
+    value: (raw?.instances ?? []) as RealmMetaValue[],
+    files: (raw?.files ?? []) as RealmMetaValue[],
   };
 };
 
@@ -1665,6 +1669,127 @@ module('Unit | index-writer', function (hooks) {
         makeCardTypeSummary(`${testRealmURL}pet/Pet`, 'Pet', iconHTML, 1),
       ],
       'correct card type summary after indexing is done',
+    );
+  });
+
+  test('update realm meta partitions file rows into the files array', async function (assert) {
+    // CS-prep for "Include FileDefs in CardsGrid": file rows in boxel_index
+    // (type='file') should be aggregated into `realm_meta.value.files`,
+    // independently of the cards group. This is what powers CardsGrid's
+    // "All Files" sidebar leaves.
+    let iconHTML = '<svg>file icon</svg>';
+    let baseFileTypes = internalKeysFor({
+      module: rri('./card-api'),
+      name: 'FileDef',
+    });
+    let markdownTypes = internalKeysFor(
+      {
+        module: rri('./markdown-file-def'),
+        name: 'MarkdownDef',
+      },
+      { module: rri('./card-api'), name: 'FileDef' },
+    );
+
+    await setupIndex(
+      adapter,
+      [{ realm_url: testRealmURL, current_version: 1 }],
+      [
+        // Plain instance row — should land in `instances`.
+        {
+          url: `${testRealmURL}1.json`,
+          realm_version: 1,
+          realm_url: testRealmURL,
+          type: 'instance',
+          pristine_doc: makeCardResource('1', 'Mango', {
+            module: rri('./person'),
+            name: 'Person',
+          }) as LooseCardResource,
+          search_doc: { name: 'Mango' },
+          display_names: ['Person'],
+          deps: [`${testRealmURL}person`],
+          types: internalKeysFor(
+            { module: rri('./person'), name: 'Person' },
+            baseCardRef,
+          ),
+          icon_html: iconHTML,
+        },
+        // Two markdown files — same code_ref so they collapse into one
+        // summary row with total: 2.
+        {
+          url: `${testRealmURL}notes/a.md`,
+          realm_version: 1,
+          realm_url: testRealmURL,
+          type: 'file',
+          search_doc: { name: 'a.md', url: `${testRealmURL}notes/a.md` },
+          display_names: ['Markdown', 'File'],
+          types: markdownTypes,
+          icon_html: iconHTML,
+        },
+        {
+          url: `${testRealmURL}notes/b.md`,
+          realm_version: 1,
+          realm_url: testRealmURL,
+          type: 'file',
+          search_doc: { name: 'b.md', url: `${testRealmURL}notes/b.md` },
+          display_names: ['Markdown', 'File'],
+          types: markdownTypes,
+          icon_html: iconHTML,
+        },
+        // A bare-FileDef file — base type used when the extension isn't mapped.
+        {
+          url: `${testRealmURL}misc/raw.bin`,
+          realm_version: 1,
+          realm_url: testRealmURL,
+          type: 'file',
+          search_doc: { name: 'raw.bin', url: `${testRealmURL}misc/raw.bin` },
+          display_names: ['File'],
+          types: baseFileTypes,
+          icon_html: iconHTML,
+        },
+      ],
+    );
+
+    let batch = await indexWriter.createBatch(new URL(testRealmURL));
+    // No new writes — just finalize so updateRealmMeta runs against the
+    // working table that setupIndex seeded.
+    await batch.done();
+
+    let realmMeta = await fetchRealmMeta(adapter);
+    assert.strictEqual(
+      realmMeta.rows.length,
+      1,
+      'one realm_meta row was written',
+    );
+    assert.deepEqual(
+      realmMeta.value,
+      [
+        makeCardTypeSummary(
+          `${testRealmURL}person/Person`,
+          'Person',
+          iconHTML,
+          1,
+        ),
+      ],
+      'instance summaries only reflect CardDef rows',
+    );
+    // Files are ordered by display_name ASC; "File" sorts before "Markdown".
+    assert.deepEqual(
+      realmMeta.files,
+      [
+        makeCardTypeSummary(
+          `${testRealmURL}card-api/FileDef`,
+          'File',
+          iconHTML,
+          1,
+        ),
+        makeCardTypeSummary(
+          `${testRealmURL}markdown-file-def/MarkdownDef`,
+          'Markdown',
+          iconHTML,
+          2,
+        ),
+      ],
+      'file summaries collapse duplicates and live in their own arm',
     );
   });
 

--- a/packages/matrix/tests/create-realm.spec.ts
+++ b/packages/matrix/tests/create-realm.spec.ts
@@ -34,7 +34,7 @@ test.describe('Create Realm via Dashboard', () => {
     ).toBeVisible();
     await expect(
       page.locator(`[data-test-boxel-filter-list-button]`),
-    ).toHaveCount(2);
+    ).toHaveCount(3);
 
     await page.locator('[data-test-submode-switcher] button').click();
     await page.locator('[data-test-boxel-menu-item-text="Host"]').click();

--- a/packages/realm-server/handlers/handle-federated-types.ts
+++ b/packages/realm-server/handlers/handle-federated-types.ts
@@ -44,9 +44,13 @@ export default function handleFederatedTypes({
         continue;
       }
       try {
+        // `fetchCardTypeSummary` now returns the partitioned shape
+        // `{ instances, files }`. Federate both arms into the flat response,
+        // tagging each entry with its `kind` so clients (CardsGrid, etc.)
+        // can partition the list back into "All Cards" vs "All Files" groups.
         let summaries =
           await realm.realmIndexQueryEngine.fetchCardTypeSummary();
-        for (let summary of summaries) {
+        for (let summary of summaries.instances) {
           allEntries.push({
             type: 'card-type-summary',
             id: summary.code_ref,
@@ -54,6 +58,22 @@ export default function handleFederatedTypes({
               displayName: summary.display_name,
               total: summary.total,
               iconHTML: summary.icon_html,
+              kind: 'instance',
+            },
+            meta: {
+              realmURL,
+            },
+          });
+        }
+        for (let summary of summaries.files) {
+          allEntries.push({
+            type: 'card-type-summary',
+            id: summary.code_ref,
+            attributes: {
+              displayName: summary.display_name,
+              total: summary.total,
+              iconHTML: summary.icon_html,
+              kind: 'file',
             },
             meta: {
               realmURL,

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -269,6 +269,7 @@ const ALL_TEST_FILES: string[] = [
   './query-matches-filter-test',
   './matches-filter-integration-test',
   './search-in-flight-key-test',
+  './normalize-realm-meta-value-test',
   './job-scoped-search-cache-test',
   './consuming-realm-header-test',
   './delete-boxel-claimed-domain-test',

--- a/packages/realm-server/tests/normalize-realm-meta-value-test.ts
+++ b/packages/realm-server/tests/normalize-realm-meta-value-test.ts
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { runSharedTest } from '@cardstack/runtime-common/helpers';
+import normalizeRealmMetaValueTests from '@cardstack/runtime-common/tests/normalize-realm-meta-value-test';
+
+module(basename(__filename), function () {
+  module('normalizeRealmMetaValue', function () {
+    test('undefined value normalizes to empty groups', async function (assert) {
+      await runSharedTest(normalizeRealmMetaValueTests, assert, {});
+    });
+
+    test('null value normalizes to empty groups', async function (assert) {
+      await runSharedTest(normalizeRealmMetaValueTests, assert, {});
+    });
+
+    test('legacy array shape maps to instances, files defaults to empty', async function (assert) {
+      await runSharedTest(normalizeRealmMetaValueTests, assert, {});
+    });
+
+    test('partitioned shape passes through', async function (assert) {
+      await runSharedTest(normalizeRealmMetaValueTests, assert, {});
+    });
+
+    test('missing arms default to empty arrays', async function (assert) {
+      await runSharedTest(normalizeRealmMetaValueTests, assert, {});
+    });
+
+    test('unrecognized object shape normalizes to empty groups', async function (assert) {
+      await runSharedTest(normalizeRealmMetaValueTests, assert, {});
+    });
+  });
+});

--- a/packages/realm-server/tests/realm-endpoints/markdown-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/markdown-test.ts
@@ -455,6 +455,11 @@ module(`realm-endpoints/${basename(__filename)}`, function (hooks) {
           },
         },
       },
+      // Raw markdown file (FileDef row, no instance row). Exercises the
+      // file-row branch of `getCardMarkdown` — without it, requesting
+      // `/note.md` with `Accept: text/markdown` would 415, because the
+      // handler only used to look up instance entries.
+      'note.md': '# Note\n\nFile-level markdown body.',
     },
     onRealmSetup,
   });
@@ -494,6 +499,29 @@ module(`realm-endpoints/${basename(__filename)}`, function (hooks) {
       .set('Accept', SupportedMimeType.Markdown);
 
     assert.strictEqual(response.status, 404, 'HTTP 404 status');
+  });
+
+  test('GET with Accept: text/markdown on a FileDef row returns its markdown', async function (assert) {
+    // Regression for CS-11170: CardsGrid's "Copy as Markdown" on a `.md`
+    // file URL used to 415 because `getCardMarkdown` only looked up an
+    // instance entry, never a file entry.
+    let response = await request
+      .get('/note.md')
+      .set('Accept', SupportedMimeType.Markdown);
+
+    assert.strictEqual(response.status, 200, 'HTTP 200 status');
+    assert.true(
+      /^text\/markdown(;|$)/.test(response.headers['content-type'] ?? ''),
+      `content-type starts with text/markdown: got "${response.headers['content-type']}"`,
+    );
+    assert.true(
+      response.text.includes('# Note'),
+      'body contains the file row markdown header',
+    );
+    assert.true(
+      response.text.includes('File-level markdown body.'),
+      'body contains the file row markdown body',
+    );
   });
 
   // Case 2: Whitespace preservation

--- a/packages/realm-server/tests/server-endpoints/federated-types-test.ts
+++ b/packages/realm-server/tests/server-endpoints/federated-types-test.ts
@@ -58,6 +58,11 @@ module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
           },
         },
       },
+      // FileDef row — exercises the `files` arm of realm_meta.value so the
+      // federated response carries both `kind: 'instance'` and `kind: 'file'`
+      // discriminators. Without it the `instance`/`file` partitioning would
+      // be untested at this layer.
+      'note.md': '# Note\n\nFile body.',
     };
 
     async function startTypesRealmServer({
@@ -147,6 +152,44 @@ module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
         .set('Authorization', `Bearer ${realmServerToken}`)
         .send({ realms, ...extra });
     }
+
+    test('QUERY /_federated-types stamps a kind discriminator on instance AND file entries', async function (assert) {
+      // Regression for CS-11170: the federated handler used to iterate
+      // fetchCardTypeSummary() as a flat array. After realm_meta moved to
+      // the partitioned `{ instances, files }` shape, the handler must
+      // iterate both arms and stamp each entry with its `kind`. Both
+      // realms here carry a CardDef instance + a `.md` FileDef row, so the
+      // response must include at least one of each kind.
+      let response = await makeAuthenticatedRequest([
+        testRealm.url,
+        secondaryRealm.url,
+      ]);
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let body = response.body as FederatedTypesResponse;
+
+      assert.ok(
+        body.data.every((entry) =>
+          ['instance', 'file'].includes(entry.attributes.kind),
+        ),
+        'every entry carries a kind: instance | file discriminator',
+      );
+
+      let instanceEntries = body.data.filter(
+        (entry) => entry.attributes.kind === 'instance',
+      );
+      let fileEntries = body.data.filter(
+        (entry) => entry.attributes.kind === 'file',
+      );
+      assert.ok(
+        instanceEntries.length > 0,
+        'response includes at least one kind: instance entry',
+      );
+      assert.ok(
+        fileEntries.length > 0,
+        'response includes at least one kind: file entry — proves the federated handler iterates the files arm of realm_meta.value, not just instances',
+      );
+    });
 
     test('QUERY /_federated-types returns flat type summaries from multiple realms', async function (assert) {
       let response = await makeAuthenticatedRequest([

--- a/packages/realm-server/tests/types-endpoint-test.ts
+++ b/packages/realm-server/tests/types-endpoint-test.ts
@@ -236,10 +236,6 @@ module(basename(__filename), function () {
         sortCardTypeSummaries(instanceEntries),
         'instance summaries match expected fixture',
       );
-      // Files may or may not be present in this realistic fixture; the more
-      // specific file-presence assertions live in the dedicated FileDefs test
-      // below. Here we only insist that every entry on the response carries a
-      // `kind` discriminator.
       assert.ok(
         response.body.data.every(
           (entry: any) =>
@@ -247,6 +243,17 @@ module(basename(__filename), function () {
             entry.attributes.kind === 'file',
         ),
         'every summary entry carries an instance/file kind',
+      );
+      // The realistic fixture seeds `.md` files (sample.md, card-refs.md),
+      // so the response must include at least one `kind: 'file'` entry.
+      // Anchoring the test here protects against a regression that drops
+      // the `files` arm before `makeCardTypeSummaryDoc` emits the doc.
+      let fileEntries = response.body.data.filter(
+        (entry: any) => entry.attributes.kind === 'file',
+      );
+      assert.ok(
+        fileEntries.length > 0,
+        'response includes at least one kind: file entry from the indexed .md fixtures',
       );
     });
   });

--- a/packages/realm-server/tests/types-endpoint-test.ts
+++ b/packages/realm-server/tests/types-endpoint-test.ts
@@ -136,7 +136,7 @@ module(basename(__filename), function () {
           return aName.localeCompare(bName);
         });
       assert.strictEqual(response.status, 200, 'HTTP 200 status');
-      let expectedData = [
+      let instanceEntries = [
         {
           type: 'card-type-summary',
           id: `${testRealm.url}chess-gallery/ChessGallery`,
@@ -144,6 +144,7 @@ module(basename(__filename), function () {
             displayName: 'Chess Gallery',
             total: 3,
             iconHTML: chessIconHTML,
+            kind: 'instance' as const,
           },
         },
         {
@@ -153,6 +154,7 @@ module(basename(__filename), function () {
             displayName: 'Family Photo Card',
             total: 2,
             iconHTML,
+            kind: 'instance' as const,
           },
         },
         {
@@ -162,6 +164,7 @@ module(basename(__filename), function () {
             displayName: 'Friend',
             total: 2,
             iconHTML,
+            kind: 'instance' as const,
           },
         },
         {
@@ -171,6 +174,7 @@ module(basename(__filename), function () {
             displayName: 'FriendWithUsedLink',
             total: 2,
             iconHTML,
+            kind: 'instance' as const,
           },
         },
         {
@@ -180,6 +184,7 @@ module(basename(__filename), function () {
             displayName: 'Home',
             total: 1,
             iconHTML,
+            kind: 'instance' as const,
           },
         },
         {
@@ -189,6 +194,7 @@ module(basename(__filename), function () {
             displayName: 'Person',
             total: 3,
             iconHTML,
+            kind: 'instance' as const,
           },
         },
         {
@@ -198,6 +204,7 @@ module(basename(__filename), function () {
             displayName: 'Person',
             total: 4,
             iconHTML,
+            kind: 'instance' as const,
           },
         },
         {
@@ -207,6 +214,7 @@ module(basename(__filename), function () {
             displayName: 'Realm Config',
             total: 1,
             iconHTML: fileSettingsIconHTML,
+            kind: 'instance' as const,
           },
         },
         {
@@ -216,12 +224,29 @@ module(basename(__filename), function () {
             displayName: 'TimersCard',
             total: 1,
             iconHTML,
+            kind: 'instance' as const,
           },
         },
       ];
+      let actualInstances = response.body.data.filter(
+        (entry: any) => entry.attributes.kind === 'instance',
+      );
       assert.deepEqual(
-        sortCardTypeSummaries(response.body.data),
-        sortCardTypeSummaries(expectedData),
+        sortCardTypeSummaries(actualInstances),
+        sortCardTypeSummaries(instanceEntries),
+        'instance summaries match expected fixture',
+      );
+      // Files may or may not be present in this realistic fixture; the more
+      // specific file-presence assertions live in the dedicated FileDefs test
+      // below. Here we only insist that every entry on the response carries a
+      // `kind` discriminator.
+      assert.ok(
+        response.body.data.every(
+          (entry: any) =>
+            entry.attributes.kind === 'instance' ||
+            entry.attributes.kind === 'file',
+        ),
+        'every summary entry carries an instance/file kind',
       );
     });
   });

--- a/packages/runtime-common/document-types.ts
+++ b/packages/runtime-common/document-types.ts
@@ -1,6 +1,6 @@
 import type { RealmInfo } from './realm';
 import type { QueryResultsMeta, PrerenderedCard } from './index-query-engine';
-import type { CardTypeSummary } from './index-structure';
+import type { CardTypeSummary, RealmMetaValue } from './index-structure';
 import {
   type CardResource,
   type FileMetaResource,
@@ -162,17 +162,56 @@ export function transformResultsToPrerenderedCardsDoc(results: {
   };
 }
 
-export function makeCardTypeSummaryDoc(summaries: CardTypeSummary[]) {
-  let data = summaries.map((summary) => ({
+export type CardTypeSummaryKind = 'instance' | 'file';
+
+// JSON:API representation of one entry from `realm_meta.value`. Clients
+// partition the flat array by `kind` on read — see CardsGrid's
+// `loadFilterList`. Keeping a single resource shape with a discriminator
+// (rather than two parallel `data` arrays) preserves the existing contract for
+// callers that only care about one kind.
+export interface CardTypeSummaryEntry {
+  type: 'card-type-summary';
+  id: string;
+  attributes: {
+    displayName: string;
+    total: number;
+    iconHTML: string;
+    kind: CardTypeSummaryKind;
+  };
+}
+
+function summaryToEntry(
+  summary: CardTypeSummary,
+  kind: CardTypeSummaryKind,
+): CardTypeSummaryEntry {
+  return {
     type: 'card-type-summary',
     id: summary.code_ref,
     attributes: {
       displayName: summary.display_name,
       total: summary.total,
       iconHTML: summary.icon_html,
+      kind,
     },
-  }));
+  };
+}
 
+// Accepts either the partitioned RealmMetaValue (current shape) or a bare
+// CardTypeSummary[] (legacy callers that pre-filtered to instances). In both
+// cases the output is a flat list of entries discriminated by `kind`.
+export function makeCardTypeSummaryDoc(
+  summaries: RealmMetaValue | CardTypeSummary[],
+) {
+  let value: RealmMetaValue;
+  if (Array.isArray(summaries)) {
+    value = { instances: summaries, files: [] };
+  } else {
+    value = summaries;
+  }
+  let data: CardTypeSummaryEntry[] = [
+    ...value.instances.map((s) => summaryToEntry(s, 'instance')),
+    ...value.files.map((s) => summaryToEntry(s, 'file')),
+  ];
   return { data };
 }
 
@@ -183,6 +222,7 @@ export interface FederatedCardTypeSummaryEntry {
     displayName: string;
     total: number;
     iconHTML: string;
+    kind: CardTypeSummaryKind;
   };
   meta: {
     realmURL: string;

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -924,20 +924,25 @@ export class IndexQueryEngine {
   }
 
   async fetchCardTypeSummary(realmURL: URL): Promise<RealmMetaValue> {
-    // ORDER BY realm_version DESC + LIMIT 1 because `pruneObsoleteEntries`
-    // doesn't always reach stale rows — a from-scratch reindex resets the
-    // realm_version to a low number, so older incremental rows at higher
-    // versions survive the `realm_version < <new>` prune predicate. Without
-    // an explicit ordering Postgres can return any of them; that bug caused
-    // CardsGrid's "All Files" group to vanish on every realm whose latest
-    // index happened after a from-scratch and whose physical row order
-    // happened to put a legacy `array`-shape row first.
+    // JOIN against realm_versions.current_version so we always pick the
+    // realm_meta row that matches the realm's authoritative current
+    // version. Naive `SELECT … WHERE realm_url=…` returns an arbitrary
+    // row when stale rows linger (e.g., a from-scratch reindex resets
+    // the version to a low number, leaving older high-version rows that
+    // the legacy prune predicate `realm_version < <new>` never reaches).
+    // Ordering by `realm_version DESC` would actually pick the *wrong*
+    // row after a from-scratch — the highest version is the oldest.
+    // realm_versions is the system source of truth for "which version
+    // is current," so anchoring the read there is the robust fix.
     let results = (await this.#query([
-      `SELECT value
+      `SELECT rm.value
        FROM realm_meta rm
+       JOIN realm_versions rv
+         ON rv.realm_url = rm.realm_url
+        AND rv.current_version = rm.realm_version
        WHERE`,
       ...every([['rm.realm_url =', param(realmURL.href)]]),
-      `ORDER BY rm.realm_version DESC LIMIT 1`,
+      `LIMIT 1`,
     ] as Expression)) as { value: unknown }[];
 
     return normalizeRealmMetaValue(results[0]?.value);

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -55,11 +55,11 @@ import {
 } from './query';
 import type { SerializedError } from './error';
 import type { DBAdapter } from './db';
-import type { RealmMetaTable } from './index-structure';
 import {
   coerceTypes,
+  normalizeRealmMetaValue,
   type BoxelIndexTable,
-  type CardTypeSummary,
+  type RealmMetaValue,
 } from './index-structure';
 import {
   getFieldDef,
@@ -923,15 +923,15 @@ export class IndexQueryEngine {
     return usedRenderTypeColumnExpression;
   }
 
-  async fetchCardTypeSummary(realmURL: URL): Promise<CardTypeSummary[]> {
+  async fetchCardTypeSummary(realmURL: URL): Promise<RealmMetaValue> {
     let results = (await this.#query([
       `SELECT value
        FROM realm_meta rm
        WHERE`,
       ...every([['rm.realm_url =', param(realmURL.href)]]),
-    ] as Expression)) as Pick<RealmMetaTable, 'value'>[];
+    ] as Expression)) as { value: unknown }[];
 
-    return (results[0]?.value ?? []) as unknown as CardTypeSummary[];
+    return normalizeRealmMetaValue(results[0]?.value);
   }
 
   private filterCondition(filter: Filter, onRef: CodeRef): CardExpression {

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -924,11 +924,20 @@ export class IndexQueryEngine {
   }
 
   async fetchCardTypeSummary(realmURL: URL): Promise<RealmMetaValue> {
+    // ORDER BY realm_version DESC + LIMIT 1 because `pruneObsoleteEntries`
+    // doesn't always reach stale rows — a from-scratch reindex resets the
+    // realm_version to a low number, so older incremental rows at higher
+    // versions survive the `realm_version < <new>` prune predicate. Without
+    // an explicit ordering Postgres can return any of them; that bug caused
+    // CardsGrid's "All Files" group to vanish on every realm whose latest
+    // index happened after a from-scratch and whose physical row order
+    // happened to put a legacy `array`-shape row first.
     let results = (await this.#query([
       `SELECT value
        FROM realm_meta rm
        WHERE`,
       ...every([['rm.realm_url =', param(realmURL.href)]]),
+      `ORDER BY rm.realm_version DESC LIMIT 1`,
     ] as Expression)) as { value: unknown }[];
 
     return normalizeRealmMetaValue(results[0]?.value);

--- a/packages/runtime-common/index-runner/file-indexer.ts
+++ b/packages/runtime-common/index-runner/file-indexer.ts
@@ -194,7 +194,7 @@ export async function performFileIndexing({
       ...(extractResult.searchDoc ?? {}),
     },
     types: fileTypes,
-    displayNames: [],
+    displayNames: extractResult.displayNames ?? [],
     isolatedHtml: renderResult?.isolatedHTML ?? undefined,
     headHtml: renderResult?.headHTML ?? undefined,
     atomHtml: renderResult?.atomHTML ?? undefined,

--- a/packages/runtime-common/index-structure.ts
+++ b/packages/runtime-common/index-structure.ts
@@ -68,8 +68,8 @@ export interface CardTypeSummary {
 //
 // Legacy realms written before this column was partitioned stored `value` as a
 // bare `CardTypeSummary[]` (instances only). Readers should call
-// `normalizeRealmMetaValue` (see index-query-engine.ts) to tolerate that shape
-// during the transition until every realm has been reindexed.
+// `normalizeRealmMetaValue` (defined below) to tolerate that shape during the
+// transition until every realm has been reindexed.
 export interface RealmMetaValue {
   instances: CardTypeSummary[];
   files: CardTypeSummary[];

--- a/packages/runtime-common/index-structure.ts
+++ b/packages/runtime-common/index-structure.ts
@@ -60,11 +60,43 @@ export interface CardTypeSummary {
   icon_html: string;
 }
 
+// Top-level shape of `realm_meta.value`. `instances` summarizes CardDef rows
+// (boxel_index.type='instance') and `files` summarizes FileDef rows
+// (boxel_index.type='file'). Both arrays use the same per-type-summary shape.
+// CardsGrid's sidebar partitions these into the "All Cards" and "All Files"
+// top-level groups.
+//
+// Legacy realms written before this column was partitioned stored `value` as a
+// bare `CardTypeSummary[]` (instances only). Readers should call
+// `normalizeRealmMetaValue` (see index-query-engine.ts) to tolerate that shape
+// during the transition until every realm has been reindexed.
+export interface RealmMetaValue {
+  instances: CardTypeSummary[];
+  files: CardTypeSummary[];
+}
+
 export interface RealmMetaTable {
   realm_version: number;
   realm_url: string;
-  value: Record<string, string>[];
+  value: RealmMetaValue;
   indexed_at: string | null;
+}
+
+// Tolerate the legacy `value` shape (a bare CardTypeSummary[]) stored before
+// realm_meta was partitioned into instances/files. Once every realm has been
+// reindexed, the array branch becomes dead code and can be removed.
+export function normalizeRealmMetaValue(raw: unknown): RealmMetaValue {
+  if (!raw) {
+    return { instances: [], files: [] };
+  }
+  if (Array.isArray(raw)) {
+    return { instances: raw as CardTypeSummary[], files: [] };
+  }
+  let value = raw as Partial<RealmMetaValue>;
+  return {
+    instances: value.instances ?? [],
+    files: value.files ?? [],
+  };
 }
 
 export const coerceTypes = Object.freeze({

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -674,11 +674,22 @@ export class Batch {
   // for one kind of row in boxel_index_working — either CardDef instances or
   // FileDef files. The shape of the result rows matches `CardTypeSummary`
   // exactly, so callers can drop them straight into `realm_meta.value`.
+  //
+  // Grouping is by `code_ref` only (not also by display_name). Display name
+  // is aggregated with `MAX(...)`, which skips NULLs — so if some rows for
+  // a given code_ref carry a populated display_name (extracted by the
+  // current FileDefAttributesExtractor) and others carry an empty
+  // `display_names` array (extracted by older indexer code that hadn't
+  // shipped Step 2 yet), the rollup still produces a single summary row
+  // with the non-null label. Without this, CardsGrid's sidebar shows two
+  // entries for the same type — one labeled "Markdown", one labeled
+  // "MarkdownDef" (the CodeRef-name fallback) — that resolve to identical
+  // searches and confuse users during the transition window.
   async #fetchTypeSummary(
     indexType: BoxelIndexTable['type'],
   ): Promise<CardTypeSummary[]> {
     let results = await this.#query([
-      `SELECT CAST(count(DISTINCT i.url) AS INTEGER) as total, i.display_names->>0 as display_name, i.types->>0 as code_ref, MAX(i.icon_html) as icon_html
+      `SELECT CAST(count(DISTINCT i.url) AS INTEGER) as total, MAX(i.display_names->>0) as display_name, i.types->>0 as code_ref, MAX(i.icon_html) as icon_html
        FROM boxel_index_working as i
           WHERE`,
       ...every([
@@ -693,8 +704,8 @@ export class Batch {
         ],
         any([['i.is_deleted = false'], ['i.is_deleted IS NULL']]),
       ]),
-      `GROUP BY i.display_names->>0, i.types->>0`,
-      `ORDER BY i.display_names->>0 ASC`,
+      `GROUP BY i.types->>0`,
+      `ORDER BY MAX(i.display_names->>0) ASC NULLS LAST`,
     ] as Expression);
     return results as unknown as CardTypeSummary[];
   }

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -40,6 +40,7 @@ import type { TimingDiagnostics } from './index';
 import {
   coerceTypes,
   type BoxelIndexTable,
+  type CardTypeSummary,
   type RealmVersionsTable,
 } from './index-structure';
 import { v4 as uuidv4 } from '@lukeed/uuid';
@@ -640,31 +641,16 @@ export class Batch {
   }
 
   private async updateRealmMeta() {
-    let results = await this.#query([
-      `SELECT CAST(count(DISTINCT i.url) AS INTEGER) as total, i.display_names->>0 as display_name, i.types->>0 as code_ref, MAX(i.icon_html) as icon_html
-       FROM boxel_index_working as i
-          WHERE`,
-      ...every([
-        ['i.realm_url =', param(this.realmURL.href)],
-        ['i.type = ', param('instance')],
-        ['i.types IS NOT NULL'],
-        [
-          dbExpression({
-            pg: `(i.types->>0) IS NOT NULL`,
-            sqlite: `json_extract(i.types, '$[0]') IS NOT NULL`,
-          }),
-        ],
-        any([['i.is_deleted = false'], ['i.is_deleted IS NULL']]),
-      ]),
-      `GROUP BY i.display_names->>0, i.types->>0`,
-      `ORDER BY i.display_names->>0 ASC`,
-    ] as Expression);
+    let instances = await this.#fetchTypeSummary('instance');
+    let files = await this.#fetchTypeSummary('file');
+
+    let value = { instances, files };
 
     let { nameExpressions, valueExpressions } = asExpressions(
       {
         realm_url: this.realmURL.href,
         realm_version: this.realmVersion,
-        value: results,
+        value,
         indexed_at: unixTime(new Date().getTime()),
       } as Omit<RealmMetaTable, 'indexed_at'> & {
         indexed_at: number;
@@ -682,6 +668,35 @@ export class Batch {
         valueExpressions,
       ),
     ]);
+  }
+
+  // Aggregates per-type summaries (count, display name, code-ref key, icon)
+  // for one kind of row in boxel_index_working — either CardDef instances or
+  // FileDef files. The shape of the result rows matches `CardTypeSummary`
+  // exactly, so callers can drop them straight into `realm_meta.value`.
+  async #fetchTypeSummary(
+    indexType: BoxelIndexTable['type'],
+  ): Promise<CardTypeSummary[]> {
+    let results = await this.#query([
+      `SELECT CAST(count(DISTINCT i.url) AS INTEGER) as total, i.display_names->>0 as display_name, i.types->>0 as code_ref, MAX(i.icon_html) as icon_html
+       FROM boxel_index_working as i
+          WHERE`,
+      ...every([
+        ['i.realm_url =', param(this.realmURL.href)],
+        ['i.type = ', param(indexType)],
+        ['i.types IS NOT NULL'],
+        [
+          dbExpression({
+            pg: `(i.types->>0) IS NOT NULL`,
+            sqlite: `json_extract(i.types, '$[0]') IS NOT NULL`,
+          }),
+        ],
+        any([['i.is_deleted = false'], ['i.is_deleted IS NULL']]),
+      ]),
+      `GROUP BY i.display_names->>0, i.types->>0`,
+      `ORDER BY i.display_names->>0 ASC`,
+    ] as Expression);
+    return results as unknown as CardTypeSummary[];
   }
 
   private async applyBatchUpdates() {

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -743,11 +743,20 @@ export class Batch {
   }
 
   private async pruneObsoleteEntries() {
+    // Delete every realm_meta row for this realm except the one we just
+    // wrote. The previous predicate (`realm_version < this.realmVersion`)
+    // only swept rows from incremental indexing where versions march
+    // forward. A from-scratch reindex resets the version to a low number,
+    // leaving older high-version rows orphaned forever — those legacy rows
+    // then poisoned `_types` reads when the SELECT picked the wrong one.
+    // Cleaning by `!=` covers both directions safely; the unique key on
+    // (realm_url, realm_version) guarantees we never accidentally keep
+    // two current rows.
     await this.#query([
       `DELETE FROM realm_meta`,
       'WHERE',
       ...every([
-        ['realm_version <', param(this.realmVersion)],
+        ['realm_version !=', param(this.realmVersion)],
         ['realm_url =', param(this.realmURL.href)],
       ]),
     ] as Expression);

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -225,6 +225,10 @@ export interface FileExtractResponse {
   searchDoc: Record<string, any> | null;
   resource?: FileMetaResource | null;
   types?: string[] | null;
+  // Display names walked from the resolved FileDef subclass up its prototype
+  // chain (e.g. `['Markdown', 'File']`). Persisted as `boxel_index.display_names`
+  // so CardsGrid's "All Files" sidebar can label each subtype.
+  displayNames?: string[] | null;
   deps: string[];
   error?: RenderError;
   mismatch?: true;

--- a/packages/runtime-common/prerendered-card-search.ts
+++ b/packages/runtime-common/prerendered-card-search.ts
@@ -23,6 +23,12 @@ export interface PrerenderedCardLike {
   cardType?: string;
   iconHtml?: string;
   usedRenderType?: ResolvedCodeRef;
+  // True iff the prerender pipeline produced HTML for this row. Currently
+  // false for executable-module FileDef rows (`.gts`/`.ts`) because the
+  // fused visit skips the FileRender pass when `isModule` is true — see
+  // CS-11171. Consumers (e.g., CardList) can use this to render a fallback
+  // when html is missing so the row stays visible and clickable.
+  hasHtml?: boolean;
 }
 
 export interface PrerenderedCardComponentSignature {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -4662,40 +4662,64 @@ export class Realm {
     if (localPath === '') {
       localPath = 'index';
     }
-    localPath = localPath.replace(/\.json$/, '');
-    let url = this.paths.fileURL(localPath);
-    let entry = await this.#realmIndexQueryEngine.instance(url, {
+    let trimmedLocalPath = localPath.replace(/\.json$/, '');
+    let url = this.paths.fileURL(trimmedLocalPath);
+    let instanceEntry = await this.#realmIndexQueryEngine.instance(url, {
       includeErrors: true,
     });
-    if (!entry) {
-      if (await this.nonJsonFileExists(localPath)) {
-        return unsupportedMediaType(request, requestContext);
+    if (instanceEntry) {
+      if (instanceEntry.type === 'instance-error') {
+        return notAcceptable(
+          request,
+          requestContext,
+          `markdown representation unavailable: ${request.url} has an indexing error`,
+        );
       }
-      return notFound(request, requestContext);
-    }
-    if (entry.type === 'instance-error') {
-      return notAcceptable(
-        request,
-        requestContext,
-        `markdown representation unavailable: ${request.url} has an indexing error`,
-      );
-    }
-    if (entry.markdown == null) {
-      return notAcceptable(
-        request,
-        requestContext,
-        `markdown representation not available for ${request.url}`,
-      );
-    }
-    return createResponse({
-      body: entry.markdown,
-      init: {
-        headers: {
-          'content-type': 'text/markdown; charset=utf-8',
+      if (instanceEntry.markdown == null) {
+        return notAcceptable(
+          request,
+          requestContext,
+          `markdown representation not available for ${request.url}`,
+        );
+      }
+      return createResponse({
+        body: instanceEntry.markdown,
+        init: {
+          headers: {
+            'content-type': 'text/markdown; charset=utf-8',
+          },
         },
-      },
-      requestContext,
-    });
+        requestContext,
+      });
+    }
+    // No instance row — for FileDef rows (e.g. `.md`, `.csv`, `.gts`) the
+    // markdown lives on the `file` entry instead. Look the unstripped local
+    // path up against the file index before giving up. Without this branch
+    // CardsGrid's "Copy as Markdown" action 415s on any non-card file.
+    let fileURL = this.paths.fileURL(localPath);
+    let fileEntry = await this.#realmIndexQueryEngine.file(fileURL);
+    if (fileEntry) {
+      if (fileEntry.markdown == null) {
+        return notAcceptable(
+          request,
+          requestContext,
+          `markdown representation not available for ${request.url}`,
+        );
+      }
+      return createResponse({
+        body: fileEntry.markdown,
+        init: {
+          headers: {
+            'content-type': 'text/markdown; charset=utf-8',
+          },
+        },
+        requestContext,
+      });
+    }
+    if (await this.nonJsonFileExists(localPath)) {
+      return unsupportedMediaType(request, requestContext);
+    }
+    return notFound(request, requestContext);
   }
 
   private async removeCard(

--- a/packages/runtime-common/tests/normalize-realm-meta-value-test.ts
+++ b/packages/runtime-common/tests/normalize-realm-meta-value-test.ts
@@ -1,0 +1,73 @@
+import type { SharedTests } from '../helpers';
+import {
+  normalizeRealmMetaValue,
+  type CardTypeSummary,
+} from '../index-structure';
+
+const personSummary: CardTypeSummary = {
+  code_ref: 'http://example.test/realm/person/Person',
+  display_name: 'Person',
+  total: 3,
+  icon_html: '<svg />',
+};
+
+const markdownSummary: CardTypeSummary = {
+  code_ref: 'https://cardstack.com/base/markdown-file-def/MarkdownDef',
+  display_name: 'Markdown',
+  total: 5,
+  icon_html: '<svg />',
+};
+
+const tests = Object.freeze({
+  'undefined value normalizes to empty groups': async (assert) => {
+    let normalized = normalizeRealmMetaValue(undefined);
+    assert.deepEqual(normalized, { instances: [], files: [] });
+  },
+
+  'null value normalizes to empty groups': async (assert) => {
+    let normalized = normalizeRealmMetaValue(null);
+    assert.deepEqual(normalized, { instances: [], files: [] });
+  },
+
+  'legacy array shape maps to instances, files defaults to empty': async (
+    assert,
+  ) => {
+    // Realms indexed before realm_meta.value was partitioned stored a bare
+    // CardTypeSummary[] (instances only). Readers must accept that shape until
+    // every realm has been reindexed.
+    let normalized = normalizeRealmMetaValue([personSummary]);
+    assert.deepEqual(normalized, {
+      instances: [personSummary],
+      files: [],
+    });
+  },
+
+  'partitioned shape passes through': async (assert) => {
+    let value = { instances: [personSummary], files: [markdownSummary] };
+    let normalized = normalizeRealmMetaValue(value);
+    assert.deepEqual(normalized, value);
+  },
+
+  'missing arms default to empty arrays': async (assert) => {
+    // A partial object (e.g. data inserted by a test that only wrote one arm)
+    // shouldn't propagate undefined into consumers — both arms always exist on
+    // the normalized result.
+    let normalized = normalizeRealmMetaValue({ instances: [personSummary] });
+    assert.deepEqual(normalized, {
+      instances: [personSummary],
+      files: [],
+    });
+  },
+
+  'unrecognized object shape normalizes to empty groups': async (assert) => {
+    // Defensive: if some other writer parked an unrelated JSONB blob in
+    // realm_meta.value (older delete-realm test fixture used this), neither
+    // arm contains those rows but readers don't crash.
+    let normalized = normalizeRealmMetaValue({
+      somethingElse: { foo: 'bar' },
+    });
+    assert.deepEqual(normalized, { instances: [], files: [] });
+  },
+} as SharedTests<{}>);
+
+export default tests;


### PR DESCRIPTION
Linear: [CS-11170](https://linear.app/cardstack/issue/CS-11170/implement-include-filedefs-in-cardsgrid)
Project: [Include FileDefs in CardsGrid](https://linear.app/cardstack/project/include-filedefs-in-cardsgrid-302762ce6b78)

## Summary

Surfaces FileDef instances alongside CardDef instances in the CardsGrid sidebar. Implements the six-step plan from the Linear project description. The sidebar now shows two top-level groups — **All Cards** and **All Files** — each expandable to specific subtypes. Clicking a file opens it as an isolated stack item in interact-mode; editing remains in code-mode (a new "Open in Code Mode" affordance is added to the file kebab).

## What landed

- **Index pipeline** — `realm_meta.value` is now a `{ instances, files }` object instead of a bare array. `index-writer` runs the per-type aggregation via a new `#fetchTypeSummary` helper. `normalizeRealmMetaValue` tolerates the legacy array shape so this is a hot rollout, no DB migration, no required reindex (the next index run upgrades each realm in place).
- **File display names** — `FileExtractResponse` carries `displayNames` walked from the resolved FileDef class chain (new `getDisplayNames` helper in `FileDefAttributesExtractor`, mirroring the card-side meta route). `file-indexer` persists those to `boxel_index.display_names`.
- **`_types` endpoint** — `makeCardTypeSummaryDoc` emits a flat JSON:API list with a `kind: 'instance' | 'file'` discriminator. `FederatedCardTypeSummaryEntry` and host-side typings updated to match.
- **CardsGrid sidebar** — `cards-grid.gts` partitions `_types` results by `kind`, builds `fileTypeFilters`, and adds an `allFilesFilter` group that's hidden when the realm has no files. Base `FileDef` is excluded from the leaf list to avoid duplicating the group label.
- **File clicks → interact-mode** — Extracted `knownFileMetaUrls` to `host/app/lib/known-file-meta-urls.ts` (back-compat re-export from `prerendered-card-search.gts`). `detectStackItemTypeForTarget` consults the registry as a fallback so file URLs clicked from a freshly-loaded CardsGrid resolve to `'file'` stack items even before the file-meta resource has landed in the store. Added an "Open in Code Mode" entry to the interact-context file kebab menu.

## Test plan

- [x] Type-clean across `runtime-common`, `host`, `base`, `realm-server` for touched files.
- [x] Existing `realm-server/tests/types-endpoint-test.ts` updated to require the `kind` discriminator on every response entry.
- [x] New `host/tests/unit/index-writer-test.ts` case asserts file rows partition into `realm_meta.value.files`, collapse duplicates, and don't bleed into the instances arm.
- [x] New `normalize-realm-meta-value-test` covers the legacy array, partitioned object, partial shape, null/undefined, and unrecognized JSONB.
- [ ] **Manual:** boot a local realm with a markdown file, hit `/_types` and verify each entry has `attributes.kind`. Open CardsGrid in the realm and verify the All Files group appears, expanded clicks build a file-typed query, and clicking a result opens a file stack item with no edit button but with "Open in Code Mode" available.
- [ ] **Manual:** boot against an unmigrated realm (no reindex yet — `realm_meta.value` is still an array) and verify CardsGrid still renders All Cards correctly, no All Files group, no errors.

## Deferred (per project plan)

- Polish for the full set of FileDef isolated subtypes — MVP ships with `TextFileDef` / `JsonFileDef` / `MarkdownDef` polished; the rest land behind a follow-up.
- Binary-file (image/PDF) fallback isolated component — out of scope for this PR.


https://github.com/user-attachments/assets/35edeb03-4401-49ff-a150-3ee5f6b9b9e1


🤖 Generated with [Claude Code](https://claude.com/claude-code)