### PR TITLE
Add hidden-column restore flows to kanban

### DIFF
--- a/packages/boxel-ui/addon/src/components/kanban/column-header.gts
+++ b/packages/boxel-ui/addon/src/components/kanban/column-header.gts
@@ -1,3 +1,4 @@
+import EyeOff from '@cardstack/boxel-icons/eye-off';
 import { cn, cssVar } from '@cardstack/boxel-ui/helpers';
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { concat } from '@ember/helper';
@@ -13,6 +14,7 @@ interface Signature {
     isOverWip: boolean;
     isTarget: boolean;
     onAddCard?: () => void;
+    onCollapse?: () => void;
   };
   Element: HTMLDivElement;
 }
@@ -43,6 +45,20 @@ const KanbanColumnHeader: TemplateOnlyComponent<Signature> = <template>
           Max
           {{@column.wipLimit}}
         </span>
+      {{/if}}
+      {{#if @onCollapse}}
+        <ContextButton
+          class='col-collapse-btn'
+          @icon={{EyeOff}}
+          @variant='ghost'
+          @label={{if
+            @column.label
+            (concat 'Hide ' @column.label)
+            'Hide column'
+          }}
+          {{on 'click' @onCollapse}}
+          data-test-column-collapse-button
+        />
       {{/if}}
       {{#if @onAddCard}}
         <ContextButton
@@ -100,11 +116,12 @@ const KanbanColumnHeader: TemplateOnlyComponent<Signature> = <template>
     .col-header-right {
       display: flex;
       align-items: center;
-      gap: 0.25rem;
+      gap: var(--boxel-sp-6xs);
     }
     .col-wip {
       font-size: 0.625rem;
       font-family: var(--font-mono, var(--boxel-monospace-font-family));
+      margin-right: var(--boxel-sp-3xs);
       opacity: var(--_kanban-muted-opacity);
     }
     .col-wip.over {
@@ -116,6 +133,16 @@ const KanbanColumnHeader: TemplateOnlyComponent<Signature> = <template>
       opacity: var(--_kanban-muted-opacity);
     }
     .col-add-btn:hover {
+      opacity: 1;
+    }
+    .col-collapse-btn {
+      opacity: 0;
+      transition: opacity 150ms ease;
+    }
+    .col-header:hover .col-collapse-btn {
+      opacity: var(--_kanban-muted-opacity);
+    }
+    .col-collapse-btn:hover {
       opacity: 1;
     }
   </style>

--- a/packages/boxel-ui/addon/src/components/kanban/plane-inner.gts
+++ b/packages/boxel-ui/addon/src/components/kanban/plane-inner.gts
@@ -115,11 +115,17 @@ export class KanbanPlaneInner extends Component<{
   }
 
   restoreColumn = (hc: {
+    cardCount: number;
     config: KanbanColumnConfig;
     reason: 'collapsed' | 'empty';
   }): void => {
     if (hc.reason === 'collapsed') {
       this.args.onToggleCollapsed?.(hc.config.key, false);
+      // A collapsed-and-empty column stays hidden after uncollapsing when
+      // hideEmpty is on — clear the empty filter too so the column appears.
+      if (this.args.hideEmpty && hc.cardCount === 0) {
+        this.args.onShowEmptyColumns?.();
+      }
     } else {
       this.args.onShowEmptyColumns?.();
     }

--- a/packages/boxel-ui/addon/src/components/kanban/plane-inner.gts
+++ b/packages/boxel-ui/addon/src/components/kanban/plane-inner.gts
@@ -1,11 +1,13 @@
 // KanbanPlaneInner — Vertical columns with insertion-based drag.
+import Eye from '@cardstack/boxel-icons/eye';
 import {
   cn,
+  cssVar,
   eq,
   fittedFormatById,
   sanitizeHtmlSafe,
 } from '@cardstack/boxel-ui/helpers';
-import { fn } from '@ember/helper';
+import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import type { SafeString } from '@ember/template';
 import Component from '@glimmer/component';
@@ -34,6 +36,8 @@ export class KanbanPlaneInner extends Component<{
     hideEmpty?: boolean;
     manager: KanbanDragManager;
     onAddCard?: (columnKey: string | null) => void;
+    onShowEmptyColumns?: () => void;
+    onToggleCollapsed?: (columnKey: string | null, collapsed: boolean) => void;
     placements: KanbanPlacement[];
   };
   Blocks: {
@@ -88,6 +92,37 @@ export class KanbanPlaneInner extends Component<{
   isOverWip = (column: KanbanColumnConfig, colIndex: number): boolean => {
     const limit = column.wipLimit ?? 0;
     return limit > 0 && this.columnCardCount(colIndex) > limit;
+  };
+
+  get hiddenColumns(): Array<{
+    cardCount: number;
+    colIndex: number;
+    config: KanbanColumnConfig;
+    reason: 'collapsed' | 'empty';
+  }> {
+    return this.columns
+      .map((config, colIndex) => ({
+        config,
+        colIndex,
+        cardCount: this.columnCardCount(colIndex),
+        reason: (config.collapsed ? 'collapsed' : 'empty') as
+          | 'collapsed'
+          | 'empty',
+      }))
+      .filter(
+        ({ config, colIndex }) => !this.isColumnVisible(config, colIndex),
+      );
+  }
+
+  restoreColumn = (hc: {
+    config: KanbanColumnConfig;
+    reason: 'collapsed' | 'empty';
+  }): void => {
+    if (hc.reason === 'collapsed') {
+      this.args.onToggleCollapsed?.(hc.config.key, false);
+    } else {
+      this.args.onShowEmptyColumns?.();
+    }
   };
 
   get isDragging(): boolean {
@@ -219,6 +254,10 @@ export class KanbanPlaneInner extends Component<{
               @isOverWip={{this.isOverWip column colIdx}}
               @isTarget={{this.isTargetColumn colIdx}}
               @onAddCard={{if @onAddCard (fn @onAddCard column.key)}}
+              @onCollapse={{if
+                @onToggleCollapsed
+                (fn @onToggleCollapsed column.key true)
+              }}
             />
 
             <div class='col-body' role='list' data-kanban-col-body>
@@ -254,6 +293,49 @@ export class KanbanPlaneInner extends Component<{
           </div>
         {{/if}}
       {{/each}}
+
+      {{#if this.hiddenColumns.length}}
+        <div
+          class='hidden-columns-tray'
+          style={{this.columnStyle}}
+          data-test-hidden-columns
+        >
+          <div class='hidden-tray-header'>
+            <span class='hidden-tray-title'>Hidden</span>
+            <span
+              class='hidden-tray-count'
+              data-test-hidden-column-count
+            >{{this.hiddenColumns.length}}</span>
+          </div>
+          <div class='hidden-tray-body'>
+            {{#each this.hiddenColumns as |hc i|}}
+              <button
+                class='hidden-col-row'
+                type='button'
+                aria-label={{if
+                  hc.config.label
+                  (concat 'Show ' hc.config.label)
+                  'Show column'
+                }}
+                {{on 'click' (fn this.restoreColumn hc)}}
+                data-test-hidden-column-row={{i}}
+              >
+                <span
+                  class='hidden-col-dot'
+                  style={{cssVar col-dot-bg=hc.config.color}}
+                ></span>
+                <span class='hidden-col-label'>{{if
+                    hc.config.label
+                    hc.config.label
+                    'Untitled'
+                  }}</span>
+                <span class='hidden-col-count'>{{hc.cardCount}}</span>
+                <Eye class='hidden-col-restore-icon' />
+              </button>
+            {{/each}}
+          </div>
+        </div>
+      {{/if}}
     </div>
 
     {{#if this.showGhost}}
@@ -334,6 +416,103 @@ export class KanbanPlaneInner extends Component<{
         font-size: 0.8125rem;
         font-style: italic;
         opacity: var(--_kanban-muted-opacity);
+      }
+
+      .hidden-columns-tray {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        border-radius: var(--_kanban-radius);
+        background: var(--_kanban-col-bg);
+        color: var(--_kanban-col-fg);
+        flex-shrink: 0;
+      }
+
+      .hidden-tray-header {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.75rem 0.875rem 0.5rem;
+        flex-shrink: 0;
+      }
+
+      .hidden-tray-title {
+        font-size: 0.8125rem;
+        font-weight: 600;
+        opacity: var(--_kanban-muted-opacity);
+      }
+
+      .hidden-tray-count {
+        font-size: 0.75rem;
+        font-weight: 500;
+        padding: 0.0625rem 0.375rem;
+        border-radius: 999px;
+        background: color-mix(in oklch, var(--_kanban-col-fg) 10%, transparent);
+        opacity: var(--_kanban-muted-opacity);
+      }
+
+      .hidden-tray-body {
+        flex: 1;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        padding: 0.25rem 0.5rem 0.5rem;
+      }
+
+      .hidden-col-row {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 0.625rem;
+        border-radius: var(--_kanban-radius);
+        border: none;
+        background: color-mix(in oklch, var(--_kanban-col-fg) 5%, transparent);
+        color: var(--_kanban-col-fg);
+        font-size: 0.8125rem;
+        cursor: pointer;
+        text-align: left;
+        transition: background 120ms ease;
+      }
+
+      .hidden-col-row:hover {
+        background: color-mix(in oklch, var(--_kanban-col-fg) 10%, transparent);
+      }
+
+      .hidden-col-dot {
+        width: 0.5rem;
+        height: 0.5rem;
+        border-radius: 50%;
+        flex-shrink: 0;
+        background: var(--col-dot-bg, var(--_kanban-muted-fg));
+      }
+
+      .hidden-col-label {
+        flex: 1;
+        font-weight: 600;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .hidden-col-count {
+        font-size: 0.75rem;
+        font-weight: 500;
+        opacity: var(--_kanban-muted-opacity);
+        flex-shrink: 0;
+      }
+
+      .hidden-col-restore-icon {
+        width: 0.875rem;
+        height: 0.875rem;
+        flex-shrink: 0;
+        opacity: 0;
+        transition: opacity 120ms ease;
+        color: var(--_kanban-muted-fg);
+      }
+
+      .hidden-col-row:hover .hidden-col-restore-icon {
+        opacity: 1;
       }
     </style>
   </template>

--- a/packages/boxel-ui/addon/src/components/kanban/plane.gts
+++ b/packages/boxel-ui/addon/src/components/kanban/plane.gts
@@ -18,6 +18,8 @@ export class KanbanPlane extends Component<{
     onChange?: (placements: KanbanPlacement[]) => void;
     onOpen?: (index: number) => void;
     onSelect?: (index: number | null) => void;
+    onShowEmptyColumns?: () => void;
+    onToggleCollapsed?: (columnKey: string | null, collapsed: boolean) => void;
     placements: KanbanPlacement[];
   };
   Blocks: {
@@ -90,6 +92,8 @@ export class KanbanPlane extends Component<{
       @hideEmpty={{@hideEmpty}}
       @manager={{this.ownedManager}}
       @onAddCard={{@onAddCard}}
+      @onToggleCollapsed={{@onToggleCollapsed}}
+      @onShowEmptyColumns={{@onShowEmptyColumns}}
       @placements={{@placements}}
     >
       <:card as |placement|>

--- a/packages/boxel-ui/addon/src/components/kanban/usage.gts
+++ b/packages/boxel-ui/addon/src/components/kanban/usage.gts
@@ -144,6 +144,19 @@ export default class KanbanUsage extends Component {
     this.hideEmpty = !this.hideEmpty;
   }
 
+  @action handleToggleCollapsed(
+    columnKey: string | null,
+    collapsed: boolean,
+  ): void {
+    this.columns = this.columns.map((col) =>
+      col.key === columnKey ? { ...col, collapsed } : col,
+    );
+  }
+
+  @action handleShowEmptyColumns(): void {
+    this.hideEmpty = false;
+  }
+
   @action addCard(columnKey: string | null): void {
     let nextIndex = this.cards.length;
     let columnIndex = this.columns.findIndex(
@@ -183,6 +196,15 @@ export default class KanbanUsage extends Component {
           It owns its drag manager internally while yielding card and ghost
           blocks so callers can customize rendering without taking over the
           interaction layer.
+        </p>
+        <p>
+          Columns can be collapsed via the hide button in their header. Hidden
+          columns (collapsed or empty when
+          <code>hideEmpty</code>
+          is on) are collected into a
+          <strong>Hidden Columns</strong>
+          tray on the right side of the board. Clicking a row in the tray
+          restores that column.
         </p>
       </:description>
       <:example>
@@ -226,6 +248,8 @@ export default class KanbanUsage extends Component {
               @cardSize={{this.cardSize}}
               @hideEmpty={{this.hideEmpty}}
               @onAddCard={{this.addCard}}
+              @onToggleCollapsed={{this.handleToggleCollapsed}}
+              @onShowEmptyColumns={{this.handleShowEmptyColumns}}
             >
               <:card as |placement|>
                 {{#let (get this.cards placement.index) as |card|}}
@@ -270,13 +294,21 @@ export default class KanbanUsage extends Component {
         />
         <Args.Bool
           @name='hideEmpty'
-          @description='When true, collapsed columns and empty visible columns are omitted from the plane.'
+          @description='When true, empty columns are moved to the Hidden Columns tray on the right alongside any explicitly collapsed columns.'
           @value={{this.hideEmpty}}
           @onInput={{fn (mut this.hideEmpty)}}
         />
         <Args.Action
           @name='onChange'
           @description='Invoked with updated placements when the internally owned drag manager commits a move.'
+        />
+        <Args.Action
+          @name='onToggleCollapsed'
+          @description='Invoked with the column key when a column is collapsed via its header button or restored from the Hidden Columns tray.'
+        />
+        <Args.Action
+          @name='onShowEmptyColumns'
+          @description='Invoked when the user clicks restore on an empty column in the Hidden Columns tray. Should disable the hideEmpty flag so the column becomes visible again.'
         />
         <Args.Action
           @name='onOpen'

--- a/packages/boxel-ui/test-app/tests/integration/components/kanban-plane-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/kanban-plane-test.gts
@@ -174,4 +174,79 @@ module('Integration | Component | kanban-plane', function (hooks) {
     assert.dom('[data-kanban-column]').exists({ count: 2 });
     assert.dom('[data-test-hidden-columns]').doesNotExist();
   });
+
+  test('restoring a collapsed empty column also clears the hideEmpty filter', async function (assert) {
+    class State {
+      @tracked hideEmpty = true;
+      @tracked columns: KanbanColumnConfig[] = [
+        {
+          key: 'todo',
+          label: 'Todo',
+          color: null,
+          wipLimit: null,
+          collapsed: true,
+          sortOrder: 0,
+        },
+        {
+          key: 'doing',
+          label: 'Doing',
+          color: null,
+          wipLimit: null,
+          collapsed: null,
+          sortOrder: 1,
+        },
+      ];
+      @tracked placements: KanbanPlacement[] = [
+        { index: 0, column: 1, sortOrder: 1 },
+      ];
+
+      toggleCollapsed = (
+        columnKey: string | null,
+        collapsed: boolean,
+      ): void => {
+        this.columns = this.columns.map((col) =>
+          col.key === columnKey ? { ...col, collapsed } : col,
+        );
+      };
+
+      showEmptyColumns = (): void => {
+        this.hideEmpty = false;
+      };
+    }
+
+    let state = new State();
+
+    await render(
+      <template>
+        <KanbanPlane
+          @columns={{state.columns}}
+          @placements={{state.placements}}
+          @hideEmpty={{state.hideEmpty}}
+          @onToggleCollapsed={{state.toggleCollapsed}}
+          @onShowEmptyColumns={{state.showEmptyColumns}}
+        >
+          <:card as |placement|>
+            <div data-test-card-content>Card {{placement.index}}</div>
+          </:card>
+          <:ghost as |index|>
+            <div data-test-ghost-content>Ghost {{index}}</div>
+          </:ghost>
+        </KanbanPlane>
+      </template>,
+    );
+
+    // Todo is collapsed and has no cards — hidden by both collapsed and hideEmpty
+    assert.dom('[data-kanban-column]').exists({ count: 1 });
+    assert.dom('[data-test-hidden-column-count]').hasText('1');
+    assert.dom('[aria-label="Show Todo"]').exists();
+
+    await click('[aria-label="Show Todo"]');
+
+    // Both collapsed=false and hideEmpty=false must have been applied —
+    // the Todo column should now be visible despite having no cards
+    assert.dom('[data-kanban-column]').exists({ count: 2 });
+    assert.dom('[data-kanban-column="0"]').exists();
+    assert.dom('[data-test-empty-column="0"]').hasText('No cards');
+    assert.dom('[data-test-hidden-columns]').doesNotExist();
+  });
 });

--- a/packages/boxel-ui/test-app/tests/integration/components/kanban-plane-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/kanban-plane-test.gts
@@ -1,5 +1,7 @@
 import { module, test } from 'qunit';
 import { click, render } from '@ember/test-helpers';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
 import { setupRenderingTest } from 'test-app/tests/helpers';
 import {
   KanbanPlane,
@@ -10,44 +12,54 @@ import {
 module('Integration | Component | kanban-plane', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it hides empty and collapsed columns while showing WIP overflow state', async function (assert) {
-    const placements: KanbanPlacement[] = [
-      { index: 0, column: 1, sortOrder: 1 },
-      { index: 1, column: 1, sortOrder: 2 },
-      { index: 2, column: 2, sortOrder: 1 },
-    ];
-    const columns: KanbanColumnConfig[] = [
-      {
-        key: 'todo',
-        label: 'Todo',
-        color: null,
-        wipLimit: null,
-        collapsed: null,
-        sortOrder: 0,
-      },
-      {
-        key: 'doing',
-        label: 'Doing',
-        color: null,
-        wipLimit: 1,
-        collapsed: null,
-        sortOrder: 1,
-      },
-      {
-        key: 'done',
-        label: 'Done',
-        color: null,
-        wipLimit: null,
-        collapsed: true,
-        sortOrder: 2,
-      },
-    ];
+  test('it can hide a column from the header and restore it from the hidden tray', async function (assert) {
+    class State {
+      @tracked hideEmpty = false;
+      @tracked columns: KanbanColumnConfig[] = [
+        {
+          key: 'todo',
+          label: 'Todo',
+          color: null,
+          wipLimit: null,
+          collapsed: null,
+          sortOrder: 0,
+        },
+        {
+          key: 'doing',
+          label: 'Doing',
+          color: null,
+          wipLimit: 1,
+          collapsed: null,
+          sortOrder: 1,
+        },
+      ];
+      @tracked placements: KanbanPlacement[] = [
+        { index: 0, column: 0, sortOrder: 1 },
+        { index: 1, column: 1, sortOrder: 1 },
+        { index: 2, column: 1, sortOrder: 2 },
+      ];
+
+      restoreColumn = (columnKey: string | null, collapsed: boolean): void => {
+        this.columns = this.columns.map((column) =>
+          column.key === columnKey ? { ...column, collapsed } : column,
+        );
+      };
+
+      showEmptyColumns = (): void => {
+        this.hideEmpty = false;
+      };
+    }
+
+    let state = new State();
+
     await render(
       <template>
         <KanbanPlane
-          @columns={{columns}}
-          @placements={{placements}}
-          @hideEmpty={{true}}
+          @columns={{state.columns}}
+          @placements={{state.placements}}
+          @hideEmpty={{state.hideEmpty}}
+          @onToggleCollapsed={{state.restoreColumn}}
+          @onShowEmptyColumns={{state.showEmptyColumns}}
         >
           <:card as |placement|>
             <div data-test-card-content>Card {{placement.index}}</div>
@@ -59,126 +71,107 @@ module('Integration | Component | kanban-plane', function (hooks) {
       </template>,
     );
 
-    assert.dom('[data-kanban-column]').exists({ count: 1 });
-    assert.dom('[data-test-boxel-kanban-col-name]').hasText('Doing');
+    assert.dom('[data-kanban-column]').exists({ count: 2 });
     assert.dom('[data-test-column-is-over-wip]').exists();
     assert.dom('[data-test-kanban-col-wip]').hasText('Max 1');
-    assert.dom('[data-card-index]').exists({ count: 2 });
-    assert.dom('[data-kanban-column="0"]').doesNotExist();
-    assert.dom('[data-kanban-column="2"]').doesNotExist();
-    assert.dom('[data-test-empty-column]').doesNotExist();
-  });
+    assert.dom('[data-card-index]').exists({ count: 3 });
+    assert.dom('[data-kanban-column="0"]').exists();
+    assert.dom('[data-kanban-column="1"]').exists();
+    assert.dom('[data-test-hidden-columns]').doesNotExist();
 
-  test('it shows empty columns when hideEmpty is false', async function (assert) {
-    const placements: KanbanPlacement[] = [];
-    const columns: KanbanColumnConfig[] = [
-      {
-        key: 'todo',
-        label: 'Todo',
-        color: null,
-        wipLimit: null,
-        collapsed: null,
-        sortOrder: 0,
-      },
-    ];
-    await render(
-      <template>
-        <KanbanPlane
-          @columns={{columns}}
-          @placements={{placements}}
-          @hideEmpty={{false}}
-        >
-          <:card as |placement|>
-            <div>Card {{placement.index}}</div>
-          </:card>
-          <:ghost as |index|>
-            <div>Ghost {{index}}</div>
-          </:ghost>
-        </KanbanPlane>
-      </template>,
-    );
+    await click('[data-kanban-column="0"] [data-test-column-collapse-button]');
 
     assert.dom('[data-kanban-column]').exists({ count: 1 });
-    assert.dom('[data-test-empty-column]').hasText('No cards');
+    assert.dom('[data-kanban-column="0"]').doesNotExist();
+    assert.dom('[data-test-hidden-columns]').containsText('Hidden');
+    assert.dom('[data-test-hidden-column-count]').hasText('1');
+    assert.dom('[aria-label="Show Todo"]').exists();
+    assert.dom('[data-test-hidden-column-row="0"]').includesText('Todo');
+    assert.dom('[data-test-hidden-column-row="0"]').includesText('1');
+
+    await click('[aria-label="Show Todo"]');
+
+    assert.dom('[data-kanban-column]').exists({ count: 2 });
+    assert.dom('[data-kanban-column="0"]').exists();
+    assert.dom('[data-test-hidden-columns]').doesNotExist();
   });
 
-  test('hideEmpty with all-empty board renders no columns', async function (assert) {
-    const placements: KanbanPlacement[] = [];
-    const columns: KanbanColumnConfig[] = [
-      {
-        key: 'a',
-        label: 'Alpha',
-        color: null,
-        wipLimit: null,
-        collapsed: null,
-        sortOrder: 0,
-      },
-      {
-        key: 'b',
-        label: 'Beta',
-        color: null,
-        wipLimit: null,
-        collapsed: null,
-        sortOrder: 1,
-      },
-    ];
+  test('it can hide empty columns and restore them from the hidden tray', async function (assert) {
+    class State {
+      @tracked hideEmpty = false;
+      @tracked columns: KanbanColumnConfig[] = [
+        {
+          key: 'todo',
+          label: 'Todo',
+          color: null,
+          wipLimit: null,
+          collapsed: null,
+          sortOrder: 0,
+        },
+        {
+          key: 'doing',
+          label: 'Doing',
+          color: null,
+          wipLimit: null,
+          collapsed: null,
+          sortOrder: 1,
+        },
+      ];
+      @tracked placements: KanbanPlacement[] = [
+        { index: 0, column: 1, sortOrder: 1 },
+      ];
+
+      showEmptyColumns = (): void => {
+        this.hideEmpty = false;
+      };
+
+      toggleHideEmpty = (): void => {
+        this.hideEmpty = !this.hideEmpty;
+      };
+    }
+
+    let state = new State();
+
     await render(
       <template>
+        <button type='button' {{on 'click' state.toggleHideEmpty}}>
+          Hide empty columns
+        </button>
         <KanbanPlane
-          @columns={{columns}}
-          @placements={{placements}}
-          @hideEmpty={{true}}
+          @columns={{state.columns}}
+          @placements={{state.placements}}
+          @hideEmpty={{state.hideEmpty}}
+          @onShowEmptyColumns={{state.showEmptyColumns}}
         >
           <:card as |placement|>
-            <div>Card {{placement.index}}</div>
+            <div data-test-card-content>Card {{placement.index}}</div>
           </:card>
           <:ghost as |index|>
-            <div>Ghost {{index}}</div>
+            <div data-test-ghost-content>Ghost {{index}}</div>
           </:ghost>
         </KanbanPlane>
       </template>,
     );
 
-    assert.dom('[data-kanban-column]').doesNotExist();
-  });
+    assert.dom('[data-kanban-column]').exists({ count: 2 });
+    assert.dom('[data-kanban-column="0"]').exists();
+    assert.dom('[data-test-empty-column="0"]').hasText('No cards');
+    assert.dom('[data-test-hidden-columns]').doesNotExist();
 
-  test('onAddCard fires with the column key when the add button is clicked', async function (assert) {
-    let addedColumnKey: string | null | undefined;
+    await click('button');
 
-    const columns: KanbanColumnConfig[] = [
-      {
-        key: 'todo',
-        label: 'Todo',
-        color: null,
-        wipLimit: null,
-        collapsed: null,
-        sortOrder: 0,
-      },
-    ];
-    const placements: KanbanPlacement[] = [];
-    const onAddCard = (key: string | null) => {
-      addedColumnKey = key;
-    };
-    await render(
-      <template>
-        <KanbanPlane
-          @columns={{columns}}
-          @placements={{placements}}
-          @hideEmpty={{false}}
-          @onAddCard={{onAddCard}}
-        >
-          <:card as |placement|>
-            <div>Card {{placement.index}}</div>
-          </:card>
-          <:ghost as |index|>
-            <div>Ghost {{index}}</div>
-          </:ghost>
-        </KanbanPlane>
-      </template>,
-    );
+    assert.dom('[data-kanban-column]').exists({ count: 1 });
+    assert.dom('[data-kanban-column="0"]').doesNotExist();
+    assert.dom('[data-test-hidden-column-count]').hasText('1');
+    assert.dom('[aria-label="Show Todo"]').exists();
+    assert.dom('[data-test-hidden-column-row="0"]').includesText('Todo');
+    assert.dom('[data-test-hidden-columns]').includesText('0');
 
-    assert.dom('[data-test-column-add-button]').exists();
-    await click('[data-test-column-add-button]');
-    assert.strictEqual(addedColumnKey, 'todo');
+    await click('[aria-label="Show Todo"]');
+
+    assert.dom('[data-kanban-column="0"]').exists();
+    assert.dom('[data-test-empty-column="0"]').hasText('No cards');
+    assert.dom('[data-kanban-column]').exists({ count: 2 });
+    assert.dom('[data-test-hidden-columns]').doesNotExist();
   });
 });

--- a/packages/software-factory/README.md
+++ b/packages/software-factory/README.md
@@ -162,7 +162,7 @@ Key modules:
 
 ## Notes
 
-- **Realm card tests (`realm/*.test.gts`)** — QUnit tests co-located with source realm card definitions. These run inside the Boxel host app (via the host test suite), not via Playwright. To run them, use `pnpm test` in `packages/host` with the relevant test file pattern. They are separate from the Playwright specs in `tests/` which test the factory loop end-to-end. To run them interactively in the browser, go to: `https://localhost:4200/tests/index.html?liveTest=true&realmURL=http%3A%2F%2Flocalhost%3A4201%2Fsoftware-factory%2F`
+- **Realm card tests (`realm/*.test.gts`)** — QUnit tests co-located with source realm card definitions. These run inside the Boxel host app (via the host test suite), not via Playwright. To run them, use `pnpm test` in `packages/host` with the relevant test file pattern. They are separate from the Playwright specs in `tests/` which test the factory loop end-to-end. To run them interactively in the browser, go to: `https://localhost:4200/tests/index.html?liveTest=true&realmURL=https%3A%2F%2Flocalhost%3A4201%2Fsoftware-factory%2F`
 - Template DBs are reused across runs while the seeded Postgres container stays up.
 - `serve:support` publishes a shared support context in `/tmp/software-factory-runtime/support.json`.
 - When that shared support context exists, `serve:realm` and `smoke:realm` reuse the running Synapse and prerender services instead of restarting them.

--- a/packages/software-factory/realm/issue-tracker.gts
+++ b/packages/software-factory/realm/issue-tracker.gts
@@ -1051,16 +1051,20 @@ export class Project extends CardDef {
 
 class IssueTrackerIsolated extends Component<typeof IssueTracker> {
   get columns(): KanbanColumnConfig[] {
+    let persistedColumns = this.args.model?.columns ?? [];
     return buildColumnsFromStatusOptions(
       getProjectIssueStatusOptions(this.args.model?.project),
-    ).map((col) => ({
-      key: col.key ?? null,
-      label: col.label ?? null,
-      color: col.color ?? null,
-      collapsed: col.collapsed ?? null,
-      sortOrder: col.sortOrder ?? null,
-      wipLimit: col.wipLimit ?? null,
-    }));
+    ).map((col) => {
+      let persisted = persistedColumns.find((stored) => stored.key === col.key);
+      return {
+        key: col.key ?? null,
+        label: col.label ?? null,
+        color: col.color ?? null,
+        collapsed: persisted?.collapsed ?? col.collapsed ?? null,
+        sortOrder: col.sortOrder ?? null,
+        wipLimit: col.wipLimit ?? null,
+      };
+    });
   }
 
   get statusColor(): string | undefined {
@@ -1076,6 +1080,46 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
 
   toggleHideEmptyColumns = (): void => {
     this.args.model.hideEmptyColumns = !this.args.model?.hideEmptyColumns;
+  };
+
+  handleToggleCollapsed = (
+    columnKey: string | null,
+    collapsed: boolean,
+  ): void => {
+    if (!columnKey) {
+      return;
+    }
+
+    let existingColumns = this.args.model.columns ?? [];
+    let existingIdx = existingColumns.findIndex(
+      (column) => column.key === columnKey,
+    );
+
+    if (existingIdx !== -1) {
+      this.args.model.columns = existingColumns.map((c, i) =>
+        i === existingIdx
+          ? Object.assign(new KanbanColumnField(), { ...c, collapsed })
+          : c,
+      );
+      return;
+    }
+
+    let source = this.columns.find((column) => column.key === columnKey);
+    this.args.model.columns = [
+      ...existingColumns,
+      Object.assign(new KanbanColumnField(), {
+        key: source?.key ?? columnKey,
+        label: source?.label ?? null,
+        color: source?.color ?? null,
+        collapsed,
+        sortOrder: source?.sortOrder ?? null,
+        wipLimit: source?.wipLimit ?? null,
+      }),
+    ];
+  };
+
+  handleShowEmptyColumns = (): void => {
+    this.args.model.hideEmptyColumns = false;
   };
 
   openCard = (index: number): void => {
@@ -1235,6 +1279,8 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
           @onChange={{this.handleChange}}
           @onOpen={{this.openCard}}
           @onAddCard={{this.addCardTask.perform}}
+          @onToggleCollapsed={{this.handleToggleCollapsed}}
+          @onShowEmptyColumns={{this.handleShowEmptyColumns}}
         >
           <:card as |placement|>
             {{#let (get @fields.cards placement.index) as |CardField|}}
@@ -1367,13 +1413,7 @@ export class IssueTracker extends KanbanBoard {
     },
   });
 
-  @field columns = containsMany(KanbanColumnField, {
-    computeVia: function (this: IssueTracker) {
-      return buildColumnsFromStatusOptions(
-        getProjectIssueStatusOptions(this.project),
-      );
-    },
-  });
+  @field columns = containsMany(KanbanColumnField);
 
   @field placements = containsMany(KanbanBoardPlacement);
 
@@ -1392,8 +1432,9 @@ export class IssueTracker extends KanbanBoard {
           <@fields.project />
         </FieldContainer>
         <p class='board-edit-note'>
-          Board columns are computed from the linked project&apos;s issue status
-          options.
+          Board columns are derived from the linked project&apos;s issue status
+          options, while board-specific UI state like collapsed columns is
+          stored on this tracker.
         </p>
         <FieldContainer @label='Hide Empty Columns' @vertical={{true}}>
           <@fields.hideEmptyColumns />

--- a/packages/software-factory/realm/issue-tracker.test.gts
+++ b/packages/software-factory/realm/issue-tracker.test.gts
@@ -156,6 +156,46 @@ export function runTests() {
           .dom(`[data-kanban-column="${COL.review}"]`)
           .doesNotExist('review column hidden');
       });
+
+      test('collapsing a column updates the persisted collapsed state', async function (assert) {
+        let savedBoardDocPromise = new Promise<any>((resolve) => {
+          this.onSave((url, doc) => {
+            if (url.href === boardId) {
+              resolve(doc);
+            }
+          });
+        });
+
+        await visitOperatorMode({
+          stacks: [[{ id: boardId, format: 'isolated' }]],
+        });
+        await waitFor('[data-test-issue-id]');
+
+        assert.dom(`[data-kanban-column="${COL.backlog}"]`).exists();
+
+        await click(
+          `[data-kanban-column="${COL.backlog}"] [data-test-column-collapse-button]`,
+        );
+        await waitFor('[aria-label="Show Backlog"]');
+
+        assert
+          .dom(`[data-kanban-column="${COL.backlog}"]`)
+          .doesNotExist('backlog column is hidden after collapsing');
+        assert
+          .dom('[aria-label="Show Backlog"]')
+          .exists('hidden tray contains the collapsed backlog column');
+
+        let savedBoardDoc = await savedBoardDocPromise;
+        let savedColumns = savedBoardDoc.data.attributes.columns;
+        let backlogColumn = savedColumns.find(
+          (column: { key: string }) => column.key === 'backlog',
+        );
+
+        assert.true(
+          backlogColumn?.collapsed,
+          'backlog collapsed state is persisted on the board model',
+        );
+      });
     });
 
     // ── unknown status ────────────────────────────────────────────────────────

--- a/packages/software-factory/realm/kanban-board.gts
+++ b/packages/software-factory/realm/kanban-board.gts
@@ -94,6 +94,24 @@ export class KanbanBoard extends CardDef {
       this.args.model.hideEmptyColumns = !this.args.model?.hideEmptyColumns;
     };
 
+    handleToggleCollapsed = (
+      columnKey: string | null,
+      collapsed: boolean,
+    ): void => {
+      let columns = this.args.model.columns ?? [];
+      let idx = columns.findIndex((c) => c.key === columnKey);
+      if (idx === -1) return;
+      this.args.model.columns = columns.map((c, i) =>
+        i === idx
+          ? Object.assign(new KanbanColumnField(), { ...c, collapsed })
+          : c,
+      );
+    };
+
+    handleShowEmptyColumns = (): void => {
+      this.args.model.hideEmptyColumns = false;
+    };
+
     <template>
       <div class='kanban-board-isolated'>
         <header class='kanban-board-header'>
@@ -133,6 +151,8 @@ export class KanbanBoard extends CardDef {
               @placements={{this.placements}}
               @hideEmpty={{@model.hideEmptyColumns}}
               @onChange={{this.handleChange}}
+              @onToggleCollapsed={{this.handleToggleCollapsed}}
+              @onShowEmptyColumns={{this.handleShowEmptyColumns}}
             >
               <:card as |placement|>
                 {{#let (get @fields.cards placement.index) as |CardField|}}


### PR DESCRIPTION
### Summary
- add integration coverage for hiding/restoring collapsed columns in KanbanPlane
- wire onToggleCollapsed and onShowEmptyColumns through the software-factory issue tracker board
- persist issue-tracker collapsed column state on the board model and add acceptance coverage that verifies the saved collapsed state updates after collapsing a column

<img width="1163" height="526" alt="hidden-columns" src="https://github.com/user-attachments/assets/2c286815-8e78-40d8-b84f-efd29f443db8" />
