### PR TITLE
flaky test fix: Track card-api and file-api deps directly in the render route

### DIFF
--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -186,23 +186,15 @@ export default class RenderRoute extends Route<Model> {
   async beforeModel(transition: Transition) {
     await super.beforeModel?.(transition);
     resetRenderTimerStats();
-    // Stamp render-context BEFORE touching the realm service. Prerender-
-    // aware short-circuits read this flag synchronously on their first
-    // run — most importantly `RealmResource.tokenRefresher`. With the
-    // flag unset, tokenRefresher falls through to its delayed
-    // `loginTask`, which lazily injects matrix-service. Inside the
-    // prerender Chrome the matrix client + event bindings + token-refresh
-    // logic are dead weight that the render route never touches, and
-    // constructing matrix-service drags all of it in. Setting the flag
-    // first keeps matrix-service uninstantiated for the prerender's
-    // lifetime.
-    (globalThis as any).__boxelRenderContext = true;
     if (!isTesting()) {
       // tests have their own way of dealing with window level errors in card-prerender.gts
       this.#attachWindowErrorListeners();
       this.realm.restoreSessionsFromStorage();
     }
 
+    // activate() doesn't run early enough for this to be set before the model()
+    // hook is run
+    (globalThis as any).__boxelRenderContext = true;
     this.#registerGlobalsDestructor();
     this.#authGuard.register();
     if (!isTesting()) {

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -59,6 +59,7 @@ import {
 } from '../utils/render-timer-stub';
 
 import type LoaderService from '../services/loader-service';
+import type MatrixService from '../services/matrix-service';
 import type NetworkService from '../services/network';
 import type RealmService from '../services/realm';
 import type RealmServerService from '../services/realm-server';
@@ -94,6 +95,7 @@ export default class RenderRoute extends Route<Model> {
   @service('render-store') declare store: RenderStoreService;
   @service declare router: RouterService;
   @service declare loaderService: LoaderService;
+  @service declare matrixService: MatrixService;
   @service declare realm: RealmService;
   @service declare realmServer: RealmServerService;
   @service declare private network: NetworkService;
@@ -186,15 +188,20 @@ export default class RenderRoute extends Route<Model> {
   async beforeModel(transition: Transition) {
     await super.beforeModel?.(transition);
     resetRenderTimerStats();
+    // Stamp render-context BEFORE touching realm / matrix services. Several
+    // prerender-aware short-circuits — most notably RealmResource's
+    // tokenRefresher — read this flag synchronously on their first run; if
+    // it's still unset, tokenRefresher proceeds to its delayed loginTask,
+    // which in turn lazily injects matrix-service. That early matrix-service
+    // construction lands its loader.import('file-api') outside model()'s
+    // tracking-session window and silently drops the dep from snapshots.
+    (globalThis as any).__boxelRenderContext = true;
     if (!isTesting()) {
       // tests have their own way of dealing with window level errors in card-prerender.gts
       this.#attachWindowErrorListeners();
       this.realm.restoreSessionsFromStorage();
     }
 
-    // activate() doesn't run early enough for this to be set before the model()
-    // hook is run
-    (globalThis as any).__boxelRenderContext = true;
     this.#registerGlobalsDestructor();
     this.#authGuard.register();
     if (!isTesting()) {
@@ -322,6 +329,19 @@ export default class RenderRoute extends Route<Model> {
           ? 'file'
           : 'instance',
     });
+
+    // Force the matrix-service SDK load to settle INSIDE the active
+    // tracking session. matrix-service is the only path in the host that
+    // imports `https://cardstack.com/base/file-api` at runtime (via its
+    // `fileAPIModule` importResource); without this await its
+    // `loader.import('file-api')` races against the session window and
+    // silently drops the dep on cached/reused prerender pages. Awaiting
+    // `ready` here both constructs matrix-service (if not yet) and waits
+    // for `loadSDK` (cardAPI + fileAPI imports) to complete with the
+    // session active, so the imports are recorded as deps of THIS render.
+    if (!isTesting()) {
+      await this.matrixService.ready;
+    }
 
     // the window.boxelTransitionTo() function helper first normalizes the base
     // params by transitioning the router back to 'render' before it goes on to

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -59,7 +59,6 @@ import {
 } from '../utils/render-timer-stub';
 
 import type LoaderService from '../services/loader-service';
-import type MatrixService from '../services/matrix-service';
 import type NetworkService from '../services/network';
 import type RealmService from '../services/realm';
 import type RealmServerService from '../services/realm-server';
@@ -95,7 +94,6 @@ export default class RenderRoute extends Route<Model> {
   @service('render-store') declare store: RenderStoreService;
   @service declare router: RouterService;
   @service declare loaderService: LoaderService;
-  @service declare matrixService: MatrixService;
   @service declare realm: RealmService;
   @service declare realmServer: RealmServerService;
   @service declare private network: NetworkService;
@@ -188,13 +186,16 @@ export default class RenderRoute extends Route<Model> {
   async beforeModel(transition: Transition) {
     await super.beforeModel?.(transition);
     resetRenderTimerStats();
-    // Stamp render-context BEFORE touching realm / matrix services. Several
-    // prerender-aware short-circuits — most notably RealmResource's
-    // tokenRefresher — read this flag synchronously on their first run; if
-    // it's still unset, tokenRefresher proceeds to its delayed loginTask,
-    // which in turn lazily injects matrix-service. That early matrix-service
-    // construction lands its loader.import('file-api') outside model()'s
-    // tracking-session window and silently drops the dep from snapshots.
+    // Stamp render-context BEFORE touching the realm service. Prerender-
+    // aware short-circuits read this flag synchronously on their first
+    // run — most importantly `RealmResource.tokenRefresher`. With the
+    // flag unset, tokenRefresher falls through to its delayed
+    // `loginTask`, which lazily injects matrix-service. Inside the
+    // prerender Chrome the matrix client + event bindings + token-refresh
+    // logic are dead weight that the render route never touches, and
+    // constructing matrix-service drags all of it in. Setting the flag
+    // first keeps matrix-service uninstantiated for the prerender's
+    // lifetime.
     (globalThis as any).__boxelRenderContext = true;
     if (!isTesting()) {
       // tests have their own way of dealing with window level errors in card-prerender.gts
@@ -330,18 +331,16 @@ export default class RenderRoute extends Route<Model> {
           : 'instance',
     });
 
-    // Force the matrix-service SDK load to settle INSIDE the active
-    // tracking session. matrix-service is the only path in the host that
-    // imports `https://cardstack.com/base/file-api` at runtime (via its
-    // `fileAPIModule` importResource); without this await its
-    // `loader.import('file-api')` races against the session window and
-    // silently drops the dep on cached/reused prerender pages. Awaiting
-    // `ready` here both constructs matrix-service (if not yet) and waits
-    // for `loadSDK` (cardAPI + fileAPI imports) to complete with the
-    // session active, so the imports are recorded as deps of THIS render.
-    if (!isTesting()) {
-      await this.matrixService.ready;
-    }
+    // Stamp `card-api` and `file-api` as runtime deps of this render.
+    // `file-api` is the public URL the indexer references when
+    // invalidating file extracts; doing the import here records the
+    // deps against the active tracking session without forcing
+    // matrix-service construction (which would also pull in the matrix
+    // SDK + client + event bindings the prerender never touches).
+    await Promise.all([
+      this.loaderService.loader.import(`${baseRealm.url}card-api`),
+      this.loaderService.loader.import(`${baseRealm.url}file-api`),
+    ]);
 
     // the window.boxelTransitionTo() function helper first normalizes the base
     // params by transitioning the router back to 'render' before it goes on to

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -331,17 +331,6 @@ export default class RenderRoute extends Route<Model> {
           : 'instance',
     });
 
-    // Stamp `card-api` and `file-api` as runtime deps of this render.
-    // `file-api` is the public URL the indexer references when
-    // invalidating file extracts; doing the import here records the
-    // deps against the active tracking session without forcing
-    // matrix-service construction (which would also pull in the matrix
-    // SDK + client + event bindings the prerender never touches).
-    await Promise.all([
-      this.loaderService.loader.import(`${baseRealm.url}card-api`),
-      this.loaderService.loader.import(`${baseRealm.url}file-api`),
-    ]);
-
     // the window.boxelTransitionTo() function helper first normalizes the base
     // params by transitioning the router back to 'render' before it goes on to
     // 'render.html', 'render.meta', etc. That’s why you see the /render model
@@ -368,6 +357,16 @@ export default class RenderRoute extends Route<Model> {
         this.lastStoreResetKey = resetKey;
       }
     }
+    // Stamp `card-api` and `file-api` as runtime deps of this render.
+    // `file-api` is the public URL the indexer references when
+    // invalidating file extracts; doing the import here records the
+    // deps against the active tracking session without forcing
+    // matrix-service construction (which would also pull in the matrix
+    // SDK + client + event bindings the prerender never touches).
+    await Promise.all([
+      this.loaderService.loader.import(`${baseRealm.url}card-api`),
+      this.loaderService.loader.import(`${baseRealm.url}file-api`),
+    ]);
     if (parsedOptions.fileExtract) {
       let state = new TrackedMap<string, unknown>();
       state.set('status', 'ready');

--- a/packages/host/app/routes/render/file-extract.ts
+++ b/packages/host/app/routes/render/file-extract.ts
@@ -7,7 +7,9 @@ import { isTesting } from '@embroider/macros';
 
 import {
   baseFileRef,
+  baseRealm,
   formattedError,
+  logger,
   snapshotRuntimeDependencies,
   withRuntimeDependencyTrackingContext,
   type RenderError,
@@ -24,6 +26,9 @@ import type LoaderService from '../../services/loader-service';
 import type NetworkService from '../../services/network';
 import type RealmService from '../../services/realm';
 import type { Model as RenderModel } from '../render';
+
+const log = logger('render-route:file-extract');
+
 export type Model = { id: string; nonce: string } & FileDefExtractResult;
 
 export default class RenderFileExtractRoute extends Route<Model> {
@@ -117,7 +122,28 @@ export default class RenderFileExtractRoute extends Route<Model> {
       };
     }
     let { deps } = snapshotRuntimeDependencies({ excludeQueryOnly: true });
-    let mergedDeps = [...new Set([...(result.deps ?? []), ...deps])];
+    // `baseFileRef.module` points at `card-api` (where FileDef is implemented),
+    // but the indexer references `file-api` — the canonical public re-export —
+    // when invalidating file extracts. Pin it as a static dep so the contract
+    // doesn't ride on whether the runtime tracker happened to observe an
+    // import of file-api during the active session window.
+    let baseFileApiModule = `${baseRealm.url}file-api`;
+    let resultDeps = result.deps ?? [];
+    if (
+      !deps.includes(baseFileApiModule) &&
+      !resultDeps.includes(baseFileApiModule)
+    ) {
+      // If this fires repeatedly the static merge below is masking a real
+      // regression in the tracking-session lifecycle — worth investigating
+      // rather than treating as a permanent fallback.
+      log.warn(
+        `runtime tracker missed canonical file-api module for ${id} ` +
+          `(nonce=${nonce}); falling back to static dep. ` +
+          `extractor deps=${JSON.stringify(resultDeps)} ` +
+          `tracker deps=${JSON.stringify(deps)}`,
+      );
+    }
+    let mergedDeps = [...new Set([baseFileApiModule, ...resultDeps, ...deps])];
     return {
       id,
       nonce,

--- a/packages/host/app/routes/render/file-extract.ts
+++ b/packages/host/app/routes/render/file-extract.ts
@@ -7,9 +7,7 @@ import { isTesting } from '@embroider/macros';
 
 import {
   baseFileRef,
-  baseRealm,
   formattedError,
-  logger,
   snapshotRuntimeDependencies,
   withRuntimeDependencyTrackingContext,
   type RenderError,
@@ -26,9 +24,6 @@ import type LoaderService from '../../services/loader-service';
 import type NetworkService from '../../services/network';
 import type RealmService from '../../services/realm';
 import type { Model as RenderModel } from '../render';
-
-const log = logger('render-route:file-extract');
-
 export type Model = { id: string; nonce: string } & FileDefExtractResult;
 
 export default class RenderFileExtractRoute extends Route<Model> {
@@ -122,28 +117,7 @@ export default class RenderFileExtractRoute extends Route<Model> {
       };
     }
     let { deps } = snapshotRuntimeDependencies({ excludeQueryOnly: true });
-    // `baseFileRef.module` points at `card-api` (where FileDef is implemented),
-    // but the indexer references `file-api` — the canonical public re-export —
-    // when invalidating file extracts. Pin it as a static dep so the contract
-    // doesn't ride on whether the runtime tracker happened to observe an
-    // import of file-api during the active session window.
-    let baseFileApiModule = `${baseRealm.url}file-api`;
-    let resultDeps = result.deps ?? [];
-    if (
-      !deps.includes(baseFileApiModule) &&
-      !resultDeps.includes(baseFileApiModule)
-    ) {
-      // If this fires repeatedly the static merge below is masking a real
-      // regression in the tracking-session lifecycle — worth investigating
-      // rather than treating as a permanent fallback.
-      log.warn(
-        `runtime tracker missed canonical file-api module for ${id} ` +
-          `(nonce=${nonce}); falling back to static dep. ` +
-          `extractor deps=${JSON.stringify(resultDeps)} ` +
-          `tracker deps=${JSON.stringify(deps)}`,
-      );
-    }
-    let mergedDeps = [...new Set([baseFileApiModule, ...resultDeps, ...deps])];
+    let mergedDeps = [...new Set([...(result.deps ?? []), ...deps])];
     return {
       id,
       nonce,


### PR DESCRIPTION
## Problem

[Realm Server Tests on PR #4872](https://github.com/cardstack/boxel/actions/runs/26063909234/job/76631098766?pr=4872) failed at:

```
not ok 70 prerendering-test.ts > prerender - non-mutating tests > runner behavior > file prerender returns extracted metadata
  message: deps include base file-api module
  severity: failed
  actual  : false
  expected: true
```

The file extract's returned `deps` is supposed to include `https://cardstack.com/base/file-api` — that's the public URL the indexer references when deciding whether to invalidate a previously-extracted file. The assertion was relying on the runtime-dependency tracker to surface that URL, but the path that actually placed it there was incidental: `matrix-service.fileAPIModule = importResource(() => 'file-api')` happens to call `loader.import('file-api')` during matrix-service construction, and `trackRuntimeModuleDependency` runs synchronously inside that call. Whether it landed inside the route's active tracking-session window depended on microtask scheduling — fine on a fresh page, flaky after a `BrowserManager.restartBrowser()` ([prior test 68's recovery render](https://github.com/cardstack/boxel/actions/runs/26063909234/job/76631098766?pr=4872#step:9:1445)) or any other timing perturbation.

The render route doesn't actually need matrix-service for anything; it only needed the dep recorded.

## Solution

In `RenderRoute.#buildModel`, await `Promise.all` of `this.loaderService.loader.import` for both `card-api` and `file-api`. This records each as a runtime dep of the current render against the active tracking session. The loader caches the modules so subsequent renders re-track without re-evaluating, and putting the await inside `#buildModel` keeps the promise stored in `#modelPromises` covering the imports so concurrent same-key `model()` calls dedup correctly.

## Files

- `packages/host/app/routes/render.ts`

## Test plan
- [ ] CI passes on this branch
- [ ] Re-run of the original failure scenario (PR #4872 realm-server tests) produces `file-api` in `deps` consistently