### PR TITLE
Grafana indexing dashboard: Delete on Active Indexing + CORS fix

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/indexing.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/indexing.json
@@ -718,8 +718,57 @@
               },
               "properties": [
                 {
-                  "id": "custom.hidden",
-                  "value": true
+                  "id": "actions",
+                  "value": [
+                    {
+                      "type": "fetch",
+                      "title": "Delete reservation ${__value.raw}",
+                      "fetch": {
+                        "method": "POST",
+                        "url": "${realm_server}_grafana-complete-job",
+                        "queryParams": [
+                          [
+                            "reservation_id",
+                            "${__value.raw}"
+                          ]
+                        ],
+                        "headers": [
+                          [
+                            "Authorization",
+                            "Bearer ${grafana_secret}"
+                          ]
+                        ],
+                        "body": ""
+                      },
+                      "confirmation": "Cancel running reservation ${__value.raw}? The worker will stop processing it.",
+                      "oneClick": false
+                    }
+                  ]
+                },
+                {
+                  "id": "mappings",
+                  "value": [
+                    {
+                      "options": {
+                        "from": 0,
+                        "result": {
+                          "color": "red",
+                          "index": 0,
+                          "text": "Delete"
+                        },
+                        "to": 9999999999999
+                      },
+                      "type": "range"
+                    }
+                  ]
+                },
+                {
+                  "id": "displayName",
+                  "value": "Action"
+                },
+                {
+                  "id": "custom.filterable",
+                  "value": false
                 }
               ]
             },

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -395,7 +395,7 @@ export class RealmServer {
         cors({
           origin: '*',
           allowHeaders:
-            'Authorization, Content-Type, If-Match, If-None-Match, X-Requested-With, X-Boxel-Client-Request-Id, X-Boxel-Assume-User, X-HTTP-Method-Override, X-Boxel-Disable-Module-Cache, X-Filename, X-Boxel-During-Prerender, X-Boxel-Consuming-Realm, X-Boxel-Job-Id, X-Grafana-Device-Id',
+            'Authorization, Content-Type, If-Match, If-None-Match, X-Requested-With, X-Boxel-Client-Request-Id, X-Boxel-Assume-User, X-HTTP-Method-Override, X-Boxel-Disable-Module-Cache, X-Filename, X-Boxel-During-Prerender, X-Boxel-Consuming-Realm, X-Boxel-Job-Id, X-Grafana-Device-Id, X-Grafana-Action',
           allowMethods: 'GET,HEAD,PUT,POST,DELETE,PATCH,OPTIONS,QUERY',
           // Cache the preflight response for 24 h. Without this @koa/cors
           // omits Access-Control-Max-Age and Chrome falls back to its


### PR DESCRIPTION
## Summary

Two related fixes bundled in one PR:

1. **Add Delete button to the Active Indexing panel** (`indexing.json`)
   The Active Indexing panel had `reservation_id` as a hidden column. Surface it as a red "Delete" action, identical in shape to the Pending/Queued Indexing Jobs and Running Jobs patterns. The button POSTs to the existing `_grafana-complete-job` endpoint with `reservation_id`, which routes through `forceCancelJobById` to stop the in-flight worker.

2. **Fix CORS preflight failure on every "Delete" button in Grafana** (`server.ts`)
   Grafana's table-cell `"type": "fetch"` action automatically adds an `x-grafana-action: fieldActions` request header. The realm server's `@koa/cors` allowlist didn't include it, so every cross-origin click failed preflight with:
   ```
   Request header field x-grafana-action is not allowed by Access-Control-Allow-Headers in preflight response.
   ```
   Adding `X-Grafana-Action` to `allowHeaders` unblocks all four affected buttons at once:
   - `job-queue.json` → Waiting Jobs → Delete
   - `job-queue.json` → Running Jobs → Delete
   - `indexing.json` → Queued Indexing Jobs → Delete
   - `indexing.json` → Active Indexing → Delete *(new in this PR)*

   Other Grafana operator actions in `users.json` use inline `customCode` with plain `fetch(...)`, which doesn't add that header, so they were unaffected.

## Test plan

- [ ] Apply staging dashboards (`grafanactl resources push`) and confirm Active Indexing now shows a red Delete column instead of hidden `reservation_id`.
- [ ] Click Delete on a row in `dashboard-staging.stack.cards` → Active Indexing → reservation is force-cancelled, no CORS error in console.
- [ ] Re-click Delete on `Waiting Jobs` (job-queue) → succeeds (no more CORS preflight failure).
- [ ] Re-click Delete on `Queued Indexing Jobs` (indexing) → succeeds.
- [ ] Re-click Delete on `Running Jobs` (job-queue) → succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)