### PR TITLE
Fix flaky 'broadcasts realm events' tests by waiting for both index events

### DIFF
--- a/packages/realm-server/tests/helpers/indexing.ts
+++ b/packages/realm-server/tests/helpers/indexing.ts
@@ -23,18 +23,42 @@ export async function waitForIncrementalIndexEvent(
   since: number,
   timeout = 5000,
 ) {
+  // The initiation and completion events are broadcast without await
+  // ordering (see Realm#sendIndexInitiationEvent + broadcastIncrementalInvalidationEvent),
+  // so matrix sync can surface them in either order. Wait until BOTH are
+  // visible so callers that re-fetch and assert on each event don't race.
+  let lastSeenInitiation = false;
+  let lastSeenIncremental = false;
   await waitUntil(
     async () => {
       let matrixMessages = await getMessagesSince(since);
-
-      return matrixMessages.some(
-        (m) =>
-          m.type === APP_BOXEL_REALM_EVENT_TYPE &&
-          m.content.eventName === 'index' &&
-          m.content.indexType === 'incremental',
-      );
+      let sawInitiation = false;
+      let sawIncremental = false;
+      for (let m of matrixMessages) {
+        if (
+          m.type !== APP_BOXEL_REALM_EVENT_TYPE ||
+          m.content.eventName !== 'index'
+        ) {
+          continue;
+        }
+        if (m.content.indexType === 'incremental-index-initiation') {
+          sawInitiation = true;
+        } else if (m.content.indexType === 'incremental') {
+          sawIncremental = true;
+        }
+        if (sawInitiation && sawIncremental) {
+          return true;
+        }
+      }
+      lastSeenInitiation = sawInitiation;
+      lastSeenIncremental = sawIncremental;
+      return false;
     },
-    { timeout },
+    {
+      timeout,
+      timeoutMessage: () =>
+        `incremental index events not both received (initiation=${lastSeenInitiation}, incremental=${lastSeenIncremental}, since=${since})`,
+    },
   );
 }
 
@@ -85,10 +109,29 @@ export async function expectIncrementalIndexEvent(
     ? trimJsonExtension(targetUrl)
     : targetUrl;
 
-  if (!incrementalIndexInitiationEventContent) {
-    throw new Error('Incremental index initiation event not found');
-  }
-  if (!incrementalEventContent) {
+  if (!incrementalIndexInitiationEventContent || !incrementalEventContent) {
+    let realmEventSummary = messages
+      .filter((m) => m.type === APP_BOXEL_REALM_EVENT_TYPE)
+      .map((m) => ({
+        eventName: (m.content as { eventName?: string })?.eventName,
+        indexType: (m.content as { indexType?: string })?.indexType,
+        updatedFile: (m.content as { updatedFile?: string })?.updatedFile,
+        invalidations: (m.content as { invalidations?: string[] })
+          ?.invalidations,
+        originServerTs: m.origin_server_ts,
+      }));
+    console.error(
+      `[expectIncrementalIndexEvent] missing event(s) for url=${url} since=${since} realm=${realm}. ` +
+        `initiationPresent=${Boolean(
+          incrementalIndexInitiationEventContent,
+        )} incrementalPresent=${Boolean(
+          incrementalEventContent,
+        )}. realm events seen (${realmEventSummary.length}): ` +
+        JSON.stringify(realmEventSummary),
+    );
+    if (!incrementalIndexInitiationEventContent) {
+      throw new Error('Incremental index initiation event not found');
+    }
     throw new Error('Incremental event content not found');
   }
   assert.deepEqual(incrementalIndexInitiationEventContent, {

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -2214,18 +2214,32 @@ async function waitForIncrementalIndexEvent(
   try {
     await waitUntil(async () => {
       let matrixMessages = await getMessagesSince(since);
-
-      return matrixMessages.some(
-        (m) =>
-          m.type === APP_BOXEL_REALM_EVENT_TYPE &&
-          m.content.eventName === 'index' &&
-          m.content.indexType === 'incremental',
-      );
+      let sawInitiation = false;
+      let sawIncremental = false;
+      for (let m of matrixMessages) {
+        if (
+          m.type !== APP_BOXEL_REALM_EVENT_TYPE ||
+          m.content.eventName !== 'index'
+        ) {
+          continue;
+        }
+        if (m.content.indexType === 'incremental-index-initiation') {
+          sawInitiation = true;
+        } else if (m.content.indexType === 'incremental') {
+          sawIncremental = true;
+        }
+        if (sawInitiation && sawIncremental) {
+          return true;
+        }
+      }
+      return false;
     });
   } catch (e) {
     let matrixMessages = await getMessagesSince(since);
 
-    console.log('waitForIncrementalIndexEvent failed, no event found. Events:');
+    console.log(
+      'waitForIncrementalIndexEvent failed: at least one of the initiation or incremental event was missing. Events:',
+    );
     console.log(JSON.stringify(matrixMessages, null, 2));
     throw e;
   }

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -42,7 +42,6 @@ import {
   makeTestReconciler,
   matrixRegistrationSecret,
   testRealmInfo,
-  waitUntil,
   testRealmHref,
   createJWT,
   cardInfo,
@@ -51,7 +50,10 @@ import {
   type RealmRequest,
   withRealmPath,
 } from './helpers';
-import { expectIncrementalIndexEvent } from './helpers/indexing';
+import {
+  expectIncrementalIndexEvent,
+  waitForIncrementalIndexEvent,
+} from './helpers/indexing';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import { RealmServer } from '../server';
 import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
@@ -2206,44 +2208,6 @@ module(basename(__filename), function () {
     });
   });
 });
-
-async function waitForIncrementalIndexEvent(
-  getMessagesSince: (since: number) => Promise<MatrixEvent[]>,
-  since: number,
-) {
-  try {
-    await waitUntil(async () => {
-      let matrixMessages = await getMessagesSince(since);
-      let sawInitiation = false;
-      let sawIncremental = false;
-      for (let m of matrixMessages) {
-        if (
-          m.type !== APP_BOXEL_REALM_EVENT_TYPE ||
-          m.content.eventName !== 'index'
-        ) {
-          continue;
-        }
-        if (m.content.indexType === 'incremental-index-initiation') {
-          sawInitiation = true;
-        } else if (m.content.indexType === 'incremental') {
-          sawIncremental = true;
-        }
-        if (sawInitiation && sawIncremental) {
-          return true;
-        }
-      }
-      return false;
-    });
-  } catch (e) {
-    let matrixMessages = await getMessagesSince(since);
-
-    console.log(
-      'waitForIncrementalIndexEvent failed: at least one of the initiation or incremental event was missing. Events:',
-    );
-    console.log(JSON.stringify(matrixMessages, null, 2));
-    throw e;
-  }
-}
 
 function findRealmEvent(
   events: MatrixEvent[],


### PR DESCRIPTION
## Summary
- The `broadcasts realm events` tests in `card-source-endpoints-test.ts` and `realm-endpoints-test.ts` intermittently fail with `Incremental index initiation event not found` (seen in [run 26105757476](https://github.com/cardstack/boxel/actions/runs/26105757476/job/76769629695)).
- Root cause: the initiation and completion realm events are broadcast without await ordering, so matrix sync can surface them in either order. The wait helper polled only for the completion event, then the caller re-fetched and asserted on both — racing on the initiation event still being in flight.
- Fix: wait until *both* `incremental-index-initiation` and `incremental` events are visible before returning. Same fix applied in both copies of the helper.
- Diagnostic logging added in case the fix doesn't fully land: the throw path now logs the realm events actually seen, and the wait timeout message reports which of the two events were observed at timeout.

## Test plan
- [ ] Re-run the Realm Server Tests shard 4 in CI; `card source DELETE request > public writable realm > broadcasts realm events` and the sibling cases should pass consistently.
- [ ] If a future flake recurs, the realm-server log will include a `[expectIncrementalIndexEvent] missing event(s) …` line (or the timeout message variant) listing what was visible, so we can distinguish a real missing-event bug from sync ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)