### PR TITLE
Drop dangling isWorldReadable() call from Realm#startup

### DIFF
--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2486,10 +2486,6 @@ export class Realm {
         }
       }
       this.#readinessDiag.debug(
-        `startup awaiting isWorldReadable for realm ${this.url}`,
-      );
-      await this.isWorldReadable();
-      this.#readinessDiag.debug(
         `startup complete for realm ${this.url} in ${Date.now() - startTime}ms`,
       );
     } finally {


### PR DESCRIPTION
## Summary
- `packages/runtime-common/realm.ts:2491` calls `await this.isWorldReadable()`, but `isWorldReadable` is no longer a method on `Realm` — it was removed in #4868 (CS-11126). `lint:types` on main currently fails with `TS2339: Property 'isWorldReadable' does not exist on type 'Realm'`.
- Removes the call and its companion `[readiness-diag]` "startup awaiting isWorldReadable" log line; keeps the "startup complete" marker.

## How the regression slipped in
PR #4868 deleted the `isWorldReadable()` method and its boot-time warmup (commit message: "Removes the boot-time `await this.isWorldReadable()` warmup"). Between that branch being cut and merged, commit af826c6 ("CI flake diagnostics: readiness-check + startup phase logging") landed on main and wrapped the same `await this.isWorldReadable()` line in new debug log calls. The merge resolved textually but kept the wrapped call, undoing that single deletion.

## Test plan
- [x] `pnpm --filter @cardstack/runtime-common lint:types` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)