### PR TITLE
indexer: clear has_error / error_doc on tombstone + write-boundary invariant

### DIFF
--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1436,6 +1436,110 @@ module(basename(__filename), function () {
         );
       });
 
+      test('batch invalidation clears has_error and error_doc when tombstoning a previously-errored row', async function (assert) {
+        // The primary key is `(url, realm_url, type)` — no `realm_version` —
+        // so a tombstone upsert always collides with the prior row for the
+        // same URL. Any column NOT in the tombstone upsert's SET list keeps
+        // its previous value. Before this guard, `has_error` and `error_doc`
+        // were not in that list, so an errored row stayed errored across
+        // every subsequent reindex even after the file was deleted —
+        // producing a "has_error = true, error_doc = jsonb null" shape
+        // that propagates forever and is invisible to UI / DB triage.
+        let mangoURL = new URL(`${testRealm}mango.json`);
+
+        // 1. Plant an error row in boxel_index by writing an
+        //    instance-error entry and committing the batch.
+        let errorBatch = await new IndexWriter(testDbAdapter).createBatch(
+          new URL(realm.url),
+        );
+        await errorBatch.updateEntry(mangoURL, {
+          type: 'instance-error',
+          error: {
+            id: mangoURL.href,
+            status: 500,
+            title: 'synthetic test error',
+            message: 'synthetic test error to verify tombstone clears it',
+            additionalErrors: null,
+          },
+        });
+        await errorBatch.done();
+
+        let plantedRows = (await testDbAdapter.execute(
+          `SELECT has_error, error_doc
+             FROM boxel_index
+             WHERE realm_url = $1 AND url = $2 AND type = 'instance'`,
+          { bind: [realm.url, mangoURL.href] },
+        )) as { has_error: boolean; error_doc: unknown }[];
+        assert.strictEqual(plantedRows.length, 1, 'planted row is present');
+        assert.true(
+          plantedRows[0].has_error,
+          'planted row carries has_error = true',
+        );
+        assert.ok(plantedRows[0].error_doc, 'planted row has an error_doc');
+
+        // 2. Tombstone the URL.
+        let tombstoneBatch = await new IndexWriter(testDbAdapter).createBatch(
+          new URL(realm.url),
+        );
+        await tombstoneBatch.invalidate([mangoURL]);
+        await tombstoneBatch.done();
+
+        // 3. The resulting row must be tombstoned AND have the stale
+        //    error state cleared, not preserved by the upsert.
+        let postRows = (await testDbAdapter.execute(
+          `SELECT is_deleted, has_error, error_doc
+             FROM boxel_index
+             WHERE realm_url = $1 AND url = $2 AND type = 'instance'`,
+          { bind: [realm.url, mangoURL.href] },
+        )) as {
+          is_deleted: boolean;
+          has_error: boolean;
+          error_doc: unknown;
+        }[];
+        assert.strictEqual(postRows.length, 1, 'tombstone row is present');
+        assert.true(postRows[0].is_deleted, 'row is marked is_deleted');
+        assert.false(
+          postRows[0].has_error,
+          'tombstone clears has_error from prior errored state',
+        );
+        assert.strictEqual(
+          postRows[0].error_doc,
+          null,
+          'tombstone clears error_doc from prior errored state',
+        );
+      });
+
+      test('updateEntry refuses to write an instance-error entry with no error.message', async function (assert) {
+        // Defense at the write boundary: a row with `has_error = true`
+        // and `error_doc` that lacks a human-readable message is a
+        // black hole for triage (the UI surface, the worker stderr,
+        // and the DB all show nothing useful). Throw here so the
+        // worker reservation can finalize against the per-job cap
+        // instead of silently writing the unusable row.
+        let batch = await new IndexWriter(testDbAdapter).createBatch(
+          new URL(realm.url),
+        );
+
+        for (let badError of [
+          undefined,
+          {},
+          { status: 500, additionalErrors: null },
+          { message: '', status: 500, additionalErrors: null },
+        ]) {
+          await assert.rejects(
+            batch.updateEntry(new URL(`${testRealm}mango.json`), {
+              type: 'instance-error',
+              // The cast is required because the type system already
+              // forbids these shapes — the runtime guard exists for
+              // the path where bad data slips past TypeScript.
+              error: badError as never,
+            }),
+            /indexer refused instance-error entry/,
+            `rejected error shape: ${JSON.stringify(badError)}`,
+          );
+        }
+      });
+
       test('can incrementally index updated instance', async function (assert) {
         await realm.write(
           'mango.json',

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -394,6 +394,28 @@ export class Batch {
       // drop this band-aid
       return;
     }
+    // An instance-error / file-error entry whose `.error.message` is
+    // empty would persist as a row with `has_error = true` and an
+    // error_doc that is null or missing the human-readable text. Such
+    // a row is invisible to UI and DB-only triage, and historically
+    // produced indexing jobs that re-reserved indefinitely without
+    // ever rejecting. Throw at the boundary so the caller's stderr log
+    // carries the underlying render error and the worker can finalize
+    // the reservation against the per-job cap instead of silently
+    // writing a black-hole row.
+    if (
+      isErrorEntry(entry) &&
+      (!entry.error ||
+        typeof entry.error.message !== 'string' ||
+        entry.error.message.length === 0)
+    ) {
+      throw new Error(
+        `indexer refused ${entry.type} entry for ${url.href}: ` +
+          `error.message is empty. An upstream entry-construction site dropped ` +
+          `the underlying render error. Check worker stderr for the actual ` +
+          `failure text.`,
+      );
+    }
     let href = url.href;
     this.#invalidations.add(url.href);
     // Build the per-row timing_diagnostics blob. Render-side fields
@@ -817,6 +839,15 @@ export class Batch {
       return;
     }
     let existingTypes = await this.existingIndexTypes(toTombstone);
+    // `has_error` and `error_doc` are listed (with explicit false / null
+    // values per row) so the upsert's ON CONFLICT SET clause clears them.
+    // The primary key is `(url, realm_url, type)` — no `realm_version` —
+    // so a tombstone always collides with the prior row, and any column
+    // NOT in this list keeps its previous value. Without these two,
+    // a row that ever held `has_error = true` would carry that flag
+    // (and whatever `error_doc` it had at the time, including
+    // `jsonb null`) through every subsequent reindex, producing a row
+    // that reads as "errored but with no message" indefinitely.
     let columns = [
       'url',
       'file_alias',
@@ -824,6 +855,8 @@ export class Batch {
       'realm_version',
       'realm_url',
       'is_deleted',
+      'has_error',
+      'error_doc',
       'timing_diagnostics',
       'job_id',
     ].map((c) => [c]);
@@ -850,7 +883,10 @@ export class Batch {
           type,
           this.realmVersion,
           this.realmURL.href,
-          true,
+          true, // is_deleted
+          false, // has_error — explicit clear so stale error state from
+          // a prior pass does not survive the deletion
+          null, // error_doc — same rationale
           tombstoneDiagnosticsJson,
           jobIdValue,
         ].map((v) => [param(v)]),


### PR DESCRIPTION
## Summary

- **`tombstoneEntries`** now lists `has_error` (= `false`) and `error_doc` (= `null`) in its upsert column set, so the ON CONFLICT SET clause explicitly clears any stale error state when marking a URL deleted.
- **`updateEntry`** rejects any `instance-error` / `file-error` entry whose `error.message` is empty / missing, so a future upstream regression that hands over an unusable error fails fast into the worker's per-job reservation cap instead of writing a black-hole row.

## The bug

A row in `boxel_index` / `boxel_index_working` that ever held `has_error = true` carried that flag (and whatever `error_doc` it had — including the literal `jsonb null` shape) **forever**. Two interacting facts:

1. The table's primary key is `(url, realm_url, type)` — no `realm_version` — so a tombstone always collides with the prior row for the same URL.
2. The tombstone upsert's column list did **not** include `has_error` or `error_doc`. The ON CONFLICT SET clause generated by `upsertMultipleRows` only updates listed columns; any column not in the list keeps its previous value.

So once a row reached the `has_error = true, error_doc = jsonb null` shape (for any reason — a transient empty-error payload from an upstream construction site, a deleted file whose `tryToVisit` 404 was silently logged, an early write that pre-dated a later normalization fix), every subsequent reindex re-tombstoned the URL but never cleaned up the stale error fields. The row was invisible to the UI and to DB triage because nothing in `error_doc` named the underlying failure.

Observed on staging in `ctse/personal` for `FancyBrandGuide/c28b185c-...json` — same URL, same null shape, four separate reindex passes in a row, including one user-triggered priority-10 reindex that I watched land in real time.

## Confidence the fix is right

The fix is two lines of explicit defaults on a tombstone upsert. The behavior of the upsert helper is symmetrical for any column added to its list: `INSERT ... ON CONFLICT DO UPDATE SET col = EXCLUDED.col`. So adding `has_error` (with value `false`) and `error_doc` (with value `null`) means a tombstone always lands with cleared error fields, regardless of what was there before.

The write-boundary invariant is a guard against a class of regression rather than a fix for a specific bug, but it cooperates with the post-fatal-child finalize path: a throw at `updateEntry` reaches the worker's per-job reservation cap and the job rejects, rather than the silent thrash the cap fix was designed to terminate.

## Test plan

- [ ] `pnpm test` in `packages/realm-server` exercises the two new tests in `indexing-test.ts`:
  - `batch invalidation clears has_error and error_doc when tombstoning a previously-errored row` — plants an errored row, runs a tombstone batch, asserts `is_deleted = true`, `has_error = false`, `error_doc = null`.
  - `updateEntry refuses to write an instance-error entry with no error.message` — covers `undefined`, `{}`, missing-message, and empty-string-message shapes.
- [ ] After deploy, watch staging `ctse/personal`'s `boxel_index_working` for the FancyBrandGuide row. On the next reindex it should clear to `has_error = false, error_doc = null` (since the file is still missing — it becomes a clean tombstone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)