### PR TITLE
CS-11178: invalidate cached RealmInfo on _permissions PATCH

### DIFF
--- a/packages/realm-server/tests/realm-endpoints/permissions-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/permissions-test.ts
@@ -12,6 +12,7 @@ import {
   testRealmHref,
   testRealmURL,
   createJWT,
+  waitUntil,
 } from '../helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import type { PgAdapter } from '@cardstack/postgres';
@@ -399,12 +400,18 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
       // Dispatch on the receiver side is covered separately in
       // `realm-index-updated-listener-test.ts`.
       test('PATCH /_permissions invalidates cached RealmInfo and broadcasts to peers', async function (assert) {
-        let notifyPayloads: string[] = [];
+        // Only count NOTIFYs whose payload matches this realm — the
+        // `realm_index_updated` channel is shared across every realm
+        // mounted in this process, and the test fixture's own boot
+        // sequence (or any racing index swap) can fan out unrelated
+        // payloads on the same listener. Filtering by `testRealm.url`
+        // keeps the assertion specific to the PATCH under test.
+        let sawNotifyForThisRealm = false;
         let subscription = await dbAdapter.subscribe(
           REALM_INDEX_UPDATED_CHANNEL,
           (notification) => {
-            if (notification.payload) {
-              notifyPayloads.push(notification.payload);
+            if (notification.payload === testRealm.url) {
+              sawNotifyForThisRealm = true;
             }
           },
         );
@@ -448,15 +455,13 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
           );
 
           // The NOTIFY is delivered over a separate libpq connection,
-          // so it may arrive slightly after the HTTP response. Poll
-          // briefly rather than racing the event loop.
-          let pollStart = Date.now();
-          while (notifyPayloads.length === 0 && Date.now() - pollStart < 3000) {
-            await new Promise((resolve) => setTimeout(resolve, 20));
-          }
-          assert.deepEqual(
-            notifyPayloads,
-            [testRealm.url],
+          // so it may arrive slightly after the HTTP response.
+          await waitUntil(async () => sawNotifyForThisRealm, {
+            timeout: 3000,
+            timeoutMessage: `expected NOTIFY ${REALM_INDEX_UPDATED_CHANNEL} for ${testRealm.url} after PATCH /_permissions`,
+          });
+          assert.ok(
+            sawNotifyForThisRealm,
             'realm_index_updated NOTIFY emitted with this realm URL (peer replicas drop their #cachedRealmInfo on receipt)',
           );
         } finally {

--- a/packages/realm-server/tests/realm-endpoints/permissions-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/permissions-test.ts
@@ -5,6 +5,7 @@ import type { Realm } from '@cardstack/runtime-common';
 import {
   fetchRealmPermissions,
   insertPermissions,
+  REALM_INDEX_UPDATED_CHANNEL,
 } from '@cardstack/runtime-common';
 import {
   setupPermissionedRealmCached,
@@ -377,6 +378,90 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
           'shared',
           'after out-of-band *: read revoke, visibility flips back without restart',
         );
+      });
+
+      // CS-11178: `RealmInfo.visibility` is permissions-derived but
+      // memoized into `Realm#cachedRealmInfo` and consumed by every
+      // card-document response via `attachRealmInfo()` and by the
+      // card-JSON ETag hash. A `_permissions` PATCH must therefore
+      // invalidate that cache locally AND broadcast the same wipe on
+      // `realm_index_updated` so peer replicas drop their copies too.
+      // Two assertions:
+      //   1. `getRealmInfo()` after the PATCH reflects the new
+      //      visibility (proves the local `#cachedRealmInfo` clear ran).
+      //   2. A NOTIFY on `realm_index_updated` lands with this realm's
+      //      URL (proves the broadcast half ran). If a future refactor
+      //      replaces `clearRealmIndexCachesAndBroadcast()` with the
+      //      bare `clearRealmIndexCaches()`, the second assertion is
+      //      what catches it — peer replicas would silently keep
+      //      serving stale `meta.realmInfo.visibility` from their own
+      //      cached RealmInfo.
+      // Dispatch on the receiver side is covered separately in
+      // `realm-index-updated-listener-test.ts`.
+      test('PATCH /_permissions invalidates cached RealmInfo and broadcasts to peers', async function (assert) {
+        let notifyPayloads: string[] = [];
+        let subscription = await dbAdapter.subscribe(
+          REALM_INDEX_UPDATED_CHANNEL,
+          (notification) => {
+            if (notification.payload) {
+              notifyPayloads.push(notification.payload);
+            }
+          },
+        );
+        try {
+          let beforeInfo = await testRealm.getRealmInfo();
+          assert.strictEqual(
+            beforeInfo.visibility,
+            'shared',
+            'baseline: cached RealmInfo reflects mary+bob (shared)',
+          );
+
+          let response = await request
+            .patch('/_permissions')
+            .set('Accept', 'application/vnd.api+json')
+            .set(
+              'Authorization',
+              `Bearer ${createJWT(testRealm, 'mary', [
+                'read',
+                'write',
+                'realm-owner',
+              ])}`,
+            )
+            .send({
+              data: {
+                id: testRealmHref,
+                type: 'permissions',
+                attributes: {
+                  permissions: {
+                    '*': ['read'],
+                  },
+                },
+              },
+            });
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+
+          let afterInfo = await testRealm.getRealmInfo();
+          assert.strictEqual(
+            afterInfo.visibility,
+            'public',
+            'after PATCH, next getRealmInfo() reflects the new *: read grant (local cache invalidated)',
+          );
+
+          // The NOTIFY is delivered over a separate libpq connection,
+          // so it may arrive slightly after the HTTP response. Poll
+          // briefly rather than racing the event loop.
+          let pollStart = Date.now();
+          while (notifyPayloads.length === 0 && Date.now() - pollStart < 3000) {
+            await new Promise((resolve) => setTimeout(resolve, 20));
+          }
+          assert.deepEqual(
+            notifyPayloads,
+            [testRealm.url],
+            'realm_index_updated NOTIFY emitted with this realm URL (peer replicas drop their #cachedRealmInfo on receipt)',
+          );
+        } finally {
+          await subscription.unsubscribe();
+        }
       });
 
       test('receive 400 error on invalid JSON API', async function (assert) {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -307,20 +307,27 @@ const CARD_JSON_ETAG_VARIANT = 'card';
 export const REALM_FILE_CHANGES_CHANNEL = 'realm_file_changes';
 export const REALM_FILE_CHANGES_WILDCARD = '*';
 
-// CS-11119: Postgres NOTIFY channel announcing that a realm's index has
-// just been updated (the worker's batch.done() has committed
-// boxel_index). Payload is the realm URL.
+// CS-11119: Postgres NOTIFY channel announcing that a realm's read-side
+// derived caches (`#inFlightSearch`, `#cachedRealmInfo`) must drop.
+// Payload is the realm URL.
 //
 // Distinct from REALM_FILE_CHANGES_CHANNEL (which fires at file-WRITE
-// time, before indexing has run) — this channel fires at INDEX-UPDATE
-// time, after the swap of boxel_index has landed. Peer replicas
-// subscribe and drop their RealmIndexQueryEngine.#inFlightSearch so a new
-// caller arriving after a peer's update does not coalesce into a
-// pre-update pending promise and receive pre-update data.
+// time, before indexing has run). Originally introduced for INDEX-UPDATE
+// fan-out — emitted after the worker's batch.done() committed
+// boxel_index — but the receiver also drops `#cachedRealmInfo`, which is
+// derived from `realm_permissions`. CS-11178 extends the publisher list
+// so a `realm_permissions` write (`patchRealmPermissions`) fires the
+// same NOTIFY: peers drop their cached RealmInfo (whose `visibility`
+// field is permissions-derived) and an unrelated in-flight searchCards
+// pays at most one extra DB round-trip — admin-rare PATCHes make the
+// over-invalidation negligible. If a future caller needs to invalidate
+// permissions-derived state without touching index-derived state,
+// introduce a dedicated `realm_permissions_changed` channel.
 //
 // Same best-effort semantics as the other realm-server NOTIFY channels: a
 // missed NOTIFY leaves a bounded staleness window (one in-flight
-// searchCards walk), not data corruption.
+// searchCards walk plus a stale RealmInfo on `_info` until the next swap
+// or write), not data corruption.
 export const REALM_INDEX_UPDATED_CHANNEL = 'realm_index_updated';
 
 // Emit `NOTIFY realm_index_updated, '<realmURL>'`. Called from every
@@ -1477,19 +1484,19 @@ export class Realm {
   }
   #testOnlyTranspileDelay?: () => Promise<void>;
 
-  // CS-11119: Drop every read-side cache whose content derives from the
-  // realm's index — currently `#inFlightSearch` (the searchCards
-  // coalesce map) and `#cachedRealmInfo` (cached `RealmInfo` +
-  // ETag-hash; the ETag's hash component derives from indexed metadata
-  // and `realm_registry` rows, so a from-scratch reindex pass that
-  // re-reads /realm.json invalidates both). Called by the
+  // CS-11119: Drop every read-side cache whose content derives from
+  // server-side state — currently `#inFlightSearch` (the searchCards
+  // coalesce map, index-derived) and `#cachedRealmInfo` (cached
+  // `RealmInfo` + ETag-hash; mostly index-derived but its `visibility`
+  // field is permissions-derived per CS-11178). Called by the
   // realm_index_updated LISTEN handler on peer instances after a swap
-  // commits somewhere else in the fleet. Public so the realm-server
-  // process can wire the listener without reaching into private state.
-  // Callers awaiting a pre-clear in-flight searchCards promise still
-  // receive its pre-update result (the SQL was already in motion);
-  // only NEW callers after the clear miss the map and fire a fresh
-  // search against the now-current index.
+  // commits — or after a `realm_permissions` PATCH lands — somewhere
+  // else in the fleet. Public so the realm-server process can wire the
+  // listener without reaching into private state. Callers awaiting a
+  // pre-clear in-flight searchCards promise still receive its
+  // pre-update result (the SQL was already in motion); only NEW callers
+  // after the clear miss the map and fire a fresh search against the
+  // now-current index.
   clearRealmIndexCaches(): void {
     this.#realmIndexQueryEngine.clearInFlightSearch();
     this.invalidateCachedRealmInfo();
@@ -5921,6 +5928,19 @@ export class Realm {
     }
 
     await insertPermissions(this.#dbAdapter, new URL(this.url), patch);
+    // CS-11178: `RealmInfo.visibility` is derived from `realm_permissions`
+    // and memoized into `#cachedRealmInfo` by `parseRealmInfo`. Without
+    // this invalidation a PATCH on this replica leaves the *local*
+    // `_info` response stale until the next index swap, and a PATCH on
+    // any peer replica leaves *every* replica's `_info` response stale
+    // until process restart — the same multi-replica staleness pattern
+    // CS-11126 closed at the auth layer, surviving one layer up.
+    // Reuses the existing realm_index_updated channel: the peer listener
+    // calls `clearRealmIndexCaches()` which drops `#cachedRealmInfo`
+    // (exactly what we need) and `#inFlightSearch` (a no-op when empty;
+    // permission PATCHes are admin-rare so the over-invalidation is
+    // negligible).
+    await this.clearRealmIndexCachesAndBroadcast();
     return await this.getRealmPermissions(request, requestContext);
   }
 


### PR DESCRIPTION
## Summary
- Follow-up to [CS-11126](https://linear.app/cardstack/issue/CS-11126) and PR #4868. CS-11126 dropped `Realm.visibility()` / `isWorldReadable()` per-instance caches so a permissions PATCH on replica A took effect on replica B without restart. But `RealmInfo.visibility` is **separately** memoized into `#cachedRealmInfo` by `parseRealmInfo()`, consumed by every card-document response via `attachRealmInfo()` and folded into the card-JSON ETag hash. `patchRealmPermissions` wrote `realm_permissions` without invalidating that cache — same multi-replica staleness pattern, surviving one layer up.
- Fix: `patchRealmPermissions` now calls `clearRealmIndexCachesAndBroadcast()` after `insertPermissions` succeeds, reusing the existing `realm_index_updated` NOTIFY channel whose listener already drops `#cachedRealmInfo` on every peer.
- Trade-off: this over-invalidates `#inFlightSearch` (cleared as part of the same broadcast). Permission PATCHes are admin-rare, so at-most-one-extra DB round-trip per concurrent `searchCards` is negligible. If we ever need to invalidate permissions-derived state without touching index-derived state, we'd introduce a dedicated `realm_permissions_changed` channel — YAGNI until then. Channel docstrings updated to acknowledge the broadened trigger set.

## Linear
[CS-11178](https://linear.app/cardstack/issue/CS-11178/patchrealmpermissions-leaves-cached-realminfovisibility-stale-across)

## Stacks on
This PR is based on #4887 (`fix-isworldreadable-removed-from-startup`), which removes a dangling `await this.isWorldReadable()` left over from CS-11126's merge. Lint:types fails without #4887, so this PR cannot land first. Will rebase onto main once #4887 merges, or this can merge naturally afterward.

## Test plan
- [x] `pnpm --filter @cardstack/realm-server lint:types`
- [x] `pnpm --filter @cardstack/runtime-common lint:types`
- [x] `pnpm --filter @cardstack/realm-server test-module` with `TEST_MODULE=realm-endpoints/permissions-test.ts` (12/12 pass, including the new `PATCH /_permissions invalidates cached RealmInfo and broadcasts to peers`)
- [ ] CI green

## New test
`PATCH /_permissions invalidates cached RealmInfo and broadcasts to peers` exercises both halves end-to-end:

1. Primes `#cachedRealmInfo` via `getRealmInfo()`, PATCHes a `*: read` grant, asserts the next `getRealmInfo()` reports `'public'` — proves the local cache invalidated. Without the fix, `getRealmInfo()` returns the memoized `'shared'` value.
2. Subscribes to `realm_index_updated` before the PATCH and asserts a NOTIFY with this realm's URL lands — proves the broadcast half ran. Without this, a refactor that swaps `clearRealmIndexCachesAndBroadcast()` for the bare `clearRealmIndexCaches()` would silently break cross-replica fan-out and only the local assertion would still pass.

Dispatch on the receiver side is covered separately by `realm-index-updated-listener-test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)