### PR TITLE
CS-11169: render divider in card selection menu

### DIFF
--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -30,6 +30,7 @@ import {
   LoadingIndicator,
 } from '@cardstack/boxel-ui/components';
 import {
+  MenuDivider,
   MenuItem,
   getContrastColor,
   toMenuItems,
@@ -543,7 +544,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
     const totalAvailableCount = availableCards.length;
     const allSelected = selectedCount >= totalAvailableCount;
 
-    const menuItems: (MenuItem | { type: 'divider' })[] = [];
+    const menuItems: (MenuItem | MenuDivider)[] = [];
 
     // Add "Select All" option if not all cards are selected
     if (!allSelected && totalAvailableCount > selectedCount) {
@@ -566,8 +567,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
       }),
     );
 
-    // Add divider before delete action
-    menuItems.push({ type: 'divider' });
+    menuItems.push(new MenuDivider());
 
     // Add "Delete N items" option
     menuItems.push(


### PR DESCRIPTION
## Summary
- Fixes [CS-11169](https://linear.app/cardstack/issue/CS-11169/card-menu-dropdown-has-blank-slot-instead-of-divider): the card selection dropdown (shown when one or more cards are selected) renders a blank slot between "Deselect All" and the destructive "Delete N item(s)" action instead of a divider.
- Root cause: `stack-item.gts` was pushing a plain `{ type: 'divider' }` object into `menuItems`. The `Menu` component only renders a divider when `menuItem.isDivider` is truthy, which is set on `MenuDivider` instances — so the entry rendered as an empty `<li>`.
- Fix: use `new MenuDivider()`, matching the pattern in `code-submode.gts` / `interact-submode.gts` and the `CardHeaderUtilityMenu.menuItems: (MenuItem | MenuDivider)[]` type the value already had to flow into.

## Test plan
- [ ] Operator mode → enter multi-select on a card stack → open the "N Selected" dropdown → confirm a thin divider line is rendered between "Deselect All" and "Delete N item(s)" (no more blank gap).
- [ ] Repeat with two or more cards selected to confirm "Delete N items" plural label still shows above the divider correctly.
- [ ] Verify the existing acceptance test `workspace-delete-multiple-test.gts` still passes (it exercises this menu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)