### PR TITLE
JobScopedSearchCache: store serialized response bytes

### DIFF
--- a/packages/realm-server/handlers/handle-search-prerendered.ts
+++ b/packages/realm-server/handlers/handle-search-prerendered.ts
@@ -56,11 +56,15 @@ export default function handleSearchPrerendered(opts?: {
       cardUrls: parsed.cardUrls,
       renderType: parsed.renderType,
     };
-    let runSearch = () =>
-      searchPrerenderedRealms(
-        realmList.map((realmURL) => realmByURL.get(realmURL)),
-        parsed.cardsQuery,
-        searchOpts,
+    let runSearch = async () =>
+      JSON.stringify(
+        await searchPrerenderedRealms(
+          realmList.map((realmURL) => realmByURL.get(realmURL)),
+          parsed.cardsQuery,
+          searchOpts,
+        ),
+        null,
+        2,
       );
 
     // Symmetric to `_federated-search`'s gating. Cache is consulted
@@ -92,7 +96,7 @@ export default function handleSearchPrerendered(opts?: {
       : null;
     let cacheable = searchCache && jobId && consumingRealm;
 
-    let combined = cacheable
+    let body = cacheable
       ? await searchCache!.getOrPopulate({
           jobId: jobId!,
           realms: realmList,
@@ -104,7 +108,7 @@ export default function handleSearchPrerendered(opts?: {
 
     await setContextResponse(
       ctxt,
-      new Response(JSON.stringify(combined, null, 2), {
+      new Response(body, {
         headers: { 'content-type': SupportedMimeType.CardJson },
       }),
     );

--- a/packages/realm-server/handlers/handle-search.ts
+++ b/packages/realm-server/handlers/handle-search.ts
@@ -71,11 +71,15 @@ export default function handleSearch(opts?: {
     if (jobPriority !== null) searchOpts.priority = jobPriority;
     let normalizedSearchOpts =
       Object.keys(searchOpts).length > 0 ? searchOpts : undefined;
-    let runSearch = () =>
-      searchRealms(
-        realmList.map((realmURL) => realmByURL.get(realmURL)),
-        cardsQuery,
-        normalizedSearchOpts,
+    let runSearch = async () =>
+      JSON.stringify(
+        await searchRealms(
+          realmList.map((realmURL) => realmByURL.get(realmURL)),
+          cardsQuery,
+          normalizedSearchOpts,
+        ),
+        null,
+        2,
       );
 
     // Job-scoped cache. Gated on:
@@ -107,7 +111,7 @@ export default function handleSearch(opts?: {
       : null;
     let cacheable = searchCache && jobId && consumingRealm;
 
-    let combined = cacheable
+    let body = cacheable
       ? await searchCache!.getOrPopulate({
           jobId: jobId!,
           realms: realmList,
@@ -119,7 +123,7 @@ export default function handleSearch(opts?: {
 
     await setContextResponse(
       ctxt,
-      new Response(JSON.stringify(combined, null, 2), {
+      new Response(body, {
         headers: { 'content-type': SupportedMimeType.CardJson },
       }),
     );

--- a/packages/realm-server/job-scoped-search-cache.ts
+++ b/packages/realm-server/job-scoped-search-cache.ts
@@ -30,14 +30,19 @@ const DEFAULT_TTL_MS = 10 * 60 * 1000;
 const DEFAULT_MAX_ENTRIES = 5000;
 
 type CachedEntry = {
-  // Result is stored opaquely so both `_federated-search`'s
-  // `LinkableCollectionDocument` and `_federated-search-prerendered`'s
-  // `PrerenderedCardCollectionDocument` can share the same cache
-  // instance. Inner-key canonicalisation already includes the
-  // endpoint-distinguishing params (htmlFormat / cardUrls / renderType
-  // are passed through `opts`), so two endpoints' entries cannot
-  // collide on a key they don't both fully share.
-  result: unknown;
+  // Entries store the *serialized* JSON response body, not the parsed
+  // document. The handler hands off a populate thunk that wraps its
+  // `searchRealms` / `searchPrerenderedRealms` call in
+  // `JSON.stringify(..., null, 2)`, so the cache holds the exact bytes
+  // shipped to the next caller — no re-stringify on hit, no parsed
+  // object graph kept alive for the TTL window. Both
+  // `_federated-search` (`LinkableCollectionDocument`) and
+  // `_federated-search-prerendered` (`PrerenderedCardCollectionDocument`)
+  // share this single instance: inner-key canonicalisation already
+  // includes the endpoint-distinguishing params (htmlFormat /
+  // cardUrls / renderType pass through `opts`), so two endpoints'
+  // entries cannot collide on a key they don't both fully share.
+  result: string;
   timer: ReturnType<typeof setTimeout>;
   // Position in the FIFO eviction ring. Stored on the entry so a
   // cache hit doesn't need a separate map lookup to know its slot.
@@ -79,13 +84,14 @@ type CachedEntry = {
 // only stamped by indexer-driven prerender requests, so user-facing
 // API callers always bypass and see live state.
 //
-// Entries store the *resolved* doc, not the in-flight promise.
-// Concurrent same-key callers each run their own `populate` (Phase 1's
-// in-flight dedup at `RealmIndexQueryEngine.searchCards` already
-// coalesces the heavy inner SQL+loadLinks walk for same-realm calls
-// arriving concurrently). The first to finish stores its result here;
-// later sequential callers within the same job see the cached doc and
-// short-circuit before re-entering `searchRealms`.
+// Entries store the *resolved, serialized* response bytes, not the
+// in-flight promise. Concurrent same-key callers each run their own
+// `populate` (Phase 1's in-flight dedup at
+// `RealmIndexQueryEngine.searchCards` already coalesces the heavy
+// inner SQL+loadLinks walk for same-realm calls arriving concurrently).
+// The first to finish stores its serialized bytes here; later
+// sequential callers within the same job see the cached string and
+// ship it directly with no re-stringify pass.
 //
 // Storing promises was tempting (it would also dedupe at this layer)
 // but creates a tail-latency stall: a slow first populate blocks every
@@ -117,13 +123,13 @@ export class JobScopedSearchCache {
     this.#maxEntries = opts?.maxEntries ?? DEFAULT_MAX_ENTRIES;
   }
 
-  async getOrPopulate<T>(args: {
+  async getOrPopulate(args: {
     jobId: string;
     realms: string[];
     query: Query;
     opts: unknown | undefined;
-    populate: () => Promise<T>;
-  }): Promise<T> {
+    populate: () => Promise<string>;
+  }): Promise<string> {
     let innerKey = buildInnerKey(args.realms, args.query, args.opts);
     let jobMap = this.#byJob.get(args.jobId);
     let existing = jobMap?.get(innerKey);
@@ -133,7 +139,7 @@ export class JobScopedSearchCache {
       // test ever pre-seeds entries without going through populate.
       let stat = this.#stats.get(args.jobId);
       if (stat) stat.hits += 1;
-      return existing.result as T;
+      return existing.result;
     }
 
     let result = await args.populate();

--- a/packages/realm-server/tests/job-scoped-search-cache-test.ts
+++ b/packages/realm-server/tests/job-scoped-search-cache-test.ts
@@ -1,9 +1,6 @@
 import { module, test } from 'qunit';
 import { basename } from 'path';
-import type {
-  LinkableCollectionDocument,
-  Query,
-} from '@cardstack/runtime-common';
+import type { Query } from '@cardstack/runtime-common';
 import { JobScopedSearchCache } from '../job-scoped-search-cache';
 
 const realmA = 'http://localhost:4201/test/';
@@ -17,11 +14,19 @@ function makeQuery(firstName = 'Mango'): Query {
   };
 }
 
-function makeDoc(label: string): LinkableCollectionDocument {
-  return {
-    data: [{ type: 'card', id: `${realmA}${label}` }],
-    meta: { page: { total: 1, realmVersion: 1 } },
-  } as unknown as LinkableCollectionDocument;
+// Cache stores serialized response bytes, not parsed docs. Tests
+// model that by returning JSON strings directly. The shape matches
+// what a real `searchRealms` populate thunk would produce after
+// `JSON.stringify(..., null, 2)`.
+function makeDoc(label: string): string {
+  return JSON.stringify(
+    {
+      data: [{ type: 'card', id: `${realmA}${label}` }],
+      meta: { page: { total: 1, realmVersion: 1 } },
+    },
+    null,
+    2,
+  );
 }
 
 module(basename(__filename), function () {
@@ -52,6 +57,45 @@ module(basename(__filename), function () {
       assert.strictEqual(calls, 1, 'populate ran exactly once');
       assert.strictEqual(a, b, 'second caller got the cached doc');
       assert.strictEqual(cache.size(), 1, 'one entry stored');
+    });
+
+    test('cache returns the originally-serialized bytes on hit (no re-stringify)', async function (assert) {
+      // The whole point of storing strings is to ship the cached bytes
+      // directly. A populate that mutates its output on every call
+      // makes this observable: if the cache ever re-ran populate or
+      // re-serialized, the second hit would surface the newer bytes.
+      let cache = new JobScopedSearchCache();
+      let calls = 0;
+      let populate = async () => {
+        calls++;
+        return makeDoc(`call-${calls}`);
+      };
+
+      let firstHit = await cache.getOrPopulate({
+        jobId: '42.1',
+        realms: [realmA],
+        query: makeQuery(),
+        opts: undefined,
+        populate,
+      });
+      let secondHit = await cache.getOrPopulate({
+        jobId: '42.1',
+        realms: [realmA],
+        query: makeQuery(),
+        opts: undefined,
+        populate,
+      });
+
+      assert.strictEqual(calls, 1, 'populate only ran on the first miss');
+      assert.strictEqual(
+        secondHit,
+        firstHit,
+        'hit byte-equals the originally-cached body',
+      );
+      assert.ok(
+        firstHit.includes('call-1'),
+        'cached bytes are from the first populate, not a re-stringify',
+      );
     });
 
     test('cache miss when jobId differs', async function (assert) {


### PR DESCRIPTION
## Summary

Refactors `JobScopedSearchCache` to store the serialized JSON response body (`string`) instead of the parsed document.

- `getOrPopulate` loses its generic and is now fixed to `Promise<string>`.
- Both handlers (`handle-search.ts` and `handle-search-prerendered.ts`) move their `JSON.stringify(..., null, 2)` into the `populate` thunk — cache hits ship the cached bytes directly via `new Response(body, ...)`.
- `CachedEntry.result` tightens from `unknown` → `string`; header comment updated.

This removes the per-hit `JSON.stringify` on the search hot path. With ~358 federated-search calls per piranha-class from-scratch reindex, that's hundreds of large-doc stringify passes saved across one job. It also lays the value-type groundwork for the planned DB-backed cache swap — the migration becomes "swap the storage backend" rather than "redesign the marshalling layer."

PR1 of 2 for [CS-11176](https://linear.app/cardstack/issue/CS-11176/refactor-jobscopedsearchcache-to-string-blob-storage-job-id-based). PR2 (job-id-based ETag + If-None-Match) stacks on this.

## Test plan

- [x] Existing `job-scoped-search-cache-test.ts` suite passes after switching fixtures from parsed-doc objects to JSON strings
- [x] Added explicit test: hit returns the originally-serialized bytes (`call-1`) even when populate would have returned `call-2` on a re-run — catches accidental re-serialization
- [x] Targeted prettier + eslint clean on changed files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)