### PR TITLE
CS-11072: CardsGrid "+" button falls back to direct create when type has no spec

### DIFF
--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -310,6 +310,13 @@ class Isolated extends Component<typeof CardsGrid> {
       await this.args.createCard?.(spec.ref, cardIdToURL(spec.id!), {
         realmURL: this.args.model[realmURL],
       });
+    } else if (activeFilterRef) {
+      // No spec exists for the active type filter — create an instance of
+      // the type directly. `activeFilterRef` is an absolute CodeRef sourced
+      // from the realm's `_types` summary, so no `relativeTo` is needed.
+      await this.args.createCard?.(activeFilterRef, undefined, {
+        realmURL: this.args.model[realmURL],
+      });
     }
   });
 

--- a/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
@@ -902,6 +902,34 @@ module('Integration | operator-mode | card catalog', function (hooks) {
     assert.dom('[data-test-card-catalog-item-selected]').doesNotExist();
   });
 
+  test(`+ button creates a new instance directly when the filtered type has no spec`, async function (assert) {
+    // Author has no Spec card in the test realm — the + button should still
+    // open a new Author instance in edit mode instead of silently failing.
+    ctx.setCardInOperatorModeState(`${testRealmURL}grid`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await waitFor(`[data-test-stack-card="${testRealmURL}grid"]`);
+    await waitFor(`[data-test-boxel-filter-list-button="Author"]`);
+    await click(`[data-test-boxel-filter-list-button="Author"]`);
+    await waitFor(`[data-test-cards-grid-item]`);
+
+    await click(`[data-test-create-new-card-button]`);
+
+    assert
+      .dom('[data-test-card-catalog-modal]')
+      .doesNotExist('no spec chooser appears for a type without a spec');
+
+    await waitFor('[data-test-stack-card-index="1"]');
+    assert
+      .dom(
+        '[data-test-stack-card-index="1"] [data-test-boxel-card-header-title]',
+      )
+      .hasText('Author');
+  });
+
   test(`cancel button closes the field picker`, async function (assert) {
     ctx.setCardInOperatorModeState(`${testRealmURL}BlogPost/2`);
     await renderComponent(


### PR DESCRIPTION
## Summary
- The CardsGrid "+" button silently failed when the active type filter pointed at a card type with no corresponding Spec card in the realm — `createCard` was guarded by `if (spec && isCardInstance<Spec>(spec))`, so the click was a no-op.
- When `activeFilterRef` is set and no Spec is found, fall back to calling `args.createCard` with the filter's CodeRef directly. `activeFilterRef` is sourced from the realm's `_types` summary (an absolute CodeRef), so `relativeTo` can be `undefined`.
- Existing happy-paths are unchanged: when a Spec exists, it is still used; the "All Cards" / no-filter path still opens the Spec chooser.

Closes [CS-11072](https://linear.app/cardstack/issue/CS-11072/cardsgrid-button-should-successfully-add-new-instance-of-a-type-even).

## Test plan
- [x] Added integration regression test `+ button creates a new instance directly when the filtered type has no spec` in `operator-mode-card-catalog-test.gts` that filters to `Author` (no Spec in the test realm), clicks `+`, asserts no chooser modal appears, and asserts a new Author opens at stack index 1.
- [x] `pnpm lint:types` (packages/host).
- [x] CI: run `Integration | operator-mode | card catalog` module.
- [ ] Manual smoke: in a realm, filter to a card type that has no Spec card and click `+`; verify a fresh instance opens in edit mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)