### PR TITLE
worker-manager: log exit code/signal when child dies

### DIFF
--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -839,7 +839,7 @@ async function startWorker(
 
   workers.push(worker);
 
-  worker.on('exit', () => {
+  worker.on('exit', (code, signal) => {
     clearInterval(watchdog);
     // Remove from workers array
     const index = workers.indexOf(worker);
@@ -850,7 +850,15 @@ async function startWorker(
     // Spawn the replacement first so a stalled DB call inside finalize
     // (connection lock, network blip, etc.) can't delay recovery.
     if (!isExiting) {
-      log.info(`worker ${name} exited. spawning replacement worker`);
+      // `code` and `signal` are mutually exclusive: a clean process exit
+      // sets `code`, a kill-by-signal sets `signal`. The distinction
+      // matters when triaging why a child died — silent SIGKILLs (cgroup
+      // OOM, external kill) bypass the in-process fatal handlers in
+      // worker.ts, and we currently can't tell those apart from a clean
+      // exit without this on the parent side.
+      log.info(
+        `worker ${name} exited (code=${code}, signal=${signal}). spawning replacement worker`,
+      );
       startWorker(priority, urlMappings);
     }
 


### PR DESCRIPTION
## Summary

The parent's `worker.on('exit')` log currently only says `worker <name> exited. spawning replacement worker` — no code, no signal. That makes it impossible to tell apart:

- a clean `process.exit(0)`
- a Node-level fatal caught by the in-process `unhandledRejection` / `uncaughtException` handlers in `worker.ts`
- a SIGKILL from outside the process (cgroup OOM, external kill, native abort)

The distinction matters because the in-process fatal handlers in `worker.ts` only fire for the second case. The third case bypasses them entirely, the reservation closes as `'interrupted'` (which the per-job cap excludes), and a deterministic-crash job will loop forever without abandonment. Right now we have to guess at which path a thrashing realm is on.

## Change

`worker.on('exit', (code, signal) => ...)` and include both in the log line. `code` and `signal` are mutually exclusive on the `child_process` exit event — clean exit sets `code`, kill-by-signal sets `signal` — so the pair unambiguously identifies the kill mechanism.

## Test plan

- [x] CI green
- [ ] After deploy, observe `worker <name> exited (code=…, signal=…). spawning replacement worker` lines in the worker-staging log group. For a realm currently thrashing, the expected output should narrow the diagnosis to one of: `(code=0|1, signal=null)` (clean / in-process fatal) vs `(code=null, signal=SIGKILL|SIGTERM|SIGABRT)` (external kill / native crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)