### PR TITLE
query-field-support: stop re-arming the render-cycle barrier on field reuse

### DIFF
--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -91,7 +91,18 @@ export function ensureQueryFieldSearchResource(
   }
   let searchResource = fieldState.searchResource;
   if (searchResource) {
-    trackQueryFieldLoads(store, field.name, fieldState);
+    // Intentionally do NOT call `trackQueryFieldLoads` here. The barrier
+    // it registers exists to plug a one-shot timing race at resource
+    // creation, between the field getter returning and the resource's
+    // `modify` lifecycle running `store.trackLoad` for the real search.
+    // On the reuse path that race no longer applies — the resource
+    // already exists and its own `modify`-driven trackLoad is the
+    // authoritative signal for render-stability. Re-arming the barrier
+    // on every read creates a feedback loop: the barrier registers a
+    // tracked load, its resolution invalidates the read-tracker that
+    // drove the read, Glimmer reads again, a fresh barrier registers,
+    // and so on. With N query-field consumers in a single render the
+    // loop saturates the JS thread for minutes per card.
     log.debug(
       `ensureQueryFieldSearchResource: reusing existing resource from fieldState for field=${field.name}`,
     );

--- a/packages/host/tests/integration/resources/query-field-barrier-test.ts
+++ b/packages/host/tests/integration/resources/query-field-barrier-test.ts
@@ -1,0 +1,154 @@
+import { getOwner } from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import type { Loader } from '@cardstack/runtime-common';
+import { baseRealm } from '@cardstack/runtime-common';
+
+import type LoaderService from '@cardstack/host/services/loader-service';
+import RealmService from '@cardstack/host/services/realm';
+import type StoreService from '@cardstack/host/services/store';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  testRealmURL,
+  testRRI,
+} from '../../helpers';
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+class StubRealmService extends RealmService {
+  realmOf(_input: URL | string) {
+    return testRealmURL;
+  }
+}
+
+// Lets microtasks drain so the render-cycle barrier (a 2-microtask
+// Promise) has had time to resolve and its `finally` has run before
+// we observe the next read.
+async function flushMicrotasks(turns = 5) {
+  for (let i = 0; i < turns; i++) {
+    await Promise.resolve();
+  }
+}
+
+module(`Integration | query field render-cycle barrier`, function (hooks) {
+  let loader: Loader;
+  let loaderService: LoaderService;
+  let storeService: StoreService;
+  let cardApi: typeof import('https://cardstack.com/base/card-api');
+  let string: typeof import('https://cardstack.com/base/string');
+
+  setupRenderingTest(hooks);
+  hooks.beforeEach(function () {
+    getOwner(this)!.register('service:realm', StubRealmService);
+    loaderService = getService('loader-service');
+    loader = loaderService.loader;
+    storeService = getService('store');
+  });
+
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [baseRealm.url, testRealmURL],
+    autostart: true,
+  });
+  setupBaseRealm(hooks);
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    cardApi = await loader.import(`${baseRealm.url}card-api`);
+    string = await loader.import(`${baseRealm.url}string`);
+
+    let { contains, field, CardDef, linksToMany, createFromSerialized } =
+      cardApi;
+    let { default: StringField } = string;
+
+    class Target extends CardDef {
+      static displayName = 'Target';
+      @field name = contains(StringField);
+    }
+
+    class Parent extends CardDef {
+      static displayName = 'Parent';
+      @field cardTitle = contains(StringField);
+      @field items = linksToMany(() => Target, {
+        query: {
+          filter: { eq: { name: '$this.cardTitle' } },
+        },
+      });
+    }
+
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'test-cards.gts': { Parent, Target },
+        'Target/anchor.json': new Target({ name: 'Anchor' }),
+      },
+    });
+
+    // Cache the constructor + serializer on the test context so the
+    // test body doesn't have to re-import them.
+    (this as any).cardApi = cardApi;
+    (this as any).Parent = Parent;
+    (this as any).createFromSerialized = createFromSerialized;
+  });
+
+  test('re-reading a linksToMany query field does not register a new trackLoad each time', async function (this: RenderingTestContext, assert) {
+    let { createFromSerialized } = (this as any).cardApi;
+    let resource = {
+      attributes: { cardTitle: 'Anchor' },
+      meta: {
+        adoptsFrom: { module: testRRI('test-cards'), name: 'Parent' },
+      },
+    };
+    let parent: any = await createFromSerialized(
+      resource as any,
+      { data: resource } as any,
+      undefined,
+    );
+
+    // First read fires the create path inside `ensureQueryFieldSearchResource`:
+    //   - it registers one render-cycle barrier with `store.trackLoad`
+    //   - the SearchResource's own `modify()` then registers the real
+    //     search promise with `store.trackLoad` as well
+    // Let those two registrations settle before we start counting.
+    void parent.items;
+    await flushMicrotasks(10);
+
+    // Now hook the store's trackLoad to count any further registrations.
+    // The bug we're guarding against: every re-read of a query field
+    // synthesized a fresh 2-microtask barrier and registered it as a
+    // tracked load, creating a feedback loop that pegged the JS thread.
+    // Post-fix the reuse path must not register anything new.
+    let trackLoadCount = 0;
+    let originalTrackLoad = storeService.trackLoad.bind(storeService);
+    (storeService as any).trackLoad = (load: Promise<void>) => {
+      trackLoadCount++;
+      originalTrackLoad(load);
+    };
+
+    try {
+      // Three re-reads with microtask hops between them. With the bug
+      // present, each read would re-arm the barrier and bump the count.
+      void parent.items;
+      await flushMicrotasks(10);
+      void parent.items;
+      await flushMicrotasks(10);
+      void parent.items;
+      await flushMicrotasks(10);
+
+      assert.strictEqual(
+        trackLoadCount,
+        0,
+        'reusing the query field across reads does not register new trackLoad calls',
+      );
+    } finally {
+      (storeService as any).trackLoad = originalTrackLoad;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`trackQueryFieldLoads` in `packages/base/query-field-support.ts` was being called on **both** the create path and the reuse path of `ensureQueryFieldSearchResource`. On reuse it served no purpose — the resource's own `modify` lifecycle already registers the real search with `store.trackLoad` — but it was setting up a feedback loop that pegged the JS main thread during card render.

This PR drops the reuse-path call. The create-path call stays — that's the one that plugs the original one-shot timing race described in the barrier's comment.

## The bug

`trackQueryFieldLoads` registers a 2-microtask Promise as a tracked load on the store, then clears `fieldState.renderCycleBarrier` in a `finally` so the slot can be refilled by the next call. On the reuse path:

1. Glimmer reads a query field getter → calls `ensureQueryFieldSearchResource` → calls `trackQueryFieldLoads`.
2. A fresh barrier is registered with `store.trackLoad`.
3. The barrier resolves (~2 microtasks); `renderCycleBarrier` clears in `finally`.
4. The store's tracked-load state changed — any read that depended on it is invalidated; Glimmer re-reads the field.
5. Back to step 1.

With **N independent query-field consumers in one render**, this loop spins forever in microtask scheduling — no real work, no network, just Promise allocation + `trackLoad` register/unregister churn.

## Observed in production

A `Cohort` card with 95 linked `Policy` instances (each with its own `claims` query field) on `ctse/ambitious-piranha`. A from-scratch reindex hit the worker's 150-second prerender-visit abort and was rejected.

A 189-second Chrome performance trace of a live render in this state showed:

| | |
|---|---|
| `RunTask` total CPU | 184.5 s (97.6% of trace) |
| `RunMicrotasks` total CPU | 181.6 s |
| Network requests during the busy window | **0** |
| V8 GC scavenger (parallel) | 8.4 s |

Top V8 CPU samples:

| samples | function |
|---|---|
| 29,342 | `trackLoad` |
| 19,471 | `waitForNextMicrotaskTurn` (query-field-support) |
| 18,505 | (garbage collector) |
| 13,891 | `trackQueryFieldLoads` (query-field-support) |

Direct `_federated-search` curl against the same realm: ~110 ms per query, 0.82 s wall for 95 parallel — the server was never the bottleneck. RDS metrics during the render window held at 10–15% CPU and dropping IOPS. The entire stall was in the browser's microtask queue.

## The fix

```diff
   let searchResource = fieldState.searchResource;
   if (searchResource) {
-    trackQueryFieldLoads(store, field.name, fieldState);
+    // (see comment in code — barrier on the reuse path is redundant
+    // and creates a feedback loop)
     log.debug(`ensureQueryFieldSearchResource: reusing…`);
     return searchResource;
   }
```

The create-path call at line 129 remains. The barrier still fires once per `searchResource` lifetime, exactly as the original comment intended.

## Why this is safe

- `SearchResource.modify` (in `packages/host/app/resources/search.ts`) already calls `runtimeStore.trackLoad(load)` itself with the real search promise. The store has an authoritative tracking signal for the in-flight search; the synthetic barrier is purely a one-shot creation-time guard.
- The barrier's own comment confirms its narrow purpose: "keep render-route settle from completing in the same frame before query loads can join" — that race only exists *at the moment the resource is created*, not on subsequent reads.
- `StoreSearchResource` doesn't expose its load promise (the resource intentionally encapsulates it), so removing the barrier wouldn't be safe without the resource's own `modify`-driven `trackLoad` — which it already does.
- Audited all references to `renderCycleBarrier`, `trackQueryFieldLoads`, and `waitForNextMicrotaskTurn`: all are internal to `query-field-support.ts`. No external callers, no tests assert on barrier shape. The two production callers of `ensureQueryFieldSearchResource` (the `linksTo` and `linksToMany` field getters in `card-api.gts`) only consume the returned resource — they don't touch the barrier.

## Test plan

- [ ] `packages/host/tests/integration/resources/query-field-barrier-test.ts` (new): renders a `Parent` with a `linksToMany` query field, reads the field three times with microtask hops between, asserts no further `store.trackLoad` calls happen after the create-path registrations have settled. Pre-fix this test fails because the reuse path registers a fresh barrier on every read; post-fix it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)