### PR TITLE
Keep markdown signifier consistent across the app

### DIFF
--- a/packages/boxel-ui/addon/raw-icons/markdown.svg
+++ b/packages/boxel-ui/addon/raw-icons/markdown.svg
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg viewBox='0 0 16 16' fill='currentColor'>
-  <text x='8' y='11.5' text-anchor='middle' font-size='9.5' font-weight='800' font-family='ui-monospace, SFMono-Regular, Menlo, monospace'>MD</text>
-</svg>

--- a/packages/boxel-ui/addon/src/icons.gts
+++ b/packages/boxel-ui/addon/src/icons.gts
@@ -66,7 +66,6 @@ import ImagePlaceholder from './icons/image-placeholder.gts';
 import Isolated from './icons/isolated.gts';
 import LoadingIndicator from './icons/loading-indicator.gts';
 import Lock from './icons/lock.gts';
-import Markdown from './icons/markdown.gts';
 import Profile from './icons/profile.gts';
 import PublishSiteIcon from './icons/publish-site-icon.gts';
 import Rows4 from './icons/rows-4.gts';
@@ -147,7 +146,6 @@ export const ALL_ICON_COMPONENTS = [
   Isolated,
   LoadingIndicator,
   Lock,
-  Markdown,
   Profile,
   PublishSiteIcon,
   Rows4,
@@ -230,7 +228,6 @@ export {
   Isolated,
   LoadingIndicator,
   Lock,
-  Markdown,
   Profile,
   PublishSiteIcon,
   Rows4,

--- a/packages/host/app/components/operator-mode/code-submode/format-chooser.gts
+++ b/packages/host/app/components/operator-mode/code-submode/format-chooser.gts
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import MetadataIcon from '@cardstack/boxel-icons/clipboard-data';
+import MarkdownIcon from '@cardstack/boxel-icons/markdown';
 import EditIcon from '@cardstack/boxel-icons/pencil';
 import { modifier } from 'ember-modifier';
 import window from 'ember-window-mock';
@@ -19,7 +20,6 @@ import {
   Fitted as FittedIcon,
   Atom as AtomIcon,
   Head as HeadIcon,
-  Markdown as MarkdownIcon,
   Form as FormIcon,
   type Icon,
 } from '@cardstack/boxel-ui/icons';
@@ -86,7 +86,12 @@ const FormatButton: TemplateOnlyComponent<FormatButtonSignature> = <template>
     {{on 'click' @onClick}}
   >
     {{#if @icon}}
-      <@icon class='pf-icon' width={{ICON_W}} height={{ICON_W}} />
+      {{! md icon is larger because tabler icons have extra padding which shrinks them }}
+      <@icon
+        class='pf-icon'
+        width={{if (eq @format 'markdown') '24' ICON_W}}
+        height={{if (eq @format 'markdown') '24' ICON_W}}
+      />
     {{/if}}
   </Button>
   <style scoped>
@@ -124,15 +129,9 @@ const FormatButton: TemplateOnlyComponent<FormatButtonSignature> = <template>
     }
     .pf-icon {
       flex: 0 0 auto;
-      height: var(--pf-icon-w);
       display: inline-flex;
       align-items: center;
       justify-content: center;
-    }
-    .pf-icon :deep(svg) {
-      height: var(--pf-icon-w);
-      width: auto;
-      display: block;
     }
   </style>
 </template>;
@@ -430,7 +429,11 @@ export default class PillFormatChooser extends Component<Signature> {
         </svg>
         <div class='pill-content'>
           {{#if this.pillTargetIcon}}
-            <this.pillTargetIcon class='pf-icon' width='16' height='16' />
+            <this.pillTargetIcon
+              class='pf-icon'
+              width={{ICON_W}}
+              height={{ICON_W}}
+            />
           {{/if}}
           <span
             class='pf-label'


### PR DESCRIPTION
<img width="378" height="85" alt="format-chooser" src="https://github.com/user-attachments/assets/bf09df1b-9589-43bd-91d2-57d241a45d7b" />
