### PR TITLE
Guarantee non-empty error.message on instance-error entries (CS-11185)

### DIFF
--- a/packages/host/app/lib/window-error-handler.ts
+++ b/packages/host/app/lib/window-error-handler.ts
@@ -2,6 +2,7 @@ import {
   isCardErrorJSONAPI,
   isCardError,
   CardError,
+  coerceErrorMessage,
   type CardErrorJSONAPI,
   type RenderError,
   type ErrorEntry,
@@ -45,12 +46,20 @@ export function windowErrorHandler({
       // leave as string
     }
   }
+  // Synthesized when an upstream caller hands us a value with no usable
+  // `message` text. Names the URL so the persisted error row at least
+  // identifies which card was being rendered.
+  let synthesizedMessage = `Unhandled render-time error at ${id ?? currentURL ?? 'unknown URL'} (host produced no message)`;
   let errorPayload: RenderError;
   if (reason) {
     if (isCardError(reason)) {
       errorPayload = {
         type: 'instance-error',
-        error: { ...reason, stack: reason.stack },
+        error: {
+          ...reason,
+          stack: reason.stack,
+          message: coerceErrorMessage(reason, synthesizedMessage),
+        },
       };
     } else if (isCardErrorJSONAPI(reason)) {
       errorPayload = errorJsonApiToErrorEntry({ ...reason });
@@ -70,10 +79,13 @@ export function windowErrorHandler({
         type: 'instance-error',
         error:
           reason instanceof CardError
-            ? { ...serializableError(reason) }
+            ? {
+                ...serializableError(reason),
+                message: coerceErrorMessage(reason, synthesizedMessage),
+              }
             : {
                 id,
-                message: reason.message,
+                message: coerceErrorMessage(reason, synthesizedMessage),
                 stack: reason.stack,
                 status: 500,
               },
@@ -85,6 +97,15 @@ export function windowErrorHandler({
       error: new CardError('indexing failed', { status: 500, id }),
     };
   }
+  // Final belt-and-suspenders: regardless of which branch above ran,
+  // guarantee the error.message is a non-empty string before we send
+  // it to the prerender server. The indexer-side guard at
+  // index-writer.ts:412 refuses entries with empty message and fails
+  // the whole indexing job.
+  errorPayload.error.message = coerceErrorMessage(
+    errorPayload.error,
+    synthesizedMessage,
+  );
 
   if ('stack' in errorPayload.error) {
     let updatedStack = appendRenderTimerSummaryToStack(

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -32,7 +32,10 @@ import {
   logger as runtimeLogger,
 } from '@cardstack/runtime-common';
 import { Deferred } from '@cardstack/runtime-common/deferred';
-import { serializableError } from '@cardstack/runtime-common/error';
+import {
+  coerceErrorMessage,
+  serializableError,
+} from '@cardstack/runtime-common/error';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
@@ -1164,8 +1167,22 @@ export default class RenderRoute extends Route<Model> {
       withTimerSummary,
       fallbackDeps,
     );
+    // The persisted error doc is useless if `message` is empty or
+    // undefined — the indexer's index-writer guard refuses such rows
+    // and fails the whole indexing job. Guarantee a non-empty message
+    // here as the last stop before serialization to the DOM.
+    let withGuaranteedMessage: RenderError = {
+      ...withRuntimeDeps,
+      error: {
+        ...withRuntimeDeps.error,
+        message: coerceErrorMessage(
+          withRuntimeDeps.error,
+          'Render failed (host produced no error message)',
+        ),
+      },
+    };
     return JSON.stringify(
-      this.#stripLastKnownGoodHtml(withRuntimeDeps),
+      this.#stripLastKnownGoodHtml(withGuaranteedMessage),
       null,
       2,
     );

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -1170,14 +1170,23 @@ export default class RenderRoute extends Route<Model> {
     // The persisted error doc is useless if `message` is empty or
     // undefined — the indexer's index-writer guard refuses such rows
     // and fails the whole indexing job. Guarantee a non-empty message
-    // here as the last stop before serialization to the DOM.
+    // here as the last stop before serialization to the DOM. The
+    // synthesized fallback names the affected URL (from error.id,
+    // the first dep, or the most recent render base param) so the
+    // persisted row is at least diagnosable by URL.
+    let urlContext =
+      (typeof withRuntimeDeps.error.id === 'string' &&
+        withRuntimeDeps.error.id) ||
+      withRuntimeDeps.error.deps?.[0] ||
+      this.renderBaseParams?.[0] ||
+      'unknown URL';
     let withGuaranteedMessage: RenderError = {
       ...withRuntimeDeps,
       error: {
         ...withRuntimeDeps.error,
         message: coerceErrorMessage(
           withRuntimeDeps.error,
-          'Render failed (host produced no error message)',
+          `Render failed for ${urlContext} (host produced no error message)`,
         ),
       },
     };

--- a/packages/realm-server/tests/coerce-error-message-test.ts
+++ b/packages/realm-server/tests/coerce-error-message-test.ts
@@ -48,5 +48,13 @@ module(basename(__filename), function () {
     test('guarantees non-empty for the CS-11185 production shape', async function (assert) {
       await runSharedTest(coerceErrorMessageTests, assert, {});
     });
+
+    test('prefers custom toString() output over placeholder', async function (assert) {
+      await runSharedTest(coerceErrorMessageTests, assert, {});
+    });
+
+    test('skips the default "[object Object]" output', async function (assert) {
+      await runSharedTest(coerceErrorMessageTests, assert, {});
+    });
   });
 });

--- a/packages/realm-server/tests/coerce-error-message-test.ts
+++ b/packages/realm-server/tests/coerce-error-message-test.ts
@@ -1,0 +1,52 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { runSharedTest } from '@cardstack/runtime-common/helpers';
+import coerceErrorMessageTests from '@cardstack/runtime-common/tests/coerce-error-message-test';
+
+module(basename(__filename), function () {
+  module('coerceErrorMessage', function () {
+    test('returns the existing non-empty message', async function (assert) {
+      await runSharedTest(coerceErrorMessageTests, assert, {});
+    });
+
+    test('falls back to title when message is missing', async function (assert) {
+      await runSharedTest(coerceErrorMessageTests, assert, {});
+    });
+
+    test('falls back to title when message is empty string', async function (assert) {
+      await runSharedTest(coerceErrorMessageTests, assert, {});
+    });
+
+    test('falls back to first stack line when message and title are missing', async function (assert) {
+      await runSharedTest(coerceErrorMessageTests, assert, {});
+    });
+
+    test('returns the placeholder for an empty object', async function (assert) {
+      await runSharedTest(coerceErrorMessageTests, assert, {});
+    });
+
+    test('returns the placeholder for undefined', async function (assert) {
+      await runSharedTest(coerceErrorMessageTests, assert, {});
+    });
+
+    test('returns the placeholder for null', async function (assert) {
+      await runSharedTest(coerceErrorMessageTests, assert, {});
+    });
+
+    test('coerces a non-empty string thrown value', async function (assert) {
+      await runSharedTest(coerceErrorMessageTests, assert, {});
+    });
+
+    test('ignores whitespace-only message in favor of title', async function (assert) {
+      await runSharedTest(coerceErrorMessageTests, assert, {});
+    });
+
+    test('preserves the message on a real CardError', async function (assert) {
+      await runSharedTest(coerceErrorMessageTests, assert, {});
+    });
+
+    test('guarantees non-empty for the CS-11185 production shape', async function (assert) {
+      await runSharedTest(coerceErrorMessageTests, assert, {});
+    });
+  });
+});

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -271,6 +271,7 @@ const ALL_TEST_FILES: string[] = [
   './query-matches-filter-test',
   './matches-filter-integration-test',
   './search-in-flight-key-test',
+  './coerce-error-message-test',
   './normalize-realm-meta-value-test',
   './job-scoped-search-cache-test',
   './consuming-realm-header-test',

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -513,8 +513,16 @@ export function serializableError(err: any): any {
 //   1. err.message (if a non-empty string)
 //   2. err.title (if a non-empty string)
 //   3. err.stack first line (if available)
-//   4. String(err) (catches primitives, falls back to "[object Object]")
-//   5. the supplied placeholder
+//   4. For object-shaped errors, String(err) — but only if it's not
+//      the useless default Object.prototype.toString output. A class
+//      with a custom toString() (or some host-provided error wrapper)
+//      may surface real failure text here even when message/title/
+//      stack are absent. The "[object Object]" / "[object …]" output
+//      from the default toString is filtered out: it carries no
+//      diagnostic value, and the placeholder (which names the URL)
+//      is strictly more informative.
+//   5. For primitives, String(err) (numbers, booleans, symbols).
+//   6. the supplied placeholder
 export function coerceErrorMessage(err: unknown, placeholder: string): string {
   let candidates: unknown[] = [];
   if (err != null && typeof err === 'object') {
@@ -528,6 +536,15 @@ export function coerceErrorMessage(err: unknown, placeholder: string): string {
       if (firstLine) {
         candidates.push(firstLine);
       }
+    }
+    let stringified: string;
+    try {
+      stringified = String(err);
+    } catch {
+      stringified = '';
+    }
+    if (stringified && !/^\[object [^\]]*\]$/.test(stringified)) {
+      candidates.push(stringified);
     }
   } else if (typeof err === 'string') {
     candidates.push(err);

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -506,6 +506,42 @@ export function serializableError(err: any): any {
   return result;
 }
 
+// Coerce an arbitrary thrown / serialized value into a non-empty
+// human-readable string. Used to guarantee the `message` of an
+// instance-/file-/module-error row carries enough text to debug.
+// Order of preference:
+//   1. err.message (if a non-empty string)
+//   2. err.title (if a non-empty string)
+//   3. err.stack first line (if available)
+//   4. String(err) (catches primitives, falls back to "[object Object]")
+//   5. the supplied placeholder
+export function coerceErrorMessage(err: unknown, placeholder: string): string {
+  let candidates: unknown[] = [];
+  if (err != null && typeof err === 'object') {
+    candidates.push(
+      (err as { message?: unknown }).message,
+      (err as { title?: unknown }).title,
+    );
+    let stack = (err as { stack?: unknown }).stack;
+    if (typeof stack === 'string') {
+      let firstLine = stack.split('\n', 1)[0]?.trim();
+      if (firstLine) {
+        candidates.push(firstLine);
+      }
+    }
+  } else if (typeof err === 'string') {
+    candidates.push(err);
+  } else if (err !== undefined && err !== null) {
+    candidates.push(String(err));
+  }
+  for (let candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate;
+    }
+  }
+  return placeholder;
+}
+
 export function responseWithError(
   error: CardError,
   requestContext: RequestContext,

--- a/packages/runtime-common/index-runner/card-indexer.ts
+++ b/packages/runtime-common/index-runner/card-indexer.ts
@@ -13,7 +13,12 @@ import {
   type RenderResponse,
   type TimingDiagnostics,
 } from '../index';
-import { CardError, isCardError, serializableError } from '../error';
+import {
+  CardError,
+  coerceErrorMessage,
+  isCardError,
+  serializableError,
+} from '../error';
 import { unresolveResourceInstanceURLs } from '../url';
 import type { IndexRunnerDependencyManager } from './dependency-resolver';
 import { uniqueDeps } from './dependency-collections';
@@ -93,6 +98,10 @@ export async function performCardIndexing({
      * entry with an error, rejects malformed entries missing error payloads,
      * and synthesizes an ErrorEntry from either a CardError or generic Error.
      */
+    // The synthesized fallback message names the instance URL so the
+    // persisted error doc is at least diagnosable by URL when an
+    // upstream caller produced an entry with no usable message text.
+    let missingMessageFallback = `Render error for ${instanceURL.href} produced no error message (upstream entry-construction site dropped the underlying render error text)`;
     let normalizeToErrorEntry = (
       entry: ErrorEntry | undefined,
       err: unknown,
@@ -102,6 +111,10 @@ export async function performCardIndexing({
         normalizedError.additionalErrors =
           normalizedError.additionalErrors ?? null;
         normalizedError.status = normalizedError.status ?? 500;
+        normalizedError.message = coerceErrorMessage(
+          normalizedError,
+          coerceErrorMessage(err, missingMessageFallback),
+        );
         return {
           ...entry,
           type: 'instance-error',
@@ -114,10 +127,15 @@ export async function performCardIndexing({
         });
       }
       if (isCardError(err)) {
-        return { type: 'instance-error', error: serializableError(err) };
+        let serialized = serializableError(err);
+        serialized.message = coerceErrorMessage(
+          serialized,
+          missingMessageFallback,
+        );
+        return { type: 'instance-error', error: serialized };
       }
       let fallback = new CardError(
-        (err as Error)?.message ?? 'unknown render error',
+        coerceErrorMessage(err, missingMessageFallback),
         { status: 500 },
       );
       fallback.stack = (err as Error)?.stack;
@@ -210,9 +228,16 @@ export async function performCardIndexing({
       instanceURL,
     );
   if (dependencyError) {
+    let normalizedDependencyError = {
+      ...dependencyError,
+      message: coerceErrorMessage(
+        dependencyError,
+        `Indexing failed because a dependency of ${instanceURL.href} is in error state`,
+      ),
+    };
     await updateEntry(instanceURL, {
       type: 'instance-error',
-      error: dependencyError,
+      error: normalizedDependencyError,
       searchData: searchDoc ?? undefined,
       types: types ?? undefined,
       cardType:

--- a/packages/runtime-common/index-runner/file-indexer.ts
+++ b/packages/runtime-common/index-runner/file-indexer.ts
@@ -12,7 +12,12 @@ import {
   type ResolvedCodeRef,
   type TimingDiagnostics,
 } from '../index';
-import { CardError, isCardError, serializableError } from '../error';
+import {
+  CardError,
+  coerceErrorMessage,
+  isCardError,
+  serializableError,
+} from '../error';
 import type { IndexRunnerDependencyManager } from './dependency-resolver';
 import { uniqueDeps } from './dependency-collections';
 import {
@@ -78,6 +83,7 @@ export async function performFileIndexing({
   let extractResult: FileExtractResponse | undefined = precomputedExtractResult;
   let uncaughtError: Error | undefined;
 
+  let missingMessageFallback = `File extract error for ${fileURL} produced no error message (upstream entry-construction site dropped the underlying extract error text)`;
   let normalizeToErrorEntry = (
     entry: ErrorEntry | undefined,
     err: unknown,
@@ -87,6 +93,10 @@ export async function performFileIndexing({
       normalizedError.additionalErrors =
         normalizedError.additionalErrors ?? null;
       normalizedError.status = normalizedError.status ?? 500;
+      normalizedError.message = coerceErrorMessage(
+        normalizedError,
+        coerceErrorMessage(err, missingMessageFallback),
+      );
       return {
         ...entry,
         type: 'file-error',
@@ -99,10 +109,15 @@ export async function performFileIndexing({
       });
     }
     if (isCardError(err)) {
-      return { type: 'file-error', error: serializableError(err) };
+      let serialized = serializableError(err);
+      serialized.message = coerceErrorMessage(
+        serialized,
+        missingMessageFallback,
+      );
+      return { type: 'file-error', error: serialized };
     }
     let fallback = new CardError(
-      (err as Error)?.message ?? 'unknown file extract error',
+      coerceErrorMessage(err, missingMessageFallback),
       { status: 500 },
     );
     fallback.stack = (err as Error)?.stack;
@@ -151,9 +166,16 @@ export async function performFileIndexing({
   let dependencyError =
     await dependencyResolver.indexBackedDependencyErrorForEntry(deps, entryURL);
   if (dependencyError) {
+    let normalizedDependencyError = {
+      ...dependencyError,
+      message: coerceErrorMessage(
+        dependencyError,
+        `File indexing failed because a dependency of ${fileURL} is in error state`,
+      ),
+    };
     await updateEntry(entryURL, {
       type: 'file-error',
-      error: dependencyError,
+      error: normalizedDependencyError,
       searchData: {
         url: fileURL,
         sourceUrl: fileURL,

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -519,6 +519,7 @@ export {
   type CardErrorsJSONAPI,
   isCardErrorJSONAPI,
   clampSerializedError,
+  coerceErrorMessage,
   ERROR_DOC_MAX_BYTES,
   ERROR_DOC_MAX_ADDITIONAL_ERRORS,
 } from './error';

--- a/packages/runtime-common/tests/coerce-error-message-test.ts
+++ b/packages/runtime-common/tests/coerce-error-message-test.ts
@@ -96,6 +96,30 @@ const tests = Object.freeze({
     );
     assert.strictEqual(result, PLACEHOLDER);
   },
+
+  // Object with a custom toString() — codex review feedback: prefer
+  // the real text the wrapper exposes over a generic placeholder.
+  'prefers custom toString() output over placeholder': async (assert) => {
+    let err = {
+      toString() {
+        return 'wrapper-specific failure text';
+      },
+    };
+    assert.strictEqual(
+      coerceErrorMessage(err, PLACEHOLDER),
+      'wrapper-specific failure text',
+    );
+  },
+
+  // Plain object's default String(err) is "[object Object]" — that's
+  // less informative than the placeholder (which names the URL), so
+  // it must NOT win. Same for the Object.prototype output of
+  // objects with a tagged toStringTag.
+  'skips the default "[object Object]" output': async (assert) => {
+    assert.strictEqual(coerceErrorMessage({}, PLACEHOLDER), PLACEHOLDER);
+    let tagged = { [Symbol.toStringTag]: 'TaggedError' };
+    assert.strictEqual(coerceErrorMessage(tagged, PLACEHOLDER), PLACEHOLDER);
+  },
 } as SharedTests<{}>);
 
 export default tests;

--- a/packages/runtime-common/tests/coerce-error-message-test.ts
+++ b/packages/runtime-common/tests/coerce-error-message-test.ts
@@ -1,0 +1,101 @@
+import { CardError, coerceErrorMessage } from '../error';
+import type { SharedTests } from '../helpers';
+
+const PLACEHOLDER = 'placeholder fallback message';
+
+const tests = Object.freeze({
+  'returns the existing non-empty message': async (assert) => {
+    assert.strictEqual(
+      coerceErrorMessage({ message: 'render failed' }, PLACEHOLDER),
+      'render failed',
+    );
+  },
+
+  'falls back to title when message is missing': async (assert) => {
+    assert.strictEqual(
+      coerceErrorMessage(
+        { message: undefined, title: 'Internal Server Error' },
+        PLACEHOLDER,
+      ),
+      'Internal Server Error',
+    );
+  },
+
+  'falls back to title when message is empty string': async (assert) => {
+    assert.strictEqual(
+      coerceErrorMessage({ message: '', title: 'Bad Request' }, PLACEHOLDER),
+      'Bad Request',
+    );
+  },
+
+  'falls back to first stack line when message and title are missing': async (
+    assert,
+  ) => {
+    assert.strictEqual(
+      coerceErrorMessage(
+        {
+          message: undefined,
+          stack:
+            'TypeError: Cannot read properties of undefined\n    at foo (bar.ts:1:2)',
+        },
+        PLACEHOLDER,
+      ),
+      'TypeError: Cannot read properties of undefined',
+    );
+  },
+
+  'returns the placeholder for an empty object': async (assert) => {
+    assert.strictEqual(coerceErrorMessage({}, PLACEHOLDER), PLACEHOLDER);
+  },
+
+  'returns the placeholder for undefined': async (assert) => {
+    assert.strictEqual(coerceErrorMessage(undefined, PLACEHOLDER), PLACEHOLDER);
+  },
+
+  'returns the placeholder for null': async (assert) => {
+    assert.strictEqual(coerceErrorMessage(null, PLACEHOLDER), PLACEHOLDER);
+  },
+
+  'coerces a non-empty string thrown value': async (assert) => {
+    assert.strictEqual(
+      coerceErrorMessage('Something went wrong', PLACEHOLDER),
+      'Something went wrong',
+    );
+  },
+
+  'ignores whitespace-only message in favor of title': async (assert) => {
+    assert.strictEqual(
+      coerceErrorMessage({ message: '   ', title: 'Bad Gateway' }, PLACEHOLDER),
+      'Bad Gateway',
+    );
+  },
+
+  'preserves the message on a real CardError': async (assert) => {
+    let err = new CardError('the underlying render error', { status: 500 });
+    assert.strictEqual(
+      coerceErrorMessage(err, PLACEHOLDER),
+      'the underlying render error',
+    );
+  },
+
+  // Reproduces the production scenario behind CS-11185: an
+  // upstream entry-construction site (host window-error-handler or
+  // render route) hands the indexer a serialized error whose
+  // `message` is the JS value `undefined` (often because the host
+  // built `{ message: reason.message }` for a non-Error thrown
+  // value and JSON.stringify dropped the undefined key). The
+  // indexer's index-writer guard would have rejected the upsert and
+  // failed the whole from-scratch reindex job; the chokepoint
+  // helper must now produce a usable placeholder string instead.
+  'guarantees non-empty for the CS-11185 production shape': async (assert) => {
+    let entry = { status: 500, additionalErrors: null };
+    let result = coerceErrorMessage(entry, PLACEHOLDER);
+    assert.ok(
+      typeof result === 'string' && result.length > 0,
+      'result is a non-empty string',
+    );
+    assert.strictEqual(result, PLACEHOLDER);
+  },
+} as SharedTests<{}>);
+
+export default tests;


### PR DESCRIPTION
## Summary

- The `index-writer.ts:412` guard refuses instance-error / file-error rows whose `error.message` is empty/undefined, because such a row is a black hole for triage. Prod CloudWatch confirms upstream host paths were handing the indexer entries where `error.message` was the JS literal `undefined` — JSON.stringify drops undefined keys, so the empty shape survived host → prerender → worker. The guard then aborted the whole from-scratch reindex job for the affected realm on every deploy.
- Defense-in-depth fix: a new `coerceErrorMessage` helper in `runtime-common/error.ts` is applied at every construction site that can feed the guard — both indexer-side (`card-indexer.ts`, `file-indexer.ts`) and host-side (`window-error-handler.ts`, `render.ts`). The helper walks `message → title → stack first line → String(err) → placeholder` and returns the first non-empty string. Synthesized fallbacks name the affected URL so the persisted row is diagnosable by URL even when every upstream signal is lost.

## Linear

CS-11185 — Indexer refused instance-error entry: error.message is empty (upstream dropped underlying render error).

## Affected cards (from prod CloudWatch, last 12h)

All three are `from-scratch-index` jobs — consistent with the post-deploy storm hitting them on every deploy:

- `chris/sparkling-hedgehog/EmbeddedFieldRichMarkdown/inline-widgets-lab.json` (job 209668)
- `dtaylor56/saffron-haven/FormCard/86f2e271-4822-4355-ba62-08ab0a799561.json` (job 209743)
- `mjohnson87/granite-equinox/ProfessionalPost/ai-healthcare-breakthrough.json` (job 209962)

The worker log line `encountered error indexing card instance ...: undefined` (interpolating `${renderError.error.message}`) is the smoking gun that the upstream `RenderError.error.message` is literally the JS value `undefined`, not even an empty string.

## Test plan

- [x] `pnpm lint` (full: js + hbs + types) passes on `packages/host`, `packages/runtime-common`, `packages/realm-server`
- [x] New unit tests for `coerceErrorMessage` cover: non-empty passthrough, title fallback, stack fallback, empty/null/undefined inputs, whitespace-only message, the literal CS-11185 production shape (`{ status: 500, additionalErrors: null }` with no `message` key). Wired through `packages/realm-server/tests/coerce-error-message-test.ts`.
- [ ] CI green (host tests, realm-server tests, indexing-test.ts)
- [ ] Post-merge: confirm Sentry `REALM-SERVER-G5` issue stops accruing new events after next deploy. The from-scratch storm on the next deploy is the natural regression test — affected realms should index cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)