### PR TITLE
Add env-name banner to Grafana overview dashboard

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -31,6 +31,29 @@
     "links": [],
     "panels": [
       {
+        "id": 32,
+        "type": "text",
+        "title": "",
+        "gridPos": {
+          "h": 3,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "description": "Which Grafana environment you are looking at. Rendered from the `env` constant template variable, which apply.sh substitutes to local / staging / production at push time. Designed to make staging vs production unmistakable at a glance.",
+        "transparent": true,
+        "options": {
+          "mode": "html",
+          "code": {
+            "language": "plaintext",
+            "showLineNumbers": false,
+            "showMiniMap": false
+          },
+          "content": "<div style=\"display:flex;align-items:center;justify-content:center;height:100%;width:100%;overflow:hidden;font-size:36px;font-weight:700;letter-spacing:2px;text-transform:capitalize;font-family:Inter,system-ui,sans-serif;color:var(--text-primary)\">${env}</div>"
+        },
+        "pluginVersion": "12.4.3"
+      },
+      {
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "cef5v5sl9k7i8f"
@@ -87,7 +110,7 @@
           "h": 8,
           "w": 8,
           "x": 0,
-          "y": 0
+          "y": 3
         },
         "id": 21,
         "links": [
@@ -105,7 +128,9 @@
           "justifyMode": "auto",
           "orientation": "auto",
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "",
             "values": false
           },
@@ -187,7 +212,7 @@
           "h": 8,
           "w": 8,
           "x": 8,
-          "y": 0
+          "y": 3
         },
         "id": 22,
         "links": [
@@ -205,7 +230,9 @@
           "justifyMode": "auto",
           "orientation": "auto",
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "",
             "values": false
           },
@@ -287,7 +314,7 @@
           "h": 5,
           "w": 8,
           "x": 16,
-          "y": 0
+          "y": 3
         },
         "id": 30,
         "links": [
@@ -397,7 +424,7 @@
           "h": 3,
           "w": 8,
           "x": 16,
-          "y": 5
+          "y": 8
         },
         "id": 31,
         "options": {
@@ -546,12 +573,24 @@
                 "options": "p50"
               },
               "properties": [
-                { "id": "unit", "value": "s" },
-                { "id": "custom.axisPlacement", "value": "right" },
-                { "id": "custom.fillOpacity", "value": 0 },
+                {
+                  "id": "unit",
+                  "value": "s"
+                },
+                {
+                  "id": "custom.axisPlacement",
+                  "value": "right"
+                },
+                {
+                  "id": "custom.fillOpacity",
+                  "value": 0
+                },
                 {
                   "id": "color",
-                  "value": { "mode": "fixed", "fixedColor": "#73bf69" }
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "#73bf69"
+                  }
                 }
               ]
             },
@@ -561,12 +600,24 @@
                 "options": "p95"
               },
               "properties": [
-                { "id": "unit", "value": "s" },
-                { "id": "custom.axisPlacement", "value": "right" },
-                { "id": "custom.fillOpacity", "value": 0 },
+                {
+                  "id": "unit",
+                  "value": "s"
+                },
+                {
+                  "id": "custom.axisPlacement",
+                  "value": "right"
+                },
+                {
+                  "id": "custom.fillOpacity",
+                  "value": 0
+                },
                 {
                   "id": "color",
-                  "value": { "mode": "fixed", "fixedColor": "#ff9830" }
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "#ff9830"
+                  }
                 }
               ]
             },
@@ -576,12 +627,24 @@
                 "options": "p99"
               },
               "properties": [
-                { "id": "unit", "value": "s" },
-                { "id": "custom.axisPlacement", "value": "right" },
-                { "id": "custom.fillOpacity", "value": 0 },
+                {
+                  "id": "unit",
+                  "value": "s"
+                },
+                {
+                  "id": "custom.axisPlacement",
+                  "value": "right"
+                },
+                {
+                  "id": "custom.fillOpacity",
+                  "value": 0
+                },
                 {
                   "id": "color",
-                  "value": { "mode": "fixed", "fixedColor": "#f2495c" }
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "#f2495c"
+                  }
                 }
               ]
             }
@@ -591,12 +654,14 @@
           "h": 8,
           "w": 8,
           "x": 0,
-          "y": 8
+          "y": 11
         },
         "id": 1,
         "options": {
           "legend": {
-            "calcs": ["mean"],
+            "calcs": [
+              "mean"
+            ],
             "displayMode": "list",
             "placement": "bottom",
             "showLegend": true
@@ -629,12 +694,17 @@
             "refId": "B"
           },
           {
-            "datasource": { "type": "cloudwatch", "uid": "cef5x9o3yzawwf" },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
             "namespace": "AWS/ApplicationELB",
             "metricName": "TargetResponseTime",
             "metricEditorMode": 0,
             "metricQueryType": 0,
-            "dimensions": { "LoadBalancer": "$realm_server_alb" },
+            "dimensions": {
+              "LoadBalancer": "$realm_server_alb"
+            },
             "statistic": "p50",
             "period": "",
             "region": "default",
@@ -642,12 +712,17 @@
             "refId": "C"
           },
           {
-            "datasource": { "type": "cloudwatch", "uid": "cef5x9o3yzawwf" },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
             "namespace": "AWS/ApplicationELB",
             "metricName": "TargetResponseTime",
             "metricEditorMode": 0,
             "metricQueryType": 0,
-            "dimensions": { "LoadBalancer": "$realm_server_alb" },
+            "dimensions": {
+              "LoadBalancer": "$realm_server_alb"
+            },
             "statistic": "p95",
             "period": "",
             "region": "default",
@@ -655,12 +730,17 @@
             "refId": "D"
           },
           {
-            "datasource": { "type": "cloudwatch", "uid": "cef5x9o3yzawwf" },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
             "namespace": "AWS/ApplicationELB",
             "metricName": "TargetResponseTime",
             "metricEditorMode": 0,
             "metricQueryType": 0,
-            "dimensions": { "LoadBalancer": "$realm_server_alb" },
+            "dimensions": {
+              "LoadBalancer": "$realm_server_alb"
+            },
             "statistic": "p99",
             "period": "",
             "region": "default",
@@ -685,7 +765,7 @@
           "type": "grafana-postgresql-datasource",
           "uid": "cef5v5sl9k7i8f"
         },
-        "description": "Priority-pending worker jobs (status='unfulfilled' with no active reservation AND priority < 0). Sparkline shows resolved jobs/min over the dashboard time range, with the trailing point set to the current priority-pending count so `lastNotNull` matches the displayed value. Color thresholds: green \u22643, yellow >3, red >10. Counts ALL job types \u2014 for indexing-only depth see the Indexing dashboard.",
+        "description": "Priority-pending worker jobs (status='unfulfilled' with no active reservation AND priority < 0). Sparkline shows resolved jobs/min over the dashboard time range, with the trailing point set to the current priority-pending count so `lastNotNull` matches the displayed value. Color thresholds: green ≤3, yellow >3, red >10. Counts ALL job types — for indexing-only depth see the Indexing dashboard.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -725,7 +805,7 @@
           "h": 8,
           "w": 8,
           "x": 8,
-          "y": 8
+          "y": 11
         },
         "id": 4,
         "links": [
@@ -743,7 +823,9 @@
           "justifyMode": "auto",
           "orientation": "vertical",
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "",
             "values": false
           },
@@ -848,7 +930,7 @@
           "h": 8,
           "w": 8,
           "x": 16,
-          "y": 8
+          "y": 11
         },
         "id": 5,
         "links": [
@@ -862,7 +944,9 @@
         ],
         "options": {
           "legend": {
-            "calcs": ["mean"],
+            "calcs": [
+              "mean"
+            ],
             "displayMode": "list",
             "placement": "bottom",
             "showLegend": true
@@ -1006,7 +1090,7 @@
           "h": 4,
           "w": 4,
           "x": 0,
-          "y": 16
+          "y": 19
         },
         "id": 13,
         "options": {
@@ -1020,7 +1104,9 @@
           "maxVizHeight": 300,
           "sizing": "auto",
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "",
             "values": false
           }
@@ -1122,7 +1208,7 @@
           "h": 3,
           "w": 4,
           "x": 0,
-          "y": 20
+          "y": 23
         },
         "id": 23,
         "options": {
@@ -1131,7 +1217,9 @@
           "justifyMode": "center",
           "orientation": "horizontal",
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "e1",
             "values": false
           },
@@ -1333,7 +1421,7 @@
           "h": 4,
           "w": 4,
           "x": 4,
-          "y": 16
+          "y": 19
         },
         "id": 14,
         "options": {
@@ -1347,7 +1435,9 @@
           "maxVizHeight": 300,
           "sizing": "auto",
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "",
             "values": false
           }
@@ -1449,7 +1539,7 @@
           "h": 3,
           "w": 4,
           "x": 4,
-          "y": 20
+          "y": 23
         },
         "id": 24,
         "options": {
@@ -1458,7 +1548,9 @@
           "justifyMode": "center",
           "orientation": "horizontal",
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "e1",
             "values": false
           },
@@ -1660,7 +1752,7 @@
           "h": 4,
           "w": 4,
           "x": 8,
-          "y": 16
+          "y": 19
         },
         "id": 15,
         "options": {
@@ -1674,7 +1766,9 @@
           "maxVizHeight": 300,
           "sizing": "auto",
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "",
             "values": false
           }
@@ -1776,7 +1870,7 @@
           "h": 3,
           "w": 4,
           "x": 8,
-          "y": 20
+          "y": 23
         },
         "id": 25,
         "options": {
@@ -1785,7 +1879,9 @@
           "justifyMode": "center",
           "orientation": "horizontal",
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "e1",
             "values": false
           },
@@ -1987,7 +2083,7 @@
           "h": 4,
           "w": 4,
           "x": 12,
-          "y": 16
+          "y": 19
         },
         "id": 16,
         "options": {
@@ -2001,7 +2097,9 @@
           "maxVizHeight": 300,
           "sizing": "auto",
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "",
             "values": false
           }
@@ -2103,7 +2201,7 @@
           "h": 3,
           "w": 4,
           "x": 12,
-          "y": 20
+          "y": 23
         },
         "id": 26,
         "options": {
@@ -2112,7 +2210,9 @@
           "justifyMode": "center",
           "orientation": "horizontal",
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "e1",
             "values": false
           },
@@ -2310,7 +2410,7 @@
           "h": 7,
           "w": 4,
           "x": 16,
-          "y": 16
+          "y": 19
         },
         "id": 17,
         "links": [
@@ -2337,7 +2437,9 @@
             "valueSize": 21
           },
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "",
             "values": false
           }
@@ -2409,7 +2511,7 @@
           "h": 7,
           "w": 4,
           "x": 20,
-          "y": 16
+          "y": 19
         },
         "id": 18,
         "options": {
@@ -2418,7 +2520,9 @@
           "justifyMode": "auto",
           "orientation": "vertical",
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "",
             "values": false
           },
@@ -2447,7 +2551,7 @@
           "h": 8,
           "w": 24,
           "x": 0,
-          "y": 33
+          "y": 36
         },
         "id": 6,
         "options": {
@@ -2512,7 +2616,7 @@
           "h": 4,
           "w": 6,
           "x": 0,
-          "y": 23
+          "y": 26
         },
         "id": 7,
         "options": {
@@ -2521,7 +2625,9 @@
           "justifyMode": "auto",
           "orientation": "horizontal",
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "",
             "values": false
           },
@@ -2578,7 +2684,7 @@
           "h": 4,
           "w": 6,
           "x": 6,
-          "y": 23
+          "y": 26
         },
         "id": 8,
         "options": {
@@ -2587,7 +2693,9 @@
           "justifyMode": "auto",
           "orientation": "horizontal",
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "",
             "values": false
           },
@@ -2653,7 +2761,7 @@
           "h": 4,
           "w": 6,
           "x": 12,
-          "y": 23
+          "y": 26
         },
         "id": 9,
         "options": {
@@ -2662,7 +2770,9 @@
           "justifyMode": "auto",
           "orientation": "horizontal",
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "",
             "values": false
           },
@@ -2723,7 +2833,7 @@
           "h": 4,
           "w": 6,
           "x": 18,
-          "y": 23
+          "y": 26
         },
         "id": 10,
         "options": {
@@ -2732,7 +2842,9 @@
           "justifyMode": "auto",
           "orientation": "horizontal",
           "reduceOptions": {
-            "calcs": ["lastNotNull"],
+            "calcs": [
+              "lastNotNull"
+            ],
             "fields": "",
             "values": false
           },
@@ -2865,7 +2977,7 @@
           "h": 6,
           "w": 24,
           "x": 0,
-          "y": 27
+          "y": 30
         },
         "id": 11,
         "options": {
@@ -2924,7 +3036,7 @@
           "h": 8,
           "w": 24,
           "x": 0,
-          "y": 41
+          "y": 44
         },
         "id": 12,
         "options": {
@@ -2943,7 +3055,9 @@
     ],
     "refresh": "30s",
     "schemaVersion": 42,
-    "tags": ["overview"],
+    "tags": [
+      "overview"
+    ],
     "templating": {
       "list": [
         {
@@ -2955,7 +3069,10 @@
         },
         {
           "current": {},
-          "datasource": { "type": "cloudwatch", "uid": "cef5x9o3yzawwf" },
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "cef5x9o3yzawwf"
+          },
           "definition": "dimension_values(default,AWS/ApplicationELB,RequestCount,LoadBalancer)",
           "hide": 2,
           "includeAll": false,


### PR DESCRIPTION
## Summary
- Adds a wide, theme-aware banner across the top of the Boxel Status → Overview dashboard that displays the current environment (Local / Staging / Production) so it's harder to mistake staging for production at a glance.
- Reads from the existing \`env\` constant template variable (apply.sh already substitutes \`__ENV__\` → \`local|staging|production\` at push time). No new datasources, no new env vars.
- Text panel with HTML mode and inline CSS; color comes from Grafana's \`var(--text-primary)\` so the banner adapts automatically to dark vs light mode and matches the panel background (transparent).

## Test plan
- [x] Local docker-compose Grafana renders the banner with "Local" centered, no scrollbar, panel-matching background.
- [ ] On merge, staging picks up the banner via the observability-apply workflow and renders "Staging".
- [ ] Same for production: renders "Production".

🤖 Generated with [Claude Code](https://claude.com/claude-code)