### PR TITLE
Optimize RuntimeDependencyTracker hot path (CS-11197)

### DIFF
--- a/packages/runtime-common/dependency-tracker.ts
+++ b/packages/runtime-common/dependency-tracker.ts
@@ -283,7 +283,13 @@ export class RuntimeDependencyTracker {
     }
 
     let context = explicitContext ?? this.#currentContext();
+
+    // The short-circuit cache only applies to stack-top contexts. Those frames
+    // are constructed inside withContext() and never mutated afterward, so
+    // reference equality is sound. Caller-supplied explicit contexts are
+    // structurally mutable, so identity equality does not imply field equality.
     if (
+      !explicitContext &&
       rawURL === this.#lastTrackRawURL &&
       kind === this.#lastTrackKind &&
       context === this.#lastTrackContext
@@ -296,9 +302,11 @@ export class RuntimeDependencyTracker {
       return;
     }
 
-    this.#lastTrackKind = kind;
-    this.#lastTrackRawURL = rawURL;
-    this.#lastTrackContext = context;
+    if (!explicitContext) {
+      this.#lastTrackKind = kind;
+      this.#lastTrackRawURL = rawURL;
+      this.#lastTrackContext = context;
+    }
 
     let label = contextLabel(context);
     let consumer = this.#normalizeConsumer(context, label);

--- a/packages/runtime-common/dependency-tracker.ts
+++ b/packages/runtime-common/dependency-tracker.ts
@@ -1,4 +1,3 @@
-import { logger } from './log';
 import { executableExtensions } from './index';
 
 export type RuntimeDependencyNodeKind = 'module' | 'instance' | 'file';
@@ -34,12 +33,6 @@ interface NodeRecord {
   queryContexts: Set<string>;
   nonQueryContexts: Set<string>;
   hasUnscopedAccess: boolean;
-}
-
-interface EdgeRecord {
-  from: string;
-  to: string;
-  contexts: Set<string>;
 }
 
 interface ContextStackEntry {
@@ -132,14 +125,18 @@ function isPromiseLike<T = unknown>(value: unknown): value is Promise<T> {
 }
 
 export class RuntimeDependencyTracker {
-  #summaryLog: ReturnType<typeof logger> | undefined;
-  #edgesLog: ReturnType<typeof logger> | undefined;
   #sessionKey: string | undefined;
   #isActive = false;
   #contextStack: ContextStackEntry[] = [];
   #nodes = new Map<string, NodeRecord>();
-  #edges = new Map<string, EdgeRecord>();
   #rootCandidates = new Set<string>();
+
+  // Short-circuit cache: repeated field reads under the same context call
+  // #track with the same (kind, rawURL, context) triple. Skipping those is
+  // safe because all downstream work (normalization, Set.add) is idempotent.
+  #lastTrackKind: RuntimeDependencyNodeKind | undefined;
+  #lastTrackRawURL: string | undefined;
+  #lastTrackContext: RuntimeDependencyTrackingContext | undefined;
 
   startSession({
     sessionKey,
@@ -152,23 +149,22 @@ export class RuntimeDependencyTracker {
     }
     this.#isActive = true;
     this.#setRoot(rootURL, rootKind);
-    this.#summaryLogger().debug(`start session ${sessionKey}`);
   }
 
   stopSession(): void {
     if (!this.#isActive) {
       return;
     }
-    this.#summaryLogger().debug(`stop session ${this.#sessionKey ?? '(none)'}`);
     this.#isActive = false;
     this.#contextStack = [];
+    this.#clearTrackCache();
   }
 
   reset(): void {
     this.#nodes.clear();
-    this.#edges.clear();
     this.#rootCandidates.clear();
     this.#contextStack = [];
+    this.#clearTrackCache();
   }
 
   withContext<T>(context: RuntimeDependencyTrackingContext, cb: () => T): T {
@@ -254,10 +250,6 @@ export class RuntimeDependencyTracker {
     excludedQueryOnlyDeps.sort();
     unscopedDeps.sort();
 
-    this.#summaryLogger().debug(
-      `session=${this.#sessionKey ?? '(none)'} deps=${deps.length} excludedQueryOnly=${excludedQueryOnlyDeps.length} unscoped=${unscopedDeps.length} nodes=${this.#nodes.size} edges=${this.#edges.size}`,
-    );
-
     return { deps, excludedQueryOnlyDeps, unscopedDeps };
   }
 
@@ -289,28 +281,35 @@ export class RuntimeDependencyTracker {
     if (!this.#isActive) {
       return;
     }
+
+    let context = explicitContext ?? this.#currentContext();
+    if (
+      rawURL === this.#lastTrackRawURL &&
+      kind === this.#lastTrackKind &&
+      context === this.#lastTrackContext
+    ) {
+      return;
+    }
+
     let dep = normalizeByKind(kind, rawURL);
     if (!dep) {
       return;
     }
 
-    let context = explicitContext ?? this.#currentContext();
+    this.#lastTrackKind = kind;
+    this.#lastTrackRawURL = rawURL;
+    this.#lastTrackContext = context;
+
     let label = contextLabel(context);
-    let consumer = this.#normalizeConsumer(context);
+    let consumer = this.#normalizeConsumer(context, label);
 
-    this.#recordNode(dep, kind, context, !consumer);
-    if (!consumer) {
-      this.#edgesLogger().debug(`unscoped ${kind} ${dep} context=${label}`);
-      return;
-    }
-
-    this.#recordEdge(consumer.url, dep, label);
-    this.#edgesLogger().debug(
-      `edge ${consumer.url} -> ${dep} context=${label} source=${context.source ?? '(unknown-source)'}`,
-    );
+    this.#recordNode(dep, kind, context.mode, label, !consumer);
   }
 
-  #normalizeConsumer(context: RuntimeDependencyTrackingContext): {
+  #normalizeConsumer(
+    context: RuntimeDependencyTrackingContext,
+    label: string,
+  ): {
     url: string;
     kind: RuntimeDependencyNodeKind;
   } | null {
@@ -320,13 +319,13 @@ export class RuntimeDependencyTracker {
     let preferredKind = context.consumerKind ?? 'instance';
     let preferredURL = normalizeByKind(preferredKind, context.consumer);
     if (preferredURL) {
-      this.#recordNode(preferredURL, preferredKind, context, false);
+      this.#recordNode(preferredURL, preferredKind, context.mode, label, false);
       return { url: preferredURL, kind: preferredKind };
     }
 
     let fallbackFile = normalizeFileURL(context.consumer);
     if (fallbackFile) {
-      this.#recordNode(fallbackFile, 'file', context, false);
+      this.#recordNode(fallbackFile, 'file', context.mode, label, false);
       return { url: fallbackFile, kind: 'file' };
     }
     return null;
@@ -335,7 +334,8 @@ export class RuntimeDependencyTracker {
   #recordNode(
     dep: string,
     kind: RuntimeDependencyNodeKind,
-    context: RuntimeDependencyTrackingContext,
+    mode: RuntimeDependencyContextMode | undefined,
+    label: string,
     unscoped: boolean,
   ) {
     let record = this.#nodes.get(dep);
@@ -350,46 +350,24 @@ export class RuntimeDependencyTracker {
     }
 
     record.kinds.add(kind);
-    if (context.mode === 'query') {
-      record.queryContexts.add(contextLabel(context));
+    if (mode === 'query') {
+      record.queryContexts.add(label);
     } else {
-      record.nonQueryContexts.add(contextLabel(context));
+      record.nonQueryContexts.add(label);
     }
     if (unscoped) {
       record.hasUnscopedAccess = true;
     }
   }
 
-  #recordEdge(from: string, to: string, context: string) {
-    let key = `${from}|${to}`;
-    let edge = this.#edges.get(key);
-    if (!edge) {
-      edge = {
-        from,
-        to,
-        contexts: new Set(),
-      };
-      this.#edges.set(key, edge);
-    }
-    edge.contexts.add(context);
-  }
-
   #currentContext(): RuntimeDependencyTrackingContext {
     return this.#contextStack[this.#contextStack.length - 1]?.context ?? {};
   }
 
-  #summaryLogger(): ReturnType<typeof logger> {
-    if (!this.#summaryLog) {
-      this.#summaryLog = logger('dependency-tracker:summary');
-    }
-    return this.#summaryLog;
-  }
-
-  #edgesLogger(): ReturnType<typeof logger> {
-    if (!this.#edgesLog) {
-      this.#edgesLog = logger('dependency-tracker:edges');
-    }
-    return this.#edgesLog;
+  #clearTrackCache(): void {
+    this.#lastTrackKind = undefined;
+    this.#lastTrackRawURL = undefined;
+    this.#lastTrackContext = undefined;
   }
 }
 


### PR DESCRIPTION
## Why

`RuntimeDependencyTracker.#recordEdge` + `#track` were the second-largest hot path in the wide cohort-render Chrome trace from [CS-11197](https://linear.app/cardstack/issue/CS-11197) — ~10 s of CPU in a 190 s trace (~14.6%), invoked thousands of times per render because every dependency-tracked field read flows through them. The ticket breaks the cost into three sources; this PR addresses all three by removing the work outright wherever possible.

## What changed

### 1. Debug loggers retired

Both `dependency-tracker:summary` and `dependency-tracker:edges` loggers built their template-literal payloads on every tracked field access:

```ts
this.#edgesLogger().debug(`unscoped ${kind} ${dep} context=${label}`);
this.#edgesLogger().debug(
  `edge ${consumer.url} -> ${dep} context=${label} source=${context.source ?? '(unknown-source)'}`,
);
```

The strings were allocated unconditionally, before `.debug()` decided whether to emit. They were originally added for diagnosing the dependency-graph rollout and have served that purpose; removing them eliminates the per-call string + GC churn.

### 2. `#edges` / `EdgeRecord` / `#recordEdge` removed as dead code

Once the summary debug log went away, the only remaining reads of `#edges` disappeared with it — `snapshot()` builds its result from `#nodes`, never `#edges`. That made the entire edge-tracking subsystem unreferenced. Removing it eliminates outright:

- The per-call `let key = \`${from}|${to}\`;` string-concat allocation.
- The `Map.get` + `Map.set` for new edges.
- The `Set.add` for each `(from, to, context)` triple.
- The `EdgeRecord` interface and the `#edges` field itself.

This is the bulk of the win — the ticket suggested a two-level `Map<from, Map<to, EdgeRecord>>` to avoid the concat, but the deeper truth is that no code reads the structure at all.

### 3. `#track` short-circuit cache for repeat reads under one frame

A field read 50× during a render fires 50 calls into `#track` with the same `(kind, rawURL)` under the same `withContext` frame. The cache caches the previous call's `(kind, rawURL, context)` and bails after three `===` checks — no normalization, no `Map.get`, no `Set.add`.

**Soundness:** the cache only applies when the call came through the stack (no explicit context argument). Those frames are constructed inside `withContext()` and never mutated afterward, so reference equality implies field equality. Caller-supplied explicit contexts are caller-owned and structurally mutable (per `RuntimeDependencyTrackingContext`), so identity equality would not be safe there — that path skips the cache. (See commit `e0e5c84` for the narrowed check, prompted by Codex's review.)

### 4. `contextLabel` computed once per `#track`

Previously `contextLabel(context)` ran up to 3× per `#track` call — once in `#track`, then again inside `#recordNode` for the consumer node (via `#normalizeConsumer`) and once more for the dep node. The label is now computed once and threaded through `#normalizeConsumer` + `#recordNode`.

## Expected impact

Per the ticket's trace breakdown (`#recordEdge` cumulative 74,255 samples, `#track` self-time 1,807):

- Debug-string removal: 1–3 s + meaningful GC reduction.
- `#recordEdge` deletion (subsuming the ticket's "short-circuit duplicate edges" + "two-level Map keys" wins): 3–6 s.
- `#track` short-circuit + single-label compute: 1–2 s on top.

Realistic ceiling: 5–7 s of the 10 s spent here, plus indirect GC wins.

## Risk

- Public surface unchanged — exported functions, signatures, and `snapshot()` shape are all preserved.
- Tracking behavior is unchanged: every dep that was previously recorded in `#nodes` is still recorded; the deleted `#edges` was already write-only.
- 9/9 existing `runtime-dependency-tracker-test.ts` cases pass, including the explicit-context overlap test that exercises the no-cache path.

## Test plan

- [x] `runtime-dependency-tracker-test.ts` — 9/9 pass locally on both commits
- [x] `pnpm lint:js` clean for `packages/runtime-common`
- [ ] CI green
- [ ] Re-trace a wide cohort render after this lands and confirm tracker drops out of the top-2 hot paths