### PR TITLE
CS-11013 include Copy Card URL in error-card menu

### DIFF
--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -623,8 +623,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
       new MenuItem({
         label: 'Copy Card URL',
         action: () =>
-          this.cardIdentifier &&
-          copyCardURLToClipboard(this.cardIdentifier),
+          this.cardIdentifier && copyCardURLToClipboard(this.cardIdentifier),
         icon: IconLink,
         disabled: !this.cardIdentifier,
       }),

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -32,12 +32,13 @@ import {
 import {
   MenuDivider,
   MenuItem,
+  copyCardURLToClipboard,
   getContrastColor,
   toMenuItems,
 } from '@cardstack/boxel-ui/helpers';
 import { cn, cssVar, optional, not } from '@cardstack/boxel-ui/helpers';
 
-import { IconTrash } from '@cardstack/boxel-ui/icons';
+import { IconLink, IconTrash } from '@cardstack/boxel-ui/icons';
 
 import type { CommandContext } from '@cardstack/runtime-common';
 import {
@@ -619,6 +620,14 @@ export default class OperatorModeStackItem extends Component<Signature> {
       return undefined;
     }
     return [
+      new MenuItem({
+        label: 'Copy Card URL',
+        action: () =>
+          this.cardIdentifier &&
+          copyCardURLToClipboard(this.cardIdentifier),
+        icon: IconLink,
+        disabled: !this.cardIdentifier,
+      }),
       new MenuItem({
         label: 'Delete Card',
         action: () =>

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -664,6 +664,23 @@ module('Acceptance | operator mode tests', function (hooks) {
       .includesText(`Person/missing-link.json not found`);
   });
 
+  test('error card header more-options menu includes Copy Card URL', async function (assert) {
+    await visit('/test/Person/error');
+
+    await waitFor(
+      `[data-test-stack-card="${testRealmURL}Person/error"] [data-test-card-error]`,
+    );
+    await click(
+      `[data-test-stack-card="${testRealmURL}Person/error"] [data-test-more-options-button]`,
+    );
+    assert
+      .dom('[data-test-boxel-menu-item-text="Copy Card URL"]')
+      .exists('Copy Card URL is available even when the card is an error doc');
+    assert
+      .dom('[data-test-boxel-menu-item-text="Delete Card"]')
+      .exists('Delete Card remains available on the error card menu');
+  });
+
   test('can visit a card via canonical URL from second realm', async function (assert) {
     await visit(`/user/test2/Person/1`);
 


### PR DESCRIPTION
## Summary
- Add **Copy Card URL** to the stack-item header's "more options" menu when the card is rendered as an error doc. Previously the menu offered only **Delete Card**, even though operators usually need that URL to triage the failure.
- `cardIdentifier` (used by the existing Delete action) already falls back to `cardError.id`, so the new action works for any error row whose `id` is known. It's disabled when the id is missing (e.g. 404s with no id).
- Adds an acceptance test alongside the existing `can visit a card in error state via canonical URL` test.

Linear: [CS-11013](https://linear.app/cardstack/issue/CS-11013/make-copy-card-url-appear-in-interact-menu-when-card-is-error-doc)

## Test plan
- [ ] `pnpm --filter @cardstack/host test --path=dist --filter "operator mode tests"` passes, including the new `error card header more-options menu includes Copy Card URL` test.
- [ ] Manually: visit a card whose linked module is missing → open the "..." menu in the stack header → confirm both **Copy Card URL** and **Delete Card** appear and that Copy Card URL writes the card's canonical URL to the clipboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)