### PR TITLE
Brand realm identifiers on RealmServerService and Workspace

### DIFF
--- a/packages/host/app/commands/create-submission-workflow.ts
+++ b/packages/host/app/commands/create-submission-workflow.ts
@@ -37,7 +37,7 @@ export default class CreateSubmissionWorkflowCommand extends HostBaseCommand<
   requireInputFields = ['realm', 'listingId'];
 
   get submissionsRealm(): string | undefined {
-    return this.realmServer.catalogRealmURLs.find((realm) =>
+    return this.realmServer.catalogRealmIdentifiers.find((realm) =>
       realm.endsWith('/submissions/'),
     );
   }
@@ -165,7 +165,7 @@ export default class CreateSubmissionWorkflowCommand extends HostBaseCommand<
   }
 
   private get catalogRealm(): string | undefined {
-    return this.realmServer.catalogRealmURLs.find((realm) =>
+    return this.realmServer.catalogRealmIdentifiers.find((realm) =>
       realm.endsWith('/catalog/'),
     );
   }

--- a/packages/host/app/commands/get-available-realm-identifiers.ts
+++ b/packages/host/app/commands/get-available-realm-identifiers.ts
@@ -23,7 +23,7 @@ export default class GetAvailableRealmIdentifiersCommand extends HostBaseCommand
     let commandModule = await this.loadCommandModule();
     const { GetAvailableRealmIdentifiersResult } = commandModule;
     return new GetAvailableRealmIdentifiersResult({
-      realmIdentifiers: this.realmServer.availableRealmURLs,
+      realmIdentifiers: this.realmServer.availableRealmIdentifiers,
     });
   }
 }

--- a/packages/host/app/commands/get-catalog-realm-identifiers.ts
+++ b/packages/host/app/commands/get-catalog-realm-identifiers.ts
@@ -23,7 +23,7 @@ export default class GetCatalogRealmIdentifiersCommand extends HostBaseCommand<
     let commandModule = await this.loadCommandModule();
     const { GetCatalogRealmIdentifiersResult } = commandModule;
     return new GetCatalogRealmIdentifiersResult({
-      realmIdentifiers: this.realmServer.catalogRealmURLs,
+      realmIdentifiers: this.realmServer.catalogRealmIdentifiers,
     });
   }
 }

--- a/packages/host/app/commands/search-cards.ts
+++ b/packages/host/app/commands/search-cards.ts
@@ -75,7 +75,7 @@ export class SearchCardsByQueryCommand extends HostBaseCommand<
     input: BaseCommandModule.SearchCardsByQueryInput,
   ): Promise<BaseCommandModule.SearchCardsResult> {
     assertQuery(input.query);
-    let realmUrls = this.realmServer.availableRealmURLs;
+    let realmUrls = this.realmServer.availableRealmIdentifiers;
     let instances: CardDef[] = [];
     try {
       instances = await this.store.search(input.query, realmUrls);

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -344,7 +344,7 @@ export default class CardCatalogModal extends Component<Signature> {
       await this.realmServer.ready;
       // Preload realm info without blocking the modal from opening.
       let prefetchRealmInfo = Promise.all(
-        this.realmServer.availableRealmURLs.map(async (realmURL) => {
+        this.realmServer.availableRealmIdentifiers.map(async (realmURL) => {
           let resource = this.realm.getOrCreateRealmResource(realmURL);
           try {
             await resource.fetchInfo();
@@ -378,7 +378,7 @@ export default class CardCatalogModal extends Component<Signature> {
       if (opts?.preselectedCardTypeQuery) {
         let instances: CardDef[] = await this.store.search(
           opts.preselectedCardTypeQuery!,
-          this.realmServer.availableRealmURLs,
+          this.realmServer.availableRealmIdentifiers,
         );
         if (instances?.[0]?.id) {
           preselectedCardUrl = `${instances[0].id}.json`;
@@ -399,7 +399,7 @@ export default class CardCatalogModal extends Component<Signature> {
         searchKey: '',
         dismissModal: false,
         baseFilter: query.filter,
-        availableRealmUrls: this.realmServer.availableRealmURLs,
+        availableRealmUrls: this.realmServer.availableRealmIdentifiers,
         selectedCards: preselectedCardUrls,
         multiSelect: opts?.multiSelect ?? false,
         hasPreselectedCard: preselectedCardUrls.length > 0,

--- a/packages/host/app/components/card-search/panel.gts
+++ b/packages/host/app/components/card-search/panel.gts
@@ -66,7 +66,7 @@ export default class SearchPanel extends Component<Signature> {
 
   private get selectedRealmURLs(): string[] {
     if (this.selectedRealms.length === 0) {
-      return this.realmServer.availableRealmURLs;
+      return this.realmServer.availableRealmIdentifiers;
     }
     return this.selectedRealms.map((url) => url.href);
   }

--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -167,7 +167,7 @@ export default class SearchContent extends Component<Signature> {
   private get searchKeyAsURL() {
     return resolveSearchKeyAsURL(
       this.args.searchKey,
-      this.realmServer.availableRealmURLs,
+      this.realmServer.availableRealmIdentifiers,
     );
   }
 
@@ -328,7 +328,7 @@ export default class SearchContent extends Component<Signature> {
     const urls =
       this.args.realmFilter.selectedURLs.length > 0
         ? this.args.realmFilter.selectedURLs
-        : this.realmServer.availableRealmURLs;
+        : this.realmServer.availableRealmIdentifiers;
     return urls ?? [];
   }
 

--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -465,7 +465,7 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
     this.specSearch = this.getCards(
       this,
       () => this.queryForSpecsForSelectedDefinition,
-      () => this.realmServer.availableRealmURLs,
+      () => this.realmServer.availableRealmIdentifiers,
       { isLive: true, doWhileRefreshing: this.doWhileRefreshing },
     ) as ReturnType<getCards<Spec>>;
   };

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -360,7 +360,7 @@ export default class PlaygroundPanel extends Component<Signature> {
     this.fileSearchResults = this.getCards(
       this,
       () => this.fileMetaQuery,
-      () => this.realmServer.availableRealmURLs,
+      () => this.realmServer.availableRealmIdentifiers,
       { isLive: true },
     );
   };
@@ -997,7 +997,7 @@ export default class PlaygroundPanel extends Component<Signature> {
             <PrerenderedCardSearch
               @query={{this.expandedQuery}}
               @format='fitted'
-              @realms={{this.realmServer.availableRealmURLs}}
+              @realms={{this.realmServer.availableRealmIdentifiers}}
             >
               <:response as |maybeCards|>
                 {{! TODO: remove side-effects for instance chooser in CS-8746 }}
@@ -1139,7 +1139,7 @@ export default class PlaygroundPanel extends Component<Signature> {
               {{else if this.maybeGenerateFieldSpec}}
                 <SpecSearch
                   @query={{this.specQuery}}
-                  @realms={{this.realmServer.availableRealmURLs}}
+                  @realms={{this.realmServer.availableRealmIdentifiers}}
                   @createNewCard={{this.createNew}}
                 />
               {{else if @isFileDef}}

--- a/packages/host/app/components/operator-mode/workspace-chooser/index.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/index.gts
@@ -189,7 +189,10 @@ export default class WorkspaceChooser extends Component<Signature> {
             {{else}}
               <div class='workspace-list' data-test-workspace-list>
                 {{#each this.filteredUserRealmIdentifiers as |realmIdentifier|}}
-                  <Workspace @realmIdentifier={{realmIdentifier}} @showMenu={{true}} />
+                  <Workspace
+                    @realmIdentifier={{realmIdentifier}}
+                    @showMenu={{true}}
+                  />
                 {{/each}}
                 {{#if this.matrixService.isInitializingNewUser}}
                   <WorkspaceLoadingIndicator />
@@ -211,7 +214,10 @@ export default class WorkspaceChooser extends Component<Signature> {
                 >{{this.catalogEmptyMessage}}</span>
               {{else}}
                 <div class='workspace-list' data-test-catalog-list>
-                  {{#each this.filteredCatalogRealmIdentifiers as |realmIdentifier|}}
+                  {{#each
+                    this.filteredCatalogRealmIdentifiers
+                    as |realmIdentifier|
+                  }}
                     <Workspace @realmIdentifier={{realmIdentifier}} />
                   {{/each}}
                 </div>

--- a/packages/host/app/components/operator-mode/workspace-chooser/index.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/index.gts
@@ -10,6 +10,8 @@ import { BoxelSelect } from '@cardstack/boxel-ui/components';
 import { IconGlobe, Lock, StarFilled } from '@cardstack/boxel-ui/icons';
 import type { Icon } from '@cardstack/boxel-ui/icons';
 
+import { ri } from '@cardstack/runtime-common';
+
 import config from '@cardstack/host/config/environment';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 import type RealmService from '@cardstack/host/services/realm';
@@ -54,13 +56,13 @@ export default class WorkspaceChooser extends Component<Signature> {
 
   private get displayCatalogWorkspaces() {
     return (
-      this.realmServer.displayedCatalogRealmURLs &&
-      this.realmServer.displayedCatalogRealmURLs.length > 0
+      this.realmServer.displayedCatalogRealmIdentifiers &&
+      this.realmServer.displayedCatalogRealmIdentifiers.length > 0
     );
   }
 
-  private get communityRealmURLs() {
-    let realmURLs = this.realmServer.displayedCatalogRealmURLs ?? [];
+  private get communityRealmIdentifiers() {
+    let realmURLs = this.realmServer.displayedCatalogRealmIdentifiers ?? [];
     if (config.environment !== 'production') {
       return realmURLs;
     }
@@ -78,35 +80,35 @@ export default class WorkspaceChooser extends Component<Signature> {
     );
   };
 
-  private filterByHosted(urls: string[]): string[] {
+  private filterByHosted<T extends string>(urls: T[]): T[] {
     if (this.sortOrder === 'hosted-only') {
       return urls.filter(this.isHosted);
     }
     return urls;
   }
 
-  private get filteredUserRealmURLs() {
-    return this.filterByHosted(this.realmServer.userRealmURLs);
+  private get filteredUserRealmIdentifiers() {
+    return this.filterByHosted(this.realmServer.userRealmIdentifiers);
   }
 
-  private get filteredCatalogRealmURLs() {
-    return this.filterByHosted(this.communityRealmURLs);
+  private get filteredCatalogRealmIdentifiers() {
+    return this.filterByHosted(this.communityRealmIdentifiers);
   }
 
-  private get favoriteRealmURLs() {
+  private get favoriteRealmIdentifiers() {
     let favorites = this.matrixService.workspaceFavorites;
-    let allURLs = [
-      ...this.realmServer.userRealmURLs,
-      ...(this.realmServer.displayedCatalogRealmURLs ?? []),
-    ];
-    let filtered = favorites.filter((url) => allURLs.includes(url));
+    let allURLs = new Set<string>([
+      ...this.realmServer.userRealmIdentifiers,
+      ...(this.realmServer.displayedCatalogRealmIdentifiers ?? []),
+    ]);
+    let filtered = favorites.filter((url) => allURLs.has(url)).map(ri);
     return this.filterByHosted(filtered);
   }
 
   private get userWorkspacesEmptyMessage(): string | null {
     if (
       this.sortOrder === 'hosted-only' &&
-      this.filteredUserRealmURLs.length === 0
+      this.filteredUserRealmIdentifiers.length === 0
     ) {
       return 'No matching results';
     }
@@ -116,7 +118,7 @@ export default class WorkspaceChooser extends Component<Signature> {
   private get catalogEmptyMessage(): string | null {
     if (
       this.sortOrder === 'hosted-only' &&
-      this.filteredCatalogRealmURLs.length === 0
+      this.filteredCatalogRealmIdentifiers.length === 0
     ) {
       return 'No matching results';
     }
@@ -127,7 +129,7 @@ export default class WorkspaceChooser extends Component<Signature> {
     if (this.matrixService.workspaceFavorites.length === 0) {
       return 'You have no favorites yet';
     }
-    if (this.favoriteRealmURLs.length === 0) {
+    if (this.favoriteRealmIdentifiers.length === 0) {
       return 'No matching results';
     }
     return null;
@@ -168,8 +170,8 @@ export default class WorkspaceChooser extends Component<Signature> {
               >{{this.favoritesEmptyMessage}}</span>
             {{else}}
               <div class='workspace-list' data-test-favorites-list>
-                {{#each this.favoriteRealmURLs as |realmURL|}}
-                  <Workspace @realmURL={{realmURL}} />
+                {{#each this.favoriteRealmIdentifiers as |realmIdentifier|}}
+                  <Workspace @realmIdentifier={{realmIdentifier}} />
                 {{/each}}
               </div>
             {{/if}}
@@ -186,8 +188,8 @@ export default class WorkspaceChooser extends Component<Signature> {
               >{{this.userWorkspacesEmptyMessage}}</span>
             {{else}}
               <div class='workspace-list' data-test-workspace-list>
-                {{#each this.filteredUserRealmURLs as |realmURL|}}
-                  <Workspace @realmURL={{realmURL}} @showMenu={{true}} />
+                {{#each this.filteredUserRealmIdentifiers as |realmIdentifier|}}
+                  <Workspace @realmIdentifier={{realmIdentifier}} @showMenu={{true}} />
                 {{/each}}
                 {{#if this.matrixService.isInitializingNewUser}}
                   <WorkspaceLoadingIndicator />
@@ -209,8 +211,8 @@ export default class WorkspaceChooser extends Component<Signature> {
                 >{{this.catalogEmptyMessage}}</span>
               {{else}}
                 <div class='workspace-list' data-test-catalog-list>
-                  {{#each this.filteredCatalogRealmURLs as |realmURL|}}
-                    <Workspace @realmURL={{realmURL}} />
+                  {{#each this.filteredCatalogRealmIdentifiers as |realmIdentifier|}}
+                    <Workspace @realmIdentifier={{realmIdentifier}} />
                   {{/each}}
                 </div>
               {{/if}}

--- a/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
@@ -128,7 +128,10 @@ export default class Workspace extends Component<Signature> {
           </button>
 
           {{#if this.isHostDropdownOpen}}
-            <div class='host-dropdown' data-test-host-dropdown={{@realmIdentifier}}>
+            <div
+              class='host-dropdown'
+              data-test-host-dropdown={{@realmIdentifier}}
+            >
               <span class='dropdown-header'>Launch in new window</span>
               <ul class='dropdown-list'>
                 {{#each this.publishedRealmURLs as |url|}}
@@ -774,7 +777,9 @@ export default class Workspace extends Component<Signature> {
   </template>
 
   get isFavorited() {
-    return this.matrixService.workspaceFavorites.includes(this.args.realmIdentifier);
+    return this.matrixService.workspaceFavorites.includes(
+      this.args.realmIdentifier,
+    );
   }
 
   @service declare private operatorModeStateService: OperatorModeStateService;
@@ -827,7 +832,9 @@ export default class Workspace extends Component<Signature> {
 
   @action async toggleFavorite() {
     if (this.isFavorited) {
-      await this.matrixService.removeWorkspaceFavorite(this.args.realmIdentifier);
+      await this.matrixService.removeWorkspaceFavorite(
+        this.args.realmIdentifier,
+      );
     } else {
       await this.matrixService.addWorkspaceFavorite(this.args.realmIdentifier);
     }
@@ -934,7 +941,9 @@ export default class Workspace extends Component<Signature> {
   }
 
   @action async openWorkspace() {
-    await this.operatorModeStateService.openWorkspace(this.args.realmIdentifier);
+    await this.operatorModeStateService.openWorkspace(
+      this.args.realmIdentifier,
+    );
   }
 
   @action openDeleteModal() {
@@ -1001,8 +1010,12 @@ export default class Workspace extends Component<Signature> {
         );
 
       await this.realmServer.deleteRealm(this.args.realmIdentifier);
-      await this.matrixService.removeRealmFromAccountData(this.args.realmIdentifier);
-      this.recentFilesService.removeRecentFilesForRealmURL(this.args.realmIdentifier);
+      await this.matrixService.removeRealmFromAccountData(
+        this.args.realmIdentifier,
+      );
+      this.recentFilesService.removeRecentFilesForRealmURL(
+        this.args.realmIdentifier,
+      );
       for (let publishedRealmURL of this.publishedRealmURLs) {
         this.recentFilesService.removeRecentFilesForRealmURL(publishedRealmURL);
       }

--- a/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
@@ -33,9 +33,9 @@ import {
 import {
   hasExecutableExtension,
   RealmPaths,
-  ri,
   rri,
   SupportedMimeType,
+  type RealmIdentifier,
 } from '@cardstack/runtime-common';
 
 import ModalContainer from '@cardstack/host/components/modal-container';
@@ -52,7 +52,7 @@ import WorkspaceLoadingIndicator from './workspace-loading-indicator';
 interface Signature {
   Element: HTMLDivElement;
   Args: {
-    realmURL: string;
+    realmIdentifier: RealmIdentifier;
     showMenu?: boolean;
   };
 }
@@ -94,7 +94,7 @@ export default class Workspace extends Component<Signature> {
           @width='16'
           @height='16'
           {{on 'click' this.toggleFavorite}}
-          data-test-workspace-favorite-btn={{@realmURL}}
+          data-test-workspace-favorite-btn={{@realmIdentifier}}
         />
         <div class='tile-menu-btn'>
           <BoxelDropdown>
@@ -104,7 +104,7 @@ export default class Workspace extends Component<Signature> {
                 @variant='ghost'
                 @width='16'
                 @height='16'
-                data-test-workspace-menu-trigger={{@realmURL}}
+                data-test-workspace-menu-trigger={{@realmIdentifier}}
                 {{bindings}}
               />
             </:trigger>
@@ -117,7 +117,7 @@ export default class Workspace extends Component<Signature> {
           <button
             class='host-trigger'
             type='button'
-            data-test-host-trigger={{@realmURL}}
+            data-test-host-trigger={{@realmIdentifier}}
             {{on 'click' this.toggleHostDropdown}}
           >
             <span class='trigger-house'><Home width='13' height='13' /></span>
@@ -128,7 +128,7 @@ export default class Workspace extends Component<Signature> {
           </button>
 
           {{#if this.isHostDropdownOpen}}
-            <div class='host-dropdown' data-test-host-dropdown={{@realmURL}}>
+            <div class='host-dropdown' data-test-host-dropdown={{@realmIdentifier}}>
               <span class='dropdown-header'>Launch in new window</span>
               <ul class='dropdown-list'>
                 {{#each this.publishedRealmURLs as |url|}}
@@ -180,7 +180,7 @@ export default class Workspace extends Component<Signature> {
           @size='medium'
           @cardContainerClass='workspace-chooser-delete-modal'
           class='workspace-chooser-delete-modal-container'
-          data-test-delete-modal={{@realmURL}}
+          data-test-delete-modal={{@realmIdentifier}}
         >
           <:content>
             <div class='delete-modal__header'>
@@ -774,7 +774,7 @@ export default class Workspace extends Component<Signature> {
   </template>
 
   get isFavorited() {
-    return this.matrixService.workspaceFavorites.includes(this.args.realmURL);
+    return this.matrixService.workspaceFavorites.includes(this.args.realmIdentifier);
   }
 
   @service declare private operatorModeStateService: OperatorModeStateService;
@@ -795,13 +795,13 @@ export default class Workspace extends Component<Signature> {
   }
 
   private loadRealmTask = task(async () => {
-    await this.realm.login(this.args.realmURL);
-    await this.realm.ensureRealmMeta(this.args.realmURL);
+    await this.realm.login(this.args.realmIdentifier);
+    await this.realm.ensureRealmMeta(this.args.realmIdentifier);
   });
 
   @cached
   private get realmInfo() {
-    return this.realm.info(this.args.realmURL);
+    return this.realm.info(this.args.realmIdentifier);
   }
 
   private get name() {
@@ -827,9 +827,9 @@ export default class Workspace extends Component<Signature> {
 
   @action async toggleFavorite() {
     if (this.isFavorited) {
-      await this.matrixService.removeWorkspaceFavorite(this.args.realmURL);
+      await this.matrixService.removeWorkspaceFavorite(this.args.realmIdentifier);
     } else {
-      await this.matrixService.addWorkspaceFavorite(this.args.realmURL);
+      await this.matrixService.addWorkspaceFavorite(this.args.realmIdentifier);
     }
   }
 
@@ -901,7 +901,7 @@ export default class Workspace extends Component<Signature> {
   }
 
   private get canDeleteWorkspace() {
-    return this.realm.isRealmOwner(this.args.realmURL);
+    return this.realm.isRealmOwner(this.args.realmIdentifier);
   }
 
   private get deleteSummaryText() {
@@ -934,7 +934,7 @@ export default class Workspace extends Component<Signature> {
   }
 
   @action async openWorkspace() {
-    await this.operatorModeStateService.openWorkspace(this.args.realmURL);
+    await this.operatorModeStateService.openWorkspace(this.args.realmIdentifier);
   }
 
   @action openDeleteModal() {
@@ -958,7 +958,7 @@ export default class Workspace extends Component<Signature> {
   private loadDeleteSummaryTask = dropTask(async () => {
     try {
       let response = await this.network.authedFetch(
-        `${this.args.realmURL}_mtimes`,
+        `${this.args.realmIdentifier}_mtimes`,
         {
           headers: {
             Accept: SupportedMimeType.Mtimes,
@@ -990,23 +990,23 @@ export default class Workspace extends Component<Signature> {
     this.deleteError = undefined;
 
     try {
-      let realmPath = new RealmPaths(ri(this.args.realmURL));
+      let realmPath = new RealmPaths(this.args.realmIdentifier);
       let isActiveWorkspace =
-        this.operatorModeStateService.realmURL === this.args.realmURL ||
+        this.operatorModeStateService.realmURL === this.args.realmIdentifier ||
         this.operatorModeStateService
           .getOpenCardIds()
           .some((cardId) => realmPath.inRealm(rri(cardId))) ||
         this.operatorModeStateService.codePathString?.startsWith(
-          this.args.realmURL,
+          this.args.realmIdentifier,
         );
 
-      await this.realmServer.deleteRealm(this.args.realmURL);
-      await this.matrixService.removeRealmFromAccountData(this.args.realmURL);
-      this.recentFilesService.removeRecentFilesForRealmURL(this.args.realmURL);
+      await this.realmServer.deleteRealm(this.args.realmIdentifier);
+      await this.matrixService.removeRealmFromAccountData(this.args.realmIdentifier);
+      this.recentFilesService.removeRecentFilesForRealmURL(this.args.realmIdentifier);
       for (let publishedRealmURL of this.publishedRealmURLs) {
         this.recentFilesService.removeRecentFilesForRealmURL(publishedRealmURL);
       }
-      this.realm.removeRealm(this.args.realmURL);
+      this.realm.removeRealm(this.args.realmIdentifier);
 
       if (isActiveWorkspace) {
         this.operatorModeStateService.clearStacks();

--- a/packages/host/app/components/realm-picker/index.gts
+++ b/packages/host/app/components/realm-picker/index.gts
@@ -36,7 +36,7 @@ export default class RealmPicker extends Component<Signature> {
   // interprets as a user-initiated filter change (expanding the search sheet).
   @cached
   get selectAllOption(): PickerOption {
-    const urls = this.realmServer.availableRealmURLs;
+    const urls = this.realmServer.availableRealmIdentifiers;
     return {
       id: 'select-all',
       label: `Select All (${urls.length})`,
@@ -60,7 +60,7 @@ export default class RealmPicker extends Component<Signature> {
   }
 
   get realmOptions(): PickerOption[] {
-    const urls = this.realmServer.availableRealmURLs;
+    const urls = this.realmServer.availableRealmIdentifiers;
     const options: PickerOption[] = [this.selectAllOption];
     for (const realmURL of urls) {
       const info = this.realm.info(realmURL);

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -197,7 +197,7 @@ export default class SearchSheet extends Component<Signature> {
   private get searchKeyAsURL() {
     return resolveSearchKeyAsURL(
       this.searchKey,
-      this.realmServer.availableRealmURLs,
+      this.realmServer.availableRealmIdentifiers,
     );
   }
 

--- a/packages/host/app/components/with-known-realms-loaded.gts
+++ b/packages/host/app/components/with-known-realms-loaded.gts
@@ -23,7 +23,7 @@ export default class WithKnownRealmsLoaded extends Component<Signature> {
   }
 
   private loadRealmsTask = task(async () => {
-    let realmURLs = this.realmServer.availableRealmURLs;
+    let realmURLs = this.realmServer.availableRealmIdentifiers;
     await Promise.all(
       realmURLs.map(
         async (realmURL) => await this.realm.ensureRealmMeta(realmURL),

--- a/packages/host/app/resources/prerendered-search.ts
+++ b/packages/host/app/resources/prerendered-search.ts
@@ -142,7 +142,7 @@ export class PrerenderedSearchResource extends Resource<Args> {
     // Normalize realms
     let normalizedRealms = realms
       ? normalizeRealms(realms)
-      : normalizeRealms(this.realmServer.availableRealmURLs);
+      : normalizeRealms(this.realmServer.availableRealmIdentifiers);
 
     this.realmsToSearch = normalizedRealms;
 

--- a/packages/host/app/resources/search-data.ts
+++ b/packages/host/app/resources/search-data.ts
@@ -84,7 +84,7 @@ export class SearchDataResource extends Resource<SearchDataArgs> {
     this.#isLive = isLive;
     this.realmsToSearch =
       realms === undefined || realms.length === 0
-        ? this.realmServer.availableRealmURLs
+        ? this.realmServer.availableRealmIdentifiers
         : realms;
 
     if (

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -15,6 +15,7 @@ import { TrackedArray } from 'tracked-built-ins';
 import type {
   QueryResultsMeta,
   ErrorEntry,
+  RealmIdentifier,
   RuntimeDependencyTrackingContext,
 } from '@cardstack/runtime-common';
 import {
@@ -73,7 +74,7 @@ export class SearchResource<
   @service declare private realmServer: RealmServerService;
   @service declare private store: StoreService;
   #storeServiceOverride: StoreService | undefined;
-  @tracked private realmsToSearch: string[] = [];
+  @tracked private realmsToSearch: RealmIdentifier[] = [];
   // Resist the urge to expose this property publicly as that may entice
   // consumers of this resource to use it in a non-reactive manner (pluck off
   // the instances and throw away the resource).
@@ -206,8 +207,8 @@ export class SearchResource<
     this.#dependencyTracking = named.dependencyTracking;
     this.realmsToSearch =
       realms === undefined || realms.length === 0
-        ? this.realmServer.availableRealmURLs
-        : realms;
+        ? this.realmServer.availableRealmIdentifiers
+        : realms.map(ri);
     this.#log.info(
       `modify: prepared realms for subscription=${this.realmsToSearch.join(',')}`,
     );
@@ -302,7 +303,7 @@ export class SearchResource<
   get instancesByRealm() {
     return this.realmsToSearch
       .map((realm) => {
-        let realmPath = new RealmPaths(ri(realm));
+        let realmPath = new RealmPaths(realm);
         let cards = this.instances.filter((card) =>
           realmPath.inRealm(rri(card.id)),
         );

--- a/packages/host/app/routes/index.gts
+++ b/packages/host/app/routes/index.gts
@@ -206,8 +206,8 @@ export default class Card extends Route {
   private async getCardUrl(cardPath: string): Promise<string | undefined> {
     let cardUrl;
     if (hostsOwnAssets) {
-      // availableRealmURLs is set in matrixService.start(), so we can use it here
-      let realmUrl = this.realmServer.availableRealmURLs.find((realmUrl) => {
+      // availableRealmIdentifiers is set in matrixService.start(), so we can use it here
+      let realmUrl = this.realmServer.availableRealmIdentifiers.find((realmUrl) => {
         let realmPathParts = new URL(realmUrl).pathname
           .split('/')
           .filter((part) => part !== '');

--- a/packages/host/app/routes/index.gts
+++ b/packages/host/app/routes/index.gts
@@ -207,22 +207,26 @@ export default class Card extends Route {
     let cardUrl;
     if (hostsOwnAssets) {
       // availableRealmIdentifiers is set in matrixService.start(), so we can use it here
-      let realmUrl = this.realmServer.availableRealmIdentifiers.find((realmUrl) => {
-        let realmPathParts = new URL(realmUrl).pathname
-          .split('/')
-          .filter((part) => part !== '');
-        let cardPathParts = cardPath!.split('/').filter((part) => part !== '');
-        let isMatch = false;
-        for (let i = 0; i < realmPathParts.length; i++) {
-          if (realmPathParts[i] === cardPathParts[i]) {
-            isMatch = true;
-          } else {
-            isMatch = false;
-            break;
+      let realmUrl = this.realmServer.availableRealmIdentifiers.find(
+        (realmUrl) => {
+          let realmPathParts = new URL(realmUrl).pathname
+            .split('/')
+            .filter((part) => part !== '');
+          let cardPathParts = cardPath!
+            .split('/')
+            .filter((part) => part !== '');
+          let isMatch = false;
+          for (let i = 0; i < realmPathParts.length; i++) {
+            if (realmPathParts[i] === cardPathParts[i]) {
+              isMatch = true;
+            } else {
+              isMatch = false;
+              break;
+            }
           }
-        }
-        return isMatch;
-      });
+          return isMatch;
+        },
+      );
       cardUrl = new URL(
         `/${cardPath}`,
         realmUrl ?? this.realm.defaultReadableRealm.path,

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -371,7 +371,7 @@ export default class MatrixService extends Service {
         async (e) => {
           switch (e.event.type) {
             case APP_BOXEL_REALMS_EVENT_TYPE:
-              await this.realmServer.setAvailableRealmURLs(
+              await this.realmServer.setAvailableRealmIdentifiers(
                 e.event.content.realms,
               );
               // Only do this after we've completed our overall login
@@ -654,7 +654,7 @@ export default class MatrixService extends Service {
     await this.client.setAccountData(APP_BOXEL_REALMS_EVENT_TYPE, {
       realms: newRealms,
     });
-    await this.realmServer.setAvailableRealmURLs(newRealms);
+    await this.realmServer.setAvailableRealmIdentifiers(newRealms);
   }
 
   public async removeRealmFromAccountData(realmURLString: string) {
@@ -667,7 +667,7 @@ export default class MatrixService extends Service {
     await this.client.setAccountData(APP_BOXEL_REALMS_EVENT_TYPE, {
       realms: newRealms,
     });
-    await this.realmServer.setAvailableRealmURLs(newRealms);
+    await this.realmServer.setAvailableRealmIdentifiers(newRealms);
   }
 
   public async getWorkspaceFavorites(): Promise<string[]> {
@@ -767,13 +767,13 @@ export default class MatrixService extends Service {
 
         await Promise.all([
           this.realmServer.fetchCatalogRealms(),
-          this.realmServer.setAvailableRealmURLs(
+          this.realmServer.setAvailableRealmIdentifiers(
             accountDataContent?.realms ?? [],
           ),
         ]);
 
         await this.realm.prefetchRealmInfos(
-          this.realmServer.availableRealmURLs,
+          this.realmServer.availableRealmIdentifiers,
         );
 
         await this.initSlidingSync(accountDataContent);
@@ -882,7 +882,7 @@ export default class MatrixService extends Service {
   async loginToRealms() {
     // This is where we would actually load user-specific choices out of the
     // user's profile based on this.client.getUserId();
-    let activeRealms = this.realmServer.availableRealmURLs;
+    let activeRealms = this.realmServer.availableRealmIdentifiers;
 
     await Promise.all(
       activeRealms.map(async (realmURL: string) => {

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -33,6 +33,7 @@ import {
   logger,
   isCardInstance,
   Deferred,
+  ri,
   SEARCH_MARKER,
   REPLACE_MARKER,
   SEPARATOR_MARKER,
@@ -372,7 +373,7 @@ export default class MatrixService extends Service {
           switch (e.event.type) {
             case APP_BOXEL_REALMS_EVENT_TYPE:
               await this.realmServer.setAvailableRealmIdentifiers(
-                e.event.content.realms,
+                (e.event.content.realms as string[]).map(ri),
               );
               // Only do this after we've completed our overall login
               if (this.postLoginCompleted) {
@@ -654,7 +655,7 @@ export default class MatrixService extends Service {
     await this.client.setAccountData(APP_BOXEL_REALMS_EVENT_TYPE, {
       realms: newRealms,
     });
-    await this.realmServer.setAvailableRealmIdentifiers(newRealms);
+    await this.realmServer.setAvailableRealmIdentifiers(newRealms.map(ri));
   }
 
   public async removeRealmFromAccountData(realmURLString: string) {
@@ -667,7 +668,7 @@ export default class MatrixService extends Service {
     await this.client.setAccountData(APP_BOXEL_REALMS_EVENT_TYPE, {
       realms: newRealms,
     });
-    await this.realmServer.setAvailableRealmIdentifiers(newRealms);
+    await this.realmServer.setAvailableRealmIdentifiers(newRealms.map(ri));
   }
 
   public async getWorkspaceFavorites(): Promise<string[]> {
@@ -768,7 +769,7 @@ export default class MatrixService extends Service {
         await Promise.all([
           this.realmServer.fetchCatalogRealms(),
           this.realmServer.setAvailableRealmIdentifiers(
-            accountDataContent?.realms ?? [],
+            (accountDataContent?.realms ?? []).map(ri),
           ),
         ]);
 

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -1469,11 +1469,13 @@ export default class OperatorModeStateService extends Service {
         name: this.realm.info(url).name,
         type: 'user-workspace' as const,
       }));
-      let catalogWorkspaces = this.realmServer.catalogRealmIdentifiers.map((url) => ({
-        url,
-        name: this.realm.info(url).name,
-        type: 'catalog-workspace' as const,
-      }));
+      let catalogWorkspaces = this.realmServer.catalogRealmIdentifiers.map(
+        (url) => ({
+          url,
+          name: this.realm.info(url).name,
+          type: 'catalog-workspace' as const,
+        }),
+      );
       let result: BoxelContext = {
         agentId: this.matrixService.agentId,
         submode: 'workspace-chooser',

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -1464,12 +1464,12 @@ export default class OperatorModeStateService extends Service {
   ): Promise<BoxelContext> {
     let codeMode: BoxelContext['codeMode'] = undefined;
     if (this._state.workspaceChooserOpened) {
-      let userWorkspaces = this.realmServer.userRealmURLs.map((url) => ({
+      let userWorkspaces = this.realmServer.userRealmIdentifiers.map((url) => ({
         url,
         name: this.realm.info(url).name,
         type: 'user-workspace' as const,
       }));
-      let catalogWorkspaces = this.realmServer.catalogRealmURLs.map((url) => ({
+      let catalogWorkspaces = this.realmServer.catalogRealmIdentifiers.map((url) => ({
         url,
         name: this.realm.info(url).name,
         type: 'catalog-workspace' as const,

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -391,22 +391,22 @@ export default class RealmServerService extends Service {
     }
   }
 
-  async setAvailableRealmIdentifiers(userRealmIdentifiers: string[]) {
+  async setAvailableRealmIdentifiers(userRealmIdentifiers: RealmIdentifier[]) {
     await this._ready.promise;
-    userRealmIdentifiers.forEach((userRealmURL) => {
-      if (!this.availableRealms.find((r) => r.url === userRealmURL)) {
+    userRealmIdentifiers.forEach((userRealmIdentifier) => {
+      if (!this.availableRealms.find((r) => r.url === userRealmIdentifier)) {
         this.availableRealms.push({
           type: 'user',
-          url: userRealmURL,
+          url: userRealmIdentifier,
         });
       }
     });
 
-    // pluck out any user realms that aren't a part of the userRealmsURLs
+    // pluck out any user realms that aren't a part of userRealmIdentifiers
     this.availableRealms
       .filter((r) => r.type === 'user')
       .forEach((realm) => {
-        if (!userRealmIdentifiers.includes(realm.url)) {
+        if (!userRealmIdentifiers.includes(ri(realm.url))) {
           this.availableRealms.splice(
             this.availableRealms.findIndex((r) => r.url === realm.url),
             1,

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -17,7 +17,9 @@ import {
   ensureTrailingSlash,
   SupportedMimeType,
   Deferred,
+  ri,
   testRealmURL,
+  type RealmIdentifier,
   type RealmInfo,
   type JWTPayload,
 } from '@cardstack/runtime-common';
@@ -253,8 +255,8 @@ export default class RealmServerService extends Service {
   }
 
   @cached
-  get availableRealmURLs() {
-    return this.availableRealms.map((r) => r.url);
+  get availableRealmIdentifiers(): RealmIdentifier[] {
+    return this.availableRealms.map((r) => ri(r.url));
   }
 
   assertOwnRealmServer(realmServerURLs: string[]): void {
@@ -338,27 +340,27 @@ export default class RealmServerService extends Service {
   }
 
   @cached
-  get userRealmURLs() {
+  get userRealmIdentifiers(): RealmIdentifier[] {
     return this.availableRealms
       .filter((r) => r.type === 'user')
-      .map((r) => r.url);
+      .map((r) => ri(r.url));
   }
 
   @cached
-  get catalogRealmURLs() {
+  get catalogRealmIdentifiers(): RealmIdentifier[] {
     return this.availableRealms
       .filter((r) => r.type === 'catalog')
-      .map((r) => r.url);
+      .map((r) => ri(r.url));
   }
 
   @cached
-  get displayedCatalogRealmURLs() {
-    return this.catalogRealmURLs;
+  get displayedCatalogRealmIdentifiers(): RealmIdentifier[] {
+    return this.catalogRealmIdentifiers;
   }
 
   @cached
   get availableRealmIndexCardIds() {
-    return this.availableRealmURLs.map((url) => `${url}index`);
+    return this.availableRealmIdentifiers.map((url) => `${url}index`);
   }
 
   async authenticateToAllAccessibleRealms() {
@@ -389,9 +391,9 @@ export default class RealmServerService extends Service {
     }
   }
 
-  async setAvailableRealmURLs(userRealmURLs: string[]) {
+  async setAvailableRealmIdentifiers(userRealmIdentifiers: string[]) {
     await this._ready.promise;
-    userRealmURLs.forEach((userRealmURL) => {
+    userRealmIdentifiers.forEach((userRealmURL) => {
       if (!this.availableRealms.find((r) => r.url === userRealmURL)) {
         this.availableRealms.push({
           type: 'user',
@@ -404,7 +406,7 @@ export default class RealmServerService extends Service {
     this.availableRealms
       .filter((r) => r.type === 'user')
       .forEach((realm) => {
-        if (!userRealmURLs.includes(realm.url)) {
+        if (!userRealmIdentifiers.includes(realm.url)) {
           this.availableRealms.splice(
             this.availableRealms.findIndex((r) => r.url === realm.url),
             1,
@@ -414,7 +416,7 @@ export default class RealmServerService extends Service {
   }
 
   async fetchCatalogRealms() {
-    if (this.catalogRealmURLs.length > 0) {
+    if (this.catalogRealmIdentifiers.length > 0) {
       return;
     }
     let response = await this.network.fetch(

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -942,7 +942,7 @@ export default class StoreService extends Service implements StoreInterface {
     let searchRealms =
       normalizedRealms.length > 0
         ? normalizedRealms
-        : this.realmServer.availableRealmURLs;
+        : this.realmServer.availableRealmIdentifiers;
     if (searchRealms.length === 0) {
       if (query.asData) {
         return opts?.includeMeta

--- a/packages/host/app/utils/card-search/url.ts
+++ b/packages/host/app/utils/card-search/url.ts
@@ -1,3 +1,5 @@
+import type { RealmIdentifier } from '@cardstack/runtime-common';
+
 export function isURLSearchKey(searchKey: string): boolean {
   try {
     new URL(searchKey);
@@ -13,11 +15,13 @@ export function isSearchKeyEmpty(searchKey: string): boolean {
 
 export function resolveSearchKeyAsURL(
   searchKey: string,
-  availableRealmIdentifiers: string[],
+  availableRealmIdentifiers: readonly RealmIdentifier[],
 ): string | undefined {
   if (!isURLSearchKey(searchKey)) {
     return undefined;
   }
-  let maybeIndexCardURL = availableRealmIdentifiers.find((u) => u === searchKey + '/');
+  let maybeIndexCardURL = availableRealmIdentifiers.find(
+    (u) => u === searchKey + '/',
+  );
   return maybeIndexCardURL ?? searchKey;
 }

--- a/packages/host/app/utils/card-search/url.ts
+++ b/packages/host/app/utils/card-search/url.ts
@@ -13,11 +13,11 @@ export function isSearchKeyEmpty(searchKey: string): boolean {
 
 export function resolveSearchKeyAsURL(
   searchKey: string,
-  availableRealmURLs: string[],
+  availableRealmIdentifiers: string[],
 ): string | undefined {
   if (!isURLSearchKey(searchKey)) {
     return undefined;
   }
-  let maybeIndexCardURL = availableRealmURLs.find((u) => u === searchKey + '/');
+  let maybeIndexCardURL = availableRealmIdentifiers.find((u) => u === searchKey + '/');
   return maybeIndexCardURL ?? searchKey;
 }

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -1368,7 +1368,7 @@ async function setupTestRealm({
 
   let realmServer = getService('realm-server');
   if (!realmServer.availableRealmIdentifiers.includes(ri(realmURL))) {
-    await realmServer.setAvailableRealmIdentifiers([realmURL]);
+    await realmServer.setAvailableRealmIdentifiers([ri(realmURL)]);
   }
 
   return { realm, adapter };

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -1367,8 +1367,8 @@ async function setupTestRealm({
   }
 
   let realmServer = getService('realm-server');
-  if (!realmServer.availableRealmURLs.includes(realmURL)) {
-    await realmServer.setAvailableRealmURLs([realmURL]);
+  if (!realmServer.availableRealmIdentifiers.includes(ri(realmURL))) {
+    await realmServer.setAvailableRealmIdentifiers([realmURL]);
   }
 
   return { realm, adapter };

--- a/packages/host/tests/integration/commands/get-available-realm-identifiers-test.gts
+++ b/packages/host/tests/integration/commands/get-available-realm-identifiers-test.gts
@@ -59,7 +59,7 @@ module(
       );
 
       let realmServer = getService('realm-server') as RealmServerService;
-      Object.defineProperty(realmServer, 'availableRealmURLs', {
+      Object.defineProperty(realmServer, 'availableRealmIdentifiers', {
         get: () => [
           'https://example.com/realm-a/',
           'https://example.com/realm-b/',

--- a/packages/host/tests/integration/commands/get-catalog-realm-identifiers-test.gts
+++ b/packages/host/tests/integration/commands/get-catalog-realm-identifiers-test.gts
@@ -59,7 +59,7 @@ module(
       );
 
       let realmServer = getService('realm-server') as RealmServerService;
-      Object.defineProperty(realmServer, 'catalogRealmURLs', {
+      Object.defineProperty(realmServer, 'catalogRealmIdentifiers', {
         get: () => ['https://example.com/catalog/'],
         configurable: true,
       });


### PR DESCRIPTION
## Summary

Tightens the realm-membership boundary so callers can pass branded `RealmIdentifier` values directly instead of casting via `ri()` at the call site. Follow-up to CS-10982, which branded `RealmService.contains(...)` but left the two known callers holding unbranded `string`.

- `RealmServerService` getters now return `RealmIdentifier[]` and are renamed for accuracy:
  - `availableRealmURLs` → `availableRealmIdentifiers`
  - `userRealmURLs` → `userRealmIdentifiers`
  - `catalogRealmURLs` → `catalogRealmIdentifiers`
  - `displayedCatalogRealmURLs` → `displayedCatalogRealmIdentifiers`
  - `setAvailableRealmURLs` → `setAvailableRealmIdentifiers`
- `Workspace.Args.realmURL: string` → `realmIdentifier: RealmIdentifier`, plus the corresponding `|realmIdentifier|` block locals in `workspace-chooser/index.gts`.
- `SearchResource.realmsToSearch` is `RealmIdentifier[]`; drops `ri(realm)` at `search.ts:305` and `ri(this.args.realmURL)` at `workspace.gts:993`, as called out in the ticket.

Closes [CS-11041](https://linear.app/cardstack/issue/CS-11041/brand-availablerealmurls-and-workspacerealmurl-with-realmidentifier).

The resource-side branding of `CardDef.id` remains out of scope (tracked in CS-11042).

## Test plan

- [x] `pnpm --filter @cardstack/host run lint:types`
- [x] `pnpm --filter @cardstack/runtime-common run lint:types`
- [x] `pnpm --filter @cardstack/realm-server run lint:types`
- [x] CI green on the host integration tests that exercise workspace-chooser, search resources, and the realm-identifier commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)