### PR TITLE
Smooth memory baseline over last 5 builds

### DIFF
--- a/packages/host/scripts/check-memory-baseline.mjs
+++ b/packages/host/scripts/check-memory-baseline.mjs
@@ -44,6 +44,23 @@ const HARD_ABSOLUTE_MB = 50;
 
 const escapeMd = (s) => String(s).replace(/\|/g, '\\|');
 
+// Compare against the rolling-window mean of recent baseline samples so a
+// single noisy build can't trip — or anchor — the budget. Fall back to the
+// pre-rolling-window `delta_mb` shape so this script keeps working against
+// older baseline files until the next main run upgrades them in place.
+const baselineDelta = (entry) => {
+  if (Array.isArray(entry?.samples) && entry.samples.length > 0) {
+    const sum = entry.samples.reduce((a, b) => a + b, 0);
+    return sum / entry.samples.length;
+  }
+  return entry?.delta_mb;
+};
+
+const fmtSamples = (entry) =>
+  Array.isArray(entry?.samples) && entry.samples.length > 0
+    ? `[${entry.samples.map((s) => s.toFixed(1)).join(', ')}]`
+    : null;
+
 const warnings = [];
 const failures = [];
 const newModules = [];
@@ -58,7 +75,7 @@ for (const [mod, data] of Object.entries(current)) {
     continue;
   }
 
-  const baseDelta = base.delta_mb;
+  const baseDelta = baselineDelta(base);
   if (baseDelta == null) continue;
 
   // A negative baseline delta means the prior module's garbage was reclaimed
@@ -74,6 +91,7 @@ for (const [mod, data] of Object.entries(current)) {
   const hardThreshold = Math.max(HARD_ABSOLUTE_MB, effectiveBase * HARD_RELATIVE);
 
   const pct = effectiveBase > 0 ? ((diff / effectiveBase) * 100).toFixed(0) : null;
+  const samples = fmtSamples(base);
 
   if (diff >= hardThreshold) {
     failures.push({
@@ -82,6 +100,7 @@ for (const [mod, data] of Object.entries(current)) {
       current: data.delta_mb,
       diff,
       pct,
+      samples,
     });
   } else if (diff >= softThreshold) {
     warnings.push({
@@ -90,6 +109,7 @@ for (const [mod, data] of Object.entries(current)) {
       current: data.delta_mb,
       diff,
       pct,
+      samples,
     });
   }
 }
@@ -108,14 +128,18 @@ if (failures.length === 0 && warnings.length === 0) {
   lines.push('All modules within threshold. No memory regressions detected.\n');
 }
 
+const samplesWindow = baseline.samplesWindow ?? 1;
+const baselineHeader =
+  samplesWindow > 1 ? `Baseline (mean of last ${samplesWindow})` : 'Baseline';
+
 if (failures.length > 0) {
   lines.push(`### Failures (>${HARD_RELATIVE * 100}% increase or +${HARD_ABSOLUTE_MB}MB)\n`);
-  lines.push('| Module | Baseline | Current | Change |');
-  lines.push('|--------|----------|---------|--------|');
+  lines.push(`| Module | ${baselineHeader} | Current | Change | Recent samples |`);
+  lines.push('|--------|----------|---------|--------|----------------|');
   for (const f of failures.sort((a, b) => b.diff - a.diff)) {
     const pctStr = f.pct != null ? ` (+${f.pct}%)` : '';
     lines.push(
-      `| ${escapeMd(f.mod)} | ${f.baseline.toFixed(1)} MB | ${f.current.toFixed(1)} MB | +${f.diff.toFixed(1)} MB${pctStr} |`,
+      `| ${escapeMd(f.mod)} | ${f.baseline.toFixed(1)} MB | ${f.current.toFixed(1)} MB | +${f.diff.toFixed(1)} MB${pctStr} | ${f.samples ?? '—'} |`,
     );
   }
   lines.push('');
@@ -123,12 +147,12 @@ if (failures.length > 0) {
 
 if (warnings.length > 0) {
   lines.push(`### Warnings (>${SOFT_RELATIVE * 100}% + ${SOFT_ABSOLUTE_MB}MB increase)\n`);
-  lines.push('| Module | Baseline | Current | Change |');
-  lines.push('|--------|----------|---------|--------|');
+  lines.push(`| Module | ${baselineHeader} | Current | Change | Recent samples |`);
+  lines.push('|--------|----------|---------|--------|----------------|');
   for (const w of warnings.sort((a, b) => b.diff - a.diff)) {
     const pctStr = w.pct != null ? ` (+${w.pct}%)` : '';
     lines.push(
-      `| ${escapeMd(w.mod)} | ${w.baseline.toFixed(1)} MB | ${w.current.toFixed(1)} MB | +${w.diff.toFixed(1)} MB${pctStr} |`,
+      `| ${escapeMd(w.mod)} | ${w.baseline.toFixed(1)} MB | ${w.current.toFixed(1)} MB | +${w.diff.toFixed(1)} MB${pctStr} | ${w.samples ?? '—'} |`,
     );
   }
   lines.push('');

--- a/packages/host/scripts/update-memory-baseline.mjs
+++ b/packages/host/scripts/update-memory-baseline.mjs
@@ -5,15 +5,22 @@
 //
 // Usage: node update-memory-baseline.mjs <reports-dir> <baseline-json>
 //
+// Smoothing: each module retains the last SAMPLES_WINDOW raw per-build
+// readings. The baselined `delta_mb` is the mean of those samples, so a
+// single noisy build can't lock in a runaway baseline. PR checks compare
+// against the smoothed mean rather than the latest single measurement.
+//
 // Missing-shard policy: modules present in the current reports are updated
 // from those readings. Modules absent from the current reports (because a
 // shard failed to upload, or was renamed/removed) retain their prior baseline
-// entries. CI runs this job even when host-test reports partial failure, so
-// retaining prior values avoids silently dropping baseline coverage for a
-// module the run simply didn't observe.
+// entries unchanged. CI runs this job even when host-test reports partial
+// failure, so retaining prior values avoids silently dropping baseline
+// coverage for a module the run simply didn't observe.
 
 import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+
+const SAMPLES_WINDOW = 5;
 
 const [reportsDir, baselinePath] = process.argv.slice(2);
 
@@ -45,6 +52,17 @@ for (const file of readdirSync(reportsDir)) {
   Object.assign(merged, shard);
 }
 
+const round1 = (n) => Math.round(n * 10) / 10;
+const mean = (xs) => xs.reduce((a, b) => a + b, 0) / xs.length;
+
+// Treat a prior single-value baseline as a one-sample window so the rolling
+// average grows naturally on subsequent runs.
+const priorSamples = (entry) => {
+  if (Array.isArray(entry?.samples)) return entry.samples;
+  if (entry?.delta_mb != null) return [entry.delta_mb];
+  return [];
+};
+
 // Start from the prior baseline, then overlay current readings. Warmup is
 // excluded from both sources since it varies by environment.
 const modules = { ...prior };
@@ -55,10 +73,15 @@ let added = 0;
 for (const [mod, data] of Object.entries(merged)) {
   if (mod === '__shard_warmup__') continue;
   if (data.delta_mb == null) continue;
-  const next = { delta_mb: Math.round(data.delta_mb * 10) / 10 };
-  if (mod in modules) updated++;
+  const samples = [...priorSamples(prior[mod]), data.delta_mb]
+    .slice(-SAMPLES_WINDOW)
+    .map(round1);
+  modules[mod] = {
+    delta_mb: round1(mean(samples)),
+    samples,
+  };
+  if (mod in prior) updated++;
   else added++;
-  modules[mod] = next;
 }
 
 const retained =
@@ -73,8 +96,9 @@ const sortedModules = Object.fromEntries(
 );
 
 const baseline = {
-  version: 1,
+  version: 2,
   generated: new Date().toISOString().slice(0, 10),
+  samplesWindow: SAMPLES_WINDOW,
   threshold: { relative: 0.1, absolute_mb: 5 },
   modules: sortedModules,
 };


### PR DESCRIPTION
## Summary

Single-build memory measurements are flaky enough that one noisy run can either trip the PR check on an unrelated branch or, worse, lock in a runaway baseline once it lands on main. Switch to a rolling-window mean over the last 5 builds so a one-build spike no longer dominates.

- `update-memory-baseline.mjs`: each module now retains a `samples` array (newest last, capped at 5). `delta_mb` is the mean of those samples. Modules absent from the current reports keep their prior entries unchanged (existing missing-shard behavior is preserved).
- `check-memory-baseline.mjs`: comparison computes the mean from `samples` when present, falling back to `delta_mb` so the script keeps working against v1 baselines until the first main run upgrades them. Adds a "Recent samples" column so reviewers can see whether a flagged value is a one-off outlier or a sustained trend.
- Baseline schema bumps to version 2 and gains `samplesWindow: 5`. The existing `packages/host/memory-baseline.json` is left as-is — the first post-merge main run will populate `samples` naturally (the prior `delta_mb` becomes a one-sample history that the new reading appends onto). Full smoothing is reached after 5 main runs.

## Why this matters

Recent flakes that this change would have softened:
- PR #4908 saw `Integration | ai-assistant-panel | file-attachment` jump 7.0 → 102.2 MB on a diff that didn't touch that area. A 5-build mean would absorb the spike instead of either failing the PR or, post-merge, pinning the baseline at 102 MB.
- The current main (`838df0e620` "Change CardDef.id to be RRI") tripped a +56 MB / +177% failure on `Acceptance | host submode`. Smoothing would let two more boring runs pull the baseline back down without manual intervention.

## Test plan

- [x] Smoke test locally: 6 simulated runs against a v1 baseline → migration produces `samples = [old_delta_mb]` on first run, grows to 5 then rolls.
- [x] Smoke test: PR-style check against v2 baseline reports "Baseline (mean of last 5)" header + recent samples column.
- [x] Smoke test: PR-style check against legacy v1 baseline (no `samples`, no `samplesWindow`) still works; falls back to `delta_mb`, header reads "Baseline".
- [x] `pnpm --filter @cardstack/host run lint` clean.
- [ ] Confirm in CI that the first main run after merge produces a v2 baseline diff (samples populated for every module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)