### PR TITLE
cleanup mise run dev-all shutdown so Ctrl-C is quiet

### DIFF
--- a/mise-tasks/dev-all
+++ b/mise-tasks/dev-all
@@ -49,7 +49,17 @@ spawn_cleanup_guardian $$
 # Start host app in background and wait for it before launching the rest.
 # start-server-and-test v1.x only supports 2 server phases (5 args), so we
 # start the host manually and use wait-on to gate readiness.
-pnpm --filter @cardstack/host start &
+#
+# `exec node …` instead of `pnpm --filter @cardstack/host start` so that
+# Node is bash's direct child. pnpm has a known behavior where, on
+# receiving SIGTERM (via the pgroup-kill on Ctrl-C), it prints
+# `[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL]` and `Command failed with signal
+# "SIGTERM"` even when its own child script exited cleanly with code 0.
+# Bypassing pnpm here avoids that spurious error during shutdown; the
+# `start` script's only content is `node scripts/vite-serve.js`, which
+# already runs `ensure-boxel-ui` inline (see that file's header), so
+# nothing about pnpm's script-runner is actually needed.
+(cd "$REPO_ROOT/packages/host" && exec node scripts/vite-serve.js) &
 HOST_PID=$!
 record_dev_pid host "$HOST_PID"
 # Fast shutdown helper: SIGTERM every recorded pgroup and return. The slow


### PR DESCRIPTION
## Summary

`mise run dev-all` shutdown printed
```
[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] @cardstack/host@0.0.0 start: \`node scripts/vite-serve.js\`
Command failed with signal "SIGTERM"
```
on Ctrl-C even though `node scripts/vite-serve.js` itself exited cleanly with code 0.

Root cause is pnpm's own behavior: when pnpm receives SIGTERM via the process-group kill (the Ctrl-C path through mise), it reports its recursively-run script as having failed by signal regardless of the child's actual exit code. Reproduced with a 5-line minimal test (`pnpm --filter <pkg> start` + `kill -TERM -- -$pnpm_pid`) — child's `process.on('SIGTERM', () => process.exit(0))` ran cleanly, but pnpm still printed `[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] ... Command failed with signal "SIGTERM"`.

No way to suppress this from inside the child. Fix is to remove pnpm from the chain — spawn `node scripts/vite-serve.js` directly from the dev-all bash so Node is bash's direct child:

```sh
(cd "$REPO_ROOT/packages/host" && exec node scripts/vite-serve.js) &
```

The host's `start` script's only content was `node scripts/vite-serve.js`, and that file already runs `ensure-boxel-ui` inline (see its header comment), so nothing about pnpm's script runner is actually needed in this start path. Same `set -m` pgroup semantics and `record_dev_pid host …` behavior as before.

## Test plan

- [ ] `mise run dev-all`, wait for the stack to come up, then Ctrl-C. Expect no `[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL]` and no `Command failed with signal "SIGTERM"` in the shutdown output.
- [ ] Shell prompt still returns in well under 5 seconds (no regression vs the prior dev-all shutdown timing).
- [ ] Ports 4200/4201/4202/4210/4211/4221/4222 are free after shutdown.
- [ ] Host comes up at https://localhost:4200 and the readiness probe still gates phase 1 services on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)