### PR TITLE
Accept *.localhost wildcard in Node-side TLS validation

### DIFF
--- a/packages/realm-server/setup-localhost-resolver.ts
+++ b/packages/realm-server/setup-localhost-resolver.ts
@@ -13,9 +13,13 @@ if (process.env.BOXEL_ENVIRONMENT) {
     const undici = require('undici') as typeof import('undici');
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const dns = require('dns');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const wildcardTls = require('@cardstack/runtime-common/permissive-localhost-wildcard-tls');
 
     const agent = new undici.Agent({
       connect: {
+        checkServerIdentity:
+          wildcardTls.permissiveLocalhostWildcardCheckServerIdentity,
         lookup(hostname: string, options: any, cb: (...args: any[]) => void) {
           if (hostname?.endsWith('.localhost')) {
             if (options.all) {

--- a/packages/realm-server/setup-localhost-resolver.ts
+++ b/packages/realm-server/setup-localhost-resolver.ts
@@ -1,8 +1,16 @@
-// In environment mode, Node.js fetch() (backed by undici) may fail to resolve
-// *.localhost subdomains because getaddrinfo() doesn't always handle them per
-// RFC 6761.  This module installs a global undici dispatcher that short-circuits
-// DNS for *.localhost → 127.0.0.1 so that inter-service fetch() calls through
-// Traefik work reliably.
+// In environment mode, Node.js fetch() (backed by undici) needs two
+// adjustments to talk to *.localhost subdomains over HTTPS:
+//
+//   1. DNS: getaddrinfo() doesn't always resolve *.localhost per RFC 6761,
+//      so the Agent's connect.lookup short-circuits *.localhost → 127.0.0.1
+//      and inter-service fetch()es through Traefik resolve reliably.
+//
+//   2. TLS: the dev mkcert leaf advertises DNS:*.localhost as a SAN, but
+//      tls.checkServerIdentity refuses two-label wildcards per RFC 6125
+//      §7.2 — so the Agent's connect.checkServerIdentity wraps the default
+//      check and accepts the *.localhost wildcard for single-label
+//      .localhost hosts when the cert really does advertise it. Strict
+//      validation is preserved for every other host/cert combination.
 //
 // NOTE: This runs before logger setup, so we check the env var directly instead
 // of importing isEnvironmentMode() (which would trigger a logger import).

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -274,6 +274,7 @@ const ALL_TEST_FILES: string[] = [
   './search-in-flight-key-test',
   './coerce-error-message-test',
   './normalize-realm-meta-value-test',
+  './permissive-localhost-wildcard-tls-test',
   './job-scoped-search-cache-test',
   './consuming-realm-header-test',
   './delete-boxel-claimed-domain-test',

--- a/packages/realm-server/tests/permissive-localhost-wildcard-tls-test.ts
+++ b/packages/realm-server/tests/permissive-localhost-wildcard-tls-test.ts
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { runSharedTest } from '@cardstack/runtime-common/helpers';
+import permissiveLocalhostWildcardTlsTests from '@cardstack/runtime-common/tests/permissive-localhost-wildcard-tls-test';
+
+module(basename(__filename), function () {
+  module('permissiveLocalhostWildcardCheckServerIdentity', function () {
+    test('accepts user.localhost when cert has DNS:*.localhost SAN', async function (assert) {
+      await runSharedTest(permissiveLocalhostWildcardTlsTests, assert, {});
+    });
+
+    test('accepts user.localhost. (FQDN trailing-dot form) when cert has DNS:*.localhost SAN', async function (assert) {
+      await runSharedTest(permissiveLocalhostWildcardTlsTests, assert, {});
+    });
+
+    test('rejects user.localhost when cert lacks DNS:*.localhost SAN', async function (assert) {
+      await runSharedTest(permissiveLocalhostWildcardTlsTests, assert, {});
+    });
+
+    test('rejects multi-label foo.bar.localhost even when cert has DNS:*.localhost SAN', async function (assert) {
+      await runSharedTest(permissiveLocalhostWildcardTlsTests, assert, {});
+    });
+
+    test('leaves the exact-match localhost case alone (defers to default check)', async function (assert) {
+      await runSharedTest(permissiveLocalhostWildcardTlsTests, assert, {});
+    });
+
+    test('does not relax checks for non-localhost hosts even when SAN is permissive', async function (assert) {
+      await runSharedTest(permissiveLocalhostWildcardTlsTests, assert, {});
+    });
+  });
+});

--- a/packages/runtime-common/fetch-node.ts
+++ b/packages/runtime-common/fetch-node.ts
@@ -1,3 +1,5 @@
+import { permissiveLocalhostWildcardCheckServerIdentity } from './permissive-localhost-wildcard-tls';
+
 /**
  * Creates a fetch implementation that's appropriate for the current environment.
  * In Node.js, it enhances localhost subdomain resolution using Undici agent.
@@ -22,6 +24,7 @@ export function createEnvironmentAwareFetch(): typeof globalThis.fetch {
     // Create a custom agent with localhost subdomain resolution
     const agent = new Agent({
       connect: {
+        checkServerIdentity: permissiveLocalhostWildcardCheckServerIdentity,
         // This replaces dns.lookup for sockets created by this Agent
         lookup(hostname: string, options: any, cb: any) {
           if (hostname?.endsWith('.localhost')) {

--- a/packages/runtime-common/permissive-localhost-wildcard-tls.ts
+++ b/packages/runtime-common/permissive-localhost-wildcard-tls.ts
@@ -1,0 +1,50 @@
+// Node's `tls.checkServerIdentity` rejects two-label wildcard certs like
+// `DNS:*.localhost` (RFC 6125 §7.2 requires a wildcard pattern to have at
+// least three dot-separated parts, e.g. `*.example.com`). The dev cert
+// `infra:ensure-dev-cert` provisions intentionally lists `*.localhost` so
+// the realm-server can terminate TLS for arbitrary tenant subdomains
+// (`<realm>.localhost:4201`), but Node-side `fetch()` against those
+// subdomains fails with `ERR_TLS_CERT_ALTNAME_INVALID`.
+//
+// This helper wraps the default check: it defers to `tls.checkServerIdentity`
+// first, and only overrides the result when the request is for a single-label
+// `.localhost` host AND the cert actually advertises `DNS:*.localhost`. Every
+// other host / cert combination keeps strict validation.
+
+import type { PeerCertificate } from 'node:tls';
+
+const SINGLE_LABEL_LOCALHOST_HOST = /^[^.]+\.localhost\.?$/i;
+const WILDCARD_LOCALHOST_SAN_RE = /(?:^|,\s*)DNS:\*\.localhost(?:,|$)/i;
+
+let cachedCheckServerIdentity:
+  | ((host: string, cert: PeerCertificate) => Error | undefined)
+  | undefined;
+
+function defaultCheckServerIdentity(
+  host: string,
+  cert: PeerCertificate,
+): Error | undefined {
+  if (!cachedCheckServerIdentity) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    cachedCheckServerIdentity = require('node:tls').checkServerIdentity;
+  }
+  return cachedCheckServerIdentity!(host, cert);
+}
+
+export function permissiveLocalhostWildcardCheckServerIdentity(
+  host: string,
+  cert: PeerCertificate,
+): Error | undefined {
+  let err = defaultCheckServerIdentity(host, cert);
+  if (!err) {
+    return undefined;
+  }
+  if (!SINGLE_LABEL_LOCALHOST_HOST.test(host)) {
+    return err;
+  }
+  let san = cert.subjectaltname ?? '';
+  if (!WILDCARD_LOCALHOST_SAN_RE.test(san)) {
+    return err;
+  }
+  return undefined;
+}

--- a/packages/runtime-common/tests/permissive-localhost-wildcard-tls-test.ts
+++ b/packages/runtime-common/tests/permissive-localhost-wildcard-tls-test.ts
@@ -1,0 +1,93 @@
+import type { PeerCertificate } from 'node:tls';
+
+import { permissiveLocalhostWildcardCheckServerIdentity } from '../permissive-localhost-wildcard-tls';
+import type { SharedTests } from '../helpers';
+
+function makeCert(opts: {
+  subjectaltname?: string;
+  subjectCN?: string;
+}): PeerCertificate {
+  return {
+    subject: { CN: opts.subjectCN ?? 'localhost' },
+    subjectaltname: opts.subjectaltname,
+  } as unknown as PeerCertificate;
+}
+
+const wildcardLocalhostCert = makeCert({
+  subjectaltname:
+    'DNS:localhost, DNS:*.localhost, DNS:published.realm, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1',
+});
+
+const certWithoutWildcard = makeCert({
+  subjectaltname:
+    'DNS:localhost, DNS:published.realm, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1',
+});
+
+const tests = Object.freeze({
+  'accepts user.localhost when cert has DNS:*.localhost SAN': async (
+    assert,
+  ) => {
+    let result = permissiveLocalhostWildcardCheckServerIdentity(
+      'user.localhost',
+      wildcardLocalhostCert,
+    );
+    assert.strictEqual(result, undefined);
+  },
+
+  'accepts user.localhost. (FQDN trailing-dot form) when cert has DNS:*.localhost SAN':
+    async (assert) => {
+      let result = permissiveLocalhostWildcardCheckServerIdentity(
+        'user.localhost.',
+        wildcardLocalhostCert,
+      );
+      assert.strictEqual(result, undefined);
+    },
+
+  'rejects user.localhost when cert lacks DNS:*.localhost SAN': async (
+    assert,
+  ) => {
+    let result = permissiveLocalhostWildcardCheckServerIdentity(
+      'user.localhost',
+      certWithoutWildcard,
+    );
+    assert.ok(
+      result instanceof Error,
+      'expected the original Node TLS error to be returned',
+    );
+  },
+
+  'rejects multi-label foo.bar.localhost even when cert has DNS:*.localhost SAN':
+    async (assert) => {
+      let result = permissiveLocalhostWildcardCheckServerIdentity(
+        'foo.bar.localhost',
+        wildcardLocalhostCert,
+      );
+      assert.ok(
+        result instanceof Error,
+        'two-label-deep subdomain should not be silently accepted by the *.localhost wildcard override',
+      );
+    },
+
+  'leaves the exact-match localhost case alone (defers to default check)':
+    async (assert) => {
+      let result = permissiveLocalhostWildcardCheckServerIdentity(
+        'localhost',
+        wildcardLocalhostCert,
+      );
+      assert.strictEqual(result, undefined);
+    },
+
+  'does not relax checks for non-localhost hosts even when SAN is permissive':
+    async (assert) => {
+      let result = permissiveLocalhostWildcardCheckServerIdentity(
+        'evil.example.com',
+        wildcardLocalhostCert,
+      );
+      assert.ok(
+        result instanceof Error,
+        'override must be scoped to *.localhost host pattern',
+      );
+    },
+} as SharedTests<{}>);
+
+export default tests;


### PR DESCRIPTION
## Summary

Publishing a realm against a local dev stack fails inside the worker with `ERR_TLS_CERT_ALTNAME_INVALID` and an aborted `from-scratch-index` job. This PR makes the Node-side TLS validator stop rejecting the `*.localhost` wildcard SAN that the local mkcert dev cert has carried (intentionally) since the HTTP/2 work landed.

Linear: [CS-11209](https://linear.app/cardstack/issue/CS-11209)

## What we see

Worker log when publishing a realm to a tenant subdomain:

```
TypeError: fetch failed
    at VirtualNetwork.fetch (packages/runtime-common/virtual-network.ts:166:20)
    at authorization-middleware.ts:31:20
  [cause]: Error: Hostname/IP does not match certificate's altnames:
    Host: <tenant>.localhost. is not in the cert's altnames:
      DNS:localhost, DNS:*.localhost, DNS:published.realm,
      IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1
    code: 'ERR_TLS_CERT_ALTNAME_INVALID'
```

The dev cert that `infra:ensure-dev-cert` provisions via mkcert lists `DNS:*.localhost` exactly so the realm-server can terminate TLS for arbitrary tenant subdomains:

```sh
# mise-tasks/infra/ensure-dev-cert
mkcert -cert-file ... -key-file ... \
  localhost 127.0.0.1 ::1 "*.localhost" published.realm
```

So the SAN is present. The check still fails.

## Initial wrong diagnosis

The first read on the error pointed at the trailing dot in `Host: <tenant>.localhost.` — the assumption being that something in the publish path was appending an FQDN dot to the host before fetch, and a hostname-with-trailing-dot wouldn't structurally match `*.localhost` (no trailing dot).

That was wrong, and confirming it took a one-file repro.

## Actual root cause

The trailing dot is a *display* artifact. Node's TLS error formatter literally writes the error message as `` `Host: ${hostname}. is not in the cert's altnames: ...` `` — the `.` is a sentence terminator, not part of the hostname being checked.

The real defect is Node's `tls.checkServerIdentity` policy on **two-label wildcards**. RFC 6125 §7.2 requires a wildcard pattern to have at least three dot-separated parts (e.g. `*.example.com`). `*.localhost` has only two parts, so Node rejects the wildcard outright — before any subject/hostname comparison happens.

Direct empirical check on Node 24:

```js
const tls = require('tls');
const cert = { subject: { CN: 'localhost' },
  subjectaltname: 'DNS:localhost, DNS:*.localhost, DNS:published.realm, ...' };

tls.checkServerIdentity('user.localhost',     cert) // FAIL
tls.checkServerIdentity('user.localhost.',    cert) // FAIL (same)
tls.checkServerIdentity('localhost',          cert) // OK   (exact match, no wildcard)
tls.checkServerIdentity('foo.bar.localhost',  cert) // FAIL
```

The `*.localhost` SAN is effectively dead text for any Node client. Only the bare `localhost` SAN works.

This is also why `packages/matrix/helpers/isolated-realm-server.ts` already sets `NODE_TLS_REJECT_UNAUTHORIZED: '0'` for its spawned children — that file's comments name the same Node behavior. The dev / worker process doesn't get that env var, so it hits the bug at publish time.

## Why not one of the obvious alternatives

- **Regenerate the cert with each subdomain enumerated.** Tenant subdomains are chosen by users at publish time, so the SAN list can't be known up front. mkcert can issue a new leaf, but not a new leaf for every realm someone might create.
- **Set `NODE_TLS_REJECT_UNAUTHORIZED=0` in the worker / realm-server.** Disables certificate validation entirely for every fetch the process makes — far too broad. The matrix harness gets away with it because its children are short-lived and only fetch loopback URLs.
- **Strip a trailing dot from the host before fetch.** Doesn't help: the trailing dot was a red herring.
- **Wait for Node to relax the RFC 6125 rule.** It will not — this is a deliberate policy.

## What this PR actually does

Wrap `tls.checkServerIdentity` in a small helper:

```ts
// packages/runtime-common/permissive-localhost-wildcard-tls.ts
export function permissiveLocalhostWildcardCheckServerIdentity(host, cert) {
  let err = defaultCheckServerIdentity(host, cert);
  if (!err) return undefined;
  if (!SINGLE_LABEL_LOCALHOST_HOST.test(host)) return err;
  if (!WILDCARD_LOCALHOST_SAN_RE.test(cert.subjectaltname ?? '')) return err;
  return undefined;
}
```

The override only fires when **both** conditions hold:
1. The host is a single-label `.localhost` name (`<tenant>.localhost`, with or without an FQDN trailing dot, case-insensitive).
2. The cert actually advertises `DNS:*.localhost`.

Everything else — multi-label subdomains, non-localhost hosts, certs without the wildcard SAN — keeps strict validation. The helper defers to `node:tls.checkServerIdentity` for the default path, so any future Node policy update flows through.

The helper is installed in the Undici Agent's `connect.checkServerIdentity` in **two** places:

- `packages/runtime-common/fetch-node.ts` — the Agent that backs `VirtualNetwork.fetch` (the worker's path).
- `packages/realm-server/setup-localhost-resolver.ts` — the global dispatcher set when `BOXEL_ENVIRONMENT` is set (environment-mode boot).

Both files already special-case `.localhost` hostnames in `connect.lookup` (redirect → `127.0.0.1`); this PR extends that same scope to the TLS check.

## Production safety

Hosted realm-servers run behind real DNS and a real cert. They never present a `DNS:*.localhost` SAN, and clients never connect to a `*.localhost` host. The wildcard-override branch is therefore unreachable in production — strict `tls.checkServerIdentity` continues to govern every real fetch.

## Test plan

- [x] New shared-test module exercises the helper across six cases:
  - accepts `user.localhost` when cert has `DNS:*.localhost`
  - accepts `user.localhost.` (FQDN trailing-dot form) when cert has the same
  - rejects `user.localhost` when cert lacks the wildcard
  - rejects multi-label `foo.bar.localhost` even with the wildcard SAN
  - leaves the exact-match `localhost` case alone (defers to default check)
  - does not relax checks for non-localhost hosts even when the cert is permissive
- [x] Tests are registered in `packages/realm-server/tests/index.ts` and pass via `TEST_FILES=permissive-localhost-wildcard-tls-test pnpm test` (qunit-on-node runner).
- [x] `pnpm lint` and `ember-tsc --noEmit` clean on `runtime-common` and `realm-server` for the touched files.
- [ ] Manual: with the local dev stack running on this branch, publish a realm and confirm the worker no longer logs `ERR_TLS_CERT_ALTNAME_INVALID` from the `from-scratch-index` job — indexing should run to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)