### PR TITLE
Migrate published-realm dev domain to 3-label *.boxel-dev.localhost

### DIFF
--- a/mise-tasks/dev-minimal
+++ b/mise-tasks/dev-minimal
@@ -6,11 +6,13 @@ export PATH="./node_modules/.bin:$PATH"
 
 # Match dev-common.sh: pin the published-realm domain to the 3-label
 # `*.boxel-dev.localhost` form that the dev cert covers, so browsers
-# accept TLS for published-realm subdomains. See lib/dev-common.sh
-# for the why; this script doesn't source it, so the export lives
-# inline here.
-export PUBLISHED_REALM_BOXEL_SPACE_DOMAIN="${PUBLISHED_REALM_BOXEL_SPACE_DOMAIN:-boxel-dev.localhost:4201}"
-export PUBLISHED_REALM_BOXEL_SITE_DOMAIN="${PUBLISHED_REALM_BOXEL_SITE_DOMAIN:-boxel-dev.localhost:4201}"
+# accept TLS for published-realm subdomains. Skip in env-mode where
+# Traefik-routed URLs apply. See lib/dev-common.sh for the why; this
+# script doesn't source it, so the export lives inline here.
+if [ -z "${BOXEL_ENVIRONMENT:-}" ]; then
+  export PUBLISHED_REALM_BOXEL_SPACE_DOMAIN="${PUBLISHED_REALM_BOXEL_SPACE_DOMAIN:-boxel-dev.localhost:4201}"
+  export PUBLISHED_REALM_BOXEL_SITE_DOMAIN="${PUBLISHED_REALM_BOXEL_SITE_DOMAIN:-boxel-dev.localhost:4201}"
+fi
 
 READY_PATH="_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson"
 BASE_REALM_READY="http-get://${REALM_BASE_URL#http://}/base/${READY_PATH}"

--- a/mise-tasks/dev-minimal
+++ b/mise-tasks/dev-minimal
@@ -4,6 +4,14 @@
 
 export PATH="./node_modules/.bin:$PATH"
 
+# Match dev-common.sh: pin the published-realm domain to the 3-label
+# `*.boxel-dev.localhost` form that the dev cert covers, so browsers
+# accept TLS for published-realm subdomains. See lib/dev-common.sh
+# for the why; this script doesn't source it, so the export lives
+# inline here.
+export PUBLISHED_REALM_BOXEL_SPACE_DOMAIN="${PUBLISHED_REALM_BOXEL_SPACE_DOMAIN:-boxel-dev.localhost:4201}"
+export PUBLISHED_REALM_BOXEL_SITE_DOMAIN="${PUBLISHED_REALM_BOXEL_SITE_DOMAIN:-boxel-dev.localhost:4201}"
+
 READY_PATH="_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson"
 BASE_REALM_READY="http-get://${REALM_BASE_URL#http://}/base/${READY_PATH}"
 NODE_TEST_REALM_READY="http-get://${REALM_TEST_URL#http://}/node-test/${READY_PATH}"

--- a/mise-tasks/dev-without-matrix
+++ b/mise-tasks/dev-without-matrix
@@ -4,11 +4,13 @@
 
 # Match dev-common.sh: pin the published-realm domain to the 3-label
 # `*.boxel-dev.localhost` form that the dev cert covers, so browsers
-# accept TLS for published-realm subdomains. See lib/dev-common.sh
-# for the why; this script doesn't source it, so the export lives
-# inline here.
-export PUBLISHED_REALM_BOXEL_SPACE_DOMAIN="${PUBLISHED_REALM_BOXEL_SPACE_DOMAIN:-boxel-dev.localhost:4201}"
-export PUBLISHED_REALM_BOXEL_SITE_DOMAIN="${PUBLISHED_REALM_BOXEL_SITE_DOMAIN:-boxel-dev.localhost:4201}"
+# accept TLS for published-realm subdomains. Skip in env-mode where
+# Traefik-routed URLs apply. See lib/dev-common.sh for the why; this
+# script doesn't source it, so the export lives inline here.
+if [ -z "${BOXEL_ENVIRONMENT:-}" ]; then
+  export PUBLISHED_REALM_BOXEL_SPACE_DOMAIN="${PUBLISHED_REALM_BOXEL_SPACE_DOMAIN:-boxel-dev.localhost:4201}"
+  export PUBLISHED_REALM_BOXEL_SITE_DOMAIN="${PUBLISHED_REALM_BOXEL_SITE_DOMAIN:-boxel-dev.localhost:4201}"
+fi
 
 READY_PATH="_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson"
 BASE_REALM_READY="http-get://${REALM_BASE_URL#http://}/base/${READY_PATH}"

--- a/mise-tasks/dev-without-matrix
+++ b/mise-tasks/dev-without-matrix
@@ -2,6 +2,14 @@
 #MISE description="Start dev stack without starting Matrix/SMTP (expects them already running)"
 #MISE dir="packages/realm-server"
 
+# Match dev-common.sh: pin the published-realm domain to the 3-label
+# `*.boxel-dev.localhost` form that the dev cert covers, so browsers
+# accept TLS for published-realm subdomains. See lib/dev-common.sh
+# for the why; this script doesn't source it, so the export lives
+# inline here.
+export PUBLISHED_REALM_BOXEL_SPACE_DOMAIN="${PUBLISHED_REALM_BOXEL_SPACE_DOMAIN:-boxel-dev.localhost:4201}"
+export PUBLISHED_REALM_BOXEL_SITE_DOMAIN="${PUBLISHED_REALM_BOXEL_SITE_DOMAIN:-boxel-dev.localhost:4201}"
+
 READY_PATH="_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson"
 BASE_REALM_READY="http-get://${REALM_BASE_URL#http://}/base/${READY_PATH}"
 EXPERIMENTS_READY="http-get://${REALM_BASE_URL#http://}/experiments/${READY_PATH}"

--- a/mise-tasks/infra/ensure-dev-cert
+++ b/mise-tasks/infra/ensure-dev-cert
@@ -157,19 +157,29 @@ fi
 echo "[ensure-dev-cert] mkcert root CA already trusted (system + NSS DB)"
 
 # Idempotent skip when the leaf cert already exists, isn't within 7
-# days of expiry, AND covers the subdomains the matrix harness's
-# publish-realm fixtures use (`*.localhost` for tenant subdomains and
-# `published.realm` for the host-resolver-mapped custom domain).
-# Older certs were issued for `localhost 127.0.0.1 ::1` only and silently
-# fail with `TypeError: fetch failed` against any subdomain even though
-# Node trusts the mkcert root CA.
+# days of expiry, AND covers the subdomains the dev + matrix-harness
+# publish-realm flows use.
+#
+# SAN layout note: published-realm tenant subdomains use a 3-label
+# wildcard (`*.boxel-dev.localhost`). RFC 6125 §7.2 — which Node's
+# tls.checkServerIdentity and every mainstream browser enforce —
+# refuses 2-label wildcards (e.g. `*.localhost`), so a single-label
+# `.localhost` SAN cannot wildcard-cover dev tenant subdomains. The
+# second label `boxel-dev` exists purely as the RFC-required filler
+# and reads as obviously-local-only in browser tabs. Source realms
+# in the dev stack (`user.localhost`) are covered as an explicit
+# SAN entry, no wildcard needed.
+#
+# Older certs were issued for `localhost 127.0.0.1 ::1` only, or with
+# the no-longer-effective `*.localhost`; the SAN check below forces a
+# regenerate when an older shape is detected.
 if [ -f "$CERT_FILE" ] && [ -f "$KEY_FILE" ]; then
   if openssl x509 -in "$CERT_FILE" -checkend $((7 * 24 * 60 * 60)) -noout >/dev/null 2>&1; then
     if openssl x509 -in "$CERT_FILE" -noout -text 2>/dev/null \
-      | grep -q 'DNS:\*\.localhost'; then
+      | grep -q 'DNS:\*\.boxel-dev\.localhost'; then
       exit 0
     fi
-    echo "[ensure-dev-cert] Existing cert at $CERT_FILE is missing *.localhost SAN; regenerating."
+    echo "[ensure-dev-cert] Existing cert at $CERT_FILE is missing *.boxel-dev.localhost SAN; regenerating."
   else
     echo "[ensure-dev-cert] Existing cert at $CERT_FILE is near expiry; regenerating."
   fi
@@ -181,4 +191,4 @@ echo "[ensure-dev-cert] Generating cert at $CERT_FILE"
 mkcert \
   -cert-file "$CERT_FILE" \
   -key-file "$KEY_FILE" \
-  localhost 127.0.0.1 ::1 "*.localhost" published.realm
+  localhost user.localhost 127.0.0.1 ::1 "*.boxel-dev.localhost" published.realm

--- a/mise-tasks/infra/ensure-dev-cert
+++ b/mise-tasks/infra/ensure-dev-cert
@@ -175,11 +175,23 @@ echo "[ensure-dev-cert] mkcert root CA already trusted (system + NSS DB)"
 # regenerate when an older shape is detected.
 if [ -f "$CERT_FILE" ] && [ -f "$KEY_FILE" ]; then
   if openssl x509 -in "$CERT_FILE" -checkend $((7 * 24 * 60 * 60)) -noout >/dev/null 2>&1; then
-    if openssl x509 -in "$CERT_FILE" -noout -text 2>/dev/null \
-      | grep -q 'DNS:\*\.boxel-dev\.localhost'; then
+    # Validate the SAN set against the current recipe — checking just
+    # the wildcard isn't enough, because a cert with `*.boxel-dev
+    # .localhost` but missing `user.localhost` (the explicit
+    # source-realm SAN) or `published.realm` would silently pass and
+    # then fail at runtime against URLs we expect to cover.
+    CERT_TEXT=$(openssl x509 -in "$CERT_FILE" -noout -text 2>/dev/null || true)
+    cert_has_san() {
+      printf '%s\n' "$CERT_TEXT" | grep -q -- "$1"
+    }
+    if cert_has_san 'DNS:localhost' \
+      && cert_has_san 'DNS:user\.localhost' \
+      && cert_has_san 'DNS:\*\.boxel-dev\.localhost' \
+      && cert_has_san 'DNS:published\.realm' \
+      && cert_has_san 'IP Address:127\.0\.0\.1'; then
       exit 0
     fi
-    echo "[ensure-dev-cert] Existing cert at $CERT_FILE is missing *.boxel-dev.localhost SAN; regenerating."
+    echo "[ensure-dev-cert] Existing cert at $CERT_FILE is missing one or more required SANs; regenerating."
   else
     echo "[ensure-dev-cert] Existing cert at $CERT_FILE is near expiry; regenerating."
   fi

--- a/mise-tasks/lib/dev-common.sh
+++ b/mise-tasks/lib/dev-common.sh
@@ -10,21 +10,28 @@ REPO_ROOT="$(cd "../.." && pwd)"
 # reliable regardless of how the binary was originally resolved by PATH.
 export PATH="${REPO_ROOT}/node_modules/.bin:${REPO_ROOT}/packages/realm-server/node_modules/.bin:./node_modules/.bin:$PATH"
 
-# Pin the published-realm domain for the local dev stack to a
-# 3-label form that browsers and Node accept as a wildcard SAN
+# In *standard* dev mode, pin the published-realm domain to a 3-label
+# form that browsers and Node accept as a wildcard SAN
 # (`*.boxel-dev.localhost`). RFC 6125 §7.2 refuses single-label
 # wildcards like `*.localhost`, so the dev cert can't usefully cover
 # `<tenant>.localhost` no matter what's in the SAN list.
 #
-# Setting these here (rather than in lib/env-vars.sh) deliberately
-# scopes the override to the dev tasks that source dev-common.sh —
-# the matrix-test harness spawns its own realm-server with its own
-# PUBLISHED_REALM_BOXEL_* values and relies on the `localhost:4201`
-# literal sentinel that handlers/serve-index.ts rewrites on the fly.
-# Bleeding `boxel-dev.localhost:4201` into that path would break the
-# rewrite. Per-shell overrides still win via the `:-` default.
-export PUBLISHED_REALM_BOXEL_SPACE_DOMAIN="${PUBLISHED_REALM_BOXEL_SPACE_DOMAIN:-boxel-dev.localhost:4201}"
-export PUBLISHED_REALM_BOXEL_SITE_DOMAIN="${PUBLISHED_REALM_BOXEL_SITE_DOMAIN:-boxel-dev.localhost:4201}"
+# Skip when BOXEL_ENVIRONMENT is set — env-mode uses Traefik-routed
+# `https://realm-server.<slug>.localhost` URLs on dynamic ports
+# (see lib/env-vars.sh), and forcing `boxel-dev.localhost:4201`
+# there would steer the publish-realm modal at a host that isn't
+# being served. Env-mode harnesses set their own
+# PUBLISHED_REALM_BOXEL_* values explicitly when they need them.
+#
+# Setting these here (rather than in lib/env-vars.sh) also keeps
+# matrix-test runs unaffected: the matrix harness doesn't source
+# dev-common.sh, so it keeps relying on the `localhost:4201` literal
+# sentinel that handlers/serve-index.ts rewrites on the fly.
+# Per-shell overrides still win via the `:-` default.
+if [ -z "${BOXEL_ENVIRONMENT:-}" ]; then
+  export PUBLISHED_REALM_BOXEL_SPACE_DOMAIN="${PUBLISHED_REALM_BOXEL_SPACE_DOMAIN:-boxel-dev.localhost:4201}"
+  export PUBLISHED_REALM_BOXEL_SITE_DOMAIN="${PUBLISHED_REALM_BOXEL_SITE_DOMAIN:-boxel-dev.localhost:4201}"
+fi
 
 # How long to wait for SIGTERM'd processes to exit before escalating to
 # SIGKILL. The dev stack has slow propagators in it (pnpm, npm exec, vite,

--- a/mise-tasks/lib/dev-common.sh
+++ b/mise-tasks/lib/dev-common.sh
@@ -10,6 +10,22 @@ REPO_ROOT="$(cd "../.." && pwd)"
 # reliable regardless of how the binary was originally resolved by PATH.
 export PATH="${REPO_ROOT}/node_modules/.bin:${REPO_ROOT}/packages/realm-server/node_modules/.bin:./node_modules/.bin:$PATH"
 
+# Pin the published-realm domain for the local dev stack to a
+# 3-label form that browsers and Node accept as a wildcard SAN
+# (`*.boxel-dev.localhost`). RFC 6125 §7.2 refuses single-label
+# wildcards like `*.localhost`, so the dev cert can't usefully cover
+# `<tenant>.localhost` no matter what's in the SAN list.
+#
+# Setting these here (rather than in lib/env-vars.sh) deliberately
+# scopes the override to the dev tasks that source dev-common.sh —
+# the matrix-test harness spawns its own realm-server with its own
+# PUBLISHED_REALM_BOXEL_* values and relies on the `localhost:4201`
+# literal sentinel that handlers/serve-index.ts rewrites on the fly.
+# Bleeding `boxel-dev.localhost:4201` into that path would break the
+# rewrite. Per-shell overrides still win via the `:-` default.
+export PUBLISHED_REALM_BOXEL_SPACE_DOMAIN="${PUBLISHED_REALM_BOXEL_SPACE_DOMAIN:-boxel-dev.localhost:4201}"
+export PUBLISHED_REALM_BOXEL_SITE_DOMAIN="${PUBLISHED_REALM_BOXEL_SITE_DOMAIN:-boxel-dev.localhost:4201}"
+
 # How long to wait for SIGTERM'd processes to exit before escalating to
 # SIGKILL. The dev stack has slow propagators in it (pnpm, npm exec, vite,
 # start-server-and-test, run-p) that don't immediately forward SIGTERM to


### PR DESCRIPTION
## Summary

Publishing a realm in local dev fails with `ERR_TLS_CERT_ALTNAME_INVALID` (Node) and `NET::ERR_CERT_COMMON_NAME_INVALID` (Chrome) because the dev mkcert leaf's `DNS:*.localhost` SAN is a structurally invalid wildcard pattern: RFC 6125 §7.2 requires a wildcard pattern to have at least three dot-separated parts (e.g. `*.example.com`), and `*.localhost` has only two. Every mainstream TLS validator — Node, Chrome, Firefox, Safari, openssl — refuses it. The SAN has always been dead text on the wire.

Fix structurally instead of patching a single client: move the dev published-realm domain to a 3-label form so a wildcard SAN is actually valid. Tenant subdomains become `<sub>.boxel-dev.localhost:4201` instead of `<sub>.localhost:4201`. The cert wildcard becomes `*.boxel-dev.localhost`. Source-realm URLs (`https://user.localhost:4201/...`) keep their existing shape and get covered by an explicit `user.localhost` SAN (single hostname, no wildcard needed).

Linear: [CS-11209](https://linear.app/cardstack/issue/CS-11209).

## Why a second label at all

The natural impulse is "just add more entries to the SAN list" — but the dev published-realm subdomain is user-chosen at publish time, so there's no enumerable set to put in the cert up front. A wildcard SAN is necessary. RFC 6125 §7.2 simply doesn't let that wildcard sit one label above the TLD, regardless of what the TLD is. So we have to introduce a structural second label — anything works mechanically, and `boxel-dev` was chosen because it reads as obviously-local-dev-only in browser tabs (`mysite.boxel-dev.localhost:4201` is unambiguously a local dev URL).

## Why this is local-dev-only

The dev cert and `infra:ensure-dev-cert` only exist for the developer's machine. Hosted realm-servers run behind real DNS + a real cert; the published-realm domain there is set by deployment env vars (already wired) and the SAN is whatever the public DNS host actually is. None of this code or the SAN list ships in any production image.

## Changes

- **`mise-tasks/infra/ensure-dev-cert`** — SAN list switches from `localhost 127.0.0.1 ::1 "*.localhost" published.realm` to `localhost user.localhost 127.0.0.1 ::1 "*.boxel-dev.localhost" published.realm`. Idempotency-skip check now matches on `DNS:*.boxel-dev.localhost`, so older cert shapes get force-regenerated on the next `mise run dev`.
- **`mise-tasks/lib/dev-common.sh`** — exports `PUBLISHED_REALM_BOXEL_SPACE_DOMAIN` and `PUBLISHED_REALM_BOXEL_SITE_DOMAIN = boxel-dev.localhost:4201` so vite bakes the new value into the host bundle and the publish-realm modal constructs the right URL. Scoped here (not in `lib/env-vars.sh`) so the matrix-test harness keeps relying on the `localhost:4201` literal sentinel that `handlers/serve-index.ts` rewrites on the fly to each test server's actual host.
- **`mise-tasks/dev-minimal`, `mise-tasks/dev-without-matrix`** — same exports inline (they don't source `dev-common.sh`).

No changes to host/realm-server source defaults, no test fixtures touched. Source-realm URLs (`https://user.localhost:4201/...`) keep their existing shape.

## Verification

- `mise run infra:ensure-dev-cert` regenerates the cert. `openssl x509 -ext subjectAltName` confirms the SAN list is `DNS:localhost, DNS:user.localhost, DNS:*.boxel-dev.localhost, DNS:published.realm, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1`.
- Node's `tls.checkServerIdentity` against that cert: `localhost` ✓, `user.localhost` ✓, `mysite.boxel-dev.localhost` ✓ (3-label wildcard match). Negative cases reject as expected: `foo.localhost` ✗ (no wildcard at this level), `a.b.boxel-dev.localhost` ✗ (one-level wildcard only).
- Affected realm-server tests (`serve-index-test`, `server-config-test`) — 4/4 pass.
- Bash syntax check on all four shell files clean.
- [x] Manual: restart the dev stack on this branch, publish a realm, and confirm the resulting URL (`https://<sub>.boxel-dev.localhost:4201/<realm>/`) loads in Chrome with no cert warning.

<img width="3040" height="2491" alt="image" src="https://github.com/user-attachments/assets/0ddda84f-d921-4cf8-a6dc-bae7911803c7" />


## Migration note for existing realms

Realms that were already published under the old `<sub>.localhost:4201` URLs keep those URLs — the registry stores the publish URL verbatim. Those existing entries will still hit the same browser warning until they're republished (or until the dev visits with the Chrome `allow-insecure-localhost` flag). New publishes on this branch use the new domain automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)