### PR TITLE
Stabilize prerender LRU eviction test against cross-affinity-steal flake

### DIFF
--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -4951,6 +4951,23 @@ module(basename(__filename), function () {
           const cardB = `${realmURL2}1`;
           const cardC = `${realmURL3}1`;
 
+          // `desiredStandbyCount` caps at 1 once any tab is active, so a
+          // fire-and-forget refill kicked off by the previous acquisition
+          // may not have produced a real standby by the time the next
+          // sequential acquisition runs. With `queue='file'` (the path
+          // every `prerenderCard` takes) the entryList-empty branch in
+          // `#selectEntryForAffinity` skips its `ensureStandbyPool` await
+          // whenever a refill is in flight (`creatingStandbys` already
+          // counts toward `currentStandbyCount`), and the caller falls
+          // through to cross-affinity-steal. That steal repurposes a
+          // donor tab and KEEPS the donor's `pageId` — see the warning
+          // log around `#selectEntryForAffinity`'s reassign path. A
+          // chain of steals (A→B, B→C, C→A) makes `firstA.pageId ===
+          // secondA.pageId` and trips the eviction assertion below.
+          // Awaiting `warmStandbys` between phases blocks until any
+          // in-flight standby creation AND any LRU eviction kicked by
+          // the post-acquire refill have settled, so the next call
+          // commandeers a fresh standby instead of stealing.
           let firstA = await prerenderCard(prerenderer, {
             affinityType: 'realm',
             affinityValue: realmURL1,
@@ -4958,7 +4975,8 @@ module(basename(__filename), function () {
             url: cardA,
             auth: auth(),
           });
-          assert.false(firstA.pool.reused, 'first A not reused');
+          await prerenderer.warmStandbys();
+          let firstAWaits = firstA.timings.waits;
 
           let firstB = await prerenderCard(prerenderer, {
             affinityType: 'realm',
@@ -4967,7 +4985,8 @@ module(basename(__filename), function () {
             url: cardB,
             auth: auth(),
           });
-          assert.false(firstB.pool.reused, 'first B not reused');
+          await prerenderer.warmStandbys();
+          let firstBWaits = firstB.timings.waits;
 
           // Now adding C should evict the LRU (A), since maxPages=2
           let firstC = await prerenderCard(prerenderer, {
@@ -4977,7 +4996,8 @@ module(basename(__filename), function () {
             url: cardC,
             auth: auth(),
           });
-          assert.false(firstC.pool.reused, 'first C not reused');
+          await prerenderer.warmStandbys();
+          let firstCWaits = firstC.timings.waits;
 
           // Returning to A should not reuse because it was evicted
           let secondA = await prerenderCard(prerenderer, {
@@ -4987,11 +5007,48 @@ module(basename(__filename), function () {
             url: cardA,
             auth: auth(),
           });
-          assert.false(secondA.pool.reused, 'A was evicted, so not reused');
+          let secondAWaits = secondA.timings.waits;
+          // Snapshot the live pool state at the assertion site so that
+          // if the flake recurs the YAML failure block names the donor
+          // affinity, the in-flight standby count, and per-call wait
+          // shape (`tabStartupMs=0` signals a steal; non-zero signals
+          // the standby path). Without this the only hint a reviewer
+          // gets is two identical UUIDs and no provenance.
+          let queueSnapshot = prerenderer.getQueueDepthSnapshot();
+          let diagnostics =
+            `firstA.pageId=${firstA.pool.pageId} ` +
+            `firstB.pageId=${firstB.pool.pageId} ` +
+            `firstC.pageId=${firstC.pool.pageId} ` +
+            `secondA.pageId=${secondA.pool.pageId} ` +
+            `firstA.reused=${firstA.pool.reused} ` +
+            `firstB.reused=${firstB.pool.reused} ` +
+            `firstC.reused=${firstC.pool.reused} ` +
+            `secondA.reused=${secondA.pool.reused} ` +
+            `firstA.waits=${JSON.stringify(firstAWaits)} ` +
+            `firstB.waits=${JSON.stringify(firstBWaits)} ` +
+            `firstC.waits=${JSON.stringify(firstCWaits)} ` +
+            `secondA.waits=${JSON.stringify(secondAWaits)} ` +
+            `queueSnapshot=${JSON.stringify(queueSnapshot)}`;
+          assert.false(
+            firstA.pool.reused,
+            `first A not reused — ${diagnostics}`,
+          );
+          assert.false(
+            firstB.pool.reused,
+            `first B not reused — ${diagnostics}`,
+          );
+          assert.false(
+            firstC.pool.reused,
+            `first C not reused — ${diagnostics}`,
+          );
+          assert.false(
+            secondA.pool.reused,
+            `A was evicted, so not reused — ${diagnostics}`,
+          );
           assert.notStrictEqual(
             firstA.pool.pageId,
             secondA.pool.pageId,
-            'A got a new page after eviction',
+            `A got a new page after eviction — ${diagnostics}`,
           );
         });
 


### PR DESCRIPTION
## Summary

- The realm-server test `prerendering-test.ts > prerender - non-mutating tests > formats and pooling > affinity pooling > evicts LRU when capacity reached` has been intermittently failing in CI with `firstA.pageId === secondA.pageId`. Example: https://github.com/cardstack/boxel/actions/runs/26235607189/job/77208448621
- Root cause: at `maxPages=2` with three sequential affinities, the fire-and-forget standby refill kicked by the previous acquisition is often still in-flight when the next call arrives. With `queue='file'`, the entryList-empty branch in `#selectEntryForAffinity` skips its `ensureStandbyPool` await (because `creatingStandbys` already counts toward `currentStandbyCount` so the `<` gate sees current==desired==1), and the caller falls through to cross-affinity-steal. The steal reassigns a donor tab and **keeps the donor's `pageId`**, so a chain (A→B, B→C, C→A) walks the original `pageId` back around and the eviction assertion trips.
- Fix: `await prerenderer.warmStandbys()` between phases blocks until any in-flight standby creation AND any LRU eviction kicked by the post-acquire refill have settled, so each follow-on call commandeers a fresh standby instead of stealing.
- Insurance: the four `assert.false(reused)` calls and the `notStrictEqual(pageId)` assertion now inline `pageId`, `reused`, per-call `timings.waits`, and `prerenderer.getQueueDepthSnapshot()` in their failure messages. `tabStartupMs=0` in a `waits` snapshot signals a steal; non-zero signals the standby path — so if this ever flakes again, the YAML failure block carries enough provenance to attribute the path without a guessing match.

## Prior art

Commit `8313a373b0` (`Stabilize prerender "distinct pages per realm" against cross-affinity steal`) applied this same pattern to the sibling test in the same module: `Prerenderer.warmStandbys()` was added as public API, `disposeAllRealms` in the `formats and pooling` beforeEach was switched to await it, and a `cross-affinity steal: reassigning pageId=...` warn-log was added inside `getPage`. That fix ensures each test STARTS on a warm pool — but the LRU eviction test issues four sequential acquisitions WITHIN one test, which exhausts the standby buffer past the second acquisition (`desiredStandbyCount` caps at 1 once any tab is active). This PR is complementary: it applies the same `warmStandbys` mechanism BETWEEN acquisitions within the test, where the prior fix applied it BETWEEN tests. The diagnostic enrichment mirrors the pattern the prior fix established on `does not reuse across different realms`.

## Test plan

- [ ] CI green on this branch (the realm-server shards 1/6, 2/6, 5/6 that hit the flake in the linked run).
- [ ] No regression in the surrounding `affinity pooling` test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)