### PR TITLE
Fix flaky module-cache-race-test errored-transpile-shared assertion

### DIFF
--- a/packages/realm-server/tests/module-cache-race-test.ts
+++ b/packages/realm-server/tests/module-cache-race-test.ts
@@ -376,6 +376,68 @@ module(basename(__filename), function () {
         );
       }
 
+      // Same shape as waitForInflight but polls the join counter — the
+      // dedup tests use it to confirm a concurrent caller actually
+      // joined an in-flight entry before releasing the gate. Without
+      // this signal, an error-path test using a real .gts that throws
+      // fast at babel can settle the first caller (and run its identity-
+      // checked .finally cleanup) before the second caller's HTTP
+      // request reaches #transpileModuleDeduped — at which point the
+      // second caller installs its own pending and the "shared one
+      // transpile" assertion fails non-deterministically on CI under
+      // load. Together with __testOnlyDelayTranspile this gives the
+      // tests an explicit "B has joined" handle.
+      async function waitForJoinCount(
+        expected: number,
+        timeoutMs = 5000,
+      ): Promise<void> {
+        let deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+          if (testRealm.__testOnlyGetTranspileJoinCount() === expected) {
+            return;
+          }
+          await new Promise((r) => setTimeout(r, 5));
+        }
+        throw new Error(
+          `timed out waiting for join count to reach ${expected}; saw ${testRealm.__testOnlyGetTranspileJoinCount()}`,
+        );
+      }
+
+      // Timestamped event log used by the dedup tests to capture the
+      // hook entries, gate releases, counter readings, and HTTP responses
+      // around the concurrent-arrive window. Dumped via assert.pushResult
+      // only on assertion failure, so a CI flake leaves a forensic trail
+      // in the QUnit output instead of just the bare actual/expected
+      // line — future investigations can read CI logs to see WHICH
+      // event the race happened around. Each test fires at most a
+      // handful of events; no bounding needed.
+      function createDiagLog() {
+        let started = Date.now();
+        let events: string[] = [];
+        return {
+          note(label: string, extra: Record<string, unknown> = {}) {
+            let snapshot = {
+              t: Date.now() - started,
+              inflight: testRealm.__testOnlyGetInFlightTranspileCount(),
+              transpileCalls: testRealm.__testOnlyGetTranspileCallCount(),
+              joinCount: testRealm.__testOnlyGetTranspileJoinCount(),
+              ...extra,
+            };
+            events.push(`[${label}] ${JSON.stringify(snapshot)}`);
+          },
+          dump(assert: Assert) {
+            for (let line of events) {
+              assert.pushResult({
+                result: true,
+                actual: line,
+                expected: line,
+                message: line,
+              });
+            }
+          },
+        };
+      }
+
       test('N concurrent same-path readers trigger exactly one transpile call', async function (assert) {
         let modulePath = 'dedup-same-path.gts';
         await testRealm.write(modulePath, transpilerHeavySource);
@@ -636,39 +698,114 @@ module(basename(__filename), function () {
         );
         testRealm.__testOnlyClearCaches();
 
-        let before = testRealm.__testOnlyGetTranspileCallCount();
-        let [resA, resB] = await Promise.all([
-          fireRequest(modulePath),
-          fireRequest(modulePath),
-        ]);
-        let deltaShared = testRealm.__testOnlyGetTranspileCallCount() - before;
+        // Without a gate, transpileJS throws fast on invalid source — A
+        // can settle and its identity-checked .finally can clear the
+        // in-flight slot before B's HTTP request even reaches
+        // #transpileModuleDeduped on a loaded CI runner, at which point
+        // B installs its own pending and the "shared one transpile"
+        // assertion observes deltaShared = 2 (one per request). Park A
+        // at a gate so the in-flight overlap window is held open until
+        // both callers have demonstrably reached the dedup site, then
+        // release to let the rejection propagate to both.
+        let releaseGate: () => void = () => {};
+        let gate = new Promise<void>((r) => {
+          releaseGate = r;
+        });
+        let hookEntries = 0;
+        testRealm.__testOnlyDelayTranspile(() => {
+          hookEntries += 1;
+          return gate;
+        });
 
-        assert.strictEqual(
-          resA.status,
-          406,
-          'first errored request returns a transpile-failed response',
-        );
-        assert.strictEqual(
-          resB.status,
-          406,
-          'concurrent waiter shares the same error response',
-        );
-        assert.strictEqual(
-          deltaShared,
-          1,
-          'concurrent waiters shared exactly one transpile attempt — the rejection propagates without a second babel pass',
-        );
+        let diag = createDiagLog();
+        let passed = false;
+        try {
+          let before = testRealm.__testOnlyGetTranspileCallCount();
+          diag.note('start', { before });
 
-        // After both fail, the in-flight slot must release so a fresh
-        // caller re-attempts transpile against current source.
-        let resC = await fireRequest(modulePath);
-        assert.strictEqual(resC.status, 406);
-        let deltaAfter = testRealm.__testOnlyGetTranspileCallCount() - before;
-        assert.strictEqual(
-          deltaAfter,
-          2,
-          'subsequent caller triggers a fresh transpile attempt — error did not pin the in-flight slot',
-        );
+          // Fire A but DON'T await — we need it parked at the gate so
+          // B can race in.
+          let pendingA = fireRequest(modulePath);
+          await waitForInflight(1);
+          diag.note('A-parked-at-gate', { hookEntries });
+
+          // Fire B. B's HTTP request travels through Express +
+          // supertest until it reaches #transpileModuleDeduped, where
+          // it should observe A's pending in #inFlightTranspiles and
+          // take the `existing` branch — bumping joinCount to 1 —
+          // instead of installing its own. Polling joinCount is
+          // deterministic; polling inflight=1 is not (already 1 from
+          // A).
+          let pendingB = fireRequest(modulePath);
+          await waitForJoinCount(1);
+          diag.note('B-joined', { hookEntries });
+
+          // Sanity: only A's hook fired. If hookEntries > 1, the gate
+          // released early (impossible — we hold `releaseGate`) or B
+          // bypassed the dedup. Either is a real bug worth surfacing.
+          assert.strictEqual(
+            hookEntries,
+            1,
+            'only A entered the transpile hook — B joined A’s pending',
+          );
+
+          // Release the gate. A's transpileJS throws on the invalid
+          // source. Both pendingA and pendingB receive the same
+          // rejection through the shared promise.
+          releaseGate();
+          diag.note('gate-released');
+          let [resA, resB] = await Promise.all([pendingA, pendingB]);
+          diag.note('both-responded', {
+            statusA: resA.status,
+            statusB: resB.status,
+          });
+
+          let deltaShared =
+            testRealm.__testOnlyGetTranspileCallCount() - before;
+
+          assert.strictEqual(
+            resA.status,
+            406,
+            'first errored request returns a transpile-failed response',
+          );
+          assert.strictEqual(
+            resB.status,
+            406,
+            'concurrent waiter shares the same error response',
+          );
+          assert.strictEqual(
+            deltaShared,
+            1,
+            'concurrent waiters shared exactly one transpile attempt — the rejection propagates without a second babel pass',
+          );
+
+          // After both fail, the in-flight slot must release so a
+          // fresh caller re-attempts transpile against current source.
+          // Drop the gate hook so C runs unblocked (and so we don't
+          // park forever on a stale gate Promise).
+          testRealm.__testOnlyDelayTranspile(undefined);
+          let resC = await fireRequest(modulePath);
+          diag.note('C-responded', { statusC: resC.status });
+          assert.strictEqual(resC.status, 406);
+          let deltaAfter = testRealm.__testOnlyGetTranspileCallCount() - before;
+          assert.strictEqual(
+            deltaAfter,
+            2,
+            'subsequent caller triggers a fresh transpile attempt — error did not pin the in-flight slot',
+          );
+
+          passed = true;
+        } finally {
+          // Release the gate in case we threw before reaching the
+          // explicit release (e.g. waitForJoinCount timed out). Any
+          // still-parked pending then settles instead of leaking into
+          // the next test as an unhandled rejection.
+          releaseGate();
+          testRealm.__testOnlyDelayTranspile(undefined);
+          if (!passed) {
+            diag.dump(assert);
+          }
+        }
       });
     },
   );

--- a/packages/realm-server/tests/module-cache-race-test.ts
+++ b/packages/realm-server/tests/module-cache-race-test.ts
@@ -405,13 +405,14 @@ module(basename(__filename), function () {
 
       // Timestamped event log used by the dedup tests to capture the
       // hook entries, gate releases, counter readings, and HTTP responses
-      // around the concurrent-arrive window. Dumped via assert.pushResult
-      // only on assertion failure, so a CI flake leaves a forensic trail
-      // in the QUnit output instead of just the bare actual/expected
-      // line — future investigations can read CI logs to see WHICH
-      // event the race happened around. Each test fires at most a
-      // handful of events; no bounding needed.
-      function createDiagLog() {
+      // around the concurrent-arrive window. Dumped to stderr only on
+      // assertion failure, so a CI flake leaves a forensic trail in the
+      // realm-server log artifacts that future investigations can grep
+      // for the event timeline. `assert.pushResult({ result: true })`
+      // does NOT work here: this repo's QUnit JUnit reporter only
+      // serializes `data.errors` for failed tests, so passing diagnostic
+      // rows are silently dropped from the CI report.
+      function createDiagLog(testLabel: string) {
         let started = Date.now();
         let events: string[] = [];
         return {
@@ -425,14 +426,10 @@ module(basename(__filename), function () {
             };
             events.push(`[${label}] ${JSON.stringify(snapshot)}`);
           },
-          dump(assert: Assert) {
+          dump() {
+            console.error(`[dedup-flake-diag] test=${testLabel}`);
             for (let line of events) {
-              assert.pushResult({
-                result: true,
-                actual: line,
-                expected: line,
-                message: line,
-              });
+              console.error(`[dedup-flake-diag]   ${line}`);
             }
           },
         };
@@ -443,29 +440,91 @@ module(basename(__filename), function () {
         await testRealm.write(modulePath, transpilerHeavySource);
         testRealm.__testOnlyClearCaches();
 
-        let before = testRealm.__testOnlyGetTranspileCallCount();
-        let responses = await Promise.all([
-          fireRequest(modulePath),
-          fireRequest(modulePath),
-          fireRequest(modulePath),
-        ]);
-        let delta = testRealm.__testOnlyGetTranspileCallCount() - before;
+        // Park A at the gate so the in-flight window is held open until
+        // B and C have demonstrably joined. transpilerHeavySource takes
+        // 50–500 ms in babel which usually masks this race, but on a
+        // saturated CI runner A can settle before later fireRequests
+        // reach #transpileModuleDeduped — same shape as the error-path
+        // flake; deterministic for the same reasons.
+        //
+        // signalAEntered fires from inside the gate hook, so the test
+        // can wait on the actual hook-entry event rather than the
+        // in-flight slot being set — the slot is installed BEFORE the
+        // hook fires (there's a DB read + file read in between), so
+        // polling inflight=1 doesn't prove A has reached the gate.
+        let releaseGate: () => void = () => {};
+        let gate = new Promise<void>((r) => {
+          releaseGate = r;
+        });
+        let signalAEntered: () => void = () => {};
+        let aEntered = new Promise<void>((r) => {
+          signalAEntered = r;
+        });
+        let hookEntries = 0;
+        testRealm.__testOnlyDelayTranspile(() => {
+          hookEntries += 1;
+          signalAEntered();
+          return gate;
+        });
 
-        assert.deepEqual(
-          responses.map((r) => r.status),
-          [200, 200, 200],
-          'all three concurrent same-path requests succeed',
-        );
-        assert.strictEqual(
-          delta,
-          1,
-          'exactly one transpileJS call serviced three concurrent same-path readers',
-        );
-        assert.strictEqual(
-          testRealm.__testOnlyGetInFlightTranspileCount(),
-          0,
-          'in-flight slot released after the shared transpile settled',
-        );
+        // Hoist the pending* promises so the finally block can settle
+        // them with Promise.allSettled before teardown — otherwise a
+        // throw between fireRequest and the explicit await would leak
+        // background requests into the next test's afterEach.
+        let pendingA: ReturnType<typeof fireRequest> | undefined;
+        let pendingB: ReturnType<typeof fireRequest> | undefined;
+        let pendingC: ReturnType<typeof fireRequest> | undefined;
+        let diag = createDiagLog('N concurrent same-path readers');
+        let passed = false;
+        try {
+          let before = testRealm.__testOnlyGetTranspileCallCount();
+          diag.note('start', { before });
+
+          pendingA = fireRequest(modulePath);
+          await aEntered;
+          diag.note('A-entered-hook');
+
+          pendingB = fireRequest(modulePath);
+          pendingC = fireRequest(modulePath);
+          await waitForJoinCount(2);
+          diag.note('B-and-C-joined', { hookEntries });
+
+          releaseGate();
+          diag.note('gate-released');
+          let responses = await Promise.all([pendingA, pendingB, pendingC]);
+          diag.note('all-responded', {
+            statuses: responses.map((r) => r.status),
+          });
+          let delta = testRealm.__testOnlyGetTranspileCallCount() - before;
+
+          assert.deepEqual(
+            responses.map((r) => r.status),
+            [200, 200, 200],
+            'all three concurrent same-path requests succeed',
+          );
+          assert.strictEqual(
+            delta,
+            1,
+            'exactly one transpileJS call serviced three concurrent same-path readers',
+          );
+          assert.strictEqual(
+            testRealm.__testOnlyGetInFlightTranspileCount(),
+            0,
+            'in-flight slot released after the shared transpile settled',
+          );
+          passed = true;
+        } finally {
+          releaseGate();
+          testRealm.__testOnlyDelayTranspile(undefined);
+          await Promise.allSettled(
+            [pendingA, pendingB, pendingC].filter(
+              (p): p is ReturnType<typeof fireRequest> => p !== undefined,
+            ),
+          );
+          if (!passed) {
+            diag.dump();
+          }
+        }
       });
 
       test('concurrent different-path readers each trigger their own transpile (no false coalesce)', async function (assert) {
@@ -707,17 +766,38 @@ module(basename(__filename), function () {
         // at a gate so the in-flight overlap window is held open until
         // both callers have demonstrably reached the dedup site, then
         // release to let the rejection propagate to both.
+        //
+        // signalAEntered fires from inside the gate hook, NOT from
+        // waitForInflight: the in-flight slot is set BEFORE the hook
+        // fires (#transpileWithLayers reads the L2 cache row +
+        // materializes the file ref in between), so polling inflight=1
+        // doesn't prove A is actually parked at the gate. Without the
+        // explicit signal, a slow DB read can let B's joinCount tick
+        // before A's hook entry, and the later hookEntries === 1
+        // assertion would observe 0.
         let releaseGate: () => void = () => {};
         let gate = new Promise<void>((r) => {
           releaseGate = r;
         });
+        let signalAEntered: () => void = () => {};
+        let aEntered = new Promise<void>((r) => {
+          signalAEntered = r;
+        });
         let hookEntries = 0;
         testRealm.__testOnlyDelayTranspile(() => {
           hookEntries += 1;
+          signalAEntered();
           return gate;
         });
 
-        let diag = createDiagLog();
+        // Hoist pending promises so the finally block can settle them
+        // with Promise.allSettled before the next test's afterEach
+        // tears the realm down — otherwise a throw between fireRequest
+        // and the explicit await leaks background HTTP requests across
+        // the test boundary.
+        let pendingA: ReturnType<typeof fireRequest> | undefined;
+        let pendingB: ReturnType<typeof fireRequest> | undefined;
+        let diag = createDiagLog('errored transpile shared');
         let passed = false;
         try {
           let before = testRealm.__testOnlyGetTranspileCallCount();
@@ -725,24 +805,23 @@ module(basename(__filename), function () {
 
           // Fire A but DON'T await — we need it parked at the gate so
           // B can race in.
-          let pendingA = fireRequest(modulePath);
-          await waitForInflight(1);
-          diag.note('A-parked-at-gate', { hookEntries });
+          pendingA = fireRequest(modulePath);
+          await aEntered;
+          diag.note('A-entered-hook', { hookEntries });
 
           // Fire B. B's HTTP request travels through Express +
           // supertest until it reaches #transpileModuleDeduped, where
           // it should observe A's pending in #inFlightTranspiles and
           // take the `existing` branch — bumping joinCount to 1 —
-          // instead of installing its own. Polling joinCount is
-          // deterministic; polling inflight=1 is not (already 1 from
-          // A).
-          let pendingB = fireRequest(modulePath);
+          // instead of installing its own.
+          pendingB = fireRequest(modulePath);
           await waitForJoinCount(1);
           diag.note('B-joined', { hookEntries });
 
-          // Sanity: only A's hook fired. If hookEntries > 1, the gate
-          // released early (impossible — we hold `releaseGate`) or B
-          // bypassed the dedup. Either is a real bug worth surfacing.
+          // Sanity: only A's hook fired. We awaited aEntered above and
+          // hold releaseGate, so hookEntries can't be anything other
+          // than 1 here — if it is, B bypassed the dedup, which is a
+          // real bug worth surfacing.
           assert.strictEqual(
             hookEntries,
             1,
@@ -797,13 +876,19 @@ module(basename(__filename), function () {
           passed = true;
         } finally {
           // Release the gate in case we threw before reaching the
-          // explicit release (e.g. waitForJoinCount timed out). Any
-          // still-parked pending then settles instead of leaking into
-          // the next test as an unhandled rejection.
+          // explicit release (e.g. waitForJoinCount timed out), then
+          // settle any background pending requests before this test's
+          // afterEach tears the realm down — otherwise orphaned
+          // requests would race teardown and leak into the next test.
           releaseGate();
           testRealm.__testOnlyDelayTranspile(undefined);
+          await Promise.allSettled(
+            [pendingA, pendingB].filter(
+              (p): p is ReturnType<typeof fireRequest> => p !== undefined,
+            ),
+          );
           if (!passed) {
-            diag.dump(assert);
+            diag.dump();
           }
         }
       });

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -744,6 +744,13 @@ export class Realm {
   // exactly one transpile call. Reset by __testOnlyClearCaches so each
   // test reasons from a clean baseline.
   #transpileCallCount = 0;
+  // Monotonic count of times the `existing` branch was taken in
+  // #transpileModuleDeduped — i.e., a concurrent caller joined a
+  // previously-installed in-flight promise instead of installing its
+  // own. Lets the dedup tests deterministically observe "B has joined
+  // A's pending" without racing on event-loop timing in CI. Reset by
+  // __testOnlyClearCaches alongside #transpileCallCount.
+  #transpileJoinCount = 0;
   // CS-11030: optional cross-process coalesce coordinator. When set, the
   // first realm-server in the fleet to miss the in-memory cache for a
   // given (realm_url, canonical_path) acquires an advisory lock, writes
@@ -1467,6 +1474,7 @@ export class Realm {
     // delta. Production never reads this counter — only the CS-11029
     // dedup tests do (CS-11029).
     this.#transpileCallCount = 0;
+    this.#transpileJoinCount = 0;
   }
 
   // CS-11043. Bulk-invalidate this realm's in-process byte caches.
@@ -1501,6 +1509,15 @@ export class Realm {
   }
   __testOnlyGetInFlightTranspileCount(): number {
     return this.#inFlightTranspiles.size;
+  }
+  // Counts every time a concurrent caller of #transpileModuleDeduped
+  // joined an existing in-flight entry instead of starting a new one.
+  // The dedup tests poll this to know "B has joined A's pending" so
+  // they can release the gate at a deterministic point — without it,
+  // tests using a real .gts that throws fast at babel can't reliably
+  // observe the in-flight overlap window before A settles.
+  __testOnlyGetTranspileJoinCount(): number {
+    return this.#transpileJoinCount;
   }
   // Test-only gate: when set, #materializeAndTranspile awaits the
   // returned promise before calling transpileJS. Lets the dedup tests
@@ -2958,6 +2975,7 @@ export class Realm {
   ): Promise<ModuleTranspileResult> {
     let existing = this.#inFlightTranspiles.get(localPath);
     if (existing) {
+      this.#transpileJoinCount += 1;
       return existing;
     }
     // Assign the chained `.finally` to `pending` and store/return THAT


### PR DESCRIPTION
## Summary

- Park A's transpile at the existing `__testOnlyDelayTranspile` gate so the in-flight window is held open until B has demonstrably joined the dedup slot, then release. Without this, transpileJS throws fast on syntactically-invalid source, A's `.finally` clears the slot before B's HTTP request arrives at `#transpileModuleDeduped`, and B installs its own pending — observed in CI as `deltaShared = 2`, expected `1` (see https://github.com/cardstack/boxel/actions/runs/26235607189/job/77208448648).
- New `__testOnlyGetTranspileJoinCount` test seam on `Realm` increments every time the `existing` branch is taken in `#transpileModuleDeduped`. Together with the gate this gives the test an explicit "B has joined" handle without racing on event-loop timing.
- Diagnostic event log captures timestamped hook entries, gate releases, counter readings, and HTTP responses around the concurrent-arrive window. Dumped via `assert.pushResult` only on assertion failure, so if the dedup ever flakes again the QUnit output shows the timeline rather than just the bare actual/expected line.

## Test plan

- [x] `TEST_FILES=module-cache-race-test pnpm test` passes locally — full module-cache-race file, 20/20 tests
- [x] Looped 7×+ locally with the same filter, no flakes (full 10× loop ran to completion; see local notes)
- [x] Production `#transpileModuleDeduped` behavior unchanged — only adds a counter increment on the `existing` branch
- [ ] CI shard 5 (the one that flaked on the source run) passes