### PR TITLE
Stabilize 'monaco editor live updates when index changes' + flake probe

### DIFF
--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -2358,20 +2358,27 @@ module('Acceptance | code submode tests', function (_hooks) {
       } catch (err) {
         let monacoContent = getMonacoContent();
         let sourceProbe: string;
+        let sourceOk: boolean;
         try {
           let network = getService('network');
           let res = await network.authedFetch(
             `${testRealmURL}Person/fadhlan.json`,
             { headers: { Accept: 'application/vnd.card+source' } },
           );
-          sourceProbe = await res.text();
+          let body = await res.text();
+          sourceOk = res.ok;
+          sourceProbe = sourceOk
+            ? body
+            : `<source-probe non-ok: ${res.status} ${res.statusText} body=${JSON.stringify(body)}>`;
         } catch (e: any) {
+          sourceOk = false;
           sourceProbe = `<source-probe error: ${e?.message ?? e}>`;
         }
         console.warn(
           '[monaco-live-updates flake-probe] waitUntil timed out. ' +
             `monaco includes "FadhlanXXX"=${monacoContent.includes('FadhlanXXX')}; ` +
-            `source on disk includes "FadhlanXXX"=${sourceProbe.includes('FadhlanXXX')}. ` +
+            `source fetch ok=${sourceOk}; ` +
+            `source on disk includes "FadhlanXXX"=${sourceOk && sourceProbe.includes('FadhlanXXX')}. ` +
             `monaco snapshot: ${JSON.stringify(monacoContent)}. ` +
             `source snapshot: ${JSON.stringify(sourceProbe)}.`,
         );

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -2320,7 +2320,9 @@ module('Acceptance | code submode tests', function (_hooks) {
         submode: 'code',
         codePath: `${testRealmURL}Person/fadhlan.json`,
       });
-      await waitUntil(() => getMonacoContent().includes('Fadhlan'));
+      await waitUntil(() => getMonacoContent().includes('Fadhlan'), {
+        timeout: 5_000,
+      });
 
       await realm.write(
         'Person/fadhlan.json',
@@ -2340,7 +2342,41 @@ module('Acceptance | code submode tests', function (_hooks) {
         } as LooseSingleCardDocument),
       );
 
-      await waitUntil(() => getMonacoContent().includes('FadhlanXXX'));
+      // The realm-write → matrix-broadcast → message-service → file-resource
+      // refetch → monaco rerender chain crosses a setTimeout(0) hop in
+      // mock-matrix's addRoomEvent, so realm.write resolves before the event
+      // is even dispatched. Default waitUntil timeout (1s) is too tight for
+      // this chain under CI load — matches sibling 'card preview live updates
+      // when there is a change in module' which already uses 5s for the same
+      // reason. On timeout we dump enough state to tell next time whether the
+      // failure was monaco-side render lag, file-resource refetch never firing,
+      // or the source file itself never updating.
+      try {
+        await waitUntil(() => getMonacoContent().includes('FadhlanXXX'), {
+          timeout: 5_000,
+        });
+      } catch (err) {
+        let monacoContent = getMonacoContent();
+        let sourceProbe: string;
+        try {
+          let network = getService('network');
+          let res = await network.authedFetch(
+            `${testRealmURL}Person/fadhlan.json`,
+            { headers: { Accept: 'application/vnd.card+source' } },
+          );
+          sourceProbe = await res.text();
+        } catch (e: any) {
+          sourceProbe = `<source-probe error: ${e?.message ?? e}>`;
+        }
+        console.warn(
+          '[monaco-live-updates flake-probe] waitUntil timed out. ' +
+            `monaco includes "FadhlanXXX"=${monacoContent.includes('FadhlanXXX')}; ` +
+            `source on disk includes "FadhlanXXX"=${sourceProbe.includes('FadhlanXXX')}. ` +
+            `monaco snapshot: ${JSON.stringify(monacoContent)}. ` +
+            `source snapshot: ${JSON.stringify(sourceProbe)}.`,
+        );
+        throw err;
+      }
       assert.true(
         getMonacoContent().includes('FadhlanXXX'),
         'monaco editor updated from index event',


### PR DESCRIPTION
## Summary

[Host Tests shard 16 / job 77211155741](https://github.com/cardstack/boxel/actions/runs/26236379154/job/77211155741?pr=4918) failed `Acceptance | code submode tests > single realm: monaco editor live updates when index changes` with `Error: waitUntil timed out`. Confirmed flake (passes locally; PR 4918's changes are scoped to `mise-tasks/` shell scripts that the host test runner doesn't touch).

Root cause: mock-matrix's `addRoomEvent` (`packages/host/tests/helpers/mock-matrix/_server-state.ts:250`) dispatches realm events via `setTimeout(() => listeners.forEach(...), 0)`, so `realm.write` resolves before the realm-incremental event is even queued for the host's matrix-service. The full chain — matrix-broadcast → `messageService.relayRealmEvent` → file-resource subscription callback → `read.perform()` HTTP refetch → monaco editor rerender — regularly exceeds `waitUntil`'s default 1s timeout under CI load. The sibling test `card preview live updates when there is a change in module` (~70 lines below) already passes `{ timeout: 5_000 }` for the same chain.

## Changes

- Both `waitUntil`s in this test now use an explicit `{ timeout: 5_000 }`, matching the sibling pattern.
- The post-write `waitUntil` is wrapped in a try/catch. On timeout it fetches the source file directly via `network.authedFetch` and `console.warn`s whether monaco's content vs. the file on disk contains the expected token. Three failure modes become distinguishable next time:
  - `monaco=false, source=true` → monaco render lag / file-resource updated but UI not flushed
  - `monaco=false, source=false` → file-resource never refetched (realm event lost or invalidation filter rejected it)
  - `monaco=true, source=*` → false-negative on the wait predicate itself
- Re-throws to preserve the original failure signal.

Diagnostic stays in even after the timeout bump is "obviously right" — flaky tests aren't always what they look like.

## Test plan

- [x] `pnpm lint` (full, all three sub-steps: js / hbs / types) clean inside `packages/host`
- [ ] CI host shards green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)