### PR TITLE
observability: fix Overview Web Requests panel queries

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/aws-elb.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/aws-elb.json
@@ -225,6 +225,171 @@
           "type": "cloudwatch",
           "uid": "cef5x9o3yzawwf"
         },
+        "description": "ALB target-group health: how many backend tasks the load balancer's health check considers healthy vs unhealthy. A task can be Running in ECS but failing the ALB health check — those show up here as UnHealthyHostCount. Healthy = 0 means clients get 503s. Filter by the TargetGroup template variable; defaults to all groups under the selected ALB.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 20,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "stepAfter",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 0,
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "HealthyHostCount"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "#56a64b"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "UnHealthyHostCount"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "#e02f44"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 7
+        },
+        "id": 16,
+        "options": {
+          "dataLinks": [],
+          "legend": {
+            "calcs": [
+              "mean",
+              "max",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.1",
+        "targets": [
+          {
+            "alias": "",
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername",
+              "TargetGroup": "$targetgroup"
+            },
+            "expression": "",
+            "id": "",
+            "metricEditorMode": 0,
+            "metricName": "HealthyHostCount",
+            "metricQueryType": 0,
+            "namespace": "AWS/ApplicationELB",
+            "period": "",
+            "refId": "A",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Average"
+          },
+          {
+            "alias": "",
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "dimensions": {
+              "LoadBalancer": "$loadbalancername",
+              "TargetGroup": "$targetgroup"
+            },
+            "expression": "",
+            "id": "",
+            "metricEditorMode": 0,
+            "metricName": "UnHealthyHostCount",
+            "metricQueryType": 0,
+            "namespace": "AWS/ApplicationELB",
+            "period": "",
+            "refId": "B",
+            "region": "$region",
+            "returnData": false,
+            "statistic": "Average"
+          }
+        ],
+        "title": "HealthyHostCount / UnHealthyHostCount",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "cloudwatch",
+          "uid": "cef5x9o3yzawwf"
+        },
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -286,7 +451,7 @@
           "h": 10,
           "w": 24,
           "x": 0,
-          "y": 7
+          "y": 14
         },
         "id": 1,
         "options": {
@@ -535,7 +700,7 @@
           "h": 7,
           "w": 24,
           "x": 0,
-          "y": 17
+          "y": 24
         },
         "id": 12,
         "options": {
@@ -744,7 +909,7 @@
           "h": 7,
           "w": 24,
           "x": 0,
-          "y": 24
+          "y": 31
         },
         "id": 10,
         "options": {
@@ -1012,7 +1177,7 @@
           "h": 8,
           "w": 24,
           "x": 0,
-          "y": 31
+          "y": 38
         },
         "id": 8,
         "options": {
@@ -1224,7 +1389,7 @@
           "h": 7,
           "w": 24,
           "x": 0,
-          "y": 39
+          "y": 46
         },
         "id": 11,
         "options": {
@@ -1411,7 +1576,7 @@
           "h": 7,
           "w": 24,
           "x": 0,
-          "y": 46
+          "y": 53
         },
         "id": 15,
         "options": {
@@ -1581,7 +1746,7 @@
           "h": 7,
           "w": 24,
           "x": 0,
-          "y": 53
+          "y": 60
         },
         "id": 13,
         "options": {
@@ -1729,7 +1894,7 @@
           "h": 14,
           "w": 24,
           "x": 0,
-          "y": 60
+          "y": 67
         },
         "id": 14,
         "options": {
@@ -1994,7 +2159,7 @@
           "h": 3,
           "w": 24,
           "x": 0,
-          "y": 74
+          "y": 81
         },
         "id": 2,
         "options": {
@@ -2047,6 +2212,24 @@
           "name": "loadbalancername",
           "options": [],
           "query": "dimension_values($region,AWS/ApplicationELB,ActiveConnectionCount,LoadBalancer)",
+          "refresh": 1,
+          "regex": "",
+          "sort": 1,
+          "type": "query"
+        },
+        {
+          "current": {},
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "cef5x9o3yzawwf"
+          },
+          "definition": "dimension_values($region,AWS/ApplicationELB,HealthyHostCount,TargetGroup,{\"LoadBalancer\":\"$loadbalancername\"})",
+          "includeAll": true,
+          "label": "TargetGroup",
+          "multi": true,
+          "name": "targetgroup",
+          "options": [],
+          "query": "dimension_values($region,AWS/ApplicationELB,HealthyHostCount,TargetGroup,{\"LoadBalancer\":\"$loadbalancername\"})",
           "refresh": 1,
           "regex": "",
           "sort": 1,

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -671,7 +671,7 @@
         },
         "gridPos": {
           "h": 8,
-          "w": 6,
+          "w": 8,
           "x": 0,
           "y": 11
         },
@@ -879,102 +879,6 @@
         ],
         "title": "Application Load Balancer",
         "type": "timeseries",
-        "links": [
-          {
-            "title": "Open Application Load Balancer dashboard",
-            "url": "/d/boxel-aws-elb?var-loadbalancername=$realm_server_alb",
-            "targetBlank": false,
-            "type": "link",
-            "icon": "external link"
-          }
-        ]
-      },
-      {
-        "datasource": {
-          "type": "cloudwatch",
-          "uid": "cef5x9o3yzawwf"
-        },
-        "description": "ALB target-group health: realm-server tasks currently passing the load balancer's health check. Distinct from the ECS Tasks stat — a task can be Running in ECS but failing ALB health checks. Zero means the LB sees no healthy backends and clients get 503s. Locally shows 'No data' — CloudWatch is staging/production only.",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "decimals": 0,
-            "links": [
-              {
-                "title": "Open Application Load Balancer dashboard",
-                "url": "/d/boxel-aws-elb?var-loadbalancername=$realm_server_alb",
-                "targetBlank": false
-              }
-            ],
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "red",
-                  "value": null
-                },
-                {
-                  "color": "yellow",
-                  "value": 1
-                },
-                {
-                  "color": "green",
-                  "value": 2
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 2,
-          "x": 6,
-          "y": 11
-        },
-        "id": 33,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "center",
-          "orientation": "vertical",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "value",
-          "wideLayout": true
-        },
-        "pluginVersion": "12.4.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "cloudwatch",
-              "uid": "cef5x9o3yzawwf"
-            },
-            "namespace": "AWS/ApplicationELB",
-            "metricName": "HealthyHostCount",
-            "metricEditorMode": 0,
-            "metricQueryType": 0,
-            "dimensions": {
-              "LoadBalancer": "$realm_server_alb",
-              "TargetGroup": "$realm_server_tg"
-            },
-            "statistic": "Average",
-            "period": "",
-            "region": "default",
-            "refId": "A"
-          }
-        ],
-        "title": "Healthy Tasks",
-        "type": "stat",
         "links": [
           {
             "title": "Open Application Load Balancer dashboard",
@@ -3306,24 +3210,6 @@
           "query": "dimension_values(default,AWS/ApplicationELB,RequestCount,LoadBalancer)",
           "refresh": 1,
           "regex": "/^(?<value>app\\/boxel-realm-server-${env}\\/[a-f0-9]+)$/",
-          "skipUrlSync": true,
-          "sort": 1,
-          "type": "query"
-        },
-        {
-          "current": {},
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "cef5x9o3yzawwf"
-          },
-          "definition": "dimension_values(default,AWS/ApplicationELB,HealthyHostCount,TargetGroup,{\"LoadBalancer\":\"$realm_server_alb\"})",
-          "hide": 2,
-          "includeAll": false,
-          "name": "realm_server_tg",
-          "options": [],
-          "query": "dimension_values(default,AWS/ApplicationELB,HealthyHostCount,TargetGroup,{\"LoadBalancer\":\"$realm_server_alb\"})",
-          "refresh": 1,
-          "regex": "/^(?<value>targetgroup\\/boxel-realm-server-${env}[^/]*\\/[a-f0-9]+)$/",
           "skipUrlSync": true,
           "sort": 1,
           "type": "query"

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -675,23 +675,67 @@
         "targets": [
           {
             "datasource": {
-              "type": "loki",
-              "uid": "loki"
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
             },
-            "expr": "60 * sum(rate({service=\"realm-server\"} |~ \"^-->\" [1m])) or vector(0)",
-            "queryType": "range",
-            "legendFormat": "HTTP req/min",
+            "namespace": "AWS/ApplicationELB",
+            "metricName": "RequestCount",
+            "metricEditorMode": 0,
+            "metricQueryType": 0,
+            "dimensions": {
+              "LoadBalancer": "$realm_server_alb"
+            },
+            "statistic": "Sum",
+            "period": "",
+            "region": "default",
+            "id": "a",
+            "hide": true,
             "refId": "A"
           },
           {
             "datasource": {
-              "type": "loki",
-              "uid": "loki"
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
             },
-            "expr": "60 * sum(rate({service=\"realm-server\"} |~ \"(?i)error|exception|fatal\" [1m])) or vector(0)",
-            "queryType": "range",
-            "legendFormat": "HTTP err/min",
+            "namespace": "AWS/ApplicationELB",
+            "metricName": "HTTPCode_Target_5XX_Count",
+            "metricEditorMode": 0,
+            "metricQueryType": 0,
+            "dimensions": {
+              "LoadBalancer": "$realm_server_alb"
+            },
+            "statistic": "Sum",
+            "period": "",
+            "region": "default",
+            "id": "b",
+            "hide": true,
             "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "metricEditorMode": 1,
+            "metricQueryType": 0,
+            "expression": "FILL(a, 0) / PERIOD(a) * 60",
+            "label": "HTTP req/min",
+            "region": "default",
+            "id": "f",
+            "refId": "F"
+          },
+          {
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "metricEditorMode": 1,
+            "metricQueryType": 0,
+            "expression": "FILL(b, 0) / PERIOD(b) * 60",
+            "label": "HTTP err/min",
+            "region": "default",
+            "id": "g",
+            "refId": "G"
           },
           {
             "datasource": {

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -479,10 +479,10 @@
       },
       {
         "datasource": {
-          "type": "loki",
-          "uid": "loki"
+          "type": "cloudwatch",
+          "uid": "cef5x9o3yzawwf"
         },
-        "description": "Realm-server HTTP throughput, errors, and target response time. Throughput / errors come from Loki (`httpLogging` exit lines `--> METHOD ACCEPT URL: STATUS` and any line matching `error|exception|fatal`). p50 / p95 / p99 come from the realm-server ALB's `AWS/ApplicationELB.TargetResponseTime` metric (CloudWatch ExtendedStatistic) on the right axis in seconds — locally these read 'No data' but throughput/errors keep working. Legend shows the mean over the visible time range.",
+        "description": "Realm-server ALB metrics: request count, error rate (target 5XX + ELB-emitted 5XX combined), client 4xx rate, and target response time (p50/p95/p99 on the right axis in seconds). All series come from `AWS/ApplicationELB` CloudWatch metrics; request/error/4xx counts are normalized to per-minute regardless of the selected time range. Locally these read 'No data' — CloudWatch is staging/production only. Legend shows the mean over the visible window.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -519,8 +519,8 @@
             "decimals": 1,
             "links": [
               {
-                "title": "Open Realm Server dashboard",
-                "url": "/d/boxel-svc-realm-server",
+                "title": "Open Application Load Balancer dashboard",
+                "url": "/d/boxel-aws-elb?var-loadbalancername=$realm_server_alb",
                 "targetBlank": false
               }
             ],
@@ -881,8 +881,8 @@
         "type": "timeseries",
         "links": [
           {
-            "title": "Open Realm Server dashboard",
-            "url": "/d/boxel-svc-realm-server",
+            "title": "Open Application Load Balancer dashboard",
+            "url": "/d/boxel-aws-elb?var-loadbalancername=$realm_server_alb",
             "targetBlank": false,
             "type": "link",
             "icon": "external link"
@@ -903,8 +903,8 @@
             "decimals": 0,
             "links": [
               {
-                "title": "Open Realm Server dashboard",
-                "url": "/d/boxel-svc-realm-server",
+                "title": "Open Application Load Balancer dashboard",
+                "url": "/d/boxel-aws-elb?var-loadbalancername=$realm_server_alb",
                 "targetBlank": false
               }
             ],
@@ -977,8 +977,8 @@
         "type": "stat",
         "links": [
           {
-            "title": "Open Realm Server dashboard",
-            "url": "/d/boxel-svc-realm-server",
+            "title": "Open Application Load Balancer dashboard",
+            "url": "/d/boxel-aws-elb?var-loadbalancername=$realm_server_alb",
             "targetBlank": false,
             "type": "link",
             "icon": "external link"

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/overview.json
@@ -570,6 +570,25 @@
             {
               "matcher": {
                 "id": "byName",
+                "options": "HTTP 4xx/min"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "#f2cc0c"
+                  }
+                },
+                {
+                  "id": "custom.fillOpacity",
+                  "value": 5
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
                 "options": "p50"
               },
               "properties": [
@@ -652,7 +671,7 @@
         },
         "gridPos": {
           "h": 8,
-          "w": 8,
+          "w": 6,
           "x": 0,
           "y": 11
         },
@@ -716,26 +735,92 @@
               "type": "cloudwatch",
               "uid": "cef5x9o3yzawwf"
             },
-            "metricEditorMode": 1,
+            "namespace": "AWS/ApplicationELB",
+            "metricName": "HTTPCode_ELB_5XX_Count",
+            "metricEditorMode": 0,
             "metricQueryType": 0,
-            "expression": "FILL(a, 0) / PERIOD(a) * 60",
-            "label": "HTTP req/min",
+            "dimensions": {
+              "LoadBalancer": "$realm_server_alb"
+            },
+            "statistic": "Sum",
+            "period": "",
             "region": "default",
-            "id": "f",
-            "refId": "F"
+            "id": "h",
+            "hide": true,
+            "refId": "H"
           },
           {
             "datasource": {
               "type": "cloudwatch",
               "uid": "cef5x9o3yzawwf"
             },
-            "metricEditorMode": 1,
+            "namespace": "AWS/ApplicationELB",
+            "metricName": "HTTPCode_Target_4XX_Count",
+            "metricEditorMode": 0,
             "metricQueryType": 0,
-            "expression": "FILL(b, 0) / PERIOD(b) * 60",
-            "label": "HTTP err/min",
+            "dimensions": {
+              "LoadBalancer": "$realm_server_alb"
+            },
+            "statistic": "Sum",
+            "period": "",
             "region": "default",
-            "id": "g",
-            "refId": "G"
+            "id": "i",
+            "hide": true,
+            "refId": "I"
+          },
+          {
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "expression": "FILL(a, 0) / PERIOD(a) * 60",
+            "metricQueryType": 0,
+            "metricEditorMode": 1,
+            "namespace": "",
+            "metricName": "",
+            "dimensions": {},
+            "statistic": "",
+            "period": "",
+            "region": "default",
+            "label": "HTTP req/min",
+            "refId": "e1",
+            "id": "e1"
+          },
+          {
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "expression": "(FILL(b, 0) + FILL(h, 0)) / PERIOD(b) * 60",
+            "metricQueryType": 0,
+            "metricEditorMode": 1,
+            "namespace": "",
+            "metricName": "",
+            "dimensions": {},
+            "statistic": "",
+            "period": "",
+            "region": "default",
+            "label": "HTTP err/min",
+            "refId": "e2",
+            "id": "e2"
+          },
+          {
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "expression": "FILL(i, 0) / PERIOD(i) * 60",
+            "metricQueryType": 0,
+            "metricEditorMode": 1,
+            "namespace": "",
+            "metricName": "",
+            "dimensions": {},
+            "statistic": "",
+            "period": "",
+            "region": "default",
+            "label": "HTTP 4xx/min",
+            "refId": "e3",
+            "id": "e3"
           },
           {
             "datasource": {
@@ -792,8 +877,104 @@
             "refId": "E"
           }
         ],
-        "title": "Web Requests",
+        "title": "Application Load Balancer",
         "type": "timeseries",
+        "links": [
+          {
+            "title": "Open Realm Server dashboard",
+            "url": "/d/boxel-svc-realm-server",
+            "targetBlank": false,
+            "type": "link",
+            "icon": "external link"
+          }
+        ]
+      },
+      {
+        "datasource": {
+          "type": "cloudwatch",
+          "uid": "cef5x9o3yzawwf"
+        },
+        "description": "ALB target-group health: realm-server tasks currently passing the load balancer's health check. Distinct from the ECS Tasks stat — a task can be Running in ECS but failing ALB health checks. Zero means the LB sees no healthy backends and clients get 503s. Locally shows 'No data' — CloudWatch is staging/production only.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 0,
+            "links": [
+              {
+                "title": "Open Realm Server dashboard",
+                "url": "/d/boxel-svc-realm-server",
+                "targetBlank": false
+              }
+            ],
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "red",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 1
+                },
+                {
+                  "color": "green",
+                  "value": 2
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 2,
+          "x": 6,
+          "y": 11
+        },
+        "id": 33,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "center",
+          "orientation": "vertical",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "value",
+          "wideLayout": true
+        },
+        "pluginVersion": "12.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "namespace": "AWS/ApplicationELB",
+            "metricName": "HealthyHostCount",
+            "metricEditorMode": 0,
+            "metricQueryType": 0,
+            "dimensions": {
+              "LoadBalancer": "$realm_server_alb",
+              "TargetGroup": "$realm_server_tg"
+            },
+            "statistic": "Average",
+            "period": "",
+            "region": "default",
+            "refId": "A"
+          }
+        ],
+        "title": "Healthy Tasks",
+        "type": "stat",
         "links": [
           {
             "title": "Open Realm Server dashboard",
@@ -3125,6 +3306,24 @@
           "query": "dimension_values(default,AWS/ApplicationELB,RequestCount,LoadBalancer)",
           "refresh": 1,
           "regex": "/^(?<value>app\\/boxel-realm-server-${env}\\/[a-f0-9]+)$/",
+          "skipUrlSync": true,
+          "sort": 1,
+          "type": "query"
+        },
+        {
+          "current": {},
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "cef5x9o3yzawwf"
+          },
+          "definition": "dimension_values(default,AWS/ApplicationELB,HealthyHostCount,TargetGroup,{\"LoadBalancer\":\"$realm_server_alb\"})",
+          "hide": 2,
+          "includeAll": false,
+          "name": "realm_server_tg",
+          "options": [],
+          "query": "dimension_values(default,AWS/ApplicationELB,HealthyHostCount,TargetGroup,{\"LoadBalancer\":\"$realm_server_alb\"})",
+          "refresh": 1,
+          "regex": "/^(?<value>targetgroup\\/boxel-realm-server-${env}[^/]*\\/[a-f0-9]+)$/",
           "skipUrlSync": true,
           "sort": 1,
           "type": "query"


### PR DESCRIPTION
[CS-11234](https://linear.app/cardstack/issue/CS-11234/fix-overview-web-requests-panel-and-add-alb-host-health-visibility)

## Summary

Originally fixed the `HTTP req/min` line in the **Web Requests** panel that was flat-zero in staging/prod — the LogQL used `|~ "^-->"`, but FireLens (`infra/modules/aws/ecs/firelens/templates/extra.conf.tftpl` `Line_format json`) wraps each ECS task log line in a JSON envelope before shipping to Loki, so anchored regexes silently match nothing. (Locally Alloy delivers raw stdout, which is why the panel looked fine in dev.)

Switched to ALB CloudWatch metrics, then extended the panel based on review feedback:

- **`HTTP req/min`** → `RequestCount` (Sum) normalized to per-minute via `FILL(a, 0) / PERIOD(a) * 60`. `FILL(…, 0)` keeps the line at zero in quiet windows instead of going to gaps; the math expression normalizes to per-minute regardless of the time range's selected period.
- **`HTTP err/min`** → combined `HTTPCode_Target_5XX_Count + HTTPCode_ELB_5XX_Count` so the panel surfaces both "app threw an error" AND "LB couldn't reach the app" (502/503/504). The original Loki query missed ELB-side 5XX entirely.
- **`HTTP 4xx/min`** (new, muted yellow) → `HTTPCode_Target_4XX_Count`. Useful for auth/CORS/bad-route visibility without screaming for attention.
- **Latency** — `TargetResponseTime` p50/p95/p99 on the right axis, unchanged.
- **Renamed panel** from "Web Requests" → "Application Load Balancer" since it now covers request rate, error rate, latency, and host health under one umbrella.
- **Drilldowns** — all four links on the ALB timeseries + the new ALB-dashboard host-health panel now point to `/d/boxel-aws-elb?var-loadbalancername=$realm_server_alb` (pre-selecting the realm-server ALB on the destination dashboard).

Host-health: initially added a Healthy Tasks stat panel next to the Overview timeseries, but on review it wasn't worth the column. Moved to a new `HealthyHostCount / UnHealthyHostCount` timeseries on the AWS ELB dashboard instead, with a new `$targetgroup` template variable.

Mid-PR fix: the first commit's math expressions hit "parse error: unexpected $end" in staging because they were missing the empty `namespace`/`metricName`/`dimensions`/`statistic`/`period` fields that Grafana's CloudWatch datasource expects on every target. Math `refId` + `id` also need to be matching lowercase. Second commit mirrors the working pattern from the existing "Tasks" math panel.

Side effect: the Overview ALB panel has no signal in local-dev mode (no ALB). Acceptable since this dashboard is for hosted observability.

## Test plan

- [ ] After deploy, verify `HTTP req/min`, `HTTP err/min`, and `HTTP 4xx/min` all render real values on the staging Overview dashboard (no "parse error" tooltip)
- [ ] Verify the legend's mean values are stable across time ranges (1h, 6h, 24h, 7d), confirming the per-minute normalization works
- [ ] Verify the blue/red/yellow color overrides apply correctly (rules match by series name)
- [ ] Verify p50/p95/p99 latency lines on the right axis are unaffected
- [ ] On the AWS ELB dashboard, verify the new HealthyHostCount/UnHealthyHostCount panel renders, and the `TargetGroup` selector populates with target groups under the selected ALB
- [ ] Click through the Overview ALB panel's drilldown link and confirm the destination AWS ELB dashboard loads with the realm-server ALB pre-selected