### PR TITLE
CS-11167 followup: atomic write skips prior-indexing gate

### DIFF
--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1735,7 +1735,20 @@ export class Realm {
     files: Map<LocalPath, string | Uint8Array>,
     options?: WriteOptions,
   ): Promise<FileWriteResult[]> {
-    await this.incrementalIndexing();
+    // The /_atomic endpoint (and any other writeMany caller that opts
+    // out of post-write indexing via waitForIndex:false) does not read
+    // its response from the index, so it has no reason to wait for
+    // prior incremental indexing to settle either. Skipping the gate
+    // here is what keeps consecutive atomic writes responsive when a
+    // previous mutation's deferred indexing job is back-pressured in
+    // the worker pool — without it, every follow-up POST /_atomic
+    // stalls on whichever earlier write/delete is still draining.
+    // Callers that DO read indexed state after the write (the JSON-API
+    // postCardInstance / patchCardInstance handlers) keep the original
+    // deadlock-prevention semantics by omitting waitForIndex.
+    if (options?.waitForIndex !== false) {
+      await this.incrementalIndexing();
+    }
     let urls: URL[] = [];
     // Collect write results for all files we wrote
     let results: { path: LocalPath; lastModified: number }[] = [];


### PR DESCRIPTION
## Summary
Followup to #4857. PR #4857 made HTTP DELETE `application/vnd.card+source` return without awaiting indexing, but the originally-flaky `re-pushes a file that was deleted on the realm out-of-band` test continued failing in CI ([run 26240121457](https://github.com/cardstack/boxel/actions/runs/26240121457/job/77225122768?pr=4920)). Diagnosis from that run's job log:

| Step | Result |
|---|---|
| push#1 → `POST /_atomic` | `201` in 11ms ✓ |
| `DELETE /f.gts` | `204` in 9ms ✓ (CS-11167 fix is working) |
| `GET /f.gts` | `404` ✓ |
| push#2 → `POST /_atomic` | **no response in 30s** ✗ |

No `Deferred delete-indexing settled for …/f.gts` line in the log either, even though the diagnostic emits for ~8 other realms in the same shard within 45–141ms.

The hang is at `_batchWrite`'s top-of-function `await this.incrementalIndexing()` gate ([realm.ts:1541](https://github.com/cardstack/boxel/blob/main/packages/runtime-common/realm.ts#L1541)) — the gate from commit 5e8eb44715 that prevents a deadlock for JSON-API callers reading their own response from the index. `_atomic` doesn't read from the index for its response (already passes `waitForIndex: false`), so the gate served no purpose there — but it still blocked push#2's `_atomic` POST waiting for the deferred DELETE-indexing job from push#1's path to drain, and that job was starved in the worker pool.

This PR skips the gate whenever the caller passes `waitForIndex: false`. JSON-API `postCardInstance` / `patchCardInstance` (the original deadlock-fix path) keep the existing semantics because they pass the default `waitForIndex: true`. The in-loop module→instance flush inside `_batchWrite` is unrelated to this gate and stays intact (it's a within-batch ordering requirement for `fileSerialization`).

## Test plan
- [x] Local: 5 consecutive runs of `packages/boxel-cli` `tests/integration/realm-push.test.ts` pass; the previously-flaky `re-pushes a file that was deleted on the realm out-of-band` now finishes in ~1.4s (vs. timing out at 30s on PR #4920).
- [ ] CI: full Boxel CLI Tests, Host Tests, Realm Server Tests shards (JSON-API postCardInstance / patchCardInstance regression coverage).

Closes-ish CS-11167 (the test that motivated it is finally green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)