### PR TITLE
Pass-scoped compute memo 

### DIFF
--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -167,6 +167,25 @@ WHERE timing_diagnostics->>'renderElapsedMs' IS NOT NULL
 GROUP BY 1
 ORDER BY p95_ms DESC NULLS LAST
 LIMIT 20;
+
+-- Rows where the render.meta computed-field traversal dominates the
+-- render budget. `computedCalls` + the host-side `searchDocMs` /
+-- `serializeMs` are emitted by the host route per row. Use these to
+-- find aggregate-style cards that are eating their render budget on
+-- compute work rather than data loads or template stalls.
+SELECT
+  url,
+  to_timestamp((timing_diagnostics->>'indexedAt')::bigint / 1000) AS indexed_at,
+  (timing_diagnostics->>'computedCalls')::int                     AS calls,
+  (timing_diagnostics->>'computedCacheHits')::int                 AS cache_hits,
+  (timing_diagnostics->>'serializeMs')::numeric                   AS serialize_ms,
+  (timing_diagnostics->>'searchDocMs')::numeric                   AS search_doc_ms,
+  (timing_diagnostics->>'renderElapsedMs')::int                   AS render_ms
+FROM boxel_index
+WHERE realm_url = 'https://localhost:4201/user/your-realm/'
+  AND timing_diagnostics->>'computedCalls' IS NOT NULL
+ORDER BY (timing_diagnostics->>'computedCalls')::int DESC NULLS LAST
+LIMIT 20;
 ```
 
 ## Mode C — a worker job is stuck or got rejected
@@ -735,7 +754,30 @@ WHERE timing_diagnostics->>'requestId' = '<request-id>';
   ],
   "docsInFlight": 3,             // legacy count, kept for rollback safety
   "capturedDom": "<section data-prerender>…</section>",
-  "blockedTimerSummary": "Timers blocked during prerender: …"
+  "blockedTimerSummary": "Timers blocked during prerender: …",
+  "computedCalls": 187,          // distinct `computeVia` invocations during this row's
+                                 // render.meta traversal (serializeCard + searchDoc combined).
+                                 // Host-emitted; pass-scoped memo elides repeated reads of
+                                 // the same `(instance, fieldName)` so this number reflects
+                                 // distinct compute work, not total field-access pressure.
+                                 // Absent on rows produced by host builds before CS-11208.
+  "computedCacheHits": 374,      // repeated reads of the same `(instance, fieldName)`
+                                 // that hit the pass-scoped memo. `computedCalls +
+                                 // computedCacheHits` is the total computed-read pressure
+                                 // of the render.meta pass; the ratio tells you how much
+                                 // duplicate work the memo elided. A high `cacheHits`
+                                 // count relative to `calls` is normal for cards that
+                                 // serialize + searchDoc the same field (every contains /
+                                 // contains-many / links-to field does this).
+  "serializeMs": 42.1,           // host-side wall-clock of `serializeCard(instance, {
+                                 // includeComputeds: true })` for this card.
+  "searchDocMs": 18.3            // host-side wall-clock of `searchDoc(instance)` for
+                                 // this card. Sum with `serializeMs` to get the host's
+                                 // contribution to `renderElapsedMs`. Pairs with
+                                 // `computedCalls` so you can normalize: a card with
+                                 // `computedCalls=500, searchDocMs=80` is ~6 calls/ms
+                                 // — a sign of a hot compute that may be worth a
+                                 // dependency-aware skip.
 }
 ```
 
@@ -752,6 +794,7 @@ All ms values are server-observed walltime.
 - `recentQueryLoads[*].ms` is the wall time a completed query-field/search load ultimately took. The store keeps a bounded top-N so even queries that resolved just before the timer fired stay visible. Compare with `renderElapsedMs` to see which fraction of the render budget went to query work.
 - `cardDocLoadsInFlight[*].ageMs` / `fileMetaDocLoadsInFlight[*].ageMs` mirror the query version for linked-field (card doc) / file-meta loads. One URL with a very large `ageMs` = one slow linksTo target; many URLs with small `ageMs` = fan-out.
 - `recentCardDocLoads[*].ms` / `recentFileMetaLoads[*].ms` are the completed-load histories; same usage as `recentQueryLoads`.
+- `computedCalls` + `computedCacheHits` together represent total compute pressure on the render.meta pass. The split tells you how much duplicate work the pass-scoped memo absorbed — a 1:0 ratio means every field was read once, a 1:5 ratio means the cards re-read each computed five extra times (typical for cards where many sibling fields share a computed input). `searchDocMs` + `serializeMs` are the host's contribution to `renderElapsedMs`; comparing `computedCalls / (searchDocMs + serializeMs)` across cards finds the slow-per-call computes that are worth profiling.
 
 Keep the field names in lock-step with the type in `packages/runtime-common/index.ts`.
 
@@ -774,6 +817,7 @@ Walk the fields top-down. The _first_ positive signal wins; stop there.
 | `renderStage` = `waiting-stability` with empty in-flight arrays                                                                                                                                                                                       | **Render stall**                                                             | Nothing is loading but settlement never finishes. Classic Glimmer tracking loop — template is invalidating itself. `capturedDom` usually shows the partially-rendered component. `blockedTimerSummary` will list swallowed timers that may hint at a scheduling loop.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `currentlyEvaluatingModule` non-null, or `stageAgeMs` large with empty in-flight arrays                                                                                                                                                               | **Synchronous browser stall (typically Glimmer compile during module eval)** | `recentModuleEvaluations` shows the worst offenders. A single URL with `ms > 5000` usually means "this module has a giant template that takes forever to compile". Many small entries (say 50+ at 100–500 ms each) summing into the stall budget mean card fan-out where each dependent card contributes a compile. Split the module, lazy-load the template, or reduce the component fan-out.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | `blockedTimerSummary` populated                                                                                                                                                                                                                       | **Supplementary**                                                            | Tells you which timer-driven code is fighting the render. Not a root cause on its own.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `computedCalls` large (e.g. > 1000) AND `searchDocMs + serializeMs` ≈ `renderElapsedMs`                                                                                                                                                               | **Computed-field hot path**                                                  | The render.meta traversal itself is the bottleneck, not data loads or browser stalls. Look at `computedCalls / (searchDocMs + serializeMs)` — > ~5 calls/ms is fast, < ~1 call/ms means a few slow `computeVia` functions dominate. Inspect the card class for aggregate computeds that scan a `linksToMany` relation on every read (Portfolio-over-Policies style) and consider hoisting the scan into a shared rollup or adding `computeDeps` so the field can be skipped when its inputs don't change. The pass-scoped memo already eliminates duplicate reads in one traversal (visible in `computedCacheHits`); further wins require structural changes to the card.                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 
 ### Special cases
 
@@ -935,7 +979,7 @@ Slot-by-slot:
   | `realms-staging.stack.cards`            | `https://boxel-host-staging.stack.cards`                |
   | `realms.stack.cards`                    | `https://boxel-host.stack.cards`                        |
   | `realm-server.<slug>.localhost`         | `http://host.<slug>.localhost` (BOXEL_ENVIRONMENT mode) |
-  | `localhost` or `*.localhost` (standard) | `https://localhost:4200`                                 |
+  | `localhost` or `*.localhost` (standard) | `https://localhost:4200`                                |
 
   If the realm host doesn't match any of these patterns, ask the user — don't guess. Constrain `realms-` matching to `*.stack.cards` so any future deployment using a `realms-` prefix on a different domain isn't silently mapped to a wrong (and possibly non-existent) host.
 

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -152,6 +152,8 @@ import {
 } from './card-serialization';
 import {
   assertScalar,
+  beginComputePass,
+  endComputePass,
   entangleWithCardTracking,
   getDataBucket,
   getFieldDescription,
@@ -169,6 +171,7 @@ import {
   relationshipMeta,
   setFieldDescription,
   setRealmContextOnField,
+  type ComputePassSnapshot,
   type NotLoadedValue,
 } from './field-support';
 import { TextInputValidator } from './text-input-validator';
@@ -189,6 +192,8 @@ interface CardOrFieldTypeIconSignature {
 export type CardOrFieldTypeIcon = ComponentLike<CardOrFieldTypeIconSignature>;
 
 export {
+  beginComputePass,
+  endComputePass,
   deserialize,
   getCardMeta,
   getDataBucket,
@@ -210,6 +215,7 @@ export {
   ensureQueryFieldSearchResource,
   getStore,
   type BoxComponent,
+  type ComputePassSnapshot,
   type DeserializeOpts,
   type GetMenuItemParams,
   type JSONAPISingleResourceDocument,
@@ -2276,9 +2282,13 @@ export class BaseDef {
             }
             return [fieldName, { id: makeAbsoluteURL(rawValue.reference) }];
           }
+          // Reuse the value we already peeked above instead of re-reading
+          // through the descriptor — for computed fields the descriptor
+          // get path re-invokes `computeVia`, doubling the work for every
+          // contains/contains-many/links-to field in the search doc.
           return [
             fieldName,
-            getQueryableValue(field!, value[fieldName], [value, ...stack]),
+            getQueryableValue(field!, rawValue, [value, ...stack]),
           ];
         }),
       );
@@ -4154,10 +4164,7 @@ export type SignatureFor<CardT extends BaseDefConstructor> = {
 // mutated. Field invocations (field !== undefined) go through `fieldComponent`
 // → `Box.field(name)` (already cached on the parent Box), so they bypass
 // this cache.
-const componentByModel = new WeakMap<
-  object,
-  Map<string, BoxComponent>
->();
+const componentByModel = new WeakMap<object, Map<string, BoxComponent>>();
 
 function codeRefCacheKey(codeRef: CodeRef | undefined): string {
   return codeRef ? JSON.stringify(codeRef) : '';

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -54,6 +54,49 @@ const fieldOverrides = initSharedState(
   () => new WeakMap<BaseDef, Map<string, any>>(),
 );
 
+// Pass-scoped computed-field memo. When non-null, `getter` consults a
+// per-instance Map before invoking `computeVia` and stores the result for
+// the duration of the synchronous traversal that opened the pass (see
+// `beginComputePass`). Off-pass reads pay only a single null check on this
+// module local and follow the original path — the JIT branch-predicts the
+// off-pass case in the host-UI hot loop.
+let passComputeMemo: WeakMap<BaseDef, Map<string, any>> | null = null;
+// Counters snapshotted by the render/meta route to populate
+// `boxel_index.timing_diagnostics`. They are unconditional integer
+// increments inside `getter` — cheap enough to keep on in production, but
+// only meaningful between `beginComputePass`/`endComputePass`.
+let computedCallCount = 0;
+let computedCacheHitCount = 0;
+
+export interface ComputePassSnapshot {
+  calls: number;
+  cacheHits: number;
+}
+
+// Open a synchronous compute-memo pass. Callers MUST pair this with
+// `endComputePass()` and must not await between the two — the WeakMap
+// would otherwise be observable across reactive cycles. Intended for
+// pure traversals like `serializeCard` + `searchDoc` inside one
+// `render.meta` capture.
+export function beginComputePass(): void {
+  passComputeMemo = new WeakMap();
+  computedCallCount = 0;
+  computedCacheHitCount = 0;
+}
+
+// Close the pass and return the per-traversal counter delta. The memo
+// is dropped so subsequent `getter` calls run `computeVia` fresh.
+export function endComputePass(): ComputePassSnapshot {
+  passComputeMemo = null;
+  let snapshot = {
+    calls: computedCallCount,
+    cacheHits: computedCacheHitCount,
+  };
+  computedCallCount = 0;
+  computedCacheHitCount = 0;
+  return snapshot;
+}
+
 export function getter<CardT extends BaseDefConstructor>(
   instance: BaseDef,
   field: Field<CardT>,
@@ -63,10 +106,32 @@ export function getter<CardT extends BaseDefConstructor>(
   cardTracking.get(instance);
 
   if (field.computeVia) {
+    // Fast path when no pass is open: skip the counter + memo entirely
+    // so production reads pay only one branch on the module-local null
+    // check. JIT branch-predicts this and the original behaviour is
+    // unchanged.
+    if (passComputeMemo === null) {
+      let value = field.computeVia.bind(instance)();
+      if (value === undefined) {
+        value = field.emptyValue(instance);
+      }
+      return value as BaseInstanceType<CardT>;
+    }
+    let perInstance = passComputeMemo.get(instance);
+    if (perInstance && perInstance.has(field.name)) {
+      computedCacheHitCount++;
+      return perInstance.get(field.name);
+    }
+    computedCallCount++;
     let value = field.computeVia.bind(instance)();
     if (value === undefined) {
       value = field.emptyValue(instance);
     }
+    if (!perInstance) {
+      perInstance = new Map();
+      passComputeMemo.set(instance, perInstance);
+    }
+    perInstance.set(field.name, value);
     return value as BaseInstanceType<CardT>;
   } else {
     if (deserialized.has(field.name)) {

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -11,12 +11,14 @@ import {
   cardIdToURL,
   identifyCard,
   internalKeyFor,
+  logger,
   maybeRelativeURL,
   relationshipEntries,
   realmURL,
   snapshotRuntimeDependencies,
   type SingleCardDocument,
   type PrerenderMeta,
+  type PrerenderMetaDiagnostics,
   type RenderError,
 } from '@cardstack/runtime-common';
 
@@ -29,6 +31,8 @@ import { friendlyCardType } from '../../utils/render-error';
 import type { Model as ParentModel } from '../render';
 
 export type Model = PrerenderMeta | RenderError | undefined;
+
+const computePerfLog = logger('host:computed-perf');
 
 export default class RenderMetaRoute extends Route<Model> {
   @service declare cardService: CardService;
@@ -54,6 +58,14 @@ export default class RenderMetaRoute extends Route<Model> {
       renderModel?.capturedDeps ??
       snapshotRuntimeDependencies({ excludeQueryOnly: true }).deps;
 
+    // Open a synchronous compute-memo pass that spans both
+    // serializeCard and searchDoc. Computed fields invoked through the
+    // descriptor or through peekAtField hit the per-instance memo
+    // instead of re-running `computeVia` — one compute per distinct
+    // (instance, fieldName) for the whole traversal. The pass MUST
+    // close before any await so it doesn't leak across reactive cycles.
+    api.beginComputePass();
+    let serializeStart = performance.now();
     let serialized = api.serializeCard(instance, {
       includeComputeds: true,
       maybeRelativeURL: (url: string) =>
@@ -63,6 +75,7 @@ export default class RenderMetaRoute extends Route<Model> {
           instance[realmURL],
         ),
     }) as SingleCardDocument;
+    let serializeMs = performance.now() - serializeStart;
     for (let { relationship } of relationshipEntries(
       serialized.data.relationships,
     )) {
@@ -74,11 +87,24 @@ export default class RenderMetaRoute extends Route<Model> {
 
     let types = getTypes(Klass);
     let displayNames = getDisplayNames(Klass);
+    let searchDocStart = performance.now();
     let searchDoc = api.searchDoc(instance);
+    let searchDocMs = performance.now() - searchDocStart;
+    let passSnapshot = api.endComputePass();
     // Add a "pseudo field" to the search doc for the card type. We use the
     // "_" prefix to make a decent attempt to not pollute the userland
     // namespace for cards
     searchDoc._cardType = friendlyCardType(Klass);
+
+    let diagnostics: PrerenderMetaDiagnostics = {
+      computedCalls: passSnapshot.calls,
+      computedCacheHits: passSnapshot.cacheHits,
+      serializeMs: Math.round(serializeMs * 100) / 100,
+      searchDocMs: Math.round(searchDocMs * 100) / 100,
+    };
+    computePerfLog.debug(
+      `render.meta computed counts cardId=${instance.id} calls=${diagnostics.computedCalls} cacheHits=${diagnostics.computedCacheHits} serializeMs=${diagnostics.serializeMs} searchDocMs=${diagnostics.searchDocMs}`,
+    );
 
     return {
       serialized,
@@ -86,6 +112,7 @@ export default class RenderMetaRoute extends Route<Model> {
       types: types.map((t) => internalKeyFor(t, undefined)),
       searchDoc,
       deps,
+      diagnostics,
     };
   }
 }

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -24,7 +24,11 @@ import {
 
 import type CardService from '@cardstack/host/services/card-service';
 
-import type { BaseDef, CardDef } from 'https://cardstack.com/base/card-api';
+import type {
+  BaseDef,
+  CardDef,
+  ComputePassSnapshot,
+} from 'https://cardstack.com/base/card-api';
 
 import { friendlyCardType } from '../../utils/render-error';
 
@@ -64,46 +68,76 @@ export default class RenderMetaRoute extends Route<Model> {
     // instead of re-running `computeVia` — one compute per distinct
     // (instance, fieldName) for the whole traversal. The pass MUST
     // close before any await so it doesn't leak across reactive cycles.
-    api.beginComputePass();
-    let serializeStart = performance.now();
-    let serialized = api.serializeCard(instance, {
-      includeComputeds: true,
-      maybeRelativeURL: (url: string) =>
-        maybeRelativeURL(
-          cardIdToURL(url),
-          cardIdToURL(instance.id),
-          instance[realmURL],
-        ),
-    }) as SingleCardDocument;
-    let serializeMs = performance.now() - serializeStart;
-    for (let { relationship } of relationshipEntries(
-      serialized.data.relationships,
-    )) {
-      // we want to emulate the file serialization here
-      delete relationship.data;
+    //
+    // Guarded by typeof checks: during a cold dev boot the host can briefly
+    // load a base/card-api build that predates these exports (vite is still
+    // bundling, or a stale realm-transpile is in flight). In that window we
+    // skip the pass — `getter` falls through its `passComputeMemo === null`
+    // fast path and the render still produces a correct serialized + search
+    // doc, just without the per-row diagnostics fields.
+    //
+    // Pass close is in a `finally` so a throw inside serializeCard /
+    // searchDoc still closes the pass — otherwise the module-global
+    // memo in field-support.ts stays set and later off-pass `getter`
+    // calls would read stale memoized values across reactive cycles.
+    let passOpen = typeof api.beginComputePass === 'function';
+    if (passOpen) {
+      api.beginComputePass();
+    }
+    let serialized: SingleCardDocument;
+    let serializeMs: number;
+    let searchDoc: Record<string, any>;
+    let searchDocMs: number;
+    let passSnapshot: ComputePassSnapshot | undefined;
+    try {
+      let serializeStart = performance.now();
+      serialized = api.serializeCard(instance, {
+        includeComputeds: true,
+        maybeRelativeURL: (url: string) =>
+          maybeRelativeURL(
+            cardIdToURL(url),
+            cardIdToURL(instance.id),
+            instance[realmURL],
+          ),
+      }) as SingleCardDocument;
+      serializeMs = performance.now() - serializeStart;
+      for (let { relationship } of relationshipEntries(
+        serialized.data.relationships,
+      )) {
+        // we want to emulate the file serialization here
+        delete relationship.data;
+      }
+
+      let searchDocStart = performance.now();
+      searchDoc = api.searchDoc(instance);
+      searchDocMs = performance.now() - searchDocStart;
+    } finally {
+      if (passOpen && typeof api.endComputePass === 'function') {
+        passSnapshot = api.endComputePass();
+      }
     }
 
     let Klass = getClass(instance);
 
     let types = getTypes(Klass);
     let displayNames = getDisplayNames(Klass);
-    let searchDocStart = performance.now();
-    let searchDoc = api.searchDoc(instance);
-    let searchDocMs = performance.now() - searchDocStart;
-    let passSnapshot = api.endComputePass();
     // Add a "pseudo field" to the search doc for the card type. We use the
     // "_" prefix to make a decent attempt to not pollute the userland
     // namespace for cards
     searchDoc._cardType = friendlyCardType(Klass);
 
     let diagnostics: PrerenderMetaDiagnostics = {
-      computedCalls: passSnapshot.calls,
-      computedCacheHits: passSnapshot.cacheHits,
+      ...(passSnapshot
+        ? {
+            computedCalls: passSnapshot.calls,
+            computedCacheHits: passSnapshot.cacheHits,
+          }
+        : {}),
       serializeMs: Math.round(serializeMs * 100) / 100,
       searchDocMs: Math.round(searchDocMs * 100) / 100,
     };
     computePerfLog.debug(
-      `render.meta computed counts cardId=${instance.id} calls=${diagnostics.computedCalls} cacheHits=${diagnostics.computedCacheHits} serializeMs=${diagnostics.serializeMs} searchDocMs=${diagnostics.searchDocMs}`,
+      `render.meta computed counts cardId=${instance.id} calls=${diagnostics.computedCalls ?? 'n/a'} cacheHits=${diagnostics.computedCacheHits ?? 'n/a'} serializeMs=${diagnostics.serializeMs} searchDocMs=${diagnostics.searchDocMs}`,
     );
 
     return {

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -1082,6 +1082,7 @@ export class RenderRunner {
           types: null,
         };
         let meta: PrerenderMeta = emptyMeta;
+        let metaForTypes: PrerenderMeta = emptyMeta;
         let headHTML: string | null = null;
         let atomHTML: string | null = null;
         let iconHTML: string | null = null;
@@ -1127,31 +1128,38 @@ export class RenderRunner {
           }
         }
 
-        // Capture render.meta once before the ancestor renders so we have
-        // `meta.types` to drive fitted/embedded. The host route's
-        // serializeCard + searchDoc traversal is the most expensive part
-        // of the per-card prerender; running it twice (once for types and
-        // again for the final payload) is duplicate work because nothing
-        // about the instance changes between the two calls — the parent
-        // route freezes `model.capturedDeps` at ready-promise resolution
-        // and the fitted/embedded ancestor renders that run in between
-        // don't mutate the card model. Capture once and reuse.
+        // Two render.meta calls. The first extracts `meta.types` for
+        // the ancestor renders below; the second captures the final
+        // serialized + searchDoc payload. The two are not duplicate
+        // work: the ancestor renders that run in between cause
+        // fitted/embedded format reads to load + mark linksTo /
+        // linksToMany fields as "used", which the final renderMeta's
+        // queryableValue then includes in the search doc. Collapsing
+        // these into one call breaks the isUsed-via-non-isolated-render
+        // contract that
+        // `non-isolated formats render linked fields and those links appear in search doc`
+        // covers.
         if (!cardShortCircuit) {
-          let metaResult = await runTimedStep<PrerenderMeta>(
-            'visit card render.meta',
+          let metaForTypesResult = await runTimedStep<PrerenderMeta>(
+            'visit card render.meta (types)',
             () => renderMeta(page, captureOptions),
           );
-          if (metaResult !== undefined) {
-            meta = metaResult;
+          if (metaForTypesResult !== undefined) {
+            metaForTypes = metaForTypesResult;
           }
         }
 
-        if (!cardShortCircuit && meta.types) {
+        if (!cardShortCircuit && metaForTypes.types) {
           const ancestorSteps = [
             {
               name: 'visit card fitted render',
               cb: () =>
-                renderAncestors(page, 'fitted', meta.types!, captureOptions),
+                renderAncestors(
+                  page,
+                  'fitted',
+                  metaForTypes.types!,
+                  captureOptions,
+                ),
               assign: (v: Record<string, string>) => {
                 fittedHTML = v;
               },
@@ -1159,7 +1167,12 @@ export class RenderRunner {
             {
               name: 'visit card embedded render',
               cb: () =>
-                renderAncestors(page, 'embedded', meta.types!, captureOptions),
+                renderAncestors(
+                  page,
+                  'embedded',
+                  metaForTypes.types!,
+                  captureOptions,
+                ),
               assign: (v: Record<string, string>) => {
                 embeddedHTML = v;
               },
@@ -1172,6 +1185,16 @@ export class RenderRunner {
               step.cb,
             );
             if (v !== undefined) step.assign(v);
+          }
+        }
+
+        if (!cardShortCircuit) {
+          let finalMetaResult = await runTimedStep<PrerenderMeta>(
+            'visit card render.meta (final)',
+            () => renderMeta(page, captureOptions),
+          );
+          if (finalMetaResult !== undefined) {
+            meta = finalMetaResult;
           }
         }
 

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -1082,7 +1082,6 @@ export class RenderRunner {
           types: null,
         };
         let meta: PrerenderMeta = emptyMeta;
-        let metaForTypes: PrerenderMeta = emptyMeta;
         let headHTML: string | null = null;
         let atomHTML: string | null = null;
         let iconHTML: string | null = null;
@@ -1128,27 +1127,31 @@ export class RenderRunner {
           }
         }
 
+        // Capture render.meta once before the ancestor renders so we have
+        // `meta.types` to drive fitted/embedded. The host route's
+        // serializeCard + searchDoc traversal is the most expensive part
+        // of the per-card prerender; running it twice (once for types and
+        // again for the final payload) is duplicate work because nothing
+        // about the instance changes between the two calls — the parent
+        // route freezes `model.capturedDeps` at ready-promise resolution
+        // and the fitted/embedded ancestor renders that run in between
+        // don't mutate the card model. Capture once and reuse.
         if (!cardShortCircuit) {
-          let metaForTypesResult = await runTimedStep<PrerenderMeta>(
-            'visit card render.meta (types)',
+          let metaResult = await runTimedStep<PrerenderMeta>(
+            'visit card render.meta',
             () => renderMeta(page, captureOptions),
           );
-          if (metaForTypesResult !== undefined) {
-            metaForTypes = metaForTypesResult;
+          if (metaResult !== undefined) {
+            meta = metaResult;
           }
         }
 
-        if (!cardShortCircuit && metaForTypes.types) {
+        if (!cardShortCircuit && meta.types) {
           const ancestorSteps = [
             {
               name: 'visit card fitted render',
               cb: () =>
-                renderAncestors(
-                  page,
-                  'fitted',
-                  metaForTypes.types!,
-                  captureOptions,
-                ),
+                renderAncestors(page, 'fitted', meta.types!, captureOptions),
               assign: (v: Record<string, string>) => {
                 fittedHTML = v;
               },
@@ -1156,12 +1159,7 @@ export class RenderRunner {
             {
               name: 'visit card embedded render',
               cb: () =>
-                renderAncestors(
-                  page,
-                  'embedded',
-                  metaForTypes.types!,
-                  captureOptions,
-                ),
+                renderAncestors(page, 'embedded', meta.types!, captureOptions),
               assign: (v: Record<string, string>) => {
                 embeddedHTML = v;
               },
@@ -1174,16 +1172,6 @@ export class RenderRunner {
               step.cb,
             );
             if (v !== undefined) step.assign(v);
-          }
-        }
-
-        if (!cardShortCircuit) {
-          let finalMetaResult = await runTimedStep<PrerenderMeta>(
-            'visit card render.meta (final)',
-            () => renderMeta(page, captureOptions),
-          );
-          if (finalMetaResult !== undefined) {
-            meta = finalMetaResult;
           }
         }
 

--- a/packages/realm-server/prerender/render-settlement.ts
+++ b/packages/realm-server/prerender/render-settlement.ts
@@ -222,6 +222,14 @@ export function decorateRenderErrorsWithTimings(
     let sub = r[key];
     if (sub && typeof sub === 'object') {
       lift((sub as { error?: unknown }).error);
+      // Card sub-responses also carry a success-path host diagnostics
+      // block — captured by render.meta and spread onto the card
+      // response as `diagnostics`. Lift the same way as error-path
+      // diagnostics so the computed-field counters reach the indexer's
+      // `boxel_index.timing_diagnostics` column.
+      if (key === 'card') {
+        lift(sub);
+      }
     }
   }
   let { affinitySnapshot, priority, tabReused } = meta;

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -44,6 +44,28 @@ export type PatchData = {
   };
 };
 
+// Per-render computed-field counters captured by the host's render.meta
+// route. Emitted alongside PrerenderMeta so the Prerenderer can lift them
+// onto `response.meta.diagnostics` and the indexer can persist them onto
+// `boxel_index.timing_diagnostics`. All fields optional — older host
+// builds that predate the counters omit the block entirely.
+export interface PrerenderMetaDiagnostics {
+  // Number of `computeVia` invocations that ran during the
+  // serializeCard + searchDoc traversal for this card. After the
+  // pass-scoped memo lands this is one call per distinct computed read
+  // per card-instance touched in the pass.
+  computedCalls?: number;
+  // Number of times the pass memo short-circuited a repeated read of
+  // the same computed in the same traversal. `computedCalls +
+  // computedCacheHits` is the total computed-read pressure of the
+  // pass; the ratio tells you how much duplicate work the memo elided.
+  computedCacheHits?: number;
+  // Wall-clock of the host-side serializeCard call.
+  serializeMs?: number;
+  // Wall-clock of the host-side searchDoc call.
+  searchDocMs?: number;
+}
+
 // Shared type produced by the host app when visiting the render.meta route and
 // consumed by the server.
 export interface PrerenderMeta {
@@ -52,6 +74,10 @@ export interface PrerenderMeta {
   displayNames: string[] | null;
   deps: string[] | null;
   types: string[] | null;
+  // Optional host-side timing block. The Prerenderer lifts this onto
+  // `response.meta.diagnostics` so it persists to
+  // `boxel_index.timing_diagnostics` for SQL-side perf triage.
+  diagnostics?: PrerenderMetaDiagnostics;
 }
 
 export interface RenderResponse extends PrerenderMeta {
@@ -204,6 +230,13 @@ export interface RenderTimeoutDiagnostics {
       priority?: number;
     }>;
   };
+  // Host-emitted computed-field counters lifted out of
+  // PrerenderMeta.diagnostics so they ride alongside the existing
+  // server-observed timings in `boxel_index.timing_diagnostics`.
+  computedCalls?: number;
+  computedCacheHits?: number;
+  serializeMs?: number;
+  searchDocMs?: number;
 }
 
 export interface RenderError extends ErrorEntry {


### PR DESCRIPTION
Reduces redundant `computeVia` invocations during the per-card prerender by ~60–67% on the heaviest cards via two complementary fixes: the gist's "double-read" Phase 2 plus a pass-scoped compute memo. Driven by [CS-11208](https://linear.app/cardstack/issue/CS-11208/computed-performance-improvements) and the [computed-performance gist](https://gist.github.com/christse/a899a9fa66c8469fb4350077f3a063d1).

## Background

The gist proposed a six-phase optimization plan for computed fields. Audited each phase against the current code:

1. **Double-read in `BaseDef.[queryableValue]`** (Phase 2) — for every contains / contains-many / links-to field in the search doc, we ran `peekAtField` (which invokes `computeVia`) and then re-read `value[fieldName]` through the descriptor (which invokes `computeVia` *again*). One traversal walked every computed twice. **Landed.**
2. **Pass-scoped compute memo** (Phase 3, scoped variant) — `serializeCard + searchDoc` together touch the same `(instance, fieldName)` pair multiple times. A WeakMap-backed memo opened just for the synchronous traversal collapses those to a single `computeVia` invocation each. Bounded to one sync traversal so it can't interact with Glimmer reactivity. **Landed.**
3. **Two `render.meta` calls collapsed into one** — initially attempted; **reverted after CI**. The two calls aren't redundant: between them the fitted/embedded ancestor renders cause linksTo / linksToMany template reads to mark fields as "used" in the data bucket, which the *second* render.meta's `queryableValue` then includes in the search doc via `usedLinksToFieldsOnly: true`. The `non-isolated formats render linked fields and those links appear in search doc` test caught this. Filed as follow-up.

Deferred from the gist: Phases 5 (shared aggregate rollups) and 6 (dependency-aware invalidation) — not worth complexity until we measure post-this-PR baselines.

## Changes

### `packages/base/field-support.ts`
- New `beginComputePass()` / `endComputePass()` open a synchronous per-instance memo (`WeakMap<BaseDef, Map<string, any>>`).
- `getter()` consults the memo when a pass is open; off-pass reads pay only **one** `if (passComputeMemo === null)` branch.
- Counters `computedCalls` + `computedCacheHits` are incremented only inside the pass — production reads outside `render.meta` are unaffected.

### `packages/base/card-api.gts`
- `BaseDef.[queryableValue]` reuses the value already peeked at the top of each iteration instead of re-reading `value[fieldName]`. For computed fields the re-read re-invoked `computeVia` — this is the gist's Phase 2 fix.
- Re-exports `beginComputePass`, `endComputePass`, `ComputePassSnapshot` so the host route can consume them.

### `packages/host/app/routes/render/meta.ts`
- Wraps the `serializeCard` + `searchDoc` traversal with `beginComputePass` / `endComputePass`.
- Emits `PrerenderMetaDiagnostics { computedCalls, computedCacheHits, serializeMs, searchDocMs }` on the PrerenderMeta response.
- Logs the per-card counts to the new `host:computed-perf` logger for local dev.
- `try { ... } finally { endComputePass() }` so a throw inside `serializeCard` or `searchDoc` always closes the pass — without this, the module-global memo in `field-support.ts` would stay set and later off-pass `getter` calls would read stale memoized values across reactive cycles (raised by Codex + Copilot bot review).
- Defensive `typeof api.beginComputePass === 'function'` guard — during a cold dev boot the host can briefly load a stale `base/card-api` build (vite still optimizing, or a transpile race). In that window the route skips the pass; `getter`'s fast-path produces a correct doc + searchDoc, just without per-row compute counters for those few cards.

### `packages/realm-server/prerender/render-settlement.ts`
- `decorateRenderErrorsWithTimings` now lifts the host's success-path `diagnostics` block off `response.card` (same way it already lifts error-path diagnostics). This is how `computedCalls` etc. reach the indexer's `boxel_index.timing_diagnostics` column.

### `packages/runtime-common/index.ts`
- New `PrerenderMetaDiagnostics` interface; extends `PrerenderMeta` with an optional `diagnostics` field.
- Extends `RenderTimeoutDiagnostics` with the same four fields so they ride alongside the existing server-observed timings in `boxel_index.timing_diagnostics` and `error_doc.diagnostics`.

### `.claude/skills/indexing-diagnostics/SKILL.md`
- Documents the four new diagnostic fields in the JSONC reference example.
- Adds a "Computed-field hot path" row to *Classify in one pass* — describes the pattern (`computedCalls > 1000` AND `searchDocMs + serializeMs ≈ renderElapsedMs` → look at the card's computeds, not data loads or browser stalls).
- Adds an SQL pattern to rank rows in a realm by `computedCalls` so operators can find the compute-heavy outliers.

## Measurement methodology

Local stack against a compute-heavy fixture realm (an insurance-pricing workload with aggregate cards over a `linksToMany` policy collection — the aggregate card has 27 computeds, each linked card has 64). Triggered a single-realm reindex via the `_grafana-reindex` route and read `computedCalls` / `computedCacheHits` / `serializeMs` / `searchDocMs` straight off `boxel_index.timing_diagnostics`.

Identifying card slugs are in CS-11208; the table below uses role labels.

## Results

| Card role | calls | cacheHits | total reads | % elided by memo | serializeMs | searchDocMs | renderElapsedMs |
|---|---|---|---|---|---|---|---|
| Policy (heaviest of 6 ranked) | 393 | 747 | 1140 | 65.5% | 58.4 | 16.5 | 855 |
| Customer | 393 | 680 | 1073 | 63.4% | 68.3 | 18.3 | 1133 |
| Policy | 357 | 668 | 1025 | 65.2% | 34.1 | 9.6 | 990 |
| **Aggregate Portfolio** | 351 | 643 | 994 | **64.7%** | 62 | 8.3 | 1370 |
| Policy | 331 | 643 | 974 | 66.0% | 40.8 | 12.2 | 1061 |
| Policy | 331 | 563 | 894 | 63.0% | 41.7 | 7.9 | 1065 |

Across the compute-heavy slice the memo elides **63–66% of compute reads** consistently — combined gain from the double-read fix + pass-memo. The gist's Phase 2 alone projected 10–40% on this card shape; with the pass-memo layered on, we hit the upper end of Phase 3's 50–80% range.

## Hot-path overhead — direct microbenchmark

Concern was that adding any per-`getter` check might tax the host UI's tight reactive-read loop where pass is *closed*. Measured directly in the running host app:

```
1,000,000 iterations:
  baseline (empty loop):           3.9 ms
  with `if (memo === null)` check: 5.7 ms
  overhead per call:               1.8 ns
```

A typical `computeVia` invocation costs 1–100 µs. The new branch costs ~10,000× less than the work it gates and is well below the floor of anything visible in a Chrome flame chart.

## Follow-up: optimizing the render.meta double pass

The current two-call `renderMeta` exists because the *second* call's `queryableValue` depends on linksTo / linksToMany field-usage state that the fitted/embedded renders between the calls populate. A clean win is still possible (e.g. expose card types via a cheaper synchronous endpoint, or run a single render.meta after all formats), but it needs its own design + test plan. Tracked in [CS-11237](https://linear.app/cardstack/issue/CS-11237/eliminate-redundant-rendermeta-double-pass-per-card-prerender).

## Deferred from the gist

- **Phase 5** (shared aggregate rollups) — pattern only matters if aggregate cards dominate the post-this-PR budget. Wait for prod numbers.
- **Phase 6** (dependency-aware invalidation via `compute.bxl.deps` / a `computeDeps` annotation) — BXL-specific today; needs an additive opt-in for plain-JS computeds; plumbing through `getFields` is real work. Deferred until incremental edit numbers prove it necessary.

## Test plan
- [ ] CI green (the `non-isolated formats render linked fields and those links appear in search doc` regression triggered the revert in commit 3)
- [ ] Local reindex of a compute-heavy fixture realm — confirm 0 errors, `computedCalls` populated on every row
- [ ] Spot-check `serializeMs + searchDocMs` doesn't regress wall-clock for compute-light cards (e.g. base realm cards)
- [ ] Run host test suite (`pnpm test --filter @cardstack/host`) — pass-memo lifecycle must not interact with Glimmer's tracked entanglement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
