### PR TITLE
CS-11207: Adopt Adorn overlay treatment for cards / atoms

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -119,6 +119,7 @@ import ImageDefFittedTemplate from './default-templates/image-def-fitted';
 import ImageDefIsolatedTemplate from './default-templates/image-def-isolated';
 import CaptionsIcon from '@cardstack/boxel-icons/captions';
 import FileIcon from '@cardstack/boxel-icons/file';
+import ImageIcon from '@cardstack/boxel-icons/image';
 import LetterCaseIcon from '@cardstack/boxel-icons/letter-case';
 import MarkdownIcon from '@cardstack/boxel-icons/align-box-left-middle';
 import RectangleEllipsisIcon from '@cardstack/boxel-icons/rectangle-ellipsis';
@@ -2858,6 +2859,7 @@ export { getDefaultFileMenuItems } from './file-menu-items';
 
 export class ImageDef extends FileDef {
   static displayName = 'Image';
+  static icon = ImageIcon;
   static acceptTypes = 'image/*';
 
   @field width = contains(NumberField);

--- a/packages/base/components/card-list.gts
+++ b/packages/base/components/card-list.gts
@@ -41,7 +41,14 @@ interface Signature {
   Element: HTMLElement;
 }
 
-const noopCardModifier = modifier(() => undefined);
+type CardComponentModifier = NonNullable<CardContext['cardComponentModifier']>;
+
+// Cast: a function-based no-op stands in for the class-based tracking
+// modifier so applying it is always type-safe even when no context provides
+// a real one.
+const noopCardModifier = modifier(
+  () => undefined,
+) as unknown as CardComponentModifier;
 
 export default class CardList extends Component<Signature> {
   @consume(CardCrudFunctionsContextName)
@@ -54,7 +61,7 @@ export default class CardList extends Component<Signature> {
   // PrerenderedCard does for rows that produced HTML. Falls back to a no-op
   // when no context provides one (e.g. CardList used outside operator mode),
   // so applying the modifier is always safe.
-  private get cardComponentModifier() {
+  private get cardComponentModifier(): CardComponentModifier {
     return this.cardContext?.cardComponentModifier ?? noopCardModifier;
   }
 
@@ -62,8 +69,13 @@ export default class CardList extends Component<Signature> {
   // <li> itself). HTML rows are tracked by PrerenderedCard on their own
   // component root, so tracking the <li> too would double-register them and
   // misplace the overlay — hence the no-op for those.
-  private trackerFor = (card: { hasHtml?: boolean; isError?: boolean }) =>
-    this.shouldRenderFallback(card) ? this.cardComponentModifier : noopCardModifier;
+  private trackerFor = (card: {
+    hasHtml?: boolean;
+    isError?: boolean;
+  }): CardComponentModifier =>
+    this.shouldRenderFallback(card)
+      ? this.cardComponentModifier
+      : noopCardModifier;
 
   @action
   handleCardClick(cardUrl: string, event?: Event) {

--- a/packages/base/components/card-list.gts
+++ b/packages/base/components/card-list.gts
@@ -50,13 +50,20 @@ export default class CardList extends Component<Signature> {
   @consume(CardContextName)
   declare cardContext: CardContext | undefined;
 
-  // Tracks the fallback element with the overlay system the same way
+  // Tracks the fallback row with the overlay system the same way
   // PrerenderedCard does for rows that produced HTML. Falls back to a no-op
   // when no context provides one (e.g. CardList used outside operator mode),
   // so applying the modifier is always safe.
   private get cardComponentModifier() {
     return this.cardContext?.cardComponentModifier ?? noopCardModifier;
   }
+
+  // Only fallback rows are tracked on the <li> (their visible card is the
+  // <li> itself). HTML rows are tracked by PrerenderedCard on their own
+  // component root, so tracking the <li> too would double-register them and
+  // misplace the overlay — hence the no-op for those.
+  private trackerFor = (card: { hasHtml?: boolean; isError?: boolean }) =>
+    this.shouldRenderFallback(card) ? this.cardComponentModifier : noopCardModifier;
 
   @action
   handleCardClick(cardUrl: string, event?: Event) {
@@ -128,9 +135,23 @@ export default class CardList extends Component<Signature> {
                 data-test-cards-grid-item={{removeFileExtension card.url}}
                 {{! In order to support scrolling cards into view we use a selector that is not pruned out in production builds }}
                 data-cards-grid-item={{removeFileExtension card.url}}
+                data-card-type-display-name={{if
+                  (this.shouldRenderFallback card)
+                  card.cardType
+                }}
+                data-card-type-icon-html={{if
+                  (this.shouldRenderFallback card)
+                  card.iconHtml
+                }}
                 role={{if this.cardCrudFunctions.viewCard 'button'}}
                 tabindex={{if this.cardCrudFunctions.viewCard '0'}}
                 {{on 'click' (fn this.handleCardClick card.url)}}
+                {{(this.trackerFor card)
+                  cardId=card.url
+                  format='data'
+                  fieldType=undefined
+                  fieldName=undefined
+                }}
               >
                 {{#if (this.shouldRenderFallback card)}}
                   {{! CS-11171: file rows whose prerender produced no HTML
@@ -140,21 +161,10 @@ export default class CardList extends Component<Signature> {
                       (and from there into Code Mode via the kebab menu).
                       Error rows are excluded so PrerenderedCard's dedicated
                       error component still gets rendered for them.
-                      The tracking modifier + type attributes mirror what
-                      PrerenderedCard stamps on HTML rows, so the overlay
-                      system labels and acts on these rows too. }}
-                  <div
-                    class='card-fallback'
-                    data-test-card-fallback
-                    data-card-type-display-name={{card.cardType}}
-                    data-card-type-icon-html={{card.iconHtml}}
-                    {{this.cardComponentModifier
-                      cardId=card.url
-                      format='data'
-                      fieldType=undefined
-                      fieldName=undefined
-                    }}
-                  >
+                      The <li> carries the tracking modifier + type attributes
+                      (see trackerFor) so the overlay system labels and acts on
+                      these rows too, aligned to the visible card. }}
+                  <div class='card-fallback' data-test-card-fallback>
                     {{#if card.iconHtml}}
                       <span
                         class='card-fallback__icon card-fallback__icon--svg'

--- a/packages/base/components/card-list.gts
+++ b/packages/base/components/card-list.gts
@@ -1,9 +1,11 @@
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 
 import { consume } from 'ember-provide-consume-context';
+import { modifier } from 'ember-modifier';
 
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
@@ -15,6 +17,7 @@ import {
   removeFileExtension,
   rri,
   CardCrudFunctionsContextName,
+  CardContextName,
   type Query,
 } from '@cardstack/runtime-common';
 
@@ -38,9 +41,22 @@ interface Signature {
   Element: HTMLElement;
 }
 
+const noopCardModifier = modifier(() => undefined);
+
 export default class CardList extends Component<Signature> {
   @consume(CardCrudFunctionsContextName)
   declare cardCrudFunctions: CardCrudFunctions | undefined;
+
+  @consume(CardContextName)
+  declare cardContext: CardContext | undefined;
+
+  // Tracks the fallback element with the overlay system the same way
+  // PrerenderedCard does for rows that produced HTML. Falls back to a no-op
+  // when no context provides one (e.g. CardList used outside operator mode),
+  // so applying the modifier is always safe.
+  private get cardComponentModifier() {
+    return this.cardContext?.cardComponentModifier ?? noopCardModifier;
+  }
 
   @action
   handleCardClick(cardUrl: string, event?: Event) {
@@ -123,9 +139,32 @@ export default class CardList extends Component<Signature> {
                       this `<li>` can still route the user into interact-mode
                       (and from there into Code Mode via the kebab menu).
                       Error rows are excluded so PrerenderedCard's dedicated
-                      error component still gets rendered for them. }}
-                  <div class='card-fallback' data-test-card-fallback>
-                    <FileIcon class='card-fallback__icon' role='presentation' />
+                      error component still gets rendered for them.
+                      The tracking modifier + type attributes mirror what
+                      PrerenderedCard stamps on HTML rows, so the overlay
+                      system labels and acts on these rows too. }}
+                  <div
+                    class='card-fallback'
+                    data-test-card-fallback
+                    data-card-type-display-name={{card.cardType}}
+                    data-card-type-icon-html={{card.iconHtml}}
+                    {{this.cardComponentModifier
+                      cardId=card.url
+                      format='data'
+                      fieldType=undefined
+                      fieldName=undefined
+                    }}
+                  >
+                    {{#if card.iconHtml}}
+                      <span
+                        class='card-fallback__icon card-fallback__icon--svg'
+                      >{{htmlSafe card.iconHtml}}</span>
+                    {{else}}
+                      <FileIcon
+                        class='card-fallback__icon'
+                        role='presentation'
+                      />
+                    {{/if}}
                     <div class='card-fallback__name'>
                       {{this.fileNameFromUrl card.url}}
                     </div>
@@ -217,6 +256,13 @@ export default class CardList extends Component<Signature> {
         height: 2rem;
         color: var(--boxel-500);
         flex-shrink: 0;
+      }
+      .card-fallback__icon--svg {
+        display: inline-flex;
+      }
+      .card-fallback__icon--svg > svg {
+        width: 100%;
+        height: 100%;
       }
       .card-fallback__name {
         font: 500 var(--boxel-font-sm);

--- a/packages/base/gif-image-def.gts
+++ b/packages/base/gif-image-def.gts
@@ -1,10 +1,12 @@
 import { readFirstBytes } from '@cardstack/runtime-common';
+import GifIcon from '@cardstack/boxel-icons/gif';
 import ImageDef from './image-file-def';
 import { type ByteStream, type SerializedFile } from './file-api';
 import { extractGifDimensions } from './gif-meta-extractor';
 
 export class GifDef extends ImageDef {
   static displayName = 'GIF Image';
+  static icon = GifIcon;
   static acceptTypes = '.gif,image/gif';
 
   static async extractAttributes(

--- a/packages/base/jpg-image-def.gts
+++ b/packages/base/jpg-image-def.gts
@@ -1,4 +1,5 @@
 import { readFirstBytes } from '@cardstack/runtime-common';
+import JpgIcon from '@cardstack/boxel-icons/file-type-jpg';
 import ImageDef from './image-file-def';
 import { type ByteStream, type SerializedFile } from './file-api';
 import { extractJpgDimensions } from './jpg-meta-extractor';
@@ -9,6 +10,7 @@ const JPEG_MAX_HEADER_BYTES = 65_536;
 
 export class JpgDef extends ImageDef {
   static displayName = 'JPEG Image';
+  static icon = JpgIcon;
   static acceptTypes = '.jpg,.jpeg,image/jpeg';
 
   static async extractAttributes(

--- a/packages/base/markdown-file-def.gts
+++ b/packages/base/markdown-file-def.gts
@@ -438,6 +438,7 @@ class Head extends Component<typeof MarkdownDef> {
 
 export class MarkdownDef extends FileDef {
   static displayName = 'Markdown';
+  static icon = MarkdownIcon;
   static acceptTypes = '.md,.markdown';
 
   @field title = contains(StringField);

--- a/packages/base/png-image-def.gts
+++ b/packages/base/png-image-def.gts
@@ -1,10 +1,12 @@
 import { readFirstBytes } from '@cardstack/runtime-common';
+import PngIcon from '@cardstack/boxel-icons/file-type-png';
 import ImageDef from './image-file-def';
 import { type ByteStream, type SerializedFile } from './file-api';
 import { extractPngDimensions } from './png-meta-extractor';
 
 export class PngDef extends ImageDef {
   static displayName = 'PNG Image';
+  static icon = PngIcon;
   static acceptTypes = '.png,image/png';
 
   static async extractAttributes(

--- a/packages/base/svg-image-def.gts
+++ b/packages/base/svg-image-def.gts
@@ -1,10 +1,12 @@
 import { byteStreamToUint8Array } from '@cardstack/runtime-common';
+import SvgIcon from '@cardstack/boxel-icons/file-type-svg';
 import ImageDef from './image-file-def';
 import { type ByteStream, type SerializedFile } from './file-api';
 import { extractSvgDimensions } from './svg-meta-extractor';
 
 export class SvgDef extends ImageDef {
   static displayName = 'SVG Image';
+  static icon = SvgIcon;
   static acceptTypes = '.svg,image/svg+xml';
 
   static async extractAttributes(

--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -12,7 +12,6 @@ import { MenuItem } from '../../helpers/menu-item.ts';
 import { and } from '../../helpers/truth-helpers.ts';
 import { bool, or } from '../../helpers/truth-helpers.ts';
 import setCssVar from '../../modifiers/set-css-var.ts';
-import Button from '../button/index.gts';
 import ContextButton from '../context-button/index.gts';
 import BoxelDropdown from '../dropdown/index.gts';
 import Menu from '../menu/index.gts';
@@ -20,6 +19,10 @@ import RealmIcon, { type RealmDisplayInfo } from '../realm-icon/index.gts';
 import Tooltip from '../tooltip/index.gts';
 
 export interface CardHeaderUtilityMenu {
+  // Optional non-interactive header rendered above the menu items inside
+  // the dropdown panel — used by the operator-mode multi-select chip to
+  // echo the selection count ("N Selected") with teal styling.
+  headerText?: string;
   menuItems: (MenuItem | MenuDivider)[];
   triggerText: string;
 }
@@ -129,8 +132,27 @@ export default class CardHeader extends Component<Signature> {
               <div class='utility-menu-positioner'>
                 <BoxelDropdown @autoClose={{true}}>
                   <:trigger as |ddModifier|>
-                    <Button class='utility-menu-trigger' {{ddModifier}}>
-                      <span>
+                    <button
+                      type='button'
+                      class='utility-menu-trigger'
+                      {{ddModifier}}
+                    >
+                      <svg
+                        class='utility-menu-trigger-icon'
+                        viewBox='0 0 14 14'
+                        fill='none'
+                        aria-hidden='true'
+                      >
+                        <circle cx='7' cy='7' r='7' fill='#0a2e1c' />
+                        <path
+                          d='M3.5 7.5L5.5 9.5L10.5 4.5'
+                          stroke='var(--boxel-teal)'
+                          stroke-width='1.5'
+                          stroke-linecap='round'
+                          stroke-linejoin='round'
+                        />
+                      </svg>
+                      <span class='utility-menu-trigger-text'>
                         {{@utilityMenu.triggerText}}
                       </span>
                       <DropdownArrowDown
@@ -138,9 +160,32 @@ export default class CardHeader extends Component<Signature> {
                         width='13px'
                         height='13px'
                       />
-                    </Button>
+                    </button>
                   </:trigger>
                   <:content as |dd|>
+                    {{#if @utilityMenu.headerText}}
+                      <div
+                        class='utility-menu-header'
+                        data-test-utility-menu-header
+                      >
+                        <svg
+                          class='utility-menu-header-icon'
+                          viewBox='0 0 14 14'
+                          fill='none'
+                          aria-hidden='true'
+                        >
+                          <circle cx='7' cy='7' r='7' fill='#0a2e1c' />
+                          <path
+                            d='M3.5 7.5L5.5 9.5L10.5 4.5'
+                            stroke='var(--boxel-teal)'
+                            stroke-width='1.5'
+                            stroke-linecap='round'
+                            stroke-linejoin='round'
+                          />
+                        </svg>
+                        {{@utilityMenu.headerText}}
+                      </div>
+                    {{/if}}
                     <Menu
                       @items={{@utilityMenu.menuItems}}
                       @closeMenu={{dd.close}}
@@ -411,21 +456,60 @@ export default class CardHeader extends Component<Signature> {
           height: var(--utility-menu-trigger-height);
         }
         .utility-menu-trigger {
-          --boxel-button-min-height: var(--utility-menu-trigger-height);
-          --boxel-button-padding: 0 var(--boxel-sp-xxs);
-          --boxel-button-border-radius: calc(var(--boxel-border-radius) - 4px);
-          --boxel-button-font: var(--boxel-font-sm);
-          --boxel-button-box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.5);
-          --boxel-button-border: solid 1px rgba(0, 0, 0, 0.35);
-
           position: absolute;
           top: 0;
           right: 0;
+          display: inline-flex;
+          align-items: center;
+          gap: var(--boxel-sp-5xs);
+          min-height: var(--utility-menu-trigger-height);
           width: max-content;
+          padding: 0 var(--boxel-sp-xs);
+          border: none;
+          border-radius: 6px;
+          background-color: var(--boxel-teal);
+          color: var(--boxel-dark);
+          font: 700 var(--boxel-font-sm);
+          cursor: pointer;
+        }
+        .utility-menu-trigger:hover:not(:disabled),
+        .utility-menu-trigger:focus-visible:not(:disabled) {
+          background-color: #00da9f;
+        }
+        .utility-menu-trigger-icon {
+          width: 14px;
+          height: 14px;
+          flex-shrink: 0;
+        }
+        .utility-menu-trigger-text {
+          line-height: 1;
         }
         .utility-menu-dropdown-arrow {
-          margin-left: var(--boxel-sp-xl);
+          margin-left: 0;
           vertical-align: middle;
+        }
+        .utility-menu-header {
+          display: flex;
+          align-items: center;
+          gap: var(--boxel-sp-xxs);
+          padding: var(--boxel-sp-xxs) var(--boxel-sp-sm);
+          margin: calc(-1 * var(--boxel-sp-5xs) + 1px)
+            calc(-1 * var(--boxel-sp-5xs) + 1px) var(--boxel-sp-xxxs);
+          min-height: 32px;
+          box-sizing: border-box;
+          background: var(--boxel-teal);
+          color: var(--boxel-dark);
+          font: 700 var(--boxel-font-xs);
+          letter-spacing: var(--boxel-lsp-xs);
+          border-top-left-radius: var(--boxel-border-radius-sm);
+          border-top-right-radius: var(--boxel-border-radius-sm);
+          cursor: default;
+          user-select: none;
+        }
+        .utility-menu-header-icon {
+          width: 14px;
+          height: 14px;
+          flex-shrink: 0;
         }
 
         @container card-header (min-width: 30rem) {

--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -19,10 +19,6 @@ import RealmIcon, { type RealmDisplayInfo } from '../realm-icon/index.gts';
 import Tooltip from '../tooltip/index.gts';
 
 export interface CardHeaderUtilityMenu {
-  // Optional non-interactive header rendered above the menu items inside
-  // the dropdown panel — used by the operator-mode multi-select chip to
-  // echo the selection count ("N Selected") with teal styling.
-  headerText?: string;
   menuItems: (MenuItem | MenuDivider)[];
   triggerText: string;
 }
@@ -163,29 +159,6 @@ export default class CardHeader extends Component<Signature> {
                     </button>
                   </:trigger>
                   <:content as |dd|>
-                    {{#if @utilityMenu.headerText}}
-                      <div
-                        class='utility-menu-header'
-                        data-test-utility-menu-header
-                      >
-                        <svg
-                          class='utility-menu-header-icon'
-                          viewBox='0 0 14 14'
-                          fill='none'
-                          aria-hidden='true'
-                        >
-                          <circle cx='7' cy='7' r='7' fill='#0a2e1c' />
-                          <path
-                            d='M3.5 7.5L5.5 9.5L10.5 4.5'
-                            stroke='var(--boxel-teal)'
-                            stroke-width='1.5'
-                            stroke-linecap='round'
-                            stroke-linejoin='round'
-                          />
-                        </svg>
-                        {{@utilityMenu.headerText}}
-                      </div>
-                    {{/if}}
                     <Menu
                       @items={{@utilityMenu.menuItems}}
                       @closeMenu={{dd.close}}
@@ -488,30 +461,6 @@ export default class CardHeader extends Component<Signature> {
           margin-left: 0;
           vertical-align: middle;
         }
-        .utility-menu-header {
-          display: flex;
-          align-items: center;
-          gap: var(--boxel-sp-xxs);
-          padding: var(--boxel-sp-xxs) var(--boxel-sp-sm);
-          margin: calc(-1 * var(--boxel-sp-5xs) + 1px)
-            calc(-1 * var(--boxel-sp-5xs) + 1px) var(--boxel-sp-xxxs);
-          min-height: 32px;
-          box-sizing: border-box;
-          background: var(--boxel-teal);
-          color: var(--boxel-dark);
-          font: 700 var(--boxel-font-xs);
-          letter-spacing: var(--boxel-lsp-xs);
-          border-top-left-radius: var(--boxel-border-radius-sm);
-          border-top-right-radius: var(--boxel-border-radius-sm);
-          cursor: default;
-          user-select: none;
-        }
-        .utility-menu-header-icon {
-          width: 14px;
-          height: 14px;
-          flex-shrink: 0;
-        }
-
         @container card-header (min-width: 30rem) {
           .card-type-display-name {
             padding-inline: 1.875rem;

--- a/packages/boxel-ui/addon/src/components/menu/index.gts
+++ b/packages/boxel-ui/addon/src/components/menu/index.gts
@@ -79,9 +79,11 @@ export default class Menu extends Component<Signature> {
                   boxel-menu__item--has-icon=(if menuItem.icon true false)
                   boxel-menu__item--checked=menuItem.checked
                   boxel-menu__item--disabled=menuItem.disabled
+                  boxel-menu__item--header=menuItem.header
                 }}
                 data-test-boxel-menu-item
                 data-test-boxel-menu-item-selected={{menuItem.checked}}
+                data-test-boxel-menu-item-header={{menuItem.header}}
               >
                 {{! template-lint-disable require-context-role }}
                 <button
@@ -224,6 +226,23 @@ export default class Menu extends Component<Signature> {
         .boxel-menu__item--disabled.boxel-menu__item:hover {
           background-color: initial;
           opacity: 0.4;
+        }
+
+        /* Header item — inert, teal background. Used as a contextual title
+           inside the menu (e.g. "N Selected" for the operator-mode multi-
+           select chip). */
+        .boxel-menu__item--header,
+        .boxel-menu__item--header.boxel-menu__item:hover {
+          background-color: var(--boxel-teal);
+          color: var(--boxel-dark);
+          cursor: default;
+        }
+        .boxel-menu__item--header .boxel-menu__item__content {
+          pointer-events: none;
+          font-weight: 700;
+        }
+        .boxel-menu__item--header .check-icon {
+          display: none;
         }
 
         .boxel-menu__separator {

--- a/packages/boxel-ui/addon/src/components/menu/index.gts
+++ b/packages/boxel-ui/addon/src/components/menu/index.gts
@@ -237,6 +237,14 @@ export default class Menu extends Component<Signature> {
           color: var(--boxel-dark);
           cursor: default;
         }
+        .boxel-menu__item--header:first-child {
+          border-top-left-radius: inherit;
+          border-top-right-radius: inherit;
+        }
+        .boxel-menu__item--header:last-child {
+          border-bottom-left-radius: inherit;
+          border-bottom-right-radius: inherit;
+        }
         .boxel-menu__item--header .boxel-menu__item__content {
           pointer-events: none;
           font-weight: 700;

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -284,8 +284,8 @@ export default class OperatorModeOverlays extends Overlays {
       /* Selection indicator — rounded square chip at the bottom-right corner. */
       .adorn-select-button {
         position: absolute;
-        bottom: 2px;
-        right: 4px;
+        bottom: 10px;
+        right: 10px;
         width: 20px;
         height: 20px;
         padding: 3px;

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -51,6 +51,7 @@ import type {
   Format,
 } from 'https://cardstack.com/base/card-api';
 
+import { htmlComponent } from '../../lib/html-component';
 import { detectStackItemTypeForTarget } from '../../lib/stack-item';
 
 import { knownFileMetaUrls } from '../prerendered-card-search';
@@ -508,12 +509,22 @@ export default class OperatorModeOverlays extends Overlays {
   private getCardTypeIcon(
     cardDefOrId: CardDefOrId,
     renderedCard: StackItemRenderedCardForOverlayActions,
-  ) {
+  ): unknown {
     let instance = this.peekInstance(cardDefOrId, renderedCard);
-    if (!instance) {
-      return undefined;
+    if (instance) {
+      return cardTypeIcon(instance);
     }
-    return cardTypeIcon(instance);
+    // Prerendered rows expose the type icon as raw SVG markup on the
+    // rendered element — wrap it in an htmlComponent so it can be invoked
+    // like any other Icon. htmlComponent caches by source string, so
+    // repeated lookups for the same icon return the same component.
+    let iconHtml = renderedCard.element?.getAttribute(
+      'data-card-type-icon-html',
+    );
+    if (iconHtml) {
+      return htmlComponent(iconHtml);
+    }
+    return undefined;
   }
 
   @action

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -3,6 +3,7 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 
+import DotsVertical from '@cardstack/boxel-icons/dots-vertical';
 import { consume } from 'ember-provide-consume-context';
 import { velcro } from 'ember-velcro';
 
@@ -11,7 +12,6 @@ import {
   BoxelDropdown,
   IconButton,
   Menu,
-  Tooltip,
 } from '@cardstack/boxel-ui/components';
 
 import {
@@ -24,15 +24,16 @@ import type { MenuItemOptions } from '@cardstack/boxel-ui/helpers';
 
 import {
   Eye,
-  IconCircle,
-  IconCircleSelected,
   IconLink,
   IconPencil,
   IconTrash,
-  ThreeDotsHorizontal,
 } from '@cardstack/boxel-ui/icons';
 
-import type { CommandContext } from '@cardstack/runtime-common';
+import {
+  cardTypeDisplayName,
+  cardTypeIcon,
+  type CommandContext,
+} from '@cardstack/runtime-common';
 
 import {
   CardCrudFunctionsContextName,
@@ -80,14 +81,16 @@ export default class OperatorModeOverlays extends Overlays {
         renderedCard.cardDefOrId
         (this.getCardId renderedCard.cardDefOrId)
         (this.isSelected renderedCard.cardDefOrId)
-        as |cardDefOrId cardId isSelected|
+        (this.isHovered renderedCard)
+        as |cardDefOrId cardId isSelected isHovered|
       }}
-        {{#if (or isSelected (this.isHovered renderedCard))}}
+        {{#if (or isSelected isHovered)}}
           <div
             class={{cn
               'actions-overlay'
               selected=isSelected
-              hovered=(this.isHovered renderedCard)
+              hovered=isHovered
+              field=(this.isField renderedCard)
             }}
             {{velcro renderedCard.element middleware=(array this.offset)}}
             data-test-overlay-selected={{if
@@ -98,251 +101,282 @@ export default class OperatorModeOverlays extends Overlays {
             style={{renderedCard.overlayZIndexStyle}}
             ...attributes
           >
-            <div class={{cn 'actions' field=(this.isField renderedCard)}}>
-              {{#if (this.isButtonDisplayed 'select' renderedCard)}}
-                <div class='actions-item select'>
-                  <IconButton
-                    class='actions-item__button'
-                    {{! @glint-ignore (glint thinks toggleSelect is not in this scope but it actually is - we check for it in the condition above) }}
-                    {{on 'click' (fn @toggleSelect cardDefOrId)}}
-                    @width='100%'
-                    @height='100%'
-                    @icon={{if isSelected IconCircleSelected IconCircle}}
-                    aria-label='select card'
-                    data-test-overlay-select={{removeFileExtension cardId}}
-                  />
-                </div>
-              {{/if}}
-              {{#if
-                (or
-                  (this.isButtonDisplayed 'edit' renderedCard)
-                  (this.isButtonDisplayed 'more-options' renderedCard)
-                )
-              }}
-                <div class='actions-item'>
-                  {{#if (this.isButtonDisplayed 'edit' renderedCard)}}
+            {{! Type-label tab — hover only, anchored top-left, overflows when long }}
+            {{#if isHovered}}
+              <div
+                class='adorn-label'
+                data-test-overlay-label
+                {{on 'mouseenter' this.cancelHoverClear}}
+                {{on 'mouseleave' this.scheduleHoverClear}}
+              >
+                {{#let (this.getCardTypeIcon cardDefOrId) as |TypeIcon|}}
+                  {{#if TypeIcon}}
+                    <TypeIcon class='adorn-label-icon' />
+                  {{/if}}
+                {{/let}}
+                <span class='adorn-label-text'>
+                  {{this.getCardTypeName cardDefOrId renderedCard}}
+                </span>
+                <BoxelDropdown
+                  @registerAPI={{this.registerDropdownAPI renderedCard}}
+                  @onClose={{this.handleMenuClose}}
+                >
+                  <:trigger as |bindings|>
                     <IconButton
-                      @icon={{IconPencil}}
-                      @width='100%'
-                      @height='100%'
-                      class='actions-item__button'
-                      aria-label='Edit'
-                      data-test-overlay-edit
+                      @icon={{DotsVertical}}
+                      class='adorn-label-menu'
+                      aria-label='Options'
+                      data-test-overlay-more-options
+                      {{bindings}}
                       {{on
                         'click'
-                        (fn
-                          this.openOrSelectCard
-                          cardDefOrId
-                          'edit'
-                          renderedCard.fieldType
-                          renderedCard.fieldName
-                        )
+                        (fn this.handleMenuTriggerClick renderedCard)
                       }}
                     />
-                  {{/if}}
-                  {{#if (this.isButtonDisplayed 'more-options' renderedCard)}}
-                    <div>
-                      <BoxelDropdown
-                        @registerAPI={{this.registerDropdownAPI renderedCard}}
-                      >
-                        <:trigger as |bindings|>
-                          <Tooltip @placement='top'>
-                            <:trigger>
-                              <IconButton
-                                @icon={{ThreeDotsHorizontal}}
-                                @width='100%'
-                                @height='100%'
-                                class='actions-item__button'
-                                aria-label='Options'
-                                data-test-overlay-more-options
-                                {{bindings}}
-                              />
-                            </:trigger>
-                            <:content>
-                              More Options
-                            </:content>
-                          </Tooltip>
-                        </:trigger>
-                        <:content as |dd|>
-                          <Menu
-                            @closeMenu={{dd.close}}
-                            @items={{this.getMenuItemsForCard
-                              cardDefOrId
-                              renderedCard
-                            }}
-                          />
-                        </:content>
-                      </BoxelDropdown>
-                    </div>
-                  {{/if}}
-                </div>
-              {{/if}}
-            </div>
+                  </:trigger>
+                  <:content as |dd|>
+                    <Menu
+                      @closeMenu={{dd.close}}
+                      @items={{this.getMenuItemsForCard
+                        cardDefOrId
+                        renderedCard
+                      }}
+                    />
+                  </:content>
+                </BoxelDropdown>
+              </div>
+            {{/if}}
+
+            {{! Selection indicator — bottom-right rounded square chip }}
+            {{#if (this.isButtonDisplayed 'select' renderedCard)}}
+              <button
+                type='button'
+                class='adorn-select-button'
+                {{! @glint-ignore (glint thinks toggleSelect is not in this scope but it actually is - we check for it in the condition above) }}
+                {{on 'click' (fn @toggleSelect cardDefOrId)}}
+                aria-label='select card'
+                aria-pressed={{if isSelected 'true' 'false'}}
+                data-test-overlay-select={{removeFileExtension cardId}}
+              >
+                {{#if isSelected}}
+                  <svg
+                    class='adorn-select-icon'
+                    viewBox='0 0 14 14'
+                    fill='none'
+                    aria-hidden='true'
+                  >
+                    <circle cx='7' cy='7' r='7' fill='#0a2e1c' />
+                    <path
+                      d='M3.5 7.5L5.5 9.5L10.5 4.5'
+                      stroke='currentColor'
+                      stroke-width='1.5'
+                      stroke-linecap='round'
+                      stroke-linejoin='round'
+                    />
+                  </svg>
+                {{else}}
+                  <svg
+                    class='adorn-select-icon'
+                    viewBox='-1 -1 16 16'
+                    fill='none'
+                    aria-hidden='true'
+                  >
+                    <circle
+                      cx='7'
+                      cy='7'
+                      r='6.5'
+                      stroke='#0a2e1c'
+                      stroke-width='1.5'
+                    />
+                  </svg>
+                {{/if}}
+              </button>
+            {{/if}}
           </div>
         {{/if}}
       {{/let}}
     {{/each}}
     <style scoped>
-      :global(:root) {
-        --overlay-fitted-card-header-height: 2.5rem;
-      }
       .actions-overlay {
-        border-radius: var(--boxel-border-radius);
-        pointer-events: none;
+        /* Adorn accent palette (local to operator-mode overlay).
+           --boxel-teal (#00ffba) is the light accent already in boxel-ui;
+           the medium and dark values are exclusive to this overlay. */
+        --adorn-accent-light: var(--boxel-teal);
+        --adorn-accent: #00da9f;
 
+        pointer-events: none;
         container-name: actions-overlay;
         container-type: size;
+        /* Allow the type-label tab and selection chip to extend outside the
+           overlay's bounding box without being clipped. */
+        overflow: visible;
       }
+
+      /* Hover, not selected: 2px outer stroke */
+      .actions-overlay.hovered:not(.selected) {
+        box-shadow: 0 0 0 2px var(--adorn-accent-light);
+      }
+
+      /* Selected: 4px outer stroke */
       .actions-overlay.selected {
-        box-shadow: 0 0 0 var(--boxel-outline-width) var(--boxel-highlight);
+        box-shadow: 0 0 0 4px var(--adorn-accent-light);
       }
-      .hovered {
-        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.16);
+
+      /* Hover on a selected card: stroke shifts to darker accent */
+      .actions-overlay.selected.hovered {
+        box-shadow: 0 0 0 4px var(--adorn-accent);
       }
-      .hover-button {
-        display: none;
+
+      /* Type-label tab — flag shape with sloped right edge, anchored above
+         the card's top-left corner so its left edge aligns with the 4px
+         selection stroke. */
+      .adorn-label {
         position: absolute;
-        width: 30px;
-        height: 30px;
-        pointer-events: auto;
-      }
-      .hovered .hover-button:not(:disabled),
-      .hovered .hover-button.select {
-        display: block;
-      }
-
-      @container actions-overlay (aspect-ratio <= 1.0) {
-        .actions {
-          --overlay-embedded-card-header-height: 2.2rem;
-        }
-
-        .actions-item {
-          padding: var(--boxel-sp-5xs);
-        }
-
-        .actions-item__button {
-          padding: var(--boxel-sp-4xs);
-          --boxel-icon-button-width: calc(
-            var(--overlay-embedded-card-header-height) -
-              calc(var(--boxel-sp-4xs) + var(--boxel-sp-5xs))
-          );
-          --boxel-icon-button-height: calc(
-            var(--overlay-embedded-card-header-height) -
-              calc(var(--boxel-sp-4xs) + var(--boxel-sp-5xs))
-          );
-        }
-      }
-
-      @container actions-overlay (aspect-ratio <= 1.0) and (width <= 120px) {
-        .actions {
-          --overlay-embedded-card-header-height: 1.8rem;
-        }
-
-        .actions-item__button {
-          padding: var(--boxel-sp-5xs);
-          --boxel-icon-button-width: calc(
-            var(--overlay-embedded-card-header-height) -
-              calc(var(--boxel-sp-5xs) * 2)
-          );
-          --boxel-icon-button-height: calc(
-            var(--overlay-embedded-card-header-height) -
-              calc(var(--boxel-sp-5xs) * 2)
-          );
-        }
-      }
-
-      @container actions-overlay (aspect-ratio > 1.0) {
-        .actions {
-          --overlay-embedded-card-header-height: 2.2rem;
-        }
-
-        .actions-item {
-          padding: var(--boxel-sp-5xs);
-        }
-
-        .actions-item__button {
-          padding: var(--boxel-sp-4xs);
-          --boxel-icon-button-width: calc(
-            var(--overlay-embedded-card-header-height) -
-              calc(var(--boxel-sp-4xs) + var(--boxel-sp-5xs))
-          );
-          --boxel-icon-button-height: calc(
-            var(--overlay-embedded-card-header-height) -
-              calc(var(--boxel-sp-4xs) + var(--boxel-sp-5xs))
-          );
-        }
-      }
-
-      @container actions-overlay (aspect-ratio > 2.0) and (height <= 57px) {
-        .actions {
-          --overlay-embedded-card-header-height: 1.5rem;
-          margin-top: var(--boxel-sp-5xs);
-        }
-
-        .actions-item {
-          padding: var(--boxel-sp-6xs);
-        }
-
-        .actions-item__button {
-          padding: var(--boxel-sp-6xs);
-          --boxel-icon-button-width: calc(
-            var(--overlay-embedded-card-header-height) -
-              calc(var(--boxel-sp-6xs) * 2)
-          );
-          --boxel-icon-button-height: calc(
-            var(--overlay-embedded-card-header-height) -
-              calc(var(--boxel-sp-6xs) * 2)
-          );
-        }
-      }
-      .hovered .actions {
-        visibility: visible;
-      }
-      .actions {
-        visibility: hidden;
-        height: auto;
-        display: flex;
-        justify-content: space-between;
-
-        margin-top: var(--boxel-sp-xxxs);
-        margin-left: var(--boxel-sp-xxxs);
-        margin-right: var(--boxel-sp-xxxs);
-      }
-      .actions.field {
-        justify-content: flex-end;
-      }
-      .actions-item {
-        display: flex;
+        bottom: calc(100% + 2px);
+        left: -4px;
+        right: auto;
+        top: auto;
+        display: inline-flex;
         align-items: center;
-        background: var(--boxel-light);
-        border: 1px solid var(--boxel-450);
-        border-radius: var(--boxel-border-radius-sm);
-        gap: var(--boxel-sp-xxxs);
-        box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.5);
+        gap: 5px;
+        max-width: max-content;
+        padding: 3px 12px 3px 7px;
+        background: var(--adorn-accent-light);
+        color: #0a2e1c;
+        font: 700 10px/1 var(--boxel-font-family, inherit);
+        letter-spacing: 0.5px;
+        text-transform: uppercase;
+        white-space: nowrap;
+        border-radius: 5px 0 0 5px;
+        clip-path: polygon(0 0, calc(100% - 13px) 0, 100% 100%, 0 100%);
+        pointer-events: auto;
+        z-index: 1;
+        filter: drop-shadow(0 5px 8px rgba(0, 0, 0, 0.2));
       }
-      .actions-item__button {
-        --icon-bg: var(--boxel-dark);
-        --icon-color: var(--boxel-dark);
+      .actions-overlay.selected .adorn-label {
+        background: var(--adorn-accent);
+      }
+      .adorn-label-icon {
+        width: 14px;
+        height: 14px;
+        flex-shrink: 0;
+        color: #0a2e1c;
+      }
+      .adorn-label-text {
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .adorn-label-menu {
+        width: 18px;
+        height: 18px;
+        margin-inline-start: 0;
+        padding: 2px;
+        border-radius: 4px;
+        --icon-bg: #0a2e1c;
+        --icon-color: #0a2e1c;
+        --boxel-icon-button-width: 18px;
+        --boxel-icon-button-height: 18px;
+      }
+      .adorn-label-menu:hover {
+        background: rgba(0, 0, 0, 0.12);
+      }
 
-        pointer-events: auto; /* pointer events are disabled in the overlay, we re-enable it here for header actions */
-        display: flex;
+      /* Selection indicator — rounded square chip at the bottom-right corner. */
+      .adorn-select-button {
+        position: absolute;
+        bottom: 2px;
+        right: 4px;
+        width: 20px;
+        height: 20px;
+        padding: 3px;
+        border: none;
         border-radius: 5px;
+        background: var(--adorn-accent-light);
+        color: var(--adorn-accent-light);
+        cursor: pointer;
+        pointer-events: auto;
+        z-index: 1;
       }
-      .actions-item__button:hover {
-        --icon-bg: var(--boxel-dark);
-        --icon-color: var(--boxel-dark);
-        background-color: var(--boxel-highlight);
+      .adorn-select-icon {
+        display: block;
+        width: 14px;
+        height: 14px;
       }
-      .selected .actions-item.select {
-        visibility: visible;
+
+      /* Field overlays (containsMany items, linksToMany items) don't get the
+         select indicator — see isButtonDisplayed('select'). The label tab is
+         still useful so it stays. */
+      .actions-overlay.field .adorn-select-button {
+        display: none;
+      }
+
+      /* Compact mode for small atom-format cards */
+      @container actions-overlay (aspect-ratio > 2.0) and (height <= 57px) {
+        .adorn-label {
+          padding: 2px 10px 2px 5px;
+          font-size: 9px;
+          gap: 4px;
+        }
+        .adorn-label-icon {
+          width: 11px;
+          height: 11px;
+        }
+        .adorn-label-menu {
+          width: 14px;
+          height: 14px;
+          --boxel-icon-button-width: 14px;
+          --boxel-icon-button-height: 14px;
+        }
+        .adorn-select-button {
+          width: 16px;
+          height: 16px;
+          padding: 2px;
+          bottom: 4px;
+          right: 4px;
+        }
+        .adorn-select-icon {
+          width: 12px;
+          height: 12px;
+        }
       }
     </style>
   </template>
 
-  private dropdownAPIs: WeakMap<
+  private dropdownAPIs: Map<
     StackItemRenderedCardForOverlayActions,
     BoxelDropdownAPI
   > = new Map();
+  private openDropdownCount = 0;
+
+  protected override shouldDelayHoverClear(): boolean {
+    return this.openDropdownCount > 0;
+  }
+
+  protected override shouldSwallowCardClick(): boolean {
+    return this.openDropdownCount > 0;
+  }
+
+  @action
+  private handleMenuTriggerClick(
+    renderedCard: StackItemRenderedCardForOverlayActions,
+  ) {
+    // BasicDropdown updates isOpen on the same tick as the click handler;
+    // a 0ms timeout lets us read the post-toggle state.
+    setTimeout(() => {
+      let api = this.dropdownAPIs.get(renderedCard);
+      if (api?.isOpen) {
+        this.openDropdownCount += 1;
+        this.cancelHoverClear();
+      }
+    }, 0);
+  }
+
+  @action
+  private handleMenuClose() {
+    this.openDropdownCount = Math.max(0, this.openDropdownCount - 1);
+    // Now that the menu is gone, see if we should retire the chrome.
+    this.scheduleHoverClear();
+  }
 
   @action
   private isButtonDisplayed(
@@ -357,8 +391,6 @@ export default class OperatorModeOverlays extends Overlays {
           return false;
         }
         return this.realm.canWrite(this.getCardId(renderedCard.cardDefOrId));
-      case 'more-options':
-        return true;
       default:
         return false;
     }
@@ -409,37 +441,12 @@ export default class OperatorModeOverlays extends Overlays {
     renderedCard: StackItemRenderedCardForOverlayActions,
   ) {
     return (dropdownAPI: BoxelDropdownAPI) => {
-      if (this.dropdownAPIs.has(renderedCard)) {
-        return;
-      }
-
+      // Always overwrite. The dropdown trigger lives inside an {{#if
+      // isHovered}}, so the BoxelDropdown component re-mounts every time the
+      // chip re-appears and emits a fresh API; reading isOpen on a stale
+      // (destroyed) instance always returns false.
       this.dropdownAPIs.set(renderedCard, dropdownAPI);
     };
-  }
-
-  @action
-  protected override setCurrentlyHoveredCard(
-    renderedCard: StackItemRenderedCardForOverlayActions | null,
-  ) {
-    // Hide the dropdown content when the overlay is not hovered.
-    // Make it visible again when it is hovered.
-    let hoveredCard = (this.currentlyHoveredCard ??
-      renderedCard) as StackItemRenderedCardForOverlayActions;
-    if (hoveredCard) {
-      let dropdownContentElement = document.querySelector(
-        `#ember-basic-dropdown-content-${
-          this.dropdownAPIs.get(hoveredCard)?.uniqueId
-        }`,
-      );
-
-      if (dropdownContentElement) {
-        const dropdownElement = dropdownContentElement as HTMLElement;
-        dropdownElement.style.visibility =
-          dropdownElement.style.visibility === 'hidden' ? 'visible' : 'hidden';
-      }
-    }
-
-    super.setCurrentlyHoveredCard(renderedCard);
   }
 
   /**
@@ -453,6 +460,41 @@ export default class OperatorModeOverlays extends Overlays {
       return 'isolated';
     }
     return renderedCard.stackItem.format as Format;
+  }
+
+  private peekCardDef(cardDefOrId: CardDefOrId): CardDef | undefined {
+    if (typeof cardDefOrId !== 'string') {
+      return cardDefOrId;
+    }
+    let instance = this.store.peek<CardDef>(cardDefOrId);
+    return instance && !('error' in instance) ? instance : undefined;
+  }
+
+  @action
+  private getCardTypeName(
+    cardDefOrId: CardDefOrId,
+    renderedCard: StackItemRenderedCardForOverlayActions,
+  ): string {
+    let card = this.peekCardDef(cardDefOrId);
+    if (card) {
+      return cardTypeDisplayName(card);
+    }
+    // Prerendered cards in the cards-grid don't have their CardDef loaded in
+    // the store yet — fall back to the type name embedded on the rendered
+    // element by prerendered-card-search.
+    let domName = renderedCard.element?.getAttribute(
+      'data-card-type-display-name',
+    );
+    return domName ?? 'Card';
+  }
+
+  @action
+  private getCardTypeIcon(cardDefOrId: CardDefOrId) {
+    let card = this.peekCardDef(cardDefOrId);
+    if (!card) {
+      return undefined;
+    }
+    return cardTypeIcon(card);
   }
 
   @action
@@ -469,10 +511,31 @@ export default class OperatorModeOverlays extends Overlays {
       icon: Eye,
     };
 
+    const editItem: MenuItemOptions | undefined = this.isButtonDisplayed(
+      'edit',
+      renderedCard,
+    )
+      ? {
+          label: 'Edit',
+          action: () =>
+            this.openOrSelectCard(
+              cardDefOrId,
+              'edit',
+              renderedCard.fieldType,
+              renderedCard.fieldName,
+            ),
+          icon: IconPencil,
+        }
+      : undefined;
+
     // When cardDefOrId is a string (e.g., prerendered cards in the grid),
     // we can't call [getMenuItems] on it, so construct default menu items
     if (typeof cardDefOrId === 'string') {
-      const menuItems: MenuItemOptions[] = [viewCardItem];
+      const menuItems: MenuItemOptions[] = [];
+      if (editItem) {
+        menuItems.push(editItem);
+      }
+      menuItems.push(viewCardItem);
       menuItems.push({
         label: 'Copy Card URL',
         action: () => copyCardURLToClipboard(cardId),
@@ -506,6 +569,12 @@ export default class OperatorModeOverlays extends Overlays {
         )
       : cardMenuItems;
 
-    return toMenuItems([viewCardItem, ...visibleItems]);
+    const leadingItems: MenuItemOptions[] = [];
+    if (editItem) {
+      leadingItems.push(editItem);
+    }
+    leadingItems.push(viewCardItem);
+
+    return toMenuItems([...leadingItems, ...visibleItems]);
   }
 }

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -44,8 +44,10 @@ import {
 import { removeFileExtension } from '@cardstack/host/utils/card-search/types';
 
 import type {
+  BaseDef,
   CardCrudFunctions,
   CardDef,
+  FileDef,
   Format,
 } from 'https://cardstack.com/base/card-api';
 
@@ -109,7 +111,10 @@ export default class OperatorModeOverlays extends Overlays {
                 {{on 'mouseenter' this.cancelHoverClear}}
                 {{on 'mouseleave' this.scheduleHoverClear}}
               >
-                {{#let (this.getCardTypeIcon cardDefOrId) as |TypeIcon|}}
+                {{#let
+                  (this.getCardTypeIcon cardDefOrId renderedCard)
+                  as |TypeIcon|
+                }}
                   {{#if TypeIcon}}
                     <TypeIcon class='adorn-label-icon' />
                   {{/if}}
@@ -462,12 +467,20 @@ export default class OperatorModeOverlays extends Overlays {
     return renderedCard.stackItem.format as Format;
   }
 
-  private peekCardDef(cardDefOrId: CardDefOrId): CardDef | undefined {
+  private peekInstance(
+    cardDefOrId: CardDefOrId,
+    renderedCard?: StackItemRenderedCardForOverlayActions,
+  ): BaseDef | undefined {
     if (typeof cardDefOrId !== 'string') {
-      return cardDefOrId;
+      return cardDefOrId as BaseDef;
     }
-    let instance = this.store.peek<CardDef>(cardDefOrId);
-    return instance && !('error' in instance) ? instance : undefined;
+    let isFile = renderedCard != null && this.isFileMetaTarget(renderedCard);
+    let instance = isFile
+      ? this.store.peek<FileDef>(cardDefOrId, { type: 'file-meta' })
+      : this.store.peek<CardDef>(cardDefOrId);
+    return instance && !('error' in instance)
+      ? (instance as BaseDef)
+      : undefined;
   }
 
   @action
@@ -475,26 +488,32 @@ export default class OperatorModeOverlays extends Overlays {
     cardDefOrId: CardDefOrId,
     renderedCard: StackItemRenderedCardForOverlayActions,
   ): string {
-    let card = this.peekCardDef(cardDefOrId);
-    if (card) {
-      return cardTypeDisplayName(card);
+    let instance = this.peekInstance(cardDefOrId, renderedCard);
+    if (instance) {
+      return cardTypeDisplayName(instance);
     }
-    // Prerendered cards in the cards-grid don't have their CardDef loaded in
+    // Prerendered rows in the cards-grid don't have their instance loaded in
     // the store yet — fall back to the type name embedded on the rendered
     // element by prerendered-card-search.
     let domName = renderedCard.element?.getAttribute(
       'data-card-type-display-name',
     );
-    return domName ?? 'Card';
+    if (domName) {
+      return domName;
+    }
+    return this.isFileMetaTarget(renderedCard) ? 'File' : 'Card';
   }
 
   @action
-  private getCardTypeIcon(cardDefOrId: CardDefOrId) {
-    let card = this.peekCardDef(cardDefOrId);
-    if (!card) {
+  private getCardTypeIcon(
+    cardDefOrId: CardDefOrId,
+    renderedCard: StackItemRenderedCardForOverlayActions,
+  ) {
+    let instance = this.peekInstance(cardDefOrId, renderedCard);
+    if (!instance) {
       return undefined;
     }
-    return cardTypeIcon(card);
+    return cardTypeIcon(instance);
   }
 
   @action
@@ -503,10 +522,11 @@ export default class OperatorModeOverlays extends Overlays {
     renderedCard: StackItemRenderedCardForOverlayActions,
   ) {
     const isField = this.isField(renderedCard);
+    const isFile = this.isFileMetaTarget(renderedCard);
     const cardId = this.getCardId(cardDefOrId);
 
-    const viewCardItem: MenuItemOptions = {
-      label: 'View card',
+    const viewItem: MenuItemOptions = {
+      label: isFile ? 'View file' : 'View card',
       action: () => this.openOrSelectCard(cardDefOrId),
       icon: Eye,
     };
@@ -528,19 +548,21 @@ export default class OperatorModeOverlays extends Overlays {
         }
       : undefined;
 
+    const copyUrlItem: MenuItemOptions = {
+      label: isFile ? 'Copy File URL' : 'Copy Card URL',
+      action: () => copyCardURLToClipboard(cardId),
+      icon: IconLink,
+    };
+
     // When cardDefOrId is a string (e.g., prerendered cards in the grid),
     // we can't call [getMenuItems] on it, so construct default menu items
     if (typeof cardDefOrId === 'string') {
       const menuItems: MenuItemOptions[] = [];
-      menuItems.push(viewCardItem);
+      menuItems.push(viewItem);
       if (editItem) {
         menuItems.push(editItem);
       }
-      menuItems.push({
-        label: 'Copy Card URL',
-        action: () => copyCardURLToClipboard(cardId),
-        icon: IconLink,
-      });
+      menuItems.push(copyUrlItem);
       if (!isField && this.realm.canWrite(cardId)) {
         menuItems.push({
           label: 'Delete',
@@ -573,7 +595,7 @@ export default class OperatorModeOverlays extends Overlays {
     if (editItem) {
       leadingItems.push(editItem);
     }
-    leadingItems.push(viewCardItem);
+    leadingItems.push(viewItem);
 
     return toMenuItems([...leadingItems, ...visibleItems]);
   }

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -506,26 +506,56 @@ export default class OperatorModeOverlays extends Overlays {
     cardDefOrId: CardDefOrId,
     renderedCard: StackItemRenderedCardForOverlayActions,
   ): string {
-    // Prefer the indexer-populated DOM attribute over the in-memory
-    // instance. FileDef subclasses currently round-trip through
-    // createFileDef which always returns a generic FileDef base instance
-    // (constructor.displayName === 'File'), losing the specific class —
-    // but the realm server's indexer records the proper subclass display
-    // name in `display_names`, which prerendered-card-search stamps onto
-    // the rendered wrapper. So the DOM attribute is the more accurate
-    // source for file rows and matches the in-store CardDef result for
-    // card rows.
+    let isFile = this.isFileMetaTarget(renderedCard);
     let domName = renderedCard.element?.getAttribute(
       'data-card-type-display-name',
     );
-    if (domName) {
-      return domName;
-    }
     let instance = this.peekInstance(cardDefOrId, renderedCard);
-    if (instance) {
-      return cardTypeDisplayName(instance);
+    let instanceName = instance ? cardTypeDisplayName(instance) : undefined;
+
+    // Prefer a specific class name from either source. The realm-server
+    // indexer's getDisplayNames walks the prototype chain and stops at the
+    // base FileDef / CardDef — so display_names is empty for bare FileDef /
+    // CardDef rows and `cardType` lands as undefined; the in-memory
+    // instance returns 'File' / 'Card' for the same case. Both are
+    // uninformative; skip them when picking the label.
+    let specific = [domName, instanceName].find(
+      (name): name is string =>
+        typeof name === 'string' && name !== 'File' && name !== 'Card',
+    );
+    if (specific) {
+      return specific;
     }
-    return this.isFileMetaTarget(renderedCard) ? 'File' : 'Card';
+
+    // No specific subclass info available. For file rows, derive a hint
+    // from the URL extension so the user can still tell file types apart
+    // (e.g. 'MD', 'GTS', 'PNG') rather than every file row reading 'FILE'.
+    if (isFile) {
+      let extName = this.deriveFileTypeFromExtension(cardDefOrId);
+      if (extName) {
+        return extName;
+      }
+    }
+
+    return domName ?? instanceName ?? (isFile ? 'File' : 'Card');
+  }
+
+  private deriveFileTypeFromExtension(
+    cardDefOrId: CardDefOrId,
+  ): string | undefined {
+    let cardId = this.getCardId(cardDefOrId);
+    if (!cardId) return undefined;
+    let pathWithoutQuery = cardId.split('?')[0].split('#')[0];
+    let lastDot = pathWithoutQuery.lastIndexOf('.');
+    let lastSlash = pathWithoutQuery.lastIndexOf('/');
+    if (lastDot <= lastSlash || lastDot === pathWithoutQuery.length - 1) {
+      return undefined;
+    }
+    let ext = pathWithoutQuery.slice(lastDot + 1);
+    if (!/^[A-Za-z0-9]+$/.test(ext)) {
+      return undefined;
+    }
+    return ext.toUpperCase();
   }
 
   @action

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -354,6 +354,12 @@ export default class OperatorModeOverlays extends Overlays {
   > = new Map();
   private openDropdownCount = 0;
 
+  protected override get hoverClearDelayMs(): number {
+    // The type-label tab floats a few pixels above the card; the cursor
+    // needs to bridge that gap without the chrome dismissing itself.
+    return 100;
+  }
+
   protected override shouldDelayHoverClear(): boolean {
     return this.openDropdownCount > 0;
   }
@@ -479,9 +485,20 @@ export default class OperatorModeOverlays extends Overlays {
     let instance = isFile
       ? this.store.peek<FileDef>(cardDefOrId, { type: 'file-meta' })
       : this.store.peek<CardDef>(cardDefOrId);
-    return instance && !('error' in instance)
-      ? (instance as BaseDef)
-      : undefined;
+    if (!instance || 'error' in instance) {
+      return undefined;
+    }
+    // Defensive: errored or partial reads may return shapes that don't
+    // implement the BaseDef interface (e.g. error envelopes). Only return
+    // instances whose constructor exposes getDisplayName, since that's what
+    // cardTypeDisplayName / cardTypeIcon rely on.
+    let ctor = (instance as { constructor?: unknown }).constructor as
+      | { getDisplayName?: unknown }
+      | undefined;
+    if (typeof ctor?.getDisplayName !== 'function') {
+      return undefined;
+    }
+    return instance as unknown as BaseDef;
   }
 
   @action
@@ -489,18 +506,24 @@ export default class OperatorModeOverlays extends Overlays {
     cardDefOrId: CardDefOrId,
     renderedCard: StackItemRenderedCardForOverlayActions,
   ): string {
-    let instance = this.peekInstance(cardDefOrId, renderedCard);
-    if (instance) {
-      return cardTypeDisplayName(instance);
-    }
-    // Prerendered rows in the cards-grid don't have their instance loaded in
-    // the store yet — fall back to the type name embedded on the rendered
-    // element by prerendered-card-search.
+    // Prefer the indexer-populated DOM attribute over the in-memory
+    // instance. FileDef subclasses currently round-trip through
+    // createFileDef which always returns a generic FileDef base instance
+    // (constructor.displayName === 'File'), losing the specific class —
+    // but the realm server's indexer records the proper subclass display
+    // name in `display_names`, which prerendered-card-search stamps onto
+    // the rendered wrapper. So the DOM attribute is the more accurate
+    // source for file rows and matches the in-store CardDef result for
+    // card rows.
     let domName = renderedCard.element?.getAttribute(
       'data-card-type-display-name',
     );
     if (domName) {
       return domName;
+    }
+    let instance = this.peekInstance(cardDefOrId, renderedCard);
+    if (instance) {
+      return cardTypeDisplayName(instance);
     }
     return this.isFileMetaTarget(renderedCard) ? 'File' : 'Card';
   }
@@ -510,19 +533,20 @@ export default class OperatorModeOverlays extends Overlays {
     cardDefOrId: CardDefOrId,
     renderedCard: StackItemRenderedCardForOverlayActions,
   ): unknown {
-    let instance = this.peekInstance(cardDefOrId, renderedCard);
-    if (instance) {
-      return cardTypeIcon(instance);
-    }
-    // Prerendered rows expose the type icon as raw SVG markup on the
-    // rendered element — wrap it in an htmlComponent so it can be invoked
-    // like any other Icon. htmlComponent caches by source string, so
-    // repeated lookups for the same icon return the same component.
+    // Same precedence as getCardTypeName — the realm server stamps the
+    // proper subclass icon HTML on the rendered wrapper, which the
+    // in-memory FileDef base class can't supply.
     let iconHtml = renderedCard.element?.getAttribute(
       'data-card-type-icon-html',
     );
     if (iconHtml) {
+      // htmlComponent caches by source string, so repeat lookups for the
+      // same icon return the same component.
       return htmlComponent(iconHtml);
+    }
+    let instance = this.peekInstance(cardDefOrId, renderedCard);
+    if (instance) {
+      return cardTypeIcon(instance);
     }
     return undefined;
   }
@@ -547,7 +571,7 @@ export default class OperatorModeOverlays extends Overlays {
       renderedCard,
     )
       ? {
-          label: 'Edit card',
+          label: 'Edit',
           action: () =>
             this.openOrSelectCard(
               cardDefOrId,

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -284,8 +284,8 @@ export default class OperatorModeOverlays extends Overlays {
       /* Selection indicator — rounded square chip at the bottom-right corner. */
       .adorn-select-button {
         position: absolute;
-        bottom: 10px;
-        right: 10px;
+        bottom: 4px;
+        right: 4px;
         width: 20px;
         height: 20px;
         padding: 3px;
@@ -331,8 +331,8 @@ export default class OperatorModeOverlays extends Overlays {
           width: 16px;
           height: 16px;
           padding: 2px;
-          bottom: 4px;
-          right: 4px;
+          bottom: 2px;
+          right: 2px;
         }
         .adorn-select-icon {
           width: 12px;
@@ -516,7 +516,7 @@ export default class OperatorModeOverlays extends Overlays {
       renderedCard,
     )
       ? {
-          label: 'Edit',
+          label: 'Edit card',
           action: () =>
             this.openOrSelectCard(
               cardDefOrId,
@@ -532,10 +532,10 @@ export default class OperatorModeOverlays extends Overlays {
     // we can't call [getMenuItems] on it, so construct default menu items
     if (typeof cardDefOrId === 'string') {
       const menuItems: MenuItemOptions[] = [];
+      menuItems.push(viewCardItem);
       if (editItem) {
         menuItems.push(editItem);
       }
-      menuItems.push(viewCardItem);
       menuItems.push({
         label: 'Copy Card URL',
         action: () => copyCardURLToClipboard(cardId),

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -108,6 +108,14 @@ export default class Overlays extends Component<OverlaySignature> {
   @tracked
   protected currentlyHoveredCard: RenderedCardForOverlayActions | null = null;
 
+  // When the cursor leaves the underlying card it may still be travelling to
+  // floating chrome rendered above the card (e.g. the type-label tab in
+  // OperatorModeOverlays which sits a couple of pixels above the card's top
+  // edge). We defer the hover clear so the cursor can bridge that gap; any
+  // mouseenter on the chrome cancels the pending clear.
+  private hoverClearTimer: ReturnType<typeof setTimeout> | null = null;
+  private static readonly HOVER_CLEAR_DELAY_MS = 100;
+
   protected offset = {
     name: 'offset',
     fn: (state: MiddlewareState) => {
@@ -118,6 +126,12 @@ export default class Overlays extends Component<OverlaySignature> {
       floating.style.width = width + 'px';
       floating.style.height = height + 'px';
       floating.style.position = 'absolute';
+      // Mirror the underlying card's corner radius so any decorative
+      // outline / box-shadow on the overlay follows the same curve.
+      if (reference instanceof Element) {
+        floating.style.borderRadius =
+          window.getComputedStyle(reference).borderRadius;
+      }
       return {
         x: rects.reference.x,
         y: rects.reference.y,
@@ -149,6 +163,7 @@ export default class Overlays extends Component<OverlaySignature> {
         continue;
       }
       let mouseenter = (_ev: MouseEvent) => {
+        this.cancelHoverClear();
         if (this.currentlyHoveredCard === renderedCard) {
           return;
         }
@@ -159,12 +174,18 @@ export default class Overlays extends Component<OverlaySignature> {
         if (relatedTarget?.closest?.(`.${this.overlayClassName}`)) {
           return;
         }
-        this.setCurrentlyHoveredCard(null);
+        this.scheduleHoverClear();
       };
       let click = (e: MouseEvent) => {
         // prevent outer nested contains fields from triggering when inner most
         // contained field was clicked
         e.stopPropagation();
+        if (this.shouldSwallowCardClick()) {
+          // A subclass is currently holding chrome open (e.g. an overlay
+          // dropdown is open). This click is the outside-click that's about
+          // to dismiss that chrome — don't *also* open the underlying card.
+          return;
+        }
         this.openOrSelectCard(
           renderedCard.cardDefOrId,
           this.getFormatForCard(renderedCard),
@@ -210,6 +231,56 @@ export default class Overlays extends Component<OverlaySignature> {
     renderedCard: RenderedCardForOverlayActions | null,
   ) {
     this.currentlyHoveredCard = renderedCard;
+  }
+
+  @action
+  protected scheduleHoverClear() {
+    if (this.shouldDelayHoverClear()) {
+      return;
+    }
+    if (this.hoverClearTimer) {
+      return;
+    }
+    this.hoverClearTimer = setTimeout(() => {
+      this.hoverClearTimer = null;
+      if (this.shouldDelayHoverClear()) {
+        // A subclass began holding hover state (e.g. menu opened) while the
+        // timer was pending — re-schedule so we'll re-check after the hold
+        // lifts.
+        this.scheduleHoverClear();
+        return;
+      }
+      this.setCurrentlyHoveredCard(null);
+    }, Overlays.HOVER_CLEAR_DELAY_MS);
+  }
+
+  @action
+  protected cancelHoverClear() {
+    if (this.hoverClearTimer) {
+      clearTimeout(this.hoverClearTimer);
+      this.hoverClearTimer = null;
+    }
+  }
+
+  /**
+   * Hook for subclasses to pin the current hover state. While this returns
+   * true, scheduleHoverClear is a no-op and any in-flight timer re-schedules
+   * itself. Use for "the cursor logically left but we don't want to dismiss
+   * the chrome yet" — e.g. a dropdown opened from the chrome is now floating
+   * in a portal outside the overlay.
+   */
+  protected shouldDelayHoverClear(): boolean {
+    return false;
+  }
+
+  /**
+   * Hook for subclasses to suppress the default card-open behavior on click.
+   * Use when the overlay has floating chrome whose outside-click dismissal
+   * shouldn't also trigger card navigation (e.g. clicking outside an open
+   * dropdown menu).
+   */
+  protected shouldSwallowCardClick(): boolean {
+    return false;
   }
 
   @action protected openOrSelectCard(
@@ -336,6 +407,10 @@ export default class Overlays extends Component<OverlaySignature> {
   private teardownBoundRenderedCards() {
     for (let [element, handlers] of this.boundRenderedCardElements) {
       this.unbindRenderedCardElement(element, handlers);
+    }
+    if (this.hoverClearTimer) {
+      clearTimeout(this.hoverClearTimer);
+      this.hoverClearTimer = null;
     }
     this.currentlyHoveredCard = null;
   }

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -114,7 +114,14 @@ export default class Overlays extends Component<OverlaySignature> {
   // edge). We defer the hover clear so the cursor can bridge that gap; any
   // mouseenter on the chrome cancels the pending clear.
   private hoverClearTimer: ReturnType<typeof setTimeout> | null = null;
-  private static readonly HOVER_CLEAR_DELAY_MS = 100;
+
+  // Subclasses opt into a hover-bridge delay by overriding this getter.
+  // The base Overlays has no floating chrome, so the default is immediate
+  // (0ms) — preserving existing immediate-clear behaviour for consumers
+  // like spec-preview and playground-panel.
+  protected get hoverClearDelayMs(): number {
+    return 0;
+  }
 
   protected offset = {
     name: 'offset',
@@ -251,7 +258,7 @@ export default class Overlays extends Component<OverlaySignature> {
         return;
       }
       this.setCurrentlyHoveredCard(null);
-    }, Overlays.HOVER_CLEAR_DELAY_MS);
+    }, this.hoverClearDelayMs);
   }
 
   @action

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -581,7 +581,8 @@ export default class OperatorModeStackItem extends Component<Signature> {
     );
 
     return {
-      triggerText: `${selectedCount} Selected`,
+      triggerText: `${selectedCount}`,
+      headerText: `${selectedCount} Selected`,
       menuItems,
     };
   }

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -95,7 +95,7 @@ import type StoreService from '../../services/store';
 // Inert "N Selected" header icon for the multi-select utility menu —
 // dark filled circle with a teal check, matching the per-card selection chip.
 const SelectionCheckmarkIcon: TemplateOnlyComponent<{
-  Element: SVGElement;
+  Element: SVGSVGElement;
 }> = <template>
   <svg
     viewBox='0 0 14 14'

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -1,3 +1,4 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { fn } from '@ember/helper';
 import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
@@ -90,6 +91,28 @@ import type CardService from '../../services/card-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
 import type RealmService from '../../services/realm';
 import type StoreService from '../../services/store';
+
+// Inert "N Selected" header icon for the multi-select utility menu —
+// dark filled circle with a teal check, matching the per-card selection chip.
+const SelectionCheckmarkIcon: TemplateOnlyComponent<{
+  Element: SVGElement;
+}> = <template>
+  <svg
+    viewBox='0 0 14 14'
+    fill='none'
+    xmlns='http://www.w3.org/2000/svg'
+    ...attributes
+  >
+    <circle cx='7' cy='7' r='7' fill='#0a2e1c' />
+    <path
+      d='M3.5 7.5L5.5 9.5L10.5 4.5'
+      stroke='var(--boxel-teal)'
+      stroke-width='1.5'
+      stroke-linecap='round'
+      stroke-linejoin='round'
+    />
+  </svg>
+</template>;
 
 export interface StackItemComponentAPI {
   clearSelections: () => void;
@@ -547,6 +570,17 @@ export default class OperatorModeStackItem extends Component<Signature> {
 
     const menuItems: (MenuItem | MenuDivider)[] = [];
 
+    // Inert teal header echoing the chip's count — uses the same
+    // dark-circle-with-teal-check artwork as the per-card selection chip.
+    menuItems.push(
+      new MenuItem({
+        label: `${selectedCount} Selected`,
+        action: () => {},
+        icon: SelectionCheckmarkIcon,
+        header: true,
+      }),
+    );
+
     // Add "Select All" option if not all cards are selected
     if (!allSelected && totalAvailableCount > selectedCount) {
       menuItems.push(
@@ -582,7 +616,6 @@ export default class OperatorModeStackItem extends Component<Signature> {
 
     return {
       triggerText: `${selectedCount}`,
-      headerText: `${selectedCount} Selected`,
       menuItems,
     };
   }

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -62,6 +62,12 @@ export class PrerenderedCard implements PrerenderedCardLike {
       if (data.isError) {
         extraAttributes['data-is-error'] = 'true';
       }
+      if (data.cardType) {
+        // Expose the prerendered card's type display name so consumers (e.g.
+        // OperatorModeOverlays) can label the card before its CardDef is
+        // loaded into the store.
+        extraAttributes['data-card-type-display-name'] = data.cardType;
+      }
       this.component = wrapWithModifier(
         htmlComponent(data.html, extraAttributes),
         cardComponentModifier,

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -68,6 +68,11 @@ export class PrerenderedCard implements PrerenderedCardLike {
         // loaded into the store.
         extraAttributes['data-card-type-display-name'] = data.cardType;
       }
+      if (data.iconHtml) {
+        // Expose the prerendered card's type icon (raw SVG markup) so
+        // consumers can render it before the instance is loaded.
+        extraAttributes['data-card-type-icon-html'] = data.iconHtml;
+      }
       this.component = wrapWithModifier(
         htmlComponent(data.html, extraAttributes),
         cardComponentModifier,

--- a/packages/host/tests/acceptance/interact-submode-creation-and-permissions-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-creation-and-permissions-test.gts
@@ -669,11 +669,14 @@ module(
         assert
           .dom(`[data-test-overlay-card="${testRealmURL}Pet/mango"]`)
           .exists();
+        await click(
+          `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-more-options]`,
+        );
         assert
-          .dom(
-            `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-edit]`,
-          )
-          .doesNotExist('edit icon not displayed for linked card');
+          .dom('[data-test-boxel-menu-item-text="Edit"]')
+          .doesNotExist(
+            'Edit menu item not displayed for read-only linked card',
+          );
         await click(
           `[data-test-links-to-editor="pet"] [data-test-field-component-card]`,
         );

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -824,14 +824,11 @@ module('Acceptance | interact submode tests', function (hooks) {
         `[data-test-stack-card="${testRealm2URL}Person/hassan"] [data-test-links-to-editor="pet"] [data-test-field-component-card]`,
         'mouseenter',
       );
-      assert
-        .dom(
-          `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-edit]`,
-        )
-        .exists();
       await click(
-        `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-edit]`,
+        `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-more-options]`,
       );
+      assert.dom('[data-test-boxel-menu-item-text="Edit"]').exists();
+      await click('[data-test-boxel-menu-item-text="Edit"]');
       assert
         .dom(
           `[data-test-stack-card="${testRealmURL}Pet/mango"] [data-test-card-format="edit"]`,
@@ -856,8 +853,9 @@ module('Acceptance | interact submode tests', function (hooks) {
         'mouseenter',
       );
       await click(
-        `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-edit]`,
+        `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-more-options]`,
       );
+      await click('[data-test-boxel-menu-item-text="Edit"]');
       assert
         .dom(
           `[data-test-stack-card="${testRealmURL}Pet/mango"] [data-test-field="name"] input`,
@@ -1081,8 +1079,9 @@ module('Acceptance | interact submode tests', function (hooks) {
       );
 
       await click(
-        `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-edit]`,
+        `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-more-options]`,
       );
+      await click('[data-test-boxel-menu-item-text="Edit"]');
 
       assert
         .dom(

--- a/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
+++ b/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
@@ -1,4 +1,10 @@
-import { click, findAll, triggerEvent, waitFor } from '@ember/test-helpers';
+import {
+  click,
+  findAll,
+  triggerEvent,
+  waitFor,
+  waitUntil,
+} from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
@@ -219,7 +225,10 @@ module('Acceptance | workspace-delete-multiple', function (hooks) {
       .dom('.utility-menu-trigger')
       .doesNotExist('Selection summary is cleared after deselect');
 
-    // Verify overlay checkboxes are not checked
+    // Verify overlay chrome is gone. The overlay clears on hover-out via a
+    // 100ms hover-bridge timer (native setTimeout, not tracked by settled),
+    // so poll rather than asserting synchronously.
+    await waitUntil(() => findAll('[data-test-overlay-card]').length === 0);
     assert.dom('[data-test-overlay-card]').doesNotExist();
   });
 

--- a/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
+++ b/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
@@ -138,13 +138,13 @@ module('Acceptance | workspace-delete-multiple', function (hooks) {
     // Verify selection state is active
     assert
       .dom('.utility-menu-trigger')
-      .containsText('1 Selected', 'Selection menu appears');
+      .containsText('1', 'Selection chip shows count');
 
     // Select additional cards
     await selectCard('Pet/2');
 
     // Verify selection count
-    assert.dom('.utility-menu-trigger').containsText('2 Selected');
+    assert.dom('.utility-menu-trigger').containsText('2');
 
     // Open utility menu
     await click('.utility-menu-trigger');
@@ -249,7 +249,7 @@ module('Acceptance | workspace-delete-multiple', function (hooks) {
     // Verify selection state is active
     assert
       .dom('.utility-menu-trigger')
-      .containsText('1 Selected', 'Selection menu appears');
+      .containsText('1', 'Selection chip shows count');
 
     // Open utility menu
     await click('.utility-menu-trigger');
@@ -260,7 +260,7 @@ module('Acceptance | workspace-delete-multiple', function (hooks) {
     // Verify all cards are selected
     assert
       .dom('.utility-menu-trigger')
-      .containsText(`${totalCardCount} Selected`, 'All cards are now selected');
+      .containsText(`${totalCardCount}`, 'All cards are now selected');
 
     // Open utility menu again to verify "Select All" is no longer available
     await click('.utility-menu-trigger');

--- a/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
+++ b/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
@@ -104,10 +104,10 @@ module('Acceptance | workspace-delete-multiple', function (hooks) {
     let cardSelector = `[data-test-cards-grid-item="${testRealmURL}${cardPath}"] .field-component-card`;
     await triggerEvent(cardSelector, 'mouseenter');
     await waitFor(
-      `[data-test-overlay-card="${testRealmURL}${cardPath}"] button.actions-item__button`,
+      `[data-test-overlay-card="${testRealmURL}${cardPath}"] [data-test-overlay-select="${testRealmURL}${cardPath}"]`,
     );
     await click(
-      `[data-test-overlay-card="${testRealmURL}${cardPath}"] button.actions-item__button`,
+      `[data-test-overlay-card="${testRealmURL}${cardPath}"] [data-test-overlay-select="${testRealmURL}${cardPath}"]`,
     );
     await triggerEvent(cardSelector, 'mouseleave');
   }

--- a/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
+++ b/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
@@ -206,7 +206,7 @@ module('Acceptance | workspace-delete-multiple', function (hooks) {
     await selectCard('Pet/3');
 
     // Verify selection count
-    assert.dom('.utility-menu-trigger').containsText('3 Selected');
+    assert.dom('.utility-menu-trigger').containsText('3');
 
     // Open utility menu
     await click('.utility-menu-trigger');
@@ -303,7 +303,7 @@ module('Acceptance | workspace-delete-multiple', function (hooks) {
     await selectCard('Pet/2');
 
     // Verify selection count
-    assert.dom('.utility-menu-trigger').containsText('2 Selected');
+    assert.dom('.utility-menu-trigger').containsText('2');
 
     // Open utility menu
     await click('.utility-menu-trigger');
@@ -338,6 +338,6 @@ module('Acceptance | workspace-delete-multiple', function (hooks) {
     // Verify selection is still active
     assert
       .dom('.utility-menu-trigger')
-      .containsText('2 Selected', 'Selection remains active after cancel');
+      .containsText('2', 'Selection remains active after cancel');
   });
 });

--- a/packages/host/tests/integration/components/card-def-field-def-relationships-test.gts
+++ b/packages/host/tests/integration/components/card-def-field-def-relationships-test.gts
@@ -514,16 +514,16 @@ module('Integration | CardDef-FieldDef relationships test', function (hooks) {
     await triggerEvent(`[data-test-card="${testRealmURL}usd"]`, 'mouseenter');
     assert
       .dom(
-        `[data-test-overlay-card="${testRealmURL}usd"] [data-test-overlay-edit]`,
-      )
-      .exists()
-      .isNotDisabled();
-    assert
-      .dom(
         `[data-test-overlay-card="${testRealmURL}usd"] [data-test-overlay-more-options]`,
       )
       .exists()
       .isNotDisabled();
+    await click(
+      `[data-test-overlay-card="${testRealmURL}usd"] [data-test-overlay-more-options]`,
+    );
+    assert
+      .dom('[data-test-boxel-menu-item-text="Edit"]')
+      .exists('Edit menu item exposed for editable linked card');
 
     await click(
       '[data-test-field="denomination"] [data-test-links-to-editor] [data-test-remove-card]',

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -597,6 +597,12 @@ module('Integration | card-delete', function (hooks) {
     assert
       .dom('[data-test-copy-button]')
       .containsText('Copy 2 Cards', 'button text is correct');
+    // The per-card more-options menu lives inside the type-label tab, which
+    // only renders on hover — re-hover Pet/mango to surface it again.
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealmURL}Pet/mango"] .field-component-card`,
+      'mouseenter',
+    );
     await click(
       `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-more-options]`,
     );

--- a/packages/host/tests/integration/components/overlay-menu-items-test.gts
+++ b/packages/host/tests/integration/components/overlay-menu-items-test.gts
@@ -143,7 +143,8 @@ module('Integration | overlay-menu-items', function (hooks) {
         'card-with-custom-menu.gts': { CardWithCustomMenu },
         'parent-card.gts': { ParentCard },
         'parent-with-file.gts': { ParentWithFile },
-        'notes.md': '# Hello\n\nMarkdown content for the FileDef overlay test.',
+        'ParentWithFile/notes.md':
+          '# Hello\n\nMarkdown content for the FileDef overlay test.',
         'index.json': {
           data: {
             type: 'card',

--- a/packages/host/tests/integration/components/overlay-menu-items-test.gts
+++ b/packages/host/tests/integration/components/overlay-menu-items-test.gts
@@ -288,7 +288,9 @@ module('Integration | overlay-menu-items', function (hooks) {
       },
     );
     let fileURL = `${testRealmURL}ParentWithFile/notes.md`;
-    let fileCardSelector = `[data-test-overlay-card="${fileURL}"]`;
+    // The overlay strips the file extension from cardId for its data-test
+    // attributes (removeFileExtension), so data-test-overlay-card lacks `.md`.
+    let fileCardSelector = `[data-test-overlay-card="${testRealmURL}ParentWithFile/notes"]`;
     await waitFor(`[data-test-card="${fileURL}"]`);
     await triggerEvent(`[data-test-card="${fileURL}"]`, 'mouseenter');
     await waitFor(`${fileCardSelector} [data-test-overlay-more-options]`);

--- a/packages/host/tests/integration/components/overlay-menu-items-test.gts
+++ b/packages/host/tests/integration/components/overlay-menu-items-test.gts
@@ -287,12 +287,10 @@ module('Integration | overlay-menu-items', function (hooks) {
         <template><OperatorMode @onClose={{noop}} /></template>
       },
     );
-    let fileCardSelector = `[data-test-overlay-card="${testRealmURL}notes.md"]`;
-    await waitFor(`[data-test-card="${testRealmURL}notes.md"]`);
-    await triggerEvent(
-      `[data-test-card="${testRealmURL}notes.md"]`,
-      'mouseenter',
-    );
+    let fileURL = `${testRealmURL}ParentWithFile/notes.md`;
+    let fileCardSelector = `[data-test-overlay-card="${fileURL}"]`;
+    await waitFor(`[data-test-card="${fileURL}"]`);
+    await triggerEvent(`[data-test-card="${fileURL}"]`, 'mouseenter');
     await waitFor(`${fileCardSelector} [data-test-overlay-more-options]`);
 
     assert

--- a/packages/host/tests/integration/components/overlay-menu-items-test.gts
+++ b/packages/host/tests/integration/components/overlay-menu-items-test.gts
@@ -71,11 +71,14 @@ module('Integration | overlay-menu-items', function (hooks) {
 
     let cardApi: typeof import('https://cardstack.com/base/card-api');
     let string: typeof import('https://cardstack.com/base/string');
+    let markdownFileDef: typeof import('https://cardstack.com/base/markdown-file-def');
     cardApi = await loader.import(`${baseRealm.url}card-api`);
     string = await loader.import(`${baseRealm.url}string`);
+    markdownFileDef = await loader.import(`${baseRealm.url}markdown-file-def`);
 
     let { field, contains, linksTo, CardDef, Component } = cardApi;
     let { default: StringField } = string;
+    let { MarkdownDef } = markdownFileDef;
 
     class CardWithCustomMenu extends CardDef {
       static displayName = 'Card With Custom Menu';
@@ -117,11 +120,30 @@ module('Integration | overlay-menu-items', function (hooks) {
       };
     }
 
+    class ParentWithFile extends CardDef {
+      static displayName = 'Parent With File';
+      @field name = contains(StringField);
+      @field markdown = linksTo(MarkdownDef);
+      @field cardTitle = contains(StringField, {
+        computeVia: function (this: ParentWithFile) {
+          return this.name;
+        },
+      });
+      static isolated = class Isolated extends Component<typeof this> {
+        <template>
+          <h2 data-test-parent-with-file={{@model.name}}><@fields.name /></h2>
+          <@fields.markdown />
+        </template>
+      };
+    }
+
     await setupIntegrationTestRealm({
       mockMatrixUtils,
       contents: {
         'card-with-custom-menu.gts': { CardWithCustomMenu },
         'parent-card.gts': { ParentCard },
+        'parent-with-file.gts': { ParentWithFile },
+        'notes.md': '# Hello\n\nMarkdown content for the FileDef overlay test.',
         'index.json': {
           data: {
             type: 'card',
@@ -164,6 +186,31 @@ module('Integration | overlay-menu-items', function (hooks) {
               adoptsFrom: {
                 module: '../parent-card',
                 name: 'ParentCard',
+              },
+            },
+          },
+        },
+        'ParentWithFile/1.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              name: 'My Parent With File',
+            },
+            relationships: {
+              markdown: {
+                links: {
+                  self: './notes.md',
+                },
+                data: {
+                  type: 'file-meta',
+                  id: './notes.md',
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../parent-with-file',
+                name: 'ParentWithFile',
               },
             },
           },
@@ -230,5 +277,44 @@ module('Integration | overlay-menu-items', function (hooks) {
     assert
       .dom('[data-test-boxel-menu-item-text="Copy Card URL"]')
       .exists('Copy Card URL menu item is also present');
+  });
+
+  test('linked FileDef overlay menu uses file-specific labels', async function (assert) {
+    setCardInOperatorModeState([`${testRealmURL}ParentWithFile/1`]);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    let fileCardSelector = `[data-test-overlay-card="${testRealmURL}notes.md"]`;
+    await waitFor(`[data-test-card="${testRealmURL}notes.md"]`);
+    await triggerEvent(
+      `[data-test-card="${testRealmURL}notes.md"]`,
+      'mouseenter',
+    );
+    await waitFor(`${fileCardSelector} [data-test-overlay-more-options]`);
+
+    assert
+      .dom(`${fileCardSelector} [data-test-overlay-label]`)
+      .containsText(
+        'Markdown',
+        "type-label tab uses the FileDef's displayName, not the generic 'Card' fallback",
+      );
+
+    await click(`${fileCardSelector} [data-test-overlay-more-options]`);
+    assert
+      .dom('[data-test-boxel-menu-item-text="View file"]')
+      .exists('menu shows View file, not View card');
+    assert
+      .dom('[data-test-boxel-menu-item-text="View card"]')
+      .doesNotExist('the card-flavored label is suppressed for file targets');
+    assert
+      .dom('[data-test-boxel-menu-item-text="Copy File URL"]')
+      .exists('menu shows Copy File URL, not Copy Card URL');
+    assert
+      .dom('[data-test-boxel-menu-item-text="Copy Card URL"]')
+      .doesNotExist(
+        'the card-flavored URL label is suppressed for file targets',
+      );
   });
 });

--- a/packages/realm-server/tests/search-prerendered-test.ts
+++ b/packages/realm-server/tests/search-prerendered-test.ts
@@ -233,6 +233,15 @@ module(basename(__filename), function () {
                 json.meta.isFileMeta,
                 `isFileMeta flag is set for ${format} file-meta query`,
               );
+              assert.strictEqual(
+                json.data[0].attributes.cardType,
+                'Markdown',
+                `${format} result carries the FileDef subclass display name as cardType`,
+              );
+              assert.ok(
+                json.data[0].attributes.iconHtml,
+                `${format} result carries the FileDef subclass iconHtml`,
+              );
             }
           });
         },

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -439,6 +439,7 @@ export class IndexQueryEngine {
       embedded_html: embeddedHtml,
       fitted_html: fittedHtml,
       atom_html: atomHtml,
+      icon_html: iconHtml,
       markdown,
       realm_version: realmVersion,
       realm_url: realmURL,
@@ -466,6 +467,7 @@ export class IndexQueryEngine {
       embeddedHtml,
       fittedHtml,
       atomHtml,
+      iconHtml: iconHtml ?? null,
       markdown,
       lastModified: lastModified != null ? parseInt(lastModified) : null,
       resourceCreatedAt:

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -88,6 +88,7 @@ export interface IndexedFile {
   embeddedHtml: { [refURL: string]: string } | null;
   fittedHtml: { [refURL: string]: string } | null;
   atomHtml: string | null;
+  iconHtml: string | null;
   markdown: string | null;
   realmVersion: number;
   realmURL: string;
@@ -655,7 +656,7 @@ export class IndexQueryEngine {
       { filter, sort, page },
       opts,
       [
-        'SELECT url, ANY_VALUE(pristine_doc) AS pristine_doc, ANY_VALUE(search_doc) AS search_doc, ANY_VALUE(types) AS types, ANY_VALUE(display_names) AS display_names, ANY_VALUE(deps) AS deps, ANY_VALUE(last_modified) AS last_modified, ANY_VALUE(resource_created_at) AS resource_created_at, ANY_VALUE(isolated_html) AS isolated_html, ANY_VALUE(head_html) AS head_html, ANY_VALUE(embedded_html) AS embedded_html, ANY_VALUE(fitted_html) AS fitted_html, ANY_VALUE(atom_html) AS atom_html, ANY_VALUE(markdown) AS markdown, ANY_VALUE(realm_version) AS realm_version, ANY_VALUE(realm_url) AS realm_url, ANY_VALUE(indexed_at) AS indexed_at',
+        'SELECT url, ANY_VALUE(pristine_doc) AS pristine_doc, ANY_VALUE(search_doc) AS search_doc, ANY_VALUE(types) AS types, ANY_VALUE(display_names) AS display_names, ANY_VALUE(deps) AS deps, ANY_VALUE(last_modified) AS last_modified, ANY_VALUE(resource_created_at) AS resource_created_at, ANY_VALUE(isolated_html) AS isolated_html, ANY_VALUE(head_html) AS head_html, ANY_VALUE(embedded_html) AS embedded_html, ANY_VALUE(fitted_html) AS fitted_html, ANY_VALUE(atom_html) AS atom_html, ANY_VALUE(icon_html) AS icon_html, ANY_VALUE(markdown) AS markdown, ANY_VALUE(realm_version) AS realm_version, ANY_VALUE(realm_url) AS realm_url, ANY_VALUE(indexed_at) AS indexed_at',
       ],
       'file',
     );
@@ -696,6 +697,7 @@ export class IndexQueryEngine {
       fittedHtml:
         (result.fitted_html as { [refURL: string]: string } | null) ?? null,
       atomHtml: result.atom_html ?? null,
+      iconHtml: result.icon_html ?? null,
       markdown: result.markdown ?? null,
       lastModified,
       resourceCreatedAt,

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -523,6 +523,8 @@ export class RealmIndexQueryEngine {
     return {
       url: file.canonicalURL,
       html,
+      ...(file.displayNames?.[0] ? { cardType: file.displayNames[0] } : {}),
+      ...(file.iconHtml ? { iconHtml: file.iconHtml } : {}),
       ...(usedRenderType ? { usedRenderType } : {}),
     };
   }


### PR DESCRIPTION
## Summary

- Per-card operator-mode overlay rebuilt to the **Adorn** pattern from CS-11207: hover-only type-label tab carrying the per-card menu (3-dots), bottom-right rounded-square select chip, and `box-shadow` strokes that follow the card's actual `border-radius` (2px on hover, 4px on selected, darker accent on hover-on-selected).
- **Edit** moves off the floating pencil into the per-card menu (next to View / Copy URL / Delete).
- Stack-header **multi-select chip** restyled to teal with `[✓ N ▼]`; its dropdown gets a teal `N Selected` header above the existing Select All / Deselect All / Delete N items.
- New base-overlay hooks (`shouldDelayHoverClear`, `shouldSwallowCardClick`) so the chrome stays mounted while a portal'd dropdown is open and so the dismiss-click doesn't ALSO open the card underneath.

## Test plan

- [ ] Cards-grid: hover a card and confirm the teal type-label tab + bottom-right circle, 2px stroke.
- [ ] Click the select chip, confirm 4px stroke + filled check.
- [ ] Hover a selected card, confirm stroke shifts to the darker accent.
- [ ] Open the per-card 3-dots menu, walk the mouse from the chip → menu → menu item without the menu disappearing.
- [ ] Click anywhere outside the open menu; the menu closes, the card underneath does *not* open.
- [ ] Select 2+ cards; confirm the teal count chip in the stack header, open it, see the `N Selected` header + Select All / Deselect All / Delete N items.
- [ ] Pre-existing overlay tests still pass (one integration + four acceptance tests updated to walk the new menu).

## Deferred (out of tight scope)

- The Figma-asset texture overlay Chris's POC layers on the bar — left out pending designer confirmation of whether that's intended for production and an asset commitable to the repo.
- The JS-driven flip-left + portal-clone behavior the POC uses when the bar overflows past the card's right edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)