### PR TITLE
Change relativeTo parameter to accept RRIs

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -91,7 +91,7 @@ import {
   runtimeQueryDependencyContext,
   type RuntimeDependencyTrackingContext,
   resolveCardReference,
-  cardIdToURL,
+  rri,
   type RealmResourceIdentifier,
 } from '@cardstack/runtime-common';
 import {
@@ -540,7 +540,7 @@ export interface Field<
     store: CardStore | undefined,
     instancePromise: Promise<BaseDef>,
     loadedValue: any,
-    relativeTo: URL | undefined,
+    relativeTo: RealmResourceIdentifier | URL | undefined,
     opts?: DeserializeOpts,
   ): Promise<any>;
   emptyValue(instance: BaseDef): any;
@@ -760,7 +760,7 @@ class ContainsMany<FieldT extends FieldDefConstructor> implements Field<
     store: CardStore,
     instancePromise: Promise<BaseDef>,
     _loadedValue: any,
-    relativeTo: URL | undefined,
+    relativeTo: RealmResourceIdentifier | URL | undefined,
     opts: DeserializeOpts,
   ): Promise<BaseInstanceType<FieldT>[] | null> {
     if (value == null) {
@@ -1053,7 +1053,7 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
     store: CardStore,
     _instancePromise: Promise<BaseDef>,
     _loadedValue: any,
-    relativeTo: URL | undefined,
+    relativeTo: RealmResourceIdentifier | URL | undefined,
     opts: DeserializeOpts,
   ): Promise<BaseInstanceType<CardT>> {
     if (primitive in this.card) {
@@ -1325,7 +1325,7 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
     store: CardStore,
     _instancePromise: Promise<CardDef>,
     loadedValue: any,
-    relativeTo: URL | undefined,
+    relativeTo: RealmResourceIdentifier | URL | undefined,
     opts: DeserializeOpts,
   ): Promise<BaseInstanceType<CardT> | null | NotLoadedValue> {
     if (!isRelationship(value)) {
@@ -1821,7 +1821,7 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
     store: CardStore,
     instancePromise: Promise<BaseDef>,
     loadedValues: any,
-    relativeTo: URL | undefined,
+    relativeTo: RealmResourceIdentifier | URL | undefined,
     opts: DeserializeOpts,
   ): Promise<(BaseInstanceType<FieldT> | NotLoadedValue)[]> {
     let relationships: Relationship[];
@@ -2191,7 +2191,7 @@ export class BaseDef {
   // may contain interior fields that have relative links. FieldDef's though have no ID.
   // So we need a [relativeTo] property that derives from the root document ID in order to
   // resolve relative links at the FieldDef level.
-  [relativeTo]: URL | undefined = undefined;
+  [relativeTo]: RealmResourceIdentifier | URL | undefined = undefined;
   [meta]: CardResourceMeta | undefined = undefined;
   declare ['constructor']: BaseDefConstructor;
   static baseDef: undefined;
@@ -2300,7 +2300,7 @@ export class BaseDef {
   static async [deserialize]<T extends BaseDefConstructor>(
     this: T,
     data: any,
-    relativeTo: URL | undefined,
+    relativeTo: RealmResourceIdentifier | URL | undefined,
     doc?: CardDocument,
     store?: CardStore,
     opts?: DeserializeOpts,
@@ -2341,7 +2341,7 @@ export class Component<
 
 export type CreateCardFn = (
   ref: CodeRef,
-  relativeTo: URL | undefined,
+  relativeTo: RealmResourceIdentifier | URL | undefined,
   opts?: {
     realmURL?: URL; // the realm to create the card in
     localDir?: LocalPath; // the local directory path within the realm to create the card file
@@ -3293,7 +3293,7 @@ function lazilyLoadLink(
         fieldValue = (await createFromSerialized(
           fileMetaDoc.data,
           fileMetaDoc,
-          cardIdToURL(fileMetaDoc.data.id!),
+          fileMetaDoc.data.id!,
           { store, dependencyTrackingContext },
         )) as FileDef;
       } else {
@@ -3309,7 +3309,7 @@ function lazilyLoadLink(
         fieldValue = (await createFromSerialized(
           cardDoc.data,
           cardDoc,
-          cardIdToURL(cardDoc.data.id!),
+          cardDoc.data.id!,
           { store, dependencyTrackingContext },
         )) as CardDef;
       }
@@ -3548,7 +3548,7 @@ async function getDeserializedValue<CardT extends BaseDefConstructor>({
   modelPromise: Promise<BaseDef>;
   doc: LooseSingleCardDocument | CardDocument;
   store: CardStore;
-  relativeTo: URL | undefined;
+  relativeTo: RealmResourceIdentifier | URL | undefined;
   opts?: DeserializeOpts;
 }): Promise<any> {
   let field = getField(isCardInstance(value) ? value : card, fieldName);
@@ -3588,7 +3588,7 @@ export async function createFromSerialized<T extends BaseDefConstructor>(
   doc:
     | LooseSingleResourceDocument<CardResource | FileMetaResource>
     | LinkableDocument,
-  relativeTo: URL | undefined,
+  relativeTo: RealmResourceIdentifier | URL | undefined,
   opts?: DeserializeOpts & {
     store?: CardStore;
     dependencyTrackingContext?: RuntimeDependencyTrackingContext;
@@ -3634,7 +3634,7 @@ export async function updateFromSerialized<T extends BaseDefConstructor>(
 ): Promise<BaseInstanceType<T>> {
   stores.set(instance, store);
   if (!instance[relativeTo] && doc.data.id) {
-    instance[relativeTo] = cardIdToURL(doc.data.id);
+    instance[relativeTo] = rri(doc.data.id);
   }
 
   if (isCardInstance(instance)) {
@@ -3660,7 +3660,7 @@ async function _createFromSerialized<T extends BaseDefConstructor>(
   card: T,
   data: T extends { [primitive]: infer P } ? P : LooseCardResource,
   doc: LooseSingleCardDocument | CardDocument | undefined,
-  _relativeTo: URL | undefined,
+  _relativeTo: RealmResourceIdentifier | URL | undefined,
   store: CardStore = new FallbackCardStore(),
   opts?: DeserializeOpts,
 ): Promise<BaseInstanceType<T>> {
@@ -3757,10 +3757,10 @@ async function _updateFromSerialized<T extends BaseDefConstructor>({
 
   let existingOverrides = getFieldOverrides(instance);
   let loadedValues = getDataBucket(instance);
-  let instanceRelativeTo =
+  let instanceRelativeTo: RealmResourceIdentifier | URL | undefined =
     instance[relativeTo] ??
     ('id' in instance && typeof instance.id === 'string'
-      ? cardIdToURL(instance.id)
+      ? (instance.id as RealmResourceIdentifier)
       : undefined);
 
   function getFieldMeta(
@@ -3830,10 +3830,7 @@ async function _updateFromSerialized<T extends BaseDefConstructor>({
       // Prefer the deserialization context (instanceRelativeTo) so overrides resolve
       // relative to the document we fetched (e.g. catalog/index), then fall back to the resource id.
       relativeTo:
-        instanceRelativeTo ??
-        (resource.id && typeof resource.id === 'string'
-          ? cardIdToURL(resource.id)
-          : undefined),
+        instanceRelativeTo ?? (resource.id ? rri(resource.id) : undefined),
       dependencyTrackingContext: opts?.dependencyTrackingContext,
     });
     if (!override) {
@@ -3940,10 +3937,10 @@ async function _updateFromSerialized<T extends BaseDefConstructor>({
         field = (getField(instance, fieldName) ?? field) as Field<T>;
       }
       // Prefer the deserialization context ([relativeTo]) when available; fall back to the instance id
-      let relativeToVal =
+      let relativeToVal: RealmResourceIdentifier | URL | undefined =
         instance[relativeTo] ??
         ('id' in instance && typeof instance.id === 'string'
-          ? cardIdToURL(instance.id)
+          ? (instance.id as RealmResourceIdentifier)
           : undefined);
       let deserializedValue = await getDeserializedValue({
         card,

--- a/packages/base/card-serialization.ts
+++ b/packages/base/card-serialization.ts
@@ -11,6 +11,7 @@ import type {
   LooseSingleCardDocument,
   LooseSingleFileMetaDocument,
   Meta,
+  RealmResourceIdentifier,
   RuntimeDependencyTrackingContext,
   SingleFileMetaDocument,
 } from '@cardstack/runtime-common';
@@ -40,6 +41,7 @@ import {
   meta,
   primitive,
   relativeTo,
+  rri,
 } from '@cardstack/runtime-common';
 import { getFieldOverrides, getFields, serializedGet } from './field-support';
 
@@ -100,7 +102,7 @@ function myLoader(): Loader {
 export async function cardClassFromResource<CardT extends BaseDefConstructor>(
   resource: LooseCardResource | CardResource | FileMetaResource | undefined,
   fallback: CardT,
-  relativeTo: URL | undefined,
+  relativeTo: RealmResourceIdentifier | URL | undefined,
 ): Promise<CardT> {
   let cardIdentity = identifyCard(fallback);
   if (!cardIdentity) {
@@ -113,8 +115,7 @@ export async function cardClassFromResource<CardT extends BaseDefConstructor>(
       resource.meta.adoptsFrom,
       {
         loader: myLoader(),
-        relativeTo:
-          relativeTo ?? (resource.id ? cardIdToURL(resource.id) : undefined),
+        relativeTo: relativeTo ?? (resource.id ? rri(resource.id) : undefined),
       },
     );
     if (!card) {
@@ -216,10 +217,8 @@ export function serializeCard(
       ...(model.id != null ? { id: model.id } : { lid: model[localId] }),
     },
   };
-  let modelRelativeTo =
-    model.id != null
-      ? cardIdToURL(model.id)
-      : (model[relativeTo] as URL | undefined);
+  let modelRelativeTo: RealmResourceIdentifier | URL | undefined =
+    model.id ?? model[relativeTo];
   let data = serializeCardResource(model, doc, {
     ...opts,
     ...{
@@ -229,7 +228,11 @@ export function serializeCard(
         if (isRegisteredPrefix(possibleReference)) {
           return possibleReference;
         }
-        let url = maybeURL(possibleReference, modelRelativeTo);
+        let modelRelativeToForURL =
+          typeof modelRelativeTo === 'string'
+            ? cardIdToURL(modelRelativeTo)
+            : modelRelativeTo;
+        let url = maybeURL(possibleReference, modelRelativeToForURL);
         if (!url) {
           throw new Error(
             `could not determine url from '${possibleReference}' relative to ${modelRelativeTo}`,
@@ -313,10 +316,8 @@ export function serializeFileDef(
       ...(model.id != null ? { id: model.id } : {}),
     },
   };
-  let modelRelativeTo =
-    model.id != null
-      ? cardIdToURL(model.id)
-      : (model[relativeTo] as URL | undefined);
+  let modelRelativeTo: RealmResourceIdentifier | URL | undefined =
+    model.id ?? model[relativeTo];
   let data = serializeCardResource(
     model,
     doc,
@@ -329,7 +330,11 @@ export function serializeFileDef(
           if (isRegisteredPrefix(possibleReference)) {
             return possibleReference;
           }
-          let url = maybeURL(possibleReference, modelRelativeTo);
+          let modelRelativeToForURL =
+            typeof modelRelativeTo === 'string'
+              ? cardIdToURL(modelRelativeTo)
+              : modelRelativeTo;
+          let url = maybeURL(possibleReference, modelRelativeToForURL);
           if (!url) {
             throw new Error(
               `could not determine url from '${possibleReference}' relative to ${modelRelativeTo}`,

--- a/packages/base/rich-markdown.gts
+++ b/packages/base/rich-markdown.gts
@@ -1,4 +1,5 @@
 import {
+  cardIdToURL,
   extractCardReferenceUrls,
   fieldSerializer,
   relativeTo,
@@ -53,7 +54,12 @@ export class RichMarkdownField extends FieldDef {
       if (!this.content) {
         return [];
       }
-      let baseUrl = this[relativeTo]?.href ?? '';
+      let rel = this[relativeTo];
+      let baseUrl = rel
+        ? typeof rel === 'string'
+          ? cardIdToURL(rel).href
+          : rel.href
+        : '';
       return extractCardReferenceUrls(this.content, baseUrl);
     },
   });
@@ -73,7 +79,11 @@ export class RichMarkdownField extends FieldDef {
       return this.args.model?.content ?? null;
     }
     get baseUrl(): string | null {
-      return this.args.model?.[relativeTo]?.href ?? null;
+      let rel = this.args.model?.[relativeTo];
+      if (!rel) {
+        return null;
+      }
+      return typeof rel === 'string' ? cardIdToURL(rel).href : rel.href;
     }
     <template>
       <MarkdownTemplate
@@ -89,7 +99,11 @@ export class RichMarkdownField extends FieldDef {
       return this.args.model?.content ?? null;
     }
     get baseUrl(): string | null {
-      return this.args.model?.[relativeTo]?.href ?? null;
+      let rel = this.args.model?.[relativeTo];
+      if (!rel) {
+        return null;
+      }
+      return typeof rel === 'string' ? cardIdToURL(rel).href : rel.href;
     }
     <template>
       <MarkdownTemplate
@@ -121,7 +135,11 @@ export class RichMarkdownField extends FieldDef {
       this.args.model.content = markdown;
     };
     get baseUrl(): string | null {
-      return this.args.model?.[relativeTo]?.href ?? null;
+      let rel = this.args.model?.[relativeTo];
+      if (!rel) {
+        return null;
+      }
+      return typeof rel === 'string' ? cardIdToURL(rel).href : rel.href;
     }
     get linkedCards(): CardDef[] | null {
       try {

--- a/packages/base/spec.gts
+++ b/packages/base/spec.gts
@@ -145,7 +145,7 @@ export class SpecHeader extends GlimmerComponent<SpecHeaderSignature> {
         if (this.args.model.ref && this.args.model.id) {
           let cardDef = await loadCardDef(this.args.model.ref, {
             loader: myLoader(),
-            relativeTo: cardIdToURL(this.args.model.id),
+            relativeTo: this.args.model.id,
           });
           cardDefObj.value = cardDef;
         }
@@ -377,7 +377,7 @@ export class SpecExamplesSection extends GlimmerComponent<SpecExamplesSectionSig
         if (this.args.model.ref && this.args.model.id) {
           let cardDef = await loadCardDef(this.args.model.ref, {
             loader: myLoader(),
-            relativeTo: cardIdToURL(this.args.model.id),
+            relativeTo: this.args.model.id,
           });
           cardDefObj.value = cardDef;
         }
@@ -720,7 +720,7 @@ class Fitted extends Component<typeof Spec> {
         if (this.args.model.ref && this.args.model.id) {
           let card = await loadCardDef(this.args.model.ref, {
             loader: myLoader(),
-            relativeTo: cardIdToURL(this.args.model.id),
+            relativeTo: this.args.model.id,
           });
           icon.value = card.icon;
         }

--- a/packages/experiments-realm/asset.gts
+++ b/packages/experiments-realm/asset.gts
@@ -6,6 +6,7 @@ import {
   Component,
   relativeTo,
 } from 'https://cardstack.com/base/card-api';
+import { cardIdToURL } from '@cardstack/runtime-common';
 import StringField from 'https://cardstack.com/base/string';
 import CurrencyIcon from '@cardstack/boxel-icons/currency';
 import CircleDotIcon from '@cardstack/boxel-icons/circle-dot';
@@ -20,7 +21,10 @@ export class Asset extends CardDef {
       if (!this.logoURL) {
         return null;
       }
-      return new URL(this.logoURL, this[relativeTo] || this.id).href;
+      let rel = this[relativeTo] || this.id;
+      let base =
+        typeof rel === 'string' ? cardIdToURL(rel) : rel;
+      return new URL(this.logoURL, base).href;
     },
   });
   @field cardTitle = contains(StringField, {
@@ -89,7 +93,10 @@ class AssetField extends FieldDef {
       if (!this.logoURL) {
         return null;
       }
-      return new URL(this.logoURL, this[relativeTo] || this.id).href;
+      let rel = this[relativeTo] || this.id;
+      let base =
+        typeof rel === 'string' ? cardIdToURL(rel) : rel;
+      return new URL(this.logoURL, base).href;
     },
   });
   @field cardTitle = contains(StringField, {

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -32,7 +32,6 @@ import {
 } from '@cardstack/boxel-ui/icons';
 
 import {
-  cardIdToURL,
   specRef,
   chooseCard,
   baseRealm,
@@ -946,7 +945,7 @@ export class ${className} extends ${exportName} {
 
     let { ref } = (this.definitionClass ? this.definitionClass : spec)!; // we just checked above to make sure one of these exist
 
-    let relativeTo = spec?.id ? cardIdToURL(spec.id) : undefined;
+    let relativeTo = spec?.id;
     // we make the code ref use an absolute URL for safety in
     // the case it's being created in a different realm than where the card
     // definition comes from. The server will make relative URL if appropriate after creation

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -23,6 +23,7 @@ import {
   isCardError,
   isBaseDefInstance,
   cardIdToURL,
+  rri,
   type CardErrorsJSONAPI,
   type LooseSingleCardDocument,
   type RealmIdentifier,
@@ -532,7 +533,7 @@ export default class RenderRoute extends Route<Model> {
 
           (globalThis as any).__boxelSetRenderStage?.('buildModel:hydrating');
           let hydratedInstance = await this.store.add(enhancedDoc, {
-            relativeTo: cardIdToURL(id),
+            relativeTo: rri(id),
             realm: realmURL,
             doNotPersist: true,
           });

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -854,10 +854,7 @@ export default class StoreService extends Service implements StoreInterface {
     if (patch.meta) {
       doc.data.meta = merge(doc.data.meta, patch.meta);
     }
-    let linkedCards = await this.loadPatchedInstances(
-      patch,
-      instance.id ? cardIdToURL(instance.id) : undefined,
-    );
+    let linkedCards = await this.loadPatchedInstances(patch, instance.id);
     for (let [field, value] of Object.entries(linkedCards)) {
       if (field.includes('.')) {
         let parts = field.split('.');
@@ -1362,7 +1359,7 @@ export default class StoreService extends Service implements StoreInterface {
   private async createFromSerialized<T extends CardDef>(
     resource: LooseCardResource,
     doc: LooseSingleCardDocument | CardDocument,
-    relativeTo?: URL | undefined,
+    relativeTo?: RealmResourceIdentifier | URL | undefined,
     dependencyTrackingContext?: RuntimeDependencyTrackingContext,
   ): Promise<T> {
     let api = await this.cardService.getAPI();
@@ -1667,7 +1664,7 @@ export default class StoreService extends Service implements StoreInterface {
   protected async createFileMetaFromSerialized(
     resource: LooseLinkableResource<FileMetaResource>,
     doc: LooseSingleResourceDocument<FileMetaResource>,
-    relativeTo: URL | undefined,
+    relativeTo: RealmResourceIdentifier | URL | undefined,
     dependencyTrackingContext?: RuntimeDependencyTrackingContext,
   ): Promise<FileDef> {
     let api = await this.cardService.getAPI();
@@ -1700,7 +1697,7 @@ export default class StoreService extends Service implements StoreInterface {
       return this.createFileMetaFromSerialized(
         resource,
         doc,
-        cardIdToURL(resource.id),
+        resource.id,
         dependencyTrackingContext,
       ) as Promise<T>;
     }
@@ -1715,7 +1712,7 @@ export default class StoreService extends Service implements StoreInterface {
     (resource as any)[queryFieldSeedFromSearchSymbol] = true;
     return this.add({ data: resource } as SingleCardDocument, {
       doNotPersist: true,
-      relativeTo: cardIdToURL(resource.id),
+      relativeTo: resource.id,
       dependencyTrackingContext,
     }) as Promise<T>;
   }
@@ -1752,7 +1749,7 @@ export default class StoreService extends Service implements StoreInterface {
     opts,
   }: {
     idOrDoc: string | LooseSingleCardDocument;
-    relativeTo?: URL;
+    relativeTo?: RealmResourceIdentifier | URL;
     realm?: string; // used for new cards
     opts?: {
       noCache?: boolean;
@@ -1859,8 +1856,14 @@ export default class StoreService extends Service implements StoreInterface {
         ${JSON.stringify(json, null, 2)}`,
           );
         }
-        if (!json.data.id) {
-          // card source format is not serialized with the ID, so we add that back in.
+        if (!json.data.id || !isResolvableInstanceId(json.data.id)) {
+          // Normalize the instance id to the canonical URL form when the
+          // server-returned doc is missing one, or when it carries a bare
+          // local id that doesn't resolve to a realm location (e.g. a
+          // system card with a hardcoded literal `data.id`). Without this,
+          // the bare id would be assigned to `instance.id` and later
+          // collide with the canonical URL form during re-deserialization
+          // (card-api.gts's "cannot change the id" guard).
           json.data.id = url as RealmResourceIdentifier;
         }
         if (!json.data.meta?.realmURL) {
@@ -1880,7 +1883,7 @@ export default class StoreService extends Service implements StoreInterface {
       let instance = await this.createFromSerialized(
         doc.data,
         doc,
-        cardIdToURL(doc.data.id!), // instances from the server will have id's
+        doc.data.id!, // normalized above to a URL/RRI by isResolvableInstanceId
         opts?.dependencyTrackingContext,
       );
       // in case the url is an alias for the id (like index card without the
@@ -1972,7 +1975,7 @@ export default class StoreService extends Service implements StoreInterface {
       let fileInstance = await api.createFromSerialized(
         fileMetaDoc.data,
         fileMetaDoc,
-        fileMetaDoc.data.id ? cardIdToURL(fileMetaDoc.data.id) : new URL(url),
+        fileMetaDoc.data.id ?? new URL(url),
         {
           store: this.store,
           dependencyTrackingContext: opts?.dependencyTrackingContext,
@@ -2378,7 +2381,7 @@ export default class StoreService extends Service implements StoreInterface {
 
   private async loadPatchedInstances(
     patchData: PatchData,
-    relativeTo: URL | undefined,
+    relativeTo: RealmResourceIdentifier | URL | undefined,
   ): Promise<{
     [fieldName: string]: CardDef | CardDef[];
   }> {
@@ -2412,7 +2415,7 @@ export default class StoreService extends Service implements StoreInterface {
 
   private async loadRelationshipInstance(
     rel: Relationship,
-    relativeTo: URL | undefined,
+    relativeTo: RealmResourceIdentifier | URL | undefined,
   ) {
     if (!rel.links?.self) {
       return;
@@ -2469,6 +2472,22 @@ function needsServerStateMerge(
   return (
     instance.id !== serverState.data.id ||
     !isEqual(instance[meta]?.realmInfo, serverState.data.meta.realmInfo)
+  );
+}
+
+// A doc's `data.id` can usually be resolved against either a registered
+// prefix (e.g. `@cardstack/base/foo`) or a URL form. Bare local ids that
+// match neither (e.g. a system card with a hardcoded literal `id` field)
+// can't be assigned to `instance.id` without later colliding with the
+// canonical URL form when the same doc is re-deserialized. Callers that
+// receive an id over the wire should pass it through this gate; if it
+// returns false the caller substitutes the canonical URL form before
+// deserialization.
+function isResolvableInstanceId(id: string): boolean {
+  return (
+    isRegisteredPrefix(id) ||
+    id.startsWith('http://') ||
+    id.startsWith('https://')
   );
 }
 

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1864,7 +1864,7 @@ export default class StoreService extends Service implements StoreInterface {
           // the bare id would be assigned to `instance.id` and later
           // collide with the canonical URL form during re-deserialization
           // (card-api.gts's "cannot change the id" guard).
-          json.data.id = url as RealmResourceIdentifier;
+          json.data.id = rri(url);
         }
         if (!json.data.meta?.realmURL) {
           // Source-mode loads in render context don't include realm metadata.

--- a/packages/runtime-common/commands.ts
+++ b/packages/runtime-common/commands.ts
@@ -3,6 +3,7 @@ import {
   isCardDef,
   codeRefWithAbsoluteIdentifier,
 } from './code-ref';
+import type { RealmResourceIdentifier } from './card-reference-resolver';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import type { CardDefConstructor } from 'https://cardstack.com/base/card-api';
 import type { AttributesSchema, CardSchema } from './helpers/ai';
@@ -116,7 +117,7 @@ function friendlyModuleName(fullModuleUrl: string) {
 
 export function buildCommandFunctionName(
   commandCodeRef: ResolvedCodeRef,
-  relativeTo?: URL,
+  relativeTo?: RealmResourceIdentifier | URL,
 ) {
   if (!commandCodeRef?.module || !commandCodeRef?.name) {
     return '';

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -810,7 +810,7 @@ export function isMatrixCardError(
 
 export type CreateNewCard = (
   ref: CodeRef,
-  relativeTo: URL | undefined,
+  relativeTo: RealmResourceIdentifier | URL | undefined,
   opts?: {
     isLinkedCard?: boolean;
     doc?: LooseSingleCardDocument;
@@ -821,7 +821,7 @@ export type CreateNewCard = (
 interface CardChooserOpts {
   offerToCreate?: {
     ref: CodeRef;
-    relativeTo: URL | undefined;
+    relativeTo: RealmResourceIdentifier | URL | undefined;
     realmURL: URL | undefined;
   };
   createNewCard?: CreateNewCard;
@@ -953,7 +953,7 @@ export type getSearchData = (
 export interface CreateOptions {
   realm?: string;
   localDir?: LocalPath;
-  relativeTo?: URL | undefined;
+  relativeTo?: RealmResourceIdentifier | URL | undefined;
 }
 
 export interface AddOptions extends CreateOptions {
@@ -1019,7 +1019,7 @@ export type CardCatalogQuery = Query & {
 export interface CardCreator {
   create(
     ref: CodeRef,
-    relativeTo: URL | undefined,
+    relativeTo: RealmResourceIdentifier | URL | undefined,
     opts?: {
       realmURL?: URL;
       doc?: LooseSingleCardDocument;
@@ -1097,7 +1097,7 @@ export function trimExecutableExtension(
 
 export function internalKeyFor(
   ref: CodeRef,
-  relativeTo: URL | undefined,
+  relativeTo: RealmResourceIdentifier | URL | undefined,
 ): string {
   if (!('type' in ref)) {
     let resolved = resolveCardReference(ref.module, relativeTo);

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -36,6 +36,7 @@ import type {
   RealmResourceIdentifier,
   RealmIdentifier,
 } from './card-reference-resolver';
+import { rri } from './card-reference-resolver';
 import {
   normalizeQueryForSignature,
   sortKeysDeep,
@@ -612,7 +613,9 @@ export class RealmIndexQueryEngine {
       return;
     }
 
-    let relativeTo = resource.id ? cardIdToURL(resource.id) : realmURL;
+    let relativeTo: RealmResourceIdentifier | URL = resource.id
+      ? rri(resource.id)
+      : realmURL;
     let codeRef = codeRefWithAbsoluteIdentifier(
       resource.meta.adoptsFrom,
       relativeTo,

--- a/packages/runtime-common/serializers/code-ref.ts
+++ b/packages/runtime-common/serializers/code-ref.ts
@@ -12,6 +12,7 @@ import {
   resolveCardReference,
   cardIdToURL,
   rri,
+  type RealmResourceIdentifier,
 } from '../card-reference-resolver';
 // We only use a subset of SerializeOpts here; accept any to align with the
 // serializer interface without surfacing unused properties.
@@ -50,7 +51,7 @@ export function serialize(
 export async function deserialize<T extends BaseDefConstructor>(
   this: T,
   codeRef: ResolvedCodeRef | {},
-  _relativeTo: URL | undefined,
+  _relativeTo: RealmResourceIdentifier | URL | undefined,
 ): Promise<BaseInstanceType<T>> {
   return { ...codeRef } as BaseInstanceType<T>; // return a new object so that the model cannot be mutated from the outside
 }
@@ -62,7 +63,7 @@ export function formatQuery(codeRef: ResolvedCodeRef | {}): string | undefined {
 export async function deserializeAbsolute<T extends BaseDefConstructor>(
   this: T,
   codeRef: ResolvedCodeRef | {},
-  relativeTo: URL | undefined,
+  relativeTo: RealmResourceIdentifier | URL | undefined,
 ): Promise<BaseInstanceType<T>> {
   return {
     ...codeRef,
@@ -72,7 +73,7 @@ export async function deserializeAbsolute<T extends BaseDefConstructor>(
 
 function codeRefAdjustments(
   codeRef: any,
-  relativeTo?: URL,
+  relativeTo?: RealmResourceIdentifier | URL,
   opts?: SerializeOpts & {
     trimExecutableExtension?: true;
     maybeRelativeReference?: (reference: string) => string;

--- a/packages/runtime-common/serializers/code-ref.ts
+++ b/packages/runtime-common/serializers/code-ref.ts
@@ -30,18 +30,20 @@ export function serialize(
   doc: any,
   _visited?: Set<string>,
   opts?: SerializeOpts & {
-    relativeTo?: URL;
+    relativeTo?: RealmResourceIdentifier | URL;
     trimExecutableExtension?: true;
     maybeRelativeReference?: (reference: string) => string;
     allowRelative?: true;
   },
 ): ResolvedCodeRef | {} {
-  let baseURL =
-    opts?.relativeTo instanceof URL
-      ? opts.relativeTo
-      : doc?.data?.id && typeof doc.data.id === 'string'
-        ? cardIdToURL(doc.data.id)
-        : undefined;
+  let baseURL: URL | undefined;
+  if (opts?.relativeTo instanceof URL) {
+    baseURL = opts.relativeTo;
+  } else if (typeof opts?.relativeTo === 'string') {
+    baseURL = cardIdToURL(opts.relativeTo);
+  } else if (doc?.data?.id && typeof doc.data.id === 'string') {
+    baseURL = cardIdToURL(doc.data.id);
+  }
   return {
     ...codeRef,
     ...codeRefAdjustments(codeRef, baseURL, opts),

--- a/packages/runtime-common/serializers/index.ts
+++ b/packages/runtime-common/serializers/index.ts
@@ -11,7 +11,7 @@ import * as ImageSizeSerializer from './image-size';
 import * as PhoneSerializer from './phone';
 import * as StringToContentSerializer from './string-to-content';
 
-import type { CardDocument } from '../index';
+import type { CardDocument, RealmResourceIdentifier } from '../index';
 import type {
   JSONAPISingleResourceDocument,
   SerializeOpts,
@@ -46,7 +46,7 @@ interface Serializer {
   ): any;
   deserialize<T extends BaseDefConstructor>(
     data: any,
-    relativeTo: URL | undefined,
+    relativeTo: RealmResourceIdentifier | URL | undefined,
     doc?: CardDocument,
     store?: CardStore,
     opts?: DeserializeOpts,


### PR DESCRIPTION
The intermediate goal here on the way to `@cardstack/base` is to remove `resolveCardReference`, prefix mappings, `cardIdToURL`. This is a step toward that, where `relativeTo` would then no longer accept URLs.