### PR TITLE
CS-11238: federated-search resolves registry-only realms

### DIFF
--- a/packages/realm-server/handlers/handle-federated-types.ts
+++ b/packages/realm-server/handlers/handle-federated-types.ts
@@ -10,21 +10,25 @@ import {
   getMultiRealmAuthorization,
   getSearchRequestPayload,
 } from '../middleware/multi-realm-authorization';
+import { resolveRealmsForFederatedRequest } from '../lib/realm-routing';
+import type { RealmRegistryReconciler } from '../lib/realm-registry-reconciler';
 import { getPublicReadableRealms } from '../utils/realm-readability';
 
 const log = logger('realm-server');
 
 export default function handleFederatedTypes({
   dbAdapter,
+  reconciler,
 }: {
   dbAdapter: DBAdapter;
+  reconciler: RealmRegistryReconciler;
 }): (ctxt: Koa.Context) => Promise<void> {
   return async function (ctxt: Koa.Context) {
-    let { realmList, realmByURL } = getMultiRealmAuthorization(ctxt);
-    let publicReadableRealms = await getPublicReadableRealms(
-      dbAdapter,
-      realmList,
-    );
+    let { realmList } = getMultiRealmAuthorization(ctxt);
+    let [publicReadableRealms, realmInstances] = await Promise.all([
+      getPublicReadableRealms(dbAdapter, realmList),
+      resolveRealmsForFederatedRequest(reconciler, realmList),
+    ]);
 
     let payload = getSearchRequestPayload(ctxt) as
       | {
@@ -38,8 +42,9 @@ export default function handleFederatedTypes({
 
     let allEntries: FederatedCardTypeSummaryEntry[] = [];
 
-    for (let realmURL of realmList) {
-      let realm = realmByURL.get(realmURL);
+    for (let i = 0; i < realmList.length; i++) {
+      let realmURL = realmList[i];
+      let realm = realmInstances[i];
       if (!realm) {
         continue;
       }

--- a/packages/realm-server/handlers/handle-realm-info.ts
+++ b/packages/realm-server/handlers/handle-realm-info.ts
@@ -4,26 +4,31 @@ import { logger, SupportedMimeType } from '@cardstack/runtime-common';
 
 import { setContextResponse } from '../middleware';
 import { getMultiRealmAuthorization } from '../middleware/multi-realm-authorization';
+import { resolveRealmsForFederatedRequest } from '../lib/realm-routing';
+import type { RealmRegistryReconciler } from '../lib/realm-registry-reconciler';
 import { getPublicReadableRealms } from '../utils/realm-readability';
 
 const log = logger('realm-server');
 
 export default function handleRealmInfo({
   dbAdapter,
+  reconciler,
 }: {
   dbAdapter: DBAdapter;
+  reconciler: RealmRegistryReconciler;
 }): (ctxt: Koa.Context) => Promise<void> {
   return async function (ctxt: Koa.Context) {
-    let { realmList, realmByURL } = getMultiRealmAuthorization(ctxt);
-    let publicReadableRealms = await getPublicReadableRealms(
-      dbAdapter,
-      realmList,
-    );
+    let { realmList } = getMultiRealmAuthorization(ctxt);
+    let [publicReadableRealms, realmInstances] = await Promise.all([
+      getPublicReadableRealms(dbAdapter, realmList),
+      resolveRealmsForFederatedRequest(reconciler, realmList),
+    ]);
 
     let data: { id: string; type: 'realm-info'; attributes: RealmInfo }[] = [];
 
-    for (let realmURL of realmList) {
-      let realm = realmByURL.get(realmURL);
+    for (let i = 0; i < realmList.length; i++) {
+      let realmURL = realmList[i];
+      let realm = realmInstances[i];
       if (!realm) {
         continue;
       }

--- a/packages/realm-server/handlers/handle-search-prerendered.ts
+++ b/packages/realm-server/handlers/handle-search-prerendered.ts
@@ -19,18 +19,21 @@ import {
   getMultiRealmAuthorization,
   getSearchRequestPayload,
 } from '../middleware/multi-realm-authorization';
+import { resolveRealmsForFederatedRequest } from '../lib/realm-routing';
+import type { RealmRegistryReconciler } from '../lib/realm-registry-reconciler';
 import type { JobScopedSearchCache } from '../job-scoped-search-cache';
 import {
   PRERENDER_JOB_ID_HEADER,
   sanitizePrerenderJobId,
 } from '../prerender/prerender-constants';
 
-export default function handleSearchPrerendered(opts?: {
+export default function handleSearchPrerendered(opts: {
+  reconciler: RealmRegistryReconciler;
   searchCache?: JobScopedSearchCache;
 }): (ctxt: Koa.Context) => Promise<void> {
-  let searchCache = opts?.searchCache;
+  let { reconciler, searchCache } = opts;
   return async function (ctxt: Koa.Context) {
-    let { realmList, realmByURL } = getMultiRealmAuthorization(ctxt);
+    let { realmList } = getMultiRealmAuthorization(ctxt);
 
     let request = await fetchRequestFromContext(ctxt);
     let parsed;
@@ -57,16 +60,23 @@ export default function handleSearchPrerendered(opts?: {
       cardUrls: parsed.cardUrls,
       renderType: parsed.renderType,
     };
-    let runSearch = async () =>
-      JSON.stringify(
+    // Lazy-mount inside runSearch so cache hits (304 / cached body)
+    // skip the lazy-mount work entirely.
+    let runSearch = async () => {
+      let realmInstances = await resolveRealmsForFederatedRequest(
+        reconciler,
+        realmList,
+      );
+      return JSON.stringify(
         await searchPrerenderedRealms(
-          realmList.map((realmURL) => realmByURL.get(realmURL)),
+          realmInstances,
           parsed.cardsQuery,
           searchOpts,
         ),
         null,
         2,
       );
+    };
 
     // Symmetric to `_federated-search`'s gating. Cache is consulted
     // only when both indexer-traffic headers are present and well-

--- a/packages/realm-server/handlers/handle-search.ts
+++ b/packages/realm-server/handlers/handle-search.ts
@@ -20,6 +20,8 @@ import {
   getMultiRealmAuthorization,
   getSearchRequestPayload,
 } from '../middleware/multi-realm-authorization';
+import { resolveRealmsForFederatedRequest } from '../lib/realm-routing';
+import type { RealmRegistryReconciler } from '../lib/realm-registry-reconciler';
 import type { JobScopedSearchCache } from '../job-scoped-search-cache';
 import {
   PRERENDER_JOB_ID_HEADER,
@@ -28,12 +30,13 @@ import {
   sanitizePrerenderJobId,
 } from '../prerender/prerender-constants';
 
-export default function handleSearch(opts?: {
+export default function handleSearch(opts: {
+  reconciler: RealmRegistryReconciler;
   searchCache?: JobScopedSearchCache;
 }): (ctxt: Koa.Context) => Promise<void> {
-  let searchCache = opts?.searchCache;
+  let { reconciler, searchCache } = opts;
   return async function (ctxt: Koa.Context) {
-    let { realmList, realmByURL } = getMultiRealmAuthorization(ctxt);
+    let { realmList } = getMultiRealmAuthorization(ctxt);
 
     let cardsQuery;
     let request = await fetchRequestFromContext(ctxt);
@@ -72,16 +75,19 @@ export default function handleSearch(opts?: {
     if (jobPriority !== null) searchOpts.priority = jobPriority;
     let normalizedSearchOpts =
       Object.keys(searchOpts).length > 0 ? searchOpts : undefined;
-    let runSearch = async () =>
-      JSON.stringify(
-        await searchRealms(
-          realmList.map((realmURL) => realmByURL.get(realmURL)),
-          cardsQuery,
-          normalizedSearchOpts,
-        ),
+    // Lazy-mount inside runSearch so cache hits (304 / cached body)
+    // skip the lazy-mount work entirely.
+    let runSearch = async () => {
+      let realmInstances = await resolveRealmsForFederatedRequest(
+        reconciler,
+        realmList,
+      );
+      return JSON.stringify(
+        await searchRealms(realmInstances, cardsQuery, normalizedSearchOpts),
         null,
         2,
       );
+    };
 
     // Job-scoped cache. Gated on:
     //   (a) `x-boxel-job-id` is present and well-formed (only the

--- a/packages/realm-server/lib/realm-routing.ts
+++ b/packages/realm-server/lib/realm-routing.ts
@@ -249,6 +249,11 @@ export async function resolveRealmsForFederatedRequest(
   );
   return results.map((result, idx) => {
     if (result.status === 'fulfilled') {
+      if (result.value === undefined) {
+        federatedLog.warn(
+          `lookupOrMount fulfilled without a realm for ${realmList[idx]} during federated request; registry presence was already confirmed by middleware`,
+        );
+      }
       return result.value;
     }
     federatedLog.warn(

--- a/packages/realm-server/lib/realm-routing.ts
+++ b/packages/realm-server/lib/realm-routing.ts
@@ -5,6 +5,7 @@ import {
   executableExtensions,
   fetchRealmPermissions,
   hasExtension,
+  logger,
   param,
   query,
   RealmPaths,
@@ -14,6 +15,8 @@ import {
   indexURLCandidates,
 } from './index-url-utils';
 import type { RealmRegistryReconciler } from './realm-registry-reconciler';
+
+const federatedLog = logger('realm-server:federated');
 
 export type RealmRoutingDeps = {
   realms: Realm[];
@@ -227,6 +230,34 @@ export async function hasPublicPermissions(
   );
 
   return permissions['*']?.includes('read') ?? false;
+}
+
+// Resolve realms for a federated request (CS-11238). The
+// multiRealmAuthorization middleware has already confirmed every URL
+// is a registry row, but Phase 3 may not have mounted them yet — the
+// handler is responsible for lazy-mounting on demand. Each lookup is
+// independent (Promise.allSettled): a per-realm mount failure logs
+// + drops to undefined, matching searchRealms / handle-realm-info's
+// existing "skip missing realm, return partial results" semantics so
+// one broken realm does not 5xx the whole federated request.
+export async function resolveRealmsForFederatedRequest(
+  reconciler: RealmRegistryReconciler,
+  realmList: string[],
+): Promise<Array<Realm | undefined>> {
+  let results = await Promise.allSettled(
+    realmList.map((url) => reconciler.lookupOrMount(url)),
+  );
+  return results.map((result, idx) => {
+    if (result.status === 'fulfilled') {
+      return result.value;
+    }
+    federatedLog.warn(
+      `failed to lazy-mount realm ${realmList[idx]} for federated request: ${String(
+        result.reason,
+      )}`,
+    );
+    return undefined;
+  });
 }
 
 // Build candidate realm URLs from a request URL by trimming the

--- a/packages/realm-server/middleware/multi-realm-authorization.ts
+++ b/packages/realm-server/middleware/multi-realm-authorization.ts
@@ -2,11 +2,16 @@ import type Koa from 'koa';
 import type { DBAdapter, Realm } from '@cardstack/runtime-common';
 import {
   fetchUserPermissions,
+  param,
   parseRealmsFromPayload,
   parseSearchRequestPayload,
+  query,
   SearchRequestError,
+  separatedByCommas,
+  type Expression,
 } from '@cardstack/runtime-common';
 import { AuthenticationError } from '@cardstack/runtime-common/router';
+import type { RealmRegistryReconciler } from '../lib/realm-registry-reconciler';
 import { retrieveTokenClaim, type RealmServerTokenClaim } from '../utils/jwt';
 import {
   buildReadableRealms,
@@ -22,7 +27,6 @@ import {
 
 export type MultiRealmAuthorizationState = {
   realmList: string[];
-  realmByURL: Map<string, Realm>;
 };
 
 const MULTI_REALM_AUTH_STATE = 'multiRealmAuthorization';
@@ -32,10 +36,12 @@ export function multiRealmAuthorization({
   dbAdapter,
   realmSecretSeed,
   realms,
+  reconciler,
 }: {
   dbAdapter: DBAdapter;
   realmSecretSeed: string;
   realms: Realm[];
+  reconciler: RealmRegistryReconciler;
 }): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
   return async function (ctxt: Koa.Context, next: Koa.Next) {
     let request = await fetchRequestFromContext(ctxt);
@@ -53,10 +59,47 @@ export function multiRealmAuthorization({
       throw e;
     }
 
-    let realmByURL = new Map(realms.map((realm) => [realm.url, realm]));
-    let unknownRealms = realmList.filter(
-      (realmURL) => !realmByURL.has(realmURL),
-    );
+    // Registry-presence check (CS-11238). Phase 3 lazy-mounts source
+    // realms on first per-realm request via findOrMountRealm; a
+    // federated request for a realm that hasn't been touched yet in
+    // this process's lifetime must not 404 just because realms[]
+    // hasn't observed it. The middleware confirms the URL is a known
+    // registry row but does NOT force a mount — handlers mount
+    // lazily per-realm via reconciler.lookupOrMount() as they need a
+    // Realm reference, avoiding N simultaneous realm.start() calls
+    // on a cold first federated search.
+    //
+    // Mirrors findOrMountRealm's lookup order for the exact-URL case:
+    //   1. realms[] — covers mounted realms including the mid-start
+    //      window. Federated payloads carry exact realm URLs so we
+    //      don't need findOrMountRealm's prefix walk.
+    //   2. reconciler.knownByUrl — the reconciler's in-memory
+    //      reflection of realm_registry, refreshed on boot,
+    //      NOTIFY, and the safety-net poll.
+    //   3. direct realm_registry probe — covers the gap between a
+    //      peer instance's INSERT + NOTIFY and this instance's next
+    //      reconcile pass.
+    let mountedUrls = new Set(realms.map((r) => r.url));
+    let urlsToProbe: string[] = [];
+    for (let realmURL of realmList) {
+      if (mountedUrls.has(realmURL)) continue;
+      if (reconciler.knownByUrl.has(realmURL)) continue;
+      urlsToProbe.push(realmURL);
+    }
+    let unknownRealms: string[] = [];
+    if (urlsToProbe.length > 0) {
+      let rows = (await query(dbAdapter, [
+        'SELECT url FROM realm_registry WHERE url IN (',
+        ...separatedByCommas(urlsToProbe.map((url) => [param(url)])),
+        ')',
+      ] as Expression)) as { url: string }[];
+      let foundInDb = new Set(rows.map((r) => r.url));
+      for (let realmURL of urlsToProbe) {
+        if (!foundInDb.has(realmURL)) {
+          unknownRealms.push(realmURL);
+        }
+      }
+    }
     if (unknownRealms.length > 0) {
       await sendResponseForNotFound(
         ctxt,
@@ -126,7 +169,6 @@ export function multiRealmAuthorization({
 
     (ctxt.state as Record<string, unknown>)[MULTI_REALM_AUTH_STATE] = {
       realmList,
-      realmByURL,
     } satisfies MultiRealmAuthorizationState;
 
     await next();

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -185,22 +185,28 @@ export function createRoutes(args: CreateRoutesArgs) {
   router.all(
     '/_federated-search',
     multiRealmAuthorization(args),
-    handleSearch({ searchCache }),
+    handleSearch({ reconciler: args.reconciler, searchCache }),
   );
   router.all(
     '/_federated-info',
     multiRealmAuthorization(args),
-    handleRealmInfo({ dbAdapter: args.dbAdapter }),
+    handleRealmInfo({
+      dbAdapter: args.dbAdapter,
+      reconciler: args.reconciler,
+    }),
   );
   router.all(
     '/_federated-types',
     multiRealmAuthorization(args),
-    handleFederatedTypes({ dbAdapter: args.dbAdapter }),
+    handleFederatedTypes({
+      dbAdapter: args.dbAdapter,
+      reconciler: args.reconciler,
+    }),
   );
   router.all(
     '/_federated-search-prerendered',
     multiRealmAuthorization(args),
-    handleSearchPrerendered({ searchCache }),
+    handleSearchPrerendered({ reconciler: args.reconciler, searchCache }),
   );
   router.post(
     '/_prerender-card',

--- a/packages/realm-server/tests/server-endpoints/search-test.ts
+++ b/packages/realm-server/tests/server-endpoints/search-test.ts
@@ -9,7 +9,14 @@ import type {
   QueueRunner,
   Realm,
 } from '@cardstack/runtime-common';
-import { baseCardRef, rri } from '@cardstack/runtime-common';
+import {
+  asExpressions,
+  baseCardRef,
+  insert,
+  insertPermissions,
+  query,
+  rri,
+} from '@cardstack/runtime-common';
 import type { Query } from '@cardstack/runtime-common/query';
 import type { PgAdapter } from '@cardstack/postgres';
 import { stringify } from 'qs';
@@ -609,6 +616,111 @@ module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
         .send({ realms: [testRealm.url], invalid: 'query structure' });
 
       assert.strictEqual(response.status, 400, 'HTTP 400 status');
+    });
+
+    test('QUERY /_federated-search returns 404 when a realm URL is not in the registry', async function (assert) {
+      let realmServerToken = createRealmServerJWT(
+        { user: ownerUserId, sessionRoom: 'session-room-test' },
+        realmSecretSeed,
+      );
+      let query: Query = {
+        filter: {
+          on: baseCardRef,
+          eq: { cardTitle: 'Shared Card' },
+        },
+      };
+      let unknownURL = 'http://127.0.0.1:4444/never-heard-of/';
+
+      let response = await request
+        .post('/_federated-search')
+        .set('Accept', 'application/vnd.card+json')
+        .set('Content-Type', 'application/json')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Authorization', `Bearer ${realmServerToken}`)
+        .send({ ...query, realms: [testRealm.url, unknownURL] });
+
+      assert.strictEqual(response.status, 404, 'HTTP 404 status');
+      assert.ok(
+        response.body.errors?.[0]?.includes('Realms not found'),
+        'response uses the "Realms not found" framing',
+      );
+      assert.ok(
+        response.body.errors?.[0]?.includes(unknownURL),
+        'response names the unknown URL',
+      );
+    });
+
+    // Regression test for CS-11238. Under Phase 3 lazy-mount semantics
+    // source realms live in realm_registry but only get pushed into
+    // realms[] on first per-realm request. The middleware used to 404
+    // federated requests for any URL not in realms[]; the fix
+    // confirms registry presence and lets the handler lazy-mount on
+    // demand. Inserting a registry row + permissions for a URL that
+    // is NOT in realms[] models exactly that pre-first-hit state.
+    //
+    // We deliberately stop short of asserting the lazy-mount succeeds
+    // end-to-end — the handler's lazy-mount may or may not produce a
+    // usable Realm in this test fixture, and that's the handler's
+    // concern. What this test pins down is the middleware contract:
+    // a known-to-the-registry URL must not be rejected as "Realms not
+    // found", and a non-readable / unknown URL is still rejected
+    // upstream of the handler.
+    test('QUERY /_federated-search does not 404 a registry-only (not-yet-mounted) realm (CS-11238)', async function (assert) {
+      let realmServerToken = createRealmServerJWT(
+        { user: ownerUserId, sessionRoom: 'session-room-test' },
+        realmSecretSeed,
+      );
+      let registryOnlyURL = 'http://127.0.0.1:4444/registry-only/';
+
+      // Seed: registry row + read permissions for ownerUserId. The
+      // disk_id points at a directory the lazy-mount won't actually
+      // be able to read — irrelevant here because we're asserting the
+      // middleware's pre-handler verdict.
+      let { nameExpressions, valueExpressions } = asExpressions({
+        url: registryOnlyURL,
+        kind: 'source',
+        disk_id: 'registry-only-ghost',
+        owner_username: 'mango',
+        source_url: null,
+        last_published_at: null,
+        pinned: false,
+      });
+      await query(
+        dbAdapter,
+        insert('realm_registry', nameExpressions, valueExpressions),
+      );
+      await insertPermissions(dbAdapter, new URL(registryOnlyURL), {
+        [ownerUserId]: ['read'],
+      });
+
+      let cardsQuery: Query = {
+        filter: {
+          on: baseCardRef,
+          eq: { cardTitle: 'Shared Card' },
+        },
+      };
+
+      let response = await request
+        .post('/_federated-search')
+        .set('Accept', 'application/vnd.card+json')
+        .set('Content-Type', 'application/json')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Authorization', `Bearer ${realmServerToken}`)
+        .send({ ...cardsQuery, realms: [testRealm.url, registryOnlyURL] });
+
+      assert.notStrictEqual(
+        response.status,
+        404,
+        'registry-only realm is not rejected as "not found"',
+      );
+      let errorMessage: string =
+        (response.body && Array.isArray(response.body.errors)
+          ? response.body.errors.join(' ')
+          : '') || '';
+      assert.notOk(
+        errorMessage.includes('Realms not found'),
+        'response body does not carry the "Realms not found" error',
+      );
     });
 
     test('QUERY /_federated-search returns 400 when realms param is missing', async function (assert) {


### PR DESCRIPTION
## Summary

Phase 3 lazy-mounts source realms on first per-realm request, but `multi-realm-authorization` was rejecting any URL not in `realms[]` with `Realms not found` — so `/_federated-*` 404'd for every source realm the user hadn't directly touched in the current process's lifetime ([CS-11238](https://linear.app/cardstack/issue/CS-11238)).

- Middleware now confirms registry presence (`realms[]` → `reconciler.knownByUrl` → direct `realm_registry` probe) instead of requiring an already-mounted Realm.
- Handlers lazy-mount per-realm via `reconciler.lookupOrMount()` through a new `resolveRealmsForFederatedRequest` helper; per-realm mount failures log + drop via `Promise.allSettled`, matching the existing "skip missing realm, return partial results" semantics in `searchRealms` / `handle-realm-info`.
- The two search handlers do the resolve inside `runSearch` so cache hits (304 / cached body) skip the lazy-mount work entirely.
- The middleware deliberately does **not** force a mount — shape (b) from the ticket — avoiding the thundering-herd hazard of N simultaneous `realm.start()` calls on a cold first federated search across many realms.

## Affected endpoints

- `/_federated-search`
- `/_federated-info`
- `/_federated-types`
- `/_federated-search-prerendered`

## Test plan

- [x] `lint:js` clean
- [x] `lint:types` clean on touched files (pre-existing `../base/*.gts` errors are unrelated)
- [x] Added regression test `does not 404 a registry-only (not-yet-mounted) realm` in `tests/server-endpoints/search-test.ts`
- [x] Added negative test `returns 404 when a realm URL is not in the registry` (locks in 404 for truly-unknown realms)
- [x] Run `TEST_MODULES="server-endpoints/search-test.ts" pnpm test` from `packages/realm-server` — couldn't execute locally (Docker daemon not running while I was iterating)
- [x] Full federated-search test suite
- [ ] Manual repro of the staging incident: hit a non-pinned source realm via `/_federated-search-prerendered` before any per-realm request to that realm — should now resolve instead of 404