### PR TITLE
fix(boxel-cli): preserve atomic-upload error detail + retry SF seed sync

### DIFF
--- a/packages/boxel-cli/src/commands/realm/sync.ts
+++ b/packages/boxel-cli/src/commands/realm/sync.ts
@@ -330,7 +330,12 @@ class RealmSyncer extends RealmSyncBase {
         // payload (e.g. "Write Error"), not just the HTTP status
         // line. Distinct titles only — repeated identical titles
         // (the common case for a top-level write failure) would
-        // otherwise produce noisy duplicates.
+        // otherwise produce noisy duplicates. The summary line is
+        // re-echoed by registerSyncCommand at the end of the run
+        // via `Error: ${result.error}`, so we no longer also emit
+        // the standalone status line inline — that would duplicate
+        // it in CLI output. The per-file loop stays because it
+        // carries path-level detail the summary aggregates away.
         let titles = Array.from(
           new Set(result.error.perFile.map((e) => e.title)),
         );
@@ -338,7 +343,6 @@ class RealmSyncer extends RealmSyncBase {
           titles.length > 0
             ? `${result.error.message} (${titles.join('; ')})`
             : result.error.message;
-        console.error(result.error.message);
         for (const entry of result.error.perFile) {
           console.error(`  ${entry.path}: ${entry.title}`);
         }

--- a/packages/boxel-cli/src/commands/realm/sync.ts
+++ b/packages/boxel-cli/src/commands/realm/sync.ts
@@ -51,6 +51,11 @@ class RealmSyncer extends RealmSyncBase {
   remoteDeletedFiles: string[] = [];
   localDeletedFiles: string[] = [];
   skippedConflicts: string[] = [];
+  // Top-level message from a failed /_atomic batch (e.g. "Atomic upload
+  // failed: 500 Internal Server Error"). Surfaced in `SyncResult.error`
+  // so callers don't have to scrape stderr to learn why the batch
+  // failed.
+  uploadFatalMessage?: string;
 
   constructor(
     private syncOptions: BiSyncOptions,
@@ -320,6 +325,7 @@ class RealmSyncer extends RealmSyncBase {
       this.pushedFiles.push(...result.succeeded);
       if (result.error) {
         this.hasError = true;
+        this.uploadFatalMessage = result.error.message;
         console.error(result.error.message);
         for (const entry of result.error.perFile) {
           console.error(`  ${entry.path}: ${entry.title}`);
@@ -679,7 +685,11 @@ function buildSyncErrorMessage(syncer: RealmSyncer): string {
     `${syncer.skippedConflicts.length} conflicts skipped`,
   ].join(', ');
 
-  return `Sync completed with errors. ${summary}.`;
+  let base = `Sync completed with errors. ${summary}.`;
+  if (syncer.uploadFatalMessage) {
+    return `${base} ${syncer.uploadFatalMessage}`;
+  }
+  return base;
 }
 function emptyResult(partial: Pick<SyncResult, 'error'>): SyncResult {
   return {

--- a/packages/boxel-cli/src/commands/realm/sync.ts
+++ b/packages/boxel-cli/src/commands/realm/sync.ts
@@ -325,7 +325,19 @@ class RealmSyncer extends RealmSyncBase {
       this.pushedFiles.push(...result.succeeded);
       if (result.error) {
         this.hasError = true;
-        this.uploadFatalMessage = result.error.message;
+        // Fold the per-file titles into the surfaced message so
+        // SyncResult.error carries the server's JSON:API error
+        // payload (e.g. "Write Error"), not just the HTTP status
+        // line. Distinct titles only — repeated identical titles
+        // (the common case for a top-level write failure) would
+        // otherwise produce noisy duplicates.
+        let titles = Array.from(
+          new Set(result.error.perFile.map((e) => e.title)),
+        );
+        this.uploadFatalMessage =
+          titles.length > 0
+            ? `${result.error.message} (${titles.join('; ')})`
+            : result.error.message;
         console.error(result.error.message);
         for (const entry of result.error.perFile) {
           console.error(`  ${entry.path}: ${entry.title}`);

--- a/packages/software-factory/tests/helpers/instantiate-test-fixtures.ts
+++ b/packages/software-factory/tests/helpers/instantiate-test-fixtures.ts
@@ -219,13 +219,43 @@ async function seedFilesAndWaitForIndex(
       mkdirSync(dirname(absolute), { recursive: true });
       writeFileSync(absolute, content);
     }
-    let syncResult = await client.sync(realmUrl, stagingDir, {
-      preferLocal: true,
-      waitForIndex: true,
-    });
+    // Retry the sync once on failure. The realm-server's /_atomic
+    // endpoint can return 500 ("Write Error") for transient causes
+    // — for example a concurrent indexing pass or a worker-side
+    // fileSerialization that doesn't recur on retry — and a one-shot
+    // retry with a short backoff lets the helper recover instead of
+    // surfacing the failure as a confusing test flake. If the retry
+    // also fails, the diagnostic logs below preserve the first
+    // attempt's error message so the next CI failure has signal.
+    const maxAttempts = 2;
+    let syncResult: Awaited<ReturnType<typeof client.sync>> | undefined;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      syncResult = await client.sync(realmUrl, stagingDir, {
+        preferLocal: true,
+        waitForIndex: true,
+      });
+      if (!syncResult.hasError) {
+        if (attempt > 1) {
+          console.log(
+            `seedFilesAndWaitForIndex: sync succeeded on attempt ${attempt}/${maxAttempts} for ${realmUrl}`,
+          );
+        }
+        break;
+      }
+      console.log(
+        `seedFilesAndWaitForIndex: sync attempt ${attempt}/${maxAttempts} for ${realmUrl} failed: ${
+          syncResult.error ?? '(no error message)'
+        }`,
+      );
+      if (attempt < maxAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
+      }
+    }
     expect(
-      syncResult.hasError,
-      `seed sync to ${realmUrl} reported an error: ${syncResult.error ?? '(no error message)'}`,
+      syncResult!.hasError,
+      `seed sync to ${realmUrl} reported an error after ${maxAttempts} attempt(s): ${
+        syncResult!.error ?? '(no error message)'
+      }`,
     ).toBe(false);
   } finally {
     rmSync(stagingDir, { recursive: true, force: true });

--- a/packages/software-factory/tests/helpers/instantiate-test-fixtures.ts
+++ b/packages/software-factory/tests/helpers/instantiate-test-fixtures.ts
@@ -207,59 +207,70 @@ async function seedFilesAndWaitForIndex(
   realmUrl: string,
   files: { path: string; content: string }[],
 ): Promise<void> {
-  let stagingDir = mkdtempSync(join(tmpdir(), 'sf-instantiate-seed-'));
-  try {
-    for (let { path, content } of files) {
-      if (isAbsolute(path) || path.split('/').includes('..')) {
-        throw new Error(
-          `seedFilesAndWaitForIndex path must be a realm-relative path under the staging dir; got ${JSON.stringify(path)}`,
-        );
-      }
-      let absolute = join(stagingDir, path);
-      mkdirSync(dirname(absolute), { recursive: true });
-      writeFileSync(absolute, content);
+  for (let { path } of files) {
+    if (isAbsolute(path) || path.split('/').includes('..')) {
+      throw new Error(
+        `seedFilesAndWaitForIndex path must be a realm-relative path under the staging dir; got ${JSON.stringify(path)}`,
+      );
     }
-    // Retry the sync once on failure. The realm-server's /_atomic
-    // endpoint can return 500 ("Write Error") for transient causes
-    // — for example a concurrent indexing pass or a worker-side
-    // fileSerialization that doesn't recur on retry — and a one-shot
-    // retry with a short backoff lets the helper recover instead of
-    // surfacing the failure as a confusing test flake. If the retry
-    // also fails, the diagnostic logs below preserve the first
-    // attempt's error message so the next CI failure has signal.
-    const maxAttempts = 2;
-    let syncResult: Awaited<ReturnType<typeof client.sync>> | undefined;
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+  }
+
+  // Retry the sync once on failure. The realm-server's /_atomic
+  // endpoint can return 500 ("Write Error") for transient causes —
+  // for example a concurrent indexing pass or a worker-side
+  // fileSerialization that doesn't recur on retry — and a one-shot
+  // retry with a short backoff lets the helper recover instead of
+  // surfacing the failure as a confusing test flake.
+  //
+  // Each attempt uses a fresh staging dir: `RealmSyncer` writes
+  // `.boxel-sync.json` even when the batch failed, recording hashes
+  // for the staged files. A retry against the same dir would see
+  // those hashes match the (unchanged) local files, classify the
+  // entries as "unchanged locally / deleted remotely" (since the
+  // failed batch never actually wrote them), and with `preferLocal:
+  // true` resolve as a noop — silently skipping the upload while
+  // reporting success. Fresh dir = no stale manifest = honest
+  // re-upload on attempt 2.
+  const maxAttempts = 2;
+  let syncResult: Awaited<ReturnType<typeof client.sync>> | undefined;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let stagingDir = mkdtempSync(join(tmpdir(), 'sf-instantiate-seed-'));
+    try {
+      for (let { path, content } of files) {
+        let absolute = join(stagingDir, path);
+        mkdirSync(dirname(absolute), { recursive: true });
+        writeFileSync(absolute, content);
+      }
       syncResult = await client.sync(realmUrl, stagingDir, {
         preferLocal: true,
         waitForIndex: true,
       });
-      if (!syncResult.hasError) {
-        if (attempt > 1) {
-          console.log(
-            `seedFilesAndWaitForIndex: sync succeeded on attempt ${attempt}/${maxAttempts} for ${realmUrl}`,
-          );
-        }
-        break;
-      }
-      console.log(
-        `seedFilesAndWaitForIndex: sync attempt ${attempt}/${maxAttempts} for ${realmUrl} failed: ${
-          syncResult.error ?? '(no error message)'
-        }`,
-      );
-      if (attempt < maxAttempts) {
-        await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
-      }
+    } finally {
+      rmSync(stagingDir, { recursive: true, force: true });
     }
-    expect(
-      syncResult!.hasError,
-      `seed sync to ${realmUrl} reported an error after ${maxAttempts} attempt(s): ${
-        syncResult!.error ?? '(no error message)'
+    if (!syncResult.hasError) {
+      if (attempt > 1) {
+        console.log(
+          `seedFilesAndWaitForIndex: sync succeeded on attempt ${attempt}/${maxAttempts} for ${realmUrl}`,
+        );
+      }
+      break;
+    }
+    console.log(
+      `seedFilesAndWaitForIndex: sync attempt ${attempt}/${maxAttempts} for ${realmUrl} failed: ${
+        syncResult.error ?? '(no error message)'
       }`,
-    ).toBe(false);
-  } finally {
-    rmSync(stagingDir, { recursive: true, force: true });
+    );
+    if (attempt < maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
+    }
   }
+  expect(
+    syncResult!.hasError,
+    `seed sync to ${realmUrl} reported an error after ${maxAttempts} attempt(s): ${
+      syncResult!.error ?? '(no error message)'
+    }`,
+  ).toBe(false);
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses a flaky `instantiate-validation.spec.ts:92` failure (`InstantiateValidationStep e2e: containsMany with non-array value fails instantiation`) seen on PR CI — observed signature: `seed sync to http://localhost:NNNNN/test/ reported an error: Sync completed with errors. 0 pushed, 6 pulled, ...`, with `Atomic upload failed: 500 Internal Server Error: Write Error` on stderr.

Two prior PRs already chased this same test (`#4782` then `#4802 — Actually fix the …`). PR #4802 fixed the *original* root cause (a Spec being silently dropped from `_federated-search` because its `linkedExamples` target was in error_doc) by seeding the realm-side example as a well-formed placeholder and overwriting the workspace copy with the broken shape. That fix is correct and stays — this is a *different* failure mode (the upload itself returning 500, not a search miss).

## What the failure looks like

1. Test #16 in the spec passes (`containsMany with array value succeeds instantiation`).
2. ~9s later, Test #17's `seedFilesAndWaitForIndex` calls `client.sync(..., { waitForIndex: true })`.
3. The realm-server's `/_atomic?waitForIndex=true` POST returns **500 with `{"errors":[{"title":"Write Error", ...}]}`** — i.e. `_batchWriteUnlocked` threw something.
4. boxel-cli's `RealmSyncer` logs `Atomic upload failed: 500 Internal Server Error: Write Error` to stderr but does **not** include that detail in `SyncResult.error`.
5. The test's assertion message ends up being the generic summary string with no signal about the underlying 500.

The realm-server's `Atomic write failed: …` log line (with the original exception + stack) goes to its captured stdout but is only surfaced when the realm-server crashes, not on a one-off 500.

## What this PR does

**1. `fix(boxel-cli)`: include atomic-upload error message in `SyncResult.error`.**
Captures the fatal-upload message on the syncer and appends it to the result text returned by `buildSyncErrorMessage`. Callers no longer have to scrape stderr to learn why a `/_atomic` batch failed.

**2. Retry seed sync once in software-factory `seedFilesAndWaitForIndex`.**
A one-shot retry with a 500ms backoff in the test helper. The retry is cheap (~1s worst case) and rescues the transient case; if both attempts fail the assertion now reports `"… after 2 attempt(s): …"` and the first attempt's error is `console.log`d so the next CI failure has signal. Test-only — does not touch boxel-cli upload semantics for real users.

## Why retry + diagnostics, not a deeper fix

The realm-server-side `console.log('Atomic write failed: …')` is captured by `captureProcessLogs` but never surfaced unless the realm-server crashes. We can't tell from the CI artifact what `_batchWriteUnlocked` actually threw on this particular run. The retry handles the common transient-500 class; the diagnostic improvement means the next failure, if any, carries the underlying message in the test output so we can root-cause without guessing.

## Test plan

- [x] `pnpm lint:js` + `pnpm prettier --check` clean in both `boxel-cli` and `software-factory`
- [x] `pnpm --filter @cardstack/software-factory lint` clean from repo root (full lint including ember-tsc)
- [ ] CI — `Software Factory Tests` shard 1/3 (the historically flaky shard for this spec) passes