### PR TITLE
Add tracked-built-ins to @cardstack/catalog devDependencies

### DIFF
--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -31,7 +31,8 @@
     "prettier": "catalog:",
     "prettier-plugin-ember-template-tag": "catalog:",
     "qunit": "catalog:",
-    "qunit-dom": "catalog:"
+    "qunit-dom": "catalog:",
+    "tracked-built-ins": "catalog:"
   },
   "dependencies": {
     "ember-modify-based-class-resource": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1776,6 +1776,9 @@ importers:
       qunit-dom:
         specifier: 'catalog:'
         version: 3.5.1
+      tracked-built-ins:
+        specifier: ^4.1.2
+        version: 4.1.2(@babel/core@7.29.0)
 
   packages/catalog-realm:
     dependencies:


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-11240/add-tracked-built-ins-to-cardstackcatalog-devdependencies

-- Add the dependency to match the setup in @cardstack/catalog-realm.

##Related PR:
https://github.com/cardstack/boxel-catalog/pull/577

