### PR TITLE
fix(realm-server): make page-pool contraction test observe the full shrink sequence

### DIFF
--- a/packages/realm-server/tests/page-pool-expansion-test.ts
+++ b/packages/realm-server/tests/page-pool-expansion-test.ts
@@ -698,24 +698,33 @@ module(basename(__filename), function () {
           }
           assert.strictEqual(pool.currentMaxPages, 6, 'expanded to HP_MAX');
 
-          // Contraction should walk us back to MIN regardless of tier.
-          // Poll instead of sleeping a fixed duration: each tick is
-          // bounded to one tab per cooldown window, but event-loop
-          // scheduling under CI load can stretch the wall time.
-          let pollUntil = async (target: number, label: string) => {
+          // Contraction shrinks by one cap-unit per cooldown window, so
+          // the pool must transit through each tier boundary on its way
+          // down from HP_MAX=6 to MIN=2. Sampling `currentMaxPages` at a
+          // fixed cadence can miss transient values when scheduler jitter
+          // lets two shrinks fall inside one sleep; instead, sample at a
+          // tight interval and record every distinct cap value into a
+          // sequence, then assert that each tier boundary appears in it.
+          // The recorded sequence is included in the failure message so
+          // any future regression shows the actual trajectory.
+          let observed: number[] = [pool.currentMaxPages];
+          let pollDownTo = async (target: number, label: string) => {
             let deadlineMs = Date.now() + 5000;
             while (pool.currentMaxPages > target && Date.now() < deadlineMs) {
-              await new Promise((r) => setTimeout(r, 20));
+              await new Promise((r) => setTimeout(r, 1));
+              let current = pool.currentMaxPages;
+              if (current !== observed[observed.length - 1]) {
+                observed.push(current);
+              }
             }
-            assert.strictEqual(pool.currentMaxPages, target, label);
+            let deadlineHit = Date.now() >= deadlineMs;
+            assert.ok(
+              observed.includes(target),
+              `${label} (observed=[${observed.join(',')}], deadline=${deadlineHit ? 'hit' : 'not hit'})`,
+            );
           };
-          // Intermediate stop: contraction must walk through the
-          // burst-tier ceiling on its way down. From HP_MAX=6 the
-          // pool has to pass through MAX=4 before reaching MIN=2;
-          // verifying that step explicitly catches a regression
-          // where contraction would skip past tier boundaries.
-          await pollUntil(4, 'contraction passes through MAX on the way down');
-          await pollUntil(2, 'contraction reaches MIN even from HP tier');
+          await pollDownTo(4, 'contraction passes through MAX on the way down');
+          await pollDownTo(2, 'contraction reaches MIN even from HP tier');
         },
       );
     });

--- a/packages/realm-server/tests/page-pool-expansion-test.ts
+++ b/packages/realm-server/tests/page-pool-expansion-test.ts
@@ -725,6 +725,15 @@ module(basename(__filename), function () {
           };
           await pollDownTo(4, 'contraction passes through MAX on the way down');
           await pollDownTo(2, 'contraction reaches MIN even from HP tier');
+          // Belt-and-suspenders: MIN is a stable terminal state — once
+          // reached, contraction must stop there. Verifying equality
+          // alongside sequence membership catches a regression where the
+          // pool brushes past MIN but settles elsewhere.
+          assert.strictEqual(
+            pool.currentMaxPages,
+            2,
+            `pool settles at MIN after contraction (observed=[${observed.join(',')}])`,
+          );
         },
       );
     });


### PR DESCRIPTION
## Symptom

Failing CI job: https://github.com/cardstack/boxel/actions/runs/26274009497/job/77334220130

```
not ok 80 page-pool-expansion-test.ts > PagePool expansion / contraction > high-priority tier: contraction returns to MIN regardless of which tier expansion reached
    message: contraction passes through MAX on the way down
    actual  : 3
    expected: 4
```

## Root cause

The test polled `pool.currentMaxPages` every 20 ms — exactly the cadence at which the contraction loop shrinks the cap (one cap-unit per `PRERENDER_POOL_IDLE_CONTRACTION_MS=20` cooldown window). When event-loop scheduling jitter delays a single `setTimeout` wakeup, two shrinks can land inside one polling sleep, so the pool transitions `5 → 4 → 3` between two samples. The point-in-time `strictEqual(currentMaxPages, 4)` assertion then sees 3 even though the pool did pass through 4.

## Fix

Replace the point-in-time poll with a sequence-observing helper. Sample `currentMaxPages` at a tight (~1 ms) interval, append every distinct value to a shared `observed` array, then assert that each tier boundary (`MAX=4`, `MIN=2`) appears in the recorded sequence. The full trajectory is included in the failure message so any future regression in the contraction state machine shows the actual sequence the pool produced.

Production code in `prerender/page-pool.ts` is unchanged. Same env-var config, same two tier-boundary assertions.

## Prior art

None. The test was added in #4598; no prior flake-fix PR for this file.

## Verification

- `pnpm test` on `page-pool-expansion-test.ts`: 20/20 pass, including both `high-priority tier: contraction returns to MIN ...` and `legacy fixed pool: contraction loop never starts ...`.
- 10-run local stress loop: 10/10 green.
- `pnpm lint` in `packages/realm-server`: clean.
