### PR TITLE
test(boxel-cli): stabilize delete-vs-change sync test against post-DELETE visibility race

### DIFF
--- a/packages/boxel-cli/tests/integration/realm-sync.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-sync.test.ts
@@ -200,19 +200,23 @@ async function fetchRemoteFileEventually(
   return { body, elapsedMs: Date.now() - start, retries: attempts - 1 };
 }
 
-// Symmetric to fetchRemoteFileEventually for delete-side assertions. Polls
-// `remoteFileExists` until it returns false (the expected post-delete state)
-// or the timeout elapses. Returns `{ isGone: true, retries: 0 }` when the
-// first probe already sees 404; `retries > 0` means the realm needed time
-// after sync returned for the DELETE to become visible to a subsequent GET,
-// which is the post-write race shape (the realm's DELETE handler responds
-// 204 once #adapter.remove returns, but a follow-up GET in the same process
-// has been observed to still return 200 for a few tens of ms; cache-
-// invalidation echoes, the deferred delete-indexing chain that fires after
-// the response, or watcher event reordering are all plausible). `isGone:
-// false` with `finalStatus: 200` means it never went away — the DELETE
-// didn't take effect. The final-state fields let on-miss diagnostics
-// distinguish "DELETE didn't run" from "DELETE ran but visibility lagged".
+// Symmetric to fetchRemoteFileEventually for delete-side assertions. GETs
+// the file's source URL on a 100ms cadence and resolves with `isGone:
+// true` the moment the response status is 404. Any other status (200 or a
+// transient 5xx / 401) keeps the loop running; only 404 is the unambiguous
+// "file is gone" signal. If the timeout elapses without ever seeing a 404,
+// resolves with `isGone: false` and the most recent status/body so callers
+// can dump them as a diagnostic. `retries > 0` after a successful poll
+// means the realm needed time after sync returned for the DELETE to
+// become visible to a subsequent GET — the post-write race shape (the
+// realm's DELETE handler responds 204 once #adapter.remove returns, but a
+// follow-up GET in the same process has been observed to still return 200
+// for a few tens of ms; cache-invalidation echoes, the deferred delete-
+// indexing chain that fires after the response, or watcher event
+// reordering are all plausible). `isGone: false` with `finalStatus: 200`
+// means it never went away — the DELETE didn't take effect. The final-
+// state fields let on-miss diagnostics distinguish "DELETE didn't run"
+// from "DELETE ran but visibility lagged".
 async function remoteFileGoneEventually(
   realmUrl: string,
   relPath: string,

--- a/packages/boxel-cli/tests/integration/realm-sync.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-sync.test.ts
@@ -235,10 +235,16 @@ async function remoteFileGoneEventually(
       headers: { Accept: 'application/vnd.card+source' },
     });
     finalStatus = response.status;
-    if (!response.ok) {
-      // Drain the body so the connection can be reused; it's empty on 404
-      // but Response objects must be consumed.
-      finalBody = await response.text().catch(() => '');
+    // Drain the body so the connection can be reused.
+    finalBody = await response.text().catch(() => '');
+    // Only 404 is the unambiguous "file is gone" signal. Treating every
+    // non-OK status as success would silently green-light the assertion on
+    // a transient 5xx or an auth glitch and mask a real sync failure
+    // (e.g. the DELETE never landed). For any non-404 / non-200 status we
+    // keep polling — if the realm is consistently 5xx-ing we'll time out
+    // and the diagnostic dump records the final status so the failure
+    // mode is attributable.
+    if (response.status === 404) {
       return {
         isGone: true,
         elapsedMs: Date.now() - start,
@@ -247,7 +253,6 @@ async function remoteFileGoneEventually(
         finalBody,
       };
     }
-    finalBody = await response.text().catch(() => '');
     await sleep(100);
   }
   return {

--- a/packages/boxel-cli/tests/integration/realm-sync.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-sync.test.ts
@@ -101,6 +101,22 @@ async function remoteFileExists(
   return response.ok;
 }
 
+// Fetch the realm's `_mtimes` payload as a raw string for diagnostic dumps.
+// Returns the body (or the error message) — never throws — so on-failure
+// instrumentation can include "what does the realm think exists right now?"
+// without risking a secondary failure in the catch path.
+async function fetchRemoteMtimesRaw(realmUrl: string): Promise<string> {
+  try {
+    let base = realmUrl.endsWith('/') ? realmUrl : `${realmUrl}/`;
+    let response = await profileManager.authedRealmFetch(`${base}_mtimes`, {
+      headers: { Accept: 'application/vnd.api+json' },
+    });
+    return await response.text();
+  } catch (err) {
+    return `<fetch error: ${err instanceof Error ? err.message : String(err)}>`;
+  }
+}
+
 async function writeRemoteFile(
   realmUrl: string,
   relPath: string,
@@ -182,6 +198,65 @@ async function fetchRemoteFileEventually(
     await sleep(100);
   }
   return { body, elapsedMs: Date.now() - start, retries: attempts - 1 };
+}
+
+// Symmetric to fetchRemoteFileEventually for delete-side assertions. Polls
+// `remoteFileExists` until it returns false (the expected post-delete state)
+// or the timeout elapses. Returns `{ isGone: true, retries: 0 }` when the
+// first probe already sees 404; `retries > 0` means the realm needed time
+// after sync returned for the DELETE to become visible to a subsequent GET,
+// which is the post-write race shape (the realm's DELETE handler responds
+// 204 once #adapter.remove returns, but a follow-up GET in the same process
+// has been observed to still return 200 for a few tens of ms; cache-
+// invalidation echoes, the deferred delete-indexing chain that fires after
+// the response, or watcher event reordering are all plausible). `isGone:
+// false` with `finalStatus: 200` means it never went away — the DELETE
+// didn't take effect. The final-state fields let on-miss diagnostics
+// distinguish "DELETE didn't run" from "DELETE ran but visibility lagged".
+async function remoteFileGoneEventually(
+  realmUrl: string,
+  relPath: string,
+  timeoutMs = 2000,
+): Promise<{
+  isGone: boolean;
+  elapsedMs: number;
+  retries: number;
+  finalStatus: number;
+  finalBody: string;
+}> {
+  const start = Date.now();
+  let attempts = 0;
+  let url = buildFileUrl(realmUrl, relPath);
+  let finalStatus = 0;
+  let finalBody = '';
+  while (Date.now() - start < timeoutMs) {
+    attempts++;
+    let response = await profileManager.authedRealmFetch(url, {
+      headers: { Accept: 'application/vnd.card+source' },
+    });
+    finalStatus = response.status;
+    if (!response.ok) {
+      // Drain the body so the connection can be reused; it's empty on 404
+      // but Response objects must be consumed.
+      finalBody = await response.text().catch(() => '');
+      return {
+        isGone: true,
+        elapsedMs: Date.now() - start,
+        retries: attempts - 1,
+        finalStatus,
+        finalBody,
+      };
+    }
+    finalBody = await response.text().catch(() => '');
+    await sleep(100);
+  }
+  return {
+    isGone: false,
+    elapsedMs: Date.now() - start,
+    retries: attempts - 1,
+    finalStatus,
+    finalBody,
+  };
 }
 
 beforeAll(async () => {
@@ -578,17 +653,43 @@ describe('realm sync (integration)', () => {
       'dvc.gts': 'export const dvc = 1;\n',
     });
 
-    // Delete locally, modify remotely
+    // Delete locally, modify remotely. Snapshot the local + remote state
+    // before sync so the diagnostic dump on a future failure proves whether
+    // the conflict setup actually landed (rather than guessing whether
+    // `fs.unlinkSync` / `writeRemoteFile` were the failure point).
     fs.unlinkSync(path.join(localDir, 'dvc.gts'));
     await writeRemoteFile(realmUrl, 'dvc.gts', 'export const dvc = 2;\n');
+    let preSyncLocalExists = localFileExists(localDir, 'dvc.gts');
+    let preSyncRemote = await fetchRemoteFile(realmUrl, 'dvc.gts');
 
     await sync(localDir, realmUrl, {
       preferLocal: true,
       profileManager,
     });
 
-    // Local delete wins - remote should be gone
-    expect(await remoteFileExists(realmUrl, 'dvc.gts')).toBe(false);
+    // Local delete wins - remote should be gone. Poll up to 2s rather than
+    // a single immediate read: the realm's DELETE handler is observed in
+    // CI to return 204 ~50ms before a follow-up GET stops returning 200
+    // (deferred delete-indexing chain still settling, watcher echoes, or
+    // an in-process cache-invalidation race are all plausible — see the
+    // PR description). `retries > 0` after a successful poll proves the
+    // delete eventually became visible (a brief post-write visibility
+    // race that the sync caller doesn't need to care about); a timeout
+    // dumps every relevant state snapshot so the next CI failure has
+    // enough signal to attribute root cause without re-running.
+    let result = await remoteFileGoneEventually(realmUrl, 'dvc.gts');
+    if (!result.isGone) {
+      let postCheckMtimes = await fetchRemoteMtimesRaw(realmUrl);
+      console.error(
+        `[delete-vs-change diagnostic] dvc.gts still present ${result.elapsedMs}ms after sync (${result.retries} retries, final status ${result.finalStatus}); ` +
+          `preSyncLocalExists=${preSyncLocalExists}, ` +
+          `preSyncRemoteBody=${JSON.stringify(preSyncRemote)}, ` +
+          `postCheckRemoteBody=${JSON.stringify(result.finalBody)}, ` +
+          `postCheckMtimesIncludesDvc=${postCheckMtimes.includes('dvc.gts')}, ` +
+          `realmUrl=${realmUrl}`,
+      );
+    }
+    expect(result.isGone).toBe(true);
   });
 
   it('change-vs-delete conflict with --prefer-remote deletes local', async () => {


### PR DESCRIPTION
## Summary

The `realm sync (integration) > delete-vs-change conflict with --prefer-local deletes remote` test in `packages/boxel-cli/tests/integration/realm-sync.test.ts` has flaked repeatedly on CI with `AssertionError: expected true to be false` against `remoteFileExists` ([latest run](https://github.com/cardstack/boxel/actions/runs/26274991530/job/77337903633?pr=4934)).

The failing realm-server log shows the relevant requests landing in this order:

```
07:50:08.6240  POST   /dvc.gts: 204  (writeRemoteFile: remote content = "= 2")
07:50:08.6628  DELETE /dvc.gts: 204  (sync push-delete; reported 11ms RTT)
07:50:08.7248  GET    /dvc.gts: 200  (remoteFileExists; file still present)
07:50:08.7554  [deferred delete-indexing settled for /dvc.gts in 99ms]
```

So the sync did pick the right action (push-delete), the realm-server DELETE handler did acknowledge 204, but a follow-up GET ~50ms later still returned 200 for the same path in the same process. The race shape matches a few plausible mechanisms — the deferred delete-indexing chain that settles after the response, a cache-invalidation echo through `realm_file_changes`, watcher event ordering — but none is provable from code alone, so this PR stabilizes the assertion and arms it with diagnostics to attribute root cause from the next failure instead of guessing at a realm-server fix.

## What this change does

- Adds `remoteFileGoneEventually(realmUrl, relPath, timeoutMs)` — symmetric to the existing `fetchRemoteFileEventually` helper used by the prefer-local content-conflict test that landed in #4929. Polls `remoteFileExists` every 100ms for up to 2s and returns `{ isGone, retries, elapsedMs, finalStatus, finalBody }`. A successful poll with `retries > 0` is the unambiguous signal that the post-write visibility race was real but the realm caught up on its own.
- Adds `fetchRemoteMtimesRaw` as a never-throwing helper so the on-miss diagnostic can include the realm's view of "what exists right now" without risking a secondary failure inside the catch path.
- Replaces the eager `expect(remoteFileExists).toBe(false)` in the delete-vs-change test with a poll on `remoteFileGoneEventually`, snapshots the pre-sync local-existence + remote-content state, and emits a single-line `console.error` dump on timeout that includes the current GET status/body, the post-sync `_mtimes` payload, and the pre-sync snapshots. The next CI failure will carry enough signal to attribute root cause without re-running.

The symmetric `change-vs-delete conflict with --prefer-remote deletes local` test asserts on `localFileExists` (a direct `fs.existsSync`, not a network call), so it doesn't share the race shape and is left as-is.

## Why not also "fix" the realm-server

I can see in the log that the realm-server's DELETE handler reports `removeSync` having returned before the 204, and the in-process `#sourceCache.invalidate` runs synchronously before the response — yet the next GET still returns 200. That implies a real visibility race in the realm-server's source-cache or watcher path, but without local repro I can't confidently point at the mechanism, and a speculative realm-server change is higher-risk than a test-side poll. The diagnostic dump is the bridge: if the next CI failure shows `retries > 0`, the realm catches up and there's no production issue worth chasing; if it times out with the post-check `_mtimes` payload still listing `dvc.gts`, that's a realm-server bug worth pursuing with a concrete failure signature.

## Test plan

- [x] Boxel CLI Tests pass on CI (no longer flakes on the delete-vs-change case)
- [ ] If it flakes again, the failure log carries the `[delete-vs-change diagnostic]` line and we can attribute root cause without re-running
