### PR TITLE
Pin file-api as a runtime dep of file extracts (flaky test fix)

### DIFF
--- a/packages/host/app/routes/render/file-extract.ts
+++ b/packages/host/app/routes/render/file-extract.ts
@@ -7,6 +7,7 @@ import { isTesting } from '@embroider/macros';
 
 import {
   baseFileRef,
+  baseRealm,
   formattedError,
   snapshotRuntimeDependencies,
   withRuntimeDependencyTrackingContext,
@@ -97,6 +98,7 @@ export default class RenderFileExtractRoute extends Route<Model> {
       contentSize,
       buildError: this.#buildError.bind(this),
     });
+    let fileApiURL = `${baseRealm.url}file-api`;
     let result: FileDefExtractResult;
     try {
       result = await withRuntimeDependencyTrackingContext(
@@ -106,7 +108,16 @@ export default class RenderFileExtractRoute extends Route<Model> {
           consumer: id,
           consumerKind: 'file',
         },
-        async () => await extractor.extract(),
+        async () => {
+          // `${baseRealm.url}file-api` is the public URL the indexer
+          // uses to invalidate file extracts, but the FileDef class
+          // physically lives in `card-api` (`baseFileRef.module`). The
+          // extractor only imports `card-api`, so without this line
+          // `file-api` would never enter the tracker. Doing the import
+          // inside the tracking window pins it as a runtime dep.
+          await this.loaderService.loader.import(fileApiURL);
+          return extractor.extract();
+        },
       );
     } catch (error) {
       result = {
@@ -118,6 +129,20 @@ export default class RenderFileExtractRoute extends Route<Model> {
     }
     let { deps } = snapshotRuntimeDependencies({ excludeQueryOnly: true });
     let mergedDeps = [...new Set([...(result.deps ?? []), ...deps])];
+    if (!mergedDeps.includes(fileApiURL)) {
+      // The explicit `loader.import(fileApiURL)` above runs inside the
+      // active tracker context, so file-api must always land in the
+      // snapshot. If it doesn't, the tracker session was closed early
+      // or the URL was rewritten; log enough state to diagnose.
+      console.warn(
+        `[file-extract] file-api missing from runtime deps for ${id} after explicit import`,
+        {
+          fileApiURL,
+          extractorDeps: result.deps ?? [],
+          runtimeDeps: deps,
+        },
+      );
+    }
     return {
       id,
       nonce,


### PR DESCRIPTION
## Problem

`prerendering-test.ts > prerender - non-mutating tests > runner behavior > file prerender returns extracted metadata` intermittently fails on the assertion:

```
deps include base file-api module
  actual  : false
  expected: true
```

Most recent failure: https://github.com/cardstack/boxel/actions/runs/26289527361/job/77386270791

The file-extract pipeline only natively imports `${baseRealm.url}card-api` (because `baseFileRef.module` resolves there — that's where the `FileDef` class actually lives). The public `${baseRealm.url}file-api` URL — which is what the indexer keys on when invalidating file extracts — landed in `deps` only because matrix-service's `fileAPIModule = importResource(() => '…/file-api')` happened to call `loader.import('file-api')` synchronously inside the active `withRuntimeDependencyTrackingContext` window.

Whether that import landed inside the window was a microtask-scheduling race. It was reliable on a fresh page but flaky after a `BrowserManager.restartBrowser()` (e.g., from a preceding test like `concurrent restart coalescing`), where the matrix-service resource fires either too early (before the route starts the session) or too late (after `extract()` resolves).

## Prior art

PR #4875 attempted to fix this by pinning the imports in `RenderRoute.#buildModel`, but that ran the imports for **every** render — card prerenders too — and was reverted because it introduced cross-test instability.

## Solution

Pin `loader.import('${baseRealm.url}file-api')` **only inside** the file-extract route's `withRuntimeDependencyTrackingContext`. This makes the dep deterministic for file extracts and is invisible to the card-prerender path, so it can't reintroduce the destabilisation that closed #4875.

Adds a `console.warn` diagnostic that fires if `file-api` is still missing from the snapshot after the explicit import — insurance in case the tracker session is ever closed early or the URL is rewritten.

## Files

- `packages/host/app/routes/render/file-extract.ts`

## Test plan
- [ ] CI passes on this branch (specifically the Realm Server Tests shards)
- [ ] No card-prerender regressions in `prerendering-test.ts` (the broader test module)