### PR TITLE
Widen test fetch-retry window and add timeout diagnostics

### DIFF
--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -133,7 +133,10 @@ function setupFetchDebugging(hooks: NestedHooks) {
     }
     originalFetch = undefined;
     wrappedFetch = undefined;
-    inFlightFetches.clear();
+    // Don't clear inFlightFetches here: QUnit.testDone runs AFTER
+    // afterEach, so clearing here would empty the snapshot exactly when
+    // the timeout-diagnostics callback needs it. beforeEach already
+    // resets the buffer at the start of the next test.
   });
 }
 

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -41,6 +41,59 @@ const recentFailedFetches: string[] = [];
 const RECENT_FAILED_FETCHES_LIMIT = 20;
 let currentTestEpoch = 0;
 
+// Lazily install a single global QUnit.testDone callback that fires the
+// existing diagnostic dump when a failed test ran longer than 60s. Silent
+// QUnit timeouts (e.g. a waitFor that never resolves) don't surface through
+// `unhandledrejection` or `onUncaughtException`, so without this hook a
+// timeout shows only accumulated `[test-fetch]` lines with no in-flight /
+// recent-failed snapshot at the moment QUnit gave up. QUnit's logging
+// callbacks have no deregistration API, hence the install-once pattern; the
+// callback reads the live module-level fetch state, which is reset each
+// beforeEach, so it is consistent with the per-test fetch lifecycle.
+let timeoutDiagnosticsInstalled = false;
+function installTimeoutDiagnosticsOnce() {
+  if (timeoutDiagnosticsInstalled) return;
+  let qunitGlobal = getQUnitWithCallbacks();
+  if (!qunitGlobal || typeof qunitGlobal.testDone !== 'function') return;
+  qunitGlobal.testDone((details: QUnitTestDoneDetails) => {
+    if (
+      details &&
+      typeof details.failed === 'number' &&
+      details.failed > 0 &&
+      typeof details.runtime === 'number' &&
+      details.runtime > 60_000
+    ) {
+      logRejectionDiagnostics(
+        '[test-timeout]',
+        `failed test "${details.module ?? '<unknown module>'} > ${
+          details.name ?? '<unknown test>'
+        }" ran for ${details.runtime}ms`,
+      );
+    }
+  });
+  timeoutDiagnosticsInstalled = true;
+}
+
+interface QUnitTestDoneDetails {
+  name?: string;
+  module?: string;
+  failed?: number;
+  passed?: number;
+  total?: number;
+  runtime?: number;
+}
+
+function getQUnitWithCallbacks():
+  | { testDone?: (cb: (details: QUnitTestDoneDetails) => void) => void }
+  | undefined {
+  let q = (globalThis as { QUnit?: unknown }).QUnit;
+  return q && typeof q === 'object'
+    ? (q as {
+        testDone?: (cb: (details: QUnitTestDoneDetails) => void) => void;
+      })
+    : undefined;
+}
+
 function setupFetchDebugging(hooks: NestedHooks) {
   let originalFetch: typeof globalThis.fetch | undefined;
   let wrappedFetch: typeof globalThis.fetch | undefined;
@@ -49,6 +102,7 @@ function setupFetchDebugging(hooks: NestedHooks) {
     inFlightFetches.clear();
     recentFailedFetches.length = 0;
     currentTestEpoch++;
+    installTimeoutDiagnosticsOnce();
     if (!globalThis.fetch) {
       return;
     }

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -276,7 +276,15 @@ export function isUrlLike(moduleIdentifier: string): boolean {
 // This is to handle a very mysterious situation in our CI environment where
 // fetches for base realm artifacts seem to vanish and we see "TypeError:
 // Fetch failed" exceptions.
-const maxAttempts = 5;
+//
+// Why 10 attempts: with the triangular backoff below (attempt * backOffMs),
+// 10 retries widens the total backoff window from ~1.5s to ~5.5s. CI has been
+// observed losing localhost:4201/base/* fetches for multi-second stretches
+// (TCP/process scheduling glitches), so the prior 5-attempt cap was tight
+// enough that a single transient stall would surface as a test timeout.
+// Gated on `__environment === 'test'` via shouldRetryFetch, so production
+// behaviour is unaffected.
+const maxAttempts = 10;
 const backOffMs = 100;
 const retryableLocalHosts = new Set(['localhost', '127.0.0.1']);
 
@@ -306,6 +314,15 @@ async function withRetries(
       return await fetchFn();
     } catch (err: any) {
       if (!shouldRetryFetch(url) || ++attempt > maxAttempts) {
+        if (shouldRetryFetch(url) && attempt > maxAttempts) {
+          // Final-exhaustion log: distinct from the per-attempt warning so
+          // CI output can be grepped for the actual cap being hit.
+          console.error(
+            `Exhausted ${attempt - 1} fetch retries for ${url.href}: ${
+              err?.name ?? 'Error'
+            }: ${err?.message ?? String(err)}`,
+          );
+        }
         throw err;
       }
       console.error(


### PR DESCRIPTION
## Symptom

A host acceptance test (`Acceptance | code-submode | card-playground > multiple realms: edit format is enabled for writable instances of read-only card definitions`) timed out at ~125s on shard 4 of Host Tests. The CI log shows a single transient `TypeError: Failed to fetch` for `https://localhost:4201/base/color` followed by exactly one `Encountered fetch failed ... retry attempt #1` line — meaning `withRetries` did one retry and gave up. With the existing 5-attempt cap and a triangular backoff (`attempt * 100ms`), the total retry window is only ~1.5s, which isn't enough headroom for the multi-second `localhost:4201/base/*` stalls that have been hitting CI.

Once that one card-type-analysis fetch fails, the playground UI never renders `[data-test-instance-chooser]`, and the test's `waitFor` accumulates to the QUnit timeout. Sibling tests in the same module that only touch mock realms aren't sensitive because they never reach for `base/color`.

## Root cause hypothesis

Transient base-realm fetch failures from a CI environment glitch (TCP / process scheduling stall) exceeding the existing retry window. The retry path is already a known CI-only mitigation — `virtual-network.ts` explicitly notes the "very mysterious situation in our CI environment where fetches for base realm artifacts seem to vanish". This PR widens the window and adds diagnostics; it does not try to fix the underlying glitch.

## Changes

**`packages/runtime-common/virtual-network.ts`**
- Bump `maxAttempts` from 5 to 10. Total retry window widens from ~1.5s to ~5.5s. The retry path is gated on `globalThis.__environment === 'test'` via `shouldRetryFetch`, so production behaviour is unchanged.
- When `withRetries` is about to throw after exhausting the cap, emit a distinct `Exhausted N fetch retries for <url>: <err.name>: <err.message>` log alongside the existing per-attempt warning so future cap-hits are greppable in CI output.

**`packages/host/tests/helpers/setup.ts`**
- Install a single `QUnit.testDone` callback that fires the existing `logRejectionDiagnostics` snapshot (in-flight fetches + recently-failed fetches) when a failed test ran for more than 60s. Silent QUnit timeouts don't surface through `unhandledrejection` or `onUncaughtException`, so today this dump never fires for the exact failure mode we just hit. Installed lazily and once (QUnit's logging-callback API has no deregistration); the callback reads the module-level state that's already reset each `beforeEach`. Observation-only — no failure state is mutated.

## Test plan

- [ ] Watch CI for recurrence of the same timeout. If it happens again, the new `Exhausted N fetch retries ...` line + `[test-timeout]` diagnostic dump will identify the specific URL and in-flight fetch state at the timeout instant.
- [ ] No behaviour change is expected outside `__environment === 'test'`; production fetch flow is unaffected.

Reference for the original failing run: https://github.com/cardstack/boxel/actions/runs/26289526696/job/77386235633