### PR TITLE
Fix flaky AI assistant skill menu test (await default skill render)

### DIFF
--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -3005,7 +3005,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
             '[data-test-skill-menu] [data-test-attached-card]',
           )?.length === 1,
       );
-    } catch (e) {
+    } catch {
       let attached = Array.from(
         document.querySelectorAll(
           '[data-test-skill-menu] [data-test-attached-card]',
@@ -3015,7 +3015,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
         false,
         `Default skill never rendered on the new session's skill menu. Attached cards seen: ${JSON.stringify(attached)}; expected exactly [${envSkillId}].`,
       );
-      throw e;
+      return;
     }
     assert
       .dom('[data-test-skill-menu] [data-test-attached-card]')

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -2998,6 +2998,25 @@ module('Acceptance | AI Assistant tests', function (hooks) {
 
     await click('[data-test-skill-menu][data-test-pill-menu-button]');
     await waitFor('[data-test-skill-menu]');
+    try {
+      await waitUntil(
+        () =>
+          document.querySelectorAll(
+            '[data-test-skill-menu] [data-test-attached-card]',
+          )?.length === 1,
+      );
+    } catch (e) {
+      let attached = Array.from(
+        document.querySelectorAll(
+          '[data-test-skill-menu] [data-test-attached-card]',
+        ),
+      ).map((el) => el.getAttribute('data-test-attached-card'));
+      assert.ok(
+        false,
+        `Default skill never rendered on the new session's skill menu. Attached cards seen: ${JSON.stringify(attached)}; expected exactly [${envSkillId}].`,
+      );
+      throw e;
+    }
     assert
       .dom('[data-test-skill-menu] [data-test-attached-card]')
       .exists({ count: 1 });


### PR DESCRIPTION
## Summary
- `ai-assistant-test.gts` opens the skill menu twice in the "Add Same Skills" test. The first open already uses a `waitUntil` for the attached-card count; the second open (after a plain new-session click) was asserting directly, racing the async default-skill (`envSkillId`) attachment.
- Mirror the symmetric `waitUntil` and surface the observed attached-card list if the wait times out, so the next failure is debuggable.

Observed failure on CS-11236 CI shard 1: `Element [data-test-skill-menu] [data-test-attached-card] does not exist` (expected: `exists once`).

## Test plan
- [ ] CI Host shards pass.
- [ ] Run `packages/host` acceptance test `"Add Same Skills" copies skill configuration to new session` locally.