### PR TITLE
host tests: wait for new-room skills to load before simulating bot message

### DIFF
--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -60,6 +60,7 @@ import {
   visitOperatorMode,
   setupAuthEndpoints,
   setupUserSubscription,
+  waitForNewRoomSkillsLoaded,
 } from '../helpers';
 
 import {
@@ -1019,6 +1020,13 @@ module('Acceptance | Commands tests', function (hooks) {
 
     // simulate message
     roomId = getRoomIds().pop()!;
+    // The new room's default skills (env skill, which carries show-card) are
+    // loaded asynchronously by the room resource's processRoomTask. If we
+    // dispatch the bot message before loadSkills finishes, message-builder
+    // can't match show-card_566f to a known codeRef and the command resolves
+    // as invalid ("No command for the name X was found") instead of being
+    // auto-applied.
+    await waitForNewRoomSkillsLoaded(roomId);
     simulateRemoteMessage(roomId, '@aibot:localhost', {
       body: 'Show the card',
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
@@ -1048,9 +1056,45 @@ module('Acceptance | Commands tests', function (hooks) {
 
     // Note: you don't have to click on apply button, because command on Skill
     // has requireApproval set to false
-    await waitFor(
-      '[data-test-message-idx="0"] [data-test-apply-state="applied"]',
-    );
+    try {
+      await waitFor(
+        '[data-test-message-idx="0"] [data-test-apply-state="applied"]',
+      );
+    } catch (err) {
+      let applyButtons = findAll('[data-test-command-apply]').map((el) => ({
+        idx: el
+          .closest('[data-test-message-idx]')
+          ?.getAttribute('data-test-message-idx'),
+        state: el.getAttribute('data-test-command-apply'),
+      }));
+      let applyStates = findAll('[data-test-apply-state]').map((el) =>
+        el.getAttribute('data-test-apply-state'),
+      );
+      let warnings = findAll('[data-test-boxel-alert="warning"]').map(
+        (el) => el.textContent?.trim() ?? '',
+      );
+      let roomData = getService('matrix-service').getRoomData(roomId);
+      let roomResource = getService('matrix-service').roomResources.get(roomId);
+      console.error(
+        '[commands-test/show-card-auto-apply] timed out waiting for applied state. Diagnostic:',
+        JSON.stringify(
+          {
+            roomId,
+            renderedApplyButtonStates: applyButtons,
+            renderedApplyStates: applyStates,
+            warnings,
+            enabledSkillCards:
+              roomData?.skillsConfig?.enabledSkillCards?.map(
+                (f) => f.sourceUrl,
+              ) ?? null,
+            roomResourceCommandCount: roomResource?.commands?.length ?? null,
+          },
+          null,
+          2,
+        ),
+      );
+      throw err;
+    }
 
     assert.dom('[data-test-command-id]').doesNotHaveClass('is-failed');
 
@@ -1108,6 +1152,10 @@ module('Acceptance | Commands tests', function (hooks) {
 
     // simulate message
     roomId = getRoomIds().pop()!;
+    // Same skill-load race as the sister "agentId matches" test — wait for
+    // default skills to be available so show-card_566f resolves to a known
+    // codeRef before the simulated bot message arrives.
+    await waitForNewRoomSkillsLoaded(roomId);
     simulateRemoteMessage(roomId, '@aibot:localhost', {
       body: 'Show the card',
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
@@ -1464,6 +1512,11 @@ module('Acceptance | Commands tests', function (hooks) {
 
     // simulate message
     let roomId = getRoomIds().pop()!;
+    // The JSON-schema validation failure we're asserting only runs once
+    // message-builder has resolved show-card_566f to its codeRef via the
+    // room's loaded skills. Without this wait we sometimes hit the upstream
+    // "No command for the name X was found" branch instead.
+    await waitForNewRoomSkillsLoaded(roomId);
     simulateRemoteMessage(roomId, '@aibot:localhost', {
       body: 'Show the card',
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
@@ -1493,11 +1546,40 @@ module('Acceptance | Commands tests', function (hooks) {
     await waitFor(
       '[data-test-message-idx="0"] [data-test-apply-state="invalid"]',
     );
+    // The CI flake mode for this test is that the warning reads "No command
+    // for the name X was found" (skill not yet loaded) instead of the
+    // expected JSON-schema validation message. Log enough state to
+    // distinguish the skill-load race from a genuine validation regression
+    // before the qunit-dom assertion records the failure.
+    let expectedValidationText =
+      'Command "show-card_566f" validation failed: data/attributes must have required property \'cardId\'';
+    let warningText =
+      document
+        .querySelector('[data-test-boxel-alert="warning"]')
+        ?.textContent?.trim() ?? '';
+    if (!warningText.includes(expectedValidationText)) {
+      let roomData = getService('matrix-service').getRoomData(roomId);
+      let roomResource = getService('matrix-service').roomResources.get(roomId);
+      console.error(
+        '[commands-test/json-schema-validation] warning text mismatch. Diagnostic:',
+        JSON.stringify(
+          {
+            roomId,
+            warningText,
+            enabledSkillCards:
+              roomData?.skillsConfig?.enabledSkillCards?.map(
+                (f) => f.sourceUrl,
+              ) ?? null,
+            roomResourceCommandCount: roomResource?.commands?.length ?? null,
+          },
+          null,
+          2,
+        ),
+      );
+    }
     assert
       .dom('[data-test-boxel-alert="warning"]')
-      .containsText(
-        'Command "show-card_566f" validation failed: data/attributes must have required property \'cardId\'',
-      );
+      .containsText(expectedValidationText);
 
     assert.dom('[data-test-command-id]').doesNotHaveClass('is-failed');
 

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -2097,3 +2097,80 @@ export async function addSkillToAiAssistant(
     throw enriched;
   }
 }
+
+// Waits for a freshly-created AI assistant room to finish loading its
+// default skills, so that simulateRemoteMessage can resolve a command name
+// (e.g. show-card_566f) against the room's skill commands. Without this the
+// room's processRoomTask can still be mid-loadSkills when the simulated
+// timeline event is processed, in which case message-builder finds no
+// matching codeRef and the command is reported as "No command for the name
+// X was found" instead of executing/validating.
+export async function waitForNewRoomSkillsLoaded(roomId: string) {
+  await settled();
+
+  let matrixService = getService('matrix-service') as {
+    getRoomData(roomId: string): {
+      skillsConfig: {
+        enabledSkillCards?: Array<{ sourceUrl?: string }>;
+        disabledSkillCards?: Array<{ sourceUrl?: string }>;
+        commandDefinitions?: Array<{ sourceUrl?: string }>;
+      };
+    } | null;
+    roomResources: Map<
+      string,
+      {
+        skills?: Array<{ cardId: string }>;
+        commands?: Array<unknown>;
+      }
+    >;
+  };
+
+  try {
+    await waitUntil(
+      () => {
+        let roomData = matrixService.getRoomData(roomId);
+        let enabled = roomData?.skillsConfig?.enabledSkillCards ?? [];
+        if (enabled.length === 0) {
+          return false;
+        }
+        let roomResource = matrixService.roomResources.get(roomId);
+        // commands is computed from loaded skill instances in the store, so
+        // a non-empty list proves that loadSkills finished and the skill
+        // card's @field commands is populated — i.e. message-builder will be
+        // able to resolve the request's functionName.
+        return Boolean(
+          roomResource && (roomResource.commands?.length ?? 0) > 0,
+        );
+      },
+      {
+        timeout: 5000,
+        timeoutMessage: `Timed out waiting for new AI room ${roomId} skills/commands to load`,
+      },
+    );
+  } catch (err) {
+    let roomData = matrixService.getRoomData(roomId);
+    let roomResource = matrixService.roomResources.get(roomId);
+    let diagnostic = {
+      roomId,
+      hasRoomData: Boolean(roomData),
+      hasRoomResource: Boolean(roomResource),
+      enabledSkillCards:
+        roomData?.skillsConfig?.enabledSkillCards?.map((f) => f.sourceUrl) ??
+        null,
+      disabledSkillCards:
+        roomData?.skillsConfig?.disabledSkillCards?.map((f) => f.sourceUrl) ??
+        null,
+      commandDefinitionsCount:
+        roomData?.skillsConfig?.commandDefinitions?.length ?? null,
+      roomResourceSkillIds: roomResource?.skills?.map((s) => s.cardId) ?? null,
+      roomResourceCommandCount: roomResource?.commands?.length ?? null,
+    };
+    let originalMessage = err instanceof Error ? err.message : String(err);
+    let enriched = new Error(
+      `${originalMessage} | diagnostics: ${JSON.stringify(diagnostic)}`,
+    );
+    (enriched as Error & { cause?: unknown }).cause =
+      err instanceof Error ? err : undefined;
+    throw enriched;
+  }
+}


### PR DESCRIPTION
## Summary

Two acceptance tests in `commands-test.gts` intermittently failed on CI (shard 17 of the host test suite):

- *ShowCard command added from a skill, can be automatically executed when agentId matches* — timed out waiting for `apply-state="applied"`
- *command request with arguments that do not match the json schema gets an "invalid" result* — warning text was `No command for the name "show-card_566f" was found` instead of the expected JSON-schema validation message

### Root cause

Both tests click `[data-test-create-room-btn]` and then immediately `simulateRemoteMessage` with a command request for `show-card_566f`, which is a function on the env skill that the new room auto-attaches.

The new room's `processRoomTask` is still mid-`loadSkills` when the simulated bot event lands; `message-builder` walks `builderContext.skills` and calls `store.get<Skill>(skill.cardId)`, but the env skill is not in the store yet, so the request never resolves to a `codeRef` and `command-service` falls into the *"No command for the name X was found"* branch instead of executing or running the JSON-schema validator.

### Fix

- New helper `waitForNewRoomSkillsLoaded(roomId)`: polls until the room's `enabledSkillCards` is populated **and** `roomResource.commands.length > 0` (commands is computed from the loaded skill instances in the store, so a non-empty list proves `loadSkills` finished and the skill's `@field commands` field is materialised). On timeout it throws with a JSON diagnostic snapshot of `skillsConfig` + the room resource's view, so a future flake reports enough state to distinguish "no skill loaded" from "skill loaded but commands missing".
- Used in the two failing tests and the third sister test (*is not automatically executed when agentId does not match*), which has the same setup and was passing by luck.
- Inline diagnostic logging in the two failing tests around the assertions that have been flaking, so we capture rendered apply states, warnings, and room/skill state if either still misses after the fix.

## Test plan

- [ ] CI passes shard 17 of host tests
- [ ] Run the three affected tests locally a few times to confirm no flake
- [ ] If a CI failure recurs, the diagnostic logs in the test/helper attribute it cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)