### PR TITLE
Add custom css variables to Brand Guide

### DIFF
--- a/packages/base/brand-guide.gts
+++ b/packages/base/brand-guide.gts
@@ -15,6 +15,7 @@ import {
 import ColorField from './color';
 import {
   BasicFitted,
+  CopyButton,
   Swatch,
   Button,
   FieldContainer,
@@ -103,7 +104,11 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
         />
         <GridContainer class='brand-guide-grid'>
           {{#each this.sectionsWithContent as |section|}}
-            <NavSection @id={{section.id}} @title={{section.title}}>
+            <NavSection
+              @id={{section.id}}
+              @title={{section.title}}
+              data-test-brand-guide-section={{section.id}}
+            >
               {{#if (eq section.id 'brand-palette')}}
                 <GridContainer>
                   {{#if @model.brandColorPalette.length}}
@@ -363,28 +368,50 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
                         <code>--brand-secondary-mark-min-height</code>)</dd>
                     </dl>
                   </div>
-                  {{#if @model.brandColorPalette.length}}
-                    <h3 class='brand-guide-vars-heading'>Brand-Specific
-                      Variables</h3>
-                    <p class='brand-guide-vars-description'>These variables are
-                      custom css properties for usage by the specific brand.</p>
-                    <div class='brand-guide-vars-box'>
-                      <h4 class='brand-guide-vars-title'>Custom Brand Variables</h4>
-                      <p class='brand-guide-vars-description'>Additional brand
-                        colors as defined in the Brand Color Palette.</p>
-                      <dl class='brand-guide-vars'>
-                        {{#each @model.brandColorPalette as |color|}}
-                          {{#if color.name}}
-                            <dt><code>{{buildCssVariableName
-                                  color.name
-                                }}</code></dt>
-                            <dd>Custom brand color</dd>
-                          {{/if}}
-                        {{/each}}
-                      </dl>
-                    </div>
-                  {{/if}}
                 {{/if}}
+              {{else if (eq section.id 'custom-css')}}
+                <p class='brand-guide-vars-description'>These variables are
+                  custom css properties for usage by this theme only.</p>
+                <div class='brand-guide-vars-box brand-guide-custom-css-block'>
+                  <CopyButton
+                    class='brand-guide-custom-css-block-copy-button'
+                    @textToCopy={{this.customCssVarsBlock}}
+                  />
+                  <dl class='brand-guide-vars'>
+                    {{#each this.paletteVarEntries as |entry|}}
+                      <dt class='var-row' data-test-brand-guide-palette-var>
+                        <code
+                          data-test-brand-guide-palette-var-name
+                        >{{entry.varName}}</code>
+                      </dt>
+                      <dd
+                        class='color-entry var-row'
+                        data-test-brand-guide-palette-swatch
+                      >
+                        <Swatch
+                          class='color-swatch-mini'
+                          @color={{entry.color.value}}
+                          @style='round'
+                        />
+                      </dd>
+                    {{/each}}
+                    {{#each @model.customCssVariables as |cssVar|}}
+                      {{#if cssVar.name}}
+                        <dt class='var-row' data-test-brand-guide-css-var>
+                          <code
+                            data-test-brand-guide-css-var-name
+                          >{{buildCssVariableName cssVar.name}}</code>
+                        </dt>
+                        <dd class='var-row'>
+                          <code
+                            class='css-var-value'
+                            data-test-brand-guide-css-var-value
+                          >{{cssVar.value}}</code>
+                        </dd>
+                      {{/if}}
+                    {{/each}}
+                  </dl>
+                </div>
               {{else if (eq section.id 'import-css')}}
                 <CssFieldEditor @setCss={{@model.setCss}} />
               {{else if (eq section.id 'inspirations')}}
@@ -412,6 +439,10 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
         --brand-guide-border: 1px solid var(--dsr-border);
         --brand-guide-spacing: var(--boxel-sp-xl);
         --boxel-container-padding: var(--brand-guide-spacing);
+        /* Pin tooltip colors so brand theme vars don't bleed into the overlay */
+        --boxel-tooltip-background-color: rgb(0 0 0 / 85%);
+        --boxel-tooltip-text-color: var(--boxel-light, #fff);
+        --boxel-tooltip-border-color: transparent;
       }
       .brand-guide-dashboard-header {
         position: relative;
@@ -680,7 +711,34 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
         font-size: 0.9em;
       }
 
-      /* Import Custom CSS */
+      /* Custom CSS / color variables section */
+      .brand-guide-custom-css-block {
+        position: relative;
+      }
+      .brand-guide-custom-css-block-copy-button {
+        position: absolute;
+        top: var(--boxel-sp-xs);
+        right: var(--boxel-sp-xs);
+      }
+      .var-row {
+        display: flex;
+        align-items: center;
+        gap: var(--boxel-sp-xs);
+      }
+      .color-entry {
+        display: flex;
+        align-items: center;
+      }
+      .css-var-value {
+        font-family: var(
+          --font-mono,
+          var(--boxel-monospace-font-family, monospace)
+        );
+        font-size: 0.9em;
+        color: var(--dsr-muted-fg);
+      }
+
+      /* Import CSS */
       .css-textarea {
         --boxel-input-height: 19rem;
       }
@@ -770,6 +828,11 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
       title: 'Brand Palette',
     },
     {
+      id: 'custom-css',
+      navTitle: 'Custom CSS',
+      title: 'Custom CSS Variables',
+    },
+    {
       id: 'typography',
       navTitle: 'Typography',
       title: 'Typography',
@@ -799,6 +862,10 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
 
       if (section.id === 'card-container-css') {
         return Boolean(this.args.model.cssVariables);
+      }
+
+      if (section.id === 'custom-css') {
+        return this.hasCustomVariables;
       }
 
       if (section.id === 'brand-palette') {
@@ -831,6 +898,51 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
     return (
       this.args.model?.brandColorPalette?.length ||
       this.args.model?.functionalPalette?.cssVariableFields?.length
+    );
+  }
+
+  private get paletteVarEntries() {
+    if (!entriesToCssRuleMap || !this.args.model?.brandColorPalette?.length) {
+      return [];
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let paletteRules = entriesToCssRuleMap(
+      this.args.model.brandColorPalette as any,
+    );
+    return this.args.model.brandColorPalette
+      .filter((color) => color.name)
+      .map((color) => ({
+        color,
+        varName: buildCssVariableName(color.name!),
+        colorValue: paletteRules.get(color.name!) ?? '',
+      }));
+  }
+
+  private get customCssVarsBlock() {
+    let lines: string[] = [];
+    if (entriesToCssRuleMap && this.args.model?.brandColorPalette?.length) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let paletteRules = entriesToCssRuleMap(
+        this.args.model.brandColorPalette as any,
+      );
+      for (let [name, colorValue] of paletteRules.entries()) {
+        lines.push(`${buildCssVariableName(name)}: ${colorValue};`);
+      }
+    }
+    for (let cssVar of this.args.model?.customCssVariables ?? []) {
+      let name = cssVar.name?.trim();
+      let value = cssVar.value?.trim();
+      if (name && value) {
+        lines.push(`${buildCssVariableName(name)}: ${value};`);
+      }
+    }
+    return lines.join('\n');
+  }
+
+  private get hasCustomVariables() {
+    return Boolean(
+      this.args.model?.brandColorPalette?.length ||
+      this.args.model?.customCssVariables?.length,
     );
   }
 
@@ -874,6 +986,52 @@ export class CompoundColorField extends FieldDef {
         }
         :deep(.boxel-swatch-value) {
           text-transform: lowercase;
+        }
+      </style>
+    </template>
+  };
+
+  static edit = class Edit extends Component<typeof this> {
+    <template>
+      <div class='compound-color-edit'>
+        <FieldContainer @label='Name' @vertical={{true}}>
+          <@fields.name />
+        </FieldContainer>
+        <FieldContainer @label='Color' @vertical={{true}}>
+          <@fields.value />
+        </FieldContainer>
+      </div>
+      <style scoped>
+        .compound-color-edit {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: var(--boxel-sp-sm);
+        }
+      </style>
+    </template>
+  };
+}
+
+export class CustomCssVariable extends FieldDef {
+  static displayName = 'Custom CSS Variable';
+  @field name = contains(StringField);
+  @field value = contains(StringField);
+
+  static edit = class Edit extends Component<typeof this> {
+    <template>
+      <div class='custom-css-variable-edit'>
+        <FieldContainer @label='Variable Name' @vertical={{true}}>
+          <@fields.name />
+        </FieldContainer>
+        <FieldContainer @label='Value' @vertical={{true}}>
+          <@fields.value />
+        </FieldContainer>
+      </div>
+      <style scoped>
+        .custom-css-variable-edit {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: var(--boxel-sp-sm);
         }
       </style>
     </template>
@@ -927,6 +1085,15 @@ export default class BrandGuide extends DetailedStyleRef {
         }
         brandRules.set(name, value);
       }
+    }
+
+    // add custom CSS variables
+    for (let cssVar of this.customCssVariables ?? []) {
+      let name = cssVar.name?.trim();
+      let value = cssVar.value?.trim();
+      if (!name || !value) continue;
+      let varName = buildCssVariableName(name);
+      if (!brandRules.has(varName)) brandRules.set(varName, value);
     }
 
     if (!brandRules.size) {
@@ -995,6 +1162,7 @@ export default class BrandGuide extends DetailedStyleRef {
   }
 
   @field brandColorPalette = containsMany(CompoundColorField);
+  @field customCssVariables = containsMany(CustomCssVariable);
   @field functionalPalette = contains(BrandFunctionalPalette);
   @field typography = contains(ThemeTypographyField);
   @field markUsage = contains(BrandLogo);

--- a/packages/base/brand-guide.gts
+++ b/packages/base/brand-guide.gts
@@ -29,6 +29,7 @@ import {
   buildCssVariableName,
   sanitizeHtmlSafe,
   eq,
+  CssVariableEntry,
 } from '@cardstack/boxel-ui/helpers';
 
 import { cardTypeDisplayName } from '@cardstack/runtime-common';
@@ -395,20 +396,18 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
                         />
                       </dd>
                     {{/each}}
-                    {{#each @model.customCssVariables as |cssVar|}}
-                      {{#if cssVar.name}}
-                        <dt class='var-row' data-test-brand-guide-css-var>
-                          <code
-                            data-test-brand-guide-css-var-name
-                          >{{buildCssVariableName cssVar.name}}</code>
-                        </dt>
-                        <dd class='var-row'>
-                          <code
-                            class='css-var-value'
-                            data-test-brand-guide-css-var-value
-                          >{{cssVar.value}}</code>
-                        </dd>
-                      {{/if}}
+                    {{#each this.customCssVarEntries as |entry|}}
+                      <dt class='var-row' data-test-brand-guide-css-var>
+                        <code
+                          data-test-brand-guide-css-var-name
+                        >{{entry.name}}</code>
+                      </dt>
+                      <dd class='var-row'>
+                        <code
+                          class='css-var-value'
+                          data-test-brand-guide-css-var-value
+                        >{{entry.value}}</code>
+                      </dd>
                     {{/each}}
                   </dl>
                 </div>
@@ -905,12 +904,11 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
     if (!entriesToCssRuleMap || !this.args.model?.brandColorPalette?.length) {
       return [];
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let paletteRules = entriesToCssRuleMap(
-      this.args.model.brandColorPalette as any,
+      this.args.model.brandColorPalette as any as CssVariableEntry[],
     );
     return this.args.model.brandColorPalette
-      .filter((color) => color.name)
+      .filter((color) => color.name && color.value)
       .map((color) => ({
         color,
         varName: buildCssVariableName(color.name!),
@@ -929,20 +927,27 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
         lines.push(`${buildCssVariableName(name)}: ${colorValue};`);
       }
     }
-    for (let cssVar of this.args.model?.customCssVariables ?? []) {
-      let name = cssVar.name?.trim();
-      let value = cssVar.value?.trim();
-      if (name && value) {
-        lines.push(`${buildCssVariableName(name)}: ${value};`);
-      }
+    for (let cssVar of this.customCssVarEntries) {
+      lines.push(`${cssVar.name}: ${cssVar.value};`);
     }
     return lines.join('\n');
+  }
+
+  private get customCssVarEntries() {
+    if (!entriesToCssRuleMap || !this.args.model?.customCssVariables?.length) {
+      return [];
+    }
+    let rules = entriesToCssRuleMap(this.args.model?.customCssVariables);
+    return [...rules.entries()].map(([name, value]) => ({
+      name: buildCssVariableName(name),
+      value,
+    }));
   }
 
   private get hasCustomVariables() {
     return Boolean(
       this.args.model?.brandColorPalette?.length ||
-      this.args.model?.customCssVariables?.length,
+      this.customCssVarEntries.length,
     );
   }
 

--- a/packages/base/structured-theme.gts
+++ b/packages/base/structured-theme.gts
@@ -51,7 +51,7 @@ export const GUIDE_SECTIONS = [
   {
     id: 'import-css',
     navTitle: 'Import CSS',
-    title: 'Import Custom CSS',
+    title: 'Import CSS',
     fieldName: null,
   },
   {

--- a/packages/host/tests/integration/components/brand-guide-custom-css-test.gts
+++ b/packages/host/tests/integration/components/brand-guide-custom-css-test.gts
@@ -58,10 +58,11 @@ module('Integration | brand-guide | custom-css section', function (hooks) {
       .exists('section appears with brandColorPalette');
   });
 
-  test('custom CSS variable names are normalized and values are rendered, with empty names filtered out', async function (this: RenderingTestContext, assert) {
+  test('custom CSS variable names are normalized and values are rendered, with incomplete entries filtered out', async function (this: RenderingTestContext, assert) {
     let card = new BrandGuide({
       customCssVariables: [
         new CustomCssVariable({ name: '', value: 'should-be-hidden' }),
+        new CustomCssVariable({ name: 'noValue', value: '' }),
         new CustomCssVariable({ name: 'myFont', value: 'Georgia, serif' }),
         new CustomCssVariable({ name: 'spacing', value: '1.5rem' }),
       ],
@@ -70,7 +71,10 @@ module('Integration | brand-guide | custom-css section', function (hooks) {
 
     assert
       .dom('[data-test-brand-guide-css-var]')
-      .exists({ count: 2 }, 'only entries with a name are rendered');
+      .exists(
+        { count: 2 },
+        'only entries with both name and value are rendered',
+      );
     assert
       .dom('[data-test-brand-guide-css-var-name]')
       .hasText(
@@ -79,12 +83,60 @@ module('Integration | brand-guide | custom-css section', function (hooks) {
       );
     assert
       .dom('[data-test-brand-guide-css-var-value]')
-      .exists({ count: 2 }, 'values render for each named entry');
+      .exists({ count: 2 }, 'values render for each complete entry');
     assert
       .dom(
         '[data-test-brand-guide-section="custom-css"] [data-test-boxel-copy-button]',
       )
       .exists('copy button is present');
+  });
+
+  test('custom-css section is hidden when all entries have missing name or value', async function (this: RenderingTestContext, assert) {
+    let card = new BrandGuide({
+      customCssVariables: [
+        new CustomCssVariable({ name: 'noValue', value: '' }),
+        new CustomCssVariable({ name: '', value: 'noName' }),
+      ],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    assert
+      .dom('[data-test-brand-guide-section="custom-css"]')
+      .doesNotExist('section hidden when no entry has both name and value');
+  });
+
+  test('trailing semicolons in custom CSS variable values are stripped in display and copy block', async function (this: RenderingTestContext, assert) {
+    let card = new BrandGuide({
+      customCssVariables: [
+        new CustomCssVariable({ name: 'myFont', value: 'Georgia, serif;' }),
+        new CustomCssVariable({ name: 'spacing', value: '1.5rem;;' }),
+      ],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    let valueEls = document.querySelectorAll(
+      '[data-test-brand-guide-css-var-value]',
+    );
+    assert.strictEqual(
+      valueEls[0]?.textContent,
+      'Georgia, serif',
+      'trailing semicolon is stripped in display',
+    );
+    assert.strictEqual(
+      valueEls[1]?.textContent,
+      '1.5rem',
+      'multiple trailing semicolons are stripped in display',
+    );
+
+    let css = card.cssVariables ?? '';
+    assert.ok(
+      css.includes('--my-font: Georgia, serif;'),
+      'copy block value has exactly one trailing semicolon',
+    );
+    assert.notOk(
+      css.includes(';;'),
+      'copy block never produces double semicolons',
+    );
   });
 
   test('customCssVariables appear in computed cssVariables with normalized names, empty-name entries excluded', async function (this: RenderingTestContext, assert) {
@@ -112,10 +164,11 @@ module('Integration | brand-guide | custom-css section', function (hooks) {
     );
   });
 
-  test('palette entries render var names and swatches, with nameless entries filtered out', async function (this: RenderingTestContext, assert) {
+  test('palette entries render var names and swatches, filtering entries missing name or value', async function (this: RenderingTestContext, assert) {
     let card = new BrandGuide({
       brandColorPalette: [
         new CompoundColorField({ name: '', value: '#ff0000' }),
+        new CompoundColorField({ name: 'noColor', value: '' }),
         new CompoundColorField({ name: 'primary', value: '#ff0000' }),
       ],
     });
@@ -123,7 +176,7 @@ module('Integration | brand-guide | custom-css section', function (hooks) {
 
     assert
       .dom('[data-test-brand-guide-palette-var]')
-      .exists({ count: 1 }, 'nameless palette entry is filtered out');
+      .exists({ count: 1 }, 'entries missing name or value are filtered out');
     assert
       .dom('[data-test-brand-guide-palette-var-name]')
       .hasText(

--- a/packages/host/tests/integration/components/brand-guide-custom-css-test.gts
+++ b/packages/host/tests/integration/components/brand-guide-custom-css-test.gts
@@ -1,0 +1,137 @@
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { baseRealm, type Loader } from '@cardstack/runtime-common';
+
+import type * as BrandGuideModule from 'https://cardstack.com/base/brand-guide';
+
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { renderCard } from '../../helpers/render-component';
+import { setupRenderingTest } from '../../helpers/setup';
+
+module('Integration | brand-guide | custom-css section', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+
+  let loader: Loader;
+  let BrandGuide: typeof BrandGuideModule.default;
+  let CompoundColorField: typeof BrandGuideModule.CompoundColorField;
+  let CustomCssVariable: typeof BrandGuideModule.CustomCssVariable;
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    loader = getService('loader-service').loader;
+    let brandGuideModule = await loader.import<typeof BrandGuideModule>(
+      `${baseRealm.url}brand-guide`,
+    );
+    BrandGuide = brandGuideModule.default;
+    CompoundColorField = brandGuideModule.CompoundColorField;
+    CustomCssVariable = brandGuideModule.CustomCssVariable;
+  });
+
+  test('custom-css section is visible when customCssVariables or brandColorPalette has entries', async function (this: RenderingTestContext, assert) {
+    let card = new BrandGuide();
+    await renderCard(loader, card, 'isolated');
+    assert
+      .dom('[data-test-brand-guide-section="custom-css"]')
+      .doesNotExist('hidden when no custom variables or palette entries exist');
+
+    let cardWithVars = new BrandGuide({
+      customCssVariables: [
+        new CustomCssVariable({ name: 'spacing-sm', value: '0.5rem' }),
+      ],
+    });
+    await renderCard(loader, cardWithVars, 'isolated');
+    assert
+      .dom('[data-test-brand-guide-section="custom-css"]')
+      .exists('section appears with customCssVariables');
+
+    let cardWithPalette = new BrandGuide({
+      brandColorPalette: [
+        new CompoundColorField({ name: 'brand-blue', value: '#0050ff' }),
+      ],
+    });
+    await renderCard(loader, cardWithPalette, 'isolated');
+    assert
+      .dom('[data-test-brand-guide-section="custom-css"]')
+      .exists('section appears with brandColorPalette');
+  });
+
+  test('custom CSS variable names are normalized and values are rendered, with empty names filtered out', async function (this: RenderingTestContext, assert) {
+    let card = new BrandGuide({
+      customCssVariables: [
+        new CustomCssVariable({ name: '', value: 'should-be-hidden' }),
+        new CustomCssVariable({ name: 'myFont', value: 'Georgia, serif' }),
+        new CustomCssVariable({ name: 'spacing', value: '1.5rem' }),
+      ],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    assert
+      .dom('[data-test-brand-guide-css-var]')
+      .exists({ count: 2 }, 'only entries with a name are rendered');
+    assert
+      .dom('[data-test-brand-guide-css-var-name]')
+      .hasText(
+        '--my-font',
+        'camelCase name is kebab-cased and prefixed with --',
+      );
+    assert
+      .dom('[data-test-brand-guide-css-var-value]')
+      .exists({ count: 2 }, 'values render for each named entry');
+    assert
+      .dom(
+        '[data-test-brand-guide-section="custom-css"] [data-test-boxel-copy-button]',
+      )
+      .exists('copy button is present');
+  });
+
+  test('customCssVariables appear in computed cssVariables with normalized names, empty-name entries excluded', async function (this: RenderingTestContext, assert) {
+    let card = new BrandGuide({
+      customCssVariables: [
+        new CustomCssVariable({ name: '', value: 'should-be-excluded' }),
+        new CustomCssVariable({ name: 'myFont', value: 'Georgia, serif' }),
+        new CustomCssVariable({ name: 'spacingSm', value: '0.5rem' }),
+      ],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    let css = card.cssVariables ?? '';
+    assert.ok(
+      css.includes('--my-font: Georgia, serif'),
+      'camelCase name is dasherized and prefixed with --',
+    );
+    assert.ok(
+      css.includes('--spacing-sm: 0.5rem'),
+      'camelCase compound name is dasherized correctly',
+    );
+    assert.notOk(
+      css.includes('should-be-excluded'),
+      'entry with empty name is excluded from cssVariables',
+    );
+  });
+
+  test('palette entries render var names and swatches, with nameless entries filtered out', async function (this: RenderingTestContext, assert) {
+    let card = new BrandGuide({
+      brandColorPalette: [
+        new CompoundColorField({ name: '', value: '#ff0000' }),
+        new CompoundColorField({ name: 'primary', value: '#ff0000' }),
+      ],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    assert
+      .dom('[data-test-brand-guide-palette-var]')
+      .exists({ count: 1 }, 'nameless palette entry is filtered out');
+    assert
+      .dom('[data-test-brand-guide-palette-var-name]')
+      .hasText(
+        '--primary',
+        'palette entry var name is shown as a CSS variable',
+      );
+    assert
+      .dom('[data-test-brand-guide-palette-swatch]')
+      .exists('palette entry renders a color swatch cell');
+  });
+});


### PR DESCRIPTION
Add "custom css variables" section to Brand Guide card after the custom brand colors section. Custom variables section will display the combination of all custom vars specific to this brand guide.

Edit:
<img width="772" height="306" alt="custom-css-edit" src="https://github.com/user-attachments/assets/4d1b8e40-8b17-4c53-9084-e2816db2c777" />

View:
<img width="778" height="499" alt="custom-css-display" src="https://github.com/user-attachments/assets/34e5d891-6896-4efb-9dca-7a983e63589c" />
