### PR TITLE
catalog-update: opt-out via SKIP_CATALOG_UPDATE

### DIFF
--- a/packages/catalog/scripts/catalog-update.sh
+++ b/packages/catalog/scripts/catalog-update.sh
@@ -9,6 +9,14 @@
 # git's original message.
 set -e
 
+# CI / sync-managed checkouts opt out: the caller has already placed the
+# exact commit they want at contents/, so a `git pull` would either fail
+# (detached HEAD) or silently move HEAD off the intended ref.
+if [ -n "${SKIP_CATALOG_UPDATE:-}" ]; then
+  echo "catalog: SKIP_CATALOG_UPDATE set, skipping update"
+  exit 0
+fi
+
 # Anchor to packages/catalog/ so the script works regardless of CWD
 # (e.g. `sh packages/catalog/scripts/catalog-update.sh` from repo root).
 SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
## Summary
- [cardstack/boxel-catalog](https://github.com/cardstack/boxel-catalog)'s CI does an explicit `actions/checkout` of the PR commit into `packages/catalog/contents/`, then runs `mise run test-services:host`. That eventually invokes `catalog:update` (`pnpm catalog:setup && cd contents && git pull` on `split-out-commands`).
- In CI logs this surfaces as:
  ```
  > @cardstack/catalog catalog:update
  > pnpm catalog:setup && cd contents && git pull
  > @cardstack/catalog catalog:setup
  > [ -d contents ] || (git clone …)
   ELIFECYCLE  Command failed with exit code 1.
   WARN   Local package.json exists, but node_modules missing, did you mean to install?
  ```
  The `WARN` is the tell: `pnpm` refuses to enter `contents/` because the checked-out catalog has its own `package.json` with no installed `node_modules`. The pull never even runs.
- Today this is **non-fatal**: [`mise-tasks/services/realm-server`](mise-tasks/services/realm-server) doesn't `set -e`, the realm-server boots normally off the existing checkout, and the surrounding workflow step is backgrounded with `&` — so the failure is invisible at the step level. But it's also fragile: tightening to `set -e`, or "fixing" pnpm to install on demand, would make catalog-update either kill the realm-server or silently move HEAD off the PR commit (`git pull` against `main`).
- Honor `SKIP_CATALOG_UPDATE=1` as an early-exit so CI / sync-managed checkouts can opt out cleanly. Local dev behavior is unchanged when the var is unset.

## Files
- `packages/catalog/scripts/catalog-update.sh` — env-gated early-exit

## Test plan
- [ ] Local `pnpm catalog:update` still pulls / stashes as documented when run with the env var unset.
- [ ] Setting `SKIP_CATALOG_UPDATE=1` prints the skip message and exits 0 without touching `contents/`.
- [ ] After boxel-catalog's companion change lands, its CI log no longer contains the `ELIFECYCLE` / `node_modules missing` warning under `catalog:update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)