### PR TITLE
Disable Embroider useAddonAppBoot

### DIFF
--- a/packages/host/ember-cli-build.js
+++ b/packages/host/ember-cli-build.js
@@ -12,5 +12,6 @@ module.exports = async function (defaults) {
   });
   return compatBuild(app, buildOnce, {
     staticAppPaths: ['lib'],
+    useAddonAppBoot: false,
   });
 };


### PR DESCRIPTION
## Summary

Embroider build was failing with a `WaitForTrees` error because some classic addon in the host dependency tree still provides `content-for 'app-boot'`, which Embroider no longer supports. The boot script in `packages/host/index.html` already initializes the application inline, so the addon-injected boot is redundant — opting out with `useAddonAppBoot: false` clears the error without changing runtime behavior.

## The build error

```
Build Error (WaitForTrees)

  Your app uses at least one classic addon that provides content-for 'app-boot'. This is no longer supported.
  With Embroider, you have full control over the app-boot script, so classic addons no longer need to modify it under the hood.
  The following code is used for your app boot:

    if (!runningTests) {
      require("@cardstack/host/app")["default"].create({"version":"0.0.0+<hash>"});
    }

  1. If you want to keep the same behavior, copy and paste it to the app-boot script included in app/index.html.
  2. Once app/index.html has the content you need, remove the present error by setting "useAddonAppBoot" to false in the build options.
```

## Why `useAddonAppBoot: false` is the right fix

Step 1 in the error is already satisfied. `packages/host/index.html` boots the app inline:

```html
<script type="module">
  import Application from './app/app';
  import environment from './app/config/environment';
  Application.create(environment.APP);
</script>
```

Tests use a separate `packages/host/tests/index.html`, so the legacy `!runningTests` guard from the addon-injected boot is not needed in the production `index.html` — the runtime behavior is preserved.

That leaves step 2 from the error: set `useAddonAppBoot: false` in the `compatBuild` options. That is the entirety of this PR.

## Test plan

- [ ] `cd packages/host && pnpm build` succeeds without the WaitForTrees `app-boot` error
- [ ] `pnpm start` boots the host app locally and renders normally
