### PR TITLE
Add phantom value factory for safe traversal through broken linked cards

### DIFF
--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -478,16 +478,19 @@ interface PhantomInternalState {
   sentinel: LinkSentinel | null;
 }
 
-// Cache key for the not-set state (no sentinel). Sentinel objects are used as
-// keys directly so a fresh sentinel for the same logical state still mints a
-// fresh phantom — identity tracks the sentinel object, not its `type` string.
-const NOT_SET_KEY: object = Object.freeze({});
-
-type PhantomFieldCache = Map<string, Map<unknown, PhantomValue>>;
+// Per-field cache: one slot for the not-set state and a WeakMap keyed by
+// sentinel object for the loaded / error / not-found states. Weak keys let an
+// obsolete sentinel (and its phantom) become collectable once the bucket
+// rewrites the field with a new sentinel — without weak keys the cache would
+// pin every historical sentinel for the lifetime of the card instance.
+interface PhantomFieldCache {
+  notSet: PhantomValue | undefined;
+  bySentinel: WeakMap<LinkSentinel, PhantomValue>;
+}
 
 const phantomCache = initSharedState(
   'phantomCache',
-  () => new WeakMap<BaseDef, PhantomFieldCache>(),
+  () => new WeakMap<BaseDef, Map<string, PhantomFieldCache>>(),
 );
 
 export function getPhantom(
@@ -502,24 +505,30 @@ export function getPhantom(
   }
   let byField = byInstance.get(fieldName);
   if (!byField) {
-    byField = new Map();
+    byField = { notSet: undefined, bySentinel: new WeakMap() };
     byInstance.set(fieldName, byField);
   }
-  let cacheKey: unknown = sentinel ?? NOT_SET_KEY;
-  let cached = byField.get(cacheKey);
+  if (sentinel === null) {
+    if (!byField.notSet) {
+      byField.notSet = createPhantom({ instance, fieldName, sentinel: null });
+    }
+    return byField.notSet;
+  }
+  let cached = byField.bySentinel.get(sentinel);
   if (cached) {
     return cached;
   }
   let phantom = createPhantom({ instance, fieldName, sentinel });
-  byField.set(cacheKey, phantom);
+  byField.bySentinel.set(sentinel, phantom);
   return phantom;
 }
 
 function createPhantom(state: PhantomInternalState): PhantomValue {
   // Arrow target keeps the proxy callable without dragging a non-configurable
-  // `prototype` own property (which would prevent the `has` trap from hiding
-  // it). `length` and `name` on arrows are configurable, so the `has` trap can
-  // report them absent without violating proxy invariants.
+  // `prototype` own property — that would force `has` to report `prototype`
+  // present and break the "every external key is absent" contract. `length`
+  // and `name` on arrows stay configurable, so `has` can hide them so long as
+  // the target stays extensible (see `preventExtensions` trap below).
   let target: object = () => {};
   let toPrimitive = () => null;
   let proxy = new Proxy(target, {
@@ -546,6 +555,20 @@ function createPhantom(state: PhantomInternalState): PhantomValue {
     },
     deleteProperty() {
       return true;
+    },
+    // Refuse hardening operations. Once the target is non-extensible, every
+    // own property on it must be reported by `has`; once any own property is
+    // non-configurable it cannot be hidden either. Letting `Object.freeze` /
+    // `Object.seal` / `Object.preventExtensions` / `Object.defineProperty`
+    // mutate the target would lock those properties down and break the
+    // "every external key is absent" invariant on subsequent access. Refusing
+    // raises a `TypeError` at the hardening call instead of corrupting the
+    // proxy.
+    preventExtensions() {
+      return false;
+    },
+    defineProperty() {
+      return false;
     },
     getPrototypeOf() {
       return null;

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -458,6 +458,29 @@ export function isNonPresentLink(val: any): val is LinkSentinel {
   return isNotLoadedValue(val) || isLinkError(val) || isLinkNotFound(val);
 }
 
+// A "phantom" is the stand-in value the linksTo / linksToMany getters
+// hand back when the link cannot produce a real card — i.e. for the
+// `not-loaded`, `link-error`, `link-not-found`, and `not-set` states.
+// The phantom replaces what those states surface as today (raw `null` or
+// a thrown TypeError when a computed traverses through the broken link)
+// with a safe placeholder so user code at the field-access boundary does
+// not blow up: `card.brokenLink.name` evaluates to `undefined` without
+// throwing.
+//
+// Concretely the phantom is a callable Proxy: every external property
+// read resolves to `undefined`, `apply` returns `undefined`,
+// `getPrototypeOf` is `null`, and `Symbol.toPrimitive` is `null`. It
+// carries its `(instance, fieldName, sentinel)` triple under a hidden
+// Symbol so the Relationship API can introspect *why* the link is broken
+// without that state leaking through the public `get` surface.
+//
+// The phantom is an object, not literal `undefined`. So
+// `card.brokenLink === undefined`, `card.brokenLink == null`, and
+// `!card.brokenLink` are all `false` — none of these can be made true on
+// a Proxy in standard ECMAScript (only `document.all`'s `[[IsHTMLDDA]]`
+// slot has that behaviour). Detection uses `isPhantom` or the
+// Relationship API, not falsiness.
+
 const PHANTOM_BRAND = Symbol('cardstack:phantom-brand');
 const PHANTOM_STATE = Symbol('cardstack:phantom-state');
 

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -481,8 +481,23 @@ export function isNonPresentLink(val: any): val is LinkSentinel {
 // slot has that behaviour). Detection uses `isPhantom` or the
 // Relationship API, not falsiness.
 
-const PHANTOM_BRAND = Symbol('cardstack:phantom-brand');
-const PHANTOM_STATE = Symbol('cardstack:phantom-state');
+// The Symbols are themselves shared state. `phantomCache` lives in
+// `initSharedState` (global across cooperating loaders), so a phantom minted
+// by one loader's copy of this module is reachable from another loader's
+// copy via the same cache. If each loader created its own `Symbol(...)`,
+// the two loaders would disagree on the brand and `isPhantom` /
+// `readPhantomState` would report false negatives across the boundary.
+// Stashing the Symbols in the shared bucket guarantees that every loader
+// copy ends up with the same Symbol identity, while keeping the Symbols
+// unreachable through the global Symbol registry (unlike `Symbol.for`).
+const PHANTOM_BRAND = initSharedState(
+  'phantomBrand',
+  () => Symbol('cardstack:phantom-brand'),
+);
+const PHANTOM_STATE = initSharedState(
+  'phantomState',
+  () => Symbol('cardstack:phantom-state'),
+);
 
 // Type-level brand declared independently from the runtime Symbols so the
 // public interface stays exportable without leaking the module-private
@@ -496,9 +511,9 @@ export interface PhantomValue {
 }
 
 interface PhantomInternalState {
-  instance: BaseDef;
-  fieldName: string;
-  sentinel: LinkSentinel | null;
+  readonly instance: BaseDef;
+  readonly fieldName: string;
+  readonly sentinel: LinkSentinel | null;
 }
 
 // Per-field cache: one slot for the not-set state and a WeakMap keyed by
@@ -547,6 +562,12 @@ export function getPhantom(
 }
 
 function createPhantom(state: PhantomInternalState): PhantomValue {
+  // Freeze the introspection record so `readPhantomState` consumers cannot
+  // mutate the phantom's `(instance, fieldName, sentinel)` triple in place.
+  // The proxy returns this exact object from `get(PHANTOM_STATE)`, so an
+  // unfrozen copy would let a single hostile caller corrupt every future
+  // read of the same phantom.
+  Object.freeze(state);
   // Arrow target keeps the proxy callable without dragging a non-configurable
   // `prototype` own property — that would force `has` to report `prototype`
   // present and break the "every external key is absent" contract. `length`

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -458,6 +458,132 @@ export function isNonPresentLink(val: any): val is LinkSentinel {
   return isNotLoadedValue(val) || isLinkError(val) || isLinkNotFound(val);
 }
 
+const PHANTOM_BRAND = Symbol('cardstack:phantom-brand');
+const PHANTOM_STATE = Symbol('cardstack:phantom-state');
+
+// Type-level brand declared independently from the runtime Symbols so the
+// public interface stays exportable without leaking the module-private
+// symbols. The runtime check that backs `isPhantom` consults the runtime
+// `PHANTOM_BRAND` Symbol; the declared brand below is purely for type
+// narrowing.
+declare const phantomBrand: unique symbol;
+
+export interface PhantomValue {
+  readonly [phantomBrand]: true;
+}
+
+interface PhantomInternalState {
+  instance: BaseDef;
+  fieldName: string;
+  sentinel: LinkSentinel | null;
+}
+
+// Cache key for the not-set state (no sentinel). Sentinel objects are used as
+// keys directly so a fresh sentinel for the same logical state still mints a
+// fresh phantom — identity tracks the sentinel object, not its `type` string.
+const NOT_SET_KEY: object = Object.freeze({});
+
+type PhantomFieldCache = Map<string, Map<unknown, PhantomValue>>;
+
+const phantomCache = initSharedState(
+  'phantomCache',
+  () => new WeakMap<BaseDef, PhantomFieldCache>(),
+);
+
+export function getPhantom(
+  instance: BaseDef,
+  fieldName: string,
+  sentinel: LinkSentinel | null,
+): PhantomValue {
+  let byInstance = phantomCache.get(instance);
+  if (!byInstance) {
+    byInstance = new Map();
+    phantomCache.set(instance, byInstance);
+  }
+  let byField = byInstance.get(fieldName);
+  if (!byField) {
+    byField = new Map();
+    byInstance.set(fieldName, byField);
+  }
+  let cacheKey: unknown = sentinel ?? NOT_SET_KEY;
+  let cached = byField.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  let phantom = createPhantom({ instance, fieldName, sentinel });
+  byField.set(cacheKey, phantom);
+  return phantom;
+}
+
+function createPhantom(state: PhantomInternalState): PhantomValue {
+  // Arrow target keeps the proxy callable without dragging a non-configurable
+  // `prototype` own property (which would prevent the `has` trap from hiding
+  // it). `length` and `name` on arrows are configurable, so the `has` trap can
+  // report them absent without violating proxy invariants.
+  let target: object = () => {};
+  let toPrimitive = () => null;
+  let proxy = new Proxy(target, {
+    get(_t, prop) {
+      if (prop === PHANTOM_BRAND) {
+        return true;
+      }
+      if (prop === PHANTOM_STATE) {
+        return state;
+      }
+      if (prop === Symbol.toPrimitive) {
+        return toPrimitive;
+      }
+      return undefined;
+    },
+    apply() {
+      return undefined;
+    },
+    has(_t, prop) {
+      return prop === PHANTOM_BRAND;
+    },
+    set() {
+      return true;
+    },
+    deleteProperty() {
+      return true;
+    },
+    getPrototypeOf() {
+      return null;
+    },
+  });
+  return proxy as PhantomValue;
+}
+
+export function isPhantom(v: unknown): v is PhantomValue {
+  if (v == null) {
+    return false;
+  }
+  if (typeof v !== 'object' && typeof v !== 'function') {
+    return false;
+  }
+  try {
+    return (v as { [PHANTOM_BRAND]?: unknown })[PHANTOM_BRAND] === true;
+  } catch {
+    return false;
+  }
+}
+
+// Internal accessor for introspecting the phantom's
+// `(instance, fieldName, sentinel)` triple without leaking it through the
+// public `get` surface — every external property read still resolves to
+// `undefined`. The public Relationship API consumes this to disambiguate
+// non-Present states.
+export function readPhantomState(
+  phantom: PhantomValue,
+): PhantomInternalState | undefined {
+  if (!isPhantom(phantom)) {
+    return undefined;
+  }
+  return (phantom as unknown as { [PHANTOM_STATE]: PhantomInternalState })[
+    PHANTOM_STATE
+  ];
+}
+
 export function peekAtField(instance: BaseDef, fieldName: string): any {
   let field = getField(instance, fieldName);
   if (!field) {

--- a/packages/host/tests/integration/field-support-phantom-test.gts
+++ b/packages/host/tests/integration/field-support-phantom-test.gts
@@ -1,0 +1,273 @@
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { baseRealm } from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import type { BaseDef } from 'https://cardstack.com/base/card-api';
+import type * as FieldSupportModule from 'https://cardstack.com/base/field-support';
+import type {
+  LinkErrorValue,
+  LinkNotFoundValue,
+  NotLoadedValue,
+} from 'https://cardstack.com/base/field-support';
+
+import { setupCardLogs, setupLocalIndexing } from '../helpers';
+import { setupBaseRealm } from '../helpers/base-realm';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupRenderingTest } from '../helpers/setup';
+
+let loader: Loader;
+let getPhantom: (typeof FieldSupportModule)['getPhantom'];
+let isPhantom: (typeof FieldSupportModule)['isPhantom'];
+let readPhantomState: (typeof FieldSupportModule)['readPhantomState'];
+
+const ref = 'https://example.test/cards/pet-1';
+
+function stubInstance(): BaseDef {
+  return {} as unknown as BaseDef;
+}
+
+function makeNotLoaded(reference = ref): NotLoadedValue {
+  return { type: 'not-loaded', reference };
+}
+
+function makeLinkError(reference = ref): LinkErrorValue {
+  return {
+    type: 'link-error',
+    reference,
+    errorDoc: { status: 500, message: 'boom', additionalErrors: null },
+  };
+}
+
+function makeLinkNotFound(reference = ref): LinkNotFoundValue {
+  return {
+    type: 'link-not-found',
+    reference,
+    errorDoc: { status: 404, message: 'missing', additionalErrors: null },
+  };
+}
+
+module('Integration | field-support | phantom value', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupCardLogs(
+    hooks,
+    async () => await loader.import(`${baseRealm.url}card-api`),
+  );
+  setupLocalIndexing(hooks);
+  setupMockMatrix(hooks);
+
+  hooks.beforeEach(async function () {
+    loader = getService('loader-service').loader;
+    let fieldSupport = await loader.import<typeof FieldSupportModule>(
+      `${baseRealm.url}field-support`,
+    );
+    getPhantom = fieldSupport.getPhantom;
+    isPhantom = fieldSupport.isPhantom;
+    readPhantomState = fieldSupport.readPhantomState;
+  });
+
+  test('every property access on the phantom resolves to undefined', function (assert) {
+    let phantom = getPhantom(stubInstance(), 'pet', makeNotLoaded());
+    assert.strictEqual((phantom as any).anyField, undefined);
+    assert.strictEqual((phantom as any).deeply, undefined);
+    assert.strictEqual((phantom as any)['kebab-prop'], undefined);
+    assert.strictEqual((phantom as any)[Symbol.iterator], undefined);
+    assert.strictEqual((phantom as any)[Symbol.asyncIterator], undefined);
+  });
+
+  test('invoking the phantom as a function returns undefined', function (assert) {
+    let phantom = getPhantom(stubInstance(), 'pet', makeNotLoaded());
+    let callable = phantom as unknown as (...args: unknown[]) => unknown;
+    assert.strictEqual(callable(), undefined);
+    assert.strictEqual(callable('a', 'b', 'c'), undefined);
+  });
+
+  test('getPrototypeOf returns null', function (assert) {
+    let phantom = getPhantom(stubInstance(), 'pet', makeNotLoaded());
+    assert.strictEqual(Object.getPrototypeOf(phantom), null);
+  });
+
+  test('Symbol.toPrimitive returns null', function (assert) {
+    let phantom = getPhantom(stubInstance(), 'pet', makeNotLoaded()) as any;
+    let toPrim = phantom[Symbol.toPrimitive];
+    assert.strictEqual(typeof toPrim, 'function');
+    assert.strictEqual(toPrim('default'), null);
+    assert.strictEqual(toPrim('number'), null);
+    assert.strictEqual(toPrim('string'), null);
+    // Coercions that flow through Symbol.toPrimitive collapse to null/zero.
+    assert.strictEqual(
+      +phantom,
+      0,
+      'numeric coercion yields ToNumber(null) = 0',
+    );
+    assert.strictEqual(
+      `${phantom}`,
+      'null',
+      'string coercion yields ToString(null)',
+    );
+  });
+
+  test('the phantom is identity-stable per (instance, fieldName, sentinel)', function (assert) {
+    let instance = stubInstance();
+    let sentinel = makeNotLoaded();
+    let a = getPhantom(instance, 'pet', sentinel);
+    let b = getPhantom(instance, 'pet', sentinel);
+    assert.strictEqual(a, b, 'same triple returns the same Proxy');
+  });
+
+  test('a different sentinel object yields a different phantom', function (assert) {
+    let instance = stubInstance();
+    let a = getPhantom(instance, 'pet', makeNotLoaded());
+    let b = getPhantom(instance, 'pet', makeNotLoaded());
+    assert.notStrictEqual(
+      a,
+      b,
+      'two distinct sentinel objects mint two distinct phantoms even if their type matches',
+    );
+  });
+
+  test('a different field name yields a different phantom', function (assert) {
+    let instance = stubInstance();
+    let sentinel = makeNotLoaded();
+    let petPhantom = getPhantom(instance, 'pet', sentinel);
+    let ownerPhantom = getPhantom(instance, 'owner', sentinel);
+    assert.notStrictEqual(petPhantom, ownerPhantom);
+  });
+
+  test('a different instance yields a different phantom', function (assert) {
+    let sentinel = makeNotLoaded();
+    let a = getPhantom(stubInstance(), 'pet', sentinel);
+    let b = getPhantom(stubInstance(), 'pet', sentinel);
+    assert.notStrictEqual(a, b);
+  });
+
+  test('null sentinel (not-set state) is supported and identity-stable', function (assert) {
+    let instance = stubInstance();
+    let a = getPhantom(instance, 'pet', null);
+    let b = getPhantom(instance, 'pet', null);
+    assert.strictEqual(
+      a,
+      b,
+      'the not-set phantom is cached per (instance, field)',
+    );
+    assert.true(isPhantom(a));
+  });
+
+  test('Error and NotFound sentinels each mint their own phantom', function (assert) {
+    let instance = stubInstance();
+    let err = makeLinkError();
+    let notFound = makeLinkNotFound();
+    let errPhantom = getPhantom(instance, 'pet', err);
+    let notFoundPhantom = getPhantom(instance, 'pet', notFound);
+    assert.notStrictEqual(errPhantom, notFoundPhantom);
+    assert.true(isPhantom(errPhantom));
+    assert.true(isPhantom(notFoundPhantom));
+  });
+
+  test('isPhantom narrows phantoms and rejects everything else', function (assert) {
+    let phantom = getPhantom(stubInstance(), 'pet', makeNotLoaded());
+    assert.true(isPhantom(phantom), 'phantom is recognized');
+
+    assert.false(isPhantom(null), 'null is not a phantom');
+    assert.false(isPhantom(undefined), 'undefined is not a phantom');
+    assert.false(isPhantom(0), 'numbers are not phantoms');
+    assert.false(isPhantom(''), 'strings are not phantoms');
+    assert.false(isPhantom(false), 'booleans are not phantoms');
+    assert.false(isPhantom({}), 'plain objects are not phantoms');
+    assert.false(isPhantom([]), 'arrays are not phantoms');
+    assert.false(
+      isPhantom(() => {}),
+      'arbitrary functions are not phantoms',
+    );
+    assert.false(
+      isPhantom(new Proxy({}, {})),
+      'unbranded proxies are not phantoms',
+    );
+    assert.false(
+      isPhantom({ type: 'link-error', reference: ref }),
+      'sentinel-shaped objects are not phantoms',
+    );
+
+    let v: unknown = phantom;
+    if (isPhantom(v)) {
+      // type narrowing exercise — `v` is `PhantomValue`, an opaque branded type
+      assert.ok(v, 'narrowed value remains an object');
+    } else {
+      assert.ok(false, 'isPhantom did not narrow');
+    }
+  });
+
+  test('readPhantomState exposes the (instance, fieldName, sentinel) triple', function (assert) {
+    let instance = stubInstance();
+    let sentinel = makeLinkError();
+    let phantom = getPhantom(instance, 'pet', sentinel);
+    let state = readPhantomState(phantom);
+    assert.ok(state, 'state is exposed for phantoms');
+    assert.strictEqual(state!.instance, instance);
+    assert.strictEqual(state!.fieldName, 'pet');
+    assert.strictEqual(state!.sentinel, sentinel);
+  });
+
+  test('readPhantomState returns undefined for non-phantoms', function (assert) {
+    assert.strictEqual(readPhantomState(null as any), undefined);
+    assert.strictEqual(readPhantomState({} as any), undefined);
+    assert.strictEqual(readPhantomState(makeNotLoaded() as any), undefined);
+  });
+
+  test('the hidden state symbol is not enumerable on the phantom surface', function (assert) {
+    let phantom = getPhantom(stubInstance(), 'pet', makeNotLoaded());
+    assert.deepEqual(
+      Object.keys(phantom as object),
+      [],
+      'Object.keys returns no own keys',
+    );
+    assert.deepEqual(
+      Object.getOwnPropertySymbols(phantom as object),
+      [],
+      'Object.getOwnPropertySymbols returns no own symbols',
+    );
+    let in_ = (key: PropertyKey) => key in (phantom as object);
+    assert.false(in_('anyField'), '"anyField" in phantom is false');
+    assert.false(in_(Symbol.iterator), 'Symbol.iterator in phantom is false');
+  });
+
+  test('writes and deletes against the phantom are silently absorbed', function (assert) {
+    let phantom = getPhantom(stubInstance(), 'pet', makeNotLoaded()) as any;
+    phantom.foo = 'bar';
+    assert.strictEqual(phantom.foo, undefined, 'a write does not change reads');
+    delete phantom.foo;
+    assert.strictEqual(phantom.foo, undefined, 'a delete is a no-op');
+  });
+
+  // Documenting JS-spec deviations from the ticket's stated mechanics:
+  // ECMAScript Abstract Equality returns false for any (Object, Null) pair
+  // without invoking Symbol.toPrimitive, and unary `!` on any object (outside
+  // `document.all`'s [[IsHTMLDDA]] slot) is always false. Detect non-Present
+  // via isPhantom or the Relationship API, not via `== null` or `!value`.
+  test('phantom is not loosely equal to null and is truthy', function (assert) {
+    let phantom = getPhantom(stubInstance(), 'pet', makeNotLoaded());
+    let looseEqualsNull = (phantom as unknown) == null;
+    assert.false(
+      looseEqualsNull,
+      '`phantom == null` is false: spec returns false for (Object, Null)',
+    );
+    let bangPhantom = !phantom;
+    assert.false(bangPhantom, '`!phantom` is false: any object is truthy');
+    assert.notStrictEqual(phantom as unknown, undefined);
+    assert.notStrictEqual(phantom as unknown, null);
+  });
+
+  test('one-level safe traversal: author.publisher.name returns undefined', function (assert) {
+    // Simulates the computed-traversal acceptance: a contained `author` field
+    // with a broken `publisher` linksTo. The phantom is returned for
+    // `author.publisher`, and `.name` on the phantom evaluates to undefined
+    // without TypeError. The broken-link boundary is the only thing shielded
+    // — deeper chains from undefined throw per ordinary JS semantics.
+    let publisher = getPhantom(stubInstance(), 'publisher', makeLinkNotFound());
+    let author = { publisher } as { publisher: unknown };
+    let name = (author.publisher as any).name;
+    assert.strictEqual(name, undefined);
+  });
+});

--- a/packages/host/tests/integration/field-support-phantom-test.gts
+++ b/packages/host/tests/integration/field-support-phantom-test.gts
@@ -241,6 +241,46 @@ module('Integration | field-support | phantom value', function (hooks) {
     assert.strictEqual(phantom.foo, undefined, 'a delete is a no-op');
   });
 
+  // Object.freeze / Object.seal / Object.preventExtensions on the proxy would
+  // make the function target non-extensible and (for freeze) lock its `length`
+  // and `name` properties to non-configurable. After that, the `has` trap
+  // returning false for those keys violates proxy invariants, turning the
+  // next property access into a TypeError. Refusing the hardening operation
+  // raises a TypeError at the freeze/seal call instead, and the phantom stays
+  // valid for subsequent reads.
+  test('freezing the phantom is refused and leaves it intact', function (assert) {
+    let phantom = getPhantom(stubInstance(), 'pet', makeNotLoaded());
+    assert.throws(
+      () => Object.preventExtensions(phantom as object),
+      TypeError,
+      'Object.preventExtensions throws TypeError',
+    );
+    assert.throws(
+      () => Object.freeze(phantom as object),
+      TypeError,
+      'Object.freeze throws TypeError',
+    );
+    assert.throws(
+      () => Object.seal(phantom as object),
+      TypeError,
+      'Object.seal throws TypeError',
+    );
+    assert.throws(
+      () => Object.defineProperty(phantom as object, 'foo', { value: 'bar' }),
+      TypeError,
+      'Object.defineProperty throws TypeError',
+    );
+    assert.strictEqual(
+      (phantom as any).anyField,
+      undefined,
+      'post-attempt property reads still resolve to undefined',
+    );
+    assert.true(
+      isPhantom(phantom),
+      'post-attempt the phantom still satisfies isPhantom',
+    );
+  });
+
   // Documenting JS-spec deviations from the ticket's stated mechanics:
   // ECMAScript Abstract Equality returns false for any (Object, Null) pair
   // without invoking Symbol.toPrimitive, and unary `!` on any object (outside

--- a/packages/host/tests/integration/field-support-phantom-test.gts
+++ b/packages/host/tests/integration/field-support-phantom-test.gts
@@ -216,6 +216,31 @@ module('Integration | field-support | phantom value', function (hooks) {
     assert.strictEqual(readPhantomState(makeNotLoaded() as any), undefined);
   });
 
+  test('readPhantomState returns a frozen record that cannot be mutated', function (assert) {
+    let instance = stubInstance();
+    let sentinel = makeLinkError();
+    let phantom = getPhantom(instance, 'pet', sentinel);
+    let state = readPhantomState(phantom)!;
+    assert.true(Object.isFrozen(state), 'state object is frozen');
+    assert.throws(
+      () => {
+        (state as any).fieldName = 'hacked';
+      },
+      TypeError,
+      'assigning fieldName throws in strict mode',
+    );
+    assert.throws(
+      () => {
+        (state as any).sentinel = null;
+      },
+      TypeError,
+      'assigning sentinel throws in strict mode',
+    );
+    let again = readPhantomState(phantom)!;
+    assert.strictEqual(again.fieldName, 'pet', 'fieldName unchanged');
+    assert.strictEqual(again.sentinel, sentinel, 'sentinel unchanged');
+  });
+
   test('the hidden state symbol is not enumerable on the phantom surface', function (assert) {
     let phantom = getPhantom(stubInstance(), 'pet', makeNotLoaded());
     assert.deepEqual(


### PR DESCRIPTION
Adds the phantom value factory and `isPhantom` predicate in
`packages/base/field-support.ts`. Stacked on the sentinel-union PR — no
producers yet; this is the second foundation piece of the broken-linksTo
tolerance project.

## What is a phantom

The phantom is the stand-in value the `linksTo` / `linksToMany` getters
will hand back when the link cannot produce a real card — for the
`not-loaded`, `link-error`, `link-not-found`, and `not-set` states.
Today those states surface as raw `null` or as a thrown `TypeError`
when a computed traverses through the broken link; the phantom replaces
both with a safe placeholder so user code at the field-access boundary
does not blow up: `card.brokenLink.name` evaluates to `undefined`
without throwing.

Concretely the phantom is a callable `Proxy`. Every external property
read resolves to `undefined`, `apply` returns `undefined`,
`getPrototypeOf` is `null`, and `Symbol.toPrimitive` is `null`. It
carries its `(instance, fieldName, sentinel)` triple under a hidden
Symbol so the upcoming Relationship API can introspect *why* the link
is broken without that state leaking through the public `get` surface.

The phantom is an **object**, not literal `undefined`. So
`card.brokenLink === undefined`, `card.brokenLink == null`, and
`!card.brokenLink` are all `false`. Detection uses `isPhantom` or the
Relationship API, not falsiness.

## API

```ts
function getPhantom(
  instance: BaseDef,
  fieldName: string,
  sentinel: LinkSentinel | null,
): PhantomValue;

function isPhantom(v: unknown): v is PhantomValue;
function readPhantomState(phantom: PhantomValue):
  | { instance: BaseDef; fieldName: string; sentinel: LinkSentinel | null }
  | undefined;
```

### Proxy mechanics

- **Callable.** Target is an arrow so the proxy is callable without
  dragging a non-configurable `prototype` own property — that would
  force `has` to report `prototype` present and break the "every
  external key is absent" contract. `length` and `name` on arrows stay
  configurable, so `has` can hide them as long as the target stays
  extensible.
- **`get`** returns `undefined` for every external property, including
  string keys, symbol keys, `Symbol.iterator`, and
  `Symbol.asyncIterator`. Two internal Symbols (module-private, not
  exported) carry the brand and state; consumers reach the state only
  through `readPhantomState`.
- **`apply`** returns `undefined`.
- **`getPrototypeOf`** returns `null`.
- **`Symbol.toPrimitive`** returns `null` so explicit numeric/string
  coercion (`+phantom`, `` `${phantom}` ``) collapses to `0` / `"null"`.
- **`set` / `deleteProperty`** are silent no-ops — writes never change
  what subsequent reads return.
- **`has`** reports every external key as absent; the brand symbol is
  the only `key in phantom` that returns true.
- **`preventExtensions` / `defineProperty`** refuse (return `false`).
  Letting them through would make the function target non-extensible
  and (for freeze) lock its own properties to non-configurable, after
  which the `has` trap hiding those keys would violate proxy
  invariants and the next property access would throw. Refusing raises
  `TypeError` at the freeze/seal call instead of corrupting the
  phantom.

### Identity stability

Cached per `(instance, fieldName, sentinel)`:

```
WeakMap<BaseDef, Map<fieldName, {
  notSet: PhantomValue | undefined;
  bySentinel: WeakMap<LinkSentinel, PhantomValue>;
}>>
```

Sentinel objects are weak keys: once the data bucket rewrites the field
with a fresh sentinel, the prior sentinel (and its phantom) become
unreachable externally and the WeakMap entry is collectable. The
not-set case uses a single slot — at most one phantom per
`(instance, field)` for that state. The cache is non-tracked, so
reading from it during render doesn't dirty any tag and doesn't violate
Glimmer's no-tracked-writes rule.

### Type-level brand

`PhantomValue` is declared with an opaque `unique symbol` brand
separate from the runtime brand Symbol. The runtime check inside
`isPhantom` consults the module-private runtime symbol; the
type-level brand keeps `PhantomValue` exportable without leaking the
runtime symbol. Callers narrow via `isPhantom(v)` and have no other
way to construct or inspect a `PhantomValue`.

## Spec deviations from the original mechanics sketch

The ticket's stated mechanics claimed `phantom == null` would be true
and `!phantom` would be true. Both are unachievable in standard
ECMAScript:

- Abstract Equality returns `false` for any `(Object, Null)` pair
  without invoking `Symbol.toPrimitive`.
- `!phantom` is `false` because any object that isn't `document.all`'s
  `[[IsHTMLDDA]]` slot is truthy.

The phantom still implements `Symbol.toPrimitive` returning `null` so
explicit coercion behaves null-ish, but loose `==` and unary `!` will
not. The recommended detection paths are `isPhantom(value)` and the
Relationship API. Two tests pin this behaviour to the spec so the
limitation is visible at review time. If you want a different
trade-off (e.g. transitive-self phantom so deep chains traverse, at
the cost of truthiness still being true), let me know — that is a
different mechanism, not a tweak.

## Not in this PR

- Producers — the `linksTo` / `linksToMany` getters still return their
  current values. Wiring is the next step in the project.
- General `computeVia` try/catch. Throws from user code in computeds
  still propagate.
- Multi-level traversal through the phantom. `get` returns `undefined`,
  so `phantom.foo.bar` throws per ordinary JS semantics — a literal
  reading of the mechanics. Switching to transitive-self would change
  that.

## Test plan

- [x] `pnpm lint:types` (host) — clean.
- [x] `eslint` on `packages/base/field-support.ts` (only a pre-existing
      warning at the legacy `getDataBucket(instance)?.keys()` line,
      unrelated to this change) and on the new
      `field-support-phantom-test.gts` (clean).
- [ ] `packages/host/tests/integration/field-support-phantom-test.gts`
      covers: per-property `undefined`, callability, prototype null,
      `Symbol.toPrimitive`, three-axis identity stability (instance /
      field / sentinel) including the not-set case, `isPhantom`
      positive + negative cases including unbranded proxies, hidden
      state accessor positive + negative cases, hidden state
      non-enumerable under `Object.keys` /
      `Object.getOwnPropertySymbols`, write/delete no-op, freeze/seal/
      preventExtensions/defineProperty refusal with post-attempt
      sanity check, the two documented spec deviations, and the
      one-level safe-traversal case (`author.publisher.name` returns
      `undefined` where `publisher` is the broken linksTo). Local test
      execution skipped — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
