### PR TITLE
Scan rendered instance for broken-link sentinels

### DIFF
--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -473,50 +473,42 @@ export interface BrokenLinkFinding {
   sentinel: LinkErrorValue | LinkNotFoundValue;
 }
 
-// Walks the top-level linksTo/linksToMany fields of `instance` and returns
-// every LinkError/LinkNotFound sentinel currently sitting in the data
-// bucket. NotLoaded sentinels are deliberately ignored — they represent
-// in-flight fetches, not terminal failures, and reading them does not
-// constitute a render error. Callers are expected to invoke this only
-// after the store has settled (e.g. after `await store.loaded()`), so any
-// remaining sentinel reliably reflects a completed fetch outcome.
+// Walks the declared top-level linksTo/linksToMany fields of `instance`
+// and returns every LinkError/LinkNotFound sentinel currently sitting in
+// the data bucket. NotLoaded sentinels are deliberately ignored — they
+// represent in-flight fetches, not terminal failures, and reading them
+// does not constitute a render error. Callers are expected to invoke
+// this only after the store has settled (e.g. after `await
+// store.loaded()`), so any remaining sentinel reliably reflects a
+// completed fetch outcome.
 //
-// Computed relationship fields (`computeVia`) are included so a computed
-// linksToMany that derives from a broken upstream link still surfaces
-// here. They go through `peekAtField` because their value lives in the
-// computeVia return, not the data bucket. For declared (non-computed)
-// fields we read the bucket directly — routing through the getter would
-// write the empty-value into the bucket as a side effect and pollute
-// `getUsedFields` for any subsequent caller.
+// This is intentionally side-effect-free: we read from the data bucket
+// directly rather than going through `peekAtField`/`getter`. That means
+// (a) untouched linksTo fields stay untouched (the getter would write
+// the empty-value back into the bucket and pollute `getUsedFields`),
+// and (b) the scan never invokes user-defined `computeVia` and so
+// cannot mutate tracked state or destabilize live field components if
+// the scan is ever called from a reactive context. Computed
+// relationship fields are therefore excluded — a follow-up can revisit
+// once we have a side-effect-safe way to inspect a computed value.
 export function scanForBrokenLinks(instance: BaseDef): BrokenLinkFinding[] {
   let findings: BrokenLinkFinding[] = [];
   let bucket = getDataBucket(instance);
-  let fields = getFields(instance, { includeComputeds: true });
+  let fields = getFields(instance);
   for (let [fieldName, field] of Object.entries(fields)) {
     if (!field) {
+      continue;
+    }
+    if (field.computeVia) {
       continue;
     }
     if (field.fieldType !== 'linksTo' && field.fieldType !== 'linksToMany') {
       continue;
     }
-    let value: unknown;
-    if (field.computeVia) {
-      // A user-defined computeVia is free to throw — that contract is
-      // theirs, not the scan's. The scan is a passive safety net, so
-      // swallow the exception and move on to the next field rather than
-      // dragging an unrelated computed-field error into the render
-      // pipeline through a new code path.
-      try {
-        value = peekAtField(instance, fieldName);
-      } catch (_e) {
-        continue;
-      }
-    } else {
-      if (!bucket.has(fieldName)) {
-        continue;
-      }
-      value = bucket.get(fieldName);
+    if (!bucket.has(fieldName)) {
+      continue;
     }
+    let value = bucket.get(fieldName);
     if (isLinkError(value) || isLinkNotFound(value)) {
       findings.push({ fieldName, sentinel: value });
       continue;

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -481,14 +481,17 @@ export interface BrokenLinkFinding {
 // after the store has settled (e.g. after `await store.loaded()`), so any
 // remaining sentinel reliably reflects a completed fetch outcome.
 //
-// We read from `getDataBucket` directly rather than `peekAtField` so that
-// linksTo fields that were never touched stay untouched — going through
-// the getter would write the empty-value into the bucket as a side effect
-// and pollute `getUsedFields` for any subsequent caller.
+// Computed relationship fields (`computeVia`) are included so a computed
+// linksToMany that derives from a broken upstream link still surfaces
+// here. They go through `peekAtField` because their value lives in the
+// computeVia return, not the data bucket. For declared (non-computed)
+// fields we read the bucket directly — routing through the getter would
+// write the empty-value into the bucket as a side effect and pollute
+// `getUsedFields` for any subsequent caller.
 export function scanForBrokenLinks(instance: BaseDef): BrokenLinkFinding[] {
   let findings: BrokenLinkFinding[] = [];
   let bucket = getDataBucket(instance);
-  let fields = getFields(instance);
+  let fields = getFields(instance, { includeComputeds: true });
   for (let [fieldName, field] of Object.entries(fields)) {
     if (!field) {
       continue;
@@ -496,10 +499,15 @@ export function scanForBrokenLinks(instance: BaseDef): BrokenLinkFinding[] {
     if (field.fieldType !== 'linksTo' && field.fieldType !== 'linksToMany') {
       continue;
     }
-    if (!bucket.has(fieldName)) {
-      continue;
+    let value: unknown;
+    if (field.computeVia) {
+      value = peekAtField(instance, fieldName);
+    } else {
+      if (!bucket.has(fieldName)) {
+        continue;
+      }
+      value = bucket.get(fieldName);
     }
-    let value = bucket.get(fieldName);
     if (isLinkError(value) || isLinkNotFound(value)) {
       findings.push({ fieldName, sentinel: value });
       continue;

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -482,15 +482,19 @@ export interface BrokenLinkFinding {
 // store.loaded()`), so any remaining sentinel reliably reflects a
 // completed fetch outcome.
 //
-// This is intentionally side-effect-free: we read from the data bucket
-// directly rather than going through `peekAtField`/`getter`. That means
-// (a) untouched linksTo fields stay untouched (the getter would write
-// the empty-value back into the bucket and pollute `getUsedFields`),
-// and (b) the scan never invokes user-defined `computeVia` and so
-// cannot mutate tracked state or destabilize live field components if
-// the scan is ever called from a reactive context. Computed
-// relationship fields are therefore excluded — a follow-up can revisit
-// once we have a side-effect-safe way to inspect a computed value.
+// Computed relationship fields are skipped: a computeVia returns the
+// field's value, and for linksTo / linksToMany that value has to be a
+// live CardDef instance (or null). The Error / NotFound sentinels are
+// only ever planted into the data bucket by `lazilyLoadLink`'s failure
+// path on a declared field, never produced by a computeVia — there is
+// no way to materialize a CardDef for a card that does not exist. The
+// declared field a computed derives from is itself in scope, so any
+// real broken-link state surfaces there.
+//
+// We also read from the data bucket directly rather than going through
+// `peekAtField` / the getter: routing through the getter would write
+// the empty-value back into the bucket for untouched linksTo fields
+// and pollute `getUsedFields` for any subsequent caller.
 export function scanForBrokenLinks(instance: BaseDef): BrokenLinkFinding[] {
   let findings: BrokenLinkFinding[] = [];
   let bucket = getDataBucket(instance);

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -482,14 +482,19 @@ export interface BrokenLinkFinding {
 // store.loaded()`), so any remaining sentinel reliably reflects a
 // completed fetch outcome.
 //
-// Computed relationship fields are skipped: a computeVia returns the
-// field's value, and for linksTo / linksToMany that value has to be a
-// live CardDef instance (or null). The Error / NotFound sentinels are
-// only ever planted into the data bucket by `lazilyLoadLink`'s failure
-// path on a declared field, never produced by a computeVia — there is
-// no way to materialize a CardDef for a card that does not exist. The
-// declared field a computed derives from is itself in scope, so any
-// real broken-link state surfaces there.
+// Computed relationship fields are skipped: the only producer of
+// LinkError / LinkNotFound sentinels is `lazilyLoadLink`'s failure
+// path in card-api.gts, and it only writes into the data bucket of
+// the **declared** field that failed to load — never into a computed
+// field (computed fields do not use the bucket; their value is the
+// return of `computeVia`). User computeVia code typically derives its
+// value from another field on the same instance (e.g. `return
+// this.declaredLink`), and the LinksTo getter for a NotLoaded
+// declared field returns `undefined` rather than handing the sentinel
+// back to user code, so a sentinel does not naturally flow through
+// the computed pipeline either. The declared field a computed derives
+// from is in scope here and is the only place a real broken-link
+// sentinel can live.
 //
 // We also read from the data bucket directly rather than going through
 // `peekAtField` / the getter: routing through the getter would write

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -468,6 +468,53 @@ export function peekAtField(instance: BaseDef, fieldName: string): any {
   return getter(instance, field);
 }
 
+export interface BrokenLinkFinding {
+  fieldName: string;
+  sentinel: LinkErrorValue | LinkNotFoundValue;
+}
+
+// Walks the top-level linksTo/linksToMany fields of `instance` and returns
+// every LinkError/LinkNotFound sentinel currently sitting in the data
+// bucket. NotLoaded sentinels are deliberately ignored — they represent
+// in-flight fetches, not terminal failures, and reading them does not
+// constitute a render error. Callers are expected to invoke this only
+// after the store has settled (e.g. after `await store.loaded()`), so any
+// remaining sentinel reliably reflects a completed fetch outcome.
+//
+// We read from `getDataBucket` directly rather than `peekAtField` so that
+// linksTo fields that were never touched stay untouched — going through
+// the getter would write the empty-value into the bucket as a side effect
+// and pollute `getUsedFields` for any subsequent caller.
+export function scanForBrokenLinks(instance: BaseDef): BrokenLinkFinding[] {
+  let findings: BrokenLinkFinding[] = [];
+  let bucket = getDataBucket(instance);
+  let fields = getFields(instance);
+  for (let [fieldName, field] of Object.entries(fields)) {
+    if (!field) {
+      continue;
+    }
+    if (field.fieldType !== 'linksTo' && field.fieldType !== 'linksToMany') {
+      continue;
+    }
+    if (!bucket.has(fieldName)) {
+      continue;
+    }
+    let value = bucket.get(fieldName);
+    if (isLinkError(value) || isLinkNotFound(value)) {
+      findings.push({ fieldName, sentinel: value });
+      continue;
+    }
+    if (field.fieldType === 'linksToMany' && Array.isArray(value)) {
+      for (let item of value) {
+        if (isLinkError(item) || isLinkNotFound(item)) {
+          findings.push({ fieldName, sentinel: item });
+        }
+      }
+    }
+  }
+  return findings;
+}
+
 type RelationshipMeta = NotLoadedRelationship | LoadedRelationship;
 interface NotLoadedRelationship {
   type: 'not-loaded';

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -501,7 +501,16 @@ export function scanForBrokenLinks(instance: BaseDef): BrokenLinkFinding[] {
     }
     let value: unknown;
     if (field.computeVia) {
-      value = peekAtField(instance, fieldName);
+      // A user-defined computeVia is free to throw — that contract is
+      // theirs, not the scan's. The scan is a passive safety net, so
+      // swallow the exception and move on to the next field rather than
+      // dragging an unrelated computed-field error into the render
+      // pipeline through a new code path.
+      try {
+        value = peekAtField(instance, fieldName);
+      } catch (_e) {
+        continue;
+      }
     } else {
       if (!bucket.has(fieldName)) {
         continue;

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -14,6 +14,7 @@ import Component from '@glimmer/component';
 import { didCancel, enqueueTask } from 'ember-concurrency';
 
 import {
+  baseRealm,
   CardError,
   SupportedMimeType,
   type CardErrorsJSONAPI,
@@ -35,6 +36,9 @@ import {
 } from '@cardstack/runtime-common';
 
 import { readFileAsText as _readFileAsText } from '@cardstack/runtime-common/stream';
+
+import type { CardDef } from 'https://cardstack.com/base/card-api';
+import type * as FieldSupport from 'https://cardstack.com/base/field-support';
 
 import {
   buildModuleModel,
@@ -359,6 +363,16 @@ export default class CardPrerender extends Component {
             0,
             initialRenderOptions,
           );
+          // Walk the rendered instance for LinkError/LinkNotFound
+          // sentinels and throw the structured failure payload — the
+          // catch block parses it into `cardError` the same way the
+          // legacy `boxel-render-error` CustomEvent path did. Reading
+          // the sentinel off the data bucket means we no longer need an
+          // event to fire during render to flag the failure.
+          let brokenLinkPayload = await this.#brokenLinkPayload();
+          if (brokenLinkPayload) {
+            throw new Error(brokenLinkPayload);
+          }
           meta = await this.renderMeta.perform(url, subsequentRenderOptions);
           headHTML = await this.renderHTML.perform(
             url,
@@ -692,6 +706,48 @@ export default class CardPrerender extends Component {
     } catch (_error) {
       // ignore
     }
+  }
+
+  async #brokenLinkPayload(): Promise<string | undefined> {
+    let renderModel = (globalThis as any).__renderModel as
+      | { instance?: CardDef }
+      | undefined;
+    let instance = renderModel?.instance;
+    if (!instance) {
+      return undefined;
+    }
+    let fieldSupport;
+    try {
+      fieldSupport = await this.loaderService.loader.import<
+        typeof FieldSupport
+      >(`${baseRealm.url}field-support`);
+    } catch (_e) {
+      return undefined;
+    }
+    let findings = fieldSupport.scanForBrokenLinks(instance);
+    if (findings.length === 0) {
+      return undefined;
+    }
+    let primary = findings[0].sentinel.errorDoc;
+    let deps = new Set<string>();
+    for (let finding of findings) {
+      deps.add(finding.sentinel.reference);
+    }
+    for (let dep of primary.deps ?? []) {
+      deps.add(dep);
+    }
+    let additionalErrors = [
+      ...(primary.additionalErrors ?? []),
+      ...findings.slice(1).map((f) => f.sentinel.errorDoc),
+    ];
+    return JSON.stringify({
+      type: 'instance-error',
+      error: {
+        ...primary,
+        deps: [...deps],
+        additionalErrors: additionalErrors.length ? additionalErrors : null,
+      },
+    });
   }
 
   #handleRenderErrorEvent = (

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -721,7 +721,15 @@ export default class CardPrerender extends Component {
       fieldSupport = await this.loaderService.loader.import<
         typeof FieldSupport
       >(`${baseRealm.url}field-support`);
-    } catch (_e) {
+    } catch (e) {
+      // Surface unexpected failures so a syntax error or missing export
+      // in field-support does not silently disable detection. Skip the
+      // scan rather than fail the render — the scan is a safety net,
+      // not the rendering contract.
+      console.warn(
+        'card-prerender: failed to load field-support for broken-link scan',
+        e,
+      );
       return undefined;
     }
     let findings = fieldSupport.scanForBrokenLinks(instance);
@@ -740,14 +748,23 @@ export default class CardPrerender extends Component {
       ...(primary.additionalErrors ?? []),
       ...findings.slice(1).map((f) => f.sentinel.errorDoc),
     ];
-    return JSON.stringify({
+    // Run the payload through the same normalize + withCardType
+    // enrichment that the legacy `boxel-render-error` listener uses, so
+    // downstream consumers (catch block parses `cardError`, indexer reads
+    // `searchData._cardType`) see the identical shape regardless of
+    // whether the failure arrived via event or sentinel scan.
+    let context = this.#currentContext ?? this.#contextFromDom();
+    let cardType = context ? this.#cardTypeTracker.get(context) : undefined;
+    let raw: RenderError = {
       type: 'instance-error',
       error: {
         ...primary,
         deps: [...deps],
         additionalErrors: additionalErrors.length ? additionalErrors : null,
       },
-    });
+    };
+    let normalized = normalizeRenderError(raw, { cardId: context?.cardId });
+    return JSON.stringify(withCardType(normalized, cardType));
   }
 
   #handleRenderErrorEvent = (

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -40,7 +40,6 @@ import {
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
-import type * as FieldSupport from 'https://cardstack.com/base/field-support';
 
 import {
   windowErrorHandler,
@@ -589,50 +588,6 @@ export default class RenderRoute extends Route<Model> {
     );
   }
 
-  async #brokenLinkPayload(instance: CardDef): Promise<string | undefined> {
-    let fieldSupport;
-    try {
-      fieldSupport = await this.loaderService.loader.import<
-        typeof FieldSupport
-      >(`${baseRealm.url}field-support`);
-    } catch (e) {
-      // Surface unexpected failures so a syntax error or missing export
-      // in field-support does not silently disable detection. Skip the
-      // scan rather than fail the render — the scan is a safety net,
-      // not the rendering contract.
-      console.warn(
-        'render-route: failed to load field-support for broken-link scan',
-        e,
-      );
-      return undefined;
-    }
-    let findings = fieldSupport.scanForBrokenLinks(instance);
-    if (findings.length === 0) {
-      return undefined;
-    }
-    let primary = findings[0].sentinel.errorDoc;
-    let deps = new Set<string>();
-    for (let finding of findings) {
-      deps.add(finding.sentinel.reference);
-    }
-    for (let dep of primary.deps ?? []) {
-      deps.add(dep);
-    }
-    let additionalErrors = [
-      ...(primary.additionalErrors ?? []),
-      ...findings.slice(1).map((f) => f.sentinel.errorDoc),
-    ];
-    let payload = {
-      type: 'instance-error' as const,
-      error: {
-        ...primary,
-        deps: [...deps],
-        additionalErrors: additionalErrors.length ? additionalErrors : null,
-      },
-    };
-    return JSON.stringify(payload);
-  }
-
   #touchFieldSafely(container: any, fieldName: string): unknown {
     try {
       // accessing the field triggers lazy loading for links
@@ -829,19 +784,6 @@ export default class RenderRoute extends Route<Model> {
     renderReadyLogger.debug(
       `settleModelAfterRender store.loaded resolved cardId=${model.cardId}`,
     );
-    // Walk the rendered instance's linksTo/linksToMany fields for
-    // LinkError/LinkNotFound sentinels and surface any finding as a
-    // structured render error. This complements (and post-T7 replaces)
-    // the legacy `boxel-render-error` CustomEvent path: by reading the
-    // sentinel off the deserialized bucket directly we no longer rely on
-    // an event firing during render to flag the failure.
-    if (model.instance) {
-      let brokenLinkPayload = await this.#brokenLinkPayload(model.instance);
-      if (brokenLinkPayload) {
-        this.#processRenderError(brokenLinkPayload);
-        return;
-      }
-    }
     modelState.state.set('status', 'ready');
     modelState.isReady = true;
     modelState.readyDeferred.fulfill();

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -40,6 +40,7 @@ import {
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
+import type * as FieldSupport from 'https://cardstack.com/base/field-support';
 
 import {
   windowErrorHandler,
@@ -108,6 +109,7 @@ export default class RenderRoute extends Route<Model> {
   private renderBaseParams: [string, string, string] | undefined;
   private lastRenderErrorSignature: string | undefined;
   #windowListenersAttached = false;
+  #fieldSupport: typeof FieldSupport | undefined;
   #cardTypeTracker = new RenderCardTypeTracker();
   #modelStates = new Map<Model, ModelState>();
   #pendingReadyModels = new Set<Model>();
@@ -190,6 +192,10 @@ export default class RenderRoute extends Route<Model> {
     this.#detachWindowErrorListeners();
     this.lastStoreResetKey = undefined;
     this.renderBaseParams = undefined;
+    // Drop the cached field-support reference so each fresh route
+    // activation re-resolves it through the current loader — important
+    // in tests where the loader is rebuilt between runs.
+    this.#fieldSupport = undefined;
     this.lastRenderErrorSignature = undefined;
     this.renderErrorState.clear();
     this.#modelStates.clear();
@@ -222,6 +228,24 @@ export default class RenderRoute extends Route<Model> {
       await this.store.ensureSetupComplete();
       this.#restoreRenderTimers = enableRenderTimerStub();
       this.#releaseTimerBlock = beginTimerBlock();
+    }
+    // Resolve field-support eagerly so the post-render broken-link scan
+    // in #settleModelAfterRender can run synchronously. Awaiting the
+    // import in settle adds a microtask between waiting for stability
+    // and fulfilling readyDeferred, which shifts the meta route's
+    // observed instance state and breaks tests that capture serialized
+    // output without first triggering a template render.
+    if (!this.#fieldSupport) {
+      try {
+        this.#fieldSupport = await this.loaderService.loader.import<
+          typeof FieldSupport
+        >(`${baseRealm.url}field-support`);
+      } catch (e) {
+        console.warn(
+          'render-route: failed to pre-load field-support for broken-link scan',
+          e,
+        );
+      }
     }
   }
 
@@ -588,6 +612,36 @@ export default class RenderRoute extends Route<Model> {
     );
   }
 
+  #brokenLinkPayload(instance: CardDef): string | undefined {
+    if (!this.#fieldSupport) {
+      return undefined;
+    }
+    let findings = this.#fieldSupport.scanForBrokenLinks(instance);
+    if (findings.length === 0) {
+      return undefined;
+    }
+    let primary = findings[0].sentinel.errorDoc;
+    let deps = new Set<string>();
+    for (let finding of findings) {
+      deps.add(finding.sentinel.reference);
+    }
+    for (let dep of primary.deps ?? []) {
+      deps.add(dep);
+    }
+    let additionalErrors = [
+      ...(primary.additionalErrors ?? []),
+      ...findings.slice(1).map((f) => f.sentinel.errorDoc),
+    ];
+    return JSON.stringify({
+      type: 'instance-error',
+      error: {
+        ...primary,
+        deps: [...deps],
+        additionalErrors: additionalErrors.length ? additionalErrors : null,
+      },
+    });
+  }
+
   #touchFieldSafely(container: any, fieldName: string): unknown {
     try {
       // accessing the field triggers lazy loading for links
@@ -784,6 +838,22 @@ export default class RenderRoute extends Route<Model> {
     renderReadyLogger.debug(
       `settleModelAfterRender store.loaded resolved cardId=${model.cardId}`,
     );
+    // Walk the rendered instance's declared linksTo/linksToMany fields
+    // for LinkError/LinkNotFound sentinels and route any finding through
+    // `#processRenderError` so the prerender server picks the failure up
+    // via the `data-prerender-error` DOM marker — the same way the
+    // legacy `boxel-render-error` listener (still attached above) does.
+    // We use the pre-resolved field-support reference so this stays
+    // synchronous: adding an `await` between stability and readyDeferred
+    // fulfillment shifts microtask timing and changes what the meta
+    // route observes when serializing the instance.
+    if (model.instance && this.#fieldSupport) {
+      let brokenLinkPayload = this.#brokenLinkPayload(model.instance);
+      if (brokenLinkPayload) {
+        this.#processRenderError(brokenLinkPayload);
+        return;
+      }
+    }
     modelState.state.set('status', 'ready');
     modelState.isReady = true;
     modelState.readyDeferred.fulfill();

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -40,6 +40,7 @@ import {
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
+import type * as FieldSupport from 'https://cardstack.com/base/field-support';
 
 import {
   windowErrorHandler,
@@ -588,6 +589,45 @@ export default class RenderRoute extends Route<Model> {
     );
   }
 
+  async #brokenLinkPayload(instance: CardDef): Promise<string | undefined> {
+    let fieldSupport;
+    try {
+      fieldSupport = await this.loaderService.loader.import<
+        typeof FieldSupport
+      >(`${baseRealm.url}field-support`);
+    } catch (_e) {
+      // During a cold dev boot the field-support module may briefly be
+      // unavailable; fall through and skip the scan rather than error out
+      // the render.
+      return undefined;
+    }
+    let findings = fieldSupport.scanForBrokenLinks(instance);
+    if (findings.length === 0) {
+      return undefined;
+    }
+    let primary = findings[0].sentinel.errorDoc;
+    let deps = new Set<string>();
+    for (let finding of findings) {
+      deps.add(finding.sentinel.reference);
+    }
+    for (let dep of primary.deps ?? []) {
+      deps.add(dep);
+    }
+    let additionalErrors = [
+      ...(primary.additionalErrors ?? []),
+      ...findings.slice(1).map((f) => f.sentinel.errorDoc),
+    ];
+    let payload = {
+      type: 'instance-error' as const,
+      error: {
+        ...primary,
+        deps: [...deps],
+        additionalErrors: additionalErrors.length ? additionalErrors : null,
+      },
+    };
+    return JSON.stringify(payload);
+  }
+
   #touchFieldSafely(container: any, fieldName: string): unknown {
     try {
       // accessing the field triggers lazy loading for links
@@ -784,6 +824,19 @@ export default class RenderRoute extends Route<Model> {
     renderReadyLogger.debug(
       `settleModelAfterRender store.loaded resolved cardId=${model.cardId}`,
     );
+    // Walk the rendered instance's linksTo/linksToMany fields for
+    // LinkError/LinkNotFound sentinels and surface any finding as a
+    // structured render error. This complements (and post-T7 replaces)
+    // the legacy `boxel-render-error` CustomEvent path: by reading the
+    // sentinel off the deserialized bucket directly we no longer rely on
+    // an event firing during render to flag the failure.
+    if (model.instance) {
+      let brokenLinkPayload = await this.#brokenLinkPayload(model.instance);
+      if (brokenLinkPayload) {
+        this.#processRenderError(brokenLinkPayload);
+        return;
+      }
+    }
     modelState.state.set('status', 'ready');
     modelState.isReady = true;
     modelState.readyDeferred.fulfill();

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -595,10 +595,15 @@ export default class RenderRoute extends Route<Model> {
       fieldSupport = await this.loaderService.loader.import<
         typeof FieldSupport
       >(`${baseRealm.url}field-support`);
-    } catch (_e) {
-      // During a cold dev boot the field-support module may briefly be
-      // unavailable; fall through and skip the scan rather than error out
-      // the render.
+    } catch (e) {
+      // Surface unexpected failures so a syntax error or missing export
+      // in field-support does not silently disable detection. Skip the
+      // scan rather than fail the render — the scan is a safety net,
+      // not the rendering contract.
+      console.warn(
+        'render-route: failed to load field-support for broken-link scan',
+        e,
+      );
       return undefined;
     }
     let findings = fieldSupport.scanForBrokenLinks(instance);

--- a/packages/host/tests/integration/field-support-predicates-test.gts
+++ b/packages/host/tests/integration/field-support-predicates-test.gts
@@ -367,7 +367,14 @@ module(
       assert.strictEqual(findings[0].sentinel.type, 'link-error');
     });
 
-    test('scanForBrokenLinks finds a sentinel returned by a computed linksTo', function (assert) {
+    test('scanForBrokenLinks skips computed linksTo fields', function (assert) {
+      // The scan is deliberately side-effect-free and does not invoke
+      // any field's computeVia (the getter writes to the bucket and
+      // entangles tracking; both are unsafe if the scan ever runs in a
+      // reactive context near a live field component). Computed
+      // relationships are therefore out of scope; any LinkError /
+      // LinkNotFound surfacing through a computed must be detected by
+      // the declared field it derives from.
       class Pet extends CardDef {
         @field name = contains(StringField);
       }
@@ -381,30 +388,11 @@ module(
         });
       }
       let alice = new Person({ firstName: 'Alice' });
-      let findings = scanForBrokenLinks(alice);
-      assert.strictEqual(findings.length, 1, 'computed linksTo is scanned');
-      assert.strictEqual(findings[0].fieldName, 'favoritePet');
-      assert.strictEqual(findings[0].sentinel.type, 'link-error');
-    });
-
-    test('scanForBrokenLinks finds sentinels returned inside a computed linksToMany array', function (assert) {
-      class Pet extends CardDef {
-        @field name = contains(StringField);
-      }
-      let brokenSentinel = makeLinkNotFound();
-      class Person extends CardDef {
-        @field firstName = contains(StringField);
-        @field pets = linksToMany(Pet, {
-          computeVia: function (this: Person) {
-            return [brokenSentinel as unknown as Pet];
-          },
-        });
-      }
-      let alice = new Person({ firstName: 'Alice' });
-      let findings = scanForBrokenLinks(alice);
-      assert.strictEqual(findings.length, 1, 'computed linksToMany is scanned');
-      assert.strictEqual(findings[0].fieldName, 'pets');
-      assert.strictEqual(findings[0].sentinel.type, 'link-not-found');
+      assert.deepEqual(
+        scanForBrokenLinks(alice),
+        [],
+        'computed linksTo is intentionally not scanned',
+      );
     });
 
     test('scanForBrokenLinks aggregates findings across multiple linksTo fields', function (assert) {

--- a/packages/host/tests/integration/field-support-predicates-test.gts
+++ b/packages/host/tests/integration/field-support-predicates-test.gts
@@ -368,13 +368,12 @@ module(
     });
 
     test('scanForBrokenLinks skips computed linksTo fields', function (assert) {
-      // The scan is deliberately side-effect-free and does not invoke
-      // any field's computeVia (the getter writes to the bucket and
-      // entangles tracking; both are unsafe if the scan ever runs in a
-      // reactive context near a live field component). Computed
-      // relationships are therefore out of scope; any LinkError /
-      // LinkNotFound surfacing through a computed must be detected by
-      // the declared field it derives from.
+      // A computeVia returns the field's value, and for linksTo the
+      // value has to be a live CardDef instance — Error/NotFound
+      // sentinels are only ever planted by lazilyLoadLink's failure
+      // path on a declared field, never produced by a computed. The
+      // synthetic-sentinel return below is contrived to confirm the
+      // scan does not attempt to inspect computeds at all.
       class Pet extends CardDef {
         @field name = contains(StringField);
       }

--- a/packages/host/tests/integration/field-support-predicates-test.gts
+++ b/packages/host/tests/integration/field-support-predicates-test.gts
@@ -367,6 +367,46 @@ module(
       assert.strictEqual(findings[0].sentinel.type, 'link-error');
     });
 
+    test('scanForBrokenLinks finds a sentinel returned by a computed linksTo', function (assert) {
+      class Pet extends CardDef {
+        @field name = contains(StringField);
+      }
+      let brokenSentinel = makeLinkError();
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field favoritePet = linksTo(Pet, {
+          computeVia: function (this: Person) {
+            return brokenSentinel as unknown as Pet;
+          },
+        });
+      }
+      let alice = new Person({ firstName: 'Alice' });
+      let findings = scanForBrokenLinks(alice);
+      assert.strictEqual(findings.length, 1, 'computed linksTo is scanned');
+      assert.strictEqual(findings[0].fieldName, 'favoritePet');
+      assert.strictEqual(findings[0].sentinel.type, 'link-error');
+    });
+
+    test('scanForBrokenLinks finds sentinels returned inside a computed linksToMany array', function (assert) {
+      class Pet extends CardDef {
+        @field name = contains(StringField);
+      }
+      let brokenSentinel = makeLinkNotFound();
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pets = linksToMany(Pet, {
+          computeVia: function (this: Person) {
+            return [brokenSentinel as unknown as Pet];
+          },
+        });
+      }
+      let alice = new Person({ firstName: 'Alice' });
+      let findings = scanForBrokenLinks(alice);
+      assert.strictEqual(findings.length, 1, 'computed linksToMany is scanned');
+      assert.strictEqual(findings[0].fieldName, 'pets');
+      assert.strictEqual(findings[0].sentinel.type, 'link-not-found');
+    });
+
     test('scanForBrokenLinks aggregates findings across multiple linksTo fields', function (assert) {
       class Pet extends CardDef {
         @field name = contains(StringField);

--- a/packages/host/tests/integration/field-support-predicates-test.gts
+++ b/packages/host/tests/integration/field-support-predicates-test.gts
@@ -7,7 +7,15 @@ import type { Loader } from '@cardstack/runtime-common/loader';
 import type * as FieldSupportModule from 'https://cardstack.com/base/field-support';
 
 import { setupCardLogs, setupLocalIndexing } from '../helpers';
-import { setupBaseRealm } from '../helpers/base-realm';
+import {
+  setupBaseRealm,
+  CardDef,
+  StringField,
+  field,
+  contains,
+  linksTo,
+  linksToMany,
+} from '../helpers/base-realm';
 import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupRenderingTest } from '../helpers/setup';
 
@@ -16,6 +24,8 @@ let isNotLoadedValue: (typeof FieldSupportModule)['isNotLoadedValue'];
 let isLinkError: (typeof FieldSupportModule)['isLinkError'];
 let isLinkNotFound: (typeof FieldSupportModule)['isLinkNotFound'];
 let isNonPresentLink: (typeof FieldSupportModule)['isNonPresentLink'];
+let scanForBrokenLinks: (typeof FieldSupportModule)['scanForBrokenLinks'];
+let getDataBucket: (typeof FieldSupportModule)['getDataBucket'];
 
 const ref = 'https://example.test/cards/pet-1';
 
@@ -68,6 +78,8 @@ module(
       isLinkError = fieldSupport.isLinkError;
       isLinkNotFound = fieldSupport.isLinkNotFound;
       isNonPresentLink = fieldSupport.isNonPresentLink;
+      scanForBrokenLinks = fieldSupport.scanForBrokenLinks;
+      getDataBucket = fieldSupport.getDataBucket;
     });
 
     test('isNotLoadedValue only matches the not-loaded sentinel', function (assert) {
@@ -248,6 +260,134 @@ module(
       } else {
         assert.ok(false, 'isNonPresentLink did not narrow as expected');
       }
+    });
+
+    test('scanForBrokenLinks finds nothing on a card with no sentinels', function (assert) {
+      class Pet extends CardDef {
+        @field name = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      let alice = new Person({ firstName: 'Alice' });
+      assert.deepEqual(scanForBrokenLinks(alice), []);
+    });
+
+    test('scanForBrokenLinks finds a singular linksTo link-error sentinel', function (assert) {
+      class Pet extends CardDef {
+        @field name = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      let alice = new Person({ firstName: 'Alice' });
+      getDataBucket(alice).set('pet', makeLinkError());
+      let findings = scanForBrokenLinks(alice);
+      assert.strictEqual(findings.length, 1, 'one finding emitted');
+      assert.strictEqual(findings[0].fieldName, 'pet');
+      assert.strictEqual(findings[0].sentinel.type, 'link-error');
+      assert.strictEqual(findings[0].sentinel.reference, ref);
+    });
+
+    test('scanForBrokenLinks finds a singular linksTo link-not-found sentinel', function (assert) {
+      class Pet extends CardDef {
+        @field name = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      let alice = new Person({ firstName: 'Alice' });
+      getDataBucket(alice).set('pet', makeLinkNotFound());
+      let findings = scanForBrokenLinks(alice);
+      assert.strictEqual(findings.length, 1);
+      assert.strictEqual(findings[0].fieldName, 'pet');
+      assert.strictEqual(findings[0].sentinel.type, 'link-not-found');
+    });
+
+    test('scanForBrokenLinks ignores not-loaded sentinels', function (assert) {
+      class Pet extends CardDef {
+        @field name = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      let alice = new Person({ firstName: 'Alice' });
+      getDataBucket(alice).set('pet', makeNotLoaded());
+      assert.deepEqual(
+        scanForBrokenLinks(alice),
+        [],
+        'not-loaded is a transient state, not a render failure',
+      );
+    });
+
+    test('scanForBrokenLinks finds a broken element inside a linksToMany array', function (assert) {
+      class Pet extends CardDef {
+        @field name = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pets = linksToMany(Pet);
+      }
+      let alice = new Person({ firstName: 'Alice' });
+      let healthyPet = new Pet({ name: 'Mango' });
+      getDataBucket(alice).set('pets', [
+        healthyPet,
+        makeLinkError(),
+        makeLinkNotFound(),
+      ]);
+      let findings = scanForBrokenLinks(alice);
+      assert.strictEqual(findings.length, 2);
+      assert.strictEqual(findings[0].fieldName, 'pets');
+      assert.strictEqual(findings[0].sentinel.type, 'link-error');
+      assert.strictEqual(findings[1].fieldName, 'pets');
+      assert.strictEqual(findings[1].sentinel.type, 'link-not-found');
+    });
+
+    test('scanForBrokenLinks finds a sentinel-shaped linksToMany whole-field value', function (assert) {
+      class Pet extends CardDef {
+        @field name = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pets = linksToMany(Pet);
+      }
+      let alice = new Person({ firstName: 'Alice' });
+      // Computed linksToMany that consumes a not-yet-resolved link can
+      // surface a single sentinel as the whole field value (see
+      // relationshipMeta's plural branch). Verify the scan handles that
+      // shape as well.
+      getDataBucket(alice).set('pets', makeLinkError());
+      let findings = scanForBrokenLinks(alice);
+      assert.strictEqual(findings.length, 1);
+      assert.strictEqual(findings[0].fieldName, 'pets');
+      assert.strictEqual(findings[0].sentinel.type, 'link-error');
+    });
+
+    test('scanForBrokenLinks aggregates findings across multiple linksTo fields', function (assert) {
+      class Pet extends CardDef {
+        @field name = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+        @field rival = linksTo(Pet);
+      }
+      let alice = new Person({ firstName: 'Alice' });
+      getDataBucket(alice).set('pet', makeLinkError());
+      getDataBucket(alice).set('rival', makeLinkNotFound());
+      let findings = scanForBrokenLinks(alice);
+      assert.strictEqual(findings.length, 2);
+      let byField = Object.fromEntries(
+        findings.map((f) => [f.fieldName, f.sentinel.type]),
+      );
+      assert.deepEqual(byField, {
+        pet: 'link-error',
+        rival: 'link-not-found',
+      });
     });
   },
 );


### PR DESCRIPTION
Stacked on #4953 (CS-11215). No producers of the LinkError/LinkNotFound
sentinels exist yet, so this is dormant infrastructure until
`lazilyLoadLink`'s rewrite (CS-11218 / T7) lands.

## What

`scanForBrokenLinks(instance)` walks an instance's declared top-level
linksTo/linksToMany fields and returns every LinkError/LinkNotFound
sentinel sitting in the data bucket. NotLoaded is ignored (transient
state, not a render failure).

The scan is deliberately side-effect-free:
- reads `getDataBucket(instance)` directly (no `peekAtField`/getter,
  so untouched fields are not poked and the bucket is not polluted
  with empty-value writes that would later mislead `getUsedFields`);
- never invokes user `computeVia`, so it cannot mutate tracked state
  or destabilize a live field component if the scan is ever called
  near a reactive context;
- computed relationship fields are skipped — a computed linksTo can
  only surface a sentinel that exists on the declared field it
  derives from, and the declared field is scanned.

Two callers wire the scan into the existing render-error pipeline:

- `routes/render.ts` `#settleModelAfterRender` — after
  `#waitForRenderLoadStability` resolves, runs the scan and routes
  findings through `#processRenderError` so the prerender server
  picks the failure up via the `data-prerender-error` DOM marker.
  This is the **production indexing path**. Field-support is
  resolved once in `beforeModel` and stashed on the route, so settle
  stays synchronous — an earlier attempt awaited the import inside
  settle and shifted microtask timing between stability and
  `readyDeferred.fulfill`, which changed what the meta route
  observed and broke three prerender-meta tests. The cached
  reference is dropped in `deactivate` so each fresh activation
  re-resolves through the current loader.
- `card-prerender.gts` cardRender pass — the Ember-test-only
  prerender component scans after the isolated `renderHTML` returns
  and throws the structured payload so `response.card.error` is
  populated in tests the same way the legacy `boxel-render-error`
  listener used to populate it. The payload is normalized via
  `normalizeRenderError` + `withCardType` to match the legacy event
  path one-for-one — including `applyMissingLinkOverrides` for 404
  sentinels and the `cardType` enrichment the indexer reads as
  `searchData._cardType`.

The legacy `boxel-render-error` dispatch in `card-api.gts` and both
listeners stay in place — removing them is explicitly out of scope
per the Linear ticket.

## Why

Per the project plan, the lazyLoadLink rewrite (next ticket in the
chain) stops dispatching `boxel-render-error` and starts planting
LinkError/LinkNotFound sentinels into the data bucket instead. This
PR provides the sentinel-aware path that consumes the new state so
the legacy event-dispatch path can be retired without losing the
indexer's structured failure signal — on both the production
(prerender-server) and Ember-test indexing paths.

## Test plan

- [x] Lint clean on the changed files.
- [x] Unit tests in `field-support-predicates-test.gts`: no findings
  on a clean instance, link-error / link-not-found detected on a
  singular linksTo, not-loaded ignored, broken element detected
  inside a linksToMany array, whole-field sentinel value on a
  linksToMany also detected, computed linksTo intentionally skipped,
  multiple linksTo findings aggregated by field name.
- [ ] End-to-end coverage of the route + prerender wiring lands
  with the lazyLoadLink rewrite once a producer of the sentinels
  exists. Until then both call sites are unreachable in normal
  indexing flow and are exercised only by the unit tests.

Linear: CS-11217 (T6 in the project plan).