### PR TITLE
Add more environment mode fixes

### DIFF
--- a/packages/host/scripts/traefik-helpers.js
+++ b/packages/host/scripts/traefik-helpers.js
@@ -9,7 +9,10 @@ const fs = require('fs');
 
 function getEnvSlug() {
   // Prefer ENV_SLUG from mise's env-vars.sh (canonical: scripts/env-slug.sh);
-  // fall back to computing it for non-mise contexts.
+  // fall back to computing it for non-mise contexts. Cap at 63 chars
+  // (DNS label limit) so the slug works as a hostname label in
+  // `<service>.<slug>.localhost` — Chrome silently routes hostnames
+  // with over-63-char labels to the search engine.
   if (process.env.ENV_SLUG) return process.env.ENV_SLUG;
   const raw = process.env.BOXEL_ENVIRONMENT || '';
   return raw
@@ -17,6 +20,7 @@ function getEnvSlug() {
     .replace(/\//g, '-')
     .replace(/[^a-z0-9-]/g, '')
     .replace(/-+/g, '-')
+    .slice(0, 63)
     .replace(/^-|-$/g, '');
 }
 

--- a/packages/host/scripts/traefik-helpers.js
+++ b/packages/host/scripts/traefik-helpers.js
@@ -6,22 +6,14 @@
 
 const path = require('path');
 const fs = require('fs');
+const { sanitizeSlug } = require('../../../scripts/env-slug.js');
 
 function getEnvSlug() {
-  // Prefer ENV_SLUG from mise's env-vars.sh (canonical: scripts/env-slug.sh);
-  // fall back to computing it for non-mise contexts. Cap at 63 chars
-  // (DNS label limit) so the slug works as a hostname label in
-  // `<service>.<slug>.localhost` — Chrome silently routes hostnames
-  // with over-63-char labels to the search engine.
+  // Prefer ENV_SLUG from mise's env-vars.sh (already pre-sanitized by
+  // scripts/env-slug.sh); fall back to sanitizing BOXEL_ENVIRONMENT
+  // directly for non-mise contexts.
   if (process.env.ENV_SLUG) return process.env.ENV_SLUG;
-  const raw = process.env.BOXEL_ENVIRONMENT || '';
-  return raw
-    .toLowerCase()
-    .replace(/\//g, '-')
-    .replace(/[^a-z0-9-]/g, '')
-    .replace(/-+/g, '-')
-    .slice(0, 63)
-    .replace(/^-|-$/g, '');
+  return sanitizeSlug(process.env.BOXEL_ENVIRONMENT);
 }
 
 function getTraefikDynamicDir() {

--- a/packages/matrix/helpers/environment-config.ts
+++ b/packages/matrix/helpers/environment-config.ts
@@ -3,6 +3,8 @@ import { writeFileSync, renameSync, unlinkSync } from 'fs';
 import { join, resolve } from 'path';
 import yaml from 'yaml';
 
+import { sanitizeSlug } from '../../../scripts/env-slug.js';
+
 const DOMAIN = 'localhost';
 
 let _traefikDir: string | undefined;
@@ -42,21 +44,6 @@ export function getEnvironmentSlug(): string {
   } catch {
     return 'default';
   }
-}
-
-function sanitizeSlug(raw: string): string {
-  // Cap at 63 chars (DNS label limit) so the slug works as a hostname
-  // label in `<service>.<slug>.localhost`. Chrome silently routes
-  // hostnames with over-63-char labels to the search engine instead of
-  // resolving them. `^-|-$` runs after the slice so a truncate that
-  // lands on a hyphen doesn't leave the slug ending in one.
-  return raw
-    .toLowerCase()
-    .replace(/\//g, '-')
-    .replace(/[^a-z0-9-]/g, '')
-    .replace(/-+/g, '-')
-    .slice(0, 63)
-    .replace(/^-|-$/g, '');
 }
 
 export function getSynapseContainerName(): string {

--- a/packages/matrix/helpers/environment-config.ts
+++ b/packages/matrix/helpers/environment-config.ts
@@ -45,11 +45,17 @@ export function getEnvironmentSlug(): string {
 }
 
 function sanitizeSlug(raw: string): string {
+  // Cap at 63 chars (DNS label limit) so the slug works as a hostname
+  // label in `<service>.<slug>.localhost`. Chrome silently routes
+  // hostnames with over-63-char labels to the search engine instead of
+  // resolving them. `^-|-$` runs after the slice so a truncate that
+  // lands on a hyphen doesn't leave the slug ending in one.
   return raw
     .toLowerCase()
     .replace(/\//g, '-')
     .replace(/[^a-z0-9-]/g, '')
     .replace(/-+/g, '-')
+    .slice(0, 63)
     .replace(/^-|-$/g, '');
 }
 

--- a/packages/realm-server/lib/dev-service-registry.ts
+++ b/packages/realm-server/lib/dev-service-registry.ts
@@ -5,6 +5,8 @@ import { logger } from '@cardstack/runtime-common';
 import type { AddressInfo, Server } from 'net';
 import yaml from 'yaml';
 
+import { sanitizeSlug } from '../../../scripts/env-slug.js';
+
 const log = logger('dev-service-registry');
 
 const DOMAIN = 'localhost';
@@ -47,20 +49,6 @@ export function getEnvironmentSlug(): string {
   }
 }
 
-function sanitizeSlug(raw: string): string {
-  // Cap at 63 chars (DNS label limit) so the slug works as a hostname
-  // label in `<service>.<slug>.localhost`. Chrome silently routes
-  // hostnames with over-63-char labels to the search engine instead of
-  // resolving them. `^-|-$` runs after the slice so a truncate that
-  // lands on a hyphen doesn't leave the slug ending in one.
-  return raw
-    .toLowerCase()
-    .replace(/\//g, '-')
-    .replace(/[^a-z0-9-]/g, '')
-    .replace(/-+/g, '-')
-    .slice(0, 63)
-    .replace(/^-|-$/g, '');
-}
 
 export function serviceHostname(serviceName: string, env?: string): string {
   let slug = env ?? getEnvironmentSlug();

--- a/packages/realm-server/lib/dev-service-registry.ts
+++ b/packages/realm-server/lib/dev-service-registry.ts
@@ -48,11 +48,17 @@ export function getEnvironmentSlug(): string {
 }
 
 function sanitizeSlug(raw: string): string {
+  // Cap at 63 chars (DNS label limit) so the slug works as a hostname
+  // label in `<service>.<slug>.localhost`. Chrome silently routes
+  // hostnames with over-63-char labels to the search engine instead of
+  // resolving them. `^-|-$` runs after the slice so a truncate that
+  // lands on a hyphen doesn't leave the slug ending in one.
   return raw
     .toLowerCase()
     .replace(/\//g, '-')
     .replace(/[^a-z0-9-]/g, '')
     .replace(/-+/g, '-')
+    .slice(0, 63)
     .replace(/^-|-$/g, '');
 }
 

--- a/packages/realm-server/lib/dev-service-registry.ts
+++ b/packages/realm-server/lib/dev-service-registry.ts
@@ -49,7 +49,6 @@ export function getEnvironmentSlug(): string {
   }
 }
 
-
 export function serviceHostname(serviceName: string, env?: string): string {
   let slug = env ?? getEnvironmentSlug();
   return `${serviceName}.${slug}.${DOMAIN}`;

--- a/scripts/env-slug.js
+++ b/scripts/env-slug.js
@@ -1,0 +1,35 @@
+/**
+ * Canonical environment-slug sanitizer for JS/TS callers.
+ * Mirror of scripts/env-slug.sh's `compute_env_slug` — keep the two in
+ * sync. Required by:
+ *   packages/host/scripts/traefik-helpers.js
+ *   packages/matrix/helpers/environment-config.ts
+ *   packages/realm-server/lib/dev-service-registry.ts
+ */
+
+'use strict';
+
+/**
+ * Normalize a raw branch/environment name into a slug suitable for
+ * hostnames, container names, db names, and filesystem paths.
+ *
+ * Caps at 63 chars (DNS label limit) so the slug works as a hostname
+ * label in `<service>.<slug>.localhost`. Chrome silently routes
+ * hostnames with over-63-char labels to the search engine instead of
+ * resolving them. `^-|-$` runs after the slice so a truncate that
+ * lands on a hyphen doesn't leave the slug ending in one.
+ *
+ * @param {string | null | undefined} raw
+ * @returns {string}
+ */
+function sanitizeSlug(raw) {
+  return (raw || '')
+    .toLowerCase()
+    .replace(/\//g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .slice(0, 63)
+    .replace(/^-|-$/g, '');
+}
+
+module.exports = { sanitizeSlug };

--- a/scripts/env-slug.sh
+++ b/scripts/env-slug.sh
@@ -9,7 +9,12 @@
 #   SLUG=$(compute_env_slug "my/Branch-Name")         # explicit input
 
 compute_env_slug() {
-  echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's|/|-|g; s|[^a-z0-9-]||g; s|-\+|-|g; s|^-\|-$||g'
+  # Cap at 63 chars (DNS label limit) so the slug works as a hostname
+  # label in `<service>.<slug>.localhost`. Chrome treats hostnames with
+  # over-63-char labels as search queries instead of URLs. Strip any
+  # leading/trailing hyphens after the cut so a truncate that lands on
+  # a hyphen doesn't leave the slug ending in one.
+  echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's|/|-|g; s|[^a-z0-9-]||g; s|-\+|-|g' | cut -c -63 | sed 's|^-||; s|-$||'
 }
 
 # Use `${VAR:-}` so callers running under `set -u` (e.g.

--- a/scripts/start-traefik.sh
+++ b/scripts/start-traefik.sh
@@ -7,6 +7,19 @@ set -e
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+# If a Traefik container exists but its dynamic-config bind mount points
+# at a directory other than this worktree's traefik/dynamic (e.g. the
+# originating worktree was deleted), remove it so the compose-up branch
+# below recreates it from the current worktree.
+if docker ps -a --format '{{.Names}}' | grep -q '^boxel-traefik$'; then
+  MOUNTED="$(docker inspect boxel-traefik --format '{{range .Mounts}}{{if eq .Destination "/etc/traefik/dynamic"}}{{.Source}}{{end}}{{end}}' 2>/dev/null || true)"
+  EXPECTED="$REPO_ROOT/traefik/dynamic"
+  if [ -n "$MOUNTED" ] && [ "$MOUNTED" != "$EXPECTED" ]; then
+    echo "Traefik dynamic-config mount is stale ($MOUNTED); recreating from $EXPECTED"
+    docker rm -f boxel-traefik >/dev/null
+  fi
+fi
+
 # --- Start Traefik ---
 if docker ps --format '{{.Names}}' | grep -q '^boxel-traefik$'; then
   echo "Traefik is already running."


### PR DESCRIPTION
This is a quick followup to #4903; I learned after that was merged that deleted worktrees caused problems like this with environment mode’s Traefik setup:

```
Started synapse with id 528c5c3b1a3803ad1bcf152bacaaa4eab04d2a513486681d11cd8c571977f23f on port 62513
Synapse dynamic host port: 62513
unexpected error Error: ENOENT: no such file or directory, open '/Users/b/Documents/Cardstack/Code/boxel-motion-worktrees/https-environment/traefik/dynamic/https-environment-synapse-matrix.yml.tmp'
```

I deleted the `https-environment` worktree after merging that PR, but then other environments couldn’t start up. Now they can.

---

This also truncates slugs at 63 characters, as I was unable to visit https://host.cs-11259-boxel-realm-create-deadlocks-90s-on-federated-search-self.localhost/ because the middle section of the domain was too long. Since the slug calculation is used in three places, I extracted it to a shared script.
