### PR TITLE
Fix HTTPS downmigration and CI to catch it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,7 @@ jobs:
               - 'packages/eslint-plugin-cardstack-host/**'
             postgres-migrations:
               - 'packages/postgres/migrations/**'
+              - 'packages/postgres/scripts/determine-changed-migrations.sh'
             boxel-icons:
               - *shared
               - 'packages/boxel-icons/**'

--- a/packages/postgres/migrations/1712771547705_initial.js
+++ b/packages/postgres/migrations/1712771547705_initial.js
@@ -143,12 +143,10 @@ exports.up = (pgm) => {
   `);
 };
 
-// CS-11246: explicit down so the Postgres Migration Test can roll back
-// the full chain on any PR that touches a migration file. node-pg-migrate
-// can't auto-infer a reversal for the `ALTER TABLE … SET UNLOGGED` calls
-// above, so an inferred down would crash mid-rollback. Order is the
-// reverse of the up — types are dropped after the tables that reference
-// them.
+// Explicit down because node-pg-migrate can't auto-infer a reversal for
+// the `ALTER TABLE … SET UNLOGGED` calls above; an inferred down would
+// crash mid-rollback. Order is the reverse of the up — types are dropped
+// after the tables that reference them.
 exports.down = (pgm) => {
   pgm.sql('DROP FUNCTION IF EXISTS jsonb_tree(jsonb, text)');
   pgm.dropTable('queues');

--- a/packages/postgres/migrations/1712771547705_initial.js
+++ b/packages/postgres/migrations/1712771547705_initial.js
@@ -142,3 +142,19 @@ exports.up = (pgm) => {
     LANGUAGE SQL;
   `);
 };
+
+// CS-11246: explicit down so the Postgres Migration Test can roll back
+// the full chain on any PR that touches a migration file. node-pg-migrate
+// can't auto-infer a reversal for the `ALTER TABLE … SET UNLOGGED` calls
+// above, so an inferred down would crash mid-rollback. Order is the
+// reverse of the up — types are dropped after the tables that reference
+// them.
+exports.down = (pgm) => {
+  pgm.sql('DROP FUNCTION IF EXISTS jsonb_tree(jsonb, text)');
+  pgm.dropTable('queues');
+  pgm.dropType('queue_statuses');
+  pgm.dropTable('jobs');
+  pgm.dropType('job_statuses');
+  pgm.dropTable('realm_versions');
+  pgm.dropTable('boxel_index');
+};

--- a/packages/postgres/migrations/1753976049308_create-published-realms.js
+++ b/packages/postgres/migrations/1753976049308_create-published-realms.js
@@ -25,4 +25,11 @@ exports.up = (pgm) => {
   });
 };
 
-exports.down = (pgm) => {};
+// CS-11246: drop the table so the Postgres Migration Test can roll back
+// the full chain and reapply without colliding on a leftover relation.
+// 1779100257123_drop-published-realms drops this table on UP and
+// re-creates it on DOWN, so during a full rollback the table is restored
+// by that migration's DOWN and must be removed again here.
+exports.down = (pgm) => {
+  pgm.dropTable('published_realms');
+};

--- a/packages/postgres/migrations/1753976049308_create-published-realms.js
+++ b/packages/postgres/migrations/1753976049308_create-published-realms.js
@@ -25,11 +25,10 @@ exports.up = (pgm) => {
   });
 };
 
-// CS-11246: drop the table so the Postgres Migration Test can roll back
-// the full chain and reapply without colliding on a leftover relation.
 // 1779100257123_drop-published-realms drops this table on UP and
 // re-creates it on DOWN, so during a full rollback the table is restored
-// by that migration's DOWN and must be removed again here.
+// by that migration's DOWN and must be removed again here. Without this,
+// the reapply UP collides on the leftover relation.
 exports.down = (pgm) => {
   pgm.dropTable('published_realms');
 };

--- a/packages/postgres/migrations/1777591052962_create-realm-metadata.js
+++ b/packages/postgres/migrations/1777591052962_create-realm-metadata.js
@@ -1,9 +1,8 @@
 // CS-10053 — moves realm-level metadata flags out of the legacy
 // .realm.json sidecar and into a database table. Two flags move in this
 // ticket (showAsCatalog, publishable). The table is intentionally
-// open-ended so future fields (hostHome / interactHome from CS-10055,
-// realmUserId, etc.) can land as additional columns without re-doing
-// the schema design.
+// open-ended so future per-realm mutable flags (e.g. realmUserId) can
+// land as additional columns without re-doing the schema design.
 //
 // Why a new table rather than columns on realm_registry:
 //   - These are mutable per-realm settings, not realm identity.

--- a/packages/postgres/migrations/1779348449320_remove-legacy-catalog-realm-permissions.js
+++ b/packages/postgres/migrations/1779348449320_remove-legacy-catalog-realm-permissions.js
@@ -38,33 +38,83 @@ exports.up = (pgm) => {
 // by realm-server's startup registry-backfill, so a rewind here would be
 // incomplete. If the realm is brought back, the next boot of realm-server
 // with the realm on disk re-registers it automatically.
+//
+// CS-11246: each INSERT is guarded by NOT EXISTS against both http- and
+// https-forms of the (realm_url, username) pair. Background: an earlier
+// migration (1779100257124_canonical-url-http-to-https) rewrites localhost
+// URLs in place from http→https on UP. On dev that runs before this
+// migration, so by the time this UP fires the legacy-catalog rows are
+// already in https form and its http-targeted DELETE matches nothing — the
+// rows persist into the rollback. Then this DOWN inserts the http row, and
+// 1779100257124's DOWN rewrites the leftover https row back to http, which
+// collides with the just-inserted http row on realm_user_permissions_pkey.
+// Guarding the INSERT keeps the chain idempotent regardless of which form
+// is sitting in the table. Staging/production never hit the underlying
+// trigger (their canonicals are always https) but use the same guard for
+// uniformity.
+function guardedRestore(realmUrl, username, write, realmOwner) {
+  let httpsUrl = realmUrl.replace(/^http:/, 'https:');
+  let httpUrl = realmUrl.replace(/^https:/, 'http:');
+  return `
+    INSERT INTO realm_user_permissions (realm_url, username, read, write, realm_owner)
+    SELECT '${realmUrl}', '${username}', true, ${write}, ${realmOwner}
+    WHERE NOT EXISTS (
+      SELECT 1 FROM realm_user_permissions
+      WHERE realm_url IN ('${httpUrl}', '${httpsUrl}')
+        AND username = '${username}'
+    )
+  `;
+}
+
 exports.down = (pgm) => {
   switch (process.env.REALM_SENTRY_ENVIRONMENT) {
     case 'staging':
       pgm.sql(
-        `INSERT INTO realm_user_permissions (realm_url, username, read, write, realm_owner)
-         VALUES
-           ('https://realms-staging.stack.cards/legacy-catalog/', '@legacy_catalog_realm:stack.cards', true, true, true),
-           ('https://realms-staging.stack.cards/legacy-catalog/', '*', true, false, false)
-         ON CONFLICT ON CONSTRAINT realm_user_permissions_pkey DO NOTHING`,
+        guardedRestore(
+          'https://realms-staging.stack.cards/legacy-catalog/',
+          '@legacy_catalog_realm:stack.cards',
+          true,
+          true,
+        ),
+      );
+      pgm.sql(
+        guardedRestore(
+          'https://realms-staging.stack.cards/legacy-catalog/',
+          '*',
+          false,
+          false,
+        ),
       );
       break;
     case 'production':
       pgm.sql(
-        `INSERT INTO realm_user_permissions (realm_url, username, read, write, realm_owner)
-         VALUES
-           ('https://app.boxel.ai/legacy-catalog/', '@legacy_catalog_realm:boxel.ai', true, true, true),
-           ('https://app.boxel.ai/legacy-catalog/', '*', true, false, false)
-         ON CONFLICT ON CONSTRAINT realm_user_permissions_pkey DO NOTHING`,
+        guardedRestore(
+          'https://app.boxel.ai/legacy-catalog/',
+          '@legacy_catalog_realm:boxel.ai',
+          true,
+          true,
+        ),
+      );
+      pgm.sql(
+        guardedRestore('https://app.boxel.ai/legacy-catalog/', '*', false, false),
       );
       break;
     default:
       pgm.sql(
-        `INSERT INTO realm_user_permissions (realm_url, username, read, write, realm_owner)
-         VALUES
-           ('http://localhost:4201/legacy-catalog/', '@legacy_catalog_realm:localhost', true, true, true),
-           ('http://localhost:4201/legacy-catalog/', '*', true, false, false)
-         ON CONFLICT ON CONSTRAINT realm_user_permissions_pkey DO NOTHING`,
+        guardedRestore(
+          'http://localhost:4201/legacy-catalog/',
+          '@legacy_catalog_realm:localhost',
+          true,
+          true,
+        ),
+      );
+      pgm.sql(
+        guardedRestore(
+          'http://localhost:4201/legacy-catalog/',
+          '*',
+          false,
+          false,
+        ),
       );
   }
 };

--- a/packages/postgres/migrations/1779348449320_remove-legacy-catalog-realm-permissions.js
+++ b/packages/postgres/migrations/1779348449320_remove-legacy-catalog-realm-permissions.js
@@ -39,19 +39,19 @@ exports.up = (pgm) => {
 // incomplete. If the realm is brought back, the next boot of realm-server
 // with the realm on disk re-registers it automatically.
 //
-// CS-11246: each INSERT is guarded by NOT EXISTS against both http- and
-// https-forms of the (realm_url, username) pair. Background: an earlier
-// migration (1779100257124_canonical-url-http-to-https) rewrites localhost
-// URLs in place from http→https on UP. On dev that runs before this
-// migration, so by the time this UP fires the legacy-catalog rows are
-// already in https form and its http-targeted DELETE matches nothing — the
-// rows persist into the rollback. Then this DOWN inserts the http row, and
-// 1779100257124's DOWN rewrites the leftover https row back to http, which
-// collides with the just-inserted http row on realm_user_permissions_pkey.
-// Guarding the INSERT keeps the chain idempotent regardless of which form
-// is sitting in the table. Staging/production never hit the underlying
-// trigger (their canonicals are always https) but use the same guard for
-// uniformity.
+// Each INSERT is guarded by NOT EXISTS against both http- and https-forms
+// of the (realm_url, username) pair. Background: 1779100257124_canonical-
+// url-http-to-https rewrites localhost URLs in place from http→https on
+// UP. On dev that runs before this migration, so by the time this UP
+// fires the legacy-catalog rows are already in https form and its
+// http-targeted DELETE matches nothing — the rows persist into the
+// rollback. Then this DOWN inserts the http row, and 1779100257124's
+// DOWN rewrites the leftover https row back to http, which collides with
+// the just-inserted http row on realm_user_permissions_pkey. Guarding
+// the INSERT keeps the chain idempotent regardless of which form is
+// sitting in the table. Staging/production never hit the underlying
+// trigger (their canonicals are always https) but use the same guard
+// for uniformity.
 function guardedRestore(realmUrl, username, write, realmOwner) {
   let httpsUrl = realmUrl.replace(/^http:/, 'https:');
   let httpUrl = realmUrl.replace(/^https:/, 'http:');

--- a/packages/postgres/scripts/determine-changed-migrations.sh
+++ b/packages/postgres/scripts/determine-changed-migrations.sh
@@ -53,13 +53,13 @@ printf '%s\n' "$SORTED"
   echo "EOF"
 } >> "$GITHUB_OUTPUT"
 
-# CS-11246: always roll back the full chain when any migration file
-# changes, not just down to the earliest-changed migration. The narrower
-# window left cross-migration interaction bugs latent — a non-idempotent
-# DOWN in migration X only fails when a PR happens to edit a migration
-# older than X, which could be months between triggers. Full rollback
-# costs a few extra seconds per CI run but exercises every DOWN/UP
-# cycle on every migration-touching PR.
+# Always roll back the full chain when any migration file changes, not
+# just down to the earliest-changed migration. The narrower window left
+# cross-migration interaction bugs latent — a non-idempotent DOWN in
+# migration X only fails when a PR happens to edit a migration older
+# than X, which could be months between triggers. Full rollback costs a
+# few extra seconds per CI run but exercises every DOWN/UP cycle on
+# every migration-touching PR.
 # Match node-pg-migrate's own discovery: only timestamp-prefixed files
 # count as migrations (excludes .eslintrc.js, README, etc.).
 TOTAL="$(find packages/postgres/migrations -maxdepth 1 -type f \( -name '[0-9]*.js' -o -name '[0-9]*.ts' \) | wc -l | tr -d ' ')"

--- a/packages/postgres/scripts/determine-changed-migrations.sh
+++ b/packages/postgres/scripts/determine-changed-migrations.sh
@@ -53,35 +53,20 @@ printf '%s\n' "$SORTED"
   echo "EOF"
 } >> "$GITHUB_OUTPUT"
 
-EARLIEST_CHANGED="$(printf '%s\n' "$SORTED" | head -n 1)"
-if [[ -z "$EARLIEST_CHANGED" ]]; then
-  echo "Could not determine earliest changed migration" >&2
-  exit 1
-fi
-
-EARLIEST_BASENAME="$(basename "$EARLIEST_CHANGED")"
-
-ALL_MIGRATIONS="$(find packages/postgres/migrations -maxdepth 1 -type f \( -name '*.js' -o -name '*.ts' \) | sort)"
-if [[ -z "$ALL_MIGRATIONS" ]]; then
+# CS-11246: always roll back the full chain when any migration file
+# changes, not just down to the earliest-changed migration. The narrower
+# window left cross-migration interaction bugs latent — a non-idempotent
+# DOWN in migration X only fails when a PR happens to edit a migration
+# older than X, which could be months between triggers. Full rollback
+# costs a few extra seconds per CI run but exercises every DOWN/UP
+# cycle on every migration-touching PR.
+# Match node-pg-migrate's own discovery: only timestamp-prefixed files
+# count as migrations (excludes .eslintrc.js, README, etc.).
+TOTAL="$(find packages/postgres/migrations -maxdepth 1 -type f \( -name '[0-9]*.js' -o -name '[0-9]*.ts' \) | wc -l | tr -d ' ')"
+if [[ "$TOTAL" -eq 0 ]]; then
   echo "No migrations found in packages/postgres/migrations" >&2
   exit 1
 fi
 
-TOTAL=0
-EARLIEST_INDEX=0
-while IFS= read -r FILE; do
-  [[ -z "$FILE" ]] && continue
-  TOTAL=$((TOTAL + 1))
-  if [[ "$EARLIEST_INDEX" -eq 0 && "$(basename "$FILE")" == "$EARLIEST_BASENAME" ]]; then
-    EARLIEST_INDEX=$TOTAL
-  fi
-done <<< "$ALL_MIGRATIONS"
-
-if [[ "$EARLIEST_INDEX" -eq 0 ]]; then
-  echo "Unable to locate changed migration $EARLIEST_BASENAME in migration list" >&2
-  exit 1
-fi
-
-DOWN_COUNT=$((TOTAL - EARLIEST_INDEX + 1))
-echo "down_count=$DOWN_COUNT" >> "$GITHUB_OUTPUT"
-echo "Will migrate down $DOWN_COUNT migration(s) to cover earliest changed migration"
+echo "down_count=$TOTAL" >> "$GITHUB_OUTPUT"
+echo "Will migrate down all $TOTAL migration(s) to exercise the full down/up chain"


### PR DESCRIPTION
In #4943 I needed to [remove a migration comment change](https://github.com/cardstack/boxel/pull/4943/changes/8f53ac175552fdce4cafc613f1533a403fabc5a0) because it was revealing a problem in the [a different downmigration](https://github.com/cardstack/boxel/actions/runs/26309624533/job/77458689108). This fixes that downmigration and others, restores the migration comment change, and updates the downmigration CI job to run all downmigrations when triggered instead of just as far back as the earliest-changed one.