### PR TITLE
realm-server: sync granted realm to user's matrix account_data on grafana upsert

### DIFF
--- a/packages/realm-server/handlers/handle-upsert-realm-user-permission.ts
+++ b/packages/realm-server/handlers/handle-upsert-realm-user-permission.ts
@@ -73,7 +73,8 @@ function resolveAdminCreds(
   }
   return {
     ok: false,
-    reason: 'MATRIX_ADMIN_USERNAME / MATRIX_ADMIN_PASSWORD unset and MATRIX_URL is not a local homeserver',
+    reason:
+      'MATRIX_ADMIN_USERNAME / MATRIX_ADMIN_PASSWORD unset and MATRIX_URL is not a local homeserver',
   };
 }
 

--- a/packages/realm-server/handlers/handle-upsert-realm-user-permission.ts
+++ b/packages/realm-server/handlers/handle-upsert-realm-user-permission.ts
@@ -12,6 +12,7 @@ import {
   adminImpersonateUser,
   appendRealmToUserAccountData,
   loginAsMatrixAdmin,
+  logoutMatrixAccessToken,
 } from '../synapse';
 
 const log = logger('realm-server');
@@ -167,13 +168,15 @@ export default function handleUpsertRealmUserPermission({
         matrixAdminPassword,
       );
       if (creds.ok) {
+        let adminToken: string | undefined;
+        let userToken: string | undefined;
         try {
-          let adminToken = await loginAsMatrixAdmin({
+          adminToken = await loginAsMatrixAdmin({
             matrixURL: matrixClient.matrixURL,
             adminUsername: creds.username,
             adminPassword: creds.password,
           });
-          let userToken = await adminImpersonateUser({
+          userToken = await adminImpersonateUser({
             matrixURL: matrixClient.matrixURL,
             adminAccessToken: adminToken,
             userId: user,
@@ -190,6 +193,40 @@ export default function handleUpsertRealmUserPermission({
           log.warn(
             `[grafana-upsert-realm-user-permission] ${matrixAccountDataWarning}`,
           );
+        } finally {
+          // Synapse admin login + admin-impersonate both mint
+          // non-expiring tokens by default. Invalidate them after the
+          // sync so each grafana grant doesn't leave a long-lived
+          // credential behind in synapse's access_tokens table.
+          // Best-effort: a logout failure does not change the sync
+          // result reported above.
+          let cleanups: Promise<unknown>[] = [];
+          if (userToken) {
+            cleanups.push(
+              logoutMatrixAccessToken({
+                matrixURL: matrixClient.matrixURL,
+                accessToken: userToken,
+              }),
+            );
+          }
+          if (adminToken) {
+            cleanups.push(
+              logoutMatrixAccessToken({
+                matrixURL: matrixClient.matrixURL,
+                accessToken: adminToken,
+              }),
+            );
+          }
+          let results = await Promise.allSettled(cleanups);
+          for (let r of results) {
+            if (r.status === 'rejected') {
+              log.warn(
+                `[grafana-upsert-realm-user-permission] token logout failed: ${
+                  (r.reason as any)?.message ?? String(r.reason)
+                }`,
+              );
+            }
+          }
         }
       } else {
         matrixAccountDataWarning = `account_data sync skipped: ${creds.reason}`;

--- a/packages/realm-server/handlers/handle-upsert-realm-user-permission.ts
+++ b/packages/realm-server/handlers/handle-upsert-realm-user-permission.ts
@@ -45,22 +45,35 @@ function isMatrixUserId(user: string): boolean {
 
 // Resolve admin credentials for the synapse admin-impersonate flow. When
 // explicit env-derived values are present (any environment), use them.
-// When both are absent AND the matrix homeserver is localhost, fall back
-// to the dev `admin`/`password` pair that register-matrix-users.ts seeds
-// — this keeps local dev and tests friction-free without baking the
-// default into every other deployment.
+// When both are absent AND the matrix homeserver is on a `.localhost`
+// hostname (covers bare `localhost` and env-mode Traefik names like
+// `matrix.<slug>.localhost`), fall back to the dev `admin`/`password`
+// pair that register-matrix-users.ts seeds — keeps local dev and tests
+// friction-free without baking the default into every other deployment.
 function resolveAdminCreds(
   matrixURL: URL,
   username: string | undefined,
   password: string | undefined,
-): { username: string; password: string } | undefined {
+):
+  | { ok: true; username: string; password: string }
+  | { ok: false; reason: string } {
   if (username && password) {
-    return { username, password };
+    return { ok: true, username, password };
   }
-  if (!username && !password && matrixURL.hostname === 'localhost') {
-    return { username: 'admin', password: 'password' };
+  if (username || password) {
+    return {
+      ok: false,
+      reason: `MATRIX_ADMIN_USERNAME and MATRIX_ADMIN_PASSWORD must be set together (got only ${username ? 'USERNAME' : 'PASSWORD'})`,
+    };
   }
-  return undefined;
+  let h = matrixURL.hostname;
+  if (h === 'localhost' || h.endsWith('.localhost')) {
+    return { ok: true, username: 'admin', password: 'password' };
+  }
+  return {
+    ok: false,
+    reason: 'MATRIX_ADMIN_USERNAME / MATRIX_ADMIN_PASSWORD unset and MATRIX_URL is not a local homeserver',
+  };
 }
 
 export default function handleUpsertRealmUserPermission({
@@ -153,7 +166,7 @@ export default function handleUpsertRealmUserPermission({
         matrixAdminUsername,
         matrixAdminPassword,
       );
-      if (creds) {
+      if (creds.ok) {
         try {
           let adminToken = await loginAsMatrixAdmin({
             matrixURL: matrixClient.matrixURL,
@@ -179,8 +192,7 @@ export default function handleUpsertRealmUserPermission({
           );
         }
       } else {
-        matrixAccountDataWarning =
-          'account_data sync skipped: MATRIX_ADMIN_USERNAME / MATRIX_ADMIN_PASSWORD unset and MATRIX_URL is not localhost';
+        matrixAccountDataWarning = `account_data sync skipped: ${creds.reason}`;
       }
     } else {
       matrixAccountDataWarning = `account_data sync skipped: "${user}" is not a fully-qualified matrix user-id`;

--- a/packages/realm-server/handlers/handle-upsert-realm-user-permission.ts
+++ b/packages/realm-server/handlers/handle-upsert-realm-user-permission.ts
@@ -2,11 +2,19 @@ import type Koa from 'koa';
 import {
   ensureTrailingSlash,
   insertPermissions,
+  logger,
   type RealmAction,
   SupportedMimeType,
 } from '@cardstack/runtime-common';
 import { sendResponseForBadRequest, setContextResponse } from '../middleware';
 import type { CreateRoutesArgs } from '../routes';
+import {
+  adminImpersonateUser,
+  appendRealmToUserAccountData,
+  loginAsMatrixAdmin,
+} from '../synapse';
+
+const log = logger('realm-server');
 
 function parseBoolFlag(
   raw: string | null,
@@ -27,8 +35,39 @@ function parseBoolFlag(
   };
 }
 
+// Only fully-qualified matrix user-ids can carry account_data. Wildcards
+// (the public-read sentinel `*`) and bare localparts have no synapse
+// account to write to, so we skip the matrix sync rather than 400 — the
+// DB grant still stands.
+function isMatrixUserId(user: string): boolean {
+  return user.startsWith('@') && user.includes(':');
+}
+
+// Resolve admin credentials for the synapse admin-impersonate flow. When
+// explicit env-derived values are present (any environment), use them.
+// When both are absent AND the matrix homeserver is localhost, fall back
+// to the dev `admin`/`password` pair that register-matrix-users.ts seeds
+// — this keeps local dev and tests friction-free without baking the
+// default into every other deployment.
+function resolveAdminCreds(
+  matrixURL: URL,
+  username: string | undefined,
+  password: string | undefined,
+): { username: string; password: string } | undefined {
+  if (username && password) {
+    return { username, password };
+  }
+  if (!username && !password && matrixURL.hostname === 'localhost') {
+    return { username: 'admin', password: 'password' };
+  }
+  return undefined;
+}
+
 export default function handleUpsertRealmUserPermission({
   dbAdapter,
+  matrixClient,
+  matrixAdminUsername,
+  matrixAdminPassword,
 }: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
     let realm = ctxt.URL.searchParams.get('realm');
@@ -99,16 +138,67 @@ export default function handleUpsertRealmUserPermission({
       [user]: actions,
     });
 
+    // The granted user only learns about the realm on their next host
+    // load if it's present in their matrix `app.boxel.realms`
+    // account_data — that's what the host reads to render the workspace
+    // list. Push the realm in here so the grant becomes visible without
+    // the user manually adding it. Best-effort: a matrix failure logs a
+    // warning and returns 200 so the DB grant doesn't roll back, and
+    // re-running this endpoint is idempotent on both sides.
+    let matrixAccountDataWarning: string | undefined;
+    let appendedToAccountData = false;
+    if (isMatrixUserId(user)) {
+      let creds = resolveAdminCreds(
+        matrixClient.matrixURL,
+        matrixAdminUsername,
+        matrixAdminPassword,
+      );
+      if (creds) {
+        try {
+          let adminToken = await loginAsMatrixAdmin({
+            matrixURL: matrixClient.matrixURL,
+            adminUsername: creds.username,
+            adminPassword: creds.password,
+          });
+          let userToken = await adminImpersonateUser({
+            matrixURL: matrixClient.matrixURL,
+            adminAccessToken: adminToken,
+            userId: user,
+          });
+          let { alreadyPresent } = await appendRealmToUserAccountData({
+            matrixURL: matrixClient.matrixURL,
+            userId: user,
+            userAccessToken: userToken,
+            realmURL: normalizedRealmHref,
+          });
+          appendedToAccountData = !alreadyPresent;
+        } catch (e: any) {
+          matrixAccountDataWarning = `account_data sync failed: ${e?.message ?? String(e)}`;
+          log.warn(
+            `[grafana-upsert-realm-user-permission] ${matrixAccountDataWarning}`,
+          );
+        }
+      } else {
+        matrixAccountDataWarning =
+          'account_data sync skipped: MATRIX_ADMIN_USERNAME / MATRIX_ADMIN_PASSWORD unset and MATRIX_URL is not localhost';
+      }
+    } else {
+      matrixAccountDataWarning = `account_data sync skipped: "${user}" is not a fully-qualified matrix user-id`;
+    }
+
+    let responseBody: Record<string, unknown> = {
+      message: `Set ${actions.join('+')} on ${normalizedRealmHref} for user "${user}"`,
+      appendedToAccountData,
+    };
+    if (matrixAccountDataWarning) {
+      responseBody.matrixAccountDataWarning = matrixAccountDataWarning;
+    }
+
     return setContextResponse(
       ctxt,
-      new Response(
-        JSON.stringify({
-          message: `Set ${actions.join('+')} on ${normalizedRealmHref} for user "${user}"`,
-        }),
-        {
-          headers: { 'content-type': SupportedMimeType.JSON },
-        },
-      ),
+      new Response(JSON.stringify(responseBody), {
+        headers: { 'content-type': SupportedMimeType.JSON },
+      }),
     );
   };
 }

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -111,6 +111,15 @@ if (!REALM_SERVER_MATRIX_USERNAME) {
 const MATRIX_REGISTRATION_SHARED_SECRET =
   process.env.MATRIX_REGISTRATION_SHARED_SECRET;
 
+// Synapse admin credentials. Optional: only consumed by operator-action
+// endpoints that need to admin-impersonate a target user to read or write
+// their account_data on their behalf (synapse admin tokens can read but
+// not write another user's account_data). When unset on a localhost
+// matrix homeserver, the grafana upsert handler defaults to the dev
+// admin/password pair register-matrix-users.ts creates.
+const MATRIX_ADMIN_USERNAME = process.env.MATRIX_ADMIN_USERNAME;
+const MATRIX_ADMIN_PASSWORD = process.env.MATRIX_ADMIN_PASSWORD;
+
 if (process.env.DISABLE_MODULE_CACHING === 'true') {
   console.warn(
     `module caching has been disabled, module executables will be served directly from the filesystem`,
@@ -582,6 +591,8 @@ const smokeTestHostApp = async () => {
     getIndexHTML,
     serverURL: new URL(serverURL),
     matrixRegistrationSecret: MATRIX_REGISTRATION_SHARED_SECRET,
+    matrixAdminUsername: MATRIX_ADMIN_USERNAME,
+    matrixAdminPassword: MATRIX_ADMIN_PASSWORD,
     enableFileWatcher: ENABLE_FILE_WATCHER,
     domainsForPublishedRealms,
     getRegistrationSecret: useRegistrationSecretFunction

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -85,6 +85,12 @@ export type CreateRoutesArgs = {
   reconciler: RealmRegistryReconciler;
   realmsRootPath: string;
   getMatrixRegistrationSecret: () => Promise<string>;
+  // Synapse admin credentials. Optional at the top: when both are unset the
+  // grafana upsert handler falls back to a localhost-only default so local
+  // dev / tests don't need to thread env vars through. When provided they
+  // are used as-is for any environment (staging, prod).
+  matrixAdminUsername?: string;
+  matrixAdminPassword?: string;
   serveHostApp: (ctxt: Koa.Context, next: Koa.Next) => Promise<any>;
   serveIndex: (ctxt: Koa.Context, next: Koa.Next) => Promise<any>;
   serveFromRealm: (ctxt: Koa.Context, next: Koa.Next) => Promise<any>;

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -277,6 +277,8 @@ export class RealmServer {
   private getIndexHTML: () => Promise<string>;
   private serverURL: URL;
   private matrixRegistrationSecret: string | undefined;
+  private matrixAdminUsername: string | undefined;
+  private matrixAdminPassword: string | undefined;
   private getRegistrationSecret:
     | (() => Promise<string | undefined>)
     | undefined;
@@ -307,6 +309,8 @@ export class RealmServer {
     assetsURL,
     getIndexHTML,
     matrixRegistrationSecret,
+    matrixAdminUsername,
+    matrixAdminPassword,
     getRegistrationSecret,
     domainsForPublishedRealms,
     prerenderer,
@@ -326,6 +330,8 @@ export class RealmServer {
     assetsURL: URL;
     getIndexHTML: () => Promise<string>;
     matrixRegistrationSecret?: string;
+    matrixAdminUsername?: string;
+    matrixAdminPassword?: string;
     getRegistrationSecret?: () => Promise<string | undefined>;
     enableFileWatcher?: boolean;
     domainsForPublishedRealms?: {
@@ -362,6 +368,8 @@ export class RealmServer {
     this.assetsURL = assetsURL;
     this.getIndexHTML = getIndexHTML;
     this.matrixRegistrationSecret = matrixRegistrationSecret;
+    this.matrixAdminUsername = matrixAdminUsername;
+    this.matrixAdminPassword = matrixAdminPassword;
     this.getRegistrationSecret = getRegistrationSecret;
     this.domainsForPublishedRealms = domainsForPublishedRealms;
     // Pass-by-reference: handlers and the reconciler both mutate this
@@ -465,6 +473,8 @@ export class RealmServer {
           assetsURL: this.assetsURL,
           realmsRootPath: this.realmsRootPath,
           getMatrixRegistrationSecret: this.getMatrixRegistrationSecret,
+          matrixAdminUsername: this.matrixAdminUsername,
+          matrixAdminPassword: this.matrixAdminPassword,
           domainsForPublishedRealms: this.domainsForPublishedRealms,
           prerenderer: this.prerenderer,
           reconciler: this.reconciler,

--- a/packages/realm-server/synapse.ts
+++ b/packages/realm-server/synapse.ts
@@ -46,19 +46,29 @@ export async function registerUser({
   username,
   password,
   registrationSecret,
+  admin = false,
 }: {
   matrixURL: URL;
   displayname: string;
   username: string;
   password: string;
   registrationSecret: string;
+  // Mint the user as a synapse admin. Required for any user that will
+  // later drive synapse's admin-only endpoints (e.g. the admin-
+  // impersonate "log in as user" flow used by the grafana-grant
+  // account_data sync). The MAC's last segment is "admin" / "notadmin"
+  // — both must match between the nonce-MAC and the body's `admin`
+  // bool, hence the joint switch.
+  admin?: boolean;
 }) {
   let nonceResponse = await fetch(
     `${matrixURL.href}_synapse/admin/v1/register`,
   );
   let { nonce } = (await nonceResponse.json()) as { nonce: string };
   let mac = createHmac('sha1', registrationSecret)
-    .update(`${nonce}\0${username}\0${password}\0notadmin`)
+    .update(
+      `${nonce}\0${username}\0${password}\0${admin ? 'admin' : 'notadmin'}`,
+    )
     .digest('hex');
 
   let registerResponse = await fetch(
@@ -74,7 +84,7 @@ export async function registerUser({
         displayname,
         password,
         mac,
-        admin: false,
+        admin,
       }),
     },
   );

--- a/packages/realm-server/synapse.ts
+++ b/packages/realm-server/synapse.ts
@@ -160,6 +160,28 @@ export async function adminImpersonateUser({
   return body.access_token;
 }
 
+// Invalidate a single matrix access token via the standard logout
+// endpoint. Used so the short-lived admin login + admin-impersonate
+// tokens minted for one grafana grant don't pile up in synapse's
+// access_tokens table. Treats 401 as "token already invalid" — fine.
+export async function logoutMatrixAccessToken({
+  matrixURL,
+  accessToken,
+}: {
+  matrixURL: URL;
+  accessToken: string;
+}): Promise<void> {
+  let response = await fetch(`${matrixURL.href}_matrix/client/v3/logout`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!response.ok && response.status !== 401) {
+    throw new Error(
+      `matrix logout failed: HTTP ${response.status} ${await response.text()}`,
+    );
+  }
+}
+
 // Append a single realm URL to a user's `app.boxel.realms` account_data,
 // preserving any existing entries. Idempotent: if `realmURL` is already in
 // the user's `realms` array, no PUT is fired and `{ alreadyPresent: true }`

--- a/packages/realm-server/synapse.ts
+++ b/packages/realm-server/synapse.ts
@@ -189,6 +189,16 @@ export async function logoutMatrixAccessToken({
 // from the GET is treated as "user has no realms list yet" — equivalent to
 // an empty array. Requires a user-scoped access token (admin-impersonate
 // first; synapse admin tokens cannot write other users' account_data).
+//
+// Lost-update protection: synapse account_data has no optimistic-
+// concurrency primitive, so two appenders racing on the same user can
+// stomp each other. After each PUT we re-GET and check our entry is
+// present; if not, a concurrent PUT overwrote us and we loop. Capped at
+// 3 attempts (one extra retry after the initial GET→PUT→verify) — beyond
+// that the upstream caller logs a warning and returns 200 per the
+// best-effort contract, and re-running the upsert recovers.
+const APPEND_REALM_MAX_ATTEMPTS = 3;
+
 export async function appendRealmToUserAccountData({
   matrixURL,
   userId,
@@ -200,36 +210,81 @@ export async function appendRealmToUserAccountData({
   userAccessToken: string;
   realmURL: string;
 }): Promise<{ alreadyPresent: boolean }> {
+  let firstAttemptAlreadyPresent: boolean | undefined;
+  for (let attempt = 1; attempt <= APPEND_REALM_MAX_ATTEMPTS; attempt++) {
+    let existing = await fetchRealmsAccountData(
+      matrixURL,
+      userId,
+      userAccessToken,
+    );
+    let realms = Array.isArray(existing.realms) ? existing.realms : [];
+    if (realms.includes(realmURL)) {
+      // First-attempt observation: the caller cares whether THIS
+      // invocation appended, so a realm that was already there before
+      // we did anything reads as `alreadyPresent: true`. A retry-loop
+      // observation: a concurrent writer added our realm for us — still
+      // a fresh append from the caller's perspective.
+      return { alreadyPresent: firstAttemptAlreadyPresent ?? true };
+    }
+    firstAttemptAlreadyPresent = false;
+    await putRealmsAccountData(matrixURL, userId, userAccessToken, {
+      ...existing,
+      realms: [...realms, realmURL],
+    });
+    // Verify our entry survived; if another writer raced us we retry.
+    let verified = await fetchRealmsAccountData(
+      matrixURL,
+      userId,
+      userAccessToken,
+    );
+    let verifiedRealms = Array.isArray(verified.realms) ? verified.realms : [];
+    if (verifiedRealms.includes(realmURL)) {
+      return { alreadyPresent: false };
+    }
+  }
+  throw new Error(
+    `matrix ${APP_BOXEL_REALMS_EVENT_TYPE} append for "${userId}" lost to a concurrent writer after ${APPEND_REALM_MAX_ATTEMPTS} attempts`,
+  );
+}
+
+async function fetchRealmsAccountData(
+  matrixURL: URL,
+  userId: string,
+  userAccessToken: string,
+): Promise<Record<string, unknown>> {
   let path = `_matrix/client/v3/user/${encodeURIComponent(userId)}/account_data/${APP_BOXEL_REALMS_EVENT_TYPE}`;
-  let getResponse = await fetch(`${matrixURL.href}${path}`, {
+  let response = await fetch(`${matrixURL.href}${path}`, {
     headers: { Authorization: `Bearer ${userAccessToken}` },
   });
-  let existing: { realms?: string[] } = {};
-  if (getResponse.status === 404) {
-    existing = { realms: [] };
-  } else if (!getResponse.ok) {
+  if (response.status === 404) {
+    return {};
+  }
+  if (!response.ok) {
     throw new Error(
-      `matrix GET ${APP_BOXEL_REALMS_EVENT_TYPE} for "${userId}" failed: HTTP ${getResponse.status} ${await getResponse.text()}`,
+      `matrix GET ${APP_BOXEL_REALMS_EVENT_TYPE} for "${userId}" failed: HTTP ${response.status} ${await response.text()}`,
     );
-  } else {
-    existing = (await getResponse.json()) as { realms?: string[] };
   }
-  let realms = Array.isArray(existing.realms) ? existing.realms : [];
-  if (realms.includes(realmURL)) {
-    return { alreadyPresent: true };
-  }
-  let putResponse = await fetch(`${matrixURL.href}${path}`, {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+async function putRealmsAccountData(
+  matrixURL: URL,
+  userId: string,
+  userAccessToken: string,
+  content: Record<string, unknown>,
+): Promise<void> {
+  let path = `_matrix/client/v3/user/${encodeURIComponent(userId)}/account_data/${APP_BOXEL_REALMS_EVENT_TYPE}`;
+  let response = await fetch(`${matrixURL.href}${path}`, {
     method: 'PUT',
     headers: {
       Authorization: `Bearer ${userAccessToken}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ ...existing, realms: [...realms, realmURL] }),
+    body: JSON.stringify(content),
   });
-  if (!putResponse.ok) {
+  if (!response.ok) {
     throw new Error(
-      `matrix PUT ${APP_BOXEL_REALMS_EVENT_TYPE} for "${userId}" failed: HTTP ${putResponse.status} ${await putResponse.text()}`,
+      `matrix PUT ${APP_BOXEL_REALMS_EVENT_TYPE} for "${userId}" failed: HTTP ${response.status} ${await response.text()}`,
     );
   }
-  return { alreadyPresent: false };
 }

--- a/packages/realm-server/synapse.ts
+++ b/packages/realm-server/synapse.ts
@@ -4,6 +4,7 @@ import { resolve, join } from 'path';
 import { createHmac } from 'crypto';
 import yaml from 'yaml';
 import { existsSync } from 'fs';
+import { APP_BOXEL_REALMS_EVENT_TYPE } from '@cardstack/runtime-common';
 
 function homeserverFile(): string {
   if (process.env.BOXEL_ENVIRONMENT) {
@@ -94,4 +95,119 @@ export async function registerUser({
     device_id: string;
   };
   return { accessToken, userId, homeServer, deviceId };
+}
+
+// Log in as a matrix admin user via the standard password-login endpoint and
+// return the resulting access token. The token is later used to drive synapse
+// admin endpoints (notably the per-user admin-impersonation login below).
+export async function loginAsMatrixAdmin({
+  matrixURL,
+  adminUsername,
+  adminPassword,
+}: {
+  matrixURL: URL;
+  adminUsername: string;
+  adminPassword: string;
+}): Promise<string> {
+  let response = await fetch(`${matrixURL.href}_matrix/client/r0/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      type: 'm.login.password',
+      user: adminUsername,
+      password: adminPassword,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `matrix admin login for "${adminUsername}" failed: HTTP ${response.status} ${await response.text()}`,
+    );
+  }
+  let body = (await response.json()) as { access_token: string };
+  return body.access_token;
+}
+
+// Use the synapse admin-only "log in as user" endpoint to mint an access
+// token on behalf of `userId`. Requires an existing admin access token.
+// Synapse rejects this for the admin's own user-id ("Cannot use admin API
+// to login as self"), so callers shouldn't pass the admin's user-id here.
+export async function adminImpersonateUser({
+  matrixURL,
+  adminAccessToken,
+  userId,
+}: {
+  matrixURL: URL;
+  adminAccessToken: string;
+  userId: string;
+}): Promise<string> {
+  let response = await fetch(
+    `${matrixURL.href}_synapse/admin/v1/users/${encodeURIComponent(userId)}/login`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${adminAccessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `matrix admin-impersonate for "${userId}" failed: HTTP ${response.status} ${await response.text()}`,
+    );
+  }
+  let body = (await response.json()) as { access_token: string };
+  return body.access_token;
+}
+
+// Append a single realm URL to a user's `app.boxel.realms` account_data,
+// preserving any existing entries. Idempotent: if `realmURL` is already in
+// the user's `realms` array, no PUT is fired and `{ alreadyPresent: true }`
+// is returned so callers can distinguish a no-op from a fresh append. A 404
+// from the GET is treated as "user has no realms list yet" — equivalent to
+// an empty array. Requires a user-scoped access token (admin-impersonate
+// first; synapse admin tokens cannot write other users' account_data).
+export async function appendRealmToUserAccountData({
+  matrixURL,
+  userId,
+  userAccessToken,
+  realmURL,
+}: {
+  matrixURL: URL;
+  userId: string;
+  userAccessToken: string;
+  realmURL: string;
+}): Promise<{ alreadyPresent: boolean }> {
+  let path = `_matrix/client/v3/user/${encodeURIComponent(userId)}/account_data/${APP_BOXEL_REALMS_EVENT_TYPE}`;
+  let getResponse = await fetch(`${matrixURL.href}${path}`, {
+    headers: { Authorization: `Bearer ${userAccessToken}` },
+  });
+  let existing: { realms?: string[] } = {};
+  if (getResponse.status === 404) {
+    existing = { realms: [] };
+  } else if (!getResponse.ok) {
+    throw new Error(
+      `matrix GET ${APP_BOXEL_REALMS_EVENT_TYPE} for "${userId}" failed: HTTP ${getResponse.status} ${await getResponse.text()}`,
+    );
+  } else {
+    existing = (await getResponse.json()) as { realms?: string[] };
+  }
+  let realms = Array.isArray(existing.realms) ? existing.realms : [];
+  if (realms.includes(realmURL)) {
+    return { alreadyPresent: true };
+  }
+  let putResponse = await fetch(`${matrixURL.href}${path}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${userAccessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ ...existing, realms: [...realms, realmURL] }),
+  });
+  if (!putResponse.ok) {
+    throw new Error(
+      `matrix PUT ${APP_BOXEL_REALMS_EVENT_TYPE} for "${userId}" failed: HTTP ${putResponse.status} ${await putResponse.text()}`,
+    );
+  }
+  return { alreadyPresent: false };
 }

--- a/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
@@ -24,11 +24,42 @@ import { APP_BOXEL_REALMS_EVENT_TYPE } from '@cardstack/runtime-common';
 import { setupServerEndpointsTest, testRealmURL } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 
+// The handle-upsert-realm-user-permission flow logs in as the local
+// matrix admin to admin-impersonate the granted user and write their
+// `app.boxel.realms` account_data. CI's `register-matrix-users realms-
+// only` step only registers realm-owning users, not the synapse admin,
+// so a lazy bootstrap here ensures `@admin:localhost` exists with
+// `admin: true` before any test that needs to log in as admin runs.
+// Local dev that already has admin registered keeps the same creds.
+async function ensureMatrixAdminUser(): Promise<void> {
+  let loginResponse = await fetch(`${matrixURL.href}_matrix/client/r0/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      type: 'm.login.password',
+      user: 'admin',
+      password: 'password',
+    }),
+  });
+  if (loginResponse.ok) {
+    return;
+  }
+  await registerUser({
+    matrixURL,
+    displayname: 'admin',
+    username: 'admin',
+    password: 'password',
+    registrationSecret: matrixRegistrationSecret,
+    admin: true,
+  });
+}
+
 module(`server-endpoints/${basename(__filename)}`, function () {
   module(
     'Realm Server Endpoints (not specific to one realm)',
     function (hooks) {
       let context = setupServerEndpointsTest(hooks);
+      hooks.before(ensureMatrixAdminUser);
 
       test('can force job completion by job_id via grafana endpoint', async function (assert) {
         let [{ id }] = (await context.dbAdapter.execute(`INSERT INTO jobs

--- a/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
@@ -1500,6 +1500,11 @@ module(`server-endpoints/${basename(__filename)}`, function () {
           )}/account_data/${APP_BOXEL_REALMS_EVENT_TYPE}`,
           { headers: { Authorization: `Bearer ${userToken}` } },
         );
+        assert.strictEqual(
+          accountDataResponse.status,
+          200,
+          'account_data GET returned 200',
+        );
         let body = (await accountDataResponse.json()) as { realms?: string[] };
         assert.deepEqual(
           body.realms,
@@ -1561,6 +1566,11 @@ module(`server-endpoints/${basename(__filename)}`, function () {
             userId,
           )}/account_data/${APP_BOXEL_REALMS_EVENT_TYPE}`,
           { headers: { Authorization: `Bearer ${userToken}` } },
+        );
+        assert.strictEqual(
+          after.status,
+          200,
+          'account_data GET returned 200',
         );
         let body = (await after.json()) as { realms?: string[] };
         assert.deepEqual(

--- a/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
@@ -6,8 +6,21 @@ import { PgAdapter, PgQueueRunner } from '@cardstack/postgres';
 import { sumUpCreditsLedger } from '@cardstack/billing/billing-queries';
 import * as boxelUIChangeChecker from '../../lib/boxel-ui-change-checker';
 import { fetchRealmPermissions } from '@cardstack/runtime-common';
-import { grafanaSecret, insertUser, realmSecretSeed } from '../helpers';
+import {
+  grafanaSecret,
+  insertUser,
+  matrixRegistrationSecret,
+  matrixURL,
+  realmSecretSeed,
+} from '../helpers';
 import { createJWT as createRealmServerJWT } from '../../utils/jwt';
+import {
+  adminImpersonateUser,
+  appendRealmToUserAccountData,
+  loginAsMatrixAdmin,
+  registerUser,
+} from '../../synapse';
+import { APP_BOXEL_REALMS_EVENT_TYPE } from '@cardstack/runtime-common';
 import { setupServerEndpointsTest, testRealmURL } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 
@@ -1360,6 +1373,201 @@ module(`server-endpoints/${basename(__filename)}`, function () {
           .set('Authorization', `Bearer ${grafanaSecret}`)
           .set('Content-Type', 'application/json');
         assert.strictEqual(response.status, 404, 'HTTP 404 status');
+      });
+
+      test("grafana upsert syncs realm to granted user's app.boxel.realms account_data", async function (assert) {
+        // Register a fresh matrix user so the admin-impersonate step
+        // resolves and we own the entire pre/post account_data state for
+        // this test (no carryover from other suites poking the same uid).
+        let localpart = `grafana-grant-${uuidv4().slice(0, 8)}`;
+        let userId = `@${localpart}:localhost`;
+        await registerUser({
+          matrixURL,
+          displayname: localpart,
+          username: localpart,
+          password: 'password',
+          registrationSecret: matrixRegistrationSecret,
+        });
+
+        let response = await context.request
+          .post(
+            `/_grafana-upsert-realm-user-permission` +
+              `?realm=${encodeURIComponent(testRealmURL.href)}` +
+              `&user=${encodeURIComponent(userId)}` +
+              `&read=true&write=false`,
+          )
+          .set('Authorization', `Bearer ${grafanaSecret}`)
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(response.status, 200, 'HTTP 200 status');
+        assert.notOk(
+          response.body.matrixAccountDataWarning,
+          `no matrix warning: ${response.body.matrixAccountDataWarning}`,
+        );
+        assert.true(
+          response.body.appendedToAccountData,
+          'response signals a fresh append',
+        );
+
+        // Read the user's account_data back over matrix to confirm the
+        // workspace list now contains the granted realm.
+        let adminToken = await loginAsMatrixAdmin({
+          matrixURL,
+          adminUsername: 'admin',
+          adminPassword: 'password',
+        });
+        let userToken = await adminImpersonateUser({
+          matrixURL,
+          adminAccessToken: adminToken,
+          userId,
+        });
+        let accountDataResponse = await fetch(
+          `${matrixURL.href}_matrix/client/v3/user/${encodeURIComponent(
+            userId,
+          )}/account_data/${APP_BOXEL_REALMS_EVENT_TYPE}`,
+          { headers: { Authorization: `Bearer ${userToken}` } },
+        );
+        assert.strictEqual(
+          accountDataResponse.status,
+          200,
+          'account_data row exists',
+        );
+        let body = (await accountDataResponse.json()) as { realms?: string[] };
+        assert.deepEqual(
+          body.realms,
+          [testRealmURL.href],
+          'realm appears in the user account_data',
+        );
+      });
+
+      test('grafana upsert is idempotent on the account_data side', async function (assert) {
+        let localpart = `grafana-grant-idem-${uuidv4().slice(0, 8)}`;
+        let userId = `@${localpart}:localhost`;
+        await registerUser({
+          matrixURL,
+          displayname: localpart,
+          username: localpart,
+          password: 'password',
+          registrationSecret: matrixRegistrationSecret,
+        });
+
+        let firstResponse = await context.request
+          .post(
+            `/_grafana-upsert-realm-user-permission` +
+              `?realm=${encodeURIComponent(testRealmURL.href)}` +
+              `&user=${encodeURIComponent(userId)}` +
+              `&read=true&write=false`,
+          )
+          .set('Authorization', `Bearer ${grafanaSecret}`)
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(firstResponse.status, 200, 'first call HTTP 200');
+        assert.true(
+          firstResponse.body.appendedToAccountData,
+          'first call appends',
+        );
+
+        // Same user, same realm, second time — the realm should already
+        // be in account_data and the handler should skip the PUT.
+        let secondResponse = await context.request
+          .post(
+            `/_grafana-upsert-realm-user-permission` +
+              `?realm=${encodeURIComponent(testRealmURL.href)}` +
+              `&user=${encodeURIComponent(userId)}` +
+              `&read=true&write=true`,
+          )
+          .set('Authorization', `Bearer ${grafanaSecret}`)
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(secondResponse.status, 200, 'second call HTTP 200');
+        assert.false(
+          secondResponse.body.appendedToAccountData,
+          'second call does not re-append',
+        );
+
+        // And the account_data should still contain the realm exactly
+        // once — no duplicate entry from the re-grant.
+        let adminToken = await loginAsMatrixAdmin({
+          matrixURL,
+          adminUsername: 'admin',
+          adminPassword: 'password',
+        });
+        let userToken = await adminImpersonateUser({
+          matrixURL,
+          adminAccessToken: adminToken,
+          userId,
+        });
+        let accountDataResponse = await fetch(
+          `${matrixURL.href}_matrix/client/v3/user/${encodeURIComponent(
+            userId,
+          )}/account_data/${APP_BOXEL_REALMS_EVENT_TYPE}`,
+          { headers: { Authorization: `Bearer ${userToken}` } },
+        );
+        let body = (await accountDataResponse.json()) as { realms?: string[] };
+        assert.deepEqual(
+          body.realms,
+          [testRealmURL.href],
+          'realm appears exactly once after two upserts',
+        );
+      });
+
+      test('appendRealmToUserAccountData preserves prior entries', async function (assert) {
+        // Direct exercise of the helper: pre-seed an unrelated realm in
+        // a fresh user's account_data, then ensure the new realm is
+        // appended without dropping or reordering existing entries.
+        let localpart = `grafana-grant-preserve-${uuidv4().slice(0, 8)}`;
+        let userId = `@${localpart}:localhost`;
+        await registerUser({
+          matrixURL,
+          displayname: localpart,
+          username: localpart,
+          password: 'password',
+          registrationSecret: matrixRegistrationSecret,
+        });
+        let priorRealm = 'http://other-realm.example/r/';
+
+        let adminToken = await loginAsMatrixAdmin({
+          matrixURL,
+          adminUsername: 'admin',
+          adminPassword: 'password',
+        });
+        let userToken = await adminImpersonateUser({
+          matrixURL,
+          adminAccessToken: adminToken,
+          userId,
+        });
+        let seed = await fetch(
+          `${matrixURL.href}_matrix/client/v3/user/${encodeURIComponent(
+            userId,
+          )}/account_data/${APP_BOXEL_REALMS_EVENT_TYPE}`,
+          {
+            method: 'PUT',
+            headers: {
+              Authorization: `Bearer ${userToken}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ realms: [priorRealm] }),
+          },
+        );
+        assert.strictEqual(seed.status, 200, 'seed PUT succeeded');
+
+        let result = await appendRealmToUserAccountData({
+          matrixURL,
+          userId,
+          userAccessToken: userToken,
+          realmURL: testRealmURL.href,
+        });
+        assert.false(result.alreadyPresent, 'realm was not already present');
+
+        let after = await fetch(
+          `${matrixURL.href}_matrix/client/v3/user/${encodeURIComponent(
+            userId,
+          )}/account_data/${APP_BOXEL_REALMS_EVENT_TYPE}`,
+          { headers: { Authorization: `Bearer ${userToken}` } },
+        );
+        let body = (await after.json()) as { realms?: string[] };
+        assert.deepEqual(
+          body.realms,
+          [priorRealm, testRealmURL.href],
+          'new realm appended after prior entry',
+        );
       });
     },
   );

--- a/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
@@ -1567,11 +1567,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
           )}/account_data/${APP_BOXEL_REALMS_EVENT_TYPE}`,
           { headers: { Authorization: `Bearer ${userToken}` } },
         );
-        assert.strictEqual(
-          after.status,
-          200,
-          'account_data GET returned 200',
-        );
+        assert.strictEqual(after.status, 200, 'account_data GET returned 200');
         let body = (await after.json()) as { realms?: string[] };
         assert.deepEqual(
           body.realms,


### PR DESCRIPTION
## Summary

The grafana `/_grafana-upsert-realm-user-permission` endpoint now updates the granted user's matrix `app.boxel.realms` account_data in addition to writing the `realm_user_permissions` row, so the realm appears in their workspace list on their next host load without manual intervention.

## Mechanism

After `insertPermissions` succeeds, when `user` is a fully-qualified matrix user-id (`@localpart:homeserver` form — starts with `@`, contains `:`):

1. Log in to matrix as the synapse admin (creds below).
2. Use the synapse admin-only `_synapse/admin/v1/users/<userId>/login` endpoint to mint an access token for the granted user.
3. GET the user's `app.boxel.realms` account_data, append the realm URL if not already present, PUT it back.

The append is idempotent: if the realm is already in the user's `realms` array no PUT fires. The endpoint response includes `appendedToAccountData` (boolean) and, on failure or skip, `matrixAccountDataWarning` (string).

Best-effort: a matrix failure logs a warning and returns 200 so a flaky matrix doesn't roll back the DB grant. Re-running the endpoint is idempotent on both sides — the DB upsert overwrites with the same row, and the matrix append skips when the realm is already present.

Wildcard (`*`) and bare-localpart users skip the matrix step (no synapse account to write to).

## Required environment

Two new optional env vars on the realm-server:

- `MATRIX_ADMIN_USERNAME`
- `MATRIX_ADMIN_PASSWORD`

When both are unset and `MATRIX_URL`'s hostname is `localhost`, the handler defaults to `admin`/`password` (matches the dev creds `packages/matrix/scripts/register-matrix-users.ts` seeds). For staging / prod the env vars must be supplied — the infra PR forwarding these from SSM lands separately.

## Test plan

- [x] `pnpm -F @cardstack/realm-server lint:types` — no new errors in the changed files (pre-existing `packages/base/*.gts` errors are unrelated)
- [x] `eslint` clean on all 6 changed files
- [x] All 12 grafana upsert-realm-user-permission tests pass against a real local synapse, including 3 new ones:
  - `grafana upsert syncs realm to granted user's app.boxel.realms account_data`
  - `grafana upsert is idempotent on the account_data side`
  - `appendRealmToUserAccountData preserves prior entries`

🤖 Generated with [Claude Code](https://claude.com/claude-code)