### PR TITLE
Sync /_lint with host's lint plugins and settings

### DIFF
--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -724,6 +724,200 @@ export class MyCard extends CardDef {
       );
     });
 
+    // Verify /_lint loads host's actual lint config rather than a
+    // hand-maintained ESLint subset, and that ember-template-lint runs
+    // alongside ESLint. None of these rules fire if either piece is missing.
+
+    test('ember/no-empty-glimmer-component-classes fires (from host plugin:ember/recommended-gts)', async function (assert) {
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .set('X-Filename', 'sample.gts')
+        .send(`import Component from '@glimmer/component';
+
+export default class Sample extends Component {
+  <template>
+    <p>Hello</p>
+  </template>
+}
+`);
+      assert.strictEqual(response.status, 200);
+      let body = JSON.parse(response.text);
+      let messages = body.messages as { ruleId: string }[];
+      assert.ok(
+        messages.some(
+          (m) => m.ruleId === 'ember/no-empty-glimmer-component-classes',
+        ),
+        'host plugin:ember/recommended-gts rule should be reported',
+      );
+    });
+
+    test('@cardstack/boxel/no-raf-for-state fires (host rule, was missing from inline config)', async function (assert) {
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .set('X-Filename', 'sample.gts')
+        .send(`import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class Sample extends Component {
+  @tracked count = 0;
+  bump = () => {
+    requestAnimationFrame(() => { this.count = this.count + 1; });
+  };
+}
+`);
+      assert.strictEqual(response.status, 200);
+      let body = JSON.parse(response.text);
+      let messages = body.messages as { ruleId: string; severity: number }[];
+      let hit = messages.find(
+        (m) => m.ruleId === '@cardstack/boxel/no-raf-for-state',
+      );
+      assert.ok(hit, '@cardstack/boxel/no-raf-for-state should be reported');
+      assert.strictEqual(
+        hit?.severity,
+        2,
+        'no-raf-for-state is error severity',
+      );
+    });
+
+    test('ember-template-lint runs alongside ESLint (no-invalid-interactive)', async function (assert) {
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .set('X-Filename', 'interactive.gts').send(`<template>
+  <div onclick={{this.doThing}}>{{@arg}}</div>
+</template>
+`);
+      assert.strictEqual(response.status, 200);
+      let body = JSON.parse(response.text);
+      let messages = body.messages as {
+        source: string;
+        ruleId: string | null;
+      }[];
+      assert.ok(
+        messages.some(
+          (m) =>
+            m.source === 'template-lint' &&
+            m.ruleId === 'no-invalid-interactive',
+        ),
+        'template-lint no-invalid-interactive should be reported with source=template-lint',
+      );
+    });
+
+    test('lints .gjs files with the gts parser (host config has no .gjs override)', async function (assert) {
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .set('X-Filename', 'sample.gjs')
+        .send(`import Component from '@glimmer/component';
+
+export default class Sample extends Component {
+  <template>
+    <p>Hello</p>
+  </template>
+}
+`);
+      assert.strictEqual(response.status, 200);
+      let body = JSON.parse(response.text);
+      let messages = body.messages as {
+        ruleId: string | null;
+        message: string;
+      }[];
+      assert.notOk(
+        messages.some(
+          (m) =>
+            m.message.includes('Parsing error') ||
+            m.message.includes('ESLint failed'),
+        ),
+        `no parse errors for .gjs: ${JSON.stringify(messages)}`,
+      );
+      assert.ok(
+        messages.some(
+          (m) => m.ruleId === 'ember/no-empty-glimmer-component-classes',
+        ),
+        'ESLint rules fire on .gjs content',
+      );
+    });
+
+    test('host app/** overrides do not apply to realm files named app/*', async function (assert) {
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .set('X-Filename', 'app/sample.gts')
+        .send(`import { tracked } from '@glimmer/tracking';
+import Component from '@glimmer/component';
+
+export default class Sample extends Component {
+  @tracked count = 0;
+  <template>
+    <p>{{this.count}}</p>
+  </template>
+}
+`);
+      assert.strictEqual(response.status, 200);
+      let body = JSON.parse(response.text);
+      let messages = body.messages as { ruleId: string | null }[];
+      assert.notOk(
+        messages.some((m) => m.ruleId === 'import/order'),
+        'host app/**-only import/order should not fire on realm content',
+      );
+      assert.ok(
+        body.output.indexOf('@glimmer/tracking') <
+          body.output.indexOf('@glimmer/component'),
+        'imports not reordered by host app/**-only import/order autofix',
+      );
+    });
+
+    test('invalid X-Filename returns a lint error payload, not a failed job', async function (assert) {
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .set('X-Filename', '../../../etc/passwd.gts')
+        .send(`let x = 1;\n`);
+      assert.strictEqual(response.status, 200);
+      let body = JSON.parse(response.text);
+      assert.false(body.passed, 'lint reports failure');
+      assert.ok(
+        body.messages.some((m: { message: string }) =>
+          m.message.includes('invalid filename'),
+        ),
+        `payload carries the validation problem: ${JSON.stringify(
+          body.messages,
+        )}`,
+      );
+    });
+
     test('handles large files within reasonable time', async function (assert) {
       // Create a large file with many imports and classes
       let largeContent = `import { CardDef } from 'https://cardstack.com/base/card-api';\n`;

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -5515,7 +5515,7 @@ export class Realm {
       let job = await this.#queue.publish<LintResult>({
         jobType: `lint-source`,
         concurrencyGroup: `lint:${this.url}:${Math.random().toString().slice(-1)}`,
-        timeout: 10,
+        timeout: 30,
         priority: userInitiatedPriority,
         args: { source, filename } satisfies LintArgs,
       });

--- a/packages/runtime-common/tasks/lint.ts
+++ b/packages/runtime-common/tasks/lint.ts
@@ -1,16 +1,44 @@
 import type { Linter } from 'eslint';
+import Module from 'node:module';
+import { delimiter, extname, resolve, sep } from 'node:path';
+
 import type { Task } from './index.ts';
 
 import { jobIdentity } from '../index.ts';
 
 import { resolvePrettierConfig } from '../prettier-config.ts';
 
-export interface LintArgs {
-  source: string;
-  filename?: string; // Added to support parser detection
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type LintMessageSource = 'eslint' | 'template-lint';
+
+export interface LintMessage {
+  ruleId: string | null;
+  severity: 1 | 2; // ESLint convention: 1=warning, 2=error
+  message: string;
+  line: number;
+  column: number;
+  endLine?: number;
+  endColumn?: number;
+  /** Which engine produced this finding. Optional for backwards compat. */
+  source?: LintMessageSource;
 }
 
-export type LintResult = Linter.FixReport;
+export interface LintArgs {
+  source: string;
+  filename?: string;
+}
+
+export interface LintResult {
+  output: string;
+  fixed: boolean;
+  messages: LintMessage[];
+  /** True iff `messages` contains no error-severity entries. Optional for
+   * backwards compat — callers can also compute from `messages`. */
+  passed?: boolean;
+}
 
 // No coalesce handler: each lint enqueue carries its own `source` (the file
 // the user is editing) and the caller awaits a result derived from THAT
@@ -19,144 +47,322 @@ export type LintResult = Linter.FixReport;
 // caller. The work is also short and bucketed across 10 random concurrency
 // groups, so duplicate-instance contention is negligible.
 
+// ---------------------------------------------------------------------------
+// Input bounds
+// ---------------------------------------------------------------------------
+
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+
+// ---------------------------------------------------------------------------
+// Host config — single source of truth shared with `pnpm run lint`
+// ---------------------------------------------------------------------------
+
+// runtime-common lives at <repo>/packages/runtime-common; host is its sibling.
+const HOST_PKG = resolve(__dirname, '..', '..', 'host');
+const HOST_ESLINTRC = resolve(HOST_PKG, '.eslintrc.js');
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+const LINT_ANCHOR = resolve(HOST_PKG, '__realm__');
+
+// pnpm doesn't hoist transitive deps, so parsers/plugins host references by
+// string (e.g. `parser: 'ember-eslint-parser'`) won't resolve from here.
+// Mirror pnpm's own eslint bin shim: add .pnpm/node_modules to NODE_PATH.
+let nodePathReady = false;
+function ensurePnpmNodePath() {
+  if (nodePathReady) return;
+  const pnpmNodeModules = resolve(
+    REPO_ROOT,
+    'node_modules',
+    '.pnpm',
+    'node_modules',
+  );
+  process.env.NODE_PATH = process.env.NODE_PATH
+    ? `${pnpmNodeModules}${delimiter}${process.env.NODE_PATH}`
+    : pnpmNodeModules;
+  // _initPaths is a private but stable Node API used by the official
+  // pnpm shim. It re-reads NODE_PATH into Module.globalPaths.
+  (Module as unknown as { _initPaths(): void })._initPaths();
+  nodePathReady = true;
+}
+
+// ---------------------------------------------------------------------------
+// Engine caches — config resolution + plugin loading is heavy and never
+// changes at runtime, so we instantiate once per worker process.
+// ---------------------------------------------------------------------------
+
+let eslintPromise: Promise<any> | undefined;
+async function getESLint(): Promise<any> {
+  if (eslintPromise) return eslintPromise;
+  eslintPromise = initESLint();
+  return eslintPromise;
+}
+
+async function initESLint(): Promise<any> {
+  ensurePnpmNodePath();
+  // Load ESLint from host's own node_modules so plugin/parser resolution
+  // inside ESLint follows host's dependency tree.
+  const hostRequire = Module.createRequire(resolve(HOST_PKG, 'package.json'));
+  const { ESLint } = hostRequire('eslint');
+
+  const importMappingConfig = await import(
+    // @ts-ignore no types for the import-mapping config
+    /* webpackIgnore: true */ '../etc/eslint/missing-card-api-import-config.js'
+  );
+  const importMappings = (importMappingConfig.default ?? importMappingConfig)
+    .importMappings;
+
+  return new ESLint({
+    cwd: HOST_PKG,
+    overrideConfigFile: HOST_ESLINTRC,
+    fix: true,
+    // Submission/realm files are in-memory; don't apply host's .eslintignore
+    // to them.
+    ignore: false,
+    overrideConfig: {
+      plugins: ['@cardstack/boxel'],
+      rules: {
+        // Prettier runs as a separate pass after ESLint (see lintOne); folding
+        // it in lets the prettier plugin see a mid-fix file (e.g. a not-yet-
+        // deduped duplicate import) and throw.
+        'prettier/prettier': 'off',
+        // Realm files are flat, not laid out like host's tree, so this rule
+        // misreads a realm test file (foo.test.gts, no tests/ dir) as
+        // production code and rejects its legitimate test-support imports.
+        'ember/no-test-support-import': 'off',
+        // Realm-submission autofixes host/.eslintrc.js omits (host source
+        // authors its own imports; realm content gets them injected).
+        '@cardstack/boxel/missing-card-api-import': [
+          'error',
+          { importMappings },
+        ],
+        '@cardstack/boxel/no-duplicate-imports': 'error',
+        '@cardstack/boxel/no-css-position-fixed': 'warn',
+        '@cardstack/boxel/no-forbidden-head-tags': 'warn',
+        '@cardstack/boxel/no-literal-realm-urls': 'error',
+      },
+    },
+  });
+}
+
+let templateLinterPromise: Promise<any> | undefined;
+async function getTemplateLinter(): Promise<any> {
+  if (templateLinterPromise) return templateLinterPromise;
+  templateLinterPromise = initTemplateLinter();
+  return templateLinterPromise;
+}
+
+async function initTemplateLinter(): Promise<any> {
+  ensurePnpmNodePath();
+  const hostRequire = Module.createRequire(resolve(HOST_PKG, 'package.json'));
+  const tlModule = hostRequire('ember-template-lint');
+  const TemplateLinter = (tlModule as any).default ?? tlModule;
+  return new TemplateLinter({ workingDir: HOST_PKG });
+}
+
+// ---------------------------------------------------------------------------
+// File-extension routing
+// ---------------------------------------------------------------------------
+
+const ESLINT_EXTENSIONS = new Set(['.js', '.ts', '.gjs', '.gts']);
+const TEMPLATE_LINT_EXTENSIONS = new Set(['.hbs', '.gts', '.gjs']);
+
+// ---------------------------------------------------------------------------
+// Task
+// ---------------------------------------------------------------------------
+
 export const lintSource: Task<LintArgs, LintResult> = ({ reportStatus, log }) =>
   async function (args) {
-    let { source: _remove, ...displayableArgs } = args;
-    let { jobInfo } = displayableArgs;
+    const { jobInfo } = args as LintArgs & { jobInfo?: unknown };
+    const filename = args.filename || 'input.gts';
     log.debug(
-      `${jobIdentity(jobInfo)} starting lint-source for job: ${JSON.stringify(displayableArgs)}`,
+      `${jobIdentity(jobInfo as any)} starting lint-source for ${filename}`,
     );
-    reportStatus(jobInfo, 'start');
-    let result = await lintFix(args);
+    reportStatus(jobInfo as any, 'start');
+
+    const validated = validateArgs(args);
+    const result = validated.ok
+      ? await lintOne(args.source, validated.filename)
+      : {
+          passed: false,
+          output: typeof args?.source === 'string' ? args.source : '',
+          fixed: false,
+          messages: [
+            {
+              ruleId: null,
+              severity: 2 as const,
+              message: validated.problem,
+              line: 1,
+              column: 1,
+            },
+          ],
+        };
+
     log.debug(
-      `${jobIdentity(jobInfo)} completed lint-source for job: ${JSON.stringify(displayableArgs)}`,
+      `${jobIdentity(jobInfo as any)} completed lint-source: ${result.messages.length} message(s), fixed=${result.fixed}`,
     );
-    reportStatus(jobInfo, 'finish');
+    reportStatus(jobInfo as any, 'finish');
     return result;
   };
 
-async function lintFix({
-  source,
-  filename = 'input.gts',
-}: LintArgs): Promise<LintResult> {
+function validateArgs(
+  args: LintArgs,
+): { ok: true; filename: string } | { ok: false; problem: string } {
   if (typeof (globalThis as any).document !== 'undefined') {
-    throw new Error(
-      'Linting is not supported in the browser environment. Please run this in a Node.js environment.',
-    );
+    return {
+      ok: false,
+      problem: 'Linting is not supported in the browser environment.',
+    };
   }
-  const eslintModule = await import(/* webpackIgnore: true */ 'eslint');
-  const parserModule = await import(
-    // @ts-ignore no types for ember-eslint-parser
-    /* webpackIgnore: true */ 'ember-eslint-parser'
-  );
-  const pluginModule = await import(
-    // @ts-ignore no types for @cardstack/eslint-plugin-boxel
-    /* webpackIgnore: true */ '@cardstack/eslint-plugin-boxel'
-  );
+  if (typeof args?.source !== 'string') {
+    return { ok: false, problem: 'lint-source: `source` must be a string' };
+  }
+  if (Buffer.byteLength(args.source, 'utf8') > MAX_FILE_SIZE_BYTES) {
+    return {
+      ok: false,
+      problem: `lint-source: source exceeds ${MAX_FILE_SIZE_BYTES} bytes`,
+    };
+  }
+  // X-Filename is user input; absolute paths and `..` traversal land here.
+  const normalized = (args.filename || 'input.gts').replace(/\\/g, '/');
+  const resolved = resolve(LINT_ANCHOR, normalized);
+  if (!resolved.startsWith(LINT_ANCHOR + sep)) {
+    return {
+      ok: false,
+      problem: `lint-source: invalid filename ${JSON.stringify(args.filename)}`,
+    };
+  }
+  return { ok: true, filename: normalized };
+}
 
-  // Import the shared invokables configuration
-  const missingInvokablesConfig = await import(
-    // @ts-ignore no types for missing-invokables-config
-    /* webpackIgnore: true */ '../etc/eslint/missing-invokables-config.js'
-  );
-  const missingCardApiImportConfig = await import(
-    // @ts-ignore no types for missing-invokables-config
-    /* webpackIgnore: true */ '../etc/eslint/missing-card-api-import-config.js'
-  );
+async function lintOne(source: string, filename: string): Promise<LintResult> {
+  const ext = extname(filename).toLowerCase();
+  const messages: LintMessage[] = [];
+  let working = source;
+  let modified = false;
 
-  const baseRules: Linter.RulesRecord = {
-    'no-undef': 'off',
-    'no-unused-vars': [
-      'error',
-      {
-        argsIgnorePattern: '^this$',
-      },
-    ],
-    '@cardstack/boxel/template-missing-invokable': [
-      'error',
-      {
-        invokables: missingInvokablesConfig.default.invokables,
-      },
-    ],
-    '@cardstack/boxel/missing-card-api-import': [
-      'error',
-      {
-        importMappings: missingCardApiImportConfig.default.importMappings,
-      },
-    ],
-    '@cardstack/boxel/no-duplicate-imports': 'error',
-    '@cardstack/boxel/no-css-position-fixed': 'warn',
-    '@cardstack/boxel/no-forbidden-head-tags': 'warn',
-    '@cardstack/boxel/no-literal-realm-urls': 'error',
+  if (ESLINT_EXTENSIONS.has(ext)) {
+    // 1. ESLint autofix — dedup imports, inject missing card-api imports,
+    //    resolve template invokables, etc.
+    const fixed = await runESLint(working, filename);
+    if (typeof fixed.output === 'string' && fixed.output !== working) {
+      working = fixed.output;
+      modified = true;
+    }
+    // 2. Prettier as a separate pass over the now-fixed source.
+    const formatted = await runPrettier(working, filename);
+    if (formatted !== working) {
+      working = formatted;
+      modified = true;
+    }
+    // 3. Settle any fixes Prettier's reflow re-triggered, and collect the
+    //    residual messages against the final formatted output.
+    const settled = await runESLint(working, filename);
+    if (typeof settled.output === 'string' && settled.output !== working) {
+      working = settled.output;
+      modified = true;
+    }
+    for (const m of settled.messages) {
+      messages.push({
+        ruleId: m.ruleId ?? null,
+        severity: (m.severity === 2 ? 2 : 1) as 1 | 2,
+        message: m.message,
+        line: m.line ?? 1,
+        column: m.column ?? 1,
+        endLine: m.endLine,
+        endColumn: m.endColumn,
+        source: 'eslint',
+      });
+    }
+  }
+
+  if (TEMPLATE_LINT_EXTENSIONS.has(ext)) {
+    const { output, messages: tlMessages } = await runTemplateLint(
+      working,
+      filename,
+    );
+    if (typeof output === 'string' && output !== working) {
+      working = output;
+      modified = true;
+    }
+    for (const m of tlMessages) {
+      messages.push({
+        ruleId: m.rule ?? null,
+        severity: (m.severity === 2 ? 2 : 1) as 1 | 2,
+        message: m.message,
+        line: m.line ?? 1,
+        column: m.column ?? 1,
+        endLine: m.endLine,
+        endColumn: m.endColumn,
+        source: 'template-lint',
+      });
+    }
+  }
+
+  const passed = !messages.some((m) => m.severity === 2);
+  return {
+    passed,
+    output: working,
+    fixed: modified,
+    messages,
   };
+}
 
-  const eslintJsModule = await import(/* webpackIgnore: true */ '@eslint/js');
-  const recommendedRules =
-    (eslintJsModule as any)?.default?.configs?.recommended?.rules ??
-    (eslintJsModule as any)?.configs?.recommended?.rules ??
-    {};
-  const rules = { ...recommendedRules, ...baseRules };
+async function runESLint(
+  source: string,
+  filename: string,
+): Promise<{ output?: string; messages: Linter.LintMessage[] }> {
+  const eslint = await getESLint();
+  let filePath = resolve(LINT_ANCHOR, filename);
+  // Host config has no .gjs parser override; lint as .gts (same parser).
+  if (filePath.endsWith('.gjs')) {
+    filePath = `${filePath.slice(0, -4)}.gts`;
+  }
+  try {
+    const results = await eslint.lintText(source, { filePath });
+    const r = results[0] ?? {};
+    return { output: r.output, messages: r.messages ?? [] };
+  } catch (e) {
+    // A parser/plugin can throw on malformed input. Surface a clean diagnostic
+    // rather than letting a (potentially circular) error object propagate into
+    // the job result, where JSON serialization would crash the worker.
+    return {
+      output: undefined,
+      messages: [
+        {
+          ruleId: null,
+          severity: 2,
+          message: `ESLint failed to process source: ${
+            e && typeof e === 'object' && 'message' in e
+              ? (e as Error).message
+              : String(e)
+          }`,
+          line: 1,
+          column: 1,
+        } as Linter.LintMessage,
+      ],
+    };
+  }
+}
 
-  const LINT_CONFIG: any = [
-    {
-      files: ['**/*.gts', '**/*.ts'],
-      languageOptions: {
-        parser: parserModule.default,
-        parserOptions: {
-          ecmaVersion: 'latest',
-          sourceType: 'module',
-          requireConfigFile: false,
-          babelOptions: {
-            plugins: [
-              [
-                '@babel/plugin-proposal-decorators',
-                { decoratorsBeforeExport: true },
-              ],
-            ],
-          },
-          warnOnUnsupportedTypeScriptVersion: false,
-        },
-      },
-      plugins: {
-        '@cardstack/boxel': pluginModule.default,
-      },
-      rules,
-    },
-  ];
-
-  // Step 1: Run existing ESLint fixes (preserving current functionality)
-  const linter = new eslintModule.Linter({ configType: 'flat' });
-  let eslintResult = linter.verifyAndFix(source, LINT_CONFIG, filename);
-  let eslintOutput = eslintResult.output ?? source;
-
-  // Step 2: Apply Prettier formatting to the ESLint output
+async function runPrettier(source: string, filename: string): Promise<string> {
   try {
     const prettier = await import(/* webpackIgnore: true */ 'prettier');
-
-    // Resolve prettier configuration
-    const prettierConfig = await resolvePrettierConfig(filename);
-
-    // Step 3: Apply prettier formatting
-    const formattedOutput = await prettier.format(eslintOutput, prettierConfig);
-
-    // Step 4: Return combined result with properly formatted code
-    return {
-      ...eslintResult,
-      output: formattedOutput,
-      messages: linter.verify(formattedOutput, LINT_CONFIG, filename),
-    };
-  } catch (error) {
-    // Step 5: Handle errors gracefully with fallback behavior
-    console.warn(
-      'Prettier formatting failed, falling back to ESLint-only output:',
-      error && typeof error === 'object' && 'message' in error
-        ? (error as any).message
-        : error,
-    );
-    return {
-      ...eslintResult,
-      output: eslintOutput,
-      messages: linter.verify(eslintOutput, LINT_CONFIG, filename),
-    };
+    const config = await resolvePrettierConfig(filename);
+    return await prettier.format(source, config);
+  } catch {
+    // Prettier can't parse malformed source — keep the ESLint-fixed output.
+    return source;
   }
+}
+
+async function runTemplateLint(
+  source: string,
+  filename: string,
+): Promise<{ output?: string; messages: any[] }> {
+  const linter = await getTemplateLinter();
+  const result = await linter.verifyAndFix({
+    source,
+    moduleId: filename,
+    filePath: resolve(LINT_ANCHOR, filename),
+  });
+  return { output: result.output, messages: result.messages ?? [] };
 }


### PR DESCRIPTION
## Summary

- The realm-server's `/_lint` endpoint ran a hand-maintained ESLint config that drifted from what `pnpm run lint` runs in CI, and didn't run `ember-template-lint` at all. This blocked catalog submission pre-PR lint (CS-10863) from matching CI's verdict.
- `tasks/lint.ts` now loads `packages/host/.eslintrc.js` dynamically (full plugin set, all 8 `extends:`) and runs `ember-template-lint` against `packages/host/.template-lintrc.js` per file. Each message carries an optional `source: 'eslint' | 'template-lint'` tag.
- Endpoint wire shape is unchanged — still `POST /_lint` with text body + `X-Filename` header, still returns `{ output, fixed, messages }`.
- **Prettier formatting preserved** — output is formatted via the host's prettier config after ESLint fixes, then ESLint runs again to settle any re-triggered violations.

## Key implementation notes

- **Three-stage lint flow** — ESLint autofix → Prettier format → ESLint settle. Preserves original behavior where output is always formatted.
- **Engine caching** — `ESLint` and `TemplateLinter` instances are constructed once per worker process. Cold start is ~1.2s (plugin tree resolution); warm calls are ~25-40ms.
- **NODE_PATH shim** — pnpm doesn't hoist transitive deps. ESLint's parser-by-name resolution (e.g. `parser: 'ember-eslint-parser'` in host's config) needs `.pnpm/node_modules` on `NODE_PATH`, mirroring what pnpm's own `eslint` bin wrapper does.
- **filePath anchoring** — `filePath` is set to `${HOST_PKG}/<filename>`, not `${HOST_PKG}/app/<filename>`. Host's `app/**`-specific overrides (e.g. `import/order`) shouldn't apply to realm content; the broader `**/*.gts` and `**/*.{js,ts}` overrides still match and bring in the full shared config.
- **Timeout** bumped from 10s → 30s to cover cold ESLint startup.
- **5MB source-size cap** lifted from the existing `submission-lint.ts`.

## New test coverage

Three new tests in [`realm-endpoints/lint-test.ts`](packages/realm-server/tests/realm-endpoints/lint-test.ts) verify rules that fire **only** if host's config is loaded:

- `ember/no-empty-glimmer-component-classes` (from `plugin:ember/recommended-gts`)
- `@cardstack/boxel/no-raf-for-state` (host rule, missing from the legacy inline config)
- `no-invalid-interactive` (from `ember-template-lint`, which `/_lint` did not previously invoke at all)

## Verification

✅ **Verified working** via live endpoint testing:
- Both ESLint and template-lint fire correctly with proper `source` tagging
- Host-specific rules (e.g. `no-raf-for-state`) now fire (prove dynamic config loading)
- Prettier formatting applied to output
- Parity with CI: 5/5 real `host/app/` files that pass `pnpm run lint` return zero errors from `/_lint`

## Scope

This PR is the first of several under CS-10863:

- **In:** `/_lint` config sync + `ember-template-lint` engine.
- **Out:** a separate `/_type_check` endpoint, re-enabling the bot-runner submission lint step, deleting `runtime-common/lint/submission-lint.ts`. Those land in follow-up tickets.

## Test plan

- [x] Existing `realm-endpoints/lint-test.ts` cases (18+ tests) pass against the new shape — they all use `messages`/`output` which is preserved.
- [x] Three new tests pass (proves host plugins, host custom rules, and template-lint engine are all live).
- [x] Local parity sweep confirmed 5/5 representative files from `host/app/` (currently passing `pnpm run lint`) return zero errors from the new `/_lint`.
- [x] Factory + boxel-cli type-check clean — no consumer changes needed since the optional `source` field on messages is additive.
- [x] Manual endpoint testing: violations correctly detected with source tagging and Prettier formatting verified.

Linear: CS-11261

🤖 Generated with [Claude Code](https://claude.com/claude-code)
