### PR TITLE
CS-11264: route _realm-auth through reconciler.lookupOrMount

### DIFF
--- a/packages/realm-server/handlers/handle-realm-auth.ts
+++ b/packages/realm-server/handlers/handle-realm-auth.ts
@@ -4,6 +4,7 @@ import type { CreateRoutesArgs } from '../routes';
 import {
   SupportedMimeType,
   fetchUserPermissions,
+  type Realm,
 } from '@cardstack/runtime-common';
 import type { RealmServerTokenClaim } from 'utils/jwt';
 import { getUserByMatrixUserId } from '@cardstack/billing/billing-queries';
@@ -14,11 +15,10 @@ import * as Sentry from '@sentry/node';
 export default function handleRealmAuth({
   dbAdapter,
   realmSecretSeed,
-  realms,
+  reconciler,
   serverURL,
 }: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
-    let allRealms = realms;
     let token = ctxt.state.token as RealmServerTokenClaim;
     let { user: matrixUserId } = token;
     let user = await getUserByMatrixUserId(dbAdapter, matrixUserId);
@@ -42,7 +42,18 @@ export default function handleRealmAuth({
     for (let [realmUrl, permissions] of Object.entries(
       permissionsForAllRealms,
     )) {
-      let realm = allRealms.find((r) => r.url === realmUrl);
+      let realm: Realm | undefined;
+      try {
+        realm = await reconciler.lookupOrMount(realmUrl);
+      } catch (error) {
+        Sentry.withScope((scope) => {
+          scope.setExtra('realmUrl', realmUrl);
+          scope.setExtra('matrixUserId', matrixUserId);
+          scope.setExtra('permissionsForAllRealms', permissionsForAllRealms);
+          Sentry.captureException(error);
+        });
+        continue;
+      }
       if (!realm) {
         console.error(
           `Permissions found pointing to unknown realm ${realmUrl}`,

--- a/packages/realm-server/handlers/handle-realm-auth.ts
+++ b/packages/realm-server/handlers/handle-realm-auth.ts
@@ -56,15 +56,27 @@ export default function handleRealmAuth({
     // the mount happens later, when the holder actually hits a realm
     // endpoint and findOrMountRealm/lookupOrMount runs there.
     //
-    // Same lookup order as multiRealmAuthorization (CS-11238): in-memory
-    // reconciler.knownByUrl first, then a single batched probe against
-    // realm_registry for any URLs not yet reflected in this process
-    // (e.g. a freshly-published row from a peer instance between NOTIFY
-    // and the next reconcile pass).
+    // Mirrors multiRealmAuthorization's three-step lookup order
+    // (CS-11238):
+    //   1. reconciler.mounted — covers realms currently mounted on
+    //      this process, including the mid-start window AND legacy-
+    //      registered mounts from registerExistingMounts that have
+    //      no realm_registry row (test fixtures and the pre-Phase-3
+    //      boot path use this — the reconciler intentionally does
+    //      not put them in knownByUrl so the unmount phase doesn't
+    //      tear them down).
+    //   2. reconciler.knownByUrl — in-memory mirror of realm_registry,
+    //      refreshed at boot, on NOTIFY, and by the safety-net poll.
+    //   3. Direct realm_registry probe — covers the gap between a
+    //      peer instance's INSERT+NOTIFY and this instance's next
+    //      reconcile pass.
     let registeredUrls = new Set<string>();
     let urlsToProbe: string[] = [];
     for (let realmUrl of accessibleRealmUrls) {
-      if (reconciler.knownByUrl.has(realmUrl)) {
+      if (
+        reconciler.mounted.has(realmUrl) ||
+        reconciler.knownByUrl.has(realmUrl)
+      ) {
         registeredUrls.add(realmUrl);
       } else {
         urlsToProbe.push(realmUrl);

--- a/packages/realm-server/handlers/handle-realm-auth.ts
+++ b/packages/realm-server/handlers/handle-realm-auth.ts
@@ -2,9 +2,14 @@ import type Koa from 'koa';
 
 import type { CreateRoutesArgs } from '../routes';
 import {
-  SupportedMimeType,
+  fetchSessionRoom,
   fetchUserPermissions,
-  type Realm,
+  param,
+  query,
+  separatedByCommas,
+  SupportedMimeType,
+  upsertSessionRoom,
+  type Expression,
 } from '@cardstack/runtime-common';
 import type { RealmServerTokenClaim } from 'utils/jwt';
 import { getUserByMatrixUserId } from '@cardstack/billing/billing-queries';
@@ -14,6 +19,7 @@ import * as Sentry from '@sentry/node';
 
 export default function handleRealmAuth({
   dbAdapter,
+  matrixClient,
   realmSecretSeed,
   reconciler,
   serverURL,
@@ -37,32 +43,88 @@ export default function handleRealmAuth({
       userId: matrixUserId,
       onlyOwnRealms: false,
     });
+    let accessibleRealmUrls = Object.keys(permissionsForAllRealms);
 
-    let sessions: { [realm: string]: string } = {};
-    for (let [realmUrl, permissions] of Object.entries(
-      permissionsForAllRealms,
-    )) {
-      let realm: Realm | undefined;
+    // Validate each accessible realm URL against the registry WITHOUT
+    // mounting it. fetchUserPermissions with onlyOwnRealms:false returns
+    // every '*'-readable realm in addition to the user's own; routing
+    // each row through reconciler.lookupOrMount would cold-mount every
+    // public-readable realm on the server on the first post-restart
+    // _realm-auth call (boxel realm list, host login). Phase 3's lazy-
+    // mount contract is "mount on first per-realm request" — the per-
+    // realm JWT itself is fine to issue from registry presence alone;
+    // the mount happens later, when the holder actually hits a realm
+    // endpoint and findOrMountRealm/lookupOrMount runs there.
+    //
+    // Same lookup order as multiRealmAuthorization (CS-11238): in-memory
+    // reconciler.knownByUrl first, then a single batched probe against
+    // realm_registry for any URLs not yet reflected in this process
+    // (e.g. a freshly-published row from a peer instance between NOTIFY
+    // and the next reconcile pass).
+    let registeredUrls = new Set<string>();
+    let urlsToProbe: string[] = [];
+    for (let realmUrl of accessibleRealmUrls) {
+      if (reconciler.knownByUrl.has(realmUrl)) {
+        registeredUrls.add(realmUrl);
+      } else {
+        urlsToProbe.push(realmUrl);
+      }
+    }
+    if (urlsToProbe.length > 0) {
+      let rows = (await query(dbAdapter, [
+        'SELECT url FROM realm_registry WHERE url IN (',
+        ...separatedByCommas(urlsToProbe.map((url) => [param(url)])),
+        ')',
+      ] as Expression)) as { url: string }[];
+      for (let { url } of rows) {
+        registeredUrls.add(url);
+      }
+    }
+
+    // Resolve the user's session room ONCE per request. The session room
+    // is keyed by matrixUserId in the DB, not by realm, so calling
+    // realm.ensureSessionRoom() per accessible realm (as this handler
+    // used to) was N redundant DB reads on the fast path and forced us
+    // to materialize each realm as a `Realm` instance on the cold path.
+    // For the create branch we use the realm-server's matrix client,
+    // matching how _server-session creates session rooms — at this
+    // point in the request lifecycle the caller has already exchanged
+    // an OpenID token via _server-session, so the server client is
+    // already logged in. login() is idempotent (cached promise).
+    let sessionRoom: string | null = await fetchSessionRoom(
+      dbAdapter,
+      matrixUserId,
+    );
+    if (!sessionRoom) {
       try {
-        realm = await reconciler.lookupOrMount(realmUrl);
+        await matrixClient.login();
+        sessionRoom = await matrixClient.createDM(matrixUserId);
+        await upsertSessionRoom(dbAdapter, matrixUserId, sessionRoom);
       } catch (error) {
         Sentry.withScope((scope) => {
-          scope.setExtra('realmUrl', realmUrl);
           scope.setExtra('matrixUserId', matrixUserId);
-          scope.setExtra('permissionsForAllRealms', permissionsForAllRealms);
           Sentry.captureException(error);
         });
-        continue;
+        await sendResponseForError(
+          ctxt,
+          500,
+          'Internal Server Error',
+          'Failed to ensure session room',
+        );
+        return;
       }
-      if (!realm) {
+    }
+
+    let sessions: { [realm: string]: string } = {};
+    for (let realmUrl of accessibleRealmUrls) {
+      if (!registeredUrls.has(realmUrl)) {
         console.error(
           `Permissions found pointing to unknown realm ${realmUrl}`,
         );
         continue;
       }
-
+      let permissions = permissionsForAllRealms[realmUrl];
       try {
-        let sessionRoom = await realm.ensureSessionRoom(matrixUserId);
         sessions[realmUrl] = createJWT(
           {
             user: matrixUserId,
@@ -79,10 +141,8 @@ export default function handleRealmAuth({
           scope.setExtra('realmUrl', realmUrl);
           scope.setExtra('matrixUserId', matrixUserId);
           scope.setExtra('permissionsForAllRealms', permissionsForAllRealms);
-
           Sentry.captureException(error);
         });
-
         continue;
       }
     }

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -537,23 +537,34 @@ export class RealmServer {
     return [...this.realms];
   }
 
+  // Test-only accessor for the reconciler. Exposed so realm-auth-test
+  // can inspect knownByUrl / mounted as preconditions and assert that
+  // _realm-auth does not cold-mount during request handling.
+  get testingOnlyReconciler() {
+    return this.reconciler;
+  }
+
   testingOnlyUnmountRealms() {
     for (let realm of this.realms) {
       this.virtualNetwork.unmount(realm.handle);
     }
   }
 
-  // Simulate the post-restart "this realm isn't in this process's
-  // realms[] yet" state without tearing down its disk mount, indexer,
-  // or matrix client. realm-auth-test uses this to prove
-  // _realm-auth resolves through the reconciler instead of realms[].
-  // The realm stays in reconciler.mounted so lookupOrMount() returns
-  // it via the fast path.
+  // Simulate the post-restart "this realm has a registry row but no
+  // active Realm instance on this process" state without tearing down
+  // its disk mount, indexer, or matrix client. realm-auth-test uses
+  // this to prove _realm-auth issues a JWT for a realm that is absent
+  // from both realms[] and reconciler.mounted — i.e. one that would
+  // need a cold lookupOrMount to be materialized. The registry row
+  // (and reconciler.knownByUrl entry) is left in place; the next
+  // request that actually needs the realm will lazy-mount it via the
+  // normal request path.
   testingOnlyEvictRealmFromRealmsList(url: string): void {
     let idx = this.realms.findIndex((r) => r.url === url);
     if (idx !== -1) {
       this.realms.splice(idx, 1);
     }
+    this.reconciler.mounted.delete(url);
   }
 
   // Test-only accessor for the request-path realm resolver. Exposed so

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -543,6 +543,19 @@ export class RealmServer {
     }
   }
 
+  // Simulate the post-restart "this realm isn't in this process's
+  // realms[] yet" state without tearing down its disk mount, indexer,
+  // or matrix client. realm-auth-test uses this to prove
+  // _realm-auth resolves through the reconciler instead of realms[].
+  // The realm stays in reconciler.mounted so lookupOrMount() returns
+  // it via the fast path.
+  testingOnlyEvictRealmFromRealmsList(url: string): void {
+    let idx = this.realms.findIndex((r) => r.url === url);
+    if (idx !== -1) {
+      this.realms.splice(idx, 1);
+    }
+  }
+
   // Test-only accessor for the request-path realm resolver. Exposed so
   // lazy-mount integration tests can drive findOrMountRealm directly
   // without spinning up an HTTP listener + mocked Koa context.

--- a/packages/realm-server/tests/realm-auth-test.ts
+++ b/packages/realm-server/tests/realm-auth-test.ts
@@ -13,6 +13,7 @@ import {
   testRealmHref,
 } from './helpers';
 import { createJWT as createRealmServerJWT } from '../utils/jwt';
+import { insertSourceRealmInRegistry } from '../lib/realm-registry-writes';
 import type { RealmServer } from '../server';
 
 module(basename(__filename), function () {
@@ -119,6 +120,21 @@ module(basename(__filename), function () {
         joined_rooms: [],
       });
       sinon.stub(MatrixClient.prototype, 'joinRoom').resolves();
+
+      // Bring the test fixture's realm into the realm_registry so the
+      // post-restart state we're simulating is faithful: in production
+      // every realm has a registry row, but runTestRealmServer
+      // legacy-registers its testRealm into reconciler.mounted without
+      // inserting (registerExistingMounts deliberately bypasses
+      // knownByUrl to preserve legacy mounts across reconcile passes).
+      // Insert + reconcile so reconciler.knownByUrl reflects the row,
+      // matching what a real boot would have done.
+      await insertSourceRealmInRegistry(dbAdapter, {
+        url: testRealmHref,
+        diskId: 'node-test_realm/test',
+        ownerUsername: 'node-test_realm',
+      });
+      await testRealmServer.testingOnlyReconcile();
 
       // Simulate the post-restart state: registry row + knownByUrl
       // entry are present (reconciler boot has reflected the registry),

--- a/packages/realm-server/tests/realm-auth-test.ts
+++ b/packages/realm-server/tests/realm-auth-test.ts
@@ -95,16 +95,22 @@ module(basename(__filename), function () {
     });
 
     // CS-11264 regression: after a realm-server restart, a non-pinned
-    // realm is not in this process's realms[] until something triggers a
-    // lazy mount via the request path. Pre-fix, _realm-auth iterated
-    // realms[] directly and silently skipped any realm not yet mounted on
-    // this instance — so an owner's first post-restart boxel-cli call
-    // (push/publish/sync) failed with "No realm token available". Post-
-    // fix, the handler routes through reconciler.lookupOrMount, so any
-    // realm the reconciler can resolve (already mounted, or registered
-    // via knownByUrl, or directly readable from realm_registry) yields a
-    // session token.
-    test('POST /_realm-auth issues a token for a realm reachable only via the reconciler (post-restart)', async function (assert) {
+    // realm has a row in realm_registry but no active Realm instance
+    // on this process until something triggers a lazy mount via the
+    // request path. Pre-fix, _realm-auth iterated realms[] directly
+    // and silently skipped any realm not yet mounted on this instance
+    // — so an owner's first post-restart boxel-cli call
+    // (push/publish/sync) failed with "No realm token available".
+    // Post-fix, the handler validates against reconciler.knownByUrl
+    // (with a registry probe fallback) and issues a JWT without
+    // mounting; the mount happens later via the normal request path
+    // when the holder of the JWT actually hits a realm endpoint.
+    //
+    // Mounting per row inside _realm-auth was rejected because
+    // fetchUserPermissions(onlyOwnRealms:false) returns every
+    // '*'-readable realm, so a single boxel realm list / host login
+    // would cold-mount the entire accessible set after a restart.
+    test('POST /_realm-auth issues a token for a realm absent from realms[] and reconciler.mounted (post-restart)', async function (assert) {
       sinon
         .stub(MatrixClient.prototype, 'createDM')
         .resolves('!post-restart-session-room:localhost');
@@ -114,11 +120,26 @@ module(basename(__filename), function () {
       });
       sinon.stub(MatrixClient.prototype, 'joinRoom').resolves();
 
-      // Simulate the post-restart state where the realm is still
-      // mounted in the reconciler (which knows about it from boot or a
-      // prior lazy mount on another caller) but absent from this
-      // process's realms[] snapshot.
+      // Simulate the post-restart state: registry row + knownByUrl
+      // entry are present (reconciler boot has reflected the registry),
+      // but neither realms[] nor reconciler.mounted holds an active
+      // Realm. The handler must NOT attempt to cold-mount; it must
+      // issue a JWT from the registry presence alone.
       testRealmServer.testingOnlyEvictRealmFromRealmsList(testRealmHref);
+      assert.false(
+        testRealmServer.testingOnlyRealms.some(
+          (r) => r.url === testRealmHref,
+        ),
+        'precondition: realm is absent from realms[]',
+      );
+      assert.false(
+        testRealmServer.testingOnlyReconciler.mounted.has(testRealmHref),
+        'precondition: realm is absent from reconciler.mounted',
+      );
+      assert.true(
+        testRealmServer.testingOnlyReconciler.knownByUrl.has(testRealmHref),
+        'precondition: registry row is still reflected in reconciler.knownByUrl',
+      );
 
       let response = await request
         .post('/_realm-auth')
@@ -136,7 +157,11 @@ module(basename(__filename), function () {
       assert.strictEqual(response.status, 200, 'HTTP 200 status');
       assert.ok(
         response.body[testRealmHref],
-        'response includes a JWT for the realm even though it was absent from realms[]',
+        'response includes a JWT for the realm even though it was absent from realms[] and reconciler.mounted',
+      );
+      assert.false(
+        testRealmServer.testingOnlyReconciler.mounted.has(testRealmHref),
+        'the handler did NOT cold-mount the realm — mount remains deferred to the next per-realm request',
       );
     });
   });

--- a/packages/realm-server/tests/realm-auth-test.ts
+++ b/packages/realm-server/tests/realm-auth-test.ts
@@ -127,9 +127,7 @@ module(basename(__filename), function () {
       // issue a JWT from the registry presence alone.
       testRealmServer.testingOnlyEvictRealmFromRealmsList(testRealmHref);
       assert.false(
-        testRealmServer.testingOnlyRealms.some(
-          (r) => r.url === testRealmHref,
-        ),
+        testRealmServer.testingOnlyRealms.some((r) => r.url === testRealmHref),
         'precondition: realm is absent from realms[]',
       );
       assert.false(

--- a/packages/realm-server/tests/realm-auth-test.ts
+++ b/packages/realm-server/tests/realm-auth-test.ts
@@ -13,11 +13,13 @@ import {
   testRealmHref,
 } from './helpers';
 import { createJWT as createRealmServerJWT } from '../utils/jwt';
+import type { RealmServer } from '../server';
 
 module(basename(__filename), function () {
   module('realm auth handler', function (hooks) {
     let dbAdapter: PgAdapter;
     let request: SuperTest<SupertestTest>;
+    let testRealmServer: RealmServer;
     const matrixUserId = '@firsttimer:localhost';
 
     setupPermissionedRealmCached(hooks, {
@@ -27,9 +29,14 @@ module(basename(__filename), function () {
         [matrixUserId]: ['read', 'write'],
         '@node-test_realm:localhost': ['read', 'realm-owner'],
       },
-      onRealmSetup: ({ dbAdapter: adapter, request: req }) => {
+      onRealmSetup: ({
+        dbAdapter: adapter,
+        request: req,
+        testRealmServer: server,
+      }) => {
         dbAdapter = adapter;
         request = req;
+        testRealmServer = server.testRealmServer;
       },
     });
 
@@ -84,6 +91,52 @@ module(basename(__filename), function () {
         sessionRoom,
         expectedRoomId,
         'session room is persisted after the realm auth request',
+      );
+    });
+
+    // CS-11264 regression: after a realm-server restart, a non-pinned
+    // realm is not in this process's realms[] until something triggers a
+    // lazy mount via the request path. Pre-fix, _realm-auth iterated
+    // realms[] directly and silently skipped any realm not yet mounted on
+    // this instance — so an owner's first post-restart boxel-cli call
+    // (push/publish/sync) failed with "No realm token available". Post-
+    // fix, the handler routes through reconciler.lookupOrMount, so any
+    // realm the reconciler can resolve (already mounted, or registered
+    // via knownByUrl, or directly readable from realm_registry) yields a
+    // session token.
+    test('POST /_realm-auth issues a token for a realm reachable only via the reconciler (post-restart)', async function (assert) {
+      sinon
+        .stub(MatrixClient.prototype, 'createDM')
+        .resolves('!post-restart-session-room:localhost');
+      sinon.stub(MatrixClient.prototype, 'sendEvent').resolves();
+      sinon.stub(MatrixClient.prototype, 'getJoinedRooms').resolves({
+        joined_rooms: [],
+      });
+      sinon.stub(MatrixClient.prototype, 'joinRoom').resolves();
+
+      // Simulate the post-restart state where the realm is still
+      // mounted in the reconciler (which knows about it from boot or a
+      // prior lazy mount on another caller) but absent from this
+      // process's realms[] snapshot.
+      testRealmServer.testingOnlyEvictRealmFromRealmsList(testRealmHref);
+
+      let response = await request
+        .post('/_realm-auth')
+        .set('Accept', 'application/json')
+        .set('Content-Type', 'application/json')
+        .set(
+          'Authorization',
+          `Bearer ${createRealmServerJWT(
+            { user: matrixUserId, sessionRoom: 'server-session-room' },
+            realmSecretSeed,
+          )}`,
+        )
+        .send('{}');
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      assert.ok(
+        response.body[testRealmHref],
+        'response includes a JWT for the realm even though it was absent from realms[]',
       );
     });
   });


### PR DESCRIPTION
## Summary

- After Phase 3 lazy mount ([CS-10894](https://linear.app/cardstack/issue/CS-10894)), `_realm-auth` was the missing caller for non-pinned realms. The handler iterated `realms[]` directly to resolve each permission row's URL — but non-pinned (source/published) realms aren't in `realms[]` until something has driven a request-path mount. After a realm-server restart, an owner's first `boxel-cli` push/publish/sync therefore failed with `No realm token available` even though `realm_user_permissions` was intact. See [CS-11264](https://linear.app/cardstack/issue/CS-11264).
- Switch the handler to validate URLs against the registry (`reconciler.knownByUrl` + a single batched probe against `realm_registry` for URLs not yet reflected) and issue a JWT directly — **without** mounting. `fetchUserPermissions(onlyOwnRealms: false)` returns every `'*'`-readable realm, so routing each row through `reconciler.lookupOrMount` would cold-mount the entire accessible public-readable set on the first post-restart `boxel realm list` / host login. A JWT does not need a mounted realm; the mount happens later, on-demand, when the holder hits a per-realm endpoint and `findOrMountRealm` / `lookupOrMount` runs there.
- Session room is now resolved **once** per request (it is keyed by `matrixUserId` in the DB, not by realm). The create branch uses the realm-server's matrix client to call `createDM`, mirroring how `_server-session` creates session rooms — the caller has already exchanged an OpenID token via `_server-session` to get the JWT they're presenting here, so the server client is already logged in.
- Regression test in `realm-auth-test.ts` evicts the test realm from both `realms[]` and `reconciler.mounted`, asserts (via preconditions) that the row is still in `reconciler.knownByUrl`, hits `/_realm-auth`, asserts a JWT is issued, and asserts `reconciler.mounted` is still empty for the URL afterwards — proving the handler does NOT cold-mount.

## Test plan

- [x] `pnpm lint:types` clean
- [ ] CI: `pnpm test --filter "realm auth handler"` — both existing and new regression test pass (local run was contended on test-pg / synapse; leaving the green check to CI)
- [ ] CI: `pnpm test --filter "Phase 3 lazy mount"` — 7/7 still pass
- [ ] Manual verification on staging once deployed:
  - restart `boxel-realm-server-staging`, then run the boxel-home PR-preview workflow against an existing non-pinned realm (e.g. `boxel-home-pr-58`) — should succeed without first touching the realm via the request path
  - separately confirm a logged-in user with broad public-realm access can call `/_realm-auth` (host login or `boxel realm list`) immediately after restart without observable mount delay