### PR TITLE
file resource: skip Last-Modified short-circuit on invalidation-driven reads

### DIFF
--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -225,17 +225,24 @@ class _FileResource extends Resource<Args> {
 
     let lastModified = response.headers.get('last-modified') || undefined;
 
-    // Skip the lastModified short-circuit when the read was triggered by an
-    // explicit invalidation event — the realm has authoritatively told us the
-    // file changed. The Last-Modified header is only unix-second precision
-    // (unixTime() in @cardstack/runtime-common, used by both the node-realm
-    // adapter and the in-memory test adapter), so two writes within the same
-    // wall-clock second carry identical headers and would otherwise leave
-    // the editor stale on the second write.
+    // The short-circuit skips a no-op state update when nothing has changed.
+    // Two guards both have to hold:
+    //   1. Same URL as the prior state. Last-Modified is only unix-second
+    //      precision (formatRFC7231(fileRef.lastModified * 1000) where
+    //      fileRef.lastModified is unixTime(Date.now()) in both the
+    //      node-realm and in-memory test adapters), so two DIFFERENT files
+    //      written within the same wall-clock second carry identical
+    //      headers — without the URL guard, navigating between such files
+    //      would leave innerState pointing at the prior file.
+    //   2. force !== true. An invalidation-driven read passes force: true
+    //      because the realm has authoritatively told us the file changed,
+    //      which outranks our cached timestamp — same reason same-second
+    //      rewrites of the SAME file would otherwise be skipped.
     if (
       !opts?.force &&
       lastModified &&
       this.innerState.state === 'ready' &&
+      this.innerState.url === rri(response.url) &&
       this.innerState.lastModified === lastModified
     ) {
       return;

--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -197,7 +197,7 @@ class _FileResource extends Resource<Args> {
     }
   }
 
-  private read = restartableTask(async () => {
+  private read = restartableTask(async (opts?: { force?: boolean }) => {
     let response;
     try {
       response = await this.network.authedFetch(this._url, {
@@ -225,7 +225,15 @@ class _FileResource extends Resource<Args> {
 
     let lastModified = response.headers.get('last-modified') || undefined;
 
+    // Skip the lastModified short-circuit when the read was triggered by an
+    // explicit invalidation event — the realm has authoritatively told us the
+    // file changed. The Last-Modified header is only unix-second precision
+    // (unixTime() in @cardstack/runtime-common, used by both the node-realm
+    // adapter and the in-memory test adapter), so two writes within the same
+    // wall-clock second carry identical headers and would otherwise leave
+    // the editor stale on the second write.
     if (
+      !opts?.force &&
       lastModified &&
       this.innerState.state === 'ready' &&
       this.innerState.lastModified === lastModified
@@ -323,7 +331,7 @@ class _FileResource extends Resource<Args> {
         }
 
         if (reloadFile) {
-          this.read.perform();
+          this.read.perform({ force: true });
         }
       }
     });


### PR DESCRIPTION
## Summary

Second flake on `Acceptance | code submode tests > single realm: monaco editor live updates when index changes`, same shard 16, this time on [run 26456271150 / job 77891668197](https://github.com/cardstack/boxel/actions/runs/26456271150/job/77891668197?pr=4964). The diagnostic added in #4921 made the failure mode unambiguous:

```
[monaco-live-updates flake-probe] waitUntil timed out.
  monaco includes "FadhlanXXX"=false;
  source fetch ok=true;
  source on disk includes "FadhlanXXX"=true.
```

The file was written, the matrix event fired, the file-resource subscription callback ran — but `read.perform()` bailed out before refreshing content, leaving the editor on the prior version.

## Root cause

`packages/host/app/resources/file.ts` short-circuits `read.perform()` when the response's `Last-Modified` header matches `innerState.lastModified`. That cache is keyed at unix-second precision: realm responses set `Last-Modified` via `formatRFC7231(fileRef.lastModified * 1000)` where `fileRef.lastModified` is `unixTime(Date.now())` (i.e. `Math.floor(ms/1000)`). Both adapters do this — `packages/realm-server/node-realm.ts` for production and `packages/host/tests/helpers/adapter.ts` for tests.

So when test setup writes `Person/fadhlan.json` and `realm.write(...)` rewrites it inside the same wall-clock second, both responses carry identical `Last-Modified` headers, the second read bails, and `innerState.content` keeps the old JSON. The matrix-event plumbing and invalidation-filter logic were never the problem — the bug was the bail itself trusting a second-precision timestamp as a content fingerprint.

## Fix

Thread `opts: { force?: boolean }` through `read.perform()`. The invalidation-driven callback passes `force: true`, which skips the `Last-Modified` short-circuit. The initial read (`modify()`) keeps the default opportunistic semantics so opportunistic refreshes (focus / route change / etc.) still bail when nothing has changed.

The reasoning: a realm-incremental invalidation event is the realm authoritatively telling the client "this file changed, re-read it." That assertion outranks our cached timestamp.

This also fixes a real (if rare) production bug: a user making two edits to the same JSON card within the same second would otherwise see their second edit not refresh in the editor.

## What I'm keeping in place from the previous attempt

The 5s `waitUntil` timeout and the on-timeout flake probe added in #4921 stay as-is. With this fix the probe should no longer fire, but if a different failure mode surfaces later, the probe will already be there to tell us which side of the chain broke.

## Test plan

- [x] `pnpm lint` (full: js + hbs + types) clean inside `packages/host`
- [ ] CI host shards green on this branch
- [ ] No regression in sibling live-update tests in `code-submode-test.ts` (`card preview live updates when index changes`, `card preview live updates when there is a change in module`, `card preview live updates with error`) — same code path, all hit the invalidation-driven re-read

🤖 Generated with [Claude Code](https://claude.com/claude-code)