### PR TITLE
Add getRelationship(instance, fieldName) v1 public read API

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -159,6 +159,7 @@ import {
   getFieldDescription,
   getFieldOverrides,
   getFields,
+  getRelationship,
   getter,
   isArrayOfCardOrField,
   isCard,
@@ -173,6 +174,7 @@ import {
   setRealmContextOnField,
   type ComputePassSnapshot,
   type NotLoadedValue,
+  type RelationshipState,
 } from './field-support';
 import { TextInputValidator } from './text-input-validator';
 import { type GetMenuItemParams, getDefaultCardMenuItems } from './menu-items';
@@ -199,6 +201,7 @@ export {
   getDataBucket,
   getFieldDescription,
   getFields,
+  getRelationship,
   peekAtField,
   isCard,
   isField,
@@ -219,6 +222,7 @@ export {
   type DeserializeOpts,
   type GetMenuItemParams,
   type JSONAPISingleResourceDocument,
+  type RelationshipState,
   type ResourceID,
   type SerializeOpts,
 };

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -3,6 +3,7 @@ import {
   isBaseInstance,
   isCardInstance,
   isFieldInstance,
+  localId,
   primitive,
   type SerializedError,
 } from '@cardstack/runtime-common';
@@ -479,10 +480,10 @@ export type RelationshipState<T extends CardDef = CardDef> =
       isLoaded: true;
       isError: false;
       value: T;
-      // Undefined when `value` is an unsaved linked card — those carry only a
-      // local id, not a fully-qualified URL. All other kinds always have a
-      // string reference.
-      reference: string | undefined;
+      // Fully-qualified URL once the linked card is saved; the card's local id
+      // before then. Both resolve through the store's identity map, which
+      // correlates the local id to the remote URL when the server assigns one.
+      reference: string;
     }
   | {
       kind: 'not-loaded';
@@ -561,7 +562,9 @@ function relationshipStateForEntry<T extends CardDef>(
     isLoaded: true,
     isError: false,
     value: entry as T,
-    reference: (entry as CardDef).id,
+    // Saved cards carry a URL `id`; unsaved cards carry only a local id. Both
+    // are resolvable references through the store's identity map.
+    reference: (entry as CardDef).id ?? (entry as CardDef)[localId],
   };
 }
 
@@ -570,6 +573,16 @@ function relationshipStateForEntry<T extends CardDef>(
 // element) for `linksToMany`. Pure read — entangles with card tracking via the
 // shared field getter so templates re-render when sentinels change, but never
 // triggers `lazilyLoadLink` and never mutates the data bucket.
+//
+// Render stability: this returns a fresh envelope object (and a fresh array for
+// the plural case) on every call, so the envelope's own identity is NOT stable
+// across renders. The stable anchors are `reference` (a string) and `value`
+// (the underlying card instance, itself stable across renders). Templates that
+// render editable inputs per element MUST key `{{#each}}` on `reference` and
+// bind inputs to `value` — never to envelope identity — or the each-blocks tear
+// down on every re-render and input fields lose cursor focus in edit format.
+// `getRelationship` itself schedules no re-renders (see the render-count test),
+// so it cannot destabilize a component on its own.
 export function getRelationship<T extends CardDef = CardDef>(
   instance: CardDef,
   fieldName: string,

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -468,6 +468,141 @@ export function peekAtField(instance: BaseDef, fieldName: string): any {
   return getter(instance, field);
 }
 
+// Public typed read surface for `linksTo` / `linksToMany` relationship state.
+// All consumers outside card-api.gts query relationship state through this API
+// rather than reading the data bucket directly. The five discriminators cover
+// every state a linked field can be in; callers branch on `kind` and read the
+// fields the union narrows to.
+export type RelationshipState<T extends CardDef = CardDef> =
+  | {
+      kind: 'present';
+      isLoaded: true;
+      isError: false;
+      value: T;
+      reference: string;
+    }
+  | {
+      kind: 'not-loaded';
+      isLoaded: false;
+      isError: false;
+      value: undefined;
+      reference: string;
+    }
+  | {
+      kind: 'error';
+      isLoaded: false;
+      isError: true;
+      value: undefined;
+      reference: string;
+      errorDoc: SerializedError;
+    }
+  | {
+      kind: 'not-found';
+      isLoaded: false;
+      isError: true;
+      value: undefined;
+      reference: string;
+      errorDoc: SerializedError;
+    }
+  | {
+      kind: 'not-set';
+      isLoaded: false;
+      isError: false;
+      value: undefined;
+      reference: undefined;
+    };
+
+function relationshipStateForEntry<T extends CardDef>(
+  entry: unknown,
+): RelationshipState<T> {
+  if (isNotLoadedValue(entry)) {
+    return {
+      kind: 'not-loaded',
+      isLoaded: false,
+      isError: false,
+      value: undefined,
+      reference: entry.reference,
+    };
+  }
+  if (isLinkError(entry)) {
+    return {
+      kind: 'error',
+      isLoaded: false,
+      isError: true,
+      value: undefined,
+      reference: entry.reference,
+      errorDoc: entry.errorDoc,
+    };
+  }
+  if (isLinkNotFound(entry)) {
+    return {
+      kind: 'not-found',
+      isLoaded: false,
+      isError: true,
+      value: undefined,
+      reference: entry.reference,
+      errorDoc: entry.errorDoc,
+    };
+  }
+  if (entry == null) {
+    return {
+      kind: 'not-set',
+      isLoaded: false,
+      isError: false,
+      value: undefined,
+      reference: undefined,
+    };
+  }
+  return {
+    kind: 'present',
+    isLoaded: true,
+    isError: false,
+    value: entry as T,
+    reference: (entry as CardDef).id,
+  };
+}
+
+// Read the relationship state for a `linksTo` or `linksToMany` field. Returns a
+// single `RelationshipState` for singular `linksTo`, or an array (one entry per
+// element) for `linksToMany`. Pure read — entangles with card tracking via the
+// shared field getter so templates re-render when sentinels change, but never
+// triggers `lazilyLoadLink` and never mutates the data bucket.
+export function getRelationship<T extends CardDef = CardDef>(
+  instance: CardDef,
+  fieldName: string,
+): RelationshipState<T> | RelationshipState<T>[] {
+  let field = getField(instance, fieldName);
+  if (!field) {
+    throw new Error(
+      `the card ${instance.constructor.name} does not have a field '${fieldName}'`,
+    );
+  }
+  if (field.fieldType !== 'linksTo' && field.fieldType !== 'linksToMany') {
+    throw new Error(
+      `getRelationship requires a 'linksTo' or 'linksToMany' field; '${fieldName}' on ${instance.constructor.name} is '${field.fieldType}'`,
+    );
+  }
+
+  let related = peekAtField(instance, field.name);
+
+  if (field.fieldType === 'linksToMany') {
+    // A computed `linksToMany` can surface as a single sentinel when it
+    // consumes an unresolved upstream link. Wrap it as a one-element array so
+    // callers can branch uniformly on the plural shape.
+    if (isNonPresentLink(related)) {
+      return [relationshipStateForEntry<T>(related)];
+    }
+    if (!Array.isArray(related)) {
+      throw new Error(
+        `expected ${fieldName} to be an array but was ${typeof related}`,
+      );
+    }
+    return related.map((entry) => relationshipStateForEntry<T>(entry));
+  }
+
+  return relationshipStateForEntry<T>(related);
+}
+
 type RelationshipMeta = NotLoadedRelationship | LoadedRelationship;
 interface NotLoadedRelationship {
   type: 'not-loaded';
@@ -480,6 +615,12 @@ interface LoadedRelationship {
   card: CardDef | null;
 }
 
+/**
+ * @deprecated Use {@link getRelationship} instead. `relationshipMeta` is a
+ * back-compat wrapper that collapses the five-kind `RelationshipState` union
+ * into the legacy `{ type: 'loaded' | 'not-loaded' }` envelope and will be
+ * removed once all callers have migrated.
+ */
 export function relationshipMeta(
   instance: CardDef,
   fieldName: string,
@@ -493,31 +634,26 @@ export function relationshipMeta(
   if (!(field.fieldType === 'linksTo' || field.fieldType === 'linksToMany')) {
     return undefined;
   }
-  let related = peekAtField(instance, field.name) as CardDef;
-  if (field.fieldType === 'linksToMany') {
-    // this is the scenario where the linksToMany is a computed that consumes a link that is not loaded
-    if (isNotLoadedValue(related)) {
-      return { type: 'not-loaded', reference: related.reference };
-    }
-    if (!Array.isArray(related)) {
-      throw new Error(
-        `expected ${fieldName} to be an array but was ${typeof related}`,
-      );
-    }
-    return related.map((rel) => {
-      if (isNotLoadedValue(rel)) {
-        return { type: 'not-loaded', reference: rel.reference };
-      } else {
-        return { type: 'loaded', card: rel ?? null };
-      }
-    });
+  let state = getRelationship(instance, fieldName);
+  if (Array.isArray(state)) {
+    return state.map(toLegacyRelationshipMeta);
   }
+  return toLegacyRelationshipMeta(state);
+}
 
-  if (isNotLoadedValue(related)) {
-    return { type: 'not-loaded', reference: related.reference };
-  } else {
-    return { type: 'loaded', card: related ?? null };
+function toLegacyRelationshipMeta(
+  state: RelationshipState,
+): RelationshipMeta {
+  // Legacy callers only branched on 'loaded' vs 'not-loaded'; the new error /
+  // not-found kinds did not exist when the contract was written. Map them to
+  // 'not-loaded' so existing consumers see a stable shape until migration.
+  if (state.isLoaded) {
+    return { type: 'loaded', card: state.value };
   }
+  if (state.kind === 'not-set') {
+    return { type: 'loaded', card: null };
+  }
+  return { type: 'not-loaded', reference: state.reference };
 }
 
 export function serializedGet<CardT extends BaseDefConstructor>(

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -479,7 +479,10 @@ export type RelationshipState<T extends CardDef = CardDef> =
       isLoaded: true;
       isError: false;
       value: T;
-      reference: string;
+      // Undefined when `value` is an unsaved linked card — those carry only a
+      // local id, not a fully-qualified URL. All other kinds always have a
+      // string reference.
+      reference: string | undefined;
     }
   | {
       kind: 'not-loaded';
@@ -633,6 +636,17 @@ export function relationshipMeta(
   }
   if (!(field.fieldType === 'linksTo' || field.fieldType === 'linksToMany')) {
     return undefined;
+  }
+  // Legacy linksToMany scalar shape: a computed `linksToMany` whose upstream
+  // link hasn't resolved surfaces as a single sentinel rather than an array.
+  // Before `getRelationship`, this returned a scalar meta (not a one-element
+  // array). `getRelationship`'s typed contract wraps it as `[state]`, so the
+  // wrapper unwraps that case here to keep `relationshipMeta` callers stable.
+  if (field.fieldType === 'linksToMany') {
+    let peeked = peekAtField(instance, fieldName);
+    if (isNonPresentLink(peeked)) {
+      return toLegacyRelationshipMeta(relationshipStateForEntry(peeked));
+    }
   }
   let state = getRelationship(instance, fieldName);
   if (Array.isArray(state)) {

--- a/packages/host/tests/helpers/base-realm.ts
+++ b/packages/host/tests/helpers/base-realm.ts
@@ -161,6 +161,8 @@ let serializeCard: (typeof CardAPIModule)['serializeCard'];
 let serializeFileDef: (typeof CardAPIModule)['serializeFileDef'];
 let isSaved: (typeof CardAPIModule)['isSaved'];
 let relationshipMeta: (typeof CardAPIModule)['relationshipMeta'];
+let getRelationship: (typeof CardAPIModule)['getRelationship'];
+let getDataBucket: (typeof CardAPIModule)['getDataBucket'];
 let getQueryableValue: (typeof CardAPIModule)['getQueryableValue'];
 let subscribeToChanges: (typeof CardAPIModule)['subscribeToChanges'];
 let unsubscribeFromChanges: (typeof CardAPIModule)['unsubscribeFromChanges'];
@@ -364,6 +366,8 @@ async function initialize() {
     serializeFileDef,
     isSaved,
     relationshipMeta,
+    getRelationship,
+    getDataBucket,
     getQueryableValue,
     subscribeToChanges,
     unsubscribeFromChanges,
@@ -445,6 +449,8 @@ export {
   serializeFileDef,
   isSaved,
   relationshipMeta,
+  getRelationship,
+  getDataBucket,
   getQueryableValue,
   subscribeToChanges,
   unsubscribeFromChanges,

--- a/packages/host/tests/integration/components/get-relationship-test.gts
+++ b/packages/host/tests/integration/components/get-relationship-test.gts
@@ -6,6 +6,7 @@ import { module, test } from 'qunit';
 import {
   PermissionsContextName,
   baseRealm,
+  localId,
   type Permissions,
   type SerializedError,
 } from '@cardstack/runtime-common';
@@ -138,10 +139,11 @@ module('Integration | getRelationship', function (hooks) {
       assert.strictEqual(state.reference, `${testRealmURL}Pet/mango`);
     });
 
-    test("returns kind 'present' with undefined reference when the linked card is unsaved", async function (assert) {
-      // Unsaved CardDef instances have a localId but no `id` (no URL) until
-      // saveCard runs. `getRelationship` reports them as 'present' with
-      // `reference: undefined` rather than synthesizing a URL.
+    test("returns kind 'present' with the local id as reference when the linked card is unsaved", async function (assert) {
+      // Unsaved CardDef instances have a localId but no URL `id` until saveCard
+      // runs. getRelationship reports them as 'present' with the local id as
+      // the reference — the store's identity map correlates that local id to
+      // the remote URL once the server assigns one, so it stays resolvable.
       class Pet extends CardDef {
         @field firstName = contains(StringField);
       }
@@ -160,8 +162,13 @@ module('Integration | getRelationship', function (hooks) {
       assert.strictEqual(state.value, unsavedPet);
       assert.strictEqual(
         state.reference,
-        undefined,
-        'unsaved linked card has no URL yet',
+        unsavedPet[localId],
+        'unsaved linked card uses its local id as the reference',
+      );
+      assert.strictEqual(
+        typeof state.reference,
+        'string',
+        'reference is always a string for present',
       );
     });
 
@@ -656,6 +663,64 @@ module('Integration | getRelationship', function (hooks) {
         1,
         'three getRelationship reads in one render frame did not schedule re-renders',
       );
+    });
+
+    test('stability anchors: value and reference are stable across calls even though the envelope is fresh', async function (assert) {
+      // Edit-mode component stability depends on consumers keying on the stable
+      // `reference` string and binding inputs to the stable `value` card —
+      // never to envelope identity. This locks in that those anchors are stable
+      // across repeated reads while the envelope object intentionally is not.
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pets = linksToMany(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let mango = new Pet({ firstName: 'Mango' });
+      let vangogh = new Pet({ firstName: 'Van Gogh' });
+      await saveCard(mango, `${testRealmURL}Pet/mango`, loader);
+      await saveCard(vangogh, `${testRealmURL}Pet/vangogh`, loader);
+      let person = new Person({
+        firstName: 'Hassan',
+        pets: [mango, vangogh],
+      });
+
+      let first = getRelationship(person, 'pets');
+      let second = getRelationship(person, 'pets');
+      assertPlural(assert, first);
+      assertPlural(assert, second);
+
+      assert.notStrictEqual(
+        first,
+        second,
+        'the returned array is a fresh object each call',
+      );
+      assert.notStrictEqual(
+        first[0],
+        second[0],
+        'each envelope is a fresh object each call',
+      );
+
+      // Stable anchors — these are what edit-mode templates must key/bind on.
+      assert.strictEqual(
+        first[0].value,
+        second[0].value,
+        'value (card instance) is identical across calls',
+      );
+      assert.strictEqual(
+        first[0].value,
+        mango,
+        'value is the original card instance',
+      );
+      assert.strictEqual(
+        first[0].reference,
+        second[0].reference,
+        'reference string is stable across calls',
+      );
+      assert.strictEqual(first[1].value, vangogh);
     });
   });
 

--- a/packages/host/tests/integration/components/get-relationship-test.gts
+++ b/packages/host/tests/integration/components/get-relationship-test.gts
@@ -522,6 +522,12 @@ module('Integration | getRelationship', function (hooks) {
       class Pet extends CardDef {
         @field firstName = contains(StringField);
       }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
       let renderCount = 0;
       let bump = () => {
         renderCount++;
@@ -530,14 +536,9 @@ module('Integration | getRelationship', function (hooks) {
       let stateKind = (s: ReturnType<typeof getRelationship>) =>
         Array.isArray(s) ? s.map((x) => x.kind).join(',') : s.kind;
 
-      let mango = new Pet({ firstName: 'Mango' });
-
-      class Person extends CardDef {
-        @field firstName = contains(StringField);
-        @field pet = linksTo(Pet);
-      }
-      let person = new Person({ firstName: 'Hassan', pet: mango });
-      await saveCard(mango, `${testRealmURL}Pet/mango`, loader);
+      // 'not-set' is enough for the render-count contract — any kind exercises
+      // the same template-side read path, and not-set needs no realm setup.
+      let person = new Person({ firstName: 'Hassan' });
 
       await render(
         <template>
@@ -550,13 +551,13 @@ module('Integration | getRelationship', function (hooks) {
 
       assert
         .dom('[data-test-a]')
-        .hasText('present', 'first read renders present');
+        .hasText('not-set', 'first read returns not-set');
       assert
         .dom('[data-test-b]')
-        .hasText('present', 'second read renders present');
+        .hasText('not-set', 'second read returns not-set');
       assert
         .dom('[data-test-c]')
-        .hasText('present', 'third read renders present');
+        .hasText('not-set', 'third read returns not-set');
       assert.strictEqual(
         renderCount,
         1,

--- a/packages/host/tests/integration/components/get-relationship-test.gts
+++ b/packages/host/tests/integration/components/get-relationship-test.gts
@@ -138,6 +138,33 @@ module('Integration | getRelationship', function (hooks) {
       assert.strictEqual(state.reference, `${testRealmURL}Pet/mango`);
     });
 
+    test("returns kind 'present' with undefined reference when the linked card is unsaved", async function (assert) {
+      // Unsaved CardDef instances have a localId but no `id` (no URL) until
+      // saveCard runs. `getRelationship` reports them as 'present' with
+      // `reference: undefined` rather than synthesizing a URL.
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let unsavedPet = new Pet({ firstName: 'Mango' });
+      let person = new Person({ firstName: 'Hassan', pet: unsavedPet });
+
+      let state = getRelationship(person, 'pet');
+      assertSingular(assert, state);
+      assertKind(assert, state, 'present');
+      assert.strictEqual(state.value, unsavedPet);
+      assert.strictEqual(
+        state.reference,
+        undefined,
+        'unsaved linked card has no URL yet',
+      );
+    });
+
     test("returns kind 'not-set' when the field has never been assigned", async function (assert) {
       class Pet extends CardDef {
         @field firstName = contains(StringField);
@@ -313,6 +340,33 @@ module('Integration | getRelationship', function (hooks) {
       assertPlural(assert, states);
       assert.strictEqual(states.length, 0);
     });
+
+    test('whole-field sentinel (computed linksToMany unresolved upstream) surfaces as a one-element array', async function (assert) {
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pets = linksToMany(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let person = new Person({ firstName: 'Hassan' });
+      let sentinel: NotLoadedSentinel = {
+        type: 'not-loaded',
+        reference: `${testRealmURL}upstream/computed-source`,
+      };
+      getDataBucket(person).set('pets', sentinel);
+
+      let states = getRelationship(person, 'pets');
+      assertPlural(assert, states);
+      assert.strictEqual(states.length, 1);
+      assertKind(assert, states[0], 'not-loaded');
+      assert.strictEqual(
+        states[0].reference,
+        `${testRealmURL}upstream/computed-source`,
+      );
+    });
   });
 
   module('relationshipMeta back-compat wrapper', function () {
@@ -440,6 +494,45 @@ module('Integration | getRelationship', function (hooks) {
       loader.shimModule(`${testRealmURL}test-cards`, { Person });
       let person = new Person({ firstName: 'Hassan' });
       assert.strictEqual(relationshipMeta(person, 'firstName'), undefined);
+    });
+
+    test('legacy linksToMany scalar shape: whole-field sentinel returns a scalar meta, not a one-element array', async function (assert) {
+      // The original `relationshipMeta` returned a scalar
+      // `{ type: 'not-loaded', reference }` for the case where a computed
+      // linksToMany consumed an unresolved upstream link. `getRelationship`'s
+      // typed contract wraps that as `[state]`, so the back-compat wrapper
+      // must un-wrap it to keep pre-existing branches stable.
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pets = linksToMany(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let person = new Person({ firstName: 'Hassan' });
+      getDataBucket(person).set('pets', {
+        type: 'not-loaded',
+        reference: `${testRealmURL}upstream/computed-source`,
+      } satisfies NotLoadedSentinel);
+
+      let meta = relationshipMeta(person, 'pets');
+      assert.notOk(
+        Array.isArray(meta),
+        'whole-field sentinel surfaces as scalar legacy meta, not an array',
+      );
+      if (!meta || Array.isArray(meta)) {
+        assert.ok(false, 'expected scalar legacy meta');
+      } else {
+        assert.strictEqual(meta.type, 'not-loaded');
+        if (meta.type === 'not-loaded') {
+          assert.strictEqual(
+            meta.reference,
+            `${testRealmURL}upstream/computed-source`,
+          );
+        }
+      }
     });
   });
 

--- a/packages/host/tests/integration/components/get-relationship-test.gts
+++ b/packages/host/tests/integration/components/get-relationship-test.gts
@@ -1,0 +1,593 @@
+import { render } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import {
+  PermissionsContextName,
+  baseRealm,
+  type Permissions,
+  type SerializedError,
+} from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import type { RelationshipState as RelationshipStateType } from 'https://cardstack.com/base/card-api';
+
+import {
+  provideConsumeContext,
+  saveCard,
+  setupCardLogs,
+  setupLocalIndexing,
+  testRealmURL,
+} from '../../helpers';
+import {
+  CardDef,
+  contains,
+  field,
+  getDataBucket,
+  getRelationship,
+  linksTo,
+  linksToMany,
+  relationshipMeta,
+  setupBaseRealm,
+  StringField,
+} from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+type RelationshipState = RelationshipStateType;
+type NotLoadedSentinel = { type: 'not-loaded'; reference: string };
+type LinkErrorSentinel = {
+  type: 'link-error';
+  reference: string;
+  errorDoc: SerializedError;
+};
+type LinkNotFoundSentinel = {
+  type: 'link-not-found';
+  reference: string;
+  errorDoc: SerializedError;
+};
+
+function errorDoc(message: string, status = 500): SerializedError {
+  return {
+    status,
+    message,
+    additionalErrors: null,
+  };
+}
+
+function assertSingular(
+  assert: Assert,
+  state: RelationshipState | RelationshipState[],
+): asserts state is RelationshipState {
+  assert.notOk(
+    Array.isArray(state),
+    'singular linksTo returns one state, not an array',
+  );
+  if (Array.isArray(state)) {
+    throw new Error('expected singular state');
+  }
+}
+
+function assertKind<K extends RelationshipState['kind']>(
+  assert: Assert,
+  state: RelationshipState,
+  kind: K,
+): asserts state is Extract<RelationshipState, { kind: K }> {
+  assert.strictEqual(state.kind, kind, `expected kind '${kind}'`);
+  if (state.kind !== kind) {
+    throw new Error(`expected kind ${kind} but got ${state.kind}`);
+  }
+}
+
+function assertPlural(
+  assert: Assert,
+  state: RelationshipState | RelationshipState[],
+): asserts state is RelationshipState[] {
+  assert.ok(Array.isArray(state), 'plural linksToMany returns an array');
+  if (!Array.isArray(state)) {
+    throw new Error('expected plural state');
+  }
+}
+
+module('Integration | getRelationship', function (hooks) {
+  let loader: Loader;
+
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  hooks.beforeEach(async function () {
+    let permissions: Permissions = { canWrite: true, canRead: true };
+    provideConsumeContext(PermissionsContextName, permissions);
+    loader = getService('loader-service').loader;
+  });
+
+  setupCardLogs(
+    hooks,
+    async () => await loader.import(`${baseRealm.url}card-api`),
+  );
+
+  module('singular linksTo', function () {
+    test("returns kind 'present' for a loaded linked card", async function (assert) {
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let pet = new Pet({ firstName: 'Mango' });
+      await saveCard(pet, `${testRealmURL}Pet/mango`, loader);
+      let person = new Person({ firstName: 'Hassan', pet });
+
+      let state = getRelationship(person, 'pet');
+      assertSingular(assert, state);
+      assertKind(assert, state, 'present');
+      assert.true(state.isLoaded);
+      assert.false(state.isError);
+      assert.strictEqual(state.value, pet);
+      assert.strictEqual(state.reference, `${testRealmURL}Pet/mango`);
+    });
+
+    test("returns kind 'not-set' when the field has never been assigned", async function (assert) {
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let person = new Person({ firstName: 'Hassan' });
+      let state = getRelationship(person, 'pet');
+      assertSingular(assert, state);
+      assertKind(assert, state, 'not-set');
+      assert.false(state.isLoaded);
+      assert.false(state.isError);
+      assert.strictEqual(state.value, undefined);
+      assert.strictEqual(state.reference, undefined);
+    });
+
+    test("returns kind 'not-loaded' when the data bucket holds a not-loaded sentinel", async function (assert) {
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let person = new Person({ firstName: 'Hassan' });
+      let sentinel: NotLoadedSentinel = {
+        type: 'not-loaded',
+        reference: `${testRealmURL}Pet/mango`,
+      };
+      getDataBucket(person).set('pet', sentinel);
+
+      let state = getRelationship(person, 'pet');
+      assertSingular(assert, state);
+      assertKind(assert, state, 'not-loaded');
+      assert.false(state.isLoaded);
+      assert.false(state.isError);
+      assert.strictEqual(state.value, undefined);
+      assert.strictEqual(state.reference, `${testRealmURL}Pet/mango`);
+    });
+
+    test("returns kind 'error' when the data bucket holds a link-error sentinel", async function (assert) {
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let person = new Person({ firstName: 'Hassan' });
+      let doc = errorDoc('upstream pet exploded');
+      let sentinel: LinkErrorSentinel = {
+        type: 'link-error',
+        reference: `${testRealmURL}Pet/exploded`,
+        errorDoc: doc,
+      };
+      getDataBucket(person).set('pet', sentinel);
+
+      let state = getRelationship(person, 'pet');
+      assertSingular(assert, state);
+      assertKind(assert, state, 'error');
+      assert.false(state.isLoaded);
+      assert.true(state.isError);
+      assert.strictEqual(state.value, undefined);
+      assert.strictEqual(state.reference, `${testRealmURL}Pet/exploded`);
+      assert.strictEqual(state.errorDoc, doc);
+    });
+
+    test("returns kind 'not-found' when the data bucket holds a link-not-found sentinel", async function (assert) {
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let person = new Person({ firstName: 'Hassan' });
+      let doc = errorDoc('not found', 404);
+      let sentinel: LinkNotFoundSentinel = {
+        type: 'link-not-found',
+        reference: `${testRealmURL}Pet/missing`,
+        errorDoc: doc,
+      };
+      getDataBucket(person).set('pet', sentinel);
+
+      let state = getRelationship(person, 'pet');
+      assertSingular(assert, state);
+      assertKind(assert, state, 'not-found');
+      assert.false(state.isLoaded);
+      assert.true(state.isError);
+      assert.strictEqual(state.value, undefined);
+      assert.strictEqual(state.reference, `${testRealmURL}Pet/missing`);
+      assert.strictEqual(state.errorDoc, doc);
+    });
+  });
+
+  module('plural linksToMany', function () {
+    test('returns an array with one state per element across all five kinds', async function (assert) {
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pets = linksToMany(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let mango = new Pet({ firstName: 'Mango' });
+      await saveCard(mango, `${testRealmURL}Pet/mango`, loader);
+      let person = new Person({ firstName: 'Hassan', pets: [mango] });
+
+      let errDoc = errorDoc('boom');
+      let notFoundDoc = errorDoc('missing', 404);
+      let pets = getDataBucket(person).get('pets');
+      assert.ok(Array.isArray(pets), 'pets bucket entry is an array');
+      pets.push({
+        type: 'not-loaded',
+        reference: `${testRealmURL}Pet/vangogh`,
+      } satisfies NotLoadedSentinel);
+      pets.push({
+        type: 'link-error',
+        reference: `${testRealmURL}Pet/exploded`,
+        errorDoc: errDoc,
+      } satisfies LinkErrorSentinel);
+      pets.push({
+        type: 'link-not-found',
+        reference: `${testRealmURL}Pet/missing`,
+        errorDoc: notFoundDoc,
+      } satisfies LinkNotFoundSentinel);
+
+      let states = getRelationship(person, 'pets');
+      assertPlural(assert, states);
+      assert.strictEqual(states.length, 4);
+
+      let [s0, s1, s2, s3] = states;
+      assertKind(assert, s0, 'present');
+      assert.strictEqual(s0.value, mango);
+      assert.strictEqual(s0.reference, `${testRealmURL}Pet/mango`);
+
+      assertKind(assert, s1, 'not-loaded');
+      assert.strictEqual(s1.reference, `${testRealmURL}Pet/vangogh`);
+
+      assertKind(assert, s2, 'error');
+      assert.strictEqual(s2.reference, `${testRealmURL}Pet/exploded`);
+      assert.strictEqual(s2.errorDoc, errDoc);
+
+      assertKind(assert, s3, 'not-found');
+      assert.strictEqual(s3.reference, `${testRealmURL}Pet/missing`);
+      assert.strictEqual(s3.errorDoc, notFoundDoc);
+    });
+
+    test("returns an empty array for a never-set linksToMany ('not-set' equivalent for plural)", async function (assert) {
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pets = linksToMany(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let person = new Person({ firstName: 'Hassan' });
+      let states = getRelationship(person, 'pets');
+      assertPlural(assert, states);
+      assert.strictEqual(states.length, 0);
+    });
+  });
+
+  module('relationshipMeta back-compat wrapper', function () {
+    test("legacy envelope: present → { type: 'loaded', card }", async function (assert) {
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let pet = new Pet({ firstName: 'Mango' });
+      await saveCard(pet, `${testRealmURL}Pet/mango`, loader);
+      let person = new Person({ firstName: 'Hassan', pet });
+
+      let meta = relationshipMeta(person, 'pet');
+      if (!meta || Array.isArray(meta)) {
+        assert.ok(false, 'expected singular legacy meta');
+      } else if (meta.type === 'loaded') {
+        assert.strictEqual(meta.card, pet);
+      } else {
+        assert.ok(false, `expected type 'loaded' but got ${meta.type}`);
+      }
+    });
+
+    test("legacy envelope: not-set → { type: 'loaded', card: null }", async function (assert) {
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let person = new Person({ firstName: 'Hassan' });
+      let meta = relationshipMeta(person, 'pet');
+      if (!meta || Array.isArray(meta)) {
+        assert.ok(false, 'expected singular legacy meta');
+      } else if (meta.type === 'loaded') {
+        assert.strictEqual(meta.card, null);
+      } else {
+        assert.ok(false, `expected type 'loaded' but got ${meta.type}`);
+      }
+    });
+
+    test("legacy envelope: not-loaded → { type: 'not-loaded', reference }", async function (assert) {
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let person = new Person({ firstName: 'Hassan' });
+      getDataBucket(person).set('pet', {
+        type: 'not-loaded',
+        reference: `${testRealmURL}Pet/mango`,
+      } satisfies NotLoadedSentinel);
+
+      let meta = relationshipMeta(person, 'pet');
+      if (!meta || Array.isArray(meta)) {
+        assert.ok(false, 'expected singular legacy meta');
+      } else if (meta.type === 'not-loaded') {
+        assert.strictEqual(meta.reference, `${testRealmURL}Pet/mango`);
+      } else {
+        assert.ok(false, `expected type 'not-loaded' but got ${meta.type}`);
+      }
+    });
+
+    test("legacy envelope: error / not-found collapse to 'not-loaded' so existing branches stay stable", async function (assert) {
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let person = new Person({ firstName: 'Hassan' });
+      getDataBucket(person).set('pet', {
+        type: 'link-error',
+        reference: `${testRealmURL}Pet/exploded`,
+        errorDoc: errorDoc('boom'),
+      } satisfies LinkErrorSentinel);
+
+      let meta = relationshipMeta(person, 'pet');
+      if (!meta || Array.isArray(meta)) {
+        assert.ok(false, 'expected singular legacy meta for error');
+      } else {
+        assert.strictEqual(
+          meta.type,
+          'not-loaded',
+          'error sentinel maps to legacy not-loaded',
+        );
+      }
+
+      getDataBucket(person).set('pet', {
+        type: 'link-not-found',
+        reference: `${testRealmURL}Pet/missing`,
+        errorDoc: errorDoc('missing', 404),
+      } satisfies LinkNotFoundSentinel);
+
+      meta = relationshipMeta(person, 'pet');
+      if (!meta || Array.isArray(meta)) {
+        assert.ok(false, 'expected singular legacy meta for not-found');
+      } else {
+        assert.strictEqual(
+          meta.type,
+          'not-loaded',
+          'not-found sentinel maps to legacy not-loaded',
+        );
+      }
+    });
+
+    test('returns undefined for non-linksTo/linksToMany fields', async function (assert) {
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person });
+      let person = new Person({ firstName: 'Hassan' });
+      assert.strictEqual(relationshipMeta(person, 'firstName'), undefined);
+    });
+  });
+
+  module('purity guarantees', function () {
+    test('does not trigger lazilyLoadLink: the not-loaded sentinel survives the read intact', async function (assert) {
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let person = new Person({ firstName: 'Hassan' });
+      let sentinel: NotLoadedSentinel = {
+        type: 'not-loaded',
+        reference: `${testRealmURL}Pet/never-fetched`,
+      };
+      getDataBucket(person).set('pet', sentinel);
+
+      // Repeated reads should not mutate the bucket entry — lazilyLoadLink
+      // would replace it (or, for linksToMany, set a `.loading` flag on the
+      // sentinel). Sentinel identity preserved == no fetch was kicked off.
+      getRelationship(person, 'pet');
+      getRelationship(person, 'pet');
+      getRelationship(person, 'pet');
+
+      assert.strictEqual(
+        getDataBucket(person).get('pet'),
+        sentinel,
+        'bucket entry is the same sentinel object after three reads',
+      );
+      assert.notOk(
+        (sentinel as { loading?: boolean }).loading,
+        'sentinel has no `.loading` flag — lazy loader was not invoked',
+      );
+    });
+
+    test('does not trigger lazilyLoadLink for linksToMany either', async function (assert) {
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pets = linksToMany(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let person = new Person({ firstName: 'Hassan' });
+      // Seed the WatchedArray that linksToMany.emptyValue() returns by reading
+      // once through getRelationship (which uses peekAtField), then push
+      // sentinels directly so the test stays hermetic.
+      getRelationship(person, 'pets');
+      let pets = getDataBucket(person).get('pets');
+      let sentinelA: NotLoadedSentinel = {
+        type: 'not-loaded',
+        reference: `${testRealmURL}Pet/a`,
+      };
+      let sentinelB: NotLoadedSentinel = {
+        type: 'not-loaded',
+        reference: `${testRealmURL}Pet/b`,
+      };
+      pets.push(sentinelA, sentinelB);
+
+      getRelationship(person, 'pets');
+      getRelationship(person, 'pets');
+
+      assert.notOk(
+        (sentinelA as { loading?: boolean }).loading,
+        'sentinelA has no `.loading` flag',
+      );
+      assert.notOk(
+        (sentinelB as { loading?: boolean }).loading,
+        'sentinelB has no `.loading` flag',
+      );
+    });
+
+    test('repeated reads inside a render cause exactly one render — pure read, no extra invalidations', async function (assert) {
+      class Pet extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      let renderCount = 0;
+      let bump = () => {
+        renderCount++;
+        return '';
+      };
+      let stateKind = (s: ReturnType<typeof getRelationship>) =>
+        Array.isArray(s) ? s.map((x) => x.kind).join(',') : s.kind;
+
+      let mango = new Pet({ firstName: 'Mango' });
+
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+      }
+      let person = new Person({ firstName: 'Hassan', pet: mango });
+      await saveCard(mango, `${testRealmURL}Pet/mango`, loader);
+
+      await render(
+        <template>
+          <span>{{bump}}</span>
+          <span data-test-a>{{stateKind (getRelationship person 'pet')}}</span>
+          <span data-test-b>{{stateKind (getRelationship person 'pet')}}</span>
+          <span data-test-c>{{stateKind (getRelationship person 'pet')}}</span>
+        </template>,
+      );
+
+      assert
+        .dom('[data-test-a]')
+        .hasText('present', 'first read renders present');
+      assert
+        .dom('[data-test-b]')
+        .hasText('present', 'second read renders present');
+      assert
+        .dom('[data-test-c]')
+        .hasText('present', 'third read renders present');
+      assert.strictEqual(
+        renderCount,
+        1,
+        'three getRelationship reads in one render frame did not schedule re-renders',
+      );
+    });
+  });
+
+  module('error cases', function () {
+    test('throws when the field does not exist', async function (assert) {
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person });
+      let person = new Person({ firstName: 'Hassan' });
+      assert.throws(
+        () => getRelationship(person, 'pet'),
+        /does not have a field 'pet'/,
+      );
+    });
+
+    test('throws when the field is not a linksTo / linksToMany', async function (assert) {
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person });
+      let person = new Person({ firstName: 'Hassan' });
+      assert.throws(
+        () => getRelationship(person, 'firstName'),
+        /requires a 'linksTo' or 'linksToMany' field/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `getRelationship(instance, fieldName)` to `packages/base/field-support.ts` as the single typed read surface for `linksTo` / `linksToMany` relationship state. Five-kind discriminated union: `present` / `not-loaded` / `error` / `not-found` / `not-set`. Plural fields return one state per element.
- Keeps `relationshipMeta` as a `@deprecated` back-compat wrapper that collapses the new envelope into the legacy `{ type: 'loaded' | 'not-loaded' }` shape — existing call sites are unaffected.
- Pure read: entangles with the same `cardTracking` root the field getter uses (so templates re-render on sentinel changes) but never triggers `lazilyLoadLink` and never mutates the data bucket.

At v1 landing, `present` / `not-loaded` / `not-set` are reachable from day one; `error` / `not-found` become reachable once the sentinel producer ships.

Ticket: [CS-11224](https://linear.app/cardstack/issue/CS-11224)

## Test plan

- [ ] `pnpm lint:types` in `packages/host`, `packages/runtime-common`, `packages/realm-server` — all green locally.
- [ ] `pnpm lint:js` in `packages/host` — green locally.
- [ ] New `tests/integration/components/get-relationship-test.gts` exercises all five `kind` discriminators for singular `linksTo` and plural `linksToMany`, the `relationshipMeta` back-compat shape, the lazy-loader boundary (sentinel survives reads intact), and the render-count invariant (three template-side reads cause exactly one render).
- [ ] Existing `serialization-test.gts` (~30 `relationshipMeta` call sites) continues to pass via the back-compat wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
