### PR TITLE
CS-11270: resolve _download-realm path without iterating realms[]

### DIFF
--- a/packages/realm-server/handlers/handle-download-realm.ts
+++ b/packages/realm-server/handlers/handle-download-realm.ts
@@ -1,5 +1,5 @@
 import type Koa from 'koa';
-import type { DBAdapter, Realm } from '@cardstack/runtime-common';
+import type { DBAdapter } from '@cardstack/runtime-common';
 import {
   ensureTrailingSlash,
   fetchUserPermissions,
@@ -34,7 +34,7 @@ const log = logger('download-realm');
 export default function handleDownloadRealm({
   dbAdapter,
   realmSecretSeed,
-  realms,
+  reconciler,
   realmsRootPath,
 }: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
@@ -70,7 +70,30 @@ export default function handleDownloadRealm({
       );
       return;
     }
-    if (!hasRealm(realms, realmURL)) {
+    // Resolve the realm's disk path WITHOUT iterating `realms[]`. Phase 3
+    // lazy mount (CS-10894) leaves non-pinned realms absent from
+    // `realms[]` until something drives a request-path `lookupOrMount`;
+    // iterating `realms[]` here would 404 a perfectly valid post-restart
+    // download (CS-11270).
+    //
+    // We don't need a started Realm to stream the archive — the download
+    // is `archiver.directory(realmPath, false)` over on-disk files,
+    // which exist whether or not the realm process is running. Two-tier
+    // lookup mirrors how `multiRealmAuthorization` does presence checks:
+    //   1. `reconciler.mounted` — already-mounted realms (including
+    //      pinned bootstrap realms and any non-pinned realm that has
+    //      been lazy-mounted earlier in this process's lifetime, as
+    //      well as constructor-supplied test realms registered via
+    //      `registerExistingMounts`). Use `realm.dir` directly.
+    //   2. `realm_registry` — non-pinned realms that haven't been
+    //      mounted yet on this instance. Resolve the disk path from
+    //      the row's `kind` + `disk_id`. This is the post-restart path
+    //      CS-11270 is about.
+    let mounted = reconciler.mounted.get(realmURL);
+    let registryRow = mounted
+      ? null
+      : await fetchRegistryRow(dbAdapter, realmURL);
+    if (!mounted && !registryRow) {
       await sendResponseForNotFound(ctxt, `Realm not found: ${realmURL}`);
       return;
     }
@@ -140,12 +163,9 @@ export default function handleDownloadRealm({
       }
     }
 
-    let realmPath = await resolveRealmPath({
-      dbAdapter,
-      realms,
-      realmURL,
-      realmsRootPath,
-    });
+    let realmPath = mounted
+      ? (mounted.dir ?? null)
+      : resolveRealmPath(registryRow!, realmsRootPath);
     if (!realmPath) {
       await sendResponseForNotFound(
         ctxt,
@@ -196,31 +216,40 @@ export default function handleDownloadRealm({
   };
 }
 
-function hasRealm(realms: Realm[], realmURL: string): boolean {
-  return realms.some((realm) => ensureTrailingSlash(realm.url) === realmURL);
+type RegistryRow = {
+  kind: 'bootstrap' | 'source' | 'published';
+  disk_id: string;
+};
+
+async function fetchRegistryRow(
+  dbAdapter: DBAdapter,
+  realmURL: string,
+): Promise<RegistryRow | null> {
+  let rows = (await query(dbAdapter, [
+    'SELECT kind, disk_id FROM realm_registry WHERE url =',
+    param(realmURL),
+  ])) as RegistryRow[];
+  return rows[0] ?? null;
 }
 
-async function resolveRealmPath({
-  dbAdapter,
-  realms,
-  realmURL,
-  realmsRootPath,
-}: {
-  dbAdapter: DBAdapter;
-  realms: Realm[];
-  realmURL: string;
-  realmsRootPath: string;
-}): Promise<string | null> {
-  let published = (await query(dbAdapter, [
-    "SELECT disk_id FROM realm_registry WHERE kind = 'published' AND url =",
-    param(realmURL),
-  ])) as { disk_id: string }[];
-  if (published.length > 0) {
-    return join(realmsRootPath, PUBLISHED_DIRECTORY_NAME, published[0].disk_id);
+// `disk_id` is kind-specific (see the realm_registry migration column
+// comment): for `bootstrap` it's an absolute path; for `source` it's a
+// directory under `realmsRootPath`; for `published` it's a directory
+// under `realmsRootPath/PUBLISHED_DIRECTORY_NAME`.
+function resolveRealmPath(
+  row: RegistryRow,
+  realmsRootPath: string,
+): string | null {
+  switch (row.kind) {
+    case 'bootstrap':
+      return row.disk_id;
+    case 'source':
+      return join(realmsRootPath, row.disk_id);
+    case 'published':
+      return join(realmsRootPath, PUBLISHED_DIRECTORY_NAME, row.disk_id);
+    default:
+      return null;
   }
-
-  let realm = realms.find((r) => ensureTrailingSlash(r.url) === realmURL);
-  return realm?.dir ?? null;
 }
 
 function buildArchiveName(realmURL: URL): string {

--- a/packages/realm-server/handlers/handle-download-realm.ts
+++ b/packages/realm-server/handlers/handle-download-realm.ts
@@ -13,7 +13,7 @@ import { parseRealmsParam } from '@cardstack/runtime-common/search-utils';
 import { verifyURLSignature } from '@cardstack/runtime-common/url-signature';
 import archiver from 'archiver';
 import { existsSync, statSync } from 'fs-extra';
-import { join } from 'path';
+import { join, relative, resolve, sep, isAbsolute } from 'path';
 import type { CreateRoutesArgs } from '../routes';
 import { retrieveTokenClaim } from '../utils/jwt';
 import {
@@ -236,6 +236,16 @@ async function fetchRegistryRow(
 // comment): for `bootstrap` it's an absolute path; for `source` it's a
 // directory under `realmsRootPath`; for `published` it's a directory
 // under `realmsRootPath/PUBLISHED_DIRECTORY_NAME`.
+//
+// `source`/`published` rows go through `safeJoinUnderRoot` rather than
+// a bare `path.join`. Both write paths today validate inputs
+// (`create-realm.ts` rejects endpoints that don't match
+// /^[a-z0-9-]+$/, etc.), but `disk_id` is just a string column and a
+// future write path (or a backfill rebuilt from disk by an operator
+// with shell access) could write an absolute path or `..` segments
+// that would let `path.join` escape `realmsRootPath`. Anchoring with
+// `path.resolve` + a prefix check keeps the handler's blast radius
+// pinned to the realm root regardless of how the row was written.
 function resolveRealmPath(
   row: RegistryRow,
   realmsRootPath: string,
@@ -244,12 +254,33 @@ function resolveRealmPath(
     case 'bootstrap':
       return row.disk_id;
     case 'source':
-      return join(realmsRootPath, row.disk_id);
+      return safeJoinUnderRoot(realmsRootPath, row.disk_id);
     case 'published':
-      return join(realmsRootPath, PUBLISHED_DIRECTORY_NAME, row.disk_id);
+      return safeJoinUnderRoot(
+        join(realmsRootPath, PUBLISHED_DIRECTORY_NAME),
+        row.disk_id,
+      );
     default:
       return null;
   }
+}
+
+function safeJoinUnderRoot(root: string, segment: string): string | null {
+  if (isAbsolute(segment)) {
+    return null;
+  }
+  let absoluteRoot = resolve(root);
+  let candidate = resolve(absoluteRoot, segment);
+  if (candidate !== absoluteRoot && !candidate.startsWith(absoluteRoot + sep)) {
+    return null;
+  }
+  // Belt and suspenders — `path.relative` should agree, and surfaces any
+  // edge case path.resolve might smooth over.
+  let rel = relative(absoluteRoot, candidate);
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    return null;
+  }
+  return candidate;
 }
 
 function buildArchiveName(realmURL: URL): string {

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -537,6 +537,15 @@ export class RealmServer {
     return [...this.realms];
   }
 
+  // Test-only accessor for the on-disk root that source/published realm
+  // disk_ids resolve under. Exposed so download-realm tests can stage a
+  // source realm at <realmsRootPath>/<disk_id> + matching realm_registry
+  // row to exercise the post-restart code path (CS-11270) without
+  // spinning up a full RealmServer for a second realm.
+  get testingOnlyRealmsRootPath() {
+    return this.realmsRootPath;
+  }
+
   testingOnlyUnmountRealms() {
     for (let realm of this.realms) {
       this.virtualNetwork.unmount(realm.handle);

--- a/packages/realm-server/tests/server-endpoints/download-realm-test.ts
+++ b/packages/realm-server/tests/server-endpoints/download-realm-test.ts
@@ -198,7 +198,13 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
     );
     writeFileSync(join(realmDir, 'marker.txt'), 'cs-11270-regression-marker');
 
-    let realmHref = `http://127.0.0.1:9999/${realmId}/`;
+    // Anchor the new realm's URL to the test server's origin so the
+    // URL is structurally identical to the testRealm's (same host:port,
+    // different path) — keeps the test representative of a real
+    // post-restart download against this server and won't get caught
+    // out if `_download-realm` ever grows an "is this URL hosted by
+    // this realm-server?" check.
+    let realmHref = new URL(`/${realmId}/`, testRealmURL.origin).href;
     await context.dbAdapter.execute(`INSERT INTO realm_registry
         (url, kind, disk_id, owner_username, pinned)
         VALUES (
@@ -255,6 +261,44 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
     assert.notOk(
       mountedAfter.includes(realmHref),
       'handler did not mount the realm as a side effect of the download',
+    );
+  });
+
+  // Defense-in-depth: `disk_id` is just a string column on
+  // `realm_registry`. Today every write path validates input
+  // (`create-realm.ts` accepts endpoints matching /^[a-z0-9-]+$/ only),
+  // but the path resolver shouldn't trust that — a future write path
+  // (or a backfill rebuilt from an operator-controlled disk layout)
+  // could store an absolute path or `..` segments. The handler must
+  // refuse to zip anything outside `realmsRootPath`.
+  test('refuses to resolve source realms whose disk_id escapes realmsRootPath', async function (assert) {
+    let realmHref = new URL(`/traversal-${uuidv4()}/`, testRealmURL.origin)
+      .href;
+    await context.dbAdapter.execute(`INSERT INTO realm_registry
+        (url, kind, disk_id, owner_username, pinned)
+        VALUES (
+          '${realmHref}',
+          'source',
+          '../etc',
+          'cs-11270-owner',
+          false
+        )`);
+    await context.dbAdapter.execute(`INSERT INTO realm_user_permissions
+        (realm_url, username, read, write, realm_owner)
+        VALUES ('${realmHref}', '*', true, false, false)`);
+
+    let response = await context.request
+      .get('/_download-realm')
+      .query({ realm: realmHref });
+
+    assert.strictEqual(
+      response.status,
+      404,
+      'traversal disk_id is rejected before any file access',
+    );
+    assert.ok(
+      response.body.errors?.[0]?.includes('not stored in realmsRootPath'),
+      'error message points at the realmsRootPath constraint',
     );
   });
 

--- a/packages/realm-server/tests/server-endpoints/download-realm-test.ts
+++ b/packages/realm-server/tests/server-endpoints/download-realm-test.ts
@@ -1,5 +1,7 @@
 import { module, test } from 'qunit';
-import { basename } from 'path';
+import { basename, join } from 'path';
+import { mkdirSync, writeFileSync } from 'fs';
+import { v4 as uuidv4 } from 'uuid';
 import { setupServerEndpointsTest, testRealmURL } from './helpers';
 import { realmSecretSeed } from '../helpers';
 import { createJWT } from '../../utils/jwt';
@@ -172,6 +174,87 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
       response.status,
       401,
       'returns unauthorized for invalid signature',
+    );
+  });
+
+  // CS-11270 regression: Phase 3 lazy mount (CS-10894) means non-pinned
+  // source/published realms aren't in `realms[]` after a realm-server
+  // restart until something has driven a request-path lookupOrMount for
+  // them. Pre-fix, /_download-realm gated on `realms.some(...)` and
+  // 404'd for any realm not yet mounted on this instance. Post-fix the
+  // handler resolves the realm's disk path from `realm_registry`
+  // directly (kind + disk_id) so downloads of post-restart non-pinned
+  // realms succeed without needing a mount. The fix is intentionally
+  // mount-free: the download is a stream of on-disk files, no realm
+  // process work is required.
+  test('downloads a source realm that has a registry row but is not mounted (post-restart)', async function (assert) {
+    let realmId = `unmounted-${uuidv4()}`;
+    let realmsRootPath = context.testRealmServer.testingOnlyRealmsRootPath;
+    let realmDir = join(realmsRootPath, realmId);
+    mkdirSync(realmDir, { recursive: true });
+    writeFileSync(
+      join(realmDir, '.realm.json'),
+      JSON.stringify({ name: 'CS-11270 regression realm' }, null, 2),
+    );
+    writeFileSync(join(realmDir, 'marker.txt'), 'cs-11270-regression-marker');
+
+    let realmHref = `http://127.0.0.1:9999/${realmId}/`;
+    await context.dbAdapter.execute(`INSERT INTO realm_registry
+        (url, kind, disk_id, owner_username, pinned)
+        VALUES (
+          '${realmHref}',
+          'source',
+          '${realmId}',
+          'cs-11270-owner',
+          false
+        )`);
+    await context.dbAdapter.execute(`INSERT INTO realm_user_permissions
+        (realm_url, username, read, write, realm_owner)
+        VALUES ('${realmHref}', '*', true, false, false)`);
+
+    // Precondition: the realm is NOT mounted in this process. realms[]
+    // is empty for this URL, reconciler.mounted has no entry — i.e.
+    // exactly the post-restart state CS-11270 is about.
+    let mountedRealms = context.testRealmServer.testingOnlyRealms.map(
+      (r) => r.url,
+    );
+    assert.notOk(
+      mountedRealms.includes(realmHref),
+      'precondition: realm is absent from realms[]',
+    );
+
+    let response = await context.request
+      .get('/_download-realm')
+      .query({ realm: realmHref })
+      .buffer(true)
+      .parse(binaryParser);
+
+    let bodyPreview = response.body?.toString?.('utf8') ?? response.text ?? '';
+    assert.strictEqual(response.status, 200, bodyPreview.slice(0, 200));
+    assert.strictEqual(
+      response.headers['content-type'],
+      'application/zip',
+      'serves a zip archive',
+    );
+    assert.ok(response.body instanceof Buffer, 'response body is a Buffer');
+    assert.strictEqual(
+      response.body.subarray(0, 2).toString('utf8'),
+      'PK',
+      'zip file signature is present',
+    );
+    assert.ok(
+      response.body.includes(Buffer.from('marker.txt')),
+      'archive includes the on-disk files',
+    );
+    // Postcondition: the handler did NOT mount the realm — the download
+    // is a pure on-disk read, no realm.start() should have been
+    // triggered as a side effect.
+    let mountedAfter = context.testRealmServer.testingOnlyRealms.map(
+      (r) => r.url,
+    );
+    assert.notOk(
+      mountedAfter.includes(realmHref),
+      'handler did not mount the realm as a side effect of the download',
     );
   });
 


### PR DESCRIPTION
## Summary

Same lazy-mount gap as [CS-11264](https://linear.app/cardstack/issue/CS-11264), surfaced in a separate handler. `handle-download-realm.ts` decided whether a realm existed on this server by iterating the in-memory `realms[]` array (both the `hasRealm` gate and the source-realm branch of `resolveRealmPath`). Under [Phase 3 lazy mount (CS-10894)](https://linear.app/cardstack/issue/CS-10894), non-pinned realms (`kind='source'` or `kind='published'`) are absent from `realms[]` after a realm-server restart until something has driven a request-path `lookupOrMount`. A download request that arrives before that first mount returns `404 Realm not found` even though the registry row and disk files are intact. See [CS-11270](https://linear.app/cardstack/issue/CS-11270).

## Approach

Resolve the path WITHOUT mounting. A download is `archiver.directory` over on-disk files — the realm process is not involved — so paying a `realm.start()` for a download that doesn't otherwise interact with the realm is pure overhead. Two-tier lookup, mirroring the presence-check pattern in `multiRealmAuthorization`:

1. **`reconciler.mounted`** — covers pinned bootstrap realms, anything lazy-mounted earlier in this process's lifetime, and the constructor-supplied test realms registered via `registerExistingMounts`. Uses `realm.dir` directly.
2. **`realm_registry`** — the post-restart case CS-11270 is about. Resolves the disk path from the row's `kind` + `disk_id`. `disk_id` semantics (per the realm_registry column comment): absolute path for `bootstrap`, under `realmsRootPath` for `source`, under `realmsRootPath/published` for `published`.

The `realms` arg to `handleDownloadRealm` is dropped — the handler no longer touches `realms[]`.

## Test plan

- [x] `pnpm lint:js` clean
- [x] `pnpm lint:types` clean (no new errors on changed files)
- [ ] CI: existing `download-realm-test.ts` cases still pass — the testRealm is in `reconciler.mounted` (via `registerExistingMounts`), so they take the tier-1 path and don't depend on registry rows.
- [ ] CI: new regression test `downloads a source realm that has a registry row but is not mounted (post-restart)` — stages a source realm directly under `testingOnlyRealmsRootPath`, inserts a `realm_registry` row + public-read permission, never mounts it, and asserts 200 + zip containing on-disk marker. Pre-fix this 404s; post-fix it succeeds without mounting.
- [ ] Manual verification on staging once deployed:
  - restart `boxel-realm-server-staging`, then immediately download a non-pinned source realm via the host's left-panel download button — should succeed without first browsing into the realm via the request path.

## Related

- [CS-11264](https://linear.app/cardstack/issue/CS-11264) (PR #4966) — same anti-pattern in `_realm-auth`.
- [CS-10894](https://linear.app/cardstack/issue/CS-10894) — Phase 3 lazy mount, the change that introduced the gap class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)