### PR TITLE
CS-11271: route _grafana-reindex through reconciler.lookupOrMount

### DIFF
--- a/packages/realm-server/handlers/handle-reindex.ts
+++ b/packages/realm-server/handlers/handle-reindex.ts
@@ -22,7 +22,7 @@ export default function handleReindex({
   serverURL,
   dbAdapter,
   definitionLookup,
-  realms,
+  reconciler,
 }: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
     let realmPath = ctxt.URL.searchParams.get('realm')?.replace(/\/$/, '');
@@ -36,7 +36,17 @@ export default function handleReindex({
     let realmURL = new RealmPaths(new URL(serverURL)).directoryURL(
       realmPath,
     ).href;
-    let realm = realms.find((r) => r.url === realmURL);
+    // CS-11271: route through the reconciler so a non-pinned realm that
+    // hasn't been touched on this process since the last restart still
+    // mounts on demand, instead of failing with a confusing
+    // "does not exist on this server" 400.
+    let realm: Realm | undefined;
+    try {
+      realm = await reconciler.lookupOrMount(realmURL);
+    } catch (e: any) {
+      await sendResponseForSystemError(ctxt, e.message);
+      return;
+    }
     if (!realm) {
       await sendResponseForBadRequest(
         ctxt,

--- a/packages/realm-server/handlers/handle-reindex.ts
+++ b/packages/realm-server/handlers/handle-reindex.ts
@@ -33,9 +33,27 @@ export default function handleReindex({
       );
       return;
     }
-    let realmURL = new RealmPaths(new URL(serverURL)).directoryURL(
-      realmPath,
-    ).href;
+    let serverURLObj = new URL(serverURL);
+    let realmURLObj = new RealmPaths(serverURLObj).directoryURL(realmPath);
+    let realmURL = realmURLObj.href;
+    // Reject `realm=` values that resolve to a URL outside this server's
+    // URL space. `directoryURL` uses `new URL(local, base)`, which lets
+    // an absolute `local` ("http://evil/", "//foo/", etc.) override the
+    // base — the pre-CS-11271 `realms.find()` check accidentally
+    // enforced "must be hosted here" because the in-memory list only
+    // contained local mounts, but the reconciler probe against the
+    // cluster-wide `realm_registry` doesn't. Defence-in-depth on top
+    // of `grafanaAuthorization`.
+    if (
+      realmURLObj.origin !== serverURLObj.origin ||
+      !realmURLObj.pathname.startsWith(serverURLObj.pathname)
+    ) {
+      await sendResponseForBadRequest(
+        ctxt,
+        `"realm" must be a path under this server (${serverURLObj.href})`,
+      );
+      return;
+    }
     // CS-11271: route through the reconciler so a non-pinned realm that
     // hasn't been touched on this process since the last restart still
     // mounts on demand, instead of failing with a confusing

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -543,12 +543,18 @@ export class RealmServer {
     }
   }
 
-  // Simulate the post-restart "this realm isn't in this process's
-  // realms[] yet" state without tearing down its disk mount, indexer,
-  // or matrix client. CS-11264 / CS-11271 regression tests use this
-  // to prove handlers resolve through the reconciler instead of
-  // realms[]. The realm stays in reconciler.mounted so
-  // lookupOrMount() returns it via the fast path.
+  // Remove a realm from the in-memory `realms[]` view without touching
+  // reconciler.mounted or tearing down the realm's workers / matrix
+  // client / indexer. CS-11264 / CS-11271 regression tests use this to
+  // prove handlers consult the reconciler rather than iterating
+  // `realms[]` directly — after eviction, lookups must still resolve
+  // via reconciler.mounted's fast path. This is NOT a full post-
+  // restart simulation: in a real restart non-pinned realms are also
+  // absent from reconciler.mounted, which would then drive a cold
+  // mount via lookupOrMount. The cold-mount path through the
+  // reconciler itself is covered in lazy-mount-test.ts; reproducing
+  // it inside an HTTP handler test would race a second Realm
+  // instance against the pre-existing legacy mount.
   testingOnlyEvictRealmFromRealmsList(url: string): void {
     let idx = this.realms.findIndex((r) => r.url === url);
     if (idx !== -1) {

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -543,6 +543,19 @@ export class RealmServer {
     }
   }
 
+  // Simulate the post-restart "this realm isn't in this process's
+  // realms[] yet" state without tearing down its disk mount, indexer,
+  // or matrix client. CS-11264 / CS-11271 regression tests use this
+  // to prove handlers resolve through the reconciler instead of
+  // realms[]. The realm stays in reconciler.mounted so
+  // lookupOrMount() returns it via the fast path.
+  testingOnlyEvictRealmFromRealmsList(url: string): void {
+    let idx = this.realms.findIndex((r) => r.url === url);
+    if (idx !== -1) {
+      this.realms.splice(idx, 1);
+    }
+  }
+
   // Test-only accessor for the request-path realm resolver. Exposed so
   // lazy-mount integration tests can drive findOrMountRealm directly
   // without spinning up an HTTP listener + mocked Koa context.

--- a/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
@@ -676,17 +676,28 @@ module(`server-endpoints/${basename(__filename)}`, function () {
         );
       });
 
-      // CS-11271 regression: after a realm-server restart, a non-pinned
-      // realm is not in this process's realms[] until something triggers
-      // a lazy mount via the request path. Pre-fix, handle-reindex
-      // iterated realms[] directly and 400'd with "does not exist on
-      // this server" — so the operator's first grafana-reindex on a
-      // non-pinned realm after a deploy / ECS task replacement /
-      // scheduled restart failed with a confusing 400 until something
-      // else triggered a mount. Post-fix, the handler routes through
-      // reconciler.lookupOrMount, so any realm the reconciler can
-      // resolve enqueues a reindex job.
-      test('can reindex a realm via grafana endpoint even when the realm is absent from realms[] (post-restart)', async function (assert) {
+      // CS-11271 regression: pre-fix, handle-reindex resolved the
+      // target realm via `realms.find(...)` against the in-memory
+      // list. Under Phase 3 lazy mount that list is no longer the
+      // authoritative view — non-pinned realms only appear in it
+      // after some request has driven a `reconciler.lookupOrMount`
+      // for them. The operator-facing failure mode was "first
+      // grafana-reindex after a deploy / ECS task replacement on a
+      // non-pinned realm returns 400 'realm does not exist on this
+      // server'". This test proves the handler now resolves through
+      // the reconciler instead of `realms[]`: we evict the realm
+      // from `realms[]` only (leaving it in `reconciler.mounted`),
+      // so `lookupOrMount` resolves via its mounted fast path.
+      // Pre-fix the same eviction caused the 400.
+      //
+      // The true cold-mount path (registry row present, mounted
+      // empty) is exercised against the reconciler directly in
+      // `tests/lazy-mount-test.ts`; reproducing it inside this
+      // handler test would require constructing a second `Realm`
+      // instance against the disk of the realm `/_create-realm`
+      // already mounted, which races on workers / matrix / queue
+      // subscribers.
+      test('can reindex a realm via grafana endpoint even when the realm is absent from realms[]', async function (assert) {
         let endpoint = `test-realm-${uuidv4()}`;
         let owner = 'mango';
         let ownerUserId = `@${owner}:localhost`;
@@ -718,10 +729,6 @@ module(`server-endpoints/${basename(__filename)}`, function () {
           realmURL = response.body.data.id;
         }
 
-        // Simulate post-restart: the realm_registry row + reconciler
-        // mount are intact, but this process's realms[] doesn't
-        // include the realm. Pre-fix, the next line caused the
-        // grafana-reindex POST below to 400.
         context.testRealmServer.testingOnlyEvictRealmFromRealmsList(realmURL);
 
         let initialJobs = await context.dbAdapter.execute('select * from jobs');
@@ -743,7 +750,21 @@ module(`server-endpoints/${basename(__filename)}`, function () {
           initialJobs.length + 1,
           'a from-scratch-index job was enqueued',
         );
-        let job = finalJobs.pop()!;
+        // Identify the new job by id rather than relying on row order
+        // — `select * from jobs` has no ORDER BY so the grafana-
+        // reindex job isn't guaranteed to be the last element, and
+        // filtering by `args.realmURL` would also match the
+        // /_create-realm bootstrap index.
+        let initialJobIds = new Set(initialJobs.map((j: any) => String(j.id)));
+        let newJobs = finalJobs.filter(
+          (j: any) => !initialJobIds.has(String(j.id)),
+        );
+        assert.strictEqual(
+          newJobs.length,
+          1,
+          'exactly one new job was enqueued',
+        );
+        let job = newJobs[0];
         assert.strictEqual(
           job.job_type,
           'from-scratch-index',

--- a/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
@@ -676,6 +676,90 @@ module(`server-endpoints/${basename(__filename)}`, function () {
         );
       });
 
+      // CS-11271 regression: after a realm-server restart, a non-pinned
+      // realm is not in this process's realms[] until something triggers
+      // a lazy mount via the request path. Pre-fix, handle-reindex
+      // iterated realms[] directly and 400'd with "does not exist on
+      // this server" — so the operator's first grafana-reindex on a
+      // non-pinned realm after a deploy / ECS task replacement /
+      // scheduled restart failed with a confusing 400 until something
+      // else triggered a mount. Post-fix, the handler routes through
+      // reconciler.lookupOrMount, so any realm the reconciler can
+      // resolve enqueues a reindex job.
+      test('can reindex a realm via grafana endpoint even when the realm is absent from realms[] (post-restart)', async function (assert) {
+        let endpoint = `test-realm-${uuidv4()}`;
+        let owner = 'mango';
+        let ownerUserId = `@${owner}:localhost`;
+        let realmURL: string;
+        {
+          let response = await context.request
+            .post('/_create-realm')
+            .set('Accept', 'application/vnd.api+json')
+            .set('Content-Type', 'application/json')
+            .set(
+              'Authorization',
+              `Bearer ${createRealmServerJWT(
+                { user: ownerUserId, sessionRoom: 'session-room-test' },
+                realmSecretSeed,
+              )}`,
+            )
+            .send(
+              JSON.stringify({
+                data: {
+                  type: 'realm',
+                  attributes: {
+                    name: 'Test Realm',
+                    endpoint,
+                  },
+                },
+              }),
+            );
+          assert.strictEqual(response.status, 202, 'HTTP 202 status');
+          realmURL = response.body.data.id;
+        }
+
+        // Simulate post-restart: the realm_registry row + reconciler
+        // mount are intact, but this process's realms[] doesn't
+        // include the realm. Pre-fix, the next line caused the
+        // grafana-reindex POST below to 400.
+        context.testRealmServer.testingOnlyEvictRealmFromRealmsList(realmURL);
+
+        let initialJobs = await context.dbAdapter.execute('select * from jobs');
+        let realmPath = realmURL.substring(
+          new URL(testRealmURL.origin).href.length,
+        );
+        let response = await context.request
+          .post(`/_grafana-reindex?realm=${realmPath}`)
+          .set('Authorization', `Bearer ${grafanaSecret}`)
+          .set('Content-Type', 'application/json');
+        assert.strictEqual(
+          response.status,
+          200,
+          'reindex succeeds against a realm absent from realms[]',
+        );
+        let finalJobs = await context.dbAdapter.execute('select * from jobs');
+        assert.strictEqual(
+          finalJobs.length,
+          initialJobs.length + 1,
+          'a from-scratch-index job was enqueued',
+        );
+        let job = finalJobs.pop()!;
+        assert.strictEqual(
+          job.job_type,
+          'from-scratch-index',
+          'job type is correct',
+        );
+        assert.deepEqual(
+          job.args,
+          {
+            realmURL,
+            realmUsername: owner,
+            clearLastModified: true,
+          },
+          'job args target the evicted realm',
+        );
+      });
+
       test('returns 401 when calling grafana reindex endpoint without a grafana secret', async function (assert) {
         let endpoint = `test-realm-${uuidv4()}`;
         let owner = 'mango';


### PR DESCRIPTION
## Summary

- Same anti-pattern [CS-11264](https://linear.app/cardstack/issue/CS-11264) just fixed in `_realm-auth`. After Phase 3 lazy mount ([CS-10894](https://linear.app/cardstack/issue/CS-10894)), non-pinned realms are absent from `realms[]` after a realm-server restart. `handle-reindex.ts:39` did `realms.find(...)` to decide "does this realm exist on this server", so an operator-triggered `/_grafana-reindex` for a non-pinned realm returned `400 realm <url> does not exist on this server` until something else happened to lazy-mount the realm. See [CS-11271](https://linear.app/cardstack/issue/CS-11271).
- Route through `reconciler.lookupOrMount(realmURL)`. Pinned realms keep the O(1) `mounted` fast-path; non-pinned realms pay one cold-mount cost on first hit. Mount failures bubble as 500 via `sendResponseForSystemError` (same shape as the already-present catch around `reindex()`). `undefined` (URL absent from `realm_registry`) preserves the existing 400 + error message.
- Regression test in `maintenance-endpoints-test.ts` evicts the created realm from `realms[]`, hits `/_grafana-reindex`, and asserts the from-scratch-index job lands with `clearLastModified: true`. Confirmed it fails pre-fix.

## Rebase note

This branch adds `testingOnlyEvictRealmFromRealmsList(url)` to `RealmServer` — identical to the shim CS-11264 (#4966) introduces. Whichever branch lands first, the other will hit a trivial duplicate-add conflict on `server.ts`; resolution is a no-op (drop the duplicate).

## Test plan

- [x] `pnpm test --filter "can reindex a realm via grafana endpoint"` — both existing test and new regression test pass
- [x] Confirmed regression test fails when handler is reverted to `realms.find(...)`
- [x] `pnpm lint:types` clean
- [ ] Manual verification on staging once deployed: restart boxel-realm-server-staging, then trigger Grafana "Reindex realm" against a non-pinned source realm — should enqueue the job instead of 400ing

🤖 Generated with [Claude Code](https://claude.com/claude-code)