### PR TITLE
CS-11245: broadcast source-cache wipe before bootstrap reindex

### DIFF
--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -1002,6 +1002,7 @@ export async function createRealm({
   cardSizeLimitBytes,
   fileSizeLimitBytes,
   transpileCoordinator,
+  fullIndexOnStartup,
 }: {
   dir: string;
   definitionLookup: DefinitionLookup;
@@ -1024,6 +1025,12 @@ export async function createRealm({
   // is the only thing serializing them — that's the behavior we want to
   // exercise.
   transpileCoordinator?: PopulateCoordinator;
+  // Forwarded to the Realm constructor's `fullIndexOnStartup` option so
+  // tests can exercise the bootstrap-realm code path in `Realm.#startup`
+  // (the kind='bootstrap' branch that triggers the CS-11245 broadcast).
+  // Production sets this via `resolveFullIndexOnStartup`; tests opt in
+  // explicitly because `createRealm` has no realm-registry row to read.
+  fullIndexOnStartup?: true;
   // if you are creating a realm  to test it directly without a server, you can
   // also specify `withWorker: true` to also include a worker with your realm
   withWorker?: true;
@@ -1071,28 +1078,31 @@ export async function createRealm({
     username: realmServerTestMatrix.username,
     seed: realmSecretSeed,
   });
-  let realm = new Realm({
-    url: realmURL,
-    adapter,
-    secretSeed: realmSecretSeed,
-    virtualNetwork,
-    dbAdapter,
-    queue: publisher,
-    matrixClient,
-    realmServerURL: new URL(new URL(realmURL).origin).href,
-    definitionLookup,
-    cardSizeLimitBytes:
-      cardSizeLimitBytes ??
-      Number(
-        process.env.CARD_SIZE_LIMIT_BYTES ?? DEFAULT_CARD_SIZE_LIMIT_BYTES,
-      ),
-    fileSizeLimitBytes:
-      fileSizeLimitBytes ??
-      Number(
-        process.env.FILE_SIZE_LIMIT_BYTES ?? DEFAULT_FILE_SIZE_LIMIT_BYTES,
-      ),
-    transpileCoordinator,
-  });
+  let realm = new Realm(
+    {
+      url: realmURL,
+      adapter,
+      secretSeed: realmSecretSeed,
+      virtualNetwork,
+      dbAdapter,
+      queue: publisher,
+      matrixClient,
+      realmServerURL: new URL(new URL(realmURL).origin).href,
+      definitionLookup,
+      cardSizeLimitBytes:
+        cardSizeLimitBytes ??
+        Number(
+          process.env.CARD_SIZE_LIMIT_BYTES ?? DEFAULT_CARD_SIZE_LIMIT_BYTES,
+        ),
+      fileSizeLimitBytes:
+        fileSizeLimitBytes ??
+        Number(
+          process.env.FILE_SIZE_LIMIT_BYTES ?? DEFAULT_FILE_SIZE_LIMIT_BYTES,
+        ),
+      transpileCoordinator,
+    },
+    fullIndexOnStartup ? { fullIndexOnStartup: true as const } : undefined,
+  );
   if (worker) {
     virtualNetwork.mount(realm.handle);
     await worker.run();

--- a/packages/realm-server/tests/module-cache-race-test.ts
+++ b/packages/realm-server/tests/module-cache-race-test.ts
@@ -1784,8 +1784,7 @@ module(basename(__filename), function () {
           'RealmIndexUpdater.fullIndex was invoked exactly once on startup',
         );
         assert.ok(
-          wildcardNotifyCall &&
-            wildcardNotifyCall.calledBefore(fullIndexStub.getCall(0)),
+          wildcardNotifyCall?.calledBefore(fullIndexStub.getCall(0)),
           'the NOTIFY happened before from-scratch-index was enqueued',
         );
       });

--- a/packages/realm-server/tests/module-cache-race-test.ts
+++ b/packages/realm-server/tests/module-cache-race-test.ts
@@ -1699,8 +1699,8 @@ module(basename(__filename), function () {
   // `setup:<realm>-in-deployment` rsync). The broadcast is the
   // prevent layer; without it the reindex persists stale bytes into
   // `boxel_index.pristine_doc` plus sticky `error_doc` rows that
-  // survive past fleet stabilization (the 2026-05-22
-  // whitepaper.boxel.ai incident).
+  // survive past fleet stabilization (see CS-11245 for the
+  // originating incident).
   module(
     '#startup broadcasts source-cache wipe for bootstrap realms (CS-11245)',
     function (hooks) {

--- a/packages/realm-server/tests/module-cache-race-test.ts
+++ b/packages/realm-server/tests/module-cache-race-test.ts
@@ -8,6 +8,8 @@ import type { RealmHttpServer as Server } from '../server';
 import type { Realm } from '@cardstack/runtime-common';
 import {
   CachingDefinitionLookup,
+  REALM_FILE_CHANGES_CHANNEL,
+  RealmIndexUpdater,
   SupportedMimeType,
   param,
   query,
@@ -1679,6 +1681,144 @@ module(basename(__filename), function () {
           await waitForZeroLiveRows(),
           0,
           'L2 rows tombstoned by the worker-side NOTIFY even though startReindex never ran',
+        );
+      });
+    },
+  );
+
+  // CS-11245: bootstrap realms (kind='bootstrap': base, catalog, skills,
+  // …) full-index on every realm-server boot. The from-scratch-index
+  // worker that picks up the resulting job fans HTTP source reads
+  // through the load balancer, which during a rolling deploy can land
+  // on a still-warm pre-deploy peer whose `#sourceCache` is populated
+  // from pre-rsync bytes. `Realm.#startup` now broadcasts a
+  // `realm_file_changes:<url>:*` NOTIFY before enqueueing the
+  // from-scratch-index, so every peer drops its cache for this URL
+  // and the next HTTP read falls through to `/persistent/` (EFS,
+  // already brought up to date by the new container's
+  // `setup:<realm>-in-deployment` rsync). The broadcast is the
+  // prevent layer; without it the reindex persists stale bytes into
+  // `boxel_index.pristine_doc` plus sticky `error_doc` rows that
+  // survive past fleet stabilization (the 2026-05-22
+  // whitepaper.boxel.ai incident).
+  module(
+    '#startup broadcasts source-cache wipe for bootstrap realms (CS-11245)',
+    function (hooks) {
+      let dbAdapter: PgAdapter;
+      let publisher: import('@cardstack/runtime-common').QueuePublisher;
+      let runner: import('@cardstack/runtime-common').QueueRunner;
+      setupDB(hooks, {
+        beforeEach: async (adapter, pub, run) => {
+          dbAdapter = adapter;
+          publisher = pub;
+          runner = run;
+        },
+      });
+
+      hooks.afterEach(function () {
+        sinon.restore();
+      });
+
+      const startupRealmURL = 'http://127.0.0.1:6666/startup/';
+
+      async function buildStartupRealm({
+        fullIndexOnStartup,
+      }: {
+        fullIndexOnStartup: boolean;
+      }): Promise<Realm> {
+        let tmp = dirSync();
+        let dir = join(tmp.name, 'startup-realm');
+        ensureDirSync(dir);
+        writeJSONSync(join(dir, '.realm.json'), { name: 'Startup Realm' });
+        let virtualNetwork = createVirtualNetwork();
+        let prerenderer = await getTestPrerenderer();
+        let definitionLookup = new CachingDefinitionLookup(
+          dbAdapter,
+          prerenderer,
+          virtualNetwork,
+          testCreatePrerenderAuth,
+        );
+        let { realm } = await createRealm({
+          dir,
+          definitionLookup,
+          realmURL: startupRealmURL,
+          permissions: { '*': ['read'] },
+          virtualNetwork,
+          publisher,
+          runner,
+          dbAdapter,
+          ...(fullIndexOnStartup ? { fullIndexOnStartup: true as const } : {}),
+        });
+        return realm;
+      }
+
+      test('bootstrap realm emits realm_file_changes wildcard NOTIFY before enqueuing the from-scratch-index', async function (assert) {
+        let originalNotify = dbAdapter.notify.bind(dbAdapter);
+        let notifyStub = sinon
+          .stub(dbAdapter, 'notify')
+          .callsFake((channel, payload) => originalNotify(channel, payload));
+        // Stub fullIndex so the test doesn't actually run a from-scratch
+        // pass — we only care that the broadcast precedes the call.
+        let fullIndexStub = sinon
+          .stub(RealmIndexUpdater.prototype, 'fullIndex')
+          .resolves();
+
+        let realm = await buildStartupRealm({ fullIndexOnStartup: true });
+        await realm.start();
+
+        let wildcardNotifyCall = notifyStub
+          .getCalls()
+          .find(
+            (c) =>
+              c.args[0] === REALM_FILE_CHANGES_CHANNEL &&
+              c.args[1] === `${startupRealmURL}:*`,
+          );
+
+        assert.ok(
+          wildcardNotifyCall,
+          'realm_file_changes wildcard NOTIFY was emitted for the realm URL during startup',
+        );
+        assert.strictEqual(
+          fullIndexStub.callCount,
+          1,
+          'RealmIndexUpdater.fullIndex was invoked exactly once on startup',
+        );
+        assert.ok(
+          wildcardNotifyCall &&
+            wildcardNotifyCall.calledBefore(fullIndexStub.getCall(0)),
+          'the NOTIFY happened before from-scratch-index was enqueued',
+        );
+      });
+
+      test('non-bootstrap realm (isNewIndex-only branch) does NOT broadcast on startup', async function (assert) {
+        let originalNotify = dbAdapter.notify.bind(dbAdapter);
+        let notifyStub = sinon
+          .stub(dbAdapter, 'notify')
+          .callsFake((channel, payload) => originalNotify(channel, payload));
+        let fullIndexStub = sinon
+          .stub(RealmIndexUpdater.prototype, 'fullIndex')
+          .resolves();
+
+        let realm = await buildStartupRealm({ fullIndexOnStartup: false });
+        await realm.start();
+
+        let wildcardNotifyCall = notifyStub
+          .getCalls()
+          .find(
+            (c) =>
+              c.args[0] === REALM_FILE_CHANGES_CHANNEL &&
+              c.args[1] === `${startupRealmURL}:*`,
+          );
+
+        assert.strictEqual(
+          wildcardNotifyCall,
+          undefined,
+          'no realm_file_changes wildcard NOTIFY on a first-mount fresh-index realm whose kind is not bootstrap',
+        );
+        assert.strictEqual(
+          fullIndexStub.callCount,
+          1,
+          'fullIndex still ran via the isNewIndex branch, even without a broadcast',
         );
       });
     },

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2526,6 +2526,29 @@ export class Realm {
           `startup isNewIndex=${isNewIndex} fullIndexOnStartup=${this.#fullIndexOnStartup} for realm ${this.url}`,
         );
         if (isNewIndex || this.#fullIndexOnStartup) {
+          if (this.#fullIndexOnStartup) {
+            // CS-11245: bootstrap realms (kind='bootstrap': base,
+            // catalog, skills, …) full-index on every realm-server
+            // boot. On a rolling deploy the worker that picks up the
+            // resulting from-scratch-index job fans HTTP source reads
+            // through the LB, which can route to a still-warm
+            // pre-deploy peer whose `#sourceCache` was populated from
+            // pre-rsync bytes. `getSourceOrRedirect` would return those
+            // stale bytes and the reindex would persist them into
+            // `boxel_index.pristine_doc` plus sticky `error_doc` rows
+            // that survive past fleet stabilization (the 2026-05-22
+            // whitepaper.boxel.ai incident). Broadcast a per-realm
+            // NOTIFY so every peer drops its entries for this URL and
+            // the next read falls through to `/persistent/` (EFS,
+            // already brought up to date by this container's
+            // `setup:<realm>-in-deployment` rsync at PID 1). The local
+            // clear is a no-op on a freshly booted container; the
+            // broadcast is what does the work. Skipped on the
+            // `isNewIndex` branch — that branch fires for first-ever
+            // mounts (e.g., brand-new publish), where peer caches for
+            // a never-before-seen URL are empty by construction.
+            await this.clearLocalSourceCachesAndBroadcast();
+          }
           let priority =
             opts?.fromScratchIndexPriority ?? this.#fromScratchIndexPriority;
           let promise = this.#realmIndexUpdater.fullIndex(priority);

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2536,8 +2536,8 @@ export class Realm {
             // pre-rsync bytes. `getSourceOrRedirect` would return those
             // stale bytes and the reindex would persist them into
             // `boxel_index.pristine_doc` plus sticky `error_doc` rows
-            // that survive past fleet stabilization (the 2026-05-22
-            // whitepaper.boxel.ai incident). Broadcast a per-realm
+            // that survive past fleet stabilization (see CS-11245 for
+            // the originating incident). Broadcast a per-realm
             // NOTIFY so every peer drops its entries for this URL and
             // the next read falls through to `/persistent/` (EFS,
             // already brought up to date by this container's


### PR DESCRIPTION
## Summary
- Bootstrap realms (`kind='bootstrap'`: base, catalog, skills, …) full-index on every realm-server boot. On a rolling deploy the resulting from-scratch-index worker fans HTTP source reads through the LB, which can route to a still-warm pre-deploy peer whose `#sourceCache` holds pre-rsync bytes; `getSourceOrRedirect` returns those bytes and the reindex persists them into `boxel_index.pristine_doc` plus sticky `error_doc` rows that survive past fleet stabilization.
- `Realm.#startup` now `await`s `clearLocalSourceCachesAndBroadcast()` before enqueueing the from-scratch-index when `fullIndexOnStartup` is true. The NOTIFY drops each peer's `#sourceCache` for the realm URL so the next HTTP source read falls through to `/persistent/` (EFS, already updated by the new container's `setup:<realm>-in-deployment` rsync at PID 1).
- The `isNewIndex`-only branch is deliberately skipped: first-mounts of brand-new realms have no peer `#sourceCache` to invalidate by construction, so broadcasting there would be a no-op round-trip on every new-realm publish.
- Mirrors the same primitive the publish-realm handler already uses for the analogous republish race (CS-11043 / CS-11156).
- See Linear ticket CS-11245 for the originating incident, the list of residual realms that still need a one-time `_grafana-reindex` to clear pre-fix stale rows, and the wider race analysis.

## Test plan
- [ ] `TEST_MODULES=module-cache-race-test.ts pnpm test` in `packages/realm-server/` — two new spy tests under `#startup broadcasts source-cache wipe for bootstrap realms (CS-11245)` pass, the existing 20 tests in that file still pass (22/22 green locally).
- [ ] CI: full realm-server suite + ci-host shards.
- [ ] Staging soak: after merge + auto-deploy, watch a subsequent rolling-deploy event and confirm no new `error_doc` rows for bootstrap realms are created during the deploy window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)