### PR TITLE
CS-11171: render FileDef format HTML for executable modules

### DIFF
--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -976,6 +976,22 @@ module(basename(__filename), function () {
         'text/typescript+glimmer',
         'file entry includes contentType',
       );
+
+      // CS-11171: executable modules are FileDef subclasses
+      // (GtsFileDef/TsFileDef) and CardsGrid's "All Files" group renders
+      // their fitted/isolated formats. Before the fix, the fused visit
+      // gated fileRender behind `!isModule`, so every HTML column on
+      // these rows was NULL and the grid showed nothing. The FileDef
+      // FileRender pass now runs for modules too.
+      assert.ok(
+        entry?.isolatedHtml?.includes('data-test-ts-isolated'),
+        'executable file entry has FileDef isolated HTML rendered from the TsFileDef template',
+      );
+      let fittedHtml = Object.values(entry?.fittedHtml ?? {}).join('');
+      assert.ok(
+        fittedHtml.includes('data-test-ts-fitted'),
+        'executable file entry has FileDef fitted HTML rendered from the TsFileDef template',
+      );
     });
 
     test('indexes card json resources as file entries too', async function (assert) {

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -977,20 +977,21 @@ module(basename(__filename), function () {
         'file entry includes contentType',
       );
 
-      // CS-11171: executable modules are FileDef subclasses
-      // (GtsFileDef/TsFileDef) and CardsGrid's "All Files" group renders
-      // their fitted/isolated formats. Before the fix, the fused visit
-      // gated fileRender behind `!isModule`, so every HTML column on
-      // these rows was NULL and the grid showed nothing. The FileDef
-      // FileRender pass now runs for modules too.
+      // CS-11171: executable modules are FileDef subclasses — `person.gts`
+      // resolves to GtsFileDef, which inherits its fitted/isolated/etc.
+      // templates (and their `data-test-ts-*` markers) from TsFileDef.
+      // CardsGrid's "All Files" group renders those formats. Before the
+      // fix, the fused visit gated fileRender behind `!isModule`, so every
+      // HTML column on these rows was NULL and the grid showed nothing.
+      // The FileDef FileRender pass now runs for modules too.
       assert.ok(
         entry?.isolatedHtml?.includes('data-test-ts-isolated'),
-        'executable file entry has FileDef isolated HTML rendered from the TsFileDef template',
+        'executable file entry has FileDef isolated HTML (GtsFileDef, via the inherited TsFileDef template)',
       );
       let fittedHtml = Object.values(entry?.fittedHtml ?? {}).join('');
       assert.ok(
         fittedHtml.includes('data-test-ts-fitted'),
-        'executable file entry has FileDef fitted HTML rendered from the TsFileDef template',
+        'executable file entry has FileDef fitted HTML (GtsFileDef, via the inherited TsFileDef template)',
       );
     });
 

--- a/packages/runtime-common/index-runner/visit-file.ts
+++ b/packages/runtime-common/index-runner/visit-file.ts
@@ -142,9 +142,10 @@ export async function visitFileForIndexingFused({
   // (.gts/.ts). Module files are also FileDef subclasses (GtsFileDef /
   // TsFileDef) with their own fitted/embedded/atom/isolated templates, and
   // CardsGrid's "All Files" group renders those formats — so they need the
-  // FileDef-format HTML just like .json/.md/image files do (CS-11171). The
-  // module prerender pass (gated by `isModule` below via `hasModulePrerender`)
-  // is orthogonal: it produces the compiled module artifact, not format HTML.
+  // FileDef-format HTML just like .json/.md/image files do (CS-11171).
+  // `isModule` does NOT gate this: it's only recorded as the
+  // `hasModulePrerender` flag on the file-index row below (a metadata hint
+  // for downstream consumers; the file indexer no longer acts on it).
   // Missing-resource cases are handled downstream by the file indexer.
   let needFileRender = true;
 

--- a/packages/runtime-common/index-runner/visit-file.ts
+++ b/packages/runtime-common/index-runner/visit-file.ts
@@ -138,10 +138,15 @@ export async function visitFileForIndexingFused({
 
   let needCardRender = Boolean(parsedCardResource);
   let needFileExtract = true; // every file gets a file entry
-  // fileRender is requested for all non-module files. This is broader than
-  // the legacy file-indexer gating (`extractResult.resource && !hasModulePrerender`);
-  // missing-resource cases are handled downstream by the file indexer.
-  let needFileRender = !isModule;
+  // fileRender is requested for every file, including executable modules
+  // (.gts/.ts). Module files are also FileDef subclasses (GtsFileDef /
+  // TsFileDef) with their own fitted/embedded/atom/isolated templates, and
+  // CardsGrid's "All Files" group renders those formats — so they need the
+  // FileDef-format HTML just like .json/.md/image files do (CS-11171). The
+  // module prerender pass (gated by `isModule` below via `hasModulePrerender`)
+  // is orthogonal: it produces the compiled module artifact, not format HTML.
+  // Missing-resource cases are handled downstream by the file indexer.
+  let needFileRender = true;
 
   if (lastModified == null) {
     logWarn(


### PR DESCRIPTION
## Summary

CardsGrid's "All Files" group lists `.gts`/`.ts` files (via the `GtsFileDef` / `TsFileDef` summaries in `realm_meta.value.files`), but selecting one showed zero results — every HTML column (`fitted_html`, `embedded_html`, `isolated_html`, `head_html`) on those `boxel_index` rows was NULL. See [CS-11171](https://linear.app/cardstack/issue/CS-11171).

`packages/runtime-common/index-runner/visit-file.ts` gated the FileRender pass behind `!isModule`, so executable extensions only got the **module prerender** pass (compiled template / scoped CSS artifacts) and never the **FileDef-format HTML** the grid renders. The two passes are orthogonal — module prerender produces the module artifact; file render produces the FileDef format HTML. `GtsFileDef`/`TsFileDef` both define fitted/embedded/atom/isolated templates.

## Change

- `visit-file.ts`: `let needFileRender = !isModule;` → `let needFileRender = true;`.

No downstream change needed:
- The file indexer (`file-indexer.ts`) already writes the HTML columns straight from the render result — its old `hasModulePrerender` gate is already dead code (`void hasModulePrerender;`).
- The prerender server's `fileRender` pass (`render-runner.ts`) has no executable-extension guard, and `resolveFileDefCodeRef` already maps `.ts → TsFileDef` / `.gts → GtsFileDef`.

## Test plan

- [x] `pnpm lint:js` clean; `pnpm lint:types` clean on changed files (`visit-file.ts`, `indexing-test.ts`)
- [ ] CI: extended `indexes executable files as file entries too` (`indexing-test.ts`) now asserts `person.gts`'s FileDef isolated + fitted HTML is populated (`data-test-ts-isolated` / `data-test-ts-fitted`). I could not run this locally — `indexing-test` needs the prerender dev services (`pnpm start:all`) which weren't up in my environment; leaving the green check to CI.
- [ ] Manual: reindex a realm with `.gts`/`.ts` files, then open CardsGrid → "All Files" → select a module file and confirm the FileDef fitted/isolated content renders.

## Rollout notes

- Existing realms need a reindex for the HTML to backfill; incremental indexing fills it in on the next edit.
- Each `.gts`/`.ts` file now costs one extra prerender pass on full reindex (~137 extra renders for the experiments realm cited in the ticket). Worth keeping an eye on full-reindex duration but expected to be fine.

## Related

- [CS-11170](https://linear.app/cardstack/issue/CS-11170) — Include FileDefs in CardsGrid. Shipped a `CardList` fallback placeholder for html-less cards; this PR makes the FileDef's real templates render instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)