### PR TITLE
Plant linksTo error/not-found sentinels in the data bucket on fetch failure

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -3456,7 +3456,12 @@ function lazilyLoadLink(
           }
         }
       } else {
+        // Mirror `setField`'s notification (minus validate, which rejects a
+        // non-card value): write the bucket, notify change subscribers, then
+        // card tracking. Without the `notifySubscribers` call, `subscribeToChanges`
+        // listeners would observe a successful lazy load but not a failed one.
         getDataBucket(instance).set(field.name, sentinel);
+        notifySubscribers(instance, field.name, sentinel);
         notifyCardTracking(instance);
       }
 

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -164,6 +164,9 @@ import {
   isArrayOfCardOrField,
   isCard,
   isCardOrField,
+  isLinkError,
+  isLinkNotFound,
+  isNonPresentLink,
   isNotLoadedValue,
   notifyCardTracking,
   peekAtField,
@@ -173,6 +176,8 @@ import {
   setFieldDescription,
   setRealmContextOnField,
   type ComputePassSnapshot,
+  type LinkErrorValue,
+  type LinkNotFoundValue,
   type NotLoadedValue,
   type RelationshipState,
 } from './field-support';
@@ -1204,6 +1209,14 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
       lazilyLoadLink(instance, this, maybeNotLoaded.reference);
       return undefined;
     }
+    // link-error / link-not-found are terminal failure states planted by
+    // lazilyLoadLink. They surface to userland as `undefined` (the same shape a
+    // not-loaded link produces) and are NOT retried — re-reading must not kick
+    // off another fetch. `getRelationship` is the only way to observe the
+    // structured failure from outside this module.
+    if (isLinkError(maybeNotLoaded) || isLinkNotFound(maybeNotLoaded)) {
+      return undefined;
+    }
     let value = getter(instance, this);
     trackRuntimeRelationshipDependency(value, this.card);
     return value;
@@ -1218,6 +1231,11 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
     if (instance == null) {
       return null;
     }
+    // A terminal sentinel queries by its reference, the same as a not-loaded
+    // link — the broken reference is preserved in the search doc.
+    if (isNonPresentLink(instance)) {
+      return { id: instance.reference };
+    }
     return this.card[queryableValue](instance, stack);
   }
 
@@ -1230,7 +1248,11 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
     let relationshipType = isFileDef(this.card)
       ? FileMetaResourceType
       : CardResourceType;
-    if (isNotLoadedValue(value)) {
+    // A terminal sentinel (link-error / link-not-found) serializes the same way
+    // a not-loaded link does — the reference is preserved as a relationship
+    // link so a save→reload cycle keeps the broken reference rather than
+    // silently dropping it.
+    if (isNonPresentLink(value)) {
       return {
         relationships: {
           [this.name]: {
@@ -1407,7 +1429,7 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
       );
     }
     if (value) {
-      if (isNotLoadedValue(value)) {
+      if (isNonPresentLink(value)) {
         return value;
       }
       if (isFileDef(this.card) && !value.id) {
@@ -1615,6 +1637,15 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
       return this.emptyValue(instance) as BaseInstanceType<FieldT>;
     }
 
+    // A whole-field terminal sentinel (a computed linksToMany that consumes an
+    // upstream link which resolved to an error / not-found) is terminal: surface
+    // an empty array to userland and do NOT retrigger the loader. Per-slot
+    // terminal sentinels living inside the array are handled below — they are
+    // simply skipped by the not-loaded retrigger scan.
+    if (isLinkError(value) || isLinkNotFound(value)) {
+      return this.emptyValue(instance) as BaseInstanceType<FieldT>;
+    }
+
     if (!Array.isArray(value)) {
       throw new Error(
         `LinksToMany field '${
@@ -1689,7 +1720,7 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
             `the linksToMany field '${this.name}' contains a primitive card '${instance.name}'`,
           );
         }
-        if (isNotLoadedValue(instance)) {
+        if (isNonPresentLink(instance)) {
           return { id: instance.reference };
         }
         return this.card[queryableValue](instance, stack);
@@ -1715,8 +1746,9 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
     }
 
     // this can be a not loaded value happen when the linksToMany is a
-    // computed that consumes a linkTo field that is not loaded
-    if (isNotLoadedValue(values)) {
+    // computed that consumes a linkTo field that is not loaded (or a terminal
+    // error / not-found sentinel surfacing through the same computed path)
+    if (isNonPresentLink(values)) {
       return { relationships: {} };
     }
 
@@ -1748,7 +1780,7 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
         };
         return;
       }
-      if (isNotLoadedValue(value)) {
+      if (isNonPresentLink(value)) {
         relationships[`${this.name}\.${i}`] = {
           links: {
             self: makeRelativeURL(value.reference, opts),
@@ -1979,7 +2011,7 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
     let expectedCard = this.declaredCard;
     for (let value of values) {
       if (
-        !isNotLoadedValue(value) &&
+        !isNonPresentLink(value) &&
         value != null &&
         !instanceOf(value, expectedCard)
       ) {
@@ -1988,7 +2020,7 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
         );
       }
       if (
-        !isNotLoadedValue(value) &&
+        !isNonPresentLink(value) &&
         value != null &&
         isFileDef(expectedCard) &&
         !value.id
@@ -2283,7 +2315,7 @@ export class BaseDef {
                 }) ?? null,
             ];
           }
-          if (isNotLoadedValue(rawValue)) {
+          if (isNonPresentLink(rawValue)) {
             let normalizedId = rawValue.reference;
             if (value[relativeTo]) {
               normalizedId = resolveCardReference(
@@ -3344,10 +3376,6 @@ function lazilyLoadLink(
         (instance as any)[field.name] = fieldValue;
       }
     } catch (e) {
-      // we replace the node-loaded value with a null
-      // TODO in the future consider recording some link meta that this reference is actually missing
-      (instance as any)[field.name] = null;
-
       let error = e as Error;
       let isMissingFile =
         (isCardError(error) && error.status === 404) ||
@@ -3394,6 +3422,44 @@ function lazilyLoadLink(
         }
       }
       payloadError.deps = [...deps];
+
+      // Plant a typed sentinel into the data bucket (singular) or the failed
+      // array slot(s) (plural), replacing the legacy `field = null` write. The
+      // field getter surfaces these as `undefined` to userland — the same
+      // surface a not-loaded link produces — and never retriggers the loader
+      // for them; `getRelationship` is the only way to read the structured
+      // failure from outside this module. HTTP 404 → `link-not-found`, every
+      // other failure → `link-error`.
+      let errorDoc: SerializedError = {
+        ...payloadError,
+        additionalErrors: payloadError.additionalErrors ?? null,
+      };
+      let sentinel: LinkErrorValue | LinkNotFoundValue = isMissingFile
+        ? { type: 'link-not-found', reference, errorDoc }
+        : { type: 'link-error', reference, errorDoc };
+      if (pluralArgs) {
+        // Swap the sentinel into the slot(s) whose reference just failed,
+        // leaving the WatchedArray identity intact so Glimmer re-renders. We
+        // match the same not-loaded entries the success path would have
+        // replaced with the loaded card.
+        let { value } = pluralArgs;
+        for (let [index, item] of value.entries()) {
+          if (!isNotLoadedValue(item)) {
+            continue;
+          }
+          let notLoadedRef = resolveCardReference(
+            item.reference,
+            instance.id ?? instance[relativeTo],
+          );
+          if (reference === notLoadedRef) {
+            value[index] = sentinel;
+          }
+        }
+      } else {
+        getDataBucket(instance).set(field.name, sentinel);
+        notifyCardTracking(instance);
+      }
+
       let payload = JSON.stringify({
         type: 'error',
         error: payloadError,
@@ -3420,7 +3486,7 @@ function trackRuntimeRelationshipDependency(
   declaredCard: LinkableDefConstructor,
   dependencyTrackingContext?: RuntimeDependencyTrackingContext,
 ): void {
-  if (!value || isNotLoadedValue(value)) {
+  if (!value || isNonPresentLink(value)) {
     return;
   }
   let id = (value as { id?: unknown }).id;

--- a/packages/host/tests/integration/components/linksto-error-sentinel-test.gts
+++ b/packages/host/tests/integration/components/linksto-error-sentinel-test.gts
@@ -1,0 +1,351 @@
+import { render, waitUntil } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import {
+  baseRealm,
+  PermissionsContextName,
+  type LooseCardResource,
+  type Permissions,
+  type SerializedError,
+} from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import type { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
+import type { RelationshipState } from 'https://cardstack.com/base/card-api';
+import type * as FieldSupportModule from 'https://cardstack.com/base/field-support';
+
+import {
+  provideConsumeContext,
+  setupCardLogs,
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  testRealmURL,
+  testRRI,
+} from '../../helpers';
+import {
+  CardDef,
+  contains,
+  field,
+  getDataBucket,
+  getRelationship,
+  linksTo,
+  linksToMany,
+  setupBaseRealm,
+  StringField,
+} from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+// A terminal sentinel never escapes the field getter — userland reads
+// `undefined` — so tests read the raw bucket entry to observe the planted
+// shape, and `getRelationship` to observe the structured failure.
+function bucketEntry(instance: CardDefType, fieldName: string): any {
+  return getDataBucket(instance).get(fieldName);
+}
+
+function singularState(
+  state: RelationshipState | RelationshipState[],
+): RelationshipState {
+  if (Array.isArray(state)) {
+    throw new Error('expected a singular relationship state');
+  }
+  return state;
+}
+
+// The base-realm helpers (CardDef, field, …) are only populated once
+// `setupBaseRealm` has run, so cards must be declared inside a test rather than
+// at module scope.
+function makeCards() {
+  class Pet extends CardDef {
+    @field firstName = contains(StringField);
+  }
+  class Person extends CardDef {
+    @field firstName = contains(StringField);
+    @field pet = linksTo(Pet);
+    @field pets = linksToMany(Pet);
+  }
+  return { Person, Pet };
+}
+
+// Build a Person instance attached to the realm-backed store *without*
+// indexing it, so reading a relationship drives the real lazilyLoadLink fetch
+// (and its failure path) rather than surfacing a persisted error doc.
+async function createPerson(
+  relationships: LooseCardResource['relationships'],
+): Promise<CardDefType & { pet: unknown; pets: unknown }> {
+  let store = getService('store');
+  let resource: LooseCardResource = {
+    attributes: { firstName: 'Hassan' },
+    relationships,
+    meta: { adoptsFrom: { module: testRRI('test-cards'), name: 'Person' } },
+  };
+  return (await store.__dangerousCreateFromSerialized(
+    resource,
+    { data: resource },
+    new URL(testRealmURL),
+  )) as CardDefType & { pet: unknown; pets: unknown };
+}
+
+let loader: Loader;
+let isLinkError: (typeof FieldSupportModule)['isLinkError'];
+let isLinkNotFound: (typeof FieldSupportModule)['isLinkNotFound'];
+
+module('Integration | linksTo error sentinel producer', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  hooks.beforeEach(async function () {
+    let permissions: Permissions = { canWrite: true, canRead: true };
+    provideConsumeContext(PermissionsContextName, permissions);
+    loader = getService('loader-service').loader;
+    let fieldSupport = await loader.import<typeof FieldSupportModule>(
+      `${baseRealm.url}field-support`,
+    );
+    isLinkError = fieldSupport.isLinkError;
+    isLinkNotFound = fieldSupport.isLinkNotFound;
+  });
+
+  setupCardLogs(
+    hooks,
+    async () => await loader.import(`${baseRealm.url}card-api`),
+  );
+
+  // Realm holds the Person/Pet module and one real Pet, but never `Pet/ghost`
+  // — links to it resolve to a 404.
+  async function setupRealm() {
+    let { Person, Pet } = makeCards();
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'test-cards.gts': { Person, Pet },
+        'Pet/mango.json': {
+          data: {
+            attributes: { firstName: 'Mango' },
+            meta: {
+              adoptsFrom: { module: testRRI('test-cards'), name: 'Pet' },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  test('a 404 lazy-load failure plants a link-not-found sentinel in the data bucket', async function (assert) {
+    await setupRealm();
+
+    let renderErrors: string[] = [];
+    let onRenderError = (e: Event) => {
+      renderErrors.push((e as CustomEvent).detail.reason);
+    };
+    globalThis.addEventListener('boxel-render-error', onRenderError);
+
+    try {
+      let person = await createPerson({
+        pet: { links: { self: `${testRealmURL}Pet/ghost` } },
+      });
+
+      // reading the field kicks off the lazy load
+      assert.strictEqual(
+        person.pet,
+        undefined,
+        'a not-yet-resolved broken link reads as undefined',
+      );
+
+      await waitUntil(() => isLinkNotFound(bucketEntry(person, 'pet')));
+
+      let sentinel = bucketEntry(person, 'pet');
+      assert.true(
+        isLinkNotFound(sentinel),
+        'bucket holds a link-not-found sentinel after the 404',
+      );
+      assert.strictEqual(
+        sentinel.reference,
+        `${testRealmURL}Pet/ghost`,
+        'sentinel preserves the broken reference',
+      );
+      assert.strictEqual(
+        (sentinel.errorDoc as SerializedError).status,
+        404,
+        'errorDoc status is 404',
+      );
+
+      // `undefined` is the same nullish surface a not-loaded link produces, so
+      // existing `== null` consumer checks keep working unchanged.
+      assert.strictEqual(
+        person.pet,
+        undefined,
+        'the field getter surfaces the terminal sentinel as undefined',
+      );
+
+      let state = singularState(getRelationship(person, 'pet'));
+      assert.strictEqual(state.kind, 'not-found', 'getRelationship kind');
+      if (state.kind === 'not-found') {
+        assert.strictEqual(
+          state.reference,
+          `${testRealmURL}Pet/ghost`,
+          'getRelationship reference',
+        );
+        assert.true(
+          state.isError,
+          'getRelationship marks the state as an error',
+        );
+        assert.strictEqual(
+          state.errorDoc.status,
+          404,
+          'getRelationship carries the errorDoc',
+        );
+      }
+
+      assert.ok(
+        renderErrors.length > 0,
+        'boxel-render-error dispatch still fires',
+      );
+    } finally {
+      globalThis.removeEventListener('boxel-render-error', onRenderError);
+    }
+  });
+
+  test('reading a broken link repeatedly does not refetch (terminal sentinel)', async function (assert) {
+    await setupRealm();
+    let person = await createPerson({
+      pet: { links: { self: `${testRealmURL}Pet/ghost` } },
+    });
+
+    person.pet;
+    await waitUntil(() => isLinkNotFound(bucketEntry(person, 'pet')));
+    let firstSentinel = bucketEntry(person, 'pet');
+
+    // Three more reads must not replace the sentinel — a terminal state never
+    // retriggers lazilyLoadLink.
+    person.pet;
+    person.pet;
+    person.pet;
+    await new Promise((r) => setTimeout(r, 50));
+
+    assert.strictEqual(
+      bucketEntry(person, 'pet'),
+      firstSentinel,
+      'bucket entry is the same sentinel object — no refetch was kicked off',
+    );
+  });
+
+  test('a permanently-broken link converges in at most two renders', async function (assert) {
+    await setupRealm();
+    let person = await createPerson({
+      pet: { links: { self: `${testRealmURL}Pet/ghost` } },
+    });
+
+    let renderCount = 0;
+    let bump = () => {
+      renderCount++;
+      return '';
+    };
+    // Reading `person.pet` drives the lazy load (and entangles card tracking),
+    // so the template re-renders once when the sentinel lands. `getRelationship`
+    // reports the resulting state without itself scheduling a render.
+    let petKind = () => {
+      void person.pet;
+      return singularState(getRelationship(person, 'pet')).kind;
+    };
+
+    await render(
+      <template>
+        <span>{{bump}}</span>
+        <span data-test-kind>{{petKind}}</span>
+      </template>,
+    );
+    await waitUntil(() => isLinkNotFound(bucketEntry(person, 'pet')));
+
+    assert.dom('[data-test-kind]').hasText('not-found');
+    assert.ok(
+      renderCount <= 2,
+      `card with a permanently-broken linksTo converged in ${renderCount} render(s) (initial + post-lazy-load)`,
+    );
+  });
+
+  test('the singular getter recognizes a hand-planted link-error sentinel and returns undefined', async function (assert) {
+    await setupRealm();
+    let person = await createPerson({});
+
+    let sentinel = {
+      type: 'link-error' as const,
+      reference: `${testRealmURL}Pet/exploded`,
+      errorDoc: {
+        status: 500,
+        message: 'upstream exploded',
+        additionalErrors: null,
+      } satisfies SerializedError,
+    };
+    getDataBucket(person).set('pet', sentinel);
+
+    assert.strictEqual(
+      person.pet,
+      undefined,
+      'a link-error sentinel surfaces as undefined to userland',
+    );
+    assert.strictEqual(
+      bucketEntry(person, 'pet'),
+      sentinel,
+      'reading the field does not retrigger the loader for a link-error',
+    );
+    assert.true(isLinkError(bucketEntry(person, 'pet')));
+
+    let state = singularState(getRelationship(person, 'pet'));
+    assert.strictEqual(state.kind, 'error');
+    if (state.kind === 'error') {
+      assert.strictEqual(state.reference, `${testRealmURL}Pet/exploded`);
+    }
+  });
+
+  test('a plural lazy-load failure swaps the sentinel into the failed slot in place', async function (assert) {
+    await setupRealm();
+    let person = await createPerson({
+      'pets.0': { links: { self: `${testRealmURL}Pet/mango` } },
+      'pets.1': { links: { self: `${testRealmURL}Pet/ghost` } },
+    });
+
+    // reading the field kicks off the lazy loads for both slots
+    person.pets;
+    let arrayBefore = getDataBucket(person).get('pets');
+
+    // Both slots load concurrently; wait until neither is still in-flight so
+    // the good slot has resolved to a card and the broken one to a sentinel.
+    await waitUntil(() => {
+      let arr = getDataBucket(person).get('pets');
+      if (!Array.isArray(arr)) {
+        return false;
+      }
+      let stillLoading = arr.some(
+        (e: any) => e?.type === 'not-loaded' || e?.loading,
+      );
+      return !stillLoading && arr.some((e: any) => isLinkNotFound(e));
+    });
+
+    let arrayAfter = getDataBucket(person).get('pets');
+    assert.strictEqual(
+      arrayBefore,
+      arrayAfter,
+      'WatchedArray identity is preserved — the sentinel was swapped in place',
+    );
+
+    let states = getRelationship(person, 'pets');
+    if (!Array.isArray(states)) {
+      throw new Error('expected plural relationship states');
+    }
+    let kinds = states.map((s) => s.kind).sort();
+    assert.deepEqual(
+      kinds,
+      ['not-found', 'present'],
+      'the good slot stays present while the broken slot becomes not-found',
+    );
+  });
+});

--- a/packages/host/tests/integration/components/linksto-error-sentinel-test.gts
+++ b/packages/host/tests/integration/components/linksto-error-sentinel-test.gts
@@ -34,6 +34,8 @@ import {
   linksToMany,
   setupBaseRealm,
   StringField,
+  subscribeToChanges,
+  unsubscribeFromChanges,
 } from '../../helpers/base-realm';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupRenderingTest } from '../../helpers/setup';
@@ -303,6 +305,34 @@ module('Integration | linksTo error sentinel producer', function (hooks) {
     assert.strictEqual(state.kind, 'error');
     if (state.kind === 'error') {
       assert.strictEqual(state.reference, `${testRealmURL}Pet/exploded`);
+    }
+  });
+
+  test('a failed singular lazy load notifies change subscribers with the sentinel', async function (assert) {
+    await setupRealm();
+    let person = await createPerson({
+      pet: { links: { self: `${testRealmURL}Pet/ghost` } },
+    });
+
+    let changes: Array<{ fieldName: string; value: unknown }> = [];
+    let subscriber = (_instance: unknown, fieldName: string, value: unknown) =>
+      changes.push({ fieldName, value });
+    subscribeToChanges(person, subscriber);
+
+    try {
+      // trigger the lazy load that will fail
+      person.pet;
+      await waitUntil(() => isLinkNotFound(bucketEntry(person, 'pet')));
+
+      let petChange = changes.find(
+        (c) => c.fieldName === 'pet' && isLinkNotFound(c.value),
+      );
+      assert.ok(
+        petChange,
+        'subscribeToChanges listeners observe the failed lazy load — change propagation matches a successful load',
+      );
+    } finally {
+      unsubscribeFromChanges(person, subscriber);
     }
   });
 


### PR DESCRIPTION
## Summary

`lazilyLoadLink`'s failure path now plants a typed `link-error` / `link-not-found` sentinel into the data bucket (singular) or the failed array slot (plural), replacing the legacy `(instance as any)[field.name] = null` write.

- HTTP 404 → `{ type: 'link-not-found', reference, errorDoc }`; every other failure → `{ type: 'link-error', reference, errorDoc }`. `errorDoc` is built from the existing `CardError`-shaped payload.
- The singular and plural field getters recognize the new sentinels and return `undefined` to userland — the same nullish surface a not-loaded link produces — and never retrigger the loader. A permanently-broken link is terminal and converges in two renders (initial + post-lazy-load).
- The sentinel never escapes the getter; `getRelationship` (from the parent PR) is the only way to read the structured failure.
- For the plural case the sentinel is swapped into the failed slot in place, so the `WatchedArray` identity is preserved and Glimmer re-renders.

Bucket consumers that can now observe a sentinel — `serialize`, `queryableValue`, `validate`, the search-doc loop, and dependency tracking — treat the terminal states like a not-loaded link, preserving the broken reference rather than dropping it.

The `boxel-render-error` CustomEvent dispatch still fires (its removal is tracked under CS-11269), so indexer-side `error_doc` capture is unchanged.

Stacked on #4968 (CS-11224, `getRelationship`). Base will retarget to `main` once the parent merges.

Ticket: [CS-11218](https://linear.app/cardstack/issue/CS-11218)

## Test plan

New `tests/integration/components/linksto-error-sentinel-test.gts` (5/5 passing locally):

- a 404 lazy-load failure plants a `link-not-found` sentinel in the bucket; the getter reads `undefined`, `getRelationship` reports `not-found` with the reference + `errorDoc`, and the dispatch still fires
- reading a broken link repeatedly does not refetch (terminal sentinel identity preserved)
- a permanently-broken link converges in ≤2 renders
- the singular getter recognizes a hand-planted `link-error` sentinel and returns `undefined`
- a plural lazy-load failure swaps the sentinel into the failed slot in place (array identity preserved; good slots stay `present`)

Regression suites green locally: `realm indexing: can recover from indexing a card with a broken link`, `getRelationship` (21), `linksTo sentinel predicates` (5), `serialization` (107), `CardDef-FieldDef relationships` (7), `operator-mode | links` (24). `pnpm lint:types` and `pnpm lint:js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
