### PR TITLE
fix(ci): build @cardstack/boxel-ui before host in boxel-cli publish

### DIFF
--- a/.github/workflows/boxel-cli-publish.yml
+++ b/.github/workflows/boxel-cli-publish.yml
@@ -344,8 +344,8 @@ jobs:
           # See the unstable job's "Publish to npm" step for the full
           # rationale on the dep ordering — `build:test-harness` reads from
           # `packages/host/dist/`, so the host's dev bundle has to exist
-          # before we can build the slim harness, and the host's vite build
-          # in turn needs `@cardstack/boxel-ui`'s `dist/`, which itself
+          # before we can build the bundled test harness, and the host's vite
+          # build in turn needs `@cardstack/boxel-ui`'s `dist/`, which itself
           # needs `@cardstack/boxel-icons`'s `declarations/` for its type
           # build. Plain `pnpm --filter <name>` does NOT include workspace
           # deps, so they have to be built explicitly.

--- a/.github/workflows/boxel-cli-publish.yml
+++ b/.github/workflows/boxel-cli-publish.yml
@@ -240,6 +240,12 @@ jobs:
           # because production strips the test entry (`tests/index.html`)
           # entirely. Only sourcemaps are dropped; the resulting harness
           # is ~60MB unpacked / ~15MB compressed.
+          #
+          # Build @cardstack/boxel-ui first: the host's vite build imports
+          # `@cardstack/boxel-ui/styles/global.css`, which resolves to the
+          # addon's `dist/`. Without this the host build fails with
+          # "Rolldown failed to resolve import @cardstack/boxel-ui/styles/global.css".
+          pnpm --filter @cardstack/boxel-ui build
           pnpm --filter @cardstack/host build
           pnpm run build
           # Use --no-git-checks because the workflow's commit + tag is already
@@ -327,7 +333,9 @@ jobs:
           # See the unstable job's "Publish to npm" step for the rationale —
           # `build:test-harness` reads from `packages/host/dist/`, so the
           # host's dev bundle has to exist before we can build the slim
-          # harness.
+          # harness. boxel-ui must be built before host (the host build
+          # imports `@cardstack/boxel-ui/styles/global.css` from its dist/).
+          pnpm --filter @cardstack/boxel-ui build
           pnpm --filter @cardstack/host build
           pnpm build
 

--- a/.github/workflows/boxel-cli-publish.yml
+++ b/.github/workflows/boxel-cli-publish.yml
@@ -241,10 +241,21 @@ jobs:
           # entirely. Only sourcemaps are dropped; the resulting harness
           # is ~60MB unpacked / ~15MB compressed.
           #
-          # Build @cardstack/boxel-ui first: the host's vite build imports
-          # `@cardstack/boxel-ui/styles/global.css`, which resolves to the
-          # addon's `dist/`. Without this the host build fails with
-          # "Rolldown failed to resolve import @cardstack/boxel-ui/styles/global.css".
+          # Build workspace deps in topological order before the host:
+          #   * @cardstack/boxel-icons — boxel-ui's `build:types` resolves
+          #     `@cardstack/boxel-icons/*` against its `declarations/`,
+          #     which only exists after the icons package is built.
+          #   * @cardstack/boxel-ui    — the host's vite build imports
+          #     `@cardstack/boxel-ui/styles/global.css`, which resolves
+          #     to the addon's `dist/`.
+          # Plain `pnpm --filter <name>` does NOT include workspace
+          # dependencies; they must be built explicitly (or with the
+          # `<name>...` syntax). Without this chain the host build fails
+          # with "Rolldown failed to resolve import
+          # @cardstack/boxel-ui/styles/global.css" — and before that,
+          # boxel-ui's own type build can fail on missing boxel-icons
+          # declarations.
+          pnpm --filter @cardstack/boxel-icons build
           pnpm --filter @cardstack/boxel-ui build
           pnpm --filter @cardstack/host build
           pnpm run build
@@ -330,11 +341,15 @@ jobs:
         working-directory: packages/boxel-cli
         run: |
           set -euo pipefail
-          # See the unstable job's "Publish to npm" step for the rationale —
-          # `build:test-harness` reads from `packages/host/dist/`, so the
-          # host's dev bundle has to exist before we can build the slim
-          # harness. boxel-ui must be built before host (the host build
-          # imports `@cardstack/boxel-ui/styles/global.css` from its dist/).
+          # See the unstable job's "Publish to npm" step for the full
+          # rationale on the dep ordering — `build:test-harness` reads from
+          # `packages/host/dist/`, so the host's dev bundle has to exist
+          # before we can build the slim harness, and the host's vite build
+          # in turn needs `@cardstack/boxel-ui`'s `dist/`, which itself
+          # needs `@cardstack/boxel-icons`'s `declarations/` for its type
+          # build. Plain `pnpm --filter <name>` does NOT include workspace
+          # deps, so they have to be built explicitly.
+          pnpm --filter @cardstack/boxel-icons build
           pnpm --filter @cardstack/boxel-ui build
           pnpm --filter @cardstack/host build
           pnpm build


### PR DESCRIPTION
_(Written by Claude on Matic's behalf.)_

## Problem

The boxel-cli publish workflow has been failing on every run since #4914 merged, so npm's `unstable` tag is stuck at `0.3.0-unstable.87` (May 22) while `main` is at `0.3.0-unstable.122`. The published CLI predates the bundled self-contained test harness + Playwright runtime dep, so `boxel test` is unusable from a global install (it errors on a missing host `dist/` and `@playwright/test`).

## Root cause

#4914 added `pnpm --filter @cardstack/host build` to the publish flow (to populate `bundled-test-harness/` from `packages/host/dist/`). The host's vite build imports `@cardstack/boxel-ui/styles/global.css`, which resolves to the **boxel-ui addon's `dist/`** — but the workflow never builds boxel-ui, so the host build fails:

```
⚠️  Boxel-UI dist directory not found. Run "pnpm build" in packages/boxel-ui/addon first.
Error: [vite]: Rolldown failed to resolve import "@cardstack/boxel-ui/styles/global.css" from ".../packages/host/app/app.ts"
[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] @cardstack/host@0.0.0 build: `vite build --mode=development`
```

This bites both publish paths: the `unstable` "Publish to npm" step and the `stable` "Build boxel-cli" step. (Pre-#4914 publishes never built the host, so this prerequisite never mattered.)

## Fix

Build `@cardstack/boxel-ui` before the host build in both steps. Verified locally that `@cardstack/boxel-ui/styles/global.css` resolves to `packages/boxel-ui/addon/dist/styles/global.css`, which boxel-ui's build produces.

## After merge

`main`'s package.json is already bumped to `0.3.0-unstable.122` from #4914's run (the bump committed; only the publish failed). Re-running the promote workflow — or any boxel-cli `feat:`/`fix:` merge — will now get through the build and actually publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)