### PR TITLE
Add pr-comment-attribution skill

### DIFF
--- a/.claude/skills/pr-comment-attribution/SKILL.md
+++ b/.claude/skills/pr-comment-attribution/SKILL.md
@@ -23,9 +23,10 @@ Every PR comment the agent posts, with no exceptions:
 
 …across whichever tool posts it:
 
-- `gh pr comment`
+- `gh pr comment` (top-level issue comment)
+- `gh pr review --comment` / `--approve` / `--request-changes` (review-summary body)
 - `gh api repos/<owner>/<repo>/issues/<n>/comments` and `.../pulls/<n>/comments/<id>/replies`
-- the GitHub MCP tools (`add_reply_to_pull_request_comment`, `add_issue_comment`, etc.)
+- the GitHub MCP tools (`add_reply_to_pull_request_comment`, `add_issue_comment`, `pull_request_review_write`, etc.)
 
 ## Example
 

--- a/.claude/skills/pr-comment-attribution/SKILL.md
+++ b/.claude/skills/pr-comment-attribution/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: pr-comment-attribution
+description: Prefix every PR comment the agent posts with the literal "[Claude Code 🤖]" marker so reviewers can tell the agent's replies apart from the account owner's own. Use whenever posting a PR review-thread reply, an inline review comment, or a top-level issue comment on a PR — via gh pr comment, gh api .../comments, or the GitHub MCP comment tools.
+---
+
+# PR Comment Attribution
+
+The agent posts PR comments under the human account owner's GitHub identity. Without a marker, reviewers cannot tell an agent-authored reply from one the account owner wrote themselves. Every comment the agent posts therefore **begins with the literal prefix**:
+
+```
+[Claude Code 🤖]
+```
+
+Exactly that — square brackets, the words `Claude Code`, a space, the robot emoji. Same capitalization and spacing every time.
+
+## Where it applies
+
+Every PR comment the agent posts, with no exceptions:
+
+- **Per-thread inline replies** on review comments
+- **Top-level issue comments** on a PR
+- **Review-summary bodies**
+
+…across whichever tool posts it:
+
+- `gh pr comment`
+- `gh api repos/<owner>/<repo>/issues/<n>/comments` and `.../pulls/<n>/comments/<id>/replies`
+- the GitHub MCP tools (`add_reply_to_pull_request_comment`, `add_issue_comment`, etc.)
+
+## Example
+
+```
+[Claude Code 🤖] Good catch — fixed in abc1234. The endpoint now validates
+the token before reading the body, so the unauthenticated path can't reach
+the parser.
+```
+
+## Self-check
+
+Before sending any PR comment: does the body start with `[Claude Code 🤖]`? If not, prepend it. The prefix leads the comment — it is the first thing in the body, not buried mid-paragraph.


### PR DESCRIPTION
Adds a `pr-comment-attribution` Claude Code skill under `.claude/skills/`, so the convention ships to the team on checkout and is invocable as `/pr-comment-attribution`.

The agent posts PR comments under the account owner's GitHub identity, which makes agent-authored replies indistinguishable from the owner's own. The skill requires every PR comment the agent posts to begin with the literal prefix `[Claude Code 🤖]` — across inline review replies, top-level issue comments, and review summaries, via `gh pr comment`, `gh api`, or the GitHub MCP comment tools.

Includes an example and a pre-send self-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
