### PR TITLE
Size markdown embedded-card loading and broken-link states to the card

### DIFF
--- a/packages/base/default-templates/markdown.gts
+++ b/packages/base/default-templates/markdown.gts
@@ -5,7 +5,6 @@ import { cached, tracked } from '@glimmer/tracking';
 import { htmlSafe } from '@ember/template';
 import { modifier } from 'ember-modifier';
 
-import { Pill } from '@cardstack/boxel-ui/components';
 import { eq } from '@cardstack/boxel-ui/helpers';
 import LinkOffIcon from '@cardstack/boxel-icons/link-off';
 
@@ -454,27 +453,27 @@ export default class MarkDownTemplate extends GlimmerComponent<{
           {{/if}}
         {{else}}
           {{#if (eq slot.kind 'inline')}}
-            <Pill
-              @variant='muted'
-              @size='extra-small'
+            <span
+              class='markdown-bfm-broken markdown-bfm-broken--inline'
               title={{slot.url}}
               data-test-markdown-bfm-unresolved-inline
             >
-              <:iconLeft><LinkOffIcon width='12' height='12' /></:iconLeft>
-              <:default>{{slot.typeName}}</:default>
-            </Pill>
+              <span class='markdown-bfm-broken-label'>
+                <LinkOffIcon width='12' height='12' />
+                {{slot.typeName}}
+              </span>
+            </span>
           {{else}}
             <div
-              class='markdown-bfm-broken markdown-bfm-broken--{{slot.format}}'
+              class='markdown-bfm-broken markdown-bfm-broken--block
+                markdown-bfm-broken--{{slot.format}}'
               style={{slot.style}}
               title={{slot.url}}
               data-test-markdown-bfm-unresolved-block
             >
               <span class='markdown-bfm-broken-label'>
-                <Pill @variant='muted' @size='small'>
-                  <:iconLeft><LinkOffIcon width='14' height='14' /></:iconLeft>
-                  <:default>{{slot.typeName}}</:default>
-                </Pill>
+                <LinkOffIcon width='14' height='14' />
+                {{slot.typeName}}
               </span>
             </div>
           {{/if}}
@@ -875,14 +874,13 @@ export default class MarkDownTemplate extends GlimmerComponent<{
           }
         }
 
-        /* Broken-link placeholder: card-sized box with a diagonal cross and a
-           centered type-name chip. */
+        /* Broken-link placeholder: a card-sized box with a faint diagonal
+           cross and a centered icon + type-name label (no chip). */
         .markdown-bfm-broken {
           display: flex;
           align-items: center;
           justify-content: center;
           max-width: 100%;
-          margin: var(--boxel-sp-xxxs) 0;
           border: 1px solid var(--md-border);
           border-radius: var(--boxel-border-radius);
           background-color: var(--boxel-light-100);
@@ -902,11 +900,32 @@ export default class MarkDownTemplate extends GlimmerComponent<{
             );
           overflow: hidden;
         }
-        .markdown-bfm-broken-label {
-          position: relative;
-          padding: var(--boxel-sp-5xs);
+        .markdown-bfm-broken--inline {
+          display: inline-flex;
+          min-height: 1.6em;
+          padding: 0 var(--boxel-sp-5xs);
+          vertical-align: middle;
           border-radius: var(--boxel-border-radius-sm);
+        }
+        .markdown-bfm-broken--block {
+          display: flex;
+          margin: var(--boxel-sp-xxxs) 0;
+        }
+        .markdown-bfm-broken-label {
+          display: inline-flex;
+          align-items: center;
+          gap: var(--boxel-sp-5xs);
+          padding: 0 var(--boxel-sp-4xs);
+          /* Match the box fill so the cross does not slice through the text. */
           background-color: var(--boxel-light-100);
+          color: var(--boxel-500);
+          font-size: 0.75rem;
+          font-weight: 500;
+          line-height: 1.5;
+          white-space: nowrap;
+        }
+        .markdown-bfm-broken-label svg {
+          flex: none;
         }
       }
     </style>

--- a/packages/base/default-templates/markdown.gts
+++ b/packages/base/default-templates/markdown.gts
@@ -10,6 +10,7 @@ import { eq } from '@cardstack/boxel-ui/helpers';
 import LinkOffIcon from '@cardstack/boxel-icons/link-off';
 
 import {
+  bfmBlockFormatAndSize,
   cardTypeName,
   extractMermaidBlocks,
   processKatexPlaceholders,
@@ -42,25 +43,21 @@ function wrapTablesHtml(html: string | null | undefined): string {
 }
 
 type CardSlotFormat = 'atom' | 'embedded' | 'fitted' | 'isolated';
+type SlotState = 'resolved' | 'loading' | 'unresolved';
 
-interface ResolvedSlot {
+interface RenderSlot {
   element: HTMLElement;
-  card: CardDef;
+  kind: 'inline' | 'block';
+  state: SlotState;
   format: CardSlotFormat;
-  kind: 'inline' | 'block';
+  // Inline sizing (width/height) so loading and broken placeholders match the
+  // eventual card's footprint; also carries `overflow: hidden` for resolved
+  // fitted cards.
   style?: ReturnType<typeof htmlSafe>;
+  card?: CardDef; // present when state === 'resolved'
+  url?: string; // present when state === 'loading' | 'unresolved'
+  typeName?: string; // present when state === 'unresolved'
 }
-
-interface UnresolvedSlot {
-  element: HTMLElement;
-  url: string;
-  typeName: string;
-  kind: 'inline' | 'block';
-}
-
-type RenderSlot =
-  | (ResolvedSlot & { card: CardDef })
-  | (UnresolvedSlot & { card?: undefined });
 
 function resolveUrl(raw: string, baseUrl: string | null | undefined): string {
   try {
@@ -192,87 +189,74 @@ export default class MarkDownTemplate extends GlimmerComponent<{
         }
 
         let slots: RenderSlot[] = [];
-        let resolvedEls = new Set<HTMLElement>();
 
-        for (let el of Array.from(
-          element.querySelectorAll<HTMLElement>(
-            '[data-boxel-bfm-inline-ref][data-boxel-bfm-type="card"]',
-          ),
-        )) {
-          let rawUrl = el.dataset.boxelBfmInlineRef;
-          if (!rawUrl) continue;
-          let resolved = resolveUrl(rawUrl, baseUrl);
-          let card = cardsByUrl.get(resolved);
-          if (card) {
-            resolvedEls.add(el);
-            slots.push({ element: el, card, format: 'atom', kind: 'inline' });
-          }
-        }
-
-        for (let el of Array.from(
-          element.querySelectorAll<HTMLElement>(
-            '[data-boxel-bfm-block-ref][data-boxel-bfm-type="card"]',
-          ),
-        )) {
-          let rawUrl = el.dataset.boxelBfmBlockRef;
-          if (!rawUrl) continue;
-          let resolved = resolveUrl(rawUrl, baseUrl);
-          let card = cardsByUrl.get(resolved);
-          if (card) {
-            let bfmFormat = el.dataset.boxelBfmFormat;
-            let format: CardSlotFormat =
-              bfmFormat === 'fitted' || bfmFormat === 'isolated'
-                ? bfmFormat
-                : 'embedded';
-
-            let style: ReturnType<typeof htmlSafe> | undefined;
-            if (format === 'fitted') {
-              let w = el.dataset.boxelBfmWidth;
-              let h = el.dataset.boxelBfmHeight;
-              let parts: string[] = [];
-              if (w && /^\d+%$/.test(w)) {
-                parts.push(`width: ${w}`);
-              } else if (w && /^\d+$/.test(w)) {
-                parts.push(`width: ${w}px`);
-              }
-              if (h && /^\d+$/.test(h)) {
-                parts.push(`height: ${h}px`);
-              }
-              parts.push('overflow: hidden');
-              style = htmlSafe(parts.join('; '));
-            }
-
-            resolvedEls.add(el);
-            slots.push({
-              element: el,
-              card,
-              format,
-              kind: 'block',
-              style,
-            });
-          }
-        }
-
-        // Build unresolved slots for card refs that could not be matched to a
-        // linkedCard. Skipped on the first modifier run (showFallback=false)
-        // to avoid flashing Pills while linkedCards is still loading.
-        if (!showFallback) return slots;
         for (let el of Array.from(
           element.querySelectorAll<HTMLElement>(
             '[data-boxel-bfm-type="card"]',
           ),
         )) {
-          let url =
-            el.dataset.boxelBfmInlineRef || el.dataset.boxelBfmBlockRef || '';
-          if (!resolvedEls.has(el) && url) {
-            let kind: 'inline' | 'block' = el.dataset.boxelBfmInlineRef
-              ? 'inline'
-              : 'block';
+          let isInline = !!el.dataset.boxelBfmInlineRef;
+          let rawUrl =
+            el.dataset.boxelBfmInlineRef ?? el.dataset.boxelBfmBlockRef ?? '';
+          if (!rawUrl) continue;
+          let kind: 'inline' | 'block' = isInline ? 'inline' : 'block';
+
+          let format: CardSlotFormat = 'atom';
+          let sizeStyle: string | undefined;
+          if (!isInline) {
+            let derived = bfmBlockFormatAndSize(
+              el.dataset.boxelBfmFormat,
+              el.dataset.boxelBfmWidth,
+              el.dataset.boxelBfmHeight,
+            );
+            format = derived.format;
+            sizeStyle = derived.sizeStyle;
+          }
+
+          let card = cardsByUrl.get(resolveUrl(rawUrl, baseUrl));
+          if (card) {
+            let style: ReturnType<typeof htmlSafe> | undefined;
+            if (format === 'fitted') {
+              style = htmlSafe(
+                sizeStyle
+                  ? `${sizeStyle}; overflow: hidden`
+                  : 'overflow: hidden',
+              );
+            }
             slots.push({
               element: el,
-              url,
-              typeName: cardTypeName(url),
               kind,
+              state: 'resolved',
+              format,
+              card,
+              style,
+            });
+            continue;
+          }
+
+          // No matching linkedCard yet: show the sized loading shimmer until
+          // linkedCards has settled (showFallback), then fall back to the
+          // broken-link box. Skipping the broken state on the first modifier
+          // run avoids flashing it for refs that will soon resolve.
+          let style = sizeStyle ? htmlSafe(sizeStyle) : undefined;
+          if (!showFallback) {
+            slots.push({
+              element: el,
+              kind,
+              state: 'loading',
+              format,
+              style,
+              url: rawUrl,
+            });
+          } else {
+            slots.push({
+              element: el,
+              kind,
+              state: 'unresolved',
+              format,
+              style,
+              url: rawUrl,
+              typeName: cardTypeName(rawUrl),
             });
           }
         }
@@ -293,24 +277,11 @@ export default class MarkDownTemplate extends GlimmerComponent<{
             let current = this.renderSlots[index];
             if (!current || current.element !== slot.element) return true;
             if (current.kind !== slot.kind) return true;
-            // Resolved ↔ unresolved transition
-            if (!!current.card !== !!slot.card) return true;
-            if (current.card && slot.card) {
-              return (
-                current.card !== slot.card ||
-                (current as ResolvedSlot).format !==
-                  (slot as ResolvedSlot).format ||
-                String((current as ResolvedSlot).style ?? '') !==
-                  String((slot as ResolvedSlot).style ?? '')
-              );
-            }
-            if (!current.card && !slot.card) {
-              return (
-                (current as UnresolvedSlot).url !==
-                (slot as UnresolvedSlot).url
-              );
-            }
-            return false;
+            if (current.state !== slot.state) return true;
+            if (current.format !== slot.format) return true;
+            if (current.card !== slot.card) return true;
+            if (current.url !== slot.url) return true;
+            return String(current.style ?? '') !== String(slot.style ?? '');
           });
 
         if (didChange) {
@@ -425,7 +396,7 @@ export default class MarkDownTemplate extends GlimmerComponent<{
     </div>
     {{#each this.renderSlots key="element" as |slot|}}
       {{#in-element slot.element insertBefore=null}}
-        {{#if slot.card}}
+        {{#if (eq slot.state 'resolved')}}
           <CardContextConsumer as |context|>
             {{#let (this.getCardComponent slot.card) as |CardComponent|}}
               {{#if (eq slot.kind 'inline')}}
@@ -465,6 +436,22 @@ export default class MarkDownTemplate extends GlimmerComponent<{
               {{/if}}
             {{/let}}
           </CardContextConsumer>
+        {{else if (eq slot.state 'loading')}}
+          {{#if (eq slot.kind 'inline')}}
+            <span
+              class='markdown-bfm-loading markdown-bfm-loading--inline'
+              aria-hidden='true'
+              data-test-markdown-bfm-loading-inline
+            />
+          {{else}}
+            <div
+              class='markdown-bfm-loading markdown-bfm-loading--block
+                markdown-bfm-loading--{{slot.format}}'
+              style={{slot.style}}
+              aria-hidden='true'
+              data-test-markdown-bfm-loading-block
+            />
+          {{/if}}
         {{else}}
           {{#if (eq slot.kind 'inline')}}
             <Pill
@@ -478,14 +465,17 @@ export default class MarkDownTemplate extends GlimmerComponent<{
             </Pill>
           {{else}}
             <div
-              class='markdown-bfm-unresolved--block'
+              class='markdown-bfm-broken markdown-bfm-broken--{{slot.format}}'
+              style={{slot.style}}
               title={{slot.url}}
               data-test-markdown-bfm-unresolved-block
             >
-              <Pill @variant='muted' @size='small'>
-                <:iconLeft><LinkOffIcon width='14' height='14' /></:iconLeft>
-                <:default>{{slot.typeName}}</:default>
-              </Pill>
+              <span class='markdown-bfm-broken-label'>
+                <Pill @variant='muted' @size='small'>
+                  <:iconLeft><LinkOffIcon width='14' height='14' /></:iconLeft>
+                  <:default>{{slot.typeName}}</:default>
+                </Pill>
+              </span>
             </div>
           {{/if}}
         {{/if}}
@@ -825,14 +815,45 @@ export default class MarkDownTemplate extends GlimmerComponent<{
           border-radius: var(--boxel-border-radius);
         }
 
+        /* Placeholder footprint shared by loading + broken states. The
+           default block sizes approximate the eventual card so the layout does
+           not jump when the card resolves; explicit fitted dimensions arrive
+           as an inline style that overrides these. */
+        .markdown-bfm-loading--embedded,
+        .markdown-bfm-broken--embedded {
+          width: 100%;
+          min-height: 9.375rem;
+        }
+        .markdown-bfm-loading--isolated,
+        .markdown-bfm-broken--isolated {
+          width: 100%;
+          min-height: 18.75rem;
+        }
+        .markdown-bfm-loading--fitted,
+        .markdown-bfm-broken--fitted {
+          width: 15.625rem;
+          height: 10.625rem;
+        }
+
         /* Loading shimmer for card refs before content is rendered */
-        .markdown-content :deep([data-boxel-bfm-type='card']:empty) {
-          background-color: var(--boxel-light-200);
-          border-radius: var(--boxel-border-radius-sm);
+        .markdown-bfm-loading {
           position: relative;
           overflow: hidden;
+          max-width: 100%;
+          background-color: var(--boxel-light-200);
+          border-radius: var(--boxel-border-radius);
         }
-        .markdown-content :deep([data-boxel-bfm-type='card']:empty::after) {
+        .markdown-bfm-loading--inline {
+          display: inline-block;
+          width: 6em;
+          height: 1.2em;
+          vertical-align: middle;
+          border-radius: var(--boxel-border-radius-sm);
+        }
+        .markdown-bfm-loading--block {
+          display: block;
+        }
+        .markdown-bfm-loading::after {
           content: '';
           position: absolute;
           inset: 0;
@@ -842,21 +863,8 @@ export default class MarkDownTemplate extends GlimmerComponent<{
             var(--boxel-light-100),
             transparent
           );
-          animation: bfm-shimmer 1.6s linear 0.5s infinite;
           transform: translateX(-100%);
-        }
-        /* Inline shimmer sizing */
-        .markdown-content :deep([data-boxel-bfm-inline-ref]:empty) {
-          display: inline-block;
-          width: 6em;
-          height: 1.2em;
-          vertical-align: middle;
-        }
-        /* Block shimmer sizing */
-        .markdown-content :deep([data-boxel-bfm-block-ref]:empty) {
-          display: block;
-          width: 100%;
-          height: 3em;
+          animation: bfm-shimmer 1.6s linear 0.5s infinite;
         }
         @keyframes bfm-shimmer {
           0% {
@@ -867,10 +875,38 @@ export default class MarkDownTemplate extends GlimmerComponent<{
           }
         }
 
-        /* Unresolved block indicator */
-        .markdown-bfm-unresolved--block {
-          display: block;
+        /* Broken-link placeholder: card-sized box with a diagonal cross and a
+           centered type-name chip. */
+        .markdown-bfm-broken {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          max-width: 100%;
           margin: var(--boxel-sp-xxxs) 0;
+          border: 1px solid var(--md-border);
+          border-radius: var(--boxel-border-radius);
+          background-color: var(--boxel-light-100);
+          background-image: linear-gradient(
+              to top right,
+              transparent calc(50% - 0.5px),
+              var(--md-border) calc(50% - 0.5px),
+              var(--md-border) calc(50% + 0.5px),
+              transparent calc(50% + 0.5px)
+            ),
+            linear-gradient(
+              to bottom right,
+              transparent calc(50% - 0.5px),
+              var(--md-border) calc(50% - 0.5px),
+              var(--md-border) calc(50% + 0.5px),
+              transparent calc(50% + 0.5px)
+            );
+          overflow: hidden;
+        }
+        .markdown-bfm-broken-label {
+          position: relative;
+          padding: var(--boxel-sp-5xs);
+          border-radius: var(--boxel-border-radius-sm);
+          background-color: var(--boxel-light-100);
         }
       }
     </style>

--- a/packages/host/app/components/operator-mode/preview-panel/rendered-markdown.gts
+++ b/packages/host/app/components/operator-mode/preview-panel/rendered-markdown.gts
@@ -19,7 +19,6 @@ import Modifier from 'ember-modifier';
 import { modifier } from 'ember-modifier';
 import { consume } from 'ember-provide-consume-context';
 
-import { Pill } from '@cardstack/boxel-ui/components';
 import { eq } from '@cardstack/boxel-ui/helpers';
 
 import {
@@ -348,27 +347,26 @@ export default class RenderedMarkdown extends Component<Signature> {
           {{/if}}
         {{else}}
           {{#if (eq slot.kind 'inline')}}
-            <Pill
-              @variant='muted'
-              @size='extra-small'
+            <span
+              class='markdown-bfm-broken markdown-bfm-broken--inline'
               title={{slot.url}}
               data-test-markdown-bfm-unresolved-inline
             >
-              <:iconLeft><LinkOffIcon width='12' height='12' /></:iconLeft>
-              <:default>{{slot.typeName}}</:default>
-            </Pill>
+              <span class='markdown-bfm-broken-label'>
+                <LinkOffIcon width='12' height='12' />
+                {{slot.typeName}}
+              </span>
+            </span>
           {{else}}
             <div
-              class='markdown-bfm-broken markdown-bfm-broken--{{slot.format}}'
+              class='markdown-bfm-broken markdown-bfm-broken--block markdown-bfm-broken--{{slot.format}}'
               style={{slot.style}}
               title={{slot.url}}
               data-test-markdown-bfm-unresolved-block
             >
               <span class='markdown-bfm-broken-label'>
-                <Pill @variant='muted' @size='small'>
-                  <:iconLeft><LinkOffIcon width='14' height='14' /></:iconLeft>
-                  <:default>{{slot.typeName}}</:default>
-                </Pill>
+                <LinkOffIcon width='14' height='14' />
+                {{slot.typeName}}
               </span>
             </div>
           {{/if}}
@@ -727,14 +725,13 @@ export default class RenderedMarkdown extends Component<Signature> {
           }
         }
 
-        /* Broken-link placeholder: card-sized box with a diagonal cross and a
-           centered type-name chip. */
+        /* Broken-link placeholder: a card-sized box with a faint diagonal
+           cross and a centered icon + type-name label (no chip). */
         .markdown-bfm-broken {
           display: flex;
           align-items: center;
           justify-content: center;
           max-width: 100%;
-          margin: var(--boxel-sp-xxxs) 0;
           border: 1px solid var(--md-border);
           border-radius: var(--boxel-border-radius);
           background-color: var(--boxel-light-100);
@@ -755,11 +752,32 @@ export default class RenderedMarkdown extends Component<Signature> {
             );
           overflow: hidden;
         }
-        .markdown-bfm-broken-label {
-          position: relative;
-          padding: var(--boxel-sp-5xs);
+        .markdown-bfm-broken--inline {
+          display: inline-flex;
+          min-height: 1.6em;
+          padding: 0 var(--boxel-sp-5xs);
+          vertical-align: middle;
           border-radius: var(--boxel-border-radius-sm);
+        }
+        .markdown-bfm-broken--block {
+          display: flex;
+          margin: var(--boxel-sp-xxxs) 0;
+        }
+        .markdown-bfm-broken-label {
+          display: inline-flex;
+          align-items: center;
+          gap: var(--boxel-sp-5xs);
+          padding: 0 var(--boxel-sp-4xs);
+          /* Match the box fill so the cross does not slice through the text. */
           background-color: var(--boxel-light-100);
+          color: var(--boxel-500);
+          font-size: 0.75rem;
+          font-weight: 500;
+          line-height: 1.5;
+          white-space: nowrap;
+        }
+        .markdown-bfm-broken-label svg {
+          flex: none;
         }
       } /* end @layer baseComponent */
     </style>

--- a/packages/host/app/components/operator-mode/preview-panel/rendered-markdown.gts
+++ b/packages/host/app/components/operator-mode/preview-panel/rendered-markdown.gts
@@ -23,6 +23,7 @@ import { Pill } from '@cardstack/boxel-ui/components';
 import { eq } from '@cardstack/boxel-ui/helpers';
 
 import {
+  bfmBlockFormatAndSize,
   CardContextName,
   cardTypeName,
   extractCardReferenceUrls,
@@ -39,25 +40,21 @@ import type StoreService from '@cardstack/host/services/store';
 import type { CardContext, CardDef } from 'https://cardstack.com/base/card-api';
 
 type CardSlotFormat = 'atom' | 'embedded' | 'fitted' | 'isolated';
+type SlotState = 'resolved' | 'loading' | 'unresolved';
 
-interface ResolvedSlot {
+interface RenderSlot {
   element: HTMLElement;
-  card: CardDef;
+  kind: 'inline' | 'block';
+  state: SlotState;
   format: CardSlotFormat;
-  kind: 'inline' | 'block';
+  // Inline sizing (width/height) so loading and broken placeholders match the
+  // eventual card's footprint; also carries `overflow: hidden` for resolved
+  // fitted cards.
   style?: ReturnType<typeof htmlSafe>;
+  card?: CardDef; // present when state === 'resolved'
+  url?: string; // present when state === 'loading' | 'unresolved'
+  typeName?: string; // present when state === 'unresolved'
 }
-
-interface UnresolvedSlot {
-  element: HTMLElement;
-  url: string;
-  typeName: string;
-  kind: 'inline' | 'block';
-}
-
-type RenderSlot =
-  | (ResolvedSlot & { card: CardDef })
-  | (UnresolvedSlot & { card?: undefined });
 
 function resolveUrl(raw: string, baseUrl: string | undefined): string {
   try {
@@ -179,76 +176,63 @@ export default class RenderedMarkdown extends Component<Signature> {
       let collectSlots = (): RenderSlot[] => {
         let cardsByUrl = this.loadedCards;
         let slots: RenderSlot[] = [];
-        let resolvedEls = new Set<HTMLElement>();
 
-        for (let el of Array.from(
-          element.querySelectorAll<HTMLElement>(
-            '[data-boxel-bfm-inline-ref][data-boxel-bfm-type="card"]',
-          ),
-        )) {
-          let rawUrl = el.dataset.boxelBfmInlineRef;
-          if (!rawUrl) continue;
-          let resolved = resolveUrl(rawUrl, baseUrl);
-          let card = cardsByUrl.get(resolved);
-          if (card) {
-            resolvedEls.add(el);
-            slots.push({ element: el, card, format: 'atom', kind: 'inline' });
-          }
-        }
-
-        for (let el of Array.from(
-          element.querySelectorAll<HTMLElement>(
-            '[data-boxel-bfm-block-ref][data-boxel-bfm-type="card"]',
-          ),
-        )) {
-          let rawUrl = el.dataset.boxelBfmBlockRef;
-          if (!rawUrl) continue;
-          let resolved = resolveUrl(rawUrl, baseUrl);
-          let card = cardsByUrl.get(resolved);
-          if (card) {
-            let bfmFormat = el.dataset.boxelBfmFormat;
-            let format: CardSlotFormat =
-              bfmFormat === 'fitted' || bfmFormat === 'isolated'
-                ? bfmFormat
-                : 'embedded';
-
-            let style: ReturnType<typeof htmlSafe> | undefined;
-            if (format === 'fitted') {
-              let w = el.dataset.boxelBfmWidth;
-              let h = el.dataset.boxelBfmHeight;
-              let parts: string[] = [];
-              if (w && /^\d+%$/.test(w)) {
-                parts.push(`width: ${w}`);
-              } else if (w && /^\d+$/.test(w)) {
-                parts.push(`width: ${w}px`);
-              }
-              if (h && /^\d+$/.test(h)) {
-                parts.push(`height: ${h}px`);
-              }
-              parts.push('overflow: hidden');
-              style = htmlSafe(parts.join('; '));
-            }
-
-            resolvedEls.add(el);
-            slots.push({ element: el, card, format, kind: 'block', style });
-          }
-        }
-
-        if (!showFallback) return slots;
         for (let el of Array.from(
           element.querySelectorAll<HTMLElement>('[data-boxel-bfm-type="card"]'),
         )) {
-          let url =
-            el.dataset.boxelBfmInlineRef || el.dataset.boxelBfmBlockRef || '';
-          if (!resolvedEls.has(el) && url) {
-            let kind: 'inline' | 'block' = el.dataset.boxelBfmInlineRef
-              ? 'inline'
-              : 'block';
+          let isInline = !!el.dataset.boxelBfmInlineRef;
+          let rawUrl =
+            el.dataset.boxelBfmInlineRef ?? el.dataset.boxelBfmBlockRef ?? '';
+          if (!rawUrl) continue;
+          let kind: 'inline' | 'block' = isInline ? 'inline' : 'block';
+
+          let format: CardSlotFormat = 'atom';
+          let sizeStyle: string | undefined;
+          if (!isInline) {
+            let derived = bfmBlockFormatAndSize(
+              el.dataset.boxelBfmFormat,
+              el.dataset.boxelBfmWidth,
+              el.dataset.boxelBfmHeight,
+            );
+            format = derived.format;
+            sizeStyle = derived.sizeStyle;
+          }
+
+          let card = cardsByUrl.get(resolveUrl(rawUrl, baseUrl));
+          if (card) {
+            let style: ReturnType<typeof htmlSafe> | undefined;
+            if (format === 'fitted') {
+              style = htmlSafe(
+                sizeStyle
+                  ? `${sizeStyle}; overflow: hidden`
+                  : 'overflow: hidden',
+              );
+            }
+            slots.push({ element: el, kind, state: 'resolved', format, card, style });
+            continue;
+          }
+
+          // No card yet: show the sized loading shimmer until linkedCards has
+          // settled (showFallback), then fall back to the broken-link box.
+          let style = sizeStyle ? htmlSafe(sizeStyle) : undefined;
+          if (!showFallback) {
             slots.push({
               element: el,
-              url,
-              typeName: cardTypeName(url),
               kind,
+              state: 'loading',
+              format,
+              style,
+              url: rawUrl,
+            });
+          } else {
+            slots.push({
+              element: el,
+              kind,
+              state: 'unresolved',
+              format,
+              style,
+              url: rawUrl,
+              typeName: cardTypeName(rawUrl),
             });
           }
         }
@@ -265,20 +249,11 @@ export default class RenderedMarkdown extends Component<Signature> {
             let current = this.renderSlots[index];
             if (!current || current.element !== slot.element) return true;
             if (current.kind !== slot.kind) return true;
-            if (!!current.card !== !!slot.card) return true;
-            if (current.card && slot.card) {
-              return (
-                current.card !== slot.card ||
-                (current as ResolvedSlot).format !==
-                  (slot as ResolvedSlot).format
-              );
-            }
-            if (!current.card && !slot.card) {
-              return (
-                (current as UnresolvedSlot).url !== (slot as UnresolvedSlot).url
-              );
-            }
-            return false;
+            if (current.state !== slot.state) return true;
+            if (current.format !== slot.format) return true;
+            if (current.card !== slot.card) return true;
+            if (current.url !== slot.url) return true;
+            return String(current.style ?? '') !== String(slot.style ?? '');
           });
 
         if (didChange) {
@@ -311,7 +286,7 @@ export default class RenderedMarkdown extends Component<Signature> {
     </div>
     {{#each this.renderSlots key='element' as |slot|}}
       {{#in-element slot.element insertBefore=null}}
-        {{#if slot.card}}
+        {{#if (eq slot.state 'resolved')}}
           {{#if (eq slot.kind 'inline')}}
             <span
               class='markdown-bfm-card-slot markdown-bfm-card-slot--inline'
@@ -349,6 +324,22 @@ export default class RenderedMarkdown extends Component<Signature> {
               />
             </div>
           {{/if}}
+        {{else if (eq slot.state 'loading')}}
+          {{#if (eq slot.kind 'inline')}}
+            <span
+              class='markdown-bfm-loading markdown-bfm-loading--inline'
+              aria-hidden='true'
+              data-test-markdown-bfm-loading-inline
+            />
+          {{else}}
+            <div
+              class='markdown-bfm-loading markdown-bfm-loading--block
+                markdown-bfm-loading--{{slot.format}}'
+              style={{slot.style}}
+              aria-hidden='true'
+              data-test-markdown-bfm-loading-block
+            />
+          {{/if}}
         {{else}}
           {{#if (eq slot.kind 'inline')}}
             <Pill
@@ -362,14 +353,17 @@ export default class RenderedMarkdown extends Component<Signature> {
             </Pill>
           {{else}}
             <div
-              class='markdown-bfm-unresolved--block'
+              class='markdown-bfm-broken markdown-bfm-broken--{{slot.format}}'
+              style={{slot.style}}
               title={{slot.url}}
               data-test-markdown-bfm-unresolved-block
             >
-              <Pill @variant='muted' @size='small'>
-                <:iconLeft><LinkOffIcon width='14' height='14' /></:iconLeft>
-                <:default>{{slot.typeName}}</:default>
-              </Pill>
+              <span class='markdown-bfm-broken-label'>
+                <Pill @variant='muted' @size='small'>
+                  <:iconLeft><LinkOffIcon width='14' height='14' /></:iconLeft>
+                  <:default>{{slot.typeName}}</:default>
+                </Pill>
+              </span>
             </div>
           {{/if}}
         {{/if}}
@@ -667,14 +661,45 @@ export default class RenderedMarkdown extends Component<Signature> {
           border-radius: var(--boxel-border-radius);
         }
 
+        /* Placeholder footprint shared by loading + broken states. The
+           default block sizes approximate the eventual card so the layout does
+           not jump when the card resolves; explicit fitted dimensions arrive
+           as an inline style that overrides these. */
+        .markdown-bfm-loading--embedded,
+        .markdown-bfm-broken--embedded {
+          width: 100%;
+          min-height: 9.375rem;
+        }
+        .markdown-bfm-loading--isolated,
+        .markdown-bfm-broken--isolated {
+          width: 100%;
+          min-height: 18.75rem;
+        }
+        .markdown-bfm-loading--fitted,
+        .markdown-bfm-broken--fitted {
+          width: 15.625rem;
+          height: 10.625rem;
+        }
+
         /* Loading shimmer */
-        .markdown-content :deep([data-boxel-bfm-type='card']:empty) {
-          background-color: var(--boxel-light-200);
-          border-radius: var(--boxel-border-radius-sm);
+        .markdown-bfm-loading {
           position: relative;
           overflow: hidden;
+          max-width: 100%;
+          background-color: var(--boxel-light-200);
+          border-radius: var(--boxel-border-radius);
         }
-        .markdown-content :deep([data-boxel-bfm-type='card']:empty::after) {
+        .markdown-bfm-loading--inline {
+          display: inline-block;
+          width: 6em;
+          height: 1.2em;
+          vertical-align: middle;
+          border-radius: var(--boxel-border-radius-sm);
+        }
+        .markdown-bfm-loading--block {
+          display: block;
+        }
+        .markdown-bfm-loading::after {
           content: '';
           position: absolute;
           inset: 0;
@@ -684,19 +709,8 @@ export default class RenderedMarkdown extends Component<Signature> {
             var(--boxel-light-100),
             transparent
           );
-          animation: bfm-shimmer 1.6s linear 0.5s infinite;
           transform: translateX(-100%);
-        }
-        .markdown-content :deep([data-boxel-bfm-inline-ref]:empty) {
-          display: inline-block;
-          width: 6em;
-          height: 1.2em;
-          vertical-align: middle;
-        }
-        .markdown-content :deep([data-boxel-bfm-block-ref]:empty) {
-          display: block;
-          width: 100%;
-          height: 3em;
+          animation: bfm-shimmer 1.6s linear 0.5s infinite;
         }
         @keyframes bfm-shimmer {
           0% {
@@ -707,10 +721,38 @@ export default class RenderedMarkdown extends Component<Signature> {
           }
         }
 
-        /* Unresolved block indicator */
-        .markdown-bfm-unresolved--block {
-          display: block;
+        /* Broken-link placeholder: card-sized box with a diagonal cross and a
+           centered type-name chip. */
+        .markdown-bfm-broken {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          max-width: 100%;
           margin: var(--boxel-sp-xxxs) 0;
+          border: 1px solid var(--md-border);
+          border-radius: var(--boxel-border-radius);
+          background-color: var(--boxel-light-100);
+          background-image: linear-gradient(
+              to top right,
+              transparent calc(50% - 0.5px),
+              var(--md-border) calc(50% - 0.5px),
+              var(--md-border) calc(50% + 0.5px),
+              transparent calc(50% + 0.5px)
+            ),
+            linear-gradient(
+              to bottom right,
+              transparent calc(50% - 0.5px),
+              var(--md-border) calc(50% - 0.5px),
+              var(--md-border) calc(50% + 0.5px),
+              transparent calc(50% + 0.5px)
+            );
+          overflow: hidden;
+        }
+        .markdown-bfm-broken-label {
+          position: relative;
+          padding: var(--boxel-sp-5xs);
+          border-radius: var(--boxel-border-radius-sm);
+          background-color: var(--boxel-light-100);
         }
       } /* end @layer baseComponent */
     </style>

--- a/packages/host/app/components/operator-mode/preview-panel/rendered-markdown.gts
+++ b/packages/host/app/components/operator-mode/preview-panel/rendered-markdown.gts
@@ -208,7 +208,14 @@ export default class RenderedMarkdown extends Component<Signature> {
                   : 'overflow: hidden',
               );
             }
-            slots.push({ element: el, kind, state: 'resolved', format, card, style });
+            slots.push({
+              element: el,
+              kind,
+              state: 'resolved',
+              format,
+              card,
+              style,
+            });
             continue;
           }
 
@@ -333,8 +340,7 @@ export default class RenderedMarkdown extends Component<Signature> {
             />
           {{else}}
             <div
-              class='markdown-bfm-loading markdown-bfm-loading--block
-                markdown-bfm-loading--{{slot.format}}'
+              class='markdown-bfm-loading markdown-bfm-loading--block markdown-bfm-loading--{{slot.format}}'
               style={{slot.style}}
               aria-hidden='true'
               data-test-markdown-bfm-loading-block
@@ -732,7 +738,8 @@ export default class RenderedMarkdown extends Component<Signature> {
           border: 1px solid var(--md-border);
           border-radius: var(--boxel-border-radius);
           background-color: var(--boxel-light-100);
-          background-image: linear-gradient(
+          background-image:
+            linear-gradient(
               to top right,
               transparent calc(50% - 0.5px),
               var(--md-border) calc(50% - 0.5px),

--- a/packages/host/tests/integration/components/rendered-markdown-test.gts
+++ b/packages/host/tests/integration/components/rendered-markdown-test.gts
@@ -303,4 +303,158 @@ module('Integration | rendered-markdown', function (hooks) {
       'height is set',
     );
   });
+
+  test('unresolved embedded block ref renders with embedded format class', async function (assert) {
+    let cardUrl = 'http://nonexistent.example.com/Article/missing';
+    let content = `::card[${cardUrl}]`;
+
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><RenderedMarkdown @content={{content}} /></template>
+      },
+    );
+
+    await waitUntil(
+      () =>
+        document.querySelector('[data-test-markdown-bfm-unresolved-block]') !==
+        null,
+      { timeout: 5000, timeoutMessage: 'unresolved block did not appear' },
+    );
+
+    assert
+      .dom('[data-test-markdown-bfm-unresolved-block]')
+      .hasClass(
+        'markdown-bfm-broken--embedded',
+        'block ref defaults to the embedded footprint',
+      );
+    assert
+      .dom('[data-test-markdown-bfm-unresolved-block]')
+      .doesNotHaveAttribute(
+        'style',
+        'embedded broken-link box does not carry an inline width/height style',
+      );
+  });
+
+  test('unresolved isolated block ref renders with isolated format class', async function (assert) {
+    let cardUrl = 'http://nonexistent.example.com/Article/missing-isolated';
+    let content = `::card[${cardUrl} | isolated]`;
+
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><RenderedMarkdown @content={{content}} /></template>
+      },
+    );
+
+    await waitUntil(
+      () =>
+        document.querySelector('[data-test-markdown-bfm-unresolved-block]') !==
+        null,
+      { timeout: 5000, timeoutMessage: 'unresolved block did not appear' },
+    );
+
+    assert
+      .dom('[data-test-markdown-bfm-unresolved-block]')
+      .hasClass(
+        'markdown-bfm-broken--isolated',
+        'isolated ref carries the isolated footprint class',
+      );
+  });
+
+  test('unresolved fitted block ref carries inline width/height matching the card footprint', async function (assert) {
+    let cardUrl = 'http://nonexistent.example.com/Article/missing-fitted';
+    let content = `::card[${cardUrl} | 400x200]`;
+
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><RenderedMarkdown @content={{content}} /></template>
+      },
+    );
+
+    await waitUntil(
+      () =>
+        document.querySelector('[data-test-markdown-bfm-unresolved-block]') !==
+        null,
+      { timeout: 5000, timeoutMessage: 'unresolved block did not appear' },
+    );
+
+    let brokenBlock = document.querySelector(
+      '[data-test-markdown-bfm-unresolved-block]',
+    ) as HTMLElement | null;
+    assert.ok(brokenBlock, 'broken-link block exists');
+    assert
+      .dom(brokenBlock)
+      .hasClass(
+        'markdown-bfm-broken--fitted',
+        'fitted ref carries the fitted footprint class',
+      );
+    let style = brokenBlock?.getAttribute('style') ?? '';
+    assert.true(
+      /width:\s*400px/.test(style),
+      `broken-link inline style includes width: 400px (got "${style}")`,
+    );
+    assert.true(
+      /height:\s*200px/.test(style),
+      `broken-link inline style includes height: 200px (got "${style}")`,
+    );
+  });
+
+  test('loading placeholder appears before unresolved card ref settles', async function (assert) {
+    // The modifier emits a loading shimmer on its first run (before
+    // loadReferencedCards has settled) and only transitions to the broken-link
+    // box afterwards. Observe the DOM to confirm the loading element actually
+    // appears — the existing "no broken Pill flashed" tests only check absence
+    // of the unresolved selector and would still pass if the loading element
+    // never rendered.
+    let cardUrl = 'http://nonexistent.example.com/Article/missing-loading';
+    let content = `::card[${cardUrl} | 400x200]`;
+
+    let loadingEverAppeared = false;
+    let capturedLoadingStyle = '';
+    let capturedLoadingClasses = '';
+    let testRoot = document.querySelector('#ember-testing')!;
+    let observer = new MutationObserver(() => {
+      let loadingEl = testRoot.querySelector(
+        '[data-test-markdown-bfm-loading-block]',
+      ) as HTMLElement | null;
+      if (loadingEl) {
+        loadingEverAppeared = true;
+        capturedLoadingStyle =
+          loadingEl.getAttribute('style') ?? capturedLoadingStyle;
+        capturedLoadingClasses = loadingEl.className || capturedLoadingClasses;
+      }
+    });
+    observer.observe(testRoot, { childList: true, subtree: true });
+
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><RenderedMarkdown @content={{content}} /></template>
+      },
+    );
+
+    await waitUntil(
+      () =>
+        document.querySelector('[data-test-markdown-bfm-unresolved-block]') !==
+        null,
+      { timeout: 5000, timeoutMessage: 'unresolved block did not appear' },
+    );
+
+    observer.disconnect();
+
+    assert.true(
+      loadingEverAppeared,
+      'loading shimmer block appeared before the broken-link box',
+    );
+    assert.true(
+      capturedLoadingClasses.includes('markdown-bfm-loading--fitted'),
+      `loading block carries the fitted footprint class (got "${capturedLoadingClasses}")`,
+    );
+    assert.true(
+      /width:\s*400px/.test(capturedLoadingStyle),
+      `loading block inline style includes width: 400px (got "${capturedLoadingStyle}")`,
+    );
+    assert.true(
+      /height:\s*200px/.test(capturedLoadingStyle),
+      `loading block inline style includes height: 200px (got "${capturedLoadingStyle}")`,
+    );
+  });
 });

--- a/packages/host/tests/integration/components/rich-markdown-field-test.gts
+++ b/packages/host/tests/integration/components/rich-markdown-field-test.gts
@@ -571,6 +571,73 @@ module('Integration | RichMarkdownField', function (hooks) {
       );
   });
 
+  test('unresolved block ref with fitted size spec carries the card footprint', async function (assert) {
+    // Exercises the base default-templates/markdown.gts path (mirrors the
+    // host's rendered-markdown coverage). The broken-link box should adopt
+    // the fitted format class + inline width/height so the layout matches
+    // the eventual card.
+    class ArticleCard extends CardDef {
+      @field body = contains(RichMarkdownField);
+      static isolated = class Isolated extends Component<typeof this> {
+        <template><@fields.body /></template>
+      };
+    }
+
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'article.gts': { ArticleCard },
+        'article-fitted-unresolved.json': {
+          data: {
+            attributes: {
+              body: {
+                content: `::card[https://nonexistent.example/BlogPost/gone | 400x200]\n`,
+              },
+            },
+            meta: {
+              adoptsFrom: { module: './article', name: 'ArticleCard' },
+            },
+          },
+        },
+      },
+    });
+
+    let store = getService('store');
+    let article = (await store.get(
+      `${testRealmURL}article-fitted-unresolved`,
+    )) as BaseDef;
+    await store.loaded();
+
+    await renderCard(loader, article, 'isolated');
+
+    await waitUntil(
+      () =>
+        document.querySelector('[data-test-markdown-bfm-unresolved-block]') !==
+        null,
+      { timeout: 10_000 },
+    );
+
+    let brokenBlock = document.querySelector(
+      '[data-test-markdown-bfm-unresolved-block]',
+    ) as HTMLElement | null;
+    assert.ok(brokenBlock, 'broken-link block exists');
+    assert
+      .dom(brokenBlock)
+      .hasClass(
+        'markdown-bfm-broken--fitted',
+        'fitted ref carries the fitted footprint class',
+      );
+    let style = brokenBlock?.getAttribute('style') ?? '';
+    assert.true(
+      /width:\s*400px/.test(style),
+      `broken-link inline style includes width: 400px (got "${style}")`,
+    );
+    assert.true(
+      /height:\s*200px/.test(style),
+      `broken-link inline style includes height: 200px (got "${style}")`,
+    );
+  });
+
   test('linkedCards resolve when markdown uses relative card references', async function (assert) {
     class Pet extends CardDef {
       static displayName = 'Pet';

--- a/packages/host/tests/unit/bfm-card-references-test.ts
+++ b/packages/host/tests/unit/bfm-card-references-test.ts
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import {
   extractCardReferenceUrls,
   extractBfmReferences,
+  bfmBlockFormatAndSize,
   bfmCardReferenceExtensions,
   bfmExtensionsForKeyword,
   parseBfmSizeSpec,
@@ -697,6 +698,76 @@ module('Unit | bfm-card-references', function () {
       ].join('\n');
       let urls = extractCardReferenceUrls(markdown, 'https://base.com/');
       assert.deepEqual(urls, ['https://example.com/cards/1']);
+    });
+  });
+
+  module('bfmBlockFormatAndSize', function () {
+    test('defaults to embedded with no sizeStyle when format attr is missing', function (assert) {
+      assert.deepEqual(bfmBlockFormatAndSize(undefined, undefined, undefined), {
+        format: 'embedded',
+      });
+    });
+
+    test('defaults to embedded when format attr is unrecognized', function (assert) {
+      assert.deepEqual(bfmBlockFormatAndSize('something', '400', '200'), {
+        format: 'embedded',
+      });
+    });
+
+    test('passes isolated through and ignores width/height', function (assert) {
+      assert.deepEqual(bfmBlockFormatAndSize('isolated', '400', '200'), {
+        format: 'isolated',
+      });
+    });
+
+    test('fitted with no width/height returns undefined sizeStyle', function (assert) {
+      assert.deepEqual(bfmBlockFormatAndSize('fitted', undefined, undefined), {
+        format: 'fitted',
+        sizeStyle: undefined,
+      });
+    });
+
+    test('fitted converts integer width attr to a px value', function (assert) {
+      assert.deepEqual(bfmBlockFormatAndSize('fitted', '400', undefined), {
+        format: 'fitted',
+        sizeStyle: 'width: 400px',
+      });
+    });
+
+    test('fitted passes percentage width attr through unchanged', function (assert) {
+      assert.deepEqual(bfmBlockFormatAndSize('fitted', '50%', undefined), {
+        format: 'fitted',
+        sizeStyle: 'width: 50%',
+      });
+    });
+
+    test('fitted converts integer height attr to a px value', function (assert) {
+      assert.deepEqual(bfmBlockFormatAndSize('fitted', undefined, '200'), {
+        format: 'fitted',
+        sizeStyle: 'height: 200px',
+      });
+    });
+
+    test('fitted combines width + height into one sizeStyle string', function (assert) {
+      assert.deepEqual(bfmBlockFormatAndSize('fitted', '400', '200'), {
+        format: 'fitted',
+        sizeStyle: 'width: 400px; height: 200px',
+      });
+    });
+
+    test('fitted ignores width with unsupported units', function (assert) {
+      // Only `\d+` (px implied) and `\d+%` are accepted; anything else is dropped.
+      assert.deepEqual(bfmBlockFormatAndSize('fitted', '100em', '200'), {
+        format: 'fitted',
+        sizeStyle: 'height: 200px',
+      });
+    });
+
+    test('fitted ignores height with unsupported units', function (assert) {
+      assert.deepEqual(bfmBlockFormatAndSize('fitted', '400', '50%'), {
+        format: 'fitted',
+        sizeStyle: 'width: 400px',
+      });
     });
   });
 });

--- a/packages/runtime-common/bfm-card-references.ts
+++ b/packages/runtime-common/bfm-card-references.ts
@@ -106,6 +106,38 @@ export function parseBfmSizeSpec(specifier: string): BfmSizeSpec | null {
   return null;
 }
 
+export type BfmBlockFormat = 'embedded' | 'fitted' | 'isolated';
+
+/**
+ * Derives the block-level render format and an optional inline sizing style
+ * (`width`/`height`) from a BFM block-ref element's `data-boxel-bfm-*`
+ * attributes. Shared so that resolved cards, the loading shimmer, and the
+ * broken-link placeholder all occupy the same footprint as the eventual card.
+ */
+export function bfmBlockFormatAndSize(
+  formatAttr: string | undefined,
+  widthAttr: string | undefined,
+  heightAttr: string | undefined,
+): { format: BfmBlockFormat; sizeStyle?: string } {
+  let format: BfmBlockFormat =
+    formatAttr === 'fitted' || formatAttr === 'isolated'
+      ? formatAttr
+      : 'embedded';
+  if (format !== 'fitted') {
+    return { format };
+  }
+  let parts: string[] = [];
+  if (widthAttr && /^\d+%$/.test(widthAttr)) {
+    parts.push(`width: ${widthAttr}`);
+  } else if (widthAttr && /^\d+$/.test(widthAttr)) {
+    parts.push(`width: ${widthAttr}px`);
+  }
+  if (heightAttr && /^\d+$/.test(heightAttr)) {
+    parts.push(`height: ${heightAttr}px`);
+  }
+  return { format, sizeStyle: parts.length ? parts.join('; ') : undefined };
+}
+
 /**
  * Splits the content between `[` and `]` in a BFM directive into the URL
  * part and an optional size specifier (after `|`).


### PR DESCRIPTION
## Summary
Loading and broken-link states for markdown-embedded cards now match the [Figma design](https://www.figma.com/design/0kLJtYVLhjyDZaVBXmuYOU/?node-id=1-2) and the eventual card's footprint. ([CS-11273](https://linear.app/cardstack/issue/CS-11273))

- **Loading** — animated shimmer placeholders sized to the eventual card across atom, embedded, and fitted formats (named sizes like strip/tile/compact-card plus custom `WxH`), so the layout doesn't jump when the card resolves.
- **Broken link** — a card-sized box with a faint diagonal cross and a centered icon + type-name label (no pill chip). Inline references use the same crossed-box treatment at atom size.
- Adds a shared `bfmBlockFormatAndSize()` helper in `runtime-common` so resolved cards, loading, and broken-link states derive format + sizing identically from the `data-boxel-bfm-*` attributes. The change is mirrored across the host preview component (`rendered-markdown.gts`) and the base-realm markdown template (`default-templates/markdown.gts`).

The previous behavior used a fixed-size CSS `:empty` shimmer and a small standalone muted pill for unresolved refs; both are replaced by the sized, design-matching placeholders.

## Test plan
- [x] `glint`/`ember-tsc` typecheck (host) — 0 errors
- [x] host + base lint (eslint, prettier, ember-template-lint) — clean
- [x] `Integration | rendered-markdown` — 12/12 pass (preserves the `data-test-markdown-bfm-unresolved-inline/-block` selectors, `title`, and type-name text)
- [x] `Integration | RichMarkdownField` — all assertions pass (one pre-existing, environment-level `import statement outside a module` global error, confirmed present on `main`)
- [x] Visual review of loading + broken-link states against the Figma design

<img width="1200" height="1400" alt="cs11273-states-v2" src="https://github.com/user-attachments/assets/3f711919-1b7e-4886-8c13-819c1e5cb29e" />
