### PR TITLE
Resolve message LLM mode by room order for code-patch auto-apply

### DIFF
--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -499,33 +499,35 @@ export class RoomResource extends Resource<Args> {
   }
 
   /**
-   * Get the active LLM mode at a specific timestamp by looking at the most recent
-   * LLM mode event that occurred before or at the given timestamp.
+   * Get the LLM mode that was active when a given message was created.
+   *
+   * Matrix `origin_server_ts` has millisecond resolution, so a message and a
+   * mode transition can share a timestamp; a bare timestamp comparison cannot
+   * tell whether such a transition happened just before or just after the
+   * message. `sortedEvents` is a stable sort on `origin_server_ts`, so for
+   * equal timestamps it preserves room (insertion) order. Walking it up to the
+   * message and tracking the last mode transition seen yields the mode in
+   * effect when the message arrived, regardless of same-millisecond ties.
    */
-  getActiveLLMModeAtTimestamp(timestamp: number): LLMMode {
-    let latestLLMModeEvent: DiscreteMatrixEvent | undefined;
-
-    for (let event of this.llmModeEvents) {
-      if (event.origin_server_ts <= timestamp) {
-        if (
-          !latestLLMModeEvent ||
-          // Matrix timestamps have millisecond resolution, so two mode
-          // transitions can share an origin_server_ts. llmModeEvents preserves
-          // chronological insertion order, so on a tie the later-iterated event
-          // is the more recent transition and must win.
-          event.origin_server_ts >= latestLLMModeEvent.origin_server_ts
-        ) {
-          latestLLMModeEvent = event;
-        }
+  getActiveLLMModeForMessage(messageEventId: string): LLMMode {
+    let activeMode: LLMMode = 'ask';
+    let foundMessage = false;
+    for (let event of this.sortedEvents) {
+      if (event.event_id === messageEventId) {
+        foundMessage = true;
+        break;
+      }
+      if (event.type === APP_BOXEL_LLM_MODE) {
+        activeMode = (event as any).content?.mode ?? 'ask';
       }
     }
-
-    // If no LLM mode event found before the timestamp, default to 'ask'
-    if (!latestLLMModeEvent) {
+    // If the message isn't in the timeline yet, don't infer 'act' from later
+    // transitions — fall back to 'ask' so a patch is never auto-applied on
+    // incomplete data.
+    if (!foundMessage) {
       return 'ask';
     }
-
-    return (latestLLMModeEvent as any).content?.mode ?? 'ask';
+    return activeMode;
   }
 
   get isActivatingLLMMode() {

--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -509,7 +509,11 @@ export class RoomResource extends Resource<Args> {
       if (event.origin_server_ts <= timestamp) {
         if (
           !latestLLMModeEvent ||
-          event.origin_server_ts > latestLLMModeEvent.origin_server_ts
+          // Matrix timestamps have millisecond resolution, so two mode
+          // transitions can share an origin_server_ts. llmModeEvents preserves
+          // chronological insertion order, so on a tie the later-iterated event
+          // is the more recent transition and must win.
+          event.origin_server_ts >= latestLLMModeEvent.origin_server_ts
         ) {
           latestLLMModeEvent = event;
         }

--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -482,6 +482,21 @@ export default class CommandService extends Service {
           roomResource.getActiveLLMModeAtTimestamp(messageTimestamp);
         // Only auto-apply if in 'act' mode
         if (activeModeAtMessageTime !== 'act') {
+          let llmModeEvents = roomResource.llmModeEvents;
+          if (llmModeEvents.some((e) => (e as any).content?.mode === 'act')) {
+            // The room has used 'act' mode, so a non-'act' resolution here is
+            // worth recording: it pins the timestamp the decision was made
+            // against alongside every mode transition — the data needed to
+            // explain an auto-apply that didn't fire.
+            console.log(
+              `[code-patch-autoapply] event ${eventId} resolved to LLM mode "${activeModeAtMessageTime}" at message timestamp ${messageTimestamp}; mode transitions: ${JSON.stringify(
+                llmModeEvents.map((e) => ({
+                  ts: e.origin_server_ts,
+                  mode: (e as any).content?.mode,
+                })),
+              )}`,
+            );
+          }
           continue;
         }
 

--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -469,6 +469,13 @@ export default class CommandService extends Service {
         }
         let message = roomResource.messages.find((m) => m.eventId === eventId);
         if (!message) {
+          // The event was queued for auto-apply but its message isn't in the
+          // room timeline yet — room processing lagged or dropped it. The event
+          // is consumed here and never retried, so a patch that should
+          // auto-apply silently won't. Log enough to recognize that race.
+          console.log(
+            `[code-patch-autoapply] event ${eventId} queued but no matching message in room ${roomId}; isProcessing=${roomResource.isProcessing}, messageCount=${roomResource.messages.length}`,
+          );
           continue;
         }
         if (message.agentId !== this.matrixService.agentId) {
@@ -838,6 +845,18 @@ export default class CommandService extends Service {
         if (patchResult.status === 'applied') {
           this.executedCommandRequestIds.add(
             `${codeData.eventId}:${codeData.codeBlockIndex}`,
+          );
+        } else if (this.acceptingAllRoomIds.has(roomId)) {
+          // During an auto-apply / accept-all run a non-'applied' result means
+          // the patch never reaches the "applied" UI state a caller may be
+          // waiting on. Record why (e.g. a search block that no longer matches
+          // because a prior chained patch hadn't landed yet).
+          console.log(
+            `[code-patch-autoapply] patch ${codeData.eventId}:${codeData.codeBlockIndex} on ${fileUrl} did not apply (status=${patchResult.status}${
+              patchResult.failureReason
+                ? `, reason=${patchResult.failureReason}`
+                : ''
+            })`,
           );
         }
       }

--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -473,9 +473,11 @@ export default class CommandService extends Service {
           // room timeline yet — room processing lagged or dropped it. The event
           // is consumed here and never retried, so a patch that should
           // auto-apply silently won't. Log enough to recognize that race.
-          console.log(
-            `[code-patch-autoapply] event ${eventId} queued but no matching message in room ${roomId}; isProcessing=${roomResource.isProcessing}, messageCount=${roomResource.messages.length}`,
-          );
+          if (isTesting()) {
+            console.log(
+              `[code-patch-autoapply] event ${eventId} queued but no matching message in room ${roomId}; isProcessing=${roomResource.isProcessing}, messageCount=${roomResource.messages.length}`,
+            );
+          }
           continue;
         }
         if (message.agentId !== this.matrixService.agentId) {
@@ -490,7 +492,10 @@ export default class CommandService extends Service {
         // Only auto-apply if in 'act' mode
         if (activeModeAtMessageTime !== 'act') {
           let llmModeEvents = roomResource.llmModeEvents;
-          if (llmModeEvents.some((e) => (e as any).content?.mode === 'act')) {
+          if (
+            isTesting() &&
+            llmModeEvents.some((e) => (e as any).content?.mode === 'act')
+          ) {
             // The room has used 'act' mode, so a non-'act' resolution here is
             // worth recording: it pins the message against every mode
             // transition — the data needed to explain an auto-apply that
@@ -846,7 +851,7 @@ export default class CommandService extends Service {
           this.executedCommandRequestIds.add(
             `${codeData.eventId}:${codeData.codeBlockIndex}`,
           );
-        } else if (this.acceptingAllRoomIds.has(roomId)) {
+        } else if (isTesting() && this.acceptingAllRoomIds.has(roomId)) {
           // During an auto-apply / accept-all run a non-'applied' result means
           // the patch never reaches the "applied" UI state a caller may be
           // waiting on. Record why (e.g. a search block that no longer matches

--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -380,9 +380,9 @@ export default class CommandService extends Service {
           }
 
           // Get the LLM mode that was active when this message was created
-          let messageTimestamp = message.created.getTime();
-          let activeModeAtMessageTime =
-            roomResource.getActiveLLMModeAtTimestamp(messageTimestamp);
+          let activeModeAtMessageTime = roomResource.getActiveLLMModeForMessage(
+            message.eventId,
+          );
 
           // Auto-execute if LLM mode is 'act' AND the command came after the LLM mode was set to 'act',
           // or if requiresApproval is false
@@ -477,19 +477,19 @@ export default class CommandService extends Service {
         }
 
         // Get the LLM mode that was active when this message was created
-        let messageTimestamp = message.created.getTime();
-        let activeModeAtMessageTime =
-          roomResource.getActiveLLMModeAtTimestamp(messageTimestamp);
+        let activeModeAtMessageTime = roomResource.getActiveLLMModeForMessage(
+          message.eventId,
+        );
         // Only auto-apply if in 'act' mode
         if (activeModeAtMessageTime !== 'act') {
           let llmModeEvents = roomResource.llmModeEvents;
           if (llmModeEvents.some((e) => (e as any).content?.mode === 'act')) {
             // The room has used 'act' mode, so a non-'act' resolution here is
-            // worth recording: it pins the timestamp the decision was made
-            // against alongside every mode transition — the data needed to
-            // explain an auto-apply that didn't fire.
+            // worth recording: it pins the message against every mode
+            // transition — the data needed to explain an auto-apply that
+            // didn't fire.
             console.log(
-              `[code-patch-autoapply] event ${eventId} resolved to LLM mode "${activeModeAtMessageTime}" at message timestamp ${messageTimestamp}; mode transitions: ${JSON.stringify(
+              `[code-patch-autoapply] event ${eventId} resolved to LLM mode "${activeModeAtMessageTime}" at message timestamp ${message.created.getTime()}; mode transitions: ${JSON.stringify(
                 llmModeEvents.map((e) => ({
                   ts: e.origin_server_ts,
                   mode: (e as any).content?.mode,

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -25,6 +25,7 @@ import {
   APP_BOXEL_MESSAGE_MSGTYPE,
   APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE,
   APP_BOXEL_COMMAND_REQUESTS_KEY,
+  APP_BOXEL_LLM_MODE,
 } from '@cardstack/runtime-common/matrix-constants';
 
 import {
@@ -1599,6 +1600,71 @@ ${REPLACE_MARKER}
       .doesNotExist(
         'Code patch sent before act mode is still not auto-applied',
       );
+  });
+
+  test('LLM mode for a message is resolved by room order, not just timestamp', async function (assert) {
+    // Matrix origin_server_ts has millisecond resolution, so a message and a
+    // mode transition can share a timestamp. The active mode for a message must
+    // be decided by where the transition sits relative to the message in the
+    // timeline, not by a bare timestamp comparison. Inject events with explicit
+    // (and deliberately colliding) timestamps so the tie-break is exercised
+    // deterministically rather than by chance.
+    await visitOperatorMode({
+      submode: 'code',
+      codePath: `${testRealmURL}hello.txt`,
+    });
+    await click('[data-test-open-ai-assistant]');
+    let roomId = getRoomIds().pop()!;
+
+    let llmMode = (mode: 'ask' | 'act', ts: number) =>
+      simulateRemoteMessage(
+        roomId,
+        '@testuser:localhost',
+        { mode },
+        { type: APP_BOXEL_LLM_MODE, state_key: '', origin_server_ts: ts },
+      );
+    let aiMessage = (ts: number) =>
+      simulateRemoteMessage(
+        roomId,
+        '@aibot:localhost',
+        {
+          body: 'hello',
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          isStreamingFinished: true,
+        },
+        { origin_server_ts: ts },
+      );
+
+    // Injection order is room order; for equal timestamps a stable sort keeps it.
+    llmMode('act', 1000);
+    let msgActBeforeTie = aiMessage(2000); // act@1000 precedes; ask@2000 below comes later
+    llmMode('ask', 2000); // shares the message's ms but lands after it
+    llmMode('act', 2000); // ask -> act, both at 2000, act inserted later
+    let msgActWinsTie = aiMessage(2000); // act@2000 precedes it in room order
+    llmMode('ask', 3000);
+    let msgAskBeforeLateAct = aiMessage(4000);
+    llmMode('act', 4000); // shares the message's ms but lands after it
+
+    await settled();
+
+    let roomResource = getService('matrix-service').roomResources.get(roomId)!;
+
+    assert.strictEqual(
+      roomResource.getActiveLLMModeForMessage(msgActBeforeTie),
+      'act',
+      'a later same-ms switch to ask does not retroactively change the message',
+    );
+    assert.strictEqual(
+      roomResource.getActiveLLMModeForMessage(msgActWinsTie),
+      'act',
+      'on a same-ms ask->act tie the later transition (act) wins for a following message',
+    );
+    assert.strictEqual(
+      roomResource.getActiveLLMModeForMessage(msgAskBeforeLateAct),
+      'ask',
+      'a same-ms switch to act after the message does not back-date onto it',
+    );
   });
 
   test<TestContextWithSave>('automatic Accept All spinner appears in Act mode for multiple patches', async function (assert) {


### PR DESCRIPTION
## What

`getActiveLLMModeForMessage(messageEventId)` replaces the timestamp-based `getActiveLLMModeAtTimestamp`. It determines the LLM mode in effect when a message arrived by walking the stable-sorted room timeline up to that message and returning the last mode transition seen before it. Both the command and code-patch auto-apply gates use it.

## Why

Matrix `origin_server_ts` has millisecond resolution, so a message and a mode transition can share a timestamp. A bare timestamp comparison can't tell whether such a transition happened just before or just after the message, so a code patch could be evaluated against the wrong mode — either auto-applied when it shouldn't be, or skipped when it should auto-apply (the latter leaves a `waitFor('[data-test-apply-state="applied"]')` hanging until the test times out).

Room order is the unambiguous signal. A switch into `act` that shares a message's millisecond but follows it no longer back-dates onto the message; a switch that genuinely precedes the message is honored.

## Diagnostics (test-only)

A queued code patch can fail to reach the `applied` state through several paths that were previously silent. Gated behind `isTesting()` so production console output is unaffected, these now log:

- a queued code-patch event whose message isn't in the room timeline yet (consumed once, never retried);
- a patch that resolves to a non-`act` mode in a room that has used `act` mode, with every mode transition;
- a non-`applied` patch result during an accept-all run, with its failure reason.

Together these make a future auto-apply that doesn't fire diagnosable from CI output alone.

## Test

A deterministic test injects a message and a mode transition that share an `origin_server_ts` and asserts room order decides the message's active mode in both tie orders — a later same-millisecond switch does not retroactively change a message, and on a same-millisecond `ask`→`act` tie the later transition wins for a following message. It exercises `getActiveLLMModeForMessage` directly, independent of auto-apply timing or file state.
