### PR TITLE
Wire NOTIFY-driven eviction for the in-memory JobScopedSearchCache

### DIFF
--- a/packages/realm-server/lib/jobs-finished-listener.ts
+++ b/packages/realm-server/lib/jobs-finished-listener.ts
@@ -1,0 +1,147 @@
+import { logger, query, param, any } from '@cardstack/runtime-common';
+import type { Expression } from '@cardstack/runtime-common';
+import type { PgAdapter, NotificationSubscription } from '@cardstack/postgres';
+
+import type { JobScopedSearchCache } from '../job-scoped-search-cache';
+
+const log = logger('realm-server:jobs-finished-listener');
+
+// CS-11179: NOTIFY-driven eviction for the in-memory JobScopedSearchCache.
+//
+// `pg-queue` emits `NOTIFY jobs_finished` (no payload) whenever a job's
+// finalize transaction commits. The cache otherwise releases a finished job's
+// entries only when their TTL elapses — fine on a single replica, but a
+// from-scratch reindex of a large realm fans out hundreds of distinct queries
+// within one job, so across many concurrent jobs that residue adds up. Wiring
+// the LISTEN side here drops a job's entries as soon as the worker signals
+// completion instead of waiting for TTL.
+//
+// Best-effort, like the other realm-server NOTIFY listeners: a missed
+// notification just leaves entries to TTL out (a bounded memory window, never
+// a correctness issue — a re-run of a job hashes to a different cache key
+// because the key embeds `<jobId>.<reservationId>`).
+//
+// The NOTIFY has no payload, so on each notification we sweep: take the
+// `<jobId>.<reservationId>` keys the cache currently holds, ask `jobs` which
+// of those job ids have finalized (status resolved | rejected), and clear the
+// matching entries. This queries only the jobs we actually hold entries for,
+// rather than scanning by a recency window.
+const JOBS_FINISHED_CHANNEL = 'jobs_finished';
+
+type SearchCacheView = Pick<JobScopedSearchCache, 'jobIds' | 'clearJob'>;
+
+export interface JobsFinishedListenerDeps {
+  dbAdapter: PgAdapter;
+  searchCache: SearchCacheView;
+  // Test seam: given the job ids the cache currently holds entries for, return
+  // the subset that have finalized. Defaults to a query against `jobs`.
+  fetchFinalizedJobIds?: (candidateJobIds: number[]) => Promise<Set<number>>;
+}
+
+export class JobsFinishedListener {
+  #deps: JobsFinishedListenerDeps;
+  #fetchFinalizedJobIds: (candidateJobIds: number[]) => Promise<Set<number>>;
+  #subscription?: NotificationSubscription;
+  #starting?: Promise<void>;
+
+  constructor(deps: JobsFinishedListenerDeps) {
+    this.#deps = deps;
+    this.#fetchFinalizedJobIds =
+      deps.fetchFinalizedJobIds ??
+      ((ids) => fetchFinalizedJobIdsFromDb(deps.dbAdapter, ids));
+  }
+
+  async start(): Promise<void> {
+    if (this.#subscription || this.#starting) {
+      await this.#starting;
+      return;
+    }
+    this.#starting = (async () => {
+      this.#subscription = await this.#deps.dbAdapter.subscribe(
+        JOBS_FINISHED_CHANNEL,
+        () => {
+          // The notification carries no payload — sweep the cache against the
+          // jobs table. Fire-and-forget: failures are logged, never thrown.
+          void this.handleNotification();
+        },
+      );
+    })();
+    try {
+      await this.#starting;
+    } finally {
+      this.#starting = undefined;
+    }
+  }
+
+  async shutDown(): Promise<void> {
+    // Mirror the sibling listeners: wait for any in-flight start() to finish
+    // wiring #subscription before tearing down, so a racing start() can't
+    // install a live subscription after we thought we were shut down. Swallow
+    // start() errors — if startup failed there's nothing to unsubscribe.
+    try {
+      await this.#starting;
+    } catch {
+      // ignore
+    }
+    const sub = this.#subscription;
+    this.#subscription = undefined;
+    await sub?.unsubscribe();
+  }
+
+  // Exposed for tests; also invoked internally by the LISTEN handler. Returns
+  // the sweep promise so tests can await it; the subscribe callback fires it
+  // best-effort and swallows errors.
+  async handleNotification(): Promise<void> {
+    try {
+      await this.#sweep();
+    } catch (err: unknown) {
+      log.warn(`jobs_finished sweep failed: ${String(err)}`);
+    }
+  }
+
+  async #sweep(): Promise<void> {
+    let keys = this.#deps.searchCache.jobIds();
+    if (keys.length === 0) {
+      return;
+    }
+    // Cache keys are `<jobId>.<reservationId>`; group by the numeric jobId so
+    // a single job's finalize clears every reservation's entries.
+    let keysByJobId = new Map<number, string[]>();
+    for (let key of keys) {
+      let jobId = Number(key.split('.')[0]);
+      if (!Number.isSafeInteger(jobId)) {
+        continue;
+      }
+      let group = keysByJobId.get(jobId);
+      if (!group) {
+        group = [];
+        keysByJobId.set(jobId, group);
+      }
+      group.push(key);
+    }
+    if (keysByJobId.size === 0) {
+      return;
+    }
+    let finalized = await this.#fetchFinalizedJobIds([...keysByJobId.keys()]);
+    for (let jobId of finalized) {
+      for (let key of keysByJobId.get(jobId) ?? []) {
+        this.#deps.searchCache.clearJob(key);
+      }
+    }
+  }
+}
+
+async function fetchFinalizedJobIdsFromDb(
+  dbAdapter: PgAdapter,
+  candidateJobIds: number[],
+): Promise<Set<number>> {
+  if (candidateJobIds.length === 0) {
+    return new Set();
+  }
+  let rows = (await query(dbAdapter, [
+    `SELECT id FROM jobs WHERE status IN ('resolved', 'rejected') AND (`,
+    ...any(candidateJobIds.map((id) => [`id=`, param(id)])),
+    `)`,
+  ] as Expression)) as { id: number | string }[];
+  return new Set(rows.map((row) => Number(row.id)));
+}

--- a/packages/realm-server/lib/jobs-finished-listener.ts
+++ b/packages/realm-server/lib/jobs-finished-listener.ts
@@ -1,4 +1,9 @@
-import { logger, query, param, any } from '@cardstack/runtime-common';
+import {
+  logger,
+  query,
+  param,
+  separatedByCommas,
+} from '@cardstack/runtime-common';
 import type { Expression } from '@cardstack/runtime-common';
 import type { PgAdapter, NotificationSubscription } from '@cardstack/postgres';
 
@@ -43,6 +48,12 @@ export class JobsFinishedListener {
   #fetchFinalizedJobIds: (candidateJobIds: number[]) => Promise<Set<number>>;
   #subscription?: NotificationSubscription;
   #starting?: Promise<void>;
+  // Single-flight guard: `jobs_finished` fires once per job completion, so a
+  // burst of completions would otherwise launch overlapping sweeps (and DB
+  // queries). Collapse the burst — run one sweep at a time, and if more
+  // notifications land mid-sweep, re-run exactly once afterward.
+  #sweeping = false;
+  #sweepQueued = false;
 
   constructor(deps: JobsFinishedListenerDeps) {
     this.#deps = deps;
@@ -88,14 +99,27 @@ export class JobsFinishedListener {
     await sub?.unsubscribe();
   }
 
-  // Exposed for tests; also invoked internally by the LISTEN handler. Returns
-  // the sweep promise so tests can await it; the subscribe callback fires it
-  // best-effort and swallows errors.
+  // Exposed for tests; also invoked internally by the LISTEN handler. Resolves
+  // when the work prompted by this notification has settled. Coalesces
+  // concurrent calls: if a sweep is already running, just mark that another
+  // pass is needed and let the in-flight sweep re-run once when it finishes.
   async handleNotification(): Promise<void> {
+    if (this.#sweeping) {
+      this.#sweepQueued = true;
+      return;
+    }
+    this.#sweeping = true;
     try {
-      await this.#sweep();
-    } catch (err: unknown) {
-      log.warn(`jobs_finished sweep failed: ${String(err)}`);
+      do {
+        this.#sweepQueued = false;
+        try {
+          await this.#sweep();
+        } catch (err: unknown) {
+          log.warn(`jobs_finished sweep failed: ${String(err)}`);
+        }
+      } while (this.#sweepQueued);
+    } finally {
+      this.#sweeping = false;
     }
   }
 
@@ -139,8 +163,8 @@ async function fetchFinalizedJobIdsFromDb(
     return new Set();
   }
   let rows = (await query(dbAdapter, [
-    `SELECT id FROM jobs WHERE status IN ('resolved', 'rejected') AND (`,
-    ...any(candidateJobIds.map((id) => [`id=`, param(id)])),
+    `SELECT id FROM jobs WHERE status IN ('resolved', 'rejected') AND id IN (`,
+    ...separatedByCommas(candidateJobIds.map((id) => [param(id)])),
     `)`,
   ] as Expression)) as { id: number | string }[];
   return new Set(rows.map((row) => Number(row.id)));

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -40,6 +40,8 @@ import { RealmFileChangesListener } from './lib/realm-file-changes-listener';
 import { RealmIndexUpdatedListener } from './lib/realm-index-updated-listener';
 import { ModuleCacheInvalidationListener } from './lib/module-cache-invalidation-listener';
 import { ModuleCacheCoordinator } from './lib/module-cache-coordination';
+import { JobsFinishedListener } from './lib/jobs-finished-listener';
+import { JobScopedSearchCache } from './job-scoped-search-cache';
 import { resolveFullIndexOnStartup } from './lib/full-index-on-startup';
 import { PUBLISHED_DIRECTORY_NAME } from '@cardstack/runtime-common';
 
@@ -367,9 +369,14 @@ const smokeTestHostApp = async () => {
   let realms: Realm[] = [];
   let dbAdapter = new PgAdapter({ autoMigrate });
   let queue = new PgQueuePublisher(dbAdapter);
+  // One process-wide job-scoped search cache, shared between the request
+  // handlers (via RealmServer → createRoutes) and the JobsFinishedListener
+  // so a `jobs_finished` NOTIFY evicts the same entries the handlers populate.
+  let searchCache = new JobScopedSearchCache();
   let reconciler: RealmRegistryReconciler | undefined;
   let fileChangesListener: RealmFileChangesListener | undefined;
   let indexUpdatedListener: RealmIndexUpdatedListener | undefined;
+  let jobsFinishedListener: JobsFinishedListener | undefined;
   let moduleCacheInvalidationListener:
     | ModuleCacheInvalidationListener
     | undefined;
@@ -554,6 +561,7 @@ const smokeTestHostApp = async () => {
     grafanaSecret: GRAFANA_SECRET,
     dbAdapter,
     queue,
+    searchCache,
     definitionLookup,
     assetsURL: process.env.ASSETS_URL_OVERRIDE
       ? new URL(process.env.ASSETS_URL_OVERRIDE)
@@ -619,6 +627,7 @@ const smokeTestHostApp = async () => {
           reconciler?.shutDown(),
           fileChangesListener?.shutDown(),
           indexUpdatedListener?.shutDown(),
+          jobsFinishedListener?.shutDown(),
           moduleCacheInvalidationListener?.shutDown(),
           moduleCacheCoordinator?.shutDown(),
         ]);
@@ -728,6 +737,16 @@ const smokeTestHostApp = async () => {
     lookupMountedRealm: (url) => realms.find((r) => r.url === url),
   });
   await indexUpdatedListener.start();
+
+  // CS-11179: NOTIFY-driven eviction for the in-memory JobScopedSearchCache.
+  // On `jobs_finished` it drops the finished job's cache entries immediately
+  // instead of waiting for their TTL. Shares the same searchCache instance the
+  // request handlers populate (passed into RealmServer above).
+  jobsFinishedListener = new JobsFinishedListener({
+    dbAdapter,
+    searchCache,
+  });
+  await jobsFinishedListener.start();
 
   // Cross-instance module-cache invalidation (CS-10952). When a peer
   // realm-server emits NOTIFY module_cache_invalidated, replay the bump on

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -39,7 +39,7 @@ import handleClaimBoxelDomainRequest from './handlers/handle-claim-boxel-domain'
 import handleDeleteBoxelClaimedDomainRequest from './handlers/handle-delete-boxel-claimed-domain';
 import handlePrerenderProxy from './handlers/handle-prerender-proxy';
 import handleSearch from './handlers/handle-search';
-import { JobScopedSearchCache } from './job-scoped-search-cache';
+import type { JobScopedSearchCache } from './job-scoped-search-cache';
 import handleSearchPrerendered from './handlers/handle-search-prerendered';
 import handleRealmInfo from './handlers/handle-realm-info';
 import handleFederatedTypes from './handlers/handle-federated-types';
@@ -105,6 +105,7 @@ export type CreateRoutesArgs = {
   };
   assetsURL: URL;
   prerenderer?: Prerenderer;
+  searchCache: JobScopedSearchCache;
 };
 
 export function createRoutes(args: CreateRoutesArgs) {
@@ -113,15 +114,15 @@ export function createRoutes(args: CreateRoutesArgs) {
     args.serverURL,
   );
   let router = new Router();
-  // One job-scoped same-realm search cache per realm-server process.
-  // Lives for the life of the process; TTL-evicts entries 10 min after
-  // their initial populate (hits do NOT refresh the TTL — tying it to
-  // populate time bounds the leak deterministically, where touch-
-  // refresh would let a hot entry survive indefinitely past job
-  // completion). Future work wires NOTIFY-driven eviction so a job
-  // completion releases its entries immediately. Hard-capped to bound
-  // worst-case memory under a synthetic-jobId flood.
-  let searchCache = new JobScopedSearchCache();
+  // One job-scoped same-realm search cache per realm-server process,
+  // created by the composition root (main.ts) and shared with the
+  // JobsFinishedListener so a `jobs_finished` NOTIFY can evict a job's
+  // entries immediately rather than waiting on TTL (CS-11179). TTL-evicts
+  // entries 10 min after their initial populate as the missed-NOTIFY
+  // backstop (hits do NOT refresh the TTL — tying it to populate time
+  // bounds the leak deterministically). Hard-capped to bound worst-case
+  // memory under a synthetic-jobId flood.
+  let searchCache = args.searchCache;
 
   let createRealmDeps: CreateRealmDeps = {
     serverURL: new URL(args.serverURL),

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -117,11 +117,11 @@ export function createRoutes(args: CreateRoutesArgs) {
   // One job-scoped same-realm search cache per realm-server process,
   // created by the composition root (main.ts) and shared with the
   // JobsFinishedListener so a `jobs_finished` NOTIFY can evict a job's
-  // entries immediately rather than waiting on TTL (CS-11179). TTL-evicts
-  // entries 10 min after their initial populate as the missed-NOTIFY
-  // backstop (hits do NOT refresh the TTL — tying it to populate time
-  // bounds the leak deterministically). Hard-capped to bound worst-case
-  // memory under a synthetic-jobId flood.
+  // entries immediately rather than waiting on TTL (CS-11179). The cache
+  // still TTL-evicts entries after its configured TTL (DEFAULT_TTL_MS) as
+  // the missed-NOTIFY backstop (hits do NOT refresh the TTL — tying it to
+  // populate time bounds the leak deterministically). Hard-capped to bound
+  // worst-case memory under a synthetic-jobId flood.
   let searchCache = args.searchCache;
 
   let createRealmDeps: CreateRealmDeps = {

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -28,6 +28,7 @@ import { extractSupportedMimeType } from '@cardstack/runtime-common/router';
 import * as Sentry from '@sentry/node';
 import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import { createRoutes } from './routes';
+import { JobScopedSearchCache } from './job-scoped-search-cache';
 import { createSendEvent } from './handlers/send-event';
 import { createServeFromRealm } from './handlers/serve-from-realm';
 import { createServeIndex } from './handlers/serve-index';
@@ -292,6 +293,7 @@ export class RealmServer {
     | undefined;
   private prerenderer: Prerenderer | undefined;
   private reconciler: RealmRegistryReconciler;
+  private searchCache: JobScopedSearchCache;
 
   constructor({
     serverURL,
@@ -314,6 +316,7 @@ export class RealmServer {
     getRegistrationSecret,
     domainsForPublishedRealms,
     prerenderer,
+    searchCache,
   }: {
     serverURL: URL;
     realms: Realm[];
@@ -339,6 +342,10 @@ export class RealmServer {
       boxelSite?: string;
     };
     prerenderer?: Prerenderer;
+    // Optional so test harnesses that construct a RealmServer directly get a
+    // private cache for free. main.ts passes a shared instance so the
+    // JobsFinishedListener can evict the same cache the handlers populate.
+    searchCache?: JobScopedSearchCache;
   }) {
     if (!matrixRegistrationSecret && !getRegistrationSecret) {
       throw new Error(
@@ -379,6 +386,7 @@ export class RealmServer {
     this.realms = realms;
     this.reconciler = reconciler;
     this.prerenderer = prerenderer;
+    this.searchCache = searchCache ?? new JobScopedSearchCache();
   }
 
   @Memoize()
@@ -478,6 +486,7 @@ export class RealmServer {
           domainsForPublishedRealms: this.domainsForPublishedRealms,
           prerenderer: this.prerenderer,
           reconciler: this.reconciler,
+          searchCache: this.searchCache,
         }),
       )
       .use(

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -216,6 +216,7 @@ const ALL_TEST_FILES: string[] = [
   './realm-registry-writes-test',
   './realm-file-changes-listener-test',
   './realm-index-updated-listener-test',
+  './jobs-finished-listener-test',
   './realm-routing-test',
   './module-cache-invalidation-listener-test',
   './pg-adapter-subscribe-test',

--- a/packages/realm-server/tests/jobs-finished-listener-test.ts
+++ b/packages/realm-server/tests/jobs-finished-listener-test.ts
@@ -167,6 +167,40 @@ module(basename(__filename), function () {
         'a failed sweep leaves the cache intact (entries fall back to TTL)',
       );
     });
+
+    test('coalesces a burst of notifications into one in-flight sweep + one re-run', async function (assert) {
+      let calls = 0;
+      let release!: () => void;
+      let gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      let cache = new FakeSearchCache(['5.1']);
+      let listener = new JobsFinishedListener({
+        dbAdapter: {} as unknown as PgAdapter,
+        searchCache: cache,
+        fetchFinalizedJobIds: async () => {
+          calls++;
+          // Hold the first sweep open so the next notifications land while it
+          // is still in flight.
+          if (calls === 1) {
+            await gate;
+          }
+          return new Set();
+        },
+      });
+
+      let first = listener.handleNotification(); // starts the sweep, awaits gate
+      await listener.handleNotification(); // arrives mid-sweep → queued
+      await listener.handleNotification(); // also mid-sweep → still just queued
+      release();
+      await first;
+
+      assert.strictEqual(
+        calls,
+        2,
+        'the burst collapses to the in-flight sweep plus a single re-run',
+      );
+    });
   });
 
   module('JobsFinishedListener (DB-backed sweep)', function (hooks) {

--- a/packages/realm-server/tests/jobs-finished-listener-test.ts
+++ b/packages/realm-server/tests/jobs-finished-listener-test.ts
@@ -1,0 +1,238 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import type { PgAdapter } from '@cardstack/postgres';
+import { query, param } from '@cardstack/runtime-common';
+import { setupDB } from './helpers';
+import { JobsFinishedListener } from '../lib/jobs-finished-listener';
+
+// Minimal stand-in for JobScopedSearchCache exposing only the surface the
+// listener touches: the set of `<jobId>.<reservationId>` keys it holds and a
+// clearJob that removes one.
+class FakeSearchCache {
+  #keys: Set<string>;
+  constructor(keys: string[] = []) {
+    this.#keys = new Set(keys);
+  }
+  jobIds(): string[] {
+    return [...this.#keys];
+  }
+  clearJob(jobId: string): void {
+    this.#keys.delete(jobId);
+  }
+}
+
+function waitFor<T>(
+  getValue: () => T | undefined,
+  timeoutMs = 3000,
+  pollMs = 20,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    const tick = () => {
+      const value = getValue();
+      if (value !== undefined) {
+        resolve(value);
+        return;
+      }
+      if (Date.now() - started > timeoutMs) {
+        reject(new Error(`timeout after ${timeoutMs}ms`));
+        return;
+      }
+      setTimeout(tick, pollMs);
+    };
+    tick();
+  });
+}
+
+module(basename(__filename), function () {
+  module('JobsFinishedListener (sweep dispatch)', function () {
+    test('clears every cached key whose job has finalized', async function (assert) {
+      let cache = new FakeSearchCache(['5.1', '9.1']);
+      let listener = new JobsFinishedListener({
+        dbAdapter: {} as unknown as PgAdapter,
+        searchCache: cache,
+        // 5 finalized, 9 still running.
+        fetchFinalizedJobIds: async () => new Set([5]),
+      });
+
+      await listener.handleNotification();
+
+      assert.deepEqual(
+        cache.jobIds().sort(),
+        ['9.1'],
+        'the finalized job entry is cleared; the running job entry is kept',
+      );
+    });
+
+    test('clears every reservation of a finalized job', async function (assert) {
+      let cache = new FakeSearchCache(['5.1', '5.2', '5.3']);
+      let listener = new JobsFinishedListener({
+        dbAdapter: {} as unknown as PgAdapter,
+        searchCache: cache,
+        fetchFinalizedJobIds: async () => new Set([5]),
+      });
+
+      await listener.handleNotification();
+
+      assert.deepEqual(
+        cache.jobIds(),
+        [],
+        'all reservations of the finalized job are cleared',
+      );
+    });
+
+    test('passes the distinct numeric job ids parsed from cache keys', async function (assert) {
+      let seen: number[] | undefined;
+      let cache = new FakeSearchCache(['12.3', '12.4', '7.1']);
+      let listener = new JobsFinishedListener({
+        dbAdapter: {} as unknown as PgAdapter,
+        searchCache: cache,
+        fetchFinalizedJobIds: async (ids) => {
+          seen = [...ids].sort((a, b) => a - b);
+          return new Set();
+        },
+      });
+
+      await listener.handleNotification();
+
+      assert.deepEqual(
+        seen,
+        [7, 12],
+        'the `<jobId>.<reservationId>` keys collapse to distinct numeric job ids',
+      );
+    });
+
+    test('skips malformed keys without querying them', async function (assert) {
+      let seen: number[] | undefined;
+      let cache = new FakeSearchCache(['not-a-number', '5.1']);
+      let listener = new JobsFinishedListener({
+        dbAdapter: {} as unknown as PgAdapter,
+        searchCache: cache,
+        fetchFinalizedJobIds: async (ids) => {
+          seen = [...ids];
+          return new Set([5]);
+        },
+      });
+
+      await listener.handleNotification();
+
+      assert.deepEqual(
+        seen,
+        [5],
+        'only the well-formed key contributes a job id',
+      );
+      assert.deepEqual(
+        cache.jobIds(),
+        ['not-a-number'],
+        'the finalized entry is cleared; the malformed key is left untouched',
+      );
+    });
+
+    test('no-ops on an empty cache without querying', async function (assert) {
+      let fetchCalls = 0;
+      let cache = new FakeSearchCache([]);
+      let listener = new JobsFinishedListener({
+        dbAdapter: {} as unknown as PgAdapter,
+        searchCache: cache,
+        fetchFinalizedJobIds: async () => {
+          fetchCalls++;
+          return new Set();
+        },
+      });
+
+      await listener.handleNotification();
+
+      assert.strictEqual(
+        fetchCalls,
+        0,
+        'no DB query when there is nothing cached',
+      );
+    });
+
+    test('swallows fetch errors (best-effort)', async function (assert) {
+      let cache = new FakeSearchCache(['5.1']);
+      let listener = new JobsFinishedListener({
+        dbAdapter: {} as unknown as PgAdapter,
+        searchCache: cache,
+        fetchFinalizedJobIds: async () => {
+          throw new Error('boom');
+        },
+      });
+
+      await listener.handleNotification();
+
+      assert.deepEqual(
+        cache.jobIds(),
+        ['5.1'],
+        'a failed sweep leaves the cache intact (entries fall back to TTL)',
+      );
+    });
+  });
+
+  module('JobsFinishedListener (DB-backed sweep)', function (hooks) {
+    let dbAdapter: PgAdapter;
+
+    setupDB(hooks, {
+      beforeEach: async (adapter) => {
+        dbAdapter = adapter;
+      },
+    });
+
+    async function insertJob(status: string): Promise<number> {
+      let rows = (await query(dbAdapter, [
+        `INSERT INTO jobs (job_type, status) VALUES (`,
+        param('from-scratch-index'),
+        `,`,
+        param(status),
+        `) RETURNING id`,
+      ])) as { id: number | string }[];
+      return Number(rows[0].id);
+    }
+
+    test('queries jobs and clears entries for resolved + rejected jobs only', async function (assert) {
+      let resolvedId = await insertJob('resolved');
+      let rejectedId = await insertJob('rejected');
+      let runningId = await insertJob('unfulfilled');
+
+      let cache = new FakeSearchCache([
+        `${resolvedId}.1`,
+        `${rejectedId}.1`,
+        `${runningId}.1`,
+      ]);
+      // No fetch override: exercises the real `jobs` query.
+      let listener = new JobsFinishedListener({
+        dbAdapter,
+        searchCache: cache,
+      });
+
+      await listener.handleNotification();
+
+      assert.deepEqual(
+        cache.jobIds(),
+        [`${runningId}.1`],
+        'resolved and rejected jobs are evicted; the unfulfilled job is kept',
+      );
+    });
+
+    test('NOTIFY jobs_finished drives the sweep end-to-end', async function (assert) {
+      let resolvedId = await insertJob('resolved');
+      let cache = new FakeSearchCache([`${resolvedId}.1`]);
+      let listener = new JobsFinishedListener({
+        dbAdapter,
+        searchCache: cache,
+      });
+      await listener.start();
+      try {
+        await dbAdapter.notify('jobs_finished', '');
+        await waitFor(() => (cache.jobIds().length === 0 ? true : undefined));
+        assert.deepEqual(
+          cache.jobIds(),
+          [],
+          'the finalized job entry was evicted in response to the NOTIFY',
+        );
+      } finally {
+        await listener.shutDown();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Wire NOTIFY-driven eviction for the in-memory `JobScopedSearchCache`: a finished indexing job's search-cache entries are released as soon as the worker signals completion, instead of sitting in heap until their TTL.

- A `JobsFinishedListener` subscribes to the `jobs_finished` NOTIFY channel. The notification carries no payload, so each one **sweeps**: it groups the cached `<jobId>.<reservationId>` keys by numeric jobId, queries `jobs` for which of those have finalized (`status IN ('resolved','rejected')`), and calls `clearJob` on the matches — querying only the jobs currently holding entries.
- Best-effort, like the sibling realm-server NOTIFY listeners: a missed notification just leaves entries to TTL out (a bounded memory window, never a correctness issue — a job re-run hashes to a different cache key). Concurrent notifications coalesce: one sweep at a time, re-running once if more arrive mid-sweep.
- The `JobScopedSearchCache` is created once and injected into both the request handlers (via `RealmServer` → `createRoutes`) and the listener so they share one instance. The `RealmServer` arg is optional and defaults to a fresh cache, so existing test harnesses are unaffected.

Tracker: [CS-11179](https://linear.app/cardstack/issue/CS-11179).

## Test plan
- [x] `ember-tsc --noEmit` (realm-server) — 0 errors
- [x] eslint + prettier — clean
- [x] `jobs-finished-listener-test` — sweep dispatch + burst-coalescing + DB-backed + end-to-end `NOTIFY jobs_finished`
- [x] `job-scoped-search-cache-test` — no regression

A pre-existing, environment-level `Uncaught SyntaxError: Cannot use import statement outside a module` global error surfaces intermittently in `RichMarkdownField` integration runs; it is independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)