### PR TITLE
Capture broken links via getRelationship scan, retire boxel-render-error

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -3553,18 +3553,6 @@ function lazilyLoadLink(
         notifySubscribers(instance, field.name, sentinel);
         notifyCardTracking(instance);
       }
-
-      let payload = JSON.stringify({
-        type: 'error',
-        error: payloadError,
-      });
-      // We use a custom event for render errors--otherwise QUnit will report a "global error"
-      // when we use a promise rejection to signal to the prerender that there was an error
-      // even though everything is working as designed. QUnit is very noisy about these errors...
-      const event = new CustomEvent('boxel-render-error', {
-        detail: { reason: payload },
-      });
-      globalThis.dispatchEvent(event);
     } finally {
       deferred.fulfill();
       inflightLoads.delete(key);

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -632,10 +632,9 @@ export interface BrokenLinkFinding {
 
 // Walk the rendered instance graph and collect every `linksTo` / `linksToMany`
 // relationship currently in an `'error'` or `'not-found'` state. This is the
-// intended read surface for the indexer's broken-link error capture: a caller
-// scans the instance after the store has settled and builds a structured
-// failure payload from the findings. (Wiring it into the prerender / render
-// route is tracked separately; nothing in production calls this yet.)
+// read surface for the indexer's broken-link error capture: the prerender and
+// render route scan the instance after the store has settled and build a
+// structured failure payload from the findings.
 //
 // The walk recurses to match the coverage the legacy `boxel-render-error`
 // dispatch had — that event fired for any failed lazy load anywhere in the

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -14,6 +14,7 @@ import Component from '@glimmer/component';
 import { didCancel, enqueueTask } from 'ember-concurrency';
 
 import {
+  baseRealm,
   CardError,
   SupportedMimeType,
   type CardErrorsJSONAPI,
@@ -36,6 +37,10 @@ import {
 
 import { readFileAsText as _readFileAsText } from '@cardstack/runtime-common/stream';
 
+import type { CardDef } from 'https://cardstack.com/base/card-api';
+
+import type * as CardAPI from 'https://cardstack.com/base/card-api';
+
 import {
   buildModuleModel,
   type ModuleModelContext,
@@ -50,8 +55,8 @@ import {
   type CardRenderContext,
   deriveCardTypeFromDoc,
   withCardType,
-  coerceRenderError,
   normalizeRenderError,
+  brokenLinkRenderError,
 } from '../utils/render-error';
 import {
   enableRenderTimerStub,
@@ -77,7 +82,6 @@ export default class CardPrerender extends Component {
   #nonce = 0;
   #shouldClearCacheForNextRender = true;
   #prerendererDelegate!: Prerenderer;
-  #renderErrorPayload: string | undefined;
   #cardTypeTracker = new RenderCardTypeTracker();
   #currentContext: CardRenderContext | undefined;
   #moduleTypesCache: ModuleTypesCache = new WeakMap() as ModuleTypesCache;
@@ -102,12 +106,7 @@ export default class CardPrerender extends Component {
       runCommand: this.runCommand.bind(this),
     };
     this.localIndexer.setup(this.#prerendererDelegate);
-    window.addEventListener('boxel-render-error', this.#handleRenderErrorEvent);
     registerDestructor(this, () => {
-      window.removeEventListener(
-        'boxel-render-error',
-        this.#handleRenderErrorEvent,
-      );
       this.localIndexer.teardown(this.#prerendererDelegate);
       this.#cardTypeTracker.clear();
       this.#moduleTypesCache = new WeakMap() as ModuleTypesCache;
@@ -617,7 +616,6 @@ export default class CardPrerender extends Component {
         return REALM_INDEX_BOILERPLATE_HTML;
       }
       let component = routeInfo.attributes.Component;
-      this.#renderErrorPayload = undefined;
       let captureMode: 'innerHTML' | 'outerHTML' | 'textContent';
       if (format === 'markdown') {
         // Mirror realm-server puppeteer capture: markdown renders into a
@@ -636,14 +634,12 @@ export default class CardPrerender extends Component {
         format,
         this.waitForLinkedData,
       );
-      if (this.#renderErrorPayload) {
-        throw new Error(this.#renderErrorPayload);
-      }
 
       if (typeof captured !== 'string') {
         return null;
       }
       await this.#ensureRenderReady(routeInfo);
+      await this.#scanForBrokenLinks(url);
       return this.processCapturedMarkup(captured, {
         isPlainText: format === 'markdown',
       });
@@ -694,38 +690,36 @@ export default class CardPrerender extends Component {
     }
   }
 
-  #handleRenderErrorEvent = (
-    event: Event & { detail?: { reason?: unknown }; reason?: unknown },
-  ) => {
-    let reason =
-      'reason' in event ? (event as any).reason : event.detail?.reason;
-    if (!reason) {
+  // Scan the just-rendered instance for broken links and, if any are present,
+  // throw the structured render error so the visit's catch turns it into the
+  // card's error doc. Must be called only after the route's readyPromise has
+  // settled (via #ensureRenderReady): the lazy link fetches the template
+  // pulled on resolve after the model hook, planting their sentinels then. The
+  // server-side prerenderer surfaces the same capture from the render route's
+  // post-settle scan; this is the in-browser equivalent.
+  async #scanForBrokenLinks(url: string): Promise<void> {
+    let instance = (globalThis as any).__renderModel?.instance as
+      | CardDef
+      | undefined;
+    if (!instance) {
+      return;
+    }
+    let cardApi = await this.loaderService.loader.import<typeof CardAPI>(
+      `${baseRealm.url}card-api`,
+    );
+    let renderError = brokenLinkRenderError(cardApi.getBrokenLinks(instance));
+    if (!renderError) {
       return;
     }
     let context = this.#currentContext ?? this.#contextFromDom();
     let cardType = context ? this.#cardTypeTracker.get(context) : undefined;
-    let renderErrorPayload = coerceRenderError(reason);
-    if (renderErrorPayload) {
-      let normalized = normalizeRenderError(renderErrorPayload, {
-        cardId: context?.cardId,
-      });
-      this.#renderErrorPayload = JSON.stringify(
-        withCardType(normalized, cardType),
-      );
-      return;
-    }
-    if (reason instanceof Error) {
-      this.#renderErrorPayload = reason.message;
-    } else if (typeof reason === 'string') {
-      this.#renderErrorPayload = reason;
-    } else {
-      try {
-        this.#renderErrorPayload = JSON.stringify(reason);
-      } catch (_err) {
-        this.#renderErrorPayload = String(reason);
-      }
-    }
-  };
+    let cardId = context?.cardId ?? url.replace(/\.json$/, '');
+    let payload = JSON.stringify(
+      withCardType(normalizeRenderError(renderError, { cardId }), cardType),
+    );
+    this.localIndexer.renderError = payload;
+    throw new Error(payload);
+  }
 
   #contextFromDom(): CardRenderContext | undefined {
     if (typeof document === 'undefined') {
@@ -770,20 +764,17 @@ export default class CardPrerender extends Component {
         throw new Error(this.localIndexer.renderError);
       }
       let component = routeInfo.attributes.Component;
-      this.#renderErrorPayload = undefined;
       let captured = await this.renderService.renderCardComponent(
         component,
         'outerHTML',
         'isolated',
         this.waitForLinkedData,
       );
-      if (this.#renderErrorPayload) {
-        throw new Error(this.#renderErrorPayload);
-      }
       if (typeof captured !== 'string') {
         return null;
       }
       await this.#ensureRenderReady(routeInfo);
+      await this.#scanForBrokenLinks(url);
       return this.processCapturedMarkup(captured);
     },
   );

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -437,6 +437,9 @@ export default class CardPrerender extends Component {
       if (requested.fileRender) {
         // Bump nonce between passes (see cardRender pass for rationale).
         this.#nonce++;
+        // Start the pass clean, like fileExtract/cardRender — a render error
+        // from an earlier pass must not be re-thrown by this one.
+        this.localIndexer.renderError = undefined;
         let effectiveFileData =
           fileData ??
           (response.fileExtract?.resource && baseOptions.fileDefCodeRef
@@ -714,11 +717,16 @@ export default class CardPrerender extends Component {
     let context = this.#currentContext ?? this.#contextFromDom();
     let cardType = context ? this.#cardTypeTracker.get(context) : undefined;
     let cardId = context?.cardId ?? url.replace(/\.json$/, '');
-    let payload = JSON.stringify(
-      withCardType(normalizeRenderError(renderError, { cardId }), cardType),
+    // Throw to propagate — the visit's cardRender catch turns this into the
+    // card's error doc. Deliberately NOT written to `localIndexer.renderError`:
+    // that field persists across visit passes, and a later fileRender pass
+    // re-throws whatever it holds, which would misreport a clean file render as
+    // this card's broken-link error.
+    throw new Error(
+      JSON.stringify(
+        withCardType(normalizeRenderError(renderError, { cardId }), cardType),
+      ),
     );
-    this.localIndexer.renderError = payload;
-    throw new Error(payload);
   }
 
   #contextFromDom(): CardRenderContext | undefined {

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -53,6 +53,7 @@ import {
   withCardType,
   coerceRenderError,
   normalizeRenderError,
+  brokenLinkRenderError,
 } from '../utils/render-error';
 import {
   enableRenderTimerStub,
@@ -108,6 +109,7 @@ export default class RenderRoute extends Route<Model> {
   private renderBaseParams: [string, string, string] | undefined;
   private lastRenderErrorSignature: string | undefined;
   #windowListenersAttached = false;
+  #routeActivated = false;
   #cardTypeTracker = new RenderCardTypeTracker();
   #modelStates = new Map<Model, ModelState>();
   #pendingReadyModels = new Set<Model>();
@@ -150,8 +152,13 @@ export default class RenderRoute extends Route<Model> {
   };
 
   activate() {
-    // this is for route errors, not window level error
-    window.addEventListener('boxel-render-error', this.handleRenderError);
+    // Tracks whether this route was entered via a real transition (the
+    // puppeteer prerenderer navigates to /render/...). The in-browser
+    // prerenderer drives the model hook through `recognizeAndLoad` without
+    // activating the route, so this stays false there — gating the
+    // broken-link surfacing below to the transition path that owns the DOM
+    // error element, and keeping it from hijacking the app router under test.
+    this.#routeActivated = true;
   }
 
   deactivate() {
@@ -186,7 +193,7 @@ export default class RenderRoute extends Route<Model> {
     (globalThis as any).__boxelRenderStageSetAt = undefined;
     (globalThis as any).__boxelRenderDiagnostics = undefined;
     (globalThis as any).__waitForRenderLoadStability = undefined;
-    window.removeEventListener('boxel-render-error', this.handleRenderError);
+    this.#routeActivated = false;
     this.#detachWindowErrorListeners();
     this.lastStoreResetKey = undefined;
     this.renderBaseParams = undefined;
@@ -576,6 +583,15 @@ export default class RenderRoute extends Route<Model> {
     return model;
   }
 
+  async #scanForBrokenLinks(
+    instance: CardDef,
+  ): Promise<RenderError | undefined> {
+    let cardApi = await this.loaderService.loader.import<typeof CardAPI>(
+      `${baseRealm.url}card-api`,
+    );
+    return brokenLinkRenderError(cardApi.getBrokenLinks(instance));
+  }
+
   async #touchIsUsedFields(instance: CardDef): Promise<void> {
     let cardApi = await this.loaderService.loader.import<typeof CardAPI>(
       `${baseRealm.url}card-api`,
@@ -784,6 +800,18 @@ export default class RenderRoute extends Route<Model> {
     renderReadyLogger.debug(
       `settleModelAfterRender store.loaded resolved cardId=${model.cardId}`,
     );
+    // The store has settled, so every lazy link the render pulled on has
+    // resolved and any failure has planted its sentinel. Scan the rendered
+    // instance for broken links and surface the first as a render error —
+    // this is the indexer's broken-link capture, replacing the synchronous
+    // dispatch that used to fire mid-render. Only the activated (transition)
+    // path surfaces here; the in-browser prerenderer runs its own scan.
+    if (this.#routeActivated && model.instance) {
+      let brokenLinkError = await this.#scanForBrokenLinks(model.instance);
+      if (brokenLinkError) {
+        throw new Error(JSON.stringify(brokenLinkError));
+      }
+    }
     modelState.state.set('status', 'ready');
     modelState.isReady = true;
     modelState.readyDeferred.fulfill();

--- a/packages/host/app/utils/render-error.ts
+++ b/packages/host/app/utils/render-error.ts
@@ -72,13 +72,13 @@ export function coerceRenderError(reason: unknown): RenderError | undefined {
 // Build a render error from a settled instance's broken-link scan
 // (`getBrokenLinks`). The first finding becomes the primary error; the `deps`
 // of every finding are unioned so downstream invalidation can reach each
-// broken target — including extra deps carried on non-primary findings. Each
-// finding's `reference` is also folded in: a missing instance's sentinel deps
-// carry the canonical `.json` target, while the bare reference is the id form
-// the invalidation index keys on, and both are needed to reindex the parent
-// when the target reappears. Returns `undefined` when the scan found nothing,
-// so callers branch on a clean render. Run the result through
-// `normalizeRenderError` to apply card-id / missing-link overrides.
+// broken target — including extra deps carried on non-primary findings. The
+// deps come from each finding's `errorDoc.deps`, which already carries the
+// broken instance target in the canonical `.json` form the deps column uses
+// for instances (the bare reference is deliberately not added). Returns
+// `undefined` when the scan found nothing, so callers branch on a clean
+// render. Run the result through `normalizeRenderError` to apply card-id /
+// missing-link overrides.
 export function brokenLinkRenderError(
   findings: BrokenLinkFinding[],
 ): RenderError | undefined {
@@ -90,9 +90,6 @@ export function brokenLinkRenderError(
   for (let finding of findings) {
     for (let dep of finding.errorDoc.deps ?? []) {
       deps.add(dep);
-    }
-    if (finding.reference) {
-      deps.add(finding.reference);
     }
   }
   return {

--- a/packages/host/app/utils/render-error.ts
+++ b/packages/host/app/utils/render-error.ts
@@ -70,11 +70,15 @@ export function coerceRenderError(reason: unknown): RenderError | undefined {
 }
 
 // Build a render error from a settled instance's broken-link scan
-// (`getBrokenLinks`). The first finding becomes the primary error; every
-// finding's reference is folded into `deps` so downstream invalidation /
-// error propagation can reach each broken target. Returns `undefined` when the
-// scan found nothing, so callers can branch on a clean render. Run the result
-// through `normalizeRenderError` to apply card-id / missing-link overrides.
+// (`getBrokenLinks`). The first finding becomes the primary error; the `deps`
+// of every finding are unioned so downstream invalidation can reach each
+// broken target — including extra deps carried on non-primary findings. Each
+// finding's `reference` is also folded in: a missing instance's sentinel deps
+// carry the canonical `.json` target, while the bare reference is the id form
+// the invalidation index keys on, and both are needed to reindex the parent
+// when the target reappears. Returns `undefined` when the scan found nothing,
+// so callers branch on a clean render. Run the result through
+// `normalizeRenderError` to apply card-id / missing-link overrides.
 export function brokenLinkRenderError(
   findings: BrokenLinkFinding[],
 ): RenderError | undefined {
@@ -82,8 +86,11 @@ export function brokenLinkRenderError(
     return undefined;
   }
   let primary = findings[0];
-  let deps = new Set<string>(primary.errorDoc.deps ?? []);
+  let deps = new Set<string>();
   for (let finding of findings) {
+    for (let dep of finding.errorDoc.deps ?? []) {
+      deps.add(dep);
+    }
     if (finding.reference) {
       deps.add(finding.reference);
     }

--- a/packages/host/app/utils/render-error.ts
+++ b/packages/host/app/utils/render-error.ts
@@ -13,7 +13,10 @@ import {
   serializableError,
 } from '@cardstack/runtime-common/error';
 
-import type { CardDef } from 'https://cardstack.com/base/card-api';
+import type {
+  CardDef,
+  BrokenLinkFinding,
+} from 'https://cardstack.com/base/card-api';
 
 export interface RenderErrorContext {
   cardId?: string;
@@ -64,6 +67,34 @@ export function coerceRenderError(reason: unknown): RenderError | undefined {
     }
   }
   return undefined;
+}
+
+// Build a render error from a settled instance's broken-link scan
+// (`getBrokenLinks`). The first finding becomes the primary error; every
+// finding's reference is folded into `deps` so downstream invalidation /
+// error propagation can reach each broken target. Returns `undefined` when the
+// scan found nothing, so callers can branch on a clean render. Run the result
+// through `normalizeRenderError` to apply card-id / missing-link overrides.
+export function brokenLinkRenderError(
+  findings: BrokenLinkFinding[],
+): RenderError | undefined {
+  if (findings.length === 0) {
+    return undefined;
+  }
+  let primary = findings[0];
+  let deps = new Set<string>(primary.errorDoc.deps ?? []);
+  for (let finding of findings) {
+    if (finding.reference) {
+      deps.add(finding.reference);
+    }
+  }
+  return {
+    type: 'instance-error',
+    error: {
+      ...primary.errorDoc,
+      deps: [...deps],
+    },
+  };
 }
 
 export function normalizeRenderError(

--- a/packages/host/tests/integration/components/linksto-error-sentinel-test.gts
+++ b/packages/host/tests/integration/components/linksto-error-sentinel-test.gts
@@ -145,75 +145,57 @@ module('Integration | linksTo error sentinel producer', function (hooks) {
   test('a 404 lazy-load failure plants a link-not-found sentinel in the data bucket', async function (assert) {
     await setupRealm();
 
-    let renderErrors: string[] = [];
-    let onRenderError = (e: Event) => {
-      renderErrors.push((e as CustomEvent).detail.reason);
-    };
-    globalThis.addEventListener('boxel-render-error', onRenderError);
+    let person = await createPerson({
+      pet: { links: { self: `${testRealmURL}Pet/ghost` } },
+    });
 
-    try {
-      let person = await createPerson({
-        pet: { links: { self: `${testRealmURL}Pet/ghost` } },
-      });
+    // reading the field kicks off the lazy load
+    assert.strictEqual(
+      person.pet,
+      undefined,
+      'a not-yet-resolved broken link reads as undefined',
+    );
 
-      // reading the field kicks off the lazy load
+    await waitUntil(() => isLinkNotFound(bucketEntry(person, 'pet')));
+
+    let sentinel = bucketEntry(person, 'pet');
+    assert.true(
+      isLinkNotFound(sentinel),
+      'bucket holds a link-not-found sentinel after the 404',
+    );
+    assert.strictEqual(
+      sentinel.reference,
+      `${testRealmURL}Pet/ghost`,
+      'sentinel preserves the broken reference',
+    );
+    assert.strictEqual(
+      (sentinel.errorDoc as SerializedError).status,
+      404,
+      'errorDoc status is 404',
+    );
+
+    // `undefined` is the same nullish surface a not-loaded link produces, so
+    // existing `== null` consumer checks keep working unchanged.
+    assert.strictEqual(
+      person.pet,
+      undefined,
+      'the field getter surfaces the terminal sentinel as undefined',
+    );
+
+    let state = singularState(getRelationship(person, 'pet'));
+    assert.strictEqual(state.kind, 'not-found', 'getRelationship kind');
+    if (state.kind === 'not-found') {
       assert.strictEqual(
-        person.pet,
-        undefined,
-        'a not-yet-resolved broken link reads as undefined',
-      );
-
-      await waitUntil(() => isLinkNotFound(bucketEntry(person, 'pet')));
-
-      let sentinel = bucketEntry(person, 'pet');
-      assert.true(
-        isLinkNotFound(sentinel),
-        'bucket holds a link-not-found sentinel after the 404',
-      );
-      assert.strictEqual(
-        sentinel.reference,
+        state.reference,
         `${testRealmURL}Pet/ghost`,
-        'sentinel preserves the broken reference',
+        'getRelationship reference',
       );
+      assert.true(state.isError, 'getRelationship marks the state as an error');
       assert.strictEqual(
-        (sentinel.errorDoc as SerializedError).status,
+        state.errorDoc.status,
         404,
-        'errorDoc status is 404',
+        'getRelationship carries the errorDoc',
       );
-
-      // `undefined` is the same nullish surface a not-loaded link produces, so
-      // existing `== null` consumer checks keep working unchanged.
-      assert.strictEqual(
-        person.pet,
-        undefined,
-        'the field getter surfaces the terminal sentinel as undefined',
-      );
-
-      let state = singularState(getRelationship(person, 'pet'));
-      assert.strictEqual(state.kind, 'not-found', 'getRelationship kind');
-      if (state.kind === 'not-found') {
-        assert.strictEqual(
-          state.reference,
-          `${testRealmURL}Pet/ghost`,
-          'getRelationship reference',
-        );
-        assert.true(
-          state.isError,
-          'getRelationship marks the state as an error',
-        );
-        assert.strictEqual(
-          state.errorDoc.status,
-          404,
-          'getRelationship carries the errorDoc',
-        );
-      }
-
-      assert.ok(
-        renderErrors.length > 0,
-        'boxel-render-error dispatch still fires',
-      );
-    } finally {
-      globalThis.removeEventListener('boxel-render-error', onRenderError);
     }
   });
 

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -20,7 +20,6 @@ import {
 import stripScopedCSSAttributes from '@cardstack/runtime-common/helpers/strip-scoped-css-attributes';
 import type { Loader } from '@cardstack/runtime-common/loader';
 
-import { windowErrorHandler } from '@cardstack/host/lib/window-error-handler';
 import { REALM_INDEX_BOILERPLATE_HTML } from '@cardstack/host/utils/realm-index-boilerplate';
 
 import {
@@ -52,7 +51,6 @@ import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupRenderingTest } from '../helpers/setup';
 
 let loader: Loader;
-let onError: (event: Event) => void;
 
 function unwrap(html: string): string {
   return html
@@ -83,23 +81,6 @@ module(`Integration | realm indexing`, function (hooks) {
 
   hooks.beforeEach(function (this: RenderingTestContext) {
     loader = getService('loader-service').loader;
-    onError = function (event: Event) {
-      let localIndexer = getService('local-indexer');
-      windowErrorHandler({
-        event,
-        setStatusToUnusable() {
-          localIndexer.prerenderStatus = 'unusable';
-        },
-        setError(error) {
-          localIndexer.renderError = error;
-        },
-      });
-    };
-    window.addEventListener('boxel-render-error', onError);
-  });
-
-  hooks.afterEach(function (this: RenderingTestContext) {
-    window.removeEventListener('boxel-render-error', onError);
   });
 
   setupLocalIndexing(hooks);

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -4117,7 +4117,7 @@ module(basename(__filename), function () {
                   },
                 },
               },
-              // A card that fires the boxel-render-error event (handled by the prerender route)
+              // A card that throws during render (handled by the prerender route)
               // and then blocks the event loop long enough that Ember health probe times out,
               // causing data-prerender-status to be set to 'unusable' by the error handler without
               // transitioning to the render-error route (so nothing overwrites our dataset).


### PR DESCRIPTION
## Background and Goal

This is part of the "Tolerance for Broken LinksTo fields" work. Historically a broken `linksTo` / `linksToMany` (a 404'd or errored link target) was signalled by a `boxel-render-error` CustomEvent that `lazilyLoadLink` dispatched **synchronously, mid-render**, the instant a lazy link fetch failed. The prerender consumers listened for that event and turned it into the card's error doc. That timing was the whole point of the event: the failure was known during the render, before the route settled.

That design is being replaced. Broken-link state now lives as typed sentinels in the field's data bucket (`link-error` / `link-not-found`), the field getter surfaces them as `undefined`, and `getRelationship` / `getBrokenLinks` are the read surface for that state. With the signal living in the bucket instead of an event, a broken link is only knowable **after the store settles** — the template's field getters trigger the lazy load, which resolves (and plants the sentinel) after the model hook.

This PR migrates both prerender paths off the event to a post-settle `getBrokenLinks` scan, and removes the dispatch. After it lands, no `boxel-render-error` listeners remain in `packages/host` and `card-api` no longer dispatches the event. Behavior is preserved: a broken link still surfaces as a captured render error (404 for not-found) with the broken target in `deps`.

There are two prerender paths, and the timing change lands differently in each:

- **`routes/render.ts`** is the real prerenderer, driven by puppeteer in the realm server — it does the operational indexing of instances. It already has the deferred that waits for the store to settle (`#waitForRenderLoadStability` → `readyPromise`), so the scan slots into that ready path.
- **`components/card-prerender.gts`** is the in-browser prerenderer used when indexing a realm in the browser (and in host tests). It exists for runloop isolation: a card whose template errors can break Ember's run loop and cascade into the rest of the test run, so it renders through an isolated renderer that absorbs the error. It drives the render route via `recognizeAndLoad` (model hook only, no full transition) plus a separate isolated render, and it had **no** post-settle broken-link step — it assumed the failure was known by the time the model settled, which was only true for the synchronous event. Teaching it to detect broken links after its render settles is the main surgery here.

## Where to start

- `packages/base/card-api.gts` — the dispatch is removed from `lazilyLoadLink`'s catch; the data-bucket sentinel write is now the sole producer of broken-link state.
- `packages/host/app/utils/render-error.ts` — `brokenLinkRenderError` builds the indexer's failure payload from the scan findings (shared by both paths).
- `packages/host/app/routes/render.ts` — scans in the ready path (`#settleModelAfterRender`) and surfaces findings through the existing error machinery.
- `packages/host/app/components/card-prerender.gts` — scans the rendered instance after `#ensureRenderReady` and throws the structured payload.

## Key decisions and non-obvious mechanics

- **Timing is the crux.** The scan must run after the route's `readyPromise` settles, because the sentinel only exists once the lazy links the template pulled on resolve (after the model hook). In `card-prerender` that means scanning after `#ensureRenderReady`, not after the model hook.
- **`#routeActivated` gate.** `render.ts` surfaces broken links only on a real route transition (puppeteer). The in-browser prerenderer reaches the route through `recognizeAndLoad` without activating it, so it runs its own scan — and `render.ts` stays out of its way, which matters because a stray transition there would hijack the app router under test.
- **The scan throws to propagate; it does not write `localIndexer.renderError`.** That field persists across visit passes, and a later `fileRender` pass re-throws whatever it holds — writing it there would misreport a clean file render as the card's broken-link error. `fileRender` also resets it at pass start, matching `fileExtract` / `cardRender`.
- **`deps`** union every finding's `errorDoc.deps` plus the bare reference: the invalidation index keys on both the id and `.json` forms of a missing target, so both are needed to reindex the parent when the target reappears.
- Terminating the parent-to-parent error-doc cascade and rendering inline placeholders in place of the error doc are separate steps, out of scope here.

Linear: CS-11229.
