### PR TITLE
Log realm-index diagnostics when _types reads back empty

### DIFF
--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -734,6 +734,100 @@ async function waitForQueueIdle(
   );
 }
 
+// Pure diagnostics — never changes behavior. `_types` (and any reader of the
+// precomputed `realm_meta`) returns instances from the `realm_meta` row whose
+// `realm_version` equals `realm_versions.current_version`. An empty result has
+// three distinguishable causes, and this dump tells them apart in the CI log
+// without needing another iteration:
+//   1. The from-scratch index produced no instance rows at all
+//      (boxel_index.instances = 0).
+//   2. Instances were indexed but their `types` couldn't be resolved (a render
+//      or module fetch failed) — `#fetchTypeSummary` requires `types->>0`, so
+//      those rows silently drop out of `realm_meta` (null_types > 0).
+//   3. No `realm_meta` row matches `current_version` (a version mismatch —
+//      e.g. a from-scratch reset left only orphan rows), so the JOIN is empty
+//      even though instances exist (matched = NONE while instances > 0).
+// Logged unconditionally as a one-liner; degraded/error instance rows are
+// dumped only when something looks off. Wrapped so a diagnostics failure can
+// never affect a test result.
+export async function logRealmIndexDiagnostics(
+  dbAdapter: PgAdapter,
+  realmURL: string,
+  label: string,
+): Promise<void> {
+  try {
+    let [versionRow] = await dbAdapter.execute(
+      `SELECT current_version FROM realm_versions WHERE realm_url = $1`,
+      { bind: [realmURL] },
+    );
+    let currentVersion = versionRow?.current_version ?? null;
+
+    let metaRows = await dbAdapter.execute(
+      `SELECT realm_version,
+              COALESCE(jsonb_array_length(value->'instances'), -1) AS instances,
+              COALESCE(jsonb_array_length(value->'files'), -1) AS files
+       FROM realm_meta WHERE realm_url = $1 ORDER BY realm_version`,
+      { bind: [realmURL] },
+    );
+
+    let [counts] = await dbAdapter.execute(
+      `SELECT
+         COUNT(*) FILTER (WHERE type = 'instance' AND (is_deleted IS NULL OR is_deleted = false)) AS instances,
+         COUNT(*) FILTER (WHERE type = 'instance' AND types IS NULL AND (is_deleted IS NULL OR is_deleted = false)) AS null_types,
+         COUNT(*) FILTER (WHERE type = 'instance' AND has_error = true AND (is_deleted IS NULL OR is_deleted = false)) AS errored
+       FROM boxel_index WHERE realm_url = $1`,
+      { bind: [realmURL] },
+    );
+
+    let metaSummary =
+      metaRows
+        .map(
+          (r) =>
+            `v${r.realm_version}{instances:${r.instances},files:${r.files}}`,
+        )
+        .join(', ') || '(none)';
+    let matched = metaRows.find((r) => r.realm_version === currentVersion);
+    let nullTypes = Number(counts?.null_types ?? 0);
+    let errored = Number(counts?.errored ?? 0);
+
+    console.log(
+      `[realm-index-diag ${label}] realm=${realmURL} current_version=${currentVersion} ` +
+        `realm_meta=[${metaSummary}] ` +
+        `matched=${matched ? `instances:${matched.instances}` : 'NONE(version-mismatch)'} ` +
+        `boxel_index.instances=${counts?.instances ?? '?'} null_types=${nullTypes} errored=${errored}`,
+    );
+
+    if (
+      !matched ||
+      Number(matched.instances) <= 0 ||
+      nullTypes > 0 ||
+      errored > 0
+    ) {
+      let badRows = await dbAdapter.execute(
+        `SELECT url, has_error, error_doc->>'message' AS message
+         FROM boxel_index
+         WHERE realm_url = $1 AND type = 'instance'
+           AND (types IS NULL OR has_error = true)
+           AND (is_deleted IS NULL OR is_deleted = false)
+         ORDER BY url
+         LIMIT 25`,
+        { bind: [realmURL] },
+      );
+      for (let r of badRows) {
+        console.log(
+          `[realm-index-diag ${label}]   instance ${r.url} has_error=${r.has_error} ` +
+            `error_doc.message=${r.message ?? 'none'}`,
+        );
+      }
+    }
+  } catch (e) {
+    console.log(
+      `[realm-index-diag ${label}] failed to gather diagnostics for ${realmURL}: ` +
+        `${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+}
+
 interface CachedPermissionedRealmTemplateEntry {
   ready: Promise<void>;
 }
@@ -2158,6 +2252,11 @@ async function buildPermissionedRealmTemplate(
     );
 
     await waitForQueueIdle(builderDatabaseName);
+    await logRealmIndexDiagnostics(
+      dbAdapter,
+      (options.realmURL ?? testRealmURL).href,
+      'template-build',
+    );
     await teardownPermissionedRealmFixture(fixture.testRealmServer);
     fixture = undefined;
 
@@ -2323,6 +2422,13 @@ async function buildPermissionedRealmsTemplate(
     );
 
     await waitForQueueIdle(builderDatabaseName);
+    for (let fixtureRealm of fixture.realms) {
+      await logRealmIndexDiagnostics(
+        dbAdapter,
+        fixtureRealm.realm.url,
+        'template-build',
+      );
+    }
     await teardownPermissionedRealmsFixture(fixture.realms);
     fixture = undefined;
 

--- a/packages/realm-server/tests/types-endpoint-test.ts
+++ b/packages/realm-server/tests/types-endpoint-test.ts
@@ -9,6 +9,7 @@ import type { QueuePublisher, QueueRunner } from '@cardstack/runtime-common';
 import {
   setupPermissionedRealmCached,
   runTestRealmServer,
+  logRealmIndexDiagnostics,
   setupDB,
   setupMatrixRoom,
   createVirtualNetwork,
@@ -231,6 +232,18 @@ module(basename(__filename), function () {
       let actualInstances = response.body.data.filter(
         (entry: any) => entry.attributes.kind === 'instance',
       );
+      if (actualInstances.length === 0) {
+        // Read-time companion to the build-time diagnostic: an empty instance
+        // set here means the realm served by this (cached-template-restored)
+        // realm-server has no `realm_meta` instances. Dump the restored DB
+        // state so the next failure shows whether the snapshot itself was
+        // empty/degraded or a version mismatch surfaced on read.
+        await logRealmIndexDiagnostics(
+          dbAdapter,
+          realmURL.href,
+          'types-endpoint-read',
+        );
+      }
       assert.deepEqual(
         sortCardTypeSummaries(actualInstances),
         sortCardTypeSummaries(instanceEntries),


### PR DESCRIPTION
## What

Adds `logRealmIndexDiagnostics(dbAdapter, realmURL, label)` and calls it where a realm-server test realm's `_types` / `realm_meta` instance set can read back empty. Pure logging — no behavior change.

`_types` returns instances from the `realm_meta` row whose `realm_version` equals `realm_versions.current_version`. The diagnostic logs, as a one-liner:

- `current_version` for the realm,
- every `realm_meta` row's instance/file counts, and whether one matches `current_version`,
- the `boxel_index` instance breakdown: total / `types IS NULL` / errored.

When something is off (no matching `realm_meta` row, zero matched instances, or any null-types/errored rows) it also dumps those instance rows with their `error_doc.message`.

Together these distinguish the otherwise-identical ways an instance set reads empty:

- **no instance rows** — `boxel_index.instances = 0`,
- **unresolved `types`** — instances exist but `types` is NULL (a render/module fetch failed), so they don't count toward `realm_meta`,
- **version mismatch** — instances and a `realm_meta` row exist, but none matches `current_version`, so the read JOIN is empty.

## Where it runs

- In the cached-template builders, after the build's queue drains — reports the state captured into the snapshot.
- In `types-endpoint-test`, when the read returns no instances — reports the restored realm's live state.

Comparing the two attributes an empty read to the build snapshot vs. restore/read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
