### PR TITLE
Harden host-test service startup and restore its CI diagnostics

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -130,6 +130,15 @@ jobs:
         working-directory: packages/host
         env:
           DBUS_SYSTEM_BUS_ADDRESS: unix:path=/run/dbus/system_bus_socket
+          # [readiness-diag] — start-server-and-test reads DEBUG and
+          # propagates `log: true` + `verbose: true` to wait-on, so each
+          # readiness-probe attempt prints its HTTP status / connection
+          # error. Distinguishes "server not listening" from "server
+          # hanging mid-request" from "server returning 500" when the
+          # 10-minute wait-on timer fires. Remove together with the
+          # other [readiness-diag] markers once the root cause is
+          # identified.
+          DEBUG: start-server-and-test
 
       - name: Upload junit report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/mise-tasks/infra/ensure-pg
+++ b/mise-tasks/infra/ensure-pg
@@ -27,3 +27,36 @@ while ! docker exec boxel-pg pg_isready -U postgres >/dev/null 2>&1; do
   printf '.'
   sleep 5
 done
+
+# Create the databases the services connect to before anything uses them.
+# Workers fatally crash on startup with `database "<name>" does not exist`
+# if they out-race the realm-server's `--migrateDB` — the only other thing
+# that creates these — and a crash-looping worker never indexes, so the
+# realm's readiness check never passes. This task is a shared dependency of
+# the realm-server and worker tasks, so creating the databases here closes
+# the race for every host CI job, not just one.
+#
+# `docker exec ... -h localhost -p 5432` forces TCP inside the container:
+# the postgres:16.3 image does not always create the unix socket, so a bare
+# `psql -U postgres` can fail on the socket path. Postgres listens on
+# *:5432 (trust auth), so localhost works regardless.
+ensure_db() {
+  db="$1"
+  [ -z "$db" ] && return 0
+  # Create unconditionally and treat "already exists" as success, so a
+  # concurrent creator (the realm-server and worker tasks may run this in
+  # parallel) can't lose a check-then-create race.
+  if out=$(docker exec boxel-pg psql -h localhost -p 5432 -U postgres -w -c "CREATE DATABASE $db" 2>&1); then
+    echo "Created database $db"
+  elif echo "$out" | grep -q "already exists"; then
+    echo "Database $db already exists"
+  else
+    echo "$out" >&2
+    return 1
+  fi
+}
+
+ensure_db "${PGDATABASE:-boxel}"
+if [ -n "${PGDATABASE_TEST:-}" ]; then
+  ensure_db "$PGDATABASE_TEST"
+fi

--- a/mise-tasks/services/realm-server
+++ b/mise-tasks/services/realm-server
@@ -82,7 +82,7 @@ LOW_CREDIT_THRESHOLD="${LOW_CREDIT_THRESHOLD:-2000}" \
   NODE_NO_WARNINGS=1 \
   PGPORT="${PGPORT}" \
   PGDATABASE="${PGDATABASE}" \
-  LOG_LEVELS='*=info' \
+  LOG_LEVELS="${LOG_LEVELS:-*=info}" \
   REALM_SERVER_SECRET_SEED="mum's the word" \
   REALM_SECRET_SEED="shhh! it's a secret" \
   GRAFANA_SECRET="shhh! it's a secret" \

--- a/mise-tasks/services/worker
+++ b/mise-tasks/services/worker
@@ -35,7 +35,7 @@ NODE_ENV=development \
   NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=4096}" \
   PGPORT="${PGPORT}" \
   PGDATABASE="${PGDATABASE}" \
-  LOG_LEVELS='*=info' \
+  LOG_LEVELS="${LOG_LEVELS:-*=info}" \
   REALM_SECRET_SEED="shhh! it's a secret" \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
   LOW_CREDIT_THRESHOLD=2000 \

--- a/packages/realm-server/lib/unbuffer-stdio.ts
+++ b/packages/realm-server/lib/unbuffer-stdio.ts
@@ -1,0 +1,20 @@
+// Put stdout/stderr in blocking mode under NODE_ENV=development so service
+// processes (and dev-only startup probes that share their pipe topology)
+// flush each write immediately to a piped consumer — run-p, dev-log-tee,
+// CI's `| tee server.log` — the way a TTY already does. Node block-buffers
+// writes to a pipe and flushes the remainder only when the process exits,
+// so a process that hangs prints nothing until teardown and then dumps
+// everything at once with teardown timestamps, hiding where it actually
+// stalled.
+//
+// Side-effect module: importing it is the contract. Production keeps async
+// writes — a blocking stdout there could stall the event loop if the log
+// reader backs up.
+if (process.env.NODE_ENV === 'development') {
+  for (let stream of [process.stdout, process.stderr]) {
+    let handle = (stream as any)._handle;
+    if (handle && typeof handle.setBlocking === 'function') {
+      handle.setBlocking(true);
+    }
+  }
+}

--- a/packages/realm-server/scripts/wait-for-host-standby.ts
+++ b/packages/realm-server/scripts/wait-for-host-standby.ts
@@ -32,6 +32,11 @@
 // against a genuinely broken vite — in normal dev that ceiling is never
 // reached.
 
+// First, so this probe's own progress logs flush in real time instead of
+// at process exit (Node block-buffers writes to a pipe; in CI this script
+// runs piped through run-p + tee, so retry-attempt output otherwise hides
+// behind buffering until teardown).
+import '../lib/unbuffer-stdio';
 import puppeteer, { type Browser } from 'puppeteer';
 
 const PER_ATTEMPT_TIMEOUT_MS = 30_000;

--- a/packages/realm-server/setup-logger.ts
+++ b/packages/realm-server/setup-logger.ts
@@ -3,3 +3,22 @@ import { makeLogDefinitions } from '@cardstack/runtime-common';
 (globalThis as any)._logDefinitions = makeLogDefinitions(
   process.env.LOG_LEVELS || '*=info',
 );
+
+// In dev and CI these services run with stdout/stderr piped (run-p, the
+// dev-log-tee per-service files, the CI `| tee server.log`). Node
+// block-buffers writes to a pipe and flushes the remainder only when the
+// process exits, so a process that hangs prints nothing until teardown and
+// then dumps everything at once with teardown timestamps — which hides
+// where it actually stalled. Putting the handles in blocking mode makes
+// each write flush immediately, the way a TTY already does. Scoped to
+// development (the mode the mise service tasks run under) so production
+// keeps async writes, where a blocking stdout could stall the event loop
+// if the log reader backs up.
+if (process.env.NODE_ENV === 'development') {
+  for (let stream of [process.stdout, process.stderr]) {
+    let handle = (stream as any)._handle;
+    if (handle && typeof handle.setBlocking === 'function') {
+      handle.setBlocking(true);
+    }
+  }
+}

--- a/packages/realm-server/setup-logger.ts
+++ b/packages/realm-server/setup-logger.ts
@@ -1,24 +1,6 @@
 import './setup-localhost-resolver';
+import './lib/unbuffer-stdio';
 import { makeLogDefinitions } from '@cardstack/runtime-common';
 (globalThis as any)._logDefinitions = makeLogDefinitions(
   process.env.LOG_LEVELS || '*=info',
 );
-
-// In dev and CI these services run with stdout/stderr piped (run-p, the
-// dev-log-tee per-service files, the CI `| tee server.log`). Node
-// block-buffers writes to a pipe and flushes the remainder only when the
-// process exits, so a process that hangs prints nothing until teardown and
-// then dumps everything at once with teardown timestamps — which hides
-// where it actually stalled. Putting the handles in blocking mode makes
-// each write flush immediately, the way a TTY already does. Scoped to
-// development (the mode the mise service tasks run under) so production
-// keeps async writes, where a blocking stdout could stall the event loop
-// if the log reader backs up.
-if (process.env.NODE_ENV === 'development') {
-  for (let stream of [process.stdout, process.stderr]) {
-    let handle = (stream as any)._handle;
-    if (handle && typeof handle.setBlocking === 'function') {
-      handle.setBlocking(true);
-    }
-  }
-}


### PR DESCRIPTION
## Background and Goal

The host-test CI jobs that boot the realm-server + worker stack — **Live Tests (realm)** and the host-test shards — intermittently fail at startup: the `software-factory` realm's `_readiness-check` never returns 200 inside the 10-minute `wait-on` window. The root cause is a startup ordering race — workers connect to postgres and fatally crash with `database "boxel" does not exist` before the realm-server's `--migrateDB` has created it; a crash-looping worker never indexes, so readiness never passes.

When it failed, the logs were almost useless: the services' stdout is block-buffered and only flushes at process exit (so a hung service prints nothing until teardown), and the diagnostics that exist for this flake were inert in these jobs.

This PR fixes the startup race and makes startup observable.

## Where to start

- `mise-tasks/infra/ensure-pg` — creates the `boxel` / `boxel_test` databases once postgres is ready. This task is a shared dependency of the realm-server and worker tasks, so the databases exist before anything connects, across every host CI job.
- `packages/realm-server/lib/unbuffer-stdio.ts` — side-effect module that puts stdout/stderr in blocking mode under `NODE_ENV=development`, so piped writes flush in real time instead of only at process exit. Imported from `setup-logger.ts` (covers the realm-server, worker, worker-manager, and prerender server entrypoints) and from `scripts/wait-for-host-standby.ts` (the dev-only puppeteer probe, which runs as its own ts-node process). Production keeps async writes.
- `mise-tasks/services/realm-server`, `mise-tasks/services/worker` — honor an inherited `LOG_LEVELS` (falling back to `*=info`), so the `readiness-diag` and index/worker debug loggers the host test suite enables actually reach those processes.
- `.github/workflows/ci-host.yaml` — the "Live test suite" step sets `DEBUG=start-server-and-test`, so `wait-on` logs each readiness probe's HTTP status / connection error on a timeout.

## Key decisions

- **`ensure-pg` is the right home for DB creation** — it already gates pg readiness and is the single shared dependency both the workers and realm-servers wait on, so the fix covers the whole stack rather than one job. `CREATE DATABASE` is run tolerant of a concurrent creator and of "already exists", since the realm-server and worker tasks can run it in parallel.
- **Blocking stdout is scoped to development.** A blocking stdout can stall the event loop if a production log reader backs up; the mise service tasks run under `NODE_ENV=development`, so gating there enables it exactly where the buffered-until-teardown problem bites without touching production.
- **The blocking-stdio setup lives in one module** so it can ride on top of any ts-node entrypoint that runs in the same piped topology — both the long-lived services and the dev-only startup probes need it, and a shared side-effect module keeps the two consumers honest with the same gate and the same rationale.
- **The `readiness-diag` log lines embed elapsed time**, so they stay diagnostic even if a future buffering edge case flushes them late.
