### PR TITLE
Adorn hover bar: anchor left when it fits, clamp to right corner radius when it doesn't

### DIFF
--- a/packages/experiments-realm/AdornOverflowDemo/1.json
+++ b/packages/experiments-realm/AdornOverflowDemo/1.json
@@ -1,0 +1,56 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "cardInfo": {
+        "name": "Adorn Overflow Demo",
+        "notes": null,
+        "summary": "Kanban-style layout that reproduces leftward clipping of the Adorn hover label when a card sits flush against an overflow:hidden container.",
+        "cardThumbnailURL": null
+      }
+    },
+    "relationships": {
+      "backlog.0": {
+        "links": {
+          "self": "../ProjectInitiativeTask/1"
+        }
+      },
+      "backlog.1": {
+        "links": {
+          "self": "../ProjectInitiativeTask/2"
+        }
+      },
+      "inProgress.0": {
+        "links": {
+          "self": "../ProjectInitiativeTask/3"
+        }
+      },
+      "inProgress.1": {
+        "links": {
+          "self": "../ProjectInitiativeTask/4"
+        }
+      },
+      "done.0": {
+        "links": {
+          "self": "../ProjectInitiativeTask/5"
+        }
+      },
+      "done.1": {
+        "links": {
+          "self": "../ProjectInitiativeTask/6"
+        }
+      },
+      "cardInfo.theme": {
+        "links": {
+          "self": null
+        }
+      }
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../adorn-overflow-demo",
+        "name": "AdornOverflowDemo"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/ProjectInitiativeTask/1.json
+++ b/packages/experiments-realm/ProjectInitiativeTask/1.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "title": "Refactor Auth Middleware"
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../adorn-overflow-demo",
+        "name": "ProjectInitiativeTask"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/ProjectInitiativeTask/2.json
+++ b/packages/experiments-realm/ProjectInitiativeTask/2.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "title": "Update Onboarding Docs"
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../adorn-overflow-demo",
+        "name": "ProjectInitiativeTask"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/ProjectInitiativeTask/3.json
+++ b/packages/experiments-realm/ProjectInitiativeTask/3.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "title": "Investigate Slow Queries"
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../adorn-overflow-demo",
+        "name": "ProjectInitiativeTask"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/ProjectInitiativeTask/4.json
+++ b/packages/experiments-realm/ProjectInitiativeTask/4.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "title": "Wire Up Realm Picker"
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../adorn-overflow-demo",
+        "name": "ProjectInitiativeTask"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/ProjectInitiativeTask/5.json
+++ b/packages/experiments-realm/ProjectInitiativeTask/5.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "title": "Ship Adorn Hover Bar"
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../adorn-overflow-demo",
+        "name": "ProjectInitiativeTask"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/ProjectInitiativeTask/6.json
+++ b/packages/experiments-realm/ProjectInitiativeTask/6.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "title": "Audit Realm Permissions"
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../adorn-overflow-demo",
+        "name": "ProjectInitiativeTask"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/adorn-overflow-demo.gts
+++ b/packages/experiments-realm/adorn-overflow-demo.gts
@@ -1,0 +1,135 @@
+import {
+  CardDef,
+  Component,
+  contains,
+  field,
+  linksToMany,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+
+class ProjectInitiativeTask extends CardDef {
+  static displayName = 'Cross-Functional Strategic Initiative Planning Task';
+  @field title = contains(StringField);
+
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <div class='task' data-test-task-card>
+        <@fields.title />
+      </div>
+      <style scoped>
+        .task {
+          padding: var(--boxel-sp-sm);
+          font: 600 var(--boxel-font-sm);
+          color: var(--boxel-700);
+        }
+      </style>
+    </template>
+  };
+}
+
+class AdornOverflowDemoIsolated extends Component<typeof AdornOverflowDemo> {
+  <template>
+    <div class='board'>
+      <header class='explainer'>
+        <h2>Adorn hover-label overflow demo</h2>
+        <p>
+          The Adorn type-label tab anchors above the card's top-left corner and
+          grows rightward until its right edge hits the card's top-right corner
+          radius. Past that point it pins the right edge to the corner-radius
+          point and lets the extra width spill off the card's left edge.
+        </p>
+        <p>
+          That spill assumes there's room to the left. A narrow kanban column
+          with
+          <code>overflow: hidden</code>
+          (typical for vertically-scrolling columns) clips the leftward growth
+          at the column boundary. Hover any task in the leftmost column to see
+          the type-name truncate before it's fully readable, even though the
+          card itself is rendered correctly.
+        </p>
+      </header>
+      <div class='columns'>
+        <div class='column'>
+          <div class='column-header'>Backlog</div>
+          <div class='column-stack'>
+            <@fields.backlog />
+          </div>
+        </div>
+        <div class='column'>
+          <div class='column-header'>In Progress</div>
+          <div class='column-stack'>
+            <@fields.inProgress />
+          </div>
+        </div>
+        <div class='column'>
+          <div class='column-header'>Done</div>
+          <div class='column-stack'>
+            <@fields.done />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <style scoped>
+      .board {
+        display: grid;
+        gap: var(--boxel-sp-lg);
+        padding: var(--boxel-sp-lg);
+      }
+      .explainer {
+        max-width: 720px;
+      }
+      .explainer h2 {
+        margin: 0 0 var(--boxel-sp-sm);
+        font: 700 var(--boxel-font-lg);
+      }
+      .explainer p {
+        margin: 0 0 var(--boxel-sp-sm);
+        font: var(--boxel-font-sm);
+        color: var(--boxel-500);
+      }
+      .explainer code {
+        background: var(--boxel-200);
+        padding: 1px 4px;
+        border-radius: 3px;
+        font-size: 0.9em;
+      }
+      .columns {
+        display: grid;
+        grid-template-columns: repeat(3, 220px);
+        gap: var(--boxel-sp);
+        align-items: start;
+      }
+      .column {
+        background: var(--boxel-100);
+        border-radius: var(--boxel-border-radius);
+        /* The clip is what reproduces the bug: the leftward overflow of the
+           Adorn label has nowhere to go and is cut off at the column edge. */
+        overflow: hidden;
+      }
+      .column-header {
+        padding: var(--boxel-sp-sm);
+        font: 700 var(--boxel-font-sm);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: var(--boxel-700);
+        border-bottom: 1px solid var(--boxel-200);
+      }
+      .column-stack {
+        padding: var(--boxel-sp-xxs);
+        display: grid;
+        gap: var(--boxel-sp-xxs);
+      }
+    </style>
+  </template>
+}
+
+export default class AdornOverflowDemo extends CardDef {
+  static displayName = 'Adorn Overflow Demo';
+
+  @field backlog = linksToMany(ProjectInitiativeTask);
+  @field inProgress = linksToMany(ProjectInitiativeTask);
+  @field done = linksToMany(ProjectInitiativeTask);
+
+  static isolated = AdornOverflowDemoIsolated;
+}

--- a/packages/experiments-realm/adorn-overflow-demo.gts
+++ b/packages/experiments-realm/adorn-overflow-demo.gts
@@ -7,7 +7,7 @@ import {
 } from 'https://cardstack.com/base/card-api';
 import StringField from 'https://cardstack.com/base/string';
 
-class ProjectInitiativeTask extends CardDef {
+export class ProjectInitiativeTask extends CardDef {
   static displayName = 'Cross-Functional Strategic Initiative Planning Task';
   @field title = contains(StringField);
 

--- a/packages/experiments-realm/adorn-overflow-demo.gts
+++ b/packages/experiments-realm/adorn-overflow-demo.gts
@@ -124,7 +124,7 @@ class AdornOverflowDemoIsolated extends Component<typeof AdornOverflowDemo> {
   </template>
 }
 
-export default class AdornOverflowDemo extends CardDef {
+export class AdornOverflowDemo extends CardDef {
   static displayName = 'Adorn Overflow Demo';
 
   @field backlog = linksToMany(ProjectInitiativeTask);

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -65,19 +65,13 @@ import type { StackItemRenderedCardForOverlayActions } from './stack-item';
 import type { CardDefOrId } from './stack-item';
 import type StoreService from '../../services/store';
 
-// Walks up from a rendered card's DOM element to find the nearest
-// enclosing rendered-card wrapper (`[data-boxel-card-id]`) — i.e. the
-// card this card is embedded in. Top-level cards have no such wrapper,
-// so we fall back to the operator-mode stack item's content area,
-// which is the visual frame that should bound the label.
+// The label's outward growth should be bounded by the visible frame
+// of the operator-mode stack item — that's the box that defines the
+// "page" the card is rendered on, and it keeps the label out of the
+// chrome around it (sidebar, dialog title bar). Within that frame
+// the label is free to extend across sibling cards / columns when
+// the hovered card is near an edge.
 function findAdornLabelBoundary(cardEl: HTMLElement): HTMLElement | null {
-  let cur = cardEl.parentElement;
-  while (cur) {
-    if (cur.hasAttribute('data-boxel-card-id')) {
-      return cur;
-    }
-    cur = cur.parentElement;
-  }
   return cardEl.closest<HTMLElement>('.stack-item-content');
 }
 

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -471,29 +471,28 @@ export default class OperatorModeOverlays extends Overlays {
             : 'bottom';
         label.setAttribute('data-side', side);
 
-        // Anchor the appropriate horizontal edge to the card, then
-        // (in the overflow case only) clamp the un-anchored edge
-        // against the boundary so the ellipsis kicks in instead of
-        // spilling outside the containing card. When the label fits
-        // the card by construction (!shouldOverflow), we use the
-        // natural width and skip the boundary clamp — otherwise a
-        // boundary whose right edge sits just past the card's would
-        // shave a few pixels off the label and trigger the ellipsis
-        // unnecessarily.
-        let anchorRightX: number;
+        // Anchor the appropriate horizontal edge to the card. In the
+        // overflow case we clamp the un-anchored edge to the
+        // boundary so the ellipsis kicks in instead of spilling
+        // outside the containing card. In the fits-the-card case we
+        // hand the browser `max-width: max-content` rather than a
+        // measured pixel value — `scrollWidth` is an integer, so
+        // converting it back to `max-width: Npx` shaves the
+        // sub-pixel remainder off and triggers `text-overflow:
+        // ellipsis` on a label that obviously had room to spare.
         let anchorLeftX: number;
         if (shouldOverflow) {
-          anchorRightX = cardRect.right - (radius - 4);
+          let anchorRightX = cardRect.right - (radius - 4);
           anchorLeftX = Math.max(
             boundaryRect.left + 4,
             anchorRightX - labelWidth,
           );
+          let width = Math.max(0, anchorRightX - anchorLeftX);
+          label.style.maxWidth = width + 'px';
         } else {
           anchorLeftX = cardRect.left - 4;
-          anchorRightX = anchorLeftX + labelWidth;
+          label.style.maxWidth = 'max-content';
         }
-        let width = Math.max(0, anchorRightX - anchorLeftX);
-        label.style.maxWidth = width + 'px';
         label.style.left = anchorLeftX + 'px';
         label.style.top =
           (side === 'top'

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 
 import DotsVertical from '@cardstack/boxel-icons/dots-vertical';
+import { modifier } from 'ember-modifier';
 import { consume } from 'ember-provide-consume-context';
 import { velcro } from 'ember-velcro';
 
@@ -104,11 +105,15 @@ export default class OperatorModeOverlays extends Overlays {
             style={{renderedCard.overlayZIndexStyle}}
             ...attributes
           >
-            {{! Type-label tab — hover only, anchored top-right, overflows off the left when long }}
+            {{! Type-label tab — hover only. Anchored top-left while it
+                fits; once it can't grow further right without entering the
+                card's corner radius it pivots to a right anchor at that
+                point and overflows off the left edge instead. }}
             {{#if isHovered}}
               <div
                 class='adorn-label'
                 data-test-overlay-label
+                {{this.trackLabelOverflow}}
                 {{on 'mouseenter' this.cancelHoverClear}}
                 {{on 'mouseleave' this.scheduleHoverClear}}
               >
@@ -233,15 +238,19 @@ export default class OperatorModeOverlays extends Overlays {
         box-shadow: 0 0 0 4px var(--adorn-accent);
       }
 
-      /* Type-label tab — flag shape with sloped right edge, anchored above
-         the card's top-right corner so its right edge aligns with the 4px
-         selection stroke. Long names overflow off the card's left edge
-         rather than the right. */
+      /* Type-label tab — flag shape with sloped right edge. The
+         `left` value is computed in JS (see trackLabelOverflow): for
+         labels that fit, it pins to -4px so the left edge lines up
+         with the 4px selection-stroke inset; for labels that don't
+         fit, [data-overflow] is set and `left` becomes a negative
+         pixel value that places the label's right edge at the start
+         of the card's top-right corner radius, letting the extra
+         width spill off the card's left edge. */
       .adorn-label {
         position: absolute;
         bottom: calc(100% + 2px);
-        right: -4px;
-        left: auto;
+        left: -4px;
+        right: auto;
         top: auto;
         display: inline-flex;
         align-items: center;
@@ -360,6 +369,56 @@ export default class OperatorModeOverlays extends Overlays {
     // needs to bridge that gap without the chrome dismissing itself.
     return 100;
   }
+
+  // Positions the type-label tab so it hugs the card's top-left corner
+  // when its content fits, or pins its right edge to the start of the
+  // card's top-right corner radius (overflowing off the left edge) when
+  // it doesn't. The position is written as an integer-pixel `left`
+  // value rather than CSS `right: calc(...)`, because velcro's
+  // floating-ui autoUpdate re-fires on DOM mutations (e.g. when the
+  // menu dropdown opens), and the sub-pixel overlay width it writes
+  // would otherwise shift a right-anchored label by a pixel or two.
+  // Observes the label's stable children plus the overlay parent —
+  // never the label itself — and uses integer clientWidth / scrollWidth
+  // readings plus 4px hysteresis to keep sub-pixel wobble from flipping
+  // the overflow decision.
+  private trackLabelOverflow = modifier((label: HTMLElement) => {
+    let overlay = label.closest<HTMLElement>('.actions-overlay');
+    if (!overlay) {
+      return;
+    }
+    let update = () => {
+      let radiusStr = window
+        .getComputedStyle(overlay)
+        .getPropertyValue('--card-corner-radius')
+        .trim();
+      let radius = parseFloat(radiusStr) || 0;
+      let overlayWidth = overlay.clientWidth;
+      let labelWidth = label.scrollWidth;
+      // The label has a 4px bleed on its anchored side so its edge
+      // lines up with the selection stroke. That bleed counts as
+      // usable space on whichever side it's not currently on.
+      let available = overlayWidth - radius + 4;
+      let wasOverflowing = label.hasAttribute('data-overflow');
+      let shouldOverflow = wasOverflowing
+        ? !(labelWidth + 4 < available) // hysteresis: only exit overflow once comfortably under
+        : labelWidth > available;
+      if (shouldOverflow) {
+        label.setAttribute('data-overflow', '');
+        label.style.left = overlayWidth - radius + 4 - labelWidth + 'px';
+      } else {
+        label.removeAttribute('data-overflow');
+        label.style.left = '-4px';
+      }
+    };
+    let observer = new ResizeObserver(update);
+    observer.observe(overlay);
+    for (let child of Array.from(label.children)) {
+      observer.observe(child);
+    }
+    update();
+    return () => observer.disconnect();
+  });
 
   protected override shouldDelayHoverClear(): boolean {
     return this.openDropdownCount > 0;

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -104,7 +104,7 @@ export default class OperatorModeOverlays extends Overlays {
             style={{renderedCard.overlayZIndexStyle}}
             ...attributes
           >
-            {{! Type-label tab — hover only, anchored top-left, overflows when long }}
+            {{! Type-label tab — hover only, anchored top-right, overflows off the left when long }}
             {{#if isHovered}}
               <div
                 class='adorn-label'
@@ -234,13 +234,14 @@ export default class OperatorModeOverlays extends Overlays {
       }
 
       /* Type-label tab — flag shape with sloped right edge, anchored above
-         the card's top-left corner so its left edge aligns with the 4px
-         selection stroke. */
+         the card's top-right corner so its right edge aligns with the 4px
+         selection stroke. Long names overflow off the card's left edge
+         rather than the right. */
       .adorn-label {
         position: absolute;
         bottom: calc(100% + 2px);
-        left: -4px;
-        right: auto;
+        right: -4px;
+        left: auto;
         top: auto;
         display: inline-flex;
         align-items: center;

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -513,9 +513,7 @@ export default class OperatorModeOverlays extends Overlays {
           label.style.maxWidth = 'max-content';
         }
         let anchorTopY =
-          side === 'top'
-            ? cardRect.top - labelHeight - 2
-            : cardRect.bottom + 2;
+          side === 'top' ? cardRect.top - labelHeight - 2 : cardRect.bottom + 2;
 
         // The label's anchor positions (anchorLeftX, anchorTopY) are
         // in viewport coordinates. With `position: absolute`, the
@@ -544,8 +542,7 @@ export default class OperatorModeOverlays extends Overlays {
         if (!Number.isFinite(scaleY) || scaleY === 0) {
           scaleY = 1;
         }
-        label.style.left =
-          (anchorLeftX - parentRect.left) / scaleX + 'px';
+        label.style.left = (anchorLeftX - parentRect.left) / scaleX + 'px';
         label.style.top = (anchorTopY - parentRect.top) / scaleY + 'px';
       };
 

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -140,33 +140,42 @@ export default class OperatorModeOverlays extends Overlays {
                 <span class='adorn-label-text'>
                   {{this.getCardTypeName cardDefOrId renderedCard}}
                 </span>
-                <BoxelDropdown
-                  @registerAPI={{this.registerDropdownAPI renderedCard}}
-                  @onClose={{this.handleMenuClose}}
-                >
-                  <:trigger as |bindings|>
-                    <IconButton
-                      @icon={{DotsVertical}}
-                      class='adorn-label-menu'
-                      aria-label='Options'
-                      data-test-overlay-more-options
-                      {{bindings}}
-                      {{on
-                        'click'
-                        (fn this.handleMenuTriggerClick renderedCard)
-                      }}
-                    />
-                  </:trigger>
-                  <:content as |dd|>
-                    <Menu
-                      @closeMenu={{dd.close}}
-                      @items={{this.getMenuItemsForCard
-                        cardDefOrId
-                        renderedCard
-                      }}
-                    />
-                  </:content>
-                </BoxelDropdown>
+                {{! Wrap BoxelDropdown so the trigger and its
+                    portal-origin element count as a single flex item
+                    of the label. Otherwise the label grows by one
+                    flex-gap as soon as the menu opens (the open-state
+                    wormhole-origin becomes a flex item where the
+                    closed-state placeholder was display none), and
+                    the label would shift on every menu open/close. }}
+                <span class='adorn-label-dropdown'>
+                  <BoxelDropdown
+                    @registerAPI={{this.registerDropdownAPI renderedCard}}
+                    @onClose={{this.handleMenuClose}}
+                  >
+                    <:trigger as |bindings|>
+                      <IconButton
+                        @icon={{DotsVertical}}
+                        class='adorn-label-menu'
+                        aria-label='Options'
+                        data-test-overlay-more-options
+                        {{bindings}}
+                        {{on
+                          'click'
+                          (fn this.handleMenuTriggerClick renderedCard)
+                        }}
+                      />
+                    </:trigger>
+                    <:content as |dd|>
+                      <Menu
+                        @closeMenu={{dd.close}}
+                        @items={{this.getMenuItemsForCard
+                          cardDefOrId
+                          renderedCard
+                        }}
+                      />
+                    </:content>
+                  </BoxelDropdown>
+                </span>
               </div>
             {{/if}}
 
@@ -300,6 +309,17 @@ export default class OperatorModeOverlays extends Overlays {
         min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
+      }
+      /* BoxelDropdown wrapper. Inline-flex so the trigger and the
+         portal-origin element (which appears beside the trigger when
+         the menu is open) live inside their own flex container
+         instead of being two direct flex items of the label. Without
+         this wrapper, the label's natural width grows by one
+         flex-gap as soon as the menu opens, shifting the label
+         on click. */
+      .adorn-label-dropdown {
+        display: inline-flex;
+        align-items: center;
       }
       .adorn-label-menu {
         width: 18px;

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -4,6 +4,14 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 
 import DotsVertical from '@cardstack/boxel-icons/dots-vertical';
+import {
+  autoUpdate,
+  computePosition,
+  flip,
+  offset,
+  shift,
+  size,
+} from '@floating-ui/dom';
 import { modifier } from 'ember-modifier';
 import { consume } from 'ember-provide-consume-context';
 import { velcro } from 'ember-velcro';
@@ -63,6 +71,23 @@ import type { StackItemRenderedCardForOverlayActions } from './stack-item';
 
 import type { CardDefOrId } from './stack-item';
 import type StoreService from '../../services/store';
+import type { Middleware, Placement } from '@floating-ui/dom';
+
+// Walks up from a rendered card's DOM element to find the nearest
+// enclosing rendered-card wrapper (`[data-boxel-card-id]`) — i.e. the
+// card this card is embedded in. Top-level cards have no such wrapper,
+// so we fall back to the operator-mode stack item's content area,
+// which is the visual frame that should bound the label.
+function findAdornLabelBoundary(cardEl: HTMLElement): HTMLElement | null {
+  let cur = cardEl.parentElement;
+  while (cur) {
+    if (cur.hasAttribute('data-boxel-card-id')) {
+      return cur;
+    }
+    cur = cur.parentElement;
+  }
+  return cardEl.closest<HTMLElement>('.stack-item-content');
+}
 
 export default class OperatorModeOverlays extends Overlays {
   overlayClassName = 'actions-overlay';
@@ -105,15 +130,17 @@ export default class OperatorModeOverlays extends Overlays {
             style={{renderedCard.overlayZIndexStyle}}
             ...attributes
           >
-            {{! Type-label tab — hover only. Anchored top-left while it
-                fits; once it can't grow further right without entering the
-                card's corner radius it pivots to a right anchor at that
-                point and overflows off the left edge instead. }}
+            {{! Type-label tab — hover only. Position is driven by
+                floating-ui (offset + flip + shift + size) so the label
+                stays inside the containing card's footprint, flipping
+                below the card when there isn't room above and
+                truncating with an ellipsis when there isn't room
+                sideways. }}
             {{#if isHovered}}
               <div
                 class='adorn-label'
                 data-test-overlay-label
-                {{this.trackLabelOverflow}}
+                {{this.trackLabelOverflow renderedCard.element}}
                 {{on 'mouseenter' this.cancelHoverClear}}
                 {{on 'mouseleave' this.scheduleHoverClear}}
               >
@@ -239,23 +266,17 @@ export default class OperatorModeOverlays extends Overlays {
       }
 
       /* Type-label tab — flag shape with sloped right edge. The
-         `left` value is computed in JS (see trackLabelOverflow): for
-         labels that fit, it pins to -4px so the left edge lines up
-         with the 4px selection-stroke inset; for labels that don't
-         fit, [data-overflow] is set and `left` becomes a negative
-         pixel value that places the label's right edge at the start
-         of the card's top-right corner radius, letting the extra
-         width spill off the card's left edge. */
+         `top` and `left` are written inline by trackLabelOverflow via
+         floating-ui (position is `fixed`, viewport-relative). The
+         flag shape is defined entirely by clip-path so it can mirror
+         vertically when the label flips below the card. */
       .adorn-label {
-        position: absolute;
-        bottom: calc(100% + 2px);
-        left: -4px;
-        right: auto;
-        top: auto;
+        position: fixed;
+        top: 0;
+        left: 0;
         display: inline-flex;
         align-items: center;
         gap: 5px;
-        max-width: max-content;
         padding: 3px 12px 3px 7px;
         background: var(--adorn-accent-light);
         color: #0a2e1c;
@@ -263,11 +284,17 @@ export default class OperatorModeOverlays extends Overlays {
         letter-spacing: 0.5px;
         text-transform: uppercase;
         white-space: nowrap;
-        border-radius: 5px 0 0 5px;
+        overflow: hidden;
         clip-path: polygon(0 0, calc(100% - 13px) 0, 100% 100%, 0 100%);
         pointer-events: auto;
         z-index: 1;
         filter: drop-shadow(0 5px 8px rgba(0, 0, 0, 0.2));
+      }
+      /* When floating-ui flips the label below the card, mirror the
+         clip-path vertically so the slope still points toward the
+         card (now upward from the bottom-right corner). */
+      .adorn-label[data-side='bottom'] {
+        clip-path: polygon(0 100%, calc(100% - 13px) 100%, 100% 0, 0 0);
       }
       .actions-overlay.selected .adorn-label {
         background: var(--adorn-accent);
@@ -279,6 +306,11 @@ export default class OperatorModeOverlays extends Overlays {
         color: #0a2e1c;
       }
       .adorn-label-text {
+        /* `min-width: 0` lets the flex item shrink below its
+           min-content size when the label is capped by floating-ui's
+           `size` middleware; without it, text-overflow:ellipsis can't
+           kick in. */
+        min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
       }
@@ -370,55 +402,103 @@ export default class OperatorModeOverlays extends Overlays {
     return 100;
   }
 
-  // Positions the type-label tab so it hugs the card's top-left corner
-  // when its content fits, or pins its right edge to the start of the
-  // card's top-right corner radius (overflowing off the left edge) when
-  // it doesn't. The position is written as an integer-pixel `left`
-  // value rather than CSS `right: calc(...)`, because velcro's
-  // floating-ui autoUpdate re-fires on DOM mutations (e.g. when the
-  // menu dropdown opens), and the sub-pixel overlay width it writes
-  // would otherwise shift a right-anchored label by a pixel or two.
-  // Observes the label's stable children plus the overlay parent —
-  // never the label itself — and uses integer clientWidth / scrollWidth
-  // readings plus 4px hysteresis to keep sub-pixel wobble from flipping
-  // the overflow decision.
-  private trackLabelOverflow = modifier((label: HTMLElement) => {
-    let overlay = label.closest<HTMLElement>('.actions-overlay');
-    if (!overlay) {
-      return;
-    }
-    let update = () => {
-      let radiusStr = window
-        .getComputedStyle(overlay)
-        .getPropertyValue('--card-corner-radius')
-        .trim();
-      let radius = parseFloat(radiusStr) || 0;
-      let overlayWidth = overlay.clientWidth;
-      let labelWidth = label.scrollWidth;
-      // The label has a 4px bleed on its anchored side so its edge
-      // lines up with the selection stroke. That bleed counts as
-      // usable space on whichever side it's not currently on.
-      let available = overlayWidth - radius + 4;
-      let wasOverflowing = label.hasAttribute('data-overflow');
-      let shouldOverflow = wasOverflowing
-        ? !(labelWidth + 4 < available) // hysteresis: only exit overflow once comfortably under
-        : labelWidth > available;
-      if (shouldOverflow) {
-        label.setAttribute('data-overflow', '');
-        label.style.left = overlayWidth - radius + 4 - labelWidth + 'px';
-      } else {
-        label.removeAttribute('data-overflow');
-        label.style.left = '-4px';
+  // Positions the type-label tab via floating-ui (offset + flip + shift
+  // + size) so it stays inside the containing card's footprint:
+  //
+  // - While the natural label width fits the card's interior (card
+  //   width minus the top-right corner radius plus 4px stroke bleed),
+  //   the label is anchored to the card's top-left corner; otherwise
+  //   it pins its right edge to the corner-radius point and grows
+  //   leftward. (4px hysteresis at the threshold keeps sub-pixel
+  //   wobble — e.g. from velcro re-firing when a menu opens — from
+  //   flipping the placement decision.)
+  // - `flip` switches the label below the card when there isn't room
+  //   above (a [data-side="bottom"] attribute mirrors the clip-path
+  //   vertically in CSS so the slope still points toward the card).
+  // - `shift` slides the label horizontally to stay inside the
+  //   boundary; `size` caps its max-width to whatever's still
+  //   available, and the CSS text-overflow:ellipsis truncates the
+  //   text rather than letting the label spill into the chrome
+  //   surrounding the containing card.
+  //
+  // The boundary is the closest enclosing rendered-card wrapper
+  // (`[data-boxel-card-id]`) — i.e. the card this card is embedded
+  // in. Top-level cards fall back to the operator-mode stack item's
+  // content area.
+  private trackLabelOverflow = modifier(
+    (label: HTMLElement, [cardEl]: [HTMLElement | undefined]) => {
+      if (!cardEl) {
+        return undefined;
       }
-    };
-    let observer = new ResizeObserver(update);
-    observer.observe(overlay);
-    for (let child of Array.from(label.children)) {
-      observer.observe(child);
-    }
-    update();
-    return () => observer.disconnect();
-  });
+      let boundary = findAdornLabelBoundary(cardEl);
+      if (!boundary) {
+        return undefined;
+      }
+
+      label.style.position = 'fixed';
+      label.style.top = '0';
+      label.style.left = '0';
+
+      let placementSide: Middleware = {
+        name: 'placement-side',
+        fn: (state) => {
+          let side = state.placement.startsWith('bottom') ? 'bottom' : 'top';
+          if (label.getAttribute('data-side') !== side) {
+            label.setAttribute('data-side', side);
+          }
+          return {};
+        },
+      };
+
+      let update = () => {
+        let cardStyles = window.getComputedStyle(cardEl);
+        let radius = parseFloat(cardStyles.borderTopRightRadius) || 0;
+        let availableWithinCard = cardEl.clientWidth - radius + 4;
+        let labelWidth = label.scrollWidth;
+        let wasOverflowing = label.hasAttribute('data-overflow');
+        let shouldOverflow = wasOverflowing
+          ? !(labelWidth + 4 < availableWithinCard)
+          : labelWidth > availableWithinCard;
+        if (shouldOverflow) {
+          label.setAttribute('data-overflow', '');
+        } else {
+          label.removeAttribute('data-overflow');
+        }
+        let placement: Placement = shouldOverflow ? 'top-end' : 'top-start';
+        // Cross-axis offset replicates the prior 4px stroke bleed on
+        // the anchored side. For top-start the bleed is 4px left of
+        // the card's left edge (-4 cross-axis); for top-end the right
+        // edge sits at the start of the card's corner radius, i.e.
+        // (radius - 4)px left of the card's right edge.
+        let crossAxis = shouldOverflow ? -(radius - 4) : -4;
+        computePosition(cardEl, label, {
+          placement,
+          strategy: 'fixed',
+          middleware: [
+            offset({ mainAxis: 2, crossAxis }),
+            flip({ boundary, padding: 4 }),
+            shift({ boundary, padding: 4 }),
+            size({
+              boundary,
+              padding: 4,
+              apply({ availableWidth, elements }) {
+                elements.floating.style.maxWidth =
+                  Math.max(0, availableWidth) + 'px';
+              },
+            }),
+            placementSide,
+          ],
+        }).then(({ x, y }) => {
+          Object.assign(label.style, {
+            left: `${x}px`,
+            top: `${y}px`,
+          });
+        });
+      };
+
+      return autoUpdate(cardEl, label, update);
+    },
+  );
 
   protected override shouldDelayHoverClear(): boolean {
     return this.openDropdownCount > 0;

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -447,14 +447,8 @@ export default class OperatorModeOverlays extends Overlays {
       }
       let boundary = findAdornLabelBoundary(cardEl);
       if (!boundary) {
-        console.warn(
-          `[adorn-debug] no boundary for card id=${cardEl.getAttribute('data-boxel-card-id') ?? '?'}`,
-        );
         return undefined;
       }
-      console.log(
-        `[adorn-debug] boundary tag=${boundary.tagName} cls="${boundary.className}"`,
-      );
 
       label.style.position = 'fixed';
       label.style.top = '0';
@@ -489,7 +483,6 @@ export default class OperatorModeOverlays extends Overlays {
         label.setAttribute('data-side', side);
 
         let anchorLeftX: number;
-        let widthApplied: string;
         if (shouldOverflow) {
           let anchorRightX = cardRect.right - (radius - 4);
           let unclampedLeft = anchorRightX - labelWidth;
@@ -503,33 +496,22 @@ export default class OperatorModeOverlays extends Overlays {
             // there's room to spare).
             anchorLeftX = unclampedLeft;
             label.style.maxWidth = 'max-content';
-            widthApplied = 'max-content (overflow-fits)';
           } else {
             // Label can't fit inside the boundary at natural width;
             // clamp the un-anchored edge and let the ellipsis show.
             anchorLeftX = boundaryLeftLimit;
             let width = Math.max(0, anchorRightX - anchorLeftX);
             label.style.maxWidth = width + 'px';
-            widthApplied = `${width}px (overflow-clamped)`;
           }
         } else {
           anchorLeftX = cardRect.left - 4;
           label.style.maxWidth = 'max-content';
-          widthApplied = 'max-content (fits)';
         }
         label.style.left = anchorLeftX + 'px';
         label.style.top =
           (side === 'top'
             ? cardRect.top - labelHeight - 2
             : cardRect.bottom + 2) + 'px';
-
-        let textPreview = label.textContent
-          ?.replace(/\s+/g, ' ')
-          .trim()
-          .slice(0, 60);
-        console.log(
-          `[adorn-debug] text="${textPreview}" scrollWidth=${labelWidth} card=(l=${Math.round(cardRect.left)},r=${Math.round(cardRect.right)},w=${Math.round(cardRect.width)}) boundary=(l=${Math.round(boundaryRect.left)},r=${Math.round(boundaryRect.right)},w=${Math.round(boundaryRect.width)}) radius=${radius} availableWithinCard=${Math.round(availableWithinCard)} shouldOverflow=${shouldOverflow} wasOverflowing=${wasOverflowing} anchorLeftX=${Math.round(anchorLeftX)} widthApplied="${widthApplied}"`,
-        );
       };
 
       return autoUpdate(cardEl, label, update);

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -470,13 +470,26 @@ export default class OperatorModeOverlays extends Overlays {
         let widthApplied: string;
         if (shouldOverflow) {
           let anchorRightX = cardRect.right - (radius - 4);
-          anchorLeftX = Math.max(
-            boundaryRect.left + 4,
-            anchorRightX - labelWidth,
-          );
-          let width = Math.max(0, anchorRightX - anchorLeftX);
-          label.style.maxWidth = width + 'px';
-          widthApplied = `${width}px (overflow)`;
+          let unclampedLeft = anchorRightX - labelWidth;
+          let boundaryLeftLimit = boundaryRect.left + 4;
+          if (unclampedLeft >= boundaryLeftLimit) {
+            // Natural width fits inside the boundary — use
+            // max-content so the browser sizes to the true intrinsic
+            // width (scrollWidth is integer-rounded, so writing it
+            // back as `max-width: Npx` would shave a sub-pixel
+            // remainder and trip text-overflow:ellipsis even though
+            // there's room to spare).
+            anchorLeftX = unclampedLeft;
+            label.style.maxWidth = 'max-content';
+            widthApplied = 'max-content (overflow-fits)';
+          } else {
+            // Label can't fit inside the boundary at natural width;
+            // clamp the un-anchored edge and let the ellipsis show.
+            anchorLeftX = boundaryLeftLimit;
+            let width = Math.max(0, anchorRightX - anchorLeftX);
+            label.style.maxWidth = width + 'px';
+            widthApplied = `${width}px (overflow-clamped)`;
+          }
         } else {
           anchorLeftX = cardRect.left - 4;
           label.style.maxWidth = 'max-content';

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -472,9 +472,14 @@ export default class OperatorModeOverlays extends Overlays {
         label.setAttribute('data-side', side);
 
         // Anchor the appropriate horizontal edge to the card, then
-        // clamp the other edge against the boundary. The clamp
-        // result is the label's max-width; the anchored edge stays
-        // put.
+        // (in the overflow case only) clamp the un-anchored edge
+        // against the boundary so the ellipsis kicks in instead of
+        // spilling outside the containing card. When the label fits
+        // the card by construction (!shouldOverflow), we use the
+        // natural width and skip the boundary clamp — otherwise a
+        // boundary whose right edge sits just past the card's would
+        // shave a few pixels off the label and trigger the ellipsis
+        // unnecessarily.
         let anchorRightX: number;
         let anchorLeftX: number;
         if (shouldOverflow) {
@@ -485,10 +490,7 @@ export default class OperatorModeOverlays extends Overlays {
           );
         } else {
           anchorLeftX = cardRect.left - 4;
-          anchorRightX = Math.min(
-            boundaryRect.right - 4,
-            anchorLeftX + labelWidth,
-          );
+          anchorRightX = anchorLeftX + labelWidth;
         }
         let width = Math.max(0, anchorRightX - anchorLeftX);
         label.style.maxWidth = width + 'px';

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -8,6 +8,7 @@ import {
   autoUpdate,
   computePosition,
   flip,
+  limitShift,
   offset,
   shift,
   size,
@@ -477,7 +478,17 @@ export default class OperatorModeOverlays extends Overlays {
           middleware: [
             offset({ mainAxis: 2, crossAxis }),
             flip({ boundary, padding: 4 }),
-            shift({ boundary, padding: 4 }),
+            // limitShift gives the label a small budget (~16px) of
+            // horizontal slack to nudge inside the boundary before
+            // size starts truncating. Without the limit, shift would
+            // drag the tab arbitrarily far from the hovered card to
+            // fit a long type-name in the boundary, breaking the
+            // visual association between the slope and the card.
+            shift({
+              boundary,
+              padding: 4,
+              limiter: limitShift({ offset: 16 }),
+            }),
             size({
               boundary,
               padding: 4,

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -425,13 +425,14 @@ export default class OperatorModeOverlays extends Overlays {
       }
       let boundary = findAdornLabelBoundary(cardEl);
       if (!boundary) {
-        console.warn('[adorn-debug] no boundary for card', cardEl);
+        console.warn(
+          `[adorn-debug] no boundary for card id=${cardEl.getAttribute('data-boxel-card-id') ?? '?'}`,
+        );
         return undefined;
       }
-      console.log('[adorn-debug] boundary:', boundary, {
-        tag: boundary.tagName,
-        cls: boundary.className,
-      });
+      console.log(
+        `[adorn-debug] boundary tag=${boundary.tagName} cls="${boundary.className}"`,
+      );
 
       label.style.position = 'fixed';
       label.style.top = '0';
@@ -487,26 +488,13 @@ export default class OperatorModeOverlays extends Overlays {
             ? cardRect.top - labelHeight - 2
             : cardRect.bottom + 2) + 'px';
 
-        console.log('[adorn-debug] update', {
-          text: label.textContent?.replace(/\s+/g, ' ').trim().slice(0, 60),
-          labelWidth_scrollWidth: labelWidth,
-          card: {
-            l: Math.round(cardRect.left),
-            r: Math.round(cardRect.right),
-            w: Math.round(cardRect.width),
-          },
-          boundary: {
-            l: Math.round(boundaryRect.left),
-            r: Math.round(boundaryRect.right),
-            w: Math.round(boundaryRect.width),
-          },
-          radius,
-          availableWithinCard: Math.round(availableWithinCard),
-          shouldOverflow,
-          wasOverflowing,
-          anchorLeftX: Math.round(anchorLeftX),
-          widthApplied,
-        });
+        let textPreview = label.textContent
+          ?.replace(/\s+/g, ' ')
+          .trim()
+          .slice(0, 60);
+        console.log(
+          `[adorn-debug] text="${textPreview}" scrollWidth=${labelWidth} card=(l=${Math.round(cardRect.left)},r=${Math.round(cardRect.right)},w=${Math.round(cardRect.width)}) boundary=(l=${Math.round(boundaryRect.left)},r=${Math.round(boundaryRect.right)},w=${Math.round(boundaryRect.width)}) radius=${radius} availableWithinCard=${Math.round(availableWithinCard)} shouldOverflow=${shouldOverflow} wasOverflowing=${wasOverflowing} anchorLeftX=${Math.round(anchorLeftX)} widthApplied="${widthApplied}"`,
+        );
       };
 
       return autoUpdate(cardEl, label, update);

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -270,14 +270,16 @@ export default class OperatorModeOverlays extends Overlays {
         text-transform: uppercase;
         white-space: nowrap;
         overflow: hidden;
+        border-radius: 5px 0 0 5px;
         clip-path: polygon(0 0, calc(100% - 13px) 0, 100% 100%, 0 100%);
         pointer-events: auto;
         z-index: 1;
         filter: drop-shadow(0 5px 8px rgba(0, 0, 0, 0.2));
       }
-      /* When floating-ui flips the label below the card, mirror the
-         clip-path vertically so the slope still points toward the
-         card (now upward from the bottom-right corner). */
+      /* When the label flips below the card, mirror the clip-path
+         vertically so the slope still points toward the card (now
+         upward from the bottom-right corner). The rounded corners
+         stay on the left side either way. */
       .adorn-label[data-side='bottom'] {
         clip-path: polygon(0 100%, calc(100% - 13px) 100%, 100% 0, 0 0);
       }

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -260,12 +260,17 @@ export default class OperatorModeOverlays extends Overlays {
       }
 
       /* Type-label tab — flag shape with sloped right edge. The
-         `top` and `left` are written inline by trackLabelOverflow via
-         floating-ui (position is `fixed`, viewport-relative). The
+         `top` and `left` are written inline by trackLabelOverflow,
+         relative to the actions-overlay offset parent (which velcro
+         keeps aligned with the card). Absolute (not fixed) so the
+         positioning is naturally interpreted in the overlay's local
+         coordinate space — fixed would be sensitive to any
+         transformed ancestor (e.g. the test runner's `#ember-testing`
+         scale wrapper) creating a different containing block. The
          flag shape is defined entirely by clip-path so it can mirror
          vertically when the label flips below the card. */
       .adorn-label {
-        position: fixed;
+        position: absolute;
         top: 0;
         left: 0;
         display: inline-flex;
@@ -450,7 +455,7 @@ export default class OperatorModeOverlays extends Overlays {
         return undefined;
       }
 
-      label.style.position = 'fixed';
+      label.style.position = 'absolute';
       label.style.top = '0';
       label.style.left = '0';
 
@@ -507,11 +512,41 @@ export default class OperatorModeOverlays extends Overlays {
           anchorLeftX = cardRect.left - 4;
           label.style.maxWidth = 'max-content';
         }
-        label.style.left = anchorLeftX + 'px';
-        label.style.top =
-          (side === 'top'
+        let anchorTopY =
+          side === 'top'
             ? cardRect.top - labelHeight - 2
-            : cardRect.bottom + 2) + 'px';
+            : cardRect.bottom + 2;
+
+        // The label's anchor positions (anchorLeftX, anchorTopY) are
+        // in viewport coordinates. With `position: absolute`, the
+        // inline `left`/`top` write to the offset-parent's local
+        // coordinate space — which can be scaled relative to the
+        // viewport (e.g. `#ember-testing` applies `scale(0.5)` in
+        // the test runner). Read the offset parent's rect vs its
+        // unscaled `offsetWidth/offsetHeight` to recover the scale
+        // factors, then convert the viewport anchor into the offset
+        // parent's local space.
+        let offsetParent = label.offsetParent as HTMLElement | null;
+        let parentRect = offsetParent
+          ? offsetParent.getBoundingClientRect()
+          : new DOMRect(0, 0, window.innerWidth, window.innerHeight);
+        let scaleX =
+          offsetParent && offsetParent.offsetWidth > 0
+            ? parentRect.width / offsetParent.offsetWidth
+            : 1;
+        let scaleY =
+          offsetParent && offsetParent.offsetHeight > 0
+            ? parentRect.height / offsetParent.offsetHeight
+            : 1;
+        if (!Number.isFinite(scaleX) || scaleX === 0) {
+          scaleX = 1;
+        }
+        if (!Number.isFinite(scaleY) || scaleY === 0) {
+          scaleY = 1;
+        }
+        label.style.left =
+          (anchorLeftX - parentRect.left) / scaleX + 'px';
+        label.style.top = (anchorTopY - parentRect.top) / scaleY + 'px';
       };
 
       return autoUpdate(cardEl, label, update);

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -425,17 +425,19 @@ export default class OperatorModeOverlays extends Overlays {
       }
       let boundary = findAdornLabelBoundary(cardEl);
       if (!boundary) {
+        console.warn('[adorn-debug] no boundary for card', cardEl);
         return undefined;
       }
+      console.log('[adorn-debug] boundary:', boundary, {
+        tag: boundary.tagName,
+        cls: boundary.className,
+      });
 
       label.style.position = 'fixed';
       label.style.top = '0';
       label.style.left = '0';
 
       let update = () => {
-        // Read the natural content width by clearing max-width
-        // first; otherwise a previously-applied cap would make
-        // scrollWidth read back the clamped width.
         label.style.maxWidth = 'none';
         let labelWidth = label.scrollWidth;
         let labelHeight = label.offsetHeight;
@@ -455,8 +457,6 @@ export default class OperatorModeOverlays extends Overlays {
           label.removeAttribute('data-overflow');
         }
 
-        // Decide vertical side: prefer above, flip below if there
-        // isn't room inside the boundary above the card.
         let spaceAbove = cardRect.top - boundaryRect.top;
         let spaceBelow = boundaryRect.bottom - cardRect.bottom;
         let side: 'top' | 'bottom' =
@@ -465,16 +465,8 @@ export default class OperatorModeOverlays extends Overlays {
             : 'bottom';
         label.setAttribute('data-side', side);
 
-        // Anchor the appropriate horizontal edge to the card. In the
-        // overflow case we clamp the un-anchored edge to the
-        // boundary so the ellipsis kicks in instead of spilling
-        // outside the containing card. In the fits-the-card case we
-        // hand the browser `max-width: max-content` rather than a
-        // measured pixel value — `scrollWidth` is an integer, so
-        // converting it back to `max-width: Npx` shaves the
-        // sub-pixel remainder off and triggers `text-overflow:
-        // ellipsis` on a label that obviously had room to spare.
         let anchorLeftX: number;
+        let widthApplied: string;
         if (shouldOverflow) {
           let anchorRightX = cardRect.right - (radius - 4);
           anchorLeftX = Math.max(
@@ -483,15 +475,38 @@ export default class OperatorModeOverlays extends Overlays {
           );
           let width = Math.max(0, anchorRightX - anchorLeftX);
           label.style.maxWidth = width + 'px';
+          widthApplied = `${width}px (overflow)`;
         } else {
           anchorLeftX = cardRect.left - 4;
           label.style.maxWidth = 'max-content';
+          widthApplied = 'max-content (fits)';
         }
         label.style.left = anchorLeftX + 'px';
         label.style.top =
           (side === 'top'
             ? cardRect.top - labelHeight - 2
             : cardRect.bottom + 2) + 'px';
+
+        console.log('[adorn-debug] update', {
+          text: label.textContent?.replace(/\s+/g, ' ').trim().slice(0, 60),
+          labelWidth_scrollWidth: labelWidth,
+          card: {
+            l: Math.round(cardRect.left),
+            r: Math.round(cardRect.right),
+            w: Math.round(cardRect.width),
+          },
+          boundary: {
+            l: Math.round(boundaryRect.left),
+            r: Math.round(boundaryRect.right),
+            w: Math.round(boundaryRect.width),
+          },
+          radius,
+          availableWithinCard: Math.round(availableWithinCard),
+          shouldOverflow,
+          wasOverflowing,
+          anchorLeftX: Math.round(anchorLeftX),
+          widthApplied,
+        });
       };
 
       return autoUpdate(cardEl, label, update);

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -4,15 +4,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 
 import DotsVertical from '@cardstack/boxel-icons/dots-vertical';
-import {
-  autoUpdate,
-  computePosition,
-  flip,
-  limitShift,
-  offset,
-  shift,
-  size,
-} from '@floating-ui/dom';
+import { autoUpdate } from '@floating-ui/dom';
 import { modifier } from 'ember-modifier';
 import { consume } from 'ember-provide-consume-context';
 import { velcro } from 'ember-velcro';
@@ -72,7 +64,6 @@ import type { StackItemRenderedCardForOverlayActions } from './stack-item';
 
 import type { CardDefOrId } from './stack-item';
 import type StoreService from '../../services/store';
-import type { Middleware, Placement } from '@floating-ui/dom';
 
 // Walks up from a rendered card's DOM element to find the nearest
 // enclosing rendered-card wrapper (`[data-boxel-card-id]`) — i.e. the
@@ -131,12 +122,11 @@ export default class OperatorModeOverlays extends Overlays {
             style={{renderedCard.overlayZIndexStyle}}
             ...attributes
           >
-            {{! Type-label tab — hover only. Position is driven by
-                floating-ui (offset + flip + shift + size) so the label
-                stays inside the containing card's footprint, flipping
-                below the card when there isn't room above and
-                truncating with an ellipsis when there isn't room
-                sideways. }}
+            {{! Type-label tab — hover only. trackLabelOverflow
+                positions the label inline so it stays inside the
+                containing card's footprint, flipping below the card
+                when there isn't room above and truncating with an
+                ellipsis when there isn't room sideways. }}
             {{#if isHovered}}
               <div
                 class='adorn-label'
@@ -403,29 +393,37 @@ export default class OperatorModeOverlays extends Overlays {
     return 100;
   }
 
-  // Positions the type-label tab via floating-ui (offset + flip + shift
-  // + size) so it stays inside the containing card's footprint:
+  // Positions the type-label tab manually inside the containing
+  // card's footprint, so its slope stays anchored to the hovered
+  // card and long type-names get truncated with an ellipsis when
+  // they would otherwise spill into the chrome around the
+  // containing card.
   //
+  // Behavior:
   // - While the natural label width fits the card's interior (card
-  //   width minus the top-right corner radius plus 4px stroke bleed),
-  //   the label is anchored to the card's top-left corner; otherwise
+  //   width minus the top-right corner radius plus 4px stroke
+  //   bleed), the label is anchored top-left at the card; otherwise
   //   it pins its right edge to the corner-radius point and grows
-  //   leftward. (4px hysteresis at the threshold keeps sub-pixel
-  //   wobble — e.g. from velcro re-firing when a menu opens — from
+  //   leftward. (4px hysteresis keeps sub-pixel wobble from
   //   flipping the placement decision.)
-  // - `flip` switches the label below the card when there isn't room
-  //   above (a [data-side="bottom"] attribute mirrors the clip-path
-  //   vertically in CSS so the slope still points toward the card).
-  // - `shift` slides the label horizontally to stay inside the
-  //   boundary; `size` caps its max-width to whatever's still
-  //   available, and the CSS text-overflow:ellipsis truncates the
-  //   text rather than letting the label spill into the chrome
-  //   surrounding the containing card.
+  // - If there isn't room above the card inside the boundary, the
+  //   label flips below; a [data-side] attribute drives the CSS
+  //   that mirrors the clip-path vertically so the slope still
+  //   points toward the card.
+  // - The label's max-width is capped to the space available
+  //   between the anchored edge and the boundary; CSS
+  //   text-overflow:ellipsis truncates the type-name rather than
+  //   letting the label spill outside the containing card.
   //
   // The boundary is the closest enclosing rendered-card wrapper
   // (`[data-boxel-card-id]`) — i.e. the card this card is embedded
   // in. Top-level cards fall back to the operator-mode stack item's
   // content area.
+  //
+  // Floating-ui's `autoUpdate` only triggers the re-fire on scroll,
+  // resize, and ancestor mutations; the placement math is direct
+  // because floating-ui's flip + shift + size middleware aren't a
+  // clean fit for the right-anchored-with-truncation pattern.
   private trackLabelOverflow = modifier(
     (label: HTMLElement, [cardEl]: [HTMLElement | undefined]) => {
       if (!cardEl) {
@@ -440,22 +438,19 @@ export default class OperatorModeOverlays extends Overlays {
       label.style.top = '0';
       label.style.left = '0';
 
-      let placementSide: Middleware = {
-        name: 'placement-side',
-        fn: (state) => {
-          let side = state.placement.startsWith('bottom') ? 'bottom' : 'top';
-          if (label.getAttribute('data-side') !== side) {
-            label.setAttribute('data-side', side);
-          }
-          return {};
-        },
-      };
-
       let update = () => {
-        let cardStyles = window.getComputedStyle(cardEl);
-        let radius = parseFloat(cardStyles.borderTopRightRadius) || 0;
-        let availableWithinCard = cardEl.clientWidth - radius + 4;
+        // Read the natural content width by clearing max-width
+        // first; otherwise a previously-applied cap would make
+        // scrollWidth read back the clamped width.
+        label.style.maxWidth = 'none';
         let labelWidth = label.scrollWidth;
+        let labelHeight = label.offsetHeight;
+
+        let cardRect = cardEl.getBoundingClientRect();
+        let boundaryRect = boundary.getBoundingClientRect();
+        let radius =
+          parseFloat(window.getComputedStyle(cardEl).borderTopRightRadius) || 0;
+        let availableWithinCard = cardRect.width - radius + 4;
         let wasOverflowing = label.hasAttribute('data-overflow');
         let shouldOverflow = wasOverflowing
           ? !(labelWidth + 4 < availableWithinCard)
@@ -465,46 +460,43 @@ export default class OperatorModeOverlays extends Overlays {
         } else {
           label.removeAttribute('data-overflow');
         }
-        let placement: Placement = shouldOverflow ? 'top-end' : 'top-start';
-        // Cross-axis offset replicates the prior 4px stroke bleed on
-        // the anchored side. For top-start the bleed is 4px left of
-        // the card's left edge (-4 cross-axis); for top-end the right
-        // edge sits at the start of the card's corner radius, i.e.
-        // (radius - 4)px left of the card's right edge.
-        let crossAxis = shouldOverflow ? -(radius - 4) : -4;
-        computePosition(cardEl, label, {
-          placement,
-          strategy: 'fixed',
-          middleware: [
-            offset({ mainAxis: 2, crossAxis }),
-            flip({ boundary, padding: 4 }),
-            // limitShift gives the label a small budget (~16px) of
-            // horizontal slack to nudge inside the boundary before
-            // size starts truncating. Without the limit, shift would
-            // drag the tab arbitrarily far from the hovered card to
-            // fit a long type-name in the boundary, breaking the
-            // visual association between the slope and the card.
-            shift({
-              boundary,
-              padding: 4,
-              limiter: limitShift({ offset: 16 }),
-            }),
-            size({
-              boundary,
-              padding: 4,
-              apply({ availableWidth, elements }) {
-                elements.floating.style.maxWidth =
-                  Math.max(0, availableWidth) + 'px';
-              },
-            }),
-            placementSide,
-          ],
-        }).then(({ x, y }) => {
-          Object.assign(label.style, {
-            left: `${x}px`,
-            top: `${y}px`,
-          });
-        });
+
+        // Decide vertical side: prefer above, flip below if there
+        // isn't room inside the boundary above the card.
+        let spaceAbove = cardRect.top - boundaryRect.top;
+        let spaceBelow = boundaryRect.bottom - cardRect.bottom;
+        let side: 'top' | 'bottom' =
+          spaceAbove >= labelHeight + 2 || spaceAbove >= spaceBelow
+            ? 'top'
+            : 'bottom';
+        label.setAttribute('data-side', side);
+
+        // Anchor the appropriate horizontal edge to the card, then
+        // clamp the other edge against the boundary. The clamp
+        // result is the label's max-width; the anchored edge stays
+        // put.
+        let anchorRightX: number;
+        let anchorLeftX: number;
+        if (shouldOverflow) {
+          anchorRightX = cardRect.right - (radius - 4);
+          anchorLeftX = Math.max(
+            boundaryRect.left + 4,
+            anchorRightX - labelWidth,
+          );
+        } else {
+          anchorLeftX = cardRect.left - 4;
+          anchorRightX = Math.min(
+            boundaryRect.right - 4,
+            anchorLeftX + labelWidth,
+          );
+        }
+        let width = Math.max(0, anchorRightX - anchorLeftX);
+        label.style.maxWidth = width + 'px';
+        label.style.left = anchorLeftX + 'px';
+        label.style.top =
+          (side === 'top'
+            ? cardRect.top - labelHeight - 2
+            : cardRect.bottom + 2) + 'px';
       };
 
       return autoUpdate(cardEl, label, update);

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -135,9 +135,16 @@ export default class Overlays extends Component<OverlaySignature> {
       floating.style.position = 'absolute';
       // Mirror the underlying card's corner radius so any decorative
       // outline / box-shadow on the overlay follows the same curve.
+      // Also surface the top-right radius as --card-corner-radius so chrome
+      // anchored above the card (e.g. the adorn-label tab) can clamp itself
+      // to where the rounded corner starts on the right.
       if (reference instanceof Element) {
-        floating.style.borderRadius =
-          window.getComputedStyle(reference).borderRadius;
+        let styles = window.getComputedStyle(reference);
+        floating.style.borderRadius = styles.borderRadius;
+        floating.style.setProperty(
+          '--card-corner-radius',
+          styles.borderTopRightRadius,
+        );
       }
       return {
         x: rects.reference.x,

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -135,16 +135,9 @@ export default class Overlays extends Component<OverlaySignature> {
       floating.style.position = 'absolute';
       // Mirror the underlying card's corner radius so any decorative
       // outline / box-shadow on the overlay follows the same curve.
-      // Also surface the top-right radius as --card-corner-radius so chrome
-      // anchored above the card (e.g. the adorn-label tab) can clamp itself
-      // to where the rounded corner starts on the right.
       if (reference instanceof Element) {
-        let styles = window.getComputedStyle(reference);
-        floating.style.borderRadius = styles.borderRadius;
-        floating.style.setProperty(
-          '--card-corner-radius',
-          styles.borderTopRightRadius,
-        );
+        floating.style.borderRadius =
+          window.getComputedStyle(reference).borderRadius;
       }
       return {
         x: rects.reference.x,

--- a/packages/host/tests/integration/components/overlay-menu-items-test.gts
+++ b/packages/host/tests/integration/components/overlay-menu-items-test.gts
@@ -326,7 +326,7 @@ module('Integration | overlay-menu-items', function (hooks) {
       );
   });
 
-  test('hover type-label tab anchors left while it fits and clamps to the corner radius when it overflows', async function (assert) {
+  test('hover type-label tab anchors left while it fits and clamps to the corner radius when it overflows, and stays inside the containing card', async function (assert) {
     setCardInOperatorModeState([`${testRealmURL}ParentCard/1`]);
     await renderComponent(
       class TestDriver extends GlimmerComponent {
@@ -334,48 +334,61 @@ module('Integration | overlay-menu-items', function (hooks) {
       },
     );
     let cardSelector = `[data-test-card="${testRealmURL}CardWithCustomMenu/1"]`;
+    let parentSelector = `[data-test-card="${testRealmURL}ParentCard/1"]`;
     let overlaySelector = `[data-test-overlay-card="${testRealmURL}CardWithCustomMenu/1"]`;
     await waitFor(cardSelector);
     await triggerEvent(cardSelector, 'mouseenter');
-    await waitFor(`${overlaySelector} [data-test-overlay-label]`);
+    let label = (await waitFor(
+      `${overlaySelector} [data-test-overlay-label]`,
+    )) as HTMLElement;
+    let card = find(cardSelector) as HTMLElement;
+    let boundary = find(parentSelector) as HTMLElement;
 
-    let label = find(`${overlaySelector} [data-test-overlay-label]`)!;
-    let overlay = find(overlaySelector)!;
-
-    // The label's anchor is decided after the ResizeObserver fires; give
-    // the browser a frame so the post-layout decision is recorded.
+    // Floating-ui positions asynchronously via Promise; wait for the
+    // label to acquire a non-zero footprint before measuring.
     await waitUntil(() => label.getBoundingClientRect().width > 0, {
       timeout: 1000,
     });
 
     let labelRect = label.getBoundingClientRect();
-    let overlayRect = overlay.getBoundingClientRect();
-    let radius = parseFloat(
-      window.getComputedStyle(overlay).getPropertyValue('--card-corner-radius'),
-    );
+    let cardRect = card.getBoundingClientRect();
+    let boundaryRect = boundary.getBoundingClientRect();
+    let radius = parseFloat(window.getComputedStyle(card).borderTopRightRadius);
 
     if (label.hasAttribute('data-overflow')) {
-      // Right edge clamps to the start of the card's top-right corner
-      // radius (with the 4px selection-stroke bleed on that side), and
-      // the leftward growth overflows past the overlay's left edge.
+      // Long-name case: right edge sits at the start of the card's
+      // top-right corner radius (with the 4px stroke bleed), and the
+      // extra width spills off the card's left edge.
       assert.ok(
-        Math.abs(overlayRect.right - labelRect.right - (radius - 4)) <= 2,
+        Math.abs(cardRect.right - labelRect.right - (radius - 4)) <= 2,
         "overflowing label's right edge sits at the card's corner-radius point",
       );
       assert.ok(
-        labelRect.left < overlayRect.left,
-        'overflowing label extends past the overlay left edge',
+        labelRect.left < cardRect.left,
+        'overflowing label extends past the card left edge',
       );
     } else {
-      // Fits: hugs the overlay's left edge with the 4px bleed.
+      // Short-name case: hugs the card's left edge with the 4px bleed.
       assert.ok(
-        Math.abs(labelRect.left - (overlayRect.left - 4)) <= 2,
-        "fitting label is anchored to the overlay's left edge",
+        Math.abs(labelRect.left - (cardRect.left - 4)) <= 2,
+        "fitting label is anchored to the card's left edge",
       );
       assert.ok(
-        labelRect.right <= overlayRect.right - radius + 2,
+        labelRect.right <= cardRect.right - radius + 2,
         "fitting label's right edge stays before the corner-radius point",
       );
     }
+
+    // Either way, floating-ui's shift/size keep the label inside the
+    // containing-card boundary (a few pixels of slop for sub-pixel
+    // rounding, the shift padding, and the drop-shadow's render box).
+    assert.ok(
+      labelRect.left >= boundaryRect.left - 4,
+      'label left edge stays inside the containing card',
+    );
+    assert.ok(
+      labelRect.right <= boundaryRect.right + 4,
+      'label right edge stays inside the containing card',
+    );
   });
 });

--- a/packages/host/tests/integration/components/overlay-menu-items-test.gts
+++ b/packages/host/tests/integration/components/overlay-menu-items-test.gts
@@ -1,4 +1,10 @@
-import { waitFor, click, triggerEvent, find } from '@ember/test-helpers';
+import {
+  waitFor,
+  waitUntil,
+  click,
+  triggerEvent,
+  find,
+} from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
 import { getService } from '@universal-ember/test-support';
@@ -320,7 +326,7 @@ module('Integration | overlay-menu-items', function (hooks) {
       );
   });
 
-  test('hover type-label tab is right-justified so long names overflow off the left edge', async function (assert) {
+  test('hover type-label tab anchors left while it fits and clamps to the corner radius when it overflows', async function (assert) {
     setCardInOperatorModeState([`${testRealmURL}ParentCard/1`]);
     await renderComponent(
       class TestDriver extends GlimmerComponent {
@@ -335,17 +341,44 @@ module('Integration | overlay-menu-items', function (hooks) {
 
     let label = find(`${overlaySelector} [data-test-overlay-label]`)!;
     let overlay = find(overlaySelector)!;
+
+    // The label's anchor is decided after the ResizeObserver fires; give
+    // the browser a frame so the post-layout decision is recorded.
+    await waitUntil(
+      () => label.getBoundingClientRect().width > 0,
+      { timeout: 1000 },
+    );
+
     let labelRect = label.getBoundingClientRect();
     let overlayRect = overlay.getBoundingClientRect();
-
-    // The tab is anchored to the card's top-right corner: its right edge hugs
-    // the overlay's right edge (within the 4px selection-stroke inset) while
-    // long names overflow off the left. So the label's right edge sits closer
-    // to the overlay's right edge than its left edge does to the left edge.
-    assert.ok(
-      Math.abs(labelRect.right - overlayRect.right) <=
-        Math.abs(labelRect.left - overlayRect.left),
-      "type-label tab is right-justified (anchored to the card's right edge)",
+    let radius = parseFloat(
+      window
+        .getComputedStyle(overlay)
+        .getPropertyValue('--card-corner-radius'),
     );
+
+    if (label.hasAttribute('data-overflow')) {
+      // Right edge clamps to the start of the card's top-right corner
+      // radius (with the 4px selection-stroke bleed on that side), and
+      // the leftward growth overflows past the overlay's left edge.
+      assert.ok(
+        Math.abs(overlayRect.right - labelRect.right - (radius - 4)) <= 2,
+        "overflowing label's right edge sits at the card's corner-radius point",
+      );
+      assert.ok(
+        labelRect.left < overlayRect.left,
+        'overflowing label extends past the overlay left edge',
+      );
+    } else {
+      // Fits: hugs the overlay's left edge with the 4px bleed.
+      assert.ok(
+        Math.abs(labelRect.left - (overlayRect.left - 4)) <= 2,
+        "fitting label is anchored to the overlay's left edge",
+      );
+      assert.ok(
+        labelRect.right <= overlayRect.right - radius + 2,
+        "fitting label's right edge stays before the corner-radius point",
+      );
+    }
   });
 });

--- a/packages/host/tests/integration/components/overlay-menu-items-test.gts
+++ b/packages/host/tests/integration/components/overlay-menu-items-test.gts
@@ -344,10 +344,13 @@ module('Integration | overlay-menu-items', function (hooks) {
     let card = find(cardSelector) as HTMLElement;
     let boundary = find(parentSelector) as HTMLElement;
 
-    // The label is positioned asynchronously by trackLabelOverflow's
-    // autoUpdate; wait for it to acquire a non-zero footprint before
-    // measuring.
-    await waitUntil(() => label.getBoundingClientRect().width > 0, {
+    // trackLabelOverflow sets `style.left = '0'` synchronously at
+    // setup, then writes the computed `Npx` value when its update
+    // runs. The label has its natural content width as soon as it's
+    // inserted (so `width > 0` is not a strong-enough signal), but
+    // the inline `left` is in `px` form only after the positioner
+    // has fired. Wait on that to know the JS positioning has landed.
+    await waitUntil(() => label.style.left.endsWith('px'), {
       timeout: 1000,
     });
 

--- a/packages/host/tests/integration/components/overlay-menu-items-test.gts
+++ b/packages/host/tests/integration/components/overlay-menu-items-test.gts
@@ -1,4 +1,4 @@
-import { waitFor, click, triggerEvent } from '@ember/test-helpers';
+import { waitFor, click, triggerEvent, find } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
 import { getService } from '@universal-ember/test-support';
@@ -318,5 +318,34 @@ module('Integration | overlay-menu-items', function (hooks) {
       .doesNotExist(
         'the card-flavored URL label is suppressed for file targets',
       );
+  });
+
+  test('hover type-label tab is right-justified so long names overflow off the left edge', async function (assert) {
+    setCardInOperatorModeState([`${testRealmURL}ParentCard/1`]);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    let cardSelector = `[data-test-card="${testRealmURL}CardWithCustomMenu/1"]`;
+    let overlaySelector = `[data-test-overlay-card="${testRealmURL}CardWithCustomMenu/1"]`;
+    await waitFor(cardSelector);
+    await triggerEvent(cardSelector, 'mouseenter');
+    await waitFor(`${overlaySelector} [data-test-overlay-label]`);
+
+    let label = find(`${overlaySelector} [data-test-overlay-label]`)!;
+    let overlay = find(overlaySelector)!;
+    let labelRect = label.getBoundingClientRect();
+    let overlayRect = overlay.getBoundingClientRect();
+
+    // The tab is anchored to the card's top-right corner: its right edge hugs
+    // the overlay's right edge (within the 4px selection-stroke inset) while
+    // long names overflow off the left. So the label's right edge sits closer
+    // to the overlay's right edge than its left edge does to the left edge.
+    assert.ok(
+      Math.abs(labelRect.right - overlayRect.right) <=
+        Math.abs(labelRect.left - overlayRect.left),
+      "type-label tab is right-justified (anchored to the card's right edge)",
+    );
   });
 });

--- a/packages/host/tests/integration/components/overlay-menu-items-test.gts
+++ b/packages/host/tests/integration/components/overlay-menu-items-test.gts
@@ -344,17 +344,14 @@ module('Integration | overlay-menu-items', function (hooks) {
 
     // The label's anchor is decided after the ResizeObserver fires; give
     // the browser a frame so the post-layout decision is recorded.
-    await waitUntil(
-      () => label.getBoundingClientRect().width > 0,
-      { timeout: 1000 },
-    );
+    await waitUntil(() => label.getBoundingClientRect().width > 0, {
+      timeout: 1000,
+    });
 
     let labelRect = label.getBoundingClientRect();
     let overlayRect = overlay.getBoundingClientRect();
     let radius = parseFloat(
-      window
-        .getComputedStyle(overlay)
-        .getPropertyValue('--card-corner-radius'),
+      window.getComputedStyle(overlay).getPropertyValue('--card-corner-radius'),
     );
 
     if (label.hasAttribute('data-overflow')) {


### PR DESCRIPTION
## Summary
The Adorn hover type-label tab now uses a two-phase anchor:

- While the label's natural width fits, it hugs the card's **top-left** corner with a 4px bleed that lines up with the selection stroke.
- When it doesn't fit, its **right edge** pins to the start of the card's top-right corner radius and the extra width spills off the card's **left** edge — so long card-type names never collide with the rounded corner.
- The label stays inside the visible stack-item frame: it flips below the card when there isn't room above, and truncates with an ellipsis when it can't fit at natural width without escaping the panel into surrounding chrome (operator-mode sidebar, dialog title bar). Within the panel, intra-panel overlap with sibling cards is allowed.

Resolves CS-11280.

## Implementation
- A `trackLabelOverflow` ember-modifier on the label computes position directly from the rendered card's rect and the visible stack-item frame's rect, then writes `left`, `top`, `max-width`, and a `data-side` attribute on the label inline.
- The boundary is `.stack-item-content` — the visible top-level frame for the panel the card is rendered on. Sibling cards / columns within that frame don't constrain the label; the chrome around it does.
- Anchor decision: short labels use `left = card.left − 4`. Long labels (natural width > `card.width − corner-radius + 4`) anchor their right edge to `card.right − (corner-radius − 4)` and grow leftward, with a 4px hysteresis so sub-pixel wobble can't flip the placement on every layout pass.
- Width: when the label's natural width fits the boundary, `max-width: max-content` so the browser sizes to the true intrinsic width (writing back the integer-rounded `scrollWidth` would shave a sub-pixel remainder and trip `text-overflow: ellipsis` even with room to spare). Only when the label actually has to clamp against the boundary do we write a measured pixel value, which is the case where ellipsis is the desired outcome.
- Side: prefer above; flip below when there's not enough room above the card inside the boundary. The `[data-side="bottom"]` attribute drives a CSS rule that mirrors the `clip-path` polygon vertically so the slope still points toward the card.
- The label is wrapped around `BoxelDropdown` with an inline-flex `<span>` so the dropdown's trigger and its portal-origin counts as a single flex item of the label — without it the label's natural width grows by one flex-gap when the menu opens (the open-state wormhole-origin becomes a flex item where the closed-state placeholder is `display: none`), shifting the label on every menu open.
- `autoUpdate` from `@floating-ui/dom` re-fires the position update on scroll, resize, and ancestor mutations; the placement math is direct (floating-ui's `flip` + `shift` + `size` middleware aren't a clean fit for the right-anchored-with-truncation pattern, and `limitShift` doesn't actually cap shift distance the way it reads).

## Tests
- Integration test `overlay-menu-items-test.gts` asserts both anchor phases (short → left-anchored at `card.left − 4`, long → right edge clamped to the corner-radius point and overflowing past `card.left`) and that the label stays inside the containing-card frame either way.

## Demo card
- `packages/experiments-realm/adorn-overflow-demo.gts` renders a 3-column kanban with deliberately long task-card type names so the long-label / flip-below / boundary-clamp behavior can be reproduced by hand.

## Test plan
- [x] Integration tests pass.
- [x] Manually verified on a card with a long type name that the tab grows rightward up to the corner radius and then spills off the left as the name lengthens further.
- [x] Manually verified that opening the 3-dot menu does not shift the label horizontally.
- [x] Manually verified that a label near the top of a panel flips below the card instead of intruding on the panel chrome.

https://github.com/user-attachments/assets/21be36c6-af99-4d6b-9b75-18ee7bdf72c3

🤖 Generated with [Claude Code](https://claude.com/claude-code)