### PR TITLE
Remove light-grey corner seam on the Adorn hover bar

### DIFF
--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -253,8 +253,19 @@ export default class OperatorModeOverlays extends Overlays {
         letter-spacing: 0.5px;
         text-transform: uppercase;
         white-space: nowrap;
-        border-radius: 5px 0 0 5px;
-        clip-path: polygon(0 0, calc(100% - 13px) 0, 100% 100%, 0 100%);
+        /* The rounded left corners are part of the clip-path itself (a 4px
+           bevel) rather than a separate border-radius. Combining border-radius
+           with clip-path leaves a faint light-grey anti-aliasing seam at the
+           rounded corners; folding the rounding into the single clip shape so
+           the fill and the drop-shadow share identical geometry removes it. */
+        clip-path: polygon(
+          4px 0,
+          calc(100% - 13px) 0,
+          100% 100%,
+          4px 100%,
+          0 calc(100% - 4px),
+          0 4px
+        );
         pointer-events: auto;
         z-index: 1;
         filter: drop-shadow(0 5px 8px rgba(0, 0, 0, 0.2));

--- a/packages/host/tests/integration/components/overlay-menu-items-test.gts
+++ b/packages/host/tests/integration/components/overlay-menu-items-test.gts
@@ -1,4 +1,4 @@
-import { waitFor, click, triggerEvent, find } from '@ember/test-helpers';
+import { waitFor, click, triggerEvent } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
 import { getService } from '@universal-ember/test-support';
@@ -333,23 +333,31 @@ module('Integration | overlay-menu-items', function (hooks) {
       `[data-test-card="${testRealmURL}CardWithCustomMenu/1"]`,
       'mouseenter',
     );
-    await waitFor(`${overlaySelector} [data-test-overlay-label]`);
-
-    let label = find(`${overlaySelector} [data-test-overlay-label]`)!;
+    let label = (await waitFor(
+      `${overlaySelector} [data-test-overlay-label]`,
+    )) as HTMLElement;
     let styles = window.getComputedStyle(label);
 
     // The rounded corners live in the clip-path, not border-radius. Combining
     // the two leaves a light-grey anti-aliasing seam at the corners, so the
-    // label must keep its corner rounding entirely within the clip shape.
+    // label must keep its corner rounding entirely within the clip shape on
+    // every corner — a partial radius on any side reintroduces the seam.
     assert.notEqual(
       styles.clipPath,
       'none',
       'type-label tab clips its flag shape via clip-path',
     );
-    assert.strictEqual(
-      styles.borderTopLeftRadius,
-      '0px',
-      'type-label tab has no border-radius (rounding is folded into the clip-path)',
-    );
+    for (let corner of [
+      'borderTopLeftRadius',
+      'borderTopRightRadius',
+      'borderBottomRightRadius',
+      'borderBottomLeftRadius',
+    ] as const) {
+      assert.strictEqual(
+        styles[corner],
+        '0px',
+        `${corner} is 0 (corner rounding is folded into the clip-path)`,
+      );
+    }
   });
 });

--- a/packages/host/tests/integration/components/overlay-menu-items-test.gts
+++ b/packages/host/tests/integration/components/overlay-menu-items-test.gts
@@ -1,4 +1,4 @@
-import { waitFor, click, triggerEvent } from '@ember/test-helpers';
+import { waitFor, click, triggerEvent, find } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
 import { getService } from '@universal-ember/test-support';
@@ -318,5 +318,38 @@ module('Integration | overlay-menu-items', function (hooks) {
       .doesNotExist(
         'the card-flavored URL label is suppressed for file targets',
       );
+  });
+
+  test('hover type-label tab clips its shape without a separate border-radius', async function (assert) {
+    setCardInOperatorModeState([`${testRealmURL}ParentCard/1`]);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    let overlaySelector = `[data-test-overlay-card="${testRealmURL}CardWithCustomMenu/1"]`;
+    await waitFor(`[data-test-card="${testRealmURL}CardWithCustomMenu/1"]`);
+    await triggerEvent(
+      `[data-test-card="${testRealmURL}CardWithCustomMenu/1"]`,
+      'mouseenter',
+    );
+    await waitFor(`${overlaySelector} [data-test-overlay-label]`);
+
+    let label = find(`${overlaySelector} [data-test-overlay-label]`)!;
+    let styles = window.getComputedStyle(label);
+
+    // The rounded corners live in the clip-path, not border-radius. Combining
+    // the two leaves a light-grey anti-aliasing seam at the corners, so the
+    // label must keep its corner rounding entirely within the clip shape.
+    assert.notEqual(
+      styles.clipPath,
+      'none',
+      'type-label tab clips its flag shape via clip-path',
+    );
+    assert.strictEqual(
+      styles.borderTopLeftRadius,
+      '0px',
+      'type-label tab has no border-radius (rounding is folded into the clip-path)',
+    );
   });
 });

--- a/packages/host/tests/integration/components/overlay-menu-items-test.gts
+++ b/packages/host/tests/integration/components/overlay-menu-items-test.gts
@@ -338,10 +338,12 @@ module('Integration | overlay-menu-items', function (hooks) {
     )) as HTMLElement;
     let styles = window.getComputedStyle(label);
 
-    // The rounded corners live in the clip-path, not border-radius. Combining
-    // the two leaves a light-grey anti-aliasing seam at the corners, so the
-    // label must keep its corner rounding entirely within the clip shape on
-    // every corner — a partial radius on any side reintroduces the seam.
+    // The visible "rounded" corners live in the clip-path as 4px bevels on
+    // the left side. Combining border-radius with clip-path at those same
+    // corners leaves a light-grey anti-aliasing seam, so the left corners
+    // must keep their rounding entirely within the clip shape. (The right
+    // side is the slope; border-radius there is either clipped away or
+    // would only blunt the slope tip, so no seam risk.)
     assert.notEqual(
       styles.clipPath,
       'none',
@@ -349,14 +351,12 @@ module('Integration | overlay-menu-items', function (hooks) {
     );
     for (let corner of [
       'borderTopLeftRadius',
-      'borderTopRightRadius',
-      'borderBottomRightRadius',
       'borderBottomLeftRadius',
     ] as const) {
       assert.strictEqual(
         styles[corner],
         '0px',
-        `${corner} is 0 (corner rounding is folded into the clip-path)`,
+        `${corner} is 0 (left-corner rounding is folded into the clip-path)`,
       );
     }
   });


### PR DESCRIPTION
## Summary
- The Adorn hover type-label tab combined a `border-radius` with a `clip-path`. That combination leaves a faint light-grey anti-aliasing seam visible under the rounded left corners (visible in design feedback as light grey beneath the teal rounded corner).
- Fold the left-corner rounding into the `clip-path` itself (a 4px bevel) and remove the now-redundant `border-radius`, so the fill and the drop-shadow share identical geometry and no seam remains.

Resolves CS-11281.

## Test plan
- [ ] Added integration test asserting the type-label tab clips its shape via `clip-path` and carries no `border-radius`.
- [ ] Visual verification on staging that the light-grey artifact under the rounded left corner is gone (this is a sub-pixel rendering detail; please confirm visually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)