### PR TITLE
Keep card title centered when the selection utility menu is present

### DIFF
--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -390,6 +390,7 @@ export default class CardHeader extends Component<Signature> {
         }
 
         .actions {
+          position: relative;
           display: flex;
           align-items: center;
           margin-left: auto;
@@ -421,10 +422,16 @@ export default class CardHeader extends Component<Signature> {
           background-color: var(--boxel-light);
         }
 
+        /* The selection pill floats out of the actions flex flow, anchored
+           just left of the action buttons. Keeping it out of flow means its
+           presence doesn't widen the actions column, which would otherwise
+           shift the centered card title off-center. */
         .utility-menu-positioner {
           --utility-menu-trigger-height: 26px;
-          position: relative;
-          margin-right: var(--boxel-sp);
+          position: absolute;
+          right: calc(100% + var(--boxel-sp-5xs));
+          top: 50%;
+          transform: translateY(-50%);
           width: 1px;
           height: var(--utility-menu-trigger-height);
         }

--- a/packages/boxel-ui/test-app/tests/integration/components/card-header-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/card-header-test.gts
@@ -35,6 +35,7 @@ module('Integration | Component | card-header', function (hooks) {
   test('the card title stays centered whether or not the selection utility menu is present', async function (assert) {
     await render(
       <template>
+        {{! template-lint-disable no-inline-styles }}
         <div style='width: 600px'>
           <CardHeader
             @cardTitle='A Centered Card Title'
@@ -55,6 +56,7 @@ module('Integration | Component | card-header', function (hooks) {
 
     await render(
       <template>
+        {{! template-lint-disable no-inline-styles }}
         <div style='width: 600px'>
           <CardHeader
             @cardTitle='A Centered Card Title'

--- a/packages/boxel-ui/test-app/tests/integration/components/card-header-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/card-header-test.gts
@@ -1,0 +1,88 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+import { find, render } from '@ember/test-helpers';
+import { CardHeader } from '@cardstack/boxel-ui/components';
+import { MenuItem } from '@cardstack/boxel-ui/helpers';
+
+function centerX(selector: string): number {
+  let el = find(selector);
+  if (!el) {
+    throw new Error(`expected to find element: ${selector}`);
+  }
+  let rect = el.getBoundingClientRect();
+  return rect.left + rect.width / 2;
+}
+
+module('Integration | Component | card-header', function (hooks) {
+  setupRenderingTest(hooks);
+
+  // The header is rendered wide enough (>= 28rem) for the symmetric
+  // icon/actions min-widths to apply, mirroring how the host sizes a top
+  // card's header. The action buttons make the actions column wider than its
+  // min-width so that any extra width contributed by the utility menu would
+  // shift the centered title — which is exactly the regression we guard.
+  const realmInfo = {
+    name: 'Test Workspace',
+    iconURL: 'https://example.com/icon.png',
+    publishable: null,
+  };
+  const noop = () => {};
+  const utilityMenu = {
+    triggerText: '2',
+    menuItems: [new MenuItem({ label: 'Deselect All', action: noop })],
+  };
+
+  test('the card title stays centered whether or not the selection utility menu is present', async function (assert) {
+    await render(
+      <template>
+        <div style='width: 600px'>
+          <CardHeader
+            @cardTitle='A Centered Card Title'
+            @realmInfo={{realmInfo}}
+            @isTopCard={{true}}
+            @onEdit={{noop}}
+            @onExpand={{noop}}
+            @onClose={{noop}}
+            style='--boxel-card-header-icon-container-min-width: 95px; --boxel-card-header-actions-min-width: 95px;'
+          />
+        </div>
+      </template>,
+    );
+
+    let headerCenterWithoutMenu = centerX('[data-test-card-header]');
+    let titleCenterWithoutMenu = centerX('[data-test-boxel-card-header-title]');
+    let offsetWithoutMenu = titleCenterWithoutMenu - headerCenterWithoutMenu;
+
+    await render(
+      <template>
+        <div style='width: 600px'>
+          <CardHeader
+            @cardTitle='A Centered Card Title'
+            @realmInfo={{realmInfo}}
+            @isTopCard={{true}}
+            @utilityMenu={{utilityMenu}}
+            @onEdit={{noop}}
+            @onExpand={{noop}}
+            @onClose={{noop}}
+            style='--boxel-card-header-icon-container-min-width: 95px; --boxel-card-header-actions-min-width: 95px;'
+          />
+        </div>
+      </template>,
+    );
+
+    let headerCenterWithMenu = centerX('[data-test-card-header]');
+    let titleCenterWithMenu = centerX('[data-test-boxel-card-header-title]');
+    let offsetWithMenu = titleCenterWithMenu - headerCenterWithMenu;
+
+    assert
+      .dom('[data-test-card-header] .utility-menu-trigger')
+      .exists('the selection utility menu pill is rendered');
+
+    assert.ok(
+      Math.abs(offsetWithMenu - offsetWithoutMenu) <= 1.5,
+      `title center should not shift when the utility menu appears (without: ${offsetWithoutMenu.toFixed(
+        1,
+      )}px, with: ${offsetWithMenu.toFixed(1)}px)`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- When one or more cards are selected, the teal selection pill ("N Selected" dropdown) appears in the header's actions column. Because the pill was a flex child of `.actions`, its width widened that column and pushed the centered card/workspace title off-center.
- Float the pill out of the actions flex flow (absolutely positioned just left of the action buttons) so its presence no longer changes the actions column width — the title now stays centered whether or not the dropdown is shown.

Resolves CS-11283.

## Test plan
- [x] Added a boxel-ui integration test for `CardHeader` asserting the title's center does not shift when `@utilityMenu` is added.
- [x] Manually verify: select 1+ cards in a workspace and confirm the title (e.g. "Workspace - Experiments Workspace") stays centered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)