### PR TITLE
Stop loading a card instance per selection to fix Select All freeze

### DIFF
--- a/packages/host/app/components/operator-mode/copy-button.gts
+++ b/packages/host/app/components/operator-mode/copy-button.gts
@@ -20,8 +20,6 @@ import {
 
 import type { StackItem } from '@cardstack/host/lib/stack-item';
 
-import type { CardDef } from 'https://cardstack.com/base/card-api';
-
 import consumeContext from '../../helpers/consume-context';
 
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
@@ -29,9 +27,9 @@ import type RealmService from '../../services/realm';
 
 interface Signature {
   Args: {
-    selectedCards: CardDef[][]; // the selected cards for each stack
+    selectedCardIds: string[][]; // the selected card ids for each stack
     copy: (
-      sources: CardDef[],
+      sourceIds: string[],
       sourceItem: StackItem,
       destinationItem: StackItem,
     ) => void;
@@ -189,7 +187,7 @@ export default class CopyButton extends Component<Signature> {
         // if only one of the top most cards are index cards, and the index card
         // has no selections, then the copy state reflects the copy of the top most
         // card to the index card
-        if (this.args.selectedCards[indexCardIndicies[0]].length) {
+        if (this.args.selectedCardIds[indexCardIndicies[0]].length) {
           // the index card should be the destination card--if it has any
           // selections then don't show the copy button
           return undefined;
@@ -214,7 +212,7 @@ export default class CopyButton extends Component<Signature> {
 
         return {
           direction: indexCardIndicies[0] === LEFT ? 'left' : 'right',
-          sources: [sourceCard],
+          sources: [sourceCard.id],
           destinationItem,
           sourceItem,
         };
@@ -230,7 +228,7 @@ export default class CopyButton extends Component<Signature> {
         for (let [
           index,
           stackSelections,
-        ] of this.args.selectedCards.entries()) {
+        ] of this.args.selectedCardIds.entries()) {
           // both stacks have selections--in this case don't show a copy button
           if (stackSelections.length > 0 && sourceStack != null) {
             return undefined;
@@ -263,7 +261,7 @@ export default class CopyButton extends Component<Signature> {
 
         return {
           direction: sourceStack === LEFT ? 'right' : 'left',
-          sources: this.args.selectedCards[sourceStack],
+          sources: this.args.selectedCardIds[sourceStack],
           sourceItem,
           destinationItem,
         };

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -97,7 +97,11 @@ const waiter = buildWaiter('operator-mode:interact-submode-waiter');
 
 export type Stack = StackItem[];
 
-const cardSelections = new TrackedWeakMap<StackItem, TrackedSet<CardDef>>();
+// Selections are tracked by card id rather than by loaded instance. Materializing
+// a CardDef for every selected card is expensive (a fetch + deserialize per card
+// that isn't already resident), which made "Select All" over a large grid freeze
+// the UI for seconds. Instances are now loaded lazily, only when a copy is invoked.
+const cardSelections = new TrackedWeakMap<StackItem, TrackedSet<string>>();
 const stackItemComponentAPI = new WeakMap<StackItem, StackItemComponentAPI>();
 
 const CodeSubmodeNewFileOptions: TemplateOnlyComponent = <template>
@@ -430,10 +434,7 @@ export default class InteractSubmode extends Component {
         if (!selections) {
           continue;
         }
-        let removedCard = [...selections].find((c: CardDef) => c.id === cardId);
-        if (removedCard) {
-          selections.delete(removedCard);
-        }
+        selections.delete(cardId);
       }
     }
     await this.withTestWaiters(async () => {
@@ -462,7 +463,7 @@ export default class InteractSubmode extends Component {
   // dropTask will ignore any subsequent copy requests until the one in progress is done
   private copy = dropTask(
     async (
-      sources: CardDef[],
+      sourceIds: string[],
       sourceItem: StackItem,
       destinationItem: StackItem,
     ) => {
@@ -484,6 +485,11 @@ export default class InteractSubmode extends Component {
             `destination index card ${destinationIndexCardUrl} is not a card`,
           );
         }
+        // Materialize the selected cards now (lazily, only for a copy) rather
+        // than when they were selected.
+        let sources = (
+          await Promise.all(sourceIds.map((id) => this.store.get(id)))
+        ).filter(isCardInstance) as CardDef[];
         sources.sort((a, b) => a.cardTitle.localeCompare(b.cardTitle));
         let scrollToCardId: string | undefined;
         let newCardId: string | undefined;
@@ -563,15 +569,11 @@ export default class InteractSubmode extends Component {
     async (selectedCards: CardDefOrId[], stackItem: StackItem) => {
       let waiterToken = waiter.beginAsync();
       try {
-        let loadedCards = await Promise.all(
-          selectedCards.map((cardDefOrId: CardDefOrId) => {
-            if (typeof cardDefOrId === 'string') {
-              // WARNING This card is not part of the identity map!
-              return this.store.get(cardDefOrId);
-            }
-            return cardDefOrId;
-          }),
-        );
+        let ids = selectedCards
+          .map((cardDefOrId) =>
+            typeof cardDefOrId === 'string' ? cardDefOrId : cardDefOrId.id,
+          )
+          .filter(Boolean) as string[];
 
         let selected = cardSelections.get(stackItem);
         if (!selected) {
@@ -579,10 +581,8 @@ export default class InteractSubmode extends Component {
           cardSelections.set(stackItem, selected);
         }
         selected.clear();
-        for (let card of loadedCards) {
-          if (isCardInstance(card)) {
-            selected.add(card);
-          }
+        for (let id of ids) {
+          selected.add(id);
         }
       } finally {
         waiter.endAsync(waiterToken);
@@ -590,7 +590,7 @@ export default class InteractSubmode extends Component {
     },
   );
 
-  private get selectedCards() {
+  private get selectedCardIds() {
     return this.operatorModeStateService
       .topMostStackItems()
       .map((i) => [...(cardSelections.get(i) ?? [])]);
@@ -910,7 +910,7 @@ export default class InteractSubmode extends Component {
           {{/each}}
 
           <CopyButton
-            @selectedCards={{this.selectedCards}}
+            @selectedCardIds={{this.selectedCardIds}}
             @copy={{fn (perform this.copy)}}
             @isCopying={{this.copy.isRunning}}
           />

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -69,6 +69,8 @@ import type { Spec } from 'https://cardstack.com/base/spec';
 
 import consumeContext from '../../helpers/consume-context';
 
+import { removeFileExtension } from '../../utils/card-search/types';
+
 import CopyButton from './copy-button';
 import DeleteModal from './delete-modal';
 import NeighborStackTriggerButton, {
@@ -569,10 +571,16 @@ export default class InteractSubmode extends Component {
     async (selectedCards: CardDefOrId[], stackItem: StackItem) => {
       let waiterToken = waiter.beginAsync();
       try {
+        // Prerendered-card IDs arrive with the `.json` file extension on
+        // them, but the canonical card id (and `cardToDelete.id` in the
+        // delete handler) is the extensionless URL. Strip the extension
+        // here so prune-on-delete and copy lookups match.
         let ids = selectedCards
-          .map((cardDefOrId) =>
-            typeof cardDefOrId === 'string' ? cardDefOrId : cardDefOrId.id,
-          )
+          .map((cardDefOrId) => {
+            let raw =
+              typeof cardDefOrId === 'string' ? cardDefOrId : cardDefOrId.id;
+            return raw ? removeFileExtension(raw) : undefined;
+          })
           .filter(Boolean) as string[];
 
         let selected = cardSelections.get(stackItem);

--- a/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
+++ b/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
@@ -331,9 +331,10 @@ module('Acceptance | workspace-delete-multiple', function (hooks) {
       assert
         .dom('.utility-menu-trigger')
         .containsText(`${totalCardCount}`, 'All cards are now selected');
-      assert.ok(
-        getsDuringSelectAll < totalCardCount,
-        `Select All should not load an instance per card (store.get called ${getsDuringSelectAll}x while selecting ${totalCardCount} cards)`,
+      assert.strictEqual(
+        getsDuringSelectAll,
+        0,
+        `Select All should not load any instance (selections are tracked by id); store.get was called ${getsDuringSelectAll}x while selecting ${totalCardCount} cards`,
       );
     } finally {
       (store as any).get = originalGet;

--- a/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
+++ b/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
@@ -284,6 +284,62 @@ module('Acceptance | workspace-delete-multiple', function (hooks) {
       .exists('Deselect All option is available');
   });
 
+  test('Select All does not load a card instance for every selected card', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}index`,
+            format: 'isolated',
+          },
+        ],
+      ],
+    });
+
+    await click('[data-test-boxel-filter-list-button="All Cards"]');
+    await waitFor('[data-test-cards-grid-item]');
+
+    let cards = findAll('[data-test-cards-grid-item]');
+    let totalCardCount = cards.length;
+    assert.ok(totalCardCount >= 3, 'Multiple cards are available');
+
+    // Enter selection mode with a single card, then count store.get calls
+    // made specifically by the Select All action. Selecting cards must not
+    // materialize an instance per card — that eager loading is what froze the
+    // UI for seconds on large grids.
+    await selectCard('Pet/1');
+
+    let store = getService('store');
+    let originalGet = store.get;
+    let getCallCount = 0;
+    (store as any).get = function (...args: unknown[]) {
+      getCallCount += 1;
+      return (originalGet as any).apply(store, args);
+    };
+
+    try {
+      await click('.utility-menu-trigger');
+      let countBeforeSelectAll = getCallCount;
+      await click('[data-test-boxel-menu-item-text="Select All"]');
+      await waitUntil(() =>
+        document
+          .querySelector('.utility-menu-trigger')
+          ?.textContent?.includes(`${totalCardCount}`),
+      );
+      let getsDuringSelectAll = getCallCount - countBeforeSelectAll;
+
+      assert
+        .dom('.utility-menu-trigger')
+        .containsText(`${totalCardCount}`, 'All cards are now selected');
+      assert.ok(
+        getsDuringSelectAll < totalCardCount,
+        `Select All should not load an instance per card (store.get called ${getsDuringSelectAll}x while selecting ${totalCardCount} cards)`,
+      );
+    } finally {
+      (store as any).get = originalGet;
+    }
+  });
+
   test('can cancel bulk delete operation', async function (assert) {
     await visitOperatorMode({
       stacks: [


### PR DESCRIPTION
## Summary
- "Select All" froze the UI for several seconds on large grids. The cause: every selection materialized a `CardDef` instance for each selected id (`selectCards` did `store.get` per card). For grid cards that aren't already resident, each `store.get` is a `fetchJSON` + synchronous deserialize, so Select All fired N of them at once.
- Track selections by **id** rather than by loaded instance, and materialize instances **lazily** — only inside the `copy` task, when a copy is actually invoked. Delete already matched by id; bulk delete now removes ids directly.
- `CopyButton` now takes `@selectedCardIds: string[][]` (counts are unchanged; the copy action receives ids and the copy task loads the few instances it needs).

Resolves CS-11282.

## Test plan
- [ ] Added acceptance test asserting Select All does not call `store.get` once per card.
- [ ] Existing `workspace-delete-multiple` (select all / deselect / bulk delete) and `card-copy` tests still pass (copy/delete paths refactored to ids).
- [ ] Manually verify Select All over a large workspace is instant, and copying selected cards between stacks still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)