### PR TITLE
Run coordinated module-transpile DB work on the lock's pinned connection

### DIFF
--- a/packages/realm-server/lib/module-cache-coordination.ts
+++ b/packages/realm-server/lib/module-cache-coordination.ts
@@ -6,6 +6,7 @@ import {
   type Expression,
   type PgPrimitive,
   type PopulateCoordinator,
+  type Querier,
 } from '@cardstack/runtime-common';
 import type { NotificationSubscription, PgAdapter } from '@cardstack/postgres';
 
@@ -44,14 +45,18 @@ export function hashCoalesceKeyForAdvisoryLock(key: string): string {
 //     the coalesce key, and (if won) runs `fn` inside the BEGIN/COMMIT
 //     window with a `pg_notify` emit between persist and commit.
 //
-// The pinned connection ONLY holds the advisory lock and emits the
-// NOTIFY. The `fn` callback issues its DB work (readFromDatabaseCache,
-// persistDefinitionCacheEntry) through the shared dbAdapter — a separate
-// pool connection autocommits each query as today. Pool pressure is
-// bounded by N processes (each pins one extra client per concurrent
-// coordinated load) rather than N × M concurrent callers, since the
-// in-process #inFlight coalescer fans every same-key callers into one
-// coordinated load per process.
+// The pinned connection holds the advisory lock, emits the NOTIFY, and
+// is handed to `fn` as a querier so `fn` can run its own DB work
+// (cache re-read + persist) on that same connection instead of checking
+// out additional pool clients. This keeps a coordinated load to exactly
+// ONE pool connection: because each distinct coalesce key wins its own
+// lock, a burst of N distinct-key winners pins N connections, and if
+// each also needed a second client for its queries the pool would
+// deadlock once N approached the ceiling (the schema editor alone fans
+// out to ~31 distinct cold base modules). The in-process #inFlight
+// coalescer still fans same-key callers into one coordinated load per
+// process; `fn` callbacks that are not DB-bound (e.g. a prerender) may
+// ignore the querier and use the shared dbAdapter.
 //
 // `pg_try_advisory_xact_lock` is non-blocking by design: a blocking
 // `pg_advisory_xact_lock` would hold a pool client for the full
@@ -136,7 +141,7 @@ export class ModuleCacheCoordinator implements PopulateCoordinator {
   // PopulateCoordinator — winner path.
   async tryAcquireAndRun<T>(
     coalesceKey: string,
-    fn: () => Promise<T>,
+    fn: (querier: Querier) => Promise<T>,
   ): Promise<{ acquired: true; result: T } | { acquired: false }> {
     const lockKey = hashCoalesceKeyForAdvisoryLock(coalesceKey);
     return await this.#deps.dbAdapter.withConnection(async (queryFn) => {
@@ -162,11 +167,15 @@ export class ModuleCacheCoordinator implements PopulateCoordinator {
         return { acquired: false };
       }
       try {
-        const result = await fn();
+        const result = await fn(queryFn);
         // Emit pg_notify INSIDE the same transaction as the lock so
-        // peers only see the signal on commit. The persist itself ran
-        // through the shared dbAdapter (already autocommitted), so the
-        // row is visible by the time peers re-read on wake.
+        // peers only see the signal on commit. When `fn` persisted
+        // through the pinned `queryFn`, that write is part of THIS
+        // transaction and becomes visible to peers at the COMMIT below —
+        // which is also when the NOTIFY is delivered, so a woken peer's
+        // re-read always observes it. When `fn` persisted through the
+        // shared dbAdapter instead, the row autocommitted even earlier.
+        // Either way the row is visible by the time peers re-read on wake.
         //
         // We notify regardless of whether `fn` produced a row or
         // undefined — a "no row" outcome (all populationCandidates

--- a/packages/realm-server/tests/module-cache-coordination-test.ts
+++ b/packages/realm-server/tests/module-cache-coordination-test.ts
@@ -245,44 +245,32 @@ module(basename(__filename), function () {
       const coordinator = new ModuleCacheCoordinator({ dbAdapter });
       await coordinator.start();
       try {
-        const peerCoordinator = new ModuleCacheCoordinator({ dbAdapter });
-        await peerCoordinator.start();
-        try {
-          await new Promise((r) => setTimeout(r, 100));
-          let notified = false;
-          const waitPromise = peerCoordinator
-            .waitForKey('savepoint-key', 5000)
-            .then(() => {
-              notified = true;
-            });
-          await new Promise((r) => setTimeout(r, 50));
+        const outcome = await coordinator.tryAcquireAndRun(
+          'savepoint-key',
+          async (querier) => {
+            await querier(['SAVEPOINT best_effort_write']);
+            try {
+              await querier(['SELECT * FROM table_that_does_not_exist']);
+            } catch {
+              // Best-effort: swallow and roll back just this statement.
+              await querier(['ROLLBACK TO SAVEPOINT best_effort_write']);
+            }
+            // The connection must be usable again after the rollback — a
+            // real follow-on write would succeed here. Issuing one proves
+            // the savepoint recovered the transaction; without it this
+            // query would error with "current transaction is aborted".
+            const rows = await querier(['SELECT 1 AS ok']);
+            return Number(rows[0].ok);
+          },
+        );
 
-          const outcome = await coordinator.tryAcquireAndRun(
-            'savepoint-key',
-            async (querier) => {
-              await querier(['SAVEPOINT best_effort_write']);
-              try {
-                await querier(['SELECT * FROM table_that_does_not_exist']);
-              } catch {
-                // Best-effort: swallow and roll back just this statement.
-                await querier(['ROLLBACK TO SAVEPOINT best_effort_write']);
-              }
-              return 'served-despite-write-failure';
-            },
-          );
-
-          assert.deepEqual(outcome, {
-            acquired: true,
-            result: 'served-despite-write-failure',
-          });
-          await waitPromise;
-          assert.true(
-            notified,
-            'NOTIFY fired → lock transaction committed despite the inner write failure',
-          );
-        } finally {
-          await peerCoordinator.shutDown();
-        }
+        // acquired:true is only returned after the coordinator's pg_notify
+        // and COMMIT both ran on this same connection — a transaction left
+        // aborted by the inner failure would have made those throw and
+        // rejected instead. So this single assertion proves both that the
+        // post-rollback query succeeded and that the lock transaction
+        // committed cleanly.
+        assert.deepEqual(outcome, { acquired: true, result: 1 });
       } finally {
         await coordinator.shutDown();
       }

--- a/packages/realm-server/tests/module-cache-coordination-test.ts
+++ b/packages/realm-server/tests/module-cache-coordination-test.ts
@@ -235,6 +235,83 @@ module(basename(__filename), function () {
       }
     });
 
+    test('tryAcquireAndRun: a savepoint-guarded fn write failure does not abort the lock transaction', async function (assert) {
+      // A winner runs its DB work on the pinned querier inside the
+      // coordinator's lock transaction. A best-effort write (like the
+      // transpile cache UPSERT) that fails must NOT poison that
+      // transaction, or the coordinator's pg_notify + COMMIT would fail
+      // and the already-produced result would never be served. Wrapping
+      // the write in a savepoint keeps the transaction usable.
+      const coordinator = new ModuleCacheCoordinator({ dbAdapter });
+      await coordinator.start();
+      try {
+        const peerCoordinator = new ModuleCacheCoordinator({ dbAdapter });
+        await peerCoordinator.start();
+        try {
+          await new Promise((r) => setTimeout(r, 100));
+          let notified = false;
+          const waitPromise = peerCoordinator
+            .waitForKey('savepoint-key', 5000)
+            .then(() => {
+              notified = true;
+            });
+          await new Promise((r) => setTimeout(r, 50));
+
+          const outcome = await coordinator.tryAcquireAndRun(
+            'savepoint-key',
+            async (querier) => {
+              await querier(['SAVEPOINT best_effort_write']);
+              try {
+                await querier(['SELECT * FROM table_that_does_not_exist']);
+              } catch {
+                // Best-effort: swallow and roll back just this statement.
+                await querier(['ROLLBACK TO SAVEPOINT best_effort_write']);
+              }
+              return 'served-despite-write-failure';
+            },
+          );
+
+          assert.deepEqual(outcome, {
+            acquired: true,
+            result: 'served-despite-write-failure',
+          });
+          await waitPromise;
+          assert.true(
+            notified,
+            'NOTIFY fired → lock transaction committed despite the inner write failure',
+          );
+        } finally {
+          await peerCoordinator.shutDown();
+        }
+      } finally {
+        await coordinator.shutDown();
+      }
+    });
+
+    test('tryAcquireAndRun: an unguarded fn write failure aborts the lock transaction and the winner throws', async function (assert) {
+      // Documents why the savepoint above is required: without it, a
+      // swallowed write failure leaves the transaction aborted, so the
+      // coordinator's pg_notify + COMMIT fail and the winner rejects
+      // instead of returning its result.
+      const coordinator = new ModuleCacheCoordinator({ dbAdapter });
+      await coordinator.start();
+      try {
+        await assert.rejects(
+          coordinator.tryAcquireAndRun('unguarded-key', async (querier) => {
+            try {
+              await querier(['SELECT * FROM table_that_does_not_exist']);
+            } catch {
+              // Swallow like a best-effort write, but with no savepoint the
+              // transaction is now aborted.
+            }
+            return 'returned-but-transaction-poisoned';
+          }),
+        );
+      } finally {
+        await coordinator.shutDown();
+      }
+    });
+
     test('waitForKey: resolves on NOTIFY before timeout', async function (assert) {
       const coordinator = new ModuleCacheCoordinator({ dbAdapter });
       await coordinator.start();

--- a/packages/realm-server/tests/module-cache-coordination-test.ts
+++ b/packages/realm-server/tests/module-cache-coordination-test.ts
@@ -330,6 +330,85 @@ module(basename(__filename), function () {
     });
   });
 
+  // Each distinct coalesce key wins its OWN advisory lock, so a burst of
+  // distinct-key callers produces that many concurrent winners — there is
+  // no loser path to throttle them (the schema editor alone fetches ~31
+  // distinct cold base modules in one page load). Each winner pins one
+  // pool connection for its lock transaction; if its `fn` also had to
+  // check out a SECOND pool client for the cache re-read + persist, then
+  // once concurrent winners reach the pool ceiling every pinned
+  // connection's `fn` would block waiting for a client its peers hold —
+  // a self-deadlock that hangs all module serving. Threading the pinned
+  // querier into `fn` keeps a coordinated load to exactly one connection,
+  // so winners drain through a pool far smaller than their count.
+  module('ModuleCacheCoordinator pool exhaustion', function (hooks) {
+    let savedPoolMax: string | undefined;
+    hooks.before(function () {
+      savedPoolMax = process.env.PG_POOL_MAX;
+      // Force a pool smaller than the concurrent-winner count below so the
+      // test would deadlock if a winner needed a second connection.
+      process.env.PG_POOL_MAX = '2';
+    });
+    hooks.after(function () {
+      if (savedPoolMax === undefined) {
+        delete process.env.PG_POOL_MAX;
+      } else {
+        process.env.PG_POOL_MAX = savedPoolMax;
+      }
+    });
+
+    let dbAdapter: PgAdapter;
+    setupDB(hooks, {
+      before: async (adapter) => {
+        dbAdapter = adapter;
+      },
+    });
+
+    test('concurrent distinct-key winners doing DB work on the pinned querier do not deadlock a small pool', async function (assert) {
+      const coordinator = new ModuleCacheCoordinator({ dbAdapter });
+      await coordinator.start();
+      try {
+        const winnerCount = 5; // > PG_POOL_MAX (2)
+        const runs = Array.from({ length: winnerCount }, (_unused, i) =>
+          coordinator.tryAcquireAndRun(
+            `pool-exhaustion-key-${i}`,
+            async (querier) => {
+              // DB work a winner must do while holding the lock. Routing it
+              // through the pinned querier (instead of the shared dbAdapter)
+              // is what keeps this to a single pool connection.
+              const rows = await querier(['SELECT', param(i), '::int AS n']);
+              return Number(rows[0].n);
+            },
+          ),
+        );
+
+        const timeout = new Promise<never>((_resolve, reject) => {
+          const t = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  'coordinated transpiles deadlocked: winners did not all complete — pinned querier likely not being used for fn DB work',
+                ),
+              ),
+            20_000,
+          );
+          (t as { unref?: () => void }).unref?.();
+        });
+
+        const outcomes = await Promise.race([Promise.all(runs), timeout]);
+        assert.deepEqual(
+          outcomes
+            .map((o) => (o.acquired ? o.result : 'loser'))
+            .sort((a, b) => Number(a) - Number(b)),
+          [0, 1, 2, 3, 4],
+          'all distinct-key winners acquired and completed',
+        );
+      } finally {
+        await coordinator.shutDown();
+      }
+    });
+  });
+
   module(
     'CachingDefinitionLookup coordinated path (integration)',
     function (hooks) {

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -8,6 +8,7 @@ import {
   query,
   separatedByCommas,
   type Expression,
+  type Querier,
 } from './expression';
 import { clampSerializedError, type SerializedError } from './error';
 import {
@@ -244,12 +245,18 @@ export interface PopulateCoordinator {
   // `{ acquired: false }` immediately so the caller can transition to
   // the loser path.
   //
-  // `fn` runs against the shared dbAdapter (separate pool connections
-  // for any DB work it does). The pinned connection inside this helper
-  // only holds the advisory lock + emits the NOTIFY + commits.
+  // `fn` receives the pinned querier that holds the advisory lock. DB
+  // work it does through that querier shares the lock's single pinned
+  // connection rather than checking out additional pool clients — which
+  // matters because each distinct coalesce key wins its own lock, so a
+  // burst of N distinct-key winners would otherwise pin N connections
+  // AND each need another for its own queries, deadlocking the pool when
+  // N approaches the pool ceiling. Callers that don't need the querier
+  // (their inner work is a prerender or otherwise not DB-bound) may
+  // ignore it and continue using the shared dbAdapter.
   tryAcquireAndRun<T>(
     coalesceKey: string,
-    fn: () => Promise<T>,
+    fn: (querier: Querier) => Promise<T>,
   ): Promise<{ acquired: true; result: T } | { acquired: false }>;
   // Wait until a NOTIFY for `coalesceKey` arrives on the populate
   // channel, or `timeoutMs` elapses — whichever comes first. Resolves in

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -65,7 +65,9 @@ import {
   query,
   param,
   dbExpression,
+  dbAdapterQuerier,
   isValidPrerenderedHtmlFormat,
+  type Querier,
   type CodeRef,
   type LooseSingleCardDocument,
   type ResourceObjectWithId,
@@ -3085,22 +3087,30 @@ export class Realm {
     }
 
     let coalesceKey = `transpile|${this.url}|${canonicalPath}`;
-    let attempt = await coordinator.tryAcquireAndRun(coalesceKey, async () => {
-      // Winner path: a peer may have written between our miss and our
-      // lock acquisition; re-read so we don't redo their work AND
-      // refresh our captured generation in case a tombstone landed.
-      let recheck = await this.#readTranspileCacheRow(canonicalPath);
-      if (recheck?.result) {
-        return recheck.result;
-      }
-      let result = await this.#materializeAndTranspile(fileRef, etag);
-      await this.#writeTranspileCacheRow(
-        canonicalPath,
-        result,
-        recheck?.generation ?? 0,
-      );
-      return result;
-    });
+    let attempt = await coordinator.tryAcquireAndRun(
+      coalesceKey,
+      async (querier) => {
+        // Winner path: a peer may have written between our miss and our
+        // lock acquisition; re-read so we don't redo their work AND
+        // refresh our captured generation in case a tombstone landed.
+        // Run the re-read and the persist on the coordinator's pinned
+        // querier so this whole coordinated transpile holds exactly one
+        // pool connection — the lock connection — rather than pinning it
+        // and then checking out more for these queries.
+        let recheck = await this.#readTranspileCacheRow(canonicalPath, querier);
+        if (recheck?.result) {
+          return recheck.result;
+        }
+        let result = await this.#materializeAndTranspile(fileRef, etag);
+        await this.#writeTranspileCacheRow(
+          canonicalPath,
+          result,
+          recheck?.generation ?? 0,
+          querier,
+        );
+        return result;
+      },
+    );
     if (attempt.acquired) {
       return attempt.result;
     }
@@ -3127,14 +3137,20 @@ export class Realm {
     return result;
   }
 
-  async #readTranspileCacheRow(canonicalPath: string): Promise<
+  async #readTranspileCacheRow(
+    canonicalPath: string,
+    // When provided (winner path), reads run on the coordinator's pinned
+    // lock connection; otherwise they fall back to the shared pool.
+    querier?: Querier,
+  ): Promise<
     | {
         result?: ModuleTranspileResult;
         generation: number;
       }
     | undefined
   > {
-    let rows = (await query(this.#dbAdapter, [
+    let runQuery = querier ?? dbAdapterQuerier(this.#dbAdapter);
+    let rows = (await runQuery([
       'SELECT body, headers, dependency_keys, generation',
       'FROM',
       MODULE_TRANSPILE_CACHE_TABLE,
@@ -3209,7 +3225,13 @@ export class Realm {
     canonicalPath: string,
     result: ModuleTranspileResult,
     capturedGeneration: number,
+    // When provided (winner path), the UPSERT runs on the coordinator's
+    // pinned lock connection — so it commits with the lock + NOTIFY and
+    // doesn't check out a second pool client. Otherwise it falls back to
+    // the shared pool, autocommitting on its own connection.
+    querier?: Querier,
   ): Promise<void> {
+    let runQuery = querier ?? dbAdapterQuerier(this.#dbAdapter);
     try {
       // INSERT a row at `capturedGeneration`. On conflict, UPDATE only
       // if the row's current generation is still <= capturedGeneration.
@@ -3220,7 +3242,7 @@ export class Realm {
       // that case the WHERE 0 <= 0 still allows a no-op same-gen
       // overwrite which is benign because the bytes are deterministic
       // for the same source.
-      await query(this.#dbAdapter, [
+      await runQuery([
         'INSERT INTO',
         MODULE_TRANSPILE_CACHE_TABLE,
         '(realm_url, canonical_path, body, headers, dependency_keys, generation, created_at)',

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -3232,7 +3232,20 @@ export class Realm {
     querier?: Querier,
   ): Promise<void> {
     let runQuery = querier ?? dbAdapterQuerier(this.#dbAdapter);
+    // On the pinned-querier path this UPSERT runs inside the
+    // coordinator's lock transaction. L2 persistence is best-effort, but
+    // a pg error here would abort that transaction and break the
+    // coordinator's following pg_notify + COMMIT — failing a request that
+    // could otherwise serve the already-transpiled bytes. Wrap the write
+    // in a savepoint so a failure rolls back just this statement and
+    // leaves the enclosing transaction usable. On the shared adapter each
+    // query autocommits on its own connection, so no savepoint is needed.
+    let inLockTransaction = querier != null;
+    const savepoint = 'transpile_cache_write';
     try {
+      if (inLockTransaction) {
+        await runQuery([`SAVEPOINT ${savepoint}`]);
+      }
       // INSERT a row at `capturedGeneration`. On conflict, UPDATE only
       // if the row's current generation is still <= capturedGeneration.
       // If an invalidate has tombstoned-and-bumped the row past that
@@ -3274,11 +3287,25 @@ export class Realm {
         'created_at = EXCLUDED.created_at',
         `WHERE ${MODULE_TRANSPILE_CACHE_TABLE}.generation <= EXCLUDED.generation`,
       ]);
+      if (inLockTransaction) {
+        await runQuery([`RELEASE SAVEPOINT ${savepoint}`]);
+      }
     } catch (err: unknown) {
       // L2 persistence is best-effort. A transient pg failure must not
       // break the response the caller is about to serve — they already
       // have the bytes in memory. Log and move on; the next reader will
       // re-try the write.
+      if (inLockTransaction) {
+        // Roll back just the failed write so the coordinator's enclosing
+        // lock transaction stays usable for its pg_notify + COMMIT.
+        try {
+          await runQuery([`ROLLBACK TO SAVEPOINT ${savepoint}`]);
+        } catch (rollbackErr: unknown) {
+          this.#log.warn(
+            `ROLLBACK TO SAVEPOINT after ${MODULE_TRANSPILE_CACHE_TABLE} write failure failed for ${this.url}${canonicalPath}: ${String(rollbackErr)}`,
+          );
+        }
+      }
       this.#log.warn(
         `${MODULE_TRANSPILE_CACHE_TABLE} insert failed for ${this.url}${canonicalPath}: ${String(err)}`,
       );


### PR DESCRIPTION
## Background and Goal

This fixes the root cause of a flaky host acceptance test: `code submode | editor tests > when the user lacks write permissions: the editor is read-only` intermittently timed out at the 140s QUnit limit. The telling run showed ~31 base-module GETs to `…/base/*` (card-api, field-support, every default template) hung and never resolving — the realm-server had simply stopped serving base modules. That test opens a code-submode schema editor, the heaviest base-module loader in its shard, so it's the first to fall over under load; the stall is server-side, and the test failure is collateral.

The stall is a DB-pool self-deadlock in the module-cache transpile coordinator. The coordinator deduplicates cross-process module transpiles behind a Postgres advisory lock: a winner pins a pool connection for the lock's `BEGIN…COMMIT` and runs its callback inside it, while losers wait on a NOTIFY. But the winner's callback did its cache re-read and persist through the *shared* adapter — checking out **additional** pool clients while the lock connection stays pinned. Each distinct module is its own coalesce key, so a single page that requests many cold base modules at once (the schema editor pulls ~31) spawns that many concurrent winners, with no loser path to throttle them. Once concurrent winners reach the connection-pool ceiling, every pinned connection's callback blocks waiting for a client its peers hold — a self-deadlock that stalls all base-module serving until requests time out. `packages/postgres/pg-adapter.ts` already flagged this as the `withWriteLock` pool-exhaustion caveat ("acceptable under low write concurrency"); the per-module coordinator violates that low-concurrency assumption.

This makes a coordinated transpile use exactly one pool connection so the deadlock can't form.

## Where to start

`packages/realm-server/lib/module-cache-coordination.ts` — `tryAcquireAndRun` now hands its pinned `queryFn` to the callback. `packages/runtime-common/realm.ts` — `#transpileWithLayers`'s winner threads that querier into `#readTranspileCacheRow` / `#writeTranspileCacheRow`, which take an optional `Querier` and fall back to the shared pool when absent. The regression test is `ModuleCacheCoordinator pool exhaustion` in `packages/realm-server/tests/module-cache-coordination-test.ts`: it forces `PG_POOL_MAX=2` and drives 5 concurrent distinct-key winners that do DB work on the pinned querier, asserting they all complete (it deadlocks with the shared-adapter pattern, passes with the pinned querier).

## Key decisions

- **Thread the pinned querier rather than cap concurrency or drop coordination.** Keeps the cross-process dedup intact and makes each coordinated load O(1) connections — the minimum possible — instead of relying on a tuned semaphore.
- **Persist moves inside the lock transaction.** It commits with the lock and NOTIFY; a woken peer's re-read always observes it, since NOTIFY is delivered on commit.
- **Definition-lookup's coordinated path is unchanged.** Its callback runs a prerender (not DB-bound) and is throttled by indexer concurrency, so it keeps using the shared adapter; the querier param is optional and ignored there.
- **Tombstone/invalidate writes stay on the shared pool** — they run outside the coordinator, not inside a pinned-lock window.
