### PR TITLE
Enable Adorn UI overlays in the search results pane

### DIFF
--- a/packages/host/app/components/adorn/adorn-label.gts
+++ b/packages/host/app/components/adorn/adorn-label.gts
@@ -35,7 +35,12 @@ export interface AdornLabelSignature {
 }
 
 const AdornLabel: TemplateOnlyComponent<AdornLabelSignature> = <template>
-  <div class='adorn-label {{if @compact "compact"}}' ...attributes>
+  <div
+    class='adorn-label
+      {{if @compact "compact"}}
+      {{unless (has-block "dropdown") "no-menu"}}'
+    ...attributes
+  >
     {{#if (has-block 'icon')}}
       <span class='adorn-label-icon-slot'>{{yield to='icon'}}</span>
     {{/if}}
@@ -71,6 +76,15 @@ const AdornLabel: TemplateOnlyComponent<AdornLabelSignature> = <template>
       padding: 2px 10px 2px 5px;
       font-size: 9px;
       gap: 4px;
+    }
+    /* Without an in-tab menu filling the right side, the text would
+       crowd the flag's sloped right edge — add clearance so it clears
+       the slope. */
+    .adorn-label.no-menu {
+      padding-right: 18px;
+    }
+    .adorn-label.no-menu.compact {
+      padding-right: 15px;
     }
 
     .adorn-label-icon-slot {

--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -1,5 +1,6 @@
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { scheduleOnce } from '@ember/runloop';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -48,14 +49,21 @@ const captureAdornCardMeta = modifier(
     [setMeta, enabled]: [(meta: AdornCardMeta) => void, boolean | undefined],
   ) => {
     if (!enabled) return;
+    let destroyed = false;
     let read = () => {
+      if (destroyed) return;
       let inner = element.querySelector('[data-card-type-display-name]');
       setMeta({
         name: inner?.getAttribute('data-card-type-display-name') ?? undefined,
         iconHtml: inner?.getAttribute('data-card-type-icon-html') ?? undefined,
       });
     };
-    read();
+    // Defer the initial read out of the current render. This modifier
+    // installs during render commit, and setMeta writes tracked state
+    // the label getters already consumed this render — writing it
+    // synchronously here trips a backtracking assertion. MutationObserver
+    // callbacks are always async, so subsequent reads are already safe.
+    scheduleOnce('afterRender', null, read);
     let observer = new MutationObserver(read);
     observer.observe(element, {
       childList: true,
@@ -66,7 +74,10 @@ const captureAdornCardMeta = modifier(
         'data-card-type-icon-html',
       ],
     });
-    return () => observer.disconnect();
+    return () => {
+      destroyed = true;
+      observer.disconnect();
+    };
   },
 );
 
@@ -146,8 +157,16 @@ export default class ItemButton extends Component<Signature> {
   }
 
   @action private setAdornCardMeta(meta: AdornCardMeta) {
-    this.prerenderedTypeName = meta.name;
-    this.prerenderedTypeIconHtml = meta.iconHtml;
+    // Only write when a value actually changed. The MutationObserver
+    // that feeds this fires on any mutation inside the button subtree —
+    // including our own label/icon render — so re-assigning identical
+    // values would dirty tracked state and re-render in a loop.
+    if (meta.name !== this.prerenderedTypeName) {
+      this.prerenderedTypeName = meta.name;
+    }
+    if (meta.iconHtml !== this.prerenderedTypeIconHtml) {
+      this.prerenderedTypeIconHtml = meta.iconHtml;
+    }
   }
 
   private get adornTypeName(): string | undefined {

--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -2,13 +2,22 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import { modifier } from 'ember-modifier';
 
 import { Button } from '@cardstack/boxel-ui/components';
 import { and, cn, not } from '@cardstack/boxel-ui/helpers';
 import { IconPlus } from '@cardstack/boxel-ui/icons';
 
-import { isCardInstance, rri } from '@cardstack/runtime-common';
+import {
+  cardTypeDisplayName,
+  isCardInstance,
+  rri,
+} from '@cardstack/runtime-common';
 
+import AdornLabel from '@cardstack/host/components/adorn/adorn-label';
+import AdornSelectChip from '@cardstack/host/components/adorn/adorn-select-chip';
 import type RealmService from '@cardstack/host/services/realm';
 
 import {
@@ -20,7 +29,45 @@ import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import CardRenderer from '../card-renderer';
 
-import type { ComponentLike } from '@glint/template';
+import type { ComponentLike, ModifierLike } from '@glint/template';
+
+// CardRenderer stamps `data-card-type-display-name` on each rendered card, so
+// look it up inside the button DOM once it has rendered. This is the same
+// attribute that OperatorModeOverlays reads to label the hover tab.
+const captureAdornTypeName = modifier(
+  (
+    element: HTMLElement,
+    [setName, enabled]: [
+      (name: string | undefined) => void,
+      boolean | undefined,
+    ],
+  ) => {
+    if (!enabled) return;
+    let read = () => {
+      let inner = element.querySelector('[data-card-type-display-name]');
+      let name =
+        inner?.getAttribute('data-card-type-display-name') ?? undefined;
+      setName(name);
+    };
+    read();
+    let observer = new MutationObserver(read);
+    observer.observe(element, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-card-type-display-name'],
+    });
+    return () => observer.disconnect();
+  },
+);
+
+// Fallback used when no AdornContext positioner was threaded in (e.g.
+// ItemButton rendered in isolation by a component test). Real callers
+// inside an AdornContext thread its pre-wired `positionLabel`.
+const noopPositionLabel = modifier<{
+  Element: HTMLElement;
+  Args: { Positional: [cardEl: HTMLElement | undefined] };
+}>(() => {});
 
 type ItemType = ComponentLike<{ Element: Element }> | CardDef | NewCardArgs;
 
@@ -33,6 +80,23 @@ interface Signature {
     multiSelect?: boolean;
     onSelect: (selection: string | NewCardArgs) => void;
     onSubmit?: (selection: string | NewCardArgs) => void;
+    // When true, render the Adorn visual treatment: a teal hover type-label
+    // tab, teal hover/selection outline, and a teal selection chip in place
+    // of the legacy grey selection circle.
+    adorn?: boolean;
+    // The outline class yielded by the enclosing <AdornContext> (the
+    // caller threads it down from `as |adorn|`). Applied to the button
+    // so AdornContext's stroke rules match it, instead of hard-coding
+    // the primitive's internal class name here.
+    adornStrokeClass?: string;
+    // The label positioner yielded by the enclosing <AdornContext>
+    // (positionAdornLabel with the boundary resolver pre-wired). The
+    // caller threads it down; we attach it to the type-label tab and
+    // pass the card element to anchor against.
+    adornPositionLabel?: ModifierLike<{
+      Element: HTMLElement;
+      Args: { Positional: [cardEl: HTMLElement | undefined] };
+    }>;
   };
 }
 
@@ -48,6 +112,41 @@ function isNewCardArgs(item: ItemType): item is NewCardArgs {
 
 export default class ItemButton extends Component<Signature> {
   @service declare realm: RealmService;
+
+  @tracked private prerenderedTypeName: string | undefined;
+
+  // The catalog-item button element, captured so the shared
+  // positionAdornLabel modifier can anchor the type-label tab to the
+  // card's footprint (the same way the stack-item overlay anchors to
+  // the rendered card). Tracked so the label positioner re-runs once
+  // the element is available, regardless of modifier install order.
+  @tracked private cardEl: HTMLElement | undefined;
+
+  private registerCardEl = modifier((element: HTMLElement) => {
+    this.cardEl = element;
+  });
+
+  // AdornContext's pre-wired label positioner, or a no-op when this
+  // button is rendered outside an AdornContext.
+  private get positionLabel(): ModifierLike<{
+    Element: HTMLElement;
+    Args: { Positional: [cardEl: HTMLElement | undefined] };
+  }> {
+    return this.args.adornPositionLabel ?? noopPositionLabel;
+  }
+
+  @action private setPrerenderedTypeName(name: string | undefined) {
+    this.prerenderedTypeName = name;
+  }
+
+  private get adornTypeName(): string | undefined {
+    if (!this.args.adorn) return undefined;
+    if (this.isNewCard) return undefined; // hover bar isn't relevant for "Create New"
+    if (this.cardItem) {
+      return cardTypeDisplayName(this.cardItem);
+    }
+    return this.prerenderedTypeName;
+  }
 
   private get isNewCard(): boolean {
     return isNewCardArgs(this.args.item);
@@ -129,26 +228,58 @@ export default class ItemButton extends Component<Signature> {
   }
 
   <template>
+    {{! Note: the caller is responsible for wrapping the item list in
+        an AdornContext when @adorn is true — the context publishes
+        the Adorn tokens, the outline utility, and the label boundary
+        anchor at the outer-container level so they don't need
+        re-establishing for each item. }}
     <Button
       @rectangular={{true}}
       class={{cn
         'catalog-item'
+        @adornStrokeClass
         selected=@isSelected
         create-new-button=this.isNewCard
         multi-select=@multiSelect
+        adorn=@adorn
       }}
       {{on 'click' this.handleClick}}
       {{on 'dblclick' this.handleDblClick}}
       {{on 'keydown' this.handleKeydown}}
+      {{captureAdornTypeName this.setPrerenderedTypeName @adorn}}
+      {{this.registerCardEl}}
       data-test-card-catalog-create-new-button={{this.newCardItem.realmURL}}
       data-test-card-catalog-item={{removeFileExtension this.resolvedItemId}}
       data-test-card-catalog-item-selected={{if @isSelected 'true'}}
       ...attributes
     >
+      {{#if @adorn}}
+        {{#if this.adornTypeName}}
+          {{! The type-label tab is positioned by the same shared
+              modifier the stack-item overlay uses: it anchors to the
+              card's top-left and clamps to the AdornContext boundary.
+              The class only carries hover-fade + interaction concerns;
+              the flag shape lives in the AdornLabel primitive. }}
+          <AdornLabel
+            class='search-type-label'
+            data-test-adorn-label
+            aria-hidden='true'
+            {{this.positionLabel this.cardEl}}
+          >
+            <:text>{{this.adornTypeName}}</:text>
+          </AdornLabel>
+        {{/if}}
+      {{/if}}
       {{#if (and @multiSelect @isSelected (not this.isNewCard))}}
-        <div class='selection-indicator'>
-          <div class='selection-circle' />
-        </div>
+        {{#if @adorn}}
+          <span class='adorn-select-position'>
+            <AdornSelectChip @selected={{true}} data-test-adorn-selected />
+          </span>
+        {{else}}
+          <div class='selection-indicator'>
+            <div class='selection-circle' />
+          </div>
+        {{/if}}
       {{/if}}
       {{#if this.isNewCard}}
         <IconPlus
@@ -237,6 +368,39 @@ export default class ItemButton extends Component<Signature> {
         border-radius: 50%;
         background-color: var(--boxel-highlight);
         border: 1.5px solid var(--boxel-dark);
+      }
+
+      /* Adorn treatment — the outline, the label tab, and the
+         selection chip are provided by AdornContext + the AdornLabel /
+         AdornSelectChip primitives. The rules below only position the
+         catalog-rendered wrappers around those primitives and drop the
+         Button's default border so AdornContext's teal outline shows
+         through when adorn is active. */
+      .catalog-item.adorn:hover,
+      .catalog-item.adorn.selected {
+        border-color: transparent;
+      }
+      /* The type-label tab is placed by the shared positionAdornLabel
+         modifier (inline position/top/left), so this class only carries
+         the consumer's concerns: keep it out of pointer events and fade
+         it in on hover. */
+      .search-type-label {
+        pointer-events: none;
+        opacity: 0;
+        transition: opacity 0.1s;
+        z-index: 1;
+      }
+      .catalog-item.adorn:hover .search-type-label {
+        opacity: 1;
+      }
+      /* Selection chip in the bottom-right corner — purely
+         decorative here, so no button wrapper. */
+      .adorn-select-position {
+        position: absolute;
+        bottom: 4px;
+        right: 4px;
+        pointer-events: none;
+        z-index: 1;
       }
     </style>
   </template>

--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -12,12 +12,14 @@ import { IconPlus } from '@cardstack/boxel-ui/icons';
 
 import {
   cardTypeDisplayName,
+  cardTypeIcon,
   isCardInstance,
   rri,
 } from '@cardstack/runtime-common';
 
 import AdornLabel from '@cardstack/host/components/adorn/adorn-label';
 import AdornSelectChip from '@cardstack/host/components/adorn/adorn-select-chip';
+import { htmlComponent } from '@cardstack/host/lib/html-component';
 import type RealmService from '@cardstack/host/services/realm';
 
 import {
@@ -31,23 +33,27 @@ import CardRenderer from '../card-renderer';
 
 import type { ComponentLike, ModifierLike } from '@glint/template';
 
-// CardRenderer stamps `data-card-type-display-name` on each rendered card, so
-// look it up inside the button DOM once it has rendered. This is the same
-// attribute that OperatorModeOverlays reads to label the hover tab.
-const captureAdornTypeName = modifier(
+interface AdornCardMeta {
+  name: string | undefined;
+  iconHtml: string | undefined;
+}
+
+// CardRenderer / the prerendered wrapper stamp `data-card-type-display-name`
+// and `data-card-type-icon-html` on each rendered card, so look them up
+// inside the button DOM once it has rendered. These are the same attributes
+// OperatorModeOverlays reads to label and icon the hover tab.
+const captureAdornCardMeta = modifier(
   (
     element: HTMLElement,
-    [setName, enabled]: [
-      (name: string | undefined) => void,
-      boolean | undefined,
-    ],
+    [setMeta, enabled]: [(meta: AdornCardMeta) => void, boolean | undefined],
   ) => {
     if (!enabled) return;
     let read = () => {
       let inner = element.querySelector('[data-card-type-display-name]');
-      let name =
-        inner?.getAttribute('data-card-type-display-name') ?? undefined;
-      setName(name);
+      setMeta({
+        name: inner?.getAttribute('data-card-type-display-name') ?? undefined,
+        iconHtml: inner?.getAttribute('data-card-type-icon-html') ?? undefined,
+      });
     };
     read();
     let observer = new MutationObserver(read);
@@ -55,7 +61,10 @@ const captureAdornTypeName = modifier(
       childList: true,
       subtree: true,
       attributes: true,
-      attributeFilter: ['data-card-type-display-name'],
+      attributeFilter: [
+        'data-card-type-display-name',
+        'data-card-type-icon-html',
+      ],
     });
     return () => observer.disconnect();
   },
@@ -114,6 +123,7 @@ export default class ItemButton extends Component<Signature> {
   @service declare realm: RealmService;
 
   @tracked private prerenderedTypeName: string | undefined;
+  @tracked private prerenderedTypeIconHtml: string | undefined;
 
   // The catalog-item button element, captured so the shared
   // positionAdornLabel modifier can anchor the type-label tab to the
@@ -135,8 +145,9 @@ export default class ItemButton extends Component<Signature> {
     return this.args.adornPositionLabel ?? noopPositionLabel;
   }
 
-  @action private setPrerenderedTypeName(name: string | undefined) {
-    this.prerenderedTypeName = name;
+  @action private setAdornCardMeta(meta: AdornCardMeta) {
+    this.prerenderedTypeName = meta.name;
+    this.prerenderedTypeIconHtml = meta.iconHtml;
   }
 
   private get adornTypeName(): string | undefined {
@@ -146,6 +157,21 @@ export default class ItemButton extends Component<Signature> {
       return cardTypeDisplayName(this.cardItem);
     }
     return this.prerenderedTypeName;
+  }
+
+  // Type-name precedence mirrored for the icon: card instances supply
+  // it in-memory; prerendered items carry it as icon HTML stamped on
+  // the rendered wrapper (the realm server resolves the proper
+  // subclass icon there).
+  private get adornTypeIcon(): unknown {
+    if (!this.args.adorn || this.isNewCard) return undefined;
+    if (this.cardItem) {
+      return cardTypeIcon(this.cardItem);
+    }
+    if (this.prerenderedTypeIconHtml) {
+      return htmlComponent(this.prerenderedTypeIconHtml);
+    }
+    return undefined;
   }
 
   private get isNewCard(): boolean {
@@ -246,7 +272,7 @@ export default class ItemButton extends Component<Signature> {
       {{on 'click' this.handleClick}}
       {{on 'dblclick' this.handleDblClick}}
       {{on 'keydown' this.handleKeydown}}
-      {{captureAdornTypeName this.setPrerenderedTypeName @adorn}}
+      {{captureAdornCardMeta this.setAdornCardMeta @adorn}}
       {{this.registerCardEl}}
       data-test-card-catalog-create-new-button={{this.newCardItem.realmURL}}
       data-test-card-catalog-item={{removeFileExtension this.resolvedItemId}}
@@ -266,6 +292,13 @@ export default class ItemButton extends Component<Signature> {
             aria-hidden='true'
             {{this.positionLabel this.cardEl}}
           >
+            <:icon>
+              {{#let this.adornTypeIcon as |TypeIcon|}}
+                {{#if TypeIcon}}
+                  <TypeIcon />
+                {{/if}}
+              {{/let}}
+            </:icon>
             <:text>{{this.adornTypeName}}</:text>
           </AdornLabel>
         {{/if}}

--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -144,6 +144,11 @@ export default class ItemButton extends Component<Signature> {
   @tracked private cardEl: HTMLElement | undefined;
 
   private registerCardEl = modifier((element: HTMLElement) => {
+    // Assigned unconditionally: this modifier takes no tracked args, so
+    // it installs once and never re-runs. A guard that read `this.cardEl`
+    // here would instead trip a backtracking assertion, since the
+    // modifier install reads tracked state the label positioner consumes
+    // in the same render.
     this.cardEl = element;
   });
 
@@ -282,7 +287,7 @@ export default class ItemButton extends Component<Signature> {
       @rectangular={{true}}
       class={{cn
         'catalog-item'
-        @adornStrokeClass
+        (if @adorn @adornStrokeClass)
         selected=@isSelected
         create-new-button=this.isNewCard
         multi-select=@multiSelect
@@ -291,7 +296,13 @@ export default class ItemButton extends Component<Signature> {
       {{on 'click' this.handleClick}}
       {{on 'dblclick' this.handleDblClick}}
       {{on 'keydown' this.handleKeydown}}
-      {{captureAdornCardMeta this.setAdornCardMeta @adorn}}
+      {{! Only prerendered (component) items need the DOM observer — card
+          instances supply their type name/icon directly, and the
+          "Create New" row has no label. }}
+      {{captureAdornCardMeta
+        this.setAdornCardMeta
+        (and @adorn this.isComponent)
+      }}
       {{this.registerCardEl}}
       data-test-card-catalog-create-new-button={{this.newCardItem.realmURL}}
       data-test-card-catalog-item={{removeFileExtension this.resolvedItemId}}

--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -609,6 +609,11 @@ export default class SearchContent extends Component<Signature> {
         flex-direction: row;
         flex-wrap: nowrap;
         padding-inline: var(--boxel-sp-xs);
+        /* `overflow-y: hidden` (needed so only the row scrolls
+           horizontally) would otherwise clip the Adorn outline stroke
+           and the type-label tab, which extend a few px outside each
+           card. Block padding keeps them inside the clip region. */
+        padding-block: var(--boxel-sp-xs);
         overflow-y: hidden;
         overflow-x: auto;
       }

--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -23,6 +23,7 @@ import {
   internalKeyFor,
 } from '@cardstack/runtime-common';
 
+import AdornContext from '@cardstack/host/components/adorn/adorn-context';
 import type { PrerenderedCard } from '@cardstack/host/components/prerendered-card-search';
 import type { RealmFilter } from '@cardstack/host/components/realm-picker';
 import type { TypeFilter } from '@cardstack/host/components/type-picker';
@@ -138,6 +139,9 @@ interface Signature {
     activeSort: SortOption;
     onSortChange: (sort: SortOption) => void;
     initialFocusedSection?: string | null;
+    // When true, search-result cards render the Adorn visual treatment
+    // (teal hover type-label tab + teal selection chip).
+    adorn?: boolean;
   };
   Blocks: {};
 }
@@ -506,73 +510,88 @@ export default class SearchContent extends Component<Signature> {
       class='search-sheet-content {{if @isCompact "compact"}}'
       ...attributes
     >
-      {{#if this.showHeader}}
-        {{#unless @isCompact}}
-          <SearchResultHeader
-            @summaryText={{this.summaryText}}
-            @viewOptions={{VIEW_OPTIONS}}
-            @activeViewId={{this.activeViewId}}
-            @activeSort={{@activeSort}}
-            @sortOptions={{SORT_OPTIONS}}
-            @onChangeView={{this.onChangeView}}
-            @onChangeSort={{this.onChangeSort}}
-            @multiSelect={{@multiSelect}}
-            @selectedCards={{@selectedCards}}
-            @allCards={{this.allCards}}
-            @onSelectAll={{@onSelectAll}}
-            @onDeselectAll={{@onDeselectAll}}
-          />
-        {{/unless}}
-      {{/if}}
-
-      {{! Handle empty URL search state — only after loading completes }}
-      {{#if this.searchKeyIsURL}}
-        {{#if this.isCardResourceLoaded}}
-          {{#unless this.resolvedCard}}
-            <div class='empty-state' data-test-search-sheet-empty>
-              No card found at
-              {{@searchKey}}
-            </div>
+      {{! AdornContext aligns with this search-sheet-content div as
+          the visual region for adorn-decorated items. The Adorn
+          tokens + outline rules anchor here, so child ItemButtons
+          don't need to re-establish them per item. We thread the
+          yielded `strokeClass` down to each ItemButton rather than
+          letting them hard-code it. Harmless when @adorn is false (no
+          adorn-decorated descendants for the rules to match). }}
+      <AdornContext as |adorn|>
+        {{#if this.showHeader}}
+          {{#unless @isCompact}}
+            <SearchResultHeader
+              @summaryText={{this.summaryText}}
+              @viewOptions={{VIEW_OPTIONS}}
+              @activeViewId={{this.activeViewId}}
+              @activeSort={{@activeSort}}
+              @sortOptions={{SORT_OPTIONS}}
+              @onChangeView={{this.onChangeView}}
+              @onChangeSort={{this.onChangeSort}}
+              @multiSelect={{@multiSelect}}
+              @selectedCards={{@selectedCards}}
+              @allCards={{this.allCards}}
+              @onSelectAll={{@onSelectAll}}
+              @onDeselectAll={{@onDeselectAll}}
+            />
           {{/unless}}
         {{/if}}
-      {{/if}}
 
-      {{#if @isCompact}}
-        {{#if this.recentCardsSection}}
-          <SearchResultSection
-            @section={{this.recentCardsSection}}
-            @isCompact={{true}}
-            @handleSelect={{@handleSelect}}
-            data-test-search-result-section='recent-cards'
-          />
+        {{! Handle empty URL search state — only after loading completes }}
+        {{#if this.searchKeyIsURL}}
+          {{#if this.isCardResourceLoaded}}
+            {{#unless this.resolvedCard}}
+              <div class='empty-state' data-test-search-sheet-empty>
+                No card found at
+                {{@searchKey}}
+              </div>
+            {{/unless}}
+          {{/if}}
         {{/if}}
-      {{else}}
-        {{! Render all sections }}
-        {{#each this.sections key='sid' as |section i|}}
-          <SearchResultSection
-            @section={{section}}
-            @viewOption={{this.activeViewId}}
-            @handleSelect={{@handleSelect}}
-            @isFocused={{eq this.pagination.focusedSection section.sid}}
-            @isCollapsed={{this.isSectionCollapsed section.sid}}
-            @onFocusSection={{this.onFocusSection}}
-            @getDisplayedCount={{this.getDisplayedCount}}
-            @onShowMore={{this.onShowMore}}
-            @selectedCards={{@selectedCards}}
-            @multiSelect={{@multiSelect}}
-            @offerToCreate={{@offerToCreate}}
-            @onSubmit={{@onSubmit}}
-            data-section-sid={{section.sid}}
-            data-test-search-result-section={{i}}
-          />
-        {{/each}}
-      {{/if}}
 
-      {{#if this.hasNoResults}}
-        <div class='empty-state' data-test-search-content-empty>
-          No cards available
-        </div>
-      {{/if}}
+        {{#if @isCompact}}
+          {{#if this.recentCardsSection}}
+            <SearchResultSection
+              @section={{this.recentCardsSection}}
+              @isCompact={{true}}
+              @handleSelect={{@handleSelect}}
+              @adorn={{@adorn}}
+              @adornStrokeClass={{adorn.strokeClass}}
+              @adornPositionLabel={{adorn.positionLabel}}
+              data-test-search-result-section='recent-cards'
+            />
+          {{/if}}
+        {{else}}
+          {{! Render all sections }}
+          {{#each this.sections key='sid' as |section i|}}
+            <SearchResultSection
+              @section={{section}}
+              @viewOption={{this.activeViewId}}
+              @handleSelect={{@handleSelect}}
+              @isFocused={{eq this.pagination.focusedSection section.sid}}
+              @isCollapsed={{this.isSectionCollapsed section.sid}}
+              @onFocusSection={{this.onFocusSection}}
+              @getDisplayedCount={{this.getDisplayedCount}}
+              @onShowMore={{this.onShowMore}}
+              @selectedCards={{@selectedCards}}
+              @multiSelect={{@multiSelect}}
+              @offerToCreate={{@offerToCreate}}
+              @onSubmit={{@onSubmit}}
+              @adorn={{@adorn}}
+              @adornStrokeClass={{adorn.strokeClass}}
+              @adornPositionLabel={{adorn.positionLabel}}
+              data-section-sid={{section.sid}}
+              data-test-search-result-section={{i}}
+            />
+          {{/each}}
+        {{/if}}
+
+        {{#if this.hasNoResults}}
+          <div class='empty-state' data-test-search-content-empty>
+            No cards available
+          </div>
+        {{/if}}
+      </AdornContext>
     </div>
     <style scoped>
       .search-sheet-content {

--- a/packages/host/app/components/card-search/search-result-section.gts
+++ b/packages/host/app/components/card-search/search-result-section.gts
@@ -34,6 +34,8 @@ import { SECTION_SHOW_MORE_INCREMENT } from './constants';
 import ItemButton from './item-button';
 import SearchSheetSectionHeader from './section-header';
 
+import type { ModifierLike } from '@glint/template';
+
 // Tracks which realm URLs we've already warned about to keep the diagnostic
 // to one-per-realm-per-test-run. Only populated under `isTesting()` (the
 // warning is silenced in production), so growth is bounded by realms
@@ -80,6 +82,19 @@ interface Signature {
       relativeTo: URL | undefined;
     };
     onSubmit?: (selection: string | NewCardArgs) => void;
+    // When true, ItemButton renders the Adorn visual treatment (teal hover
+    // type-label tab + teal selection chip) rather than the legacy grey
+    // hover/selection visuals.
+    adorn?: boolean;
+    // The outline class yielded by the enclosing <AdornContext>,
+    // threaded down to each ItemButton.
+    adornStrokeClass?: string;
+    // The pre-wired label positioner yielded by the enclosing
+    // <AdornContext>, threaded down to each ItemButton.
+    adornPositionLabel?: ModifierLike<{
+      Element: HTMLElement;
+      Args: { Positional: [cardEl: HTMLElement | undefined] };
+    }>;
   };
   Blocks: {};
 }
@@ -326,6 +341,9 @@ export default class SearchResultSection extends Component<Signature> {
               @multiSelect={{@multiSelect}}
               @onSelect={{@handleSelect}}
               @onSubmit={{@onSubmit}}
+              @adorn={{@adorn}}
+              @adornStrokeClass={{@adornStrokeClass}}
+              @adornPositionLabel={{@adornPositionLabel}}
             />
           {{/if}}
           {{#each this.displayedRealmCards as |card i|}}
@@ -337,6 +355,9 @@ export default class SearchResultSection extends Component<Signature> {
                 @multiSelect={{@multiSelect}}
                 @onSelect={{@handleSelect}}
                 @onSubmit={{@onSubmit}}
+                @adorn={{@adorn}}
+                @adornStrokeClass={{@adornStrokeClass}}
+                @adornPositionLabel={{@adornPositionLabel}}
                 data-test-search-sheet-search-result={{i}}
               />
             {{/unless}}
@@ -377,6 +398,9 @@ export default class SearchResultSection extends Component<Signature> {
             @multiSelect={{@multiSelect}}
             @onSelect={{@handleSelect}}
             @onSubmit={{@onSubmit}}
+            @adorn={{@adorn}}
+            @adornStrokeClass={{@adornStrokeClass}}
+            @adornPositionLabel={{@adornPositionLabel}}
             data-test-search-sheet-search-result='0'
           />
         </GridContainer>
@@ -410,6 +434,9 @@ export default class SearchResultSection extends Component<Signature> {
                   @multiSelect={{@multiSelect}}
                   @onSelect={{@handleSelect}}
                   @onSubmit={{@onSubmit}}
+                  @adorn={{@adorn}}
+                  @adornStrokeClass={{@adornStrokeClass}}
+                  @adornPositionLabel={{@adornPositionLabel}}
                   data-test-recent-card-result={{removeFileExtension card.url}}
                 />
               </:default>
@@ -448,6 +475,9 @@ export default class SearchResultSection extends Component<Signature> {
                   @multiSelect={{@multiSelect}}
                   @onSelect={{@handleSelect}}
                   @onSubmit={{@onSubmit}}
+                  @adorn={{@adorn}}
+                  @adornStrokeClass={{@adornStrokeClass}}
+                  @adornPositionLabel={{@adornPositionLabel}}
                   data-test-recent-card-result={{card.id}}
                 />
               </:default>

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -285,6 +285,7 @@ export default class SearchSheet extends Component<Signature> {
             class='search-sheet__content'
             @isCompact={{this.isCompact}}
             @handleSelect={{this.handleCardSelect}}
+            @adorn={{true}}
           />
           <div class='footer'>
             <div class='buttons'>

--- a/packages/host/tests/integration/components/card-search-adorn-test.gts
+++ b/packages/host/tests/integration/components/card-search-adorn-test.gts
@@ -74,6 +74,28 @@ module('Integration | card-search/item-button (adorn)', function (hooks) {
       .doesNotExist('the legacy treatment is unchanged without @adorn');
   });
 
+  test('does not apply the Adorn stroke class when @adorn is false', async function (assert) {
+    // SearchContent wraps every item in an AdornContext and threads its
+    // strokeClass down even to non-adorn callers (e.g. Card Catalog), so
+    // the class must stay gated on @adorn or those items would pick up
+    // the teal outline.
+    await render(
+      <template>
+        <ItemButton
+          @item={{newCardItem}}
+          @isSelected={{false}}
+          @onSelect={{noop}}
+          @adornStrokeClass='adorn-stroke'
+        />
+      </template>,
+    );
+    assert
+      .dom('.catalog-item.adorn-stroke')
+      .doesNotExist(
+        'a non-adorn item does not receive the Adorn outline class',
+      );
+  });
+
   test('renders the teal adorn select chip when adorn + multi-select + selected', async function (assert) {
     await render(
       <template>

--- a/packages/host/tests/integration/components/card-search-adorn-test.gts
+++ b/packages/host/tests/integration/components/card-search-adorn-test.gts
@@ -1,0 +1,109 @@
+import { render, settled, waitFor } from '@ember/test-helpers';
+
+import { module, test } from 'qunit';
+
+import { rri } from '@cardstack/runtime-common';
+
+import ItemButton from '@cardstack/host/components/card-search/item-button';
+import type { NewCardArgs } from '@cardstack/host/utils/card-search/types';
+
+import { setupRenderingTest } from '../../helpers/setup';
+
+import type { ComponentLike } from '@glint/template';
+
+// Stand-in for a prerendered card component. ItemButton extracts the
+// type-label name from the rendered card DOM, where CardRenderer normally
+// stamps it.
+const PrerenderedStub: ComponentLike<{ Element: Element }> = <template>
+  <div data-card-type-display-name='Authenticated Image Tester'>
+    Authenticated Image Tester preview
+  </div>
+</template>;
+
+const noop = () => {};
+const newCardItem: NewCardArgs = {
+  ref: { module: rri('http://test/foo.gts'), name: 'Foo' },
+  relativeTo: undefined,
+  realmURL: rri('http://test/'),
+};
+
+module('Integration | card-search/item-button (adorn)', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('passes through the adorn class when @adorn is true', async function (assert) {
+    await render(
+      <template>
+        <ItemButton
+          @item={{newCardItem}}
+          @isSelected={{false}}
+          @onSelect={{noop}}
+          @adorn={{true}}
+        />
+      </template>,
+    );
+    assert
+      .dom('.catalog-item.adorn')
+      .exists('the catalog-item button carries the adorn class');
+  });
+
+  test('does not add the adorn class when @adorn is omitted', async function (assert) {
+    await render(
+      <template>
+        <ItemButton
+          @item={{newCardItem}}
+          @isSelected={{false}}
+          @onSelect={{noop}}
+        />
+      </template>,
+    );
+    assert.dom('.catalog-item').exists();
+    assert
+      .dom('.catalog-item.adorn')
+      .doesNotExist('the legacy treatment is unchanged without @adorn');
+  });
+
+  test('renders the teal adorn select chip when adorn + multi-select + selected', async function (assert) {
+    await render(
+      <template>
+        <ItemButton
+          @item={{PrerenderedStub}}
+          @itemId='http://test/Foo/1'
+          @isSelected={{true}}
+          @multiSelect={{true}}
+          @onSelect={{noop}}
+          @adorn={{true}}
+        />
+      </template>,
+    );
+
+    assert
+      .dom('[data-test-adorn-selected]')
+      .exists('the teal adorn selection chip is rendered');
+    assert
+      .dom('.selection-indicator')
+      .doesNotExist('the legacy grey selection circle is suppressed');
+  });
+
+  test('hover type-label tab picks up the card type display name from the rendered card', async function (assert) {
+    await render(
+      <template>
+        <ItemButton
+          @item={{PrerenderedStub}}
+          @itemId='http://test/Foo/1'
+          @isSelected={{false}}
+          @onSelect={{noop}}
+          @adorn={{true}}
+        />
+      </template>,
+    );
+    await waitFor('[data-test-adorn-label]');
+    await settled();
+
+    assert
+      .dom('[data-test-adorn-label]')
+      .containsText(
+        'Authenticated Image Tester',
+        'the type-label tab reflects data-card-type-display-name from the inner card render',
+      );
+  });
+});

--- a/packages/host/tests/integration/components/card-search-adorn-test.gts
+++ b/packages/host/tests/integration/components/card-search-adorn-test.gts
@@ -20,6 +20,18 @@ const PrerenderedStub: ComponentLike<{ Element: Element }> = <template>
   </div>
 </template>;
 
+// Same as above, but also carries the type-icon HTML the realm server
+// stamps on prerendered cards — ItemButton renders it into the label's
+// icon slot.
+const PrerenderedStubWithIcon: ComponentLike<{ Element: Element }> = <template>
+  <div
+    data-card-type-display-name='Authenticated Image Tester'
+    data-card-type-icon-html='<svg data-test-type-icon></svg>'
+  >
+    Authenticated Image Tester preview
+  </div>
+</template>;
+
 const noop = () => {};
 const newCardItem: NewCardArgs = {
   ref: { module: rri('http://test/foo.gts'), name: 'Foo' },
@@ -105,5 +117,27 @@ module('Integration | card-search/item-button (adorn)', function (hooks) {
         'Authenticated Image Tester',
         'the type-label tab reflects data-card-type-display-name from the inner card render',
       );
+  });
+
+  test('renders the type icon from data-card-type-icon-html and settles (no render loop)', async function (assert) {
+    await render(
+      <template>
+        <ItemButton
+          @item={{PrerenderedStubWithIcon}}
+          @itemId='http://test/Foo/1'
+          @isSelected={{false}}
+          @onSelect={{noop}}
+          @adorn={{true}}
+        />
+      </template>,
+    );
+    await waitFor('[data-test-adorn-label]');
+    // `settled()` would never resolve if reading the icon HTML and
+    // rendering it fed the capture MutationObserver in a loop.
+    await settled();
+
+    assert
+      .dom('[data-test-adorn-label] [data-test-type-icon]')
+      .exists('the type icon is rendered in the label icon slot');
   });
 });


### PR DESCRIPTION
## Summary
Bring search-result cards in line with the Adorn treatment used in the workspace cards-grid: a teal hover type-label tab showing the card type name, a teal hover/selection outline, and a teal selection chip in place of the legacy grey selection circle.

The treatment is opt-in via a new `@adorn` arg on `ItemButton`, plumbed through `SearchResultSection` and `SearchContent` and turned on at the search-sheet call site. Other callers keep the legacy visuals.

The label tab uses the **shared `AdornContext` positioner** (see #5067, which this stacks on): `search-content` wraps the list in `<AdornContext>` and threads the yielded `strokeClass` + `positionLabel` down to each `ItemButton`, so the tab anchors to the card and clamps to the boundary exactly like the stack-item overlay — no bespoke positioning, no hard-coded Adorn class names at the call site.

Stacked on #5067 (positioner extraction); **review/merge that first**. The diff shown here against `main` will collapse to just the `card-search` / `search-sheet` files once #5067 lands.

## Test plan
- [x] `lint:types` + eslint pass.
- [x] `card-search/item-button (adorn)` integration module passes (adorn class pass-through, teal select chip on multi-select, type-label tab picks up the card type name).
- [ ] Manual: open the search sheet — hovered/selected result cards show the teal outline, type-label tab, and selection chip; non-adorn callers are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
