### PR TITLE
Enable Adorn UI overlays in the card chooser

### DIFF
--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -152,6 +152,7 @@ export default class CardCatalogModal extends Component<Signature> {
                   @onSelectAll={{this.selectAll}}
                   @onDeselectAll={{this.deselectAll}}
                   @offerToCreate={{this.offerToCreateArg}}
+                  @adorn={{true}}
                 />
               </:content>
               <:footer>

--- a/packages/host/tests/integration/components/card-catalog-test.gts
+++ b/packages/host/tests/integration/components/card-catalog-test.gts
@@ -300,6 +300,24 @@ module('Integration | card-catalog', function (hooks) {
         'http://test-realm/test/Spec/tree',
       ]);
     });
+
+    test('catalog items render with the Adorn visual treatment', async function (assert) {
+      await waitFor(
+        `[data-test-realm="${realmName}"] [data-test-card-catalog-item]`,
+      );
+
+      // The card chooser opts in to the Adorn treatment (teal hover tab +
+      // chip + outline), so every catalog item button carries the `adorn`
+      // class — matching the operator-mode cards-grid look.
+      assert
+        .dom(`[data-test-realm="${realmName}"] [data-test-card-catalog-item]`)
+        .exists({ count: 5 }, 'catalog items are rendered');
+      assert
+        .dom(
+          `[data-test-realm="${realmName}"] [data-test-card-catalog-item]:not(.adorn)`,
+        )
+        .doesNotExist('every catalog item renders with the adorn class');
+    });
   });
 
   module('mouse and key events', function () {


### PR DESCRIPTION
## Summary
Turn on the Adorn visual treatment for the card-catalog chooser so its hover/selection visuals match the operator-mode cards-grid and the search-results pane. The plumbing (the `@adorn` arg forwarded through SearchContent → SearchResultSection → ItemButton) is already on `main`; this is the one-line opt-in at the chooser call site, plus a test.

Stacked on #5080 (Adorn search pane improvements), which polishes the shared treatment (stroke clipping, hover darkening) the chooser benefits from — review/merge that first. The diff here against `main` collapses to just the `card-catalog` files once #5080 lands.

## Test plan
- [x] `lint:types` + eslint pass.
- [x] `card-catalog` integration test: every catalog item renders with the `adorn` class.
- [ ] Manual: open the card chooser — cards show the teal hover tab + outline + selection chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
