### PR TITLE
Drop wait-on probe-logging DEBUG flag from host CI

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -130,15 +130,6 @@ jobs:
         working-directory: packages/host
         env:
           DBUS_SYSTEM_BUS_ADDRESS: unix:path=/run/dbus/system_bus_socket
-          # [readiness-diag] — start-server-and-test reads DEBUG and
-          # propagates `log: true` + `verbose: true` to wait-on, so each
-          # readiness-probe attempt prints its HTTP status / connection
-          # error. Distinguishes "server not listening" from "server
-          # hanging mid-request" from "server returning 500" when the
-          # 10-minute wait-on timer fires. Remove together with the
-          # other [readiness-diag] markers once the root cause is
-          # identified.
-          DEBUG: start-server-and-test
 
       - name: Upload junit report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -259,15 +250,6 @@ jobs:
           HOST_TEST_PARTITION: ${{ matrix.shardIndex }}
           HOST_TEST_PARTITION_COUNT: ${{ matrix.shardTotal }}
           DBUS_SYSTEM_BUS_ADDRESS: unix:path=/run/dbus/system_bus_socket
-          # [readiness-diag] — start-server-and-test reads DEBUG and
-          # propagates `log: true` + `verbose: true` to wait-on, so each
-          # readiness-probe attempt prints its HTTP status / connection
-          # error. Distinguishes "server not listening" from "server
-          # hanging mid-request" from "server returning 500" when the
-          # 10-minute wait-on timer fires. Remove together with the
-          # other [readiness-diag] markers once the root cause is
-          # identified.
-          DEBUG: start-server-and-test
         working-directory: packages/host
 
       - name: Upload junit report to GitHub Actions Artifacts


### PR DESCRIPTION
## Background and Goal

The host CI workflow (live-tests job + host-shard job) set `DEBUG=start-server-and-test`, which causes start-server-and-test to forward `log: true` + `verbose: true` to wait-on. That printed a status line per readiness-probe attempt — useful while diagnosing readiness-check timeouts, noisy now that the probe-level signal isn't being used.

## Where to start

`.github/workflows/ci-host.yaml` — both occurrences of `DEBUG: start-server-and-test` (plus their preceding 8-line comment block) are removed; nothing else changes. The `LOG_LEVELS="${LOG_LEVELS:-*=info}"` plumbing in `mise-tasks/services/{realm-server,worker}` and the in-process `readiness-diag` logger remain — those control realm-server / worker logs, not wait-on output.

## Key decisions

- Scope kept narrow to the wait-on chatter. Other diagnostic plumbing (settled-state dump, readiness-diag debug logger, indexing telemetry) stays — it's cheap when nothing flakes and load-bearing when something does.