### PR TITLE
Drop legacy boxel-render-error reference from getBrokenLinks comment

### DIFF
--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -636,9 +636,8 @@ export interface BrokenLinkFinding {
 // render route scan the instance after the store has settled and build a
 // structured failure payload from the findings.
 //
-// The walk recurses to match the coverage the legacy `boxel-render-error`
-// dispatch had — that event fired for any failed lazy load anywhere in the
-// rendered graph, not just the root card:
+// The walk recurses so a broken link anywhere in the rendered graph is
+// captured, not just one held directly by the root card:
 //   - present `linksTo` / `linksToMany` values are recursed into, since a
 //     loaded linked card can itself hold a link that was dereferenced (and
 //     failed) during this render;


### PR DESCRIPTION
## Background and Goal

The `boxel-render-error` CustomEvent path was retired when broken-link capture moved to the post-settle scan over data-bucket sentinels (`getBrokenLinks`). The dispatch in `lazilyLoadLink` and the host listeners in `card-prerender.gts` / `routes/render.ts` are already gone.

The lone residual textual reference was a comment in `getBrokenLinks` that anchored the recursion rationale to "match the coverage the legacy `boxel-render-error` dispatch had." This drops that legacy anchor so the comment reads as the enduring contract on its own terms.

Closes [CS-11269](https://linear.app/cardstack/issue/CS-11269/retire-boxel-render-error-customevent-dispatch-from-lazilyloadlink).

## Where to start

`packages/base/field-support.ts` — one comment rewrite inside `getBrokenLinks`'s header. No behavior change.

## Key decisions

- Comment-only edit; no code paths, fixtures, or tests are modified.
- The `'boxel-render-error'` string in `bench-fixtures/runtime-common/amd-transpile/card-api.js` is left alone — it's a frozen AMD-transpile bench input, not live code.
