### PR TITLE
Stabilize software-factory shard 1 against per-test realm-server restart races

### DIFF
--- a/packages/host/tests/unit/loader-parallel-prefetch-test.ts
+++ b/packages/host/tests/unit/loader-parallel-prefetch-test.ts
@@ -176,7 +176,7 @@ module('Unit | loader prefetch', function (hooks) {
   });
 
   test('prefetch surfaces dependency failures when dependency import is requested', async function (assert) {
-    assert.expect(5);
+    assert.expect(4);
 
     let mainURL = `${testRealmURL}prefetch/broken-main.js`;
     let depURL = `${testRealmURL}prefetch/broken-dep.js`;
@@ -197,8 +197,12 @@ module('Unit | loader prefetch', function (hooks) {
 
       if (url === depURL || url === trimmedDepURL) {
         depFetchAttempted = true;
-        // Simulate network failure for the dependency. Loader._fetch will catch and
-        // convert this into a failing Response, which becomes a CardError.
+        // Simulate a transport-level failure for the dependency (the fetch
+        // never reaches a server). Loader._fetch catches this and returns a
+        // synthetic 500 tagged as a transient transport failure, so the
+        // module is not cached as `broken` — inability to reach the server
+        // isn't a deterministic property of the module, and the next import
+        // should retry rather than replay a cached error.
         throw new Error('boom from dep');
       }
       return originalFetch.call(testLoader, input, init);
@@ -217,23 +221,18 @@ module('Unit | loader prefetch', function (hooks) {
         'importing parent surfaces dependency failure with correct URL',
       );
 
-      // @ts-expect-error TS2341: we explicitly reach into the loader to confirm the broken dependency bookkeeping.
+      // @ts-expect-error TS2341: we explicitly reach into the loader to confirm the new contract — transport-level failures must not be cached.
       let depModule = testLoader.getModule(depURL);
       assert.strictEqual(
-        (depModule as any)?.state,
-        'broken',
-        'broken dependency recorded',
-      );
-      assert.strictEqual(
-        (depModule as any)?.exception.id,
-        trimmedDepURL,
-        'broken dependency error corresponds to dependency URL',
+        depModule,
+        undefined,
+        'transport-level dependency failure leaves no cached module entry',
       );
 
       await assert.rejects(
         testLoader.import(depURL),
         (e: any) => e.id === trimmedDepURL,
-        'importing dependency directly surfaces failure',
+        'importing dependency directly re-fetches and surfaces failure',
       );
     } finally {
       (testLoader as any).fetchImplementation = originalFetch;

--- a/packages/host/tests/unit/loader-parallel-prefetch-test.ts
+++ b/packages/host/tests/unit/loader-parallel-prefetch-test.ts
@@ -231,7 +231,7 @@ module('Unit | loader prefetch', function (hooks) {
 
       await assert.rejects(
         testLoader.import(depURL),
-        (e: any) => e.id === trimmedDepURL,
+        (e: any) => e.id === trimmedDepURL || e.id === depURL,
         'importing dependency directly re-fetches and surfaces failure',
       );
     } finally {

--- a/packages/realm-test-harness/src/api.ts
+++ b/packages/realm-test-harness/src/api.ts
@@ -389,6 +389,7 @@ export async function startFactoryRealmServer(
         fullIndexOnStartup: false,
         realmServerPort: options.realmServerPort,
         prerenderURL: options.prerenderURL,
+        noCompatProxy: options.noCompatProxy,
       });
     } catch (error) {
       let cleanupError: unknown;

--- a/packages/realm-test-harness/src/index.ts
+++ b/packages/realm-test-harness/src/index.ts
@@ -28,6 +28,10 @@ export {
 
 export { startHarnessPrerenderServer } from './support-services';
 
+export { startCompatRealmProxy } from './isolated-realm-stack';
+
+export type { StartedCompatRealmProxy } from './shared';
+
 export * from './runtime-metadata';
 
 export {

--- a/packages/realm-test-harness/src/isolated-realm-stack.ts
+++ b/packages/realm-test-harness/src/isolated-realm-stack.ts
@@ -986,27 +986,8 @@ export async function stopIsolatedRealmStack(
 ): Promise<void> {
   let cleanupError: unknown;
 
-  // Order matters: close the front door before killing what's behind it.
-  // The worker-scoped prerender (when shared across tests) keeps issuing
-  // standby refills and other requests at the stable compat-proxy port.
-  // Killing the realm-server first would leave the proxy briefly alive
-  // with a dead upstream — any request landing in that window would loop
-  // through `fetchUpstreamWithRetry`'s ECONNREFUSED backoff and come back
-  // as a 502, which (a) ties up the proxy and (b) surfaces in the
-  // prerender as a `StandbyTargetNotReadyError` / render failure on a
-  // realm whose teardown the test thought was over. Stopping the proxy
-  // first sets its `stopping` flag and aborts in-flight retries
-  // immediately (see `startCompatRealmProxy`), so subsequent requests
-  // get an immediate 503 with no chance to race the realm-server's
-  // SIGTERM.
   try {
     await stack.prerender?.stop();
-  } catch (error) {
-    cleanupError ??= error;
-  }
-
-  try {
-    await stack.compatProxy?.stop();
   } catch (error) {
     cleanupError ??= error;
   }
@@ -1019,6 +1000,12 @@ export async function stopIsolatedRealmStack(
 
   try {
     await stopManagedProcess(stack.workerManager);
+  } catch (error) {
+    cleanupError ??= error;
+  }
+
+  try {
+    await stack.compatProxy?.stop();
   } catch (error) {
     cleanupError ??= error;
   }

--- a/packages/realm-test-harness/src/isolated-realm-stack.ts
+++ b/packages/realm-test-harness/src/isolated-realm-stack.ts
@@ -279,7 +279,7 @@ async function fetchUpstreamWithRetry(
   }
 }
 
-async function startCompatRealmProxy({
+export async function startCompatRealmProxy({
   listenPort,
 }: {
   listenPort: number;
@@ -512,6 +512,7 @@ export async function startIsolatedRealmStack({
   workerManagerPort: explicitWorkerManagerPort,
   realmServerPort: explicitRealmServerPort,
   prerenderURL: explicitPrerenderURL,
+  noCompatProxy,
 }: {
   realms: RealmConfig[];
   realmServerURL: URL;
@@ -533,6 +534,13 @@ export async function startIsolatedRealmStack({
    *  starting a new one. The Playwright harness keeps prerender alive for
    *  the lifetime of a testWorker and passes its URL here. */
   prerenderURL?: string;
+  /** When true, skip creating an in-stack compat proxy. The caller owns
+   *  the proxy out-of-band (e.g., the Playwright worker keeps one alive
+   *  for the whole testWorker's lifetime so the stable
+   *  compat-realm-server port has no listener gap between tests, and
+   *  calls `setTargetPort` on it itself once the realm-server binds).
+   *  The returned stack's `compatProxy` is `undefined` in that case. */
+  noCompatProxy?: boolean;
 }): Promise<RunningFactoryStack> {
   if (realms.length === 0) {
     throw new Error('startIsolatedRealmStack requires at least one realm');
@@ -626,9 +634,11 @@ export async function startIsolatedRealmStack({
         username,
       });
     }
-    let compatProxy = await startCompatRealmProxy({
-      listenPort: Number(realmServerURL.port),
-    });
+    let compatProxy = noCompatProxy
+      ? undefined
+      : await startCompatRealmProxy({
+          listenPort: Number(realmServerURL.port),
+        });
     // The software-factory Playwright harness can keep prerender alive for the
     // lifetime of a Playwright testWorker even though the realm stack itself is
     // recreated per test. When provided, reuse that long-lived prerender URL so
@@ -689,8 +699,12 @@ export async function startIsolatedRealmStack({
       LOW_CREDIT_THRESHOLD: '2000',
       LOG_LEVELS: DEFAULT_REALM_LOG_LEVELS,
       BOXEL_TRUST_FORWARDED_URL: 'true',
-      PUBLISHED_REALM_BOXEL_SPACE_DOMAIN: `localhost:${compatProxy.listenPort}`,
-      PUBLISHED_REALM_BOXEL_SITE_DOMAIN: `localhost:${compatProxy.listenPort}`,
+      PUBLISHED_REALM_BOXEL_SPACE_DOMAIN: `localhost:${
+        compatProxy?.listenPort ?? Number(realmServerURL.port)
+      }`,
+      PUBLISHED_REALM_BOXEL_SITE_DOMAIN: `localhost:${
+        compatProxy?.listenPort ?? Number(realmServerURL.port)
+      }`,
       TEST_HARNESS_WORKER_MANAGER_METADATA_FILE: workerManagerMetadataFile,
       TEST_HARNESS_REALM_SERVER_METADATA_FILE: realmServerMetadataFile,
     };
@@ -908,7 +922,11 @@ export async function startIsolatedRealmStack({
           Date.now() - realmServerSpawnedAt
         }ms`,
       );
-      compatProxy.setTargetPort(realmServerRuntime.port, () =>
+      // When the caller owns the proxy externally (`noCompatProxy`), they
+      // call `setTargetPort` themselves after reading the realm-server
+      // port from the metadata file this child writes — so we skip it
+      // here. Otherwise (proxy lives in this stack), repoint it now.
+      compatProxy?.setTargetPort(realmServerRuntime.port, () =>
         describeRealmServerHealth(realmServer, realmServerExit, getServerLogs),
       );
       await Promise.race([
@@ -935,12 +953,16 @@ export async function startIsolatedRealmStack({
       );
 
       return {
+        // Undefined when the caller owns the proxy externally (see
+        // `noCompatProxy`); that proxy stays alive across this stack's
+        // teardown so the next stack can rebind the realm-server behind
+        // it without a listener gap on the stable compat port.
         compatProxy,
         prerender,
         realmServer,
         realmServerURL,
         ports: {
-          publicPort: compatProxy.listenPort,
+          publicPort: compatProxy?.listenPort ?? Number(realmServerURL.port),
           realmServerPort: realmServerRuntime.port,
           workerManagerPort: workerManagerRuntime.port,
         },

--- a/packages/realm-test-harness/src/isolated-realm-stack.ts
+++ b/packages/realm-test-harness/src/isolated-realm-stack.ts
@@ -286,6 +286,17 @@ export async function startCompatRealmProxy({
 }): Promise<StartedCompatRealmProxy> {
   realmLog.debug(`startCompatRealmProxy: requested listenPort=${listenPort}`);
   let targetPort: number | undefined;
+  // Notifier for `clearTargetPort()` → `setTargetPort()` round-trips. While
+  // `targetPort` is unset, incoming requests `await` this promise instead
+  // of 502-ing against a non-existent upstream. Recreated on each
+  // `clearTargetPort` call so the next `setTargetPort` can resolve a
+  // fresh set of waiters.
+  let targetReady: Promise<void> = Promise.resolve();
+  let resolveTargetReady: (() => void) | undefined;
+  // Cap how long a single request will block waiting for a new target.
+  // 30s is well under Playwright's 300s test timeout and the 240s
+  // metadata-file wait in fixtures.ts.
+  const PROXY_TARGET_WAIT_TIMEOUT_MS = 30_000;
   // Set alongside the target port: returns a one-shot snapshot of the
   // upstream realm-server child's liveness and recent buffered output. The
   // child's stdout/stderr are otherwise only flushed to CI on an
@@ -311,10 +322,27 @@ export async function startCompatRealmProxy({
         return;
       }
       if (targetPort == null) {
-        res.statusCode = 503;
-        res.setHeader('content-type', 'text/plain; charset=utf-8');
-        res.end('software-factory compat proxy target is not ready');
-        return;
+        // Per-test realm-server restart in progress. Block briefly so the
+        // prerender's standby refill doesn't pin a broken page-load state
+        // for 90s waiting for `#standby-ready`. Cap with both an explicit
+        // timeout and the proxy's stopAbort signal so a hung handoff
+        // still surfaces a 503 (not an indefinite wait).
+        let timedOut = false;
+        await Promise.race([
+          targetReady,
+          new Promise<void>((resolveTimeout) =>
+            setTimeout(() => {
+              timedOut = true;
+              resolveTimeout();
+            }, PROXY_TARGET_WAIT_TIMEOUT_MS),
+          ),
+        ]);
+        if (stopping || timedOut || targetPort == null) {
+          res.statusCode = 503;
+          res.setHeader('content-type', 'text/plain; charset=utf-8');
+          res.end('software-factory compat proxy target is not ready');
+          return;
+        }
       }
       let incomingURL = new URL(
         req.url ?? '/',
@@ -407,8 +435,24 @@ export async function startCompatRealmProxy({
     setTargetPort(nextTargetPort: number, nextDescribeUpstreamHealth) {
       targetPort = nextTargetPort;
       describeUpstreamHealth = nextDescribeUpstreamHealth;
+      // Release any requests that blocked while the previous target was
+      // cleared (per-test realm-server restart window).
+      resolveTargetReady?.();
+      resolveTargetReady = undefined;
       realmLog.debug(
         `startCompatRealmProxy: ${actualListenPort} -> ${nextTargetPort} ready`,
+      );
+    },
+    clearTargetPort() {
+      if (targetPort == null && resolveTargetReady != null) {
+        return; // already in "transitioning" state
+      }
+      targetPort = undefined;
+      targetReady = new Promise<void>((resolveReady) => {
+        resolveTargetReady = resolveReady;
+      });
+      realmLog.debug(
+        `startCompatRealmProxy: ${actualListenPort} -> (transitioning, awaiting next setTargetPort)`,
       );
     },
     async stop() {
@@ -420,6 +464,11 @@ export async function startCompatRealmProxy({
       // can't hang on a request looping against a dead upstream.
       stopping = true;
       stopAbort.abort();
+      // Release any requests blocked in `targetReady` so they observe
+      // `stopping=true` and short-circuit to 503 instead of hanging until
+      // PROXY_TARGET_WAIT_TIMEOUT_MS.
+      resolveTargetReady?.();
+      resolveTargetReady = undefined;
       (server as { closeAllConnections?: () => void }).closeAllConnections?.();
       await new Promise<void>((resolve, reject) => {
         server.close((error) => {

--- a/packages/realm-test-harness/src/isolated-realm-stack.ts
+++ b/packages/realm-test-harness/src/isolated-realm-stack.ts
@@ -986,8 +986,27 @@ export async function stopIsolatedRealmStack(
 ): Promise<void> {
   let cleanupError: unknown;
 
+  // Order matters: close the front door before killing what's behind it.
+  // The worker-scoped prerender (when shared across tests) keeps issuing
+  // standby refills and other requests at the stable compat-proxy port.
+  // Killing the realm-server first would leave the proxy briefly alive
+  // with a dead upstream — any request landing in that window would loop
+  // through `fetchUpstreamWithRetry`'s ECONNREFUSED backoff and come back
+  // as a 502, which (a) ties up the proxy and (b) surfaces in the
+  // prerender as a `StandbyTargetNotReadyError` / render failure on a
+  // realm whose teardown the test thought was over. Stopping the proxy
+  // first sets its `stopping` flag and aborts in-flight retries
+  // immediately (see `startCompatRealmProxy`), so subsequent requests
+  // get an immediate 503 with no chance to race the realm-server's
+  // SIGTERM.
   try {
     await stack.prerender?.stop();
+  } catch (error) {
+    cleanupError ??= error;
+  }
+
+  try {
+    await stack.compatProxy?.stop();
   } catch (error) {
     cleanupError ??= error;
   }
@@ -1000,12 +1019,6 @@ export async function stopIsolatedRealmStack(
 
   try {
     await stopManagedProcess(stack.workerManager);
-  } catch (error) {
-    cleanupError ??= error;
-  }
-
-  try {
-    await stack.compatProxy?.stop();
   } catch (error) {
     cleanupError ??= error;
   }

--- a/packages/realm-test-harness/src/isolated-realm-stack.ts
+++ b/packages/realm-test-harness/src/isolated-realm-stack.ts
@@ -328,15 +328,24 @@ export async function startCompatRealmProxy({
         // timeout and the proxy's stopAbort signal so a hung handoff
         // still surfaces a 503 (not an indefinite wait).
         let timedOut = false;
-        await Promise.race([
-          targetReady,
-          new Promise<void>((resolveTimeout) =>
-            setTimeout(() => {
-              timedOut = true;
-              resolveTimeout();
-            }, PROXY_TARGET_WAIT_TIMEOUT_MS),
-          ),
-        ]);
+        let waitTimer: NodeJS.Timeout | undefined;
+        try {
+          await Promise.race([
+            targetReady,
+            new Promise<void>((resolveTimeout) => {
+              waitTimer = setTimeout(() => {
+                timedOut = true;
+                resolveTimeout();
+              }, PROXY_TARGET_WAIT_TIMEOUT_MS);
+            }),
+          ]);
+        } finally {
+          // Clear the timer whenever `targetReady` wins the race — an
+          // un-cleared 30s timer keeps the event loop (and the Playwright
+          // worker) alive past teardown. Harmless when the timer is the
+          // one that fired.
+          clearTimeout(waitTimer);
+        }
         if (stopping || timedOut || targetPort == null) {
           res.statusCode = 503;
           res.setHeader('content-type', 'text/plain; charset=utf-8');

--- a/packages/realm-test-harness/src/shared.ts
+++ b/packages/realm-test-harness/src/shared.ts
@@ -141,6 +141,14 @@ export type StartedCompatRealmProxy = {
     targetPort: number,
     describeUpstreamHealth?: () => string,
   ): void;
+  /**
+   * Mark the upstream as transitioning (no current target). Incoming
+   * requests will block briefly waiting for `setTargetPort` instead of
+   * 502-ing against a torn-down realm-server — this prevents the
+   * prerender's standby pages from caching broken module loads during
+   * the per-test realm-server restart window.
+   */
+  clearTargetPort(): void;
   stop(): Promise<void>;
 };
 

--- a/packages/realm-test-harness/src/shared.ts
+++ b/packages/realm-test-harness/src/shared.ts
@@ -79,6 +79,12 @@ export interface FactoryRealmOptions {
   realmServerPort?: number;
   /** Explicit prerender URL to reuse instead of starting a new prerender. */
   prerenderURL?: string;
+  /** When true, skip creating an in-stack compat proxy — the caller owns
+   *  it externally (typically a Playwright worker fixture that keeps the
+   *  proxy alive across per-test serve-realm spawns) and calls
+   *  `setTargetPort` itself after reading the realm-server port from this
+   *  child's metadata file. */
+  noCompatProxy?: boolean;
 }
 
 export interface FactoryRealmTemplate {

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -722,12 +722,29 @@ export class Loader {
         urlOrRequest instanceof Request
           ? urlOrRequest.url
           : String(urlOrRequest);
-      this.log.error(`fetch failed for ${url}`, err);
+      // `err.code` is present in Node (undici surfaces ECONNREFUSED /
+      // ENOTFOUND / etc.) but absent in browsers — Chromium logs the
+      // underlying `net::ERR_*` through its own network-layer channel
+      // rather than the JS Error. Include whatever's available so the
+      // synthetic Response carries the most specific detail we can get
+      // wherever the loader runs.
+      let detail = err?.code
+        ? `${err.message} (${err.code})`
+        : (err?.message ?? String(err));
+      this.log.error(`fetch failed for ${url}: ${detail}`, err);
 
-      return new Response(`fetch failed for ${url}`, {
+      let synthetic = new Response(`fetch failed for ${url}: ${detail}`, {
         status: 500,
-        statusText: err.message,
+        statusText: detail.slice(0, 200) || 'fetch failed',
       });
+      // Mark this Response as a transport-level (server-unreachable) failure.
+      // The thrown CardError above this gets flagged downstream so callers
+      // know not to poison the module cache with this exception — a
+      // "Failed to fetch" means the server wasn't there, not that the
+      // module is broken.
+      (synthetic as any)[Symbol.for('boxel-loader-transient-fetch-failure')] =
+        true;
+      return synthetic;
     }
   };
 
@@ -811,11 +828,23 @@ export class Loader {
     try {
       loaded = await this.load(moduleURL);
     } catch (exception) {
-      this.setModule(moduleIdentifier, {
-        state: 'broken',
-        exception,
-        consumedModules: new Set(), // we blew up before we could understand what was inside ourselves
-      });
+      if (
+        (exception as { isTransientFetchFailure?: boolean })
+          ?.isTransientFetchFailure
+      ) {
+        // Inability to talk to the server isn't a deterministic property
+        // of the module — caching this as `broken` would poison the
+        // module entry for the lifetime of this loader (every future
+        // `import` would rethrow without retrying). Drop the entry so
+        // the next `import` re-enters `fetchModule` and refetches.
+        this.modules.delete(trimModuleIdentifier(moduleIdentifier));
+      } else {
+        this.setModule(moduleIdentifier, {
+          state: 'broken',
+          exception,
+          consumedModules: new Set(), // we blew up before we could understand what was inside ourselves
+        });
+      }
       module.deferred.fulfill();
       throw exception;
     }
@@ -1045,6 +1074,19 @@ export class Loader {
     }
     if (!response.ok) {
       let error = await CardError.fromFetchResponse(moduleURL.href, response);
+      // Surfaced from `_fetch`'s catch: the request never reached the
+      // server. Tag the error so `fetchModule` skips caching it as a
+      // broken module — transport-level failures are non-deterministic
+      // and the next import should retry rather than replay this error.
+      if (
+        (response as unknown as Record<symbol, unknown>)[
+          Symbol.for('boxel-loader-transient-fetch-failure')
+        ]
+      ) {
+        (
+          error as CardError & { isTransientFetchFailure?: boolean }
+        ).isTransientFetchFailure = true;
+      }
       throw error;
     }
 

--- a/packages/software-factory/playwright.config.ts
+++ b/packages/software-factory/playwright.config.ts
@@ -1,11 +1,17 @@
 import { defineConfig } from '@playwright/test';
 
-// `render-desync=info` stays on so the desync detector's verdicts (warns
-// on detection, plus any debug logs we add later) make it into CI output;
-// everything else is at the same warn-baseline as before CS-10860.
+// TEMPORARY diagnostic verbosity (revert before merge): surface what the
+// harness and the realm-server / worker / prerender children are doing so
+// the residual `instantiate-card` upstream-unreachable race (now fast-
+// failing post-hard-stop) is legible in CI. `*=info` lifts the harness
+// loggers above the warn baseline; the two TEST_HARNESS_* knobs stream
+// the child output (`inherit`) and forward the serve-realm child's stdout
+// to the test output. Shell env still wins via `??=`.
 const defaultPlaywrightLogLevels =
-  '*=warn,software-factory:playwright=info,software-factory:playwright:support=info,software-factory:playwright:cache=info,render-desync=info,prerenderer-chrome=none';
+  '*=info,render-desync=info,prerenderer-chrome=none';
 process.env.LOG_LEVELS ??= defaultPlaywrightLogLevels;
+process.env.TEST_HARNESS_DEBUG_SERVER ??= '1';
+process.env.TEST_HARNESS_FORWARD_REALM_LOGS ??= '1';
 
 const realmPort = Number(process.env.TEST_HARNESS_REALM_PORT ?? 4205);
 const realmURL =

--- a/packages/software-factory/playwright.config.ts
+++ b/packages/software-factory/playwright.config.ts
@@ -1,17 +1,11 @@
 import { defineConfig } from '@playwright/test';
 
-// TEMPORARY diagnostic verbosity (revert before merge): surface what the
-// harness and the realm-server / worker / prerender children are doing so
-// the residual `instantiate-card` upstream-unreachable race (now fast-
-// failing post-hard-stop) is legible in CI. `*=info` lifts the harness
-// loggers above the warn baseline; the two TEST_HARNESS_* knobs stream
-// the child output (`inherit`) and forward the serve-realm child's stdout
-// to the test output. Shell env still wins via `??=`.
+// `render-desync=info` stays on so the desync detector's verdicts (warns
+// on detection, plus any debug logs we add later) make it into CI output;
+// everything else is at the same warn-baseline as before CS-10860.
 const defaultPlaywrightLogLevels =
-  '*=info,render-desync=info,prerenderer-chrome=info';
+  '*=warn,software-factory:playwright=info,software-factory:playwright:support=info,software-factory:playwright:cache=info,render-desync=info,prerenderer-chrome=none';
 process.env.LOG_LEVELS ??= defaultPlaywrightLogLevels;
-process.env.TEST_HARNESS_DEBUG_SERVER ??= '1';
-process.env.TEST_HARNESS_FORWARD_REALM_LOGS ??= '1';
 
 const realmPort = Number(process.env.TEST_HARNESS_REALM_PORT ?? 4205);
 const realmURL =

--- a/packages/software-factory/playwright.config.ts
+++ b/packages/software-factory/playwright.config.ts
@@ -8,7 +8,7 @@ import { defineConfig } from '@playwright/test';
 // the child output (`inherit`) and forward the serve-realm child's stdout
 // to the test output. Shell env still wins via `??=`.
 const defaultPlaywrightLogLevels =
-  '*=info,render-desync=info,prerenderer-chrome=none';
+  '*=info,render-desync=info,prerenderer-chrome=info';
 process.env.LOG_LEVELS ??= defaultPlaywrightLogLevels;
 process.env.TEST_HARNESS_DEBUG_SERVER ??= '1';
 process.env.TEST_HARNESS_FORWARD_REALM_LOGS ??= '1';

--- a/packages/software-factory/src/cli/serve-realm.ts
+++ b/packages/software-factory/src/cli/serve-realm.ts
@@ -159,6 +159,12 @@ async function main(): Promise<void> {
     realmServerPort: parseCliNumber('realmServerPort'),
     compatRealmServerPort: parseCliNumber('compatRealmServerPort'),
     prerenderURL: parseCliArg('prerenderURL'),
+    // The Playwright worker process owns the compat proxy for the whole
+    // testWorker lifetime (so the stable compat-realm-server port stays
+    // bound across per-test serve-realm spawns) and calls `setTargetPort`
+    // itself after reading the realm-server port out of this child's
+    // metadata file. This child must not bind that port.
+    noCompatProxy: true,
   });
 
   let payload = {

--- a/packages/software-factory/src/cli/serve-realm.ts
+++ b/packages/software-factory/src/cli/serve-realm.ts
@@ -59,6 +59,10 @@ function parseCliNumber(name: string): number | undefined {
   return parsed;
 }
 
+function parseCliBool(name: string): boolean {
+  return process.argv.includes(`--${name}`);
+}
+
 interface SerializableRealmConfig {
   dir: string;
   path: string;
@@ -159,12 +163,15 @@ async function main(): Promise<void> {
     realmServerPort: parseCliNumber('realmServerPort'),
     compatRealmServerPort: parseCliNumber('compatRealmServerPort'),
     prerenderURL: parseCliArg('prerenderURL'),
-    // The Playwright worker process owns the compat proxy for the whole
-    // testWorker lifetime (so the stable compat-realm-server port stays
-    // bound across per-test serve-realm spawns) and calls `setTargetPort`
-    // itself after reading the realm-server port out of this child's
-    // metadata file. This child must not bind that port.
-    noCompatProxy: true,
+    // When the Playwright fixture spawns this child, the worker process
+    // owns the compat proxy for the testWorker's whole lifetime (so the
+    // stable compat-realm-server port stays bound across per-test
+    // serve-realm spawns) and calls `setTargetPort` itself after reading
+    // the realm-server port out of this child's metadata file. In that
+    // mode the child must not bind the compat port — the fixture passes
+    // `--no-compat-proxy`. Standalone `pnpm serve:realm` omits the flag
+    // and gets the in-stack proxy.
+    noCompatProxy: parseCliBool('no-compat-proxy'),
   });
 
   let payload = {

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -283,6 +283,9 @@ async function startRealmProcess(
         `--compatRealmServerPort=${testWorkerPortSet.compatRealmServerPort}`,
         `--realmServerPort=${testWorkerPortSet.realmServerPort}`,
         `--prerenderURL=${testWorkerPrerenderURL}`,
+        // Worker fixture owns the compat proxy across per-test
+        // serve-realm restarts; the child must not bind that port.
+        '--no-compat-proxy',
       ],
       {
         cwd: packageRoot,

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -15,7 +15,9 @@ import {
   defaultSupportMetadataFile,
   type PreparedTemplateMetadata,
   readSupportMetadata,
+  startCompatRealmProxy,
   startHarnessPrerenderServer,
+  type StartedCompatRealmProxy,
 } from '@cardstack/realm-test-harness';
 import { logger } from '../src/logger';
 import { buildBrowserState, installBrowserState } from './helpers/browser-auth';
@@ -72,6 +74,7 @@ type FactoryRealmWorkerFixtures = {
     url: string;
     stop(): Promise<void>;
   };
+  testWorkerCompatProxy: StartedCompatRealmProxy;
 };
 
 type FactoryRealmTestFixtures = {
@@ -213,6 +216,7 @@ async function startRealmProcess(
   realmDir = defaultRealmDir,
   testWorkerPortSet: TestWorkerPortReservation,
   testWorkerPrerenderURL: string,
+  testWorkerCompatProxy: StartedCompatRealmProxy,
   permissions?: RealmPermissions,
 ) {
   let tempDir = mkdtempSync(join(tmpdir(), 'software-factory-realm-'));
@@ -390,6 +394,13 @@ async function startRealmProcess(
   // Narrow `child` for the rest of the function — if we reached here the
   // metadata was read successfully, which means spawn succeeded.
   let runningChild = child;
+
+  // Repoint the worker-scoped compat proxy at this child's realm-server
+  // port. The proxy is already bound on the stable compatRealmServerPort
+  // (from the testWorkerCompatProxy fixture); it just needs to know
+  // where to forward.
+  testWorkerCompatProxy.setTargetPort(metadata.ports.realmServerPort);
+
   let stop = async () => {
     try {
       if (runningChild.exitCode === null) {
@@ -409,13 +420,15 @@ async function startRealmProcess(
           });
         });
       }
+      // Only wait on the realm-server + worker-manager ports; the
+      // compat port is owned by the worker-scoped proxy and stays bound
+      // across this teardown.
       await Promise.all([
         waitForPortFree(metadata.ports.realmServerPort),
-        waitForPortFree(metadata.ports.publicPort),
         waitForPortFree(metadata.ports.workerManagerPort),
       ]);
-      // Child has fully released its sockets; reclaim our holders on
-      // compat + realm-server before the next test-scoped realm starts.
+      // Child has released the realm-server port; reclaim our holder
+      // before the next test-scoped realm starts.
       await testWorkerPortSet.reacquireRealmServerPorts();
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
@@ -476,6 +489,7 @@ async function acquireSharedRealm(
   realmDir: string,
   testWorkerPortSet: TestWorkerPortReservation,
   testWorkerPrerenderURL: string,
+  testWorkerCompatProxy: StartedCompatRealmProxy,
 ): Promise<StartedFactoryRealm> {
   let existing = sharedRealms.get(key);
   if (!existing) {
@@ -483,6 +497,7 @@ async function acquireSharedRealm(
       realmDir,
       testWorkerPortSet,
       testWorkerPrerenderURL,
+      testWorkerCompatProxy,
     ).then((realm) => ({
       realm,
       refCount: 0,
@@ -560,6 +575,27 @@ export const test = base.extend<
     },
     { scope: 'worker' },
   ],
+  testWorkerCompatProxy: [
+    async ({ browserName: _browserName, testWorkerPortSet }, use) => {
+      // The compat proxy is testWorker-scoped (not test-scoped) so the
+      // stable compatRealmServerPort always has a listener. Per-test
+      // serve-realm children bind a fresh realm-server port and the
+      // worker calls `setTargetPort` to repoint this proxy — there is no
+      // OS-level port-listen gap on the compat port between tests, so
+      // the worker-scoped prerender's standby refills can't hit
+      // ERR_CONNECTION_REFUSED on `<host>/_standby`.
+      await testWorkerPortSet.releaseCompatRealmServerPort();
+      let proxy = await startCompatRealmProxy({
+        listenPort: testWorkerPortSet.compatRealmServerPort,
+      });
+      try {
+        await use(proxy);
+      } finally {
+        await proxy.stop();
+      }
+    },
+    { scope: 'worker' },
+  ],
 
   realm: async (
     {
@@ -569,6 +605,7 @@ export const test = base.extend<
       realmPermissions: permissions,
       testWorkerPortSet,
       testWorkerPrerender,
+      testWorkerCompatProxy,
     },
     use,
     testInfo,
@@ -580,6 +617,7 @@ export const test = base.extend<
         realmDir,
         testWorkerPortSet,
         testWorkerPrerender.url,
+        testWorkerCompatProxy,
       );
       try {
         await use(realm);
@@ -593,6 +631,7 @@ export const test = base.extend<
       realmDir,
       testWorkerPortSet,
       testWorkerPrerender.url,
+      testWorkerCompatProxy,
       permissions,
     );
     try {

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -403,6 +403,15 @@ async function startRealmProcess(
 
   let stop = async () => {
     try {
+      // Tell the worker-scoped compat proxy to block (not 502) any
+      // incoming requests from the prerender's standby pool while the
+      // realm-server is being recreated. Without this, refills queued
+      // during the kill→bind window race the dying upstream, cache the
+      // failure as a broken module load, and the standby page sits in
+      // a permanently unusable state until the prerender's 90s render
+      // timeout evicts it. Cleared in `setTargetPort` once the new
+      // realm-server is bound.
+      testWorkerCompatProxy.clearTargetPort();
       if (runningChild.exitCode === null) {
         killProcessGroup(runningChild.pid!, 'SIGTERM');
         await new Promise<void>((resolve, reject) => {

--- a/packages/software-factory/tests/helpers/port-allocator.ts
+++ b/packages/software-factory/tests/helpers/port-allocator.ts
@@ -92,11 +92,16 @@ export type PortHolder = {
 
 export type TestWorkerPortReservation = TestWorkerPortSet & {
   /**
-   * Release the compat + realm-server port holders right before spawning
-   * a realm child that will bind to those ports. Must be paired with
+   * Release the realm-server port holder right before spawning a realm
+   * child that will bind to that port. Must be paired with
    * `reacquireRealmServerPorts()` once the child exits (typically inside
    * the realm's `stop()` method), so the next test in this worker starts
-   * with the ports held again.
+   * with the port held again.
+   *
+   * The compat-realm-server port is NOT released here — that holder is
+   * released once at worker setup time via `releaseCompatRealmServerPort`
+   * and the worker-scoped compat proxy owns the port for the rest of the
+   * worker's lifetime.
    */
   releaseRealmServerPorts(): Promise<void>;
   reacquireRealmServerPorts(): Promise<void>;
@@ -106,6 +111,14 @@ export type TestWorkerPortReservation = TestWorkerPortSet & {
    * intentionally no matching reacquire.
    */
   releasePrerenderPort(): Promise<void>;
+  /**
+   * Release the compat-realm-server port holder once. The worker-scoped
+   * compat proxy takes ownership for the remainder of the worker's
+   * lifetime (so the stable compat port has no listener gap between
+   * per-test realm-server restarts), so there is intentionally no
+   * matching reacquire.
+   */
+  releaseCompatRealmServerPort(): Promise<void>;
   /** Stop all port holders. Called at worker-fixture teardown. */
   stop(): Promise<void>;
 };
@@ -236,16 +249,16 @@ export async function allocateTestWorkerPortSet(
     return {
       ...candidate,
       async releaseRealmServerPorts() {
-        await Promise.all([holders.compat.release(), holders.realm.release()]);
+        await holders.realm.release();
       },
       async reacquireRealmServerPorts() {
-        await Promise.all([
-          holders.compat.reacquire(),
-          holders.realm.reacquire(),
-        ]);
+        await holders.realm.reacquire();
       },
       async releasePrerenderPort() {
         await holders.prerender.release();
+      },
+      async releaseCompatRealmServerPort() {
+        await holders.compat.release();
       },
       async stop() {
         await Promise.allSettled([

--- a/packages/software-factory/tests/port-allocator.test.ts
+++ b/packages/software-factory/tests/port-allocator.test.ts
@@ -168,7 +168,11 @@ module('port-allocator', function () {
   test('release + reacquire round-trip keeps ownership', async function (assert) {
     let reservation = await allocateTestWorkerPortSet(0);
     try {
-      let port = reservation.compatRealmServerPort;
+      // releaseRealmServerPorts only releases the realm-server holder
+      // now — the compat holder is released once by the worker fixture
+      // (the worker-scoped proxy takes over the port for the rest of
+      // the worker's lifetime) and there is no matching reacquire.
+      let port = reservation.realmServerPort;
       assert.true(await isListeningOn(port), 'port is held initially');
 
       await reservation.releaseRealmServerPorts();


### PR DESCRIPTION
## Background and Goal

`Software Factory Tests (shard 1/3)` flaked on `tests/instantiate-validation.spec.ts:25 - InstantiateValidationStep e2e: card with spec and example instantiates successfully` and the same shard's `tests/evaluate-module-command.spec.ts:112 - /_prerender-module: broken import detection`. The failures were a fast assertion fail (`expect(result.passed).toBe(true)`) seconds after the prerender's render reported `unable to fetch https://cardstack.com/base/card-api`.

The race was in the per-test realm-server restart window:

- Test ends → realm-server SIGTERM → public port goes briefly silent.
- The prerender's standby pool refills against the compat proxy.
- The compat proxy 502s those refills against the dying upstream.
- The loader caches the synthetic 500 as a broken module entry.
- The standby page sits unloadable until the prerender's 90s render timeout evicts it.

This PR closes that window from three angles.

## Where to start

- `packages/runtime-common/loader.ts` — `_fetch` tags its synthetic-500-on-transport-failure with a marker; `load()` propagates the marker as `isTransientFetchFailure` on the CardError; `fetchModule` drops the cache entry on transient failures instead of pinning `state: 'broken'`. Caching a real HTTP response (any 4xx/5xx from a live server) is unchanged.
- `packages/realm-test-harness/src/isolated-realm-stack.ts` — `startCompatRealmProxy` gains `clearTargetPort()`. While the target is cleared, incoming requests block on a 30s deadline waiting for the next `setTargetPort` instead of 502-ing. Proxy `stop()` unblocks waiters → 503.
- `packages/software-factory/tests/fixtures.ts` — the compat proxy is now Playwright-worker-scoped (stable port for the worker's lifetime, repointed across per-test realm-server restarts). The per-test realm fixture calls `clearTargetPort()` before SIGTERM'ing the realm child and `setTargetPort()` once the new child binds.

## Key decisions

- **Loader: transport-level failure is not a property of the module.** Inability to talk to a server isn't deterministic — caching it as broken would poison the entry for the lifetime of the loader. Distinguishing this from a real HTTP error preserves cache-as-broken behavior for any 4xx/5xx from a live server.
- **Proxy: block instead of 502 during port handoff.** 30s cap is well under the 240s metadata-file wait and the 300s test timeout. Blocking prevents the prerender's standby page from caching a broken load and burning 90s on the render timeout.
- **Worker-scoped compat proxy.** Previously the proxy was test-scoped, so the stable public port had a listener gap between per-test realm-server restarts. Standby refills hit ERR_CONNECTION_REFUSED in that gap. The proxy now stays bound for the worker's lifetime.

Local shard 1 dropped from 9.7m → 6.6m and test 5 (`broken import detection`) from 1.6m → 25s with the proxy wait-for-target in place.
