### PR TITLE
Fix environment mode database and mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,6 +673,8 @@ If the isolated realm server fails to get stopped you may see an error about por
 
 All environment configuration is centralized in `mise-tasks/lib/env-vars.sh`, which is automatically sourced by every mise task. The slug computation used for hostnames and database names lives in `scripts/env-slug.sh`.
 
+Run one environment per Git worktree. The host package's embroider cache (`packages/host/node_modules/.embroider/content-for.json`) is rewritten at vite startup with that env's URLs; two vites launched from the same worktree would fight over it and silently serve each other's URLs even though Traefik routes correctly. The vite launcher refuses to start a second env-mode vite when it detects one already running in this worktree.
+
 Here’s an example using Git worktrees and a `parallel` environment name:
 
 ```bash

--- a/mise-tasks/infra/ensure-db
+++ b/mise-tasks/infra/ensure-db
@@ -6,7 +6,10 @@
 [ -z "$BOXEL_ENVIRONMENT" ] && exit 0
 
 DB_SUFFIX="${1:-$ENV_SLUG}"
-DB_NAME="boxel_${DB_SUFFIX}"
+# Hyphens in slugs aren't valid in unquoted Postgres identifiers (see
+# scripts/env-slug.sh `pg_db_slug`). Inlined here because mise tasks
+# can run standalone without sourcing env-slug.sh.
+DB_NAME="boxel_$(echo "$DB_SUFFIX" | tr '-' '_')"
 
 echo "Ensuring database '${DB_NAME}' exists…"
 

--- a/mise-tasks/lib/env-vars.sh
+++ b/mise-tasks/lib/env-vars.sh
@@ -45,6 +45,8 @@ export WORKER_ALL_PRIORITY_COUNT="${WORKER_ALL_PRIORITY_COUNT:-1}"
 if [ -n "${BOXEL_ENVIRONMENT:-}" ]; then
   ENV_SLUG=$(compute_env_slug "$BOXEL_ENVIRONMENT")
   export ENV_SLUG
+  ENV_DB_SLUG=$(pg_db_slug "$ENV_SLUG")
+  export ENV_DB_SLUG
   export ENV_MODE=true
 
   # Drop standard-mode TLS env vars if they leaked in from a parent
@@ -73,9 +75,11 @@ if [ -n "${BOXEL_ENVIRONMENT:-}" ]; then
   export ICONS_URL="https://icons.${ENV_SLUG}.localhost"
   export HOST_URL="https://host.${ENV_SLUG}.localhost"
 
-  # Database
-  export PGDATABASE="${PGDATABASE:-boxel_${ENV_SLUG}}"
-  export PGDATABASE_TEST="boxel_test_${ENV_SLUG}"
+  # Database. Hyphens in slugs (e.g. `cs-12345-foo`) aren't valid in
+  # unquoted Postgres identifiers, so use the underscored variant for
+  # the DB name while keeping ENV_SLUG hyphenated for hostnames/paths.
+  export PGDATABASE="${PGDATABASE:-boxel_${ENV_DB_SLUG}}"
+  export PGDATABASE_TEST="boxel_test_${ENV_DB_SLUG}"
 
   # Ports (dynamic in env mode)
   export REALM_PORT=0
@@ -93,6 +97,7 @@ else
   # Capture previous ENV_MODE before resetting it, so we can detect transitions
   _PREV_ENV_MODE="${ENV_MODE:-}"
   export ENV_SLUG=""
+  export ENV_DB_SLUG=""
   export ENV_MODE=""
 
   if [ "$_PREV_ENV_MODE" = true ]; then

--- a/packages/ai-bot/scripts/start-development.sh
+++ b/packages/ai-bot/scripts/start-development.sh
@@ -23,7 +23,7 @@ if [ -n "$BOXEL_ENVIRONMENT" ]; then
   SYNAPSE_PORT=$(echo "$PORT_OUTPUT" | sed 's/.*://')
 
   export MATRIX_URL="http://localhost:${SYNAPSE_PORT}"
-  export PGDATABASE="${PGDATABASE:-boxel_${SLUG}}"
+  export PGDATABASE="${PGDATABASE:-boxel_$(pg_db_slug "$SLUG")}"
 
   echo "Environment mode: $BOXEL_ENVIRONMENT (slug: $SLUG)"
   echo "  MATRIX_URL=$MATRIX_URL"

--- a/packages/host/scripts/env-mode-lock.js
+++ b/packages/host/scripts/env-mode-lock.js
@@ -1,0 +1,128 @@
+/**
+ * Per-worktree lock for env-mode host vites.
+ *
+ * Embroider writes packages/host/node_modules/.embroider/content-for.json
+ * once at vite boot with the URL-encoded `config/environment.js` ENV blob
+ * (the `<meta name="@cardstack/host/config/environment">` content shipped
+ * to every page). Two env-mode vites launched from the same worktree
+ * share that file: whichever booted last wins, and
+ * `host.<slug-1>.localhost` ends up serving `<slug-2>`'s realm/matrix/icons
+ * URLs even though Traefik is routing to the correct port.
+ *
+ * The launchers (`vite-serve.js`, `serve-dist.js`) call
+ * `refuseIfAnotherSlugLocked` BEFORE any expensive setup (boxel-ui
+ * conditional build, vite require) so a second start exits immediately
+ * with a clear message instead of looking like a hang.
+ *
+ * Cross-worktree envs are not affected — each worktree has its own
+ * node_modules, so each gets its own lockfile and its own embroider
+ * cache.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { sanitizeSlug } = require('../../../scripts/env-slug.js');
+
+const ENV_MODE_LOCK_PATH = path.resolve(
+  __dirname,
+  '..',
+  'node_modules',
+  '.embroider',
+  '.env-mode-lock',
+);
+
+function getEnvSlug() {
+  // Mirrors traefik-helpers.js's `getEnvSlug`: prefer ENV_SLUG set by
+  // mise's env-vars.sh (already sanitized), fall back to sanitizing
+  // BOXEL_ENVIRONMENT directly when invoked outside mise.
+  if (process.env.ENV_SLUG) return process.env.ENV_SLUG;
+  return sanitizeSlug(process.env.BOXEL_ENVIRONMENT);
+}
+
+function isPidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    // EPERM means the process exists but is owned by someone else —
+    // still "alive" for our purposes (the cache fight applies regardless
+    // of owner).
+    return e.code === 'EPERM';
+  }
+}
+
+function readEnvModeLock() {
+  let content;
+  try {
+    content = fs.readFileSync(ENV_MODE_LOCK_PATH, 'utf-8');
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      console.warn(
+        `[environment-mode] Could not read ${ENV_MODE_LOCK_PATH}: ${e.message}`,
+      );
+    }
+    return null;
+  }
+  let [pidStr, lockedSlug] = content.trim().split(/\s+/, 2);
+  let pid = Number(pidStr);
+  if (!pid || !lockedSlug) return null;
+  return { pid, slug: lockedSlug };
+}
+
+function refuseIfAnotherSlugLocked() {
+  // Only relevant in env mode — standard mode doesn't touch the cache
+  // in a slug-dependent way.
+  if (!process.env.BOXEL_ENVIRONMENT) return;
+  let currentSlug = getEnvSlug();
+  if (!currentSlug) return;
+  let lock = readEnvModeLock();
+  if (!lock) return;
+  if (lock.slug === currentSlug) return; // same env, idempotent
+  if (!isPidAlive(lock.pid)) return; // stale, will be overwritten later
+  console.error(
+    '\n[environment-mode] Refusing to start: another env-mode vite is already\n' +
+      `running from this worktree's packages/host (PID ${lock.pid},\n` +
+      `BOXEL_ENVIRONMENT slug "${lock.slug}"). This worktree's embroider cache\n` +
+      `at packages/host/node_modules/.embroider/ is shared across processes,\n` +
+      'so a second env launched here would silently make both vites serve\n' +
+      'identical HTML for whichever started last (the upstream port routing\n' +
+      "is fine — it's the bundled config/environment that gets clobbered).\n" +
+      '\n' +
+      'Use a separate git worktree per environment; see the "Environment\n' +
+      'mode: parallel environments" section of the repo-root README.\n',
+  );
+  process.exit(1);
+}
+
+function writeEnvModeLock(slug) {
+  try {
+    fs.mkdirSync(path.dirname(ENV_MODE_LOCK_PATH), { recursive: true });
+    fs.writeFileSync(
+      ENV_MODE_LOCK_PATH,
+      `${process.pid} ${slug}\n`,
+      'utf-8',
+    );
+  } catch (e) {
+    console.warn(
+      `[environment-mode] Could not write ${ENV_MODE_LOCK_PATH}: ${e.message}`,
+    );
+  }
+}
+
+function removeEnvModeLockIfOwned() {
+  let lock = readEnvModeLock();
+  if (lock && lock.pid === process.pid) {
+    try {
+      fs.unlinkSync(ENV_MODE_LOCK_PATH);
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+module.exports = {
+  ENV_MODE_LOCK_PATH,
+  refuseIfAnotherSlugLocked,
+  writeEnvModeLock,
+  removeEnvModeLockIfOwned,
+};

--- a/packages/host/scripts/serve-dist.js
+++ b/packages/host/scripts/serve-dist.js
@@ -7,6 +7,8 @@
  * `preview`.
  */
 
+require('./env-mode-lock').refuseIfAnotherSlugLocked();
+
 const { startWithTraefik } = require('./vite-with-traefik');
 
 startWithTraefik({

--- a/packages/host/scripts/vite-serve.js
+++ b/packages/host/scripts/vite-serve.js
@@ -16,6 +16,12 @@
 const { execFileSync } = require('child_process');
 const path = require('path');
 
+// Refuse a second env-mode vite from this worktree BEFORE the boxel-ui
+// conditional-build runs — that step can take many seconds when the
+// addon dist is stale, which would look like a hang to the user instead
+// of a clear error. See env-mode-lock.js for the underlying constraint.
+require('./env-mode-lock').refuseIfAnotherSlugLocked();
+
 execFileSync(
   path.join(
     __dirname,

--- a/packages/host/scripts/vite-with-traefik.js
+++ b/packages/host/scripts/vite-with-traefik.js
@@ -20,96 +20,12 @@
 require('./wtfnode-on-signal');
 const { spawn } = require('child_process');
 const path = require('path');
-const fs = require('fs');
 const net = require('net');
-
-// Embroider writes node_modules/.embroider/content-for.json once at boot
-// with the URL-encoded `config/environment.js` ENV blob, then serves it
-// to every `index.html` request. Two env-mode vites launched from the
-// same packages/host share that file: whichever booted last wins, and
-// `host.<slug-1>.localhost` ends up serving `<slug-2>`'s URLs even
-// though Traefik is routing to the correct port. Use a small lockfile
-// next to the cache to refuse the second startup with a clear message.
-// One env per worktree is the supported pattern.
-const ENV_MODE_LOCK_PATH = path.resolve(
-  __dirname,
-  '..',
-  'node_modules',
-  '.embroider',
-  '.env-mode-lock',
-);
-
-function isPidAlive(pid) {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (e) {
-    // EPERM means the process exists but is owned by someone else —
-    // still "alive" for our purposes (the embroider cache fight applies
-    // regardless of owner).
-    return e.code === 'EPERM';
-  }
-}
-
-function readEnvModeLock() {
-  let content;
-  try {
-    content = fs.readFileSync(ENV_MODE_LOCK_PATH, 'utf-8');
-  } catch (e) {
-    if (e.code !== 'ENOENT') {
-      console.warn(
-        `[environment-mode] Could not read ${ENV_MODE_LOCK_PATH}: ${e.message}`,
-      );
-    }
-    return null;
-  }
-  let [pidStr, lockedSlug] = content.trim().split(/\s+/, 2);
-  let pid = Number(pidStr);
-  if (!pid || !lockedSlug) return null;
-  return { pid, slug: lockedSlug };
-}
-
-function refuseIfAnotherSlugLocked(currentSlug) {
-  let lock = readEnvModeLock();
-  if (!lock) return;
-  if (lock.slug === currentSlug) return; // same env, idempotent
-  if (!isPidAlive(lock.pid)) return; // stale, will be overwritten below
-  console.error(
-    '\n[environment-mode] Refusing to start: another env-mode vite is already\n' +
-      `running from this worktree's packages/host (PID ${lock.pid},\n` +
-      `BOXEL_ENVIRONMENT slug "${lock.slug}"). This worktree's embroider cache\n` +
-      `at packages/host/node_modules/.embroider/ is shared across processes,\n` +
-      'so a second env launched here would silently make both vites serve\n' +
-      'identical HTML for whichever started last (the upstream port routing\n' +
-      "is fine — it's the bundled config/environment that gets clobbered).\n" +
-      '\n' +
-      'Use a separate git worktree per environment; see the "Environment\n' +
-      'mode: parallel environments" section of the repo-root README.\n',
-  );
-  process.exit(1);
-}
-
-function writeEnvModeLock(slug) {
-  try {
-    fs.mkdirSync(path.dirname(ENV_MODE_LOCK_PATH), { recursive: true });
-    fs.writeFileSync(ENV_MODE_LOCK_PATH, `${process.pid} ${slug}\n`, 'utf-8');
-  } catch (e) {
-    console.warn(
-      `[environment-mode] Could not write ${ENV_MODE_LOCK_PATH}: ${e.message}`,
-    );
-  }
-}
-
-function removeEnvModeLockIfOwned() {
-  let lock = readEnvModeLock();
-  if (lock && lock.pid === process.pid) {
-    try {
-      fs.unlinkSync(ENV_MODE_LOCK_PATH);
-    } catch {
-      /* already gone */
-    }
-  }
-}
+const {
+  refuseIfAnotherSlugLocked,
+  writeEnvModeLock,
+  removeEnvModeLockIfOwned,
+} = require('./env-mode-lock');
 
 function runVite({ subcommand, port, allHosts, host, extraEnv, nodeMemory }) {
   const args = ['vite'];
@@ -377,7 +293,10 @@ function startWithTraefik({ subcommand, defaultPort, label, nodeMemory }) {
   const { getEnvSlug, registerWithTraefik } = require('./traefik-helpers');
 
   const slug = getEnvSlug();
-  refuseIfAnotherSlugLocked(slug);
+  // Belt-and-suspenders: vite-serve.js / serve-dist.js also call this
+  // up-front (before boxel-ui conditional-build) so the second start
+  // exits immediately. Repeat here for direct callers of startWithTraefik.
+  refuseIfAnotherSlugLocked();
 
   ensureTraefik();
 

--- a/packages/host/scripts/vite-with-traefik.js
+++ b/packages/host/scripts/vite-with-traefik.js
@@ -92,11 +92,7 @@ function refuseIfAnotherSlugLocked(currentSlug) {
 function writeEnvModeLock(slug) {
   try {
     fs.mkdirSync(path.dirname(ENV_MODE_LOCK_PATH), { recursive: true });
-    fs.writeFileSync(
-      ENV_MODE_LOCK_PATH,
-      `${process.pid} ${slug}\n`,
-      'utf-8',
-    );
+    fs.writeFileSync(ENV_MODE_LOCK_PATH, `${process.pid} ${slug}\n`, 'utf-8');
   } catch (e) {
     console.warn(
       `[environment-mode] Could not write ${ENV_MODE_LOCK_PATH}: ${e.message}`,

--- a/packages/host/scripts/vite-with-traefik.js
+++ b/packages/host/scripts/vite-with-traefik.js
@@ -20,7 +20,100 @@
 require('./wtfnode-on-signal');
 const { spawn } = require('child_process');
 const path = require('path');
+const fs = require('fs');
 const net = require('net');
+
+// Embroider writes node_modules/.embroider/content-for.json once at boot
+// with the URL-encoded `config/environment.js` ENV blob, then serves it
+// to every `index.html` request. Two env-mode vites launched from the
+// same packages/host share that file: whichever booted last wins, and
+// `host.<slug-1>.localhost` ends up serving `<slug-2>`'s URLs even
+// though Traefik is routing to the correct port. Use a small lockfile
+// next to the cache to refuse the second startup with a clear message.
+// One env per worktree is the supported pattern.
+const ENV_MODE_LOCK_PATH = path.resolve(
+  __dirname,
+  '..',
+  'node_modules',
+  '.embroider',
+  '.env-mode-lock',
+);
+
+function isPidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    // EPERM means the process exists but is owned by someone else —
+    // still "alive" for our purposes (the embroider cache fight applies
+    // regardless of owner).
+    return e.code === 'EPERM';
+  }
+}
+
+function readEnvModeLock() {
+  let content;
+  try {
+    content = fs.readFileSync(ENV_MODE_LOCK_PATH, 'utf-8');
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      console.warn(
+        `[environment-mode] Could not read ${ENV_MODE_LOCK_PATH}: ${e.message}`,
+      );
+    }
+    return null;
+  }
+  let [pidStr, lockedSlug] = content.trim().split(/\s+/, 2);
+  let pid = Number(pidStr);
+  if (!pid || !lockedSlug) return null;
+  return { pid, slug: lockedSlug };
+}
+
+function refuseIfAnotherSlugLocked(currentSlug) {
+  let lock = readEnvModeLock();
+  if (!lock) return;
+  if (lock.slug === currentSlug) return; // same env, idempotent
+  if (!isPidAlive(lock.pid)) return; // stale, will be overwritten below
+  console.error(
+    '\n[environment-mode] Refusing to start: another env-mode vite is already\n' +
+      `running from this worktree's packages/host (PID ${lock.pid},\n` +
+      `BOXEL_ENVIRONMENT slug "${lock.slug}"). This worktree's embroider cache\n` +
+      `at packages/host/node_modules/.embroider/ is shared across processes,\n` +
+      'so a second env launched here would silently make both vites serve\n' +
+      'identical HTML for whichever started last (the upstream port routing\n' +
+      "is fine — it's the bundled config/environment that gets clobbered).\n" +
+      '\n' +
+      'Use a separate git worktree per environment; see the "Environment\n' +
+      'mode: parallel environments" section of the repo-root README.\n',
+  );
+  process.exit(1);
+}
+
+function writeEnvModeLock(slug) {
+  try {
+    fs.mkdirSync(path.dirname(ENV_MODE_LOCK_PATH), { recursive: true });
+    fs.writeFileSync(
+      ENV_MODE_LOCK_PATH,
+      `${process.pid} ${slug}\n`,
+      'utf-8',
+    );
+  } catch (e) {
+    console.warn(
+      `[environment-mode] Could not write ${ENV_MODE_LOCK_PATH}: ${e.message}`,
+    );
+  }
+}
+
+function removeEnvModeLockIfOwned() {
+  let lock = readEnvModeLock();
+  if (lock && lock.pid === process.pid) {
+    try {
+      fs.unlinkSync(ENV_MODE_LOCK_PATH);
+    } catch {
+      /* already gone */
+    }
+  }
+}
 
 function runVite({ subcommand, port, allHosts, host, extraEnv, nodeMemory }) {
   const args = ['vite'];
@@ -287,9 +380,11 @@ function startWithTraefik({ subcommand, defaultPort, label, nodeMemory }) {
   const { ensureTraefik } = require('./ensure-traefik');
   const { getEnvSlug, registerWithTraefik } = require('./traefik-helpers');
 
+  const slug = getEnvSlug();
+  refuseIfAnotherSlugLocked(slug);
+
   ensureTraefik();
 
-  const slug = getEnvSlug();
   const hostname = `host.${slug}.localhost`;
 
   // Point the client at the per-environment Synapse via Traefik
@@ -331,6 +426,12 @@ function startWithTraefik({ subcommand, defaultPort, label, nodeMemory }) {
           '[environment-mode] Failed to register with Traefik:',
           e.message,
         );
+      }
+
+      writeEnvModeLock(slug);
+      process.on('exit', removeEnvModeLockIfOwned);
+      for (const signal of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
+        process.on(signal, removeEnvModeLockIfOwned);
       }
     });
   });

--- a/packages/realm-server/scripts/start-matrix.sh
+++ b/packages/realm-server/scripts/start-matrix.sh
@@ -12,7 +12,7 @@ pnpm assert-synapse-running
 # In environment mode, register users once per fresh Synapse data dir.
 if [ -n "$BOXEL_ENVIRONMENT" ]; then
   SLUG=$(resolve_env_slug)
-  export PGDATABASE="${PGDATABASE:-boxel_${SLUG}}"
+  export PGDATABASE="${PGDATABASE:-boxel_$(pg_db_slug "$SLUG")}"
   export PGPORT="${PGPORT:-5435}"
 
   MARKER="./synapse-data-${SLUG}/.users-registered"

--- a/scripts/ensure-branch-db.sh
+++ b/scripts/ensure-branch-db.sh
@@ -18,7 +18,7 @@ else
   SLUG=$(compute_env_slug "$(git branch --show-current)")
 fi
 
-DB_NAME="boxel_${SLUG}"
+DB_NAME="boxel_$(pg_db_slug "$SLUG")"
 
 echo "Ensuring database '${DB_NAME}' exists..."
 

--- a/scripts/env-slug.js
+++ b/scripts/env-slug.js
@@ -32,4 +32,19 @@ function sanitizeSlug(raw) {
     .replace(/^-|-$/g, '');
 }
 
-module.exports = { sanitizeSlug };
+/**
+ * Convert a sanitized slug into a Postgres-safe database-name suffix.
+ *
+ * Postgres allows hyphens in identifiers only when quoted; unquoted
+ * references (CREATE DATABASE foo-bar, psql -d foo-bar, libpq's
+ * URI parser) treat them as operators or delimiters. Swap hyphens for
+ * underscores so the slug is usable unquoted.
+ *
+ * @param {string | null | undefined} slug
+ * @returns {string}
+ */
+function pgDbSlug(slug) {
+  return (slug || '').replace(/-/g, '_');
+}
+
+module.exports = { sanitizeSlug, pgDbSlug };

--- a/scripts/env-slug.sh
+++ b/scripts/env-slug.sh
@@ -17,6 +17,15 @@ compute_env_slug() {
   echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's|/|-|g; s|[^a-z0-9-]||g; s|-\+|-|g' | cut -c -63 | sed 's|^-||; s|-$||'
 }
 
+# Postgres identifiers can technically contain hyphens, but only when
+# quoted — every unquoted reference (CREATE DATABASE foo-bar, psql -d
+# foo-bar, connection-string parsers that split on '-') treats them as
+# operators or delimiters. Swap hyphens for underscores so the slug is
+# safe to use unquoted as a database name.
+pg_db_slug() {
+  echo "$1" | tr '-' '_'
+}
+
 # Use `${VAR:-}` so callers running under `set -u` (e.g.
 # `mise-tasks/infra/ensure-dev-cert`) don't get killed by a bare
 # reference to an unset env var — bash's nounset terminates the

--- a/scripts/start-traefik.sh
+++ b/scripts/start-traefik.sh
@@ -8,15 +8,23 @@ set -e
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 # If a Traefik container exists but its dynamic-config bind mount points
-# at a directory other than this worktree's traefik/dynamic (e.g. the
-# originating worktree was deleted), remove it so the compose-up branch
-# below recreates it from the current worktree.
+# at a worktree that no longer exists on disk, remove it so the compose-up
+# branch below recreates it from the current worktree. When the originating
+# worktree is still around (i.e. another env is running there), leave the
+# container alone — dev-service-registry.ts and traefik-helpers.js both
+# discover the mount via `docker inspect` and write into whichever dir is
+# currently mounted, so this worktree's services register alongside the
+# other's instead of clobbering them.
 if docker ps -a --format '{{.Names}}' | grep -q '^boxel-traefik$'; then
   MOUNTED="$(docker inspect boxel-traefik --format '{{range .Mounts}}{{if eq .Destination "/etc/traefik/dynamic"}}{{.Source}}{{end}}{{end}}' 2>/dev/null || true)"
   EXPECTED="$REPO_ROOT/traefik/dynamic"
   if [ -n "$MOUNTED" ] && [ "$MOUNTED" != "$EXPECTED" ]; then
-    echo "Traefik dynamic-config mount is stale ($MOUNTED); recreating from $EXPECTED"
-    docker rm -f boxel-traefik >/dev/null
+    if [ -d "$MOUNTED" ]; then
+      echo "Traefik is mounted from another worktree ($MOUNTED); reusing it so services already registered there keep routing. This worktree's per-service configs will be written into that shared dir."
+    else
+      echo "Traefik dynamic-config mount is stale ($MOUNTED no longer exists); recreating from $EXPECTED"
+      docker rm -f boxel-traefik >/dev/null
+    fi
   fi
 fi
 

--- a/scripts/stop-environment.sh
+++ b/scripts/stop-environment.sh
@@ -39,6 +39,7 @@ if [ -z "$BRANCH" ]; then
 fi
 
 SLUG=$(compute_env_slug "$BRANCH")
+DB_SLUG=$(pg_db_slug "$SLUG")
 
 echo "Stopping all services for environment: $BRANCH (slug: $SLUG)"
 
@@ -51,7 +52,7 @@ echo "Stopping all services for environment: $BRANCH (slug: $SLUG)"
 # Exclude this script itself and grep.
 
 # Build a pattern that matches the slug in various contexts
-MATCH_PATTERN="${SLUG}\.localhost|realms/${SLUG}|boxel_${SLUG}|BOXEL_ENVIRONMENT=${BRANCH}"
+MATCH_PATTERN="${SLUG}\.localhost|realms/${SLUG}|boxel_${DB_SLUG}|BOXEL_ENVIRONMENT=${BRANCH}"
 
 # Extract dynamic ports from Traefik configs so we can match processes by port
 if [ -d "$TRAEFIK_DIR" ]; then
@@ -164,7 +165,7 @@ fi
 
 # --- 4. Optionally drop per-environment databases ---
 if [ "$DROP_DB" = true ]; then
-  for DB_NAME in "boxel_${SLUG}" "boxel_test_${SLUG}"; do
+  for DB_NAME in "boxel_${DB_SLUG}" "boxel_test_${DB_SLUG}"; do
     if docker exec boxel-pg psql -U postgres -lqt 2>/dev/null | cut -d \| -f 1 | grep -qw "$DB_NAME"; then
       if [ "$DRY_RUN" = true ]; then
         echo "Would drop database $DB_NAME"

--- a/scripts/stop-environment.sh
+++ b/scripts/stop-environment.sh
@@ -13,7 +13,19 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPT_DIR/env-slug.sh"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-TRAEFIK_DIR="$REPO_ROOT/traefik/dynamic"
+
+# Scan this worktree's `traefik/dynamic` plus whatever directory the
+# running Traefik container actually bind-mounts (when start-traefik.sh
+# reuses a container from another worktree, this env's services
+# registered into that worktree's dir, not ours). Union, not either-or:
+# the same slug can have files in both places if Traefik was bounced
+# between registrations.
+TRAEFIK_DIRS="$REPO_ROOT/traefik/dynamic"
+MOUNTED="$(docker inspect boxel-traefik --format '{{range .Mounts}}{{if eq .Destination "/etc/traefik/dynamic"}}{{.Source}}{{end}}{{end}}' 2>/dev/null || true)"
+if [ -n "$MOUNTED" ] && [ -d "$MOUNTED" ] && [ "$MOUNTED" != "$REPO_ROOT/traefik/dynamic" ]; then
+  TRAEFIK_DIRS="$TRAEFIK_DIRS
+$MOUNTED"
+fi
 
 DROP_DB=false
 DRY_RUN=false
@@ -54,16 +66,23 @@ echo "Stopping all services for environment: $BRANCH (slug: $SLUG)"
 # Build a pattern that matches the slug in various contexts
 MATCH_PATTERN="${SLUG}\.localhost|realms/${SLUG}|boxel_${DB_SLUG}|BOXEL_ENVIRONMENT=${BRANCH}"
 
-# Extract dynamic ports from Traefik configs so we can match processes by port
-if [ -d "$TRAEFIK_DIR" ]; then
-  for f in "$TRAEFIK_DIR/${SLUG}"-*.yml; do
+# Extract dynamic ports from Traefik configs so we can match processes by port.
+# Iterate via IFS=newline rather than `echo | while`, so MATCH_PATTERN updates
+# stay in this shell (a piped `while` body runs in a subshell).
+OLD_IFS="$IFS"
+IFS='
+'
+for DIR in $TRAEFIK_DIRS; do
+  [ -d "$DIR" ] || continue
+  for f in "$DIR/${SLUG}"-*.yml; do
     [ -f "$f" ] || continue
     PORT=$(grep -oE 'host\.docker\.internal:[0-9]+' "$f" 2>/dev/null | head -1 | sed 's/.*://')
     if [ -n "$PORT" ]; then
       MATCH_PATTERN="${MATCH_PATTERN}|--port ${PORT}([^0-9]|$)"
     fi
   done
-fi
+done
+IFS="$OLD_IFS"
 
 ROOT_PIDS=$(ps ax -o pid,command 2>/dev/null \
   | grep -E "($MATCH_PATTERN)" \
@@ -144,23 +163,28 @@ else
 fi
 
 # --- 3. Clean up Traefik dynamic config files ---
-if [ -d "$TRAEFIK_DIR" ]; then
-  REMOVED=0
-  for f in "$TRAEFIK_DIR/${SLUG}"-*.yml; do
+REMOVED=0
+OLD_IFS="$IFS"
+IFS='
+'
+for DIR in $TRAEFIK_DIRS; do
+  [ -d "$DIR" ] || continue
+  for f in "$DIR/${SLUG}"-*.yml; do
     [ -f "$f" ] || continue
     if [ "$DRY_RUN" = true ]; then
-      echo "  Would remove $(basename "$f")"
+      echo "  Would remove $f"
     else
       rm -f "$f"
-      echo "  Removed $(basename "$f")"
+      echo "  Removed $f"
     fi
     REMOVED=$((REMOVED + 1))
   done
-  if [ "$REMOVED" -gt 0 ]; then
-    [ "$DRY_RUN" = true ] && echo "Would remove $REMOVED Traefik config file(s)." || echo "Removed $REMOVED Traefik config file(s)."
-  else
-    echo "No Traefik configs found for environment $SLUG."
-  fi
+done
+IFS="$OLD_IFS"
+if [ "$REMOVED" -gt 0 ]; then
+  [ "$DRY_RUN" = true ] && echo "Would remove $REMOVED Traefik config file(s)." || echo "Removed $REMOVED Traefik config file(s)."
+else
+  echo "No Traefik configs found for environment $SLUG."
 fi
 
 # --- 4. Optionally drop per-environment databases ---


### PR DESCRIPTION
#4958 consolidated environment mode slug calculation but I only tried it with short environment names, with longer names I’m getting errors like this:

```
[start:worker-development   ] [infra:ensure-pg] ERROR:  syntax error at or near "-"
[start:worker-development   ] [infra:ensure-pg] LINE 1: CREATE DATABASE boxel_unexpected-token-cs-11287
[start:worker-development   ] [infra:ensure-pg]                                         ^
```

This converts `-` to `_` for Postgres database names.

Also, starting services in a different worktree has been erasing the existing worktree’s Traefik mappings, this fixes that too.