### PR TITLE
Tolerance state machine for query-field linksTo / linksToMany

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1227,6 +1227,16 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
       // structured read.
       let bucketEntry = deserialized.get(this.name);
       if (isLinkError(bucketEntry) || isLinkNotFound(bucketEntry)) {
+        // DIAGNOSTIC LOGGING (CS-11221) — remove after CI passes.
+        // eslint-disable-next-line no-console
+        console.error(
+          '[CS-11221 DIAG] linksTo getter returning undefined (bucket sentinel)',
+          {
+            fieldName: this.name,
+            ownerType: instance?.constructor?.name,
+            sentinelType: (bucketEntry as { type?: string })?.type,
+          },
+        );
         return undefined;
       }
       let records = (searchResource as any)?.instances ?? ([] as any[]);
@@ -1664,6 +1674,16 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
       // shape; the structured failure surfaces through `getRelationship`.
       let bucketEntry = deserialized.get(this.name);
       if (isLinkError(bucketEntry) || isLinkNotFound(bucketEntry)) {
+        // DIAGNOSTIC LOGGING (CS-11221) — remove after CI passes.
+        // eslint-disable-next-line no-console
+        console.error(
+          '[CS-11221 DIAG] linksToMany getter returning emptyValue (bucket sentinel)',
+          {
+            fieldName: this.name,
+            ownerType: instance?.constructor?.name,
+            sentinelType: (bucketEntry as { type?: string })?.type,
+          },
+        );
         return this.emptyValue(instance) as BaseInstanceType<FieldT>;
       }
       let records = searchResource.instances ?? ([] as any[]);

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1220,6 +1220,15 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
         this,
         dependencyTrackingContext,
       );
+      // `ensureQueryFieldSearchResource` mirrors the resource's error state
+      // into the bucket. The recognition pattern mirrors the declared
+      // `linksTo` path above — a terminal `link-error` / `link-not-found`
+      // sentinel surfaces as `undefined`, and `getRelationship` is the
+      // structured read.
+      let bucketEntry = deserialized.get(this.name);
+      if (isLinkError(bucketEntry) || isLinkNotFound(bucketEntry)) {
+        return undefined;
+      }
       let records = (searchResource as any)?.instances ?? ([] as any[]);
       let value = (records as any[])[0] as BaseInstanceType<CardT> | undefined;
       trackRuntimeRelationshipDependency(
@@ -1649,6 +1658,14 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
         this,
         dependencyTrackingContext,
       )!;
+      // Resource-level failure: `ensureQueryFieldSearchResource` plants a
+      // single whole-field sentinel in the bucket (the search fails as a
+      // unit, not per element). The empty array hands callers a usable
+      // shape; the structured failure surfaces through `getRelationship`.
+      let bucketEntry = deserialized.get(this.name);
+      if (isLinkError(bucketEntry) || isLinkNotFound(bucketEntry)) {
+        return this.emptyValue(instance) as BaseInstanceType<FieldT>;
+      }
       let records = searchResource.instances ?? ([] as any[]);
       trackRuntimeRelationshipDependencies(
         records,

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1228,7 +1228,6 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
       let bucketEntry = deserialized.get(this.name);
       if (isLinkError(bucketEntry) || isLinkNotFound(bucketEntry)) {
         // DIAGNOSTIC LOGGING (CS-11221) — remove after CI passes.
-        // eslint-disable-next-line no-console
         console.error(
           '[CS-11221 DIAG] linksTo getter returning undefined (bucket sentinel)',
           {
@@ -1675,7 +1674,6 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
       let bucketEntry = deserialized.get(this.name);
       if (isLinkError(bucketEntry) || isLinkNotFound(bucketEntry)) {
         // DIAGNOSTIC LOGGING (CS-11221) — remove after CI passes.
-        // eslint-disable-next-line no-console
         console.error(
           '[CS-11221 DIAG] linksToMany getter returning emptyValue (bucket sentinel)',
           {

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1770,6 +1770,21 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
   }
 
   queryableValue(instances: any[] | null, stack: CardDef[]): any[] | null {
+    // A whole-field sentinel (a query-field whose search resource errored, or
+    // a computed `linksToMany` that consumes an unresolved upstream link)
+    // arrives here as a single LinkErrorValue / LinkNotFoundValue / NotLoaded
+    // object — NOT an array. Without this guard, the `[...instances]` spread
+    // below would throw `instances is not iterable`, the render would fail,
+    // and the indexer would classify the consumer as instance-error — the
+    // exact cascade the field-getter side of the tolerance machine avoids.
+    // Treat a non-present whole-field sentinel as an empty plural for index
+    // purposes; the broken reference is preserved on the wire via the
+    // serializer (`relationships.{field}` carries the sentinel's `reference`),
+    // and `getRelationship` is the structured read surface for the failure
+    // state outside the index.
+    if (isNonPresentLink(instances)) {
+      return null;
+    }
     if (instances === null || instances.length === 0) {
       // we intentionally use a "null" to represent an empty plural field as
       // this is a limitation to SQLite's json_tree() function when trying to match

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -704,7 +704,6 @@ export function getBrokenLinks(
           // reading `instance.id` here would write the `id` field's
           // emptyValue into the bucket and violate the pure-read contract
           // the surrounding `getBrokenLinks` upholds.
-          // eslint-disable-next-line no-console
           console.error('[CS-11221 DIAG] getBrokenLinks finding', {
             ownerType: instance?.constructor?.name,
             fieldName,

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -698,15 +698,14 @@ export function getBrokenLinks(
       let state = getRelationship(instance as CardDef, fieldName);
       for (let entry of Array.isArray(state) ? state : [state]) {
         if (entry.kind === 'error' || entry.kind === 'not-found') {
-          // DIAGNOSTIC LOGGING (CS-11221) — remove after CI passes. The
-          // declared-`linksTo` scan should only find a broken link for a
-          // failed lazy-load; query-field findings are skipped above. A
-          // sighting on a test that doesn't intentionally break a
-          // declared `linksTo` means something else is misclassifying
-          // state, and we want a clear trail in the CI log.
+          // DIAGNOSTIC LOGGING (CS-11221) — remove after CI passes. Read
+          // only fields that won't initialize bucket entries via the
+          // field getter (constructor name + the entry's own reference);
+          // reading `instance.id` here would write the `id` field's
+          // emptyValue into the bucket and violate the pure-read contract
+          // the surrounding `getBrokenLinks` upholds.
           // eslint-disable-next-line no-console
           console.error('[CS-11221 DIAG] getBrokenLinks finding', {
-            ownerId: (instance as CardDef).id ?? '(unsaved)',
             ownerType: instance?.constructor?.name,
             fieldName,
             fieldType: field.fieldType,

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -698,6 +698,21 @@ export function getBrokenLinks(
       let state = getRelationship(instance as CardDef, fieldName);
       for (let entry of Array.isArray(state) ? state : [state]) {
         if (entry.kind === 'error' || entry.kind === 'not-found') {
+          // DIAGNOSTIC LOGGING (CS-11221) — remove after CI passes. The
+          // declared-`linksTo` scan should only find a broken link for a
+          // failed lazy-load; query-field findings are skipped above. A
+          // sighting on a test that doesn't intentionally break a
+          // declared `linksTo` means something else is misclassifying
+          // state, and we want a clear trail in the CI log.
+          // eslint-disable-next-line no-console
+          console.error('[CS-11221 DIAG] getBrokenLinks finding', {
+            ownerId: (instance as CardDef).id ?? '(unsaved)',
+            ownerType: instance?.constructor?.name,
+            fieldName,
+            fieldType: field.fieldType,
+            kind: entry.kind,
+            reference: entry.reference,
+          });
           findings.push({
             fieldName,
             kind: entry.kind,

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -677,6 +677,18 @@ export function getBrokenLinks(
     if (!field || field.computeVia) {
       continue;
     }
+    // Query-backed `linksTo` / `linksToMany` fields (the `{ query }` form
+    // resolved through `_federated-search`) sit outside the
+    // broken-link / declared-`linksTo` scan: their failure surface is
+    // `getRelationship`, not the indexer-side cascade. A search resource
+    // can fail for "soft" reasons that should not classify the consuming
+    // card as instance-error (cross-realm assertions, transient federated
+    // failures), and the field getter already routes them through a
+    // structured state machine. Skip them here so a planted resource-level
+    // sentinel does not flow into a render error.
+    if (field.queryDefinition) {
+      continue;
+    }
     // Only inspect fields already in the data bucket — reading an absent field
     // through the getter would initialize it (see above).
     if (!bucket.has(fieldName)) {

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -250,6 +250,19 @@ function surfaceSearchResourceErrorState(
   }
 
   let sentinel = buildQueryFieldSentinel(instance, field, errors);
+  // DIAGNOSTIC LOGGING (CS-11221) — remove after CI passes. Surface should
+  // only ever plant a sentinel for a genuine search failure; a sighting
+  // during a same-realm successful-query test (e.g. realm-server-tests
+  // shard 3) means something is misclassifying success as failure.
+  // eslint-disable-next-line no-console
+  console.error('[CS-11221 DIAG] surface plant sentinel', {
+    fieldName: field.name,
+    ownerId: (instance as CardDef).id ?? '(unsaved)',
+    sentinelType: sentinel.type,
+    errorCount: errors.length,
+    firstErrorStatus: errors[0]?.error?.status,
+    firstErrorMessage: errors[0]?.error?.message,
+  });
   bucket.set(field.name, sentinel);
   fieldState.surfacedErrorSentinel = sentinel;
 }

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -225,6 +225,10 @@ export function peekQueryFieldSearchResource(
 // the first call (errors === undefined on a fresh resource, source ===
 // undefined on a fresh fieldState) from clobbering a sentinel that was put
 // in place before the field was first read.
+// DIAGNOSTIC (CS-11221): function kept around while the call sites in
+// ensureQueryFieldSearchResource are commented out; the `void` reference at
+// the bottom of this module is what tells TypeScript the symbol is
+// intentionally retained for later re-enable.
 function surfaceSearchResourceErrorState(
   fieldState: QueryFieldState,
   instance: BaseDef,
@@ -632,3 +636,7 @@ function buildFieldDefinition(field: Field): FieldDefinition | undefined {
     fieldOrCard: ref,
   };
 }
+
+// DIAGNOSTIC (CS-11221): retain `surfaceSearchResourceErrorState` while its
+// call sites are commented out for the shard-3 diagnostic experiment.
+void surfaceSearchResourceErrorState;

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -134,11 +134,12 @@ export function ensureQueryFieldSearchResource(
     log.debug(
       `ensureQueryFieldSearchResource: reusing existing resource from fieldState for field=${field.name}`,
     );
-    // DIAGNOSTIC (CS-11221): surface call temporarily disabled to confirm
-    // whether surface or the search-task catch is the source of shard-3
-    // regressions. If shard 3 goes green with this disabled, the
-    // tolerance machinery needs different plumbing.
-    // surfaceSearchResourceErrorState(fieldState, instance, field, searchResource);
+    surfaceSearchResourceErrorState(
+      fieldState,
+      instance,
+      field,
+      searchResource,
+    );
     return searchResource;
   }
 
@@ -187,9 +188,7 @@ export function ensureQueryFieldSearchResource(
   );
   fieldState.searchResource = searchResource;
   trackQueryFieldLoads(store, field.name, fieldState);
-  // DIAGNOSTIC (CS-11221): surface call temporarily disabled. See the
-  // matching comment on the cached-return path above.
-  // surfaceSearchResourceErrorState(fieldState, instance, field, searchResource);
+  surfaceSearchResourceErrorState(fieldState, instance, field, searchResource);
 
   return searchResource;
 }
@@ -225,10 +224,6 @@ export function peekQueryFieldSearchResource(
 // the first call (errors === undefined on a fresh resource, source ===
 // undefined on a fresh fieldState) from clobbering a sentinel that was put
 // in place before the field was first read.
-// DIAGNOSTIC (CS-11221): function kept around while the call sites in
-// ensureQueryFieldSearchResource are commented out; the `void` reference at
-// the bottom of this module is what tells TypeScript the symbol is
-// intentionally retained for later re-enable.
 function surfaceSearchResourceErrorState(
   fieldState: QueryFieldState,
   instance: BaseDef,
@@ -636,7 +631,3 @@ function buildFieldDefinition(field: Field): FieldDefinition | undefined {
     fieldOrCard: ref,
   };
 }
-
-// DIAGNOSTIC (CS-11221): retain `surfaceSearchResourceErrorState` while its
-// call sites are commented out for the shard-3 diagnostic experiment.
-void surfaceSearchResourceErrorState;

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -134,7 +134,11 @@ export function ensureQueryFieldSearchResource(
     log.debug(
       `ensureQueryFieldSearchResource: reusing existing resource from fieldState for field=${field.name}`,
     );
-    surfaceSearchResourceErrorState(fieldState, instance, field, searchResource);
+    // DIAGNOSTIC (CS-11221): surface call temporarily disabled to confirm
+    // whether surface or the search-task catch is the source of shard-3
+    // regressions. If shard 3 goes green with this disabled, the
+    // tolerance machinery needs different plumbing.
+    // surfaceSearchResourceErrorState(fieldState, instance, field, searchResource);
     return searchResource;
   }
 
@@ -183,7 +187,9 @@ export function ensureQueryFieldSearchResource(
   );
   fieldState.searchResource = searchResource;
   trackQueryFieldLoads(store, field.name, fieldState);
-  surfaceSearchResourceErrorState(fieldState, instance, field, searchResource);
+  // DIAGNOSTIC (CS-11221): surface call temporarily disabled. See the
+  // matching comment on the cached-return path above.
+  // surfaceSearchResourceErrorState(fieldState, instance, field, searchResource);
 
   return searchResource;
 }

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -68,8 +68,9 @@ interface QueryFieldState {
   // time surface ran. Tracking this lets surface short-circuit on
   // unchanged errors (the common per-render no-op case) and detect a
   // real transition into / out of the errored state without reading
-  // the bucket on every call.
-  surfacedErrorSource?: readonly unknown[] | null;
+  // the bucket on every call. Stored as-is — including `undefined` —
+  // so the steady-state no-errors render hits the identity check.
+  surfacedErrorSource?: readonly unknown[];
 }
 
 const queryFieldSeedFromSearchSymbol = Symbol.for(
@@ -228,7 +229,11 @@ function surfaceSearchResourceErrorState(
   if (errors === fieldState.surfacedErrorSource) {
     return;
   }
-  fieldState.surfacedErrorSource = errors ?? null;
+  // Store the snapshot as-is (including `undefined`) so the next-render
+  // identity check matches when `searchResource.errors` is still undefined —
+  // coercing to `null` would miss the early-return and force an extra
+  // bucket read per render.
+  fieldState.surfacedErrorSource = errors;
 
   let bucket = getDataBucket(instance);
   let existing = bucket.get(field.name);

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -258,7 +258,6 @@ function surfaceSearchResourceErrorState(
   // DIAGNOSTIC LOGGING (CS-11221) — remove after CI passes. Don't read
   // `instance.id` here: the field getter for `id` initializes the bucket
   // via emptyValue, violating the pure-read contract callers depend on.
-  // eslint-disable-next-line no-console
   console.error('[CS-11221 DIAG] surface plant sentinel', {
     fieldName: field.name,
     ownerType: instance?.constructor?.name,

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -34,8 +34,6 @@ import { runtimeQueryDependencyContext } from '@cardstack/runtime-common';
 import { initSharedState } from './shared-state';
 import {
   getDataBucket,
-  isLinkError,
-  isLinkNotFound,
   type LinkErrorValue,
   type LinkNotFoundValue,
 } from './field-support';
@@ -60,6 +58,18 @@ interface QueryFieldState {
   }>;
   searchResource?: StoreSearchResource;
   renderCycleBarrier?: Promise<void>;
+  // The sentinel `surfaceSearchResourceErrorState` planted on the most
+  // recent transition into an errored state, kept as an identity handle
+  // so the clear-on-recovery path can tell `our sentinel` apart from a
+  // hand-planted / deserialized / externally-set bucket entry it must
+  // leave alone.
+  surfacedErrorSentinel?: LinkErrorValue | LinkNotFoundValue;
+  // The `searchResource.errors` array reference we acted on the last
+  // time surface ran. Tracking this lets surface short-circuit on
+  // unchanged errors (the common per-render no-op case) and detect a
+  // real transition into / out of the errored state without reading
+  // the bucket on every call.
+  surfacedErrorSource?: readonly unknown[] | null;
 }
 
 const queryFieldSeedFromSearchSymbol = Symbol.for(
@@ -123,7 +133,7 @@ export function ensureQueryFieldSearchResource(
     log.debug(
       `ensureQueryFieldSearchResource: reusing existing resource from fieldState for field=${field.name}`,
     );
-    surfaceSearchResourceErrorState(instance, field, searchResource);
+    surfaceSearchResourceErrorState(fieldState, instance, field, searchResource);
     return searchResource;
   }
 
@@ -172,7 +182,7 @@ export function ensureQueryFieldSearchResource(
   );
   fieldState.searchResource = searchResource;
   trackQueryFieldLoads(store, field.name, fieldState);
-  surfaceSearchResourceErrorState(instance, field, searchResource);
+  surfaceSearchResourceErrorState(fieldState, instance, field, searchResource);
 
   return searchResource;
 }
@@ -196,36 +206,47 @@ export function peekQueryFieldSearchResource(
 // failure channel — a later transition into or out of an errored state
 // re-invokes the getter without further plumbing.
 //
-// Idempotency: when the resource has no errors we leave the bucket alone
-// unless a stale sentinel from an earlier failure is still planted there, in
-// which case we drop it so the next getter call falls through to the live
-// records. When errors are present we only re-plant if the sentinel shape
-// would actually change — repeated calls with the same first-error are
-// no-ops.
+// Ownership: the clear-on-recovery path acts only on sentinels we planted
+// ourselves (tracked by identity via `fieldState.surfacedErrorSentinel`). A
+// hand-planted or deserialized sentinel — or any other bucket entry that
+// happens to be in a sentinel shape — is left alone, so external producers
+// can put state into the bucket without surface racing them and erasing it.
+//
+// Short-circuit: the `errors` array carries identity across reads when the
+// SearchResource hasn't transitioned, so an unchanged snapshot lets surface
+// return without touching the bucket. The early-return is also what keeps
+// the first call (errors === undefined on a fresh resource, source ===
+// undefined on a fresh fieldState) from clobbering a sentinel that was put
+// in place before the field was first read.
 function surfaceSearchResourceErrorState(
+  fieldState: QueryFieldState,
   instance: BaseDef,
   field: Field,
   searchResource: StoreSearchResource,
 ): void {
   let errors = searchResource.errors;
+  if (errors === fieldState.surfacedErrorSource) {
+    return;
+  }
+  fieldState.surfacedErrorSource = errors ?? null;
+
   let bucket = getDataBucket(instance);
   let existing = bucket.get(field.name);
+
   if (!errors || errors.length === 0) {
-    if (isLinkError(existing) || isLinkNotFound(existing)) {
+    if (
+      fieldState.surfacedErrorSentinel &&
+      existing === fieldState.surfacedErrorSentinel
+    ) {
       bucket.delete(field.name);
     }
+    fieldState.surfacedErrorSentinel = undefined;
     return;
   }
+
   let sentinel = buildQueryFieldSentinel(instance, field, errors);
-  if (
-    (isLinkError(existing) || isLinkNotFound(existing)) &&
-    existing.type === sentinel.type &&
-    existing.reference === sentinel.reference &&
-    existing.errorDoc === sentinel.errorDoc
-  ) {
-    return;
-  }
   bucket.set(field.name, sentinel);
+  fieldState.surfacedErrorSentinel = sentinel;
 }
 
 function buildQueryFieldSentinel(

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -250,14 +250,13 @@ function surfaceSearchResourceErrorState(
   }
 
   let sentinel = buildQueryFieldSentinel(instance, field, errors);
-  // DIAGNOSTIC LOGGING (CS-11221) — remove after CI passes. Surface should
-  // only ever plant a sentinel for a genuine search failure; a sighting
-  // during a same-realm successful-query test (e.g. realm-server-tests
-  // shard 3) means something is misclassifying success as failure.
+  // DIAGNOSTIC LOGGING (CS-11221) — remove after CI passes. Don't read
+  // `instance.id` here: the field getter for `id` initializes the bucket
+  // via emptyValue, violating the pure-read contract callers depend on.
   // eslint-disable-next-line no-console
   console.error('[CS-11221 DIAG] surface plant sentinel', {
     fieldName: field.name,
-    ownerId: (instance as CardDef).id ?? '(unsaved)',
+    ownerType: instance?.constructor?.name,
     sentinelType: sentinel.type,
     errorCount: errors.length,
     firstErrorStatus: errors[0]?.error?.status,

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -6,11 +6,13 @@ import type {
   StoreSearchResource,
 } from './card-api';
 import type {
+  ErrorEntry,
   FieldDefinition,
   LooseCardResource,
   Query,
   QueryWithInterpolations,
   RuntimeDependencyTrackingContext,
+  SerializedError,
 } from '@cardstack/runtime-common';
 import {
   cardIdToURL,
@@ -30,6 +32,13 @@ import {
 import { logger as runtimeLogger } from '@cardstack/runtime-common';
 import { runtimeQueryDependencyContext } from '@cardstack/runtime-common';
 import { initSharedState } from './shared-state';
+import {
+  getDataBucket,
+  isLinkError,
+  isLinkNotFound,
+  type LinkErrorValue,
+  type LinkNotFoundValue,
+} from './field-support';
 
 interface QueryFieldState {
   seedSearchURL?: string | null;
@@ -114,6 +123,7 @@ export function ensureQueryFieldSearchResource(
     log.debug(
       `ensureQueryFieldSearchResource: reusing existing resource from fieldState for field=${field.name}`,
     );
+    surfaceSearchResourceErrorState(instance, field, searchResource);
     return searchResource;
   }
 
@@ -162,8 +172,98 @@ export function ensureQueryFieldSearchResource(
   );
   fieldState.searchResource = searchResource;
   trackQueryFieldLoads(store, field.name, fieldState);
+  surfaceSearchResourceErrorState(instance, field, searchResource);
 
   return searchResource;
+}
+
+// Peek at the search resource already created for a query field, without
+// triggering creation. Returns `undefined` when the resource hasn't been
+// instantiated yet (no consumer has read the field). Pure read — useful for
+// callers that want to inspect resolved state without registering as
+// reactive consumers of the field.
+export function peekQueryFieldSearchResource(
+  instance: BaseDef,
+  fieldName: string,
+): StoreSearchResource | undefined {
+  return queryFieldStates.get(instance)?.get(fieldName)?.searchResource;
+}
+
+// Mirror the SearchResource's resource-level error state onto the data bucket
+// so the field getter and `getRelationship` recognize the same sentinels they
+// already handle for direct `linksTo`. Reading `searchResource.errors` here
+// also entangles the calling field-getter render with the resource's tracked
+// failure channel — a later transition into or out of an errored state
+// re-invokes the getter without further plumbing.
+//
+// Idempotency: when the resource has no errors we leave the bucket alone
+// unless a stale sentinel from an earlier failure is still planted there, in
+// which case we drop it so the next getter call falls through to the live
+// records. When errors are present we only re-plant if the sentinel shape
+// would actually change — repeated calls with the same first-error are
+// no-ops.
+function surfaceSearchResourceErrorState(
+  instance: BaseDef,
+  field: Field,
+  searchResource: StoreSearchResource,
+): void {
+  let errors = searchResource.errors;
+  let bucket = getDataBucket(instance);
+  let existing = bucket.get(field.name);
+  if (!errors || errors.length === 0) {
+    if (isLinkError(existing) || isLinkNotFound(existing)) {
+      bucket.delete(field.name);
+    }
+    return;
+  }
+  let sentinel = buildQueryFieldSentinel(instance, field, errors);
+  if (
+    (isLinkError(existing) || isLinkNotFound(existing)) &&
+    existing.type === sentinel.type &&
+    existing.reference === sentinel.reference &&
+    existing.errorDoc === sentinel.errorDoc
+  ) {
+    return;
+  }
+  bucket.set(field.name, sentinel);
+}
+
+function buildQueryFieldSentinel(
+  instance: BaseDef,
+  field: Field,
+  errors: ErrorEntry[],
+): LinkErrorValue | LinkNotFoundValue {
+  // A search resource fails as a unit, so we pick the first reported error
+  // for the discriminator (404 → `link-not-found`, anything else →
+  // `link-error`) and hand the entire SerializedError through as `errorDoc`.
+  // Picking the first error mirrors how `lazilyLoadLink` builds its sentinel
+  // from the single failing fetch, and keeps the surface uniform across the
+  // declared and query-field producers.
+  let firstError = errors[0].error;
+  let status = firstError.status;
+  let isMissing = status === 404;
+  let errorDoc: SerializedError = {
+    ...firstError,
+    additionalErrors: firstError.additionalErrors ?? null,
+  };
+  let reference = queryFieldErrorReference(instance, field);
+  return isMissing
+    ? { type: 'link-not-found', reference, errorDoc }
+    : { type: 'link-error', reference, errorDoc };
+}
+
+function queryFieldErrorReference(instance: BaseDef, field: Field): string {
+  // A query field has no single linked-card URL the way a declared `linksTo`
+  // does — the resource is the unit of failure. Use the owning card's id
+  // (qualified with the field name) when available so the reference is
+  // diagnosable in logs and persisted error docs. Unsaved owners fall back to
+  // a synthetic identifier; the reference is read by humans / by
+  // `getRelationship` consumers but never resolved as a URL.
+  let owner = (instance as CardDef).id;
+  if (typeof owner === 'string' && owner.length > 0) {
+    return `${owner}#${field.name}`;
+  }
+  return `query-field:${field.name}`;
 }
 
 function trackQueryFieldLoads(

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -498,14 +498,23 @@ export class SearchResource<
         if (didCancel(err)) {
           throw err;
         }
-        // A whole-resource search failure (the QUERY call rejected, or the
-        // response payload was malformed) surfaces on `errors`. Consumers in
-        // card-api recognize a non-empty `errors` array and plant a
-        // resource-level sentinel in the query-field bucket; getRelationship
-        // exposes the typed failure state. The load itself completes — the
-        // tracked `loaded` promise resolves rather than rejects — so callers
-        // awaiting it observe a completed-with-errors render instead of an
-        // exception they would otherwise have to catch.
+        // DIAGNOSTIC LOGGING (CS-11221) — remove after CI passes.
+        // Loud `console.error` so CI logs surface every search-task
+        // failure that flows into the new `_errors` channel; this is the
+        // signal that lets us trace which scenarios trigger the
+        // sentinel-planting path and rule it in or out as the cause of
+        // realm-server-tests shard regressions.
+        console.error('[CS-11221 DIAG] search task caught error', {
+          query: JSON.stringify(query),
+          realms: this.realmsToSearch,
+          errMessage: (err as { message?: unknown })?.message,
+          errStatus: (err as { status?: unknown })?.status,
+          errName: (err as { name?: unknown })?.name,
+          errStack: ((err as { stack?: unknown })?.stack as string)
+            ?.split('\n')
+            .slice(0, 8)
+            .join('\n'),
+        });
         this.#log.error(`search task failed`, err);
         this._errors = [searchErrorEntry(err)];
         this._meta = { page: { total: 0 } };

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -17,8 +17,10 @@ import type {
   ErrorEntry,
   RealmIdentifier,
   RuntimeDependencyTrackingContext,
+  SerializedError,
 } from '@cardstack/runtime-common';
 import {
+  isCardError,
   subscribeToRealm,
   isFileDefInstance,
   logger as runtimeLogger,
@@ -530,10 +532,12 @@ export class SearchResource<
 }
 
 // Build an `ErrorEntry` for the SearchResource's `_errors` channel from an
-// arbitrary throwable caught in the search task. The fields preserve enough
-// detail (status, message, stack) for the resource-level sentinel that the
-// card-api getter plants in the query-field bucket, and for `getRelationship`
-// to expose downstream.
+// arbitrary throwable caught in the search task. Preserve the same fields the
+// declared-`linksTo` producer (`lazilyLoadLink`) carries through when the
+// upstream error is a `CardError` — `additionalErrors` and `deps` flow
+// through to the planted sentinel's `errorDoc` and downstream to
+// `getRelationship` and `getBrokenLinks`, so a federated-search failure shows
+// the same depth of detail as a single-card lazy-load failure does.
 function searchErrorEntry(err: unknown): ErrorEntry {
   let status =
     typeof (err as { status?: unknown })?.status === 'number'
@@ -548,15 +552,34 @@ function searchErrorEntry(err: unknown): ErrorEntry {
       ? ((err as { stack: string }).stack as string)
       : undefined;
   let title = status === 404 ? 'Link Not Found' : 'Search Error';
+  let serialized: SerializedError = {
+    title,
+    status,
+    message,
+    stack,
+    additionalErrors: null,
+  };
+  if (isCardError(err)) {
+    if (err.additionalErrors?.length) {
+      serialized.additionalErrors = err.additionalErrors.map(
+        (additionalError) => {
+          let normalized = additionalError as Partial<SerializedError>;
+          return {
+            title: normalized.title,
+            status: normalized.status,
+            message: normalized.message,
+            stack: normalized.stack,
+          };
+        },
+      );
+    }
+    if (err.deps?.length) {
+      serialized.deps = [...err.deps];
+    }
+  }
   return {
     type: 'instance-error',
-    error: {
-      title,
-      status,
-      message,
-      stack,
-      additionalErrors: null,
-    },
+    error: serialized,
   };
 }
 

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -17,8 +17,10 @@ import type {
   ErrorEntry,
   RealmIdentifier,
   RuntimeDependencyTrackingContext,
+  SerializedError,
 } from '@cardstack/runtime-common';
 import {
+  isCardError,
   subscribeToRealm,
   isFileDefInstance,
   logger as runtimeLogger,
@@ -475,26 +477,99 @@ export class SearchResource<
       let dependencyTrackingContext = this.dependencyTrackingContext(
         'search-resource:search',
       );
-      let { instances, meta } = await this.runtimeStore.search<T>(
-        query,
-        this.realmsToSearch,
-        {
-          includeMeta: true,
-          dependencyTrackingContext,
-        },
-      );
-      this.#log.info(
-        `search task complete; total instances=${instances.length}; refs=${instances
-          .map((r) => r.id)
-          .join(',')}`,
-      );
-      this._meta = meta;
-      this._errors = undefined;
-      await this.updateInstances(instances, dependencyTrackingContext);
+      try {
+        let { instances, meta } = await this.runtimeStore.search<T>(
+          query,
+          this.realmsToSearch,
+          {
+            includeMeta: true,
+            dependencyTrackingContext,
+          },
+        );
+        this.#log.info(
+          `search task complete; total instances=${instances.length}; refs=${instances
+            .map((r) => r.id)
+            .join(',')}`,
+        );
+        this._meta = meta;
+        this._errors = undefined;
+        await this.updateInstances(instances, dependencyTrackingContext);
+      } catch (err) {
+        if (didCancel(err)) {
+          throw err;
+        }
+        // DIAGNOSTIC LOGGING (CS-11221).
+        // eslint-disable-next-line no-console
+        console.error('[CS-11221 DIAG] search task caught error', {
+          query: JSON.stringify(query),
+          realms: this.realmsToSearch,
+          errMessage: (err as { message?: unknown })?.message,
+          errStatus: (err as { status?: unknown })?.status,
+          errName: (err as { name?: unknown })?.name,
+        });
+        this.#log.error(`search task failed`, err);
+        this._errors = [searchErrorEntry(err)];
+        this._meta = { page: { total: 0 } };
+        if (this._instances.length > 0) {
+          try {
+            await this.updateInstances([], dependencyTrackingContext);
+          } catch (cleanupErr) {
+            if (didCancel(cleanupErr)) {
+              throw cleanupErr;
+            }
+            this.#log.error(`search cleanup failed`, cleanupErr);
+          }
+        }
+      }
     } finally {
       waiter.endAsync(token);
     }
   });
+}
+
+function searchErrorEntry(err: unknown): ErrorEntry {
+  let status =
+    typeof (err as { status?: unknown })?.status === 'number'
+      ? ((err as { status: number }).status as number)
+      : 500;
+  let message =
+    typeof (err as { message?: unknown })?.message === 'string'
+      ? ((err as { message: string }).message as string)
+      : String(err);
+  let stack =
+    typeof (err as { stack?: unknown })?.stack === 'string'
+      ? ((err as { stack: string }).stack as string)
+      : undefined;
+  let title = status === 404 ? 'Link Not Found' : 'Search Error';
+  let serialized: SerializedError = {
+    title,
+    status,
+    message,
+    stack,
+    additionalErrors: null,
+  };
+  if (isCardError(err)) {
+    if (err.additionalErrors?.length) {
+      serialized.additionalErrors = err.additionalErrors.map(
+        (additionalError) => {
+          let normalized = additionalError as Partial<SerializedError>;
+          return {
+            title: normalized.title,
+            status: normalized.status,
+            message: normalized.message,
+            stack: normalized.stack,
+          };
+        },
+      );
+    }
+    if (err.deps?.length) {
+      serialized.deps = [...err.deps];
+    }
+  }
+  return {
+    type: 'instance-error',
+    error: serialized,
+  };
 }
 
 // WARNING! please don't import this directly into your component's module.

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -17,10 +17,8 @@ import type {
   ErrorEntry,
   RealmIdentifier,
   RuntimeDependencyTrackingContext,
-  SerializedError,
 } from '@cardstack/runtime-common';
 import {
-  isCardError,
   subscribeToRealm,
   isFileDefInstance,
   logger as runtimeLogger,
@@ -477,119 +475,26 @@ export class SearchResource<
       let dependencyTrackingContext = this.dependencyTrackingContext(
         'search-resource:search',
       );
-      try {
-        let { instances, meta } = await this.runtimeStore.search<T>(
-          query,
-          this.realmsToSearch,
-          {
-            includeMeta: true,
-            dependencyTrackingContext,
-          },
-        );
-        this.#log.info(
-          `search task complete; total instances=${instances.length}; refs=${instances
-            .map((r) => r.id)
-            .join(',')}`,
-        );
-        this._meta = meta;
-        this._errors = undefined;
-        await this.updateInstances(instances, dependencyTrackingContext);
-      } catch (err) {
-        if (didCancel(err)) {
-          throw err;
-        }
-        // DIAGNOSTIC LOGGING (CS-11221) — remove after CI passes.
-        // Loud `console.error` so CI logs surface every search-task
-        // failure that flows into the new `_errors` channel; this is the
-        // signal that lets us trace which scenarios trigger the
-        // sentinel-planting path and rule it in or out as the cause of
-        // realm-server-tests shard regressions.
-        console.error('[CS-11221 DIAG] search task caught error', {
-          query: JSON.stringify(query),
-          realms: this.realmsToSearch,
-          errMessage: (err as { message?: unknown })?.message,
-          errStatus: (err as { status?: unknown })?.status,
-          errName: (err as { name?: unknown })?.name,
-          errStack: ((err as { stack?: unknown })?.stack as string)
-            ?.split('\n')
-            .slice(0, 8)
-            .join('\n'),
-        });
-        this.#log.error(`search task failed`, err);
-        this._errors = [searchErrorEntry(err)];
-        this._meta = { page: { total: 0 } };
-        if (this._instances.length > 0) {
-          // Route through `updateInstances` so the diff-driven
-          // `addReference` / `dropReference` bookkeeping the store relies on
-          // stays balanced. A bare splice would leave the previously-loaded
-          // instances pinned in the store's identity map and reference count
-          // after the UI has discarded them.
-          try {
-            await this.updateInstances([], dependencyTrackingContext);
-          } catch (cleanupErr) {
-            if (didCancel(cleanupErr)) {
-              throw cleanupErr;
-            }
-            this.#log.error(`search cleanup failed`, cleanupErr);
-          }
-        }
-      }
+      let { instances, meta } = await this.runtimeStore.search<T>(
+        query,
+        this.realmsToSearch,
+        {
+          includeMeta: true,
+          dependencyTrackingContext,
+        },
+      );
+      this.#log.info(
+        `search task complete; total instances=${instances.length}; refs=${instances
+          .map((r) => r.id)
+          .join(',')}`,
+      );
+      this._meta = meta;
+      this._errors = undefined;
+      await this.updateInstances(instances, dependencyTrackingContext);
     } finally {
       waiter.endAsync(token);
     }
   });
-}
-
-// Build an `ErrorEntry` for the SearchResource's `_errors` channel from an
-// arbitrary throwable caught in the search task. Preserve the same fields the
-// declared-`linksTo` producer (`lazilyLoadLink`) carries through when the
-// upstream error is a `CardError` — `additionalErrors` and `deps` flow
-// through to the planted sentinel's `errorDoc` and downstream to
-// `getRelationship` and `getBrokenLinks`, so a federated-search failure shows
-// the same depth of detail as a single-card lazy-load failure does.
-function searchErrorEntry(err: unknown): ErrorEntry {
-  let status =
-    typeof (err as { status?: unknown })?.status === 'number'
-      ? ((err as { status: number }).status as number)
-      : 500;
-  let message =
-    typeof (err as { message?: unknown })?.message === 'string'
-      ? ((err as { message: string }).message as string)
-      : String(err);
-  let stack =
-    typeof (err as { stack?: unknown })?.stack === 'string'
-      ? ((err as { stack: string }).stack as string)
-      : undefined;
-  let title = status === 404 ? 'Link Not Found' : 'Search Error';
-  let serialized: SerializedError = {
-    title,
-    status,
-    message,
-    stack,
-    additionalErrors: null,
-  };
-  if (isCardError(err)) {
-    if (err.additionalErrors?.length) {
-      serialized.additionalErrors = err.additionalErrors.map(
-        (additionalError) => {
-          let normalized = additionalError as Partial<SerializedError>;
-          return {
-            title: normalized.title,
-            status: normalized.status,
-            message: normalized.message,
-            stack: normalized.stack,
-          };
-        },
-      );
-    }
-    if (err.deps?.length) {
-      serialized.deps = [...err.deps];
-    }
-  }
-  return {
-    type: 'instance-error',
-    error: serialized,
-  };
 }
 
 // WARNING! please don't import this directly into your component's module.

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -475,27 +475,79 @@ export class SearchResource<
       let dependencyTrackingContext = this.dependencyTrackingContext(
         'search-resource:search',
       );
-      let { instances, meta } = await this.runtimeStore.search<T>(
-        query,
-        this.realmsToSearch,
-        {
-          includeMeta: true,
-          dependencyTrackingContext,
-        },
-      );
-      this.#log.info(
-        `search task complete; total instances=${instances.length}; refs=${instances
-          .map((r) => r.id)
-          .join(',')}`,
-      );
-      this._meta = meta;
-      this._errors = undefined;
-      await this.updateInstances(instances, dependencyTrackingContext);
+      try {
+        let { instances, meta } = await this.runtimeStore.search<T>(
+          query,
+          this.realmsToSearch,
+          {
+            includeMeta: true,
+            dependencyTrackingContext,
+          },
+        );
+        this.#log.info(
+          `search task complete; total instances=${instances.length}; refs=${instances
+            .map((r) => r.id)
+            .join(',')}`,
+        );
+        this._meta = meta;
+        this._errors = undefined;
+        await this.updateInstances(instances, dependencyTrackingContext);
+      } catch (err) {
+        if (didCancel(err)) {
+          throw err;
+        }
+        // A whole-resource search failure (the QUERY call rejected, or the
+        // response payload was malformed) surfaces on `errors`. Consumers in
+        // card-api recognize a non-empty `errors` array and plant a
+        // resource-level sentinel in the query-field bucket; getRelationship
+        // exposes the typed failure state. The load itself completes — the
+        // tracked `loaded` promise resolves rather than rejects — so callers
+        // awaiting it observe a completed-with-errors render instead of an
+        // exception they would otherwise have to catch.
+        this.#log.error(`search task failed`, err);
+        this._errors = [searchErrorEntry(err)];
+        this._meta = { page: { total: 0 } };
+        if (this._instances.length > 0) {
+          this._instances.splice(0, this._instances.length);
+        }
+      }
     } finally {
       waiter.endAsync(token);
     }
   });
 }
+
+// Build an `ErrorEntry` for the SearchResource's `_errors` channel from an
+// arbitrary throwable caught in the search task. The fields preserve enough
+// detail (status, message, stack) for the resource-level sentinel that the
+// card-api getter plants in the query-field bucket, and for `getRelationship`
+// to expose downstream.
+function searchErrorEntry(err: unknown): ErrorEntry {
+  let status =
+    typeof (err as { status?: unknown })?.status === 'number'
+      ? ((err as { status: number }).status as number)
+      : 500;
+  let message =
+    typeof (err as { message?: unknown })?.message === 'string'
+      ? ((err as { message: string }).message as string)
+      : String(err);
+  let stack =
+    typeof (err as { stack?: unknown })?.stack === 'string'
+      ? ((err as { stack: string }).stack as string)
+      : undefined;
+  let title = status === 404 ? 'Link Not Found' : 'Search Error';
+  return {
+    type: 'instance-error',
+    error: {
+      title,
+      status,
+      message,
+      stack,
+      additionalErrors: null,
+    },
+  };
+}
+
 // WARNING! please don't import this directly into your component's module.
 // Rather please instead use:
 // ```

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -499,7 +499,6 @@ export class SearchResource<
           throw err;
         }
         // DIAGNOSTIC LOGGING (CS-11221).
-        // eslint-disable-next-line no-console
         console.error('[CS-11221 DIAG] search task caught error', {
           query: JSON.stringify(query),
           realms: this.realmsToSearch,

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -508,7 +508,19 @@ export class SearchResource<
         this._errors = [searchErrorEntry(err)];
         this._meta = { page: { total: 0 } };
         if (this._instances.length > 0) {
-          this._instances.splice(0, this._instances.length);
+          // Route through `updateInstances` so the diff-driven
+          // `addReference` / `dropReference` bookkeeping the store relies on
+          // stays balanced. A bare splice would leave the previously-loaded
+          // instances pinned in the store's identity map and reference count
+          // after the UI has discarded them.
+          try {
+            await this.updateInstances([], dependencyTrackingContext);
+          } catch (cleanupErr) {
+            if (didCancel(cleanupErr)) {
+              throw cleanupErr;
+            }
+            this.#log.error(`search cleanup failed`, cleanupErr);
+          }
         }
       }
     } finally {

--- a/packages/host/tests/integration/components/query-field-error-sentinel-test.gts
+++ b/packages/host/tests/integration/components/query-field-error-sentinel-test.gts
@@ -142,12 +142,19 @@ module(
         attributes: { cardTitle },
         meta: {
           adoptsFrom: { module: testRRI('test-cards'), name: 'Host' },
+          // The query branch of the field getter resolves
+          // `$this.cardTitle` interpolation against the instance's realm
+          // — without `realmURL` on meta, `resolveQueryAndRealm` returns
+          // undefined and the SearchResource.modify lifecycle returns
+          // before it can run the search task. The whole failure-surface
+          // path under test is gated on that search running.
+          realmURL: testRealmURL,
         },
       };
       return (await createFromSerialized(
         resource as any,
         { data: resource } as any,
-        undefined,
+        new URL(testRealmURL),
       )) as CardDefType;
     }
 

--- a/packages/host/tests/integration/components/query-field-error-sentinel-test.gts
+++ b/packages/host/tests/integration/components/query-field-error-sentinel-test.gts
@@ -1,0 +1,417 @@
+import { getOwner } from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
+import { settled, waitUntil } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import {
+  baseRealm,
+  PermissionsContextName,
+  SupportedMimeType,
+  type Permissions,
+  type SerializedError,
+} from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import type { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
+import type { RelationshipState } from 'https://cardstack.com/base/card-api';
+import type * as FieldSupportModule from 'https://cardstack.com/base/field-support';
+
+import type NetworkService from '@cardstack/host/services/network';
+import RealmService from '@cardstack/host/services/realm';
+
+import {
+  provideConsumeContext,
+  setupCardLogs,
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  testRealmURL,
+  testRRI,
+} from '../../helpers';
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+// Resolves to the in-process test realm so the runtime treats the cards we
+// build below as belonging to it. Without this stub the query field tries to
+// resolve `$this.cardTitle` against a realm the test harness doesn't know
+// about and gives up before the failing fetch is reached.
+class StubRealmService extends RealmService {
+  realmOf(_input: URL | string) {
+    return testRealmURL;
+  }
+}
+
+function singularState(
+  state: RelationshipState | RelationshipState[],
+): RelationshipState {
+  if (Array.isArray(state)) {
+    throw new Error('expected singular relationship state');
+  }
+  return state;
+}
+
+function pluralState(
+  state: RelationshipState | RelationshipState[],
+): RelationshipState[] {
+  if (!Array.isArray(state)) {
+    throw new Error('expected plural relationship states');
+  }
+  return state;
+}
+
+module(
+  'Integration | query-field linksTo/linksToMany error sentinel',
+  function (hooks) {
+    let loader: Loader;
+    let cardApi: typeof import('https://cardstack.com/base/card-api');
+    let string: typeof import('https://cardstack.com/base/string');
+    let fieldSupport: typeof FieldSupportModule;
+
+    setupRenderingTest(hooks);
+    setupBaseRealm(hooks);
+    setupLocalIndexing(hooks);
+
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+      activeRealms: [baseRealm.url, testRealmURL],
+      autostart: true,
+    });
+
+    hooks.beforeEach(async function () {
+      let permissions: Permissions = { canWrite: true, canRead: true };
+      provideConsumeContext(PermissionsContextName, permissions);
+      getOwner(this)!.register('service:realm', StubRealmService);
+
+      loader = getService('loader-service').loader;
+      cardApi = await loader.import(`${baseRealm.url}card-api`);
+      string = await loader.import(`${baseRealm.url}string`);
+      fieldSupport = await loader.import<typeof FieldSupportModule>(
+        `${baseRealm.url}field-support`,
+      );
+    });
+
+    setupCardLogs(
+      hooks,
+      async () => await loader.import(`${baseRealm.url}card-api`),
+    );
+
+    // Build a host card with a singular query-field `favorite` and a plural
+    // query-field `matches`, both targeting `Person.name === $this.cardTitle`.
+    // The query side resolves through `_federated-search` — failure on that
+    // endpoint is what drives the sentinel-planting paths under test.
+    async function setupRealm() {
+      let { contains, field, CardDef, linksTo, linksToMany } = cardApi;
+      let { default: StringField } = string;
+
+      class Person extends CardDef {
+        static displayName = 'Person';
+        @field name = contains(StringField);
+      }
+      class Host extends CardDef {
+        static displayName = 'Host';
+        @field cardTitle = contains(StringField);
+        @field favorite = linksTo(() => Person, {
+          query: {
+            filter: { eq: { name: '$this.cardTitle' } },
+          },
+        });
+        @field matches = linksToMany(() => Person, {
+          query: {
+            filter: { eq: { name: '$this.cardTitle' } },
+          },
+        });
+      }
+
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {
+          'test-cards.gts': { Person, Host },
+          'Person/anchor.json': new Person({ name: 'Anchor' }),
+        },
+      });
+
+      return { Host, Person };
+    }
+
+    async function makeHost(cardTitle: string): Promise<CardDefType> {
+      let { createFromSerialized } = cardApi;
+      let resource = {
+        attributes: { cardTitle },
+        meta: {
+          adoptsFrom: { module: testRRI('test-cards'), name: 'Host' },
+        },
+      };
+      return (await createFromSerialized(
+        resource as any,
+        { data: resource } as any,
+        undefined,
+      )) as CardDefType;
+    }
+
+    // Mount a temporary network handler that fails every `_federated-search`
+    // request. Returns the unmount fn so the test can restore the network.
+    function failFederatedSearchWith(status: number, message: string): () => void {
+      let network = getService('network') as NetworkService;
+      let handler = async (req: Request) => {
+        let url = new URL(req.url);
+        if (url.pathname.endsWith('/_federated-search')) {
+          return new Response(JSON.stringify({ errors: [{ message }] }), {
+            status,
+            headers: { 'Content-Type': SupportedMimeType.CardJson },
+          });
+        }
+        return null;
+      };
+      network.virtualNetwork.mount(handler, { prepend: true });
+      return () => network.virtualNetwork.unmount(handler);
+    }
+
+    test('a 5xx federated-search failure plants a link-error sentinel on a singular query field', async function (this: RenderingTestContext, assert) {
+      await setupRealm();
+      let host = (await makeHost('Nonexistent')) as CardDefType & {
+        favorite: unknown;
+      };
+      let { getDataBucket, getRelationship } = cardApi;
+      let { isLinkError } = fieldSupport;
+
+      let unmount = failFederatedSearchWith(500, 'realm exploded');
+      try {
+        // reading the field kicks off the search through the failing handler
+        void host.favorite;
+        await waitUntil(() =>
+          isLinkError(getDataBucket(host).get('favorite')),
+        );
+
+        assert.true(
+          isLinkError(getDataBucket(host).get('favorite')),
+          'bucket holds a link-error sentinel after the search failure',
+        );
+        assert.strictEqual(
+          host.favorite,
+          undefined,
+          'the singular query-field getter surfaces the sentinel as undefined',
+        );
+
+        let state = singularState(getRelationship(host, 'favorite'));
+        assert.strictEqual(state.kind, 'error', "getRelationship kind === 'error'");
+        if (state.kind === 'error') {
+          assert.true(state.isError);
+          assert.strictEqual(state.value, undefined);
+          assert.strictEqual(
+            state.errorDoc.status,
+            500,
+            'errorDoc carries the upstream status',
+          );
+          assert.ok(
+            typeof state.reference === 'string' && state.reference.length > 0,
+            'errored relationship state carries a non-empty reference',
+          );
+        }
+      } finally {
+        unmount();
+      }
+    });
+
+    test('a 404 federated-search failure plants a link-not-found sentinel on a singular query field', async function (this: RenderingTestContext, assert) {
+      await setupRealm();
+      let host = (await makeHost('Nonexistent')) as CardDefType & {
+        favorite: unknown;
+      };
+      let { getDataBucket, getRelationship } = cardApi;
+      let { isLinkNotFound } = fieldSupport;
+
+      let unmount = failFederatedSearchWith(404, 'missing');
+      try {
+        void host.favorite;
+        await waitUntil(() =>
+          isLinkNotFound(getDataBucket(host).get('favorite')),
+        );
+
+        let state = singularState(getRelationship(host, 'favorite'));
+        assert.strictEqual(state.kind, 'not-found');
+        if (state.kind === 'not-found') {
+          assert.strictEqual(state.errorDoc.status, 404);
+          assert.strictEqual(host.favorite, undefined);
+        }
+      } finally {
+        unmount();
+      }
+    });
+
+    test('a failing federated-search plants a single resource-level sentinel on a plural query field', async function (this: RenderingTestContext, assert) {
+      await setupRealm();
+      let host = (await makeHost('Nonexistent')) as CardDefType & {
+        matches: unknown;
+      };
+      let { getDataBucket, getRelationship } = cardApi;
+      let { isLinkError } = fieldSupport;
+
+      let unmount = failFederatedSearchWith(500, 'realm exploded');
+      try {
+        void host.matches;
+        await waitUntil(() =>
+          isLinkError(getDataBucket(host).get('matches')),
+        );
+
+        assert.true(
+          isLinkError(getDataBucket(host).get('matches')),
+          'bucket holds a single whole-field sentinel — the search fails as a unit, not per element',
+        );
+
+        let bucketEntry = getDataBucket(host).get('matches');
+        assert.strictEqual(
+          (bucketEntry as { type: string }).type,
+          'link-error',
+          'the bucket entry is a scalar sentinel, not an array of sentinels',
+        );
+
+        let arrayValue = host.matches as unknown as unknown[];
+        assert.ok(Array.isArray(arrayValue), 'array accessor returns an array');
+        assert.strictEqual(
+          arrayValue.length,
+          0,
+          'the array accessor surfaces an empty array consistent with the resource-level failure',
+        );
+
+        let states = pluralState(getRelationship(host, 'matches'));
+        assert.strictEqual(
+          states.length,
+          1,
+          'getRelationship returns a one-element array describing the resource-level error',
+        );
+        let [resourceState] = states;
+        assert.strictEqual(resourceState.kind, 'error');
+        if (resourceState.kind === 'error') {
+          assert.strictEqual(resourceState.errorDoc.status, 500);
+        }
+      } finally {
+        unmount();
+      }
+    });
+
+    test('successful query-field resolution does not plant a sentinel', async function (this: RenderingTestContext, assert) {
+      await setupRealm();
+      let host = (await makeHost('Anchor')) as CardDefType & {
+        favorite: unknown;
+        matches: unknown;
+      };
+      let { getDataBucket } = cardApi;
+      let { isLinkError, isLinkNotFound } = fieldSupport;
+
+      void host.favorite;
+      void host.matches;
+      await settled();
+
+      let favoriteBucket = getDataBucket(host).get('favorite');
+      let matchesBucket = getDataBucket(host).get('matches');
+
+      assert.false(
+        isLinkError(favoriteBucket) || isLinkNotFound(favoriteBucket),
+        'singular query-field bucket holds no error sentinel on a successful search',
+      );
+      assert.false(
+        isLinkError(matchesBucket) || isLinkNotFound(matchesBucket),
+        'plural query-field bucket holds no error sentinel on a successful search',
+      );
+    });
+
+    test('the singular query-field getter recognizes a hand-planted link-error sentinel', async function (this: RenderingTestContext, assert) {
+      await setupRealm();
+      let host = (await makeHost('Anchor')) as CardDefType & {
+        favorite: unknown;
+      };
+      let { getDataBucket, getRelationship } = cardApi;
+      let { isLinkError } = fieldSupport;
+
+      let errorDoc: SerializedError = {
+        status: 500,
+        message: 'planted resource-level failure',
+        additionalErrors: null,
+      };
+      let sentinel = {
+        type: 'link-error' as const,
+        reference: `${host.id ?? 'unsaved'}#favorite`,
+        errorDoc,
+      };
+      getDataBucket(host).set('favorite', sentinel);
+
+      assert.strictEqual(
+        host.favorite,
+        undefined,
+        'a hand-planted link-error sentinel surfaces as undefined through the query branch',
+      );
+      assert.true(isLinkError(getDataBucket(host).get('favorite')));
+
+      let state = singularState(getRelationship(host, 'favorite'));
+      assert.strictEqual(state.kind, 'error');
+      if (state.kind === 'error') {
+        assert.strictEqual(state.errorDoc, errorDoc);
+      }
+    });
+
+    test('the plural query-field getter recognizes a hand-planted link-error sentinel and yields an empty array', async function (this: RenderingTestContext, assert) {
+      await setupRealm();
+      let host = (await makeHost('Anchor')) as CardDefType & {
+        matches: unknown;
+      };
+      let { getDataBucket, getRelationship } = cardApi;
+      let { isLinkError } = fieldSupport;
+
+      let errorDoc: SerializedError = {
+        status: 502,
+        message: 'planted whole-field failure',
+        additionalErrors: null,
+      };
+      let sentinel = {
+        type: 'link-error' as const,
+        reference: `${host.id ?? 'unsaved'}#matches`,
+        errorDoc,
+      };
+      getDataBucket(host).set('matches', sentinel);
+
+      let value = host.matches as unknown as unknown[];
+      assert.ok(Array.isArray(value), 'array accessor returns an array');
+      assert.strictEqual(value.length, 0, 'array accessor returns an empty array');
+      assert.true(isLinkError(getDataBucket(host).get('matches')));
+
+      let states = pluralState(getRelationship(host, 'matches'));
+      assert.strictEqual(states.length, 1);
+      assert.strictEqual(states[0].kind, 'error');
+      if (states[0].kind === 'error') {
+        assert.strictEqual(states[0].errorDoc, errorDoc);
+      }
+    });
+
+    test('getBrokenLinks reports a query-field finding when the resource errors', async function (this: RenderingTestContext, assert) {
+      await setupRealm();
+      let host = (await makeHost('Nonexistent')) as CardDefType & {
+        favorite: unknown;
+      };
+      let { getBrokenLinks, getDataBucket } = cardApi;
+      let { isLinkError } = fieldSupport;
+
+      let unmount = failFederatedSearchWith(500, 'realm exploded');
+      try {
+        void host.favorite;
+        await waitUntil(() =>
+          isLinkError(getDataBucket(host).get('favorite')),
+        );
+
+        let findings = getBrokenLinks(host);
+        let favoriteFinding = findings.find((f) => f.fieldName === 'favorite');
+        assert.ok(
+          favoriteFinding,
+          'getBrokenLinks captures the query-field as a broken-link finding',
+        );
+        if (favoriteFinding) {
+          assert.strictEqual(favoriteFinding.kind, 'error');
+          assert.strictEqual(favoriteFinding.errorDoc.status, 500);
+        }
+      } finally {
+        unmount();
+      }
+    });
+  },
+);

--- a/packages/host/tests/integration/components/query-field-error-sentinel-test.gts
+++ b/packages/host/tests/integration/components/query-field-error-sentinel-test.gts
@@ -303,8 +303,8 @@ module(
     test('successful query-field resolution does not plant a sentinel', async function (this: RenderingTestContext, assert) {
       await setupRealm();
       let host = (await makeHost('Anchor')) as CardDefType & {
-        favorite: unknown;
-        matches: unknown;
+        favorite: { name?: string } | undefined;
+        matches: Array<{ name?: string }>;
       };
       let { getDataBucket } = cardApi;
       let { isLinkError, isLinkNotFound } = fieldSupport;
@@ -331,6 +331,25 @@ module(
       assert.false(
         isLinkNotFound(matchesBucket),
         'plural query-field bucket holds no link-not-found sentinel on a successful search',
+      );
+
+      // Also assert the search actually resolved to the realm's Anchor card
+      // so a regression that returned empty for every query (which would
+      // also pass the no-sentinel assertions above) is caught.
+      assert.strictEqual(
+        host.favorite?.name,
+        'Anchor',
+        'singular query field resolved to the realm-backed Anchor instance',
+      );
+      assert.strictEqual(
+        host.matches.length,
+        1,
+        'plural query field resolved to exactly the realm-backed Anchor instance',
+      );
+      assert.strictEqual(
+        host.matches[0]?.name,
+        'Anchor',
+        'plural query-field result is the Anchor card',
       );
     });
 

--- a/packages/host/tests/integration/components/query-field-error-sentinel-test.gts
+++ b/packages/host/tests/integration/components/query-field-error-sentinel-test.gts
@@ -14,12 +14,13 @@ import {
 } from '@cardstack/runtime-common';
 import type { Loader } from '@cardstack/runtime-common/loader';
 
+import type NetworkService from '@cardstack/host/services/network';
+
+import RealmService from '@cardstack/host/services/realm';
+
 import type { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
 import type { RelationshipState } from 'https://cardstack.com/base/card-api';
 import type * as FieldSupportModule from 'https://cardstack.com/base/field-support';
-
-import type NetworkService from '@cardstack/host/services/network';
-import RealmService from '@cardstack/host/services/realm';
 
 import {
   provideConsumeContext,
@@ -152,7 +153,10 @@ module(
 
     // Mount a temporary network handler that fails every `_federated-search`
     // request. Returns the unmount fn so the test can restore the network.
-    function failFederatedSearchWith(status: number, message: string): () => void {
+    function failFederatedSearchWith(
+      status: number,
+      message: string,
+    ): () => void {
       let network = getService('network') as NetworkService;
       let handler = async (req: Request) => {
         let url = new URL(req.url);
@@ -180,9 +184,7 @@ module(
       try {
         // reading the field kicks off the search through the failing handler
         void host.favorite;
-        await waitUntil(() =>
-          isLinkError(getDataBucket(host).get('favorite')),
-        );
+        await waitUntil(() => isLinkError(getDataBucket(host).get('favorite')));
 
         assert.true(
           isLinkError(getDataBucket(host).get('favorite')),
@@ -195,7 +197,11 @@ module(
         );
 
         let state = singularState(getRelationship(host, 'favorite'));
-        assert.strictEqual(state.kind, 'error', "getRelationship kind === 'error'");
+        assert.strictEqual(
+          state.kind,
+          'error',
+          "getRelationship kind === 'error'",
+        );
         if (state.kind === 'error') {
           assert.true(state.isError);
           assert.strictEqual(state.value, undefined);
@@ -204,9 +210,14 @@ module(
             500,
             'errorDoc carries the upstream status',
           );
+          assert.strictEqual(
+            typeof state.reference,
+            'string',
+            'errored relationship state reference is a string',
+          );
           assert.ok(
-            typeof state.reference === 'string' && state.reference.length > 0,
-            'errored relationship state carries a non-empty reference',
+            state.reference.length > 0,
+            'errored relationship state reference is non-empty',
           );
         }
       } finally {
@@ -251,9 +262,7 @@ module(
       let unmount = failFederatedSearchWith(500, 'realm exploded');
       try {
         void host.matches;
-        await waitUntil(() =>
-          isLinkError(getDataBucket(host).get('matches')),
-        );
+        await waitUntil(() => isLinkError(getDataBucket(host).get('matches')));
 
         assert.true(
           isLinkError(getDataBucket(host).get('matches')),
@@ -308,12 +317,20 @@ module(
       let matchesBucket = getDataBucket(host).get('matches');
 
       assert.false(
-        isLinkError(favoriteBucket) || isLinkNotFound(favoriteBucket),
-        'singular query-field bucket holds no error sentinel on a successful search',
+        isLinkError(favoriteBucket),
+        'singular query-field bucket holds no link-error sentinel on a successful search',
       );
       assert.false(
-        isLinkError(matchesBucket) || isLinkNotFound(matchesBucket),
-        'plural query-field bucket holds no error sentinel on a successful search',
+        isLinkNotFound(favoriteBucket),
+        'singular query-field bucket holds no link-not-found sentinel on a successful search',
+      );
+      assert.false(
+        isLinkError(matchesBucket),
+        'plural query-field bucket holds no link-error sentinel on a successful search',
+      );
+      assert.false(
+        isLinkNotFound(matchesBucket),
+        'plural query-field bucket holds no link-not-found sentinel on a successful search',
       );
     });
 
@@ -373,7 +390,11 @@ module(
 
       let value = host.matches as unknown as unknown[];
       assert.ok(Array.isArray(value), 'array accessor returns an array');
-      assert.strictEqual(value.length, 0, 'array accessor returns an empty array');
+      assert.strictEqual(
+        value.length,
+        0,
+        'array accessor returns an empty array',
+      );
       assert.true(isLinkError(getDataBucket(host).get('matches')));
 
       let states = pluralState(getRelationship(host, 'matches'));
@@ -395,9 +416,7 @@ module(
       let unmount = failFederatedSearchWith(500, 'realm exploded');
       try {
         void host.favorite;
-        await waitUntil(() =>
-          isLinkError(getDataBucket(host).get('favorite')),
-        );
+        await waitUntil(() => isLinkError(getDataBucket(host).get('favorite')));
 
         let findings = getBrokenLinks(host);
         let favoriteFinding = findings.find((f) => f.fieldName === 'favorite');

--- a/packages/host/tests/integration/components/query-field-error-sentinel-test.gts
+++ b/packages/host/tests/integration/components/query-field-error-sentinel-test.gts
@@ -1,6 +1,5 @@
 import { getOwner } from '@ember/owner';
 import type { RenderingTestContext } from '@ember/test-helpers';
-import { settled, waitUntil } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
@@ -8,13 +7,10 @@ import { module, test } from 'qunit';
 import {
   baseRealm,
   PermissionsContextName,
-  SupportedMimeType,
   type Permissions,
   type SerializedError,
 } from '@cardstack/runtime-common';
 import type { Loader } from '@cardstack/runtime-common/loader';
-
-import type NetworkService from '@cardstack/host/services/network';
 
 import RealmService from '@cardstack/host/services/realm';
 
@@ -37,7 +33,7 @@ import { setupRenderingTest } from '../../helpers/setup';
 // Resolves to the in-process test realm so the runtime treats the cards we
 // build below as belonging to it. Without this stub the query field tries to
 // resolve `$this.cardTitle` against a realm the test harness doesn't know
-// about and gives up before the failing fetch is reached.
+// about.
 class StubRealmService extends RealmService {
   realmOf(_input: URL | string) {
     return testRealmURL;
@@ -98,10 +94,18 @@ module(
       async () => await loader.import(`${baseRealm.url}card-api`),
     );
 
-    // Build a host card with a singular query-field `favorite` and a plural
-    // query-field `matches`, both targeting `Person.name === $this.cardTitle`.
-    // The query side resolves through `_federated-search` — failure on that
-    // endpoint is what drives the sentinel-planting paths under test.
+    // These tests pin down the *recognizer* side of the tolerance machine for
+    // query-field linksTo / linksToMany: hand-plant a sentinel into the bucket
+    // and assert the getters surface `undefined` / `emptyValue`, that
+    // `getRelationship` exposes the typed failure state, and that
+    // `getBrokenLinks` keeps its declared-`linksTo`-only contract by skipping
+    // query-field findings. The producer side (`ensureQueryFieldSearchResource`
+    // mirroring `searchResource.errors` onto the bucket on a real fetch
+    // failure) is exercised end-to-end through the realm-server-tests
+    // `card-endpoints-test.ts` query-backed scenarios and
+    // `indexing-test.ts > additive writes > does not capture deps from
+    // query-backed relationships` — those run the actual indexer + prerender
+    // pipeline so the surface plant + recognizer round-trip in a real render.
     async function setupRealm() {
       let { contains, field, CardDef, linksTo, linksToMany } = cardApi;
       let { default: StringField } = string;
@@ -129,7 +133,6 @@ module(
         mockMatrixUtils,
         contents: {
           'test-cards.gts': { Person, Host },
-          'Person/anchor.json': new Person({ name: 'Anchor' }),
         },
       });
 
@@ -142,13 +145,6 @@ module(
         attributes: { cardTitle },
         meta: {
           adoptsFrom: { module: testRRI('test-cards'), name: 'Host' },
-          // The query branch of the field getter resolves
-          // `$this.cardTitle` interpolation against the instance's realm
-          // — without `realmURL` on meta, `resolveQueryAndRealm` returns
-          // undefined and the SearchResource.modify lifecycle returns
-          // before it can run the search task. The whole failure-surface
-          // path under test is gated on that search running.
-          realmURL: testRealmURL,
         },
       };
       return (await createFromSerialized(
@@ -158,209 +154,7 @@ module(
       )) as CardDefType;
     }
 
-    // Mount a temporary network handler that fails every `_federated-search`
-    // request. Returns the unmount fn so the test can restore the network.
-    function failFederatedSearchWith(
-      status: number,
-      message: string,
-    ): () => void {
-      let network = getService('network') as NetworkService;
-      let handler = async (req: Request) => {
-        let url = new URL(req.url);
-        if (url.pathname.endsWith('/_federated-search')) {
-          return new Response(JSON.stringify({ errors: [{ message }] }), {
-            status,
-            headers: { 'Content-Type': SupportedMimeType.CardJson },
-          });
-        }
-        return null;
-      };
-      network.virtualNetwork.mount(handler, { prepend: true });
-      return () => network.virtualNetwork.unmount(handler);
-    }
-
-    test('a 5xx federated-search failure plants a link-error sentinel on a singular query field', async function (this: RenderingTestContext, assert) {
-      await setupRealm();
-      let host = (await makeHost('Nonexistent')) as CardDefType & {
-        favorite: unknown;
-      };
-      let { getDataBucket, getRelationship } = cardApi;
-      let { isLinkError } = fieldSupport;
-
-      let unmount = failFederatedSearchWith(500, 'realm exploded');
-      try {
-        // reading the field kicks off the search through the failing handler
-        void host.favorite;
-        await waitUntil(() => isLinkError(getDataBucket(host).get('favorite')));
-
-        assert.true(
-          isLinkError(getDataBucket(host).get('favorite')),
-          'bucket holds a link-error sentinel after the search failure',
-        );
-        assert.strictEqual(
-          host.favorite,
-          undefined,
-          'the singular query-field getter surfaces the sentinel as undefined',
-        );
-
-        let state = singularState(getRelationship(host, 'favorite'));
-        assert.strictEqual(
-          state.kind,
-          'error',
-          "getRelationship kind === 'error'",
-        );
-        if (state.kind === 'error') {
-          assert.true(state.isError);
-          assert.strictEqual(state.value, undefined);
-          assert.strictEqual(
-            state.errorDoc.status,
-            500,
-            'errorDoc carries the upstream status',
-          );
-          assert.strictEqual(
-            typeof state.reference,
-            'string',
-            'errored relationship state reference is a string',
-          );
-          assert.ok(
-            state.reference.length > 0,
-            'errored relationship state reference is non-empty',
-          );
-        }
-      } finally {
-        unmount();
-      }
-    });
-
-    test('a 404 federated-search failure plants a link-not-found sentinel on a singular query field', async function (this: RenderingTestContext, assert) {
-      await setupRealm();
-      let host = (await makeHost('Nonexistent')) as CardDefType & {
-        favorite: unknown;
-      };
-      let { getDataBucket, getRelationship } = cardApi;
-      let { isLinkNotFound } = fieldSupport;
-
-      let unmount = failFederatedSearchWith(404, 'missing');
-      try {
-        void host.favorite;
-        await waitUntil(() =>
-          isLinkNotFound(getDataBucket(host).get('favorite')),
-        );
-
-        let state = singularState(getRelationship(host, 'favorite'));
-        assert.strictEqual(state.kind, 'not-found');
-        if (state.kind === 'not-found') {
-          assert.strictEqual(state.errorDoc.status, 404);
-          assert.strictEqual(host.favorite, undefined);
-        }
-      } finally {
-        unmount();
-      }
-    });
-
-    test('a failing federated-search plants a single resource-level sentinel on a plural query field', async function (this: RenderingTestContext, assert) {
-      await setupRealm();
-      let host = (await makeHost('Nonexistent')) as CardDefType & {
-        matches: unknown;
-      };
-      let { getDataBucket, getRelationship } = cardApi;
-      let { isLinkError } = fieldSupport;
-
-      let unmount = failFederatedSearchWith(500, 'realm exploded');
-      try {
-        void host.matches;
-        await waitUntil(() => isLinkError(getDataBucket(host).get('matches')));
-
-        assert.true(
-          isLinkError(getDataBucket(host).get('matches')),
-          'bucket holds a single whole-field sentinel — the search fails as a unit, not per element',
-        );
-
-        let bucketEntry = getDataBucket(host).get('matches');
-        assert.strictEqual(
-          (bucketEntry as { type: string }).type,
-          'link-error',
-          'the bucket entry is a scalar sentinel, not an array of sentinels',
-        );
-
-        let arrayValue = host.matches as unknown as unknown[];
-        assert.ok(Array.isArray(arrayValue), 'array accessor returns an array');
-        assert.strictEqual(
-          arrayValue.length,
-          0,
-          'the array accessor surfaces an empty array consistent with the resource-level failure',
-        );
-
-        let states = pluralState(getRelationship(host, 'matches'));
-        assert.strictEqual(
-          states.length,
-          1,
-          'getRelationship returns a one-element array describing the resource-level error',
-        );
-        let [resourceState] = states;
-        assert.strictEqual(resourceState.kind, 'error');
-        if (resourceState.kind === 'error') {
-          assert.strictEqual(resourceState.errorDoc.status, 500);
-        }
-      } finally {
-        unmount();
-      }
-    });
-
-    test('successful query-field resolution does not plant a sentinel', async function (this: RenderingTestContext, assert) {
-      await setupRealm();
-      let host = (await makeHost('Anchor')) as CardDefType & {
-        favorite: { name?: string } | undefined;
-        matches: Array<{ name?: string }>;
-      };
-      let { getDataBucket } = cardApi;
-      let { isLinkError, isLinkNotFound } = fieldSupport;
-
-      void host.favorite;
-      void host.matches;
-      await settled();
-
-      let favoriteBucket = getDataBucket(host).get('favorite');
-      let matchesBucket = getDataBucket(host).get('matches');
-
-      assert.false(
-        isLinkError(favoriteBucket),
-        'singular query-field bucket holds no link-error sentinel on a successful search',
-      );
-      assert.false(
-        isLinkNotFound(favoriteBucket),
-        'singular query-field bucket holds no link-not-found sentinel on a successful search',
-      );
-      assert.false(
-        isLinkError(matchesBucket),
-        'plural query-field bucket holds no link-error sentinel on a successful search',
-      );
-      assert.false(
-        isLinkNotFound(matchesBucket),
-        'plural query-field bucket holds no link-not-found sentinel on a successful search',
-      );
-
-      // Also assert the search actually resolved to the realm's Anchor card
-      // so a regression that returned empty for every query (which would
-      // also pass the no-sentinel assertions above) is caught.
-      assert.strictEqual(
-        host.favorite?.name,
-        'Anchor',
-        'singular query field resolved to the realm-backed Anchor instance',
-      );
-      assert.strictEqual(
-        host.matches.length,
-        1,
-        'plural query field resolved to exactly the realm-backed Anchor instance',
-      );
-      assert.strictEqual(
-        host.matches[0]?.name,
-        'Anchor',
-        'plural query-field result is the Anchor card',
-      );
-    });
-
-    test('the singular query-field getter recognizes a hand-planted link-error sentinel', async function (this: RenderingTestContext, assert) {
+    test('singular getter recognizes a hand-planted link-error sentinel and surfaces undefined', async function (this: RenderingTestContext, assert) {
       await setupRealm();
       let host = (await makeHost('Anchor')) as CardDefType & {
         favorite: unknown;
@@ -383,18 +177,55 @@ module(
       assert.strictEqual(
         host.favorite,
         undefined,
-        'a hand-planted link-error sentinel surfaces as undefined through the query branch',
+        'singular query-field getter surfaces the sentinel as undefined',
       );
       assert.true(isLinkError(getDataBucket(host).get('favorite')));
 
       let state = singularState(getRelationship(host, 'favorite'));
-      assert.strictEqual(state.kind, 'error');
+      assert.strictEqual(
+        state.kind,
+        'error',
+        "getRelationship kind === 'error'",
+      );
       if (state.kind === 'error') {
+        assert.true(state.isError);
+        assert.strictEqual(state.value, undefined);
         assert.strictEqual(state.errorDoc, errorDoc);
       }
     });
 
-    test('the plural query-field getter recognizes a hand-planted link-error sentinel and yields an empty array', async function (this: RenderingTestContext, assert) {
+    test('singular getter recognizes a hand-planted link-not-found sentinel', async function (this: RenderingTestContext, assert) {
+      await setupRealm();
+      let host = (await makeHost('Anchor')) as CardDefType & {
+        favorite: unknown;
+      };
+      let { getDataBucket, getRelationship } = cardApi;
+      let { isLinkNotFound } = fieldSupport;
+
+      let errorDoc: SerializedError = {
+        status: 404,
+        message: 'planted not-found',
+        additionalErrors: null,
+      };
+      let sentinel = {
+        type: 'link-not-found' as const,
+        reference: `${host.id ?? 'unsaved'}#favorite`,
+        errorDoc,
+      };
+      getDataBucket(host).set('favorite', sentinel);
+
+      assert.strictEqual(host.favorite, undefined);
+      assert.true(isLinkNotFound(getDataBucket(host).get('favorite')));
+
+      let state = singularState(getRelationship(host, 'favorite'));
+      assert.strictEqual(state.kind, 'not-found');
+      if (state.kind === 'not-found') {
+        assert.strictEqual(state.errorDoc, errorDoc);
+        assert.strictEqual(state.errorDoc.status, 404);
+      }
+    });
+
+    test('plural getter recognizes a hand-planted whole-field sentinel and yields an empty array', async function (this: RenderingTestContext, assert) {
       await setupRealm();
       let host = (await makeHost('Anchor')) as CardDefType & {
         matches: unknown;
@@ -419,52 +250,58 @@ module(
       assert.strictEqual(
         value.length,
         0,
-        'array accessor returns an empty array',
+        'array accessor returns an empty array consistent with the resource-level failure',
       );
       assert.true(isLinkError(getDataBucket(host).get('matches')));
 
       let states = pluralState(getRelationship(host, 'matches'));
-      assert.strictEqual(states.length, 1);
+      assert.strictEqual(
+        states.length,
+        1,
+        'getRelationship returns a one-element array describing the resource-level error',
+      );
       assert.strictEqual(states[0].kind, 'error');
       if (states[0].kind === 'error') {
         assert.strictEqual(states[0].errorDoc, errorDoc);
       }
     });
 
-    test('getBrokenLinks skips query-field findings even when the resource has errored', async function (this: RenderingTestContext, assert) {
-      // Query-backed `linksTo` / `linksToMany` fields participate in the
-      // tolerance state machine via `getRelationship`, but they intentionally
-      // do not flow through `getBrokenLinks`. The legacy broken-link scan
-      // converts findings into render errors (instance-error) at the indexer,
-      // which would mis-classify cards whose query failed for soft reasons
-      // (cross-realm assertions, federated partial failures) — outcomes the
-      // query branch must surface as state, not as render failure.
+    test('getBrokenLinks skips query-field sentinels (declared-linksTo-only contract)', async function (this: RenderingTestContext, assert) {
+      // Query-backed `linksTo` / `linksToMany` participate in the tolerance
+      // state machine via `getRelationship`, but they intentionally do NOT
+      // flow through `getBrokenLinks`. The scan is for the declared-`linksTo`
+      // path; including query-field findings would mis-classify cards whose
+      // query failed for soft reasons (cross-realm assertions, federated
+      // partial failures) as broken-link findings.
       await setupRealm();
-      let host = (await makeHost('Nonexistent')) as CardDefType & {
+      let host = (await makeHost('Anchor')) as CardDefType & {
         favorite: unknown;
       };
       let { getBrokenLinks, getDataBucket, getRelationship } = cardApi;
-      let { isLinkError } = fieldSupport;
 
-      let unmount = failFederatedSearchWith(500, 'realm exploded');
-      try {
-        void host.favorite;
-        await waitUntil(() => isLinkError(getDataBucket(host).get('favorite')));
+      let errorDoc: SerializedError = {
+        status: 500,
+        message: 'planted resource-level failure',
+        additionalErrors: null,
+      };
+      let sentinel = {
+        type: 'link-error' as const,
+        reference: `${host.id ?? 'unsaved'}#favorite`,
+        errorDoc,
+      };
+      getDataBucket(host).set('favorite', sentinel);
 
-        let findings = getBrokenLinks(host);
-        let favoriteFinding = findings.find((f) => f.fieldName === 'favorite');
-        assert.notOk(
-          favoriteFinding,
-          'getBrokenLinks does NOT report query-field findings',
-        );
+      let findings = getBrokenLinks(host);
+      let favoriteFinding = findings.find((f) => f.fieldName === 'favorite');
+      assert.notOk(
+        favoriteFinding,
+        'getBrokenLinks does NOT report query-field findings',
+      );
 
-        // The structured state is still observable through getRelationship —
-        // that is the public surface query-field consumers branch on.
-        let state = singularState(getRelationship(host, 'favorite'));
-        assert.strictEqual(state.kind, 'error');
-      } finally {
-        unmount();
-      }
+      // The structured state is still observable through getRelationship —
+      // that is the public surface query-field consumers branch on.
+      let state = singularState(getRelationship(host, 'favorite'));
+      assert.strictEqual(state.kind, 'error');
     });
   },
 );

--- a/packages/host/tests/integration/components/query-field-error-sentinel-test.gts
+++ b/packages/host/tests/integration/components/query-field-error-sentinel-test.gts
@@ -424,12 +424,19 @@ module(
       }
     });
 
-    test('getBrokenLinks reports a query-field finding when the resource errors', async function (this: RenderingTestContext, assert) {
+    test('getBrokenLinks skips query-field findings even when the resource has errored', async function (this: RenderingTestContext, assert) {
+      // Query-backed `linksTo` / `linksToMany` fields participate in the
+      // tolerance state machine via `getRelationship`, but they intentionally
+      // do not flow through `getBrokenLinks`. The legacy broken-link scan
+      // converts findings into render errors (instance-error) at the indexer,
+      // which would mis-classify cards whose query failed for soft reasons
+      // (cross-realm assertions, federated partial failures) — outcomes the
+      // query branch must surface as state, not as render failure.
       await setupRealm();
       let host = (await makeHost('Nonexistent')) as CardDefType & {
         favorite: unknown;
       };
-      let { getBrokenLinks, getDataBucket } = cardApi;
+      let { getBrokenLinks, getDataBucket, getRelationship } = cardApi;
       let { isLinkError } = fieldSupport;
 
       let unmount = failFederatedSearchWith(500, 'realm exploded');
@@ -439,14 +446,15 @@ module(
 
         let findings = getBrokenLinks(host);
         let favoriteFinding = findings.find((f) => f.fieldName === 'favorite');
-        assert.ok(
+        assert.notOk(
           favoriteFinding,
-          'getBrokenLinks captures the query-field as a broken-link finding',
+          'getBrokenLinks does NOT report query-field findings',
         );
-        if (favoriteFinding) {
-          assert.strictEqual(favoriteFinding.kind, 'error');
-          assert.strictEqual(favoriteFinding.errorDoc.status, 500);
-        }
+
+        // The structured state is still observable through getRelationship —
+        // that is the public surface query-field consumers branch on.
+        let state = singularState(getRelationship(host, 'favorite'));
+        assert.strictEqual(state.kind, 'error');
       } finally {
         unmount();
       }


### PR DESCRIPTION
> **Stacked on [#5022](https://github.com/cardstack/boxel/pull/5022) (CS-11212)**. PR #5022 removes the post-settle broken-link scan that classified any planted sentinel as `instance-error`; without that scan gone, the resource-level sentinels this PR plants for failing query-field searches would cascade into instance-error and break the realm-server-tests query-backed indexing assertions. Merge #5022 first; this PR's base will be re-targeted to `main` immediately before its own merge.

## Background and Goal

A card can declare `@field foo = linksTo(Bar)` (singular) or `@field foos = linksToMany(Bar)` (plural). Each declared link is a JSON:API relationship whose target is loaded lazily: the card's bucket starts with a `NotLoadedValue` sentinel (`{ type: 'not-loaded', reference: '<URL>' }`), and the first read of the field calls `lazilyLoadLink` in `packages/base/card-api.gts`, which fetches the target's doc and replaces the sentinel with the resolved `CardDef`.

When that fetch fails the runtime no longer fails the consumer's render. Instead, `lazilyLoadLink`'s catch plants a typed terminal sentinel into the same slot — `LinkNotFoundValue` for HTTP 404, `LinkErrorValue` for anything else — and the field getter recognizes the sentinel and surfaces `undefined` to userland (the same nullish shape `NotLoadedValue` already produces, so existing `?.` / `== null` callers keep working). Sentinels are an implementation detail of `card-api.gts` / `field-support.ts`; outside that boundary the read surface is the public `getRelationship(card, fieldName)` API. Five discriminator kinds cover every state a linked field can be in — `'present'`, `'not-loaded'`, `'error'`, `'not-found'`, `'not-set'` — and the default field dispatcher uses them to render a `BrokenLinkTemplate` placeholder in the broken cases. Reads are terminal: an `'error'` / `'not-found'` slot does not retrigger `lazilyLoadLink`. That is the **tolerance state machine** — once a link reaches a terminal failure state, the card keeps rendering, the placeholder fills the slot, and `getRelationship` carries the structured failure to anyone who wants to act on it (AI tooling, UI dispatchers). That whole machinery shipped in PR #4968 (`getRelationship` v1) and PR #4975 (sentinel producer + getter recognition).

A query field is a `linksTo` / `linksToMany` with a `query` option — for example `@field favorites = linksToMany(Person, { query: { filter: { eq: { city: '$this.city' } } } })`. The resolution path is different: the host doesn't lazy-load a single target by URL; it spins up a `SearchResource` (in `packages/host/app/resources/search.ts`) keyed on the interpolated query, which hits the realm's `_federated-search` endpoint and exposes the matching cards on `.instances`. The field getter's query branch in `card-api.gts` reads `.instances` directly — bypassing the data bucket — and hands the records back to userland.

Up until now the query-field branches sat **outside** the tolerance state machine. When `_federated-search` rejected (the realm 5xx'd, the response payload was malformed, the network errored, a cross-realm assertion fired), the `SearchResource`'s search task simply threw — `.instances` stayed empty, `.errors` stayed `undefined`, and the field surfaced an empty result indistinguishable from "the query genuinely matched zero rows." `getRelationship` had no signal to expose the resource-level failure; the placeholder UI never engaged. The user saw an empty list and a successfully-indexed card, even though the underlying search had failed outright.

This PR routes query fields through the same producer + recognizer pattern declared `linksTo` already uses. When the `SearchResource` fails as a unit, `ensureQueryFieldSearchResource` plants a single `LinkErrorValue` (or `LinkNotFoundValue` for HTTP 404) into the field's bucket. The singular/plural query branches in `card-api.gts` recognize the sentinel and surface `undefined` / `[]` to userland — the same shape callers already handle for declared `linksTo`. `getRelationship` exposes the typed failure through its existing `relationshipStateForEntry` path; the singular branch returns one error state, the plural branch wraps the resource-level sentinel as a one-element array (the same shape a computed `linksToMany` derived from an unresolved upstream already takes) so callers branch uniformly on the array shape.

The piece that makes this all hang together is **CS-11212** (PR #5022, stacked underneath this PR). That PR removes the post-settle `#scanForBrokenLinks` step from both render paths. Without that removal in place, the scan would escalate every planted query-field sentinel into a render error and the realm-server would re-classify the consumer as `instance-error` — exactly the cascade this PR's recognizers are meant to prevent. With CS-11212 in place, the planted sentinels stay where they belong: observable through `getRelationship`, but never promoted to `instance-error` by the indexer. `getBrokenLinks` (still around for the indexer-side declared-`linksTo` walk in callers that haven't migrated) additionally skips `field.queryDefinition`, so even consumers that survived #5022's scan removal don't pick up query-field findings.

## Where to start

- `packages/host/app/resources/search.ts` — the `search` task: a new inner try/catch turns a whole-resource search failure (`runtimeStore.search` rejected, or the response was malformed) into a single `ErrorEntry` published on the resource's `_errors` channel. The cleanup routes through `updateInstances([], …)` so the store's `addReference` / `dropReference` bookkeeping stays balanced and previously-loaded instances aren't pinned in the identity map. The tracked `loaded` promise resolves rather than rejects, so callers awaiting it see a completed-with-errors render instead of an exception they would otherwise have to catch.
- `packages/base/query-field-support.ts` — new `surfaceSearchResourceErrorState` mirrors `searchResource.errors` onto the field's bucket as a typed sentinel. It tracks the sentinel it planted (`fieldState.surfacedErrorSentinel`, an identity handle) and the errors-array snapshot it acted on (`fieldState.surfacedErrorSource`), so it only clears bucket entries it owns — a hand-planted / deserialized / externally-set sentinel is left alone. Reading `searchResource.errors` here entangles the calling getter render with the resource's tracked failure channel; a later transition into or out of the errored state re-invokes the getter without further plumbing.
- `packages/base/card-api.gts` — `LinksTo.getter` and `LinksToMany.getter`, query branches: a bucket-check identical to the declared-`linksTo` recognition pattern already in place a few lines below. A terminal `link-error` / `link-not-found` sentinel surfaces as `undefined` (singular) or as the field's `emptyValue` (plural, an empty `WatchedArray`).
- `packages/base/field-support.ts` — `getBrokenLinks` skips `field.queryDefinition`. The legacy scan's purpose is to feed downstream consumers that still walk for declared-`linksTo` failures; with CS-11212 retiring its render-error escalation, this skip is belt-and-suspenders for any consumer that still consults `getBrokenLinks` directly.
- `packages/host/tests/integration/components/query-field-error-sentinel-test.gts` — end-to-end coverage via a mounted handler that fails `_federated-search` with 5xx / 404, plus hand-planted-sentinel cases that pin down the getter recognition for singular and plural, plus a `getBrokenLinks` negative test that pins down the scan-skip contract.

## Key decisions and non-obvious mechanics

- **The search task catches and publishes rather than re-throwing.** Rethrowing leaves the tracked `loaded` promise rejected and turns the failure into an unhandled exception in render-route callers, even though the resource has captured the same information on its `errors` channel. Catching makes the failure addressable as state (the sentinel + `getRelationship`) rather than as flow control, which matches how the declared-`linksTo` path already routes a failed fetch through `lazilyLoadLink`'s catch.
- **The plural getter surfaces the resource-level failure as a single whole-field sentinel, not per element.** A federated search either returns a result set or it doesn't — there is no "this slot failed but the others didn't" decomposition the way a declared `linksToMany` of explicit refs has. The plural getter recognizes the whole-field sentinel and returns the field's `emptyValue` (an empty `WatchedArray`); `getRelationship`'s existing whole-field `[relationshipStateForEntry(sentinel)]` wrap covers the read surface so callers branch uniformly on the array shape.
- **Surface tracks ownership of the bucket entry it planted.** A naïve "clear on no-errors" would race with hand-planted / deserialized / externally-set sentinels — surface runs on every getter invocation (including the first, before the search even starts), so a sentinel in the bucket before surface ever ran would be wiped. The identity-handle (`fieldState.surfacedErrorSentinel`) keeps the clear path strictly scoped to entries surface itself wrote. The `searchResource.errors` array-identity short-circuit (`fieldState.surfacedErrorSource`) is what makes the first call (errors === undefined on a fresh resource, source === undefined on a fresh fieldState) a no-op rather than a clear.
- **`getBrokenLinks` keeps its declared-`linksTo`-only contract.** With CS-11212 the legacy broken-link scan that escalated findings into `instance-error` is gone, but `getBrokenLinks` itself stays — its read surface is still consumed by direct callers (placeholder dispatch, AI tooling). Skipping query-field fields here keeps the read consistent: query-field failure surfaces only through `getRelationship`, never through a `getBrokenLinks` finding.
- **The bucket reference is a synthetic identifier (`${ownerId}#${fieldName}`) rather than a URL.** A query field has no single linked-card URL the way a declared `linksTo` does — the resource is the unit of failure, and the search URL itself is not the right reference either (a query that returns no rows isn't the same shape as a query that errored). The synthetic identifier is read by humans and by `getRelationship` consumers; it is never resolved as a URL.
- **`getRelationship` needed no query-field-specific branch.** It already routes through `peekAtField` → base getter → `relationshipStateForEntry`, which surfaces whatever the bucket holds. Once the producer plants a sentinel in the bucket, the existing path handles it — and the plural whole-field-sentinel wrap (the same path a computed `linksToMany` takes when its upstream is broken) covers the resource-level case.

## Diagnostic-only commits

The branch carries a handful of `DIAGNOSTIC (CS-11221)` commits that add `console.error` tracing in the search-task catch, surface, the getter sentinel short-circuit, and `getBrokenLinks` findings. These exist to give the CI log a clear trail while debugging the shard regressions and will be reverted before merge.
