### PR TITLE
linksToMany per-slot JS-access contract: Card | undefined

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1,7 +1,7 @@
 import Modifier from 'ember-modifier';
 import GlimmerComponent from '@glimmer/component';
 import { isEqual } from 'lodash';
-import { WatchedArray } from './watched-array';
+import { WatchedArray, rawArrayValues } from './watched-array';
 import { BoxelInput, CopyButton } from '@cardstack/boxel-ui/components';
 import {
   markdownEscape,
@@ -1690,39 +1690,26 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
       );
     }
 
-    let notLoadedRefs: string[] = [];
-    for (let entry of value) {
+    // Sentinels live in the backing array, but the WatchedArray hides them from
+    // userland per-slot access (`arr[i]` is `Card | undefined`). Scan the raw
+    // backing array — not the hiding proxy — so the not-loaded slots are still
+    // visible to kick off their lazy load.
+    let rawEntries = rawArrayValues(value);
+    let hasNotLoaded = false;
+    for (let entry of rawEntries) {
       if (isNotLoadedValue(entry)) {
-        notLoadedRefs = [...notLoadedRefs, entry.reference];
+        hasNotLoaded = true;
+        break;
       }
     }
-    if (notLoadedRefs.length > 0) {
-      // Important: we intentionally leave the NotLoadedValue sentinels inside the
-      // WatchedArray so the lazy loader can swap them out in place once the linked
-      // cards finish loading. Because the array identity never changes, Glimmer’s
-      // tracking sees the mutation and re-renders when lazilyLoadLink replaces each
-      // sentinel with a CardDef instance. Callers should treat these entries as
-      // placeholders (e.g. check for constructor.getComponent) rather than assuming
-      // every element is immediately renderable. Ideally the .value refactor can
-      // iron out this kink.
-      // TODO
-      // Codex has offered a couple interim solutions to ease the burden on card
-      // authors around this:
-      // We can wrap the guard in a reusable helper/component so card authors don’t
-      // have to think about the sentinel:
-      //
-      // - Helper – export something like `has-card-component` (just checks
-      //   `value?.constructor?.getComponent`) from card-api. Then in templates
-      //   they write: `{{#if (has-card-component card)}}…{{/if}}` or
-      //   `{{#each (filter-loadable cards) as |c|}}`.
-      //
-      // - Component – provide a `LoadableCard` component that takes a card instance
-      //   and renders the correct `CardContainer` only when the component is ready;
-      //   otherwise it renders nothing or a skeleton. Card authors use
-      //   `<LoadableCard @card={{card}}/>` instead of calling `getComponent`
-      //   themselves.
-
-      for (let entry of value) {
+    if (hasNotLoaded) {
+      // Each not-loaded sentinel stays in place so the lazy loader can swap it
+      // for the resolved card (success) or a terminal error/not-found sentinel
+      // (failure). The array identity never changes, so Glimmer re-renders on
+      // the in-place swap. A failed slot becomes terminal and surfaces as
+      // `undefined` per-slot — `getRelationship` is the only way to read its
+      // structured failure state.
+      for (let entry of rawEntries) {
         if (isNotLoadedValue(entry) && !(entry as any).loading) {
           lazilyLoadLink(instance, this, entry.reference, { value });
           (entry as any).loading = true;
@@ -1730,7 +1717,7 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
       }
     }
 
-    trackRuntimeRelationshipDependencies(value, this.card);
+    trackRuntimeRelationshipDependencies(rawEntries, this.card);
     return value as BaseInstanceType<FieldT>;
   }
 
@@ -1742,11 +1729,11 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
       return null;
     }
 
-    // Need to replace the WatchedArray proxy with an actual array because the
-    // WatchedArray proxy is not structuredClone-able, and hence cannot be
-    // communicated over the postMessage boundary between worker and DOM.
-    // TODO: can this be simplified since we don't have the worker anymore?
-    let results = [...instances]
+    // Read the raw backing array (not the hiding proxy) so a broken slot still
+    // serializes its reference into the queryable value rather than dropping out
+    // as `undefined`. Replacing the WatchedArray proxy with a plain array also
+    // keeps the result structuredClone-able for the postMessage boundary.
+    let results = rawArrayValues(instances)
       .map((instance) => {
         if (instance == null) {
           return null;
@@ -1806,7 +1793,9 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
       ? FileMetaResourceType
       : CardResourceType;
     let relationships: Record<string, Relationship> = {};
-    values.map((value, i) => {
+    // Iterate the raw backing array so broken slots serialize their reference
+    // through `serializeNonPresentLink` instead of collapsing to `data: null`.
+    rawArrayValues(values).map((value, i) => {
       if (value == null) {
         relationships[`${this.name}\.${i}`] = {
           links: {
@@ -2010,20 +1999,25 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
           notifyCardTracking(instance);
         }),
       await Promise.all(resources),
+      { hideSlot: isNonPresentLink },
     );
   }
 
   emptyValue(instance: BaseDef) {
-    return new WatchedArray((oldValue, value) => {
-      applySubscribersToInstanceValue(
-        instance,
-        this,
-        oldValue as BaseDef[],
-        value as BaseDef[],
-      );
-      notifySubscribers(instance, this.name, value);
-      notifyCardTracking(instance);
-    });
+    return new WatchedArray(
+      (oldValue, value) => {
+        applySubscribersToInstanceValue(
+          instance,
+          this,
+          oldValue as BaseDef[],
+          value as BaseDef[],
+        );
+        notifySubscribers(instance, this.name, value);
+        notifyCardTracking(instance);
+      },
+      [],
+      { hideSlot: isNonPresentLink },
+    );
   }
 
   validate(instance: BaseDef, values: any[] | null) {
@@ -2066,16 +2060,22 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
       }
     }
 
-    return new WatchedArray((oldValue, value) => {
-      applySubscribersToInstanceValue(
-        instance,
-        this,
-        oldValue as BaseDef[],
-        value as BaseDef[],
-      );
-      notifySubscribers(instance, this.name, value);
-      notifyCardTracking(instance);
-    }, values);
+    return new WatchedArray(
+      (oldValue, value) => {
+        applySubscribersToInstanceValue(
+          instance,
+          this,
+          oldValue as BaseDef[],
+          value as BaseDef[],
+        );
+        notifySubscribers(instance, this.name, value);
+        notifyCardTracking(instance);
+      },
+      // Read raw so re-assigning a field that already holds broken slots keeps
+      // the sentinels in the new backing array rather than baking in `undefined`.
+      rawArrayValues(values),
+      { hideSlot: isNonPresentLink },
+    );
   }
 
   captureQueryFieldSeedData(
@@ -3445,8 +3445,11 @@ function lazilyLoadLink(
       }
       if (pluralArgs) {
         let { value } = pluralArgs;
+        // Match against the raw backing array (the proxy hides not-loaded
+        // sentinels from index access); swap through the proxy so the in-place
+        // mutation notifies subscribers and Glimmer re-renders.
         let indices: number[] = [];
-        for (let [index, item] of value.entries()) {
+        for (let [index, item] of rawArrayValues(value).entries()) {
           if (!isNotLoadedValue(item)) {
             continue;
           }
@@ -3530,9 +3533,10 @@ function lazilyLoadLink(
         // Swap the sentinel into the slot(s) whose reference just failed,
         // leaving the WatchedArray identity intact so Glimmer re-renders. We
         // match the same not-loaded entries the success path would have
-        // replaced with the loaded card.
+        // replaced with the loaded card. Match against the raw backing array
+        // (the proxy hides sentinels) but write through the proxy to notify.
         let { value } = pluralArgs;
-        for (let [index, item] of value.entries()) {
+        for (let [index, item] of rawArrayValues(value).entries()) {
           if (!isNotLoadedValue(item)) {
             continue;
           }

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1795,7 +1795,7 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
     let relationships: Record<string, Relationship> = {};
     // Iterate the raw backing array so broken slots serialize their reference
     // through `serializeNonPresentLink` instead of collapsing to `data: null`.
-    rawArrayValues(values).map((value, i) => {
+    rawArrayValues(values).forEach((value, i) => {
       if (value == null) {
         relationships[`${this.name}\.${i}`] = {
           links: {

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -22,6 +22,7 @@ import {
   type SerializeOpts,
 } from './card-serialization';
 import { initSharedState } from './shared-state';
+import { rawArrayValues } from './watched-array';
 import { flatMap } from 'lodash';
 import { TrackedWeakMap } from 'tracked-built-ins';
 import type { ConfigurationInput, FieldConfiguration } from './card-api';
@@ -613,7 +614,12 @@ export function getRelationship<T extends CardDef = CardDef>(
         `expected ${fieldName} to be an array but was ${typeof related}`,
       );
     }
-    return related.map((entry) => relationshipStateForEntry<T>(entry));
+    // Read the raw backing array: per-slot index access hides the broken-link
+    // sentinels (surfacing them as `undefined`), but `getRelationship` is the
+    // typed surface whose whole job is to report each slot's true state.
+    return rawArrayValues(related).map((entry) =>
+      relationshipStateForEntry<T>(entry),
+    );
   }
 
   return relationshipStateForEntry<T>(related);
@@ -760,9 +766,7 @@ export function relationshipMeta(
   return toLegacyRelationshipMeta(state);
 }
 
-function toLegacyRelationshipMeta(
-  state: RelationshipState,
-): RelationshipMeta {
+function toLegacyRelationshipMeta(state: RelationshipState): RelationshipMeta {
   // Legacy callers only branched on 'loaded' vs 'not-loaded'; the new error /
   // not-found kinds did not exist when the contract was written. Map them to
   // 'not-loaded' so existing consumers see a stable shape until migration.

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -18,6 +18,7 @@ import {
 } from './card-api';
 import BrokenLinkTemplate from './default-templates/broken-link-template';
 import { getRelationship, type RelationshipState } from './field-support';
+import { rawArrayValues } from './watched-array';
 import {
   BoxComponentSignature,
   DefaultFormatsConsumer,
@@ -120,10 +121,16 @@ class LinksToManyEditor extends GlimmerComponent<Signature> {
         fileType ? { fileType, fileTypeName } : undefined,
       );
       if (file) {
-        let selectedCards =
-          (this.args.model.value as any)[this.args.field.name] ?? [];
-        selectedCards = [...selectedCards, file];
-        (this.args.model.value as any)[this.args.field.name] = selectedCards;
+        // Rebuild from the raw backing array so any broken sibling slot keeps
+        // its sentinel instead of collapsing to `undefined` (per-slot reads are
+        // masked). The new file is appended after the existing entries.
+        let existing = rawArrayValues(
+          (this.args.model.value as any)[this.args.field.name] ?? [],
+        );
+        (this.args.model.value as any)[this.args.field.name] = [
+          ...existing,
+          file,
+        ];
       }
       return;
     }
@@ -162,16 +169,31 @@ class LinksToManyEditor extends GlimmerComponent<Signature> {
         isCardInstance(card),
       ) as CardDef[];
       if (newCards.length > 0) {
-        selectedCards = [...selectedCards, ...newCards];
-        (this.args.model.value as any)[this.args.field.name] = selectedCards;
+        // `selectedCards` above is the masked read used only to build the
+        // already-selected query filter. Rebuild the field from the raw backing
+        // array so broken sibling slots keep their sentinels rather than
+        // collapsing to `undefined` on append.
+        let existing = rawArrayValues(
+          (this.args.model.value as any)[this.args.field.name] ?? [],
+        );
+        (this.args.model.value as any)[this.args.field.name] = [
+          ...existing,
+          ...newCards,
+        ];
       }
     }
   });
 
   remove = (index: number) => {
-    let cards = (this.args.model.value as any)[this.args.field.name];
-    cards = cards.filter((_c: CardDef, i: number) => i !== index);
-    (this.args.model.value as any)[this.args.field.name] = cards;
+    // Drop the slot by position on the raw backing array so the other slots —
+    // including any broken sentinels — are preserved verbatim. Filtering the
+    // masked field value would turn every other broken slot into `undefined`.
+    let raw = rawArrayValues(
+      (this.args.model.value as any)[this.args.field.name] ?? [],
+    );
+    (this.args.model.value as any)[this.args.field.name] = raw.filter(
+      (_c: CardDef, i: number) => i !== index,
+    );
   };
 }
 
@@ -211,11 +233,18 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
     // still keys on the stable index `key`, so adding this never changes block
     // identity and an input elsewhere in the edit form keeps focus.
     let broken = brokenSlotsFor(this.args.model, this.args.field.name);
+    // `raw` is the per-slot backing value handed to ember-sortable as its item
+    // model. A broken slot's masked value is `undefined` (non-unique and lossy
+    // across a reorder), so we pass the raw entry — the card for a present slot,
+    // the sentinel object for a broken one — as an opaque, stable token. This is
+    // never inspected here; it only keeps reorder from dropping broken slots.
+    let raw = rawArrayValues(this.args.arrayField.value ?? []);
     return this.args.arrayField.children.map((child, index) => ({
       box: child,
       index,
       key: index,
       broken: broken[index],
+      raw: raw[index],
     }));
   }
 
@@ -239,10 +268,7 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
             <li
               class='editor {{if permissions.canWrite "can-write" "read-only"}}'
               data-test-item={{entry.index}}
-              {{sortableItem
-                groupName=this.sortableGroupId
-                model=entry.box.value
-              }}
+              {{sortableItem groupName=this.sortableGroupId model=entry.raw}}
             >
               {{#if permissions.canWrite}}
                 <IconButton

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -188,11 +188,11 @@ class LinksToManyEditor extends GlimmerComponent<Signature> {
     // Drop the slot by position on the raw backing array so the other slots —
     // including any broken sentinels — are preserved verbatim. Filtering the
     // masked field value would turn every other broken slot into `undefined`.
-    let raw = rawArrayValues(
+    let raw = rawArrayValues<CardDef>(
       (this.args.model.value as any)[this.args.field.name] ?? [],
     );
     (this.args.model.value as any)[this.args.field.name] = raw.filter(
-      (_c: CardDef, i: number) => i !== index,
+      (_c, i) => i !== index,
     );
   };
 }

--- a/packages/base/watched-array.ts
+++ b/packages/base/watched-array.ts
@@ -1,8 +1,10 @@
 // Reading `proxy[rawValues]` returns the underlying backing array with every
-// slot intact — including the link sentinels that the index getter hides from
-// userland. Only the link-aware modules in `packages/base` (card-api.gts,
-// field-support.ts) read through this to inspect or swap sentinels; everything
-// else sees the `Card | undefined` per-slot surface.
+// slot intact — including any values the index getter hides from userland.
+// `WatchedArray` is generic: when a `hideSlot` predicate is supplied the masked
+// per-slot surface is `T | undefined` (for the `linksToMany` caller, that is
+// `Card | undefined`); without one the array is unmasked. Only the link-aware
+// modules in `packages/base` (card-api.gts, field-support.ts) read through this
+// escape hatch to inspect or swap the hidden values.
 export const rawValues = Symbol.for('@cardstack/watched-array:raw-values');
 
 // Return the raw backing array for a value that may be a `WatchedArray` proxy
@@ -53,9 +55,11 @@ class WatchedArray<T> {
         }
         if (hideSlot !== undefined) {
           let index = arrayIndex(prop);
-          if (index !== undefined) {
-            let value = target[index];
-            if (hideSlot(value)) {
+          // Only consult the predicate for indices that actually hold a value;
+          // an out-of-range read (`arr[999]`) falls straight through to
+          // `undefined` without handing the predicate a missing slot.
+          if (index !== undefined && index < target.length) {
+            if (hideSlot(target[index])) {
               return undefined;
             }
           }

--- a/packages/base/watched-array.ts
+++ b/packages/base/watched-array.ts
@@ -1,12 +1,67 @@
+// Reading `proxy[rawValues]` returns the underlying backing array with every
+// slot intact — including the link sentinels that the index getter hides from
+// userland. Only the link-aware modules in `packages/base` (card-api.gts,
+// field-support.ts) read through this to inspect or swap sentinels; everything
+// else sees the `Card | undefined` per-slot surface.
+export const rawValues = Symbol.for('@cardstack/watched-array:raw-values');
+
+// Return the raw backing array for a value that may be a `WatchedArray` proxy
+// or an ordinary array. A plain array has no `rawValues` slot, so it is returned
+// as-is; a `WatchedArray` returns its sentinel-bearing backing store.
+export function rawArrayValues<T>(value: ArrayLike<T>): T[] {
+  let raw = (value as any)?.[rawValues];
+  return (raw ?? value) as T[];
+}
+
+interface WatchedArrayOptions<T> {
+  // When provided, a numeric-index read whose backing value satisfies this
+  // predicate resolves to `undefined` instead of the stored value. The value
+  // remains in the backing array (so `length`, iteration count, and in-place
+  // swaps are unaffected); it is simply never handed to userland through `[i]`.
+  hideSlot?: (value: T) => boolean;
+}
+
+function arrayIndex(prop: string | symbol): number | undefined {
+  if (typeof prop !== 'string') {
+    return undefined;
+  }
+  let n = Number(prop);
+  // Canonical array indices only: non-negative integers whose string form round
+  // -trips (rules out '01', '1.0', '-1', 'length', etc.).
+  if (Number.isInteger(n) && n >= 0 && String(n) === prop) {
+    return n;
+  }
+  return undefined;
+}
+
 class WatchedArray<T> {
   constructor(
     subscriber: (oldArr: Array<T>, arr: Array<T>) => void,
     arr: T[] = [],
+    opts: WatchedArrayOptions<T> = {},
   ) {
     this.#subscriber = subscriber;
+    let { hideSlot } = opts;
     let clone = arr.slice();
     let self = this;
     return new Proxy(clone, {
+      get(target, prop, receiver) {
+        // Escape hatch for the link-aware base modules: hand back the raw
+        // backing array so they can read/swap sentinels directly.
+        if (prop === rawValues) {
+          return target;
+        }
+        if (hideSlot !== undefined) {
+          let index = arrayIndex(prop);
+          if (index !== undefined) {
+            let value = target[index];
+            if (hideSlot(value)) {
+              return undefined;
+            }
+          }
+        }
+        return Reflect.get(target, prop, receiver);
+      },
       set(target, prop, value /*, _receiver */) {
         let prevValues = [...target];
         (target as any)[prop] = value;

--- a/packages/host/tests/acceptance/prerender-html-test.gts
+++ b/packages/host/tests/acceptance/prerender-html-test.gts
@@ -179,7 +179,9 @@ module('Acceptance | prerender | html', function (hooks) {
       @field friendsOfFriend = linksToMany(() => Person, {
         computeVia(this: Person) {
           if (Array.isArray(this.friends) && this.friends.length > 0) {
-            return this.friends[0].friends;
+            // Per-slot access is `Card | undefined`: a not-loaded/broken first
+            // slot reads as `undefined`, so optional-chain before traversing.
+            return this.friends[0]?.friends;
           }
           return [];
         },

--- a/packages/host/tests/integration/components/linksto-error-sentinel-test.gts
+++ b/packages/host/tests/integration/components/linksto-error-sentinel-test.gts
@@ -362,15 +362,15 @@ module('Integration | linksTo error sentinel producer', function (hooks) {
 
     // Both slots load concurrently; wait until neither is still in-flight so
     // the good slot has resolved to a card and the broken one to a sentinel.
+    // Per-slot index access is masked to `Card | undefined`, so settle on the
+    // typed `getRelationship` surface rather than probing the array for shapes.
     await waitUntil(() => {
-      let arr = getDataBucket(person).get('pets');
-      if (!Array.isArray(arr)) {
+      let states = getRelationship(person, 'pets');
+      if (!Array.isArray(states)) {
         return false;
       }
-      let stillLoading = arr.some(
-        (e: any) => e?.type === 'not-loaded' || e?.loading,
-      );
-      return !stillLoading && arr.some((e: any) => isLinkNotFound(e));
+      let kinds = states.map((s) => s.kind);
+      return !kinds.includes('not-loaded') && kinds.includes('not-found');
     });
 
     let arrayAfter = getDataBucket(person).get('pets');

--- a/packages/host/tests/integration/components/linksto-many-broken-link-placeholder-test.gts
+++ b/packages/host/tests/integration/components/linksto-many-broken-link-placeholder-test.gts
@@ -406,5 +406,78 @@ module(
         .dom('[data-test-broken-link-template]')
         .exists({ count: 1 }, 'the broken placeholder is still in place');
     });
+
+    test('removing a present sibling preserves a broken element in the list', async function (assert) {
+      await setupRealm();
+      // Present / broken / present. Removing the FIRST present slot must not
+      // disturb the broken middle slot — the per-slot read mask turns broken
+      // slots into `undefined`, so a naive array rebuild would silently drop the
+      // broken reference. The editor rebuilds from the raw backing array instead.
+      let person = await createPerson({
+        'pets.0': { links: { self: MANGO_URL } },
+        'pets.1': { links: { self: GHOST_URL } },
+        'pets.2': { links: { self: VANGOGH_URL } },
+      });
+
+      await renderCard(loader, person, 'edit');
+      await waitFor('[data-test-broken-link-template]');
+      await waitFor('[data-test-item="0"] [data-test-pet]');
+      await waitFor('[data-test-item="2"] [data-test-pet]');
+
+      // Remove the present slot at index 0 (Mango).
+      await click('[data-test-remove="0"]');
+      await waitUntil(
+        () => document.querySelectorAll('[data-test-pet]').length === 1,
+      );
+
+      // The broken slot survived — its placeholder and broken URL are intact —
+      // and the other present sibling (Van Gogh) remains.
+      assert
+        .dom('[data-test-broken-link-template]')
+        .exists(
+          { count: 1 },
+          'the broken element is preserved after removing a present sibling',
+        );
+      assert
+        .dom('[data-test-broken-link-url]')
+        .hasText(GHOST_URL, 'the broken reference is not lost on removal');
+      assert
+        .dom('[data-test-pet]')
+        .exists({ count: 1 }, 'the surviving present sibling still renders');
+      assert.dom('[data-test-pet]').hasText('Van Gogh');
+    });
+
+    test('typing into a sibling field while a broken element is present keeps input focus', async function (assert) {
+      await setupRealm();
+      let person = await createPerson({
+        'pets.0': { links: { self: MANGO_URL } },
+        'pets.1': { links: { self: GHOST_URL } },
+      });
+
+      await renderCard(loader, person, 'edit');
+      await waitFor('[data-test-broken-link-template]');
+      await waitFor('[data-test-pet]');
+
+      // Capture the firstName input node, then type into it. If the broken slot
+      // destabilized the edit form, this subtree would re-create and the input
+      // node would be replaced — `document.activeElement` would no longer be the
+      // node we captured, i.e. focus would have been stolen mid-edit.
+      let inputBefore = document.querySelector('[data-test-name-field] input');
+      await fillIn('[data-test-name-field] input', 'Hassan A.');
+
+      assert.strictEqual(
+        document.querySelector('[data-test-name-field] input'),
+        inputBefore,
+        'the firstName input keeps its DOM identity across the re-render',
+      );
+      assert.strictEqual(
+        document.activeElement,
+        inputBefore,
+        'focus stays on the firstName input — the broken slot does not steal it',
+      );
+      assert
+        .dom('[data-test-broken-link-template]')
+        .exists({ count: 1 }, 'the broken placeholder is still in place');
+    });
   },
 );

--- a/packages/host/tests/integration/components/linksto-many-per-slot-access-test.gts
+++ b/packages/host/tests/integration/components/linksto-many-per-slot-access-test.gts
@@ -1,0 +1,345 @@
+import { waitUntil } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import {
+  baseRealm,
+  PermissionsContextName,
+  type LooseCardResource,
+  type Permissions,
+  type SerializedError,
+} from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import type {
+  CardDef as CardDefType,
+  RelationshipState as RelationshipStateType,
+} from 'https://cardstack.com/base/card-api';
+
+import {
+  provideConsumeContext,
+  saveCard,
+  setupCardLogs,
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  testRealmURL,
+  testRRI,
+} from '../../helpers';
+import {
+  CardDef,
+  FieldDef,
+  contains,
+  field,
+  getDataBucket,
+  getRelationship,
+  linksToMany,
+  setupBaseRealm,
+  StringField,
+} from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+const MANGO_URL = `${testRealmURL}Pet/mango`;
+const VANGOGH_URL = `${testRealmURL}Pet/vangogh`;
+const GHOST_URL = `${testRealmURL}Pet/ghost`;
+const EXPLODED_URL = `${testRealmURL}Pet/exploded`;
+
+function errorDoc(message: string, status = 500): SerializedError {
+  return { status, message, additionalErrors: null };
+}
+
+function notFoundSentinel(reference: string) {
+  return {
+    type: 'link-not-found' as const,
+    reference,
+    errorDoc: errorDoc(`missing file ${reference}`, 404),
+  };
+}
+
+function linkErrorSentinel(reference: string) {
+  return {
+    type: 'link-error' as const,
+    reference,
+    errorDoc: errorDoc('upstream exploded', 500),
+  };
+}
+
+module(
+  'Integration | linksToMany per-slot JS-access contract',
+  function (hooks) {
+    let loader: Loader;
+
+    setupRenderingTest(hooks);
+    setupBaseRealm(hooks);
+    setupLocalIndexing(hooks);
+
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+      activeRealms: [testRealmURL],
+      autostart: true,
+    });
+
+    hooks.beforeEach(function () {
+      let permissions: Permissions = { canWrite: true, canRead: true };
+      provideConsumeContext(PermissionsContextName, permissions);
+      loader = getService('loader-service').loader;
+    });
+
+    setupCardLogs(
+      hooks,
+      async () => await loader.import(`${baseRealm.url}card-api`),
+    );
+
+    // Build a Person whose `pets` array holds two present cards (Mango, Van Gogh)
+    // and one broken slot wedged between them, so the "siblings render normally"
+    // claim is about the middle slot, not an edge. The broken slot is planted
+    // directly as a terminal sentinel (assigned through the field setter, the
+    // real userland write path) so the test never depends on lazy-load timing.
+    async function makeMixedPerson(brokenSlot: object) {
+      class Pet extends CardDef {
+        static displayName = 'Pet';
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        static displayName = 'Person';
+        @field firstName = contains(StringField);
+        @field pets = linksToMany(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let mango = new Pet({ firstName: 'Mango' });
+      let vangogh = new Pet({ firstName: 'Van Gogh' });
+      await saveCard(mango, MANGO_URL, loader);
+      await saveCard(vangogh, VANGOGH_URL, loader);
+
+      let person = new Person({ firstName: 'Hassan' });
+      (person as any).pets = [mango, brokenSlot, vangogh];
+      return { person, mango, vangogh };
+    }
+
+    test('present slots are the card, a not-found slot is undefined, length includes the broken slot', async function (assert) {
+      let { person, mango, vangogh } = await makeMixedPerson(
+        notFoundSentinel(GHOST_URL),
+      );
+      let pets = (person as any).pets;
+
+      assert.strictEqual(pets.length, 3, 'length counts the broken slot');
+      assert.strictEqual(pets[0], mango, 'present slot 0 is the card');
+      assert.strictEqual(pets[2], vangogh, 'present slot 2 is the card');
+      assert.strictEqual(
+        pets[1],
+        undefined,
+        'the not-found slot reads as undefined, never the sentinel',
+      );
+    });
+
+    test('a link-error slot is also undefined per-slot', async function (assert) {
+      let { person, mango, vangogh } = await makeMixedPerson(
+        linkErrorSentinel(EXPLODED_URL),
+      );
+      let pets = (person as any).pets;
+
+      assert.strictEqual(pets[0], mango);
+      assert.strictEqual(pets[2], vangogh);
+      assert.strictEqual(
+        pets[1],
+        undefined,
+        'the error slot reads as undefined, never the sentinel',
+      );
+    });
+
+    test('repeated reads of a terminal slot return undefined consistently', async function (assert) {
+      let { person } = await makeMixedPerson(notFoundSentinel(GHOST_URL));
+      let pets = (person as any).pets;
+
+      assert.strictEqual(pets[1], undefined, 'first read');
+      assert.strictEqual(pets[1], undefined, 'second read');
+      assert.strictEqual(pets[1], undefined, 'third read');
+      // The slot never re-triggers a load, so its structured failure is still
+      // readable through the typed surface — it is hidden, not erased.
+      let states = getRelationship(person, 'pets') as RelationshipStateType[];
+      assert.strictEqual(states[1].kind, 'not-found');
+      assert.strictEqual(states[1].reference, GHOST_URL);
+    });
+
+    test('iteration with a c == null guard skips the broken slot and keeps the siblings', async function (assert) {
+      let { person } = await makeMixedPerson(notFoundSentinel(GHOST_URL));
+      let pets = (person as any).pets;
+
+      let names: string[] = [];
+      for (let c of pets) {
+        if (c == null) {
+          continue;
+        }
+        names.push((c as CardDefType & { firstName: string }).firstName);
+      }
+      assert.deepEqual(
+        names,
+        ['Mango', 'Van Gogh'],
+        'one broken element does not break iteration over its siblings',
+      );
+    });
+
+    test('map with optional chaining yields undefined for the broken slot; map without it throws', async function (assert) {
+      let { person } = await makeMixedPerson(notFoundSentinel(GHOST_URL));
+      let pets = (person as any).pets as ({ firstName: string } | undefined)[];
+
+      assert.deepEqual(
+        pets.map((c) => c?.firstName),
+        ['Mango', undefined, 'Van Gogh'],
+        'optional chaining surfaces undefined for the broken slot',
+      );
+      assert.throws(
+        () => pets.map((c) => (c as { firstName: string }).firstName),
+        /Cannot read properties of undefined/,
+        'a non-optional read throws on the broken slot per ordinary JS semantics',
+      );
+    });
+
+    test('a broken slot nested in a contained FieldDef surfaces as undefined; siblings render', async function (assert) {
+      class Tag extends CardDef {
+        static displayName = 'Tag';
+        @field name = contains(StringField);
+      }
+      class TagSet extends FieldDef {
+        static displayName = 'TagSet';
+        @field items = linksToMany(Tag);
+      }
+      class Post extends CardDef {
+        static displayName = 'Post';
+        @field tags = contains(TagSet);
+      }
+      loader.shimModule(`${testRealmURL}nested-cards`, { Post, TagSet, Tag });
+
+      let red = new Tag({ name: 'red' });
+      let blue = new Tag({ name: 'blue' });
+      await saveCard(red, `${testRealmURL}Tag/red`, loader);
+      await saveCard(blue, `${testRealmURL}Tag/blue`, loader);
+
+      let post = new Post();
+      (post as any).tags.items = [red, notFoundSentinel(GHOST_URL), blue];
+
+      let items = (post as any).tags.items;
+      assert.strictEqual(items.length, 3, 'length counts the broken slot');
+      assert.strictEqual(items[0], red, 'present nested slot 0 is the card');
+      assert.strictEqual(items[2], blue, 'present nested slot 2 is the card');
+      assert.strictEqual(
+        items[1],
+        undefined,
+        'the broken nested slot surfaces as undefined in card.tags.items[i]',
+      );
+    });
+
+    // The seeded tests above prove the hiding contract for terminal slots
+    // deterministically. This one drives the real `lazilyLoadLink` failure path
+    // end to end: an unresolved reference starts as `not-loaded` (also hidden),
+    // the read kicks off the fetch, it 404s, and the slot settles to a terminal
+    // not-found — staying `undefined` throughout, with the sibling resolving.
+    test('a not-loaded slot reads undefined, drives the load, and stays undefined once it fails', async function (assert) {
+      class Pet extends CardDef {
+        static displayName = 'Pet';
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        static displayName = 'Person';
+        @field firstName = contains(StringField);
+        @field pets = linksToMany(Pet);
+      }
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {
+          'test-cards.gts': { Person, Pet },
+          'Pet/mango.json': {
+            data: {
+              attributes: { firstName: 'Mango' },
+              meta: {
+                adoptsFrom: { module: testRRI('test-cards'), name: 'Pet' },
+              },
+            },
+          },
+        },
+      });
+
+      let store = getService('store');
+      let resource: LooseCardResource = {
+        attributes: { firstName: 'Hassan' },
+        relationships: {
+          'pets.0': { links: { self: MANGO_URL } },
+          'pets.1': { links: { self: GHOST_URL } },
+        },
+        meta: { adoptsFrom: { module: testRRI('test-cards'), name: 'Person' } },
+      };
+      let person = (await store.__dangerousCreateFromSerialized(
+        resource,
+        { data: resource },
+        new URL(testRealmURL),
+      )) as CardDefType & { pets: ({ firstName: string } | undefined)[] };
+
+      // First read returns the array (length 2) with both slots hidden while the
+      // loads are in flight, and kicks off lazilyLoadLink for each.
+      assert.strictEqual(person.pets.length, 2, 'length includes both slots');
+      assert.strictEqual(
+        person.pets[1],
+        undefined,
+        'a not-loaded slot reads as undefined',
+      );
+
+      // Wait until the broken reference settles to a terminal not-found and the
+      // present sibling has resolved to its card.
+      await waitUntil(() => {
+        let states = getRelationship(person, 'pets') as RelationshipStateType[];
+        return states[0]?.kind === 'present' && states[1]?.kind === 'not-found';
+      });
+
+      assert.strictEqual(
+        person.pets[0]?.firstName,
+        'Mango',
+        'the present sibling resolves to its card',
+      );
+      assert.strictEqual(
+        person.pets[1],
+        undefined,
+        'the failed slot stays undefined — terminal, never the sentinel',
+      );
+
+      // The data bucket still holds the terminal sentinel even though per-slot
+      // access hides it, so the structured failure remains readable.
+      let bucket = getDataBucket(person).get('pets');
+      assert.strictEqual(
+        bucket.length,
+        2,
+        'the backing array still has both slots',
+      );
+    });
+
+    test('a list of only present links exposes every slot as its card', async function (assert) {
+      class Pet extends CardDef {
+        static displayName = 'Pet';
+        @field firstName = contains(StringField);
+      }
+      class Person extends CardDef {
+        static displayName = 'Person';
+        @field firstName = contains(StringField);
+        @field pets = linksToMany(Pet);
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Pet });
+
+      let mango = new Pet({ firstName: 'Mango' });
+      let vangogh = new Pet({ firstName: 'Van Gogh' });
+      await saveCard(mango, MANGO_URL, loader);
+      await saveCard(vangogh, VANGOGH_URL, loader);
+      let person = new Person({ firstName: 'Hassan', pets: [mango, vangogh] });
+
+      let pets = (person as any).pets;
+      assert.strictEqual(pets.length, 2);
+      assert.strictEqual(pets[0], mango);
+      assert.strictEqual(pets[1], vangogh);
+      assert.deepEqual(
+        pets.map((c: any) => c.firstName),
+        ['Mango', 'Van Gogh'],
+        'a healthy list reads cleanly with a non-optional map',
+      );
+    });
+  },
+);

--- a/packages/host/tests/integration/components/linksto-sentinel-roundtrip-test.gts
+++ b/packages/host/tests/integration/components/linksto-sentinel-roundtrip-test.gts
@@ -267,9 +267,13 @@ module(
         'pets.1': { links: { self: GHOST } },
       });
       broken.pets; // triggers lazy loads for both slots
+      // Per-slot index access is masked to `Card | undefined`, so observe the
+      // planted broken state through the typed `getRelationship` surface.
       await waitUntil(() => {
-        let arr = bucketEntry(broken, 'pets');
-        return Array.isArray(arr) && arr.some((e: any) => isLinkNotFound(e));
+        let states = getRelationship(broken, 'pets');
+        return (
+          Array.isArray(states) && states.some((s) => s.kind === 'not-found')
+        );
       });
 
       let notLoaded = await createPerson({


### PR DESCRIPTION
## Background and Goal

A plural `linksToMany` field whose elements failed to load held *link sentinels*
(`not-loaded` / `link-error` / `link-not-found`) directly inside its
`WatchedArray`. Reading `arr[i]` handed those sentinel objects to userland, so
every consumer had to recognize and skip them to render a list.

This pins down the per-slot accessor contract: `arr[i]` is now `Card | undefined`
— never a sentinel.

- **Present** slot → `arr[i] === <the card>`
- **Not-loaded** slot → `arr[i] === undefined`, and the read triggers its lazy load
- **Error / Not-found** slot → `arr[i] === undefined`, terminal (no retrigger)
- `arr.length` still counts every slot, including broken ones
- Iteration / `map` surface `undefined` for broken slots, so
  `for (const c of arr) if (c == null) continue;` skips them and
  `arr.map(c => c?.name)` yields `undefined` per broken slot
- The in-place sentinel swap on lazy-load completion is preserved, so Glimmer
  still re-renders

## Where to start

- `packages/base/watched-array.ts` — the `Proxy` now takes an optional `hideSlot`
  predicate; a numeric-index read whose backing value matches resolves to
  `undefined`. The sentinel stays in the backing array (so `length`, iteration
  count, and in-place swaps are unaffected). A `rawValues` symbol / `rawArrayValues`
  helper hands the backing array to the link-aware base modules.
- `packages/base/card-api.gts` — `LinksToMany` builds its `WatchedArray` with
  `hideSlot: isNonPresentLink`; the not-loaded scan, `serialize`,
  `queryableValue`, and the `lazilyLoadLink` swap loops read the raw backing
  array so they still observe and swap sentinels.
- `packages/base/field-support.ts` — `getRelationship` reads the raw backing
  array, remaining the typed surface that reports each slot's true state (the
  render path's broken-link placeholder reads through it, not through `arr[i]`).

## Key decisions

- **Hide via the proxy, keep sentinels in the backing array.** The contract is a
  read concern; the sentinels still drive lazy-load swaps, serialization, and
  `getRelationship`, so they must remain stored. Only per-slot index access is
  masked.
- **`hideSlot` is injected, not imported.** `WatchedArray` stays generic and link
  -agnostic; `card-api` supplies `isNonPresentLink`, avoiding a
  `watched-array → field-support → card-api` import cycle. `containsMany` arrays
  pass no predicate and are unaffected.
- **Raw access is confined to the three link-aware base modules.** No test or
  production code outside `card-api.gts`, `field-support.ts`, and
  `watched-array.ts` observes a sentinel through per-slot access.

Closes CS-11220.
