### PR TITLE
Skip software-factory in realm-server test startup

### DIFF
--- a/mise-tasks/test-services/realm-server
+++ b/mise-tasks/test-services/realm-server
@@ -32,11 +32,12 @@ WAIT_ON_TIMEOUT=900000 \
   SKIP_CATALOG=true \
   SKIP_BOXEL_HOMEPAGE=true \
   SKIP_SUBMISSION=true \
+  SKIP_SOFTWARE_FACTORY=true \
   NODE_NO_WARNINGS=1 \
   START_SERVER_AND_TEST_INSECURE=1 \
   start-server-and-test \
     'run-p -ln start:icons start:host-dist start:pg start:prerender-dev start:prerender-manager-dev start:matrix start:smtp start:worker-development start:development' \
-    "${BASE_REALM_READY}|${REALM_READY_SCHEME}://${REALM_BASE_URL#*://}/software-factory/${READY_PATH}|${MATRIX_URL_VAL}|http://localhost:5001|${ICONS_URL}|${HOST_URL}" \
+    "${BASE_REALM_READY}|${MATRIX_URL_VAL}|http://localhost:5001|${ICONS_URL}|${HOST_URL}" \
     'run-p -ln start:worker-test start:test-realms' \
     "${NODE_TEST_REALM_READY}" \
     'wait'


### PR DESCRIPTION
## Background and Goal

The realm-server test-services startup hosts the `software-factory` realm and waits on its readiness, even though the realm-server test suite never exercises it (no references under `packages/realm-server/tests`). The realm-server full-indexes every hosted realm serially at boot under `--migrateDB`, so hosting software-factory adds its from-scratch-index cost to startup and puts it on the wait-on critical path — for no test coverage. The suite already skips catalog / experiments / boxel-homepage / submission for exactly this reason; software-factory was just never added to the list.

This mirrors the host test-services change already on `main` (the live-test job stopped hosting/waiting on software-factory and uses the small skills realm as its empty placeholder instead).

## Where to start

- `mise-tasks/test-services/realm-server` — adds `SKIP_SOFTWARE_FACTORY=true` and drops the software-factory readiness URL from the `start-server-and-test` wait list. The `SKIP_SOFTWARE_FACTORY` gate it relies on already exists in `mise-tasks/services/realm-server`.

## Key decisions

- **Reuse the existing `SKIP_SOFTWARE_FACTORY` gate** rather than introduce a new mechanism — it's the same flag the host test-services task uses, in the same shape as `SKIP_CATALOG`.
- **No timeout change.** This task already allows `WAIT_ON_TIMEOUT=900000` (15 min); dropping a realm from startup only reduces the time needed, so the existing budget stays.
