### PR TITLE
test: abort hung test-env realm fetches so a vanished CI request retries instead of timing out

### DIFF
--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -200,9 +200,37 @@ export class VirtualNetwork {
     });
 
     return withRetries(new URL(request.url), () =>
-      fetcher(this.nativeFetch, handlers)(request, init),
+      fetcher(this.timedFetch, handlers)(request, init),
     );
   }
+
+  // Native fetch wrapped with a per-call abort watchdog for the retryable
+  // test-env hosts (see shouldRetryFetch / withRetries). A lost
+  // localhost:4201/base/* request sometimes arrives not as a `TypeError: Failed
+  // to fetch` — which withRetries already catches and retries — but as a
+  // connection that is accepted and then never answered: the fetch promise
+  // neither resolves nor rejects. That leaves the `fetcher` test-waiter open
+  // forever, so `settled()` never returns and the test dies with an opaque 60s
+  // QUnit timeout. Aborting the attempt turns the hang into a TimeoutError that
+  // propagates through `fetcher` (releasing the waiter) and into the retry loop,
+  // so a transient stall recovers instead of timing out the whole test. Gated on
+  // `__environment === 'test'`, so production fetch behaviour is unchanged.
+  // `fetcher` always hands the inner fetch a freshly cloned Request, so
+  // overriding its signal here can never disturb a body a retry will reuse.
+  private timedFetch: typeof globalThis.fetch = (input, init) => {
+    if (
+      (globalThis as any).__environment === 'test' &&
+      input instanceof Request
+    ) {
+      let url = new URL(input.url);
+      if (shouldRetryFetch(url)) {
+        input = new Request(input, {
+          signal: AbortSignal.timeout(perAttemptTimeoutMs),
+        });
+      }
+    }
+    return this.nativeFetch(input, init);
+  };
 
   // This method is used to handle the boundary between the real and virtual network,
   // when a request is made to the realm from the realm server - it maps requests
@@ -286,6 +314,12 @@ export function isUrlLike(moduleIdentifier: string): boolean {
 // behaviour is unaffected.
 const maxAttempts = 10;
 const backOffMs = 100;
+// Per-attempt watchdog for the retryable test-env hosts below. Bounds how long a
+// single attempt may stay in flight before it is aborted into a (retryable)
+// TimeoutError — see `timedFetch`. Sized generously above any real CI response
+// time (these reads are sub-second normally) while leaving several attempts'
+// worth of headroom inside QUnit's 60s per-test budget.
+const perAttemptTimeoutMs = 15_000;
 const retryableLocalHosts = new Set(['localhost', '127.0.0.1']);
 
 function shouldRetryFetch(url: URL) {
@@ -326,9 +360,9 @@ async function withRetries(
         throw err;
       }
       console.error(
-        `Encountered fetch failed for ${
-          url.href
-        } retry attempt #${attempt} in ${attempt * backOffMs}ms`,
+        `Encountered fetch failed for ${url.href} (${
+          err?.name ?? 'Error'
+        }) retry attempt #${attempt} in ${attempt * backOffMs}ms`,
       );
       await new Promise((r) => setTimeout(r, attempt * backOffMs));
     }


### PR DESCRIPTION
## Background and Goal

The `code-submode | field playground` acceptance tests that drive the "Fill in Sample Data with AI" / "Generate examples with AI" flow intermittently die with a bare `Test took longer than 60000ms; test timed out.` in CI.

The timeout diagnostics already in `tests/helpers/setup.ts` pinned the cause exactly: at the moment QUnit gave up, a single fetch was still in flight —

```
in-flight fetches at rejection time (1):
  QUERY https://localhost:4201/base/_info
settled state: hasRunLoop=false hasPendingWaiters=true ...
pending test waiters (1):
  fetcher (2): at TestWaiterImpl.beginAsync ...
```

A base-realm `_info` request was **accepted and then never answered** — the fetch promise neither resolved nor rejected. The `fetcher` middleware brackets every fetch with a test waiter (`beginAsync`/`endAsync` in a `finally`), so a fetch that never settles holds that waiter open forever, `settled()` never returns, and the test burns the full 60s.

This is the same CI "base-realm fetches vanish" class the existing `withRetries` loop in `virtual-network.ts` already accommodates — but that loop only retries fetches that **reject**. A fetch that **hangs** never enters its `catch`, so the retry never fires.

## Where to start

`packages/runtime-common/virtual-network.ts`:
- `timedFetch` (new) — wraps the native fetch with a per-call `AbortSignal.timeout` watchdog, applied only to the hosts `shouldRetryFetch` already treats as retryable, and only when `__environment === 'test'`.
- `runFetch` now routes through `timedFetch` instead of `nativeFetch`.
- `withRetries` retry log now names the error so a future failure shows which path fired.

A stalled attempt aborts into a `TimeoutError`, which propagates through `fetcher` (running its `finally` and releasing the waiter) into the existing retry loop — so a transient stall recovers on the next attempt instead of hanging the whole test.

## Key decisions

- **Watchdog at the native-fetch boundary, not around the request.** `fetcher` hands the inner fetch a freshly `clone()`d Request, so overriding its signal there can never disturb a body a retry will reuse, and the abort signal doesn't need to survive virtual→real URL remapping.
- **Scoped to the already-retryable test hosts.** Same gate as the existing retry accommodation (`shouldRetryFetch` + `__environment === 'test'`); production fetch behaviour is unchanged.
- **Complements the existing retry loop rather than replacing it.** The reject-manifestation is still handled by `withRetries`; this adds coverage for the hang-manifestation.
- **15s per-attempt budget** — far above any real CI response time (these reads are sub-second normally) while leaving room for several attempts inside QUnit's 60s per-test window, so the watchdog is inert on a healthy run.
