### PR TITLE
diagnostic: dump HTTP/2 stream state to localize the realm-server h2 stall

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -190,6 +190,10 @@ jobs:
         run: mise run test-services:host | tee -a /tmp/server.log &
         env:
           SKIP_CATALOG: true
+          # Dump HTTP/2 session/stream state for any realm-server stream that
+          # stalls, to localize the Chrome ↔ Node http2 hang behind the flaky
+          # 60s host-test timeouts. Diagnostics-only; see server.ts.
+          REALM_SERVER_HTTP2_DIAGNOSTICS: '1'
       - name: create realm users
         run: pnpm register-realm-users
         working-directory: packages/matrix

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -193,7 +193,7 @@ jobs:
           # Dump HTTP/2 session/stream state for any realm-server stream that
           # stalls, to localize the Chrome ↔ Node http2 hang behind the flaky
           # 60s host-test timeouts. Diagnostics-only; see server.ts.
-          REALM_SERVER_HTTP2_DIAGNOSTICS: '1'
+          REALM_SERVER_HTTP2_DIAGNOSTICS: "1"
       - name: create realm users
         run: pnpm register-realm-users
         working-directory: packages/matrix

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -39,6 +39,14 @@ import type { RealmRegistryReconciler } from './lib/realm-registry-reconciler';
 const TLS_CERT_FILE_ENV = 'REALM_SERVER_TLS_CERT_FILE';
 const TLS_KEY_FILE_ENV = 'REALM_SERVER_TLS_KEY_FILE';
 
+// Opt-in HTTP/2 stall diagnostics (see installHttp2Diagnostics). Off by
+// default; set in the host-test CI job so an intermittent "request accepted
+// but never answered" h2 stall dumps its full session/stream state instead of
+// surfacing only as an opaque 60s host-test timeout. The h2 path is never
+// reached in production (BOXEL_ENVIRONMENT short-circuits to plain HTTP above),
+// so this only ever runs in local dev / CI.
+const HTTP2_DIAGNOSTICS_ENV = 'REALM_SERVER_HTTP2_DIAGNOSTICS';
+
 export type RealmHttpServer =
   | http.Server
   | http2.Http2SecureServer
@@ -142,6 +150,9 @@ export function createListener(
     );
     return { server: http.createServer(app.callback()), proto: 'http' };
   }
+  if (process.env[HTTP2_DIAGNOSTICS_ENV]) {
+    installHttp2Diagnostics(tlsServer, log);
+  }
   let redirectServer = http.createServer(redirectToHttps);
   // Track every accepted socket so shutdown can force-close them. Without
   // this, `dispatcher.close()` waits for active HTTP/2 sessions and
@@ -212,6 +223,134 @@ export function createListener(
     activeSockets.clear();
   };
   return { server: dispatcher, proto: 'https/h2' };
+}
+
+// Instrument the HTTP/2 secure server so an intermittent stall — a stream that
+// is accepted but whose response never reaches the browser — is observable
+// instead of surfacing only as a downstream 60s host-test timeout. The flake
+// has been isolated to "something in the Chrome ↔ Node http2 path" (the h1
+// toggle made it vanish and the byte-peek dispatcher was exonerated), but the
+// mechanism is still unknown. This narrows it down by answering, for any
+// long-open stream:
+//   - did the app ever produce a response? (sawRequest / res.writableEnded /
+//     headersSent) — distinguishes an app-side hang from an h2 transport stall
+//   - is the stream flow-control-blocked? (stream localWindowSize, session
+//     effectiveLocalWindowSize / remoteWindowSize / outboundQueueSize)
+//   - is the connection over its stream budget? (local/remote
+//     maxConcurrentStreams vs. live open-stream count)
+//   - how did it finally end? (rstCode / aborted on close)
+// Read-only: it attaches observer listeners and reads getters, never consuming
+// the stream body or writing a response, so it cannot perturb the path it
+// watches. Periodic so a single stuck stream is dumped repeatedly and its
+// window/queue evolution is visible.
+function installHttp2Diagnostics(
+  tlsServer: http2.Http2SecureServer,
+  log: ReturnType<typeof logger>,
+) {
+  const STALL_THRESHOLD_MS = 8000;
+  const SWEEP_INTERVAL_MS = 5000;
+
+  interface TrackedStream {
+    id: number;
+    method: string;
+    path: string;
+    startedAt: number;
+    sawRequest: boolean;
+    res?: http2.Http2ServerResponse;
+    everStalled: boolean;
+  }
+
+  let nextId = 0;
+  let sessions = new Set<http2.ServerHttp2Session>();
+  let open = new Map<http2.ServerHttp2Stream, TrackedStream>();
+
+  tlsServer.on('session', (session) => {
+    sessions.add(session);
+    log.info(`[h2-diag] session opened (live sessions=${sessions.size})`);
+    session.on('close', () => {
+      sessions.delete(session);
+      log.info(`[h2-diag] session closed (live sessions=${sessions.size})`);
+    });
+    session.on('error', (e) =>
+      log.warn(`[h2-diag] session error: ${e.message}`),
+    );
+    session.on('frameError', (type, code, id) =>
+      log.warn(
+        `[h2-diag] session frameError type=${type} code=${code} streamId=${id}`,
+      ),
+    );
+    session.on('goaway', (code, lastStreamID) =>
+      log.warn(
+        `[h2-diag] session goaway errorCode=${code} lastStreamID=${lastStreamID}`,
+      ),
+    );
+    session.on('timeout', () => log.warn(`[h2-diag] session timeout`));
+  });
+
+  tlsServer.on('stream', (stream, headers) => {
+    let tracked: TrackedStream = {
+      id: nextId++,
+      method: String(headers[':method'] ?? '?'),
+      path: String(headers[':path'] ?? '?'),
+      startedAt: Date.now(),
+      sawRequest: false,
+      everStalled: false,
+    };
+    open.set(stream, tracked);
+    stream.once('close', () => {
+      let rec = open.get(stream);
+      open.delete(stream);
+      if (rec && rec.everStalled) {
+        log.warn(
+          `[h2-diag] stream #${rec.id} ${rec.method} ${rec.path} CLOSED after ` +
+            `${Date.now() - rec.startedAt}ms rstCode=${stream.rstCode} ` +
+            `aborted=${stream.aborted} sawRequest=${rec.sawRequest} ` +
+            `resWritableEnded=${rec.res?.writableEnded ?? 'n/a'}`,
+        );
+      }
+    });
+  });
+
+  tlsServer.on('request', (req, res) => {
+    let rec = open.get(req.stream);
+    if (rec) {
+      rec.sawRequest = true;
+      rec.res = res;
+    }
+  });
+
+  let timer = setInterval(() => {
+    let now = Date.now();
+    for (let [stream, rec] of open) {
+      let age = now - rec.startedAt;
+      if (age < STALL_THRESHOLD_MS) {
+        continue;
+      }
+      rec.everStalled = true;
+      let session = stream.session;
+      let ss = session?.state ?? {};
+      let st = stream.state ?? {};
+      log.warn(
+        `[h2-diag] STALLED stream #${rec.id} ${rec.method} ${rec.path} age=${age}ms ` +
+          `sawRequest=${rec.sawRequest} ` +
+          `res(headersSent=${rec.res?.headersSent ?? 'n/a'} ` +
+          `writableEnded=${rec.res?.writableEnded ?? 'n/a'}) ` +
+          `stream(closed=${stream.closed} destroyed=${stream.destroyed} ` +
+          `aborted=${stream.aborted} ` +
+          `localClose=${st.localClose} remoteClose=${st.remoteClose} ` +
+          `localWindow=${st.localWindowSize}) ` +
+          `session(closed=${session?.closed} destroyed=${session?.destroyed} ` +
+          `outboundQueueSize=${ss.outboundQueueSize} ` +
+          `effectiveLocalWindow=${ss.effectiveLocalWindowSize} ` +
+          `effectiveRecvData=${ss.effectiveRecvDataLength} ` +
+          `remoteWindow=${ss.remoteWindowSize} liveStreams=${open.size}) ` +
+          `maxConcurrentStreams(local=${session?.localSettings?.maxConcurrentStreams} ` +
+          `remote=${session?.remoteSettings?.maxConcurrentStreams})`,
+      );
+    }
+  }, SWEEP_INTERVAL_MS);
+  // Don't let the sweep timer hold the process open during shutdown.
+  timer.unref?.();
 }
 
 // Same-port 308 redirect for plain-text HTTP requests that land on the

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -287,16 +287,43 @@ function installHttp2Diagnostics(
     session.on('timeout', () => log.warn(`[h2-diag] session timeout`));
   });
 
+  // Get-or-create the per-stream record. Both the `stream` and `request`
+  // events populate it, and either may fire first: the compat `request`
+  // listener that `createSecureServer(..., app.callback())` registers runs
+  // before this function's `stream` listener and emits `request`
+  // synchronously, so for a normal request the record is created from the
+  // `request` side; a stream that stalls before the app ever dispatches is
+  // created from the `stream` side with `sawRequest` left false. (Creating it
+  // only from `stream` would always report `sawRequest=false`, defeating the
+  // app-hang-vs-transport-stall distinction.)
+  function trackStream(
+    stream: http2.ServerHttp2Stream,
+    method: string,
+    path: string,
+  ): TrackedStream {
+    let rec = open.get(stream);
+    if (!rec) {
+      rec = {
+        id: nextId++,
+        method,
+        path,
+        startedAt: Date.now(),
+        sawRequest: false,
+        everStalled: false,
+      };
+      open.set(stream, rec);
+    }
+    return rec;
+  }
+
   tlsServer.on('stream', (stream, headers) => {
-    let tracked: TrackedStream = {
-      id: nextId++,
-      method: String(headers[':method'] ?? '?'),
-      path: String(headers[':path'] ?? '?'),
-      startedAt: Date.now(),
-      sawRequest: false,
-      everStalled: false,
-    };
-    open.set(stream, tracked);
+    trackStream(
+      stream,
+      String(headers[':method'] ?? '?'),
+      String(headers[':path'] ?? '?'),
+    );
+    // The `stream` event always fires for an h2 stream, so attach the close
+    // cleanup here exactly once regardless of which event created the record.
     stream.once('close', () => {
       let rec = open.get(stream);
       open.delete(stream);
@@ -312,11 +339,14 @@ function installHttp2Diagnostics(
   });
 
   tlsServer.on('request', (req, res) => {
-    let rec = open.get(req.stream);
-    if (rec) {
-      rec.sawRequest = true;
-      rec.res = res;
+    // h1 requests (allowHTTP1) have no backing h2 stream; only h2 is in scope.
+    let stream = req.stream as http2.ServerHttp2Stream | undefined;
+    if (stream == null) {
+      return;
     }
+    let rec = trackStream(stream, req.method ?? '?', req.url ?? '?');
+    rec.sawRequest = true;
+    rec.res = res;
   });
 
   let timer = setInterval(() => {

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -357,9 +357,22 @@ function installHttp2Diagnostics(
         continue;
       }
       rec.everStalled = true;
+      // `stream.session` can be undefined once a stalled stream's session has
+      // gone away — keep the optional chaining rather than assuming it's live.
       let session = stream.session;
-      let ss = session?.state ?? {};
-      let st = stream.state ?? {};
+      let ss = session?.state;
+      let st = stream.state;
+      // maxConcurrentStreams is negotiated per-session, so the budget signal
+      // must compare against this session's own live stream count, not the
+      // process-wide total (which spans every browser session).
+      let liveThisSession = 0;
+      if (session) {
+        for (let other of open.keys()) {
+          if (other.session === session) {
+            liveThisSession++;
+          }
+        }
+      }
       log.warn(
         `[h2-diag] STALLED stream #${rec.id} ${rec.method} ${rec.path} age=${age}ms ` +
           `sawRequest=${rec.sawRequest} ` +
@@ -367,13 +380,14 @@ function installHttp2Diagnostics(
           `writableEnded=${rec.res?.writableEnded ?? 'n/a'}) ` +
           `stream(closed=${stream.closed} destroyed=${stream.destroyed} ` +
           `aborted=${stream.aborted} ` +
-          `localClose=${st.localClose} remoteClose=${st.remoteClose} ` +
-          `localWindow=${st.localWindowSize}) ` +
+          `localClose=${st?.localClose} remoteClose=${st?.remoteClose} ` +
+          `localWindow=${st?.localWindowSize}) ` +
           `session(closed=${session?.closed} destroyed=${session?.destroyed} ` +
-          `outboundQueueSize=${ss.outboundQueueSize} ` +
-          `effectiveLocalWindow=${ss.effectiveLocalWindowSize} ` +
-          `effectiveRecvData=${ss.effectiveRecvDataLength} ` +
-          `remoteWindow=${ss.remoteWindowSize} liveStreams=${open.size}) ` +
+          `outboundQueueSize=${ss?.outboundQueueSize} ` +
+          `effectiveLocalWindow=${ss?.effectiveLocalWindowSize} ` +
+          `effectiveRecvData=${ss?.effectiveRecvDataLength} ` +
+          `remoteWindow=${ss?.remoteWindowSize} ` +
+          `liveStreamsThisSession=${liveThisSession} liveStreamsTotal=${open.size}) ` +
           `maxConcurrentStreams(local=${session?.localSettings?.maxConcurrentStreams} ` +
           `remote=${session?.remoteSettings?.maxConcurrentStreams})`,
       );


### PR DESCRIPTION
## Background and Goal

Host-test shards intermittently die with a bare `Test took longer than 60000ms; test timed out`. The timeout diagnostics in `tests/helpers/setup.ts` pin it precisely: at the moment QUnit gives up, a single browser fetch to the realm server is still in flight (e.g. `QUERY https://localhost:4201/base/_info`), neither resolved nor rejected, holding the `fetcher` test waiter open so `settled()` never returns.

Prior investigation isolated this to the **Chrome ↔ Node HTTP/2 path**: an h1 toggle makes the hang vanish, and the byte-peek dispatcher in `server.ts` was explicitly exonerated. But the mechanism — flow-control deadlock, stream-budget exhaustion, an app-side hang, or a transport stall — is still unknown.

This PR is **diagnostics only**. It does not attempt a fix; it instruments the h2 server so the next CI hang names the mechanism.

## Where to start

`packages/realm-server/server.ts` — `installHttp2Diagnostics()`, called from `createListener` only when `REALM_SERVER_HTTP2_DIAGNOSTICS` is set.

It attaches read-only observers to `http2.createSecureServer` and, every 5s, dumps the full HTTP/2 state of any stream open longer than 8s:
- **app hang vs transport stall** — `sawRequest`, `res.headersSent`, `res.writableEnded` (did the app ever produce a response?)
- **flow control** — stream `localWindowSize`; session `effectiveLocalWindowSize` / `remoteWindowSize` / `outboundQueueSize`
- **stream budget** — live stream count vs local/remote `maxConcurrentStreams`
- **terminal state** — `rstCode` / `aborted` when the stream finally closes

`.github/workflows/ci-host.yaml` sets `REALM_SERVER_HTTP2_DIAGNOSTICS=1` on the host-test job's service-start step. Output lands in the existing realm-server log artifact (`[h2-diag]` lines).

## Key decisions

- **Read-only observer.** It only attaches listeners and reads getters — never consumes a stream body or writes a response — so it cannot perturb the path it watches.
- **Env-gated, default off.** The h2 path is never reached in production (`BOXEL_ENVIRONMENT` short-circuits to plain HTTP), so this only ever runs in local dev / CI, and only when the flag is set.
- **Periodic, not one-shot.** A stuck stream is dumped on every sweep so its window/queue evolution over the stall is visible, not just a single snapshot.
- **8s threshold.** Far above normal sub-second realm reads, so a healthy run logs nothing; the ~60s stall window yields ~10 dumps.
