### PR TITLE
Remove "Link [type]" replace button from broken singular linksTo editor

### DIFF
--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -37,8 +37,10 @@ import { type RelationshipState } from './field-support';
 // A broken singular link surfaces as a terminal failure state from
 // `getRelationship`. The owning `linksTo` component reads it (it has the
 // containing instance in scope) and hands it down so the editor can show the
-// placeholder alongside remove and replace controls, rather than the bare
-// "Link" button it shows for a never-set field.
+// placeholder alongside a remove control, rather than the bare "Link" button it
+// shows for a never-set field. To swap in a working link, the user removes the
+// broken reference, which reverts the field to the not-set state and its "Link"
+// button.
 type BrokenLink = Extract<RelationshipState, { kind: 'error' | 'not-found' }>;
 
 interface Signature {
@@ -66,32 +68,19 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
       >
         {{#if @brokenLink}}
           {{! A broken reference still occupies the slot — show the placeholder
-              (so the broken URL is visible) and, when writable, the controls to
-              clear it (remove) or swap it for a working link (replace) without
-              first reverting to the empty state. }}
+              (so the broken URL is visible) and, when writable, a remove control
+              to clear it. Removing reverts the field to the not-set state, where
+              the existing "Link" button can add a working replacement. }}
           {{#if permissions.canWrite}}
-            <div class='broken-controls'>
-              <IconButton
-                @icon={{IconMinusCircle}}
-                @width='20px'
-                @height='20px'
-                class='remove'
-                {{on 'click' this.remove}}
-                aria-label='Remove'
-                data-test-remove-card
-              />
-              <Button
-                class='replace'
-                @kind='muted'
-                @size='small'
-                @rectangular={{true}}
-                {{on 'click' this.add}}
-                data-test-add-new={{@field.name}}
-              >
-                Link
-                {{@field.card.displayName}}
-              </Button>
-            </div>
+            <IconButton
+              @icon={{IconMinusCircle}}
+              @width='20px'
+              @height='20px'
+              class='remove'
+              {{on 'click' this.remove}}
+              aria-label='Remove'
+              data-test-remove-card
+            />
           {{/if}}
           {{! The editor lays the slot out in flow (a `1fr auto` grid), not a
               fixed-dimension card slot, so the placeholder renders `embedded`
@@ -184,20 +173,6 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
       }
       .add-new {
         width: fit-content;
-        letter-spacing: var(--boxel-lsp-xs);
-      }
-      /* Broken-state controls stack in the trailing `auto` column beside the
-         placeholder: remove (clear the reference) above replace (swap in a
-         working link via the card chooser). */
-      .broken-controls {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: var(--boxel-sp-xs);
-      }
-      .replace {
-        width: fit-content;
-        white-space: nowrap;
         letter-spacing: var(--boxel-lsp-xs);
       }
     </style>

--- a/packages/host/tests/integration/components/linksto-broken-link-placeholder-test.gts
+++ b/packages/host/tests/integration/components/linksto-broken-link-placeholder-test.gts
@@ -310,7 +310,9 @@ module(
         .exists('editor offers a remove affordance for the broken reference');
       assert
         .dom('[data-test-add-new="pet"]')
-        .doesNotExist('the broken state offers no inline "Link" replace button');
+        .doesNotExist(
+          'the broken state offers no inline "Link" replace button',
+        );
 
       // Removing the broken reference reverts to the not-set state, whose "Link"
       // button is the single entry point for adding a working replacement.
@@ -318,7 +320,10 @@ module(
       assert
         .dom('[data-test-add-new="pet"]')
         .exists('the not-set state offers the "Link" affordance to relink')
-        .hasText('Link Pet', 'the relink control is labelled for the field type');
+        .hasText(
+          'Link Pet',
+          'the relink control is labelled for the field type',
+        );
     });
 
     test('removing a broken link reverts the slot to the empty "Link" affordance', async function (assert) {

--- a/packages/host/tests/integration/components/linksto-broken-link-placeholder-test.gts
+++ b/packages/host/tests/integration/components/linksto-broken-link-placeholder-test.gts
@@ -286,7 +286,7 @@ module(
       );
     });
 
-    test('in edit format a broken link shows the placeholder plus remove and replace affordances', async function (assert) {
+    test('in edit format a broken link shows the placeholder plus a remove-only affordance', async function (assert) {
       await setupRealm();
       let person = await createPerson({
         pet: { links: { self: GHOST_URL } },
@@ -297,8 +297,8 @@ module(
 
       // The broken state is distinguished from the empty state by the
       // placeholder: a never-set link shows only the bare "Link" button, while a
-      // broken link surfaces the URL alongside remove (clear) and replace (swap)
-      // controls.
+      // broken link surfaces the URL alongside a remove control. There is no
+      // inline replace affordance — relinking routes through the not-set state.
       assert
         .dom('[data-test-broken-link-template]')
         .exists('editor shows the broken-link placeholder');
@@ -310,11 +310,15 @@ module(
         .exists('editor offers a remove affordance for the broken reference');
       assert
         .dom('[data-test-add-new="pet"]')
-        .exists('editor offers a "Link" affordance to replace the broken link')
-        .hasText(
-          'Link Pet',
-          'the replace control is labelled for the field type',
-        );
+        .doesNotExist('the broken state offers no inline "Link" replace button');
+
+      // Removing the broken reference reverts to the not-set state, whose "Link"
+      // button is the single entry point for adding a working replacement.
+      await click('[data-test-remove-card]');
+      assert
+        .dom('[data-test-add-new="pet"]')
+        .exists('the not-set state offers the "Link" affordance to relink')
+        .hasText('Link Pet', 'the relink control is labelled for the field type');
     });
 
     test('removing a broken link reverts the slot to the empty "Link" affordance', async function (assert) {


### PR DESCRIPTION
## Background and Goal

In edit mode, a broken singular `linksTo` previously rendered two controls next to the placeholder: a remove (X) button and an inline "Link [type]" replace button. The replace button duplicated machinery the not-set state already provides. This removes it so the broken state shows the placeholder and a remove control only — to swap in a working link, the user removes the broken reference (reverting the field to the not-set state) and uses the existing "Link [type]" button there. One entry point into the card chooser.

## Where to start

- `packages/base/links-to-editor.gts` — the `{{#if @brokenLink}}` branch now renders just the remove `IconButton` (the `.broken-controls` wrapper and the `<Button class='replace'>` are gone), and the corresponding `.broken-controls` / `.replace` style rules are dropped.
- `packages/host/tests/integration/components/linksto-broken-link-placeholder-test.gts` — the edit-mode test now asserts the inline replace button does **not** exist, then clicks remove and confirms the not-set "Link Pet" button appears.

## Key decisions

- The `Button` import stays — the not-set (`isEmpty`) branch still uses it for its "Link [type]" button.
- Read-only broken links and the linksToMany editor branches are untouched (linksToMany never carried a per-slot replace affordance).
