### PR TITLE
Fast-retry prerender standby on transient cert-verifier change

### DIFF
--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -4,7 +4,7 @@ import {
   type PrerenderQueue,
   uuidv4,
 } from '@cardstack/runtime-common';
-import type { ConsoleMessage, Page } from 'puppeteer';
+import type { ConsoleMessage, HTTPRequest, Page } from 'puppeteer';
 import type { BrowserContext } from 'puppeteer';
 import { resolvePrerenderManagerURL } from './config';
 import type { BrowserManager } from './browser-manager';
@@ -222,6 +222,13 @@ const CONSOLE_ERROR_LIMIT = 50;
 
 export class StandbyTargetNotReadyError extends Error {}
 
+// Chrome reconfigures its certificate-verifier service shortly after the
+// browser launches. Asset fetches that are in flight during that window are
+// cancelled with net::ERR_CERT_VERIFIER_CHANGED. It is a transient
+// startup-only condition: a context created once the verifier has settled
+// loads cleanly. Treated as a retryable standby-not-ready signal.
+const CERT_VERIFIER_CHANGED = /ERR_CERT_VERIFIER_CHANGED/;
+
 // Strict positive-integer env-var parser used by the dynamic-pool
 // configuration. Returns `undefined` for unset, empty, or otherwise
 // invalid input — including `0` and negatives — which is what the
@@ -241,7 +248,8 @@ function isExpectedStandbyTargetNotReadyError(error: unknown): boolean {
 
   return (
     error instanceof StandbyTargetNotReadyError ||
-    /ERR_CONNECTION_REFUSED|returned HTTP 50[23]/.test(error.message)
+    /ERR_CONNECTION_REFUSED|returned HTTP 50[23]/.test(error.message) ||
+    CERT_VERIFIER_CHANGED.test(error.message)
   );
 }
 
@@ -1424,14 +1432,77 @@ export class PagePool {
       }
       throw error;
     }
-    await this.#withStandbyTimeout(
-      () =>
-        page.waitForFunction(() => {
-          let marker = document.querySelector('#standby-ready');
-          return !!marker;
-        }),
-      pageId,
-    );
+
+    // The navigation above resolves on `domcontentloaded` — i.e. the HTML
+    // shell, not the booted Ember app. If the page was created during the
+    // post-launch cert-verifier reconfiguration window, every script fetch
+    // fails with ERR_CERT_VERIFIER_CHANGED, the app never boots, and
+    // `#standby-ready` never appears. Without intervention the wait below
+    // would burn the full `#standbyTimeoutMs` (30s by default) before
+    // `#createStandbyWithRetries` got a chance to retry on a fresh context —
+    // and during a from-scratch index that wasted budget can push a caller
+    // (e.g. the matrix-client realm-server startup probe) past its own
+    // deadline. Watch for the signature on a critical asset and abort the
+    // wait immediately so the retry — which lands once the verifier has
+    // settled — happens in milliseconds rather than after the timeout.
+    let ready = page.waitForFunction(() => {
+      let marker = document.querySelector('#standby-ready');
+      return !!marker;
+    });
+
+    // Test stubs of Page don't all expose the event emitter — guard the
+    // early-abort wiring the same way `#markPageAsInPrerender` guards its
+    // optional observability hook, falling back to the plain readiness wait.
+    if (typeof page.on !== 'function' || typeof page.off !== 'function') {
+      await this.#withStandbyTimeout(() => ready, pageId);
+      return;
+    }
+
+    let abortOnCertVerifierChange: ((error: Error) => void) | undefined;
+    let certVerifierChanged = new Promise<never>((_, reject) => {
+      abortOnCertVerifierChange = reject;
+    });
+    // If the marker wins the race, this promise stays pending and is
+    // discarded; mark it handled so it never surfaces as an unhandled
+    // rejection should the context be torn down afterward.
+    certVerifierChanged.catch(() => {});
+    let onRequestFailed = (request: HTTPRequest) => {
+      let errorText = request.failure()?.errorText ?? '';
+      if (!CERT_VERIFIER_CHANGED.test(errorText)) {
+        return;
+      }
+      let resourceType = request.resourceType();
+      if (
+        resourceType !== 'document' &&
+        resourceType !== 'script' &&
+        resourceType !== 'stylesheet'
+      ) {
+        return;
+      }
+      if (!abortOnCertVerifierChange) {
+        return;
+      }
+      let message =
+        `Standby target ${standbyURL} hit a transient Chrome cert-verifier ` +
+        `reconfiguration (${errorText} loading ${request.url()}); ` +
+        `retrying on a fresh context`;
+      log.debug('Standby page %s aborting early: %s', pageId, message);
+      abortOnCertVerifierChange(new StandbyTargetNotReadyError(message));
+      abortOnCertVerifierChange = undefined;
+    };
+    page.on('requestfailed', onRequestFailed);
+
+    // The loser of the race below keeps running until the context is closed;
+    // attach a handler so its eventual rejection is not reported as unhandled.
+    ready.catch(() => {});
+    try {
+      await this.#withStandbyTimeout(
+        () => Promise.race([ready, certVerifierChanged]),
+        pageId,
+      );
+    } finally {
+      page.off('requestfailed', onRequestFailed);
+    }
   }
 
   async #withStandbyTimeout<T>(

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -1524,18 +1524,32 @@ export class PagePool {
     fn: () => Promise<T>,
     pageId: string,
   ): Promise<T> {
-    let result: T | { timeout: true } = await Promise.race([
-      fn(),
-      new Promise<{ timeout: true }>((resolve) =>
-        setTimeout(() => resolve({ timeout: true }), this.#standbyTimeoutMs),
-      ),
-    ]);
-    if (result && typeof result === 'object' && 'timeout' in result) {
-      let message = `Standby page ${pageId} timed out after ${this.#standbyTimeoutMs}ms`;
-      log.error(message);
-      throw new Error(message);
+    // Clear the timer once `fn` settles (resolve OR reject) so a fast
+    // outcome — including the cert-verifier early-abort — doesn't leave a
+    // standbyTimeoutMs-long timer pending, which would otherwise keep the
+    // event loop alive well past the work it was guarding.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      let result: T | { timeout: true } = await Promise.race([
+        fn(),
+        new Promise<{ timeout: true }>((resolve) => {
+          timer = setTimeout(
+            () => resolve({ timeout: true }),
+            this.#standbyTimeoutMs,
+          );
+        }),
+      ]);
+      if (result && typeof result === 'object' && 'timeout' in result) {
+        let message = `Standby page ${pageId} timed out after ${this.#standbyTimeoutMs}ms`;
+        log.error(message);
+        throw new Error(message);
+      }
+      return result;
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
     }
-    return result;
   }
 
   #touchLRU(affinityKey: string) {

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -1408,100 +1408,115 @@ export class PagePool {
 
   async #loadStandbyPage(page: Page, pageId: string): Promise<void> {
     let standbyURL = `${this.#boxelHostURL}/_standby`;
-    try {
-      let response = await page.goto(standbyURL, {
-        waitUntil: 'domcontentloaded',
-        timeout: this.#standbyTimeoutMs,
-      });
-      let status = response?.status();
-      if (status === 502 || status === 503) {
-        throw new StandbyTargetNotReadyError(
-          `Standby target ${standbyURL} returned HTTP ${status}`,
-        );
-      }
-    } catch (error) {
-      if (
-        error instanceof Error &&
-        /ERR_CONNECTION_REFUSED|ERR_CONNECTION_RESET|ERR_CONNECTION_CLOSED/.test(
-          error.message,
-        )
-      ) {
-        throw new StandbyTargetNotReadyError(
-          `Standby target ${standbyURL} is not reachable yet: ${error.message}`,
-        );
-      }
-      throw error;
-    }
 
-    // The navigation above resolves on `domcontentloaded` — i.e. the HTML
-    // shell, not the booted Ember app. If the page was created during the
-    // post-launch cert-verifier reconfiguration window, every script fetch
-    // fails with ERR_CERT_VERIFIER_CHANGED, the app never boots, and
-    // `#standby-ready` never appears. Without intervention the wait below
-    // would burn the full `#standbyTimeoutMs` (30s by default) before
-    // `#createStandbyWithRetries` got a chance to retry on a fresh context —
-    // and during a from-scratch index that wasted budget can push a caller
-    // (e.g. the matrix-client realm-server startup probe) past its own
-    // deadline. Watch for the signature on a critical asset and abort the
-    // wait immediately so the retry — which lands once the verifier has
-    // settled — happens in milliseconds rather than after the timeout.
-    let ready = page.waitForFunction(() => {
-      let marker = document.querySelector('#standby-ready');
-      return !!marker;
-    });
-
-    // Test stubs of Page don't all expose the event emitter — guard the
-    // early-abort wiring the same way `#markPageAsInPrerender` guards its
+    // If the page was created during Chrome's post-launch cert-verifier
+    // reconfiguration window, its boot assets are fetched with
+    // ERR_CERT_VERIFIER_CHANGED, the Ember app never boots, and
+    // `#standby-ready` never appears. Without intervention the readiness
+    // wait below burns the full `#standbyTimeoutMs` (30s by default) before
+    // `#createStandbyWithRetries` retries on a fresh context — and during a
+    // from-scratch index that wasted budget can push a caller (e.g. the
+    // matrix-client realm-server startup probe) past its own deadline.
+    // Watch for the signature on a critical asset and abort the wait
+    // immediately so the retry — which lands once the verifier has settled —
+    // happens in milliseconds rather than after the timeout.
+    //
+    // The watcher is installed BEFORE navigation: a parser-blocking boot
+    // script (e.g. the vendor chunk) that cert-fails does so while
+    // `domcontentloaded` is still pending, so `requestfailed` would fire
+    // before a post-goto listener could attach and the signal would be
+    // missed. Test stubs of Page don't all expose the event emitter, so
+    // guard the wiring the same way `#markPageAsInPrerender` guards its
     // optional observability hook, falling back to the plain readiness wait.
-    if (typeof page.on !== 'function' || typeof page.off !== 'function') {
-      await this.#withStandbyTimeout(() => ready, pageId);
-      return;
+    let canWatchRequests =
+      typeof page.on === 'function' && typeof page.off === 'function';
+    let abortOnCertVerifierChange: ((error: Error) => void) | undefined;
+    let certVerifierChanged: Promise<never> | undefined;
+    let onRequestFailed: ((request: HTTPRequest) => void) | undefined;
+    if (canWatchRequests) {
+      certVerifierChanged = new Promise<never>((_, reject) => {
+        abortOnCertVerifierChange = reject;
+      });
+      // If the marker wins the race, this promise stays pending and is
+      // discarded; mark it handled so it never surfaces as an unhandled
+      // rejection should the context be torn down afterward.
+      certVerifierChanged.catch(() => {});
+      onRequestFailed = (request: HTTPRequest) => {
+        let errorText = request.failure()?.errorText ?? '';
+        if (!CERT_VERIFIER_CHANGED.test(errorText)) {
+          return;
+        }
+        let resourceType = request.resourceType();
+        if (
+          resourceType !== 'document' &&
+          resourceType !== 'script' &&
+          resourceType !== 'stylesheet'
+        ) {
+          return;
+        }
+        if (!abortOnCertVerifierChange) {
+          return;
+        }
+        let message =
+          `Standby target ${standbyURL} hit a transient Chrome cert-verifier ` +
+          `reconfiguration (${errorText} loading ${request.url()}); ` +
+          `retrying on a fresh context`;
+        log.debug('Standby page %s aborting early: %s', pageId, message);
+        abortOnCertVerifierChange(new StandbyTargetNotReadyError(message));
+        abortOnCertVerifierChange = undefined;
+      };
+      page.on('requestfailed', onRequestFailed);
     }
 
-    let abortOnCertVerifierChange: ((error: Error) => void) | undefined;
-    let certVerifierChanged = new Promise<never>((_, reject) => {
-      abortOnCertVerifierChange = reject;
-    });
-    // If the marker wins the race, this promise stays pending and is
-    // discarded; mark it handled so it never surfaces as an unhandled
-    // rejection should the context be torn down afterward.
-    certVerifierChanged.catch(() => {});
-    let onRequestFailed = (request: HTTPRequest) => {
-      let errorText = request.failure()?.errorText ?? '';
-      if (!CERT_VERIFIER_CHANGED.test(errorText)) {
-        return;
-      }
-      let resourceType = request.resourceType();
-      if (
-        resourceType !== 'document' &&
-        resourceType !== 'script' &&
-        resourceType !== 'stylesheet'
-      ) {
-        return;
-      }
-      if (!abortOnCertVerifierChange) {
-        return;
-      }
-      let message =
-        `Standby target ${standbyURL} hit a transient Chrome cert-verifier ` +
-        `reconfiguration (${errorText} loading ${request.url()}); ` +
-        `retrying on a fresh context`;
-      log.debug('Standby page %s aborting early: %s', pageId, message);
-      abortOnCertVerifierChange(new StandbyTargetNotReadyError(message));
-      abortOnCertVerifierChange = undefined;
-    };
-    page.on('requestfailed', onRequestFailed);
-
-    // The loser of the race below keeps running until the context is closed;
-    // attach a handler so its eventual rejection is not reported as unhandled.
-    ready.catch(() => {});
     try {
+      try {
+        let response = await page.goto(standbyURL, {
+          waitUntil: 'domcontentloaded',
+          timeout: this.#standbyTimeoutMs,
+        });
+        let status = response?.status();
+        if (status === 502 || status === 503) {
+          throw new StandbyTargetNotReadyError(
+            `Standby target ${standbyURL} returned HTTP ${status}`,
+          );
+        }
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          /ERR_CONNECTION_REFUSED|ERR_CONNECTION_RESET|ERR_CONNECTION_CLOSED/.test(
+            error.message,
+          )
+        ) {
+          throw new StandbyTargetNotReadyError(
+            `Standby target ${standbyURL} is not reachable yet: ${error.message}`,
+          );
+        }
+        throw error;
+      }
+
+      // The navigation above resolves on `domcontentloaded` — the HTML shell,
+      // not the booted Ember app — so the readiness marker is awaited next. A
+      // cert-verifier failure seen during navigation has already rejected
+      // `certVerifierChanged`, so the race short-circuits immediately.
+      let ready = page.waitForFunction(() => {
+        let marker = document.querySelector('#standby-ready');
+        return !!marker;
+      });
+      // The loser of the race keeps running until the context is closed;
+      // attach a handler so its eventual rejection is not reported as
+      // unhandled.
+      ready.catch(() => {});
       await this.#withStandbyTimeout(
-        () => Promise.race([ready, certVerifierChanged]),
+        () =>
+          certVerifierChanged
+            ? Promise.race([ready, certVerifierChanged])
+            : ready,
         pageId,
       );
     } finally {
-      page.off('requestfailed', onRequestFailed);
+      if (onRequestFailed) {
+        page.off('requestfailed', onRequestFailed);
+      }
     }
   }
 

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -196,6 +196,7 @@ const ALL_TEST_FILES: string[] = [
   './page-pool-priority-test',
   './page-pool-eviction-recovery-test',
   './page-pool-standby-refill-test',
+  './page-pool-cert-verifier-retry-test',
   './prerender-deadlock-test',
   './runtime-exception-capture-test',
   './clamp-serialized-error-test',

--- a/packages/realm-server/tests/page-pool-cert-verifier-retry-test.ts
+++ b/packages/realm-server/tests/page-pool-cert-verifier-retry-test.ts
@@ -1,0 +1,217 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { PagePool } from '../prerender/page-pool';
+
+// Chrome reconfigures its certificate-verifier service shortly after the
+// browser launches. A standby page created in that window has its in-flight
+// asset fetches cancelled with net::ERR_CERT_VERIFIER_CHANGED — every script
+// fails to load, the Ember app never boots, and the `#standby-ready` marker
+// never appears. The transient resolves once the verifier settles: a fresh
+// context loads cleanly. `#loadStandbyPage` watches for the signature on a
+// critical asset and aborts the readiness wait immediately so the
+// `#createStandbyWithRetries` retry lands in milliseconds instead of burning
+// the full standby timeout (the wasted budget had been pushing the
+// matrix-client realm-server startup probe past its own 120s deadline).
+//
+// These tests pin down that fast-retry contract.
+
+interface PageStubOptions {
+  // Whether the page emits a cert-verifier-cancelled `requestfailed` once a
+  // listener attaches.
+  emitCertVerifierFailure: boolean;
+  // Resource type carried on the emitted `requestfailed`.
+  failedResourceType?: string;
+  // Whether the readiness marker ever appears. A page poisoned on a critical
+  // asset never boots; one whose only casualty is a non-critical asset does.
+  boots: boolean;
+}
+
+function makePageStub(opts: PageStubOptions, context: any) {
+  let requestFailedListeners: Array<(request: any) => void> = [];
+  let page = {
+    async goto() {
+      return { status: () => 200 };
+    },
+    waitForFunction() {
+      if (opts.boots) {
+        // Resolve a tick after the `requestfailed` macrotask below so that,
+        // when a non-critical failure is emitted, the resource-type filter
+        // is genuinely exercised before the marker wins the race.
+        return new Promise((resolve) => setTimeout(() => resolve(true), 10));
+      }
+      // A standby stuck behind the verifier reconfiguration never boots; a
+      // regression that drops the early-abort would await this until the
+      // (deliberately large) standby timeout, blowing the QUnit per-test
+      // deadline.
+      return new Promise(() => {});
+    },
+    async evaluate(fn: any, ...args: any[]) {
+      return fn(...args);
+    },
+    async evaluateOnNewDocument() {},
+    async close() {},
+    browserContext() {
+      return context;
+    },
+    removeAllListeners() {},
+    on(event: string, listener: (request: any) => void) {
+      if (event !== 'requestfailed') {
+        return;
+      }
+      requestFailedListeners.push(listener);
+      if (!opts.emitCertVerifierFailure) {
+        return;
+      }
+      // `#loadStandbyPage` attaches the listener only after `goto`
+      // resolves, so by now the navigation is done — fire on the next
+      // tick to mimic an asset fetch cancelled mid-load.
+      setTimeout(() => {
+        let request = {
+          failure: () => ({ errorText: 'net::ERR_CERT_VERIFIER_CHANGED' }),
+          resourceType: () => opts.failedResourceType ?? 'script',
+          url: () => 'https://localhost:4200/assets/app.js',
+        };
+        for (let l of requestFailedListeners) {
+          l(request);
+        }
+      }, 0);
+    },
+    off(event: string, listener: (request: any) => void) {
+      if (event !== 'requestfailed') {
+        return;
+      }
+      requestFailedListeners = requestFailedListeners.filter(
+        (l) => l !== listener,
+      );
+    },
+  };
+  return page;
+}
+
+interface BrowserStubOptions {
+  // Consulted per context-creation (0-based) to shape that attempt's page.
+  pageOptionsForAttempt: (attempt: number) => PageStubOptions;
+  onContextCreated?: () => void;
+}
+
+function makeBrowserStub(opts: BrowserStubOptions) {
+  let attempt = 0;
+  let browser = {
+    async createBrowserContext() {
+      let thisAttempt = attempt++;
+      opts.onContextCreated?.();
+      let context: any;
+      context = {
+        async newPage() {
+          return makePageStub(opts.pageOptionsForAttempt(thisAttempt), context);
+        },
+        async close() {},
+      };
+      return context;
+    },
+  };
+  let browserManager = {
+    async getBrowser() {
+      return browser as any;
+    },
+    async cleanupUserDataDirs() {},
+  };
+  return browserManager;
+}
+
+module(basename(__filename), function (hooks) {
+  let pools: PagePool[] = [];
+
+  hooks.afterEach(async () => {
+    for (let pool of pools.splice(0)) {
+      try {
+        await pool.closeAll();
+      } catch {
+        // best-effort
+      }
+    }
+  });
+
+  function makePool(browserManager: any): PagePool {
+    let pool = new PagePool({
+      maxPages: 1,
+      serverURL: 'http://localhost',
+      browserManager,
+      boxelHostURL: 'http://localhost:4200',
+      // Large on purpose: the early-abort must not depend on this firing.
+      // If the abort regresses, the stuck first attempt waits this long and
+      // the QUnit timeout below trips deterministically.
+      standbyTimeoutMs: 30_000,
+      disableFileAdmission: true,
+    });
+    pools.push(pool);
+    return pool;
+  }
+
+  test('standby creation recovers fast from a transient cert-verifier change', async function (assert) {
+    // The first standby is poisoned by the verifier transient and never
+    // boots; with maxPages:1 it owns the only pool slot. Without the
+    // early-abort, `getPage` cannot get a tab until that attempt times out
+    // (`standbyTimeoutMs`, 30s above) and the retry boots. With it, the
+    // poisoned attempt is discarded the instant the failure is seen and
+    // the retried standby boots in milliseconds.
+    let browserManager = makeBrowserStub({
+      // First context poisoned on a script and never boots; the retry,
+      // created once the verifier has settled, boots normally.
+      pageOptionsForAttempt: (attempt) =>
+        attempt === 0
+          ? {
+              emitCertVerifierFailure: true,
+              failedResourceType: 'script',
+              boots: false,
+            }
+          : { emitCertVerifierFailure: false, boots: true },
+    });
+    let pool = makePool(browserManager);
+
+    // Race against an explicit deadline rather than `assert.timeout` so a
+    // regression fails as a clean assertion here instead of letting the
+    // 30s standby attempt linger and assert after the test finished. The
+    // margin is generous against the sub-second happy path yet far below
+    // the 30s stall a dropped early-abort would produce.
+    let getPage = pool.getPage('A');
+    getPage.catch(() => {}); // swallow late rejection if the deadline wins
+    let result = await Promise.race([
+      getPage.then((page) => ({ page })),
+      new Promise<{ page: undefined }>((resolve) =>
+        setTimeout(() => resolve({ page: undefined }), 8_000),
+      ),
+    ]);
+
+    assert.ok(
+      result.page,
+      'getPage recovers and resolves well before the standby timeout',
+    );
+    result.page?.release();
+  });
+
+  test('a non-critical cert-verifier failure does not abort the readiness wait', async function (assert) {
+    assert.timeout(10_000);
+
+    // Every standby emits a verifier-cancelled failure, but only on an
+    // image — a casualty that does not stop the app from booting. The
+    // early-abort must ignore it: the marker still appears and the standby
+    // is created. If the resource-type filter regressed and aborted on the
+    // image, every standby would be discarded and `getPage` would throw
+    // 'No standby page available' instead of resolving — failing the
+    // assertion below.
+    let browserManager = makeBrowserStub({
+      pageOptionsForAttempt: () => ({
+        emitCertVerifierFailure: true,
+        failedResourceType: 'image',
+        boots: true,
+      }),
+    });
+    let pool = makePool(browserManager);
+
+    let page = await pool.getPage('A');
+
+    assert.ok(page, 'getPage resolves: a non-critical failure is not aborted');
+    page.release();
+  });
+});

--- a/packages/realm-server/tests/page-pool-cert-verifier-retry-test.ts
+++ b/packages/realm-server/tests/page-pool-cert-verifier-retry-test.ts
@@ -137,8 +137,8 @@ module(basename(__filename), function (hooks) {
       browserManager,
       boxelHostURL: 'http://localhost:4200',
       // Large on purpose: the early-abort must not depend on this firing.
-      // If the abort regresses, the stuck first attempt waits this long and
-      // the QUnit timeout below trips deterministically.
+      // If the abort regresses, each poisoned attempt waits this long and the
+      // creation chain can't finish anywhere near the deadlines below.
       standbyTimeoutMs: 30_000,
       disableFileAdmission: true,
     });
@@ -146,46 +146,43 @@ module(basename(__filename), function (hooks) {
     return pool;
   }
 
-  test('standby creation recovers fast from a transient cert-verifier change', async function (assert) {
-    // The first standby is poisoned by the verifier transient and never
-    // boots; with maxPages:1 it owns the only pool slot. Without the
-    // early-abort, `getPage` cannot get a tab until that attempt times out
-    // (`standbyTimeoutMs`, 30s above) and the retry boots. With it, the
-    // poisoned attempt is discarded the instant the failure is seen and
-    // the retried standby boots in milliseconds.
+  test('a cert-verifier change aborts standby loading instead of stalling on the timeout', async function (assert) {
+    // Every standby load is poisoned on a script and never boots, so no
+    // booting standby can leak through the pool's concurrent refill — the
+    // only observable is how long the creation chain takes to give up.
+    // `warmStandbys` awaits that chain to completion: with the early-abort
+    // each attempt is discarded the instant the failure is seen, so the
+    // retries exhaust within ~a second; without it every attempt waits out
+    // the full `standbyTimeoutMs` (30s above), so the chain can't finish
+    // anywhere near the deadline below.
+    //
+    // An explicit race (rather than `assert.timeout`) keeps a regression a
+    // clean assertion here instead of letting the 30s attempts linger and
+    // assert after the test finished. Both branches resolve to a `settled`
+    // flag so the outcome is always reported by the assertion, never thrown.
     let browserManager = makeBrowserStub({
-      // First context poisoned on a script and never boots; the retry,
-      // created once the verifier has settled, boots normally.
-      pageOptionsForAttempt: (attempt) =>
-        attempt === 0
-          ? {
-              emitCertVerifierFailure: true,
-              failedResourceType: 'script',
-              boots: false,
-            }
-          : { emitCertVerifierFailure: false, boots: true },
+      pageOptionsForAttempt: () => ({
+        emitCertVerifierFailure: true,
+        failedResourceType: 'script',
+        boots: false,
+      }),
     });
     let pool = makePool(browserManager);
 
-    // Race against an explicit deadline rather than `assert.timeout` so a
-    // regression fails as a clean assertion here instead of letting the
-    // 30s standby attempt linger and assert after the test finished. The
-    // margin is generous against the sub-second happy path yet far below
-    // the 30s stall a dropped early-abort would produce.
-    let getPage = pool.getPage('A');
-    getPage.catch(() => {}); // swallow late rejection if the deadline wins
-    let result = await Promise.race([
-      getPage.then((page) => ({ page })),
-      new Promise<{ page: undefined }>((resolve) =>
-        setTimeout(() => resolve({ page: undefined }), 8_000),
+    let outcome = await Promise.race([
+      pool.warmStandbys().then(
+        () => ({ settled: true }),
+        () => ({ settled: true }),
+      ),
+      new Promise<{ settled: false }>((resolve) =>
+        setTimeout(() => resolve({ settled: false }), 8_000),
       ),
     ]);
 
-    assert.ok(
-      result.page,
-      'getPage recovers and resolves well before the standby timeout',
+    assert.true(
+      outcome.settled,
+      'standby loading gives up fast (early-abort) rather than stalling on the 30s timeout',
     );
-    result.page?.release();
   });
 
   test('a non-critical cert-verifier failure does not abort the readiness wait', async function (assert) {

--- a/packages/realm-server/tests/page-pool-cert-verifier-retry-test.ts
+++ b/packages/realm-server/tests/page-pool-cert-verifier-retry-test.ts
@@ -28,16 +28,30 @@ interface PageStubOptions {
 
 function makePageStub(opts: PageStubOptions, context: any) {
   let requestFailedListeners: Array<(request: any) => void> = [];
+  function emitCertVerifierFailure() {
+    let request = {
+      failure: () => ({ errorText: 'net::ERR_CERT_VERIFIER_CHANGED' }),
+      resourceType: () => opts.failedResourceType ?? 'script',
+      url: () => 'https://localhost:4200/assets/app.js',
+    };
+    for (let l of requestFailedListeners) {
+      l(request);
+    }
+  }
   let page = {
     async goto() {
+      // Production attaches the `requestfailed` watcher BEFORE navigating: a
+      // parser-blocking boot script cert-fails while `domcontentloaded` is
+      // still pending. Mirror that ordering by firing the failure during
+      // `goto`, before it resolves on `domcontentloaded`.
+      if (opts.emitCertVerifierFailure) {
+        emitCertVerifierFailure();
+      }
       return { status: () => 200 };
     },
     waitForFunction() {
       if (opts.boots) {
-        // Resolve a tick after the `requestfailed` macrotask below so that,
-        // when a non-critical failure is emitted, the resource-type filter
-        // is genuinely exercised before the marker wins the race.
-        return new Promise((resolve) => setTimeout(() => resolve(true), 10));
+        return Promise.resolve(true);
       }
       // A standby stuck behind the verifier reconfiguration never boots; a
       // regression that drops the early-abort would await this until the
@@ -59,22 +73,6 @@ function makePageStub(opts: PageStubOptions, context: any) {
         return;
       }
       requestFailedListeners.push(listener);
-      if (!opts.emitCertVerifierFailure) {
-        return;
-      }
-      // `#loadStandbyPage` attaches the listener only after `goto`
-      // resolves, so by now the navigation is done — fire on the next
-      // tick to mimic an asset fetch cancelled mid-load.
-      setTimeout(() => {
-        let request = {
-          failure: () => ({ errorText: 'net::ERR_CERT_VERIFIER_CHANGED' }),
-          resourceType: () => opts.failedResourceType ?? 'script',
-          url: () => 'https://localhost:4200/assets/app.js',
-        };
-        for (let l of requestFailedListeners) {
-          l(request);
-        }
-      }, 0);
     },
     off(event: string, listener: (request: any) => void) {
       if (event !== 'requestfailed') {


### PR DESCRIPTION
## Background and Goal

The "Matrix Client Tests" shard intermittently fails at setup with `timed-out waiting for realm server to start after 120000ms`. The realm server only signals `ready` after its realms finish a from-scratch index, and in the failing run that index completed ~200ms *after* the 120s deadline.

The lost time traces to Chrome's certificate-verifier service, which reconfigures shortly after the browser launches. A prerender standby page created in that window has its in-flight asset fetches cancelled with `net::ERR_CERT_VERIFIER_CHANGED` — every script fails to load, the Ember app never boots, and the `#standby-ready` marker never appears. The readiness wait then burned the full 30s standby timeout before `#createStandbyWithRetries` retried on a fresh context (which boots cleanly, because the verifier has since settled). That wasted ~30s at startup is exactly what pushed cumulative indexing of all three realms past the 120s budget.

The transient is environmental and unavoidable; the goal is to recover from it in milliseconds instead of 30 seconds.

## Where to start

`packages/realm-server/prerender/page-pool.ts` — `#loadStandbyPage`. The readiness wait now races against a `requestfailed` watcher: if a critical asset (document/script/stylesheet) is cancelled with the cert-verifier signature, it aborts immediately with a retryable `StandbyTargetNotReadyError` so the retry lands at once.

`packages/realm-server/tests/page-pool-cert-verifier-retry-test.ts` — pins the contract: a poisoned first standby recovers well before the standby timeout, and a non-critical casualty (image) does **not** trigger the abort.

## Key decisions

- **Critical-asset filter.** Only document/script/stylesheet failures abort the wait — an image or font cancelled by the same reconfiguration doesn't stop the app booting, so discarding that page would be wasteful churn.
- **Reuse the existing retry path** rather than reloading in place: `#createStandbyWithRetries` already creates a fresh context, which is what loads cleanly once the verifier settles. The cert-verifier signature is also folded into `isExpectedStandbyTargetNotReadyError` so it logs at debug, not error.
- **No timeout bump.** The 120s realm-server budget is left alone; the fix restores the startup margin the transient was eating rather than papering over it.
- **Capability-guarded wiring** mirrors `#markPageAsInPrerender`, so partial `Page` test stubs fall back to the plain readiness wait.
