### PR TITLE
Retire legacy DEFAULT_LLM constants (CS-11255)

### DIFF
--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -7,7 +7,7 @@ import OpenAI from 'openai';
 import {
   logger,
   aiBotUsername,
-  DEFAULT_LLM,
+  DEFAULT_FALLBACK_MODEL_ID,
   APP_BOXEL_STOP_GENERATING_EVENT_TYPE,
   uuidv4,
   MINIMUM_AI_CREDITS_TO_CONTINUE,
@@ -164,7 +164,7 @@ class Assistant {
   }
 
   getModel(prompt: PromptParts) {
-    return prompt.model ?? DEFAULT_LLM;
+    return prompt.model ?? DEFAULT_FALLBACK_MODEL_ID;
   }
 
   async handleDebugCommands(

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -12,7 +12,7 @@ import {
   APP_BOXEL_CODE_PATCH_RESULT_REL_TYPE,
   APP_BOXEL_CODE_PATCH_CORRECTNESS_MSGTYPE,
   APP_BOXEL_CODE_PATCH_CORRECTNESS_REL_TYPE,
-  DEFAULT_LLM,
+  DEFAULT_FALLBACK_MODEL_ID,
   APP_BOXEL_COMMAND_REQUESTS_KEY,
 } from '@cardstack/runtime-common/matrix-constants';
 
@@ -6534,7 +6534,7 @@ module('set model in prompt', (hooks) => {
     fakeMatrixClient.resetSentEvents();
   });
 
-  test('default active LLM must be equal to `DEFAULT_LLM`', async () => {
+  test('default active LLM must be equal to `DEFAULT_FALLBACK_MODEL_ID`', async () => {
     const eventList: DiscreteMatrixEvent[] = JSON.parse(
       readFileSync(
         path.join(
@@ -6550,7 +6550,7 @@ module('set model in prompt', (hooks) => {
       '@aibot:localhost',
       fakeMatrixClient,
     );
-    assert.strictEqual(model, DEFAULT_LLM);
+    assert.strictEqual(model, DEFAULT_FALLBACK_MODEL_ID);
   });
 
   test('use latest active llm', async () => {

--- a/packages/base/llm-model.gts
+++ b/packages/base/llm-model.gts
@@ -2,11 +2,12 @@ import { Component } from './card-api';
 import StringField from './string';
 import { BoxelSelect } from '@cardstack/boxel-ui/components';
 import { markdownEscape } from '@cardstack/boxel-ui/helpers';
-import { DEFAULT_LLM_ID_TO_NAME } from '@cardstack/runtime-common';
+import { DEFAULT_FALLBACK_MODELS } from '@cardstack/runtime-common';
 
-const LLM_MODEL_OPTIONS = Object.entries(DEFAULT_LLM_ID_TO_NAME).map(
-  ([value, label]) => ({ value, label }),
-);
+const LLM_MODEL_OPTIONS = DEFAULT_FALLBACK_MODELS.map((m) => ({
+  value: m.modelId,
+  label: m.displayName,
+}));
 
 class LLMModelEdit extends Component<typeof LLMModelField> {
   options = LLM_MODEL_OPTIONS;
@@ -46,18 +47,15 @@ export default class LLMModelField extends StringField {
   static displayName = 'LLM Model';
   static edit = LLMModelEdit;
 
-  // CS-10786: prefer the human-readable label when we recognize the model
-  // id, falling back to the id itself. Escaped so any metacharacters in the
-  // label don't leak into the document.
   static markdown = class Markdown extends Component<typeof LLMModelField> {
     get text() {
       let value = this.args.model;
       if (value == null || value === '') {
         return '';
       }
-      let label =
-        (DEFAULT_LLM_ID_TO_NAME as Record<string, string>)[value] ?? value;
-      return markdownEscape(label);
+      let match = DEFAULT_FALLBACK_MODELS.find((m) => m.modelId === value);
+      // Escape so label metacharacters don't leak into the document.
+      return markdownEscape(match?.displayName ?? value);
     }
     <template>{{this.text}}</template>
   };

--- a/packages/host/app/commands/create-ai-assistant-room.ts
+++ b/packages/host/app/commands/create-ai-assistant-room.ts
@@ -6,7 +6,7 @@ import {
   APP_BOXEL_ACTIVE_LLM,
   APP_BOXEL_LLM_MODE,
   APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
-  DEFAULT_LLM,
+  DEFAULT_FALLBACK_MODEL_ID,
 } from '@cardstack/runtime-common/matrix-constants';
 
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
@@ -36,7 +36,7 @@ export default class CreateAiAssistantRoomCommand extends HostBaseCommand<
   private getDefaultLLMDetails() {
     let configuration = this.getDefaultModelConfiguration();
     return {
-      model: configuration?.modelId ?? DEFAULT_LLM,
+      model: configuration?.modelId ?? DEFAULT_FALLBACK_MODEL_ID,
       toolsSupported: Boolean(configuration?.toolsSupported),
       reasoningEffort: configuration?.reasoningEffort ?? undefined,
     };

--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -26,7 +26,7 @@ import {
   APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE,
   APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE,
   APP_BOXEL_LLM_MODE,
-  DEFAULT_LLM,
+  DEFAULT_FALLBACK_MODEL_ID,
   type LLMMode,
 } from '@cardstack/runtime-common/matrix-constants';
 
@@ -411,7 +411,7 @@ export class RoomResource extends Resource<Args> {
     return (
       systemCard?.defaultModelConfiguration?.id ??
       systemCard?.modelConfigurations?.[0]?.id ??
-      DEFAULT_LLM
+      DEFAULT_FALLBACK_MODEL_ID
     );
   }
 

--- a/packages/host/app/services/ai-assistant-panel-service.ts
+++ b/packages/host/app/services/ai-assistant-panel-service.ts
@@ -14,7 +14,7 @@ import {
   APP_BOXEL_ACTIVE_LLM,
   APP_BOXEL_LLM_MODE,
   APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
-  DEFAULT_LLM,
+  DEFAULT_FALLBACK_MODEL_ID,
   type LLMMode,
 } from '@cardstack/runtime-common/matrix-constants';
 
@@ -510,7 +510,7 @@ export default class AiAssistantPanelService extends Service {
         {
           type: APP_BOXEL_ACTIVE_LLM,
           content: {
-            model: configuration?.modelId ?? DEFAULT_LLM,
+            model: configuration?.modelId ?? DEFAULT_FALLBACK_MODEL_ID,
             toolsSupported: Boolean(configuration?.toolsSupported),
             reasoningEffort: configuration?.reasoningEffort ?? undefined,
           },

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -52,7 +52,7 @@ import {
   APP_BOXEL_CODE_PATCH_CORRECTNESS_REL_TYPE,
   APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
   APP_BOXEL_ACTIVE_LLM,
-  DEFAULT_LLM,
+  DEFAULT_FALLBACK_MODEL_ID,
 } from '../matrix-constants';
 import { decodeCommandRequest } from '../commands';
 import type { CommandRequest } from '../commands';
@@ -2250,7 +2250,7 @@ function getActiveLLMDetails(eventlist: DiscreteMatrixEvent[]): {
   ) as ActiveLLMEvent | undefined;
   if (!activeLLMEvent) {
     return {
-      model: DEFAULT_LLM,
+      model: DEFAULT_FALLBACK_MODEL_ID,
       toolsSupported: undefined,
       reasoningEffort: undefined,
     };

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -1233,4 +1233,3 @@ export {
   type BotCommandFilter,
   type BotCommandMatrixFilter,
 } from './bot-command';
-export { DEFAULT_LLM_ID_TO_NAME } from './matrix-constants';

--- a/packages/runtime-common/matrix-constants.ts
+++ b/packages/runtime-common/matrix-constants.ts
@@ -36,43 +36,9 @@ export const APP_BOXEL_CONTINUATION_OF_CONTENT_KEY =
 export const APP_BOXEL_LLM_MODE = 'app.boxel.llm-mode';
 export const APP_BOXEL_RELOAD_BILLING_DATA_KEY = 'app.boxel.reloadBillingData';
 export type LLMMode = 'ask' | 'act';
-export const DEFAULT_LLM = 'anthropic/claude-sonnet-4.6';
 export const DEFAULT_CODING_LLM = 'anthropic/claude-sonnet-4.6';
 export const DEFAULT_REMIX_LLM = 'openai/gpt-5-nano';
 export const DEFAULT_IMAGE_GENERATION_LLM = 'google/gemini-2.5-flash-image';
-
-export const DEFAULT_LLM_ID_TO_NAME: Record<string, string> = {
-  'anthropic/claude-3.5-sonnet': 'Anthropic: Claude 3.5 Sonnet',
-  'anthropic/claude-3.7-sonnet': 'Anthropic: Claude 3.7 Sonnet',
-  'anthropic/claude-3.7-sonnet:thinking':
-    'Anthropic: Claude 3.7 Sonnet (thinking)',
-  'anthropic/claude-haiku-4.5': 'Anthropic: Claude Haiku 4.5',
-  'anthropic/claude-sonnet-4': 'Anthropic: Claude Sonnet 4',
-  'anthropic/claude-sonnet-4.5': 'Anthropic: Claude Sonnet 4.5',
-  'anthropic/claude-sonnet-4.6': 'Anthropic: Claude Sonnet 4.6',
-  'anthropic/claude-opus-4.1': 'Anthropic: Claude Opus 4.1',
-  'deepseek/deepseek-chat-v3-0324': 'DeepSeek: DeepSeek V3 0324',
-  'google/gemini-2.5-pro': 'Google: Gemini 2.5 Pro',
-  'google/gemini-2.5-flash-lite': 'Google: Gemini 2.5 Flash Lite',
-  'google/gemini-2.5-flash': 'Google: Gemini 2.5 Flash',
-  'meta-llama/llama-3.2-3b-instruct': 'Meta: Llama 3.2 3B Instruct',
-  'openai/gpt-4.1-nano': 'OpenAI: GPT-4.1 Nano',
-  'openai/gpt-4.1-mini': 'OpenAI: GPT-4.1 Mini',
-  'openai/gpt-4.1': 'OpenAI: GPT-4.1',
-  'openai/gpt-4o': 'OpenAI: GPT-4o',
-  'openai/gpt-4o-mini': 'OpenAI: GPT-4o-mini',
-  'openai/gpt-5-nano': 'OpenAI: GPT-5 Nano',
-  'openai/gpt-5-mini': 'OpenAI: GPT-5 Mini',
-  'openai/gpt-5': 'OpenAI: GPT-5',
-  'openai/gpt-oss-20b': 'OpenAI: GPT OSS 20B',
-};
-
-// Note - we are moving towards using the system card for defining these for users
-// See:
-// - packages/catalog-realm/ModelConfiguration for a list of models for all users
-// - packages/catalog-realm/SystemCard/default.json for the default system card for users
-// - packages/host/README.md for how to add new models
-export const DEFAULT_LLM_LIST = Object.keys(DEFAULT_LLM_ID_TO_NAME);
 
 // Realm-independent fallback model surface. Used when SystemCard /
 // SystemCard.modelConfigurations is unavailable so we never ship undefined


### PR DESCRIPTION
## Summary

Removes the now-dead `DEFAULT_LLM` (string), `DEFAULT_LLM_LIST` (unused),
and 22-entry `DEFAULT_LLM_ID_TO_NAME` (map) exports from
`packages/runtime-common/matrix-constants.ts`. T1 (CS-11249) introduced the
realm-independent fallback surface (`DEFAULT_FALLBACK_MODEL_ID` +
`DEFAULT_FALLBACK_MODELS`); the seven remaining `DEFAULT_LLM` call sites now
read from `DEFAULT_FALLBACK_MODEL_ID` (identical value, no behavior change).

`packages/base/llm-model.gts` was the only consumer of `DEFAULT_LLM_ID_TO_NAME`.
Its `BoxelSelect` dropdown and markdown label lookup now derive from
`DEFAULT_FALLBACK_MODELS`. Visible options shrink from 22 to the 6 curated
models; stored ids outside the curated set still render their raw modelId
(same fallback semantics as before).

Also drops a redundant explicit re-export of `DEFAULT_LLM_ID_TO_NAME` at
`packages/runtime-common/index.ts:1236` (the bulk `export * from './matrix-constants'` already covered it).

**Public-surface note** for downstream realms importing from
`@cardstack/runtime-common/matrix-constants`: `DEFAULT_LLM`,
`DEFAULT_LLM_LIST`, and `DEFAULT_LLM_ID_TO_NAME` are removed. Use
`DEFAULT_FALLBACK_MODEL_ID` and `DEFAULT_FALLBACK_MODELS` instead.

Closes the fallback-SystemCard project cleanup work; depends on CS-11249.

## Test plan

- [x] `grep -rn 'DEFAULT_LLM_ID_TO_NAME\|DEFAULT_LLM_LIST\|\bDEFAULT_LLM\b' packages/` returns no hits
- [x] `pnpm lint` clean in `runtime-common`, `host`, `ai-bot`, `base`
- [x] `packages/ai-bot/tests/prompt-construction-test.ts` — renamed `default active LLM must be equal to DEFAULT_FALLBACK_MODEL_ID` test passes locally
- [x] CI: full host integration suite (including `fallback-models-test.gts`)
- [x] CI: runtime-common + realm-server shared fallback-models tests
- [ ] Manual smoke: SystemCard editor `LLMModelField` dropdown shows the 6 curated models
- [ ] Manual smoke: AI assistant picker with empty SystemCard still selects fallback model and ships full capability fields on `sendActiveLLMEvent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)