### PR TITLE
Persist broken-link findings on the success index entry

### DIFF
--- a/.claude/skills/aws-access/SKILL.md
+++ b/.claude/skills/aws-access/SKILL.md
@@ -258,7 +258,7 @@ When constructing a query, the cheapest sanity check is: does the SQL begin with
 
 ### What's actually in the database
 
-The `indexing-diagnostics` skill is the right entry point for `boxel_index` / `boxel_index_working` / `error_doc` exploration — it documents the schema, the `timing_diagnostics` JSONB shape, and the canonical query patterns. This skill only covers *getting connected*; the queries themselves live there.
+The `indexing-diagnostics` skill is the right entry point for `boxel_index` / `boxel_index_working` / `error_doc` exploration — it documents the schema, the `diagnostics` JSONB shape, and the canonical query patterns. This skill only covers *getting connected*; the queries themselves live there.
 
 ## Browsing the EFS filesystem (read-only)
 

--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -1,28 +1,29 @@
 ---
 name: indexing-diagnostics
-description: Investigate slow or failing indexing using the diagnostics persisted on every `boxel_index` row (`timing_diagnostics` JSONB column, mirrored onto `error_doc.diagnostics` for error rows) plus the matching prerender-server / manager logs. Covers (1) a render inside indexing timed out — classify which part of the prerender pipeline stalled, (2) an incremental or full reindex was slow but didn't fail — attribute time across the invalidation fan-out and find the rows that cost the most, and (3) enumerating cards with broken `linksTo` / `linksToMany` targets via `timing_diagnostics.brokenLinks` (those cards index cleanly, so this is the only indexed signal). Use when indexing fails with "Render timeout", when a user sees a 504, when a reindex took much longer than expected, when an `.gts` edit triggers a surprising amount of re-render work, when investigating the CS-10820 saturation class of incidents, or when asked to list / count cards with broken links in a realm. For staging/prod investigations this skill layers on top of `aws-access`, which provides the AWS session and the SSM port-forward path into the in-VPC database (authenticated as `claude_readonly_user`) — read that skill first when the question is about a deployed environment.
+description: Investigate slow or failing indexing using the diagnostics persisted on every `boxel_index` row (`diagnostics` JSONB column, mirrored onto `error_doc.diagnostics` for error rows) plus the matching prerender-server / manager logs. Covers (1) a render inside indexing timed out — classify which part of the prerender pipeline stalled, (2) an incremental or full reindex was slow but didn't fail — attribute time across the invalidation fan-out and find the rows that cost the most, and (3) enumerating cards with broken `linksTo` / `linksToMany` targets via `diagnostics.brokenLinks` (those cards index cleanly, so this is the only indexed signal). Use when indexing fails with "Render timeout", when a user sees a 504, when a reindex took much longer than expected, when an `.gts` edit triggers a surprising amount of re-render work, when investigating the CS-10820 saturation class of incidents, or when asked to list / count cards with broken links in a realm. For staging/prod investigations this skill layers on top of `aws-access`, which provides the AWS session and the SSM port-forward path into the in-VPC database (authenticated as `claude_readonly_user`) — read that skill first when the question is about a deployed environment.
 allowed-tools: Read, Grep, Glob, Bash
 ---
 
 # Indexing diagnostics
 
-Every indexer write (`IndexWriter.updateEntry`) persists a diagnostic blob on the row it wrote. The blob captures what the prerender pipeline spent its time on and what category of stall (if any) the render was stuck in. It's the primary tool for investigating:
+Every indexer write (`IndexWriter.updateEntry`) persists a diagnostic blob on the row it wrote — the `diagnostics` JSONB column. Most of the blob is about what the prerender pipeline spent its time on and what category of stall (if any) the render was stuck in, but it also records non-timing render findings, notably `brokenLinks`. It's the primary tool for investigating:
 
 - **A render that timed out during indexing** — classify the stall, fix the right layer. (Also applies to user-facing 504s since the UI path goes through the same prerender.)
 - **A reindex that was slow but succeeded** — attribute wall-clock across the cards that got re-rendered, find the real culprit in the fan-out.
+- **Which cards have broken links** — enumerate cards with a broken `linksTo` / `linksToMany` target straight from the column; those cards index cleanly, so `diagnostics.brokenLinks` is the only indexed signal. See [Mode E](#mode-e--enumerate-cards-with-broken-links).
 
-Both use cases read from the same data. The difference is the query you start with.
+All three read from the same column. The difference is the query you start with.
 
 ## Where the diagnostics live
 
 Four places, all correlated:
 
-1. **`boxel_index.timing_diagnostics` (and `boxel_index_working.timing_diagnostics`)** — JSONB column, populated for **every** row the indexer writes, regardless of `has_error`. Source of truth for **card** renders. Carries the full `RenderTimeoutDiagnostics` payload plus three write-side stamps: `invalidationId`, `indexedAt`, `requestId`. It also carries a `brokenLinks` array on any card row whose render found a broken `linksTo` / `linksToMany` target — see [Mode E](#mode-e--enumerate-cards-with-broken-links). Note this is the one block that isn't about *timing*: a card with broken links still indexes as a clean `type='instance'` (the broken slot renders a placeholder), so `brokenLinks` is the only indexed signal that the row has a broken reference.
-2. **`modules.timing_diagnostics`** — JSONB column, populated for every row `persistModuleCacheEntry` writes (success and error paths). Source of truth for **module** renders (`prerenderModule` → definition extraction). Same `RenderTimeoutDiagnostics` shape with `requestId` flattened in; no `invalidationId` (modules don't go through `Batch.invalidate`). The row's existing `created_at` column is the wall-clock stamp for cross-table joins. See [Mode D](#mode-d--a-module-render-was-slow-or-hung) below.
-3. **`error_doc.diagnostics`** — derived copy of `timing_diagnostics`, written only for error rows on `boxel_index`. Exists so the existing UI read path (`error_doc` → `CardErrorJSONAPI.meta.diagnostics` via `formattedError`) keeps working without a schema rename. Non-error rows have `error_doc = null`; go to `timing_diagnostics` directly.
-4. **Logs** — `prerender-server`, `manager`, and `remote-prerenderer` lines all carry `requestId=…`. `grep requestId=<uuid>` collates one call across all three processes. The same `requestId` lands on both `boxel_index.timing_diagnostics->>'requestId'` and `modules.timing_diagnostics->>'requestId'`, so a hung card render and the module renders it triggered (via `getDefinition`) can be joined back to one investigation. For saturation incidents there's also the periodic `prerender-queue-snapshot` line on each prerender server.
+1. **`boxel_index.diagnostics` (and `boxel_index_working.diagnostics`)** — JSONB column, populated for **every** row the indexer writes, regardless of `has_error`. Source of truth for **card** renders. Carries the full `RenderTimeoutDiagnostics` payload plus three write-side stamps: `invalidationId`, `indexedAt`, `requestId`. It also carries a `brokenLinks` array on any card row whose render found a broken `linksTo` / `linksToMany` target — see [Mode E](#mode-e--enumerate-cards-with-broken-links). Note this is the one block that isn't about *timing*: a card with broken links still indexes as a clean `type='instance'` (the broken slot renders a placeholder), so `brokenLinks` is the only indexed signal that the row has a broken reference.
+2. **`modules.diagnostics`** — JSONB column, populated for every row `persistModuleCacheEntry` writes (success and error paths). Source of truth for **module** renders (`prerenderModule` → definition extraction). Same `RenderTimeoutDiagnostics` shape with `requestId` flattened in; no `invalidationId` (modules don't go through `Batch.invalidate`). The row's existing `created_at` column is the wall-clock stamp for cross-table joins. See [Mode D](#mode-d--a-module-render-was-slow-or-hung) below.
+3. **`error_doc.diagnostics`** — derived copy of `diagnostics`, written only for error rows on `boxel_index`. Exists so the existing UI read path (`error_doc` → `CardErrorJSONAPI.meta.diagnostics` via `formattedError`) keeps working without a schema rename. Non-error rows have `error_doc = null`; go to `diagnostics` directly.
+4. **Logs** — `prerender-server`, `manager`, and `remote-prerenderer` lines all carry `requestId=…`. `grep requestId=<uuid>` collates one call across all three processes. The same `requestId` lands on both `boxel_index.diagnostics->>'requestId'` and `modules.diagnostics->>'requestId'`, so a hung card render and the module renders it triggered (via `getDefinition`) can be joined back to one investigation. For saturation incidents there's also the periodic `prerender-queue-snapshot` line on each prerender server.
 
-For UI triage you'll typically read the JSON error response (which surfaces `error_doc.diagnostics` as `meta.diagnostics`). For operator / SQL triage — especially slow non-failing reindexes — query the `timing_diagnostics` column directly.
+For UI triage you'll typically read the JSON error response (which surfaces `error_doc.diagnostics` as `meta.diagnostics`). For operator / SQL triage — especially slow non-failing reindexes — query the `diagnostics` column directly.
 
 ## How to actually run these queries
 
@@ -59,18 +60,18 @@ Why this matters for triage:
 
 2. **Distinguishing capacity issues from priority misrouting**: a `priority=10` row that waited >1s in `tabQueueMs` while the affinity's `prerender-queue-snapshot` shows `priorities=tab:10:N` (queued behind other priority-10 work) is a **capacity** problem — the user-priority workload exceeded the fleet. A `priority=10` row queued behind `priorities=tab:0:N` (queued behind background work, with manager-side priority routing live in the build) is a **routing** failure — the manager picked the wrong server, or the file render the row was queued behind isn't releasing. These need different fixes.
 
-3. **Confirming priority routing actually fired**: if a known-user `_reindex` shows up in `timing_diagnostics` with `priority=0`, the producer-side threading (job → IndexRunner → `prerenderVisit`) regressed somewhere. Most-likely place is a new task type that didn't pick up `jobInfo.priority`.
+3. **Confirming priority routing actually fired**: if a known-user `_reindex` shows up in `diagnostics` with `priority=0`, the producer-side threading (job → IndexRunner → `prerenderVisit`) regressed somewhere. Most-likely place is a new task type that didn't pick up `jobInfo.priority`.
 
 4. **Sharpening the deadlock fingerprint**: `affinitySnapshot.sameAffinityActivity[*].priority` lets you tell a self-referential prerender deadlock apart from priority-driven queuing. Same-priority queued module sub-render on a stuck same-priority file render → deadlock. Higher-priority queued sibling → priority routing working as intended.
 
-The priority value lives on the `timing_diagnostics.priority` field and on every `sameAffinityActivity` entry. The periodic `prerender-queue-snapshot` log line carries per-affinity priority breakdowns. See [Classify in one pass](#classify-in-one-pass) and the field-by-field section below for the exact triage rules.
+The priority value lives on the `diagnostics.priority` field and on every `sameAffinityActivity` entry. The periodic `prerender-queue-snapshot` log line carries per-affinity priority breakdowns. See [Classify in one pass](#classify-in-one-pass) and the field-by-field section below for the exact triage rules.
 
 ## Mode A — a render timed out
 
 Pull the diagnostic JSON for the erroring row:
 
 ```sql
-SELECT timing_diagnostics
+SELECT diagnostics
 FROM boxel_index
 WHERE url = '<errored-card-url>'
   AND type = 'instance';
@@ -82,25 +83,25 @@ Walk the fields per [Classify in one pass](#classify-in-one-pass). The _first_ p
 
 ## Mode B — an incremental reindex was slow
 
-Every `Batch.invalidate(urls)` call mints a UUID stashed into `timing_diagnostics.invalidationId` for every row written during that fan-out. If a `.gts` edit invalidates 8 rows (one file + seven card instances), all eight carry the same `invalidationId` — so you can look at the whole reindex as a group.
+Every `Batch.invalidate(urls)` call mints a UUID stashed into `diagnostics.invalidationId` for every row written during that fan-out. If a `.gts` edit invalidates 8 rows (one file + seven card instances), all eight carry the same `invalidationId` — so you can look at the whole reindex as a group.
 
 **Step 1 — find the invalidation you care about.** If you don't already have the ID, discover recent big ones:
 
 ```sql
 -- Biggest fan-outs in the realm, most recent first
 SELECT
-  timing_diagnostics->>'invalidationId' AS id,
+  diagnostics->>'invalidationId' AS id,
   count(*)                              AS rows_touched,
   to_timestamp(
-    max((timing_diagnostics->>'indexedAt')::bigint) / 1000
+    max((diagnostics->>'indexedAt')::bigint) / 1000
   )                                     AS last_indexed_at,
-  sum((timing_diagnostics->>'renderElapsedMs')::int)
+  sum((diagnostics->>'renderElapsedMs')::int)
                                         AS total_render_ms,
-  max((timing_diagnostics->>'renderElapsedMs')::int)
+  max((diagnostics->>'renderElapsedMs')::int)
                                         AS slowest_ms
 FROM boxel_index
 WHERE realm_url = 'https://localhost:4201/user/your-realm/'
-  AND timing_diagnostics->>'invalidationId' IS NOT NULL
+  AND diagnostics->>'invalidationId' IS NOT NULL
 GROUP BY 1
 ORDER BY last_indexed_at DESC
 LIMIT 20;
@@ -113,25 +114,25 @@ SELECT
   url,
   type,
   has_error,
-  timing_diagnostics->>'renderStage'                  AS stage,
-  (timing_diagnostics->>'renderElapsedMs')::int       AS render_ms,
-  (timing_diagnostics->>'launchMs')::int              AS launch_ms,
-  timing_diagnostics->'waits'                         AS waits,
+  diagnostics->>'renderStage'                  AS stage,
+  (diagnostics->>'renderElapsedMs')::int       AS render_ms,
+  (diagnostics->>'launchMs')::int              AS launch_ms,
+  diagnostics->'waits'                         AS waits,
   jsonb_array_length(
-    COALESCE(timing_diagnostics->'queryLoadsInFlight', '[]'::jsonb)
+    COALESCE(diagnostics->'queryLoadsInFlight', '[]'::jsonb)
   )                                                   AS queries_stuck,
   jsonb_array_length(
-    COALESCE(timing_diagnostics->'inFlightModuleImports', '[]'::jsonb)
+    COALESCE(diagnostics->'inFlightModuleImports', '[]'::jsonb)
   )                                                   AS modules_stuck,
-  to_timestamp((timing_diagnostics->>'indexedAt')::bigint / 1000)
+  to_timestamp((diagnostics->>'indexedAt')::bigint / 1000)
                                                       AS indexed_at
 FROM boxel_index
 WHERE realm_url = 'https://localhost:4201/user/your-realm/'
-  AND timing_diagnostics->>'invalidationId' = '<uuid>'
+  AND diagnostics->>'invalidationId' = '<uuid>'
 ORDER BY render_ms DESC NULLS LAST;
 ```
 
-**Step 3 — classify each slow row.** For the top offenders, pull the full `timing_diagnostics` and apply the [Classify in one pass](#classify-in-one-pass) table to each. Common patterns:
+**Step 3 — classify each slow row.** For the top offenders, pull the full `diagnostics` and apply the [Classify in one pass](#classify-in-one-pass) table to each. Common patterns:
 
 - One row dominates (e.g. a dashboard card) and the rest are cheap. The big row is the real target — investigate its `queryLoadsInFlight` / `recentModuleEvaluations` / `cardDocLoadsInFlight`.
 - All rows share a large `launchMs`. Capacity contention during the reindex, not the cards' fault.
@@ -144,10 +145,10 @@ ORDER BY render_ms DESC NULLS LAST;
 -- Slowest single renders in the realm, regardless of error state
 SELECT
   url,
-  to_timestamp((timing_diagnostics->>'indexedAt')::bigint / 1000) AS indexed_at,
-  (timing_diagnostics->>'renderElapsedMs')::int                   AS render_ms,
-  timing_diagnostics->>'renderStage'                              AS stage,
-  timing_diagnostics->>'invalidationId'                           AS group,
+  to_timestamp((diagnostics->>'indexedAt')::bigint / 1000) AS indexed_at,
+  (diagnostics->>'renderElapsedMs')::int                   AS render_ms,
+  diagnostics->>'renderStage'                              AS stage,
+  diagnostics->>'invalidationId'                           AS group,
   has_error
 FROM boxel_index
 WHERE realm_url = 'https://localhost:4201/user/your-realm/'
@@ -157,13 +158,13 @@ LIMIT 20;
 -- p95 render time by realm
 SELECT
   realm_url,
-  avg((timing_diagnostics->>'renderElapsedMs')::int) AS avg_ms,
+  avg((diagnostics->>'renderElapsedMs')::int) AS avg_ms,
   percentile_cont(0.95) WITHIN GROUP (
-    ORDER BY (timing_diagnostics->>'renderElapsedMs')::int
+    ORDER BY (diagnostics->>'renderElapsedMs')::int
   )                                                   AS p95_ms,
   count(*)                                            AS rows
 FROM boxel_index
-WHERE timing_diagnostics->>'renderElapsedMs' IS NOT NULL
+WHERE diagnostics->>'renderElapsedMs' IS NOT NULL
 GROUP BY 1
 ORDER BY p95_ms DESC NULLS LAST
 LIMIT 20;
@@ -175,22 +176,22 @@ LIMIT 20;
 -- compute work rather than data loads or template stalls.
 SELECT
   url,
-  to_timestamp((timing_diagnostics->>'indexedAt')::bigint / 1000) AS indexed_at,
-  (timing_diagnostics->>'computedCalls')::int                     AS calls,
-  (timing_diagnostics->>'computedCacheHits')::int                 AS cache_hits,
-  (timing_diagnostics->>'serializeMs')::numeric                   AS serialize_ms,
-  (timing_diagnostics->>'searchDocMs')::numeric                   AS search_doc_ms,
-  (timing_diagnostics->>'renderElapsedMs')::int                   AS render_ms
+  to_timestamp((diagnostics->>'indexedAt')::bigint / 1000) AS indexed_at,
+  (diagnostics->>'computedCalls')::int                     AS calls,
+  (diagnostics->>'computedCacheHits')::int                 AS cache_hits,
+  (diagnostics->>'serializeMs')::numeric                   AS serialize_ms,
+  (diagnostics->>'searchDocMs')::numeric                   AS search_doc_ms,
+  (diagnostics->>'renderElapsedMs')::int                   AS render_ms
 FROM boxel_index
 WHERE realm_url = 'https://localhost:4201/user/your-realm/'
-  AND timing_diagnostics->>'computedCalls' IS NOT NULL
-ORDER BY (timing_diagnostics->>'computedCalls')::int DESC NULLS LAST
+  AND diagnostics->>'computedCalls' IS NOT NULL
+ORDER BY (diagnostics->>'computedCalls')::int DESC NULLS LAST
 LIMIT 20;
 ```
 
 ## Mode C — a worker job is stuck or got rejected
 
-Mode A and Mode B both assume `boxel_index` has up-to-date `timing_diagnostics` for the rows you're investigating. That assumption breaks when an indexing job is _in progress_ or got rejected mid-flight: nothing has been committed to `boxel_index` yet (the indexer writes to a staging table and only swaps on success — see [Reading partial progress from `boxel_index_working`](#5-reading-partial-progress-from-boxel_index_working) below), so the diagnostics column there is stale or null for the affected rows.
+Mode A and Mode B both assume `boxel_index` has up-to-date `diagnostics` for the rows you're investigating. That assumption breaks when an indexing job is _in progress_ or got rejected mid-flight: nothing has been committed to `boxel_index` yet (the indexer writes to a staging table and only swaps on success — see [Reading partial progress from `boxel_index_working`](#5-reading-partial-progress-from-boxel_index_working) below), so the diagnostics column there is stale or null for the affected rows.
 
 For this mode the diagnostic stance flips from "what timed out" (Mode A) or "what was slow" (Mode B) to **"what hasn't happened yet"**. You're reconstructing the work the job _would have done_ from three sources together:
 
@@ -203,7 +204,7 @@ For this mode the diagnostic stance flips from "what timed out" (Mode A) or "wha
 You're in Mode C territory if any of these hold:
 
 - The worker log shows a `starting from-scratch indexing` or `starting from incremental indexing` line for the realm but no matching `completed from scratch indexing` / `completed incremental indexing` line in the same `[job: <id>.<rid>]` group (the job-identity prefix is `[job: <jobId>.<reservationId>]`; see `jobIdentity` in `packages/runtime-common/utils.ts`).
-- `boxel_index` rows for the realm look stale (`last_modified` predates the file's EFS mtime, or `timing_diagnostics->>'indexedAt'` is older than you'd expect for the last reindex you triggered).
+- `boxel_index` rows for the realm look stale (`last_modified` predates the file's EFS mtime, or `diagnostics->>'indexedAt'` is older than you'd expect for the last reindex you triggered).
 - The job-id appears as `unfulfilled` in `jobs` and has at least one row in `job_reservations` whose `completed_at IS NULL` (in-flight). A `rejected` row in `jobs` with no `completed_at` on its newest reservation means the worker bailed but the worker-finalize transaction may not have run cleanly.
 - A subsequent reindex was enqueued and re-reserved the same concurrency group (`indexing:<realm-url>`) — check `job_reservations.created_at` for the same `job_id`.
 
@@ -421,7 +422,7 @@ Two-hop fan-out: rerun with the first hop's `(url, file_alias, type)` plugged in
 -- that was being worked on when things froze.
 --
 -- The diagnostic projection mirrors Mode B's fan-out query — use
--- timing_diagnostics->>'renderStage' / 'currentlyEvaluatingModule' /
+-- diagnostics->>'renderStage' / 'currentlyEvaluatingModule' /
 -- 'recentModuleEvaluations[0].url' to identify the specific module the
 -- worker stalled on.
 SELECT
@@ -429,41 +430,41 @@ SELECT
   type,
   has_error,
   realm_version,
-  to_timestamp((timing_diagnostics->>'indexedAt')::bigint / 1000)
+  to_timestamp((diagnostics->>'indexedAt')::bigint / 1000)
                                                        AS indexed_at,
-  timing_diagnostics->>'invalidationId'                AS invalidation_id,
-  timing_diagnostics->>'renderStage'                   AS render_stage,
-  timing_diagnostics->>'currentlyEvaluatingModule'     AS evaluating_module,
-  timing_diagnostics->'recentModuleEvaluations'->0->>'url'
+  diagnostics->>'invalidationId'                AS invalidation_id,
+  diagnostics->>'renderStage'                   AS render_stage,
+  diagnostics->>'currentlyEvaluatingModule'     AS evaluating_module,
+  diagnostics->'recentModuleEvaluations'->0->>'url'
                                                        AS slowest_module,
   jsonb_array_length(
-    COALESCE(timing_diagnostics->'inFlightModuleImports', '[]'::jsonb)
+    COALESCE(diagnostics->'inFlightModuleImports', '[]'::jsonb)
   )                                                    AS modules_in_flight,
   jsonb_array_length(
-    COALESCE(timing_diagnostics->'queryLoadsInFlight', '[]'::jsonb)
+    COALESCE(diagnostics->'queryLoadsInFlight', '[]'::jsonb)
   )                                                    AS queries_in_flight
 FROM boxel_index_working
 WHERE realm_url = '<realm-url>'
-  AND timing_diagnostics->>'invalidationId' = '<invalidation-id>'
-ORDER BY (timing_diagnostics->>'indexedAt')::bigint ASC;
+  AND diagnostics->>'invalidationId' = '<invalidation-id>'
+ORDER BY (diagnostics->>'indexedAt')::bigint ASC;
 ```
 
 If you don't already have an `invalidationId`, find the most recent batch's ID against the working table (the last `updateEntry` for the realm wins):
 
 ```sql
 SELECT
-  timing_diagnostics->>'invalidationId'                AS invalidation_id,
+  diagnostics->>'invalidationId'                AS invalidation_id,
   realm_version,
   count(*)                                             AS rows_written,
   to_timestamp(
-    min((timing_diagnostics->>'indexedAt')::bigint) / 1000
+    min((diagnostics->>'indexedAt')::bigint) / 1000
   )                                                    AS first_write,
   to_timestamp(
-    max((timing_diagnostics->>'indexedAt')::bigint) / 1000
+    max((diagnostics->>'indexedAt')::bigint) / 1000
   )                                                    AS last_write
 FROM boxel_index_working
 WHERE realm_url = '<realm-url>'
-  AND timing_diagnostics->>'invalidationId' IS NOT NULL
+  AND diagnostics->>'invalidationId' IS NOT NULL
 GROUP BY 1, 2
 ORDER BY last_write DESC
 LIMIT 10;
@@ -557,7 +558,7 @@ cw --profile claude-staging --region us-east-1 tail -b 2h \
 
 A short rubric for the most common shapes:
 
-- **High confidence the stall is at file X**: the bottom row of `boxel_index_working` (max `indexedAt` for the batch's `invalidationId`) is X **AND** the worker's last `begin fused visit of file X` line has no matching `completed fused visit of file X` line **AND** the bottom row's `recentModuleEvaluations[0].url` (or `currentlyEvaluatingModule` / `inFlightModuleImports[0]`) is a module under X. Treat the row's `timing_diagnostics` as a Mode A capture and walk the [Classify in one pass](#classify-in-one-pass) table.
+- **High confidence the stall is at file X**: the bottom row of `boxel_index_working` (max `indexedAt` for the batch's `invalidationId`) is X **AND** the worker's last `begin fused visit of file X` line has no matching `completed fused visit of file X` line **AND** the bottom row's `recentModuleEvaluations[0].url` (or `currentlyEvaluatingModule` / `inFlightModuleImports[0]`) is a module under X. Treat the row's `diagnostics` as a Mode A capture and walk the [Classify in one pass](#classify-in-one-pass) table.
 - **Medium confidence**: only two of the three signals agree. Most often the worker log is the dropout — debug-level logging wasn't on. Promote `index-runner` to debug and trigger a follow-up reindex to validate.
 - **Low confidence — the runner stalled before any per-file work**: `boxel_index_working` has no rows for this batch's `invalidationId` (no row stamped with the batch UUID, no `is_deleted = TRUE` tombstones at the batch's `realm_version`). The worker is still in **invalidation discovery** — either the mtime walk (no `discovering invalidations in dir` line yet) or the consumer fan-out (the `discovering` line is there but no per-file visit-start lines). Look at the worker's `index-perf` `time to get file system mtimes` / `time to invalidate` lines — if those are missing too, you're stuck in the realm-server fetch (`reader.mtimes()` → `_mtimes` HTTP call) or in `Batch.invalidate`'s own jsonb-containment SQL (`itemsThatReference`). Then go look at what _should_ have been in the seed but wasn't — cross-check the EFS file listing against the realm's `boxel_index.last_modified` per step 3.
 - **Confirm a "rejected" job actually failed cleanly**: `jobs.status = 'rejected'` should pair with the matching reservation's `completed_at IS NOT NULL`. If `completed_at IS NULL`, the worker bailed before its finalize transaction (see `pg-queue.ts` lines 619-696); the reservation's `locked_until` will eventually expire and another worker can claim it.
@@ -579,12 +580,12 @@ A short rubric for the most common shapes:
 ### 9. What this mode can't tell you
 
 - If the worker died _before_ any DB write — crashed during `discoverInvalidations`, OOM-killed during the mtime walk, or threw inside `Batch.invalidate`'s own SQL — `boxel_index_working` will have no rows for this batch's `invalidationId`. The `Batch` object mints the `invalidationId` in its constructor, but it only lands on disk when the first `updateEntry` or `tombstoneEntries` call runs. Until then the only diagnostic signals are the worker log and the EFS state. Mode C cannot reconstruct _which_ file the worker was processing in that case — you need either `index-runner=debug` log output or a Sentry trace.
-- The `timing_diagnostics` for partial-progress rows is the **per-render** capture for that row's prerender call. It won't tell you why the _next_ render froze. If the bottom-row's diagnostic is clean (low `renderElapsedMs`, no in-flight loads), the stall is between renders — usually `Batch.invalidate` recursion against a tightly-cycled module graph, or DB contention on the `boxel_index_working` upsert. The `index-perf` `time to determine items that reference …` lines are the only fingerprints of that loop.
-- A `boxel_index` row's `timing_diagnostics` reflects the **last successful** indexing pass, not the in-flight one. Don't confuse a stale `boxel_index` `indexedAt` with the stuck job — always cross-reference against the matching `boxel_index_working` row (same `(url, realm_url)`) before drawing conclusions.
+- The `diagnostics` for partial-progress rows is the **per-render** capture for that row's prerender call. It won't tell you why the _next_ render froze. If the bottom-row's diagnostic is clean (low `renderElapsedMs`, no in-flight loads), the stall is between renders — usually `Batch.invalidate` recursion against a tightly-cycled module graph, or DB contention on the `boxel_index_working` upsert. The `index-perf` `time to determine items that reference …` lines are the only fingerprints of that loop.
+- A `boxel_index` row's `diagnostics` reflects the **last successful** indexing pass, not the in-flight one. Don't confuse a stale `boxel_index` `indexedAt` with the stuck job — always cross-reference against the matching `boxel_index_working` row (same `(url, realm_url)`) before drawing conclusions.
 
 ## Mode D — a module render was slow or hung
 
-Module renders (`prerenderModule`, used by `getDefinition` to convert filter JSON into SQL on `_federated-search`, plus everywhere else a card definition is needed without a card render) go through the same prerender pipeline as card renders, but they land in the `modules` table — not `boxel_index`. The `timing_diagnostics` JSONB column on `modules` carries the same `RenderTimeoutDiagnostics`-with-`requestId` shape, so the field-by-field reading and the [Classify in one pass](#classify-in-one-pass) table apply unchanged. Only the lookup queries differ.
+Module renders (`prerenderModule`, used by `getDefinition` to convert filter JSON into SQL on `_federated-search`, plus everywhere else a card definition is needed without a card render) go through the same prerender pipeline as card renders, but they land in the `modules` table — not `boxel_index`. The `diagnostics` JSONB column on `modules` carries the same `RenderTimeoutDiagnostics`-with-`requestId` shape, so the field-by-field reading and the [Classify in one pass](#classify-in-one-pass) table apply unchanged. Only the lookup queries differ.
 
 **When to use this mode:** a card render hung waiting on `getDefinition` (Mode A captured `cardDocLoadsInFlight = 0`, `queryLoadsInFlight = 0`, but the realm-server's reply to `_federated-search` itself was slow); an investigation needs to attribute time across both card renders and the module renders they triggered; or you want to find the slowest module renders fleet-wide. Same payload shape, queryable via SQL.
 
@@ -592,14 +593,14 @@ Module renders (`prerenderModule`, used by `getDefinition` to convert filter JSO
 
 ```sql
 SELECT m.url,
-       (m.timing_diagnostics->>'renderElapsedMs')::int AS render_ms,
-       m.timing_diagnostics->>'renderStage'            AS stage,
-       m.timing_diagnostics->>'requestId'              AS request_id,
+       (m.diagnostics->>'renderElapsedMs')::int AS render_ms,
+       m.diagnostics->>'renderStage'            AS stage,
+       m.diagnostics->>'requestId'              AS request_id,
        to_timestamp(m.created_at::bigint / 1000)       AS created_at,
        m.error_doc IS NOT NULL                         AS has_error
 FROM modules m
 WHERE m.resolved_realm_url = '<realm-url>'
-  AND m.timing_diagnostics IS NOT NULL
+  AND m.diagnostics IS NOT NULL
 ORDER BY render_ms DESC NULLS LAST
 LIMIT 20;
 ```
@@ -608,12 +609,12 @@ LIMIT 20;
 
 ```sql
 SELECT m.url,
-       (m.timing_diagnostics->>'renderElapsedMs')::int AS render_ms,
-       m.timing_diagnostics->>'requestId'              AS request_id,
+       (m.diagnostics->>'renderElapsedMs')::int AS render_ms,
+       m.diagnostics->>'requestId'              AS request_id,
        to_timestamp(m.created_at::bigint / 1000)       AS created_at
 FROM modules m
 WHERE m.resolved_realm_url = '<realm-url>'
-  AND (m.timing_diagnostics->>'renderElapsedMs')::int > 5000
+  AND (m.diagnostics->>'renderElapsedMs')::int > 5000
   AND m.created_at BETWEEN <window_start_ms> AND <window_end_ms>
 ORDER BY render_ms DESC;
 ```
@@ -625,18 +626,18 @@ ORDER BY render_ms DESC;
 ```sql
 -- Full diagnostic picture for one requestId — card + module(s) that
 -- the same investigation should walk together.
-SELECT 'card'   AS kind, url, jsonb_pretty(timing_diagnostics) AS diagnostics
+SELECT 'card'   AS kind, url, jsonb_pretty(diagnostics) AS diagnostics
 FROM boxel_index
-WHERE timing_diagnostics->>'requestId' = '<request-id>'
+WHERE diagnostics->>'requestId' = '<request-id>'
 UNION ALL
-SELECT 'module' AS kind, url, jsonb_pretty(timing_diagnostics) AS diagnostics
+SELECT 'module' AS kind, url, jsonb_pretty(diagnostics) AS diagnostics
 FROM modules
-WHERE timing_diagnostics->>'requestId' = '<request-id>';
+WHERE diagnostics->>'requestId' = '<request-id>';
 ```
 
 (In practice the card-side `requestId` is the original outer call. Internal sub-prerenders fired by `CachingDefinitionLookup` typically mint their own `requestId` per `_prerender-module` call, so the time-window join in step 2 is usually the one that catches them. The `requestId` join here works for the rarer in-line case.)
 
-**Step 4 — classify the module render with the same rubric.** Once you have a slow module's `timing_diagnostics`, walk it through the [Classify in one pass](#classify-in-one-pass) table the same way you would a card render. The interpretation is identical: `waiting-stability + queryLoadsInFlight=N` is a data stall on a `_search` (rare for module renders but possible for query-field driven module-extract paths), `model:start + inFlightModuleImports>0` is the loader stall, etc. The only field that's not present on module rows is `invalidationId` (modules don't go through `Batch.invalidate`), so any Mode B-style cross-row grouping has to use `requestId` or `created_at` windows instead.
+**Step 4 — classify the module render with the same rubric.** Once you have a slow module's `diagnostics`, walk it through the [Classify in one pass](#classify-in-one-pass) table the same way you would a card render. The interpretation is identical: `waiting-stability + queryLoadsInFlight=N` is a data stall on a `_search` (rare for module renders but possible for query-field driven module-extract paths), `model:start + inFlightModuleImports>0` is the loader stall, etc. The only field that's not present on module rows is `invalidationId` (modules don't go through `Batch.invalidate`), so any Mode B-style cross-row grouping has to use `requestId` or `created_at` windows instead.
 
 ### What Mode D can't tell you
 
@@ -647,7 +648,7 @@ WHERE timing_diagnostics->>'requestId' = '<request-id>';
 
 Unlike Modes A–D, this isn't a perf investigation: it's a realm-health / content-integrity query. A card whose `linksTo` / `linksToMany` target is unreachable (deleted, 404, upstream 5xx, network failure) **still indexes as a clean `type='instance'`** — the broken slot renders the placeholder template and the broken reference is preserved on the wire as `relationships.<field>.links.self`, identical to a not-yet-loaded link. So `has_error` is `false` and `error_doc` is `null`; nothing in the row's *status* tells you the link is broken.
 
-What records it is `timing_diagnostics.brokenLinks` — an array the host's `render.meta` route builds by running `getBrokenLinks(instance)` on the settled instance and attaching the findings to the diagnostics block. Each finding is the minimal queryable summary:
+What records it is `diagnostics.brokenLinks` — an array the host's `render.meta` route builds by running `getBrokenLinks(instance)` on the settled instance and attaching the findings to the diagnostics block. Each finding is the minimal queryable summary:
 
 ```jsonc
 "brokenLinks": [
@@ -671,10 +672,10 @@ SELECT
   bl->>'reference' AS broken_reference,
   bl->>'kind'      AS kind
 FROM boxel_index i
-CROSS JOIN LATERAL jsonb_array_elements(i.timing_diagnostics->'brokenLinks') AS bl
+CROSS JOIN LATERAL jsonb_array_elements(i.diagnostics->'brokenLinks') AS bl
 WHERE i.realm_url = 'https://localhost:4201/user/your-realm/'
   AND i.type = 'instance'
-  AND jsonb_typeof(i.timing_diagnostics->'brokenLinks') = 'array'
+  AND jsonb_typeof(i.diagnostics->'brokenLinks') = 'array'
 ORDER BY i.url, field_name;
 
 -- Just the count of affected cards (cheap realm-health gauge).
@@ -682,13 +683,13 @@ SELECT count(*) AS cards_with_broken_links
 FROM boxel_index
 WHERE realm_url = 'https://localhost:4201/user/your-realm/'
   AND type = 'instance'
-  AND jsonb_typeof(timing_diagnostics->'brokenLinks') = 'array';
+  AND jsonb_typeof(diagnostics->'brokenLinks') = 'array';
 
 -- Find every card pointing at one specific broken target (e.g. to gauge
 -- the blast radius before deleting / after un-deleting a card).
 SELECT i.url, bl->>'fieldName' AS field_name, bl->>'kind' AS kind
 FROM boxel_index i
-CROSS JOIN LATERAL jsonb_array_elements(i.timing_diagnostics->'brokenLinks') AS bl
+CROSS JOIN LATERAL jsonb_array_elements(i.diagnostics->'brokenLinks') AS bl
 WHERE bl->>'reference' = 'https://realm.example/people/ringo';
 ```
 
@@ -700,7 +701,7 @@ Caveats:
 
 ## Field-by-field reading
 
-`timing_diagnostics` carries `RenderTimeoutDiagnostics` (defined in `packages/runtime-common/index.ts`) plus `invalidationId` / `indexedAt` / `requestId`. Every render-side field is optional — absent means the hook wasn't available in that build or the page died before the capture could read it.
+`diagnostics` carries `RenderTimeoutDiagnostics` (defined in `packages/runtime-common/index.ts`) plus `invalidationId` / `indexedAt` / `requestId`. Every render-side field is optional — absent means the hook wasn't available in that build or the page died before the capture could read it.
 
 ```jsonc
 {
@@ -929,7 +930,7 @@ Each affinity with queued waiters gets a `priorities=` segment (skipped when no 
 
 The `pending=` count on the same line includes the in-flight render holding the tab (legacy `pendingCount = held + queued` semantics), but `priorities=` counts queued waiters only. So `pending=4` with `priorities=tab:10:1,0:2` is consistent: 1 in-flight render + 1 priority-10 waiter + 2 priority-0 waiters = 4. Don't expect the priority counts to sum to `pending`.
 
-Read with `priority` on the per-render `timing_diagnostics`: a priority-10 row stuck on `waits.tabQueueMs` while the snapshot for its affinity shows `priorities=tab:10:N` is the smoking gun for an over-saturated user-priority workload (capacity issue, not priority misrouting). A priority-10 row stuck behind `priorities=tab:0:N` (with manager-side priority routing live in the build) is a priority-routing failure — manager picked the wrong server, or the file render the row was queued behind isn't releasing. Investigate the manager log for `requestId=…` to see where the manager-side scoring went.
+Read with `priority` on the per-render `diagnostics`: a priority-10 row stuck on `waits.tabQueueMs` while the snapshot for its affinity shows `priorities=tab:10:N` is the smoking gun for an over-saturated user-priority workload (capacity issue, not priority misrouting). A priority-10 row stuck behind `priorities=tab:0:N` (with manager-side priority routing live in the build) is a priority-routing failure — manager picked the wrong server, or the file render the row was queued behind isn't releasing. Investigate the manager log for `requestId=…` to see where the manager-side scoring went.
 
 Read this alongside a timeout when `waits.semaphoreMs` is large. A snapshot with `totalPending >> totalTabs` near the timestamp confirms saturation.
 
@@ -948,7 +949,7 @@ In practice steps 1-5 catch ~90% of timeouts.
 ## Quick triage rubric (Mode B — slow reindex)
 
 1. **Pull the fan-out with the `invalidationId` query above** — you now have every row touched.
-2. **Does one row dominate total `render_ms`?** If yes, it's the real target. Read its `timing_diagnostics` and apply Mode A's rubric to it.
+2. **Does one row dominate total `render_ms`?** If yes, it's the real target. Read its `diagnostics` and apply Mode A's rubric to it.
 3. **Are `launch_ms` and `waits.semaphoreMs` large across all rows?** If yes, capacity contention during the reindex, not the cards' fault.
 4. **Is only the first-indexed row (min `indexedAt`) slow and the rest fast?** That's the cold-loader tax paid by the first render after a `.gts` invalidation (`clearCache: true` fired once for the batch). Expected on any executable invalidation — only worth chasing if the cold cost is disproportionate to the module graph.
 5. **Is the sum of `render_ms` wildly larger than the card count × a reasonable per-card budget?** Look for `queryLoadsInFlight` / `recentQueryLoads` entries that repeat across rows — that's a query-field that multiple dependents all wait on.
@@ -1344,6 +1345,6 @@ Grep for `file-queue admission: cap=` in prerender-server logs to confirm the ef
 
 ## Extending the diagnostics
 
-If you find you want a signal that isn't here, add it to `RenderTimeoutDiagnostics` in `packages/runtime-common/index.ts` (optional field), populate it in `packages/realm-server/prerender/utils.ts` (the `withTimeout` capture block) by evaluating a new globalThis hook on the page, and expose that hook from `packages/host/app/routes/render.ts::__boxelRenderDiagnostics`. The Prerenderer decorator lifts it onto `response.meta.diagnostics` and the indexer persists it into `timing_diagnostics` unchanged.
+If you find you want a signal that isn't here, add it to `RenderTimeoutDiagnostics` in `packages/runtime-common/index.ts` (optional field), populate it in `packages/realm-server/prerender/utils.ts` (the `withTimeout` capture block) by evaluating a new globalThis hook on the page, and expose that hook from `packages/host/app/routes/render.ts::__boxelRenderDiagnostics`. The Prerenderer decorator lifts it onto `response.meta.diagnostics` and the indexer persists it into `diagnostics` unchanged.
 
 Remember to also surface it on the error log line in `withTimeout` so operators see it without opening the JSON.

--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: indexing-diagnostics
-description: Investigate slow or failing indexing using the diagnostics persisted on every `boxel_index` row (`timing_diagnostics` JSONB column, mirrored onto `error_doc.diagnostics` for error rows) plus the matching prerender-server / manager logs. Covers (1) a render inside indexing timed out — classify which part of the prerender pipeline stalled, and (2) an incremental or full reindex was slow but didn't fail — attribute time across the invalidation fan-out and find the rows that cost the most. Use when indexing fails with "Render timeout", when a user sees a 504, when a reindex took much longer than expected, when an `.gts` edit triggers a surprising amount of re-render work, or when investigating the CS-10820 saturation class of incidents. For staging/prod investigations this skill layers on top of `aws-access`, which provides the AWS session and the SSM port-forward path into the in-VPC database (authenticated as `claude_readonly_user`) — read that skill first when the question is about a deployed environment.
+description: Investigate slow or failing indexing using the diagnostics persisted on every `boxel_index` row (`timing_diagnostics` JSONB column, mirrored onto `error_doc.diagnostics` for error rows) plus the matching prerender-server / manager logs. Covers (1) a render inside indexing timed out — classify which part of the prerender pipeline stalled, (2) an incremental or full reindex was slow but didn't fail — attribute time across the invalidation fan-out and find the rows that cost the most, and (3) enumerating cards with broken `linksTo` / `linksToMany` targets via `timing_diagnostics.brokenLinks` (those cards index cleanly, so this is the only indexed signal). Use when indexing fails with "Render timeout", when a user sees a 504, when a reindex took much longer than expected, when an `.gts` edit triggers a surprising amount of re-render work, when investigating the CS-10820 saturation class of incidents, or when asked to list / count cards with broken links in a realm. For staging/prod investigations this skill layers on top of `aws-access`, which provides the AWS session and the SSM port-forward path into the in-VPC database (authenticated as `claude_readonly_user`) — read that skill first when the question is about a deployed environment.
 allowed-tools: Read, Grep, Glob, Bash
 ---
 
@@ -17,7 +17,7 @@ Both use cases read from the same data. The difference is the query you start wi
 
 Four places, all correlated:
 
-1. **`boxel_index.timing_diagnostics` (and `boxel_index_working.timing_diagnostics`)** — JSONB column, populated for **every** row the indexer writes, regardless of `has_error`. Source of truth for **card** renders. Carries the full `RenderTimeoutDiagnostics` payload plus three write-side stamps: `invalidationId`, `indexedAt`, `requestId`.
+1. **`boxel_index.timing_diagnostics` (and `boxel_index_working.timing_diagnostics`)** — JSONB column, populated for **every** row the indexer writes, regardless of `has_error`. Source of truth for **card** renders. Carries the full `RenderTimeoutDiagnostics` payload plus three write-side stamps: `invalidationId`, `indexedAt`, `requestId`. It also carries a `brokenLinks` array on any card row whose render found a broken `linksTo` / `linksToMany` target — see [Mode E](#mode-e--enumerate-cards-with-broken-links). Note this is the one block that isn't about *timing*: a card with broken links still indexes as a clean `type='instance'` (the broken slot renders a placeholder), so `brokenLinks` is the only indexed signal that the row has a broken reference.
 2. **`modules.timing_diagnostics`** — JSONB column, populated for every row `persistModuleCacheEntry` writes (success and error paths). Source of truth for **module** renders (`prerenderModule` → definition extraction). Same `RenderTimeoutDiagnostics` shape with `requestId` flattened in; no `invalidationId` (modules don't go through `Batch.invalidate`). The row's existing `created_at` column is the wall-clock stamp for cross-table joins. See [Mode D](#mode-d--a-module-render-was-slow-or-hung) below.
 3. **`error_doc.diagnostics`** — derived copy of `timing_diagnostics`, written only for error rows on `boxel_index`. Exists so the existing UI read path (`error_doc` → `CardErrorJSONAPI.meta.diagnostics` via `formattedError`) keeps working without a schema rename. Non-error rows have `error_doc = null`; go to `timing_diagnostics` directly.
 4. **Logs** — `prerender-server`, `manager`, and `remote-prerenderer` lines all carry `requestId=…`. `grep requestId=<uuid>` collates one call across all three processes. The same `requestId` lands on both `boxel_index.timing_diagnostics->>'requestId'` and `modules.timing_diagnostics->>'requestId'`, so a hung card render and the module renders it triggered (via `getDefinition`) can be joined back to one investigation. For saturation incidents there's also the periodic `prerender-queue-snapshot` line on each prerender server.
@@ -642,6 +642,61 @@ WHERE timing_diagnostics->>'requestId' = '<request-id>';
 
 - **No partial-progress equivalent.** `modules` has no working-table sibling; the row only lands on `persistModuleCacheEntry` after the prerender returns. If a `prerenderModule` call hangs forever and the worker is killed, no row is written and Mode D has nothing to query. Cross-reference against the prerender server logs for `requestId=…` directly, same as a hung card render before the host's withTimeout fires.
 - **No invalidationId, so no Mode B fan-out.** Module renders are independent units; they don't belong to a "batch" that you can group by. If you need to attribute a slow `getDefinition` storm across many concurrent searches, you're stuck doing it via `created_at` time windows + the `#inFlight` dedupe behavior in `CachingDefinitionLookup` — i.e. one slow row may have been the bottleneck for many in-flight callers, but the `modules` table doesn't record those waiters.
+
+## Mode E — enumerate cards with broken links
+
+Unlike Modes A–D, this isn't a perf investigation: it's a realm-health / content-integrity query. A card whose `linksTo` / `linksToMany` target is unreachable (deleted, 404, upstream 5xx, network failure) **still indexes as a clean `type='instance'`** — the broken slot renders the placeholder template and the broken reference is preserved on the wire as `relationships.<field>.links.self`, identical to a not-yet-loaded link. So `has_error` is `false` and `error_doc` is `null`; nothing in the row's *status* tells you the link is broken.
+
+What records it is `timing_diagnostics.brokenLinks` — an array the host's `render.meta` route builds by running `getBrokenLinks(instance)` on the settled instance and attaching the findings to the diagnostics block. Each finding is the minimal queryable summary:
+
+```jsonc
+"brokenLinks": [
+  { "fieldName": "author", "reference": "https://realm.example/people/ringo", "kind": "not-found" },
+  { "fieldName": "pets",   "reference": "https://realm.example/pets/missing", "kind": "error" }
+]
+```
+
+- `fieldName` — the declared `linksTo` / `linksToMany` field holding the broken reference. A `linksToMany` field with one broken element produces one finding for that element; present siblings produce none.
+- `reference` — the broken target reference, as captured from relationship state.
+- `kind` — `'not-found'` for an HTTP 404 (the canonical "target was deleted" case), `'error'` for any other upstream failure (5xx, network, fetch error).
+- `errorDoc` is **not** persisted here (it's large) — read it at runtime via `getRelationship(card, fieldName)` or see it inline in the rendered placeholder. The broken target is also carried in the row's `deps`, so if the target later reappears the card is invalidated and re-rendered, clearing the finding.
+
+```sql
+-- List every card in a realm with at least one broken link, one row per
+-- broken slot. `jsonb_array_elements` fans the array out so you get the
+-- field + reference + kind per finding.
+SELECT
+  i.url,
+  bl->>'fieldName' AS field_name,
+  bl->>'reference' AS broken_reference,
+  bl->>'kind'      AS kind
+FROM boxel_index i
+CROSS JOIN LATERAL jsonb_array_elements(i.timing_diagnostics->'brokenLinks') AS bl
+WHERE i.realm_url = 'https://localhost:4201/user/your-realm/'
+  AND i.type = 'instance'
+  AND jsonb_typeof(i.timing_diagnostics->'brokenLinks') = 'array'
+ORDER BY i.url, field_name;
+
+-- Just the count of affected cards (cheap realm-health gauge).
+SELECT count(*) AS cards_with_broken_links
+FROM boxel_index
+WHERE realm_url = 'https://localhost:4201/user/your-realm/'
+  AND type = 'instance'
+  AND jsonb_typeof(timing_diagnostics->'brokenLinks') = 'array';
+
+-- Find every card pointing at one specific broken target (e.g. to gauge
+-- the blast radius before deleting / after un-deleting a card).
+SELECT i.url, bl->>'fieldName' AS field_name, bl->>'kind' AS kind
+FROM boxel_index i
+CROSS JOIN LATERAL jsonb_array_elements(i.timing_diagnostics->'brokenLinks') AS bl
+WHERE bl->>'reference' = 'https://realm.example/people/ringo';
+```
+
+Caveats:
+
+- **Older rows predate the scan.** A row last indexed before this capability shipped has no `brokenLinks` key even if its links are broken — it'll only appear after the next reindex. Don't read "absent" as "no broken links" for stale rows; check `indexedAt` if in doubt.
+- **`boxel_index_working` carries it too**, so you can watch broken-link findings accrue mid-reindex the same way as the timing fields (see [Reading partial progress](#5-reading-partial-progress-from-boxel_index_working)).
+- This is the cheap enumeration path the rendered-HTML / `getRelationship` runtime surfaces were too expensive for — querying the column avoids parsing HTML or re-running `getBrokenLinks` per read.
 
 ## Field-by-field reading
 

--- a/.claude/skills/prerender-sizing/SKILL.md
+++ b/.claude/skills/prerender-sizing/SKILL.md
@@ -138,31 +138,31 @@ The output is a histogram: how many snapshots saw each `(totalTabs, totalPending
 
 #### DB — render-timing distribution
 
-Confirms whether the system held under pressure (zero render-timeouts) or was at the edge. Queries the `boxel_index.timing_diagnostics` JSONB column via the `aws-access` skill's port-forward + `claude_readonly_user` flow.
+Confirms whether the system held under pressure (zero render-timeouts) or was at the edge. Queries the `boxel_index.diagnostics` JSONB column via the `aws-access` skill's port-forward + `claude_readonly_user` flow.
 
 ```sql
 -- 7-day render-timing histogram. The `::int` casts assume the
 -- diagnostic shape Prerenderer emits today; if a row is missing
 -- a key (older diagnostic shape, partial write, manual edit) the
 -- whole query errors. If that happens, narrow the WHERE clause to
--- skip the malformed rows: e.g. `AND timing_diagnostics->'waits' ?
+-- skip the malformed rows: e.g. `AND diagnostics->'waits' ?
 -- 'tabQueueMs'` (the JSONB `?` operator tests for a key) keeps
 -- only rows with that key present.
 SELECT 
   count(*) AS rows_with_diag,
-  count(*) FILTER (WHERE (timing_diagnostics->>'totalElapsedMs')::int >= 145000) AS at_or_over_timeout,
-  percentile_cont(0.95) WITHIN GROUP (ORDER BY (timing_diagnostics->>'totalElapsedMs')::int) AS p95_total_ms,
-  percentile_cont(0.99) WITHIN GROUP (ORDER BY (timing_diagnostics->>'totalElapsedMs')::int) AS p99_total_ms,
-  max((timing_diagnostics->>'totalElapsedMs')::int) AS max_total_ms,
-  percentile_cont(0.95) WITHIN GROUP (ORDER BY (timing_diagnostics->'waits'->>'tabQueueMs')::int) AS p95_tabq_ms,
-  max((timing_diagnostics->'waits'->>'tabQueueMs')::int) AS max_tabq_ms,
-  percentile_cont(0.95) WITHIN GROUP (ORDER BY (timing_diagnostics->'waits'->>'semaphoreMs')::int) AS p95_sem_ms,
-  max((timing_diagnostics->'waits'->>'semaphoreMs')::int) AS max_sem_ms
+  count(*) FILTER (WHERE (diagnostics->>'totalElapsedMs')::int >= 145000) AS at_or_over_timeout,
+  percentile_cont(0.95) WITHIN GROUP (ORDER BY (diagnostics->>'totalElapsedMs')::int) AS p95_total_ms,
+  percentile_cont(0.99) WITHIN GROUP (ORDER BY (diagnostics->>'totalElapsedMs')::int) AS p99_total_ms,
+  max((diagnostics->>'totalElapsedMs')::int) AS max_total_ms,
+  percentile_cont(0.95) WITHIN GROUP (ORDER BY (diagnostics->'waits'->>'tabQueueMs')::int) AS p95_tabq_ms,
+  max((diagnostics->'waits'->>'tabQueueMs')::int) AS max_tabq_ms,
+  percentile_cont(0.95) WITHIN GROUP (ORDER BY (diagnostics->'waits'->>'semaphoreMs')::int) AS p95_sem_ms,
+  max((diagnostics->'waits'->>'semaphoreMs')::int) AS max_sem_ms
 FROM boxel_index
-WHERE timing_diagnostics IS NOT NULL
-  AND timing_diagnostics ? 'totalElapsedMs'
-  AND (timing_diagnostics->>'indexedAt') ~ '^[0-9]+$'
-  AND (timing_diagnostics->>'indexedAt')::bigint > extract(epoch from now() - interval '7 days')*1000;
+WHERE diagnostics IS NOT NULL
+  AND diagnostics ? 'totalElapsedMs'
+  AND (diagnostics->>'indexedAt') ~ '^[0-9]+$'
+  AND (diagnostics->>'indexedAt')::bigint > extract(epoch from now() - interval '7 days')*1000;
 ```
 
 Key signals to look for:
@@ -253,7 +253,7 @@ Captured on 2026-04-30 ~20:00 UTC for the CS-10976 PR 12 staging activation.
 | Memory avg of 5-min Avg | 35 % | 39 % |
 | Memory 5-min peak | 64 % | 98.3 % |
 
-7-d render-timing histogram from `boxel_index.timing_diagnostics`:
+7-d render-timing histogram from `boxel_index.diagnostics`:
 
 - 58,549 rows with diagnostics
 - 0 timeouts (`totalElapsedMs ≥ 145 000`)

--- a/docs/aws-operations.md
+++ b/docs/aws-operations.md
@@ -76,7 +76,7 @@ Before promoting to prod, run a synthetic saturating workload on staging:
 - High-priority p95 `tabQueueMs` < 1 s during the burst.
 - Memory peak < 80 % of allocated.
 - CPU peak < 80 % of allocated, sustained over a 1-minute window (brief overshoots OK).
-- Zero 145-second render-timeouts (`SELECT count(*) FROM boxel_index WHERE (timing_diagnostics->>'totalElapsedMs')::int >= 145000`).
+- Zero 145-second render-timeouts (`SELECT count(*) FROM boxel_index WHERE (diagnostics->>'totalElapsedMs')::int >= 145000`).
 
 **Adjustment paths:**
 - CPU peak > 80 % sustained → drop `MAX` by 1, retest.

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -78,7 +78,7 @@ const fieldOverrides = initSharedState(
 // off-pass case in the host-UI hot loop.
 let passComputeMemo: WeakMap<BaseDef, Map<string, any>> | null = null;
 // Counters snapshotted by the render/meta route to populate
-// `boxel_index.timing_diagnostics`. They are unconditional integer
+// `boxel_index.diagnostics`. They are unconditional integer
 // increments inside `getter` — cheap enough to keep on in production, but
 // only meaningful between `beginComputePass`/`endComputePass`.
 let computedCallCount = 0;

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -136,6 +136,27 @@ export default class RenderMetaRoute extends Route<Model> {
       serializeMs: Math.round(serializeMs * 100) / 100,
       searchDocMs: Math.round(searchDocMs * 100) / 100,
     };
+
+    // Record broken `linksTo` / `linksToMany` targets as searchable
+    // metadata on the success entry. We awaited `readyPromise` above, so
+    // the store has settled: every lazy link the render pulled on has
+    // resolved and any failure has planted its sentinel. `getBrokenLinks`
+    // reads that terminal state through `getRelationship` without
+    // retriggering a load. The card still indexes as `type='instance'`
+    // (the broken slot renders a placeholder); this block is the only
+    // direct, indexed signal of which slots are broken, persisted to
+    // `boxel_index.timing_diagnostics.brokenLinks`. Guarded like the
+    // compute-pass hooks above: a stale base/card-api build loaded during
+    // a cold boot may predate the export, in which case we omit the
+    // findings and the render still produces a correct meta doc.
+    if (typeof api.getBrokenLinks === 'function') {
+      let brokenLinks = api.getBrokenLinks(instance);
+      if (brokenLinks.length > 0) {
+        diagnostics.brokenLinks = brokenLinks.map(
+          ({ fieldName, reference, kind }) => ({ fieldName, reference, kind }),
+        );
+      }
+    }
     computePerfLog.debug(
       `render.meta computed counts cardId=${instance.id} calls=${diagnostics.computedCalls ?? 'n/a'} cacheHits=${diagnostics.computedCacheHits ?? 'n/a'} serializeMs=${diagnostics.serializeMs} searchDocMs=${diagnostics.searchDocMs}`,
     );

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -145,7 +145,7 @@ export default class RenderMetaRoute extends Route<Model> {
     // retriggering a load. The card still indexes as `type='instance'`
     // (the broken slot renders a placeholder); this block is the only
     // direct, indexed signal of which slots are broken, persisted to
-    // `boxel_index.timing_diagnostics.brokenLinks`. Guarded like the
+    // `boxel_index.diagnostics.brokenLinks`. Guarded like the
     // compute-pass hooks above: a stale base/card-api build loaded during
     // a cold boot may predate the export, in which case we omit the
     // findings and the render still produces a correct meta doc.

--- a/packages/host/app/utils/render-desync-detector.ts
+++ b/packages/host/app/utils/render-desync-detector.ts
@@ -327,7 +327,7 @@ function emitDesyncError(ctx: DesyncDetectorContext): void {
       stack: augmentedStack,
       // Structured diagnostics ride on the `diagnostics` field per
       // SerializedError; the indexer copies these onto
-      // `boxel_index.timing_diagnostics`.
+      // `boxel_index.diagnostics`.
       diagnostics: { renderStage: stage },
       deps: [ctx.cardId],
       additionalErrors: null,

--- a/packages/host/config/schema/1780059236455_schema.sql
+++ b/packages/host/config/schema/1780059236455_schema.sql
@@ -42,7 +42,7 @@
    has_error BOOLEAN DEFAULT false NOT NULL,
    last_known_good_deps BLOB,
    markdown TEXT,
-   timing_diagnostics BLOB,
+   diagnostics BLOB,
    PRIMARY KEY ( url, realm_url, type ) 
 );
 
@@ -71,7 +71,7 @@
    has_error BOOLEAN DEFAULT false NOT NULL,
    last_known_good_deps BLOB,
    markdown TEXT,
-   timing_diagnostics BLOB,
+   diagnostics BLOB,
    job_id INTEGER,
    PRIMARY KEY ( url, realm_url, type ) 
 );
@@ -110,7 +110,7 @@
    created_at,
    file_alias TEXT,
    url_hash TEXT GENERATED ALWAYS AS (url) STORED NOT NULL,
-   timing_diagnostics BLOB,
+   diagnostics BLOB,
    PRIMARY KEY ( url, cache_scope, auth_user_id ) 
 );
 

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -748,11 +748,7 @@ module('Unit | index-writer', function (hooks) {
     // the error_doc (the indexer mirrors diagnostics onto
     // error_doc.diagnostics for UI compat); they're verified
     // separately below.
-    let {
-      indexed_at: _remove,
-      diagnostics,
-      ...errorEntry
-    } = rawErrorEntry;
+    let { indexed_at: _remove, diagnostics, ...errorEntry } = rawErrorEntry;
     assert.ok(errorEntry.error_doc, 'row has an error_doc');
     // The indexer mirrors `diagnostics` onto `error_doc.diagnostics`
     // for UI compat. Strip it out before the deep-equal (and verify the
@@ -840,11 +836,7 @@ module('Unit | index-writer', function (hooks) {
       'SELECT * FROM boxel_index WHERE realm_version = 2 AND type = \'instance\' AND has_error = TRUE ORDER BY url COLLATE "POSIX"',
       { coerceTypes },
     )) as unknown as BoxelIndexTable[];
-    let {
-      indexed_at: _remove,
-      diagnostics,
-      ...errorEntry
-    } = rawErrorEntry;
+    let { indexed_at: _remove, diagnostics, ...errorEntry } = rawErrorEntry;
     assert.ok(errorEntry.error_doc, 'row has an error_doc');
     // The indexer mirrors `diagnostics` onto `error_doc.diagnostics`
     // for UI compat. Strip it out before the deep-equal (and verify the

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -649,7 +649,7 @@ module('Unit | index-writer', function (hooks) {
         icon_html: '<svg>test icon</svg>',
         markdown: null,
         is_deleted: null,
-        timing_diagnostics: null,
+        diagnostics: null,
       },
       'the copied instance is correct',
     );
@@ -745,16 +745,16 @@ module('Unit | index-writer', function (hooks) {
       { coerceTypes },
     )) as unknown as BoxelIndexTable[];
     // Strip non-deterministic write-time stamps from both the row and
-    // the error_doc (the indexer mirrors timing_diagnostics onto
+    // the error_doc (the indexer mirrors diagnostics onto
     // error_doc.diagnostics for UI compat); they're verified
     // separately below.
     let {
       indexed_at: _remove,
-      timing_diagnostics,
+      diagnostics,
       ...errorEntry
     } = rawErrorEntry;
     assert.ok(errorEntry.error_doc, 'row has an error_doc');
-    // The indexer mirrors `timing_diagnostics` onto `error_doc.diagnostics`
+    // The indexer mirrors `diagnostics` onto `error_doc.diagnostics`
     // for UI compat. Strip it out before the deep-equal (and verify the
     // mirror relationship separately below). `diagnostics` is a declared
     // optional field on `SerializedError`, so this is a plain destructure
@@ -806,16 +806,16 @@ module('Unit | index-writer', function (hooks) {
       },
       'the error entry includes last known good state of instance',
     );
-    assert.ok(timing_diagnostics, 'timing_diagnostics populated on error row');
+    assert.ok(diagnostics, 'diagnostics populated on error row');
     assert.strictEqual(
-      typeof timing_diagnostics,
+      typeof diagnostics,
       'object',
-      'timing_diagnostics is an object',
+      'diagnostics is an object',
     );
     assert.deepEqual(
       errorDocDiagnostics,
-      timing_diagnostics,
-      'error_doc.diagnostics mirrors timing_diagnostics',
+      diagnostics,
+      'error_doc.diagnostics mirrors diagnostics',
     );
   });
 
@@ -842,11 +842,11 @@ module('Unit | index-writer', function (hooks) {
     )) as unknown as BoxelIndexTable[];
     let {
       indexed_at: _remove,
-      timing_diagnostics,
+      diagnostics,
       ...errorEntry
     } = rawErrorEntry;
     assert.ok(errorEntry.error_doc, 'row has an error_doc');
-    // The indexer mirrors `timing_diagnostics` onto `error_doc.diagnostics`
+    // The indexer mirrors `diagnostics` onto `error_doc.diagnostics`
     // for UI compat. Strip it out before the deep-equal (and verify the
     // mirror relationship separately below). `diagnostics` is a declared
     // optional field on `SerializedError`, so this is a plain destructure
@@ -888,16 +888,16 @@ module('Unit | index-writer', function (hooks) {
       },
       'the error entry does not include last known good state of instance',
     );
-    assert.ok(timing_diagnostics, 'timing_diagnostics populated on error row');
+    assert.ok(diagnostics, 'diagnostics populated on error row');
     assert.strictEqual(
-      typeof timing_diagnostics,
+      typeof diagnostics,
       'object',
-      'timing_diagnostics is an object',
+      'diagnostics is an object',
     );
     assert.deepEqual(
       errorDocDiagnostics,
-      timing_diagnostics,
-      'error_doc.diagnostics mirrors timing_diagnostics',
+      diagnostics,
+      'error_doc.diagnostics mirrors diagnostics',
     );
   });
 

--- a/packages/postgres/migrations/1780059236455_rename-timing-diagnostics-to-diagnostics.js
+++ b/packages/postgres/migrations/1780059236455_rename-timing-diagnostics-to-diagnostics.js
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 exports.shorthands = undefined;
 
 exports.up = (pgm) => {

--- a/packages/postgres/migrations/1780059236455_rename-timing-diagnostics-to-diagnostics.js
+++ b/packages/postgres/migrations/1780059236455_rename-timing-diagnostics-to-diagnostics.js
@@ -1,0 +1,15 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.renameColumn('boxel_index', 'timing_diagnostics', 'diagnostics');
+  pgm.renameColumn('boxel_index_working', 'timing_diagnostics', 'diagnostics');
+  pgm.renameColumn('modules', 'timing_diagnostics', 'diagnostics');
+};
+
+exports.down = (pgm) => {
+  pgm.renameColumn('boxel_index', 'diagnostics', 'timing_diagnostics');
+  pgm.renameColumn('boxel_index_working', 'diagnostics', 'timing_diagnostics');
+  pgm.renameColumn('modules', 'diagnostics', 'timing_diagnostics');
+};

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -41,7 +41,7 @@ const defaultPrerenderServerPort = 4221;
 
 // Stamp the per-request `requestId` onto `response.meta.requestId`
 // so it flows through the same channel as timings / host-side
-// diagnostics and ends up on `boxel_index.timing_diagnostics` for
+// diagnostics and ends up on `boxel_index.diagnostics` for
 // cross-log grepping. The launch/waits/render/total timings are
 // already attached inside Prerenderer (regardless of HTTP vs
 // in-process); this layer just adds the HTTP-only correlation id.

--- a/packages/realm-server/prerender/render-settlement.ts
+++ b/packages/realm-server/prerender/render-settlement.ts
@@ -16,7 +16,7 @@ const log = logger('prerenderer');
 //     timings + the captured affinity snapshot onto response.meta
 //     (decorateRenderErrorsWithTimings).
 // Both end up in `RenderTimeoutDiagnostics` on the eventual
-// `boxel_index.timing_diagnostics` JSONB column.
+// `boxel_index.diagnostics` JSONB column.
 
 // One registration with the shared peak sampler. `currentPeak()` samples
 // on demand and returns the richest observation seen so far; `stop()`
@@ -161,7 +161,7 @@ function isPeakBetter(
 // Merges timings + (optionally) affinitySnapshot onto `response.meta`,
 // lifting any host-side RenderError.diagnostics the handler attached
 // onto the inner error wrapper. Callers read `response.meta.diagnostics`
-// to persist into `timing_diagnostics`.
+// to persist into `diagnostics`.
 //
 // Why two channels: the response body carries the rendered HTML / card
 // JSON and needs to stay minimal; `response.meta` is the opt-in place
@@ -178,7 +178,7 @@ export interface RenderSettlementMeta {
   affinitySnapshot?: RenderTimeoutDiagnostics['affinitySnapshot'];
   // Worker-job priority of the request that produced this render.
   // Stamped into `response.meta.diagnostics.priority` so the indexer
-  // persists it on `boxel_index.timing_diagnostics`. `0` means
+  // persists it on `boxel_index.diagnostics`. `0` means
   // system-priority / undefined caller (default).
   priority?: number;
   // Whether this render landed on a reused / warm tab vs a freshly
@@ -226,7 +226,7 @@ export function decorateRenderErrorsWithTimings(
       // block — captured by render.meta and spread onto the card
       // response as `diagnostics`. Lift the same way as error-path
       // diagnostics so the computed-field counters reach the indexer's
-      // `boxel_index.timing_diagnostics` column.
+      // `boxel_index.diagnostics` column.
       if (key === 'card') {
         lift(sub);
       }

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -1388,7 +1388,7 @@ export async function withTimeout<T>(
     // Diagnostics ride on the outer `RenderError.diagnostics` as a
     // transient transport; the Prerenderer lifts them to
     // `response.meta.diagnostics` before returning, where the indexer
-    // reads them and persists into `timing_diagnostics`. The field is
+    // reads them and persists into `diagnostics`. The field is
     // dropped from the final response.
     let diagnostics: RenderTimeoutDiagnostics = {
       ...(richDiagnostics?.renderStage

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -2303,7 +2303,7 @@ module(basename(__filename), function () {
       nextPrerenderMeta = undefined;
     });
 
-    test('persists timing_diagnostics from prerender meta on module rows', async function (assert) {
+    test('persists diagnostics from prerender meta on module rows', async function (assert) {
       nextPrerenderMeta = {
         requestId: 'req-test-123',
         diagnostics: {
@@ -2320,11 +2320,11 @@ module(basename(__filename), function () {
       assert.strictEqual(definition?.displayName, 'Person');
 
       let rows = (await adapter.execute(
-        `SELECT timing_diagnostics FROM modules WHERE url = $1`,
+        `SELECT diagnostics FROM modules WHERE url = $1`,
         { bind: [`${realmURL}person.gts`] },
-      )) as { timing_diagnostics: unknown }[];
+      )) as { diagnostics: unknown }[];
       assert.strictEqual(rows.length, 1, 'one modules row was written');
-      let raw = rows[0].timing_diagnostics;
+      let raw = rows[0].diagnostics;
       let persisted =
         typeof raw === 'string'
           ? (JSON.parse(raw) as Record<string, any>)
@@ -2336,7 +2336,7 @@ module(basename(__filename), function () {
       assert.strictEqual(persisted?.totalElapsedMs, 4334);
     });
 
-    test('persists null timing_diagnostics when prerender returns no meta', async function (assert) {
+    test('persists null diagnostics when prerender returns no meta', async function (assert) {
       let definition = await definitionLookup.lookupDefinition({
         module: rri(`${realmURL}person.gts`),
         name: 'Person',
@@ -2344,14 +2344,14 @@ module(basename(__filename), function () {
       assert.strictEqual(definition?.displayName, 'Person');
 
       let rows = (await adapter.execute(
-        `SELECT timing_diagnostics FROM modules WHERE url = $1`,
+        `SELECT diagnostics FROM modules WHERE url = $1`,
         { bind: [`${realmURL}person.gts`] },
-      )) as { timing_diagnostics: unknown }[];
+      )) as { diagnostics: unknown }[];
       assert.strictEqual(rows.length, 1, 'one modules row was written');
       assert.strictEqual(
-        rows[0].timing_diagnostics,
+        rows[0].diagnostics,
         null,
-        'timing_diagnostics is null when meta is absent',
+        'diagnostics is null when meta is absent',
       );
     });
   });

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -709,6 +709,31 @@ module(basename(__filename), function () {
         deps.includes(`http://localhost:9000/this-is-a-link-to-nowhere`),
         'deps include the unreachable link target so invalidation can reach this card if it becomes reachable',
       );
+
+      // The broken slot is also recorded as searchable metadata on the
+      // (successful) index row: the render.meta scan runs getBrokenLinks
+      // after the store settles and the finding rides the diagnostics
+      // channel into `boxel_index.timing_diagnostics.brokenLinks`. This is
+      // the direct, indexed signal that lets a consumer enumerate
+      // cards-with-broken-links without parsing HTML or re-running the scan.
+      let [diagRow] = (await testDbAdapter.execute(
+        `SELECT timing_diagnostics FROM boxel_index WHERE realm_url = $1 AND url = $2 AND type = 'instance'`,
+        { bind: [realm.url, `${testRealm}bad-link.json`] },
+      )) as { timing_diagnostics: { brokenLinks?: unknown } | null }[];
+      let brokenLinks = diagRow?.timing_diagnostics?.brokenLinks as
+        | { fieldName: string; reference: string; kind: string }[]
+        | undefined;
+      assert.deepEqual(
+        brokenLinks,
+        [
+          {
+            fieldName: 'author',
+            reference: 'http://localhost:9000/this-is-a-link-to-nowhere',
+            kind: 'error',
+          },
+        ],
+        'timing_diagnostics.brokenLinks records the broken author slot',
+      );
     });
 
     // Note this particular test should only be a server test as the nature of

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -713,26 +713,38 @@ module(basename(__filename), function () {
       // The broken slot is also recorded as searchable metadata on the
       // (successful) index row: the render.meta scan runs getBrokenLinks
       // after the store settles and the finding rides the diagnostics
-      // channel into `boxel_index.timing_diagnostics.brokenLinks`. This is
+      // channel into `boxel_index.diagnostics.brokenLinks`. This is
       // the direct, indexed signal that lets a consumer enumerate
       // cards-with-broken-links without parsing HTML or re-running the scan.
       let [diagRow] = (await testDbAdapter.execute(
-        `SELECT timing_diagnostics FROM boxel_index WHERE realm_url = $1 AND url = $2 AND type = 'instance'`,
+        `SELECT diagnostics FROM boxel_index WHERE realm_url = $1 AND url = $2 AND type = 'instance'`,
         { bind: [realm.url, `${testRealm}bad-link.json`] },
-      )) as { timing_diagnostics: { brokenLinks?: unknown } | null }[];
-      let brokenLinks = diagRow?.timing_diagnostics?.brokenLinks as
+      )) as { diagnostics: { brokenLinks?: unknown } | null }[];
+      let brokenLinks = diagRow?.diagnostics?.brokenLinks as
         | { fieldName: string; reference: string; kind: string }[]
         | undefined;
-      assert.deepEqual(
-        brokenLinks,
-        [
-          {
-            fieldName: 'author',
-            reference: 'http://localhost:9000/this-is-a-link-to-nowhere',
-            kind: 'error',
-          },
-        ],
-        'timing_diagnostics.brokenLinks records the broken author slot',
+      assert.strictEqual(
+        brokenLinks?.length,
+        1,
+        `diagnostics.brokenLinks records the single broken slot, got: ${JSON.stringify(
+          brokenLinks,
+        )}`,
+      );
+      assert.strictEqual(
+        brokenLinks?.[0]?.fieldName,
+        'author',
+        'broken-link finding names the linksTo field',
+      );
+      assert.strictEqual(
+        brokenLinks?.[0]?.reference,
+        'http://localhost:9000/this-is-a-link-to-nowhere',
+        'broken-link finding carries the unreachable reference',
+      );
+      // An unreachable external host fails as a generic fetch error rather
+      // than a 404; either is a valid terminal broken-link kind.
+      assert.ok(
+        ['error', 'not-found'].includes(brokenLinks?.[0]?.kind ?? ''),
+        `broken-link finding carries a terminal kind, got: ${brokenLinks?.[0]?.kind}`,
       );
     });
 

--- a/packages/realm-server/tests/prerender-diagnostics-persistence-test.ts
+++ b/packages/realm-server/tests/prerender-diagnostics-persistence-test.ts
@@ -8,7 +8,7 @@ import { decorateRenderErrorDiagnostics } from '../prerender/prerender-app';
 // breadcrumbs lifted from `RenderError.diagnostics`, and the HTTP
 // correlation ID) ends up on `response.meta`, not on any embedded
 // inner `SerializedError`. The indexer reads from `response.meta`
-// and persists into `boxel_index.timing_diagnostics`; the error-row
+// and persists into `boxel_index.diagnostics`; the error-row
 // write path also copies the same blob onto `error_doc.diagnostics`
 // so the UI read surface (CardErrorJSONAPI.meta.diagnostics) keeps
 // working without a schema rename. The point of these tests is to
@@ -168,7 +168,7 @@ module(basename(__filename), function () {
 
     test('decorator populates response.meta even when there is no embedded error (successful render)', function (assert) {
       // Successful renders still get timing summaries so the indexer
-      // can persist them onto `timing_diagnostics` — that's the whole
+      // can persist them onto `diagnostics` — that's the whole
       // point of the consolidated column: operators can retrospectively
       // ask "why did this instance take N seconds?" regardless of
       // error status.
@@ -191,7 +191,7 @@ module(basename(__filename), function () {
       // but render.meta records the broken slot on the card's success-path
       // diagnostics block. The decorator must lift that onto
       // response.meta.diagnostics — the consolidated channel the indexer
-      // flattens into `boxel_index.timing_diagnostics.brokenLinks`.
+      // flattens into `boxel_index.diagnostics.brokenLinks`.
       let response: FakeVisitResponse = {
         card: {
           diagnostics: {

--- a/packages/realm-server/tests/prerender-diagnostics-persistence-test.ts
+++ b/packages/realm-server/tests/prerender-diagnostics-persistence-test.ts
@@ -33,6 +33,11 @@ type FakeVisitResponse = {
       // `response.meta.diagnostics` and then deleted.
       diagnostics?: Record<string, unknown>;
     };
+    // Success-path host diagnostics block (computed-field counters,
+    // broken-link findings) captured by render.meta and spread onto the
+    // card response. Lifted onto `response.meta.diagnostics` the same way
+    // as the error-path block.
+    diagnostics?: Record<string, unknown>;
   };
   meta?: {
     timing?: Record<string, unknown>;
@@ -179,6 +184,63 @@ module(basename(__filename), function () {
       assert.strictEqual(response.meta?.diagnostics?.renderElapsedMs, 2);
       assert.strictEqual(response.meta?.diagnostics?.totalElapsedMs, 3);
       assert.deepEqual(response.meta?.diagnostics?.waits, {});
+    });
+
+    test('broken-link findings on the success-path card diagnostics are lifted onto response.meta.diagnostics', function (assert) {
+      // A card with a broken linksTo indexes cleanly (no error wrapper),
+      // but render.meta records the broken slot on the card's success-path
+      // diagnostics block. The decorator must lift that onto
+      // response.meta.diagnostics — the consolidated channel the indexer
+      // flattens into `boxel_index.timing_diagnostics.brokenLinks`.
+      let response: FakeVisitResponse = {
+        card: {
+          diagnostics: {
+            serializeMs: 1.5,
+            brokenLinks: [
+              {
+                fieldName: 'pet',
+                reference: 'http://realm.example/missing-pet',
+                kind: 'not-found',
+              },
+            ],
+          },
+        } as FakeVisitResponse['card'],
+      };
+      Prerenderer.decorateRenderErrorsWithTimings(
+        response,
+        { launchMs: 1, renderMs: 2, waits: {} },
+        3,
+      );
+
+      let diagnostics = response.meta?.diagnostics;
+      assert.deepEqual(
+        diagnostics?.brokenLinks,
+        [
+          {
+            fieldName: 'pet',
+            reference: 'http://realm.example/missing-pet',
+            kind: 'not-found',
+          },
+        ],
+        'brokenLinks lifted onto response.meta.diagnostics',
+      );
+      assert.strictEqual(
+        diagnostics?.serializeMs,
+        1.5,
+        'sibling host-side counters lifted alongside brokenLinks',
+      );
+      assert.strictEqual(
+        diagnostics?.launchMs,
+        1,
+        'server timings merged into the same block',
+      );
+      // The card success-path diagnostics was a transient transport,
+      // deleted after the lift just like the error-path block.
+      assert.strictEqual(
+        response.card?.diagnostics,
+        undefined,
+        'card success-path diagnostics cleared after lift',
+      );
     });
 
     test('both decorators stack: host-lifted diagnostics + server timings + requestId coexist on response.meta', function (assert) {

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -1452,7 +1452,7 @@ module(basename(__filename), function () {
         // the settled instance, attaches the findings to its diagnostics
         // block, and the Prerenderer lifts that onto
         // `response.meta.diagnostics` — exactly the blob the indexer flattens
-        // into `boxel_index.timing_diagnostics`.
+        // into `boxel_index.diagnostics`.
         let result = await prerenderer.prerenderVisit({
           affinityType: 'realm',
           affinityValue: realmURL,
@@ -2192,7 +2192,7 @@ module(basename(__filename), function () {
         // block so operators can classify the stall. Diagnostics
         // live on `response.meta.diagnostics` (the consolidated
         // channel — the indexer reads from there and persists into
-        // `boxel_index.timing_diagnostics`, mirroring to
+        // `boxel_index.diagnostics`, mirroring to
         // `error_doc.diagnostics` at write time for UI compat).
         let diagnostics = (timedOut.response as any)?.meta?.diagnostics;
         assert.strictEqual(
@@ -2309,7 +2309,7 @@ module(basename(__filename), function () {
 
           // Diagnostics live on `response.meta.diagnostics` — the
           // consolidated channel the indexer reads from and persists
-          // onto `boxel_index.timing_diagnostics` (mirrored to
+          // onto `boxel_index.diagnostics` (mirrored to
           // `error_doc.diagnostics` for UI compat).
           let diagnostics = (result.response as any)?.meta?.diagnostics;
           assert.strictEqual(

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -1446,6 +1446,96 @@ module(basename(__filename), function () {
         );
       });
 
+      test('card prerender records a broken linksTo target on meta.diagnostics.brokenLinks for persistence', async function (assert) {
+        // The broken-link findings ride the same consolidated diagnostics
+        // channel as the server timings: render.meta runs getBrokenLinks on
+        // the settled instance, attaches the findings to its diagnostics
+        // block, and the Prerenderer lifts that onto
+        // `response.meta.diagnostics` — exactly the blob the indexer flattens
+        // into `boxel_index.timing_diagnostics`.
+        let result = await prerenderer.prerenderVisit({
+          affinityType: 'realm',
+          affinityValue: realmURL,
+          realm: realmURL,
+          url: `${realmURL}owner-with-broken-pet.json`,
+          auth: auth(),
+          renderOptions: { cardRender: true },
+        });
+
+        assert.notOk(
+          result.response.card?.error,
+          'prerender succeeds — the card indexes cleanly',
+        );
+        let brokenLinks = (result.response.meta as any)?.diagnostics
+          ?.brokenLinks as
+          | { fieldName: string; reference: string; kind: string }[]
+          | undefined;
+        assert.strictEqual(
+          brokenLinks?.length,
+          1,
+          `meta.diagnostics.brokenLinks has the single broken slot, got: ${JSON.stringify(
+            brokenLinks,
+          )}`,
+        );
+        assert.strictEqual(
+          brokenLinks?.[0]?.fieldName,
+          'pet',
+          'broken-link finding names the linksTo field',
+        );
+        assert.ok(
+          brokenLinks?.[0]?.reference.includes('missing-pet'),
+          `broken-link finding carries the broken reference, got: ${brokenLinks?.[0]?.reference}`,
+        );
+        assert.strictEqual(
+          brokenLinks?.[0]?.kind,
+          'not-found',
+          'a missing realm target is classified not-found',
+        );
+      });
+
+      test('card prerender records a broken linksToMany element on meta.diagnostics.brokenLinks for persistence', async function (assert) {
+        let result = await prerenderer.prerenderVisit({
+          affinityType: 'realm',
+          affinityValue: realmURL,
+          realm: realmURL,
+          url: `${realmURL}owner-with-broken-pets.json`,
+          auth: auth(),
+          renderOptions: { cardRender: true },
+        });
+
+        assert.notOk(
+          result.response.card?.error,
+          'prerender succeeds — the card indexes cleanly',
+        );
+        let brokenLinks = (result.response.meta as any)?.diagnostics
+          ?.brokenLinks as
+          | { fieldName: string; reference: string; kind: string }[]
+          | undefined;
+        // Only the broken element is recorded; the present sibling slot
+        // (./real-pet) produces no finding.
+        assert.strictEqual(
+          brokenLinks?.length,
+          1,
+          `meta.diagnostics.brokenLinks has only the broken element, got: ${JSON.stringify(
+            brokenLinks,
+          )}`,
+        );
+        assert.strictEqual(
+          brokenLinks?.[0]?.fieldName,
+          'pets',
+          'broken-link finding names the linksToMany field',
+        );
+        assert.ok(
+          brokenLinks?.[0]?.reference.includes('missing-pet-2'),
+          `broken-link finding carries the broken element reference, got: ${brokenLinks?.[0]?.reference}`,
+        );
+        assert.strictEqual(
+          brokenLinks?.[0]?.kind,
+          'not-found',
+          'a missing realm element is classified not-found',
+        );
+      });
+
       test('card prerender surfaces actionable error for bad icon import', async function (assert) {
         let cardURL = `${realmURL}bad-icon-import.json`;
 

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -1466,10 +1466,7 @@ module(basename(__filename), function () {
           result.response.card?.error,
           'prerender succeeds — the card indexes cleanly',
         );
-        let brokenLinks = (result.response.meta as any)?.diagnostics
-          ?.brokenLinks as
-          | { fieldName: string; reference: string; kind: string }[]
-          | undefined;
+        let brokenLinks = result.response.meta?.diagnostics?.brokenLinks;
         assert.strictEqual(
           brokenLinks?.length,
           1,
@@ -1507,10 +1504,7 @@ module(basename(__filename), function () {
           result.response.card?.error,
           'prerender succeeds — the card indexes cleanly',
         );
-        let brokenLinks = (result.response.meta as any)?.diagnostics
-          ?.brokenLinks as
-          | { fieldName: string; reference: string; kind: string }[]
-          | undefined;
+        let brokenLinks = result.response.meta?.diagnostics?.brokenLinks;
         // Only the broken element is recorded; the present sibling slot
         // (./real-pet) produces no finding.
         assert.strictEqual(

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -23,7 +23,7 @@ import {
   type Realm,
   type RealmPermissions,
   type ResolvedCodeRef,
-  type TimingDiagnostics,
+  type Diagnostics,
   executableExtensions,
   hasExecutableExtension,
   trimExecutableExtension,
@@ -187,9 +187,9 @@ interface WriteToDatabaseCacheParams {
   authUserId: string;
   // Server-observed render timings + host-side breadcrumbs flattened from
   // the prerender response's `meta` block (same shape as
-  // `boxel_index.timing_diagnostics`). Lets operators query slow / hung
+  // `boxel_index.diagnostics`). Lets operators query slow / hung
   // module renders the same way they query slow / hung card renders.
-  timingDiagnostics?: TimingDiagnostics;
+  diagnostics?: Diagnostics;
 }
 
 export class FilterRefersToNonexistentTypeError extends Error {
@@ -1290,7 +1290,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     resolvedRealmURL,
     cacheScope,
     authUserId,
-    timingDiagnostics,
+    diagnostics,
   }: WriteToDatabaseCacheParams): Promise<void> {
     await this.query([
       'INSERT INTO',
@@ -1306,7 +1306,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
           ['resolved_realm_url'],
           ['cache_scope'],
           ['auth_user_id'],
-          ['timing_diagnostics'],
+          ['diagnostics'],
         ]),
       ) as Expression),
       'VALUES',
@@ -1330,7 +1330,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
           [param(resolvedRealmURL)],
           [param(cacheScope)],
           [param(authUserId)],
-          [param(timingDiagnostics ? JSON.stringify(timingDiagnostics) : null)],
+          [param(diagnostics ? JSON.stringify(diagnostics) : null)],
         ]),
       ) as Expression),
       'ON CONFLICT ON CONSTRAINT modules_pkey DO UPDATE SET',
@@ -1341,7 +1341,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
         ['error_doc = excluded.error_doc'],
         ['created_at = excluded.created_at'],
         ['resolved_realm_url = excluded.resolved_realm_url'],
-        ['timing_diagnostics = excluded.timing_diagnostics'],
+        ['diagnostics = excluded.diagnostics'],
       ]) as Expression),
     ]);
   }
@@ -1397,7 +1397,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       resolvedRealmURL,
       cacheScope,
       authUserId: cacheScope === 'public' ? '' : userId,
-      timingDiagnostics: flattenPrerenderMeta(response.meta),
+      diagnostics: flattenPrerenderMeta(response.meta),
     });
     return cacheEntry;
   }

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -29,7 +29,7 @@ export interface SerializedError {
   stack?: string;
   // Structured render-timeout diagnostics (e.g. launchMs, waits,
   // renderStage, queryLoadsInFlight). The source of truth is the
-  // `boxel_index.timing_diagnostics` column; the IndexWriter copies
+  // `boxel_index.diagnostics` column; the IndexWriter copies
   // the payload onto this field when persisting an error row so the
   // existing UI read path (formattedError → CardErrorJSONAPI.meta.
   // diagnostics) continues to work unchanged.

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -28,7 +28,7 @@ import {
   type LocalPath,
   type Reader,
   type Stats,
-  type TimingDiagnostics,
+  type Diagnostics,
 } from './index';
 import { moduleFrom } from './code-ref';
 import type { CacheScope, DefinitionLookup } from './definition-lookup';
@@ -774,7 +774,7 @@ export class IndexRunner {
     resourceCreatedAt,
     resource,
     renderResult,
-    timingDiagnostics,
+    diagnostics,
   }: {
     path: LocalPath;
     lastModified: number;
@@ -784,7 +784,7 @@ export class IndexRunner {
     renderResult: NonNullable<
       Parameters<typeof performCardIndexing>[0]['precomputedRenderResult']
     >;
-    timingDiagnostics?: TimingDiagnostics;
+    diagnostics?: Diagnostics;
   }): Promise<void> {
     let fileURL = this.#realmPaths.fileURL(path).href;
     let instanceURL = new URL(
@@ -810,7 +810,7 @@ export class IndexRunner {
         auth: this.#auth,
         jobInfo: this.#jobInfo,
         precomputedRenderResult: renderResult,
-        timingDiagnostics,
+        diagnostics,
         dependencyResolver: this.#dependencyResolver,
         updateEntry: async (entryURL, entry) =>
           await this.updateEntry(entryURL, entry),
@@ -829,7 +829,7 @@ export class IndexRunner {
     hasModulePrerender,
     extractResult,
     renderResult,
-    timingDiagnostics,
+    diagnostics,
   }: {
     path: LocalPath;
     lastModified: number;
@@ -844,7 +844,7 @@ export class IndexRunner {
     renderResult?: Parameters<
       typeof performFileIndexing
     >[0]['precomputedRenderResult'];
-    timingDiagnostics?: TimingDiagnostics;
+    diagnostics?: Diagnostics;
   }): Promise<void> {
     let fileURL = this.#realmPaths.fileURL(path).href;
     let result = await performFileIndexing({
@@ -858,7 +858,7 @@ export class IndexRunner {
       jobInfo: this.#jobInfo,
       precomputedExtractResult: extractResult,
       precomputedRenderResult: renderResult,
-      timingDiagnostics,
+      diagnostics,
       dependencyResolver: this.#dependencyResolver,
       updateEntry: async (entryURL, entry) => {
         await this.batch.updateEntry(entryURL, entry);

--- a/packages/runtime-common/index-runner/card-indexer.ts
+++ b/packages/runtime-common/index-runner/card-indexer.ts
@@ -11,7 +11,7 @@ import {
   type LocalPath,
   type LooseCardResource,
   type RenderResponse,
-  type TimingDiagnostics,
+  type Diagnostics,
 } from '../index';
 import {
   CardError,
@@ -38,8 +38,8 @@ export interface CardIndexerOptions {
   // by the fused indexer.
   precomputedRenderResult: RenderResponse;
   // Timing / diagnostic payload attached to the fused-visit
-  // response; persisted onto `boxel_index.timing_diagnostics`.
-  timingDiagnostics?: TimingDiagnostics;
+  // response; persisted onto `boxel_index.diagnostics`.
+  diagnostics?: Diagnostics;
   dependencyResolver: IndexRunnerDependencyManager;
   updateEntry(
     instanceURL: URL,
@@ -59,7 +59,7 @@ export async function performCardIndexing({
   auth: _auth,
   jobInfo,
   precomputedRenderResult,
-  timingDiagnostics,
+  diagnostics,
   dependencyResolver,
   updateEntry,
   logWarn,
@@ -199,7 +199,7 @@ export async function performCardIndexing({
     logWarn(
       `${jobIdentity(jobInfo)} encountered error indexing card instance ${path}: ${renderError.error.message}`,
     );
-    await updateEntry(instanceURL, { ...renderError, timingDiagnostics });
+    await updateEntry(instanceURL, { ...renderError, diagnostics });
     return;
   }
 
@@ -244,7 +244,7 @@ export async function performCardIndexing({
         typeof searchDoc?._cardType === 'string'
           ? searchDoc._cardType
           : undefined,
-      timingDiagnostics,
+      diagnostics,
     });
     return;
   }
@@ -265,6 +265,6 @@ export async function performCardIndexing({
     types: types!,
     displayNames: displayNames ?? [],
     deps,
-    timingDiagnostics,
+    diagnostics,
   });
 }

--- a/packages/runtime-common/index-runner/file-indexer.ts
+++ b/packages/runtime-common/index-runner/file-indexer.ts
@@ -10,7 +10,7 @@ import {
   type JobInfo,
   type LocalPath,
   type ResolvedCodeRef,
-  type TimingDiagnostics,
+  type Diagnostics,
 } from '../index';
 import {
   CardError,
@@ -41,8 +41,8 @@ export interface FileIndexerOptions {
   precomputedExtractResult: FileExtractResponse | undefined;
   precomputedRenderResult?: FileRenderResponse;
   // Timing / diagnostic payload attached to the fused-visit response;
-  // persisted onto `boxel_index.timing_diagnostics` for this file's row.
-  timingDiagnostics?: TimingDiagnostics;
+  // persisted onto `boxel_index.diagnostics` for this file's row.
+  diagnostics?: Diagnostics;
   dependencyResolver: IndexRunnerDependencyManager;
   updateEntry(
     entryURL: URL,
@@ -62,7 +62,7 @@ export async function performFileIndexing({
   jobInfo,
   precomputedExtractResult,
   precomputedRenderResult,
-  timingDiagnostics,
+  diagnostics,
   dependencyResolver,
   updateEntry,
   logWarn,
@@ -145,7 +145,7 @@ export async function performFileIndexing({
     logWarn(
       `${jobIdentity(jobInfo)} encountered error indexing file ${path}: ${renderError.error.message}`,
     );
-    await updateEntry(entryURL, { ...renderError, timingDiagnostics });
+    await updateEntry(entryURL, { ...renderError, diagnostics });
     return 'error';
   }
 
@@ -184,7 +184,7 @@ export async function performFileIndexing({
         ...(extractResult.searchDoc ?? {}),
       },
       types: fileTypes,
-      timingDiagnostics,
+      diagnostics,
     });
     return 'error';
   }
@@ -224,7 +224,7 @@ export async function performFileIndexing({
     fittedHtml: renderResult?.fittedHTML ?? undefined,
     iconHTML: renderResult?.iconHTML ?? undefined,
     markdown: renderResult?.markdown ?? undefined,
-    timingDiagnostics,
+    diagnostics,
   });
 
   return 'indexed';

--- a/packages/runtime-common/index-runner/visit-file.ts
+++ b/packages/runtime-common/index-runner/visit-file.ts
@@ -16,7 +16,7 @@ import {
   type RealmPaths,
   type RenderRouteOptions,
   type RenderVisitResponse,
-  type TimingDiagnostics,
+  type Diagnostics,
 } from '../index';
 import { CardError } from '../error';
 import { resolveFileDefCodeRef } from '../file-def-code-ref';
@@ -52,9 +52,9 @@ interface VisitFileFusedOptions {
     renderResult: NonNullable<RenderVisitResponse['card']>;
     // Timing / diagnostic payload flattened from the fused visit's
     // `response.meta` (server timings + host-side breadcrumbs +
-    // HTTP requestId). Persisted onto `boxel_index.timing_diagnostics`
+    // HTTP requestId). Persisted onto `boxel_index.diagnostics`
     // so operators can investigate slow renders after the fact.
-    timingDiagnostics?: TimingDiagnostics;
+    diagnostics?: Diagnostics;
   }): Promise<void>;
   indexFileWithResults(args: {
     path: LocalPath;
@@ -63,7 +63,7 @@ interface VisitFileFusedOptions {
     hasModulePrerender?: boolean;
     extractResult?: RenderVisitResponse['fileExtract'];
     renderResult?: RenderVisitResponse['fileRender'];
-    timingDiagnostics?: TimingDiagnostics;
+    diagnostics?: Diagnostics;
   }): Promise<void>;
 }
 
@@ -227,7 +227,7 @@ export async function visitFileForIndexingFused({
       resourceCreatedAt,
       resource: parsedCardResource,
       renderResult: cardResult,
-      timingDiagnostics: flattenPrerenderMeta(visitResponse.meta),
+      diagnostics: flattenPrerenderMeta(visitResponse.meta),
     });
   }
 
@@ -241,7 +241,7 @@ export async function visitFileForIndexingFused({
     hasModulePrerender: isModule,
     extractResult: visitResponse.fileExtract,
     renderResult: visitResponse.fileRender,
-    timingDiagnostics: flattenPrerenderMeta(visitResponse.meta),
+    diagnostics: flattenPrerenderMeta(visitResponse.meta),
   });
 
   logDebug(

--- a/packages/runtime-common/index-structure.ts
+++ b/packages/runtime-common/index-structure.ts
@@ -34,12 +34,14 @@ export interface BoxelIndexTable {
   last_modified: string | null; // pg represents big integers as strings in javascript
   resource_created_at: string | null; // pg represents big integers as strings in javascript
   is_deleted: boolean | null;
-  // Per-row render timing diagnostics (launch/waits breakdown,
-  // render elapsed, host-side renderStage, top-N module evaluations,
-  // etc.). Populated on every updateEntry — success or error — so
-  // operators can post-hoc investigate slow (but not failing)
-  // renders too.
-  timing_diagnostics: Record<string, unknown> | null;
+  // Per-row render diagnostics. Carries the render timing breakdown
+  // (launch/waits, render elapsed, host-side renderStage, top-N module
+  // evaluations, etc.) plus non-timing render findings — notably
+  // `brokenLinks`, the broken `linksTo` / `linksToMany` targets the
+  // render surfaced. Populated on every updateEntry — success or error —
+  // so operators can post-hoc investigate slow (but not failing) renders
+  // and enumerate cards with broken links. See `Diagnostics` in `index.ts`.
+  diagnostics: Record<string, unknown> | null;
   // Originating worker job id. Stamped on every working-table write so
   // a retry of the same job can find (and skip) URLs the previous
   // attempt already processed. Only present on `boxel_index_working`
@@ -115,5 +117,5 @@ export const coerceTypes = Object.freeze({
   resource_created_at: 'VARCHAR',
   indexed_at: 'VARCHAR',
   value: 'JSON',
-  timing_diagnostics: 'JSON',
+  diagnostics: 'JSON',
 });

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -36,7 +36,7 @@ import { clampSerializedError, type SerializedError } from './error';
 import type { DBAdapter } from './db';
 import type { RealmMetaTable } from './index-structure';
 import type { FileMetaResource } from './resource-types';
-import type { TimingDiagnostics } from './index';
+import type { Diagnostics } from './index';
 import {
   coerceTypes,
   type BoxelIndexTable,
@@ -94,11 +94,11 @@ export interface InstanceEntry {
   deps: Set<string>;
   // Per-row render timing diagnostics (launch/waits/render timings
   // plus host-side breadcrumbs). Populated from the Prerenderer's
-  // `response.meta` and persisted onto `boxel_index.timing_diagnostics`.
+  // `response.meta` and persisted onto `boxel_index.diagnostics`.
   // Not tied to `has_error` — we persist this for successful rows too
   // so operators can retrospectively answer "why did this instance
   // take N seconds on the last reindex?".
-  timingDiagnostics?: TimingDiagnostics;
+  diagnostics?: Diagnostics;
 }
 
 export interface IndexErrorEntry {
@@ -107,10 +107,10 @@ export interface IndexErrorEntry {
   types?: string[];
   searchData?: Record<string, any>;
   cardType?: string;
-  // See InstanceEntry.timingDiagnostics. On the error path, the
+  // See InstanceEntry.diagnostics. On the error path, the
   // same payload is also copied into `error_doc.diagnostics` at
   // write time so the UI read path keeps working unchanged.
-  timingDiagnostics?: TimingDiagnostics;
+  diagnostics?: Diagnostics;
 }
 
 export type InstanceErrorIndexEntry = IndexErrorEntry & {
@@ -154,8 +154,8 @@ export interface FileEntry {
   atomHtml?: string;
   iconHTML?: string;
   markdown?: string;
-  // See InstanceEntry.timingDiagnostics.
-  timingDiagnostics?: TimingDiagnostics;
+  // See InstanceEntry.diagnostics.
+  diagnostics?: Diagnostics;
 }
 
 export class Batch {
@@ -171,8 +171,8 @@ export class Batch {
   // with stale content.
   #resumedRows = new Map<string, number | null>();
   // Correlation ID minted once per Batch and stamped into every row's
-  // `timing_diagnostics` via `updateEntry`, so operators can
-  // `SELECT ... WHERE timing_diagnostics->>'invalidationId' = '...'`
+  // `diagnostics` via `updateEntry`, so operators can
+  // `SELECT ... WHERE diagnostics->>'invalidationId' = '...'`
   // and see every row that was part of the same indexing fan-out in
   // one query. Minted in the constructor (not `invalidate()`) so
   // fromScratch — which doesn't call `invalidate()` — still gets a
@@ -418,7 +418,7 @@ export class Batch {
     }
     let href = url.href;
     this.#invalidations.add(url.href);
-    // Build the per-row timing_diagnostics blob. Render-side fields
+    // Build the per-row diagnostics blob. Render-side fields
     // come from the Prerenderer's `response.meta` (already flattened
     // in `visit-file.ts`); write-side stamps are added here:
     //
@@ -428,14 +428,14 @@ export class Batch {
     //     correlation key.
     //   - `indexedAt` — wall-clock the write happened.
     //
-    // The canonical storage is the `timing_diagnostics` column. For
+    // The canonical storage is the `diagnostics` column. For
     // error rows we ALSO mirror the blob onto `error_doc.diagnostics`
     // so the UI read path (error doc → CardErrorJSONAPI.meta.
     // diagnostics via `formattedError`) keeps working unchanged —
     // no schema rename needed. The column remains source of truth;
     // the error-doc copy is derived.
-    let timingDiagnostics: TimingDiagnostics = {
-      ...(entry.timingDiagnostics ?? {}),
+    let diagnostics: Diagnostics = {
+      ...(entry.diagnostics ?? {}),
       invalidationId: this.#currentInvalidationId,
       indexedAt: Date.now(),
     };
@@ -448,9 +448,9 @@ export class Batch {
               // The SerializedError shape's `diagnostics` is
               // `Record<string, unknown>` by design (it tolerates
               // extra fields for derived / legacy payloads);
-              // `TimingDiagnostics` is structurally-compatible
+              // `Diagnostics` is structurally-compatible
               // but needs an explicit cast across the boundary.
-              diagnostics: timingDiagnostics as Record<string, unknown>,
+              diagnostics: diagnostics as Record<string, unknown>,
             },
             url,
           ),
@@ -480,7 +480,7 @@ export class Batch {
           resource_created_at: entry.resourceCreatedAt,
           error_doc: null,
           has_error: false,
-          timing_diagnostics: timingDiagnostics,
+          diagnostics: diagnostics,
         };
         break;
       case 'file':
@@ -503,7 +503,7 @@ export class Batch {
           resource_created_at: entry.resourceCreatedAt,
           error_doc: null,
           has_error: false,
-          timing_diagnostics: timingDiagnostics,
+          diagnostics: diagnostics,
         };
         break;
       case 'instance-error':
@@ -525,7 +525,7 @@ export class Batch {
           type: baseTypeFromError(entry),
           error_doc: errorEntry?.error ?? entry.error,
           has_error: true,
-          timing_diagnostics: timingDiagnostics,
+          diagnostics: diagnostics,
         };
         break;
       default:
@@ -823,7 +823,7 @@ export class Batch {
   private async tombstoneEntries(invalidations: string[]) {
     // insert tombstone into next version of the realm index. Stamp
     // the current `invalidationId` + `indexedAt` on every tombstone
-    // so fan-out queries (`WHERE timing_diagnostics->>'invalidationId'
+    // so fan-out queries (`WHERE diagnostics->>'invalidationId'
     // = <id>`) also surface the delete rows for this pass — otherwise
     // tombstones would inherit a stale ID from a prior write or stay
     // NULL entirely, misattributing deletes in the grouping view.
@@ -857,14 +857,14 @@ export class Batch {
       'is_deleted',
       'has_error',
       'error_doc',
-      'timing_diagnostics',
+      'diagnostics',
       'job_id',
     ].map((c) => [c]);
-    let tombstoneDiagnostics: TimingDiagnostics = {
+    let tombstoneDiagnostics: Diagnostics = {
       invalidationId: this.#currentInvalidationId,
       indexedAt: Date.now(),
     };
-    // `timing_diagnostics` is a jsonb column. This helper uses
+    // `diagnostics` is a jsonb column. This helper uses
     // `upsertMultipleRows` which passes each value through `param()`
     // as a raw `PgPrimitive`, so we pre-serialize the JSON here (the
     // regular `updateEntry` path reaches jsonb via `asExpressions`
@@ -992,7 +992,7 @@ export class Batch {
     await this.ready;
     // Mint a fresh correlation ID for this invalidation fan-out; every
     // subsequent `updateEntry` on this batch stamps it into the row's
-    // `timing_diagnostics` so operators can group the rows touched by
+    // `diagnostics` so operators can group the rows touched by
     // the same triggering change.
     this.#currentInvalidationId = uuidv4();
     let start = Date.now();

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -355,13 +355,17 @@ export interface ModuleRenderResponse extends ModulePrerenderModel {
 export interface PrerenderResponseMeta {
   // Aggregated diagnostic payload — server-observed timings
   // (launchMs, waits, renderElapsedMs, totalElapsedMs from
-  // `RenderTimeoutDiagnostics`) plus host-side breadcrumbs
-  // (renderStage, in-flight loads, recent module evaluations,
-  // blocked-timer summary, etc.). Populated by the Prerenderer from
-  // both its own timing measurements and any `RenderError.diagnostics`
-  // lifted out of embedded errors. The indexer picks this up, merges
-  // in the HTTP `requestId`, and persists into `diagnostics`.
-  diagnostics?: RenderTimeoutDiagnostics;
+  // `RenderTimeoutDiagnostics`) plus the host-side `render.meta` block
+  // (`PrerenderMetaDiagnostics`: computed-field counters and the
+  // `brokenLinks` findings) lifted off the card sub-response. Typed as
+  // the full persisted `Diagnostics` shape so consumers of the response
+  // contract can read every lifted field — notably `brokenLinks` —
+  // without casts; the write-side stamps it adds (`invalidationId`,
+  // `indexedAt`) are simply absent at this stage. Populated by the
+  // Prerenderer from its own timing measurements and any lifted
+  // `RenderError.diagnostics`; the indexer merges in the HTTP `requestId`
+  // and persists the result into the `diagnostics` column.
+  diagnostics?: Diagnostics;
   // HTTP correlation ID stamped by the prerender server's Koa layer.
   // Lets operators join client → manager → prerender-server logs for
   // a single request. Absent for in-process (non-HTTP) callers.
@@ -387,14 +391,15 @@ export interface PrerenderResponseMeta {
 // write-side stamps come from the IndexWriter. Any stage may skip
 // pieces that aren't applicable (e.g. non-timeout renders have no
 // `renderStage`, in-process callers have no `requestId`).
-export interface Diagnostics extends RenderTimeoutDiagnostics {
+// Extends both render-side diagnostic shapes so the persisted blob types
+// every field that actually lands in it: server-observed timings from
+// `RenderTimeoutDiagnostics` and the host-side `render.meta` block from
+// `PrerenderMetaDiagnostics` (computed-field counters plus `brokenLinks`).
+// The two write-side stamps below are added at `IndexWriter.updateEntry`.
+export interface Diagnostics
+  extends RenderTimeoutDiagnostics, PrerenderMetaDiagnostics {
   invalidationId?: string;
   indexedAt?: number;
-  // Broken-link findings lifted from the render.meta `diagnostics` block
-  // (see `PrerenderMetaDiagnostics.brokenLinks`). Surfaced on the
-  // persisted shape so SQL-side consumers can read it as a queryable
-  // property of the index row.
-  brokenLinks?: BrokenLinkSummary[];
 }
 
 // Flatten a prerender `response.meta` block into the shape persisted to

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -44,6 +44,25 @@ export type PatchData = {
   };
 };
 
+// A broken `linksTo` / `linksToMany` target found on the rendered
+// instance, recorded as searchable metadata on the (successful) index
+// entry. The card itself indexes as `type='instance'` — the broken slot
+// renders a placeholder and the reference is preserved on the wire — so
+// this is the only direct, indexed signal that lets a consumer (AI
+// tooling, realm-health reports) enumerate cards-with-broken-links
+// without parsing the rendered HTML or re-running `getBrokenLinks` at
+// read time. `errorDoc` is intentionally omitted: it's large, and the
+// error detail is still available at runtime via
+// `getRelationship(card, fieldName)` and inline in the rendered placeholder.
+export interface BrokenLinkSummary {
+  // The declared `linksTo` / `linksToMany` field holding the broken reference.
+  fieldName: string;
+  // The broken target reference, preserved from the relationship state.
+  reference: string;
+  // `'error'` for a generic upstream failure, `'not-found'` for an HTTP 404.
+  kind: 'error' | 'not-found';
+}
+
 // Per-render computed-field counters captured by the host's render.meta
 // route. Emitted alongside PrerenderMeta so the Prerenderer can lift them
 // onto `response.meta.diagnostics` and the indexer can persist them onto
@@ -64,6 +83,12 @@ export interface PrerenderMetaDiagnostics {
   serializeMs?: number;
   // Wall-clock of the host-side searchDoc call.
   searchDocMs?: number;
+  // Broken `linksTo` / `linksToMany` targets found on the rendered
+  // instance after the store settled. Captured by the render.meta scan
+  // and persisted to `boxel_index.timing_diagnostics.brokenLinks` so
+  // cards-with-broken-links are cheaply enumerable. Omitted entirely
+  // when the card has no broken links.
+  brokenLinks?: BrokenLinkSummary[];
 }
 
 // Shared type produced by the host app when visiting the render.meta route and
@@ -362,6 +387,11 @@ export interface PrerenderResponseMeta {
 export interface TimingDiagnostics extends RenderTimeoutDiagnostics {
   invalidationId?: string;
   indexedAt?: number;
+  // Broken-link findings lifted from the render.meta `diagnostics` block
+  // (see `PrerenderMetaDiagnostics.brokenLinks`). Surfaced on the
+  // persisted shape so SQL-side consumers can read it as a queryable
+  // property of the index row.
+  brokenLinks?: BrokenLinkSummary[];
 }
 
 // Flatten a prerender `response.meta` block into the shape persisted to

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -66,7 +66,7 @@ export interface BrokenLinkSummary {
 // Per-render computed-field counters captured by the host's render.meta
 // route. Emitted alongside PrerenderMeta so the Prerenderer can lift them
 // onto `response.meta.diagnostics` and the indexer can persist them onto
-// `boxel_index.timing_diagnostics`. All fields optional — older host
+// `boxel_index.diagnostics`. All fields optional — older host
 // builds that predate the counters omit the block entirely.
 export interface PrerenderMetaDiagnostics {
   // Number of `computeVia` invocations that ran during the
@@ -85,7 +85,7 @@ export interface PrerenderMetaDiagnostics {
   searchDocMs?: number;
   // Broken `linksTo` / `linksToMany` targets found on the rendered
   // instance after the store settled. Captured by the render.meta scan
-  // and persisted to `boxel_index.timing_diagnostics.brokenLinks` so
+  // and persisted to `boxel_index.diagnostics.brokenLinks` so
   // cards-with-broken-links are cheaply enumerable. Omitted entirely
   // when the card has no broken links.
   brokenLinks?: BrokenLinkSummary[];
@@ -101,7 +101,7 @@ export interface PrerenderMeta {
   types: string[] | null;
   // Optional host-side timing block. The Prerenderer lifts this onto
   // `response.meta.diagnostics` so it persists to
-  // `boxel_index.timing_diagnostics` for SQL-side perf triage.
+  // `boxel_index.diagnostics` for SQL-side perf triage.
   diagnostics?: PrerenderMetaDiagnostics;
 }
 
@@ -263,7 +263,7 @@ export interface RenderTimeoutDiagnostics {
       // — e.g. a priority-10 file render stuck behind a priority-0
       // module call sticks out cleanly. Optional in the schema even
       // though fresh producers always emit a value: the same shape is
-      // deserialized from `boxel_index.timing_diagnostics`, where rows
+      // deserialized from `boxel_index.diagnostics`, where rows
       // persisted before priority threading landed will lack the
       // field. Consumers should treat absent as `0`.
       priority?: number;
@@ -271,7 +271,7 @@ export interface RenderTimeoutDiagnostics {
   };
   // Host-emitted computed-field counters lifted out of
   // PrerenderMeta.diagnostics so they ride alongside the existing
-  // server-observed timings in `boxel_index.timing_diagnostics`.
+  // server-observed timings in `boxel_index.diagnostics`.
   computedCalls?: number;
   computedCacheHits?: number;
   serializeMs?: number;
@@ -284,7 +284,7 @@ export interface RenderError extends ErrorEntry {
   // in-flight loads, blocked-timer summary, etc.) produced by
   // `withTimeout`. The Prerenderer lifts these onto
   // `response.meta.diagnostics` before returning, where the indexer
-  // picks them up and persists them into `timing_diagnostics`. The
+  // picks them up and persists them into `diagnostics`. The
   // field is dropped from the final response — callers should read
   // `response.meta.diagnostics` instead.
   diagnostics?: RenderTimeoutDiagnostics;
@@ -346,7 +346,7 @@ export interface ModulePrerenderModel {
 
 export interface ModuleRenderResponse extends ModulePrerenderModel {
   // Server-observed timing breakdown, carried in the response body
-  // so the indexer can persist it onto `boxel_index.timing_diagnostics`
+  // so the indexer can persist it onto `boxel_index.diagnostics`
   // for both in-process and remote prerender paths without needing a
   // separate side channel.
   meta?: PrerenderResponseMeta;
@@ -360,7 +360,7 @@ export interface PrerenderResponseMeta {
   // blocked-timer summary, etc.). Populated by the Prerenderer from
   // both its own timing measurements and any `RenderError.diagnostics`
   // lifted out of embedded errors. The indexer picks this up, merges
-  // in the HTTP `requestId`, and persists into `timing_diagnostics`.
+  // in the HTTP `requestId`, and persists into `diagnostics`.
   diagnostics?: RenderTimeoutDiagnostics;
   // HTTP correlation ID stamped by the prerender server's Koa layer.
   // Lets operators join client → manager → prerender-server logs for
@@ -368,14 +368,17 @@ export interface PrerenderResponseMeta {
   requestId?: string;
 }
 
-// The shape persisted to `boxel_index.timing_diagnostics`. Extends
-// `RenderTimeoutDiagnostics` (which already carries `requestId`) with
-// two write-side stamps applied at `IndexWriter.updateEntry` time:
+// The shape persisted to `boxel_index.diagnostics`. Named `Diagnostics`
+// (not `TimingDiagnostics`) because the block is no longer purely about
+// timing: it also carries `brokenLinks`, the broken-link findings the
+// render surfaced. Extends `RenderTimeoutDiagnostics` (which already
+// carries `requestId`) with two write-side stamps applied at
+// `IndexWriter.updateEntry` time:
 //
 //   - `invalidationId` — one UUID per `Batch`; every row touched by
 //     the same indexing pass (incremental fan-out or fromScratch)
 //     shares it, so operators can `SELECT ... WHERE
-//     timing_diagnostics->>'invalidationId' = '<id>'` and see the
+//     diagnostics->>'invalidationId' = '<id>'` and see the
 //     whole batch.
 //   - `indexedAt` — wall-clock the write happened.
 //
@@ -384,7 +387,7 @@ export interface PrerenderResponseMeta {
 // write-side stamps come from the IndexWriter. Any stage may skip
 // pieces that aren't applicable (e.g. non-timeout renders have no
 // `renderStage`, in-process callers have no `requestId`).
-export interface TimingDiagnostics extends RenderTimeoutDiagnostics {
+export interface Diagnostics extends RenderTimeoutDiagnostics {
   invalidationId?: string;
   indexedAt?: number;
   // Broken-link findings lifted from the render.meta `diagnostics` block
@@ -395,14 +398,14 @@ export interface TimingDiagnostics extends RenderTimeoutDiagnostics {
 }
 
 // Flatten a prerender `response.meta` block into the shape persisted to
-// `*.timing_diagnostics` columns. Keeps the rich host-side payload (from
+// `*.diagnostics` columns. Keeps the rich host-side payload (from
 // `meta.diagnostics`) at the top level and promotes the HTTP `requestId`
 // alongside it for jsonb-path querying. Returns `undefined` when there's
 // nothing to persist. Used by both the indexer (boxel_index rows) and the
 // definition-lookup module-cache writer (modules rows).
 export function flattenPrerenderMeta(
   meta: PrerenderResponseMeta | undefined,
-): TimingDiagnostics | undefined {
+): Diagnostics | undefined {
   if (!meta) return undefined;
   let diagnostics = meta.diagnostics ?? {};
   let hasRequestId = meta.requestId != null;
@@ -514,7 +517,7 @@ export interface RenderVisitResponse {
   pageUnusableError?: RenderError;
   // See ModuleRenderResponse.meta — server-observed timing breakdown
   // embedded in the response so the indexer can persist it to
-  // `boxel_index.timing_diagnostics`.
+  // `boxel_index.diagnostics`.
   meta?: PrerenderResponseMeta;
 }
 


### PR DESCRIPTION
## Background and Goal

A card whose `linksTo` / `linksToMany` target is unreachable (deleted, 404, upstream 5xx, network failure) indexes as a clean `type='instance'`: the broken slot renders the placeholder and the broken reference is preserved on the wire as `relationships.<field>.links.self`. `has_error` is `false` and `error_doc` is `null`, so nothing in the row's status tells you a link is broken. Listing every card with a broken link previously meant parsing rendered HTML or re-running `getBrokenLinks` per read.

This records the broken-link findings as a queryable property of the success entry: a `brokenLinks` array on the index row's diagnostics column (and `boxel_index_working`). Consumers — AI tooling, realm-health reports, search — can now cheaply enumerate cards-with-broken-links straight from the column.

It also **renames the `timing_diagnostics` column to `diagnostics`** on `boxel_index`, `boxel_index_working`, and `modules`. The blob is no longer purely about timing now that it carries broken-link findings, so the name no longer fit. The shared TypeScript type `TimingDiagnostics` is renamed to `Diagnostics` and the in-memory carrier property `timingDiagnostics` to `diagnostics` to match.

Stacked on #5022, which is what makes broken-link cards index as `type='instance'` in the first place (it removes the post-settle scan-and-throw). Retarget the base to `main` once #5022 lands.

## Where to start

- `packages/host/app/routes/render/meta.ts` — the success path. After the store settles, `getBrokenLinks(instance)` runs and the findings are attached to the `diagnostics` block the route already returns. Guarded by a `typeof` check like the adjacent compute-pass hooks.
- `packages/runtime-common/index.ts` — `BrokenLinkSummary` plus the `brokenLinks?` field on `PrerenderMetaDiagnostics` (host carrier) and `Diagnostics` (persisted shape). The finding rides the same lift (`decorateRenderErrorsWithTimings`) and flatten (`flattenPrerenderMeta`) path as `computedCalls` / `serializeMs`, so no plumbing change is needed in `render-settlement.ts`.
- `packages/postgres/migrations/1780059236455_rename-timing-diagnostics-to-diagnostics.js` — the column rename (3 tables, reversible). `packages/host/config/schema/1780059236455_schema.sql` is the regenerated SQLite schema (`pnpm make-schema`).
- `.claude/skills/indexing-diagnostics/SKILL.md` — documents the renamed column, the `brokenLinks` key, and the enumeration / count / blast-radius queries (Mode E).

## Key decisions and non-obvious mechanics

- **No new column.** The rename reuses the existing JSONB column; `brokenLinks` is a new key inside it. The whole point of the consolidated diagnostics column is that new render-side signals are additive.
- **The `modules` column is renamed too.** It carries the same `Diagnostics` shape and the skill documents it alongside the index column, so leaving it as `timing_diagnostics` would split the naming for one concept.
- **`errorDoc` is not persisted.** Each finding is the minimal `{ fieldName, reference, kind }`. The error detail stays available at runtime via `getRelationship(card, fieldName)` and inline in the rendered placeholder; the broken target is also in `deps`, so the card is re-rendered (clearing the finding) if the target reappears.
- **`kind`** is `'not-found'` for an HTTP 404 (the canonical "target was deleted" case) and `'error'` for any other upstream failure. A `linksToMany` field with one broken element produces one finding for that element; present siblings produce none.
- **The scan is on the success path only.** It runs in `render.meta` after `readyPromise` resolves, so it reads terminal relationship state through `getRelationship` without retriggering a load.
- **`error_doc.diagnostics` is unchanged.** The error-row UI mirror keeps its existing field name; only the canonical column was renamed.
