### PR TITLE
Make indexer module pre-warm populate the definition cache

### DIFF
--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: indexing-diagnostics
-description: Investigate slow or failing indexing using the diagnostics persisted on every `boxel_index` row (`diagnostics` JSONB column, mirrored onto `error_doc.diagnostics` for error rows) plus the matching prerender-server / manager logs. Covers (1) a render inside indexing timed out — classify which part of the prerender pipeline stalled, (2) an incremental or full reindex was slow but didn't fail — attribute time across the invalidation fan-out and find the rows that cost the most, and (3) enumerating cards with broken `linksTo` / `linksToMany` targets via `diagnostics.brokenLinks` (those cards index cleanly, so this is the only indexed signal). Use when indexing fails with "Render timeout", when a user sees a 504, when a reindex took much longer than expected, when an `.gts` edit triggers a surprising amount of re-render work, when investigating the CS-10820 saturation class of incidents, or when asked to list / count cards with broken links in a realm. For staging/prod investigations this skill layers on top of `aws-access`, which provides the AWS session and the SSM port-forward path into the in-VPC database (authenticated as `claude_readonly_user`) — read that skill first when the question is about a deployed environment.
+description: Investigate slow or failing indexing using the diagnostics persisted on every `boxel_index` row (`diagnostics` JSONB column, mirrored onto `error_doc.diagnostics` for error rows) plus the matching prerender-server / manager logs. Covers (1) a render inside indexing timed out — classify which part of the prerender pipeline stalled, (2) an incremental or full reindex was slow but didn't fail — attribute time across the invalidation fan-out and find the rows that cost the most, (3) enumerating cards with broken `linksTo` / `linksToMany` targets via `diagnostics.brokenLinks` (those cards index cleanly, so this is the only indexed signal), and (4) verifying the module pre-warm phase populates the definition cache under a key the indexer / on-demand prerender reads actually hit — i.e. it isn't a silent no-op — via the `definition-cache-key` hit/miss log channel. Use when indexing fails with "Render timeout", when a user sees a 504, when a reindex took much longer than expected, when an `.gts` edit triggers a surprising amount of re-render work, when investigating the CS-10820 saturation class of incidents, or when asked to list / count cards with broken links in a realm. For staging/prod investigations this skill layers on top of `aws-access`, which provides the AWS session and the SSM port-forward path into the in-VPC database (authenticated as `claude_readonly_user`) — read that skill first when the question is about a deployed environment.
 allowed-tools: Read, Grep, Glob, Bash
 ---
 
@@ -11,8 +11,9 @@ Every indexer write (`IndexWriter.updateEntry`) persists a diagnostic blob on th
 - **A render that timed out during indexing** — classify the stall, fix the right layer. (Also applies to user-facing 504s since the UI path goes through the same prerender.)
 - **A reindex that was slow but succeeded** — attribute wall-clock across the cards that got re-rendered, find the real culprit in the fan-out.
 - **Which cards have broken links** — enumerate cards with a broken `linksTo` / `linksToMany` target straight from the column; those cards index cleanly, so `diagnostics.brokenLinks` is the only indexed signal. See [Mode E](#mode-e--enumerate-cards-with-broken-links).
+- **Whether module pre-warm is effective** — confirm the pre-warm phase populates the definition cache under a key the indexer / on-demand reads actually hit (not a silent no-op), using the `definition-cache-key` hit/miss log channel. This one isn't about the `diagnostics` column — it reads the logs. See [Mode F](#mode-f--module-pre-warm-and-definition-cache-hitmiss).
 
-All three read from the same column. The difference is the query you start with.
+The first three read from the same `diagnostics` column; the difference is the query you start with. Mode F is log-based.
 
 ## Where the diagnostics live
 
@@ -698,6 +699,101 @@ Caveats:
 - **Older rows predate the scan.** A row last indexed before this capability shipped has no `brokenLinks` key even if its links are broken — it'll only appear after the next reindex. Don't read "absent" as "no broken links" for stale rows; check `indexedAt` if in doubt.
 - **`boxel_index_working` carries it too**, so you can watch broken-link findings accrue mid-reindex the same way as the timing fields (see [Reading partial progress](#5-reading-partial-progress-from-boxel_index_working)).
 - This is the cheap enumeration path the rendered-HTML / `getRelationship` runtime surfaces were too expensive for — querying the column avoids parsing HTML or re-running `getBrokenLinks` per read.
+
+## Mode F — module pre-warm and definition-cache hit/miss
+
+Use this when you're asking *"is the module pre-warm actually populating the definition cache, and are the indexer / prerender reads hitting it — or silently re-computing?"* This is about **cache effectiveness**, not render timing.
+
+### What pre-warm is
+
+A from-scratch (and incremental) index runs a **pre-warm phase** before the visit phase: `IndexRunner.preWarmModulesTable` walks the realm's modules and calls `definitionLookup.populateDefinitionCacheEntry(...)`, which prerenders each module's definitions and persists them to the `modules` table. The intent is that the subsequent **visit phase** (indexing instances) and **on-demand reads** (the realm-server serving `getDefinition` to prerender tabs) then find those rows already cached instead of re-prerendering them.
+
+The original failure this guards against: a worker pre-warm that ran with a self-resolved *null* cache context wrote nothing (or wrote under a key nobody reads), so pre-warm was a silent no-op. The diagnostic below tells you definitively whether that's happening.
+
+### The cache key
+
+The `modules` table row is keyed on **`(resolved_realm_url, cache_scope, auth_user_id)`**. The two derivations that MUST agree:
+
+- **Write** (`persistDefinitionCacheEntry`): stores `auth_user_id = cacheScope === 'public' ? '' : userId`.
+- **Read** (`buildLookupContext`): looks up with `cacheUserId = isPublic ? '' : prerenderUserId`.
+
+So the key differs by realm visibility:
+
+- **Public realm** → `cache_scope='public'`, `auth_user_id=''` (empty). The realm owner / render identity is **not** part of the key.
+- **Private realm** → `cache_scope='realm-auth'`, `auth_user_id=@<owner>:<matrix-domain>`.
+
+If write and read ever derive `auth_user_id` differently for the same module, pre-warm writes a row no reader probes → permanent miss. The hit/miss log is how you catch that.
+
+### Enabling the hit/miss log channel
+
+Category: **`definition-cache-key=debug`** (and `definition-lookup=debug` for the pre-warm warnings/skips). Locally:
+
+```sh
+LOG_LEVELS='*=info,definition-cache-key=debug' mise run dev-all
+```
+
+Deployed: set `LOG_LEVELS` in the worker's SSM param and redeploy (same mechanics as [Mode C step 7](#7-cross-referencing-with-worker-logs)). It applies to subsequently-launched workers.
+
+Three events are emitted (all via the framework `logger`, so the lines carry **no `[category]` prefix** — grep the message text, not the word `definition-cache-key`):
+
+| Line | Where | Meaning |
+| --- | --- | --- |
+| `WRITE module=<u> scope=<s> user=<id\|(empty)> realm=<r>` | `persistDefinitionCacheEntry` | A definition was persisted. The `user=` shown is the **normalized stored key** (public → `(empty)`), not the render identity. |
+| `HIT module=<u> scope=<s> user=<…> realm=<r> alias=<a>` | `readFromDatabaseCache` | A DB read found the row. Always a real hit (logged at the read choke point, covers worker + realm-server). |
+| `MISS source=pre-warm\|on-demand module=<u> …` | `loadDefinitionCacheEntryUncached` | A lookup **exhausted the cache** (primary URL + every alias/extension candidate) and committed to a prerender. Logged **once per logical lookup** — not per alias probe. `source=pre-warm` is the pre-warm phase's own cold probe; `source=on-demand` is a visit-phase / live read. |
+
+> Two logging facts that will mislead you if you don't know them:
+> 1. **Category overrides only take effect because `setup-logger.ts` calls `reapplyLogLevels()`** after installing `_logDefinitions`. Module-scope `logger()` calls (like this one) are evaluated during the barrel import *before* `_logDefinitions` exists, so without the re-apply they stay stuck at loglevel's default and `definition-cache-key=debug` silently no-ops. If you add a new module-scope category and it won't emit, this is why.
+> 2. A bare `readFromDatabaseCache` returning no rows is **not** a real miss — it's one probe (the reader tries `foo`, `foo.ts`, `foo.js`, `foo.gts`, `foo.gjs`). Counting those as misses inflates the number ~5×. The `MISS source=…` line is the de-duplicated, real signal; trust it over raw DB-read counts.
+
+### The healthy shape
+
+For a cold from-scratch of a single realm, healthy looks like:
+
+- `MISS source=pre-warm` ≈ one per module being warmed. **These are expected** — they *are* the warming (probe cold → prerender → `WRITE`).
+- `MISS source=on-demand` = **0**.
+- Realm-server on-demand reads = all HIT, **0 miss**, after the pre-warm phase.
+
+i.e. **misses occur only during the pre-warm phase.** Anything else is a bug.
+
+### The unhealthy shape (what you're hunting)
+
+- **`MISS source=on-demand` > 0 for canonical modules** (the `.gts`/`.ts` form, not an alias probe), or persistent realm-server misses for a module pre-warm already `WRITE`-d → the write key ≠ the read key. Compare the `user=`/`scope=` on the `WRITE` line vs the `MISS`/read line for the same module. The usual culprit is a divergence between `persistDefinitionCacheEntry`'s `auth_user_id` normalization and `buildLookupContext`'s `cacheUserId` (e.g. one resolving the owner where the other uses empty). Public realms are the sensitive case — both paths must collapse the user to `''`.
+- **No `WRITE` lines at all during pre-warm** → pre-warm is skipping (context-resolve failure → `definition-lookup` warn line, empty user, browser-test env, or empty candidate set). Check `definition-lookup=debug`.
+
+### Verification protocol (isolated, repeatable)
+
+```sh
+# 1. Pick a CLEAN realm (0 error rows). Confirm public vs private from the cache:
+#    public realms have cache_scope='public' rows.
+SELECT regexp_replace(resolved_realm_url,'^https?://[^/]+/','') realm, cache_scope, count(*)
+FROM modules GROUP BY 1,2 ORDER BY 1,2;
+
+# 2. Force a cold pre-warm: delete the realm's module rows.
+DELETE FROM modules WHERE resolved_realm_url LIKE '%/<realm-path>/';
+
+# 3. Mark the log offset, trigger a single-realm reindex (see "Triggering a reindex"):
+OFF=$(wc -l < /tmp/stack.log)
+curl -sk -X POST "https://localhost:4201/_grafana-reindex?realm=<realm-path>" \
+  -H "Authorization: Bearer $GRAFANA_SECRET"
+
+# 4. After it settles, split HIT/MISS by process and source:
+tail -n +$((OFF+1)) /tmp/stack.log | grep -a '<realm-path>' \
+  | grep -aoE 'HIT |MISS source=pre-warm|MISS source=on-demand|WRITE ' | sort | uniq -c
+# and the realm-server's on-demand misses specifically:
+tail -n +$((OFF+1)) /tmp/stack.log | grep -a 'services:realm-server' | grep -a '<realm-path>' \
+  | grep -acE 'MISS source=on-demand'   # expect 0
+```
+
+Run it once on a **private** realm and once on a **public** realm — the public case is where a key-derivation divergence hides. Reference numbers from a healthy run (a private 234-file realm): worker `MISS source=pre-warm`=159, `MISS source=on-demand`=0, realm-server on-demand misses=0; pre-warm phase ~8.5s for 86 modules (~99 ms/module), serial.
+
+### Pre-warm concurrency
+
+Pre-warm is **serial by default** (`INDEXER_PREWARM_CONCURRENCY=1`). It's opt-in tunable — a bounded worker pool over `populateDefinitionCacheEntry`. On a cold / shared prerender pool, raising it can be *slower* (tab materialization cost vs warm-tab reuse), so measure the pre-warm-phase wall-clock (the `modules.created_at` min→max window for the realm) before and after rather than assuming parallel wins. Align the ceiling with the prerender affinity tab budget (`PRERENDER_AFFINITY_TAB_MAX`); beyond that you just queue inside the prerender server.
+
+### What Mode F can't tell you
+
+Pre-warm only populates module **definitions**. A realm whose card-authored modules fail to *evaluate* (e.g. a circular-dependency TDZ in a bundled module — `Cannot access 'X' before initialization`) will still fail the **visit phase** instance renders regardless of a clean pre-warm; those show up as `boxel_index` error rows, not cache misses. Mode F confirms the cache is keyed and populated correctly; it says nothing about whether the modules themselves render.
 
 ## Field-by-field reading
 

--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -247,6 +247,9 @@ module('Unit | query', function (hooks) {
       async getCachedDefinitions(): Promise<undefined> {
         return undefined;
       },
+      async populateDefinitionCacheEntry(): Promise<undefined> {
+        return undefined;
+      },
       async getCachedDefinitionsBatch(): Promise<Record<string, never>> {
         return {};
       },

--- a/packages/realm-server/handlers/handle-indexing-dashboard.ts
+++ b/packages/realm-server/handlers/handle-indexing-dashboard.ts
@@ -266,11 +266,18 @@ export function renderIndexingDashboard(snapshot: DashboardSnapshot): string {
       border-radius: 4px;
       transition: width 0.3s ease;
     }
-    /* "Calculating" state: full-width subdued bar that pulses while the
-       invalidation/pre-warm phase determines how much work the job has. */
+    /* "Calculating" state: full-width subdued striped bar shown while the
+       invalidation/pre-warm phase determines how much work the job has.
+       Intentionally static (no animation) — the dashboard reloads every
+       2s, which would restart any animation and make it flicker. */
     .progress-bar.calculating {
-      background: linear-gradient(90deg, #30363d, #484f58);
-      animation: pulse 1.4s ease-in-out infinite;
+      background: repeating-linear-gradient(
+        45deg,
+        #30363d,
+        #30363d 10px,
+        #3a414b 10px,
+        #3a414b 20px
+      );
       transition: none;
     }
     .progress-text {

--- a/packages/realm-server/handlers/handle-indexing-dashboard.ts
+++ b/packages/realm-server/handlers/handle-indexing-dashboard.ts
@@ -48,6 +48,11 @@ function renderActiveCard(state: RealmIndexingState): string {
     state.totalFiles > 0
       ? Math.round((state.filesCompleted / state.totalFiles) * 100)
       : 0;
+  // The job announces itself at kickoff with a total of 0 and fills it in
+  // once invalidation discovery + pre-warm have determined how much work
+  // there is. Show a "calculating" state for that window instead of a
+  // misleading 0 / 0 (0%).
+  let calculating = state.status === 'indexing' && state.totalFiles === 0;
 
   const completedSet = new Set(state.completedFiles);
   let remainingFiles = state.files.filter((f) => !completedSet.has(f));
@@ -69,12 +74,20 @@ function renderActiveCard(state: RealmIndexingState): string {
         <span class="job-meta">job #${state.jobId} &middot; started ${timeSince(state.startedAt)} &middot; ${durationMs(state.startedAt)} elapsed</span>
       </div>
       <div class="progress-bar-container">
-        <div class="progress-bar" style="width: ${pct}%"></div>
-        <span class="progress-text">${state.filesCompleted} / ${state.totalFiles} files (${pct}%)</span>
+        <div class="progress-bar${calculating ? ' calculating' : ''}" style="width: ${calculating ? 100 : pct}%"></div>
+        <span class="progress-text">${
+          calculating
+            ? 'Calculating files to index&hellip;'
+            : `${state.filesCompleted} / ${state.totalFiles} files (${pct}%)`
+        }</span>
       </div>
-      <div class="remaining-count">${remaining} file${remaining !== 1 ? 's' : ''} remaining</div>
       ${
-        remainingFiles.length > 0
+        calculating
+          ? ''
+          : `<div class="remaining-count">${remaining} file${remaining !== 1 ? 's' : ''} remaining</div>`
+      }
+      ${
+        !calculating && remainingFiles.length > 0
           ? `<details>
         <summary>${remaining} file${remaining !== 1 ? 's' : ''} left to index</summary>
         <ul class="file-list">${remainingList}</ul>
@@ -252,6 +265,13 @@ export function renderIndexingDashboard(snapshot: DashboardSnapshot): string {
       height: 100%;
       border-radius: 4px;
       transition: width 0.3s ease;
+    }
+    /* "Calculating" state: full-width subdued bar that pulses while the
+       invalidation/pre-warm phase determines how much work the job has. */
+    .progress-bar.calculating {
+      background: linear-gradient(90deg, #30363d, #484f58);
+      animation: pulse 1.4s ease-in-out infinite;
+      transition: none;
     }
     .progress-text {
       position: absolute;

--- a/packages/realm-server/handlers/handle-indexing-dashboard.ts
+++ b/packages/realm-server/handlers/handle-indexing-dashboard.ts
@@ -276,19 +276,30 @@ export function renderIndexingDashboard(snapshot: DashboardSnapshot): string {
       border-radius: 4px;
       transition: width 0.3s ease;
     }
-    /* "Calculating" state: full-width subdued striped bar shown while the
-       invalidation/pre-warm phase determines how much work the job has.
-       Intentionally static (no animation) — the dashboard reloads every
-       2s, which would restart any animation and make it flicker. */
+    /* "Calculating" state: full-width subdued bar with moving diagonal
+       stripes, shown while the invalidation/pre-warm phase determines how
+       much work the job has. The animation runs continuously across
+       refreshes because morphdom patches the bar in place (it isn't
+       recreated), so the stripes don't restart or flicker. */
     .progress-bar.calculating {
-      background: repeating-linear-gradient(
+      background-color: #30363d;
+      background-image: linear-gradient(
         45deg,
-        #30363d,
-        #30363d 10px,
-        #3a414b 10px,
-        #3a414b 20px
+        rgba(255, 255, 255, 0.08) 25%,
+        transparent 25%,
+        transparent 50%,
+        rgba(255, 255, 255, 0.08) 50%,
+        rgba(255, 255, 255, 0.08) 75%,
+        transparent 75%,
+        transparent
       );
+      background-size: 40px 40px;
+      animation: calc-stripes 1s linear infinite;
       transition: none;
+    }
+    @keyframes calc-stripes {
+      from { background-position: 40px 0; }
+      to { background-position: 0 0; }
     }
     .progress-text {
       position: absolute;

--- a/packages/realm-server/handlers/handle-indexing-dashboard.ts
+++ b/packages/realm-server/handlers/handle-indexing-dashboard.ts
@@ -1,4 +1,14 @@
+import { readFileSync } from 'node:fs';
+
 import type { RealmIndexingState } from '../indexing-event-sink';
+
+// morphdom's UMD build, inlined into the dashboard so the auto-refresh can
+// patch the live DOM in place instead of reloading the page. Read once at
+// module load; the dashboard is a local-only debug surface.
+const MORPHDOM_SOURCE = readFileSync(
+  require.resolve('morphdom/dist/morphdom-umd.min.js'),
+  'utf8',
+);
 
 export interface PendingJob {
   jobId: number;
@@ -378,6 +388,7 @@ export function renderIndexingDashboard(snapshot: DashboardSnapshot): string {
     </div>
   </div>
 
+  <div id="dashboard-content">
   <div class="summary-bar">
     <div class="summary-item${active.length > 0 ? ' alert' : ''}">
       <div class="value">${active.length}</div>
@@ -441,14 +452,46 @@ export function renderIndexingDashboard(snapshot: DashboardSnapshot): string {
   </div>`
       : '<div class="empty-state">No completed jobs yet (history is populated from events received since the worker manager started)</div>'
   }
+  </div>
 
+  <script>${MORPHDOM_SOURCE}</script>
   <script>
-    document.getElementById('last-updated').textContent =
-      'Updated: ' + new Date().toLocaleTimeString();
+    function stamp() {
+      document.getElementById('last-updated').textContent =
+        'Updated: ' + new Date().toLocaleTimeString();
+    }
+    stamp();
+
+    // Refresh by patching the live DOM toward a freshly fetched copy
+    // instead of reloading the page. morphdom preserves element identity,
+    // so open <details> disclosures, focus, scroll position, and text
+    // selection survive each tick (the whole #dashboard-content subtree —
+    // every active card and table — updates in one pass).
+    async function refresh() {
+      let res = await fetch(location.href, { headers: { 'X-Requested-With': 'fetch' } });
+      if (!res.ok) return;
+      let html = await res.text();
+      let incoming = new DOMParser()
+        .parseFromString(html, 'text/html')
+        .getElementById('dashboard-content');
+      let live = document.getElementById('dashboard-content');
+      if (!incoming || !live) return;
+      window.morphdom(live, incoming, {
+        onBeforeElUpdated(fromEl, toEl) {
+          // The server always renders <details> closed; keep whatever the
+          // user has toggled open rather than letting the morph snap it shut.
+          if (fromEl.nodeName === 'DETAILS') {
+            toEl.open = fromEl.open;
+          }
+          return true;
+        },
+      });
+      stamp();
+    }
 
     let refreshInterval;
     function startRefresh() {
-      refreshInterval = setInterval(() => location.reload(), 2000);
+      refreshInterval = setInterval(refresh, 2000);
     }
     function stopRefresh() {
       clearInterval(refreshInterval);

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -145,6 +145,7 @@
     "stripe": "docker run --rm --add-host=host.docker.internal:host-gateway -it stripe/stripe-cli:latest"
   },
   "dependencies": {
+    "morphdom": "^2.7.8",
     "puppeteer": "^24.8.2"
   }
 }

--- a/packages/realm-server/setup-logger.ts
+++ b/packages/realm-server/setup-logger.ts
@@ -1,6 +1,15 @@
 import './setup-localhost-resolver';
 import './lib/unbuffer-stdio';
-import { makeLogDefinitions } from '@cardstack/runtime-common';
+import {
+  makeLogDefinitions,
+  reapplyLogLevels,
+} from '@cardstack/runtime-common';
 (globalThis as any)._logDefinitions = makeLogDefinitions(
   process.env.LOG_LEVELS || '*=info',
 );
+// Importing the barrel above eagerly evaluates module-scope `logger()`
+// calls (e.g. in definition-lookup.ts) before `_logDefinitions` is set,
+// leaving those loggers at loglevel's default. Re-apply the configured
+// levels now that the definitions are installed so category overrides
+// (e.g. `definition-cache-key=debug`) actually take effect.
+reapplyLogLevels();

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -2527,5 +2527,81 @@ module(basename(__filename), function () {
         'reader hit the cache the pre-warm wrote — no second prerender',
       );
     });
+
+    test('pre-warm does not persist error entries for modules that fail to prerender', async function (assert) {
+      // The realm-wide `.gts`/`.gjs` sweep speculatively warms every card
+      // module, so it also touches `.gts` files that aren't cards and fail
+      // to prerender (a non-card `realm.gts`). A non-missing prerender
+      // error must NOT be persisted — that would pollute the modules cache
+      // with error rows no reader asked for.
+      let erroringModule = `${realmURL}realm.gts`;
+      let errorPrerenderer: Prerenderer = {
+        async prerenderModule(args: ModulePrerenderArgs) {
+          prerenderModuleCalls++;
+          return Promise.resolve({
+            id: args.url,
+            status: 'error',
+            nonce: '12345',
+            isShimmed: false,
+            lastModified: +new Date(),
+            createdAt: +new Date(),
+            deps: [],
+            definitions: {},
+            error: {
+              type: 'module-error',
+              error: {
+                id: args.url,
+                message: 'simulated non-card module render failure',
+                status: 500,
+                title: 'Module error',
+                deps: [],
+                additionalErrors: null,
+              },
+            },
+          }) as Promise<ModuleRenderResponse>;
+        },
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+      };
+      let workerLookup = new CachingDefinitionLookup(
+        adapter,
+        errorPrerenderer,
+        createVirtualNetwork(),
+        testCreatePrerenderAuth,
+      );
+
+      let entry = await workerLookup.populateDefinitionCacheEntry({
+        moduleURL: erroringModule,
+        realmURL,
+        resolvedRealmURL: realmURL,
+        cacheScope: 'realm-auth',
+        cacheUserId: testUserId,
+        prerenderUserId: testUserId,
+        priority: 0,
+      });
+      assert.strictEqual(
+        prerenderModuleCalls,
+        1,
+        'pre-warm did attempt the prerender',
+      );
+      assert.strictEqual(
+        entry,
+        undefined,
+        'pre-warm returns undefined for a module that failed to prerender',
+      );
+      let rows = await adapter.execute(
+        `SELECT url, error_doc FROM modules WHERE url = $1`,
+        { bind: [erroringModule] },
+      );
+      assert.strictEqual(
+        rows.length,
+        0,
+        'pre-warm persisted no row (no error_doc) for the failed module',
+      );
+    });
   });
 });

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -2355,4 +2355,177 @@ module(basename(__filename), function () {
       );
     });
   });
+
+  // Lightweight tests for the worker pre-warm path. Like the timing
+  // diagnostics module above, these use createTestPgAdapter + an in-memory
+  // CachingDefinitionLookup rather than the heavier
+  // setupPermissionedRealmsCached fixture — pre-warm runs in the worker,
+  // which has no realm-server / prerender / Chromium, so we only need a pg
+  // adapter, a fake registered realm for the reader, and a mock prerenderer.
+  module('module pre-warm (worker bare lookup)', function (hooks) {
+    let adapter: PgAdapter;
+    let realmURL = 'http://127.0.0.1:4452/';
+    let testUserId = '@user1:localhost';
+    let prerenderModuleCalls = 0;
+    let prerenderModulePriorities: (number | undefined)[] = [];
+
+    function buildMockPrerenderer(): Prerenderer {
+      return {
+        async prerenderModule(args: ModulePrerenderArgs) {
+          prerenderModuleCalls++;
+          prerenderModulePriorities.push(args.priority);
+          let moduleURL = new URL(args.url);
+          let modulePathWithoutExtension = moduleURL.href.replace(/\.gts$/, '');
+          return Promise.resolve({
+            id: 'example-id',
+            status: 'ready',
+            nonce: '12345',
+            isShimmed: false,
+            lastModified: +new Date(),
+            createdAt: +new Date(),
+            deps: [],
+            definitions: {
+              [`${modulePathWithoutExtension}/Person`]: {
+                type: 'definition',
+                moduleURL: moduleURL.href,
+                definition: {
+                  type: 'card-def',
+                  codeRef: { module: rri(moduleURL.href), name: 'Person' },
+                  displayName: 'Person',
+                  fields: {},
+                  fieldDefs: {},
+                },
+                types: [],
+              },
+            },
+          }) as Promise<ModuleRenderResponse>;
+        },
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+      };
+    }
+
+    let fakeRealm = {
+      url: realmURL,
+      async getRealmOwnerUserId() {
+        return testUserId;
+      },
+      async visibility(): Promise<'private'> {
+        return 'private';
+      },
+    };
+
+    hooks.beforeEach(async function () {
+      prepareTestDB();
+      adapter = await createTestPgAdapter();
+      prerenderModuleCalls = 0;
+      prerenderModulePriorities = [];
+      // The reader's prerender (on a cache miss) resolves permissions for
+      // the realm owner; the populate path likewise prerenders as the owner.
+      await adapter.execute(
+        `INSERT INTO realm_user_permissions (realm_url, username, read, write, realm_owner)
+         VALUES ($1, $2, true, true, true)`,
+        { bind: [realmURL, testUserId] },
+      );
+    });
+
+    hooks.afterEach(async function () {
+      await adapter.close();
+    });
+
+    test('explicit-context populate persists where the self-resolving lookup no-ops', async function (assert) {
+      let virtualNetwork = createVirtualNetwork();
+
+      // The indexer worker constructs a bare CachingDefinitionLookup and
+      // never registers the realm — registerRealm is only reached via
+      // forRealm, which the realm-server alone calls. Reproduce that.
+      let workerLookup = new CachingDefinitionLookup(
+        adapter,
+        buildMockPrerenderer(),
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+
+      // Self-resolving path: with no registered realm and no requesting
+      // realm, buildLookupContext returns null, so getCachedDefinitions is a
+      // silent no-op — it never reaches the prerenderer and persists
+      // nothing. This is the bug pre-warm was silently hitting.
+      let noOp = await workerLookup.getCachedDefinitions(
+        `${realmURL}person.gts`,
+      );
+      assert.strictEqual(
+        noOp,
+        undefined,
+        'self-resolving lookup on a bare worker lookup returns undefined',
+      );
+      assert.strictEqual(
+        prerenderModuleCalls,
+        0,
+        'no-op path never reached the prerenderer',
+      );
+      let afterNoOp = await adapter.execute('SELECT url FROM modules');
+      assert.strictEqual(
+        afterNoOp.length,
+        0,
+        'no-op path persisted zero module rows',
+      );
+
+      // Explicit-context path: pre-warm supplies the same context the
+      // visit-phase reader produces (realm-auth / realm-owner user id), so
+      // the read-through populate persists a row.
+      let entry = await workerLookup.populateDefinitionCacheEntry({
+        moduleURL: `${realmURL}person.gts`,
+        realmURL,
+        resolvedRealmURL: realmURL,
+        cacheScope: 'realm-auth',
+        cacheUserId: testUserId,
+        prerenderUserId: testUserId,
+        priority: 10,
+      });
+      assert.ok(entry, 'explicit-context populate returned an entry');
+      assert.strictEqual(
+        prerenderModuleCalls,
+        1,
+        'explicit-context populate fired the prerenderer once',
+      );
+      assert.deepEqual(
+        prerenderModulePriorities,
+        [10],
+        'job priority forwarded to the prerenderer',
+      );
+      let afterPopulate = await adapter.execute(
+        `SELECT url FROM modules WHERE resolved_realm_url = $1`,
+        { bind: [realmURL] },
+      );
+      assert.ok(
+        afterPopulate.length > 0,
+        'explicit-context populate persisted module rows',
+      );
+
+      // The key it wrote must be the one the visit-phase reader reads. A
+      // realm-scoped reader (registered realm, same realm-auth/owner key)
+      // reads the pre-warmed row without re-firing the prerenderer —
+      // proving the warm key matches the read key (no silent mismatch).
+      let readerLookup = new CachingDefinitionLookup(
+        adapter,
+        buildMockPrerenderer(),
+        createVirtualNetwork(),
+        testCreatePrerenderAuth,
+      );
+      readerLookup.registerRealm(fakeRealm);
+      let cached = await readerLookup.getCachedDefinitions(
+        `${realmURL}person.gts`,
+      );
+      assert.ok(cached, 'realm-scoped reader read the pre-warmed row');
+      assert.strictEqual(
+        prerenderModuleCalls,
+        1,
+        'reader hit the cache the pre-warm wrote — no second prerender',
+      );
+    });
+  });
 });

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -246,6 +246,11 @@ module(basename(__filename), function () {
     });
 
     test('lookupDefinition', async function (assert) {
+      // Start from a cold modules cache: the fixture realm's indexing
+      // pre-warms its card modules (including person.gts), so without this
+      // reset the first lookup below would hit a populated row and never
+      // reach the prerenderer, breaking the call-count assertions.
+      await dbAdapter.execute('DELETE FROM modules');
       let definition = await definitionLookup.lookupDefinition({
         module: rri(`${realmURL}person.gts`),
         name: 'Person',
@@ -271,6 +276,8 @@ module(basename(__filename), function () {
     });
 
     test('invalidation', async function (assert) {
+      // Start from a cold modules cache; see lookupDefinition above.
+      await dbAdapter.execute('DELETE FROM modules');
       let definition = await definitionLookup.lookupDefinition({
         module: rri(`${realmURL}person.gts`),
         name: 'Person',
@@ -310,6 +317,8 @@ module(basename(__filename), function () {
     });
 
     test('invalidates module cache entries without file extensions', async function (assert) {
+      // Start from a cold modules cache; see lookupDefinition above.
+      await dbAdapter.execute('DELETE FROM modules');
       let definition = await definitionLookup.lookupDefinition({
         module: rri(`${realmURL}person.gts`),
         name: 'Person',

--- a/packages/realm-server/tests/matches-filter-integration-test.ts
+++ b/packages/realm-server/tests/matches-filter-integration-test.ts
@@ -31,6 +31,9 @@ const stubDefinitionLookup: DefinitionLookup = {
   async getCachedDefinitions() {
     return undefined;
   },
+  async populateDefinitionCacheEntry() {
+    return undefined;
+  },
   async getCachedDefinitionsBatch() {
     return {};
   },

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -285,6 +285,21 @@ export interface DefinitionLookupOptions {
   priority?: number;
 }
 
+// Explicit cache context for a read-through populate. Callers that
+// already know the realm context (the IndexRunner pre-warm, which runs
+// in the worker against a bare lookup that has no registered realm and
+// thus cannot self-resolve a context) supply it directly instead of
+// relying on `buildLookupContext`'s `#realms` / remote-probe resolution.
+export interface PopulateDefinitionCacheEntryArgs {
+  moduleURL: string;
+  realmURL: string;
+  resolvedRealmURL: string;
+  cacheScope: CacheScope;
+  cacheUserId: string;
+  prerenderUserId: string;
+  priority?: number;
+}
+
 export interface DefinitionLookup {
   lookupDefinition(
     codeRef: ResolvedCodeRef,
@@ -305,6 +320,14 @@ export interface DefinitionLookup {
   getCachedDefinitions(
     moduleUrl: string,
     opts?: DefinitionLookupOptions,
+  ): Promise<DefinitionCacheEntry | undefined>;
+  // Like getCachedDefinitions, but the caller supplies the cache context
+  // explicitly rather than letting `buildLookupContext` self-resolve it.
+  // Required by callers running against a lookup with no registered realm
+  // (the worker's IndexRunner pre-warm), where self-resolution returns
+  // null and the populate silently no-ops.
+  populateDefinitionCacheEntry(
+    args: PopulateDefinitionCacheEntryArgs,
   ): Promise<DefinitionCacheEntry | undefined>;
   getCachedDefinitionsBatch(
     query: DefinitionCacheEntryQuery,
@@ -464,6 +487,15 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       cacheUserId,
       prerenderUserId,
       priority: opts?.priority,
+    });
+  }
+
+  async populateDefinitionCacheEntry(
+    args: PopulateDefinitionCacheEntryArgs,
+  ): Promise<DefinitionCacheEntry | undefined> {
+    return await this.loadDefinitionCacheEntry({
+      ...args,
+      moduleURL: canonicalURL(args.moduleURL, undefined, this.#virtualNetwork),
     });
   }
 
@@ -1838,6 +1870,12 @@ class RealmScopedDefinitionLookup implements DefinitionLookup {
     opts?: DefinitionLookupOptions,
   ): Promise<DefinitionCacheEntry | undefined> {
     return await this.#inner.getCachedDefinitions(moduleUrl, opts);
+  }
+
+  async populateDefinitionCacheEntry(
+    args: PopulateDefinitionCacheEntryArgs,
+  ): Promise<DefinitionCacheEntry | undefined> {
+    return await this.#inner.populateDefinitionCacheEntry(args);
   }
 
   async getCachedDefinitionsBatch(

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -672,9 +672,12 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     priority?: number;
     skipErrorPersist?: boolean;
   }): Promise<DefinitionCacheEntry | undefined> {
-    keyLog.debug(
-      `LOOKUP source=${skipErrorPersist ? 'pre-warm' : 'on-demand'} ${fmtKey(moduleURL, cacheScope, cacheUserId, resolvedRealmURL)}`,
-    );
+    // Real cache-effectiveness signal: a MISS is logged exactly once below,
+    // only when the lookup exhausts the cache (primary + every alias/extension
+    // candidate) and commits to a prerender. Per-probe DB reads are NOT logged
+    // as misses — those alias probes inflate the count with non-real misses.
+    // HITs are logged at the DB read itself (the choke point for all callers).
+    let prerenderMissLogged = false;
     // Snapshot invalidation generations BEFORE the first await.
     // clearRealmDefinitions (and any future synchronous bump) runs entirely before
     // its first await, so a snapshot taken after an await above would already
@@ -706,6 +709,12 @@ export class CachingDefinitionLookup implements DefinitionLookup {
         if (candidateCached && !this.isExpiredErrorEntry(candidateCached)) {
           return candidateCached;
         }
+      }
+      if (!prerenderMissLogged) {
+        keyLog.debug(
+          `MISS source=${skipErrorPersist ? 'pre-warm' : 'on-demand'} ${fmtKey(moduleURL, cacheScope, cacheUserId, resolvedRealmURL)}`,
+        );
+        prerenderMissLogged = true;
       }
       let response = await this.getModuleDefinitionsViaPrerenderer(
         candidateURL,
@@ -1284,13 +1293,17 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       created_at: string | null;
     }[];
 
-    keyLog.debug(
-      `READ ${rows.length ? 'HIT' : 'MISS'} ${fmtKey(moduleUrl, cacheScope, authUserId, resolvedRealmURL)} alias=${moduleAlias}`,
-    );
-
+    // Only HITs are logged here — a HIT (row found) is unambiguous. A "no
+    // rows" result is just one probe (primary URL or an alias/extension
+    // candidate) and is NOT a real miss on its own; the real miss is logged
+    // once at the prerender-commit point in loadDefinitionCacheEntryUncached.
     if (!rows.length) {
       return undefined;
     }
+
+    keyLog.debug(
+      `HIT ${fmtKey(moduleUrl, cacheScope, authUserId, resolvedRealmURL)} alias=${moduleAlias}`,
+    );
 
     let row = rows[0];
     let definitions =
@@ -1467,7 +1480,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     userId: string,
   ): Promise<DefinitionCacheEntry> {
     keyLog.debug(
-      `WRITE ${response.status === 'error' ? '(error) ' : ''}${fmtKey(moduleUrl, cacheScope, userId, resolvedRealmURL)}`,
+      `WRITE ${response.status === 'error' ? '(error) ' : ''}${fmtKey(moduleUrl, cacheScope, cacheScope === 'public' ? '' : userId, resolvedRealmURL)}`,
     );
     let entryURL = new URL(moduleUrl);
     let normalizedDeps = this.normalizeDependencies(

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -496,6 +496,15 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     return await this.loadDefinitionCacheEntry({
       ...args,
       moduleURL: canonicalURL(args.moduleURL, undefined, this.#virtualNetwork),
+      // Pre-warm is speculative and best-effort: the IndexRunner sweeps
+      // every realm `.gts`/`.gjs` to prime sibling card modules, so it
+      // also touches modules that aren't cards and fail to prerender
+      // (e.g. a non-card `realm.gts`). Persisting those errors would
+      // pollute the modules cache with rows no reader asked for. Skip
+      // error persistence here; if a module is genuinely needed and
+      // genuinely errors, the on-demand lookup during the visit phase
+      // re-derives and caches the error.
+      skipErrorPersist: true,
     });
   }
 
@@ -511,6 +520,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     cacheUserId: string;
     prerenderUserId: string;
     priority?: number;
+    skipErrorPersist?: boolean;
   }): Promise<DefinitionCacheEntry | undefined> {
     let key = inFlightKey(args);
     let existing = this.#inFlight.get(key);
@@ -585,6 +595,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       cacheUserId: string;
       prerenderUserId: string;
       priority?: number;
+      skipErrorPersist?: boolean;
     },
     coordinator: PopulateCoordinator,
   ): Promise<DefinitionCacheEntry | undefined> {
@@ -634,6 +645,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     cacheUserId,
     prerenderUserId,
     priority,
+    skipErrorPersist,
   }: {
     moduleURL: string;
     realmURL: string;
@@ -642,6 +654,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     cacheUserId: string;
     prerenderUserId: string;
     priority?: number;
+    skipErrorPersist?: boolean;
   }): Promise<DefinitionCacheEntry | undefined> {
     // Snapshot invalidation generations BEFORE the first await.
     // clearRealmDefinitions (and any future synchronous bump) runs entirely before
@@ -686,6 +699,14 @@ export class CachingDefinitionLookup implements DefinitionLookup {
         this.isMissingModuleError(response, candidateURL)
       ) {
         continue;
+      }
+      if (skipErrorPersist && response.status === 'error') {
+        // Speculative pre-warm: don't leave error state behind for a
+        // module that failed to prerender. Returning here without
+        // persisting reverts to the same outcome as a pre-warm miss —
+        // the visit phase re-derives and caches the error if the module
+        // is genuinely needed.
+        return undefined;
       }
       if (this.generationChanged(resolvedRealmURL, moduleURL, startSnapshot)) {
         // Invalidate (or a wider cache wipe) ran while we were prerendering.

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -11,6 +11,22 @@ import {
   type Querier,
 } from './expression';
 import { clampSerializedError, type SerializedError } from './error';
+import { logger } from './log';
+
+// Debug instrumentation for diagnosing pre-warm vs visit-phase cache-key
+// mismatches: every cache read logs its exact key + HIT/MISS, every write
+// logs its key, and each definition load is tagged pre-warm vs on-demand.
+// Off unless `LOG_LEVELS` enables it, e.g. `*=info,definition-cache-key=debug`.
+const log = logger('definition-lookup');
+const keyLog = logger('definition-cache-key');
+function fmtKey(
+  moduleUrl: string,
+  cacheScope: string,
+  authUserId: string,
+  resolvedRealmURL: string,
+): string {
+  return `module=${moduleUrl} scope=${cacheScope} user=${authUserId || '(empty)'} realm=${resolvedRealmURL}`;
+}
 import {
   fetchUserPermissions,
   flattenPrerenderMeta,
@@ -656,6 +672,9 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     priority?: number;
     skipErrorPersist?: boolean;
   }): Promise<DefinitionCacheEntry | undefined> {
+    keyLog.debug(
+      `LOOKUP source=${skipErrorPersist ? 'pre-warm' : 'on-demand'} ${fmtKey(moduleURL, cacheScope, cacheUserId, resolvedRealmURL)}`,
+    );
     // Snapshot invalidation generations BEFORE the first await.
     // clearRealmDefinitions (and any future synchronous bump) runs entirely before
     // its first await, so a snapshot taken after an await above would already
@@ -1063,7 +1082,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     } catch (err: unknown) {
       // Local state is already consistent; cross-instance staleness is
       // bounded and self-healing. Don't fail the invalidation.
-      console.warn(
+      log.warn(
         `pg_notify ${MODULE_CACHE_INVALIDATED_CHANNEL} failed for "${payload}": ${String(err)}`,
       );
     }
@@ -1208,10 +1227,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
         resolvedRealmURL,
       };
     } catch (err) {
-      console.warn(
-        `Failed to probe remote realm visibility for ${moduleURL}`,
-        err,
-      );
+      log.warn(`Failed to probe remote realm visibility for ${moduleURL}`, err);
       return null;
     }
   }
@@ -1267,6 +1283,10 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       resolved_realm_url: string | null;
       created_at: string | null;
     }[];
+
+    keyLog.debug(
+      `READ ${rows.length ? 'HIT' : 'MISS'} ${fmtKey(moduleUrl, cacheScope, authUserId, resolvedRealmURL)} alias=${moduleAlias}`,
+    );
 
     if (!rows.length) {
       return undefined;
@@ -1446,6 +1466,9 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     cacheScope: CacheScope,
     userId: string,
   ): Promise<DefinitionCacheEntry> {
+    keyLog.debug(
+      `WRITE ${response.status === 'error' ? '(error) ' : ''}${fmtKey(moduleUrl, cacheScope, userId, resolvedRealmURL)}`,
+    );
     let entryURL = new URL(moduleUrl);
     let normalizedDeps = this.normalizeDependencies(
       response.deps ?? [],

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -190,6 +190,18 @@ export class IndexRunner {
       current.#jobInfo,
       current.#virtualNetwork,
     );
+    // Announce the job at kickoff — before invalidation discovery and
+    // pre-warm — so the dashboard shows it immediately. The total starts
+    // at 0 and is filled in by the first `file-visited` once the
+    // pre-warm + invalidation counts are known.
+    current.#onProgress?.({
+      type: 'indexing-started',
+      realmURL: current.realmURL.href,
+      jobId: current.#jobInfo.jobId,
+      jobType: 'from-scratch',
+      totalFiles: 0,
+      files: [],
+    });
     let invalidations: URL[] = [];
     let mtimesStart = Date.now();
     let mtimes = await current.batch.getModifiedTimes();
@@ -222,19 +234,29 @@ export class IndexRunner {
     let allRealmCardModules = Object.keys(
       discoverResult.filesystemMtimes,
     ).filter(hasCardExtension);
-    await current.preWarmModulesTable(invalidations, allRealmCardModules);
+    // Pre-warm reports each warmed module as a `file-visited`; the modules
+    // and the files visited below share one `totalFiles`, so the dashboard
+    // bar advances through pre-warming and into the visit phase.
+    let filesCompleted = 0;
+    let preWarmedCount = await current.preWarmModulesTable(
+      invalidations,
+      allRealmCardModules,
+      ({ moduleUrl, filesCompleted: completed, totalFiles }) => {
+        filesCompleted = completed;
+        current.#onProgress?.({
+          type: 'file-visited',
+          realmURL: current.realmURL.href,
+          jobId: current.#jobInfo.jobId,
+          url: moduleUrl,
+          filesCompleted,
+          totalFiles,
+        });
+      },
+    );
+    let totalFiles = preWarmedCount + invalidations.length;
     let resumedRows = current.batch.resumedRows;
     let resumedSkipped = 0;
-    current.#onProgress?.({
-      type: 'indexing-started',
-      realmURL: current.realmURL.href,
-      jobId: current.#jobInfo.jobId,
-      jobType: 'from-scratch',
-      totalFiles: invalidations.length,
-      files: invalidations.map((u) => u.href),
-    });
     try {
-      let filesCompleted = 0;
       for (let invalidation of invalidations) {
         // Resume guard. If a previous attempt of this same job already
         // wrote URL_X to the working table AND the EFS mtime hasn't
@@ -256,7 +278,7 @@ export class IndexRunner {
               jobId: current.#jobInfo.jobId,
               url: invalidation.href,
               filesCompleted,
-              totalFiles: invalidations.length,
+              totalFiles,
             });
             continue;
           }
@@ -269,7 +291,7 @@ export class IndexRunner {
           jobId: current.#jobInfo.jobId,
           url: invalidation.href,
           filesCompleted,
-          totalFiles: invalidations.length,
+          totalFiles,
         });
       }
       if (resumedSkipped > 0) {
@@ -351,6 +373,17 @@ export class IndexRunner {
       current.#jobInfo,
       current.#virtualNetwork,
     );
+    // Announce the job at kickoff — before invalidation and pre-warm — so
+    // the dashboard shows it immediately. The total starts at 0 and the
+    // first `file-visited` fills it in once the counts are known.
+    current.#onProgress?.({
+      type: 'indexing-started',
+      realmURL: current.realmURL.href,
+      jobId: current.#jobInfo.jobId,
+      jobType: 'incremental',
+      totalFiles: 0,
+      files: [],
+    });
     urls.forEach((url) =>
       current.#dependencyResolver.invalidateRelationshipDependencyRowCache(url),
     );
@@ -381,21 +414,31 @@ export class IndexRunner {
     let incrementalMtimes = await current.#reader.mtimes();
     let allRealmCardModules =
       Object.keys(incrementalMtimes).filter(hasCardExtension);
-    await current.preWarmModulesTable(invalidations, allRealmCardModules);
+    // Pre-warm reports each warmed module as a `file-visited`; modules and
+    // the files visited below share one `totalFiles` so the dashboard bar
+    // spans both phases.
+    let filesCompleted = 0;
+    let preWarmedCount = await current.preWarmModulesTable(
+      invalidations,
+      allRealmCardModules,
+      ({ moduleUrl, filesCompleted: completed, totalFiles }) => {
+        filesCompleted = completed;
+        current.#onProgress?.({
+          type: 'file-visited',
+          realmURL: current.realmURL.href,
+          jobId: current.#jobInfo.jobId,
+          url: moduleUrl,
+          filesCompleted,
+          totalFiles,
+        });
+      },
+    );
+    let totalFiles = preWarmedCount + invalidations.length;
 
     let hrefs = urls.map((u) => u.href);
     let resumedRows = current.batch.resumedRows;
     let resumedSkipped = 0;
-    current.#onProgress?.({
-      type: 'indexing-started',
-      realmURL: current.realmURL.href,
-      jobId: current.#jobInfo.jobId,
-      jobType: 'incremental',
-      totalFiles: invalidations.length,
-      files: invalidations.map((u) => u.href),
-    });
     try {
-      let filesCompleted = 0;
       for (let invalidation of invalidations) {
         if (
           operations.get(invalidation.href) === 'delete' &&
@@ -418,7 +461,7 @@ export class IndexRunner {
           jobId: current.#jobInfo.jobId,
           url: invalidation.href,
           filesCompleted,
-          totalFiles: invalidations.length,
+          totalFiles,
         });
       }
       if (resumedSkipped > 0) {
@@ -596,10 +639,21 @@ export class IndexRunner {
   // Failures here are warned but do not fail the batch — a mid-render
   // sub-prerender will still fire on demand if pre-warm misses a
   // module.
+  // Returns the number of modules pre-warmed. Callers fold this into the
+  // job's `totalFiles` so the dashboard progress bar covers pre-warming +
+  // the visit phase as one total, and `onModuleWarmed` advances the bar as
+  // each module lands. Returns 0 when pre-warm is skipped (in-browser, no
+  // candidates, or an unresolvable cache context), so those modules don't
+  // inflate the total.
   private async preWarmModulesTable(
     invalidations: URL[],
     allRealmCardModules: string[] = [],
-  ): Promise<void> {
+    onModuleWarmed?: (progress: {
+      moduleUrl: string;
+      filesCompleted: number;
+      totalFiles: number;
+    }) => void,
+  ): Promise<number> {
     // Pre-warm exists to keep the prerender server's affinity-scoped tab
     // pool from deadlocking when a mid-render `lookupDefinition` fires a
     // same-affinity sub-`prerenderModule`. The in-browser realm (host
@@ -611,10 +665,10 @@ export class IndexRunner {
     // the prefixed reader can't match. A real server never sees this — it
     // only receives resolved URLs over the wire. Skip pre-warm in-browser.
     if (isBrowserTestEnv()) {
-      return;
+      return 0;
     }
     if (invalidations.length === 0 && allRealmCardModules.length === 0) {
-      return;
+      return 0;
     }
     let preWarmStart = Date.now();
 
@@ -694,7 +748,7 @@ export class IndexRunner {
     }
 
     if (toWarm.size === 0) {
-      return;
+      return 0;
     }
 
     // Supply the cache context explicitly. The worker constructs a bare
@@ -719,7 +773,7 @@ export class IndexRunner {
         `${jobIdentity(this.#jobInfo)} skipping module pre-warm: could not resolve cache context for realm ${this.realmURL.href}; the visit phase will populate on demand`,
         err,
       );
-      return;
+      return 0;
     }
 
     // The visit-phase reader (the realm-server's realm-scoped lookup)
@@ -735,10 +789,14 @@ export class IndexRunner {
       this.#log.warn(
         `${jobIdentity(this.#jobInfo)} skipping module pre-warm for private realm ${this.realmURL.href}: empty cache user id would write cache keys the visit phase cannot read`,
       );
-      return;
+      return 0;
     }
 
+    // Pre-warmed modules and the files visited below share one progress
+    // total, so the dashboard bar spans both phases.
+    let totalFiles = toWarm.size + invalidations.length;
     let failed = 0;
+    let warmed = 0;
     for (let moduleUrl of toWarm) {
       try {
         await this.#definitionLookup.populateDefinitionCacheEntry({
@@ -753,6 +811,8 @@ export class IndexRunner {
       } catch {
         failed += 1;
       }
+      warmed += 1;
+      onModuleWarmed?.({ moduleUrl, filesCompleted: warmed, totalFiles });
     }
     if (failed > 0) {
       this.#log.warn(
@@ -763,6 +823,7 @@ export class IndexRunner {
     this.#perfLog.debug(
       `${jobIdentity(this.#jobInfo)} pre-warm complete in ${Date.now() - preWarmStart} ms (candidates=${toWarm.size} failed=${failed})`,
     );
+    return warmed;
   }
 
   async #readAdoptsFromModuleFromDisk(url: URL): Promise<string | undefined> {

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -689,8 +689,24 @@ export class IndexRunner {
     // `buildLookupContext` and persist nothing — pre-warm would log
     // success while doing nothing. This is the same context the read-only
     // batch reader uses (`getModuleCacheContext` → `getCachedDefinitionsBatch`).
-    let { resolvedRealmURL, cacheScope, authUserId } =
-      await this.getModuleCacheContext();
+    //
+    // Resolving the context fetches realm `_info`, which can transiently
+    // fail. Pre-warm is best-effort, so a failure here must degrade to a
+    // warn/skip — the visit phase still populates on demand — rather than
+    // throwing out of this method and aborting the whole indexing run.
+    let resolvedRealmURL: string;
+    let cacheScope: CacheScope;
+    let authUserId: string;
+    try {
+      ({ resolvedRealmURL, cacheScope, authUserId } =
+        await this.getModuleCacheContext());
+    } catch (err) {
+      this.#log.warn(
+        `${jobIdentity(this.#jobInfo)} skipping module pre-warm: could not resolve cache context for realm ${this.realmURL.href}; the visit phase will populate on demand`,
+        err,
+      );
+      return;
+    }
 
     // The visit-phase reader (the realm-server's realm-scoped lookup)
     // keys a private realm's modules cache on (realm-auth, realm-owner

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -683,10 +683,41 @@ export class IndexRunner {
       return;
     }
 
+    // Supply the cache context explicitly. The worker constructs a bare
+    // `CachingDefinitionLookup` with no registered realm, so the
+    // self-resolving `getCachedDefinitions` would return null from
+    // `buildLookupContext` and persist nothing — pre-warm would log
+    // success while doing nothing. This is the same context the read-only
+    // batch reader uses (`getModuleCacheContext` → `getCachedDefinitionsBatch`).
+    let { resolvedRealmURL, cacheScope, authUserId } =
+      await this.getModuleCacheContext();
+
+    // The visit-phase reader (the realm-server's realm-scoped lookup)
+    // keys a private realm's modules cache on (realm-auth, realm-owner
+    // user id). Writing a different key — e.g. an empty user id — would
+    // replace the silent no-op with a silent *mismatch*: pre-warm would
+    // persist rows the reader never reads. A private realm with no owner
+    // user id is a misconfiguration that should never happen
+    // (`realmOwnerUserId` is derived from the realm username); if it does,
+    // skip pre-warm and let the visit phase populate on demand rather than
+    // writing keys the reader can't read.
+    if (cacheScope === 'realm-auth' && !authUserId) {
+      this.#log.warn(
+        `${jobIdentity(this.#jobInfo)} skipping module pre-warm for private realm ${this.realmURL.href}: empty cache user id would write cache keys the visit phase cannot read`,
+      );
+      return;
+    }
+
     let failed = 0;
     for (let moduleUrl of toWarm) {
       try {
-        await this.#definitionLookup.getCachedDefinitions(moduleUrl, {
+        await this.#definitionLookup.populateDefinitionCacheEntry({
+          moduleURL: moduleUrl,
+          realmURL: this.realmURL.href,
+          resolvedRealmURL,
+          cacheScope,
+          cacheUserId: authUserId,
+          prerenderUserId: this.#realmOwnerUserId,
           priority: this.#jobPriority,
         });
       } catch {

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -13,6 +13,7 @@ import {
   SupportedMimeType,
   jobIdentity,
   Deferred,
+  isBrowserTestEnv,
   RealmPaths,
   type IndexWriter,
   type Batch,
@@ -599,6 +600,19 @@ export class IndexRunner {
     invalidations: URL[],
     allRealmCardModules: string[] = [],
   ): Promise<void> {
+    // Pre-warm exists to keep the prerender server's affinity-scoped tab
+    // pool from deadlocking when a mid-render `lookupDefinition` fires a
+    // same-affinity sub-`prerenderModule`. The in-browser realm (host
+    // tests run a Realm + IndexRunner inside a Chrome tab) has no separate
+    // prerender server and no tab pool, so pre-warm is pointless there.
+    // It is also actively harmful: the in-browser realm shares the global
+    // card-reference prefix registry with the host, so populating the
+    // definition cache before the host registers a prefix bakes in keys
+    // the prefixed reader can't match. A real server never sees this — it
+    // only receives resolved URLs over the wire. Skip pre-warm in-browser.
+    if (isBrowserTestEnv()) {
+      return;
+    }
     if (invalidations.length === 0 && allRealmCardModules.length === 0) {
       return;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2554,6 +2554,9 @@ importers:
 
   packages/realm-server:
     dependencies:
+      morphdom:
+        specifier: ^2.7.8
+        version: 2.7.8
       puppeteer:
         specifier: ^24.8.2
         version: 24.43.1(typescript@5.9.3)
@@ -12204,6 +12207,9 @@ packages:
   morgan@1.10.1:
     resolution: {integrity: sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==}
     engines: {node: '>= 0.8.0'}
+
+  morphdom@2.7.8:
+    resolution: {integrity: sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg==}
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -26852,6 +26858,8 @@ snapshots:
       on-headers: 1.1.0
     transitivePeerDependencies:
       - supports-color
+
+  morphdom@2.7.8: {}
 
   ms@2.0.0: {}
 


### PR DESCRIPTION
## Background and Goal

The indexer's module-definition **pre-warm** step runs in the worker, reports success, and persists zero definition-cache rows. Every type-filtered `store.search()` during the visit phase then resolves its card definition **on demand**, firing a same-affinity `prerenderModule` mid-render — the exact mid-render sub-prerender serialization pre-warm exists to prevent, which contributes to render timeouts on aggregate-card-heavy realms.

Root cause: the worker builds a **bare** `CachingDefinitionLookup` with no registered realm, so `preWarmModulesTable`'s `getCachedDefinitions` call self-resolves a null cache context (`buildLookupContext` returns `null`) and returns without persisting. Because it returns rather than throws, the failure counter stays 0 — so pre-warm logs success while doing nothing. Definitions still get cached, but lazily, by the realm-server during the visit phase — precisely the on-demand path pre-warm was meant to eliminate.

This PR makes pre-warm actually populate the cache, and surfaces its progress on the indexing dashboard.

## Where to start

- `packages/runtime-common/definition-lookup.ts` — new `populateDefinitionCacheEntry(args)` on the `DefinitionLookup` interface: a read-through populate that takes **explicit** cache context rather than self-resolving it via `#realms` / a remote probe.
- `packages/runtime-common/index-runner.ts` — `preWarmModulesTable` threads the context `getModuleCacheContext()` already computes into the populate call; it also emits `indexing-started` at job kickoff and counts each pre-warmed module toward the job's progress total.

## Key decisions

- The explicit warm context is keyed **identically to the visit-phase reader** (`cacheScope: 'realm-auth'`, `cacheUserId` = realm-owner user id, `resolvedRealmURL` = realm URL) — the same context the read-only batch reader already uses — so the warmed row is the one the reader reads, not a mismatched key.
- If a private realm resolves an empty cache user id (a misconfiguration that shouldn't occur, since the owner id derives from the realm username), pre-warm is **skipped with a warning** rather than writing keys the reader can't read or failing the index job — preserving the existing "pre-warm never fails the batch" contract.
- Pre-warm **does not persist prerender errors.** The realm-wide `.gts`/`.gjs` sweep speculatively touches modules that aren't cards and fail to prerender (e.g. a non-card `realm.gts`); caching those errors would pollute the modules cache with rows no reader asked for, so a non-missing prerender error during pre-warm is dropped (the visit phase re-derives on demand).
- Pre-warm is **skipped in the in-browser realm** (host tests run a Realm + IndexRunner in a Chrome tab). It has no separate prerender server / tab pool, so pre-warm is pointless there, and the in-browser realm shares the host's global card-reference prefix registry — populating the cache before the host registers a prefix would write keys the prefixed reader can't match. A real server only ever receives resolved URLs over the wire and never hits this.
- **Dashboard progress:** `indexing-started` is emitted at job kickoff (before invalidation discovery) so the dashboard shows the job immediately, and each pre-warmed module counts toward the job's `totalFiles` (reported as a `file-visited` as it lands). The progress bar now appears as soon as the job starts and spans pre-warming and the visit phase as one total. No new event types — Grafana's "Active Indexing" panel reflects this automatically through the existing `job_progress` write-through, which the same event sink feeds.

## Tests

The regression test uses a lightweight pg-adapter + mock-prerenderer setup (no realm-server / Chromium) to assert the bare-lookup no-op vs. the explicit-context persist, that a realm-scoped reader reads the warmed row without re-prerendering, and that a failed pre-warm prerender persists no row.
