### PR TITLE
Bound-parallelize indexer module pre-warm

### DIFF
--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -613,10 +613,6 @@ export class IndexRunner {
   // process coalescer, so two callers asking for the same URL share
   // one prerender.
   //
-  // Phase 1: serial. Validates that pre-warm as a concept clears the
-  // deadlock without concurrency-driven variability. Phase 2 will
-  // bound-parallelize this loop.
-  //
   // Failures here are warned but do not fail the batch — a mid-render
   // sub-prerender will still fire on demand if pre-warm misses a
   // module.

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -48,14 +48,17 @@ import { visitFileForIndexingFused } from './index-runner/visit-file';
 import { performCardIndexing } from './index-runner/card-indexer';
 import { performFileIndexing } from './index-runner/file-indexer';
 
-// Default module pre-warm concurrency. Aligned with the prerender
-// server's per-affinity tab budget (`PRERENDER_AFFINITY_TAB_MAX`, default
-// 5): a single realm's pre-warm targets one prerender affinity, so beyond
-// this many concurrent module prerenders the requests just queue at the
-// server's per-affinity admission. Raising it past the affinity budget
-// shifts the queueing into the prerender server rather than adding real
-// parallelism.
-const DEFAULT_PREWARM_CONCURRENCY = 5;
+// Default module pre-warm concurrency. Serial by default: a cold/shared
+// prerender pool serves serial pre-warm by reusing a single warm tab,
+// whereas concurrent module prerenders force the pool to materialize one
+// tab per in-flight request — and that tab-startup cost outweighs the
+// parallelism for the fast definition-extraction renders pre-warm fires.
+// Raise `INDEXER_PREWARM_CONCURRENCY` only where the prerender pool is
+// pre-sized for the extra concurrent module renders; the ceiling that
+// matters is the per-affinity tab budget (`PRERENDER_AFFINITY_TAB_MAX`),
+// since a realm's pre-warm targets one prerender affinity and beyond that
+// the requests just queue at the server's per-affinity admission.
+const DEFAULT_PREWARM_CONCURRENCY = 1;
 
 // Resolve the pre-warm fan-out width from `INDEXER_PREWARM_CONCURRENCY`,
 // falling back to the default. Reads `process.env` defensively — pre-warm
@@ -758,15 +761,11 @@ export class IndexRunner {
       return;
     }
 
-    // Bound-parallelize the populate loop. Each populate fires a
+    // Drain the populate set with a bounded worker pool (serial by
+    // default — see DEFAULT_PREWARM_CONCURRENCY). Each populate fires a
     // `prerenderModule` on a cache miss; DefinitionLookup owns the
     // in-flight dedup and cross-process coalescer, so different modules
     // run independently while same-URL callers share one prerender.
-    // Concurrency is capped at the prerender server's per-affinity tab
-    // budget (`INDEXER_PREWARM_CONCURRENCY`, default aligned with
-    // `PRERENDER_AFFINITY_TAB_MAX`): a single realm's pre-warm is one
-    // prerender affinity, so beyond that the requests just queue at the
-    // server's per-affinity admission rather than running in parallel.
     let urls = [...toWarm];
     let failed = 0;
     let nextIndex = 0;

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -48,6 +48,30 @@ import { visitFileForIndexingFused } from './index-runner/visit-file';
 import { performCardIndexing } from './index-runner/card-indexer';
 import { performFileIndexing } from './index-runner/file-indexer';
 
+// Default module pre-warm concurrency. Aligned with the prerender
+// server's per-affinity tab budget (`PRERENDER_AFFINITY_TAB_MAX`, default
+// 5): a single realm's pre-warm targets one prerender affinity, so beyond
+// this many concurrent module prerenders the requests just queue at the
+// server's per-affinity admission. Raising it past the affinity budget
+// shifts the queueing into the prerender server rather than adding real
+// parallelism.
+const DEFAULT_PREWARM_CONCURRENCY = 5;
+
+// Resolve the pre-warm fan-out width from `INDEXER_PREWARM_CONCURRENCY`,
+// falling back to the default. Reads `process.env` defensively — pre-warm
+// is skipped in the browser (see `isBrowserTestEnv`), but the bundle is
+// shared, so guard against a missing `process`.
+function prewarmConcurrency(): number {
+  let raw =
+    typeof process !== 'undefined'
+      ? process.env?.INDEXER_PREWARM_CONCURRENCY
+      : undefined;
+  let parsed = raw != null && raw !== '' ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed > 0
+    ? Math.floor(parsed)
+    : DEFAULT_PREWARM_CONCURRENCY;
+}
+
 export class IndexRunner {
   #indexingInstances = new Map<string, Promise<void>>();
   #reader: Reader;
@@ -738,30 +762,47 @@ export class IndexRunner {
       return;
     }
 
+    // Bound-parallelize the populate loop. Each populate fires a
+    // `prerenderModule` on a cache miss; DefinitionLookup owns the
+    // in-flight dedup and cross-process coalescer, so different modules
+    // run independently while same-URL callers share one prerender.
+    // Concurrency is capped at the prerender server's per-affinity tab
+    // budget (`INDEXER_PREWARM_CONCURRENCY`, default aligned with
+    // `PRERENDER_AFFINITY_TAB_MAX`): a single realm's pre-warm is one
+    // prerender affinity, so beyond that the requests just queue at the
+    // server's per-affinity admission rather than running in parallel.
+    let urls = [...toWarm];
     let failed = 0;
-    for (let moduleUrl of toWarm) {
-      try {
-        await this.#definitionLookup.populateDefinitionCacheEntry({
-          moduleURL: moduleUrl,
-          realmURL: this.realmURL.href,
-          resolvedRealmURL,
-          cacheScope,
-          cacheUserId: authUserId,
-          prerenderUserId: this.#realmOwnerUserId,
-          priority: this.#jobPriority,
-        });
-      } catch {
-        failed += 1;
+    let nextIndex = 0;
+    let concurrency = Math.max(1, Math.min(prewarmConcurrency(), urls.length));
+    let warmOne = async (): Promise<void> => {
+      // `nextIndex++` is atomic between awaits (single-threaded event
+      // loop), so each worker claims a distinct URL.
+      for (let i = nextIndex++; i < urls.length; i = nextIndex++) {
+        try {
+          await this.#definitionLookup.populateDefinitionCacheEntry({
+            moduleURL: urls[i],
+            realmURL: this.realmURL.href,
+            resolvedRealmURL,
+            cacheScope,
+            cacheUserId: authUserId,
+            prerenderUserId: this.#realmOwnerUserId,
+            priority: this.#jobPriority,
+          });
+        } catch {
+          failed += 1;
+        }
       }
-    }
+    };
+    await Promise.all(Array.from({ length: concurrency }, () => warmOne()));
     if (failed > 0) {
       this.#log.warn(
-        `${jobIdentity(this.#jobInfo)} ${failed} of ${toWarm.size} module pre-warm lookups failed; the visit phase will retry on-demand if needed`,
+        `${jobIdentity(this.#jobInfo)} ${failed} of ${urls.length} module pre-warm lookups failed; the visit phase will retry on-demand if needed`,
       );
     }
 
     this.#perfLog.debug(
-      `${jobIdentity(this.#jobInfo)} pre-warm complete in ${Date.now() - preWarmStart} ms (candidates=${toWarm.size} failed=${failed})`,
+      `${jobIdentity(this.#jobInfo)} pre-warm complete in ${Date.now() - preWarmStart} ms (candidates=${urls.length} failed=${failed} concurrency=${concurrency})`,
     );
   }
 


### PR DESCRIPTION
## Background and Goal

Stacked on #5042. Now that the indexer's module pre-warm actually populates the definition cache, this makes the populate loop's fan-out **tunable** via `INDEXER_PREWARM_CONCURRENCY` so it can be benchmarked against a given prerender-pool envelope.

## Where to start

- `packages/runtime-common/index-runner.ts` — `preWarmModulesTable` drains the candidate set with a bounded worker pool; `prewarmConcurrency()` resolves the width from `INDEXER_PREWARM_CONCURRENCY`.

## Key decisions

- **Serial by default (`INDEXER_PREWARM_CONCURRENCY=1`).** Measured against a cold/shared prerender pool, concurrent pre-warm is a *regression*, not a win: visit renders run with `flags=[reused]`, so serial pre-warm reuses a **single warm tab**, whereas firing N concurrent module prerenders forces the pool to **materialize one Chrome tab per in-flight request** — and that tab-startup cost outweighs the parallelism for the fast definition-extraction renders pre-warm fires. (In CI this surfaced as a ~16–21% per-realm indexing slowdown.) So the default preserves the proven serial behavior and parallelism is opt-in.
- **Opt-in ceiling = the per-affinity tab budget** (`PRERENDER_AFFINITY_TAB_MAX`): a realm's pre-warm targets one prerender affinity, so beyond that the requests just queue at the server's per-affinity admission. Raise the env var only where the pool is pre-sized for the extra concurrent module renders.
- **Safety is free.** `DefinitionLookup` already owns the in-flight dedup and the cross-process advisory-lock coalescer, so different modules populate independently while same-URL callers share one prerender; per-module `try/catch` failure accounting is preserved (a failed warm never fails the batch). Module renders don't recurse into same-affinity sub-prerenders, so raising the width can't reintroduce the file→module deadlock.
