### PR TITLE
Make silent host-test timeouts diagnosable and stop one timeout cascading into sibling failures

### DIFF
--- a/packages/host/app/components/matrix/login.gts
+++ b/packages/host/app/components/matrix/login.gts
@@ -1,8 +1,10 @@
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import type Owner from '@ember/owner';
 import type RouterService from '@ember/routing/router-service';
 import { service } from '@ember/service';
+import { isTesting } from '@embroider/macros';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
@@ -152,6 +154,19 @@ export default class Login extends Component<Signature> {
   @tracked private password: string | undefined;
   @service declare private matrixService: MatrixService;
   @service declare router: RouterService;
+
+  constructor(owner: Owner, args: Signature['Args']) {
+    super(owner, args);
+    if (isTesting()) {
+      // Names which isLoggedIn precondition is unmet when the login UI mounts
+      // in a test (the intermittent cold-boot login-screen flake). Test-gated;
+      // no production effect.
+      console.warn(
+        `[login-diag] login UI mounted: ` +
+          JSON.stringify(this.matrixService.loginReadinessDebug),
+      );
+    }
+  }
 
   private get isLoginButtonDisabled() {
     return (

--- a/packages/host/app/lib/gc-card-store.ts
+++ b/packages/host/app/lib/gc-card-store.ts
@@ -11,6 +11,7 @@ import {
   localId as localIdSymbol,
   loadCardDocument,
   loadFileMetaDocument,
+  rri,
   trackRuntimeFileDependency,
   trackRuntimeInstanceDependency,
   logger,
@@ -72,6 +73,10 @@ type StoreHooks = {
     },
   ): StoreSearchResource<T>;
 };
+
+function isCardOrFileInstance(item: unknown): item is StoredInstance {
+  return isCardInstance(item) || isFileDefInstance(item);
+}
 
 // we use this 2 way mapping between local ID and remote ID because if we end up
 // trying to search thru all the entries in a single direction Map to find the
@@ -792,19 +797,14 @@ export default class CardStoreWithGarbageCollection implements CardStore {
       }
 
       localId = this.#idResolver.getLocalId(remoteId);
-      // Correlate the last segment of the remote URL with a local ID to find
-      // an instance that was created locally and has since been given a remote
-      // id the resolver doesn't know about yet. This runs inside render-time
-      // reads (store.peek), so it must not mutate tracked state: assigning the
-      // remote id to the instance here would dirty the instance's tracked `id`
-      // field while that same field is being consumed by the in-progress
-      // render, tripping Glimmer's backtracking re-render assertion. The
-      // instance's id is reconciled outside of render by the save/deserialize
-      // flow (api.setId / updateFromSerialized); here we only locate the
-      // already-stored instance.
+      // try correlating the last part of the URL with a local ID to handle
+      // the scenario where the instance has a newly assigned remote id
       if (!localId) {
         localId = remoteId.split('/').pop()!;
         item = bucket.get(localId) ?? silentBucket.get(localId);
+        if (item && type === 'instance' && isCardOrFileInstance(item)) {
+          item.id = rri(remoteId);
+        }
       }
     }
 

--- a/packages/host/app/lib/gc-card-store.ts
+++ b/packages/host/app/lib/gc-card-store.ts
@@ -11,7 +11,6 @@ import {
   localId as localIdSymbol,
   loadCardDocument,
   loadFileMetaDocument,
-  rri,
   trackRuntimeFileDependency,
   trackRuntimeInstanceDependency,
   logger,
@@ -73,10 +72,6 @@ type StoreHooks = {
     },
   ): StoreSearchResource<T>;
 };
-
-function isCardOrFileInstance(item: unknown): item is StoredInstance {
-  return isCardInstance(item) || isFileDefInstance(item);
-}
 
 // we use this 2 way mapping between local ID and remote ID because if we end up
 // trying to search thru all the entries in a single direction Map to find the
@@ -797,14 +792,19 @@ export default class CardStoreWithGarbageCollection implements CardStore {
       }
 
       localId = this.#idResolver.getLocalId(remoteId);
-      // try correlating the last part of the URL with a local ID to handle
-      // the scenario where the instance has a newly assigned remote id
+      // Correlate the last segment of the remote URL with a local ID to find
+      // an instance that was created locally and has since been given a remote
+      // id the resolver doesn't know about yet. This runs inside render-time
+      // reads (store.peek), so it must not mutate tracked state: assigning the
+      // remote id to the instance here would dirty the instance's tracked `id`
+      // field while that same field is being consumed by the in-progress
+      // render, tripping Glimmer's backtracking re-render assertion. The
+      // instance's id is reconciled outside of render by the save/deserialize
+      // flow (api.setId / updateFromSerialized); here we only locate the
+      // already-stored instance.
       if (!localId) {
         localId = remoteId.split('/').pop()!;
         item = bucket.get(localId) ?? silentBucket.get(localId);
-        if (item && type === 'instance' && isCardOrFileInstance(item)) {
-          item.id = rri(remoteId);
-        }
       }
     }
 

--- a/packages/host/app/routes/index.gts
+++ b/packages/host/app/routes/index.gts
@@ -103,6 +103,12 @@ export default class Card extends Route {
     }
 
     if (!this.matrixService.isLoggedIn) {
+      if (isTesting()) {
+        console.warn(
+          `[login-diag] index route rendering login form: didMatrixServiceStart=${this.didMatrixServiceStart} ` +
+            JSON.stringify(this.matrixService.loginReadinessDebug),
+        );
+      }
       return; // Show login component
     }
 

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -780,36 +780,23 @@ export default class MatrixService extends Service {
           ([_url, realmResource]) => !realmResource.isLoggedIn,
         );
 
-        await Promise.all([
-          this.realmServer.fetchCatalogRealms(),
-          this.realmServer.setAvailableRealmIdentifiers(
-            (accountDataContent?.realms ?? []).map(ri),
-          ),
-        ]);
-
-        await this.realm.prefetchRealmInfos(
-          this.realmServer.availableRealmIdentifiers,
-        );
-
         await this.initSlidingSync(accountDataContent);
         await this.client.startClient({ slidingSync: this.slidingSync });
-        let systemCardAccountData = (await this.client.getAccountDataFromServer(
-          APP_BOXEL_SYSTEM_CARD_EVENT_TYPE,
-        )) as { id?: string } | null;
-        await this.setSystemCard(systemCardAccountData?.id);
-        if (noRealmsLoggedIn) {
-          // In this case we want to authenticate to all accessible realms in a single request,
-          // for performance reasons (otherwise we would make 2 auth requests for
-          // each realm, which could be a lot of requests).
 
-          await this.realmServer.authenticateToAllAccessibleRealms();
-        }
-        // Login here triggers other setup code that needs to happen after
-        // otherwise we don't have the realm info.
-        // This should be cleaned up as we move to single logins
-        await this.loginToRealms();
-
+        // The Matrix session is valid and synced, so the user is logged in.
+        // Mark login complete here rather than after the realm catalog / info
+        // prefetch / system-card / eager realm auth below: those hit the realm
+        // server, which can be slow to respond on a cold start, and `isLoggedIn`
+        // gates on `postLoginCompleted` — awaiting them here strands the app on
+        // the login screen even though the session is established. None is
+        // required for the session to be usable (card loads authenticate their
+        // realm and fetch realm info on demand), so run them in the background.
         this.postLoginCompleted = true;
+
+        void this.completeRealmSetupAfterLogin(
+          accountDataContent,
+          noRealmsLoggedIn,
+        );
       } catch (e) {
         console.log('Error starting Matrix client', e);
         await this.logout();
@@ -827,6 +814,38 @@ export default class MatrixService extends Service {
       } else if (refreshRoutes) {
         await this.router.refresh();
       }
+    }
+  }
+
+  // Realm catalog, realm-info prefetch, system-card load, and eager realm
+  // authentication. Invoked (not awaited) by `start` after login is marked
+  // complete, so a slow realm-server cold start can't block `isLoggedIn` and
+  // strand the app on the login screen. Failures are non-fatal — card loads
+  // authenticate and fetch realm info on demand — so they're logged, not thrown.
+  private async completeRealmSetupAfterLogin(
+    accountDataContent: { realms: string[] } | null,
+    noRealmsLoggedIn: boolean,
+  ) {
+    try {
+      await this.realmServer.setAvailableRealmIdentifiers(
+        (accountDataContent?.realms ?? []).map(ri),
+      );
+      await this.realmServer.fetchCatalogRealms();
+      await this.realm.prefetchRealmInfos(
+        this.realmServer.availableRealmIdentifiers,
+      );
+      let systemCardAccountData = (await this.client.getAccountDataFromServer(
+        APP_BOXEL_SYSTEM_CARD_EVENT_TYPE,
+      )) as { id?: string } | null;
+      await this.setSystemCard(systemCardAccountData?.id);
+      if (noRealmsLoggedIn) {
+        // Authenticate to all accessible realms in a single request for
+        // performance (otherwise ~2 auth requests per realm).
+        await this.realmServer.authenticateToAllAccessibleRealms();
+      }
+      await this.loginToRealms();
+    } catch (e) {
+      console.log('Error completing realm setup after login', e);
     }
   }
 

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -319,8 +319,12 @@ export default class MatrixService extends Service {
   );
 
   private loadState = task(async () => {
+    if (isTesting())
+      console.warn('[start-phase] loadState:requestStorageAccess');
     await this.requestStorageAccess();
+    if (isTesting()) console.warn('[start-phase] loadState:loadSDK');
     await this.loadSDK();
+    if (isTesting()) console.warn('[start-phase] loadState:done');
   });
 
   private get inIframe() {
@@ -751,6 +755,7 @@ export default class MatrixService extends Service {
 
     if (this.client.isLoggedIn()) {
       this.realmServer.setClient(this.client);
+      if (isTesting()) console.warn('[start-phase] realmServer.login');
       await this.realmServer.login(registrationToken);
       this.saveAuth(auth);
       this.bindEventListeners();
@@ -766,6 +771,8 @@ export default class MatrixService extends Service {
         if (this.startedAtTs === -1) {
           this.startedAtTs = 0;
         }
+        if (isTesting())
+          console.warn('[start-phase] getAccountData(realms,favorites)');
         let [accountDataContent, favoritesData] = await Promise.all([
           this.client.getAccountDataFromServer(
             APP_BOXEL_REALMS_EVENT_TYPE,
@@ -780,6 +787,10 @@ export default class MatrixService extends Service {
           ([_url, realmResource]) => !realmResource.isLoggedIn,
         );
 
+        if (isTesting())
+          console.warn(
+            '[start-phase] fetchCatalogRealms+setAvailableRealmIdentifiers',
+          );
         await Promise.all([
           this.realmServer.fetchCatalogRealms(),
           this.realmServer.setAvailableRealmIdentifiers(
@@ -787,29 +798,39 @@ export default class MatrixService extends Service {
           ),
         ]);
 
+        if (isTesting()) console.warn('[start-phase] prefetchRealmInfos');
         await this.realm.prefetchRealmInfos(
           this.realmServer.availableRealmIdentifiers,
         );
 
+        if (isTesting()) console.warn('[start-phase] initSlidingSync');
         await this.initSlidingSync(accountDataContent);
+        if (isTesting()) console.warn('[start-phase] startClient');
         await this.client.startClient({ slidingSync: this.slidingSync });
+        if (isTesting())
+          console.warn('[start-phase] getAccountData(systemCard)');
         let systemCardAccountData = (await this.client.getAccountDataFromServer(
           APP_BOXEL_SYSTEM_CARD_EVENT_TYPE,
         )) as { id?: string } | null;
+        if (isTesting()) console.warn('[start-phase] setSystemCard');
         await this.setSystemCard(systemCardAccountData?.id);
         if (noRealmsLoggedIn) {
           // In this case we want to authenticate to all accessible realms in a single request,
           // for performance reasons (otherwise we would make 2 auth requests for
           // each realm, which could be a lot of requests).
 
+          if (isTesting())
+            console.warn('[start-phase] authenticateToAllAccessibleRealms');
           await this.realmServer.authenticateToAllAccessibleRealms();
         }
         // Login here triggers other setup code that needs to happen after
         // otherwise we don't have the realm info.
         // This should be cleaned up as we move to single logins
+        if (isTesting()) console.warn('[start-phase] loginToRealms');
         await this.loginToRealms();
 
         this.postLoginCompleted = true;
+        if (isTesting()) console.warn('[start-phase] postLoginCompleted=true');
       } catch (e) {
         console.log('Error starting Matrix client', e);
         await this.logout();

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -396,6 +396,18 @@ export default class MatrixService extends Service {
     return this._client?.isLoggedIn() === true && this.postLoginCompleted;
   }
 
+  // Test-only diagnostic for the intermittent "operator-mode renders the login
+  // form" flake: names which precondition of `isLoggedIn` is unmet when a route
+  // decides to render <Auth/>. No production caller.
+  get loginReadinessDebug() {
+    return {
+      authPresent: Boolean(this.getAuth()),
+      clientExists: Boolean(this._client),
+      clientLoggedIn: this._client?.isLoggedIn() === true,
+      postLoginCompleted: this.postLoginCompleted,
+    };
+  }
+
   private get client() {
     if (!this._client) {
       throw new Error(`cannot use matrix client before matrix SDK has loaded`);

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -780,23 +780,36 @@ export default class MatrixService extends Service {
           ([_url, realmResource]) => !realmResource.isLoggedIn,
         );
 
+        await Promise.all([
+          this.realmServer.fetchCatalogRealms(),
+          this.realmServer.setAvailableRealmIdentifiers(
+            (accountDataContent?.realms ?? []).map(ri),
+          ),
+        ]);
+
+        await this.realm.prefetchRealmInfos(
+          this.realmServer.availableRealmIdentifiers,
+        );
+
         await this.initSlidingSync(accountDataContent);
         await this.client.startClient({ slidingSync: this.slidingSync });
+        let systemCardAccountData = (await this.client.getAccountDataFromServer(
+          APP_BOXEL_SYSTEM_CARD_EVENT_TYPE,
+        )) as { id?: string } | null;
+        await this.setSystemCard(systemCardAccountData?.id);
+        if (noRealmsLoggedIn) {
+          // In this case we want to authenticate to all accessible realms in a single request,
+          // for performance reasons (otherwise we would make 2 auth requests for
+          // each realm, which could be a lot of requests).
 
-        // The Matrix session is valid and synced, so the user is logged in.
-        // Mark login complete here rather than after the realm catalog / info
-        // prefetch / system-card / eager realm auth below: those hit the realm
-        // server, which can be slow to respond on a cold start, and `isLoggedIn`
-        // gates on `postLoginCompleted` — awaiting them here strands the app on
-        // the login screen even though the session is established. None is
-        // required for the session to be usable (card loads authenticate their
-        // realm and fetch realm info on demand), so run them in the background.
+          await this.realmServer.authenticateToAllAccessibleRealms();
+        }
+        // Login here triggers other setup code that needs to happen after
+        // otherwise we don't have the realm info.
+        // This should be cleaned up as we move to single logins
+        await this.loginToRealms();
+
         this.postLoginCompleted = true;
-
-        void this.completeRealmSetupAfterLogin(
-          accountDataContent,
-          noRealmsLoggedIn,
-        );
       } catch (e) {
         console.log('Error starting Matrix client', e);
         await this.logout();
@@ -814,38 +827,6 @@ export default class MatrixService extends Service {
       } else if (refreshRoutes) {
         await this.router.refresh();
       }
-    }
-  }
-
-  // Realm catalog, realm-info prefetch, system-card load, and eager realm
-  // authentication. Invoked (not awaited) by `start` after login is marked
-  // complete, so a slow realm-server cold start can't block `isLoggedIn` and
-  // strand the app on the login screen. Failures are non-fatal — card loads
-  // authenticate and fetch realm info on demand — so they're logged, not thrown.
-  private async completeRealmSetupAfterLogin(
-    accountDataContent: { realms: string[] } | null,
-    noRealmsLoggedIn: boolean,
-  ) {
-    try {
-      await this.realmServer.setAvailableRealmIdentifiers(
-        (accountDataContent?.realms ?? []).map(ri),
-      );
-      await this.realmServer.fetchCatalogRealms();
-      await this.realm.prefetchRealmInfos(
-        this.realmServer.availableRealmIdentifiers,
-      );
-      let systemCardAccountData = (await this.client.getAccountDataFromServer(
-        APP_BOXEL_SYSTEM_CARD_EVENT_TYPE,
-      )) as { id?: string } | null;
-      await this.setSystemCard(systemCardAccountData?.id);
-      if (noRealmsLoggedIn) {
-        // Authenticate to all accessible realms in a single request for
-        // performance (otherwise ~2 auth requests per realm).
-        await this.realmServer.authenticateToAllAccessibleRealms();
-      }
-      await this.loginToRealms();
-    } catch (e) {
-      console.log('Error completing realm setup after login', e);
     }
   }
 

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -71,6 +71,12 @@ const log = logger('service:realm');
 // fixing the test surface that pre-CS-11003 relied on the synchronous-
 // indexing semantic of the +source POST.
 const indexingWaiter = buildWaiter('realm:incremental-indexing');
+// Held while a realm session login is in flight so `await settled()` (and other
+// Ember test helpers) wait for the realm JWT to be minted before proceeding.
+// `realm.canWrite` reads the session claims; without this gate a card editor can
+// render during the anonymous→logged-in window with its fields disabled, so a
+// `fillIn` throws even though nothing is otherwise "pending". No-op outside tests.
+const sessionWaiter = buildWaiter('realm:session-login');
 
 // The name returned by `RealmService#info()` when the corresponding realm
 // resource hasn't yet resolved its `_info` document. Exported so consumers
@@ -293,6 +299,7 @@ class RealmResource {
   }
 
   private loginTask = task(async () => {
+    let sessionWaiterToken = sessionWaiter.beginAsync();
     try {
       let token = await this.matrixService.createRealmSession(
         new URL(this.realmURL),
@@ -305,6 +312,7 @@ class RealmResource {
       globalThis.dispatchEvent(event);
     } finally {
       this.loggingIn = undefined;
+      sessionWaiter.endAsync(sessionWaiterToken);
     }
   });
 

--- a/packages/host/tests/helpers/mock-matrix/_utils.ts
+++ b/packages/host/tests/helpers/mock-matrix/_utils.ts
@@ -25,7 +25,18 @@ export class MockUtils {
     return this.testState.sdk!.getRoomEvents(roomId);
   };
   getRoomIds = () => {
-    return this.testState.sdk!.serverState.rooms.map((r) => r.id);
+    // A realm can fire a deferred `broadcastRealmEvent` (the trailing `index`
+    // event of an indexing run) after the owning test has ended and
+    // `setupMockMatrix`'s afterEach has torn the mock SDK down. The test
+    // adapter's broadcast path reads room ids through here; without this guard
+    // a late broadcast throws `Cannot read properties of undefined (reading
+    // 'serverState')` as a QUnit *global failure*, which fails an unrelated
+    // sibling test instead of the test that leaked the broadcast. No SDK means
+    // there are no rooms to deliver to, so report none.
+    if (!this.testState.sdk) {
+      return [];
+    }
+    return this.testState.sdk.serverState.rooms.map((r) => r.id);
   };
 
   getRoomIdForRealmAndUser = (realmURL: string, userId: string) => {

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @cardstack/host/wrapped-setup-helpers-only */
 // This is the one place we allow these to be used directly.
 
-import { getSettledState, settled } from '@ember/test-helpers';
+import { getContext, getSettledState, settled } from '@ember/test-helpers';
 
 import { getPendingWaiterState } from '@ember/test-waiters';
 import type { TestWaiterDebugInfo } from '@ember/test-waiters';
@@ -276,6 +276,7 @@ function logRejectionDiagnostics(prefix: string, formattedReason: string) {
         ? `recent failed fetches this test (${recent.length}):\n  ${recent.join('\n  ')}`
         : 'recent failed fetches this test: <none>',
       summarizeSettledState(),
+      summarizeRealmAuth(),
       summarizeEventLoopLag(),
       summarizeDomSnapshot(),
     ].join('\n'),
@@ -347,6 +348,55 @@ function summarizeDomSnapshot(): string {
 // something other than the network. Snapshot Ember's settledness metrics and,
 // when a test waiter is the culprit, name it (with any captured begin-async
 // origin) so the next timeout points at the stuck gate instead of being opaque.
+// `realm.canWrite(url)` drives whether the card editor renders its fields
+// editable; it reads the realm session JWT claims, which populate
+// asynchronously once the realm token is minted. A silent timeout — or a
+// `fillIn`-on-disabled failure with everything settled — is consistent with
+// the editor having rendered before the session resolved, so report each realm
+// resource's auth/permission state at failure time. Read-only, and only looked
+// up on failure, so it never instantiates the service for tests that don't use
+// it. Note: on QUnit's post-teardown timeout path the owner is already gone,
+// so this reports `<no active test owner>` there; the during-test uncaught /
+// unhandled-rejection paths still capture it.
+function summarizeRealmAuth(): string {
+  try {
+    let owner = (
+      getContext() as { owner?: { lookup(name: string): unknown } } | undefined
+    )?.owner;
+    if (!owner) {
+      return 'realm auth: <no active test owner>';
+    }
+    let realmService = owner.lookup('service:realm') as
+      | {
+          realms?: ReadonlyMap<
+            string,
+            {
+              url: string;
+              isLoggedIn: boolean;
+              canRead: boolean;
+              canWrite: boolean;
+            }
+          >;
+        }
+      | undefined;
+    let realms = realmService?.realms;
+    if (!realms) {
+      return 'realm auth: <no realm service>';
+    }
+    let lines: string[] = [];
+    for (let resource of realms.values()) {
+      lines.push(
+        `${resource.url} loggedIn=${resource.isLoggedIn} canRead=${resource.canRead} canWrite=${resource.canWrite}`,
+      );
+    }
+    return lines.length
+      ? `realm auth:\n  ${lines.join('\n  ')}`
+      : 'realm auth: <no realm resources>';
+  } catch (error) {
+    return `realm auth: <unavailable: ${formatErrorForLog(error)}>`;
+  }
+}
+
 function summarizeSettledState(): string {
   try {
     let state = getSettledState();

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -294,6 +294,11 @@ const EVENT_LOOP_LAG_SAMPLE_LIMIT = 12;
 const EVENT_LOOP_LAG_INTERVAL_MS = 500;
 let eventLoopLagLastTick = 0;
 let eventLoopLagSamplerStarted = false;
+// Last substantial #ember-testing HTML captured while a test was still
+// mounted. On a silent timeout the dump runs at QUnit.testDone — after the app
+// is torn down and the live container is empty — so this preserves what the
+// hung test was actually rendering ~during the stall.
+let lastMountedDomSnapshot = '';
 function startEventLoopLagSampler() {
   if (eventLoopLagSamplerStarted) return;
   eventLoopLagSamplerStarted = true;
@@ -308,6 +313,17 @@ function startEventLoopLagSampler() {
     EVENT_LOOP_LAG_SAMPLES_MS.push(Math.round(lag));
     if (EVENT_LOOP_LAG_SAMPLES_MS.length > EVENT_LOOP_LAG_SAMPLE_LIMIT) {
       EVENT_LOOP_LAG_SAMPLES_MS.shift();
+    }
+    try {
+      let root = document.querySelector('#ember-testing');
+      let html = root ? root.innerHTML.replace(/\s+/g, ' ').trim() : '';
+      // Only keep substantial renders so a between-tests empty container
+      // doesn't clobber the last real one.
+      if (html.length > 60) {
+        lastMountedDomSnapshot = html;
+      }
+    } catch {
+      // never let diagnostics sampling throw
     }
   }, EVENT_LOOP_LAG_INTERVAL_MS);
 }
@@ -328,16 +344,20 @@ function summarizeEventLoopLag(): string {
 function summarizeDomSnapshot(): string {
   try {
     let root = document.querySelector('#ember-testing') ?? document.body;
-    if (!root) {
-      return 'dom snapshot: <no test container>';
-    }
-    let html = root.innerHTML.replace(/\s+/g, ' ').trim();
+    let live = root ? root.innerHTML.replace(/\s+/g, ' ').trim() : '';
+    // At QUnit.testDone the app is already torn down, so the live container is
+    // empty; fall back to the last substantial DOM the sampler captured while
+    // the test was still mounted (i.e. ~during the hang).
+    let useSampled =
+      live.length <= 60 && lastMountedDomSnapshot.length > live.length;
+    let html = useSampled ? lastMountedDomSnapshot : live;
+    let source = useSampled ? 'last sampled while mounted' : 'live';
     const LIMIT = 4000;
     let body =
       html.length > LIMIT
         ? `${html.slice(0, LIMIT)}… (+${html.length - LIMIT} more chars)`
         : html;
-    return `dom snapshot (#ember-testing, ${html.length} chars):\n  ${body}`;
+    return `dom snapshot (#ember-testing, ${source}, ${html.length} chars):\n  ${body}`;
   } catch (error) {
     return `dom snapshot: <unavailable: ${formatErrorForLog(error)}>`;
   }

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -44,6 +44,65 @@ const recentFailedFetches: string[] = [];
 const RECENT_FAILED_FETCHES_LIMIT = 20;
 let currentTestEpoch = 0;
 
+// Module/name of the test currently running, captured from QUnit.testStart so a
+// global error can be attributed to the test that produced it. Resets on page
+// reload (i.e. per shard), which is exactly the lifetime over which the
+// renderer-corruption tracking below is meaningful.
+let currentTestLabel = '<unknown test>';
+
+// An error thrown synchronously during render (e.g. a backtracking re-render
+// assertion: "attempted to update X, but it had already been used previously in
+// the same computation") leaves Ember's renderer in an unrecoverable state for
+// the rest of the page load. Every later test that tries to render or fetch
+// then fails too — typically as an opaque `settled()` timeout or `Failed to
+// fetch` — with nothing tying it back to the test that actually broke the app.
+// Remember the first such error so a later cascade victim's diagnostic can name
+// the originating test instead of looking like an independent failure. Gated to
+// the render-corruption signatures so a benign earlier rejection is never
+// blamed for an unrelated downstream failure.
+interface CapturedRenderError {
+  epoch: number;
+  label: string;
+  message: string;
+}
+let firstRenderCorruptingError: CapturedRenderError | undefined;
+
+function isRenderCorruptingError(message: string): boolean {
+  return (
+    message.includes(
+      'had already been used previously in the same computation',
+    ) ||
+    message.includes('unrecoverable error occur during render') ||
+    message.includes('Attempted to rerender')
+  );
+}
+
+function rememberRenderCorruptingError(message: string) {
+  if (firstRenderCorruptingError || !isRenderCorruptingError(message)) {
+    return;
+  }
+  firstRenderCorruptingError = {
+    epoch: currentTestEpoch,
+    label: currentTestLabel,
+    message,
+  };
+}
+
+// Only surfaced for a test that ran AFTER the corrupting one — the originating
+// test's own diagnostic already prints the error directly, so flagging it there
+// as a "cascade" would be misleading.
+function summarizePriorRenderCorruption(): string | undefined {
+  let prior = firstRenderCorruptingError;
+  if (!prior || prior.epoch >= currentTestEpoch) {
+    return undefined;
+  }
+  return (
+    `prior render-corrupting error (in "${prior.label}") left Ember's renderer ` +
+    `unrecoverable for the rest of this page load — this failure is likely a ` +
+    `cascade of it, not an independent failure:\n  ${prior.message}`
+  );
+}
+
 // Lazily install a single global QUnit.testDone callback that fires the
 // existing diagnostic dump when a failed test ran longer than 60s. Silent
 // QUnit timeouts (e.g. a waitFor that never resolves) don't surface through
@@ -59,6 +118,13 @@ function installTimeoutDiagnosticsOnce() {
   startEventLoopLagSampler();
   let qunitGlobal = getQUnitWithCallbacks();
   if (!qunitGlobal || typeof qunitGlobal.testDone !== 'function') return;
+  if (typeof qunitGlobal.testStart === 'function') {
+    qunitGlobal.testStart((details: QUnitTestStartDetails) => {
+      currentTestLabel = `${details?.module ?? '<unknown module>'} > ${
+        details?.name ?? '<unknown test>'
+      }`;
+    });
+  }
   qunitGlobal.testDone((details: QUnitTestDoneDetails) => {
     if (
       details &&
@@ -87,13 +153,22 @@ interface QUnitTestDoneDetails {
   runtime?: number;
 }
 
+interface QUnitTestStartDetails {
+  name?: string;
+  module?: string;
+}
+
 function getQUnitWithCallbacks():
-  | { testDone?: (cb: (details: QUnitTestDoneDetails) => void) => void }
+  | {
+      testDone?: (cb: (details: QUnitTestDoneDetails) => void) => void;
+      testStart?: (cb: (details: QUnitTestStartDetails) => void) => void;
+    }
   | undefined {
   let q = (globalThis as { QUnit?: unknown }).QUnit;
   return q && typeof q === 'object'
     ? (q as {
         testDone?: (cb: (details: QUnitTestDoneDetails) => void) => void;
+        testStart?: (cb: (details: QUnitTestStartDetails) => void) => void;
       })
     : undefined;
 }
@@ -202,10 +277,9 @@ function setupUnhandledRejectionDiagnostics(hooks: NestedHooks) {
       handler = (event: PromiseRejectionEvent) => {
         // Observation only — do NOT call event.preventDefault(). QUnit's own
         // unhandled-rejection handling must still run and fail the test.
-        logRejectionDiagnostics(
-          '[test-unhandled-rejection]',
-          formatRejectionReason(event.reason),
-        );
+        let reason = formatRejectionReason(event.reason);
+        rememberRenderCorruptingError(reason);
+        logRejectionDiagnostics('[test-unhandled-rejection]', reason);
       };
       target.addEventListener('unhandledrejection', handler);
     }
@@ -222,10 +296,9 @@ function setupUnhandledRejectionDiagnostics(hooks: NestedHooks) {
       originalOnUncaughtException = qunitGlobal.onUncaughtException;
       wrappedOnUncaughtException = (error: unknown) => {
         try {
-          logRejectionDiagnostics(
-            '[test-qunit-uncaught]',
-            formatRejectionReason(error),
-          );
+          let reason = formatRejectionReason(error);
+          rememberRenderCorruptingError(reason);
+          logRejectionDiagnostics('[test-qunit-uncaught]', reason);
         } catch (_e) {
           // never let diagnostic logging swallow the original failure
         }
@@ -265,10 +338,12 @@ function setupUnhandledRejectionDiagnostics(hooks: NestedHooks) {
 function logRejectionDiagnostics(prefix: string, formattedReason: string) {
   let inFlightSnapshot = Array.from(inFlightFetches.values());
   let recent = recentFailedFetches.slice();
+  let priorCorruption = summarizePriorRenderCorruption();
   console.error(
     [
       prefix,
       formattedReason,
+      priorCorruption,
       inFlightSnapshot.length
         ? `in-flight fetches at rejection time (${inFlightSnapshot.length}):\n  ${inFlightSnapshot.join('\n  ')}`
         : 'in-flight fetches at rejection time: <none>',
@@ -279,7 +354,9 @@ function logRejectionDiagnostics(prefix: string, formattedReason: string) {
       summarizeRealmAuth(),
       summarizeEventLoopLag(),
       summarizeDomSnapshot(),
-    ].join('\n'),
+    ]
+      .filter((line): line is string => Boolean(line))
+      .join('\n'),
   );
 }
 

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -56,6 +56,7 @@ let currentTestEpoch = 0;
 let timeoutDiagnosticsInstalled = false;
 function installTimeoutDiagnosticsOnce() {
   if (timeoutDiagnosticsInstalled) return;
+  startEventLoopLagSampler();
   let qunitGlobal = getQUnitWithCallbacks();
   if (!qunitGlobal || typeof qunitGlobal.testDone !== 'function') return;
   qunitGlobal.testDone((details: QUnitTestDoneDetails) => {
@@ -275,8 +276,70 @@ function logRejectionDiagnostics(prefix: string, formattedReason: string) {
         ? `recent failed fetches this test (${recent.length}):\n  ${recent.join('\n  ')}`
         : 'recent failed fetches this test: <none>',
       summarizeSettledState(),
+      summarizeEventLoopLag(),
+      summarizeDomSnapshot(),
     ].join('\n'),
   );
+}
+
+// Sample event-loop lag across the whole suite so a silent timeout can be
+// attributed. Flat lag while a single await never resolves points at a real
+// code/render hang; lag spiking to seconds points at runner CPU/GC contention
+// — the suite was simply too slow to beat the 60s budget, not stuck. Uses a
+// raw setInterval, which is invisible to Ember's `settled()`, so it never
+// perturbs the state it measures.
+const EVENT_LOOP_LAG_SAMPLES_MS: number[] = [];
+const EVENT_LOOP_LAG_SAMPLE_LIMIT = 12;
+const EVENT_LOOP_LAG_INTERVAL_MS = 500;
+let eventLoopLagLastTick = 0;
+let eventLoopLagSamplerStarted = false;
+function startEventLoopLagSampler() {
+  if (eventLoopLagSamplerStarted) return;
+  eventLoopLagSamplerStarted = true;
+  eventLoopLagLastTick = performance.now();
+  setInterval(() => {
+    let now = performance.now();
+    let lag = Math.max(
+      0,
+      now - eventLoopLagLastTick - EVENT_LOOP_LAG_INTERVAL_MS,
+    );
+    eventLoopLagLastTick = now;
+    EVENT_LOOP_LAG_SAMPLES_MS.push(Math.round(lag));
+    if (EVENT_LOOP_LAG_SAMPLES_MS.length > EVENT_LOOP_LAG_SAMPLE_LIMIT) {
+      EVENT_LOOP_LAG_SAMPLES_MS.shift();
+    }
+  }, EVENT_LOOP_LAG_INTERVAL_MS);
+}
+
+function summarizeEventLoopLag(): string {
+  if (!EVENT_LOOP_LAG_SAMPLES_MS.length) {
+    return 'event-loop lag: <no samples>';
+  }
+  let samples = EVENT_LOOP_LAG_SAMPLES_MS.slice();
+  let max = Math.max(...samples);
+  return `event-loop lag (last ${samples.length} @ ${EVENT_LOOP_LAG_INTERVAL_MS}ms, max=${max}ms): ${samples.join(',')}ms`;
+}
+
+// On a silent timeout the client is usually fully settled, so the real failure
+// is "the awaited DOM never appeared" rather than a hung promise. Capturing the
+// rendered test container shows what DID render (an error card, an empty stack,
+// a spinner) in place of the element the test was waiting for.
+function summarizeDomSnapshot(): string {
+  try {
+    let root = document.querySelector('#ember-testing') ?? document.body;
+    if (!root) {
+      return 'dom snapshot: <no test container>';
+    }
+    let html = root.innerHTML.replace(/\s+/g, ' ').trim();
+    const LIMIT = 4000;
+    let body =
+      html.length > LIMIT
+        ? `${html.slice(0, LIMIT)}… (+${html.length - LIMIT} more chars)`
+        : html;
+    return `dom snapshot (#ember-testing, ${html.length} chars):\n  ${body}`;
+  } catch (error) {
+    return `dom snapshot: <unavailable: ${formatErrorForLog(error)}>`;
+  }
 }
 
 // A silent QUnit timeout (e.g. a `waitFor`/`settled` that never resolves)


### PR DESCRIPTION
## Background and Goal

Host-test shards intermittently fail with opaque `settled()` timeouts, "editor is read-only"/disabled-field assertion failures, and cascades of unrelated downstream tests. This PR (a) makes those failures self-explaining with targeted, test-gated diagnostics, and (b) lands two test-infrastructure fixes for concrete races the diagnostics pinned down. It stacks on #5050, which carries the `store.peek` render-corruption fix.

## Where to start

- `packages/host/tests/helpers/setup.ts` — the silent-timeout dump (fired only on a failed >60s test) now reports, in addition to in-flight/recent fetches: settled-state metrics + pending test-waiter names, a **DOM snapshot of `#ember-testing` sampled while the test was still mounted** (what actually rendered in place of the awaited element, instead of the post-teardown empty container), **event-loop-lag samples** (runner CPU/GC contention vs. a genuine code hang), per-realm **auth state** (`loggedIn`/`canRead`/`canWrite`), and a **cascade flag** that names the earlier test whose render-corrupting global error a later timeout is a downstream cascade of.
- `packages/host/app/services/matrix-service.ts`, `app/routes/index.gts`, `app/components/matrix/login.gts` — `[login-diag]` reports which `isLoggedIn` precondition (`authPresent` / `clientLoggedIn` / `postLoginCompleted`) is unmet when operator-mode renders the login form, and `[start-phase]` markers name which `start()` / `loadState` await is in flight when a cold-boot login hang occurs.
- `packages/host/tests/helpers/mock-matrix/_utils.ts` — `getRoomIds()` returns `[]` when the mock SDK is torn down, so a realm's late `broadcastRealmEvent` becomes a no-op instead of a QUnit global failure that reds an unrelated sibling test.
- `packages/host/app/services/realm.ts` — a `realm:session-login` test waiter held across `RealmResource`'s login task, so `await settled()` waits for the realm session JWT to be minted; without it a card editor renders with disabled/read-only fields during the anonymous→logged-in window.

## Key decisions

- Everything here is additive and test-gated: the dump prints only on a failed >60s test; the lag sampler is a raw `setInterval` (invisible to `settled()`) holding ≤12 samples; the `[login-diag]` / `[start-phase]` markers are gated by `isTesting()`; and `buildWaiter` (the realm session waiter) is inert outside tests. No production code path changes behavior.
- Stacks on #5050 for the `store.peek` backtracking fix rather than carrying a divergent copy here — #5050 is the single source of truth for that change.
