### PR TITLE
Reconcile remote ids at the invalidation event, not during render reads

### DIFF
--- a/packages/host/app/lib/gc-card-store.ts
+++ b/packages/host/app/lib/gc-card-store.ts
@@ -11,7 +11,6 @@ import {
   localId as localIdSymbol,
   loadCardDocument,
   loadFileMetaDocument,
-  rri,
   trackRuntimeFileDependency,
   trackRuntimeInstanceDependency,
   logger,
@@ -73,10 +72,6 @@ type StoreHooks = {
     },
   ): StoreSearchResource<T>;
 };
-
-function isCardOrFileInstance(item: unknown): item is StoredInstance {
-  return isCardInstance(item) || isFileDefInstance(item);
-}
 
 // we use this 2 way mapping between local ID and remote ID because if we end up
 // trying to search thru all the entries in a single direction Map to find the
@@ -797,14 +792,18 @@ export default class CardStoreWithGarbageCollection implements CardStore {
       }
 
       localId = this.#idResolver.getLocalId(remoteId);
-      // try correlating the last part of the URL with a local ID to handle
-      // the scenario where the instance has a newly assigned remote id
+      // Correlate the last segment of the remote URL with a local ID to find an
+      // instance that was created locally and has since been given a remote id
+      // the resolver doesn't know about yet. This is a pure lookup: it does NOT
+      // reconcile the instance's `id` to the remote id, because it runs inside
+      // render-time reads (`store.peek`) and writing the tracked `id` mid-render
+      // trips Glimmer's backtracking re-render assertion. Identity reconciliation
+      // happens when the store learns the remote id out of band — at the realm
+      // invalidation event (StoreService.handleInvalidations) and the
+      // save/deserialize flow (api.setId / updateFromSerialized).
       if (!localId) {
         localId = remoteId.split('/').pop()!;
         item = bucket.get(localId) ?? silentBucket.get(localId);
-        if (item && type === 'instance' && isCardOrFileInstance(item)) {
-          item.id = rri(remoteId);
-        }
       }
     }
 

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1477,6 +1477,24 @@ export default class StoreService extends Service implements StoreInterface {
       let instance = this.peekError(invalidation) ?? this.peek(invalidation);
       if (instance) {
         if (isCardInstance(instance)) {
+          // The invalidation id is the canonical remote id for this card. When
+          // the server has just assigned a remote id to a locally-created
+          // instance, this event is the first the store hears of it: the
+          // instance is still keyed by its local id with an unset/local `id`.
+          // Reconcile the identity now — this event is precisely when we learn a
+          // remote id exists for the local id. We only learn the identity here,
+          // not the new content: the instance keeps its original local content
+          // until `reloadInstance` (below) fetches the server state, but its
+          // `id` must be the remote id first so that fetch targets the right
+          // URL. Doing it here, in the event handler, keeps `store.peek` a pure
+          // read — reconciling during a render-time peek would mutate the
+          // tracked `id` mid-render and trip a backtracking re-render assertion.
+          if (
+            invalidation.split('/').pop() === instance[localIdSymbol] &&
+            instance.id !== rri(invalidation)
+          ) {
+            instance.id = rri(invalidation);
+          }
           // Do not reload if the event is a result of an instance-editing request that we made. Otherwise we risk
           // overwriting the inputs with past values. This can happen if the user makes edits in the time between
           // the auto save request and the arrival realm event.

--- a/packages/host/tests/unit/garbage-collection-test.ts
+++ b/packages/host/tests/unit/garbage-collection-test.ts
@@ -738,22 +738,30 @@ module('Unit | identity-context garbage collection', function (hooks) {
     );
   });
 
-  test('can get a card from the identity map by correlating the last part of the remote id with the local id for an instance that has a newly assigned remote id', async function (assert) {
+  test('can get a card from the identity map by correlating the last part of the remote id with the local id, without reconciling the instance id', async function (assert) {
     let {
       store,
       instances: { hassan },
     } = await setupTest();
 
+    let idBefore = hassan.id;
+
     assert.strictEqual(
       store.getCardInstanceOrError(`${testRealmURL}${hassan[localId]}`),
       hassan,
-      'card instance is returned',
+      'card instance is returned by correlating the remote id tail to the local id',
     );
 
+    // The lookup is a pure read: it must NOT write the instance's tracked `id`.
+    // Identity reconciliation (local id -> remote id) happens when the store
+    // learns the remote id out of band (the realm invalidation event /
+    // save-deserialize flow), not as a side effect of a bare lookup — which can
+    // run during render, where mutating the tracked id trips a backtracking
+    // re-render assertion.
     assert.strictEqual(
       hassan.id,
-      `${testRealmURL}${hassan[localId]}`,
-      'instance has remote id set correctly',
+      idBefore,
+      'the bare lookup leaves the instance id unchanged',
     );
   });
 


### PR DESCRIPTION
## Background and Goal

A locally-created card that the server has just assigned a remote id can be looked up by that remote id before the store's id resolver knows the local↔remote mapping. The store's correlation fallback matched the remote URL's last segment to the local id and, as part of that lookup, reconciled the instance's `id` to the remote id. That lookup also runs on the **render read path** (`store.peek` — e.g. a card-pill's `isCreating` getter reads the card), so it mutated the instance's tracked `id` field mid-render and tripped Glimmer's backtracking re-render assertion (*"attempted to update X, but it had already been used previously in the same computation"*). That throws a global render failure, leaving Ember's renderer unrecoverable for the rest of the page load — so it surfaces in host CI as a cascade: one assertion followed by a string of downstream `settled()` timeouts and `Failed to fetch`.

Goal: keep card lookups (and therefore `store.peek`) free of tracked-state mutation, while still reconciling an instance's `id` to its newly-assigned remote id.

## Where to start

- `packages/host/app/services/store.ts` — `handleInvalidations`: when a realm index event reports a remote id whose last URL segment matches a locally-created instance, reconcile that instance's `id` to the remote id there — the moment the store learns the remote id exists — which is outside of render.
- `packages/host/app/lib/gc-card-store.ts` — `tryFindingCardItem`: the last-segment correlation is now a pure lookup. It still finds and returns the already-stored instance, but no longer writes its `id`.

## Key decisions

- Identity reconciliation moves off the read path to where the store actually *learns* a remote id exists: the realm invalidation event, plus the existing save/deserialize flow (`api.setId` / `updateFromSerialized`). Both run outside render, so `store.peek` stays a pure read.
- Only the identity is reconciled at the invalidation event; the instance keeps its local content until `reloadInstance` fetches the server state.
- The GC unit test for the correlation lookup is updated to assert it returns the instance without mutating the `id` (reconciliation is now the invalidation handler's responsibility); the live-update / error-state integration tests are unchanged.
