### PR TITLE
Keep the realm-server mock off the network for in-process test realms

### DIFF
--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -520,6 +520,12 @@ export default class MatrixService extends Service {
       // Waiting on background Matrix flush promises first can leave the
       // authenticated shell visible for an arbitrarily long time.
       this.clearAuth();
+      if (isTesting() && this.postLoginCompleted) {
+        console.warn(
+          '[login-diag] postLoginCompleted reset to false via logout()\n' +
+            new Error().stack,
+        );
+      }
       this.postLoginCompleted = false;
       // Logout is the explicit boundary where we forget persisted workspace UI
       // state for the signed-in user. Generic reset paths must stay in-memory
@@ -747,6 +753,9 @@ export default class MatrixService extends Service {
     if (!auth) {
       auth = this.getAuth();
       if (!auth) {
+        if (isTesting()) {
+          console.warn('[login-diag] start() aborted: no auth present');
+        }
         return;
       }
     }
@@ -848,6 +857,15 @@ export default class MatrixService extends Service {
       } else if (refreshRoutes) {
         await this.router.refresh();
       }
+    } else if (isTesting()) {
+      // start() did nothing because the client wasn't logged in at this point,
+      // so postLoginCompleted is left untouched. The index route's start() is a
+      // one-shot, so a no-op here strands it on the login form. Name the unmet
+      // precondition so a cold-boot timeout points at the gap.
+      console.warn(
+        '[login-diag] start() no-op: client not logged in ' +
+          JSON.stringify(this.loginReadinessDebug),
+      );
     }
   }
 
@@ -1447,6 +1465,12 @@ export default class MatrixService extends Service {
     this._client = this.#matrixSDK?.createClient({ baseUrl: matrixURL });
     this._currentRoomId = undefined;
     this._isInitializingNewUser = false;
+    if (isTesting() && this.postLoginCompleted) {
+      console.warn(
+        '[login-diag] postLoginCompleted reset to false via resetState()\n' +
+          new Error().stack,
+      );
+    }
     this.postLoginCompleted = false;
     this._isLoadingMoreAIRooms = false;
     this.messagesToSend.clear();

--- a/packages/host/tests/helpers/realm-server-mock/routes.ts
+++ b/packages/host/tests/helpers/realm-server-mock/routes.ts
@@ -471,6 +471,11 @@ function getSearchableRealmForURL(
   }
 
   let resolvedRealmURL = resolveRemoteRealmURL(realmURL);
+  if (isInProcessRealmURL(resolvedRealmURL)) {
+    // In-process realm not in the registry: there is no real server to search,
+    // so treat it as unavailable. searchRealms() drops undefined entries.
+    return undefined;
+  }
   let remoteRealm: SearchableRealm = {
     url: resolvedRealmURL,
     // pass thru for live realms on localhost:4201 (base, skills, catalog)
@@ -542,6 +547,13 @@ async function getRealmInfoForURL(realmURL: string): Promise<RealmInfo | null> {
   }
 
   let resolvedRealmURL = resolveRemoteRealmURL(realmURL);
+  if (isInProcessRealmURL(resolvedRealmURL)) {
+    // In-process realm that isn't (yet) in the registry — e.g. its setup
+    // hasn't run, or a prior test's destroyed-owner entry was just evicted.
+    // There is no real server to fall back to, so report it as unavailable
+    // rather than fetching a non-existent host.
+    return null;
+  }
   try {
     let response = await globalThis.fetch(`${resolvedRealmURL}_info`, {
       method: 'QUERY',
@@ -623,4 +635,21 @@ function resolveRemoteRealmURL(realmURL: string): string {
     return ensureTrailingSlash(ENV.resolvedBaseRealmURL);
   }
   return normalizedRealmURL;
+}
+
+// The realm server is mocked at ENV.realmServerURL (http://test-realm); realms
+// under that origin are served in-process via the test-realm registry and have
+// no listener on the real network. Only realms that resolve to a genuinely
+// served origin — the base and skills realms on localhost:4201 — can be reached
+// with a real fetch. A `globalThis.fetch` against an in-process realm always
+// rejects with `TypeError: Failed to fetch`; besides the noise, that rejection
+// can escape as an uncaught error and red an unrelated sibling test.
+function isInProcessRealmURL(resolvedRealmURL: string): boolean {
+  try {
+    return (
+      new URL(resolvedRealmURL).origin === new URL(ENV.realmServerURL).origin
+    );
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Background and goal

Host acceptance tests can time out at the login screen: the app stays on the login form for 60s (`postLoginCompleted` false), the test fails, and the next test then fails with an uncaught `TypeError: Failed to fetch` cascading from the stranded app.

The realm-server mock's `_info` and `_search` fallbacks call `globalThis.fetch` for any realm missing from the in-process test-realm registry. A realm under the mocked realm-server origin (`http://test-realm`) is served entirely in-process and has no listener on the real network, so that fetch always rejects with `Failed to fetch`. The registry routinely lacks such a realm for a window — its own setup hasn't run yet, or a prior test's destroyed-owner entry was just evicted — so the doomed fetch fires on the normal path. Beyond the noise, that rejection can escape as an uncaught error and red an unrelated sibling test.

This keeps the mock off the network for in-process realms and adds test-only diagnostics that localize why a cold boot leaves the app on the login form.

## Where to start

- `packages/host/tests/helpers/realm-server-mock/routes.ts` — `isInProcessRealmURL` plus the two guarded fallbacks (`getRealmInfoForURL`, `getSearchableRealmForURL`). An in-process miss now returns `null` / `undefined` directly instead of fetching a non-existent host.
- `packages/host/app/services/matrix-service.ts` — `[login-diag]` probes on `start()`'s no-auth and not-logged-in no-op paths, and at both `postLoginCompleted` reset sites (`logout()`, `resetState()`).

## Key decisions

- The discriminator is origin. Realms under `ENV.realmServerURL` (`http://test-realm`) are in-process and unreachable on the network; base and skills resolve to `localhost:4201` and remain genuinely fetchable. Returning unavailable for an in-process miss yields the same result the failed fetch produced, minus the rejection — `searchRealms()` already drops `undefined` entries.
- The login diagnostics are insurance. The precise reason a cold boot leaves `postLoginCompleted` false isn't yet pinned; these name the unmet `isLoggedIn` precondition and capture the reset stack, so the next CI occurrence is diagnosable rather than opaque.
