### PR TITLE
Add session-level h2 diagnostics to localize the stall

### DIFF
--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -28,7 +28,7 @@ import { cleanupMonacoEditorModels } from './index';
 // than reassigning, otherwise late-resolving fetches would mutate the next
 // test's tracking container. Snapshotted by the unhandled-rejection
 // diagnostics helper to surface what was outstanding when a rejection fired.
-const inFlightFetches = new Map<number, string>();
+const inFlightFetches = new Map<number, { desc: string; startedAt: number }>();
 let nextFetchId = 0;
 
 // Track the most recent failed fetches per test so a "Promise rejected during X"
@@ -191,7 +191,10 @@ function setupFetchDebugging(hooks: NestedHooks) {
       let { method, url } = describeFetchRequest(input, init);
       let id = nextFetchId++;
       let epoch = currentTestEpoch;
-      inFlightFetches.set(id, `${method} ${url}`);
+      inFlightFetches.set(id, {
+        desc: `${method} ${url}`,
+        startedAt: Date.now(),
+      });
       try {
         return await boundFetch(input, init);
       } catch (error) {
@@ -336,7 +339,14 @@ function setupUnhandledRejectionDiagnostics(hooks: NestedHooks) {
 }
 
 function logRejectionDiagnostics(prefix: string, formattedReason: string) {
-  let inFlightSnapshot = Array.from(inFlightFetches.values());
+  // Include how long each fetch has been outstanding — a request hung for most
+  // of the test's lifetime (vs one just dispatched) is the wedge signature, and
+  // pairing the age with the `recent failed fetches` list below shows whether
+  // earlier retry attempts of the same URL rejected before this one stuck.
+  let now = Date.now();
+  let inFlightSnapshot = Array.from(inFlightFetches.values()).map(
+    (f) => `${f.desc} (outstanding ${now - f.startedAt}ms)`,
+  );
   let recent = recentFailedFetches.slice();
   let priorCorruption = summarizePriorRenderCorruption();
   console.error(

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -243,6 +243,21 @@ export function createListener(
 // the stream body or writing a response, so it cannot perturb the path it
 // watches. Periodic so a single stuck stream is dumped repeatedly and its
 // window/queue evolution is visible.
+//
+// The per-stream sweep above only fires once a server-side stream has been
+// open >8s. A captured hang showed it completely clean, which is itself the
+// clue: the wedge is somewhere that never becomes a long-open server stream.
+// So each sweep ALSO emits a session-level snapshot to cover what the
+// per-stream view is blind to:
+//   - did the server receive the hung request at all? (the roll-up's
+//     `openStreams` count + the per-session `inFlight=[…]` path list — a client
+//     hang with `openStreams=0` means it never arrived)
+//   - is the session at its concurrent-stream ceiling, so the browser is
+//     queueing requests it never sends? (live/peak vs maxConcurrentStreams)
+//   - is the connection flow-control-deadlocked? (session windows + outbound
+//     queue, sampled continuously rather than only per stalled stream)
+//   - is the transport even alive during the hang? (a passive PING round-trip
+//     per session — observe only, never tear anything down)
 function installHttp2Diagnostics(
   tlsServer: http2.Http2SecureServer,
   log: ReturnType<typeof logger>,
@@ -260,31 +275,53 @@ function installHttp2Diagnostics(
     everStalled: boolean;
   }
 
+  interface SessionRec {
+    id: number;
+    peakStreams: number;
+    lastPingAt?: number;
+    lastPongAt?: number;
+    lastRttMs?: number;
+    pingInFlight: boolean;
+  }
+
   let nextId = 0;
-  let sessions = new Set<http2.ServerHttp2Session>();
+  let nextSessionId = 0;
+  let sessions = new Map<http2.ServerHttp2Session, SessionRec>();
   let open = new Map<http2.ServerHttp2Stream, TrackedStream>();
 
   tlsServer.on('session', (session) => {
-    sessions.add(session);
-    log.info(`[h2-diag] session opened (live sessions=${sessions.size})`);
+    let srec: SessionRec = {
+      id: nextSessionId++,
+      peakStreams: 0,
+      pingInFlight: false,
+    };
+    sessions.set(session, srec);
+    log.info(
+      `[h2-diag] session #${srec.id} opened (live sessions=${sessions.size})`,
+    );
+    probeSession(session, srec);
     session.on('close', () => {
       sessions.delete(session);
-      log.info(`[h2-diag] session closed (live sessions=${sessions.size})`);
+      log.info(
+        `[h2-diag] session #${srec.id} closed (live sessions=${sessions.size})`,
+      );
     });
     session.on('error', (e) =>
-      log.warn(`[h2-diag] session error: ${e.message}`),
+      log.warn(`[h2-diag] session #${srec.id} error: ${e.message}`),
     );
     session.on('frameError', (type, code, id) =>
       log.warn(
-        `[h2-diag] session frameError type=${type} code=${code} streamId=${id}`,
+        `[h2-diag] session #${srec.id} frameError type=${type} code=${code} streamId=${id}`,
       ),
     );
     session.on('goaway', (code, lastStreamID) =>
       log.warn(
-        `[h2-diag] session goaway errorCode=${code} lastStreamID=${lastStreamID}`,
+        `[h2-diag] session #${srec.id} goaway errorCode=${code} lastStreamID=${lastStreamID}`,
       ),
     );
-    session.on('timeout', () => log.warn(`[h2-diag] session timeout`));
+    session.on('timeout', () =>
+      log.warn(`[h2-diag] session #${srec.id} timeout`),
+    );
   });
 
   // Get-or-create the per-stream record. Both the `stream` and `request`
@@ -349,6 +386,37 @@ function installHttp2Diagnostics(
     rec.res = res;
   });
 
+  // Passive liveness probe — send one PING and record its round-trip. Observe
+  // only; never tears the session down (that distinguishes this from a
+  // keepalive). Run once on session open so the first sweep already has a
+  // reading, then again each sweep.
+  function probeSession(
+    session: http2.ServerHttp2Session,
+    srec: SessionRec,
+  ): void {
+    if (srec.pingInFlight || session.destroyed || session.closed) {
+      return;
+    }
+    srec.pingInFlight = true;
+    srec.lastPingAt = Date.now();
+    let sent = false;
+    try {
+      sent =
+        session.ping((err: Error | null, duration: number) => {
+          srec.pingInFlight = false;
+          if (!err) {
+            srec.lastPongAt = Date.now();
+            srec.lastRttMs = Math.round(duration);
+          }
+        }) !== false;
+    } catch {
+      srec.pingInFlight = false;
+    }
+    if (!sent) {
+      srec.pingInFlight = false;
+    }
+  }
+
   let timer = setInterval(() => {
     let now = Date.now();
     for (let [stream, rec] of open) {
@@ -392,6 +460,63 @@ function installHttp2Diagnostics(
           `remote=${session?.remoteSettings?.maxConcurrentStreams})`,
       );
     }
+
+    // Session-level snapshot — see the function comment. Covers the wedges the
+    // per-stream sweep above is structurally blind to (request queued before a
+    // server stream exists, connection-level flow-control stall, dead transport).
+    let healthyPongs = 0;
+    for (let [session, srec] of sessions) {
+      let inFlight: { rec: TrackedStream; age: number }[] = [];
+      for (let [stream, rec] of open) {
+        if (stream.session === session) {
+          inFlight.push({ rec, age: now - rec.startedAt });
+        }
+      }
+      if (inFlight.length > srec.peakStreams) {
+        srec.peakStreams = inFlight.length;
+      }
+      let pongAge = srec.lastPongAt != null ? now - srec.lastPongAt : undefined;
+      let pongHealthy = pongAge != null && pongAge < SWEEP_INTERVAL_MS * 2;
+      if (pongHealthy) {
+        healthyPongs++;
+      }
+      // Log a per-session line only when it's doing work or its last ping went
+      // unanswered; idle, healthy sessions are covered by the roll-up below.
+      let pongOverdue = srec.lastPingAt != null && !pongHealthy;
+      if (inFlight.length > 0 || pongOverdue) {
+        let ss = session.state;
+        let shown = inFlight.slice(0, 12);
+        let list = shown
+          .map((e) => `${e.rec.method} ${e.rec.path} ${e.age}ms`)
+          .join(', ');
+        let more =
+          inFlight.length > shown.length
+            ? ` +${inFlight.length - shown.length} more`
+            : '';
+        log.warn(
+          `[h2-diag] session #${srec.id} ` +
+            `streams=${inFlight.length}/peak=${srec.peakStreams}/` +
+            `max(local=${session.localSettings?.maxConcurrentStreams} ` +
+            `remote=${session.remoteSettings?.maxConcurrentStreams}) ` +
+            `win(localEff=${ss?.effectiveLocalWindowSize} ` +
+            `remote=${ss?.remoteWindowSize} ` +
+            `recvData=${ss?.effectiveRecvDataLength} ` +
+            `outQ=${ss?.outboundQueueSize}) ` +
+            `ping(rtt=${srec.lastRttMs ?? 'n/a'}ms ` +
+            `pongAge=${pongAge != null ? `${pongAge}ms` : 'never'}) ` +
+            `inFlight=[${list}${more}]`,
+        );
+      }
+      probeSession(session, srec);
+    }
+    // Greppable roll-up: a client hang showing `openStreams=0 pingHealthy=N/N`
+    // means the request never reached the server (it's wedged client-side or in
+    // transit); `openStreams>0` with the hung path in a session's inFlight list
+    // means the server received it and the response is what's stuck.
+    log.info(
+      `[h2-diag] sweep liveSessions=${sessions.size} ` +
+        `openStreams=${open.size} pingHealthy=${healthyPongs}/${sessions.size}`,
+    );
   }, SWEEP_INTERVAL_MS);
   // Don't let the sweep timer hold the process open during shutdown.
   timer.unref?.();

--- a/packages/realm-server/tests/listener-dispatcher-test.ts
+++ b/packages/realm-server/tests/listener-dispatcher-test.ts
@@ -377,6 +377,56 @@ module(basename(__filename), function (hooks) {
     }
   });
 
+  test('h2 diagnostics (passive ping + session snapshot) do not disrupt serving', async function (assert) {
+    // With REALM_SERVER_HTTP2_DIAGNOSTICS on, every accepted session is swept
+    // every 5s — a passive PING + a state snapshot. Hold one h2 connection open
+    // across a sweep and confirm the session still serves afterwards, i.e. the
+    // observer-only diagnostics neither throw in the interval nor perturb the
+    // session they watch.
+    let prior = process.env.REALM_SERVER_HTTP2_DIAGNOSTICS;
+    process.env.REALM_SERVER_HTTP2_DIAGNOSTICS = '1';
+    let restoreEnv = () => {
+      if (prior !== undefined) {
+        process.env.REALM_SERVER_HTTP2_DIAGNOSTICS = prior;
+      } else {
+        delete process.env.REALM_SERVER_HTTP2_DIAGNOSTICS;
+      }
+    };
+    let { port, isHttp2, close } = await startListener({
+      cert: certFile,
+      key: keyFile,
+    });
+    let client = http2.connect(`https://127.0.0.1:${port}`, {
+      rejectUnauthorized: false,
+    });
+    let request = (path: string) =>
+      new Promise<number>((resolve, reject) => {
+        let req = client.request({ ':method': 'GET', ':path': path });
+        let status = 0;
+        req.on('response', (h) => (status = Number(h[':status'] ?? 0)));
+        req.on('error', reject);
+        req.resume();
+        req.on('end', () => resolve(status));
+        req.end();
+      });
+    try {
+      assert.true(isHttp2, 'listener advertises h2 mode');
+      assert.strictEqual(await request('/_alive'), 200, 'first request OK');
+      // Cross at least one 5s sweep so the passive ping + snapshot run against
+      // the live session.
+      await new Promise((r) => setTimeout(r, 5500));
+      assert.strictEqual(
+        await request('/_alive'),
+        200,
+        'request after a diagnostics sweep still OK — ping did not disrupt the session',
+      );
+    } finally {
+      client.close();
+      await close();
+      restoreEnv();
+    }
+  });
+
   test('no cert env vars produces plain HTTP listener', async function (assert) {
     let { port, isHttp2, close } = await startListener({
       cert: null,


### PR DESCRIPTION
## Background and Goal

A host acceptance test intermittently times out with no assertion failure: a single browser `fetch` to the realm server (e.g. `QUERY https://localhost:4201/base/_info`) hangs forever — it never resolves *and* never rejects, so the `fetcher` test waiter stays open and `settled()` never returns.

The realm server's existing `[h2-diag]` instrumentation only dumps a **server-side stream that's been open >8s**, and on a captured hang it came back completely clean — no stalled stream, no GOAWAY, no session error. That cleanliness is the clue: the hung request never becomes a long-open server stream, so the wedge lives somewhere the per-stream view is structurally blind to. This change adds the diagnostics needed to tell *where*, before committing to any fix.

This is **diagnostics only** — no behavior change. (An earlier keepalive attempt was a recovery mechanism, not a root-cause fix; this PR replaces it with the instrumentation to actually identify the wedge.)

## Where to start

- `packages/realm-server/server.ts` — `installHttp2Diagnostics`. The per-stream stall sweep is unchanged; each sweep now also emits a **per-session snapshot** and a one-line roll-up, and a new `probeSession` sends a passive PING (observe-only).
- `packages/host/tests/helpers/setup.ts` — the `[test-timeout]` dump now reports how long each in-flight fetch has been outstanding.
- `packages/realm-server/tests/listener-dispatcher-test.ts` — a test that holds an h2 connection open across a sweep and confirms the passive ping + snapshot don't disrupt serving.

## What the new logs answer

Each sweep (gated behind `REALM_SERVER_HTTP2_DIAGNOSTICS`, already set on the host-test CI job):

- **Did the server even receive the hung request?** The roll-up `[h2-diag] sweep liveSessions=N openStreams=M pingHealthy=X/Y` plus each session's `inFlight=[method path age, …]`. A client hang showing `openStreams=0` means the request never arrived (wedged client-side or in transit); the hung URL appearing in a session's `inFlight` list means the server has it and the *response* is stuck.
- **Concurrency ceiling?** `streams=live/peak/max(local… remote…)` — if peak approaches `maxConcurrentStreams`, the browser is queueing requests it never sends.
- **Flow-control deadlock?** `win(localEff… remote… recvData… outQ…)` per session, sampled continuously rather than only per stalled stream.
- **Is the transport alive during the hang?** `ping(rtt… pongAge…)` from the passive PING — responsive session vs gone-silent.

Client side: `in-flight fetches at rejection time` now shows `… (outstanding Nms)`, which paired with the `recent failed fetches` list shows whether earlier retry attempts of the same URL rejected before one stuck.

## Key decisions

- **Passive PING, never a teardown.** The probe measures round-trip liveness only; it explicitly does not close or destroy sessions, so it can't perturb the path it watches (and can't itself become a fix-shaped behavior change).
- **Probe on session open, not just in the sweep**, so the first sweep already has a reading instead of reporting a misleading `pingHealthy=0/1` for fresh sessions.
- **Per-session line only when it has in-flight streams or an overdue pong**; idle healthy sessions are covered by the roll-up, keeping the log readable.
