### PR TITLE
Omit search included[] during prerender indexing

### DIFF
--- a/packages/realm-server/handlers/handle-search.ts
+++ b/packages/realm-server/handlers/handle-search.ts
@@ -66,6 +66,13 @@ export default function handleSearch(opts: {
     // re-query, so the eager closure is a wasted round-trip in this
     // path. Same gating as `cacheOnlyDefinitions`.
     let skipQueryBackedExpansion = cacheOnlyDefinitions;
+    // Inside a prerender the host never reads the response's
+    // `included[]` — it resolves every linked card by URL via
+    // card+source (query fields from the seed umbrella, static links via
+    // a lazy-loading `not-loaded` sentinel). Omit `included[]` entirely:
+    // seed the root result cards and skip the static-link BFS that builds
+    // it. Same gating as `cacheOnlyDefinitions`.
+    let omitIncluded = cacheOnlyDefinitions;
     // The host's `_federated-search` fetch wrapper stamps
     // `x-boxel-job-priority` while rendering inside a prerender tab.
     // Threading it into search opts here lets `CachingDefinitionLookup`
@@ -80,10 +87,12 @@ export default function handleSearch(opts: {
     let searchOpts: {
       cacheOnlyDefinitions?: true;
       skipQueryBackedExpansion?: true;
+      omitIncluded?: true;
       priority?: number;
     } = {};
     if (cacheOnlyDefinitions) searchOpts.cacheOnlyDefinitions = true;
     if (skipQueryBackedExpansion) searchOpts.skipQueryBackedExpansion = true;
+    if (omitIncluded) searchOpts.omitIncluded = true;
     if (jobPriority !== null) searchOpts.priority = jobPriority;
     let normalizedSearchOpts =
       Object.keys(searchOpts).length > 0 ? searchOpts : undefined;

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -289,6 +289,7 @@ const ALL_TEST_FILES: string[] = [
   './node-realm-test',
   './session-room-queries-test',
   './indexing-event-sink-test',
+  './skip-query-backed-expansion-test',
 ];
 
 // TEST_FILES limits which test files are loaded (parsed and executed). Useful

--- a/packages/realm-server/tests/skip-query-backed-expansion-test.ts
+++ b/packages/realm-server/tests/skip-query-backed-expansion-test.ts
@@ -15,6 +15,9 @@ function buildFileSystem(): Record<string, string | LooseSingleCardDocument> {
 
     export class Target extends CardDef {
       @field name = contains(StringField);
+      // cardTitle is the field the query-backed linksToMany below filters
+      // on; it must be a real field on the target for the query to match.
+      @field cardTitle = contains(StringField);
     }
   `;
 
@@ -143,7 +146,7 @@ module(basename(__filename), function () {
       let doc = await realm.realmIndexQueryEngine.searchCards(
         {
           filter: {
-            type: { module: rri('./consumer'), name: 'Consumer' },
+            type: { module: rri(`${testRealm}consumer`), name: 'Consumer' },
           },
         },
         { loadLinks: true, skipQueryBackedExpansion: true },
@@ -159,6 +162,113 @@ module(basename(__filename), function () {
         includedIds.filter((id) => id?.includes('/query-target-')).length,
         0,
         'no query-backed linksToMany matches in included',
+      );
+    });
+  });
+
+  module('omitIncluded', function (hooks) {
+    let realm: Realm;
+
+    setupPermissionedRealmCached(hooks, {
+      mode: 'before',
+      realmURL: testRealm,
+      permissions: { '*': ['read'] },
+      fileSystem: buildFileSystem(),
+      onRealmSetup({ testRealm: r }) {
+        realm = r;
+      },
+    });
+
+    test('searchCards with omitIncluded: no included[], but roots keep their query-backed seed', async function (assert) {
+      let doc = await realm.realmIndexQueryEngine.searchCards(
+        {
+          filter: {
+            type: { module: rri(`${testRealm}consumer`), name: 'Consumer' },
+          },
+        },
+        { loadLinks: true, skipQueryBackedExpansion: true, omitIncluded: true },
+      );
+
+      assert.strictEqual(doc.data.length, 1, 'one consumer matched');
+      assert.strictEqual(
+        (doc.included ?? []).length,
+        0,
+        'included[] is omitted entirely — neither static nor query-backed targets are expanded',
+      );
+
+      let relationships = doc.data[0].relationships as
+        | Record<
+            string,
+            {
+              links?: { self?: string | null; search?: string | null };
+              data?: { id: string } | Array<{ id: string }> | null;
+            }
+          >
+        | undefined;
+
+      // The query-backed seed survives so the host can hydrate the listed
+      // IDs by URL via card+source without firing a fresh live search.
+      let queryLinks = relationships?.queryLinks;
+      assert.strictEqual(
+        Array.isArray(queryLinks?.data) ? queryLinks?.data.length : -1,
+        3,
+        'relationships.queryLinks.data still names the three matched IDs',
+      );
+      assert.ok(
+        queryLinks?.links?.search,
+        'relationships.queryLinks keeps its links.search seed',
+      );
+
+      // The per-item `queryLinks.N` sub-entries are stripped so they do not
+      // deserialize to orphan links against the empty included[].
+      let perItemKeys = Object.keys(relationships ?? {}).filter((k) =>
+        /^queryLinks\.\d+$/.test(k),
+      );
+      assert.deepEqual(
+        perItemKeys,
+        [],
+        'query-backed per-item sub-entries are stripped',
+      );
+
+      // The static linksTo keeps a resolvable reference (the host turns an
+      // absent target into a not-loaded sentinel and lazy-loads it via
+      // card+source) but its target is NOT in included[].
+      let directLink = relationships?.directLink;
+      let directRef =
+        directLink?.links?.self ??
+        (directLink?.data && !Array.isArray(directLink.data)
+          ? directLink.data.id
+          : undefined);
+      assert.ok(
+        directRef ? directRef.includes('direct-target') : false,
+        'static linksTo keeps a reference to its target for lazy loading',
+      );
+      let includedIds = (doc.included ?? []).map((r) => r.id);
+      assert.notOk(
+        includedIds.some((id) => id?.endsWith('/direct-target')),
+        'static linksTo target is NOT expanded into included',
+      );
+    });
+
+    test('omitIncluded is prerender-scoped: default search still ships a compound included[]', async function (assert) {
+      let doc = await realm.realmIndexQueryEngine.searchCards(
+        {
+          filter: {
+            type: { module: rri(`${testRealm}consumer`), name: 'Consumer' },
+          },
+        },
+        { loadLinks: true },
+      );
+
+      let includedIds = (doc.included ?? []).map((r) => r.id);
+      assert.ok(
+        includedIds.some((id) => id?.endsWith('/direct-target')),
+        'static linksTo target is in included for non-prerender callers',
+      );
+      assert.strictEqual(
+        includedIds.filter((id) => id?.includes('/query-target-')).length,
+        3,
+        'query-backed matches are in included for non-prerender callers',
       );
     });
   });

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -103,10 +103,12 @@ type Options = {
   // follow time.
   skipQueryBackedExpansion?: boolean;
   // When true, `loadLinks` seeds the top-level result cards
-  // (`populateQueryFields` on the roots) and then returns an empty
-  // `included[]` — the transitive static-link BFS, the deeper-layer
+  // (`populateQueryFields` on the roots) and then returns an empty array —
+  // the transitive static-link BFS, the deeper-layer
   // `populateQueryFields`, and the clone-into-`included` step are all
-  // skipped. Set by the realm-server search handlers when the request
+  // skipped. (The search assembler only sets `doc.included` when the array
+  // is non-empty, so the response document omits the `included` member
+  // entirely.) Set by the realm-server search handlers when the request
   // originates inside a prerender: the host resolves every linked card
   // by URL via card+source (query fields from the seed umbrella, static
   // links via a `not-loaded` sentinel that lazy-loads), so the response's
@@ -1306,7 +1308,9 @@ export class RealmIndexQueryEngine {
       // sentinel that lazy-loads). Once the root result cards are seeded,
       // the transitive static-link BFS (Steps 2-5) and the deeper-layer
       // `populateQueryFields` are pure waste, so stop after the root
-      // layer and return an empty `included[]`. Strictly prerender-scoped.
+      // layer and return an empty array (the caller then omits the
+      // `included` member from the response document). Strictly
+      // prerender-scoped.
       if (opts?.omitIncluded) {
         break;
       }

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -102,6 +102,19 @@ type Options = {
   // so that key is the per-field "is this query-backed?" signal at
   // follow time.
   skipQueryBackedExpansion?: boolean;
+  // When true, `loadLinks` seeds the top-level result cards
+  // (`populateQueryFields` on the roots) and then returns an empty
+  // `included[]` — the transitive static-link BFS, the deeper-layer
+  // `populateQueryFields`, and the clone-into-`included` step are all
+  // skipped. Set by the realm-server search handlers when the request
+  // originates inside a prerender: the host resolves every linked card
+  // by URL via card+source (query fields from the seed umbrella, static
+  // links via a `not-loaded` sentinel that lazy-loads), so the response's
+  // `included[]` is dead weight. Strictly prerender-scoped — live /
+  // external `_federated-search` callers still receive compound documents.
+  // Implies the query-backed `${field}.N` sub-entry stripping
+  // (see `skipQueryBackedExpansion`) so the seeded roots stay orphan-free.
+  omitIncluded?: boolean;
 } & QueryOptions;
 
 type SearchResult = SearchResultDoc | SearchResultError;
@@ -1254,6 +1267,50 @@ export class RealmIndexQueryEngine {
         throw err;
       }
 
+      // Step 1b: strip `fieldName.N` sub-entries from query-backed fields.
+      // The host deserializer treats every per-item entry as a
+      // follow-able relationship and expects its target in `included[]`,
+      // so leaving them on the wire alongside an omitted / query-backed
+      // `included[]` produces orphan-link errors. The umbrella entry
+      // (`fieldName`) stays — it carries `links.search` and
+      // `data: [array of IDs]` for the host's per-URL hydration path.
+      // Runs for both the query-backed-only prerender skip and the
+      // broader `omitIncluded` short-circuit below.
+      if (opts?.skipQueryBackedExpansion || opts?.omitIncluded) {
+        for (let { resource } of layer) {
+          if (!resource.relationships) {
+            continue;
+          }
+          for (let fieldName of Object.keys(resource.relationships)) {
+            let umbrella = resource.relationships[fieldName];
+            if (
+              !umbrella ||
+              Array.isArray(umbrella) ||
+              !umbrella.links?.search
+            ) {
+              continue;
+            }
+            for (let key of Object.keys(resource.relationships)) {
+              if (key !== fieldName && key.startsWith(`${fieldName}.`)) {
+                delete resource.relationships[key];
+              }
+            }
+          }
+        }
+      }
+
+      // Prerender included-omission: the host never reads the search
+      // response's `included[]` — it resolves every linked card by URL
+      // via card+source (query fields from the seed umbrella written by
+      // `populateQueryFields` above; static links via a `not-loaded`
+      // sentinel that lazy-loads). Once the root result cards are seeded,
+      // the transitive static-link BFS (Steps 2-5) and the deeper-layer
+      // `populateQueryFields` are pure waste, so stop after the root
+      // layer and return an empty `included[]`. Strictly prerender-scoped.
+      if (opts?.omitIncluded) {
+        break;
+      }
+
       // Step 2: walk every resource's relationships, classify each link,
       // and accumulate URL sets for the batched DB queries.
       type Entry = {
@@ -1282,31 +1339,6 @@ export class RealmIndexQueryEngine {
           : opts?.linkFields
             ? { ...opts, linkFields: undefined }
             : opts;
-        if (activeOpts?.skipQueryBackedExpansion && resource.relationships) {
-          // Strip `fieldName.N` sub-entries from query-backed fields
-          // before traversal: the host deserializer treats every
-          // per-item entry as a follow-able relationship and expects
-          // its target in `included[]`, so leaving them on the wire
-          // alongside an empty `included[]` produces orphan-link
-          // errors. The umbrella entry (`fieldName`) stays — it
-          // carries `links.search` and `data: [array of IDs]` for the
-          // host's per-URL hydration path.
-          for (let fieldName of Object.keys(resource.relationships)) {
-            let umbrella = resource.relationships[fieldName];
-            if (
-              !umbrella ||
-              Array.isArray(umbrella) ||
-              !umbrella.links?.search
-            ) {
-              continue;
-            }
-            for (let key of Object.keys(resource.relationships)) {
-              if (key !== fieldName && key.startsWith(`${fieldName}.`)) {
-                delete resource.relationships[key];
-              }
-            }
-          }
-        }
         let processed = new Set<string>();
 
         for (let entry of relationshipEntries(resource.relationships)) {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -5124,6 +5124,7 @@ export class Realm {
     opts?: {
       cacheOnlyDefinitions?: boolean;
       skipQueryBackedExpansion?: boolean;
+      omitIncluded?: boolean;
     },
   ): Promise<LinkableCollectionDocument> {
     assertQuery(query);
@@ -5133,6 +5134,7 @@ export class Realm {
       ...(opts?.skipQueryBackedExpansion
         ? { skipQueryBackedExpansion: true }
         : {}),
+      ...(opts?.omitIncluded ? { omitIncluded: true } : {}),
     });
   }
 
@@ -5194,6 +5196,11 @@ export class Realm {
         // instance-GET); the eager closure is a wasted round-trip in
         // the prerender path.
         skipQueryBackedExpansion: duringPrerender,
+        // Inside a prerender the host discards the response's
+        // `included[]` entirely (it resolves every linked card by URL
+        // via card+source), so omit it: seed the root result cards and
+        // skip the static-link BFS that would otherwise build it.
+        omitIncluded: duringPrerender,
       });
       return createResponse({
         body: JSON.stringify(doc, null, 2),

--- a/packages/runtime-common/search-utils.ts
+++ b/packages/runtime-common/search-utils.ts
@@ -322,6 +322,7 @@ type SearchableRealm = {
     opts?: {
       cacheOnlyDefinitions?: boolean;
       skipQueryBackedExpansion?: boolean;
+      omitIncluded?: boolean;
     },
   ) => Promise<LinkableCollectionDocument>;
   url?: string;
@@ -333,6 +334,7 @@ export async function searchRealms(
   opts?: {
     cacheOnlyDefinitions?: boolean;
     skipQueryBackedExpansion?: boolean;
+    omitIncluded?: boolean;
   },
 ): Promise<LinkableCollectionDocument> {
   let realmEntries = realms


### PR DESCRIPTION
## Background and Goal

During indexing, every card render runs in a prerender host tab that treats card+source as the source of truth. The host never reads the `_federated-search` response's `included[]` — it resolves query-backed fields from the relationship seed (`relationships.{field}.data` + `links.search`) via per-URL card+source fetches, and resolves static links via a lazy-loading `not-loaded` sentinel. Yet the realm server still builds `included[]` for every prerender search: a transitive static-link BFS (per-layer batched `getInstances`/`getFiles` + cross-realm fetches), the clone/push of every linked resource, deeper-layer `populateQueryFields`, serialization, transfer, and a host-side parse — all of which the host discards.

This PR makes prerender-context searches skip building `included[]` entirely. It seeds the top-level result cards and returns an empty `included[]`. Strictly prerender-scoped — live / external `_federated-search` callers still receive compound documents.

## Where to start

- `packages/runtime-common/realm-index-query-engine.ts` — the `omitIncluded` option and the `loadLinks` change. After `populateQueryFields` seeds the root layer and the query-backed `${field}.N` sub-entries are stripped, it short-circuits before the static-link BFS (the old "Steps 2-5") and returns an empty `included[]`.
- `packages/realm-server/handlers/handle-search.ts` and `packages/runtime-common/realm.ts` (`searchResponse`) — where the flag is set, on the same prerender gate as `skipQueryBackedExpansion`.

## Key decisions and non-obvious mechanics

- **Seed, don't expand.** `populateQueryFields` still runs on the roots — that's what propagates the relationship seed one hop so embedded results resolve via card+source instead of each firing a fresh live search. Only the transitive expansion into `included[]` (and the deeper-layer `populateQueryFields` it would drive) is skipped.
- **Why empty `included[]` is safe.** A static link absent from `included[]` deserializes to a `not-loaded` sentinel and lazy-loads via card+source — no orphan-link error. Query-backed fields resolve from the umbrella seed (`data` ID array + `links.search`). The per-item `${field}.N` sub-entries for query-backed fields are stripped (as they already were under `skipQueryBackedExpansion`) so they don't deserialize to orphan links against the empty `included[]`.
- **Separate flag, not a behavior change to `skipQueryBackedExpansion`.** `omitIncluded` is set together with `skipQueryBackedExpansion` on the prerender gate, but it's distinct so the `cardDocument` GET/PATCH/POST paths (which set only `skipQueryBackedExpansion`) keep their current behavior.
- **Resurrected test coverage.** `tests/skip-query-backed-expansion-test.ts` was never registered in the test runner, so it had never run and carried two latent fixture bugs (a query-filtered field that wasn't a real field on the target, and a relative module in a `type:` filter). It's now wired into `tests/index.ts` and fixed, so the existing `skipQueryBackedExpansion` coverage runs alongside the new `omitIncluded` tests.
