### PR TITLE
Seed base realm from a template in the multi-realm full-indexing test

### DIFF
--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -2579,10 +2579,12 @@ export async function acquireBaseRealmTemplate(
 
 // Dedicated port for the throwaway base-realm server the template builder
 // stands up so the prerenderer can fetch base modules during the cold index.
-// Kept out of the 4444-4446 range the in-process fixture servers bind; the
-// builder runs in a module `before` hook and tears its server down before any
-// test's `beforeEach` binds its own ports, so there is no overlap.
-const baseRealmTemplateBuilderPort = 4459;
+// Routed through `testPort()` like the rest of the suite so environment-mode
+// runs offset it per environment — two parallel realm-test processes both
+// building the template won't collide on `127.0.0.1` with EADDRINUSE. Kept
+// just below the prerender port (testPort(4460)); the builder also tears its
+// server down before any test's `beforeEach` binds its own ports.
+const baseRealmTemplateBuilderPort = testPort(4459);
 
 async function buildBaseRealmTemplate(
   cacheKey: string,

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -2477,6 +2477,250 @@ async function buildPermissionedRealmsTemplate(
   }
 }
 
+// Periodic heartbeat for long indexing phases. A from-scratch index runs as a
+// single QUnit phase with no intermediate output, so a slow or stuck index
+// surfaces only as an opaque `Test took longer than Nms` phase timeout — no
+// signal about whether it was making progress or wedged. This logs elapsed
+// time plus index progress (boxel_index rows per realm + unfulfilled job
+// count) every `intervalMs` while `fn` runs, so the next failure on this path
+// shows a moving row count (slow) versus a frozen one (stuck) and which realm
+// is mid-index. The timer is unref'd by the suite bootstrap, so it never keeps
+// the process alive on its own; it only fires while the awaited work is
+// holding the event loop.
+export async function withIndexProgressHeartbeat<T>(
+  label: string,
+  dbAdapter: PgAdapter,
+  fn: () => Promise<T>,
+  { intervalMs = 15000 }: { intervalMs?: number } = {},
+): Promise<T> {
+  let startedAt = Date.now();
+  let beat = async () => {
+    let elapsedS = Math.round((Date.now() - startedAt) / 1000);
+    let detail = '';
+    try {
+      let rows = await dbAdapter.execute(
+        `SELECT realm_url, COUNT(*)::int AS rows FROM boxel_index GROUP BY realm_url ORDER BY realm_url`,
+      );
+      let jobs = await dbAdapter.execute(
+        `SELECT COUNT(*)::int AS count FROM jobs WHERE status = 'unfulfilled'`,
+      );
+      detail = ` boxel_index=[${rows
+        .map((r) => `${r.realm_url}:${r.rows}`)
+        .join(', ')}] unfulfilled_jobs=${jobs[0]?.count ?? '?'}`;
+    } catch (e) {
+      detail = ` (progress query failed: ${(e as Error).message})`;
+    }
+    console.log(
+      `[index-heartbeat] ${label} still running after ${elapsedS}s;${detail}`,
+    );
+  };
+  let timer = setInterval(() => void beat(), intervalMs);
+  try {
+    return await fn();
+  } finally {
+    clearInterval(timer);
+  }
+}
+
+// Template-database cache for a fully-indexed base realm. Cold-indexing the
+// whole base realm (every `.gts` definition rendered through the single-tab
+// in-process prerenderer) is the most expensive setup in the suite — tens of
+// seconds — and any test that does it inline pays that cost inside a QUnit
+// phase bounded by `config.testTimeout`. Building it once here, snapshotting
+// to a template database, and cloning that per test turns each test's
+// `base.start()` into a no-op: the cloned database already holds base's
+// `boxel_index` rows (so `isNewIndex()` is false and startup skips the
+// from-scratch pass) and its `modules` definition cache (so a later
+// `reindex()` re-derives every definition from a cache hit instead of a fresh
+// prerender). Keyed by prerenderer identity so unrelated injected
+// prerenderers don't share a snapshot; built at most once per qunit process.
+let baseRealmTemplateCache = new Map<string, { ready: Promise<void> }>();
+
+function baseRealmTemplateCacheKey(prerenderer: Prerenderer): string {
+  return hashCacheKeyPayload({
+    version: 1,
+    type: 'base-realm',
+    prerenderer: prerendererCacheKeyPart(prerenderer),
+  });
+}
+
+// Build (or reuse) a template database with the base realm fully indexed and
+// return its name. Pass the resulting name as `setupDB`'s `templateDatabase`
+// so each test clones a base-indexed database instead of re-indexing base.
+// `basePath` is the on-disk base realm source (packages/base).
+export async function acquireBaseRealmTemplate(
+  basePath: string,
+  prerenderer: Prerenderer,
+): Promise<string> {
+  let cacheKey = baseRealmTemplateCacheKey(prerenderer);
+  let templateDatabaseName = templateDatabaseNameForCacheKey(cacheKey);
+  let existing = baseRealmTemplateCache.get(cacheKey);
+  if (existing) {
+    await existing.ready;
+    return templateDatabaseName;
+  }
+
+  let entry: { ready: Promise<void> } = { ready: Promise.resolve() };
+  entry.ready = buildBaseRealmTemplate(cacheKey, basePath, prerenderer).catch(
+    async (error) => {
+      baseRealmTemplateCache.delete(cacheKey);
+      try {
+        await dropDatabase(templateDatabaseName);
+      } catch {
+        // best-effort cleanup
+      }
+      throw error;
+    },
+  );
+  baseRealmTemplateCache.set(cacheKey, entry);
+  await entry.ready;
+  return templateDatabaseName;
+}
+
+// Dedicated port for the throwaway base-realm server the template builder
+// stands up so the prerenderer can fetch base modules during the cold index.
+// Kept out of the 4444-4446 range the in-process fixture servers bind; the
+// builder runs in a module `before` hook and tears its server down before any
+// test's `beforeEach` binds its own ports, so there is no overlap.
+const baseRealmTemplateBuilderPort = 4459;
+
+async function buildBaseRealmTemplate(
+  cacheKey: string,
+  basePath: string,
+  prerenderer: Prerenderer,
+): Promise<void> {
+  let templateDatabaseName = templateDatabaseNameForCacheKey(cacheKey);
+  let builderDatabaseName = builderDatabaseNameForCacheKey(cacheKey);
+
+  let dbAdapter: PgAdapter | undefined;
+  let publisher: QueuePublisher | undefined;
+  let runner: QueueRunner | undefined;
+  let httpServer: Server | undefined;
+  let base: Realm | undefined;
+
+  await dropDatabase(templateDatabaseName);
+  await dropDatabase(builderDatabaseName);
+
+  try {
+    dbAdapter = await createTestPgAdapter({
+      databaseName: builderDatabaseName,
+      templateDatabase: migratedTestDatabaseTemplate,
+    });
+    publisher = new PgQueuePublisher(dbAdapter);
+    runner = new PgQueueRunner({
+      adapter: dbAdapter,
+      workerId: 'base-template-worker',
+    });
+
+    let virtualNetwork = createVirtualNetwork();
+    let localBaseRealmURL = new URL(
+      `http://127.0.0.1:${baseRealmTemplateBuilderPort}/base/`,
+    );
+    virtualNetwork.addURLMapping(new URL(baseRealm.url), localBaseRealmURL);
+
+    let definitionLookup = new CachingDefinitionLookup(
+      dbAdapter,
+      prerenderer,
+      virtualNetwork,
+      testCreatePrerenderAuth,
+    );
+
+    ({ realm: base } = await createRealm({
+      definitionLookup,
+      withWorker: true,
+      prerenderer,
+      dir: basePath,
+      realmURL: baseRealm.url,
+      virtualNetwork,
+      publisher,
+      runner,
+      dbAdapter,
+      deferStartUp: true,
+    }));
+    virtualNetwork.mount(base.handle);
+
+    let matrixClient = new MatrixClient({
+      matrixURL: realmServerTestMatrix.url,
+      username: realmServerTestMatrix.username,
+      seed: realmSecretSeed,
+    });
+    let server = new RealmServer({
+      realms: [base],
+      reconciler: makeTestReconciler(dbAdapter, [base]),
+      virtualNetwork,
+      matrixClient,
+      realmServerSecretSeed,
+      realmSecretSeed,
+      grafanaSecret,
+      matrixRegistrationSecret,
+      realmsRootPath: dirSync().name,
+      dbAdapter,
+      queue: publisher,
+      getIndexHTML,
+      serverURL: new URL(`http://127.0.0.1:${baseRealmTemplateBuilderPort}`),
+      assetsURL: new URL(`http://example.com/notional-assets-host/`),
+      definitionLookup,
+      prerenderer,
+    });
+    httpServer = server.listen(baseRealmTemplateBuilderPort);
+    await withIndexProgressHeartbeat(
+      'base-realm template build (base.start)',
+      dbAdapter,
+      () => base!.start(),
+    );
+
+    await waitForQueueIdle(builderDatabaseName);
+
+    await closeServer(httpServer);
+    httpServer = undefined;
+    base.__testOnlyClearCaches();
+    base = undefined;
+
+    await publisher.destroy();
+    publisher = undefined;
+    await runner.destroy();
+    runner = undefined;
+    await dbAdapter.close();
+    dbAdapter = undefined;
+
+    await createTemplateSnapshot(builderDatabaseName, templateDatabaseName);
+  } finally {
+    if (httpServer) {
+      try {
+        await closeServer(httpServer);
+      } catch {
+        // best-effort cleanup
+      }
+    }
+    if (publisher) {
+      try {
+        await publisher.destroy();
+      } catch {
+        // best-effort cleanup
+      }
+    }
+    if (runner) {
+      try {
+        await runner.destroy();
+      } catch {
+        // best-effort cleanup
+      }
+    }
+    if (dbAdapter && !dbAdapter.isClosed) {
+      try {
+        await dbAdapter.close();
+      } catch {
+        // best-effort cleanup
+      }
+    }
+    try {
+      await dropDatabase(builderDatabaseName);
+    } catch {
+      // best-effort cleanup
+    }
+  }
+}
+
 async function acquirePermissionedRealmsTemplate(
   options: SetupPermissionedRealmsCachedOptions,
 ): Promise<{ cacheKey: string; templateDatabaseName: string }> {

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -2482,11 +2482,13 @@ async function buildPermissionedRealmsTemplate(
 // surfaces only as an opaque `Test took longer than Nms` phase timeout — no
 // signal about whether it was making progress or wedged. This logs elapsed
 // time plus index progress (boxel_index rows per realm + unfulfilled job
-// count) every `intervalMs` while `fn` runs, so the next failure on this path
-// shows a moving row count (slow) versus a frozen one (stuck) and which realm
-// is mid-index. The timer is unref'd by the suite bootstrap, so it never keeps
-// the process alive on its own; it only fires while the awaited work is
-// holding the event loop.
+// count) roughly every `intervalMs` while `fn` runs, so the next failure on
+// this path shows a moving row count (slow) versus a frozen one (stuck) and
+// which realm is mid-index. The next beat is scheduled only after the previous
+// one finishes, so a progress query slower than `intervalMs` can't pile up
+// concurrent queries on the same adapter during already-slow indexing. The
+// timer is unref'd by the suite bootstrap, so it never keeps the process alive
+// on its own; it only fires while the awaited work is holding the event loop.
 export async function withIndexProgressHeartbeat<T>(
   label: string,
   dbAdapter: PgAdapter,
@@ -2494,6 +2496,8 @@ export async function withIndexProgressHeartbeat<T>(
   { intervalMs = 15000 }: { intervalMs?: number } = {},
 ): Promise<T> {
   let startedAt = Date.now();
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
   let beat = async () => {
     let elapsedS = Math.round((Date.now() - startedAt) / 1000);
     let detail = '';
@@ -2514,11 +2518,25 @@ export async function withIndexProgressHeartbeat<T>(
       `[index-heartbeat] ${label} still running after ${elapsedS}s;${detail}`,
     );
   };
-  let timer = setInterval(() => void beat(), intervalMs);
+  let schedule = () => {
+    timer = setTimeout(async () => {
+      if (stopped) {
+        return;
+      }
+      await beat();
+      if (!stopped) {
+        schedule();
+      }
+    }, intervalMs);
+  };
+  schedule();
   try {
     return await fn();
   } finally {
-    clearInterval(timer);
+    stopped = true;
+    if (timer) {
+      clearTimeout(timer);
+    }
   }
 }
 
@@ -2532,14 +2550,19 @@ export async function withIndexProgressHeartbeat<T>(
 // `boxel_index` rows (so `isNewIndex()` is false and startup skips the
 // from-scratch pass) and its `modules` definition cache (so a later
 // `reindex()` re-derives every definition from a cache hit instead of a fresh
-// prerender). Keyed by prerenderer identity so unrelated injected
-// prerenderers don't share a snapshot; built at most once per qunit process.
+// prerender). Keyed by base source path + prerenderer identity so a different
+// base directory or unrelated injected prerenderer doesn't reuse the wrong
+// snapshot; built at most once per qunit process.
 let baseRealmTemplateCache = new Map<string, { ready: Promise<void> }>();
 
-function baseRealmTemplateCacheKey(prerenderer: Prerenderer): string {
+function baseRealmTemplateCacheKey(
+  basePath: string,
+  prerenderer: Prerenderer,
+): string {
   return hashCacheKeyPayload({
     version: 1,
     type: 'base-realm',
+    basePath,
     prerenderer: prerendererCacheKeyPart(prerenderer),
   });
 }
@@ -2552,7 +2575,7 @@ export async function acquireBaseRealmTemplate(
   basePath: string,
   prerenderer: Prerenderer,
 ): Promise<string> {
-  let cacheKey = baseRealmTemplateCacheKey(prerenderer);
+  let cacheKey = baseRealmTemplateCacheKey(basePath, prerenderer);
   let templateDatabaseName = templateDatabaseNameForCacheKey(cacheKey);
   let existing = baseRealmTemplateCache.get(cacheKey);
   if (existing) {

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import QUnit, { module, test } from 'qunit';
 import type { Test, SuperTest } from 'supertest';
 import supertest from 'supertest';
 import { join, resolve, basename } from 'path';
@@ -25,6 +25,8 @@ import {
   type QueueRunner,
 } from '@cardstack/runtime-common';
 import {
+  acquireBaseRealmTemplate,
+  withIndexProgressHeartbeat,
   setupPermissionedRealmCached,
   runTestRealmServer,
   setupDB,
@@ -2018,12 +2020,49 @@ module(basename(__filename), function () {
       ),
     };
 
+    let dbAdapter: PgAdapter;
+    let baseRealmTemplateDatabase: string | undefined;
+    let savedTestTimeout: number | null | undefined;
+
+    // Build a base-realm-indexed template database once, up front, and clone
+    // it per test (see `templateDatabase` below). Cold-indexing the whole base
+    // realm through the single-tab in-process prerenderer takes tens of
+    // seconds; doing it inline in each test's `beforeEach` rode the per-phase
+    // `QUnit.config.testTimeout` and timed out under CI load — and the killed
+    // `beforeEach` left `request` undefined, surfacing as a downstream
+    // TypeError in the test body. With base pre-indexed, `base.start()` is a
+    // no-op (`isNewIndex()` is false), so the cold index leaves the per-test
+    // path entirely.
+    //
+    // The test body still fully re-indexes the realms several times, which is
+    // the behavior under test; a from-scratch index clears the realm's
+    // definition cache on completion, so each `reindex()` legitimately
+    // re-renders base. That work, plus the one-time build, needs more than the
+    // default per-phase timeout, so raise it for this module and restore it
+    // afterwards. The `withIndexProgressHeartbeat` wrappers keep a stalled or
+    // unexpectedly slow index diagnosable instead of an opaque phase timeout.
+    hooks.before(function () {
+      savedTestTimeout = QUnit.config.testTimeout;
+      QUnit.config.testTimeout = 240_000;
+    });
+    hooks.before(async function () {
+      baseRealmTemplateDatabase = await acquireBaseRealmTemplate(
+        basePath,
+        await getTestPrerenderer(),
+      );
+    });
+    hooks.after(function () {
+      QUnit.config.testTimeout = savedTestTimeout;
+    });
+
     hooks.beforeEach(async function () {
       dir = dirSync();
     });
 
     setupDB(hooks, {
-      beforeEach: async (dbAdapter, publisher, runner) => {
+      templateDatabase: () => baseRealmTemplateDatabase,
+      beforeEach: async (_dbAdapter, publisher, runner) => {
+        dbAdapter = _dbAdapter;
         let localBaseRealmURL = new URL('http://127.0.0.1:4446/base/');
         let prerenderer = await getTestPrerenderer();
         let definitionLookup = new CachingDefinitionLookup(
@@ -2086,8 +2125,18 @@ module(basename(__filename), function () {
           definitionLookup,
           prerenderer,
         }).listen(parseInt(localBaseRealmURL.port));
-        await base.start();
-        await testRealm.start();
+        // base.start() is a no-op now that the cloned template already holds
+        // base's index; demo is the only realm cold-indexed here. The
+        // heartbeat keeps a future regression (base no longer skipping, an
+        // index wedging) diagnosable instead of an opaque phase timeout.
+        await withIndexProgressHeartbeat(
+          'multiple realms beforeEach (base + demo start)',
+          dbAdapter,
+          async () => {
+            await base.start();
+            await testRealm.start();
+          },
+        );
 
         request = supertest(testRealmServer);
       },
@@ -2104,8 +2153,14 @@ module(basename(__filename), function () {
         assert.strictEqual(response.status, 200, 'HTTP 200 status');
       }
 
-      await base.reindex();
-      await testRealm.reindex();
+      await withIndexProgressHeartbeat(
+        'multiple realms reindex (base + demo)',
+        dbAdapter,
+        async () => {
+          await base.reindex();
+          await testRealm.reindex();
+        },
+      );
 
       {
         let response = await request
@@ -2114,8 +2169,14 @@ module(basename(__filename), function () {
         assert.strictEqual(response.status, 200, 'HTTP 200 status');
       }
 
-      await base.reindex();
-      await testRealm.reindex();
+      await withIndexProgressHeartbeat(
+        'multiple realms reindex (base + demo)',
+        dbAdapter,
+        async () => {
+          await base.reindex();
+          await testRealm.reindex();
+        },
+      );
 
       {
         let response = await request


### PR DESCRIPTION
## Background and Goal

The realm-server test `realm-endpoints-test.ts > Realm server serving multiple realms > Can perform full indexing multiple times on a server that runs multiple realms` is intermittently flaky: it fails with `Test took longer than 60000ms; test timed out` together with `Cannot read properties of undefined (reading 'get')` at the first `request.get(...)`.

The two symptoms are one cause. The test's `setupDB` `beforeEach` cold-indexes the **entire base realm** (~180 files) through the single-tab in-process prerenderer, which takes tens of seconds and runs as a single QUnit phase bounded by the global 60s `testTimeout`. On passing runs this test already takes **50–65s** (measured across recent green `main` runs); under shard-6 contention the `beforeEach` overruns 60s, QUnit kills the phase, and the body then runs with `request` still unassigned (assigned on the last line of `beforeEach`) — hence the `undefined.get` TypeError.

Goal: stop paying the base cold-index toll in the per-test path so the phase that was timing out no longer does that work, while keeping the multi-realm full-reindex behavior the test exists to exercise.

## Where to start

- `packages/realm-server/tests/helpers/index.ts` — `acquireBaseRealmTemplate()` builds a base-realm-indexed template database once (cold-indexing base into a builder DB, then snapshotting it), caches it per qunit process, and returns its name. `withIndexProgressHeartbeat()` is a small diagnostic wrapper.
- `packages/realm-server/tests/realm-endpoints-test.ts` — the "Realm server serving multiple realms" module now builds that template in a `before` hook and passes it as `setupDB`'s `templateDatabase`, so each test clones a base-indexed database.

## Key decisions

- **Seed base from a template rather than raise the timeout alone.** With base pre-indexed, `base.start()` is a no-op (`isNewIndex()` is false), so the cold index leaves the per-test `beforeEach` — the phase that was actually timing out — entirely. The expensive index runs once, in a `before` hook, not on every test.
- **The module's `testTimeout` is still raised** (and restored in `after`). The body genuinely re-indexes the realms several times, and a from-scratch index clears the realm's definition cache on completion, so each `reindex()` legitimately re-renders base. The one-time build also needs more than the default per-phase budget. The heartbeat keeps both honest.
- **Diagnostics are bundled.** `withIndexProgressHeartbeat` logs elapsed time + `boxel_index` rows per realm + unfulfilled job count every 15s while an index phase runs, so a future stall shows a moving row count (slow) vs. a frozen one (stuck) and which realm is mid-index — instead of an opaque phase timeout.
