### PR TITLE
Add group-by column options to IssueTracker board

### DIFF
--- a/packages/software-factory/realm/issue-tracker.gts
+++ b/packages/software-factory/realm/issue-tracker.gts
@@ -21,6 +21,7 @@ import MarkdownField from 'https://cardstack.com/base/markdown';
 import NumberField from 'https://cardstack.com/base/number';
 
 import {
+  BoxelSelect,
   FieldContainer,
   KanbanColumnConfigSidebar,
   KanbanPlane,
@@ -45,7 +46,10 @@ import { KanbanColumnField } from './kanban-column';
 import { KanbanBoardPlacement } from './kanban-board-placement';
 import {
   issueStatusOptions,
+  issuePriorityOptions,
+  issueTypeOptions,
   projectStatusOptions,
+  defaultColumns,
   findOptionColor,
   buildIssueOptionFields,
   configuredIssueStatusOptions,
@@ -53,6 +57,7 @@ import {
   IssueTypeField,
   IssuePriorityField,
   ProjectStatusField,
+  type Column,
 } from './kanban-config';
 import { Comment } from './comment';
 import { KnowledgeArticle } from './knowledge-article';
@@ -105,19 +110,6 @@ function getIssueStatusColor(
   value: string | null | undefined,
 ) {
   return getIssueStatusOption(issue, value)?.color;
-}
-
-function buildColumnsFromStatusOptions(
-  options: ReturnType<typeof getProjectIssueStatusOptions>,
-): KanbanColumnConfig[] {
-  return options.map((option, i) => ({
-    key: option.value,
-    label: option.label,
-    color: option.color ?? null,
-    collapsed: false,
-    wipLimit: 0,
-    sortOrder: i + 1,
-  }));
 }
 
 class IssueIsolated extends Component<typeof Issue> {
@@ -1052,11 +1044,57 @@ export class Project extends CardDef {
 
 class IssueTrackerIsolated extends Component<typeof IssueTracker> {
   @tracked isSidebarOpen = false;
+  @tracked uncategorizedCollapsed = false;
+
+  get activeGroupBy(): string {
+    return this.args.model.groupBy ?? 'status';
+  }
+
+  get groupByFieldName(): string {
+    switch (this.activeGroupBy) {
+      case 'priority':
+        return 'priority';
+      case 'issueType':
+        return 'issueType';
+      default:
+        return 'status';
+    }
+  }
+
+  get groupByDimensions(): Column[] {
+    return defaultColumns;
+  }
+
+  get selectedGroupByDimension(): Column | undefined {
+    return defaultColumns.find((d) => d.key === this.activeGroupBy);
+  }
+
+  updateGroupBy = (dim: Column): void => {
+    this.args.model.groupBy = dim.key;
+    this.args.model.columns = [];
+    this.uncategorizedCollapsed = false;
+  };
 
   get columns(): KanbanColumnConfig[] {
+    let options =
+      this.activeGroupBy === 'priority'
+        ? issuePriorityOptions
+        : this.activeGroupBy === 'issueType'
+          ? issueTypeOptions
+          : getProjectIssueStatusOptions(this.args.model?.project);
+
     let stored = this.args.model.columns ?? [];
-    if (stored.length) {
-      return stored.map((col) => ({
+    let optionKeys = new Set(options.map((o) => o.value));
+    let storedMatchesCurrent =
+      stored.length > 0 && stored.every((c) => optionKeys.has(c.key));
+
+    let fieldName = this.groupByFieldName;
+    let cards = this.args.model.cards ?? [];
+    let hideEmpty = this.args.model.hideEmptyColumns ?? false;
+
+    let baseColumns: KanbanColumnConfig[];
+    if (storedMatchesCurrent) {
+      baseColumns = stored.map((col) => ({
         key: col.key,
         label: col.label,
         color: col.color,
@@ -1064,10 +1102,41 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
         wipLimit: col.wipLimit ?? null,
         sortOrder: col.sortOrder,
       }));
+    } else {
+      baseColumns = options.map((option, i) => {
+        let isEmpty =
+          hideEmpty &&
+          !cards.some((c) => (c as any)[fieldName] === option.value);
+        return {
+          key: option.value,
+          label: option.label,
+          color: option.color ?? null,
+          collapsed: isEmpty,
+          wipLimit: 0,
+          sortOrder: i + 1,
+        };
+      });
     }
-    return buildColumnsFromStatusOptions(
-      getProjectIssueStatusOptions(this.args.model?.project),
-    );
+
+    if (this.args.model.groupByFallbackKey) return baseColumns;
+    let hasOrphan = cards.some((card) => {
+      let v = (card as any)[fieldName];
+      return !v || !optionKeys.has(v);
+    });
+
+    if (!hasOrphan) return baseColumns;
+
+    return [
+      ...baseColumns,
+      {
+        key: 'uncategorized',
+        label: 'Uncategorized',
+        color: null,
+        collapsed: this.uncategorizedCollapsed,
+        wipLimit: null,
+        sortOrder: baseColumns.length + 1,
+      },
+    ];
   }
 
   get statusColor(): string | undefined {
@@ -1075,6 +1144,10 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
       projectStatusOptions,
       this.args.model?.project?.projectStatus,
     );
+  }
+
+  get configurableColumns(): KanbanColumnConfig[] {
+    return this.columns.filter((c) => c.key !== 'uncategorized');
   }
 
   get firstColumn(): KanbanColumnConfig | undefined {
@@ -1122,6 +1195,10 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
 
   handleToggleCollapsed = (col: KanbanColumnConfig | null): void => {
     if (!col) return;
+    if (col.key === 'uncategorized') {
+      this.uncategorizedCollapsed = !this.uncategorizedCollapsed;
+      return;
+    }
     this.handleColumnsChange(
       this.columns.map((c: KanbanColumnConfig) =>
         c.key === col.key ? { ...c, collapsed: !c.collapsed } : c,
@@ -1130,28 +1207,32 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
   };
 
   handleColumnsChange = (newColumns: KanbanColumnConfig[]): void => {
-    this.args.model.columns = newColumns.map((cfg) =>
-      Object.assign(new KanbanColumnField(), {
-        key: cfg.key,
-        label: cfg.label,
-        color: cfg.color,
-        collapsed: cfg.collapsed,
-        wipLimit: cfg.wipLimit,
-        sortOrder: cfg.sortOrder,
-      }),
-    );
+    this.args.model.columns = newColumns
+      .filter((cfg) => cfg.key !== 'uncategorized')
+      .map((cfg) =>
+        Object.assign(new KanbanColumnField(), {
+          key: cfg.key,
+          label: cfg.label,
+          color: cfg.color,
+          collapsed: cfg.collapsed,
+          wipLimit: cfg.wipLimit,
+          sortOrder: cfg.sortOrder,
+        }),
+      );
 
-    let project = this.args.model.project;
-    if (project?.issueStatusOptions?.length) {
-      project.issueStatusOptions = project.issueStatusOptions.map((opt) => {
-        let col = newColumns.find((c) => c.key === opt.value);
-        if (!col) return opt;
-        return Object.assign(new IssueOptionField(), {
-          value: opt.value,
-          label: col.label ?? opt.label,
-          color: col.color ?? opt.color,
+    if (this.activeGroupBy === 'status') {
+      let project = this.args.model.project;
+      if (project?.issueStatusOptions?.length) {
+        project.issueStatusOptions = project.issueStatusOptions.map((opt) => {
+          let col = newColumns.find((c) => c.key === opt.value);
+          if (!col) return opt;
+          return Object.assign(new IssueOptionField(), {
+            value: opt.value,
+            label: col.label ?? opt.label,
+            color: col.color ?? opt.color,
+          });
         });
-      });
+      }
     }
   };
 
@@ -1203,6 +1284,8 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
     let model = this.args.model as any;
     let boardRealmURL: URL | undefined = model[realmURL];
     let projectId: string | null = model.project?.id ?? null;
+    let fieldName = this.groupByFieldName;
+    let fieldValue = columnKey !== 'uncategorized' ? columnKey : null;
     let cardId = await this.args.createCard?.(
       issueCodeRef,
       new URL(issueCodeRef.module),
@@ -1211,7 +1294,7 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
         doc: {
           data: {
             type: 'card',
-            attributes: { status: columnKey },
+            attributes: { [fieldName]: fieldValue },
             relationships: projectId
               ? { project: { links: { self: projectId } } }
               : {},
@@ -1238,10 +1321,15 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
 
   handleChange = (newPlacements: KanbanPlacement[]) => {
     let cards = this.args.model?.cards ?? [];
+    let fieldName = this.groupByFieldName;
     this.args.model.placements = newPlacements.map((p) => {
       let card = cards[p.index] as any;
-      if (card && card.status !== p.columnId) {
-        card.status = p.columnId;
+      if (
+        card &&
+        p.columnId !== 'uncategorized' &&
+        (card as any)[fieldName] !== p.columnId
+      ) {
+        (card as any)[fieldName] = p.columnId;
       }
       return Object.assign(new KanbanBoardPlacement(), {
         itemId: card?.id ?? '',
@@ -1263,6 +1351,23 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
   get placements(): KanbanPlacement[] {
     let stored = this.args.model?.placements;
     let cards = this.args.model?.cards ?? [];
+    let fieldName = this.groupByFieldName;
+    let fallbackKey = this.args.model.groupByFallbackKey;
+
+    let resolveColumn = (fieldValue: string | null | undefined): string => {
+      return (
+        (fieldValue
+          ? this.columns.find((c) => c.key === fieldValue)?.key
+          : undefined) ??
+        (fallbackKey
+          ? this.columns.find((c) => c.key === fallbackKey)?.key
+          : undefined) ??
+        this.columns.find((c) => c.key === 'uncategorized')?.key ??
+        this.firstColumn?.key ??
+        ''
+      );
+    };
+
     if (stored?.length) {
       let placedCardIds = new Set(stored.map((p) => p.itemId));
       let resolved = stored
@@ -1270,12 +1375,7 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
           let cardIdx = cards.findIndex((c) => (c as any).id === p.itemId);
           if (cardIdx === -1) return null;
           let card = cards[cardIdx] as any;
-          let effectiveKey = card?.status ?? p.columnKey;
-          let colKey =
-            this.columns.find((c) => c.key === effectiveKey)?.key ??
-            this.columns.find((c) => c.key === p.columnKey)?.key ??
-            this.columns.find((c) => c.key === 'backlog')?.key ??
-            this.firstColumn?.key;
+          let colKey = resolveColumn(card[fieldName] ?? p.columnKey);
           if (!colKey) return null;
           return {
             columnId: colKey,
@@ -1290,32 +1390,18 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
       let unplaced = cards
         .map((card, idx) => ({ card, idx }))
         .filter(({ card }) => !placedCardIds.has((card as any).id))
-        .map(({ card, idx }, i) => {
-          let status = (card as any).status ?? 'backlog';
-          let colKey =
-            this.columns.find((c) => c.key === status)?.key ??
-            this.columns.find((c) => c.key === 'backlog')?.key ??
-            this.firstColumn?.key;
-          return {
-            columnId: colKey ?? '',
-            index: idx,
-            sortOrder: maxOrder + 1 + i,
-          };
-        });
+        .map(({ card, idx }, i) => ({
+          columnId: resolveColumn((card as any)[fieldName]),
+          index: idx,
+          sortOrder: maxOrder + 1 + i,
+        }));
       return [...resolved, ...unplaced];
     }
-    return cards.map((card, idx) => {
-      let status = (card as any).status ?? 'backlog';
-      let colKey =
-        this.columns.find((c) => c.key === status)?.key ??
-        this.columns.find((c) => c.key === 'backlog')?.key ??
-        this.firstColumn?.key;
-      return {
-        columnId: colKey ?? '',
-        index: idx,
-        sortOrder: idx,
-      };
-    });
+    return cards.map((card, idx) => ({
+      columnId: resolveColumn((card as any)[fieldName]),
+      index: idx,
+      sortOrder: idx,
+    }));
   }
 
   <template>
@@ -1346,15 +1432,33 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
           </div>
         </div>
         <div class='toolbar-right'>
-          <div class='kanban-column-visibility-toggle'>
-            <span class='kanban-header-label'>Hide empty</span>
+          <FieldContainer
+            @label='Group by'
+            class='toolbar-field group-by-selector'
+            data-test-group-by-selector
+          >
+            <BoxelSelect
+              @options={{this.groupByDimensions}}
+              @selected={{this.selectedGroupByDimension}}
+              @onChange={{this.updateGroupBy}}
+              @renderInPlace={{true}}
+              as |dim|
+            >
+              <span data-test-group-by-option={{dim.key}}>{{dim.label}}</span>
+            </BoxelSelect>
+          </FieldContainer>
+          <FieldContainer
+            @label='Hide empty'
+            @inline={{true}}
+            class='toolbar-field'
+          >
             <Switch
               @isEnabled={{this.hideEmpty}}
               @onChange={{this.toggleHideEmptyColumns}}
               @label='Hide empty columns'
               data-test-hide-empty-switch
             />
-          </div>
+          </FieldContainer>
           <Tooltip @placement='bottom'>
             <:trigger>
               <ContextButton
@@ -1420,7 +1524,7 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
           class={{cn 'kanban-config-sidebar-wrap' is-open=this.isSidebarOpen}}
         >
           <KanbanColumnConfigSidebar
-            @columns={{this.columns}}
+            @columns={{this.configurableColumns}}
             @cardCounts={{this.columnCardCountsByKey}}
             @onClose={{this.toggleSidebar}}
             @onToggleCollapsed={{this.handleToggleCollapsed}}
@@ -1480,7 +1584,7 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
       .toolbar-right {
         display: flex;
         align-items: center;
-        gap: 0.375rem;
+        gap: var(--boxel-sp-sm);
         color: var(--board-muted-fg);
       }
       .kanban-title {
@@ -1511,10 +1615,32 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
         text-transform: uppercase;
         letter-spacing: 0.05em;
       }
-      .kanban-column-visibility-toggle {
-        display: flex;
+      .toolbar-field {
+        --boxel-field-label-font-size: 0.75rem;
+        --boxel-field-label-color: var(--board-muted-fg);
+        display: inline-flex;
         align-items: center;
-        gap: 0.5rem;
+        gap: var(--boxel-sp-2xs);
+        white-space: nowrap;
+      }
+      .group-by-selector :deep(.label-container) {
+        padding-top: unset;
+      }
+      .group-by-selector :deep(.ember-power-select-trigger) {
+        width: 7rem;
+      }
+      .group-by-selector :deep(.ember-power-select-trigger),
+      .group-by-selector :deep(.boxel-trigger-content),
+      .group-by-selector :deep(.boxel-trigger-content > span) {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .group-by-selector :deep(.ember-power-select-dropdown) {
+        min-width: max-content;
+      }
+      .group-by-selector :deep(.ember-power-select-option) {
+        white-space: nowrap;
       }
       .kanban-header-label {
         font-size: 0.75rem;
@@ -1557,6 +1683,8 @@ export class IssueTracker extends KanbanBoard {
   static displayName = 'Issue Tracker Board';
 
   @field project = linksTo(() => Project);
+  @field groupBy = contains(StringField);
+  @field groupByFallbackKey = contains(StringField);
   @field cards = linksToMany(() => Issue, {
     computeVia: function (this: IssueTracker) {
       return this.project?.issues;

--- a/packages/software-factory/realm/issue-tracker.gts
+++ b/packages/software-factory/realm/issue-tracker.gts
@@ -57,6 +57,7 @@ import {
   IssueTypeField,
   IssuePriorityField,
   ProjectStatusField,
+  GroupByField,
   type Column,
 } from './kanban-config';
 import { Comment } from './comment';
@@ -1047,7 +1048,10 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
   @tracked uncategorizedCollapsed = false;
 
   get activeGroupBy(): string {
-    return this.args.model.groupBy ?? 'status';
+    const stored = this.args.model.groupBy;
+    return stored && defaultColumns.some((d) => d.key === stored)
+      ? stored
+      : 'status';
   }
 
   get groupByFieldName(): string {
@@ -1118,7 +1122,8 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
       });
     }
 
-    if (this.args.model.groupByFallbackKey) return baseColumns;
+    let fallbackKey = this.args.model.groupByFallbackKey;
+    if (fallbackKey && optionKeys.has(fallbackKey)) return baseColumns;
     let hasOrphan = cards.some((card) => {
       let v = (card as any)[fieldName];
       return !v || !optionKeys.has(v);
@@ -1285,7 +1290,7 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
     let boardRealmURL: URL | undefined = model[realmURL];
     let projectId: string | null = model.project?.id ?? null;
     let fieldName = this.groupByFieldName;
-    let fieldValue = columnKey !== 'uncategorized' ? columnKey : null;
+    let fieldValue = columnKey !== 'uncategorized' ? columnKey : undefined;
     let cardId = await this.args.createCard?.(
       issueCodeRef,
       new URL(issueCodeRef.module),
@@ -1683,7 +1688,7 @@ export class IssueTracker extends KanbanBoard {
   static displayName = 'Issue Tracker Board';
 
   @field project = linksTo(() => Project);
-  @field groupBy = contains(StringField);
+  @field groupBy = contains(GroupByField);
   @field groupByFallbackKey = contains(StringField);
   @field cards = linksToMany(() => Issue, {
     computeVia: function (this: IssueTracker) {

--- a/packages/software-factory/realm/issue-tracker.gts
+++ b/packages/software-factory/realm/issue-tracker.gts
@@ -1324,12 +1324,12 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
     let fieldName = this.groupByFieldName;
     this.args.model.placements = newPlacements.map((p) => {
       let card = cards[p.index] as any;
-      if (
-        card &&
-        p.columnId !== 'uncategorized' &&
-        (card as any)[fieldName] !== p.columnId
-      ) {
-        (card as any)[fieldName] = p.columnId;
+      if (card) {
+        if (p.columnId === 'uncategorized') {
+          (card as any)[fieldName] = undefined;
+        } else if ((card as any)[fieldName] !== p.columnId) {
+          (card as any)[fieldName] = p.columnId;
+        }
       }
       return Object.assign(new KanbanBoardPlacement(), {
         itemId: card?.id ?? '',

--- a/packages/software-factory/realm/issue-tracker.test.gts
+++ b/packages/software-factory/realm/issue-tracker.test.gts
@@ -1253,6 +1253,50 @@ export function runTests() {
             .dom('[data-kanban-column="critical"] [data-test-issue-id="IT-3"]')
             .doesNotExist('IT-3 is not placed in the first regular column');
         });
+
+        test<TestContextWithSave>('dragging a card into Uncategorized clears its priority field', async function (assert) {
+          let savedIssueDocs: any[] = [];
+          this.onSave((url, doc) => {
+            if (url.href === `${testRealmURL}Issues/issue-1`) {
+              savedIssueDocs.push(doc);
+            }
+          });
+
+          await visitOperatorMode({
+            stacks: [[{ id: boardId, format: 'isolated' }]],
+          });
+          await waitFor('[data-test-issue-id]');
+
+          assert
+            .dom('[data-kanban-column="critical"] [data-test-issue-id]')
+            .hasText('IT-1', 'IT-1 starts in critical');
+
+          // critical → high → medium → low → uncategorized
+          await triggerKeyEvent('[data-card-index="0"]', 'keydown', ' ');
+          for (let i = 0; i < 4; i++) {
+            await triggerKeyEvent(
+              '[data-test-kanban-board]',
+              'keydown',
+              'ArrowRight',
+            );
+          }
+          await triggerKeyEvent('[data-test-kanban-board]', 'keydown', ' ');
+          await settled();
+
+          assert
+            .dom('[data-kanban-column="uncategorized"] [data-test-issue-id]')
+            .includesText('IT-1', 'IT-1 is now in the Uncategorized column');
+          assert
+            .dom('[data-kanban-column="critical"] [data-test-issue-id="IT-1"]')
+            .doesNotExist('IT-1 is no longer in the critical column');
+
+          let savedDoc = savedIssueDocs[savedIssueDocs.length - 1];
+          assert.strictEqual(
+            savedDoc?.data?.attributes?.priority,
+            undefined,
+            'priority field is cleared when card is moved to Uncategorized',
+          );
+        });
       });
 
       module('groupBy=priority with fallback column', function (hooks) {

--- a/packages/software-factory/realm/issue-tracker.test.gts
+++ b/packages/software-factory/realm/issue-tracker.test.gts
@@ -44,6 +44,29 @@ function makeIssue(
   };
 }
 
+async function selectGroupBy(key: string) {
+  await click('[data-test-group-by-selector] .ember-power-select-trigger');
+  await waitFor('.ember-power-select-option');
+  await click(`[data-test-group-by-option="${key}"]`);
+}
+
+function makeIssueWithFields(
+  issueId: string,
+  attrs: Record<string, string | null | undefined>,
+  filename: string,
+): Record<string, Record<string, unknown>> {
+  return {
+    [filename]: {
+      data: {
+        type: 'card',
+        attributes: { issueId, summary: `${issueId} issue`, ...attrs },
+        relationships: { project: { links: { self: projectId } } },
+        meta: { adoptsFrom: { module: issueTrackerModule, name: 'Issue' } },
+      },
+    },
+  };
+}
+
 function makeProject(
   issueStatusOptions?: { value: string; label: string }[],
 ): Record<string, Record<string, unknown>> {
@@ -72,6 +95,8 @@ function makeBoard(
     collapsed: boolean;
     sortOrder: number;
   }[],
+  groupBy?: string,
+  groupByFallbackKey?: string,
 ): Record<string, Record<string, unknown>> {
   return {
     'Boards/test-board.json': {
@@ -80,6 +105,8 @@ function makeBoard(
         attributes: {
           boardTitle: 'Test Board',
           ...(columns ? { columns } : {}),
+          ...(groupBy !== undefined ? { groupBy } : {}),
+          ...(groupByFallbackKey !== undefined ? { groupByFallbackKey } : {}),
         },
         relationships: { project: { links: { self: projectId } } },
         meta: {
@@ -698,6 +725,151 @@ export function runTests() {
       });
     });
 
+    // ── column config with non-status groupBy ────────────────────────────────
+    module('column config with non-status groupBy', function (hooks) {
+      hooks.beforeEach(async function () {
+        await setupAcceptanceTestRealm({
+          realmURL: testRealmURL,
+          mockMatrixUtils,
+          contents: {
+            ...SYSTEM_CARD_FIXTURE_CONTENTS,
+            ...makeProject(),
+            // IT-1 has a priority so it lands in a real column
+            ...makeIssueWithFields(
+              'IT-1',
+              { status: 'backlog', priority: 'high' },
+              'Issues/issue-1.json',
+            ),
+            // IT-2 has no priority, which triggers the Uncategorized column
+            ...makeIssueWithFields(
+              'IT-2',
+              { status: 'done' },
+              'Issues/issue-2.json',
+            ),
+            ...makeBoard(undefined, 'priority'),
+          },
+        });
+      });
+
+      test<TestContextWithSave>('collapsing a column persists collapsed state and does not save the Uncategorized column', async function (assert) {
+        let savedBoardDocs: any[] = [];
+        this.onSave((url, doc) => {
+          if (url.href === boardId) savedBoardDocs.push(doc);
+        });
+
+        await visitOperatorMode({
+          stacks: [[{ id: boardId, format: 'isolated' }]],
+        });
+        await waitFor('[data-kanban-column]');
+
+        assert
+          .dom('[data-kanban-column="uncategorized"]')
+          .exists(
+            'Uncategorized column is present because IT-2 has no priority',
+          );
+
+        await click('[data-test-column-collapse-button="high"]');
+        await waitFor('[data-test-show-hidden-column="high"]');
+
+        let savedDoc = savedBoardDocs[savedBoardDocs.length - 1];
+        let savedColumns = savedDoc?.data?.attributes?.columns;
+
+        let highColumn = savedColumns?.find(
+          (c: { key: string }) => c.key === 'high',
+        );
+        assert.true(
+          highColumn?.collapsed,
+          'high column collapsed state is persisted',
+        );
+
+        assert.false(
+          savedColumns?.some((c: { key: string }) => c.key === 'uncategorized'),
+          'Uncategorized column is not persisted in model.columns',
+        );
+      });
+
+      test<TestContextWithSave>('renaming a priority column persists the label and survives a re-render', async function (assert) {
+        let savedBoardDocs: any[] = [];
+        this.onSave((url, doc) => {
+          if (url.href === boardId) savedBoardDocs.push(doc);
+        });
+
+        await visitOperatorMode({
+          stacks: [[{ id: boardId, format: 'isolated' }]],
+        });
+        await waitFor('[data-kanban-column]');
+
+        await click('[data-test-configure-columns-btn]');
+        await fillIn('[data-test-col-config-label="high"]', 'Urgent');
+        await settled();
+
+        let savedDoc = savedBoardDocs[savedBoardDocs.length - 1];
+        let savedColumns = savedDoc?.data?.attributes?.columns;
+
+        assert.strictEqual(
+          savedColumns?.find((c: { key: string }) => c.key === 'high')?.label,
+          'Urgent',
+          'renamed label is persisted on the board model',
+        );
+        assert.false(
+          savedColumns?.some((c: { key: string }) => c.key === 'uncategorized'),
+          'Uncategorized is excluded from saved columns, so storedMatchesCurrent stays true on re-render',
+        );
+
+        // Trigger a re-render by visiting again — if storedMatchesCurrent were
+        // broken the columns getter would rebuild from issuePriorityOptions and
+        // the label would revert to 'High'.
+        await visitOperatorMode({
+          stacks: [[{ id: boardId, format: 'isolated' }]],
+        });
+        await waitFor('[data-kanban-column]');
+
+        await click('[data-test-configure-columns-btn]');
+        assert
+          .dom('[data-test-col-config-label="high"]')
+          .hasValue('Urgent', 'renamed label survives a re-render');
+      });
+
+      test('clicking the column header hide button hides the Uncategorized column', async function (assert) {
+        await visitOperatorMode({
+          stacks: [[{ id: boardId, format: 'isolated' }]],
+        });
+        await waitFor('[data-kanban-column="uncategorized"]');
+
+        await click('[data-test-column-collapse-button="uncategorized"]');
+        await waitFor('[data-test-show-hidden-column="uncategorized"]');
+
+        assert
+          .dom('[data-kanban-column="uncategorized"]')
+          .doesNotExist(
+            'Uncategorized column is hidden after clicking collapse',
+          );
+        assert
+          .dom('[data-test-show-hidden-column="uncategorized"]')
+          .exists('Uncategorized appears in the hidden-columns tray');
+      });
+
+      test('clicking the hidden-columns tray reveals the Uncategorized column again', async function (assert) {
+        await visitOperatorMode({
+          stacks: [[{ id: boardId, format: 'isolated' }]],
+        });
+        await waitFor('[data-kanban-column="uncategorized"]');
+
+        await click('[data-test-column-collapse-button="uncategorized"]');
+        await waitFor('[data-test-show-hidden-column="uncategorized"]');
+
+        await click('[data-test-show-hidden-column="uncategorized"]');
+        await waitFor('[data-kanban-column="uncategorized"]');
+
+        assert
+          .dom('[data-kanban-column="uncategorized"]')
+          .exists('Uncategorized column is visible again after revealing');
+        assert
+          .dom('[data-test-hidden-columns]')
+          .doesNotExist('hidden-columns tray is gone');
+      });
+    });
+
     // ── unknown status ────────────────────────────────────────────────────────
     module('unknown status', function (hooks) {
       hooks.beforeEach(async function () {
@@ -713,17 +885,22 @@ export function runTests() {
         });
       });
 
-      test('issue with unrecognised status falls to column 0', async function (assert) {
+      test('issue with unrecognised status is placed in an Uncategorized column', async function (assert) {
         await visitOperatorMode({
           stacks: [[{ id: boardId, format: 'isolated' }]],
         });
         await waitFor('[data-test-issue-id]');
 
         assert
-          .dom(`[data-kanban-column="backlog"] [data-test-issue-id]`)
+          .dom('[data-kanban-column="uncategorized"]')
+          .exists(
+            'an Uncategorized column is added for unrecognised status values',
+          );
+        assert
+          .dom('[data-kanban-column="uncategorized"] [data-test-issue-id]')
           .hasText(
             'IT-1',
-            'unknown status falls back to first column (index 0)',
+            'card with unknown status is placed in Uncategorized',
           );
       });
     });
@@ -972,18 +1149,365 @@ export function runTests() {
         });
       });
 
-      test('a card with an unknown status is placed in the first column', async function (assert) {
+      test('a card with an unknown status is placed in an Uncategorized column', async function (assert) {
         await visitOperatorMode({
           stacks: [[{ id: boardId, format: 'isolated' }]],
         });
         await waitFor('[data-test-issue-id]');
 
         assert
-          .dom(`[data-kanban-column="backlog"] [data-test-issue-id]`)
+          .dom('[data-kanban-column="uncategorized"]')
+          .exists(
+            'an Uncategorized column is added for unrecognised status values',
+          );
+        assert
+          .dom('[data-kanban-column="uncategorized"] [data-test-issue-id]')
           .hasText(
             'IT-99',
-            'card with unknown status lands in the first column',
+            'card with unknown status is placed in Uncategorized',
           );
+      });
+    });
+
+    // ── group by ──────────────────────────────────────────────────────────────
+    module('group by', function () {
+      module('groupBy=priority', function (hooks) {
+        hooks.beforeEach(async function () {
+          await setupAcceptanceTestRealm({
+            realmURL: testRealmURL,
+            mockMatrixUtils,
+            contents: {
+              ...SYSTEM_CARD_FIXTURE_CONTENTS,
+              ...makeProject(),
+              ...makeIssueWithFields(
+                'IT-1',
+                { status: 'backlog', priority: 'critical' },
+                'Issues/issue-1.json',
+              ),
+              ...makeIssueWithFields(
+                'IT-2',
+                { status: 'in_progress', priority: 'medium' },
+                'Issues/issue-2.json',
+              ),
+              ...makeIssueWithFields(
+                'IT-3',
+                { status: 'done' },
+                'Issues/issue-3.json',
+              ),
+              ...makeBoard(undefined, 'priority'),
+            },
+          });
+        });
+
+        test('columns are the four priority options', async function (assert) {
+          await visitOperatorMode({
+            stacks: [[{ id: boardId, format: 'isolated' }]],
+          });
+          await waitFor('[data-kanban-column]');
+          // 4 priority columns + 1 Uncategorized (IT-3 has no priority)
+          assert
+            .dom('[data-kanban-column]')
+            .exists(
+              { count: 5 },
+              '4 priority columns + Uncategorized rendered',
+            );
+          assert.dom('[data-kanban-column="critical"]').exists();
+          assert.dom('[data-kanban-column="high"]').exists();
+          assert.dom('[data-kanban-column="medium"]').exists();
+          assert.dom('[data-kanban-column="low"]').exists();
+          assert.dom('[data-kanban-column="uncategorized"]').exists();
+        });
+
+        test('issues appear in their priority column', async function (assert) {
+          await visitOperatorMode({
+            stacks: [[{ id: boardId, format: 'isolated' }]],
+          });
+          await waitFor('[data-test-issue-id]');
+
+          assert
+            .dom('[data-kanban-column="critical"] [data-test-issue-id]')
+            .hasText('IT-1', 'IT-1 is in the critical column');
+          assert
+            .dom('[data-kanban-column="medium"] [data-test-issue-id]')
+            .hasText('IT-2', 'IT-2 is in the medium column');
+        });
+
+        test('issue with no priority is placed in an Uncategorized column', async function (assert) {
+          await visitOperatorMode({
+            stacks: [[{ id: boardId, format: 'isolated' }]],
+          });
+          await waitFor('[data-test-issue-id]');
+
+          assert
+            .dom('[data-kanban-column="uncategorized"]')
+            .exists(
+              'an Uncategorized column is added for cards with no matching field value',
+            );
+          assert
+            .dom('[data-kanban-column="uncategorized"] [data-test-issue-id]')
+            .hasText(
+              'IT-3',
+              'IT-3 with no priority is placed in Uncategorized',
+            );
+          assert
+            .dom('[data-kanban-column="critical"] [data-test-issue-id="IT-3"]')
+            .doesNotExist('IT-3 is not placed in the first regular column');
+        });
+      });
+
+      module('groupBy=priority with fallback column', function (hooks) {
+        hooks.beforeEach(async function () {
+          await setupAcceptanceTestRealm({
+            realmURL: testRealmURL,
+            mockMatrixUtils,
+            contents: {
+              ...SYSTEM_CARD_FIXTURE_CONTENTS,
+              ...makeProject(),
+              ...makeIssueWithFields(
+                'IT-1',
+                { status: 'backlog', priority: 'critical' },
+                'Issues/issue-1.json',
+              ),
+              ...makeIssueWithFields(
+                'IT-2',
+                { status: 'done' },
+                'Issues/issue-2.json',
+              ),
+              ...makeBoard(undefined, 'priority', 'low'),
+            },
+          });
+        });
+
+        test('issue with no priority falls back to a user-specified column', async function (assert) {
+          await visitOperatorMode({
+            stacks: [[{ id: boardId, format: 'isolated' }]],
+          });
+          await waitFor('[data-test-issue-id]');
+
+          assert
+            .dom('[data-kanban-column="uncategorized"]')
+            .doesNotExist(
+              'no Uncategorized column when a fallback column is configured',
+            );
+          assert
+            .dom('[data-kanban-column="low"] [data-test-issue-id]')
+            .hasText(
+              'IT-2',
+              'IT-2 with no priority lands in the user-specified fallback column (low)',
+            );
+        });
+      });
+
+      module('groupBy=issueType', function (hooks) {
+        hooks.beforeEach(async function () {
+          await setupAcceptanceTestRealm({
+            realmURL: testRealmURL,
+            mockMatrixUtils,
+            contents: {
+              ...SYSTEM_CARD_FIXTURE_CONTENTS,
+              ...makeProject(),
+              ...makeIssueWithFields(
+                'IT-1',
+                { status: 'backlog', issueType: 'feature' },
+                'Issues/issue-feature.json',
+              ),
+              ...makeIssueWithFields(
+                'IT-2',
+                { status: 'in_progress', issueType: 'bug' },
+                'Issues/issue-bug.json',
+              ),
+              ...makeBoard(undefined, 'issueType'),
+            },
+          });
+        });
+
+        test('columns are the six issue type options', async function (assert) {
+          await visitOperatorMode({
+            stacks: [[{ id: boardId, format: 'isolated' }]],
+          });
+          await waitFor('[data-kanban-column]');
+
+          assert
+            .dom('[data-kanban-column]')
+            .exists({ count: 6 }, 'exactly 6 issue type columns rendered');
+          assert.dom('[data-kanban-column="bootstrap"]').exists();
+          assert.dom('[data-kanban-column="feature"]').exists();
+          assert.dom('[data-kanban-column="bug"]').exists();
+          assert.dom('[data-kanban-column="task"]').exists();
+          assert.dom('[data-kanban-column="research"]').exists();
+          assert.dom('[data-kanban-column="infrastructure"]').exists();
+        });
+
+        test('issues appear in their type column', async function (assert) {
+          await visitOperatorMode({
+            stacks: [[{ id: boardId, format: 'isolated' }]],
+          });
+          await waitFor('[data-test-issue-id]');
+
+          assert
+            .dom('[data-kanban-column="feature"] [data-test-issue-id]')
+            .hasText('IT-1', 'IT-1 is in the feature column');
+          assert
+            .dom('[data-kanban-column="bug"] [data-test-issue-id]')
+            .hasText('IT-2', 'IT-2 is in the bug column');
+        });
+      });
+
+      module('changing group by from UI', function (hooks) {
+        hooks.beforeEach(async function () {
+          await setupAcceptanceTestRealm({
+            realmURL: testRealmURL,
+            mockMatrixUtils,
+            contents: {
+              ...SYSTEM_CARD_FIXTURE_CONTENTS,
+              ...makeProject(),
+              ...makeIssueWithFields(
+                'IT-1',
+                { status: 'backlog', priority: 'high', issueType: 'feature' },
+                'Issues/issue-1.json',
+              ),
+              ...makeBoard(),
+            },
+          });
+        });
+
+        test('group-by selector shows all three options', async function (assert) {
+          await visitOperatorMode({
+            stacks: [[{ id: boardId, format: 'isolated' }]],
+          });
+          await waitFor('[data-test-group-by-selector]');
+
+          await click(
+            '[data-test-group-by-selector] .ember-power-select-trigger',
+          );
+          await waitFor('.ember-power-select-option');
+
+          assert.dom('[data-test-group-by-option="status"]').exists();
+          assert.dom('[data-test-group-by-option="priority"]').exists();
+          assert.dom('[data-test-group-by-option="issueType"]').exists();
+        });
+
+        test('switching to priority grouping shows priority columns and re-places cards', async function (assert) {
+          await visitOperatorMode({
+            stacks: [[{ id: boardId, format: 'isolated' }]],
+          });
+          await waitFor('[data-kanban-column]');
+
+          assert
+            .dom('[data-kanban-column="backlog"]')
+            .exists('starts grouped by status');
+
+          await selectGroupBy('priority');
+          await settled();
+
+          assert
+            .dom('[data-kanban-column="backlog"]')
+            .doesNotExist('status columns gone after switching');
+          assert
+            .dom('[data-kanban-column="high"]')
+            .exists('priority column visible');
+          assert
+            .dom('[data-kanban-column="high"] [data-test-issue-id]')
+            .hasText('IT-1', 'IT-1 placed in high priority column');
+        });
+
+        test('switching to issueType grouping shows type columns', async function (assert) {
+          await visitOperatorMode({
+            stacks: [[{ id: boardId, format: 'isolated' }]],
+          });
+          await waitFor('[data-kanban-column]');
+
+          await selectGroupBy('issueType');
+          await settled();
+
+          assert
+            .dom('[data-kanban-column="feature"]')
+            .exists('feature column visible');
+          assert
+            .dom('[data-kanban-column="feature"] [data-test-issue-id]')
+            .hasText('IT-1', 'IT-1 placed in feature type column');
+        });
+
+        test('switching back to status grouping restores status columns', async function (assert) {
+          await visitOperatorMode({
+            stacks: [[{ id: boardId, format: 'isolated' }]],
+          });
+          await waitFor('[data-kanban-column]');
+
+          await selectGroupBy('priority');
+          await settled();
+          assert
+            .dom('[data-kanban-column="high"]')
+            .exists('in priority grouping');
+
+          await selectGroupBy('status');
+          await settled();
+
+          assert
+            .dom('[data-kanban-column="backlog"]')
+            .exists('status columns restored');
+          assert
+            .dom('[data-kanban-column="high"]')
+            .doesNotExist('priority columns gone');
+          assert
+            .dom('[data-kanban-column="backlog"] [data-test-issue-id]')
+            .hasText('IT-1', 'IT-1 back in backlog column');
+        });
+
+        test<TestContextWithSave>('switching group by persists the value to the board model', async function (assert) {
+          let savedBoardDocs: any[] = [];
+          this.onSave((url, doc) => {
+            if (url.href === boardId) savedBoardDocs.push(doc);
+          });
+
+          await visitOperatorMode({
+            stacks: [[{ id: boardId, format: 'isolated' }]],
+          });
+          await waitFor('[data-kanban-column]');
+
+          await selectGroupBy('issueType');
+          await settled();
+
+          let savedDoc = savedBoardDocs[savedBoardDocs.length - 1];
+          assert.strictEqual(
+            savedDoc?.data?.attributes?.groupBy,
+            'issueType',
+            'groupBy is persisted as issueType on the board model',
+          );
+        });
+
+        test('hide-empty stays effective after switching group by', async function (assert) {
+          await visitOperatorMode({
+            stacks: [[{ id: boardId, format: 'isolated' }]],
+          });
+          await waitFor('[data-kanban-column]');
+
+          // Turn on hide-empty while grouped by status.
+          // IT-1 is in backlog so the other 4 status columns are empty and hidden.
+          await click('[data-test-hide-empty-switch]');
+          await waitFor('[data-test-hidden-columns]');
+          assert
+            .dom('[data-kanban-column]')
+            .exists({ count: 1 }, 'only 1 status column visible (has a card)');
+
+          // Switch to priority. IT-1 has priority=high, so only the high column
+          // is non-empty. The other three priority columns should be hidden.
+          await selectGroupBy('priority');
+          await settled();
+
+          assert
+            .dom('[data-kanban-column="high"]')
+            .exists('high priority column visible (IT-1 is here)');
+          assert
+            .dom('[data-kanban-column="critical"]')
+            .doesNotExist('critical hidden — empty and hide-empty is on');
+          assert
+            .dom('[data-kanban-column="medium"]')
+            .doesNotExist('medium hidden — empty and hide-empty is on');
+          assert
+            .dom('[data-kanban-column="low"]')
+            .doesNotExist('low hidden — empty and hide-empty is on');
+        });
       });
     });
   });

--- a/packages/software-factory/realm/issue-tracker.test.gts
+++ b/packages/software-factory/realm/issue-tracker.test.gts
@@ -1218,7 +1218,7 @@ export function runTests() {
           assert.dom('[data-kanban-column="uncategorized"]').exists();
         });
 
-        test('issues appear in their priority column', async function (assert) {
+        test('cards are placed in their priority column; cards with no priority land in Uncategorized', async function (assert) {
           await visitOperatorMode({
             stacks: [[{ id: boardId, format: 'isolated' }]],
           });
@@ -1230,19 +1230,9 @@ export function runTests() {
           assert
             .dom('[data-kanban-column="medium"] [data-test-issue-id]')
             .hasText('IT-2', 'IT-2 is in the medium column');
-        });
-
-        test('issue with no priority is placed in an Uncategorized column', async function (assert) {
-          await visitOperatorMode({
-            stacks: [[{ id: boardId, format: 'isolated' }]],
-          });
-          await waitFor('[data-test-issue-id]');
-
           assert
             .dom('[data-kanban-column="uncategorized"]')
-            .exists(
-              'an Uncategorized column is added for cards with no matching field value',
-            );
+            .exists('Uncategorized column appears for cards with no priority');
           assert
             .dom('[data-kanban-column="uncategorized"] [data-test-issue-id]')
             .hasText(
@@ -1365,11 +1355,11 @@ export function runTests() {
           });
         });
 
-        test('columns are the six issue type options', async function (assert) {
+        test('six issue-type columns are rendered and cards appear in the correct column', async function (assert) {
           await visitOperatorMode({
             stacks: [[{ id: boardId, format: 'isolated' }]],
           });
-          await waitFor('[data-kanban-column]');
+          await waitFor('[data-test-issue-id]');
 
           assert
             .dom('[data-kanban-column]')
@@ -1380,14 +1370,6 @@ export function runTests() {
           assert.dom('[data-kanban-column="task"]').exists();
           assert.dom('[data-kanban-column="research"]').exists();
           assert.dom('[data-kanban-column="infrastructure"]').exists();
-        });
-
-        test('issues appear in their type column', async function (assert) {
-          await visitOperatorMode({
-            stacks: [[{ id: boardId, format: 'isolated' }]],
-          });
-          await waitFor('[data-test-issue-id]');
-
           assert
             .dom('[data-kanban-column="feature"] [data-test-issue-id]')
             .hasText('IT-1', 'IT-1 is in the feature column');
@@ -1431,7 +1413,7 @@ export function runTests() {
           assert.dom('[data-test-group-by-option="issueType"]').exists();
         });
 
-        test('switching to priority grouping shows priority columns and re-places cards', async function (assert) {
+        test('switching group-by re-renders columns and re-places cards', async function (assert) {
           await visitOperatorMode({
             stacks: [[{ id: boardId, format: 'isolated' }]],
           });
@@ -1446,27 +1428,17 @@ export function runTests() {
 
           assert
             .dom('[data-kanban-column="backlog"]')
-            .doesNotExist('status columns gone after switching');
-          assert
-            .dom('[data-kanban-column="high"]')
-            .exists('priority column visible');
+            .doesNotExist('status columns gone after switching to priority');
           assert
             .dom('[data-kanban-column="high"] [data-test-issue-id]')
             .hasText('IT-1', 'IT-1 placed in high priority column');
-        });
-
-        test('switching to issueType grouping shows type columns', async function (assert) {
-          await visitOperatorMode({
-            stacks: [[{ id: boardId, format: 'isolated' }]],
-          });
-          await waitFor('[data-kanban-column]');
 
           await selectGroupBy('issueType');
           await settled();
 
           assert
-            .dom('[data-kanban-column="feature"]')
-            .exists('feature column visible');
+            .dom('[data-kanban-column="high"]')
+            .doesNotExist('priority columns gone after switching to issueType');
           assert
             .dom('[data-kanban-column="feature"] [data-test-issue-id]')
             .hasText('IT-1', 'IT-1 placed in feature type column');


### PR DESCRIPTION
"Group by" dropdown:
<img width="1037" height="419" alt="group-by" src="https://github.com/user-attachments/assets/0b2ed244-409a-4295-a243-1d583af2f38a" />

## Summary
Adds a `groupBy` field to `IssueTracker` (status / priority / issueType) with a `BoxelSelect` dropdown in the board toolbar to switch between them. The board columns and card placements re-derive from the chosen field on every render.

### Key details:
- Cards with no value for the active groupBy field land in a synthetic Uncategorized column (never stored in `model.columns`); alternatively a `groupByFallbackKey` can be set to route them to an existing column instead
- Uncategorized is excluded from the column-config sidebar but can still be collapsed/revealed via the column header button
- Hide-empty carries over correctly when switching groupBy — empty columns in the new grouping are collapsed immediately
- Column config sidebar (rename, recolor, WIP limit, reorder, collapse) works for all groupBy options, not just status
`handleColumnsChange` filters out the synthetic Uncategorized column before persisting so storedMatchesCurrent stays valid across renders
- Full acceptance test coverage across all new behaviors