### PR TITLE
ci: Add staging deployment cancellation

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -18,6 +18,19 @@ permissions:
   deployments: write
   id-token: write
 
+# Serialize deploys per environment so overlapping runs can't land out of
+# order. A deploy is a ~50-60 min serial chain that ends by pointing each ECS
+# service at a :<git-sha> image; when two runs overlap, whichever finishes last
+# wins, so an older commit's build can overwrite a newer one. For staging
+# (auto-deployed on every merge to main) we cancel any in-flight deploy when a
+# newer one starts, so the newest commit always wins — the superseding run is a
+# full deploy of every service, so it reconciles any partially-updated state
+# left by the cancelled run. For production (manual only) we queue instead of
+# cancel, to avoid interrupting a deliberate deploy mid-chain.
+concurrency:
+  group: deploy-${{ inputs.environment }}
+  cancel-in-progress: ${{ inputs.environment != 'production' }}
+
 jobs:
   create-deployment:
     name: Create GitHub deployment

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -25,8 +25,11 @@ permissions:
 # (auto-deployed on every merge to main) we cancel any in-flight deploy when a
 # newer one starts, so the newest commit always wins — the superseding run is a
 # full deploy of every service, so it reconciles any partially-updated state
-# left by the cancelled run. For production (manual only) we queue instead of
-# cancel, to avoid interrupting a deliberate deploy mid-chain.
+# left by the cancelled run. Every other environment — production (manual only),
+# and any value we don't explicitly recognize — queues instead of cancelling, to
+# avoid interrupting a deliberate deploy mid-chain. Cancelling is opt-in per
+# environment (== 'staging') rather than opt-out (!= 'production') so an
+# unexpected env errs toward the safe behavior (queue), not the risky one.
 #
 # The environment is read with a fallback: `inputs.environment` for the
 # workflow_call path (merge-to-main auto deploy), then
@@ -38,7 +41,7 @@ permissions:
 # non-empty and matches every caller's default.
 concurrency:
   group: deploy-${{ inputs.environment || github.event.inputs.environment || 'staging' }}
-  cancel-in-progress: ${{ (inputs.environment || github.event.inputs.environment || 'staging') != 'production' }}
+  cancel-in-progress: ${{ (inputs.environment || github.event.inputs.environment || 'staging') == 'staging' }}
 
 jobs:
   create-deployment:

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -27,9 +27,18 @@ permissions:
 # full deploy of every service, so it reconciles any partially-updated state
 # left by the cancelled run. For production (manual only) we queue instead of
 # cancel, to avoid interrupting a deliberate deploy mid-chain.
+#
+# The environment is read with a fallback: `inputs.environment` for the
+# workflow_call path (merge-to-main auto deploy), then
+# `github.event.inputs.environment` for the workflow_dispatch path. The
+# fallback is required because the `inputs` context is NOT populated in a
+# workflow-level concurrency expression for workflow_dispatch — without it a
+# manual deploy would land in an empty-env group with cancel-in-progress
+# silently defaulting to false. The trailing 'staging' default keeps the group
+# non-empty and matches every caller's default.
 concurrency:
-  group: deploy-${{ inputs.environment }}
-  cancel-in-progress: ${{ inputs.environment != 'production' }}
+  group: deploy-${{ inputs.environment || github.event.inputs.environment || 'staging' }}
+  cancel-in-progress: ${{ (inputs.environment || github.event.inputs.environment || 'staging') != 'production' }}
 
 jobs:
   create-deployment:


### PR DESCRIPTION
Since we deploy to staging with every merge to `main` and the workflow can take up to an hour to complete, we have two problems:
* wasted CI time on deployments that will soon be superseded
* race conditions that can result in services running off older code

Regarding the second point, analysis of realm server ECS task deployments shows example times older merges clobbered newer ones:
* #4996 was merged 9s after #4998 but the latter won for ≈9m until the next deployment completed 
* #5019 was merged 39s after #4993 but the latter won for ≈2.5h