### PR TITLE
Show the broken-link placeholder live when a linked card is deleted in the same session

### DIFF
--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -784,8 +784,23 @@ export default class StoreService extends Service implements StoreInterface {
       // the card isn't actually saved yet, so do nothing
       return;
     }
+    // Snapshot the consumers BEFORE removing the deleted instance from the
+    // store, then rewrite each consumer's slot to a link-not-found sentinel so
+    // the placeholder render takes over without a navigation. This is the same
+    // rewrite the realm-invalidation path performs when a delete originates
+    // elsewhere — but that path keys off the deleted id still being loaded when
+    // its invalidation event arrives, and the eager eviction below removes it
+    // first. So for a delete initiated in this session the invalidation handler
+    // has nothing to reload, and without this the consumer's render stays stale
+    // on the now-orphaned card object until a reload.
+    let api = await this.cardService.getAPI();
+    let instance = this.store.getCard(id);
+    let consumers = instance ? this.store.consumersOf(api, instance) : [];
     this.unsubscribeFromInstance(id);
     this.store.delete(id);
+    for (let consumer of consumers) {
+      api.notifyLinksToTargetDeleted(consumer, id);
+    }
     await this.cardService.fetchJSON(id, { method: 'DELETE' });
   }
 

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -793,13 +793,16 @@ export default class StoreService extends Service implements StoreInterface {
     // first. So for a delete initiated in this session the invalidation handler
     // has nothing to reload, and without this the consumer's render stays stale
     // on the now-orphaned card object until a reload.
-    let api = await this.cardService.getAPI();
     let instance = this.store.getCard(id);
-    let consumers = instance ? this.store.consumersOf(api, instance) : [];
+    let api = instance ? await this.cardService.getAPI() : undefined;
+    let consumers =
+      api && instance ? this.store.consumersOf(api, instance) : [];
     this.unsubscribeFromInstance(id);
     this.store.delete(id);
-    for (let consumer of consumers) {
-      api.notifyLinksToTargetDeleted(consumer, id);
+    if (api) {
+      for (let consumer of consumers) {
+        api.notifyLinksToTargetDeleted(consumer, id);
+      }
     }
     await this.cardService.fetchJSON(id, { method: 'DELETE' });
   }

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -5,6 +5,7 @@ import {
   waitFor,
   click,
   typeIn,
+  settled,
 } from '@ember/test-helpers';
 
 import GlimmerComponent from '@glimmer/component';
@@ -337,6 +338,96 @@ module('Integration | Store', function (hooks) {
 
     let file = await testRealmAdapter.openFile(`Person/boris.json`);
     assert.strictEqual(file, undefined, 'delete() removes the remote card');
+  });
+
+  test('deleting a linked target rewrites a loaded consumer linksTo slot to a broken-link sentinel', async function (assert) {
+    // Load the consumer and the target, then link them so the consumer holds
+    // the target as a resolved (present) link — the state a user is looking at
+    // when they delete the linked card. The delete must flip that slot to a
+    // broken-link sentinel in place, so the placeholder render takes over
+    // without a reload. (delete() evicts the target from the store before its
+    // own invalidation event arrives, so the realm-event reload path never
+    // sees it; the rewrite has to happen here.)
+    storeService.addReference(`${testRealmURL}Person/hassan`);
+    storeService.addReference(`${testRealmURL}Person/boris`);
+    await storeService.flush();
+    let hassan = storeService.peek(
+      `${testRealmURL}Person/hassan`,
+    ) as CardDefType;
+    let boris = storeService.peek(`${testRealmURL}Person/boris`) as CardDefType;
+    (hassan as any).bestFriend = boris;
+    await settled();
+
+    assert.strictEqual(
+      (api.getRelationship(hassan, 'bestFriend') as CardAPI.RelationshipState)
+        .kind,
+      'present',
+      'the consumer link resolves to the target before the delete',
+    );
+
+    await storeService.delete(`${testRealmURL}Person/boris`);
+
+    let after = api.getRelationship(
+      hassan,
+      'bestFriend',
+    ) as CardAPI.RelationshipState;
+    assert.strictEqual(
+      after.kind,
+      'not-found',
+      'deleting the target rewrites the consumer slot to a broken-link sentinel without a reload',
+    );
+    assert.strictEqual(
+      after.reference,
+      `${testRealmURL}Person/boris`,
+      'the sentinel preserves the deleted target reference for the placeholder',
+    );
+  });
+
+  test('deleting a linked target rewrites only the matching element of a loaded consumer linksToMany slot', async function (assert) {
+    storeService.addReference(`${testRealmURL}Person/hassan`);
+    storeService.addReference(`${testRealmURL}Person/boris`);
+    storeService.addReference(`${testRealmURL}Person/jade`);
+    await storeService.flush();
+    let hassan = storeService.peek(
+      `${testRealmURL}Person/hassan`,
+    ) as CardDefType;
+    let boris = storeService.peek(`${testRealmURL}Person/boris`) as CardDefType;
+    let jade = storeService.peek(`${testRealmURL}Person/jade`) as CardDefType;
+    (hassan as any).friends = [jade, boris];
+    await settled();
+
+    let before = api.getRelationship(
+      hassan,
+      'friends',
+    ) as CardAPI.RelationshipState[];
+    assert.deepEqual(
+      before.map((s) => s.kind),
+      ['present', 'present'],
+      'both linksToMany elements resolve before the delete',
+    );
+
+    await storeService.delete(`${testRealmURL}Person/boris`);
+
+    let after = api.getRelationship(
+      hassan,
+      'friends',
+    ) as CardAPI.RelationshipState[];
+    let borisEntry = after.find(
+      (s) => s.reference === `${testRealmURL}Person/boris`,
+    );
+    let jadeEntry = after.find(
+      (s) => s.reference === `${testRealmURL}Person/jade`,
+    );
+    assert.strictEqual(
+      borisEntry?.kind,
+      'not-found',
+      'the deleted element becomes a broken-link sentinel',
+    );
+    assert.strictEqual(
+      jadeEntry?.kind,
+      'present',
+      'the surviving element is left untouched',
+    );
   });
 
   test('peekError returns the server state error when a stale instance exists', async function (assert) {


### PR DESCRIPTION
## Background and Goal

A card that links (`linksTo` / `linksToMany`) to another instance shows a broken-link placeholder once the target is gone. That already worked on a fresh load and when the target was deleted by another client — but not when the target was deleted in the *same* session: the consumer kept rendering the now-orphaned card object until a manual reload.

The goal is for the placeholder to take over live, with no reload.

## Where to start

- `packages/host/app/services/store.ts` — `Store.delete`. It evicts the target from the store immediately, so the realm-event reload path (which keys off the target still being loaded when its invalidation event arrives) never fires for a same-session delete. The fix snapshots the consumers before eviction and plants the `link-not-found` sentinel directly via `notifyLinksToTargetDeleted` — the same rewrite the realm-event path already performs for deletes that originate elsewhere.
- `packages/host/tests/integration/store-test.gts` — two regression tests: the singular `linksTo` case (the reported scenario) and the per-element `linksToMany` case, asserting the consumer's relationship flips to `not-found` after the delete while a sibling link is left untouched.

## Key decisions

- Reuse the existing `consumersOf` + `notifyLinksToTargetDeleted` machinery rather than touching deserialization. Re-deserializing the consumer does not help here: deserialization deliberately preserves an already-resolved link when the target isn't side-loaded, so the broken-link rewrite has to be driven explicitly at delete time.
- Guard for an unloaded target — when the deleted card isn't in the store there are no consumers to rewrite, so deleting a card that was never loaded is unaffected.
