### PR TITLE
ci: Add top-level cancel-in-progress

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -23,6 +23,10 @@ on:
       - "packages/observability/scripts/**"
   workflow_dispatch:
 
+concurrency:
+  group: ci-host-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -14,6 +14,10 @@ on:
     paths-ignore:
       - "packages/observability/**"
 
+concurrency:
+  group: ci-lint-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   checks: write
   contents: read

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   checks: write
   contents: read

--- a/.github/workflows/preview-host.yml
+++ b/.github/workflows/preview-host.yml
@@ -11,6 +11,10 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
 
+concurrency:
+  group: preview-host-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   issues: write


### PR DESCRIPTION
We have job-level concurrency cancellation for CI jobs, but cancellation doesn’t actually
occur until a job has started. Specifying a concurrency group for the entire workflow
will cancel redundant runs much earlier, which should help reduce the backlog.

You can see it worked when I pushed an empty commit:

<img width="2178" height="1764" alt="CleanShot 2026-06-01 at 16 28 35@2x" src="https://github.com/user-attachments/assets/d786978d-baf2-4882-a74d-e1cce175defe" />
