### PR TITLE
Can attach or select ImageFileDef in BrandGuide

### DIFF
--- a/packages/base/brand-guide.gts
+++ b/packages/base/brand-guide.gts
@@ -7,10 +7,12 @@ import {
   Component,
   CSSField,
   FieldDef,
+  ImageDef,
   StringField,
   contains,
   containsMany,
   field,
+  linksTo,
 } from './card-api';
 import ColorField from './color';
 import {
@@ -370,9 +372,39 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
                     </dl>
                   </div>
                 {{/if}}
+              {{else if (eq section.id 'brand-image-attachments')}}
+                <p class='brand-guide-vars-description'>Custom CSS variables for
+                  image attachments:</p>
+                <div class='brand-guide-vars-box brand-guide-custom-css-block'>
+                  <CopyButton
+                    class='brand-guide-custom-css-block-copy-button'
+                    @textToCopy={{this.brandImageAttachmentCssBlock}}
+                  />
+                  <dl class='brand-guide-vars'>
+                    {{#each this.brandImageAttachmentVarEntries as |entry|}}
+                      <dt class='var-row' data-test-brand-image-attachment-var>
+                        <code
+                          data-test-brand-image-attachment-varname
+                        >{{entry.varName}}</code>
+                      </dt>
+                      <dd
+                        class='var-row brand-image-attachment-var-dd'
+                        data-test-brand-image-attachment-url
+                      >
+                        <img
+                          src={{entry.url}}
+                          alt={{entry.altText}}
+                          class='brand-image-attachment-thumb-mini'
+                          data-test-brand-image-attachment-thumb
+                        />
+                        <code class='css-var-value'>url({{entry.url}})</code>
+                      </dd>
+                    {{/each}}
+                  </dl>
+                </div>
               {{else if (eq section.id 'custom-css')}}
-                <p class='brand-guide-vars-description'>These variables are
-                  custom css properties for usage by this theme only.</p>
+                <p class='brand-guide-vars-description'>These variables are all
+                  of the custom CSS properties for usage by this theme only.</p>
                 <div class='brand-guide-vars-box brand-guide-custom-css-block'>
                   <CopyButton
                     class='brand-guide-custom-css-block-copy-button'
@@ -407,6 +439,27 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
                           class='css-var-value'
                           data-test-brand-guide-css-var-value
                         >{{entry.value}}</code>
+                      </dd>
+                    {{/each}}
+                    {{#each this.brandImageAttachmentVarEntries as |entry|}}
+                      <dt
+                        class='var-row'
+                        data-test-brand-guide-image-attachment-var
+                      >
+                        <code
+                          data-test-brand-guide-image-attachment-varname
+                        >{{entry.varName}}</code>
+                      </dt>
+                      <dd
+                        class='var-row brand-image-attachment-var-dd'
+                        data-test-brand-guide-image-attachment-url
+                      >
+                        <img
+                          src={{entry.url}}
+                          alt={{entry.altText}}
+                          class='brand-image-attachment-thumb-mini'
+                        />
+                        <code class='css-var-value'>url({{entry.url}})</code>
                       </dd>
                     {{/each}}
                   </dl>
@@ -534,11 +587,13 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
         display: flex;
         flex-direction: column;
         gap: var(--boxel-sp-sm);
+        height: 100%;
       }
       .typography-preview {
         display: flex;
         align-items: center;
         justify-content: center;
+        flex: 1;
         min-height: 11.25rem;
         background-color: var(--muted, var(--boxel-100));
         color: var(--foreground, var(--boxel-dark));
@@ -693,7 +748,6 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
         grid-template-columns: max-content 1fr;
         gap: var(--boxel-sp-xs) var(--boxel-sp-lg);
         font-size: var(--boxel-font-size-sm);
-        align-items: baseline;
       }
       .brand-guide-vars dt {
         font-weight: 600;
@@ -737,6 +791,23 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
         color: var(--dsr-muted-fg);
       }
 
+      /* Attachments */
+      .brand-image-attachment-var-dd {
+        align-items: center;
+        gap: var(--boxel-sp-sm);
+        word-break: break-all;
+      }
+      .brand-image-attachment-thumb-mini {
+        width: 2.5rem;
+        height: 2.5rem;
+        object-fit: cover;
+        border-radius: var(--boxel-border-radius-sm);
+        flex-shrink: 0;
+        border: 1px solid var(--dsr-border);
+      }
+      .brand-image-attachment-vars {
+        align-items: center;
+      }
       /* Import CSS */
       .css-textarea {
         --boxel-input-height: 19rem;
@@ -827,11 +898,6 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
       title: 'Brand Palette',
     },
     {
-      id: 'custom-css',
-      navTitle: 'Custom CSS',
-      title: 'Custom CSS Variables',
-    },
-    {
       id: 'typography',
       navTitle: 'Typography',
       title: 'Typography',
@@ -842,6 +908,16 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
       navTitle: 'Mark Usage',
       title: 'Mark Usage',
       fieldName: 'markUsage',
+    },
+    {
+      id: 'brand-image-attachments',
+      navTitle: 'Image Attachments',
+      title: 'Image Attachments',
+    },
+    {
+      id: 'custom-css',
+      navTitle: 'Custom CSS',
+      title: 'Custom CSS Variables',
     },
     {
       id: 'ui-components',
@@ -865,6 +941,10 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
 
       if (section.id === 'custom-css') {
         return this.hasCustomVariables;
+      }
+
+      if (section.id === 'brand-image-attachments') {
+        return Boolean(this.brandImageAttachmentVarEntries.length);
       }
 
       if (section.id === 'brand-palette') {
@@ -916,6 +996,12 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
       }));
   }
 
+  private get brandImageAttachmentCssBlock() {
+    return this.brandImageAttachmentVarEntries
+      .map((entry) => `${entry.varName}: url(${entry.url});`)
+      .join('\n');
+  }
+
   private get customCssVarsBlock() {
     let lines: string[] = [];
     if (entriesToCssRuleMap && this.args.model?.brandColorPalette?.length) {
@@ -929,6 +1015,9 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
     }
     for (let cssVar of this.customCssVarEntries) {
       lines.push(`${cssVar.name}: ${cssVar.value};`);
+    }
+    for (let entry of this.brandImageAttachmentVarEntries) {
+      lines.push(`${entry.varName}: url(${entry.url});`);
     }
     return lines.join('\n');
   }
@@ -944,10 +1033,21 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
     }));
   }
 
+  private get brandImageAttachmentVarEntries() {
+    return (this.args.model?.brandImageAttachments ?? [])
+      .filter((item) => item.name?.trim() && item.image?.url)
+      .map((item) => ({
+        varName: buildCssVariableName(item.name!.trim()),
+        url: item.image!.url!,
+        altText: item.image!.name ?? '',
+      }));
+  }
+
   private get hasCustomVariables() {
     return Boolean(
       this.args.model?.brandColorPalette?.length ||
-      this.customCssVarEntries.length,
+      this.customCssVarEntries.length ||
+      this.brandImageAttachmentVarEntries.length,
     );
   }
 
@@ -1043,6 +1143,89 @@ export class CustomCssVariable extends FieldDef {
   };
 }
 
+export class CompoundImageField extends FieldDef {
+  static displayName = 'Named Image';
+  @field name = contains(StringField);
+  @field image = linksTo(() => ImageDef);
+
+  static embedded = class Embedded extends Component<
+    typeof CompoundImageField
+  > {
+    <template>
+      {{#if @model.image.url}}
+        <figure
+          class='brand-image-attachment-embedded'
+          data-test-brand-image-attachment
+        >
+          <img
+            src={{@model.image.url}}
+            alt={{@model.image.name}}
+            class='brand-image-attachment-thumb'
+            data-test-brand-image-attachment-thumb
+          />
+          {{#if @model.name}}
+            <figcaption
+              class='brand-image-attachment-varname'
+              data-test-brand-image-attachment-varname
+            >
+              <code>{{buildCssVariableName @model.name}}</code>
+            </figcaption>
+          {{/if}}
+        </figure>
+      {{/if}}
+      <style scoped>
+        .brand-image-attachment-embedded {
+          margin: 0;
+          border-radius: var(--boxel-border-radius);
+          overflow: hidden;
+          background-color: var(--dsr-card);
+          border: 1px solid var(--dsr-border);
+          display: flex;
+          flex-direction: column;
+        }
+        .brand-image-attachment-thumb {
+          width: 100%;
+          aspect-ratio: 16 / 10;
+          object-fit: cover;
+          display: block;
+        }
+        .brand-image-attachment-varname {
+          padding: var(--boxel-sp-xs) var(--boxel-sp-sm);
+          font-size: var(--boxel-font-size-xs);
+          color: var(--dsr-muted-fg);
+        }
+        .brand-image-attachment-varname code {
+          font-family: var(
+            --font-mono,
+            var(--boxel-monospace-font-family, monospace)
+          );
+          font-size: 0.9em;
+        }
+      </style>
+    </template>
+  };
+
+  static edit = class Edit extends Component<typeof CompoundImageField> {
+    <template>
+      <div class='brand-image-attachment-edit'>
+        <FieldContainer @label='Variable Name' @vertical={{true}}>
+          <@fields.name />
+        </FieldContainer>
+        <FieldContainer @label='Image' @vertical={{true}}>
+          <@fields.image />
+        </FieldContainer>
+      </div>
+      <style scoped>
+        .brand-image-attachment-edit {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: var(--boxel-sp-sm);
+        }
+      </style>
+    </template>
+  };
+}
+
 export default class BrandGuide extends DetailedStyleRef {
   static displayName = 'Brand Guide';
 
@@ -1090,6 +1273,15 @@ export default class BrandGuide extends DetailedStyleRef {
         }
         brandRules.set(name, value);
       }
+    }
+
+    // add brand image attachment variables as url() references
+    for (let item of this.brandImageAttachments ?? []) {
+      let name = item.name?.trim();
+      let url = item.image?.url;
+      if (!name || !url) continue;
+      let varName = buildCssVariableName(name);
+      if (!brandRules.has(varName)) brandRules.set(varName, `url(${url})`);
     }
 
     // add custom CSS variables
@@ -1167,10 +1359,11 @@ export default class BrandGuide extends DetailedStyleRef {
   }
 
   @field brandColorPalette = containsMany(CompoundColorField);
-  @field customCssVariables = containsMany(CustomCssVariable);
   @field functionalPalette = contains(BrandFunctionalPalette);
   @field typography = contains(ThemeTypographyField);
   @field markUsage = contains(BrandLogo);
+  @field brandImageAttachments = containsMany(CompoundImageField);
+  @field customCssVariables = containsMany(CustomCssVariable);
 
   // CSS Variables computed from field entries
   @field cssVariables = contains(CSSField, {
@@ -1198,6 +1391,10 @@ export default class BrandGuide extends DetailedStyleRef {
           [
             '--brand-secondary-mark-greyscale',
             toUrlValue(markMap?.get('--brand-secondary-mark-greyscale-1')),
+          ],
+          [
+            '--brand-social-media-profile-icon',
+            toUrlValue(markMap?.get('--brand-social-media-profile-icon')),
           ],
         ].filter(([, v]) => v) as [string, string][],
       );
@@ -1230,6 +1427,10 @@ export default class BrandGuide extends DetailedStyleRef {
               markMap?.get('--brand-secondary-mark-greyscale-2') ??
                 markMap?.get('--brand-secondary-mark-greyscale-1'),
             ),
+          ],
+          [
+            '--brand-social-media-profile-icon',
+            toUrlValue(markMap?.get('--brand-social-media-profile-icon')),
           ],
         ].filter(([, v]) => v) as [string, string][],
       );

--- a/packages/base/brand-logo.gts
+++ b/packages/base/brand-logo.gts
@@ -1,9 +1,18 @@
-import { FieldContainer, GridContainer } from '@cardstack/boxel-ui/components';
+import { on } from '@ember/modifier';
+import {
+  FieldContainer,
+  GridContainer,
+  Button,
+  BoxelInput,
+} from '@cardstack/boxel-ui/components';
 import {
   entriesToCssRuleMap,
   markdownEscape,
+  not,
   type CssRuleMap,
 } from '@cardstack/boxel-ui/helpers';
+
+import { chooseFile, identifyCard } from '@cardstack/runtime-common';
 
 import {
   field,
@@ -11,6 +20,7 @@ import {
   getFields,
   Component,
   FieldDef,
+  ImageDef,
   StringField,
   getFieldDescription,
 } from './card-api';
@@ -290,9 +300,109 @@ class Embedded extends Component<typeof BrandLogo> {
   </template>
 }
 
+class MarkFieldEdit extends Component<typeof MarkField> {
+  uploadImage = async () => {
+    let imageRef = identifyCard(ImageDef);
+    let file = await chooseFile(
+      imageRef ? { fileType: imageRef, fileTypeName: 'Image' } : undefined,
+    );
+    if (file?.url) {
+      this.args.set(file.url);
+    }
+  };
+
+  <template>
+    <div class='mark-field-edit'>
+      {{#if @model}}
+        <img
+          src={{@model}}
+          alt=''
+          class='mark-field-preview'
+          aria-hidden='true'
+        />
+      {{else}}
+        <div class='mark-field-preview mark-field-preview--empty' />
+      {{/if}}
+      <div class='mark-field-inputs'>
+        <BoxelInput
+          type='url'
+          value={{@model}}
+          @onInput={{@set}}
+          @disabled={{not @canEdit}}
+        />
+        {{#if @canEdit}}
+          <span class='mark-field-or'>or</span>
+          <Button
+            @kind='secondary'
+            @size='extra-small'
+            {{on 'click' this.uploadImage}}
+          >
+            Select Image
+          </Button>
+        {{/if}}
+      </div>
+    </div>
+    <style scoped>
+      .mark-field-edit {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: var(--boxel-sp-sm);
+      }
+      .mark-field-preview {
+        flex-shrink: 0;
+        width: 3rem;
+        height: 3rem;
+        object-fit: contain;
+        border-radius: var(--boxel-border-radius-sm);
+        border: 1px solid var(--border, var(--boxel-border-color));
+        background-color: var(--muted, var(--boxel-100));
+      }
+      .mark-field-preview--empty {
+        background-image: repeating-linear-gradient(
+          -45deg,
+          transparent,
+          transparent 3px,
+          color-mix(
+              in oklch,
+              var(--border, var(--boxel-border-color)) 50%,
+              transparent
+            )
+            3px,
+          color-mix(
+              in oklch,
+              var(--border, var(--boxel-border-color)) 50%,
+              transparent
+            )
+            4px
+        );
+      }
+      .mark-field-inputs {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: var(--boxel-sp-xs);
+      }
+      .mark-field-inputs :deep(input) {
+        flex: 1;
+        min-width: 0;
+      }
+      .mark-field-or {
+        flex-shrink: 0;
+        font-size: var(--boxel-font-size-xs);
+        color: var(--muted-foreground, var(--boxel-400));
+      }
+    </style>
+  </template>
+}
+
 export class MarkField extends URLField {
   static displayName = 'Mark URL';
-  static embedded = class Embedded extends Component<typeof this> {
+  static edit = MarkFieldEdit;
+
+  static embedded = class Embedded extends Component<typeof MarkField> {
     <template>
       <img
         class='mark-image'
@@ -423,8 +533,14 @@ export default class BrandLogo extends FieldDef {
       let pairs: { key: keyof typeof model; label: string }[] = [
         { key: 'primaryMark1', label: 'Primary mark (light)' },
         { key: 'primaryMark2', label: 'Primary mark (dark)' },
-        { key: 'primaryMarkGreyscale1', label: 'Primary mark greyscale (light)' },
-        { key: 'primaryMarkGreyscale2', label: 'Primary mark greyscale (dark)' },
+        {
+          key: 'primaryMarkGreyscale1',
+          label: 'Primary mark greyscale (light)',
+        },
+        {
+          key: 'primaryMarkGreyscale2',
+          label: 'Primary mark greyscale (dark)',
+        },
         { key: 'secondaryMark1', label: 'Secondary mark (light)' },
         { key: 'secondaryMark2', label: 'Secondary mark (dark)' },
         {
@@ -447,7 +563,10 @@ export default class BrandLogo extends FieldDef {
         return '';
       }
       return rows
-        .map(({ label, url }) => `- ${markdownEscape(label)}: ${markdownLink(url, url)}`)
+        .map(
+          ({ label, url }) =>
+            `- ${markdownEscape(label)}: ${markdownLink(url, url)}`,
+        )
         .join('\n');
     }
     <template>{{this.text}}</template>

--- a/packages/base/brand-logo.gts
+++ b/packages/base/brand-logo.gts
@@ -442,6 +442,109 @@ export class MarkField extends URLField {
   };
 }
 
+class BrandLogoEdit extends Component<typeof BrandLogo> {
+  <template>
+    <div class='brand-logo-edit'>
+
+      <section class='brand-logo-edit-section'>
+        <h4 class='brand-logo-edit-heading'>Primary Mark</h4>
+        <div class='brand-logo-edit-row brand-logo-edit-row--2col'>
+          <FieldContainer @label='Min Height' @vertical={{true}}>
+            <@fields.primaryMarkMinHeight />
+          </FieldContainer>
+          <FieldContainer @label='Clearance Ratio' @vertical={{true}}>
+            <@fields.primaryMarkClearanceRatio />
+          </FieldContainer>
+        </div>
+        <div class='brand-logo-edit-row brand-logo-edit-row--2col'>
+          <FieldContainer @label='Light Background' @vertical={{true}}>
+            <@fields.primaryMark1 />
+          </FieldContainer>
+          <FieldContainer @label='Dark Background' @vertical={{true}}>
+            <@fields.primaryMark2 />
+          </FieldContainer>
+        </div>
+        <div class='brand-logo-edit-row brand-logo-edit-row--2col'>
+          <FieldContainer @label='Greyscale — Light' @vertical={{true}}>
+            <@fields.primaryMarkGreyscale1 />
+          </FieldContainer>
+          <FieldContainer @label='Greyscale — Dark' @vertical={{true}}>
+            <@fields.primaryMarkGreyscale2 />
+          </FieldContainer>
+        </div>
+      </section>
+
+      <section class='brand-logo-edit-section'>
+        <h4 class='brand-logo-edit-heading'>Secondary Mark</h4>
+        <div class='brand-logo-edit-row brand-logo-edit-row--2col'>
+          <FieldContainer @label='Min Height' @vertical={{true}}>
+            <@fields.secondaryMarkMinHeight />
+          </FieldContainer>
+          <FieldContainer @label='Clearance Ratio' @vertical={{true}}>
+            <@fields.secondaryMarkClearanceRatio />
+          </FieldContainer>
+        </div>
+        <div class='brand-logo-edit-row brand-logo-edit-row--2col'>
+          <FieldContainer @label='Light Background' @vertical={{true}}>
+            <@fields.secondaryMark1 />
+          </FieldContainer>
+          <FieldContainer @label='Dark Background' @vertical={{true}}>
+            <@fields.secondaryMark2 />
+          </FieldContainer>
+        </div>
+        <div class='brand-logo-edit-row brand-logo-edit-row--2col'>
+          <FieldContainer @label='Greyscale — Light' @vertical={{true}}>
+            <@fields.secondaryMarkGreyscale1 />
+          </FieldContainer>
+          <FieldContainer @label='Greyscale — Dark' @vertical={{true}}>
+            <@fields.secondaryMarkGreyscale2 />
+          </FieldContainer>
+        </div>
+      </section>
+
+      <section class='brand-logo-edit-section'>
+        <h4 class='brand-logo-edit-heading'>Social Media Icon</h4>
+        <FieldContainer @label='Profile Icon' @vertical={{true}}>
+          <@fields.socialMediaProfileIcon />
+        </FieldContainer>
+      </section>
+
+    </div>
+    <style scoped>
+      .brand-logo-edit {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-lg);
+      }
+      .brand-logo-edit-section {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-sm);
+      }
+      .brand-logo-edit-heading {
+        margin: 0;
+        font-size: var(--boxel-font-size-sm);
+        font-weight: 600;
+        color: var(--muted-foreground, var(--boxel-400));
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        padding-bottom: var(--boxel-sp-xs);
+        border-bottom: 1px solid var(--border, var(--boxel-border-color));
+      }
+      .brand-logo-edit-row {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-sm);
+      }
+      .brand-logo-edit-row--2col {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--boxel-sp-sm);
+      }
+    </style>
+  </template>
+}
+
 export default class BrandLogo extends FieldDef {
   static displayName = 'Mark Usage';
 
@@ -519,6 +622,7 @@ export default class BrandLogo extends FieldDef {
     return entriesToCssRuleMap(this.cssVariableFields);
   }
 
+  static edit = BrandLogoEdit;
   static embedded = Embedded;
 
   // CS-10787: emit a bulleted list of the logo URLs that are actually

--- a/packages/base/brand-logo.gts
+++ b/packages/base/brand-logo.gts
@@ -4,6 +4,7 @@ import {
   GridContainer,
   Button,
   BoxelInput,
+  IconButton,
 } from '@cardstack/boxel-ui/components';
 import {
   entriesToCssRuleMap,
@@ -13,6 +14,7 @@ import {
 } from '@cardstack/boxel-ui/helpers';
 
 import { chooseFile, identifyCard } from '@cardstack/runtime-common';
+import XIcon from '@cardstack/boxel-icons/x';
 
 import {
   field,
@@ -30,7 +32,7 @@ import {
   type CssVariableField,
   type CssVariableFieldEntry,
 } from './structured-theme-variables';
-import URLField from './url';
+import URLField, { isValidUrl } from './url';
 
 class Embedded extends Component<typeof BrandLogo> {
   <template>
@@ -301,6 +303,14 @@ class Embedded extends Component<typeof BrandLogo> {
 }
 
 class MarkFieldEdit extends Component<typeof MarkField> {
+  get validationState() {
+    if (!this.args.model) {
+      // do not error before any input
+      return;
+    }
+    return isValidUrl(this.args.model) ? 'valid' : 'invalid';
+  }
+
   uploadImage = async () => {
     let imageRef = identifyCard(ImageDef);
     let file = await chooseFile(
@@ -311,36 +321,48 @@ class MarkFieldEdit extends Component<typeof MarkField> {
     }
   };
 
+  clearImage = () => {
+    this.args.set(null);
+  };
+
   <template>
     <div class='mark-field-edit'>
-      {{#if @model}}
-        <img
-          src={{@model}}
-          alt=''
-          class='mark-field-preview'
-          aria-hidden='true'
-        />
-      {{else}}
-        <div class='mark-field-preview mark-field-preview--empty' />
-      {{/if}}
       <div class='mark-field-inputs'>
         <BoxelInput
           type='url'
           value={{@model}}
           @onInput={{@set}}
           @disabled={{not @canEdit}}
+          @state={{this.validationState}}
+          data-test-mark-url-input
         />
+        {{#if @model}}
+          {{#if @canEdit}}
+            <IconButton
+              class='mark-field-clear'
+              @icon={{XIcon}}
+              @width='16px'
+              @height='16px'
+              aria-label='Clear image'
+              data-test-mark-clear
+              {{on 'click' this.clearImage}}
+            />
+          {{/if}}
+        {{/if}}
+      </div>
+      {{#unless @model}}
         {{#if @canEdit}}
           <span class='mark-field-or'>or</span>
           <Button
             @kind='secondary'
             @size='extra-small'
+            data-test-mark-select-image
             {{on 'click' this.uploadImage}}
           >
             Select Image
           </Button>
         {{/if}}
-      </div>
+      {{/unless}}
     </div>
     <style scoped>
       .mark-field-edit {
@@ -349,45 +371,31 @@ class MarkFieldEdit extends Component<typeof MarkField> {
         align-items: center;
         gap: var(--boxel-sp-sm);
       }
-      .mark-field-preview {
-        flex-shrink: 0;
-        width: 3rem;
-        height: 3rem;
-        object-fit: contain;
-        border-radius: var(--boxel-border-radius-sm);
-        border: 1px solid var(--border, var(--boxel-border-color));
-        background-color: var(--muted, var(--boxel-100));
-      }
-      .mark-field-preview--empty {
-        background-image: repeating-linear-gradient(
-          -45deg,
-          transparent,
-          transparent 3px,
-          color-mix(
-              in oklch,
-              var(--border, var(--boxel-border-color)) 50%,
-              transparent
-            )
-            3px,
-          color-mix(
-              in oklch,
-              var(--border, var(--boxel-border-color)) 50%,
-              transparent
-            )
-            4px
-        );
-      }
       .mark-field-inputs {
         flex: 1;
         min-width: 0;
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        gap: var(--boxel-sp-xs);
+        position: relative;
       }
       .mark-field-inputs :deep(input) {
-        flex: 1;
-        min-width: 0;
+        width: 100%;
+        padding-right: 2.5rem;
+      }
+      .mark-field-clear {
+        position: absolute;
+        top: 0;
+        right: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 2.5rem;
+        height: 100%;
+        opacity: 0.5;
+        z-index: 1;
+      }
+      .mark-field-clear:hover,
+      .mark-field-clear:focus {
+        opacity: 1;
+        outline: 0;
       }
       .mark-field-or {
         flex-shrink: 0;
@@ -449,26 +457,50 @@ class BrandLogoEdit extends Component<typeof BrandLogo> {
       <section class='brand-logo-edit-section'>
         <h4 class='brand-logo-edit-heading'>Primary Mark</h4>
         <div class='brand-logo-edit-row brand-logo-edit-row--2col'>
-          <FieldContainer @label='Min Height' @vertical={{true}}>
+          <FieldContainer
+            @label='Min Height'
+            @vertical={{true}}
+            data-test-field='primaryMarkMinHeight'
+          >
             <@fields.primaryMarkMinHeight />
           </FieldContainer>
-          <FieldContainer @label='Clearance Ratio' @vertical={{true}}>
+          <FieldContainer
+            @label='Clearance Ratio'
+            @vertical={{true}}
+            data-test-field='primaryMarkClearanceRatio'
+          >
             <@fields.primaryMarkClearanceRatio />
           </FieldContainer>
         </div>
         <div class='brand-logo-edit-row brand-logo-edit-row--2col'>
-          <FieldContainer @label='Light Background' @vertical={{true}}>
+          <FieldContainer
+            @label='Light Background'
+            @vertical={{true}}
+            data-test-field='primaryMark1'
+          >
             <@fields.primaryMark1 />
           </FieldContainer>
-          <FieldContainer @label='Dark Background' @vertical={{true}}>
+          <FieldContainer
+            @label='Dark Background'
+            @vertical={{true}}
+            data-test-field='primaryMark2'
+          >
             <@fields.primaryMark2 />
           </FieldContainer>
         </div>
         <div class='brand-logo-edit-row brand-logo-edit-row--2col'>
-          <FieldContainer @label='Greyscale — Light' @vertical={{true}}>
+          <FieldContainer
+            @label='Greyscale — Light'
+            @vertical={{true}}
+            data-test-field='primaryMarkGreyscale1'
+          >
             <@fields.primaryMarkGreyscale1 />
           </FieldContainer>
-          <FieldContainer @label='Greyscale — Dark' @vertical={{true}}>
+          <FieldContainer
+            @label='Greyscale — Dark'
+            @vertical={{true}}
+            data-test-field='primaryMarkGreyscale2'
+          >
             <@fields.primaryMarkGreyscale2 />
           </FieldContainer>
         </div>
@@ -477,26 +509,50 @@ class BrandLogoEdit extends Component<typeof BrandLogo> {
       <section class='brand-logo-edit-section'>
         <h4 class='brand-logo-edit-heading'>Secondary Mark</h4>
         <div class='brand-logo-edit-row brand-logo-edit-row--2col'>
-          <FieldContainer @label='Min Height' @vertical={{true}}>
+          <FieldContainer
+            @label='Min Height'
+            @vertical={{true}}
+            data-test-field='secondaryMarkMinHeight'
+          >
             <@fields.secondaryMarkMinHeight />
           </FieldContainer>
-          <FieldContainer @label='Clearance Ratio' @vertical={{true}}>
+          <FieldContainer
+            @label='Clearance Ratio'
+            @vertical={{true}}
+            data-test-field='secondaryMarkClearanceRatio'
+          >
             <@fields.secondaryMarkClearanceRatio />
           </FieldContainer>
         </div>
         <div class='brand-logo-edit-row brand-logo-edit-row--2col'>
-          <FieldContainer @label='Light Background' @vertical={{true}}>
+          <FieldContainer
+            @label='Light Background'
+            @vertical={{true}}
+            data-test-field='secondaryMark1'
+          >
             <@fields.secondaryMark1 />
           </FieldContainer>
-          <FieldContainer @label='Dark Background' @vertical={{true}}>
+          <FieldContainer
+            @label='Dark Background'
+            @vertical={{true}}
+            data-test-field='secondaryMark2'
+          >
             <@fields.secondaryMark2 />
           </FieldContainer>
         </div>
         <div class='brand-logo-edit-row brand-logo-edit-row--2col'>
-          <FieldContainer @label='Greyscale — Light' @vertical={{true}}>
+          <FieldContainer
+            @label='Greyscale — Light'
+            @vertical={{true}}
+            data-test-field='secondaryMarkGreyscale1'
+          >
             <@fields.secondaryMarkGreyscale1 />
           </FieldContainer>
-          <FieldContainer @label='Greyscale — Dark' @vertical={{true}}>
+          <FieldContainer
+            @label='Greyscale — Dark'
+            @vertical={{true}}
+            data-test-field='secondaryMarkGreyscale2'
+          >
             <@fields.secondaryMarkGreyscale2 />
           </FieldContainer>
         </div>
@@ -504,7 +560,11 @@ class BrandLogoEdit extends Component<typeof BrandLogo> {
 
       <section class='brand-logo-edit-section'>
         <h4 class='brand-logo-edit-heading'>Social Media Icon</h4>
-        <FieldContainer @label='Profile Icon' @vertical={{true}}>
+        <FieldContainer
+          @label='Profile Icon'
+          @vertical={{true}}
+          data-test-field='socialMediaProfileIcon'
+        >
           <@fields.socialMediaProfileIcon />
         </FieldContainer>
       </section>

--- a/packages/base/default-templates/theme-dashboard.gts
+++ b/packages/base/default-templates/theme-dashboard.gts
@@ -19,6 +19,8 @@ import {
 } from '@cardstack/boxel-ui/components';
 import { bool, cn } from '@cardstack/boxel-ui/helpers';
 
+import { DEFAULT_THEME_SCALE } from '../structured-theme-variables';
+
 function scrollToSection(sectionId: string, event: Event) {
   event.preventDefault();
   let navEl = event.currentTarget as HTMLElement;
@@ -146,9 +148,10 @@ export class CardContainerCss extends GlimmerComponent<{
   private get currentScale(): string {
     void this.args.cssVariables;
     let el = this.cardElement;
-    if (!el) return '1.333';
+    if (!el) return DEFAULT_THEME_SCALE;
     return (
-      getComputedStyle(el).getPropertyValue('--theme-scale').trim() || '1.333'
+      getComputedStyle(el).getPropertyValue('--theme-scale').trim() ||
+      DEFAULT_THEME_SCALE
     );
   }
 

--- a/packages/base/structured-theme-variables.gts
+++ b/packages/base/structured-theme-variables.gts
@@ -1,9 +1,14 @@
-import { CopyButton, Swatch } from '@cardstack/boxel-ui/components';
+import {
+  CopyButton,
+  FieldContainer,
+  Swatch,
+} from '@cardstack/boxel-ui/components';
 import {
   buildCssVariableName,
   dasherize,
   entriesToCssRuleMap,
   markdownEscape,
+  sanitizeHtmlSafe,
   type CssVariableEntry,
   type CssRuleMap,
 } from '@cardstack/boxel-ui/helpers';
@@ -36,12 +41,14 @@ export type CssVariableField = Record<string, any>;
 const COLOR_VALUE_INPUT_HELP =
   'Use CSS color values such as hex (#ff00ff), rgb(...), hsl(...), or okhcl(...).';
 
+export const DEFAULT_THEME_SCALE = '1.333';
+
 const TYPESCALE_OPTIONS = [
   { value: '1.067', label: 'Minor Second (1.067)' },
   { value: '1.125', label: 'Major Second (1.125)' },
   { value: '1.200', label: 'Minor Third (1.200)' },
   { value: '1.250', label: 'Major Third (1.250)' },
-  { value: '1.333', label: 'Perfect Fourth (1.333)' },
+  { value: DEFAULT_THEME_SCALE, label: 'Perfect Fourth (1.333)' },
   { value: '1.414', label: 'Augmented Fourth (1.414)' },
   { value: '1.500', label: 'Perfect Fifth (1.500)' },
   { value: '1.618', label: 'Golden Ratio (1.618)' },
@@ -161,9 +168,7 @@ export class ThemeTypographyField extends FieldDef {
       let rows: string[] = [];
       for (let { name, value } of entries) {
         if (!value) continue;
-        rows.push(
-          `- ${markdownEscape(name ?? '')}: \`${value}\``,
-        );
+        rows.push(`- ${markdownEscape(name ?? '')}: \`${value}\``);
       }
       return rows.join('\n');
     }
@@ -550,8 +555,7 @@ export default class ThemeVarField extends FieldDef {
   @field themeScale = contains(
     enumField(StringField, { options: TYPESCALE_OPTIONS }),
     {
-      description:
-        'Typescale ratio used to derive --boxel-fs-* (font-size) steps and --boxel-sp-* (spacing) steps from the base --boxel-font-size and --boxel-sp values, respectively (both default to 1rem - 16px). Scale defaults to Perfect Fourth (1.333).',
+      description: `Typescale ratio used to derive --boxel-fs-* (font-size) steps and --boxel-sp-* (spacing) steps from the base --boxel-font-size and --boxel-sp values, respectively (both default to 1rem - 16px). Scale defaults to Perfect Fourth (${DEFAULT_THEME_SCALE}).`,
     },
   );
   @field trackingNormal = contains(CSSValueField, {
@@ -685,6 +689,500 @@ export default class ThemeVarField extends FieldDef {
     }
     return entriesToCssRuleMap(this.cssVariableFields);
   }
+
+  static edit = class Edit extends Component<typeof ThemeVarField> {
+    private get fontSansStyle() {
+      let v = this.args.model.fontSans;
+      return v ? sanitizeHtmlSafe(`font-family: ${v}`) : undefined;
+    }
+    private get fontSerifStyle() {
+      let v = this.args.model.fontSerif;
+      return v ? sanitizeHtmlSafe(`font-family: ${v}`) : undefined;
+    }
+    private get fontMonoStyle() {
+      let v = this.args.model.fontMono;
+      return v ? sanitizeHtmlSafe(`font-family: ${v}`) : undefined;
+    }
+
+    private get typescaleSteps() {
+      let baseStr = this.args.model.themeFontSize;
+      let scaleStr = this.args.model.themeScale;
+      if (!baseStr && !scaleStr) return [];
+      let base = 1;
+      if (baseStr) {
+        let remMatch = baseStr.match(/^([\d.]+)rem$/);
+        let pxMatch = baseStr.match(/^([\d.]+)px$/);
+        if (remMatch) base = parseFloat(remMatch[1]);
+        else if (pxMatch) base = parseFloat(pxMatch[1]) / 16;
+      }
+      let scale = parseFloat(scaleStr ?? DEFAULT_THEME_SCALE);
+      return [
+        { label: '2xs', exp: -3 },
+        { label: 'xs', exp: -2 },
+        { label: 'sm', exp: -1 },
+        { label: 'base', exp: 0 },
+        { label: 'md', exp: 1 },
+        { label: 'lg', exp: 2 },
+        { label: 'xl', exp: 3 },
+        { label: '2xl', exp: 4 },
+      ].map(({ label, exp }) => {
+        let size = base * Math.pow(scale, exp);
+        return {
+          label,
+          remLabel: `${parseFloat(size.toFixed(2))}rem`,
+          pxLabel: `${parseFloat((size * 16).toFixed(2))}px`,
+          style: sanitizeHtmlSafe(`font-size: ${size.toFixed(3)}rem`),
+        };
+      });
+    }
+
+    private shadowStyle(value: string | undefined) {
+      return value ? sanitizeHtmlSafe(`box-shadow: ${value}`) : undefined;
+    }
+    private get shadows() {
+      let m = this.args.model;
+      return [
+        { label: '2xs', value: m.shadow2xs },
+        { label: 'xs', value: m.shadowXs },
+        { label: 'sm', value: m.shadowSm },
+        { label: 'Base', value: m.shadow },
+        { label: 'md', value: m.shadowMd },
+        { label: 'lg', value: m.shadowLg },
+        { label: 'xl', value: m.shadowXl },
+        { label: '2xl', value: m.shadow2xl },
+      ].filter((s) => s.value);
+    }
+
+    <template>
+      <div class='theme-var-edit'>
+
+        <section class='theme-var-edit-section'>
+          <h4 class='theme-var-edit-heading'>Main</h4>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Background' @vertical={{true}}>
+              <@fields.background />
+            </FieldContainer>
+            <FieldContainer @label='Foreground' @vertical={{true}}>
+              <@fields.foreground />
+            </FieldContainer>
+          </div>
+        </section>
+
+        <section class='theme-var-edit-section'>
+          <h4 class='theme-var-edit-heading'>Primary</h4>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Primary' @vertical={{true}}>
+              <@fields.primary />
+            </FieldContainer>
+            <FieldContainer @label='Primary Foreground' @vertical={{true}}>
+              <@fields.primaryForeground />
+            </FieldContainer>
+          </div>
+        </section>
+
+        <section class='theme-var-edit-section'>
+          <h4 class='theme-var-edit-heading'>Secondary & Accent</h4>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Secondary' @vertical={{true}}>
+              <@fields.secondary />
+            </FieldContainer>
+            <FieldContainer @label='Secondary Foreground' @vertical={{true}}>
+              <@fields.secondaryForeground />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Accent' @vertical={{true}}>
+              <@fields.accent />
+            </FieldContainer>
+            <FieldContainer @label='Accent Foreground' @vertical={{true}}>
+              <@fields.accentForeground />
+            </FieldContainer>
+          </div>
+        </section>
+
+        <section class='theme-var-edit-section'>
+          <h4 class='theme-var-edit-heading'>UI Components</h4>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Card' @vertical={{true}}>
+              <@fields.card />
+            </FieldContainer>
+            <FieldContainer @label='Card Foreground' @vertical={{true}}>
+              <@fields.cardForeground />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Popover' @vertical={{true}}>
+              <@fields.popover />
+            </FieldContainer>
+            <FieldContainer @label='Popover Foreground' @vertical={{true}}>
+              <@fields.popoverForeground />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Muted' @vertical={{true}}>
+              <@fields.muted />
+            </FieldContainer>
+            <FieldContainer @label='Muted Foreground' @vertical={{true}}>
+              <@fields.mutedForeground />
+            </FieldContainer>
+          </div>
+        </section>
+
+        <section class='theme-var-edit-section'>
+          <h4 class='theme-var-edit-heading'>Form & Feedback</h4>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Border' @vertical={{true}}>
+              <@fields.border />
+            </FieldContainer>
+            <FieldContainer @label='Input' @vertical={{true}}>
+              <@fields.input />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Ring' @vertical={{true}}>
+              <@fields.ring />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Destructive' @vertical={{true}}>
+              <@fields.destructive />
+            </FieldContainer>
+            <FieldContainer @label='Destructive Foreground' @vertical={{true}}>
+              <@fields.destructiveForeground />
+            </FieldContainer>
+          </div>
+        </section>
+
+        <section class='theme-var-edit-section'>
+          <h4 class='theme-var-edit-heading'>Chart Colors</h4>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Chart 1' @vertical={{true}}>
+              <@fields.chart1 />
+            </FieldContainer>
+            <FieldContainer @label='Chart 2' @vertical={{true}}>
+              <@fields.chart2 />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Chart 3' @vertical={{true}}>
+              <@fields.chart3 />
+            </FieldContainer>
+            <FieldContainer @label='Chart 4' @vertical={{true}}>
+              <@fields.chart4 />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Chart 5' @vertical={{true}}>
+              <@fields.chart5 />
+            </FieldContainer>
+          </div>
+        </section>
+
+        <section class='theme-var-edit-section'>
+          <h4 class='theme-var-edit-heading'>Sidebar</h4>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Sidebar' @vertical={{true}}>
+              <@fields.sidebar />
+            </FieldContainer>
+            <FieldContainer @label='Sidebar Foreground' @vertical={{true}}>
+              <@fields.sidebarForeground />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Sidebar Primary' @vertical={{true}}>
+              <@fields.sidebarPrimary />
+            </FieldContainer>
+            <FieldContainer
+              @label='Sidebar Primary Foreground'
+              @vertical={{true}}
+            >
+              <@fields.sidebarPrimaryForeground />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Sidebar Accent' @vertical={{true}}>
+              <@fields.sidebarAccent />
+            </FieldContainer>
+            <FieldContainer
+              @label='Sidebar Accent Foreground'
+              @vertical={{true}}
+            >
+              <@fields.sidebarAccentForeground />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Sidebar Border' @vertical={{true}}>
+              <@fields.sidebarBorder />
+            </FieldContainer>
+            <FieldContainer @label='Sidebar Ring' @vertical={{true}}>
+              <@fields.sidebarRing />
+            </FieldContainer>
+          </div>
+        </section>
+
+        <section class='theme-var-edit-section'>
+          <h4 class='theme-var-edit-heading'>Fonts</h4>
+          <p class='theme-var-edit-hint'>
+            Custom font family links must be added to the
+            <strong>CSS Imports</strong>
+            section (e.g. a Google Fonts url) before they will render correctly.
+          </p>
+          <div class='theme-var-font-previews'>
+            {{#if @model.fontSans}}
+              <div class='theme-var-font-preview' style={{this.fontSansStyle}}>
+                <span class='theme-var-font-label'>Sans-serif</span>
+                The quick brown fox
+              </div>
+            {{/if}}
+            {{#if @model.fontSerif}}
+              <div class='theme-var-font-preview' style={{this.fontSerifStyle}}>
+                <span class='theme-var-font-label'>Serif</span>
+                The quick brown fox
+              </div>
+            {{/if}}
+            {{#if @model.fontMono}}
+              <div
+                class='theme-var-font-preview theme-var-font-preview--mono'
+                style={{this.fontMonoStyle}}
+              >
+                <span class='theme-var-font-label'>Monospace</span>
+                const hello = "world"
+              </div>
+            {{/if}}
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Sans-serif' @vertical={{true}}>
+              <@fields.fontSans />
+            </FieldContainer>
+            <FieldContainer @label='Serif' @vertical={{true}}>
+              <@fields.fontSerif />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Monospace' @vertical={{true}}>
+              <@fields.fontMono />
+            </FieldContainer>
+          </div>
+        </section>
+
+        <section class='theme-var-edit-section'>
+          <h4 class='theme-var-edit-heading'>Geometry</h4>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Border Radius' @vertical={{true}}>
+              <@fields.radius />
+            </FieldContainer>
+            <FieldContainer @label='Spacing' @vertical={{true}}>
+              <@fields.spacing />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Base Font Size' @vertical={{true}}>
+              <@fields.themeFontSize />
+            </FieldContainer>
+            <FieldContainer @label='Typescale' @vertical={{true}}>
+              <@fields.themeScale />
+            </FieldContainer>
+          </div>
+          {{#if this.typescaleSteps.length}}
+            <div class='theme-var-typescale-preview'>
+              {{#each this.typescaleSteps as |step|}}
+                <div class='theme-var-typescale-step'>
+                  <span
+                    class='theme-var-typescale-sample'
+                    style={{step.style}}
+                  >Aa</span>
+                  <span class='theme-var-typescale-label'>{{step.label}}</span>
+                  <span
+                    class='theme-var-typescale-size'
+                  >{{step.remLabel}}</span>
+                  <span class='theme-var-typescale-size'>{{step.pxLabel}}</span>
+                </div>
+              {{/each}}
+            </div>
+          {{/if}}
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Letter Spacing' @vertical={{true}}>
+              <@fields.trackingNormal />
+            </FieldContainer>
+          </div>
+        </section>
+
+        <section class='theme-var-edit-section'>
+          <h4 class='theme-var-edit-heading'>Box Shadows</h4>
+          {{#if this.shadows.length}}
+            <div class='theme-var-shadow-previews'>
+              {{#each this.shadows as |s|}}
+                <div class='theme-var-shadow-preview'>
+                  <div
+                    class='theme-var-shadow-swatch'
+                    style={{this.shadowStyle s.value}}
+                  ></div>
+                  <span class='theme-var-shadow-label'>{{s.label}}</span>
+                </div>
+              {{/each}}
+            </div>
+          {{/if}}
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='2xs' @vertical={{true}}>
+              <@fields.shadow2xs />
+            </FieldContainer>
+            <FieldContainer @label='xs' @vertical={{true}}>
+              <@fields.shadowXs />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='sm' @vertical={{true}}>
+              <@fields.shadowSm />
+            </FieldContainer>
+            <FieldContainer @label='Base' @vertical={{true}}>
+              <@fields.shadow />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='md' @vertical={{true}}>
+              <@fields.shadowMd />
+            </FieldContainer>
+            <FieldContainer @label='lg' @vertical={{true}}>
+              <@fields.shadowLg />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='xl' @vertical={{true}}>
+              <@fields.shadowXl />
+            </FieldContainer>
+            <FieldContainer @label='2xl' @vertical={{true}}>
+              <@fields.shadow2xl />
+            </FieldContainer>
+          </div>
+        </section>
+
+      </div>
+      <style scoped>
+        .theme-var-edit {
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-lg);
+        }
+        .theme-var-edit-section {
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-sm);
+        }
+        .theme-var-edit-heading {
+          margin: 0;
+          font-size: var(--boxel-font-size-sm);
+          font-weight: 600;
+          color: var(--muted-foreground, var(--boxel-400));
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+          padding-bottom: var(--boxel-sp-xs);
+          border-bottom: 1px solid var(--border, var(--boxel-border-color));
+        }
+        .theme-var-edit-row {
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-sm);
+        }
+        .theme-var-edit-row--2col {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: var(--boxel-sp-sm);
+        }
+        .theme-var-edit-hint {
+          margin: 0;
+          font-size: var(--boxel-font-size-sm);
+          color: var(--muted-foreground, var(--boxel-400));
+        }
+        .theme-var-typescale-preview {
+          display: flex;
+          align-items: flex-end;
+          gap: var(--boxel-sp);
+          padding: var(--boxel-sp-sm) var(--boxel-sp);
+          background: var(--muted, var(--boxel-100));
+          border-radius: var(--boxel-border-radius-sm);
+          overflow-x: auto;
+        }
+        .theme-var-typescale-step {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: var(--boxel-sp-4xs);
+          flex-shrink: 0;
+        }
+        .theme-var-typescale-sample {
+          color: var(--foreground, var(--boxel-dark));
+          line-height: 1;
+        }
+        .theme-var-typescale-label {
+          font-size: var(--boxel-font-size-xs);
+          font-weight: 600;
+          color: var(--muted-foreground, var(--boxel-400));
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+        }
+        .theme-var-typescale-size {
+          font-size: var(--boxel-font-size-xs);
+          color: var(--muted-foreground, var(--boxel-400));
+          font-variant-numeric: tabular-nums;
+        }
+        .theme-var-shadow-previews {
+          display: flex;
+          flex-wrap: wrap;
+          gap: var(--boxel-sp-lg) var(--boxel-sp);
+          padding: var(--boxel-sp) var(--boxel-sp-sm);
+          background: var(--muted, var(--boxel-100));
+          border-radius: var(--boxel-border-radius-sm);
+        }
+        .theme-var-shadow-preview {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: var(--boxel-sp-xs);
+        }
+        .theme-var-shadow-swatch {
+          width: 2.5rem;
+          height: 2.5rem;
+          background: var(--card, var(--boxel-light));
+          border-radius: var(--boxel-border-radius-sm);
+        }
+        .theme-var-shadow-label {
+          font-size: var(--boxel-font-size-xs);
+          font-weight: 600;
+          color: var(--muted-foreground, var(--boxel-400));
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+        }
+        .theme-var-font-previews {
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-2xs);
+        }
+        .theme-var-font-preview {
+          display: flex;
+          align-items: baseline;
+          gap: var(--boxel-sp-sm);
+          padding: var(--boxel-sp-xs) var(--boxel-sp);
+          background: var(--muted, var(--boxel-100));
+          border-radius: var(--boxel-border-radius-sm);
+          color: var(--foreground, var(--boxel-dark));
+          font-size: 1rem;
+          word-break: break-word;
+        }
+        .theme-var-font-preview--mono {
+          font-size: 0.875rem;
+        }
+        .theme-var-font-label {
+          flex-shrink: 0;
+          font-size: var(--boxel-font-size-xs);
+          font-weight: 600;
+          color: var(--muted-foreground, var(--boxel-400));
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+          font-family: var(--boxel-font);
+        }
+      </style>
+    </template>
+  };
 
   static embedded: BaseDefComponent = Embedded;
 

--- a/packages/base/structured-theme-variables.gts
+++ b/packages/base/structured-theme-variables.gts
@@ -759,10 +759,10 @@ export default class ThemeVarField extends FieldDef {
         <section class='theme-var-edit-section'>
           <h4 class='theme-var-edit-heading'>Main</h4>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Background' @vertical={{true}}>
+            <FieldContainer @label='Background' @vertical={{true}} data-test-field='background'>
               <@fields.background />
             </FieldContainer>
-            <FieldContainer @label='Foreground' @vertical={{true}}>
+            <FieldContainer @label='Foreground' @vertical={{true}} data-test-field='foreground'>
               <@fields.foreground />
             </FieldContainer>
           </div>
@@ -771,10 +771,10 @@ export default class ThemeVarField extends FieldDef {
         <section class='theme-var-edit-section'>
           <h4 class='theme-var-edit-heading'>Primary</h4>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Primary' @vertical={{true}}>
+            <FieldContainer @label='Primary' @vertical={{true}} data-test-field='primary'>
               <@fields.primary />
             </FieldContainer>
-            <FieldContainer @label='Primary Foreground' @vertical={{true}}>
+            <FieldContainer @label='Primary Foreground' @vertical={{true}} data-test-field='primaryForeground'>
               <@fields.primaryForeground />
             </FieldContainer>
           </div>
@@ -783,18 +783,18 @@ export default class ThemeVarField extends FieldDef {
         <section class='theme-var-edit-section'>
           <h4 class='theme-var-edit-heading'>Secondary & Accent</h4>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Secondary' @vertical={{true}}>
+            <FieldContainer @label='Secondary' @vertical={{true}} data-test-field='secondary'>
               <@fields.secondary />
             </FieldContainer>
-            <FieldContainer @label='Secondary Foreground' @vertical={{true}}>
+            <FieldContainer @label='Secondary Foreground' @vertical={{true}} data-test-field='secondaryForeground'>
               <@fields.secondaryForeground />
             </FieldContainer>
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Accent' @vertical={{true}}>
+            <FieldContainer @label='Accent' @vertical={{true}} data-test-field='accent'>
               <@fields.accent />
             </FieldContainer>
-            <FieldContainer @label='Accent Foreground' @vertical={{true}}>
+            <FieldContainer @label='Accent Foreground' @vertical={{true}} data-test-field='accentForeground'>
               <@fields.accentForeground />
             </FieldContainer>
           </div>
@@ -803,26 +803,26 @@ export default class ThemeVarField extends FieldDef {
         <section class='theme-var-edit-section'>
           <h4 class='theme-var-edit-heading'>UI Components</h4>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Card' @vertical={{true}}>
+            <FieldContainer @label='Card' @vertical={{true}} data-test-field='card'>
               <@fields.card />
             </FieldContainer>
-            <FieldContainer @label='Card Foreground' @vertical={{true}}>
+            <FieldContainer @label='Card Foreground' @vertical={{true}} data-test-field='cardForeground'>
               <@fields.cardForeground />
             </FieldContainer>
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Popover' @vertical={{true}}>
+            <FieldContainer @label='Popover' @vertical={{true}} data-test-field='popover'>
               <@fields.popover />
             </FieldContainer>
-            <FieldContainer @label='Popover Foreground' @vertical={{true}}>
+            <FieldContainer @label='Popover Foreground' @vertical={{true}} data-test-field='popoverForeground'>
               <@fields.popoverForeground />
             </FieldContainer>
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Muted' @vertical={{true}}>
+            <FieldContainer @label='Muted' @vertical={{true}} data-test-field='muted'>
               <@fields.muted />
             </FieldContainer>
-            <FieldContainer @label='Muted Foreground' @vertical={{true}}>
+            <FieldContainer @label='Muted Foreground' @vertical={{true}} data-test-field='mutedForeground'>
               <@fields.mutedForeground />
             </FieldContainer>
           </div>
@@ -831,23 +831,23 @@ export default class ThemeVarField extends FieldDef {
         <section class='theme-var-edit-section'>
           <h4 class='theme-var-edit-heading'>Form & Feedback</h4>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Border' @vertical={{true}}>
+            <FieldContainer @label='Border' @vertical={{true}} data-test-field='border'>
               <@fields.border />
             </FieldContainer>
-            <FieldContainer @label='Input' @vertical={{true}}>
+            <FieldContainer @label='Input' @vertical={{true}} data-test-field='input'>
               <@fields.input />
             </FieldContainer>
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Ring' @vertical={{true}}>
+            <FieldContainer @label='Ring' @vertical={{true}} data-test-field='ring'>
               <@fields.ring />
             </FieldContainer>
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Destructive' @vertical={{true}}>
+            <FieldContainer @label='Destructive' @vertical={{true}} data-test-field='destructive'>
               <@fields.destructive />
             </FieldContainer>
-            <FieldContainer @label='Destructive Foreground' @vertical={{true}}>
+            <FieldContainer @label='Destructive Foreground' @vertical={{true}} data-test-field='destructiveForeground'>
               <@fields.destructiveForeground />
             </FieldContainer>
           </div>
@@ -856,23 +856,23 @@ export default class ThemeVarField extends FieldDef {
         <section class='theme-var-edit-section'>
           <h4 class='theme-var-edit-heading'>Chart Colors</h4>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Chart 1' @vertical={{true}}>
+            <FieldContainer @label='Chart 1' @vertical={{true}} data-test-field='chart1'>
               <@fields.chart1 />
             </FieldContainer>
-            <FieldContainer @label='Chart 2' @vertical={{true}}>
+            <FieldContainer @label='Chart 2' @vertical={{true}} data-test-field='chart2'>
               <@fields.chart2 />
             </FieldContainer>
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Chart 3' @vertical={{true}}>
+            <FieldContainer @label='Chart 3' @vertical={{true}} data-test-field='chart3'>
               <@fields.chart3 />
             </FieldContainer>
-            <FieldContainer @label='Chart 4' @vertical={{true}}>
+            <FieldContainer @label='Chart 4' @vertical={{true}} data-test-field='chart4'>
               <@fields.chart4 />
             </FieldContainer>
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Chart 5' @vertical={{true}}>
+            <FieldContainer @label='Chart 5' @vertical={{true}} data-test-field='chart5'>
               <@fields.chart5 />
             </FieldContainer>
           </div>
@@ -881,40 +881,42 @@ export default class ThemeVarField extends FieldDef {
         <section class='theme-var-edit-section'>
           <h4 class='theme-var-edit-heading'>Sidebar</h4>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Sidebar' @vertical={{true}}>
+            <FieldContainer @label='Sidebar' @vertical={{true}} data-test-field='sidebar'>
               <@fields.sidebar />
             </FieldContainer>
-            <FieldContainer @label='Sidebar Foreground' @vertical={{true}}>
+            <FieldContainer @label='Sidebar Foreground' @vertical={{true}} data-test-field='sidebarForeground'>
               <@fields.sidebarForeground />
             </FieldContainer>
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Sidebar Primary' @vertical={{true}}>
+            <FieldContainer @label='Sidebar Primary' @vertical={{true}} data-test-field='sidebarPrimary'>
               <@fields.sidebarPrimary />
             </FieldContainer>
             <FieldContainer
               @label='Sidebar Primary Foreground'
               @vertical={{true}}
+              data-test-field='sidebarPrimaryForeground'
             >
               <@fields.sidebarPrimaryForeground />
             </FieldContainer>
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Sidebar Accent' @vertical={{true}}>
+            <FieldContainer @label='Sidebar Accent' @vertical={{true}} data-test-field='sidebarAccent'>
               <@fields.sidebarAccent />
             </FieldContainer>
             <FieldContainer
               @label='Sidebar Accent Foreground'
               @vertical={{true}}
+              data-test-field='sidebarAccentForeground'
             >
               <@fields.sidebarAccentForeground />
             </FieldContainer>
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Sidebar Border' @vertical={{true}}>
+            <FieldContainer @label='Sidebar Border' @vertical={{true}} data-test-field='sidebarBorder'>
               <@fields.sidebarBorder />
             </FieldContainer>
-            <FieldContainer @label='Sidebar Ring' @vertical={{true}}>
+            <FieldContainer @label='Sidebar Ring' @vertical={{true}} data-test-field='sidebarRing'>
               <@fields.sidebarRing />
             </FieldContainer>
           </div>
@@ -951,15 +953,15 @@ export default class ThemeVarField extends FieldDef {
             {{/if}}
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Sans-serif' @vertical={{true}}>
+            <FieldContainer @label='Sans-serif' @vertical={{true}} data-test-field='fontSans'>
               <@fields.fontSans />
             </FieldContainer>
-            <FieldContainer @label='Serif' @vertical={{true}}>
+            <FieldContainer @label='Serif' @vertical={{true}} data-test-field='fontSerif'>
               <@fields.fontSerif />
             </FieldContainer>
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Monospace' @vertical={{true}}>
+            <FieldContainer @label='Monospace' @vertical={{true}} data-test-field='fontMono'>
               <@fields.fontMono />
             </FieldContainer>
           </div>
@@ -968,18 +970,18 @@ export default class ThemeVarField extends FieldDef {
         <section class='theme-var-edit-section'>
           <h4 class='theme-var-edit-heading'>Geometry</h4>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Border Radius' @vertical={{true}}>
+            <FieldContainer @label='Border Radius' @vertical={{true}} data-test-field='radius'>
               <@fields.radius />
             </FieldContainer>
-            <FieldContainer @label='Spacing' @vertical={{true}}>
+            <FieldContainer @label='Spacing' @vertical={{true}} data-test-field='spacing'>
               <@fields.spacing />
             </FieldContainer>
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Base Font Size' @vertical={{true}}>
+            <FieldContainer @label='Base Font Size' @vertical={{true}} data-test-field='themeFontSize'>
               <@fields.themeFontSize />
             </FieldContainer>
-            <FieldContainer @label='Typescale' @vertical={{true}}>
+            <FieldContainer @label='Typescale' @vertical={{true}} data-test-field='themeScale'>
               <@fields.themeScale />
             </FieldContainer>
           </div>
@@ -1001,7 +1003,7 @@ export default class ThemeVarField extends FieldDef {
             </div>
           {{/if}}
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='Letter Spacing' @vertical={{true}}>
+            <FieldContainer @label='Letter Spacing' @vertical={{true}} data-test-field='trackingNormal'>
               <@fields.trackingNormal />
             </FieldContainer>
           </div>
@@ -1023,34 +1025,34 @@ export default class ThemeVarField extends FieldDef {
             </div>
           {{/if}}
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='2xs' @vertical={{true}}>
+            <FieldContainer @label='2xs' @vertical={{true}} data-test-field='shadow2xs'>
               <@fields.shadow2xs />
             </FieldContainer>
-            <FieldContainer @label='xs' @vertical={{true}}>
+            <FieldContainer @label='xs' @vertical={{true}} data-test-field='shadowXs'>
               <@fields.shadowXs />
             </FieldContainer>
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='sm' @vertical={{true}}>
+            <FieldContainer @label='sm' @vertical={{true}} data-test-field='shadowSm'>
               <@fields.shadowSm />
             </FieldContainer>
-            <FieldContainer @label='Base' @vertical={{true}}>
+            <FieldContainer @label='Base' @vertical={{true}} data-test-field='shadow'>
               <@fields.shadow />
             </FieldContainer>
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='md' @vertical={{true}}>
+            <FieldContainer @label='md' @vertical={{true}} data-test-field='shadowMd'>
               <@fields.shadowMd />
             </FieldContainer>
-            <FieldContainer @label='lg' @vertical={{true}}>
+            <FieldContainer @label='lg' @vertical={{true}} data-test-field='shadowLg'>
               <@fields.shadowLg />
             </FieldContainer>
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
-            <FieldContainer @label='xl' @vertical={{true}}>
+            <FieldContainer @label='xl' @vertical={{true}} data-test-field='shadowXl'>
               <@fields.shadowXl />
             </FieldContainer>
-            <FieldContainer @label='2xl' @vertical={{true}}>
+            <FieldContainer @label='2xl' @vertical={{true}} data-test-field='shadow2xl'>
               <@fields.shadow2xl />
             </FieldContainer>
           </div>

--- a/packages/base/structured-theme-variables.gts
+++ b/packages/base/structured-theme-variables.gts
@@ -170,6 +170,61 @@ export class ThemeTypographyField extends FieldDef {
     <template>{{this.text}}</template>
   };
 
+  static edit = class Edit extends Component<typeof ThemeTypographyField> {
+    <template>
+      <div class='theme-typography-edit'>
+
+        <section class='theme-typography-edit-section'>
+          <h4 class='theme-typography-edit-heading'>Heading</h4>
+          <@fields.heading />
+        </section>
+
+        <section class='theme-typography-edit-section'>
+          <h4 class='theme-typography-edit-heading'>Section Heading</h4>
+          <@fields.sectionHeading />
+        </section>
+
+        <section class='theme-typography-edit-section'>
+          <h4 class='theme-typography-edit-heading'>Subheading</h4>
+          <@fields.subheading />
+        </section>
+
+        <section class='theme-typography-edit-section'>
+          <h4 class='theme-typography-edit-heading'>Body</h4>
+          <@fields.body />
+        </section>
+
+        <section class='theme-typography-edit-section'>
+          <h4 class='theme-typography-edit-heading'>Caption</h4>
+          <@fields.caption />
+        </section>
+
+      </div>
+      <style scoped>
+        .theme-typography-edit {
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-lg);
+        }
+        .theme-typography-edit-section {
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-sm);
+        }
+        .theme-typography-edit-heading {
+          margin: 0;
+          font-size: var(--boxel-font-size-sm);
+          font-weight: 600;
+          color: var(--muted-foreground, var(--boxel-400));
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+          padding-bottom: var(--boxel-sp-xs);
+          border-bottom: 1px solid var(--border, var(--boxel-border-color));
+        }
+      </style>
+    </template>
+  };
+
   static embedded = class Embedded extends Component<typeof this> {
     <template>
       <section class='theme-typography'>

--- a/packages/base/typography.gts
+++ b/packages/base/typography.gts
@@ -3,6 +3,7 @@ import {
   sanitizeHtmlSafe,
   type CssVariableEntry,
 } from '@cardstack/boxel-ui/helpers';
+import { FieldContainer } from '@cardstack/boxel-ui/components';
 
 import {
   field,
@@ -114,6 +115,76 @@ export default class TypographyField extends FieldDef {
       `${fontFamily} ${fontWeight ?? 'regular'}, ${fontSize ?? '14px'}`,
     );
   }
+
+  static edit = class Edit extends Component<typeof TypographyField> {
+    private get styles() {
+      let { fontFamily, fontSize, fontWeight, lineHeight } = this.args.model;
+      let styles = [];
+      if (fontFamily) styles.push(`font-family: ${fontFamily}`);
+      if (fontSize) styles.push(`font-size: ${fontSize}`);
+      if (fontWeight) styles.push(`font-weight: ${fontWeight}`);
+      if (lineHeight) styles.push(`line-height: ${lineHeight}`);
+      return sanitizeHtmlSafe(styles.join('; '));
+    }
+
+    <template>
+      <div class='typography-edit'>
+        <div class='typography-edit-preview' style={{this.styles}}>
+          {{#if @model.sampleText}}
+            {{@model.sampleText}}
+          {{else}}
+            The quick brown fox
+          {{/if}}
+        </div>
+        <div class='typography-edit-row typography-edit-row--2col'>
+          <FieldContainer @label='Font Family' @vertical={{true}}>
+            <@fields.fontFamily />
+          </FieldContainer>
+          <FieldContainer @label='Font Size' @vertical={{true}}>
+            <@fields.fontSize />
+          </FieldContainer>
+        </div>
+        <div class='typography-edit-row typography-edit-row--2col'>
+          <FieldContainer @label='Font Weight' @vertical={{true}}>
+            <@fields.fontWeight />
+          </FieldContainer>
+          <FieldContainer @label='Line Height' @vertical={{true}}>
+            <@fields.lineHeight />
+          </FieldContainer>
+        </div>
+        <FieldContainer @label='Sample Text' @vertical={{true}}>
+          <@fields.sampleText />
+        </FieldContainer>
+      </div>
+      <style scoped>
+        .typography-edit {
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-sm);
+        }
+        .typography-edit-preview {
+          padding: var(--boxel-sp-sm) var(--boxel-sp);
+          background: var(--muted, var(--boxel-100));
+          border-radius: var(--boxel-border-radius-sm);
+          color: var(--foreground, var(--boxel-dark));
+          min-height: 2.5rem;
+          display: flex;
+          align-items: center;
+          word-break: break-word;
+        }
+        .typography-edit-row {
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-sm);
+        }
+        .typography-edit-row--2col {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: var(--boxel-sp-sm);
+        }
+      </style>
+    </template>
+  };
 
   static embedded = TypographyEmbedded;
 

--- a/packages/base/url.gts
+++ b/packages/base/url.gts
@@ -65,7 +65,7 @@ export default class UrlField extends StringField {
   };
 }
 
-function isValidUrl(urlString: string): boolean {
+export function isValidUrl(urlString: string): boolean {
   try {
     new URL(urlString);
     return true;
@@ -79,8 +79,6 @@ export class CardWithURL extends CardDef {
   static displayName = 'Card with URL';
   @field url = contains(UrlField);
   static isolated = class Isolated extends Component<typeof CardWithURL> {
-    <template>
-      <@fields.url @format='atom' />
-    </template>
+    <template><@fields.url @format='atom' /></template>
   };
 }

--- a/packages/host/tests/integration/components/brand-guide-attachments-test.gts
+++ b/packages/host/tests/integration/components/brand-guide-attachments-test.gts
@@ -1,0 +1,186 @@
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { baseRealm, type Loader } from '@cardstack/runtime-common';
+
+import type * as BrandGuideModule from 'https://cardstack.com/base/brand-guide';
+import type * as CardApiModule from 'https://cardstack.com/base/card-api';
+
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { renderCard } from '../../helpers/render-component';
+import { setupRenderingTest } from '../../helpers/setup';
+
+module('Integration | brand-guide | brand image attachments', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+
+  let loader: Loader;
+  let BrandGuide: typeof BrandGuideModule.default;
+  let CompoundImageField: typeof BrandGuideModule.CompoundImageField;
+  let ImageDef: typeof CardApiModule.ImageDef;
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    loader = getService('loader-service').loader;
+    let brandGuideModule = await loader.import<typeof BrandGuideModule>(
+      `${baseRealm.url}brand-guide`,
+    );
+    let cardApiModule = await loader.import<typeof CardApiModule>(
+      `${baseRealm.url}card-api`,
+    );
+    BrandGuide = brandGuideModule.default;
+    CompoundImageField = brandGuideModule.CompoundImageField;
+    ImageDef = cardApiModule.ImageDef;
+  });
+
+  function makeImage(
+    ImageDefClass: typeof CardApiModule.ImageDef,
+    url: string,
+    name: string,
+  ) {
+    return new ImageDefClass({
+      id: url,
+      url,
+      sourceUrl: url,
+      name,
+      contentType: 'image/png',
+    });
+  }
+
+  // --- brand-image-attachments section ---
+
+  test('brand-image-attachments section appears when brand image attachments are present', async function (this: RenderingTestContext, assert) {
+    let image = makeImage(ImageDef, 'https://example.com/hero.png', 'hero.png');
+    let card = new BrandGuide({
+      brandImageAttachments: [
+        new CompoundImageField({ name: 'heroBanner', image }),
+      ],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    assert
+      .dom('[data-test-brand-guide-section="brand-image-attachments"]')
+      .exists('brand-image-attachments section appears');
+    assert
+      .dom('[data-test-brand-image-attachment-var]')
+      .exists({ count: 1 }, 'one row is rendered in the dedicated section');
+  });
+
+  test('brand image attachment row renders thumbnail, dasherized variable name, and url() value', async function (this: RenderingTestContext, assert) {
+    let image = makeImage(ImageDef, 'https://example.com/hero.png', 'hero.png');
+    let card = new BrandGuide({
+      brandImageAttachments: [
+        new CompoundImageField({ name: 'heroBanner', image }),
+      ],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    assert
+      .dom('[data-test-brand-image-attachment-thumb]')
+      .hasAttribute('src', 'https://example.com/hero.png', 'thumbnail src is correct');
+    assert
+      .dom('[data-test-brand-image-attachment-varname]')
+      .hasText('--hero-banner', 'camelCase name is dasherized and prefixed with --');
+    assert
+      .dom('[data-test-brand-image-attachment-url]')
+      .hasText('url(https://example.com/hero.png)', 'url() value is rendered in the dd cell');
+  });
+
+  test('brand image attachments without a url are not rendered in the dedicated section', async function (this: RenderingTestContext, assert) {
+    let card = new BrandGuide({
+      brandImageAttachments: [new CompoundImageField({ name: 'missing' })],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    assert
+      .dom('[data-test-brand-image-attachment-var]')
+      .doesNotExist('item with no image url is not rendered');
+  });
+
+  // --- custom-css section ---
+
+  test('custom-css section appears when only brand image attachments are present', async function (this: RenderingTestContext, assert) {
+    let image = makeImage(ImageDef, 'https://example.com/hero.png', 'hero.png');
+    let card = new BrandGuide({
+      brandImageAttachments: [
+        new CompoundImageField({ name: 'heroBanner', image }),
+      ],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    assert
+      .dom('[data-test-brand-guide-section="custom-css"]')
+      .exists('custom-css section appears when only brand image attachments are present');
+  });
+
+  test('brand image attachments appear in custom-css section with var name and url value', async function (this: RenderingTestContext, assert) {
+    let image = makeImage(ImageDef, 'https://example.com/hero.png', 'hero.png');
+    let card = new BrandGuide({
+      brandImageAttachments: [
+        new CompoundImageField({ name: 'heroBanner', image }),
+      ],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    assert
+      .dom('[data-test-brand-guide-image-attachment-var]')
+      .exists({ count: 1 }, 'one row appears in the custom-css section');
+    assert
+      .dom('[data-test-brand-guide-image-attachment-varname]')
+      .hasText('--hero-banner', 'var name is rendered in custom-css section');
+    assert
+      .dom('[data-test-brand-guide-image-attachment-url]')
+      .hasText('url(https://example.com/hero.png)', 'url() value is rendered in custom-css section');
+  });
+
+  test('brand image attachments without a url are excluded from custom-css section', async function (this: RenderingTestContext, assert) {
+    let card = new BrandGuide({
+      brandImageAttachments: [new CompoundImageField({ name: 'missing' })],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    assert
+      .dom('[data-test-brand-guide-section="custom-css"]')
+      .doesNotExist('custom-css section is hidden when all entries have no url');
+    assert
+      .dom('[data-test-brand-guide-image-attachment-var]')
+      .doesNotExist('no rows rendered for entries with no image url');
+  });
+
+  // --- CSS generation ---
+
+  test('brand image attachments produce url() CSS variables in cssVariables', async function (this: RenderingTestContext, assert) {
+    let image = makeImage(ImageDef, 'https://example.com/hero.png', 'hero.png');
+    let card = new BrandGuide({
+      brandImageAttachments: [
+        new CompoundImageField({ name: 'heroBanner', image }),
+      ],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    let css = card.cssVariables ?? '';
+    assert.ok(
+      css.includes('--hero-banner: url(https://example.com/hero.png)'),
+      'brand image attachment is emitted as a url() CSS variable',
+    );
+  });
+
+  test('brand image attachment with missing name or url is excluded from cssVariables', async function (this: RenderingTestContext, assert) {
+    let image = makeImage(ImageDef, 'https://example.com/hero.png', 'hero.png');
+    let card = new BrandGuide({
+      brandImageAttachments: [
+        new CompoundImageField({ name: '', image }),
+        new CompoundImageField({ name: 'noImage' }),
+      ],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    let css = card.cssVariables ?? '';
+    assert.notOk(
+      css.includes('url(https://example.com/hero.png)'),
+      'entry with empty name is excluded',
+    );
+    assert.notOk(css.includes('--no-image'), 'entry with no image is excluded');
+  });
+});

--- a/packages/host/tests/integration/components/brand-guide-attachments-test.gts
+++ b/packages/host/tests/integration/components/brand-guide-attachments-test.gts
@@ -50,7 +50,7 @@ module('Integration | brand-guide | brand image attachments', function (hooks) {
 
   // --- brand-image-attachments section ---
 
-  test('brand-image-attachments section appears when brand image attachments are present', async function (this: RenderingTestContext, assert) {
+  test('attachment row renders thumbnail, var name, and url value', async function (this: RenderingTestContext, assert) {
     let image = makeImage(ImageDef, 'https://example.com/hero.png', 'hero.png');
     let card = new BrandGuide({
       brandImageAttachments: [
@@ -59,23 +59,9 @@ module('Integration | brand-guide | brand image attachments', function (hooks) {
     });
     await renderCard(loader, card, 'isolated');
 
-    assert
-      .dom('[data-test-brand-guide-section="brand-image-attachments"]')
-      .exists('brand-image-attachments section appears');
     assert
       .dom('[data-test-brand-image-attachment-var]')
-      .exists({ count: 1 }, 'one row is rendered in the dedicated section');
-  });
-
-  test('brand image attachment row renders thumbnail, dasherized variable name, and url() value', async function (this: RenderingTestContext, assert) {
-    let image = makeImage(ImageDef, 'https://example.com/hero.png', 'hero.png');
-    let card = new BrandGuide({
-      brandImageAttachments: [
-        new CompoundImageField({ name: 'heroBanner', image }),
-      ],
-    });
-    await renderCard(loader, card, 'isolated');
-
+      .exists({ count: 1 }, 'one row is rendered');
     assert
       .dom('[data-test-brand-image-attachment-thumb]')
       .hasAttribute(
@@ -91,26 +77,12 @@ module('Integration | brand-guide | brand image attachments', function (hooks) {
       );
     assert
       .dom('[data-test-brand-image-attachment-url]')
-      .hasText(
-        'url(https://example.com/hero.png)',
-        'url() value is rendered in the dd cell',
-      );
-  });
-
-  test('brand image attachments without a url are not rendered in the dedicated section', async function (this: RenderingTestContext, assert) {
-    let card = new BrandGuide({
-      brandImageAttachments: [new CompoundImageField({ name: 'missing' })],
-    });
-    await renderCard(loader, card, 'isolated');
-
-    assert
-      .dom('[data-test-brand-image-attachment-var]')
-      .doesNotExist('item with no image url is not rendered');
+      .hasText('url(https://example.com/hero.png)', 'url() value is rendered');
   });
 
   // --- custom-css section ---
 
-  test('custom-css section appears when only brand image attachments are present', async function (this: RenderingTestContext, assert) {
+  test('attachment appears in custom-css section with var name and url value', async function (this: RenderingTestContext, assert) {
     let image = makeImage(ImageDef, 'https://example.com/hero.png', 'hero.png');
     let card = new BrandGuide({
       brandImageAttachments: [
@@ -121,20 +93,7 @@ module('Integration | brand-guide | brand image attachments', function (hooks) {
 
     assert
       .dom('[data-test-brand-guide-section="custom-css"]')
-      .exists(
-        'custom-css section appears when only brand image attachments are present',
-      );
-  });
-
-  test('brand image attachments appear in custom-css section with var name and url value', async function (this: RenderingTestContext, assert) {
-    let image = makeImage(ImageDef, 'https://example.com/hero.png', 'hero.png');
-    let card = new BrandGuide({
-      brandImageAttachments: [
-        new CompoundImageField({ name: 'heroBanner', image }),
-      ],
-    });
-    await renderCard(loader, card, 'isolated');
-
+      .exists('custom-css section appears');
     assert
       .dom('[data-test-brand-guide-image-attachment-var]')
       .exists({ count: 1 }, 'one row appears in the custom-css section');
@@ -149,12 +108,17 @@ module('Integration | brand-guide | brand image attachments', function (hooks) {
       );
   });
 
-  test('brand image attachments without a url are excluded from custom-css section', async function (this: RenderingTestContext, assert) {
+  test('attachments without a url are excluded from both sections', async function (this: RenderingTestContext, assert) {
     let card = new BrandGuide({
       brandImageAttachments: [new CompoundImageField({ name: 'missing' })],
     });
     await renderCard(loader, card, 'isolated');
 
+    assert
+      .dom('[data-test-brand-image-attachment-var]')
+      .doesNotExist(
+        'item with no url is not rendered in brand-image-attachments',
+      );
     assert
       .dom('[data-test-brand-guide-section="custom-css"]')
       .doesNotExist(
@@ -162,7 +126,7 @@ module('Integration | brand-guide | brand image attachments', function (hooks) {
       );
     assert
       .dom('[data-test-brand-guide-image-attachment-var]')
-      .doesNotExist('no rows rendered for entries with no image url');
+      .doesNotExist('no rows rendered in custom-css section');
   });
 
   // --- CSS generation ---

--- a/packages/host/tests/integration/components/brand-guide-attachments-test.gts
+++ b/packages/host/tests/integration/components/brand-guide-attachments-test.gts
@@ -78,13 +78,23 @@ module('Integration | brand-guide | brand image attachments', function (hooks) {
 
     assert
       .dom('[data-test-brand-image-attachment-thumb]')
-      .hasAttribute('src', 'https://example.com/hero.png', 'thumbnail src is correct');
+      .hasAttribute(
+        'src',
+        'https://example.com/hero.png',
+        'thumbnail src is correct',
+      );
     assert
       .dom('[data-test-brand-image-attachment-varname]')
-      .hasText('--hero-banner', 'camelCase name is dasherized and prefixed with --');
+      .hasText(
+        '--hero-banner',
+        'camelCase name is dasherized and prefixed with --',
+      );
     assert
       .dom('[data-test-brand-image-attachment-url]')
-      .hasText('url(https://example.com/hero.png)', 'url() value is rendered in the dd cell');
+      .hasText(
+        'url(https://example.com/hero.png)',
+        'url() value is rendered in the dd cell',
+      );
   });
 
   test('brand image attachments without a url are not rendered in the dedicated section', async function (this: RenderingTestContext, assert) {
@@ -111,7 +121,9 @@ module('Integration | brand-guide | brand image attachments', function (hooks) {
 
     assert
       .dom('[data-test-brand-guide-section="custom-css"]')
-      .exists('custom-css section appears when only brand image attachments are present');
+      .exists(
+        'custom-css section appears when only brand image attachments are present',
+      );
   });
 
   test('brand image attachments appear in custom-css section with var name and url value', async function (this: RenderingTestContext, assert) {
@@ -131,7 +143,10 @@ module('Integration | brand-guide | brand image attachments', function (hooks) {
       .hasText('--hero-banner', 'var name is rendered in custom-css section');
     assert
       .dom('[data-test-brand-guide-image-attachment-url]')
-      .hasText('url(https://example.com/hero.png)', 'url() value is rendered in custom-css section');
+      .hasText(
+        'url(https://example.com/hero.png)',
+        'url() value is rendered in custom-css section',
+      );
   });
 
   test('brand image attachments without a url are excluded from custom-css section', async function (this: RenderingTestContext, assert) {
@@ -142,7 +157,9 @@ module('Integration | brand-guide | brand image attachments', function (hooks) {
 
     assert
       .dom('[data-test-brand-guide-section="custom-css"]')
-      .doesNotExist('custom-css section is hidden when all entries have no url');
+      .doesNotExist(
+        'custom-css section is hidden when all entries have no url',
+      );
     assert
       .dom('[data-test-brand-guide-image-attachment-var]')
       .doesNotExist('no rows rendered for entries with no image url');

--- a/packages/host/tests/integration/components/brand-logo-mark-field-test.gts
+++ b/packages/host/tests/integration/components/brand-logo-mark-field-test.gts
@@ -1,0 +1,160 @@
+import type { RenderingTestContext } from '@ember/test-helpers';
+import { click, fillIn } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { baseRealm, type Loader } from '@cardstack/runtime-common';
+
+import type * as BrandLogoModule from 'https://cardstack.com/base/brand-logo';
+import type * as CardApiModule from 'https://cardstack.com/base/card-api';
+
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { renderCard } from '../../helpers/render-component';
+import { setupRenderingTest } from '../../helpers/setup';
+
+module('Integration | brand-logo | MarkField edit', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+
+  let loader: Loader;
+  let MarkField: typeof BrandLogoModule.MarkField;
+  let BrandLogo: typeof BrandLogoModule.default;
+  let ImageDef: typeof CardApiModule.ImageDef;
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    loader = getService('loader-service').loader;
+    let brandLogoModule = await loader.import<typeof BrandLogoModule>(
+      `${baseRealm.url}brand-logo`,
+    );
+    let cardApiModule = await loader.import<typeof CardApiModule>(
+      `${baseRealm.url}card-api`,
+    );
+    MarkField = brandLogoModule.MarkField;
+    BrandLogo = brandLogoModule.default;
+    ImageDef = cardApiModule.ImageDef;
+  });
+
+  hooks.afterEach(function () {
+    delete (globalThis as any)._CARDSTACK_FILE_CHOOSER;
+  });
+
+  function stubFileChooser(file: CardApiModule.ImageDef) {
+    (globalThis as any)._CARDSTACK_FILE_CHOOSER = {
+      async chooseFile() {
+        return file;
+      },
+    };
+  }
+
+  // --- edit view structure ---
+
+  test('edit view shows a url input and upload button when editable', async function (this: RenderingTestContext, assert) {
+    let card = new BrandLogo();
+    await renderCard(loader, card, 'edit');
+
+    assert
+      .dom('[data-test-field="primaryMark1"] input[type="url"]')
+      .exists('url input is rendered');
+    assert
+      .dom('[data-test-field="primaryMark1"] button')
+      .hasText('Select Image', 'upload button is rendered');
+  });
+
+  test('empty placeholder is shown when no url is set', async function (this: RenderingTestContext, assert) {
+    let card = new BrandLogo();
+    await renderCard(loader, card, 'edit');
+
+    assert
+      .dom('[data-test-field="primaryMark1"] .mark-field-preview--empty')
+      .exists('empty placeholder is shown when no url');
+    assert
+      .dom('[data-test-field="primaryMark1"] .mark-field-preview img')
+      .doesNotExist('no img element when url is empty');
+  });
+
+  test('preview image is shown when a url is set', async function (this: RenderingTestContext, assert) {
+    let card = new BrandLogo({
+      primaryMark1: 'https://example.com/logo.svg',
+    });
+    await renderCard(loader, card, 'edit');
+
+    assert
+      .dom('[data-test-field="primaryMark1"] img.mark-field-preview')
+      .exists('preview img is rendered');
+    assert
+      .dom('[data-test-field="primaryMark1"] img.mark-field-preview')
+      .hasAttribute('src', 'https://example.com/logo.svg', 'preview src matches the url');
+    assert
+      .dom('[data-test-field="primaryMark1"] .mark-field-preview--empty')
+      .doesNotExist('empty placeholder is hidden when url is set');
+  });
+
+  // --- url input ---
+
+  test('typing a url in the input updates the field value', async function (this: RenderingTestContext, assert) {
+    let card = new BrandLogo();
+    await renderCard(loader, card, 'edit');
+
+    await fillIn(
+      '[data-test-field="primaryMark1"] input[type="url"]',
+      'https://example.com/logo.svg',
+    );
+
+    assert.strictEqual(
+      card.primaryMark1,
+      'https://example.com/logo.svg',
+      'field value is updated after input',
+    );
+  });
+
+  // --- upload button ---
+
+  test('clicking upload sets the field url from the chosen file', async function (this: RenderingTestContext, assert) {
+    let image = new ImageDef({
+      id: 'https://example.com/uploaded.png',
+      url: 'https://example.com/uploaded.png',
+      sourceUrl: 'https://example.com/uploaded.png',
+      name: 'uploaded.png',
+      contentType: 'image/png',
+    });
+    stubFileChooser(image);
+
+    let card = new BrandLogo();
+    await renderCard(loader, card, 'edit');
+
+    await click('[data-test-field="primaryMark1"] button');
+
+    assert.strictEqual(
+      card.primaryMark1,
+      'https://example.com/uploaded.png',
+      'field value is set to the uploaded file url',
+    );
+    assert
+      .dom('[data-test-field="primaryMark1"] img.mark-field-preview')
+      .hasAttribute(
+        'src',
+        'https://example.com/uploaded.png',
+        'preview updates after upload',
+      );
+  });
+
+  test('cancelling the file chooser leaves the field unchanged', async function (this: RenderingTestContext, assert) {
+    (globalThis as any)._CARDSTACK_FILE_CHOOSER = {
+      async chooseFile() {
+        return undefined;
+      },
+    };
+
+    let card = new BrandLogo({ primaryMark1: 'https://example.com/original.svg' });
+    await renderCard(loader, card, 'edit');
+
+    await click('[data-test-field="primaryMark1"] button');
+
+    assert.strictEqual(
+      card.primaryMark1,
+      'https://example.com/original.svg',
+      'field value is unchanged after cancel',
+    );
+  });
+});

--- a/packages/host/tests/integration/components/brand-logo-mark-field-test.gts
+++ b/packages/host/tests/integration/components/brand-logo-mark-field-test.gts
@@ -4,11 +4,16 @@ import { click, fillIn } from '@ember/test-helpers';
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
-import { baseRealm, type Loader } from '@cardstack/runtime-common';
+import {
+  baseRealm,
+  PermissionsContextName,
+  type Loader,
+} from '@cardstack/runtime-common';
 
 import type * as BrandLogoModule from 'https://cardstack.com/base/brand-logo';
 import type * as CardApiModule from 'https://cardstack.com/base/card-api';
 
+import { provideConsumeContext } from '../../helpers';
 import { setupBaseRealm } from '../../helpers/base-realm';
 import { renderCard } from '../../helpers/render-component';
 import { setupRenderingTest } from '../../helpers/setup';
@@ -18,7 +23,6 @@ module('Integration | brand-logo | MarkField edit', function (hooks) {
   setupBaseRealm(hooks);
 
   let loader: Loader;
-  let MarkField: typeof BrandLogoModule.MarkField;
   let BrandLogo: typeof BrandLogoModule.default;
   let ImageDef: typeof CardApiModule.ImageDef;
 
@@ -30,16 +34,22 @@ module('Integration | brand-logo | MarkField edit', function (hooks) {
     let cardApiModule = await loader.import<typeof CardApiModule>(
       `${baseRealm.url}card-api`,
     );
-    MarkField = brandLogoModule.MarkField;
     BrandLogo = brandLogoModule.default;
     ImageDef = cardApiModule.ImageDef;
+  });
+
+  hooks.beforeEach(function () {
+    provideConsumeContext(PermissionsContextName, {
+      canWrite: true,
+      canRead: true,
+    });
   });
 
   hooks.afterEach(function () {
     delete (globalThis as any)._CARDSTACK_FILE_CHOOSER;
   });
 
-  function stubFileChooser(file: CardApiModule.ImageDef) {
+  function stubFileChooser(file: CardApiModule.ImageDef | undefined) {
     (globalThis as any)._CARDSTACK_FILE_CHOOSER = {
       async chooseFile() {
         return file;
@@ -49,45 +59,28 @@ module('Integration | brand-logo | MarkField edit', function (hooks) {
 
   // --- edit view structure ---
 
-  test('edit view shows a url input and upload button when editable', async function (this: RenderingTestContext, assert) {
+  test('shows url input and Select Image button when no value is set', async function (this: RenderingTestContext, assert) {
     let card = new BrandLogo();
     await renderCard(loader, card, 'edit');
 
     assert
-      .dom('[data-test-field="primaryMark1"] input[type="url"]')
+      .dom('[data-test-field="primaryMark1"] [data-test-mark-url-input]')
       .exists('url input is rendered');
     assert
-      .dom('[data-test-field="primaryMark1"] button')
-      .hasText('Select Image', 'upload button is rendered');
+      .dom('[data-test-field="primaryMark1"] [data-test-mark-select-image]')
+      .hasText('Select Image', 'Select Image button is shown when no value');
   });
 
-  test('empty placeholder is shown when no url is set', async function (this: RenderingTestContext, assert) {
-    let card = new BrandLogo();
+  test('shows X button and no Select Image button when a url is set', async function (this: RenderingTestContext, assert) {
+    let card = new BrandLogo({ primaryMark1: 'https://example.com/logo.svg' });
     await renderCard(loader, card, 'edit');
 
     assert
-      .dom('[data-test-field="primaryMark1"] .mark-field-preview--empty')
-      .exists('empty placeholder is shown when no url');
+      .dom('[data-test-field="primaryMark1"] [data-test-mark-clear]')
+      .exists('X clear button is shown when a url is set');
     assert
-      .dom('[data-test-field="primaryMark1"] .mark-field-preview img')
-      .doesNotExist('no img element when url is empty');
-  });
-
-  test('preview image is shown when a url is set', async function (this: RenderingTestContext, assert) {
-    let card = new BrandLogo({
-      primaryMark1: 'https://example.com/logo.svg',
-    });
-    await renderCard(loader, card, 'edit');
-
-    assert
-      .dom('[data-test-field="primaryMark1"] img.mark-field-preview')
-      .exists('preview img is rendered');
-    assert
-      .dom('[data-test-field="primaryMark1"] img.mark-field-preview')
-      .hasAttribute('src', 'https://example.com/logo.svg', 'preview src matches the url');
-    assert
-      .dom('[data-test-field="primaryMark1"] .mark-field-preview--empty')
-      .doesNotExist('empty placeholder is hidden when url is set');
+      .dom('[data-test-field="primaryMark1"] [data-test-mark-select-image]')
+      .doesNotExist('Select Image button is hidden when a url is set');
   });
 
   // --- url input ---
@@ -97,7 +90,7 @@ module('Integration | brand-logo | MarkField edit', function (hooks) {
     await renderCard(loader, card, 'edit');
 
     await fillIn(
-      '[data-test-field="primaryMark1"] input[type="url"]',
+      '[data-test-field="primaryMark1"] [data-test-mark-url-input]',
       'https://example.com/logo.svg',
     );
 
@@ -108,9 +101,26 @@ module('Integration | brand-logo | MarkField edit', function (hooks) {
     );
   });
 
+  // --- X clear button ---
+
+  test('clicking the X button clears the field value', async function (this: RenderingTestContext, assert) {
+    let card = new BrandLogo({ primaryMark1: 'https://example.com/logo.svg' });
+    await renderCard(loader, card, 'edit');
+
+    await click('[data-test-field="primaryMark1"] [data-test-mark-clear]');
+
+    assert.strictEqual(card.primaryMark1, null, 'field value is cleared');
+    assert
+      .dom('[data-test-field="primaryMark1"] [data-test-mark-clear]')
+      .doesNotExist('X button is hidden after clearing');
+    assert
+      .dom('[data-test-field="primaryMark1"] [data-test-mark-select-image]')
+      .hasText('Select Image', 'Select Image button reappears after clearing');
+  });
+
   // --- upload button ---
 
-  test('clicking upload sets the field url from the chosen file', async function (this: RenderingTestContext, assert) {
+  test('clicking Select Image sets the field url from the chosen file', async function (this: RenderingTestContext, assert) {
     let image = new ImageDef({
       id: 'https://example.com/uploaded.png',
       url: 'https://example.com/uploaded.png',
@@ -123,7 +133,9 @@ module('Integration | brand-logo | MarkField edit', function (hooks) {
     let card = new BrandLogo();
     await renderCard(loader, card, 'edit');
 
-    await click('[data-test-field="primaryMark1"] button');
+    await click(
+      '[data-test-field="primaryMark1"] [data-test-mark-select-image]',
+    );
 
     assert.strictEqual(
       card.primaryMark1,
@@ -131,30 +143,30 @@ module('Integration | brand-logo | MarkField edit', function (hooks) {
       'field value is set to the uploaded file url',
     );
     assert
-      .dom('[data-test-field="primaryMark1"] img.mark-field-preview')
-      .hasAttribute(
-        'src',
-        'https://example.com/uploaded.png',
-        'preview updates after upload',
-      );
+      .dom('[data-test-field="primaryMark1"] [data-test-mark-clear]')
+      .exists('X button appears after upload');
   });
 
   test('cancelling the file chooser leaves the field unchanged', async function (this: RenderingTestContext, assert) {
-    (globalThis as any)._CARDSTACK_FILE_CHOOSER = {
-      async chooseFile() {
-        return undefined;
-      },
-    };
+    stubFileChooser(undefined);
 
-    let card = new BrandLogo({ primaryMark1: 'https://example.com/original.svg' });
+    let card = new BrandLogo();
     await renderCard(loader, card, 'edit');
 
-    await click('[data-test-field="primaryMark1"] button');
+    await click(
+      '[data-test-field="primaryMark1"] [data-test-mark-select-image]',
+    );
 
     assert.strictEqual(
       card.primaryMark1,
-      'https://example.com/original.svg',
-      'field value is unchanged after cancel',
+      undefined,
+      'field value remains empty after cancel',
     );
+    assert
+      .dom('[data-test-field="primaryMark1"] [data-test-mark-select-image]')
+      .hasText(
+        'Select Image',
+        'Select Image button is still shown after cancel',
+      );
   });
 });


### PR DESCRIPTION
## Summary

- Adds a `MarkField` edit component to `brand-logo.gts` with a URL input, an X clear button, and a "Select Image" button that opens the file chooser to pick an `ImageDef`
- Adds an image attachments section to `brand-guide.gts` that renders brand image attachment fields as `url()` CSS variables (both in a dedicated display section and in the custom-css output)
- Tightens the brand mark edit layout and cleans up the typography edit template

## Test plan

- [x] `Integration | brand-guide | brand image attachments` — 5 tests covering attachment row rendering, custom-css section, no-url exclusion, and `cssVariables` output
- [x] `Integration | brand-logo | MarkField edit` — 6 tests covering initial render state, URL input, X clear, Select Image, and cancel flows

## Screenshots
**Mark Usage Edit template:**
<img width="626" height="675" alt="mark-usage" src="https://github.com/user-attachments/assets/79fa0cd7-9faa-4872-8081-2a5cf3b3a12b" />

**Edit field for generating css vars for ImageFileDefs:**
<img width="615" height="191" alt="image-attachments" src="https://github.com/user-attachments/assets/fbe7ee9f-5d4e-41ca-92ab-539fe9ad2dc4" />

**Edit and isolated views:**
<img width="1328" height="983" alt="edit-isolated" src="https://github.com/user-attachments/assets/bd919a22-22f6-481c-bfad-66863d52f113" />


