### PR TITLE
ci: Fix consolidated preview/tests comment

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -149,7 +149,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        shardIndex:
+          [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+          ]
         shardTotal: [20]
     concurrency:
       group: boxel-host-test${{ github.head_ref || github.run_id }}-shard${{ matrix.shardIndex }}
@@ -463,6 +485,7 @@ jobs:
       actions: read
     with:
       head-sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      pr-number: ${{ github.event.pull_request.number }}
       slots: host-tests
     secrets: inherit
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -823,6 +823,7 @@ jobs:
       actions: read
     with:
       head-sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      pr-number: ${{ github.event.pull_request.number }}
       slots: realm-tests
     secrets: inherit
 

--- a/.github/workflows/pr-boxel-ui.yml
+++ b/.github/workflows/pr-boxel-ui.yml
@@ -88,5 +88,6 @@ jobs:
       actions: read
     with:
       head-sha: ${{ github.event.pull_request.head.sha }}
+      pr-number: ${{ github.event.pull_request.number }}
       slots: ${{ needs.post-preview-comment.outputs.slots }}
     secrets: inherit

--- a/.github/workflows/pr-status-comment.yml
+++ b/.github/workflows/pr-status-comment.yml
@@ -21,6 +21,17 @@ on:
         description: Commit SHA the calling run is targeting
         required: true
         type: string
+      pr-number:
+        description: >-
+          PR number the calling run is targeting. Pass this whenever the
+          caller has it (i.e. on pull_request events) so the freshness check
+          uses the triggering PR directly. A single commit can be the head of
+          more than one open PR, so resolving the PR from the SHA alone is
+          ambiguous. Empty for non-PR (push) builds, which fall back to
+          SHA-based resolution.
+        required: false
+        type: string
+        default: ""
       slots:
         description: Space-separated list of slot names this invocation refreshes
         required: true
@@ -44,9 +55,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           SHA: ${{ inputs.head-sha }}
+          PR_NUMBER: ${{ inputs.pr-number }}
         run: |
           set -euo pipefail
-          pr=$(gh api "/repos/$REPO/commits/$SHA/pulls" --jq '.[0].number // empty')
+          pr="$PR_NUMBER"
+          if [ -z "$pr" ]; then
+            # No PR number from the triggering event (e.g. a push build);
+            # derive it from the commit, preferring the PR this SHA is the
+            # head of rather than any PR that merely contains the commit.
+            pr=$(gh api "/repos/$REPO/commits/$SHA/pulls" \
+                 --jq "map(select(.head.sha == \"$SHA\")) | .[0].number // empty")
+          fi
           if [ -z "$pr" ]; then
             echo "No PR for $SHA, skipping."
             echo "skip=true" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/preview-host.yml
+++ b/.github/workflows/preview-host.yml
@@ -129,5 +129,6 @@ jobs:
       actions: read
     with:
       head-sha: ${{ github.event.pull_request.head.sha }}
+      pr-number: ${{ github.event.pull_request.number }}
       slots: ${{ needs.post-preview-comment.outputs.slots }}
     secrets: inherit


### PR DESCRIPTION
I noticed that #5067 was missing the comment with links to preview deployments and test results. That’s because #5009 included the same commit but had a newer one too, so the comment freshness check caused no comment to be posted. This adds a PR number parameter so commits in parallel PRs don’t interfere with the comment.