### PR TITLE
Stream file extraction instead of buffering whole files

### DIFF
--- a/packages/host/app/utils/file-def-attributes-extractor.ts
+++ b/packages/host/app/utils/file-def-attributes-extractor.ts
@@ -236,6 +236,13 @@ export class FileDefAttributesExtractor {
   // Instead, the rare retry path (a subclass mismatch falling back to a parent
   // class, after the primary stream has already been consumed) re-fetches the
   // file once and buffers that copy for any further attempts.
+  //
+  // A FileDef that reads only a prefix MUST cancel the stream rather than
+  // abandon it — an undrained response body can hold the underlying HTTP
+  // connection open until GC. The `readFirstBytes()` helper in
+  // runtime-common/stream.ts does this (it cancels in a `finally`), and is what
+  // the header-only extractors (the image defs) already use; partial readers
+  // should go through it rather than draining the stream by hand.
   #getStreamForAttempt = async () => {
     if (!this.#primaryUsed) {
       this.#primaryUsed = true;

--- a/packages/host/app/utils/file-def-attributes-extractor.ts
+++ b/packages/host/app/utils/file-def-attributes-extractor.ts
@@ -57,12 +57,6 @@ export class FileDefAttributesExtractor {
   #contentSize: number | undefined;
   #fileBytes: Uint8Array | undefined;
   #buildError: (url: string, error: unknown) => RenderError;
-  #streamsPromise: Promise<
-    [
-      ReadableStream<Uint8Array> | Uint8Array,
-      ReadableStream<Uint8Array> | Uint8Array,
-    ]
-  > | null = null;
   #fallbackBytes: Uint8Array | null = null;
   #primaryUsed = false;
 
@@ -232,6 +226,16 @@ export class FileDefAttributesExtractor {
     };
   }
 
+  // Each extractAttributes attempt asks for a stream. The first attempt — the
+  // most-specific FileDef subclass — gets the response body streamed directly,
+  // so a FileDef that only needs a small header (e.g. an audio duration in the
+  // `moov` box) can read what it needs and let the rest flow past without the
+  // whole file ever being buffered. The streams are deliberately NOT tee'd:
+  // teeing queues every chunk of the consumed branch for the unread retry
+  // branch, which pins the entire file in memory and defeats the streaming.
+  // Instead, the rare retry path (a subclass mismatch falling back to a parent
+  // class, after the primary stream has already been consumed) re-fetches the
+  // file once and buffers that copy for any further attempts.
   #getStreamForAttempt = async () => {
     if (!this.#primaryUsed) {
       this.#primaryUsed = true;
@@ -240,87 +244,64 @@ export class FileDefAttributesExtractor {
     return this.#getRetryStream();
   };
 
-  async #getStreams() {
-    if (!this.#streamsPromise) {
-      this.#streamsPromise = (async () => {
-        if (this.#fileBytes) {
-          return [this.#fileBytes, this.#fileBytes];
-        }
-
-        let response: Response;
-        try {
-          let request = new Request(this.#fileURL, {
-            method: 'GET',
-            headers: {
-              Accept: SupportedMimeType.CardSource,
-            },
-          });
-          if (this.#authGuard) {
-            response = await this.#authGuard.race(() =>
-              this.#network.authedFetch(request),
-            );
-          } else {
-            response = await this.#network.authedFetch(request);
-          }
-        } catch (error) {
-          console.warn('file extract fetch failed', {
-            fileURL: this.#fileURL,
-            error,
-          });
-          throw error;
-        }
-        if (!response.ok) {
-          console.warn('file extract fetch returned non-ok', {
-            fileURL: this.#fileURL,
-            status: response.status,
-          });
-          throw await CardError.fromFetchResponse(this.#fileURL, response);
-        }
-        return await this.#teeResponse(response);
-      })();
+  async #getPrimaryStream(): Promise<ReadableStream<Uint8Array> | Uint8Array> {
+    if (this.#fileBytes) {
+      return this.#fileBytes;
     }
-    return this.#streamsPromise;
+    let response = await this.#fetch();
+    // Hand back the live body so the consumer decides how much to read. Fall
+    // back to a buffered read only when the body isn't a stream (real fetches
+    // always expose one; this keeps non-streaming environments working).
+    if (response.body) {
+      return response.body;
+    }
+    return new Uint8Array(await response.arrayBuffer());
   }
 
-  async #getPrimaryStream() {
-    return (await this.#getStreams())[0];
-  }
-
-  async #getFallbackStream() {
-    return (await this.#getStreams())[1];
-  }
-
-  async #getRetryStream() {
+  async #getRetryStream(): Promise<Uint8Array> {
+    if (this.#fileBytes) {
+      return this.#fileBytes;
+    }
+    // Buffer the re-fetched copy once and reuse it for any subsequent
+    // attempts, so a chain of N fallbacks costs at most one extra fetch.
     if (!this.#fallbackBytes) {
-      this.#fallbackBytes = await this.#streamToBytes(
-        await this.#getFallbackStream(),
-      );
+      let response = await this.#fetch();
+      this.#fallbackBytes = new Uint8Array(await response.arrayBuffer());
     }
     return this.#fallbackBytes;
   }
 
-  async #teeResponse(
-    response: Response,
-  ): Promise<
-    [
-      ReadableStream<Uint8Array> | Uint8Array,
-      ReadableStream<Uint8Array> | Uint8Array,
-    ]
-  > {
-    if (response.body && 'tee' in response.body) {
-      return response.body.tee();
+  async #fetch(): Promise<Response> {
+    let response: Response;
+    try {
+      let request = new Request(this.#fileURL, {
+        method: 'GET',
+        headers: {
+          Accept: SupportedMimeType.CardSource,
+        },
+      });
+      if (this.#authGuard) {
+        response = await this.#authGuard.race(() =>
+          this.#network.authedFetch(request),
+        );
+      } else {
+        response = await this.#network.authedFetch(request);
+      }
+    } catch (error) {
+      console.warn('file extract fetch failed', {
+        fileURL: this.#fileURL,
+        error,
+      });
+      throw error;
     }
-    let bytes = new Uint8Array(await response.arrayBuffer());
-    return [bytes, bytes];
-  }
-
-  async #streamToBytes(
-    stream: ReadableStream<Uint8Array> | Uint8Array,
-  ): Promise<Uint8Array> {
-    if (stream instanceof Uint8Array) {
-      return stream;
+    if (!response.ok) {
+      console.warn('file extract fetch returned non-ok', {
+        fileURL: this.#fileURL,
+        status: response.status,
+      });
+      throw await CardError.fromFetchResponse(this.#fileURL, response);
     }
-    return new Uint8Array(await new Response(stream).arrayBuffer());
+    return response;
   }
 
   // Extract query field definitions (linksTo/linksToMany with a query) from

--- a/packages/host/tests/acceptance/prerender-file-extract-test.gts
+++ b/packages/host/tests/acceptance/prerender-file-extract-test.gts
@@ -137,6 +137,13 @@ module('Acceptance | prerender | file-extract', function (hooks) {
           'filedef-missing.gts': `
           export const NotFileDef = {};
         `,
+          'filedef-passthrough.gts': `
+          import { FileDef as BaseFileDef } from "${baseRealm.url}file-api";
+
+          // Inherits the base extractAttributes unchanged, so it exercises the
+          // base hash/size handling (including the provided-options shortcut).
+          export class PassthroughDef extends BaseFileDef {}
+        `,
           'sample.txt': 'hello world',
           'mismatch.txt': 'mismatch content',
         },
@@ -195,6 +202,34 @@ module('Acceptance | prerender | file-extract', function (hooks) {
         fileDefCodeRef('filedef-success', 'SuccessDef').module,
       ),
       'deps include custom file def module',
+    );
+  });
+
+  test('uses the provided contentHash and contentSize without re-reading the file', async function (assert) {
+    // The indexer forwards the realm's already-persisted hash/size so the base
+    // FileDef.extractAttributes skips its buffered MD5/size pass. Sentinel
+    // values that deliberately do NOT match 'hello world' prove they are used
+    // verbatim — a recompute would yield the real md5 and a size of 11.
+    let url = fileURL('sample.txt');
+    await visit(
+      renderPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: fileDefCodeRef('filedef-passthrough', 'PassthroughDef'),
+        fileContentHash: 'sentinel-content-hash',
+        fileContentSize: 4242,
+      }),
+    );
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.strictEqual(
+      result.searchDoc?.contentHash,
+      'sentinel-content-hash',
+      'uses the provided content hash instead of recomputing it',
+    );
+    assert.strictEqual(
+      result.searchDoc?.contentSize,
+      4242,
+      'uses the provided content size instead of re-reading the file',
     );
   });
 

--- a/packages/runtime-common/file-meta.ts
+++ b/packages/runtime-common/file-meta.ts
@@ -19,22 +19,47 @@ export async function getCreatedTime(
   return typeof created === 'string' ? parseInt(created) : Number(created);
 }
 
-export async function getContentHash(
+// Reads the content hash and size the realm persisted at write time in a
+// single row lookup. Callers that need both (e.g. the file-extract indexing
+// pass) should use this rather than calling getContentHash + getContentSize,
+// which would hit the same row twice.
+export async function getContentMeta(
   db: DBAdapter,
   realmURL: string,
   localPath: string,
-): Promise<string | undefined> {
+): Promise<{
+  contentHash: string | undefined;
+  contentSize: number | undefined;
+}> {
   let rows = await query(db, [
-    'SELECT content_hash FROM realm_file_meta WHERE realm_url =',
+    'SELECT content_hash, content_size FROM realm_file_meta WHERE realm_url =',
     param(realmURL),
     'AND file_path =',
     param(localPath),
     'LIMIT 1',
   ]);
-  if (!rows || rows.length === 0) return undefined;
+  if (!rows || rows.length === 0) {
+    return { contentHash: undefined, contentSize: undefined };
+  }
   let contentHash = rows[0]['content_hash'];
-  if (contentHash == null) return undefined;
-  return String(contentHash);
+  let contentSize = rows[0]['content_size'];
+  return {
+    contentHash: contentHash == null ? undefined : String(contentHash),
+    contentSize:
+      contentSize == null
+        ? undefined
+        : typeof contentSize === 'string'
+          ? parseInt(contentSize)
+          : Number(contentSize),
+  };
+}
+
+export async function getContentHash(
+  db: DBAdapter,
+  realmURL: string,
+  localPath: string,
+): Promise<string | undefined> {
+  return (await getContentMeta(db, realmURL, localPath)).contentHash;
 }
 
 export async function getContentSize(
@@ -42,19 +67,7 @@ export async function getContentSize(
   realmURL: string,
   localPath: string,
 ): Promise<number | undefined> {
-  let rows = await query(db, [
-    'SELECT content_size FROM realm_file_meta WHERE realm_url =',
-    param(realmURL),
-    'AND file_path =',
-    param(localPath),
-    'LIMIT 1',
-  ]);
-  if (!rows || rows.length === 0) return undefined;
-  let contentSize = rows[0]['content_size'];
-  if (contentSize == null) return undefined;
-  return typeof contentSize === 'string'
-    ? parseInt(contentSize)
-    : Number(contentSize);
+  return (await getContentMeta(db, realmURL, localPath)).contentSize;
 }
 
 // Ensures a created_at row exists for the given path; returns epoch seconds

--- a/packages/runtime-common/file-meta.ts
+++ b/packages/runtime-common/file-meta.ts
@@ -20,9 +20,7 @@ export async function getCreatedTime(
 }
 
 // Reads the content hash and size the realm persisted at write time in a
-// single row lookup. Callers that need both (e.g. the file-extract indexing
-// pass) should use this rather than calling getContentHash + getContentSize,
-// which would hit the same row twice.
+// single row lookup.
 export async function getContentMeta(
   db: DBAdapter,
   realmURL: string,
@@ -52,22 +50,6 @@ export async function getContentMeta(
           ? parseInt(contentSize)
           : Number(contentSize),
   };
-}
-
-export async function getContentHash(
-  db: DBAdapter,
-  realmURL: string,
-  localPath: string,
-): Promise<string | undefined> {
-  return (await getContentMeta(db, realmURL, localPath)).contentHash;
-}
-
-export async function getContentSize(
-  db: DBAdapter,
-  realmURL: string,
-  localPath: string,
-): Promise<number | undefined> {
-  return (await getContentMeta(db, realmURL, localPath)).contentSize;
 }
 
 // Ensures a created_at row exists for the given path; returns epoch seconds

--- a/packages/runtime-common/index-runner/visit-file.ts
+++ b/packages/runtime-common/index-runner/visit-file.ts
@@ -163,12 +163,37 @@ export async function visitFileForIndexingFused({
   let fileDefCodeRef = resolveFileDefCodeRef(new URL(fileURL), virtualNetwork);
 
   let clearCache = consumeClearCacheForRender();
+
+  // The file-extract pass runs `FileDef.extractAttributes` in the prerenderer,
+  // which otherwise buffers the entire file just to MD5 it and measure its
+  // size. The realm already persisted both values at write time (computed over
+  // the exact bytes it wrote, which is what the prerenderer would re-fetch), so
+  // hand them through and let `extractAttributes` skip the buffer entirely.
+  // Only forwarded when BOTH are present — `extractAttributes` re-reads the
+  // stream unless it has the hash and the size — so a partial lookup buys
+  // nothing. Absent values (pre-hashing files, no-op rewrites) fall back to the
+  // prerenderer's own buffered read.
+  let fileContentHash: string | undefined;
+  let fileContentSize: number | undefined;
+  if (needFileExtract) {
+    let [hash, size] = await Promise.all([
+      batch.getContentHash(localPath),
+      batch.getContentSize(localPath),
+    ]);
+    if (hash !== undefined && size !== undefined) {
+      fileContentHash = hash;
+      fileContentSize = size;
+    }
+  }
+
   let renderOptions: RenderRouteOptions = {
     fileDefCodeRef,
     ...(needCardRender ? { cardRender: true } : {}),
     ...(needFileExtract ? { fileExtract: true } : {}),
     ...(needFileRender ? { fileRender: true } : {}),
     ...(clearCache ? { clearCache } : {}),
+    ...(fileContentHash !== undefined ? { fileContentHash } : {}),
+    ...(fileContentSize !== undefined ? { fileContentSize } : {}),
   };
 
   let visitResponse: RenderVisitResponse;

--- a/packages/runtime-common/index-runner/visit-file.ts
+++ b/packages/runtime-common/index-runner/visit-file.ts
@@ -176,13 +176,10 @@ export async function visitFileForIndexingFused({
   let fileContentHash: string | undefined;
   let fileContentSize: number | undefined;
   if (needFileExtract) {
-    let [hash, size] = await Promise.all([
-      batch.getContentHash(localPath),
-      batch.getContentSize(localPath),
-    ]);
-    if (hash !== undefined && size !== undefined) {
-      fileContentHash = hash;
-      fileContentSize = size;
+    let { contentHash, contentSize } = await batch.getContentMeta(localPath);
+    if (contentHash !== undefined && contentSize !== undefined) {
+      fileContentHash = contentHash;
+      fileContentSize = contentSize;
     }
   }
 

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -19,7 +19,12 @@ import {
   type RealmIdentifier,
 } from './card-reference-resolver';
 import type { VirtualNetwork } from './virtual-network';
-import { getCreatedTime, ensureFileCreatedAt } from './file-meta';
+import {
+  getCreatedTime,
+  ensureFileCreatedAt,
+  getContentHash,
+  getContentSize,
+} from './file-meta';
 import {
   type Expression,
   param,
@@ -301,6 +306,20 @@ export class Batch {
   // Ensure a created_at row exists for this file in realm_file_meta and return it
   async ensureFileCreatedAt(localPath: string): Promise<number> {
     return ensureFileCreatedAt(this.#dbAdapter, this.realmURL.href, localPath);
+  }
+
+  // Look up the content hash persisted at write time for a given file path.
+  // Returns undefined when the realm has no recorded hash (e.g. files written
+  // before file-meta hashing existed, or a no-op rewrite that left the column
+  // untouched).
+  async getContentHash(localPath: string): Promise<string | undefined> {
+    return getContentHash(this.#dbAdapter, this.realmURL.href, localPath);
+  }
+
+  // Look up the content size (in bytes) persisted at write time for a given
+  // file path. Returns undefined when no size was recorded.
+  async getContentSize(localPath: string): Promise<number | undefined> {
+    return getContentSize(this.#dbAdapter, this.realmURL.href, localPath);
   }
 
   @Memoize()

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -22,8 +22,7 @@ import type { VirtualNetwork } from './virtual-network';
 import {
   getCreatedTime,
   ensureFileCreatedAt,
-  getContentHash,
-  getContentSize,
+  getContentMeta,
 } from './file-meta';
 import {
   type Expression,
@@ -308,18 +307,15 @@ export class Batch {
     return ensureFileCreatedAt(this.#dbAdapter, this.realmURL.href, localPath);
   }
 
-  // Look up the content hash persisted at write time for a given file path.
-  // Returns undefined when the realm has no recorded hash (e.g. files written
-  // before file-meta hashing existed, or a no-op rewrite that left the column
-  // untouched).
-  async getContentHash(localPath: string): Promise<string | undefined> {
-    return getContentHash(this.#dbAdapter, this.realmURL.href, localPath);
-  }
-
-  // Look up the content size (in bytes) persisted at write time for a given
-  // file path. Returns undefined when no size was recorded.
-  async getContentSize(localPath: string): Promise<number | undefined> {
-    return getContentSize(this.#dbAdapter, this.realmURL.href, localPath);
+  // Look up the content hash and size persisted at write time for a given file
+  // path, in a single row lookup. Either value is undefined when the realm has
+  // no recorded value (e.g. files written before file-meta hashing existed, or
+  // a no-op rewrite that left the columns untouched).
+  async getContentMeta(localPath: string): Promise<{
+    contentHash: string | undefined;
+    contentSize: number | undefined;
+  }> {
+    return getContentMeta(this.#dbAdapter, this.realmURL.href, localPath);
   }
 
   @Memoize()

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -30,8 +30,7 @@ import {
   persistFileMeta,
   removeFileMeta,
   getCreatedTime,
-  getContentHash,
-  getContentSize,
+  getContentMeta,
 } from './file-meta';
 import {
   systemError,
@@ -4014,14 +4013,13 @@ export class Realm {
     let inferredContentType = inferContentType(name);
     let createdAt = await this.getCreatedTime(localPath);
     let realmInfo = await this.parseRealmInfo();
+    let persistedMeta = this.#dbAdapter
+      ? await getContentMeta(this.#dbAdapter, this.url, localPath)
+      : { contentHash: undefined, contentSize: undefined };
     let contentHash =
-      (this.#dbAdapter
-        ? await getContentHash(this.#dbAdapter, this.url, localPath)
-        : undefined) ?? (await computeContentHashFromRef(fileRef));
+      persistedMeta.contentHash ?? (await computeContentHashFromRef(fileRef));
     let contentSize =
-      (this.#dbAdapter
-        ? await getContentSize(this.#dbAdapter, this.url, localPath)
-        : undefined) ?? (await computeContentSizeFromRef(fileRef));
+      persistedMeta.contentSize ?? (await computeContentSizeFromRef(fileRef));
     let doc: SingleFileMetaDocument = {
       data: {
         type: 'file-meta',
@@ -4066,18 +4064,21 @@ export class Realm {
     let createdAt = fileEntry.resourceCreatedAt ?? fileEntry.lastModified;
     let realmInfo = await this.parseRealmInfo();
     let searchDoc = fileEntry.searchDoc ?? {};
-    let contentHash =
+    let searchHash =
       typeof searchDoc.contentHash === 'string'
         ? searchDoc.contentHash
-        : this.#dbAdapter
-          ? await getContentHash(this.#dbAdapter, this.url, localPath)
-          : undefined;
-    let contentSize =
+        : undefined;
+    let searchSize =
       typeof searchDoc.contentSize === 'number'
         ? searchDoc.contentSize
-        : this.#dbAdapter
-          ? await getContentSize(this.#dbAdapter, this.url, localPath)
-          : undefined;
+        : undefined;
+    // Only hit the DB when the indexed searchDoc is missing a value.
+    let persistedMeta =
+      (searchHash === undefined || searchSize === undefined) && this.#dbAdapter
+        ? await getContentMeta(this.#dbAdapter, this.url, localPath)
+        : { contentHash: undefined, contentSize: undefined };
+    let contentHash = searchHash ?? persistedMeta.contentHash;
+    let contentSize = searchSize ?? persistedMeta.contentSize;
     let adoptsFrom =
       codeRefFromInternalKey(fileEntry.types?.[0]) ??
       (isCodeRef(fileEntry.resource?.meta?.adoptsFrom)


### PR DESCRIPTION
## Problem

The prerender file-extract path keeps each file resident in memory **twice**:

1. `FileDefAttributesExtractor` calls `response.body.tee()` and holds both branches. Reading the primary stream to EOF queues every chunk for the *unread* retry branch, so the whole file is buffered even when the consumer only needs a few header bytes.
2. `FileDef.extractAttributes` then reads the entire stream into a `Uint8Array` purely to compute an MD5 `contentHash` and `contentSize`.

For large audio (e.g. an hour-long iPhone voice memo, tens of MB) this is wasteful, and it caps any per-FileDef streaming optimization at `O(file)`.

## Changes

- **`index-writer.ts`** — add `Batch.getContentHash()` / `getContentSize()` reading the values the realm already persisted in `realm_file_meta` at write time (computed over the exact bytes it wrote — i.e. what the prerenderer re-fetches, so they match `extractAttributes` byte-for-byte).
- **`visit-file.ts`** — the indexer looks both up and forwards them as `fileContentHash` / `fileContentSize`, **only when both are present**. `extractAttributes` skips its buffered read when it has the hash *and* the size. Files with no recorded values (pre-hashing files, no-op rewrites) fall back to today's behavior.
- **`file-def-attributes-extractor.ts`** — remove the `tee()`. Hand the primary attempt the live response body so a FileDef can read only what it needs and let the rest flow past. The rare subclass-mismatch retry (which runs after the primary stream is already consumed) re-fetches the file once and buffers that copy for any further attempts.

## Effect

The base file-extract path drops from ~2×file resident to streaming. This is also the enabling change for streaming per-format extractors (e.g. M4A duration from the `moov` box — see the companion PR on the audio-FileDef branch).

## Tradeoff

Dropping the tee means a fallback attempt re-fetches the file (one extra GET) instead of reading an in-memory copy. This only happens on the subclass-mismatch path (wrong extension / corrupt header), not on the common success-first-attempt path, which still does exactly one fetch — now without buffering.

## Verification

- `runtime-common` and `host` typecheck clean; eslint clean.
- Host acceptance suite not yet run live (needs full build + browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)