### PR TITLE
Stream M4A duration extraction, discarding mdat

### DIFF
--- a/packages/base/m4a-audio-def.gts
+++ b/packages/base/m4a-audio-def.gts
@@ -1,8 +1,7 @@
-import { byteStreamToUint8Array } from '@cardstack/runtime-common';
 import FileAudioIcon from '@cardstack/boxel-icons/file-audio';
 import AudioDef from './audio-file-def';
 import { type ByteStream, type SerializedFile } from './file-api';
-import { extractM4aDuration } from './m4a-meta-extractor';
+import { extractM4aDurationFromStream } from './m4a-meta-extractor';
 
 export class M4aDef extends AudioDef {
   static displayName = 'M4A Audio';
@@ -12,20 +11,17 @@ export class M4aDef extends AudioDef {
   static async extractAttributes(
     url: string,
     getStream: () => Promise<ByteStream>,
-    options: { contentHash?: string } = {},
+    options: { contentHash?: string; contentSize?: number } = {},
   ): Promise<SerializedFile<{ duration: number }>> {
-    // M4A files written by iPhone / Apple Voice Memos place `moov` at the
-    // end of the file; fast-start optimised files place it near the start.
-    // Read the whole stream once so either layout works without seeking.
-    let bytesPromise: Promise<Uint8Array> | undefined;
-    let memoizedStream = async () => {
-      bytesPromise ??= byteStreamToUint8Array(await getStream());
-      return bytesPromise;
-    };
-
-    let base = await super.extractAttributes(url, memoizedStream, options);
-    let bytes = await memoizedStream();
-    let { duration } = extractM4aDuration(bytes);
+    // Duration lives in the small `moov` box; the bulk of an M4A file is the
+    // `mdat` media payload, which we never need. Walk the container off the
+    // stream, retaining only `moov` and discarding `mdat`, so even a long
+    // recording is parsed with a few KB resident rather than the whole file.
+    // `super` derives the hash/size from `options` (supplied by the indexer)
+    // without re-reading, so when those are present the stream is consumed
+    // exactly once — by this walk.
+    let base = await super.extractAttributes(url, getStream, options);
+    let { duration } = await extractM4aDurationFromStream(await getStream());
 
     return {
       ...base,

--- a/packages/base/m4a-meta-extractor.ts
+++ b/packages/base/m4a-meta-extractor.ts
@@ -172,6 +172,18 @@ export function extractM4aDuration(bytes: Uint8Array): { duration: number } {
       'MP4 file does not contain a moov box',
     );
   }
+  return durationFromMoov(bytes, view, moov);
+}
+
+// Given a located `moov` box, find its `mvhd` child and convert the
+// timescale/duration pair into seconds. Shared by the whole-buffer
+// (`extractM4aDuration`) and streaming (`extractM4aDurationFromStream`) entry
+// points so both agree on the parse.
+function durationFromMoov(
+  bytes: Uint8Array,
+  view: DataView,
+  moov: BoxLocation,
+): { duration: number } {
   let mvhd = findChildBox(bytes, view, moov.payloadOffset, moov.payloadEnd, MVHD);
   if (!mvhd) {
     throw new FileContentMismatchError(
@@ -186,4 +198,227 @@ export function extractM4aDuration(bytes: Uint8Array): { duration: number } {
     );
   }
   return { duration: duration / timescale };
+}
+
+// Pull reader over a byte stream: lets the box walk read exact-length headers
+// and reassemble the small `moov` box while skipping (discarding) the large
+// `mdat` payload, so a long recording never has to be buffered whole.
+class ChunkReader {
+  #reader: ReadableStreamDefaultReader<Uint8Array>;
+  #queue: Uint8Array[] = [];
+  #queued = 0;
+  #done = false;
+
+  constructor(stream: ReadableStream<Uint8Array>) {
+    this.#reader = stream.getReader();
+  }
+
+  // Pull one more chunk into the queue. Returns false at end of stream.
+  async #pull(): Promise<boolean> {
+    if (this.#done) {
+      return false;
+    }
+    let { done, value } = await this.#reader.read();
+    if (done) {
+      this.#done = true;
+      return false;
+    }
+    if (value && value.length) {
+      this.#queue.push(value);
+      this.#queued += value.length;
+    }
+    return true;
+  }
+
+  // Read exactly `n` bytes as a contiguous array, or null if the stream ends
+  // before `n` bytes are available.
+  async readExact(n: number): Promise<Uint8Array | null> {
+    while (this.#queued < n) {
+      if (!(await this.#pull())) {
+        return null;
+      }
+    }
+    return this.#take(n);
+  }
+
+  // Discard exactly `n` bytes without retaining them. Returns false if the
+  // stream ends first.
+  async skip(n: number): Promise<boolean> {
+    while (n > 0) {
+      if (this.#queued === 0 && !(await this.#pull())) {
+        return false;
+      }
+      let head = this.#queue[0]!;
+      if (head.length <= n) {
+        this.#queue.shift();
+        this.#queued -= head.length;
+        n -= head.length;
+      } else {
+        this.#queue[0] = head.subarray(n);
+        this.#queued -= n;
+        n = 0;
+      }
+    }
+    return true;
+  }
+
+  // Read whatever bytes remain in the stream (used for a `moov` box whose size
+  // field says "extends to end of file").
+  async readRemaining(): Promise<Uint8Array> {
+    while (await this.#pull()) {
+      // keep buffering
+    }
+    return this.#take(this.#queued);
+  }
+
+  #take(n: number): Uint8Array {
+    let out = new Uint8Array(n);
+    let off = 0;
+    while (off < n) {
+      let head = this.#queue[0]!;
+      let need = n - off;
+      if (head.length <= need) {
+        out.set(head, off);
+        off += head.length;
+        this.#queue.shift();
+        this.#queued -= head.length;
+      } else {
+        out.set(head.subarray(0, need), off);
+        off += need;
+        this.#queue[0] = head.subarray(need);
+        this.#queued -= need;
+      }
+    }
+    return out;
+  }
+
+  async cancel(): Promise<void> {
+    try {
+      await this.#reader.cancel();
+    } catch {
+      // A consumer that already finished reading may have released the lock;
+      // cancelling then is a harmless no-op.
+    }
+  }
+}
+
+// Parse duration from a standalone `moov` box (its own bytes, header at offset
+// 0) reassembled by the streaming walk.
+function durationFromMoovBox(moovBytes: Uint8Array): { duration: number } {
+  let view = new DataView(
+    moovBytes.buffer,
+    moovBytes.byteOffset,
+    moovBytes.byteLength,
+  );
+  let moov = readBoxAt(moovBytes, view, 0, moovBytes.length);
+  if (!moov || moov.type !== 'moov') {
+    throw new FileContentMismatchError('MP4 moov box is malformed');
+  }
+  return durationFromMoov(moovBytes, view, moov);
+}
+
+// Streaming counterpart to `extractM4aDuration`. Walks top-level boxes off the
+// stream, retaining only the `moov` box and discarding everything else (most
+// importantly the `mdat` media payload), so peak memory is ~`moov` rather than
+// the whole file. A `Uint8Array` input (already-buffered bytes) is parsed
+// directly. Works for both fast-start files (`moov` near the start, where the
+// walk stops early) and iPhone / Voice Memo files (`moov` at the end, where
+// the preceding `mdat` is skipped chunk by chunk).
+export async function extractM4aDurationFromStream(
+  stream: ReadableStream<Uint8Array> | Uint8Array,
+): Promise<{ duration: number }> {
+  if (stream instanceof Uint8Array) {
+    return extractM4aDuration(stream);
+  }
+
+  let reader = new ChunkReader(stream);
+  try {
+    let isFirstBox = true;
+    for (;;) {
+      let header = await reader.readExact(BOX_HEADER_BYTES);
+      if (!header) {
+        // Clean EOF on a box boundary with no `moov` seen.
+        break;
+      }
+      let headerView = new DataView(
+        header.buffer,
+        header.byteOffset,
+        header.byteLength,
+      );
+      let size = headerView.getUint32(0);
+      let type = typeAt(header, 4);
+      let headerSize = BOX_HEADER_BYTES;
+      let largeSize: Uint8Array | undefined;
+
+      if (size === 1) {
+        // 64-bit extended size lives in the next 8 bytes.
+        let ext = await reader.readExact(LARGE_SIZE_BYTES);
+        if (!ext) {
+          throw new FileContentMismatchError(
+            `MP4 ${type} box declares a 64-bit size but is truncated`,
+          );
+        }
+        largeSize = ext;
+        let largeView = new DataView(
+          ext.buffer,
+          ext.byteOffset,
+          ext.byteLength,
+        );
+        let hi = largeView.getUint32(0);
+        let lo = largeView.getUint32(4);
+        size = hi * 0x1_0000_0000 + lo;
+        headerSize = BOX_HEADER_BYTES + LARGE_SIZE_BYTES;
+      }
+
+      if (size !== 0 && size < headerSize) {
+        throw new FileContentMismatchError(
+          `MP4 ${type} box declares an impossible size`,
+        );
+      }
+
+      if (isFirstBox) {
+        // Match extractM4aDuration: a real MP4/M4A starts with `ftyp`, so a
+        // mismatch can fall back to a less specific FileDef gracefully.
+        if (type !== 'ftyp') {
+          throw new FileContentMismatchError(
+            'MP4 file does not start with an ftyp box',
+          );
+        }
+        isFirstBox = false;
+      }
+
+      if (type === 'moov') {
+        // Reassemble the box bytes (header + payload) so the offset-based
+        // parser can run against it directly.
+        let payload =
+          size === 0
+            ? await reader.readRemaining()
+            : await reader.readExact(size - headerSize);
+        if (!payload) {
+          throw new FileContentMismatchError('MP4 moov box is truncated');
+        }
+        let moovBytes = new Uint8Array(headerSize + payload.length);
+        moovBytes.set(header, 0);
+        if (largeSize) {
+          moovBytes.set(largeSize, BOX_HEADER_BYTES);
+        }
+        moovBytes.set(payload, headerSize);
+        return durationFromMoovBox(moovBytes);
+      }
+
+      if (size === 0) {
+        // A non-`moov` box that runs to end of file means no `moov` follows.
+        break;
+      }
+      if (!(await reader.skip(size - headerSize))) {
+        // Truncated mid-box: no `moov`.
+        break;
+      }
+    }
+    throw new FileContentMismatchError(
+      'MP4 file does not contain a moov box',
+    );
+  } finally {
+    await reader.cancel();
+  }
 }

--- a/packages/host/tests/acceptance/audio-def/m4a-audio-def-test.gts
+++ b/packages/host/tests/acceptance/audio-def/m4a-audio-def-test.gts
@@ -69,6 +69,29 @@ function makeMinimalM4a(): Uint8Array {
   return out;
 }
 
+// iPhone / Apple Voice Memos layout: the moov box trails a large mdat media
+// payload, so the duration is only reachable after streaming past (and
+// discarding) mdat. Reuses makeMinimalM4a's ftyp + moov and splices a chunky
+// mdat box between them.
+function makeM4aMoovAtEnd(): Uint8Array {
+  let fastStart = makeMinimalM4a(); // ftyp (16 bytes) + moov
+  let ftyp = fastStart.subarray(0, 16);
+  let moov = fastStart.subarray(16);
+
+  let mdatPayload = new Uint8Array(4096).fill(0xab);
+  let mdat = new Uint8Array(8 + mdatPayload.length);
+  let mdatView = new DataView(mdat.buffer);
+  mdatView.setUint32(0, mdat.length); // box size
+  mdat.set([0x6d, 0x64, 0x61, 0x74], 4); // "mdat"
+  mdat.set(mdatPayload, 8);
+
+  let out = new Uint8Array(ftyp.length + mdat.length + moov.length);
+  out.set(ftyp, 0);
+  out.set(mdat, ftyp.length);
+  out.set(moov, ftyp.length + mdat.length);
+  return out;
+}
+
 module('Acceptance | m4a audio def', function (hooks) {
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
@@ -154,6 +177,7 @@ module('Acceptance | m4a audio def', function (hooks) {
         contents: {
           ...SYSTEM_CARD_FIXTURE_CONTENTS,
           'sample.m4a': m4aBytes,
+          'sample-moov-at-end.m4a': makeM4aMoovAtEnd(),
           'not-an-m4a.m4a': 'This is plain text, not an M4A file.',
         },
       }),
@@ -182,6 +206,27 @@ module('Acceptance | m4a audio def', function (hooks) {
     let isM4aCompatibleType =
       contentType.includes('mp4') || contentType.includes('m4a');
     assert.true(isM4aCompatibleType, 'sets m4a-compatible content type');
+  });
+
+  test('extracts duration from M4A with a trailing moov box', async function (assert) {
+    // Exercises the streaming walk's mdat-skipping: the moov box only appears
+    // after the media payload, as in iPhone / Voice Memo recordings.
+    let url = makeFileURL('sample-moov-at-end.m4a');
+    await visit(
+      fileExtractPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: m4aDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.strictEqual(
+      result.searchDoc?.duration,
+      2,
+      'extracts duration after skipping past mdat',
+    );
+    assert.strictEqual(result.searchDoc?.name, 'sample-moov-at-end.m4a');
   });
 
   test('falls back when M4aDef is used for non-M4A content', async function (assert) {


### PR DESCRIPTION
Builds on #5075 (companion: low-memory file extraction off `main`).

## Problem

`M4aDef.extractAttributes` reads the **whole file** into memory to extract the duration, because the `moov` box (which carries `timescale`/`duration`) can sit at the *end* of the file in iPhone / Apple Voice Memo recordings. The bulk of an M4A is the `mdat` media payload — which the duration never needs.

## Changes

- **`m4a-meta-extractor.ts`** — add `extractM4aDurationFromStream()`: a chunk reader plus a top-level box walk that retains only the `moov` box and **skips `mdat`** chunk by chunk without buffering it. A `Uint8Array` input is still parsed directly via the existing `extractM4aDuration`, and `mvhd` parsing is shared between both paths.
- **`m4a-audio-def.gts`** — drop the whole-file memoization and stream once; widen `options` to include `contentSize` (forwarded to `super`).
- **test** — add a trailing-`moov` (iPhone layout) fixture so the skip-`mdat` walk is exercised end-to-end through the real prerender fetch, alongside the existing fast-start fixture.

## Effect

Combined with #5075 (which removes the extractor's tee and lets the base skip its own buffer), the M4A duration path becomes `O(moov)` — a few KB regardless of recording length — for both fast-start and moov-at-end layouts. Without #5075 the extractor still buffers underneath, so this PR's full benefit depends on it.

## Verification

- New streaming logic typechecks (isolated) and passes a standalone runtime test: fast-start + moov-at-end across chunk sizes 3 / 7 / 8 / 16 / 4K / 1M, the `Uint8Array` path, and both `FileContentMismatchError` paths (non-MP4, ftyp-but-no-moov).
- Host acceptance suite not yet run live (needs full build + browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)