### PR TITLE
Stream OGG duration extraction with a rolling tail window

### DIFF
--- a/packages/base/ogg-audio-def.gts
+++ b/packages/base/ogg-audio-def.gts
@@ -1,8 +1,7 @@
-import { byteStreamToUint8Array } from '@cardstack/runtime-common';
 import FileAudioIcon from '@cardstack/boxel-icons/file-audio';
 import AudioDef from './audio-file-def';
 import { type ByteStream, type SerializedFile } from './file-api';
-import { extractOggDuration } from './ogg-meta-extractor';
+import { extractOggDurationFromStream } from './ogg-meta-extractor';
 
 export class OggDef extends AudioDef {
   static displayName = 'OGG Audio';
@@ -12,20 +11,17 @@ export class OggDef extends AudioDef {
   static async extractAttributes(
     url: string,
     getStream: () => Promise<ByteStream>,
-    options: { contentHash?: string } = {},
+    options: { contentHash?: string; contentSize?: number } = {},
   ): Promise<SerializedFile<{ duration: number }>> {
-    // OGG duration requires the final page's granule position, which lives
-    // at the tail of the file. Read the whole stream once and reuse the
-    // bytes for both base attribute extraction and duration parsing.
-    let bytesPromise: Promise<Uint8Array> | undefined;
-    let memoizedStream = async () => {
-      bytesPromise ??= byteStreamToUint8Array(await getStream());
-      return bytesPromise;
-    };
-
-    let base = await super.extractAttributes(url, memoizedStream, options);
-    let bytes = await memoizedStream();
-    let { duration } = extractOggDuration(bytes);
+    // OGG duration needs the first page (codec id / sample rate) and the final
+    // page's granule position — the head and tail of the file, never the audio
+    // payload in between. Stream the container keeping only a small head buffer
+    // and a rolling tail window, so even a long recording is parsed with
+    // ~64 KB resident rather than the whole file. `super` derives the hash/size
+    // from `options` (supplied by the indexer) without re-reading, so when
+    // those are present the stream is consumed exactly once — by this walk.
+    let base = await super.extractAttributes(url, getStream, options);
+    let { duration } = await extractOggDurationFromStream(await getStream());
 
     return {
       ...base,

--- a/packages/base/ogg-meta-extractor.ts
+++ b/packages/base/ogg-meta-extractor.ts
@@ -212,20 +212,32 @@ export async function extractOggDurationFromStream(
         continue;
       }
       // Accumulate the head until we have enough to parse the first page.
+      // Cap what we keep at OGG_HEAD_BYTES and copy it (slice, not subarray)
+      // so a large first chunk isn't pinned in memory by the head view.
       if (headLen < OGG_HEAD_BYTES) {
-        headParts.push(value);
-        headLen += value.length;
+        let take = Math.min(value.length, OGG_HEAD_BYTES - headLen);
+        headParts.push(value.slice(0, take));
+        headLen += take;
       }
-      // Maintain a rolling window of the most recent bytes: drop a front chunk
-      // only while the remainder still covers a full tail window.
-      tailParts.push(value);
-      tailLen += value.length;
-      while (
-        tailParts.length > 1 &&
-        tailLen - tailParts[0]!.length >= OGG_TAIL_BYTES
-      ) {
-        tailLen -= tailParts[0]!.length;
-        tailParts.shift();
+      // Maintain a rolling window of the last OGG_TAIL_BYTES bytes. Keeping
+      // memory bounded by the window rather than the chunking requires handling
+      // a single oversized chunk explicitly: copy just its tail and drop the
+      // rest (a subarray would pin the whole chunk's buffer). Smaller chunks
+      // accumulate, dropping whole front chunks once the remainder still covers
+      // the window — so the tail stays under 2 * OGG_TAIL_BYTES.
+      if (value.length >= OGG_TAIL_BYTES) {
+        tailParts = [value.slice(value.length - OGG_TAIL_BYTES)];
+        tailLen = OGG_TAIL_BYTES;
+      } else {
+        tailParts.push(value);
+        tailLen += value.length;
+        while (
+          tailParts.length > 1 &&
+          tailLen - tailParts[0]!.length >= OGG_TAIL_BYTES
+        ) {
+          tailLen -= tailParts[0]!.length;
+          tailParts.shift();
+        }
       }
     }
   } finally {

--- a/packages/base/ogg-meta-extractor.ts
+++ b/packages/base/ogg-meta-extractor.ts
@@ -158,3 +158,115 @@ export function extractOggDuration(bytes: Uint8Array): { duration: number } {
   let playable = Math.max(0, granule - preSkipSamples);
   return { duration: playable / outputSampleRate };
 }
+
+// Enough of the file's start to cover the first page header (27 bytes + up to
+// 255 lacing values) plus the Vorbis/Opus identification packet that follows.
+const OGG_HEAD_BYTES = 4096;
+
+// The final page's "OggS" sits at most one max-size Ogg page (27 + 255 +
+// 255*255 = 65307 bytes) before EOF in a well-formed stream. A tail window at
+// least that large always contains the last page header and its granule
+// position. Files with more than this much trailing data after the last Ogg
+// page (non-standard) fall back to the buffered AudioDef path with no
+// duration, rather than being mis-parsed.
+const OGG_TAIL_BYTES = 65536;
+
+function concatParts(parts: Uint8Array[], length: number): Uint8Array {
+  if (parts.length === 1) {
+    return parts[0]!;
+  }
+  let out = new Uint8Array(length);
+  let offset = 0;
+  for (let part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+// Streaming counterpart to `extractOggDuration`. The duration only needs the
+// first page (codec id / sample rate) and the final page (granule position) —
+// the head and tail of the file. We retain a small head buffer and a rolling
+// tail window, letting the audio payload in between stream past without being
+// buffered, so peak memory is ~`OGG_TAIL_BYTES` rather than the whole file. A
+// `Uint8Array` input (already-buffered bytes) is parsed directly.
+export async function extractOggDurationFromStream(
+  stream: ReadableStream<Uint8Array> | Uint8Array,
+): Promise<{ duration: number }> {
+  if (stream instanceof Uint8Array) {
+    return extractOggDuration(stream);
+  }
+
+  let reader = stream.getReader();
+  let headParts: Uint8Array[] = [];
+  let headLen = 0;
+  let tailParts: Uint8Array[] = [];
+  let tailLen = 0;
+  try {
+    for (;;) {
+      let { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value || value.length === 0) {
+        continue;
+      }
+      // Accumulate the head until we have enough to parse the first page.
+      if (headLen < OGG_HEAD_BYTES) {
+        headParts.push(value);
+        headLen += value.length;
+      }
+      // Maintain a rolling window of the most recent bytes: drop a front chunk
+      // only while the remainder still covers a full tail window.
+      tailParts.push(value);
+      tailLen += value.length;
+      while (
+        tailParts.length > 1 &&
+        tailLen - tailParts[0]!.length >= OGG_TAIL_BYTES
+      ) {
+        tailLen -= tailParts[0]!.length;
+        tailParts.shift();
+      }
+    }
+  } finally {
+    await reader.cancel().catch(() => {
+      // Reader already drained to EOF (or released); cancelling is a no-op.
+    });
+  }
+
+  let head = concatParts(headParts, headLen);
+  let tail = concatParts(tailParts, tailLen);
+
+  if (!matchBytes(head, 0, OGGS)) {
+    throw new FileContentMismatchError(
+      'File does not start with an Ogg "OggS" page',
+    );
+  }
+
+  let dataOffset = firstPageDataOffset(head);
+  let { outputSampleRate, preSkipSamples } = readCodecInfo(head, dataOffset);
+
+  // The last "OggS" in the whole file is at or after the final page's start,
+  // which lies within the retained tail window — so scanning the window
+  // backward yields the same page the buffered parser would find.
+  let lastPageOffset = findLastOggSPage(tail);
+  if (lastPageOffset === undefined) {
+    throw new FileContentMismatchError(
+      'OGG file does not contain a parseable page header',
+    );
+  }
+  if (lastPageOffset + GRANULE_POSITION_OFFSET + 8 > tail.length) {
+    throw new FileContentMismatchError(
+      'OGG file final page header is truncated',
+    );
+  }
+
+  let view = new DataView(tail.buffer, tail.byteOffset, tail.byteLength);
+  let granule = readUint64LEAsNumber(
+    view,
+    lastPageOffset + GRANULE_POSITION_OFFSET,
+  );
+
+  let playable = Math.max(0, granule - preSkipSamples);
+  return { duration: playable / outputSampleRate };
+}

--- a/packages/host/tests/acceptance/audio-def/ogg-audio-def-test.gts
+++ b/packages/host/tests/acceptance/audio-def/ogg-audio-def-test.gts
@@ -82,6 +82,27 @@ function makeMinimalOggOpus(): Uint8Array {
   return out;
 }
 
+// Same BOS/EOS pages as makeMinimalOggOpus, but with a large opaque payload
+// spliced between them so the file exceeds the streaming tail window. This
+// forces the head (first page) and tail (final page) to be parsed without the
+// middle ever being buffered — the streaming walk's whole point. Zero-filled
+// so it contains no stray "OggS" marker.
+function makeLargeOggOpus(): Uint8Array {
+  let minimal = makeMinimalOggOpus();
+  // makeMinimalOggOpus lays out page1 then page2. page1 = 27-byte header +
+  // 1 segment count + 19-byte OpusHead = 47 bytes; page2 follows.
+  const PAGE1_LEN = 47;
+  let page1 = minimal.subarray(0, PAGE1_LEN);
+  let page2 = minimal.subarray(PAGE1_LEN);
+  let middle = new Uint8Array(200 * 1024); // 200 KB, > tail window
+
+  let out = new Uint8Array(page1.length + middle.length + page2.length);
+  out.set(page1, 0);
+  out.set(middle, page1.length);
+  out.set(page2, page1.length + middle.length);
+  return out;
+}
+
 module('Acceptance | ogg audio def', function (hooks) {
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
@@ -167,6 +188,7 @@ module('Acceptance | ogg audio def', function (hooks) {
         contents: {
           ...SYSTEM_CARD_FIXTURE_CONTENTS,
           'sample.ogg': oggBytes,
+          'large.ogg': makeLargeOggOpus(),
           'not-an-ogg.ogg': 'This is plain text, not an OGG file.',
         },
       }),
@@ -195,6 +217,28 @@ module('Acceptance | ogg audio def', function (hooks) {
       String(result.searchDoc?.contentType).includes('ogg'),
       'sets ogg content type',
     );
+  });
+
+  test('extracts duration from a large OGG (streams past the middle)', async function (assert) {
+    // The 200 KB payload between the first and final pages exceeds the
+    // streaming tail window, so this only passes if the walk parses the head
+    // and tail without buffering the middle.
+    let url = makeFileURL('large.ogg');
+    await visit(
+      fileExtractPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: oggDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.strictEqual(
+      result.searchDoc?.duration,
+      1,
+      'extracts duration from the trailing page of a large file',
+    );
+    assert.strictEqual(result.searchDoc?.name, 'large.ogg');
   });
 
   test('falls back when OggDef is used for non-OGG content', async function (assert) {


### PR DESCRIPTION
Companion to the M4A streaming PR; builds on #5075 (low-memory file extraction off `main`).

## Problem

`OggDef.extractAttributes` reads the **whole file** into memory to extract the duration. It only actually needs two small regions: the **first page** (codec id → sample rate / pre-skip) and the **final page** (granule position). The audio payload in between is never used.

This is the same antipattern the M4A extractor had. Of the five audio extractors added in #5055, OGG is the only other one affected — MP3 / WAV / FLAC already bound their reads via `readFirstBytes` (1 MB / 64 KB / 256 B respectively).

## Why it's shaped differently from M4A

M4A boxes are length-prefixed, so `mdat` can be skipped by an exact byte count. Ogg pages aren't forward-skippable like that, and the `ByteStream` is forward-only (no seek). So instead the streaming walk keeps:

- a small **head buffer** (first page → `readCodecInfo`), and
- a **rolling tail window** sized to the maximum Ogg page (65307 B), so the final page's `OggS` header and granule are always retained,

discarding everything in between. Peak memory is ~64 KB regardless of recording length. (Files with more than a max-page of trailing data after the last Ogg page — non-standard — fall back to the buffered `AudioDef` path with no duration rather than being mis-parsed.)

## Changes

- **`ogg-meta-extractor.ts`** — add `extractOggDurationFromStream()`, reusing the existing `firstPageDataOffset` / `readCodecInfo` / `findLastOggSPage` / granule parsing against the retained head and tail buffers. A `Uint8Array` input is parsed directly via `extractOggDuration`.
- **`ogg-audio-def.gts`** — drop the whole-file memoization; stream once; widen `options` to include `contentSize` (forwarded to `super`).
- **test** — add a `large.ogg` fixture (200 KB spliced between the first and final pages, exceeding the tail window) that only passes if the middle is streamed past.

## Verification

- New streaming logic typechecks (isolated) and passes a standalone runtime test: Opus + Vorbis, pre-skip handling, the 200 KB-middle large file, chunk sizes 3 / 7 / 28 / 64 / 4K / 70K, the `Uint8Array` path, and the non-OGG mismatch path — each compared against the whole-buffer parser.
- Host acceptance suite not yet run live (needs full build + browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)