### PR TITLE
ci: Restore PR review reminder

### DIFF
--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -2,8 +2,7 @@ name: PR Review Reminder
 
 on:
   schedule:
-    - cron: "0 13 * * 1-5" # 9 AM EDT (summer)
-    - cron: "0 14 * * 1-5" # 9 AM EST (winter)
+    - cron: "0 0 * * 1-5" # midnight UTC, weekdays
   workflow_dispatch:
 
 permissions:
@@ -25,13 +24,6 @@ jobs:
           if [ -z "$DISCORD_WEBHOOK" ]; then
             echo "::error::PR_REVIEW_DISCORD_WEBHOOK secret is not set"
             exit 1
-          fi
-
-          # Only run at 9 AM ET — skip the trigger that doesn't match current DST
-          current_et_hour="$(TZ=America/New_York date +%H)"
-          if [ "$current_et_hour" != "09" ]; then
-            echo "Current ET hour is $current_et_hour, not 9 AM. Skipping."
-            exit 0
           fi
 
           prs="$(gh api graphql -f query='


### PR DESCRIPTION
The PR review reminder stopped posting because it was queuing long enough that it didn’t run until after the hour, so the DST/non-check was never matching the correct hour.

This changes to post at 00:00 UTC instead, which is much simpler, and a daily reminder is fine, regardless of the time.