### PR TITLE
Job-scoped per-instance wire-format cache for prerender assembly

### DIFF
--- a/packages/host/config/schema/1780412666457_schema.sql
+++ b/packages/host/config/schema/1780412666457_schema.sql
@@ -88,6 +88,14 @@
    PRIMARY KEY ( id ) 
 );
 
+ CREATE TABLE IF NOT EXISTS job_scoped_instance_cache (
+   job_id TEXT NOT NULL,
+   url TEXT NOT NULL,
+   result TEXT NOT NULL,
+   created_at DEFAULT CURRENT_TIMESTAMP NOT NULL,
+   PRIMARY KEY ( job_id, url ) 
+);
+
  CREATE TABLE IF NOT EXISTS module_transpile_cache (
    realm_url TEXT NOT NULL,
    canonical_path TEXT NOT NULL,

--- a/packages/postgres/migrations/1780412666457_create-job-scoped-instance-cache.js
+++ b/packages/postgres/migrations/1780412666457_create-job-scoped-instance-cache.js
@@ -1,0 +1,53 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+// Shared storage for the job-scoped per-instance wire-format cache. Each row
+// holds one card's fully-assembled JSON:API resource (its `pristine_doc` plus
+// its populated query-field umbrellas) computed once during one indexing job
+// and reused for every later occurrence of that instance within the job — as a
+// search result, a per-URL card GET, or a linked target of another card. Like
+// the federated-search cache it lives in Postgres so every realm-server replica
+// shares the same entries.
+//
+// Key: the outer `job_id` is the `<jobId>.<reservationId>` job identity stamped
+// on `x-boxel-job-id` (a job can re-run under a new reservation, and committed
+// `boxel_index` may move between runs, so the reservation must be part of the
+// key); the inner key is the instance URL. Correctness rests on `boxel_index`
+// being frozen for a job's lifetime (the writer touches `boxel_index_working`
+// until the final swap), so a per-instance entry is stable within the job and
+// no cross-entry invalidation is needed.
+//
+// UNLOGGED: pure cache data — losing it on a Postgres crash just means the next
+// assembly recomputes and re-populates. No historical value, and UNLOGGED
+// bypasses WAL + replication for this hot-write table. (node-pg-migrate's
+// createTable doesn't expose UNLOGGED, so the table is built with raw SQL.)
+//
+// Eviction: a finished job's rows are dropped by the jobs_finished NOTIFY
+// listener; the created_at index backs an age-based janitor that sweeps rows a
+// job left behind on a missed NOTIFY — the same lifecycle as
+// job_scoped_search_cache.
+exports.up = (pgm) => {
+  pgm.sql(`
+    CREATE UNLOGGED TABLE job_scoped_instance_cache (
+      job_id      varchar     NOT NULL,
+      url         varchar     NOT NULL,
+      result      text        NOT NULL,
+      created_at  timestamptz NOT NULL DEFAULT NOW(),
+      PRIMARY KEY (job_id, url)
+    );
+    CREATE INDEX job_scoped_instance_cache_created_at_idx
+      ON job_scoped_instance_cache (created_at);
+  `);
+
+  // Clear the federated-search cache on rollout. Both caches now sit on the
+  // prerender search/GET assembly path; dropping any warm search-cache rows
+  // here guarantees a clean slate so no entry predating this change is served
+  // alongside the new per-instance path. Safe and cheap: entries are
+  // job-scoped and transient, so there is no warm state worth preserving.
+  pgm.sql(`TRUNCATE job_scoped_search_cache;`);
+};
+
+exports.down = (pgm) => {
+  pgm.sql(`DROP TABLE IF EXISTS job_scoped_instance_cache;`);
+};

--- a/packages/postgres/migrations/1780412666457_create-job-scoped-instance-cache.js
+++ b/packages/postgres/migrations/1780412666457_create-job-scoped-instance-cache.js
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 exports.shorthands = undefined;
 
 // Shared storage for the job-scoped per-instance wire-format cache. Each row

--- a/packages/realm-server/handlers/handle-search.ts
+++ b/packages/realm-server/handlers/handle-search.ts
@@ -84,16 +84,26 @@ export default function handleSearch(opts: {
     let jobPriority = sanitizeJobPriorityHeader(
       ctxt.get(PRERENDER_JOB_PRIORITY_HEADER),
     );
+    // `<jobId>.<reservationId>` identity stamped by indexer-driven prerender
+    // requests. Threaded into searchOpts so the per-instance wire-format cache
+    // (`job_scoped_instance_cache`, consulted inside `loadLinks`) scopes its
+    // entries to one indexing job; also reused below as the query-level
+    // cache's job key. Absent for live / external callers.
+    let prerenderJobId = sanitizePrerenderJobId(
+      ctxt.get(PRERENDER_JOB_ID_HEADER),
+    );
     let searchOpts: {
       cacheOnlyDefinitions?: true;
       skipQueryBackedExpansion?: true;
       omitIncluded?: true;
       priority?: number;
+      jobIdentity?: string;
     } = {};
     if (cacheOnlyDefinitions) searchOpts.cacheOnlyDefinitions = true;
     if (skipQueryBackedExpansion) searchOpts.skipQueryBackedExpansion = true;
     if (omitIncluded) searchOpts.omitIncluded = true;
     if (jobPriority !== null) searchOpts.priority = jobPriority;
+    if (prerenderJobId) searchOpts.jobIdentity = prerenderJobId;
     let normalizedSearchOpts =
       Object.keys(searchOpts).length > 0 ? searchOpts : undefined;
     // `consumingRealm` is read unconditionally — even when the
@@ -139,9 +149,7 @@ export default function handleSearch(opts: {
     // `multiRealmAuthorization` has already validated read access to
     // every entry of `realmList` for this caller, so the cache cannot
     // surface results across an authorization boundary.
-    let jobId = searchCache
-      ? sanitizePrerenderJobId(ctxt.get(PRERENDER_JOB_ID_HEADER))
-      : null;
+    let jobId = searchCache ? prerenderJobId : null;
     let cacheable = searchCache && jobId && consumingRealm;
 
     if (cacheable) {

--- a/packages/realm-server/job-scoped-instance-cache.ts
+++ b/packages/realm-server/job-scoped-instance-cache.ts
@@ -1,0 +1,109 @@
+import {
+  logger,
+  query,
+  param,
+  type DBAdapter,
+  type Expression,
+} from '@cardstack/runtime-common';
+
+const log = logger('job-scoped-instance-cache');
+
+const TABLE = 'job_scoped_instance_cache';
+
+// Missed-NOTIFY backstop, mirroring JobScopedSearchCache. Eviction is normally
+// driven by the jobs_finished listener; this TTL only governs the janitor sweep
+// that reclaims rows a job left behind when a replica missed the NOTIFY. Picked
+// to comfortably outlive a single indexing batch while bounding the leak window.
+const DEFAULT_TTL_MS = 6 * 60 * 60 * 1000;
+const DEFAULT_JANITOR_INTERVAL_MS = 30 * 60 * 1000;
+
+// Eviction + janitor surface for the job-scoped per-instance wire-format cache.
+//
+// Unlike JobScopedSearchCache this class deliberately has no getOrPopulate: the
+// reads and writes happen inside `RealmIndexQueryEngine.loadLinks`
+// (runtime-common), where the assembled resource is produced and consumed. The
+// table is the shared contract — runtime-common populates it, this class owns
+// its lifecycle on the realm-server side (NOTIFY-driven eviction via
+// JobsFinishedListener + an age-based janitor backstop), exactly like the
+// search cache. Keyed by the `<jobId>.<reservationId>` job identity so a job
+// that re-runs under a new reservation never reuses a prior run's entries.
+export class JobScopedInstanceCache {
+  readonly #dbAdapter: DBAdapter;
+  readonly #ttlMs: number;
+  readonly #janitorIntervalMs: number;
+  #janitorTimer: ReturnType<typeof setInterval> | undefined;
+
+  constructor(
+    dbAdapter: DBAdapter,
+    opts?: { ttlMs?: number; janitorIntervalMs?: number },
+  ) {
+    this.#dbAdapter = dbAdapter;
+    this.#ttlMs = opts?.ttlMs ?? DEFAULT_TTL_MS;
+    this.#janitorIntervalMs =
+      opts?.janitorIntervalMs ?? DEFAULT_JANITOR_INTERVAL_MS;
+  }
+
+  // Distinct `<jobId>.<reservationId>` keys currently holding entries. The
+  // JobsFinishedListener parses these to learn which jobs to check for
+  // finalization.
+  async jobIds(): Promise<string[]> {
+    let rows = (await query(this.#dbAdapter, [
+      `SELECT DISTINCT job_id FROM ${TABLE}`,
+    ] as Expression)) as { job_id: string }[];
+    return rows.map((row) => row.job_id);
+  }
+
+  // Drop every entry for a given job identity. Driven by the jobs_finished
+  // NOTIFY listener so the cache releases rows as soon as the worker signals
+  // completion, rather than waiting on the janitor.
+  async clearJob(jobId: string): Promise<void> {
+    await query(this.#dbAdapter, [
+      `DELETE FROM ${TABLE} WHERE job_id=`,
+      param(jobId),
+    ] as Expression);
+  }
+
+  async size(): Promise<number> {
+    let rows = (await query(this.#dbAdapter, [
+      `SELECT COUNT(*)::int AS count FROM ${TABLE}`,
+    ] as Expression)) as { count: number }[];
+    return rows[0]?.count ?? 0;
+  }
+
+  startJanitor(): void {
+    if (this.#janitorTimer) {
+      return;
+    }
+    this.#janitorTimer = setInterval(() => {
+      void this.sweepExpired();
+    }, this.#janitorIntervalMs);
+    if (
+      typeof (this.#janitorTimer as { unref?: () => void }).unref === 'function'
+    ) {
+      (this.#janitorTimer as { unref: () => void }).unref();
+    }
+  }
+
+  stopJanitor(): void {
+    if (this.#janitorTimer) {
+      clearInterval(this.#janitorTimer);
+      this.#janitorTimer = undefined;
+    }
+  }
+
+  // Delete rows older than the TTL — the rows a job left behind because some
+  // replica missed its jobs_finished NOTIFY. Best-effort.
+  async sweepExpired(): Promise<void> {
+    try {
+      await query(this.#dbAdapter, [
+        `DELETE FROM ${TABLE} WHERE created_at < NOW() - (`,
+        param(this.#ttlMs),
+        ` * INTERVAL '1 millisecond')`,
+      ] as Expression);
+    } catch (err: unknown) {
+      log.warn(
+        `job-scoped instance cache janitor sweep failed: ${String(err)}`,
+      );
+    }
+  }
+}

--- a/packages/realm-server/lib/jobs-finished-listener.ts
+++ b/packages/realm-server/lib/jobs-finished-listener.ts
@@ -128,11 +128,12 @@ export class JobsFinishedListener {
 
   async #sweep(): Promise<void> {
     // Union the keys held by both job-scoped caches; a key may live in only
-    // one of them, and a finalized job should be cleared from both.
-    let searchKeys = await this.#deps.searchCache.jobIds();
-    let instanceKeys = this.#deps.instanceCache
-      ? await this.#deps.instanceCache.jobIds()
-      : [];
+    // one of them, and a finalized job should be cleared from both. The two
+    // reads hit independent tables, so run them concurrently.
+    let [searchKeys, instanceKeys] = await Promise.all([
+      this.#deps.searchCache.jobIds(),
+      this.#deps.instanceCache?.jobIds() ?? Promise.resolve<string[]>([]),
+    ]);
     let keys = [...new Set([...searchKeys, ...instanceKeys])];
     if (keys.length === 0) {
       return;

--- a/packages/realm-server/lib/jobs-finished-listener.ts
+++ b/packages/realm-server/lib/jobs-finished-listener.ts
@@ -36,7 +36,12 @@ type SearchCacheView = Pick<JobScopedSearchCache, 'jobIds' | 'clearJob'>;
 export interface JobsFinishedListenerDeps {
   dbAdapter: PgAdapter;
   searchCache: SearchCacheView;
-  // Test seam: given the job ids the cache currently holds entries for, return
+  // The per-instance wire-format cache (job_scoped_instance_cache). Swept on
+  // the same notification as the search cache — both are job-scoped and keyed
+  // by the same `<jobId>.<reservationId>` identity. Optional so deployments
+  // without the per-instance cache wired keep working unchanged.
+  instanceCache?: SearchCacheView;
+  // Test seam: given the job ids the caches currently hold entries for, return
   // the subset that have finalized. Defaults to a query against `jobs`.
   fetchFinalizedJobIds?: (candidateJobIds: number[]) => Promise<Set<number>>;
 }
@@ -122,7 +127,13 @@ export class JobsFinishedListener {
   }
 
   async #sweep(): Promise<void> {
-    let keys = await this.#deps.searchCache.jobIds();
+    // Union the keys held by both job-scoped caches; a key may live in only
+    // one of them, and a finalized job should be cleared from both.
+    let searchKeys = await this.#deps.searchCache.jobIds();
+    let instanceKeys = this.#deps.instanceCache
+      ? await this.#deps.instanceCache.jobIds()
+      : [];
+    let keys = [...new Set([...searchKeys, ...instanceKeys])];
     if (keys.length === 0) {
       return;
     }
@@ -147,7 +158,9 @@ export class JobsFinishedListener {
     let finalized = await this.#fetchFinalizedJobIds([...keysByJobId.keys()]);
     for (let jobId of finalized) {
       for (let key of keysByJobId.get(jobId) ?? []) {
+        // clearJob on a cache that doesn't hold the key is a no-op DELETE.
         await this.#deps.searchCache.clearJob(key);
+        await this.#deps.instanceCache?.clearJob(key);
       }
     }
   }

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -42,6 +42,7 @@ import { ModuleCacheInvalidationListener } from './lib/module-cache-invalidation
 import { ModuleCacheCoordinator } from './lib/module-cache-coordination';
 import { JobsFinishedListener } from './lib/jobs-finished-listener';
 import { JobScopedSearchCache } from './job-scoped-search-cache';
+import { JobScopedInstanceCache } from './job-scoped-instance-cache';
 import { resolveFullIndexOnStartup } from './lib/full-index-on-startup';
 import { PUBLISHED_DIRECTORY_NAME } from '@cardstack/runtime-common';
 
@@ -383,6 +384,13 @@ const smokeTestHostApp = async () => {
   // `jobs_finished` NOTIFY evicts the same entries the handlers populate.
   let searchCache = new JobScopedSearchCache(dbAdapter);
   searchCache.startJanitor();
+  // Per-instance wire-format cache (job_scoped_instance_cache). Reads/writes
+  // happen in runtime-common's loadLinks; this process owns its eviction (via
+  // the JobsFinishedListener below) and the age-based janitor backstop. Inert
+  // until INDEXER_INSTANCE_CACHE is enabled (loadLinks never populates the
+  // table otherwise), so the janitor just sweeps an empty table.
+  let instanceCache = new JobScopedInstanceCache(dbAdapter);
+  instanceCache.startJanitor();
   let reconciler: RealmRegistryReconciler | undefined;
   let fileChangesListener: RealmFileChangesListener | undefined;
   let indexUpdatedListener: RealmIndexUpdatedListener | undefined;
@@ -633,6 +641,7 @@ const smokeTestHostApp = async () => {
       (httpServer as any).closeAllConnections();
     }
     searchCache.stopJanitor();
+    instanceCache.stopJanitor();
     httpServer.close(() => {
       (async () => {
         await Promise.all([
@@ -758,6 +767,7 @@ const smokeTestHostApp = async () => {
   jobsFinishedListener = new JobsFinishedListener({
     dbAdapter,
     searchCache,
+    instanceCache,
   });
   await jobsFinishedListener.start();
 

--- a/packages/realm-server/prerender/prerender-constants.ts
+++ b/packages/realm-server/prerender/prerender-constants.ts
@@ -68,19 +68,11 @@ export {
 // Re-exported here for the host fetch wrapper's import-locality.
 export { DURING_PRERENDER_HEADER } from '@cardstack/runtime-common';
 
-// Sanitize the inbound job-id header. Format is `<digits>.<digits>`
-// (job.id + reservation.id, both bigint-shaped); accept up to 32
-// digits per side (so up to 65 chars total including the separator)
-// to be defensive without admitting newlines or other log-injection.
-const JOB_ID_PATTERN = /^[0-9]{1,32}\.[0-9]{1,32}$/;
-export function sanitizePrerenderJobId(
-  raw: string | null | undefined,
-): string | null {
-  if (typeof raw !== 'string') return null;
-  let trimmed = raw.trim();
-  if (!trimmed) return null;
-  return JOB_ID_PATTERN.test(trimmed) ? trimmed : null;
-}
+// Sanitize the inbound job-id header (`<digits>.<digits>` = job.id +
+// reservation.id). Defined in runtime-common alongside
+// `X_BOXEL_JOB_ID_HEADER` so the Realm class can normalize the identity
+// without depending on realm-server; re-exported here for import-locality.
+export { sanitizePrerenderJobId } from '@cardstack/runtime-common';
 
 // Base timeout for a single prerender capture on the prerender server
 // (DOM rendering + data loading inside the headless browser).

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -291,6 +291,8 @@ const ALL_TEST_FILES: string[] = [
   './session-room-queries-test',
   './indexing-event-sink-test',
   './skip-query-backed-expansion-test',
+  './job-scoped-instance-cache-test',
+  './per-instance-cache-test',
 ];
 
 // TEST_FILES limits which test files are loaded (parsed and executed). Useful

--- a/packages/realm-server/tests/job-scoped-instance-cache-test.ts
+++ b/packages/realm-server/tests/job-scoped-instance-cache-test.ts
@@ -1,0 +1,89 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import type { PgAdapter } from '@cardstack/postgres';
+import { query, param, type Expression } from '@cardstack/runtime-common';
+import { setupDB } from './helpers';
+import { JobScopedInstanceCache } from '../job-scoped-instance-cache';
+
+const TABLE = 'job_scoped_instance_cache';
+const realm = 'http://localhost:4201/test/';
+
+async function seed(
+  dbAdapter: PgAdapter,
+  jobId: string,
+  url: string,
+  ageSql = 'NOW()',
+): Promise<void> {
+  await query(dbAdapter, [
+    `INSERT INTO ${TABLE} (job_id, url, result, created_at) VALUES (`,
+    param(jobId),
+    `,`,
+    param(url),
+    `,`,
+    param('{}'),
+    `, ${ageSql})`,
+  ] as Expression);
+}
+
+module(basename(__filename), function (hooks) {
+  let dbAdapter: PgAdapter;
+
+  setupDB(hooks, {
+    beforeEach: async (adapter) => {
+      dbAdapter = adapter;
+    },
+  });
+
+  module('JobScopedInstanceCache eviction', function () {
+    test('jobIds returns the distinct job identities holding entries', async function (assert) {
+      let cache = new JobScopedInstanceCache(dbAdapter);
+      await seed(dbAdapter, '42.1', `${realm}a`);
+      await seed(dbAdapter, '42.1', `${realm}b`);
+      await seed(dbAdapter, '43.1', `${realm}c`);
+
+      let ids = (await cache.jobIds()).sort();
+      assert.deepEqual(ids, ['42.1', '43.1'], 'one entry per distinct job id');
+      assert.strictEqual(await cache.size(), 3, 'three rows total');
+    });
+
+    test('clearJob deletes only the named job identity', async function (assert) {
+      let cache = new JobScopedInstanceCache(dbAdapter);
+      await seed(dbAdapter, '42.1', `${realm}a`);
+      await seed(dbAdapter, '42.1', `${realm}b`);
+      await seed(dbAdapter, '43.1', `${realm}c`);
+
+      await cache.clearJob('42.1');
+
+      assert.deepEqual(await cache.jobIds(), ['43.1'], 'only 43.1 remains');
+      assert.strictEqual(await cache.size(), 1, 'one row left');
+    });
+
+    test('clearJob distinguishes reservations of the same job', async function (assert) {
+      let cache = new JobScopedInstanceCache(dbAdapter);
+      await seed(dbAdapter, '50.1', `${realm}a`);
+      await seed(dbAdapter, '50.2', `${realm}a`);
+
+      await cache.clearJob('50.1');
+
+      assert.deepEqual(
+        await cache.jobIds(),
+        ['50.2'],
+        'the other reservation’s entry survives a per-reservation clear',
+      );
+    });
+
+    test('sweepExpired drops rows older than the TTL, keeps fresh ones', async function (assert) {
+      let cache = new JobScopedInstanceCache(dbAdapter);
+      await seed(dbAdapter, '42.1', `${realm}old`, `NOW() - INTERVAL '1 day'`);
+      await seed(dbAdapter, '43.1', `${realm}fresh`);
+
+      await cache.sweepExpired();
+
+      assert.deepEqual(
+        await cache.jobIds(),
+        ['43.1'],
+        'the day-old row was swept, the fresh row kept',
+      );
+    });
+  });
+});

--- a/packages/realm-server/tests/per-instance-cache-test.ts
+++ b/packages/realm-server/tests/per-instance-cache-test.ts
@@ -1,0 +1,204 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { rri, query, param, type Expression } from '@cardstack/runtime-common';
+import type { LooseSingleCardDocument, Realm } from '@cardstack/runtime-common';
+import type { PgAdapter } from '@cardstack/postgres';
+import { setupPermissionedRealmCached } from './helpers';
+
+// Exercises the job-scoped per-instance wire-format cache
+// (job_scoped_instance_cache) that RealmIndexQueryEngine.loadLinks consults
+// per root resource. The flag (INDEXER_INSTANCE_CACHE) gates it and a request
+// must carry a job identity, so the assertions toggle the env var per test.
+
+const testRealm = new URL('http://127.0.0.1:4452/test/');
+const CACHE_TABLE = 'job_scoped_instance_cache';
+
+function buildFileSystem(): Record<string, string | LooseSingleCardDocument> {
+  let fs: Record<string, string | LooseSingleCardDocument> = {};
+
+  fs['target.gts'] = `
+    import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
+    import StringField from "https://cardstack.com/base/string";
+
+    export class Target extends CardDef {
+      @field name = contains(StringField);
+      @field cardTitle = contains(StringField);
+    }
+  `;
+
+  fs['consumer.gts'] = `
+    import { contains, field, linksTo, linksToMany, CardDef } from "https://cardstack.com/base/card-api";
+    import StringField from "https://cardstack.com/base/string";
+    import { Target } from "./target";
+
+    export class Consumer extends CardDef {
+      @field name = contains(StringField);
+      @field directLink = linksTo(() => Target);
+      @field queryLinks = linksToMany(() => Target, {
+        query: {
+          filter: { eq: { cardTitle: 'query-match' } },
+          page: { size: 10, number: 0 },
+        },
+      });
+    }
+  `;
+
+  for (let i = 0; i < 3; i++) {
+    fs[`query-target-${i}.json`] = {
+      data: {
+        attributes: { name: `QT${i}`, cardTitle: 'query-match' },
+        meta: { adoptsFrom: { module: rri('./target'), name: 'Target' } },
+      },
+    } as LooseSingleCardDocument;
+  }
+
+  fs['direct-target.json'] = {
+    data: {
+      attributes: { name: 'DT', cardTitle: 'direct' },
+      meta: { adoptsFrom: { module: rri('./target'), name: 'Target' } },
+    },
+  } as LooseSingleCardDocument;
+
+  fs['consumer-1.json'] = {
+    data: {
+      attributes: { name: 'C1' },
+      relationships: { directLink: { links: { self: './direct-target' } } },
+      meta: { adoptsFrom: { module: rri('./consumer'), name: 'Consumer' } },
+    },
+  } as LooseSingleCardDocument;
+
+  return fs;
+}
+
+module(basename(__filename), function () {
+  module('per-instance wire-format cache', function (hooks) {
+    let realm: Realm;
+    let dbAdapter: PgAdapter;
+
+    setupPermissionedRealmCached(hooks, {
+      mode: 'before',
+      realmURL: testRealm,
+      permissions: { '*': ['read'] },
+      fileSystem: buildFileSystem(),
+      onRealmSetup({ testRealm: r, dbAdapter: a }) {
+        realm = r;
+        dbAdapter = a;
+      },
+    });
+
+    hooks.beforeEach(async function () {
+      await query(dbAdapter, [`DELETE FROM ${CACHE_TABLE}`] as Expression);
+      delete process.env.INDEXER_INSTANCE_CACHE;
+    });
+
+    hooks.afterEach(function () {
+      delete process.env.INDEXER_INSTANCE_CACHE;
+    });
+
+    async function queryLinkCount(jobIdentity?: string): Promise<number> {
+      let result = await realm.realmIndexQueryEngine.cardDocument(
+        new URL(`${testRealm}consumer-1`),
+        { loadLinks: true, ...(jobIdentity ? { jobIdentity } : {}) },
+      );
+      let doc = result?.type === 'doc' ? result.doc : undefined;
+      let queryLinks = (
+        doc?.data.relationships as
+          | Record<string, { data?: Array<{ id: string }> }>
+          | undefined
+      )?.queryLinks;
+      return queryLinks?.data?.length ?? -1;
+    }
+
+    async function cacheRowCount(jobIdentity: string): Promise<number> {
+      let rows = (await query(dbAdapter, [
+        `SELECT COUNT(*)::int AS count FROM ${CACHE_TABLE} WHERE job_id =`,
+        param(jobIdentity),
+      ] as Expression)) as { count: number }[];
+      return rows[0]?.count ?? 0;
+    }
+
+    test('flag off: no cache rows written, query-backed field resolves live', async function (assert) {
+      assert.strictEqual(await queryLinkCount('1.1'), 3, 'three live matches');
+      assert.strictEqual(
+        await cacheRowCount('1.1'),
+        0,
+        'nothing cached when the flag is off',
+      );
+    });
+
+    test('flag on but no job identity: live traffic never touches the cache', async function (assert) {
+      process.env.INDEXER_INSTANCE_CACHE = 'true';
+      assert.strictEqual(await queryLinkCount(), 3, 'three live matches');
+      let rows = (await query(dbAdapter, [
+        `SELECT COUNT(*)::int AS count FROM ${CACHE_TABLE}`,
+      ] as Expression)) as { count: number }[];
+      let total = rows[0]?.count ?? 0;
+      assert.strictEqual(total, 0, 'table untouched');
+    });
+
+    test('flag on + job identity: writes the assembled resource, and a hit is served from the cache', async function (assert) {
+      process.env.INDEXER_INSTANCE_CACHE = 'true';
+
+      // First call assembles live and writes the cache.
+      assert.strictEqual(await queryLinkCount('7.1'), 3, 'first call is live');
+      assert.ok(
+        (await cacheRowCount('7.1')) >= 1,
+        'an entry was written for this job',
+      );
+
+      // Mutate the cached consumer row so the umbrella names zero matches.
+      // A subsequent assembly under the same job must reflect the cached
+      // (pinned) value, proving the read path short-circuits populateQueryFields.
+      let rows = (await query(dbAdapter, [
+        `SELECT url, result FROM ${CACHE_TABLE} WHERE job_id =`,
+        param('7.1'),
+        ` AND url LIKE '%consumer-1'`,
+      ] as Expression)) as { url: string; result: string }[];
+      assert.strictEqual(rows.length, 1, 'consumer row is cached');
+      let rels = JSON.parse(rows[0].result) as {
+        queryLinks?: { data?: unknown[] };
+      };
+      rels.queryLinks = { ...(rels.queryLinks ?? {}), data: [] };
+      await query(dbAdapter, [
+        `UPDATE ${CACHE_TABLE} SET result =`,
+        param(JSON.stringify(rels)),
+        ` WHERE job_id =`,
+        param('7.1'),
+        ` AND url =`,
+        param(rows[0].url),
+      ] as Expression);
+
+      assert.strictEqual(
+        await queryLinkCount('7.1'),
+        0,
+        'second call under the same job is served from the (mutated) cache',
+      );
+    });
+
+    test('cache is scoped per job identity', async function (assert) {
+      process.env.INDEXER_INSTANCE_CACHE = 'true';
+
+      // Populate + poison job 8.1's cached consumer row.
+      await queryLinkCount('8.1');
+      await query(dbAdapter, [
+        `UPDATE ${CACHE_TABLE} SET result =`,
+        param(JSON.stringify({ queryLinks: { data: [] } })),
+        ` WHERE job_id =`,
+        param('8.1'),
+        ` AND url LIKE '%consumer-1'`,
+      ] as Expression);
+      assert.strictEqual(
+        await queryLinkCount('8.1'),
+        0,
+        'job 8.1 reads its own poisoned entry',
+      );
+
+      // A different job identity must not see job 8.1's entry.
+      assert.strictEqual(
+        await queryLinkCount('9.1'),
+        3,
+        'job 9.1 assembles live, ignoring job 8.1 entries',
+      );
+    });
+  });
+});

--- a/packages/runtime-common/prerender-headers.ts
+++ b/packages/runtime-common/prerender-headers.ts
@@ -11,6 +11,24 @@
 // for backwards-compatibility with existing imports.
 export const X_BOXEL_JOB_ID_HEADER = 'x-boxel-job-id';
 
+// Sanitize the inbound job-id header. Format is `<digits>.<digits>`
+// (job.id + reservation.id, both bigint-shaped); accept up to 32 digits
+// per side (so up to 65 chars total including the separator) to be
+// defensive without admitting newlines or other log-injection. Lives
+// here alongside the header so both the realm-server search handlers and
+// the Realm class (card-GET assembly) normalize the identity the same way
+// before using it as a job-scoped cache key. realm-server's
+// `prerender-constants.ts` re-exports this as `sanitizePrerenderJobId`.
+const JOB_ID_PATTERN = /^[0-9]{1,32}\.[0-9]{1,32}$/;
+export function sanitizePrerenderJobId(
+  raw: string | null | undefined,
+): string | null {
+  if (typeof raw !== 'string') return null;
+  let trimmed = raw.trim();
+  if (!trimmed) return null;
+  return JOB_ID_PATTERN.test(trimmed) ? trimmed : null;
+}
+
 // HTTP header sent by the host's `_federated-search` fetch wrapper while
 // rendering inside a prerender tab. Carries the URL of the realm whose
 // card is currently being rendered (the "consuming" realm). The realm-

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -27,6 +27,9 @@ import {
   visitInstanceURLs,
   maybeRelativeReference,
   codeRefFromInternalKey,
+  query,
+  param,
+  type Expression,
 } from '.';
 import type { Realm } from './realm';
 import type { VirtualNetwork } from './virtual-network';
@@ -76,6 +79,21 @@ import {
 // uses the same depth for repeated card types).
 const RECURSING_DEPTH = 3;
 
+const INSTANCE_CACHE_TABLE = 'job_scoped_instance_cache';
+
+// Feature flag for the job-scoped per-instance wire-format cache. Default off
+// so the indexing hot path is byte-for-byte unchanged until an operator opts
+// in; read live (not memoized) so tests can toggle it per-case. Only ever
+// consulted when a request also carries a job identity, so live / external
+// traffic is unaffected regardless of the flag.
+function instanceCacheEnabled(): boolean {
+  return (
+    typeof process !== 'undefined' &&
+    (process.env?.INDEXER_INSTANCE_CACHE === 'true' ||
+      process.env?.INDEXER_INSTANCE_CACHE === '1')
+  );
+}
+
 type Options = {
   loadLinks?: true;
   linkFields?: string[];
@@ -117,6 +135,17 @@ type Options = {
   // Implies the query-backed `${field}.N` sub-entry stripping
   // (see `skipQueryBackedExpansion`) so the seeded roots stay orphan-free.
   omitIncluded?: boolean;
+  // The `<jobId>.<reservationId>` job identity (from the `x-boxel-job-id`
+  // header), threaded by the realm-server search / card-GET handlers when a
+  // request originates inside an indexing prerender. Enables the per-instance
+  // wire-format cache (`job_scoped_instance_cache`): within one job
+  // `boxel_index` is frozen, so an instance's assembled query-field
+  // relationships are stable and can be reused across every search / GET that
+  // touches it. The reservation is part of the key because a job can re-run
+  // under a new reservation, between which committed state may move. Absent
+  // for live / external callers, which therefore never read or write the
+  // cache.
+  jobIdentity?: string;
 } & QueryOptions;
 
 type SearchResult = SearchResultDoc | SearchResultError;
@@ -209,6 +238,7 @@ export class RealmIndexQueryEngine {
   #fetch: typeof globalThis.fetch;
   #indexQueryEngine: IndexQueryEngine;
   #definitionLookup: DefinitionLookup;
+  #dbAdapter: DBAdapter;
   #log = logger('realm:index-query-engine');
   // In-flight dedup for searchCards: concurrent callers asking for the same
   // (realm, query, opts) share one in-flight promise instead of each running
@@ -263,6 +293,7 @@ export class RealmIndexQueryEngine {
     }
     this.#indexQueryEngine = new IndexQueryEngine(dbAdapter, definitionLookup);
     this.#definitionLookup = definitionLookup;
+    this.#dbAdapter = dbAdapter;
     this.#realm = realm;
     this.#fetch = fetch;
   }
@@ -1171,6 +1202,84 @@ export class RealmIndexQueryEngine {
   // in-realm cards and one for in-realm file-meta resources, alongside
   // Promise.all-fanout cross-realm fetches, all running concurrently
   // regardless of how many siblings reference links at that depth.
+  // ── Job-scoped per-instance wire-format cache (job_scoped_instance_cache) ──
+  // Within one indexing job `boxel_index` is frozen, so an instance's assembled
+  // query-field relationships are stable. Caching them per (jobIdentity, url)
+  // lets every later occurrence of the instance in the job — another search
+  // result, a per-URL card GET, a linked target — skip the definition lookup +
+  // field-tree walk that `populateQueryFields` would otherwise repeat.
+
+  // Cache coordinates for a resource, or undefined when caching doesn't apply:
+  // no job identity (live / external traffic), no id, a sparse-fieldset
+  // (partial) population that mustn't masquerade as a full assembly, or the
+  // flag is off.
+  #instanceCacheKey(
+    resource: LooseCardResource | FileMetaResource,
+    opts: Options | undefined,
+  ): { jobId: string; url: string } | undefined {
+    if (
+      !opts?.jobIdentity ||
+      !resource.id ||
+      opts.linkFields ||
+      !instanceCacheEnabled()
+    ) {
+      return undefined;
+    }
+    return { jobId: opts.jobIdentity, url: resource.id };
+  }
+
+  // `undefined` = cache miss (no row); `null` = cached "no relationships";
+  // object = cached relationships map. Best-effort: a read failure degrades to
+  // a recompute, never an error.
+  async #readCachedRelationships(
+    jobId: string,
+    url: string,
+  ): Promise<Record<string, unknown> | null | undefined> {
+    try {
+      let rows = (await query(this.#dbAdapter, [
+        `SELECT result FROM ${INSTANCE_CACHE_TABLE} WHERE job_id =`,
+        param(jobId),
+        ` AND url =`,
+        param(url),
+      ] as Expression)) as { result: string }[];
+      if (!rows.length) {
+        return undefined;
+      }
+      return JSON.parse(rows[0].result) as Record<string, unknown> | null;
+    } catch (err: unknown) {
+      this.#log.warn(
+        `per-instance cache read failed for ${url} (job ${jobId}): ${String(err)}`,
+      );
+      return undefined;
+    }
+  }
+
+  // First write wins (ON CONFLICT DO NOTHING) — concurrent populates of the
+  // same instance in one job produce equivalent results against the frozen
+  // index, so either is valid. Best-effort: a write failure is logged, never
+  // thrown.
+  async #writeCachedRelationships(
+    jobId: string,
+    url: string,
+    relationships: unknown,
+  ): Promise<void> {
+    try {
+      await query(this.#dbAdapter, [
+        `INSERT INTO ${INSTANCE_CACHE_TABLE} (job_id, url, result) VALUES (`,
+        param(jobId),
+        `,`,
+        param(url),
+        `,`,
+        param(JSON.stringify(relationships ?? null)),
+        `) ON CONFLICT (job_id, url) DO NOTHING`,
+      ] as Expression);
+    } catch (err: unknown) {
+      this.#log.warn(
+        `per-instance cache write failed for ${url} (job ${jobId}): ${String(err)}`,
+      );
+    }
+  }
+
   private async loadLinks(
     {
       realmURL,
@@ -1240,6 +1349,28 @@ export class RealmIndexQueryEngine {
               : opts?.linkFields
                 ? { ...opts, linkFields: undefined }
                 : opts;
+            let cacheKey = this.#instanceCacheKey(resource, popOpts);
+            if (cacheKey) {
+              let cached = await this.#readCachedRelationships(
+                cacheKey.jobId,
+                cacheKey.url,
+              );
+              if (cached !== undefined) {
+                // Hit: reuse this instance's assembled query-field
+                // relationships from an earlier occurrence in the same job,
+                // skipping the definition lookup + field-tree walk. The
+                // cached value is pre-strip; the `${field}.N` /
+                // included-omission steps below run uniformly on hit and miss.
+                if (cached === null) {
+                  delete (resource as { relationships?: unknown })
+                    .relationships;
+                } else {
+                  (resource as { relationships?: unknown }).relationships =
+                    cached;
+                }
+                return;
+              }
+            }
             let storedDefs = (
               resource.meta as {
                 queryFieldDefs?: Record<string, QueryFieldMeta>;
@@ -1254,6 +1385,13 @@ export class RealmIndexQueryEngine {
               );
             } else {
               await this.populateQueryFields(resource, realmURL, popOpts);
+            }
+            if (cacheKey) {
+              await this.#writeCachedRelationships(
+                cacheKey.jobId,
+                cacheKey.url,
+                (resource as { relationships?: unknown }).relationships,
+              );
             }
           }),
         );

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1,5 +1,9 @@
 import { Deferred } from './deferred';
 import {
+  X_BOXEL_JOB_ID_HEADER,
+  sanitizePrerenderJobId,
+} from './prerender-headers';
+import {
   rri,
   type RealmResourceIdentifier,
   type RealmIdentifier,
@@ -231,6 +235,17 @@ const PROTECTED_REALM_CONFIG_PROPERTIES = ['showAsCatalog'];
 export const DURING_PRERENDER_HEADER = 'x-boxel-during-prerender';
 function isDuringPrerenderRequest(request: Request): boolean {
   return (request.headers.get(DURING_PRERENDER_HEADER) ?? '').length > 0;
+}
+
+// The `<jobId>.<reservationId>` job identity carried on inbound prerender
+// requests (`x-boxel-job-id`), normalized. Threaded into card-document opts so
+// the per-instance wire-format cache scopes its entries to one indexing job.
+// Undefined for live / external traffic, which never carries the header.
+function prerenderJobIdentity(request: Request): string | undefined {
+  return (
+    sanitizePrerenderJobId(request.headers.get(X_BOXEL_JOB_ID_HEADER)) ??
+    undefined
+  );
 }
 
 // Fields owned by the RealmConfig card instance at /realm.json. A PATCH
@@ -4287,6 +4302,7 @@ export class Realm {
       {
         loadLinks: true,
         skipQueryBackedExpansion: isDuringPrerenderRequest(request),
+        jobIdentity: prerenderJobIdentity(request),
       },
     );
     if (!entry || entry?.type === 'error') {
@@ -4453,6 +4469,7 @@ export class Realm {
           {
             loadLinks: true,
             skipQueryBackedExpansion: isDuringPrerenderRequest(request),
+            jobIdentity: prerenderJobIdentity(request),
           },
         );
         if (entry && entry.type !== 'error') {
@@ -4563,6 +4580,7 @@ export class Realm {
         {
           loadLinks: true,
           skipQueryBackedExpansion: isDuringPrerenderRequest(request),
+          jobIdentity: prerenderJobIdentity(request),
         },
       );
       let doc: SingleCardDocument;
@@ -4817,6 +4835,7 @@ export class Realm {
       let maybeError = await this.#realmIndexQueryEngine.cardDocument(url, {
         loadLinks: true,
         skipQueryBackedExpansion: isDuringPrerenderRequest(request),
+        jobIdentity: prerenderJobIdentity(request),
       });
       if (maybeError === undefined) {
         if (await this.nonJsonFileExists(localPath)) {


### PR DESCRIPTION
## Background and Goal

During prerender indexing, the dominant server-side cost of `_federated-search` and per-URL card GETs is assembling each card's wire-format JSON:API resource — reading its `pristine_doc` and running `populateQueryFields` to populate its query-backed `linksTo` / `linksToMany` umbrellas. The matching SQL is cheap; the per-result expansion (a definition lookup plus a recursive field-tree walk, in Node, with no memoization) is not. Within a single indexing job the same instance is assembled many times — as a search result, a per-URL card GET, and a linked target of other cards — repeating that expansion each time.

This adds a job-scoped, per-instance cache of the assembled query-field relationships so each instance is expanded at most once per job.

## Where to start

- `packages/runtime-common/realm-index-query-engine.ts` — `loadLinks` consults the cache per root resource (the chokepoint shared by `searchCardsUncoalesced` and `cardDocument`). `#instanceCacheKey` / `#readCachedRelationships` / `#writeCachedRelationships` are the cache surface; a new `jobIdentity` option carries the key.
- `packages/postgres/migrations/1780412666457_create-job-scoped-instance-cache.js` — the new `job_scoped_instance_cache` table.
- `packages/realm-server/job-scoped-instance-cache.ts` + `lib/jobs-finished-listener.ts` — eviction (NOTIFY-driven + age-based janitor), wired in `main.ts`.
- Identity threading: `handlers/handle-search.ts` and the `cardDocument` call sites in `runtime-common/realm.ts` pass the job identity from the `x-boxel-job-id` header (`sanitizePrerenderJobId` now lives in runtime-common).
- Tests: `tests/job-scoped-instance-cache-test.ts` (eviction) and `tests/per-instance-cache-test.ts` (write / read-pin / per-job scoping / flag-off / no-identity, driven through the engine).

## Key decisions

- **Key is `(<jobId>.<reservationId>, url)`** — the full job identity, not the bare job id. A job can re-run under a new reservation, and committed `boxel_index` can move between runs, so reservation scoping prevents reuse across runs.
- **Job-scoped and single-shot — no cross-job state.** Correctness rests on `boxel_index` being frozen for a job's lifetime (the writer only touches `boxel_index_working` until the final swap), so no invalidation machinery is needed and entries are vacated on `jobs_finished`. Making query-field membership current across batches is explicitly out of scope.
- **Default off** behind `INDEXER_INSTANCE_CACHE`, and only consulted when a request carries a job identity — so live / external traffic and the indexing hot path are byte-for-byte unchanged until opted in.
- Reuses the existing `JobScopedSearchCache` infrastructure (shared Postgres table, `jobs_finished` eviction, janitor, `ON CONFLICT DO NOTHING`); the migration also clears `job_scoped_search_cache` on rollout. The query-level search cache is kept as a complementary layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
