### PR TITLE
Adorn search pane improvements

### DIFF
--- a/packages/host/app/components/adorn/adorn-context.gts
+++ b/packages/host/app/components/adorn/adorn-context.gts
@@ -101,14 +101,18 @@ const AdornContext: TemplateOnlyComponent<AdornContextSignature> = <template>
       /* Token definitions live with the context, not in the global
          stylesheet. --boxel-teal is the light accent shipped by
          boxel-ui; the darker accent is exclusive to the Adorn
-         treatment and used when both hovered and selected. */
+         treatment and used when a selected card is hovered. */
       --adorn-accent-light: var(--boxel-teal);
       --adorn-accent: #00da9f;
     }
     /* Stroke utility. The consumer applies `.adorn-stroke` to
        whichever descendant should carry the outline (typically the
        card-like element itself), then drives `.selected` and either
-       the `:hover` pseudo-class or a `.hovered` class. */
+       the `:hover` pseudo-class or a `.hovered` class. Plain hover and
+       selection use the light accent; hovering a selected card shifts
+       both the stroke and the type-label background to the darker
+       accent — the label inherits `--adorn-label-bg` from the stroke
+       element it's rendered inside. */
     .adorn-context :deep(.adorn-stroke:hover:not(.selected)),
     .adorn-context :deep(.adorn-stroke.hovered:not(.selected)) {
       box-shadow: 0 0 0 2px var(--adorn-accent-light);
@@ -119,6 +123,7 @@ const AdornContext: TemplateOnlyComponent<AdornContextSignature> = <template>
     .adorn-context :deep(.adorn-stroke.selected:hover),
     .adorn-context :deep(.adorn-stroke.selected.hovered) {
       box-shadow: 0 0 0 4px var(--adorn-accent);
+      --adorn-label-bg: var(--adorn-accent);
     }
   </style>
 </template>;

--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -619,10 +619,12 @@ export default class SearchContent extends Component<Signature> {
         flex-wrap: nowrap;
         padding-inline: var(--boxel-sp-xs);
         /* `overflow-y: hidden` (needed so only the row scrolls
-           horizontally) would otherwise clip the Adorn outline stroke
-           and the type-label tab, which extend a few px outside each
-           card. Block padding keeps them inside the clip region. */
-        padding-block: var(--boxel-sp-xs);
+           horizontally) would clip the Adorn outline stroke and the
+           hover type-label tab, which flips below the card. Bias the
+           block padding toward the block-end so the tab has room below
+           (the block-start only needs to clear the outline stroke),
+           working with the taller prompt sheet (--search-sheet-prompt-height). */
+        padding-block: var(--boxel-sp-2xs) var(--boxel-sp);
         overflow-y: hidden;
         overflow-x: auto;
       }

--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -604,7 +604,14 @@ export default class SearchContent extends Component<Signature> {
         overscroll-behavior: none;
         height: 100%;
         background-color: var(--boxel-light);
-        padding-right: var(--boxel-sp);
+        /* `overflow-y: auto` also clips horizontal overflow, so the
+           Adorn outline stroke and type-label tab (which extend a few
+           px outside each card) get cut off on the top/left edges
+           without room. Block + inline-start padding keeps them inside
+           the clip region; the larger inline-end padding is the
+           existing scrollbar gutter. */
+        padding-block: var(--boxel-sp-xs);
+        padding-inline: var(--boxel-sp-xs) var(--boxel-sp);
         transition: opacity calc(var(--boxel-transition) / 4);
       }
       .search-sheet-content.compact {

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -305,7 +305,7 @@ export default class SearchSheet extends Component<Signature> {
             var(--operator-mode-spacing)
         );
         --search-sheet-closed-width: var(--container-button-size);
-        --search-sheet-prompt-height: 8.75rem;
+        --search-sheet-prompt-height: 9.45rem;
       }
 
       .search-sheet {


### PR DESCRIPTION
## Summary
Visual refinements to the shared Adorn search components (the operator-mode search sheet, and the card chooser once it opts in). No new opt-in — these polish the treatment that's already live in the search sheet.

- **Stroke no longer clips in the grid** — `.search-sheet-content`'s `overflow-y: auto` also clips horizontally, cutting off the teal outline stroke / type-label tab on the top/left edge cards. Added block + inline-start padding so they stay inside the clip region.
- **Darken the label when a selected card is hovered** — the outline stroke already shifts to the darker accent on selected+hover; the type-label tab now follows via `--adorn-label-bg` (plain hover and the resting selected state keep the light accent).
- **Room for the recents label tab** — in the compact quick-menu the hover tab flips below each recent card; raised the prompt-sheet height and biased the row's block padding so the tab isn't clipped (it overlaps the realm-name line, which is acceptable).

## Test plan
- [x] `lint:types` + eslint pass.
- [x] Manual: search sheet grid — hover/select edge cards; stroke + tab not clipped.
- [x] Manual: hover a selected card — stroke and label both darken.
- [x] Manual: compact recents quick-menu — hover tab appears below the card, fully visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
