### PR TITLE
Fix realm-indexing shard flakiness from leaked card-reference prefix

### DIFF
--- a/packages/host/tests/helpers/setup-qunit.js
+++ b/packages/host/tests/helpers/setup-qunit.js
@@ -93,7 +93,8 @@ export function setupQUnit() {
             `LEAKED_CARD_REFERENCE_PREFIXES module=${JSON.stringify(
               details.name,
             )} prefixes=${JSON.stringify(leaked)} — register/unregister must ` +
-              `be symmetric (clean up addRealmMapping in an afterEach), or ` +
+              `be symmetric: clean up addRealmMapping/removeRealmMapping (or ` +
+              `register/unregister) in an afterEach, after, or try/finally, or ` +
               `these mappings will unresolve URLs in sibling test modules.`,
           );
         }

--- a/packages/host/tests/helpers/setup-qunit.js
+++ b/packages/host/tests/helpers/setup-qunit.js
@@ -5,7 +5,10 @@ import * as TestWaiters from '@ember/test-waiters';
 import * as QUnit from 'qunit';
 import { setup } from 'qunit-dom';
 
-import { useTestWaiters } from '@cardstack/runtime-common';
+import {
+  registeredCardReferencePrefixes,
+  useTestWaiters,
+} from '@cardstack/runtime-common';
 
 export function setupQUnit() {
   // ResizeObserver fires this when a callback causes a layout change that
@@ -46,6 +49,11 @@ export function setupQUnit() {
   // are tracked with a simple depth counter so we only probe top-level ones.
   let usedAtModuleStart = null;
   let moduleDepth = 0;
+  // The permanent base-realm prefix mappings (@cardstack/base/, etc.) are
+  // registered during boot/warmup and are expected for the whole suite.
+  // Captured after the first top-level module so the leak guard below only
+  // flags prefixes a test module added and failed to clean up.
+  let baselineCardReferencePrefixes = null;
   async function settledGc() {
     if (typeof globalThis.gc !== 'function') return;
     for (let i = 0; i < 3; i++) {
@@ -65,6 +73,32 @@ export function setupQUnit() {
     }
   });
   QUnit.moduleDone(async (details) => {
+    // Diagnostic: a card-reference prefix mapping a test module added but
+    // didn't clean up leaks into the global registry and corrupts later
+    // modules — `unresolveCardReference` rewrites their indexed/resolved
+    // URLs into the prefix form. The first top-level module establishes the
+    // permanent baseline (base-realm prefixes); after that, name any module
+    // that leaves an extra prefix so the next such failure is
+    // self-explanatory instead of an opaque deepEqual diff.
+    if (moduleDepth === 1) {
+      let current = registeredCardReferencePrefixes();
+      if (baselineCardReferencePrefixes === null) {
+        baselineCardReferencePrefixes = new Set(current);
+      } else {
+        let leaked = current.filter(
+          (p) => !baselineCardReferencePrefixes.has(p),
+        );
+        if (leaked.length > 0) {
+          console.warn(
+            `LEAKED_CARD_REFERENCE_PREFIXES module=${JSON.stringify(
+              details.name,
+            )} prefixes=${JSON.stringify(leaked)} — register/unregister must ` +
+              `be symmetric (clean up addRealmMapping in an afterEach), or ` +
+              `these mappings will unresolve URLs in sibling test modules.`,
+          );
+        }
+      }
+    }
     if (moduleDepth === 1) {
       await settledGc();
       try {

--- a/packages/host/tests/unit/services/render-service-test.ts
+++ b/packages/host/tests/unit/services/render-service-test.ts
@@ -32,7 +32,17 @@ function makeVN(): VirtualNetwork {
   return vn;
 }
 
-module('Unit | Service | render-service', function () {
+module('Unit | Service | render-service', function (hooks) {
+  // `makeVN()` calls `addRealmMapping`, which registers `@test-prefix/`
+  // in the module-level card-reference prefix registry (a global the
+  // VirtualNetwork bridges to). Without cleanup that mapping leaks into
+  // sibling test modules — e.g. realm indexing, whose server-side
+  // indexing would then unresolve indexed card URLs back to the
+  // `@test-prefix/` form and break its deepEqual assertions.
+  hooks.afterEach(function () {
+    new VirtualNetwork(globalThis.fetch).removeRealmMapping(prefix);
+  });
+
   test('CardStoreWithErrors resolves registered prefix ids for card and file lookups', function (assert) {
     let store = new CardStoreWithErrors(globalThis.fetch, makeVN());
     let card = {} as CardDef;

--- a/packages/runtime-common/card-reference-resolver.ts
+++ b/packages/runtime-common/card-reference-resolver.ts
@@ -78,6 +78,17 @@ export function unregisterCardReferencePrefix(prefix: string): void {
 }
 
 /**
+ * Diagnostic helper: the prefixes currently registered in the
+ * module-level registry. The test harness reads this after each module
+ * to surface prefix mappings that leaked across tests — a leaked prefix
+ * makes `unresolveCardReference` rewrite indexed/resolved URLs into the
+ * prefix form, which corrupts sibling tests in hard-to-diagnose ways.
+ */
+export function registeredCardReferencePrefixes(): string[] {
+  return [...prefixMappings.keys()];
+}
+
+/**
  * @deprecated Use {@link VirtualNetwork.isRegisteredPrefix} instead.
  * Reads from the soon-to-be-removed module-level `prefixMappings`.
  */

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -616,6 +616,7 @@ export {
   resolveCardReference,
   unresolveCardReference,
   isRegisteredPrefix,
+  registeredCardReferencePrefixes,
   cardIdToURL,
 } from './card-reference-resolver';
 


### PR DESCRIPTION
## Summary
Fixes the deterministic-but-shard-dependent failure of two host integration tests:
- `Integration | realm indexing: full indexing discovers card instances`
- `Integration | realm indexing: a card with a broken linksTo target indexes cleanly…`

(Both were failing "Host Tests (15, 20)" on `main`, turning CI Host red.)

## Root cause
`render-service-test`'s `makeVN()` calls `VirtualNetwork.addRealmMapping`, which registers `@test-prefix/ → http://test-realm/test/` in the **module-level** card-reference prefix registry (a global the VN bridges to). The module never removed it, so the mapping leaked into whatever ran next in the shard.

When the realm-indexing module followed, its server-side indexing **unresolved** indexed card URLs back to the prefix form — `@test-prefix/empty` instead of `http://test-realm/test/empty` — breaking the `deepEqual` assertions. The TAP output only showed `[object Object]`, so it was opaque.

It surfaced now (not earlier) because recent merges shifted those modules into the **same shard** (`ember exam --split 20 --partition 15` re-partitions as the suite grows), and #5029 / #4954 routed more URL resolution through the prefix registry.

## Fix
`render-service-test` now removes the `@test-prefix/` mapping in an `afterEach`, matching the other prefix-using test modules (store-test, loader-test, etc.).

## Diagnostics (insurance)
A `moduleDone` guard in `setup-qunit.js` names any module that leaves an **extra** card-reference prefix registered (over the permanent base-realm baseline). The next such leak prints `LEAKED_CARD_REFERENCE_PREFIXES module=… prefixes=…` instead of an opaque `deepEqual` diff. (Added `registeredCardReferencePrefixes()` to enumerate the registry.)

## Test plan
- [x] Reproduced the failure locally with `ember exam --path dist --split 20 --partition 15` (a diagnostic dump showed the indexed `id` was `@test-prefix/empty`).
- [x] With the fix, re-ran shard 15: **162 tests, 160 pass, 2 skip, 0 fail**; both target tests pass; **zero** leak warnings (baseline correctly excludes the permanent prefixes).
- [x] `lint:types` + eslint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
