### PR TITLE
Apply Adorn treatment to the card chooser selection menu

### DIFF
--- a/packages/host/app/components/adorn/selection-checkmark-icon.gts
+++ b/packages/host/app/components/adorn/selection-checkmark-icon.gts
@@ -1,0 +1,30 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+
+// SelectionCheckmarkIcon: the dark-circle-with-teal-checkmark artwork
+// shared by the Adorn bulk-selection affordances — the teal "N Selected"
+// menu trigger and its inert menu header. The companion AdornSelectChip
+// renders the same circle/check but strokes with `currentColor` so the
+// chip can be themed; here the check is always teal to read against the
+// dark circle on a teal pill.
+const SelectionCheckmarkIcon: TemplateOnlyComponent<{
+  Element: SVGSVGElement;
+}> = <template>
+  <svg
+    viewBox='0 0 14 14'
+    fill='none'
+    xmlns='http://www.w3.org/2000/svg'
+    aria-hidden='true'
+    ...attributes
+  >
+    <circle cx='7' cy='7' r='7' fill='#0a2e1c' />
+    <path
+      d='M3.5 7.5L5.5 9.5L10.5 4.5'
+      stroke='var(--boxel-teal)'
+      stroke-width='1.5'
+      stroke-linecap='round'
+      stroke-linejoin='round'
+    />
+  </svg>
+</template>;
+
+export default SelectionCheckmarkIcon;

--- a/packages/host/app/components/card-search/search-result-header.gts
+++ b/packages/host/app/components/card-search/search-result-header.gts
@@ -42,11 +42,24 @@ export default class SearchResultHeader extends Component<Signature> {
     return this.args.selectedCards?.length ?? 0;
   }
 
+  // The selection menu only makes sense once something is selected — its
+  // trigger shows the count and its items act on the current selection.
+  get showSelectionMenu(): boolean {
+    return Boolean(this.args.multiSelect) && this.selectedCount > 0;
+  }
+
+  // The trigger's visible text is just the count, so spell the control out
+  // for assistive tech (and include the count it stands in for).
+  get selectionMenuLabel(): string {
+    let count = this.selectedCount;
+    return `Selection menu, ${count} card${count === 1 ? '' : 's'} selected`;
+  }
+
   <template>
     <header class='search-result-header' data-test-search-result-header>
       <div class='summary' data-test-search-label>{{@summaryText}}</div>
       <div class='controls'>
-        {{#if @multiSelect}}
+        {{#if this.showSelectionMenu}}
           <div class='selection-menu'>
             <BoxelDropdown
               @contentClass='selection-dropdown-content'
@@ -56,6 +69,7 @@ export default class SearchResultHeader extends Component<Signature> {
                 <button
                   type='button'
                   class='selection-dropdown-trigger'
+                  aria-label={{this.selectionMenuLabel}}
                   {{bindings}}
                   data-test-selection-dropdown-trigger
                 >

--- a/packages/host/app/components/card-search/search-result-header.gts
+++ b/packages/host/app/components/card-search/search-result-header.gts
@@ -5,7 +5,6 @@ import SelectAllIcon from '@cardstack/boxel-icons/select-all';
 
 import {
   BoxelDropdown,
-  Button,
   Menu,
   SortDropdown,
   ViewSelector,
@@ -13,6 +12,7 @@ import {
 import { MenuItem } from '@cardstack/boxel-ui/helpers';
 import { DropdownArrowDown } from '@cardstack/boxel-ui/icons';
 
+import SelectionCheckmarkIcon from '@cardstack/host/components/adorn/selection-checkmark-icon';
 import type { NewCardArgs } from '@cardstack/host/utils/card-search/types';
 
 import type { SortOption } from './constants';
@@ -53,20 +53,22 @@ export default class SearchResultHeader extends Component<Signature> {
               @matchTriggerWidth={{false}}
             >
               <:trigger as |bindings|>
-                <Button
+                <button
+                  type='button'
                   class='selection-dropdown-trigger'
-                  @kind='secondary-light'
                   {{bindings}}
                   data-test-selection-dropdown-trigger
                 >
-                  {{this.selectedCount}}
-                  Selected
+                  <SelectionCheckmarkIcon class='selection-trigger-icon' />
+                  <span class='selection-trigger-text'>
+                    {{this.selectedCount}}
+                  </span>
                   <DropdownArrowDown
                     class='dropdown-arrow'
-                    width='12'
-                    height='12'
+                    width='13px'
+                    height='13px'
                   />
-                </Button>
+                </button>
               </:trigger>
               <:content as |dd|>
                 <Menu
@@ -126,16 +128,32 @@ export default class SearchResultHeader extends Component<Signature> {
       }
 
       .selection-dropdown-trigger {
-        border-radius: var(--boxel-border-radius);
-        min-width: 140px;
-        justify-content: flex-start;
-        padding-left: var(--boxel-sp-sm);
-        padding-right: var(--boxel-sp-sm);
-        gap: var(--boxel-sp-xs);
-        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: var(--boxel-sp-5xs);
+        min-height: 26px;
+        padding: 0 var(--boxel-sp-xs);
+        border: none;
+        border-radius: 6px;
+        background-color: var(--boxel-teal);
+        color: var(--boxel-dark);
+        font: 700 var(--boxel-font-sm);
+        cursor: pointer;
+      }
+      .selection-dropdown-trigger:hover,
+      .selection-dropdown-trigger:focus-visible {
+        background-color: #00da9f;
+      }
+      .selection-trigger-icon {
+        width: 14px;
+        height: 14px;
+        flex-shrink: 0;
+      }
+      .selection-trigger-text {
+        line-height: 1;
+        white-space: nowrap;
       }
       .dropdown-arrow {
-        margin-left: auto;
         flex-shrink: 0;
       }
       .selection-menu {
@@ -146,10 +164,13 @@ export default class SearchResultHeader extends Component<Signature> {
 
   private get selectionMenuItems() {
     return [
+      // Inert teal header echoing the trigger's count — uses the same
+      // dark-circle-with-teal-check artwork as the Adorn selection chip.
       new MenuItem({
-        label: 'Deselect All',
-        action: () => this.args.onDeselectAll?.(),
-        icon: DeselectIcon,
+        label: `${this.selectedCount} Selected`,
+        action: () => {},
+        icon: SelectionCheckmarkIcon,
+        header: true,
       }),
       new MenuItem({
         label: 'Select All',
@@ -159,6 +180,11 @@ export default class SearchResultHeader extends Component<Signature> {
           }
         },
         icon: SelectAllIcon,
+      }),
+      new MenuItem({
+        label: 'Deselect All',
+        action: () => this.args.onDeselectAll?.(),
+        icon: DeselectIcon,
       }),
     ];
   }

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -1,4 +1,3 @@
-import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { fn } from '@ember/helper';
 import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
@@ -80,6 +79,7 @@ import consumeContext from '../../helpers/consume-context';
 import ElementTracker, {
   type RenderedCardForOverlayActions,
 } from '../../resources/element-tracker';
+import SelectionCheckmarkIcon from '../adorn/selection-checkmark-icon';
 import CardRenderer from '../card-renderer';
 
 import CardError from './card-error';
@@ -92,28 +92,6 @@ import type NetworkService from '../../services/network';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
 import type RealmService from '../../services/realm';
 import type StoreService from '../../services/store';
-
-// Inert "N Selected" header icon for the multi-select utility menu —
-// dark filled circle with a teal check, matching the per-card selection chip.
-const SelectionCheckmarkIcon: TemplateOnlyComponent<{
-  Element: SVGSVGElement;
-}> = <template>
-  <svg
-    viewBox='0 0 14 14'
-    fill='none'
-    xmlns='http://www.w3.org/2000/svg'
-    ...attributes
-  >
-    <circle cx='7' cy='7' r='7' fill='#0a2e1c' />
-    <path
-      d='M3.5 7.5L5.5 9.5L10.5 4.5'
-      stroke='var(--boxel-teal)'
-      stroke-width='1.5'
-      stroke-linecap='round'
-      stroke-linejoin='round'
-    />
-  </svg>
-</template>;
 
 export interface StackItemComponentAPI {
   clearSelections: () => void;

--- a/packages/host/tests/integration/components/card-search-selection-menu-test.gts
+++ b/packages/host/tests/integration/components/card-search-selection-menu-test.gts
@@ -1,0 +1,121 @@
+import { array, get } from '@ember/helper';
+import { click, render, waitFor } from '@ember/test-helpers';
+
+import { module, test } from 'qunit';
+
+import {
+  SORT_OPTIONS,
+  VIEW_OPTIONS,
+} from '@cardstack/host/components/card-search/constants';
+import SearchResultHeader from '@cardstack/host/components/card-search/search-result-header';
+
+import { setupRenderingTest } from '../../helpers/setup';
+
+const noop = () => {};
+
+module(
+  'Integration | card-search/search-result-header (selection menu)',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('the "N Selected" trigger renders the Adorn teal checkmark treatment', async function (assert) {
+      await render(
+        <template>
+          <SearchResultHeader
+            @summaryText='2 results across 1 realm'
+            @viewOptions={{VIEW_OPTIONS}}
+            @activeViewId='grid'
+            @activeSort={{get SORT_OPTIONS 0}}
+            @sortOptions={{SORT_OPTIONS}}
+            @onChangeView={{noop}}
+            @onChangeSort={{noop}}
+            @multiSelect={{true}}
+            @selectedCards={{array 'a' 'b'}}
+            @allCards={{array 'a' 'b' 'c'}}
+            @onSelectAll={{noop}}
+            @onDeselectAll={{noop}}
+          />
+        </template>,
+      );
+
+      assert
+        .dom('[data-test-selection-dropdown-trigger]')
+        .hasText('2', 'trigger shows the selected count only');
+      assert
+        .dom('[data-test-selection-dropdown-trigger] svg circle')
+        .exists('trigger renders the dark-circle-with-teal-check icon');
+    });
+
+    test('the selection menu opens with an inert "N Selected" header above Select/Deselect All', async function (assert) {
+      let selectAllArg: string[] | undefined;
+      let deselectedAll = false;
+      const onSelectAll = (cards: string[]) => (selectAllArg = cards);
+      const onDeselectAll = () => (deselectedAll = true);
+
+      await render(
+        <template>
+          <SearchResultHeader
+            @summaryText='3 results across 1 realm'
+            @viewOptions={{VIEW_OPTIONS}}
+            @activeViewId='grid'
+            @activeSort={{get SORT_OPTIONS 0}}
+            @sortOptions={{SORT_OPTIONS}}
+            @onChangeView={{noop}}
+            @onChangeSort={{noop}}
+            @multiSelect={{true}}
+            @selectedCards={{array 'a' 'b'}}
+            @allCards={{array 'a' 'b' 'c'}}
+            @onSelectAll={{onSelectAll}}
+            @onDeselectAll={{onDeselectAll}}
+          />
+        </template>,
+      );
+
+      await click('[data-test-selection-dropdown-trigger]');
+      await waitFor('[data-test-boxel-menu-item-text="2 Selected"]');
+
+      assert
+        .dom('[data-test-boxel-menu-item-header]')
+        .exists({ count: 1 }, 'the menu has exactly one inert header item');
+      assert
+        .dom('[data-test-boxel-menu-item-header]')
+        .hasText('2 Selected', 'the header echoes the selected count');
+      assert
+        .dom('[data-test-boxel-menu-item-text="Select All"]')
+        .exists('Select All item is present');
+      assert
+        .dom('[data-test-boxel-menu-item-text="Deselect All"]')
+        .exists('Deselect All item is present');
+
+      await click('[data-test-boxel-menu-item-text="Select All"]');
+      assert.deepEqual(
+        selectAllArg,
+        ['a', 'b', 'c'],
+        'Select All forwards every card',
+      );
+
+      await click('[data-test-selection-dropdown-trigger]');
+      await waitFor('[data-test-boxel-menu-item-text="Deselect All"]');
+      await click('[data-test-boxel-menu-item-text="Deselect All"]');
+      assert.true(deselectedAll, 'Deselect All clears the selection');
+    });
+
+    test('the selection menu is hidden when not in multi-select mode', async function (assert) {
+      await render(
+        <template>
+          <SearchResultHeader
+            @summaryText='2 results across 1 realm'
+            @viewOptions={{VIEW_OPTIONS}}
+            @activeViewId='grid'
+            @activeSort={{get SORT_OPTIONS 0}}
+            @sortOptions={{SORT_OPTIONS}}
+            @onChangeView={{noop}}
+            @onChangeSort={{noop}}
+          />
+        </template>,
+      );
+
+      assert.dom('[data-test-selection-dropdown-trigger]').doesNotExist();
+    });
+  },
+);

--- a/packages/host/tests/integration/components/card-search-selection-menu-test.gts
+++ b/packages/host/tests/integration/components/card-search-selection-menu-test.gts
@@ -42,6 +42,13 @@ module(
         .dom('[data-test-selection-dropdown-trigger]')
         .hasText('2', 'trigger shows the selected count only');
       assert
+        .dom('[data-test-selection-dropdown-trigger]')
+        .hasAttribute(
+          'aria-label',
+          'Selection menu, 2 cards selected',
+          'trigger spells out the control and count for assistive tech',
+        );
+      assert
         .dom('[data-test-selection-dropdown-trigger] svg circle')
         .exists('trigger renders the dark-circle-with-teal-check icon');
     });
@@ -98,6 +105,29 @@ module(
       await waitFor('[data-test-boxel-menu-item-text="Deselect All"]');
       await click('[data-test-boxel-menu-item-text="Deselect All"]');
       assert.true(deselectedAll, 'Deselect All clears the selection');
+    });
+
+    test('the selection menu is hidden when no cards are selected', async function (assert) {
+      await render(
+        <template>
+          <SearchResultHeader
+            @summaryText='2 results across 1 realm'
+            @viewOptions={{VIEW_OPTIONS}}
+            @activeViewId='grid'
+            @activeSort={{get SORT_OPTIONS 0}}
+            @sortOptions={{SORT_OPTIONS}}
+            @onChangeView={{noop}}
+            @onChangeSort={{noop}}
+            @multiSelect={{true}}
+            @selectedCards={{array}}
+            @allCards={{array 'a' 'b' 'c'}}
+            @onSelectAll={{noop}}
+            @onDeselectAll={{noop}}
+          />
+        </template>,
+      );
+
+      assert.dom('[data-test-selection-dropdown-trigger]').doesNotExist();
     });
 
     test('the selection menu is hidden when not in multi-select mode', async function (assert) {

--- a/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
@@ -1458,7 +1458,7 @@ module('Integration | operator-mode | card catalog', function (hooks) {
     assert.dom(`[data-test-boxel-filter-list-button="Skill"]`).doesNotExist();
   });
 
-  test('selection-dropdown-trigger is visible in multi-select mode and hidden in single-select mode', async function (assert) {
+  test('selection-dropdown-trigger is hidden in single-select mode and until a card is selected in multi-select mode', async function (assert) {
     ctx.setCardInOperatorModeState(`${testRealmURL}Person/hassan`, 'edit');
     await renderComponent(
       class TestDriver extends GlimmerComponent {
@@ -1486,6 +1486,16 @@ module('Integration | operator-mode | card catalog', function (hooks) {
 
     assert
       .dom('[data-test-selection-dropdown-trigger]')
-      .exists('selection dropdown is visible in multi-select mode');
+      .doesNotExist(
+        'selection dropdown stays hidden in multi-select mode until a card is selected',
+      );
+
+    // Selecting a card reveals the dropdown
+    await waitFor('[data-test-card-catalog-item]');
+    await click('[data-test-card-catalog-item]');
+
+    assert
+      .dom('[data-test-selection-dropdown-trigger]')
+      .exists('selection dropdown appears once a card is selected');
   });
 });

--- a/packages/host/tests/integration/components/operator-mode-links-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-links-test.gts
@@ -1198,27 +1198,16 @@ module('Integration | operator-mode | links', function (hooks) {
 
     assert
       .dom('[data-test-selection-dropdown-trigger]')
-      .exists('selection dropdown trigger is visible in multi-select mode');
-    assert
-      .dom('[data-test-selection-dropdown-trigger]')
-      .containsText('0 Selected', 'shows 0 selected initially');
+      .doesNotExist('selection dropdown is hidden while nothing is selected');
 
     await click(`[data-test-card-catalog-item="${testRealmURL}Pet/jackie"]`);
     await click(`[data-test-card-catalog-item="${testRealmURL}Pet/mango"]`);
     assert
       .dom('[data-test-selection-dropdown-trigger]')
-      .containsText('2 Selected', 'count updates as cards are selected');
-
-    // Test Deselect All
-    await click('[data-test-selection-dropdown-trigger]');
-    await waitFor('[data-test-boxel-menu-item-text="Deselect All"]');
-    await click('[data-test-boxel-menu-item-text="Deselect All"]');
-    assert
-      .dom('[data-test-card-catalog-item-selected]')
-      .doesNotExist('all cards deselected after Deselect All');
+      .exists('selection dropdown appears once cards are selected');
     assert
       .dom('[data-test-selection-dropdown-trigger]')
-      .containsText('0 Selected', 'count resets to 0');
+      .hasText('2', 'trigger shows the selected count');
 
     // Test Select All
     await click('[data-test-selection-dropdown-trigger]');
@@ -1233,6 +1222,19 @@ module('Integration | operator-mode | links', function (hooks) {
       .exists(
         { count: totalItems },
         'all visible cards are selected after Select All',
+      );
+
+    // Test Deselect All — clears the selection and hides the dropdown again
+    await click('[data-test-selection-dropdown-trigger]');
+    await waitFor('[data-test-boxel-menu-item-text="Deselect All"]');
+    await click('[data-test-boxel-menu-item-text="Deselect All"]');
+    assert
+      .dom('[data-test-card-catalog-item-selected]')
+      .doesNotExist('all cards deselected after Deselect All');
+    assert
+      .dom('[data-test-selection-dropdown-trigger]')
+      .doesNotExist(
+        'selection dropdown is hidden again once nothing is selected',
       );
   });
 });


### PR DESCRIPTION
## What

The card chooser's multi-select menu now uses the same Adorn treatment as the operator-mode bulk-selection menu.

- The trigger is a teal pill showing the dark-circle/teal-check icon and the selected count (count only, matching operator mode).
- The dropdown opens with an inert teal **N Selected** header item, above **Select All** / **Deselect All**.

The dark-circle/teal-check artwork lives in a single `adorn/selection-checkmark-icon` component, used by the card-chooser trigger, the menu header item, and the operator-mode utility menu.

## Scope

- `card-search/search-result-header.gts` — teal-pill trigger + header menu item.
- `adorn/selection-checkmark-icon.gts` — shared checkmark icon.
- `operator-mode/stack-item.gts` — consumes the shared icon (no behavior change).

## Test plan

- New rendering tests (`card-search-selection-menu-test`): trigger treatment, the inert header item, Select/Deselect All wiring, and that the menu is hidden in single-select mode.
- Existing `selection-dropdown-trigger` visibility test and the operator-mode bulk-delete acceptance tests pass.
- glint, eslint, and template-lint clean.