### PR TITLE
CS-11057: Lint against compilation-required TypeScript syntax

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,9 @@
 'use strict';
 
-// Selectors for TypeScript syntax that Node 24+ cannot run via
-// `--experimental-strip-types` (it only handles "erasable" TS). The
-// migration target — see Linear project "Migrate off ts-node to run
-// directly in node 24+" — requires keeping new code free of these.
+// Selectors for TypeScript syntax that Node cannot run via
+// `--experimental-strip-types`, which only handles "erasable" TS —
+// syntax that vanishes once type annotations are stripped. New code
+// must avoid these so it can run under Node natively, without ts-node.
 const NO_COMPILATION_REQUIRED_TS_SELECTORS = [
   {
     selector: 'TSEnumDeclaration',
@@ -94,10 +94,10 @@ module.exports = {
       },
     },
     {
-      // Files predating the "non-erasable TypeScript" lint rules added for
-      // the ts-node → Node-native-TypeScript migration. New files MUST NOT
-      // be added to these lists; refactor a grandfathered file to remove
-      // its entry as part of that migration.
+      // Files exempted from the erasable-TypeScript rules because they use
+      // TypeScript constructor parameter properties, which are not erasable.
+      // Do not add new files here; refactor a file to declare its fields
+      // explicitly to remove its entry.
       files: [
         'packages/bot-runner/lib/command-runner.ts',
         'packages/bot-runner/lib/github.ts',
@@ -132,15 +132,21 @@ module.exports = {
       },
     },
     {
-      // Same grandfathering as above, but for the `enum` selector. The
-      // surrounding `data-test-*` selectors don't apply to these files,
-      // so it's safe to disable `no-restricted-syntax` wholesale here.
+      // Files exempted only for TypeScript `enum`, which is not erasable.
+      // The remaining erasable-syntax guards (`import =`, `export =`) still
+      // apply here — only the `enum` selector is lifted. Do not add new
+      // files here; replace the enum with a `const` object to remove the entry.
       files: [
         'packages/runtime-common/router.ts',
         'packages/runtime-common/supported-mime-type.ts',
       ],
       rules: {
-        'no-restricted-syntax': 'off',
+        'no-restricted-syntax': [
+          'error',
+          ...NO_COMPILATION_REQUIRED_TS_SELECTORS.filter(
+            (s) => s.selector !== 'TSEnumDeclaration',
+          ),
+        ],
       },
     },
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,40 @@
 'use strict';
 
+// Selectors for TypeScript syntax that Node 24+ cannot run via
+// `--experimental-strip-types` (it only handles "erasable" TS). The
+// migration target — see Linear project "Migrate off ts-node to run
+// directly in node 24+" — requires keeping new code free of these.
+const NO_COMPILATION_REQUIRED_TS_SELECTORS = [
+  {
+    selector: 'TSEnumDeclaration',
+    message:
+      'TypeScript `enum` is not erasable and requires compilation. Use a `const` object with `as const` (or a union of string literals) instead.',
+  },
+  {
+    selector: 'TSImportEqualsDeclaration',
+    message:
+      '`import =` syntax requires TypeScript compilation. Use standard ES module `import` instead.',
+  },
+  {
+    selector: 'TSExportAssignment',
+    message:
+      '`export =` syntax requires TypeScript compilation. Use a standard ES module `export default` (or named exports) instead.',
+  },
+];
+
+const DATA_TEST_SELECTORS = [
+  {
+    selector: 'Literal[value=/\\[data-test-/]',
+    message:
+      '`data-test-*` attributes are stripped in production builds. Use a plain `data-*` attribute (e.g. `[data-foo]`) for functional selectors.',
+  },
+  {
+    selector: 'TemplateElement[value.raw=/\\[data-test-/]',
+    message:
+      '`data-test-*` attributes are stripped in production builds. Use a plain `data-*` attribute (e.g. `[data-foo]`) for functional selectors.',
+  },
+];
+
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
@@ -36,6 +71,13 @@ module.exports = {
       'error',
       { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
     ],
+    // Keep new code "erasable" so it can run under Node's
+    // `--experimental-strip-types` without ts-node.
+    '@typescript-eslint/parameter-properties': [
+      'error',
+      { prefer: 'class-property' },
+    ],
+    'no-restricted-syntax': ['error', ...NO_COMPILATION_REQUIRED_TS_SELECTORS],
   },
   overrides: [
     {
@@ -46,17 +88,59 @@ module.exports = {
       rules: {
         'no-restricted-syntax': [
           'error',
-          {
-            selector: 'Literal[value=/\\[data-test-/]',
-            message:
-              '`data-test-*` attributes are stripped in production builds. Use a plain `data-*` attribute (e.g. `[data-foo]`) for functional selectors.',
-          },
-          {
-            selector: 'TemplateElement[value.raw=/\\[data-test-/]',
-            message:
-              '`data-test-*` attributes are stripped in production builds. Use a plain `data-*` attribute (e.g. `[data-foo]`) for functional selectors.',
-          },
+          ...NO_COMPILATION_REQUIRED_TS_SELECTORS,
+          ...DATA_TEST_SELECTORS,
         ],
+      },
+    },
+    {
+      // Files predating the "non-erasable TypeScript" lint rules added for
+      // the ts-node → Node-native-TypeScript migration. New files MUST NOT
+      // be added to these lists; refactor a grandfathered file to remove
+      // its entry as part of that migration.
+      files: [
+        'packages/bot-runner/lib/command-runner.ts',
+        'packages/bot-runner/lib/github.ts',
+        'packages/bot-runner/lib/pr-listing/create-listing-pr-handler.ts',
+        'packages/bot-runner/lib/pr-listing/pr-listing-workflow-handler.ts',
+        'packages/boxel-cli/src/commands/realm/pull.ts',
+        'packages/boxel-cli/src/commands/realm/push.ts',
+        'packages/boxel-cli/src/commands/realm/status.ts',
+        'packages/boxel-cli/src/commands/realm/sync.ts',
+        'packages/boxel-cli/src/lib/realm-sync-base.ts',
+        'packages/matrix/helpers/isolated-realm-server.ts',
+        'packages/postgres/pg-queue.ts',
+        'packages/postgres/pg-transaction-manager.ts',
+        'packages/realm-server/node-realm.ts',
+        'packages/realm-test-harness/src/support-services.ts',
+        'packages/runtime-common/amd-transpile/identifier-rewriter.ts',
+        'packages/runtime-common/commands.ts',
+        'packages/runtime-common/index-writer.ts',
+        'packages/runtime-common/matrix-backend-authentication.ts',
+        'packages/runtime-common/queue.ts',
+        'packages/runtime-common/realm-auth-client.ts',
+        'packages/vscode-boxel-tools/src/local-file-system.ts',
+        'packages/vscode-boxel-tools/src/realms.ts',
+        'packages/vscode-boxel-tools/src/skills.ts',
+        'packages/vscode-boxel-tools/src/synapse-auth-provider.ts',
+        'packages/workspace-sync-cli/src/pull.ts',
+        'packages/workspace-sync-cli/src/push.ts',
+        'packages/workspace-sync-cli/src/realm-sync-base.ts',
+      ],
+      rules: {
+        '@typescript-eslint/parameter-properties': 'off',
+      },
+    },
+    {
+      // Same grandfathering as above, but for the `enum` selector. The
+      // surrounding `data-test-*` selectors don't apply to these files,
+      // so it's safe to disable `no-restricted-syntax` wholesale here.
+      files: [
+        'packages/runtime-common/router.ts',
+        'packages/runtime-common/supported-mime-type.ts',
+      ],
+      rules: {
+        'no-restricted-syntax': 'off',
       },
     },
   ],

--- a/packages/ai-bot/.eslintrc.js
+++ b/packages/ai-bot/.eslintrc.js
@@ -69,9 +69,10 @@ module.exports = {
   },
   overrides: [
     {
-      // Files predating the "non-erasable TypeScript" lint rules added
-      // for the ts-node → Node-native-TypeScript migration. Refactor a
-      // grandfathered file to remove its entry as part of that migration.
+      // Files exempted from the erasable-TypeScript rules because they use
+      // TypeScript constructor parameter properties, which are not erasable.
+      // Do not add new files here; refactor a file to declare its fields
+      // explicitly to remove its entry.
       files: [
         'lib/matrix/response-event-data.ts',
         'lib/matrix/response-publisher.ts',

--- a/packages/ai-bot/.eslintrc.js
+++ b/packages/ai-bot/.eslintrc.js
@@ -1,5 +1,27 @@
 'use strict';
 
+// See the root `.eslintrc.js` — these selectors guard against TypeScript
+// syntax that requires compilation (so it would not work under Node's
+// native `--experimental-strip-types`). This package has `root: true`,
+// so the root config does not apply here.
+const NO_COMPILATION_REQUIRED_TS_SELECTORS = [
+  {
+    selector: 'TSEnumDeclaration',
+    message:
+      'TypeScript `enum` is not erasable and requires compilation. Use a `const` object with `as const` (or a union of string literals) instead.',
+  },
+  {
+    selector: 'TSImportEqualsDeclaration',
+    message:
+      '`import =` syntax requires TypeScript compilation. Use standard ES module `import` instead.',
+  },
+  {
+    selector: 'TSExportAssignment',
+    message:
+      '`export =` syntax requires TypeScript compilation. Use a standard ES module `export default` (or named exports) instead.',
+  },
+];
+
 module.exports = {
   root: true,
   env: {
@@ -39,5 +61,24 @@ module.exports = {
       'error',
       { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
     ],
+    '@typescript-eslint/parameter-properties': [
+      'error',
+      { prefer: 'class-property' },
+    ],
+    'no-restricted-syntax': ['error', ...NO_COMPILATION_REQUIRED_TS_SELECTORS],
   },
+  overrides: [
+    {
+      // Files predating the "non-erasable TypeScript" lint rules added
+      // for the ts-node → Node-native-TypeScript migration. Refactor a
+      // grandfathered file to remove its entry as part of that migration.
+      files: [
+        'lib/matrix/response-event-data.ts',
+        'lib/matrix/response-publisher.ts',
+      ],
+      rules: {
+        '@typescript-eslint/parameter-properties': 'off',
+      },
+    },
+  ],
 };


### PR DESCRIPTION
## Summary

- Adds an ESLint guardrail so new TypeScript code stays "erasable" — i.e. runnable under Node's `--experimental-strip-types` without ts-node. Prevents new `enum`, constructor parameter properties, `namespace` (already covered by `@typescript-eslint/no-namespace` in the recommended preset), `import = require(...)`, and `export =`.
- Wires the same rules into `packages/ai-bot/.eslintrc.js`, which has `root: true` and doesn't inherit from the repo root.
- Grandfathers existing pre-erasable files via a single `overrides` block in each config — that list is the to-do list for the ts-node → Node-native migration.

Belongs to the Linear project "Migrate off ts-node to run directly in node 24+". The grandfathered list shrinks as files in it get refactored.

## Notes for reviewers

- `host` is intentionally not in scope — it has `root: true` and is Embroider-compiled, so it doesn't need to be erasable.
- `bot-runner` and `matrix` don't have an `eslint` CI script today, but they still get the rules via the inherited root config; their pre-existing files are grandfathered for completeness.
- A few packages with `eslint` in CI (`billing`, `software-factory`, `catalog`) already had no violations and need no entries.

## Test plan

- [x] `pnpm lint:js` passes in every package that runs it in CI: `runtime-common`, `postgres`, `vscode-boxel-tools`, `ai-bot`, `realm-server`, `boxel-cli`, `workspace-sync-cli`, `realm-test-harness`, `software-factory`, `billing`, `catalog`.
- [x] A fixture file containing `enum`, multi-line parameter-properties, `namespace`, and `import = require(...)` produces one error per pattern.
- [ ] CI green.