### PR TITLE
Thread jobIdentity through Realm.search so the per-instance cache populates during indexing

### DIFF
--- a/packages/realm-server/tests/per-instance-cache-test.ts
+++ b/packages/realm-server/tests/per-instance-cache-test.ts
@@ -68,6 +68,18 @@ function buildFileSystem(): Record<string, string | LooseSingleCardDocument> {
     },
   } as LooseSingleCardDocument;
 
+  // Extra Consumers so a `type: Consumer` search returns multiple data[]
+  // results, letting the search-path test assert every result instance is
+  // cached (not just that some row exists).
+  for (let i = 2; i <= 3; i++) {
+    fs[`consumer-${i}.json`] = {
+      data: {
+        attributes: { name: `C${i}` },
+        meta: { adoptsFrom: { module: rri('./consumer'), name: 'Consumer' } },
+      },
+    } as LooseSingleCardDocument;
+  }
+
   return fs;
 }
 
@@ -181,6 +193,64 @@ module(basename(__filename), function () {
         3,
         'job 9.1 assembles live, ignoring job 8.1 entries',
       );
+    });
+
+    // Regression for the real search path. Indexing funnels through
+    // `Realm.search`, which rebuilds the `searchCards` opts; if it drops
+    // `jobIdentity`, `loadLinks` never gets a cache key and the cache is
+    // silently never populated during indexing — even though the search itself
+    // runs fine. The `cardDocument`-based tests above cannot catch this because
+    // they pass `jobIdentity` straight into the engine, bypassing `Realm.search`.
+    //
+    // Precise assertion: every instance in the search's `data[]` is cached, by
+    // its own URL, with its assembled query-field umbrella (not merely that
+    // "some row" exists).
+    test('Realm.search caches every data[] result instance with its expanded query fields', async function (assert) {
+      let doc = await realm.search(
+        {
+          filter: {
+            type: { module: rri(`${testRealm}consumer`), name: 'Consumer' },
+          },
+        },
+        {
+          cacheOnlyDefinitions: true,
+          skipQueryBackedExpansion: true,
+          omitIncluded: true,
+          jobIdentity: '11.1',
+        },
+      );
+
+      let resultIds = (doc.data ?? [])
+        .map((r) => r.id)
+        .filter(Boolean) as string[];
+      assert.strictEqual(
+        resultIds.length,
+        3,
+        'search returned all three Consumer data[] results',
+      );
+
+      let rows = (await query(dbAdapter, [
+        `SELECT url, result FROM ${CACHE_TABLE} WHERE job_id =`,
+        param('11.1'),
+      ] as Expression)) as { url: string; result: string }[];
+      let cachedByUrl = new Map(rows.map((r) => [r.url, r.result]));
+
+      for (let id of resultIds) {
+        let cached = cachedByUrl.get(id);
+        assert.notStrictEqual(
+          cached,
+          undefined,
+          `data[] result ${id} is cached`,
+        );
+        let rels = JSON.parse(cached ?? '{}') as {
+          queryLinks?: { data?: unknown[] };
+        };
+        assert.strictEqual(
+          rels.queryLinks?.data?.length,
+          3,
+          `cached entry for ${id} holds its expanded queryLinks umbrella`,
+        );
+      }
     });
   });
 });

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -81,6 +81,41 @@ const RECURSING_DEPTH = 3;
 
 const INSTANCE_CACHE_TABLE = 'job_scoped_instance_cache';
 
+// Hit/miss observability for the per-instance cache. Counters are kept per job
+// identity and a running summary is emitted as cache traffic accumulates — a
+// low-volume aggregate (not one line per event) so an indexing run reports its
+// cache hit rate in the ordinary logs. The map is diagnostics-only and bounded.
+// Lazily created (not at module load): a top-level `logger()` call here races
+// the circular import that populates it, whereas first use happens well after.
+let instanceCacheLog: ReturnType<typeof logger> | undefined;
+const instanceCacheStats = new Map<string, { hits: number; misses: number }>();
+const INSTANCE_CACHE_LOG_EVERY = 200;
+
+function recordInstanceCacheEvent(jobId: string, hit: boolean): void {
+  let stat = instanceCacheStats.get(jobId);
+  if (!stat) {
+    // Bound memory without tracking job lifecycle here: drop the whole map if
+    // it grows past a sane number of concurrent jobs.
+    if (instanceCacheStats.size > 256) {
+      instanceCacheStats.clear();
+    }
+    stat = { hits: 0, misses: 0 };
+    instanceCacheStats.set(jobId, stat);
+  }
+  if (hit) {
+    stat.hits++;
+  } else {
+    stat.misses++;
+  }
+  let total = stat.hits + stat.misses;
+  if (total === 1 || total % INSTANCE_CACHE_LOG_EVERY === 0) {
+    (instanceCacheLog ??= logger('instance-cache')).info(
+      `job=${jobId} hits=${stat.hits} misses=${stat.misses} ` +
+        `hitRate=${Math.round((100 * stat.hits) / total)}%`,
+    );
+  }
+}
+
 type Options = {
   loadLinks?: true;
   linkFields?: string[];
@@ -1345,6 +1380,7 @@ export class RealmIndexQueryEngine {
                 cacheKey.url,
               );
               if (cached !== undefined) {
+                recordInstanceCacheEvent(cacheKey.jobId, true);
                 // Hit: reuse this instance's assembled query-field
                 // relationships from an earlier occurrence in the same job,
                 // skipping the definition lookup + field-tree walk. The
@@ -1359,6 +1395,7 @@ export class RealmIndexQueryEngine {
                 }
                 return;
               }
+              recordInstanceCacheEvent(cacheKey.jobId, false);
             }
             let storedDefs = (
               resource.meta as {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -5165,6 +5165,7 @@ export class Realm {
       cacheOnlyDefinitions?: boolean;
       skipQueryBackedExpansion?: boolean;
       omitIncluded?: boolean;
+      jobIdentity?: string;
     },
   ): Promise<LinkableCollectionDocument> {
     assertQuery(query);
@@ -5175,6 +5176,7 @@ export class Realm {
         ? { skipQueryBackedExpansion: true }
         : {}),
       ...(opts?.omitIncluded ? { omitIncluded: true } : {}),
+      ...(opts?.jobIdentity ? { jobIdentity: opts.jobIdentity } : {}),
     });
   }
 

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -3,6 +3,7 @@ import {
   X_BOXEL_JOB_ID_HEADER,
   sanitizePrerenderJobId,
 } from './prerender-headers';
+import type { SearchOpts } from './search-utils';
 import {
   rri,
   type RealmResourceIdentifier,
@@ -5161,12 +5162,7 @@ export class Realm {
 
   public async search(
     query: Query,
-    opts?: {
-      cacheOnlyDefinitions?: boolean;
-      skipQueryBackedExpansion?: boolean;
-      omitIncluded?: boolean;
-      jobIdentity?: string;
-    },
+    opts?: SearchOpts,
   ): Promise<LinkableCollectionDocument> {
     assertQuery(query);
     return await this.#realmIndexQueryEngine.searchCards(query, {
@@ -5176,6 +5172,8 @@ export class Realm {
         ? { skipQueryBackedExpansion: true }
         : {}),
       ...(opts?.omitIncluded ? { omitIncluded: true } : {}),
+      // `!== undefined` so an explicit priority 0 (system-initiated) survives.
+      ...(opts?.priority !== undefined ? { priority: opts.priority } : {}),
       ...(opts?.jobIdentity ? { jobIdentity: opts.jobIdentity } : {}),
     });
   }

--- a/packages/runtime-common/search-utils.ts
+++ b/packages/runtime-common/search-utils.ts
@@ -316,14 +316,22 @@ export function combinePrerenderedSearchResults(
   return combined;
 }
 
+// Shared opts contract for the federated-search path, kept in one place so
+// SearchableRealm.search, searchRealms, and Realm.search can't drift —
+// dropping a field here (e.g. priority / jobIdentity) silently breaks the
+// threading from the realm-server handler down to searchCards.
+export type SearchOpts = {
+  cacheOnlyDefinitions?: boolean;
+  skipQueryBackedExpansion?: boolean;
+  omitIncluded?: boolean;
+  priority?: number;
+  jobIdentity?: string;
+};
+
 type SearchableRealm = {
   search: (
     query: Query,
-    opts?: {
-      cacheOnlyDefinitions?: boolean;
-      skipQueryBackedExpansion?: boolean;
-      omitIncluded?: boolean;
-    },
+    opts?: SearchOpts,
   ) => Promise<LinkableCollectionDocument>;
   url?: string;
 };
@@ -331,12 +339,7 @@ type SearchableRealm = {
 export async function searchRealms(
   realms: Array<SearchableRealm | null | undefined>,
   query: Query,
-  opts?: {
-    cacheOnlyDefinitions?: boolean;
-    skipQueryBackedExpansion?: boolean;
-    omitIncluded?: boolean;
-    jobIdentity?: string;
-  },
+  opts?: SearchOpts,
 ): Promise<LinkableCollectionDocument> {
   let realmEntries = realms
     .filter((realm): realm is SearchableRealm => Boolean(realm))

--- a/packages/runtime-common/search-utils.ts
+++ b/packages/runtime-common/search-utils.ts
@@ -335,6 +335,7 @@ export async function searchRealms(
     cacheOnlyDefinitions?: boolean;
     skipQueryBackedExpansion?: boolean;
     omitIncluded?: boolean;
+    jobIdentity?: string;
   },
 ): Promise<LinkableCollectionDocument> {
   let realmEntries = realms


### PR DESCRIPTION
The job-scoped per-instance wire-format cache (CS-11316) caches each card's assembled query-field relationships — keyed by `(jobId.reservationId, instanceURL)` — so an instance isn't re-expanded every time it recurs during a from-scratch reindex. This PR fixes a bug where that cache never populated on the search path, and adds the observability to tell whether it's actually paying off.

**The path it lives on.** During indexing the worker prerenders each card, and a card's render fires its query-field searches at the realm server's `_federated-search` endpoint. `handle-search` stamps the indexing job identity (the `x-boxel-job-id` header → a `jobIdentity` opt) onto the search opts, then calls `searchRealms` → each realm's `search` → `RealmIndexQueryEngine.searchCards` → `loadLinks`. The cache lives inside `loadLinks`: for each result instance it builds a key from `jobIdentity` + the instance URL, and only reads/writes when a `jobIdentity` is present (which is what scopes it to indexer-driven traffic — live requests never carry the header).

**The bug.** `Realm.search` doesn't pass its opts straight through — it *rebuilds* the opts object it hands to `searchCards` from a hand-listed set of fields (`cacheOnlyDefinitions`, `skipQueryBackedExpansion`, `omitIncluded`). `jobIdentity` wasn't in that list, so it got dropped between `Realm.search` and `loadLinks`. The identity reached the search *handler* — which is why the separate query-level search cache, that reads the header directly, populated fine — but never reached the cache key in `loadLinks`, so the key was always `undefined` and nothing was ever written. `priority` (threaded so definition sub-lookups fired during a search inherit the originating job's priority) was being dropped at the same spot.

**The fix.** Forward both `jobIdentity` and `priority` through `Realm.search` (priority with a `!== undefined` check so an explicit priority 0 survives), and collapse the three opts types that had drifted apart — `SearchableRealm.search`, `searchRealms`, and `Realm.search` — into one shared `SearchOpts`, so a field can't silently go missing along this path again.

**Observability.** A per-job running summary on the `instance-cache` logger — `job=… hits=… misses=… hitRate=…%` — emitted as a low-volume aggregate (not one line per event, and no per-hit DB writes), so an indexing run reports the cache's real hit rate in the ordinary logs. That's how we'll judge whether the cache earns its keep, rather than assuming it.

**Test.** The regression test drives the real `Realm.search` path. The pre-existing tests called `cardDocument` / `searchCards` directly with `jobIdentity` already in the engine opts, which bypassed the very opts-reconstruction that held the bug — so they couldn't catch it. The new test issues a `type: Consumer` search that returns several `data[]` results and asserts each result instance is cached by its own URL, with its expanded query-field umbrella, not merely that "some row" exists.
