### PR TITLE
Limit full-realm module pre-warm sweep to from-scratch indexing

### DIFF
--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -2198,6 +2198,55 @@ module(basename(__filename), function () {
         );
       });
 
+      test('the full-realm module pre-warm sweep runs on from-scratch indexing but not on incrementals', async function (assert) {
+        // `fancy-person.gts` is an orphan card module: it defines a CardDef
+        // (FancyPerson) but no instance adopts it and no other module
+        // imports it. Because nothing ever invalidates it, the only code
+        // path that can land it in the module cache is the realm-wide
+        // pre-warm sweep — which runs on from-scratch indexing and is
+        // skipped on incrementals. Its presence in the `modules` table is
+        // therefore a deterministic signal of whether the sweep ran.
+        let orphanAlias = `${testRealm}fancy-person`;
+
+        async function isCached(moduleAlias: string): Promise<boolean> {
+          let rows = (await testDbAdapter.execute(
+            `SELECT url FROM modules WHERE url = $1 OR file_alias = $1`,
+            { bind: [moduleAlias] },
+          )) as { url: string }[];
+          return rows.length > 0;
+        }
+
+        // The realm was from-scratch indexed during setup; the realm-wide
+        // sweep warmed every card module, including the orphan that no
+        // instance references.
+        assert.true(
+          await isCached(orphanAlias),
+          'from-scratch pre-warm caches the orphan module via the full-realm sweep',
+        );
+
+        // Clear the cache, then run an incremental on an unrelated instance.
+        // The incremental has no realm-wide sweep, and the orphan is neither
+        // visited nor a dependency of the change, so it does not come back —
+        // only the realm-wide sweep (from-scratch) would re-cache a module
+        // that no instance consumes.
+        await testDbAdapter.execute('DELETE FROM modules');
+        await realm.write(
+          'vangogh.json',
+          JSON.stringify({
+            data: {
+              attributes: { firstName: 'Van Gogh', hourlyRate: 51 },
+              meta: {
+                adoptsFrom: { module: rri('./person'), name: 'Person' },
+              },
+            },
+          }),
+        );
+        assert.false(
+          await isCached(orphanAlias),
+          'incremental skips the full-realm sweep, leaving the orphan module uncached',
+        );
+      });
+
       test('propagates module errors to dependent instances and recovers after missing modules are added', async function (assert) {
         await testDbAdapter.execute('DELETE FROM modules');
 

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -434,20 +434,25 @@ export class IndexRunner {
       }
       current.#scheduleClearCacheForNextRender();
     }
-    // Pre-warm: combine per-row deps with a realm-wide `.gts`/`.gjs`
-    // sweep. Incremental skips `discoverInvalidations` so the
-    // filesystem-mtimes walk hasn't happened yet — call it here.
-    // Typical realm sizes make this < 200 ms; one call per job.
-    let incrementalMtimes = await current.#reader.mtimes();
-    let allRealmCardModules =
-      Object.keys(incrementalMtimes).filter(hasCardExtension);
+    // Pre-warm only the modules this batch's invalidations actually
+    // touch — the invalidated module files plus the per-row deps of the
+    // invalidated cards. The realm-wide `.gts`/`.gjs` sweep is reserved
+    // for from-scratch indexing, where the persistent module cache is
+    // cold by definition. On an incremental that cache is already
+    // populated by the prior from-scratch, so a sibling module a card
+    // references only by string resolves through the on-demand
+    // `lookupDefinition` read-through during the visit (PagePool-safe:
+    // the sub-prerender materializes its own tab) rather than paying an
+    // O(realm) sweep for a single-file edit. Passing an empty base set
+    // also skips the filesystem-mtimes walk this path would otherwise
+    // run only to build that sweep.
     // Pre-warm reports each warmed module as a `file-visited`; modules and
     // the files visited below share one `totalFiles` so the dashboard bar
     // spans both phases.
     let filesCompleted = 0;
     let preWarmedCount = await current.preWarmModulesTable(
       invalidations,
-      allRealmCardModules,
+      [],
       ({ moduleUrl, filesCompleted: completed, totalFiles }) => {
         filesCompleted = completed;
         current.#onProgress?.({
@@ -703,7 +708,10 @@ export class IndexRunner {
     // this layer the search fires a same-affinity `prerenderModule`
     // mid-card-render at lookup time, which is the wait-shape the
     // PagePool's tab-materialization for module/command callers is
-    // meant to relieve.
+    // meant to relieve. Populated only on from-scratch indexing, where
+    // the module cache is cold; incrementals pass an empty base set and
+    // rely on the cache the last from-scratch left warm (the cost of
+    // this sweep is O(realm module count), not O(files changed)).
     //
     // `.gts` / `.gjs` only is an optimization, not a correctness gate:
     // `.ts` / `.js` files CAN host `CardDef` (e.g. command-input

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -434,18 +434,26 @@ export class IndexRunner {
       }
       current.#scheduleClearCacheForNextRender();
     }
-    // Pre-warm only the modules this batch's invalidations actually
-    // touch — the invalidated module files plus the per-row deps of the
-    // invalidated cards. The realm-wide `.gts`/`.gjs` sweep is reserved
-    // for from-scratch indexing, where the persistent module cache is
-    // cold by definition. On an incremental that cache is already
-    // populated by the prior from-scratch, so a sibling module a card
-    // references only by string resolves through the on-demand
-    // `lookupDefinition` read-through during the visit (PagePool-safe:
-    // the sub-prerender materializes its own tab) rather than paying an
-    // O(realm) sweep for a single-file edit. Passing an empty base set
-    // also skips the filesystem-mtimes walk this path would otherwise
-    // run only to build that sweep.
+    // Still pre-warm, but only the modules this batch will actually
+    // render. For each invalidation `preWarmModulesTable` primes the
+    // definition cache for the invalidated module file itself (when
+    // executable) plus the per-row `boxel_index` deps of the invalidated
+    // cards (and the `adoptsFrom` module of a novel `.json`). Front-
+    // loading those before the visit phase lets a dependent card's render
+    // hit the cache instead of firing a same-affinity sub-`prerenderModule`
+    // mid-render — the per-invalidation warming, bounded by invalidation
+    // size rather than realm size.
+    //
+    // The empty base set drops only the realm-wide `.gts`/`.gjs` sweep.
+    // That sweep exists to prime sibling modules a card references by
+    // string (which never appear in any instance's runtime deps) and is
+    // worth its O(realm) cost only on from-scratch, where the cache is
+    // cold by definition. On an incremental the cache is already warm from
+    // the prior from-scratch, and any miss resolves through the on-demand
+    // `lookupDefinition` read-through during the visit (PagePool-safe: the
+    // sub-prerender materializes its own tab). Skipping it also avoids the
+    // filesystem-mtimes walk this path would otherwise run only to build
+    // the sweep.
     // Pre-warm reports each warmed module as a `file-visited`; modules and
     // the files visited below share one `totalFiles` so the dashboard bar
     // spans both phases.


### PR DESCRIPTION
`IndexRunner` pre-warmed the definition cache for every `.gts`/`.gjs` module in the realm on every index — from-scratch and incremental alike. That sweep is O(realm module count), not O(files changed), so a single-file edit on a module-heavy realm pays the full-realm tax: warming hundreds of modules (mostly cache hits, but serial) dominates the wall time of an incremental whose real work is a handful of cards. When the cache is cold (e.g. right after a deploy), the same sweep re-prerenders every module and the cost balloons further.

The sweep exists for one reason: to prime sibling card modules that a card references only as a string (e.g. a `Search` query's `type.module`), which never appear in any instance's runtime `deps`. Without it, a render's `lookupDefinition` for such a module fires a same-affinity sub-`prerenderModule` mid-render. That cold-cache concern is real only on from-scratch. On an incremental the module cache is already warm from the prior from-scratch, and a miss now resolves through the on-demand read-through during the visit — which is PagePool-safe (it materializes its own tab) rather than deadlocking.

This change runs the realm-wide sweep on **from-scratch only**. Incrementals pass an empty base set to `preWarmModulesTable` and keep the per-invalidation warming (bounded by the invalidation set — the invalidated module files plus the per-row deps of the invalidated cards). It also drops the incremental-only filesystem-mtimes walk that existed solely to build the sweep.

### Test

Adds a realm-server test that uses an orphan card module — defined but adopted by no instance and imported by no module — as a deterministic probe. Nothing ever invalidates it, so the only code path that can land it in the `modules` cache is the realm-wide sweep. The test asserts it is present after from-scratch indexing and absent after an incremental of an unrelated instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
