### PR TITLE
fix: update boxel-cli profile localhost realmServerUrl to https

### DIFF
--- a/packages/boxel-cli/README.md
+++ b/packages/boxel-cli/README.md
@@ -38,7 +38,7 @@ boxel --version
 These are read by `boxel profile add`:
 
 - `BOXEL_PASSWORD` — password for non-interactive profile creation. Preferred over `-p/--password`, which exposes the password in shell history and process listings.
-- `BOXEL_ENVIRONMENT` — env-mode slug (typically a branch name) for per-branch local dev. Interpreted like `scripts/env-slug.sh`: the value is slugified (lowercased, `/` → `-`, other chars stripped) and URLs are derived as `http://matrix.<slug>.localhost` and `http://realm-server.<slug>.localhost/`. Overridden by `--matrix-url` / `--realm-server-url` if those flags are provided. Values that slugify to empty (e.g. `!!!`) exit with an error.
+- `BOXEL_ENVIRONMENT` — env-mode slug (typically a branch name) for per-branch local dev. Interpreted like `scripts/env-slug.sh`: the value is slugified (lowercased, `/` → `-`, other chars stripped) and URLs are derived as `https://matrix.<slug>.localhost` and `https://realm-server.<slug>.localhost/`. Overridden by `--matrix-url` / `--realm-server-url` if those flags are provided. Values that slugify to empty (e.g. `!!!`) exit with an error.
 
 Example — create a profile for a branch running in env mode:
 

--- a/packages/boxel-cli/plugin/skills/profile/SKILL.md
+++ b/packages/boxel-cli/plugin/skills/profile/SKILL.md
@@ -8,13 +8,13 @@ Wraps `boxel profile`, which manages credentials for different users and environ
 
 ## When the user asks to...
 
-| Ask | Run |
-|---|---|
-| "what profiles do I have?" / "who am I logged in as?" | `boxel profile list` |
-| "log in" / "add a new account" | `boxel profile add` (interactive — preferred) |
-| "switch to my staging account" | `boxel profile switch <username-or-fragment>` |
-| "remove that old profile" | `boxel profile remove <profile-id>` |
-| "import from my old .env" | `boxel profile migrate` |
+| Ask                                                   | Run                                           |
+| ----------------------------------------------------- | --------------------------------------------- |
+| "what profiles do I have?" / "who am I logged in as?" | `boxel profile list`                          |
+| "log in" / "add a new account"                        | `boxel profile add` (interactive — preferred) |
+| "switch to my staging account"                        | `boxel profile switch <username-or-fragment>` |
+| "remove that old profile"                             | `boxel profile remove <profile-id>`           |
+| "import from my old .env"                             | `boxel profile migrate`                       |
 
 ## Profile IDs
 
@@ -42,8 +42,8 @@ For ephemeral environments (PR previews, branch deploys), `BOXEL_ENVIRONMENT` de
 
 ```bash
 BOXEL_ENVIRONMENT=my-branch boxel profile add -u @sarah:my-branch.localhost
-# → matrix at http://matrix.my-branch.localhost
-# → realm-server at http://realm-server.my-branch.localhost/
+# → matrix at https://matrix.my-branch.localhost
+# → realm-server at https://realm-server.my-branch.localhost/
 ```
 
 Override individually with `--matrix-url` / `--realm-server-url` if needed.

--- a/packages/boxel-cli/src/build-program.ts
+++ b/packages/boxel-cli/src/build-program.ts
@@ -61,8 +61,8 @@ Environment variables (for 'add'):
   BOXEL_PASSWORD       Password; preferred over -p to avoid shell history.
   BOXEL_ENVIRONMENT    An env-mode slug (e.g. a branch name), interpreted
                        like scripts/env-slug.sh: URLs are derived as
-                       http://matrix.<slug>.localhost and
-                       http://realm-server.<slug>.localhost/. Overridden
+                       https://matrix.<slug>.localhost and
+                       https://realm-server.<slug>.localhost/. Overridden
                        by --matrix-url / --realm-server-url if provided.`,
     )
     .action(

--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -103,8 +103,8 @@ export function resolveBoxelEnvironment(): EnvironmentDefaults | null {
   }
   return {
     domain: `${slug}.localhost`,
-    matrixUrl: `http://matrix.${slug}.localhost`,
-    realmServerUrl: `http://realm-server.${slug}.localhost/`,
+    matrixUrl: `https://matrix.${slug}.localhost`,
+    realmServerUrl: `https://realm-server.${slug}.localhost/`,
   };
 }
 

--- a/packages/boxel-cli/src/commands/profile.ts
+++ b/packages/boxel-cli/src/commands/profile.ts
@@ -49,7 +49,7 @@ const MENU_ENVIRONMENTS: Record<
   local: {
     domain: 'localhost',
     matrixUrl: 'http://localhost:8008',
-    realmServerUrl: 'http://localhost:4201/',
+    realmServerUrl: 'https://localhost:4201/',
   },
 };
 

--- a/packages/boxel-cli/src/lib/profile-manager.ts
+++ b/packages/boxel-cli/src/lib/profile-manager.ts
@@ -245,7 +245,7 @@ export class ProfileManager implements RealmAuthenticator {
       defaultRealmUrl = 'https://app.boxel.ai/';
     } else if (env === 'local') {
       defaultMatrixUrl = 'http://localhost:8008';
-      defaultRealmUrl = 'http://localhost:4201/';
+      defaultRealmUrl = 'https://localhost:4201/';
     } else {
       defaultMatrixUrl = 'https://matrix-staging.stack.cards';
       defaultRealmUrl = 'https://realms-staging.stack.cards/';

--- a/packages/boxel-cli/tests/commands/profile-env-resolution.test.ts
+++ b/packages/boxel-cli/tests/commands/profile-env-resolution.test.ts
@@ -58,8 +58,8 @@ describe('resolveBoxelEnvironment', () => {
     process.env.BOXEL_ENVIRONMENT = 'cs-10998-foo';
     expect(resolveBoxelEnvironment()).toEqual({
       domain: 'cs-10998-foo.localhost',
-      matrixUrl: 'http://matrix.cs-10998-foo.localhost',
-      realmServerUrl: 'http://realm-server.cs-10998-foo.localhost/',
+      matrixUrl: 'https://matrix.cs-10998-foo.localhost',
+      realmServerUrl: 'https://realm-server.cs-10998-foo.localhost/',
     });
   });
 
@@ -67,8 +67,8 @@ describe('resolveBoxelEnvironment', () => {
     process.env.BOXEL_ENVIRONMENT = 'My/Branch_Name!';
     expect(resolveBoxelEnvironment()).toEqual({
       domain: 'my-branchname.localhost',
-      matrixUrl: 'http://matrix.my-branchname.localhost',
-      realmServerUrl: 'http://realm-server.my-branchname.localhost/',
+      matrixUrl: 'https://matrix.my-branchname.localhost',
+      realmServerUrl: 'https://realm-server.my-branchname.localhost/',
     });
   });
 });

--- a/packages/boxel-cli/tests/commands/profile.test.ts
+++ b/packages/boxel-cli/tests/commands/profile.test.ts
@@ -218,7 +218,7 @@ describe('ProfileManager', () => {
     );
     const profile = manager.getProfile('@dev:localhost')!;
     expect(profile.matrixUrl).toBe('http://localhost:8008');
-    expect(profile.realmServerUrl).toBe('http://localhost:4201/');
+    expect(profile.realmServerUrl).toBe('https://localhost:4201/');
   });
 
   it('adds a production profile with correct defaults', async () => {


### PR DESCRIPTION
Had trouble using software-factory `factory go` command to push to localhost. The reason is that we haven't updated the realmServeUrl in the localhost profile setup to `https`.