### PR TITLE
Replace hardcoded localhost links in experiments-realm fixtures

### DIFF
--- a/packages/experiments-realm/AtomExamples/d7aa387b-6514-47c0-ace2-7de011453e51.json
+++ b/packages/experiments-realm/AtomExamples/d7aa387b-6514-47c0-ace2-7de011453e51.json
@@ -3,17 +3,9 @@
     "type": "card",
     "attributes": {
       "name": "Lila",
-      "names": [
-        "Evie",
-        "Lila",
-        "Marco"
-      ],
+      "names": ["Evie", "Lila", "Marco"],
       "date": "2024-12-04",
-      "dates": [
-        "2024-12-11",
-        "2024-12-25",
-        "2024-12-31"
-      ],
+      "dates": ["2024-12-11", "2024-12-25", "2024-12-31"],
       "trip": {
         "cardTitle": "Trip 1"
       },
@@ -93,22 +85,22 @@
       },
       "trip.country": {
         "links": {
-          "self": "https://localhost:4201/experiments/Country/argentina"
+          "self": "../Country/argentina"
         }
       },
       "trip.countries.0": {
         "links": {
-          "self": "https://localhost:4201/experiments/Country/brazil"
+          "self": "../Country/brazil"
         }
       },
       "trip.countries.1": {
         "links": {
-          "self": "https://localhost:4201/experiments/Country/4"
+          "self": "../Country/4"
         }
       },
       "trip.countries.2": {
         "links": {
-          "self": "https://localhost:4201/experiments/Country/1"
+          "self": "../Country/1"
         }
       },
       "trips.0.country": {

--- a/packages/experiments-realm/AuthenticatedImageTester/1.json
+++ b/packages/experiments-realm/AuthenticatedImageTester/1.json
@@ -14,7 +14,7 @@
         "summary": null,
         "cardThumbnailURL": null
       },
-      "imageUrl": "https://localhost:4201/experiments/green-mango.png"
+      "imageUrl": ""
     },
     "relationships": {
       "cardInfo.theme": {

--- a/packages/experiments-realm/BotRequestDemo/bot-request-demo.json
+++ b/packages/experiments-realm/BotRequestDemo/bot-request-demo.json
@@ -17,7 +17,7 @@
       "cardId": "",
       "format": "isolated",
       "roomId": "",
-      "realm": "https://localhost:4201/experiments/",
+      "realm": "",
       "listingId": ""
     },
     "relationships": {

--- a/packages/experiments-realm/DemoFields/c8f3842a-4e5d-4660-bab7-6d0266db6a64.json
+++ b/packages/experiments-realm/DemoFields/c8f3842a-4e5d-4660-bab7-6d0266db6a64.json
@@ -11,7 +11,7 @@
       "url": "https://www.pixar.com/finding-nemo",
       "color": "#ff6d1f",
       "email": "nemo@email.com",
-      "realm": "https://localhost:4201/experiments/",
+      "realm": "",
       "address": {
         "city": "Sydney",
         "state": "NSW",

--- a/packages/experiments-realm/Spec/7705e324-4949-43f8-a6fe-4f3c94c365f5.json
+++ b/packages/experiments-realm/Spec/7705e324-4949-43f8-a6fe-4f3c94c365f5.json
@@ -56,7 +56,7 @@
     "attributes": {
       "ref": {
         "name": "TravelGoalWithProgress",
-        "module": "https://localhost:4201/experiments/trip-info"
+        "module": "../trip-info"
       },
       "readMe": null,
       "cardInfo": {


### PR DESCRIPTION
## Problem

Several `experiments-realm` instances referenced `https://localhost:4201/experiments/...` URLs that only resolve in local dev. When such a value is a `linksTo`/`linksToMany` target or a module ref, the realm server resolves it by fetching the URL — and on a deployed environment `localhost:4201` is unreachable. undici throws `TypeError: fetch failed` at the network layer, which is not caught as a "broken link", so it surfaces as an **HTTP 500** and breaks the entire card (e.g. the Atom Examples card) rather than degrading to a broken-link placeholder.

## Approach

Fixtures are deployed to local, staging, and prod from the repo, so **no absolute environment URL is correct everywhere** (that's what `migrate-realm-references.sh` exists to rewrite). Following the in-repo convention:

- **Within-realm references → relative paths** (`../`), which resolve against the card's own realm in every environment.
- **Fields with no relative form** (a `RealmField` realm identifier; the auth-image tester's raw image URL) are cleared to their empty/default state rather than pinned to one environment.

## Changes

- **AtomExamples** — `trip.country` / `trip.countries.*` → relative `../Country/*` (matches the already-working `trips.*` links in the same card). This is the card that was 500-ing.
- **Spec** — `ref.module` → relative `../trip-info`.
- **BotRequestDemo**, **DemoFields** — `realm` (a `RealmField`) → empty. The value is a per-environment realm identifier with no relative form; empty shows the field's "Select a realm" state for the user to choose.
- **AuthenticatedImageTester** — `imageUrl` → empty. This card tests that the auth service worker injects credentials for realm-hosted images, so it needs an absolute realm URL (a relative one would resolve against the host origin, not the realm) — which is inherently per-environment. It's a manual tester, so the field is left empty for the user to paste a URL.

## Follow-up worth considering (separate)

Treat a connection-level failure during link resolution like a broken link (placeholder) instead of a 500, so a single unreachable link URL can't take down an entire card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)