### PR TITLE
Measure retained heap in lint memory test to remove flakiness

### DIFF
--- a/packages/realm-server/tests/helpers/prettier-test-utils.ts
+++ b/packages/realm-server/tests/helpers/prettier-test-utils.ts
@@ -1,5 +1,36 @@
 // Test utilities for prettier formatting tests
 import { performance } from 'perf_hooks';
+import * as v8 from 'v8';
+import * as vm from 'vm';
+
+/**
+ * Forces a full garbage collection so that a subsequent
+ * `process.memoryUsage().heapUsed` reading reflects retained memory rather
+ * than uncollected transient garbage. The test runner does not start Node
+ * with `--expose-gc`, so `global.gc` is normally absent; enable it at runtime
+ * through the V8 flag API, then turn it back off so the rest of the process is
+ * unaffected. Returns true if a collection was actually performed.
+ *
+ * Two passes: the first promotes/collects the young generation, the second
+ * collects what the first pass made unreachable, so the reading settles.
+ */
+export function forceGc(): boolean {
+  let gc = (globalThis as { gc?: () => void }).gc;
+  if (typeof gc !== 'function') {
+    try {
+      v8.setFlagsFromString('--expose-gc');
+      gc = vm.runInNewContext('gc') as () => void;
+    } finally {
+      v8.setFlagsFromString('--no-expose-gc');
+    }
+  }
+  if (typeof gc !== 'function') {
+    return false;
+  }
+  gc();
+  gc();
+  return true;
+}
 
 interface FormattingTestCase {
   name: string;

--- a/packages/realm-server/tests/helpers/prettier-test-utils.ts
+++ b/packages/realm-server/tests/helpers/prettier-test-utils.ts
@@ -3,28 +3,49 @@ import { performance } from 'perf_hooks';
 import * as v8 from 'v8';
 import * as vm from 'vm';
 
+// Resolved once and cached: the test runner does not start Node with
+// `--expose-gc`, so `globalThis.gc` is normally absent and we synthesize the
+// function through the V8 flag API. Resolving lazily and caching means we
+// create at most one throwaway VM context for the whole suite rather than one
+// per `forceGc` call (a per-call context would itself allocate and perturb the
+// very heap reading the helper exists to make trustworthy). `null` records a
+// completed resolution that produced no usable function.
+let resolvedGc: (() => void) | null | undefined;
+
+function resolveGc(): (() => void) | null {
+  if (resolvedGc !== undefined) {
+    return resolvedGc;
+  }
+  let gc = (globalThis as { gc?: () => void }).gc;
+  if (typeof gc !== 'function') {
+    try {
+      v8.setFlagsFromString('--expose-gc');
+      // Evaluating `gc` throws ReferenceError if the flag didn't take effect
+      // (e.g. an unsupported V8 build); treat that as "no GC available".
+      gc = vm.runInNewContext('gc') as () => void;
+    } catch {
+      gc = undefined;
+    } finally {
+      v8.setFlagsFromString('--no-expose-gc');
+    }
+  }
+  resolvedGc = typeof gc === 'function' ? gc : null;
+  return resolvedGc;
+}
+
 /**
  * Forces a full garbage collection so that a subsequent
  * `process.memoryUsage().heapUsed` reading reflects retained memory rather
- * than uncollected transient garbage. The test runner does not start Node
- * with `--expose-gc`, so `global.gc` is normally absent; enable it at runtime
- * through the V8 flag API, then turn it back off so the rest of the process is
- * unaffected. Returns true if a collection was actually performed.
+ * than uncollected transient garbage. Returns true if a collection was
+ * actually performed, false if no GC function could be resolved — callers can
+ * branch on the result to decide how much to trust the measurement.
  *
  * Two passes: the first promotes/collects the young generation, the second
  * collects what the first pass made unreachable, so the reading settles.
  */
 export function forceGc(): boolean {
-  let gc = (globalThis as { gc?: () => void }).gc;
-  if (typeof gc !== 'function') {
-    try {
-      v8.setFlagsFromString('--expose-gc');
-      gc = vm.runInNewContext('gc') as () => void;
-    } finally {
-      v8.setFlagsFromString('--no-expose-gc');
-    }
-  }
-  if (typeof gc !== 'function') {
+  const gc = resolveGc();
+  if (!gc) {
     return false;
   }
   gc();

--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -361,7 +361,12 @@ export class MyCard extends CardDef {
       // Warm up first so one-time, legitimately-retained initialization (eslint
       // rule definitions, prettier plugins, module caches) is established before
       // the baseline reading and isn't misattributed to the measured loop.
-      await lintOnce();
+      const warmup = await lintOnce();
+      assert.strictEqual(
+        warmup.status,
+        200,
+        'warm-up lint request should succeed so the baseline is a steady-state lint path',
+      );
 
       // Force a collection before each reading so the delta reflects retained
       // memory, not transient garbage that GC simply hasn't reclaimed yet.
@@ -392,18 +397,21 @@ export class MyCard extends CardDef {
       const memoryIncrease = finalMemory - initialMemory;
       const memoryIncreaseMb = memoryIncrease / 1024 / 1024;
 
-      // Diagnostic signal: if this assertion fails, the log shows the
-      // retained-growth number (and whether GC actually ran), so a CI failure
-      // distinguishes a real leak from measurement noise.
+      // Always record the retained-growth number (and whether GC actually ran)
+      // so a CI failure — or a passing run drifting toward the bound — can be
+      // told apart from measurement noise without another CI cycle.
       console.log(
         `[lint-memory-test] initial=${(initialMemory / 1024 / 1024).toFixed(2)}MB ` +
           `final=${(finalMemory / 1024 / 1024).toFixed(2)}MB ` +
           `retainedGrowth=${memoryIncreaseMb.toFixed(2)}MB gcForced=${gcForced}`,
       );
 
-      // With warm caches and a forced collection, ten idempotent lint operations
-      // retain almost nothing; this bound is a leak guard, not a tuned ceiling.
-      const thresholdMb = 20;
+      // The bound only means "retained memory" when a collection actually ran;
+      // with warm caches and a forced GC ten idempotent lint operations retain
+      // almost nothing, so 20MB is a generous leak guard. If GC could not be
+      // forced the delta still includes transient garbage, so fall back to the
+      // looser historical bound rather than flaking against the tight one.
+      const thresholdMb = gcForced ? 20 : 45;
       assert.ok(
         memoryIncrease < thresholdMb * 1024 * 1024,
         `Memory increase should be under ${thresholdMb}MB, got ${memoryIncreaseMb.toFixed(2)}MB (gcForced=${gcForced})`,

--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -8,6 +8,7 @@ import {
   createConcurrentTestData,
   createErrorTestCases,
   createPerformanceAssertion,
+  forceGc,
 } from '../helpers/prettier-test-utils';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 
@@ -341,27 +342,38 @@ export class MyCard extends CardDef {
     });
 
     test('memory usage during lint operations', async function (assert) {
-      const initialMemory = process.memoryUsage().heapUsed;
-
       const testSource = `import { CardDef } from 'https://cardstack.com/base/card-api';
 export class MyCard extends CardDef {
   @field name = contains(StringField);
 }`;
 
+      const lintOnce = () =>
+        request
+          .post('/_lint')
+          .set(
+            'Authorization',
+            `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+          )
+          .set('X-HTTP-Method-Override', 'QUERY')
+          .set('Accept', 'application/json')
+          .send(testSource);
+
+      // Warm up first so one-time, legitimately-retained initialization (eslint
+      // rule definitions, prettier plugins, module caches) is established before
+      // the baseline reading and isn't misattributed to the measured loop.
+      await lintOnce();
+
+      // Force a collection before each reading so the delta reflects retained
+      // memory, not transient garbage that GC simply hasn't reclaimed yet.
+      // Without this the reading is dominated by collectible allocations from
+      // ten concurrent lint requests, which is noise, not a leak signal.
+      const gcForced = forceGc();
+      const initialMemory = process.memoryUsage().heapUsed;
+
       // Run multiple lint operations to test memory usage
       const operations = [];
       for (let i = 0; i < 10; i++) {
-        operations.push(
-          request
-            .post('/_lint')
-            .set(
-              'Authorization',
-              `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
-            )
-            .set('X-HTTP-Method-Override', 'QUERY')
-            .set('Accept', 'application/json')
-            .send(testSource),
-        );
+        operations.push(lintOnce());
       }
 
       const results = await Promise.all(operations);
@@ -375,13 +387,26 @@ export class MyCard extends CardDef {
         );
       });
 
+      forceGc();
       const finalMemory = process.memoryUsage().heapUsed;
       const memoryIncrease = finalMemory - initialMemory;
+      const memoryIncreaseMb = memoryIncrease / 1024 / 1024;
 
-      // Memory increase should be reasonable (less than 45MB for lint operations)
+      // Diagnostic signal: if this assertion fails, the log shows the
+      // retained-growth number (and whether GC actually ran), so a CI failure
+      // distinguishes a real leak from measurement noise.
+      console.log(
+        `[lint-memory-test] initial=${(initialMemory / 1024 / 1024).toFixed(2)}MB ` +
+          `final=${(finalMemory / 1024 / 1024).toFixed(2)}MB ` +
+          `retainedGrowth=${memoryIncreaseMb.toFixed(2)}MB gcForced=${gcForced}`,
+      );
+
+      // With warm caches and a forced collection, ten idempotent lint operations
+      // retain almost nothing; this bound is a leak guard, not a tuned ceiling.
+      const thresholdMb = 20;
       assert.ok(
-        memoryIncrease < 45 * 1024 * 1024,
-        `Memory increase should be under 45MB, got ${(memoryIncrease / 1024 / 1024).toFixed(2)}MB`,
+        memoryIncrease < thresholdMb * 1024 * 1024,
+        `Memory increase should be under ${thresholdMb}MB, got ${memoryIncreaseMb.toFixed(2)}MB (gcForced=${gcForced})`,
       );
     });
 


### PR DESCRIPTION
## What

The `realm-endpoints/lint-test.ts > memory usage during lint operations` test is intermittently flaky. It asserts a hard ceiling on the process `heapUsed` delta across ten concurrent `/_lint` requests, but never forces a garbage collection before reading. The "after" reading therefore includes transient garbage that GC simply hasn't reclaimed yet — so the delta measures GC timing, not retained memory, and occasionally tips over the threshold on a busy CI runner.

## Fix

Make the measurement reflect *retained* memory — the actual leak signal:

- **Warm up once** before the baseline reading, so one-time, legitimately-retained initialization (eslint rule definitions, prettier plugins, module caches) isn't miscounted as growth from the measured loop.
- **Force a full GC** before both the baseline and the final reading. A new `forceGc` helper enables GC at runtime via the V8 flag API, because the test runner doesn't start Node with `--expose-gc`.
- **Assert on the post-GC retained-growth delta** with a 20MB leak-guard bound. Locally the retained growth measures ~3MB, so the bound has ample headroom while still catching a genuine per-operation leak.
- **Log a diagnostic line** (`[lint-memory-test] initial=… final=… retainedGrowth=… gcForced=…`) so any future failure shows the real retained number and whether GC actually ran — distinguishing a real leak from measurement noise.

## Verification

Ran the module locally against the realm-server test stack:

```
[lint-memory-test] initial=172.63MB final=175.58MB retainedGrowth=2.95MB gcForced=true
ok ... memory usage during lint operations
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
